### PR TITLE
fix(desktop): ensure main bundle after npm install

### DIFF
--- a/apps/desktop/electron.cjs
+++ b/apps/desktop/electron.cjs
@@ -1,7 +1,19 @@
 // Electron entrypoint for `electron .`
 // We point Electron at the compiled main process output.
+const fs = require("node:fs");
 const path = require("node:path");
 
-// When developing, `tsup --watch` writes to `dist/main/main.cjs`.
-require(path.join(__dirname, "dist", "main", "main.cjs"));
+// `tsup` writes `dist/main/main.cjs` (watch mode in dev, or one-shot after install/build).
+const mainEntry = path.join(__dirname, "dist", "main", "main.cjs");
+if (!fs.existsSync(mainEntry)) {
+  console.error(
+    "[ade] Missing main process bundle:\n" +
+      `  ${mainEntry}\n` +
+      "Run from apps/desktop: npm run dev  (or: npx tsup  /  npm run build)\n" +
+      "After npm install, postinstall should run tsup once if this file was absent.",
+  );
+  process.exit(1);
+}
+
+require(mainEntry);
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,6 +7,7 @@
   "author": "Arul Sharma",
   "license": "AGPL-3.0",
   "scripts": {
+    "postinstall": "node ./scripts/ensure-main-bundle.cjs",
     "predev": "node ./scripts/clear-vite-cache.cjs && node ./scripts/normalize-runtime-binaries.cjs",
     "prebuild": "node ./scripts/normalize-runtime-binaries.cjs",
     "dev": "node ./scripts/ensure-electron.cjs && node ./scripts/dev.cjs",

--- a/apps/desktop/scripts/ensure-main-bundle.cjs
+++ b/apps/desktop/scripts/ensure-main-bundle.cjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/**
+ * After a fresh `npm install`, `dist/main/main.cjs` does not exist until `tsup` runs.
+ * `electron .` loads that file via electron.cjs, so generate it once when missing.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const cp = require("node:child_process");
+
+const projectRoot = path.resolve(__dirname, "..");
+const mainBundle = path.join(projectRoot, "dist", "main", "main.cjs");
+
+function main() {
+  if (fs.existsSync(mainBundle)) {
+    return;
+  }
+
+  console.log("[ade] dist/main/main.cjs missing; running tsup (main/preload compile)…");
+  const result = cp.spawnSync("npx", ["tsup"], {
+    cwd: projectRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  if (result.status !== 0) {
+    console.error("[ade] tsup failed; main process bundle was not created.");
+    process.exit(result.status ?? 1);
+  }
+
+  if (!fs.existsSync(mainBundle)) {
+    console.error("[ade] tsup finished but dist/main/main.cjs is still missing.");
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`electron.cjs` loads `dist/main/main.cjs`, which is produced by **tsup**, not by `npm install`. A fresh install left that path missing, so running `electron .` (or anything that assumed the bundle existed) failed with a confusing module error.

## Changes

- **`postinstall`**: Run `scripts/ensure-main-bundle.cjs`, which invokes `npx tsup` once when `dist/main/main.cjs` is absent.
- **`electron.cjs`**: If the bundle is still missing, exit with a short message pointing to `npm run dev`, `npx tsup`, or `npm run build`.

## Validation

- Ran `node ./scripts/ensure-main-bundle.cjs` with `dist/` removed; bundle is created successfully.
- Second run is a no-op when the file already exists.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d00d896e-2912-428b-8bc8-ba48d1612826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d00d896e-2912-428b-8bc8-ba48d1612826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

