### PR TITLE
feat: add Test tab to sidebar with Coming Soon screen

### DIFF
--- a/apps/desktop/src/renderer/components/app/App.tsx
+++ b/apps/desktop/src/renderer/components/app/App.tsx
@@ -47,6 +47,9 @@ const MissionsPage = React.lazy(() =>
 const CtoPage = React.lazy(() =>
   import("../cto/CtoPage").then((m) => ({ default: m.CtoPage }))
 );
+const TestPage = React.lazy(() =>
+  import("../test/TestPage").then((m) => ({ default: m.TestPage }))
+);
 
 import { useAppStore } from "../../state/appStore";
 
@@ -183,6 +186,7 @@ export function App() {
             <Route path="/automations" element={guardedLazy(<AutomationsPage />)} />
             <Route path="/missions" element={guardedLazy(<MissionsPage />)} />
             <Route path="/cto" element={guardedLazy(<CtoPage />)} />
+            <Route path="/test" element={guardedLazy(<TestPage />)} />
             <Route path="/settings" element={guardedLazy(<SettingsPage />)} />
             <Route path="*" element={<Navigate to="/project" replace />} />
           </Route>

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -355,6 +355,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       "/automations": "tab-tint-automations",
       "/missions": "tab-tint-missions",
       "/settings": "tab-tint-settings",
+      "/test": "tab-tint-missions",
     };
     return tintMap[location.pathname] ?? "";
   }, [location.pathname]);

--- a/apps/desktop/src/renderer/components/app/TabNav.tsx
+++ b/apps/desktop/src/renderer/components/app/TabNav.tsx
@@ -13,6 +13,7 @@ import {
   Strategy,
   Brain,
   GearSix,
+  Flask,
 } from "@phosphor-icons/react";
 import { cn } from "../ui/cn";
 import { useAppStore } from "../../state/appStore";
@@ -30,6 +31,7 @@ const mainItems = [
   { to: "/automations", label: "Automations", icon: Robot },
   { to: "/missions", label: "Missions", icon: Strategy },
   { to: "/cto", label: "CTO", icon: Brain },
+  { to: "/test", label: "Test", icon: Flask },
 ] as const;
 
 const settingsItem = { to: "/settings", label: "Settings", icon: GearSix } as const;

--- a/apps/desktop/src/renderer/components/test/TestPage.tsx
+++ b/apps/desktop/src/renderer/components/test/TestPage.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export function TestPage() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <div className="text-center">
+        <div className="text-2xl font-semibold text-fg">Coming Soon</div>
+        <div className="mt-2 text-sm text-muted-fg">This feature is under construction.</div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Added a new **Test** tab to the sidebar navigation with a Flask icon
- Created `TestPage.tsx` component displaying a centered "Coming Soon" message
- Wired up the `/test` route in the router and tint map

## Changes

- `TabNav.tsx` — added `Flask` icon import and `{ to: "/test", label: "Test", icon: Flask }` to `mainItems`
- `TestPage.tsx` — new component at `components/test/TestPage.tsx` with "Coming Soon" UI
- `App.tsx` — lazy import + `<Route path="/test">` entry
- `AppShell.tsx` — `/test` added to `tintMap`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Test" tab in the main navigation menu. Currently displays a "Coming Soon" message indicating the feature is under development and construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->