### PR TITLE
Add Test tab to sidebar with Coming Soon screen

### DIFF
--- a/apps/desktop/src/renderer/components/app/App.tsx
+++ b/apps/desktop/src/renderer/components/app/App.tsx
@@ -47,6 +47,9 @@ const MissionsPage = React.lazy(() =>
 const CtoPage = React.lazy(() =>
   import("../cto/CtoPage").then((m) => ({ default: m.CtoPage }))
 );
+const TestPage = React.lazy(() =>
+  import("../test/TestPage").then((m) => ({ default: m.TestPage }))
+);
 
 import { useAppStore } from "../../state/appStore";
 
@@ -183,6 +186,7 @@ export function App() {
             <Route path="/automations" element={guardedLazy(<AutomationsPage />)} />
             <Route path="/missions" element={guardedLazy(<MissionsPage />)} />
             <Route path="/cto" element={guardedLazy(<CtoPage />)} />
+            <Route path="/test" element={guardedLazy(<TestPage />)} />
             <Route path="/settings" element={guardedLazy(<SettingsPage />)} />
             <Route path="*" element={<Navigate to="/project" replace />} />
           </Route>

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -355,6 +355,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       "/automations": "tab-tint-automations",
       "/missions": "tab-tint-missions",
       "/settings": "tab-tint-settings",
+      "/test": "tab-tint-test",
     };
     return tintMap[location.pathname] ?? "";
   }, [location.pathname]);

--- a/apps/desktop/src/renderer/components/app/TabNav.tsx
+++ b/apps/desktop/src/renderer/components/app/TabNav.tsx
@@ -13,6 +13,7 @@ import {
   Strategy,
   Brain,
   GearSix,
+  Flask,
 } from "@phosphor-icons/react";
 import { cn } from "../ui/cn";
 import { useAppStore } from "../../state/appStore";
@@ -30,6 +31,7 @@ const mainItems = [
   { to: "/automations", label: "Automations", icon: Robot },
   { to: "/missions", label: "Missions", icon: Strategy },
   { to: "/cto", label: "CTO", icon: Brain },
+  { to: "/test", label: "Test", icon: Flask },
 ] as const;
 
 const settingsItem = { to: "/settings", label: "Settings", icon: GearSix } as const;

--- a/apps/desktop/src/renderer/components/test/TestPage.tsx
+++ b/apps/desktop/src/renderer/components/test/TestPage.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Flask } from "@phosphor-icons/react";
+
+export function TestPage() {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-4 text-fg">
+      <Flask size={48} weight="thin" className="text-muted-fg/50" />
+      <div className="text-center">
+        <div className="text-lg font-semibold">Coming Soon</div>
+        <div className="mt-1 text-sm text-muted-fg">This feature is under construction.</div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Added a new **Test** tab to the sidebar navigation (TabNav.tsx) using the `Flask` icon from `@phosphor-icons/react`
- Created `TestPage.tsx` under `apps/desktop/src/renderer/components/test/` with a centered "Coming Soon" message
- Registered the `/test` route in `App.tsx` with lazy loading and project guard
- Added `tab-tint-test` mapping in `AppShell.tsx` tintMap for route-based background tinting

## Test plan
- [ ] Launch the desktop app and verify the **Test** tab appears in the sidebar
- [ ] Click the Test tab and confirm the "Coming Soon" screen renders with the Flask icon and message
- [ ] Verify all other tabs still navigate correctly
- [ ] Confirm sidebar disabled state works (tab is grayed out when no project is open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Test" tab in the main navigation that links to a dedicated test page placeholder displaying "Coming Soon" and "This feature is under construction" messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->