### PR TITLE
Rebase tab overhaul: rename + URL routing migration

### DIFF
--- a/.claude/commands/finalize.md
+++ b/.claude/commands/finalize.md
@@ -12,6 +12,12 @@ It guarantees three outcomes:
 2. Docs are current
 3. Local CI checks pass
 
+It does **not** guarantee that remote PR review is complete after a push. GitHub's
+first visible check list can look quiet before delayed checks, bot reviews, and
+inline comments arrive. After pushing a finalized branch, hand off to
+`/shipLane` or an equivalent PR poll loop and honor the 12-minute CI-running poll
+window before concluding there are no more incoming comments.
+
 **Usage:** `/finalize`
 
 ## Execution Mode: Autonomous
@@ -412,6 +418,31 @@ Kill selectively only if the parent is clearly gone (PPID == 1 on macOS/Linux).
 
 Report killed PIDs in the Phase 4 summary under "Cleanup" so the user can see what happened.
 
+### 3k. Remote PR poll handoff
+
+If this finalize run is followed by a push or PR update, do not treat the first
+`gh pr checks` result as authoritative proof that remote review is done. Some
+checks and bot review systems appear late or post comments after the initial CI
+surface looks complete. In particular:
+
+- `gh pr checks` can omit delayed or still-registering provider checks.
+- Bot reviewers can post inline comments after CI jobs have already gone green.
+- The absence of new comments immediately after a push is not evidence that no
+  more comments are coming.
+
+Handoff rule:
+
+```bash
+# After the branch is pushed, continue with /shipLane or equivalent:
+# - poll PR checks, status rollup, review comments, issue comments, and reviews
+# - if any check is QUEUED/IN_PROGRESS/PENDING, wait the 12-minute poll window
+# - poll again before declaring the PR clean or ready for human merge
+```
+
+If `/finalize` is running as a sub-step inside `/shipLane`, return a summary that
+explicitly says remote checks/comments still require the ship-lane poll loop.
+Do not report "PR clean" from `/finalize` alone.
+
 ---
 
 ## Phase 4: Summary
@@ -447,6 +478,11 @@ Report killed PIDs in the Phase 4 summary under "Cleanup" so the user can see wh
 ### Cleanup:
 - Orphan processes killed: N (PIDs: [list] or "none")
 
+### Remote PR Handoff:
+- Post-push polling required: YES
+- Poll loop: `/shipLane` / 12-minute CI-running window
+- Reason: delayed checks and bot comments may arrive after first visible green state
+
 ### Status: Ready to push / Issues found
 ```
 
@@ -466,3 +502,4 @@ Before marking complete:
 - [ ] All apps build successfully
 - [ ] Doc validation passed
 - [ ] Orphan worker processes cleaned up (vitest/tsup/tsc) — scoped to apps/ paths only
+- [ ] Remote PR review is not declared clean by finalize alone; after push, `/shipLane` or an equivalent poll loop must wait the 12-minute CI-running window and re-check comments/reviews

--- a/.claude/commands/finalize.md
+++ b/.claude/commands/finalize.md
@@ -15,8 +15,10 @@ It guarantees three outcomes:
 It does **not** guarantee that remote PR review is complete after a push. GitHub's
 first visible check list can look quiet before delayed checks, bot reviews, and
 inline comments arrive. After pushing a finalized branch, hand off to
-`/shipLane` or an equivalent PR poll loop and honor the 12-minute CI-running poll
-window before concluding there are no more incoming comments.
+`/shipLane` or an equivalent PR poll loop. Use the ship-lane cadence: poll
+immediately after a push, wait 270s if CI has not registered, wait 720s while CI
+is running, and wait 1800s only when CI is done and the PR is just waiting on
+review.
 
 **Usage:** `/finalize`
 
@@ -435,7 +437,10 @@ Handoff rule:
 ```bash
 # After the branch is pushed, continue with /shipLane or equivalent:
 # - poll PR checks, status rollup, review comments, issue comments, and reviews
-# - if any check is QUEUED/IN_PROGRESS/PENDING, wait the 12-minute poll window
+# - poll immediately after a push so early CI registration/failures are visible
+# - if CI has not started yet, wait 270s
+# - if any check is QUEUED/IN_PROGRESS/PENDING, wait 720s
+# - if CI is done and the PR is only waiting on review, wait 1800s
 # - poll again before declaring the PR clean or ready for human merge
 ```
 
@@ -480,7 +485,7 @@ Do not report "PR clean" from `/finalize` alone.
 
 ### Remote PR Handoff:
 - Post-push polling required: YES
-- Poll loop: `/shipLane` / 12-minute CI-running window
+- Poll loop: `/shipLane` branch-specific cadence
 - Reason: delayed checks and bot comments may arrive after first visible green state
 
 ### Status: Ready to push / Issues found
@@ -502,4 +507,4 @@ Before marking complete:
 - [ ] All apps build successfully
 - [ ] Doc validation passed
 - [ ] Orphan worker processes cleaned up (vitest/tsup/tsc) — scoped to apps/ paths only
-- [ ] Remote PR review is not declared clean by finalize alone; after push, `/shipLane` or an equivalent poll loop must wait the 12-minute CI-running window and re-check comments/reviews
+- [ ] Remote PR review is not declared clean by finalize alone; after push, `/shipLane` or an equivalent poll loop must use the branch-specific cadence and re-check comments/reviews

--- a/apps/desktop/src/main/services/lanes/autoRebaseService.ts
+++ b/apps/desktop/src/main/services/lanes/autoRebaseService.ts
@@ -112,17 +112,17 @@ function blockedMessage(
   laneId: string | null,
   reason: "conflict" | "manual" | "lookup" | "failed" | "unavailable" | null,
 ): string {
-  if (!laneId) return "Pending: auto-rebase stopped at an earlier lane. Open the Rebase tab to continue.";
+  if (!laneId) return "Pending: auto-rebase stopped at an earlier lane. Open the Rebase/Merge tab to continue.";
   if (reason === "manual") {
-    return `Pending: ancestor lane '${laneId}' has a fixed PR base. Rebase that lane manually from the Rebase tab before descendants can continue.`;
+    return `Pending: ancestor lane '${laneId}' has a fixed PR base. Rebase that lane manually from the Rebase/Merge tab before descendants can continue.`;
   }
   if (reason === "lookup" || reason === "unavailable") {
-    return `Pending: ancestor lane '${laneId}' needs review before descendants can continue. Open the Rebase tab to inspect it.`;
+    return `Pending: ancestor lane '${laneId}' needs review before descendants can continue. Open the Rebase/Merge tab to inspect it.`;
   }
   if (reason === "failed") {
-    return `Pending: ancestor lane '${laneId}' failed automatic rebase. Open the Rebase tab to retry.`;
+    return `Pending: ancestor lane '${laneId}' failed automatic rebase. Open the Rebase/Merge tab to retry.`;
   }
-  return `Pending: ancestor lane '${laneId}' has unresolved rebase conflicts. Open the Rebase tab to continue.`;
+  return `Pending: ancestor lane '${laneId}' has unresolved rebase conflicts. Open the Rebase/Merge tab to continue.`;
 }
 
 function resolveAffectedChainLaneId(
@@ -459,7 +459,7 @@ export function createAutoRebaseService(args: {
             parentHeadSha: null,
             state: "rebasePending",
             conflictCount: 0,
-            message: "Pending: parent lane is unavailable. Open the Rebase tab to review the lane."
+            message: "Pending: parent lane is unavailable. Open the Rebase/Merge tab to review the lane."
           });
           blocked = true;
           blockedLaneId = lane.id;
@@ -522,7 +522,7 @@ export function createAutoRebaseService(args: {
           parentHeadSha,
           state: "rebaseConflict",
           conflictCount: Math.max(1, need.conflictingFiles.length),
-          message: `Auto-rebase blocked: ${Math.max(1, need.conflictingFiles.length)} conflict(s) expected. Open the Rebase tab to resolve and publish.`
+          message: `Auto-rebase blocked: ${Math.max(1, need.conflictingFiles.length)} conflict(s) expected. Open the Rebase/Merge tab to resolve and publish.`
         });
         continue;
       }
@@ -541,7 +541,7 @@ export function createAutoRebaseService(args: {
           parentHeadSha,
           state: "rebasePending",
           conflictCount: 0,
-          message: "PR carries an immutable base — drift detected. Rebase manually from the Rebase tab when ready."
+          message: "PR carries an immutable base — drift detected. Rebase manually from the Rebase/Merge tab when ready."
         });
         continue;
       }
@@ -572,8 +572,8 @@ export function createAutoRebaseService(args: {
           state: conflictHint ? "rebaseConflict" : "rebaseFailed",
           conflictCount: conflictHint ? 1 : 0,
           message: conflictHint
-            ? "Auto-rebase stopped due to conflicts. Open the Rebase tab to resolve, then publish."
-            : `Auto-rebase failed: ${rebaseRun.run.error}. Open the Rebase tab to retry.`
+            ? "Auto-rebase stopped due to conflicts. Open the Rebase/Merge tab to resolve, then publish."
+            : `Auto-rebase failed: ${rebaseRun.run.error}. Open the Rebase/Merge tab to retry.`
         });
         continue;
       }
@@ -625,8 +625,8 @@ export function createAutoRebaseService(args: {
           state: "rebaseFailed",
           conflictCount: 0,
           message: rollbackError
-            ? `Auto-push failed: ${pushError}. Automatic rollback also failed: ${rollbackError}. Open the Rebase tab to retry.`
-            : `Auto-push failed: ${pushError}. The lane was restored to its pre-rebase state. Open the Rebase tab to retry.`
+            ? `Auto-push failed: ${pushError}. Automatic rollback also failed: ${rollbackError}. Open the Rebase/Merge tab to retry.`
+            : `Auto-push failed: ${pushError}. The lane was restored to its pre-rebase state. Open the Rebase/Merge tab to retry.`
         });
       }
     }

--- a/apps/desktop/src/main/services/prs/prRebaseResolver.test.ts
+++ b/apps/desktop/src/main/services/prs/prRebaseResolver.test.ts
@@ -141,10 +141,10 @@ describe("launchRebaseResolutionChat", () => {
     expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: "session-rebase-1",
-        displayText: "Rebase feature/rebase-target onto main",
         reasoningEffort: "high",
       }),
     );
+    expect(sendMessage.mock.calls[0]?.[0]).not.toHaveProperty("displayText");
     expect(result).toEqual({
       sessionId: "session-rebase-1",
       laneId: lane.id,

--- a/apps/desktop/src/main/services/prs/prRebaseResolver.test.ts
+++ b/apps/desktop/src/main/services/prs/prRebaseResolver.test.ts
@@ -142,9 +142,9 @@ describe("launchRebaseResolutionChat", () => {
       expect.objectContaining({
         sessionId: "session-rebase-1",
         reasoningEffort: "high",
+        displayText: "Rebase feature/rebase-target onto main",
       }),
     );
-    expect(sendMessage.mock.calls[0]?.[0]).not.toHaveProperty("displayText");
     expect(result).toEqual({
       sessionId: "session-rebase-1",
       laneId: lane.id,

--- a/apps/desktop/src/main/services/prs/prRebaseResolver.ts
+++ b/apps/desktop/src/main/services/prs/prRebaseResolver.ts
@@ -158,6 +158,11 @@ export async function launchRebaseResolutionChat(
   await deps.agentChatService.sendMessage({
     sessionId: session.id,
     text: prompt,
+    // Show the short human-readable title in the transcript instead of the
+    // full composed prompt (which is long and technical). Mirrors
+    // prIssueResolver's pattern; agentChatService falls back to `text` when
+    // displayText is absent, which would surface the raw prompt to the user.
+    displayText: title,
     ...(reasoningEffort ? { reasoningEffort } : {}),
   });
 

--- a/apps/desktop/src/main/services/prs/prRebaseResolver.ts
+++ b/apps/desktop/src/main/services/prs/prRebaseResolver.ts
@@ -158,7 +158,6 @@ export async function launchRebaseResolutionChat(
   await deps.agentChatService.sendMessage({
     sessionId: session.id,
     text: prompt,
-    displayText: title,
     ...(reasoningEffort ? { reasoningEffort } : {}),
   });
 

--- a/apps/desktop/src/main/services/prs/prService.ts
+++ b/apps/desktop/src/main/services/prs/prService.ts
@@ -871,7 +871,7 @@ export function createPrService({
           parentHeadSha: null,
           state: "rebaseFailed",
           conflictCount: 0,
-          message: `Auto-rebase failed after '${args.landedLaneName}' merged because ADE could not find a new parent lane. Open the Rebase tab to recover this lane.`,
+          message: `Auto-rebase failed after '${args.landedLaneName}' merged because ADE could not find a new parent lane. Open the Rebase/Merge tab to recover this lane.`,
         }, child.id);
       }
       return {
@@ -979,8 +979,8 @@ export function createPrService({
           state: "rebaseFailed",
           conflictCount: 0,
           message: rollbackError
-            ? `Auto-rebase failed after '${args.landedLaneName}' merged: ${childError}. Automatic rollback also failed: ${rollbackError}. Open the Rebase tab to recover this lane.`
-            : `Auto-rebase failed after '${args.landedLaneName}' merged: ${childError}. The lane was restored to its pre-rebase state. Open the Rebase tab to recover this lane.`,
+            ? `Auto-rebase failed after '${args.landedLaneName}' merged: ${childError}. Automatic rollback also failed: ${rollbackError}. Open the Rebase/Merge tab to recover this lane.`
+            : `Auto-rebase failed after '${args.landedLaneName}' merged: ${childError}. The lane was restored to its pre-rebase state. Open the Rebase/Merge tab to recover this lane.`,
         }, child.id);
         failedLaneIds.push(child.id);
       }

--- a/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.test.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.test.tsx
@@ -328,7 +328,7 @@ describe("LaneGitActionsPane rescue action", () => {
     expect(syncButton.getAttribute("title")).toMatch(/before rebasing and pushing/i);
   });
 
-  it("treats auto-rebase conflicts as failures and links to the Rebase tab", async () => {
+  it("treats auto-rebase conflicts as failures and links to the Rebase/Merge tab", async () => {
     const user = userEvent.setup();
     const resolveRebaseConflict = vi.fn();
     mockAutoRebaseStatuses = [
@@ -345,7 +345,7 @@ describe("LaneGitActionsPane rescue action", () => {
 
     renderPane({ onResolveRebaseConflict: resolveRebaseConflict });
 
-    const rebaseTabButton = await screen.findByRole("button", { name: /open rebase tab/i });
+    const rebaseTabButton = await screen.findByRole("button", { name: /open rebase\/merge tab/i });
     screen.getByText("AUTO-REBASE FAILED");
     screen.getByText(/auto-rebase failed\. files need follow-up before this lane can be pushed\./i);
 

--- a/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx
@@ -1571,7 +1571,7 @@ export function LaneGitActionsPane({
             {autoRebaseStatus.state !== "autoRebased" ? (
               isAutoRebaseFailure ? (
                 <SmartTooltip content={{
-                  label: "Open Rebase/Merge tab",
+                  label: "Open Rebase/Merge Tab",
                   description: "View detailed rebase information and resolve issues.",
                   effect: "Navigate to the rebase details view",
                 }}>

--- a/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx
@@ -1546,7 +1546,7 @@ export function LaneGitActionsPane({
             onResolveRebaseConflict(laneId, rebaseConflictParentLaneId);
             return;
           }
-          const search = new URLSearchParams({ tab: "rebase", laneId });
+          const search = new URLSearchParams({ tab: "workflows", workflow: "rebase", laneId });
           if (rebaseConflictParentLaneId) search.set("parentLaneId", rebaseConflictParentLaneId);
           navigate(`/prs?${search.toString()}`);
         };
@@ -1571,8 +1571,8 @@ export function LaneGitActionsPane({
             {autoRebaseStatus.state !== "autoRebased" ? (
               isAutoRebaseFailure ? (
                 <SmartTooltip content={{
-                  label: "Open Rebase Tab",
-                  description: "View detailed rebase conflict information and resolve issues.",
+                  label: "Open Rebase/Merge tab",
+                  description: "View detailed rebase information and resolve issues.",
                   effect: "Navigate to the rebase details view",
                 }}>
                   <button
@@ -1581,7 +1581,7 @@ export function LaneGitActionsPane({
                     disabled={!laneId || busyAction != null}
                     onClick={openRebaseTab}
                   >
-                    OPEN REBASE TAB
+                    OPEN REBASE/MERGE TAB
                   </button>
                 </SmartTooltip>
               ) : (

--- a/apps/desktop/src/renderer/components/lanes/LaneRebaseBanner.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneRebaseBanner.tsx
@@ -50,13 +50,13 @@ export function LaneRebaseBanner({
                     </div>
                   </div>
                   <div className="flex shrink-0 flex-wrap items-center gap-1.5">
-                    <SmartTooltip content={{ label: "View in Rebase tab", description: "Open the Rebase tab for this lane." }}>
+                    <SmartTooltip content={{ label: "View in Rebase/Merge tab", description: "Open the Rebase/Merge tab for this lane." }}>
                       <button
                         type="button"
                         style={primaryButton({ height: 24, padding: "0 8px", fontSize: 10 })}
                         onClick={() => onViewRebaseDetails(s.laneId)}
                       >
-                        View in Rebase tab
+                        View in Rebase/Merge tab
                       </button>
                     </SmartTooltip>
                     <SmartTooltip content={{ label: "Dismiss", description: "Remove this rebase suggestion permanently until new parent commits arrive." }}>
@@ -120,13 +120,13 @@ export function LaneRebaseBanner({
                     </div>
                   </div>
                   <div className="shrink-0 flex items-center gap-1.5">
-                    <SmartTooltip content={{ label: "View in Rebase tab", description: "Open the Rebase tab for this lane." }}>
+                    <SmartTooltip content={{ label: "View in Rebase/Merge tab", description: "Open the Rebase/Merge tab for this lane." }}>
                       <button
                         type="button"
                         style={primaryButton({ height: 24, padding: "0 8px", fontSize: 10 })}
                         onClick={() => onViewRebaseDetails(status.laneId)}
                       >
-                        View in Rebase tab
+                        View in Rebase/Merge tab
                       </button>
                     </SmartTooltip>
                     <SmartTooltip content={{ label: "Dismiss", description: "Hide this alert until the parent or base changes again." }}>

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -1101,7 +1101,7 @@ export function LanesPage() {
         const failedLane = start.run.failedLaneId ? lanesById.get(start.run.failedLaneId)?.name ?? start.run.failedLaneId : null;
         const detail = start.run.error ?? "Rebase failed.";
         setRebaseSuggestionError(`Rebase needs attention${failedLane ? ` for ${failedLane}` : ""}. ${detail}`);
-        navigate("/prs?tab=rebase");
+        navigate("/prs?tab=workflows&workflow=rebase");
         return;
       }
 
@@ -1121,7 +1121,7 @@ export function LanesPage() {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setRebaseSuggestionError(message);
-      navigate("/prs?tab=rebase");
+      navigate("/prs?tab=workflows&workflow=rebase");
     }
   }, [lanesById, navigate, refreshLanes, requestPushSelection, requestRebaseScope]);
 

--- a/apps/desktop/src/renderer/components/prs/CreatePrModal.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/CreatePrModal.test.tsx
@@ -4,7 +4,12 @@ import React from "react";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
 import type { LaneSummary } from "../../../shared/types";
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 function makeLane(overrides: Partial<LaneSummary> = {}): LaneSummary {
   return {
@@ -117,7 +122,7 @@ describe("CreatePrModal queue workflow", () => {
 
   it("adds selected lanes to the queue order and removes them from the queue builder", async () => {
     const user = userEvent.setup();
-    render(<CreatePrModal open onOpenChange={vi.fn()} />);
+    renderWithRouter(<CreatePrModal open onOpenChange={vi.fn()} />);
 
     await user.click(screen.getAllByRole("button", { name: /queue workflow/i })[0]!);
     await user.click(screen.getByRole("checkbox", { name: /01 queue lane/i }));
@@ -136,7 +141,7 @@ describe("CreatePrModal queue workflow", () => {
 
   it("uses the dragged queue order when creating queue PRs", async () => {
     const user = userEvent.setup();
-    render(<CreatePrModal open onOpenChange={vi.fn()} />);
+    renderWithRouter(<CreatePrModal open onOpenChange={vi.fn()} />);
 
     await user.click(screen.getAllByRole("button", { name: /queue workflow/i })[0]!);
     await user.click(screen.getByRole("checkbox", { name: /01 queue lane/i }));
@@ -165,7 +170,7 @@ describe("CreatePrModal queue workflow", () => {
 
   it("lets single-PR creation target a different branch than Primary's current branch", async () => {
     const user = userEvent.setup();
-    render(<CreatePrModal open onOpenChange={vi.fn()} />);
+    renderWithRouter(<CreatePrModal open onOpenChange={vi.fn()} />);
 
     // Select source lane
     const comboboxes = screen.getAllByRole("combobox");
@@ -191,7 +196,7 @@ describe("CreatePrModal queue workflow", () => {
 
   it("warns when the PR target branch differs from the lane base branch", async () => {
     const user = userEvent.setup();
-    render(<CreatePrModal open onOpenChange={vi.fn()} />);
+    renderWithRouter(<CreatePrModal open onOpenChange={vi.fn()} />);
 
     // Select source lane
     const comboboxes = screen.getAllByRole("combobox");
@@ -210,7 +215,7 @@ describe("CreatePrModal queue workflow", () => {
 
   it("lets queue creation target a different branch than Primary's current branch", async () => {
     const user = userEvent.setup();
-    render(<CreatePrModal open onOpenChange={vi.fn()} />);
+    renderWithRouter(<CreatePrModal open onOpenChange={vi.fn()} />);
 
     await user.click(screen.getAllByRole("button", { name: /queue workflow/i })[0]!);
     await user.click(screen.getByRole("checkbox", { name: /01 queue lane/i }));

--- a/apps/desktop/src/renderer/components/prs/CreatePrModal.tsx
+++ b/apps/desktop/src/renderer/components/prs/CreatePrModal.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import * as Dialog from "@radix-ui/react-dialog";
 import { GitPullRequest, GitMerge, Stack as Layers, CheckCircle, Warning, CircleNotch, X, GitBranch, Sparkle, ArrowRight, ArrowLeft, Check, DotsSixVertical, Trash, ArrowUp, ArrowDown } from "@phosphor-icons/react";
 import { useAppStore } from "../../state/appStore";
@@ -446,7 +447,7 @@ function LaneWarningPanel({
                   cursor: "pointer",
                 }}
               >
-                Open Rebase Tab
+                Open Rebase/Merge Tab
               </button>
               <span style={{ fontSize: 10, color: C.textMuted, fontFamily: MONO_FONT }}>
                 Review rebase status before PR creation{rebaseLaneIds.length > 1 ? ` (${rebaseLaneIds.length} lanes)` : ""}.
@@ -470,6 +471,7 @@ export function CreatePrModal({
   onOpenChange: (open: boolean) => void;
   onCreated?: (created: PrSummary[]) => void | Promise<void>;
 }) {
+  const navigate = useNavigate();
   const lanes = useAppStore((s) => s.lanes);
   const primaryLane = React.useMemo(() => lanes.find((l) => l.laneType === "primary") ?? null, [lanes]);
 
@@ -596,8 +598,9 @@ export function CreatePrModal({
 
   const openRebaseTab = React.useCallback((laneId: string) => {
     onOpenChange(false);
-    window.location.hash = `#/prs?tab=rebase&laneId=${encodeURIComponent(laneId)}`;
-  }, [onOpenChange]);
+    const search = new URLSearchParams({ tab: "workflows", workflow: "rebase", laneId });
+    navigate({ pathname: "/prs", search: `?${search.toString()}` });
+  }, [navigate, onOpenChange]);
 
   // Reset on close
   React.useEffect(() => {

--- a/apps/desktop/src/renderer/components/prs/CreatePrModal.tsx
+++ b/apps/desktop/src/renderer/components/prs/CreatePrModal.tsx
@@ -447,7 +447,7 @@ function LaneWarningPanel({
                   cursor: "pointer",
                 }}
               >
-                Open Rebase/Merge Tab
+                Open Rebase/Merge tab
               </button>
               <span style={{ fontSize: 10, color: C.textMuted, fontFamily: MONO_FONT }}>
                 Review rebase status before PR creation{rebaseLaneIds.length > 1 ? ` (${rebaseLaneIds.length} lanes)` : ""}.

--- a/apps/desktop/src/renderer/components/prs/PRsPage.tsx
+++ b/apps/desktop/src/renderer/components/prs/PRsPage.tsx
@@ -92,7 +92,7 @@ function PRsPageInner() {
 
         setActiveTab(resolved.activeTab);
 
-        if (!resolved.isWorkflowRoute && (routeState.tab === "normal" || routeState.tab === "github")) {
+        if (!resolved.isWorkflowRoute) {
           setSelectedPrId(routeState.prId ?? null);
         }
         if (resolved.effectiveWorkflow === "queue") {

--- a/apps/desktop/src/renderer/components/prs/PRsPage.tsx
+++ b/apps/desktop/src/renderer/components/prs/PRsPage.tsx
@@ -11,7 +11,7 @@ import { GitHubTab } from "./tabs/GitHubTab";
 import { WorkflowsTab, type WorkflowCategory } from "./tabs/WorkflowsTab";
 import { SANS_FONT } from "../lanes/laneDesignTokens";
 import { isMissionLaneHiddenByDefault } from "../lanes/laneUtils";
-import { buildPrsRouteSearch, parsePrsRouteState } from "./prsRouteState";
+import { buildPrsRouteSearch, parsePrsRouteState, resolvePrsActiveTab } from "./prsRouteState";
 import { resolveRouteRebaseSelection } from "./shared/rebaseNeedUtils";
 import type { PrSummary } from "../../../shared/types";
 
@@ -84,31 +84,21 @@ function PRsPageInner() {
           search: location.search,
           hash: window.location.hash,
         });
-        const tab = routeState.tab;
-        const workflowTab = routeState.workflowTab;
+        const resolved = resolvePrsActiveTab(routeState);
         const routeRebaseItemId = resolveRouteRebaseSelection({
           rebaseNeeds,
           routeItemId: routeState.laneId,
         });
 
-        if (tab === "github" || tab === "normal") {
-          setActiveTab("normal");
-        } else if (tab === "workflows") {
-          const nextWorkflowTab = workflowTab === "queue" || workflowTab === "integration" || workflowTab === "rebase"
-            ? workflowTab
-            : "integration";
-          setActiveTab(nextWorkflowTab);
-        } else if (tab === "queue" || tab === "integration" || tab === "rebase") {
-          setActiveTab(tab);
-        }
+        setActiveTab(resolved.activeTab);
 
-        if (tab === "normal" || tab === "github") {
+        if (!resolved.isWorkflowRoute && (routeState.tab === "normal" || routeState.tab === "github")) {
           setSelectedPrId(routeState.prId ?? null);
         }
-        if (tab === "queue" || workflowTab === "queue") {
+        if (resolved.effectiveWorkflow === "queue") {
           setSelectedQueueGroupId(routeState.queueGroupId ?? null);
         }
-        if (tab === "rebase" || workflowTab === "rebase") {
+        if (resolved.effectiveWorkflow === "rebase") {
           setSelectedRebaseItemId(routeRebaseItemId);
         }
       } catch {

--- a/apps/desktop/src/renderer/components/prs/prsRouteState.test.ts
+++ b/apps/desktop/src/renderer/components/prs/prsRouteState.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildPrsRouteSearch, parsePrsRouteState } from "./prsRouteState";
+import { buildPrsRouteSearch, parsePrsRouteState, resolvePrsActiveTab } from "./prsRouteState";
 
 describe("prsRouteState", () => {
   it("parses route state from search params and falls back to hash params when needed", () => {
@@ -96,5 +96,48 @@ describe("prsRouteState", () => {
         selectedRebaseItemId: "lane-456",
       }),
     ).toBe("?tab=workflows&workflow=rebase&laneId=lane-456");
+  });
+});
+
+describe("resolvePrsActiveTab", () => {
+  it("routes a stale tab=normal + hash workflow=rebase to the rebase workflow", () => {
+    const parsed = parsePrsRouteState({
+      search: "?tab=normal",
+      hash: "#/prs?tab=workflows&workflow=rebase&laneId=lane-1",
+    });
+    const resolved = resolvePrsActiveTab(parsed);
+    expect(resolved.isWorkflowRoute).toBe(true);
+    expect(resolved.effectiveWorkflow).toBe("rebase");
+    expect(resolved.activeTab).toBe("rebase");
+  });
+
+  it("falls back to integration when tab=workflows has no workflow param", () => {
+    const parsed = parsePrsRouteState({ search: "?tab=workflows" });
+    const resolved = resolvePrsActiveTab(parsed);
+    expect(resolved.isWorkflowRoute).toBe(true);
+    expect(resolved.effectiveWorkflow).toBeNull();
+    expect(resolved.activeTab).toBe("integration");
+  });
+
+  it("treats a workflow-alias tab (tab=queue) as a workflow route", () => {
+    const parsed = parsePrsRouteState({ search: "?tab=queue&queueGroupId=g-1" });
+    const resolved = resolvePrsActiveTab(parsed);
+    expect(resolved.isWorkflowRoute).toBe(true);
+    expect(resolved.effectiveWorkflow).toBe("queue");
+    expect(resolved.activeTab).toBe("queue");
+  });
+
+  it("keeps tab=normal on the normal tab when no workflow signal is present", () => {
+    const parsed = parsePrsRouteState({ search: "?tab=normal&prId=pr-1" });
+    const resolved = resolvePrsActiveTab(parsed);
+    expect(resolved.isWorkflowRoute).toBe(false);
+    expect(resolved.activeTab).toBe("normal");
+  });
+
+  it("returns normal when the route has no tab or workflow signal", () => {
+    const parsed = parsePrsRouteState({ search: "" });
+    const resolved = resolvePrsActiveTab(parsed);
+    expect(resolved.isWorkflowRoute).toBe(false);
+    expect(resolved.activeTab).toBe("normal");
   });
 });

--- a/apps/desktop/src/renderer/components/prs/prsRouteState.test.ts
+++ b/apps/desktop/src/renderer/components/prs/prsRouteState.test.ts
@@ -140,4 +140,19 @@ describe("resolvePrsActiveTab", () => {
     expect(resolved.isWorkflowRoute).toBe(false);
     expect(resolved.activeTab).toBe("normal");
   });
+
+  it("prefers the hash workflow over a stale outer search workflow (BrowserRouter mock mode)", () => {
+    // Outer URL like `/?tab=workflows&workflow=queue#/prs?tab=workflows&workflow=rebase`
+    // In BrowserRouter mock mode the outer search is stale; the inner hash is the
+    // current in-app location and must win.
+    const parsed = parsePrsRouteState({
+      search: "?tab=workflows&workflow=queue",
+      hash: "#/prs?tab=workflows&workflow=rebase",
+    });
+    expect(parsed.workflowTab).toBe("rebase");
+    const resolved = resolvePrsActiveTab(parsed);
+    expect(resolved.isWorkflowRoute).toBe(true);
+    expect(resolved.effectiveWorkflow).toBe("rebase");
+    expect(resolved.activeTab).toBe("rebase");
+  });
 });

--- a/apps/desktop/src/renderer/components/prs/prsRouteState.test.ts
+++ b/apps/desktop/src/renderer/components/prs/prsRouteState.test.ts
@@ -175,4 +175,16 @@ describe("resolvePrsActiveTab", () => {
     expect(resolved.isWorkflowRoute).toBe(true);
     expect(resolved.activeTab).toBe("integration");
   });
+
+  it("ignores invalid hash route signals instead of dropping valid search params", () => {
+    const parsed = parsePrsRouteState({
+      search: "?tab=normal&prId=pr-123",
+      hash: "#/prs?tab=bogus",
+    });
+    const resolved = resolvePrsActiveTab(parsed);
+    expect(parsed.tab).toBe("normal");
+    expect(parsed.prId).toBe("pr-123");
+    expect(resolved.isWorkflowRoute).toBe(false);
+    expect(resolved.activeTab).toBe("normal");
+  });
 });

--- a/apps/desktop/src/renderer/components/prs/prsRouteState.test.ts
+++ b/apps/desktop/src/renderer/components/prs/prsRouteState.test.ts
@@ -2,17 +2,17 @@ import { describe, expect, it } from "vitest";
 import { buildPrsRouteSearch, parsePrsRouteState, resolvePrsActiveTab } from "./prsRouteState";
 
 describe("prsRouteState", () => {
-  it("parses route state from search params and falls back to hash params when needed", () => {
+  it("treats a hash PR route as authoritative over stale outer search params", () => {
     expect(
       parsePrsRouteState({
         search: "?tab=normal&prId=pr-123&laneId=lane-search",
         hash: "#/prs?tab=workflows&workflow=queue&queueGroupId=group-hash",
       }),
     ).toEqual({
-      tab: "normal",
+      tab: "workflows",
       workflowTab: "queue",
-      laneId: "lane-search",
-      prId: "pr-123",
+      laneId: null,
+      prId: null,
       queueGroupId: "group-hash",
       eventId: null,
       threadId: null,
@@ -154,5 +154,25 @@ describe("resolvePrsActiveTab", () => {
     expect(resolved.isWorkflowRoute).toBe(true);
     expect(resolved.effectiveWorkflow).toBe("rebase");
     expect(resolved.activeTab).toBe("rebase");
+  });
+
+  it("keeps hash lane ids with the hash workflow when outer search is stale", () => {
+    const parsed = parsePrsRouteState({
+      search: "?tab=workflows&workflow=rebase&laneId=old",
+      hash: "#/prs?tab=workflows&workflow=rebase&laneId=new",
+    });
+    expect(parsed.workflowTab).toBe("rebase");
+    expect(parsed.laneId).toBe("new");
+  });
+
+  it("defaults a bare hash workflows route to integration even when outer search says normal", () => {
+    const parsed = parsePrsRouteState({
+      search: "?tab=normal",
+      hash: "#/prs?tab=workflows",
+    });
+    const resolved = resolvePrsActiveTab(parsed);
+    expect(parsed.tab).toBe("workflows");
+    expect(resolved.isWorkflowRoute).toBe(true);
+    expect(resolved.activeTab).toBe("integration");
   });
 });

--- a/apps/desktop/src/renderer/components/prs/prsRouteState.test.ts
+++ b/apps/desktop/src/renderer/components/prs/prsRouteState.test.ts
@@ -141,6 +141,15 @@ describe("resolvePrsActiveTab", () => {
     expect(resolved.activeTab).toBe("normal");
   });
 
+  it("keeps legacy prId-only routes on the normal PR surface", () => {
+    const parsed = parsePrsRouteState({ search: "?prId=pr-123" });
+    const resolved = resolvePrsActiveTab(parsed);
+    expect(parsed.prId).toBe("pr-123");
+    expect(parsed.tab).toBeNull();
+    expect(resolved.isWorkflowRoute).toBe(false);
+    expect(resolved.activeTab).toBe("normal");
+  });
+
   it("prefers the hash workflow over a stale outer search workflow (BrowserRouter mock mode)", () => {
     // Outer URL like `/?tab=workflows&workflow=queue#/prs?tab=workflows&workflow=rebase`
     // In BrowserRouter mock mode the outer search is stale; the inner hash is the

--- a/apps/desktop/src/renderer/components/prs/prsRouteState.ts
+++ b/apps/desktop/src/renderer/components/prs/prsRouteState.ts
@@ -60,6 +60,42 @@ export function parsePrsRouteState(args: { search?: string | null; hash?: string
   };
 }
 
+export type ResolvedPrsRoute = {
+  isWorkflowRoute: boolean;
+  effectiveWorkflow: PrWorkflowTab | null;
+  activeTab: "normal" | PrWorkflowTab;
+};
+
+/**
+ * Collapse a parsed route into a single activeTab decision.
+ *
+ * Routing bounce-back guard: the presence of a `workflow=` param, or a
+ * workflow-alias `tab=` value (queue/integration/rebase), is treated as
+ * authoritative evidence of a workflow route. This prevents a stale
+ * `?tab=normal` in the outer search (BrowserRouter mock mode) from shadowing
+ * a hash-based workflow URL.
+ */
+export function resolvePrsActiveTab(route: ParsedPrsRouteState): ResolvedPrsRoute {
+  const workflowAlias: PrWorkflowTab | null =
+    route.tab === "queue" || route.tab === "integration" || route.tab === "rebase"
+      ? route.tab
+      : null;
+  const effectiveWorkflow = route.workflowTab ?? workflowAlias;
+  const isWorkflowRoute = Boolean(effectiveWorkflow) || route.tab === "workflows";
+  if (isWorkflowRoute) {
+    return {
+      isWorkflowRoute: true,
+      effectiveWorkflow,
+      activeTab: effectiveWorkflow ?? "integration",
+    };
+  }
+  return {
+    isWorkflowRoute: false,
+    effectiveWorkflow: null,
+    activeTab: "normal",
+  };
+}
+
 export function buildPrsRouteSearch(args: {
   activeTab: PrActiveTab;
   selectedPrId: string | null;

--- a/apps/desktop/src/renderer/components/prs/prsRouteState.ts
+++ b/apps/desktop/src/renderer/components/prs/prsRouteState.ts
@@ -44,7 +44,8 @@ function parseOptionalId(value: string | null): string | null {
 export function parsePrsRouteState(args: { search?: string | null; hash?: string | null }): ParsedPrsRouteState {
   const searchParams = parseSearch(args.search ?? "");
   const hashParams = parseHashParams(args.hash ?? "");
-  const hashHasRouteSignal = hashParams.has("tab") || hashParams.has("workflow");
+  const hashHasRouteSignal =
+    parseTab(hashParams.get("tab")) !== null || parseWorkflowTab(hashParams.get("workflow")) !== null;
   const routeParams = hashHasRouteSignal ? hashParams : searchParams;
 
   const pick = (key: string): string | null => parseOptionalId(routeParams.get(key));

--- a/apps/desktop/src/renderer/components/prs/prsRouteState.ts
+++ b/apps/desktop/src/renderer/components/prs/prsRouteState.ts
@@ -48,9 +48,19 @@ export function parsePrsRouteState(args: { search?: string | null; hash?: string
   const pick = (key: string): string | null =>
     parseOptionalId(searchParams.get(key)) ?? parseOptionalId(hashParams.get(key));
 
+  // Workflow precedence: when both search and hash carry a workflow value, the
+  // hash is authoritative. In BrowserRouter mock mode (e.g. when the outer
+  // location is `?tab=workflows&workflow=queue#/prs?...&workflow=rebase`), the
+  // inner hash is the current in-app location; the outer search may be stale
+  // and must not mask it. Still fall back to search when hash has no workflow.
+  const hashWorkflowRaw = hashParams.get("workflow");
+  const searchWorkflowRaw = searchParams.get("workflow");
+  const hashWorkflow = parseWorkflowTab(hashWorkflowRaw);
+  const workflowTab = hashWorkflow ?? parseWorkflowTab(searchWorkflowRaw);
+
   return {
     tab: parseTab(searchParams.get("tab") ?? hashParams.get("tab")),
-    workflowTab: parseWorkflowTab(searchParams.get("workflow") ?? hashParams.get("workflow")),
+    workflowTab,
     laneId: pick("laneId"),
     prId: pick("prId"),
     queueGroupId: pick("queueGroupId"),

--- a/apps/desktop/src/renderer/components/prs/prsRouteState.ts
+++ b/apps/desktop/src/renderer/components/prs/prsRouteState.ts
@@ -44,22 +44,18 @@ function parseOptionalId(value: string | null): string | null {
 export function parsePrsRouteState(args: { search?: string | null; hash?: string | null }): ParsedPrsRouteState {
   const searchParams = parseSearch(args.search ?? "");
   const hashParams = parseHashParams(args.hash ?? "");
+  const hashHasRouteSignal = hashParams.has("tab") || hashParams.has("workflow");
+  const routeParams = hashHasRouteSignal ? hashParams : searchParams;
 
-  const pick = (key: string): string | null =>
-    parseOptionalId(searchParams.get(key)) ?? parseOptionalId(hashParams.get(key));
+  const pick = (key: string): string | null => parseOptionalId(routeParams.get(key));
 
-  // Workflow precedence: when both search and hash carry a workflow value, the
-  // hash is authoritative. In BrowserRouter mock mode (e.g. when the outer
-  // location is `?tab=workflows&workflow=queue#/prs?...&workflow=rebase`), the
-  // inner hash is the current in-app location; the outer search may be stale
-  // and must not mask it. Still fall back to search when hash has no workflow.
-  const hashWorkflowRaw = hashParams.get("workflow");
-  const searchWorkflowRaw = searchParams.get("workflow");
-  const hashWorkflow = parseWorkflowTab(hashWorkflowRaw);
-  const workflowTab = hashWorkflow ?? parseWorkflowTab(searchWorkflowRaw);
+  // In BrowserRouter mock mode the inner hash is the current in-app location,
+  // while the outer search may be stale from a previous view. Once the hash
+  // carries any PR route signal, treat it as authoritative for the whole route.
+  const workflowTab = parseWorkflowTab(routeParams.get("workflow"));
 
   return {
-    tab: parseTab(searchParams.get("tab") ?? hashParams.get("tab")),
+    tab: parseTab(routeParams.get("tab")),
     workflowTab,
     laneId: pick("laneId"),
     prId: pick("prId"),

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
@@ -156,6 +156,26 @@ describe("PrsContext refresh", () => {
 
     window.history.replaceState(null, "", "/");
   });
+
+  it("hydrates a legacy PR deep link without an explicit tab as the normal surface", async () => {
+    window.history.replaceState(null, "", "/?prId=pr-123");
+    vi.mocked(window.ade.prs.listWithConflicts).mockResolvedValue([makeFakePr("pr-123")]);
+
+    render(
+      <PrsProvider>
+        <RouteHarness />
+      </PrsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-tab").textContent).toBe("normal");
+    });
+    expect(screen.getByTestId("selected-pr-id").textContent).toBe("pr-123");
+    expect(screen.getByTestId("selected-queue-group-id").textContent).toBe("");
+    expect(screen.getByTestId("selected-rebase-item-id").textContent).toBe("");
+
+    window.history.replaceState(null, "", "/");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
@@ -23,6 +23,18 @@ function Harness() {
   );
 }
 
+function RouteHarness() {
+  const { activeTab, selectedPrId, selectedQueueGroupId, selectedRebaseItemId } = usePrs();
+  return (
+    <div>
+      <div data-testid="active-tab">{activeTab}</div>
+      <div data-testid="selected-pr-id">{selectedPrId ?? ""}</div>
+      <div data-testid="selected-queue-group-id">{selectedQueueGroupId ?? ""}</div>
+      <div data-testid="selected-rebase-item-id">{selectedRebaseItemId ?? ""}</div>
+    </div>
+  );
+}
+
 describe("PrsContext refresh", () => {
   beforeEach(() => {
     const refreshedNeed: RebaseNeed = {
@@ -78,6 +90,7 @@ describe("PrsContext refresh", () => {
   afterEach(() => {
     cleanup();
     globalThis.window.ade = originalAde;
+    window.location.hash = "";
   });
 
   it("refreshes rebase needs and auto-rebase statuses without waiting for events", async () => {
@@ -101,6 +114,47 @@ describe("PrsContext refresh", () => {
       expect(screen.getByTestId("needs-count").textContent).toBe("1");
       expect(screen.getByTestId("auto-count").textContent).toBe("1");
     });
+  });
+
+  it("hydrates the Rebase/Merge workflow selection from the initial hash route", async () => {
+    window.location.hash = "#/prs?tab=workflows&workflow=rebase&laneId=lane-1";
+
+    render(
+      <PrsProvider>
+        <RouteHarness />
+      </PrsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-tab").textContent).toBe("rebase");
+    });
+    expect(screen.getByTestId("selected-pr-id").textContent).toBe("");
+    expect(screen.getByTestId("selected-queue-group-id").textContent).toBe("");
+    expect(screen.getByTestId("selected-rebase-item-id").textContent).toBe("lane-1");
+
+  });
+
+  it("does not bounce off the rebase workflow when a stale tab=normal shadows the hash", async () => {
+    // BrowserRouter mock mode can leave a stale `?tab=normal` in the outer
+    // search while the hash advances to a workflow URL. The initial route
+    // resolver must treat the hash workflow as authoritative.
+    window.history.replaceState(null, "", "/?tab=normal#/prs?tab=workflows&workflow=rebase&laneId=lane-1");
+    expect(window.location.search).toBe("?tab=normal");
+    expect(window.location.hash).toBe("#/prs?tab=workflows&workflow=rebase&laneId=lane-1");
+
+    render(
+      <PrsProvider>
+        <RouteHarness />
+      </PrsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-tab").textContent).toBe("rebase");
+    });
+    expect(screen.getByTestId("selected-pr-id").textContent).toBe("");
+    expect(screen.getByTestId("selected-rebase-item-id").textContent).toBe("lane-1");
+
+    window.history.replaceState(null, "", "/");
   });
 });
 

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
@@ -229,9 +229,7 @@ function readInitialRouteState(): {
       : "normal";
     return {
       activeTab,
-      selectedPrId: !resolved.isWorkflowRoute && (route.tab === "normal" || route.tab === "github")
-        ? route.prId
-        : null,
+      selectedPrId: !resolved.isWorkflowRoute ? route.prId : null,
       selectedQueueGroupId: resolved.effectiveWorkflow === "queue" ? route.queueGroupId : null,
       // Mirror PRsPage's resolver so the shape of this id matches what the
       // rebase UI later expects. rebaseNeeds are empty at provider mount, so

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
@@ -34,6 +34,7 @@ import type { PrTimelineFilters } from "../shared/PrTimeline";
 import { DEFAULT_PR_TIMELINE_FILTERS } from "../shared/PrTimeline";
 import { buildPrAiResolutionContextKey } from "../../../../shared/types";
 import { getModelById } from "../../../../shared/modelRegistry";
+import { parsePrsRouteState, resolvePrsActiveTab } from "../prsRouteState";
 
 type PrTab = "normal" | "queue" | "integration" | "rebase";
 
@@ -210,22 +211,36 @@ function readPersistedReasoningLevel(): string {
   return "medium";
 }
 
-function readInitialTab(): PrTab {
+function readInitialRouteState(): {
+  activeTab: PrTab;
+  selectedPrId: string | null;
+  selectedQueueGroupId: string | null;
+  selectedRebaseItemId: string | null;
+} {
   try {
-    const params = new URLSearchParams(window.location.search);
-    const tab = params.get("tab");
-    if (tab === "normal" || tab === "queue" || tab === "integration" || tab === "rebase") return tab;
+    const route = parsePrsRouteState({
+      search: window.location.search,
+      hash: window.location.hash,
+    });
+    const resolved = resolvePrsActiveTab(route);
+    const activeTab: PrTab = resolved.isWorkflowRoute
+      ? (resolved.effectiveWorkflow ?? "integration")
+      : "normal";
+    return {
+      activeTab,
+      selectedPrId: !resolved.isWorkflowRoute && (route.tab === "normal" || route.tab === "github")
+        ? route.prId
+        : null,
+      selectedQueueGroupId: resolved.effectiveWorkflow === "queue" ? route.queueGroupId : null,
+      selectedRebaseItemId: resolved.effectiveWorkflow === "rebase" ? route.laneId : null,
+    };
   } catch { /* ignore */ }
-  return "normal";
-}
-
-function readInitialPrId(): string | null {
-  try {
-    const params = new URLSearchParams(window.location.search);
-    const prId = params.get("prId");
-    if (prId && prId.trim().length > 0) return prId.trim();
-  } catch { /* ignore */ }
-  return null;
+  return {
+    activeTab: "normal",
+    selectedPrId: null,
+    selectedQueueGroupId: null,
+    selectedRebaseItemId: null,
+  };
 }
 
 function requirePrId(prId: string): string {
@@ -269,13 +284,14 @@ function diffPrIds(prev: PrWithConflicts[], next: PrWithConflicts[]): string[] {
 }
 
 export function PrsProvider({ children }: { children: React.ReactNode }) {
-  const [activeTab, setActiveTab] = useState<PrTab>(readInitialTab);
+  const initialRouteState = readInitialRouteState();
+  const [activeTab, setActiveTab] = useState<PrTab>(initialRouteState.activeTab);
   const [prs, setPrs] = useState<PrWithConflicts[]>([]);
   const [lanes, setLanes] = useState<LaneSummary[]>([]);
   const [mergeContextByPrId, setMergeContextByPrId] = useState<Record<string, PrMergeContext>>({});
-  const [selectedPrId, setSelectedPrId] = useState<string | null>(readInitialPrId);
-  const [selectedQueueGroupId, setSelectedQueueGroupId] = useState<string | null>(null);
-  const [selectedRebaseItemId, setSelectedRebaseItemId] = useState<string | null>(null);
+  const [selectedPrId, setSelectedPrId] = useState<string | null>(initialRouteState.selectedPrId);
+  const [selectedQueueGroupId, setSelectedQueueGroupId] = useState<string | null>(initialRouteState.selectedQueueGroupId);
+  const [selectedRebaseItemId, setSelectedRebaseItemId] = useState<string | null>(initialRouteState.selectedRebaseItemId);
   const [mergeMethod, setMergeMethod] = useState<MergeMethod>("squash");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
@@ -35,6 +35,7 @@ import { DEFAULT_PR_TIMELINE_FILTERS } from "../shared/PrTimeline";
 import { buildPrAiResolutionContextKey } from "../../../../shared/types";
 import { getModelById } from "../../../../shared/modelRegistry";
 import { parsePrsRouteState, resolvePrsActiveTab } from "../prsRouteState";
+import { resolveRouteRebaseSelection } from "../shared/rebaseNeedUtils";
 
 type PrTab = "normal" | "queue" | "integration" | "rebase";
 
@@ -232,7 +233,14 @@ function readInitialRouteState(): {
         ? route.prId
         : null,
       selectedQueueGroupId: resolved.effectiveWorkflow === "queue" ? route.queueGroupId : null,
-      selectedRebaseItemId: resolved.effectiveWorkflow === "rebase" ? route.laneId : null,
+      // Mirror PRsPage's resolver so the shape of this id matches what the
+      // rebase UI later expects. rebaseNeeds are empty at provider mount, so
+      // this returns the bare lane id; PRsPage's syncFromLocation effect runs
+      // the same resolver again once needs load and upgrades it to the
+      // canonical need-item key.
+      selectedRebaseItemId: resolved.effectiveWorkflow === "rebase"
+        ? resolveRouteRebaseSelection({ rebaseNeeds: [], routeItemId: route.laneId })
+        : null,
     };
   } catch { /* ignore */ }
   return {
@@ -284,7 +292,11 @@ function diffPrIds(prev: PrWithConflicts[], next: PrWithConflicts[]): string[] {
 }
 
 export function PrsProvider({ children }: { children: React.ReactNode }) {
-  const initialRouteState = readInitialRouteState();
+  // Compute initial route state exactly once per provider mount. Reading
+  // window.location + running parsePrsRouteState/resolvePrsActiveTab on every
+  // render would be wasteful; useMemo with empty deps captures it once so all
+  // four useState calls below share a single computation.
+  const initialRouteState = useMemo(() => readInitialRouteState(), []);
   const [activeTab, setActiveTab] = useState<PrTab>(initialRouteState.activeTab);
   const [prs, setPrs] = useState<PrWithConflicts[]>([]);
   const [lanes, setLanes] = useState<LaneSummary[]>([]);

--- a/apps/desktop/src/renderer/components/prs/tabs/IntegrationTab.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/IntegrationTab.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import { GitMerge, GitBranch, Lightning, Eye, Sparkle, Trash, ArrowRight, ArrowSquareOut, CheckCircle, Warning, XCircle, Clock, GithubLogo, CircleNotch, ArrowsClockwise, CaretDown, CaretRight, Robot, Gear } from "@phosphor-icons/react";
 import type {
   IntegrationProposal,
@@ -120,6 +121,7 @@ function RebaseGuidancePanel({
   onResimulate?: () => void;
   resimulateLabel?: string;
 }) {
+  const navigate = useNavigate();
   return (
     <div
       style={{
@@ -155,10 +157,11 @@ function RebaseGuidancePanel({
               cursor: "pointer",
             }}
             onClick={() => {
-              window.location.hash = `#/prs?tab=rebase&laneId=${encodeURIComponent(laneId)}`;
+              const search = new URLSearchParams({ tab: "workflows", workflow: "rebase", laneId });
+              navigate({ pathname: "/prs", search: `?${search.toString()}` });
             }}
           >
-            OPEN REBASE TAB
+            OPEN REBASE/MERGE TAB
           </button>
           {onResimulate ? (
             <button

--- a/apps/desktop/src/renderer/components/prs/tabs/IntegrationTab.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/IntegrationTab.tsx
@@ -161,7 +161,7 @@ function RebaseGuidancePanel({
               navigate({ pathname: "/prs", search: `?${search.toString()}` });
             }}
           >
-            OPEN REBASE/MERGE TAB
+            Open Rebase/Merge tab
           </button>
           {onResimulate ? (
             <button

--- a/apps/desktop/src/renderer/components/prs/tabs/QueueTab.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/QueueTab.tsx
@@ -1217,7 +1217,7 @@ export function QueueTab({
                 }}
               >
                 <GitBranch size={12} />
-                Open rebase tab
+                Open Rebase/Merge tab
               </button>
             </div>
 
@@ -1447,7 +1447,7 @@ export function QueueTab({
                   ) : null}
 
                   <div style={{ fontSize: 11, color: "#71717A", lineHeight: "18px" }}>
-                    Batch rebases stop at the first failure so the queue does not quietly drift. Use the Rebase tab for detailed lane history, aborts, rollbacks, and any follow-up after a partial run.
+                    Batch rebases stop at the first failure so the queue does not quietly drift. Use the Rebase/Merge tab for detailed lane history, aborts, rollbacks, and any follow-up after a partial run.
                   </div>
                 </div>
               </>
@@ -1502,7 +1502,7 @@ export function QueueTab({
                         cursor: "pointer",
                       }}
                     >
-                      Open failed lane in rebase tab
+                      Open failed lane in Rebase/Merge tab
                     </button>
                   </div>
                 ) : null}

--- a/apps/desktop/src/renderer/components/prs/tabs/QueueTab.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/QueueTab.tsx
@@ -469,7 +469,13 @@ export function QueueTab({
     const need = findLaneBaseNeed(visibleRebaseNeeds, laneId);
     setSelectedRebaseItemId(need ? rebaseNeedItemKey(need) : null);
     setActiveTab("rebase");
-  }, [setActiveTab, setSelectedRebaseItemId, visibleRebaseNeeds]);
+    // Keep the URL in sync with the tab switch so deep links / back-button
+    // behaviour match other openRebaseTab migrations (CreatePrModal,
+    // IntegrationTab). The `laneId` drives PRsPage's resolveRouteRebaseSelection
+    // on the receiving side.
+    const search = new URLSearchParams({ tab: "workflows", workflow: "rebase", laneId });
+    navigate({ pathname: "/prs", search: `?${search.toString()}` });
+  }, [navigate, setActiveTab, setSelectedRebaseItemId, visibleRebaseNeeds]);
 
   const handleLandCurrentPr = React.useCallback(async () => {
     if (!selectedGroup) return;

--- a/apps/desktop/src/renderer/components/prs/tabs/WorkflowsTab.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/WorkflowsTab.tsx
@@ -762,7 +762,7 @@ export function WorkflowsTab({
           {([
             { id: "integration" as WorkflowCategory, label: "Integration", icon: GitBranch },
             { id: "queue" as WorkflowCategory, label: "Queue", icon: CaretRight },
-            { id: "rebase" as WorkflowCategory, label: "Rebase", icon: Sparkle },
+            { id: "rebase" as WorkflowCategory, label: "Rebase/Merge", icon: Sparkle },
           ]).map((category) => {
             const selected = activeCategory === category.id;
             const catTheme = CATEGORY_THEMES[category.id];

--- a/apps/desktop/src/renderer/components/settings/LaneBehaviorSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/LaneBehaviorSection.tsx
@@ -224,15 +224,15 @@ export function LaneBehaviorSection() {
           )}
         </div>
 
-        {/* Save + Open Rebase tab */}
+        {/* Save + Open Rebase/Merge tab */}
         <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
           <button
             type="button"
             style={outlineButton({ height: 32 })}
             disabled={busy}
-            onClick={() => navigate("/prs?tab=rebase")}
+            onClick={() => navigate("/prs?tab=workflows&workflow=rebase")}
           >
-            Open Rebase tab
+            Open Rebase/Merge tab
           </button>
           <button type="button" style={primaryButton({ height: 32 })} disabled={busy} onClick={() => void saveSettings()}>
             {busy ? "Saving..." : "Save"}

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -416,7 +416,7 @@ describe("TerminalView", () => {
     // 1) timer flush kicks off the render + initRendererChain
     // 2) microtask flush lets the dynamic import resolve
     // 3) second timer flush lets the post-import code run
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 100; i++) {
       await act(async () => {});
       await flushAllTimers();
       const runtime = getTerminalRuntimeSnapshot("session-dom");

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 
 // ---------------------------------------------------------------------------
 // Spies used across all tests
@@ -28,7 +28,10 @@ function resetFakeAppStoreState() {
 // Module-level mocks (hoisted by vitest)
 // ---------------------------------------------------------------------------
 
-const listSessionsCachedMock = vi.fn().mockResolvedValue([]);
+const { listSessionsCachedMock, useSearchParamsMock } = vi.hoisted(() => ({
+  listSessionsCachedMock: vi.fn().mockResolvedValue([]),
+  useSearchParamsMock: vi.fn(() => [new URLSearchParams(), vi.fn()]),
+}));
 
 vi.mock("../../lib/sessionListCache", () => ({
   listSessionsCached: (...args: unknown[]) => listSessionsCachedMock(...args),
@@ -73,7 +76,7 @@ vi.mock("../../lib/sessions", () => ({
 
 vi.mock("react-router-dom", () => ({
   useNavigate: vi.fn(() => navigateSpy),
-  useSearchParams: vi.fn(() => [new URLSearchParams(), vi.fn()]),
+  useSearchParams: useSearchParamsMock,
 }));
 
 vi.mock("../../state/appStore", () => ({
@@ -121,6 +124,7 @@ describe("useWorkSessions — refresh-before-focus ordering", () => {
     resetFakeAppStoreState();
     installWindowAde();
     listSessionsCachedMock.mockResolvedValue([]);
+    useSearchParamsMock.mockReturnValue([new URLSearchParams(), vi.fn()]);
   });
 
   afterEach(() => {
@@ -307,6 +311,150 @@ describe("useWorkSessions — refresh-before-focus ordering", () => {
     expect(workState.activeItemId).toBe("session-1");
     expect(workState.selectedItemId).toBe("session-1");
     expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it("preserves saved Work filters when a URL targets a specific session", async () => {
+    const session = {
+      id: "session-1",
+      laneId: "lane-1",
+      laneName: "Lane 1",
+      ptyId: null,
+      tracked: true,
+      pinned: false,
+      goal: null,
+      toolType: "claude-chat" as const,
+      title: "Claude Chat",
+      status: "running" as const,
+      startedAt: "2026-04-01T12:00:00.000Z",
+      endedAt: null,
+      exitCode: null,
+      transcriptPath: "",
+      headShaStart: null,
+      headShaEnd: null,
+      lastOutputPreview: null,
+      summary: null,
+      runtimeState: "idle" as const,
+      resumeCommand: null,
+    };
+    listSessionsCachedMock.mockResolvedValue([session]);
+    useSearchParamsMock.mockReturnValue([
+      new URLSearchParams("laneId=lane-1&status=running&sessionId=session-1"),
+      vi.fn(),
+    ]);
+
+    const workState = {
+      openItemIds: [] as string[],
+      activeItemId: null as string | null,
+      selectedItemId: null as string | null,
+      viewMode: "tabs" as const,
+      draftKind: "chat" as const,
+      laneFilter: "lane-2",
+      statusFilter: "completed" as const,
+      search: "",
+      sessionListOrganization: "by-lane" as const,
+      workCollapsedLaneIds: [] as string[],
+      workCollapsedTabGroupIds: [] as string[],
+      workFocusSessionsHidden: false,
+    };
+    fakeAppStoreState = {
+      ...fakeAppStoreState,
+      lanes: [
+        { id: "lane-1", name: "Lane 1" },
+        { id: "lane-2", name: "Lane 2" },
+      ],
+      workViewByProject: {
+        "/fake/project": workState,
+      },
+    };
+    setWorkViewStateSpy.mockImplementation((_projectRoot: string, next: any) => {
+      const resolved = typeof next === "function" ? next(workState) : { ...workState, ...next };
+      Object.assign(workState, resolved);
+    });
+
+    renderHook(() => useWorkSessions());
+
+    await waitFor(() => {
+      expect(focusSessionSpy).toHaveBeenCalledWith("session-1");
+    });
+
+    expect(selectLaneSpy).toHaveBeenCalledWith("lane-1");
+    expect(workState.laneFilter).toBe("lane-2");
+    expect(workState.statusFilter).toBe("completed");
+    expect(workState.openItemIds).toContain("session-1");
+    expect(workState.activeItemId).toBe("session-1");
+    expect(workState.selectedItemId).toBe("session-1");
+  });
+
+  it("falls back to URL lane/status filters when the requested sessionId is stale", async () => {
+    // Only session-2 exists in the list — the URL's sessionId=missing-session
+    // is stale (e.g. deleted). The laneId/status hints must still apply so
+    // the user lands in the right filter context instead of nowhere.
+    const session = {
+      id: "session-2",
+      laneId: "lane-1",
+      laneName: "Lane 1",
+      ptyId: null,
+      tracked: true,
+      pinned: false,
+      goal: null,
+      toolType: "claude-chat" as const,
+      title: "Claude Chat",
+      status: "running" as const,
+      startedAt: "2026-04-01T12:00:00.000Z",
+      endedAt: null,
+      exitCode: null,
+      transcriptPath: "",
+      headShaStart: null,
+      headShaEnd: null,
+      lastOutputPreview: null,
+      summary: null,
+      runtimeState: "idle" as const,
+      resumeCommand: null,
+    };
+    listSessionsCachedMock.mockResolvedValue([session]);
+    useSearchParamsMock.mockReturnValue([
+      new URLSearchParams("laneId=lane-1&status=running&sessionId=missing-session"),
+      vi.fn(),
+    ]);
+
+    const workState = {
+      openItemIds: [] as string[],
+      activeItemId: null as string | null,
+      selectedItemId: null as string | null,
+      viewMode: "tabs" as const,
+      draftKind: "chat" as const,
+      laneFilter: "all",
+      statusFilter: "all" as const,
+      search: "",
+      sessionListOrganization: "by-lane" as const,
+      workCollapsedLaneIds: [] as string[],
+      workCollapsedTabGroupIds: [] as string[],
+      workFocusSessionsHidden: false,
+    };
+    fakeAppStoreState = {
+      ...fakeAppStoreState,
+      lanes: [
+        { id: "lane-1", name: "Lane 1" },
+        { id: "lane-2", name: "Lane 2" },
+      ],
+      workViewByProject: {
+        "/fake/project": workState,
+      },
+    };
+    setWorkViewStateSpy.mockImplementation((_projectRoot: string, next: any) => {
+      const resolved = typeof next === "function" ? next(workState) : { ...workState, ...next };
+      Object.assign(workState, resolved);
+    });
+
+    renderHook(() => useWorkSessions());
+
+    await waitFor(() => {
+      expect(workState.laneFilter).toBe("lane-1");
+      expect(workState.statusFilter).toBe("running");
+    });
+
+    // The stale session never existed, so focusSession must not fire for it.
+    expect(focusSessionSpy).not.toHaveBeenCalledWith("missing-session");
   });
 
   it("refreshes against the newly active project before pruning that project's saved tabs", async () => {

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
@@ -457,6 +457,93 @@ describe("useWorkSessions — refresh-before-focus ordering", () => {
     expect(focusSessionSpy).not.toHaveBeenCalledWith("missing-session");
   });
 
+  it("does not keep reapplying a partially applied URL status while lanes are loading", async () => {
+    const session = {
+      id: "session-2",
+      laneId: "lane-1",
+      laneName: "Lane 1",
+      ptyId: null,
+      tracked: true,
+      pinned: false,
+      goal: null,
+      toolType: "claude-chat" as const,
+      title: "Claude Chat",
+      status: "running" as const,
+      startedAt: "2026-04-01T12:00:00.000Z",
+      endedAt: null,
+      exitCode: null,
+      transcriptPath: "",
+      headShaStart: null,
+      headShaEnd: null,
+      lastOutputPreview: null,
+      summary: null,
+      runtimeState: "idle" as const,
+      resumeCommand: null,
+    };
+    listSessionsCachedMock.mockResolvedValue([session]);
+    useSearchParamsMock.mockReturnValue([
+      new URLSearchParams("laneId=lane-1&status=running&sessionId=missing-session"),
+      vi.fn(),
+    ]);
+
+    const workState = {
+      openItemIds: [] as string[],
+      activeItemId: null as string | null,
+      selectedItemId: null as string | null,
+      viewMode: "tabs" as const,
+      draftKind: "chat" as const,
+      laneFilter: "all",
+      statusFilter: "all" as "all" | "running" | "completed",
+      search: "",
+      sessionListOrganization: "by-lane" as const,
+      workCollapsedLaneIds: [] as string[],
+      workCollapsedTabGroupIds: [] as string[],
+      workFocusSessionsHidden: false,
+    };
+    fakeAppStoreState = {
+      ...fakeAppStoreState,
+      lanes: [],
+      workViewByProject: {
+        "/fake/project": workState,
+      },
+    };
+    setWorkViewStateSpy.mockImplementation((_projectRoot: string, next: any) => {
+      const resolved = typeof next === "function" ? next(workState) : { ...workState, ...next };
+      Object.assign(workState, resolved);
+    });
+
+    const { result, rerender } = renderHook(() => useWorkSessions());
+
+    await waitFor(() => {
+      expect(workState.statusFilter).toBe("running");
+    });
+    expect(workState.laneFilter).toBe("all");
+
+    workState.statusFilter = "completed";
+    listSessionsCachedMock.mockResolvedValue([{ ...session, id: "session-3" }]);
+
+    await act(async () => {
+      await result.current.refresh({ force: true });
+    });
+
+    expect(workState.statusFilter).toBe("completed");
+    expect(workState.laneFilter).toBe("all");
+
+    fakeAppStoreState = {
+      ...fakeAppStoreState,
+      lanes: [{ id: "lane-1", name: "Lane 1" }],
+    };
+
+    act(() => {
+      rerender();
+    });
+
+    await waitFor(() => {
+      expect(workState.laneFilter).toBe("lane-1");
+    });
+    expect(workState.statusFilter).toBe("completed");
+  });
+
   it("refreshes against the newly active project before pruning that project's saved tabs", async () => {
     const sessionA = {
       id: "session-a",

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
@@ -544,6 +544,86 @@ describe("useWorkSessions — refresh-before-focus ordering", () => {
     expect(workState.statusFilter).toBe("completed");
   });
 
+  it("reapplies the same stale-session URL filters after navigating away and back", async () => {
+    const session = {
+      id: "session-2",
+      laneId: "lane-1",
+      laneName: "Lane 1",
+      ptyId: null,
+      tracked: true,
+      pinned: false,
+      goal: null,
+      toolType: "claude-chat" as const,
+      title: "Claude Chat",
+      status: "running" as const,
+      startedAt: "2026-04-01T12:00:00.000Z",
+      endedAt: null,
+      exitCode: null,
+      transcriptPath: "",
+      headShaStart: null,
+      headShaEnd: null,
+      lastOutputPreview: null,
+      summary: null,
+      runtimeState: "idle" as const,
+      resumeCommand: null,
+    };
+    listSessionsCachedMock.mockResolvedValue([session]);
+
+    const deepLinkParams = new URLSearchParams("laneId=lane-1&status=running&sessionId=missing-session");
+    let currentSearchParams = deepLinkParams;
+    useSearchParamsMock.mockImplementation(() => [currentSearchParams, vi.fn()]);
+
+    const workState = {
+      openItemIds: [] as string[],
+      activeItemId: null as string | null,
+      selectedItemId: null as string | null,
+      viewMode: "tabs" as const,
+      draftKind: "chat" as const,
+      laneFilter: "all",
+      statusFilter: "all" as "all" | "running" | "completed",
+      search: "",
+      sessionListOrganization: "by-lane" as const,
+      workCollapsedLaneIds: [] as string[],
+      workCollapsedTabGroupIds: [] as string[],
+      workFocusSessionsHidden: false,
+    };
+    fakeAppStoreState = {
+      ...fakeAppStoreState,
+      lanes: [{ id: "lane-1", name: "Lane 1" }],
+      workViewByProject: {
+        "/fake/project": workState,
+      },
+    };
+    setWorkViewStateSpy.mockImplementation((_projectRoot: string, next: any) => {
+      const resolved = typeof next === "function" ? next(workState) : { ...workState, ...next };
+      Object.assign(workState, resolved);
+    });
+
+    const { rerender } = renderHook(() => useWorkSessions());
+
+    await waitFor(() => {
+      expect(workState.laneFilter).toBe("lane-1");
+      expect(workState.statusFilter).toBe("running");
+    });
+
+    currentSearchParams = new URLSearchParams();
+    act(() => {
+      rerender();
+    });
+
+    workState.laneFilter = "all";
+    workState.statusFilter = "completed";
+    currentSearchParams = deepLinkParams;
+    act(() => {
+      rerender();
+    });
+
+    await waitFor(() => {
+      expect(workState.laneFilter).toBe("lane-1");
+      expect(workState.statusFilter).toBe("running");
+    });
+  });
+
   it("refreshes against the newly active project before pruning that project's saved tabs", async () => {
     const sessionA = {
       id: "session-a",

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
@@ -544,7 +544,7 @@ describe("useWorkSessions — refresh-before-focus ordering", () => {
     expect(workState.statusFilter).toBe("completed");
   });
 
-  it("reapplies the same stale-session URL filters after navigating away and back", async () => {
+  it("reapplies the same stale-session URL filters after navigating to a valid session and back", async () => {
     const session = {
       id: "session-2",
       laneId: "lane-1",
@@ -606,7 +606,7 @@ describe("useWorkSessions — refresh-before-focus ordering", () => {
       expect(workState.statusFilter).toBe("running");
     });
 
-    currentSearchParams = new URLSearchParams();
+    currentSearchParams = new URLSearchParams("sessionId=session-2");
     act(() => {
       rerender();
     });

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -279,6 +279,7 @@ export function useWorkSessions() {
   const backgroundRefreshTimerRef = useRef<number | null>(null);
   const appliedQuerySessionIdRef = useRef<string | null>(null);
   const appliedUrlFilterKeyRef = useRef<string | null>(null);
+  const partiallyAppliedUrlFilterKeyRef = useRef<string | null>(null);
   const hasLoadedOnceRef = useRef(false);
   const projectRootRef = useRef<string | null>(projectRoot);
 
@@ -594,6 +595,7 @@ export function useWorkSessions() {
     hasRunningSessionsRef.current = false;
     appliedQuerySessionIdRef.current = null;
     appliedUrlFilterKeyRef.current = null;
+    partiallyAppliedUrlFilterKeyRef.current = null;
     if (!projectRoot) return;
     refresh({ showLoading: true, force: true }).catch(() => {});
   }, [projectRoot, refresh]);
@@ -632,13 +634,18 @@ export function useWorkSessions() {
     // when lanes are loaded (non-empty) so "not found" is an authoritative
     // negative signal.
     const laneDeterminable = !laneParam || laneExists || lanes.length > 0;
+    const wasPartiallyApplied = partiallyAppliedUrlFilterKeyRef.current === urlKey;
+    if (!laneDeterminable && wasPartiallyApplied) return;
     if (laneDeterminable) {
       appliedUrlFilterKeyRef.current = urlKey;
+      partiallyAppliedUrlFilterKeyRef.current = null;
+    } else {
+      partiallyAppliedUrlFilterKeyRef.current = urlKey;
     }
     setProjectViewState((prev) => ({
       ...prev,
       laneFilter: laneExists ? laneParam : prev.laneFilter,
-      statusFilter: status ?? prev.statusFilter,
+      statusFilter: status && !wasPartiallyApplied ? status : prev.statusFilter,
     }));
   }, [lanes, sessions, searchParams, setProjectViewState]);
 

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -624,7 +624,11 @@ export function useWorkSessions() {
     if (appliedUrlFilterKeyRef.current === urlKey) return;
     const laneExists = laneParam && lanes.some((lane) => lane.id === laneParam);
     const status = mapUrlStatusFilter(statusParam);
-    if (!laneExists && !status) return;
+    if (!laneExists && !status) {
+      appliedUrlFilterKeyRef.current = null;
+      partiallyAppliedUrlFilterKeyRef.current = null;
+      return;
+    }
     // When the URL specifies a laneId but lanes haven't populated yet (e.g. on
     // project open/switch the store resets lanes to [] then repopulates async),
     // we can't tell whether the lane is missing-for-good or just-not-yet-loaded.

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -614,7 +614,11 @@ export function useWorkSessions() {
     // narrow the view instead of dumping the user into an unrelated context.
     if (sessionParam) {
       const sessionExists = sessions.some((s) => s.id === sessionParam);
-      if (sessionExists) return;
+      if (sessionExists) {
+        appliedUrlFilterKeyRef.current = null;
+        partiallyAppliedUrlFilterKeyRef.current = null;
+        return;
+      }
       if (!hasLoadedOnceRef.current) return;
     }
     // Apply URL-derived filters at most once per URL signature so later

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -623,7 +623,18 @@ export function useWorkSessions() {
     const laneExists = laneParam && lanes.some((lane) => lane.id === laneParam);
     const status = mapUrlStatusFilter(statusParam);
     if (!laneExists && !status) return;
-    appliedUrlFilterKeyRef.current = urlKey;
+    // When the URL specifies a laneId but lanes haven't populated yet (e.g. on
+    // project open/switch the store resets lanes to [] then repopulates async),
+    // we can't tell whether the lane is missing-for-good or just-not-yet-loaded.
+    // In that case, apply any status hint but don't cache the URL signature —
+    // come back once lanes populate so the lane portion can apply too. We only
+    // mark the key applied when the lane portion was definitively applied, or
+    // when lanes are loaded (non-empty) so "not found" is an authoritative
+    // negative signal.
+    const laneDeterminable = !laneParam || laneExists || lanes.length > 0;
+    if (laneDeterminable) {
+      appliedUrlFilterKeyRef.current = urlKey;
+    }
     setProjectViewState((prev) => ({
       ...prev,
       laneFilter: laneExists ? laneParam : prev.laneFilter,

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -278,6 +278,7 @@ export function useWorkSessions() {
   const hasRunningSessionsRef = useRef(false);
   const backgroundRefreshTimerRef = useRef<number | null>(null);
   const appliedQuerySessionIdRef = useRef<string | null>(null);
+  const appliedUrlFilterKeyRef = useRef<string | null>(null);
   const hasLoadedOnceRef = useRef(false);
   const projectRootRef = useRef<string | null>(projectRoot);
 
@@ -592,6 +593,7 @@ export function useWorkSessions() {
     hasLoadedOnceRef.current = false;
     hasRunningSessionsRef.current = false;
     appliedQuerySessionIdRef.current = null;
+    appliedUrlFilterKeyRef.current = null;
     if (!projectRoot) return;
     refresh({ showLoading: true, force: true }).catch(() => {});
   }, [projectRoot, refresh]);
@@ -601,16 +603,33 @@ export function useWorkSessions() {
   }, [sessions]);
 
   useEffect(() => {
+    const sessionParam = (searchParams.get("sessionId") ?? "").trim();
     const laneParam = (searchParams.get("laneId") ?? searchParams.get("lane") ?? "").trim();
+    const statusParam = (searchParams.get("status") ?? "").trim();
+    // When a sessionId is requested, only skip the lane/status fallback if
+    // that session actually exists. If it's stale/missing (after the first
+    // load completes) we fall through so the URL's laneId/status hints still
+    // narrow the view instead of dumping the user into an unrelated context.
+    if (sessionParam) {
+      const sessionExists = sessions.some((s) => s.id === sessionParam);
+      if (sessionExists) return;
+      if (!hasLoadedOnceRef.current) return;
+    }
+    // Apply URL-derived filters at most once per URL signature so later
+    // session-list refreshes (which add sessions to our deps) don't stomp
+    // on a user's manually-changed lane/status filters.
+    const urlKey = `${sessionParam}|${laneParam}|${statusParam}`;
+    if (appliedUrlFilterKeyRef.current === urlKey) return;
     const laneExists = laneParam && lanes.some((lane) => lane.id === laneParam);
-    const status = mapUrlStatusFilter(searchParams.get("status") ?? "");
+    const status = mapUrlStatusFilter(statusParam);
     if (!laneExists && !status) return;
+    appliedUrlFilterKeyRef.current = urlKey;
     setProjectViewState((prev) => ({
       ...prev,
       laneFilter: laneExists ? laneParam : prev.laneFilter,
       statusFilter: status ?? prev.statusFilter,
     }));
-  }, [lanes, searchParams, setProjectViewState]);
+  }, [lanes, sessions, searchParams, setProjectViewState]);
 
   // Migrate legacy org modes to supported modes
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Rename "Rebase" → "Rebase/Merge" across lane/PR UX to reflect both operations
- Migrate URL routing from `?tab=rebase` to `?tab=workflows&workflow=rebase`; hydrate initial route state defensively against hash/search divergence in BrowserRouter mock mode
- Harden `useWorkSessions` URL filter behavior: preserve saved filters when sessionId matches, fall back to laneId/status when stale
- Clean up `prRebaseResolver` to drop `displayText` passthrough

### Ancillary

- Add portable `/shipLane` command and ship-lane playbook (`docs/playbooks/ship-lane.md`)
- Drop trailing slash on `node_modules` gitignore pattern so symlinked worktree node_modules are also ignored (unblocks `ade prs create` preflight)
- Add Phase 3j worker-process cleanup to `/finalize`

## Test plan

- [x] `pnpm -F desktop typecheck` / `pnpm -F ade-cli typecheck` / `pnpm -F web typecheck` — all pass
- [x] `pnpm -F desktop lint` — 0 errors (266 pre-existing warnings)
- [x] Feature-scoped vitest files all pass (57 tests across `prsRouteState`, `PrsContext`, `LaneGitActionsPane`, `prRebaseResolver`, `useWorkSessions`)
- [x] Desktop vitest shards 1/8 and 2/8 pass locally (shards 3–8 covered in CI)
- [x] `pnpm -F desktop build`, `pnpm -F ade-cli build`, `pnpm -F web build` — all pass
- [ ] CI green on PR

Generated with [Claude Code](https://claude.com/claude-code)

---

_Note: PR created via `gh pr create` fallback because `ade prs create` reported missing `ADE_GITHUB_TOKEN`/`GITHUB_TOKEN`. Run `ade prs inventory <PR_NUMBER>` to reconcile with ADE's tracker._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced PR workflows routing with improved deep-link and browser history support.

* **Bug Fixes**
  * Updated all navigation references from "Rebase" to "Rebase/Merge" tab across status messages, buttons, and tooltips for consistency.
  * Improved session ID URL parameter handling in work sessions view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames "Rebase" to "Rebase/Merge" across the lane/PR UX and migrates the Rebase tab's URL scheme from `?tab=rebase` to `?tab=workflows&workflow=rebase`, with backward-compatible parsing of the old alias. It also fixes `readInitialRouteState` (previously flagged: now wrapped in `useMemo`), hardens `useWorkSessions` URL filter logic to preserve saved filters when a session is live while falling back to `laneId`/`status` URL hints when the session is stale, and cleans up `prRebaseResolver` to derive `displayText` from the locally-computed title instead of an external passthrough.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 issues found; all remaining feedback is P2 or below.

The routing migration is backward-compatible (old ?tab=rebase alias still resolves correctly). The readInitialRouteState eager-evaluation concern from the previous review is addressed via useMemo. The useWorkSessions filter-preservation logic is carefully guarded with ref-based deduplication. The test plan covers typecheck, lint, build, and feature-scoped vitest suites.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/prs/prsRouteState.ts | New URL routing scheme (?tab=workflows&workflow=rebase), backward-compatible with old ?tab=rebase alias; well-tested. |
| apps/desktop/src/renderer/components/prs/state/PrsContext.tsx | Converts readInitialRouteState() from an eager call to a useMemo-guarded lazy initializer, resolving the previous review finding; no other logic changes. |
| apps/desktop/src/renderer/components/terminals/useWorkSessions.ts | Adds defensive URL-filter logic: preserves saved filters when sessionId is matched, falls back to laneId/status when the session is stale/missing after first load. |
| apps/desktop/src/renderer/components/prs/PRsPage.tsx | Adds window.location.hash to syncFromLocation reads for BrowserRouter mock mode; subscribes to both popstate and hashchange for correct deep-link hydration. |
| apps/desktop/src/main/services/prs/prRebaseResolver.ts | Drops the args.displayText passthrough, now derives displayText from the locally-computed title; no functional change to the rebase prompt logic. |
| apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx | Label change only: Rebase → Rebase/Merge in button/tooltip text within the lane git actions pane. |
| .claude/commands/finalize.md | Adds Phase 3j (remote PR poll handoff guidance) and Phase 3k documentation; documentation-only change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[URL / Location] -->|search + hash| B[parsePrsRouteState]
    B --> C{hash has route signal?}
    C -->|Yes| D[Use hash params as authoritative]
    C -->|No| E[Use search params]
    D & E --> F[ParsedPrsRouteState]
    F --> G[resolvePrsActiveTab]
    G --> H{isWorkflowRoute?}
    H -->|No| I[activeTab = 'normal']
    H -->|Yes| J{effectiveWorkflow?}
    J -->|queue| K[activeTab = 'queue']
    J -->|rebase| L[activeTab = 'rebase']
    J -->|integration or none| M[activeTab = 'integration']
    I & K & L & M --> N[PrsContext state]
    N --> O[buildPrsRouteSearch]
    O -->|normal/github| P["?tab=normal&prId=..."]
    O -->|queue| Q["?tab=workflows&workflow=queue"]
    O -->|rebase| R["?tab=workflows&workflow=rebase&laneId=..."]
    O -->|integration| S["?tab=workflows&workflow=integration"]
```

<sub>Reviews (12): Last reviewed commit: ["ship: reset iter 3 - sync legacy pr rout..."](https://github.com/arul28/ade/commit/b45afefb73a991c391d0efad73840c53c2a9234e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29504053)</sub>

<!-- /greptile_comment -->