### PR TITLE
Local model chat: shared helpers, banner merge, permission reset

### DIFF
--- a/apps/desktop/src/main/services/ai/aiIntegrationService.ts
+++ b/apps/desktop/src/main/services/ai/aiIntegrationService.ts
@@ -17,6 +17,7 @@ import {
   getAvailableModels,
   getLocalProviderDefaultEndpoint,
   listModelDescriptorsForProvider,
+  LOCAL_PROVIDER_LABELS,
   replaceDynamicLocalModelDescriptors,
   resolveModelAlias,
   enrichModelRegistry,
@@ -379,12 +380,6 @@ function redactDetectedAuth(
 
   return redacted;
 }
-
-const LOCAL_PROVIDER_LABELS: Record<LocalProviderFamily, string> = {
-  ollama: "Ollama",
-  lmstudio: "LM Studio",
-  vllm: "vLLM",
-};
 
 function apiProviderLabel(provider: string): string {
   const labels: Record<string, string> = {

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -121,6 +121,7 @@ import {
   getModelById,
   getAvailableModels as getRegistryModels,
   listModelDescriptorsForProvider,
+  LOCAL_PROVIDER_LABELS,
   MODEL_REGISTRY,
   pickDefaultCursorDescriptorFromCliList,
   replaceDynamicLocalModelDescriptors,
@@ -4294,12 +4295,6 @@ export function createAgentChatService(args: {
 
   // Unified session support — for API-key / local models using streamText + universal tools.
   // CLI-wrapped models fall through to the existing Claude/Codex runtimes.
-  const LOCAL_PROVIDER_LABELS: Record<LocalProviderFamily, string> = {
-    ollama: "Ollama",
-    lmstudio: "LM Studio",
-    vllm: "vLLM",
-  };
-
   const discoveredLocalModelToDescriptor = (model: DiscoveredLocalModel): ModelDescriptor =>
     createDynamicLocalModelDescriptor(model.provider, model.modelId, {
       ...(model.displayName ? { displayName: model.displayName } : {}),

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -30,9 +30,12 @@ import {
 } from "../../../shared/types";
 import { parseAgentChatTranscript } from "../../../shared/chatTranscript";
 import {
+  LOCAL_PROVIDER_LABELS,
   MODEL_REGISTRY,
+  getLocalModelIdTail,
   getLocalProviderDefaultEndpoint,
   getModelById,
+  parseLocalProviderFromModelId,
   resolveModelDescriptorForProvider,
   type LocalProviderFamily,
   type ModelDescriptor,
@@ -67,30 +70,17 @@ const LEGACY_PROVIDER_KEY = "ade.chat.lastProvider";
 const LEGACY_MODEL_KEY_PREFIX = "ade.chat.lastModel";
 
 const COMPUTER_USE_SNAPSHOT_COOLDOWN_MS = 750;
-const LOCAL_PROVIDER_LABELS: Record<LocalProviderFamily, string> = {
-  ollama: "Ollama",
-  lmstudio: "LM Studio",
-  vllm: "vLLM",
-};
 
 type AiStatusSnapshot = AiSettingsStatus & {
   runtimeConnections?: Record<string, AiRuntimeConnectionStatus>;
 };
 
-function getLocalProviderFromModelId(modelId: string): LocalProviderFamily | null {
-  const provider = String(modelId ?? "").trim().split("/", 1)[0]?.toLowerCase();
-  if (provider === "ollama" || provider === "lmstudio" || provider === "vllm") {
-    return provider;
-  }
-  return null;
-}
-
 function formatLocalModelLabel(modelId: string): string {
-  const provider = getLocalProviderFromModelId(modelId);
+  const provider = parseLocalProviderFromModelId(modelId);
   if (!provider) {
     return getModelById(modelId)?.displayName ?? modelId;
   }
-  const tail = String(modelId ?? "").trim().slice(provider.length + 1).trim();
+  const tail = getLocalModelIdTail(modelId, provider);
   return tail.length ? tail : modelId;
 }
 
@@ -101,6 +91,60 @@ function recommendedUnifiedPermissionModeForModel(
   return descriptor.harnessProfile === "guarded" || descriptor.harnessProfile === "read_only"
     ? "plan"
     : null;
+}
+
+function shouldResetUnifiedPermissionForModelSwitch(
+  previous: ModelDescriptor | null | undefined,
+  next: ModelDescriptor | null | undefined,
+): boolean {
+  const prevRec = recommendedUnifiedPermissionModeForModel(previous);
+  const nextRec = recommendedUnifiedPermissionModeForModel(next);
+  if (prevRec == null && nextRec == null) return false;
+  return prevRec !== nextRec;
+}
+
+type LocalRuntimeNoticeShape = {
+  tone: "success" | "warning";
+  title: string;
+  message: string;
+};
+
+function LocalRuntimeNoticeBlock(props: {
+  notice: LocalRuntimeNoticeShape;
+  endpoint?: string | null;
+  /** `inline` = text only (inside a parent runtime card). */
+  variant?: "card" | "inline";
+}) {
+  const { notice, endpoint, variant = "card" } = props;
+  const isCard = variant === "card";
+  return (
+    <div
+      className={cn(
+        isCard && "border-b px-4 py-2.5",
+        isCard && (notice.tone === "success"
+          ? "border-emerald-500/10 bg-emerald-500/[0.04]"
+          : "border-amber-500/10 bg-amber-500/[0.04]"),
+      )}
+    >
+      <div className={cn(
+        "font-mono text-[10px] uppercase tracking-[0.16em]",
+        notice.tone === "success" ? "text-emerald-200/70" : "text-amber-200/70",
+      )}>
+        {notice.title}
+      </div>
+      <div className={cn(
+        "mt-1 text-[12px] leading-5",
+        notice.tone === "success" ? "text-emerald-100/80" : "text-amber-100/80",
+      )}>
+        {notice.message}
+      </div>
+      {endpoint ? (
+        <code className="mt-2 block rounded-md border border-white/[0.06] bg-black/10 px-2 py-1 font-mono text-[10px] text-fg/60">
+          {endpoint}
+        </code>
+      ) : null}
+    </div>
+  );
 }
 
 export function resolveChatSessionProfile(_computerUsePolicy: ComputerUsePolicy): AgentChatSessionProfile {
@@ -629,6 +673,7 @@ export function AgentChatPane({
   const [codexSandbox, setCodexSandbox] = useState<AgentChatCodexSandbox>(initialNativeControls.codexSandbox);
   const [codexConfigSource, setCodexConfigSource] = useState<AgentChatCodexConfigSource>(initialNativeControls.codexConfigSource);
   const [unifiedPermissionMode, setUnifiedPermissionMode] = useState<AgentChatUnifiedPermissionMode>(initialNativeControls.unifiedPermissionMode);
+  const prevModelDescRef = useRef<ModelDescriptor | null | undefined>(undefined);
   const [cursorModeId, setCursorModeId] = useState<string | null>(initialNativeControls.cursorModeId);
   const [cursorConfigValues, setCursorConfigValues] = useState<Record<string, string | boolean>>(initialNativeControls.cursorConfigValues);
   const [computerUsePolicy, setComputerUsePolicy] = useState<ComputerUsePolicy>(createDefaultComputerUsePolicy());
@@ -728,7 +773,7 @@ export function AgentChatPane({
   const localRuntimeState = useMemo(() => {
     const provider = selectedModelDesc?.authTypes.includes("local")
       ? (selectedModelDesc.family as LocalProviderFamily)
-      : getLocalProviderFromModelId(modelId);
+      : parseLocalProviderFromModelId(modelId);
     if (!provider) return null;
     const runtimeConnection = aiStatus?.runtimeConnections?.[provider] ?? null;
     const detectedEntry = aiStatus?.detectedAuth?.find(
@@ -790,9 +835,61 @@ export function AgentChatPane({
     return {
       tone: "success" as const,
       title: `${localRuntimeState.label} runtime`,
-      message: `${localRuntimeState.label} is connected at ${localRuntimeState.endpoint} with ${localRuntimeState.modelIds.length} loaded model${localRuntimeState.modelIds.length === 1 ? "" : "s"}${localRuntimeState.health ? ` (${localRuntimeState.health})` : ""}.`,
+      message: `${localRuntimeState.label} is connected with ${localRuntimeState.modelIds.length} loaded model${localRuntimeState.modelIds.length === 1 ? "" : "s"}${localRuntimeState.health ? ` (${localRuntimeState.health})` : ""}.`,
     };
   }, [localRuntimeState, modelId, selectedModelDesc?.displayName]);
+
+  const cliRuntimeBlocked = Boolean(
+    selectedSessionId
+    && activeProviderConnection
+    && !activeProviderConnection.runtimeAvailable
+    && (activeProviderConnection.blocker || activeProviderConnection.provider === "cursor"),
+  );
+  const cliRuntimeTitle = activeProviderConnection?.provider === "claude"
+    ? "Claude runtime"
+    : activeProviderConnection?.provider === "cursor"
+      ? "Cursor runtime"
+      : "Codex runtime";
+  const cliRuntimeBody = activeProviderConnection?.blocker
+    ?? (activeProviderConnection?.provider === "cursor"
+      ? "Cursor agent is not available. Ensure Cursor is installed and the agent is enabled."
+      : null);
+
+  const mergedRuntimeBanner = useMemo(() => {
+    if (!cliRuntimeBlocked && !localRuntimeNotice) return null;
+    if (cliRuntimeBlocked && localRuntimeNotice) {
+      return {
+        kind: "merged" as const,
+        cliTitle: cliRuntimeTitle,
+        cliBody: cliRuntimeBody ?? "",
+        localNotice: localRuntimeNotice,
+        localEndpoint: localRuntimeState?.endpoint,
+      };
+    }
+    if (cliRuntimeBlocked) {
+      return {
+        kind: "cli-only" as const,
+        cliTitle: cliRuntimeTitle,
+        cliBody: cliRuntimeBody ?? "",
+      };
+    }
+    return {
+      kind: "local-only" as const,
+      localNotice: localRuntimeNotice!,
+      localEndpoint: localRuntimeState?.endpoint,
+    };
+  }, [
+    cliRuntimeBlocked,
+    cliRuntimeBody,
+    cliRuntimeTitle,
+    localRuntimeNotice,
+    localRuntimeState?.endpoint,
+  ]);
+
+  useEffect(() => {
+    prevModelDescRef.current = getModelById(modelId);
+  }, [modelId]);
+
   const surfaceMode = presentation?.mode ?? "standard";
   const identitySessionSettingsBusy = isPersistentIdentitySurface && sessionMutationKind !== null;
 
@@ -1698,32 +1795,39 @@ export function AgentChatPane({
     };
   }, [currentNativeControls]);
   const buildModelSelectionSnapshot = useCallback((nextModelId: string) => {
+    const previousDesc = prevModelDescRef.current;
     const nextDesc = getModelById(nextModelId);
     const nextProvider = resolveChatRuntimeProvider(nextDesc);
     const nextModel = nextProvider === "unified" ? nextModelId : runtimeFacingModelId(nextDesc, nextModelId);
     const tiers = nextDesc?.reasoningTiers ?? [];
     const preferred = readLastUsedReasoningEffort({ laneId, modelId: nextModelId });
     const nextReasoningEffort = selectReasoningEffort({ tiers, preferred });
+    const nextRec = recommendedUnifiedPermissionModeForModel(nextDesc);
     return {
       nextDesc,
       nextModelId,
       nextModel,
       nextProvider,
       nextReasoningEffort,
-      nextUnifiedPermissionMode: recommendedUnifiedPermissionModeForModel(nextDesc),
+      nextUnifiedPermissionMode: nextRec,
+      resetUnifiedPermissionToDefault: shouldResetUnifiedPermissionForModelSwitch(previousDesc, nextDesc),
     };
   }, [laneId]);
   const applyModelSelectionSnapshot = useCallback((snapshot: {
     nextModelId: string;
     nextReasoningEffort: string | null;
     nextUnifiedPermissionMode?: AgentChatUnifiedPermissionMode | null;
+    resetUnifiedPermissionToDefault?: boolean;
   }) => {
     setModelId(snapshot.nextModelId);
     setReasoningEffort(snapshot.nextReasoningEffort);
+    if (snapshot.resetUnifiedPermissionToDefault) {
+      setUnifiedPermissionMode(initialNativeControls.unifiedPermissionMode);
+    }
     if (snapshot.nextUnifiedPermissionMode) {
       setUnifiedPermissionMode(snapshot.nextUnifiedPermissionMode);
     }
-  }, []);
+  }, [initialNativeControls.unifiedPermissionMode]);
   const notifySessionCreated = useCallback((session: AgentChatSession) => {
     if (!onSessionCreated) return;
     void Promise.resolve(onSessionCreated(session)).catch((err) => { console.error("notifySessionCreated failed:", err); });
@@ -2433,15 +2537,15 @@ export function AgentChatPane({
               }
 
               setSessionMutationKind("model");
-              const nextNativeControlPayload = snapshot.nextUnifiedPermissionMode
+              const nextUnifiedForPayload = snapshot.resetUnifiedPermissionToDefault
+                ? (snapshot.nextUnifiedPermissionMode ?? initialNativeControls.unifiedPermissionMode)
+                : snapshot.nextUnifiedPermissionMode;
+              const nextNativeControlPayload = snapshot.nextProvider === "unified" && nextUnifiedForPayload != null
                 ? {
-                    ...summarizeNativeControls(snapshot.nextProvider, {
+                    ...summarizeNativeControls("unified", {
                       ...currentNativeControls,
-                      unifiedPermissionMode: snapshot.nextUnifiedPermissionMode,
+                      unifiedPermissionMode: nextUnifiedForPayload,
                     }),
-                    ...(snapshot.nextProvider === "cursor"
-                      ? { cursorConfigValues: currentNativeControls.cursorConfigValues }
-                      : {}),
                   }
                 : buildNativeControlPayload(snapshot.nextProvider);
               void window.ade.agentChat.updateSession({
@@ -2550,47 +2654,44 @@ export function AgentChatPane({
             {error}
           </div>
         ) : null}
-        {selectedSessionId && !activeProviderConnection?.runtimeAvailable && (activeProviderConnection?.blocker || activeProviderConnection?.provider === "cursor") ? (
+        {mergedRuntimeBanner?.kind === "cli-only" ? (
           <div className="border-b border-amber-500/10 bg-amber-500/[0.04] px-4 py-2.5">
             <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-amber-200/70">
-              {activeProviderConnection.provider === "claude"
-                ? "Claude runtime"
-                : activeProviderConnection.provider === "cursor"
-                  ? "Cursor runtime"
-                  : "Codex runtime"}
+              {mergedRuntimeBanner.cliTitle}
             </div>
             <div className="mt-1 text-[12px] leading-5 text-amber-100/80">
-              {activeProviderConnection.blocker || "Cursor agent is not available. Ensure Cursor is installed and the agent is enabled."}
+              {mergedRuntimeBanner.cliBody}
             </div>
           </div>
         ) : null}
-
-        {localRuntimeNotice ? (
-          <div
-            className={cn(
-              "border-b px-4 py-2.5",
-              localRuntimeNotice.tone === "success"
-                ? "border-emerald-500/10 bg-emerald-500/[0.04]"
-                : "border-amber-500/10 bg-amber-500/[0.04]",
-            )}
-          >
-            <div className={cn(
-              "font-mono text-[10px] uppercase tracking-[0.16em]",
-              localRuntimeNotice.tone === "success" ? "text-emerald-200/70" : "text-amber-200/70",
-            )}>
-              {localRuntimeNotice.title}
+        {mergedRuntimeBanner?.kind === "local-only" ? (
+          <LocalRuntimeNoticeBlock
+            notice={mergedRuntimeBanner.localNotice}
+            endpoint={mergedRuntimeBanner.localEndpoint}
+          />
+        ) : null}
+        {mergedRuntimeBanner?.kind === "merged" ? (
+          <div className="border-b border-amber-500/10 bg-amber-500/[0.04] px-4 py-2.5">
+            <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-amber-200/70">
+              Runtime status
             </div>
-            <div className={cn(
-              "mt-1 text-[12px] leading-5",
-              localRuntimeNotice.tone === "success" ? "text-emerald-100/80" : "text-amber-100/80",
-            )}>
-              {localRuntimeNotice.message}
+            <div className="mt-3 space-y-3">
+              <div>
+                <div className="font-mono text-[9px] uppercase tracking-[0.14em] text-amber-200/55">
+                  {mergedRuntimeBanner.cliTitle}
+                </div>
+                <div className="mt-1 text-[12px] leading-5 text-amber-100/80">
+                  {mergedRuntimeBanner.cliBody}
+                </div>
+              </div>
+              <div className="border-t border-white/[0.06] pt-3">
+                <LocalRuntimeNoticeBlock
+                  variant="inline"
+                  notice={mergedRuntimeBanner.localNotice}
+                  endpoint={mergedRuntimeBanner.localEndpoint}
+                />
+              </div>
             </div>
-            {localRuntimeState ? (
-              <code className="mt-2 block rounded-md border border-white/[0.06] bg-black/10 px-2 py-1 font-mono text-[10px] text-fg/60">
-                {localRuntimeState.endpoint}
-              </code>
-            ) : null}
           </div>
         ) : null}
 

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -35,6 +35,7 @@ import {
   getLocalModelIdTail,
   getLocalProviderDefaultEndpoint,
   getModelById,
+  getModelDescriptorForPermissionMode,
   parseLocalProviderFromModelId,
   resolveModelDescriptorForProvider,
   type LocalProviderFamily,
@@ -887,7 +888,7 @@ export function AgentChatPane({
   ]);
 
   useEffect(() => {
-    prevModelDescRef.current = getModelById(modelId);
+    prevModelDescRef.current = getModelDescriptorForPermissionMode(modelId);
   }, [modelId]);
 
   const surfaceMode = presentation?.mode ?? "standard";
@@ -1797,12 +1798,13 @@ export function AgentChatPane({
   const buildModelSelectionSnapshot = useCallback((nextModelId: string) => {
     const previousDesc = prevModelDescRef.current;
     const nextDesc = getModelById(nextModelId);
+    const nextPermissionDesc = getModelDescriptorForPermissionMode(nextModelId);
     const nextProvider = resolveChatRuntimeProvider(nextDesc);
     const nextModel = nextProvider === "unified" ? nextModelId : runtimeFacingModelId(nextDesc, nextModelId);
     const tiers = nextDesc?.reasoningTiers ?? [];
     const preferred = readLastUsedReasoningEffort({ laneId, modelId: nextModelId });
     const nextReasoningEffort = selectReasoningEffort({ tiers, preferred });
-    const nextRec = recommendedUnifiedPermissionModeForModel(nextDesc);
+    const nextRec = recommendedUnifiedPermissionModeForModel(nextPermissionDesc);
     return {
       nextDesc,
       nextModelId,
@@ -1810,7 +1812,7 @@ export function AgentChatPane({
       nextProvider,
       nextReasoningEffort,
       nextUnifiedPermissionMode: nextRec,
-      resetUnifiedPermissionToDefault: shouldResetUnifiedPermissionForModelSwitch(previousDesc, nextDesc),
+      resetUnifiedPermissionToDefault: shouldResetUnifiedPermissionForModelSwitch(previousDesc, nextPermissionDesc),
     };
   }, [laneId]);
   const applyModelSelectionSnapshot = useCallback((snapshot: {
@@ -1821,11 +1823,12 @@ export function AgentChatPane({
   }) => {
     setModelId(snapshot.nextModelId);
     setReasoningEffort(snapshot.nextReasoningEffort);
-    if (snapshot.resetUnifiedPermissionToDefault) {
-      setUnifiedPermissionMode(initialNativeControls.unifiedPermissionMode);
-    }
-    if (snapshot.nextUnifiedPermissionMode) {
-      setUnifiedPermissionMode(snapshot.nextUnifiedPermissionMode);
+    const nextUnified = snapshot.nextUnifiedPermissionMode ?? null;
+    const targetUnified = snapshot.resetUnifiedPermissionToDefault
+      ? (nextUnified ?? initialNativeControls.unifiedPermissionMode)
+      : nextUnified;
+    if (targetUnified != null) {
+      setUnifiedPermissionMode(targetUnified);
     }
   }, [initialNativeControls.unifiedPermissionMode]);
   const notifySessionCreated = useCallback((session: AgentChatSession) => {
@@ -1840,11 +1843,12 @@ export function AgentChatPane({
     if (!laneId) return null;
     const createPromise = (async () => {
       const desc = getModelById(modelId);
+      const permissionDesc = getModelDescriptorForPermissionMode(modelId);
       const provider = resolveChatRuntimeProvider(desc);
       const model = provider === "unified" ? modelId : runtimeFacingModelId(desc, modelId);
       const sessionProfile = resolveChatSessionProfile(computerUsePolicy);
       const harnessPermissionMode = provider === "unified"
-        ? recommendedUnifiedPermissionModeForModel(desc)
+        ? recommendedUnifiedPermissionModeForModel(permissionDesc)
         : null;
       const nativeControlPayload = harnessPermissionMode
         ? {

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -8,7 +8,14 @@ import type {
   AiSettingsStatus,
   ProjectConfigSnapshot,
 } from "../../../shared/types";
-import { getLocalProviderDefaultEndpoint, getModelById, type LocalProviderFamily } from "../../../shared/modelRegistry";
+import {
+  getLocalModelIdTail,
+  getLocalProviderDefaultEndpoint,
+  getModelById,
+  LOCAL_PROVIDER_LABELS,
+  parseLocalProviderFromModelId,
+  type LocalProviderFamily,
+} from "../../../shared/modelRegistry";
 import {
   ArrowsClockwise,
   CheckCircle,
@@ -71,10 +78,6 @@ const LOCAL_PROVIDER_SPECS: Array<{
   { provider: "ollama", label: "Ollama", description: "OpenAI-compatible local server" },
   { provider: "vllm", label: "vLLM", description: "OpenAI-compatible local server" },
 ];
-
-const LOCAL_PROVIDER_LABELS: Record<LocalProviderFamily, string> = Object.fromEntries(
-  LOCAL_PROVIDER_SPECS.map((entry) => [entry.provider, entry.label]),
-) as Record<LocalProviderFamily, string>;
 
 const API_KEY_PROVIDERS: Array<{
   provider: string;
@@ -184,14 +187,13 @@ function buildCliMessage(tool: (typeof CLI_TOOLS)[number], connection: AiProvide
 function formatLocalModelLabel(modelId: string): string {
   const descriptor = getModelById(modelId);
   if (descriptor) return descriptor.displayName;
-  const raw = String(modelId ?? "").trim();
-  const prefix = raw.split("/", 1)[0]?.toLowerCase();
-  if (prefix === "ollama" || prefix === "lmstudio" || prefix === "vllm") {
-    const tail = raw.slice(prefix.length + 1).trim();
-    const providerLabel = LOCAL_PROVIDER_SPECS.find((entry) => entry.provider === prefix)?.label ?? prefix;
-    return tail.length ? `${tail} (${providerLabel})` : raw;
+  const provider = parseLocalProviderFromModelId(modelId);
+  if (provider) {
+    const tail = getLocalModelIdTail(modelId, provider);
+    const brand = LOCAL_PROVIDER_LABELS[provider];
+    return tail.length ? `${tail} (${brand})` : String(modelId ?? "").trim();
   }
-  return raw;
+  return String(modelId ?? "").trim();
 }
 
 const AUTH_ERROR_SIGNALS = [

--- a/apps/desktop/src/renderer/components/shared/UnifiedModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/shared/UnifiedModelSelector.tsx
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "motion/react";
 import {
+  LOCAL_PROVIDER_LABELS,
   MODEL_REGISTRY,
+  getLocalModelIdTail,
+  parseLocalProviderFromModelId,
   resolveModelDescriptor,
   type ModelDescriptor,
 } from "../../../shared/modelRegistry";
@@ -43,11 +46,6 @@ type UnifiedModelSelectorProps = {
 };
 
 const SOURCE_KEYS: SourceSectionKey[] = ["subscription", "api", "local"];
-const LOCAL_PROVIDER_LABELS: Record<string, string> = {
-  ollama: "Ollama",
-  lmstudio: "LM Studio",
-  vllm: "vLLM",
-};
 
 const selectCls = cn(
   "h-8 rounded-lg border border-white/[0.08] bg-white/[0.04] px-2 font-sans text-[11px] text-fg/70",
@@ -65,21 +63,6 @@ function rgbaFromHex(hex: string, alpha: number): string {
 
 function providerAccent(family: string, fallback?: string): string {
   return PROVIDER_BADGE_COLORS[family] ?? fallback ?? "#A78BFA";
-}
-
-function getLocalProviderFromModelId(modelId: string): "ollama" | "lmstudio" | "vllm" | null {
-  const provider = String(modelId ?? "").trim().split("/", 1)[0]?.toLowerCase();
-  if (provider === "ollama" || provider === "lmstudio" || provider === "vllm") {
-    return provider;
-  }
-  return null;
-}
-
-function getLocalModelShortLabel(modelId: string): string {
-  const provider = getLocalProviderFromModelId(modelId);
-  if (!provider) return modelId;
-  const tail = String(modelId ?? "").trim().slice(provider.length + 1).trim();
-  return tail.length ? tail : modelId;
 }
 
 function subsectionTabTitle(sub: ModelSubsection): string {
@@ -133,10 +116,10 @@ function createUnknownModelPlaceholder(modelId: string): ModelDescriptor {
       isCliWrapped: true,
     };
   }
-  const localProvider = getLocalProviderFromModelId(modelId);
+  const localProvider = parseLocalProviderFromModelId(modelId);
   if (localProvider) {
-    const providerLabel = LOCAL_PROVIDER_LABELS[localProvider];
-    const shortId = getLocalModelShortLabel(modelId);
+    const shortId = getLocalModelIdTail(modelId, localProvider) || modelId;
+    const brand = LOCAL_PROVIDER_LABELS[localProvider];
     return {
       id: modelId,
       shortId,
@@ -148,11 +131,11 @@ function createUnknownModelPlaceholder(modelId: string): ModelDescriptor {
       capabilities: { tools: false, vision: false, reasoning: false, streaming: true },
       color: PROVIDER_BADGE_COLORS[localProvider] ?? "#64748B",
       sdkProvider: "@ai-sdk/openai-compatible",
-      sdkModelId: modelId,
+      sdkModelId: shortId,
       isCliWrapped: false,
       discoverySource: localProvider === "lmstudio" ? "lmstudio-openai" : localProvider,
       harnessProfile: "guarded",
-      aliases: [providerLabel],
+      aliases: [brand],
     };
   }
   return {

--- a/apps/desktop/src/renderer/lib/modelOptions.ts
+++ b/apps/desktop/src/renderer/lib/modelOptions.ts
@@ -1,42 +1,33 @@
 import type { AiModelDescriptor, AiRuntimeConnectionStatus, AiSettingsStatus, ModelId } from "../../shared/types";
-import { MODEL_REGISTRY, getModelById, type LocalProviderFamily, type ModelDescriptor } from "../../shared/modelRegistry";
+import {
+  LOCAL_PROVIDER_LABELS,
+  MODEL_REGISTRY,
+  getLocalModelIdTail,
+  getModelById,
+  isLocalProviderFamily,
+  parseLocalProviderFromModelId,
+  type ModelDescriptor,
+} from "../../shared/modelRegistry";
 
 function normalizeAuthProvider(provider: string | undefined): string {
   return String(provider ?? "").trim().toLowerCase();
 }
 
-const LOCAL_PROVIDER_LABELS: Record<LocalProviderFamily, string> = {
-  ollama: "Ollama",
-  lmstudio: "LM Studio",
-  vllm: "vLLM",
-};
-
-function getLocalProviderFromModelId(modelId: string): LocalProviderFamily | null {
-  const provider = String(modelId ?? "")
-    .trim()
-    .split("/", 1)[0]
-    ?.toLowerCase();
-  if (provider === "ollama" || provider === "lmstudio" || provider === "vllm") {
-    return provider;
-  }
-  return null;
-}
-
 function getLocalModelLabel(modelId: string): string {
-  const provider = getLocalProviderFromModelId(modelId);
+  const provider = parseLocalProviderFromModelId(modelId);
   if (!provider) return modelId;
-  const tail = String(modelId ?? "").trim().slice(provider.length + 1).trim();
+  const tail = getLocalModelIdTail(modelId, provider);
   return tail.length ? tail : modelId;
 }
 
 function buildFallbackModelOption(modelId: string): AiModelDescriptor {
-  const provider = getLocalProviderFromModelId(modelId);
+  const provider = parseLocalProviderFromModelId(modelId);
   if (provider) {
-    const providerLabel = LOCAL_PROVIDER_LABELS[provider];
+    const pLabel = LOCAL_PROVIDER_LABELS[provider];
     return {
       id: modelId,
       label: getLocalModelLabel(modelId),
-      description: `${providerLabel} local model`,
+      description: `${pLabel} local model`,
     };
   }
   return {
@@ -104,7 +95,7 @@ function hasDynamicLocalModelIdsForProvider(
   runtimeConnections: Record<string, AiRuntimeConnectionStatus> | undefined,
 ): boolean {
   const normalizedProvider = normalizeAuthProvider(provider);
-  if (normalizedProvider !== "ollama" && normalizedProvider !== "lmstudio" && normalizedProvider !== "vllm") {
+  if (!isLocalProviderFamily(normalizedProvider)) {
     return false;
   }
   const prefix = `${normalizedProvider}/`;
@@ -168,7 +159,7 @@ export function deriveConfiguredModelIds(
 
   for (const [provider, connection] of Object.entries(runtimeConnections ?? {})) {
     const normalizedProvider = normalizeAuthProvider(provider);
-    if (normalizedProvider !== "ollama" && normalizedProvider !== "lmstudio" && normalizedProvider !== "vllm") {
+    if (!isLocalProviderFamily(normalizedProvider)) {
       continue;
     }
     if (!hasDynamicLocalModelIdsForProvider(normalizedProvider, status.availableModelIds, runtimeConnections)) {
@@ -210,7 +201,7 @@ export function deriveConfiguredModelOptions(
     const descriptor = getModelById(modelId);
     return descriptor
       ? [descriptorToModelOption(descriptor)]
-      : getLocalProviderFromModelId(modelId)
+      : parseLocalProviderFromModelId(modelId)
         ? [buildFallbackModelOption(modelId)]
         : [];
   });
@@ -224,6 +215,6 @@ export function includeSelectedModelOption(
   if (!modelId.length || options.some((option) => option.id === modelId)) return options;
   const descriptor = getModelById(modelId);
   if (descriptor) return [descriptorToModelOption(descriptor), ...options];
-  if (getLocalProviderFromModelId(modelId)) return [buildFallbackModelOption(modelId), ...options];
+  if (parseLocalProviderFromModelId(modelId)) return [buildFallbackModelOption(modelId), ...options];
   return options;
 }

--- a/apps/desktop/src/shared/modelRegistry.test.ts
+++ b/apps/desktop/src/shared/modelRegistry.test.ts
@@ -4,6 +4,7 @@ import {
   getAvailableModels,
   getDefaultModelDescriptor,
   getModelById,
+  getModelDescriptorForPermissionMode,
   getRuntimeModelRefForDescriptor,
   listModelDescriptorsForProvider,
   MODEL_REGISTRY,
@@ -74,6 +75,19 @@ describe("modelRegistry", () => {
   it("returns undefined for unknown model IDs", () => {
     expect(getModelById("openai/gpt-99")).toBeUndefined();
     expect(resolveModelDescriptor("nonexistent/model-id")).toBeUndefined();
+  });
+
+  it("getModelDescriptorForPermissionMode matches getModelById for known locals", () => {
+    const id = "ollama/qwen2.5-coder:32b";
+    expect(getModelDescriptorForPermissionMode(id)).toEqual(getModelById(id));
+  });
+
+  it("getModelDescriptorForPermissionMode yields guarded local for ollama/auto when getModelById is undefined", () => {
+    expect(getModelById("ollama/auto")).toBeUndefined();
+    const perm = getModelDescriptorForPermissionMode("ollama/auto");
+    expect(perm?.family).toBe("ollama");
+    expect(perm?.harnessProfile).toBe("guarded");
+    expect(perm?.authTypes).toContain("local");
   });
 
   it("resolves gpt-5.4 shortId to the API-key variant, not the codex variant", () => {

--- a/apps/desktop/src/shared/modelRegistry.ts
+++ b/apps/desktop/src/shared/modelRegistry.ts
@@ -769,6 +769,23 @@ export function getLocalModelIdTail(modelId: string, provider: LocalProviderFami
   return String(modelId ?? "").trim().slice(provider.length + 1).trim();
 }
 
+/**
+ * Descriptor for unified permission / harness decisions when the registry has no row yet.
+ * `getModelById` returns undefined for refs such as `ollama/auto`; this still returns a
+ * guarded local descriptor so the UI matches main-process harness behavior.
+ */
+export function getModelDescriptorForPermissionMode(modelId: string): ModelDescriptor | undefined {
+  const resolved = getModelById(modelId);
+  if (resolved) return resolved;
+  const provider = parseLocalProviderFromModelId(modelId);
+  if (!provider) return undefined;
+  const tail = getLocalModelIdTail(modelId, provider);
+  if (!tail.length || tail === "auto") {
+    return createDynamicLocalModelDescriptor(provider, "auto", { harnessProfile: "guarded" });
+  }
+  return createDynamicLocalModelDescriptor(provider, tail);
+}
+
 function parseDynamicLocalModelRef(modelRef: string): { provider: LocalProviderFamily; modelId: string } | null {
   const normalized = modelRef.trim();
   if (!normalized.length) return null;

--- a/apps/desktop/src/shared/modelRegistry.ts
+++ b/apps/desktop/src/shared/modelRegistry.ts
@@ -82,7 +82,8 @@ export function isModelProviderGroup(value: string | null | undefined): value is
 const ALL_CAPS: ModelCapabilities = { tools: true, vision: true, reasoning: true, streaming: true };
 const NO_REASONING: ModelCapabilities = { tools: true, vision: true, reasoning: false, streaming: true };
 const BASIC_CAPS: ModelCapabilities = { tools: true, vision: false, reasoning: false, streaming: true };
-const LOCAL_PROVIDER_LABELS: Record<LocalProviderFamily, string> = {
+/** Human-readable names for Ollama / LM Studio / vLLM (shared across main, renderer, and MCP). */
+export const LOCAL_PROVIDER_LABELS: Record<LocalProviderFamily, string> = {
   ollama: "Ollama",
   lmstudio: "LM Studio",
   vllm: "vLLM",
@@ -753,8 +754,19 @@ export function validateModelRegistry(models: ModelDescriptor[] = MODEL_REGISTRY
 validateModelRegistry();
 rebuildIndexes();
 
-function isLocalProviderFamily(value: string): value is LocalProviderFamily {
+export function isLocalProviderFamily(value: string): value is LocalProviderFamily {
   return value === "ollama" || value === "lmstudio" || value === "vllm";
+}
+
+/** First path segment of `provider/modelId` when it is a known local provider. */
+export function parseLocalProviderFromModelId(modelId: string): LocalProviderFamily | null {
+  const provider = String(modelId ?? "").trim().split("/", 1)[0]?.toLowerCase() ?? "";
+  return isLocalProviderFamily(provider) ? provider : null;
+}
+
+/** Model name segment after `provider/` for local refs; empty string if missing. */
+export function getLocalModelIdTail(modelId: string, provider: LocalProviderFamily): string {
+  return String(modelId ?? "").trim().slice(provider.length + 1).trim();
 }
 
 function parseDynamicLocalModelRef(modelRef: string): { provider: LocalProviderFamily; modelId: string } | null {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the local AI runtime work: addresses the audit items for local model chat UX and code hygiene.

## Changes

- **Shared helpers** — Export `LOCAL_PROVIDER_LABELS`, `parseLocalProviderFromModelId`, `getLocalModelIdTail`, and `isLocalProviderFamily` from `modelRegistry`; dedupe labels in `agentChatService` / `aiIntegrationService`.
- **`getModelDescriptorForPermissionMode`** — When `getModelById` is undefined (e.g. `ollama/auto`), still returns a guarded local descriptor so harness / unified permission logic matches main (addresses Codex P1 on PR review).
- **Chat runtime banners** — Merged CLI + local **Runtime status** card when both apply.
- **Unified permission mode** — Single `setUnifiedPermissionMode` in `applyModelSelectionSnapshot` (CodeRabbit nitpick). Reset + recommendation combined as `(nextRec ?? surfaceDefault)`.
- **UnifiedModelSelector** — Unknown local placeholder uses correct `sdkModelId` tail.

## Post-review (commit `be3a62e6`)

- Wire `getModelDescriptorForPermissionMode` through `prevModelDescRef`, `buildModelSelectionSnapshot`, and `createSession` harness path.
- Unit tests in `modelRegistry.test.ts` for `ollama/auto` vs known local ids.

## Validation

- `npm --prefix apps/desktop run typecheck` / `lint`
- `vitest` — `modelRegistry.test.ts`, `AgentChatPane.test.ts`, `modelOptions.test.ts`, `ProvidersSection.test.tsx`
- `npm --prefix apps/mcp-server run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eec1a734-3fc8-4296-88d0-07e2c5ad7e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eec1a734-3fc8-4296-88d0-07e2c5ad7e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved runtime status display with merged banner system for local and CLI runtime information.
  * Enhanced model switching logic with intelligent permission mode handling.

* **Bug Fixes**
  * Refined local runtime connection success messages for better clarity.

* **Refactor**
  * Consolidated local provider utilities and labels into shared model registry for consistent handling across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->