### PR TITLE
feat: add Test tab to sidebar with Coming Soon screen

### DIFF
--- a/apps/desktop/src/renderer/components/app/App.tsx
+++ b/apps/desktop/src/renderer/components/app/App.tsx
@@ -47,6 +47,9 @@ const MissionsPage = React.lazy(() =>
 const CtoPage = React.lazy(() =>
   import("../cto/CtoPage").then((m) => ({ default: m.CtoPage }))
 );
+const TestPage = React.lazy(() =>
+  import("../test/TestPage").then((m) => ({ default: m.TestPage }))
+);
 
 import { useAppStore } from "../../state/appStore";
 
@@ -183,6 +186,7 @@ export function App() {
             <Route path="/automations" element={guardedLazy(<AutomationsPage />)} />
             <Route path="/missions" element={guardedLazy(<MissionsPage />)} />
             <Route path="/cto" element={guardedLazy(<CtoPage />)} />
+            <Route path="/test" element={guardedLazy(<TestPage />)} />
             <Route path="/settings" element={guardedLazy(<SettingsPage />)} />
             <Route path="*" element={<Navigate to="/project" replace />} />
           </Route>

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -355,6 +355,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       "/automations": "tab-tint-automations",
       "/missions": "tab-tint-missions",
       "/settings": "tab-tint-settings",
+      "/test": "tab-tint-test",
     };
     return tintMap[location.pathname] ?? "";
   }, [location.pathname]);

--- a/apps/desktop/src/renderer/components/app/TabNav.tsx
+++ b/apps/desktop/src/renderer/components/app/TabNav.tsx
@@ -13,6 +13,7 @@ import {
   Strategy,
   Brain,
   GearSix,
+  Flask,
 } from "@phosphor-icons/react";
 import { cn } from "../ui/cn";
 import { useAppStore } from "../../state/appStore";
@@ -30,6 +31,7 @@ const mainItems = [
   { to: "/automations", label: "Automations", icon: Robot },
   { to: "/missions", label: "Missions", icon: Strategy },
   { to: "/cto", label: "CTO", icon: Brain },
+  { to: "/test", label: "Test", icon: Flask },
 ] as const;
 
 const settingsItem = { to: "/settings", label: "Settings", icon: GearSix } as const;

--- a/apps/desktop/src/renderer/components/test/TestPage.tsx
+++ b/apps/desktop/src/renderer/components/test/TestPage.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export function TestPage() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <div className="text-center">
+        <h1 className="text-2xl font-semibold text-fg">Coming Soon</h1>
+        <p className="mt-2 text-sm text-muted-fg">This feature is under construction.</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Added a new **Test** tab to the sidebar navigation (`TabNav.tsx`) with a Flask icon
- Created a new `TestPage.tsx` component that displays a "Coming Soon" placeholder screen
- Wired the `/test` route in `App.tsx` with a lazy import
- Added `/test` to the tint map in `AppShell.tsx` for visual consistency

## Files Changed
- `apps/desktop/src/renderer/components/app/TabNav.tsx`
- `apps/desktop/src/renderer/components/app/App.tsx`
- `apps/desktop/src/renderer/components/app/AppShell.tsx`
- `apps/desktop/src/renderer/components/test/TestPage.tsx` (new file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Test" page to the application, accessible from the main navigation menu with a dedicated icon. The page currently displays a "Coming Soon" placeholder message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->