### PR TITLE
Chat Tool Streaming

### DIFF
--- a/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
@@ -197,8 +197,6 @@ struct WorkToolGroupCardView: View {
     ZStack(alignment: .bottom) {
       if !effectiveExpanded && group.count > 1 {
         collapsedStackBackdrop
-      } else {
-        EmptyView()
       }
 
       VStack(alignment: .leading, spacing: 10) {
@@ -214,7 +212,10 @@ struct WorkToolGroupCardView: View {
           .stroke(ADEColor.border.opacity(0.14), lineWidth: 0.5)
       )
     }
-    .padding(.bottom, !effectiveExpanded && group.count > 1 ? 6 : 0)
+    // Backdrop rectangles use offset(y: 4/8) below the ZStack frame, so the
+    // bottom padding needs at least 10pt of breathing room to keep them from
+    // clipping against the next row on smaller devices.
+    .padding(.bottom, !effectiveExpanded && group.count > 1 ? 10 : 0)
     .accessibilityElement(children: .contain)
     .accessibilityLabel("Tool call cluster, \(group.count) calls, \(effectiveExpanded ? "expanded" : "collapsed")")
   }
@@ -372,7 +373,9 @@ private struct WorkToolGroupMemberRow: View {
         references: extractWorkNavigationTargets(
           from: [card.argsText, card.resultText].compactMap { $0 }.joined(separator: "\n")
         ),
-        isExpanded: localExpanded,
+        // Running cards stay auto-expanded so live args/output remain visible
+        // during streaming — the whole point of the tool-streaming flow.
+        isExpanded: card.status == .running || localExpanded,
         onToggle: { localExpanded.toggle() },
         onOpenFile: onOpenFile,
         onOpenPr: onOpenPr

--- a/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
@@ -181,8 +181,8 @@ struct WorkToolCardView: View {
 
 /// Cluster of consecutive tool/command/file-change entries shown as one row
 /// to preserve space in the iOS chat. Collapsed: icon + latest-call title +
-/// "N calls" pill + 2-row mini preview of the older calls. Expanded: each
-/// member renders as its full card inline, matching the desktop
+/// count/status, with only a visual stack hint for older calls. Expanded:
+/// each member renders as its full card inline, matching the desktop
 /// `ChatWorkLogBlock` behavior.
 struct WorkToolGroupCardView: View {
   let group: WorkToolGroupModel
@@ -194,20 +194,27 @@ struct WorkToolGroupCardView: View {
   private var effectiveExpanded: Bool { isExpanded }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 10) {
-      header
-      if effectiveExpanded {
-        expandedMembers
+    ZStack(alignment: .bottom) {
+      if !effectiveExpanded && group.count > 1 {
+        collapsedStackBackdrop
       } else {
-        collapsedPreview
+        EmptyView()
       }
+
+      VStack(alignment: .leading, spacing: 10) {
+        header
+        if effectiveExpanded {
+          expandedMembers
+        }
+      }
+      .padding(12)
+      .background(ADEColor.surfaceBackground.opacity(0.35), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+      .overlay(
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
+          .stroke(ADEColor.border.opacity(0.14), lineWidth: 0.5)
+      )
     }
-    .padding(12)
-    .background(ADEColor.surfaceBackground.opacity(0.35), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
-    .overlay(
-      RoundedRectangle(cornerRadius: 16, style: .continuous)
-        .stroke(ADEColor.border.opacity(0.14), lineWidth: 0.5)
-    )
+    .padding(.bottom, !effectiveExpanded && group.count > 1 ? 6 : 0)
     .accessibilityElement(children: .contain)
     .accessibilityLabel("Tool call cluster, \(group.count) calls, \(effectiveExpanded ? "expanded" : "collapsed")")
   }
@@ -250,34 +257,29 @@ struct WorkToolGroupCardView: View {
     .buttonStyle(.plain)
   }
 
-  /// Compact stack of the older members below the header — matches the
-  /// desktop collapsed cluster where the latest call sits on top and a few
-  /// previous calls peek underneath as hint rows.
-  private var collapsedPreview: some View {
-    let older = Array(group.members.dropLast().suffix(3).reversed())
-    return VStack(alignment: .leading, spacing: 4) {
-      ForEach(older) { member in
-        HStack(spacing: 8) {
-          Image(systemName: memberIcon(member))
-            .font(.system(size: 10, weight: .semibold))
-            .foregroundStyle(color(for: member.status))
-            .frame(width: 14, height: 14)
-          Text(memberTitle(member))
-            .font(.caption2)
-            .foregroundStyle(ADEColor.textSecondary)
-            .lineLimit(1)
-            .truncationMode(.middle)
-          Spacer(minLength: 4)
-        }
-        .padding(.leading, 38)
-      }
-      if group.members.count > older.count + 1 {
-        Text("+\(group.members.count - older.count - 1) earlier")
-          .font(.caption2.weight(.medium))
-          .foregroundStyle(ADEColor.textMuted)
-          .padding(.leading, 38)
-      }
+  /// Non-textual stack hint for hidden earlier calls. The collapsed row keeps
+  /// only the latest call readable; the depth lives in the count pill.
+  private var collapsedStackBackdrop: some View {
+    ZStack(alignment: .bottom) {
+      RoundedRectangle(cornerRadius: 15, style: .continuous)
+        .fill(ADEColor.surfaceBackground.opacity(0.18))
+        .overlay(
+          RoundedRectangle(cornerRadius: 15, style: .continuous)
+            .stroke(ADEColor.border.opacity(0.08), lineWidth: 0.5)
+        )
+        .padding(.horizontal, 10)
+        .offset(y: 4)
+      RoundedRectangle(cornerRadius: 14, style: .continuous)
+        .fill(ADEColor.surfaceBackground.opacity(0.12))
+        .overlay(
+          RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .stroke(ADEColor.border.opacity(0.06), lineWidth: 0.5)
+        )
+        .padding(.horizontal, 20)
+        .offset(y: 8)
     }
+    .frame(height: 36)
+    .allowsHitTesting(false)
   }
 
   private var expandedMembers: some View {
@@ -370,7 +372,7 @@ private struct WorkToolGroupMemberRow: View {
         references: extractWorkNavigationTargets(
           from: [card.argsText, card.resultText].compactMap { $0 }.joined(separator: "\n")
         ),
-        isExpanded: card.status == .running || localExpanded,
+        isExpanded: localExpanded,
         onToggle: { localExpanded.toggle() },
         onOpenFile: onOpenFile,
         onOpenPr: onOpenPr

--- a/apps/ios/ADE/Views/Work/WorkEventMapping.swift
+++ b/apps/ios/ADE/Views/Work/WorkEventMapping.swift
@@ -7,6 +7,15 @@ func workStableTimelineItemId(itemId: String, logicalItemId: String?) -> String 
   return logical.isEmpty ? itemId : logical
 }
 
+/// Optional-itemId overload for transcript parsing, where the raw event dict
+/// may omit `itemId`. Keeps the resolution policy in one place so desktop and
+/// transcript code paths stay in sync.
+func workStableTimelineItemId(itemId: String?, logicalItemId: String?) -> String? {
+  let logical = logicalItemId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  if !logical.isEmpty { return logical }
+  return itemId
+}
+
 private final class WorkANSIAttributedStringCacheBox: NSObject {
   let value: AttributedString
 
@@ -151,8 +160,12 @@ func makeWorkChatEvent(from event: AgentChatEvent) -> WorkChatEvent {
       durationMs: durationMs,
       turnId: turnId
     )
-  case .fileChange(let path, let diff, let kind, let itemId, let logicalItemId, let turnId, let status):
-    return .fileChange(path: path, diff: diff, kind: kind.rawValue, status: toolStatus(from: status ?? "running"), itemId: workStableTimelineItemId(itemId: itemId, logicalItemId: logicalItemId), turnId: turnId)
+  case .fileChange(let path, let diff, let kind, let itemId, _, let turnId, let status):
+    // File-change events deliberately keep the raw `itemId`: the desktop
+    // emitter produces one event per file with a shared `logicalItemId` but
+    // distinct raw IDs (see agentChatService `patch` handling). Collapsing to
+    // `logicalItemId` would overwrite earlier paths in `buildWorkFileChangeCards`.
+    return .fileChange(path: path, diff: diff, kind: kind.rawValue, status: toolStatus(from: status ?? "running"), itemId: itemId, turnId: turnId)
   case .stepBoundary:
     return .unknown(type: "step_boundary")
   case .delegationState:

--- a/apps/ios/ADE/Views/Work/WorkEventMapping.swift
+++ b/apps/ios/ADE/Views/Work/WorkEventMapping.swift
@@ -2,6 +2,11 @@ import SwiftUI
 import UIKit
 import AVKit
 
+func workStableTimelineItemId(itemId: String, logicalItemId: String?) -> String {
+  let logical = logicalItemId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+  return logical.isEmpty ? itemId : logical
+}
+
 private final class WorkANSIAttributedStringCacheBox: NSObject {
   let value: AttributedString
 
@@ -23,19 +28,19 @@ func makeWorkChatEvent(from event: AgentChatEvent) -> WorkChatEvent {
     return .userMessage(text: text, turnId: turnId, steerId: steerId, deliveryState: deliveryState, processed: processed)
   case .text(let text, _, let turnId, let itemId):
     return .assistantText(text: text, turnId: turnId, itemId: itemId)
-  case .toolCall(let tool, let args, let itemId, _, let parentItemId, let turnId):
+  case .toolCall(let tool, let args, let itemId, let logicalItemId, let parentItemId, let turnId):
     return .toolCall(
       tool: tool,
       argsText: prettyPrintedRemoteJSONValue(args),
-      itemId: itemId,
+      itemId: workStableTimelineItemId(itemId: itemId, logicalItemId: logicalItemId),
       parentItemId: parentItemId,
       turnId: turnId
     )
-  case .toolResult(let tool, let result, let itemId, _, let parentItemId, let turnId, let status):
+  case .toolResult(let tool, let result, let itemId, let logicalItemId, let parentItemId, let turnId, let status):
     return .toolResult(
       tool: tool,
       resultText: prettyPrintedRemoteJSONValue(result),
-      itemId: itemId,
+      itemId: workStableTimelineItemId(itemId: itemId, logicalItemId: logicalItemId),
       parentItemId: parentItemId,
       turnId: turnId,
       status: toolStatus(from: status ?? "running")
@@ -115,8 +120,8 @@ func makeWorkChatEvent(from event: AgentChatEvent) -> WorkChatEvent {
   case .autoApprovalReview(_, let reviewStatus, let action, let review, let turnId):
     let summary = [reviewStatus.rawValue.capitalized, action, review].compactMap { $0 }.joined(separator: "\n")
     return .autoApprovalReview(summary: summary, turnId: turnId)
-  case .webSearch(let query, let action, let itemId, _, let turnId, let status):
-    return .webSearch(query: query, action: action, status: toolStatus(from: status), itemId: itemId, turnId: turnId)
+  case .webSearch(let query, let action, let itemId, let logicalItemId, let turnId, let status):
+    return .webSearch(query: query, action: action, status: toolStatus(from: status), itemId: workStableTimelineItemId(itemId: itemId, logicalItemId: logicalItemId), turnId: turnId)
   case .planText(let text, let turnId, _):
     return .planText(text: text, turnId: turnId)
   case .toolUseSummary(let summary, _, let turnId):
@@ -135,19 +140,19 @@ func makeWorkChatEvent(from event: AgentChatEvent) -> WorkChatEvent {
       blockerDescription: report.blockerDescription,
       turnId: turnId
     )
-  case .command(let command, let cwd, let output, let itemId, _, let turnId, let exitCode, let durationMs, let status):
+  case .command(let command, let cwd, let output, let itemId, let logicalItemId, let turnId, let exitCode, let durationMs, let status):
     return .command(
       command: command,
       cwd: cwd,
       output: output,
       status: toolStatus(from: status),
-      itemId: itemId,
+      itemId: workStableTimelineItemId(itemId: itemId, logicalItemId: logicalItemId),
       exitCode: exitCode,
       durationMs: durationMs,
       turnId: turnId
     )
-  case .fileChange(let path, let diff, let kind, let itemId, _, let turnId, let status):
-    return .fileChange(path: path, diff: diff, kind: kind.rawValue, status: toolStatus(from: status ?? "running"), itemId: itemId, turnId: turnId)
+  case .fileChange(let path, let diff, let kind, let itemId, let logicalItemId, let turnId, let status):
+    return .fileChange(path: path, diff: diff, kind: kind.rawValue, status: toolStatus(from: status ?? "running"), itemId: workStableTimelineItemId(itemId: itemId, logicalItemId: logicalItemId), turnId: turnId)
   case .stepBoundary:
     return .unknown(type: "step_boundary")
   case .delegationState:

--- a/apps/ios/ADE/Views/Work/WorkTranscriptParser.swift
+++ b/apps/ios/ADE/Views/Work/WorkTranscriptParser.swift
@@ -29,9 +29,8 @@ func parseWorkChatTranscript(_ raw: String) -> [WorkChatEnvelope] {
       let sequence = envelope["sequence"] as? Int
       let turnId = eventDict["turnId"] as? String
       let itemId = eventDict["itemId"] as? String
-      let logicalItemId = (eventDict["logicalItemId"] as? String)?
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-      let stableToolItemId = (logicalItemId?.isEmpty == false ? logicalItemId : nil) ?? itemId
+      let logicalItemId = eventDict["logicalItemId"] as? String
+      let stableToolItemId = workStableTimelineItemId(itemId: itemId, logicalItemId: logicalItemId)
       let parentItemId = eventDict["parentItemId"] as? String
       let event: WorkChatEvent
 
@@ -321,12 +320,15 @@ func parseWorkChatTranscript(_ raw: String) -> [WorkChatEnvelope] {
           turnId: turnId
         )
       case "file_change":
+        // Keep raw `itemId` here — the desktop emitter produces one event per
+        // file with a shared `logicalItemId`, so collapsing would overwrite
+        // earlier paths in `buildWorkFileChangeCards`.
         event = .fileChange(
           path: stringValue(eventDict["path"]),
           diff: stringValue(eventDict["diff"]),
           kind: stringValue(eventDict["kind"]),
           status: toolStatus(from: stringValue(eventDict["status"])),
-          itemId: stableToolItemId ?? workFallbackItemID(
+          itemId: itemId ?? workFallbackItemID(
             sessionId: sessionId,
             timestamp: timestamp,
             sequence: sequence,

--- a/apps/ios/ADE/Views/Work/WorkTranscriptParser.swift
+++ b/apps/ios/ADE/Views/Work/WorkTranscriptParser.swift
@@ -29,6 +29,9 @@ func parseWorkChatTranscript(_ raw: String) -> [WorkChatEnvelope] {
       let sequence = envelope["sequence"] as? Int
       let turnId = eventDict["turnId"] as? String
       let itemId = eventDict["itemId"] as? String
+      let logicalItemId = (eventDict["logicalItemId"] as? String)?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      let stableToolItemId = (logicalItemId?.isEmpty == false ? logicalItemId : nil) ?? itemId
       let parentItemId = eventDict["parentItemId"] as? String
       let event: WorkChatEvent
 
@@ -47,7 +50,7 @@ func parseWorkChatTranscript(_ raw: String) -> [WorkChatEnvelope] {
         event = .toolCall(
           tool: stringValue(eventDict["tool"]),
           argsText: prettyPrintedJSONString(eventDict["args"]),
-          itemId: itemId ?? workFallbackItemID(
+          itemId: stableToolItemId ?? workFallbackItemID(
             sessionId: sessionId,
             timestamp: timestamp,
             sequence: sequence,
@@ -67,7 +70,7 @@ func parseWorkChatTranscript(_ raw: String) -> [WorkChatEnvelope] {
         event = .toolResult(
           tool: stringValue(eventDict["tool"]),
           resultText: prettyPrintedJSONString(eventDict["result"]),
-          itemId: itemId ?? workFallbackItemID(
+          itemId: stableToolItemId ?? workFallbackItemID(
             sessionId: sessionId,
             timestamp: timestamp,
             sequence: sequence,
@@ -274,7 +277,7 @@ func parseWorkChatTranscript(_ raw: String) -> [WorkChatEnvelope] {
           query: stringValue(eventDict["query"]),
           action: optionalString(eventDict["action"]),
           status: toolStatus(from: stringValue(eventDict["status"])),
-          itemId: itemId ?? workFallbackItemID(
+          itemId: stableToolItemId ?? workFallbackItemID(
             sessionId: sessionId,
             timestamp: timestamp,
             sequence: sequence,
@@ -299,7 +302,7 @@ func parseWorkChatTranscript(_ raw: String) -> [WorkChatEnvelope] {
           cwd: stringValue(eventDict["cwd"]),
           output: stringValue(eventDict["output"]),
           status: toolStatus(from: stringValue(eventDict["status"])),
-          itemId: itemId ?? workFallbackItemID(
+          itemId: stableToolItemId ?? workFallbackItemID(
             sessionId: sessionId,
             timestamp: timestamp,
             sequence: sequence,
@@ -323,7 +326,7 @@ func parseWorkChatTranscript(_ raw: String) -> [WorkChatEnvelope] {
           diff: stringValue(eventDict["diff"]),
           kind: stringValue(eventDict["kind"]),
           status: toolStatus(from: stringValue(eventDict["status"])),
-          itemId: itemId ?? workFallbackItemID(
+          itemId: stableToolItemId ?? workFallbackItemID(
             sessionId: sessionId,
             timestamp: timestamp,
             sequence: sequence,

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -5706,6 +5706,57 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(cards.first?.status, .completed)
   }
 
+  /// Regression test: file_change events with a shared `logicalItemId` but
+  /// distinct raw `itemId` (OpenCode's patch emitter) must stay separate —
+  /// one card per file, not collapsed to a single entry.
+  func testBuildWorkFileChangeCardsKeepsDistinctFilesUnderSharedLogicalItemId() {
+    let firstFile = makeWorkChatEvent(from: .fileChange(
+      path: "Sources/First.swift",
+      diff: "diff-1",
+      kind: .modify,
+      itemId: "patch-1:Sources/First.swift",
+      logicalItemId: "patch-1",
+      turnId: "turn-1",
+      status: "completed"
+    ))
+    let secondFile = makeWorkChatEvent(from: .fileChange(
+      path: "Sources/Second.swift",
+      diff: "diff-2",
+      kind: .modify,
+      itemId: "patch-1:Sources/Second.swift",
+      logicalItemId: "patch-1",
+      turnId: "turn-1",
+      status: "completed"
+    ))
+
+    let transcript = [
+      WorkChatEnvelope(sessionId: "chat-1", timestamp: "2026-04-22T00:00:01.000Z", sequence: 1, event: firstFile),
+      WorkChatEnvelope(sessionId: "chat-1", timestamp: "2026-04-22T00:00:02.000Z", sequence: 2, event: secondFile),
+    ]
+    let cards = buildWorkFileChangeCards(from: transcript)
+
+    XCTAssertEqual(cards.count, 2)
+    XCTAssertEqual(Set(cards.map(\.path)), ["Sources/First.swift", "Sources/Second.swift"])
+    XCTAssertEqual(Set(cards.map(\.id)), [
+      "patch-1:Sources/First.swift",
+      "patch-1:Sources/Second.swift",
+    ])
+  }
+
+  /// Same regression, but driven through the transcript parser path so the
+  /// JSON-in / cards-out pipeline also preserves per-file identity.
+  func testParseWorkChatTranscriptKeepsDistinctFileChangesUnderSharedLogicalItemId() {
+    let raw = """
+    {"sessionId":"chat-1","timestamp":"2026-04-22T00:00:01.000Z","sequence":1,"event":{"type":"file_change","path":"Sources/First.swift","diff":"diff-1","kind":"modify","itemId":"patch-1:Sources/First.swift","logicalItemId":"patch-1","turnId":"turn-1","status":"completed"}}
+    {"sessionId":"chat-1","timestamp":"2026-04-22T00:00:02.000Z","sequence":2,"event":{"type":"file_change","path":"Sources/Second.swift","diff":"diff-2","kind":"modify","itemId":"patch-1:Sources/Second.swift","logicalItemId":"patch-1","turnId":"turn-1","status":"completed"}}
+    """
+    let transcript = parseWorkChatTranscript(raw)
+    let cards = buildWorkFileChangeCards(from: transcript)
+
+    XCTAssertEqual(cards.count, 2)
+    XCTAssertEqual(Set(cards.map(\.path)), ["Sources/First.swift", "Sources/Second.swift"])
+  }
+
   func testBuildWorkTimelineCollapsesConsecutiveToolCardsIntoLatestGroup() {
     let transcript: [WorkChatEnvelope] = [
       WorkChatEnvelope(

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -5661,6 +5661,98 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(toolEntries.first?.id, "tool-call-dup")
   }
 
+  func testWorkChatToolLifecycleUsesLogicalItemIdForStableCards() {
+    let call = makeWorkChatEvent(from: .toolCall(
+      tool: "functions.exec_command",
+      args: .object(["cmd": .string("pwd")]),
+      itemId: "tool-start-1",
+      logicalItemId: "tool-logical-1",
+      parentItemId: nil,
+      turnId: "turn-1"
+    ))
+    let result = makeWorkChatEvent(from: .toolResult(
+      tool: "functions.exec_command",
+      result: .object(["stdout": .string("/tmp/project")]),
+      itemId: "tool-result-1",
+      logicalItemId: "tool-logical-1",
+      parentItemId: nil,
+      turnId: "turn-1",
+      status: "completed"
+    ))
+
+    let transcript = [
+      WorkChatEnvelope(sessionId: "chat-1", timestamp: "2026-04-20T00:00:01.000Z", sequence: 1, event: call),
+      WorkChatEnvelope(sessionId: "chat-1", timestamp: "2026-04-20T00:00:02.000Z", sequence: 2, event: result),
+    ]
+    let cards = buildWorkToolCards(from: transcript)
+
+    XCTAssertEqual(cards.count, 1)
+    XCTAssertEqual(cards.first?.id, "tool-logical-1")
+    XCTAssertEqual(cards.first?.status, .completed)
+    XCTAssertNotNil(cards.first?.argsText)
+    XCTAssertNotNil(cards.first?.resultText)
+  }
+
+  func testParseWorkChatTranscriptUsesLogicalItemIdForStableToolCards() {
+    let raw = """
+    {"sessionId":"chat-1","timestamp":"2026-04-20T00:00:01.000Z","sequence":1,"event":{"type":"tool_call","tool":"functions.exec_command","args":{"cmd":"pwd"},"itemId":"tool-start-1","logicalItemId":"tool-logical-1","turnId":"turn-1"}}
+    {"sessionId":"chat-1","timestamp":"2026-04-20T00:00:02.000Z","sequence":2,"event":{"type":"tool_result","tool":"functions.exec_command","result":{"stdout":"/tmp/project"},"itemId":"tool-result-1","logicalItemId":"tool-logical-1","turnId":"turn-1","status":"completed"}}
+    """
+    let transcript = parseWorkChatTranscript(raw)
+    let cards = buildWorkToolCards(from: transcript)
+
+    XCTAssertEqual(cards.count, 1)
+    XCTAssertEqual(cards.first?.id, "tool-logical-1")
+    XCTAssertEqual(cards.first?.status, .completed)
+  }
+
+  func testBuildWorkTimelineCollapsesConsecutiveToolCardsIntoLatestGroup() {
+    let transcript: [WorkChatEnvelope] = [
+      WorkChatEnvelope(
+        sessionId: "chat-1",
+        timestamp: "2026-04-20T00:00:01.000Z",
+        sequence: 1,
+        event: .toolCall(tool: "functions.Read", argsText: "{\"path\":\"README.md\"}", itemId: "tool-1", parentItemId: nil, turnId: "turn-1")
+      ),
+      WorkChatEnvelope(
+        sessionId: "chat-1",
+        timestamp: "2026-04-20T00:00:02.000Z",
+        sequence: 2,
+        event: .toolResult(tool: "functions.Read", resultText: "{\"content\":\"ADE\"}", itemId: "tool-1", parentItemId: nil, turnId: "turn-1", status: .completed)
+      ),
+      WorkChatEnvelope(
+        sessionId: "chat-1",
+        timestamp: "2026-04-20T00:00:03.000Z",
+        sequence: 3,
+        event: .toolCall(tool: "functions.exec_command", argsText: "{\"cmd\":\"npm test\"}", itemId: "tool-2", parentItemId: nil, turnId: "turn-1")
+      ),
+    ]
+    let snapshot = buildWorkChatTimelineSnapshot(
+      transcript: transcript,
+      fallbackEntries: [],
+      artifacts: [],
+      localEchoMessages: []
+    )
+
+    let toolGroups = snapshot.timeline.compactMap { entry -> WorkToolGroupModel? in
+      guard case .toolGroup(let group) = entry.payload else { return nil }
+      return group
+    }
+    let standaloneToolCards = snapshot.timeline.compactMap { entry -> WorkToolCardModel? in
+      guard case .toolCard(let card) = entry.payload else { return nil }
+      return card
+    }
+
+    XCTAssertEqual(toolGroups.count, 1)
+    XCTAssertEqual(toolGroups.first?.members.count, 2)
+    XCTAssertTrue(standaloneToolCards.isEmpty)
+    guard case .tool(let latest)? = toolGroups.first?.latest else {
+      return XCTFail("Expected the latest visible group member to be the newest tool call.")
+    }
+    XCTAssertEqual(latest.id, "tool-2")
+    XCTAssertEqual(latest.status, .running)
+  }
+
   func testBuildWorkCommandCardsDedupesDuplicateCommandEventsByItemId() {
     let transcript: [WorkChatEnvelope] = [
       WorkChatEnvelope(


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collapsed tool-call clusters now display a visual stack indicator instead of text previews for better clarity.

* **Improvements**
  * Enhanced tool card deduplication and grouping for more stable timeline organization.
  * Tool card expansion behavior refined; running cards no longer auto-expand.

* **Tests**
  * Added test coverage for tool-card stability and timeline grouping with logical identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces two related improvements: (1) a `logicalItemId` field is now used as a stable key for tool/command/webSearch cards so that streaming updates (call → result) collapse onto the same card rather than creating duplicates, and (2) the collapsed group view replaces a text-based mini-preview with a purely visual stacked-card backdrop effect.

The deduplication logic is well-factored into `workStableTimelineItemId` overloads with appropriate test coverage, and the intentional `fileChange` carve-out (keeping raw `itemId` to preserve per-file identity under a shared `logicalItemId`) is documented and regression-tested.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are well-scoped, covered by regression tests, and prior review concerns have been addressed.

All findings from previous review threads are addressed (auto-expand preserved for running cards, backdrop padding added, shared-function comment noted). No new P0/P1 issues found. Good test coverage across both code paths (event mapping and transcript parser).

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Views/Work/WorkEventMapping.swift | Adds two `workStableTimelineItemId` overloads and wires them into toolCall, toolResult, webSearch, and command event mappings; fileChange intentionally keeps raw itemId. |
| apps/ios/ADE/Views/Work/WorkTranscriptParser.swift | Reads `logicalItemId` from the JSON envelope and applies `workStableTimelineItemId` for tool/command/webSearch events; file_change is correctly left on raw itemId. |
| apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift | Replaces the text-based collapsedPreview with a purely decorative stack-backdrop effect; VStack wrapped in ZStack with 10pt bottom padding to accommodate backdrop offsets. |
| apps/ios/ADETests/ADETests.swift | Adds 5 new test cases covering logical-ID stability for tool cards, file_change per-file identity, timeline grouping, and transcript-parser path end-to-end. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[AgentChatEvent / JSON transcript] --> B{Event type}
    B -->|toolCall / toolResult\nwebSearch / command| C[workStableTimelineItemId\nitemId + logicalItemId]
    B -->|fileChange| D[Keep raw itemId\nper-file identity preserved]
    C --> E{logicalItemId\nnon-empty?}
    E -->|Yes| F[Use logicalItemId\nas stable card key]
    E -->|No| G[Fall back to itemId\nor workFallbackItemID]
    F --> H[buildWorkToolCards\nbuildWorkCommandCards\nbuildWorkTimelineSnapshot]
    G --> H
    D --> I[buildWorkFileChangeCards\none card per file]
    H --> J[WorkToolGroupCardView\nCollapsed: stack backdrop\nExpanded: full member rows]
    I --> J
```

<sub>Reviews (2): Last reviewed commit: ["Address PR #174 review: keep file-change..."](https://github.com/arul28/ade/commit/dccc2f1c8d8f91a3de3f920b3d242e7ff655dd07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29349962)</sub>

<!-- /greptile_comment -->