### PR TITLE
release: amend v1.1.5 changelog with pty + route fix

### DIFF
--- a/changelog/v1.1.5.mdx
+++ b/changelog/v1.1.5.mdx
@@ -21,6 +21,8 @@ v1.1.5 builds the two-way pty bridge so an iOS device can drive a desktop shell,
 - **PTY title fallback.** Hardened to a deterministic CLI placeholder so a brand-new shell never renders an empty title.
 - **`ExitPlanMode` behaviour.** Flipped to `behavior:"allow"` so the SDK's native handler runs, removing a layer of indirection that was eating the resume signal.
 - **`getOptionalSyncService` resolver.** `registerIpc` routes `lanesList` and `apnsSendTestPush` through a single resolver that respects an injected `getSyncService` null result instead of falling through to `ctx`. Keeps tests honest about which projects have sync wired.
+- **PTY resume target backfill on launch.** When relaunching a tracked CLI session whose `resumeMetadata` is missing `targetId`, `ptyService` now runs `tryBackfillResumeTarget("resume-launch")` before spawning so the new pty starts on the correct resume command instead of cold-starting. Replaces the prior warn-only branch.
+- **Per-project route memory.** `AppShell` persists each project's last-visited route to `localStorage` and restores it on project switch, instead of always slamming `/work`. Allowed roots only — falls back to `/work` for anything unrecognized.
 
 ### /shipLane runbook fixes
 


### PR DESCRIPTION
Two bullets for the bug fix landed in #199.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR amends the `v1.1.5` changelog with two additional Desktop bug-fix bullets that landed in #199: PTY resume-target backfill on launch (`tryBackfillResumeTarget`) and per-project route memory in `AppShell`. Both entries follow the existing style and are placed correctly within the Desktop section. No code changes are included.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no code modifications; safe to merge.

The PR contains only two new changelog bullet points. No code, logic, or configuration is touched. Both entries are well-formed, consistent with existing style, and describe real fixes already merged in #199.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| changelog/v1.1.5.mdx | Two changelog bullets added to the Desktop section documenting the PTY resume-target backfill and per-project route memory fixes from #199. Style and placement are consistent with existing entries. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Relaunch tracked CLI session] --> B{resumeMetadata\nhas targetId?}
    B -- No --> C[tryBackfillResumeTarget\n'resume-launch']
    C --> D[Spawn PTY on correct\nresume command]
    B -- Yes --> D

    E[User switches project] --> F[AppShell reads\nlocalStorage route]
    F --> G{Route is in\nallowed roots?}
    G -- Yes --> H[Navigate to\nlast-visited route]
    G -- No --> I[Fall back to /work]
```

<sub>Reviews (1): Last reviewed commit: ["release: append pty + route fix bullets ..."](https://github.com/arul28/ade/commit/4cf0d4c263dc84728598e7d04e286b6f378e1be9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29723383)</sub>

<!-- /greptile_comment -->