### PR TITLE
Preserve Claude chat resume state and surface orphan lanes

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -763,6 +763,9 @@ app.whenReady().then(async () => {
 
   const setActiveProject = (projectRoot: string | null): void => {
     activeProjectRoot = projectRoot ? normalizeProjectRoot(projectRoot) : null;
+    for (const [root, ctx] of projectContexts) {
+      ctx.syncService?.setHostDiscoveryEnabled?.(activeProjectRoot != null && root === activeProjectRoot);
+    }
     if (activeProjectRoot) {
       projectLastActivatedAt.set(activeProjectRoot, Date.now());
       try {
@@ -2435,6 +2438,7 @@ app.whenReady().then(async () => {
       db,
       logger,
       projectRoot,
+      localDeviceIdPath: path.join(app.getPath("userData"), "sync-device-id"),
       fileService,
       laneService,
       gitService,
@@ -2466,6 +2470,7 @@ app.whenReady().then(async () => {
       getLinearSyncService: () => linearSyncServiceRef,
       processService,
       hostStartupEnabled: process.env.ADE_DISABLE_SYNC_HOST !== "1",
+      hostDiscoveryEnabled: activeProjectRoot != null && normalizeProjectRoot(projectRoot) === activeProjectRoot,
       notificationEventBus,
       projectCatalogProvider: {
         listProjects: listMobileSyncProjects,

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -5168,7 +5168,7 @@ describe("createAgentChatService", () => {
       }
     });
 
-    it("tears down idle Claude runtimes after the inactivity ttl", async () => {
+    it("tears down idle Claude runtimes after the inactivity ttl without losing resume state", async () => {
       vi.useFakeTimers();
       try {
         const close = vi.fn();
@@ -5231,6 +5231,20 @@ describe("createAgentChatService", () => {
         await vi.advanceTimersByTimeAsync(6 * 60_000);
 
         expect(close).toHaveBeenCalledTimes(1);
+        const persistedAfterIdle = readPersistedChatState(session.id);
+        expect(persistedAfterIdle.sdkSessionId).toBe("sdk-session-idle-ttl");
+        expect(persistedAfterIdle.lastLaneDirectiveKey).toEqual(expect.any(String));
+
+        await service.runSessionTurn({
+          sessionId: session.id,
+          text: "Follow up with the previous context",
+          timeoutMs: 15_000,
+        });
+
+        expect(unstable_v2_resumeSession).toHaveBeenCalledWith("sdk-session-idle-ttl", expect.any(Object));
+        expect(unstable_v2_createSession).toHaveBeenCalledTimes(1);
+        expect(send).toHaveBeenCalledTimes(3);
+        expect(String(send.mock.calls[2]?.[0] ?? "")).toContain("Follow up with the previous context");
       } finally {
         vi.useRealTimers();
       }

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -4535,6 +4535,43 @@ describe("createAgentChatService", () => {
       )).toEqual(["persisted-1", "persisted-2"]);
     });
 
+    it("keeps Claude streaming fragments that share a timestamp when hydrating", async () => {
+      // Claude V2 emits multiple text deltas inside tight streaming loops,
+      // so two legitimate envelopes with type:"text" can land on the same
+      // millisecond. A naive timestamp+type dedup key would collapse these;
+      // the cross-run-safe dedup must keep distinct payloads separate.
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "claude",
+        model: "sonnet",
+      });
+
+      const sharedTimestamp = new Date().toISOString();
+      const envelope1: AgentChatEventEnvelope = {
+        sessionId: session.id,
+        timestamp: sharedTimestamp,
+        event: { type: "text", text: "fragment-a" },
+        sequence: 1,
+      };
+      const envelope2: AgentChatEventEnvelope = {
+        sessionId: session.id,
+        timestamp: sharedTimestamp,
+        event: { type: "text", text: "fragment-b" },
+        sequence: 2,
+      };
+      const transcriptFile = path.join(tmpRoot, "transcripts", `${session.id}.chat.jsonl`);
+      fs.writeFileSync(transcriptFile, `${JSON.stringify(envelope1)}\n${JSON.stringify(envelope2)}\n`, "utf8");
+      vi.mocked(parseAgentChatTranscript).mockReturnValue([envelope1, envelope2]);
+
+      const history = service.getChatEventHistory(session.id);
+      expect(history.events).toHaveLength(2);
+      expect(history.events.map((e) => e.event.type === "text" ? e.event.text : "")).toEqual([
+        "fragment-a",
+        "fragment-b",
+      ]);
+    });
+
     it("drops history when the underlying session is deleted", async () => {
       // We don't rely on sendMessage emitting events (mock streams vary across
       // providers), so we seed the transcript directly to verify the cleanup

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -4488,6 +4488,78 @@ describe("createAgentChatService", () => {
     });
   });
 
+  describe("getChatEventHistory", () => {
+    it("returns an empty history for an unknown session", async () => {
+      const { service } = createService();
+      const history = service.getChatEventHistory("unknown-session");
+      expect(history.events).toEqual([]);
+      expect(history.truncated).toBe(false);
+    });
+
+    it("hydrates history from the on-disk transcript on first read", async () => {
+      // This is the core contract that fixes chat-history-loss on project
+      // switch / tab switch: a late subscriber that missed the live broadcast
+      // still sees the full history, because getChatEventHistory hydrates
+      // itself from the transcript the first time the session is queried.
+      const sessionId = "hydrate-test-session";
+      const envelope1: AgentChatEventEnvelope = {
+        sessionId,
+        timestamp: new Date().toISOString(),
+        event: { type: "text", text: "persisted-1" },
+        sequence: 1,
+      };
+      const envelope2: AgentChatEventEnvelope = {
+        sessionId,
+        timestamp: new Date().toISOString(),
+        event: { type: "text", text: "persisted-2" },
+        sequence: 2,
+      };
+
+      const { service } = createService();
+      // Seed a transcript file at the canonical chat transcript path so the
+      // service's disk-read fallback path has something to parse, then wire
+      // the parser mock to surface the persisted envelopes.
+      const transcriptFile = path.join(
+        tmpRoot,
+        ".ade",
+        "transcripts",
+        "chat",
+        `${sessionId}.jsonl`,
+      );
+      fs.writeFileSync(transcriptFile, `${JSON.stringify(envelope1)}\n${JSON.stringify(envelope2)}\n`, "utf8");
+      vi.mocked(parseAgentChatTranscript).mockReturnValue([envelope1, envelope2]);
+
+      const history = service.getChatEventHistory(sessionId);
+      expect(history.sessionId).toBe(sessionId);
+      expect(history.events).toHaveLength(2);
+      expect(history.events.map((envelope) =>
+        envelope.event.type === "text" ? envelope.event.text : "",
+      )).toEqual(["persisted-1", "persisted-2"]);
+    });
+
+    it("drops history when the underlying session is deleted", async () => {
+      // We don't rely on sendMessage emitting events (mock streams vary across
+      // providers), so we seed the transcript directly to verify the cleanup
+      // path. deleteSession must remove both the in-memory ring buffer and
+      // any hydrated-from-disk state so a subsequently-created session with
+      // the same id doesn't inherit stale events.
+      const emitted: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => emitted.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+      await service.deleteSession({ sessionId: session.id });
+
+      const afterDelete = service.getChatEventHistory(session.id);
+      expect(afterDelete.events).toEqual([]);
+      expect(afterDelete.truncated).toBe(false);
+    });
+  });
+
   // --------------------------------------------------------------------------
   // Session creation edge cases
   // --------------------------------------------------------------------------
@@ -5245,6 +5317,81 @@ describe("createAgentChatService", () => {
         expect(unstable_v2_createSession).toHaveBeenCalledTimes(1);
         expect(send).toHaveBeenCalledTimes(3);
         expect(String(send.mock.calls[2]?.[0] ?? "")).toContain("Follow up with the previous context");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("preserves Claude resume metadata across idle_ttl followed by shutdown", async () => {
+      vi.useFakeTimers();
+      try {
+        const close = vi.fn();
+        let streamCall = 0;
+        const send = vi.fn().mockResolvedValue(undefined);
+        const setPermissionMode = vi.fn().mockResolvedValue(undefined);
+
+        const sessionHandle = {
+          send,
+          stream: vi.fn(() => (async function* () {
+            streamCall += 1;
+            if (streamCall === 1) {
+              yield {
+                type: "system",
+                subtype: "init",
+                session_id: "sdk-session-preserve",
+                slash_commands: [],
+              };
+              yield {
+                type: "result",
+                usage: { input_tokens: 1, output_tokens: 1 },
+              };
+              return;
+            }
+            yield {
+              type: "assistant",
+              session_id: "sdk-session-preserve",
+              message: {
+                content: [{ type: "text", text: "Done." }],
+                usage: { input_tokens: 1, output_tokens: 1 },
+              },
+            };
+            yield { type: "result", usage: { input_tokens: 1, output_tokens: 1 } };
+          })()),
+          close,
+          sessionId: "sdk-session-preserve",
+          setPermissionMode,
+        };
+
+        vi.mocked(unstable_v2_createSession).mockReturnValue(sessionHandle as any);
+        vi.mocked(unstable_v2_resumeSession).mockReturnValue(sessionHandle as any);
+
+        const { service } = createService();
+        const session = await service.createSession({
+          laneId: "lane-1",
+          provider: "claude",
+          model: "sonnet",
+        });
+
+        await service.runSessionTurn({
+          sessionId: session.id,
+          text: "Say hi",
+          timeoutMs: 15_000,
+        });
+
+        // Idle-ttl teardown persists sdkSessionId + laneDirectiveKey.
+        await vi.advanceTimersByTimeAsync(6 * 60_000);
+        const persistedAfterIdle = readPersistedChatState(session.id);
+        expect(persistedAfterIdle.sdkSessionId).toBe("sdk-session-preserve");
+        const preservedLaneDirective = persistedAfterIdle.lastLaneDirectiveKey;
+        expect(preservedLaneDirective).toEqual(expect.any(String));
+
+        // Shutdown re-enters teardownRuntime with runtime already null. Must
+        // NOT clobber the preserved sdkSessionId/laneDirectiveKey.
+        service.forceDisposeAll();
+
+        const persistedAfterShutdown = readPersistedChatState(session.id);
+        expect(persistedAfterShutdown.sdkSessionId).toBe("sdk-session-preserve");
+        expect(persistedAfterShutdown.lastLaneDirectiveKey).toBe(preservedLaneDirective);
       } finally {
         vi.useRealTimers();
       }

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -4501,36 +4501,34 @@ describe("createAgentChatService", () => {
       // switch / tab switch: a late subscriber that missed the live broadcast
       // still sees the full history, because getChatEventHistory hydrates
       // itself from the transcript the first time the session is queried.
-      const sessionId = "hydrate-test-session";
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+
       const envelope1: AgentChatEventEnvelope = {
-        sessionId,
+        sessionId: session.id,
         timestamp: new Date().toISOString(),
         event: { type: "text", text: "persisted-1" },
         sequence: 1,
       };
       const envelope2: AgentChatEventEnvelope = {
-        sessionId,
+        sessionId: session.id,
         timestamp: new Date().toISOString(),
         event: { type: "text", text: "persisted-2" },
         sequence: 2,
       };
 
-      const { service } = createService();
-      // Seed a transcript file at the canonical chat transcript path so the
-      // service's disk-read fallback path has something to parse, then wire
-      // the parser mock to surface the persisted envelopes.
-      const transcriptFile = path.join(
-        tmpRoot,
-        ".ade",
-        "transcripts",
-        "chat",
-        `${sessionId}.jsonl`,
-      );
+      // Seed the transcript file at the path managed.transcriptPath points
+      // to (set by createSession → managedSessions → row.transcriptPath).
+      const transcriptFile = path.join(tmpRoot, "transcripts", `${session.id}.chat.jsonl`);
       fs.writeFileSync(transcriptFile, `${JSON.stringify(envelope1)}\n${JSON.stringify(envelope2)}\n`, "utf8");
       vi.mocked(parseAgentChatTranscript).mockReturnValue([envelope1, envelope2]);
 
-      const history = service.getChatEventHistory(sessionId);
-      expect(history.sessionId).toBe(sessionId);
+      const history = service.getChatEventHistory(session.id);
+      expect(history.sessionId).toBe(session.id);
       expect(history.events).toHaveLength(2);
       expect(history.events.map((envelope) =>
         envelope.event.type === "text" ? envelope.event.text : "",
@@ -4552,8 +4550,33 @@ describe("createAgentChatService", () => {
         provider: "codex",
         model: "gpt-5.4",
       });
+
+      // Seed the transcript on disk and populate the hydrated-from-disk cache
+      // BEFORE deleting, so a regression where deleteSession fails to clear
+      // the cache would actually be caught (an empty history trivially stays
+      // empty).
+      const envelope: AgentChatEventEnvelope = {
+        sessionId: session.id,
+        timestamp: new Date().toISOString(),
+        event: { type: "text", text: "before-delete" },
+        sequence: 1,
+      };
+      // createSession assigns managed.transcriptPath under `transcriptsDir`,
+      // so the hydration read is served from there (ahead of the
+      // chatTranscriptsDir fallback).
+      const transcriptFile = path.join(tmpRoot, "transcripts", `${session.id}.chat.jsonl`);
+      fs.mkdirSync(path.dirname(transcriptFile), { recursive: true });
+      fs.writeFileSync(transcriptFile, `${JSON.stringify(envelope)}\n`, "utf8");
+      vi.mocked(parseAgentChatTranscript).mockReturnValue([envelope]);
+      const beforeDelete = service.getChatEventHistory(session.id);
+      expect(beforeDelete.events).toHaveLength(1);
+
       await service.deleteSession({ sessionId: session.id });
 
+      // The transcript-returning parser mock is still wired up, so if
+      // deleteSession fails to clear the cache / on-disk file, the next read
+      // would still surface envelopes. An empty result proves both the
+      // in-memory ring buffer and the hydrated state were cleared.
       const afterDelete = service.getChatEventHistory(session.id);
       expect(afterDelete.events).toEqual([]);
       expect(afterDelete.truncated).toBe(false);
@@ -5392,6 +5415,80 @@ describe("createAgentChatService", () => {
         const persistedAfterShutdown = readPersistedChatState(session.id);
         expect(persistedAfterShutdown.sdkSessionId).toBe("sdk-session-preserve");
         expect(persistedAfterShutdown.lastLaneDirectiveKey).toBe(preservedLaneDirective);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("clears Claude resume metadata when a terminal teardown runs after idle_ttl", async () => {
+      vi.useFakeTimers();
+      try {
+        const close = vi.fn();
+        let streamCall = 0;
+        const send = vi.fn().mockResolvedValue(undefined);
+        const setPermissionMode = vi.fn().mockResolvedValue(undefined);
+
+        const sessionHandle = {
+          send,
+          stream: vi.fn(() => (async function* () {
+            streamCall += 1;
+            if (streamCall === 1) {
+              yield {
+                type: "system",
+                subtype: "init",
+                session_id: "sdk-session-terminal",
+                slash_commands: [],
+              };
+              yield { type: "result", usage: { input_tokens: 1, output_tokens: 1 } };
+              return;
+            }
+            yield {
+              type: "assistant",
+              session_id: "sdk-session-terminal",
+              message: {
+                content: [{ type: "text", text: "Done." }],
+                usage: { input_tokens: 1, output_tokens: 1 },
+              },
+            };
+            yield { type: "result", usage: { input_tokens: 1, output_tokens: 1 } };
+          })()),
+          close,
+          sessionId: "sdk-session-terminal",
+          setPermissionMode,
+        };
+
+        vi.mocked(unstable_v2_createSession).mockReturnValue(sessionHandle as any);
+        vi.mocked(unstable_v2_resumeSession).mockReturnValue(sessionHandle as any);
+
+        const { service } = createService();
+        const session = await service.createSession({
+          laneId: "lane-1",
+          provider: "claude",
+          model: "sonnet",
+        });
+
+        await service.runSessionTurn({
+          sessionId: session.id,
+          text: "Say hi",
+          timeoutMs: 15_000,
+        });
+
+        // idle_ttl preserves sdkSessionId/laneDirectiveKey.
+        await vi.advanceTimersByTimeAsync(6 * 60_000);
+        const persistedAfterIdle = readPersistedChatState(session.id);
+        expect(persistedAfterIdle.sdkSessionId).toBe("sdk-session-terminal");
+        expect(persistedAfterIdle.lastLaneDirectiveKey).toEqual(expect.any(String));
+
+        // Terminal teardown (user closes the chat) runs teardownRuntime with
+        // reason "ended_session" and runtime already null. Must still clear
+        // the preserved lane directive so a future resume of a different
+        // chat can't reattach to this ended session's lane context.
+        // dispose → finishSession → teardownRuntime("ended_session") without
+        // deleting the persisted state file.
+        await service.dispose({ sessionId: session.id });
+
+        const persistedAfterDispose = readPersistedChatState(session.id);
+        expect(persistedAfterDispose.lastLaneDirectiveKey ?? null).toBeNull();
       } finally {
         vi.useRealTimers();
       }

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -3724,26 +3724,29 @@ export function createAgentChatService(args: {
   ): AgentChatEventEnvelope[] => {
     if (!base.length) return tail.slice();
     if (!tail.length) return base.slice();
-    // Prefer sequence numbers when both sides have them; fall back to timestamps.
-    const baseBySequence = new Map<number, AgentChatEventEnvelope>();
-    const baseByTimestamp = new Map<string, AgentChatEventEnvelope>();
-    for (const entry of base) {
-      if (typeof entry.sequence === "number") {
-        baseBySequence.set(entry.sequence, entry);
-      }
-      baseByTimestamp.set(`${entry.timestamp}#${entry.event.type}`, entry);
-    }
+    // Don't dedup by sequence: `eventSequence` restarts at 0 every time a
+    // managed session is rebuilt (process restart, project switch), so the
+    // same ordinals legitimately appear in the persisted transcript (from
+    // a prior run) and in the in-memory buffer (from the current run) for
+    // totally different events. Use timestamp+type — writeTranscript and
+    // recordChatEventInHistory emit from the same envelope so true
+    // duplicates match exactly.
+    const baseKeys = new Set(base.map((entry) => `${entry.timestamp}#${entry.event.type}`));
     const merged = base.slice();
     for (const entry of tail) {
-      if (typeof entry.sequence === "number" && baseBySequence.has(entry.sequence)) continue;
-      if (baseByTimestamp.has(`${entry.timestamp}#${entry.event.type}`)) continue;
+      if (baseKeys.has(`${entry.timestamp}#${entry.event.type}`)) continue;
       merged.push(entry);
     }
     merged.sort((left, right) => {
+      // Timestamp is cross-run consistent; sequence is only a tiebreak
+      // within the same run.
+      const leftTime = Date.parse(left.timestamp);
+      const rightTime = Date.parse(right.timestamp);
+      if (leftTime !== rightTime) return leftTime - rightTime;
       if (typeof left.sequence === "number" && typeof right.sequence === "number") {
         return left.sequence - right.sequence;
       }
-      return Date.parse(left.timestamp) - Date.parse(right.timestamp);
+      return 0;
     });
     return merged;
   };
@@ -3768,6 +3771,13 @@ export function createAgentChatService(args: {
   ): { sessionId: string; events: AgentChatEventEnvelope[]; truncated: boolean } => {
     const trimmedId = sessionId.trim();
     if (!trimmedId.length) {
+      return { sessionId: trimmedId, events: [], truncated: false };
+    }
+    // Validate the session belongs to an agent chat before reading any
+    // transcript path — this function is reachable via IPC and builds
+    // filesystem paths from `trimmedId` downstream.
+    const row = sessionService.get(trimmedId);
+    if (!row || !isChatToolType(row.toolType)) {
       return { sessionId: trimmedId, events: [], truncated: false };
     }
     const maxEvents = Math.max(
@@ -5659,23 +5669,30 @@ export function createAgentChatService(args: {
     flushBufferedReasoning(managed);
     flushBufferedText(managed);
 
-    // If a prior teardown (e.g., idle_ttl, budget_eviction) already tore this
-    // runtime down, re-running teardown on shutdown would see runtime=null,
-    // compute preserveClaudeResumeState=false, and then clobber the
-    // previously-preserved sdkSessionId/laneDirectiveKey via the reset below.
-    // Bail early so the prior teardown's resume metadata stays on disk.
-    if (!managed.runtime) return;
+    const reasonAllowsPreservation =
+      openCodeReason === "idle_ttl"
+      || openCodeReason === "budget_eviction"
+      || openCodeReason === "pool_compaction"
+      || openCodeReason === "paused_run"
+      || openCodeReason === "project_close"
+      || openCodeReason === "shutdown";
+
+    // If a prior teardown (e.g., idle_ttl) already released the runtime:
+    //  - Non-terminal reasons keep the prior teardown's preserved resume
+    //    metadata on disk (bail).
+    //  - Terminal reasons (handle_close, ended_session, model_switch) must
+    //    still invalidate so a future resume can't reattach to a session
+    //    the user actually closed.
+    if (!managed.runtime) {
+      if (!reasonAllowsPreservation) {
+        managed.runtimeInvalidated = true;
+        clearLaneDirectiveKey(managed);
+      }
+      return;
+    }
 
     const preserveClaudeResumeState =
-      managed.runtime.kind === "claude"
-      && (
-        openCodeReason === "idle_ttl"
-        || openCodeReason === "budget_eviction"
-        || openCodeReason === "pool_compaction"
-        || openCodeReason === "paused_run"
-        || openCodeReason === "project_close"
-        || openCodeReason === "shutdown"
-      );
+      managed.runtime.kind === "claude" && reasonAllowsPreservation;
     if (managed.runtime?.kind === "codex") {
       managed.runtime.suppressExitError = true;
       try { managed.runtime.reader.close(); } catch { /* ignore */ }

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -2522,6 +2522,26 @@ export function createAgentChatService(args: {
 
   const eventSubscribers = new Set<(event: AgentChatEventEnvelope) => void>();
 
+  // In-memory ring buffer of recent chat events per session. Populated on every
+  // emitted event (see emitChatEvent → commitChatEvent), and also lazily hydrated
+  // from the on-disk transcript when a snapshot is requested. This is the canonical
+  // source of truth for "what should the renderer see right now" on resubscribe,
+  // remount, or project switch — persisted-transcript reads can miss events that
+  // were emitted while fs.appendFile was still in flight, and a project-switch
+  // gap drops all IPC deliveries until the user returns.
+  const CHAT_EVENT_HISTORY_MAX_PER_SESSION = 2_000;
+  const eventHistoryBySession = new Map<string, AgentChatEventEnvelope[]>();
+  const eventHistoryHydratedSessionIds = new Set<string>();
+
+  const recordChatEventInHistory = (envelope: AgentChatEventEnvelope): void => {
+    const current = eventHistoryBySession.get(envelope.sessionId) ?? [];
+    current.push(envelope);
+    if (current.length > CHAT_EVENT_HISTORY_MAX_PER_SESSION) {
+      current.splice(0, current.length - CHAT_EVENT_HISTORY_MAX_PER_SESSION);
+    }
+    eventHistoryBySession.set(envelope.sessionId, current);
+  };
+
   let computerUseArtifactBrokerRef = computerUseArtifactBrokerService ?? null;
 
   const layout = resolveAdeLayout(projectRoot);
@@ -3663,6 +3683,119 @@ export function createAgentChatService(args: {
     } catch {
       return [];
     }
+  };
+
+  // Read the full on-disk transcript for a session without requiring an active
+  // ManagedChatSession. Used by getChatEventHistory to hydrate the in-memory
+  // ring buffer on first read, even for sessions that haven't been resumed yet
+  // (e.g. a chat whose runtime was torn down by idle_ttl / budget_eviction).
+  const readTranscriptEnvelopesForSessionId = (sessionId: string): AgentChatEventEnvelope[] => {
+    const managed = managedSessions.get(sessionId);
+    if (managed?.transcriptPath) {
+      try {
+        return parseAgentChatTranscript(fs.readFileSync(managed.transcriptPath, "utf8"))
+          .filter((entry) => entry.sessionId === sessionId);
+      } catch {
+        return [];
+      }
+    }
+    // Fall back to the known transcript layout so sessions that were never
+    // ensured into managedSessions (e.g. because they were torn down and
+    // haven't been reopened yet) still surface their history.
+    const candidates = [
+      path.join(transcriptsDir, `${sessionId}.chat.jsonl`),
+      path.join(chatTranscriptsDir, `${sessionId}.jsonl`),
+    ];
+    for (const candidatePath of candidates) {
+      try {
+        if (!fs.existsSync(candidatePath)) continue;
+        const raw = fs.readFileSync(candidatePath, "utf8");
+        return parseAgentChatTranscript(raw).filter((entry) => entry.sessionId === sessionId);
+      } catch {
+        // try next candidate
+      }
+    }
+    return [];
+  };
+
+  const mergeEnvelopeStreams = (
+    base: AgentChatEventEnvelope[],
+    tail: AgentChatEventEnvelope[],
+  ): AgentChatEventEnvelope[] => {
+    if (!base.length) return tail.slice();
+    if (!tail.length) return base.slice();
+    // Prefer sequence numbers when both sides have them; fall back to timestamps.
+    const baseBySequence = new Map<number, AgentChatEventEnvelope>();
+    const baseByTimestamp = new Map<string, AgentChatEventEnvelope>();
+    for (const entry of base) {
+      if (typeof entry.sequence === "number") {
+        baseBySequence.set(entry.sequence, entry);
+      }
+      baseByTimestamp.set(`${entry.timestamp}#${entry.event.type}`, entry);
+    }
+    const merged = base.slice();
+    for (const entry of tail) {
+      if (typeof entry.sequence === "number" && baseBySequence.has(entry.sequence)) continue;
+      if (baseByTimestamp.has(`${entry.timestamp}#${entry.event.type}`)) continue;
+      merged.push(entry);
+    }
+    merged.sort((left, right) => {
+      if (typeof left.sequence === "number" && typeof right.sequence === "number") {
+        return left.sequence - right.sequence;
+      }
+      return Date.parse(left.timestamp) - Date.parse(right.timestamp);
+    });
+    return merged;
+  };
+
+  /**
+   * Return the complete, ordered event history for a chat session.
+   *
+   * On first call (or any call that can tolerate a larger read), we merge the
+   * on-disk transcript with the in-memory ring buffer so that:
+   *   - events that were emitted while the renderer was on a different project
+   *     (and therefore dropped by emitProjectEvent) are still recovered;
+   *   - events that are still in fs.appendFile flight but already recorded in
+   *     the buffer are still delivered;
+   *   - truncating the persistent transcript for size does not lose recent
+   *     events that the buffer still has.
+   *
+   * This is the canonical snapshot path for renderer resubscribe / remount.
+   */
+  const getChatEventHistory = (
+    sessionId: string,
+    options?: { maxEvents?: number },
+  ): { sessionId: string; events: AgentChatEventEnvelope[]; truncated: boolean } => {
+    const trimmedId = sessionId.trim();
+    if (!trimmedId.length) {
+      return { sessionId: trimmedId, events: [], truncated: false };
+    }
+    const maxEvents = Math.max(
+      1,
+      Math.min(CHAT_EVENT_HISTORY_MAX_PER_SESSION, Math.floor(options?.maxEvents ?? CHAT_EVENT_HISTORY_MAX_PER_SESSION)),
+    );
+
+    // Hydrate the in-memory buffer from disk the first time we see a session,
+    // so a resubscribe after project switch or app restart has both the
+    // persisted history and any live events that arrived afterwards.
+    const bufferExisting = eventHistoryBySession.get(trimmedId) ?? [];
+    let merged: AgentChatEventEnvelope[];
+    if (!eventHistoryHydratedSessionIds.has(trimmedId)) {
+      const diskEnvelopes = readTranscriptEnvelopesForSessionId(trimmedId);
+      merged = mergeEnvelopeStreams(diskEnvelopes, bufferExisting);
+      // Cap after hydration so subsequent writes don't drift past the limit.
+      if (merged.length > CHAT_EVENT_HISTORY_MAX_PER_SESSION) {
+        merged = merged.slice(-CHAT_EVENT_HISTORY_MAX_PER_SESSION);
+      }
+      eventHistoryBySession.set(trimmedId, merged.slice());
+      eventHistoryHydratedSessionIds.add(trimmedId);
+    } else {
+      merged = bufferExisting.slice();
+    }
+
+    const truncated = merged.length > maxEvents;
+    const windowed = truncated ? merged.slice(-maxEvents) : merged;
+    return { sessionId: trimmedId, events: windowed, truncated };
   };
 
   const deriveTranscriptTurnActive = (entries: AgentChatEventEnvelope[]): boolean => {
@@ -5105,6 +5238,7 @@ export function createAgentChatService(args: {
     };
 
     writeTranscript(managed, envelope);
+    recordChatEventInHistory(envelope);
     onEvent?.(envelope);
     for (const subscriber of eventSubscribers) {
       try {
@@ -5522,8 +5656,18 @@ export function createAgentChatService(args: {
     managed: ManagedChatSession,
     openCodeReason: "handle_close" | "idle_ttl" | "ended_session" | "model_switch" | "project_close" | "budget_eviction" | "pool_compaction" | "paused_run" | "shutdown" = "handle_close",
   ): void => {
+    flushBufferedReasoning(managed);
+    flushBufferedText(managed);
+
+    // If a prior teardown (e.g., idle_ttl, budget_eviction) already tore this
+    // runtime down, re-running teardown on shutdown would see runtime=null,
+    // compute preserveClaudeResumeState=false, and then clobber the
+    // previously-preserved sdkSessionId/laneDirectiveKey via the reset below.
+    // Bail early so the prior teardown's resume metadata stays on disk.
+    if (!managed.runtime) return;
+
     const preserveClaudeResumeState =
-      managed.runtime?.kind === "claude"
+      managed.runtime.kind === "claude"
       && (
         openCodeReason === "idle_ttl"
         || openCodeReason === "budget_eviction"
@@ -5532,9 +5676,6 @@ export function createAgentChatService(args: {
         || openCodeReason === "project_close"
         || openCodeReason === "shutdown"
       );
-
-    flushBufferedReasoning(managed);
-    flushBufferedText(managed);
     if (managed.runtime?.kind === "codex") {
       managed.runtime.suppressExitError = true;
       try { managed.runtime.reader.close(); } catch { /* ignore */ }
@@ -13008,6 +13149,8 @@ export function createAgentChatService(args: {
     } else {
       clearSubagentSnapshots(trimmedSessionId);
     }
+    eventHistoryBySession.delete(trimmedSessionId);
+    eventHistoryHydratedSessionIds.delete(trimmedSessionId);
 
     const persistedMetadataPath = metadataPathFor(trimmedSessionId);
     const dedicatedTranscriptPath = path.join(chatTranscriptsDir, `${trimmedSessionId}.jsonl`);
@@ -13820,6 +13963,7 @@ export function createAgentChatService(args: {
     listSessions,
     getSessionSummary,
     getChatTranscript,
+    getChatEventHistory,
     ensureIdentitySession,
     approveToolUse,
     respondToInput,

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -13041,7 +13041,6 @@ export function createAgentChatService(args: {
     }
     for (const [sessionId, managed] of managedSessions) {
       try {
-        managed.deleted = true;
         clearSubagentSnapshots(sessionId);
         for (const pending of managed.localPendingInputs.values()) {
           pending.resolve({ decision: "cancel" });
@@ -13050,7 +13049,10 @@ export function createAgentChatService(args: {
         managed.closed = true;
         managed.endedNotified = true;
         managed.ctoSessionStartedAt = null;
+        // teardownRuntime must run before `deleted = true` so its persistChatState()
+        // call can write the preserved Claude resume metadata for "shutdown".
         teardownRuntime(managed, "shutdown");
+        managed.deleted = true;
       } catch {
         // ignore emergency shutdown failures
       }

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -3718,23 +3718,26 @@ export function createAgentChatService(args: {
     return [];
   };
 
+  const envelopeDedupKey = (entry: AgentChatEventEnvelope): string => {
+    // Cross-run-safe key: two envelopes are true duplicates iff timestamp,
+    // type, AND payload all match. Sequence numbers can't be trusted (they
+    // restart per run), and Claude streaming emits multiple text/reasoning
+    // fragments within the same millisecond + type — timestamp+type alone
+    // would wrongly collapse those into one. JSON.stringify is fine at our
+    // scale (≤2000 events, events typically <1KB).
+    return `${entry.timestamp}#${entry.event.type}#${JSON.stringify(entry.event)}`;
+  };
+
   const mergeEnvelopeStreams = (
     base: AgentChatEventEnvelope[],
     tail: AgentChatEventEnvelope[],
   ): AgentChatEventEnvelope[] => {
     if (!base.length) return tail.slice();
     if (!tail.length) return base.slice();
-    // Don't dedup by sequence: `eventSequence` restarts at 0 every time a
-    // managed session is rebuilt (process restart, project switch), so the
-    // same ordinals legitimately appear in the persisted transcript (from
-    // a prior run) and in the in-memory buffer (from the current run) for
-    // totally different events. Use timestamp+type — writeTranscript and
-    // recordChatEventInHistory emit from the same envelope so true
-    // duplicates match exactly.
-    const baseKeys = new Set(base.map((entry) => `${entry.timestamp}#${entry.event.type}`));
+    const baseKeys = new Set(base.map(envelopeDedupKey));
     const merged = base.slice();
     for (const entry of tail) {
-      if (baseKeys.has(`${entry.timestamp}#${entry.event.type}`)) continue;
+      if (baseKeys.has(envelopeDedupKey(entry))) continue;
       merged.push(entry);
     }
     merged.sort((left, right) => {

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -5522,6 +5522,17 @@ export function createAgentChatService(args: {
     managed: ManagedChatSession,
     openCodeReason: "handle_close" | "idle_ttl" | "ended_session" | "model_switch" | "project_close" | "budget_eviction" | "pool_compaction" | "paused_run" | "shutdown" = "handle_close",
   ): void => {
+    const preserveClaudeResumeState =
+      managed.runtime?.kind === "claude"
+      && (
+        openCodeReason === "idle_ttl"
+        || openCodeReason === "budget_eviction"
+        || openCodeReason === "pool_compaction"
+        || openCodeReason === "paused_run"
+        || openCodeReason === "project_close"
+        || openCodeReason === "shutdown"
+      );
+
     flushBufferedReasoning(managed);
     flushBufferedText(managed);
     if (managed.runtime?.kind === "codex") {
@@ -5538,6 +5549,10 @@ export function createAgentChatService(args: {
     if (managed.runtime?.kind === "claude") {
       // Mark interrupted so the streaming catch block takes the graceful path
       managed.runtime.interrupted = true;
+      if (preserveClaudeResumeState) {
+        managed.runtime.sdkSessionId = managed.runtime.sdkSessionId ?? managed.runtime.v2Session?.sessionId ?? null;
+        persistChatState(managed);
+      }
       cancelClaudeWarmup(managed, managed.runtime, "teardown");
       try { managed.runtime.v2Session?.close(); } catch { /* ignore */ }
       managed.runtime.v2Session = null;
@@ -5579,8 +5594,10 @@ export function createAgentChatService(args: {
       if (rt.pooled) releaseCursorAcpConnection(rt.poolKey);
       managed.runtime = null;
     }
-    managed.runtimeInvalidated = true;
-    clearLaneDirectiveKey(managed);
+    managed.runtimeInvalidated = !preserveClaudeResumeState;
+    if (!preserveClaudeResumeState) {
+      clearLaneDirectiveKey(managed);
+    }
   };
 
   const keepChatSessionOpen = (

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -177,12 +177,12 @@ import type {
   AgentChatDeleteArgs,
   AgentChatDisposeArgs,
   AgentChatGetSummaryArgs,
+  AgentChatEventEnvelope,
   AgentChatHandoffArgs,
   AgentChatHandoffResult,
   AgentChatInterruptArgs,
   AgentChatListArgs,
   AgentChatModelInfo,
-  AgentChatEventEnvelope,
   AgentChatModelsArgs,
   AgentChatPermissionMode,
   AgentChatRespondToInputArgs,
@@ -4416,7 +4416,14 @@ export function registerIpc({
     const ctx = getCtx();
     const sessionId = typeof arg?.sessionId === "string" ? arg.sessionId.trim() : "";
     if (!sessionId) return { sessionId: "", events: [], truncated: false };
-    const maxEvents = typeof arg?.maxEvents === "number" ? arg.maxEvents : undefined;
+    // Only forward maxEvents when it is a finite positive number; the service
+    // layer applies its own clamp but guarding here avoids ambiguous NaN/0
+    // inputs from untrusted renderer IPC.
+    const rawMaxEvents = typeof arg?.maxEvents === "number" ? arg.maxEvents : undefined;
+    const maxEvents =
+      rawMaxEvents != null && Number.isFinite(rawMaxEvents) && rawMaxEvents > 0
+        ? rawMaxEvents
+        : undefined;
     return ctx.agentChatService.getChatEventHistory(sessionId, maxEvents != null ? { maxEvents } : undefined);
   });
 

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -182,6 +182,7 @@ import type {
   AgentChatInterruptArgs,
   AgentChatListArgs,
   AgentChatModelInfo,
+  AgentChatEventEnvelope,
   AgentChatModelsArgs,
   AgentChatPermissionMode,
   AgentChatRespondToInputArgs,
@@ -4406,6 +4407,17 @@ export function registerIpc({
       original: { text: origResult.exitCode === 0 ? origResult.stdout : null },
       modified: { text: modResult.exitCode === 0 ? modResult.stdout : null },
     };
+  });
+
+  ipcMain.handle(IPC.agentChatGetEventHistory, async (
+    _event,
+    arg: { sessionId?: string; maxEvents?: number },
+  ): Promise<{ sessionId: string; events: AgentChatEventEnvelope[]; truncated: boolean }> => {
+    const ctx = getCtx();
+    const sessionId = typeof arg?.sessionId === "string" ? arg.sessionId.trim() : "";
+    if (!sessionId) return { sessionId: "", events: [], truncated: false };
+    const maxEvents = typeof arg?.maxEvents === "number" ? arg.maxEvents : undefined;
+    return ctx.agentChatService.getChatEventHistory(sessionId, maxEvents != null ? { maxEvents } : undefined);
   });
 
   ipcMain.handle(IPC.computerUseListArtifacts, async (_event, arg: ComputerUseArtifactListArgs = {}): Promise<ComputerUseArtifactView[]> => {

--- a/apps/desktop/src/main/services/sync/deviceRegistryService.test.ts
+++ b/apps/desktop/src/main/services/sync/deviceRegistryService.test.ts
@@ -62,6 +62,58 @@ describe("deviceRegistryService", () => {
     db2.close();
   });
 
+  it("can share a desktop device identity across project registries", async () => {
+    const projectRootA = makeProjectRoot("ade-device-registry-global-a-");
+    const projectRootB = makeProjectRoot("ade-device-registry-global-b-");
+    const globalDeviceIdPath = path.join(os.tmpdir(), `ade-global-device-${Date.now()}-${Math.random()}`, "sync-device-id");
+
+    const dbA = await openKvDb(path.join(projectRootA, ".ade", "ade.db"), createLogger() as any);
+    const dbB = await openKvDb(path.join(projectRootB, ".ade", "ade.db"), createLogger() as any);
+    const registryA = createDeviceRegistryService({
+      db: dbA,
+      logger: createLogger() as any,
+      projectRoot: projectRootA,
+      localDeviceIdPath: globalDeviceIdPath,
+    });
+    const registryB = createDeviceRegistryService({
+      db: dbB,
+      logger: createLogger() as any,
+      projectRoot: projectRootB,
+      localDeviceIdPath: globalDeviceIdPath,
+    });
+
+    const localA = registryA.ensureLocalDevice();
+    const localB = registryB.ensureLocalDevice();
+
+    expect(localB.deviceId).toBe(localA.deviceId);
+    expect(localB.siteId).not.toBe(localA.siteId);
+
+    dbA.close();
+    dbB.close();
+  });
+
+  it("migrates the legacy project device identity into the shared desktop identity file", async () => {
+    const projectRoot = makeProjectRoot("ade-device-registry-global-migrate-");
+    const legacyDeviceId = "legacy-project-device-id";
+    const legacyDeviceIdPath = path.join(projectRoot, ".ade", "secrets", "sync-device-id");
+    const globalDeviceIdPath = path.join(os.tmpdir(), `ade-global-device-migrate-${Date.now()}-${Math.random()}`, "sync-device-id");
+    fs.mkdirSync(path.dirname(legacyDeviceIdPath), { recursive: true });
+    fs.writeFileSync(legacyDeviceIdPath, `${legacyDeviceId}\n`);
+
+    const db = await openKvDb(path.join(projectRoot, ".ade", "ade.db"), createLogger() as any);
+    const registry = createDeviceRegistryService({
+      db,
+      logger: createLogger() as any,
+      projectRoot,
+      localDeviceIdPath: globalDeviceIdPath,
+    });
+
+    expect(registry.ensureLocalDevice().deviceId).toBe(legacyDeviceId);
+    expect(fs.readFileSync(globalDeviceIdPath, "utf8").trim()).toBe(legacyDeviceId);
+
+    db.close();
+  });
+
   it("persists notification preferences in device metadata across registry restarts", async () => {
     const projectRoot = makeProjectRoot("ade-device-registry-prefs-");
     const dbPath = path.join(projectRoot, ".ade", "ade.db");

--- a/apps/desktop/src/main/services/sync/deviceRegistryService.ts
+++ b/apps/desktop/src/main/services/sync/deviceRegistryService.ts
@@ -22,6 +22,7 @@ type DeviceRegistryServiceArgs = {
   db: AdeDb;
   logger: Logger;
   projectRoot: string;
+  localDeviceIdPath?: string;
 };
 
 type DeviceRow = {
@@ -138,12 +139,20 @@ function firstPreferredHost(ipAddresses: string[]): string {
 
 export function createDeviceRegistryService(args: DeviceRegistryServiceArgs) {
   const layout = resolveAdeLayout(args.projectRoot);
-  const deviceIdPath = path.join(layout.secretsDir, DEVICE_ID_FILE);
+  const deviceIdPath = args.localDeviceIdPath ?? path.join(layout.secretsDir, DEVICE_ID_FILE);
+  const legacyProjectDeviceIdPath = path.join(layout.secretsDir, DEVICE_ID_FILE);
   fs.mkdirSync(path.dirname(deviceIdPath), { recursive: true });
 
   const readOrCreateLocalDeviceId = (): string => {
     const existing = fs.existsSync(deviceIdPath) ? fs.readFileSync(deviceIdPath, "utf8").trim() : "";
     if (existing.length > 0) return existing;
+    const legacy = deviceIdPath !== legacyProjectDeviceIdPath && fs.existsSync(legacyProjectDeviceIdPath)
+      ? fs.readFileSync(legacyProjectDeviceIdPath, "utf8").trim()
+      : "";
+    if (legacy.length > 0) {
+      writeTextAtomic(deviceIdPath, `${legacy}\n`);
+      return legacy;
+    }
     const created = randomUUID();
     writeTextAtomic(deviceIdPath, `${created}\n`);
     return created;

--- a/apps/desktop/src/main/services/sync/deviceRegistryService.ts
+++ b/apps/desktop/src/main/services/sync/deviceRegistryService.ts
@@ -144,15 +144,23 @@ export function createDeviceRegistryService(args: DeviceRegistryServiceArgs) {
   fs.mkdirSync(path.dirname(deviceIdPath), { recursive: true });
 
   const readOrCreateLocalDeviceId = (): string => {
-    const existing = fs.existsSync(deviceIdPath) ? fs.readFileSync(deviceIdPath, "utf8").trim() : "";
-    if (existing.length > 0) return existing;
+    const shared = fs.existsSync(deviceIdPath) ? fs.readFileSync(deviceIdPath, "utf8").trim() : "";
     const legacy = deviceIdPath !== legacyProjectDeviceIdPath && fs.existsSync(legacyProjectDeviceIdPath)
       ? fs.readFileSync(legacyProjectDeviceIdPath, "utf8").trim()
       : "";
+    // If this project has a legacy per-project sync-device-id, always prefer
+    // it so existing iOS pairings and `sync_cluster_state.brain_device_id`
+    // references stay valid. The shared file is only written when it would
+    // agree (empty or already matching) — never overridden with a different
+    // value, so opening project B after A no longer flips B's identity to
+    // A's ID and drops B into viewer mode.
     if (legacy.length > 0) {
-      writeTextAtomic(deviceIdPath, `${legacy}\n`);
+      if (shared.length === 0 || shared === legacy) {
+        writeTextAtomic(deviceIdPath, `${legacy}\n`);
+      }
       return legacy;
     }
+    if (shared.length > 0) return shared;
     const created = randomUUID();
     writeTextAtomic(deviceIdPath, `${created}\n`);
     return created;

--- a/apps/desktop/src/main/services/sync/syncHostService.ts
+++ b/apps/desktop/src/main/services/sync/syncHostService.ts
@@ -173,6 +173,7 @@ type SyncHostServiceArgs = {
   pinStore: SyncPinStore;
   bootstrapTokenPath?: string;
   port?: number;
+  discoveryEnabled?: boolean;
   heartbeatIntervalMs?: number;
   pollIntervalMs?: number;
   brainStatusIntervalMs?: number;
@@ -699,13 +700,18 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
   let tailnetServeSignature: string | null = null;
   let tailnetServePublishSequence = 0;
   let tailnetServeActivePublishToken = 0;
+  let discoveryEnabled = args.discoveryEnabled !== false;
   let tailnetDiscoveryStatus: SyncTailnetDiscoveryStatus = {
-    state: shouldAttemptTailnetServiceAdvertise() ? "disabled" : "unavailable",
+    state: !discoveryEnabled
+      ? "disabled"
+      : shouldAttemptTailnetServiceAdvertise() ? "disabled" : "unavailable",
     serviceName: SYNC_TAILNET_DISCOVERY_SERVICE_NAME,
     servicePort: SYNC_TAILNET_DISCOVERY_SERVICE_PORT,
     target: null,
     updatedAt: null,
-    error: shouldAttemptTailnetServiceAdvertise()
+    error: !discoveryEnabled
+      ? "Tailnet discovery is disabled for this background project context."
+      : shouldAttemptTailnetServiceAdvertise()
       ? "Tailnet discovery has not been published yet."
       : "Tailscale Serve discovery is not available in this desktop process.",
     stderr: null,
@@ -828,6 +834,10 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
 
   const publishLanDiscovery = (port: number): void => {
     if (disposed) return;
+    if (!discoveryEnabled) {
+      unpublishLanDiscovery();
+      return;
+    }
     const localDevice = args.deviceRegistryService?.ensureLocalDevice() ?? null;
     const hostName = localDevice?.name ?? os.hostname();
     const ipAddresses = uniqueStrings([
@@ -880,6 +890,18 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     });
   };
 
+  const unpublishLanDiscovery = (): void => {
+    if (!bonjourAnnouncement) return;
+    try {
+      bonjourAnnouncement.stop?.();
+    } catch {
+      // ignore cleanup failures
+    }
+    bonjourAnnouncement = null;
+    bonjourPort = null;
+    bonjourSignature = null;
+  };
+
   const updateTailnetDiscoveryStatus = (
     next: SyncTailnetDiscoveryStatus,
   ): void => {
@@ -894,6 +916,19 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     options?: { force?: boolean },
   ): void => {
     if (disposed) return;
+    if (!discoveryEnabled) {
+      void unpublishTailnetDiscovery();
+      updateTailnetDiscoveryStatus({
+        state: "disabled",
+        serviceName: SYNC_TAILNET_DISCOVERY_SERVICE_NAME,
+        servicePort: SYNC_TAILNET_DISCOVERY_SERVICE_PORT,
+        target: null,
+        updatedAt: nowIso(),
+        error: "Tailnet discovery is disabled for this background project context.",
+        stderr: null,
+      });
+      return;
+    }
     if (!shouldAttemptTailnetServiceAdvertise()) {
       updateTailnetDiscoveryStatus({
         state: "unavailable",
@@ -2018,6 +2053,30 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       }
     },
 
+    setDiscoveryEnabled(enabled: boolean): void {
+      if (discoveryEnabled === enabled) return;
+      discoveryEnabled = enabled;
+      const address = server.address();
+      if (!enabled) {
+        unpublishLanDiscovery();
+        void unpublishTailnetDiscovery();
+        updateTailnetDiscoveryStatus({
+          state: "disabled",
+          serviceName: SYNC_TAILNET_DISCOVERY_SERVICE_NAME,
+          servicePort: SYNC_TAILNET_DISCOVERY_SERVICE_PORT,
+          target: null,
+          updatedAt: nowIso(),
+          error: "Tailnet discovery is disabled for this background project context.",
+          stderr: null,
+        });
+        return;
+      }
+      if (typeof address === "object" && address) {
+        publishLanDiscovery(address.port);
+        publishTailnetDiscovery(address.port, { force: true });
+      }
+    },
+
     revokePairedDevice(deviceId: string): void {
       pairingStore.revoke(deviceId);
       let revokedConnectedPeer = false;
@@ -2127,6 +2186,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       clearInterval(pollTimer);
       clearInterval(heartbeatTimer);
       clearInterval(brainStatusTimer);
+      unpublishLanDiscovery();
       try {
         await unpublishTailnetDiscovery();
       } catch {

--- a/apps/desktop/src/main/services/sync/syncService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncService.test.ts
@@ -542,6 +542,7 @@ describe.skipIf(!isCrsqliteAvailable())("syncService", () => {
         },
         handlePtyData() {},
         handlePtyExit() {},
+        setDiscoveryEnabled: vi.fn(),
         dispose: attemptedPort === 8787 ? disposeFirstAttempt : disposeSecondAttempt,
       };
     }) as any);

--- a/apps/desktop/src/main/services/sync/syncService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncService.test.ts
@@ -37,6 +37,7 @@ const { createSyncHostServiceMock } = vi.hoisted(() => ({
     },
     handlePtyData() {},
     handlePtyExit() {},
+    setDiscoveryEnabled: vi.fn(),
     async dispose() {},
   })),
 }));

--- a/apps/desktop/src/main/services/sync/syncService.ts
+++ b/apps/desktop/src/main/services/sync/syncService.ts
@@ -64,6 +64,7 @@ type SyncServiceArgs = {
   db: AdeDb;
   logger: Logger;
   projectRoot: string;
+  localDeviceIdPath?: string;
   fileService: ReturnType<typeof createFileService>;
   laneService: ReturnType<typeof createLaneService>;
   gitService?: ReturnType<typeof createGitOperationsService>;
@@ -104,6 +105,7 @@ type SyncServiceArgs = {
   getLinearSyncService?: () => ReturnType<typeof createLinearSyncService> | null;
   processService: ReturnType<typeof createProcessService>;
   hostStartupEnabled?: boolean;
+  hostDiscoveryEnabled?: boolean;
   onStatusChanged?: (snapshot: SyncRoleSnapshot) => void;
   /**
    * Optional notification bus forwarded to the sync host. The host publishes
@@ -278,6 +280,7 @@ export function createSyncService(args: SyncServiceArgs) {
     db: args.db,
     logger: args.logger,
     projectRoot: args.projectRoot,
+    localDeviceIdPath: args.localDeviceIdPath,
   });
 
   let hostService: SyncHostService | null = null;
@@ -285,6 +288,7 @@ export function createSyncService(args: SyncServiceArgs) {
   let refreshQueued = false;
   let disposed = false;
   const hostStartupEnabled = args.hostStartupEnabled !== false;
+  let hostDiscoveryEnabled = args.hostDiscoveryEnabled !== false;
   let activeLocalLanePresenceIds: string[] = [];
   const localLanePresenceHeartbeatTimer = setInterval(() => {
     if (disposed || !hostService || activeLocalLanePresenceIds.length === 0) return;
@@ -432,6 +436,7 @@ export function createSyncService(args: SyncServiceArgs) {
         pinStore,
         bootstrapTokenPath: tokenPath,
         port: attemptedPort,
+        discoveryEnabled: hostDiscoveryEnabled,
         deviceRegistryService,
         notificationEventBus: args.notificationEventBus ?? null,
         projectCatalogProvider: args.projectCatalogProvider,
@@ -716,6 +721,12 @@ export function createSyncService(args: SyncServiceArgs) {
       const snapshot = await this.getStatus();
       args.onStatusChanged?.(snapshot);
       return snapshot;
+    },
+
+    setHostDiscoveryEnabled(enabled: boolean): void {
+      hostDiscoveryEnabled = enabled;
+      hostService?.setDiscoveryEnabled(enabled);
+      void emitStatus();
     },
 
     async updateLocalDevice(argsIn: {

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -1145,6 +1145,14 @@ declare global {
           data: string;
           filename: string;
         }) => Promise<{ path: string }>;
+        getEventHistory: (args: {
+          sessionId: string;
+          maxEvents?: number;
+        }) => Promise<{
+          sessionId: string;
+          events: AgentChatEventEnvelope[];
+          truncated: boolean;
+        }>;
       };
       computerUse: {
         listArtifacts: (

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1624,6 +1624,11 @@ contextBridge.exposeInMainWorld("ade", {
       filename: string;
     }): Promise<{ path: string }> =>
       ipcRenderer.invoke(IPC.agentChatSaveTempAttachment, args),
+    getEventHistory: async (args: {
+      sessionId: string;
+      maxEvents?: number;
+    }): Promise<{ sessionId: string; events: AgentChatEventEnvelope[]; truncated: boolean }> =>
+      ipcRenderer.invoke(IPC.agentChatGetEventHistory, args),
   },
   computerUse: {
     listArtifacts: async (

--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -2382,7 +2382,11 @@ if (typeof window !== "undefined" && !(window as any).ade) {
       onEvent: noop,
       slashCommands: resolvedArg([]),
       fileSearch: resolvedArg([]),
-      getEventHistory: resolvedArg({ sessionId: "mock", events: [], truncated: false }),
+      getEventHistory: async (arg: { sessionId: string; maxEvents?: number }) => ({
+        sessionId: typeof arg?.sessionId === "string" ? arg.sessionId : "",
+        events: [],
+        truncated: false,
+      }),
     },
     cto: {
       getState: resolvedArg({

--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -2382,6 +2382,7 @@ if (typeof window !== "undefined" && !(window as any).ade) {
       onEvent: noop,
       slashCommands: resolvedArg([]),
       fileSearch: resolvedArg([]),
+      getEventHistory: resolvedArg({ sessionId: "mock", events: [], truncated: false }),
     },
     cto: {
       getState: resolvedArg({

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -1434,19 +1434,45 @@ export function AgentChatPane({
     loadedHistoryRef.current.add(sessionId);
 
     try {
-      const summary = await window.ade.sessions.get(sessionId);
-      if (!summary || !isChatToolType(summary.toolType)) return;
-      const raw = await window.ade.sessions.readTranscriptTail({
-        sessionId,
-        maxBytes: CHAT_HISTORY_READ_MAX_BYTES,
-        raw: true
-      });
-      const parsed = parseAgentChatTranscript(raw).filter((entry) => entry.sessionId === sessionId);
+      // Prefer the main-process snapshot API which merges the in-memory event
+      // ring buffer with the on-disk transcript. This recovers events that
+      // were emitted while the user was on a different project (IPC dropped),
+      // events that were still in fs.appendFile flight when a previous load
+      // ran, and the full history even when the transcript has been truncated
+      // for size. Fall back to the disk-only readTranscriptTail path if the
+      // snapshot call fails or the desktop app is running against an older
+      // main-process build that lacks the handler.
+      let parsed: AgentChatEventEnvelope[] = [];
+      let usedSnapshotPath = false;
+      try {
+        if (typeof window.ade.agentChat.getEventHistory === "function") {
+          const snapshot = await window.ade.agentChat.getEventHistory({
+            sessionId,
+            maxEvents: MAX_SELECTED_CHAT_SESSION_EVENTS,
+          });
+          if (snapshot?.events?.length || snapshot?.sessionId === sessionId) {
+            parsed = (snapshot.events ?? []).filter((entry) => entry.sessionId === sessionId);
+            usedSnapshotPath = true;
+          }
+        }
+      } catch {
+        usedSnapshotPath = false;
+      }
+      if (!usedSnapshotPath) {
+        const summary = await window.ade.sessions.get(sessionId);
+        if (!summary || !isChatToolType(summary.toolType)) return;
+        const raw = await window.ade.sessions.readTranscriptTail({
+          sessionId,
+          maxBytes: CHAT_HISTORY_READ_MAX_BYTES,
+          raw: true
+        });
+        parsed = parseAgentChatTranscript(raw).filter((entry) => entry.sessionId === sessionId);
+      }
 
       // If real-time events have already been received for this session
-      // (via flushQueuedEvents), the on-disk transcript may be stale.
-      // Merge: use the loaded history as a base but keep any real-time
-      // events that arrived after the last event in the transcript.
+      // (via flushQueuedEvents), the snapshot may be stale by a few events.
+      // Merge: use the snapshot as a base but keep any real-time events that
+      // arrived after the last snapshot entry.
       const existing = eventsBySessionRef.current[sessionId] ?? [];
       let merged: AgentChatEventEnvelope[];
       if (existing.length && parsed.length) {
@@ -1486,7 +1512,11 @@ export function AgentChatPane({
       setPendingInputsBySession((prev) => ({ ...prev, [sessionId]: derived.pendingInputs }));
       setPendingSteersBySession((prev) => ({ ...prev, [sessionId]: derived.pendingSteers }));
     } catch {
-      // Ignore transcript history failures.
+      // Clear the loaded flag so the caller can retry on next remount or tab
+      // switch — otherwise a transient failure leaves the UI stuck with no
+      // events. Without this clearSessionView, a failed initial load
+      // permanently blocked re-entry until the chat received a new event.
+      loadedHistoryRef.current.delete(sessionId);
     }
   }, [initialSessionSummary, lockSessionId]);
 
@@ -1691,8 +1721,13 @@ export function AgentChatPane({
       void loadHistory(selectedSessionId, { force: true });
       return;
     }
+    // Locked-single-session mode (Work tab tile). Force-reload on every mount
+    // so that when the pane is unmounted and remounted (tab switch, project
+    // switch, session tile activation) we always pull the freshest snapshot
+    // rather than short-circuiting on a stale loadedHistoryRef from the
+    // previous component instance.
     const handle = window.setTimeout(() => {
-      void loadHistory(selectedSessionId);
+      void loadHistory(selectedSessionId, { force: true });
     }, 120);
     return () => window.clearTimeout(handle);
   }, [loadHistory, lockedSingleSessionMode, selectedSessionId]);

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -1460,7 +1460,14 @@ export function AgentChatPane({
       }
       if (!usedSnapshotPath) {
         const summary = await window.ade.sessions.get(sessionId);
-        if (!summary || !isChatToolType(summary.toolType)) return;
+        if (!summary || !isChatToolType(summary.toolType)) {
+          // Clear the loaded flag so a subsequent remount/tab switch can retry.
+          // Without this, a transient lookup miss (e.g. session summary not yet
+          // propagated on project switch) would leave the UI permanently
+          // unable to hydrate history. Mirrors the catch-block recovery below.
+          loadedHistoryRef.current.delete(sessionId);
+          return;
+        }
         const raw = await window.ade.sessions.readTranscriptTail({
           sessionId,
           maxBytes: CHAT_HISTORY_READ_MAX_BYTES,

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.test.tsx
@@ -1,0 +1,112 @@
+/* @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import type { LaneSummary, TerminalSessionSummary } from "../../../shared/types";
+import { SessionListPane } from "./SessionListPane";
+
+vi.mock("./useSessionDelta", () => ({
+  useSessionDelta: () => null,
+}));
+
+vi.mock("./ToolLogos", () => ({
+  ToolLogo: () => <span data-testid="tool-logo" />,
+}));
+
+function makeLane(overrides: Partial<LaneSummary> = {}): LaneSummary {
+  return {
+    id: "lane-known",
+    name: "Known Lane",
+    laneType: "worktree",
+    baseRef: "main",
+    branchRef: "known-lane",
+    worktreePath: "/tmp/known-lane",
+    parentLaneId: null,
+    childCount: 0,
+    stackDepth: 0,
+    parentStatus: null,
+    isEditProtected: false,
+    status: { dirty: false, ahead: 0, behind: 0, remoteBehind: 0, rebaseInProgress: false },
+    color: null,
+    icon: null,
+    tags: [],
+    createdAt: "2026-04-22T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<TerminalSessionSummary> = {}): TerminalSessionSummary {
+  return {
+    id: "session-mobile",
+    laneId: "lane-mobile",
+    laneName: "Mobile-created lane",
+    ptyId: null,
+    tracked: true,
+    pinned: false,
+    manuallyNamed: false,
+    goal: null,
+    toolType: "codex-chat",
+    title: "Mobile Tool Streaming UI",
+    status: "running",
+    startedAt: "2026-04-22T22:13:02.691Z",
+    endedAt: null,
+    exitCode: null,
+    transcriptPath: ".ade/transcripts/session-mobile.chat.jsonl",
+    headShaStart: null,
+    headShaEnd: null,
+    lastOutputPreview: null,
+    summary: null,
+    runtimeState: "running",
+    resumeCommand: null,
+    ...overrides,
+  };
+}
+
+function renderPane(props: Partial<ComponentProps<typeof SessionListPane>> = {}) {
+  const session = makeSession();
+  return render(
+    <MemoryRouter>
+      <SessionListPane
+        lanes={[makeLane()]}
+        runningFiltered={[session]}
+        awaitingInputFiltered={[]}
+        endedFiltered={[]}
+        loading={false}
+        filterLaneId="all"
+        setFilterLaneId={vi.fn()}
+        filterStatus="all"
+        setFilterStatus={vi.fn()}
+        q=""
+        setQ={vi.fn()}
+        selectedSessionId={null}
+        draftKind="chat"
+        showingDraft={false}
+        onShowDraftKind={vi.fn()}
+        onSelectSession={vi.fn()}
+        onResume={vi.fn()}
+        resumingSessionId={null}
+        onInfoClick={vi.fn()}
+        onContextMenu={vi.fn()}
+        sessionListOrganization="by-lane"
+        setSessionListOrganization={vi.fn()}
+        workCollapsedLaneIds={[]}
+        toggleWorkLaneCollapsed={vi.fn()}
+        workCollapsedSectionIds={[]}
+        toggleWorkSectionCollapsed={vi.fn()}
+        sessionsGroupedByLane={new Map([[session.laneId, [session]]])}
+        {...props}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("SessionListPane", () => {
+  it("renders by-lane sessions whose lane is missing from the cached lane list", () => {
+    renderPane();
+
+    expect(screen.getAllByText("Mobile-created lane")).toHaveLength(2);
+    expect(screen.getByText("Mobile Tool Streaming UI")).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
@@ -151,6 +151,22 @@ export const SessionListPane = React.memo(function SessionListPane({
     for (const lane of lanes) map.set(lane.id, lane);
     return map;
   }, [lanes]);
+  const missingLaneSessionGroups = useMemo(() => {
+    if (!sessionsGroupedByLane) return [];
+    const knownLaneIds = new Set(lanes.map((lane) => lane.id));
+    const latestStartedAt = (sessions: TerminalSessionSummary[]): number =>
+      Math.max(...sessions.map((session) => new Date(session.startedAt).getTime()));
+    return [...sessionsGroupedByLane.entries()]
+      .filter(([laneId, sessions]) => !knownLaneIds.has(laneId) && sessions.length > 0)
+      .sort(([leftLaneId, leftSessions], [rightLaneId, rightSessions]) => {
+        const leftLatest = latestStartedAt(leftSessions);
+        const rightLatest = latestStartedAt(rightSessions);
+        if (leftLatest !== rightLatest) return rightLatest - leftLatest;
+        const leftName = leftSessions[0]?.laneName ?? leftLaneId;
+        const rightName = rightSessions[0]?.laneName ?? rightLaneId;
+        return leftName.localeCompare(rightName);
+      });
+  }, [lanes, sessionsGroupedByLane]);
 
   // First-rendered card carries `data-tour="work.sessionItem"` so the Work
   // tab tour can anchor at a real session. We track whether we've already
@@ -240,6 +256,23 @@ export const SessionListPane = React.memo(function SessionListPane({
             count={total}
             collapsed={collapsed}
             onToggleCollapsed={() => toggleWorkLaneCollapsed(lane.id)}
+          >
+            {renderCards(list)}
+          </StickyGroupHeader>
+        );
+      })}
+      {missingLaneSessionGroups.map(([laneId, list]) => {
+        const collapsed = workCollapsedLaneIds.includes(laneId);
+        const label = list[0]?.laneName ?? laneId;
+        return (
+          <StickyGroupHeader
+            key={laneId}
+            sectionId={laneId}
+            icon={<GitBranch size={11} weight="regular" className="shrink-0 text-muted-fg/55" />}
+            label={label}
+            count={list.length}
+            collapsed={collapsed}
+            onToggleCollapsed={() => toggleWorkLaneCollapsed(laneId)}
           >
             {renderCards(list)}
           </StickyGroupHeader>

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
@@ -154,8 +154,12 @@ export const SessionListPane = React.memo(function SessionListPane({
   const missingLaneSessionGroups = useMemo(() => {
     if (!sessionsGroupedByLane) return [];
     const knownLaneIds = new Set(lanes.map((lane) => lane.id));
-    const latestStartedAt = (sessions: TerminalSessionSummary[]): number =>
-      Math.max(...sessions.map((session) => new Date(session.startedAt).getTime()));
+    const latestStartedAt = (sessions: TerminalSessionSummary[]): number => {
+      const times = sessions
+        .map((session) => new Date(session.startedAt).getTime())
+        .filter(Number.isFinite);
+      return times.length > 0 ? Math.max(...times) : -Infinity;
+    };
     return [...sessionsGroupedByLane.entries()]
       .filter(([laneId, sessions]) => !knownLaneIds.has(laneId) && sessions.length > 0)
       .sort(([leftLaneId, leftSessions], [rightLaneId, rightSessions]) => {

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
@@ -160,14 +160,18 @@ export const SessionListPane = React.memo(function SessionListPane({
         .filter(Number.isFinite);
       return times.length > 0 ? Math.max(...times) : -Infinity;
     };
+    const orphanLabel = (name: string | null | undefined, fallback: string): string => {
+      const trimmed = (name ?? "").trim();
+      return trimmed.length > 0 ? trimmed : fallback;
+    };
     return [...sessionsGroupedByLane.entries()]
       .filter(([laneId, sessions]) => !knownLaneIds.has(laneId) && sessions.length > 0)
       .sort(([leftLaneId, leftSessions], [rightLaneId, rightSessions]) => {
         const leftLatest = latestStartedAt(leftSessions);
         const rightLatest = latestStartedAt(rightSessions);
         if (leftLatest !== rightLatest) return rightLatest - leftLatest;
-        const leftName = leftSessions[0]?.laneName ?? leftLaneId;
-        const rightName = rightSessions[0]?.laneName ?? rightLaneId;
+        const leftName = orphanLabel(leftSessions[0]?.laneName, leftLaneId);
+        const rightName = orphanLabel(rightSessions[0]?.laneName, rightLaneId);
         return leftName.localeCompare(rightName);
       });
   }, [lanes, sessionsGroupedByLane]);
@@ -267,7 +271,8 @@ export const SessionListPane = React.memo(function SessionListPane({
       })}
       {missingLaneSessionGroups.map(([laneId, list]) => {
         const collapsed = workCollapsedLaneIds.includes(laneId);
-        const label = list[0]?.laneName ?? laneId;
+        const trimmedLaneName = (list[0]?.laneName ?? "").trim();
+        const label = trimmedLaneName.length > 0 ? trimmedLaneName : laneId;
         return (
           <StickyGroupHeader
             key={laneId}

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -148,6 +148,7 @@ export const IPC = {
   agentChatListSubagents: "ade.agentChat.listSubagents",
   agentChatGetSessionCapabilities: "ade.agentChat.getSessionCapabilities",
   agentChatGetTurnFileDiff: "ade.agentChat.getTurnFileDiff",
+  agentChatGetEventHistory: "ade.agentChat.getEventHistory",
   computerUseListArtifacts: "ade.computerUse.listArtifacts",
   computerUseGetOwnerSnapshot: "ade.computerUse.getOwnerSnapshot",
   computerUseRouteArtifact: "ade.computerUse.routeArtifact",

--- a/apps/ios/ADE/Info.plist
+++ b/apps/ios/ADE/Info.plist
@@ -37,6 +37,21 @@
   <dict>
     <key>NSAllowsLocalNetworking</key>
     <true/>
+    <key>NSExceptionDomains</key>
+    <dict>
+      <key>ade-sync</key>
+      <dict>
+        <key>NSExceptionAllowsInsecureHTTPLoads</key>
+        <true/>
+      </dict>
+      <key>ts.net</key>
+      <dict>
+        <key>NSExceptionAllowsInsecureHTTPLoads</key>
+        <true/>
+        <key>NSIncludesSubdomains</key>
+        <true/>
+      </dict>
+    </dict>
   </dict>
   <key>NSBonjourServices</key>
   <array>

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -193,6 +193,7 @@ enum SyncTailnetDiscovery {
   ]
   static let portCandidates = [
     8787,
+    8788,
   ]
 }
 
@@ -224,8 +225,14 @@ func syncNormalizedRouteHost(_ address: String) -> String {
   if let question = host.firstIndex(of: "?") { host = String(host[..<question]) }
   if let bracketEnd = host.lastIndex(of: "]"), host.hasPrefix("[") {
     host = String(host[host.index(after: host.startIndex)..<bracketEnd])
-  } else if let colon = host.lastIndex(of: ":") {
-    host = String(host[..<colon])
+  } else {
+    // Only strip a trailing `:port` for unambiguous `host:port`. Unbracketed
+    // IPv6 literals (e.g. `::1`, `fc00::1`) contain multiple colons and must
+    // be preserved verbatim — callers bracket real IPv6+port forms above.
+    let colonCount = host.reduce(0) { $1 == ":" ? $0 + 1 : $0 }
+    if colonCount == 1, let colon = host.lastIndex(of: ":") {
+      host = String(host[..<colon])
+    }
   }
   return host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 }

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -4500,8 +4500,25 @@ final class SyncService: ObservableObject {
   func recordChatEventEnvelope(_ envelope: AgentChatEventEnvelope) {
     var events = chatEventEnvelopesBySession[envelope.sessionId] ?? []
     guard !events.contains(where: { $0.id == envelope.id }) else { return }
-    events.append(envelope)
-    events = trimChatEventHistory(events)
+    // Fast path: arrival-order appends stay sorted when timestamps are
+    // monotonically non-decreasing — common for live streaming. Out-of-order
+    // deliveries (e.g., a delayed tool_result arriving after a later text
+    // fragment, or a merge with a historical snapshot) fall through to the
+    // full dedup/sort in deduplicatedChatEventHistory so bubble order matches
+    // the replace/merge paths.
+    let canAppendInOrder: Bool = {
+      guard let last = events.last else { return true }
+      let lastDate = Self.parseIso8601(last.timestamp)
+      let envelopeDate = Self.parseIso8601(envelope.timestamp)
+      if let lhs = envelopeDate, let rhs = lastDate { return lhs >= rhs }
+      return envelope.timestamp >= last.timestamp
+    }()
+    if canAppendInOrder {
+      events.append(envelope)
+      events = trimChatEventHistory(events)
+    } else {
+      events = deduplicatedChatEventHistory(events + [envelope])
+    }
     chatEventEnvelopesBySession[envelope.sessionId] = events
     chatEventRevisionsBySession[envelope.sessionId, default: 0] += 1
     lastSyncAt = Date()
@@ -4531,10 +4548,24 @@ final class SyncService: ObservableObject {
       return true
     }
     .sorted { lhs, rhs in
-      if lhs.timestamp == rhs.timestamp {
-        return (lhs.sequence ?? 0) < (rhs.sequence ?? 0)
+      // Parse timestamps to Date before comparing — a lexicographic compare
+      // misorders mixed ISO-8601 variants (e.g., "…56.500Z" sorts before
+      // "…56Z" because "." < "Z" in ASCII, even though chronologically it's
+      // half a second later).
+      let lhsDate = Self.parseIso8601(lhs.timestamp)
+      let rhsDate = Self.parseIso8601(rhs.timestamp)
+      if lhsDate == rhsDate {
+        if lhs.timestamp == rhs.timestamp {
+          return (lhs.sequence ?? 0) < (rhs.sequence ?? 0)
+        }
+        return lhs.timestamp < rhs.timestamp
       }
-      return lhs.timestamp < rhs.timestamp
+      switch (lhsDate, rhsDate) {
+      case (let l?, let r?): return l < r
+      case (nil, _?): return true
+      case (_?, nil): return false
+      case (nil, nil): return lhs.timestamp < rhs.timestamp
+      }
     }
     return trimChatEventHistory(unique)
   }

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -166,7 +166,9 @@ enum SyncRequestTimeout {
 }
 
 private let syncTerminalSubscriptionMaxBytes = 80_000
+private let syncChatSubscriptionMaxBytes = 2_000_000
 private let syncTerminalBufferMaxCharacters = 80_000
+private let chatEventHistoryMaxEvents = 1_000
 
 enum SyncBonjourTiming {
   static let searchRetryNanoseconds: UInt64 = 2_000_000_000
@@ -4057,7 +4059,11 @@ final class SyncService: ObservableObject {
       if supportsChatStreaming,
          let dict = payload as? [String: Any],
          let snapshot = try? decode(dict, as: SyncChatSubscribeSnapshotPayload.self) {
-        replaceChatEventHistory(sessionId: snapshot.sessionId, events: snapshot.events)
+        if snapshot.truncated {
+          mergeChatEventHistory(sessionId: snapshot.sessionId, events: snapshot.events)
+        } else {
+          replaceChatEventHistory(sessionId: snapshot.sessionId, events: snapshot.events)
+        }
       }
     case "chat_event":
       if supportsChatStreaming,
@@ -4474,7 +4480,10 @@ final class SyncService: ObservableObject {
   }
 
   private func chatSubscriptionPayload(sessionId: String) -> [String: Any] {
-    ["sessionId": sessionId]
+    [
+      "sessionId": sessionId,
+      "maxBytes": syncChatSubscriptionMaxBytes,
+    ]
   }
 
   private func restoreChatEventSubscriptions() {
@@ -4488,9 +4497,7 @@ final class SyncService: ObservableObject {
     var events = chatEventEnvelopesBySession[envelope.sessionId] ?? []
     guard !events.contains(where: { $0.id == envelope.id }) else { return }
     events.append(envelope)
-    if events.count > 500 {
-      events.removeFirst(events.count - 500)
-    }
+    events = trimChatEventHistory(events)
     chatEventEnvelopesBySession[envelope.sessionId] = events
     chatEventRevisionsBySession[envelope.sessionId, default: 0] += 1
     lastSyncAt = Date()
@@ -4498,15 +4505,39 @@ final class SyncService: ObservableObject {
   }
 
   func replaceChatEventHistory(sessionId: String, events: [AgentChatEventEnvelope]) {
+    chatEventEnvelopesBySession[sessionId] = deduplicatedChatEventHistory(events)
+    chatEventRevisionsBySession[sessionId, default: 0] += 1
+    lastSyncAt = Date()
+    markChatEventsChanged(immediate: true)
+  }
+
+  func mergeChatEventHistory(sessionId: String, events: [AgentChatEventEnvelope]) {
+    let current = chatEventEnvelopesBySession[sessionId] ?? []
+    chatEventEnvelopesBySession[sessionId] = deduplicatedChatEventHistory(current + events)
+    chatEventRevisionsBySession[sessionId, default: 0] += 1
+    lastSyncAt = Date()
+    markChatEventsChanged(immediate: true)
+  }
+
+  private func deduplicatedChatEventHistory(_ events: [AgentChatEventEnvelope]) -> [AgentChatEventEnvelope] {
     var seen = Set<String>()
-    chatEventEnvelopesBySession[sessionId] = events.filter { event in
+    let unique = events.filter { event in
       guard !seen.contains(event.id) else { return false }
       seen.insert(event.id)
       return true
     }
-    chatEventRevisionsBySession[sessionId, default: 0] += 1
-    lastSyncAt = Date()
-    markChatEventsChanged(immediate: true)
+    .sorted { lhs, rhs in
+      if lhs.timestamp == rhs.timestamp {
+        return (lhs.sequence ?? 0) < (rhs.sequence ?? 0)
+      }
+      return lhs.timestamp < rhs.timestamp
+    }
+    return trimChatEventHistory(unique)
+  }
+
+  private func trimChatEventHistory(_ events: [AgentChatEventEnvelope]) -> [AgentChatEventEnvelope] {
+    guard events.count > chatEventHistoryMaxEvents else { return events }
+    return Array(events.suffix(chatEventHistoryMaxEvents))
   }
 
   private func trimmedTerminalBuffer(_ buffer: String) -> String {

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -190,11 +190,9 @@ enum SyncTailnetDiscoveryTiming {
 enum SyncTailnetDiscovery {
   static let hostCandidates = [
     "ade-sync",
-    "ade-desktop",
   ]
   static let portCandidates = [
     8787,
-    8788,
   ]
 }
 
@@ -215,6 +213,29 @@ func syncIsTailscaleIPv4Address(_ host: String) -> Bool {
     return false
   }
   return first == 100 && (64...127).contains(second)
+}
+
+func syncNormalizedRouteHost(_ address: String) -> String {
+  var host = address.trimmingCharacters(in: .whitespacesAndNewlines)
+  if let schemeRange = host.range(of: "://") {
+    host = String(host[schemeRange.upperBound...])
+  }
+  if let slash = host.firstIndex(of: "/") { host = String(host[..<slash]) }
+  if let question = host.firstIndex(of: "?") { host = String(host[..<question]) }
+  if let bracketEnd = host.lastIndex(of: "]"), host.hasPrefix("[") {
+    host = String(host[host.index(after: host.startIndex)..<bracketEnd])
+  } else if let colon = host.lastIndex(of: ":") {
+    host = String(host[..<colon])
+  }
+  return host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+}
+
+func syncIsTailscaleRoute(_ address: String) -> Bool {
+  let host = syncNormalizedRouteHost(address)
+  if host.isEmpty { return false }
+  return syncIsTailscaleIPv4Address(host)
+    || syncIsTailnetDiscoveryHost(host)
+    || host.hasSuffix(".ts.net")
 }
 
 struct SyncReconnectState {
@@ -873,9 +894,9 @@ final class SyncService: ObservableObject {
       discoveredLanAddresses: addressCandidates.filter { host in
         guard !host.contains(":") else { return false }
         guard host != "127.0.0.1" else { return false }
-        return !syncIsTailscaleIPv4Address(host)
+        return !syncIsTailscaleRoute(host)
       },
-      tailscaleAddress: addressCandidates.first(where: syncIsTailscaleIPv4Address)
+      tailscaleAddress: addressCandidates.first(where: syncIsTailscaleRoute)
     )
 
     let previousActiveProjectId = activeProjectId
@@ -1216,14 +1237,14 @@ final class SyncService: ObservableObject {
     }
     let tailscaleAddress =
       profile.tailscaleAddress
-      ?? profile.savedAddressCandidates.first(where: syncIsTailscaleIPv4Address)
-      ?? profile.lastSuccessfulAddress.flatMap { syncIsTailscaleIPv4Address($0) ? $0 : nil }
-    let lanAddresses = profile.discoveredLanAddresses.filter { !syncIsTailscaleIPv4Address($0) }
-    let savedLanAddresses = profile.savedAddressCandidates.filter { !syncIsTailscaleIPv4Address($0) }
+      ?? profile.savedAddressCandidates.first(where: syncIsTailscaleRoute)
+      ?? profile.lastSuccessfulAddress.flatMap { syncIsTailscaleRoute($0) ? $0 : nil }
+    let lanAddresses = profile.discoveredLanAddresses.filter { !syncIsTailscaleRoute($0) }
+    let savedLanAddresses = profile.savedAddressCandidates.filter { !syncIsTailscaleRoute($0) }
     let addresses = deduplicatedAddresses(
       lanAddresses
       + savedLanAddresses
-      + (profile.lastSuccessfulAddress.flatMap { syncIsTailscaleIPv4Address($0) ? nil : $0 }.map { [$0] } ?? [])
+      + (profile.lastSuccessfulAddress.flatMap { syncIsTailscaleRoute($0) ? nil : $0 }.map { [$0] } ?? [])
     )
     guard tailscaleAddress != nil || !addresses.isEmpty else { return nil }
     let identity = profile.hostIdentity?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1315,7 +1336,7 @@ final class SyncService: ObservableObject {
       return
     }
 
-    let connectedOverTailnet = currentAddress.map(syncIsTailscaleIPv4Address) ?? false
+    let connectedOverTailnet = currentAddress.map(syncIsTailscaleRoute) ?? false
     let shouldRoamToTailnet =
       !connectedOverTailnet
       && profileHasTailnetRoute(profile)
@@ -1489,16 +1510,9 @@ final class SyncService: ObservableObject {
         discoveredLanAddresses: addressCandidates.filter { host in
           guard !host.contains(":") else { return false }
           if host == "127.0.0.1" { return false }
-          let octets = host.split(separator: ".")
-          guard octets.count == 4 else { return false }
-          guard let first = octets.first.flatMap({ Int($0) }),
-                let second = octets.dropFirst().first.flatMap({ Int($0) }) else {
-            return false
-          }
-          let isTailscale = first == 100 && (64...127).contains(second)
-          return !isTailscale
+          return !syncIsTailscaleRoute(host)
         },
-        tailscaleAddress: tailscaleAddress
+        tailscaleAddress: tailscaleAddress ?? addressCandidates.first(where: syncIsTailscaleRoute)
       )
       saveProfile(profile)
       currentAddress = preferredAddress
@@ -3201,35 +3215,20 @@ final class SyncService: ObservableObject {
   private func syncCanAttemptPlaintextWebSocket(_ address: String) -> Bool {
     let trimmed = address.trimmingCharacters(in: .whitespacesAndNewlines)
     if trimmed.isEmpty { return false }
-
-    // Strip a leading scheme so raw hosts like "192.168.1.10:7878" and
-    // "ws://192.168.1.10:7878" both flow through the same path.
-    var host = trimmed
-    if let schemeRange = host.range(of: "://") {
-      let scheme = host[..<schemeRange.lowerBound].lowercased()
+    if let schemeRange = trimmed.range(of: "://") {
+      let scheme = trimmed[..<schemeRange.lowerBound].lowercased()
       // wss:// is end-to-end encrypted; anything non-ws beyond that we don't know
       // how to speak, so treat it conservatively.
       if scheme == "wss" { return true }
       if scheme != "ws" && scheme != "http" { return false }
-      host = String(host[schemeRange.upperBound...])
     }
 
-    // Drop trailing path and query, then an optional :port.
-    if let slash = host.firstIndex(of: "/") { host = String(host[..<slash]) }
-    if let question = host.firstIndex(of: "?") { host = String(host[..<question]) }
-    if let bracketEnd = host.lastIndex(of: "]") {
-      // IPv6 literal: host is `[...]:port`.
-      host = String(host[host.index(after: host.startIndex)..<bracketEnd])
-    } else if let colon = host.lastIndex(of: ":") {
-      host = String(host[..<colon])
-    }
-    host = host.lowercased()
+    let host = syncNormalizedRouteHost(trimmed)
     if host.isEmpty { return false }
 
     if host == "localhost" || host.hasSuffix(".localhost") { return true }
     if host.hasSuffix(".local") { return true } // Bonjour / mDNS
-    if host.hasSuffix(".ts.net") { return true } // Tailscale MagicDNS
-    if syncIsTailnetDiscoveryHost(host) { return true } // Tailscale Serve service aliases
+    if syncIsTailscaleRoute(host) { return true } // Tailscale IP, MagicDNS, or Serve aliases
 
     if let v4 = IPv4Address(host) {
       let bytes = v4.rawValue
@@ -3278,7 +3277,7 @@ final class SyncService: ObservableObject {
     if normalized == "127.0.0.1" || normalized == "::1" {
       return "loopback"
     }
-    if syncIsTailscaleIPv4Address(normalized) ||
+    if syncIsTailscaleRoute(normalized) ||
         explicitTailscaleAddress == normalized ||
         profile?.tailscaleAddress == normalized {
       return "tailscale"
@@ -3380,9 +3379,9 @@ final class SyncService: ObservableObject {
   }
 
   private func profileHasTailnetRoute(_ profile: HostConnectionProfile) -> Bool {
-    if profile.tailscaleAddress.map(syncIsTailscaleIPv4Address) == true { return true }
-    if profile.lastSuccessfulAddress.map(syncIsTailscaleIPv4Address) == true { return true }
-    return profile.savedAddressCandidates.contains(where: syncIsTailscaleIPv4Address)
+    if profile.tailscaleAddress.map(syncIsTailscaleRoute) == true { return true }
+    if profile.lastSuccessfulAddress.map(syncIsTailscaleRoute) == true { return true }
+    return profile.savedAddressCandidates.contains(where: syncIsTailscaleRoute)
   }
 
   private func preferTailnetForUpcomingReconnect() {
@@ -3408,8 +3407,8 @@ final class SyncService: ObservableObject {
     let liveLastSuccessful = profile.lastSuccessfulAddress.flatMap { address in
       liveSet.contains(address) ? [address] : nil
     } ?? []
-    let liveLastSuccessfulTailnet = liveLastSuccessful.filter(syncIsTailscaleIPv4Address)
-    let liveLastSuccessfulLan = liveLastSuccessful.filter { !syncIsTailscaleIPv4Address($0) }
+    let liveLastSuccessfulTailnet = liveLastSuccessful.filter(syncIsTailscaleRoute)
+    let liveLastSuccessfulLan = liveLastSuccessful.filter { !syncIsTailscaleRoute($0) }
     // Prefer addresses we see RIGHT NOW on the network over anything we have
     // cached from previous sessions. If the user changed subnets, stale
     // entries would otherwise consume the first few attempts (each with its
@@ -3418,8 +3417,8 @@ final class SyncService: ObservableObject {
     let prioritizedLive = preferTailnet
       ? liveLastSuccessfulTailnet + liveTailscale + liveLastSuccessfulLan + liveLan
       : liveLastSuccessful + liveLan + liveTailscale
-    let savedTailnet = profile.savedAddressCandidates.filter(syncIsTailscaleIPv4Address)
-    let savedLan = profile.savedAddressCandidates.filter { !syncIsTailscaleIPv4Address($0) }
+    let savedTailnet = profile.savedAddressCandidates.filter(syncIsTailscaleRoute)
+    let savedLan = profile.savedAddressCandidates.filter { !syncIsTailscaleRoute($0) }
     let fallbackLastSuccessful = liveLastSuccessful.isEmpty ? (profile.lastSuccessfulAddress.map { [$0] } ?? []) : []
     let savedProfileTailnet = profile.tailscaleAddress.map { [$0] } ?? []
     let fallbackSaved: [String]
@@ -3445,9 +3444,9 @@ final class SyncService: ObservableObject {
       matchesDiscoveredHost(host, profile: profile)
     }
     guard !matchingDiscovery.isEmpty else {
-      let savedTailnet = profile.savedAddressCandidates.filter(syncIsTailscaleIPv4Address)
+      let savedTailnet = profile.savedAddressCandidates.filter(syncIsTailscaleRoute)
       let lastSuccessfulTailnet = profile.lastSuccessfulAddress.flatMap { address in
-        syncIsTailscaleIPv4Address(address) ? [address] : nil
+        syncIsTailscaleRoute(address) ? [address] : nil
       } ?? []
       return deduplicatedAddresses(
         (preferTailnet ? [] : lastSuccessfulTailnet)
@@ -3463,8 +3462,8 @@ final class SyncService: ObservableObject {
     let liveLastSuccessful = profile.lastSuccessfulAddress.flatMap { address in
       liveSet.contains(address) ? [address] : nil
     } ?? []
-    let liveLastSuccessfulTailnet = liveLastSuccessful.filter(syncIsTailscaleIPv4Address)
-    let liveLastSuccessfulLan = liveLastSuccessful.filter { !syncIsTailscaleIPv4Address($0) }
+    let liveLastSuccessfulTailnet = liveLastSuccessful.filter(syncIsTailscaleRoute)
+    let liveLastSuccessfulLan = liveLastSuccessful.filter { !syncIsTailscaleRoute($0) }
 
     let prioritizedLive = preferTailnet
       ? liveLastSuccessfulTailnet + liveTailscale + liveLastSuccessfulLan + liveLan
@@ -3871,7 +3870,9 @@ final class SyncService: ObservableObject {
     saveRemoteCommandDescriptors(commandDescriptors)
 
     let matchingDiscovery = discoveredHosts.first { discovered in
-      discovered.hostIdentity == remoteHostIdentity || discovered.addresses.contains(connectedHost)
+      discovered.hostIdentity == remoteHostIdentity
+        || discovered.addresses.contains(connectedHost)
+        || discovered.tailscaleAddress == connectedHost
     }
     // Cap saved candidates to avoid unbounded growth when the user moves
     // between networks. Put the currently-connected host first, then any
@@ -3880,6 +3881,7 @@ final class SyncService: ObservableObject {
     let savedCandidatesUncapped = deduplicatedAddresses(
       [connectedHost] +
       (matchingDiscovery?.addresses ?? []) +
+      (matchingDiscovery?.tailscaleAddress.map { [$0] } ?? []) +
       (activeHostProfile?.savedAddressCandidates ?? [])
     )
     let savedCandidates = Array(savedCandidatesUncapped.prefix(6))
@@ -3898,7 +3900,9 @@ final class SyncService: ObservableObject {
       lastSuccessfulAddress: connectedHost,
       savedAddressCandidates: savedCandidates,
       discoveredLanAddresses: discoveredLan,
-      tailscaleAddress: matchingDiscovery?.tailscaleAddress ?? activeHostProfile?.tailscaleAddress
+      tailscaleAddress: matchingDiscovery?.tailscaleAddress
+        ?? (syncIsTailscaleRoute(connectedHost) ? connectedHost : nil)
+        ?? activeHostProfile?.tailscaleAddress
     )
     saveProfile(profile)
     startRelayLoop()

--- a/apps/ios/ADE/Views/Settings/SettingsPairingSection.swift
+++ b/apps/ios/ADE/Views/Settings/SettingsPairingSection.swift
@@ -342,13 +342,17 @@ private struct DiscoveredHostRow: View {
   }
 
   private var primaryRoute: String {
-    host.addresses.first { address in
-      !isLoopback(address) && !syncIsTailscaleIPv4Address(address)
+    if let tailscaleAddress = host.tailscaleAddress,
+       detailPrefix?.localizedCaseInsensitiveContains("tailscale") == true {
+      return tailscaleAddress
+    }
+    return host.addresses.first { address in
+      !isLoopback(address) && !syncIsTailscaleRoute(address)
     } ?? host.tailscaleAddress ?? host.addresses.first ?? "No route"
   }
 
   private func inferredRoutePrefix(for route: String) -> String? {
-    if syncIsTailscaleIPv4Address(route) {
+    if syncIsTailscaleRoute(route) {
       return "Tailscale"
     }
     return nil

--- a/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
@@ -26,10 +26,12 @@ func errorPresentation(for category: String) -> WorkErrorPresentation {
 func buildWorkChatMessages(from transcript: [WorkChatEnvelope]) -> [WorkChatMessage] {
   var messages: [WorkChatMessage] = []
   let metadataByTurn = workTurnModelMetadataByTurn(from: transcript)
+  var previousEnvelopeWasAssistantText = false
 
   for envelope in transcript {
     switch envelope.event {
     case .userMessage(let text, let turnId, let steerId, let deliveryState, let processed):
+      previousEnvelopeWasAssistantText = false
       // Queued steers render as inline cards above the composer, not in the message stream.
       if deliveryState == "queued", steerId != nil {
         continue
@@ -63,10 +65,12 @@ func buildWorkChatMessages(from transcript: [WorkChatEnvelope]) -> [WorkChatMess
       let metadata = turnId
         .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
         .flatMap { metadataByTurn[$0] }
+      let canMergeWithPreviousAssistant = itemId != nil || previousEnvelopeWasAssistantText
       if let lastIndex = messages.indices.last,
          messages[lastIndex].role == "assistant",
          messages[lastIndex].turnId == turnId,
-         messages[lastIndex].itemId == itemId {
+         messages[lastIndex].itemId == itemId,
+         canMergeWithPreviousAssistant {
         messages[lastIndex].markdown += text
       } else {
         messages.append(WorkChatMessage(
@@ -80,7 +84,9 @@ func buildWorkChatMessages(from transcript: [WorkChatEnvelope]) -> [WorkChatMess
           turnModelId: metadata?.modelId
         ))
       }
+      previousEnvelopeWasAssistantText = true
     default:
+      previousEnvelopeWasAssistantText = false
       continue
     }
   }

--- a/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
@@ -26,6 +26,11 @@ func errorPresentation(for category: String) -> WorkErrorPresentation {
 func buildWorkChatMessages(from transcript: [WorkChatEnvelope]) -> [WorkChatMessage] {
   var messages: [WorkChatMessage] = []
   let metadataByTurn = workTurnModelMetadataByTurn(from: transcript)
+  // Tracks whether the previous envelope was assistantText so nil-itemId
+  // streaming fragments can merge into it. MUST be reset to false on every
+  // non-assistantText branch below — otherwise a subsequent nil-itemId
+  // fragment could wrongly merge across an intervening tool call or user
+  // message. Any new `WorkChatEvent` case added here must preserve that reset.
   var previousEnvelopeWasAssistantText = false
 
   for envelope in transcript {

--- a/apps/ios/ADE/Views/Work/WorkEventMapping.swift
+++ b/apps/ios/ADE/Views/Work/WorkEventMapping.swift
@@ -24,9 +24,9 @@ func makeWorkChatEvent(from event: AgentChatEvent) -> WorkChatEvent {
   case .text(let text, let messageId, let turnId, let itemId):
     let normalizedMessageId = messageId?.trimmingCharacters(in: .whitespacesAndNewlines)
     let normalizedItemId = itemId?.trimmingCharacters(in: .whitespacesAndNewlines)
-    let stableItemId = normalizedMessageId?.isEmpty == false
-      ? normalizedMessageId
-      : (normalizedItemId?.isEmpty == false ? normalizedItemId : nil)
+    let stableItemId = normalizedItemId?.isEmpty == false
+      ? normalizedItemId
+      : (normalizedMessageId?.isEmpty == false ? normalizedMessageId : nil)
     return .assistantText(text: text, turnId: turnId, itemId: stableItemId)
   case .toolCall(let tool, let args, let itemId, _, let parentItemId, let turnId):
     return .toolCall(

--- a/apps/ios/ADE/Views/Work/WorkEventMapping.swift
+++ b/apps/ios/ADE/Views/Work/WorkEventMapping.swift
@@ -21,8 +21,13 @@ func makeWorkChatEvent(from event: AgentChatEvent) -> WorkChatEvent {
   switch event {
   case .userMessage(let text, _, let turnId, let steerId, let deliveryState, let processed):
     return .userMessage(text: text, turnId: turnId, steerId: steerId, deliveryState: deliveryState, processed: processed)
-  case .text(let text, _, let turnId, let itemId):
-    return .assistantText(text: text, turnId: turnId, itemId: itemId)
+  case .text(let text, let messageId, let turnId, let itemId):
+    let normalizedMessageId = messageId?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let normalizedItemId = itemId?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let stableItemId = normalizedMessageId?.isEmpty == false
+      ? normalizedMessageId
+      : (normalizedItemId?.isEmpty == false ? normalizedItemId : nil)
+    return .assistantText(text: text, turnId: turnId, itemId: stableItemId)
   case .toolCall(let tool, let args, let itemId, _, let parentItemId, let turnId):
     return .toolCall(
       tool: tool,

--- a/apps/ios/ADE/Views/Work/WorkSessionGrouping.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionGrouping.swift
@@ -143,18 +143,22 @@ func workSessionGroupsByLane(
       return parsed > acc ? parsed : acc
     }
   }
+  func orphanLabel(_ name: String?, fallback: String) -> String {
+    let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return trimmed.isEmpty ? fallback : trimmed
+  }
   let orphanEntries = byLaneId
     .filter { laneId, list in !knownLaneIds.contains(laneId) && !list.isEmpty }
     .sorted { left, right in
       let leftLatest = latestStartedAt(left.value)
       let rightLatest = latestStartedAt(right.value)
       if leftLatest != rightLatest { return leftLatest > rightLatest }
-      let leftName = left.value.first?.laneName ?? left.key
-      let rightName = right.value.first?.laneName ?? right.key
+      let leftName = orphanLabel(left.value.first?.laneName, fallback: left.key)
+      let rightName = orphanLabel(right.value.first?.laneName, fallback: right.key)
       return leftName.localizedCaseInsensitiveCompare(rightName) == .orderedAscending
     }
   for (laneId, list) in orphanEntries {
-    let label = list.first?.laneName ?? laneId
+    let label = orphanLabel(list.first?.laneName, fallback: laneId)
     groups.append(WorkSessionGroup(id: "lane:\(laneId)", label: label, icon: .laneBranch, tint: ADEColor.textMuted, sessions: list))
   }
   return groups

--- a/apps/ios/ADE/Views/Work/WorkSessionGrouping.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionGrouping.swift
@@ -126,15 +126,36 @@ func workSessionGroupsByLane(
   }
 
   var groups: [WorkSessionGroup] = []
+  let knownLaneIds = Set(orderedLanes.map(\.id))
   for lane in orderedLanes {
     guard let list = byLaneId[lane.id], !list.isEmpty else { continue }
     groups.append(WorkSessionGroup(id: "lane:\(lane.id)", label: lane.name, icon: .laneBranch, tint: ADEColor.textSecondary, sessions: list))
   }
-  // Surface any sessions whose lane isn't in the ordered list (e.g., soft-deleted lanes) at the end.
-  let accounted = Set(groups.flatMap { $0.sessions.map(\.id) })
-  let orphans = sessions.filter { !accounted.contains($0.id) }
-  if !orphans.isEmpty {
-    groups.append(WorkSessionGroup(id: "lane:_orphans", label: "Other", icon: .laneBranch, tint: ADEColor.textMuted, sessions: orphans))
+  // Surface any sessions whose lane isn't in the ordered list (e.g., soft-deleted lanes)
+  // as their own per-lane groups so users still recognize which branch each belongs to.
+  let iso = ISO8601DateFormatter()
+  iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+  let isoFallback = ISO8601DateFormatter()
+  isoFallback.formatOptions = [.withInternetDateTime]
+  func latestStartedAt(_ list: [TerminalSessionSummary]) -> Date {
+    list.reduce(.distantPast) { acc, session in
+      let parsed = iso.date(from: session.startedAt) ?? isoFallback.date(from: session.startedAt) ?? .distantPast
+      return parsed > acc ? parsed : acc
+    }
+  }
+  let orphanEntries = byLaneId
+    .filter { laneId, list in !knownLaneIds.contains(laneId) && !list.isEmpty }
+    .sorted { left, right in
+      let leftLatest = latestStartedAt(left.value)
+      let rightLatest = latestStartedAt(right.value)
+      if leftLatest != rightLatest { return leftLatest > rightLatest }
+      let leftName = left.value.first?.laneName ?? left.key
+      let rightName = right.value.first?.laneName ?? right.key
+      return leftName.localizedCaseInsensitiveCompare(rightName) == .orderedAscending
+    }
+  for (laneId, list) in orphanEntries {
+    let label = list.first?.laneName ?? laneId
+    groups.append(WorkSessionGroup(id: "lane:\(laneId)", label: label, icon: .laneBranch, tint: ADEColor.textMuted, sessions: list))
   }
   return groups
 }

--- a/apps/ios/ADE/Views/Work/WorkTranscriptParser.swift
+++ b/apps/ios/ADE/Views/Work/WorkTranscriptParser.swift
@@ -45,7 +45,7 @@ func parseWorkChatTranscript(_ raw: String) -> [WorkChatEnvelope] {
         event = .assistantText(
           text: stringValue(eventDict["text"]),
           turnId: turnId,
-          itemId: itemId ?? optionalString(eventDict["messageId"])
+          itemId: optionalString(eventDict["itemId"]) ?? optionalString(eventDict["messageId"])
         )
       case "tool_call":
         event = .toolCall(

--- a/apps/ios/ADE/Views/Work/WorkTranscriptParser.swift
+++ b/apps/ios/ADE/Views/Work/WorkTranscriptParser.swift
@@ -42,7 +42,11 @@ func parseWorkChatTranscript(_ raw: String) -> [WorkChatEnvelope] {
           processed: eventDict["processed"] as? Bool
         )
       case "text":
-        event = .assistantText(text: stringValue(eventDict["text"]), turnId: turnId, itemId: itemId)
+        event = .assistantText(
+          text: stringValue(eventDict["text"]),
+          turnId: turnId,
+          itemId: itemId ?? optionalString(eventDict["messageId"])
+        )
       case "tool_call":
         event = .toolCall(
           tool: stringValue(eventDict["tool"]),

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -138,6 +138,18 @@ final class ADETests: XCTestCase {
     XCTAssertFalse(syncIsTailscaleIPv4Address("127.0.0.1"))
   }
 
+  func testSyncRecognizesTailscaleRoutes() {
+    XCTAssertTrue(syncIsTailscaleRoute("100.117.237.95"))
+    XCTAssertTrue(syncIsTailscaleRoute("ws://100.117.237.95:8787"))
+    XCTAssertTrue(syncIsTailscaleRoute("HTTPS://ADE-SYNC:8787/sync?source=settings"))
+    XCTAssertTrue(syncIsTailscaleRoute("ade-sync"))
+    XCTAssertTrue(syncIsTailscaleRoute("macbook.tailnet.ts.net"))
+    XCTAssertEqual(syncNormalizedRouteHost("ws://MACBOOK.tailnet.ts.net:8787/sync"), "macbook.tailnet.ts.net")
+    XCTAssertFalse(syncIsTailscaleRoute("192.168.68.102"))
+    XCTAssertFalse(syncIsTailscaleRoute("mac.local"))
+    XCTAssertFalse(syncIsTailscaleRoute("not-ts.net.example.com"))
+  }
+
   func testSyncBonjourTimingMatchesReliabilityRequirements() {
     XCTAssertEqual(SyncBonjourTiming.searchRetryNanoseconds, 2_000_000_000)
     XCTAssertEqual(SyncBonjourTiming.resolveRetryNanoseconds, 2_000_000_000)

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -428,6 +428,67 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(service.chatEventHistory(sessionId: "session-1"), [fresh])
   }
 
+  @MainActor
+  func testChatEventHistoryOrdersByParsedTimestampAcrossMixedFractionalVariants() async throws {
+    let service = SyncService(database: makeDatabase(baseURL: makeTemporaryDirectory()))
+    // Lexicographic compare misorders these: "…56Z" > "…56.500Z" because
+    // "Z" (0x5A) > "." (0x2E) in ASCII. Chronologically "…56Z" comes first.
+    let noFractional = AgentChatEventEnvelope(
+      sessionId: "session-1",
+      timestamp: "2026-03-17T00:00:56Z",
+      event: .userMessage(text: "first", attachments: [], turnId: "turn-1", steerId: nil, deliveryState: nil, processed: nil),
+      sequence: 1,
+      provenance: nil
+    )
+    let withFractional = AgentChatEventEnvelope(
+      sessionId: "session-1",
+      timestamp: "2026-03-17T00:00:56.500Z",
+      event: .text(text: "second", messageId: "msg-1", turnId: "turn-1", itemId: "item-1"),
+      sequence: 2,
+      provenance: nil
+    )
+
+    service.replaceChatEventHistory(sessionId: "session-1", events: [withFractional, noFractional])
+
+    let history = service.chatEventHistory(sessionId: "session-1")
+    XCTAssertEqual(history.map(\.id), [noFractional.id, withFractional.id])
+  }
+
+  @MainActor
+  func testRecordChatEventEnvelopeSortsWhenLiveEventArrivesOutOfOrder() async throws {
+    let service = SyncService(database: makeDatabase(baseURL: makeTemporaryDirectory()))
+    let earlier = AgentChatEventEnvelope(
+      sessionId: "session-1",
+      timestamp: "2026-03-17T00:00:01.000Z",
+      event: .userMessage(text: "first", attachments: [], turnId: "turn-1", steerId: nil, deliveryState: nil, processed: nil),
+      sequence: 1,
+      provenance: nil
+    )
+    let later = AgentChatEventEnvelope(
+      sessionId: "session-1",
+      timestamp: "2026-03-17T00:00:02.000Z",
+      event: .text(text: "second", messageId: "msg-1", turnId: "turn-1", itemId: "item-1"),
+      sequence: 2,
+      provenance: nil
+    )
+
+    service.mergeChatEventHistory(sessionId: "session-1", events: [earlier, later])
+    // Live envelope arrives out of order (delayed tool_result that predates the
+    // already-merged later envelope). Must be inserted in chronological order
+    // rather than appended to the end.
+    let delayedInsert = AgentChatEventEnvelope(
+      sessionId: "session-1",
+      timestamp: "2026-03-17T00:00:01.500Z",
+      event: .toolResult(tool: "fs_read", result: .string("ok"), itemId: "tool-1", logicalItemId: "tool-1", parentItemId: nil, turnId: "turn-1", status: "completed"),
+      sequence: 3,
+      provenance: nil
+    )
+    service.recordChatEventEnvelope(delayedInsert)
+
+    let history = service.chatEventHistory(sessionId: "session-1")
+    XCTAssertEqual(history.map(\.id), [earlier.id, delayedInsert.id, later.id])
+  }
+
   func testChatCommandRequestPayloadsEncodeExpectedShapes() throws {
     let subscribe = try jsonDictionary(from: AgentChatSubscriptionRequest(sessionId: "session-1"))
     XCTAssertEqual(subscribe["sessionId"] as? String, "session-1")

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -324,6 +324,7 @@ final class ADETests: XCTestCase {
 
     XCTAssertEqual(service.subscribedChatSessionIds, Set(["session-1", "session-2"]))
     XCTAssertEqual(service.chatSubscriptionPayloads().compactMap { $0["sessionId"] as? String }.sorted(), ["session-1", "session-2"])
+    XCTAssertEqual(service.chatSubscriptionPayloads().compactMap { $0["maxBytes"] as? Int }, [2_000_000, 2_000_000])
 
     service.disconnect(clearCredentials: false)
 
@@ -365,6 +366,54 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(service.chatEventHistory(sessionId: "session-1"), [envelope])
     XCTAssertEqual(service.localStateRevision, globalRevision)
     XCTAssertEqual(service.chatEventRevision(for: "session-1"), 1)
+  }
+
+  @MainActor
+  func testTruncatedChatSubscribeSnapshotMergesWithExistingHistory() async throws {
+    let service = SyncService(database: makeDatabase(baseURL: makeTemporaryDirectory()))
+    let original = AgentChatEventEnvelope(
+      sessionId: "session-1",
+      timestamp: "2026-03-17T00:00:00.000Z",
+      event: .userMessage(text: "Start here", attachments: [], turnId: "turn-1", steerId: nil, deliveryState: nil, processed: nil),
+      sequence: 1,
+      provenance: nil
+    )
+    let tail = AgentChatEventEnvelope(
+      sessionId: "session-1",
+      timestamp: "2026-03-17T00:00:01.000Z",
+      event: .text(text: "Still working", messageId: "msg-1", turnId: "turn-1", itemId: "item-1"),
+      sequence: 2,
+      provenance: nil
+    )
+
+    service.recordChatEventEnvelope(original)
+    service.mergeChatEventHistory(sessionId: "session-1", events: [original, tail])
+
+    XCTAssertEqual(service.chatEventHistory(sessionId: "session-1"), [original, tail])
+  }
+
+  @MainActor
+  func testCompleteChatSubscribeSnapshotReplacesExistingHistory() async throws {
+    let service = SyncService(database: makeDatabase(baseURL: makeTemporaryDirectory()))
+    let old = AgentChatEventEnvelope(
+      sessionId: "session-1",
+      timestamp: "2026-03-17T00:00:00.000Z",
+      event: .userMessage(text: "Old event", attachments: [], turnId: "turn-1", steerId: nil, deliveryState: nil, processed: nil),
+      sequence: 1,
+      provenance: nil
+    )
+    let fresh = AgentChatEventEnvelope(
+      sessionId: "session-1",
+      timestamp: "2026-03-17T00:00:01.000Z",
+      event: .text(text: "Fresh snapshot", messageId: "msg-1", turnId: "turn-1", itemId: "item-1"),
+      sequence: 2,
+      provenance: nil
+    )
+
+    service.recordChatEventEnvelope(old)
+    service.replaceChatEventHistory(sessionId: "session-1", events: [fresh])
+
+    XCTAssertEqual(service.chatEventHistory(sessionId: "session-1"), [fresh])
   }
 
   func testChatCommandRequestPayloadsEncodeExpectedShapes() throws {
@@ -3178,6 +3227,145 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(activeAgents.count, 1)
     XCTAssertEqual(activeAgents.first?.agentName, "Docs helper")
     XCTAssertEqual(activeAgents.first?.toolName, "functions.Read")
+  }
+
+  func testWorkChatTranscriptUsesMessageIdToSplitAssistantMessages() {
+    let raw = """
+    {"sessionId":"chat-1","timestamp":"2026-04-22T22:10:00.000Z","sequence":1,"event":{"type":"user_message","text":"Rebase Windows Port","turnId":"turn-1"}}
+    {"sessionId":"chat-1","timestamp":"2026-04-22T22:10:01.000Z","sequence":2,"event":{"type":"text","text":"I will check the branch.","messageId":"msg-progress","turnId":"turn-1"}}
+    {"sessionId":"chat-1","timestamp":"2026-04-22T22:10:02.000Z","sequence":3,"event":{"type":"tool_call","tool":"Bash","args":{"command":"git status"},"itemId":"tool-1","turnId":"turn-1"}}
+    {"sessionId":"chat-1","timestamp":"2026-04-22T22:10:03.000Z","sequence":4,"event":{"type":"text","text":"Merge complete.","messageId":"msg-final","turnId":"turn-1"}}
+    {"sessionId":"chat-1","timestamp":"2026-04-22T22:10:03.500Z","sequence":5,"event":{"type":"text","text":" I did not push.","messageId":"msg-final","turnId":"turn-1"}}
+    {"sessionId":"chat-1","timestamp":"2026-04-22T22:10:03.500Z","sequence":6,"event":{"type":"tool_result","tool":"Bash","result":{"synthetic":true,"source":"claude_turn_finalization"},"itemId":"tool-1","turnId":"turn-1","status":"completed"}}
+    """
+
+    let transcript = parseWorkChatTranscript(raw)
+    let messages = buildWorkChatMessages(from: transcript)
+    let assistantMessages = messages.filter { $0.role == "assistant" }
+
+    XCTAssertEqual(assistantMessages.count, 2)
+    XCTAssertEqual(assistantMessages.map(\.itemId), ["msg-progress", "msg-final"])
+    XCTAssertEqual(assistantMessages.map(\.markdown), [
+      "I will check the branch.",
+      "Merge complete. I did not push.",
+    ])
+
+    let snapshot = buildWorkChatTimelineSnapshot(
+      transcript: transcript,
+      fallbackEntries: [],
+      artifacts: [],
+      localEchoMessages: []
+    )
+    let visibleKinds = snapshot.timeline.compactMap { entry -> String? in
+      switch entry.payload {
+      case .message(let message) where message.role == "user":
+        return "user"
+      case .message(let message) where message.role == "assistant":
+        return "assistant:\(message.itemId ?? "")"
+      case .toolCard(let card):
+        return "tool:\(card.id)"
+      default:
+        return nil
+      }
+    }
+
+    XCTAssertEqual(visibleKinds, [
+      "user",
+      "assistant:msg-progress",
+      "tool:tool-1",
+      "assistant:msg-final",
+    ])
+  }
+
+  func testWorkChatMessagesDoNotMergeUnidentifiedAssistantTextAcrossTools() {
+    let transcript: [WorkChatEnvelope] = [
+      WorkChatEnvelope(
+        sessionId: "chat-1",
+        timestamp: "2026-04-22T22:10:01.000Z",
+        sequence: 1,
+        event: .assistantText(text: "Before tools.", turnId: "turn-1", itemId: nil)
+      ),
+      WorkChatEnvelope(
+        sessionId: "chat-1",
+        timestamp: "2026-04-22T22:10:02.000Z",
+        sequence: 2,
+        event: .toolCall(tool: "Bash", argsText: "{}", itemId: "tool-1", parentItemId: nil, turnId: "turn-1")
+      ),
+      WorkChatEnvelope(
+        sessionId: "chat-1",
+        timestamp: "2026-04-22T22:10:03.000Z",
+        sequence: 3,
+        event: .assistantText(text: "After tools.", turnId: "turn-1", itemId: nil)
+      ),
+    ]
+
+    let assistantMessages = buildWorkChatMessages(from: transcript)
+      .filter { $0.role == "assistant" }
+
+    XCTAssertEqual(assistantMessages.map(\.markdown), [
+      "Before tools.",
+      "After tools.",
+    ])
+  }
+
+  func testWorkSessionGroupsByLaneSurfacesOrphanLanesPerLaneId() {
+    let knownLane = LaneSummary(
+      id: "lane-primary",
+      name: "Primary",
+      description: nil,
+      laneType: "primary",
+      baseRef: "main",
+      branchRef: "main",
+      worktreePath: "/tmp/project",
+      attachedRootPath: nil,
+      parentLaneId: nil,
+      childCount: 0,
+      stackDepth: 0,
+      parentStatus: nil,
+      isEditProtected: true,
+      status: LaneStatus(dirty: false, ahead: 0, behind: 0, remoteBehind: 0, rebaseInProgress: false),
+      color: nil,
+      icon: nil,
+      tags: [],
+      folder: nil,
+      createdAt: "2026-03-17T00:00:00.000Z",
+      archivedAt: nil
+    )
+    let primarySession = makeTerminalSessionSummary(
+      id: "session-primary",
+      laneId: "lane-primary",
+      laneName: "Primary",
+      toolType: "codex-chat"
+    )
+    // Two distinct soft-deleted lanes — each should render as its own group.
+    let orphanOldSession = makeTerminalSessionSummary(
+      id: "session-orphan-old",
+      laneId: "lane-deleted-a",
+      laneName: "feature/cleanup",
+      toolType: "codex-chat"
+    )
+    let orphanNewSession = makeTerminalSessionSummary(
+      id: "session-orphan-new",
+      laneId: "lane-deleted-b",
+      laneName: "feature/recent",
+      toolType: "codex-chat"
+    )
+    // Same orphan lane appearing twice — must merge into the same group.
+    let orphanNewSessionSibling = makeTerminalSessionSummary(
+      id: "session-orphan-new-sibling",
+      laneId: "lane-deleted-b",
+      laneName: "feature/recent",
+      toolType: "codex-chat"
+    )
+
+    let groups = workSessionGroupsByLane(
+      sessions: [primarySession, orphanOldSession, orphanNewSession, orphanNewSessionSibling],
+      orderedLanes: [knownLane]
+    )
+
+    XCTAssertEqual(groups.map(\.id), ["lane:lane-primary", "lane:lane-deleted-a", "lane:lane-deleted-b"])
+    XCTAssertEqual(groups.map(\.label), ["Primary", "feature/cleanup", "feature/recent"])
+    XCTAssertEqual(groups.last?.sessions.count, 2)
   }
 
   func testWorkChatTranscriptPreservesReasoningIdentity() {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -3408,27 +3408,35 @@ final class ADETests: XCTestCase {
       id: "session-primary",
       laneId: "lane-primary",
       laneName: "Primary",
-      toolType: "codex-chat"
+      toolType: "codex-chat",
+      startedAt: "2026-03-25T12:00:00.000Z"
     )
     // Two distinct soft-deleted lanes — each should render as its own group.
+    // `lane-deleted-a` wins the orphan sort because its latest session started
+    // more recently than the latest on `lane-deleted-b`.
     let orphanOldSession = makeTerminalSessionSummary(
       id: "session-orphan-old",
       laneId: "lane-deleted-a",
       laneName: "feature/cleanup",
-      toolType: "codex-chat"
+      toolType: "codex-chat",
+      startedAt: "2026-03-25T11:30:00.000Z"
     )
     let orphanNewSession = makeTerminalSessionSummary(
       id: "session-orphan-new",
       laneId: "lane-deleted-b",
       laneName: "feature/recent",
-      toolType: "codex-chat"
+      toolType: "codex-chat",
+      startedAt: "2026-03-25T10:45:00.000Z"
     )
     // Same orphan lane appearing twice — must merge into the same group.
+    // This sibling is older than `orphanOldSession` so the ordering assertion
+    // below exercises the latest-startedAt-per-lane comparison.
     let orphanNewSessionSibling = makeTerminalSessionSummary(
       id: "session-orphan-new-sibling",
       laneId: "lane-deleted-b",
       laneName: "feature/recent",
-      toolType: "codex-chat"
+      toolType: "codex-chat",
+      startedAt: "2026-03-25T10:30:00.000Z"
     )
 
     let groups = workSessionGroupsByLane(
@@ -5797,7 +5805,8 @@ final class ADETests: XCTestCase {
     runtimeState: String = "running",
     status: String = "running",
     title: String = "Codex chat",
-    lastOutputPreview: String? = nil
+    lastOutputPreview: String? = nil,
+    startedAt: String = "2026-03-25T00:00:00.000Z"
   ) -> TerminalSessionSummary {
     TerminalSessionSummary(
       id: id,
@@ -5811,7 +5820,7 @@ final class ADETests: XCTestCase {
       toolType: toolType,
       title: title,
       status: status,
-      startedAt: "2026-03-25T00:00:00.000Z",
+      startedAt: startedAt,
       endedAt: nil,
       exitCode: nil,
       transcriptPath: "",

--- a/docs/features/chat/README.md
+++ b/docs/features/chat/README.md
@@ -89,6 +89,20 @@ input, and has exceeded its provider-specific inactivity window:
 free the underlying server sooner). Teardown routes through
 `teardownRuntime(managed, "idle_ttl")`.
 
+`teardownRuntime` distinguishes **terminal** close reasons
+(`handle_close`, `ended_session`, `model_switch`) from **non-terminal**
+ones (`idle_ttl`, `budget_eviction`, `pool_compaction`, `paused_run`,
+`project_close`, `shutdown`). For Claude runtimes only, a non-terminal
+teardown preserves resume state: the service pins
+`runtime.sdkSessionId` to the last known V2 session id before releasing
+the session, persists chat state immediately, and skips the usual
+`runtimeInvalidated = true` + `clearLaneDirectiveKey` cleanup. The next
+turn on that chat can therefore rehydrate the same Claude V2 session
+instead of creating a fresh one, even though the SDK process was
+released to reclaim budget or compact the pool. Terminal closes still
+run the full invalidation path so "End chat" and explicit model
+switches don't leave stale resume pointers behind.
+
 On app shutdown the service exposes `forceDisposeAll()` — called from
 `runImmediateProcessCleanup()` in `main.ts`. It stops the cleanup timer,
 rejects every outstanding `sessionTurnCollector` with a "closed during

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -603,6 +603,31 @@ reflected in the phone's UI on the next descriptor read.
   runs its polling path on reconnect / catchup to fill any gap; the
   phone de-duplicates per-event keys so a push and a catchup poll
   covering the same event produce one rendered message.
+- **Chat subscribe requests a 2 MB snapshot window.** The phone sends
+  `chat_subscribe` with `maxBytes: 2_000_000`
+  (`syncChatSubscriptionMaxBytes`) so the initial snapshot can carry
+  long transcripts without the host truncating prematurely. When the
+  host still responds with `truncated: true`, the phone calls
+  `mergeChatEventHistory` instead of `replaceChatEventHistory`: the
+  existing cached events are unioned with the truncated snapshot,
+  deduplicated by `id`, and re-sorted by `(timestamp, sequence)`.
+  Non-truncated snapshots take the replace path. Both paths run through
+  `deduplicatedChatEventHistory` and then through `trimChatEventHistory`,
+  which caps retained events at `chatEventHistoryMaxEvents = 1_000`
+  (up from the previous 500-event cap) so very long chats don't evict
+  their own recent turns on reconnect.
+- **Work transcript parser uses `messageId` as a fallback item id.**
+  `makeWorkChatEvent` (`WorkEventMapping.swift`) and
+  `parseWorkChatTranscript` (`WorkTranscriptParser.swift`) now fall back
+  to the `messageId` from `chat_event` when no `itemId` is present, so
+  streaming assistant-text fragments merge into the same transcript row
+  even when the host only surfaces a `messageId`. `buildWorkChatMessages`
+  (`WorkErrorAndMessageHelpers.swift`) tracks a
+  `previousEnvelopeWasAssistantText` flag and allows merging into the
+  previous assistant bubble when either (a) the text event has an
+  `itemId` or (b) the immediately preceding envelope was also assistant
+  text. This keeps the iOS Work chat from fanning a single assistant
+  turn into many tiny rows.
 - **Lane presence is best-effort with a TTL.** The phone
   re-announces on a 30 s cadence; the host prunes stale entries at
   60 s. A phone that crashes without sending `lanes.presence.release`

--- a/docs/features/terminals-and-sessions/ui-surfaces.md
+++ b/docs/features/terminals-and-sessions/ui-surfaces.md
@@ -34,6 +34,18 @@ Lists sessions grouped by one of three modes (controlled by
 Each group uses a `StickyGroupHeader` with collapsed-state persistence
 via `workCollapsedLaneIds` / `workCollapsedSectionIds`.
 
+In `by-lane` mode, any session whose `laneId` is not in the current
+lanes list is still rendered under its own sticky "orphan lane" group
+below the active lane groups. The list is built from
+`missingLaneSessionGroups`: every `laneId` from `sessionsGroupedByLane`
+that's absent from the `lanes` set becomes a group, labelled with the
+session's `laneName` (falling back to the raw `laneId`) and sorted by
+most-recent `startedAt`, with ties broken alphabetically. These groups
+reuse the same `workCollapsedLaneIds` persistence, so a user who
+collapses an orphan group sees it stay collapsed on reload. This keeps
+sessions reachable when their lane has been archived, deleted, or not
+yet loaded, instead of quietly dropping them from the sidebar.
+
 Also renders:
 
 - draft-kind switcher (chat vs terminal) at the top


### PR DESCRIPTION
## Summary
- Preserve Claude runtime resume metadata (`sdkSessionId`, lane directive, `runtimeInvalidated`) on non-terminal chat teardowns (`idle_ttl`, `budget_eviction`, `pool_compaction`, `paused_run`, `project_close`, `shutdown`) so the next turn re-attaches to the same V2 session instead of cold-starting.
- Render orphan-lane sessions (laneId missing from current lanes list) as their own collapsible sticky groups in both desktop `SessionListPane` and iOS `workSessionGroupsByLane`, sorted by latest `startedAt` with name tiebreak and labeled with the session's preserved `laneName`.
- Grow the iOS chat history window: request a 2 MB snapshot on `chat_subscribe`, merge truncated snapshots with existing events instead of replacing, retain up to 1,000 events per session, and fall back to `messageId` when assistant text is missing `itemId` so Claude- and Codex-produced turns stay aligned.
- Update internal docs (chat lifecycle, terminals UI surfaces, iOS companion sync) to describe the new behavior.

## Test plan
- [x] Desktop typecheck
- [x] ade-cli typecheck
- [x] web typecheck
- [x] Desktop lint
- [x] Desktop vitest (8 shards, 3,801 passed / 11 skipped)
- [x] ade-cli tests
- [x] Desktop, ade-cli, and web builds
- [x] `node scripts/validate-docs.mjs`
- [x] iOS `xcodebuild build-for-testing` on iPhone 17 Pro simulator; targeted tests green (orphan-lane grouping, chat merge, messageId fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat event history retrieval for agent sessions with optional pagination.
  * Runtime-per-project control to enable/disable host discovery.

* **Improvements**
  * Migration to a shared device identity file for consistent device IDs across projects.
  * More accurate Tailscale route detection and connectivity behavior.
  * Improved assistant message merging and chat event ordering.
  * Orphan/removed-lane sessions shown as individual groups.
  * iOS transport security updates for additional domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves Claude V2 session resume metadata across non-terminal teardowns, surfaces orphaned-lane sessions as individual collapsible groups (desktop + iOS), grows the iOS chat history window to 2 MB with merge-on-truncation semantics, and centralizes device identity to a shared `userData` file. The implementation is well-tested with targeted vitest and XCTest coverage across all new code paths.

- **P1 – silent event loss in `mergeEnvelopeStreams`**: the dedup key `${timestamp}#${event.type}` is too coarse. Rapid streaming text events within the same millisecond are treated as duplicates and the later fragments are silently dropped, which would manifest as truncated assistant replies after a project switch triggers a disk/memory merge.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the mergeEnvelopeStreams dedup key, which can silently drop streaming text fragments during post-project-switch history hydration.

All other changes are well-structured and well-tested. The single P1 finding (timestamp+type dedup collision) is a correctness issue on a new code path — it does not break existing behaviour but can silently truncate chat history after an idle_ttl teardown and project switch, which is exactly the scenario this PR is meant to fix.

apps/desktop/src/main/services/chat/agentChatService.ts — specifically the mergeEnvelopeStreams dedup key around line 397

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/chat/agentChatService.ts | Adds in-memory ring buffer, getChatEventHistory, and teardownRuntime resume-state preservation; dedup key in mergeEnvelopeStreams is too coarse for rapid streaming events |
| apps/desktop/src/main/services/chat/agentChatService.test.ts | Comprehensive new tests for getChatEventHistory hydration, cleanup on delete, idle_ttl resume preservation, and terminal teardown clearing |
| apps/ios/ADE/Services/SyncService.swift | Adds syncNormalizedRouteHost/syncIsTailscaleRoute helpers replacing inline IPv4-only detection, grows chat subscription to 2 MB, merge-vs-replace on truncated snapshots, and improved timestamp ordering |
| apps/desktop/src/main/services/sync/deviceRegistryService.ts | Adds optional shared device-identity file path with safe legacy-to-global migration; existing iOS pairings preserved when shared file disagrees |
| apps/desktop/src/main/services/sync/syncHostService.ts | Adds setDiscoveryEnabled / unpublishLanDiscovery and gates Tailnet/LAN discovery on per-project active state; cleanup on dispose is correct |
| apps/desktop/src/renderer/components/terminals/SessionListPane.tsx | Adds missingLaneSessionGroups inside byLaneList block; NaN-safe latestStartedAt uses Number.isFinite filter; orphan groups correctly scoped to by-lane view |
| apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift | Adds previousEnvelopeWasAssistantText flag to prevent nil-itemId text fragments from merging across intervening tool calls; flag reset on every non-assistantText branch |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Switches history loading to prefer getEventHistory IPC with graceful fallback to transcript tail; clears loadedHistoryRef on failure to allow retry on remount |
| apps/desktop/src/main/main.ts | setActiveProject now gates per-project host discovery; localDeviceIdPath pointed to shared userData location |
| apps/ios/ADE/Info.plist | Adds NSExceptionDomains for ade-sync and *.ts.net to allow plaintext WebSocket connections to Tailscale hosts; intentional for sync use case |
| apps/ios/ADE/Views/Work/WorkSessionGrouping.swift | Replaces single Other orphan bucket with per-lane groups, sorted by latest startedAt then name; correctly uses two ISO8601DateFormatter instances for fractional-second variants |
| apps/ios/ADE/Views/Work/WorkEventMapping.swift | Falls back from itemId to messageId to produce a stableItemId for text events; priority matches WorkTranscriptParser after previously-noted thread fix |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer
    participant IPC
    participant ACS as AgentChatService
    participant FS as Filesystem

    Note over ACS: idle_ttl fires
    ACS->>ACS: teardownRuntime(idle_ttl)
    ACS->>ACS: preserveClaudeResumeState = true
    ACS->>FS: persistChatState(sdkSessionId, laneDirectiveKey)
    ACS->>ACS: runtimeInvalidated = false

    Note over R: User switches back to project/tab
    R->>IPC: agentChat.getEventHistory(sessionId, maxEvents)
    IPC->>ACS: getChatEventHistory(sessionId)
    ACS->>ACS: Validate sessionId via sessionService
    alt Not yet hydrated
        ACS->>FS: readTranscriptEnvelopesForSessionId
        ACS->>ACS: mergeEnvelopeStreams(disk, memory buffer)
        ACS->>ACS: Mark hydrated
    end
    ACS-->>IPC: events + truncated flag
    IPC-->>R: Render full history

    Note over R: User sends next message
    R->>IPC: agentChat.runSessionTurn
    IPC->>ACS: runSessionTurn
    ACS->>ACS: Read persisted sdkSessionId
    ACS->>ACS: unstable_v2_resumeSession(sdkSessionId)
    Note over ACS: Session re-attaches to same V2 context
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `apps/desktop/src/renderer/components/terminals/SessionListPane.tsx`, line 210-211 ([link](https://github.com/arul28/ade/blob/5e97f09c02311bc891eb68ce24fb0f236feae119/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx#L210-L211)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`Math.max(...sessions.map(...))` with invalid dates produces `NaN`**

   `latestStartedAt` spreads the mapped timestamps into `Math.max`. If any `session.startedAt` is malformed (e.g., `""`), `new Date(...).getTime()` returns `NaN`, and `Math.max` propagates `NaN` to the comparator. The sort callback then receives `NaN - NaN = NaN`, which causes unpredictable ordering in V8's `Array.sort`. The `sessions.length > 0` guard prevents the zero-element case (`-Infinity`), but not the bad-date case. A small defensive fix:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
   Line: 210-211

   Comment:
   **`Math.max(...sessions.map(...))` with invalid dates produces `NaN`**

   `latestStartedAt` spreads the mapped timestamps into `Math.max`. If any `session.startedAt` is malformed (e.g., `""`), `new Date(...).getTime()` returns `NaN`, and `Math.max` propagates `NaN` to the comparator. The sort callback then receives `NaN - NaN = NaN`, which causes unpredictable ordering in V8's `Array.sort`. The `sessions.length > 0` guard prevents the zero-element case (`-Infinity`), but not the bad-date case. A small defensive fix:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fterminals%2FSessionListPane.tsx%0ALine%3A%20210-211%0A%0AComment%3A%0A**%60Math.max%28...sessions.map%28...%29%29%60%20with%20invalid%20dates%20produces%20%60NaN%60**%0A%0A%60latestStartedAt%60%20spreads%20the%20mapped%20timestamps%20into%20%60Math.max%60.%20If%20any%20%60session.startedAt%60%20is%20malformed%20%28e.g.%2C%20%60%22%22%60%29%2C%20%60new%20Date%28...%29.getTime%28%29%60%20returns%20%60NaN%60%2C%20and%20%60Math.max%60%20propagates%20%60NaN%60%20to%20the%20comparator.%20The%20sort%20callback%20then%20receives%20%60NaN%20-%20NaN%20%3D%20NaN%60%2C%20which%20causes%20unpredictable%20ordering%20in%20V8's%20%60Array.sort%60.%20The%20%60sessions.length%20%3E%200%60%20guard%20prevents%20the%20zero-element%20case%20%28%60-Infinity%60%29%2C%20but%20not%20the%20bad-date%20case.%20A%20small%20defensive%20fix%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20latestStartedAt%20%3D%20%28sessions%3A%20TerminalSessionSummary%5B%5D%29%3A%20number%20%3D%3E%20%7B%0A%20%20%20%20%20%20const%20times%20%3D%20sessions.map%28%28s%29%20%3D%3E%20new%20Date%28s.startedAt%29.getTime%28%29%29.filter%28Number.isFinite%29%3B%0A%20%20%20%20%20%20return%20times.length%20%3E%200%20%3F%20Math.max%28...times%29%20%3A%20-Infinity%3B%0A%20%20%20%20%7D%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=175&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>

2. `apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift`, line 352-357 ([link](https://github.com/arul28/ade/blob/5e97f09c02311bc891eb68ce24fb0f236feae119/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift#L352-L357)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`previousEnvelopeWasAssistantText` flag invariant is implicit**

   The logic is correct for current variants, but if a new `WorkChatEvent` case is added without resetting the flag, the merge guard could fire incorrectly. Consider adding a comment at the reset sites to make the invariant explicit for future contributors.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
   Line: 352-357

   Comment:
   **`previousEnvelopeWasAssistantText` flag invariant is implicit**

   The logic is correct for current variants, but if a new `WorkChatEvent` case is added without resetting the flag, the merge guard could fire incorrectly. Consider adding a comment at the reset sites to make the invariant explicit for future contributors.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fios%2FADE%2FViews%2FWork%2FWorkErrorAndMessageHelpers.swift%0ALine%3A%20352-357%0A%0AComment%3A%0A**%60previousEnvelopeWasAssistantText%60%20flag%20invariant%20is%20implicit**%0A%0AThe%20logic%20is%20correct%20for%20current%20variants%2C%20but%20if%20a%20new%20%60WorkChatEvent%60%20case%20is%20added%20without%20resetting%20the%20flag%2C%20the%20merge%20guard%20could%20fire%20incorrectly.%20Consider%20adding%20a%20comment%20at%20the%20reset%20sites%20to%20make%20the%20invariant%20explicit%20for%20future%20contributors.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=175&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>

3. `apps/desktop/src/main/services/chat/agentChatService.ts`, line 397-400 ([link](https://github.com/arul28/ade/blob/d0e23501993117986d8dc52331369891fd88999c/apps/desktop/src/main/services/chat/agentChatService.ts#L397-L400)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`timestamp#type` dedup key can silently drop streaming text fragments**

   `mergeEnvelopeStreams` keys each envelope as `${entry.timestamp}#${entry.event.type}`. Claude streaming turns routinely emit many `text` events in quick succession; if two fragments are timestamped within the same millisecond the second is permanently dropped from the merged history. This would silently produce a truncated assistant reply every time a user returns to a project after an `idle_ttl` teardown.

   A more collision-resistant key that stays cross-run stable would incorporate `sequence` as a secondary discriminator (sequence restarts per-run, but within a single run every event that lands in the in-memory buffer has a unique sequence; for the disk-only path, sequence is also monotone). Alternatively, keying on the first ~64 bytes of text content for `text` events would be sufficient to distinguish adjacent fragments.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/chat/agentChatService.ts
   Line: 397-400

   Comment:
   **`timestamp#type` dedup key can silently drop streaming text fragments**

   `mergeEnvelopeStreams` keys each envelope as `${entry.timestamp}#${entry.event.type}`. Claude streaming turns routinely emit many `text` events in quick succession; if two fragments are timestamped within the same millisecond the second is permanently dropped from the merged history. This would silently produce a truncated assistant reply every time a user returns to a project after an `idle_ttl` teardown.

   A more collision-resistant key that stays cross-run stable would incorporate `sequence` as a secondary discriminator (sequence restarts per-run, but within a single run every event that lands in the in-memory buffer has a unique sequence; for the disk-only path, sequence is also monotone). Alternatively, keying on the first ~64 bytes of text content for `text` events would be sufficient to distinguish adjacent fragments.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fchat%2FagentChatService.ts%0ALine%3A%20397-400%0A%0AComment%3A%0A**%60timestamp%23type%60%20dedup%20key%20can%20silently%20drop%20streaming%20text%20fragments**%0A%0A%60mergeEnvelopeStreams%60%20keys%20each%20envelope%20as%20%60%24%7Bentry.timestamp%7D%23%24%7Bentry.event.type%7D%60.%20Claude%20streaming%20turns%20routinely%20emit%20many%20%60text%60%20events%20in%20quick%20succession%3B%20if%20two%20fragments%20are%20timestamped%20within%20the%20same%20millisecond%20the%20second%20is%20permanently%20dropped%20from%20the%20merged%20history.%20This%20would%20silently%20produce%20a%20truncated%20assistant%20reply%20every%20time%20a%20user%20returns%20to%20a%20project%20after%20an%20%60idle_ttl%60%20teardown.%0A%0AA%20more%20collision-resistant%20key%20that%20stays%20cross-run%20stable%20would%20incorporate%20%60sequence%60%20as%20a%20secondary%20discriminator%20%28sequence%20restarts%20per-run%2C%20but%20within%20a%20single%20run%20every%20event%20that%20lands%20in%20the%20in-memory%20buffer%20has%20a%20unique%20sequence%3B%20for%20the%20disk-only%20path%2C%20sequence%20is%20also%20monotone%29.%20Alternatively%2C%20keying%20on%20the%20first%20~64%20bytes%20of%20text%20content%20for%20%60text%60%20events%20would%20be%20sufficient%20to%20distinguish%20adjacent%20fragments.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=175&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fchat%2FagentChatService.ts%3A397-400%0A**%60timestamp%23type%60%20dedup%20key%20can%20silently%20drop%20streaming%20text%20fragments**%0A%0A%60mergeEnvelopeStreams%60%20keys%20each%20envelope%20as%20%60%24%7Bentry.timestamp%7D%23%24%7Bentry.event.type%7D%60.%20Claude%20streaming%20turns%20routinely%20emit%20many%20%60text%60%20events%20in%20quick%20succession%3B%20if%20two%20fragments%20are%20timestamped%20within%20the%20same%20millisecond%20the%20second%20is%20permanently%20dropped%20from%20the%20merged%20history.%20This%20would%20silently%20produce%20a%20truncated%20assistant%20reply%20every%20time%20a%20user%20returns%20to%20a%20project%20after%20an%20%60idle_ttl%60%20teardown.%0A%0AA%20more%20collision-resistant%20key%20that%20stays%20cross-run%20stable%20would%20incorporate%20%60sequence%60%20as%20a%20secondary%20discriminator%20%28sequence%20restarts%20per-run%2C%20but%20within%20a%20single%20run%20every%20event%20that%20lands%20in%20the%20in-memory%20buffer%20has%20a%20unique%20sequence%3B%20for%20the%20disk-only%20path%2C%20sequence%20is%20also%20monotone%29.%20Alternatively%2C%20keying%20on%20the%20first%20~64%20bytes%20of%20text%20content%20for%20%60text%60%20events%20would%20be%20sufficient%20to%20distinguish%20adjacent%20fragments.%0A%0A&repo=arul28%2Fade&pr=175&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/main/services/chat/agentChatService.ts
Line: 397-400

Comment:
**`timestamp#type` dedup key can silently drop streaming text fragments**

`mergeEnvelopeStreams` keys each envelope as `${entry.timestamp}#${entry.event.type}`. Claude streaming turns routinely emit many `text` events in quick succession; if two fragments are timestamped within the same millisecond the second is permanently dropped from the merged history. This would silently produce a truncated assistant reply every time a user returns to a project after an `idle_ttl` teardown.

A more collision-resistant key that stays cross-run stable would incorporate `sequence` as a secondary discriminator (sequence restarts per-run, but within a single run every event that lands in the in-memory buffer has a unique sequence; for the disk-only path, sequence is also monotone). Alternatively, keying on the first ~64 bytes of text content for `text` events would be sufficient to distinguish adjacent fragments.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["Address second round of review feedback"](https://github.com/arul28/ade/commit/d0e23501993117986d8dc52331369891fd88999c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29352478)</sub>

<!-- /greptile_comment -->