### PR TITLE
lanes: stabilize URL deep-link useEffect deps

### DIFF
--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -318,9 +318,16 @@ export function LanesPage() {
   );
   const sortedLanes = useMemo(() => sortLanesForTabs(lanes), [lanes]);
   const lanesById = useMemo(() => new Map(sortedLanes.map((lane) => [lane.id, lane])), [sortedLanes]);
+  // `availableLaneIdsKey` is the content-stable dep trigger (string changes only
+  // when the id set changes). `availableLaneIds` recomputes from the key so its
+  // identity is also content-stable, letting effects depend on either safely.
   const availableLaneIdsKey = useMemo(
     () => sortedLanes.map((lane) => lane.id).sort().join("\0"),
     [sortedLanes],
+  );
+  const availableLaneIds = useMemo(
+    () => (availableLaneIdsKey ? availableLaneIdsKey.split("\0") : []),
+    [availableLaneIdsKey],
   );
   const integrationSourcesByLaneId = useMemo(
     () => buildIntegrationSourcesByLaneId(integrationProposals, lanesById),
@@ -1385,7 +1392,7 @@ export function LanesPage() {
 
   // Deep link handling: must not re-run on lane list refreshes, or a stale
   // ?laneId / focus=single from the URL overwrites the user's current tab/split
-  // selection. Multi-lane ?laneIds= re-tries as `availableLaneIdsKey` changes.
+  // selection. Multi-lane ?laneIds= re-tries as `availableLaneIds` changes.
 
   // Intentionally depend only on `urlLaneDeeplinks.action` (not
   // prepareCreateDialog) so the create dialog is not re-opened from hook churn.
@@ -1398,11 +1405,10 @@ export function LanesPage() {
 
   useEffect(() => {
     if (!urlLaneDeeplinks.laneIdsRaw) return;
-    const availableFromKey = availableLaneIdsKey ? availableLaneIdsKey.split("\0") : [];
     const laneIdsSelection = resolveLaneIdsDeepLinkSelection({
       laneIdsRaw: urlLaneDeeplinks.laneIdsRaw,
       inspectorTabParam: urlLaneDeeplinks.inspectorTab,
-      availableLaneIds: availableFromKey,
+      availableLaneIds,
       consumedSignature: consumedLaneIdsDeepLinkSignatureRef.current,
     });
     if (laneIdsSelection) {
@@ -1415,26 +1421,28 @@ export function LanesPage() {
         setLaneInspectorTab(valid[0], urlLaneDeeplinks.inspectorTab as LaneInspectorTab);
       }
     }
-  }, [availableLaneIdsKey, selectLane, setLaneInspectorTab, urlLaneDeeplinks.laneIdsRaw, urlLaneDeeplinks.inspectorTab]);
+  }, [availableLaneIds, selectLane, setLaneInspectorTab, urlLaneDeeplinks.laneIdsRaw, urlLaneDeeplinks.inspectorTab]);
 
   useEffect(() => {
-    const p = new URLSearchParams(location.search);
-    const laneIdsRaw = p.get("laneIds");
-    if (laneIdsRaw) {
-      return;
-    }
+    if (urlLaneDeeplinks.laneIdsRaw) return;
     consumedLaneIdsDeepLinkSignatureRef.current = null;
-    const laneId = p.get("laneId");
+    const laneId = urlLaneDeeplinks.laneId;
     if (!laneId) return;
     selectLane(laneId);
-    if (p.get("focus") === "single") {
+    if (urlLaneDeeplinks.focus === "single") {
       setActiveLaneIds([laneId]);
     }
-    const inspector = p.get("inspectorTab");
-    if (inspector) {
-      setLaneInspectorTab(laneId, inspector as LaneInspectorTab);
+    if (urlLaneDeeplinks.inspectorTab) {
+      setLaneInspectorTab(laneId, urlLaneDeeplinks.inspectorTab as LaneInspectorTab);
     }
-  }, [location.search, selectLane, setLaneInspectorTab]);
+  }, [
+    urlLaneDeeplinks.laneIdsRaw,
+    urlLaneDeeplinks.laneId,
+    urlLaneDeeplinks.focus,
+    urlLaneDeeplinks.inspectorTab,
+    selectLane,
+    setLaneInspectorTab,
+  ]);
 
   useEffect(() => {
     if (!urlLaneDeeplinks.sessionId) return;

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useClickOutside } from "../../hooks/useClickOutside";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { Group, Panel } from "react-resizable-panels";
 import { Check, CaretDown, FileCode, GitBranch, House, Stack, Link, ArrowsOutSimple, ArrowsInSimple, PushPin, Plus, MagnifyingGlass, Terminal, X, ArrowSquareOut, Info, ArrowCounterClockwise, UsersThree } from "@phosphor-icons/react";
 import { useAppStore, type LaneInspectorTab } from "../../state/appStore";
@@ -199,12 +199,25 @@ function laneTilingLayoutIds(laneId: string): string[] {
 
 export function LanesPage() {
   const [params] = useSearchParams();
+  const location = useLocation();
   const navigate = useNavigate();
   const selectLane = useAppStore((s) => s.selectLane);
   const selectRunLane = useAppStore((s) => s.selectRunLane);
   const selectedLaneId = useAppStore((s) => s.selectedLaneId);
   const focusSession = useAppStore((s) => s.focusSession);
   const lanes = useAppStore((s) => s.lanes);
+
+  const urlLaneDeeplinks = useMemo(() => {
+    const p = new URLSearchParams(location.search);
+    return {
+      action: p.get("action"),
+      laneIdsRaw: p.get("laneIds"),
+      laneId: p.get("laneId"),
+      sessionId: p.get("sessionId"),
+      inspectorTab: p.get("inspectorTab"),
+      focus: p.get("focus"),
+    };
+  }, [location.search]);
   const refreshLanes = useAppStore((s) => s.refreshLanes);
   const setLaneInspectorTab = useAppStore((s) => s.setLaneInspectorTab);
   const clearLaneInspectorTab = useAppStore((s) => s.clearLaneInspectorTab);
@@ -305,6 +318,10 @@ export function LanesPage() {
   );
   const sortedLanes = useMemo(() => sortLanesForTabs(lanes), [lanes]);
   const lanesById = useMemo(() => new Map(sortedLanes.map((lane) => [lane.id, lane])), [sortedLanes]);
+  const availableLaneIdsKey = useMemo(
+    () => sortedLanes.map((lane) => lane.id).sort().join("\0"),
+    [sortedLanes],
+  );
   const integrationSourcesByLaneId = useMemo(
     () => buildIntegrationSourcesByLaneId(integrationProposals, lanesById),
     [integrationProposals, lanesById],
@@ -1366,21 +1383,26 @@ export function LanesPage() {
     setCreateOpen(true);
   }, [lanes]);
 
-  // Intentionally ignore prepareCreateDialog churn so an open ?action=create URL
-  // doesn't reopen and reset the dialog when lanes refresh.
+  // Deep link handling: must not re-run on lane list refreshes, or a stale
+  // ?laneId / focus=single from the URL overwrites the user's current tab/split
+  // selection. Multi-lane ?laneIds= re-tries as `availableLaneIdsKey` changes.
+
+  // Intentionally depend only on `urlLaneDeeplinks.action` (not
+  // prepareCreateDialog) so the create dialog is not re-opened from hook churn.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    const laneIdsRaw = params.get("laneIds");
-    const laneId = params.get("laneId");
-    const sessionId = params.get("sessionId");
-    const inspectorTabParam = params.get("inspectorTab");
-    if (params.get("action") === "create") {
+    if (urlLaneDeeplinks.action === "create") {
       prepareCreateDialog();
     }
+  }, [urlLaneDeeplinks.action]);
+
+  useEffect(() => {
+    if (!urlLaneDeeplinks.laneIdsRaw) return;
+    const availableFromKey = availableLaneIdsKey ? availableLaneIdsKey.split("\0") : [];
     const laneIdsSelection = resolveLaneIdsDeepLinkSelection({
-      laneIdsRaw,
-      inspectorTabParam,
-      availableLaneIds: lanesById.keys(),
+      laneIdsRaw: urlLaneDeeplinks.laneIdsRaw,
+      inspectorTabParam: urlLaneDeeplinks.inspectorTab,
+      availableLaneIds: availableFromKey,
       consumedSignature: consumedLaneIdsDeepLinkSignatureRef.current,
     });
     if (laneIdsSelection) {
@@ -1389,26 +1411,35 @@ export function LanesPage() {
       selectLane(valid[0]!);
       setActiveLaneIds(valid);
       setPinnedLaneIds(new Set());
-      if (inspectorTabParam && valid[0]) {
-        setLaneInspectorTab(valid[0], inspectorTabParam as LaneInspectorTab);
-      }
-    } else if (laneIdsRaw) {
-      // Keep waiting for the referenced lanes to exist instead of consuming
-      // the deep link early. Once it succeeds, later refreshes will no-op.
-    } else {
-      consumedLaneIdsDeepLinkSignatureRef.current = null;
-      if (laneId) {
-        selectLane(laneId);
-        if (params.get("focus") === "single") {
-          setActiveLaneIds([laneId]);
-        }
-        if (inspectorTabParam) {
-          setLaneInspectorTab(laneId, inspectorTabParam as LaneInspectorTab);
-        }
+      if (urlLaneDeeplinks.inspectorTab && valid[0]) {
+        setLaneInspectorTab(valid[0], urlLaneDeeplinks.inspectorTab as LaneInspectorTab);
       }
     }
-    if (sessionId) focusSession(sessionId);
-  }, [params, selectLane, focusSession, setLaneInspectorTab, lanesById]);
+  }, [availableLaneIdsKey, selectLane, setLaneInspectorTab, urlLaneDeeplinks.laneIdsRaw, urlLaneDeeplinks.inspectorTab]);
+
+  useEffect(() => {
+    const p = new URLSearchParams(location.search);
+    const laneIdsRaw = p.get("laneIds");
+    if (laneIdsRaw) {
+      return;
+    }
+    consumedLaneIdsDeepLinkSignatureRef.current = null;
+    const laneId = p.get("laneId");
+    if (!laneId) return;
+    selectLane(laneId);
+    if (p.get("focus") === "single") {
+      setActiveLaneIds([laneId]);
+    }
+    const inspector = p.get("inspectorTab");
+    if (inspector) {
+      setLaneInspectorTab(laneId, inspector as LaneInspectorTab);
+    }
+  }, [location.search, selectLane, setLaneInspectorTab]);
+
+  useEffect(() => {
+    if (!urlLaneDeeplinks.sessionId) return;
+    focusSession(urlLaneDeeplinks.sessionId);
+  }, [urlLaneDeeplinks.sessionId, focusSession]);
 
   const handleCreateDialogOpenChange = useCallback((open: boolean) => {
     if (!open && createBusy) return;


### PR DESCRIPTION
## Summary

Refactors `LanesPage` URL deep-link handling so a stale `?laneId` / `focus=single` from the URL no longer overwrites the user's current tab/split selection when lanes refresh.

- Split a single composite useEffect into per-concern effects (create dialog, multi-lane selection, single-lane selection, session focus).
- Added `urlLaneDeeplinks` memo over `location.search` so URL params are derived from one stable source.
- Added `availableLaneIdsKey` memo so multi-lane resolution retries when the lane list loads, without keying off the full `lanes` array identity.

## Test plan

- [x] Existing `LanesPage.test.ts` covers `resolveLaneIdsDeepLinkSelection` (new selection / consumed-signature dedup / wait-for-lanes retry); 6/6 passing.
- [x] Typecheck `apps/desktop` passes.
- [x] Lint `LanesPage.tsx` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where deep-linked create dialog would re-open unexpectedly when navigating between lanes.
  * Improved handling of deep-linked navigation to ensure lane selection and inspector tab state are properly applied when following deep-links.
  * Enhanced reliability of deep-link parameter processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR splits a single composite `useEffect` in `LanesPage` into four per-concern effects (create dialog, multi-lane selection, single-lane selection, session focus), and introduces a `urlLaneDeeplinks` memo to give all effects one stable parse of the URL search string. It also adds `availableLaneIdsKey` / `availableLaneIds` memos so the multi-lane effect retries correctly when the lane list loads, without depending on the full `lanes` array identity.

Both issues flagged in the previous review pass — Effect 3 now reads from `urlLaneDeeplinks` instead of re-parsing `location.search` directly, and a separate `availableLaneIds` array memo was added alongside `availableLaneIdsKey` to avoid the string round-trip in effect body code.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0 or P1 issues found; both previous review concerns have been addressed.

The change is a focused refactor of effect dependencies with no new logic paths or external integrations. All four effects have well-reasoned dependency arrays, the urlLaneDeeplinks abstraction is used consistently across all effects, and the availableLaneIds memo cleanly resolves the prior round-trip concern. No regressions or security issues identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/lanes/LanesPage.tsx | Refactored deep-link useEffect into four per-concern effects with stable URL param memo; previous review concerns addressed. No new logic or security issues found. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    URL["location.search"] --> ULD["urlLaneDeeplinks memo\n(action, laneIdsRaw, laneId,\nsessionId, inspectorTab, focus)"]
    Lanes["lanes (store)"] --> SL["sortedLanes memo"]
    SL --> KEY["availableLaneIdsKey memo\n(sorted IDs joined by \\0)"]
    KEY --> AID["availableLaneIds memo\n(string[])"]

    ULD --> E1["Effect 1: Create Dialog\ndeps: [urlLaneDeeplinks.action]\n→ prepareCreateDialog()"]
    ULD & AID --> E2["Effect 2: Multi-lane Selection\ndeps: [availableLaneIds, laneIdsRaw, inspectorTab, ...]\n→ resolveLaneIdsDeepLinkSelection()"]
    ULD --> E3["Effect 3: Single-lane Selection\ndeps: [laneIdsRaw, laneId, focus, inspectorTab, ...]\n→ selectLane / setActiveLaneIds"]
    ULD --> E4["Effect 4: Session Focus\ndeps: [sessionId, focusSession]\n→ focusSession()"]

    E2 -- "laneIdsRaw present" --> CONSUMED["consumedLaneIdsDeepLinkSignatureRef\n(dedup guard)"]
    E3 -- "laneIdsRaw absent" --> CONSUMED
```

<sub>Reviews (2): Last reviewed commit: ["ship: iter 1 — rebase onto main + addres..."](https://github.com/arul28/ade/commit/76aaf0d3cff4510816501ec9677075cd8be78944) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29777074)</sub>

<!-- /greptile_comment -->