### PR TITLE
Pin CTO and worker identity sessions to the primary lane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ xcuserdata/
 apps/ios/.dry-run-derived-data/
 apps/ios/build/
 ios-signing/
-.asc/artifacts/
+/.asc/artifacts/
 
 # Tool configs (personal)
 .codex/

--- a/apps/desktop/src/main/services/ai/tools/ctoOperatorTools.ts
+++ b/apps/desktop/src/main/services/ai/tools/ctoOperatorTools.ts
@@ -773,7 +773,7 @@ export function createCtoOperatorTools(deps: CtoOperatorToolDeps): Record<string
       "This creates a full ADE chat with UI, streaming, tool approval, and service integration. " +
       "Use this when the user asks for 'a chat' or 'an agent'. If they explicitly want a terminal or CLI tool, use createTerminal instead.",
     inputSchema: z.object({
-      laneId: z.string().optional().describe("Lane to run in. Defaults to CTO's lane. A new lane is auto-created if needed."),
+      laneId: z.string().optional().describe("Lane to run in. Defaults to the primary lane. A new lane is auto-created if needed."),
       modelId: z.string().optional().describe("Full model ID (e.g. 'anthropic/claude-sonnet-4-6'). MUST be set when user specifies a model."),
       reasoningEffort: z.string().nullable().optional().describe("Reasoning effort: 'low', 'medium', 'high', 'max' (opus), 'xhigh' (openai)."),
       title: z.string().optional().describe("Display title for the chat session."),

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -1950,7 +1950,7 @@ describe("createAgentChatService", () => {
       });
 
       expect(session.laneId).toBe("lane-1");
-      expect(session.permissionMode).toBe("plan");
+      expect(session.permissionMode).toBe("full-auto");
     });
 
     it("does not reuse a foreign-lane identity session or auto-close it during migration", async () => {
@@ -1982,7 +1982,7 @@ describe("createAgentChatService", () => {
       expect(reused.laneId).toBe("lane-1");
     });
 
-    it("records headShaStart for the selected execution lane instead of the canonical host lane", async () => {
+    it("pins CTO execution state to the primary lane even when a foreign lane is requested", async () => {
       vi.mocked(runGit).mockImplementation(async (_args, opts) => ({
         stdout: String(opts?.cwd ?? "").includes(path.join(tmpRoot, "lane-2")) ? "lane-2-sha\n" : "lane-1-sha\n",
         stderr: "",
@@ -1995,7 +1995,25 @@ describe("createAgentChatService", () => {
         laneId: "lane-2",
       });
 
-      expect(sessionService.setHeadShaStart).toHaveBeenLastCalledWith(session.id, "lane-2-sha");
+      expect(sessionService.setHeadShaStart).toHaveBeenLastCalledWith(session.id, "lane-1-sha");
+    });
+
+    it("pins worker identity execution state to the primary lane", async () => {
+      vi.mocked(runGit).mockImplementation(async (_args, opts) => ({
+        stdout: String(opts?.cwd ?? "").includes(path.join(tmpRoot, "lane-2")) ? "lane-2-sha\n" : "lane-1-sha\n",
+        stderr: "",
+        exitCode: 0,
+      }));
+
+      const { service, sessionService } = createService();
+      const session = await service.ensureIdentitySession({
+        identityKey: "agent:worker-1",
+        laneId: "lane-2",
+      });
+
+      expect(session.laneId).toBe("lane-1");
+      expect(session.permissionMode).toBe("full-auto");
+      expect(sessionService.setHeadShaStart).toHaveBeenLastCalledWith(session.id, "lane-1-sha");
     });
   });
 

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -2015,6 +2015,88 @@ describe("createAgentChatService", () => {
       expect(session.permissionMode).toBe("full-auto");
       expect(sessionService.setHeadShaStart).toHaveBeenLastCalledWith(session.id, "lane-1-sha");
     });
+
+    it("ignores native provider permission overrides for pinned identities on create", async () => {
+      const { service } = createService();
+      // Callers over IPC could previously pass through `claudePermissionMode:
+      // "plan"` to keep a CTO session from ever running automatically — the
+      // identity pin must strip these so full-auto still wins.
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "claude",
+        model: "claude-sonnet-4-7",
+        modelId: "claude-sonnet-4-7",
+        identityKey: "cto",
+        claudePermissionMode: "plan",
+        interactionMode: "plan",
+      });
+
+      // `plan` must never be persisted on the claude native fields for a
+      // pinned identity — otherwise the runtime will ignore full-auto at turn
+      // start. We do not assert on the synthesized permissionMode here because
+      // the top-level mock for mapPermissionToClaude collapses to "plan" in
+      // this test file; the native fields are the real source of truth the
+      // runtime consults.
+      expect(session.claudePermissionMode).not.toBe("plan");
+      expect(session.interactionMode).not.toBe("plan");
+    });
+
+    it("ignores native codex permission overrides for worker identities on create", async () => {
+      // Locally map modes so full-auto => danger-full-access / never and the
+      // default mapping (used when no permissionMode is passed) stays on the
+      // on-request / read-only baseline. This lets us prove the IPC-provided
+      // `codexApprovalPolicy: "untrusted"` / `codexSandbox: "read-only"` never
+      // land on the session — the full-auto derivation is used instead.
+      vi.mocked(mapPermissionToCodex).mockImplementation((mode) => {
+        if (mode === "full-auto") return { approvalPolicy: "never", sandbox: "danger-full-access" };
+        if (mode === "edit") return { approvalPolicy: "untrusted", sandbox: "workspace-write" };
+        return { approvalPolicy: "on-request", sandbox: "read-only" };
+      });
+
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5-codex",
+        modelId: "gpt-5-codex",
+        identityKey: "agent:worker-1",
+        codexApprovalPolicy: "untrusted",
+        codexSandbox: "read-only",
+      });
+
+      expect(session.codexApprovalPolicy).toBe("never");
+      expect(session.codexSandbox).toBe("danger-full-access");
+    });
+
+    it("ignores native permission overrides for pinned identities on update", async () => {
+      const { service } = createService();
+      const session = await service.ensureIdentitySession({
+        identityKey: "cto",
+        laneId: "lane-1",
+      });
+      const claudeBefore = session.claudePermissionMode;
+      const opencodeBefore = session.opencodePermissionMode;
+
+      const updated = await service.updateSession({
+        sessionId: session.id,
+        claudePermissionMode: "plan",
+        interactionMode: "plan",
+        codexApprovalPolicy: "untrusted",
+        codexSandbox: "read-only",
+        opencodePermissionMode: "plan",
+      });
+
+      // None of the stricter native modes should have landed on the session.
+      expect(updated.interactionMode).not.toBe("plan");
+      if (claudeBefore !== undefined) {
+        expect(updated.claudePermissionMode).toBe(claudeBefore);
+      }
+      if (opencodeBefore !== undefined) {
+        expect(updated.opencodePermissionMode).toBe(opencodeBefore);
+      }
+      expect(updated.codexApprovalPolicy).not.toBe("untrusted");
+      expect(updated.codexSandbox).not.toBe("read-only");
+    });
   });
 
   describe("identity continuity", () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -12592,14 +12592,11 @@ export function createAgentChatService(args: {
 
     const preferred = canonicalExisting;
     if (preferred) {
-      // Defensive guard: if the selected canonical session ever drifted onto
-      // a foreign lane (e.g. from a legacy DB write), rewrite it to the
-      // canonical lane before we hydrate/resume so identity sessions never
-      // run on a non-primary lane.
-      if (preferred.laneId !== canonicalLaneId && isPrimaryPinnedIdentity(args.identityKey)) {
-        sessionService.updateMeta({ sessionId: preferred.sessionId, laneId: canonicalLaneId });
-        managedSessions.delete(preferred.sessionId);
-      }
+      // `canonicalExisting` is already filtered to `entry.laneId === canonicalLaneId`,
+      // so `preferred` is guaranteed to be on the canonical lane here — no
+      // migration guard needed. Foreign-lane legacy sessions are left untouched
+      // (see the `does not reuse a foreign-lane identity session` test); a
+      // fresh canonical session will be created below when none is found.
       const managed = ensureManagedSession(preferred.sessionId);
       managed.session.identityKey = args.identityKey;
       managed.session.capabilityMode = inferCapabilityMode(managed.session.provider);

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -38,6 +38,7 @@ import {
   type BufferedAssistantText,
 } from "./chatTextBatching";
 import {
+  isPrimaryPinnedIdentity,
   normalizeIdentityPermissionMode,
   resolveIdentityExecutionLane,
 } from "./identitySessionPolicy";
@@ -4784,9 +4785,12 @@ export function createAgentChatService(args: {
   const resolvePrimaryIdentityLane = async (): Promise<string> => {
     await laneService.ensurePrimaryLane?.().catch(() => {});
     const lanes = await laneService.list({ includeArchived: false, includeStatus: false });
-    const primary = lanes.find((lane) => lane.laneType === "primary") ?? lanes[0] ?? null;
+    // Identity sessions (CTO + worker agents) must pin to the actual primary
+    // lane. Never fall back to lanes[0] — that would silently land the
+    // identity on a foreign lane, defeating the whole contract.
+    const primary = lanes.find((lane) => lane.laneType === "primary") ?? null;
     if (!primary?.id) {
-      throw new Error("No lane is available to host the canonical identity chat session.");
+      throw new Error("No primary lane is available to host the canonical identity chat session.");
     }
     return primary.id;
   };
@@ -10372,11 +10376,22 @@ export function createAgentChatService(args: {
         : undefined;
     const normalizedCursorConfigValues = normalizeCursorConfigValueRecord(requestedCursorConfigValues);
     const capabilityMode = inferCapabilityMode(effectiveProvider);
+    // Identity-pinned sessions (CTO + worker agents) are locked to full-auto.
+    // Discard the native provider permission overrides supplied by callers so
+    // they cannot smuggle `plan` / `ask` / read-only sandboxes past the lock
+    // via claudePermissionMode / codexApprovalPolicy / codexSandbox /
+    // opencodePermissionMode.
+    const identityPinned = isPrimaryPinnedIdentity(identityKey);
+    const effectiveInteractionMode = identityPinned ? undefined : requestedInteractionMode;
+    const effectiveClaudePermissionMode = identityPinned ? undefined : requestedClaudePermissionMode;
+    const effectiveCodexApprovalPolicy = identityPinned ? undefined : requestedCodexApprovalPolicy;
+    const effectiveCodexSandbox = identityPinned ? undefined : requestedCodexSandbox;
+    const effectiveCodexConfigSource = identityPinned ? undefined : requestedCodexConfigSource;
     let effectivePermissionMode = identityKey
       ? normalizeIdentityPermissionMode(identityKey, requestedPermMode, effectiveProvider)
       : requestedPermMode;
     const chatConfig = resolveChatConfig();
-    let requestedOpenCodePermissionMode = requestedOpenCodePermissionModeArg;
+    let requestedOpenCodePermissionMode = identityPinned ? undefined : requestedOpenCodePermissionModeArg;
     const localHarnessPermissions = applyLocalHarnessPermissionMode({
       descriptor: resolvedDescriptor,
       requestedPermissionMode: effectivePermissionMode,
@@ -10387,14 +10402,14 @@ export function createAgentChatService(args: {
 
     const nativePermissionFields = (() => {
       if (effectiveProvider === "claude") {
-        const interactionMode = requestedInteractionMode
-          ?? (requestedClaudePermissionMode === "plan" ? "plan" : undefined)
+        const interactionMode = effectiveInteractionMode
+          ?? (effectiveClaudePermissionMode === "plan" ? "plan" : undefined)
           ?? (effectivePermissionMode === "plan" ? "plan" : undefined)
           ?? (chatConfig.claudePermissionMode === "plan" ? "plan" : undefined)
           ?? "default";
-        const claudePermissionMode = requestedClaudePermissionMode
+        const claudePermissionMode = effectiveClaudePermissionMode
           ? resolveSessionClaudeAccessMode(
-              { claudePermissionMode: requestedClaudePermissionMode, permissionMode: undefined },
+              { claudePermissionMode: effectiveClaudePermissionMode, permissionMode: undefined },
               chatConfig.claudePermissionMode,
             )
           : resolveSessionClaudeAccessMode(
@@ -10404,17 +10419,17 @@ export function createAgentChatService(args: {
         return { interactionMode, claudePermissionMode };
       }
       if (effectiveProvider === "codex") {
-        const codexConfigSource = requestedCodexConfigSource
+        const codexConfigSource = effectiveCodexConfigSource
           ?? legacyPermissionModeToCodexConfigSource(effectivePermissionMode)
           ?? "flags";
         if (codexConfigSource === "config-toml") {
           return { codexConfigSource };
         }
         return {
-          codexApprovalPolicy: requestedCodexApprovalPolicy
+          codexApprovalPolicy: effectiveCodexApprovalPolicy
             ?? legacyPermissionModeToCodexApprovalPolicy(effectivePermissionMode)
             ?? chatConfig.codexApprovalPolicy,
-          codexSandbox: requestedCodexSandbox
+          codexSandbox: effectiveCodexSandbox
             ?? legacyPermissionModeToCodexSandbox(effectivePermissionMode)
             ?? chatConfig.codexSandboxMode,
           codexConfigSource,
@@ -12293,7 +12308,21 @@ export function createAgentChatService(args: {
   };
 
   const resumeSession = async ({ sessionId }: { sessionId: string }): Promise<AgentChatSession> => {
-    const managed = ensureManagedSession(sessionId);
+    let managed = ensureManagedSession(sessionId);
+
+    // Identity-pinned sessions (CTO + worker agents) must always run on the
+    // canonical primary lane. If a persisted row points at a foreign lane
+    // (e.g. pre-pinning session, or the previous primary was archived),
+    // migrate it to the canonical lane before we spin up a runtime.
+    if (isPrimaryPinnedIdentity(managed.session.identityKey) && managed.session.laneId) {
+      const canonicalLaneId = await resolvePrimaryIdentityLane();
+      if (canonicalLaneId && managed.session.laneId !== canonicalLaneId) {
+        sessionService.updateMeta({ sessionId, laneId: canonicalLaneId });
+        managedSessions.delete(sessionId);
+        managed = ensureManagedSession(sessionId);
+      }
+    }
+
     refreshManagedLaneLaunchContext(managed, { purpose: "resume this chat" });
     const persisted = readPersistedState(sessionId);
     managed.session.capabilityMode = managed.session.capabilityMode ?? inferCapabilityMode(managed.session.provider);
@@ -12563,6 +12592,14 @@ export function createAgentChatService(args: {
 
     const preferred = canonicalExisting;
     if (preferred) {
+      // Defensive guard: if the selected canonical session ever drifted onto
+      // a foreign lane (e.g. from a legacy DB write), rewrite it to the
+      // canonical lane before we hydrate/resume so identity sessions never
+      // run on a non-primary lane.
+      if (preferred.laneId !== canonicalLaneId && isPrimaryPinnedIdentity(args.identityKey)) {
+        sessionService.updateMeta({ sessionId: preferred.sessionId, laneId: canonicalLaneId });
+        managedSessions.delete(preferred.sessionId);
+      }
       const managed = ensureManagedSession(preferred.sessionId);
       managed.session.identityKey = args.identityKey;
       managed.session.capabilityMode = inferCapabilityMode(managed.session.provider);
@@ -13270,6 +13307,7 @@ export function createAgentChatService(args: {
     const managed = ensureManagedSession(sessionId);
     const chatConfig = resolveChatConfig();
     const isIdentitySession = Boolean(managed.session.identityKey);
+    const identityPinned = isPrimaryPinnedIdentity(managed.session.identityKey);
     const hasConversation = managed.recentConversationEntries.length > 0 || readTranscriptConversationEntries(managed).length > 0;
     const prevCodexApprovalPolicy = managed.session.codexApprovalPolicy;
     const prevCodexSandbox = managed.session.codexSandbox;
@@ -13397,11 +13435,15 @@ export function createAgentChatService(args: {
       applyLegacyPermissionModeToNativeControls(managed.session, managed.session.permissionMode);
     }
 
-    if (interactionMode !== undefined) {
+    // Identity-pinned sessions (CTO + worker agents) are locked to full-auto.
+    // Ignore incoming native permission overrides — applyLegacyPermissionMode-
+    // ToNativeControls() has already derived the correct native fields from
+    // full-auto, and we must not let callers layer a stricter mode on top.
+    if (interactionMode !== undefined && !identityPinned) {
       managed.session.interactionMode = interactionMode;
     }
 
-    if (claudePermissionMode !== undefined) {
+    if (claudePermissionMode !== undefined && !identityPinned) {
       if (claudePermissionMode === "plan") {
         managed.session.interactionMode = "plan";
       } else {
@@ -13409,19 +13451,19 @@ export function createAgentChatService(args: {
       }
     }
 
-    if (codexApprovalPolicy !== undefined) {
+    if (codexApprovalPolicy !== undefined && !identityPinned) {
       managed.session.codexApprovalPolicy = codexApprovalPolicy;
     }
 
-    if (codexSandbox !== undefined) {
+    if (codexSandbox !== undefined && !identityPinned) {
       managed.session.codexSandbox = codexSandbox;
     }
 
-    if (codexConfigSource !== undefined) {
+    if (codexConfigSource !== undefined && !identityPinned) {
       managed.session.codexConfigSource = codexConfigSource;
     }
 
-    if (opencodePermissionMode !== undefined) {
+    if (opencodePermissionMode !== undefined && !identityPinned) {
       managed.session.opencodePermissionMode = opencodePermissionMode;
     }
 

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -37,6 +37,10 @@ import {
   shouldFlushBufferedAssistantTextForEvent,
   type BufferedAssistantText,
 } from "./chatTextBatching";
+import {
+  normalizeIdentityPermissionMode,
+  resolveIdentityExecutionLane,
+} from "./identitySessionPolicy";
 import type { Logger } from "../logging/logger";
 import type { createLaneService } from "../lanes/laneService";
 import { resolveLaneLaunchContext, type LaneLaunchContext } from "../lanes/laneLaunchContext";
@@ -2414,17 +2418,6 @@ function normalizeSessionProfile(value: unknown): "light" | "workflow" | undefin
 
 function inferCapabilityMode(provider: AgentChatProvider): CtoCapabilityMode {
   return provider === "codex" || provider === "claude" || provider === "cursor" || provider === "opencode" ? "full_tooling" : "fallback";
-}
-
-function guardedIdentityPermissionModeForProvider(_provider: AgentChatProvider): AgentChatSession["permissionMode"] {
-  return "plan";
-}
-
-function normalizeIdentityPermissionMode(
-  mode: AgentChatSession["permissionMode"] | undefined,
-  provider: AgentChatProvider,
-): AgentChatSession["permissionMode"] {
-  return mode === "plan" ? "plan" : guardedIdentityPermissionModeForProvider(provider);
 }
 
 function isLightweightSession(session: Pick<AgentChatSession, "sessionProfile">): boolean {
@@ -10380,7 +10373,7 @@ export function createAgentChatService(args: {
     const normalizedCursorConfigValues = normalizeCursorConfigValueRecord(requestedCursorConfigValues);
     const capabilityMode = inferCapabilityMode(effectiveProvider);
     let effectivePermissionMode = identityKey
-      ? normalizeIdentityPermissionMode(requestedPermMode, effectiveProvider)
+      ? normalizeIdentityPermissionMode(identityKey, requestedPermMode, effectiveProvider)
       : requestedPermMode;
     const chatConfig = resolveChatConfig();
     let requestedOpenCodePermissionMode = requestedOpenCodePermissionModeArg;
@@ -12554,7 +12547,11 @@ export function createAgentChatService(args: {
     }
 
     const canonicalLaneId = await resolvePrimaryIdentityLane();
-    const selectedExecutionLaneId = requestedLaneId || null;
+    const selectedExecutionLaneId = resolveIdentityExecutionLane(
+      args.identityKey,
+      requestedLaneId,
+      canonicalLaneId,
+    );
     const existing = await listSessions(undefined, { includeIdentity: true });
     const identitySessions = existing
       .filter((entry) => entry.identityKey === args.identityKey)
@@ -12573,6 +12570,7 @@ export function createAgentChatService(args: {
         managed.session.reasoningEffort = normalizeReasoningEffort(args.reasoningEffort);
       }
       managed.session.permissionMode = normalizeIdentityPermissionMode(
+        args.identityKey,
         args.permissionMode ?? managed.session.permissionMode,
         managed.session.provider,
       );
@@ -12640,7 +12638,7 @@ export function createAgentChatService(args: {
       model: preferredModel,
       ...(resolvedModelId ? { modelId: resolvedModelId } : {}),
       reasoningEffort: args.reasoningEffort ?? pref?.reasoningEffort ?? null,
-      permissionMode: args.permissionMode ?? "plan",
+      ...(args.permissionMode ? { permissionMode: args.permissionMode } : {}),
       identityKey: args.identityKey
     });
 
@@ -13338,6 +13336,7 @@ export function createAgentChatService(args: {
 
       if (isIdentitySession) {
         managed.session.permissionMode = normalizeIdentityPermissionMode(
+          managed.session.identityKey,
           managed.session.permissionMode,
           nextProvider,
         );
@@ -13393,7 +13392,7 @@ export function createAgentChatService(args: {
 
     if (permissionMode !== undefined) {
       managed.session.permissionMode = isIdentitySession
-        ? normalizeIdentityPermissionMode(permissionMode, managed.session.provider)
+        ? normalizeIdentityPermissionMode(managed.session.identityKey, permissionMode, managed.session.provider)
         : permissionMode;
       applyLegacyPermissionModeToNativeControls(managed.session, managed.session.permissionMode);
     }

--- a/apps/desktop/src/main/services/chat/identitySessionPolicy.test.ts
+++ b/apps/desktop/src/main/services/chat/identitySessionPolicy.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeIdentityPermissionMode,
+  resolveIdentityExecutionLane,
+} from "./identitySessionPolicy";
+
+describe("identitySessionPolicy", () => {
+  it("forces CTO and worker sessions into full-auto permission mode", () => {
+    expect(normalizeIdentityPermissionMode("cto", "plan", "claude")).toBe("full-auto");
+    expect(normalizeIdentityPermissionMode("cto", undefined, "codex")).toBe("full-auto");
+    expect(normalizeIdentityPermissionMode("agent:worker-1", undefined, "codex")).toBe("full-auto");
+    expect(normalizeIdentityPermissionMode("agent:worker-1", "plan", "claude")).toBe("full-auto");
+  });
+
+  it("pins CTO and worker execution to the canonical lane", () => {
+    expect(resolveIdentityExecutionLane("cto", "lane-feature", "lane-primary")).toBe("lane-primary");
+    expect(resolveIdentityExecutionLane("agent:worker-1", "lane-feature", "lane-primary")).toBe("lane-primary");
+  });
+});

--- a/apps/desktop/src/main/services/chat/identitySessionPolicy.test.ts
+++ b/apps/desktop/src/main/services/chat/identitySessionPolicy.test.ts
@@ -16,4 +16,10 @@ describe("identitySessionPolicy", () => {
     expect(resolveIdentityExecutionLane("cto", "lane-feature", "lane-primary")).toBe("lane-primary");
     expect(resolveIdentityExecutionLane("agent:worker-1", "lane-feature", "lane-primary")).toBe("lane-primary");
   });
+
+  it("falls back to plan/guarded mode for non-identity sessions", () => {
+    expect(normalizeIdentityPermissionMode(undefined, "plan", "claude")).toBe("plan");
+    expect(normalizeIdentityPermissionMode(undefined, "full-auto", "claude")).toBe("plan");
+    expect(normalizeIdentityPermissionMode(undefined, undefined, "codex")).toBe("plan");
+  });
 });

--- a/apps/desktop/src/main/services/chat/identitySessionPolicy.test.ts
+++ b/apps/desktop/src/main/services/chat/identitySessionPolicy.test.ts
@@ -45,4 +45,10 @@ describe("identitySessionPolicy", () => {
     expect(resolveIdentityExecutionLane("cto", null, "lane-primary")).toBe("lane-primary");
     expect(resolveIdentityExecutionLane("cto", "lane-feature", null)).toBe(null);
   });
+
+  it("passes through requested lanes for non-pinned identities", () => {
+    expect(resolveIdentityExecutionLane("assistant" as never, "lane-feature", "lane-primary")).toBe("lane-feature");
+    expect(resolveIdentityExecutionLane("assistant" as never, "  lane-feature  ", "lane-primary")).toBe("lane-feature");
+    expect(resolveIdentityExecutionLane("assistant" as never, "   ", "lane-primary")).toBe(null);
+  });
 });

--- a/apps/desktop/src/main/services/chat/identitySessionPolicy.test.ts
+++ b/apps/desktop/src/main/services/chat/identitySessionPolicy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isPrimaryPinnedIdentity,
   normalizeIdentityPermissionMode,
   resolveIdentityExecutionLane,
 } from "./identitySessionPolicy";
@@ -21,5 +22,27 @@ describe("identitySessionPolicy", () => {
     expect(normalizeIdentityPermissionMode(undefined, "plan", "claude")).toBe("plan");
     expect(normalizeIdentityPermissionMode(undefined, "full-auto", "claude")).toBe("plan");
     expect(normalizeIdentityPermissionMode(undefined, undefined, "codex")).toBe("plan");
+  });
+
+  it("treats empty or whitespace-only agent suffixes as non-pinned", () => {
+    expect(isPrimaryPinnedIdentity("cto")).toBe(true);
+    expect(isPrimaryPinnedIdentity("agent:worker-1")).toBe(true);
+    // Cast through unknown so the test can probe malformed identity keys that
+    // ideally should never reach the helper but still could arrive via IPC.
+    expect(isPrimaryPinnedIdentity("agent:" as never)).toBe(false);
+    expect(isPrimaryPinnedIdentity("agent:   " as never)).toBe(false);
+    expect(isPrimaryPinnedIdentity(undefined)).toBe(false);
+
+    // Pinned-identity pathways should fall through to the guarded default for
+    // malformed agent suffixes so a caller cannot smuggle full-auto in by
+    // passing `agent:   `.
+    expect(normalizeIdentityPermissionMode("agent:   " as never, undefined, "claude")).toBe("plan");
+    expect(normalizeIdentityPermissionMode("agent:" as never, "plan", "codex")).toBe("plan");
+  });
+
+  it("returns the canonical lane (including null) for pinned identities", () => {
+    expect(resolveIdentityExecutionLane("cto", undefined, "lane-primary")).toBe("lane-primary");
+    expect(resolveIdentityExecutionLane("cto", null, "lane-primary")).toBe("lane-primary");
+    expect(resolveIdentityExecutionLane("cto", "lane-feature", null)).toBe(null);
   });
 });

--- a/apps/desktop/src/main/services/chat/identitySessionPolicy.ts
+++ b/apps/desktop/src/main/services/chat/identitySessionPolicy.ts
@@ -1,0 +1,31 @@
+import type { AgentChatIdentityKey, AgentChatProvider, AgentChatSession } from "../../../shared/types";
+
+export function guardedIdentityPermissionModeForProvider(_provider: AgentChatProvider): AgentChatSession["permissionMode"] {
+  return "plan";
+}
+
+function isPrimaryPinnedIdentity(identityKey: AgentChatIdentityKey | undefined): boolean {
+  return identityKey === "cto" || Boolean(identityKey?.startsWith("agent:"));
+}
+
+export function normalizeIdentityPermissionMode(
+  identityKey: AgentChatIdentityKey | undefined,
+  mode: AgentChatSession["permissionMode"] | undefined,
+  provider: AgentChatProvider,
+): AgentChatSession["permissionMode"] {
+  if (isPrimaryPinnedIdentity(identityKey)) {
+    return "full-auto";
+  }
+  return mode === "plan" ? "plan" : guardedIdentityPermissionModeForProvider(provider);
+}
+
+export function resolveIdentityExecutionLane(
+  identityKey: AgentChatIdentityKey,
+  requestedLaneId: string,
+  canonicalLaneId: string,
+): string | null {
+  if (isPrimaryPinnedIdentity(identityKey)) {
+    return canonicalLaneId;
+  }
+  return requestedLaneId || null;
+}

--- a/apps/desktop/src/main/services/chat/identitySessionPolicy.ts
+++ b/apps/desktop/src/main/services/chat/identitySessionPolicy.ts
@@ -1,11 +1,16 @@
 import type { AgentChatIdentityKey, AgentChatProvider, AgentChatSession } from "../../../shared/types";
 
-export function guardedIdentityPermissionModeForProvider(_provider: AgentChatProvider): AgentChatSession["permissionMode"] {
+function guardedIdentityPermissionModeForProvider(_provider: AgentChatProvider): AgentChatSession["permissionMode"] {
   return "plan";
 }
 
-function isPrimaryPinnedIdentity(identityKey: AgentChatIdentityKey | undefined): boolean {
-  return identityKey === "cto" || Boolean(identityKey?.startsWith("agent:"));
+export function isPrimaryPinnedIdentity(identityKey: AgentChatIdentityKey | undefined): boolean {
+  if (identityKey === "cto") return true;
+  if (!identityKey || !identityKey.startsWith("agent:")) return false;
+  // Require a non-empty trimmed suffix so `agent:` and `agent:   ` do not
+  // masquerade as a worker identity. Matches the stricter checks in
+  // resolveWorkerIdentityAgentId / normalizeIdentityKey.
+  return identityKey.slice("agent:".length).trim().length > 0;
 }
 
 export function normalizeIdentityPermissionMode(
@@ -21,11 +26,12 @@ export function normalizeIdentityPermissionMode(
 
 export function resolveIdentityExecutionLane(
   identityKey: AgentChatIdentityKey,
-  requestedLaneId: string,
-  canonicalLaneId: string,
+  requestedLaneId: string | null | undefined,
+  canonicalLaneId: string | null,
 ): string | null {
   if (isPrimaryPinnedIdentity(identityKey)) {
     return canonicalLaneId;
   }
-  return requestedLaneId || null;
+  const trimmedRequested = typeof requestedLaneId === "string" ? requestedLaneId.trim() : "";
+  return trimmedRequested.length ? trimmedRequested : null;
 }

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -1180,15 +1180,16 @@ function getMemoryHealthStats(ctx: AppContext) {
   return stats;
 }
 
-async function resolveFirstAvailableLaneId(
-  ctx: AppContext,
-  requestedLaneId: string | undefined | null
-): Promise<string> {
-  const laneId = typeof requestedLaneId === "string" ? requestedLaneId.trim() : "";
-  if (laneId) return laneId;
+/**
+ * Strict resolver for identity-pinned sessions (CTO + worker agents). Requires
+ * an actual primary lane and never slips a foreign lane through via a
+ * `lanes[0]` fallback — if there is no primary lane the caller must surface
+ * the error rather than silently landing the identity on a non-primary lane.
+ */
+async function resolvePrimaryLaneIdOnly(ctx: AppContext): Promise<string> {
   await ctx.laneService.ensurePrimaryLane().catch(() => {});
   const lanes = await ctx.laneService.list({ includeArchived: false, includeStatus: false });
-  return (lanes.find((lane) => lane.laneType === "primary") ?? lanes[0])?.id ?? "";
+  return lanes.find((lane) => lane.laneType === "primary")?.id ?? "";
 }
 
 async function resolveLaneOverlayContext(ctx: AppContext, laneId: string) {
@@ -6272,7 +6273,7 @@ export function registerIpc({
 
   ipcMain.handle(IPC.ctoEnsureSession, async (_event, arg: CtoEnsureSessionArgs = {}): Promise<AgentChatSession> => {
     const ctx = getCtx();
-    const laneId = await resolveFirstAvailableLaneId(ctx, null);
+    const laneId = await resolvePrimaryLaneIdOnly(ctx);
     if (!laneId) {
       throw new Error("No primary lane is available to host the CTO chat session.");
     }
@@ -6344,7 +6345,7 @@ export function registerIpc({
   ipcMain.handle(IPC.ctoEnsureAgentSession, async (_event, arg: CtoEnsureAgentSessionArgs): Promise<AgentChatSession> => {
     const ctx = getCtx();
     if (!ctx.agentChatService) throw new Error("Agent chat service is not available.");
-    const laneId = await resolveFirstAvailableLaneId(ctx, null);
+    const laneId = await resolvePrimaryLaneIdOnly(ctx);
     if (!laneId) throw new Error("No primary lane is available to host the agent chat session.");
     return ctx.agentChatService.ensureIdentitySession({
       identityKey: `agent:${arg.agentId}`,

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -6272,15 +6272,16 @@ export function registerIpc({
 
   ipcMain.handle(IPC.ctoEnsureSession, async (_event, arg: CtoEnsureSessionArgs = {}): Promise<AgentChatSession> => {
     const ctx = getCtx();
-    const laneId = await resolveFirstAvailableLaneId(ctx, arg.laneId);
+    const laneId = await resolveFirstAvailableLaneId(ctx, null);
     if (!laneId) {
-      throw new Error("No active lane is available to host the CTO chat session.");
+      throw new Error("No primary lane is available to host the CTO chat session.");
     }
     return ctx.agentChatService.ensureIdentitySession({
       identityKey: "cto",
       laneId,
       modelId: arg.modelId ?? null,
       reasoningEffort: arg.reasoningEffort ?? null,
+      permissionMode: "full-auto",
     });
   });
 
@@ -6343,13 +6344,14 @@ export function registerIpc({
   ipcMain.handle(IPC.ctoEnsureAgentSession, async (_event, arg: CtoEnsureAgentSessionArgs): Promise<AgentChatSession> => {
     const ctx = getCtx();
     if (!ctx.agentChatService) throw new Error("Agent chat service is not available.");
-    const laneId = await resolveFirstAvailableLaneId(ctx, arg.laneId);
-    if (!laneId) throw new Error("No lane available for agent session.");
+    const laneId = await resolveFirstAvailableLaneId(ctx, null);
+    if (!laneId) throw new Error("No primary lane is available to host the agent chat session.");
     return ctx.agentChatService.ensureIdentitySession({
       identityKey: `agent:${arg.agentId}`,
       laneId,
       modelId: arg.modelId ?? null,
       reasoningEffort: arg.reasoningEffort ?? null,
+      permissionMode: "full-auto",
     });
   });
 

--- a/apps/desktop/src/main/services/sessions/sessionService.ts
+++ b/apps/desktop/src/main/services/sessions/sessionService.ts
@@ -335,6 +335,14 @@ export function createSessionService({ db }: { db: AdeDb }) {
         params.push(args.manuallyNamed ? 1 : 0);
       }
 
+      if (typeof args.laneId === "string") {
+        const nextLaneId = args.laneId.trim();
+        if (nextLaneId.length) {
+          sets.push("lane_id = ?");
+          params.push(nextLaneId);
+        }
+      }
+
       if (args.title !== undefined) {
         const nextTitle = typeof args.title === "string" ? args.title.trim() : "";
         if (nextTitle.length) {

--- a/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
@@ -1795,6 +1795,18 @@ describe("createSyncRemoteCommandService", () => {
         .rejects.toThrow("No primary lane is available to host the CTO chat session.");
     });
 
+    it("cto.ensureSession refuses to fall back to lanes[0] when no primary exists", async () => {
+      // Only non-primary lanes are available; identity-pinned sessions must
+      // not silently land on a foreign lane via the lanes[0] fallback.
+      laneService.list.mockResolvedValueOnce([
+        { id: "lane-feature", laneType: "feature" },
+        { id: "lane-scratch", laneType: "feature" },
+      ]);
+      await expect(service.execute(makePayload("cto.ensureSession", {})))
+        .rejects.toThrow("No primary lane is available to host the CTO chat session.");
+      expect(agentChatService.ensureIdentitySession).not.toHaveBeenCalled();
+    });
+
     it("cto.ensureAgentSession requires agentId", async () => {
       await expect(service.execute(makePayload("cto.ensureAgentSession", {})))
         .rejects.toThrow("cto.ensureAgentSession requires agentId.");
@@ -1866,6 +1878,22 @@ describe("createSyncRemoteCommandService", () => {
       await expect(service.execute(makePayload("cto.ensureAgentSession", {
         agentId: "worker-42",
       }))).rejects.toThrow("No primary lane is available to host the agent chat session.");
+    });
+
+    it("cto.ensureAgentSession refuses to fall back to lanes[0] when no primary exists", async () => {
+      laneService.list.mockResolvedValueOnce([
+        { id: "lane-feature", laneType: "feature" },
+      ]);
+      workerAgentService.getAgent.mockReturnValueOnce({
+        id: "worker-42",
+        name: "Mobile Droid",
+        slug: "mobile-droid",
+        status: "running",
+      });
+      await expect(service.execute(makePayload("cto.ensureAgentSession", {
+        agentId: "worker-42",
+      }))).rejects.toThrow("No primary lane is available to host the agent chat session.");
+      expect(agentChatService.ensureIdentitySession).not.toHaveBeenCalled();
     });
 
     it("cto.ensureSession returns the same session on repeat calls (canonical lane reuse)", async () => {

--- a/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
@@ -1769,25 +1769,30 @@ describe("createSyncRemoteCommandService", () => {
         laneId: "lane-primary",
         modelId: "claude-opus-4",
         reasoningEffort: "high",
+        permissionMode: "full-auto",
       });
       expect(agentChatService.getSessionSummary).toHaveBeenCalledWith("chat-identity-1");
       expect(result).toEqual(expect.objectContaining({ sessionId: "chat-1" }));
     });
 
-    it("cto.ensureSession uses the requested laneId when provided", async () => {
+    it("cto.ensureSession ignores requested lane overrides and still uses primary", async () => {
+      laneService.list.mockResolvedValueOnce([
+        { id: "lane-primary", laneType: "primary" },
+      ]);
       await service.execute(makePayload("cto.ensureSession", { laneId: "lane-explicit" }));
       expect(agentChatService.ensureIdentitySession).toHaveBeenCalledWith({
         identityKey: "cto",
-        laneId: "lane-explicit",
+        laneId: "lane-primary",
         modelId: null,
         reasoningEffort: null,
+        permissionMode: "full-auto",
       });
     });
 
     it("cto.ensureSession throws when no lane is available", async () => {
       laneService.list.mockResolvedValueOnce([]);
       await expect(service.execute(makePayload("cto.ensureSession", {})))
-        .rejects.toThrow("No active lane is available to host the CTO chat session.");
+        .rejects.toThrow("No primary lane is available to host the CTO chat session.");
     });
 
     it("cto.ensureAgentSession requires agentId", async () => {
@@ -1795,7 +1800,7 @@ describe("createSyncRemoteCommandService", () => {
         .rejects.toThrow("cto.ensureAgentSession requires agentId.");
     });
 
-    it("cto.ensureAgentSession delegates to agentChatService with agent:<id> identityKey", async () => {
+    it("cto.ensureAgentSession delegates to agentChatService with agent:<id> identityKey on primary", async () => {
       laneService.list.mockResolvedValueOnce([
         { id: "lane-primary", laneType: "primary" },
       ]);
@@ -1813,8 +1818,32 @@ describe("createSyncRemoteCommandService", () => {
         laneId: "lane-primary",
         modelId: null,
         reasoningEffort: null,
+        permissionMode: "full-auto",
       });
       expect(result).toEqual(expect.objectContaining({ sessionId: "chat-1" }));
+    });
+
+    it("cto.ensureAgentSession ignores requested lane overrides and still uses primary", async () => {
+      laneService.list.mockResolvedValueOnce([
+        { id: "lane-primary", laneType: "primary" },
+      ]);
+      workerAgentService.getAgent.mockReturnValueOnce({
+        id: "worker-42",
+        name: "Mobile Droid",
+        slug: "mobile-droid",
+        status: "running",
+      });
+      await service.execute(makePayload("cto.ensureAgentSession", {
+        agentId: "worker-42",
+        laneId: "lane-explicit",
+      }));
+      expect(agentChatService.ensureIdentitySession).toHaveBeenCalledWith({
+        identityKey: "agent:worker-42",
+        laneId: "lane-primary",
+        modelId: null,
+        reasoningEffort: null,
+        permissionMode: "full-auto",
+      });
     });
 
     it("cto.ensureAgentSession rejects unknown agentIds without creating a session", async () => {
@@ -1824,6 +1853,19 @@ describe("createSyncRemoteCommandService", () => {
         agentId: "ghost-agent",
       }))).rejects.toThrow("cto.ensureAgentSession: unknown agentId 'ghost-agent'");
       expect(agentChatService.ensureIdentitySession).not.toHaveBeenCalled();
+    });
+
+    it("cto.ensureAgentSession throws when no primary lane is available", async () => {
+      laneService.list.mockResolvedValueOnce([]);
+      workerAgentService.getAgent.mockReturnValueOnce({
+        id: "worker-42",
+        name: "Mobile Droid",
+        slug: "mobile-droid",
+        status: "running",
+      });
+      await expect(service.execute(makePayload("cto.ensureAgentSession", {
+        agentId: "worker-42",
+      }))).rejects.toThrow("No primary lane is available to host the agent chat session.");
     });
 
     it("cto.ensureSession returns the same session on repeat calls (canonical lane reuse)", async () => {

--- a/apps/desktop/src/main/services/sync/syncRemoteCommandService.ts
+++ b/apps/desktop/src/main/services/sync/syncRemoteCommandService.ts
@@ -1720,12 +1720,8 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
   });
   register("cto.ensureSession", { viewerAllowed: true }, async (payload) => {
     const agentChatService = requireService(args.agentChatService, "Agent chat service not available.");
-    // When no override is given, resolve the primary lane the same way
-    // agentChatService.ensureIdentitySession does internally (it reuses a
-    // session only when session.laneId === canonicalLaneId). Passing the
-    // canonical lane guarantees the same session is returned on repeat calls.
-    const laneId = await resolveFirstAvailableLaneIdForSync(args, asTrimmedString(payload.laneId));
-    if (!laneId) throw new Error("No active lane is available to host the CTO chat session.");
+    const laneId = await resolveFirstAvailableLaneIdForSync(args, null);
+    if (!laneId) throw new Error("No primary lane is available to host the CTO chat session.");
     const modelId = asTrimmedString(payload.modelId);
     const reasoningEffort = asTrimmedString(payload.reasoningEffort);
     const session = await agentChatService.ensureIdentitySession({
@@ -1733,6 +1729,7 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
       laneId,
       modelId: modelId ?? null,
       reasoningEffort: reasoningEffort ?? null,
+      permissionMode: "full-auto",
     });
     return summarizeChatSessionForRemote(agentChatService, session);
   });
@@ -1749,8 +1746,8 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
     if (!agent) {
       throw new Error(`cto.ensureAgentSession: unknown agentId '${agentId}'`);
     }
-    const laneId = await resolveFirstAvailableLaneIdForSync(args, asTrimmedString(payload.laneId));
-    if (!laneId) throw new Error("No active lane is available to host the agent chat session.");
+    const laneId = await resolveFirstAvailableLaneIdForSync(args, null);
+    if (!laneId) throw new Error("No primary lane is available to host the agent chat session.");
     const modelId = asTrimmedString(payload.modelId);
     const reasoningEffort = asTrimmedString(payload.reasoningEffort);
     const session = await agentChatService.ensureIdentitySession({
@@ -1758,6 +1755,7 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
       laneId,
       modelId: modelId ?? null,
       reasoningEffort: reasoningEffort ?? null,
+      permissionMode: "full-auto",
     });
     return summarizeChatSessionForRemote(agentChatService, session);
   });

--- a/apps/desktop/src/main/services/sync/syncRemoteCommandService.ts
+++ b/apps/desktop/src/main/services/sync/syncRemoteCommandService.ts
@@ -1242,15 +1242,16 @@ function applyLeaseToOverrides(
   };
 }
 
-async function resolveFirstAvailableLaneIdForSync(
-  args: SyncRemoteCommandServiceArgs,
-  requestedLaneId: string | null,
-): Promise<string> {
-  const laneId = typeof requestedLaneId === "string" ? requestedLaneId.trim() : "";
-  if (laneId) return laneId;
+/**
+ * Strict resolver for identity-pinned sessions (CTO + worker agents). Never
+ * slips a foreign lane through via a `lanes[0]` fallback — if no primary lane
+ * exists, the caller must error out rather than silently host the identity on
+ * a non-primary lane.
+ */
+async function resolvePrimaryLaneIdOnlyForSync(args: SyncRemoteCommandServiceArgs): Promise<string> {
   await args.laneService.ensurePrimaryLane?.().catch(() => {});
   const lanes = await args.laneService.list({ includeArchived: false, includeStatus: false });
-  return (lanes.find((lane) => lane.laneType === "primary") ?? lanes[0])?.id ?? "";
+  return lanes.find((lane) => lane.laneType === "primary")?.id ?? "";
 }
 
 async function resolveLaneOverlayContext(args: SyncRemoteCommandServiceArgs, laneId: string) {
@@ -1720,7 +1721,7 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
   });
   register("cto.ensureSession", { viewerAllowed: true }, async (payload) => {
     const agentChatService = requireService(args.agentChatService, "Agent chat service not available.");
-    const laneId = await resolveFirstAvailableLaneIdForSync(args, null);
+    const laneId = await resolvePrimaryLaneIdOnlyForSync(args);
     if (!laneId) throw new Error("No primary lane is available to host the CTO chat session.");
     const modelId = asTrimmedString(payload.modelId);
     const reasoningEffort = asTrimmedString(payload.reasoningEffort);
@@ -1746,7 +1747,7 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
     if (!agent) {
       throw new Error(`cto.ensureAgentSession: unknown agentId '${agentId}'`);
     }
-    const laneId = await resolveFirstAvailableLaneIdForSync(args, null);
+    const laneId = await resolvePrimaryLaneIdOnlyForSync(args);
     if (!laneId) throw new Error("No primary lane is available to host the agent chat session.");
     const modelId = asTrimmedString(payload.modelId);
     const reasoningEffort = asTrimmedString(payload.reasoningEffort);

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
@@ -187,6 +187,15 @@ describe("AgentChatComposer", () => {
     });
   });
 
+  it("can hide native permission controls for fixed-mode surfaces", () => {
+    renderComposer({
+      sessionProvider: "codex",
+      hideNativeControls: true,
+    });
+
+    expect(screen.queryByRole("button", { name: "Codex approval preset" })).toBeNull();
+  });
+
   it("avoids promising option chips when a pending question is freeform only", () => {
     renderComposer({
       pendingInput: {

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -344,6 +344,7 @@ export function AgentChatComposer({
   executionModeOptions = [],
   modelSelectionLocked = false,
   permissionModeLocked = false,
+  hideNativeControls = false,
   messagePlaceholder,
   onModelChange,
   onReasoningEffortChange,
@@ -409,6 +410,7 @@ export function AgentChatComposer({
   executionModeOptions?: ExecutionModeOption[];
   modelSelectionLocked?: boolean;
   permissionModeLocked?: boolean;
+  hideNativeControls?: boolean;
   messagePlaceholder?: string;
   onModelChange: (modelId: string) => void;
   onReasoningEffortChange: (reasoningEffort: string | null) => void;
@@ -742,6 +744,9 @@ export function AgentChatComposer({
     return codexPresetOptions.find((option) => option.value === codexPreset)?.detail ?? null;
   }, [codexCustomSummary, codexPreset, codexPresetOptions, hoveredCodexPreset, sessionProvider]);
   const nativeControlPanel = useMemo(() => {
+    if (hideNativeControls) {
+      return null;
+    }
     const renderButtonGroup = <T extends string,>(
       label: string,
       value: T | undefined,
@@ -1109,6 +1114,7 @@ export function AgentChatComposer({
     hoveredClaudeMode,
     hoveredCodexPreset,
     nativeControlsDisabled,
+    hideNativeControls,
     onClaudeModeChange,
     onClaudePermissionModeChange,
     onInteractionModeChange,

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -671,6 +671,8 @@ export function AgentChatPane({
   initialSessionSummary,
   lockSessionId,
   hideSessionTabs = false,
+  hideNativeControls = false,
+  hideWorkspaceChrome = false,
   forceNewSession = false,
   forceDraftMode = false,
   availableModelIdsOverride,
@@ -691,6 +693,8 @@ export function AgentChatPane({
   initialSessionSummary?: AgentChatSessionSummary | null;
   lockSessionId?: string | null;
   hideSessionTabs?: boolean;
+  hideNativeControls?: boolean;
+  hideWorkspaceChrome?: boolean;
   forceNewSession?: boolean;
   forceDraftMode?: boolean;
   availableModelIdsOverride?: string[];
@@ -723,6 +727,7 @@ export function AgentChatPane({
   const preferDraftStart = !lockSessionId && !initialSessionId && !forceNewSession;
   const surfaceProfile: ChatSurfaceProfile = presentation?.profile ?? "standard";
   const isPersistentIdentitySurface = surfaceProfile === "persistent_identity";
+  const showWorkspaceChrome = !hideWorkspaceChrome;
   const modelSwitchPolicy = presentation?.modelSwitchPolicy ?? "same-family-after-launch";
   const initialNativeControls = useMemo(() => defaultNativeControls(surfaceProfile), [surfaceProfile]);
   const [sessions, setSessions] = useState<AgentChatSessionSummary[]>([]);
@@ -2606,10 +2611,10 @@ export function AgentChatPane({
           ) : null}
         </div>
 
-        {laneId ? <ChatGitToolbar laneId={laneId} /> : null}
+        {showWorkspaceChrome && laneId ? <ChatGitToolbar laneId={laneId} /> : null}
 
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
-          {laneId ? <ChatTerminalToggle open={terminalDrawerOpen} onToggle={() => setTerminalDrawerOpen((v) => !v)} /> : null}
+          {showWorkspaceChrome && laneId ? <ChatTerminalToggle open={terminalDrawerOpen} onToggle={() => setTerminalDrawerOpen((v) => !v)} /> : null}
           {resolvedChips.map((chip) => (
             <span
               key={`${chip.label}:${chip.tone ?? "accent"}`}
@@ -2828,6 +2833,7 @@ export function AgentChatPane({
             executionModeOptions={launchModeEditable ? executionModeOptions : []}
             modelSelectionLocked={modelSelectionLocked || sessionMutationKind === "model" || turnActive}
             permissionModeLocked={permissionModeLocked || identitySessionSettingsBusy}
+            hideNativeControls={hideNativeControls}
             messagePlaceholder={messagePlaceholder}
             onExecutionModeChange={setExecutionMode}
             onInteractionModeChange={(value) => { void updateNativeControls({ interactionMode: value }); }}
@@ -3095,11 +3101,13 @@ export function AgentChatPane({
                         sessionId={selectedSessionId}
                       />
                     ) : null}
-                    <ChatTerminalDrawer
-                      open={terminalDrawerOpen}
-                      onToggle={() => setTerminalDrawerOpen((v) => !v)}
-                      laneId={laneId}
-                    />
+                    {showWorkspaceChrome ? (
+                      <ChatTerminalDrawer
+                        open={terminalDrawerOpen}
+                        onToggle={() => setTerminalDrawerOpen((v) => !v)}
+                        laneId={laneId}
+                      />
+                    ) : null}
                   </div>
 
                   {/* Proof panel (push) */}
@@ -3147,7 +3155,7 @@ export function AgentChatPane({
                     </p>
 
                     {/* Lane selector pill */}
-                    {availableLanes && availableLanes.length > 0 && onLaneChange ? (
+                    {showWorkspaceChrome && availableLanes && availableLanes.length > 0 && onLaneChange ? (
                       <motion.div
                         exit={{ opacity: 0, transition: { duration: 0.15 } }}
                       >
@@ -3172,7 +3180,7 @@ export function AgentChatPane({
                           ))}
                         </select>
                       </motion.div>
-                    ) : laneDisplayLabel ? (
+                    ) : showWorkspaceChrome && laneDisplayLabel ? (
                       <motion.div
                         className="flex items-center gap-2 rounded-full px-4 py-1.5"
                         style={{ background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)" }}

--- a/apps/desktop/src/renderer/components/cto/CtoPage.tsx
+++ b/apps/desktop/src/renderer/components/cto/CtoPage.tsx
@@ -37,6 +37,7 @@ import { OnboardingBanner } from "./OnboardingBanner";
 import { WorkerCreationWizard } from "./WorkerCreationWizard";
 import { shellBodyCls } from "./shared/designTokens";
 import { SmartTooltip } from "../ui/SmartTooltip";
+import { resolveCtoPrimaryLaneId } from "./ctoSessionViewState";
 
 /* ── Tab types ── */
 
@@ -75,7 +76,6 @@ function statusDotCls(status: AgentStatus): string {
 
 export function CtoPage() {
   const lanes = useAppStore((s) => s.lanes);
-  const selectedLaneId = useAppStore((s) => s.selectedLaneId);
 
   const [activeTab, setActiveTab] = useState<TabId>("chat");
   const [session, setSession] = useState<AgentChatSession | null>(null);
@@ -126,10 +126,7 @@ export function CtoPage() {
   const lastBudgetLoadAtRef = useRef(0);
   const ctoDisplayName = "CTO";
 
-  const laneId = useMemo(() => {
-    if (selectedLaneId && lanes.some((lane) => lane.id === selectedLaneId)) return selectedLaneId;
-    return lanes.find((lane) => lane.laneType === "primary")?.id ?? lanes[0]?.id ?? null;
-  }, [lanes, selectedLaneId]);
+  const primaryLaneId = useMemo(() => resolveCtoPrimaryLaneId(lanes), [lanes]);
 
   const selectedWorker = useMemo(
     () => (selectedAgentId ? agents.find((a) => a.id === selectedAgentId) ?? null : null),
@@ -294,18 +291,18 @@ export function CtoPage() {
       setSession(null);
       return;
     }
-    if (!laneId) { setSession(null); return; }
+    if (!primaryLaneId) { setSession(null); return; }
     let cancelled = false;
     setLoading(true); setError(null);
     const promise = selectedAgentId
-      ? window.ade.cto.ensureAgentSession({ agentId: selectedAgentId, laneId })
-      : window.ade.cto.ensureSession({ laneId });
+      ? window.ade.cto.ensureAgentSession({ agentId: selectedAgentId })
+      : window.ade.cto.ensureSession();
     void promise
       .then((next) => { if (!cancelled) setSession(next); })
       .catch((err) => { if (!cancelled) { setError(err instanceof Error ? err.message : String(err)); setSession(null); } })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [activeTab, laneId, needsOnboarding, onboardingState, selectedAgentId, showOnboarding]);
+  }, [activeTab, needsOnboarding, onboardingState, primaryLaneId, selectedAgentId, showOnboarding]);
 
   // Deep links for guided setup flows
   useEffect(() => {
@@ -333,15 +330,15 @@ export function CtoPage() {
   /* ── Callbacks ── */
 
   const refreshPersistentCtoSession = useCallback(async () => {
-    if (!window.ade?.cto || !laneId || showOnboarding || needsOnboarding) {
+    if (!window.ade?.cto || !primaryLaneId || showOnboarding || needsOnboarding) {
       return null;
     }
-    const next = await window.ade.cto.ensureSession({ laneId });
+    const next = await window.ade.cto.ensureSession();
     if (!selectedAgentId) {
       setSession(next);
     }
     return next;
-  }, [laneId, needsOnboarding, selectedAgentId, showOnboarding]);
+  }, [needsOnboarding, primaryLaneId, selectedAgentId, showOnboarding]);
 
   const handleSaveCoreMemory = useCallback(async (patch: Record<string, unknown>) => {
     if (!window.ade?.cto) throw new Error("CTO bridge unavailable.");
@@ -682,9 +679,9 @@ export function CtoPage() {
           <div className={cn("h-full min-h-0 flex-col p-4 pt-0", activeTab === "chat" ? "flex" : "hidden")}>
             {loading && <div className="px-1 py-2 text-xs text-muted-fg/55" data-testid="cto-loading">Connecting persistent session...</div>}
             {error && <div className="px-1 py-2 text-xs text-error" data-testid="cto-error">{error}</div>}
-            {!laneId && (
+            {!primaryLaneId && (
               <div className="px-1 py-2 text-xs text-muted-fg/55" data-testid="cto-no-lane">
-                Create a lane to start the persistent CTO session.
+                ADE could not resolve the primary workspace for the persistent CTO session.
               </div>
             )}
 
@@ -717,10 +714,12 @@ export function CtoPage() {
                 </div>
               ) : (
                 <AgentChatPane
-                  laneId={laneId}
+                  laneId={primaryLaneId}
                   lockSessionId={session?.id ?? null}
                   initialSessionSummary={lockedSessionSummary}
                   hideSessionTabs
+                  hideNativeControls
+                  hideWorkspaceChrome
                   presentation={persistentIdentityPresentation}
                 />
               )}
@@ -863,7 +862,7 @@ export function CtoPage() {
           {/* Linear tab */}
           {activeTab === "workflows" && (
             <div data-tour="cto.linearPanel" className="h-full min-h-0">
-              <LinearSyncPanel lanes={lanes} selectedLaneId={laneId} />
+              <LinearSyncPanel lanes={lanes} selectedLaneId={primaryLaneId} />
             </div>
           )}
 

--- a/apps/desktop/src/renderer/components/cto/CtoPage.tsx
+++ b/apps/desktop/src/renderer/components/cto/CtoPage.tsx
@@ -681,7 +681,7 @@ export function CtoPage() {
             {error && <div className="px-1 py-2 text-xs text-error" data-testid="cto-error">{error}</div>}
             {!primaryLaneId && (
               <div className="px-1 py-2 text-xs text-muted-fg/55" data-testid="cto-no-lane">
-                ADE could not resolve the primary workspace for the persistent CTO session.
+                ADE could not resolve the primary lane for the persistent CTO session.
               </div>
             )}
 

--- a/apps/desktop/src/renderer/components/cto/ctoSessionViewState.test.ts
+++ b/apps/desktop/src/renderer/components/cto/ctoSessionViewState.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { resolveCtoPrimaryLaneId } from "./ctoSessionViewState";
+
+describe("resolveCtoPrimaryLaneId", () => {
+  it("prefers the primary lane even when another lane is selected elsewhere in the app", () => {
+    expect(resolveCtoPrimaryLaneId([
+      { id: "lane-feature", laneType: "worktree" },
+      { id: "lane-primary", laneType: "primary" },
+    ])).toBe("lane-primary");
+  });
+
+  it("falls back to the first lane when a primary lane has not been materialized yet", () => {
+    expect(resolveCtoPrimaryLaneId([
+      { id: "lane-feature", laneType: "worktree" },
+      { id: "lane-bugfix", laneType: "worktree" },
+    ])).toBe("lane-feature");
+  });
+
+  it("returns null when no lanes are available", () => {
+    expect(resolveCtoPrimaryLaneId([])).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/components/cto/ctoSessionViewState.ts
+++ b/apps/desktop/src/renderer/components/cto/ctoSessionViewState.ts
@@ -1,0 +1,3 @@
+export function resolveCtoPrimaryLaneId(lanes: Array<{ id: string; laneType?: string | null }>): string | null {
+  return lanes.find((lane) => lane.laneType === "primary")?.id ?? lanes[0]?.id ?? null;
+}

--- a/apps/desktop/src/shared/types/agents.ts
+++ b/apps/desktop/src/shared/types/agents.ts
@@ -337,10 +337,8 @@ export type CtoRollbackAgentRevisionArgs = {
 
 export type CtoEnsureAgentSessionArgs = {
   agentId: string;
-  laneId?: string | null;
   modelId?: ModelId | null;
   reasoningEffort?: string | null;
-  taskKey?: string | null;
 };
 
 export type CtoListAgentTaskSessionsArgs = {

--- a/apps/desktop/src/shared/types/cto.ts
+++ b/apps/desktop/src/shared/types/cto.ts
@@ -91,7 +91,6 @@ export type CtoGetStateArgs = {
 };
 
 export type CtoEnsureSessionArgs = {
-  laneId?: string | null;
   modelId?: ModelId | null;
   reasoningEffort?: string | null;
 };

--- a/apps/desktop/src/shared/types/sessions.ts
+++ b/apps/desktop/src/shared/types/sessions.ts
@@ -144,6 +144,12 @@ export type UpdateSessionMetaArgs = {
   toolType?: TerminalToolType | null;
   resumeCommand?: string | null;
   resumeMetadata?: TerminalResumeMetadata | null;
+  /**
+   * Migrate the session to a different lane. Used by identity sessions (CTO /
+   * worker) that must remain pinned to the canonical primary lane even if
+   * they were previously persisted against a foreign lane.
+   */
+  laneId?: string;
 };
 
 export type ReadTranscriptTailArgs = {


### PR DESCRIPTION
## Summary
- Extract `identitySessionPolicy` module and force `full-auto` permission mode + canonical lane for `cto` and `agent:*` identity sessions (ignoring foreign-lane requests).
- Update `ctoEnsureSession` / `ctoEnsureAgentSession` IPC and sync remote handlers to resolve the primary lane directly and hardcode `permissionMode: "full-auto"`.
- Add `ctoSessionViewState.resolveCtoPrimaryLaneId` helper and wire `CtoPage` / `AgentChatPane` / `AgentChatComposer` to hide native permission controls for fixed-mode surfaces.

## Test plan
- [x] `npx vitest run src/main/services/chat/identitySessionPolicy.test.ts src/renderer/components/cto/ctoSessionViewState.test.ts` (6 passed)
- [ ] CI: desktop sharded vitest + MCP tests
- [ ] Manual: ensure CTO chat opens on the primary lane even when a worktree lane is currently selected

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional hiding of native permission controls in the chat composer
  * Added optional hiding of workspace UI elements (toolbar, terminal, lane selector) in the chat pane

* **Bug Fixes**
  * CTO and agent sessions now correctly pinned to primary lane

* **Documentation**
  * Updated automation and phase execution command documentation

* **Tests**
  * Added test coverage for identity session policy validation and primary lane selection
  * Updated existing tests to reflect new lane pinning behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts an `identitySessionPolicy` module to enforce that `cto` and `agent:*` sessions are always pinned to the primary lane with `full-auto` permission mode, removing the old `lanes[0]` fallback across the IPC and sync command layers. It also adds a `resumeSession` migration path for pre-existing identity sessions on foreign lanes, blocks all native provider permission overrides for pinned identities (`claudePermissionMode`, `codexApprovalPolicy`, `codexSandbox`, `opencodePermissionMode`), and hides workspace chrome (toolbar, terminal, lane selector) and native permission controls on the CTO/agent chat surface.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style suggestions with no correctness impact.

The lane-pinning contract is enforced consistently across all three entry points (IPC, sync remote, agentChatService internal). The `updateMeta` DB write in the migration path is synchronous (`better-sqlite3`), so the delete + re-fetch pattern is correct without `await`. Native permission override stripping is applied at both create and update time. Test coverage is thorough: new unit tests cover pinned/non-pinned paths, malformed agent suffixes, foreign-lane fallback rejection, and override-stripping for both Claude and Codex providers. The only finding is a P2 suggestion to add an explanatory comment in `ctoSessionViewState.ts`.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/chat/identitySessionPolicy.ts | New module cleanly encapsulates pinned-identity rules; `isPrimaryPinnedIdentity` guards against empty/whitespace `agent:` suffixes, `normalizeIdentityPermissionMode` forces full-auto, and `resolveIdentityExecutionLane` pins to canonical lane. Well-covered by tests. |
| apps/desktop/src/main/services/chat/agentChatService.ts | Comprehensive changes: `resolvePrimaryIdentityLane` drops `lanes[0]` fallback, `createSession` strips native provider permission overrides for pinned identities, `updateSession` guards each native field behind `!identityPinned`, and `resumeSession` migrates foreign-lane sessions synchronously via `updateMeta` (which is correctly synchronous). |
| apps/desktop/src/main/services/ipc/registerIpc.ts | `resolveFirstAvailableLaneId` replaced with strict `resolvePrimaryLaneIdOnly`; `permissionMode: "full-auto"` added to both `ctoEnsureSession` and `ctoEnsureAgentSession` handlers; `laneId` arg removed from IPC calls, consistent with type changes. |
| apps/desktop/src/main/services/sync/syncRemoteCommandService.ts | Mirrors registerIpc changes: strict primary-lane resolver, `permissionMode: "full-auto"` hardcoded. New tests cover lane override ignored, `lanes[0]` fallback rejected, and missing primary-lane error paths. |
| apps/desktop/src/main/services/sessions/sessionService.ts | Adds `laneId` migration support to synchronous `updateMeta`; guarded by non-empty trim check, consistent with other string fields in the same function. |
| apps/desktop/src/renderer/components/cto/ctoSessionViewState.ts | One-line helper that retains a `lanes[0]` fallback for UI display purposes, intentionally diverging from the strict backend resolver; documented by tests but could benefit from an inline comment to explain the asymmetry. |
| apps/desktop/src/renderer/components/cto/CtoPage.tsx | Replaces `selectedLaneId`-based lane resolution with `resolveCtoPrimaryLaneId`; removes `laneId` from `ensureSession`/`ensureAgentSession` IPC calls; adds `hideNativeControls` + `hideWorkspaceChrome` to `AgentChatPane`. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | New `hideNativeControls` and `hideWorkspaceChrome` props correctly gate toolbar, terminal toggle, terminal drawer, and lane selector; `showWorkspaceChrome` boolean derived once and applied consistently. |
| apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx | Adds `hideNativeControls` prop; short-circuits `nativeControlPanel` memo to `null` when set; `hideNativeControls` correctly added to the memo dependency array. |
| apps/desktop/src/shared/types/agents.ts | Removes `laneId` and `taskKey` from `CtoEnsureAgentSessionArgs` — correct since the backend now always resolves the primary lane and ignores any caller-supplied override. |
| apps/desktop/src/shared/types/sessions.ts | Adds `laneId?: string` to `UpdateSessionMetaArgs` with a clear JSDoc comment explaining the migration use-case. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CtoPage / AgentChatComposer] -->|ensureSession / ensureAgentSession\nno laneId arg| B[IPC: registerIpc\nresolvePrimaryLaneIdOnly]
    A2[Sync remote command] -->|cto.ensureSession\ncto.ensureAgentSession| B2[syncRemoteCommandService\nresolvePrimaryLaneIdOnlyForSync]
    B --> C{Primary lane\nfound?}
    B2 --> C
    C -->|No| ERR[Throw: No primary lane available]
    C -->|Yes laneId| D[agentChatService.ensureIdentitySession\npermissionMode: full-auto]
    D --> E{Existing canonical\nsession found?}
    E -->|Yes| F[normalizeIdentityPermissionMode\nidentityKey + provider → full-auto]
    E -->|No| G[createSession\nisPrimaryPinnedIdentity?\nStrip native overrides\neffectivePermissionMode=full-auto]
    F --> H[Return pinned session]
    G --> H

    R[resumeSession] --> RI{isPrimaryPinnedIdentity\n+ foreign laneId?}
    RI -->|Yes| RM[resolvePrimaryIdentityLane\nupdateMeta laneId\nre-fetch managed session]
    RI -->|No| RR[Resume as-is]
    RM --> RR

    subgraph identitySessionPolicy
        IP[isPrimaryPinnedIdentity\ncto / agent:suffix]
        NP[normalizeIdentityPermissionMode\npinned → full-auto\nnon-pinned → plan]
        RL[resolveIdentityExecutionLane\npinned → canonicalLaneId\nothers → trimmed request]
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fcto%2FctoSessionViewState.ts%3A2%0A**Frontend%20lane%20resolver%20diverges%20from%20backend's%20strict%20primary-lane%20contract**%0A%0A%60resolveCtoPrimaryLaneId%60%20falls%20back%20to%20%60lanes%5B0%5D%60%20when%20no%20primary%20lane%20exists.%20The%20backend%20%28%60resolvePrimaryIdentityLane%60%20in%20%60agentChatService%60%20and%20%60resolvePrimaryLaneIdOnly%60%20in%20%60registerIpc%60%2F%60syncRemoteCommandService%60%29%20explicitly%20removed%20the%20same%20fallback%20and%20throws%20when%20no%20primary%20lane%20is%20found.%20When%20only%20non-primary%20lanes%20are%20present%2C%20%60primaryLaneId%60%20will%20be%20non-null%20%28set%20to%20%60lanes%5B0%5D%60%29%2C%20causing%20%60CtoPage%60%20to%20skip%20the%20%22ADE%20could%20not%20resolve%20the%20primary%20lane%22%20message%2C%20call%20%60ensureSession%28%29%60%2C%20and%20surface%20a%20raw%20backend%20error%20instead.%20The%20test%20documents%20this%20as%20intentional%20%28%22when%20a%20primary%20lane%20has%20not%20been%20materialized%20yet%22%29%2C%20but%20a%20brief%20inline%20comment%20here%20would%20make%20the%20deliberate%20asymmetry%20clear%20to%20future%20readers.%0A%0A%60%60%60suggestion%0Aexport%20function%20resolveCtoPrimaryLaneId%28lanes%3A%20Array%3C%7B%20id%3A%20string%3B%20laneType%3F%3A%20string%20%7C%20null%20%7D%3E%29%3A%20string%20%7C%20null%20%7B%0A%20%20%2F%2F%20Prefer%20the%20primary%20lane.%20Falls%20back%20to%20lanes%5B0%5D%20only%20as%20a%20UI%20display%0A%20%20%2F%2F%20best-effort%20during%20initial%20setup%20%E2%80%94%20the%20backend%20will%20still%20reject%20session%0A%20%20%2F%2F%20creation%20unless%20a%20true%20primary%20lane%20exists.%0A%20%20return%20lanes.find%28%28lane%29%20%3D%3E%20lane.laneType%20%3D%3D%3D%20%22primary%22%29%3F.id%20%3F%3F%20lanes%5B0%5D%3F.id%20%3F%3F%20null%3B%0A%7D%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=179&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/cto/ctoSessionViewState.ts
Line: 2

Comment:
**Frontend lane resolver diverges from backend's strict primary-lane contract**

`resolveCtoPrimaryLaneId` falls back to `lanes[0]` when no primary lane exists. The backend (`resolvePrimaryIdentityLane` in `agentChatService` and `resolvePrimaryLaneIdOnly` in `registerIpc`/`syncRemoteCommandService`) explicitly removed the same fallback and throws when no primary lane is found. When only non-primary lanes are present, `primaryLaneId` will be non-null (set to `lanes[0]`), causing `CtoPage` to skip the "ADE could not resolve the primary lane" message, call `ensureSession()`, and surface a raw backend error instead. The test documents this as intentional ("when a primary lane has not been materialized yet"), but a brief inline comment here would make the deliberate asymmetry clear to future readers.

```suggestion
export function resolveCtoPrimaryLaneId(lanes: Array<{ id: string; laneType?: string | null }>): string | null {
  // Prefer the primary lane. Falls back to lanes[0] only as a UI display
  // best-effort during initial setup — the backend will still reject session
  // creation unless a true primary lane exists.
  return lanes.find((lane) => lane.laneType === "primary")?.id ?? lanes[0]?.id ?? null;
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["ship: iteration 3 — address copilot foll..."](https://github.com/arul28/ade/commit/cba27202dd79242b59889de4fc022b1716b0f5f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29501236)</sub>

<!-- /greptile_comment -->