### PR TITLE
feat: add Test tab to sidebar with Coming Soon screen

### DIFF
--- a/apps/desktop/src/renderer/components/app/App.tsx
+++ b/apps/desktop/src/renderer/components/app/App.tsx
@@ -47,6 +47,9 @@ const MissionsPage = React.lazy(() =>
 const CtoPage = React.lazy(() =>
   import("../cto/CtoPage").then((m) => ({ default: m.CtoPage }))
 );
+const TestPage = React.lazy(() =>
+  import("../test/TestPage").then((m) => ({ default: m.TestPage }))
+);
 
 import { useAppStore } from "../../state/appStore";
 
@@ -183,6 +186,7 @@ export function App() {
             <Route path="/automations" element={guardedLazy(<AutomationsPage />)} />
             <Route path="/missions" element={guardedLazy(<MissionsPage />)} />
             <Route path="/cto" element={guardedLazy(<CtoPage />)} />
+            <Route path="/test" element={guardedLazy(<TestPage />)} />
             <Route path="/settings" element={guardedLazy(<SettingsPage />)} />
             <Route path="*" element={<Navigate to="/project" replace />} />
           </Route>

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -354,6 +354,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       "/history": "tab-tint-history",
       "/automations": "tab-tint-automations",
       "/missions": "tab-tint-missions",
+      "/test": "tab-tint-missions",
       "/settings": "tab-tint-settings",
     };
     return tintMap[location.pathname] ?? "";

--- a/apps/desktop/src/renderer/components/app/TabNav.tsx
+++ b/apps/desktop/src/renderer/components/app/TabNav.tsx
@@ -13,6 +13,7 @@ import {
   Strategy,
   Brain,
   GearSix,
+  Flask,
 } from "@phosphor-icons/react";
 import { cn } from "../ui/cn";
 import { useAppStore } from "../../state/appStore";
@@ -30,6 +31,7 @@ const mainItems = [
   { to: "/automations", label: "Automations", icon: Robot },
   { to: "/missions", label: "Missions", icon: Strategy },
   { to: "/cto", label: "CTO", icon: Brain },
+  { to: "/test", label: "Test", icon: Flask },
 ] as const;
 
 const settingsItem = { to: "/settings", label: "Settings", icon: GearSix } as const;

--- a/apps/desktop/src/renderer/components/test/TestPage.tsx
+++ b/apps/desktop/src/renderer/components/test/TestPage.tsx
@@ -1,0 +1,10 @@
+export function TestPage() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <div className="text-center">
+        <h1 className="text-2xl font-semibold text-fg mb-2">Coming Soon</h1>
+        <p className="text-sm text-muted-fg">This feature is under construction.</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Added a new **Test** tab to the desktop app sidebar (`/test` route)
- Created a `TestPage` component that displays a **Coming Soon** screen
- Wired up the Flask icon, nav item, route, and AppShell tint map entry

## Changes
- `TabNav.tsx` — Flask icon import + `/test` nav item in `mainItems`
- `App.tsx` — lazy `TestPage` import + `/test` React Router route
- `AppShell.tsx` — `"/test": "tab-tint-missions"` tint map entry
- `apps/desktop/src/renderer/components/test/TestPage.tsx` — new page with "Coming Soon" message