### PR TITLE
feat: add Test tab with Coming Soon screen

### DIFF
--- a/apps/desktop/src/renderer/components/app/App.tsx
+++ b/apps/desktop/src/renderer/components/app/App.tsx
@@ -47,6 +47,9 @@ const MissionsPage = React.lazy(() =>
 const CtoPage = React.lazy(() =>
   import("../cto/CtoPage").then((m) => ({ default: m.CtoPage }))
 );
+const TestPage = React.lazy(() =>
+  import("../test/TestPage").then((m) => ({ default: m.TestPage }))
+);
 
 import { useAppStore } from "../../state/appStore";
 
@@ -183,6 +186,7 @@ export function App() {
             <Route path="/automations" element={guardedLazy(<AutomationsPage />)} />
             <Route path="/missions" element={guardedLazy(<MissionsPage />)} />
             <Route path="/cto" element={guardedLazy(<CtoPage />)} />
+            <Route path="/test" element={guardedLazy(<TestPage />)} />
             <Route path="/settings" element={guardedLazy(<SettingsPage />)} />
             <Route path="*" element={<Navigate to="/project" replace />} />
           </Route>

--- a/apps/desktop/src/renderer/components/app/TabNav.tsx
+++ b/apps/desktop/src/renderer/components/app/TabNav.tsx
@@ -12,6 +12,7 @@ import {
   Robot,
   Strategy,
   Brain,
+  Flask,
   GearSix,
 } from "@phosphor-icons/react";
 import { cn } from "../ui/cn";
@@ -30,6 +31,7 @@ const mainItems = [
   { to: "/automations", label: "Automations", icon: Robot },
   { to: "/missions", label: "Missions", icon: Strategy },
   { to: "/cto", label: "CTO", icon: Brain },
+  { to: "/test", label: "Test", icon: Flask },
 ] as const;
 
 const settingsItem = { to: "/settings", label: "Settings", icon: GearSix } as const;

--- a/apps/desktop/src/renderer/components/test/TestPage.tsx
+++ b/apps/desktop/src/renderer/components/test/TestPage.tsx
@@ -1,0 +1,8 @@
+export function TestPage() {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3">
+      <div className="text-lg font-semibold text-fg">Coming Soon</div>
+      <div className="text-sm text-muted-fg">This feature is under development.</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Added a new **Test** tab to the sidebar navigation in `TabNav.tsx`, using the `Flask` icon from `@phosphor-icons/react`
- Created a new `TestPage.tsx` component that displays a centered "Coming Soon" screen
- Registered the `/test` route in `App.tsx` with lazy loading and the standard `guardedLazy` wrapper

## Changes

| File | Action |
|------|--------|
| `apps/desktop/src/renderer/components/test/TestPage.tsx` | **Created** — "Coming Soon" screen |
| `apps/desktop/src/renderer/components/app/TabNav.tsx` | **Edited** — added Flask import + Test entry to mainItems |
| `apps/desktop/src/renderer/components/app/App.tsx` | **Edited** — added lazy import + `/test` route |

`AppShell.tsx` was not modified — routes without a tintMap entry default to `""` (same as the CTO tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Test" tab in the navigation menu. Selecting it displays a page indicating the feature is currently under development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->