### PR TITLE
fix(tests): dedupe imports + permission-mode types from #202 consolidation

### DIFF
--- a/apps/desktop/src/main/services/cto/ctoWorkerLifecycle.test.ts
+++ b/apps/desktop/src/main/services/cto/ctoWorkerLifecycle.test.ts
@@ -2,7 +2,6 @@ import YAML from "yaml";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { AgentIdentity } from "../../../shared/types";
 import type { AgentIdentity, WorkerAgentRunStatus, WorkerAgentWakeupReason } from "../../../shared/types";
 import { EventEmitter } from "node:events";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -13,10 +12,6 @@ import { createWorkerBudgetService } from "./workerBudgetService";
 import { createWorkerHeartbeatService } from "./workerHeartbeatService";
 import { createWorkerRevisionService } from "./workerRevisionService";
 import { createWorkerTaskSessionService } from "./workerTaskSessionService";
-import { describe, expect, it } from "vitest";
-import { describe, expect, it, vi } from "vitest";
-import { describe, expect, it, vi, afterEach } from "vitest";
-import { openKvDb } from "../state/kvDb";
 import { openKvDb, type AdeDb } from "../state/kvDb";
 
 describe("workerHeartbeatService (file group)", () => {

--- a/apps/desktop/src/main/services/cto/linearIntake.test.ts
+++ b/apps/desktop/src/main/services/cto/linearIntake.test.ts
@@ -2,18 +2,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type {
+  LinearWorkflowConfig,
   LinearWorkflowDefinition,
   LinearWorkflowRun,
   NormalizedLinearIssue,
 } from "../../../shared/types";
-import type { LinearWorkflowConfig, NormalizedLinearIssue } from "../../../shared/types";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createLinearCloseoutService } from "./linearCloseoutService";
 import { createLinearIngressService } from "./linearIngressService";
 import { createLinearIntakeService } from "./linearIntakeService";
 import { createLinearRoutingService } from "./linearRoutingService";
-import { describe, expect, it } from "vitest";
-import { describe, expect, it, vi } from "vitest";
 import { openKvDb } from "../state/kvDb";
 
 describe("linearIntakeService (file group)", () => {

--- a/apps/desktop/src/main/services/cto/linearSync.test.ts
+++ b/apps/desktop/src/main/services/cto/linearSync.test.ts
@@ -1,10 +1,12 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { LinearSyncConfig } from "../../../shared/types";
-import type { LinearWorkflowConfig, LinearWorkflowMatchResult, NormalizedLinearIssue } from "../../../shared/types";
-import type { LinearWorkflowConfig, NormalizedLinearIssue } from "../../../shared/types";
-import type { NormalizedLinearIssue } from "../../../shared/types";
+import type {
+  LinearSyncConfig,
+  LinearWorkflowConfig,
+  LinearWorkflowMatchResult,
+  NormalizedLinearIssue,
+} from "../../../shared/types";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createLinearCloseoutService } from "./linearCloseoutService";
 import { createLinearDispatcherService } from "./linearDispatcherService";
@@ -12,8 +14,6 @@ import { createLinearOutboundService } from "./linearOutboundService";
 import { createLinearSyncService } from "./linearSyncService";
 import { createLinearTemplateService } from "./linearTemplateService";
 import { createLinearWorkflowFileService } from "./linearWorkflowFileService";
-import { describe, expect, it } from "vitest";
-import { describe, expect, it, vi } from "vitest";
 import { openKvDb } from "../state/kvDb";
 import { pathToFileURL } from "node:url";
 

--- a/apps/desktop/src/main/services/prs/prRebase.test.ts
+++ b/apps/desktop/src/main/services/prs/prRebase.test.ts
@@ -2,7 +2,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import type { LaneSummary, RebaseNeed } from "../../../shared/types";
+import type {
+  AgentChatPermissionMode,
+  AiPermissionMode,
+  LaneSummary,
+  RebaseNeed,
+} from "../../../shared/types";
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -56,11 +61,11 @@ const mockRunGit = vi.mocked(runGit);
 describe("resolverUtils (real module)", () => {
   // Lazy-loaded handles to the real module so the prRebaseResolver mock above
   // does not interfere.
-  let mapPermissionMode: (mode: string | undefined) => string;
+  let mapPermissionMode: (mode: AiPermissionMode | undefined) => AgentChatPermissionMode;
   let mapPermissionModeForModelFamily: (
-    mode: string | undefined,
+    mode: AiPermissionMode | undefined,
     family: string | undefined,
-  ) => string;
+  ) => AgentChatPermissionMode;
   let readRecentCommits: (worktreePath: string, count?: number, ref?: string) => Promise<Array<{ sha: string; subject: string }>>;
 
   beforeAll(async () => {


### PR DESCRIPTION
Fixes the typecheck failures on main after the test consolidation in #202.

- ctoWorkerLifecycle / linearIntake / linearSync had duplicate import lines (TS2300).
- prRebase.test.ts under-typed the lazy resolverUtils handles (TS2322) — corrected to AiPermissionMode -> AgentChatPermissionMode.

Local typecheck clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes TypeScript compilation failures introduced by the test consolidation in #202. It removes duplicate `import` statements (TS2300) in three CTO service test files and corrects the lazy variable type annotations in `prRebase.test.ts` from generic `string` to the proper domain types (`AiPermissionMode` → `AgentChatPermissionMode`), matching the actual signatures of `mapPermissionMode` and `mapPermissionModeForModelFamily` in `resolverUtils.ts`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely type/import cleanup with no runtime impact.

All four files contain only import deduplication or type annotation corrections in test files. The types used (AiPermissionMode, AgentChatPermissionMode) are verified to be correctly exported from shared/types, and the function signatures in resolverUtils.ts match exactly. No logic changes, no security implications.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/cto/ctoWorkerLifecycle.test.ts | Removed duplicate `import type { AgentIdentity }` and three duplicate vitest/kvDb import lines; consolidated into single correct imports. |
| apps/desktop/src/main/services/cto/linearIntake.test.ts | Removed duplicate `import type { ... }` block and two duplicate vitest import lines; added `LinearWorkflowConfig` to the merged type import. |
| apps/desktop/src/main/services/cto/linearSync.test.ts | Consolidated four duplicate `import type` lines for shared types into a single multi-symbol import; removed two duplicate vitest import lines. |
| apps/desktop/src/main/services/prs/prRebase.test.ts | Corrected lazy variable types for `mapPermissionMode` / `mapPermissionModeForModelFamily` from `string` to `AiPermissionMode | undefined` → `AgentChatPermissionMode`, matching actual `resolverUtils` signatures. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["prRebase.test.ts\n(resolverUtils tests)"] -->|"vi.importActual"| B["resolverUtils.ts"]
    B -->|"mapPermissionMode(AiPermissionMode)"| C["AgentChatPermissionMode"]
    B -->|"mapPermissionModeForModelFamily(AiPermissionMode, family)"| C
    D["shared/types (prs.ts)"] -->|"exports"| E["AiPermissionMode\n(read_only | guarded_edit | full_edit)"]
    F["shared/types (chat.ts)"] -->|"exports"| G["AgentChatPermissionMode\n(default | plan | edit | full-auto | config-toml)"]
    E --> B
    G --> B
```

<sub>Reviews (1): Last reviewed commit: ["fix(tests): dedupe imports + correct per..."](https://github.com/arul28/ade/commit/da8984cbaf86441ad4a4ae8efd34232293be14fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29770991)</sub>

<!-- /greptile_comment -->