### PR TITLE
release: changelog for v1.1.6

### DIFF
--- a/changelog/v1.1.6.mdx
+++ b/changelog/v1.1.6.mdx
@@ -1,0 +1,40 @@
+---
+title: "v1.1.6"
+description: "Release notes for ADE v1.1.6 — April 26, 2026"
+---
+
+v1.1.6 makes automation rules first-class: per-action targeting and overrides, an explicit `laneMode` for whether a run reuses or creates a lane (with a preset → template helper that handles collisions and a synthetic `lane-setup` row when allocation fails), and a renderer pass that swaps the bespoke automations chrome for the shared CTO design tokens. Sync gets a `forceHostRole` lock so a desktop hosting the phone can't be silently demoted by stale on-disk state, and the `ade-cli` proof tools learn explicit `ownerKind` / `ownerId` routing. Test suite is consolidated heavily — orchestrator, CTO, and PR-service tests collapse from dozens of fragments into a handful of feature suites, and dead tests for ripped-out features are removed. iOS picks up a Work-surface refactor (model catalog/picker, session grouping, per-host token shelf) and a stale-host-key cleanup. Ships in **TestFlight build 8** of 1.1.1.
+
+---
+
+## Desktop
+
+- **Per-action automation overrides.** Rule actions can now carry their own `targetLaneId`, `modelConfig`, and `permissionConfig`. The planner and `automationService` merge these on top of rule-level config, with sanitation so per-action `permissionConfig` never leaks `undefined` keys and the Cursor provider key stays clean. Per-key clears in `permissionControls` replace the old wipe-all behaviour so you can reset a single override without losing the rest.
+- **`laneMode` is a first-class execution setting.** `AutomationExecution` gains `laneMode` + `laneNamePreset` (and a preserved `laneNameTemplate`). `resolveExecutionLaneId` branches on `laneMode`: `create` allocates a fresh lane via `createLaneForRun`, which resolves the preset/template, disambiguates collisions with `#issueNumber` or a short timestamp, then falls back to a 4-char random suffix. Allocation failures emit a synthetic `lane-setup` `action_results` row so they surface in run history instead of silently falling back to the primary lane.
+- **Legacy create-lane rules migrate on load.** `projectConfigService` rewrites old "create lane as first action" rules into `laneMode: 'create'` on load, carrying the prior name template forward as a `custom` preset. Unmigrated rows still render in `ActionRow` as read-only with a "now in Execution" pill so older rules display sensibly during the transition.
+- **Automations renderer adopts the shared design tokens.** New `designTokens.ts` re-exports the CTO panel tokens (`inputCls`, `selectCls`, `labelCls`, `cardCls`, …) as the single source of truth for the automations surface. `shared.ts` collapses `INPUT_CLS` / `INPUT_STYLE` / `CARD_STYLE` to thin aliases over those tokens, so existing call sites inherit the new chrome with zero churn. `RunDetailPanel` swaps hex literals for CSS variables, gives `lane-setup` rows a `GitBranch` icon + accent border, and renders `error_message` in `text-error`.
+- **Rules-tab affordances.** `RulesTab` shows a "Last run: failed" pill on the rule list with click-through to history; the empty state uses `cardCls`. `ActionList` drops "Create lane" from the +Add menu now that lane creation lives in Execution.
+- **Sync host-role lock.** `syncService` gains `forceHostRole` so the desktop instance hosting phone sync cannot be demoted to viewer by stale on-disk state. `main.ts` serialises `reconcileSyncHostContexts` so async runs land in order, and the post-clear `agentChatService` refreshes its reconstruction context when `sdkSessionId` is cleared.
+- **`syncHostService` no longer silent-fails on CONNECTING.** `sendAndWait` drops the silent `CONNECTING` fall-through; callers now get an explicit error instead of a swallowed promise.
+- **`ade-cli` proof routing.** Adds `proof attach` / `proof capture` plus explicit `ownerKind` / `ownerId` flags on the RPC proof tools, with `chat` / `pr` aliases. `adeRpcServer` rejects half-specified explicit owners and preserves PR/issue relations. Capture-style commands run headless by default. New owner/caption flags are wired into `VALUE_CARRIER_FLAGS`.
+- **`create-lane` automation action.** Available as an explicit action type in addition to the `laneMode: 'create'` execution setting, for rules that need lane creation mid-flow rather than at run start.
+
+### Test suite consolidation
+
+After the recent feature ripouts, the test tree was carrying a lot of dead and fragmented files. This release collapses them.
+
+- **Orchestrator tests: 17 → 12 suites.** `orchestratorAdapters.test.ts` absorbs `baseOrchestratorAdapter` + `providerOrchestratorAdapter` + `permissionMapping` + `modelConfigResolver`. `mission.test.ts` absorbs `missionLifecycle` + `missionBudgetService` + `missionStateDoc`. `orchestratorPlanning.test.ts` absorbs `orchestratorContext` + `delegationContracts`. All 463 cases preserved.
+- **CTO tests: 26 → 7 suites.** Linear OAuth/credential/client into `linearAuth`; sync/dispatcher/outbound/template/workflow-file into `linearSync`; intake/ingress/routing/closeout into `linearIntake`; worker-{heartbeat,adapterRuntime,agent,budget,revision,taskSession,openclawBridge} into `ctoWorkerLifecycle`; pipelineHelpers + pipelineLabels into `pipeline`; settings panel + Linear sync panel + session view state into `ctoUi`. 226 cases preserved verbatim, scoped per-source via outer `describe(...)` blocks.
+- **PR-service tests: 10 → 5 feature suites.** `prMergeQueue` (queueLandingService + integrationPlanning + integrationValidation), `prRebase` (prRebaseResolver + resolverUtils via `vi.importActual`), `prAsync` (prPollingService + prSummaryService), `prIssueResolution` (issueInventoryService + prIssueResolver). 180 cases preserved.
+- **Dead tests removed.** Orphaned tests in `orchestrator/`, `prs/`, `missions/`, and a handful of others where the source files no longer exist. A no-op `expect(true).toBe(true)` in `usageTrackingService.test.ts` is rewritten to a real `not.toThrow()` check.
+
+---
+
+## iOS
+
+- **Work surface refactor.** New `WorkModelCatalog` + `WorkModelPickerSheet` replace the inline model selection. `WorkSessionGrouping` is split out as a helper, and now counts awaiting-input sessions in `globalLiveSessionCount` so the badge matches what the user sees.
+- **Per-host token shelf in keychain.** `KeychainService` carries paired-auth payloads keyed by host, so the phone can hold credentials for multiple desktops without thrashing on switch. `SyncService` prunes legacy host keys on load and removes the stale saved profile on a failure path.
+- **Host-identity guards.** `SyncService` drops `suspendAutoReconnect` on a host-identity mismatch — a swapped desktop is treated as a fresh pairing rather than a recoverable disconnect.
+- **`SettingsPairingSection`.** New surface for managing paired desktops directly from settings.
+- **Lane stack canvas refinements.** `LaneStackCanvasScreen` and the `LaneListViewParts` / `LaneComponents` split land alongside the desktop laneMode work, keeping the iOS canvas in sync with the new lane lifecycle.
+- **Mobile UI polish.** Assorted layout fixes across Work and Lanes — caught during a hand pass on the device after the renderer changes landed.

--- a/docs.json
+++ b/docs.json
@@ -219,6 +219,7 @@
             "icon": "tag",
             "expanded": true,
             "pages": [
+              "changelog/v1.1.6",
               "changelog/v1.1.5",
               "changelog/v1.1.4",
               "changelog/v1.1.3",


### PR DESCRIPTION
Changelog for v1.1.6. Tag will be cut after this lands on main.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `changelog/v1.1.6.mdx` release notes and registers the new page in `docs.json`. The content covers the full v1.1.6 feature set (automation overrides, `laneMode`, design-token renderer, sync host-role lock, test suite consolidation, and iOS work-surface refactor).

- The summary paragraph on line 6 ends with \"Ships in **TestFlight build 8** of **1.1.1**\" — the version should be **1.1.6**. This is a factual error that will be visible to all readers of the published changelog.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — the changelog misstates the version number in the TestFlight reference.

A single P1 factual error (wrong version number in public-facing release notes) prevents a clean merge; otherwise the two-file change is straightforward and well-structured.

changelog/v1.1.6.mdx — line 6 version typo needs correction before publishing.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| changelog/v1.1.6.mdx | New changelog entry for v1.1.6; summary paragraph contains a version typo — "1.1.1" instead of "1.1.6" in the TestFlight reference on line 6. |
| docs.json | Adds `changelog/v1.1.6` at the top of the Releases page list; change is correct and ordered properly. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: changelog for v1.1.6] --> B[changelog/v1.1.6.mdx\nnew file]
    A --> C[docs.json\nadd changelog/v1.1.6 entry]
    B --> D{Content sections}
    D --> E[Desktop — automation overrides,\nlaneMode, design tokens, sync lock,\nade-cli proof routing]
    D --> F[Test suite consolidation\norchestrator · CTO · PR-service]
    D --> G[iOS — Work surface refactor,\nper-host keychain, host-identity guards]
    C --> H[Releases nav list\nv1.1.6 at top]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Achangelog%2Fv1.1.6.mdx%3A6%0A**Wrong%20version%20number%20in%20TestFlight%20reference**%0A%0AThe%20summary%20paragraph%20closes%20with%20%22Ships%20in%20**TestFlight%20build%208**%20of%201.1.1.%22%20%E2%80%94%20the%20version%20should%20be%20%601.1.6%60%2C%20not%20%601.1.1%60.%20As%20written%2C%20the%20published%20changelog%20contradicts%20its%20own%20title.%0A%0A%60%60%60suggestion%0Av1.1.6%20makes%20automation%20rules%20first-class%3A%20per-action%20targeting%20and%20overrides%2C%20an%20explicit%20%60laneMode%60%20for%20whether%20a%20run%20reuses%20or%20creates%20a%20lane%20%28with%20a%20preset%20%E2%86%92%20template%20helper%20that%20handles%20collisions%20and%20a%20synthetic%20%60lane-setup%60%20row%20when%20allocation%20fails%29%2C%20and%20a%20renderer%20pass%20that%20swaps%20the%20bespoke%20automations%20chrome%20for%20the%20shared%20CTO%20design%20tokens.%20Sync%20gets%20a%20%60forceHostRole%60%20lock%20so%20a%20desktop%20hosting%20the%20phone%20can't%20be%20silently%20demoted%20by%20stale%20on-disk%20state%2C%20and%20the%20%60ade-cli%60%20proof%20tools%20learn%20explicit%20%60ownerKind%60%20%2F%20%60ownerId%60%20routing.%20Test%20suite%20is%20consolidated%20heavily%20%E2%80%94%20orchestrator%2C%20CTO%2C%20and%20PR-service%20tests%20collapse%20from%20dozens%20of%20fragments%20into%20a%20handful%20of%20feature%20suites%2C%20and%20dead%20tests%20for%20ripped-out%20features%20are%20removed.%20iOS%20picks%20up%20a%20Work-surface%20refactor%20%28model%20catalog%2Fpicker%2C%20session%20grouping%2C%20per-host%20token%20shelf%29%20and%20a%20stale-host-key%20cleanup.%20Ships%20in%20**TestFlight%20build%208**%20of%201.1.6.%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=203&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: changelog/v1.1.6.mdx
Line: 6

Comment:
**Wrong version number in TestFlight reference**

The summary paragraph closes with "Ships in **TestFlight build 8** of 1.1.1." — the version should be `1.1.6`, not `1.1.1`. As written, the published changelog contradicts its own title.

```suggestion
v1.1.6 makes automation rules first-class: per-action targeting and overrides, an explicit `laneMode` for whether a run reuses or creates a lane (with a preset → template helper that handles collisions and a synthetic `lane-setup` row when allocation fails), and a renderer pass that swaps the bespoke automations chrome for the shared CTO design tokens. Sync gets a `forceHostRole` lock so a desktop hosting the phone can't be silently demoted by stale on-disk state, and the `ade-cli` proof tools learn explicit `ownerKind` / `ownerId` routing. Test suite is consolidated heavily — orchestrator, CTO, and PR-service tests collapse from dozens of fragments into a handful of feature suites, and dead tests for ripped-out features are removed. iOS picks up a Work-surface refactor (model catalog/picker, session grouping, per-host token shelf) and a stale-host-key cleanup. Ships in **TestFlight build 8** of 1.1.6.
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["release: changelog for v1.1.6"](https://github.com/arul28/ade/commit/ce802424dfa25e8e1a2f0f9c29fe8f7aefebc245) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29770764)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->