### PR TITLE
Retry pairing across multiple addresses with fallback

### DIFF
--- a/apps/ios/ADE.xcodeproj/project.pbxproj
+++ b/apps/ios/ADE.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		1A0D93D06509796A389A4CAA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 31EC445F22FD38F90C16343E /* Foundation.framework */; };
 		26C8992F8D661707E9360503 /* Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51942BAC0965C7D0CCE6E8B8 /* Database.swift */; };
 		28CFE3D489EA1B208D231519 /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B5024B0A05F3D9754101F1 /* SyncService.swift */; };
-		493041A1D11B75220D2C04BA /* PreviewHostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B604C3DA0CCF88E7C31A47 /* PreviewHostApp.swift */; };
 		4DC17C7C8E82D387043B01FD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B17472FAC08845853BC6B4 /* ContentView.swift */; };
 		56223CC3AF5A01B710CDC4CF /* WorkTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6ECFA9D57E70E57A60E8AB /* WorkTabView.swift */; };
 		60F4CDDB763C0A9F0E650B40 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 31EC445F22FD38F90C16343E /* Foundation.framework */; };
@@ -21,7 +20,6 @@
 		6E32ED1BF961DFEFCA12EF52 /* DatabaseBootstrap.sql in Resources */ = {isa = PBXBuildFile; fileRef = 2856F8D2F2D630DD985B870A /* DatabaseBootstrap.sql */; };
 		7B70BE6839672E5D2D006B28 /* ADETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14C0DF7FEB4C2EB854BAC888 /* ADETests.swift */; };
 		889573D8A5ED468D3BD12894 /* PRsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EE4D463D21266B62B422D11 /* PRsTabView.swift */; };
-		BE6DE22072CF77B9D7F61849 /* _PreviewGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299EFB5C0DFB103946352014 /* _PreviewGenerated.swift */; };
 		E689F42D41A500BB8CA233E4 /* LanesTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9270CF8A67F3FA79089F39C1 /* LanesTabView.swift */; };
 		FBEEF09EFB4911FEAC6A7E87 /* RemoteModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483C5F1818BAE74B19B84617 /* RemoteModels.swift */; };
 /* End PBXBuildFile section */
@@ -31,7 +29,6 @@
 		14C0DF7FEB4C2EB854BAC888 /* ADETests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ADETests.swift; path = ADETests/ADETests.swift; sourceTree = "<group>"; };
 		27A125DE2C17BA32F9291513 /* ADE.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ADE.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2856F8D2F2D630DD985B870A /* DatabaseBootstrap.sql */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = DatabaseBootstrap.sql; path = ADE/Resources/DatabaseBootstrap.sql; sourceTree = "<group>"; };
-		299EFB5C0DFB103946352014 /* _PreviewGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = _PreviewGenerated.swift; path = "/Users/admin/Projects/ADE/.ade/worktrees/phase-6-w6-14727791/apps/ios/.preview-host-5215/_PreviewGenerated.swift"; sourceTree = "<absolute>"; };
 		31EC445F22FD38F90C16343E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		483C5F1818BAE74B19B84617 /* RemoteModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RemoteModels.swift; path = ADE/Models/RemoteModels.swift; sourceTree = "<group>"; };
 		4EBFB65019F4C3F8A89428CE /* FilesTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FilesTabView.swift; path = ADE/Views/FilesTabView.swift; sourceTree = "<group>"; };
@@ -45,17 +42,9 @@
 		C9411193AF56B236BA32EFF5 /* ADEApp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ADEApp.swift; path = ADE/App/ADEApp.swift; sourceTree = "<group>"; };
 		CCAB2414C359E971B780BF99 /* PreviewHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PreviewHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3A5721EB84321D201716BC3 /* ADETests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ADETests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		F9B604C3DA0CCF88E7C31A47 /* PreviewHostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PreviewHostApp.swift; path = "/Users/admin/Projects/ADE/.ade/worktrees/phase-6-w6-14727791/apps/ios/.preview-host-5215/PreviewHostApp.swift"; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		A2277063AB920F24E252FC26 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		DE00988229EE6003DBF8D8FA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -121,16 +110,6 @@
 				7A6120AF79287BB301D63A58 /* ADE */,
 				C77DE76E58CC8D681F4D4619 /* ADETests */,
 			);
-			sourceTree = "<group>";
-		};
-		57F0F581E90BCD6667ADB538 /* PreviewHost */ = {
-			isa = PBXGroup;
-			children = (
-				F9B604C3DA0CCF88E7C31A47 /* PreviewHostApp.swift */,
-				299EFB5C0DFB103946352014 /* _PreviewGenerated.swift */,
-			);
-			name = PreviewHost;
-			path = PreviewHost;
 			sourceTree = "<group>";
 		};
 		6AC81F4E8475EA47F592B212 /* Frameworks */ = {
@@ -234,6 +213,12 @@
 				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
+					62C217CE2C1C31B3127D1ACF = {
+						DevelopmentTeam = VQ372F39G6;
+					};
+					928432ECB10B6E8870725B02 = {
+						DevelopmentTeam = VQ372F39G6;
+					};
 				};
 			};
 			buildConfigurationList = 966E640F465400271B948B96 /* Build configuration list for PBXProject "ADE" */;
@@ -245,28 +230,18 @@
 				Base,
 			);
 			mainGroup = 564208E3878DD0F0137C7E86;
-			minimizedProjectReferenceProxies = 0;
-			preferredProjectObjectVersion = 77;
 			productRefGroup = 7FAD2BF35AA6A286BCF68D49 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
 				928432ECB10B6E8870725B02 /* ADE */,
 				62C217CE2C1C31B3127D1ACF /* ADETests */,
-				472C95015F096F262DBDFB0B,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		0C78157439BD019931D9CBAD /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		55E96B18CA5590B7FE2D1B9E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -285,15 +260,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		569BFAD3D473FA50C6E4A50F /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				493041A1D11B75220D2C04BA /* PreviewHostApp.swift in Sources */,
-				BE6DE22072CF77B9D7F61849 /* _PreviewGenerated.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		73ED0BCB9618AA29B41D84DA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -327,7 +293,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGNING_ALLOWED = NO;
+				DEVELOPMENT_TEAM = VQ372F39G6;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ade.ios.tests;
@@ -344,7 +310,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGNING_ALLOWED = NO;
+				DEVELOPMENT_TEAM = VQ372F39G6;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = ADE/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
@@ -353,25 +319,6 @@
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		4DE7553D2E083BB93BC7E68A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.preview.host;
-				PRODUCT_NAME = PreviewHost;
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -423,8 +370,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -435,7 +381,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGNING_ALLOWED = NO;
+				DEVELOPMENT_TEAM = VQ372F39G6;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = ADE/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
@@ -445,25 +391,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		AD48606A456393537FF98AB9 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.preview.host;
-				PRODUCT_NAME = PreviewHost;
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -533,7 +460,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_OBJC_WEAK = NO;
-				CODE_SIGNING_ALLOWED = NO;
+				DEVELOPMENT_TEAM = VQ372F39G6;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ade.ios.tests;
@@ -574,15 +501,6 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
-		};
-		EF4AAAB241B4F2BB518D04DA = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				4DE7553D2E083BB93BC7E68A /* Debug */,
-				AD48606A456393537FF98AB9 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -231,42 +231,58 @@ final class SyncService: ObservableObject {
     }
     do {
       allowAutoReconnect = true
-      let addressCandidates = deduplicatedAddresses([host] + candidateAddresses)
-      let preferredAddress = addressCandidates.first ?? host
-      try await openSocket(host: preferredAddress, port: port)
-      let requestId = makeRequestId()
-      let raw = try await awaitResponse(requestId: requestId) {
-        self.sendEnvelope(type: "pairing_request", requestId: requestId, payload: [
-          "code": code.trimmingCharacters(in: .whitespacesAndNewlines).uppercased(),
-          "peer": self.currentPeerMetadata(),
-        ])
-      }
-      guard let payload = raw as? [String: Any], (payload["ok"] as? Bool) == true else {
-        throw NSError(domain: "ADE", code: 2, userInfo: [
-          NSLocalizedDescriptionKey: friendlyPairingFailureMessage(raw)
-        ])
-      }
-      guard let secret = payload["secret"] as? String else {
-        throw NSError(domain: "ADE", code: 3, userInfo: [NSLocalizedDescriptionKey: "Pairing secret missing from response."])
-      }
-      let pairedDeviceId = payload["deviceId"] as? String ?? deviceId
-      keychain.saveToken(secret)
-      let profile = HostConnectionProfile(
-        hostIdentity: hostIdentity,
-        hostName: hostName,
-        port: port,
-        authKind: "paired",
-        pairedDeviceId: pairedDeviceId,
-        lastRemoteDbVersion: 0,
-        lastHostDeviceId: nil,
-        lastSuccessfulAddress: preferredAddress,
-        savedAddressCandidates: addressCandidates,
-        discoveredLanAddresses: addressCandidates.filter { !$0.contains("100.") && !$0.contains(":") },
+      let addressCandidates = prioritizedPairingAddresses(
+        host: host,
+        candidateAddresses: candidateAddresses,
+        expectedHostIdentity: hostIdentity,
         tailscaleAddress: tailscaleAddress
       )
-      saveProfile(profile)
-      currentAddress = preferredAddress
-      try await hello(host: preferredAddress, port: port, token: secret, authKind: "paired", pairedDeviceId: pairedDeviceId, expectedHostIdentity: hostIdentity)
+      var lastFailure: Error?
+      for address in addressCandidates {
+        do {
+          try await openSocket(host: address, port: port)
+          let requestId = makeRequestId()
+          let raw = try await awaitResponse(requestId: requestId) {
+            self.sendEnvelope(type: "pairing_request", requestId: requestId, payload: [
+              "code": code.trimmingCharacters(in: .whitespacesAndNewlines).uppercased(),
+              "peer": self.currentPeerMetadata(),
+            ])
+          }
+          guard let payload = raw as? [String: Any], (payload["ok"] as? Bool) == true else {
+            throw makePairingFailure(raw)
+          }
+          guard let secret = payload["secret"] as? String else {
+            throw NSError(domain: "ADE", code: 3, userInfo: [NSLocalizedDescriptionKey: "Pairing secret missing from response."])
+          }
+          let pairedDeviceId = payload["deviceId"] as? String ?? deviceId
+          keychain.saveToken(secret)
+          let profile = HostConnectionProfile(
+            hostIdentity: hostIdentity,
+            hostName: hostName,
+            port: port,
+            authKind: "paired",
+            pairedDeviceId: pairedDeviceId,
+            lastRemoteDbVersion: 0,
+            lastHostDeviceId: nil,
+            lastSuccessfulAddress: address,
+            savedAddressCandidates: addressCandidates,
+            discoveredLanAddresses: addressCandidates.filter { !$0.contains("100.") && !$0.contains(":") },
+            tailscaleAddress: tailscaleAddress
+          )
+          saveProfile(profile)
+          currentAddress = address
+          try await hello(host: address, port: port, token: secret, authKind: "paired", pairedDeviceId: pairedDeviceId, expectedHostIdentity: hostIdentity)
+          return
+        } catch {
+          lastFailure = error
+          socket?.cancel(with: .goingAway, reason: nil)
+          socket = nil
+          if shouldStopPairingRetries(for: error) {
+            throw error
+          }
+        }
+      }
+      throw lastFailure ?? NSError(domain: "ADE", code: 21, userInfo: [NSLocalizedDescriptionKey: "Unable to reach the ADE host with that pairing code."])
     } catch {
       lastError = error.localizedDescription
       connectionState = .error
@@ -320,6 +336,22 @@ final class SyncService: ObservableObject {
     default:
       return message ?? "Pairing failed."
     }
+  }
+
+  private func makePairingFailure(_ raw: Any) -> NSError {
+    let error = (raw as? [String: Any])?["error"] as? [String: Any]
+    let errorCode = error?["code"] as? String
+    var userInfo: [String: Any] = [
+      NSLocalizedDescriptionKey: friendlyPairingFailureMessage(raw),
+    ]
+    if let errorCode {
+      userInfo["ADEErrorCode"] = errorCode
+    }
+    return NSError(
+      domain: "ADE",
+      code: 2,
+      userInfo: userInfo
+    )
   }
 
   func disconnect(clearCredentials: Bool = false) {
@@ -895,6 +927,21 @@ final class SyncService: ObservableObject {
       .filter { seen.insert($0).inserted }
   }
 
+  func prioritizedPairingAddresses(
+    host: String,
+    candidateAddresses: [String],
+    expectedHostIdentity: String?,
+    tailscaleAddress: String?
+  ) -> [String] {
+    let matchingDiscovery = discoveredHosts.filter { discovered in
+      guard let expectedHostIdentity else { return false }
+      return discovered.hostIdentity == expectedHostIdentity
+    }
+    let liveLan = matchingDiscovery.flatMap(\.addresses)
+    let liveTailscale = matchingDiscovery.compactMap(\.tailscaleAddress)
+    return deduplicatedAddresses(liveLan + [host] + candidateAddresses + liveTailscale + (tailscaleAddress.map { [$0] } ?? []))
+  }
+
   private func prioritizedAddresses(for profile: HostConnectionProfile) -> [String] {
     let matchingDiscovery = discoveredHosts.filter { host in
       guard let hostIdentity = profile.hostIdentity else { return true }
@@ -983,6 +1030,16 @@ final class SyncService: ObservableObject {
   private func shouldInvalidateSavedPairing(for error: Error) -> Bool {
     let nsError = error as NSError
     return nsError.userInfo["ADEErrorCode"] as? String == "auth_failed"
+  }
+
+  private func shouldStopPairingRetries(for error: Error) -> Bool {
+    let nsError = error as NSError
+    switch nsError.userInfo["ADEErrorCode"] as? String {
+    case "expired_code", "invalid_code", "pairing_unavailable":
+      return true
+    default:
+      return false
+    }
   }
 
   private func applyDiscoveredHosts(_ hosts: [DiscoveredSyncHost]) {
@@ -1107,7 +1164,10 @@ final class SyncService: ObservableObject {
       throw NSError(
         domain: "ADE",
         code: 20,
-        userInfo: [NSLocalizedDescriptionKey: "The saved pairing belongs to a different ADE host. Pair again with the current host."]
+        userInfo: [
+          NSLocalizedDescriptionKey: "The saved pairing belongs to a different ADE host. Pair again with the current host.",
+          "ADEErrorCode": "unexpected_host",
+        ]
       )
     }
 

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -78,6 +78,20 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(decoded.addressCandidates.map(\.host), ["192.168.1.8", "100.101.102.103"])
   }
 
+  @MainActor
+  func testPrioritizedPairingAddressesPreservesHostAndDeduplicatesCandidates() throws {
+    let service = SyncService(database: makeDatabase(baseURL: makeTemporaryDirectory()))
+
+    let addresses = service.prioritizedPairingAddresses(
+      host: "192.168.1.8",
+      candidateAddresses: ["192.168.1.8", "192.168.1.9", "100.101.102.103"],
+      expectedHostIdentity: "host-1",
+      tailscaleAddress: "100.101.102.103"
+    )
+
+    XCTAssertEqual(addresses, ["192.168.1.8", "192.168.1.9", "100.101.102.103"])
+  }
+
   func testDatabasePersistsStableSiteIdAcrossReopen() throws {
     let baseURL = makeTemporaryDirectory()
     let database = makeDatabase(baseURL: baseURL)

--- a/docs/architecture/IOS_APP.md
+++ b/docs/architecture/IOS_APP.md
@@ -134,11 +134,21 @@ Current Phase 6 stance:
 ### Connection Lifecycle
 
 1. App launch: read pairing token from Keychain.
-2. Resolve host address from the saved draft or manual entry.
+2. Resolve host address from the saved profile or manual entry.
 3. Open WebSocket connection.
 4. Send local `db_version`, receive catchup changesets.
 5. Enter continuous bidirectional sync.
 6. On disconnect: automatic reconnection with exponential backoff.
+
+### Pairing Address Resolution
+
+Initial pairing uses multi-address fallback to handle networks where the first candidate may be unreachable:
+
+1. `prioritizedPairingAddresses()` builds a deduplicated address list from live mDNS discovery results (filtered by expected host identity), the provided host address, any QR/manual candidate addresses, and the Tailscale address.
+2. The pairing flow iterates through each address in order, opening a socket and sending the pairing request.
+3. On success, the working address is saved as `lastSuccessfulAddress` in the connection profile for future reconnects.
+4. On failure, the socket is torn down and the next address is tried -- unless the error is terminal (expired code, pairing unavailable), in which case the flow stops immediately.
+5. If all addresses are exhausted, the last connection error is surfaced to the user.
 
 ### Message Types
 

--- a/docs/architecture/MULTI_DEVICE_SYNC.md
+++ b/docs/architecture/MULTI_DEVICE_SYNC.md
@@ -186,6 +186,7 @@ Desktop nuance:
 - W3 uses manual host/port/bootstrap-token entry in Settings > Sync.
 - Numeric-code pairing and per-device secrets are implemented.
 - mDNS discovery, QR pairing presentation/scanning, Tailscale address selection, and final network hardening remain follow-on W5 work.
+- Pairing uses multi-address fallback: `prioritizedPairingAddresses()` merges live mDNS-discovered addresses (filtered by host identity), the provided host address, QR/manual candidates, and any Tailscale address into a deduplicated priority list. The pairing flow tries each address in order, stopping early on terminal errors (expired code, pairing unavailable) and saving the successful address in the connection profile.
 
 ---
 


### PR DESCRIPTION
## Summary
- **Multi-address pairing fallback**: `pair()` now tries each candidate address sequentially (live LAN discovery, provided host, candidates, Tailscale) instead of only the first. Stops early on terminal errors (`expired_code`, `invalid_code`, `pairing_unavailable`).
- **Xcode project cleanup**: Removed stale PreviewHost target and worktree preview artifacts, added dev team, fixed code signing config.
- **Docs**: Updated `IOS_APP.md` and `MULTI_DEVICE_SYNC.md` with pairing address resolution details.

## Test plan
- [x] New test `testPrioritizedPairingAddressesPreservesHostAndDeduplicatesCandidates` passes
- [x] All 22 iOS tests pass (`xcodebuild test`)
- [x] iOS app builds successfully
- [x] Desktop typecheck and lint unaffected
- [x] Doc validation passes (61 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pairing now attempts multiple network addresses sequentially to improve connection reliability and success rates.

* **Bug Fixes**
  * Enhanced error handling for pairing failures with clearer error messaging.
  * Terminal error states are now properly identified to prevent unnecessary retry attempts.

* **Tests**
  * Added test coverage for address prioritization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->