### PR TITLE
release: changelog for v1.1.10

### DIFF
--- a/changelog/v1.1.10.mdx
+++ b/changelog/v1.1.10.mdx
@@ -1,0 +1,52 @@
+---
+title: "v1.1.10"
+description: "Release notes for ADE v1.1.10 - May 2, 2026"
+---
+
+v1.1.10 ships three commits since v1.1.9: stronger Cursor SDK model handling, a shared desktop-to-mobile model catalog, tighter iOS Simulator packaging and stream behavior, and an `asc`-backed internal TestFlight build path. The iOS companion ships in **TestFlight build 1** of 1.1.10.
+
+---
+
+## Desktop
+
+<Tabs>
+  <Tab title="Chat and providers">
+    Chat setup gets a more explicit Cursor SDK path, clearer provider status, and one shared model catalog for desktop and mobile clients.
+
+    - **Cursor API key handling.** ADE now stores provider API keys through the platform credential path, verifies Cursor keys through model discovery, and clears stale readiness state when credentials change.
+    - **Shared model catalog.** Desktop exposes a structured `chat.modelCatalog` response and moves provider grouping into shared catalog code so renderer, remote commands, and mobile model pickers use the same provider families.
+    - **Cursor SDK runtime cleanup.** Cursor SDK sessions use private socket paths, extracted hook management, and cleanup for one-shot catalog or cloud requests so temporary runtime state does not accumulate between probes.
+    - **Provider status copy.** Connection states now distinguish missing keys, unavailable credential storage, SDK initialization failures, and cached discovery results more directly.
+  </Tab>
+
+  <Tab title="Runtime and simulator">
+    The release hardens packaged desktop behavior around simulator helpers, artifact validation, and run-tab state.
+
+    - **iOS Simulator helpers.** Packaged builds resolve native simulator helper caches more reliably, keep stream fallback state ordered, and preserve the intended IOSurface path for packaged desktop sessions.
+    - **Release artifact checks.** Desktop packaging now audits macOS runtime artifacts more explicitly and validates universal app payload files during the release pipeline.
+    - **Run session titles.** Generated terminal titles are sanitized before display so live run sessions keep cleaner names and status details.
+    - **Internal TestFlight automation.** A self-hosted Mac workflow and `asc` script can bump, archive, upload, and distribute internal iOS builds from CI.
+  </Tab>
+</Tabs>
+
+---
+
+## iOS
+
+<Tabs>
+  <Tab title="Model picker">
+    The mobile companion now builds its Work chat model choices from the desktop catalog instead of carrying a separate view of provider families.
+
+    - **Desktop-backed catalog.** `SyncService` can request `chat.modelCatalog`, cache the response per host, deduplicate in-flight requests, and fall back predictably when the desktop catalog is unavailable.
+    - **Provider grouping.** `WorkModelCatalog` maps the shared desktop catalog into the mobile model picker, including current Claude, Codex, Cursor, and related provider groupings.
+    - **Model picker sheet.** `WorkModelPickerSheet` uses the refreshed catalog data so model choices line up with the connected desktop app.
+  </Tab>
+
+  <Tab title="Work chat">
+    Work chat keeps the new catalog state visible while staying compatible with the current desktop sync protocol.
+
+    - **New chat flow.** `WorkNewChatSheet` refreshes model selection behavior for new sessions and keeps the selected model aligned with the catalog returned by the desktop host.
+    - **Session state.** `WorkChatSessionView` and related remote model types handle the updated model identifiers and display labels from the shared catalog.
+    - **TestFlight build.** The 1.1.10 mobile build is cut as a new TestFlight train and will be distributed to all non-empty internal tester groups.
+  </Tab>
+</Tabs>

--- a/docs.json
+++ b/docs.json
@@ -210,6 +210,7 @@
             "icon": "tag",
             "expanded": true,
             "pages": [
+              "changelog/v1.1.10",
               "changelog/v1.1.9",
               "changelog/v1.1.8",
               "changelog/v1.1.7",


### PR DESCRIPTION
Changelog for v1.1.10. Tag will be cut after this lands on main.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the changelog entry for v1.1.10, covering Cursor SDK model handling improvements, a shared desktop-to-mobile model catalog, iOS Simulator packaging hardening, and an `asc`-backed internal TestFlight build path. The `docs.json` navigation is updated to list v1.1.10 first, maintaining the correct descending version order.

<h3>Confidence Score: 4/5</h3>

Safe to merge; only a documentation/changelog addition with one minor style inconsistency.

Only P2 findings (em dash vs hyphen inconsistency in description frontmatter). No logic, security, or structural issues.

changelog/v1.1.10.mdx — minor description separator inconsistency.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| changelog/v1.1.10.mdx | New changelog entry for v1.1.10; content and structure look correct, but description separator uses a hyphen instead of the em dash used in all prior changelogs. |
| docs.json | Adds `changelog/v1.1.10` as the first entry in the changelog pages list, correctly positioned before v1.1.9. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: changelog for v1.1.10] --> B[changelog/v1.1.10.mdx\nnew file]
    A --> C[docs.json\nadd entry]
    B --> D[Desktop section\nCursor SDK, Simulator, TestFlight]
    B --> E[iOS section\nModel picker, Work chat]
    C --> F[changelog/v1.1.10 inserted\nat top of pages list]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Achangelog%2Fv1.1.10.mdx%3A3%0AThe%20description%20field%20uses%20a%20hyphen%20%28%60-%60%29%20as%20a%20separator%2C%20while%20every%20prior%20changelog%20entry%20%28v1.1.9%2C%20v1.1.8%2C%20and%20earlier%29%20consistently%20uses%20an%20em%20dash%20%28%60%E2%80%94%60%29.%20Keeping%20this%20consistent%20avoids%20a%20subtle%20visual%20difference%20on%20the%20rendered%20changelog%20index.%0A%0A%60%60%60suggestion%0Adescription%3A%20%22Release%20notes%20for%20ADE%20v1.1.10%20%E2%80%94%20May%202%2C%202026%22%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=230&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
changelog/v1.1.10.mdx:3
The description field uses a hyphen (`-`) as a separator, while every prior changelog entry (v1.1.9, v1.1.8, and earlier) consistently uses an em dash (`—`). Keeping this consistent avoids a subtle visual difference on the rendered changelog index.

```suggestion
description: "Release notes for ADE v1.1.10 — May 2, 2026"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["release: changelog for v1.1.10"](https://github.com/arul28/ade/commit/3476518d301facad995cc96ae3e2fbec1774199d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30534117)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->