### PR TITLE
fix(release): pass --repo to gh in publish-release job

### DIFF
--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -197,6 +197,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ inputs.release_tag }}
           TARGET_REF: ${{ inputs.target_ref }}
+          GH_REPO: ${{ github.repository }}
         run: |
           shopt -s nullglob
           files=(
@@ -214,10 +215,11 @@ jobs:
             exit 1
           fi
 
-          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
-            gh release upload "$TAG_NAME" "${files[@]}" --clobber
+          if gh release view "$TAG_NAME" --repo "$GH_REPO" >/dev/null 2>&1; then
+            gh release upload "$TAG_NAME" "${files[@]}" --repo "$GH_REPO" --clobber
           else
             gh release create "$TAG_NAME" "${files[@]}" \
+              --repo "$GH_REPO" \
               --draft \
               --title "$TAG_NAME" \
               --generate-notes \


### PR DESCRIPTION
## Summary

The `publish-release` job in `release-core.yml` has no `actions/checkout` step. `gh release view` / `gh release upload` / `gh release create` need either a checked-out git repo or `--repo` to know which repository to target. On v1.1.4 (run [24914966889](https://github.com/arul28/ADE/actions/runs/24914966889)) this surfaced as:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
```

Mac + Windows artifacts uploaded fine; the publish step itself broke right at `gh release view`.

## Change

Pass `--repo "$GH_REPO"` (set from `github.repository`) to all three `gh release` calls. No checkout step added — the publish job only needs the downloaded artifacts plus `gh`, so a checkout would be wasted I/O.

## Test plan
- [ ] Cut next release, confirm `publish-release` succeeds and the draft is created/updated with all 7 expected assets.

## Related
- Manual recovery for v1.1.4 already done out-of-band: assets downloaded from the failed run and uploaded to a draft release at https://github.com/arul28/ADE/releases/tag/untagged-621f8968d48d144e34f4 (tagName v1.1.4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to ensure releases are reliably created in the correct repository through explicit repository identification in all release operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `publish-release` job in `release-core.yml` by passing `--repo "$GH_REPO"` to all three `gh release` calls (`view`, `upload`, `create`). The job has no `actions/checkout` step, so `gh` had no `.git` context to infer the target repo, causing the v1.1.4 release run to fail with `fatal: not a git repository`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted fix that correctly resolves the missing repo context for all three `gh` CLI calls.

All three `gh release` calls now receive `--repo "$GH_REPO"`, which is set from `github.repository`. The fix directly addresses the confirmed failure mode and no regressions are introduced; the rest of the job logic is unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-core.yml | Adds `GH_REPO` env var and `--repo "$GH_REPO"` to all three `gh release` calls in the checkout-less `publish-release` job; fix is complete and correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant MAC as build-mac-release
    participant WIN as build-win-release
    participant PUB as publish-release (ubuntu)
    participant GHAPI as GitHub Releases API

    GH->>MAC: trigger (needs: verify)
    GH->>WIN: trigger (needs: verify)
    MAC-->>GH: upload artifact: ade-mac-release-{tag}
    WIN-->>GH: upload artifact: ade-win-release-{tag}

    GH->>PUB: trigger (needs: mac + win, if publish=true)
    PUB->>PUB: download-artifact (mac + win)
    PUB->>GHAPI: gh release view TAG --repo OWNER/REPO
    alt release exists
        GHAPI-->>PUB: 200 OK
        PUB->>GHAPI: gh release upload TAG files --repo OWNER/REPO --clobber
    else release not found
        GHAPI-->>PUB: 404 / error
        PUB->>GHAPI: gh release create TAG files --repo OWNER/REPO --draft --generate-notes --target REF
    end
    GHAPI-->>PUB: success
```

<sub>Reviews (1): Last reviewed commit: ["fix(release): pass --repo to gh in publi..."](https://github.com/arul28/ade/commit/f2158d13020c1d4890af01916925c9d2f3e089c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29679510)</sub>

<!-- /greptile_comment -->