### PR TITLE
fix(run-tab): surface PTY startup failures and tighten run UI

### DIFF
--- a/apps/desktop/src/main/services/processes/processService.test.ts
+++ b/apps/desktop/src/main/services/processes/processService.test.ts
@@ -1000,6 +1000,89 @@ describe("processService PTY-backed run commands", () => {
     }
   });
 
+  it("writes PTY startup failures into the run transcript", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ade-process-start-failure-"));
+    const dbPath = path.join(tmpDir, "kv.sqlite");
+    const projectId = "proj-start-failure";
+    const logger = createLogger();
+    const db = await openKvDb(dbPath, createLogger());
+    const now = "2026-03-24T12:00:00.000Z";
+    const sessionStore = new Map<string, { id: string; transcriptPath: string }>();
+    const dataListeners = new Set<(event: { laneId: string; ptyId: string; sessionId: string; data: string }) => void>();
+    const exitListeners = new Set<(event: { laneId: string; ptyId: string; sessionId: string; exitCode: number | null }) => void>();
+
+    db.run(
+      "insert into projects(id, root_path, display_name, default_base_ref, created_at, last_opened_at) values (?, ?, ?, ?, ?, ?)",
+      [projectId, tmpDir, "test", "main", now, now],
+    );
+    db.run(
+      `insert into lanes(
+        id, project_id, name, description, lane_type, base_ref, branch_ref, worktree_path,
+        attached_root_path, is_edit_protected, parent_lane_id, color, icon, tags_json, status, created_at, archived_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["lane-fail", projectId, "Lane Fail", null, "worktree", "main", "feature/fail", tmpDir, null, 0, null, null, null, null, "active", now, null],
+    );
+
+    const config = makeMinimalConfig([
+      { id: "bad-command", command: ["./missing-script.sh", "dev"], cwd: "." },
+    ]);
+    const ptyService = {
+      create: vi.fn(async (args: any) => {
+        const transcriptPath = path.join(tmpDir, ".ade", "transcripts", `${args.sessionId}.log`);
+        fs.mkdirSync(path.dirname(transcriptPath), { recursive: true });
+        fs.writeFileSync(transcriptPath, "", "utf8");
+        sessionStore.set(args.sessionId, { id: args.sessionId, transcriptPath });
+        throw new Error("spawn ./missing-script.sh ENOENT");
+      }),
+      dispose: vi.fn(),
+      onData: vi.fn((listener: (event: { laneId: string; ptyId: string; sessionId: string; data: string }) => void) => {
+        dataListeners.add(listener);
+        return () => dataListeners.delete(listener);
+      }),
+      onExit: vi.fn((listener: (event: { laneId: string; ptyId: string; sessionId: string; exitCode: number | null }) => void) => {
+        exitListeners.add(listener);
+        return () => exitListeners.delete(listener);
+      }),
+    } as any;
+    const service = createProcessService({
+      db,
+      projectId,
+      logger,
+      laneService: {
+        getLaneWorktreePath: () => tmpDir,
+        list: async () => [makeLaneSummary(tmpDir, "lane-fail")],
+      } as any,
+      projectConfigService: {
+        get: () => config,
+        getEffective: () => config.effective,
+        getExecutableConfig: () => config.effective,
+      } as any,
+      sessionService: {
+        get: vi.fn((sessionId: string) => sessionStore.get(sessionId) ?? null),
+      } as any,
+      ptyService,
+      broadcastEvent: () => {},
+    });
+
+    try {
+      await expect(service.start({ laneId: "lane-fail", processId: "bad-command" })).rejects.toThrow("ENOENT");
+      const runtime = service.listRuntime("lane-fail")[0]!;
+      expect(runtime.status).toBe("crashed");
+      const tail = service.getLogTail({
+        laneId: "lane-fail",
+        processId: "bad-command",
+        runId: runtime.runId,
+      });
+      expect(tail).toContain("failed to start");
+      expect(tail).toContain("./missing-script.sh dev");
+      expect(tail).toContain("spawn ./missing-script.sh ENOENT");
+    } finally {
+      service.disposeAll();
+      db.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("getLogTail({ runId }) returns only the specified run's transcript", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ade-process-logtail-"));
     const dbPath = path.join(tmpDir, "kv.sqlite");

--- a/apps/desktop/src/main/services/processes/processService.test.ts
+++ b/apps/desktop/src/main/services/processes/processService.test.ts
@@ -1075,6 +1075,7 @@ describe("processService PTY-backed run commands", () => {
       });
       expect(tail).toContain("failed to start");
       expect(tail).toContain("./missing-script.sh dev");
+      expect(tail).toContain(`[ADE] Working directory: ${fs.realpathSync(tmpDir)}`);
       expect(tail).toContain("spawn ./missing-script.sh ENOENT");
     } finally {
       service.disposeAll();

--- a/apps/desktop/src/main/services/processes/processService.ts
+++ b/apps/desktop/src/main/services/processes/processService.ts
@@ -536,9 +536,10 @@ export function createProcessService({
   const handleStartFailure = (args: {
     entry: ManagedProcessEntry;
     startedAt: string;
+    cwd: string;
     error: unknown;
   }) => {
-    const { entry, startedAt, error } = args;
+    const { entry, startedAt, cwd, error } = args;
     const endedAt = nowIso();
     if (entry.sessionId) sessionToRunId.delete(entry.sessionId);
     if (entry.ptyId) ptyToRunId.delete(entry.ptyId);
@@ -555,6 +556,25 @@ export function createProcessService({
     entry.runtime.exitCode = null;
     entry.runtime.lastExitCode = null;
     entry.runtime.logPath = entry.transcriptPath;
+    if (entry.transcriptPath) {
+      try {
+        fs.mkdirSync(path.dirname(entry.transcriptPath), { recursive: true });
+        fs.appendFileSync(
+          entry.transcriptPath,
+          [
+            "",
+            `[ADE] Process '${entry.definition.name || entry.definition.id}' failed to start.`,
+            `[ADE] Command: ${entry.definition.command.join(" ")}`,
+            `[ADE] Working directory: ${cwd}`,
+            `[ADE] Error: ${error instanceof Error ? error.message : String(error)}`,
+            "",
+          ].join("\n"),
+          "utf8",
+        );
+      } catch {
+        // Best-effort: the renderer still receives the thrown startup error.
+      }
+    }
     emitRuntime(entry);
 
     upsertRunStart(entry.runId, entry.laneId, entry.processId, startedAt, entry.transcriptPath ?? "");
@@ -666,7 +686,7 @@ export function createProcessService({
       });
       return cloneRuntime(entry.runtime);
     } catch (error) {
-      handleStartFailure({ entry, startedAt, error });
+      handleStartFailure({ entry, startedAt, cwd, error });
       throw error;
     }
   };

--- a/apps/desktop/src/main/services/pty/ptyService.test.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.test.ts
@@ -479,6 +479,37 @@ describe("ptyService", () => {
       expect(mockPty.write).toHaveBeenCalledWith("codex --no-alt-screen \"ADE session guidance\"\r");
     });
 
+    it("falls back to a shell exec command when direct command spawn fails before a terminal attaches", async () => {
+      setPlatform("darwin");
+      const { service, mockPty, loadPty } = createHarness();
+      const spawn = vi.fn((command: string) => {
+        if (command === "./scripts/dogfood.sh") throw new Error("ENOENT");
+        return mockPty;
+      });
+      loadPty.mockImplementationOnce(() => ({ spawn: spawn as any }));
+
+      await service.create({
+        laneId: "lane-1",
+        title: "Run command",
+        cols: 80,
+        rows: 24,
+        command: "./scripts/dogfood.sh",
+        args: ["onboarding fixes", "quote's ok"],
+      });
+
+      expect(spawn).toHaveBeenCalledWith(
+        "./scripts/dogfood.sh",
+        ["onboarding fixes", "quote's ok"],
+        expect.any(Object),
+      );
+      expect(spawn).toHaveBeenCalledWith(
+        expect.stringMatching(/(?:zsh|bash|sh)$/),
+        expect.any(Array),
+        expect.any(Object),
+      );
+      expect(mockPty.write).toHaveBeenCalledWith("exec ./scripts/dogfood.sh 'onboarding fixes' 'quote'\\''s ok'\r");
+    });
+
     it("wraps direct Windows command shims through cmd.exe", async () => {
       setPlatform("win32");
       const harness = createHarness();

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -1579,7 +1579,8 @@ export function createPtyService({
             launchedDirectCommand = true;
           } catch (err) {
             lastErr = err;
-            startupCommand ||= buildDirectCommandShellFallback(directCommand, directArgs) ?? "";
+            const shellFallbackCmd = buildDirectCommandShellFallback(directCommand, directArgs);
+            if (shellFallbackCmd) startupCommand ||= shellFallbackCmd;
           }
         }
         if (!created && (!directCommand || startupCommand)) {

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -182,6 +182,17 @@ function resolveShellCandidates(): ShellSpec[] {
   return uniq.map((file) => ({ file, args: [] }));
 }
 
+function quotePosixShellArg(value: string): string {
+  if (!value.length) return "''";
+  if (/^[a-zA-Z0-9_./:@%+=,-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function buildDirectCommandShellFallback(command: string, args: string[]): string | null {
+  if (process.platform === "win32") return null;
+  return ["exec", command, ...args].map(quotePosixShellArg).join(" ");
+}
+
 function clampDims(cols: number, rows: number): { cols: number; rows: number } {
   const safeCols = Number.isFinite(cols) ? Math.max(20, Math.min(400, Math.floor(cols))) : 80;
   const safeRows = Number.isFinite(rows) ? Math.max(6, Math.min(200, Math.floor(rows))) : 24;
@@ -1568,6 +1579,7 @@ export function createPtyService({
             launchedDirectCommand = true;
           } catch (err) {
             lastErr = err;
+            startupCommand ||= buildDirectCommandShellFallback(directCommand, directArgs) ?? "";
           }
         }
         if (!created && (!directCommand || startupCommand)) {

--- a/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx
@@ -50,6 +50,8 @@ type ChatTerminalDrawerProps = {
   onToggle: () => void;
   laneId: string;
   chatSessionId?: string | null;
+  createRequestNonce?: number;
+  emptyMessage?: string;
   revealRequest?: {
     terminalId: string;
     ptyId: string;
@@ -125,6 +127,8 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
   onToggle,
   laneId,
   chatSessionId,
+  createRequestNonce = 0,
+  emptyMessage = "Create a terminal to start working in this chat.",
   revealRequest,
 }: ChatTerminalDrawerProps) {
   const uiStateKey = drawerStateKey(chatSessionId, laneId);
@@ -140,6 +144,9 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
   const pendingAutoCreateRef = useRef(false);
   const tabsRef = useRef<TabEntry[]>([]);
   const restoringUiStateRef = useRef(false);
+  const lastHandledCreateRequestRef = useRef(0);
+  const createRequestHandledThisOpenRef = useRef(false);
+  const revealHandledThisOpenRef = useRef(false);
   // revealRequest is edge-triggered (the parent re-uses the same prop slot
   // across renders). Track the (chatKey, nonce) we've already applied so a
   // stale request from a previous chat doesn't keep blocking the new chat's
@@ -278,6 +285,7 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
     );
     if (existing) {
       setActiveTabId(existing.id);
+      revealHandledThisOpenRef.current = true;
       return;
     }
     const tabId = `chat-term-${revealRequest.terminalId}`;
@@ -290,7 +298,16 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
     };
     setTabs((prev) => [...prev, nextEntry]);
     setActiveTabId(tabId);
+    revealHandledThisOpenRef.current = true;
   }, [revealRequest, uiStateKey]);
+
+  useEffect(() => {
+    if (!open || creatingTab || createRequestNonce <= 0 || lastHandledCreateRequestRef.current === createRequestNonce) return;
+    lastHandledCreateRequestRef.current = createRequestNonce;
+    pendingAutoCreateRef.current = false;
+    createRequestHandledThisOpenRef.current = true;
+    void createTab();
+  }, [createRequestNonce, createTab, creatingTab, open]);
 
   useEffect(() => {
     const wasOpen = previousOpenRef.current;
@@ -302,6 +319,16 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
     }
 
     if (!wasOpen) pendingAutoCreateRef.current = true;
+    if (createRequestHandledThisOpenRef.current) {
+      createRequestHandledThisOpenRef.current = false;
+      pendingAutoCreateRef.current = false;
+      return;
+    }
+    if (revealHandledThisOpenRef.current) {
+      revealHandledThisOpenRef.current = false;
+      pendingAutoCreateRef.current = false;
+      return;
+    }
     // Treat already-consumed reveal requests as null so switching chats with
     // a stale revealRequest in props doesn't block auto-create on the new
     // drawer.
@@ -329,7 +356,10 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
   }, [creatingTab, onToggle, open, tabs.length]);
 
   useEffect(() => {
-    const unsubscribe = window.ade.pty.onExit((ev: PtyExitEvent) => {
+    if (!open) return undefined;
+    const ptyBridge = window.ade?.pty;
+    if (!ptyBridge?.onExit) return undefined;
+    const unsubscribe = ptyBridge.onExit((ev: PtyExitEvent) => {
       setTabs((prev) => prev.map((tab) => (
         tab.ptyId === ev.ptyId
           ? { ...tab, exited: true }
@@ -337,7 +367,7 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
       )));
     });
     return unsubscribe;
-  }, []);
+  }, [open]);
 
   // Drop drawer tabs when their session is deleted from the sidebar so the user
   // can't keep working in a shell whose backing session no longer exists.
@@ -513,7 +543,7 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
           />
         ) : (
           <div className="flex h-full items-center justify-center px-4 font-mono text-[11px] text-muted-fg">
-            Create a terminal to start working in this chat.
+            {emptyMessage}
           </div>
         )}
       </div>

--- a/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx
@@ -356,7 +356,7 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
   }, [creatingTab, onToggle, open, tabs.length]);
 
   useEffect(() => {
-    if (!open) return undefined;
+    if (tabs.length === 0) return undefined;
     const ptyBridge = window.ade?.pty;
     if (!ptyBridge?.onExit) return undefined;
     const unsubscribe = ptyBridge.onExit((ev: PtyExitEvent) => {
@@ -367,7 +367,7 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
       )));
     });
     return unsubscribe;
-  }, [open]);
+  }, [tabs.length]);
 
   // Drop drawer tabs when their session is deleted from the sidebar so the user
   // can't keep working in a shell whose backing session no longer exists.

--- a/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx
@@ -50,8 +50,11 @@ type ChatTerminalDrawerProps = {
   onToggle: () => void;
   laneId: string;
   chatSessionId?: string | null;
+  autoCreateOnOpen?: boolean;
   createRequestNonce?: number;
+  disposeTabsOnUnmount?: boolean;
   emptyMessage?: string;
+  onCreateError?: (message: string) => void;
   revealRequest?: {
     terminalId: string;
     ptyId: string;
@@ -127,8 +130,11 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
   onToggle,
   laneId,
   chatSessionId,
+  autoCreateOnOpen = true,
   createRequestNonce = 0,
+  disposeTabsOnUnmount = false,
   emptyMessage = "Create a terminal to start working in this chat.",
+  onCreateError,
   revealRequest,
 }: ChatTerminalDrawerProps) {
   const uiStateKey = drawerStateKey(chatSessionId, laneId);
@@ -154,6 +160,11 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
   const lastHandledRevealRef = useRef<{ chatKey: string; nonce: number } | null>(null);
 
   tabsRef.current = tabs;
+
+  const reportCreateError = useCallback((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    onCreateError?.(message);
+  }, [onCreateError]);
 
   useEffect(() => {
     restoringUiStateRef.current = true;
@@ -227,10 +238,12 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
 
       setTabs((prev) => [...prev, nextEntry]);
       setActiveTabId(tabId);
+    } catch (error) {
+      reportCreateError(error);
     } finally {
       setCreatingTab(false);
     }
-  }, [chatSessionId, creatingTab, laneId]);
+  }, [chatSessionId, creatingTab, laneId, reportCreateError]);
 
   useEffect(() => {
     if (!chatSessionId) return;
@@ -335,7 +348,7 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
     const last = lastHandledRevealRef.current;
     const revealActive = revealRequest != null
       && !(last && last.chatKey === uiStateKey && last.nonce === revealRequest.nonce);
-    if (revealActive || tabs.length > 0) {
+    if (!autoCreateOnOpen || revealActive || tabs.length > 0) {
       pendingAutoCreateRef.current = false;
       return;
     }
@@ -343,7 +356,7 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
 
     pendingAutoCreateRef.current = false;
     void createTab();
-  }, [createTab, creatingTab, open, restoringTabs, revealRequest, tabs.length, uiStateKey]);
+  }, [autoCreateOnOpen, createTab, creatingTab, open, restoringTabs, revealRequest, tabs.length, uiStateKey]);
 
   useEffect(() => {
     if (tabs.length > 0) {
@@ -356,7 +369,6 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
   }, [creatingTab, onToggle, open, tabs.length]);
 
   useEffect(() => {
-    if (tabs.length === 0) return undefined;
     const ptyBridge = window.ade?.pty;
     if (!ptyBridge?.onExit) return undefined;
     const unsubscribe = ptyBridge.onExit((ev: PtyExitEvent) => {
@@ -367,7 +379,14 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
       )));
     });
     return unsubscribe;
-  }, [tabs.length]);
+  }, []);
+
+  useEffect(() => () => {
+    if (!disposeTabsOnUnmount) return;
+    for (const tab of tabsRef.current) {
+      window.ade.pty.dispose({ ptyId: tab.ptyId, sessionId: tab.sessionId }).catch(() => {});
+    }
+  }, [disposeTabsOnUnmount]);
 
   // Drop drawer tabs when their session is deleted from the sidebar so the user
   // can't keep working in a shell whose backing session no longer exists.

--- a/apps/desktop/src/renderer/components/run/CommandCard.tsx
+++ b/apps/desktop/src/renderer/components/run/CommandCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { DotsThreeVertical, Play, Plus, X } from "@phosphor-icons/react";
+import { DotsThreeVertical, Play, Plus, Terminal, X } from "@phosphor-icons/react";
 import type { LaneSummary, ProcessDefinition, ProcessGroupDefinition, ProcessRuntime } from "../../../shared/types";
 import { COLORS, MONO_FONT, inlineBadge, outlineButton, processStatusColor } from "../lanes/laneDesignTokens";
 import { useClickOutside } from "../../hooks/useClickOutside";
@@ -19,6 +19,7 @@ type CommandCardProps = {
   onDelete: (processId: string) => void;
   onAddToGroup?: (processId: string, groupId: string) => void;
   onKillRuntime?: (runtime: ProcessRuntime) => void;
+  onOpenRuntime?: (runtime: ProcessRuntime) => void;
 };
 
 function sortRuntimes(runtimes: ProcessRuntime[]): ProcessRuntime[] {
@@ -43,6 +44,7 @@ export function CommandCard({
   onDelete,
   onAddToGroup,
   onKillRuntime,
+  onOpenRuntime,
 }: CommandCardProps) {
   const hasLanes = lanes.length > 0;
   const laneId = selectedLaneId && lanes.some((item) => item.id === selectedLaneId)
@@ -418,6 +420,21 @@ export function CommandCard({
                   </button>
                 ))}
               </div>
+            ) : null}
+            {onOpenRuntime && latestRuntime.sessionId && latestRuntime.ptyId ? (
+              <button
+                type="button"
+                onClick={() => onOpenRuntime(latestRuntime)}
+                title="Open terminal"
+                aria-label={`Open terminal for run ${latestRuntime.runId}`}
+                style={{
+                  ...outlineButton({ height: 24, padding: "0 8px", fontSize: 9 }),
+                  marginLeft: activeRuntimes.length > 0 ? 0 : "auto",
+                }}
+              >
+                <Terminal size={12} weight="bold" />
+                Terminal
+              </button>
             ) : null}
           </div>
         ) : (

--- a/apps/desktop/src/renderer/components/run/RunPage.advancedDrawer.test.tsx
+++ b/apps/desktop/src/renderer/components/run/RunPage.advancedDrawer.test.tsx
@@ -23,6 +23,14 @@ vi.mock("./LaneRuntimeBar", () => {
   };
 });
 
+vi.mock("../terminals/TerminalView", () => {
+  const ReactMod = require("react") as typeof import("react");
+  return {
+    TerminalView: (props: { sessionId: string; ptyId: string }) =>
+      ReactMod.createElement("div", { "data-testid": "terminal-view" }, `${props.sessionId}:${props.ptyId}`),
+  };
+});
+
 const laneStatus = { dirty: false, ahead: 0, behind: 0, remoteBehind: 0, rebaseInProgress: false };
 
 const stubLane: LaneSummary = {
@@ -73,8 +81,9 @@ function installAdeStub() {
       stopGroup: vi.fn(),
     },
     pty: {
-      create: vi.fn(),
+      create: vi.fn().mockResolvedValue({ sessionId: "terminal-new", ptyId: "pty-new", pid: 1234 }),
       dispose: vi.fn().mockResolvedValue(undefined),
+      onExit: vi.fn(() => vi.fn()),
     },
     project: {
       listRecent: vi.fn().mockResolvedValue([]),
@@ -131,5 +140,75 @@ describe("RunPage Advanced lane runtime drawer", () => {
     const toggle = screen.getByRole("button", { name: /^advanced$/i });
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
     await waitFor(() => expect(mocks.laneBarSpy).toHaveBeenCalled());
+  });
+
+  it("uses the shared terminal drawer when opening a run shell", async () => {
+    render(<RunPage />);
+    fireEvent.click(screen.getByRole("button", { name: /new shell/i }));
+
+    await waitFor(() => {
+      expect(vi.mocked((window as unknown as { ade: { pty: { create: ReturnType<typeof vi.fn> } } }).ade.pty.create)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          laneId: "lane-a",
+          toolType: "shell",
+          tracked: true,
+        }),
+      );
+    });
+    expect((await screen.findByTestId("terminal-view")).textContent).toBe("terminal-new:pty-new");
+  });
+
+  it("reveals a run command terminal returned by the process service", async () => {
+    const definition = {
+      id: "proc-1",
+      name: "Dev server",
+      command: ["npm", "run", "dev"],
+      cwd: ".",
+      env: {},
+      groupIds: [],
+      autostart: false,
+      restart: "never",
+      gracefulShutdownMs: 7000,
+      dependsOn: [],
+      readiness: { type: "none" as const },
+    };
+    const runtime = {
+      runId: "run-1",
+      laneId: "lane-a",
+      processId: "proc-1",
+      status: "running" as const,
+      readiness: "unknown" as const,
+      pid: 4321,
+      sessionId: "terminal-run",
+      ptyId: "pty-run",
+      startedAt: "2026-04-30T12:00:00.000Z",
+      endedAt: null,
+      exitCode: null,
+      lastExitCode: null,
+      lastEndedAt: null,
+      uptimeMs: 0,
+      ports: [],
+      logPath: null,
+      updatedAt: "2026-04-30T12:00:00.000Z",
+    };
+    const ade = (window as unknown as { ade: {
+      projectConfig: { get: ReturnType<typeof vi.fn> };
+      processes: { listDefinitions: ReturnType<typeof vi.fn>; start: ReturnType<typeof vi.fn> };
+    } }).ade;
+    ade.projectConfig.get.mockResolvedValue({
+      effective: { processGroups: [] },
+      shared: { processGroups: [], processes: [definition] },
+      local: { processGroups: [], processes: [] },
+    });
+    ade.processes.listDefinitions.mockResolvedValue([definition]);
+    ade.processes.start.mockResolvedValue(runtime);
+
+    render(<RunPage />);
+    fireEvent.click(await screen.findByRole("button", { name: /^Run$/i }));
+
+    await waitFor(() => {
+      expect(ade.processes.start).toHaveBeenCalledWith({ laneId: "lane-a", processId: "proc-1" });
+    });
+    expect((await screen.findByTestId("terminal-view")).textContent).toBe("terminal-run:pty-run");
   });
 });

--- a/apps/desktop/src/renderer/components/run/RunPage.advancedDrawer.test.tsx
+++ b/apps/desktop/src/renderer/components/run/RunPage.advancedDrawer.test.tsx
@@ -158,6 +158,37 @@ describe("RunPage Advanced lane runtime drawer", () => {
     expect((await screen.findByTestId("terminal-view")).textContent).toBe("terminal-new:pty-new");
   });
 
+  it("opens the terminal drawer without creating a shell from the plain toggle", async () => {
+    render(<RunPage />);
+    fireEvent.click(screen.getByRole("button", { name: /^terminal$/i }));
+
+    expect(await screen.findByText("Open a shell or run a command to attach a terminal.")).toBeTruthy();
+    expect(vi.mocked((window as unknown as { ade: { pty: { create: ReturnType<typeof vi.fn> } } }).ade.pty.create)).not.toHaveBeenCalled();
+  });
+
+  it("surfaces shell creation failures from the shared terminal drawer", async () => {
+    const create = vi.mocked((window as unknown as { ade: { pty: { create: ReturnType<typeof vi.fn> } } }).ade.pty.create);
+    create.mockRejectedValueOnce(new Error("missing shell"));
+
+    render(<RunPage />);
+    fireEvent.click(screen.getByRole("button", { name: /new shell/i }));
+
+    expect(await screen.findByText("missing shell")).toBeTruthy();
+  });
+
+  it("disposes run shell terminals when RunPage unmounts", async () => {
+    const { unmount } = render(<RunPage />);
+    fireEvent.click(screen.getByRole("button", { name: /new shell/i }));
+    expect((await screen.findByTestId("terminal-view")).textContent).toBe("terminal-new:pty-new");
+
+    unmount();
+
+    expect(vi.mocked((window as unknown as { ade: { pty: { dispose: ReturnType<typeof vi.fn> } } }).ade.pty.dispose)).toHaveBeenCalledWith({
+      ptyId: "pty-new",
+      sessionId: "terminal-new",
+    });
+  });
+
   it("reveals a run command terminal returned by the process service", async () => {
     const definition = {
       id: "proc-1",

--- a/apps/desktop/src/renderer/components/run/RunPage.tsx
+++ b/apps/desktop/src/renderer/components/run/RunPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { CaretDown, CaretUp, Folder, FolderOpen, Play, Plus, Stop, Terminal, X } from "@phosphor-icons/react";
+import { CaretDown, CaretUp, Folder, FolderOpen, Play, Plus, Stop, Terminal } from "@phosphor-icons/react";
 import { useAppStore } from "../../state/appStore";
 import { COLORS, LABEL_STYLE, MONO_FONT, SANS_FONT, outlineButton, primaryButton } from "../lanes/laneDesignTokens";
 import { CommandCard } from "./CommandCard";
@@ -10,6 +10,8 @@ import { RunNetworkPanel } from "./RunNetworkPanel";
 import { commandArrayToLine, parseCommandLine } from "../../lib/shell";
 import { logRendererDebugEvent } from "../../lib/debugLog";
 import { toRelativeTime } from "../graph/graphHelpers";
+import { isActiveProcessStatus } from "./processUtils";
+import { ChatTerminalDrawer, ChatTerminalToggle } from "../chat/ChatTerminalDrawer";
 import type {
   ConfigProcessDefinition,
   ProcessDefinition,
@@ -24,13 +26,6 @@ import type {
 function generateId(): string {
   return Math.random().toString(36).slice(2, 10);
 }
-
-type RunShellSession = {
-  sessionId: string;
-  ptyId: string;
-  title: string;
-  laneId: string;
-};
 
 function parseEnvText(text: string): Record<string, string> | undefined {
   const trimmed = text.trim();
@@ -407,12 +402,19 @@ export function RunPage() {
   const [loading, setLoading] = useState(false);
   const [editingProcess, setEditingProcess] = useState<{ id: string; values: AddCommandInitialValues } | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
-  const [runShellSessions, setRunShellSessions] = useState<RunShellSession[]>([]);
-  const [shellBusy, setShellBusy] = useState(false);
   const [networkDrawerOpen, setNetworkDrawerOpen] = useState(false);
   const [laneRuntimeBarOpen, setLaneRuntimeBarOpen] = useState(readLaneRuntimeBarOpenFromStorage);
+  const [terminalDrawerOpen, setTerminalDrawerOpen] = useState(false);
+  const [terminalCreateRequestNonce, setTerminalCreateRequestNonce] = useState(0);
+  const [terminalRevealRequest, setTerminalRevealRequest] = useState<{
+    terminalId: string;
+    ptyId: string;
+    label: string;
+    nonce: number;
+  } | null>(null);
   const runtimeRefreshTimerRef = useRef<number | null>(null);
-  const runShellSessionsRef = useRef<RunShellSession[]>([]);
+  const pendingRunLaunchRef = useRef<{ laneId: string; processId: string } | null>(null);
+  const terminalRevealNonceRef = useRef(0);
 
   const fallbackRunLaneId = useMemo(
     () => lanes.find((lane) => lane.laneType === "primary")?.id ?? lanes[0]?.id ?? null,
@@ -469,27 +471,12 @@ export function RunPage() {
     });
   }, [definitions, lanes, projectRoot, refreshLanePersistence]);
 
-  runShellSessionsRef.current = runShellSessions;
-
-  const disposeRunShellSessions = useCallback(async (sessions: RunShellSession[]) => {
-    if (sessions.length === 0) return;
-    await Promise.allSettled(
-      sessions.map((session) => window.ade.pty.dispose({ ptyId: session.ptyId, sessionId: session.sessionId })),
-    );
-  }, []);
-
   useEffect(() => {
     logRendererDebugEvent("renderer.run.page_mount");
     return () => {
       logRendererDebugEvent("renderer.run.page_unmount");
     };
   }, []);
-
-  useEffect(() => {
-    return () => {
-      void disposeRunShellSessions(runShellSessionsRef.current);
-    };
-  }, [disposeRunShellSessions]);
 
   const refreshDefinitions = useCallback(async () => {
     if (showWelcome) {
@@ -521,7 +508,6 @@ export function RunPage() {
     const laneIds = Array.from(
       new Set([
         ...Object.values(commandLaneMap),
-        ...runShellSessions.map((session) => session.laneId),
       ].filter((value): value is string => Boolean(value))),
     );
     if (laneIds.length === 0) {
@@ -537,7 +523,7 @@ export function RunPage() {
     } catch (error) {
       console.error("RunPage.refreshRuntime", error);
     }
-  }, [commandLaneMap, runShellSessions, showWelcome]);
+  }, [commandLaneMap, showWelcome]);
 
   useEffect(() => {
     if (showWelcome) return;
@@ -575,22 +561,47 @@ export function RunPage() {
     };
   }, [refreshRuntime]);
 
+  const upsertRuntime = useCallback((nextRuntime: ProcessRuntime) => {
+    setRuntime((current) => {
+      const next = [...current];
+      const index = next.findIndex((runtimeItem) => runtimeItem.runId === nextRuntime.runId);
+      if (index >= 0) {
+        next[index] = nextRuntime;
+      } else {
+        next.unshift(nextRuntime);
+      }
+      return next;
+    });
+  }, []);
+
+  const revealRuntimeTerminal = useCallback((runtimeItem: ProcessRuntime): boolean => {
+    if (!runtimeItem.sessionId || !runtimeItem.ptyId) return false;
+    const definition = definitions.find((item) => item.id === runtimeItem.processId);
+    const lane = lanes.find((item) => item.id === runtimeItem.laneId);
+    terminalRevealNonceRef.current += 1;
+    setTerminalDrawerOpen(true);
+    setTerminalRevealRequest({
+      terminalId: runtimeItem.sessionId,
+      ptyId: runtimeItem.ptyId,
+      label: definition?.name ?? lane?.name ?? "Run command",
+      nonce: terminalRevealNonceRef.current,
+    });
+    return true;
+  }, [definitions, lanes]);
+
   useEffect(() => {
     const unsubscribe = window.ade.processes.onEvent((event: ProcessEvent) => {
       if (event.type !== "runtime") return;
-      setRuntime((current) => {
-        const next = [...current];
-        const index = next.findIndex((runtimeItem) => runtimeItem.runId === event.runtime.runId);
-        if (index >= 0) {
-          next[index] = event.runtime;
-        } else {
-          next.unshift(event.runtime);
+      upsertRuntime(event.runtime);
+      const pending = pendingRunLaunchRef.current;
+      if (pending?.laneId === event.runtime.laneId && pending.processId === event.runtime.processId) {
+        if (revealRuntimeTerminal(event.runtime) || !isActiveProcessStatus(event.runtime.status)) {
+          pendingRunLaunchRef.current = null;
         }
-        return next;
-      });
+      }
     });
     return unsubscribe;
-  }, []);
+  }, [revealRuntimeTerminal, upsertRuntime]);
 
   const resolveProcessLaneId = useCallback((processId: string): string | null => {
     return commandLaneMap[processId] ?? fallbackRunLaneId ?? null;
@@ -624,14 +635,23 @@ export function RunPage() {
   const handleRun = useCallback(async (processId: string) => {
     const laneId = resolveProcessLaneId(processId);
     if (!laneId) return;
+    pendingRunLaunchRef.current = { laneId, processId };
     try {
       setActionError(null);
-      await startProcess(processId, laneId);
+      const started = await startProcess(processId, laneId);
+      upsertRuntime(started);
+      if (revealRuntimeTerminal(started)) {
+        pendingRunLaunchRef.current = null;
+      }
     } catch (error) {
+      const pending = pendingRunLaunchRef.current;
+      if (pending?.laneId === laneId && pending.processId === processId) {
+        pendingRunLaunchRef.current = null;
+      }
       setActionError(error instanceof Error ? error.message : String(error));
       console.error("[RunPage] handleRun failed:", error);
     }
-  }, [resolveProcessLaneId, startProcess]);
+  }, [resolveProcessLaneId, revealRuntimeTerminal, startProcess, upsertRuntime]);
 
   const handleKillRuntime = useCallback(async (runtimeItem: ProcessRuntime) => {
     try {
@@ -646,6 +666,12 @@ export function RunPage() {
       console.error("[RunPage] handleKillRuntime failed:", error);
     }
   }, []);
+
+  const handleOpenRuntimeTerminal = useCallback((runtimeItem: ProcessRuntime) => {
+    setActionError(null);
+    if (revealRuntimeTerminal(runtimeItem)) return;
+    setActionError("This run no longer has a live terminal attached.");
+  }, [revealRuntimeTerminal]);
 
   const buildLaneMapForSelectedGroup = useCallback((): Record<string, string> | null => {
     if (!selectedGroupId) return null;
@@ -715,41 +741,12 @@ export function RunPage() {
     }
   }, [config, newGroupName, refreshDefinitions]);
 
-  const handleLaunchShell = useCallback(async () => {
-    const laneId = fallbackRunLaneId;
-    if (!laneId || shellBusy) return;
-    setShellBusy(true);
+  const handleLaunchShell = useCallback(() => {
+    if (!fallbackRunLaneId) return;
     setActionError(null);
-    try {
-      const existingCount = runShellSessionsRef.current.length;
-      const title = existingCount > 0 ? `Shell ${existingCount + 1}` : "Shell";
-      const result = await window.ade.pty.create({
-        laneId,
-        cols: 100,
-        rows: 30,
-        title,
-        tracked: false,
-        toolType: "shell",
-      });
-      const session: RunShellSession = { sessionId: result.sessionId, ptyId: result.ptyId, title, laneId };
-      setRunShellSessions((current) => [...current, session]);
-    } catch (error) {
-      setActionError(error instanceof Error ? error.message : String(error));
-    } finally {
-      setShellBusy(false);
-    }
-  }, [fallbackRunLaneId, shellBusy]);
-
-  const handleCloseRunShell = useCallback(async (sessionId: string) => {
-    const target = runShellSessionsRef.current.find((session) => session.sessionId === sessionId);
-    setRunShellSessions((current) => current.filter((session) => session.sessionId !== sessionId));
-    if (!target) return;
-    try {
-      await window.ade.pty.dispose({ ptyId: target.ptyId, sessionId: target.sessionId });
-    } catch {
-      // ignore shell disposal failures in the Run tab
-    }
-  }, []);
+    setTerminalCreateRequestNonce((nonce) => nonce + 1);
+    setTerminalDrawerOpen(true);
+  }, [fallbackRunLaneId]);
 
   const saveProcessToConfig = useCallback(async (cmd: AddCommandSubmitPayload) => {
     if (!config) {
@@ -937,19 +934,23 @@ export function RunPage() {
           Advanced
         </button>
 
+        {fallbackRunLaneId ? (
+          <ChatTerminalToggle open={terminalDrawerOpen} onToggle={() => setTerminalDrawerOpen((open) => !open)} />
+        ) : null}
+
         <button
           type="button"
           data-tour="run.newShell"
-          onClick={() => void handleLaunchShell()}
-          disabled={!fallbackRunLaneId || shellBusy}
+          onClick={handleLaunchShell}
+          disabled={!fallbackRunLaneId}
           style={{
             ...outlineButton(),
-            opacity: fallbackRunLaneId && !shellBusy ? 1 : 0.45,
-            cursor: fallbackRunLaneId && !shellBusy ? "pointer" : "default",
+            opacity: fallbackRunLaneId ? 1 : 0.45,
+            cursor: fallbackRunLaneId ? "pointer" : "default",
           }}
         >
           <Terminal size={14} weight="bold" />
-          {shellBusy ? "Opening shell..." : "New shell"}
+          New shell
         </button>
 
         {selectedGroupId ? (
@@ -1195,6 +1196,7 @@ export function RunPage() {
                     onDelete={handleDeleteProcess}
                     onAddToGroup={handleAddProcessToGroup}
                     onKillRuntime={handleKillRuntime}
+                    onOpenRuntime={handleOpenRuntimeTerminal}
                   />
                 );
               })}
@@ -1220,73 +1222,15 @@ export function RunPage() {
         ) : null}
       </div>
 
-      {runShellSessions.length > 0 ? (
-        <div
-          data-tour="run.shellSessions"
-          style={{
-            flexShrink: 0,
-            display: "flex",
-            flexWrap: "wrap",
-            alignItems: "center",
-            gap: 10,
-            padding: "10px 20px",
-            borderTop: `1px solid ${COLORS.border}`,
-            background: COLORS.recessedBg,
-          }}
-        >
-          <span
-            style={{
-              fontFamily: MONO_FONT,
-              fontSize: 9,
-              fontWeight: 700,
-              color: COLORS.textDim,
-              textTransform: "uppercase",
-              letterSpacing: "0.08em",
-            }}
-          >
-            Shells
-          </span>
-          {runShellSessions.map((session) => {
-            const shellLaneName = lanes.find((item) => item.id === session.laneId)?.name ?? session.laneId;
-            return (
-              <div
-                key={session.sessionId}
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 8,
-                  padding: "4px 10px",
-                  background: COLORS.pageBg,
-                  border: `1px solid ${COLORS.border}`,
-                }}
-              >
-                <Terminal size={14} weight="bold" style={{ color: COLORS.textMuted, flexShrink: 0 }} />
-                <span style={{ fontFamily: MONO_FONT, fontSize: 11, color: COLORS.textPrimary }}>{session.title}</span>
-                <span style={{ fontFamily: MONO_FONT, fontSize: 10, color: COLORS.textDim }}>{shellLaneName}</span>
-                <button
-                  type="button"
-                  onClick={() => {
-                    void handleCloseRunShell(session.sessionId);
-                  }}
-                  aria-label={`Close ${session.title}`}
-                  style={{
-                    width: 26,
-                    height: 26,
-                    background: "transparent",
-                    border: "none",
-                    color: COLORS.textMuted,
-                    cursor: "pointer",
-                    display: "inline-flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
-                  <X size={14} weight="bold" />
-                </button>
-              </div>
-            );
-          })}
-        </div>
+      {fallbackRunLaneId ? (
+        <ChatTerminalDrawer
+          open={terminalDrawerOpen}
+          onToggle={() => setTerminalDrawerOpen((open) => !open)}
+          laneId={fallbackRunLaneId}
+          revealRequest={terminalRevealRequest}
+          createRequestNonce={terminalCreateRequestNonce}
+          emptyMessage="Open a shell or run a command to attach a terminal."
+        />
       ) : null}
 
       <AddCommandDialog

--- a/apps/desktop/src/renderer/components/run/RunPage.tsx
+++ b/apps/desktop/src/renderer/components/run/RunPage.tsx
@@ -1227,9 +1227,12 @@ export function RunPage() {
           open={terminalDrawerOpen}
           onToggle={() => setTerminalDrawerOpen((open) => !open)}
           laneId={fallbackRunLaneId}
+          autoCreateOnOpen={false}
           revealRequest={terminalRevealRequest}
           createRequestNonce={terminalCreateRequestNonce}
+          disposeTabsOnUnmount
           emptyMessage="Open a shell or run a command to attach a terminal."
+          onCreateError={setActionError}
         />
       ) : null}
 


### PR DESCRIPTION
## Summary
- Surface PTY startup failures in the run transcript so users see what failed instead of a silent empty card
- Tighten run-tab UI: CommandCard, RunPage, and ChatTerminalDrawer behavior cleanups
- Add tests covering PTY startup failure paths and advanced drawer behavior

## Test plan
- [ ] Unit tests pass (processService, ptyService, RunPage advanced drawer)
- [ ] Manually run a command that fails to spawn — error is written to transcript
- [ ] Manually verify run tab UI still works for normal commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Terminal" button to command cards for quick access to live process terminals.
  * Introduced a dedicated terminal drawer for improved terminal interface management.

* **Bug Fixes**
  * Enhanced error reporting for process startup failures with detailed diagnostic logs.
  * Added shell execution fallback for improved command compatibility on non-Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR surfaces PTY startup failures into the run transcript (with diagnostic details like command, cwd, and error message), adds a shell-exec fallback for non-Windows systems when direct PTY spawn fails, and replaces the inline shell-session list in `RunPage` with the shared `ChatTerminalDrawer`. A new "Terminal" button on `CommandCard` lets users open a live terminal for any running process.

- **P1 — `disposeTabsOnUnmount=true` disposes process-backed PTYs:** When a user clicks the "Terminal" button on a `CommandCard`, the run-command's PTY is added to the drawer's tab list. On `RunPage` unmount the cleanup disposes every tab indiscriminately, which kills live run-command processes (e.g. `npm run dev`) that should persist in the background. Only interactive shell tabs created via "New shell" need cleanup.
- **P2 — `tracked` flag silently changed:** The old `handleLaunchShell` used `tracked: false`; `ChatTerminalDrawer.createTab` always uses `tracked: true`. If this is intentional, a note in the code would help.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — navigating away from RunPage with an open run-command terminal will kill the underlying process.

One P1 defect: disposeTabsOnUnmount=true disposes all drawer tabs on unmount, including PTYs that back live run-command processes. Navigating away from RunPage after clicking Terminal on a running command silently kills it. The rest of the changes are well-structured with good test coverage.

apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx — the disposeTabsOnUnmount cleanup effect and the createTab tracked value both need review.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx | Adds autoCreateOnOpen, createRequestNonce, disposeTabsOnUnmount, emptyMessage, and onCreateError props. disposeTabsOnUnmount=true disposes ALL tabs on unmount, including process-backed PTYs revealed from run commands — this can kill live processes on navigation. |
| apps/desktop/src/renderer/components/run/RunPage.tsx | Replaces inline shell session list with ChatTerminalDrawer. Adds revealRuntimeTerminal, upsertRuntime, and handleOpenRuntimeTerminal. The disposeTabsOnUnmount prop correctly cleans up shells on unmount, but also disposes run-command PTYs. |
| apps/desktop/src/main/services/processes/processService.ts | Adds cwd to handleStartFailure and writes a diagnostic block to the transcript on PTY startup failures. Best-effort write is correctly wrapped in try/catch. |
| apps/desktop/src/main/services/pty/ptyService.ts | Adds quotePosixShellArg and buildDirectCommandShellFallback. When direct-command spawn fails on non-Windows, falls back to spawning a shell and sending exec <command> as a startup command. Logic is sound. |
| apps/desktop/src/renderer/components/run/CommandCard.tsx | Adds optional onOpenRuntime prop; renders a Terminal button when the latest runtime has both sessionId and ptyId. Clean, safe addition. |
| apps/desktop/src/main/services/processes/processService.test.ts | Adds test covering PTY startup failure writing to transcript. Test structure mirrors existing patterns and assertions are thorough. |
| apps/desktop/src/main/services/pty/ptyService.test.ts | Adds test for shell fallback when direct command spawn fails. Verifies both the failed direct spawn call and the subsequent shell spawn with exec startup command. |
| apps/desktop/src/renderer/components/run/RunPage.advancedDrawer.test.tsx | Expands drawer test suite with scenarios: shared terminal drawer for new shells, plain toggle without auto-create, shell creation failure surfacing, unmount disposal, and runtime terminal reveal. Coverage is solid. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant RunPage
    participant ChatTerminalDrawer
    participant processService
    participant ptyService

    User->>RunPage: Click Run on CommandCard
    RunPage->>processService: start({ laneId, processId })
    processService->>ptyService: create(...)
    alt PTY spawn succeeds
        ptyService-->>processService: { ptyId, sessionId }
        processService-->>RunPage: ProcessRuntime { ptyId, sessionId }
        RunPage->>ChatTerminalDrawer: revealRequest (ptyId, sessionId)
        ChatTerminalDrawer->>ChatTerminalDrawer: addTab(ptyId) — now tracked by drawer
    else PTY spawn fails
        ptyService->>ptyService: buildDirectCommandShellFallback()
        ptyService->>ptyService: spawn shell + exec cmd
        ptyService-->>processService: throws Error
        processService->>processService: handleStartFailure → write to transcript
        processService-->>RunPage: throws Error
        RunPage->>RunPage: setActionError
    end

    User->>RunPage: Navigate away (unmount)
    RunPage->>ChatTerminalDrawer: unmount (disposeTabsOnUnmount=true)
    ChatTerminalDrawer->>ptyService: dispose(all tabs) — kills process-backed PTYs too
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx`, line 359-364 ([link](https://github.com/arul28/ade/blob/d625dac772aebfae68251c828d74606ccf9d00ba/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx#L359-L364)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`disposeTabsOnUnmount` kills process-backed PTYs alongside interactive shells**

   When a user clicks the "Terminal" button on a `CommandCard`, `revealRuntimeTerminal` adds a tab with the run command's `ptyId` to this drawer. With `disposeTabsOnUnmount=true`, **all** tabs are disposed on `RunPage` unmount — including those attached to live run-command processes. Disposing a process-backed PTY signals the process manager that the PTY has exited, which marks the process as `crashed`. A user who opens `npm run dev` in the terminal drawer and then navigates away would silently kill the process.

   Only interactive shell tabs (those created via "New shell") should be disposed on unmount; tabs revealed from existing run-command PTYs should be left alone. One approach: add a `source: "shell" | "process"` field to `TabEntry` so the cleanup can skip process-backed tabs:

   ```typescript
   if (!disposeTabsOnUnmount) return;
   for (const tab of tabsRef.current) {
     if (tab.source === "process") continue; // let processService manage its own PTYs
     window.ade.pty.dispose({ ptyId: tab.ptyId, sessionId: tab.sessionId }).catch(() => {});
   }
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx
   Line: 359-364

   Comment:
   **`disposeTabsOnUnmount` kills process-backed PTYs alongside interactive shells**

   When a user clicks the "Terminal" button on a `CommandCard`, `revealRuntimeTerminal` adds a tab with the run command's `ptyId` to this drawer. With `disposeTabsOnUnmount=true`, **all** tabs are disposed on `RunPage` unmount — including those attached to live run-command processes. Disposing a process-backed PTY signals the process manager that the PTY has exited, which marks the process as `crashed`. A user who opens `npm run dev` in the terminal drawer and then navigates away would silently kill the process.

   Only interactive shell tabs (those created via "New shell") should be disposed on unmount; tabs revealed from existing run-command PTYs should be left alone. One approach: add a `source: "shell" | "process"` field to `TabEntry` so the cleanup can skip process-backed tabs:

   ```typescript
   if (!disposeTabsOnUnmount) return;
   for (const tab of tabsRef.current) {
     if (tab.source === "process") continue; // let processService manage its own PTYs
     window.ade.pty.dispose({ ptyId: tab.ptyId, sessionId: tab.sessionId }).catch(() => {});
   }
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FChatTerminalDrawer.tsx%0ALine%3A%20359-364%0A%0AComment%3A%0A**%60disposeTabsOnUnmount%60%20kills%20process-backed%20PTYs%20alongside%20interactive%20shells**%0A%0AWhen%20a%20user%20clicks%20the%20%22Terminal%22%20button%20on%20a%20%60CommandCard%60%2C%20%60revealRuntimeTerminal%60%20adds%20a%20tab%20with%20the%20run%20command's%20%60ptyId%60%20to%20this%20drawer.%20With%20%60disposeTabsOnUnmount%3Dtrue%60%2C%20**all**%20tabs%20are%20disposed%20on%20%60RunPage%60%20unmount%20%E2%80%94%20including%20those%20attached%20to%20live%20run-command%20processes.%20Disposing%20a%20process-backed%20PTY%20signals%20the%20process%20manager%20that%20the%20PTY%20has%20exited%2C%20which%20marks%20the%20process%20as%20%60crashed%60.%20A%20user%20who%20opens%20%60npm%20run%20dev%60%20in%20the%20terminal%20drawer%20and%20then%20navigates%20away%20would%20silently%20kill%20the%20process.%0A%0AOnly%20interactive%20shell%20tabs%20%28those%20created%20via%20%22New%20shell%22%29%20should%20be%20disposed%20on%20unmount%3B%20tabs%20revealed%20from%20existing%20run-command%20PTYs%20should%20be%20left%20alone.%20One%20approach%3A%20add%20a%20%60source%3A%20%22shell%22%20%7C%20%22process%22%60%20field%20to%20%60TabEntry%60%20so%20the%20cleanup%20can%20skip%20process-backed%20tabs%3A%0A%0A%60%60%60typescript%0Aif%20%28!disposeTabsOnUnmount%29%20return%3B%0Afor%20%28const%20tab%20of%20tabsRef.current%29%20%7B%0A%20%20if%20%28tab.source%20%3D%3D%3D%20%22process%22%29%20continue%3B%20%2F%2F%20let%20processService%20manage%20its%20own%20PTYs%0A%20%20window.ade.pty.dispose%28%7B%20ptyId%3A%20tab.ptyId%2C%20sessionId%3A%20tab.sessionId%20%7D%29.catch%28%28%29%20%3D%3E%20%7B%7D%29%3B%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FChatTerminalDrawer.tsx%3A359-364%0A**%60disposeTabsOnUnmount%60%20kills%20process-backed%20PTYs%20alongside%20interactive%20shells**%0A%0AWhen%20a%20user%20clicks%20the%20%22Terminal%22%20button%20on%20a%20%60CommandCard%60%2C%20%60revealRuntimeTerminal%60%20adds%20a%20tab%20with%20the%20run%20command's%20%60ptyId%60%20to%20this%20drawer.%20With%20%60disposeTabsOnUnmount%3Dtrue%60%2C%20**all**%20tabs%20are%20disposed%20on%20%60RunPage%60%20unmount%20%E2%80%94%20including%20those%20attached%20to%20live%20run-command%20processes.%20Disposing%20a%20process-backed%20PTY%20signals%20the%20process%20manager%20that%20the%20PTY%20has%20exited%2C%20which%20marks%20the%20process%20as%20%60crashed%60.%20A%20user%20who%20opens%20%60npm%20run%20dev%60%20in%20the%20terminal%20drawer%20and%20then%20navigates%20away%20would%20silently%20kill%20the%20process.%0A%0AOnly%20interactive%20shell%20tabs%20%28those%20created%20via%20%22New%20shell%22%29%20should%20be%20disposed%20on%20unmount%3B%20tabs%20revealed%20from%20existing%20run-command%20PTYs%20should%20be%20left%20alone.%20One%20approach%3A%20add%20a%20%60source%3A%20%22shell%22%20%7C%20%22process%22%60%20field%20to%20%60TabEntry%60%20so%20the%20cleanup%20can%20skip%20process-backed%20tabs%3A%0A%0A%60%60%60typescript%0Aif%20%28!disposeTabsOnUnmount%29%20return%3B%0Afor%20%28const%20tab%20of%20tabsRef.current%29%20%7B%0A%20%20if%20%28tab.source%20%3D%3D%3D%20%22process%22%29%20continue%3B%20%2F%2F%20let%20processService%20manage%20its%20own%20PTYs%0A%20%20window.ade.pty.dispose%28%7B%20ptyId%3A%20tab.ptyId%2C%20sessionId%3A%20tab.sessionId%20%7D%29.catch%28%28%29%20%3D%3E%20%7B%7D%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FChatTerminalDrawer.tsx%3A221-229%0A**%60tracked%3A%20true%60%20silently%20changes%20shell%20session%20behavior%20from%20previous%20implementation**%0A%0AThe%20old%20%60handleLaunchShell%60%20in%20%60RunPage%60%20explicitly%20created%20shells%20with%20%60tracked%3A%20false%60.%20%60ChatTerminalDrawer.createTab%60%20always%20uses%20%60tracked%3A%20true%60.%20Run-tab%20shells%20are%20now%20tracked%2C%20which%20may%20attach%20them%20to%20session%20history%20or%20other%20tracked-session%20flows%20%28e.g.%2C%20the%20%60terminal.list%60%20restore%20path%20that%20guards%20on%20%60chatSessionId%60%29.%20If%20%22tracked%22%20implies%20inclusion%20in%20session-level%20persistence%20or%20IPC%20broadcasts%20that%20weren't%20expected%20for%20ephemeral%20run-tab%20shells%2C%20this%20could%20produce%20side%20effects.%20If%20this%20change%20is%20intentional%2C%20a%20comment%20noting%20the%20deliberate%20switch%20from%20%60false%60%20to%20%60true%60%20would%20help%20reviewers.%0A%0A&repo=arul28%2Fade&pr=222&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx:359-364
**`disposeTabsOnUnmount` kills process-backed PTYs alongside interactive shells**

When a user clicks the "Terminal" button on a `CommandCard`, `revealRuntimeTerminal` adds a tab with the run command's `ptyId` to this drawer. With `disposeTabsOnUnmount=true`, **all** tabs are disposed on `RunPage` unmount — including those attached to live run-command processes. Disposing a process-backed PTY signals the process manager that the PTY has exited, which marks the process as `crashed`. A user who opens `npm run dev` in the terminal drawer and then navigates away would silently kill the process.

Only interactive shell tabs (those created via "New shell") should be disposed on unmount; tabs revealed from existing run-command PTYs should be left alone. One approach: add a `source: "shell" | "process"` field to `TabEntry` so the cleanup can skip process-backed tabs:

```typescript
if (!disposeTabsOnUnmount) return;
for (const tab of tabsRef.current) {
  if (tab.source === "process") continue; // let processService manage its own PTYs
  window.ade.pty.dispose({ ptyId: tab.ptyId, sessionId: tab.sessionId }).catch(() => {});
}
```

### Issue 2 of 2
apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx:221-229
**`tracked: true` silently changes shell session behavior from previous implementation**

The old `handleLaunchShell` in `RunPage` explicitly created shells with `tracked: false`. `ChatTerminalDrawer.createTab` always uses `tracked: true`. Run-tab shells are now tracked, which may attach them to session history or other tracked-session flows (e.g., the `terminal.list` restore path that guards on `chatSessionId`). If "tracked" implies inclusion in session-level persistence or IPC broadcasts that weren't expected for ephemeral run-tab shells, this could produce side effects. If this change is intentional, a comment noting the deliberate switch from `false` to `true` would help reviewers.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["ship: checkpoint before merging main int..."](https://github.com/arul28/ade/commit/d625dac772aebfae68251c828d74606ccf9d00ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30412638)</sub>

<!-- /greptile_comment -->