### PR TITLE
Grid resizing: pane tiling layout for Work grid + chat refinements

### DIFF
--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -36,6 +36,7 @@ const mockState = vi.hoisted(() => ({
     aborted: boolean;
   }>(),
   codexRequestPayloads: [] as Array<Record<string, unknown>>,
+  codexResponseOverrides: new Map<string, Record<string, unknown> | ((payload: Record<string, unknown>) => Record<string, unknown>)>(),
   delayedCodexMethods: new Set<string>(),
   pendingCodexResponses: [] as Array<() => void>,
   codexCollaborationModes: [{ mode: "default" }, { mode: "plan" }] as Array<Record<string, unknown> | string>,
@@ -81,7 +82,12 @@ vi.mock("node:child_process", () => ({
           if (payload?.id == null || typeof payload?.method !== "string") return true;
 
           let result: Record<string, unknown> = {};
-          if (payload.method === "thread/start") {
+          const override = mockState.codexResponseOverrides.get(payload.method);
+          if (typeof override === "function") {
+            result = override(payload);
+          } else if (override) {
+            result = override;
+          } else if (payload.method === "thread/start") {
             mockState.codexThreadCounter += 1;
             result = { thread: { id: `thread-${mockState.codexThreadCounter}` } };
           } else if (payload.method === "turn/start" || payload.method === "review/start") {
@@ -810,6 +816,7 @@ beforeEach(() => {
   mockState.openCodeSessionCounter = 0;
   mockState.openCodeSessions.clear();
   mockState.codexRequestPayloads = [];
+  mockState.codexResponseOverrides.clear();
   mockState.delayedCodexMethods.clear();
   mockState.pendingCodexResponses = [];
   mockState.codexCollaborationModes = [{ mode: "default" }, { mode: "plan" }];
@@ -4840,11 +4847,19 @@ describe("createAgentChatService", () => {
         expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(true);
       });
       const turnStartRequest = mockState.codexRequestPayloads.find((payload) => payload.method === "turn/start");
-      const params = turnStartRequest?.params as { collaborationMode?: Record<string, unknown> } | undefined;
+      const params = turnStartRequest?.params as {
+        approvalPolicy?: unknown;
+        sandboxPolicy?: { type?: unknown; networkAccess?: unknown; access?: { type?: unknown } };
+        effort?: unknown;
+        collaborationMode?: Record<string, unknown>;
+      } | undefined;
       const collaborationMode = params?.collaborationMode as
         | { mode?: unknown; settings?: { model?: unknown; reasoning_effort?: unknown; developer_instructions?: unknown } }
         | undefined;
 
+      expect(params?.approvalPolicy).toBeUndefined();
+      expect(params?.sandboxPolicy).toBeUndefined();
+      expect(params?.effort).toBe("medium");
       expect(collaborationMode?.mode).toBe("plan");
       expect(collaborationMode?.settings?.model).toBe("gpt-5.4");
       expect(collaborationMode?.settings?.reasoning_effort).toBe("medium");
@@ -4867,6 +4882,10 @@ describe("createAgentChatService", () => {
         model: "gpt-5.4",
       });
 
+      expect(session.permissionMode).toBe("default");
+      expect(session.codexApprovalPolicy).toBe("on-request");
+      expect(session.codexSandbox).toBe("workspace-write");
+
       await service.sendMessage({
         sessionId: session.id,
         text: "Inspect the repo.",
@@ -4876,9 +4895,24 @@ describe("createAgentChatService", () => {
         expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(true);
       });
       const turnStartRequest = mockState.codexRequestPayloads.find((payload) => payload.method === "turn/start");
-      const params = turnStartRequest?.params as { collaborationMode?: Record<string, unknown> } | undefined;
+      const params = turnStartRequest?.params as {
+        approvalPolicy?: unknown;
+        sandboxPolicy?: {
+          type?: unknown;
+          networkAccess?: unknown;
+          readOnlyAccess?: { type?: unknown };
+          writableRoots?: unknown[];
+          excludeTmpdirEnvVar?: unknown;
+          excludeSlashTmp?: unknown;
+        };
+        effort?: unknown;
+        collaborationMode?: Record<string, unknown>;
+      } | undefined;
       const collaborationMode = params?.collaborationMode as { mode?: unknown } | undefined;
 
+      expect(params?.approvalPolicy).toBeUndefined();
+      expect(params?.sandboxPolicy).toBeUndefined();
+      expect(params?.effort).toBe("medium");
       expect(collaborationMode?.mode).toBe("default");
     });
 
@@ -4930,12 +4964,81 @@ describe("createAgentChatService", () => {
 
       await vi.waitFor(() => {
         expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/start")).toBe(true);
+        expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(true);
       });
 
       const threadStartRequest = mockState.codexRequestPayloads.find((payload) => payload.method === "thread/start");
-      const params = threadStartRequest?.params as { approvalPolicy?: unknown; sandbox?: unknown } | undefined;
+      const params = threadStartRequest?.params as {
+        approvalPolicy?: unknown;
+        sandbox?: unknown;
+        reasoningEffort?: unknown;
+      } | undefined;
       expect(params?.approvalPolicy).toBe("never");
       expect(params?.sandbox).toBe("danger-full-access");
+      expect(params?.reasoningEffort).toBeUndefined();
+
+      const turnStartRequest = mockState.codexRequestPayloads.find((payload) => payload.method === "turn/start");
+      const turnStartParams = turnStartRequest?.params as {
+        approvalPolicy?: unknown;
+        sandboxPolicy?: { type?: unknown };
+        effort?: unknown;
+      } | undefined;
+      expect(turnStartParams?.approvalPolicy).toBeUndefined();
+      expect(turnStartParams?.sandboxPolicy).toBeUndefined();
+      expect(turnStartParams?.effort).toBe("medium");
+    });
+
+    it("uses the app-server's effective Codex policy after thread/start without re-overriding it on turn/start", async () => {
+      mockState.codexResponseOverrides.set("thread/start", () => ({
+        thread: { id: "thread-effective-start" },
+        approvalPolicy: "on-failure",
+        sandbox: {
+          type: "workspaceWrite",
+          writableRoots: [],
+          readOnlyAccess: { type: "fullAccess" },
+          networkAccess: true,
+          excludeTmpdirEnvVar: false,
+          excludeSlashTmp: false,
+        },
+        reasoningEffort: "high",
+      }));
+
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Inspect the repo.",
+      });
+
+      await vi.waitFor(() => {
+        expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(true);
+      });
+
+      const turnStartRequest = mockState.codexRequestPayloads.find((payload) => payload.method === "turn/start");
+      const turnStartParams = turnStartRequest?.params as {
+        approvalPolicy?: unknown;
+        sandboxPolicy?: { type?: unknown };
+        effort?: unknown;
+      } | undefined;
+      expect(turnStartParams?.approvalPolicy).toBeUndefined();
+      expect(turnStartParams?.sandboxPolicy).toBeUndefined();
+      expect(turnStartParams?.effort).toBe("high");
+
+      const summary = await service.getSessionSummary(session.id);
+      expect(summary?.codexApprovalPolicy).toBe("on-failure");
+      expect(summary?.codexSandbox).toBe("workspace-write");
+      expect(summary?.permissionMode).toBe("default");
+      expect(summary?.reasoningEffort).toBe("high");
+
+      const persisted = readPersistedChatState(session.id);
+      expect(persisted.codexApprovalPolicy).toBe("on-failure");
+      expect(persisted.codexSandbox).toBe("workspace-write");
+      expect(persisted.reasoningEffort).toBe("high");
     });
 
     it("re-resumes Codex threads when permission mode changes mid-session", async () => {
@@ -4969,6 +5072,17 @@ describe("createAgentChatService", () => {
         expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/start")).toBe(true);
       });
 
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        method: "turn/completed",
+        params: {
+          turn: {
+            id: "turn-1",
+            status: "completed",
+          },
+        },
+      });
+
       mockState.codexRequestPayloads = [];
 
       await service.updateSession({
@@ -4983,12 +5097,30 @@ describe("createAgentChatService", () => {
 
       await vi.waitFor(() => {
         expect(mockState.codexRequestPayloads.some((payload) => payload.method === "thread/resume")).toBe(true);
+        expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(true);
       });
 
       const threadResumeRequest = mockState.codexRequestPayloads.find((payload) => payload.method === "thread/resume");
-      const params = threadResumeRequest?.params as { approvalPolicy?: unknown; sandbox?: unknown } | undefined;
+      const params = threadResumeRequest?.params as {
+        approvalPolicy?: unknown;
+        sandbox?: unknown;
+        reasoningEffort?: unknown;
+      } | undefined;
       expect(params?.approvalPolicy).toBe("never");
       expect(params?.sandbox).toBe("danger-full-access");
+      expect(params?.reasoningEffort).toBeUndefined();
+
+      const turnStartRequest = mockState.codexRequestPayloads.find((payload) => payload.method === "turn/start");
+      const turnStartParams = turnStartRequest?.params as {
+        approvalPolicy?: unknown;
+        sandboxPolicy?: { type?: unknown };
+        collaborationMode?: { mode?: unknown };
+        effort?: unknown;
+      } | undefined;
+      expect(turnStartParams?.approvalPolicy).toBeUndefined();
+      expect(turnStartParams?.sandboxPolicy).toBeUndefined();
+      expect(turnStartParams?.collaborationMode?.mode).toBe("default");
+      expect(turnStartParams?.effort).toBe("medium");
     });
 
     it("re-resumes Codex threads when switching from config-toml to full-auto flags", async () => {
@@ -5026,6 +5158,14 @@ describe("createAgentChatService", () => {
       const startParams = startRequest?.params as Record<string, unknown> | undefined;
       expect(startParams?.approvalPolicy).toBeUndefined();
       expect(startParams?.sandbox).toBeUndefined();
+
+      const startTurnRequest = mockState.codexRequestPayloads.find((payload) => payload.method === "turn/start");
+      const startTurnParams = startTurnRequest?.params as {
+        approvalPolicy?: unknown;
+        sandboxPolicy?: unknown;
+      } | undefined;
+      expect(startTurnParams?.approvalPolicy).toBeUndefined();
+      expect(startTurnParams?.sandboxPolicy).toBeUndefined();
 
       mockState.codexRequestPayloads = [];
 
@@ -5121,6 +5261,47 @@ describe("createAgentChatService", () => {
 
       expect(resumed.id).toBe(session.id);
       expect(sessionService.reopen).toHaveBeenCalledWith(session.id);
+    });
+
+    it("trusts the app-server's effective Codex policy on resume", async () => {
+      mockState.codexResponseOverrides.set("thread/resume", () => ({
+        thread: { id: "thread-effective-resume" },
+        approvalPolicy: "on-failure",
+        sandbox: { type: "workspaceWrite" },
+        reasoningEffort: "high",
+      }));
+
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+        permissionMode: "full-auto",
+      });
+
+      await service.dispose({ sessionId: session.id });
+      const persistedBefore = readPersistedChatState(session.id);
+      writePersistedChatState(session.id, {
+        ...persistedBefore,
+        threadId: "thread-stale-persisted",
+        codexApprovalPolicy: "never",
+        codexSandbox: "danger-full-access",
+        codexConfigSource: "flags",
+        reasoningEffort: "medium",
+      });
+
+      const resumed = await service.resumeSession({ sessionId: session.id });
+
+      expect(resumed.codexApprovalPolicy).toBe("on-failure");
+      expect(resumed.codexSandbox).toBe("workspace-write");
+      expect(resumed.permissionMode).toBe("default");
+      expect(resumed.reasoningEffort).toBe("high");
+
+      const persistedAfter = readPersistedChatState(session.id);
+      expect(persistedAfter.threadId).toBe("thread-effective-resume");
+      expect(persistedAfter.codexApprovalPolicy).toBe("on-failure");
+      expect(persistedAfter.codexSandbox).toBe("workspace-write");
+      expect(persistedAfter.reasoningEffort).toBe("high");
     });
 
     it("throws when resuming an unknown session", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -1723,53 +1723,21 @@ type CodexThreadLifecycleResponse = {
   reasoningEffort?: unknown;
 };
 
-function normalizeCodexRuntimeApprovalPolicy(value: unknown): AgentChatCodexApprovalPolicy | undefined {
-  if (typeof value !== "string") return undefined;
-  switch (value.trim()) {
-    case "untrusted":
-      return "untrusted";
-    case "on-request":
-      return "on-request";
-    case "on-failure":
-      return "on-failure";
-    case "never":
-      return "never";
-    default:
-      return undefined;
-  }
-}
+const CODEX_SANDBOX_CAMEL_CASE_ALIASES: Record<string, AgentChatCodexSandbox> = {
+  readOnly: "read-only",
+  workspaceWrite: "workspace-write",
+  dangerFullAccess: "danger-full-access",
+};
 
 function normalizeCodexRuntimeSandbox(value: unknown): AgentChatCodexSandbox | undefined {
   if (typeof value === "string") {
-    switch (value.trim()) {
-      case "read-only":
-        return "read-only";
-      case "workspace-write":
-        return "workspace-write";
-      case "danger-full-access":
-        return "danger-full-access";
-      case "readOnly":
-        return "read-only";
-      case "workspaceWrite":
-        return "workspace-write";
-      case "dangerFullAccess":
-        return "danger-full-access";
-      default:
-        return undefined;
-    }
+    const trimmed = value.trim();
+    return normalizePersistedCodexSandbox(trimmed) ?? CODEX_SANDBOX_CAMEL_CASE_ALIASES[trimmed];
   }
 
   if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
-  switch ((value as Record<string, unknown>).type) {
-    case "readOnly":
-      return "read-only";
-    case "workspaceWrite":
-      return "workspace-write";
-    case "dangerFullAccess":
-      return "danger-full-access";
-    default:
-      return undefined;
-  }
+  const type = (value as Record<string, unknown>).type;
+  return typeof type === "string" ? CODEX_SANDBOX_CAMEL_CASE_ALIASES[type] : undefined;
 }
 
 function applyCodexEffectiveThreadState(
@@ -1778,7 +1746,7 @@ function applyCodexEffectiveThreadState(
 ): void {
   if (!response) return;
 
-  const approvalPolicy = normalizeCodexRuntimeApprovalPolicy(response.approvalPolicy);
+  const approvalPolicy = normalizePersistedCodexApprovalPolicy(response.approvalPolicy);
   if (approvalPolicy) {
     managed.session.codexApprovalPolicy = approvalPolicy;
   }

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -1716,6 +1716,91 @@ function codexPolicyArgs(policy: ReturnType<typeof mapPermissionToCodex>): Recor
   return policy ? { approvalPolicy: policy.approvalPolicy, sandbox: policy.sandbox } : {};
 }
 
+type CodexThreadLifecycleResponse = {
+  thread?: { id?: string };
+  approvalPolicy?: unknown;
+  sandbox?: unknown;
+  reasoningEffort?: unknown;
+};
+
+function normalizeCodexRuntimeApprovalPolicy(value: unknown): AgentChatCodexApprovalPolicy | undefined {
+  if (typeof value !== "string") return undefined;
+  switch (value.trim()) {
+    case "untrusted":
+      return "untrusted";
+    case "on-request":
+      return "on-request";
+    case "on-failure":
+      return "on-failure";
+    case "never":
+      return "never";
+    default:
+      return undefined;
+  }
+}
+
+function normalizeCodexRuntimeSandbox(value: unknown): AgentChatCodexSandbox | undefined {
+  if (typeof value === "string") {
+    switch (value.trim()) {
+      case "read-only":
+        return "read-only";
+      case "workspace-write":
+        return "workspace-write";
+      case "danger-full-access":
+        return "danger-full-access";
+      case "readOnly":
+        return "read-only";
+      case "workspaceWrite":
+        return "workspace-write";
+      case "dangerFullAccess":
+        return "danger-full-access";
+      default:
+        return undefined;
+    }
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  switch ((value as Record<string, unknown>).type) {
+    case "readOnly":
+      return "read-only";
+    case "workspaceWrite":
+      return "workspace-write";
+    case "dangerFullAccess":
+      return "danger-full-access";
+    default:
+      return undefined;
+  }
+}
+
+function applyCodexEffectiveThreadState(
+  managed: ManagedChatSession,
+  response: CodexThreadLifecycleResponse | null | undefined,
+): void {
+  if (!response) return;
+
+  const approvalPolicy = normalizeCodexRuntimeApprovalPolicy(response.approvalPolicy);
+  if (approvalPolicy) {
+    managed.session.codexApprovalPolicy = approvalPolicy;
+  }
+
+  const sandbox = normalizeCodexRuntimeSandbox(response.sandbox);
+  if (sandbox) {
+    managed.session.codexSandbox = sandbox;
+  }
+
+  const reasoningEffort = validateReasoningEffort(
+    "codex",
+    normalizeReasoningEffort(
+      typeof response.reasoningEffort === "string" ? response.reasoningEffort : null,
+    ),
+  );
+  if (reasoningEffort) {
+    managed.session.reasoningEffort = reasoningEffort;
+  }
+
+  managed.session.permissionMode = syncLegacyPermissionMode(managed.session) ?? managed.session.permissionMode;
+}
+
 function normalizeOpenCodePermissionMode(mode: string | undefined): PermissionMode | undefined {
   if (mode === "default" || mode === "config-toml") return "edit";
   if (mode === "plan" || mode === "edit" || mode === "full-auto") return mode;
@@ -4563,9 +4648,12 @@ export function createAgentChatService(args: {
       if (chat.defaultApprovalPolicy === "auto") return "never" as const;
       if (chat.defaultApprovalPolicy === "approve_all") return "untrusted" as const;
       if (chat.defaultApprovalPolicy === "approve_mutations") return "on-request" as const;
+      // Codex chat defaults should match the documented "Default permissions"
+      // preset: workspace-write + on-request. Legacy shared CLI edit-mode
+      // fallbacks map to "untrusted", but that represents the explicit Codex
+      // edit preset rather than the default chat preset.
       if (cliMode === "full-auto") return "never" as const;
       if (cliMode === "read-only") return "on-request" as const;
-      if (cliMode === "edit") return "untrusted" as const;
       return "on-request" as const;
     })();
 
@@ -6258,6 +6346,7 @@ export function createAgentChatService(args: {
       });
     }
 
+    resolveCodexThreadParams(managed);
     await runtime.collaborationModesReady?.catch(() => {});
     const requestedCollaborationMode = resolveRequestedCodexCollaborationMode(managed.session);
     const collaborationMode = buildCodexCollaborationMode(
@@ -6285,7 +6374,7 @@ export function createAgentChatService(args: {
       result = await managed.runtime.request<{ turn?: { id?: string } }>("turn/start", {
         threadId: managed.session.threadId,
         input,
-        ...(managed.session.reasoningEffort ? { reasoningEffort: managed.session.reasoningEffort } : {}),
+        ...(managed.session.reasoningEffort ? { effort: managed.session.reasoningEffort } : {}),
         ...(collaborationMode ? { collaborationMode } : {}),
       });
     } catch (error) {
@@ -9527,14 +9616,14 @@ export function createAgentChatService(args: {
     runtime: CodexRuntime,
     codexPolicy: CodexPolicy,
   ): Promise<void> => {
-    const startResponse = await runtime.request<{ thread?: { id?: string } }>("thread/start", {
+    const startResponse = await runtime.request<CodexThreadLifecycleResponse>("thread/start", {
       model: managed.session.model,
-      ...(managed.session.reasoningEffort ? { reasoningEffort: managed.session.reasoningEffort } : {}),
       cwd: managed.laneWorktreePath,
       ...codexPolicyArgs(codexPolicy),
       experimentalRawEvents: false,
       persistExtendedHistory: true
     });
+    applyCodexEffectiveThreadState(managed, startResponse);
     const newThreadId = typeof startResponse.thread?.id === "string" ? startResponse.thread.id : undefined;
     if (newThreadId) {
       managed.session.threadId = newThreadId;
@@ -11824,16 +11913,21 @@ export function createAgentChatService(args: {
 
         if (threadIdToResume) {
           try {
-            await runtime.request("thread/resume", {
+            const resumeResponse = await runtime.request<CodexThreadLifecycleResponse>("thread/resume", {
               threadId: threadIdToResume,
               model: managed.session.model,
-              ...(managed.session.reasoningEffort ? { reasoningEffort: managed.session.reasoningEffort } : {}),
               cwd: managed.laneWorktreePath,
               ...codexPolicyArgs(codexPolicy),
               persistExtendedHistory: true
             });
-            managed.session.threadId = threadIdToResume;
+            applyCodexEffectiveThreadState(managed, resumeResponse);
+            const resumedThreadId = typeof resumeResponse.thread?.id === "string"
+              ? resumeResponse.thread.id
+              : threadIdToResume;
+            managed.session.threadId = resumedThreadId;
+            sessionService.setResumeCommand(managed.session.id, `chat:codex:${resumedThreadId}`);
             runtime.threadResumed = true;
+            persistChatState(managed);
             // Fetch skills after resume if not already fetched
             if (runtime.slashCommands.length === 0) {
               runtime.request<{ skills?: Array<{ name?: string; description?: string }> }>("skills/list", {})
@@ -12315,17 +12409,21 @@ export function createAgentChatService(args: {
       if (threadId) {
         const { codexPolicy } = resolveCodexThreadParams(managed);
         try {
-          await runtime.request("thread/resume", {
+          const resumeResponse = await runtime.request<CodexThreadLifecycleResponse>("thread/resume", {
             threadId,
             model: managed.session.model,
-            ...(managed.session.reasoningEffort ? { reasoningEffort: managed.session.reasoningEffort } : {}),
             cwd: managed.laneWorktreePath,
             ...codexPolicyArgs(codexPolicy),
             persistExtendedHistory: true
           });
-          managed.session.threadId = threadId;
+          applyCodexEffectiveThreadState(managed, resumeResponse);
+          const resumedThreadId = typeof resumeResponse.thread?.id === "string"
+            ? resumeResponse.thread.id
+            : threadId;
+          managed.session.threadId = resumedThreadId;
           runtime.threadResumed = true;
-          sessionService.setResumeCommand(sessionId, `chat:codex:${threadId}`);
+          sessionService.setResumeCommand(sessionId, `chat:codex:${resumedThreadId}`);
+          persistChatState(managed);
           // Fetch skills after resume if not already fetched
           if (runtime.slashCommands.length === 0) {
             runtime.request<{ skills?: Array<{ name?: string; description?: string }> }>("skills/list", {})
@@ -12358,9 +12456,6 @@ export function createAgentChatService(args: {
           await startFreshCodexThread(managed, runtime, codexPolicy);
         }
       }
-      // Re-sync codex approval policy from persisted/config settings
-      managed.session.codexApprovalPolicy = persisted?.codexApprovalPolicy ?? managed.session.codexApprovalPolicy;
-      managed.session.codexSandbox = persisted?.codexSandbox ?? managed.session.codexSandbox;
       managed.session.codexConfigSource = persisted?.codexConfigSource ?? managed.session.codexConfigSource;
       managed.session.permissionMode = syncLegacyPermissionMode(managed.session) ?? managed.session.permissionMode;
     } else if (managed.session.provider === "cursor") {

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, type RenderResult } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import { AgentChatComposer } from "./AgentChatComposer";
 
@@ -54,8 +54,8 @@ function buildComposerProps(overrides: Partial<ComponentProps<typeof AgentChatCo
 function renderComposer(overrides: Partial<ComponentProps<typeof AgentChatComposer>> = {}) {
   const props = buildComposerProps(overrides);
 
-  render(<AgentChatComposer {...props} />);
-  return props;
+  const view = render(<AgentChatComposer {...props} />);
+  return Object.assign(view, props) as RenderResult & ComponentProps<typeof AgentChatComposer>;
 }
 
 const executionModeOptions = [
@@ -402,7 +402,7 @@ describe("AgentChatComposer", () => {
   });
 
   it("marks the textarea layout variant in grid-tile mode", () => {
-    renderComposer({
+    const { container } = renderComposer({
       layoutVariant: "grid-tile",
       composerMaxHeightPx: 128,
     });
@@ -410,6 +410,9 @@ describe("AgentChatComposer", () => {
     const textarea = screen.getByPlaceholderText("Steer the active turn...") as HTMLTextAreaElement;
     expect(textarea.dataset.chatLayoutVariant).toBe("grid-tile");
     expect(textarea.className).toContain("resize-none");
+    const composerShell = container.querySelector("[data-chat-composer-mode]");
+    expect(composerShell?.className).not.toContain("rounded-none");
+    expect(composerShell?.parentElement?.className ?? "").not.toContain("rounded-none");
   });
 
   it("focuses the grid composer when the tile becomes active", () => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -1263,10 +1263,10 @@ export function AgentChatComposer({
         duration={composerBeamDuration}
         strength={composerBeamStrength}
         active={composerBeamActive}
-        borderRadius={layoutVariant === "grid-tile" ? 0 : 18}
+        borderRadius={18}
         className={cn(
           "m-3 mt-0 rounded-[var(--chat-radius-shell)]",
-          layoutVariant === "grid-tile" ? "m-0 rounded-none" : "",
+          layoutVariant === "grid-tile" ? "m-0" : "",
         )}
         style={{ overflow: "visible" }}
       >
@@ -1274,7 +1274,7 @@ export function AgentChatComposer({
       mode={surfaceMode}
       glowColor={composerGlowColor}
       className={cn(
-        layoutVariant === "grid-tile" ? "rounded-none border-0 bg-transparent shadow-none" : "",
+        layoutVariant === "grid-tile" ? "border-0 bg-transparent shadow-none" : "",
       )}
       pendingBanner={pendingInput ? (
         pendingInput.kind === "plan_approval" ? (

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.submit.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.submit.test.tsx
@@ -481,6 +481,67 @@ describe("AgentChatPane submit recovery", () => {
     });
   });
 
+  it("waits for Codex permission updates before sending the next turn", async () => {
+    const session = buildSession("session-1", {
+      status: "idle",
+      permissionMode: "default",
+      codexApprovalPolicy: "on-request",
+      codexSandbox: "workspace-write",
+      codexConfigSource: "flags",
+    });
+    const sessions = [session];
+    let resolveUpdateSession: (() => void) | null = null;
+    const updateSession = vi.fn().mockImplementation((args: any) => new Promise((resolve) => {
+      resolveUpdateSession = () => {
+        sessions[0] = {
+          ...sessions[0]!,
+          permissionMode: args.permissionMode ?? sessions[0]!.permissionMode,
+          codexApprovalPolicy: args.codexApprovalPolicy ?? sessions[0]!.codexApprovalPolicy,
+          codexSandbox: args.codexSandbox ?? sessions[0]!.codexSandbox,
+          codexConfigSource: args.codexConfigSource ?? sessions[0]!.codexConfigSource,
+        };
+        resolve(sessions[0]);
+      };
+    }));
+    const { send } = installAdeMocks({
+      sessions,
+    });
+    window.ade.agentChat.updateSession = updateSession as any;
+
+    renderPane(session);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Codex approval preset" }));
+    fireEvent.click(await screen.findByRole("option", { name: "Full access" }));
+
+    await waitFor(() => {
+      expect(updateSession).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: session.sessionId,
+        permissionMode: "full-auto",
+        codexApprovalPolicy: "never",
+        codexSandbox: "danger-full-access",
+        codexConfigSource: "flags",
+      }));
+    });
+
+    const textbox = await screen.findByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "Make the change now." } });
+    fireEvent.click(await screen.findByTitle("Send"));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(send).not.toHaveBeenCalled();
+
+    const flushUpdateSession = resolveUpdateSession as (() => void) | null;
+    expect(flushUpdateSession).toBeTypeOf("function");
+    flushUpdateSession?.();
+
+    await waitFor(() => {
+      expect(send).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: session.sessionId,
+        text: "Make the change now.",
+      }));
+    });
+  });
+
   it("resyncs Claude composer permissions from refreshed session state", async () => {
     const session = buildSession("session-1", {
       status: "idle",

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -789,6 +789,12 @@ export function AgentChatPane({
   const pendingSelectedSessionIdRef = useRef<string | null>(null);
   const submitInFlightRef = useRef(false);
   const createSessionPromiseRef = useRef<Promise<string | null> | null>(null);
+  const pendingNativeControlUpdateRef = useRef<{
+    sessionId: string;
+    updateId: number;
+    promise: Promise<void>;
+  } | null>(null);
+  const nativeControlUpdateCounterRef = useRef(0);
   const pendingEventQueueRef = useRef<AgentChatEventEnvelope[]>([]);
   const eventsBySessionRef = useRef<Record<string, AgentChatEventEnvelope[]>>({});
   const eventFlushTimerRef = useRef<number | null>(null);
@@ -2273,6 +2279,16 @@ export function AgentChatPane({
     if (!modelId) return;
     const text = draft.trim();
     if (!text.length || !laneId) return;
+    const pendingNativeControlUpdate = selectedSessionId
+      ? pendingNativeControlUpdateRef.current
+      : null;
+    if (pendingNativeControlUpdate?.sessionId === selectedSessionId) {
+      try {
+        await pendingNativeControlUpdate.promise;
+      } catch {
+        return;
+      }
+    }
     const draftSnapshot = draft;
     const attachmentsSnapshot = attachments;
     const isLiteralSlashCommand = isProviderSlashCommandInput(text);
@@ -2519,20 +2535,63 @@ export function AgentChatPane({
       setSessionMutationKind("permission");
     }
 
-    try {
-      await window.ade.agentChat.updateSession({
-        sessionId: selectedSessionId,
-        ...nextSummary,
-      });
-      void refreshSessions().catch(() => {});
-    } catch (err) {
-      void refreshSessions().catch(() => {});
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      if (isPersistentIdentitySurface) {
-        setSessionMutationKind(null);
+    const previousUpdate = pendingNativeControlUpdateRef.current?.sessionId === selectedSessionId
+      ? pendingNativeControlUpdateRef.current.promise
+      : null;
+    const updateId = nativeControlUpdateCounterRef.current + 1;
+    nativeControlUpdateCounterRef.current = updateId;
+
+    const updatePromise = (async () => {
+      if (previousUpdate) {
+        try {
+          await previousUpdate;
+        } catch {
+          // The previous mutation already surfaced its error; continue so the
+          // latest picker state still gets pushed to the backend.
+        }
       }
-    }
+
+      try {
+        const updatedSession = await window.ade.agentChat.updateSession({
+          sessionId: selectedSessionId,
+          ...nextSummary,
+        });
+        patchSessionSummary(selectedSessionId, {
+          permissionMode: updatedSession.permissionMode,
+          interactionMode: updatedSession.interactionMode ?? null,
+          claudePermissionMode: updatedSession.claudePermissionMode,
+          codexApprovalPolicy: updatedSession.codexApprovalPolicy,
+          codexSandbox: updatedSession.codexSandbox,
+          codexConfigSource: updatedSession.codexConfigSource,
+          opencodePermissionMode: updatedSession.opencodePermissionMode,
+          cursorModeId: updatedSession.cursorModeId,
+          cursorModeSnapshot: updatedSession.cursorModeSnapshot,
+        });
+        void refreshSessions().catch(() => {});
+      } catch (err) {
+        void refreshSessions().catch(() => {});
+        setError(err instanceof Error ? err.message : String(err));
+        throw err;
+      } finally {
+        if (
+          pendingNativeControlUpdateRef.current?.sessionId === selectedSessionId
+          && pendingNativeControlUpdateRef.current?.updateId === updateId
+        ) {
+          pendingNativeControlUpdateRef.current = null;
+        }
+        if (isPersistentIdentitySurface) {
+          setSessionMutationKind(null);
+        }
+      }
+    })();
+
+    pendingNativeControlUpdateRef.current = {
+      sessionId: selectedSessionId,
+      updateId,
+      promise: updatePromise,
+    };
+
+    await updatePromise;
   }, [
     isPersistentIdentitySurface,
     patchSessionSummary,

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -2279,10 +2279,8 @@ export function AgentChatPane({
     if (!modelId) return;
     const text = draft.trim();
     if (!text.length || !laneId) return;
-    const pendingNativeControlUpdate = selectedSessionId
-      ? pendingNativeControlUpdateRef.current
-      : null;
-    if (pendingNativeControlUpdate?.sessionId === selectedSessionId) {
+    const pendingNativeControlUpdate = pendingNativeControlUpdateRef.current;
+    if (selectedSessionId && pendingNativeControlUpdate?.sessionId === selectedSessionId) {
       try {
         await pendingNativeControlUpdate.promise;
       } catch {
@@ -2538,17 +2536,13 @@ export function AgentChatPane({
     const previousUpdate = pendingNativeControlUpdateRef.current?.sessionId === selectedSessionId
       ? pendingNativeControlUpdateRef.current.promise
       : null;
-    const updateId = nativeControlUpdateCounterRef.current + 1;
-    nativeControlUpdateCounterRef.current = updateId;
+    const updateId = ++nativeControlUpdateCounterRef.current;
 
     const updatePromise = (async () => {
       if (previousUpdate) {
-        try {
-          await previousUpdate;
-        } catch {
-          // The previous mutation already surfaced its error; continue so the
-          // latest picker state still gets pushed to the backend.
-        }
+        // Prior mutation already surfaced any error; wait for it to settle so the
+        // latest picker state still gets pushed to the backend.
+        await previousUpdate.catch(() => {});
       }
 
       try {
@@ -2573,10 +2567,8 @@ export function AgentChatPane({
         setError(err instanceof Error ? err.message : String(err));
         throw err;
       } finally {
-        if (
-          pendingNativeControlUpdateRef.current?.sessionId === selectedSessionId
-          && pendingNativeControlUpdateRef.current?.updateId === updateId
-        ) {
+        const pending = pendingNativeControlUpdateRef.current;
+        if (pending?.sessionId === selectedSessionId && pending.updateId === updateId) {
           pendingNativeControlUpdateRef.current = null;
         }
         if (isPersistentIdentitySurface) {

--- a/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
@@ -261,7 +261,7 @@ export function useLaneWorkSessions(laneId: string | null) {
   }, [laneOpenItemIds, sessionsById]);
 
   const gridLayoutId = useMemo(
-    () => `work:grid:v2:${projectRoot ?? "global"}::${laneId ?? "none"}`,
+    () => `work:grid:tiling:v1:${projectRoot ?? "global"}::${laneId ?? "none"}`,
     [laneId, projectRoot],
   );
 

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.test.tsx
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import type { ReactNode } from "react";
-import { act, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { TerminalSessionSummary } from "../../../shared/types";
 import { WorkViewArea } from "./WorkViewArea";
@@ -20,28 +20,26 @@ vi.mock("./WorkStartSurface", () => ({
   WorkStartSurface: () => <div data-testid="work-start-surface" />,
 }));
 
-vi.mock("./PackedSessionGrid", () => ({
-  PackedSessionGrid: ({
-    tiles,
-    onViewportMouseLeave,
+vi.mock("../ui/PaneTilingLayout", () => ({
+  PaneTilingLayout: ({
+    layoutId,
+    tree,
+    panes,
   }: {
-    tiles: Array<{ id: string; children: ReactNode; onHover?: () => void; onSelect?: () => void }>;
-    onViewportMouseLeave?: () => void;
+    layoutId: string;
+    tree: unknown;
+    panes: Record<string, { children: ReactNode; onPaneMouseDown?: () => void }>;
   }) => {
-    latestPackedSessionGridProps = { tiles, onViewportMouseLeave };
+    latestPaneTilingLayoutProps = { layoutId, tree, panes };
     return (
-      <div data-testid="packed-session-grid" onMouseLeave={onViewportMouseLeave}>
-        {tiles.map((tile) => (
+      <div data-testid="pane-tiling-layout">
+        {Object.entries(panes).map(([paneId, pane]) => (
           <div
-            key={tile.id}
-            data-testid={`packed-session-grid-tile:${tile.id}`}
-            onMouseOver={tile.onHover}
-            onMouseEnter={tile.onHover}
-            onPointerOver={tile.onHover}
-            onPointerEnter={tile.onHover}
-            onMouseDown={tile.onSelect}
+            key={paneId}
+            data-testid={`pane-tiling-layout-pane:${paneId}`}
+            onMouseDown={pane.onPaneMouseDown}
           >
-            {tile.children}
+            {pane.children}
           </div>
         ))}
       </div>
@@ -49,13 +47,14 @@ vi.mock("./PackedSessionGrid", () => ({
   },
 }));
 
-let latestPackedSessionGridProps: {
-  tiles: Array<{ id: string; children: ReactNode; onHover?: () => void; onSelect?: () => void }>;
-  onViewportMouseLeave?: () => void;
+let latestPaneTilingLayoutProps: {
+  layoutId: string;
+  tree: unknown;
+  panes: Record<string, { children: ReactNode; onPaneMouseDown?: () => void }>;
 } | null = null;
 
 beforeEach(() => {
-  latestPackedSessionGridProps = null;
+  latestPaneTilingLayoutProps = null;
 });
 
 vi.mock("./ToolLogos", () => ({
@@ -114,7 +113,7 @@ describe("WorkViewArea", () => {
   it("shows the draft surface when no tab is active, even if tabs are open", () => {
     const session = makeSession();
 
-    render(
+    const view = render(
       <WorkViewArea
         gridLayoutId="work:grid:test"
         lanes={[{
@@ -161,7 +160,7 @@ describe("WorkViewArea", () => {
     const first = makeRunningSession("session-1", "pty-1");
     const second = makeRunningSession("session-2", "pty-2");
 
-    render(
+    const view = render(
       <WorkViewArea
         gridLayoutId="work:grid:test"
         lanes={[{
@@ -203,12 +202,12 @@ describe("WorkViewArea", () => {
     expect(screen.getAllByTestId("terminal-view")).toHaveLength(2);
   });
 
-  it("focuses the hovered grid tile without persisting selection", async () => {
+  it("selects a tiled session when its body is clicked in grid mode", () => {
     const first = makeRunningSession("session-1", "pty-1");
     const second = makeRunningSession("session-2", "pty-2");
     const onSelectItem = vi.fn();
 
-    const { container } = render(
+    const view = render(
       <WorkViewArea
         gridLayoutId="work:grid:test"
         lanes={[{
@@ -247,20 +246,8 @@ describe("WorkViewArea", () => {
       />,
     );
 
-    expect(latestPackedSessionGridProps).not.toBeNull();
-    await act(async () => {
-      latestPackedSessionGridProps?.tiles[1].onHover?.();
-    });
-
-    expect(onSelectItem).not.toHaveBeenCalled();
-    expect(container.querySelector('[data-session-id="session-1"]')?.getAttribute("data-active")).toBe("false");
-    expect(container.querySelector('[data-session-id="session-2"]')?.getAttribute("data-active")).toBe("true");
-
-    await act(async () => {
-      latestPackedSessionGridProps?.onViewportMouseLeave?.();
-    });
-
-    expect(container.querySelector('[data-session-id="session-1"]')?.getAttribute("data-active")).toBe("true");
-    expect(container.querySelector('[data-session-id="session-2"]')?.getAttribute("data-active")).toBe("false");
+    expect(latestPaneTilingLayoutProps?.layoutId).toBe("work:grid:test");
+    fireEvent.mouseDown(within(view.container).getByTestId("pane-tiling-layout-pane:session-2"));
+    expect(onSelectItem).toHaveBeenCalledWith("session-2");
   });
 });

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
@@ -8,17 +8,12 @@ import { AgentChatPane } from "../chat/AgentChatPane";
 import { WorkStartSurface } from "./WorkStartSurface";
 import { isChatToolType, primarySessionLabel, secondarySessionLabel, truncateSessionLabel, formatToolTypeLabel } from "../../lib/sessions";
 import { sessionStatusDot } from "../../lib/terminalAttention";
-import { PackedSessionGrid } from "./PackedSessionGrid";
 import type { WorkTabGroup } from "./useWorkSessions";
-import { ClaudeCacheTtlBadge } from "../shared/ClaudeCacheTtlBadge";
-import { shouldShowClaudeCacheTtl } from "../../lib/claudeCacheTtl";
 import { SmartTooltip } from "../ui/SmartTooltip";
+import { PaneTilingLayout, type PaneConfig } from "../ui/PaneTilingLayout";
+import { cn } from "../ui/cn";
 import { resolveTrackedCliResumeCommand } from "./cliLaunch";
-
-const CHAT_TILE_MIN_WIDTH = 440;
-const CHAT_TILE_MIN_HEIGHT = 340;
-const TERMINAL_TILE_MIN_WIDTH = 320;
-const TERMINAL_TILE_MIN_HEIGHT = 220;
+import { buildWorkSessionTilingTree } from "./workSessionTiling";
 
 function isRunningPtySession(
   session: TerminalSessionSummary | null | undefined,
@@ -296,7 +291,6 @@ export function WorkViewArea({
       .filter((session): session is TerminalSessionSummary => session != null),
     [sessionsById, tabVisibleSessionIds, visibleSessions],
   );
-  const [hoveredGridSessionId, setHoveredGridSessionId] = useState<string | null>(null);
   const showingDraft = activeItemId == null;
   const activeSession = showingDraft
     ? null
@@ -308,110 +302,69 @@ export function WorkViewArea({
       onContextMenu(session, e);
     }
   }, [onContextMenu]);
-  const packedGridTiles = useMemo(() => visibleSessions.map((session) => {
-    const isSelected = activeItemId === session.id;
-    const isActive = (hoveredGridSessionId ?? activeItemId) === session.id;
-    const dot = sessionStatusDot(session);
-    const isBusy = session.ptyId ? closingPtyIds.has(session.ptyId) : false;
-    const primary = primarySessionLabel(session);
-    const secondary = secondarySessionLabel(session);
-    const showClaudeCacheTimer = shouldShowClaudeCacheTtl({
-      provider: session.toolType === "claude-chat" ? "claude" : null,
-      status: session.runtimeState === "idle" ? "idle" : "active",
-      idleSinceAt: session.chatIdleSinceAt,
-      awaitingInput: session.runtimeState === "waiting-input",
-    });
-    return {
-      id: session.id,
-      minWidth: isChatToolType(session.toolType) ? CHAT_TILE_MIN_WIDTH : TERMINAL_TILE_MIN_WIDTH,
-      minHeight: isChatToolType(session.toolType) ? CHAT_TILE_MIN_HEIGHT : TERMINAL_TILE_MIN_HEIGHT,
-      selected: isActive,
-      onSelect: () => onSelectItem(session.id),
-      onHover: () => setHoveredGridSessionId(session.id),
-      className: isActive
-        ? "ade-work-glass-tile-active"
-        : "ade-work-glass-tile",
-      header: (
-        <div
-          className="ade-work-glass-tile-header flex items-center gap-2 px-2 py-1.5"
-          onContextMenu={(e) => handleContextMenu(session, e)}
-        >
-          <button
-            type="button"
-            className="min-w-0 flex-1 text-left"
-            onClick={() => onSelectItem(session.id)}
-          >
-            <span className="flex items-center gap-2 text-[11px]">
-              <span
-                title={dot.label}
-                className={`${dot.cls} h-2 w-2 shrink-0${dot.spinning ? " animate-spin" : ""}`}
-              />
-              <ToolLogo toolType={session.toolType} size={11} />
-              <span className="truncate text-fg">
-                {truncateSessionLabel(primary)}
-              </span>
-              {showClaudeCacheTimer ? (
-                <ClaudeCacheTtlBadge idleSinceAt={session.chatIdleSinceAt} className="px-1 py-0.5 text-[8px]" />
-              ) : null}
-            </span>
-            <span className="mt-0.5 flex items-center gap-2 pl-[18px]">
-              <span className="text-[10px] text-muted-fg/50">
-                {session.laneName}
-              </span>
-              {secondary ? (
-                <span className="truncate text-[10px] text-muted-fg/60">
-                  {truncateSessionLabel(secondary, 36)}
-                </span>
-              ) : null}
-            </span>
-          </button>
-          <button
-            type="button"
-            onClick={() => onCloseItem(session.id)}
-            title={isBusy ? "Closing..." : "Close"}
-            disabled={isBusy}
-            className="inline-flex h-5 w-5 items-center justify-center text-muted-fg/50 transition-colors hover:text-fg"
-            style={{
-              border: "none",
-              background: "transparent",
-              cursor: isBusy ? "default" : "pointer",
-              opacity: isBusy ? 0.4 : 1,
-            }}
-          >
-            <X size={10} />
-          </button>
-        </div>
-      ),
-      children: (
-        <div className="min-h-0 h-full flex-1 overflow-hidden" onContextMenu={(e) => handleContextMenu(session, e)}>
-          <SessionSurface
-            session={session}
-            isActive={isActive}
-            shouldAutofocus={isSelected}
-            terminalVisible
-            layoutVariant="grid-tile"
-            onOpenChatSession={onOpenChatSession}
-            onResume={onResumeSession}
-          />
-        </div>
-      ),
-    };
-  }), [activeItemId, closingPtyIds, handleContextMenu, hoveredGridSessionId, onCloseItem, onOpenChatSession, onResumeSession, onSelectItem, visibleSessions]);
+  const gridTree = useMemo(
+    () => buildWorkSessionTilingTree(visibleSessions.map((session) => session.id)),
+    [visibleSessions],
+  );
+  const tilingPanes = useMemo<Record<string, PaneConfig>>(() => Object.fromEntries(
+    visibleSessions.map((session) => {
+      const dot = sessionStatusDot(session);
+      const isBusy = session.ptyId ? closingPtyIds.has(session.ptyId) : false;
+      const title = truncateSessionLabel(primarySessionLabel(session));
+      return [session.id, {
+        title,
+        meta: session.laneName,
+        minimizable: false,
+        className: cn(
+          "h-full",
+          activeItemId === session.id ? "ade-work-glass-tile ade-work-glass-tile-active" : "ade-work-glass-tile",
+        ),
+        bodyClassName: "overflow-hidden",
+        headerActions: (
+          <>
+            <span
+              title={dot.label}
+              className={`${dot.cls} h-2 w-2 shrink-0${dot.spinning ? " animate-spin" : ""}`}
+            />
+            <button
+              type="button"
+              onClick={() => onCloseItem(session.id)}
+              onMouseDown={(e) => e.stopPropagation()}
+              title={isBusy ? "Closing..." : "Close"}
+              disabled={isBusy}
+              className="inline-flex h-5 w-5 items-center justify-center text-muted-fg/50 transition-colors hover:text-fg"
+              style={{
+                border: "none",
+                background: "transparent",
+                cursor: isBusy ? "default" : "pointer",
+                opacity: isBusy ? 0.4 : 1,
+              }}
+            >
+              <X size={10} />
+            </button>
+          </>
+        ),
+        onPaneMouseDown: () => onSelectItem(session.id),
+        onPaneContextMenu: (e) => handleContextMenu(session, e),
+        children: (
+          <div className="min-h-0 h-full flex-1 overflow-hidden">
+            <SessionSurface
+              session={session}
+              isActive={activeItemId === session.id}
+              shouldAutofocus={activeItemId === session.id}
+              terminalVisible
+              layoutVariant="grid-tile"
+              onOpenChatSession={onOpenChatSession}
+              onResume={onResumeSession}
+            />
+          </div>
+        ),
+      } satisfies PaneConfig];
+    }),
+  ), [activeItemId, closingPtyIds, handleContextMenu, onCloseItem, onOpenChatSession, onResumeSession, onSelectItem, visibleSessions]);
   const resolvedTabGroups = tabGroups ?? [];
   const hasGroupedTabs = resolvedTabGroups.length > 0;
   const toggleTabGroupCollapsed = onToggleTabGroupCollapsed ?? (() => {});
-
-  useEffect(() => {
-    if (viewMode !== "grid") {
-      setHoveredGridSessionId(null);
-    }
-  }, [viewMode]);
-
-  useEffect(() => {
-    if (hoveredGridSessionId && !sessionsById.has(hoveredGridSessionId)) {
-      setHoveredGridSessionId(null);
-    }
-  }, [hoveredGridSessionId, sessionsById]);
 
   if (viewMode === "grid") {
     return (
@@ -439,10 +392,11 @@ export function WorkViewArea({
             </div>
           </div>
         ) : (
-          <PackedSessionGrid
+          <PaneTilingLayout
             layoutId={gridLayoutId}
-            tiles={packedGridTiles}
-            onViewportMouseLeave={() => setHoveredGridSessionId(null)}
+            tree={gridTree}
+            panes={tilingPanes}
+            className="flex-1 min-h-0 px-2 pb-2"
           />
         )}
       </div>

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
@@ -310,15 +310,12 @@ export function WorkViewArea({
     visibleSessions.map((session) => {
       const dot = sessionStatusDot(session);
       const isBusy = session.ptyId ? closingPtyIds.has(session.ptyId) : false;
-      const title = truncateSessionLabel(primarySessionLabel(session));
+      const isActive = activeItemId === session.id;
       return [session.id, {
-        title,
+        title: truncateSessionLabel(primarySessionLabel(session)),
         meta: session.laneName,
         minimizable: false,
-        className: cn(
-          "h-full",
-          activeItemId === session.id ? "ade-work-glass-tile ade-work-glass-tile-active" : "ade-work-glass-tile",
-        ),
+        className: cn("h-full ade-work-glass-tile", isActive && "ade-work-glass-tile-active"),
         bodyClassName: "overflow-hidden",
         headerActions: (
           <>
@@ -350,8 +347,8 @@ export function WorkViewArea({
           <div className="min-h-0 h-full flex-1 overflow-hidden">
             <SessionSurface
               session={session}
-              isActive={activeItemId === session.id}
-              shouldAutofocus={activeItemId === session.id}
+              isActive={isActive}
+              shouldAutofocus={isActive}
               terminalVisible
               layoutVariant="grid-tile"
               onOpenChatSession={onOpenChatSession}

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -794,7 +794,7 @@ export function useWorkSessions() {
   );
 
   const gridLayoutId = useMemo(
-    () => `work:grid:v2:${projectRoot ?? "global"}`,
+    () => `work:grid:tiling:v1:${projectRoot ?? "global"}`,
     [projectRoot],
   );
 

--- a/apps/desktop/src/renderer/components/terminals/workSessionTiling.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/workSessionTiling.test.ts
@@ -25,4 +25,52 @@ describe("buildWorkSessionTilingTree", () => {
     expect((tree.children[1]?.node as { children: unknown[] }).children).toHaveLength(2);
     expect(collectLeafIds(tree)).toEqual(["one", "two", "three", "four", "five"]);
   });
+
+  it("builds an empty vertical tree when no sessions are provided", () => {
+    const tree = buildWorkSessionTilingTree([]);
+    expect(tree.direction).toBe("vertical");
+    expect(tree.children).toHaveLength(0);
+    expect(collectLeafIds(tree)).toEqual([]);
+  });
+
+  it("builds a two-row grid for three sessions", () => {
+    const tree = buildWorkSessionTilingTree(["one", "two", "three"]);
+    expect(tree.direction).toBe("vertical");
+    expect(tree.children).toHaveLength(2);
+    expect(collectLeafIds(tree)).toEqual(["one", "two", "three"]);
+  });
+
+  it("builds a 2x2 layout for four sessions", () => {
+    const tree = buildWorkSessionTilingTree(["one", "two", "three", "four"]);
+    expect(tree.direction).toBe("vertical");
+    expect(tree.children).toHaveLength(2);
+    for (const row of tree.children) {
+      expect(row.node).toMatchObject({ type: "split", direction: "horizontal" });
+      expect((row.node as { children: unknown[] }).children).toHaveLength(2);
+    }
+    expect(collectLeafIds(tree)).toEqual(["one", "two", "three", "four"]);
+  });
+
+  it("builds balanced rows for six sessions", () => {
+    const tree = buildWorkSessionTilingTree(["a", "b", "c", "d", "e", "f"]);
+    expect(tree.direction).toBe("vertical");
+    expect(tree.children).toHaveLength(2);
+    for (const row of tree.children) {
+      expect(row.node).toMatchObject({ type: "split", direction: "horizontal" });
+      expect((row.node as { children: unknown[] }).children).toHaveLength(3);
+    }
+    expect(collectLeafIds(tree)).toEqual(["a", "b", "c", "d", "e", "f"]);
+  });
+
+  it("builds a 3x3 grid for nine sessions", () => {
+    const ids = ["a", "b", "c", "d", "e", "f", "g", "h", "i"];
+    const tree = buildWorkSessionTilingTree(ids);
+    expect(tree.direction).toBe("vertical");
+    expect(tree.children).toHaveLength(3);
+    for (const row of tree.children) {
+      expect(row.node).toMatchObject({ type: "split", direction: "horizontal" });
+      expect((row.node as { children: unknown[] }).children).toHaveLength(3);
+    }
+    expect(collectLeafIds(tree)).toEqual(ids);
+  });
 });

--- a/apps/desktop/src/renderer/components/terminals/workSessionTiling.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/workSessionTiling.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { collectLeafIds } from "../ui/paneTreeOps";
+import { buildWorkSessionTilingTree } from "./workSessionTiling";
+
+describe("buildWorkSessionTilingTree", () => {
+  it("builds a single-pane tree for one session", () => {
+    const tree = buildWorkSessionTilingTree(["one"]);
+    expect(tree.direction).toBe("vertical");
+    expect(collectLeafIds(tree)).toEqual(["one"]);
+  });
+
+  it("builds a single horizontal row for two sessions", () => {
+    const tree = buildWorkSessionTilingTree(["one", "two"]);
+    expect(tree.direction).toBe("horizontal");
+    expect(collectLeafIds(tree)).toEqual(["one", "two"]);
+  });
+
+  it("builds balanced rows for five sessions", () => {
+    const tree = buildWorkSessionTilingTree(["one", "two", "three", "four", "five"]);
+    expect(tree.direction).toBe("vertical");
+    expect(tree.children).toHaveLength(2);
+    expect(tree.children[0]?.node).toMatchObject({ type: "split", direction: "horizontal" });
+    expect(tree.children[1]?.node).toMatchObject({ type: "split", direction: "horizontal" });
+    expect((tree.children[0]?.node as { children: unknown[] }).children).toHaveLength(3);
+    expect((tree.children[1]?.node as { children: unknown[] }).children).toHaveLength(2);
+    expect(collectLeafIds(tree)).toEqual(["one", "two", "three", "four", "five"]);
+  });
+});

--- a/apps/desktop/src/renderer/components/terminals/workSessionTiling.ts
+++ b/apps/desktop/src/renderer/components/terminals/workSessionTiling.ts
@@ -3,19 +3,14 @@ import type { PaneLayoutEntry, PaneSplit } from "../ui/PaneTilingLayout";
 const MIN_PANE_SIZE = 8;
 const MIN_ROW_SIZE = 12;
 
-function createPaneEntry(id: string, defaultSize?: number): PaneLayoutEntry {
-  return {
-    node: { type: "pane", id },
-    defaultSize,
-    minSize: MIN_PANE_SIZE,
-  };
+function paneEntry(id: string, defaultSize: number, minSize: number): PaneLayoutEntry {
+  return { node: { type: "pane", id }, defaultSize, minSize };
 }
 
-function distributeCounts(total: number, bucketCount: number): number[] {
-  if (total <= 0 || bucketCount <= 0) return [];
-  const base = Math.floor(total / bucketCount);
-  const remainder = total % bucketCount;
-  return Array.from({ length: bucketCount }, (_, index) => base + (index < remainder ? 1 : 0));
+function rowSizes(total: number, rowCount: number): number[] {
+  const base = Math.floor(total / rowCount);
+  const remainder = total % rowCount;
+  return Array.from({ length: rowCount }, (_, index) => base + (index < remainder ? 1 : 0));
 }
 
 export function buildWorkSessionTilingTree(sessionIds: string[]): PaneSplit {
@@ -23,23 +18,18 @@ export function buildWorkSessionTilingTree(sessionIds: string[]): PaneSplit {
     return {
       type: "split",
       direction: "vertical",
-      children: sessionIds.map((id) => ({
-        node: { type: "pane", id },
-        defaultSize: 100,
-        minSize: MIN_ROW_SIZE,
-      })),
+      children: sessionIds.map((id) => paneEntry(id, 100, MIN_ROW_SIZE)),
     };
   }
 
   const columnCount = Math.ceil(Math.sqrt(sessionIds.length));
   const rowCount = Math.ceil(sessionIds.length / columnCount);
-  const rowSizes = distributeCounts(sessionIds.length, rowCount);
 
   if (rowCount === 1) {
     return {
       type: "split",
       direction: "horizontal",
-      children: sessionIds.map((id) => createPaneEntry(id, 100 / sessionIds.length)),
+      children: sessionIds.map((id) => paneEntry(id, 100 / sessionIds.length, MIN_PANE_SIZE)),
     };
   }
 
@@ -47,21 +37,17 @@ export function buildWorkSessionTilingTree(sessionIds: string[]): PaneSplit {
   return {
     type: "split",
     direction: "vertical",
-    children: rowSizes.map((rowSize) => {
+    children: rowSizes(sessionIds.length, rowCount).map((rowSize) => {
       const rowIds = sessionIds.slice(offset, offset + rowSize);
       offset += rowSize;
       if (rowIds.length === 1) {
-        return {
-          node: { type: "pane", id: rowIds[0]! },
-          defaultSize: 100 / rowCount,
-          minSize: MIN_ROW_SIZE,
-        };
+        return paneEntry(rowIds[0]!, 100 / rowCount, MIN_ROW_SIZE);
       }
       return {
         node: {
           type: "split",
           direction: "horizontal",
-          children: rowIds.map((id) => createPaneEntry(id, 100 / rowIds.length)),
+          children: rowIds.map((id) => paneEntry(id, 100 / rowIds.length, MIN_PANE_SIZE)),
         },
         defaultSize: 100 / rowCount,
         minSize: MIN_ROW_SIZE,

--- a/apps/desktop/src/renderer/components/terminals/workSessionTiling.ts
+++ b/apps/desktop/src/renderer/components/terminals/workSessionTiling.ts
@@ -1,0 +1,71 @@
+import type { PaneLayoutEntry, PaneSplit } from "../ui/PaneTilingLayout";
+
+const MIN_PANE_SIZE = 8;
+const MIN_ROW_SIZE = 12;
+
+function createPaneEntry(id: string, defaultSize?: number): PaneLayoutEntry {
+  return {
+    node: { type: "pane", id },
+    defaultSize,
+    minSize: MIN_PANE_SIZE,
+  };
+}
+
+function distributeCounts(total: number, bucketCount: number): number[] {
+  if (total <= 0 || bucketCount <= 0) return [];
+  const base = Math.floor(total / bucketCount);
+  const remainder = total % bucketCount;
+  return Array.from({ length: bucketCount }, (_, index) => base + (index < remainder ? 1 : 0));
+}
+
+export function buildWorkSessionTilingTree(sessionIds: string[]): PaneSplit {
+  if (sessionIds.length <= 1) {
+    return {
+      type: "split",
+      direction: "vertical",
+      children: sessionIds.map((id) => ({
+        node: { type: "pane", id },
+        defaultSize: 100,
+        minSize: MIN_ROW_SIZE,
+      })),
+    };
+  }
+
+  const columnCount = Math.ceil(Math.sqrt(sessionIds.length));
+  const rowCount = Math.ceil(sessionIds.length / columnCount);
+  const rowSizes = distributeCounts(sessionIds.length, rowCount);
+
+  if (rowCount === 1) {
+    return {
+      type: "split",
+      direction: "horizontal",
+      children: sessionIds.map((id) => createPaneEntry(id, 100 / sessionIds.length)),
+    };
+  }
+
+  let offset = 0;
+  return {
+    type: "split",
+    direction: "vertical",
+    children: rowSizes.map((rowSize) => {
+      const rowIds = sessionIds.slice(offset, offset + rowSize);
+      offset += rowSize;
+      if (rowIds.length === 1) {
+        return {
+          node: { type: "pane", id: rowIds[0]! },
+          defaultSize: 100 / rowCount,
+          minSize: MIN_ROW_SIZE,
+        };
+      }
+      return {
+        node: {
+          type: "split",
+          direction: "horizontal",
+          children: rowIds.map((id) => createPaneEntry(id, 100 / rowIds.length)),
+        },
+        defaultSize: 100 / rowCount,
+        minSize: MIN_ROW_SIZE,
+      };
+    }),
+  };
+}

--- a/apps/desktop/src/renderer/components/ui/FloatingPane.tsx
+++ b/apps/desktop/src/renderer/components/ui/FloatingPane.tsx
@@ -39,6 +39,8 @@ export function FloatingPane({
   onDragEnd,
   onDrop,
   onDragLeave,
+  onPaneMouseDown,
+  onPaneContextMenu,
   minimizeBehavior = "css",
   className,
   bodyClassName,
@@ -62,6 +64,8 @@ export function FloatingPane({
   onDragEnd?: () => void;
   onDrop?: () => void;
   onDragLeave?: () => void;
+  onPaneMouseDown?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onPaneContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void;
   minimizeBehavior?: "css" | "native";
   className?: string;
   bodyClassName?: string;
@@ -113,6 +117,8 @@ export function FloatingPane({
       onDragOver={isDraggable ? handleDragOver : undefined}
       onDrop={isDraggable ? handleDrop : undefined}
       onDragLeave={isDraggable ? handleDragLeave : undefined}
+      onMouseDown={onPaneMouseDown}
+      onContextMenu={onPaneContextMenu}
     >
       <div
         className={cn("ade-floating-pane-header", minimized && "ade-floating-pane-header-minimized")}

--- a/apps/desktop/src/renderer/components/ui/PaneTilingLayout.tsx
+++ b/apps/desktop/src/renderer/components/ui/PaneTilingLayout.tsx
@@ -12,6 +12,7 @@ import {
   splitPaneAtEdge,
   swapPanes,
   isValidTree,
+  reconcilePaneTree,
   type PaneLeaf,
   type PaneSplit,
   type DropEdge
@@ -27,9 +28,12 @@ export type PaneConfig = {
   icon?: PhosphorIcon;
   meta?: React.ReactNode;
   minimizable?: boolean;
+  className?: string;
   headerActions?: React.ReactNode;
   bodyClassName?: string;
   dataTour?: string;
+  onPaneMouseDown?: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onPaneContextMenu?: (e: React.MouseEvent<HTMLDivElement>) => void;
   children: React.ReactNode;
 };
 
@@ -67,6 +71,22 @@ export function PaneTilingLayout({
   const leafPanelRefs = useRef<Record<string, PanelImperativeHandle | null>>({});
   const leafCompactedRef = useRef<Record<string, { compacted: boolean; previousSize: number | null; parentDirection: "horizontal" | "vertical" }>>({});
 
+  const resetSavedLayout = useCallback(() => {
+    saveLayout({});
+  }, [saveLayout]);
+
+  const replaceTreeImmediately = useCallback((next: PaneSplit, resetLayout = false) => {
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+    setLiveTree(next);
+    if (resetLayout) {
+      resetSavedLayout();
+    }
+    window.ade.tilingTree.set(layoutId, next).catch(() => {});
+  }, [layoutId, resetSavedLayout]);
+
   // Load persisted tree on mount
   useEffect(() => {
     let cancelled = false;
@@ -76,8 +96,12 @@ export function PaneTilingLayout({
         if (cancelled) return;
         if (saved && typeof saved === "object" && (saved as PaneSplit).type === "split") {
           const candidate = saved as PaneSplit;
-          if (isValidTree(candidate, expectedPaneIds)) {
-            setLiveTree(candidate);
+          const reconciled = reconcilePaneTree(candidate, expectedPaneIds, tree);
+          const changed = JSON.stringify(candidate) !== JSON.stringify(reconciled);
+          if (changed) {
+            replaceTreeImmediately(reconciled, true);
+          } else {
+            setLiveTree(reconciled);
           }
         }
         setTreeLoaded(true);
@@ -92,20 +116,22 @@ export function PaneTilingLayout({
   useEffect(() => {
     if (!treeLoaded) return;
     if (!isValidTree(liveTree, expectedPaneIds)) {
-      setLiveTree(tree);
+      const reconciled = reconcilePaneTree(liveTree, expectedPaneIds, tree);
+      replaceTreeImmediately(reconciled, true);
     }
-  }, [expectedPaneIds, treeLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [expectedPaneIds, replaceTreeImmediately, tree, treeLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Persist tree changes (debounced)
   const persistTree = useCallback(
     (next: PaneSplit) => {
       setLiveTree(next);
+      resetSavedLayout();
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       saveTimerRef.current = setTimeout(() => {
         window.ade.tilingTree.set(layoutId, next).catch(() => {});
       }, 300);
     },
-    [layoutId]
+    [layoutId, resetSavedLayout]
   );
 
   /* ---- Minimize state ---- */
@@ -349,6 +375,7 @@ export function PaneTilingLayout({
           onMinimizeToggle={() => toggleMinimize(paneId)}
           minimizable={config.minimizable ?? true}
           headerActions={config.headerActions}
+          className={config.className}
           bodyClassName={config.bodyClassName}
           dataTour={config.dataTour}
           draggable
@@ -360,8 +387,9 @@ export function PaneTilingLayout({
           onDragEnd={handleDragEnd}
           onDrop={handleDrop}
           onDragLeave={handleDragLeave}
+          onPaneMouseDown={config.onPaneMouseDown}
+          onPaneContextMenu={config.onPaneContextMenu}
           minimizeBehavior="css"
-          className="h-full"
         >
           {config.children}
         </FloatingPane>

--- a/apps/desktop/src/renderer/components/ui/PaneTilingLayout.tsx
+++ b/apps/desktop/src/renderer/components/ui/PaneTilingLayout.tsx
@@ -71,21 +71,15 @@ export function PaneTilingLayout({
   const leafPanelRefs = useRef<Record<string, PanelImperativeHandle | null>>({});
   const leafCompactedRef = useRef<Record<string, { compacted: boolean; previousSize: number | null; parentDirection: "horizontal" | "vertical" }>>({});
 
-  const resetSavedLayout = useCallback(() => {
-    saveLayout({});
-  }, [saveLayout]);
-
   const replaceTreeImmediately = useCallback((next: PaneSplit, resetLayout = false) => {
     if (saveTimerRef.current) {
       clearTimeout(saveTimerRef.current);
       saveTimerRef.current = null;
     }
     setLiveTree(next);
-    if (resetLayout) {
-      resetSavedLayout();
-    }
+    if (resetLayout) saveLayout({});
     window.ade.tilingTree.set(layoutId, next).catch(() => {});
-  }, [layoutId, resetSavedLayout]);
+  }, [layoutId, saveLayout]);
 
   // Load persisted tree on mount
   useEffect(() => {
@@ -96,12 +90,10 @@ export function PaneTilingLayout({
         if (cancelled) return;
         if (saved && typeof saved === "object" && (saved as PaneSplit).type === "split") {
           const candidate = saved as PaneSplit;
-          const reconciled = reconcilePaneTree(candidate, expectedPaneIds, tree);
-          const changed = JSON.stringify(candidate) !== JSON.stringify(reconciled);
-          if (changed) {
-            replaceTreeImmediately(reconciled, true);
+          if (isValidTree(candidate, expectedPaneIds)) {
+            setLiveTree(candidate);
           } else {
-            setLiveTree(reconciled);
+            replaceTreeImmediately(reconcilePaneTree(candidate, expectedPaneIds, tree), true);
           }
         }
         setTreeLoaded(true);
@@ -116,8 +108,7 @@ export function PaneTilingLayout({
   useEffect(() => {
     if (!treeLoaded) return;
     if (!isValidTree(liveTree, expectedPaneIds)) {
-      const reconciled = reconcilePaneTree(liveTree, expectedPaneIds, tree);
-      replaceTreeImmediately(reconciled, true);
+      replaceTreeImmediately(reconcilePaneTree(liveTree, expectedPaneIds, tree), true);
     }
   }, [expectedPaneIds, replaceTreeImmediately, tree, treeLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -125,13 +116,13 @@ export function PaneTilingLayout({
   const persistTree = useCallback(
     (next: PaneSplit) => {
       setLiveTree(next);
-      resetSavedLayout();
+      saveLayout({});
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       saveTimerRef.current = setTimeout(() => {
         window.ade.tilingTree.set(layoutId, next).catch(() => {});
       }, 300);
     },
-    [layoutId, resetSavedLayout]
+    [layoutId, saveLayout]
   );
 
   /* ---- Minimize state ---- */

--- a/apps/desktop/src/renderer/components/ui/paneTreeOps.test.ts
+++ b/apps/desktop/src/renderer/components/ui/paneTreeOps.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { collectLeafIds, reconcilePaneTree, splitPaneAtEdge, type PaneSplit } from "./paneTreeOps";
+import {
+  collectLeafIds,
+  detectDropEdge,
+  flattenSingleChildSplits,
+  isValidTree,
+  reconcilePaneTree,
+  removePaneFromTree,
+  splitPaneAtEdge,
+  swapPanes,
+  type PaneLeaf,
+  type PaneSplit,
+} from "./paneTreeOps";
 
 const FALLBACK_TREE: PaneSplit = {
   type: "split",
@@ -120,4 +131,279 @@ describe("reconcilePaneTree", () => {
     expect(next.direction).toBe("vertical");
     expect(collectLeafIds(next)).toEqual(["session-a", "session-b"]);
   });
+
+  it("returns the fallback tree when every expected pane id has been dropped", () => {
+    const tree: PaneSplit = {
+      type: "split",
+      direction: "horizontal",
+      children: [
+        { node: { type: "pane", id: "dead-a" }, defaultSize: 50, minSize: 5 },
+        { node: { type: "pane", id: "dead-b" }, defaultSize: 50, minSize: 5 },
+      ],
+    };
+
+    const reconciled = reconcilePaneTree(tree, ["session-a", "session-b"], FALLBACK_TREE);
+
+    expect(reconciled).toEqual(FALLBACK_TREE);
+  });
+
+  it("leaves an unchanged valid tree structurally intact", () => {
+    const tree: PaneSplit = {
+      type: "split",
+      direction: "horizontal",
+      children: [
+        { node: { type: "pane", id: "session-a" }, defaultSize: 50, minSize: 5 },
+        { node: { type: "pane", id: "session-b" }, defaultSize: 50, minSize: 5 },
+      ],
+    };
+
+    const reconciled = reconcilePaneTree(tree, ["session-a", "session-b"], FALLBACK_TREE);
+
+    expect(reconciled).toEqual(tree);
+  });
+});
+
+describe("detectDropEdge", () => {
+  const rect = { left: 0, top: 0, width: 100, height: 100 } as DOMRect;
+
+  it("returns top when the pointer is inside the top 25% band", () => {
+    expect(detectDropEdge(rect, 50, 10)).toBe("top");
+  });
+
+  it("returns bottom when the pointer is past the 75% vertical threshold", () => {
+    expect(detectDropEdge(rect, 50, 90)).toBe("bottom");
+  });
+
+  it("returns left when the pointer is inside the left 25% band and not near a vertical edge", () => {
+    expect(detectDropEdge(rect, 10, 50)).toBe("left");
+  });
+
+  it("returns right when the pointer is past the 75% horizontal threshold", () => {
+    expect(detectDropEdge(rect, 90, 50)).toBe("right");
+  });
+
+  it("returns center when the pointer is well inside the central area", () => {
+    expect(detectDropEdge(rect, 50, 50)).toBe("center");
+  });
+
+  it("prefers vertical edges over horizontal edges when both thresholds are met", () => {
+    expect(detectDropEdge(rect, 10, 10)).toBe("top");
+  });
+});
+
+describe("removePaneFromTree", () => {
+  it("returns null when removing the only pane from a leaf", () => {
+    const leaf: PaneLeaf = { type: "pane", id: "only" };
+    expect(removePaneFromTree(leaf, "only")).toBeNull();
+  });
+
+  it("returns the leaf unchanged when the target id is not present", () => {
+    const leaf: PaneLeaf = { type: "pane", id: "keep" };
+    expect(removePaneFromTree(leaf, "missing")).toBe(leaf);
+  });
+
+  it("removes a pane from a split and flattens single-child results to a leaf", () => {
+    const split: PaneSplit = {
+      type: "split",
+      direction: "horizontal",
+      children: [
+        { node: { type: "pane", id: "a" }, defaultSize: 50, minSize: 5 },
+        { node: { type: "pane", id: "b" }, defaultSize: 50, minSize: 5 },
+      ],
+    };
+
+    const result = removePaneFromTree(split, "a");
+
+    expect(result).toEqual({ type: "pane", id: "b" });
+  });
+
+  it("removes a pane from a nested split and preserves sibling structure", () => {
+    const tree: PaneSplit = {
+      type: "split",
+      direction: "vertical",
+      children: [
+        {
+          node: {
+            type: "split",
+            direction: "horizontal",
+            children: [
+              { node: { type: "pane", id: "a" }, defaultSize: 50, minSize: 5 },
+              { node: { type: "pane", id: "b" }, defaultSize: 50, minSize: 5 },
+            ],
+          },
+          defaultSize: 50,
+          minSize: 5,
+        },
+        { node: { type: "pane", id: "c" }, defaultSize: 50, minSize: 5 },
+      ],
+    };
+
+    const result = removePaneFromTree(tree, "a");
+
+    expect(result).not.toBeNull();
+    expect(collectLeafIds(result!)).toEqual(["b", "c"]);
+  });
+});
+
+describe("flattenSingleChildSplits", () => {
+  it("returns a leaf untouched", () => {
+    const leaf: PaneLeaf = { type: "pane", id: "x" };
+    expect(flattenSingleChildSplits(leaf)).toBe(leaf);
+  });
+
+  it("collapses a split with a single child down to that child's node", () => {
+    const tree: PaneSplit = {
+      type: "split",
+      direction: "horizontal",
+      children: [
+        { node: { type: "pane", id: "only" }, defaultSize: 100, minSize: 5 },
+      ],
+    };
+
+    expect(flattenSingleChildSplits(tree)).toEqual({ type: "pane", id: "only" });
+  });
+
+  it("collapses nested single-child splits recursively", () => {
+    const tree: PaneSplit = {
+      type: "split",
+      direction: "vertical",
+      children: [
+        {
+          node: {
+            type: "split",
+            direction: "horizontal",
+            children: [
+              { node: { type: "pane", id: "inner" }, defaultSize: 100, minSize: 5 },
+            ],
+          },
+          defaultSize: 100,
+          minSize: 5,
+        },
+      ],
+    };
+
+    expect(flattenSingleChildSplits(tree)).toEqual({ type: "pane", id: "inner" });
+  });
+});
+
+describe("swapPanes", () => {
+  it("swaps two leaf ids that both appear in the tree", () => {
+    const tree: PaneSplit = {
+      type: "split",
+      direction: "horizontal",
+      children: [
+        { node: { type: "pane", id: "a" }, defaultSize: 50, minSize: 5 },
+        { node: { type: "pane", id: "b" }, defaultSize: 50, minSize: 5 },
+      ],
+    };
+
+    const swapped = swapPanes(tree, "a", "b");
+
+    expect(collectLeafIds(swapped)).toEqual(["b", "a"]);
+  });
+
+  it("swaps ids across nested splits", () => {
+    const tree: PaneSplit = {
+      type: "split",
+      direction: "vertical",
+      children: [
+        {
+          node: {
+            type: "split",
+            direction: "horizontal",
+            children: [
+              { node: { type: "pane", id: "a" }, defaultSize: 50, minSize: 5 },
+              { node: { type: "pane", id: "b" }, defaultSize: 50, minSize: 5 },
+            ],
+          },
+          defaultSize: 50,
+          minSize: 5,
+        },
+        { node: { type: "pane", id: "c" }, defaultSize: 50, minSize: 5 },
+      ],
+    };
+
+    const swapped = swapPanes(tree, "a", "c");
+
+    expect(collectLeafIds(swapped)).toEqual(["c", "b", "a"]);
+  });
+
+  it("returns the tree unchanged when neither id is present", () => {
+    const tree: PaneSplit = {
+      type: "split",
+      direction: "horizontal",
+      children: [
+        { node: { type: "pane", id: "a" }, defaultSize: 50, minSize: 5 },
+        { node: { type: "pane", id: "b" }, defaultSize: 50, minSize: 5 },
+      ],
+    };
+
+    expect(swapPanes(tree, "x", "y")).toEqual(tree);
+  });
+});
+
+describe("isValidTree", () => {
+  const baseTree: PaneSplit = {
+    type: "split",
+    direction: "horizontal",
+    children: [
+      { node: { type: "pane", id: "a" }, defaultSize: 50, minSize: 5 },
+      { node: { type: "pane", id: "b" }, defaultSize: 50, minSize: 5 },
+    ],
+  };
+
+  it("accepts a tree whose leaves exactly match the expected ids", () => {
+    expect(isValidTree(baseTree, ["a", "b"])).toBe(true);
+  });
+
+  it("rejects a tree with extra panes", () => {
+    expect(isValidTree(baseTree, ["a"])).toBe(false);
+  });
+
+  it("rejects a tree with missing panes", () => {
+    expect(isValidTree(baseTree, ["a", "b", "c"])).toBe(false);
+  });
+
+  it("rejects a tree with duplicate pane ids", () => {
+    const duplicate: PaneSplit = {
+      type: "split",
+      direction: "horizontal",
+      children: [
+        { node: { type: "pane", id: "a" }, defaultSize: 50, minSize: 5 },
+        { node: { type: "pane", id: "a" }, defaultSize: 50, minSize: 5 },
+      ],
+    };
+    expect(isValidTree(duplicate, ["a", "b"])).toBe(false);
+  });
+});
+
+describe("splitPaneAtEdge", () => {
+  const baseTree: PaneSplit = {
+    type: "split",
+    direction: "horizontal",
+    children: [
+      { node: { type: "pane", id: "a" }, defaultSize: 33, minSize: 5 },
+      { node: { type: "pane", id: "b" }, defaultSize: 33, minSize: 5 },
+      { node: { type: "pane", id: "c" }, defaultSize: 34, minSize: 5 },
+    ],
+  };
+
+  it("places the dragged pane before the target when dropping on the left edge", () => {
+    const next = splitPaneAtEdge(baseTree, "c", "a", "left");
+
+    const replaced = next.children.find((child) => child.node.type === "split");
+    const nestedIds = replaced ? collectLeafIds(replaced.node) : [];
+    expect(nestedIds).toEqual(["a", "c"]);
+  });
+
+  it("places the dragged pane after the target when dropping on the right edge", () => {
+    const next = splitPaneAtEdge(baseTree, "b", "a", "right");
+
+    const replaced = next.children.find(
+      (child) => child.node.type === "split" && collectLeafIds(child.node).includes("a"),
+    );
+    const nestedIds = replaced ? collectLeafIds(replaced.node) : [];
+    expect(nestedIds).toEqual(["b", "a"]);
+  });
+
 });

--- a/apps/desktop/src/renderer/components/ui/paneTreeOps.test.ts
+++ b/apps/desktop/src/renderer/components/ui/paneTreeOps.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { collectLeafIds, reconcilePaneTree, splitPaneAtEdge, type PaneSplit } from "./paneTreeOps";
+
+const FALLBACK_TREE: PaneSplit = {
+  type: "split",
+  direction: "vertical",
+  children: [
+    { node: { type: "pane", id: "session-a" }, defaultSize: 50, minSize: 5 },
+    { node: { type: "pane", id: "session-b" }, defaultSize: 50, minSize: 5 },
+  ],
+};
+
+describe("reconcilePaneTree", () => {
+  it("falls back when the persisted tree contains duplicate pane ids", () => {
+    const duplicateTree: PaneSplit = {
+      type: "split",
+      direction: "horizontal",
+      children: [
+        { node: { type: "pane", id: "session-a" }, defaultSize: 50, minSize: 5 },
+        { node: { type: "pane", id: "session-a" }, defaultSize: 50, minSize: 5 },
+      ],
+    };
+
+    const reconciled = reconcilePaneTree(duplicateTree, ["session-a", "session-b"], FALLBACK_TREE);
+
+    expect(reconciled).toEqual(FALLBACK_TREE);
+  });
+
+  it("preserves valid panes and inserts missing panes by splitting an existing leaf", () => {
+    const persistedTree: PaneSplit = {
+      type: "split",
+      direction: "horizontal",
+      children: [
+        { node: { type: "pane", id: "session-a" }, defaultSize: 100, minSize: 5 },
+      ],
+    };
+
+    const reconciled = reconcilePaneTree(persistedTree, ["session-a", "session-b"], FALLBACK_TREE);
+
+    expect(collectLeafIds(reconciled)).toEqual(["session-a", "session-b"]);
+    expect(reconciled.direction).toBe("horizontal");
+    expect(reconciled.children).toHaveLength(2);
+  });
+
+  it("keeps the root structure stable when adding a pane to a nested layout", () => {
+    const persistedTree: PaneSplit = {
+      type: "split",
+      direction: "vertical",
+      children: [
+        {
+          node: {
+            type: "split",
+            direction: "horizontal",
+            children: [
+              { node: { type: "pane", id: "session-a" }, defaultSize: 50, minSize: 5 },
+              { node: { type: "pane", id: "session-b" }, defaultSize: 50, minSize: 5 },
+            ],
+          },
+          defaultSize: 60,
+          minSize: 5,
+        },
+        { node: { type: "pane", id: "session-c" }, defaultSize: 40, minSize: 5 },
+      ],
+    };
+
+    const fallback: PaneSplit = {
+      type: "split",
+      direction: "vertical",
+      children: [
+        {
+          node: {
+            type: "split",
+            direction: "horizontal",
+            children: [
+              { node: { type: "pane", id: "session-a" }, defaultSize: 50, minSize: 5 },
+              { node: { type: "pane", id: "session-b" }, defaultSize: 50, minSize: 5 },
+            ],
+          },
+          defaultSize: 50,
+          minSize: 5,
+        },
+        {
+          node: {
+            type: "split",
+            direction: "horizontal",
+            children: [
+              { node: { type: "pane", id: "session-c" }, defaultSize: 50, minSize: 5 },
+              { node: { type: "pane", id: "session-d" }, defaultSize: 50, minSize: 5 },
+            ],
+          },
+          defaultSize: 50,
+          minSize: 5,
+        },
+      ],
+    };
+
+    const reconciled = reconcilePaneTree(
+      persistedTree,
+      ["session-a", "session-b", "session-c", "session-d"],
+      fallback,
+    );
+
+    expect(collectLeafIds(reconciled)).toEqual(["session-a", "session-b", "session-c", "session-d"]);
+    expect(reconciled.direction).toBe("vertical");
+    expect(reconciled.children).toHaveLength(2);
+  });
+
+  it("re-splits a two-pane layout when dropping one pane on the other's edge", () => {
+    const twoPaneTree: PaneSplit = {
+      type: "split",
+      direction: "horizontal",
+      children: [
+        { node: { type: "pane", id: "session-a" }, defaultSize: 50, minSize: 5 },
+        { node: { type: "pane", id: "session-b" }, defaultSize: 50, minSize: 5 },
+      ],
+    };
+
+    const next = splitPaneAtEdge(twoPaneTree, "session-b", "session-a", "top");
+
+    expect(next.direction).toBe("vertical");
+    expect(collectLeafIds(next)).toEqual(["session-a", "session-b"]);
+  });
+});

--- a/apps/desktop/src/renderer/components/ui/paneTreeOps.ts
+++ b/apps/desktop/src/renderer/components/ui/paneTreeOps.ts
@@ -95,6 +95,10 @@ function coercePaneNodeToSplit(
   };
 }
 
+function perpendicular(direction: PaneSplit["direction"]): PaneSplit["direction"] {
+  return direction === "horizontal" ? "vertical" : "horizontal";
+}
+
 type LeafCandidate = {
   id: string;
   parentDirection: PaneSplit["direction"] | null;
@@ -122,18 +126,15 @@ function insertPaneIntoLargestLeaf(
   paneId: string,
   fallbackDirection: PaneSplit["direction"]
 ): PaneSplit {
-  const candidates = collectLeafCandidates(tree, null, 100);
-  const target = candidates.reduce<LeafCandidate | null>((largest, candidate) => {
-    if (largest == null || candidate.weight > largest.weight) return candidate;
-    return largest;
-  }, null);
+  let target: LeafCandidate | null = null;
+  for (const candidate of collectLeafCandidates(tree, null, 100)) {
+    if (target == null || candidate.weight > target.weight) target = candidate;
+  }
   if (!target) return tree;
 
   const direction = target.parentDirection == null
     ? fallbackDirection
-    : target.parentDirection === "horizontal"
-      ? "vertical"
-      : "horizontal";
+    : perpendicular(target.parentDirection);
 
   return replaceLeaf(tree, target.id, {
     type: "split",
@@ -151,36 +152,29 @@ export function reconcilePaneTree(
   fallback: PaneSplit
 ): PaneSplit {
   const expected = new Set(expectedPaneIds);
-  let next: PaneLeaf | PaneSplit | null = tree;
+  let pruned: PaneLeaf | PaneSplit | null = tree;
   for (const paneId of collectLeafIds(tree)) {
-    if (next == null) break;
-    if (!expected.has(paneId)) {
-      next = removePaneFromTree(next, paneId);
-    }
+    if (pruned == null) break;
+    if (!expected.has(paneId)) pruned = removePaneFromTree(pruned, paneId);
   }
+  if (pruned == null) return fallback;
 
-  if (next == null) return fallback;
-
-  const flattened = flattenSingleChildSplits(next);
-  const flattenedLeafIds = collectLeafIds(flattened);
+  const flattened = flattenSingleChildSplits(pruned);
   const present = new Set<string>();
-  for (const paneId of flattenedLeafIds) {
-    if (!expected.has(paneId) || present.has(paneId)) {
-      return fallback;
-    }
+  for (const paneId of collectLeafIds(flattened)) {
+    if (!expected.has(paneId) || present.has(paneId)) return fallback;
     present.add(paneId);
   }
-  const missingPaneIds = expectedPaneIds.filter((paneId) => !present.has(paneId));
-  if (missingPaneIds.length === 0) {
-    return coercePaneNodeToSplit(flattened, fallback.direction);
-  }
 
+  const missing = expectedPaneIds.filter((paneId) => !present.has(paneId));
   const base = coercePaneNodeToSplit(flattened, fallback.direction);
-  const withInsertedPanes = missingPaneIds.reduce(
-    (currentTree, paneId) => insertPaneIntoLargestLeaf(currentTree, paneId, fallback.direction),
+  if (missing.length === 0) return base;
+
+  const withInserts = missing.reduce(
+    (current, paneId) => insertPaneIntoLargestLeaf(current, paneId, fallback.direction),
     base,
   );
-  return coercePaneNodeToSplit(flattenSingleChildSplits(withInsertedPanes), fallback.direction);
+  return coercePaneNodeToSplit(flattenSingleChildSplits(withInserts), fallback.direction);
 }
 
 /* ---- Split a pane at an edge ---- */

--- a/apps/desktop/src/renderer/components/ui/paneTreeOps.ts
+++ b/apps/desktop/src/renderer/components/ui/paneTreeOps.ts
@@ -83,6 +83,106 @@ export function flattenSingleChildSplits(
   return { ...node, children: simplified };
 }
 
+function coercePaneNodeToSplit(
+  node: PaneLeaf | PaneSplit,
+  direction: PaneSplit["direction"]
+): PaneSplit {
+  if (node.type === "split") return node;
+  return {
+    type: "split",
+    direction,
+    children: [{ node, defaultSize: 100, minSize: 5 }]
+  };
+}
+
+type LeafCandidate = {
+  id: string;
+  parentDirection: PaneSplit["direction"] | null;
+  weight: number;
+};
+
+function collectLeafCandidates(
+  node: PaneLeaf | PaneSplit,
+  parentDirection: PaneSplit["direction"] | null,
+  weight: number
+): LeafCandidate[] {
+  if (node.type === "pane") {
+    return [{ id: node.id, parentDirection, weight }];
+  }
+
+  const defaultWeight = weight / Math.max(1, node.children.length);
+  return node.children.flatMap((child) => {
+    const nextWeight = child.defaultSize != null ? (weight * child.defaultSize) / 100 : defaultWeight;
+    return collectLeafCandidates(child.node, node.direction, nextWeight);
+  });
+}
+
+function insertPaneIntoLargestLeaf(
+  tree: PaneSplit,
+  paneId: string,
+  fallbackDirection: PaneSplit["direction"]
+): PaneSplit {
+  const candidates = collectLeafCandidates(tree, null, 100);
+  const target = candidates.reduce<LeafCandidate | null>((largest, candidate) => {
+    if (largest == null || candidate.weight > largest.weight) return candidate;
+    return largest;
+  }, null);
+  if (!target) return tree;
+
+  const direction = target.parentDirection == null
+    ? fallbackDirection
+    : target.parentDirection === "horizontal"
+      ? "vertical"
+      : "horizontal";
+
+  return replaceLeaf(tree, target.id, {
+    type: "split",
+    direction,
+    children: [
+      { node: { type: "pane", id: target.id }, defaultSize: 50, minSize: 5 },
+      { node: { type: "pane", id: paneId }, defaultSize: 50, minSize: 5 },
+    ],
+  });
+}
+
+export function reconcilePaneTree(
+  tree: PaneLeaf | PaneSplit,
+  expectedPaneIds: string[],
+  fallback: PaneSplit
+): PaneSplit {
+  const expected = new Set(expectedPaneIds);
+  let next: PaneLeaf | PaneSplit | null = tree;
+  for (const paneId of collectLeafIds(tree)) {
+    if (next == null) break;
+    if (!expected.has(paneId)) {
+      next = removePaneFromTree(next, paneId);
+    }
+  }
+
+  if (next == null) return fallback;
+
+  const flattened = flattenSingleChildSplits(next);
+  const flattenedLeafIds = collectLeafIds(flattened);
+  const present = new Set<string>();
+  for (const paneId of flattenedLeafIds) {
+    if (!expected.has(paneId) || present.has(paneId)) {
+      return fallback;
+    }
+    present.add(paneId);
+  }
+  const missingPaneIds = expectedPaneIds.filter((paneId) => !present.has(paneId));
+  if (missingPaneIds.length === 0) {
+    return coercePaneNodeToSplit(flattened, fallback.direction);
+  }
+
+  const base = coercePaneNodeToSplit(flattened, fallback.direction);
+  const withInsertedPanes = missingPaneIds.reduce(
+    (currentTree, paneId) => insertPaneIntoLargestLeaf(currentTree, paneId, fallback.direction),
+    base,
+  );
+  return coercePaneNodeToSplit(flattenSingleChildSplits(withInsertedPanes), fallback.direction);
+}
+
 /* ---- Split a pane at an edge ---- */
 
 export function splitPaneAtEdge(
@@ -91,15 +191,15 @@ export function splitPaneAtEdge(
   draggedId: string,
   edge: Exclude<DropEdge, "center">
 ): PaneSplit {
-  // Step 1: Remove dragged pane from the tree
-  const pruned = removePaneFromTree(tree, draggedId);
-  if (pruned == null || pruned.type === "pane") return tree;
-  const cleanTree = flattenSingleChildSplits(pruned) as PaneSplit;
-
-  // Step 2: Replace target leaf with a new split containing both panes
-  const direction: "horizontal" | "vertical" =
+  const direction: PaneSplit["direction"] =
     edge === "left" || edge === "right" ? "horizontal" : "vertical";
 
+  // Step 1: Remove dragged pane from the tree
+  const pruned = removePaneFromTree(tree, draggedId);
+  if (pruned == null) return tree;
+  const cleanTree = coercePaneNodeToSplit(flattenSingleChildSplits(pruned), direction);
+
+  // Step 2: Replace target leaf with a new split containing both panes
   const draggedEntry: PaneLayoutEntry = {
     node: { type: "pane", id: draggedId },
     defaultSize: 50,
@@ -131,7 +231,13 @@ function replaceLeaf(
 ): PaneSplit {
   if (node.type === "pane") {
     // This shouldn't normally be the root call, but handle it gracefully
-    return node.id === targetId ? replacement : { type: "split", direction: "horizontal", children: [{ node }] };
+    return node.id === targetId
+      ? replacement
+      : {
+          type: "split",
+          direction: "horizontal",
+          children: [{ node, defaultSize: 100, minSize: 5 }],
+        };
   }
 
   return {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -470,7 +470,7 @@ app/            # shell, App.tsx, TopBar, TabNav, startup, splash
 project/        # Play tab, run/test/process controls
 lanes/          # list/detail/inspector, stacks, laneDesignTokens.ts
 files/          # tree, editor, diffs
-terminals/      # TerminalView, PackedSessionGrid, WorkViewArea, LaneCombobox
+terminals/      # TerminalView, WorkViewArea (PaneTilingLayout-backed grid), workSessionTiling, LaneCombobox
 conflicts/      # risk matrix, simulation, resolution
 context/        # shared helpers (contextShared.ts)
 graph/          # WorkspaceGraphPage (decomposed into nodes/edges/dialogs)
@@ -490,9 +490,9 @@ Design tokens have been intentionally trimmed. The CTO design tokens at `apps/de
 
 ### 7.4 Layout patterns
 
-- `PaneTilingLayout` — recursive pane trees for high-density workspaces.
+- `PaneTilingLayout` — recursive pane trees for high-density workspaces, backed by pure ops in `paneTreeOps.ts` (`reconcilePaneTree`, `splitPaneAtEdge`, `swapPanes`, `detectDropEdge`). Trees persist per `layoutId` via `window.ade.tilingTree`; panel sizes persist separately via `DockLayoutState` and are reset whenever the tree mutates.
 - `SplitPane` / resizable panels — structured 2/3-pane views.
-- `PackedSessionGrid` — bin-packed tile layout for multi-session Work views (`packedSessionGridMath.ts`). Each tile receives `layoutVariant` and `terminalVisible` so background terminals skip fit operations.
+- Work view's grid mode is `PaneTilingLayout` seeded by `buildWorkSessionTilingTree(sessionIds)` (in `renderer/components/terminals/workSessionTiling.ts`); every session becomes a `FloatingPane` leaf with `grid-tile` chrome.
 - Layout state persists to SQLite (`layout`, `tilingTree`, `graphState` domains via the `kv` table).
 
 ### 7.5 Performance contract

--- a/docs/features/chat/agent-routing.md
+++ b/docs/features/chat/agent-routing.md
@@ -140,6 +140,28 @@ Two independent controls:
   `config-toml`, ADE defers both controls to the project's
   `.codex/config.toml`.
 
+The chat adapter now rehydrates the effective approval/sandbox/reasoning
+tuple from the Codex app-server response: every `thread/start` and
+`thread/resume` call passes `{ model, cwd, ...codexPolicyArgs,
+persistExtendedHistory: true }` (no redundant `reasoningEffort`) and the
+return envelope is consumed by `applyCodexEffectiveThreadState`, which
+normalizes `approvalPolicy`, `sandbox` (including the camel-case
+aliases `readOnly` / `workspaceWrite` / `dangerFullAccess` that the
+server emits), and `reasoningEffort`. That snapshot becomes the session
+state, so the picker chips always show what the runtime actually
+applied. On resume, the persisted chat state is re-written after
+normalization instead of being re-copied from the on-disk file — the
+server's reading of `.codex/config.toml` wins over a stale persisted
+pair. Turns use the Codex-native `effort` key
+(`turn/start({ threadId, input, effort? })`) instead of the legacy
+`reasoningEffort` name.
+
+Default Codex chats map to the "Default permissions" preset
+(`workspace-write` + `on-request`). The older implicit fallback that
+mapped CLI `edit` mode to `untrusted` was removed so the first-turn
+picker state matches the documented default; the explicit Codex
+`edit` preset still resolves through the picker path.
+
 ### OpenCode
 
 `AgentChatOpenCodePermissionMode`:

--- a/docs/features/chat/composer-and-ui.md
+++ b/docs/features/chat/composer-and-ui.md
@@ -309,6 +309,19 @@ These modules are pure and unit-testable:
   sensitive to changing row heights (plan approval cards, work-log
   expansion). Measurement caching uses stable keys; rolling back to an
   unstable key causes the list to "jump" on updates.
+- **Native permission picker updates serialize before submit.**
+  `AgentChatPane` tracks the in-flight native-control update through
+  `pendingNativeControlUpdateRef` (sessionId + monotonic `updateId` +
+  promise). Every `updateSession` dispatched from the permission
+  popovers chains onto the previous promise so the backend always sees
+  the final picker state, and `submit()` awaits that chain for the
+  active session before dispatching the turn. The handler also
+  optimistically patches the renderer session summary with the fields
+  returned from `updateSession` (`permissionMode`,
+  `interactionMode`, `claudePermissionMode`, `codexApprovalPolicy`,
+  `codexSandbox`, `codexConfigSource`, `opencodePermissionMode`,
+  `cursorModeId`, `cursorModeSnapshot`) so the chip state reflects the
+  server's normalized values before the list refresh lands.
 
 ## Related docs
 

--- a/docs/features/terminals-and-sessions/README.md
+++ b/docs/features/terminals-and-sessions/README.md
@@ -78,15 +78,22 @@ Renderer surfaces:
   per-session card (status dot, title, preview line, tool type, lane,
   delta chips).
 - `apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx` —
-  multi-tab and multi-tile Work view that owns the `PackedSessionGrid`.
+  tabs/grid/single Work view. The grid mode renders through the shared
+  `PaneTilingLayout`; the seed tree comes from `buildWorkSessionTilingTree`.
 - `apps/desktop/src/renderer/components/terminals/WorkStartSurface.tsx` —
   empty-state "start new chat / terminal" surface.
 - `apps/desktop/src/renderer/components/terminals/TerminalView.tsx` —
   xterm.js wrapper; WebGL renderer with DOM fallback, fit retries, health
   counters.
-- `apps/desktop/src/renderer/components/terminals/PackedSessionGrid.tsx`
-  + `packedSessionGridMath.ts` — bin-packed resizable grid for multiple
-  simultaneous sessions.
+- `apps/desktop/src/renderer/components/terminals/workSessionTiling.ts` —
+  pure helper that produces the seed `PaneSplit` for the Work grid from
+  an ordered list of session IDs (single-column for ≤1 session, single
+  row when `ceil(sqrt(n)) == n`, otherwise a vertical stack of horizontal
+  rows with counts distributed by `distributeCounts`).
+- `apps/desktop/src/renderer/components/ui/PaneTilingLayout.tsx` +
+  `paneTreeOps.ts` — recursive pane tree component + pure operations
+  (`reconcilePaneTree`, `splitPaneAtEdge`, `swapPanes`, `removePaneFromTree`,
+  `detectDropEdge`) shared by every tiled surface, including the Work grid.
 - `apps/desktop/src/renderer/components/terminals/useWorkSessions.ts` —
   hook that owns work view state (open items, active tab, draft kind,
   view mode, filters) and persists it to `localStorage` under
@@ -113,8 +120,9 @@ Renderer surfaces:
   backfill, stale reconciliation. Covers the branch-heavy main-process
   code.
 - [ui-surfaces.md](./ui-surfaces.md) — the renderer surfaces:
-  `TerminalsPage`, `SessionListPane`, `WorkViewArea`, `WorkStartSurface`,
-  `TerminalView`, `PackedSessionGrid`, and state hooks.
+  `TerminalsPage`, `SessionListPane`, `WorkViewArea` (including the
+  `PaneTilingLayout`-backed grid mode), `WorkStartSurface`,
+  `TerminalView`, and state hooks.
 - [runtime-isolation.md](./runtime-isolation.md) — how a session stays
   bound to a single lane worktree and a single mission/run context.
 
@@ -290,9 +298,15 @@ Processes (managed):
   `transcriptBytesWritten` is not persisted.
 - Preview updates are throttled (~900 ms) and the string is capped at
   220 chars via `derivePreviewFromChunk`.
-- `PackedSessionGrid` mounts every tile; tiles that are not visible set
-  `terminalVisible={false}` so xterm skips fit work. Do not unmount a
-  grid tile just because it is offscreen — the PTY will detach.
+- `PaneTilingLayout` mounts every leaf pane in the Work grid; each
+  `SessionSurface` still passes `terminalVisible={true}` for grid tiles
+  because the tiling layout keeps them on screen. Do not unmount a grid
+  leaf just because it is inactive — the PTY will detach. The tiling
+  tree for the Work grid is persisted per `(projectRoot, laneId)` under
+  the `work:grid:tiling:v1:` key family (via `window.ade.tilingTree`),
+  and legacy `work:grid:v2:*` layouts are intentionally ignored — a new
+  tree is seeded from `buildWorkSessionTilingTree` when nothing is
+  persisted under the current key.
 
 ## Cross-links
 

--- a/docs/features/terminals-and-sessions/README.md
+++ b/docs/features/terminals-and-sessions/README.md
@@ -89,7 +89,7 @@ Renderer surfaces:
   pure helper that produces the seed `PaneSplit` for the Work grid from
   an ordered list of session IDs (single-column for ≤1 session, single
   row when `ceil(sqrt(n)) == n`, otherwise a vertical stack of horizontal
-  rows with counts distributed by `distributeCounts`).
+  rows with counts distributed by `rowSizes`).
 - `apps/desktop/src/renderer/components/ui/PaneTilingLayout.tsx` +
   `paneTreeOps.ts` — recursive pane tree component + pure operations
   (`reconcilePaneTree`, `splitPaneAtEdge`, `swapPanes`, `removePaneFromTree`,

--- a/docs/features/terminals-and-sessions/ui-surfaces.md
+++ b/docs/features/terminals-and-sessions/ui-surfaces.md
@@ -128,7 +128,7 @@ per visible session. Two helpers build the inputs:
   returns the seed `PaneSplit` used when nothing has been persisted for
   the current `gridLayoutId`. It biases toward near-square layouts:
   `columnCount = ceil(sqrt(n))`, `rowCount = ceil(n / columnCount)`,
-  then `distributeCounts(n, rowCount)` spreads sessions across rows so
+  then `rowSizes(n, rowCount)` spreads sessions across rows so
   earlier rows absorb the remainder. The outer split is vertical; each
   row becomes an inline horizontal split (or a single leaf when the row
   has one session). `minSize: 8%` (MIN_PANE_SIZE) / `12%` (MIN_ROW_SIZE)

--- a/docs/features/terminals-and-sessions/ui-surfaces.md
+++ b/docs/features/terminals-and-sessions/ui-surfaces.md
@@ -82,9 +82,12 @@ Owns the render target for open sessions. Supports three modes tied to
 `viewMode`:
 
 - `tabs` — tab-strip + single `SessionSurface` for the active tab, plus
-  a "New Chat" button in the tab strip.
-- `grid` — packed grid layout, each tile is a `SessionSurface` in
-  `grid-tile` variant.
+  a "New Chat" button in the tab strip. A second sub-mode (`hasGroupedTabs`)
+  renders lane-grouped tab chips with per-group collapse.
+- `grid` — tiled pane layout. Each session becomes a `PaneConfig` that
+  mounts a `SessionSurface` in `grid-tile` variant. The tiling tree is
+  rendered by `PaneTilingLayout`, seeded by
+  `buildWorkSessionTilingTree(visibleSessionIds)`.
 - `single` — a single focused session with no tab chrome.
 
 ### `SessionSurface` (internal component)
@@ -116,50 +119,80 @@ Constants:
 - `CHAT_TILE_MIN_WIDTH = 440`, `CHAT_TILE_MIN_HEIGHT = 340`
 - `TERMINAL_TILE_MIN_WIDTH = 320`, `TERMINAL_TILE_MIN_HEIGHT = 220`
 
-## Packed grid: `PackedSessionGrid.tsx` + `packedSessionGridMath.ts`
+## Grid mode: `PaneTilingLayout` + `workSessionTiling.ts`
 
-Resizable tile layout. Each tile has an independent `colSpan`; row
-height is determined by the container, not user-dragged. The math
-module bin-packs tiles into rows/columns to minimize gaps:
+The Work grid is a standard `PaneTilingLayout` instance with one leaf
+per visible session. Two helpers build the inputs:
 
-- `computeGridColumnCount(containerWidth, tileCount, minTileWidth)`
-- `computeMinimumRowSpan()` / `computeMinimumColSpan()`
-- `clampPackedGridSpan()` — enforces per-tile min/max spans
-- `packGridItems(items)` — places each tile in the first available
-  slot scanning rows then columns. Accepts optional `placement` hints
-  (`{ column, row }`) so resized tiles stay anchored to their
-  persisted origin instead of being re-flowed by the packer.
-- `reconcilePackedGridLayout({ layout, tileIds, defaultSpansById,
-  columnCount })` — preserves spans and persisted `colStart/rowStart/
-  colSpan/rowSpan` quads for tiles that come back later.
-- `resizePackedGridItem({ placementsById, tileId, direction, delta,
-  … })` — directional edge move. The grid currently only exposes the
-  east/west handles, so only the horizontal edge-movers
-  (`moveEastEdge`, `moveWestEdge`) run in practice. They push
-  contiguous neighbors when the edge has zero gap, or consume free
-  space when there is a gap, enforcing per-tile min-span floors and
-  the column-count ceiling.
+- `buildWorkSessionTilingTree(sessionIds)` (in `workSessionTiling.ts`)
+  returns the seed `PaneSplit` used when nothing has been persisted for
+  the current `gridLayoutId`. It biases toward near-square layouts:
+  `columnCount = ceil(sqrt(n))`, `rowCount = ceil(n / columnCount)`,
+  then `distributeCounts(n, rowCount)` spreads sessions across rows so
+  earlier rows absorb the remainder. The outer split is vertical; each
+  row becomes an inline horizontal split (or a single leaf when the row
+  has one session). `minSize: 8%` (MIN_PANE_SIZE) / `12%` (MIN_ROW_SIZE)
+  floors protect against accidentally collapsing a row.
+- `WorkViewArea` builds one `PaneConfig` per visible session (keyed by
+  `session.id`) with title, status dot, close button, mouse/context
+  handlers that forward to `onSelectItem` / `onContextMenu`, and a
+  `SessionSurface` child in `grid-tile` variant.
 
-Persistence now carries both the span and the origin: the persisted
-layout stores `<id>:colStart`, `<id>:rowStart`, `<id>:colSpan`,
-`<id>:rowSpan` per tile and legacy `<id>:col` / `<id>:row` are still
-read for backward compatibility. `readPackedGridPlacement(layout, id)`
-returns the `{ column, row, colSpan, rowSpan }` record when one has been
-written. Persisted `rowSpan` values are replayed against the current
-`defaultRowSpan` so stored layouts stay comparable across container
-height changes.
+The actual split tree, resize state, and pane origin are owned by
+`PaneTilingLayout`. See the next section for invariants the layout
+enforces.
 
-West-edge drags keep the dragged edge anchored while the tile grows
-leftward (the covered test in `PackedSessionGrid.test.tsx` asserts
-`colStart` decreases by exactly the drag delta). During a resize, the
-active tile is promoted to the front of the pack order so it "wins"
-any overlap with newly-repositioned neighbors. Vertical resize is
-intentionally disabled to keep tile rows aligned to the shared row
-height.
+## Pane tiling layout primitives
 
-`PackedSessionGrid` also accepts an `onViewportMouseLeave` callback
-and an `onHover` per tile, so surrounding layouts can clear keyboard
-focus / hover state when the pointer exits the grid.
+`PaneTilingLayout` (`apps/desktop/src/renderer/components/ui/PaneTilingLayout.tsx`)
+and its pure operations (`paneTreeOps.ts`) are shared across the Work
+grid, `LanesPage`, `TerminalsPage` itself, and history detail views.
+Reconciliation invariants the layout guarantees:
+
+- **Seed tree.** Consumers pass a `tree: PaneSplit` prop that describes
+  the default layout for the current set of pane IDs. `collectLeafIds(tree)`
+  is the canonical `expectedPaneIds` list.
+- **Persistence.** On mount the layout reads a persisted tree from
+  `window.ade.tilingTree.get(layoutId)`. Every user-driven change
+  (drop-edge split, swap, reconciliation) is written back with a 300 ms
+  debounce. Panel sizes use a separate `DockLayoutState` store keyed by
+  `layoutId` + positional path; any tree mutation resets that panel-size
+  store so newly-split panels start from their `defaultSize` instead of
+  inheriting a stale saved percentage.
+- **Tree reconciliation.** `reconcilePaneTree(candidate, expectedPaneIds,
+  fallback)` is called both on load (against the persisted tree) and on
+  prop-tree changes. It drops leaves that are no longer expected,
+  flattens any single-child splits produced by that removal, and
+  inserts missing pane IDs by splitting the leaf with the largest
+  computed weight (direction alternates: a missing pane added to a
+  horizontal parent becomes a vertical split, and vice versa).
+  Duplicate leaves or unknown IDs surviving the cleanup pass cause the
+  whole tree to be replaced with the fallback.
+- **Drop-edge detection.** `detectDropEdge(rect, clientX, clientY)`
+  maps a pointer position to `top | bottom | left | right | center`
+  using a 25 % edge threshold. The center zone triggers a swap
+  (`swapPanes`); the four edges trigger `splitPaneAtEdge(tree, targetId,
+  draggedId, edge)`, which prunes the dragged leaf, coerces the
+  remaining tree to a split in the correct orientation, and replaces
+  the target leaf with a two-child split whose child order follows the
+  edge (`right`/`bottom` keep the target first; `left`/`top` put the
+  dragged pane first).
+- **Minimization.** Each leaf can minimize via its `FloatingPane`
+  header. `PaneTilingLayout` runs two compaction passes off the
+  `minimized` map: an individual-leaf pass that shrinks the leaf's
+  containing panel to `LEAF_MINIMIZED_{HEIGHT,WIDTH}_PX`, and a
+  split-level pass that compacts an entire subtree when every
+  descendant leaf is minimized (`COMPACTED_WIDTH_PX` for horizontal
+  parents, `COMPACTED_HEIGHT_PER_LEAF_PX × leafCount` for vertical
+  parents). Both paths restore the previous panel size on un-minimize
+  via `PanelImperativeHandle.resize`.
+
+`FloatingPane` now also accepts `onPaneMouseDown` / `onPaneContextMenu`
+so consumers (like the Work grid) can run selection / context-menu
+logic on the wrapper without subscribing through drag handlers.
+`PaneConfig` exposes a `className` pass-through so callers can apply
+their own tile chrome classes (e.g. `ade-work-glass-tile`) alongside
+the floating-pane defaults.
 
 ## Terminal renderer: `TerminalView.tsx`
 
@@ -297,9 +330,12 @@ nothing when no delta is available.
 - The Work tab and the Lanes tab share the hook; changes to
   `useWorkSessions` ripple. Keep lane-scoped persistence keyed by
   `projectRoot::laneId` or the Lanes tab state leaks across projects.
-- `PackedSessionGrid` renders all tiles; only suspended tiles become
-  preview cards. The decision is driven by `terminalVisible` via
-  `IntersectionObserver` wiring inside the grid component.
+- The Work grid is `PaneTilingLayout` — every visible session has a
+  leaf and stays mounted. Grid tiles pass `terminalVisible={true}`;
+  `isActive` controls input but not mount state, so multiple PTYs can
+  stay live at once. The gridLayoutId is namespaced
+  (`work:grid:tiling:v1:<projectRoot>[::<laneId>]`) so a persisted
+  layout travels with the project/lane pair.
 
 ## Cross-links
 


### PR DESCRIPTION
## Summary

- Replace packed session grid with `PaneTilingLayout` backed by a new pure `paneTreeOps` module (reconcile, detect-drop-edge, flatten-single-child, remove-pane, swap, validate).
- Add `workSessionTiling.ts` helper to seed initial trees for the Work view grid and persist layouts under the `work:grid:tiling:v1:` namespace.
- Chat service: reuse persisted approval/sandbox normalizers when rehydrating Codex effective thread state; camel-case sandbox aliases and Codex-native `effort` in `turn/start`.
- AgentChatPane: serialize native permission picker updates via `pendingNativeControlUpdateRef` so rapid toggles submit in order without stomping session summaries.
- Tests: 28 paneTreeOps, 8 workSessionTiling, additional chat composer + pane submit coverage.
- Docs: terminals-and-sessions README + ui-surfaces and chat composer-and-ui + agent-routing updated to match.

## Test plan

- [x] Typecheck: desktop, ade-cli, web
- [x] Lint: desktop
- [x] Unit tests (desktop sharded 8-way + ade-cli): all pass
- [x] Build: desktop, ade-cli, web
- [x] Doc validation + internal Source-file-map + PRD link checks
- [ ] CI on origin branch

Ship-lane driven (PR opened via gh fallback — ADE CLI reported GitHub token missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the packed session grid with a `PaneTilingLayout` backed by a new pure `paneTreeOps` module, adds `workSessionTiling.ts` to seed initial trees, serializes native permission picker updates to prevent race conditions, and rehydrates Codex effective thread state (approval policy, sandbox, reasoning effort) from server lifecycle responses instead of re-applying persisted values after resume. Test coverage is thorough (28 pane tree ops tests, 8 tiling tests, new submit serialization tests).

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the pre-existing object-form sandbox normalization gap noted in the prior review.

All new code paths are well-tested (28 paneTreeOps tests, 8 tiling tests, new submit serialization coverage). The one lingering P1 — normalizeCodexRuntimeSandbox silently dropping hyphenated sandbox values when the server returns object form — was flagged in the previous review cycle and is not fixed in this PR. All other findings are P2 or lower.

apps/desktop/src/main/services/chat/agentChatService.ts — the normalizeCodexRuntimeSandbox object-form branch should call normalizePersistedCodexSandbox before the camelCase alias lookup.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/ui/paneTreeOps.ts | Adds reconcilePaneTree, coercePaneNodeToSplit, collectLeafCandidates, and insertPaneIntoLargestLeaf; fixes splitPaneAtEdge to handle single-leaf prune result via coerce instead of a hard cast. |
| apps/desktop/src/renderer/components/terminals/workSessionTiling.ts | New helper that seeds a balanced grid tree (sqrt-based column count) from a list of session IDs; used as the fallback/initial tree for PaneTilingLayout. |
| apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx | Replaces PackedSessionGrid with PaneTilingLayout; removes hover-based active state; passes onPaneMouseDown/onPaneContextMenu for selection and context menu handling. |
| apps/desktop/src/renderer/components/ui/PaneTilingLayout.tsx | Adds replaceTreeImmediately, reconciliation on load/mismatch, immediate saveLayout on persistTree, and forwards className/onPaneMouseDown/onPaneContextMenu to FloatingPane. |
| apps/desktop/src/main/services/chat/agentChatService.ts | Adds applyCodexEffectiveThreadState to rehydrate approval policy, sandbox, and reasoning effort from thread/start and thread/resume responses; renames reasoningEffort to effort in turn/start; drops cliMode "edit" → "untrusted" default mapping. Object-form sandbox path skips normalizePersistedCodexSandbox (flagged in prior review). |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Adds pendingNativeControlUpdateRef serialization queue so rapid permission picker toggles submit in order and submit guard awaits the in-flight update before sending a new turn. |
| apps/desktop/src/renderer/components/ui/FloatingPane.tsx | Adds onPaneMouseDown and onPaneContextMenu props forwarded to the root div; removes hardcoded h-full className so callers control sizing. |
| apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx | Removes rounded-none and borderRadius=0 overrides in grid-tile layoutVariant so the composer adopts its standard border radius in the tiling grid. |
| apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts | Layout namespace bumped from work:grid:v2 to work:grid:tiling:v1, dropping stale v2 layout records on first load. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[visibleSessions] -->|map IDs| B[buildWorkSessionTilingTree]
    B -->|PaneSplit tree| C[PaneTilingLayout]

    C -->|mount: load persisted tree| D{isValidTree?}
    D -->|yes| E[setLiveTree saved]
    D -->|no| F[reconcilePaneTree]
    F -->|prune stale IDs + insert missing| G[replaceTreeImmediately]
    G --> H[setLiveTree + saveLayout + persist]

    C -->|expectedPaneIds change| I{isValidTree liveTree?}
    I -->|no| F

    C -->|drag-drop| J[persistTree]
    J --> K[setLiveTree + saveLayout + debounced persist]

    subgraph agentChatService
        L[thread/start or thread/resume] -->|response| M[applyCodexEffectiveThreadState]
        M --> N[session.codexApprovalPolicy / codexSandbox / reasoningEffort]
        N --> O[turn/start with effort param]
    end

    subgraph AgentChatPane
        P[native picker change] -->|enqueue| Q[pendingNativeControlUpdateRef]
        R[submit] -->|await in-flight update| Q
        Q --> S[updateSession serial chain]
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/desktop/src/main/services/chat/agentChatService.ts`, line 28-31 ([link](https://github.com/arul28/ade/blob/347e2a6a1a0daa6886016039a30d604d07c82353/apps/desktop/src/main/services/chat/agentChatService.ts#L28-L31)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Object-form sandbox type not normalised through `normalizePersistedCodexSandbox`**

   When the server returns `sandbox` as an object (e.g. `{ type: "workspace-write" }` using the hyphenated form), the lookup falls through to `CODEX_SANDBOX_CAMEL_CASE_ALIASES[type]` which has no entry for hyphenated keys and returns `undefined`, silently dropping the value. The string-form path already calls `normalizePersistedCodexSandbox` as a first step; the object branch should do the same before falling back to the camelCase alias map.

   ```ts
   const type = (value as Record<string, unknown>).type;
   if (typeof type !== "string") return undefined;
   return normalizePersistedCodexSandbox(type) ?? CODEX_SANDBOX_CAMEL_CASE_ALIASES[type];
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/chat/agentChatService.ts
   Line: 28-31

   Comment:
   **Object-form sandbox type not normalised through `normalizePersistedCodexSandbox`**

   When the server returns `sandbox` as an object (e.g. `{ type: "workspace-write" }` using the hyphenated form), the lookup falls through to `CODEX_SANDBOX_CAMEL_CASE_ALIASES[type]` which has no entry for hyphenated keys and returns `undefined`, silently dropping the value. The string-form path already calls `normalizePersistedCodexSandbox` as a first step; the object branch should do the same before falling back to the camelCase alias map.

   ```ts
   const type = (value as Record<string, unknown>).type;
   if (typeof type !== "string") return undefined;
   return normalizePersistedCodexSandbox(type) ?? CODEX_SANDBOX_CAMEL_CASE_ALIASES[type];
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fchat%2FagentChatService.ts%0ALine%3A%2028-31%0A%0AComment%3A%0A**Object-form%20sandbox%20type%20not%20normalised%20through%20%60normalizePersistedCodexSandbox%60**%0A%0AWhen%20the%20server%20returns%20%60sandbox%60%20as%20an%20object%20%28e.g.%20%60%7B%20type%3A%20%22workspace-write%22%20%7D%60%20using%20the%20hyphenated%20form%29%2C%20the%20lookup%20falls%20through%20to%20%60CODEX_SANDBOX_CAMEL_CASE_ALIASES%5Btype%5D%60%20which%20has%20no%20entry%20for%20hyphenated%20keys%20and%20returns%20%60undefined%60%2C%20silently%20dropping%20the%20value.%20The%20string-form%20path%20already%20calls%20%60normalizePersistedCodexSandbox%60%20as%20a%20first%20step%3B%20the%20object%20branch%20should%20do%20the%20same%20before%20falling%20back%20to%20the%20camelCase%20alias%20map.%0A%0A%60%60%60ts%0Aconst%20type%20%3D%20%28value%20as%20Record%3Cstring%2C%20unknown%3E%29.type%3B%0Aif%20%28typeof%20type%20!%3D%3D%20%22string%22%29%20return%20undefined%3B%0Areturn%20normalizePersistedCodexSandbox%28type%29%20%3F%3F%20CODEX_SANDBOX_CAMEL_CASE_ALIASES%5Btype%5D%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=181&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>

2. `apps/desktop/src/renderer/components/chat/AgentChatPane.tsx`, line 2267-2274 ([link](https://github.com/arul28/ade/blob/347e2a6a1a0daa6886016039a30d604d07c82353/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx#L2267-L2274)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Submit guard scope should be documented**

   The guard only awaits the pending update when `pendingNativeControlUpdate?.sessionId === selectedSessionId`. If the user switches sessions mid-flight the ref holds a different `sessionId` and the submit proceeds immediately. This is intentional given session isolation, but a short inline comment explaining the scoping would aid future readers since the code otherwise reads as a potential race path.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
   Line: 2267-2274

   Comment:
   **Submit guard scope should be documented**

   The guard only awaits the pending update when `pendingNativeControlUpdate?.sessionId === selectedSessionId`. If the user switches sessions mid-flight the ref holds a different `sessionId` and the submit proceeds immediately. This is intentional given session isolation, but a short inline comment explaining the scoping would aid future readers since the code otherwise reads as a potential race path.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FAgentChatPane.tsx%0ALine%3A%202267-2274%0A%0AComment%3A%0A**Submit%20guard%20scope%20should%20be%20documented**%0A%0AThe%20guard%20only%20awaits%20the%20pending%20update%20when%20%60pendingNativeControlUpdate%3F.sessionId%20%3D%3D%3D%20selectedSessionId%60.%20If%20the%20user%20switches%20sessions%20mid-flight%20the%20ref%20holds%20a%20different%20%60sessionId%60%20and%20the%20submit%20proceeds%20immediately.%20This%20is%20intentional%20given%20session%20isolation%2C%20but%20a%20short%20inline%20comment%20explaining%20the%20scoping%20would%20aid%20future%20readers%20since%20the%20code%20otherwise%20reads%20as%20a%20potential%20race%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=181&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Docs: rename distributeCounts → rowSizes..."](https://github.com/arul28/ade/commit/8bdfef5098de1abddca1dff68d41b2b4e3b0cfd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29504927)</sub>

<!-- /greptile_comment -->