### PR TITLE
iOS: mobile polish pass across Files, Lanes, PRs, Work

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,463 @@
+---
+name: release
+description: 'Cut a new ADE release: scope desktop/iOS, write changelog, push + tag main, poll release workflow, and ship an iOS build via asc'
+---
+
+# Release Command
+
+Drive a full ADE release end-to-end: figure out what needs to ship (desktop, iOS, or both), generate the Mintlify changelog page, push + tag on `main` to kick the release workflow, poll it to completion, and (when iOS is in scope) drive the TestFlight build through `asc`.
+
+**Usage:**
+- `/release` — interactive. Agent will ask for the new version number and the iOS build number when it needs them.
+- `/release <version>` — e.g. `/release v1.1.3`. Skip the version prompt; agent will still ask for the iOS build number if iOS is in scope.
+- `/release <version> <ios-build-number>` — e.g. `/release v1.1.3 42`. Fully unattended.
+
+**Arguments:** $ARGUMENTS
+
+---
+
+## Execution mode
+
+Mostly autonomous, but **pause for explicit user input** on:
+- The new version number (if not passed in `$ARGUMENTS`).
+- The iOS build number (if iOS is in scope and not passed in `$ARGUMENTS`).
+- Any step that would force-push `main`, bypass a ruleset in a surprising way, or publish a release that is still in `draft=false`.
+
+Do NOT publish the GitHub draft release automatically. Leave it as a draft for a human to flip.
+
+---
+
+## Pipeline overview
+
+```
+Phase 0: Verify repo state and find last release
+Phase 1: Scope — desktop, iOS, or both (surface-level path scan)
+Phase 2: Version number (ask user if not provided)
+Phase 3: Generate changelog MDX + register in docs.json
+Phase 4: Commit + push changelog to main
+Phase 5: Tag the release commit, push tag, confirm workflow started
+Phase 6: Poll release workflow every 5 minutes until done (scheduled wake-ups)
+Phase 7: iOS build via asc (only if iOS is in scope)
+Phase 8: Final summary — draft release link, changelog link, TestFlight status
+```
+
+---
+
+## Phase 0 — Verify repo state and find last release
+
+1. Confirm you are on `main` locally and clean, OR that the branch you are on already contains the commits that will be released (if working in an ADE worktree, fetch and reason about `origin/main`).
+
+   ```bash
+   git fetch origin --tags --prune
+   git log origin/main --oneline -1
+   ```
+
+2. Find the last release tag:
+
+   ```bash
+   git describe --tags --abbrev=0 origin/main 2>/dev/null || \
+     git tag --list 'v*' --sort=-v:refname | head -n 1
+   ```
+
+3. Count commits since that tag on `origin/main`:
+
+   ```bash
+   LAST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n 1)
+   git log --oneline "$LAST_TAG..origin/main"
+   ```
+
+   If the list is empty → nothing to release. Exit with a clear message. Do not proceed to any later phase.
+
+4. Sanity-check GitHub state:
+
+   ```bash
+   gh release view "$LAST_TAG" --json tagName,isDraft,isLatest
+   gh run list --workflow release.yml --limit 3
+   ```
+
+   If there is already an in-flight release workflow, stop and surface it to the user before doing anything else.
+
+Record `LAST_TAG` and the ordered commit list in your working notes — Phases 1 and 3 both need them.
+
+---
+
+## Phase 1 — Release scope (surface-level)
+
+Decide whether desktop, iOS, or both need to ship. **This is intentionally shallow** — path-based signals only, no deep diff review.
+
+Produce the changed-file list:
+
+```bash
+git diff --name-only "$LAST_TAG..origin/main"
+```
+
+Classification rules:
+
+- **Desktop in scope** if any file matches:
+  - `apps/desktop/**`
+  - `apps/ade-cli/**` (ships with desktop)
+  - shared packages that desktop imports (e.g. root-level shared types used by desktop — check `apps/desktop/package.json` imports if unsure)
+  - `.github/workflows/release.yml`, `release-core.yml`, `prepare-release.yml`
+- **iOS in scope** if any file matches:
+  - `apps/ios/**`
+  - iOS-specific shared code (Swift files anywhere)
+- **Both** if both sets are non-empty.
+- If only doc-only or changelog-only files changed → warn and ask the user whether they really want to cut a release (usually no).
+
+Output a one-line scope decision:
+
+```
+Scope: desktop=<yes|no> ios=<yes|no>  — <count> commits since <LAST_TAG>
+```
+
+Store `scope.desktop` and `scope.ios` as booleans for later phases.
+
+---
+
+## Phase 2 — Version number
+
+If `$ARGUMENTS` provided a version (first positional arg that matches `v?\d+\.\d+\.\d+`), use it. Strip or add the leading `v` so you have both `v1.1.3` (tag form) and `1.1.3` (bare form) available.
+
+Otherwise, ask the user:
+
+> What version should this release be cut as? Last tagged release was `<LAST_TAG>`. Reply with e.g. `v1.1.3`.
+
+Validation:
+- Must be strictly greater than `LAST_TAG` under semver. Reject otherwise.
+- Must not already exist as a tag: `git rev-parse "v$VERSION" >/dev/null 2>&1 && exit 1`.
+- Must not already exist on GitHub: `gh release view "v$VERSION" 2>/dev/null` should fail.
+
+---
+
+## Phase 3 — Generate changelog MDX
+
+The Mintlify site renders `changelog/vX.Y.Z.mdx` at `https://www.ade-app.dev/docs/changelog/vX.Y.Z`. Match the style of `changelog/v1.1.2.mdx` (which is the current latest — read it first for tone and structure).
+
+### 3a. Gather commits per scope
+
+```bash
+git log --pretty=format:'%h %s' "$LAST_TAG..origin/main" -- apps/desktop apps/ade-cli
+git log --pretty=format:'%h %s' "$LAST_TAG..origin/main" -- apps/ios
+```
+
+For each commit, you can pull the body when you need more than the subject:
+
+```bash
+git show --no-patch --pretty=format:'%B' <sha>
+```
+
+### 3b. Write `changelog/v<VERSION>.mdx`
+
+Required frontmatter (match existing files):
+
+```mdx
+---
+title: "v<VERSION>"
+description: "Release notes for ADE v<VERSION> — <Month Day, Year>"
+---
+```
+
+Body structure — **two top-level sections, exactly these headings when both are in scope**:
+
+```mdx
+<short one-paragraph summary of what this release does>
+
+---
+
+## Desktop
+
+<grouped bullets by theme — one bullet per user-visible change, not per commit. Collapse trivial refactors. Lead with the user impact, then the mechanism in a sub-clause.>
+
+---
+
+## iOS
+
+<same shape>
+```
+
+If only one platform is in scope, include only that section (no placeholder "No changes" block for the other).
+
+**Tone rules** (from `AGENTS.md` style preferences):
+- Direct and operational, not marketing.
+- Concrete and stateful: say what changed and why it matters.
+- Sentence case for headings unless an existing UI pattern uses something else.
+- Bold the headline of each bullet (e.g. `**Chat continuity.**`) — see `v1.1.2.mdx` for pattern.
+
+### 3c. Register the new page in `docs.json`
+
+Open `docs.json`, find the `"Changelog"` group's `pages` array, and insert `"changelog/v<VERSION>"` at the **top** of the list (above the current latest). Do not touch any other `docs.json` entries.
+
+### 3d. Self-check
+
+```bash
+ls changelog/v<VERSION>.mdx
+grep -n "changelog/v<VERSION>" docs.json
+```
+
+Both must succeed before moving on.
+
+---
+
+## Phase 4 — Commit and push changelog to main
+
+### Respect the "never edit main directly" rule
+
+The user's standing guidance is to land changes through a lane/worktree, not by pushing directly to `main`. For the release changelog:
+
+1. **Preferred path — PR merge:**
+   - From the current ADE worktree branch, commit the changelog + `docs.json` change:
+     ```bash
+     git add changelog/v<VERSION>.mdx docs.json
+     git commit -m "release: changelog for v<VERSION>"
+     git push -u origin HEAD
+     gh pr create --fill --title "release: changelog for v<VERSION>" \
+       --body "Changelog for v<VERSION>. Tag will be cut after this lands on main."
+     ```
+   - Then hand off to `/shipLane` to drive the PR to merge, OR merge it yourself with `gh pr merge --admin --squash` if the user has already said "merge it".
+   - Wait for `origin/main` to contain the new commit before Phase 5.
+
+2. **Admin-bypass path (only if user explicitly says "push directly"):**
+   - `git push origin HEAD:main` with admin bypass. Note in the summary that the ruleset was bypassed.
+
+Do not force-push. Do not `--no-verify`. If the push is rejected, investigate (rebase onto latest `origin/main`) — do not bypass checks.
+
+After the commit is on `origin/main`, re-fetch and record the SHA you will tag:
+
+```bash
+git fetch origin main
+RELEASE_SHA=$(git rev-parse origin/main)
+```
+
+---
+
+## Phase 5 — Tag and trigger the release workflow
+
+1. Create the tag on the exact release SHA:
+
+   ```bash
+   git tag -a "v<VERSION>" "$RELEASE_SHA" -m "v<VERSION>"
+   git push origin "v<VERSION>"
+   ```
+
+2. `.github/workflows/release.yml` triggers on `push` of `v*` tags and calls `release-core.yml`. Confirm the workflow registered:
+
+   ```bash
+   sleep 10
+   gh run list --workflow release.yml --limit 1
+   ```
+
+   If no run appears within ~60s, fall back to a manual dispatch:
+
+   ```bash
+   gh workflow run release.yml \
+     -f tag_name="v<VERSION>" \
+     -f target_sha="$RELEASE_SHA"
+   ```
+
+3. Once the draft release appears (the workflow creates it), make sure the release body links to the Mintlify changelog page:
+
+   ```bash
+   gh release view "v<VERSION>" --json body,isDraft,url
+   gh release edit "v<VERSION>" --notes "$(cat <<EOF
+   ADE v<VERSION>
+
+   Full changelog: https://www.ade-app.dev/docs/changelog/v<VERSION>
+
+   <one-paragraph summary — same opener as the Mintlify page>
+   EOF
+   )"
+   ```
+
+   Leave `isDraft=true`. Do not publish.
+
+---
+
+## Phase 6 — Poll the release workflow
+
+Release runs can take 20–40 minutes. Wait between polls instead of holding the turn open.
+
+After kicking off the workflow, schedule a wake-up for +5 minutes and **exit the current turn**:
+
+```
+ScheduleWakeup({
+  delaySeconds: 300,
+  reason: "release v<VERSION> workflow running; poll in 5m",
+  prompt: "/release $ARGUMENTS"
+})
+```
+
+On each re-invocation, read a small state file at `.ade/release/v<VERSION>.json` (create it on first run) so you know what phase to resume in:
+
+```json
+{
+  "version": "v1.1.3",
+  "releaseSha": "<sha>",
+  "scope": { "desktop": true, "ios": true },
+  "workflowRunId": 1234567,
+  "status": "running | release-done | ios-running | done | blocked",
+  "iosBuildNumber": null
+}
+```
+
+Per iteration:
+
+```bash
+gh run view "$RUN_ID" --json status,conclusion,url,jobs
+```
+
+- `status=queued|in_progress` → schedule another `+300s` wake, exit.
+- `status=completed conclusion=success` → set `status=release-done`, move to Phase 7 (or Phase 8 if iOS is out of scope).
+- `status=completed conclusion=failure|cancelled|timed_out` → stop, dump the failing job logs:
+  ```bash
+  gh run view "$RUN_ID" --log-failed | head -400
+  ```
+  Surface to the user and set `status=blocked`. Do not re-tag automatically.
+
+Do not loop in-turn. One poll per wake-up.
+
+---
+
+## Phase 7 — iOS build via `asc`
+
+Skip entirely if `scope.ios=false`.
+
+If `scope.ios=true` and you do not have a build number:
+
+> What build number should this TestFlight build use? The last one uploaded was `<N>` (run `asc builds list --app <APP_ID> --limit 5` to confirm).
+
+Validate: must be a positive integer strictly greater than the last build number on record.
+
+### Pre-flight
+
+`AGENTS.md` and the `asc-*` skills are the source of truth. Re-read before every release; the gotchas below are stable but the skill contents may change:
+
+- `asc-xcode-build`
+- `asc-testflight-orchestration`
+- `asc-release-flow`
+- `asc-signing-setup`
+- `asc-submission-health`
+
+Quick sanity:
+
+```bash
+asc doctor
+```
+
+Fail fast if keychain auth is broken.
+
+### iOS signing gotchas (mirrored from AGENTS.md — keep in sync)
+
+- Project uses **automatic** signing (`CODE_SIGN_STYLE = Automatic`, `DEVELOPMENT_TEAM = VQ372F39G6`). `apps/ios/ExportOptions.plist` ships with `signingStyle = manual` + named profiles for CI determinism. Local ad-hoc exports need `signingStyle = automatic` instead (drop the per-bundle profile map).
+- `asc signing fetch` only downloads provisioning profiles and the `.cer` — it does **not** include the private key. Don't expect it to make local signing work on its own.
+- Local exports need the ASC API key passed to `xcodebuild`. In addition to `-allowProvisioningUpdates`:
+  ```
+  -authenticationKeyPath ~/.apple/asc/keys/AuthKey_WRRA7YU7RA.p8 \
+  -authenticationKeyID WRRA7YU7RA \
+  -authenticationKeyIssuerID 4d523a6c-e68c-49b2-8560-34e59786d8e3
+  ```
+  Pull current values from `~/.asc/config.json`; do not hard-code.
+- After upload, `processingState = VALID` is not enough for TestFlight distribution. Also set `usesNonExemptEncryption` and assign to a group:
+  ```bash
+  asc builds update --build-id <ID> --uses-non-exempt-encryption=false
+  asc publish testflight --build <ID> --group "<Beta Group>"
+  ```
+
+### One-shot publish
+
+Full flow (archive + export + upload + distribute):
+
+```bash
+asc publish testflight \
+  --app <APP_ID> \
+  --project apps/ios/ADE.xcodeproj \
+  --scheme ADE \
+  --version <VERSION-without-v> \
+  --build-number <BUILD_NUMBER> \
+  --export-options <auto-plist> \
+  --group "<Beta Group>" \
+  --wait
+```
+
+If `--wait` times out, fall back to polling via `asc builds get` every 5 minutes using the same `ScheduleWakeup` pattern as Phase 6. Update `.ade/release/v<VERSION>.json` with `status=ios-running` so a re-invocation resumes here.
+
+### Post-upload checks
+
+```bash
+asc builds get --build-id <ID> --json
+```
+
+Confirm:
+- `processingState = VALID`
+- `usesNonExemptEncryption` is answered
+- Build is in the intended beta group
+
+If any check fails, run it explicitly (see gotchas above) and re-verify.
+
+---
+
+## Phase 8 — Summary
+
+Print a single final block and stop. Example:
+
+```
+Release v<VERSION> — summary
+
+- Changelog:     https://www.ade-app.dev/docs/changelog/v<VERSION>
+- Draft release: <gh release url>  (still draft — flip manually)
+- Workflow run:  <gh run url>      (conclusion: success)
+- iOS TestFlight build <BUILD_NUMBER>: <VALID | processing | skipped>
+- Beta group:    <group name | n/a>
+
+Next step: review the draft release, then `gh release edit v<VERSION> --draft=false` to publish.
+```
+
+If any phase ended in `blocked`, the summary says `BLOCKED` at the top with the failing phase and the command to resume.
+
+---
+
+## State file schema
+
+`.ade/release/v<VERSION>.json` — created in Phase 5, read/written on every wake-up.
+
+```json
+{
+  "version": "v1.1.3",
+  "lastTag": "v1.1.2",
+  "releaseSha": "<sha>",
+  "scope": { "desktop": true, "ios": true },
+  "workflowRunId": 1234567,
+  "workflowStatus": "queued | in_progress | success | failure | cancelled",
+  "iosBuildNumber": 42,
+  "iosBuildId": "<asc build id>",
+  "iosStatus": "pending | uploading | processing | valid | distributed | failed",
+  "phase": "5 | 6 | 7 | 8",
+  "status": "running | done | blocked",
+  "notes": []
+}
+```
+
+On wake-up:
+1. Read the state file. If `status=done` or `status=blocked`, print the summary and exit.
+2. Otherwise resume at `phase`.
+
+---
+
+## Things this command will NOT do
+
+- Publish the GitHub draft release (human must flip `--draft=false`).
+- Force-push to `main` or any tag.
+- Bypass CI, pre-commit hooks, or rulesets without an explicit user ask.
+- Edit existing changelog files (only creates the new `vX.Y.Z.mdx`).
+- Guess the version number or iOS build number — always ask.
+- Re-release an already-tagged version. If `vX.Y.Z` exists, stop and surface.
+
+---
+
+## References
+
+- `AGENTS.md` — release + `asc` guidance (canonical).
+- `docs/playbooks/ship-lane.md` — how to drive the changelog PR to merge in Phase 4.
+- `.github/workflows/release.yml`, `release-core.yml`, `prepare-release.yml` — desktop release pipeline.
+- `changelog/v1.1.2.mdx` — template to match for tone, structure, and section shape.
+- `docs.json` — Mintlify page registration (insert new entry at top of the `Changelog` group).
+- `asc-*` skills — iOS build/publish specifics.

--- a/apps/ios/ADE/Services/Database.swift
+++ b/apps/ios/ADE/Services/Database.swift
@@ -395,7 +395,11 @@ final class DatabaseService {
   }
 
   func fetchLanes(includeArchived: Bool) -> [LaneSummary] {
-    guard let projectId = currentProjectId() else { return [] }
+    let projectId = currentProjectId()
+    if projectId == nil && projectCount() > 0 {
+      return []
+    }
+    let projectPredicate = projectId == nil ? "" : "l.project_id = ? and"
     let sql = """
       select l.id, l.name, l.description, l.lane_type, l.base_ref, l.branch_ref, l.worktree_path,
              l.attached_root_path, l.parent_lane_id, l.is_edit_protected, l.color, l.icon, l.tags_json, l.folder,
@@ -413,13 +417,16 @@ final class DatabaseService {
         from lanes l
         left join lane_state_snapshots s on s.lane_id = l.id
         left join lane_state_snapshots ps on ps.lane_id = l.parent_lane_id
-       where l.project_id = ?
-         and (? = 1 or l.archived_at is null)
+       where \(projectPredicate) (? = 1 or l.archived_at is null)
        order by l.created_at asc
     """
     let rows = query(sql, bind: { [self] statement in
-      try self.bindText(projectId, to: statement, index: 1)
-      sqlite3_bind_int(statement, 2, includeArchived ? 1 : 0)
+      if let projectId {
+        try self.bindText(projectId, to: statement, index: 1)
+        sqlite3_bind_int(statement, 2, includeArchived ? 1 : 0)
+      } else {
+        sqlite3_bind_int(statement, 1, includeArchived ? 1 : 0)
+      }
     }) { statement in
       LaneRow(
         id: stringValue(statement, index: 0) ?? "",
@@ -1103,12 +1110,13 @@ final class DatabaseService {
 
   func listWorkspaces() -> [FilesWorkspace] {
     let projectId = currentProjectId()
+    let hasProjects = projectCount() > 0
     let projectRoot = projectId.flatMap { id in
       queryString("select root_path from projects where id = ? limit 1", bind: { [self] statement in
         try self.bindText(id, to: statement, index: 1)
       })
     }
-    let activeLaneIds = Set(query("select id from lanes where project_id = ?", bind: { [self] statement in
+    let activeLaneIds: Set<String>? = projectId == nil && !hasProjects ? nil : Set(query("select id from lanes where project_id = ?", bind: { [self] statement in
       if let projectId {
         try self.bindText(projectId, to: statement, index: 1)
       } else {
@@ -1137,9 +1145,10 @@ final class DatabaseService {
       }
       let scoped = cached.filter { workspace in
         if let laneId = workspace.laneId {
-          return activeLaneIds.contains(laneId)
+          return activeLaneIds?.contains(laneId) ?? true
         }
-        guard workspace.kind == "primary", let projectRoot else { return false }
+        guard workspace.kind == "primary" else { return false }
+        guard let projectRoot else { return !hasProjects }
         return workspace.rootPath == projectRoot
       }
       if !scoped.isEmpty {
@@ -1163,12 +1172,13 @@ final class DatabaseService {
   func replaceFilesWorkspaces(_ workspaces: [FilesWorkspace]) throws {
     guard tableExists("files_workspaces") else { return }
     let projectId = currentProjectId()
+    let hasProjects = projectCount() > 0
     let projectRoot = projectId.flatMap { id in
       queryString("select root_path from projects where id = ? limit 1", bind: { [self] statement in
         try self.bindText(id, to: statement, index: 1)
       })
     }
-    let activeLaneIds = Set(query("select id from lanes where project_id = ?", bind: { [self] statement in
+    let activeLaneIds: Set<String>? = projectId == nil && !hasProjects ? nil : Set(query("select id from lanes where project_id = ?", bind: { [self] statement in
       if let projectId {
         try self.bindText(projectId, to: statement, index: 1)
       } else {
@@ -1190,9 +1200,10 @@ final class DatabaseService {
       }
       let scopedExistingIds = existingIds.filter { row in
         if let laneId = row.laneId {
-          return activeLaneIds.contains(laneId)
+          return activeLaneIds?.contains(laneId) ?? true
         }
-        guard row.kind == "primary", let projectRoot else { return false }
+        guard row.kind == "primary" else { return false }
+        guard let projectRoot else { return !hasProjects }
         return row.rootPath == projectRoot
       }.map(\.id)
       let staleIds = scopedExistingIds.filter { !incomingIds.contains($0) }
@@ -2786,6 +2797,10 @@ final class DatabaseService {
       return activeProjectIdOverride
     }
     return queryString("select id from projects order by last_opened_at desc, created_at desc limit 1")
+  }
+
+  private func projectCount() -> Int {
+    Int(queryInt64("select count(*) from projects") ?? 0)
   }
 
   private func hasTable(named tableName: String) -> Bool {

--- a/apps/ios/ADE/Views/Files/FilesDetailComponents.swift
+++ b/apps/ios/ADE/Views/Files/FilesDetailComponents.swift
@@ -367,37 +367,24 @@ struct SyntaxHighlightedCodeView: View {
   let text: String
   let language: FilesLanguage
   let focusLine: Int?
+  let layoutMode: FilesCodeLayoutMode
 
   private var lines: [String] {
     let split = splitPreservingEmptyLines(text)
     return split.isEmpty ? [""] : split
   }
 
+  private var wrapsLines: Bool {
+    layoutMode == .wrap
+  }
+
+  private var lineNumberWidth: CGFloat {
+    min(max(CGFloat(String(lines.count).count) * 8 + 14, 28), 58)
+  }
+
   var body: some View {
     ScrollViewReader { proxy in
-      ScrollView([.horizontal, .vertical]) {
-        LazyVStack(alignment: .leading, spacing: 0) {
-          ForEach(Array(lines.enumerated()), id: \.offset) { index, line in
-            HStack(alignment: .top, spacing: 12) {
-              Text("\(index + 1)")
-                .font(.caption2.monospaced())
-                .foregroundStyle(ADEColor.textMuted)
-                .frame(minWidth: 36, alignment: .trailing)
-              Text(SyntaxHighlighter.highlightedAttributedString(line.isEmpty ? " " : line, as: language))
-                .font(.system(.body, design: .monospaced))
-                .foregroundStyle(ADEColor.textPrimary)
-                .fixedSize(horizontal: true, vertical: false)
-                .textSelection(.enabled)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 4)
-            .background((focusLine == index + 1 ? ADEColor.accent.opacity(0.12) : Color.clear), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .id(index + 1)
-          }
-        }
-        .padding(10)
-      }
+      codeScrollView
       .adeInsetField(cornerRadius: 16, padding: 0)
       .task(id: focusLine) {
         guard let focusLine else { return }
@@ -407,41 +394,111 @@ struct SyntaxHighlightedCodeView: View {
       }
     }
   }
+
+  @ViewBuilder
+  private var codeScrollView: some View {
+    if wrapsLines {
+      ScrollView(.vertical) {
+        codeRows
+      }
+    } else {
+      ScrollView([.horizontal, .vertical]) {
+        codeRows
+      }
+    }
+  }
+
+  private var codeRows: some View {
+    LazyVStack(alignment: .leading, spacing: 0) {
+      ForEach(Array(lines.enumerated()), id: \.offset) { index, line in
+        HStack(alignment: .top, spacing: wrapsLines ? 8 : 12) {
+          Text("\(index + 1)")
+            .font(.caption2.monospaced())
+            .foregroundStyle(ADEColor.textMuted)
+            .frame(width: lineNumberWidth, alignment: .trailing)
+          Text(SyntaxHighlighter.highlightedAttributedString(line.isEmpty ? " " : line, as: language))
+            .font(.system(.body, design: .monospaced))
+            .foregroundStyle(ADEColor.textPrimary)
+            .lineLimit(nil)
+            .fixedSize(horizontal: !wrapsLines, vertical: wrapsLines)
+            .frame(maxWidth: wrapsLines ? .infinity : nil, alignment: .leading)
+            .textSelection(.enabled)
+        }
+        .frame(maxWidth: wrapsLines ? .infinity : nil, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background((focusLine == index + 1 ? ADEColor.accent.opacity(0.12) : Color.clear), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .id(index + 1)
+      }
+    }
+    .padding(10)
+    .frame(maxWidth: wrapsLines ? .infinity : nil, alignment: .leading)
+  }
 }
 
 struct FilesInlineDiffView: View {
   let lines: [FilesInlineDiffLine]
   let language: FilesLanguage
+  let layoutMode: FilesCodeLayoutMode
+
+  private var wrapsLines: Bool {
+    layoutMode == .wrap
+  }
+
+  private var lineNumberWidth: CGFloat {
+    let largestLineNumber = lines.reduce(0) { current, line in
+      max(current, line.originalLineNumber ?? 0, line.modifiedLineNumber ?? 0)
+    }
+    return min(max(CGFloat(String(max(largestLineNumber, 1)).count) * 8 + 12, 26), 54)
+  }
 
   var body: some View {
-    ScrollView([.horizontal, .vertical]) {
-      LazyVStack(alignment: .leading, spacing: 0) {
-        ForEach(lines) { line in
-          HStack(alignment: .top, spacing: 12) {
-            diffLineNumber(line.originalLineNumber)
-            diffLineNumber(line.modifiedLineNumber)
-            Text(SyntaxHighlighter.highlightedAttributedString(line.text.isEmpty ? " " : line.text, as: language))
-              .font(.system(.body, design: .monospaced))
-              .foregroundStyle(ADEColor.textPrimary)
-              .fixedSize(horizontal: true, vertical: false)
-              .textSelection(.enabled)
-          }
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .padding(.horizontal, 10)
-          .padding(.vertical, 4)
-          .background(diffBackground(for: line.kind), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-        }
-      }
-      .padding(10)
-    }
+    diffScrollView
     .adeInsetField(cornerRadius: 16, padding: 0)
+  }
+
+  @ViewBuilder
+  private var diffScrollView: some View {
+    if wrapsLines {
+      ScrollView(.vertical) {
+        diffRows
+      }
+    } else {
+      ScrollView([.horizontal, .vertical]) {
+        diffRows
+      }
+    }
+  }
+
+  private var diffRows: some View {
+    LazyVStack(alignment: .leading, spacing: 0) {
+      ForEach(lines) { line in
+        HStack(alignment: .top, spacing: wrapsLines ? 8 : 12) {
+          diffLineNumber(line.originalLineNumber)
+          diffLineNumber(line.modifiedLineNumber)
+          Text(SyntaxHighlighter.highlightedAttributedString(line.text.isEmpty ? " " : line.text, as: language))
+            .font(.system(.body, design: .monospaced))
+            .foregroundStyle(ADEColor.textPrimary)
+            .lineLimit(nil)
+            .fixedSize(horizontal: !wrapsLines, vertical: wrapsLines)
+            .frame(maxWidth: wrapsLines ? .infinity : nil, alignment: .leading)
+            .textSelection(.enabled)
+        }
+        .frame(maxWidth: wrapsLines ? .infinity : nil, alignment: .leading)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(diffBackground(for: line.kind), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+      }
+    }
+    .padding(10)
+    .frame(maxWidth: wrapsLines ? .infinity : nil, alignment: .leading)
   }
 
   private func diffLineNumber(_ lineNumber: Int?) -> some View {
     Text(lineNumber.map(String.init) ?? "•")
       .font(.caption2.monospaced())
       .foregroundStyle(ADEColor.textMuted)
-      .frame(minWidth: 32, alignment: .trailing)
+      .frame(width: lineNumberWidth, alignment: .trailing)
   }
 
   private func diffBackground(for kind: FilesInlineDiffKind) -> Color {

--- a/apps/ios/ADE/Views/Files/FilesDetailScreen.swift
+++ b/apps/ios/ADE/Views/Files/FilesDetailScreen.swift
@@ -3,7 +3,6 @@ import UIKit
 
 struct FilesDetailScreen: View {
   @EnvironmentObject var syncService: SyncService
-  @Environment(\.dismiss) var dismiss
 
   let workspace: FilesWorkspace
   let relativePath: String
@@ -23,6 +22,7 @@ struct FilesDetailScreen: View {
   @State var hasLoadedHistory = false
   @State var hasLoadedDiff = false
   @State var isDetailsSheetPresented = false
+  @State var codeLayoutMode: FilesCodeLayoutMode = .wrap
 
   var language: FilesLanguage {
     FilesLanguage.detect(languageId: blob?.languageId, filePath: relativePath)
@@ -55,9 +55,9 @@ struct FilesDetailScreen: View {
 
   var readOnlyTagline: String {
     if workspace.laneId != nil {
-      return "Read-only on iPhone — previews, metadata, history, and diffs only. Use desktop ADE for edits."
+      return "Read-only on iPhone. Preview, diff, and metadata are available here; edit on desktop."
     }
-    return "Read-only on iPhone — previews and metadata only. Use desktop ADE for edits."
+    return "Read-only on iPhone. Preview and metadata are available here; edit on desktop."
   }
 
   var body: some View {
@@ -89,21 +89,7 @@ struct FilesDetailScreen: View {
     .adeNavigationGlass()
     .navigationTitle(lastPathComponent(relativePath))
     .navigationBarTitleDisplayMode(.inline)
-    .navigationBarBackButtonHidden(true)
     .toolbar {
-      ToolbarItem(placement: .topBarLeading) {
-        HStack(spacing: 10) {
-          Button {
-            dismiss()
-          } label: {
-            Image(systemName: "chevron.left")
-          }
-          .accessibilityLabel("Back")
-          .frame(minWidth: 44, minHeight: 44)
-          .contentShape(Rectangle())
-          ADERootToolbarLeading()
-        }
-      }
       ToolbarItem(placement: .topBarTrailing) {
         Button {
           isDetailsSheetPresented = true
@@ -181,6 +167,10 @@ struct FilesDetailScreen: View {
         if editorModes.count > 1 {
           filesModeControl
         }
+
+        if showsCodeLayoutControl(blob: blob) {
+          filesCodeLayoutControl
+        }
       }
     }
     .padding(.horizontal, 16)
@@ -205,6 +195,26 @@ struct FilesDetailScreen: View {
         }
         .pickerStyle(.segmented)
       }
+    }
+  }
+
+  @ViewBuilder
+  private var filesCodeLayoutControl: some View {
+    Picker("Code layout", selection: $codeLayoutMode) {
+      ForEach(FilesCodeLayoutMode.allCases) { layoutMode in
+        Text(layoutMode.title).tag(layoutMode)
+      }
+    }
+    .pickerStyle(.segmented)
+    .accessibilityLabel("Code layout")
+  }
+
+  private func showsCodeLayoutControl(blob: SyncFileBlob) -> Bool {
+    switch mode {
+    case .preview:
+      return !blob.isBinary
+    case .diff:
+      return workspace.laneId != nil
     }
   }
 
@@ -248,7 +258,8 @@ struct FilesDetailScreen: View {
         SyntaxHighlightedCodeView(
           text: blob.content,
           language: language,
-          focusLine: focusLine
+          focusLine: focusLine,
+          layoutMode: codeLayoutMode
         )
       }
     }
@@ -278,6 +289,12 @@ struct FilesDetailScreen: View {
         title: "Binary diff",
         message: "The host reported a binary diff that cannot be rendered inline."
       )
+    } else if let diff, !filesDiffHasChanges(diff) {
+      FilesContentFallback(
+        symbol: "checkmark.circle",
+        title: "No \(diffMode.title.lowercased()) changes",
+        message: "This file matches the selected \(diffMode.title.lowercased()) diff scope."
+      )
     } else if let diff, let limit = filesDiffPreviewLimit(diff: diff) {
       FilesContentFallback(
         symbol: "arrow.left.arrow.right",
@@ -287,7 +304,8 @@ struct FilesDetailScreen: View {
     } else if let diff {
       FilesInlineDiffView(
         lines: buildInlineDiffLines(original: diff.original.text, modified: diff.modified.text),
-        language: FilesLanguage.detect(languageId: diff.language, filePath: relativePath)
+        language: FilesLanguage.detect(languageId: diff.language, filePath: relativePath),
+        layoutMode: codeLayoutMode
       )
     } else {
       FilesContentFallback(

--- a/apps/ios/ADE/Views/Files/FilesModels.swift
+++ b/apps/ios/ADE/Views/Files/FilesModels.swift
@@ -36,6 +36,20 @@ enum FilesEditorMode: String, CaseIterable, Identifiable {
   }
 }
 
+enum FilesCodeLayoutMode: String, CaseIterable, Identifiable {
+  case wrap
+  case scroll
+
+  var id: String { rawValue }
+
+  var title: String {
+    switch self {
+    case .wrap: return "Wrap"
+    case .scroll: return "Scroll"
+    }
+  }
+}
+
 struct FilesSectionFallback: Equatable {
   let title: String
   let message: String
@@ -121,6 +135,10 @@ func filesDiffPreviewLimit(diff: FileDiff) -> FilesPreviewLimit? {
     title: "Diff preview paused",
     action: "Open the file on desktop or inspect a smaller diff before rendering it on iPhone."
   )
+}
+
+func filesDiffHasChanges(_ diff: FileDiff) -> Bool {
+  diff.original.exists != diff.modified.exists || diff.original.text != diff.modified.text
 }
 
 private func filesTextLimit(byteCount: Int, lineCount: Int, lineLimit: Int, byteLimit: Int, title: String, action: String) -> FilesPreviewLimit? {

--- a/apps/ios/ADE/Views/Files/FilesRootComponents.swift
+++ b/apps/ios/ADE/Views/Files/FilesRootComponents.swift
@@ -7,15 +7,12 @@ struct FilesWorkspaceHeader: View {
   @Binding var showHidden: Bool
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 14) {
+    VStack(alignment: .leading, spacing: 12) {
       HStack(alignment: .top, spacing: 12) {
         VStack(alignment: .leading, spacing: 4) {
           Text("Workspace")
             .font(.headline)
             .foregroundStyle(ADEColor.textPrimary)
-          Text("Switch between cached lane roots without leaving the Files tab.")
-            .font(.caption)
-            .foregroundStyle(ADEColor.textSecondary)
         }
 
         Spacer(minLength: 0)
@@ -31,8 +28,8 @@ struct FilesWorkspaceHeader: View {
 
       Text(selectedWorkspace.rootPath)
         .font(.caption.monospaced())
-        .foregroundStyle(ADEColor.textSecondary)
-        .lineLimit(1)
+        .foregroundStyle(ADEColor.textPrimary)
+        .lineLimit(2)
         .truncationMode(.middle)
         .accessibilityLabel("Workspace path \(selectedWorkspace.rootPath)")
         .textSelection(.enabled)
@@ -190,18 +187,48 @@ struct FilesQueryCard: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 10) {
-      Text(title)
-        .font(.headline)
-        .foregroundStyle(ADEColor.textPrimary)
-      Text(scopeText)
-        .font(.caption.monospaced())
-        .foregroundStyle(ADEColor.textSecondary)
-        .lineLimit(1)
-      TextField(prompt, text: $query)
-        .textInputAutocapitalization(.never)
-        .autocorrectionDisabled()
-        .disabled(disabled)
-        .adeInsetField()
+      HStack(alignment: .firstTextBaseline, spacing: 8) {
+        Text(title)
+          .font(.headline)
+          .foregroundStyle(ADEColor.textPrimary)
+        Spacer(minLength: 8)
+        Text(disabled ? "Offline" : "Ready")
+          .font(.caption2.weight(.semibold))
+          .foregroundStyle(disabled ? ADEColor.textMuted : ADEColor.success)
+      }
+
+      Label {
+        Text(scopeText)
+          .font(.caption.monospaced())
+          .foregroundStyle(ADEColor.textSecondary)
+          .lineLimit(2)
+          .truncationMode(.middle)
+      } icon: {
+        Image(systemName: "folder")
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(ADEColor.textMuted)
+      }
+
+      HStack(spacing: 8) {
+        Image(systemName: "magnifyingglass")
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(ADEColor.textMuted)
+        TextField(prompt, text: $query)
+          .textInputAutocapitalization(.never)
+          .autocorrectionDisabled()
+          .submitLabel(.search)
+          .disabled(disabled)
+        if !query.isEmpty {
+          Button {
+            query = ""
+          } label: {
+            Image(systemName: "xmark.circle.fill")
+              .foregroundStyle(ADEColor.textMuted)
+          }
+          .accessibilityLabel("Clear \(title.lowercased())")
+        }
+      }
+      .adeInsetField()
       Text(emptyMessage)
         .font(.caption)
         .foregroundStyle(ADEColor.textSecondary)

--- a/apps/ios/ADE/Views/Files/FilesRootScreen+Actions.swift
+++ b/apps/ios/ADE/Views/Files/FilesRootScreen+Actions.swift
@@ -236,6 +236,9 @@ extension FilesRootScreen {
       syncService.requestedFilesNavigation = nil
       return
     }
+    if selectedWorkspaceId != workspace.id {
+      suppressNextWorkspaceNavigationReset = true
+    }
     selectedWorkspaceId = workspace.id
     if let relativePath = request.relativePath, !relativePath.isEmpty {
       selectedFileTransitionPath = relativePath

--- a/apps/ios/ADE/Views/Files/FilesRootScreen+Actions.swift
+++ b/apps/ios/ADE/Views/Files/FilesRootScreen+Actions.swift
@@ -146,7 +146,7 @@ extension FilesRootScreen {
       return
     }
 
-    try? await Task.sleep(nanoseconds: 250_000_000)
+    try? await Task.sleep(nanoseconds: 150_000_000)
     guard !Task.isCancelled, isTabActive, canUseLiveFileActions else { return }
     guard query == quickOpenQuery.trimmingCharacters(in: .whitespacesAndNewlines), workspaceId == selectedWorkspaceId else { return }
 
@@ -195,7 +195,7 @@ extension FilesRootScreen {
       return
     }
 
-    try? await Task.sleep(nanoseconds: 250_000_000)
+    try? await Task.sleep(nanoseconds: 150_000_000)
     guard !Task.isCancelled, isTabActive, canUseLiveFileActions else { return }
     guard query == textSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines), workspaceId == selectedWorkspaceId else { return }
 
@@ -248,12 +248,18 @@ extension FilesRootScreen {
   }
 
   func openDirectory(_ parentPath: String, in workspace: FilesWorkspace) {
+    if selectedWorkspaceId != workspace.id {
+      suppressNextWorkspaceNavigationReset = true
+    }
     selectedWorkspaceId = workspace.id
     selectedFileTransitionPath = nil
     navigationPath = routesForDirectory(parentPath, workspace: workspace)
   }
 
   func openFile(_ relativePath: String, in workspace: FilesWorkspace, focusLine: Int?) {
+    if selectedWorkspaceId != workspace.id {
+      suppressNextWorkspaceNavigationReset = true
+    }
     selectedWorkspaceId = workspace.id
     selectedFileTransitionPath = relativePath
     navigationPath = routesForFile(relativePath, workspace: workspace, focusLine: focusLine)

--- a/apps/ios/ADE/Views/Files/FilesRootScreen.swift
+++ b/apps/ios/ADE/Views/Files/FilesRootScreen.swift
@@ -31,6 +31,7 @@ struct FilesRootScreen: View {
   @State var lastHandledQuickOpenSearchKey: FilesSearchKey?
   @State var lastHandledTextSearchKey: FilesSearchKey?
   @State var lastHandledProofArtifactsReloadKey: FilesProofArtifactsReloadKey?
+  @State var suppressNextWorkspaceNavigationReset = false
 
   var filesProjectionReloadKey: Int? {
     isTabActive ? syncService.localStateRevision : nil
@@ -125,19 +126,36 @@ struct FilesRootScreen: View {
               showHidden: $showHidden
             )
 
-            if workspace.laneId != nil {
-              FilesProofSection(
-                artifacts: proofArtifacts,
-                errorMessage: proofErrorMessage,
-                onRefresh: { Task { await loadProofArtifacts() } },
-                onOpenArtifact: { artifact in
-                  selectedProofArtifact = artifact
+            VStack(alignment: .leading, spacing: 12) {
+              HStack(alignment: .center, spacing: 10) {
+                Label("Browser", systemImage: "folder")
+                  .font(.headline)
+                  .foregroundStyle(ADEColor.textPrimary)
+                Spacer(minLength: 8)
+                Text(canUseLiveFileActions ? "Live" : "Cached")
+                  .font(.caption2.weight(.semibold))
+                  .foregroundStyle(canUseLiveFileActions ? ADEColor.success : ADEColor.textMuted)
+              }
+
+              FilesDirectoryContentsView(
+                workspace: workspace,
+                parentPath: "",
+                showHidden: showHidden,
+                isLive: canUseLiveFileActions,
+                isTabActive: isTabActive,
+                openDirectory: { path in
+                  openDirectory(path, in: workspace)
                 },
-                onCopyReference: { artifact in
-                  UIPasteboard.general.string = artifact.uri
-                }
+                openFile: { path, line in
+                  openFile(path, in: workspace, focusLine: line)
+                },
+                transitionNamespace: transitionNamespace,
+                selectedFilePath: selectedFileTransitionPath,
+                manualReloadToken: 0
               )
+              .environmentObject(syncService)
             }
+            .adeGlassCard(cornerRadius: 18)
 
             FilesQueryCard(
               title: "Quick open",
@@ -187,38 +205,26 @@ struct FilesRootScreen: View {
               }
             }
 
-            VStack(alignment: .leading, spacing: 12) {
-              Text("Browser")
-                .font(.headline)
-                .foregroundStyle(ADEColor.textPrimary)
-              Text("Drill into folders, follow breadcrumbs, and open read-first previews without leaving the current workspace.")
-                .font(.caption)
-                .foregroundStyle(ADEColor.textSecondary)
-
-              FilesDirectoryContentsView(
-                workspace: workspace,
-                parentPath: "",
-                showHidden: showHidden,
-                isLive: canUseLiveFileActions,
-                isTabActive: isTabActive,
-                openDirectory: { path in
-                  openDirectory(path, in: workspace)
+            if workspace.laneId != nil {
+              FilesProofSection(
+                artifacts: proofArtifacts,
+                errorMessage: proofErrorMessage,
+                onRefresh: { Task { await loadProofArtifacts() } },
+                onOpenArtifact: { artifact in
+                  selectedProofArtifact = artifact
                 },
-                openFile: { path, line in
-                  openFile(path, in: workspace, focusLine: line)
-                },
-                transitionNamespace: transitionNamespace,
-                selectedFilePath: selectedFileTransitionPath,
-                manualReloadToken: 0
+                onCopyReference: { artifact in
+                  UIPasteboard.general.string = artifact.uri
+                }
               )
-              .environmentObject(syncService)
             }
-            .adeGlassCard(cornerRadius: 18)
           }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
+        .padding(.bottom, 88)
       }
+      .scrollDismissesKeyboard(.interactively)
       .scrollBounceBehavior(.basedOnSize)
       .adeScreenBackground()
       .adeNavigationGlass()
@@ -335,6 +341,10 @@ struct FilesRootScreen: View {
         lastHandledProofArtifactsReloadKey = key
       }
       .onChange(of: selectedWorkspaceId) { _, _ in
+        if suppressNextWorkspaceNavigationReset {
+          suppressNextWorkspaceNavigationReset = false
+          return
+        }
         if !navigationPath.isEmpty {
           navigationPath = []
         }

--- a/apps/ios/ADE/Views/Lanes/LaneActionsCard.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneActionsCard.swift
@@ -3,13 +3,6 @@ import SwiftUI
 struct LaneActionsCard: View {
   let canRunLiveActions: Bool
   let disabledSubtitle: String?
-  let canPush: Bool
-  let isPublish: Bool
-  let onPullMerge: () -> Void
-  let onPullRebase: () -> Void
-  let onPush: () -> Void
-  let onSync: () -> Void
-  let onFetch: () -> Void
   let onRebaseLane: () -> Void
   let onRebaseDescendants: () -> Void
   let onRebaseAndPush: () -> Void
@@ -19,60 +12,45 @@ struct LaneActionsCard: View {
   @State private var moreExpanded = false
 
   var body: some View {
-    ADEGlassSection(title: "Actions", subtitle: canRunLiveActions ? nil : disabledSubtitle) {
+    ADEGlassSection(title: "Lane actions", subtitle: canRunLiveActions ? nil : disabledSubtitle) {
       VStack(alignment: .leading, spacing: 12) {
-        primaryRow
-        secondaryRow
+        stashButton
         moreSection
       }
     }
   }
 
-  private var primaryRow: some View {
-    HStack(spacing: 10) {
-      Menu {
-        Button {
-          onPullMerge()
-        } label: {
-          Label("Pull (merge)", systemImage: "arrow.down.to.line")
+  private var stashButton: some View {
+    Button(action: onStash) {
+      HStack(spacing: 10) {
+        Image(systemName: "tray.and.arrow.down")
+          .font(.system(size: 13, weight: .semibold))
+          .foregroundStyle(ADEColor.accent)
+          .frame(width: 24)
+        VStack(alignment: .leading, spacing: 2) {
+          Text("Stash changes")
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(ADEColor.textPrimary)
+          Text("Move current work aside without discarding it.")
+            .font(.caption)
+            .foregroundStyle(ADEColor.textSecondary)
         }
-        Button {
-          onPullRebase()
-        } label: {
-          Label("Pull (rebase)", systemImage: "arrow.triangle.2.circlepath")
-        }
-      } label: {
-        actionTile(title: "Pull", symbol: "arrow.down.to.line", tint: ADEColor.textSecondary)
+        Spacer(minLength: 8)
+        Image(systemName: "chevron.right")
+          .font(.system(size: 10, weight: .bold))
+          .foregroundStyle(ADEColor.textMuted)
       }
-      .disabled(!canRunLiveActions)
-
-      Button(action: onPush) {
-        actionTile(
-          title: isPublish ? "Publish" : "Push",
-          symbol: isPublish ? "arrow.up.circle.fill" : "arrow.up.to.line",
-          tint: canPush ? ADEColor.accent : ADEColor.textMuted
-        )
-      }
-      .buttonStyle(.plain)
-      .disabled(!canRunLiveActions || !canPush)
-
-      Button(action: onSync) {
-        actionTile(title: "Sync", symbol: "arrow.triangle.2.circlepath", tint: ADEColor.textSecondary)
-      }
-      .buttonStyle(.plain)
-      .disabled(!canRunLiveActions)
+      .padding(.horizontal, 12)
+      .padding(.vertical, 11)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(ADEColor.surfaceBackground.opacity(0.28), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+      .overlay(
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .stroke(ADEColor.border.opacity(0.14), lineWidth: 0.5)
+      )
     }
-  }
-
-  private var secondaryRow: some View {
-    HStack(spacing: 10) {
-      Button(action: onFetch) {
-        actionTile(title: "Fetch", symbol: "arrow.down.circle", tint: ADEColor.textSecondary, compact: true)
-      }
-      .buttonStyle(.plain)
-      .disabled(!canRunLiveActions)
-      Spacer(minLength: 0)
-    }
+    .buttonStyle(.plain)
+    .disabled(!canRunLiveActions)
   }
 
   @ViewBuilder
@@ -80,18 +58,33 @@ struct LaneActionsCard: View {
     Button {
       withAnimation(.smooth(duration: 0.22)) { moreExpanded.toggle() }
     } label: {
-      HStack(spacing: 6) {
-        Text(moreExpanded ? "Less" : "More")
-          .font(.caption.weight(.semibold))
-          .foregroundStyle(ADEColor.textSecondary)
+      HStack(spacing: 10) {
+        Image(systemName: "exclamationmark.shield")
+          .font(.system(size: 13, weight: .semibold))
+          .foregroundStyle(ADEColor.warning)
+          .frame(width: 24)
+        VStack(alignment: .leading, spacing: 2) {
+          Text("Advanced git")
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(ADEColor.textPrimary)
+          Text("Review before rebasing or force pushing.")
+            .font(.caption)
+            .foregroundStyle(ADEColor.textSecondary)
+        }
+        Spacer(minLength: 8)
         Image(systemName: "chevron.down")
-          .font(.system(size: 9, weight: .bold))
+          .font(.system(size: 10, weight: .bold))
           .foregroundStyle(ADEColor.textMuted)
           .rotationEffect(.degrees(moreExpanded ? 180 : 0))
       }
-      .padding(.horizontal, 10)
-      .padding(.vertical, 6)
-      .background(ADEColor.surfaceBackground.opacity(0.35), in: Capsule())
+      .padding(.horizontal, 12)
+      .padding(.vertical, 11)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(ADEColor.warning.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+      .overlay(
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+          .stroke(ADEColor.warning.opacity(0.18), lineWidth: 0.5)
+      )
     }
     .buttonStyle(.plain)
 
@@ -104,8 +97,6 @@ struct LaneActionsCard: View {
         moreRow(title: "Rebase and push", symbol: "arrow.up.and.down.text.horizontal", tint: ADEColor.textPrimary, action: onRebaseAndPush)
         Divider().opacity(0.35)
         moreRow(title: "Force push (lease)", symbol: "arrow.up.forward.circle.fill", tint: ADEColor.warning, action: onForcePush)
-        Divider().opacity(0.35)
-        moreRow(title: "Stash changes", symbol: "tray.and.arrow.down", tint: ADEColor.textPrimary, action: onStash)
       }
       .background(ADEColor.surfaceBackground.opacity(0.25), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
       .overlay(
@@ -114,26 +105,6 @@ struct LaneActionsCard: View {
       )
       .transition(.opacity.combined(with: .move(edge: .top)))
     }
-  }
-
-  private func actionTile(title: String, symbol: String, tint: Color, compact: Bool = false) -> some View {
-    VStack(spacing: 4) {
-      Image(systemName: symbol)
-        .font(.system(size: 16, weight: .semibold))
-        .symbolRenderingMode(.hierarchical)
-      Text(title)
-        .font(.caption2.weight(.semibold))
-        .lineLimit(1)
-        .minimumScaleFactor(0.85)
-    }
-    .foregroundStyle(tint)
-    .frame(maxWidth: .infinity)
-    .frame(height: compact ? 44 : 58)
-    .background(ADEColor.surfaceBackground.opacity(0.35), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-    .overlay(
-      RoundedRectangle(cornerRadius: 12, style: .continuous)
-        .stroke(ADEColor.border.opacity(0.14), lineWidth: 0.5)
-    )
   }
 
   private func moreRow(title: String, symbol: String, tint: Color, action: @escaping () -> Void) -> some View {

--- a/apps/ios/ADE/Views/Lanes/LaneCommitHistoryScreen.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneCommitHistoryScreen.swift
@@ -10,6 +10,8 @@ struct LaneCommitHistoryScreen: View {
   let onRevert: (GitCommitSummary) async -> Void
   let onCherryPick: (GitCommitSummary) async -> Void
 
+  @State private var pendingConfirmation: CommitHistoryConfirmation?
+
   var body: some View {
     ScrollView {
       VStack(spacing: 14) {
@@ -34,6 +36,16 @@ struct LaneCommitHistoryScreen: View {
     .background(ADEColor.surfaceBackground.ignoresSafeArea())
     .navigationTitle("\(laneName) commits")
     .navigationBarTitleDisplayMode(.inline)
+    .alert(item: $pendingConfirmation) { confirmation in
+      Alert(
+        title: Text(confirmation.title),
+        message: Text(confirmation.message),
+        primaryButton: .destructive(Text(confirmation.confirmTitle)) {
+          Task { await perform(confirmation) }
+        },
+        secondaryButton: .cancel()
+      )
+    }
   }
 
   private var emptyState: some View {
@@ -73,26 +85,79 @@ struct LaneCommitHistoryScreen: View {
       Text("\(commit.authorName) • \(relativeTimestamp(commit.authoredAt))")
         .font(.caption2)
         .foregroundStyle(ADEColor.textSecondary)
-      ScrollView(.horizontal, showsIndicators: false) {
-        HStack(spacing: 6) {
-          LaneActionButton(title: "Files", symbol: "doc.text.magnifyingglass") {
-            Task { await onOpenDiff(commit) }
-          }
-          .disabled(!allowsDiffInspection(commit))
-          LaneActionButton(title: "Copy message", symbol: "doc.on.doc") {
-            Task { await onCopyMessage(commit) }
+      HStack(spacing: 8) {
+        LaneActionButton(title: "Files", symbol: "doc.text.magnifyingglass") {
+          Task { await onOpenDiff(commit) }
+        }
+        .disabled(!allowsDiffInspection(commit))
+        LaneActionButton(title: "Copy", symbol: "doc.on.doc") {
+          Task { await onCopyMessage(commit) }
+        }
+        .disabled(!canRunLiveActions)
+        Spacer(minLength: 0)
+        Menu {
+          Button(role: .destructive) {
+            pendingConfirmation = CommitHistoryConfirmation(kind: .revert, commit: commit)
+          } label: {
+            Label("Revert commit", systemImage: "arrow.uturn.backward")
           }
           .disabled(!canRunLiveActions)
-          LaneActionButton(title: "Revert", symbol: "arrow.uturn.backward", tint: ADEColor.warning) {
-            Task { await onRevert(commit) }
+
+          Button {
+            pendingConfirmation = CommitHistoryConfirmation(kind: .cherryPick, commit: commit)
+          } label: {
+            Label("Cherry-pick commit", systemImage: "arrow.triangle.merge")
           }
           .disabled(!canRunLiveActions)
-          LaneActionButton(title: "Cherry-pick", symbol: "arrow.triangle.merge") {
-            Task { await onCherryPick(commit) }
-          }
-          .disabled(!canRunLiveActions)
+        } label: {
+          LaneMenuLabel(title: "More")
         }
       }
+    }
+  }
+
+  private func perform(_ confirmation: CommitHistoryConfirmation) async {
+    pendingConfirmation = nil
+    switch confirmation.kind {
+    case .revert:
+      await onRevert(confirmation.commit)
+    case .cherryPick:
+      await onCherryPick(confirmation.commit)
+    }
+  }
+}
+
+private struct CommitHistoryConfirmation: Identifiable {
+  enum Kind: String {
+    case revert
+    case cherryPick
+  }
+
+  let kind: Kind
+  let commit: GitCommitSummary
+
+  var id: String { "\(kind.rawValue):\(commit.sha)" }
+
+  var title: String {
+    switch kind {
+    case .revert: return "Revert this commit?"
+    case .cherryPick: return "Cherry-pick this commit?"
+    }
+  }
+
+  var message: String {
+    switch kind {
+    case .revert:
+      return "ADE will create a new commit that reverses \(commit.shortSha)."
+    case .cherryPick:
+      return "ADE will apply \(commit.shortSha) onto the current lane."
+    }
+  }
+
+  var confirmTitle: String {
+    switch kind {
+    case .revert: return "Revert"
+    case .cherryPick: return "Cherry-pick"
     }
   }
 }

--- a/apps/ios/ADE/Views/Lanes/LaneCommitSheet.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneCommitSheet.swift
@@ -20,9 +20,11 @@ struct LaneCommitSheet: View {
           statusRow
           messageField
           amendRow
+          commitActionSection
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 14)
+        .padding(.top, 14)
+        .padding(.bottom, 24)
       }
       .background(ADEColor.surfaceBackground.ignoresSafeArea())
       .navigationTitle(amendCommit ? "Amend commit" : "Commit changes")
@@ -34,9 +36,6 @@ struct LaneCommitSheet: View {
             dismissEnv()
           }
         }
-      }
-      .safeAreaInset(edge: .bottom) {
-        commitButtonBar
       }
       .onAppear { messageFieldFocused = true }
     }
@@ -115,9 +114,8 @@ struct LaneCommitSheet: View {
     .background(ADEColor.surfaceBackground.opacity(0.35), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
   }
 
-  private var commitButtonBar: some View {
-    VStack(spacing: 0) {
-      Divider().opacity(0.4)
+  private var commitActionSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
       Button(action: onCommit) {
         HStack(spacing: 6) {
           Image(systemName: amendCommit ? "arrow.counterclockwise" : "checkmark.circle.fill")
@@ -131,10 +129,12 @@ struct LaneCommitSheet: View {
       .buttonStyle(.borderedProminent)
       .tint(ADEColor.accent)
       .disabled(!canCommit)
-      .padding(.horizontal, 16)
-      .padding(.vertical, 12)
+      Text(commitActionHint)
+        .font(.caption)
+        .foregroundStyle(ADEColor.textSecondary)
     }
-    .background(.ultraThinMaterial)
+    .padding(12)
+    .background(ADEColor.surfaceBackground.opacity(0.35), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
   }
 
   private var trimmedMessage: String {
@@ -154,5 +154,13 @@ struct LaneCommitSheet: View {
     if stagedCount == 0 { return "Stage files first" }
     if trimmedMessage.isEmpty { return "Write a message" }
     return "Commit \(stagedCount) file\(stagedCount == 1 ? "" : "s")"
+  }
+
+  private var commitActionHint: String {
+    if !canRunLiveActions { return "Reconnect to commit changes." }
+    if amendCommit { return "This replaces the last commit on this lane." }
+    if stagedCount == 0 { return "Stage files before committing." }
+    if trimmedMessage.isEmpty { return "Write a commit message before continuing." }
+    return "Creates a commit from the staged files."
   }
 }

--- a/apps/ios/ADE/Views/Lanes/LaneComponents.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneComponents.swift
@@ -244,7 +244,7 @@ struct LaneListRow: View, Equatable {
           Spacer(minLength: 0)
         }
 
-        HStack(spacing: 6) {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 58), spacing: 6, alignment: .leading)], alignment: .leading, spacing: 6) {
           if snapshot.lane.status.dirty {
             LaneMicroChip(icon: "circle.fill", text: "dirty", tint: ADEColor.warning)
           }
@@ -268,6 +268,7 @@ struct LaneListRow: View, Equatable {
             LaneMicroChip(icon: "pin.fill", text: nil, tint: ADEColor.accent)
           }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
       }
 
       Spacer(minLength: 8)
@@ -378,7 +379,7 @@ struct LaneStackCard: View, Equatable {
           .padding(.top, 4)
       }
 
-      HStack(spacing: 6) {
+      LazyVGrid(columns: [GridItem(.adaptive(minimum: 58), spacing: 6, alignment: .leading)], alignment: .leading, spacing: 6) {
         if snapshot.lane.status.dirty {
           LaneMicroChip(icon: "circle.fill", text: "dirty", tint: ADEColor.warning)
         }
@@ -401,8 +402,8 @@ struct LaneStackCard: View, Equatable {
         if isPinned {
           LaneMicroChip(icon: "pin.fill", text: nil, tint: ADEColor.accent)
         }
-        Spacer(minLength: 0)
       }
+      .frame(maxWidth: .infinity, alignment: .leading)
 
       if let activity = laneActivitySummary(snapshot) {
         Text(activity)
@@ -453,4 +454,3 @@ struct LaneStackCard: View, Equatable {
     return parts.joined(separator: ", ")
   }
 }
-

--- a/apps/ios/ADE/Views/Lanes/LaneConnectionPresentation.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneConnectionPresentation.swift
@@ -15,7 +15,7 @@ struct LaneEmptyStatePresentation: Equatable {
 }
 
 func laneAllowsLiveActions(connectionState: RemoteConnectionState, laneStatus: SyncDomainStatus) -> Bool {
-  (connectionState == .connected || connectionState == .syncing) && laneStatus.phase == .ready
+  connectionState == .connected && laneStatus.phase == .ready
 }
 
 func laneAllowsDiffInspection(

--- a/apps/ios/ADE/Views/Lanes/LaneDetailGitSection.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneDetailGitSection.swift
@@ -26,8 +26,6 @@ extension LaneDetailScreen {
           stagedSection(changes: diffChanges.staged)
         }
 
-        actionsCard
-
         NavigationLink {
           LaneSyncDetailScreen(
             laneName: detail.lane.name,
@@ -122,6 +120,8 @@ extension LaneDetailScreen {
           )
         }
         .buttonStyle(.plain)
+
+        actionsCard
       }
     }
   }
@@ -139,7 +139,7 @@ extension LaneDetailScreen {
         parentLabel: detail.lane.baseRef,
         canRunLiveActions: canRunLiveActions,
         onRebase: {
-          Task { await performAction("rebase lane") { try await syncService.startLaneRebase(laneId: laneId, scope: "lane_only") } }
+          requestGitConfirmation(.rebaseLane)
         },
         onDefer: handleRebaseSuggestionDefer,
         onDismiss: handleRebaseSuggestionDismiss
@@ -193,32 +193,15 @@ extension LaneDetailScreen {
 
   @ViewBuilder
   var actionsCard: some View {
-    if let detail {
+    if detail != nil {
       LaneActionsCard(
         canRunLiveActions: canRunLiveActions,
         disabledSubtitle: liveActionDisabledSubtitle,
-        canPush: (detail.lane.status.ahead) > 0 || detail.syncStatus?.hasUpstream == false,
-        isPublish: detail.syncStatus?.hasUpstream == false,
-        onPullMerge: {
-          Task { await performAction("pull merge") { try await syncService.pullGit(laneId: laneId) } }
-        },
-        onPullRebase: {
-          Task { await performAction("pull rebase") { try await syncService.syncGit(laneId: laneId, mode: "rebase") } }
-        },
-        onPush: {
-          Task { await performAction("push") { try await syncService.pushGit(laneId: laneId) } }
-        },
-        onSync: {
-          Task { await performAction("sync") { try await syncService.syncGit(laneId: laneId, mode: "rebase") } }
-        },
-        onFetch: {
-          Task { await performAction("fetch") { try await syncService.fetchGit(laneId: laneId) } }
-        },
         onRebaseLane: {
-          Task { await performAction("rebase lane") { try await syncService.startLaneRebase(laneId: laneId, scope: "lane_only") } }
+          requestGitConfirmation(.rebaseLane)
         },
         onRebaseDescendants: {
-          Task { await performAction("rebase descendants") { try await syncService.startLaneRebase(laneId: laneId, scope: "lane_and_descendants") } }
+          requestGitConfirmation(.rebaseDescendants)
         },
         onRebaseAndPush: {
           requestGitConfirmation(.rebaseAndPush)
@@ -385,13 +368,7 @@ extension LaneDetailScreen {
       secondaryActionTint: ADEColor.danger,
       extraBulkActions: [
         LaneFileTreeBulkAction(title: "Discard all", symbol: "trash", tint: ADEColor.danger, isDestructive: true) {
-          Task {
-            await performAction("discard all") {
-              for file in changes {
-                try await syncService.discardFile(laneId: laneId, path: file.path)
-              }
-            }
-          }
+          pendingFileConfirmation = .discardAllUnstaged(changes)
         }
       ],
       onBulkAction: {
@@ -415,7 +392,7 @@ extension LaneDetailScreen {
         Task { await performAction("stage file") { try await syncService.stageFile(laneId: laneId, path: file.path) } }
       },
       onSecondaryAction: { file in
-        confirmDiscardFile = file
+        pendingFileConfirmation = .discardUnstaged(file)
       },
       onOpenFiles: { file in
         Task { await openFiles(path: file.path) }
@@ -464,7 +441,7 @@ extension LaneDetailScreen {
         Task { await performAction("unstage file") { try await syncService.unstageFile(laneId: laneId, path: file.path) } }
       },
       onSecondaryAction: { file in
-        Task { await performAction("restore staged file") { try await syncService.restoreStagedFile(laneId: laneId, path: file.path) } }
+        pendingFileConfirmation = .restoreStaged(file)
       },
       onOpenFiles: { file in
         Task { await openFiles(path: file.path) }

--- a/apps/ios/ADE/Views/Lanes/LaneDetailScreen.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneDetailScreen.swift
@@ -22,7 +22,7 @@ struct LaneDetailScreen: View {
   @State var commitMessage = ""
   @State var amendCommit = false
   @State var stashMessage = ""
-  @State var confirmDiscardFile: FileChange?
+  @State var pendingFileConfirmation: LaneFileConfirmation?
   @State private var filesWorkspaceId: String?
   @State var showCommitSheet = false
   @State var rebaseSuggestionDismissed = false
@@ -136,22 +136,15 @@ struct LaneDetailScreen: View {
     .sheet(isPresented: $showStackGraph) {
       LaneStackGraphSheet(snapshots: allLaneSnapshots, selectedLaneId: laneId)
     }
-    .alert("Discard changes?", isPresented: Binding(
-      get: { confirmDiscardFile != nil },
-      set: { if !$0 { confirmDiscardFile = nil } }
-    )) {
-      Button("Discard", role: .destructive) {
-        if let file = confirmDiscardFile {
-          Task {
-            await performAction("discard file", refreshRoot: true) {
-              try await syncService.discardFile(laneId: laneId, path: file.path)
-            }
-          }
-        }
-      }
-      Button("Cancel", role: .cancel) {}
-    } message: {
-      Text("Unstaged changes to this file will be permanently lost.")
+    .alert(item: $pendingFileConfirmation) { confirmation in
+      Alert(
+        title: Text(confirmation.title),
+        message: Text(confirmation.message),
+        primaryButton: .destructive(Text(confirmation.confirmTitle)) {
+          Task { await performConfirmedFileAction(confirmation) }
+        },
+        secondaryButton: .cancel()
+      )
     }
     .alert(item: $pendingGitConfirmation) { confirmation in
       Alert(
@@ -356,6 +349,14 @@ struct LaneDetailScreen: View {
   private func performConfirmedGitAction(_ confirmation: LaneGitConfirmation) async {
     pendingGitConfirmation = nil
     switch confirmation {
+    case .rebaseLane:
+      await performAction(confirmation.actionLabel) {
+        try await syncService.startLaneRebase(laneId: laneId, scope: "lane_only")
+      }
+    case .rebaseDescendants:
+      await performAction(confirmation.actionLabel) {
+        try await syncService.startLaneRebase(laneId: laneId, scope: "lane_and_descendants")
+      }
     case .forcePush:
       await performAction(confirmation.actionLabel) {
         try await syncService.pushGit(laneId: laneId, forceWithLease: true)
@@ -363,6 +364,27 @@ struct LaneDetailScreen: View {
     case .rebaseAndPush:
       await performAction(confirmation.actionLabel) {
         try await runRebaseAndPush()
+      }
+    }
+  }
+
+  @MainActor
+  private func performConfirmedFileAction(_ confirmation: LaneFileConfirmation) async {
+    pendingFileConfirmation = nil
+    switch confirmation {
+    case .discardUnstaged(let file):
+      await performAction(confirmation.actionLabel, refreshRoot: true) {
+        try await syncService.discardFile(laneId: laneId, path: file.path)
+      }
+    case .discardAllUnstaged(let files):
+      await performAction(confirmation.actionLabel, refreshRoot: true) {
+        for file in files {
+          try await syncService.discardFile(laneId: laneId, path: file.path)
+        }
+      }
+    case .restoreStaged(let file):
+      await performAction(confirmation.actionLabel, refreshRoot: true) {
+        try await syncService.restoreStagedFile(laneId: laneId, path: file.path)
       }
     }
   }

--- a/apps/ios/ADE/Views/Lanes/LaneListViewParts.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneListViewParts.swift
@@ -18,9 +18,18 @@ extension LanesTabView {
 
   var visibleAutoRebaseAttention: [LaneListSnapshot] {
     filteredSnapshots.filter { snapshot in
+      guard snapshot.rebaseSuggestion == nil else { return false }
       guard let status = snapshot.autoRebaseStatus else { return false }
       return status.state != "autoRebased"
     }
+  }
+
+  var visibleAttentionLaneIds: Set<String> {
+    Set((visibleSuggestions + visibleAutoRebaseAttention).map(\.lane.id))
+  }
+
+  var normalVisibleSnapshots: [LaneListSnapshot] {
+    filteredSnapshots.filter { !visibleAttentionLaneIds.contains($0.lane.id) }
   }
 
   var primaryLane: LaneSummary? {
@@ -101,7 +110,12 @@ extension LanesTabView {
 
   @ViewBuilder
   var attentionSection: some View {
-    VStack(spacing: 12) {
+    VStack(alignment: .leading, spacing: 10) {
+      Text("Needs review")
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(ADEColor.textSecondary)
+        .padding(.horizontal, 2)
+
       ForEach(visibleSuggestions.prefix(3)) { snapshot in
         HStack(spacing: 12) {
           Image(systemName: "arrow.triangle.2.circlepath")
@@ -116,20 +130,15 @@ extension LanesTabView {
               .foregroundStyle(ADEColor.textSecondary)
           }
           Spacer(minLength: 8)
-          Button("Rebase") {
-            Task {
-              do {
-                try await syncService.startLaneRebase(laneId: snapshot.lane.id)
-                await reload(refreshRemote: true)
-              } catch {
-                ADEHaptics.error()
-                errorMessage = error.localizedDescription
-              }
-            }
+          Button("Review") {
+            detailSheetTarget = LaneDetailSheetTarget(
+              laneId: snapshot.lane.id,
+              snapshot: snapshot,
+              initialSection: .git
+            )
           }
           .font(.caption.weight(.semibold))
           .foregroundStyle(ADEColor.accent)
-          .disabled(!canRunLiveActions)
           Menu {
             Button("Defer") {
               Task {
@@ -216,6 +225,17 @@ extension LanesTabView {
     stackOrderedSnapshots.filter { $0.lane.laneType != "primary" }
   }
 
+  var normalStickyPrimarySnapshot: LaneListSnapshot? {
+    guard let stickyPrimarySnapshot, !visibleAttentionLaneIds.contains(stickyPrimarySnapshot.lane.id) else {
+      return nil
+    }
+    return stickyPrimarySnapshot
+  }
+
+  var normalTreeSnapshots: [LaneListSnapshot] {
+    treeSnapshots.filter { !visibleAttentionLaneIds.contains($0.lane.id) }
+  }
+
   @ViewBuilder
   var laneList: some View {
     if laneSnapshots.isEmpty {
@@ -238,58 +258,68 @@ extension LanesTabView {
       )
       .padding(.top, 40)
     } else {
-      VStack(spacing: 10) {
-        if let primarySnapshot = stickyPrimarySnapshot {
-          NavigationLink {
-            LaneDetailScreen(
-              laneId: primarySnapshot.lane.id,
-              initialSnapshot: primarySnapshot,
+      if normalVisibleSnapshots.isEmpty {
+        EmptyView()
+      } else {
+        VStack(spacing: 10) {
+          Text("Lanes")
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(ADEColor.textSecondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 2)
+
+          if let primarySnapshot = normalStickyPrimarySnapshot {
+            NavigationLink {
+              LaneDetailScreen(
+                laneId: primarySnapshot.lane.id,
+                initialSnapshot: primarySnapshot,
+                allLaneSnapshots: laneSnapshots,
+                transitionNamespace: transitionNamespace,
+                onRefreshRoot: { await reload(refreshRemote: true) }
+              )
+            } label: {
+              LaneStackCard(
+                snapshot: primarySnapshot,
+                isPinned: pinnedLaneIds.contains(primarySnapshot.lane.id),
+                isOpen: openLaneIds.contains(primarySnapshot.lane.id),
+                depth: 0,
+                transitionNamespace: transitionNamespace,
+                isSelectedTransitionSource: selectedLaneTransitionId == primarySnapshot.lane.id
+              )
+              .equatable()
+            }
+            .simultaneousGesture(TapGesture().onEnded {
+              selectedLaneTransitionId = primarySnapshot.lane.id
+            })
+            .buttonStyle(ADEScaleButtonStyle())
+            .contextMenu { laneContextMenu(snapshot: primarySnapshot) } preview: {
+              LanePeekPreview(snapshot: primarySnapshot)
+            }
+            .swipeActions(edge: .leading, allowsFullSwipe: false) {
+              Button {
+                togglePin(primarySnapshot.lane.id)
+              } label: {
+                Label(pinnedLaneIds.contains(primarySnapshot.lane.id) ? "Unpin" : "Pin",
+                      systemImage: pinnedLaneIds.contains(primarySnapshot.lane.id) ? "pin.slash.fill" : "pin.fill")
+              }
+              .tint(ADEColor.accent)
+            }
+          }
+
+          if !normalTreeSnapshots.isEmpty {
+            LaneTreeView(
+              snapshots: normalTreeSnapshots,
+              pinnedLaneIds: pinnedLaneIds,
+              openLaneIds: openLaneIds,
               allLaneSnapshots: laneSnapshots,
               transitionNamespace: transitionNamespace,
-              onRefreshRoot: { await reload(refreshRemote: true) }
+              selectedLaneId: selectedLaneTransitionId,
+              onRefreshRoot: { await reload(refreshRemote: true) },
+              onContextMenu: { snapshot in AnyView(laneContextMenu(snapshot: snapshot)) },
+              onTogglePin: { laneId in togglePin(laneId) },
+              onSelectLane: { laneId in selectedLaneTransitionId = laneId }
             )
-          } label: {
-            LaneStackCard(
-              snapshot: primarySnapshot,
-              isPinned: pinnedLaneIds.contains(primarySnapshot.lane.id),
-              isOpen: openLaneIds.contains(primarySnapshot.lane.id),
-              depth: 0,
-              transitionNamespace: transitionNamespace,
-              isSelectedTransitionSource: selectedLaneTransitionId == primarySnapshot.lane.id
-            )
-            .equatable()
           }
-          .simultaneousGesture(TapGesture().onEnded {
-            selectedLaneTransitionId = primarySnapshot.lane.id
-          })
-          .buttonStyle(ADEScaleButtonStyle())
-          .contextMenu { laneContextMenu(snapshot: primarySnapshot) } preview: {
-            LanePeekPreview(snapshot: primarySnapshot)
-          }
-          .swipeActions(edge: .leading, allowsFullSwipe: false) {
-            Button {
-              togglePin(primarySnapshot.lane.id)
-            } label: {
-              Label(pinnedLaneIds.contains(primarySnapshot.lane.id) ? "Unpin" : "Pin",
-                    systemImage: pinnedLaneIds.contains(primarySnapshot.lane.id) ? "pin.slash.fill" : "pin.fill")
-            }
-            .tint(ADEColor.accent)
-          }
-        }
-
-        if !treeSnapshots.isEmpty {
-          LaneTreeView(
-            snapshots: treeSnapshots,
-            pinnedLaneIds: pinnedLaneIds,
-            openLaneIds: openLaneIds,
-            allLaneSnapshots: laneSnapshots,
-            transitionNamespace: transitionNamespace,
-            selectedLaneId: selectedLaneTransitionId,
-            onRefreshRoot: { await reload(refreshRemote: true) },
-            onContextMenu: { snapshot in AnyView(laneContextMenu(snapshot: snapshot)) },
-            onTogglePin: { laneId in togglePin(laneId) },
-            onSelectLane: { laneId in selectedLaneTransitionId = laneId }
-          )
         }
       }
     }

--- a/apps/ios/ADE/Views/Lanes/LaneListViewParts.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneListViewParts.swift
@@ -116,7 +116,7 @@ extension LanesTabView {
         .foregroundStyle(ADEColor.textSecondary)
         .padding(.horizontal, 2)
 
-      ForEach(visibleSuggestions.prefix(3)) { snapshot in
+      ForEach(visibleSuggestions) { snapshot in
         HStack(spacing: 12) {
           Image(systemName: "arrow.triangle.2.circlepath")
             .font(.system(size: 13, weight: .semibold))
@@ -178,7 +178,7 @@ extension LanesTabView {
         )
       }
 
-      ForEach(visibleAutoRebaseAttention.prefix(3)) { snapshot in
+      ForEach(visibleAutoRebaseAttention) { snapshot in
         HStack(spacing: 12) {
           Image(systemName: "exclamationmark.triangle.fill")
             .font(.system(size: 13, weight: .semibold))

--- a/apps/ios/ADE/Views/Lanes/LaneSyncDetailScreen.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneSyncDetailScreen.swift
@@ -10,6 +10,8 @@ struct LaneSyncDetailScreen: View {
   let onPullRebase: () -> Void
   let onPush: () -> Void
 
+  @State private var pendingAction: LaneSyncAction?
+
   var body: some View {
     ScrollView {
       VStack(spacing: 14) {
@@ -32,15 +34,15 @@ struct LaneSyncDetailScreen: View {
           }
         }
 
-        ADEGlassSection(title: "Quick sync") {
+        ADEGlassSection(title: "Sync actions", subtitle: "Review the lane state before changing refs.") {
           VStack(spacing: 10) {
             HStack(spacing: 10) {
-              syncTile(title: "Fetch", symbol: "arrow.down.circle", action: onFetch)
-              syncTile(title: "Pull (merge)", symbol: "arrow.down.to.line", action: onPullMerge)
+              syncTile(action: .fetch)
+              syncTile(action: .pullMerge)
             }
             HStack(spacing: 10) {
-              syncTile(title: "Pull (rebase)", symbol: "arrow.triangle.2.circlepath", action: onPullRebase)
-              syncTile(title: "Push", symbol: "arrow.up.to.line", tint: ADEColor.accent, action: onPush)
+              syncTile(action: .pullRebase)
+              syncTile(action: .push)
             }
           }
         }
@@ -51,6 +53,16 @@ struct LaneSyncDetailScreen: View {
     .background(ADEColor.surfaceBackground.ignoresSafeArea())
     .navigationTitle("\(laneName) sync")
     .navigationBarTitleDisplayMode(.inline)
+    .alert(item: $pendingAction) { action in
+      Alert(
+        title: Text(action.title),
+        message: Text(action.message),
+        primaryButton: action.isDestructive
+          ? .destructive(Text(action.confirmTitle)) { perform(action) }
+          : .default(Text(action.confirmTitle)) { perform(action) },
+        secondaryButton: .cancel()
+      )
+    }
   }
 
   private var summary: String {
@@ -58,15 +70,19 @@ struct LaneSyncDetailScreen: View {
     return syncSummary(syncStatus)
   }
 
-  private func syncTile(title: String, symbol: String, tint: Color = ADEColor.textPrimary, action: @escaping () -> Void) -> some View {
-    Button(action: action) {
+  private func syncTile(action: LaneSyncAction) -> some View {
+    Button {
+      pendingAction = action
+    } label: {
       VStack(spacing: 4) {
-        Image(systemName: symbol)
+        Image(systemName: action.symbol)
           .font(.system(size: 16, weight: .semibold))
-        Text(title)
+        Text(action.buttonTitle)
           .font(.caption2.weight(.semibold))
+          .lineLimit(1)
+          .minimumScaleFactor(0.8)
       }
-      .foregroundStyle(tint)
+      .foregroundStyle(action.tint)
       .frame(maxWidth: .infinity)
       .frame(height: 58)
       .background(ADEColor.surfaceBackground.opacity(0.35), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
@@ -77,5 +93,94 @@ struct LaneSyncDetailScreen: View {
     }
     .buttonStyle(.plain)
     .disabled(!canRunLiveActions)
+  }
+
+  private func perform(_ action: LaneSyncAction) {
+    pendingAction = nil
+    switch action {
+    case .fetch:
+      onFetch()
+    case .pullMerge:
+      onPullMerge()
+    case .pullRebase:
+      onPullRebase()
+    case .push:
+      onPush()
+    }
+  }
+}
+
+private enum LaneSyncAction: String, Identifiable {
+  case fetch
+  case pullMerge
+  case pullRebase
+  case push
+
+  var id: String { rawValue }
+
+  var buttonTitle: String {
+    switch self {
+    case .fetch: return "Fetch"
+    case .pullMerge: return "Pull merge"
+    case .pullRebase: return "Pull rebase"
+    case .push: return "Push"
+    }
+  }
+
+  var title: String {
+    switch self {
+    case .fetch: return "Fetch remote refs?"
+    case .pullMerge: return "Pull with merge?"
+    case .pullRebase: return "Pull with rebase?"
+    case .push: return "Push commits?"
+    }
+  }
+
+  var message: String {
+    switch self {
+    case .fetch:
+      return "ADE will update remote-tracking refs for this lane. Local files are not changed."
+    case .pullMerge:
+      return "ADE will merge upstream changes into this lane. Review status before continuing."
+    case .pullRebase:
+      return "ADE will replay local commits on top of upstream changes. Review status before continuing."
+    case .push:
+      return "ADE will update the remote branch with local commits from this lane."
+    }
+  }
+
+  var confirmTitle: String {
+    switch self {
+    case .fetch: return "Fetch"
+    case .pullMerge: return "Pull merge"
+    case .pullRebase: return "Pull rebase"
+    case .push: return "Push"
+    }
+  }
+
+  var symbol: String {
+    switch self {
+    case .fetch: return "arrow.down.circle"
+    case .pullMerge: return "arrow.down.to.line"
+    case .pullRebase: return "arrow.triangle.2.circlepath"
+    case .push: return "arrow.up.to.line"
+    }
+  }
+
+  var tint: Color {
+    switch self {
+    case .push: return ADEColor.accent
+    case .pullRebase: return ADEColor.warning
+    default: return ADEColor.textPrimary
+    }
+  }
+
+  var isDestructive: Bool {
+    switch self {
+    case .fetch, .push:
+      return false
+    case .pullMerge, .pullRebase:
+      return true
+    }
   }
 }

--- a/apps/ios/ADE/Views/Lanes/LaneSyncDetailScreen.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneSyncDetailScreen.swift
@@ -141,7 +141,7 @@ private enum LaneSyncAction: String, Identifiable {
     case .fetch:
       return "ADE will update remote-tracking refs for this lane. Local files are not changed."
     case .pullMerge:
-      return "ADE will merge upstream changes into this lane. Review status before continuing."
+      return "ADE will fast-forward this lane to upstream. This only succeeds when local work has not diverged."
     case .pullRebase:
       return "ADE will replay local commits on top of upstream changes. Review status before continuing."
     case .push:

--- a/apps/ios/ADE/Views/Lanes/LaneTypes.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneTypes.swift
@@ -62,11 +62,15 @@ enum LaneDetailSection: String, CaseIterable, Identifiable {
 }
 
 enum LaneGitConfirmation: Identifiable {
+  case rebaseLane
+  case rebaseDescendants
   case forcePush
   case rebaseAndPush
 
   var id: String {
     switch self {
+    case .rebaseLane: return "rebase-lane"
+    case .rebaseDescendants: return "rebase-descendants"
     case .forcePush: return "force-push"
     case .rebaseAndPush: return "rebase-and-push"
     }
@@ -74,6 +78,8 @@ enum LaneGitConfirmation: Identifiable {
 
   var title: String {
     switch self {
+    case .rebaseLane: return "Rebase this lane?"
+    case .rebaseDescendants: return "Rebase lane and descendants?"
     case .forcePush: return "Force push?"
     case .rebaseAndPush: return "Rebase and push?"
     }
@@ -81,6 +87,10 @@ enum LaneGitConfirmation: Identifiable {
 
   var message: String {
     switch self {
+    case .rebaseLane:
+      return "ADE will replay this lane on top of its parent. Review the lane status before continuing."
+    case .rebaseDescendants:
+      return "ADE will replay this lane and child lanes. Review affected lanes before continuing."
     case .forcePush:
       return "This updates the remote branch with force-with-lease. Review the lane status before continuing."
     case .rebaseAndPush:
@@ -90,6 +100,8 @@ enum LaneGitConfirmation: Identifiable {
 
   var confirmTitle: String {
     switch self {
+    case .rebaseLane: return "Rebase lane"
+    case .rebaseDescendants: return "Rebase all"
     case .forcePush: return "Force push"
     case .rebaseAndPush: return "Rebase and push"
     }
@@ -97,8 +109,68 @@ enum LaneGitConfirmation: Identifiable {
 
   var actionLabel: String {
     switch self {
+    case .rebaseLane: return "rebase lane"
+    case .rebaseDescendants: return "rebase descendants"
     case .forcePush: return "force push"
     case .rebaseAndPush: return "rebase and push"
+    }
+  }
+}
+
+enum LaneFileConfirmation: Identifiable {
+  case discardUnstaged(FileChange)
+  case discardAllUnstaged([FileChange])
+  case restoreStaged(FileChange)
+
+  var id: String {
+    switch self {
+    case .discardUnstaged(let file): return "discard:\(file.id)"
+    case .discardAllUnstaged(let files): return "discard-all:\(files.count):\(files.map(\.id).joined(separator: ","))"
+    case .restoreStaged(let file): return "restore:\(file.id)"
+    }
+  }
+
+  var title: String {
+    switch self {
+    case .discardUnstaged: return "Discard changes?"
+    case .discardAllUnstaged: return "Discard all unstaged changes?"
+    case .restoreStaged: return "Restore staged file?"
+    }
+  }
+
+  var message: String {
+    switch self {
+    case .discardUnstaged:
+      return "Unstaged changes to this file will be permanently lost."
+    case .discardAllUnstaged(let files):
+      return "Unstaged changes to \(files.count) file\(files.count == 1 ? "" : "s") will be permanently lost."
+    case .restoreStaged:
+      return "The staged version of this file will be restored from HEAD."
+    }
+  }
+
+  var confirmTitle: String {
+    switch self {
+    case .discardUnstaged: return "Discard"
+    case .discardAllUnstaged: return "Discard all"
+    case .restoreStaged: return "Restore"
+    }
+  }
+
+  var actionLabel: String {
+    switch self {
+    case .discardUnstaged: return "discard file"
+    case .discardAllUnstaged: return "discard all"
+    case .restoreStaged: return "restore staged file"
+    }
+  }
+
+  var file: FileChange? {
+    switch self {
+    case .discardUnstaged(let file), .restoreStaged(let file):
+      return file
+    case .discardAllUnstaged:
+      return nil
     }
   }
 }

--- a/apps/ios/ADE/Views/PRs/CreatePrWizardView.swift
+++ b/apps/ios/ADE/Views/PRs/CreatePrWizardView.swift
@@ -181,7 +181,6 @@ struct CreatePrWizardView: View {
     NavigationStack {
       ScrollView {
         VStack(spacing: 0) {
-          dragHandle
           heroHeader
           if let errorMessage, !syncService.connectionState.isHostUnreachable {
             ADENoticeCard(
@@ -202,14 +201,14 @@ struct CreatePrWizardView: View {
           stanceSection
           reviewersSection
           labelsSection
-          whatHappensNextSection
+          finalReviewSection
           Color.clear.frame(height: 40)
         }
       }
       .scrollIndicators(.hidden)
       .adeScreenBackground()
       .adeNavigationGlass()
-      .navigationTitle("")
+      .navigationTitle("Open pull request")
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {
@@ -252,18 +251,6 @@ struct CreatePrWizardView: View {
   }
 
   // MARK: - Hero chrome
-
-  private var dragHandle: some View {
-    HStack {
-      Spacer()
-      RoundedRectangle(cornerRadius: 2, style: .continuous)
-        .fill(ADEColor.textSecondary.opacity(0.28))
-        .frame(width: 36, height: 4)
-      Spacer()
-    }
-    .padding(.top, 8)
-    .padding(.bottom, 4)
-  }
 
   private var heroHeader: some View {
     VStack(alignment: .leading, spacing: 6) {
@@ -589,12 +576,12 @@ struct CreatePrWizardView: View {
     }
   }
 
-  // MARK: - What happens next
+  // MARK: - Final review
 
-  private var whatHappensNextSection: some View {
+  private var finalReviewSection: some View {
     VStack(spacing: 0) {
-      PrSectionHdr(title: "What happens next") {
-        PrMonoText(text: "automated", color: ADEColor.textMuted, size: 10)
+      PrSectionHdr(title: "Final review") {
+        PrMonoText(text: "host action", color: ADEColor.warning, size: 10)
       }
       VStack(spacing: 0) {
         let steps = buildNextSteps()
@@ -612,14 +599,20 @@ struct CreatePrWizardView: View {
   private func buildNextSteps() -> [NextStepItem] {
     var steps: [NextStepItem] = []
     let branch = selectedOption?.branchRef ?? selectedLane?.branchRef ?? "lane"
-    steps.append(NextStepItem(id: "push", label: "Push \(branch) to origin", note: nil))
+    steps.append(
+      NextStepItem(
+        id: "push",
+        label: "Push \(branch) to origin",
+        note: "Runs before GitHub opens the PR."
+      )
+    )
 
     let stanceLabel = draft ? "draft" : "ready"
     steps.append(
       NextStepItem(
         id: "open",
-        label: "Open PR against \(baseBranch) · \(stanceLabel)",
-        note: nil
+        label: "Open PR against \(baseBranch)",
+        note: "Stance: \(stanceLabel)."
       )
     )
 
@@ -643,7 +636,7 @@ struct CreatePrWizardView: View {
             .controlSize(.small)
             .tint(Color(.sRGB, red: 0.05, green: 0.04, blue: 0.07, opacity: 1.0))
         }
-        Text(isSubmitting ? "Opening…" : "Open")
+        Text(isSubmitting ? "Pushing…" : "Push & open")
           .font(.system(size: 12, weight: .bold))
           .foregroundStyle(Color(.sRGB, red: 0.05, green: 0.04, blue: 0.07, opacity: 1.0))
       }
@@ -959,18 +952,20 @@ fileprivate struct NextStepRow: View {
       }
       .frame(width: 18, height: 18)
 
-      Text(step.label)
-        .font(.system(size: 12.5))
-        .foregroundStyle(ADEColor.textPrimary)
-        .lineLimit(2)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(step.label)
+          .font(.system(size: 12.5))
+          .foregroundStyle(ADEColor.textPrimary)
+          .lineLimit(2)
 
-      Spacer(minLength: 0)
-
-      if let note = step.note {
-        Text(note)
-          .font(.system(size: 9.5, design: .monospaced))
-          .foregroundStyle(ADEColor.textMuted)
+        if let note = step.note {
+          Text(note)
+            .font(.system(size: 10.5))
+            .foregroundStyle(ADEColor.textMuted)
+            .fixedSize(horizontal: false, vertical: true)
+        }
       }
+      Spacer(minLength: 0)
     }
     .padding(.horizontal, 14)
     .padding(.vertical, 10)

--- a/apps/ios/ADE/Views/PRs/PrFiltersCard.swift
+++ b/apps/ios/ADE/Views/PRs/PrFiltersCard.swift
@@ -55,12 +55,17 @@ struct PrGitHubFiltersCard: View {
   private var header: some View {
     HStack(alignment: .top, spacing: 12) {
       VStack(alignment: .leading, spacing: 4) {
-        Text(repo.map { "\($0.owner)/\($0.name)" } ?? "GitHub pull requests")
+        Text("GitHub pull requests")
           .font(.subheadline.weight(.semibold))
           .foregroundStyle(ADEColor.textPrimary)
           .lineLimit(1)
         HStack(spacing: 6) {
           PrMonoText(text: "\(visibleCount)/\(totalCount)", color: ADEColor.textSecondary, size: 10)
+          if let repo {
+            PrMonoText(text: "\(repo.owner)/\(repo.name)", color: ADEColor.textMuted, size: 10)
+              .lineLimit(1)
+              .truncationMode(.middle)
+          }
           if let viewerLogin, !viewerLogin.isEmpty {
             PrMonoText(text: "@\(viewerLogin)", color: ADEColor.textMuted, size: 10)
               .lineLimit(1)

--- a/apps/ios/ADE/Views/PRs/PrHelpers.swift
+++ b/apps/ios/ADE/Views/PRs/PrHelpers.swift
@@ -61,6 +61,17 @@ func filterPullRequestListItems(
   }
 }
 
+func matchedLaneForExactBranch(_ headBranch: String?, lanes: [LaneSummary]) -> LaneSummary? {
+  guard let headBranch = headBranch?.trimmingCharacters(in: .whitespacesAndNewlines),
+    !headBranch.isEmpty
+  else {
+    return nil
+  }
+  return lanes.first { lane in
+    lane.branchRef.caseInsensitiveCompare(headBranch) == .orderedSame
+  }
+}
+
 func parsePullRequestPatch(_ patch: String) -> [PrDiffDisplayLine] {
   guard !patch.isEmpty else { return [] }
 
@@ -612,10 +623,14 @@ struct PrScopeChip: View {
         Text(label)
           .font(.system(size: 13, weight: isActive ? .semibold : .medium))
           .foregroundColor(isActive ? ADEColor.tintPRs : ADEColor.textPrimary)
+          .lineLimit(1)
+          .minimumScaleFactor(0.85)
         if let count {
           Text("\(count)")
             .font(.system(size: 11, weight: .semibold, design: .monospaced))
             .foregroundColor(isActive ? ADEColor.tintPRs : ADEColor.textSecondary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
             .background(
@@ -626,6 +641,7 @@ struct PrScopeChip: View {
       }
       .padding(.horizontal, 12)
       .padding(.vertical, 7)
+      .fixedSize(horizontal: true, vertical: false)
       .background(
         Capsule()
           .fill(isActive ? ADEColor.tintPRs.opacity(0.14) : ADEColor.recessedBackground)

--- a/apps/ios/ADE/Views/PRs/PrModels.swift
+++ b/apps/ios/ADE/Views/PRs/PrModels.swift
@@ -18,7 +18,7 @@ struct PrActionAvailability: Equatable {
     case "draft":
       showsMerge = true
       mergeEnabled = false
-      showsClose = true
+      showsClose = false
       showsReopen = false
       showsRequestReviewers = true
     case "closed":

--- a/apps/ios/ADE/Views/PRs/PrRowCard.swift
+++ b/apps/ios/ADE/Views/PRs/PrRowCard.swift
@@ -44,6 +44,10 @@ struct PrRowCard: View {
             PrTagChip(label: kindLabel, color: tint)
           }
 
+          if data.isUnmapped {
+            PrTagChip(label: "unmapped", color: ADEColor.warning, filled: true)
+          }
+
           if data.isExternal {
             PrTagChip(label: "external", color: ADEColor.textSecondary)
           }
@@ -78,54 +82,67 @@ struct PrRowCard: View {
 
   @ViewBuilder
   private var metaLine: some View {
-    HStack(spacing: 10) {
-      HStack(spacing: 3) {
+    VStack(alignment: .leading, spacing: 3) {
+      HStack(spacing: 4) {
         Image(systemName: "arrow.triangle.branch")
           .font(.system(size: 9, weight: .semibold))
           .foregroundStyle(ADEColor.textSecondary.opacity(0.7))
-        PrMonoText(text: data.branchLabel, color: ADEColor.textSecondary, size: 10)
+        PrMonoText(text: data.branchDisplayLabel, color: ADEColor.textSecondary, size: 10)
           .lineLimit(1)
           .truncationMode(.tail)
-      }
-      .frame(maxWidth: 160, alignment: .leading)
+          .layoutPriority(1)
 
-      if let checks = data.checkCounts {
-        HStack(spacing: 5) {
-          if checks.fail > 0 {
-            PrMonoText(text: "✗ \(checks.fail)", color: ADEColor.danger, size: 10)
-          }
-          if checks.pass > 0 {
-            PrMonoText(text: "✓ \(checks.pass)", color: ADEColor.success, size: 10)
-          }
-          if checks.pending > 0 {
-            PrMonoText(text: "◐ \(checks.pending)", color: ADEColor.warning, size: 10)
-          }
+        if let author = data.authorLabel {
+          PrMonoText(text: "by \(author)", color: ADEColor.textMuted, size: 10)
+            .lineLimit(1)
+            .truncationMode(.tail)
         }
       }
 
-      if let approvals = data.approvals {
-        PrMonoText(
-          text: "✓ \(approvals.have)/\(approvals.need)",
-          color: approvals.have >= approvals.need ? ADEColor.success : ADEColor.textSecondary,
-          size: 10
-        )
-      }
-
-      Spacer(minLength: 0)
-
-      if let groupId = data.stackGroupId, let groupCount = data.stackGroupCount, groupCount > 0 {
-        Button {
-          onShowStack(groupId, data.stackGroupName)
-        } label: {
-          HStack(spacing: 3) {
-            Image(systemName: "list.number")
-              .font(.system(size: 9, weight: .bold))
-            Text("\(groupCount)")
-              .font(.system(size: 10, weight: .semibold, design: .monospaced))
+      HStack(spacing: 8) {
+        if let checks = data.checkCounts {
+          HStack(spacing: 5) {
+            if checks.fail > 0 {
+              PrMonoText(text: "✗ \(checks.fail)", color: ADEColor.danger, size: 10)
+            }
+            if checks.pass > 0 {
+              PrMonoText(text: "✓ \(checks.pass)", color: ADEColor.success, size: 10)
+            }
+            if checks.pending > 0 {
+              PrMonoText(text: "◐ \(checks.pending)", color: ADEColor.warning, size: 10)
+            }
           }
-          .foregroundStyle(ADEColor.textSecondary)
         }
-        .buttonStyle(.plain)
+
+        if let approvals = data.approvals {
+          PrMonoText(
+            text: "✓ \(approvals.have)/\(approvals.need)",
+            color: approvals.have >= approvals.need ? ADEColor.success : ADEColor.textSecondary,
+            size: 10
+          )
+        }
+
+        if data.isUnmapped {
+          PrMonoText(text: "read before linking", color: ADEColor.warning, size: 10)
+            .lineLimit(1)
+        }
+
+        Spacer(minLength: 0)
+
+        if let groupId = data.stackGroupId, let groupCount = data.stackGroupCount, groupCount > 0 {
+          Button {
+            onShowStack(groupId, data.stackGroupName)
+          } label: {
+            HStack(spacing: 3) {
+              Image(systemName: "list.number")
+                .font(.system(size: 9, weight: .bold))
+              Text("\(groupCount)")
+                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+            }
+            .foregroundStyle(ADEColor.textSecondary)
+          }
+          .buttonStyle(.plain)
+        }
       }
     }
   }
@@ -139,15 +156,28 @@ extension PrRowCard {
     let state: String
     let updatedAt: String
     let branchLabel: String
+    let baseBranch: String?
+    let author: String?
     let adeKindLabel: String?
     let adeKindTint: Color?
     let isExternal: Bool
+    let isUnmapped: Bool
     let checkCounts: CheckCounts?
     let approvals: Approvals?
     let warnMessage: String?
     let stackGroupId: String?
     let stackGroupName: String?
     let stackGroupCount: Int?
+
+    var branchDisplayLabel: String {
+      guard let baseBranch, !baseBranch.isEmpty else { return branchLabel }
+      return "\(branchLabel) → \(baseBranch)"
+    }
+
+    var authorLabel: String? {
+      guard let author, !author.isEmpty else { return nil }
+      return author.hasPrefix("@") ? author : "@\(author)"
+    }
 
     struct CheckCounts {
       let pass: Int
@@ -167,9 +197,12 @@ extension PrRowCard {
       self.state = pr.state
       self.updatedAt = pr.updatedAt
       self.branchLabel = pr.headBranch
+      self.baseBranch = pr.baseBranch
+      self.author = nil
       self.adeKindLabel = prAdeKindLabel(pr.adeKind)
       self.adeKindTint = pr.adeKind != nil ? ADEColor.tintPRs : nil
       self.isExternal = false
+      self.isUnmapped = false
       self.checkCounts = Self.checkCounts(from: pr.checksStatus)
       self.approvals = Self.approvals(from: pr.reviewStatus)
       self.warnMessage = Self.warnMessage(
@@ -183,22 +216,28 @@ extension PrRowCard {
     }
 
     init(item: GitHubPrListItem) {
+      let unmapped = item.linkedPrId == nil && item.linkedLaneId == nil && item.adeKind == nil
       self.id = item.linkedPrId ?? item.id
       self.prNumber = item.githubPrNumber
       self.title = item.title
       self.state = item.isDraft ? "draft" : item.state
       self.updatedAt = item.updatedAt
       self.branchLabel = item.headBranch ?? "\(item.repoOwner)/\(item.repoName)"
+      self.baseBranch = item.baseBranch
+      self.author = item.author
       self.adeKindLabel = prAdeKindLabel(item.adeKind)
       self.adeKindTint = Self.adeKindTint(for: item)
       self.isExternal = item.scope == "external"
+      self.isUnmapped = unmapped
       self.checkCounts = nil
       self.approvals = nil
-      self.warnMessage = Self.warnMessage(
-        workflowDisplayState: item.workflowDisplayState,
-        checksStatus: nil,
-        baseBranch: item.baseBranch
-      )
+      self.warnMessage = unmapped
+        ? "Unmapped: review details before linking a lane."
+        : Self.warnMessage(
+          workflowDisplayState: item.workflowDisplayState,
+          checksStatus: nil,
+          baseBranch: item.baseBranch
+        )
       self.stackGroupId = item.linkedGroupId
       self.stackGroupName = nil
       self.stackGroupCount = nil

--- a/apps/ios/ADE/Views/PRs/PrRowCard.swift
+++ b/apps/ios/ADE/Views/PRs/PrRowCard.swift
@@ -216,7 +216,10 @@ extension PrRowCard {
     }
 
     init(item: GitHubPrListItem) {
-      let unmapped = item.linkedPrId == nil && item.linkedLaneId == nil && item.adeKind == nil
+      let unmapped = item.scope != "external"
+        && item.linkedPrId == nil
+        && item.linkedLaneId == nil
+        && item.adeKind == nil
       self.id = item.linkedPrId ?? item.id
       self.prNumber = item.githubPrNumber
       self.title = item.title

--- a/apps/ios/ADE/Views/PRs/PrsRootScreen.swift
+++ b/apps/ios/ADE/Views/PRs/PrsRootScreen.swift
@@ -543,8 +543,14 @@ struct PRsTabView: View {
     if githubSnapshot != nil {
       let repoItems = filteredGitHubPrs.filter { $0.scope != "external" }
       let externalItems = filteredGitHubPrs.filter { $0.scope == "external" }
+      let repoSectionTitle: String = {
+        if let repo = githubSnapshot?.repo {
+          return "\(repo.owner)/\(repo.name)"
+        }
+        return "Repository PRs"
+      }()
       if !repoItems.isEmpty {
-        Section("Repository PRs") {
+        Section(repoSectionTitle) {
           ForEach(repoItems) { item in
             githubRowNavigation(for: item)
               .prListRow()

--- a/apps/ios/ADE/Views/PRs/PrsRootScreen.swift
+++ b/apps/ios/ADE/Views/PRs/PrsRootScreen.swift
@@ -27,6 +27,7 @@ struct PRsTabView: View {
   @State private var selectedPrTransitionId: String?
   @State private var laneContextLaneId: String?
   @State private var rootActionTask: Task<Void, Never>?
+  @State private var githubDetailRequest: PrGitHubLaneLinkRequest?
   @State private var laneLinkRequest: PrGitHubLaneLinkRequest?
   @SceneStorage("ade.prs.rootSurface") private var rootSurfaceRawValue = PrRootSurface.github.rawValue
   @SceneStorage("ade.prs.workflowFilter") private var workflowFilterRawValue = PrWorkflowKindFilter.all.rawValue
@@ -421,6 +422,21 @@ struct PRsTabView: View {
         PrStackSheet(groupId: presentation.id, groupName: presentation.groupName)
           .environmentObject(syncService)
       }
+      .sheet(item: $githubDetailRequest) { request in
+        PrGitHubReadDetailSheet(
+          item: request.item,
+          canLink: canLinkGitHubPullRequests,
+          onLink: {
+            githubDetailRequest = nil
+            DispatchQueue.main.async {
+              laneLinkRequest = request
+            }
+          },
+          onOpenGitHub: {
+            openGitHub(urlString: request.item.githubUrl)
+          }
+        )
+      }
       .sheet(item: $laneLinkRequest) { request in
         PrLaneLinkSheet(
           item: request.item,
@@ -524,11 +540,11 @@ struct PRsTabView: View {
       }
     }
 
-    if let githubSnapshot {
+    if githubSnapshot != nil {
       let repoItems = filteredGitHubPrs.filter { $0.scope != "external" }
       let externalItems = filteredGitHubPrs.filter { $0.scope == "external" }
       if !repoItems.isEmpty {
-        Section(githubSnapshot.repo.map { "\($0.owner)/\($0.name)" } ?? "Repository PRs") {
+        Section("Repository PRs") {
           ForEach(repoItems) { item in
             githubRowNavigation(for: item)
               .prListRow()
@@ -566,14 +582,14 @@ struct PRsTabView: View {
       }
     } else {
       Button {
-        laneLinkRequest = PrGitHubLaneLinkRequest(item: item)
+        githubDetailRequest = PrGitHubLaneLinkRequest(item: item)
       } label: {
         PrRowCard(item: item)
       }
       .buttonStyle(.plain)
       .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-        Button("Link lane") {
-          laneLinkRequest = PrGitHubLaneLinkRequest(item: item)
+        Button("Review") {
+          githubDetailRequest = PrGitHubLaneLinkRequest(item: item)
         }
         .tint(ADEColor.warning)
         Button("Open in GitHub") { openGitHub(urlString: item.githubUrl) }
@@ -1157,6 +1173,86 @@ struct PRsTabView: View {
   }
 }
 
+private struct PrGitHubReadDetailSheet: View {
+  @Environment(\.dismiss) private var dismiss
+  let item: GitHubPrListItem
+  let canLink: Bool
+  let onLink: () -> Void
+  let onOpenGitHub: () -> Void
+
+  private var stateLabel: String {
+    item.isDraft ? "draft" : item.state
+  }
+
+  private var branchLine: String {
+    let head = item.headBranch?.isEmpty == false ? item.headBranch! : "unknown branch"
+    let base = item.baseBranch?.isEmpty == false ? item.baseBranch! : "unknown base"
+    return "\(head) → \(base)"
+  }
+
+  var body: some View {
+    NavigationStack {
+      List {
+        Section {
+          VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+              Text("#\(item.githubPrNumber)")
+                .font(.system(size: 12, weight: .bold, design: .monospaced))
+                .foregroundStyle(prStateTint(stateLabel))
+              PrTagChip(label: stateLabel, color: prStateTint(stateLabel))
+              PrTagChip(label: "unmapped", color: ADEColor.warning, filled: true)
+            }
+
+            Text(item.title)
+              .font(.headline)
+              .foregroundStyle(ADEColor.textPrimary)
+              .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 5) {
+              PrMonoText(text: "\(item.repoOwner)/\(item.repoName)", color: ADEColor.textSecondary, size: 11)
+              PrMonoText(text: branchLine, color: ADEColor.textSecondary, size: 11)
+              if let author = item.author, !author.isEmpty {
+                PrMonoText(text: "author @\(author)", color: ADEColor.textMuted, size: 11)
+              }
+              PrMonoText(text: "updated \(prRelativeTime(item.updatedAt))", color: ADEColor.textMuted, size: 11)
+            }
+          }
+          .padding(.vertical, 4)
+        }
+
+        Section {
+          ADENoticeCard(
+            title: "Unmapped PR",
+            message: "This GitHub PR is not linked to an ADE lane. Review the branch and author before choosing Link PR.",
+            icon: "link.badge.plus",
+            tint: ADEColor.warning,
+            actionTitle: nil,
+            action: nil
+          )
+        }
+
+        Section {
+          Button("Link PR") {
+            onLink()
+          }
+          .disabled(!canLink)
+
+          Button("Open in GitHub") {
+            onOpenGitHub()
+          }
+        }
+      }
+      .navigationTitle("PR details")
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Done") { dismiss() }
+        }
+      }
+    }
+  }
+}
+
 private struct PrLaneLinkSheet: View {
   @Environment(\.dismiss) private var dismiss
   let item: GitHubPrListItem
@@ -1188,6 +1284,14 @@ private struct PrLaneLinkSheet: View {
                 .font(.caption)
                 .foregroundStyle(ADEColor.textSecondary)
             }
+            HStack(spacing: 8) {
+              if let author = item.author, !author.isEmpty {
+                Text("@\(author)")
+              }
+              Text("updated \(prRelativeTime(item.updatedAt))")
+            }
+            .font(.system(.caption2, design: .monospaced))
+            .foregroundStyle(ADEColor.textMuted)
           }
           .padding(.vertical, 4)
         }
@@ -1206,10 +1310,14 @@ private struct PrLaneLinkSheet: View {
               .font(.subheadline)
               .foregroundStyle(ADEColor.textSecondary)
           } else {
+            Text(laneSelectionMessage)
+              .font(.footnote)
+              .foregroundStyle(laneSelectionTint)
+              .fixedSize(horizontal: false, vertical: true)
             Picker("Lane", selection: $selectedLaneId) {
               Text("Choose lane").tag("")
               ForEach(availableLanes) { lane in
-                Text(lane.name).tag(lane.id)
+                Text("\(lane.name) · \(lane.branchRef)").tag(lane.id)
               }
             }
           }
@@ -1236,8 +1344,26 @@ private struct PrLaneLinkSheet: View {
     }
     .onAppear {
       if selectedLaneId.isEmpty {
-        selectedLaneId = item.linkedLaneId ?? availableLanes.first?.id ?? ""
+        selectedLaneId = item.linkedLaneId ?? exactBranchMatchedLane?.id ?? ""
       }
     }
+  }
+
+  private var exactBranchMatchedLane: LaneSummary? {
+    matchedLaneForExactBranch(item.headBranch, lanes: availableLanes)
+  }
+
+  private var laneSelectionMessage: String {
+    if let exactBranchMatchedLane, selectedLaneId == exactBranchMatchedLane.id {
+      return "Preselected because the PR branch matches \(exactBranchMatchedLane.branchRef)."
+    }
+    if selectedLaneId.isEmpty {
+      return "No lane was preselected because the PR branch does not exactly match an ADE lane."
+    }
+    return "Confirm this lane before linking; ADE will attach this GitHub PR to the selected lane."
+  }
+
+  private var laneSelectionTint: Color {
+    selectedLaneId.isEmpty ? ADEColor.warning : ADEColor.textSecondary
   }
 }

--- a/apps/ios/ADE/Views/PRs/PrsRootScreen.swift
+++ b/apps/ios/ADE/Views/PRs/PrsRootScreen.swift
@@ -586,6 +586,17 @@ struct PRsTabView: View {
         Button("Open in GitHub") { openGitHub(urlString: item.githubUrl) }
           .tint(ADEColor.accent)
       }
+    } else if item.scope == "external" {
+      Button {
+        openGitHub(urlString: item.githubUrl)
+      } label: {
+        PrRowCard(item: item)
+      }
+      .buttonStyle(.plain)
+      .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+        Button("Open in GitHub") { openGitHub(urlString: item.githubUrl) }
+          .tint(ADEColor.accent)
+      }
     } else {
       Button {
         githubDetailRequest = PrGitHubLaneLinkRequest(item: item)

--- a/apps/ios/ADE/Views/Work/WorkArtifactTerminalViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkArtifactTerminalViews.swift
@@ -133,8 +133,8 @@ struct WorkTerminalSessionView: View {
   }
 
   var body: some View {
-    ScrollView {
-      VStack(alignment: .leading, spacing: 14) {
+    VStack(alignment: .leading, spacing: 0) {
+      VStack(alignment: .leading, spacing: 10) {
         WorkSessionHeader(
           session: session,
           chatSummary: nil,
@@ -152,15 +152,24 @@ struct WorkTerminalSessionView: View {
             action: nil
           )
         }
-
-        Text(terminalDisplay.text)
-          .font(.system(.footnote, design: .monospaced))
-          .foregroundStyle(ADEColor.textSecondary)
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .padding(14)
-          .background(ADEColor.surfaceBackground.opacity(0.7), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
       }
-      .padding(16)
+      .padding(.horizontal, 16)
+      .padding(.top, 10)
+      .padding(.bottom, 8)
+      .background(.ultraThinMaterial)
+
+      ScrollView([.horizontal, .vertical]) {
+        Text(terminalDisplay.text)
+          .font(.system(size: 12, weight: .regular, design: .monospaced))
+          .foregroundStyle(ADEColor.textPrimary)
+          .textSelection(.enabled)
+          .padding(.horizontal, 14)
+          .padding(.vertical, 12)
+          .fixedSize(horizontal: true, vertical: false)
+          .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+      }
+      .background(ADEColor.recessedBackground.opacity(0.96))
+      .scrollIndicators(.visible)
     }
     .adeScreenBackground()
     .adeNavigationGlass()

--- a/apps/ios/ADE/Views/Work/WorkChatHeaderAndMessageViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatHeaderAndMessageViews.swift
@@ -27,12 +27,8 @@ struct WorkSessionHeader: View {
   }
 
   var body: some View {
-    // Compact toolbar matching the desktop ChatGitToolbar shape: a left-side
-    // chip cluster (status dot + lane chip + relative time) and a trailing
-    // overflow menu so future Run / Stage & Commit / Push / PR / Terminal /
-    // Handoff entry points have a stable home. The standalone "ENDED · …"
-    // status row that used to live below the title is gone — composer
-    // feedback already conveys the disabled state.
+    // Compact context row. Lane actions live in the nav bar and on the lane
+    // chip, so this row avoids a second anonymous overflow menu.
     HStack(spacing: 8) {
       laneChip
       Text(relativeStartLabel)
@@ -40,7 +36,6 @@ struct WorkSessionHeader: View {
         .foregroundStyle(ADEColor.textMuted)
         .lineLimit(1)
       Spacer(minLength: 0)
-      overflowMenu
     }
     .padding(.vertical, 4)
     .accessibilityElement(children: .contain)
@@ -81,36 +76,6 @@ struct WorkSessionHeader: View {
       Capsule(style: .continuous)
         .stroke(ADEColor.border.opacity(0.22), lineWidth: 0.6)
     )
-  }
-
-  @ViewBuilder
-  private var overflowMenu: some View {
-    // Single-entry menu today — the lane action set (Run / Stage & Commit /
-    // Push / PR / Terminal / Handoff) needs callbacks the iOS chat view
-    // doesn't yet thread through. Slot for them here when they land so the
-    // header layout stays stable.
-    Menu {
-      if let onOpenLane {
-        Button {
-          onOpenLane()
-        } label: {
-          Label("Open lane", systemImage: "arrow.triangle.branch")
-        }
-      }
-    } label: {
-      Image(systemName: "ellipsis")
-        .font(.system(size: 14, weight: .semibold))
-        .foregroundStyle(ADEColor.textSecondary)
-        .frame(width: 28, height: 28)
-        .background(ADEColor.surfaceBackground.opacity(0.55), in: Circle())
-        .overlay(
-          Circle()
-            .stroke(ADEColor.border.opacity(0.22), lineWidth: 0.6)
-        )
-    }
-    .menuStyle(.borderlessButton)
-    .accessibilityLabel("More lane actions")
-    .disabled(onOpenLane == nil)
   }
 }
 

--- a/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
@@ -76,7 +76,7 @@ func buildWorkChatMessages(from transcript: [WorkChatEnvelope]) -> [WorkChatMess
          messages[lastIndex].turnId == turnId,
          messages[lastIndex].itemId == itemId,
          canMergeWithPreviousAssistant {
-        messages[lastIndex].markdown += text
+        messages[lastIndex].markdown = mergeWorkStreamingText(messages[lastIndex].markdown, text)
       } else {
         messages.append(WorkChatMessage(
           id: envelope.id,
@@ -97,6 +97,27 @@ func buildWorkChatMessages(from transcript: [WorkChatEnvelope]) -> [WorkChatMess
   }
 
   return messages
+}
+
+func mergeWorkStreamingText(_ existing: String, _ incoming: String) -> String {
+  if existing.isEmpty { return incoming }
+  if incoming.isEmpty { return existing }
+  if existing == incoming { return existing }
+  if incoming.hasPrefix(existing) { return incoming }
+  if existing.hasPrefix(incoming) { return existing }
+
+  let maxOverlap = min(existing.count, incoming.count)
+  guard maxOverlap > 0 else { return existing + incoming }
+
+  for length in stride(from: maxOverlap, through: 1, by: -1) {
+    let existingSuffix = existing.suffix(length)
+    let incomingPrefix = incoming.prefix(length)
+    if existingSuffix == incomingPrefix {
+      return existing + incoming.dropFirst(length)
+    }
+  }
+
+  return existing + incoming
 }
 
 func makeWorkChatTranscript(from entries: [AgentChatTranscriptEntry], sessionId: String) -> [WorkChatEnvelope] {

--- a/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
@@ -109,6 +109,8 @@ func mergeWorkStreamingText(_ existing: String, _ incoming: String) -> String {
   let maxOverlap = min(existing.count, incoming.count)
   guard maxOverlap > 0 else { return existing + incoming }
 
+  // The hasPrefix checks above handle the common streaming-duplication cases, so this
+  // O(n*m) overlap scan only runs for rare partial-overlap chunks where n and m are small.
   for length in stride(from: maxOverlap, through: 1, by: -1) {
     let existingSuffix = existing.suffix(length)
     let incomingPrefix = incoming.prefix(length)

--- a/apps/ios/ADE/Views/Work/WorkNavigationAndTranscriptHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkNavigationAndTranscriptHelpers.swift
@@ -242,7 +242,10 @@ private func collapseDuplicatedStreamPunctuation(in input: String) -> String {
       runEnd = scalars.index(after: runEnd)
     }
     let runLength = scalars.distance(from: index, to: runEnd)
-    let collapsedLength = max(1, (runLength + 1) / 2)
+    // Preserve ellipses: a 3-dot run is a legitimate "..." the user typed; only halve
+    // dot-runs of 4+, which are the ones that came from streaming duplication.
+    let shouldHalve = scalar == "." ? runLength >= 4 : runLength >= 2
+    let collapsedLength = shouldHalve ? max(1, (runLength + 1) / 2) : runLength
     collapsed.append(contentsOf: Array(repeating: scalar, count: collapsedLength))
     index = runEnd
   }

--- a/apps/ios/ADE/Views/Work/WorkNavigationAndTranscriptHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkNavigationAndTranscriptHelpers.swift
@@ -100,7 +100,160 @@ func sanitizeTerminalOutputForDisplay(_ input: String) -> String {
     }
   }
 
-  return String(output)
+  return collapseDuplicatedWorkStreamTextIfNeeded(String(output))
+}
+
+func collapseDuplicatedWorkStreamTextIfNeeded(_ input: String) -> String {
+  let scalars = Array(input.unicodeScalars)
+  guard scalars.count >= 12 else { return input }
+
+  func collapsedRun(_ run: ArraySlice<UnicodeScalar>) -> [UnicodeScalar] {
+    guard run.count >= 4 else { return Array(run) }
+    var duplicatePairs = 0
+    var segments = 0
+    var singletonSegments = 0
+    var hasLongDuplicateSegment = false
+    var previous: UnicodeScalar?
+    var currentSegmentLength = 0
+
+    func finishSegment() {
+      guard currentSegmentLength > 0 else { return }
+      segments += 1
+      if currentSegmentLength == 1 {
+        singletonSegments += 1
+      }
+      if currentSegmentLength >= 3 {
+        hasLongDuplicateSegment = true
+      }
+    }
+
+    for scalar in run {
+      if let previous, scalar != previous {
+        finishSegment()
+        currentSegmentLength = 0
+      }
+      if scalar == previous {
+        duplicatePairs += 1
+      }
+      currentSegmentLength += 1
+      previous = scalar
+    }
+    finishSegment()
+
+    let density = Double(duplicatePairs) / Double(max(run.count - 1, 1))
+    let mostlyDuplicated = singletonSegments == 0 || singletonSegments <= max(1, segments / 4)
+    guard duplicatePairs >= 2, density >= 0.3, mostlyDuplicated || hasLongDuplicateSegment else { return Array(run) }
+
+    var collapsed: [UnicodeScalar] = []
+    var index = run.startIndex
+    while index < run.endIndex {
+      let scalar = run[index]
+      var runEnd = run.index(after: index)
+      while runEnd < run.endIndex, run[runEnd] == scalar {
+        runEnd = run.index(after: runEnd)
+      }
+      let runLength = run.distance(from: index, to: runEnd)
+      let collapsedLength = max(1, (runLength + 1) / 2)
+      collapsed.append(contentsOf: Array(repeating: scalar, count: collapsedLength))
+      index = runEnd
+    }
+    return collapsed
+  }
+
+  var locallyCollapsed = String.UnicodeScalarView()
+  locallyCollapsed.reserveCapacity(input.unicodeScalars.count)
+  var runStart: Int?
+  for index in scalars.indices {
+    if CharacterSet.alphanumerics.contains(scalars[index]) {
+      if runStart == nil {
+        runStart = index
+      }
+      continue
+    }
+    if let start = runStart {
+      locallyCollapsed.append(contentsOf: collapsedRun(scalars[start..<index]))
+      runStart = nil
+    }
+    locallyCollapsed.append(scalars[index])
+  }
+  if let start = runStart {
+    locallyCollapsed.append(contentsOf: collapsedRun(scalars[start..<scalars.endIndex]))
+  }
+  let localResult = String(locallyCollapsed)
+  if localResult != input {
+    return collapseDuplicatedStreamPunctuation(in: localResult)
+  }
+
+  var comparablePairs = 0
+  var duplicatedAlphanumericPairs = 0
+  for index in scalars.indices.dropFirst() {
+    let scalar = scalars[index]
+    guard CharacterSet.alphanumerics.contains(scalar) else { continue }
+    comparablePairs += 1
+    if scalar == scalars[index - 1] {
+      duplicatedAlphanumericPairs += 1
+    }
+  }
+
+  guard duplicatedAlphanumericPairs >= 5 else { return input }
+  let density = Double(duplicatedAlphanumericPairs) / Double(max(comparablePairs, 1))
+  guard density >= 0.32 else { return input }
+
+  var collapsed = String.UnicodeScalarView()
+  collapsed.reserveCapacity(input.unicodeScalars.count)
+  var index = scalars.startIndex
+  while index < scalars.endIndex {
+    let scalar = scalars[index]
+    guard CharacterSet.alphanumerics.contains(scalar) else {
+      collapsed.append(scalar)
+      index = scalars.index(after: index)
+      continue
+    }
+
+    var runEnd = scalars.index(after: index)
+    while runEnd < scalars.endIndex, scalars[runEnd] == scalar {
+      runEnd = scalars.index(after: runEnd)
+    }
+    let runLength = scalars.distance(from: index, to: runEnd)
+    let collapsedLength = max(1, (runLength + 1) / 2)
+    for _ in 0..<collapsedLength {
+      collapsed.append(scalar)
+    }
+    index = runEnd
+  }
+  return String(collapsed)
+}
+
+private func collapseDuplicatedStreamPunctuation(in input: String) -> String {
+  let duplicatedPunctuation = CharacterSet(charactersIn: ",.;:!?")
+  let scalars = Array(input.unicodeScalars)
+  var collapsed = String.UnicodeScalarView()
+  collapsed.reserveCapacity(input.unicodeScalars.count)
+  var index = scalars.startIndex
+  while index < scalars.endIndex {
+    let scalar = scalars[index]
+    guard duplicatedPunctuation.contains(scalar) else {
+      collapsed.append(scalar)
+      index = scalars.index(after: index)
+      continue
+    }
+    var runEnd = scalars.index(after: index)
+    while runEnd < scalars.endIndex, scalars[runEnd] == scalar {
+      runEnd = scalars.index(after: runEnd)
+    }
+    let runLength = scalars.distance(from: index, to: runEnd)
+    let collapsedLength = max(1, (runLength + 1) / 2)
+    collapsed.append(contentsOf: Array(repeating: scalar, count: collapsedLength))
+    index = runEnd
+  }
+  return String(collapsed)
+}
+
+func workSessionPreviewText(_ rawPreview: String?) -> String? {
+  guard let rawPreview else { return nil }
+  let trimmed = collapseDuplicatedWorkStreamTextIfNeeded(rawPreview)
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  return trimmed.isEmpty ? nil : trimmed
 }
 
 func extractWorkNavigationTargets(from text: String) -> WorkNavigationTargets {

--- a/apps/ios/ADE/Views/Work/WorkRootComponents.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootComponents.swift
@@ -9,15 +9,23 @@ import AVKit
 struct WorkFiltersSection: View {
   @Binding var searchText: String
   @Binding var selectedLaneId: String
+  @Binding var selectedStatus: WorkSessionStatusFilter
   @Binding var organization: WorkSessionOrganization
   @Binding var filterOpen: Bool
   let lanes: [LaneSummary]
-  let runningCount: Int
+  let liveCount: Int
   let needsInputCount: Int
+  let onClear: () -> Void
 
   private var selectedLaneName: String {
     if selectedLaneId == "all" { return "All lanes" }
     return lanes.first(where: { $0.id == selectedLaneId })?.name ?? "All lanes"
+  }
+
+  private var hasActiveFilters: Bool {
+    selectedStatus != .all
+      || selectedLaneId != "all"
+      || !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
   }
 
   var body: some View {
@@ -27,10 +35,21 @@ struct WorkFiltersSection: View {
           Image(systemName: "magnifyingglass")
             .font(.system(size: 12, weight: .semibold))
             .foregroundStyle(ADEColor.textMuted)
-          TextField("Search", text: $searchText)
+          TextField("Search sessions, lanes, output", text: $searchText)
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled()
             .font(.footnote)
+          if !searchText.isEmpty {
+            Button {
+              searchText = ""
+            } label: {
+              Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(ADEColor.textMuted)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Clear search")
+          }
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
@@ -64,91 +83,148 @@ struct WorkFiltersSection: View {
         .accessibilityLabel("Toggle filter panel")
       }
 
-      if filterOpen {
-        VStack(alignment: .leading, spacing: 10) {
-          HStack(alignment: .center, spacing: 10) {
-            Text("GROUP")
-              .font(.caption2.monospaced().weight(.bold))
-              .foregroundStyle(ADEColor.textMuted)
-              .frame(width: 48, alignment: .leading)
-            HStack(spacing: 4) {
-              ForEach(WorkSessionOrganization.allCases) { option in
-                Button {
-                  withAnimation(.snappy) { organization = option }
-                } label: {
-                  Text(option.title)
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(organization == option ? ADEColor.textPrimary : ADEColor.textSecondary)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 6)
-                    .background(
-                      organization == option ? ADEColor.surfaceBackground.opacity(0.7) : Color.clear,
-                      in: RoundedRectangle(cornerRadius: 7, style: .continuous)
-                    )
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Group by \(option.title)")
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: 6) {
+          ForEach(WorkSessionStatusFilter.allCases) { status in
+            WorkFilterChip(
+              title: status.title,
+              selected: selectedStatus == status,
+              tint: statusFilterTint(status)
+            ) {
+              withAnimation(.snappy(duration: 0.18)) {
+                selectedStatus = status
               }
-            }
-            .padding(3)
-            .background(ADEColor.recessedBackground.opacity(0.45), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
-          }
-
-          HStack(alignment: .center, spacing: 10) {
-            Text("LANE")
-              .font(.caption2.monospaced().weight(.bold))
-              .foregroundStyle(ADEColor.textMuted)
-              .frame(width: 48, alignment: .leading)
-            Menu {
-              Button("All lanes") { selectedLaneId = "all" }
-              ForEach(lanes) { lane in
-                Button(lane.name) { selectedLaneId = lane.id }
-              }
-            } label: {
-              HStack(spacing: 6) {
-                Image(systemName: "arrow.triangle.branch")
-                  .font(.system(size: 10, weight: .semibold))
-                  .foregroundStyle(ADEColor.textMuted)
-                Text(selectedLaneName)
-                  .font(.caption.weight(.medium))
-                  .foregroundStyle(ADEColor.textPrimary)
-                Spacer(minLength: 0)
-                Image(systemName: "chevron.up.chevron.down")
-                  .font(.system(size: 9, weight: .semibold))
-                  .foregroundStyle(ADEColor.textMuted)
-              }
-              .padding(.horizontal, 10)
-              .padding(.vertical, 8)
-              .background(ADEColor.surfaceBackground.opacity(0.55), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
-              .overlay(
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
-                  .stroke(ADEColor.border.opacity(0.22), lineWidth: 0.5)
-              )
-            }
-            .buttonStyle(.plain)
-          }
-
-          if runningCount > 0 || needsInputCount > 0 {
-            HStack(spacing: 6) {
-              if runningCount > 0 {
-                WorkFlatCountChip(icon: "circle.fill", text: "\(runningCount) running", tint: ADEColor.success)
-              }
-              if needsInputCount > 0 {
-                WorkFlatCountChip(icon: "exclamationmark.circle.fill", text: "\(needsInputCount) waiting", tint: ADEColor.warning)
-              }
-              Spacer(minLength: 0)
             }
           }
         }
-        .padding(10)
-        .background(ADEColor.recessedBackground.opacity(0.38), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(
-          RoundedRectangle(cornerRadius: 12, style: .continuous)
-            .stroke(ADEColor.border.opacity(0.15), lineWidth: 0.5)
-        )
+        .padding(.vertical, 1)
+      }
+
+      HStack(spacing: 6) {
+        WorkFlatCountChip(icon: "bolt.fill", text: "\(liveCount) live", tint: ADEColor.success)
+        if needsInputCount > 0 {
+          WorkFlatCountChip(icon: "exclamationmark.circle.fill", text: "\(needsInputCount) waiting", tint: ADEColor.warning)
+        }
+        Spacer(minLength: 0)
+        if hasActiveFilters {
+          Button("Clear") {
+            withAnimation(.snappy(duration: 0.18)) {
+              onClear()
+            }
+          }
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(ADEColor.accent)
+          .buttonStyle(.plain)
+          .accessibilityLabel("Clear Work filters")
+        }
+      }
+
+      if filterOpen {
+        HStack(spacing: 8) {
+          Menu {
+            ForEach(WorkSessionOrganization.allCases) { option in
+              Button(option.title) {
+                organization = option
+              }
+            }
+          } label: {
+            WorkFilterMenuLabel(
+              icon: "rectangle.stack",
+              title: "Group",
+              value: organization.title
+            )
+          }
+          .buttonStyle(.plain)
+
+          Menu {
+            Button("All lanes") { selectedLaneId = "all" }
+            ForEach(lanes) { lane in
+              Button(lane.name) { selectedLaneId = lane.id }
+            }
+          } label: {
+            WorkFilterMenuLabel(
+              icon: "arrow.triangle.branch",
+              title: "Lane",
+              value: selectedLaneName
+            )
+          }
+          .buttonStyle(.plain)
+        }
         .transition(.move(edge: .top).combined(with: .opacity))
       }
     }
+  }
+
+  private func statusFilterTint(_ status: WorkSessionStatusFilter) -> Color {
+    switch status {
+    case .needsInput: return ADEColor.warning
+    case .running: return ADEColor.success
+    case .ended: return ADEColor.textMuted
+    case .archived: return ADEColor.warning
+    case .all: return ADEColor.accent
+    }
+  }
+}
+
+struct WorkFilterChip: View {
+  let title: String
+  let selected: Bool
+  let tint: Color
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      Text(title)
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(selected ? tint : ADEColor.textSecondary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+          selected ? tint.opacity(0.12) : ADEColor.surfaceBackground.opacity(0.48),
+          in: Capsule(style: .continuous)
+        )
+        .overlay(
+          Capsule(style: .continuous)
+            .stroke(selected ? tint.opacity(0.28) : ADEColor.border.opacity(0.18), lineWidth: 0.6)
+        )
+    }
+    .buttonStyle(.plain)
+  }
+}
+
+struct WorkFilterMenuLabel: View {
+  let icon: String
+  let title: String
+  let value: String
+
+  var body: some View {
+    HStack(spacing: 7) {
+      Image(systemName: icon)
+        .font(.system(size: 11, weight: .semibold))
+        .foregroundStyle(ADEColor.textMuted)
+      VStack(alignment: .leading, spacing: 1) {
+        Text(title)
+          .font(.caption2.weight(.semibold))
+          .foregroundStyle(ADEColor.textMuted)
+        Text(value)
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(ADEColor.textPrimary)
+          .lineLimit(1)
+          .truncationMode(.middle)
+      }
+      Spacer(minLength: 0)
+      Image(systemName: "chevron.up.chevron.down")
+        .font(.system(size: 9, weight: .semibold))
+        .foregroundStyle(ADEColor.textMuted)
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 8)
+    .frame(maxWidth: .infinity)
+    .background(ADEColor.surfaceBackground.opacity(0.55), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: 10, style: .continuous)
+        .stroke(ADEColor.border.opacity(0.22), lineWidth: 0.5)
+    )
   }
 }
 
@@ -241,13 +317,17 @@ struct WorkLiveCountPill: View {
     attentionCount > 0 ? ADEColor.warning : ADEColor.success
   }
 
+  var label: String {
+    attentionCount > 0 ? "\(attentionCount) waiting" : "\(liveCount) live"
+  }
+
   var body: some View {
     Button(action: onTap) {
       HStack(spacing: 4) {
         Circle()
           .fill(tint)
           .frame(width: 6, height: 6)
-        Text("\(liveCount)")
+        Text(label)
           .font(.caption2.monospacedDigit().weight(.semibold))
           .foregroundStyle(tint)
       }
@@ -259,7 +339,7 @@ struct WorkLiveCountPill: View {
       )
     }
     .buttonStyle(.plain)
-    .accessibilityLabel("\(liveCount) chat\(liveCount == 1 ? "" : "s") live. Tap to jump.")
+    .accessibilityLabel("\(liveCount) Work session\(liveCount == 1 ? "" : "s") live, \(attentionCount) waiting for input. Tap to jump.")
   }
 }
 
@@ -489,8 +569,7 @@ struct WorkSessionRow: View {
             .lineLimit(1)
         }
 
-        if let preview = chatSummary?.summary ?? chatSummary?.lastOutputPreview ?? session.summary ?? session.lastOutputPreview,
-           !preview.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if let preview = workSessionPreviewText(chatSummary?.summary ?? chatSummary?.lastOutputPreview ?? session.summary ?? session.lastOutputPreview) {
           Text(preview)
             .font(.caption2)
             .foregroundStyle(ADEColor.textMuted)

--- a/apps/ios/ADE/Views/Work/WorkRootScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootScreen.swift
@@ -145,7 +145,39 @@ struct WorkRootScreen: View {
   }
 
   var hasActiveFilters: Bool {
-    selectedStatus != .all || selectedLaneId != "all"
+    selectedStatus != .all
+      || selectedLaneId != "all"
+      || !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+  }
+
+  var globalNeedsInputCount: Int {
+    mergedSessions.filter {
+      !archivedSessionIds.contains($0.id)
+      && normalizedWorkChatSessionStatus(session: $0, summary: chatSummaries[$0.id]) == "awaiting-input"
+    }.count
+  }
+
+  var globalLiveSessionCount: Int {
+    mergedSessions.filter { session in
+      guard !archivedSessionIds.contains(session.id) else { return false }
+      let status = normalizedWorkChatSessionStatus(session: session, summary: chatSummaries[session.id])
+      return status == "active" || status == "idle" || status == "awaiting-input"
+    }.count
+  }
+
+  var firstGlobalAttentionSession: TerminalSessionSummary? {
+    mergedSessions.first {
+      !archivedSessionIds.contains($0.id)
+      && normalizedWorkChatSessionStatus(session: $0, summary: chatSummaries[$0.id]) == "awaiting-input"
+    }
+  }
+
+  var firstGlobalLiveSession: TerminalSessionSummary? {
+    mergedSessions.first { session in
+      guard !archivedSessionIds.contains(session.id) else { return false }
+      let status = normalizedWorkChatSessionStatus(session: session, summary: chatSummaries[session.id])
+      return status == "active" || status == "idle" || status == "awaiting-input"
+    }
   }
 
   var sessionOrganizationBinding: Binding<WorkSessionOrganization> {
@@ -252,11 +284,13 @@ struct WorkRootScreen: View {
           WorkFiltersSection(
             searchText: $searchText,
             selectedLaneId: $selectedLaneId,
+            selectedStatus: $selectedStatus,
             organization: sessionOrganizationBinding,
             filterOpen: $filterPanelOpen,
             lanes: lanes,
-            runningCount: liveSessions.count,
-            needsInputCount: needsInputSessions.count
+            liveCount: globalLiveSessionCount,
+            needsInputCount: globalNeedsInputCount,
+            onClear: clearWorkFilters
           )
           .listRowBackground(Color.clear)
           .listRowSeparator(.hidden)
@@ -337,6 +371,7 @@ struct WorkRootScreen: View {
                     onCopyId: copySessionId,
                     onGoToLane: goToLane
                   )
+                  .id(session.id)
                   .listRowInsets(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0))
                   .listRowBackground(Color.clear)
                   .listRowSeparator(.hidden)
@@ -348,6 +383,7 @@ struct WorkRootScreen: View {
       }
       .listStyle(.plain)
       .scrollContentBackground(.hidden)
+      .contentMargins(.bottom, 72, for: .scrollContent)
       .adeScreenBackground()
       .adeNavigationGlass()
       .navigationTitle("")
@@ -355,14 +391,28 @@ struct WorkRootScreen: View {
       .toolbar(.hidden, for: .navigationBar)
       .safeAreaInset(edge: .top, spacing: 0) {
         ADERootTopBar(title: "Work") {
-          if !liveSessions.isEmpty || needsInputSessions.count > 0 {
+          if globalLiveSessionCount > 0 || globalNeedsInputCount > 0 {
             WorkLiveCountPill(
-              liveCount: max(liveSessions.count, needsInputSessions.count),
-              attentionCount: needsInputSessions.count,
+              liveCount: globalLiveSessionCount,
+              attentionCount: globalNeedsInputCount,
               onTap: {
-                guard let target = needsInputSessions.first ?? liveSessions.first else { return }
-                withAnimation(.snappy) {
-                  proxy.scrollTo(target.id, anchor: .top)
+                guard let target = firstGlobalAttentionSession ?? firstGlobalLiveSession else { return }
+                if displaySessions.contains(where: { $0.id == target.id }) {
+                  withAnimation(.snappy) {
+                    proxy.scrollTo(target.id, anchor: .top)
+                  }
+                } else {
+                  withAnimation(.snappy) {
+                    selectedStatus = .all
+                    selectedLaneId = "all"
+                    searchText = ""
+                  }
+                  Task { @MainActor in
+                    await Task.yield()
+                    withAnimation(.snappy) {
+                      proxy.scrollTo(target.id, anchor: .top)
+                    }
+                  }
                 }
               }
             )
@@ -506,5 +556,11 @@ struct WorkRootScreen: View {
     // Intentionally omit `localStateRevision`: it changes constantly during host DB sync and was
     // restarting this poll loop while the list `.task(id:)` also reloaded sessions every tick.
     return "\(isLive)-\(ids)"
+  }
+
+  func clearWorkFilters() {
+    searchText = ""
+    selectedLaneId = "all"
+    selectedStatus = .all
   }
 }

--- a/apps/ios/ADE/Views/Work/WorkRootScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootScreen.swift
@@ -161,7 +161,7 @@ struct WorkRootScreen: View {
     mergedSessions.filter { session in
       guard !archivedSessionIds.contains(session.id) else { return false }
       let status = normalizedWorkChatSessionStatus(session: session, summary: chatSummaries[session.id])
-      return status == "active" || status == "idle" || status == "awaiting-input"
+      return status == "active" || status == "idle"
     }.count
   }
 

--- a/apps/ios/ADE/Views/Work/WorkRootScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootScreen.swift
@@ -152,13 +152,15 @@ struct WorkRootScreen: View {
 
   var globalNeedsInputCount: Int {
     mergedSessions.filter {
-      !archivedSessionIds.contains($0.id)
+      !isRunOwnedSession($0)
+      && !archivedSessionIds.contains($0.id)
       && normalizedWorkChatSessionStatus(session: $0, summary: chatSummaries[$0.id]) == "awaiting-input"
     }.count
   }
 
   var globalLiveSessionCount: Int {
     mergedSessions.filter { session in
+      guard !isRunOwnedSession(session) else { return false }
       guard !archivedSessionIds.contains(session.id) else { return false }
       let status = normalizedWorkChatSessionStatus(session: session, summary: chatSummaries[session.id])
       return status == "active" || status == "idle"
@@ -167,13 +169,15 @@ struct WorkRootScreen: View {
 
   var firstGlobalAttentionSession: TerminalSessionSummary? {
     mergedSessions.first {
-      !archivedSessionIds.contains($0.id)
+      !isRunOwnedSession($0)
+      && !archivedSessionIds.contains($0.id)
       && normalizedWorkChatSessionStatus(session: $0, summary: chatSummaries[$0.id]) == "awaiting-input"
     }
   }
 
   var firstGlobalLiveSession: TerminalSessionSummary? {
     mergedSessions.first { session in
+      guard !isRunOwnedSession(session) else { return false }
       guard !archivedSessionIds.contains(session.id) else { return false }
       let status = normalizedWorkChatSessionStatus(session: session, summary: chatSummaries[session.id])
       return status == "active" || status == "idle" || status == "awaiting-input"

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -51,10 +51,8 @@ struct WorkSessionDestinationView: View {
     return chatSummary?.title ?? session?.title ?? "Session"
   }
 
-  /// Trailing nav-bar control: a single "…" overflow menu. The lane chip and
-  /// relative-time row that briefly lived here have been removed at the user's
-  /// request — the menu shows the active lane name and a "Go to lane" entry,
-  /// which is the only top-level action we expose from the chat header today.
+  /// Trailing nav-bar control scoped to the session's lane. The visible branch
+  /// icon keeps it distinct from in-transcript overflow menus.
   @ViewBuilder
   var sessionHeaderTrailingControls: some View {
     if let session, showsLaneActions {
@@ -68,14 +66,14 @@ struct WorkSessionDestinationView: View {
           Label("Go to lane", systemImage: "arrow.triangle.branch")
         }
       } label: {
-        Image(systemName: "ellipsis")
+        Image(systemName: "arrow.triangle.branch.circle")
           .font(.system(size: 14, weight: .semibold))
           .foregroundStyle(ADEColor.textSecondary)
           .frame(width: 28, height: 28)
           .contentShape(Rectangle())
       }
       .menuStyle(.borderlessButton)
-      .accessibilityLabel("Lane menu")
+      .accessibilityLabel("Session lane actions")
     } else {
       EmptyView()
     }
@@ -439,6 +437,8 @@ struct WorkSessionDestinationView: View {
 }
 
 private struct WorkSessionNavigationChromeModifier<TrailingControls: View>: ViewModifier {
+  @Environment(\.dismiss) private var dismiss
+
   let mode: WorkSessionNavigationChrome
   let title: String
   let trailingControls: () -> TrailingControls
@@ -450,8 +450,18 @@ private struct WorkSessionNavigationChromeModifier<TrailingControls: View>: View
       content
         .navigationTitle(title)
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .tabBar)
         .toolbar {
+          ToolbarItem(placement: .topBarLeading) {
+            Button {
+              dismiss()
+            } label: {
+              Label("Work", systemImage: "chevron.left")
+                .labelStyle(.titleAndIcon)
+            }
+            .accessibilityLabel("Back to Work")
+          }
           ToolbarItem(placement: .topBarTrailing) {
             trailingControls()
           }

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -2974,6 +2974,48 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(confirmation.confirmTitle, "Discard all")
     XCTAssertEqual(confirmation.actionLabel, "discard all")
     XCTAssertTrue(confirmation.message.contains("2 files"))
+    XCTAssertNil(confirmation.file)
+  }
+
+  func testLaneDiscardAllSingularizesMessageForOneFile() {
+    let single = LaneFileConfirmation.discardAllUnstaged([
+      FileChange(path: "Sources/App.swift", kind: "modified")
+    ])
+    XCTAssertTrue(single.message.contains("1 file "), "expected singular 'file' in: \(single.message)")
+    XCTAssertFalse(single.message.contains("1 files"))
+  }
+
+  func testLaneFileConfirmationSingleFileCasesExposeCorrectCopyAndSource() {
+    let file = FileChange(path: "Sources/App.swift", kind: "modified")
+    let discard = LaneFileConfirmation.discardUnstaged(file)
+    XCTAssertEqual(discard.title, "Discard changes?")
+    XCTAssertEqual(discard.confirmTitle, "Discard")
+    XCTAssertEqual(discard.actionLabel, "discard file")
+    XCTAssertEqual(discard.file?.path, file.path)
+    XCTAssertTrue(discard.id.hasPrefix("discard:"))
+
+    let restore = LaneFileConfirmation.restoreStaged(file)
+    XCTAssertEqual(restore.title, "Restore staged file?")
+    XCTAssertEqual(restore.confirmTitle, "Restore")
+    XCTAssertEqual(restore.actionLabel, "restore staged file")
+    XCTAssertEqual(restore.file?.path, file.path)
+    XCTAssertTrue(restore.id.hasPrefix("restore:"))
+  }
+
+  func testLaneGitConfirmationCoversRebaseLaneAndDescendantsCopy() {
+    let lane = LaneGitConfirmation.rebaseLane
+    XCTAssertEqual(lane.title, "Rebase this lane?")
+    XCTAssertEqual(lane.confirmTitle, "Rebase lane")
+    XCTAssertEqual(lane.actionLabel, "rebase lane")
+    XCTAssertEqual(lane.id, "rebase-lane")
+    XCTAssertTrue(lane.message.contains("parent"))
+
+    let descendants = LaneGitConfirmation.rebaseDescendants
+    XCTAssertEqual(descendants.title, "Rebase lane and descendants?")
+    XCTAssertEqual(descendants.confirmTitle, "Rebase all")
+    XCTAssertEqual(descendants.actionLabel, "rebase descendants")
+    XCTAssertEqual(descendants.id, "rebase-descendants")
+    XCTAssertTrue(descendants.message.contains("child lanes"))
   }
 
   func testLaneAllowsDiffInspectionKeepsCachedTargetsReadableWhileOfflineOrSyncing() {
@@ -5100,6 +5142,62 @@ final class ADETests: XCTestCase {
     // Lengths match, so only the fingerprint's tail-window distinguishes them.
     XCTAssertEqual(bufferA.count, bufferB.count)
     XCTAssertNotEqual(workActivityBufferFingerprint(bufferA), workActivityBufferFingerprint(bufferB))
+  }
+
+  func testFilesDiffHasChangesDetectsTextAndExistenceEdits() {
+    let empty = DiffSide(exists: false, text: "")
+    let same = FileDiff(
+      path: "App.swift",
+      mode: "modified",
+      original: DiffSide(exists: true, text: "let a = 1\n"),
+      modified: DiffSide(exists: true, text: "let a = 1\n"),
+      isBinary: false,
+      language: "swift"
+    )
+    XCTAssertFalse(filesDiffHasChanges(same))
+
+    let textChanged = FileDiff(
+      path: "App.swift",
+      mode: "modified",
+      original: DiffSide(exists: true, text: "let a = 1\n"),
+      modified: DiffSide(exists: true, text: "let a = 2\n"),
+      isBinary: false,
+      language: "swift"
+    )
+    XCTAssertTrue(filesDiffHasChanges(textChanged))
+
+    let created = FileDiff(
+      path: "New.swift",
+      mode: "added",
+      original: empty,
+      modified: DiffSide(exists: true, text: "// new\n"),
+      isBinary: false,
+      language: "swift"
+    )
+    XCTAssertTrue(filesDiffHasChanges(created))
+
+    let deleted = FileDiff(
+      path: "Gone.swift",
+      mode: "deleted",
+      original: DiffSide(exists: true, text: "let gone = true\n"),
+      modified: empty,
+      isBinary: false,
+      language: "swift"
+    )
+    XCTAssertTrue(filesDiffHasChanges(deleted))
+  }
+
+  func testWorkDisplayLeavesCleanRepeatedLettersAloneEvenWithManyDoubles() {
+    // Real text with many legitimate double letters must NOT get collapsed.
+    let natural = "Committee will assess the bookkeeping across all accounts, noting success, progress, commitment."
+    XCTAssertEqual(sanitizeTerminalOutputForDisplay(natural), natural)
+    XCTAssertEqual(workSessionPreviewText(natural), natural)
+  }
+
+  func testWorkSessionPreviewTextTrimsAndReturnsNilForEmptyInput() {
+    XCTAssertNil(workSessionPreviewText(nil))
+    XCTAssertNil(workSessionPreviewText("   \n\t  "))
+    XCTAssertEqual(workSessionPreviewText("  hello world  "), "hello world")
   }
 
   func testWorkDisplayCollapsesDuplicatedStreamingCharacters() {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -5224,6 +5224,17 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(workSessionPreviewText("Still visible"), "Still visible")
   }
 
+  func testWorkDisplayPreservesEllipsisWhenCollapsingStreamingDuplicates() {
+    XCTAssertEqual(
+      sanitizeTerminalOutputForDisplay("WWoorrkkiinngg..."),
+      "Working..."
+    )
+    XCTAssertEqual(
+      workSessionPreviewText("WWoorrkkiinngg..."),
+      "Working..."
+    )
+  }
+
   func testBuildWorkActivityFeedReusesCachedTerminalTranscript() {
     let session = makeTerminalSessionSummary(toolType: "codex-chat", title: "Main chat")
     let raw = """

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -2783,6 +2783,42 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(filterPullRequestListItems(items, query: "", state: .open).map(\.id), ["pr-1"])
   }
 
+  func testPrLinkLanePreselectionRequiresExactBranchMatch() {
+    func lane(id: String, name: String, branchRef: String) -> LaneSummary {
+      LaneSummary(
+        id: id,
+        name: name,
+        description: nil,
+        laneType: "feature",
+        baseRef: "main",
+        branchRef: branchRef,
+        worktreePath: "/tmp/\(id)",
+        attachedRootPath: nil,
+        parentLaneId: nil,
+        childCount: 0,
+        stackDepth: 0,
+        parentStatus: nil,
+        isEditProtected: false,
+        status: LaneStatus(dirty: false, ahead: 0, behind: 0, remoteBehind: 0, rebaseInProgress: false),
+        color: nil,
+        icon: nil,
+        tags: [],
+        folder: nil,
+        createdAt: "2026-03-20T00:00:00.000Z",
+        archivedAt: nil
+      )
+    }
+
+    let lanes = [
+      lane(id: "lane-name-collision", name: "cursor/windows-port-foundations-ede6", branchRef: "automations-overhaul"),
+      lane(id: "lane-branch-match", name: "Windows port", branchRef: "cursor/windows-port-foundations-ede6"),
+    ]
+
+    XCTAssertEqual(matchedLaneForExactBranch("cursor/windows-port-foundations-ede6", lanes: lanes)?.id, "lane-branch-match")
+    XCTAssertNil(matchedLaneForExactBranch("automations overhaul", lanes: lanes))
+    XCTAssertNil(matchedLaneForExactBranch("   ", lanes: lanes))
+  }
+
   func testLaneListFilteringMatchesSearchPrefixesAndSortOrder() {
     let snapshots = [
       makeLaneListSnapshot(
@@ -2926,6 +2962,18 @@ final class ADETests: XCTestCase {
         laneStatus: SyncDomainStatus(phase: .hydrating, lastError: nil, lastHydratedAt: nil)
       )
     )
+  }
+
+  func testLaneDiscardAllUsesExplicitDestructiveConfirmationCopy() {
+    let confirmation = LaneFileConfirmation.discardAllUnstaged([
+      FileChange(path: "Sources/App.swift", kind: "modified"),
+      FileChange(path: "Tests/AppTests.swift", kind: "modified"),
+    ])
+
+    XCTAssertEqual(confirmation.title, "Discard all unstaged changes?")
+    XCTAssertEqual(confirmation.confirmTitle, "Discard all")
+    XCTAssertEqual(confirmation.actionLabel, "discard all")
+    XCTAssertTrue(confirmation.message.contains("2 files"))
   }
 
   func testLaneAllowsDiffInspectionKeepsCachedTargetsReadableWhileOfflineOrSyncing() {
@@ -5052,6 +5100,30 @@ final class ADETests: XCTestCase {
     // Lengths match, so only the fingerprint's tail-window distinguishes them.
     XCTAssertEqual(bufferA.count, bufferB.count)
     XCTAssertNotEqual(workActivityBufferFingerprint(bufferA), workActivityBufferFingerprint(bufferB))
+  }
+
+  func testWorkDisplayCollapsesDuplicatedStreamingCharacters() {
+    XCTAssertEqual(
+      workSessionPreviewText("WWoorrkkiinngg oonn ppaassss tthhrroouugghh"),
+      "Working on pass through"
+    )
+    XCTAssertEqual(
+      sanitizeTerminalOutputForDisplay("WWoorrkkiinngg\n\u{001B}[31mDDoonnee\u{001B}[0m"),
+      "Working\nDone"
+    )
+    XCTAssertEqual(
+      sanitizeTerminalOutputForDisplay("Everything is green. WWoorrkkiinngg 200 WWoorrkkiinngg."),
+      "Everything is green. Working 200 Working."
+    )
+    XCTAssertEqual(
+      sanitizeTerminalOutputForDisplay("Success: queued job still running with a class FooController"),
+      "Success: queued job still running with a class FooController"
+    )
+    XCTAssertEqual(
+      sanitizeTerminalOutputForDisplay("TThhee bbuuiilldd ppaasssseedd,, rruunnnniinngg ffiinnaall cchheecckkss"),
+      "The build passed, running final checks"
+    )
+    XCTAssertEqual(workSessionPreviewText("Still visible"), "Still visible")
   }
 
   func testBuildWorkActivityFeedReusesCachedTerminalTranscript() {


### PR DESCRIPTION
Comprehensive mobile UI pass across the iOS companion app.

## Summary
- Files: diff/conflict-aware detail screen, code layout modes, simplified root components.
- Lanes: consolidated confirmation model (discard/restore/rebase/descendants), actions card, commit history & sync detail polish, list view parts.
- PRs: row card, filters, create-PR wizard, and root screen refinements.
- Work: chat header/message views, artifact terminal, session destination, error/message helpers, navigation/transcript helpers, root screen.
- Services: Database fallbacks touched.
- Tests: +6 XCTest cases covering new confirmation copy, filesDiffHasChanges, workSessionPreviewText, and the duplicate-letter sanitizer regression guard.

## Test plan
- [x] Local: ADETests target 205/205 pass on iPhone 17 simulator.
- [x] Local: build succeeds for ADE scheme on iPhone 17 simulator.
- [ ] CI: GitHub Actions on push.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Comprehensive mobile polish pass across all four major tabs (Files, Lanes, PRs, Work). The main structural change is that destructive git and file operations throughout Lanes are now gated behind confirmation dialogs (`LaneFileConfirmation`, `LaneGitConfirmation`, `LaneSyncAction`), and the PR tab adds a mandatory review sheet before linking unmapped GitHub PRs to lanes. Previous review concerns around `globalLiveSessionCount` overcounting, `"..."` collapse in streaming deduplication, and the generic section header in `PrsRootScreen` have all been addressed in this pass.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all P1 concerns from previous rounds are resolved; remaining findings are P2 UX suggestions.

Three prior P1/P2 findings (globalLiveSessionCount overcounting, ellipsis collapse, generic section header) are all fixed. New findings are P2: the discardAllUnstaged sequential loop leaves a confusing partial-discard state on error (but the UI refreshes after), and the pullMerge destructive label is asymmetric with push. Neither blocks correct function.

LaneDetailScreen.swift (discardAllUnstaged partial-failure path) and LaneSyncDetailScreen.swift (isDestructive asymmetry) are worth a second read before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Views/Lanes/LaneDetailScreen.swift | Replaces inline confirmDiscardFile alert with unified LaneFileConfirmation; adds rebaseLane/rebaseDescendants paths; discardAllUnstaged sequential loop can leave partial state on error (P2). |
| apps/ios/ADE/Views/Lanes/LaneSyncDetailScreen.swift | Moves sync buttons behind confirmation alerts; pullMerge and pullRebase both show as destructive (red button) while push does not — asymmetric UX (P2). |
| apps/ios/ADE/Views/Lanes/LaneTypes.swift | Adds LaneFileConfirmation and two new LaneGitConfirmation cases (rebaseLane, rebaseDescendants) with complete copy and stable IDs; well-structured and test-covered. |
| apps/ios/ADE/Views/PRs/PrsRootScreen.swift | Adds PrGitHubReadDetailSheet gate before lane-link for unmapped PRs; repoSectionTitle closure preserves owner/repo label. |
| apps/ios/ADE/Views/Work/WorkRootScreen.swift | globalLiveSessionCount now excludes awaiting-input; live-pill tap clears filters then scrolls; contentMargins bottom padding added for tab bar. |
| apps/ios/ADE/Views/Work/WorkNavigationAndTranscriptHelpers.swift | collapseDuplicatedStreamPunctuation now preserves legitimate '...' (runLength >= 4 threshold for dots); workSessionPreviewText wraps deduplication+trim pipeline. |
| apps/ios/ADETests/ADETests.swift | +6 test cases covering LaneFileConfirmation copy, LaneGitConfirmation rebase cases, filesDiffHasChanges, workSessionPreviewText, and streaming-duplicate collapse with ellipsis guard. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User taps destructive action] --> B{Action type}
    B -->|Discard file / Discard all / Restore staged| C[LaneFileConfirmation alert]
    B -->|Rebase lane / Rebase descendants / Force push / Rebase & push| D[LaneGitConfirmation alert]
    B -->|Fetch / Pull merge / Pull rebase / Push| E[LaneSyncAction alert]
    B -->|Revert commit / Cherry-pick| F[CommitHistoryConfirmation alert]
    B -->|Unmapped GitHub PR tap| G[PrGitHubReadDetailSheet]
    C -->|Confirm| H[performConfirmedFileAction]
    D -->|Confirm| I[performConfirmedGitAction]
    E -->|Confirm| J[LaneSyncDetailScreen perform]
    F -->|Confirm| K[LaneCommitHistoryScreen perform]
    G -->|Link PR| L[PrLaneLinkSheet]
    H --> M[syncService call + refresh]
    I --> M
    J --> M
    K --> M
    L --> N[Lane linked to PR]
    C -->|Cancel| O[No-op]
    D -->|Cancel| O
    E -->|Cancel| O
    F -->|Cancel| O
    G -->|Done| O
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fios%2FADE%2FViews%2FLanes%2FLaneDetailScreen.swift%3A368-376%0A**%60discardAllUnstaged%60%20stops%20on%20first%20error%2C%20leaving%20partial%20discard**%0A%0AThe%20loop%20inside%20%60performConfirmedFileAction%60%20calls%20%60discardFile%60%20sequentially%20with%20%60try%20await%60%2C%20so%20if%20one%20file%20fails%20%28e.g.%20permissions%20error%2C%20file%20already%20clean%29%2C%20the%20throw%20exits%20the%20closure%20and%20subsequent%20files%20are%20skipped.%20After%20the%20error%20the%20lane%20state%20is%20refreshed%20and%20the%20UI%20will%20reflect%20what%20actually%20happened%2C%20but%20the%20user%20sees%20a%20generic%20error%20with%20no%20indication%20of%20which%20files%20were%20already%20discarded%20and%20which%20still%20need%20to%20be%20cleaned%20up.%0A%0AConsider%20either%20%28a%29%20collecting%20errors%20and%20continuing%20the%20loop%2C%20or%20%28b%29%20propagating%20the%20partial%20result%20with%20a%20summary%20message.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fios%2FADE%2FViews%2FLanes%2FLaneSyncDetailScreen.swift%3A171-178%0A**%60pullMerge%60%20marked%20destructive%20while%20%60push%60%20is%20not**%0A%0A%60isDestructive%60%20returns%20%60true%60%20for%20both%20%60.pullMerge%60%20and%20%60.pullRebase%60%2C%20showing%20a%20red%20%22Pull%20merge%22%20confirmation%20button.%20However%2C%20%60.push%60%20%28which%20updates%20the%20remote%20branch%20and%20is%20harder%20to%20undo%29%20is%20%60false%60.%20Pull-with-merge%20is%20typically%20a%20safe%20fast-forward%20operation%2C%20while%20a%20push%20is%20at%20least%20as%20impactful%20remotely.%20The%20asymmetry%20may%20confuse%20users%20who%20expect%20the%20red%20button%20to%20signal%20the%20riskier%20action.%0A%0A&repo=arul28%2Fade&pr=187&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/ios/ADE/Views/Lanes/LaneDetailScreen.swift
Line: 368-376

Comment:
**`discardAllUnstaged` stops on first error, leaving partial discard**

The loop inside `performConfirmedFileAction` calls `discardFile` sequentially with `try await`, so if one file fails (e.g. permissions error, file already clean), the throw exits the closure and subsequent files are skipped. After the error the lane state is refreshed and the UI will reflect what actually happened, but the user sees a generic error with no indication of which files were already discarded and which still need to be cleaned up.

Consider either (a) collecting errors and continuing the loop, or (b) propagating the partial result with a summary message.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/ios/ADE/Views/Lanes/LaneSyncDetailScreen.swift
Line: 171-178

Comment:
**`pullMerge` marked destructive while `push` is not**

`isDestructive` returns `true` for both `.pullMerge` and `.pullRebase`, showing a red "Pull merge" confirmation button. However, `.push` (which updates the remote branch and is harder to undo) is `false`. Pull-with-merge is typically a safe fast-forward operation, while a push is at least as impactful remotely. The asymmetry may confuse users who expect the red button to signal the riskier action.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["ship: iteration 3 — address #3134328954,..."](https://github.com/arul28/ade/commit/8d676ae9ec46acc5f2e6a1ea744dcf2be59d8ada) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29529562)</sub>

<!-- /greptile_comment -->