### PR TITLE
Integration: merge into any lane, parent-head simulation, resolver instructions

### DIFF
--- a/apps/desktop/src/main/services/conflicts/conflictService.ts
+++ b/apps/desktop/src/main/services/conflicts/conflictService.ts
@@ -3930,7 +3930,7 @@ export function createConflictService({
     ];
     const status: PrepareResolverSessionResult["status"] = contextGaps.length > 0 ? "blocked" : "ready";
 
-    const prompt = buildExternalResolverPrompt({
+    let prompt = buildExternalResolverPrompt({
       targetLaneId,
       sourceLaneIds,
       contexts,
@@ -3939,6 +3939,10 @@ export function createConflictService({
       integrationLaneId: integrationLane?.id ?? null,
       scenario
     });
+    const extra = typeof args.additionalInstructions === "string" ? args.additionalInstructions.trim() : "";
+    if (extra.length > 0) {
+      prompt += `\n\n---\n\n## Operator instructions\n\n${extra}\n`;
+    }
     const promptPath = path.join(runDir, "prompt.md");
     fs.writeFileSync(promptPath, prompt, "utf8");
 

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -4785,6 +4785,9 @@ export function registerIpc({
     const reasoning = typeof arg?.reasoning === "string" && arg.reasoning.trim().length > 0
       ? arg.reasoning.trim()
       : null;
+    const additionalInstructions = typeof arg?.additionalInstructions === "string" && arg.additionalInstructions.trim().length > 0
+      ? arg.additionalInstructions.trim()
+      : null;
     let runId = "";
 
     if (!model) {
@@ -4841,6 +4844,7 @@ export function registerIpc({
         model,
         reasoningEffort: reasoning,
         permissionMode,
+        additionalInstructions,
         originSurface: context.sourceTab === "integration"
           ? "integration"
           : context.sourceTab === "rebase"

--- a/apps/desktop/src/main/services/prs/prService.ts
+++ b/apps/desktop/src/main/services/prs/prService.ts
@@ -151,6 +151,7 @@ type IntegrationProposalRow = {
   integration_lane_name: string | null;
   status: string;
   integration_lane_id: string | null;
+  preferred_integration_lane_id: string | null;
   resolution_state_json: string | null;
   pairwise_results_json: string | null;
   lane_summaries_json: string | null;
@@ -1282,6 +1283,7 @@ export function createPrService({
       body: String(row.body || ""),
       draft: Boolean(row.draft),
       integrationLaneName: String(row.integration_lane_name || ""),
+      preferredIntegrationLaneId: asString(row.preferred_integration_lane_id).trim() || null,
       status: String(row.status) as IntegrationProposal["status"],
       integrationLaneId,
       linkedGroupId: asString(row.linked_group_id).trim() || null,
@@ -2406,13 +2408,25 @@ export function createPrService({
     if (!preflight.baseLane) {
       throw new Error(`Could not map base branch "${args.baseBranch}" to an active lane. Create or attach that lane first.`);
     }
+    const existingIntegrationLaneId = asString(args.existingIntegrationLaneId).trim();
+    const laneMap = new Map(lanes.map((lane) => [lane.id, lane]));
+    if (existingIntegrationLaneId) {
+      if (preflight.uniqueSourceLaneIds.includes(existingIntegrationLaneId)) {
+        throw new Error("Integration lane cannot be one of the source lanes.");
+      }
+      const adoptLane = laneMap.get(existingIntegrationLaneId);
+      if (!adoptLane) {
+        throw new Error(`Integration lane not found: ${existingIntegrationLaneId}`);
+      }
+    }
     assertDirtyWorktreesAllowed({
       lanes,
-      laneIds: preflight.uniqueSourceLaneIds,
+      laneIds: existingIntegrationLaneId
+        ? [...preflight.uniqueSourceLaneIds, existingIntegrationLaneId]
+        : preflight.uniqueSourceLaneIds,
       allowDirtyWorktree: args.allowDirtyWorktree
     });
 
-    const laneMap = new Map(lanes.map((lane) => [lane.id, lane]));
     const sourceLaneNames = preflight.uniqueSourceLaneIds.map((laneId) => laneMap.get(laneId)?.name ?? laneId);
     const groupId = randomUUID();
     const now = nowIso();
@@ -2420,6 +2434,7 @@ export function createPrService({
     // Track resources created during this operation for cleanup on failure.
     let groupInserted = false;
     let integrationLane: LaneSummary | null = null;
+    let createdNewIntegrationLane = false;
 
     try {
       db.run(
@@ -2428,11 +2443,17 @@ export function createPrService({
       );
       groupInserted = true;
 
-      integrationLane = await laneService.createChild({
-        parentLaneId: preflight.baseLane.id,
-        name: integrationLaneName,
-        description: `Integration lane for merging: ${sourceLaneNames.join(", ")}`
-      });
+      if (existingIntegrationLaneId) {
+        integrationLane = laneMap.get(existingIntegrationLaneId) ?? null;
+        if (!integrationLane) throw new Error(`Integration lane not found: ${existingIntegrationLaneId}`);
+      } else {
+        integrationLane = await laneService.createChild({
+          parentLaneId: preflight.baseLane.id,
+          name: integrationLaneName,
+          description: `Integration lane for merging: ${sourceLaneNames.join(", ")}`
+        });
+        createdNewIntegrationLane = true;
+      }
 
       const mergeResults: Array<{ laneId: string; success: boolean; error?: string }> = [];
 
@@ -2510,9 +2531,8 @@ export function createPrService({
           });
         }
       }
-      // Archive the integration lane if we created one (best-effort; deletion
-      // could fail if the worktree has uncommitted state, so archive is safer).
-      if (integrationLane) {
+      // Archive the integration lane only if we created it (best-effort).
+      if (integrationLane && createdNewIntegrationLane) {
         try {
           await laneService.archive({ laneId: integrationLane.id });
         } catch (cleanupError) {
@@ -2888,11 +2908,33 @@ export function createPrService({
     const laneOrder = new Map(sourceLaneIds.map((laneId, index) => [laneId, index]));
     const zeroDiffStat: IntegrationProposalStep["diffStat"] = { insertions: 0, deletions: 0, filesChanged: 0 };
 
+    const mergeIntoLaneId = asString(args.mergeIntoLaneId).trim();
+    if (mergeIntoLaneId && sourceLaneIds.includes(mergeIntoLaneId)) {
+      throw new Error("Merge-into lane cannot be one of the source lanes.");
+    }
+    const mergeIntoLane = mergeIntoLaneId ? laneMap.get(mergeIntoLaneId) ?? null : null;
+    if (mergeIntoLaneId && !mergeIntoLane) {
+      throw new Error(`Merge-into lane not found: ${mergeIntoLaneId}`);
+    }
+
     // Resolve base branch SHA once, then compare each lane head against it.
     const baseSha = (await runGitOrThrow(
       ["rev-parse", args.baseBranch],
       { cwd: projectRoot, timeoutMs: 10_000 }
     )).trim();
+
+    let mergeIntoHeadSha: string | null = null;
+    if (mergeIntoLane) {
+      try {
+        mergeIntoHeadSha = (await runGitOrThrow(
+          ["rev-parse", branchNameFromRef(mergeIntoLane.branchRef)],
+          { cwd: projectRoot, timeoutMs: 10_000 }
+        )).trim();
+      } catch {
+        mergeIntoHeadSha = null;
+      }
+    }
+    const sequentialStartSha = mergeIntoHeadSha ?? baseSha;
 
     const laneSummariesById = new Map<
       string,
@@ -3091,6 +3133,64 @@ export function createPrService({
       }))
     });
 
+    const mergeIntoConflictLaneIds = new Set<string>();
+    const mergeIntoFilesByLaneId = new Map<string, Map<string, IntegrationProposalStep["conflictingFiles"][number]>>();
+    if (mergeIntoHeadSha) {
+      for (const laneId of sourceLaneIds) {
+        const laneSummary = laneSummariesById.get(laneId);
+        if (!laneSummary?.headSha) continue;
+        const mergeTreeResult = await runGitMergeTree({
+          cwd: projectRoot,
+          mergeBase: baseSha,
+          branchA: mergeIntoHeadSha,
+          branchB: laneSummary.headSha,
+          timeoutMs: 30_000
+        });
+        if (mergeTreeResult.exitCode === 128 || (!mergeTreeResult.conflicts.length && mergeTreeResult.exitCode !== 0)) {
+          mergeIntoConflictLaneIds.add(laneId);
+          continue;
+        }
+        if (mergeTreeResult.conflicts.length === 0) continue;
+        mergeIntoConflictLaneIds.add(laneId);
+        const fileMap = mergeIntoFilesByLaneId.get(laneId) ?? new Map<string, IntegrationProposalStep["conflictingFiles"][number]>();
+        const treeOid = mergeTreeResult.treeOid;
+        for (const filePath of mergeTreeResult.conflicts.map((c) => c.path)) {
+          if (fileMap.has(filePath)) continue;
+          if (treeOid) {
+            const detail = await extractConflictDetail(treeOid, filePath, projectRoot);
+            fileMap.set(filePath, {
+              path: filePath,
+              conflictType: detail.conflictType,
+              conflictMarkers: detail.conflictMarkers,
+              oursExcerpt: detail.oursExcerpt || null,
+              theirsExcerpt: detail.theirsExcerpt || null,
+              diffHunk: detail.diffHunk || null
+            });
+          } else {
+            let oursExcerpt: string | null = null;
+            let theirsExcerpt: string | null = null;
+            try {
+              const [diffI, diffS] = await Promise.all([
+                runGit(["diff", `${baseSha}..${mergeIntoHeadSha}`, "--", filePath], { cwd: projectRoot, timeoutMs: 10_000 }),
+                runGit(["diff", `${baseSha}..${laneSummary.headSha}`, "--", filePath], { cwd: projectRoot, timeoutMs: 10_000 })
+              ]);
+              if (diffI.exitCode === 0 && diffI.stdout.trim()) oursExcerpt = diffI.stdout.slice(0, 500);
+              if (diffS.exitCode === 0 && diffS.stdout.trim()) theirsExcerpt = diffS.stdout.slice(0, 500);
+            } catch { /* best-effort */ }
+            fileMap.set(filePath, {
+              path: filePath,
+              conflictType: null,
+              conflictMarkers: "",
+              oursExcerpt,
+              theirsExcerpt,
+              diffHunk: null
+            });
+          }
+        }
+        mergeIntoFilesByLaneId.set(laneId, fileMap);
+      }
+    }
+
     const sequentialConflictLaneIds = new Set<string>();
     const sequentialBlockedLaneIds = new Set<string>();
     const sequentialFilesByLaneId = new Map<string, Map<string, IntegrationProposalStep["conflictingFiles"][number]>>();
@@ -3098,7 +3198,7 @@ export function createPrService({
     const sequentialWorktreePath = path.join(sequentialTempRoot, "worktree");
 
     try {
-      await runGitOrThrow(["worktree", "add", "--detach", sequentialWorktreePath, baseSha], {
+      await runGitOrThrow(["worktree", "add", "--detach", sequentialWorktreePath, sequentialStartSha], {
         cwd: projectRoot,
         timeoutMs: 60_000,
       });
@@ -3192,6 +3292,14 @@ export function createPrService({
       conflictingFilesByLaneId.set(laneId, laneFiles);
     }
 
+    for (const [laneId, files] of mergeIntoFilesByLaneId.entries()) {
+      const laneFiles = conflictingFilesByLaneId.get(laneId) ?? new Map<string, IntegrationProposalStep["conflictingFiles"][number]>();
+      for (const [filePath, file] of files.entries()) {
+        if (!laneFiles.has(filePath)) laneFiles.set(filePath, file);
+      }
+      conflictingFilesByLaneId.set(laneId, laneFiles);
+    }
+
     const laneSummaries: IntegrationLaneSummary[] = sourceLaneIds.map((laneId) => {
       const laneSummary = laneSummariesById.get(laneId);
       const laneName = laneSummary?.laneName ?? laneId;
@@ -3201,7 +3309,7 @@ export function createPrService({
       let outcome: IntegrationLaneSummary["outcome"] = "clean";
       if (!laneSummary?.headSha || blockedLaneIds.has(laneId) || sequentialBlockedLaneIds.has(laneId)) {
         outcome = "blocked";
-      } else if (conflictsWith.length > 0 || sequentialConflictLaneIds.has(laneId)) {
+      } else if (conflictsWith.length > 0 || sequentialConflictLaneIds.has(laneId) || mergeIntoConflictLaneIds.has(laneId)) {
         outcome = "conflict";
       }
 
@@ -3243,6 +3351,7 @@ export function createPrService({
       overallOutcome,
       createdAt: now,
       status: "proposed",
+      preferredIntegrationLaneId: mergeIntoLaneId || null,
       linkedGroupId: null,
       linkedPrId: null,
       workflowDisplayState: "active",
@@ -3256,7 +3365,7 @@ export function createPrService({
 
     if (args.persist !== false) {
       db.run(
-        `insert into integration_proposals(id, project_id, source_lane_ids_json, base_branch, steps_json, pairwise_results_json, lane_summaries_json, overall_outcome, created_at, status) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `insert into integration_proposals(id, project_id, source_lane_ids_json, base_branch, steps_json, pairwise_results_json, lane_summaries_json, overall_outcome, created_at, status, preferred_integration_lane_id) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           proposalId,
           projectId,
@@ -3267,7 +3376,8 @@ export function createPrService({
           JSON.stringify(laneSummaries),
           overallOutcome,
           now,
-          "proposed"
+          "proposed",
+          mergeIntoLaneId || null,
         ]
       );
     }
@@ -3347,14 +3457,23 @@ export function createPrService({
       steps_json: string;
       integration_lane_id: string | null;
       integration_lane_name: string | null;
+      preferred_integration_lane_id: string | null;
     }>(
-      `select id, source_lane_ids_json, base_branch, steps_json, integration_lane_id, integration_lane_name from integration_proposals where id = ?`,
+      `select id, source_lane_ids_json, base_branch, steps_json, integration_lane_id, integration_lane_name, preferred_integration_lane_id from integration_proposals where id = ?`,
       [args.proposalId]
     );
     if (!proposalRow) throw new Error(`Proposal not found: ${args.proposalId}`);
 
     const sourceLaneIds = JSON.parse(String(proposalRow.source_lane_ids_json)) as string[];
     const existingIntegrationLaneId = asString(proposalRow.integration_lane_id).trim();
+    const preferredFromRow = asString(proposalRow.preferred_integration_lane_id).trim() || null;
+    const preferredIntegrationLaneId =
+      args.preferredIntegrationLaneId !== undefined
+        ? (asString(args.preferredIntegrationLaneId).trim() || null)
+        : preferredFromRow;
+    if (preferredIntegrationLaneId && sourceLaneIds.includes(preferredIntegrationLaneId)) {
+      throw new Error("Preferred integration lane cannot be one of the source lanes.");
+    }
 
     let result: CreateIntegrationPrResult;
     if (existingIntegrationLaneId) {
@@ -3369,9 +3488,11 @@ export function createPrService({
       });
     } else {
       const availableLanes = await laneService.list({ includeArchived: false });
+      const dirtyCheckLaneIds = [...sourceLaneIds];
+      if (preferredIntegrationLaneId) dirtyCheckLaneIds.push(preferredIntegrationLaneId);
       assertDirtyWorktreesAllowed({
         lanes: availableLanes,
-        laneIds: sourceLaneIds,
+        laneIds: dirtyCheckLaneIds,
         allowDirtyWorktree: args.allowDirtyWorktree,
       });
 
@@ -3418,6 +3539,9 @@ export function createPrService({
               || null
             )
           : null,
+      ...(args.preferredIntegrationLaneId !== undefined
+        ? { preferred_integration_lane_id: preferredIntegrationLaneId }
+        : {}),
       integration_lane_id: result.integrationLaneId,
       linked_group_id: result.groupId,
       linked_pr_id: result.pr.id,
@@ -3914,6 +4038,16 @@ export function createPrService({
     if (args.body !== undefined) { sets.push("body = ?"); params.push(args.body); }
     if (args.draft !== undefined) { sets.push("draft = ?"); params.push(args.draft ? 1 : 0); }
     if (args.integrationLaneName !== undefined) { sets.push("integration_lane_name = ?"); params.push(args.integrationLaneName); }
+    if (args.preferredIntegrationLaneId !== undefined) {
+      sets.push("preferred_integration_lane_id = ?");
+      params.push(args.preferredIntegrationLaneId?.trim() || null);
+    }
+    if (args.clearIntegrationBinding) {
+      sets.push("integration_lane_id = ?");
+      params.push(null);
+      sets.push("resolution_state_json = ?");
+      params.push(null);
+    }
     if (sets.length === 0) return;
     params.push(args.proposalId);
     db.run(`update integration_proposals set ${sets.join(", ")} where id = ?`, params);
@@ -3957,9 +4091,10 @@ export function createPrService({
     const proposalRow = db.get<{
       id: string; source_lane_ids_json: string; base_branch: string;
       steps_json: string; overall_outcome: string; integration_lane_name: string | null;
-      integration_lane_id: string | null; resolution_state_json: string | null; created_at: string;
+      integration_lane_id: string | null; preferred_integration_lane_id: string | null;
+      resolution_state_json: string | null; created_at: string;
     }>(
-      `select id, source_lane_ids_json, base_branch, steps_json, overall_outcome, integration_lane_name, integration_lane_id, resolution_state_json, created_at from integration_proposals where id = ?`,
+      `select id, source_lane_ids_json, base_branch, steps_json, overall_outcome, integration_lane_name, integration_lane_id, preferred_integration_lane_id, resolution_state_json, created_at from integration_proposals where id = ?`,
       [args.proposalId]
     );
     if (!proposalRow) throw new Error(`Proposal not found: ${args.proposalId}`);
@@ -3975,6 +4110,10 @@ export function createPrService({
       throw new Error(`Could not map base branch "${String(proposalRow.base_branch)}" to an active lane. Create or attach that lane first.`);
     }
     const laneMap = new Map(allLanes.map((l) => [l.id, l]));
+    const preferredIntegrationLaneId = asString(proposalRow.preferred_integration_lane_id).trim();
+    if (preferredIntegrationLaneId && preflight.uniqueSourceLaneIds.includes(preferredIntegrationLaneId)) {
+      throw new Error("Preferred integration lane cannot be one of the source lanes.");
+    }
     const existingIntegrationLaneId = asString(proposalRow.integration_lane_id).trim();
     if (existingIntegrationLaneId) {
       const existingLane = laneMap.get(existingIntegrationLaneId);
@@ -4001,11 +4140,18 @@ export function createPrService({
     }
     const shortId = args.proposalId.slice(0, 8);
     const integrationLaneName = String(proposalRow.integration_lane_name ?? "").trim() || `integration/${shortId}`;
-    const integrationLane = await laneService.createChild({
-      parentLaneId: preflight.baseLane.id,
-      name: integrationLaneName,
-      description: `Integration lane for proposal ${args.proposalId}`
-    });
+    let integrationLane: LaneSummary;
+    if (preferredIntegrationLaneId) {
+      const adopt = laneMap.get(preferredIntegrationLaneId);
+      if (!adopt) throw new Error(`Preferred integration lane not found: ${preferredIntegrationLaneId}`);
+      integrationLane = adopt;
+    } else {
+      integrationLane = await laneService.createChild({
+        parentLaneId: preflight.baseLane.id,
+        name: integrationLaneName,
+        description: `Integration lane for proposal ${args.proposalId}`
+      });
+    }
 
     const mergedCleanLanes: string[] = [];
     const conflictingLanes: string[] = [];

--- a/apps/desktop/src/main/services/prs/prService.ts
+++ b/apps/desktop/src/main/services/prs/prService.ts
@@ -164,6 +164,7 @@ type IntegrationProposalRow = {
   completed_at: string | null;
   cleanup_declined_at: string | null;
   cleanup_completed_at: string | null;
+  merge_into_head_sha: string | null;
 };
 
 type PrGroupLookupRow = {
@@ -1284,6 +1285,7 @@ export function createPrService({
       draft: Boolean(row.draft),
       integrationLaneName: String(row.integration_lane_name || ""),
       preferredIntegrationLaneId: asString(row.preferred_integration_lane_id).trim() || null,
+      mergeIntoHeadSha: asString(row.merge_into_head_sha).trim() || null,
       status: String(row.status) as IntegrationProposal["status"],
       integrationLaneId,
       linkedGroupId: asString(row.linked_group_id).trim() || null,
@@ -2925,14 +2927,10 @@ export function createPrService({
 
     let mergeIntoHeadSha: string | null = null;
     if (mergeIntoLane) {
-      try {
-        mergeIntoHeadSha = (await runGitOrThrow(
-          ["rev-parse", branchNameFromRef(mergeIntoLane.branchRef)],
-          { cwd: projectRoot, timeoutMs: 10_000 }
-        )).trim();
-      } catch {
-        mergeIntoHeadSha = null;
-      }
+      mergeIntoHeadSha = (await runGitOrThrow(
+        ["rev-parse", branchNameFromRef(mergeIntoLane.branchRef)],
+        { cwd: projectRoot, timeoutMs: 10_000 }
+      )).trim();
     }
     const sequentialStartSha = mergeIntoHeadSha ?? baseSha;
 
@@ -3352,6 +3350,7 @@ export function createPrService({
       createdAt: now,
       status: "proposed",
       preferredIntegrationLaneId: mergeIntoLaneId || null,
+      mergeIntoHeadSha: mergeIntoHeadSha ?? null,
       linkedGroupId: null,
       linkedPrId: null,
       workflowDisplayState: "active",
@@ -3365,7 +3364,7 @@ export function createPrService({
 
     if (args.persist !== false) {
       db.run(
-        `insert into integration_proposals(id, project_id, source_lane_ids_json, base_branch, steps_json, pairwise_results_json, lane_summaries_json, overall_outcome, created_at, status, preferred_integration_lane_id) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `insert into integration_proposals(id, project_id, source_lane_ids_json, base_branch, steps_json, pairwise_results_json, lane_summaries_json, overall_outcome, created_at, status, preferred_integration_lane_id, merge_into_head_sha) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           proposalId,
           projectId,
@@ -3378,6 +3377,7 @@ export function createPrService({
           now,
           "proposed",
           mergeIntoLaneId || null,
+          mergeIntoHeadSha ?? null,
         ]
       );
     }
@@ -4042,6 +4042,10 @@ export function createPrService({
       sets.push("preferred_integration_lane_id = ?");
       params.push(args.preferredIntegrationLaneId?.trim() || null);
     }
+    if (args.mergeIntoHeadSha !== undefined) {
+      sets.push("merge_into_head_sha = ?");
+      params.push(args.mergeIntoHeadSha?.trim() || null);
+    }
     if (args.clearIntegrationBinding) {
       sets.push("integration_lane_id = ?");
       params.push(null);
@@ -4092,9 +4096,10 @@ export function createPrService({
       id: string; source_lane_ids_json: string; base_branch: string;
       steps_json: string; overall_outcome: string; integration_lane_name: string | null;
       integration_lane_id: string | null; preferred_integration_lane_id: string | null;
+      merge_into_head_sha: string | null;
       resolution_state_json: string | null; created_at: string;
     }>(
-      `select id, source_lane_ids_json, base_branch, steps_json, overall_outcome, integration_lane_name, integration_lane_id, preferred_integration_lane_id, resolution_state_json, created_at from integration_proposals where id = ?`,
+      `select id, source_lane_ids_json, base_branch, steps_json, overall_outcome, integration_lane_name, integration_lane_id, preferred_integration_lane_id, merge_into_head_sha, resolution_state_json, created_at from integration_proposals where id = ?`,
       [args.proposalId]
     );
     if (!proposalRow) throw new Error(`Proposal not found: ${args.proposalId}`);
@@ -4114,6 +4119,13 @@ export function createPrService({
     if (preferredIntegrationLaneId && preflight.uniqueSourceLaneIds.includes(preferredIntegrationLaneId)) {
       throw new Error("Preferred integration lane cannot be one of the source lanes.");
     }
+    const dirtyCheckLaneIds = [...preflight.uniqueSourceLaneIds];
+    if (preferredIntegrationLaneId) dirtyCheckLaneIds.push(preferredIntegrationLaneId);
+    assertDirtyWorktreesAllowed({
+      lanes: allLanes,
+      laneIds: dirtyCheckLaneIds,
+      allowDirtyWorktree: args.allowDirtyWorktree,
+    });
     const existingIntegrationLaneId = asString(proposalRow.integration_lane_id).trim();
     if (existingIntegrationLaneId) {
       const existingLane = laneMap.get(existingIntegrationLaneId);
@@ -4144,6 +4156,27 @@ export function createPrService({
     if (preferredIntegrationLaneId) {
       const adopt = laneMap.get(preferredIntegrationLaneId);
       if (!adopt) throw new Error(`Preferred integration lane not found: ${preferredIntegrationLaneId}`);
+      const storedMergeHead = asString(proposalRow.merge_into_head_sha).trim();
+      try {
+        const currentHead = (await runGitOrThrow(
+          ["rev-parse", "HEAD"],
+          { cwd: adopt.worktreePath, timeoutMs: 10_000 }
+        )).trim();
+        if (storedMergeHead && currentHead && storedMergeHead !== currentHead) {
+          logger.warn("prs.integration_merge_into_head_drift", {
+            proposalId: args.proposalId,
+            preferredIntegrationLaneId,
+            storedHead: storedMergeHead,
+            currentHead,
+          });
+        }
+      } catch (error) {
+        logger.warn("prs.integration_merge_into_head_read_failed", {
+          proposalId: args.proposalId,
+          preferredIntegrationLaneId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
       integrationLane = adopt;
     } else {
       integrationLane = await laneService.createChild({

--- a/apps/desktop/src/main/services/state/kvDb.missionsMigration.test.ts
+++ b/apps/desktop/src/main/services/state/kvDb.missionsMigration.test.ts
@@ -82,6 +82,7 @@ describe("kvDb mission schema migration", () => {
         "status",
         "integration_lane_id",
         "preferred_integration_lane_id",
+        "merge_into_head_sha",
         "resolution_state_json",
         "pairwise_results_json",
         "lane_summaries_json"

--- a/apps/desktop/src/main/services/state/kvDb.missionsMigration.test.ts
+++ b/apps/desktop/src/main/services/state/kvDb.missionsMigration.test.ts
@@ -81,6 +81,7 @@ describe("kvDb mission schema migration", () => {
         "integration_lane_name",
         "status",
         "integration_lane_id",
+        "preferred_integration_lane_id",
         "resolution_state_json",
         "pairwise_results_json",
         "lane_summaries_json"

--- a/apps/desktop/src/main/services/state/kvDb.ts
+++ b/apps/desktop/src/main/services/state/kvDb.ts
@@ -1161,6 +1161,7 @@ function migrate(db: { run: (sql: string, params?: SqlValue[]) => void }) {
   try { db.run("alter table integration_proposals add column completed_at text"); } catch {}
   try { db.run("alter table integration_proposals add column cleanup_declined_at text"); } catch {}
   try { db.run("alter table integration_proposals add column cleanup_completed_at text"); } catch {}
+  try { db.run("alter table integration_proposals add column preferred_integration_lane_id text"); } catch {}
 
   // Queue landing state table (crash recovery for sequential landing)
   db.run(`

--- a/apps/desktop/src/main/services/state/kvDb.ts
+++ b/apps/desktop/src/main/services/state/kvDb.ts
@@ -1162,6 +1162,7 @@ function migrate(db: { run: (sql: string, params?: SqlValue[]) => void }) {
   try { db.run("alter table integration_proposals add column cleanup_declined_at text"); } catch {}
   try { db.run("alter table integration_proposals add column cleanup_completed_at text"); } catch {}
   try { db.run("alter table integration_proposals add column preferred_integration_lane_id text"); } catch {}
+  try { db.run("alter table integration_proposals add column merge_into_head_sha text"); } catch {}
 
   // Queue landing state table (crash recovery for sequential landing)
   db.run(`

--- a/apps/desktop/src/renderer/components/prs/CreatePrModal.tsx
+++ b/apps/desktop/src/renderer/components/prs/CreatePrModal.tsx
@@ -505,6 +505,7 @@ export function CreatePrModal({
   const [integrationTitle, setIntegrationTitle] = React.useState("");
   const [integrationBody, setIntegrationBody] = React.useState("");
   const [integrationDraft, setIntegrationDraft] = React.useState(false);
+  const [integrationMergeIntoLaneId, setIntegrationMergeIntoLaneId] = React.useState("");
   const [proposal, setProposal] = React.useState<IntegrationProposal | null>(null);
   const [simulating, setSimulating] = React.useState(false);
   const [laneSyncStatusById, setLaneSyncStatusById] = React.useState<Record<string, GitUpstreamSyncStatus | null>>({});
@@ -622,6 +623,7 @@ export function CreatePrModal({
       setDraftError(null);
       setIntegrationSources([]);
       setIntegrationBaseBranch("");
+      setIntegrationMergeIntoLaneId("");
       setIntegrationName("");
       setIntegrationTitle("");
       setIntegrationBody("");
@@ -715,9 +717,15 @@ export function CreatePrModal({
     try {
       const trimmedIntegrationBaseBranch = integrationBaseBranch.trim();
       const baseBranch = trimmedIntegrationBaseBranch || branchNameFromRef(primaryLane?.branchRef ?? "main");
+      const mergeInto = integrationMergeIntoLaneId.trim();
+      if (mergeInto && integrationSources.includes(mergeInto)) {
+        setExecError("Merge-into lane cannot be one of the source lanes.");
+        return;
+      }
       const result = await window.ade.prs.simulateIntegration({
         sourceLaneIds: integrationSources,
         baseBranch,
+        mergeIntoLaneId: mergeInto || null,
       });
       setProposal(result);
       // Auto-generate a name if empty
@@ -784,6 +792,7 @@ export function CreatePrModal({
           body: integrationBody,
           draft: integrationDraft,
           integrationLaneName: integrationName || `integration/${Date.now().toString(36)}`,
+          preferredIntegrationLaneId: integrationMergeIntoLaneId.trim() || null,
         });
         lastProgressLabel = "Creating integration lane";
         setIntegrationProgress("Creating integration lane...");
@@ -811,6 +820,19 @@ export function CreatePrModal({
   };
 
   const nonPrimaryLanes = React.useMemo(() => lanes.filter((l) => l.laneType !== "primary"), [lanes]);
+
+  const integrationMergeIntoOptions = React.useMemo(
+    () => [...nonPrimaryLanes].sort((a, b) => a.name.localeCompare(b.name)),
+    [nonPrimaryLanes],
+  );
+
+  React.useEffect(() => {
+    if (!integrationMergeIntoLaneId) return;
+    if (integrationSources.includes(integrationMergeIntoLaneId)) {
+      setIntegrationMergeIntoLaneId("");
+      setProposal(null);
+    }
+  }, [integrationMergeIntoLaneId, integrationSources]);
 
   const toggleQueueLane = (laneId: string) => {
     setQueueLaneIds((prev) =>
@@ -1497,6 +1519,37 @@ export function CreatePrModal({
                         rebaseLaneIds={selectedIntegrationRebaseLaneIds}
                         onOpenRebase={openRebaseTab}
                       />
+                    </div>
+
+                    <div>
+                      <span style={labelStyle}>MERGE INTO (OPTIONAL)</span>
+                      <select
+                        aria-label="Merge integration into existing lane"
+                        value={integrationMergeIntoLaneId}
+                        onChange={(e) => {
+                          setIntegrationMergeIntoLaneId(e.target.value);
+                          setProposal(null);
+                        }}
+                        style={selectStyle}
+                        onFocus={(ev) => { ev.currentTarget.style.borderColor = C.accent; }}
+                        onBlur={(ev) => { ev.currentTarget.style.borderColor = C.borderSubtle; }}
+                      >
+                        <option value="">New integration branch</option>
+                        {integrationMergeIntoOptions.map((lane) => (
+                          <option key={lane.id} value={lane.id} disabled={integrationSources.includes(lane.id)}>
+                            {lane.name}{integrationSources.includes(lane.id) ? " (source)" : ""}
+                          </option>
+                        ))}
+                      </select>
+                      <div style={{
+                        marginTop: 6,
+                        fontSize: 10,
+                        fontFamily: "var(--font-sans)",
+                        color: C.textMuted,
+                        lineHeight: "14px",
+                      }}>
+                        When set, simulation includes conflicts against that lane&apos;s current HEAD. Commit prepares merges there instead of creating a new lane.
+                      </div>
                     </div>
 
                     {/* Simulate button */}

--- a/apps/desktop/src/renderer/components/prs/CreatePrModal.tsx
+++ b/apps/desktop/src/renderer/components/prs/CreatePrModal.tsx
@@ -796,8 +796,12 @@ export function CreatePrModal({
         });
         lastProgressLabel = "Creating integration lane";
         setIntegrationProgress("Creating integration lane...");
-        await window.ade.prs.createIntegrationLaneForProposal({
-          proposalId: proposal.proposalId,
+        await runWithDirtyWorktreeConfirmation({
+          confirmMessage: "Continue and prepare the integration lane anyway?",
+          run: async (allowDirtyWorktree) => window.ade.prs.createIntegrationLaneForProposal({
+            proposalId: proposal.proposalId,
+            ...(allowDirtyWorktree ? { allowDirtyWorktree: true } : {}),
+          }),
         });
         setIntegrationProgress(null);
         // No PR created — proposal saved for later commit from Integration tab

--- a/apps/desktop/src/renderer/components/prs/shared/PrAiResolverPanel.tsx
+++ b/apps/desktop/src/renderer/components/prs/shared/PrAiResolverPanel.tsx
@@ -37,6 +37,8 @@ type PrAiResolverPanelProps = {
   startLabel?: string;
   defaultExpanded?: boolean;
   sessionShellClassName?: string;
+  /** Optional notes appended to the generated resolver prompt (e.g. “keep UI from lane A”). */
+  showResolverInstructions?: boolean;
 };
 
 function normalizeReasoning(value: string): string | null {
@@ -91,12 +93,14 @@ export function PrAiResolverPanel({
   startLabel = "Start AI Resolver",
   defaultExpanded = true,
   sessionShellClassName,
+  showResolverInstructions = false,
 }: PrAiResolverPanelProps) {
   const { resolverSessionsByContextKey, upsertResolverSession } = usePrs();
   const [launching, setLaunching] = React.useState(false);
   const [status, setStatus] = React.useState<"idle" | "starting" | "running" | "completed" | "failed" | "cancelled">("idle");
   const [message, setMessage] = React.useState<string | null>(null);
   const [expanded, setExpanded] = React.useState(defaultExpanded);
+  const [resolverInstructions, setResolverInstructions] = React.useState("");
   const terminalStatusRef = React.useRef<PrAiResolverCompletion["status"] | null>(null);
   const contextKey = React.useMemo(() => (context ? buildPrAiResolutionContextKey(context) : null), [context]);
   const activeSession = React.useMemo(
@@ -116,6 +120,10 @@ export function PrAiResolverPanel({
       terminalStatusRef.current = null;
     }
   }, [activeSession]);
+
+  React.useEffect(() => {
+    setResolverInstructions("");
+  }, [contextKey]);
 
   React.useEffect(() => {
     if (!context || !contextKey || activeSession) return;
@@ -173,11 +181,13 @@ export function PrAiResolverPanel({
     setStatus("starting");
     terminalStatusRef.current = null;
     try {
+      const trimmedInstructions = resolverInstructions.trim();
       const result = await window.ade.prs.aiResolutionStart({
         model: displayModelId,
         reasoning: normalizeReasoning(displayReasoning),
         permissionMode: displayPermissionMode,
         context,
+        ...(trimmedInstructions ? { additionalInstructions: trimmedInstructions } : {}),
       });
       if (result.status !== "started") {
         setStatus("failed");
@@ -208,6 +218,7 @@ export function PrAiResolverPanel({
     displayReasoning,
     launching,
     onStarted,
+    resolverInstructions,
     upsertResolverSession,
   ]);
 
@@ -262,6 +273,21 @@ export function PrAiResolverPanel({
 
       {expanded ? (!sessionId ? (
         <div className="space-y-4 px-4 py-4">
+          {showResolverInstructions ? (
+            <div className="space-y-1.5">
+              <label className="block font-mono text-[9px] font-bold uppercase tracking-wider text-fg/50">
+                Resolver instructions (optional)
+              </label>
+              <textarea
+                value={resolverInstructions}
+                onChange={(e) => setResolverInstructions(e.target.value)}
+                placeholder="e.g. Prefer UI from the first lane; keep server logic from the second."
+                rows={3}
+                disabled={launching}
+                className="w-full resize-y border border-border/20 bg-bg/60 px-3 py-2 font-mono text-[11px] leading-relaxed text-fg/85 placeholder:text-fg/35 focus:border-border/40 focus:outline-none"
+              />
+            </div>
+          ) : null}
           <div className="flex flex-wrap items-center gap-3">
             <PrResolverLaunchControls
               modelId={displayModelId}

--- a/apps/desktop/src/renderer/components/prs/tabs/IntegrationTab.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/IntegrationTab.tsx
@@ -687,7 +687,7 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
         mergeIntoLaneId: p.preferredIntegrationLaneId?.trim() || null,
       });
 
-      if (p.title || p.body || p.draft || p.integrationLaneName || p.preferredIntegrationLaneId) {
+      if (p.title || p.body || p.draft || p.integrationLaneName || p.preferredIntegrationLaneId || result.mergeIntoHeadSha) {
         await window.ade.prs.updateProposal({
           proposalId: result.proposalId,
           title: p.title,
@@ -695,6 +695,7 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
           draft: p.draft,
           integrationLaneName: p.integrationLaneName,
           preferredIntegrationLaneId: p.preferredIntegrationLaneId?.trim() || null,
+          mergeIntoHeadSha: result.mergeIntoHeadSha ?? null,
         });
       }
 
@@ -1032,9 +1033,21 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
     }
     setCreateLaneBusy(true);
     try {
-      const result = await window.ade.prs.createIntegrationLaneForProposal({
-        proposalId: selectedProposal.proposalId,
-      });
+      const runCreate = async (allowDirtyWorktree: boolean) =>
+        window.ade.prs.createIntegrationLaneForProposal({
+          proposalId: selectedProposal.proposalId,
+          ...(allowDirtyWorktree ? { allowDirtyWorktree: true } : {}),
+        });
+      let result: Awaited<ReturnType<typeof window.ade.prs.createIntegrationLaneForProposal>>;
+      try {
+        result = await runCreate(false);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!isDirtyWorktreeErrorMessage(message) || !window.confirm(`${stripDirtyWorktreePrefix(message)}\n\nContinue and prepare the integration lane anyway?`)) {
+          throw error;
+        }
+        result = await runCreate(true);
+      }
       const nextState: IntegrationResolutionState = {
         integrationLaneId: result.integrationLaneId,
         stepResolutions: {},
@@ -1215,9 +1228,13 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
     if (!selectedPr) return [];
     return selectedPrLiveModel?.liveSourceLaneIds ?? [selectedPr.laneId];
   }, [selectedPr, selectedPrLiveModel]);
-  const liveSimulationKey = React.useMemo(() => liveSimulationLaneIds.join("|"), [liveSimulationLaneIds]);
 
   const liveIntegrationLaneId = selectedPrLiveModel?.integrationLaneId ?? null;
+
+  const liveSimulationKey = React.useMemo(
+    () => [liveSimulationLaneIds.join("|"), liveIntegrationLaneId ?? ""].join(":"),
+    [liveIntegrationLaneId, liveSimulationLaneIds],
+  );
 
   const resolverTargetLaneId = React.useMemo(() => {
     if (selectedPrLiveModel?.baseLaneId) return selectedPrLiveModel.baseLaneId;
@@ -1232,13 +1249,15 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
 
   const mergeIntoLaneSelectOptions = React.useMemo(() => {
     const out: { id: string; name: string }[] = [];
+    const sourceSet = new Set(selectedProposal?.sourceLaneIds ?? []);
     for (const lane of lanes) {
       if (lane.laneType === "primary") continue;
+      if (sourceSet.has(lane.id)) continue;
       out.push({ id: lane.id, name: lane.name });
     }
     out.sort((a, b) => a.name.localeCompare(b.name));
     return out;
-  }, [lanes]);
+  }, [lanes, selectedProposal?.sourceLaneIds]);
 
   React.useEffect(() => {
     const fromProposal = selectedProposal?.preferredIntegrationLaneId?.trim() ?? "";
@@ -1261,18 +1280,27 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
         baseBranch: selectedProposal.baseBranch,
         mergeIntoLaneId: trimmed || null,
       });
-      await window.ade.prs.deleteProposal({ proposalId: oldId, deleteIntegrationLane: false });
       await window.ade.prs.updateProposal({
         proposalId: persisted.proposalId,
         preferredIntegrationLaneId: trimmed || null,
+        mergeIntoHeadSha: persisted.mergeIntoHeadSha ?? null,
         ...(selectedProposal.title ? { title: selectedProposal.title } : {}),
         ...(selectedProposal.body !== undefined ? { body: selectedProposal.body } : {}),
         ...(selectedProposal.draft !== undefined ? { draft: selectedProposal.draft } : {}),
         ...(selectedProposal.integrationLaneName ? { integrationLaneName: selectedProposal.integrationLaneName } : {}),
       });
+      let cleanupWarning: string | null = null;
+      try {
+        await window.ade.prs.deleteProposal({ proposalId: oldId, deleteIntegrationLane: false });
+      } catch (cleanupError) {
+        cleanupWarning = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+      }
       setResolutionState(null);
       await loadProposals();
       setSelectedProposalId(persisted.proposalId);
+      if (cleanupWarning) {
+        setCommitError(`Updated merge target, but the previous proposal row could not be removed: ${cleanupWarning}`);
+      }
     } catch (err: unknown) {
       setCommitError(err instanceof Error ? err.message : String(err));
       await loadProposals();
@@ -1297,7 +1325,7 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
     }
     if (selectedProposal.preferredIntegrationLaneId) {
       advisories.push(
-        `Simulation includes this lane's current HEAD as the merge base: ${laneById.get(selectedProposal.preferredIntegrationLaneId)?.name ?? selectedProposal.preferredIntegrationLaneId}. Child-vs-child conflicts still use ${selectedProposal.baseBranch} as the common ancestor.`,
+        `Sequential preview merges into this lane's current HEAD: ${laneById.get(selectedProposal.preferredIntegrationLaneId)?.name ?? selectedProposal.preferredIntegrationLaneId}. Child-vs-child pairwise checks still use ${selectedProposal.baseBranch} as the merge base.`,
       );
     }
     if (!selectedProposalTargetLaneId) {
@@ -2066,7 +2094,7 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
         >
           <SectionHeader>MERGE INTO LANE</SectionHeader>
           <p className="font-mono" style={{ fontSize: 10, color: "#71717A", marginBottom: 12, lineHeight: "16px" }}>
-            Choose an existing lane as the integration worktree (for example the parent prompt lane). Simulation then includes conflicts against that lane&apos;s current HEAD; source lanes still merge in list order.
+            Choose an existing lane as the integration lane (for example the parent prompt lane). Simulation then includes conflicts against that lane&apos;s current HEAD; source lanes still merge in list order.
           </p>
           <div className="flex flex-wrap items-end" style={{ gap: 10 }}>
             <div className="min-w-0 flex-1" style={{ minWidth: 200 }}>
@@ -2145,7 +2173,7 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
               </div>
               <button
                 type="button"
-                disabled={resimBusy}
+                disabled={resimBusy || mergeIntoLaneBusy}
                 className="inline-flex items-center font-mono font-bold uppercase tracking-[1px] transition-all duration-100"
                 style={{
                   fontSize: 10,
@@ -2154,8 +2182,8 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
                   background: "transparent",
                   color: "#F59E0B",
                   border: "1px solid #F59E0B50",
-                  cursor: resimBusy ? "not-allowed" : "pointer",
-                  opacity: resimBusy ? 0.5 : 1,
+                  cursor: resimBusy || mergeIntoLaneBusy ? "not-allowed" : "pointer",
+                  opacity: resimBusy || mergeIntoLaneBusy ? 0.5 : 1,
                 }}
                 onClick={() => void handleResimulate(selectedProposal)}
               >
@@ -2866,7 +2894,7 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
             {/* Create PR on GitHub */}
             {(() => {
               const hasUnresolved = selectedProposal.overallOutcome !== "clean" && !allStepsResolved;
-              const isDisabled = commitBusy || selectedProposal.overallOutcome === "blocked" || hasUnresolved || !selectedProposalTargetLaneId;
+              const isDisabled = commitBusy || mergeIntoLaneBusy || selectedProposal.overallOutcome === "blocked" || hasUnresolved || !selectedProposalTargetLaneId;
               return (
                 <button
                   type="button"
@@ -2922,17 +2950,17 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
             {/* Re-simulate */}
             <button
               type="button"
-              disabled={resimBusy}
+              disabled={resimBusy || mergeIntoLaneBusy}
               className="inline-flex items-center font-mono font-bold uppercase tracking-[1px] transition-all duration-100"
               style={{
                 fontSize: 10,
                 height: 32,
                 padding: "0 14px",
                 background: "transparent",
-                color: resimBusy ? "#52525B" : "#A78BFA",
+                color: resimBusy || mergeIntoLaneBusy ? "#52525B" : "#A78BFA",
                 border: "1px solid #A78BFA30",
-                cursor: resimBusy ? "not-allowed" : "pointer",
-                opacity: resimBusy ? 0.4 : 1,
+                cursor: resimBusy || mergeIntoLaneBusy ? "not-allowed" : "pointer",
+                opacity: resimBusy || mergeIntoLaneBusy ? 0.4 : 1,
               }}
               onClick={() => void handleResimulate(selectedProposal)}
             >
@@ -2947,17 +2975,17 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
             {/* Delete proposal */}
             <button
               type="button"
-              disabled={deleteProposalBusy}
+              disabled={deleteProposalBusy || mergeIntoLaneBusy}
               className="inline-flex items-center font-mono font-bold uppercase tracking-[1px] transition-all duration-100"
               style={{
                 fontSize: 10,
                 height: 32,
                 padding: "0 14px",
                 background: "transparent",
-                color: deleteProposalBusy ? "#52525B" : "#EF4444",
+                color: deleteProposalBusy || mergeIntoLaneBusy ? "#52525B" : "#EF4444",
                 border: "1px solid #EF444430",
-                cursor: deleteProposalBusy ? "not-allowed" : "pointer",
-                opacity: deleteProposalBusy ? 0.4 : 1,
+                cursor: deleteProposalBusy || mergeIntoLaneBusy ? "not-allowed" : "pointer",
+                opacity: deleteProposalBusy || mergeIntoLaneBusy ? 0.4 : 1,
                 marginLeft: "auto",
               }}
               onClick={() => setDeleteProposalConfirm((prev) => !prev)}
@@ -3138,7 +3166,7 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
       children: detailPane,
     },
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }), [prs, selectedPr, selectedPrId, mergeContextByPrId, laneById, mergeSourcesResolved, liveIntegrationLaneId, liveIntegrationRebaseNeed, liveSimulationLaneIds, resolverTargetLaneId, simulateResult, simulateBusy, simulateError, resolverOpen, proposalResolverConfig, deleteConfirm, deleteBusy, deleteCloseGh, hasConflicts, rebaseNeeds, rebaseNeedByLaneId, autoRebaseStatuses, setActiveTab, onSelectPr, onRefresh, proposals, proposalsLoaded, selectedProposal, selectedProposalId, selectedProposalRebaseLaneIds, selectedPrLiveModel, commitBusy, commitError, resimBusy, deleteProposalBusy, expandedPairKeys, resolutionState, activeWorkerStepId, createLaneBusy, resolvingLaneId, resolutionPanelDismissed, allStepsResolved, proposalLaneCards, proposalConflictingPairs, proposalConflictSteps, totalProposalConflictFiles, urlProposalId, conflictPairCountByLaneId, isLegacySequentialProposal, nextManualResolutionLaneId]);
+  }), [prs, selectedPr, selectedPrId, mergeContextByPrId, laneById, mergeSourcesResolved, liveIntegrationLaneId, liveIntegrationRebaseNeed, liveSimulationLaneIds, liveSimulationKey, resolverTargetLaneId, simulateResult, simulateBusy, simulateError, resolverOpen, proposalResolverConfig, deleteConfirm, deleteBusy, deleteCloseGh, hasConflicts, rebaseNeeds, rebaseNeedByLaneId, autoRebaseStatuses, setActiveTab, onSelectPr, onRefresh, proposals, proposalsLoaded, selectedProposal, selectedProposalId, selectedProposalRebaseLaneIds, selectedPrLiveModel, commitBusy, commitError, resimBusy, mergeIntoLaneBusy, deleteProposalBusy, expandedPairKeys, resolutionState, activeWorkerStepId, createLaneBusy, resolvingLaneId, resolutionPanelDismissed, allStepsResolved, proposalLaneCards, proposalConflictingPairs, proposalConflictSteps, totalProposalConflictFiles, urlProposalId, conflictPairCountByLaneId, isLegacySequentialProposal, nextManualResolutionLaneId]);
 
   return <PaneTilingLayout layoutId="prs:integration:v1" tree={PR_TAB_TILING_TREE} panes={paneConfigs} className="flex-1 min-h-0" />;
 }

--- a/apps/desktop/src/renderer/components/prs/tabs/IntegrationTab.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/IntegrationTab.tsx
@@ -517,6 +517,8 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
   const [createLaneBusy, setCreateLaneBusy] = React.useState(false);
   const [resolvingLaneId, setResolvingLaneId] = React.useState<string | null>(null);
   const [resolutionPanelDismissed, setResolutionPanelDismissed] = React.useState(false);
+  const [mergeIntoLaneDraft, setMergeIntoLaneDraft] = React.useState("");
+  const [mergeIntoLaneBusy, setMergeIntoLaneBusy] = React.useState(false);
 
   const loadProposals = React.useCallback(async () => {
     try {
@@ -682,15 +684,17 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
       const result = await window.ade.prs.simulateIntegration({
         sourceLaneIds: p.sourceLaneIds,
         baseBranch: p.baseBranch,
+        mergeIntoLaneId: p.preferredIntegrationLaneId?.trim() || null,
       });
 
-      if (p.title || p.body || p.draft || p.integrationLaneName) {
+      if (p.title || p.body || p.draft || p.integrationLaneName || p.preferredIntegrationLaneId) {
         await window.ade.prs.updateProposal({
           proposalId: result.proposalId,
           title: p.title,
           body: p.body,
           draft: p.draft,
           integrationLaneName: p.integrationLaneName,
+          preferredIntegrationLaneId: p.preferredIntegrationLaneId?.trim() || null,
         });
       }
 
@@ -1225,6 +1229,57 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
     if (!selectedProposal) return null;
     return resolveTargetLaneId(selectedProposal.baseBranch);
   }, [resolveTargetLaneId, selectedProposal]);
+
+  const mergeIntoLaneSelectOptions = React.useMemo(() => {
+    const out: { id: string; name: string }[] = [];
+    for (const lane of lanes) {
+      if (lane.laneType === "primary") continue;
+      out.push({ id: lane.id, name: lane.name });
+    }
+    out.sort((a, b) => a.name.localeCompare(b.name));
+    return out;
+  }, [lanes]);
+
+  React.useEffect(() => {
+    const fromProposal = selectedProposal?.preferredIntegrationLaneId?.trim() ?? "";
+    setMergeIntoLaneDraft(fromProposal);
+  }, [selectedProposal?.proposalId, selectedProposal?.preferredIntegrationLaneId]);
+
+  const handleApplyMergeIntoTarget = React.useCallback(async () => {
+    if (!selectedProposal) return;
+    const trimmed = mergeIntoLaneDraft.trim();
+    if (trimmed && selectedProposal.sourceLaneIds.includes(trimmed)) {
+      setCommitError("Merge-into lane cannot be one of the source lanes.");
+      return;
+    }
+    setMergeIntoLaneBusy(true);
+    setCommitError(null);
+    try {
+      const oldId = selectedProposal.proposalId;
+      const persisted = await window.ade.prs.simulateIntegration({
+        sourceLaneIds: selectedProposal.sourceLaneIds,
+        baseBranch: selectedProposal.baseBranch,
+        mergeIntoLaneId: trimmed || null,
+      });
+      await window.ade.prs.deleteProposal({ proposalId: oldId, deleteIntegrationLane: false });
+      await window.ade.prs.updateProposal({
+        proposalId: persisted.proposalId,
+        preferredIntegrationLaneId: trimmed || null,
+        ...(selectedProposal.title ? { title: selectedProposal.title } : {}),
+        ...(selectedProposal.body !== undefined ? { body: selectedProposal.body } : {}),
+        ...(selectedProposal.draft !== undefined ? { draft: selectedProposal.draft } : {}),
+        ...(selectedProposal.integrationLaneName ? { integrationLaneName: selectedProposal.integrationLaneName } : {}),
+      });
+      setResolutionState(null);
+      await loadProposals();
+      setSelectedProposalId(persisted.proposalId);
+    } catch (err: unknown) {
+      setCommitError(err instanceof Error ? err.message : String(err));
+      await loadProposals();
+    } finally {
+      setMergeIntoLaneBusy(false);
+    }
+  }, [loadProposals, mergeIntoLaneDraft, selectedProposal]);
   const selectedProposalRebaseLaneIds = React.useMemo(
     () => (selectedProposal?.sourceLaneIds ?? []).filter((laneId) => rebaseNeedByLaneId.has(laneId)),
     [rebaseNeedByLaneId, selectedProposal?.sourceLaneIds],
@@ -1240,6 +1295,11 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
     if (selectedProposal.sourceLaneIds.length > 1) {
       advisories.push("ADE applies source lanes sequentially in the listed order when it builds the integration lane. Re-simulate before commit if you change merge precedence.");
     }
+    if (selectedProposal.preferredIntegrationLaneId) {
+      advisories.push(
+        `Simulation includes this lane's current HEAD as the merge base: ${laneById.get(selectedProposal.preferredIntegrationLaneId)?.name ?? selectedProposal.preferredIntegrationLaneId}. Child-vs-child conflicts still use ${selectedProposal.baseBranch} as the common ancestor.`,
+      );
+    }
     if (!selectedProposalTargetLaneId) {
       advisories.push(`No active lane currently maps to base branch "${selectedProposal.baseBranch}". Create or attach that lane before AI resolution or PR creation.`);
     }
@@ -1251,7 +1311,7 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
     }
     advisories.push("The AI resolver edits the integration lane with bounded project/lane/conflict context. Treat the Run tab as the final validation gate before merging the resulting PR.");
     return advisories;
-  }, [selectedProposal, selectedProposalRebaseLaneIds.length, selectedProposalTargetLaneId]);
+  }, [laneById, selectedProposal, selectedProposalRebaseLaneIds.length, selectedProposalTargetLaneId]);
 
   const simulateAdvisories = React.useMemo(() => {
     if (!selectedPr || !simulateResult) return [];
@@ -1286,6 +1346,7 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
         sourceLaneIds,
         baseBranch,
         persist: false,
+        mergeIntoLaneId: liveIntegrationLaneId,
       });
       if (requestSeq !== simulateRequestSeqRef.current) return;
       setSimulateResult(result);
@@ -1841,6 +1902,7 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
             }}
             onDismiss={() => setResolverOpen(false)}
             startLabel="Start Integration Resolver"
+            showResolverInstructions
           />
         ) : null}
 
@@ -1993,6 +2055,65 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
         </div>
 
         <AdvisoryPanel messages={proposalAdvisories} />
+
+        <div
+          style={{
+            background: "#13101A",
+            border: "1px solid #1E1B26",
+            padding: 16,
+            marginBottom: 20,
+          }}
+        >
+          <SectionHeader>MERGE INTO LANE</SectionHeader>
+          <p className="font-mono" style={{ fontSize: 10, color: "#71717A", marginBottom: 12, lineHeight: "16px" }}>
+            Choose an existing lane as the integration worktree (for example the parent prompt lane). Simulation then includes conflicts against that lane&apos;s current HEAD; source lanes still merge in list order.
+          </p>
+          <div className="flex flex-wrap items-end" style={{ gap: 10 }}>
+            <div className="min-w-0 flex-1" style={{ minWidth: 200 }}>
+              <span className="font-mono font-bold uppercase tracking-[1px]" style={{ fontSize: 9, color: "#52525B", display: "block", marginBottom: 6 }}>
+                Target lane
+              </span>
+              <select
+                value={mergeIntoLaneDraft}
+                onChange={(e) => setMergeIntoLaneDraft(e.target.value)}
+                disabled={mergeIntoLaneBusy || resimBusy || commitBusy}
+                className="font-mono w-full"
+                style={{
+                  fontSize: 11,
+                  padding: "10px 12px",
+                  background: "#0C0A10",
+                  border: "1px solid #1E1B26",
+                  color: "#FAFAFA",
+                  borderRadius: 0,
+                }}
+              >
+                <option value="">New integration lane (default)</option>
+                {mergeIntoLaneSelectOptions.map((opt) => (
+                  <option key={opt.id} value={opt.id}>
+                    {opt.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <button
+              type="button"
+              disabled={mergeIntoLaneBusy || resimBusy || commitBusy}
+              className="inline-flex items-center font-mono font-bold uppercase tracking-[1px] transition-all duration-100"
+              style={{
+                fontSize: 10,
+                height: 36,
+                padding: "0 14px",
+                background: mergeIntoLaneBusy || resimBusy || commitBusy ? "#27272A" : "#A78BFA",
+                color: mergeIntoLaneBusy || resimBusy || commitBusy ? "#71717A" : "#0F0D14",
+                border: "none",
+                cursor: mergeIntoLaneBusy || resimBusy || commitBusy ? "not-allowed" : "pointer",
+              }}
+              onClick={() => void handleApplyMergeIntoTarget()}
+            >
+              {mergeIntoLaneBusy ? "UPDATING..." : "APPLY & RE-SIMULATE"}
+            </button>
+          </div>
+        </div>
 
         {selectedProposalRebaseLaneIds.length > 0 ? (
           <RebaseGuidancePanel
@@ -2596,6 +2717,7 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
                 })();
               }}
               startLabel="Start Proposal Resolver"
+              showResolverInstructions
             />
           </div>
         ) : null}

--- a/apps/desktop/src/shared/types/conflicts.ts
+++ b/apps/desktop/src/shared/types/conflicts.ts
@@ -408,6 +408,7 @@ export type PrepareResolverSessionArgs = {
   originMissionId?: string | null;
   originRunId?: string | null;
   originLabel?: string | null;
+  additionalInstructions?: string | null;
 };
 
 export type PrepareResolverSessionResult = {

--- a/apps/desktop/src/shared/types/prs.ts
+++ b/apps/desktop/src/shared/types/prs.ts
@@ -427,8 +427,10 @@ export type IntegrationProposal = {
   body?: string;
   draft?: boolean;
   integrationLaneName?: string;
-  /** Preferred integration worktree when none exists yet (merge sources here instead of a new lane). */
+  /** Preferred integration lane when none exists yet (merge sources here instead of a new lane). */
   preferredIntegrationLaneId?: string | null;
+  /** Git HEAD of preferred merge-into lane at last simulation (for drift warnings). */
+  mergeIntoHeadSha?: string | null;
   status: "proposed" | "committed";
   integrationLaneId?: string | null;
   linkedGroupId?: string | null;
@@ -457,6 +459,8 @@ export type UpdateIntegrationProposalArgs = {
   draft?: boolean;
   integrationLaneName?: string;
   preferredIntegrationLaneId?: string | null;
+  /** When clearing preferred lane, also clears stored simulation HEAD (optional; omit to leave unchanged). */
+  mergeIntoHeadSha?: string | null;
   /**
    * Clears integration_lane_id and resolution_state_json so the next prepare step can use a new or different lane.
    * Does not delete lanes in Git.
@@ -473,8 +477,8 @@ export type SimulateIntegrationArgs = {
   baseBranch: string;
   persist?: boolean;
   /**
-   * When set, pairwise simulation and sequential merge preview use this lane's current HEAD as the merge base
-   * (instead of only `baseBranch`), so conflicts with ongoing work on the integration/parent lane are visible.
+   * When set, sequential merge preview starts at this lane's current HEAD and extra merge-tree checks run
+   * (integration head vs each source). Child-vs-child pairwise simulation still uses `baseBranch` as the merge base.
    */
   mergeIntoLaneId?: string | null;
 };
@@ -535,6 +539,7 @@ export type CleanupIntegrationWorkflowResult = {
 
 export type CreateIntegrationLaneForProposalArgs = {
   proposalId: string;
+  allowDirtyWorktree?: boolean;
 };
 
 export type CreateIntegrationLaneForProposalResult = {

--- a/apps/desktop/src/shared/types/prs.ts
+++ b/apps/desktop/src/shared/types/prs.ts
@@ -347,6 +347,8 @@ export type CreateIntegrationPrArgs = {
   body?: string;
   draft?: boolean;
   allowDirtyWorktree?: boolean;
+  /** When set, merges sources into this existing lane instead of creating a new child lane. */
+  existingIntegrationLaneId?: string | null;
 };
 
 export type CreateIntegrationPrResult = {
@@ -425,6 +427,8 @@ export type IntegrationProposal = {
   body?: string;
   draft?: boolean;
   integrationLaneName?: string;
+  /** Preferred integration worktree when none exists yet (merge sources here instead of a new lane). */
+  preferredIntegrationLaneId?: string | null;
   status: "proposed" | "committed";
   integrationLaneId?: string | null;
   linkedGroupId?: string | null;
@@ -452,6 +456,12 @@ export type UpdateIntegrationProposalArgs = {
   body?: string;
   draft?: boolean;
   integrationLaneName?: string;
+  preferredIntegrationLaneId?: string | null;
+  /**
+   * Clears integration_lane_id and resolution_state_json so the next prepare step can use a new or different lane.
+   * Does not delete lanes in Git.
+   */
+  clearIntegrationBinding?: boolean;
 };
 
 export type ListIntegrationWorkflowsArgs = {
@@ -462,6 +472,11 @@ export type SimulateIntegrationArgs = {
   sourceLaneIds: string[];
   baseBranch: string;
   persist?: boolean;
+  /**
+   * When set, pairwise simulation and sequential merge preview use this lane's current HEAD as the merge base
+   * (instead of only `baseBranch`), so conflicts with ongoing work on the integration/parent lane are visible.
+   */
+  mergeIntoLaneId?: string | null;
 };
 
 export type CommitIntegrationArgs = {
@@ -472,6 +487,8 @@ export type CommitIntegrationArgs = {
   draft?: boolean;
   pauseOnConflict?: boolean;
   allowDirtyWorktree?: boolean;
+  /** Override stored preference; omit to use the proposal row. */
+  preferredIntegrationLaneId?: string | null;
 };
 
 export type IntegrationStepResolution = "pending" | "merged-clean" | "resolving" | "resolved" | "failed";
@@ -569,6 +586,8 @@ export type PrAiResolutionStartArgs = {
   model: string;
   reasoning?: string | null;
   permissionMode?: AiPermissionMode;
+  /** Appended to the generated resolver prompt (integration, merge conflicts, etc.). */
+  additionalInstructions?: string | null;
 };
 
 export type PrAiResolutionStartResult = {

--- a/apps/ios/ADE/Resources/DatabaseBootstrap.sql
+++ b/apps/ios/ADE/Resources/DatabaseBootstrap.sql
@@ -547,6 +547,8 @@ alter table integration_proposals add column cleanup_completed_at text;
 
 alter table integration_proposals add column preferred_integration_lane_id text;
 
+alter table integration_proposals add column merge_into_head_sha text;
+
 create table if not exists queue_landing_state (
       id text primary key,
       group_id text not null,

--- a/apps/ios/ADE/Resources/DatabaseBootstrap.sql
+++ b/apps/ios/ADE/Resources/DatabaseBootstrap.sql
@@ -545,6 +545,8 @@ alter table integration_proposals add column cleanup_declined_at text;
 
 alter table integration_proposals add column cleanup_completed_at text;
 
+alter table integration_proposals add column preferred_integration_lane_id text;
+
 create table if not exists queue_landing_state (
       id text primary key,
       group_id text not null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the integration workflow so merges can target an **existing lane** (not only a new integration child), **simulation** accounts for **ongoing work on that lane** (merge-tree and sequential preview from its current HEAD), and the **AI resolver** accepts **optional operator instructions** appended to the generated prompt.

## Follow-up (review feedback)

- **Codex**: If `mergeIntoLaneId` is set, failing to resolve that lane’s HEAD now **errors** instead of silently simulating from base only.
- **Codex / CodeRabbit**: `createIntegrationLaneForProposal` now runs **dirty-worktree checks** on source lanes plus the preferred integration lane; optional `allowDirtyWorktree` for IPC/UI confirmation paths.
- **CodeRabbit**: `handleApplyMergeIntoTarget` **updates the new proposal before** best-effort delete of the old row; **Create PR** / **re-simulate** / **delete** gated while merge-into apply runs; live simulate **resets** when `liveIntegrationLaneId` changes; merge-into picker **hides source lanes**; copy uses **lane** terminology; advisory text distinguishes **pairwise merge base** vs **sequential preview**.
- **Drift**: New `merge_into_head_sha` column stores the merge-into HEAD at simulation time; adopting a preferred lane **logs a warning** if HEAD differs.

## Changes

- **Schema**: `integration_proposals.preferred_integration_lane_id`, `merge_into_head_sha` (SQLite migration in `kvDb`, iOS bootstrap aligned).
- **Types**: `SimulateIntegrationArgs.mergeIntoLaneId`, `CreateIntegrationPrArgs.existingIntegrationLaneId`, `CommitIntegrationArgs.preferredIntegrationLaneId`, `IntegrationProposal` fields, `UpdateIntegrationProposalArgs`, `CreateIntegrationLaneForProposalArgs.allowDirtyWorktree`, resolver instruction types.
- **`prService`**, **conflict resolver**, **UI** as in prior revision.

## Validation

- `npm --prefix apps/desktop run typecheck`
- `npm --prefix apps/desktop run test -- --run src/main/services/prs/prService.integrationCommit.test.ts src/main/services/state/kvDb.missionsMigration.test.ts`
- `npm --prefix apps/desktop run lint`

## Notes

- Pairwise **child vs child** simulation still uses the proposal **base branch** as the merge base. Parent/integration-lane conflicts are layered via the merge-into path and sequential preview.
- Changing merge-into on the Integration tab **replaces** the proposal row (new id) to avoid stale simulation data.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea2b526c-c64f-4f0f-85be-34232e113296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea2b526c-c64f-4f0f-85be-34232e113296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now select an existing integration lane as the preferred merge target instead of creating a new one.
  * Added optional "merge into" lane selection for more accurate conflict detection during proposal simulations.
  * Users can now provide custom instructions to the AI conflict resolver for more tailored conflict resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->