### PR TITLE
Parallel multi-model chat: child lanes + Lanes focus

### DIFF
--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -101,6 +101,7 @@ import type {
   AgentChatSurface,
   AgentChatSteerArgs,
   AgentChatSendArgs,
+  AgentChatSuggestLaneNameArgs,
   AgentChatCursorConfigOption,
   AgentChatCursorConfigValue,
   AgentChatCursorModeSnapshot,
@@ -837,6 +838,13 @@ Return only the title text.
 - No quotes.
 - No emoji.
 - No trailing punctuation.`;
+
+const LANE_NAME_FROM_PROMPT_SYSTEM_PROMPT = `You name git worktree lanes for a software project.
+Return only the base name text (no model suffixes).
+- Use 2 to 5 words, lowercase except proper nouns if needed.
+- Slug-friendly: letters, numbers, spaces, and hyphens only (no slashes).
+- Describe the task or feature from the user's message.
+- No quotes, no emoji, no trailing punctuation.`;
 const CODEX_REASONING_EFFORTS: Array<{ effort: string; description: string }> = [
   { effort: "low", description: "Fastest turn-around with shallow reasoning." },
   { effort: "medium", description: "Balanced reasoning depth and speed." },
@@ -4401,6 +4409,80 @@ export function createAgentChatService(args: {
       summaryEnabled,
       summaryModelId,
     };
+  };
+
+  const suggestLaneNameFromPrompt = async (args: AgentChatSuggestLaneNameArgs): Promise<string> => {
+    const prompt = String(args.prompt ?? "").trim();
+    const requestedModelId = String(args.modelId ?? "").trim();
+    const sourceLaneId = String(args.laneId ?? "").trim();
+    const fallback = (): string => {
+      const collapsed = prompt.replace(/\s+/g, " ").trim();
+      if (!collapsed.length) return "parallel-task";
+      const words = collapsed.split(/\s+/).filter(Boolean).slice(0, 4);
+      const slug = words.join("-").toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+      return slug.length ? slug.slice(0, 48) : "parallel-task";
+    };
+
+    if (!prompt.length || !requestedModelId.length || !sourceLaneId.length) {
+      return fallback();
+    }
+
+    let cwd = projectRoot;
+    try {
+      ({ laneWorktreePath: cwd } = resolveLaneLaunchContext({
+        laneService,
+        laneId: sourceLaneId,
+        purpose: "name a lane from prompt",
+      }));
+    } catch {
+      cwd = projectRoot;
+    }
+
+    try {
+      const auth = await detectAuth();
+      const availableModels = getRegistryModels(auth).filter((descriptor) => !descriptor.deprecated);
+      if (!availableModels.length) return fallback();
+
+      const config = resolveChatConfig();
+      const preferredModelId =
+        [
+          requestedModelId,
+          config.autoTitleModelId,
+          DEFAULT_AUTO_TITLE_MODEL_ID,
+          "anthropic/claude-haiku-4-5",
+          "openai/gpt-5.4-mini",
+          "openai/gpt-5.2",
+          "openai/gpt-5.4",
+          availableModels[0]?.id,
+        ].find((candidate) => {
+          const modelId = typeof candidate === "string" ? candidate.trim() : "";
+          return modelId.length > 0 && availableModels.some((descriptor) => descriptor.id === modelId);
+        }) ?? null;
+
+      if (!preferredModelId) return fallback();
+
+      const descriptor = getModelById(preferredModelId);
+      if (!descriptor) return fallback();
+
+      const resolvedModel = await providerResolver.resolveModel(descriptor.id, auth, {
+        cwd,
+        middleware: false,
+      });
+      const result = await generateText({
+        model: resolvedModel,
+        system: LANE_NAME_FROM_PROMPT_SYSTEM_PROMPT,
+        prompt: `User message to parallelize across models:\n${prompt.slice(0, 2000)}`,
+      });
+      const sanitized = sanitizeAutoTitle(result.text.trim(), 56);
+      if (!sanitized) return fallback();
+      return sanitized;
+    } catch (error) {
+      logger.warn("agent_chat.suggest_lane_name_failed", {
+        modelId: requestedModelId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return fallback();
+    }
   };
 
   const computeHeadShaBestEffort = async (laneId: string): Promise<string | null> => {
@@ -13458,6 +13540,7 @@ export function createAgentChatService(args: {
 
   return {
     createSession,
+    suggestLaneNameFromPrompt,
     handoffSession,
     sendMessage,
     runSessionTurn,

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -177,6 +177,7 @@ import type {
   AgentChatRespondToInputArgs,
   AgentChatResumeArgs,
   AgentChatSendArgs,
+  AgentChatSuggestLaneNameArgs,
   AgentChatSession,
   AgentChatSessionSummary,
   AgentChatSubagentSnapshot,
@@ -3794,6 +3795,11 @@ export function registerIpc({
   ipcMain.handle(IPC.agentChatCreate, async (_event, arg: AgentChatCreateArgs): Promise<AgentChatSession> => {
     const ctx = getCtx();
     return await ctx.agentChatService.createSession(arg);
+  });
+
+  ipcMain.handle(IPC.agentChatSuggestLaneName, async (_event, arg: AgentChatSuggestLaneNameArgs): Promise<string> => {
+    const ctx = getCtx();
+    return await ctx.agentChatService.suggestLaneNameFromPrompt(arg);
   });
 
   ipcMain.handle(IPC.agentChatHandoff, async (_event, arg: AgentChatHandoffArgs): Promise<AgentChatHandoffResult> => {

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -61,6 +61,7 @@ import type {
   AgentTool,
   AgentChatApproveArgs,
   AgentChatCreateArgs,
+  AgentChatSuggestLaneNameArgs,
   AgentChatDisposeArgs,
   AgentChatEventEnvelope,
   AgentChatGetSummaryArgs,
@@ -831,6 +832,7 @@ declare global {
         list: (args?: AgentChatListArgs) => Promise<AgentChatSessionSummary[]>;
         getSummary: (args: AgentChatGetSummaryArgs) => Promise<AgentChatSessionSummary | null>;
         create: (args: AgentChatCreateArgs) => Promise<AgentChatSession>;
+        suggestLaneName: (args: AgentChatSuggestLaneNameArgs) => Promise<string>;
         handoff: (args: AgentChatHandoffArgs) => Promise<AgentChatHandoffResult>;
         send: (args: AgentChatSendArgs) => Promise<void>;
         steer: (args: AgentChatSteerArgs) => Promise<void>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -226,6 +226,7 @@ import type {
   AgentTool,
   AgentChatApproveArgs,
   AgentChatCreateArgs,
+  AgentChatSuggestLaneNameArgs,
   AgentChatDisposeArgs,
   AgentChatEventEnvelope,
   AgentChatGetSummaryArgs,
@@ -1123,6 +1124,8 @@ contextBridge.exposeInMainWorld("ade", {
       ipcRenderer.invoke(IPC.agentChatGetSummary, args),
     create: async (args: AgentChatCreateArgs): Promise<AgentChatSession> =>
       ipcRenderer.invoke(IPC.agentChatCreate, args),
+    suggestLaneName: async (args: AgentChatSuggestLaneNameArgs): Promise<string> =>
+      ipcRenderer.invoke(IPC.agentChatSuggestLaneName, args),
     handoff: async (args: AgentChatHandoffArgs): Promise<AgentChatHandoffResult> =>
       ipcRenderer.invoke(IPC.agentChatHandoff, args),
     send: async (args: AgentChatSendArgs): Promise<void> =>

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { At, Check, Image, Paperclip, PencilSimple, Square, X, PaperPlaneTilt, Cube, BookOpen, SquareSplitHorizontal, Plus, Trash } from "@phosphor-icons/react";
 import {
   inferAttachmentType,
-  PARALLEL_CHAT_MAX_IMAGES,
+  PARALLEL_CHAT_MAX_ATTACHMENTS,
   type AgentChatApprovalDecision,
   type AgentChatClaudePermissionMode,
   type AgentChatCursorConfigOption,
@@ -477,13 +477,9 @@ export function AgentChatComposer({
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileAddInProgressRef = useRef(false);
-  const parallelImageCount = useMemo(
-    () => attachments.filter((a) => a.type === "image").length,
-    [attachments],
-  );
-  const canAttach = !turnActive && (!parallelChatMode || parallelImageCount < PARALLEL_CHAT_MAX_IMAGES);
-  const attachBlockedReason = parallelChatMode && parallelImageCount >= PARALLEL_CHAT_MAX_IMAGES
-    ? `Maximum ${PARALLEL_CHAT_MAX_IMAGES} images for parallel launch`
+  const canAttach = !turnActive && (!parallelChatMode || attachments.length < PARALLEL_CHAT_MAX_ATTACHMENTS);
+  const attachBlockedReason = parallelChatMode && attachments.length >= PARALLEL_CHAT_MAX_ATTACHMENTS
+    ? `Maximum ${PARALLEL_CHAT_MAX_ATTACHMENTS} attachments for parallel launch`
     : null;
 
   const attachedPaths = useMemo(() => new Set(attachments.map((a) => a.path)), [attachments]);
@@ -505,11 +501,6 @@ export function AgentChatComposer({
     );
   }, [slashQuery, effectiveSlashCommands]);
 
-  const attachmentResultsForPicker = useMemo(() => {
-    if (!parallelChatMode) return attachmentResults;
-    return attachmentResults.filter((r) => r.type === "image");
-  }, [parallelChatMode, attachmentResults]);
-
   /* ── Attachment picker effects ── */
   useEffect(() => {
     if (!attachmentPickerOpen) {
@@ -524,8 +515,8 @@ export function AgentChatComposer({
   }, [attachmentPickerOpen]);
 
   useEffect(() => {
-    setAttachmentCursor((c) => Math.min(c, Math.max(attachmentResultsForPicker.length - 1, 0)));
-  }, [attachmentResultsForPicker.length]);
+    setAttachmentCursor((c) => Math.min(c, Math.max(attachmentResults.length - 1, 0)));
+  }, [attachmentResults.length]);
 
   useEffect(() => {
     if (!attachmentPickerOpen) return;
@@ -553,15 +544,9 @@ export function AgentChatComposer({
 
   const selectAttachment = (attachment: AgentChatFileRef) => {
     setAttachError(null);
-    if (parallelChatMode) {
-      if (attachment.type !== "image") {
-        setAttachError("Parallel launch supports images only. Remove non-image attachments or turn off parallel mode.");
-        return;
-      }
-      if (parallelImageCount >= PARALLEL_CHAT_MAX_IMAGES) {
-        setAttachError(`You can attach up to ${PARALLEL_CHAT_MAX_IMAGES} images for parallel launch.`);
-        return;
-      }
+    if (parallelChatMode && attachments.length >= PARALLEL_CHAT_MAX_ATTACHMENTS) {
+      setAttachError(`You can attach up to ${PARALLEL_CHAT_MAX_ATTACHMENTS} files for parallel launch.`);
+      return;
     }
     onAddAttachment(attachment);
     setAttachmentPickerOpen(false);
@@ -570,16 +555,16 @@ export function AgentChatComposer({
   const addFileAttachments = async (files: FileList | null | undefined) => {
     if (!files?.length) return;
     if (turnActive) return;
-    if (parallelChatMode && parallelImageCount >= PARALLEL_CHAT_MAX_IMAGES) return;
+    if (parallelChatMode && attachments.length >= PARALLEL_CHAT_MAX_ATTACHMENTS) return;
     if (!parallelChatMode && !canAttach) return;
     if (fileAddInProgressRef.current) return;
     fileAddInProgressRef.current = true;
     setAttachError(null);
     try {
-      let imageCount = parallelImageCount;
+      let addedInBatch = 0;
       for (const file of Array.from(files)) {
-        if (parallelChatMode && imageCount >= PARALLEL_CHAT_MAX_IMAGES) {
-          setAttachError(`You can attach up to ${PARALLEL_CHAT_MAX_IMAGES} images for parallel launch.`);
+        if (parallelChatMode && attachments.length + addedInBatch >= PARALLEL_CHAT_MAX_ATTACHMENTS) {
+          setAttachError(`You can attach up to ${PARALLEL_CHAT_MAX_ATTACHMENTS} files for parallel launch.`);
           break;
         }
         const fileWithPath = file as File & { path?: string };
@@ -588,12 +573,8 @@ export function AgentChatComposer({
         if (hasRealPath) {
           const filePath = fileWithPath.path!;
           const t = inferAttachmentType(filePath, file.type);
-          if (parallelChatMode && t !== "image") {
-            setAttachError("Parallel launch supports images only.");
-            continue;
-          }
           onAddAttachment({ path: filePath, type: t });
-          if (parallelChatMode && t === "image") imageCount += 1;
+          addedInBatch += 1;
           continue;
         }
 
@@ -615,12 +596,8 @@ export function AgentChatComposer({
             filename: file.name || "clipboard.png",
           });
           const t = inferAttachmentType(tempPath, file.type);
-          if (parallelChatMode && t !== "image") {
-            setAttachError("Parallel launch supports images only.");
-            continue;
-          }
           onAddAttachment({ path: tempPath, type: t });
-          if (parallelChatMode) imageCount += 1;
+          addedInBatch += 1;
         } catch {
           setAttachError(`Unable to attach "${file.name || "clipboard"}".`);
         }
@@ -1091,8 +1068,8 @@ export function AgentChatComposer({
       if (busy || parallelLaunchBusy) return;
       if (parallelModelSlots.length < 2) return;
       const hasPrompt = draft.trim().length > 0;
-      const hasImages = attachments.some((a) => a.type === "image");
-      if (!hasPrompt && !hasImages) return;
+      const hasAttachments = attachments.length > 0;
+      if (!hasPrompt && !hasAttachments) return;
       onSubmit();
       return;
     }
@@ -1209,7 +1186,6 @@ export function AgentChatComposer({
             ref={uploadInputRef}
             type="file"
             multiple
-            accept={parallelChatMode ? "image/*" : undefined}
             className="hidden"
             onChange={(event) => {
               void addFileAttachments(event.target.files);
@@ -1258,12 +1234,12 @@ export function AgentChatComposer({
                     if (event.key === "Escape") { event.preventDefault(); setAttachmentPickerOpen(false); return; }
                     if (event.key === "ArrowDown") {
                       event.preventDefault();
-                      setAttachmentCursor((v) => Math.min(v + 1, Math.max(attachmentResultsForPicker.length - 1, 0)));
+                      setAttachmentCursor((v) => Math.min(v + 1, Math.max(attachmentResults.length - 1, 0)));
                       return;
                     }
                     if (event.key === "ArrowUp") { event.preventDefault(); setAttachmentCursor((v) => Math.max(v - 1, 0)); return; }
                     if (event.key === "Enter") {
-                      const candidate = attachmentResultsForPicker[attachmentCursor];
+                      const candidate = attachmentResults[attachmentCursor];
                       if (candidate) { event.preventDefault(); selectAttachment(candidate); }
                     }
                   }}
@@ -1274,8 +1250,8 @@ export function AgentChatComposer({
                   <div className="px-3 py-2 font-mono text-[10px] text-muted-fg/25">Type to search files...</div>
                 ) : attachmentBusy ? (
                   <div className="px-3 py-2 font-mono text-[10px] text-muted-fg/25">Searching...</div>
-                ) : attachmentResultsForPicker.length ? (
-                  attachmentResultsForPicker.map((result, index) => (
+                ) : attachmentResults.length ? (
+                  attachmentResults.map((result, index) => (
                     <button
                       key={result.path}
                       type="button"
@@ -1291,11 +1267,7 @@ export function AgentChatComposer({
                     </button>
                   ))
                 ) : (
-                  <div className="px-3 py-2 font-mono text-[10px] text-muted-fg/25">
-                    {parallelChatMode && attachmentQuery.trim().length
-                      ? "No matching images in the repo search."
-                      : "No matching files."}
-                  </div>
+                  <div className="px-3 py-2 font-mono text-[10px] text-muted-fg/25">No matching files.</div>
                 )}
               </div>
             </div>
@@ -1321,7 +1293,7 @@ export function AgentChatComposer({
               <span className="min-w-0 flex-1">
                 <span className="block font-sans text-[12px] font-medium text-fg/85">Parallel models</span>
                 <span className="mt-0.5 block font-sans text-[11px] leading-snug text-muted-fg/55">
-                  Same prompt (and images) in one child lane per model
+                  Same prompt and attachments in one child lane per model
                 </span>
               </span>
             </button>
@@ -1332,7 +1304,7 @@ export function AgentChatComposer({
                 <div className="min-w-0">
                   <div className="font-sans text-[12px] font-semibold text-fg/88">Parallel launch</div>
                   <p className="mt-1 font-sans text-[11px] leading-relaxed text-muted-fg/55">
-                    Configure each model, then send once. Images attach to every lane (max {PARALLEL_CHAT_MAX_IMAGES}).
+                    Configure each model, then send once. Attachments go to every lane (max {PARALLEL_CHAT_MAX_ATTACHMENTS}).
                   </p>
                 </div>
                 <button
@@ -1481,7 +1453,7 @@ export function AgentChatComposer({
               onClick={() => canAttach && setAttachmentPickerOpen((o) => !o)}
               title={
                 parallelChatMode
-                  ? attachBlockedReason ?? "Search repo for images (@)"
+                  ? attachBlockedReason ?? "Search repo for files (@)"
                   : "Attach files or images (@)"
               }
               aria-label="Open attachment picker"
@@ -1493,7 +1465,7 @@ export function AgentChatComposer({
               className="rounded-md px-1 py-1 text-muted-fg/30 transition-colors hover:bg-white/5 hover:text-muted-fg/60"
               disabled={!canAttach}
               onClick={openUploadPicker}
-              title={parallelChatMode ? (attachBlockedReason ?? "Upload images") : "Upload file from disk"}
+              title={parallelChatMode ? (attachBlockedReason ?? "Upload files") : "Upload file from disk"}
               aria-label="Upload file from disk"
             >
               <Paperclip size={11} />
@@ -1593,7 +1565,7 @@ export function AgentChatComposer({
                     const parallelReady =
                       parallelChatMode
                       && parallelModelSlots.length >= 2
-                      && (draft.trim().length > 0 || attachments.some((a) => a.type === "image"));
+                      && (draft.trim().length > 0 || attachments.length > 0);
                     const singleReady = !parallelChatMode && Boolean(modelId) && draft.trim().length > 0;
                     const enabled = !busy && !parallelLaunchBusy && (parallelReady || singleReady);
                     return enabled
@@ -1605,7 +1577,7 @@ export function AgentChatComposer({
                   busy
                   || parallelLaunchBusy
                   || (parallelChatMode
-                    ? parallelModelSlots.length < 2 || (draft.trim().length === 0 && !attachments.some((a) => a.type === "image"))
+                    ? parallelModelSlots.length < 2 || (draft.trim().length === 0 && attachments.length === 0)
                     : !modelId || !draft.trim().length)
                 }
                 onClick={submitComposerDraft}
@@ -1613,8 +1585,8 @@ export function AgentChatComposer({
                   parallelChatMode
                     ? parallelModelSlots.length < 2
                       ? "Add at least two models"
-                      : draft.trim().length === 0 && !attachments.some((a) => a.type === "image")
-                        ? "Add a message or at least one image"
+                      : draft.trim().length === 0 && attachments.length === 0
+                        ? "Add a message or at least one attachment"
                         : "Send to all lanes"
                     : !modelId
                       ? "Select a model first"
@@ -1659,11 +1631,11 @@ export function AgentChatComposer({
           <div className="pointer-events-none absolute inset-0 z-[1] flex items-center justify-center bg-[color:color-mix(in_srgb,var(--chat-accent)_12%,rgba(5,5,8,0.58))] backdrop-blur-sm">
             <div className="rounded-[var(--chat-radius-card)] border border-[color:color-mix(in_srgb,var(--chat-accent)_32%,transparent)] bg-card/92 px-5 py-4 text-center shadow-[var(--chat-composer-shadow)]">
               <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--chat-accent)]">
-                {parallelChatMode ? "Drop images to attach" : "Drop files to attach"}
+                Drop files to attach
               </div>
               <div className="mt-1 text-[12px] text-fg/74">
                 {parallelChatMode
-                  ? `Up to ${PARALLEL_CHAT_MAX_IMAGES} images, sent to every parallel lane.`
+                  ? `Up to ${PARALLEL_CHAT_MAX_ATTACHMENTS} files, sent to every parallel lane.`
                   : "Images and files will be added to this turn."}
               </div>
             </div>

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { At, CaretDown, Check, Image, Paperclip, PencilSimple, Square, X, PaperPlaneTilt, Cube, BookOpen } from "@phosphor-icons/react";
+import { At, Check, Image, Paperclip, PencilSimple, Square, X, PaperPlaneTilt, Cube, BookOpen, SquareSplitHorizontal, Plus, Trash } from "@phosphor-icons/react";
 import {
   inferAttachmentType,
+  PARALLEL_CHAT_MAX_IMAGES,
   type AgentChatApprovalDecision,
   type AgentChatClaudePermissionMode,
   type AgentChatCursorConfigOption,
@@ -476,7 +477,14 @@ export function AgentChatComposer({
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileAddInProgressRef = useRef(false);
-  const canAttach = !turnActive && !parallelChatMode;
+  const parallelImageCount = useMemo(
+    () => attachments.filter((a) => a.type === "image").length,
+    [attachments],
+  );
+  const canAttach = !turnActive && (!parallelChatMode || parallelImageCount < PARALLEL_CHAT_MAX_IMAGES);
+  const attachBlockedReason = parallelChatMode && parallelImageCount >= PARALLEL_CHAT_MAX_IMAGES
+    ? `Maximum ${PARALLEL_CHAT_MAX_IMAGES} images for parallel launch`
+    : null;
 
   const attachedPaths = useMemo(() => new Set(attachments.map((a) => a.path)), [attachments]);
   const selectedModel = useMemo(() => getModelById(modelId), [modelId]);
@@ -497,6 +505,11 @@ export function AgentChatComposer({
     );
   }, [slashQuery, effectiveSlashCommands]);
 
+  const attachmentResultsForPicker = useMemo(() => {
+    if (!parallelChatMode) return attachmentResults;
+    return attachmentResults.filter((r) => r.type === "image");
+  }, [parallelChatMode, attachmentResults]);
+
   /* ── Attachment picker effects ── */
   useEffect(() => {
     if (!attachmentPickerOpen) {
@@ -509,6 +522,10 @@ export function AgentChatComposer({
     const timeout = window.setTimeout(() => attachmentInputRef.current?.focus(), 0);
     return () => window.clearTimeout(timeout);
   }, [attachmentPickerOpen]);
+
+  useEffect(() => {
+    setAttachmentCursor((c) => Math.min(c, Math.max(attachmentResultsForPicker.length - 1, 0)));
+  }, [attachmentResultsForPicker.length]);
 
   useEffect(() => {
     if (!attachmentPickerOpen) return;
@@ -536,23 +553,47 @@ export function AgentChatComposer({
 
   const selectAttachment = (attachment: AgentChatFileRef) => {
     setAttachError(null);
+    if (parallelChatMode) {
+      if (attachment.type !== "image") {
+        setAttachError("Parallel launch supports images only. Remove non-image attachments or turn off parallel mode.");
+        return;
+      }
+      if (parallelImageCount >= PARALLEL_CHAT_MAX_IMAGES) {
+        setAttachError(`You can attach up to ${PARALLEL_CHAT_MAX_IMAGES} images for parallel launch.`);
+        return;
+      }
+    }
     onAddAttachment(attachment);
     setAttachmentPickerOpen(false);
   };
 
   const addFileAttachments = async (files: FileList | null | undefined) => {
-    if (!canAttach || !files?.length) return;
+    if (!files?.length) return;
+    if (turnActive) return;
+    if (parallelChatMode && parallelImageCount >= PARALLEL_CHAT_MAX_IMAGES) return;
+    if (!parallelChatMode && !canAttach) return;
     if (fileAddInProgressRef.current) return;
     fileAddInProgressRef.current = true;
     setAttachError(null);
     try {
+      let imageCount = parallelImageCount;
       for (const file of Array.from(files)) {
+        if (parallelChatMode && imageCount >= PARALLEL_CHAT_MAX_IMAGES) {
+          setAttachError(`You can attach up to ${PARALLEL_CHAT_MAX_IMAGES} images for parallel launch.`);
+          break;
+        }
         const fileWithPath = file as File & { path?: string };
         const hasRealPath = typeof fileWithPath.path === "string" && fileWithPath.path.trim().length > 0;
 
         if (hasRealPath) {
           const filePath = fileWithPath.path!;
-          onAddAttachment({ path: filePath, type: inferAttachmentType(filePath, file.type) });
+          const t = inferAttachmentType(filePath, file.type);
+          if (parallelChatMode && t !== "image") {
+            setAttachError("Parallel launch supports images only.");
+            continue;
+          }
+          onAddAttachment({ path: filePath, type: t });
+          if (parallelChatMode && t === "image") imageCount += 1;
           continue;
         }
 
@@ -573,7 +614,13 @@ export function AgentChatComposer({
             data: base64,
             filename: file.name || "clipboard.png",
           });
-          onAddAttachment({ path: tempPath, type: inferAttachmentType(tempPath, file.type) });
+          const t = inferAttachmentType(tempPath, file.type);
+          if (parallelChatMode && t !== "image") {
+            setAttachError("Parallel launch supports images only.");
+            continue;
+          }
+          onAddAttachment({ path: tempPath, type: t });
+          if (parallelChatMode) imageCount += 1;
         } catch {
           setAttachError(`Unable to attach "${file.name || "clipboard"}".`);
         }
@@ -1041,14 +1088,17 @@ export function AgentChatComposer({
       return;
     }
     if (parallelChatMode) {
-      if (busy || parallelLaunchBusy || !draft.trim().length) return;
+      if (busy || parallelLaunchBusy) return;
       if (parallelModelSlots.length < 2) return;
+      const hasPrompt = draft.trim().length > 0;
+      const hasImages = attachments.some((a) => a.type === "image");
+      if (!hasPrompt && !hasImages) return;
       onSubmit();
       return;
     }
     if (busy || !modelId || !draft.trim().length) return;
     onSubmit();
-  }, [busy, draft, modelId, onApproval, onDraftChange, onSubmit, pendingInput, parallelChatMode, parallelLaunchBusy, parallelModelSlots.length]);
+  }, [attachments, busy, draft, modelId, onApproval, onDraftChange, onSubmit, pendingInput, parallelChatMode, parallelLaunchBusy, parallelModelSlots.length]);
 
   const pendingQuestionCount = getPendingInputQuestionCount(pendingInput);
   const showPendingInputOptionsHint = hasPendingInputOptions(pendingInput);
@@ -1159,6 +1209,7 @@ export function AgentChatComposer({
             ref={uploadInputRef}
             type="file"
             multiple
+            accept={parallelChatMode ? "image/*" : undefined}
             className="hidden"
             onChange={(event) => {
               void addFileAttachments(event.target.files);
@@ -1205,10 +1256,14 @@ export function AgentChatComposer({
                   className="h-5 flex-1 bg-transparent font-mono text-[11px] text-fg/80 outline-none placeholder:text-muted-fg/25"
                   onKeyDown={(event) => {
                     if (event.key === "Escape") { event.preventDefault(); setAttachmentPickerOpen(false); return; }
-                    if (event.key === "ArrowDown") { event.preventDefault(); setAttachmentCursor((v) => Math.min(v + 1, Math.max(attachmentResults.length - 1, 0))); return; }
+                    if (event.key === "ArrowDown") {
+                      event.preventDefault();
+                      setAttachmentCursor((v) => Math.min(v + 1, Math.max(attachmentResultsForPicker.length - 1, 0)));
+                      return;
+                    }
                     if (event.key === "ArrowUp") { event.preventDefault(); setAttachmentCursor((v) => Math.max(v - 1, 0)); return; }
                     if (event.key === "Enter") {
-                      const candidate = attachmentResults[attachmentCursor];
+                      const candidate = attachmentResultsForPicker[attachmentCursor];
                       if (candidate) { event.preventDefault(); selectAttachment(candidate); }
                     }
                   }}
@@ -1219,8 +1274,8 @@ export function AgentChatComposer({
                   <div className="px-3 py-2 font-mono text-[10px] text-muted-fg/25">Type to search files...</div>
                 ) : attachmentBusy ? (
                   <div className="px-3 py-2 font-mono text-[10px] text-muted-fg/25">Searching...</div>
-                ) : attachmentResults.length ? (
-                  attachmentResults.map((result, index) => (
+                ) : attachmentResultsForPicker.length ? (
+                  attachmentResultsForPicker.map((result, index) => (
                     <button
                       key={result.path}
                       type="button"
@@ -1236,7 +1291,11 @@ export function AgentChatComposer({
                     </button>
                   ))
                 ) : (
-                  <div className="px-3 py-2 font-mono text-[10px] text-muted-fg/25">No matching files.</div>
+                  <div className="px-3 py-2 font-mono text-[10px] text-muted-fg/25">
+                    {parallelChatMode && attachmentQuery.trim().length
+                      ? "No matching images in the repo search."
+                      : "No matching files."}
+                  </div>
                 )}
               </div>
             </div>
@@ -1246,33 +1305,49 @@ export function AgentChatComposer({
       footer={
         <div className="flex flex-col gap-2 px-3 py-1.5">
           {showParallelChatToggle && !parallelChatMode ? (
-            <label className="flex cursor-pointer items-center gap-2 font-sans text-[11px] text-fg/70">
-              <input
-                type="checkbox"
-                className="rounded border-white/20"
-                checked={false}
-                onChange={() => onParallelChatModeChange?.(true)}
-              />
-              <span>Use multiple models (one child lane per model)</span>
-            </label>
+            <button
+              type="button"
+              disabled={turnActive || busy}
+              onClick={() => onParallelChatModeChange?.(true)}
+              className={cn(
+                "flex w-full items-center gap-3 rounded-xl border px-3 py-2.5 text-left transition-colors",
+                "border-white/[0.08] bg-white/[0.02] hover:border-[color:color-mix(in_srgb,var(--chat-accent)_28%,transparent)] hover:bg-[color:color-mix(in_srgb,var(--chat-accent)_06%,transparent)]",
+                turnActive || busy ? "cursor-not-allowed opacity-40" : "",
+              )}
+            >
+              <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/[0.08] bg-white/[0.04] text-[var(--chat-accent)]">
+                <SquareSplitHorizontal size={18} weight="regular" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block font-sans text-[12px] font-medium text-fg/85">Parallel models</span>
+                <span className="mt-0.5 block font-sans text-[11px] leading-snug text-muted-fg/55">
+                  Same prompt (and images) in one child lane per model
+                </span>
+              </span>
+            </button>
           ) : null}
           {parallelChatMode ? (
-            <div className="flex flex-col gap-2 border-b border-white/[0.06] pb-2">
-              <label className="flex cursor-pointer items-center gap-2 font-sans text-[11px] text-fg/70">
-                <input
-                  type="checkbox"
-                  className="rounded border-white/20"
-                  checked
+            <div className="rounded-xl border border-[color:color-mix(in_srgb,var(--chat-accent)_22%,transparent)] bg-[color:color-mix(in_srgb,var(--chat-accent)_06%,transparent)] p-3">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="font-sans text-[12px] font-semibold text-fg/88">Parallel launch</div>
+                  <p className="mt-1 font-sans text-[11px] leading-relaxed text-muted-fg/55">
+                    Configure each model, then send once. Images attach to every lane (max {PARALLEL_CHAT_MAX_IMAGES}).
+                  </p>
+                </div>
+                <button
+                  type="button"
                   disabled={parallelLaunchBusy}
-                  onChange={() => {
-                    if (parallelLaunchBusy) return;
+                  className="shrink-0 rounded-lg border border-white/[0.1] px-2 py-1 font-sans text-[10px] font-medium text-muted-fg/70 transition-colors hover:bg-white/[0.06] hover:text-fg/80 disabled:opacity-40"
+                  onClick={() => {
                     onParallelChatModeChange?.(false);
                     onParallelConfiguringIndexChange?.(null);
                   }}
-                />
-                <span>Parallel models (one child lane per model)</span>
-              </label>
-              <div className="flex flex-col gap-1.5">
+                >
+                  Single model
+                </button>
+              </div>
+              <div className="mt-3 flex flex-col gap-2">
                 {parallelModelSlots.map((slotRow, idx) => {
                   const desc = getModelById(slotRow.modelId);
                   const configuring = parallelConfiguringIndex === idx;
@@ -1280,31 +1355,40 @@ export function AgentChatComposer({
                     <div
                       key={`parallel-slot-${idx}`}
                       className={cn(
-                        "flex flex-wrap items-center gap-2 rounded-lg border px-2 py-1.5",
-                        configuring ? "border-accent/30 bg-accent/[0.06]" : "border-white/[0.06] bg-white/[0.02]",
+                        "flex flex-wrap items-center gap-2 rounded-lg border px-2.5 py-2 transition-colors",
+                        configuring
+                          ? "border-[color:color-mix(in_srgb,var(--chat-accent)_35%,transparent)] bg-[color:color-mix(in_srgb,var(--chat-accent)_10%,transparent)] shadow-[0_0_0_1px_color-mix(in_srgb,var(--chat-accent)_12%,transparent)]"
+                          : "border-white/[0.07] bg-white/[0.02]",
                       )}
                     >
-                      <span className="font-mono text-[9px] uppercase tracking-wider text-muted-fg/50">
-                        Model {idx + 1}
+                      <span className="flex h-6 min-w-[1.5rem] items-center justify-center rounded-md bg-white/[0.06] font-mono text-[10px] font-bold text-muted-fg/50">
+                        {idx + 1}
                       </span>
-                      <span className="max-w-[140px] truncate font-sans text-[11px] text-fg/75">
-                        {(desc?.displayName ?? slotRow.modelId) || "Select model"}
+                      <span className="min-w-0 max-w-[min(200px,46%)] truncate font-sans text-[12px] font-medium text-fg/82">
+                        {(desc?.displayName ?? slotRow.modelId) || "Pick a model"}
                       </span>
                       <button
                         type="button"
-                        className="rounded-md border border-white/[0.08] px-2 py-0.5 font-mono text-[9px] uppercase tracking-wider text-fg/60 hover:bg-white/[0.04]"
+                        className={cn(
+                          "rounded-md px-2 py-1 font-sans text-[10px] font-medium transition-colors",
+                          configuring
+                            ? "bg-[color:color-mix(in_srgb,var(--chat-accent)_18%,transparent)] text-fg/90"
+                            : "text-muted-fg/55 hover:bg-white/[0.06] hover:text-fg/75",
+                        )}
                         disabled={parallelLaunchBusy}
                         onClick={() => onParallelConfiguringIndexChange?.(configuring ? null : idx)}
                       >
-                        {configuring ? "Done" : "Configure"}
+                        {configuring ? "Editing" : "Configure"}
                       </button>
                       {parallelModelSlots.length > 2 ? (
                         <button
                           type="button"
-                          className="ml-auto rounded-md px-2 py-0.5 font-mono text-[9px] text-red-400/70 hover:bg-red-500/10"
+                          className="ml-auto inline-flex items-center gap-1 rounded-md px-2 py-1 font-sans text-[10px] text-red-400/75 transition-colors hover:bg-red-500/10"
                           disabled={parallelLaunchBusy}
                           onClick={() => onParallelRemoveModel?.(idx)}
+                          title="Remove this model from the parallel set"
                         >
+                          <Trash size={12} />
                           Remove
                         </button>
                       ) : null}
@@ -1314,14 +1398,18 @@ export function AgentChatComposer({
               </div>
               <button
                 type="button"
-                className="self-start rounded-md border border-white/[0.08] px-2 py-1 font-mono text-[9px] uppercase tracking-wider text-fg/55 hover:bg-white/[0.04] disabled:opacity-40"
+                className="mt-2 inline-flex items-center gap-1.5 rounded-lg border border-dashed border-white/[0.12] px-2.5 py-1.5 font-sans text-[11px] font-medium text-muted-fg/65 transition-colors hover:border-white/[0.2] hover:bg-white/[0.04] hover:text-fg/75 disabled:opacity-40"
                 disabled={parallelLaunchBusy}
                 onClick={() => onParallelAddModel?.()}
               >
+                <Plus size={14} weight="bold" />
                 Add model
               </button>
               {parallelLaunchBusy && parallelLaunchStatus ? (
-                <div className="font-mono text-[10px] text-accent/80">{parallelLaunchStatus}</div>
+                <div className="mt-3 flex items-center gap-2 rounded-lg border border-white/[0.06] bg-black/20 px-2.5 py-2">
+                  <span className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-[var(--chat-accent)]" />
+                  <span className="font-sans text-[11px] text-fg/70">{parallelLaunchStatus}</span>
+                </div>
               ) : null}
             </div>
           ) : null}
@@ -1391,7 +1479,11 @@ export function AgentChatComposer({
               className="rounded-md px-1.5 py-1 font-sans text-[10px] text-muted-fg/30 transition-colors hover:bg-white/5 hover:text-muted-fg/60"
               disabled={!canAttach}
               onClick={() => canAttach && setAttachmentPickerOpen((o) => !o)}
-              title="Attach files or images (@)"
+              title={
+                parallelChatMode
+                  ? attachBlockedReason ?? "Search repo for images (@)"
+                  : "Attach files or images (@)"
+              }
               aria-label="Open attachment picker"
             >
               @
@@ -1401,7 +1493,7 @@ export function AgentChatComposer({
               className="rounded-md px-1 py-1 text-muted-fg/30 transition-colors hover:bg-white/5 hover:text-muted-fg/60"
               disabled={!canAttach}
               onClick={openUploadPicker}
-              title="Upload file from disk"
+              title={parallelChatMode ? (attachBlockedReason ?? "Upload images") : "Upload file from disk"}
               aria-label="Upload file from disk"
             >
               <Paperclip size={11} />
@@ -1497,22 +1589,33 @@ export function AgentChatComposer({
                 type="button"
                 className={cn(
                   "inline-flex h-6 items-center justify-center rounded-md border px-2.5 transition-all",
-                  busy || !draft.trim().length || !modelId
-                    ? "border-white/[0.04] text-muted-fg/12"
-                    : "border-[color:color-mix(in_srgb,var(--chat-accent)_28%,transparent)] bg-[color:color-mix(in_srgb,var(--chat-accent)_12%,transparent)] text-[var(--chat-accent)] hover:bg-[color:color-mix(in_srgb,var(--chat-accent)_20%,transparent)]",
+                  (() => {
+                    const parallelReady =
+                      parallelChatMode
+                      && parallelModelSlots.length >= 2
+                      && (draft.trim().length > 0 || attachments.some((a) => a.type === "image"));
+                    const singleReady = !parallelChatMode && Boolean(modelId) && draft.trim().length > 0;
+                    const enabled = !busy && !parallelLaunchBusy && (parallelReady || singleReady);
+                    return enabled
+                      ? "border-[color:color-mix(in_srgb,var(--chat-accent)_28%,transparent)] bg-[color:color-mix(in_srgb,var(--chat-accent)_12%,transparent)] text-[var(--chat-accent)] hover:bg-[color:color-mix(in_srgb,var(--chat-accent)_20%,transparent)]"
+                      : "border-white/[0.04] text-muted-fg/12";
+                  })(),
                 )}
                 disabled={
                   busy
                   || parallelLaunchBusy
-                  || !draft.trim().length
-                  || (parallelChatMode ? parallelModelSlots.length < 2 : !modelId)
+                  || (parallelChatMode
+                    ? parallelModelSlots.length < 2 || (draft.trim().length === 0 && !attachments.some((a) => a.type === "image"))
+                    : !modelId || !draft.trim().length)
                 }
                 onClick={submitComposerDraft}
                 title={
                   parallelChatMode
                     ? parallelModelSlots.length < 2
                       ? "Add at least two models"
-                      : "Send to all lanes"
+                      : draft.trim().length === 0 && !attachments.some((a) => a.type === "image")
+                        ? "Add a message or at least one image"
+                        : "Send to all lanes"
                     : !modelId
                       ? "Select a model first"
                       : "Send"
@@ -1555,8 +1658,14 @@ export function AgentChatComposer({
         {dragActive ? (
           <div className="pointer-events-none absolute inset-0 z-[1] flex items-center justify-center bg-[color:color-mix(in_srgb,var(--chat-accent)_12%,rgba(5,5,8,0.58))] backdrop-blur-sm">
             <div className="rounded-[var(--chat-radius-card)] border border-[color:color-mix(in_srgb,var(--chat-accent)_32%,transparent)] bg-card/92 px-5 py-4 text-center shadow-[var(--chat-composer-shadow)]">
-              <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--chat-accent)]">Drop files to attach</div>
-              <div className="mt-1 text-[12px] text-fg/74">Images and files will be added to this turn.</div>
+              <div className="font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--chat-accent)]">
+                {parallelChatMode ? "Drop images to attach" : "Drop files to attach"}
+              </div>
+              <div className="mt-1 text-[12px] text-fg/74">
+                {parallelChatMode
+                  ? `Up to ${PARALLEL_CHAT_MAX_IMAGES} images, sent to every parallel lane.`
+                  : "Images and files will be added to this turn."}
+              </div>
             </div>
           </div>
         ) : null}

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -49,6 +49,32 @@ type SlashCommandEntry = {
   source: "sdk" | "local";
 };
 
+/** When set, permission/runtime controls bind to this slot (parallel model row configuration). */
+export type ParallelComposerControlSlot = {
+  sessionProvider: string;
+  interactionMode: AgentChatInteractionMode;
+  claudePermissionMode: AgentChatClaudePermissionMode;
+  codexApprovalPolicy: AgentChatCodexApprovalPolicy;
+  codexSandbox: AgentChatCodexSandbox;
+  codexConfigSource: AgentChatCodexConfigSource;
+  unifiedPermissionMode: AgentChatUnifiedPermissionMode;
+  cursorModeSnapshot: AgentChatCursorModeSnapshot | null;
+  onInteractionModeChange: (mode: AgentChatInteractionMode) => void;
+  onClaudeModeChange: (mode: AgentChatClaudePermissionMode) => void;
+  onClaudePermissionModeChange: (mode: AgentChatClaudePermissionMode) => void;
+  onCodexPresetChange: (next: {
+    codexApprovalPolicy: AgentChatCodexApprovalPolicy;
+    codexSandbox: AgentChatCodexSandbox;
+    codexConfigSource: AgentChatCodexConfigSource;
+  }) => void;
+  onCodexApprovalPolicyChange: (policy: AgentChatCodexApprovalPolicy) => void;
+  onCodexSandboxChange: (sandbox: AgentChatCodexSandbox) => void;
+  onCodexConfigSourceChange: (source: AgentChatCodexConfigSource) => void;
+  onUnifiedPermissionModeChange: (mode: AgentChatUnifiedPermissionMode) => void;
+  onCursorModeChange: (modeId: string) => void;
+  onCursorConfigChange: (configId: string, value: string | boolean) => void;
+};
+
 /** Local-only commands that are always available regardless of provider. */
 const LOCAL_SLASH_COMMANDS: SlashCommandEntry[] = [
   { command: "/clear", label: "Clear", description: "Clear chat history", source: "local" },
@@ -328,6 +354,22 @@ export function AgentChatComposer({
   onCancelSteer,
   onEditSteer,
   onOpenAiSettings,
+  parallelChatMode = false,
+  onParallelChatModeChange,
+  parallelModelSlots = [],
+  parallelConfiguringIndex = null,
+  onParallelConfiguringIndexChange,
+  onParallelAddModel,
+  onParallelRemoveModel,
+  onParallelSlotModelChange,
+  onParallelSlotReasoningChange,
+  parallelLaunchBusy = false,
+  parallelLaunchStatus = null,
+  parallelControlSlot = null,
+  parallelSlotExecutionModeOptions = [],
+  parallelSlotExecutionMode = null,
+  onParallelSlotExecutionModeChange,
+  showParallelChatToggle = false,
 }: {
   surfaceMode?: ChatSurfaceMode;
   layoutVariant?: "standard" | "grid-tile";
@@ -398,6 +440,22 @@ export function AgentChatComposer({
   onCancelSteer?: (steerId: string) => void;
   onEditSteer?: (steerId: string, text: string) => void;
   onOpenAiSettings?: () => void;
+  parallelChatMode?: boolean;
+  onParallelChatModeChange?: (enabled: boolean) => void;
+  parallelModelSlots?: Array<{ modelId: string; reasoningEffort: string | null }>;
+  parallelConfiguringIndex?: number | null;
+  onParallelConfiguringIndexChange?: (index: number | null) => void;
+  onParallelAddModel?: () => void;
+  onParallelRemoveModel?: (index: number) => void;
+  onParallelSlotModelChange?: (index: number, modelId: string) => void;
+  onParallelSlotReasoningChange?: (index: number, effort: string | null) => void;
+  parallelLaunchBusy?: boolean;
+  parallelLaunchStatus?: string | null;
+  parallelControlSlot?: ParallelComposerControlSlot | null;
+  parallelSlotExecutionModeOptions?: ExecutionModeOption[];
+  parallelSlotExecutionMode?: AgentChatExecutionMode | null;
+  onParallelSlotExecutionModeChange?: (mode: AgentChatExecutionMode) => void;
+  showParallelChatToggle?: boolean;
 }) {
   const [attachmentPickerOpen, setAttachmentPickerOpen] = useState(false);
   const [attachmentQuery, setAttachmentQuery] = useState("");
@@ -418,7 +476,7 @@ export function AgentChatComposer({
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileAddInProgressRef = useRef(false);
-  const canAttach = !turnActive;
+  const canAttach = !turnActive && !parallelChatMode;
 
   const attachedPaths = useMemo(() => new Set(attachments.map((a) => a.path)), [attachments]);
   const selectedModel = useMemo(() => getModelById(modelId), [modelId]);
@@ -536,13 +594,23 @@ export function AgentChatComposer({
   };
 
   const nativeControlsDisabled = permissionModeLocked;
-  const claudeSelectionMode = claudePermissionMode === "plan" || interactionMode === "plan"
+  const slot = parallelControlSlot;
+  const sp = slot?.sessionProvider ?? sessionProvider ?? "unified";
+  const im = slot?.interactionMode ?? interactionMode ?? "default";
+  const cpmUse = slot?.claudePermissionMode ?? claudePermissionMode;
+  const capUse = slot?.codexApprovalPolicy ?? codexApprovalPolicy;
+  const csUse = slot?.codexSandbox ?? codexSandbox;
+  const ccsUse = slot?.codexConfigSource ?? codexConfigSource;
+  const upmUse = slot?.unifiedPermissionMode ?? unifiedPermissionMode;
+  const cmsUse = slot?.cursorModeSnapshot ?? cursorModeSnapshot;
+
+  const claudeSelectionMode = cpmUse === "plan" || im === "plan"
     ? "plan"
-    : claudePermissionMode ?? "default";
+    : cpmUse ?? "default";
   const codexPreset = resolveCodexPermissionPreset({
-    codexApprovalPolicy,
-    codexSandbox,
-    codexConfigSource,
+    codexApprovalPolicy: capUse,
+    codexSandbox: csUse,
+    codexConfigSource: ccsUse,
   });
   const codexPresetOptions = useMemo(
     () => getPermissionOptions({ family: "openai", isCliWrapped: true })
@@ -568,6 +636,10 @@ export function AgentChatComposer({
             codexConfigSource: "flags" as const,
           };
 
+    if (parallelControlSlot) {
+      parallelControlSlot.onCodexPresetChange(next);
+      return;
+    }
     if (onCodexPresetChange) {
       onCodexPresetChange(next);
       return;
@@ -580,15 +652,16 @@ export function AgentChatComposer({
     onCodexConfigSourceChange,
     onCodexPresetChange,
     onCodexSandboxChange,
+    parallelControlSlot,
   ]);
   const claudeControlDetail = useMemo(() => {
-    if (sessionProvider !== "claude") return null;
+    if (sp !== "claude") return null;
     const option = CLAUDE_MODE_OPTIONS.find((item) => item.value === (hoveredClaudeMode ?? claudeSelectionMode));
     return option?.detail ?? null;
-  }, [claudeSelectionMode, hoveredClaudeMode, sessionProvider]);
+  }, [claudeSelectionMode, hoveredClaudeMode, sp]);
   const codexCustomSummary = useMemo(() => {
-    if (sessionProvider !== "codex" || codexPreset !== "custom") return null;
-    if (codexConfigSource === "config-toml") {
+    if (sp !== "codex" || codexPreset !== "custom") return null;
+    if (ccsUse === "config-toml") {
       return "Custom Codex mode: config.toml controls approval and sandbox.";
     }
     const approvalLabel = {
@@ -596,16 +669,16 @@ export function AgentChatComposer({
       "on-request": "On request",
       "on-failure": "Guarded edit",
       "never": "Full auto",
-    }[codexApprovalPolicy ?? "on-request"];
+    }[capUse ?? "on-request"];
     const sandboxLabel = {
       "read-only": "Read only",
       "workspace-write": "Workspace write",
       "danger-full-access": "Danger full access",
-    }[codexSandbox ?? "workspace-write"];
-    return `Custom Codex mode: ${codexConfigSource === "flags" ? "ADE flags" : "config.toml"} · ${approvalLabel} · ${sandboxLabel}`;
-  }, [codexApprovalPolicy, codexConfigSource, codexPreset, codexSandbox, sessionProvider]);
+    }[csUse ?? "workspace-write"];
+    return `Custom Codex mode: ${ccsUse === "flags" ? "ADE flags" : "config.toml"} · ${approvalLabel} · ${sandboxLabel}`;
+  }, [capUse, ccsUse, codexPreset, csUse, sp]);
   const codexControlDetail = useMemo(() => {
-    if (sessionProvider !== "codex") return null;
+    if (sp !== "codex") return null;
     if (hoveredCodexPreset) {
       return codexPresetOptions.find((option) => option.value === hoveredCodexPreset)?.detail ?? null;
     }
@@ -613,7 +686,7 @@ export function AgentChatComposer({
       return codexCustomSummary;
     }
     return codexPresetOptions.find((option) => option.value === codexPreset)?.detail ?? null;
-  }, [codexCustomSummary, codexPreset, codexPresetOptions, hoveredCodexPreset, sessionProvider]);
+  }, [codexCustomSummary, codexPreset, codexPresetOptions, hoveredCodexPreset, sp]);
   const nativeControlPanel = useMemo(() => {
     const renderButtonGroup = <T extends string,>(
       label: string,
@@ -657,10 +730,20 @@ export function AgentChatComposer({
       </div>
     );
 
-    if (sessionProvider === "claude") {
+    if (sp === "claude") {
       return (
         <div className="flex flex-wrap items-start gap-2">
           {renderButtonGroup("Claude", claudeSelectionMode, CLAUDE_MODE_OPTIONS, (mode) => {
+            if (parallelControlSlot) {
+              if (mode === "plan") {
+                parallelControlSlot.onInteractionModeChange("plan");
+                parallelControlSlot.onClaudePermissionModeChange("plan");
+                return;
+              }
+              parallelControlSlot.onInteractionModeChange("default");
+              parallelControlSlot.onClaudePermissionModeChange(mode);
+              return;
+            }
             if (onClaudeModeChange) {
               onClaudeModeChange(mode);
               return;
@@ -677,7 +760,7 @@ export function AgentChatComposer({
       );
     }
 
-    if (sessionProvider === "codex") {
+    if (sp === "codex") {
       return (
         <div className="flex flex-wrap items-start gap-2">
           <div className="flex items-center gap-px rounded-md border border-white/[0.06] bg-[#1a1a22] p-0.5">
@@ -720,20 +803,20 @@ export function AgentChatComposer({
       );
     }
 
-    const cursorModeOption = resolveCursorModeOption(cursorModeSnapshot);
-    const cursorExtraOptions = (cursorModeSnapshot?.configOptions ?? []).filter((option) => {
-      if (option.id === cursorModeSnapshot?.modelConfigId) return false;
+    const cursorModeOption = resolveCursorModeOption(cmsUse);
+    const cursorExtraOptions = (cmsUse?.configOptions ?? []).filter((option) => {
+      if (option.id === cmsUse?.modelConfigId) return false;
       if (option.id === cursorModeOption?.id) return false;
       return true;
     });
 
-    if (sessionProvider === "cursor" && (cursorModeSnapshot?.availableModeIds?.length || cursorModeOption)) {
+    if (sp === "cursor" && (cmsUse?.availableModeIds?.length || cursorModeOption)) {
       const modeValue = typeof cursorModeOption?.currentValue === "string"
         ? cursorModeOption.currentValue
-        : cursorModeSnapshot?.currentModeId ?? "";
+        : cmsUse?.currentModeId ?? "";
       const modeChoices = cursorModeOption?.options?.length
         ? cursorModeOption.options.map((option) => ({ value: option.value, label: option.label }))
-        : (cursorModeSnapshot?.availableModeIds ?? []).map((modeId) => ({
+        : (cmsUse?.availableModeIds ?? []).map((modeId) => ({
             value: modeId,
             label: cursorModeLabel(modeId),
           }));
@@ -744,8 +827,11 @@ export function AgentChatComposer({
               <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-muted-fg/45">Mode</span>
               <select
                 value={modeValue}
-                disabled={nativeControlsDisabled || !onCursorModeChange}
-                onChange={(event) => onCursorModeChange?.(event.target.value)}
+                disabled={nativeControlsDisabled || (!onCursorModeChange && !parallelControlSlot)}
+                onChange={(event) => {
+                  if (parallelControlSlot) parallelControlSlot.onCursorModeChange(event.target.value);
+                  else onCursorModeChange?.(event.target.value);
+                }}
                 className="min-w-0 bg-transparent font-sans text-[11px] text-fg/82 outline-none disabled:cursor-not-allowed disabled:text-muted-fg/35"
               >
                 {modeChoices.map((option) => (
@@ -763,8 +849,11 @@ export function AgentChatComposer({
                 <button
                   key={option.id}
                   type="button"
-                  disabled={nativeControlsDisabled || !onCursorConfigChange}
-                  onClick={() => onCursorConfigChange?.(option.id, !active)}
+                  disabled={nativeControlsDisabled || (!onCursorConfigChange && !parallelControlSlot)}
+                  onClick={() => {
+                    if (parallelControlSlot) parallelControlSlot.onCursorConfigChange(option.id, !active);
+                    else onCursorConfigChange?.(option.id, !active);
+                  }}
                   className={cn(
                     "inline-flex items-center gap-2 rounded-md border px-2.5 py-1.5 font-sans text-[11px] transition-colors",
                     active
@@ -796,8 +885,11 @@ export function AgentChatComposer({
                 </span>
                 <select
                   value={typeof option.currentValue === "string" ? option.currentValue : ""}
-                  disabled={nativeControlsDisabled || !onCursorConfigChange}
-                  onChange={(event) => onCursorConfigChange?.(option.id, event.target.value)}
+                  disabled={nativeControlsDisabled || (!onCursorConfigChange && !parallelControlSlot)}
+                  onChange={(event) => {
+                    if (parallelControlSlot) parallelControlSlot.onCursorConfigChange(option.id, event.target.value);
+                    else onCursorConfigChange?.(option.id, event.target.value);
+                  }}
                   className="min-w-0 bg-transparent font-sans text-[11px] text-fg/82 outline-none disabled:cursor-not-allowed disabled:text-muted-fg/35"
                 >
                   {choices.map((choice) => (
@@ -813,14 +905,18 @@ export function AgentChatComposer({
       );
     }
 
-    const runtimeLabel = sessionProvider === "cursor" ? "Cursor" : "ADE";
+    const runtimeLabel = sp === "cursor" ? "Cursor" : "ADE";
     return (
       <label className="flex items-center gap-2 rounded-md border border-white/[0.06] bg-[#1a1a22] px-2.5 py-1.5">
         <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-muted-fg/45">{runtimeLabel}</span>
         <select
-          value={unifiedPermissionMode}
-          disabled={nativeControlsDisabled || !onUnifiedPermissionModeChange}
-          onChange={(event) => onUnifiedPermissionModeChange?.(event.target.value as AgentChatUnifiedPermissionMode)}
+          value={upmUse}
+          disabled={nativeControlsDisabled || (!onUnifiedPermissionModeChange && !parallelControlSlot)}
+          onChange={(event) => {
+            const v = event.target.value as AgentChatUnifiedPermissionMode;
+            if (parallelControlSlot) parallelControlSlot.onUnifiedPermissionModeChange(v);
+            else onUnifiedPermissionModeChange?.(v);
+          }}
           className="min-w-0 bg-transparent font-sans text-[11px] text-fg/82 outline-none disabled:cursor-not-allowed disabled:text-muted-fg/35"
         >
           {UNIFIED_PERMISSION_OPTIONS.map((option) => (
@@ -833,12 +929,10 @@ export function AgentChatComposer({
     );
   }, [
     claudeSelectionMode,
-    claudePermissionMode,
     applyCodexPreset,
     codexPreset,
     codexPresetOptions,
     codexCustomSummary,
-    codexConfigSource,
     hoveredClaudeMode,
     hoveredCodexPreset,
     nativeControlsDisabled,
@@ -848,9 +942,10 @@ export function AgentChatComposer({
     onCursorConfigChange,
     onCursorModeChange,
     onUnifiedPermissionModeChange,
-    cursorModeSnapshot,
-    sessionProvider,
-    unifiedPermissionMode,
+    cmsUse,
+    sp,
+    upmUse,
+    parallelControlSlot,
   ]);
   /* ── Keyboard handler for textarea ── */
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -945,9 +1040,15 @@ export function AgentChatComposer({
       onDraftChange("");
       return;
     }
+    if (parallelChatMode) {
+      if (busy || parallelLaunchBusy || !draft.trim().length) return;
+      if (parallelModelSlots.length < 2) return;
+      onSubmit();
+      return;
+    }
     if (busy || !modelId || !draft.trim().length) return;
     onSubmit();
-  }, [busy, draft, modelId, onApproval, onDraftChange, onSubmit, pendingInput]);
+  }, [busy, draft, modelId, onApproval, onDraftChange, onSubmit, pendingInput, parallelChatMode, parallelLaunchBusy, parallelModelSlots.length]);
 
   const pendingQuestionCount = getPendingInputQuestionCount(pendingInput);
   const showPendingInputOptionsHint = hasPendingInputOptions(pendingInput);
@@ -1143,10 +1244,132 @@ export function AgentChatComposer({
         </>
       }
       footer={
-        <div className="flex flex-wrap items-center gap-2 px-3 py-1.5">
+        <div className="flex flex-col gap-2 px-3 py-1.5">
+          {showParallelChatToggle && !parallelChatMode ? (
+            <label className="flex cursor-pointer items-center gap-2 font-sans text-[11px] text-fg/70">
+              <input
+                type="checkbox"
+                className="rounded border-white/20"
+                checked={false}
+                onChange={() => onParallelChatModeChange?.(true)}
+              />
+              <span>Use multiple models (one child lane per model)</span>
+            </label>
+          ) : null}
+          {parallelChatMode ? (
+            <div className="flex flex-col gap-2 border-b border-white/[0.06] pb-2">
+              <label className="flex cursor-pointer items-center gap-2 font-sans text-[11px] text-fg/70">
+                <input
+                  type="checkbox"
+                  className="rounded border-white/20"
+                  checked
+                  disabled={parallelLaunchBusy}
+                  onChange={() => {
+                    if (parallelLaunchBusy) return;
+                    onParallelChatModeChange?.(false);
+                    onParallelConfiguringIndexChange?.(null);
+                  }}
+                />
+                <span>Parallel models (one child lane per model)</span>
+              </label>
+              <div className="flex flex-col gap-1.5">
+                {parallelModelSlots.map((slotRow, idx) => {
+                  const desc = getModelById(slotRow.modelId);
+                  const configuring = parallelConfiguringIndex === idx;
+                  return (
+                    <div
+                      key={`parallel-slot-${idx}`}
+                      className={cn(
+                        "flex flex-wrap items-center gap-2 rounded-lg border px-2 py-1.5",
+                        configuring ? "border-accent/30 bg-accent/[0.06]" : "border-white/[0.06] bg-white/[0.02]",
+                      )}
+                    >
+                      <span className="font-mono text-[9px] uppercase tracking-wider text-muted-fg/50">
+                        Model {idx + 1}
+                      </span>
+                      <span className="max-w-[140px] truncate font-sans text-[11px] text-fg/75">
+                        {(desc?.displayName ?? slotRow.modelId) || "Select model"}
+                      </span>
+                      <button
+                        type="button"
+                        className="rounded-md border border-white/[0.08] px-2 py-0.5 font-mono text-[9px] uppercase tracking-wider text-fg/60 hover:bg-white/[0.04]"
+                        disabled={parallelLaunchBusy}
+                        onClick={() => onParallelConfiguringIndexChange?.(configuring ? null : idx)}
+                      >
+                        {configuring ? "Done" : "Configure"}
+                      </button>
+                      {parallelModelSlots.length > 2 ? (
+                        <button
+                          type="button"
+                          className="ml-auto rounded-md px-2 py-0.5 font-mono text-[9px] text-red-400/70 hover:bg-red-500/10"
+                          disabled={parallelLaunchBusy}
+                          onClick={() => onParallelRemoveModel?.(idx)}
+                        >
+                          Remove
+                        </button>
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </div>
+              <button
+                type="button"
+                className="self-start rounded-md border border-white/[0.08] px-2 py-1 font-mono text-[9px] uppercase tracking-wider text-fg/55 hover:bg-white/[0.04] disabled:opacity-40"
+                disabled={parallelLaunchBusy}
+                onClick={() => onParallelAddModel?.()}
+              >
+                Add model
+              </button>
+              {parallelLaunchBusy && parallelLaunchStatus ? (
+                <div className="font-mono text-[10px] text-accent/80">{parallelLaunchStatus}</div>
+              ) : null}
+            </div>
+          ) : null}
+          <div className="flex flex-wrap items-center gap-2">
           {/* Left: permission + model controls */}
           <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-            {nativeControlPanel}
+            {parallelChatMode && parallelConfiguringIndex != null && parallelModelSlots[parallelConfiguringIndex]
+              ? nativeControlPanel
+              : !parallelChatMode
+                ? nativeControlPanel
+                : null}
+            {parallelChatMode && parallelConfiguringIndex != null && parallelSlotExecutionModeOptions.length > 0 ? (
+              <div className="flex flex-wrap items-center gap-px rounded-md border border-white/[0.06] bg-[#1a1a22] p-0.5">
+                {parallelSlotExecutionModeOptions.map((option) => {
+                  const active = parallelSlotExecutionMode === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      className={cn(
+                        "rounded-[8px] px-2.5 py-1.5 font-mono text-[9px] font-bold uppercase tracking-wider transition-colors",
+                        active ? "bg-white/[0.08] text-fg/80" : "text-muted-fg/35 hover:text-muted-fg/60",
+                        parallelLaunchBusy ? "cursor-not-allowed opacity-50" : "",
+                      )}
+                      disabled={parallelLaunchBusy}
+                      onClick={() => onParallelSlotExecutionModeChange?.(option.value)}
+                      title={option.helper}
+                      aria-pressed={active}
+                    >
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
+            ) : null}
+            {parallelChatMode && parallelConfiguringIndex != null && parallelModelSlots[parallelConfiguringIndex] ? (
+              <UnifiedModelSelector
+                value={parallelModelSlots[parallelConfiguringIndex]!.modelId}
+                onChange={(next) => onParallelSlotModelChange?.(parallelConfiguringIndex, next)}
+                availableModelIds={availableModelIds}
+                catalogMode={restrictModelCatalogToAvailable ? "available-only" : "all"}
+                disabled={parallelLaunchBusy}
+                showReasoning
+                reasoningEffort={parallelModelSlots[parallelConfiguringIndex]!.reasoningEffort}
+                onReasoningEffortChange={(effort) => onParallelSlotReasoningChange?.(parallelConfiguringIndex, effort)}
+                onOpenAiSettings={onOpenAiSettings}
+              />
+            ) : !parallelChatMode ? (
             <UnifiedModelSelector
               value={modelId}
               onChange={onModelChange}
@@ -1158,6 +1381,7 @@ export function AgentChatComposer({
               onReasoningEffortChange={onReasoningEffortChange}
               onOpenAiSettings={onOpenAiSettings}
             />
+            ) : null}
           </div>
 
           {/* Right: attachment, commands, proof, context, send */}
@@ -1277,14 +1501,30 @@ export function AgentChatComposer({
                     ? "border-white/[0.04] text-muted-fg/12"
                     : "border-[color:color-mix(in_srgb,var(--chat-accent)_28%,transparent)] bg-[color:color-mix(in_srgb,var(--chat-accent)_12%,transparent)] text-[var(--chat-accent)] hover:bg-[color:color-mix(in_srgb,var(--chat-accent)_20%,transparent)]",
                 )}
-                disabled={busy || !draft.trim().length || !modelId}
+                disabled={
+                  busy
+                  || parallelLaunchBusy
+                  || !draft.trim().length
+                  || (parallelChatMode ? parallelModelSlots.length < 2 : !modelId)
+                }
                 onClick={submitComposerDraft}
-                title={!modelId ? "Select a model first" : "Send"}
+                title={
+                  parallelChatMode
+                    ? parallelModelSlots.length < 2
+                      ? "Add at least two models"
+                      : "Send to all lanes"
+                    : !modelId
+                      ? "Select a model first"
+                      : "Send"
+                }
               >
                 <PaperPlaneTilt size={10} weight="fill" />
-                <span className="ml-1 font-sans text-[10px]">Send</span>
+                <span className="ml-1 font-sans text-[10px]">
+                  {parallelChatMode ? "Send to lanes" : "Send"}
+                </span>
               </button>
             )}
+          </div>
           </div>
         </div>
       }
@@ -1345,10 +1585,12 @@ export function AgentChatComposer({
               if (slashPickerOpen && !val.startsWith("/")) { setSlashPickerOpen(false); setSlashQuery(""); }
               if (val.startsWith("/")) { setSlashQuery(val.slice(1)); setSlashCursor(0); }
             }}
+            disabled={parallelLaunchBusy}
             className={cn(
               "min-h-[44px] w-full bg-transparent px-4 py-2.5 text-[13px] leading-[1.6] text-fg/88 outline-none transition-colors placeholder:text-muted-fg/25",
               layoutVariant === "grid-tile" ? "resize-y" : "max-h-[200px] resize-none",
               dragActive ? "opacity-30" : "",
+              parallelLaunchBusy ? "cursor-not-allowed opacity-50" : "",
             )}
             style={layoutVariant === "grid-tile" && composerMaxHeightPx != null
               ? { maxHeight: `${composerMaxHeightPx}px` }

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -5,7 +5,7 @@ import { GitBranch, Plus } from "@phosphor-icons/react";
 import {
   createDefaultComputerUsePolicy,
   inferAttachmentType,
-  PARALLEL_CHAT_MAX_IMAGES,
+  PARALLEL_CHAT_MAX_ATTACHMENTS,
   type AgentChatApprovalDecision,
   type AgentChatClaudePermissionMode,
   type AgentChatCodexApprovalPolicy,
@@ -1872,7 +1872,7 @@ export function AgentChatPane({
 
     if (isParallelLaunch) {
       const text = draft.trim();
-      if ((!text.length && !attachments.some((a) => a.type === "image")) || !laneId || !projectRoot) return;
+      if ((!text.length && attachments.length === 0) || !laneId || !projectRoot) return;
       if (parallelModelSlots.length < 2) {
         setError("Add at least two models for a parallel launch.");
         return;
@@ -1882,25 +1882,30 @@ export function AgentChatPane({
         setError("Each parallel lane needs a different model.");
         return;
       }
-      const nonImage = attachments.filter((a) => a.type !== "image");
-      if (nonImage.length) {
-        setError("Parallel launch supports images only. Remove non-image attachments or switch to single-model chat.");
+      if (attachments.length > PARALLEL_CHAT_MAX_ATTACHMENTS) {
+        setError(`Parallel launch allows at most ${PARALLEL_CHAT_MAX_ATTACHMENTS} attachments. Remove some files or send in batches.`);
         return;
       }
 
       const draftSnapshot = draft;
-      const attachmentsSnapshot = attachments.filter((a) => a.type === "image");
+      const attachmentsSnapshot = [...attachments];
       const includeDocsSnapshot = includeProjectDocs;
       submitInFlightRef.current = true;
       setParallelLaunchBusy(true);
       setParallelLaunchStatus("Naming lanes…");
       setError(null);
       try {
+        const imageCount = attachmentsSnapshot.filter((a) => a.type === "image").length;
+        const fileCount = attachmentsSnapshot.filter((a) => a.type === "file").length;
         const namingSeed =
           text.trim().length > 0
             ? text
             : attachmentsSnapshot.length
-              ? `Parallel image task (${attachmentsSnapshot.length} image${attachmentsSnapshot.length === 1 ? "" : "s"})`
+              ? [
+                  "Parallel attachment task",
+                  imageCount ? `${imageCount} image${imageCount === 1 ? "" : "s"}` : null,
+                  fileCount ? `${fileCount} file${fileCount === 1 ? "" : "s"}` : null,
+                ].filter(Boolean).join(" · ")
               : text;
         const baseName = await window.ade.agentChat.suggestLaneName({
           laneId,
@@ -1948,7 +1953,7 @@ export function AgentChatPane({
           finalText.trim().length > 0
             ? finalText
             : attachmentsSnapshot.length
-              ? "Please review the attached images."
+              ? "Please review the attached files."
               : finalText;
         const displayForSend = text.trim().length > 0 ? text : sendText;
 
@@ -2743,7 +2748,7 @@ export function AgentChatPane({
             onParallelChatModeChange={(enabled) => {
               setParallelChatMode(enabled);
               if (enabled) {
-                setAttachments((prev) => prev.filter((a) => a.type === "image").slice(0, PARALLEL_CHAT_MAX_IMAGES));
+                setAttachments((prev) => prev.slice(0, PARALLEL_CHAT_MAX_ATTACHMENTS));
               } else {
                 setParallelModelSlots([]);
                 setParallelConfiguringIndex(null);

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -36,7 +36,7 @@ import {
 import { filterChatModelIdsForSession } from "../../../shared/chatModelSwitching";
 import { CURSOR_AVAILABLE_MODE_IDS } from "../../../shared/cursorModes";
 import { cn } from "../ui/cn";
-import { AgentChatComposer } from "./AgentChatComposer";
+import { AgentChatComposer, type ParallelComposerControlSlot } from "./AgentChatComposer";
 import { AgentChatMessageList } from "./AgentChatMessageList";
 import { ChatStatusGlyph } from "./chatStatusVisuals";
 import { isChatToolType } from "../../lib/sessions";
@@ -159,6 +159,12 @@ type NativeControlState = {
   cursorConfigValues: Record<string, string | boolean>;
 };
 
+type ParallelModelRowState = NativeControlState & {
+  modelId: string;
+  reasoningEffort: string | null;
+  executionMode: AgentChatExecutionMode;
+};
+
 function defaultNativeControls(profile: ChatSurfaceProfile): NativeControlState {
   if (profile === "persistent_identity") {
     return {
@@ -197,6 +203,40 @@ function runtimeFacingModelId(desc: ModelDescriptor | null | undefined, registry
   if (!desc?.isCliWrapped) return registryModelId;
   if (desc.family === "cursor" || desc.family === "openai") return desc.sdkModelId || registryModelId;
   return desc.shortId ?? registryModelId;
+}
+
+function nativeControlSliceFromParallelSlot(slot: ParallelModelRowState): NativeControlState {
+  return {
+    interactionMode: slot.interactionMode,
+    claudePermissionMode: slot.claudePermissionMode,
+    codexApprovalPolicy: slot.codexApprovalPolicy,
+    codexSandbox: slot.codexSandbox,
+    codexConfigSource: slot.codexConfigSource,
+    unifiedPermissionMode: slot.unifiedPermissionMode,
+    cursorModeId: slot.cursorModeId,
+    cursorConfigValues: slot.cursorConfigValues,
+  };
+}
+
+function cloneParallelSlotFromComposer(args: {
+  native: NativeControlState;
+  modelId: string;
+  reasoningEffort: string | null;
+  executionMode: AgentChatExecutionMode;
+}): ParallelModelRowState {
+  return {
+    interactionMode: args.native.interactionMode,
+    claudePermissionMode: args.native.claudePermissionMode,
+    codexApprovalPolicy: args.native.codexApprovalPolicy,
+    codexSandbox: args.native.codexSandbox,
+    codexConfigSource: args.native.codexConfigSource,
+    unifiedPermissionMode: args.native.unifiedPermissionMode,
+    cursorModeId: args.native.cursorModeId,
+    cursorConfigValues: { ...args.native.cursorConfigValues },
+    modelId: args.modelId,
+    reasoningEffort: args.reasoningEffort,
+    executionMode: args.executionMode,
+  };
 }
 
 function summarizeNativeControls(
@@ -496,6 +536,16 @@ function preferredChatLabel(raw: string | null | undefined): string | null {
   return stripOutcomePrefix(normalized);
 }
 
+function parallelLaneModelSuffix(descriptor: ModelDescriptor | null | undefined): string {
+  if (!descriptor) return "model";
+  if (descriptor.family === "openai" || descriptor.cliCommand === "codex") return "codex";
+  if (descriptor.family === "anthropic" || descriptor.cliCommand === "claude") return "claude";
+  if (descriptor.family === "cursor") return "cursor";
+  const raw = (descriptor.displayName ?? descriptor.shortId ?? descriptor.id).trim();
+  const slug = raw.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9-]+/g, "").replace(/-+/g, "-");
+  return slug.slice(0, 28) || "model";
+}
+
 function chatSessionTitle(session: AgentChatSessionSummary): string {
   const explicitTitle = preferredChatLabel(session.title);
   if (explicitTitle) return explicitTitle;
@@ -566,6 +616,10 @@ export function AgentChatPane({
     navigate("/settings?tab=ai#ai-providers");
   }, [navigate]);
   const selectLane = useAppStore((s) => s.selectLane);
+  const projectRoot = useAppStore((s) => s.project?.rootPath ?? null);
+  const setWorkViewState = useAppStore((s) => s.setWorkViewState);
+  const setLaneWorkViewState = useAppStore((s) => s.setLaneWorkViewState);
+  const refreshLanesStore = useAppStore((s) => s.refreshLanes);
   const lockedSingleSessionMode = Boolean(lockSessionId && hideSessionTabs && initialSessionSummary);
   const forceDraft = forceDraftMode || forceNewSession;
   const preferDraftStart = !lockSessionId && !initialSessionId && !forceNewSession;
@@ -620,6 +674,11 @@ export function AgentChatPane({
   const [handoffOpen, setHandoffOpen] = useState(false);
   const [handoffBusy, setHandoffBusy] = useState(false);
   const [handoffModelId, setHandoffModelId] = useState("");
+  const [parallelChatMode, setParallelChatMode] = useState(false);
+  const [parallelModelSlots, setParallelModelSlots] = useState<ParallelModelRowState[]>([]);
+  const [parallelConfiguringIndex, setParallelConfiguringIndex] = useState<number | null>(null);
+  const [parallelLaunchBusy, setParallelLaunchBusy] = useState(false);
+  const [parallelLaunchStatus, setParallelLaunchStatus] = useState<string | null>(null);
   const shellRef = useRef<HTMLElement | null>(null);
   const [composerMaxHeightPx, setComposerMaxHeightPx] = useState<number | null>(null);
   const composerMaxHeightPxRef = useRef<number | null>(null);
@@ -719,6 +778,76 @@ export function AgentChatPane({
       }),
     };
   }, [cursorConfigValues, cursorModeId, selectedSession?.cursorModeSnapshot, sessionProvider]);
+
+  const patchParallelSlot = useCallback((index: number, patch: Partial<ParallelModelRowState>) => {
+    setParallelModelSlots((prev) => {
+      if (index < 0 || index >= prev.length) return prev;
+      const next = [...prev];
+      next[index] = { ...next[index]!, ...patch };
+      return next;
+    });
+  }, []);
+
+  const parallelSlotCursorSnapshot = useMemo(() => {
+    if (parallelConfiguringIndex == null) return null;
+    const row = parallelModelSlots[parallelConfiguringIndex];
+    if (!row) return null;
+    if (resolveChatRuntimeProvider(getModelById(row.modelId)) !== "cursor") return null;
+    const base = buildFallbackCursorModeSnapshot(row.cursorModeId);
+    return {
+      ...base,
+      currentModeId: row.cursorModeId ?? base.currentModeId,
+      configOptions: base.configOptions?.map((option) => {
+        if (option.id === base.modeConfigId) {
+          return { ...option, currentValue: row.cursorModeId ?? option.currentValue };
+        }
+        if (Object.prototype.hasOwnProperty.call(row.cursorConfigValues, option.id)) {
+          return { ...option, currentValue: row.cursorConfigValues[option.id] ?? option.currentValue };
+        }
+        return option;
+      }),
+    };
+  }, [parallelConfiguringIndex, parallelModelSlots]);
+
+  const parallelComposerControlSlot = useMemo((): ParallelComposerControlSlot | null => {
+    if (parallelConfiguringIndex == null) return null;
+    const row = parallelModelSlots[parallelConfiguringIndex];
+    if (!row) return null;
+    const idx = parallelConfiguringIndex;
+    const prov = resolveChatRuntimeProvider(getModelById(row.modelId));
+    return {
+      sessionProvider: prov,
+      interactionMode: row.interactionMode,
+      claudePermissionMode: row.claudePermissionMode,
+      codexApprovalPolicy: row.codexApprovalPolicy,
+      codexSandbox: row.codexSandbox,
+      codexConfigSource: row.codexConfigSource,
+      unifiedPermissionMode: row.unifiedPermissionMode,
+      cursorModeSnapshot: parallelSlotCursorSnapshot,
+      onInteractionModeChange: (mode) => patchParallelSlot(idx, { interactionMode: mode }),
+      onClaudeModeChange: (mode) => patchParallelSlot(idx, { claudePermissionMode: mode }),
+      onClaudePermissionModeChange: (mode) => patchParallelSlot(idx, { claudePermissionMode: mode }),
+      onCodexPresetChange: (next) => patchParallelSlot(idx, {
+        codexApprovalPolicy: next.codexApprovalPolicy,
+        codexSandbox: next.codexSandbox,
+        codexConfigSource: next.codexConfigSource,
+      }),
+      onCodexApprovalPolicyChange: (policy) => patchParallelSlot(idx, { codexApprovalPolicy: policy }),
+      onCodexSandboxChange: (sandbox) => patchParallelSlot(idx, { codexSandbox: sandbox }),
+      onCodexConfigSourceChange: (source) => patchParallelSlot(idx, { codexConfigSource: source }),
+      onUnifiedPermissionModeChange: (mode) => patchParallelSlot(idx, { unifiedPermissionMode: mode }),
+      onCursorModeChange: (modeId) => patchParallelSlot(idx, { cursorModeId: modeId }),
+      onCursorConfigChange: (configId, value) => patchParallelSlot(idx, {
+        cursorConfigValues: { ...row.cursorConfigValues, [configId]: value },
+      }),
+    };
+  }, [parallelConfiguringIndex, parallelModelSlots, parallelSlotCursorSnapshot, patchParallelSlot]);
+
+  const parallelConfiguringRow = parallelConfiguringIndex != null ? parallelModelSlots[parallelConfiguringIndex] ?? null : null;
+  const parallelSlotExecutionModeOptions = useMemo(
+    () => getExecutionModeOptions(parallelConfiguringRow ? getModelById(parallelConfiguringRow.modelId) : null),
+    [parallelConfiguringRow],
+  );
 
   const syncComposerToSession = useCallback((session: AgentChatSessionSummary | null) => {
     if (!session) {
@@ -1588,12 +1717,39 @@ export function AgentChatPane({
     nativeControlsRef.current = currentNativeControls;
   }, [currentNativeControls]);
 
+  useEffect(() => {
+    if (!parallelChatMode) return;
+    if (parallelModelSlots.length >= 2) return;
+    setParallelModelSlots([
+      cloneParallelSlotFromComposer({
+        native: currentNativeControls,
+        modelId,
+        reasoningEffort,
+        executionMode,
+      }),
+      cloneParallelSlotFromComposer({
+        native: currentNativeControls,
+        modelId,
+        reasoningEffort,
+        executionMode,
+      }),
+    ]);
+  }, [parallelChatMode, parallelModelSlots.length, currentNativeControls, modelId, reasoningEffort, executionMode]);
+
   const buildNativeControlPayload = useCallback((provider: ChatRuntimeProviderKey) => {
     return {
       ...summarizeNativeControls(provider, currentNativeControls),
       ...(provider === "cursor" ? { cursorConfigValues: currentNativeControls.cursorConfigValues } : {}),
     };
   }, [currentNativeControls]);
+
+  const buildNativeControlPayloadForSlot = useCallback((slot: ParallelModelRowState, provider: ChatRuntimeProviderKey) => {
+    const native = nativeControlSliceFromParallelSlot(slot);
+    return {
+      ...summarizeNativeControls(provider, native),
+      ...(provider === "cursor" ? { cursorConfigValues: slot.cursorConfigValues } : {}),
+    };
+  }, []);
   const buildModelSelectionSnapshot = useCallback((nextModelId: string) => {
     const nextDesc = getModelById(nextModelId);
     const nextProvider = resolveChatRuntimeProvider(nextDesc);
@@ -1703,7 +1859,149 @@ export function AgentChatPane({
   }, [preferencesReady, laneId, modelId, selectedSessionId, lockSessionId, initialSessionId, forceDraft, createSession]);
 
   const submit = useCallback(async () => {
-    if (submitInFlightRef.current || busy) return;
+    if (submitInFlightRef.current || busy || parallelLaunchBusy) return;
+
+    const isParallelLaunch =
+      !lockSessionId
+      && !initialSessionId
+      && forceDraft
+      && embeddedWorkLayout
+      && parallelChatMode
+      && selectedSessionId == null;
+
+    if (isParallelLaunch) {
+      const text = draft.trim();
+      if (!text.length || !laneId || !projectRoot) return;
+      if (parallelModelSlots.length < 2) {
+        setError("Add at least two models for a parallel launch.");
+        return;
+      }
+      const modelKeys = parallelModelSlots.map((s) => s.modelId);
+      if (new Set(modelKeys).size !== modelKeys.length) {
+        setError("Each parallel lane needs a different model.");
+        return;
+      }
+
+      const draftSnapshot = draft;
+      const includeDocsSnapshot = includeProjectDocs;
+      submitInFlightRef.current = true;
+      setParallelLaunchBusy(true);
+      setParallelLaunchStatus("Naming lanes…");
+      setError(null);
+      try {
+        const baseName = await window.ade.agentChat.suggestLaneName({
+          laneId,
+          prompt: text,
+          modelId: parallelModelSlots[0]!.modelId,
+        });
+        setParallelLaunchStatus(`Creating ${parallelModelSlots.length} child lanes…`);
+        const createdLaneIds: string[] = [];
+        const sessionByLane = new Map<string, string>();
+
+        for (const slot of parallelModelSlots) {
+          const desc = getModelById(slot.modelId);
+          const suffix = parallelLaneModelSuffix(desc);
+          const laneName = `${baseName}-${suffix}`;
+          const childLane = await window.ade.lanes.createChild({ parentLaneId: laneId, name: laneName });
+          createdLaneIds.push(childLane.id);
+          const provider = resolveChatRuntimeProvider(desc);
+          const model = provider === "unified" ? slot.modelId : runtimeFacingModelId(desc, slot.modelId);
+          const created = await window.ade.agentChat.create({
+            laneId: childLane.id,
+            provider,
+            model,
+            modelId: slot.modelId,
+            sessionProfile: resolveChatSessionProfile(computerUsePolicy),
+            reasoningEffort: slot.reasoningEffort,
+            ...buildNativeControlPayloadForSlot(slot, provider),
+            computerUse: computerUsePolicy,
+          });
+          sessionByLane.set(childLane.id, created.id);
+        }
+
+        await refreshLanesStore();
+
+        let finalText = text;
+        if (!text.startsWith("/") && includeDocsSnapshot) {
+          const docPaths = [".ade/context/PRD.ade.md", ".ade/context/ARCHITECTURE.ade.md"];
+          const docNote = [
+            "[Project Context — generated from main branch, may not reflect in-progress lane work]",
+            "The following project-level docs are available for reference. Read them with read_file if you need project context:",
+            ...docPaths.map((p) => `- ${p}`),
+          ].join("\n");
+          finalText = `${docNote}\n\n---\n\n${finalText}`;
+        }
+
+        setParallelLaunchStatus("Sending prompt to each lane…");
+        for (let idx = 0; idx < parallelModelSlots.length; idx += 1) {
+          const slot = parallelModelSlots[idx]!;
+          const childLaneId = createdLaneIds[idx];
+          const sessionId = childLaneId ? sessionByLane.get(childLaneId) : undefined;
+          if (!sessionId) continue;
+          const desc = getModelById(slot.modelId);
+          const provider = resolveChatRuntimeProvider(desc);
+          try {
+            await window.ade.agentChat.send({
+              sessionId,
+              text: finalText,
+              displayText: text,
+              attachments: [],
+              reasoningEffort: slot.reasoningEffort,
+              executionMode: slot.executionMode,
+              interactionMode: provider === "claude" ? slot.interactionMode : null,
+            });
+          } catch (sendError) {
+            const sendMsg = sendError instanceof Error ? sendError.message : String(sendError);
+            const isBusyErr = /turn is already active|already active/i.test(sendMsg);
+            if (isBusyErr) {
+              await window.ade.agentChat.steer({ sessionId, text: finalText });
+            } else {
+              throw sendError;
+            }
+          }
+          if (desc?.isCliWrapped && (desc.family === "anthropic" || desc.family === "cursor")) {
+            window.ade.agentChat.warmupModel({ sessionId, modelId: slot.modelId }).catch(() => {});
+          }
+        }
+
+        setWorkViewState(projectRoot, (prev) => {
+          let nextOpen = [...prev.openItemIds];
+          for (const sid of sessionByLane.values()) {
+            if (!nextOpen.includes(sid)) nextOpen.push(sid);
+          }
+          return { ...prev, openItemIds: nextOpen };
+        });
+        for (const [childLaneId, sid] of sessionByLane) {
+          setLaneWorkViewState(projectRoot, childLaneId, {
+            activeItemId: sid,
+            selectedItemId: sid,
+            draftKind: "chat",
+            viewMode: "tabs",
+          });
+        }
+
+        setDraft("");
+        setParallelChatMode(false);
+        setParallelModelSlots([]);
+        setParallelConfiguringIndex(null);
+        if (includeDocsSnapshot) setIncludeProjectDocs(false);
+
+        const q = new URLSearchParams();
+        q.set("laneIds", createdLaneIds.join(","));
+        q.set("workFocus", "1");
+        navigate(`/lanes?${q.toString()}`);
+      } catch (submitError) {
+        const message = submitError instanceof Error ? submitError.message : String(submitError);
+        setDraft((current) => (current.trim().length ? current : draftSnapshot));
+        setError(message);
+      } finally {
+        submitInFlightRef.current = false;
+        setParallelLaunchBusy(false);
+        setParallelLaunchStatus(null);
+      }
+      return;
+    }
+
     if (!modelId) return;
     const text = draft.trim();
     if (!text.length || !laneId) return;
@@ -1854,7 +2152,22 @@ export function AgentChatPane({
     sessionProvider,
     touchSession,
     turnActive,
-    turnActiveBySession
+    turnActiveBySession,
+    parallelLaunchBusy,
+    parallelChatMode,
+    parallelModelSlots,
+    lockSessionId,
+    initialSessionId,
+    forceDraft,
+    embeddedWorkLayout,
+    projectRoot,
+    navigate,
+    buildNativeControlPayloadForSlot,
+    computerUsePolicy,
+    refreshLanesStore,
+    setWorkViewState,
+    setLaneWorkViewState,
+    includeProjectDocs,
   ]);
 
   const interrupt = useCallback(async () => {
@@ -2398,6 +2711,66 @@ export function AgentChatPane({
               if (selectedSessionId) {
                 void window.ade.agentChat.editSteer({ sessionId: selectedSessionId, steerId, text });
               }
+            }}
+            showParallelChatToggle={Boolean(
+              embeddedWorkLayout && forceDraft && !lockSessionId && !initialSessionId && selectedSessionId == null,
+            )}
+            parallelChatMode={parallelChatMode}
+            onParallelChatModeChange={(enabled) => {
+              setParallelChatMode(enabled);
+              if (!enabled) {
+                setParallelModelSlots([]);
+                setParallelConfiguringIndex(null);
+              }
+            }}
+            parallelModelSlots={parallelModelSlots}
+            parallelConfiguringIndex={parallelConfiguringIndex}
+            onParallelConfiguringIndexChange={setParallelConfiguringIndex}
+            onParallelAddModel={() => {
+              setParallelModelSlots((prev) => [
+                ...prev,
+                cloneParallelSlotFromComposer({
+                  native: nativeControlsRef.current,
+                  modelId,
+                  reasoningEffort,
+                  executionMode,
+                }),
+              ]);
+            }}
+            onParallelRemoveModel={(index) => {
+              setParallelModelSlots((prev) => prev.filter((_, i) => i !== index));
+              setParallelConfiguringIndex((cur) => {
+                if (cur == null) return cur;
+                if (cur === index) return null;
+                if (cur > index) return cur - 1;
+                return cur;
+              });
+            }}
+            onParallelSlotModelChange={(index, nextModelId) => {
+              const desc = getModelById(nextModelId);
+              const tiers = desc?.reasoningTiers ?? [];
+              const preferred = readLastUsedReasoningEffort({ laneId, modelId: nextModelId });
+              const nextEffort = selectReasoningEffort({ tiers, preferred });
+              const nextExecOpts = getExecutionModeOptions(desc);
+              patchParallelSlot(index, {
+                modelId: nextModelId,
+                reasoningEffort: nextEffort,
+                executionMode: nextExecOpts.some((o) => o.value === parallelModelSlots[index]?.executionMode)
+                  ? parallelModelSlots[index]!.executionMode
+                  : (nextExecOpts[0]?.value ?? "focused"),
+              });
+            }}
+            onParallelSlotReasoningChange={(index, effort) => {
+              patchParallelSlot(index, { reasoningEffort: effort });
+            }}
+            parallelLaunchBusy={parallelLaunchBusy}
+            parallelLaunchStatus={parallelLaunchStatus}
+            parallelControlSlot={parallelComposerControlSlot}
+            parallelSlotExecutionModeOptions={parallelSlotExecutionModeOptions}
+            parallelSlotExecutionMode={parallelConfiguringRow?.executionMode ?? null}
+            onParallelSlotExecutionModeChange={(mode) => {
+              if (parallelConfiguringIndex == null) return;
+              patchParallelSlot(parallelConfiguringIndex, { executionMode: mode });
             }}
           />
   );

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -5,6 +5,7 @@ import { GitBranch, Plus } from "@phosphor-icons/react";
 import {
   createDefaultComputerUsePolicy,
   inferAttachmentType,
+  PARALLEL_CHAT_MAX_IMAGES,
   type AgentChatApprovalDecision,
   type AgentChatClaudePermissionMode,
   type AgentChatCodexApprovalPolicy,
@@ -1871,7 +1872,7 @@ export function AgentChatPane({
 
     if (isParallelLaunch) {
       const text = draft.trim();
-      if (!text.length || !laneId || !projectRoot) return;
+      if ((!text.length && !attachments.some((a) => a.type === "image")) || !laneId || !projectRoot) return;
       if (parallelModelSlots.length < 2) {
         setError("Add at least two models for a parallel launch.");
         return;
@@ -1881,17 +1882,29 @@ export function AgentChatPane({
         setError("Each parallel lane needs a different model.");
         return;
       }
+      const nonImage = attachments.filter((a) => a.type !== "image");
+      if (nonImage.length) {
+        setError("Parallel launch supports images only. Remove non-image attachments or switch to single-model chat.");
+        return;
+      }
 
       const draftSnapshot = draft;
+      const attachmentsSnapshot = attachments.filter((a) => a.type === "image");
       const includeDocsSnapshot = includeProjectDocs;
       submitInFlightRef.current = true;
       setParallelLaunchBusy(true);
       setParallelLaunchStatus("Naming lanes…");
       setError(null);
       try {
+        const namingSeed =
+          text.trim().length > 0
+            ? text
+            : attachmentsSnapshot.length
+              ? `Parallel image task (${attachmentsSnapshot.length} image${attachmentsSnapshot.length === 1 ? "" : "s"})`
+              : text;
         const baseName = await window.ade.agentChat.suggestLaneName({
           laneId,
-          prompt: text,
+          prompt: namingSeed,
           modelId: parallelModelSlots[0]!.modelId,
         });
         setParallelLaunchStatus(`Creating ${parallelModelSlots.length} child lanes…`);
@@ -1931,6 +1944,13 @@ export function AgentChatPane({
           ].join("\n");
           finalText = `${docNote}\n\n---\n\n${finalText}`;
         }
+        const sendText =
+          finalText.trim().length > 0
+            ? finalText
+            : attachmentsSnapshot.length
+              ? "Please review the attached images."
+              : finalText;
+        const displayForSend = text.trim().length > 0 ? text : sendText;
 
         setParallelLaunchStatus("Sending prompt to each lane…");
         for (let idx = 0; idx < parallelModelSlots.length; idx += 1) {
@@ -1940,12 +1960,15 @@ export function AgentChatPane({
           if (!sessionId) continue;
           const desc = getModelById(slot.modelId);
           const provider = resolveChatRuntimeProvider(desc);
+          const steerText = attachmentsSnapshot.length
+            ? `${sendText}\n\nAttached context:\n${attachmentsSnapshot.map((entry) => `- ${entry.type}: ${entry.path}`).join("\n")}`
+            : sendText;
           try {
             await window.ade.agentChat.send({
               sessionId,
-              text: finalText,
-              displayText: text,
-              attachments: [],
+              text: sendText,
+              displayText: displayForSend,
+              attachments: attachmentsSnapshot,
               reasoningEffort: slot.reasoningEffort,
               executionMode: slot.executionMode,
               interactionMode: provider === "claude" ? slot.interactionMode : null,
@@ -1954,7 +1977,7 @@ export function AgentChatPane({
             const sendMsg = sendError instanceof Error ? sendError.message : String(sendError);
             const isBusyErr = /turn is already active|already active/i.test(sendMsg);
             if (isBusyErr) {
-              await window.ade.agentChat.steer({ sessionId, text: finalText });
+              await window.ade.agentChat.steer({ sessionId, text: steerText });
             } else {
               throw sendError;
             }
@@ -1981,6 +2004,7 @@ export function AgentChatPane({
         }
 
         setDraft("");
+        setAttachments([]);
         setParallelChatMode(false);
         setParallelModelSlots([]);
         setParallelConfiguringIndex(null);
@@ -1993,6 +2017,7 @@ export function AgentChatPane({
       } catch (submitError) {
         const message = submitError instanceof Error ? submitError.message : String(submitError);
         setDraft((current) => (current.trim().length ? current : draftSnapshot));
+        setAttachments((current) => (current.length ? current : attachmentsSnapshot));
         setError(message);
       } finally {
         submitInFlightRef.current = false;
@@ -2163,7 +2188,6 @@ export function AgentChatPane({
     projectRoot,
     navigate,
     buildNativeControlPayloadForSlot,
-    computerUsePolicy,
     refreshLanesStore,
     setWorkViewState,
     setLaneWorkViewState,
@@ -2718,7 +2742,9 @@ export function AgentChatPane({
             parallelChatMode={parallelChatMode}
             onParallelChatModeChange={(enabled) => {
               setParallelChatMode(enabled);
-              if (!enabled) {
+              if (enabled) {
+                setAttachments((prev) => prev.filter((a) => a.type === "image").slice(0, PARALLEL_CHAT_MAX_IMAGES));
+              } else {
                 setParallelModelSlots([]);
                 setParallelConfiguringIndex(null);
               }

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -28,6 +28,7 @@ import {
   laneMatchesFilter,
   chipLabel,
   LANES_TILING_TREE,
+  LANES_TILING_WORK_FOCUS_TREE,
   LANES_TILING_LAYOUT_VERSION,
   GIT_ACTIONS_FULLSCREEN_TREE,
   RESIZE_TARGET_MINIMUM_SIZE,
@@ -339,6 +340,19 @@ export function LanesPage() {
     () => activeWithPins.filter((id) => lanesById.has(id) && filteredSet.has(id)),
     [activeWithPins, lanesById, filteredSet]
   );
+
+  const workFocusTiling = useMemo(() => {
+    if (params.get("workFocus") !== "1") return false;
+    const laneIdsParam = params.get("laneIds");
+    if (!laneIdsParam) return false;
+    const ids = laneIdsParam.split(",").map((s) => s.trim()).filter(Boolean);
+    if (ids.length < 2) return false;
+    const visibleSet = new Set(visibleLaneIds);
+    return ids.every((id) => visibleSet.has(id));
+  }, [params, visibleLaneIds]);
+
+  const laneTilingTree = workFocusTiling ? LANES_TILING_WORK_FOCUS_TREE : LANES_TILING_TREE;
+  const laneTilingLayoutSuffix = workFocusTiling ? ":wf" : "";
 
   const managedLane = selectedLaneId ? lanesById.get(selectedLaneId) ?? null : null;
   const managedLanes = useMemo(
@@ -1131,13 +1145,25 @@ export function LanesPage() {
   // doesn't reopen and reset the dialog when lanes refresh.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
+    const laneIdsRaw = params.get("laneIds");
     const laneId = params.get("laneId");
     const sessionId = params.get("sessionId");
     const inspectorTabParam = params.get("inspectorTab");
     if (params.get("action") === "create") {
       prepareCreateDialog();
     }
-    if (laneId) {
+    if (laneIdsRaw) {
+      const parsed = laneIdsRaw.split(",").map((s) => s.trim()).filter(Boolean);
+      const valid = parsed.filter((id) => lanesById.has(id));
+      if (valid.length) {
+        selectLane(valid[0]!);
+        setActiveLaneIds(valid);
+        setPinnedLaneIds(new Set());
+        if (inspectorTabParam && valid[0]) {
+          setLaneInspectorTab(valid[0], inspectorTabParam as LaneInspectorTab);
+        }
+      }
+    } else if (laneId) {
       selectLane(laneId);
       if (params.get("focus") === "single") {
         setActiveLaneIds([laneId]);
@@ -1147,7 +1173,7 @@ export function LanesPage() {
       }
     }
     if (sessionId) focusSession(sessionId);
-  }, [params, selectLane, focusSession, setLaneInspectorTab]);
+  }, [params, selectLane, focusSession, setLaneInspectorTab, lanesById]);
 
   const handleCreateDialogOpenChange = useCallback((open: boolean) => {
     if (!open && createBusy) return;
@@ -1894,8 +1920,8 @@ export function LanesPage() {
         </div>
       ) : visibleLaneIds.length === 1 ? (
         <PaneTilingLayout
-          layoutId={`lanes:tiling:${LANES_TILING_LAYOUT_VERSION}:${visibleLaneIds[0]}`}
-          tree={LANES_TILING_TREE}
+          layoutId={`lanes:tiling:${LANES_TILING_LAYOUT_VERSION}${laneTilingLayoutSuffix}:${visibleLaneIds[0]}`}
+          tree={laneTilingTree}
           panes={getPaneConfigs(visibleLaneIds[0] ?? null)}
           className="flex-1 min-h-0"
         />
@@ -1913,8 +1939,8 @@ export function LanesPage() {
               <Fragment key={laneId}>
                 <Panel id={`lane-column:${laneId}`} minSize="18%" defaultSize={`${defaultSize}%`} className="min-h-0 min-w-0">
                   <PaneTilingLayout
-                    layoutId={`lanes:tiling:${LANES_TILING_LAYOUT_VERSION}:${laneId}`}
-                    tree={LANES_TILING_TREE}
+                    layoutId={`lanes:tiling:${LANES_TILING_LAYOUT_VERSION}${laneTilingLayoutSuffix}:${laneId}`}
+                    tree={laneTilingTree}
                     panes={getPaneConfigs(laneId)}
                     className="h-full min-h-0"
                   />
@@ -1952,8 +1978,8 @@ export function LanesPage() {
             </button>
           </div>
           <PaneTilingLayout
-            layoutId={`lanes:tiling:${LANES_TILING_LAYOUT_VERSION}:${expandedLaneId}`}
-            tree={LANES_TILING_TREE}
+            layoutId={`lanes:tiling:${LANES_TILING_LAYOUT_VERSION}${laneTilingLayoutSuffix}:${expandedLaneId}`}
+            tree={laneTilingTree}
             panes={getPaneConfigs(expandedLaneId)}
             className="flex-1 min-h-0"
           />

--- a/apps/desktop/src/renderer/components/lanes/laneUtils.test.ts
+++ b/apps/desktop/src/renderer/components/lanes/laneUtils.test.ts
@@ -3,6 +3,7 @@ import type { LaneSummary } from "../../../shared/types";
 import {
   LANES_TILING_LAYOUT_VERSION,
   LANES_TILING_TREE,
+  LANES_TILING_WORK_FOCUS_TREE,
   isMissionLaneHiddenByDefault,
   laneMatchesFilter,
 } from "./laneUtils";
@@ -47,7 +48,14 @@ describe("laneUtils tiling defaults", () => {
   });
 
   it("bumps the persisted tiling layout version", () => {
-    expect(LANES_TILING_LAYOUT_VERSION).toBe("v5");
+    expect(LANES_TILING_LAYOUT_VERSION).toBe("v6");
+  });
+
+  it("work-focus layout emphasizes the work pane", () => {
+    expect(LANES_TILING_WORK_FOCUS_TREE.children[1]?.defaultSize).toBeGreaterThan(40);
+    expect(LANES_TILING_WORK_FOCUS_TREE.children[2]?.defaultSize).toBeLessThan(
+      (LANES_TILING_TREE.children[2]?.defaultSize ?? 0),
+    );
   });
 
   it("hides non-result mission lanes by default but reveals them with mission filters", () => {

--- a/apps/desktop/src/renderer/components/lanes/laneUtils.ts
+++ b/apps/desktop/src/renderer/components/lanes/laneUtils.ts
@@ -157,7 +157,29 @@ export const LANES_TILING_TREE: PaneSplit = {
   ]
 };
 
-export const LANES_TILING_LAYOUT_VERSION = "v5";
+/** Emphasize the Work pane after parallel multi-model launches (stack + diff + git smaller). */
+export const LANES_TILING_WORK_FOCUS_TREE: PaneSplit = {
+  type: "split",
+  direction: "horizontal",
+  children: [
+    {
+      node: {
+        type: "split",
+        direction: "vertical",
+        children: [
+          { node: { type: "pane", id: "stack" }, defaultSize: 50, minSize: 12 },
+          { node: { type: "pane", id: "diff-viewer" }, defaultSize: 50, minSize: 12 }
+        ]
+      },
+      defaultSize: 12,
+      minSize: 8
+    },
+    { node: { type: "pane", id: "work" }, defaultSize: 58, minSize: 32 },
+    { node: { type: "pane", id: "git-actions" }, defaultSize: 30, minSize: 14 }
+  ]
+};
+
+export const LANES_TILING_LAYOUT_VERSION = "v6";
 
 export const GIT_ACTIONS_FULLSCREEN_TREE: PaneSplit = {
   type: "split",

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -99,6 +99,7 @@ export const IPC = {
   agentChatList: "ade.agentChat.list",
   agentChatGetSummary: "ade.agentChat.getSummary",
   agentChatCreate: "ade.agentChat.create",
+  agentChatSuggestLaneName: "ade.agentChat.suggestLaneName",
   agentChatHandoff: "ade.agentChat.handoff",
   agentChatSend: "ade.agentChat.send",
   agentChatSteer: "ade.agentChat.steer",

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -609,6 +609,15 @@ export type AgentChatListArgs = {
   includeAutomation?: boolean;
 };
 
+export type AgentChatSuggestLaneNameArgs = {
+  /** Lane the user is launching from (worktree path for the naming model call). */
+  laneId: string;
+  /** User prompt for the parallel chat launch (used to derive a short lane name prefix). */
+  prompt: string;
+  /** Registry model ID used to run the naming call (e.g. first selected model). */
+  modelId: string;
+};
+
 export type AgentChatGetSummaryArgs = {
   sessionId: string;
 };

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -77,8 +77,8 @@ export type AgentChatFileRef = {
   type: "file" | "image";
 };
 
-/** Max images attached to one parallel multi-lane launch (same files sent to each child session). */
-export const PARALLEL_CHAT_MAX_IMAGES = 8;
+/** Max attachments per parallel multi-lane launch (same refs sent to each child session). */
+export const PARALLEL_CHAT_MAX_ATTACHMENTS = 12;
 
 /** Infer whether a file path points to an image or a generic file. */
 export function inferAttachmentType(

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -77,6 +77,9 @@ export type AgentChatFileRef = {
   type: "file" | "image";
 };
 
+/** Max images attached to one parallel multi-lane launch (same files sent to each child session). */
+export const PARALLEL_CHAT_MAX_IMAGES = 8;
+
 /** Infer whether a file path points to an image or a generic file. */
 export function inferAttachmentType(
   filePath: string,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds optional **parallel model** mode on the Work tab **new chat** draft. When enabled, the user configures **two or more distinct models** (each with its own model, reasoning tier, permission mode, Codex execution mode where applicable). Submitting one prompt:

1. Calls **`agentChat.suggestLaneName`** (same model stack as auto-title) to derive a short **shared task prefix** from the prompt (or from an attachment-only description when there is no text).
2. Creates a **child lane** per model under the current lane with names `{prefix}-{codex|claude|cursor|…}`.
3. Creates a chat session per child lane with the matching controls and **sends the same prompt** (optional project context docs still apply when toggled).
4. **Attachments:** The same **file and image** attachments are **`send` to every child session** (max **12** total per launch, `PARALLEL_CHAT_MAX_ATTACHMENTS`). `@` search, upload, paste, and drag-drop behave like single-chat. If the draft is empty but attachments exist, a short default user line is sent so the backend always gets non-empty `text`.
5. Opens each new session in the project work tabs and sets each child lane’s work pane to that session.
6. Navigates to **`/lanes?laneIds=…&workFocus=1`** so **all new lanes are selected** and the **Work** pane is emphasized via a dedicated tiling preset (layout version **v6**).

## UX notes

- Parallel mode only appears when **no chat session is active** (Work new-chat draft with `forceDraftMode`).
- While a parallel launch runs, the composer is **disabled** and status shows progress.
- Parallel UI: card layout, **Parallel models** entry row, clearer configure/remove/add-model actions.

## Technical

- New IPC: `ade.agentChat.suggestLaneName` → `agentChatService.suggestLaneNameFromPrompt`.
- Lanes URL: `laneIds` (comma-separated) for multi-column selection; `workFocus=1` triggers work-emphasis tiling when the listed lanes match the visible split.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-144f1c02-33bb-42b6-9391-d0f4874ed2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-144f1c02-33bb-42b6-9391-d0f4874ed2bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

