### PR TITLE
Proof drawer fixes, lane creation, and PR target branch

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, nativeImage, shell } from "electron";
+import { app, BrowserWindow, nativeImage, protocol, shell } from "electron";
 import path from "node:path";
 type NodePtyType = typeof import("node-pty");
 import { registerIpc } from "./services/ipc/registerIpc";
@@ -394,7 +394,82 @@ async function createWindow(logger?: Logger): Promise<BrowserWindow> {
   return win;
 }
 
+// Register custom protocol for serving local artifact files (images, videos) to the renderer.
+// Must be called before app.whenReady().
+protocol.registerSchemesAsPrivileged([
+  { scheme: "ade-artifact", privileges: { standard: false, supportFetchAPI: true, stream: true, bypassCSP: true } },
+]);
+
 app.whenReady().then(async () => {
+  // Handle ade-artifact:// requests — serves local files for proof drawer previews.
+  // Path is encoded in the URL: ade-artifact:///absolute/path/to/file.png
+  protocol.handle("ade-artifact", (request) => {
+    const url = new URL(request.url);
+    let filePath = decodeURIComponent(url.pathname);
+    // On Windows, pathname starts with /C:/... — strip leading slash
+    if (process.platform === "win32" && /^\/[a-zA-Z]:/.test(filePath)) {
+      filePath = filePath.slice(1);
+    }
+    try {
+      const stat = fs.statSync(filePath);
+      if (!stat.isFile()) return new Response("Not found", { status: 404 });
+      const fileSize = stat.size;
+      const ext = path.extname(filePath).replace(/^\./, "").toLowerCase();
+      const mimeMap: Record<string, string> = {
+        png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", webp: "image/webp",
+        gif: "image/gif", bmp: "image/bmp", svg: "image/svg+xml",
+        mp4: "video/mp4", webm: "video/webm", mov: "video/quicktime", avi: "video/x-msvideo", mkv: "video/x-matroska",
+      };
+      const mime = mimeMap[ext] ?? "application/octet-stream";
+
+      // Support Range requests — required for <video> playback and seeking
+      const rangeHeader = request.headers.get("Range");
+      if (rangeHeader) {
+        const match = /bytes=(\d+)-(\d*)/.exec(rangeHeader);
+        const start = match ? parseInt(match[1], 10) : 0;
+        const end = match && match[2] ? parseInt(match[2], 10) : fileSize - 1;
+        const chunkSize = end - start + 1;
+        const fileStream = fs.createReadStream(filePath, { start, end });
+        const webStream = new ReadableStream({
+          start(controller) {
+            fileStream.on("data", (chunk) => controller.enqueue(typeof chunk === "string" ? Buffer.from(chunk) : chunk));
+            fileStream.on("end", () => controller.close());
+            fileStream.on("error", () => controller.close());
+          },
+          cancel() { fileStream.destroy(); },
+        });
+        return new Response(webStream, {
+          status: 206,
+          headers: {
+            "Content-Type": mime,
+            "Content-Range": `bytes ${start}-${end}/${fileSize}`,
+            "Content-Length": String(chunkSize),
+            "Accept-Ranges": "bytes",
+          },
+        });
+      }
+
+      // Full file response (images, small files)
+      const fileStream = fs.createReadStream(filePath);
+      const webStream = new ReadableStream({
+        start(controller) {
+          fileStream.on("data", (chunk) => controller.enqueue(typeof chunk === "string" ? Buffer.from(chunk) : chunk));
+          fileStream.on("end", () => controller.close());
+          fileStream.on("error", () => controller.close());
+        },
+        cancel() { fileStream.destroy(); },
+      });
+      return new Response(webStream, {
+        headers: {
+          "Content-Type": mime,
+          "Content-Length": String(fileSize),
+          "Accept-Ranges": "bytes",
+        },
+      });
+    } catch {
+      return new Response("Not found", { status: 404 });
+    }
+  });
   console.log("[info] app.hardware_acceleration", {
     enabled: !disableHardwareAcceleration,
     reason: disableHardwareAcceleration

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -131,6 +131,7 @@ import type { LinearCredentialService } from "../cto/linearCredentialService";
 import type { createPrService } from "../prs/prService";
 import type { ComputerUseArtifactBrokerService } from "../computerUse/computerUseArtifactBrokerService";
 import { createProofObserver } from "../computerUse/proofObserver";
+import { maybeSyntheticToolResult } from "../computerUse/syntheticToolResult";
 import { resolveAdeMcpServerLaunch, resolveUnifiedRuntimeRoot } from "../orchestrator/unifiedOrchestratorAdapter";
 import type { createMissionService } from "../missions/missionService";
 import type { createAiOrchestratorService } from "../orchestrator/aiOrchestratorService";
@@ -4795,6 +4796,12 @@ export function createAgentChatService(args: {
                     itemId,
                     turnId,
                   });
+                  // Synthesize a tool_result for the proof observer since the
+                  // Claude V2 SDK never surfaces tool results in the stream.
+                  const syntheticResult = maybeSyntheticToolResult(toolName, block.input ?? {}, itemId, turnId);
+                  if (syntheticResult) {
+                    emitChatEvent(managed, syntheticResult);
+                  }
                 }
               }
             }
@@ -4893,6 +4900,12 @@ export function createAgentChatService(args: {
                   itemId,
                   turnId,
                 });
+                // Synthesize a tool_result for the proof observer since the
+                // Claude V2 SDK never surfaces tool results in the stream.
+                const syntheticResult = maybeSyntheticToolResult(toolName, block.input ?? {}, itemId, turnId);
+                if (syntheticResult) {
+                  emitChatEvent(managed, syntheticResult);
+                }
               }
             }
           } else if (event.type === "message_start") {

--- a/apps/desktop/src/main/services/computerUse/syntheticToolResult.test.ts
+++ b/apps/desktop/src/main/services/computerUse/syntheticToolResult.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ComputerUseArtifactIngestionRequest } from "../../../shared/types";
+import { extractArtifactPathsFromArgs, maybeSyntheticToolResult } from "./syntheticToolResult";
+import { createProofObserver } from "./proofObserver";
+
+// ---------------------------------------------------------------------------
+// Unit tests for extractArtifactPathsFromArgs
+// ---------------------------------------------------------------------------
+
+describe("extractArtifactPathsFromArgs", () => {
+  it("extracts a png path from a Bash command string", () => {
+    const paths = extractArtifactPathsFromArgs({
+      command: "screenshot /tmp/proof.png",
+    });
+    expect(paths).toEqual(["/tmp/proof.png"]);
+  });
+
+  it("extracts multiple artifact paths from a single command", () => {
+    const paths = extractArtifactPathsFromArgs({
+      command: "cp /home/user/screenshot.png /tmp/trace.zip && cat /var/log/app.log",
+    });
+    expect(paths).toContain("/home/user/screenshot.png");
+    expect(paths).toContain("/tmp/trace.zip");
+    expect(paths).toContain("/var/log/app.log");
+    expect(paths).toHaveLength(3);
+  });
+
+  it("extracts image path from Read tool args", () => {
+    const paths = extractArtifactPathsFromArgs({
+      file_path: "/Users/dev/captures/test-result.jpg",
+    });
+    expect(paths).toEqual(["/Users/dev/captures/test-result.jpg"]);
+  });
+
+  it("extracts paths from nested object structures", () => {
+    const paths = extractArtifactPathsFromArgs({
+      options: {
+        output: {
+          screenshot: "/tmp/nested/shot.webp",
+        },
+      },
+    });
+    expect(paths).toEqual(["/tmp/nested/shot.webp"]);
+  });
+
+  it("extracts paths from arrays", () => {
+    const paths = extractArtifactPathsFromArgs({
+      files: ["/a/b.png", "/c/d.mp4"],
+    });
+    expect(paths).toContain("/a/b.png");
+    expect(paths).toContain("/c/d.mp4");
+    expect(paths).toHaveLength(2);
+  });
+
+  it("ignores relative paths (no leading slash)", () => {
+    const paths = extractArtifactPathsFromArgs({
+      command: "cat relative/path.png",
+    });
+    expect(paths).toEqual([]);
+  });
+
+  it("returns empty for args with no artifact paths", () => {
+    const paths = extractArtifactPathsFromArgs({
+      command: "echo hello world",
+    });
+    expect(paths).toEqual([]);
+  });
+
+  it("returns empty for non-artifact extensions", () => {
+    const paths = extractArtifactPathsFromArgs({
+      file_path: "/tmp/data.json",
+    });
+    expect(paths).toEqual([]);
+  });
+
+  it("deduplicates repeated paths", () => {
+    const paths = extractArtifactPathsFromArgs({
+      a: "/tmp/shot.png",
+      b: "/tmp/shot.png",
+    });
+    expect(paths).toEqual(["/tmp/shot.png"]);
+  });
+
+  it("handles null/undefined/number args gracefully", () => {
+    expect(extractArtifactPathsFromArgs(null)).toEqual([]);
+    expect(extractArtifactPathsFromArgs(undefined)).toEqual([]);
+    expect(extractArtifactPathsFromArgs(42)).toEqual([]);
+    expect(extractArtifactPathsFromArgs("")).toEqual([]);
+  });
+
+  it("respects recursion depth limit", () => {
+    // Build deeply nested structure (depth > 8)
+    let obj: any = { path: "/tmp/deep.png" };
+    for (let i = 0; i < 12; i++) {
+      obj = { nested: obj };
+    }
+    // The path is at depth 13 — beyond the limit of 8
+    const paths = extractArtifactPathsFromArgs(obj);
+    expect(paths).toEqual([]);
+  });
+
+  it("handles video extensions", () => {
+    const paths = extractArtifactPathsFromArgs({
+      command: "ffmpeg -o /tmp/recording.mp4",
+    });
+    expect(paths).toEqual(["/tmp/recording.mp4"]);
+  });
+
+  it("handles trace extensions", () => {
+    const paths = extractArtifactPathsFromArgs({
+      command: "playwright trace /tmp/session.trace",
+    });
+    expect(paths).toEqual(["/tmp/session.trace"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests for maybeSyntheticToolResult
+// ---------------------------------------------------------------------------
+
+describe("maybeSyntheticToolResult", () => {
+  it("returns null when no artifact paths found", () => {
+    const result = maybeSyntheticToolResult("Bash", { command: "echo hi" }, "item-1", "turn-1");
+    expect(result).toBeNull();
+  });
+
+  it("returns a tool_result event with artifact paths", () => {
+    const result = maybeSyntheticToolResult(
+      "Bash",
+      { command: "screenshot /tmp/proof.png" },
+      "item-1",
+      "turn-1",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("tool_result");
+    expect(result).toMatchObject({
+      type: "tool_result",
+      tool: "Bash",
+      itemId: "item-1:synthetic",
+      turnId: "turn-1",
+      status: "completed",
+    });
+    // The result object contains the artifact path
+    expect((result as any).result).toMatchObject({
+      artifactPath0: "/tmp/proof.png",
+    });
+  });
+
+  it("includes multiple artifact paths in the result", () => {
+    const result = maybeSyntheticToolResult(
+      "Bash",
+      { command: "cp /tmp/a.png /tmp/b.mp4" },
+      "item-2",
+      "turn-2",
+    );
+    expect(result).not.toBeNull();
+    const resultObj = (result as any).result;
+    expect(resultObj.artifactPath0).toBe("/tmp/a.png");
+    expect(resultObj.artifactPath1).toBe("/tmp/b.mp4");
+  });
+
+  it("appends :synthetic to the itemId to avoid collisions", () => {
+    const result = maybeSyntheticToolResult(
+      "Read",
+      { file_path: "/tmp/shot.png" },
+      "orig-id",
+      undefined,
+    );
+    expect((result as any).itemId).toBe("orig-id:synthetic");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: synthetic tool_result flows through proof observer
+// ---------------------------------------------------------------------------
+
+describe("proof observer integration with synthetic tool_result", () => {
+  function createHarness() {
+    const requests: ComputerUseArtifactIngestionRequest[] = [];
+    const broker = {
+      ingest: vi.fn((request: ComputerUseArtifactIngestionRequest) => {
+        requests.push(request);
+        return { artifacts: [], links: [] };
+      }),
+    } as any;
+    return {
+      requests,
+      broker,
+      observer: createProofObserver({ broker }),
+    };
+  }
+
+  it("proof observer ingests screenshot from synthetic Bash tool_result", () => {
+    const { observer, requests } = createHarness();
+
+    // Simulate what agentChatService does: build a synthetic tool_result from Bash args
+    const synthetic = maybeSyntheticToolResult(
+      "Bash",
+      { command: "take-screenshot /tmp/proof.png" },
+      "claude-tool:turn1:0",
+      "turn1",
+    );
+    expect(synthetic).not.toBeNull();
+
+    // Feed it to the observer
+    observer.observe(synthetic!, "session-1");
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.inputs).toEqual([
+      expect.objectContaining({
+        kind: "screenshot",
+        path: "/tmp/proof.png",
+      }),
+    ]);
+  });
+
+  it("proof observer ingests video from synthetic tool_result", () => {
+    const { observer, requests } = createHarness();
+
+    const synthetic = maybeSyntheticToolResult(
+      "Bash",
+      { command: "record /tmp/test.mp4" },
+      "claude-tool:turn1:1",
+      "turn1",
+    );
+    expect(synthetic).not.toBeNull();
+
+    observer.observe(synthetic!, "session-1");
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.inputs).toEqual([
+      expect.objectContaining({
+        kind: "video_recording",
+        path: "/tmp/test.mp4",
+      }),
+    ]);
+  });
+
+  it("proof observer ingests trace from synthetic tool_result", () => {
+    const { observer, requests } = createHarness();
+
+    const synthetic = maybeSyntheticToolResult(
+      "Bash",
+      { command: "playwright trace save /tmp/session-trace.zip" },
+      "claude-tool:turn1:2",
+      "turn1",
+    );
+    expect(synthetic).not.toBeNull();
+
+    observer.observe(synthetic!, "session-1");
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.inputs).toEqual([
+      expect.objectContaining({
+        kind: "browser_trace",
+        path: "/tmp/session-trace.zip",
+      }),
+    ]);
+  });
+
+  it("proof observer ignores synthetic tool_result with no artifacts", () => {
+    const { observer, requests } = createHarness();
+
+    const synthetic = maybeSyntheticToolResult(
+      "Bash",
+      { command: "echo hello" },
+      "claude-tool:turn1:3",
+      "turn1",
+    );
+    expect(synthetic).toBeNull();
+
+    // No event to observe
+    expect(requests).toHaveLength(0);
+  });
+
+  it("proof observer deduplicates synthetic results by itemId", () => {
+    const { observer, requests } = createHarness();
+
+    const synthetic = maybeSyntheticToolResult(
+      "Bash",
+      { command: "screenshot /tmp/proof.png" },
+      "claude-tool:turn1:0",
+      "turn1",
+    )!;
+
+    observer.observe(synthetic, "session-1");
+    observer.observe(synthetic, "session-1");
+
+    // Only ingested once
+    expect(requests).toHaveLength(1);
+  });
+
+  it("proof observer handles Read tool with image file_path", () => {
+    const { observer, requests } = createHarness();
+
+    const synthetic = maybeSyntheticToolResult(
+      "Read",
+      { file_path: "/Users/dev/screenshots/test.webp" },
+      "claude-tool:turn2:0",
+      "turn2",
+    )!;
+
+    observer.observe(synthetic, "session-1");
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.inputs).toEqual([
+      expect.objectContaining({
+        kind: "screenshot",
+        path: "/Users/dev/screenshots/test.webp",
+      }),
+    ]);
+    expect(requests[0]?.backend).toMatchObject({
+      style: "external_cli",
+      name: "chat-tool",
+      toolName: "Read",
+    });
+  });
+
+  it("proof observer handles MCP tool with artifact in args", () => {
+    const { observer, requests } = createHarness();
+
+    const synthetic = maybeSyntheticToolResult(
+      "mcp__playwright__browser_take_screenshot",
+      { outputPath: "/tmp/playwright-shot.png" },
+      "claude-tool:turn3:0",
+      "turn3",
+    )!;
+
+    observer.observe(synthetic, "session-1");
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.backend).toMatchObject({
+      style: "external_mcp",
+      name: "playwright",
+    });
+    expect(requests[0]?.inputs).toEqual([
+      expect.objectContaining({
+        kind: "screenshot",
+        path: "/tmp/playwright-shot.png",
+      }),
+    ]);
+  });
+});

--- a/apps/desktop/src/main/services/computerUse/syntheticToolResult.ts
+++ b/apps/desktop/src/main/services/computerUse/syntheticToolResult.ts
@@ -1,0 +1,82 @@
+/**
+ * Synthetic tool_result generation for the Claude V2 SDK streaming path.
+ *
+ * The Claude V2 SDK executes tools internally and only surfaces `assistant`
+ * messages in the stream — tool results are opaque. The proof observer relies
+ * on `tool_result` events to auto-ingest screenshots and other artifacts into
+ * the proof drawer.
+ *
+ * This module scans tool call *args* for artifact-indicating file paths and
+ * builds a synthetic `tool_result` event that the proof observer can process.
+ */
+
+import type { AgentChatEvent } from "../../../shared/types/chat";
+
+// Matches absolute file paths ending with known artifact extensions.
+// The leading group catches a boundary char (or start) before the path.
+const ARTIFACT_PATH_RE =
+  /(?:^|[\s"'=:,])(\/?(?:[\w.~-]+\/)*[\w.~-]+\.(?:png|jpe?g|webp|gif|bmp|tiff|svg|mp4|webm|mov|avi|mkv|zip|trace|log|txt|ndjson|jsonl))\b/gi;
+
+/**
+ * Extract file paths that look like artifacts from an arbitrary args value.
+ * Returns an array of unique absolute paths found.
+ */
+export function extractArtifactPathsFromArgs(args: unknown): string[] {
+  const paths = new Set<string>();
+
+  function scan(value: unknown, depth: number): void {
+    if (depth > 8) return;
+    if (typeof value === "string") {
+      ARTIFACT_PATH_RE.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = ARTIFACT_PATH_RE.exec(value)) !== null) {
+        const p = match[1].trim();
+        if (p.startsWith("/")) paths.add(p);
+      }
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) scan(item, depth + 1);
+      return;
+    }
+    if (value != null && typeof value === "object") {
+      for (const v of Object.values(value as Record<string, unknown>)) {
+        scan(v, depth + 1);
+      }
+    }
+  }
+
+  scan(args, 0);
+  return Array.from(paths);
+}
+
+/**
+ * Build a synthetic `tool_result` AgentChatEvent from tool call args.
+ * Returns null if no artifact paths are found in the args.
+ */
+export function maybeSyntheticToolResult(
+  toolName: string,
+  args: unknown,
+  itemId: string,
+  turnId: string | undefined,
+): AgentChatEvent | null {
+  const artifactPaths = extractArtifactPathsFromArgs(args);
+  if (artifactPaths.length === 0) return null;
+
+  // Build a result object that the proof observer's scanners will pick up.
+  // Use a structure with named fields so the observer can infer kind from
+  // both the field name and the file extension.
+  const result: Record<string, string> = {};
+  for (let i = 0; i < artifactPaths.length; i++) {
+    result[`artifactPath${i}`] = artifactPaths[i];
+  }
+
+  return {
+    type: "tool_result",
+    tool: toolName,
+    result,
+    itemId: `${itemId}:synthetic`,
+    turnId,
+    status: "completed",
+  };
+}

--- a/apps/desktop/src/main/services/conflicts/conflictService.ts
+++ b/apps/desktop/src/main/services/conflicts/conflictService.ts
@@ -4355,7 +4355,17 @@ export function createConflictService({
       onEvent({ type: "rebase-needs-updated", needs, timestamp: new Date().toISOString() });
     }
 
-    return needs;
+    // Deduplicate: when a lane has both a lane-base need and a PR-target need,
+    // keep only the PR-target need (PR target is the source of truth).
+    const laneIdsWithPrNeeds = new Set(needs.filter(n => n.prId != null).map(n => n.laneId));
+    const deduplicated = needs.filter(n => !(n.prId == null && laneIdsWithPrNeeds.has(n.laneId)));
+
+    // Emit rebase-needs-updated so renderer gets notified
+    if (onEvent) {
+      onEvent({ type: "rebase-needs-updated", needs: deduplicated, timestamp: new Date().toISOString() });
+    }
+
+    return deduplicated;
   };
 
   const getRebaseNeed = async (laneId: string): Promise<RebaseNeed | null> => {

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -1665,6 +1665,28 @@ export function registerIpc({
     shell.showItemInFolder(normalized);
   });
 
+  ipcMain.handle(IPC.appOpenPath, async (_event, arg: { path: string }): Promise<void> => {
+    const raw = typeof arg?.path === "string" ? arg.path.trim() : "";
+    if (!raw) return;
+    const normalized = path.resolve(raw);
+    const allowedDirs = getAllowedDirs(getCtx);
+    const allowed = allowedDirs.some((dir) => {
+      try {
+        resolvePathWithinRoot(dir, normalized);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    if (!allowed) {
+      throw new Error("Path is outside allowed directories.");
+    }
+    const errorMessage = await shell.openPath(normalized);
+    if (errorMessage) {
+      throw new Error(`Failed to open path: ${errorMessage}`);
+    }
+  });
+
   ipcMain.handle(IPC.appWriteClipboardText, async (_event, arg: { text: string }): Promise<void> => {
     const text = typeof arg?.text === "string" ? arg.text : "";
     clipboard.writeText(text);
@@ -3903,20 +3925,41 @@ export function registerIpc({
   });
 
   ipcMain.handle(IPC.computerUseReadArtifactPreview, async (_event, arg: { uri: string }): Promise<string | null> => {
-    const fs = await import("node:fs");
-    const pathMod = await import("node:path");
+    const ctx = getCtx();
+    const projectRoot = ctx.project.rootPath;
+    const layout = resolveAdeLayout(projectRoot);
+    // Only allow files under artifactsDir — consistent with the ade-artifact:// protocol
+    // handler in main.ts which validates exclusively against currentArtifactsDir.
+    const allowedRoots = [layout.artifactsDir];
+
     let filePath = arg.uri;
     if (filePath.startsWith("file://")) {
       const { fileURLToPath } = await import("node:url");
       try { filePath = fileURLToPath(filePath); } catch { filePath = decodeURIComponent(filePath.replace(/^file:\/\//i, "")); }
     }
-    if (!pathMod.default.isAbsolute(filePath)) {
-      const ctx = getCtx();
-      filePath = pathMod.default.resolve(ctx.project.rootPath, filePath);
+    if (!path.isAbsolute(filePath)) {
+      filePath = path.resolve(projectRoot, filePath);
     }
+    // Canonicalize and verify the resolved path is inside an allowed artifact root.
+    const canonical = path.normalize(path.resolve(filePath));
+    const inside = allowedRoots.some((root) => {
+      try {
+        resolvePathWithinRoot(root, canonical);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    if (!inside) return null;
+
+    // Cap preview size to 10 MB to avoid loading arbitrarily large files into memory.
+    const PREVIEW_SIZE_CAP = 10 * 1024 * 1024;
     try {
-      const buf = fs.default.readFileSync(filePath);
-      const ext = pathMod.default.extname(filePath).replace(/^\./, "").toLowerCase();
+      const stat = await fs.promises.stat(canonical);
+      if (!stat.isFile()) return null;
+      if (stat.size > PREVIEW_SIZE_CAP) return null;
+      const buf = await fs.promises.readFile(canonical);
+      const ext = path.extname(canonical).replace(/^\./, "").toLowerCase();
       const mimeMap: Record<string, string> = { png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", webp: "image/webp", gif: "image/gif", bmp: "image/bmp", svg: "image/svg+xml" };
       const mime = mimeMap[ext] ?? "image/png";
       return `data:${mime};base64,${buf.toString("base64")}`;

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -3902,6 +3902,29 @@ export function registerIpc({
     return ctx.computerUseArtifactBrokerService.updateArtifactReview(arg);
   });
 
+  ipcMain.handle(IPC.computerUseReadArtifactPreview, async (_event, arg: { uri: string }): Promise<string | null> => {
+    const fs = await import("node:fs");
+    const pathMod = await import("node:path");
+    let filePath = arg.uri;
+    if (filePath.startsWith("file://")) {
+      const { fileURLToPath } = await import("node:url");
+      try { filePath = fileURLToPath(filePath); } catch { filePath = decodeURIComponent(filePath.replace(/^file:\/\//i, "")); }
+    }
+    if (!pathMod.default.isAbsolute(filePath)) {
+      const ctx = getCtx();
+      filePath = pathMod.default.resolve(ctx.project.rootPath, filePath);
+    }
+    try {
+      const buf = fs.default.readFileSync(filePath);
+      const ext = pathMod.default.extname(filePath).replace(/^\./, "").toLowerCase();
+      const mimeMap: Record<string, string> = { png: "image/png", jpg: "image/jpeg", jpeg: "image/jpeg", webp: "image/webp", gif: "image/gif", bmp: "image/bmp", svg: "image/svg+xml" };
+      const mime = mimeMap[ext] ?? "image/png";
+      return `data:${mime};base64,${buf.toString("base64")}`;
+    } catch {
+      return null;
+    }
+  });
+
   ipcMain.handle(IPC.ptyCreate, async (_event, arg: PtyCreateArgs): Promise<PtyCreateResult> => {
     const ctx = getCtx();
     return await ctx.ptyService.create(arg);

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -551,6 +551,7 @@ import type { createSyncService } from "../sync/syncService";
 import type { AdeProjectService } from "../projects/adeProjectService";
 import type { ConfigReloadService } from "../projects/configReloadService";
 import { getErrorMessage, isRecord, nowIso, resolvePathWithinRoot, toMemoryEntryDto } from "../shared/utils";
+import { resolveAdeLayout } from "../../../shared/adeLayout";
 
 export type AppContext = {
   db: AdeDb;

--- a/apps/desktop/src/main/services/lanes/laneService.test.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.test.ts
@@ -515,6 +515,168 @@ describe("laneService create", () => {
   });
 });
 
+describe("laneService importBranch", () => {
+  beforeEach(() => {
+    vi.mocked(getHeadSha).mockReset();
+    vi.mocked(runGit).mockReset();
+    vi.mocked(runGitOrThrow).mockReset();
+  });
+
+  it("imports a branch from an explicit non-origin remote", async () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-lane-service-import-upstream-"));
+    const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
+    await seedProjectAndStack(db, { projectId: "proj-import-upstream", repoRoot });
+
+    vi.mocked(runGitOrThrow).mockImplementation(async (args: string[]) => {
+      if (args[0] === "branch" && args[1] === "--track") {
+        expect(args).toEqual(["branch", "--track", "feature/import", "upstream/feature/import"]);
+        return { exitCode: 0, stdout: "", stderr: "" } as any;
+      }
+      if (args[0] === "worktree" && args[1] === "add") {
+        expect(args[2]).toContain(path.join("worktrees", "imported-lane-"));
+        expect(args[3]).toBe("feature/import");
+        return { exitCode: 0, stdout: "", stderr: "" } as any;
+      }
+      throw new Error(`Unexpected git call: ${args.join(" ")}`);
+    });
+
+    vi.mocked(runGit).mockImplementation(async (args: string[]) => {
+      if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/heads/upstream/feature/import") {
+        return { exitCode: 1, stdout: "", stderr: "" };
+      }
+      if (args[0] === "fetch" && args[1] === "--prune" && args[2] === "--all") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/remotes/upstream/feature/import") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "status" && args[1] === "--porcelain=v1") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "rev-list" && args[1] === "--left-right" && args[2] === "--count") {
+        return { exitCode: 0, stdout: "0\t0\n", stderr: "" };
+      }
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref" && args[2] === "--symbolic-full-name" && args[3] === "@{upstream}") {
+        return { exitCode: 0, stdout: "upstream/feature/import\n", stderr: "" };
+      }
+      if (args[0] === "rev-list" && args[1] === "HEAD..@{upstream}" && args[2] === "--count") {
+        return { exitCode: 0, stdout: "0\n", stderr: "" };
+      }
+      if (args[0] === "rev-parse" && args[1] === "--path-format=absolute" && args[2] === "--git-dir") {
+        return { exitCode: 1, stdout: "", stderr: "fatal: no git dir" };
+      }
+      throw new Error(`Unexpected git call: ${args.join(" ")}`);
+    });
+
+    const service = createLaneService({
+      db,
+      projectRoot: repoRoot,
+      projectId: "proj-import-upstream",
+      defaultBaseRef: "main",
+      worktreesDir: path.join(repoRoot, "worktrees"),
+    });
+
+    const result = await service.importBranch({ branchRef: "upstream/feature/import", name: "Imported lane" });
+
+    expect(result.branchRef).toBe("feature/import");
+    expect(result.baseRef).toBe("main");
+    expect(result.parentLaneId).toBe("lane-main");
+    expect(runGitOrThrow).toHaveBeenCalledWith(
+      ["branch", "--track", "feature/import", "upstream/feature/import"],
+      expect.objectContaining({ cwd: repoRoot }),
+    );
+  });
+
+  it("rejects duplicate imported branches before creating a local tracking branch", async () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-lane-service-import-duplicate-"));
+    const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
+    await seedProjectAndStack(db, { projectId: "proj-import-duplicate", repoRoot });
+    const now = "2026-03-11T12:05:00.000Z";
+    db.run(
+      `
+        insert into lanes(
+          id, project_id, name, description, lane_type, base_ref, branch_ref, worktree_path,
+          attached_root_path, is_edit_protected, parent_lane_id, color, icon, tags_json, status, created_at, archived_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      ["lane-existing-import", "proj-import-duplicate", "Existing import", null, "worktree", "main", "feature/existing", path.join(repoRoot, "existing"), null, 0, "lane-main", null, null, null, "active", now, null],
+    );
+
+    vi.mocked(runGit).mockImplementation(async (args: string[]) => {
+      if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/heads/origin/feature/existing") {
+        return { exitCode: 1, stdout: "", stderr: "" };
+      }
+      if (args[0] === "fetch" && args[1] === "--prune" && args[2] === "--all") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/remotes/origin/feature/existing") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      throw new Error(`Unexpected git call: ${args.join(" ")}`);
+    });
+
+    const service = createLaneService({
+      db,
+      projectRoot: repoRoot,
+      projectId: "proj-import-duplicate",
+      defaultBaseRef: "main",
+      worktreesDir: path.join(repoRoot, "worktrees"),
+    });
+
+    await expect(service.importBranch({ branchRef: "origin/feature/existing" })).rejects.toThrow(
+      "Lane already exists for branch 'feature/existing'",
+    );
+    expect(vi.mocked(runGitOrThrow).mock.calls.some(([args]) => args[0] === "branch" && args[1] === "--track")).toBe(false);
+  });
+
+  it("removes a created tracking branch when worktree setup fails during import", async () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-lane-service-import-cleanup-"));
+    const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
+    await seedProjectAndStack(db, { projectId: "proj-import-cleanup", repoRoot });
+
+    vi.mocked(runGit).mockImplementation(async (args: string[]) => {
+      if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/heads/origin/feature/broken") {
+        return { exitCode: 1, stdout: "", stderr: "" };
+      }
+      if (args[0] === "fetch" && args[1] === "--prune" && args[2] === "--all") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/remotes/origin/feature/broken") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      throw new Error(`Unexpected git call: ${args.join(" ")}`);
+    });
+
+    vi.mocked(runGitOrThrow).mockImplementation(async (args: string[]) => {
+      if (args[0] === "branch" && args[1] === "--track") {
+        return { exitCode: 0, stdout: "", stderr: "" } as any;
+      }
+      if (args[0] === "worktree" && args[1] === "add") {
+        throw new Error("worktree add failed");
+      }
+      if (args[0] === "branch" && args[1] === "-D") {
+        expect(args[2]).toBe("feature/broken");
+        return { exitCode: 0, stdout: "", stderr: "" } as any;
+      }
+      throw new Error(`Unexpected git call: ${args.join(" ")}`);
+    });
+
+    const service = createLaneService({
+      db,
+      projectRoot: repoRoot,
+      projectId: "proj-import-cleanup",
+      defaultBaseRef: "main",
+      worktreesDir: path.join(repoRoot, "worktrees"),
+    });
+
+    await expect(service.importBranch({ branchRef: "origin/feature/broken" })).rejects.toThrow("worktree add failed");
+    expect(runGitOrThrow).toHaveBeenCalledWith(
+      ["branch", "-D", "feature/broken"],
+      expect.objectContaining({ cwd: repoRoot }),
+    );
+  });
+});
+
 describe("laneService rebaseStart", () => {
   beforeEach(() => {
     vi.mocked(getHeadSha).mockReset();

--- a/apps/desktop/src/main/services/lanes/laneService.test.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.test.ts
@@ -550,6 +550,9 @@ describe("laneService importBranch", () => {
       if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/remotes/upstream/feature/import") {
         return { exitCode: 0, stdout: "", stderr: "" };
       }
+      if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/heads/feature/import") {
+        return { exitCode: 1, stdout: "", stderr: "" };
+      }
       if (args[0] === "status" && args[1] === "--porcelain=v1") {
         return { exitCode: 0, stdout: "", stderr: "" };
       }
@@ -612,6 +615,9 @@ describe("laneService importBranch", () => {
       if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/remotes/origin/feature/existing") {
         return { exitCode: 0, stdout: "", stderr: "" };
       }
+      if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/heads/feature/existing") {
+        return { exitCode: 1, stdout: "", stderr: "" };
+      }
       throw new Error(`Unexpected git call: ${args.join(" ")}`);
     });
 
@@ -629,6 +635,64 @@ describe("laneService importBranch", () => {
     expect(vi.mocked(runGitOrThrow).mock.calls.some(([args]) => args[0] === "branch" && args[1] === "--track")).toBe(false);
   });
 
+  it("reuses an existing local branch when importing a remote-qualified ref", async () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-lane-service-import-local-existing-"));
+    const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
+    await seedProjectAndStack(db, { projectId: "proj-import-local-existing", repoRoot });
+
+    vi.mocked(runGit).mockImplementation(async (args: string[]) => {
+      if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/heads/origin/feature/existing-local") {
+        return { exitCode: 1, stdout: "", stderr: "" };
+      }
+      if (args[0] === "fetch" && args[1] === "--prune" && args[2] === "--all") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/remotes/origin/feature/existing-local") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/heads/feature/existing-local") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "status" && args[1] === "--porcelain=v1") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "rev-list" && args[1] === "--left-right" && args[2] === "--count") {
+        return { exitCode: 0, stdout: "0\t0\n", stderr: "" };
+      }
+      if (args[0] === "rev-parse" && args[1] === "--abbrev-ref" && args[2] === "--symbolic-full-name" && args[3] === "@{upstream}") {
+        return { exitCode: 0, stdout: "origin/feature/existing-local\n", stderr: "" };
+      }
+      if (args[0] === "rev-list" && args[1] === "HEAD..@{upstream}" && args[2] === "--count") {
+        return { exitCode: 0, stdout: "0\n", stderr: "" };
+      }
+      if (args[0] === "rev-parse" && args[1] === "--path-format=absolute" && args[2] === "--git-dir") {
+        return { exitCode: 1, stdout: "", stderr: "fatal: no git dir" };
+      }
+      throw new Error(`Unexpected git call: ${args.join(" ")}`);
+    });
+
+    vi.mocked(runGitOrThrow).mockImplementation(async (args: string[]) => {
+      if (args[0] === "worktree" && args[1] === "add") {
+        expect(args[3]).toBe("feature/existing-local");
+        return { exitCode: 0, stdout: "", stderr: "" } as any;
+      }
+      throw new Error(`Unexpected git call: ${args.join(" ")}`);
+    });
+
+    const service = createLaneService({
+      db,
+      projectRoot: repoRoot,
+      projectId: "proj-import-local-existing",
+      defaultBaseRef: "main",
+      worktreesDir: path.join(repoRoot, "worktrees"),
+    });
+
+    const result = await service.importBranch({ branchRef: "origin/feature/existing-local" });
+
+    expect(result.branchRef).toBe("feature/existing-local");
+    expect(vi.mocked(runGitOrThrow).mock.calls.some(([args]) => args[0] === "branch" && args[1] === "--track")).toBe(false);
+  });
+
   it("removes a created tracking branch when worktree setup fails during import", async () => {
     const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-lane-service-import-cleanup-"));
     const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
@@ -643,6 +707,9 @@ describe("laneService importBranch", () => {
       }
       if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/remotes/origin/feature/broken") {
         return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      if (args[0] === "show-ref" && args[1] === "--verify" && args[3] === "refs/heads/feature/broken") {
+        return { exitCode: 1, stdout: "", stderr: "" };
       }
       throw new Error(`Unexpected git call: ${args.join(" ")}`);
     });

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -1291,14 +1291,18 @@ export function createLaneService({
       let branchCreated = false;
       let worktreeAdded = false;
       let laneInserted = false;
-      const localExists = await runGit(["show-ref", "--verify", "--quiet", `refs/heads/${rawRef}`], {
+      let localExists = await runGit(["show-ref", "--verify", "--quiet", `refs/heads/${rawRef}`], {
         cwd: projectRoot, timeoutMs: 8_000
       }).then((r) => r.exitCode === 0);
 
       if (!localExists) {
         const resolved = await resolveImportBranchTarget({ projectRoot, rawRef });
         branchRef = resolved.localBranchName;
-        remoteRefToTrack = resolved.remoteRef;
+        localExists = await runGit(["show-ref", "--verify", "--quiet", `refs/heads/${resolved.localBranchName}`], {
+          cwd: projectRoot,
+          timeoutMs: 8_000,
+        }).then((r) => r.exitCode === 0);
+        remoteRefToTrack = localExists ? null : resolved.remoteRef;
       }
 
       // Prevent duplicates.

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -315,6 +315,69 @@ function describeBranchRebaseTarget(branchName: string, label: string): string {
   return label === branchName ? branchName : `${branchName} (${label})`;
 }
 
+function localBranchNameFromRemoteRef(ref: string): string {
+  const normalized = ref.trim();
+  const slashIndex = normalized.indexOf("/");
+  return slashIndex >= 0 ? normalized.slice(slashIndex + 1) : normalized;
+}
+
+async function resolveImportBranchTarget(args: {
+  projectRoot: string;
+  rawRef: string;
+}): Promise<{ localBranchName: string; remoteRef: string }> {
+  const rawRef = args.rawRef.trim();
+
+  // Refresh cached remote refs, but still allow import when the fetch fails and refs are already present locally.
+  await runGit(["fetch", "--prune", "--all"], {
+    cwd: args.projectRoot,
+    timeoutMs: 60_000,
+  }).catch(() => {});
+
+  const directCandidates = new Set<string>();
+  if (rawRef.includes("/")) directCandidates.add(rawRef);
+  directCandidates.add(`origin/${rawRef}`);
+
+  for (const remoteRef of directCandidates) {
+    const remoteExists = await runGit(["show-ref", "--verify", "--quiet", `refs/remotes/${remoteRef}`], {
+      cwd: args.projectRoot,
+      timeoutMs: 8_000,
+    }).then((result) => result.exitCode === 0);
+    if (remoteExists) {
+      return {
+        localBranchName: localBranchNameFromRemoteRef(remoteRef),
+        remoteRef,
+      };
+    }
+  }
+
+  const remoteRefsRes = await runGit(["for-each-ref", "--format=%(refname:short)", "refs/remotes"], {
+    cwd: args.projectRoot,
+    timeoutMs: 15_000,
+  });
+  if (remoteRefsRes.exitCode === 0) {
+    const suffix = `/${rawRef}`;
+    const matches = remoteRefsRes.stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .filter((ref) => !ref.endsWith("/HEAD"))
+      .filter((ref) => ref.endsWith(suffix));
+    if (matches.length === 1) {
+      return {
+        localBranchName: localBranchNameFromRemoteRef(matches[0]!),
+        remoteRef: matches[0]!,
+      };
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `Branch '${rawRef}' exists on multiple remotes. Import it using an explicit remote ref like '${matches[0]}'.`,
+      );
+    }
+  }
+
+  throw new Error(`Branch '${rawRef}' not found locally or on any remote`);
+}
+
 function computeStackDepth(args: {
   laneId: string;
   rowsById: Map<string, LaneRow>;
@@ -1219,12 +1282,24 @@ export function createLaneService({
     },
 
     async importBranch(args: { branchRef: string; name?: string; description?: string; parentLaneId?: string | null }): Promise<LaneSummary> {
-      const branchRef = (args.branchRef ?? "").trim();
-      if (!branchRef) throw new Error("branchRef is required");
-      if (branchRef.includes("\0")) throw new Error("Invalid branchRef");
+      const rawRef = (args.branchRef ?? "").trim();
+      if (!rawRef) throw new Error("branchRef is required");
+      if (rawRef.includes("\0")) throw new Error("Invalid branchRef");
 
-      // Ensure branch exists locally.
-      await runGitOrThrow(["rev-parse", "--verify", branchRef], { cwd: projectRoot, timeoutMs: 12_000 });
+      let branchRef = rawRef;
+      let remoteRefToTrack: string | null = null;
+      let branchCreated = false;
+      let worktreeAdded = false;
+      let laneInserted = false;
+      const localExists = await runGit(["show-ref", "--verify", "--quiet", `refs/heads/${rawRef}`], {
+        cwd: projectRoot, timeoutMs: 8_000
+      }).then((r) => r.exitCode === 0);
+
+      if (!localExists) {
+        const resolved = await resolveImportBranchTarget({ projectRoot, rawRef });
+        branchRef = resolved.localBranchName;
+        remoteRefToTrack = resolved.remoteRef;
+      }
 
       // Prevent duplicates.
       const existing = db.get<{ id: string }>(
@@ -1242,74 +1317,181 @@ export function createLaneService({
       const suffix = laneId.slice(0, 8);
       const worktreePath = path.join(worktreesDir, `${slug}-${suffix}`);
 
-      // Attaching an existing branch: do NOT create a new branch, just add a worktree checkout.
-      await runGitOrThrow(["worktree", "add", worktreePath, branchRef], {
-        cwd: projectRoot,
-        timeoutMs: 60_000
-      });
-
-      const parentLaneIdRaw = typeof args.parentLaneId === "string" ? args.parentLaneId.trim() : "";
-      let parentLaneId = parentLaneIdRaw.length ? parentLaneIdRaw : null;
-      // Default to primary lane when no parent is specified.
-      if (!parentLaneId) {
-        const primaryRow = getActivePrimaryLane();
-        if (primaryRow?.id) parentLaneId = primaryRow.id;
-      }
-      const parent = parentLaneId ? getLaneRow(parentLaneId) : null;
-      if (parentLaneId && !parent) throw new Error(`Parent lane not found: ${parentLaneId}`);
-      if (parent && parent.status === "archived") throw new Error("Parent lane is archived");
-
-      const baseRef = parent?.branch_ref ?? defaultBaseRef;
-
-      db.run(
-        `
-          insert into lanes(
-            id, project_id, name, description, lane_type, base_ref, branch_ref, worktree_path,
-            attached_root_path, is_edit_protected, parent_lane_id, color, icon, tags_json, status, created_at, archived_at
-          )
-          values(?, ?, ?, ?, 'worktree', ?, ?, ?, null, 0, ?, null, null, null, 'active', ?, null)
-        `,
-        [laneId, projectId, displayName, args.description ?? null, baseRef, branchRef, worktreePath, parentLaneId, now]
-      );
-      invalidateLaneListCache();
-
-      // Best-effort push to establish upstream if not already tracking a remote
       try {
-        const upstreamCheck = await runGit(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], { cwd: worktreePath, timeoutMs: 5_000 });
-        if (upstreamCheck.exitCode !== 0) {
-          await runGit(["push", "-u", "origin", branchRef], { cwd: worktreePath, timeoutMs: 60_000 });
+        if (remoteRefToTrack) {
+          await runGitOrThrow(["branch", "--track", branchRef, remoteRefToTrack], { cwd: projectRoot, timeoutMs: 15_000 });
+          branchCreated = true;
         }
-      } catch {
-        // Non-fatal: lane works locally even without remote tracking
-      }
 
-      const row = getLaneRow(laneId);
-      if (!row) throw new Error(`Failed to import lane: ${laneId}`);
-      const rowsById = getRowsById(true);
-      const status = await computeLaneStatus(worktreePath, baseRef, branchRef);
-      const parentStatus = parent ? await computeLaneStatus(parent.worktree_path, parent.base_ref, parent.branch_ref) : null;
+        // Attaching an existing branch: do NOT create a new branch, just add a worktree checkout.
+        await runGitOrThrow(["worktree", "add", worktreePath, branchRef], {
+          cwd: projectRoot,
+          timeoutMs: 60_000
+        });
+        worktreeAdded = true;
 
-      if (onHeadChanged) {
+        // --- Detect real parent lane via git merge-base ---
+        const parentLaneIdRaw = typeof args.parentLaneId === "string" ? args.parentLaneId.trim() : "";
+        const explicitParentLaneId = parentLaneIdRaw.length ? parentLaneIdRaw : null;
+        let parentLaneId: string | null = null;
+
+        // Try to detect the true parent by finding which lane's HEAD shares the
+        // most recent common ancestor with the imported branch.
         try {
-          const postHeadSha = await getHeadSha(worktreePath);
-          onHeadChanged({
-            laneId,
-            reason: "import_branch",
-            preHeadSha: null,
-            postHeadSha
-          });
-        } catch {
-          // ignore
-        }
-      }
+          const importedHeadSha = await getHeadSha(worktreePath);
+          if (importedHeadSha) {
+            const activeRows = getAllLaneRows(false);
+            let bestLaneId: string | null = null;
+            let bestDistance = Infinity;
 
-      return toLaneSummary({
-        row,
-        status,
-        parentStatus,
-        childCount: 0,
-        stackDepth: computeStackDepth({ laneId, rowsById, memo: new Map() })
-      });
+            for (const row of activeRows) {
+              // Skip the lane we are currently importing (same id won't exist yet,
+              // but skip by branch_ref match just in case).
+              if (row.branch_ref === branchRef) continue;
+
+              const laneWorktree = row.worktree_path;
+              if (!laneWorktree) continue;
+
+              const laneHeadSha = await getHeadSha(laneWorktree);
+              if (!laneHeadSha) continue;
+
+              const mbResult = await runGit(
+                ["merge-base", laneHeadSha, importedHeadSha],
+                { cwd: projectRoot, timeoutMs: 10_000 },
+              );
+              if (mbResult.exitCode !== 0) continue;
+              const mergeBaseSha = mbResult.stdout.trim();
+              if (!mergeBaseSha) continue;
+
+              // Count commits between merge-base and the imported branch HEAD.
+              // Fewer commits = closer ancestor = better parent candidate.
+              const countResult = await runGit(
+                ["rev-list", "--count", `${mergeBaseSha}..${importedHeadSha}`],
+                { cwd: projectRoot, timeoutMs: 10_000 },
+              );
+              if (countResult.exitCode !== 0) continue;
+              const distance = parseInt(countResult.stdout.trim(), 10);
+              if (isNaN(distance)) continue;
+
+              if (distance < bestDistance) {
+                bestDistance = distance;
+                bestLaneId = row.id;
+              }
+            }
+
+            if (bestLaneId) {
+              if (explicitParentLaneId && explicitParentLaneId !== bestLaneId) {
+                console.warn(
+                  `[laneService] importBranch: explicit parentLaneId '${explicitParentLaneId}' differs from ` +
+                  `git-detected parent '${bestLaneId}' — using detected parent`,
+                );
+              }
+              parentLaneId = bestLaneId;
+            }
+          }
+        } catch (err) {
+          console.warn("[laneService] importBranch: merge-base parent detection failed, falling back", err);
+        }
+
+        // Fallback: use explicit parent or primary lane if detection yielded nothing.
+        if (!parentLaneId) {
+          parentLaneId = explicitParentLaneId;
+        }
+        if (!parentLaneId) {
+          const primaryRow = getActivePrimaryLane();
+          if (primaryRow?.id) parentLaneId = primaryRow.id;
+        }
+
+        const parent = parentLaneId ? getLaneRow(parentLaneId) : null;
+        if (parentLaneId && !parent) throw new Error(`Parent lane not found: ${parentLaneId}`);
+        if (parent && parent.status === "archived") throw new Error("Parent lane is archived");
+
+        const baseRef = parent?.branch_ref ?? defaultBaseRef;
+
+        db.run(
+          `
+            insert into lanes(
+              id, project_id, name, description, lane_type, base_ref, branch_ref, worktree_path,
+              attached_root_path, is_edit_protected, parent_lane_id, color, icon, tags_json, status, created_at, archived_at
+            )
+            values(?, ?, ?, ?, 'worktree', ?, ?, ?, null, 0, ?, null, null, null, 'active', ?, null)
+          `,
+          [laneId, projectId, displayName, args.description ?? null, baseRef, branchRef, worktreePath, parentLaneId, now]
+        );
+        laneInserted = true;
+        invalidateLaneListCache();
+
+        // Best-effort push to establish upstream if not already tracking a remote
+        try {
+          const upstreamCheck = await runGit(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], { cwd: worktreePath, timeoutMs: 5_000 });
+          if (upstreamCheck.exitCode !== 0) {
+            await runGit(["push", "-u", "origin", branchRef], { cwd: worktreePath, timeoutMs: 60_000 });
+          }
+        } catch {
+          // Non-fatal: lane works locally even without remote tracking
+        }
+
+        const row = getLaneRow(laneId);
+        if (!row) throw new Error(`Failed to import lane: ${laneId}`);
+        const rowsById = getRowsById(true);
+        const status = await computeLaneStatus(worktreePath, baseRef, branchRef);
+        const parentStatus = parent ? await computeLaneStatus(parent.worktree_path, parent.base_ref, parent.branch_ref) : null;
+
+        if (onHeadChanged) {
+          try {
+            const postHeadSha = await getHeadSha(worktreePath);
+            onHeadChanged({
+              laneId,
+              reason: "import_branch",
+              preHeadSha: null,
+              postHeadSha
+            });
+          } catch {
+            // ignore
+          }
+        }
+
+        return toLaneSummary({
+          row,
+          status,
+          parentStatus,
+          childCount: 0,
+          stackDepth: computeStackDepth({ laneId, rowsById, memo: new Map() })
+        });
+      } catch (error) {
+        if (laneInserted) throw error;
+
+        const cleanupErrors: string[] = [];
+        if (worktreeAdded) {
+          try {
+            await runGitOrThrow(["worktree", "remove", "--force", worktreePath], {
+              cwd: projectRoot,
+              timeoutMs: 60_000,
+            });
+          } catch (cleanupError) {
+            try {
+              fs.rmSync(worktreePath, { recursive: true, force: true });
+            } catch {
+              cleanupErrors.push(`remove worktree failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`);
+            }
+          }
+        }
+        if (branchCreated) {
+          try {
+            await runGitOrThrow(["branch", "-D", branchRef], {
+              cwd: projectRoot,
+              timeoutMs: 15_000,
+            });
+          } catch (cleanupError) {
+            cleanupErrors.push(`delete branch failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`);
+          }
+        }
+
+        if (cleanupErrors.length > 0) {
+          throw new Error(`${error instanceof Error ? error.message : String(error)} Cleanup failed: ${cleanupErrors.join(" ")}`);
+        }
+        throw error;
+      }
     },
 
     async getChildren(laneId: string): Promise<LaneSummary[]> {

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -1281,7 +1281,7 @@ export function createLaneService({
       }
     },
 
-    async importBranch(args: { branchRef: string; name?: string; description?: string; parentLaneId?: string | null }): Promise<LaneSummary> {
+    async importBranch(args: { branchRef: string; name?: string; description?: string; parentLaneId?: string | null; baseBranch?: string }): Promise<LaneSummary> {
       const rawRef = (args.branchRef ?? "").trim();
       if (!rawRef) throw new Error("branchRef is required");
       if (rawRef.includes("\0")) throw new Error("Invalid branchRef");
@@ -1398,15 +1398,24 @@ export function createLaneService({
           parentLaneId = explicitParentLaneId;
         }
         if (!parentLaneId) {
+          // Only auto-assign Primary as parent when the imported branch's base
+          // matches Primary's branch — otherwise the lane is independent and
+          // should rebase directly against its baseRef (e.g. main).
           const primaryRow = getActivePrimaryLane();
-          if (primaryRow?.id) parentLaneId = primaryRow.id;
+          if (primaryRow?.id) {
+            const primary = getLaneRow(primaryRow.id);
+            const resolvedBase = args.baseBranch?.trim() || defaultBaseRef;
+            if (primary && normalizeBranchName(primary.branch_ref) === normalizeBranchName(resolvedBase)) {
+              parentLaneId = primaryRow.id;
+            }
+          }
         }
 
         const parent = parentLaneId ? getLaneRow(parentLaneId) : null;
         if (parentLaneId && !parent) throw new Error(`Parent lane not found: ${parentLaneId}`);
         if (parent && parent.status === "archived") throw new Error("Parent lane is archived");
 
-        const baseRef = parent?.branch_ref ?? defaultBaseRef;
+        const baseRef = args.baseBranch?.trim() || defaultBaseRef;
 
         db.run(
           `

--- a/apps/desktop/src/main/services/lanes/rebaseSuggestionService.ts
+++ b/apps/desktop/src/main/services/lanes/rebaseSuggestionService.ts
@@ -131,34 +131,50 @@ export function createRebaseSuggestionService(args: {
       };
     }
 
-    if (!lane.parentLaneId) return null;
-    const parent = laneById.get(lane.parentLaneId);
-    if (!parent) return null;
-    let parentHeadSha: string | null;
-    if (parent.laneType === "primary") {
-      const parentBranch = parent.branchRef.trim();
-      if (!parentBranch) return null;
-      if (primaryParentHeadByBranch.has(parentBranch)) {
-        parentHeadSha = primaryParentHeadByBranch.get(parentBranch) ?? null;
-      } else {
-        await fetchRemoteTrackingBranch({
-          projectRoot,
-          targetBranch: parentBranch,
-        }).catch(() => {});
-        parentHeadSha = await readRefHeadSha(`origin/${parentBranch}`);
-        if (!parentHeadSha) {
+    if (lane.parentLaneId) {
+      const parent = laneById.get(lane.parentLaneId);
+      if (parent) {
+        let parentHeadSha: string | null;
+        if (parent.laneType === "primary") {
+          const parentBranch = parent.branchRef.trim();
+          if (!parentBranch) return null;
+          if (primaryParentHeadByBranch.has(parentBranch)) {
+            parentHeadSha = primaryParentHeadByBranch.get(parentBranch) ?? null;
+          } else {
+            await fetchRemoteTrackingBranch({
+              projectRoot,
+              targetBranch: parentBranch,
+            }).catch(() => {});
+            parentHeadSha = await readRefHeadSha(`origin/${parentBranch}`);
+            if (!parentHeadSha) {
+              parentHeadSha = await getHeadSha(parent.worktreePath);
+            }
+            primaryParentHeadByBranch.set(parentBranch, parentHeadSha);
+          }
+        } else {
           parentHeadSha = await getHeadSha(parent.worktreePath);
         }
-        primaryParentHeadByBranch.set(parentBranch, parentHeadSha);
+        if (!parentHeadSha) return null;
+        return {
+          parentLaneId: lane.parentLaneId,
+          parentHeadSha,
+          baseLabel: parent.name ?? null,
+          groupContext: null,
+        };
       }
-    } else {
-      parentHeadSha = await getHeadSha(parent.worktreePath);
     }
-    if (!parentHeadSha) return null;
+
+    // No parent lane — fall back to baseRef (e.g. "main") for parentless imported lanes.
+    const baseRef = lane.baseRef?.trim();
+    if (!baseRef) return null;
+    if (lane.laneType === "primary") return null;
+    await fetchRemoteTrackingBranch({ projectRoot, targetBranch: baseRef }).catch(() => {});
+    const baseHeadSha = await readRefHeadSha(`origin/${baseRef}`) ?? await readRefHeadSha(baseRef);
+    if (!baseHeadSha) return null;
     return {
-      parentLaneId: lane.parentLaneId,
-      parentHeadSha,
-      baseLabel: parent.name ?? null,
+      parentLaneId: `base:${baseRef}`,
+      parentHeadSha: baseHeadSha,
+      baseLabel: baseRef,
       groupContext: null,
     };
   };

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -850,6 +850,7 @@ declare global {
         getOwnerSnapshot: (args: ComputerUseOwnerSnapshotArgs) => Promise<ComputerUseOwnerSnapshot>;
         routeArtifact: (args: ComputerUseArtifactRouteArgs) => Promise<ComputerUseArtifactView>;
         updateArtifactReview: (args: ComputerUseArtifactReviewArgs) => Promise<ComputerUseArtifactView>;
+        readArtifactPreview: (args: { uri: string }) => Promise<string | null>;
         onEvent: (cb: (ev: ComputerUseEventPayload) => void) => () => void;
       };
       pty: {

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -560,6 +560,7 @@ declare global {
         getProject: () => Promise<ProjectInfo | null>;
         openExternal: (url: string) => Promise<void>;
         revealPath: (path: string) => Promise<void>;
+        openPath: (path: string) => Promise<void>;
         writeClipboardText: (text: string) => Promise<void>;
         openPathInEditor: (args: {
           rootPath: string;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1169,6 +1169,8 @@ contextBridge.exposeInMainWorld("ade", {
       ipcRenderer.invoke(IPC.computerUseRouteArtifact, args),
     updateArtifactReview: async (args: ComputerUseArtifactReviewArgs): Promise<ComputerUseArtifactView> =>
       ipcRenderer.invoke(IPC.computerUseUpdateArtifactReview, args),
+    readArtifactPreview: async (args: { uri: string }): Promise<string | null> =>
+      ipcRenderer.invoke(IPC.computerUseReadArtifactPreview, args),
     onEvent: (cb: (ev: ComputerUseEventPayload) => void) => {
       const listener = (_event: Electron.IpcRendererEvent, payload: ComputerUseEventPayload) => cb(payload);
       ipcRenderer.on(IPC.computerUseEvent, listener);

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -556,6 +556,7 @@ contextBridge.exposeInMainWorld("ade", {
     getProject: async (): Promise<ProjectInfo | null> => ipcRenderer.invoke(IPC.appGetProject),
     openExternal: async (url: string): Promise<void> => ipcRenderer.invoke(IPC.appOpenExternal, { url }),
     revealPath: async (path: string): Promise<void> => ipcRenderer.invoke(IPC.appRevealPath, { path }),
+    openPath: async (path: string): Promise<void> => ipcRenderer.invoke(IPC.appOpenPath, { path }),
     writeClipboardText: async (text: string): Promise<void> => ipcRenderer.invoke(IPC.appWriteClipboardText, { text }),
     openPathInEditor: async (args: {
       rootPath: string;

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
@@ -187,32 +187,41 @@ describe("AgentChatComposer", () => {
     expect((screen.getByTitle("Upload file from disk") as HTMLButtonElement).disabled).toBe(true);
   });
 
-  it("opens the advanced popover and wires the advanced controls", () => {
-    const onExecutionModeChange = vi.fn();
-    const onComputerUsePolicyChange = vi.fn();
+  it("shows inline proof toggle and wires callback", () => {
     const onToggleProof = vi.fn();
+    renderComposer({
+      onToggleProof,
+      proofOpen: false,
+      proofArtifactCount: 3,
+    });
+
+    const proofButton = screen.getByTitle("Open proof drawer");
+    fireEvent.click(proofButton);
+    expect(onToggleProof).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("3")).toBeTruthy();
+  });
+
+  it("shows inline context toggle only before first message", () => {
     const onIncludeProjectDocsChange = vi.fn();
     renderComposer({
-      executionMode: "focused",
-      executionModeOptions,
-      onExecutionModeChange,
-      onComputerUsePolicyChange,
-      onToggleProof,
+      chatHasMessages: false,
       includeProjectDocs: false,
       onIncludeProjectDocsChange,
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Advanced" }));
-
-    fireEvent.click(screen.getByRole("button", { name: /^Parallel/ }));
-    fireEvent.click(screen.getByRole("button", { name: /^Proof\b/i }));
-    fireEvent.click(screen.getByRole("button", { name: /^Project Context\b/i }));
-
-    expect(onExecutionModeChange).toHaveBeenCalledWith("parallel");
-    expect(onToggleProof).toHaveBeenCalledTimes(1);
+    const contextButton = screen.getByTitle("Include project context (PRD + architecture) with first message");
+    fireEvent.click(contextButton);
     expect(onIncludeProjectDocsChange).toHaveBeenCalledWith(true);
+  });
 
-    fireEvent.click(screen.getByRole("button", { name: "Advanced" }));
-    expect(screen.queryByText("Advanced settings")).toBeNull();
+  it("hides context toggle after first message is sent", () => {
+    const onIncludeProjectDocsChange = vi.fn();
+    renderComposer({
+      chatHasMessages: true,
+      includeProjectDocs: false,
+      onIncludeProjectDocsChange,
+    });
+
+    expect(screen.queryByTitle("Include project context (PRD + architecture) with first message")).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { At, CaretDown, Image, Paperclip, Square, X, PaperPlaneTilt } from "@phosphor-icons/react";
+import { At, Image, Paperclip, Square, X, PaperPlaneTilt, Cube, BookOpen } from "@phosphor-icons/react";
 import {
   inferAttachmentType,
   type AgentChatApprovalDecision,
@@ -130,258 +130,7 @@ const UNIFIED_PERMISSION_OPTIONS: Array<{ value: AgentChatUnifiedPermissionMode;
   { value: "full-auto", label: "Full auto" },
 ];
 
-type AdvancedSettingsPopoverProps = {
-  executionModeOptions: ExecutionModeOption[];
-  executionMode: AgentChatExecutionMode | null;
-  onExecutionModeChange?: (mode: AgentChatExecutionMode) => void;
-  computerUsePolicy: ComputerUsePolicy;
-  computerUseSnapshot: ComputerUseOwnerSnapshot | null;
-  onOpenComputerUseDetails: () => void;
-  proofOpen: boolean;
-  proofArtifactCount: number;
-  onToggleProof?: () => void;
-  includeProjectDocs?: boolean;
-  onIncludeProjectDocsChange?: (checked: boolean) => void;
-};
 
-function AdvancedSettingsPopover({
-  executionModeOptions,
-  executionMode,
-  onExecutionModeChange,
-  computerUsePolicy,
-  computerUseSnapshot,
-  onOpenComputerUseDetails,
-  proofOpen,
-  proofArtifactCount,
-  onToggleProof,
-  includeProjectDocs,
-  onIncludeProjectDocsChange,
-}: AdvancedSettingsPopoverProps) {
-  const [hoveredExecutionMode, setHoveredExecutionMode] = useState<AgentChatExecutionMode | null>(null);
-  const activeBackend = computerUseSnapshot?.activeBackend?.name ?? (computerUsePolicy.allowLocalFallback ? "Fallback allowed" : "No fallback");
-  const activeExecutionMode = executionModeOptions.find((option) => option.value === executionMode) ?? executionModeOptions[0] ?? null;
-  const helpMode = hoveredExecutionMode
-    ? executionModeOptions.find((option) => option.value === hoveredExecutionMode) ?? activeExecutionMode
-    : activeExecutionMode;
-
-  return (
-    <div className="absolute bottom-full right-0 z-30 mb-3 w-[min(44rem,calc(100vw-2rem))] overflow-hidden rounded-[22px] border border-white/[0.08] bg-[linear-gradient(180deg,rgba(18,20,28,0.98),rgba(10,12,18,0.98))] shadow-[0_24px_90px_-40px_rgba(0,0,0,0.88)] backdrop-blur-xl">
-      <div className="border-b border-white/[0.05] px-4 py-3">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1">
-            <div className="font-sans text-[12px] font-semibold tracking-tight text-fg/86">Advanced settings</div>
-            <div className="max-w-[34rem] text-[11px] leading-5 text-fg/54">
-              Tune execution behavior, computer use, proof retention, and project context without widening the main composer.
-            </div>
-          </div>
-          <button
-            type="button"
-            className="rounded-[var(--chat-radius-pill)] border border-white/[0.08] bg-white/[0.03] px-3 py-1 font-sans text-[11px] font-medium text-fg/58 transition-colors hover:text-fg/82"
-            onClick={onOpenComputerUseDetails}
-            title="Open the detailed computer-use settings"
-          >
-            Computer use details
-          </button>
-        </div>
-      </div>
-
-      <div className="space-y-4 px-4 py-4">
-        {executionModeOptions.length > 0 && onExecutionModeChange ? (
-          <div className="space-y-2">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <div className="font-sans text-[11px] font-semibold uppercase tracking-[0.16em] text-fg/64">Execution mode</div>
-                <div className="mt-1 text-[11px] leading-5 text-fg/48">Choose whether the model stays in one thread or spreads work across delegates.</div>
-              </div>
-              {helpMode ? (
-                <div className="rounded-md border border-white/[0.08] bg-white/[0.03] px-2 py-1 font-sans text-[10px] font-medium text-fg/72">
-                  {helpMode.summary}
-                </div>
-              ) : null}
-            </div>
-            <div className="grid gap-2 sm:grid-cols-2">
-              {executionModeOptions.map((option) => {
-                const isActive = executionMode === option.value;
-                return (
-                  <button
-                    key={option.value}
-                    type="button"
-                    className={cn(
-                      "rounded-[18px] border px-3 py-2 text-left transition-colors",
-                      isActive
-                        ? "border-[color:color-mix(in_srgb,var(--chat-accent)_28%,transparent)] bg-[color:color-mix(in_srgb,var(--chat-accent)_12%,transparent)] text-fg/84"
-                        : "border-white/[0.06] bg-white/[0.03] text-fg/62 hover:border-white/[0.12] hover:bg-white/[0.05]",
-                    )}
-                    style={isActive ? {
-                      borderColor: `${option.accent}44`,
-                      background: `${option.accent}16`,
-                    } : undefined}
-                    onClick={() => onExecutionModeChange(option.value)}
-                    onMouseEnter={() => setHoveredExecutionMode(option.value)}
-                    onMouseLeave={() => setHoveredExecutionMode(null)}
-                    title={option.helper}
-                    aria-pressed={isActive}
-                  >
-                    <div className="flex items-center justify-between gap-2">
-                      <span className="font-sans text-[12px] font-medium text-fg/82">{option.label}</span>
-                      <span className="font-sans text-[10px] uppercase tracking-[0.16em] text-fg/34">{option.summary}</span>
-                    </div>
-                    <div className="mt-1 text-[11px] leading-5 text-fg/54">{option.helper}</div>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        ) : null}
-
-        <div className="grid gap-3 md:grid-cols-2">
-          <button
-            type="button"
-            className={cn(
-              "rounded-[18px] border px-3 py-3 text-left transition-colors",
-              proofOpen || proofArtifactCount > 0
-                ? "border-emerald-400/22 bg-emerald-500/10"
-                : "border-white/[0.06] bg-white/[0.03] hover:border-white/[0.12] hover:bg-white/[0.05]",
-            )}
-            onClick={onToggleProof}
-            aria-pressed={proofOpen}
-            disabled={!onToggleProof}
-            title="Open or hide the proof drawer for retained screenshots, traces, logs, and verification output"
-          >
-            <div className="flex items-center justify-between gap-2">
-              <span className="font-sans text-[12px] font-medium text-fg/84">Proof</span>
-              <span className={cn(
-                "rounded-md border px-2 py-0.5 font-sans text-[9px] font-semibold uppercase tracking-[0.14em]",
-                proofOpen
-                  ? "border-emerald-400/25 bg-emerald-500/10 text-emerald-200"
-                  : "border-white/[0.08] bg-white/[0.03] text-fg/45",
-              )}>
-                {proofArtifactCount > 0 ? `${proofArtifactCount} artifacts` : proofOpen ? "Open" : "Closed"}
-              </span>
-            </div>
-            <div className="mt-1 text-[11px] leading-5 text-fg/58">
-              Inspect retained screenshots, traces, logs, and validation output from this chat.
-            </div>
-          </button>
-
-          <button
-            type="button"
-            className={cn(
-              "rounded-[18px] border px-3 py-3 text-left transition-colors md:col-span-2",
-              includeProjectDocs
-                ? "border-accent/22 bg-accent/10"
-                : "border-white/[0.06] bg-white/[0.03] hover:border-white/[0.12] hover:bg-white/[0.05]",
-            )}
-            onClick={() => onIncludeProjectDocsChange?.(!includeProjectDocs)}
-            aria-pressed={!!includeProjectDocs}
-            disabled={!onIncludeProjectDocsChange}
-            title="Include project-level context docs (PRD and architecture) with the first message"
-          >
-            <div className="flex items-center justify-between gap-2">
-              <span className="font-sans text-[12px] font-medium text-fg/84">Project Context</span>
-              <span className={cn(
-                "rounded-md border px-2 py-0.5 font-sans text-[9px] font-semibold uppercase tracking-[0.14em]",
-                includeProjectDocs
-                  ? "border-accent/25 bg-accent/10 text-accent"
-                  : "border-white/[0.08] bg-white/[0.03] text-fg/45",
-              )}>
-                {includeProjectDocs ? "Included" : "Off"}
-              </span>
-            </div>
-            <div className="mt-1 text-[11px] leading-5 text-fg/58">
-              Attach the project-level PRD and architecture context to the next turn so the agent starts with more background.
-            </div>
-          </button>
-        </div>
-
-        {helpMode ? (
-          <div className="rounded-[18px] border border-white/[0.06] bg-black/20 px-3 py-2">
-            <div className="flex items-center justify-between gap-2">
-              <span className="font-sans text-[10px] font-semibold uppercase tracking-[0.16em] text-fg/48">Mode help</span>
-              <span className="font-sans text-[10px] text-fg/38">{helpMode.label}</span>
-            </div>
-            <div className="mt-1 text-[11px] leading-5 text-fg/58">{hoveredExecutionMode ? helpMode.helper : helpMode.summary}</div>
-          </div>
-        ) : null}
-      </div>
-    </div>
-  );
-}
-
-function ComputerUseSettingsModal({
-  open,
-  policy,
-  snapshot,
-  onClose,
-  onChange,
-  onOpenProof,
-}: {
-  open: boolean;
-  policy: ComputerUsePolicy;
-  snapshot: ComputerUseOwnerSnapshot | null;
-  onClose: () => void;
-  onChange: (policy: ComputerUsePolicy) => void;
-  onOpenProof: () => void;
-}) {
-  if (!open) return null;
-
-  const activeBackend = snapshot?.activeBackend?.name ?? "None";
-  const artifactCount = snapshot?.artifacts.length ?? 0;
-
-  return (
-    <div
-      className="fixed inset-0 z-[9999] flex items-center justify-center bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.1),rgba(7,10,18,0.88))] px-4 backdrop-blur-md"
-      onClick={(event) => {
-        if (event.target === event.currentTarget) onClose();
-      }}
-    >
-      <div className="w-full max-w-sm overflow-hidden rounded-[28px] border border-white/[0.08] bg-[linear-gradient(180deg,rgba(15,21,34,0.96),rgba(10,13,22,0.94))] shadow-[0_28px_110px_-36px_rgba(0,0,0,0.82)]">
-        <div className="border-b border-white/[0.05] bg-[linear-gradient(90deg,rgba(56,189,248,0.12),transparent)] px-5 py-4">
-          <div className="flex items-start justify-between gap-4">
-            <div className="space-y-1">
-              <div className="font-sans text-[15px] font-semibold tracking-tight text-fg/88">Computer use</div>
-              <div className="text-[12px] leading-5 text-fg/58">
-                ADE captures proof from your agent's tool calls automatically.
-              </div>
-            </div>
-            <button
-              type="button"
-              className="rounded-[var(--chat-radius-pill)] border border-white/[0.08] bg-white/[0.03] px-3 py-1 font-sans text-[11px] font-medium text-fg/60 transition-colors hover:text-fg/85"
-              onClick={onClose}
-              title="Close"
-            >
-              Close
-            </button>
-          </div>
-        </div>
-
-        <div className="space-y-4 px-5 py-5">
-          <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <span className="font-sans text-[11px] uppercase tracking-[0.14em] text-muted-fg/40">Backend</span>
-              <span className="text-[12px] text-fg/78">{activeBackend}</span>
-            </div>
-            <div className="flex items-center justify-between">
-              <span className="font-sans text-[11px] uppercase tracking-[0.14em] text-muted-fg/40">Artifacts</span>
-              <span className="text-[12px] text-fg/78">{artifactCount} captured</span>
-            </div>
-          </div>
-
-          <div className="grid gap-3">
-            <button
-              type="button"
-              className="rounded-[18px] border border-white/[0.06] bg-white/[0.03] px-4 py-2.5 font-sans text-[12px] font-medium text-fg/78 transition-colors hover:border-white/[0.12] hover:text-fg/90"
-              onClick={onOpenProof}
-              title="Open the proof drawer"
-            >
-              Open proof drawer
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 export function AgentChatComposer({
   surfaceMode = "standard",
@@ -437,6 +186,7 @@ export function AgentChatComposer({
   onClearEvents,
   promptSuggestion,
   subagentSnapshots = [],
+  chatHasMessages = false,
 }: {
   surfaceMode?: ChatSurfaceMode;
   sdkSlashCommands?: AgentChatSlashCommand[];
@@ -495,6 +245,7 @@ export function AgentChatComposer({
   onClearEvents?: () => void;
   promptSuggestion?: string | null;
   subagentSnapshots?: ChatSubagentSnapshot[];
+  chatHasMessages?: boolean;
 }) {
   const [attachmentPickerOpen, setAttachmentPickerOpen] = useState(false);
   const [attachmentQuery, setAttachmentQuery] = useState("");
@@ -510,14 +261,10 @@ export function AgentChatComposer({
   const [hoveredCodexPreset, setHoveredCodexPreset] = useState<"plan" | "edit" | "full-auto" | null>(null);
 
   const [dragActive, setDragActive] = useState(false);
-  const [advancedMenuOpen, setAdvancedMenuOpen] = useState(false);
-  const [computerUseModalOpen, setComputerUseModalOpen] = useState(false);
 
   const attachmentInputRef = useRef<HTMLInputElement | null>(null);
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const advancedMenuRef = useRef<HTMLDivElement | null>(null);
-  const advancedButtonRef = useRef<HTMLButtonElement | null>(null);
   const fileAddInProgressRef = useRef(false);
   const canAttach = !turnActive;
 
@@ -552,41 +299,6 @@ export function AgentChatComposer({
     const timeout = window.setTimeout(() => attachmentInputRef.current?.focus(), 0);
     return () => window.clearTimeout(timeout);
   }, [attachmentPickerOpen]);
-
-  useEffect(() => {
-    if (!computerUseModalOpen) return;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.stopPropagation();
-        setComputerUseModalOpen(false);
-      }
-    };
-    window.addEventListener("keydown", onKeyDown, true);
-    return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [computerUseModalOpen]);
-
-  useEffect(() => {
-    if (!advancedMenuOpen) return;
-    const onPointerDown = (event: PointerEvent) => {
-      const target = event.target;
-      if (!(target instanceof Node)) return;
-      if (advancedMenuRef.current?.contains(target)) return;
-      if (advancedButtonRef.current?.contains(target)) return;
-      setAdvancedMenuOpen(false);
-    };
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setAdvancedMenuOpen(false);
-        advancedButtonRef.current?.focus();
-      }
-    };
-    window.addEventListener("pointerdown", onPointerDown, true);
-    window.addEventListener("keydown", onKeyDown, true);
-    return () => {
-      window.removeEventListener("pointerdown", onPointerDown, true);
-      window.removeEventListener("keydown", onKeyDown, true);
-    };
-  }, [advancedMenuOpen]);
 
   useEffect(() => {
     if (!attachmentPickerOpen) return;
@@ -1210,44 +922,47 @@ export function AgentChatComposer({
             </div>
 
             <div className="ml-auto flex shrink-0 items-center gap-1.5">
-              <div className="relative">
+              {/* Proof drawer toggle */}
+              {onToggleProof ? (
                 <button
-                  ref={advancedButtonRef}
                   type="button"
                   className={cn(
-                    "inline-flex h-7 items-center gap-1 rounded-md border px-2.5 font-sans text-[10px] font-medium transition-colors",
-                    advancedMenuOpen
-                      ? "border-[color:color-mix(in_srgb,var(--chat-accent)_28%,transparent)] bg-[color:color-mix(in_srgb,var(--chat-accent)_12%,transparent)] text-[var(--chat-accent)]"
+                    "relative inline-flex h-7 items-center gap-1 rounded-md border px-2 font-sans text-[10px] font-medium transition-colors",
+                    proofOpen
+                      ? "border-emerald-400/22 bg-emerald-500/10 text-emerald-200/80"
                       : "border-white/[0.06] bg-white/[0.02] text-muted-fg/40 hover:border-white/[0.12] hover:text-fg/68",
                   )}
-                  onClick={() => setAdvancedMenuOpen((open) => !open)}
-                  title="Open advanced composer settings"
-                  aria-expanded={advancedMenuOpen}
+                  onClick={onToggleProof}
+                  title={proofOpen ? "Close proof drawer" : "Open proof drawer"}
+                  aria-pressed={proofOpen}
                 >
-                  <span>Advanced</span>
-                  <CaretDown size={10} weight="bold" />
+                  <Cube size={12} weight={proofOpen ? "fill" : "regular"} />
+                  {proofArtifactCount > 0 ? (
+                    <span className="inline-flex h-[14px] min-w-[14px] items-center justify-center rounded-full bg-emerald-500/20 px-1 font-mono text-[8px] font-bold text-emerald-200/90">
+                      {proofArtifactCount}
+                    </span>
+                  ) : null}
                 </button>
-                {advancedMenuOpen ? (
-                  <div ref={advancedMenuRef}>
-                    <AdvancedSettingsPopover
-                      executionModeOptions={executionModeOptions}
-                      executionMode={executionMode ?? null}
-                      onExecutionModeChange={onExecutionModeChange}
-                      computerUsePolicy={computerUsePolicy}
-                      computerUseSnapshot={computerUseSnapshot ?? null}
-                      onOpenComputerUseDetails={() => {
-                        setAdvancedMenuOpen(false);
-                        setComputerUseModalOpen(true);
-                      }}
-                      proofOpen={proofOpen}
-                      proofArtifactCount={proofArtifactCount}
-                      onToggleProof={onToggleProof}
-                      includeProjectDocs={includeProjectDocs}
-                      onIncludeProjectDocsChange={onIncludeProjectDocsChange}
-                    />
-                  </div>
-                ) : null}
-              </div>
+              ) : null}
+
+              {/* Include context toggle -- only before first message */}
+              {!chatHasMessages && onIncludeProjectDocsChange ? (
+                <button
+                  type="button"
+                  className={cn(
+                    "inline-flex h-7 items-center gap-1 rounded-md border px-2 font-sans text-[10px] font-medium transition-colors",
+                    includeProjectDocs
+                      ? "border-accent/22 bg-accent/10 text-accent"
+                      : "border-white/[0.06] bg-white/[0.02] text-muted-fg/40 hover:border-white/[0.12] hover:text-fg/68",
+                  )}
+                  onClick={() => onIncludeProjectDocsChange(!includeProjectDocs)}
+                  title="Include project context (PRD + architecture) with first message"
+                  aria-pressed={!!includeProjectDocs}
+                >
+                  <BookOpen size={12} weight={includeProjectDocs ? "fill" : "regular"} />
+                  <span>Context</span>
+                </button>
+              ) : null}
 
               {turnActive ? (
                 <>
@@ -1352,17 +1067,6 @@ export function AgentChatComposer({
         </div>
       </div>
       </ChatComposerShell>
-      <ComputerUseSettingsModal
-        open={computerUseModalOpen}
-        policy={computerUsePolicy}
-        snapshot={computerUseSnapshot ?? null}
-        onClose={() => setComputerUseModalOpen(false)}
-        onChange={onComputerUsePolicyChange}
-        onOpenProof={() => {
-          if (!proofOpen) onToggleProof?.();
-          setComputerUseModalOpen(false);
-        }}
-      />
     </>
   );
 }

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -2081,9 +2081,7 @@ export function AgentChatPane({
                   </div>
                   <div className="max-h-[48vh] overflow-auto px-4 pb-4">
                     <ChatComputerUsePanel
-                      laneId={laneId}
                       sessionId={selectedSessionId}
-                      policy={computerUsePolicy}
                       snapshot={computerUseSnapshot}
                       onRefresh={() => refreshComputerUseSnapshot(selectedSessionId, { force: true })}
                     />

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -2026,6 +2026,7 @@ export function AgentChatPane({
             }}
             promptSuggestion={promptSuggestion}
             subagentSnapshots={selectedSubagentSnapshots}
+            chatHasMessages={selectedEvents.length > 0}
           />
         }
         bodyClassName="flex min-h-0 flex-col overflow-hidden"

--- a/apps/desktop/src/renderer/components/chat/ChatComputerUsePanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatComputerUsePanel.tsx
@@ -1,42 +1,95 @@
-import React, { useEffect, useMemo, useState } from "react";
-import type { ComputerUseArtifactOwnerKind, ComputerUseOwnerSnapshot, ComputerUsePolicy } from "../../../shared/types";
-import {
-  buildComputerUseRoutePresets,
-  describeComputerUseLinks,
-  formatComputerUseKind,
-  formatComputerUseMode,
-  summarizeComputerUseProof,
-} from "../../lib/computerUse";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import type { ComputerUseArtifactView, ComputerUseOwnerSnapshot, ComputerUsePolicy } from "../../../shared/types";
 import { cn } from "../ui/cn";
 
-function isExternalUri(value: string): boolean {
-  return /^https?:\/\//i.test(value);
+function isImageArtifact(artifact: ComputerUseArtifactView): boolean {
+  return artifact.kind === "screenshot" || (artifact.mimeType?.startsWith("image/") ?? false);
 }
 
-function openArtifactUri(uri: string | null) {
-  if (!uri) return;
-  if (isExternalUri(uri)) {
-    void window.ade.app.openExternal(uri);
-    return;
+function isVideoArtifact(artifact: ComputerUseArtifactView): boolean {
+  return artifact.kind === "video_recording" || (artifact.mimeType?.startsWith("video/") ?? false);
+}
+
+function kindLabel(kind: string): string {
+  return kind.replace(/_/g, " ");
+}
+
+/** Convert an artifact URI to an ade-artifact:// URL that Electron's custom protocol can serve. */
+function toPreviewSrc(uri: string): string {
+  // Already a remote URL — use directly
+  if (/^https?:\/\//i.test(uri)) return uri;
+  // Strip file:// prefix if present
+  let filePath = uri;
+  if (filePath.startsWith("file://")) {
+    try { filePath = decodeURIComponent(new URL(filePath).pathname); } catch { filePath = filePath.replace(/^file:\/\//i, ""); }
   }
-  void window.ade.app.revealPath(uri);
+  // For relative paths, we can't resolve here — the protocol handler in main will need the project root.
+  // But artifacts stored by the broker are typically absolute or relative to project root.
+  return `ade-artifact://${filePath.startsWith("/") ? "" : "/"}${encodeURI(filePath)}`;
 }
 
-function resolveArtifactPreviewUri(uri: string | null, projectRoot: string | null): string | null {
-  if (!uri) return null;
-  if (isExternalUri(uri)) return uri;
-  const absolutePath = uri.startsWith("/")
-    ? uri
-    : projectRoot
-      ? `${projectRoot.replace(/\/$/, "")}/${uri.replace(/^\.\//, "")}`
-      : null;
-  return absolutePath ? encodeURI(`file://${absolutePath}`) : null;
+function openInSystemPlayer(uri: string) {
+  if (/^https?:\/\//i.test(uri)) {
+    void window.ade.app.openExternal(uri);
+  } else {
+    void window.ade.app.revealPath(uri);
+  }
+}
+
+function VideoPreview({ artifact, src }: { artifact: ComputerUseArtifactView; src: string }) {
+  const [canPlay, setCanPlay] = useState(true);
+
+  if (!canPlay) {
+    return (
+      <button
+        type="button"
+        onClick={() => artifact.uri && openInSystemPlayer(artifact.uri)}
+        className="flex h-28 w-full items-center justify-center gap-2 rounded-md border border-white/[0.06] bg-black/20 text-[11px] text-fg/40 transition-colors hover:bg-white/[0.04] hover:text-fg/60"
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className="opacity-50">
+          <path d="M6 3.5L12 8L6 12.5V3.5Z" fill="currentColor" />
+        </svg>
+        Open in system player
+      </button>
+    );
+  }
+
+  return (
+    <video
+      src={src}
+      controls
+      className="block max-h-[360px] w-full rounded-md border border-white/[0.06] bg-black"
+      onError={() => setCanPlay(false)}
+      onStalled={() => setCanPlay(false)}
+    />
+  );
+}
+
+function ArtifactPreview({ artifact }: { artifact: ComputerUseArtifactView }) {
+  if (!artifact.uri) return null;
+
+  const src = toPreviewSrc(artifact.uri);
+
+  if (isImageArtifact(artifact)) {
+    return (
+      <img
+        src={src}
+        alt={artifact.title}
+        className="block max-h-[360px] w-full rounded-md border border-white/[0.06] object-contain"
+        onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
+      />
+    );
+  }
+
+  if (isVideoArtifact(artifact)) {
+    return <VideoPreview artifact={artifact} src={src} />;
+  }
+
+  return null;
 }
 
 export function ChatComputerUsePanel({
-  laneId,
   sessionId,
-  policy,
   snapshot,
   onRefresh,
 }: {
@@ -46,278 +99,171 @@ export function ChatComputerUsePanel({
   snapshot: ComputerUseOwnerSnapshot | null;
   onRefresh: () => void | Promise<void>;
 }) {
-  const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(snapshot?.artifacts[0]?.id ?? null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [routeKind, setRouteKind] = useState<ComputerUseArtifactOwnerKind>("mission");
-  const [routeTargetId, setRouteTargetId] = useState("");
-  const [projectRoot, setProjectRoot] = useState<string | null>(null);
 
-  const selectedArtifact = useMemo(
-    () => snapshot?.artifacts.find((artifact) => artifact.id === selectedArtifactId) ?? snapshot?.artifacts[0] ?? null,
-    [selectedArtifactId, snapshot],
-  );
-  const routePresets = useMemo(
-    () => buildComputerUseRoutePresets({ laneId, chatSessionId: sessionId }),
-    [laneId, sessionId],
+  const artifacts = useMemo(() => snapshot?.artifacts ?? [], [snapshot]);
+  const selected = useMemo(
+    () => artifacts.find((a) => a.id === selectedId) ?? artifacts[0] ?? null,
+    [selectedId, artifacts],
   );
 
   useEffect(() => {
-    setSelectedArtifactId((current) => current && snapshot?.artifacts.some((artifact) => artifact.id === current)
-      ? current
-      : snapshot?.artifacts[0]?.id ?? null);
-  }, [snapshot]);
+    setSelectedId((current) =>
+      current && artifacts.some((a) => a.id === current)
+        ? current
+        : artifacts[0]?.id ?? null,
+    );
+  }, [artifacts]);
 
-  useEffect(() => {
-    let cancelled = false;
-    window.ade.project.getSnapshot()
-      .then((project) => {
-        if (!cancelled) setProjectRoot(project.rootPath);
-      })
-      .catch(() => {
-        if (!cancelled) setProjectRoot(null);
+  const handleReveal = useCallback(() => {
+    if (!selected?.uri) return;
+    if (/^https?:\/\//i.test(selected.uri)) {
+      void window.ade.app.openExternal(selected.uri);
+    } else {
+      const path = selected.uri.startsWith("/")
+        ? selected.uri
+        : selected.uri;
+      void window.ade.app.revealPath(path);
+    }
+  }, [selected]);
+
+  const handleAccept = useCallback(async () => {
+    if (!selected) return;
+    setBusy(true);
+    try {
+      await window.ade.computerUse.updateArtifactReview({
+        artifactId: selected.id,
+        reviewState: "accepted",
+        workflowState: "promoted",
       });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+      await onRefresh();
+    } catch { /* ignore */ }
+    setBusy(false);
+  }, [selected, onRefresh]);
 
-  if (!snapshot) {
+  const handleDismiss = useCallback(async () => {
+    if (!selected) return;
+    setBusy(true);
+    try {
+      await window.ade.computerUse.updateArtifactReview({
+        artifactId: selected.id,
+        reviewState: "dismissed",
+        workflowState: "dismissed",
+      });
+      await onRefresh();
+    } catch { /* ignore */ }
+    setBusy(false);
+  }, [selected, onRefresh]);
+
+  if (!snapshot || artifacts.length === 0) {
     return (
-      <div className="rounded-[var(--chat-radius-card)] border border-white/[0.06] bg-black/10 px-3 py-2 font-sans text-[11px] text-muted-fg/35">
-        Computer use is {formatComputerUseMode(policy).toLowerCase()} for this chat. Start a session or capture proof to see backend activity and artifacts here.
+      <div className="px-4 py-6 text-center text-[12px] text-fg/30">
+        No artifacts captured yet.
       </div>
     );
   }
 
-  const previewUri = resolveArtifactPreviewUri(selectedArtifact?.uri ?? null, projectRoot);
-  const showImagePreview = Boolean(
-    selectedArtifact
-      && previewUri
-      && (selectedArtifact.kind === "screenshot" || selectedArtifact.mimeType?.startsWith("image/")),
-  );
-  const showVideoPreview = Boolean(
-    selectedArtifact
-      && previewUri
-      && (selectedArtifact.kind === "video_recording" || selectedArtifact.mimeType?.startsWith("video/")),
-  );
-
-  const updateReview = async (artifactId: string, reviewState: "accepted" | "needs_more" | "dismissed", workflowState?: "promoted" | "published" | "dismissed") => {
-    setBusy(true);
-    setError(null);
-    try {
-      await window.ade.computerUse.updateArtifactReview({
-        artifactId,
-        reviewState,
-        ...(workflowState ? { workflowState } : {}),
-      });
-      await onRefresh();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const routeArtifact = async (artifactId: string, ownerKind: ComputerUseArtifactOwnerKind, ownerId: string) => {
-    if (!ownerId.trim()) return;
-    setBusy(true);
-    setError(null);
-    try {
-      await window.ade.computerUse.routeArtifact({
-        artifactId,
-        owner: { kind: ownerKind, id: ownerId.trim() },
-      });
-      setRouteTargetId("");
-      await onRefresh();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
   return (
-    <div className="space-y-3">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <div className="font-sans text-[11px] font-medium text-sky-300/60">
-            Computer Use
-          </div>
-          <div className="mt-1 font-sans text-[12px] text-fg/50">{snapshot.summary}</div>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <span className="inline-flex items-center rounded-[var(--chat-radius-pill)] border border-sky-400/18 bg-sky-500/8 px-2.5 py-1 font-sans text-[10px] font-medium text-sky-200/80">
-            {formatComputerUseMode(policy)}
+    <div className="flex flex-col gap-3 p-3">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-[12px] font-medium text-fg/70">Proof</span>
+          <span className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-white/[0.08] px-1.5 text-[10px] font-medium tabular-nums text-fg/50">
+            {artifacts.length}
           </span>
-          <span className={cn(
-            "inline-flex items-center rounded-[var(--chat-radius-pill)] border px-2.5 py-1 font-sans text-[10px] font-medium",
-            snapshot.usingLocalFallback
-              ? "border-amber-400/18 bg-amber-500/8 text-amber-200/80"
-              : "border-emerald-400/18 bg-emerald-500/8 text-emerald-200/80",
-          )}>
-            {snapshot.usingLocalFallback ? "Fallback" : "External"}
-          </span>
-          <button
-            type="button"
-            className="rounded-[var(--chat-radius-pill)] border border-white/[0.06] bg-black/10 px-2.5 py-1 font-sans text-[10px] font-medium text-fg/50 hover:text-fg/78"
-            onClick={() => void onRefresh()}
-            disabled={busy}
-          >
-            Refresh
-          </button>
         </div>
+        <button
+          type="button"
+          onClick={() => void onRefresh()}
+          disabled={busy}
+          className="rounded px-1.5 py-0.5 text-[10px] text-fg/40 transition-colors hover:bg-white/[0.06] hover:text-fg/60"
+        >
+          Refresh
+        </button>
       </div>
 
-      <div className="flex flex-wrap gap-3 font-sans text-[11px] text-muted-fg/35">
-        <span>{summarizeComputerUseProof(snapshot)}</span>
-        <span>Backend: {snapshot.activeBackend?.name ?? "not selected"}</span>
-        <span>Artifacts: {snapshot.artifacts.length}</span>
-      </div>
-
-      {snapshot.activity.length > 0 ? (
-        <div className="grid gap-2 lg:grid-cols-2">
-          {snapshot.activity.slice(0, 4).map((item) => (
-            <div key={item.id} className="rounded-[var(--chat-radius-card)] border border-white/[0.05] bg-black/10 px-3 py-2">
-              <div className="font-sans text-[10px] font-medium text-muted-fg/30">{item.kind.replace(/_/g, " ")}</div>
-              <div className="mt-1 text-[11px] text-fg/72">{item.title}</div>
-              <div className="mt-1 font-sans text-[10px] text-muted-fg/30">{item.detail}</div>
-            </div>
-          ))}
-        </div>
-      ) : null}
-
-      <div className="grid gap-3 lg:grid-cols-[220px_minmax(0,1fr)]">
-        <div className="space-y-2">
-          {snapshot.artifacts.length === 0 ? (
-            <div className="rounded-[var(--chat-radius-card)] border border-white/[0.05] bg-black/10 px-3 py-2 font-sans text-[11px] text-muted-fg/30">
-              No screenshots, traces, logs, or verification output retained yet.
-            </div>
-          ) : snapshot.artifacts.map((artifact) => (
+      {/* Thumbnail strip */}
+      {artifacts.length > 1 && (
+        <div className="flex gap-1.5 overflow-x-auto pb-1">
+          {artifacts.map((artifact) => (
             <button
               key={artifact.id}
               type="button"
-              onClick={() => setSelectedArtifactId(artifact.id)}
+              onClick={() => setSelectedId(artifact.id)}
               className={cn(
-                "w-full rounded-[var(--chat-radius-card)] border px-3 py-2 text-left transition-colors",
-                selectedArtifact?.id === artifact.id
-                  ? "border-sky-400/24 bg-sky-500/10"
-                  : "border-white/[0.05] bg-black/10 hover:border-white/[0.1]",
+                "shrink-0 rounded-md border px-2.5 py-1.5 text-left transition-colors",
+                selected?.id === artifact.id
+                  ? "border-sky-400/30 bg-sky-500/10"
+                  : "border-white/[0.06] bg-white/[0.03] hover:border-white/[0.12]",
               )}
             >
-              <div className="font-sans text-[10px] font-medium text-muted-fg/30">{artifact.backendName}</div>
-              <div className="mt-1 text-[11px] text-fg/78">{artifact.title}</div>
-              <div className="mt-1 font-sans text-[10px] text-muted-fg/30">
-                {formatComputerUseKind(artifact.kind)} • {artifact.reviewState}
+              <div className="text-[10px] font-medium text-fg/60 whitespace-nowrap">
+                {kindLabel(artifact.kind)}
+              </div>
+              <div className="mt-0.5 text-[10px] text-fg/30 whitespace-nowrap">
+                {artifact.backendName}
               </div>
             </button>
           ))}
         </div>
+      )}
 
-        {selectedArtifact ? (
-          <div className="space-y-3">
-            <div className="rounded-[var(--chat-radius-card)] border border-white/[0.05] bg-black/10 px-3 py-3">
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div>
-                  <div className="font-sans text-[10px] font-medium text-muted-fg/30">{selectedArtifact.backendName}</div>
-                  <div className="mt-1 text-[13px] text-fg/82">{selectedArtifact.title}</div>
-                  {selectedArtifact.description ? (
-                    <div className="mt-2 text-[11px] leading-relaxed text-fg/58">{selectedArtifact.description}</div>
-                  ) : null}
-                </div>
-                {selectedArtifact.uri ? (
-                  <button
-                    type="button"
-                    className="rounded-[var(--chat-radius-pill)] border border-white/[0.06] bg-black/10 px-2.5 py-1 font-sans text-[10px] font-medium text-fg/50 hover:text-fg/78"
-                    onClick={() => openArtifactUri(selectedArtifact.uri)}
-                  >
-                    {isExternalUri(selectedArtifact.uri) ? "Open" : "Reveal"}
-                  </button>
-                ) : null}
-              </div>
-              <div className="mt-3 flex flex-wrap gap-2 font-sans text-[10px] font-medium text-muted-fg/30">
-                <span>{formatComputerUseKind(selectedArtifact.kind)}</span>
-                <span>{selectedArtifact.workflowState}</span>
-                <span>{describeComputerUseLinks(selectedArtifact.links)}</span>
+      {/* Selected artifact */}
+      {selected && (
+        <>
+          <ArtifactPreview artifact={selected} />
+
+          <div className="flex items-center justify-between gap-2">
+            <div className="min-w-0">
+              <div className="truncate text-[11px] text-fg/60">{selected.title}</div>
+              <div className="mt-0.5 flex items-center gap-2 text-[10px] text-fg/30">
+                <span>{kindLabel(selected.kind)}</span>
+                <span className={cn(
+                  "rounded px-1 py-px text-[9px] font-medium",
+                  selected.reviewState === "accepted" ? "bg-emerald-500/15 text-emerald-300/70" :
+                  selected.reviewState === "dismissed" ? "bg-red-500/15 text-red-300/70" :
+                  "bg-white/[0.06] text-fg/40",
+                )}>
+                  {selected.reviewState}
+                </span>
               </div>
             </div>
-
-            {showImagePreview ? (
-              <div className="overflow-hidden rounded-[var(--chat-radius-card)] border border-white/[0.05] bg-black/20">
-                <img
-                  src={previewUri!}
-                  alt={selectedArtifact.title}
-                  className="block max-h-[420px] w-full object-contain"
-                />
-              </div>
-            ) : null}
-
-            {showVideoPreview ? (
-              <div className="overflow-hidden rounded-[var(--chat-radius-card)] border border-white/[0.05] bg-black/20 p-2">
-                <video src={previewUri!} controls className="block max-h-[420px] w-full rounded-[calc(var(--chat-radius-card)-8px)] bg-black" />
-              </div>
-            ) : null}
-
-            {!showImagePreview && !showVideoPreview && selectedArtifact.uri ? (
-              <div className="rounded-[var(--chat-radius-card)] border border-white/[0.05] bg-black/10 px-3 py-2 font-sans text-[11px] text-muted-fg/34">
-                Inline preview is available for screenshots and recordings. Use open or reveal for this artifact type.
-              </div>
-            ) : null}
-
-            <div className="flex flex-wrap gap-2">
-              <button type="button" className="rounded-[var(--chat-radius-pill)] border border-emerald-400/18 bg-emerald-500/8 px-2.5 py-1 font-sans text-[10px] font-medium text-emerald-200/80" onClick={() => void updateReview(selectedArtifact.id, "accepted", "promoted")} disabled={busy}>Accept</button>
-              <button type="button" className="rounded-[var(--chat-radius-pill)] border border-amber-400/18 bg-amber-500/8 px-2.5 py-1 font-sans text-[10px] font-medium text-amber-200/80" onClick={() => void updateReview(selectedArtifact.id, "needs_more")} disabled={busy}>Need more</button>
-              <button type="button" className="rounded-[var(--chat-radius-pill)] border border-red-400/18 bg-red-500/8 px-2.5 py-1 font-sans text-[10px] font-medium text-red-200/80" onClick={() => void updateReview(selectedArtifact.id, "dismissed", "dismissed")} disabled={busy}>Dismiss</button>
-              <button type="button" className="rounded-[var(--chat-radius-pill)] border border-sky-400/18 bg-sky-500/8 px-2.5 py-1 font-sans text-[10px] font-medium text-sky-200/80" onClick={() => void updateReview(selectedArtifact.id, "accepted", "published")} disabled={busy}>Publish</button>
-            </div>
-
-            <div className="rounded-[var(--chat-radius-card)] border border-white/[0.05] bg-black/10 px-3 py-3">
-              <div className="font-sans text-[10px] font-medium text-muted-fg/30">Route Artifact</div>
-              <div className="mt-2 flex flex-wrap gap-2">
-                {routePresets.map((preset) => (
+            <div className="flex shrink-0 gap-1.5">
+              {selected.reviewState === "pending" && (
+                <>
                   <button
-                    key={`${preset.owner.kind}:${preset.owner.id}`}
                     type="button"
-                    className="rounded-[var(--chat-radius-pill)] border border-white/[0.06] bg-black/10 px-2.5 py-1 font-sans text-[10px] font-medium text-fg/50 hover:text-fg/78"
-                    onClick={() => void routeArtifact(selectedArtifact.id, preset.owner.kind, preset.owner.id)}
+                    onClick={() => void handleAccept()}
                     disabled={busy}
+                    className="rounded-md border border-emerald-400/20 bg-emerald-500/10 px-2 py-1 text-[10px] font-medium text-emerald-300/80 transition-colors hover:bg-emerald-500/20"
                   >
-                    {preset.label}
+                    Accept
                   </button>
-                ))}
-              </div>
-              <div className="mt-3 grid gap-2 md:grid-cols-[140px_minmax(0,1fr)_auto]">
-                <select
-                  value={routeKind}
-                  onChange={(event) => setRouteKind(event.target.value as ComputerUseArtifactOwnerKind)}
-                  className="h-8 rounded-[var(--chat-radius-pill)] border border-white/[0.06] bg-black/10 px-2 font-sans text-[11px] text-fg/78 outline-none"
-                >
-                  <option value="mission">mission</option>
-                  <option value="lane">lane</option>
-                  <option value="github_pr">GitHub PR</option>
-                  <option value="linear_issue">linear issue</option>
-                </select>
-                <input
-                  value={routeTargetId}
-                  onChange={(event) => setRouteTargetId(event.target.value)}
-                  placeholder="Target ID"
-                  className="h-8 rounded-[var(--chat-radius-pill)] border border-white/[0.06] bg-black/10 px-2 font-sans text-[11px] text-fg/78 outline-none placeholder:text-muted-fg/24"
-                />
+                  <button
+                    type="button"
+                    onClick={() => void handleDismiss()}
+                    disabled={busy}
+                    className="rounded-md border border-white/[0.06] px-2 py-1 text-[10px] font-medium text-fg/40 transition-colors hover:bg-white/[0.06] hover:text-fg/60"
+                  >
+                    Dismiss
+                  </button>
+                </>
+              )}
+              {selected.uri && (
                 <button
                   type="button"
-                  className="rounded-[var(--chat-radius-pill)] border border-white/[0.06] bg-black/10 px-3 font-sans text-[10px] font-medium text-fg/50 hover:text-fg/78"
-                  onClick={() => void routeArtifact(selectedArtifact.id, routeKind, routeTargetId)}
-                  disabled={busy || !routeTargetId.trim()}
+                  onClick={handleReveal}
+                  className="rounded-md border border-white/[0.06] px-2 py-1 text-[10px] font-medium text-fg/40 transition-colors hover:bg-white/[0.06] hover:text-fg/60"
                 >
-                  Attach
+                  Reveal
                 </button>
-              </div>
+              )}
             </div>
           </div>
-        ) : null}
-      </div>
-
-      {error ? <div className="font-sans text-[11px] text-amber-200/80">{error}</div> : null}
+        </>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/chat/ChatComputerUsePanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatComputerUsePanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import type { ComputerUseArtifactView, ComputerUseOwnerSnapshot, ComputerUsePolicy } from "../../../shared/types";
+import type { ComputerUseArtifactView, ComputerUseOwnerSnapshot } from "../../../shared/types";
 import { cn } from "../ui/cn";
 
 function isImageArtifact(artifact: ComputerUseArtifactView): boolean {
@@ -32,7 +32,10 @@ function openInSystemPlayer(uri: string) {
   if (/^https?:\/\//i.test(uri)) {
     void window.ade.app.openExternal(uri);
   } else {
-    void window.ade.app.revealPath(uri);
+    const fsPath = normalizeToFsPath(uri);
+    window.ade.app.openPath(fsPath).catch((err: unknown) => {
+      console.error("[ChatComputerUsePanel] Failed to open local path:", fsPath, err);
+    });
   }
 }
 
@@ -93,9 +96,7 @@ export function ChatComputerUsePanel({
   snapshot,
   onRefresh,
 }: {
-  laneId: string | null;
   sessionId: string;
-  policy: ComputerUsePolicy;
   snapshot: ComputerUseOwnerSnapshot | null;
   onRefresh: () => void | Promise<void>;
 }) {

--- a/apps/desktop/src/renderer/components/chat/ChatComputerUsePanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatComputerUsePanel.tsx
@@ -28,6 +28,13 @@ function toPreviewSrc(uri: string): string {
   return `ade-artifact://${filePath.startsWith("/") ? "" : "/"}${encodeURI(filePath)}`;
 }
 
+function normalizeToFsPath(uri: string): string {
+  if (uri.startsWith("file://")) {
+    try { return decodeURIComponent(new URL(uri).pathname); } catch { return uri.replace(/^file:\/\//i, ""); }
+  }
+  return uri;
+}
+
 function openInSystemPlayer(uri: string) {
   if (/^https?:\/\//i.test(uri)) {
     void window.ade.app.openExternal(uri);

--- a/apps/desktop/src/renderer/components/chat/ChatComputerUsePanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatComputerUsePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ComputerUseArtifactView, ComputerUseOwnerSnapshot } from "../../../shared/types";
 import { cn } from "../ui/cn";
 
@@ -39,21 +39,70 @@ function openInSystemPlayer(uri: string) {
   }
 }
 
+function PreviewFallback({
+  message,
+  actionLabel,
+  onOpen,
+}: {
+  message: string;
+  actionLabel: string;
+  onOpen: () => void;
+}) {
+  return (
+    <div className="flex min-h-28 w-full flex-col items-center justify-center gap-2 rounded-md border border-white/[0.06] bg-black/20 px-3 py-4 text-center">
+      <div className="text-[11px] text-fg/40">{message}</div>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="rounded-md border border-white/[0.08] px-2.5 py-1 text-[11px] text-fg/50 transition-colors hover:bg-white/[0.04] hover:text-fg/70"
+      >
+        {actionLabel}
+      </button>
+    </div>
+  );
+}
+
 function VideoPreview({ artifact, src }: { artifact: ComputerUseArtifactView; src: string }) {
   const [canPlay, setCanPlay] = useState(true);
+  const stalledTimeoutRef = useRef<number | null>(null);
+
+  const clearStalledTimeout = useCallback(() => {
+    if (stalledTimeoutRef.current == null) return;
+    window.clearTimeout(stalledTimeoutRef.current);
+    stalledTimeoutRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    setCanPlay(true);
+    clearStalledTimeout();
+    return clearStalledTimeout;
+  }, [clearStalledTimeout, src]);
+
+  const handlePlaybackRecovered = useCallback(() => {
+    clearStalledTimeout();
+    setCanPlay(true);
+  }, [clearStalledTimeout]);
+
+  const handlePlaybackError = useCallback(() => {
+    clearStalledTimeout();
+    setCanPlay(false);
+  }, [clearStalledTimeout]);
+
+  const handleStalled = useCallback(() => {
+    clearStalledTimeout();
+    stalledTimeoutRef.current = window.setTimeout(() => {
+      stalledTimeoutRef.current = null;
+      setCanPlay(false);
+    }, 3000);
+  }, [clearStalledTimeout]);
 
   if (!canPlay) {
     return (
-      <button
-        type="button"
-        onClick={() => artifact.uri && openInSystemPlayer(artifact.uri)}
-        className="flex h-28 w-full items-center justify-center gap-2 rounded-md border border-white/[0.06] bg-black/20 text-[11px] text-fg/40 transition-colors hover:bg-white/[0.04] hover:text-fg/60"
-      >
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className="opacity-50">
-          <path d="M6 3.5L12 8L6 12.5V3.5Z" fill="currentColor" />
-        </svg>
-        Open in system player
-      </button>
+      <PreviewFallback
+        message="Video preview unavailable."
+        actionLabel="Open in system player"
+        onOpen={() => artifact.uri && openInSystemPlayer(artifact.uri)}
+      />
     );
   }
 
@@ -62,8 +111,37 @@ function VideoPreview({ artifact, src }: { artifact: ComputerUseArtifactView; sr
       src={src}
       controls
       className="block max-h-[360px] w-full rounded-md border border-white/[0.06] bg-black"
-      onError={() => setCanPlay(false)}
-      onStalled={() => setCanPlay(false)}
+      onCanPlay={handlePlaybackRecovered}
+      onPlaying={handlePlaybackRecovered}
+      onError={handlePlaybackError}
+      onStalled={handleStalled}
+    />
+  );
+}
+
+function ImagePreview({ artifact, src }: { artifact: ComputerUseArtifactView; src: string }) {
+  const [imageError, setImageError] = useState(false);
+
+  useEffect(() => {
+    setImageError(false);
+  }, [src]);
+
+  if (imageError) {
+    return (
+      <PreviewFallback
+        message="Image preview unavailable."
+        actionLabel="Open in system viewer"
+        onOpen={() => artifact.uri && openInSystemPlayer(artifact.uri)}
+      />
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt={artifact.title}
+      className="block max-h-[360px] w-full rounded-md border border-white/[0.06] object-contain"
+      onError={() => setImageError(true)}
     />
   );
 }
@@ -74,14 +152,7 @@ function ArtifactPreview({ artifact }: { artifact: ComputerUseArtifactView }) {
   const src = toPreviewSrc(artifact.uri);
 
   if (isImageArtifact(artifact)) {
-    return (
-      <img
-        src={src}
-        alt={artifact.title}
-        className="block max-h-[360px] w-full rounded-md border border-white/[0.06] object-contain"
-        onError={(e) => { (e.target as HTMLImageElement).style.display = "none"; }}
-      />
-    );
+    return <ImagePreview artifact={artifact} src={src} />;
   }
 
   if (isVideoArtifact(artifact)) {
@@ -139,8 +210,11 @@ export function ChatComputerUsePanel({
         workflowState: "promoted",
       });
       await onRefresh();
-    } catch { /* ignore */ }
-    setBusy(false);
+    } catch (err) {
+      console.error("[ChatComputerUsePanel] Failed to accept artifact review:", selected.id, err);
+    } finally {
+      setBusy(false);
+    }
   }, [selected, onRefresh]);
 
   const handleDismiss = useCallback(async () => {
@@ -153,8 +227,11 @@ export function ChatComputerUsePanel({
         workflowState: "dismissed",
       });
       await onRefresh();
-    } catch { /* ignore */ }
-    setBusy(false);
+    } catch (err) {
+      console.error("[ChatComputerUsePanel] Failed to dismiss artifact review:", selected.id, err);
+    } finally {
+      setBusy(false);
+    }
   }, [selected, onRefresh]);
 
   if (!snapshot || artifacts.length === 0) {

--- a/apps/desktop/src/renderer/components/lanes/CreateLaneDialog.tsx
+++ b/apps/desktop/src/renderer/components/lanes/CreateLaneDialog.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, Plus, StackSimple } from "@phosphor-icons/react";
+import { GitBranch, GitFork, Plus, StackSimple } from "@phosphor-icons/react";
 import { Button } from "../ui/Button";
 import type { LaneSummary, LaneEnvInitProgress, LaneTemplate } from "../../../shared/types";
 import type { LaneBranchOption } from "./laneUtils";
@@ -6,9 +6,18 @@ import { LaneEnvInitProgressPanel } from "./LaneEnvInitProgress";
 import { LaneDialogShell } from "./LaneDialogShell";
 import { SECTION_CLASS_NAME, LABEL_CLASS_NAME, INPUT_CLASS_NAME, SELECT_CLASS_NAME } from "./laneDialogTokens";
 
-function buttonLabel(busy: boolean | undefined, createAsChild: boolean, parentLaneId: string, baseBranch: string): string {
-  if (busy) return "Setting up lane...";
-  if (createAsChild && parentLaneId) return "Create child lane";
+export type CreateLaneMode = "primary" | "existing" | "child";
+
+const MODE_META: Record<CreateLaneMode, { icon: typeof GitBranch; label: string }> = {
+  primary:  { icon: GitBranch,    label: "From primary" },
+  existing: { icon: GitFork,      label: "Existing branch" },
+  child:    { icon: StackSimple,  label: "Child lane" },
+};
+
+function submitLabel(busy: boolean | undefined, mode: CreateLaneMode, baseBranch: string): string {
+  if (busy) return "Setting up lane\u2026";
+  if (mode === "child") return "Create child lane";
+  if (mode === "existing") return "Import as lane";
   return `Create from ${baseBranch || "primary"}`;
 }
 
@@ -17,12 +26,14 @@ export function CreateLaneDialog({
   onOpenChange,
   createLaneName,
   setCreateLaneName,
-  createAsChild,
-  setCreateAsChild,
+  createMode,
+  setCreateMode,
   createParentLaneId,
   setCreateParentLaneId,
   createBaseBranch,
   setCreateBaseBranch,
+  createImportBranch,
+  setCreateImportBranch,
   createBranches,
   lanes,
   onSubmit,
@@ -38,12 +49,14 @@ export function CreateLaneDialog({
   onOpenChange: (open: boolean) => void;
   createLaneName: string;
   setCreateLaneName: (v: string) => void;
-  createAsChild: boolean;
-  setCreateAsChild: (v: boolean) => void;
+  createMode: CreateLaneMode;
+  setCreateMode: (v: CreateLaneMode) => void;
   createParentLaneId: string;
   setCreateParentLaneId: (v: string) => void;
   createBaseBranch: string;
   setCreateBaseBranch: (v: string) => void;
+  createImportBranch: string;
+  setCreateImportBranch: (v: string) => void;
   createBranches: LaneBranchOption[];
   lanes: LaneSummary[];
   onSubmit: () => void;
@@ -55,26 +68,33 @@ export function CreateLaneDialog({
   setSelectedTemplateId: (id: string) => void;
   onNavigateToTemplates?: () => void;
 }) {
-  const localBranches = createBranches.filter((branch) => !branch.isRemote);
-  const selectedTemplate = templates.find((template) => template.id === selectedTemplateId) ?? null;
+  const localBranches = createBranches.filter((b) => !b.isRemote);
+  const allBranches = createBranches;
+  const selectedTemplate = templates.find((t) => t.id === selectedTemplateId) ?? null;
+
+  const isSubmitDisabled = busy
+    || !createLaneName.trim()
+    || (createMode === "child" && !createParentLaneId)
+    || (createMode === "primary" && !createBaseBranch)
+    || (createMode === "existing" && !createImportBranch);
 
   return (
     <LaneDialogShell
       open={open}
       onOpenChange={onOpenChange}
       title="Create lane"
-      description="Start a fresh lane from primary or branch from an existing lane. Templates can install deps, copy files, and preconfigure the lane."
       icon={Plus}
-      widthClassName="w-[min(720px,calc(100vw-24px))]"
+      widthClassName="w-[min(560px,calc(100vw-24px))]"
       busy={busy}
     >
-      <div className="space-y-4">
+      <div className="space-y-3">
+        {/* Lane name */}
         <section className={SECTION_CLASS_NAME}>
           <label className="block">
             <span className={LABEL_CLASS_NAME}>Lane name</span>
             <input
               value={createLaneName}
-              onChange={(event) => setCreateLaneName(event.target.value)}
+              onChange={(e) => setCreateLaneName(e.target.value)}
               placeholder="e.g. feature/auth-refresh"
               className={INPUT_CLASS_NAME}
               autoFocus
@@ -83,25 +103,134 @@ export function CreateLaneDialog({
           </label>
         </section>
 
+        {/* Starting point — mode picker + contextual field */}
         <section className={SECTION_CLASS_NAME}>
-          <div className="flex items-start justify-between gap-3">
-            <div>
-              <div className={LABEL_CLASS_NAME}>Template</div>
-              <div className="mt-1 text-sm text-muted-fg">
-                Optional automation for dependency install, file copy, and lane setup.
-              </div>
-            </div>
+          <span className={LABEL_CLASS_NAME}>Starting point</span>
+
+          {/* Compact pill tabs */}
+          <div className="mt-2 inline-flex rounded-lg border border-white/[0.06] bg-white/[0.02] p-0.5">
+            {(["primary", "existing", "child"] as const).map((mode) => {
+              const meta = MODE_META[mode];
+              const Icon = meta.icon;
+              const active = createMode === mode;
+              return (
+                <button
+                  key={mode}
+                  type="button"
+                  disabled={busy}
+                  onClick={() => {
+                    setCreateMode(mode);
+                    if (mode !== "child") setCreateParentLaneId("");
+                  }}
+                  className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                    active
+                      ? "bg-accent/15 text-accent shadow-sm"
+                      : "text-muted-fg hover:text-fg"
+                  }`}
+                >
+                  <Icon size={12} />
+                  {meta.label}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Contextual field for selected mode */}
+          <div className="mt-3">
+            {createMode === "primary" ? (
+              localBranches.length > 0 ? (
+                <>
+                  <select
+                    value={createBaseBranch}
+                    onChange={(e) => setCreateBaseBranch(e.target.value)}
+                    className={SELECT_CLASS_NAME + " !mt-0"}
+                    disabled={busy}
+                  >
+                    {localBranches.map((b) => (
+                      <option key={b.name} value={b.name}>
+                        {b.name}{b.isCurrent ? " (current)" : ""}
+                      </option>
+                    ))}
+                  </select>
+                  {createBaseBranch ? (
+                    <div className="mt-1.5 text-[11px] text-muted-fg/60">
+                      Base: {createBaseBranch} — rebase suggestions will track this branch
+                    </div>
+                  ) : null}
+                </>
+              ) : (
+                <div className="rounded-lg border border-dashed border-white/[0.08] bg-black/10 px-3 py-2 text-xs text-muted-fg">
+                  No local branches found.
+                </div>
+              )
+            ) : null}
+
+            {createMode === "existing" ? (
+              allBranches.length > 0 ? (
+                <>
+                  <select
+                    value={createImportBranch}
+                    onChange={(e) => setCreateImportBranch(e.target.value)}
+                    className={SELECT_CLASS_NAME + " !mt-0"}
+                    disabled={busy}
+                  >
+                    <option value="">Select a branch\u2026</option>
+                    {allBranches.map((b) => (
+                      <option key={b.name} value={b.name}>
+                        {b.name}{b.isRemote ? " (remote)" : ""}
+                      </option>
+                    ))}
+                  </select>
+                  {createImportBranch ? (
+                    <div className="mt-1.5 text-[11px] text-muted-fg/60">
+                      Base will be auto-detected from git history
+                    </div>
+                  ) : null}
+                </>
+              ) : (
+                <div className="rounded-lg border border-dashed border-white/[0.08] bg-black/10 px-3 py-2 text-xs text-muted-fg">
+                  No branches found.
+                </div>
+              )
+            ) : null}
+
+            {createMode === "child" ? (
+              <>
+                <select
+                  value={createParentLaneId}
+                  onChange={(e) => setCreateParentLaneId(e.target.value)}
+                  className={SELECT_CLASS_NAME + " !mt-0"}
+                  disabled={busy}
+                >
+                  <option value="">Select parent lane\u2026</option>
+                  {lanes.map((lane) => (
+                    <option key={lane.id} value={lane.id}>
+                      {lane.name} ({lane.branchRef})
+                    </option>
+                  ))}
+                </select>
+                {createParentLaneId ? (
+                  <div className="mt-1.5 text-[11px] text-muted-fg/60">
+                    Base: {lanes.find((l) => l.id === createParentLaneId)?.branchRef ?? "unknown"} — rebase suggestions will track parent lane
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+          </div>
+        </section>
+
+        {/* Template — compact row, not a big section */}
+        <section className={SECTION_CLASS_NAME}>
+          <div className="flex items-center justify-between gap-3">
+            <span className={LABEL_CLASS_NAME}>Template</span>
             {onNavigateToTemplates ? (
               <button
                 type="button"
-                className="inline-flex h-8 items-center rounded-lg border border-white/[0.06] bg-white/[0.03] px-3 text-[11px] font-medium text-fg transition-colors hover:border-accent/30 hover:text-accent"
+                className="text-[10px] font-medium text-muted-fg/60 transition-colors hover:text-accent"
                 disabled={busy}
-                onClick={() => {
-                  onOpenChange(false);
-                  onNavigateToTemplates();
-                }}
+                onClick={() => { onOpenChange(false); onNavigateToTemplates(); }}
               >
-                {templates.length > 0 ? "Manage templates" : "Create template"}
+                {templates.length > 0 ? "Manage" : "Create template"}
               </button>
             ) : null}
           </div>
@@ -109,120 +238,26 @@ export function CreateLaneDialog({
             <>
               <select
                 value={selectedTemplateId}
-                onChange={(event) => setSelectedTemplateId(event.target.value)}
+                onChange={(e) => setSelectedTemplateId(e.target.value)}
                 className={SELECT_CLASS_NAME}
                 disabled={busy}
               >
-                <option value="">No template</option>
-                {templates.map((template) => (
-                  <option key={template.id} value={template.id}>
-                    {template.name}
-                    {template.description ? ` — ${template.description}` : ""}
+                <option value="">None</option>
+                {templates.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.name}{t.description ? ` — ${t.description}` : ""}
                   </option>
                 ))}
               </select>
-              <div className="mt-2 text-xs text-muted-fg/80">
-                {selectedTemplate?.description ?? "Create a lane with the default environment setup."}
-              </div>
+              {selectedTemplate?.description ? (
+                <div className="mt-1.5 text-[11px] text-muted-fg/60">{selectedTemplate.description}</div>
+              ) : null}
             </>
           ) : (
-            <div className="mt-3 rounded-lg border border-dashed border-white/[0.08] bg-black/10 px-3 py-3 text-sm text-muted-fg">
-              No templates yet. Create one to copy folders, install dependencies, and configure lanes automatically.
+            <div className="mt-2 text-xs text-muted-fg/50">
+              No templates yet.
             </div>
           )}
-        </section>
-
-        <section className={SECTION_CLASS_NAME}>
-          <div className="flex items-start gap-3">
-            <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-white/[0.06] bg-white/[0.03] text-accent">
-              {createAsChild ? <StackSimple size={16} /> : <GitBranch size={16} />}
-            </span>
-            <div className="min-w-0 flex-1">
-              <div className={LABEL_CLASS_NAME}>Starting point</div>
-              <div className="mt-1 text-sm text-muted-fg">
-                Choose whether the new lane starts as its own branch from primary or stacks under another lane.
-              </div>
-              <div className="mt-3 grid grid-cols-2 gap-2">
-                <button
-                  type="button"
-                  className={`rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
-                    !createAsChild
-                      ? "border-accent/35 bg-accent/10 text-fg"
-                      : "border-white/[0.06] bg-white/[0.02] text-muted-fg hover:text-fg"
-                  }`}
-                  disabled={busy}
-                  onClick={() => {
-                    setCreateAsChild(false);
-                    setCreateParentLaneId("");
-                  }}
-                >
-                  <div className="font-medium">From primary</div>
-                  <div className="mt-1 text-xs text-muted-fg">Create an independent lane from the selected branch on primary.</div>
-                </button>
-                <button
-                  type="button"
-                  className={`rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
-                    createAsChild
-                      ? "border-accent/35 bg-accent/10 text-fg"
-                      : "border-white/[0.06] bg-white/[0.02] text-muted-fg hover:text-fg"
-                  }`}
-                  disabled={busy}
-                  onClick={() => setCreateAsChild(true)}
-                >
-                  <div className="font-medium">Child lane</div>
-                  <div className="mt-1 text-xs text-muted-fg">Stack the lane under an existing lane and follow that parent for rebases.</div>
-                </button>
-              </div>
-
-              {createAsChild ? (
-                <label className="mt-4 block">
-                  <span className={LABEL_CLASS_NAME}>Parent lane</span>
-                  <select
-                    value={createParentLaneId}
-                    onChange={(event) => setCreateParentLaneId(event.target.value)}
-                    className={SELECT_CLASS_NAME}
-                    disabled={busy}
-                  >
-                    <option value="">Select a parent lane...</option>
-                    {lanes.map((lane) => (
-                      <option key={lane.id} value={lane.id}>
-                        {lane.name} ({lane.branchRef})
-                      </option>
-                    ))}
-                  </select>
-                  <div className="mt-2 text-xs text-muted-fg/80">
-                    The new lane will be created as a child of the selected lane.
-                  </div>
-                </label>
-              ) : (
-                <label className="mt-4 block">
-                  <span className={LABEL_CLASS_NAME}>Base branch on primary</span>
-                  {localBranches.length > 0 ? (
-                    <select
-                      value={createBaseBranch}
-                      onChange={(event) => setCreateBaseBranch(event.target.value)}
-                      className={SELECT_CLASS_NAME}
-                      disabled={busy}
-                    >
-                      {localBranches.map((branch) => (
-                        <option key={branch.name} value={branch.name}>
-                          {branch.name}
-                          {branch.isCurrent ? " (current)" : ""}
-                        </option>
-                      ))}
-                    </select>
-                  ) : (
-                    <div className="mt-1 rounded-lg border border-dashed border-white/[0.08] bg-black/10 px-3 py-2 text-sm text-muted-fg">
-                      No local branches found.
-                    </div>
-                  )}
-                  <div className="mt-2 text-xs text-muted-fg/80">
-                    Lane will be created from primary/{createBaseBranch || "..."} as its own lane, not stacked under Primary.
-                  </div>
-                </label>
-              )}
-            </div>
-          </div>
         </section>
 
         {error ? (
@@ -231,7 +266,7 @@ export function CreateLaneDialog({
           </div>
         ) : null}
 
-        <div className="flex items-center justify-end gap-2">
+        <div className="flex items-center justify-end gap-2 pt-1">
           <Button
             variant="outline"
             disabled={busy}
@@ -239,18 +274,15 @@ export function CreateLaneDialog({
               onOpenChange(false);
               setCreateLaneName("");
               setCreateParentLaneId("");
-              setCreateAsChild(false);
+              setCreateMode("primary");
               setCreateBaseBranch("");
+              setCreateImportBranch("");
             }}
           >
             Cancel
           </Button>
-          <Button
-            variant="primary"
-            disabled={busy || !createLaneName.trim() || (createAsChild ? !createParentLaneId : !createBaseBranch)}
-            onClick={onSubmit}
-          >
-            {buttonLabel(busy, createAsChild, createParentLaneId, createBaseBranch)}
+          <Button variant="primary" disabled={isSubmitDisabled} onClick={onSubmit}>
+            {submitLabel(busy, createMode, createBaseBranch)}
           </Button>
         </div>
 

--- a/apps/desktop/src/renderer/components/lanes/CreateLaneDialog.tsx
+++ b/apps/desktop/src/renderer/components/lanes/CreateLaneDialog.tsx
@@ -14,8 +14,9 @@ const MODE_META: Record<CreateLaneMode, { icon: typeof GitBranch; label: string 
   child:    { icon: StackSimple,  label: "Child lane" },
 };
 
-function submitLabel(busy: boolean | undefined, mode: CreateLaneMode, baseBranch: string): string {
+function submitLabel(busy: boolean | undefined, mode: CreateLaneMode, baseBranch: string, laneCreated: boolean | undefined): string {
   if (busy) return "Setting up lane\u2026";
+  if (laneCreated) return "Retry environment setup";
   if (mode === "child") return "Create child lane";
   if (mode === "existing") return "Import as lane";
   return `Create from ${baseBranch || "primary"}`;
@@ -40,6 +41,7 @@ export function CreateLaneDialog({
   busy,
   error,
   envInitProgress,
+  laneCreated,
   templates,
   selectedTemplateId,
   setSelectedTemplateId,
@@ -63,6 +65,8 @@ export function CreateLaneDialog({
   busy?: boolean;
   error?: string | null;
   envInitProgress?: LaneEnvInitProgress | null;
+  /** When true, the lane has already been created and the CTA only retries env setup. */
+  laneCreated?: boolean;
   templates: LaneTemplate[];
   selectedTemplateId: string;
   setSelectedTemplateId: (id: string) => void;
@@ -72,11 +76,15 @@ export function CreateLaneDialog({
   const allBranches = createBranches;
   const selectedTemplate = templates.find((t) => t.id === selectedTemplateId) ?? null;
 
-  const isSubmitDisabled = busy
-    || !createLaneName.trim()
-    || (createMode === "child" && !createParentLaneId)
-    || (createMode === "primary" && !createBaseBranch)
-    || (createMode === "existing" && !createImportBranch);
+  // When the lane already exists, the CTA only retries env setup — no form
+  // validation needed beyond not being busy.
+  const isSubmitDisabled = laneCreated
+    ? !!busy
+    : (busy
+      || !createLaneName.trim()
+      || (createMode === "child" && !createParentLaneId)
+      || (createMode === "primary" && !createBaseBranch)
+      || (createMode === "existing" && !createImportBranch));
 
   return (
     <LaneDialogShell
@@ -98,7 +106,7 @@ export function CreateLaneDialog({
               placeholder="e.g. feature/auth-refresh"
               className={INPUT_CLASS_NAME}
               autoFocus
-              disabled={busy}
+              disabled={busy || laneCreated}
             />
           </label>
         </section>
@@ -117,7 +125,8 @@ export function CreateLaneDialog({
                 <button
                   key={mode}
                   type="button"
-                  disabled={busy}
+                  aria-pressed={active}
+                  disabled={busy || laneCreated}
                   onClick={() => {
                     setCreateMode(mode);
                     if (mode !== "child") setCreateParentLaneId("");
@@ -144,7 +153,8 @@ export function CreateLaneDialog({
                     value={createBaseBranch}
                     onChange={(e) => setCreateBaseBranch(e.target.value)}
                     className={SELECT_CLASS_NAME + " !mt-0"}
-                    disabled={busy}
+                    disabled={busy || laneCreated}
+                    aria-label="Base branch"
                   >
                     {localBranches.map((b) => (
                       <option key={b.name} value={b.name}>
@@ -172,7 +182,8 @@ export function CreateLaneDialog({
                     value={createImportBranch}
                     onChange={(e) => setCreateImportBranch(e.target.value)}
                     className={SELECT_CLASS_NAME + " !mt-0"}
-                    disabled={busy}
+                    disabled={busy || laneCreated}
+                    aria-label="Import branch"
                   >
                     <option value="">Select a branch\u2026</option>
                     {allBranches.map((b) => (
@@ -200,7 +211,8 @@ export function CreateLaneDialog({
                   value={createParentLaneId}
                   onChange={(e) => setCreateParentLaneId(e.target.value)}
                   className={SELECT_CLASS_NAME + " !mt-0"}
-                  disabled={busy}
+                  disabled={busy || laneCreated}
+                  aria-label="Parent lane"
                 >
                   <option value="">Select parent lane\u2026</option>
                   {lanes.map((lane) => (
@@ -227,7 +239,7 @@ export function CreateLaneDialog({
               <button
                 type="button"
                 className="text-[10px] font-medium text-muted-fg/60 transition-colors hover:text-accent"
-                disabled={busy}
+                disabled={busy || laneCreated}
                 onClick={() => { onOpenChange(false); onNavigateToTemplates(); }}
               >
                 {templates.length > 0 ? "Manage" : "Create template"}
@@ -240,7 +252,8 @@ export function CreateLaneDialog({
                 value={selectedTemplateId}
                 onChange={(e) => setSelectedTemplateId(e.target.value)}
                 className={SELECT_CLASS_NAME}
-                disabled={busy}
+                disabled={busy || laneCreated}
+                aria-label="Template"
               >
                 <option value="">None</option>
                 {templates.map((t) => (
@@ -282,7 +295,7 @@ export function CreateLaneDialog({
             Cancel
           </Button>
           <Button variant="primary" disabled={isSubmitDisabled} onClick={onSubmit}>
-            {submitLabel(busy, createMode, createBaseBranch)}
+            {submitLabel(busy, createMode, createBaseBranch, laneCreated)}
           </Button>
         </div>
 

--- a/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, ArrowsClockwise, Check, Stack, Upload, Warning } from "@phosphor-icons/react";
+import { ArrowDown, ArrowsClockwise, Check, Stack, Trash, Upload, Warning } from "@phosphor-icons/react";
 import { useNavigate } from "react-router-dom";
 import { useAppStore } from "../../state/appStore";
 import { cn } from "../ui/cn";

--- a/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx
@@ -706,6 +706,26 @@ export function LaneGitActionsPane({
     await refreshChanges();
   };
 
+  const discardFile = (path: string) => {
+    if (!laneId) return;
+    const ok = window.confirm(`Discard all changes to ${path}? This cannot be undone.`);
+    if (!ok) return;
+    void runAction("discard file", async () => {
+      await window.ade.git.discardFile({ laneId, path });
+    });
+  };
+
+  const discardAll = () => {
+    if (!laneId) return;
+    const ok = window.confirm(`Discard ALL unstaged changes (${changes.unstaged.length} file${changes.unstaged.length === 1 ? "" : "s"})? This cannot be undone.`);
+    if (!ok) return;
+    void runAction("discard all", async () => {
+      for (const file of changes.unstaged) {
+        await window.ade.git.discardFile({ laneId, path: file.path });
+      }
+    });
+  };
+
   const stageAll = () => {
     if (!laneId) return;
     void runAction("stage all", async () => {
@@ -958,6 +978,32 @@ export function LaneGitActionsPane({
           >
             PARTIAL
           </span>
+        ) : null}
+        {mode === "unstaged" ? (
+          <button
+            type="button"
+            className="shrink-0 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity flex items-center justify-center"
+            style={{
+              width: 20,
+              height: 20,
+              background: "transparent",
+              border: "none",
+              cursor: "pointer",
+              color: COLORS.textDim,
+            }}
+            aria-label={`Discard changes to ${file.path}`}
+            onMouseEnter={(e) => { e.currentTarget.style.color = COLORS.danger; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = COLORS.textDim; }}
+            onFocus={(e) => { e.currentTarget.style.color = COLORS.danger; }}
+            onBlur={(e) => { e.currentTarget.style.color = COLORS.textDim; }}
+            onClick={(event) => {
+              event.stopPropagation();
+              void discardFile(file.path);
+            }}
+            title="Discard changes to this file. This cannot be undone."
+          >
+            <Trash size={12} />
+          </button>
         ) : null}
       </div>
     );
@@ -1552,13 +1598,26 @@ export function LaneGitActionsPane({
                   {changedFileCount}
                 </span>
                 {changes.unstaged.length > 0 ? (
-                  <button
-                    type="button"
-                    style={outlineButton({ height: 24, padding: "0 8px", fontSize: 10 })}
-                    onClick={stageAll}
-                  >
-                    STAGE ALL
-                  </button>
+                  <>
+                    <button
+                      type="button"
+                      style={outlineButton({ height: 24, padding: "0 8px", fontSize: 10 })}
+                      onClick={stageAll}
+                      disabled={busyAction != null}
+                      title={busyAction != null ? "Action in progress" : "Stage all unstaged changes"}
+                    >
+                      STAGE ALL
+                    </button>
+                    <button
+                      type="button"
+                      style={dangerButton({ height: 24, padding: "0 8px", fontSize: 10 })}
+                      onClick={discardAll}
+                      disabled={busyAction != null}
+                      title="Discard all unstaged changes. This cannot be undone."
+                    >
+                      DISCARD ALL
+                    </button>
+                  </>
                 ) : null}
                 {changes.staged.length > 0 ? (
                   <button

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.test.ts
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.test.ts
@@ -44,7 +44,7 @@ describe("resolveCreateLaneRequest", () => {
         name: "git actions fixes",
         createMode: "existing",
         createParentLaneId: "",
-        createBaseBranch: "",
+        createBaseBranch: "release-10",
         createImportBranch: "origin/ade/git-actions-fixes-5144fe89",
       }),
     ).toEqual({

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.test.ts
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.test.ts
@@ -6,9 +6,10 @@ describe("resolveCreateLaneRequest", () => {
     expect(
       resolveCreateLaneRequest({
         name: "git actions fixes",
-        createAsChild: false,
+        createMode: "primary",
         createParentLaneId: "lane-primary",
         createBaseBranch: "main",
+        createImportBranch: "",
       }),
     ).toEqual({
       kind: "root",
@@ -19,19 +20,38 @@ describe("resolveCreateLaneRequest", () => {
     });
   });
 
-  it("creates a stacked child lane only when child mode is selected", () => {
+  it("creates a stacked child lane when child mode is selected", () => {
     expect(
       resolveCreateLaneRequest({
         name: "git actions fixes",
-        createAsChild: true,
+        createMode: "child",
         createParentLaneId: "lane-primary",
         createBaseBranch: "main",
+        createImportBranch: "",
       }),
     ).toEqual({
       kind: "child",
       args: {
         name: "git actions fixes",
         parentLaneId: "lane-primary",
+      },
+    });
+  });
+
+  it("imports an existing branch as a lane when existing mode is selected", () => {
+    expect(
+      resolveCreateLaneRequest({
+        name: "git actions fixes",
+        createMode: "existing",
+        createParentLaneId: "",
+        createBaseBranch: "",
+        createImportBranch: "origin/ade/git-actions-fixes-5144fe89",
+      }),
+    ).toEqual({
+      kind: "import",
+      args: {
+        branchRef: "origin/ade/git-actions-fixes-5144fe89",
+        name: "git actions fixes",
       },
     });
   });

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -108,7 +108,6 @@ export function resolveCreateLaneRequest(args: {
       args: {
         branchRef: args.createImportBranch,
         name: args.name,
-        baseBranch: args.createBaseBranch,
       },
     };
   }

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -152,6 +152,7 @@ export function LanesPage() {
   const [createError, setCreateError] = useState<string | null>(null);
   const [createEnvInitProgress, setCreateEnvInitProgress] = useState<LaneEnvInitProgress | null>(null);
   const createEnvInitLaneIdRef = useRef<string | null>(null);
+  const createBaseBranchUserPickedRef = useRef(false);
   const [templates, setTemplates] = useState<LaneTemplate[]>([]);
   const [selectedTemplateId, setSelectedTemplateId] = useState("");
   const [attachOpen, setAttachOpen] = useState(false);
@@ -1070,6 +1071,7 @@ export function LanesPage() {
 
   const resetCreateDialogState = useCallback(() => {
     createEnvInitLaneIdRef.current = null;
+    createBaseBranchUserPickedRef.current = false;
     setCreateLaneName("");
     setCreateParentLaneId("");
     setCreateMode("primary");
@@ -1087,6 +1089,7 @@ export function LanesPage() {
     setCreateMode("primary");
     setCreateBaseBranch("");
     setCreateImportBranch("");
+    createBaseBranchUserPickedRef.current = false;
     const primary = lanes.find((l) => l.laneType === "primary");
     if (primary) {
       // Fetch remotes first so remote-only branches (pushed from other machines) appear.
@@ -1096,8 +1099,11 @@ export function LanesPage() {
         .then((branches) => {
           if (!branches) return;
           setCreateBranches(branches);
-          const current = branches.find((b) => b.isCurrent && !b.isRemote);
-          if (current) setCreateBaseBranch(current.name);
+          // Only auto-select the current branch if the user hasn't already picked one.
+          if (!createBaseBranchUserPickedRef.current) {
+            const current = branches.find((b) => b.isCurrent && !b.isRemote);
+            if (current) setCreateBaseBranch(current.name);
+          }
         })
         .catch(() => {});
     }
@@ -1121,7 +1127,48 @@ export function LanesPage() {
     setCreateOpen(open);
   }, [createBusy, resetCreateDialogState]);
 
+  /** Wraps setCreateBaseBranch so we can track user-driven selections and avoid
+   *  the async branch-list fetch from overwriting a value the user already picked. */
+  const handleSetCreateBaseBranch = useCallback((v: string) => {
+    createBaseBranchUserPickedRef.current = true;
+    setCreateBaseBranch(v);
+  }, []);
+
+  /** Run only the environment-setup phase (applyTemplate / initEnv) for a lane
+   *  that has already been created.  Used as the retry path when env setup fails. */
+  const runEnvSetupForCreatedLane = useCallback(async (laneId: string) => {
+    setCreateBusy(true);
+    setCreateError(null);
+    setCreateEnvInitProgress(null);
+
+    try {
+      const envProgress = selectedTemplateId
+        ? await window.ade.lanes.applyTemplate({ laneId, templateId: selectedTemplateId })
+        : await window.ade.lanes.initEnv({ laneId });
+      setCreateEnvInitProgress(envProgress);
+
+      if (envProgress.overallStatus === "failed") {
+        setCreateError("Environment setup failed. Review the progress log and retry.");
+        return;
+      }
+
+      resetCreateDialogState();
+      setCreateOpen(false);
+    } catch (err) {
+      setCreateError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCreateBusy(false);
+    }
+  }, [selectedTemplateId, resetCreateDialogState]);
+
   const handleCreateSubmit = useCallback(async () => {
+    // If the lane was already created (e.g. env-setup failed on a previous
+    // attempt), retry only the environment setup — never re-run creation.
+    if (createEnvInitLaneIdRef.current) {
+      await runEnvSetupForCreatedLane(createEnvInitLaneIdRef.current);
+      return;
+    }
+
     const name = createLaneName.trim();
     if (!name || createBusy) return;
     if (createMode === "child" && !createParentLaneId) return;
@@ -1135,7 +1182,6 @@ export function LanesPage() {
     setCreateBusy(true);
     setCreateError(null);
     setCreateEnvInitProgress(null);
-    createEnvInitLaneIdRef.current = null;
 
     try {
       const request = resolveCreateLaneRequest({
@@ -1154,28 +1200,19 @@ export function LanesPage() {
         lane = await window.ade.lanes.create(request.args);
       }
 
+      // Lane created successfully — record its id so retries skip creation.
+      createEnvInitLaneIdRef.current = lane.id;
+
       await refreshLanes();
       navigate(`/lanes?laneId=${encodeURIComponent(lane.id)}&focus=single`);
 
-      createEnvInitLaneIdRef.current = lane.id;
-      const envProgress = selectedTemplateId
-        ? await window.ade.lanes.applyTemplate({ laneId: lane.id, templateId: selectedTemplateId })
-        : await window.ade.lanes.initEnv({ laneId: lane.id });
-      setCreateEnvInitProgress(envProgress);
-
-      if (envProgress.overallStatus === "failed") {
-        setCreateError("Lane was created, but environment setup failed. Review the progress log and retry manually if needed.");
-        return;
-      }
-
-      resetCreateDialogState();
-      setCreateOpen(false);
+      // Now run environment setup as a separate phase.
+      await runEnvSetupForCreatedLane(lane.id);
     } catch (err) {
       setCreateError(err instanceof Error ? err.message : String(err));
-    } finally {
       setCreateBusy(false);
     }
-  }, [createLaneName, createMode, createParentLaneId, createBaseBranch, createImportBranch, createBusy, lanes, navigate, refreshLanes, resetCreateDialogState, selectedTemplateId, templates]);
+  }, [createLaneName, createMode, createParentLaneId, createBaseBranch, createImportBranch, createBusy, lanes, navigate, refreshLanes, runEnvSetupForCreatedLane, selectedTemplateId, templates]);
 
   const handleAttachSubmit = useCallback(async () => {
     const name = attachName.trim();
@@ -1960,7 +1997,7 @@ export function LanesPage() {
         createParentLaneId={createParentLaneId}
         setCreateParentLaneId={setCreateParentLaneId}
         createBaseBranch={createBaseBranch}
-        setCreateBaseBranch={setCreateBaseBranch}
+        setCreateBaseBranch={handleSetCreateBaseBranch}
         createImportBranch={createImportBranch}
         setCreateImportBranch={setCreateImportBranch}
         createBranches={createBranches}
@@ -1969,6 +2006,7 @@ export function LanesPage() {
         busy={createBusy}
         error={createError}
         envInitProgress={createEnvInitProgress}
+        laneCreated={createEnvInitLaneIdRef.current !== null}
         templates={templates}
         selectedTemplateId={selectedTemplateId}
         setSelectedTemplateId={setSelectedTemplateId}

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -83,7 +83,7 @@ const ADOPT_HINT_DISMISSED_KEY = "ade.lanes.adoptHintDismissed.v1";
 type CreateLaneRequest =
   | { kind: "child"; args: { name: string; parentLaneId: string } }
   | { kind: "root"; args: { name: string; baseBranch: string } }
-  | { kind: "import"; args: { branchRef: string; name: string } };
+  | { kind: "import"; args: { branchRef: string; name: string; baseBranch?: string } };
 
 export function resolveCreateLaneRequest(args: {
   name: string;
@@ -108,6 +108,7 @@ export function resolveCreateLaneRequest(args: {
       args: {
         branchRef: args.createImportBranch,
         name: args.name,
+        baseBranch: args.createBaseBranch,
       },
     };
   }
@@ -151,6 +152,7 @@ export function LanesPage() {
   const [createBusy, setCreateBusy] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   const [createEnvInitProgress, setCreateEnvInitProgress] = useState<LaneEnvInitProgress | null>(null);
+  const [laneCreated, setLaneCreated] = useState(false);
   const createEnvInitLaneIdRef = useRef<string | null>(null);
   const createBaseBranchUserPickedRef = useRef(false);
   const [templates, setTemplates] = useState<LaneTemplate[]>([]);
@@ -1072,6 +1074,7 @@ export function LanesPage() {
   const resetCreateDialogState = useCallback(() => {
     createEnvInitLaneIdRef.current = null;
     createBaseBranchUserPickedRef.current = false;
+    setLaneCreated(false);
     setCreateLaneName("");
     setCreateParentLaneId("");
     setCreateMode("primary");
@@ -1089,6 +1092,8 @@ export function LanesPage() {
     setCreateMode("primary");
     setCreateBaseBranch("");
     setCreateImportBranch("");
+    setCreateBranches([]);
+    setLaneCreated(false);
     createBaseBranchUserPickedRef.current = false;
     const primary = lanes.find((l) => l.laneType === "primary");
     if (primary) {
@@ -1202,6 +1207,7 @@ export function LanesPage() {
 
       // Lane created successfully — record its id so retries skip creation.
       createEnvInitLaneIdRef.current = lane.id;
+      setLaneCreated(true);
 
       await refreshLanes();
       navigate(`/lanes?laneId=${encodeURIComponent(lane.id)}&focus=single`);
@@ -1212,7 +1218,7 @@ export function LanesPage() {
       setCreateError(err instanceof Error ? err.message : String(err));
       setCreateBusy(false);
     }
-  }, [createLaneName, createMode, createParentLaneId, createBaseBranch, createImportBranch, createBusy, lanes, navigate, refreshLanes, runEnvSetupForCreatedLane, selectedTemplateId, templates]);
+  }, [createLaneName, createMode, createParentLaneId, createBaseBranch, createImportBranch, createBusy, navigate, refreshLanes, runEnvSetupForCreatedLane, selectedTemplateId, templates]);
 
   const handleAttachSubmit = useCallback(async () => {
     const name = attachName.trim();
@@ -2006,7 +2012,7 @@ export function LanesPage() {
         busy={createBusy}
         error={createError}
         envInitProgress={createEnvInitProgress}
-        laneCreated={createEnvInitLaneIdRef.current !== null}
+        laneCreated={laneCreated}
         templates={templates}
         selectedTemplateId={selectedTemplateId}
         setSelectedTemplateId={setSelectedTemplateId}

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -16,7 +16,7 @@ import { LaneStackPane } from "./LaneStackPane";
 import { LaneGitActionsPane } from "./LaneGitActionsPane";
 import { LaneDiffPane } from "./LaneDiffPane";
 import { LaneWorkPane } from "./LaneWorkPane";
-import { CreateLaneDialog } from "./CreateLaneDialog";
+import { CreateLaneDialog, type CreateLaneMode } from "./CreateLaneDialog";
 import { AttachLaneDialog } from "./AttachLaneDialog";
 import { ManageLaneDialog } from "./ManageLaneDialog";
 import { LaneContextMenu } from "./LaneContextMenu";
@@ -82,20 +82,32 @@ const ADOPT_HINT_DISMISSED_KEY = "ade.lanes.adoptHintDismissed.v1";
 
 type CreateLaneRequest =
   | { kind: "child"; args: { name: string; parentLaneId: string } }
-  | { kind: "root"; args: { name: string; baseBranch: string } };
+  | { kind: "root"; args: { name: string; baseBranch: string } }
+  | { kind: "import"; args: { branchRef: string; name: string } };
 
 export function resolveCreateLaneRequest(args: {
   name: string;
-  createAsChild: boolean;
+  createMode: CreateLaneMode;
   createParentLaneId: string;
   createBaseBranch: string;
+  createImportBranch: string;
 }): CreateLaneRequest {
-  if (args.createAsChild) {
+  if (args.createMode === "child") {
     return {
       kind: "child",
       args: {
         name: args.name,
         parentLaneId: args.createParentLaneId,
+      },
+    };
+  }
+
+  if (args.createMode === "existing") {
+    return {
+      kind: "import",
+      args: {
+        branchRef: args.createImportBranch,
+        name: args.name,
       },
     };
   }
@@ -132,8 +144,9 @@ export function LanesPage() {
   const [createOpen, setCreateOpen] = useState(false);
   const [createLaneName, setCreateLaneName] = useState("");
   const [createParentLaneId, setCreateParentLaneId] = useState<string>("");
-  const [createAsChild, setCreateAsChild] = useState(false);
+  const [createMode, setCreateMode] = useState<CreateLaneMode>("primary");
   const [createBaseBranch, setCreateBaseBranch] = useState("");
+  const [createImportBranch, setCreateImportBranch] = useState("");
   const [createBranches, setCreateBranches] = useState<LaneBranchOption[]>([]);
   const [createBusy, setCreateBusy] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
@@ -1059,8 +1072,9 @@ export function LanesPage() {
     createEnvInitLaneIdRef.current = null;
     setCreateLaneName("");
     setCreateParentLaneId("");
-    setCreateAsChild(false);
+    setCreateMode("primary");
     setCreateBaseBranch("");
+    setCreateImportBranch("");
     setCreateBusy(false);
     setCreateError(null);
     setCreateEnvInitProgress(null);
@@ -1070,12 +1084,17 @@ export function LanesPage() {
   const prepareCreateDialog = useCallback(() => {
     setCreateLaneName("");
     setCreateParentLaneId("");
-    setCreateAsChild(false);
+    setCreateMode("primary");
     setCreateBaseBranch("");
+    setCreateImportBranch("");
     const primary = lanes.find((l) => l.laneType === "primary");
     if (primary) {
-      window.ade.git.listBranches({ laneId: primary.id })
+      // Fetch remotes first so remote-only branches (pushed from other machines) appear.
+      window.ade.git.fetch({ laneId: primary.id })
+        .catch(() => {})
+        .then(() => window.ade.git.listBranches({ laneId: primary.id }))
         .then((branches) => {
+          if (!branches) return;
           setCreateBranches(branches);
           const current = branches.find((b) => b.isCurrent && !b.isRemote);
           if (current) setCreateBaseBranch(current.name);
@@ -1104,7 +1123,10 @@ export function LanesPage() {
 
   const handleCreateSubmit = useCallback(async () => {
     const name = createLaneName.trim();
-    if (!name || createBusy || (createAsChild && !createParentLaneId) || (!createAsChild && !createBaseBranch)) return;
+    if (!name || createBusy) return;
+    if (createMode === "child" && !createParentLaneId) return;
+    if (createMode === "primary" && !createBaseBranch) return;
+    if (createMode === "existing" && !createImportBranch) return;
     if (selectedTemplateId && !templates.some((template) => template.id === selectedTemplateId)) {
       setCreateError("The selected lane template no longer exists. Refresh templates or choose a different option.");
       return;
@@ -1118,13 +1140,19 @@ export function LanesPage() {
     try {
       const request = resolveCreateLaneRequest({
         name,
-        createAsChild,
+        createMode,
         createParentLaneId,
         createBaseBranch,
+        createImportBranch,
       });
-      const lane = request.kind === "child"
-        ? await window.ade.lanes.createChild(request.args)
-        : await window.ade.lanes.create(request.args);
+      let lane: LaneSummary;
+      if (request.kind === "import") {
+        lane = await window.ade.lanes.importBranch(request.args);
+      } else if (request.kind === "child") {
+        lane = await window.ade.lanes.createChild(request.args);
+      } else {
+        lane = await window.ade.lanes.create(request.args);
+      }
 
       await refreshLanes();
       navigate(`/lanes?laneId=${encodeURIComponent(lane.id)}&focus=single`);
@@ -1147,7 +1175,7 @@ export function LanesPage() {
     } finally {
       setCreateBusy(false);
     }
-  }, [createLaneName, createAsChild, createParentLaneId, createBusy, lanes, navigate, refreshLanes, resetCreateDialogState, selectedTemplateId, templates]);
+  }, [createLaneName, createMode, createParentLaneId, createBaseBranch, createImportBranch, createBusy, lanes, navigate, refreshLanes, resetCreateDialogState, selectedTemplateId, templates]);
 
   const handleAttachSubmit = useCallback(async () => {
     const name = attachName.trim();
@@ -1927,12 +1955,14 @@ export function LanesPage() {
         onOpenChange={handleCreateDialogOpenChange}
         createLaneName={createLaneName}
         setCreateLaneName={setCreateLaneName}
-        createAsChild={createAsChild}
-        setCreateAsChild={setCreateAsChild}
+        createMode={createMode}
+        setCreateMode={setCreateMode}
         createParentLaneId={createParentLaneId}
         setCreateParentLaneId={setCreateParentLaneId}
         createBaseBranch={createBaseBranch}
         setCreateBaseBranch={setCreateBaseBranch}
+        createImportBranch={createImportBranch}
+        setCreateImportBranch={setCreateImportBranch}
         createBranches={createBranches}
         lanes={lanes}
         onSubmit={handleCreateSubmit}

--- a/apps/desktop/src/renderer/components/prs/CreatePrModal.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/CreatePrModal.test.tsx
@@ -101,6 +101,11 @@ describe("CreatePrModal queue workflow", () => {
       },
       git: {
         getSyncStatus: vi.fn().mockResolvedValue(null),
+        listBranches: vi.fn().mockResolvedValue([
+          { name: "main", isCurrent: true, isRemote: false, upstream: "origin/main" },
+          { name: "develop", isCurrent: false, isRemote: false, upstream: "origin/develop" },
+          { name: "release-9", isCurrent: false, isRemote: false, upstream: null },
+        ]),
       },
     } as any;
   });
@@ -162,10 +167,14 @@ describe("CreatePrModal queue workflow", () => {
     const user = userEvent.setup();
     render(<CreatePrModal open onOpenChange={vi.fn()} />);
 
-    await user.selectOptions(screen.getByRole("combobox"), "lane-1");
-    const targetBranchInput = screen.getByDisplayValue("main");
-    await user.clear(targetBranchInput);
-    await user.type(targetBranchInput, "release-9");
+    // Select source lane
+    const comboboxes = screen.getAllByRole("combobox");
+    await user.selectOptions(comboboxes[0]!, "lane-1");
+
+    // Wait for branches to load, then select a different target branch
+    await waitFor(() => expect(screen.getByDisplayValue("main")).toBeTruthy());
+    const targetSelect = screen.getByDisplayValue("main");
+    await user.selectOptions(targetSelect, "release-9");
 
     await user.click(screen.getByRole("button", { name: /next step/i }));
     await user.click(screen.getByRole("button", { name: /create pr/i }));
@@ -183,10 +192,14 @@ describe("CreatePrModal queue workflow", () => {
     const user = userEvent.setup();
     render(<CreatePrModal open onOpenChange={vi.fn()} />);
 
-    await user.selectOptions(screen.getByRole("combobox"), "lane-1");
-    const targetBranchInput = screen.getByDisplayValue("main");
-    await user.clear(targetBranchInput);
-    await user.type(targetBranchInput, "release-9");
+    // Select source lane
+    const comboboxes = screen.getAllByRole("combobox");
+    await user.selectOptions(comboboxes[0]!, "lane-1");
+
+    // Wait for branches to load, then select a different target branch
+    await waitFor(() => expect(screen.getByDisplayValue("main")).toBeTruthy());
+    const targetSelect = screen.getByDisplayValue("main");
+    await user.selectOptions(targetSelect, "release-9");
 
     expect(screen.getByText("Lane Needs Attention")).toBeTruthy();
     expect(screen.getByText(/targets release-9, but this lane currently tracks main/i)).toBeTruthy();
@@ -200,9 +213,10 @@ describe("CreatePrModal queue workflow", () => {
     await user.click(screen.getAllByRole("button", { name: /queue workflow/i })[0]!);
     await user.click(screen.getByRole("checkbox", { name: /01 queue lane/i }));
 
-    const targetBranchInput = screen.getByDisplayValue("main");
-    await user.clear(targetBranchInput);
-    await user.type(targetBranchInput, "release-9");
+    // Wait for branches to load, then select a different target branch
+    await waitFor(() => expect(screen.getByDisplayValue("main")).toBeTruthy());
+    const targetSelect = screen.getByDisplayValue("main");
+    await user.selectOptions(targetSelect, "release-9");
 
     await user.click(screen.getByRole("button", { name: /next step/i }));
     await user.click(screen.getByRole("button", { name: /create pr/i }));

--- a/apps/desktop/src/renderer/components/prs/CreatePrModal.tsx
+++ b/apps/desktop/src/renderer/components/prs/CreatePrModal.tsx
@@ -1119,6 +1119,7 @@ export function CreatePrModal({
                         <select
                           value={normalBaseBranch}
                           onChange={(e) => setNormalBaseBranch(e.target.value)}
+                          aria-label="Target branch"
                           style={selectStyle}
                           onFocus={(e) => { e.currentTarget.style.borderColor = C.accent; }}
                           onBlur={(e) => { e.currentTarget.style.borderColor = C.borderSubtle; }}
@@ -1389,6 +1390,7 @@ export function CreatePrModal({
                         <select
                           value={queueTargetBranch}
                           onChange={(e) => setQueueTargetBranch(e.target.value)}
+                          aria-label="Target branch"
                           style={selectStyle}
                           onFocus={(e) => { e.currentTarget.style.borderColor = C.accent; }}
                           onBlur={(e) => { e.currentTarget.style.borderColor = C.borderSubtle; }}
@@ -1427,6 +1429,7 @@ export function CreatePrModal({
                             setIntegrationBaseBranch(e.target.value);
                             setProposal(null);
                           }}
+                          aria-label="Target branch"
                           style={selectStyle}
                           onFocus={(e) => { e.currentTarget.style.borderColor = C.accent; }}
                           onBlur={(e) => { e.currentTarget.style.borderColor = C.borderSubtle; }}

--- a/apps/desktop/src/renderer/components/prs/CreatePrModal.tsx
+++ b/apps/desktop/src/renderer/components/prs/CreatePrModal.tsx
@@ -9,6 +9,7 @@ import type {
   IntegrationProposalStep,
   CreateIntegrationPrResult,
   GitUpstreamSyncStatus,
+  GitBranchSummary,
   LaneSummary,
 } from "../../../shared/types";
 import { COLORS, MONO_FONT, LABEL_STYLE } from "../lanes/laneDesignTokens";
@@ -70,6 +71,17 @@ const inputStyle: React.CSSProperties = {
   borderRadius: 0,
   outline: "none",
   transition: "border-color 0.15s",
+};
+
+const selectStyle: React.CSSProperties = {
+  ...inputStyle,
+  paddingLeft: 32,
+  appearance: "none",
+  WebkitAppearance: "none",
+  cursor: "pointer",
+  backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%2371717A' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")`,
+  backgroundRepeat: "no-repeat",
+  backgroundPosition: "right 12px center",
 };
 
 const textareaStyle: React.CSSProperties = {
@@ -500,6 +512,37 @@ export function CreatePrModal({
 
   const [draftError, setDraftError] = React.useState<string | null>(null);
 
+  // Available branches for target-branch dropdowns
+  const [availableBranches, setAvailableBranches] = React.useState<GitBranchSummary[]>([]);
+
+  React.useEffect(() => {
+    if (!open || !primaryLane) return;
+    let cancelled = false;
+    window.ade.git.listBranches({ laneId: primaryLane.id })
+      .then((branches) => {
+        if (!cancelled) setAvailableBranches(branches);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [open, primaryLane?.id]);
+
+  /** Deduplicated list of branch names suitable for a target-branch dropdown. */
+  const targetBranchOptions = React.useMemo(() => {
+    const seen = new Set<string>();
+    const options: string[] = [];
+    for (const b of availableBranches) {
+      // For remote branches like "origin/main", strip the remote prefix
+      const name = b.isRemote
+        ? b.name.replace(/^[^/]+\//, "")
+        : b.name;
+      if (!seen.has(name)) {
+        seen.add(name);
+        options.push(name);
+      }
+    }
+    return options.sort((a, b) => a.localeCompare(b));
+  }, [availableBranches]);
+
   const handleDraftAI = async (laneId: string) => {
     setDrafting(true);
     setDraftError(null);
@@ -564,6 +607,7 @@ export function CreatePrModal({
       setIntegrationProgress(null);
       setIntegrationBranchError(null);
       setQueueErrors([]);
+      setAvailableBranches([]);
     }, 200);
     return () => clearTimeout(id);
   }, [open]);
@@ -1069,14 +1113,20 @@ export function CreatePrModal({
                             transform: "translateY(-50%)",
                             color: C.textMuted,
                             pointerEvents: "none",
+                            zIndex: 1,
                           }}
                         />
-                        <input
+                        <select
                           value={normalBaseBranch}
                           onChange={(e) => setNormalBaseBranch(e.target.value)}
-                          style={{ ...inputStyle, paddingLeft: 32 }}
-                          placeholder={branchNameFromRef(primaryLane?.branchRef ?? "main")}
-                        />
+                          style={selectStyle}
+                          onFocus={(e) => { e.currentTarget.style.borderColor = C.accent; }}
+                          onBlur={(e) => { e.currentTarget.style.borderColor = C.borderSubtle; }}
+                        >
+                          {targetBranchOptions.map((name) => (
+                            <option key={name} value={name}>{name}</option>
+                          ))}
+                        </select>
                       </div>
                     </div>
 
@@ -1333,14 +1383,20 @@ export function CreatePrModal({
                             transform: "translateY(-50%)",
                             color: C.textMuted,
                             pointerEvents: "none",
+                            zIndex: 1,
                           }}
                         />
-                        <input
+                        <select
                           value={queueTargetBranch}
                           onChange={(e) => setQueueTargetBranch(e.target.value)}
-                          style={{ ...inputStyle, paddingLeft: 32 }}
-                          placeholder={branchNameFromRef(primaryLane?.branchRef ?? "main")}
-                        />
+                          style={selectStyle}
+                          onFocus={(e) => { e.currentTarget.style.borderColor = C.accent; }}
+                          onBlur={(e) => { e.currentTarget.style.borderColor = C.borderSubtle; }}
+                        >
+                          {targetBranchOptions.map((name) => (
+                            <option key={name} value={name}>{name}</option>
+                          ))}
+                        </select>
                       </div>
                     </div>
                   </div>
@@ -1362,14 +1418,20 @@ export function CreatePrModal({
                             transform: "translateY(-50%)",
                             color: C.textMuted,
                             pointerEvents: "none",
+                            zIndex: 1,
                           }}
                         />
-                        <input
+                        <select
                           value={integrationBaseBranch}
                           onChange={(e) => setIntegrationBaseBranch(e.target.value)}
-                          style={{ ...inputStyle, paddingLeft: 32 }}
-                          placeholder={branchNameFromRef(primaryLane?.branchRef ?? "main")}
-                        />
+                          style={selectStyle}
+                          onFocus={(e) => { e.currentTarget.style.borderColor = C.accent; }}
+                          onBlur={(e) => { e.currentTarget.style.borderColor = C.borderSubtle; }}
+                        >
+                          {targetBranchOptions.map((name) => (
+                            <option key={name} value={name}>{name}</option>
+                          ))}
+                        </select>
                       </div>
                     </div>
 

--- a/apps/desktop/src/renderer/components/prs/CreatePrModal.tsx
+++ b/apps/desktop/src/renderer/components/prs/CreatePrModal.tsx
@@ -1423,7 +1423,10 @@ export function CreatePrModal({
                         />
                         <select
                           value={integrationBaseBranch}
-                          onChange={(e) => setIntegrationBaseBranch(e.target.value)}
+                          onChange={(e) => {
+                            setIntegrationBaseBranch(e.target.value);
+                            setProposal(null);
+                          }}
                           style={selectStyle}
                           onFocus={(e) => { e.currentTarget.style.borderColor = C.accent; }}
                           onBlur={(e) => { e.currentTarget.style.borderColor = C.borderSubtle; }}

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -4,6 +4,7 @@ export const IPC = {
   appGetProject: "ade.app.getProject",
   appOpenExternal: "ade.app.openExternal",
   appRevealPath: "ade.app.revealPath",
+  appOpenPath: "ade.app.openPath",
   appWriteClipboardText: "ade.app.writeClipboardText",
   appOpenPathInEditor: "ade.app.openPathInEditor",
   projectOpenRepo: "ade.project.openRepo",

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -122,6 +122,7 @@ export const IPC = {
   computerUseGetOwnerSnapshot: "ade.computerUse.getOwnerSnapshot",
   computerUseRouteArtifact: "ade.computerUse.routeArtifact",
   computerUseUpdateArtifactReview: "ade.computerUse.updateArtifactReview",
+  computerUseReadArtifactPreview: "ade.computerUse.readArtifactPreview",
   computerUseEvent: "ade.computerUse.event",
   ptyCreate: "ade.pty.create",
   ptyWrite: "ade.pty.write",

--- a/apps/desktop/src/shared/types/lanes.ts
+++ b/apps/desktop/src/shared/types/lanes.ts
@@ -127,6 +127,7 @@ export type ImportBranchLaneArgs = {
   name?: string;
   description?: string;
   parentLaneId?: string | null;
+  baseBranch?: string;
 };
 
 export type AttachLaneArgs = {


### PR DESCRIPTION
## Summary
- Add `ade-artifact://` protocol for serving local files (images, videos) to proof drawer previews
- Add synthetic `tool_result` injection for computer-use screenshot artifacts
- Revamp lane creation flow: support creating from a specific base branch, as a child lane, or by importing an existing remote branch
- Add target branch selector to PR creation modal (normal, queue, and integration modes)
- Simplify chat composer, rebase services, PTY service, process monitor, and terminal session handling
- Remove unused code: `laneLaunchContext.ts`, `laneBranchTargets.ts`, `cliLaunch.ts`, `processUtils.ts`, and stale tests

## Test plan
- [ ] Verify proof drawer displays local image/video artifacts via `ade-artifact://` protocol
- [ ] Create lanes using all three modes (from primary base branch, child lane, import existing branch)
- [ ] Create PRs targeting non-default branches in normal, queue, and integration modes
- [ ] Confirm rebase flows and conflict detection still work correctly
- [ ] Run existing test suites (`laneService`, `CreatePrModal`, `syntheticToolResult`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ade-artifact:// in-app file protocol with byte-range support and integrated image/video previews
  * Import-existing-branch lane mode and related UI flows
  * Host APIs: read artifact preview and an "open path" command exposed to the renderer

* **Improvements**
  * Simplified chat composer (proof drawer, inline context toggle) and revamped artifact viewer playback/preview fallbacks
  * Better branch-import parent detection and safer cleanup
  * Per-file and bulk "discard unstaged" actions in Files toolbar

* **Tests**
  * New tests for synthetic tool-result extraction and lane import behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->