### PR TITLE
Execution targets: workspace picker, chat tagging, and persistence

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -666,8 +666,8 @@ app.whenReady().then(async () => {
     const agentToolsService = createAgentToolsService({ logger });
     const devToolsService = createDevToolsService({ logger });
 
-    const project = toProjectInfo(projectRoot, baseRef);
-    const { projectId } = upsertProjectRow({ db, repoRoot: projectRoot, displayName: project.displayName, baseRef });
+    const { projectId } = upsertProjectRow({ db, repoRoot: projectRoot, displayName: path.basename(projectRoot), baseRef });
+    const project = toProjectInfo(projectRoot, baseRef, projectId);
 
     const operationService = createOperationService({ db, projectId });
 

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -66,6 +66,7 @@ import type { EpisodicSummaryService } from "../memory/episodicSummaryService";
 import {
   createDefaultComputerUsePolicy,
   normalizeComputerUsePolicy,
+  ADE_LOCAL_EXECUTION_TARGET_ID,
 } from "../../../shared/types";
 import type {
   AgentChatApprovalDecision,
@@ -247,6 +248,8 @@ type PersistedChatState = {
   lastLaneDirectiveKey?: string | null;
   manuallyNamed?: boolean;
   requestedCwd?: string | null;
+  executionTargetId?: string | null;
+  executionTargetLabel?: string | null;
   /** Persisted "Allow for Session" tool approval overrides (Claude runtime). */
   approvalOverrides?: string[];
   updatedAt: string;
@@ -4566,6 +4569,12 @@ export function createAgentChatService(args: {
       ...(managed.session.requestedCwd != null && String(managed.session.requestedCwd).trim().length
         ? { requestedCwd: String(managed.session.requestedCwd).trim() }
         : {}),
+      ...(managed.session.executionTargetId != null && String(managed.session.executionTargetId).trim().length
+        ? { executionTargetId: String(managed.session.executionTargetId).trim() }
+        : {}),
+      ...(managed.session.executionTargetLabel != null && String(managed.session.executionTargetLabel).trim().length
+        ? { executionTargetLabel: String(managed.session.executionTargetLabel).trim() }
+        : {}),
       updatedAt: nowIso()
     };
 
@@ -4705,6 +4714,12 @@ export function createAgentChatService(args: {
         ...(record.manuallyNamed === true ? { manuallyNamed: true } : {}),
         ...(typeof record.requestedCwd === "string" && record.requestedCwd.trim().length
           ? { requestedCwd: record.requestedCwd.trim() }
+          : {}),
+        ...(typeof record.executionTargetId === "string" && record.executionTargetId.trim().length
+          ? { executionTargetId: record.executionTargetId.trim() }
+          : {}),
+        ...(typeof record.executionTargetLabel === "string" && record.executionTargetLabel.trim().length
+          ? { executionTargetLabel: record.executionTargetLabel.trim() }
           : {}),
         updatedAt: typeof record.updatedAt === "string" && record.updatedAt.trim().length ? record.updatedAt : nowIso()
       };
@@ -5624,6 +5639,14 @@ export function createAgentChatService(args: {
         ...(persisted?.threadId ? { threadId: persisted.threadId } : {}),
         ...(persisted?.requestedCwd != null && String(persisted.requestedCwd).trim().length
           ? { requestedCwd: String(persisted.requestedCwd).trim() }
+          : {}),
+        ...(persisted?.executionTargetId != null && String(persisted.executionTargetId).trim().length
+          ? {
+              executionTargetId: String(persisted.executionTargetId).trim(),
+              ...(persisted?.executionTargetLabel != null && String(persisted.executionTargetLabel).trim().length
+                ? { executionTargetLabel: String(persisted.executionTargetLabel).trim() }
+                : {}),
+            }
           : {}),
         createdAt: row.startedAt,
         lastActivityAt: persisted?.updatedAt ?? row.endedAt ?? row.startedAt
@@ -10145,6 +10168,8 @@ export function createAgentChatService(args: {
     automationRunId,
     computerUse,
     requestedCwd,
+    executionTargetId: requestedExecutionTargetId,
+    executionTargetLabel: requestedExecutionTargetLabel,
   }: AgentChatCreateArgs): Promise<AgentChatSession> => {
     const launchContext = resolveLaneLaunchContext({
       laneService,
@@ -10219,6 +10244,15 @@ export function createAgentChatService(args: {
       ? normalizeIdentityPermissionMode(requestedPermMode, effectiveProvider)
       : requestedPermMode;
     const chatConfig = resolveChatConfig();
+
+    const rawExecTargetId = typeof requestedExecutionTargetId === "string" ? requestedExecutionTargetId.trim() : "";
+    const normalizedExecTargetId = rawExecTargetId.length ? rawExecTargetId : ADE_LOCAL_EXECUTION_TARGET_ID;
+    const normalizedExecTargetLabel =
+      typeof requestedExecutionTargetLabel === "string" && requestedExecutionTargetLabel.trim().length
+        ? requestedExecutionTargetLabel.trim()
+        : normalizedExecTargetId === ADE_LOCAL_EXECUTION_TARGET_ID
+          ? "This computer"
+          : normalizedExecTargetId;
 
     const nativePermissionFields = (() => {
       if (effectiveProvider === "claude") {
@@ -10309,6 +10343,8 @@ export function createAgentChatService(args: {
         ...(typeof requestedCwd === "string" && requestedCwd.trim().length
           ? { requestedCwd: requestedCwd.trim() }
           : {}),
+        executionTargetId: normalizedExecTargetId,
+        executionTargetLabel: normalizedExecTargetLabel,
       },
       transcriptPath,
       transcriptBytesWritten: fileSizeOrZero(transcriptPath),
@@ -10445,6 +10481,8 @@ export function createAgentChatService(args: {
       permissionMode: managed.session.permissionMode,
       surface: managed.session.surface,
       computerUse: managed.session.computerUse,
+      executionTargetId: managed.session.executionTargetId ?? null,
+      executionTargetLabel: managed.session.executionTargetLabel ?? null,
     });
 
     const createdManaged = ensureManagedSession(created.id);
@@ -12239,7 +12277,19 @@ export function createAgentChatService(args: {
       ...(hasLivePendingInput(liveManaged) ? { awaitingInput: true } : {}),
       ...(liveSession?.threadId || persisted?.threadId
         ? { threadId: liveSession?.threadId ?? persisted?.threadId }
-        : {})
+        : {}),
+      ...(() => {
+        const idRaw = liveSession?.executionTargetId ?? persisted?.executionTargetId;
+        const id = typeof idRaw === "string" && idRaw.trim().length ? idRaw.trim() : ADE_LOCAL_EXECUTION_TARGET_ID;
+        const labelRaw = liveSession?.executionTargetLabel ?? persisted?.executionTargetLabel;
+        const label =
+          typeof labelRaw === "string" && labelRaw.trim().length
+            ? labelRaw.trim()
+            : id === ADE_LOCAL_EXECUTION_TARGET_ID
+              ? "This computer"
+              : id;
+        return { executionTargetId: id, executionTargetLabel: label };
+      })()
     } satisfies AgentChatSessionSummary;
   };
 
@@ -12772,6 +12822,8 @@ export function createAgentChatService(args: {
     cursorConfigValues,
     permissionMode,
     computerUse,
+    executionTargetId,
+    executionTargetLabel,
   }: AgentChatUpdateSessionArgs): Promise<AgentChatSession> => {
     const managed = ensureManagedSession(sessionId);
     const chatConfig = resolveChatConfig();
@@ -12984,6 +13036,32 @@ export function createAgentChatService(args: {
       if (managed.runtime?.kind === "cursor" && !managed.runtime.busy) {
         await ensureCursorSessionState(managed, managed.runtime);
       }
+    }
+
+    if (executionTargetId !== undefined) {
+      const nextId = typeof executionTargetId === "string" && executionTargetId.trim().length
+        ? executionTargetId.trim()
+        : ADE_LOCAL_EXECUTION_TARGET_ID;
+      managed.session.executionTargetId = nextId;
+      if (executionTargetLabel !== undefined) {
+        const nextLabel = typeof executionTargetLabel === "string" && executionTargetLabel.trim().length
+          ? executionTargetLabel.trim()
+          : nextId === ADE_LOCAL_EXECUTION_TARGET_ID
+            ? "This computer"
+            : nextId;
+        managed.session.executionTargetLabel = nextLabel;
+      } else if (nextId === ADE_LOCAL_EXECUTION_TARGET_ID) {
+        managed.session.executionTargetLabel = "This computer";
+      } else if (!managed.session.executionTargetLabel?.trim()) {
+        managed.session.executionTargetLabel = nextId;
+      }
+    } else if (executionTargetLabel !== undefined) {
+      const nextLabel = typeof executionTargetLabel === "string" && executionTargetLabel.trim().length
+        ? executionTargetLabel.trim()
+        : managed.session.executionTargetId === ADE_LOCAL_EXECUTION_TARGET_ID
+          ? "This computer"
+          : (managed.session.executionTargetId ?? "This computer");
+      managed.session.executionTargetLabel = nextLabel;
     }
 
     if (computerUse !== undefined) {

--- a/apps/desktop/src/main/services/executionTargets/executionTargetsStateService.ts
+++ b/apps/desktop/src/main/services/executionTargets/executionTargetsStateService.ts
@@ -1,0 +1,26 @@
+import type { AdeDb } from "../state/kvDb";
+import type { AdeExecutionTargetsState } from "../../../shared/types";
+import { defaultExecutionTargetsState, normalizeExecutionTargetsState } from "../../../shared/types";
+
+function keyForProject(projectId: string): string {
+  return `ade_execution_targets:${projectId}`;
+}
+
+export function getExecutionTargetsState(db: AdeDb | null, projectId: string): AdeExecutionTargetsState {
+  const pid = projectId.trim();
+  if (!db || !pid.length) return defaultExecutionTargetsState();
+  const raw = db.getJson<unknown>(keyForProject(pid));
+  return normalizeExecutionTargetsState(raw);
+}
+
+export function setExecutionTargetsState(
+  db: AdeDb | null,
+  projectId: string,
+  next: AdeExecutionTargetsState,
+): AdeExecutionTargetsState {
+  const pid = projectId.trim();
+  if (!db || !pid.length) return defaultExecutionTargetsState();
+  const normalized = normalizeExecutionTargetsState(next);
+  db.setJson(keyForProject(pid), normalized);
+  return normalized;
+}

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -226,6 +226,7 @@ import type {
   ProjectConfigTrust,
   ProjectConfigValidationResult,
   ProjectInfo,
+  AdeExecutionTargetsState,
   RecentProjectSummary,
   PtyCreateArgs,
   PtyCreateResult,
@@ -3216,6 +3217,21 @@ export function registerIpc({
     ctx.db.setJson(key, arg.state);
   });
 
+  ipcMain.handle(IPC.executionTargetsGet, async (): Promise<AdeExecutionTargetsState> => {
+    const ctx = getCtx();
+    const { getExecutionTargetsState } = await import("../executionTargets/executionTargetsStateService");
+    return getExecutionTargetsState(ctx.db, ctx.projectId);
+  });
+
+  ipcMain.handle(
+    IPC.executionTargetsSet,
+    async (_event, arg: AdeExecutionTargetsState): Promise<AdeExecutionTargetsState> => {
+      const ctx = getCtx();
+      const { setExecutionTargetsState } = await import("../executionTargets/executionTargetsStateService");
+      return setExecutionTargetsState(ctx.db, ctx.projectId, arg);
+    },
+  );
+
   ipcMain.handle(IPC.lanesList, async (_event, arg: ListLanesArgs): Promise<LaneSummary[]> => {
     const ctx = getCtx();
     return await withIpcTiming(
@@ -3879,13 +3895,27 @@ export function registerIpc({
         const chatSummaryBySessionId = new Map(chats.map((chat) => [chat.sessionId, chat] as const));
         return sessions.map((session) => {
           if (!isChatToolType(session.toolType)) return session;
-          if (session.status !== "running") return session;
           const chat = chatSummaryBySessionId.get(session.id);
-          if (!chat) return session;
-          if (chat.awaitingInput) return { ...session, runtimeState: "waiting-input" as const };
-          if (chat.status === "active") return { ...session, runtimeState: "running" as const };
-          if (chat.status === "idle") return { ...session, runtimeState: "idle" as const };
-          return session;
+          const withTarget =
+            chat
+            && (chat.executionTargetId != null && String(chat.executionTargetId).trim().length > 0
+              || chat.executionTargetLabel != null && String(chat.executionTargetLabel).trim().length > 0)
+              ? {
+                  ...session,
+                  ...(chat.executionTargetId != null && String(chat.executionTargetId).trim().length
+                    ? { executionTargetId: String(chat.executionTargetId).trim() }
+                    : {}),
+                  ...(chat.executionTargetLabel != null && String(chat.executionTargetLabel).trim().length
+                    ? { executionTargetLabel: String(chat.executionTargetLabel).trim() }
+                    : {}),
+                }
+              : session;
+          if (session.status !== "running") return withTarget;
+          if (!chat) return withTarget;
+          if (chat.awaitingInput) return { ...withTarget, runtimeState: "waiting-input" as const };
+          if (chat.status === "active") return { ...withTarget, runtimeState: "running" as const };
+          if (chat.status === "idle") return { ...withTarget, runtimeState: "idle" as const };
+          return withTarget;
         });
       },
       {

--- a/apps/desktop/src/main/services/projects/projectService.ts
+++ b/apps/desktop/src/main/services/projects/projectService.ts
@@ -57,6 +57,11 @@ export function upsertProjectRow({
   return { projectId: id };
 }
 
-export function toProjectInfo(repoRoot: string, baseRef: string): ProjectInfo {
-  return { rootPath: repoRoot, displayName: path.basename(repoRoot), baseRef };
+export function toProjectInfo(repoRoot: string, baseRef: string, projectId?: string): ProjectInfo {
+  return {
+    rootPath: repoRoot,
+    displayName: path.basename(repoRoot),
+    baseRef,
+    ...(projectId?.trim() ? { projectId: projectId.trim() } : {}),
+  };
 }

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -351,6 +351,7 @@ import type {
   ProjectConfigTrust,
   ProjectConfigValidationResult,
   ProjectInfo,
+  AdeExecutionTargetsState,
   RecentProjectSummary,
   PtyCreateArgs,
   PtyCreateResult,
@@ -593,6 +594,10 @@ declare global {
       onMissing: (cb: (data: { rootPath: string }) => void) => () => void;
       onStateEvent: (cb: (event: AdeProjectEvent) => void) => () => void;
     };
+      executionTargets: {
+        get: () => Promise<AdeExecutionTargetsState>;
+        set: (state: AdeExecutionTargetsState) => Promise<AdeExecutionTargetsState>;
+      };
       keybindings: {
         get: () => Promise<KeybindingsSnapshot>;
         set: (overrides: KeybindingOverride[]) => Promise<KeybindingsSnapshot>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -282,6 +282,7 @@ import type {
   ProjectConfigTrust,
   ProjectConfigValidationResult,
   ProjectInfo,
+  AdeExecutionTargetsState,
   RecentProjectSummary,
   PtyCreateArgs,
   PtyCreateResult,
@@ -598,6 +599,11 @@ contextBridge.exposeInMainWorld("ade", {
       ipcRenderer.on(IPC.projectStateEvent, listener);
       return () => ipcRenderer.removeListener(IPC.projectStateEvent, listener);
     }
+  },
+  executionTargets: {
+    get: async (): Promise<AdeExecutionTargetsState> => ipcRenderer.invoke(IPC.executionTargetsGet),
+    set: async (state: AdeExecutionTargetsState): Promise<AdeExecutionTargetsState> =>
+      ipcRenderer.invoke(IPC.executionTargetsSet, state),
   },
   keybindings: {
     get: async (): Promise<KeybindingsSnapshot> => ipcRenderer.invoke(IPC.keybindingsGet),

--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -866,11 +866,7 @@ if (typeof window !== "undefined" && !(window as any).ade) {
         profiles: [{ id: "local", kind: "local" as const, label: "This computer" }],
         activeTargetId: "local",
       }),
-      set: resolvedArg({
-        version: 1,
-        profiles: [{ id: "local", kind: "local" as const, label: "This computer" }],
-        activeTargetId: "local",
-      }),
+      set: async (state: any) => state,
     },
     keybindings: {
       get: resolved({ definitions: [], overrides: [] }),

--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -860,6 +860,18 @@ if (typeof window !== "undefined" && !(window as any).ade) {
       onMissing: noop,
       onStateEvent: noop,
     },
+    executionTargets: {
+      get: resolved({
+        version: 1,
+        profiles: [{ id: "local", kind: "local" as const, label: "This computer" }],
+        activeTargetId: "local",
+      }),
+      set: resolvedArg({
+        version: 1,
+        profiles: [{ id: "local", kind: "local" as const, label: "This computer" }],
+        activeTargetId: "local",
+      }),
+    },
     keybindings: {
       get: resolved({ definitions: [], overrides: [] }),
       set: resolvedArg({ definitions: [], overrides: [] }),

--- a/apps/desktop/src/renderer/components/app/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.tsx
@@ -12,6 +12,7 @@ import {
   getStoredZoomLevel,
 } from "../../lib/zoom";
 import { cn } from "../ui/cn";
+import { TopBarExecutionTargetSelect } from "../executionTargets/TopBarExecutionTargetSelect";
 import type { ProcessRuntime, RecentProjectSummary, SyncRoleSnapshot } from "../../../shared/types";
 import { AutoUpdateControl } from "./AutoUpdateControl";
 
@@ -417,6 +418,8 @@ export function TopBar() {
         >
           <Plus size={12} weight="regular" />
         </button>
+
+        <TopBarExecutionTargetSelect projectRoot={project?.rootPath ?? null} />
       </div>
 
       {syncSnapshot && syncLabel ? (

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { At, CaretDown, Check, Image, Paperclip, PencilSimple, Square, X, PaperPlaneTilt, Cube, BookOpen } from "@phosphor-icons/react";
+import { At, CaretDown, Check, Image, Paperclip, PencilSimple, Square, X, PaperPlaneTilt, Cube, BookOpen, DesktopTower } from "@phosphor-icons/react";
 import {
   inferAttachmentType,
   type AgentChatApprovalDecision,
@@ -18,7 +18,9 @@ import {
   type ChatSurfaceMode,
   type ComputerUsePolicy,
   type PendingInputRequest,
+  type AdeExecutionTargetProfile,
 } from "../../../shared/types";
+import { executionTargetSummaryLabel } from "../../../shared/types";
 import { getModelById } from "../../../shared/modelRegistry";
 import { cn } from "../ui/cn";
 import { UnifiedModelSelector } from "../shared/UnifiedModelSelector";
@@ -328,6 +330,10 @@ export function AgentChatComposer({
   onCancelSteer,
   onEditSteer,
   onOpenAiSettings,
+  executionTargetProfiles,
+  executionTargetId,
+  executionTargetLabel,
+  onExecutionTargetChange,
 }: {
   surfaceMode?: ChatSurfaceMode;
   layoutVariant?: "standard" | "grid-tile";
@@ -398,6 +404,10 @@ export function AgentChatComposer({
   onCancelSteer?: (steerId: string) => void;
   onEditSteer?: (steerId: string, text: string) => void;
   onOpenAiSettings?: () => void;
+  executionTargetProfiles?: AdeExecutionTargetProfile[];
+  executionTargetId?: string;
+  executionTargetLabel?: string;
+  onExecutionTargetChange?: (targetId: string) => void;
 }) {
   const [attachmentPickerOpen, setAttachmentPickerOpen] = useState(false);
   const [attachmentQuery, setAttachmentQuery] = useState("");
@@ -413,12 +423,23 @@ export function AgentChatComposer({
   const [hoveredCodexPreset, setHoveredCodexPreset] = useState<"plan" | "edit" | "full-auto" | null>(null);
 
   const [dragActive, setDragActive] = useState(false);
+  const [targetMenuOpen, setTargetMenuOpen] = useState(false);
+  const targetMenuRef = useRef<HTMLDivElement | null>(null);
 
   const attachmentInputRef = useRef<HTMLInputElement | null>(null);
   const uploadInputRef = useRef<HTMLInputElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileAddInProgressRef = useRef(false);
   const canAttach = !turnActive;
+
+  useEffect(() => {
+    if (!targetMenuOpen) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!targetMenuRef.current?.contains(e.target as Node)) setTargetMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [targetMenuOpen]);
 
   const attachedPaths = useMemo(() => new Set(attachments.map((a) => a.path)), [attachments]);
   const selectedModel = useMemo(() => getModelById(modelId), [modelId]);
@@ -1191,6 +1212,42 @@ export function AgentChatComposer({
             >
               /
             </button>
+
+            {executionTargetProfiles?.length && onExecutionTargetChange && executionTargetId ? (
+              <div ref={targetMenuRef} className="relative">
+                <button
+                  type="button"
+                  className="inline-flex h-6 max-w-[140px] items-center gap-1 rounded-md border border-white/[0.06] bg-white/[0.02] px-1.5 font-sans text-[10px] font-medium text-muted-fg/55 transition-colors hover:border-white/[0.10] hover:text-fg/70"
+                  onClick={() => setTargetMenuOpen((o) => !o)}
+                  title="Tagged execution target for this chat. Remote runs are not wired yet — tools still execute on this computer."
+                >
+                  <DesktopTower size={11} className="shrink-0 text-sky-400/70" />
+                  <span className="min-w-0 truncate">{executionTargetLabel ?? executionTargetId}</span>
+                  <CaretDown size={9} className="shrink-0 opacity-50" />
+                </button>
+                {targetMenuOpen ? (
+                  <div className="absolute bottom-full left-0 z-40 mb-1 min-w-[200px] overflow-hidden rounded-lg border border-white/[0.08] bg-card py-1 shadow-lg">
+                    {executionTargetProfiles.map((p) => (
+                      <button
+                        key={p.id}
+                        type="button"
+                        className={cn(
+                          "flex w-full items-center gap-2 px-2 py-1.5 text-left text-[11px] transition-colors hover:bg-white/[0.04]",
+                          p.id === executionTargetId && "bg-white/[0.06]",
+                        )}
+                        onClick={() => {
+                          onExecutionTargetChange(p.id);
+                          setTargetMenuOpen(false);
+                        }}
+                      >
+                        <DesktopTower size={12} className="shrink-0 text-muted-fg/45" />
+                        <span className="min-w-0 truncate">{executionTargetSummaryLabel(p)}</span>
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
 
             {/* Proof drawer toggle */}
             {onToggleProof ? (

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -25,6 +25,12 @@ import {
   type ComputerUseOwnerSnapshot,
   type ComputerUsePolicy,
   type TerminalToolType,
+  type AdeExecutionTargetProfile,
+} from "../../../shared/types";
+import {
+  ADE_LOCAL_EXECUTION_TARGET_ID,
+  defaultExecutionTargetsState,
+  executionTargetSummaryLabel,
 } from "../../../shared/types";
 import { parseAgentChatTranscript } from "../../../shared/chatTranscript";
 import {
@@ -539,6 +545,9 @@ export function AgentChatPane({
   onSessionCreated,
   availableLanes,
   onLaneChange,
+  workExecutionTargetProfile,
+  projectActiveExecutionTargetId,
+  executionTargetProfiles,
 }: {
   laneId: string | null;
   laneLabel?: string | null;
@@ -560,12 +569,25 @@ export function AgentChatPane({
   availableLanes?: Array<{ id: string; name: string; color?: string | null }>;
   /** Callback when lane selection changes in empty state */
   onLaneChange?: (laneId: string) => void;
+  /** Project workspace target (Work / lane work); drives default "run on" for new chats. */
+  workExecutionTargetProfile?: AdeExecutionTargetProfile;
+  projectActiveExecutionTargetId?: string | null;
+  executionTargetProfiles?: AdeExecutionTargetProfile[];
 }) {
   const navigate = useNavigate();
   const openAiProvidersSettings = useCallback(() => {
     navigate("/settings?tab=ai#ai-providers");
   }, [navigate]);
   const selectLane = useAppStore((s) => s.selectLane);
+  const targetProfilesForPicker = useMemo((): AdeExecutionTargetProfile[] => {
+    if (executionTargetProfiles?.length) return executionTargetProfiles;
+    const localDefault = defaultExecutionTargetsState().profiles[0]!;
+    if (workExecutionTargetProfile) {
+      if (workExecutionTargetProfile.id === localDefault.id) return [workExecutionTargetProfile];
+      return [localDefault, workExecutionTargetProfile];
+    }
+    return [localDefault];
+  }, [executionTargetProfiles, workExecutionTargetProfile]);
   const lockedSingleSessionMode = Boolean(lockSessionId && hideSessionTabs && initialSessionSummary);
   const forceDraft = forceDraftMode || forceNewSession;
   const preferDraftStart = !lockSessionId && !initialSessionId && !forceNewSession;
@@ -603,6 +625,8 @@ export function AgentChatPane({
   const [sdkSlashCommands, setSdkSlashCommands] = useState<import("../../../shared/types").AgentChatSlashCommand[]>([]);
   const [sendOnEnter, setSendOnEnter] = useState(true);
   const [draft, setDraft] = useState("");
+  const [composerExecutionTargetId, setComposerExecutionTargetId] = useState<string>(ADE_LOCAL_EXECUTION_TARGET_ID);
+  const [composerExecutionTargetLabel, setComposerExecutionTargetLabel] = useState<string>("This computer");
   const draftsPerSessionRef = useRef<Map<string | null, string>>(new Map());
   const [busy, setBusy] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -730,6 +754,12 @@ export function AgentChatPane({
       setUnifiedPermissionMode(initialNativeControls.unifiedPermissionMode);
       setCursorModeId(initialNativeControls.cursorModeId);
       setCursorConfigValues(initialNativeControls.cursorConfigValues);
+      const wid = workExecutionTargetProfile?.id ?? ADE_LOCAL_EXECUTION_TARGET_ID;
+      const wlab = workExecutionTargetProfile
+        ? executionTargetSummaryLabel(workExecutionTargetProfile)
+        : "This computer";
+      setComposerExecutionTargetId(wid);
+      setComposerExecutionTargetLabel(wlab);
       return;
     }
     const nextModelId = session.modelId ?? resolveRegistryModelId(session.model);
@@ -753,7 +783,24 @@ export function AgentChatPane({
       ),
     );
     setComputerUsePolicy(session.computerUse ?? createDefaultComputerUsePolicy());
-  }, [initialNativeControls]);
+    const tid = session.executionTargetId?.trim() || ADE_LOCAL_EXECUTION_TARGET_ID;
+    const tlab =
+      session.executionTargetLabel?.trim()
+      || (tid === ADE_LOCAL_EXECUTION_TARGET_ID ? "This computer" : tid);
+    setComposerExecutionTargetId(tid);
+    setComposerExecutionTargetLabel(tlab);
+  }, [initialNativeControls, workExecutionTargetProfile]);
+
+  useEffect(() => {
+    if (selectedSessionId) return;
+    const wid = workExecutionTargetProfile?.id ?? ADE_LOCAL_EXECUTION_TARGET_ID;
+    const wlab = workExecutionTargetProfile
+      ? executionTargetSummaryLabel(workExecutionTargetProfile)
+      : "This computer";
+    setComposerExecutionTargetId(wid);
+    setComposerExecutionTargetLabel(wlab);
+  }, [selectedSessionId, workExecutionTargetProfile]);
+
   const executionModeOptions = useMemo(
     () => getExecutionModeOptions(selectedModelDesc),
     [selectedModelDesc],
@@ -1640,6 +1687,8 @@ export function AgentChatPane({
         reasoningEffort,
         ...buildNativeControlPayload(provider),
         computerUse: computerUsePolicy,
+        executionTargetId: composerExecutionTargetId,
+        executionTargetLabel: composerExecutionTargetLabel,
       });
       loadedHistoryRef.current.delete(created.id);
       optimisticSessionIdsRef.current.add(created.id);
@@ -1665,7 +1714,18 @@ export function AgentChatPane({
         createSessionPromiseRef.current = null;
       }
     }
-  }, [buildNativeControlPayload, computerUsePolicy, laneId, modelId, notifySessionCreated, reasoningEffort, refreshSessions, touchSession]);
+  }, [
+    buildNativeControlPayload,
+    computerUsePolicy,
+    composerExecutionTargetId,
+    composerExecutionTargetLabel,
+    laneId,
+    modelId,
+    notifySessionCreated,
+    reasoningEffort,
+    refreshSessions,
+    touchSession,
+  ]);
 
   const handoffSession = useCallback(async () => {
     if (!canShowHandoff || !selectedSessionId || !handoffModelId || handoffBlocked) return;
@@ -1960,6 +2020,30 @@ export function AgentChatPane({
     sessionMutationKind,
     sessionProvider,
   ]);
+
+  const handleComposerExecutionTargetChange = useCallback(
+    async (targetId: string) => {
+      const id = targetId.trim() || ADE_LOCAL_EXECUTION_TARGET_ID;
+      const profile = targetProfilesForPicker.find((p) => p.id === id);
+      const label = profile ? executionTargetSummaryLabel(profile) : id === ADE_LOCAL_EXECUTION_TARGET_ID ? "This computer" : id;
+      setComposerExecutionTargetId(id);
+      setComposerExecutionTargetLabel(label);
+      if (!selectedSessionId) return;
+      try {
+        await window.ade.agentChat.updateSession({
+          sessionId: selectedSessionId,
+          executionTargetId: id,
+          executionTargetLabel: label,
+        });
+        patchSessionSummary(selectedSessionId, { executionTargetId: id, executionTargetLabel: label });
+        void refreshSessions().catch(() => {});
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [patchSessionSummary, refreshSessions, selectedSessionId, targetProfilesForPicker],
+  );
+
   const handleClaudeModeChange = useCallback((mode: AgentChatClaudePermissionMode) => {
     void updateNativeControls({
       interactionMode: mode === "plan" ? "plan" : "default",
@@ -2044,6 +2128,16 @@ export function AgentChatPane({
       </div>
     </>
   );
+  const projectWorkspaceTargetId =
+    projectActiveExecutionTargetId?.trim() || ADE_LOCAL_EXECUTION_TARGET_ID;
+  const composerChatTargetId = selectedSessionId
+    ? (selectedSession?.executionTargetId?.trim() || ADE_LOCAL_EXECUTION_TARGET_ID)
+    : composerExecutionTargetId;
+  const showOffProjectTargetBadge =
+    workExecutionTargetProfile != null
+    && projectActiveExecutionTargetId != null
+    && composerChatTargetId !== projectWorkspaceTargetId;
+
   const shellHeader = (
     <div className="space-y-2 px-4 py-2">
       {/* Clean single-row header */}
@@ -2051,6 +2145,15 @@ export function AgentChatPane({
         <span className="min-w-0 truncate font-sans text-[13px] font-medium text-fg/80">
           {resolvedTitle}
         </span>
+
+        {showOffProjectTargetBadge ? (
+          <span
+            className="shrink-0 rounded-full border border-sky-500/30 bg-sky-500/10 px-2 py-0.5 font-sans text-[9px] font-semibold uppercase tracking-wide text-sky-200/90"
+            title="This chat is tagged for a different execution target than the project workspace focus. Tools still run locally until remote execution is connected."
+          >
+            Off workspace target
+          </span>
+        ) : null}
 
         {laneId && laneDisplayLabel && laneDisplayLabel !== laneId ? (
           <button
@@ -2240,6 +2343,12 @@ export function AgentChatPane({
             surfaceMode={surfaceMode}
             layoutVariant={layoutVariant}
             composerMaxHeightPx={composerMaxHeightPx}
+            executionTargetProfiles={workExecutionTargetProfile != null ? targetProfilesForPicker : undefined}
+            executionTargetId={composerExecutionTargetId}
+            executionTargetLabel={composerExecutionTargetLabel}
+            onExecutionTargetChange={
+              workExecutionTargetProfile != null ? handleComposerExecutionTargetChange : undefined
+            }
             sdkSlashCommands={sdkSlashCommands}
             modelId={modelId}
             availableModelIds={effectiveAvailableModelIds}

--- a/apps/desktop/src/renderer/components/executionTargets/ExecutionTargetContextBanner.tsx
+++ b/apps/desktop/src/renderer/components/executionTargets/ExecutionTargetContextBanner.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { DesktopTower } from "@phosphor-icons/react";
+import { cn } from "../ui/cn";
+import type { AdeExecutionTargetProfile } from "../../../shared/types";
+import { ADE_LOCAL_EXECUTION_TARGET_ID, executionTargetSummaryLabel } from "../../../shared/types";
+
+export function ExecutionTargetContextBanner({
+  profile,
+  className,
+  variant = "bar",
+}: {
+  profile: AdeExecutionTargetProfile | undefined;
+  className?: string;
+  variant?: "bar" | "inline";
+}) {
+  const label = executionTargetSummaryLabel(profile);
+  const isRemote = profile?.kind === "ssh";
+  const detail =
+    profile?.kind === "ssh"
+      ? `${profile.sshHost} · ${profile.workspacePath}`
+      : "Files, terminals, and lanes use this machine.";
+
+  if (variant === "inline") {
+    return (
+      <span className={cn("inline-flex items-center gap-1 text-[10px] text-muted-fg/70", className)} title={detail}>
+        <DesktopTower size={11} className={cn(isRemote ? "text-sky-400/80" : "text-muted-fg/50")} />
+        <span className="font-medium text-fg/75">{label}</span>
+        {profile?.kind === "ssh" && profile.connectionMode === "planned" ? (
+          <span className="text-amber-400/80">(SSH not connected yet)</span>
+        ) : null}
+      </span>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 border-b border-white/[0.06] bg-white/[0.02] px-3 py-1.5 text-[11px]",
+        className,
+      )}
+      role="status"
+    >
+      <DesktopTower size={14} className={cn("shrink-0", isRemote ? "text-sky-400/90" : "text-muted-fg/50")} weight="regular" />
+      <div className="min-w-0 flex-1">
+        <div className="font-medium text-fg/85">
+          Active target: <span className="text-fg">{label}</span>
+          {profile?.id === ADE_LOCAL_EXECUTION_TARGET_ID ? null : (
+            <span className="ml-1.5 font-normal text-muted-fg/55">· workspace focus</span>
+          )}
+        </div>
+        <div className="truncate text-[10px] text-muted-fg/45">{detail}</div>
+      </div>
+      {profile?.kind === "ssh" && profile.connectionMode === "planned" ? (
+        <span className="shrink-0 rounded border border-amber-500/25 bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide text-amber-200/80">
+          Planned
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/executionTargets/TopBarExecutionTargetSelect.tsx
+++ b/apps/desktop/src/renderer/components/executionTargets/TopBarExecutionTargetSelect.tsx
@@ -1,0 +1,102 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { CaretDown, DesktopTower, GearSix } from "@phosphor-icons/react";
+import { useNavigate } from "react-router-dom";
+import { cn } from "../ui/cn";
+import type { AdeExecutionTargetProfile } from "../../../shared/types";
+import { executionTargetSummaryLabel } from "../../../shared/types";
+import { useExecutionTargets } from "../../hooks/useExecutionTargets";
+
+export function TopBarExecutionTargetSelect({ projectRoot }: { projectRoot: string | null }) {
+  const navigate = useNavigate();
+  const { profiles, activeProfile, activeTargetId, setActiveTargetId, loading } = useExecutionTargets(projectRoot);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  const onPick = useCallback(
+    async (id: string) => {
+      await setActiveTargetId(id);
+      setOpen(false);
+    },
+    [setActiveTargetId],
+  );
+
+  if (!projectRoot?.trim()) return null;
+
+  const label = loading ? "…" : executionTargetSummaryLabel(activeProfile);
+
+  return (
+    <div ref={rootRef} className="relative shrink-0" style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}>
+      <button
+        type="button"
+        className={cn(
+          "ade-shell-control inline-flex max-w-[200px] items-center gap-1 rounded-md px-2 py-1",
+          "text-[11px] font-medium text-fg/80 transition-colors hover:text-fg",
+        )}
+        data-variant="ghost"
+        onClick={() => setOpen((v) => !v)}
+        title="Workspace target — files and terminals follow this selection"
+        aria-expanded={open}
+        aria-haspopup="listbox"
+      >
+        <DesktopTower size={12} weight="regular" className="shrink-0 text-muted-fg/50" />
+        <span className="min-w-0 truncate">{label}</span>
+        <CaretDown size={10} className="shrink-0 text-muted-fg/40" />
+      </button>
+      {open ? (
+        <div
+          className="absolute left-0 top-full z-50 mt-1 min-w-[240px] overflow-hidden rounded-lg border border-white/[0.08] bg-card py-1 shadow-lg"
+          role="listbox"
+        >
+          <div className="border-b border-white/[0.06] px-2 py-1.5 text-[9px] font-medium uppercase tracking-wide text-muted-fg/45">
+            Workspace target
+          </div>
+          {profiles.map((p: AdeExecutionTargetProfile) => (
+            <button
+              key={p.id}
+              type="button"
+              role="option"
+              aria-selected={p.id === activeTargetId}
+              className={cn(
+                "flex w-full items-start gap-2 px-2 py-1.5 text-left text-[11px] transition-colors hover:bg-white/[0.04]",
+                p.id === activeTargetId && "bg-white/[0.06]",
+              )}
+              onClick={() => void onPick(p.id)}
+            >
+              <DesktopTower size={14} className="mt-0.5 shrink-0 text-muted-fg/45" />
+              <span className="min-w-0 flex-1">
+                <span className="block font-medium text-fg/90">{executionTargetSummaryLabel(p)}</span>
+                {p.kind === "ssh" ? (
+                  <span className="block truncate text-[10px] text-muted-fg/45">{p.sshHost}</span>
+                ) : (
+                  <span className="block text-[10px] text-muted-fg/45">This Mac or PC running ADE</span>
+                )}
+              </span>
+            </button>
+          ))}
+          <div className="border-t border-white/[0.06] px-1 py-1">
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[11px] text-muted-fg/70 transition-colors hover:bg-white/[0.04] hover:text-fg/80"
+              onClick={() => {
+                setOpen(false);
+                navigate("/settings?tab=workspace#execution-targets");
+              }}
+            >
+              <GearSix size={14} className="shrink-0" />
+              Manage targets…
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/files/FilesPage.tsx
+++ b/apps/desktop/src/renderer/components/files/FilesPage.tsx
@@ -35,6 +35,8 @@ import type {
 import { MonacoDiffView } from "../lanes/MonacoDiffView";
 import { LaneTerminalsPanel } from "../lanes/LaneTerminalsPanel";
 import { useAppStore } from "../../state/appStore";
+import { useExecutionTargets } from "../../hooks/useExecutionTargets";
+import { ExecutionTargetContextBanner } from "../executionTargets/ExecutionTargetContextBanner";
 import { replaceDirtyBuffersForWorkspace } from "../../lib/dirtyWorkspaceBuffers";
 import { PaneTilingLayout } from "../ui/PaneTilingLayout";
 import { revealLabel } from "../../lib/platform";
@@ -343,6 +345,8 @@ export function FilesPage() {
   const location = useLocation();
   const selectedLaneId = useAppStore((s) => s.selectedLaneId);
   const projectRootPath = useAppStore((s) => s.project?.rootPath ?? "__unknown_project__");
+  const projectRootForTargets = useAppStore((s) => s.project?.rootPath ?? null);
+  const { activeProfile } = useExecutionTargets(projectRootForTargets);
   const sessionKey = filesSessionKey(projectRootPath, selectedLaneId);
   const initialSession = filesPageSessionByScope.get(sessionKey);
 
@@ -1751,6 +1755,7 @@ export function FilesPage() {
 
   return (
     <div className="relative flex h-full min-h-0 flex-col" style={{ background: COLORS.pageBg }}>
+      <ExecutionTargetContextBanner profile={activeProfile} />
       {/* Header bar */}
       <div style={{ padding: "0 24px", height: 64, display: "flex", alignItems: "center", gap: 20, background: "transparent", borderBottom: `1px solid ${COLORS.border}` }}>
         {/* Numbered title group */}

--- a/apps/desktop/src/renderer/components/lanes/LaneWorkPane.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneWorkPane.tsx
@@ -4,6 +4,8 @@ import { EmptyState } from "../ui/EmptyState";
 import { COLORS, SANS_FONT, SPACING } from "./laneDesignTokens";
 import { WorkViewArea } from "../terminals/WorkViewArea";
 import { useLaneWorkSessions } from "./useLaneWorkSessions";
+import { useAppStore } from "../../state/appStore";
+import { useExecutionTargets } from "../../hooks/useExecutionTargets";
 
 const ENTRY_OPTIONS: Array<{
   kind: WorkDraftKind;
@@ -22,6 +24,8 @@ export function LaneWorkPane({
   laneId: string | null;
 }) {
   const work = useLaneWorkSessions(laneId);
+  const projectRoot = useAppStore((s) => s.project?.rootPath ?? null);
+  const { state: execTargetsState, activeProfile, activeTargetId } = useExecutionTargets(projectRoot);
   const laneList = work.lane ? [work.lane] : [];
 
   if (!laneId) {
@@ -83,6 +87,9 @@ export function LaneWorkPane({
         <WorkViewArea
           gridLayoutId={work.gridLayoutId}
           lanes={laneList}
+          workExecutionTargetProfile={activeProfile}
+          executionTargetProfiles={execTargetsState.profiles}
+          projectActiveExecutionTargetId={activeTargetId}
           sessions={work.sessions}
           visibleSessions={work.visibleSessions}
           activeItemId={work.activeItemId}

--- a/apps/desktop/src/renderer/components/settings/ExecutionTargetsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ExecutionTargetsSection.tsx
@@ -1,0 +1,201 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { Plus, Trash } from "@phosphor-icons/react";
+import type { AdeExecutionTargetProfile, AdeExecutionTargetsState, AdeSshExecutionTargetProfile } from "../../../shared/types";
+import {
+  ADE_LOCAL_EXECUTION_TARGET_ID,
+  defaultExecutionTargetsState,
+  executionTargetSummaryLabel,
+} from "../../../shared/types";
+import { useAppStore } from "../../state/appStore";
+import { useExecutionTargets } from "../../hooks/useExecutionTargets";
+import { COLORS, MONO_FONT, SANS_FONT, LABEL_STYLE, cardStyle, outlineButton, primaryButton } from "../lanes/laneDesignTokens";
+
+const FIELD: React.CSSProperties = {
+  height: 28,
+  width: "100%",
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  padding: "0 8px",
+  fontSize: 11,
+  color: COLORS.textPrimary,
+  fontFamily: MONO_FONT,
+  borderRadius: 8,
+  outline: "none",
+};
+
+export function ExecutionTargetsSection() {
+  const projectRoot = useAppStore((s) => s.project?.rootPath ?? null);
+  const { state, persist, refresh } = useExecutionTargets(projectRoot);
+  const [label, setLabel] = useState("");
+  const [sshHost, setSshHost] = useState("");
+  const [workspacePath, setWorkspacePath] = useState("~/project");
+  const [jumpHost, setJumpHost] = useState("");
+  const [mode, setMode] = useState<AdeSshExecutionTargetProfile["connectionMode"]>("planned");
+  const [busy, setBusy] = useState(false);
+
+  const saveState = useCallback(
+    async (next: AdeExecutionTargetsState) => {
+      setBusy(true);
+      try {
+        await persist(next);
+      } finally {
+        setBusy(false);
+      }
+    },
+    [persist],
+  );
+
+  const addSshTarget = useCallback(async () => {
+    const trimmedLabel = label.trim();
+    const host = sshHost.trim();
+    const ws = workspacePath.trim();
+    if (!trimmedLabel || !host || !ws) return;
+    const id =
+      typeof globalThis.crypto?.randomUUID === "function"
+        ? globalThis.crypto.randomUUID()
+        : `ssh-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const nextProfile: AdeSshExecutionTargetProfile = {
+      id,
+      kind: "ssh",
+      label: trimmedLabel,
+      sshHost: host,
+      workspacePath: ws,
+      ...(jumpHost.trim() ? { jumpHost: jumpHost.trim() } : {}),
+      connectionMode: mode,
+    };
+    const next: AdeExecutionTargetsState = {
+      ...state,
+      profiles: [...state.profiles.filter((p) => p.id !== id), nextProfile],
+    };
+    await saveState(next);
+    setLabel("");
+    setSshHost("");
+    setJumpHost("");
+  }, [jumpHost, label, mode, saveState, sshHost, state, workspacePath]);
+
+  const removeTarget = useCallback(
+    async (id: string) => {
+      if (id === ADE_LOCAL_EXECUTION_TARGET_ID) return;
+      const next: AdeExecutionTargetsState = {
+        ...state,
+        profiles: state.profiles.filter((p) => p.id !== id),
+        activeTargetId: state.activeTargetId === id ? ADE_LOCAL_EXECUTION_TARGET_ID : state.activeTargetId,
+      };
+      if (!next.profiles.some((p) => p.id === ADE_LOCAL_EXECUTION_TARGET_ID)) {
+        next.profiles = defaultExecutionTargetsState().profiles;
+      }
+      await saveState(next);
+    },
+    [saveState, state],
+  );
+
+  if (!projectRoot?.trim()) {
+    return (
+      <div style={{ ...cardStyle({ padding: 16 }), color: COLORS.textMuted, fontFamily: SANS_FONT, fontSize: 12 }}>
+        Open a project to configure execution targets.
+      </div>
+    );
+  }
+
+  return (
+    <div id="execution-targets" style={{ maxWidth: 640 }}>
+      <div style={{ ...LABEL_STYLE, marginBottom: 8 }}>Execution targets</div>
+      <p style={{ fontFamily: SANS_FONT, fontSize: 12, color: COLORS.textMuted, marginBottom: 16, lineHeight: 1.5 }}>
+        Choose where this project&apos;s workspace focus points. Chats can record a target for when remote execution is
+        available; tools still run on this computer until SSH or a remote runner is connected.
+      </p>
+
+      <div style={{ ...cardStyle({ padding: 12 }), marginBottom: 12 }}>
+        <div style={{ fontFamily: SANS_FONT, fontSize: 11, fontWeight: 600, color: COLORS.textPrimary, marginBottom: 8 }}>
+          Saved targets
+        </div>
+        <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+          {state.profiles.map((p) => (
+            <li
+              key={p.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "8px 0",
+                borderBottom: "1px solid rgba(255,255,255,0.06)",
+                fontFamily: SANS_FONT,
+                fontSize: 11,
+              }}
+            >
+              <span style={{ flex: 1, minWidth: 0 }}>
+                <span style={{ fontWeight: 600, color: COLORS.textPrimary }}>{executionTargetSummaryLabel(p)}</span>
+                {p.kind === "ssh" ? (
+                  <span style={{ display: "block", color: COLORS.textMuted, fontFamily: MONO_FONT, fontSize: 10 }}>
+                    {p.sshHost} → {p.workspacePath}
+                  </span>
+                ) : null}
+              </span>
+              {p.id === state.activeTargetId ? (
+                <span style={{ fontSize: 9, textTransform: "uppercase", color: COLORS.accent }}>Active</span>
+              ) : (
+                <button
+                  type="button"
+                  style={outlineButton({ height: 24, padding: "0 8px", fontSize: 9 })}
+                  onClick={() => void saveState({ ...state, activeTargetId: p.id })}
+                  disabled={busy}
+                >
+                  Use
+                </button>
+              )}
+              {p.id !== ADE_LOCAL_EXECUTION_TARGET_ID ? (
+                <button
+                  type="button"
+                  style={{ ...outlineButton({ height: 24, padding: "0 6px", fontSize: 9 }), color: COLORS.danger }}
+                  title="Remove target"
+                  onClick={() => void removeTarget(p.id)}
+                  disabled={busy}
+                >
+                  <Trash size={12} />
+                </button>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div style={{ ...cardStyle({ padding: 12 }) }}>
+        <div style={{ fontFamily: SANS_FONT, fontSize: 11, fontWeight: 600, color: COLORS.textPrimary, marginBottom: 8 }}>
+          Add SSH target
+        </div>
+        <div style={{ display: "grid", gap: 8 }}>
+          <input style={FIELD} placeholder="Display name" value={label} onChange={(e) => setLabel(e.target.value)} />
+          <input style={FIELD} placeholder="SSH destination (user@host)" value={sshHost} onChange={(e) => setSshHost(e.target.value)} />
+          <input
+            style={FIELD}
+            placeholder="Remote workspace path"
+            value={workspacePath}
+            onChange={(e) => setWorkspacePath(e.target.value)}
+          />
+          <input style={FIELD} placeholder="Jump host (optional)" value={jumpHost} onChange={(e) => setJumpHost(e.target.value)} />
+          <label style={{ fontFamily: SANS_FONT, fontSize: 10, color: COLORS.textMuted }}>
+            Connection mode{" "}
+            <select
+              value={mode}
+              onChange={(e) => setMode(e.target.value as AdeSshExecutionTargetProfile["connectionMode"])}
+              style={{ ...FIELD, marginTop: 4, height: 30 }}
+            >
+              <option value="planned">Planned — metadata only</option>
+              <option value="ssh-shell">SSH shell (when implemented)</option>
+              <option value="ade-runner">ADE runner on host (when implemented)</option>
+            </select>
+          </label>
+          <button
+            type="button"
+            style={primaryButton({ height: 30, padding: "0 12px", fontSize: 11 })}
+            onClick={() => void addSshTarget()}
+            disabled={busy || !label.trim() || !sshHost.trim() || !workspacePath.trim()}
+          >
+            <Plus size={14} style={{ display: "inline", verticalAlign: "middle", marginRight: 6 }} />
+            Add target
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/settings/WorkspaceSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/WorkspaceSettingsSection.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { ContextSection } from "./ContextSection";
+import { ExecutionTargetsSection } from "./ExecutionTargetsSection";
 import { ProjectSection } from "./ProjectSection";
 
 export function WorkspaceSettingsSection() {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 28 }}>
       <ProjectSection />
+      <ExecutionTargetsSection />
       <ContextSection />
     </div>
   );

--- a/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Info, Play } from "@phosphor-icons/react";
 import type { TerminalSessionSummary } from "../../../shared/types";
+import { ADE_LOCAL_EXECUTION_TARGET_ID } from "../../../shared/types";
 import { sessionStatusDot } from "../../lib/terminalAttention";
 import { primarySessionLabel, secondarySessionLabel } from "../../lib/sessions";
 import { useSessionDelta } from "./useSessionDelta";
@@ -38,8 +39,10 @@ export const SessionCard = React.memo(function SessionCard({
   onInfoClick,
   onContextMenu,
   resumingSessionId,
+  projectActiveTargetId,
 }: {
   session: TerminalSessionSummary;
+  projectActiveTargetId?: string | null;
   isSelected: boolean;
   onSelect: (id: string) => void;
   onResume: () => void;
@@ -53,6 +56,11 @@ export const SessionCard = React.memo(function SessionCard({
   const delta = useSessionDelta(session.id, true);
   const primaryText = primarySessionLabel(session);
   const secondaryText = truncateSummary(secondarySessionLabel(session), 20);
+  const chatTargetId = session.executionTargetId?.trim() || ADE_LOCAL_EXECUTION_TARGET_ID;
+  const projectTarget = (projectActiveTargetId ?? ADE_LOCAL_EXECUTION_TARGET_ID).trim() || ADE_LOCAL_EXECUTION_TARGET_ID;
+  const showOtherTargetBadge =
+    Boolean(session.executionTargetId || session.executionTargetLabel)
+    && chatTargetId !== projectTarget;
 
   return (
     <div className="group relative" onContextMenu={onContextMenu}>
@@ -89,6 +97,14 @@ export const SessionCard = React.memo(function SessionCard({
               >
                 {primaryText}
               </span>
+              {showOtherTargetBadge ? (
+                <span
+                  className="shrink-0 rounded border border-sky-500/25 bg-sky-500/10 px-1 py-0.5 font-mono text-[8px] font-semibold uppercase tracking-wide text-sky-200/85"
+                  title={session.executionTargetLabel ?? session.executionTargetId ?? "Other target"}
+                >
+                  {session.executionTargetLabel ? session.executionTargetLabel.slice(0, 12) : "Remote"}
+                </span>
+              ) : null}
             </div>
 
             {/* Meta row */}

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
@@ -95,8 +95,10 @@ export const SessionListPane = React.memo(function SessionListPane({
   workCollapsedLaneIds,
   toggleWorkLaneCollapsed,
   sessionsGroupedByLane,
+  projectActiveTargetId,
 }: {
   lanes: LaneSummary[];
+  projectActiveTargetId?: string | null;
   runningFiltered: TerminalSessionSummary[];
   awaitingInputFiltered: TerminalSessionSummary[];
   endedFiltered: TerminalSessionSummary[];
@@ -143,6 +145,7 @@ export const SessionListPane = React.memo(function SessionListPane({
       <SessionCard
         key={session.id}
         session={session}
+        projectActiveTargetId={projectActiveTargetId}
         isSelected={selectedSessionId === session.id}
         onSelect={onSelectSession}
         onResume={() => onResume(session)}

--- a/apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx
@@ -8,6 +8,9 @@ import { SessionContextMenu, type SessionContextMenuState } from "./SessionConte
 import { SessionInfoPopover, type InfoPopoverState } from "./SessionInfoPopover";
 import type { AgentChatSession, TerminalSessionSummary } from "../../../shared/types";
 import { sortLanesForTabs } from "../lanes/laneUtils";
+import { useAppStore } from "../../state/appStore";
+import { useExecutionTargets } from "../../hooks/useExecutionTargets";
+import { ExecutionTargetContextBanner } from "../executionTargets/ExecutionTargetContextBanner";
 
 const TERMINALS_TILING_TREE: PaneSplit = {
   type: "split",
@@ -20,6 +23,8 @@ const TERMINALS_TILING_TREE: PaneSplit = {
 
 export function TerminalsPage() {
   const work = useWorkSessions();
+  const projectRoot = useAppStore((s) => s.project?.rootPath ?? null);
+  const { state: execTargetsState, activeProfile, activeTargetId } = useExecutionTargets(projectRoot);
   const sortedLanes = useMemo(() => sortLanesForTabs(work.lanes), [work.lanes]);
 
   const [contextMenu, setContextMenu] = useState<SessionContextMenuState>(null);
@@ -79,6 +84,9 @@ export function TerminalsPage() {
       <WorkViewArea
         gridLayoutId={work.gridLayoutId}
         lanes={sortedLanes}
+        workExecutionTargetProfile={activeProfile}
+        executionTargetProfiles={execTargetsState.profiles}
+        projectActiveExecutionTargetId={activeTargetId}
         sessions={work.sessions}
         visibleSessions={work.visibleSessions}
         activeItemId={work.activeItemId}
@@ -97,6 +105,9 @@ export function TerminalsPage() {
     [
       sortedLanes,
       work.gridLayoutId,
+      activeProfile,
+      execTargetsState.profiles,
+      activeTargetId,
       work.sessions,
       work.visibleSessions,
       work.activeItemId,
@@ -175,6 +186,7 @@ export function TerminalsPage() {
             workCollapsedLaneIds={work.workCollapsedLaneIds}
             toggleWorkLaneCollapsed={work.toggleWorkLaneCollapsed}
             sessionsGroupedByLane={work.sessionsGroupedByLane}
+            projectActiveTargetId={activeTargetId}
           />
         ),
       },
@@ -198,6 +210,7 @@ export function TerminalsPage() {
 
   return (
     <div className="flex h-full min-w-0 flex-col" style={{ background: "var(--color-bg)" }}>
+      <ExecutionTargetContextBanner profile={activeProfile} />
       {renameError ? (
         <div
           className="shrink-0 border-b border-red-500/25 px-4 py-2 text-[12px] text-red-300/95"

--- a/apps/desktop/src/renderer/components/terminals/WorkStartSurface.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkStartSurface.tsx
@@ -3,7 +3,12 @@ import {
   Terminal,
   ArrowRight,
 } from "@phosphor-icons/react";
-import type { AgentChatPermissionMode, AgentChatSession, LaneSummary } from "../../../shared/types";
+import type {
+  AdeExecutionTargetProfile,
+  AgentChatPermissionMode,
+  AgentChatSession,
+  LaneSummary,
+} from "../../../shared/types";
 import type { WorkDraftKind } from "../../state/appStore";
 import { useAppStore } from "../../state/appStore";
 import { AgentChatPane } from "../chat/AgentChatPane";
@@ -16,6 +21,9 @@ import { ClaudeLogo, CodexLogo } from "./ToolLogos";
 type WorkStartSurfaceProps = {
   draftKind: WorkDraftKind;
   lanes: LaneSummary[];
+  workExecutionTargetProfile?: AdeExecutionTargetProfile;
+  executionTargetProfiles?: AdeExecutionTargetProfile[];
+  projectActiveExecutionTargetId?: string | null;
   onOpenChatSession: (session: AgentChatSession) => void | Promise<void>;
   onLaunchPtySession: (args: {
     laneId: string;
@@ -29,6 +37,9 @@ type WorkStartSurfaceProps = {
 export function WorkStartSurface({
   draftKind,
   lanes,
+  workExecutionTargetProfile,
+  executionTargetProfiles,
+  projectActiveExecutionTargetId,
   onOpenChatSession,
   onLaunchPtySession,
 }: WorkStartSurfaceProps) {
@@ -143,6 +154,9 @@ export function WorkStartSurface({
             onSessionCreated={onOpenChatSession}
             availableLanes={lanes}
             onLaneChange={setLaneAndSync}
+            workExecutionTargetProfile={workExecutionTargetProfile}
+            executionTargetProfiles={executionTargetProfiles}
+            projectActiveExecutionTargetId={projectActiveExecutionTargetId}
           />
         </div>
       </div>

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { GridFour, List, Plus, X } from "@phosphor-icons/react";
-import type { AgentChatSession, LaneSummary, TerminalSessionSummary } from "../../../shared/types";
+import type { AdeExecutionTargetProfile, AgentChatSession, LaneSummary, TerminalSessionSummary } from "../../../shared/types";
 import type { WorkDraftKind, WorkViewMode } from "../../state/appStore";
 import { TerminalView } from "./TerminalView";
 import { ToolLogo } from "./ToolLogos";
@@ -32,12 +32,18 @@ function SessionSurface({
   layoutVariant = "standard",
   terminalVisible = isActive,
   onOpenChatSession,
+  workExecutionTargetProfile,
+  executionTargetProfiles,
+  projectActiveExecutionTargetId,
 }: {
   session: TerminalSessionSummary;
   isActive: boolean;
   layoutVariant?: "standard" | "grid-tile";
   terminalVisible?: boolean;
   onOpenChatSession: (session: AgentChatSession) => void | Promise<void>;
+  workExecutionTargetProfile?: AdeExecutionTargetProfile;
+  executionTargetProfiles?: AdeExecutionTargetProfile[];
+  projectActiveExecutionTargetId?: string | null;
 }) {
   const isChat = isChatToolType(session.toolType);
   if (isChat) {
@@ -48,6 +54,9 @@ function SessionSurface({
         lockSessionId={session.id}
         onSessionCreated={onOpenChatSession}
         layoutVariant={layoutVariant}
+        workExecutionTargetProfile={workExecutionTargetProfile}
+        executionTargetProfiles={executionTargetProfiles}
+        projectActiveExecutionTargetId={projectActiveExecutionTargetId}
       />
     );
   }
@@ -114,6 +123,9 @@ function ModeSwitcherPills({
 export function WorkViewArea({
   gridLayoutId,
   lanes,
+  workExecutionTargetProfile,
+  executionTargetProfiles,
+  projectActiveExecutionTargetId,
   sessions,
   visibleSessions,
   activeItemId,
@@ -130,6 +142,9 @@ export function WorkViewArea({
 }: {
   gridLayoutId: string;
   lanes: LaneSummary[];
+  workExecutionTargetProfile?: AdeExecutionTargetProfile;
+  executionTargetProfiles?: AdeExecutionTargetProfile[];
+  projectActiveExecutionTargetId?: string | null;
   sessions: TerminalSessionSummary[];
   visibleSessions: TerminalSessionSummary[];
   activeItemId: string | null;
@@ -193,6 +208,9 @@ export function WorkViewArea({
                 lanes={lanes}
                 onOpenChatSession={onOpenChatSession}
                 onLaunchPtySession={onLaunchPtySession}
+                workExecutionTargetProfile={workExecutionTargetProfile}
+                executionTargetProfiles={executionTargetProfiles}
+                projectActiveExecutionTargetId={projectActiveExecutionTargetId}
               />
             </div>
           </div>
@@ -275,6 +293,9 @@ export function WorkViewArea({
                       terminalVisible
                       layoutVariant="grid-tile"
                       onOpenChatSession={onOpenChatSession}
+                      workExecutionTargetProfile={workExecutionTargetProfile}
+                      executionTargetProfiles={executionTargetProfiles}
+                      projectActiveExecutionTargetId={projectActiveExecutionTargetId}
                     />
                   </div>
                 ),
@@ -402,7 +423,15 @@ export function WorkViewArea({
         {activeSession ? (
           activeRunningTerminalSession ? null : (
             <div className="absolute inset-0">
-              <SessionSurface session={activeSession} isActive terminalVisible onOpenChatSession={onOpenChatSession} />
+              <SessionSurface
+                session={activeSession}
+                isActive
+                terminalVisible
+                onOpenChatSession={onOpenChatSession}
+                workExecutionTargetProfile={workExecutionTargetProfile}
+                executionTargetProfiles={executionTargetProfiles}
+                projectActiveExecutionTargetId={projectActiveExecutionTargetId}
+              />
             </div>
           )
         ) : (
@@ -417,6 +446,9 @@ export function WorkViewArea({
                 lanes={lanes}
                 onOpenChatSession={onOpenChatSession}
                 onLaunchPtySession={onLaunchPtySession}
+                workExecutionTargetProfile={workExecutionTargetProfile}
+                executionTargetProfiles={executionTargetProfiles}
+                projectActiveExecutionTargetId={projectActiveExecutionTargetId}
               />
             </div>
           </div>

--- a/apps/desktop/src/renderer/hooks/useExecutionTargets.ts
+++ b/apps/desktop/src/renderer/hooks/useExecutionTargets.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from "react";
+import type { AdeExecutionTargetProfile, AdeExecutionTargetsState } from "../../shared/types";
+import {
+  ADE_LOCAL_EXECUTION_TARGET_ID,
+  defaultExecutionTargetsState,
+  executionTargetSummaryLabel,
+} from "../../shared/types";
+
+export function useExecutionTargets(projectRoot: string | null | undefined) {
+  const [state, setState] = useState<AdeExecutionTargetsState>(() => defaultExecutionTargetsState());
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    const root = typeof projectRoot === "string" ? projectRoot.trim() : "";
+    if (!root) {
+      setState(defaultExecutionTargetsState());
+      return;
+    }
+    setLoading(true);
+    try {
+      const next = await window.ade.executionTargets.get();
+      setState(next);
+    } catch {
+      setState(defaultExecutionTargetsState());
+    } finally {
+      setLoading(false);
+    }
+  }, [projectRoot]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const persist = useCallback(
+    async (next: AdeExecutionTargetsState) => {
+      const root = typeof projectRoot === "string" ? projectRoot.trim() : "";
+      if (!root) return;
+      const saved = await window.ade.executionTargets.set(next);
+      setState(saved);
+    },
+    [projectRoot],
+  );
+
+  const setActiveTargetId = useCallback(
+    async (targetId: string) => {
+      const id = targetId.trim() || ADE_LOCAL_EXECUTION_TARGET_ID;
+      const next: AdeExecutionTargetsState = {
+        ...state,
+        activeTargetId: state.profiles.some((p) => p.id === id) ? id : ADE_LOCAL_EXECUTION_TARGET_ID,
+      };
+      await persist(next);
+    },
+    [persist, state],
+  );
+
+  const activeProfile: AdeExecutionTargetProfile | undefined = state.profiles.find((p) => p.id === state.activeTargetId)
+    ?? state.profiles.find((p) => p.id === ADE_LOCAL_EXECUTION_TARGET_ID);
+
+  return {
+    state,
+    loading,
+    refresh,
+    persist,
+    setActiveTargetId,
+    activeProfile,
+    activeTargetId: state.activeTargetId,
+    profiles: state.profiles,
+    activeLabel: executionTargetSummaryLabel(activeProfile),
+  };
+}

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -17,6 +17,8 @@ export const IPC = {
   projectForgetRecent: "ade.project.forgetRecent",
   projectReorderRecent: "ade.project.reorderRecent",
   projectMissing: "ade.project.missing",
+  executionTargetsGet: "ade.executionTargets.get",
+  executionTargetsSet: "ade.executionTargets.set",
   projectStateGetSnapshot: "ade.project.state.getSnapshot",
   projectStateInitializeOrRepair: "ade.project.state.initializeOrRepair",
   projectStateRunIntegrityCheck: "ade.project.state.runIntegrityCheck",

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -477,6 +477,12 @@ export type AgentChatSession = {
   threadId?: string;
   /** Subdirectory or absolute path under the lane worktree used as cwd; persisted for relaunch/resume. */
   requestedCwd?: string | null;
+  /**
+   * Intended execution environment for this chat (`local` = this computer).
+   * Remote SSH targets are metadata until runner/SSH execution is wired.
+   */
+  executionTargetId?: string | null;
+  executionTargetLabel?: string | null;
   createdAt: string;
   lastActivityAt: string;
 };
@@ -516,6 +522,8 @@ export type AgentChatSessionSummary = {
   summary: string | null;
   awaitingInput?: boolean;
   threadId?: string;
+  executionTargetId?: string | null;
+  executionTargetLabel?: string | null;
 };
 
 export type AgentChatTranscriptEntry = {
@@ -592,6 +600,8 @@ export type AgentChatCreateArgs = {
   automationRunId?: string | null;
   computerUse?: ComputerUsePolicy | null;
   requestedCwd?: string;
+  executionTargetId?: string | null;
+  executionTargetLabel?: string | null;
 };
 
 export type AgentChatHandoffArgs = {
@@ -691,6 +701,8 @@ export type AgentChatUpdateSessionArgs = {
   cursorModeId?: string | null;
   cursorConfigValues?: Record<string, AgentChatCursorConfigValue> | null;
   computerUse?: ComputerUsePolicy | null;
+  executionTargetId?: string | null;
+  executionTargetLabel?: string | null;
 };
 
 export type AgentChatSlashCommand = {

--- a/apps/desktop/src/shared/types/core.ts
+++ b/apps/desktop/src/shared/types/core.ts
@@ -43,6 +43,8 @@ export type ProjectInfo = {
   rootPath: string;
   displayName: string;
   baseRef: string;
+  /** Stable id for project-scoped KV (SQLite); empty when project context is dormant. */
+  projectId?: string;
 };
 
 export type ClearLocalAdeDataArgs = {

--- a/apps/desktop/src/shared/types/executionTargets.ts
+++ b/apps/desktop/src/shared/types/executionTargets.ts
@@ -1,0 +1,104 @@
+// ---------------------------------------------------------------------------
+// Execution targets — where agent/chat work is intended to run (local vs SSH).
+// Tool execution on remote hosts is not fully wired yet; UI + metadata first.
+// ---------------------------------------------------------------------------
+
+export type AdeExecutionTargetKind = "local" | "ssh";
+
+/** Stable id; use "local" for the primary machine running ADE. */
+export type AdeExecutionTargetId = string;
+
+export type AdeSshExecutionTargetProfile = {
+  id: AdeExecutionTargetId;
+  kind: "ssh";
+  /** Short display name, e.g. "GPU VM" */
+  label: string;
+  /** SSH destination, e.g. user@host or token host from Daytona */
+  sshHost: string;
+  /** Optional jump / ProxyJump host */
+  jumpHost?: string;
+  /** Working directory on the remote for this repo */
+  workspacePath: string;
+  /**
+   * How ADE will run tools when implemented.
+   * `ssh-shell` — commands over SSH; `ade-runner` — headless ADE on remote; `planned` — not connected yet.
+   */
+  connectionMode: "ssh-shell" | "ade-runner" | "planned";
+};
+
+export type AdeLocalExecutionTargetProfile = {
+  id: "local";
+  kind: "local";
+  label: string;
+};
+
+export type AdeExecutionTargetProfile = AdeLocalExecutionTargetProfile | AdeSshExecutionTargetProfile;
+
+export type AdeExecutionTargetsState = {
+  version: 1;
+  /** User-defined and built-in targets (always includes `local`). */
+  profiles: AdeExecutionTargetProfile[];
+  /** Last-selected target for this project (workspace focus). */
+  activeTargetId: AdeExecutionTargetId;
+};
+
+export const ADE_LOCAL_EXECUTION_TARGET_ID = "local" as const;
+
+export function defaultExecutionTargetsState(): AdeExecutionTargetsState {
+  return {
+    version: 1,
+    profiles: [{ id: ADE_LOCAL_EXECUTION_TARGET_ID, kind: "local", label: "This computer" }],
+    activeTargetId: ADE_LOCAL_EXECUTION_TARGET_ID,
+  };
+}
+
+export function normalizeExecutionTargetsState(raw: unknown): AdeExecutionTargetsState {
+  const fallback = defaultExecutionTargetsState();
+  if (!raw || typeof raw !== "object") return fallback;
+  const rec = raw as Partial<AdeExecutionTargetsState>;
+  if (rec.version !== 1) return fallback;
+  const profilesIn = Array.isArray(rec.profiles) ? rec.profiles : [];
+  const profiles: AdeExecutionTargetProfile[] = [];
+  let sawLocal = false;
+  for (const entry of profilesIn) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Partial<AdeExecutionTargetProfile>;
+    if (e.kind === "local" && e.id === ADE_LOCAL_EXECUTION_TARGET_ID) {
+      const label = typeof e.label === "string" && e.label.trim() ? e.label.trim() : "This computer";
+      profiles.push({ id: ADE_LOCAL_EXECUTION_TARGET_ID, kind: "local", label });
+      sawLocal = true;
+      continue;
+    }
+    if (e.kind === "ssh" && typeof e.id === "string" && e.id.trim()) {
+      const id = e.id.trim();
+      if (id === ADE_LOCAL_EXECUTION_TARGET_ID) continue;
+      const label = typeof e.label === "string" && e.label.trim() ? e.label.trim() : id;
+      const sshHost = typeof e.sshHost === "string" ? e.sshHost.trim() : "";
+      const workspacePath = typeof e.workspacePath === "string" ? e.workspacePath.trim() : "";
+      const jumpHost = typeof e.jumpHost === "string" && e.jumpHost.trim() ? e.jumpHost.trim() : undefined;
+      const mode = e.connectionMode === "ade-runner" || e.connectionMode === "planned" ? e.connectionMode : "ssh-shell";
+      if (!sshHost || !workspacePath) continue;
+      profiles.push({
+        id,
+        kind: "ssh",
+        label,
+        sshHost,
+        workspacePath,
+        ...(jumpHost ? { jumpHost } : {}),
+        connectionMode: mode,
+      });
+    }
+  }
+  if (!sawLocal) {
+    profiles.unshift({ id: ADE_LOCAL_EXECUTION_TARGET_ID, kind: "local", label: "This computer" });
+  }
+  const activeRaw = typeof rec.activeTargetId === "string" ? rec.activeTargetId.trim() : "";
+  const activeTargetId = profiles.some((p) => p.id === activeRaw) ? activeRaw : ADE_LOCAL_EXECUTION_TARGET_ID;
+  return { version: 1, profiles, activeTargetId };
+}
+
+export function executionTargetSummaryLabel(profile: AdeExecutionTargetProfile | undefined): string {
+  if (!profile) return "Unknown target";
+  if (profile.kind === "local") return profile.label || "This computer";
+  return profile.label || profile.sshHost;
+}

--- a/apps/desktop/src/shared/types/index.ts
+++ b/apps/desktop/src/shared/types/index.ts
@@ -26,6 +26,7 @@ export * from "./budget";
 export * from "./usage";
 export * from "./memory";
 export * from "./projectState";
+export * from "./executionTargets";
 export * from "./sync";
 export * from "./devTools";
 

--- a/apps/desktop/src/shared/types/sessions.ts
+++ b/apps/desktop/src/shared/types/sessions.ts
@@ -43,6 +43,9 @@ export type TerminalSessionSummary = {
   summary: string | null;
   runtimeState: TerminalRuntimeState;
   resumeCommand: string | null;
+  /** Agent chat: intended execution target (local id or SSH profile id). */
+  executionTargetId?: string | null;
+  executionTargetLabel?: string | null;
 };
 
 export type TerminalSessionDetail = TerminalSessionSummary & {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces a first-cut **execution target** model aligned with the “single active workspace target + per-chat tagging” direction: users can define targets (local + SSH metadata), pick an **active** target from the top bar, see **context banners** on Work and Files, and tag chats with a target from the composer. **Agent tools still run on the local machine**; SSH targets are stored as metadata with explicit “planned” vs future connection modes until remote execution is implemented.

## What changed

- **Persistence**: `AdeExecutionTargetsState` stored in project SQLite under `ade_execution_targets:<projectId>`.
- **IPC / preload**: `window.ade.executionTargets.get` / `set`.
- **ProjectInfo**: optional `projectId` for stable scoping (set when a project context is initialized).
- **Chats**: `executionTargetId` / `executionTargetLabel` on create, update, persisted chat JSON, summaries, and merged into `sessions.list` for the Work sidebar.
- **UI**: Top bar target switcher, Settings → Workspace → execution targets section, banners, composer dropdown (when project has target config), session list badge when chat target ≠ project active target.

## Validation

- `npm --prefix apps/desktop run typecheck`
- `npm --prefix apps/desktop run lint`
- `npm --prefix apps/desktop run test -- --run src/main/services/chat/agentChatService.test.ts`

## Follow-ups (not in this PR)

- Actually route PTY / agent runs over SSH or ADE runner.
- Mobile pairing and multi-device target sync.
- Missions, CTO, automations, and other surfaces that spawn work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1763e942-e33d-49c1-9cb6-fa4101a980d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1763e942-e33d-49c1-9cb6-fa4101a980d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execution targets support: choose local or SSH targets for chat sessions and terminals.
  * Workspace settings UI to add/manage SSH targets with validation and persistence.
  * Per-chat execution-target picker in the composer and top-bar workspace target selector.
  * Context banners and badges showing active target and workspace-focus mismatches across Files, Terminals, and chat.
  * New persistence and window API for getting/setting execution-target state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->