### PR TITLE
fix(ios): restore profile dedup + remove dead reconnect path

### DIFF
--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -1423,6 +1423,16 @@ final class SyncService: ObservableObject {
       .first { !$0.isEmpty }
   }
 
+  private func shouldPreferProfile(_ candidate: HostConnectionProfile, over existing: HostConnectionProfile) -> Bool {
+    if candidate.updatedAt != existing.updatedAt {
+      return candidate.updatedAt > existing.updatedAt
+    }
+    if candidate.tailscaleAddress != nil && existing.tailscaleAddress == nil {
+      return true
+    }
+    return candidate.lastSuccessfulAddress != nil && existing.lastSuccessfulAddress == nil
+  }
+
   private func loadSavedProfilesRaw() -> [String: HostConnectionProfile] {
     guard let data = UserDefaults.standard.data(forKey: profilesKey) else {
       return [:]
@@ -1434,6 +1444,9 @@ final class SyncService: ObservableObject {
       var migrated: [String: HostConnectionProfile] = [:]
       for profile in legacyArray {
         guard let key = profileStorageKey(profile) else { continue }
+        if let existing = migrated[key], !shouldPreferProfile(profile, over: existing) {
+          continue
+        }
         migrated[key] = profile
       }
       syncConnectLog.warning("Migrated \(legacyArray.count, privacy: .public) legacy array-format host profiles to dict format (\(migrated.count, privacy: .public) keyed)")
@@ -1453,13 +1466,27 @@ final class SyncService: ObservableObject {
   }
 
   private func saveSavedProfiles(_ profiles: [String: HostConnectionProfile]) {
-    if profiles.isEmpty {
+    let normalized = deduplicatedProfiles(profiles)
+    if normalized.isEmpty {
       UserDefaults.standard.removeObject(forKey: profilesKey)
       return
     }
-    if let data = try? encoder.encode(profiles) {
+    if let data = try? encoder.encode(normalized) {
       UserDefaults.standard.set(data, forKey: profilesKey)
     }
+  }
+
+  private func deduplicatedProfiles(_ profiles: [String: HostConnectionProfile]) -> [String: HostConnectionProfile] {
+    var byKey: [String: HostConnectionProfile] = [:]
+    byKey.reserveCapacity(profiles.count)
+    for profile in profiles.values {
+      guard let key = profileStorageKey(profile) else { continue }
+      if let existing = byKey[key], !shouldPreferProfile(profile, over: existing) {
+        continue
+      }
+      byKey[key] = profile
+    }
+    return byKey
   }
 
   private func migrateTokenIfNeeded(for profile: HostConnectionProfile) {
@@ -1637,37 +1664,6 @@ final class SyncService: ObservableObject {
     connectionState = .connecting
     hostName = profile.hostName
     lastError = nil
-  }
-
-  func reconnectToSavedHost(_ host: DiscoveredSyncHost, preferTailnet: Bool = false) async {
-    guard let profile = profile(forSavedHost: host), let token = tokenForProfile(profile) else {
-      lastError = "That saved host is missing pairing credentials. Pair it again from Settings."
-      connectionState = .error
-      return
-    }
-    keychain.saveToken(token)
-    saveProfile(profile)
-    await reconnectIfPossible(userInitiated: true, preferTailnet: preferTailnet || host.tailscaleAddress != nil)
-  }
-
-  private func profile(forSavedHost host: DiscoveredSyncHost) -> HostConnectionProfile? {
-    let normalizedHostId = host.hostIdentity?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-    let hostAddresses = Set((host.addresses + (host.tailscaleAddress.map { [$0] } ?? [])).map(syncNormalizedRouteHost))
-    return loadSavedProfiles().values.first { profile in
-      if let normalizedHostId,
-         let profileIdentity = profile.hostIdentity?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
-         profileIdentity == normalizedHostId {
-        return true
-      }
-      let profileAddresses = Set(
-        (profile.savedAddressCandidates
-         + profile.discoveredLanAddresses
-         + (profile.lastSuccessfulAddress.map { [$0] } ?? [])
-         + (profile.tailscaleAddress.map { [$0] } ?? []))
-          .map(syncNormalizedRouteHost)
-      )
-      return !profileAddresses.isDisjoint(with: hostAddresses)
-    }
   }
 
   private func shouldPreferTailnetForUserReconnect(_ profile: HostConnectionProfile) -> Bool {

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -1423,12 +1423,20 @@ final class SyncService: ObservableObject {
       .first { !$0.isEmpty }
   }
 
+  private func profileHasTailnetRoute(_ profile: HostConnectionProfile) -> Bool {
+    if profile.tailscaleAddress != nil { return true }
+    if let last = profile.lastSuccessfulAddress, syncIsTailscaleRoute(last) { return true }
+    return profile.savedAddressCandidates.contains(where: syncIsTailscaleRoute)
+  }
+
   private func shouldPreferProfile(_ candidate: HostConnectionProfile, over existing: HostConnectionProfile) -> Bool {
     if candidate.updatedAt != existing.updatedAt {
       return candidate.updatedAt > existing.updatedAt
     }
-    if candidate.tailscaleAddress != nil && existing.tailscaleAddress == nil {
-      return true
+    let candidateTailnet = profileHasTailnetRoute(candidate)
+    let existingTailnet = profileHasTailnetRoute(existing)
+    if candidateTailnet != existingTailnet {
+      return candidateTailnet
     }
     return candidate.lastSuccessfulAddress != nil && existing.lastSuccessfulAddress == nil
   }
@@ -1476,14 +1484,44 @@ final class SyncService: ObservableObject {
     }
   }
 
+  private func profileIdentityKeys(_ profile: HostConnectionProfile) -> [String] {
+    var keys: [String] = []
+    if let id = profile.hostIdentity?.trimmingCharacters(in: .whitespacesAndNewlines), !id.isEmpty {
+      keys.append("identity:\(id)")
+    }
+    if let device = profile.lastHostDeviceId?.trimmingCharacters(in: .whitespacesAndNewlines), !device.isEmpty {
+      keys.append("device:\(device)")
+    }
+    if let name = profile.hostName?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+      keys.append("name:\(name.lowercased()):\(profile.port)")
+    }
+    if let last = profile.lastSuccessfulAddress?.trimmingCharacters(in: .whitespacesAndNewlines), !last.isEmpty {
+      keys.append("addr:\(last):\(profile.port)")
+    }
+    return keys
+  }
+
   private func deduplicatedProfiles(_ profiles: [String: HostConnectionProfile]) -> [String: HostConnectionProfile] {
-    var byKey: [String: HostConnectionProfile] = [:]
-    byKey.reserveCapacity(profiles.count)
+    var canonicalProfiles: [HostConnectionProfile] = []
+    var keyToIndex: [String: Int] = [:]
     for profile in profiles.values {
-      guard let key = profileStorageKey(profile) else { continue }
-      if let existing = byKey[key], !shouldPreferProfile(profile, over: existing) {
-        continue
+      let identityKeys = profileIdentityKeys(profile)
+      let matchedIndex = identityKeys.lazy.compactMap { keyToIndex[$0] }.first
+      if let index = matchedIndex {
+        if shouldPreferProfile(profile, over: canonicalProfiles[index]) {
+          canonicalProfiles[index] = profile
+        }
+        for key in identityKeys { keyToIndex[key] = index }
+      } else {
+        let index = canonicalProfiles.count
+        canonicalProfiles.append(profile)
+        for key in identityKeys { keyToIndex[key] = index }
       }
+    }
+    var byKey: [String: HostConnectionProfile] = [:]
+    byKey.reserveCapacity(canonicalProfiles.count)
+    for profile in canonicalProfiles {
+      guard let key = profileStorageKey(profile) else { continue }
       byKey[key] = profile
     }
     return byKey


### PR DESCRIPTION
## Summary

Follow-up to #209. The rebase resolution there kept the dict-based saved-profile API but dropped the recency-aware dedup that pre-existed on main. This restores it and cleans up dead code Greptile flagged in the PR review.

- `shouldPreferProfile(_:over:)` picks the better profile when two map to the same storage key (newer `updatedAt`, then Tailscale presence, then last-successful-address presence).
- `loadSavedProfilesRaw()` uses it during legacy `[HostConnectionProfile]` array migration so collisions don't fall to last-write-wins.
- `saveSavedProfiles(_:)` runs a paranoia dedup pass before encoding.
- `reconnectToSavedHost(_:preferTailnet:)` and its only helper `profile(forSavedHost:)` removed — both unreachable post-rebase, flagged by Greptile P2-A in #209.

Net diff: +29 / -33 in `apps/ios/ADE/Services/SyncService.swift`. Single file.

## Test plan

- [ ] iOS smoke: pair host, force-quit, relaunch — saved profile still loads, token still resolves under new `:` keychain key.
- [ ] iOS upgrade path: install previous TestFlight build with array-format profiles, install this build, confirm profiles migrate without loss (covered by the existing legacy-array fallback in #209 + the new dedup logic preserves the best profile when keys collide).
- [ ] CI green (typecheck-desktop, lint-desktop, ade-cli typecheck — Swift compile is iOS-side, not CI-gated locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved saved host profile persistence by deduplicating entries to prevent duplicate saved hosts from accumulating.

* **Refactor**
  * Streamlined reconnect behavior to use standard reconnection flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the recency-aware profile deduplication logic (`shouldPreferProfile`, `deduplicatedProfiles`) that was dropped in the #209 rebase, and removes the unreachable `reconnectToSavedHost`/`profile(forSavedHost:)` pair. The dedup pass runs both during legacy array migration and as a paranoia pass in `saveSavedProfiles`.

The two P2 findings are edge cases in `deduplicatedProfiles`: (1) when a bridging profile spans two pre-existing canonical slots, only the first-matched slot is merged and the second leaks through; (2) stale identity-key pointers remain in `keyToIndex` after a replacement, which can cause a later unrelated profile to merge into the wrong slot. Neither causes data corruption, but the dedup may be incomplete in adversarial orderings.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 edge cases in the dedup logic that do not corrupt data.

Only P2 findings present — both are incomplete-dedup scenarios requiring specific dict-iteration orderings and profile key configurations that are unlikely in practice. No P0/P1 issues found.

apps/ios/ADE/Services/SyncService.swift — specifically the `deduplicatedProfiles` slot-bridging and stale-key logic.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Services/SyncService.swift | Adds recency-aware profile dedup (`shouldPreferProfile`, `deduplicatedProfiles`) and removes the dead `reconnectToSavedHost`/`profile(forSavedHost:)` pair; two edge-case dedup misses in the slot-bridging and stale-key logic of `deduplicatedProfiles`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[saveSavedProfiles] --> B[deduplicatedProfiles]
    B --> C{For each profile}
    C --> D[profileIdentityKeys]
    D --> E{Any key in keyToIndex?}
    E -- yes --> F{shouldPreferProfile?}
    F -- yes --> G[Replace canonical slot\nUpdate winner keys in keyToIndex]
    F -- no --> H[Skip]
    E -- no --> I[Append new canonical slot\nAdd all keys to keyToIndex]
    G --> C
    H --> C
    I --> C
    C --> J[Rebuild output dict via profileStorageKey]
    J --> K[Encode and write to UserDefaults]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fios%2FADE%2FServices%2FSyncService.swift%3A1510-1518%0A**Slot-bridging%20miss%20in%20%60deduplicatedProfiles%60**%0A%0AWhen%20a%20profile%20whose%20identity%20keys%20span%20two%20already-distinct%20canonical%20slots%20is%20processed%2C%20only%20the%20first-matched%20slot%20is%20merged.%20The%20second%20slot%20remains%20as%20a%20separate%20entry%20in%20%60canonicalProfiles%60%20and%20is%20emitted%20at%20the%20end%2C%20producing%20a%20dedup%20miss.%0A%0AConcrete%20scenario%20%28dict%20iteration%20order%20is%20undefined%2C%20so%20this%20order%20is%20reachable%29%3A%0A1.%20Profile%20A%20%28keys%20%60%5BK1%5D%60%29%20%E2%86%92%20slot%200.%0A2.%20Profile%20B%20%28keys%20%60%5BK2%5D%60%29%20%E2%86%92%20slot%201.%0A3.%20Profile%20C%20%28keys%20%60%5BK1%2C%20K2%5D%60%29%20%E2%86%92%20%60lazy.compactMap%20%7B%20keyToIndex%5B%240%5D%20%7D.first%60%20yields%20slot%200%20%28K1%20wins%29.%20C%20is%20merged%20into%20slot%200.%20%60keyToIndex%5BK2%5D%60%20is%20overwritten%20to%200.%20But%20slot%201%20%28B%29%20survives%20in%20%60canonicalProfiles%60%20and%20is%20output%20independently.%0A%0AThe%20output%20dict%20ends%20up%20with%20both%20slot-0%20%28merged%20A%2BC%29%20and%20slot-1%20%28B%29%2C%20even%20though%20C%20established%20they%20are%20the%20same%20host.%20A%20union-find%20structure%20would%20handle%20this%20correctly%20by%20merging%20the%20two%20slots%20when%20a%20bridging%20profile%20is%20encountered.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fios%2FADE%2FServices%2FSyncService.swift%3A1510-1514%0A**Stale%20identity%20keys%20after%20slot%20replacement**%0A%0AWhen%20a%20challenger%20profile%20wins%20%28%60canonicalProfiles%5Bindex%5D%20%3D%20profile%60%29%2C%20the%20winner's%20identity%20keys%20are%20added%20to%20%60keyToIndex%60%2C%20but%20the%20loser's%20keys%20that%20are%20NOT%20in%20the%20winner's%20key%20set%20remain%20pointing%20at%20that%20slot.%20If%20a%20later%20profile%20shares%20only%20a%20stale%20key%20%28one%20that%20belonged%20to%20the%20now-replaced%20loser%29%2C%20it%20will%20be%20incorrectly%20merged%20into%20the%20winner's%20slot%20despite%20having%20no%20identity%20overlap%20with%20the%20winner.%0A%0AExample%3A%20A%20has%20%60%5BK1%2C%20K2%5D%60%2C%20B%20has%20%60%5BK1%2C%20K3%5D%60%2C%20B%20beats%20A%20%E2%86%92%20%60keyToIndex%60%3A%20%60%7BK1%3A0%2C%20K2%3A0%28stale%29%2C%20K3%3A0%7D%60.%20Profile%20C%20arrives%20with%20%60%5BK2%5D%60%20only%20%E2%80%94%20it%20matches%20slot%200%20through%20the%20stale%20addr%20key%2C%20and%20may%20get%20incorrectly%20merged%20with%20B.%20Consider%20clearing%20or%20rebuilding%20%60keyToIndex%60%20entries%20for%20the%20loser%20when%20a%20replacement%20occurs.%0A%0A&repo=arul28%2Fade&pr=210&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: apps/ios/ADE/Services/SyncService.swift
Line: 1510-1518

Comment:
**Slot-bridging miss in `deduplicatedProfiles`**

When a profile whose identity keys span two already-distinct canonical slots is processed, only the first-matched slot is merged. The second slot remains as a separate entry in `canonicalProfiles` and is emitted at the end, producing a dedup miss.

Concrete scenario (dict iteration order is undefined, so this order is reachable):
1. Profile A (keys `[K1]`) → slot 0.
2. Profile B (keys `[K2]`) → slot 1.
3. Profile C (keys `[K1, K2]`) → `lazy.compactMap { keyToIndex[$0] }.first` yields slot 0 (K1 wins). C is merged into slot 0. `keyToIndex[K2]` is overwritten to 0. But slot 1 (B) survives in `canonicalProfiles` and is output independently.

The output dict ends up with both slot-0 (merged A+C) and slot-1 (B), even though C established they are the same host. A union-find structure would handle this correctly by merging the two slots when a bridging profile is encountered.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: apps/ios/ADE/Services/SyncService.swift
Line: 1510-1514

Comment:
**Stale identity keys after slot replacement**

When a challenger profile wins (`canonicalProfiles[index] = profile`), the winner's identity keys are added to `keyToIndex`, but the loser's keys that are NOT in the winner's key set remain pointing at that slot. If a later profile shares only a stale key (one that belonged to the now-replaced loser), it will be incorrectly merged into the winner's slot despite having no identity overlap with the winner.

Example: A has `[K1, K2]`, B has `[K1, K3]`, B beats A → `keyToIndex`: `{K1:0, K2:0(stale), K3:0}`. Profile C arrives with `[K2]` only — it matches slot 0 through the stale addr key, and may get incorrectly merged with B. Consider clearing or rebuilding `keyToIndex` entries for the loser when a replacement occurs.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ios): broader tailnet detection + cr..."](https://github.com/arul28/ade/commit/6eabc94d629e81499cf57106eaddca88db8dcd2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29793990)</sub>

<!-- /greptile_comment -->