### PR TITLE
fix(desktop): pty resume backfill + persist per-project route

### DIFF
--- a/apps/desktop/src/main/services/pty/ptyService.test.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.test.ts
@@ -731,6 +731,50 @@ describe("ptyService", () => {
       expect(sessionService.create).toHaveBeenCalledTimes(createCallsBeforeResume);
     });
 
+    it("backfills a targetless Claude resume command before launching the resumed PTY", async () => {
+      (mocks.extractResumeCommandFromOutput as any).mockReturnValueOnce("claude --resume claude-session-123");
+      const { service, sessionService, mockPty } = createHarness();
+      sessionService.create({
+        sessionId: "session-claude-picker",
+        laneId: "lane-1",
+        ptyId: null,
+        tracked: true,
+        title: "Claude CLI",
+        startedAt: "2026-04-09T12:00:00.000Z",
+        transcriptPath: "/tmp/transcripts/session-claude-picker.log",
+        toolType: "claude",
+        resumeCommand: "claude --permission-mode default --resume",
+        resumeMetadata: {
+          provider: "claude",
+          targetKind: "session",
+          targetId: null,
+          launch: { permissionMode: "default" },
+        },
+      });
+      sessionService.end({
+        sessionId: "session-claude-picker",
+        endedAt: "2026-04-09T12:30:00.000Z",
+        exitCode: 0,
+        status: "completed",
+      });
+
+      await service.create({
+        sessionId: "session-claude-picker",
+        laneId: "lane-1",
+        title: "Claude CLI",
+        cols: 80,
+        rows: 24,
+        toolType: "claude",
+        startupCommand: "claude --permission-mode default --resume",
+      });
+
+      expect(sessionService.setResumeCommand).toHaveBeenCalledWith(
+        "session-claude-picker",
+        "claude --resume claude-session-123",
+      );
+      expect(mockPty.write).toHaveBeenCalledWith("claude --resume claude-session-123\r");
+    });
+
     it("preserves the strict resume path when a requested session id does not exist", async () => {
       const { service } = createHarness();
 

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -766,7 +766,7 @@ export function createPtyService({
   const tryBackfillResumeTarget = async (
     sessionId: string,
     preferredToolType: TerminalToolType | null,
-    reason: "close" | "dispose" | "orphan-dispose" | "session-list",
+    reason: "close" | "dispose" | "orphan-dispose" | "session-list" | "resume-launch",
     sessionCwd?: string | null,
   ): Promise<boolean> => {
     const session = sessionService.get(sessionId);
@@ -1104,15 +1104,15 @@ export function createPtyService({
       const tracked = existingSession?.tracked ?? (args.tracked !== false);
       const toolTypeHint = normalizeToolType(args.toolType ?? existingSession?.toolType ?? null);
       const requestedStartupCommand = typeof args.startupCommand === "string" ? args.startupCommand.trim() : "";
-      const initialResumeCommand = existingSession?.resumeCommand ?? defaultResumeCommandForTool(toolTypeHint);
-      const initialResumeMetadata = existingSession?.resumeMetadata ?? buildInitialResumeMetadata({
+      let initialResumeCommand = existingSession?.resumeCommand ?? defaultResumeCommandForTool(toolTypeHint);
+      let initialResumeMetadata = existingSession?.resumeMetadata ?? buildInitialResumeMetadata({
         toolType: toolTypeHint,
         startupCommand: requestedStartupCommand,
       });
       const transcriptPath = tracked
         ? (existingSession?.transcriptPath?.trim() || safeTranscriptPathFor(sessionId))
         : "";
-      const startupCommand = requestedStartupCommand.trim();
+      let startupCommand = requestedStartupCommand.trim();
       const cleanupPaths: string[] = [];
 
       let transcriptStream: fs.WriteStream | null = null;
@@ -1157,6 +1157,20 @@ export function createPtyService({
         ...(args.env ?? {})
       };
       const launchEnv = getAdeCliAgentEnv?.(baseLaunchEnv) ?? baseLaunchEnv;
+      const shouldBackfillResumeTarget =
+        existingSession
+        && isTrackedCliToolType(toolTypeHint)
+        && !existingSession.resumeMetadata?.targetId?.trim();
+      if (shouldBackfillResumeTarget) {
+        const backfilled = await tryBackfillResumeTarget(sessionId, toolTypeHint, "resume-launch", cwd);
+        const updatedSession = backfilled ? sessionService.get(sessionId) : null;
+        if (updatedSession?.resumeCommand?.trim()) {
+          initialResumeCommand = updatedSession.resumeCommand.trim();
+          initialResumeMetadata = updatedSession.resumeMetadata ?? initialResumeMetadata;
+          startupCommand = initialResumeCommand;
+        }
+      }
+
       const shellCandidates = resolveShellCandidates();
       let pty: IPty;
       let selectedShell: ShellSpec | null = null;
@@ -1260,19 +1274,6 @@ export function createPtyService({
             if (sha) sessionService.setHeadShaStart(sessionId, sha);
           })
           .catch(() => {});
-      }
-
-      if (
-        existingSession
-        && isTrackedCliToolType(toolTypeHint)
-        && !existingSession.resumeMetadata?.targetId?.trim()
-      ) {
-        logger.warn("pty.resume_target_missing", {
-          sessionId,
-          ptyId,
-          toolType: toolTypeHint,
-          reason: "resume-launch",
-        });
       }
 
       const entry: PtyEntry = {

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -63,6 +63,52 @@ function primaryTabPath(pathname: string): string {
   return roots.find((root) => pathname === root || pathname.startsWith(`${root}/`)) ?? pathname;
 }
 
+const PROJECT_ROUTE_STORAGE_PREFIX = "ade:project-route:";
+
+function projectRouteStorageKey(projectRoot: string): string {
+  return `${PROJECT_ROUTE_STORAGE_PREFIX}${projectRoot}`;
+}
+
+function serializeLocationRoute(location: ReturnType<typeof useLocation>): string | null {
+  const pathname = location.pathname || "/work";
+  const route = `${pathname}${location.search ?? ""}${location.hash ?? ""}`;
+  const allowedRoots = [
+    "/project",
+    "/lanes",
+    "/files",
+    "/work",
+    "/graph",
+    "/prs",
+    "/review",
+    "/history",
+    "/automations",
+    "/missions",
+    "/cto",
+    "/settings",
+  ];
+  if (!allowedRoots.some((root) => pathname === root || pathname.startsWith(`${root}/`))) {
+    return null;
+  }
+  return route;
+}
+
+function readStoredProjectRoute(projectRoot: string): string | null {
+  try {
+    const value = window.localStorage.getItem(projectRouteStorageKey(projectRoot));
+    return value?.startsWith("/") ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredProjectRoute(projectRoot: string, route: string): void {
+  try {
+    window.localStorage.setItem(projectRouteStorageKey(projectRoot), route);
+  } catch {
+    // localStorage can be unavailable in private/test environments.
+  }
+}
+
 type AiBannerState = {
   laneId: string | null;
   jobId: string | null;
@@ -206,6 +252,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const [projectMissing, setProjectMissing] = useState(false);
   const [feedbackGenerating, setFeedbackGenerating] = useState(false);
   const previousProjectRootRef = useRef<string | null | undefined>(undefined);
+  const lastRouteSaveProjectRootRef = useRef<string | null | undefined>(undefined);
   const isOnboardingRoute = location.pathname === "/onboarding";
   const isLanesRoute = location.pathname.startsWith("/lanes");
   const shouldTrackTerminalAttention =
@@ -582,10 +629,26 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
     if (previousProjectRoot === undefined) return;
     if (!nextProjectRoot || showWelcome) return;
-    if (location.pathname !== "/project") return;
     if (previousProjectRoot === nextProjectRoot) return;
-    navigate("/work", { replace: true });
-  }, [location.pathname, navigate, project?.rootPath, showWelcome]);
+    if (previousProjectRoot) {
+      const previousRoute = serializeLocationRoute(location);
+      if (previousRoute) writeStoredProjectRoute(previousProjectRoot, previousRoute);
+    }
+    navigate(readStoredProjectRoute(nextProjectRoot) ?? "/work", { replace: true });
+  }, [location, navigate, project?.rootPath, showWelcome]);
+
+  useEffect(() => {
+    const projectRoot = project?.rootPath ?? null;
+    if (!projectRoot || showWelcome) return;
+
+    if (lastRouteSaveProjectRootRef.current !== projectRoot) {
+      lastRouteSaveProjectRootRef.current = projectRoot;
+      return;
+    }
+
+    const route = serializeLocationRoute(location);
+    if (route) writeStoredProjectRoute(projectRoot, route);
+  }, [location, project?.rootPath, showWelcome]);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
Bug fix bundled into v1.1.5 release.

- pty: backfill resume target on launch (was warn-only)
- AppShell: persist last-visited route per project to localStorage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-project route persistence: The app now remembers your last visited location within each project and restores it when you switch between projects.

* **Bug Fixes**
  * Improved Claude session resumption with automatic target recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent bugs: (1) the PTY service now actively backfills the resume target (session ID) before spawning the PTY instead of only logging a warning, and (2) `AppShell` persists the last-visited route per project to `localStorage` and restores it on project switch.

<h3>Confidence Score: 4/5</h3>

Safe to merge; only P2 findings present.

Both fixes are well-scoped and backed by tests. The two P2 findings (allowedRoots inconsistency and potential flag-dropping on backfill) don't cause regressions but are worth addressing in a follow-up.

apps/desktop/src/renderer/components/app/AppShell.tsx – verify /review and /cto route handling; apps/desktop/src/main/services/pty/ptyService.ts – confirm --permission-mode is not needed in the backfilled command.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/pty/ptyService.ts | Promotes resume-target backfill from warn-only to an active async call before PTY spawn; adds "resume-launch" reason variant. One P2: backfilled command silently drops original launch flags (e.g. --permission-mode). |
| apps/desktop/src/main/services/pty/ptyService.test.ts | Adds a targeted test for the new backfill-on-resume-launch path; covers happy-path assertion of both setResumeCommand and pty.write. Good coverage of the core change. |
| apps/desktop/src/renderer/components/app/AppShell.tsx | Adds per-project route persistence via localStorage; logic is sound, but allowedRoots in serializeLocationRoute includes /review and /cto which are absent from primaryTabPath, creating a minor inconsistency. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant PtyService
    participant SessionService
    participant tryBackfillResumeTarget

    Caller->>PtyService: create({ sessionId, startupCommand: "claude --resume" })
    PtyService->>SessionService: get(sessionId) → existingSession
    alt existingSession && no targetId
        PtyService->>tryBackfillResumeTarget: await tryBackfillResumeTarget("resume-launch")
        tryBackfillResumeTarget->>SessionService: readTranscriptTail()
        tryBackfillResumeTarget->>SessionService: setResumeCommand(sessionId, "claude --resume <id>")
        tryBackfillResumeTarget-->>PtyService: true
        PtyService->>SessionService: get(sessionId) → updatedSession
        PtyService->>PtyService: startupCommand = "claude --resume <id>"
    end
    PtyService->>PtyService: spawn shell PTY
    PtyService->>PtyService: pty.write("claude --resume <id>\r")
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fapp%2FAppShell.tsx%3A75-92%0A**%60allowedRoots%60%20diverges%20from%20%60primaryTabPath%60%20roots**%0A%0A%60serializeLocationRoute%60%20adds%20%60%2Freview%60%20and%20%60%2Fcto%60%20to%20its%20allow-list%2C%20but%20%60primaryTabPath%60%20%28defined%20just%20above%29%20does%20not%20include%20them.%20Routes%20under%20those%20paths%20will%20therefore%20be%20persisted%20and%20later%20restored%2C%20but%20the%20sidebar%20tab%20won't%20be%20activated%20%28since%20%60primaryTabPath%60%20won't%20match%20them%29.%20If%20%60%2Freview%60%20and%20%60%2Fcto%60%20are%20real%20top-level%20pages%20that%20should%20be%20restored%2C%20they%20should%20also%20be%20added%20to%20%60primaryTabPath%60%3B%20otherwise%20they%20should%20be%20dropped%20from%20%60allowedRoots%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fpty%2FptyService.ts%3A1160-1172%0A**Backfilled%20command%20drops%20original%20launch%20flags**%0A%0AWhen%20%60tryBackfillResumeTarget%60%20succeeds%2C%20%60startupCommand%60%20is%20overwritten%20with%20the%20backfilled%20command%20%28e.g.%20%60claude%20--resume%20%3Cid%3E%60%29.%20However%2C%20the%20original%20%60requestedStartupCommand%60%20may%20contain%20flags%20such%20as%20%60--permission-mode%20default%60%20that%20are%20not%20preserved%20in%20the%20backfilled%20command.%20The%20PTY%20therefore%20launches%20without%20those%20flags.%0A%0AThis%20may%20be%20intentional%20if%20permission%20mode%20is%20meant%20to%20come%20from%20session%20metadata%20at%20the%20tool%20level%2C%20but%20the%20test's%20expected%20invocation%20%28%60%22claude%20--resume%20claude-session-123%5Cr%22%60%29%20silently%20drops%20%60--permission-mode%20default%60%20that%20was%20in%20the%20startup%20command.%20Worth%20verifying%20the%20tool%20CLI%20picks%20up%20the%20correct%20permission%20mode%20without%20the%20explicit%20flag%20on%20resume.%0A%0A&repo=arul28%2Fade&pr=199&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/desktop/src/renderer/components/app/AppShell.tsx
Line: 75-92

Comment:
**`allowedRoots` diverges from `primaryTabPath` roots**

`serializeLocationRoute` adds `/review` and `/cto` to its allow-list, but `primaryTabPath` (defined just above) does not include them. Routes under those paths will therefore be persisted and later restored, but the sidebar tab won't be activated (since `primaryTabPath` won't match them). If `/review` and `/cto` are real top-level pages that should be restored, they should also be added to `primaryTabPath`; otherwise they should be dropped from `allowedRoots`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/desktop/src/main/services/pty/ptyService.ts
Line: 1160-1172

Comment:
**Backfilled command drops original launch flags**

When `tryBackfillResumeTarget` succeeds, `startupCommand` is overwritten with the backfilled command (e.g. `claude --resume <id>`). However, the original `requestedStartupCommand` may contain flags such as `--permission-mode default` that are not preserved in the backfilled command. The PTY therefore launches without those flags.

This may be intentional if permission mode is meant to come from session metadata at the tool level, but the test's expected invocation (`"claude --resume claude-session-123\r"`) silently drops `--permission-mode default` that was in the startup command. Worth verifying the tool CLI picks up the correct permission mode without the explicit flag on resume.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): backfill pty resume target..."](https://github.com/arul28/ade/commit/d15bdb721cfbd88f7e8e2492d474ad928983946e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29723365)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->