### PR TITLE
feat: multi-select existing worktrees when attaching lanes

### DIFF
--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -17,6 +17,7 @@ import type {
   BatchAssessmentResult,
   AttachLaneArgs,
   AdoptAttachedLaneArgs,
+  UnregisteredWorktree,
   AppInfo,
   ClearLocalAdeDataArgs,
   ClearLocalAdeDataResult,
@@ -3305,6 +3306,11 @@ export function registerIpc({
       reason: `lanes_attach:${lane.id}`,
     });
     return lane;
+  });
+
+  ipcMain.handle(IPC.lanesListUnregisteredWorktrees, async (): Promise<UnregisteredWorktree[]> => {
+    const ctx = getCtx();
+    return ctx.laneService.listUnregisteredWorktrees();
   });
 
   ipcMain.handle(IPC.lanesAdoptAttached, async (_event, arg: AdoptAttachedLaneArgs): Promise<LaneSummary> => {

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -17,7 +17,7 @@ import type {
   BatchAssessmentResult,
   AttachLaneArgs,
   AdoptAttachedLaneArgs,
-  UnregisteredWorktree,
+  UnregisteredLaneCandidate,
   AppInfo,
   ClearLocalAdeDataArgs,
   ClearLocalAdeDataResult,
@@ -3308,7 +3308,7 @@ export function registerIpc({
     return lane;
   });
 
-  ipcMain.handle(IPC.lanesListUnregisteredWorktrees, async (): Promise<UnregisteredWorktree[]> => {
+  ipcMain.handle(IPC.lanesListUnregisteredWorktrees, async (): Promise<UnregisteredLaneCandidate[]> => {
     const ctx = getCtx();
     return ctx.laneService.listUnregisteredWorktrees();
   });

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -36,6 +36,7 @@ import type {
   RebasePushArgs,
   PushMode,
   StackChainItem,
+  UnregisteredWorktree,
   UpdateLaneAppearanceArgs
 } from "../../../shared/types";
 import { resolveAdeLayout } from "../../../shared/adeLayout";
@@ -1126,6 +1127,42 @@ export function createLaneService({
 
     async list(args: ListLanesArgs = {}): Promise<LaneSummary[]> {
       return await listLanes(args);
+    },
+
+    async listUnregisteredWorktrees(): Promise<UnregisteredWorktree[]> {
+      const stdout = await runGitOrThrow(
+        ["worktree", "list", "--porcelain"],
+        { cwd: projectRoot, timeoutMs: 15_000 }
+      );
+
+      const blocks = stdout.split(/\n\n+/).filter(Boolean);
+      const worktrees: UnregisteredWorktree[] = [];
+
+      for (const block of blocks) {
+        const lines = block.split(/\r?\n/);
+        let wtPath = "";
+        let branch = "";
+        let isBare = false;
+        for (const line of lines) {
+          if (line.startsWith("worktree ")) wtPath = line.slice("worktree ".length).trim();
+          if (line.startsWith("branch ")) branch = line.slice("branch ".length).trim().replace(/^refs\/heads\//, "");
+          if (line === "bare") isBare = true;
+        }
+        if (!wtPath || isBare) continue;
+        worktrees.push({ path: normAbs(wtPath), branch });
+      }
+
+      // Filter out primary worktree and worktrees already tracked as lanes
+      const registeredPaths = new Set(
+        db.all<{ worktree_path: string }>(
+          "select worktree_path from lanes where project_id = ?",
+          [projectId]
+        ).map((row) => normAbs(row.worktree_path))
+      );
+
+      return worktrees.filter(
+        (wt) => wt.path !== normalizedProjectRoot && !registeredPaths.has(wt.path)
+      );
     },
 
     getStateSnapshot(laneId: string): LaneStateSnapshotSummary | null {

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -36,7 +36,7 @@ import type {
   RebasePushArgs,
   PushMode,
   StackChainItem,
-  UnregisteredWorktree,
+  UnregisteredLaneCandidate,
   UpdateLaneAppearanceArgs
 } from "../../../shared/types";
 import { resolveAdeLayout } from "../../../shared/adeLayout";
@@ -1129,14 +1129,14 @@ export function createLaneService({
       return await listLanes(args);
     },
 
-    async listUnregisteredWorktrees(): Promise<UnregisteredWorktree[]> {
+    async listUnregisteredWorktrees(): Promise<UnregisteredLaneCandidate[]> {
       const stdout = await runGitOrThrow(
         ["worktree", "list", "--porcelain"],
         { cwd: projectRoot, timeoutMs: 15_000 }
       );
 
       const blocks = stdout.split(/\n\n+/).filter(Boolean);
-      const worktrees: UnregisteredWorktree[] = [];
+      const worktrees: UnregisteredLaneCandidate[] = [];
 
       for (const block of blocks) {
         const lines = block.split(/\r?\n/);

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -6,6 +6,7 @@ import type {
   ApplyConflictProposalArgs,
   AttachLaneArgs,
   AdoptAttachedLaneArgs,
+  UnregisteredWorktree,
   AppInfo,
   AutoUpdateSnapshot,
   ClearLocalAdeDataArgs,
@@ -762,6 +763,7 @@ declare global {
         createFromUnstaged: (args: CreateLaneFromUnstagedArgs) => Promise<LaneSummary>;
         importBranch: (args: ImportBranchLaneArgs) => Promise<LaneSummary>;
         attach: (args: AttachLaneArgs) => Promise<LaneSummary>;
+        listUnregisteredWorktrees: () => Promise<UnregisteredWorktree[]>;
         adoptAttached: (args: AdoptAttachedLaneArgs) => Promise<LaneSummary>;
         rename: (args: RenameLaneArgs) => Promise<void>;
         reparent: (args: ReparentLaneArgs) => Promise<ReparentLaneResult>;

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -6,7 +6,7 @@ import type {
   ApplyConflictProposalArgs,
   AttachLaneArgs,
   AdoptAttachedLaneArgs,
-  UnregisteredWorktree,
+  UnregisteredLaneCandidate,
   AppInfo,
   AutoUpdateSnapshot,
   ClearLocalAdeDataArgs,
@@ -763,7 +763,7 @@ declare global {
         createFromUnstaged: (args: CreateLaneFromUnstagedArgs) => Promise<LaneSummary>;
         importBranch: (args: ImportBranchLaneArgs) => Promise<LaneSummary>;
         attach: (args: AttachLaneArgs) => Promise<LaneSummary>;
-        listUnregisteredWorktrees: () => Promise<UnregisteredWorktree[]>;
+        listUnregisteredWorktrees: () => Promise<UnregisteredLaneCandidate[]>;
         adoptAttached: (args: AdoptAttachedLaneArgs) => Promise<LaneSummary>;
         rename: (args: RenameLaneArgs) => Promise<void>;
         reparent: (args: ReparentLaneArgs) => Promise<ReparentLaneResult>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -6,7 +6,7 @@ import type {
   ApplyConflictProposalArgs,
   AttachLaneArgs,
   AdoptAttachedLaneArgs,
-  UnregisteredWorktree,
+  UnregisteredLaneCandidate,
   AppInfo,
   AutoUpdateSnapshot,
   ClearLocalAdeDataArgs,
@@ -973,7 +973,7 @@ contextBridge.exposeInMainWorld("ade", {
       ipcRenderer.invoke(IPC.lanesCreateFromUnstaged, args),
     importBranch: async (args: ImportBranchLaneArgs): Promise<LaneSummary> => ipcRenderer.invoke(IPC.lanesImportBranch, args),
     attach: async (args: AttachLaneArgs): Promise<LaneSummary> => ipcRenderer.invoke(IPC.lanesAttach, args),
-    listUnregisteredWorktrees: async (): Promise<UnregisteredWorktree[]> =>
+    listUnregisteredWorktrees: async (): Promise<UnregisteredLaneCandidate[]> =>
       ipcRenderer.invoke(IPC.lanesListUnregisteredWorktrees),
     adoptAttached: async (args: AdoptAttachedLaneArgs): Promise<LaneSummary> => ipcRenderer.invoke(IPC.lanesAdoptAttached, args),
     rename: async (args: RenameLaneArgs): Promise<void> => ipcRenderer.invoke(IPC.lanesRename, args),

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -6,6 +6,7 @@ import type {
   ApplyConflictProposalArgs,
   AttachLaneArgs,
   AdoptAttachedLaneArgs,
+  UnregisteredWorktree,
   AppInfo,
   AutoUpdateSnapshot,
   ClearLocalAdeDataArgs,
@@ -972,6 +973,8 @@ contextBridge.exposeInMainWorld("ade", {
       ipcRenderer.invoke(IPC.lanesCreateFromUnstaged, args),
     importBranch: async (args: ImportBranchLaneArgs): Promise<LaneSummary> => ipcRenderer.invoke(IPC.lanesImportBranch, args),
     attach: async (args: AttachLaneArgs): Promise<LaneSummary> => ipcRenderer.invoke(IPC.lanesAttach, args),
+    listUnregisteredWorktrees: async (): Promise<UnregisteredWorktree[]> =>
+      ipcRenderer.invoke(IPC.lanesListUnregisteredWorktrees),
     adoptAttached: async (args: AdoptAttachedLaneArgs): Promise<LaneSummary> => ipcRenderer.invoke(IPC.lanesAdoptAttached, args),
     rename: async (args: RenameLaneArgs): Promise<void> => ipcRenderer.invoke(IPC.lanesRename, args),
     reparent: async (args: ReparentLaneArgs): Promise<ReparentLaneResult> => ipcRenderer.invoke(IPC.lanesReparent, args),

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -16,6 +16,7 @@ import { LaneDiffPane } from "./LaneDiffPane";
 import { LaneWorkPane } from "./LaneWorkPane";
 import { CreateLaneDialog, type CreateLaneMode } from "./CreateLaneDialog";
 import { AttachLaneDialog } from "./AttachLaneDialog";
+import { MultiAttachWorktreeDialog } from "./MultiAttachWorktreeDialog";
 import { ManageLaneDialog } from "./ManageLaneDialog";
 import { LaneContextMenu } from "./LaneContextMenu";
 import { LaneRebaseBanner } from "./LaneRebaseBanner";
@@ -140,6 +141,7 @@ export function LanesPage() {
   const createBaseBranchUserPickedRef = useRef(false);
   const [templates, setTemplates] = useState<LaneTemplate[]>([]);
   const [selectedTemplateId, setSelectedTemplateId] = useState("");
+  const [multiAttachOpen, setMultiAttachOpen] = useState(false);
   const [attachOpen, setAttachOpen] = useState(false);
   const [attachName, setAttachName] = useState("");
   const [attachPath, setAttachPath] = useState("");
@@ -1524,19 +1526,15 @@ export function LanesPage() {
                 className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-muted-fg transition-colors hover:bg-white/[0.04] hover:text-fg"
                 onClick={() => {
                   setAddLaneDropdownOpen(false);
-                  setAttachName("");
-                  setAttachPath("");
-                  setAttachBusy(false);
-                  setAttachError(null);
-                  setAttachOpen(true);
+                  setMultiAttachOpen(true);
                 }}
               >
                 <span className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-white/[0.06] bg-white/[0.03] text-info">
                   <Link size={14} />
                 </span>
                 <span>
-                  <span className="block font-medium">Add existing worktree as lane</span>
-                  <span className="block text-xs text-muted-fg/70">Track a worktree that already exists on disk.</span>
+                  <span className="block font-medium">Add existing worktrees as lanes</span>
+                  <span className="block text-xs text-muted-fg/70">Select from worktrees that already exist on disk.</span>
                 </span>
               </button>
             </div>
@@ -2032,6 +2030,23 @@ export function LanesPage() {
         busy={attachBusy}
         error={attachError}
         onSubmit={handleAttachSubmit}
+      />
+
+      <MultiAttachWorktreeDialog
+        open={multiAttachOpen}
+        onOpenChange={setMultiAttachOpen}
+        onFallbackToManual={() => {
+          setMultiAttachOpen(false);
+          setAttachName("");
+          setAttachPath("");
+          setAttachDescription("");
+          setAttachBusy(false);
+          setAttachError(null);
+          setAttachOpen(true);
+        }}
+        onComplete={() => {
+          refreshLanes();
+        }}
       />
 
       {adoptConfirmOpen ? (

--- a/apps/desktop/src/renderer/components/lanes/MultiAttachWorktreeDialog.tsx
+++ b/apps/desktop/src/renderer/components/lanes/MultiAttachWorktreeDialog.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useState } from "react";
+import { Link, WarningCircle, CircleNotch, TextAlignLeft } from "@phosphor-icons/react";
+import type { UnregisteredWorktree } from "../../../shared/types/lanes";
+import { Button } from "../ui/Button";
+import { LaneDialogShell } from "./LaneDialogShell";
+import { SECTION_CLASS_NAME } from "./laneDialogTokens";
+
+export function MultiAttachWorktreeDialog({
+  open,
+  onOpenChange,
+  onFallbackToManual,
+  onComplete,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onFallbackToManual: () => void;
+  onComplete: () => void;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [worktrees, setWorktrees] = useState<UnregisteredWorktree[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [attaching, setAttaching] = useState(false);
+  const [progress, setProgress] = useState({ current: 0, total: 0 });
+  const [errors, setErrors] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setFetchError(null);
+    setSelected(new Set());
+    setErrors([]);
+    setProgress({ current: 0, total: 0 });
+    window.ade.lanes
+      .listUnregisteredWorktrees()
+      .then((result) => {
+        setWorktrees(result);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setFetchError(err instanceof Error ? err.message : String(err));
+        setLoading(false);
+      });
+  }, [open]);
+
+  const allSelected = selected.size === worktrees.length && worktrees.length > 0;
+
+  const toggleAll = () => {
+    if (allSelected) setSelected(new Set());
+    else setSelected(new Set(worktrees.map((wt) => wt.path)));
+  };
+
+  const toggleOne = (path: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  };
+
+  const handleAttach = async () => {
+    const toAttach = worktrees.filter((wt) => selected.has(wt.path));
+    if (toAttach.length === 0) return;
+    setAttaching(true);
+    setErrors([]);
+    const collectedErrors: string[] = [];
+    for (let i = 0; i < toAttach.length; i++) {
+      setProgress({ current: i + 1, total: toAttach.length });
+      try {
+        const wt = toAttach[i];
+        const name = wt.branch || wt.path.split("/").pop() || "worktree";
+        await window.ade.lanes.attach({ name, attachedPath: wt.path });
+      } catch (err) {
+        collectedErrors.push(
+          `${toAttach[i].branch || toAttach[i].path}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }
+    setErrors(collectedErrors);
+    setAttaching(false);
+    if (collectedErrors.length === 0) {
+      onComplete();
+      onOpenChange(false);
+    } else {
+      // Partial success — refresh the list to remove successfully attached items
+      onComplete();
+      try {
+        const refreshed = await window.ade.lanes.listUnregisteredWorktrees();
+        setWorktrees(refreshed);
+        setSelected(new Set());
+      } catch {
+        // non-fatal
+      }
+    }
+  };
+
+  const busy = loading || attaching;
+
+  return (
+    <LaneDialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Add existing worktrees as lanes"
+      description="Select worktrees to track as lanes in this project."
+      icon={Link}
+      widthClassName="w-[min(760px,calc(100vw-24px))]"
+      busy={busy}
+    >
+      <div className="space-y-4">
+        {loading ? (
+          <section className={SECTION_CLASS_NAME}>
+            <div className="flex items-center gap-3 py-6 justify-center text-sm text-muted-fg">
+              <CircleNotch size={16} className="animate-spin" />
+              <span>Discovering worktrees...</span>
+            </div>
+          </section>
+        ) : fetchError ? (
+          <section className={SECTION_CLASS_NAME}>
+            <div className="flex items-start gap-2 text-sm text-red-200">
+              <WarningCircle size={16} className="mt-0.5 shrink-0" />
+              <span>{fetchError}</span>
+            </div>
+          </section>
+        ) : worktrees.length === 0 ? (
+          <section className={SECTION_CLASS_NAME}>
+            <div className="py-6 text-center">
+              <div className="text-sm text-muted-fg">
+                All worktrees are already tracked as lanes.
+              </div>
+              <button
+                type="button"
+                className="mt-3 text-xs text-accent hover:text-accent/80 transition-colors"
+                onClick={() => {
+                  onOpenChange(false);
+                  onFallbackToManual();
+                }}
+              >
+                Attach from a custom path instead
+              </button>
+            </div>
+          </section>
+        ) : (
+          <>
+            <section className={SECTION_CLASS_NAME}>
+              <div className="flex items-center justify-between mb-3">
+                <label className="flex items-center gap-2 text-xs text-muted-fg cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={allSelected}
+                    onChange={toggleAll}
+                    disabled={attaching}
+                  />
+                  Select all
+                </label>
+                <span className="text-xs text-muted-fg/70">
+                  {worktrees.length} worktree{worktrees.length !== 1 ? "s" : ""} found
+                </span>
+              </div>
+
+              <div className="max-h-[320px] overflow-y-auto space-y-1">
+                {worktrees.map((wt) => (
+                  <label
+                    key={wt.path}
+                    className="flex items-start gap-3 rounded-lg px-3 py-2.5 cursor-pointer transition-colors hover:bg-white/[0.04]"
+                  >
+                    <input
+                      type="checkbox"
+                      className="mt-0.5"
+                      checked={selected.has(wt.path)}
+                      onChange={() => toggleOne(wt.path)}
+                      disabled={attaching}
+                    />
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-fg truncate">
+                        {wt.branch || "(detached HEAD)"}
+                      </div>
+                      <div className="text-xs font-mono text-muted-fg/70 truncate">
+                        {wt.path}
+                      </div>
+                    </div>
+                  </label>
+                ))}
+              </div>
+            </section>
+
+            {attaching ? (
+              <div className="flex items-center gap-2 text-xs text-muted-fg">
+                <CircleNotch size={14} className="animate-spin" />
+                <span>Attaching {progress.current} of {progress.total}...</span>
+              </div>
+            ) : null}
+          </>
+        )}
+
+        {errors.length > 0 ? (
+          <div className="space-y-1">
+            {errors.map((err, i) => (
+              <div key={i} className="flex items-start gap-2 rounded-xl border border-red-500/25 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+                <WarningCircle size={16} className="mt-0.5 shrink-0" />
+                <span>{err}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            className="text-xs text-muted-fg/70 hover:text-muted-fg transition-colors flex items-center gap-1.5"
+            onClick={() => {
+              onOpenChange(false);
+              onFallbackToManual();
+            }}
+            disabled={busy}
+          >
+            <TextAlignLeft size={12} />
+            Use manual form
+          </button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            {worktrees.length > 0 ? (
+              <Button
+                variant="primary"
+                disabled={selected.size === 0 || busy}
+                onClick={handleAttach}
+              >
+                {attaching
+                  ? `Attaching ${progress.current}/${progress.total}...`
+                  : `Attach selected (${selected.size})`}
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </LaneDialogShell>
+  );
+}

--- a/apps/desktop/src/renderer/components/lanes/MultiAttachWorktreeDialog.tsx
+++ b/apps/desktop/src/renderer/components/lanes/MultiAttachWorktreeDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import { Link, WarningCircle, CircleNotch, TextAlignLeft } from "@phosphor-icons/react";
-import type { UnregisteredWorktree } from "../../../shared/types/lanes";
+import { Link, WarningCircle, CircleNotch, TextAlignLeft, Warning } from "@phosphor-icons/react";
+import type { UnregisteredLaneCandidate } from "../../../shared/types/lanes";
 import { Button } from "../ui/Button";
 import { LaneDialogShell } from "./LaneDialogShell";
 import { SECTION_CLASS_NAME } from "./laneDialogTokens";
@@ -17,30 +17,40 @@ export function MultiAttachWorktreeDialog({
   onComplete: () => void;
 }) {
   const [loading, setLoading] = useState(false);
-  const [worktrees, setWorktrees] = useState<UnregisteredWorktree[]>([]);
+  const [worktrees, setWorktrees] = useState<UnregisteredLaneCandidate[]>([]);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [attaching, setAttaching] = useState(false);
   const [progress, setProgress] = useState({ current: 0, total: 0 });
   const [errors, setErrors] = useState<string[]>([]);
+  const [moveToAde, setMoveToAde] = useState(false);
+  const [moveConfirmOpen, setMoveConfirmOpen] = useState(false);
 
   useEffect(() => {
     if (!open) return;
+    let cancelled = false;
     setLoading(true);
     setFetchError(null);
     setSelected(new Set());
     setErrors([]);
     setProgress({ current: 0, total: 0 });
+    setMoveToAde(false);
+    setMoveConfirmOpen(false);
     window.ade.lanes
       .listUnregisteredWorktrees()
       .then((result) => {
+        if (cancelled) return;
         setWorktrees(result);
         setLoading(false);
       })
       .catch((err) => {
+        if (cancelled) return;
         setFetchError(err instanceof Error ? err.message : String(err));
         setLoading(false);
       });
+    return () => {
+      cancelled = true;
+    };
   }, [open]);
 
   const allSelected = selected.size === worktrees.length && worktrees.length > 0;
@@ -74,14 +84,17 @@ export function MultiAttachWorktreeDialog({
     setErrors([]);
     const collectedErrors: string[] = [];
     for (let i = 0; i < toAttach.length; i++) {
+      const wt = toAttach[i]!;
       setProgress({ current: i + 1, total: toAttach.length });
       try {
-        const wt = toAttach[i];
         const name = wt.branch || wt.path.split("/").pop() || "worktree";
-        await window.ade.lanes.attach({ name, attachedPath: wt.path });
+        const lane = await window.ade.lanes.attach({ name, attachedPath: wt.path });
+        if (moveToAde) {
+          await window.ade.lanes.adoptAttached({ laneId: lane.id });
+        }
       } catch (err) {
         collectedErrors.push(
-          `${toAttach[i].branch || toAttach[i].path}: ${err instanceof Error ? err.message : String(err)}`
+          `${wt.branch || wt.path}: ${err instanceof Error ? err.message : String(err)}`
         );
       }
     }
@@ -202,10 +215,40 @@ export function MultiAttachWorktreeDialog({
               </div>
             </section>
 
+            {/* Move to .ade/worktrees option */}
+            <section className="rounded-xl border border-red-500/25 bg-red-500/[0.06] px-4 py-3">
+              <label className="flex items-start gap-3 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  className="mt-0.5 accent-red-500"
+                  checked={moveToAde}
+                  onChange={() => {
+                    if (!moveToAde) {
+                      setMoveConfirmOpen(true);
+                    } else {
+                      setMoveToAde(false);
+                    }
+                  }}
+                  disabled={attaching}
+                />
+                <div className="min-w-0">
+                  <div className="flex items-center gap-1.5 text-sm font-semibold text-red-300">
+                    <Warning size={14} weight="fill" />
+                    Move into .ade/worktrees after import
+                  </div>
+                  <div className="mt-1 text-xs text-red-300/70 leading-relaxed">
+                    Relocates each worktree from its current location into <code className="font-mono text-red-300/90">.ade/worktrees/</code> for
+                    full ADE lifecycle management. This physically moves files on disk using <code className="font-mono text-red-300/90">git worktree move</code>.
+                    Absolute paths, IDE project references, and terminal sessions pointing to the old location will break.
+                  </div>
+                </div>
+              </label>
+            </section>
+
             {attaching ? (
               <div className="flex items-center gap-2 text-xs text-muted-fg">
                 <CircleNotch size={14} className="animate-spin" />
-                <span>Attaching {progress.current} of {progress.total}...</span>
+                <span>Attaching {progress.current} of {progress.total}{moveToAde ? " (+ moving)" : ""}...</span>
               </div>
             ) : null}
           </>
@@ -257,6 +300,51 @@ export function MultiAttachWorktreeDialog({
           </div>
         </div>
       </div>
+      {/* Confirmation modal for move-to-.ade */}
+      {moveConfirmOpen ? (
+        <div className="fixed inset-0 z-[200] flex items-center justify-center p-4 bg-black/60">
+          <div className="w-[min(480px,100%)] rounded-2xl border border-red-500/30 bg-[#1a1a1a] p-5 shadow-2xl">
+            <div className="flex items-center gap-2 text-sm font-bold text-red-400">
+              <Warning size={18} weight="fill" />
+              Confirm: Move worktrees into .ade
+            </div>
+            <div className="mt-3 space-y-2 text-xs text-neutral-300 leading-relaxed">
+              <p>
+                This will <strong className="text-red-300">physically relocate</strong> each selected worktree
+                from its current directory into <code className="font-mono text-red-300/90">.ade/worktrees/</code>.
+              </p>
+              <p>The following may break after the move:</p>
+              <ul className="list-disc pl-4 space-y-1 text-neutral-400">
+                <li>Absolute paths in build configs, scripts, or CI pipelines</li>
+                <li>IDE project files and workspace references</li>
+                <li>Running terminal sessions or file watchers in the old path</li>
+                <li>Symlinks or external tooling that reference the worktree location</li>
+              </ul>
+              <p>
+                Git branch history and commits are <strong>not affected</strong> — only the on-disk location changes.
+              </p>
+            </div>
+            <div className="flex justify-end gap-2 mt-4">
+              <Button
+                variant="outline"
+                onClick={() => setMoveConfirmOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                className="!bg-red-600 hover:!bg-red-700 !border-red-600"
+                onClick={() => {
+                  setMoveToAde(true);
+                  setMoveConfirmOpen(false);
+                }}
+              >
+                I understand, enable move
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </LaneDialogShell>
   );
 }

--- a/apps/desktop/src/renderer/components/lanes/MultiAttachWorktreeDialog.tsx
+++ b/apps/desktop/src/renderer/components/lanes/MultiAttachWorktreeDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, WarningCircle, CircleNotch, TextAlignLeft } from "@phosphor-icons/react";
 import type { UnregisteredWorktree } from "../../../shared/types/lanes";
 import { Button } from "../ui/Button";
@@ -44,6 +44,14 @@ export function MultiAttachWorktreeDialog({
   }, [open]);
 
   const allSelected = selected.size === worktrees.length && worktrees.length > 0;
+  const someSelected = selected.size > 0 && selected.size < worktrees.length;
+
+  const selectAllRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = someSelected;
+    }
+  }, [someSelected]);
 
   const toggleAll = () => {
     if (allSelected) setSelected(new Set());
@@ -83,12 +91,21 @@ export function MultiAttachWorktreeDialog({
       onComplete();
       onOpenChange(false);
     } else {
-      // Partial success — refresh the list to remove successfully attached items
+      // Partial success — refresh the list to remove successfully attached items,
+      // then pre-select the ones that failed so the user can retry them.
+      const failedPaths = new Set(
+        toAttach
+          .filter((wt) => {
+            const prefix = wt.branch || wt.path;
+            return collectedErrors.some((e) => e.startsWith(prefix + ":"));
+          })
+          .map((wt) => wt.path)
+      );
       onComplete();
       try {
         const refreshed = await window.ade.lanes.listUnregisteredWorktrees();
         setWorktrees(refreshed);
-        setSelected(new Set());
+        setSelected(new Set(refreshed.filter((wt) => failedPaths.has(wt.path)).map((wt) => wt.path)));
       } catch {
         // non-fatal
       }
@@ -146,6 +163,7 @@ export function MultiAttachWorktreeDialog({
               <div className="flex items-center justify-between mb-3">
                 <label className="flex items-center gap-2 text-xs text-muted-fg cursor-pointer select-none">
                   <input
+                    ref={selectAllRef}
                     type="checkbox"
                     checked={allSelected}
                     onChange={toggleAll}

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -33,6 +33,7 @@ export const IPC = {
   lanesCreateFromUnstaged: "ade.lanes.createFromUnstaged",
   lanesImportBranch: "ade.lanes.importBranch",
   lanesAttach: "ade.lanes.attach",
+  lanesListUnregisteredWorktrees: "ade.lanes.listUnregisteredWorktrees",
   lanesAdoptAttached: "ade.lanes.adoptAttached",
   lanesRename: "ade.lanes.rename",
   lanesReparent: "ade.lanes.reparent",

--- a/apps/desktop/src/shared/types/lanes.ts
+++ b/apps/desktop/src/shared/types/lanes.ts
@@ -141,7 +141,7 @@ export type AttachLaneArgs = {
   description?: string;
 };
 
-export type UnregisteredWorktree = {
+export type UnregisteredLaneCandidate = {
   path: string;
   branch: string;
 };

--- a/apps/desktop/src/shared/types/lanes.ts
+++ b/apps/desktop/src/shared/types/lanes.ts
@@ -141,6 +141,11 @@ export type AttachLaneArgs = {
   description?: string;
 };
 
+export type UnregisteredWorktree = {
+  path: string;
+  branch: string;
+};
+
 export type AdoptAttachedLaneArgs = {
   laneId: string;
 };


### PR DESCRIPTION
Add a new dialog that auto-discovers unregistered git worktrees and lets users select multiple to attach as lanes at once, replacing the manual one-at-a-time path entry. The original manual form is preserved as a fallback for custom paths.

- Add listUnregisteredWorktrees() to laneService (parses git worktree list --porcelain)
- Wire through IPC, preload bridge, and type declarations
- New MultiAttachWorktreeDialog with checkbox list, select all, progress tracking
- Existing AttachLaneDialog kept accessible via "Use manual form" fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced multi-worktree attachment dialog enabling users to select and attach multiple existing worktrees as lanes simultaneously
  * Automatically discovers unregistered worktrees in the repository for quick selection and batch attachment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->