### PR TITLE
PRs Tab Fixes

### DIFF
--- a/apps/ade-cli/package-lock.json
+++ b/apps/ade-cli/package-lock.json
@@ -4071,8 +4071,7 @@
     "@connectrpc/connect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
-      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
-      "requires": {}
+      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w=="
     },
     "@connectrpc/connect-node": {
       "version": "1.7.0",
@@ -4594,8 +4593,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.6.tgz",
       "integrity": "sha512-m8lERkkQj+uek18hXOZuec3W/fCRTrU4hrnXjH3qhHy96ytuPaPiWGgu7sJb7tZxZonO75vYAjCvpe/e4VUwRw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@types/estree": {
       "version": "1.0.8",
@@ -5065,8 +5063,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "file-uri-to-path": {
       "version": "1.0.0",

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -9670,6 +9670,56 @@ describe("createAgentChatService", () => {
     expect(readPersistedChatState(session.id).awaitingInput).toBeUndefined();
   });
 
+  it("rejects normal chat sends while a pending input request is waiting", async () => {
+    const events: AgentChatEventEnvelope[] = [];
+    const { service } = createService({
+      onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+    });
+
+    const session = await service.createSession({
+      laneId: "lane-1",
+      provider: "codex",
+      model: "gpt-5.4",
+    });
+
+    const requestPromise = service.requestChatInput({
+      chatSessionId: session.id,
+      title: "Pending question",
+      body: "Which path should we take?",
+      questions: [{
+        id: "answer",
+        header: "Question 1",
+        question: "Which path should we take?",
+        allowsFreeform: true,
+      }],
+    });
+
+    const approvalEvent = await waitForEvent(
+      events,
+      (event): event is AgentChatEventEnvelope & {
+        event: Extract<AgentChatEventEnvelope["event"], { type: "approval_request" }>;
+      } => {
+        const detail = event.event.type === "approval_request"
+          ? (event.event.detail as { request?: { title?: string } } | undefined)
+          : undefined;
+        return event.event.type === "approval_request" && detail?.request?.title === "Pending question";
+      },
+    );
+
+    await expect(service.sendMessage({
+      sessionId: session.id,
+      text: "Treat this as the answer even though it came through chat.send.",
+    })).rejects.toThrow("Answer or decline the pending request before sending another message.");
+
+    await service.respondToInput({
+      sessionId: session.id,
+      itemId: approvalEvent.event.itemId,
+      decision: "decline",
+    });
+
+    await expect(requestPromise).resolves.toMatchObject({ decision: "decline" });
+  });
+
   it("maps freeform replies to the single pending question when only one answer is needed", async () => {
     const events: AgentChatEventEnvelope[] = [];
     const { service } = createService({

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -855,9 +855,12 @@ function normalizeCodexAssistantDelta(
   return args.delta;
 }
 
+const PENDING_INPUT_SEND_BLOCKED_MESSAGE = "Answer or decline the pending request before sending another message.";
+
 function validateSessionReadyForTurn(managed: ManagedChatSession): { ready: true } | { ready: false; reason: string } {
   if (managed.closed) return { ready: false, reason: "Session is disposed" };
   if (!managed.runtime) return { ready: false, reason: "No runtime initialized" };
+  if (hasLivePendingInput(managed)) return { ready: false, reason: PENDING_INPUT_SEND_BLOCKED_MESSAGE };
   const rt = managed.runtime;
   if ((rt.kind === "opencode" || rt.kind === "claude" || rt.kind === "cursor" || rt.kind === "droid") && rt.busy) {
     return { ready: false, reason: "Turn already active" };
@@ -12266,6 +12269,9 @@ export function createAgentChatService(args: {
     const visibleText = displayText?.trim().length ? displayText.trim() : trimmed;
 
     const managed = ensureManagedSession(sessionId);
+    if (hasLivePendingInput(managed)) {
+      throw new Error(PENDING_INPUT_SEND_BLOCKED_MESSAGE);
+    }
     const executionContext = refreshManagedLaneLaunchContext(managed);
     const publicAttachments = attachments.map((attachment) => ({
       ...attachment,
@@ -15573,6 +15579,9 @@ export function createAgentChatService(args: {
     }
 
     const managed = ensureManagedSession(sessionId);
+    if (hasLivePendingInput(managed)) {
+      throw new Error(PENDING_INPUT_SEND_BLOCKED_MESSAGE);
+    }
 
     // OpenCode runtime steer
     if (managed.runtime?.kind === "opencode") {
@@ -15855,6 +15864,9 @@ export function createAgentChatService(args: {
     const managed = ensureManagedSession(sessionId);
     if (managed.session.provider === "codex") {
       throw new Error("dispatchSteer is not supported on Codex sessions.");
+    }
+    if (hasLivePendingInput(managed)) {
+      throw new Error(PENDING_INPUT_SEND_BLOCKED_MESSAGE);
     }
     const runtime = managed.runtime;
     if (!runtime) return { dispatchedAt: null };

--- a/apps/desktop/src/main/services/prs/prService.test.ts
+++ b/apps/desktop/src/main/services/prs/prService.test.ts
@@ -262,7 +262,7 @@ describe("prService.getForLane", () => {
     expect(service.getForLane(lane.id)?.githubPrNumber).toBe(92);
   });
 
-  it("falls back to the newest active PR while the lane branch is unavailable", () => {
+  it("returns null for branch-less lanes so a stray PR row never claims an unbranched lane", () => {
     const lane = makeFakeLane({
       branchRef: null,
     });
@@ -274,7 +274,7 @@ describe("prService.getForLane", () => {
       }),
     ]);
 
-    expect(service.getForLane(lane.id)?.githubPrNumber).toBe(93);
+    expect(service.getForLane(lane.id)).toBeNull();
   });
 
   it("surfaces a merged PR row when it still matches the current lane branch", () => {

--- a/apps/desktop/src/main/services/prs/prService.test.ts
+++ b/apps/desktop/src/main/services/prs/prService.test.ts
@@ -277,7 +277,7 @@ describe("prService.getForLane", () => {
     expect(service.getForLane(lane.id)?.githubPrNumber).toBe(93);
   });
 
-  it("ignores terminal PR rows when resolving the current lane PR", () => {
+  it("surfaces a merged PR row when it still matches the current lane branch", () => {
     const lane = makeFakeLane({
       branchRef: "refs/heads/current-feature",
     });
@@ -286,6 +286,21 @@ describe("prService.getForLane", () => {
         lane_id: lane.id,
         state: "merged",
         head_branch: "current-feature",
+      }),
+    ]);
+
+    expect(service.getForLane(lane.id)?.state).toBe("merged");
+  });
+
+  it("ignores terminal PR rows whose head branch no longer matches the lane branch", () => {
+    const lane = makeFakeLane({
+      branchRef: "refs/heads/current-feature",
+    });
+    const service = buildGetForLaneService(lane, [
+      makePrRow({
+        lane_id: lane.id,
+        state: "merged",
+        head_branch: "old-feature",
       }),
     ]);
 

--- a/apps/desktop/src/main/services/prs/prService.ts
+++ b/apps/desktop/src/main/services/prs/prService.ts
@@ -904,7 +904,10 @@ export function createPrService({
 
   const rowMatchesCurrentLaneBranch = (row: PullRequestRow, lane: LanePrLookupRow): boolean => {
     if (!isActivePrState(row.state)) return false;
+    return rowMatchesLaneBranchForDisplay(row, lane);
+  };
 
+  const rowMatchesLaneBranchForDisplay = (row: PullRequestRow, lane: LanePrLookupRow): boolean => {
     const laneBranch = normalizeBranchName(branchNameFromRef(lane.branch_ref ?? ""));
     const prHeadBranch = normalizeBranchName(row.head_branch);
     if (!laneBranch || !prHeadBranch || laneBranch !== prHeadBranch) return false;
@@ -915,6 +918,30 @@ export function createPrService({
     }
 
     return true;
+  };
+
+  const getDisplayRowForCurrentLaneBranch = (laneId: string): PullRequestRow | null => {
+    const lane = getLanePrLookupRow(laneId);
+    if (!lane || lane.archived_at) return null;
+
+    const rows = db.all<PullRequestRow>(
+      `
+        select ${PR_COLUMNS}
+          from pull_requests
+         where lane_id = ?
+           and project_id = ?
+         order by
+           case when state in ('open', 'draft') then 0 when state = 'merged' then 1 else 2 end,
+           updated_at desc,
+           created_at desc
+      `,
+      [laneId, projectId],
+    );
+
+    const laneBranch = normalizeBranchName(branchNameFromRef(lane.branch_ref ?? ""));
+    if (!laneBranch) return rows[0] ?? null;
+
+    return rows.find((row) => rowMatchesLaneBranchForDisplay(row, lane)) ?? null;
   };
 
   const getActiveRowForCurrentLaneBranch = (laneId: string): PullRequestRow | null => {
@@ -5214,7 +5241,7 @@ export function createPrService({
     },
 
     getForLane(laneId: string): PrSummary | null {
-      const row = getActiveRowForCurrentLaneBranch(laneId);
+      const row = getDisplayRowForCurrentLaneBranch(laneId);
       return row ? rowToSummary(row) : null;
     },
 

--- a/apps/desktop/src/main/services/prs/prService.ts
+++ b/apps/desktop/src/main/services/prs/prService.ts
@@ -887,7 +887,7 @@ export function createPrService({
     );
     const lane = getLanePrLookupRow(laneId);
     if (!lane || lane.archived_at) return rows[0] ?? null;
-    return rows.find((row) => rowMatchesCurrentLaneBranch(row, lane)) ?? rows[0] ?? null;
+    return rows.find((row) => isActivePrState(row.state) && rowMatchesLaneBranchForDisplay(row, lane)) ?? rows[0] ?? null;
   };
 
   const getLanePrLookupRow = (laneId: string): LanePrLookupRow | null =>
@@ -901,11 +901,6 @@ export function createPrService({
       `,
       [laneId, projectId],
     );
-
-  const rowMatchesCurrentLaneBranch = (row: PullRequestRow, lane: LanePrLookupRow): boolean => {
-    if (!isActivePrState(row.state)) return false;
-    return rowMatchesLaneBranchForDisplay(row, lane);
-  };
 
   const rowMatchesLaneBranchForDisplay = (row: PullRequestRow, lane: LanePrLookupRow): boolean => {
     const laneBranch = normalizeBranchName(branchNameFromRef(lane.branch_ref ?? ""));
@@ -963,7 +958,7 @@ export function createPrService({
     const laneBranch = normalizeBranchName(branchNameFromRef(lane.branch_ref ?? ""));
     if (!laneBranch) return rows[0] ?? null;
 
-    return rows.find((row) => rowMatchesCurrentLaneBranch(row, lane)) ?? null;
+    return rows.find((row) => isActivePrState(row.state) && rowMatchesLaneBranchForDisplay(row, lane)) ?? null;
   };
 
   const getRowForLaneBranch = (laneId: string, headBranch: string): PullRequestRow | null => {

--- a/apps/desktop/src/main/services/prs/prService.ts
+++ b/apps/desktop/src/main/services/prs/prService.ts
@@ -934,7 +934,7 @@ export function createPrService({
     );
 
     const laneBranch = normalizeBranchName(branchNameFromRef(lane.branch_ref ?? ""));
-    if (!laneBranch) return rows[0] ?? null;
+    if (!laneBranch) return null;
 
     return rows.find((row) => rowMatchesLaneBranchForDisplay(row, lane)) ?? null;
   };
@@ -956,7 +956,7 @@ export function createPrService({
     );
 
     const laneBranch = normalizeBranchName(branchNameFromRef(lane.branch_ref ?? ""));
-    if (!laneBranch) return rows[0] ?? null;
+    if (!laneBranch) return null;
 
     return rows.find((row) => isActivePrState(row.state) && rowMatchesLaneBranchForDisplay(row, lane)) ?? null;
   };

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
@@ -303,8 +303,44 @@ describe("AgentChatComposer", () => {
       },
     });
 
-    expect(screen.getByText("Answer in the inline question card, or type below.")).toBeTruthy();
+    expect(screen.getByText("Answer in the inline question card, or decline.")).toBeTruthy();
     expect(screen.queryByText("Answer in the inline question card, or pick an option there.")).toBeNull();
+  });
+
+  it("locks the prompt box while a pending question is waiting", () => {
+    const props = renderComposer({
+      pendingInput: {
+        requestId: "req-lock",
+        itemId: "item-lock",
+        source: "claude",
+        kind: "question",
+        title: "Input needed",
+        description: "What should we do next?",
+        questions: [{
+          id: "answer",
+          header: "Question 1",
+          question: "What should we do next?",
+          allowsFreeform: true,
+        }],
+        allowsFreeform: true,
+        blocking: true,
+        canProceedWithoutAnswer: false,
+        turnId: null,
+      },
+    });
+
+    const textbox = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textbox.disabled).toBe(true);
+    expect(textbox.placeholder).toBe("Answer the question card above, or decline it.");
+    expect(screen.queryByLabelText("Send steer message")).toBeNull();
+    expect((screen.getByLabelText("Open attachment picker") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByLabelText("Upload file from disk") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByLabelText("Open command picker") as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    expect(props.onApproval).not.toHaveBeenCalled();
+    expect(props.onSubmit).not.toHaveBeenCalled();
   });
 
   it("keeps the option hint when a pending question includes selectable options", () => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -728,8 +728,16 @@ export function AgentChatComposer({
   // when the real paste event lands after the 80ms fallback has already fired.
   const clipboardImagePasteFallbackAttachedRef = useRef(false);
   const useRichComposer = iosElementContextItems.length > 0 || appControlContextItems.length > 0;
-  const canAttach = !parallelChatMode || attachments.length < PARALLEL_CHAT_MAX_ATTACHMENTS;
-  const attachBlockedReason = parallelChatMode && attachments.length >= PARALLEL_CHAT_MAX_ATTACHMENTS
+  const composerInputLocked = Boolean(pendingInput?.blocking);
+  const composerInputLockMessage = pendingInput?.kind === "question" || pendingInput?.kind === "structured_question"
+    ? "Answer the question card above, or decline it."
+    : pendingInput
+      ? "Resolve the pending request above before sending another message."
+      : null;
+  const canAttach = !composerInputLocked && (!parallelChatMode || attachments.length < PARALLEL_CHAT_MAX_ATTACHMENTS);
+  const attachBlockedReason = composerInputLocked
+    ? composerInputLockMessage ?? "Resolve the pending request before adding attachments."
+    : parallelChatMode && attachments.length >= PARALLEL_CHAT_MAX_ATTACHMENTS
     ? `Maximum ${PARALLEL_CHAT_MAX_ATTACHMENTS} attachments for parallel launch`
     : null;
 
@@ -760,6 +768,17 @@ export function AgentChatComposer({
       }
     };
   }, []);
+  useEffect(() => {
+    if (!composerInputLocked) return;
+    setAttachmentPickerOpen(false);
+    setCommandMenuTrigger(null);
+    setDragActive(false);
+    if (clipboardImagePasteFallbackTimerRef.current != null) {
+      window.clearTimeout(clipboardImagePasteFallbackTimerRef.current);
+      clipboardImagePasteFallbackTimerRef.current = null;
+    }
+    clipboardImagePasteFallbackAttachedRef.current = false;
+  }, [composerInputLocked]);
   useLayoutEffect(() => {
     resizeTextarea();
   }, [draft, resizeTextarea]);
@@ -1774,6 +1793,13 @@ export function AgentChatComposer({
   /* ── Keyboard handler for composer input ── */
   const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
     const commandModified = event.metaKey || event.ctrlKey;
+    if (composerInputLocked) {
+      if (event.key === "Escape" && pendingInput) {
+        event.preventDefault();
+        onApproval("cancel");
+      }
+      return;
+    }
     if (isMacPasteShortcut(event)) {
       const handledPasteGeneration = clipboardImagePasteHandledRef.current;
       if (clipboardImagePasteFallbackTimerRef.current != null) {
@@ -1891,6 +1917,10 @@ export function AgentChatComposer({
   };
 
   const handleCommandMenuSelect = useCallback((item: ChatCommandMenuItem) => {
+    if (composerInputLocked) {
+      setCommandMenuTrigger(null);
+      return;
+    }
     if (item.type === "file" && commandMenuTrigger) {
       if (!canAttach) {
         setAttachError(attachBlockedReason ?? "Attachments are unavailable right now.");
@@ -1917,7 +1947,7 @@ export function AgentChatComposer({
       }
     }
     setCommandMenuTrigger(null);
-  }, [attachBlockedReason, canAttach, commandMenuTrigger, draft, effectiveSlashCommands, handleSlashSelect, insertTextIntoRichEditor, onDraftChange, onAddAttachment, setRichEditorText, useRichComposer]);
+  }, [attachBlockedReason, canAttach, commandMenuTrigger, composerInputLocked, draft, effectiveSlashCommands, handleSlashSelect, insertTextIntoRichEditor, onDraftChange, onAddAttachment, setRichEditorText, useRichComposer]);
 
   const handleRichEditorInput = useCallback(() => {
     const editor = richEditorRef.current;
@@ -1953,12 +1983,7 @@ export function AgentChatComposer({
   }, [captureRichSelection, getRichCursorTextOffset, onDraftChange, serializeRichEditor]);
 
   const submitComposerDraft = useCallback(() => {
-    const isQuestionPending = pendingInput && (pendingInput.kind === "question" || pendingInput.kind === "structured_question");
-    if (isQuestionPending) {
-      const answer = draft.trim();
-      if (!answer.length && !pendingInput.canProceedWithoutAnswer) return;
-      onApproval("accept", answer || null);
-      onDraftChange("");
+    if (pendingInput?.blocking) {
       return;
     }
     if (parallelChatMode) {
@@ -1988,7 +2013,7 @@ export function AgentChatComposer({
     }
     if (busy || !modelId || (!draft.trim().length && !iosElementContextItems.length && !appControlContextItems.length)) return;
     onSubmit();
-  }, [appControlContextItems.length, attachments, busy, cursorCloudAvailable, cursorCloudCanLaunch, cursorCloudLaunchModeOpen, draft, iosElementContextItems.length, modelId, onApproval, onDraftChange, onSubmit, onSubmitToCloud, pendingInput, parallelChatMode, parallelLaunchBusy, parallelModelSlots.length]);
+  }, [appControlContextItems.length, attachments, busy, cursorCloudAvailable, cursorCloudCanLaunch, cursorCloudLaunchModeOpen, draft, iosElementContextItems.length, modelId, onDraftChange, onSubmit, onSubmitToCloud, pendingInput, parallelChatMode, parallelLaunchBusy, parallelModelSlots.length]);
 
   const pendingQuestionCount = getPendingInputQuestionCount(pendingInput);
   const showPendingInputOptionsHint = hasPendingInputOptions(pendingInput);
@@ -2032,9 +2057,10 @@ export function AgentChatComposer({
   const hasIosElementContext = iosElementContextItems.length > 0;
   const hasAppControlContext = appControlContextItems.length > 0;
   const singleReady = !parallelChatMode && Boolean(modelId) && (draft.trim().length > 0 || hasIosElementContext || hasAppControlContext);
-  const sendEnabled = !busy && !parallelLaunchBusy && (parallelReady || singleReady);
+  const sendEnabled = !busy && !parallelLaunchBusy && !composerInputLocked && (parallelReady || singleReady);
 
   function sendButtonTitle(): string {
+    if (composerInputLocked) return composerInputLockMessage ?? "Resolve the pending request before sending.";
     if (parallelChatMode) {
       if (parallelModelSlots.length < 2) return "Add at least two models";
       if (draft.trim().length === 0 && attachments.length === 0) return "Add a message or at least one attachment";
@@ -2105,7 +2131,7 @@ export function AgentChatComposer({
                 <span className="font-mono text-[length:calc(var(--chat-font-size)*10/14)] uppercase tracking-[0.14em] text-amber-200/60">
                   {showPendingInputOptionsHint
                     ? "Answer in the inline question card, or pick an option there."
-                    : "Answer in the inline question card, or type below."}
+                    : "Answer in the inline question card, or decline."}
                 </span>
                 <button
                   type="button"
@@ -2582,7 +2608,9 @@ export function AgentChatComposer({
               <button
                 type="button"
                 className="inline-flex h-8 min-w-8 items-center justify-center rounded-lg px-1.5 font-sans text-[length:calc(var(--chat-font-size)*11/14)] font-medium text-muted-fg/35 transition-colors hover:bg-violet-500/[0.06] hover:text-violet-300/60"
+                disabled={composerInputLocked}
                 onClick={() => {
+                  if (composerInputLocked) return;
                   const richEl = richEditorRef.current;
                   const el = textareaRef.current;
                   const currentDraft = useRichComposer ? serializeRichEditor() : el?.value ?? "";
@@ -2708,7 +2736,7 @@ export function AgentChatComposer({
                     </button>
                   </SmartTooltip>
                 ) : null}
-                {draft.trim().length > 0 ? (
+                {draft.trim().length > 0 && !composerInputLocked ? (
                   <SmartTooltip content={{ label: "Send steer message", description: "Queue this message for the running chat after the current turn finishes." }}>
                     <button
                       type="button"
@@ -2863,19 +2891,19 @@ export function AgentChatComposer({
             <div className="relative">
               {!draft.trim().length && !iosElementContextItems.length && !appControlContextItems.length ? (
                 <div className="pointer-events-none absolute left-4 top-2.5 font-sans text-[length:calc(var(--chat-font-size)*13/14)] leading-[1.6] text-muted-fg/30">
-                  {turnActive ? "Steer the active turn..." : (messagePlaceholder ?? "Type to vibecode...")}
+                  {composerInputLockMessage ?? (turnActive ? "Steer the active turn..." : (messagePlaceholder ?? "Type to vibecode..."))}
                 </div>
               ) : null}
               <div
                 ref={richEditorRef}
-                contentEditable={!parallelLaunchBusy}
+                contentEditable={!parallelLaunchBusy && !composerInputLocked}
                 role="textbox"
                 aria-multiline="true"
                 suppressContentEditableWarning
                 className={cn(
                   "block max-h-[200px] min-h-[2.6rem] w-full overflow-auto whitespace-pre-wrap break-words bg-transparent px-4 py-2.5 font-sans text-[length:calc(var(--chat-font-size)*13/14)] leading-[1.6] text-fg/88 outline-none transition-colors",
                   dragActive ? "opacity-30" : "",
-                  parallelLaunchBusy ? "cursor-not-allowed opacity-50" : "",
+                  parallelLaunchBusy || composerInputLocked ? "cursor-not-allowed opacity-50" : "",
                 )}
                 data-chat-layout-variant={layoutVariant}
                 onInput={handleRichEditorInput}
@@ -2956,7 +2984,7 @@ export function AgentChatComposer({
               onSelect={(event) => {
                 lastPlainSelectionRef.current = event.currentTarget.selectionStart ?? event.currentTarget.value.length;
               }}
-              disabled={parallelLaunchBusy}
+              disabled={parallelLaunchBusy || composerInputLocked}
               autoComplete="on"
               autoCorrect="on"
               autoCapitalize="sentences"
@@ -2964,10 +2992,10 @@ export function AgentChatComposer({
               className={cn(
                 "block w-full resize-none bg-transparent px-4 py-2.5 text-[length:calc(var(--chat-font-size)*13/14)] leading-[1.6] text-fg/88 outline-none transition-colors placeholder:text-muted-fg/30",
                 dragActive ? "opacity-30" : "",
-                parallelLaunchBusy ? "cursor-not-allowed opacity-50" : "",
+                parallelLaunchBusy || composerInputLocked ? "cursor-not-allowed opacity-50" : "",
               )}
               data-chat-layout-variant={layoutVariant}
-              placeholder={turnActive ? "Steer the active turn..." : (promptSuggestion ? "" : (messagePlaceholder ?? "Type to vibecode..."))}
+              placeholder={composerInputLockMessage ?? (turnActive ? "Steer the active turn..." : (promptSuggestion ? "" : (messagePlaceholder ?? "Type to vibecode...")))}
               onKeyDown={handleKeyDown}
               onPaste={handlePaste}
             />
@@ -3120,4 +3148,3 @@ function CursorCloudActionMenu({
     </div>
   );
 }
-

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.submit.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.submit.test.tsx
@@ -9,6 +9,7 @@ import type {
   AgentChatParallelLaunchState,
   AgentChatSession,
   AgentChatSessionSummary,
+  PrSummary,
 } from "../../../shared/types";
 import { getModelById } from "../../../shared/modelRegistry";
 import { invalidateAiDiscoveryCache } from "../../lib/aiDiscoveryCache";
@@ -39,6 +40,31 @@ function buildSession(sessionId: string, overrides: Partial<AgentChatSessionSumm
     reasoningEffort: "xhigh",
     executionMode: "focused",
     interactionMode: null,
+    ...overrides,
+  };
+}
+
+function buildPrSummary(overrides: Partial<PrSummary> = {}): PrSummary {
+  return {
+    id: "pr-1",
+    laneId: "lane-1",
+    projectId: "project-1",
+    repoOwner: "arul28",
+    repoName: "ADE",
+    githubPrNumber: 224,
+    githubUrl: "https://github.com/arul28/ADE/pull/224",
+    githubNodeId: "PR_node224",
+    title: "Show merged PR state",
+    state: "open",
+    baseBranch: "main",
+    headBranch: "feature/pr-state",
+    checksStatus: "passing",
+    reviewStatus: "approved",
+    additions: 1,
+    deletions: 1,
+    lastSyncedAt: null,
+    createdAt: "2026-05-01T00:00:00.000Z",
+    updatedAt: "2026-05-01T00:00:00.000Z",
     ...overrides,
   };
 }
@@ -99,6 +125,7 @@ function installAdeMocks(options?: {
   sessions?: AgentChatSessionSummary[];
   includeClaudeModel?: boolean;
   parallelLaunchState?: AgentChatParallelLaunchState | null;
+  linkedPr?: PrSummary | null;
 }) {
   const send = options?.sendError
     ? vi.fn().mockRejectedValue(options.sendError)
@@ -198,7 +225,7 @@ function installAdeMocks(options?: {
       getChanges: vi.fn().mockResolvedValue({ staged: [], unstaged: [] }),
     },
     prs: {
-      getForLane: vi.fn().mockResolvedValue(null),
+      getForLane: vi.fn().mockResolvedValue(options?.linkedPr ?? null),
     },
     pty: {
       onExit: vi.fn().mockImplementation(() => () => undefined),
@@ -383,6 +410,28 @@ describe("AgentChatPane submit recovery", () => {
     expect(await screen.findByLabelText("Waiting for your input")).toBeTruthy();
   });
 
+  it("blocks the composer prompt while a pending input request is active", async () => {
+    const session = buildSession("session-1");
+    const { send, steer } = installAdeMocks({
+      transcript: buildPendingInputTranscript(session.sessionId),
+    });
+
+    renderPane(session);
+
+    expect(await screen.findByText("Answer in the inline question card, or decline.")).toBeTruthy();
+    const textbox = screen.getByPlaceholderText("Answer the question card above, or decline it.") as HTMLTextAreaElement;
+
+    expect(textbox.disabled).toBe(true);
+    expect(textbox.placeholder).toBe("Answer the question card above, or decline it.");
+
+    fireEvent.keyDown(textbox, { key: "Enter" });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(send).not.toHaveBeenCalled();
+    expect(steer).not.toHaveBeenCalled();
+    expect(window.ade.agentChat.respondToInput).not.toHaveBeenCalled();
+  });
+
   it("falls back to the session summary when a chat is awaiting input", async () => {
     const session = buildSession("session-1", {
       status: "active",
@@ -396,6 +445,26 @@ describe("AgentChatPane submit recovery", () => {
 
     expect(await screen.findByLabelText("Waiting for your input")).toBeTruthy();
     expect(screen.queryByLabelText("Agent working")).toBeNull();
+  });
+
+  it("blocks submit when the session summary is awaiting input before the pending card loads", async () => {
+    const session = buildSession("session-1", {
+      status: "active",
+      awaitingInput: true,
+    });
+    const { send, steer } = installAdeMocks({
+      sessions: [session],
+    });
+
+    renderPane(session);
+
+    const textbox = await screen.findByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "This should wait." } });
+    fireEvent.click(await screen.findByRole("button", { name: "Send" }));
+
+    expect(await screen.findByText("Answer or decline the pending request before sending another message.")).toBeTruthy();
+    expect(send).not.toHaveBeenCalled();
+    expect(steer).not.toHaveBeenCalled();
   });
 
   it("does not keep showing a working indicator when the session summary is idle", async () => {
@@ -1277,6 +1346,28 @@ describe("AgentChatPane submit recovery", () => {
     // The git toolbar renders commit/push buttons when laneId is present
     expect(await screen.findByText("Stage & Commit")).toBeTruthy();
     expect(screen.getByText("Push")).toBeTruthy();
+  });
+
+  it("labels a merged linked PR in the git toolbar", async () => {
+    const session = buildSession("session-1");
+    installAdeMocks({
+      sessions: [session],
+      linkedPr: buildPrSummary({ state: "merged" }),
+    });
+
+    render(
+      <MemoryRouter>
+        <AgentChatPane
+          laneId={session.laneId}
+          laneLabel="feature/auth"
+          lockSessionId={session.sessionId}
+          hideSessionTabs
+          initialSessionSummary={session}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("MERGED #224")).toBeTruthy();
   });
 
   it("does not render the git toolbar when laneId is null", async () => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -3714,6 +3714,13 @@ export function AgentChatPane({
 
   const submit = useCallback(async () => {
     if (submitInFlightRef.current || busy || parallelLaunchBusy) return;
+    if (
+      selectedSessionId
+      && ((pendingInputsBySession[selectedSessionId]?.length ?? 0) > 0 || selectedSession?.awaitingInput === true)
+    ) {
+      setError("Answer or decline the pending request before sending another message.");
+      return;
+    }
 
     const isParallelLaunch =
       !lockSessionId
@@ -4079,9 +4086,11 @@ export function AgentChatPane({
     launchModeEditable,
     modelId,
     reasoningEffort,
+    pendingInputsBySession,
     refreshAvailableModels,
     refreshSessions,
     selectedSessionId,
+    selectedSession?.awaitingInput,
     selectedSessionModelId,
     sessionProvider,
     cursorRuntime,

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -3714,12 +3714,13 @@ export function AgentChatPane({
 
   const submit = useCallback(async () => {
     if (submitInFlightRef.current || busy || parallelLaunchBusy) return;
-    if (
-      selectedSessionId
-      && ((pendingInputsBySession[selectedSessionId]?.length ?? 0) > 0 || selectedSession?.awaitingInput === true)
-    ) {
-      setError("Answer or decline the pending request before sending another message.");
-      return;
+    if (selectedSessionId) {
+      const sessionPending = pendingInputsBySession[selectedSessionId] ?? [];
+      const hasBlockingPending = sessionPending.some((entry) => entry.request.blocking);
+      if (hasBlockingPending || selectedSession?.awaitingInput === true) {
+        setError("Answer or decline the pending request before sending another message.");
+        return;
+      }
     }
     setPromptSuggestion(null);
 

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -3721,6 +3721,7 @@ export function AgentChatPane({
       setError("Answer or decline the pending request before sending another message.");
       return;
     }
+    setPromptSuggestion(null);
 
     const isParallelLaunch =
       !lockSessionId
@@ -5094,7 +5095,6 @@ export function AgentChatPane({
             onDraftChange={updateComposerDraft}
             onClearDraft={() => updateComposerDraft("")}
             onSubmit={() => {
-              setPromptSuggestion(null);
               void submit();
             }}
             onInterrupt={() => {

--- a/apps/desktop/src/renderer/components/chat/ChatGitToolbar.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatGitToolbar.tsx
@@ -22,6 +22,7 @@ import {
 } from "../lanes/LaneGitActionsPane";
 import { LaneAccentDot } from "../lanes/LaneAccentDot";
 import { useAppStore } from "../../state/appStore";
+import { formatPrBadgeLabel } from "../prs/shared/prFormatters";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -243,15 +244,16 @@ export const ChatGitToolbar = React.memo(function ChatGitToolbar({
 
   const prBadge = useMemo(() => {
     if (!linkedPr) return null;
+    const label = formatPrBadgeLabel(linkedPr);
     return (
       <button
         type="button"
         className={cn(btnBase, "gap-1.5")}
         onClick={handlePr}
-        title={`${linkedPr.title} — ${linkedPr.state}`}
+        title={`${label}: ${linkedPr.title}`}
       >
         <span className={cn("inline-block h-1.5 w-1.5 rounded-full", prStateDot(linkedPr.state))} />
-        <span>#{linkedPr.githubPrNumber}</span>
+        <span>{label}</span>
         {checksIcon(linkedPr.checksStatus)}
       </button>
     );

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.test.ts
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.test.ts
@@ -1,5 +1,48 @@
 import { describe, expect, it } from "vitest";
-import { resolveCreateLaneRequest, resolveLaneIdsDeepLinkSelection } from "./LanesPage";
+import {
+  lanePrMatchesCurrentBranch,
+  resolveCreateLaneRequest,
+  resolveLaneIdsDeepLinkSelection,
+  selectLanePrTag,
+} from "./LanesPage";
+import type { LaneSummary, PrSummary } from "../../../shared/types";
+
+type LanePrTarget = Pick<LaneSummary, "id" | "laneType" | "branchRef" | "baseRef">;
+
+function makeLane(overrides: Partial<LanePrTarget> = {}): LanePrTarget {
+  return {
+    id: "lane-1",
+    laneType: "worktree",
+    branchRef: "ade/pr-state",
+    baseRef: "main",
+    ...overrides,
+  };
+}
+
+function makePr(overrides: Partial<PrSummary> = {}): PrSummary {
+  return {
+    id: "pr-1",
+    laneId: "lane-1",
+    projectId: "project-1",
+    repoOwner: "arul28",
+    repoName: "ADE",
+    githubPrNumber: 224,
+    githubUrl: "https://github.com/arul28/ADE/pull/224",
+    githubNodeId: "PR_node224",
+    title: "Show merged PR state",
+    state: "open",
+    baseBranch: "main",
+    headBranch: "origin/ade/pr-state",
+    checksStatus: "passing",
+    reviewStatus: "approved",
+    additions: 1,
+    deletions: 1,
+    lastSyncedAt: null,
+    createdAt: "2026-05-01T00:00:00.000Z",
+    updatedAt: "2026-05-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
 
 describe("resolveCreateLaneRequest", () => {
   it("creates an independent lane from the selected primary branch", () => {
@@ -86,5 +129,59 @@ describe("resolveLaneIdsDeepLinkSelection", () => {
       availableLaneIds: ["lane-a"],
       consumedSignature: null,
     })).toBeNull();
+  });
+});
+
+describe("selectLanePrTag", () => {
+  it("surfaces a merged PR when it still matches the lane branch", () => {
+    const mergedPr = makePr({ state: "merged" });
+
+    expect(selectLanePrTag(makeLane(), [mergedPr])).toBe(mergedPr);
+  });
+
+  it("ignores PR rows whose head branch no longer matches the lane branch", () => {
+    const stalePr = makePr({
+      state: "merged",
+      headBranch: "ade/old-pr-state",
+    });
+
+    expect(selectLanePrTag(makeLane(), [stalePr])).toBeNull();
+  });
+
+  it("ignores PR rows when either side has no branch to compare", () => {
+    expect(selectLanePrTag(makeLane({ branchRef: "" }), [makePr()])).toBeNull();
+    expect(selectLanePrTag(makeLane(), [makePr({ headBranch: "" })])).toBeNull();
+  });
+
+  it("prefers active PR rows over merged rows for the same lane branch", () => {
+    const mergedPr = makePr({
+      id: "pr-merged",
+      state: "merged",
+      githubPrNumber: 223,
+      updatedAt: "2026-05-03T00:00:00.000Z",
+    });
+    const openPr = makePr({
+      id: "pr-open",
+      state: "open",
+      githubPrNumber: 224,
+      updatedAt: "2026-05-01T00:00:00.000Z",
+    });
+
+    expect(selectLanePrTag(makeLane(), [mergedPr, openPr])).toBe(openPr);
+  });
+
+  it("does not match a primary lane that is currently on its base branch", () => {
+    expect(
+      lanePrMatchesCurrentBranch(
+        makeLane({
+          laneType: "primary",
+          branchRef: "main",
+          baseRef: "main",
+        }),
+        makePr({
+          headBranch: "main",
+        }),
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -2,7 +2,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "rea
 import { useClickOutside } from "../../hooks/useClickOutside";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { Group, Panel } from "react-resizable-panels";
-import { Check, CaretDown, FileCode, GitBranch, House, Stack, Link, ArrowsOutSimple, ArrowsInSimple, PushPin, Plus, MagnifyingGlass, Terminal, X, ArrowSquareOut, Info, ArrowCounterClockwise, UsersThree } from "@phosphor-icons/react";
+import { Check, CaretDown, FileCode, GitBranch, GitPullRequest, House, Stack, Link, ArrowsOutSimple, ArrowsInSimple, PushPin, Plus, MagnifyingGlass, Terminal, X, ArrowSquareOut, Info, ArrowCounterClockwise, UsersThree } from "@phosphor-icons/react";
 import { useAppStore, type LaneInspectorTab } from "../../state/appStore";
 import { buildIntegrationSourcesByLaneId } from "../../lib/integrationLanes";
 import { EmptyState } from "../ui/EmptyState";
@@ -46,8 +46,10 @@ import {
   type LaneBranchOption
 } from "./laneUtils";
 import { buildPrsRouteSearch } from "../prs/prsRouteState";
+import { formatPrBadgeLabel } from "../prs/shared/prFormatters";
 import { getProjectConfigCached } from "../../lib/projectConfigCache";
 import { logRendererDebugEvent } from "../../lib/debugLog";
+import { branchNameFromLaneRef } from "../../../shared/laneBaseResolution";
 import type {
   BranchPullRequest,
   ConflictChip,
@@ -58,6 +60,7 @@ import type {
   LaneBranchActiveWorkItem,
   LaneListSnapshot,
   LaneSummary,
+  PrSummary,
   RebaseRun,
   RebaseScope,
   IntegrationProposal,
@@ -167,6 +170,55 @@ function parseLaneIdsParam(value: string | null): string[] {
     .split(",")
     .map((entry) => entry.trim())
     .filter(Boolean);
+}
+
+function normalizeLanePrBranch(ref: string | null | undefined): string {
+  return branchNameFromLaneRef(ref).trim().toLowerCase();
+}
+
+function prStateRank(state: PrSummary["state"]): number {
+  if (state === "open" || state === "draft") return 0;
+  if (state === "merged") return 1;
+  return 2;
+}
+
+function compareLanePrTags(a: PrSummary, b: PrSummary): number {
+  const byState = prStateRank(a.state) - prStateRank(b.state);
+  if (byState !== 0) return byState;
+  const aUpdated = Date.parse(a.updatedAt);
+  const bUpdated = Date.parse(b.updatedAt);
+  if (!Number.isNaN(aUpdated) && !Number.isNaN(bUpdated) && aUpdated !== bUpdated) {
+    return bUpdated - aUpdated;
+  }
+  return b.githubPrNumber - a.githubPrNumber;
+}
+
+function lanePrTagColor(state: PrSummary["state"]): string {
+  if (state === "merged") return COLORS.success;
+  if (state === "closed") return COLORS.danger;
+  if (state === "draft") return COLORS.warning;
+  return COLORS.accent;
+}
+
+export function lanePrMatchesCurrentBranch(
+  lane: Pick<LaneSummary, "id" | "laneType" | "branchRef" | "baseRef">,
+  pr: Pick<PrSummary, "laneId" | "headBranch">,
+): boolean {
+  if (pr.laneId !== lane.id) return false;
+  const laneBranch = normalizeLanePrBranch(lane.branchRef);
+  const prHeadBranch = normalizeLanePrBranch(pr.headBranch);
+  if (!laneBranch || !prHeadBranch || laneBranch !== prHeadBranch) return false;
+  if (lane.laneType === "primary") {
+    const baseBranch = normalizeLanePrBranch(lane.baseRef);
+    if (laneBranch && baseBranch && laneBranch === baseBranch) return false;
+  }
+  return true;
+}
+
+export function selectLanePrTag(lane: Pick<LaneSummary, "id" | "laneType" | "branchRef" | "baseRef">, prs: PrSummary[]): PrSummary | null {
+  return prs
+    .filter((pr) => lanePrMatchesCurrentBranch(lane, pr))
+    .sort(compareLanePrTags)[0] ?? null;
 }
 
 export function resolveLaneIdsDeepLinkSelection(args: {
@@ -325,6 +377,7 @@ export function LanesPage() {
   const [expandedLaneId, setExpandedLaneId] = useState<string | null>(null);
   const [expandedGitActionsLaneId, setExpandedGitActionsLaneId] = useState<string | null>(null);
   const [integrationProposals, setIntegrationProposals] = useState<IntegrationProposal[]>([]);
+  const [lanePrTags, setLanePrTags] = useState<PrSummary[]>([]);
   const laneSnapshots = useAppStore((s) => s.laneSnapshots);
   const consumedLaneIdsDeepLinkSignatureRef = useRef<string | null>(null);
 
@@ -360,6 +413,14 @@ export function LanesPage() {
     () => buildIntegrationSourcesByLaneId(integrationProposals, lanesById),
     [integrationProposals, lanesById],
   );
+  const lanePrByLaneId = useMemo(() => {
+    const map = new Map<string, PrSummary>();
+    for (const lane of sortedLanes) {
+      const pr = selectLanePrTag(lane, lanePrTags);
+      if (pr) map.set(lane.id, pr);
+    }
+    return map;
+  }, [sortedLanes, lanePrTags]);
 
   const laneRuntimeById = useMemo(() => {
     const summaryByLane = new Map<string, LaneListSnapshot["runtime"]>();
@@ -605,6 +666,15 @@ export function LanesPage() {
     }
   }, []);
 
+  const refreshLanePrTags = useCallback(async () => {
+    try {
+      const prs = await window.ade.prs.listAll();
+      setLanePrTags(prs);
+    } catch {
+      setLanePrTags([]);
+    }
+  }, []);
+
   const pushConflictChips = useCallback((chips: ConflictChip[]) => {
     if (chips.length === 0) return;
     setConflictChipsByLane((prev) => {
@@ -732,6 +802,27 @@ export function LanesPage() {
     }, 140);
     return () => window.clearTimeout(timer);
   }, [refreshIntegrationProposals, project?.rootPath]);
+
+  useEffect(() => {
+    if (!project?.rootPath) {
+      setLanePrTags([]);
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      void refreshLanePrTags();
+    }, 160);
+    return () => window.clearTimeout(timer);
+  }, [refreshLanePrTags, project?.rootPath]);
+
+  useEffect(() => {
+    return window.ade.prs.onEvent((event) => {
+      if (event.type === "prs-updated") {
+        setLanePrTags(event.prs);
+      } else if (event.type === "pr-notification") {
+        void refreshLanePrTags();
+      }
+    });
+  }, [refreshLanePrTags]);
 
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -2550,6 +2641,7 @@ export function LanesPage() {
           const autoRebaseStatus = laneSnapshot?.autoRebaseStatus ?? null;
           const devicesOpen = lane.devicesOpen ?? [];
           const tabNumber = String(index + 1).padStart(2, "0");
+          const lanePr = lanePrByLaneId.get(lane.id) ?? null;
 
           return (
             <div
@@ -2637,6 +2729,32 @@ export function LanesPage() {
 	                fontWeight: isSelected ? 600 : 500,
 	                color: isSelected ? COLORS.textPrimary : COLORS.textMuted,
 	              }}>{lane.name}</span>
+              {lanePr ? (
+                <button
+                  type="button"
+                  className="shrink-0"
+                  style={{
+                    ...inlineBadge(lanePrTagColor(lanePr.state), { fontSize: 9 }),
+                    gap: 4,
+                    cursor: "pointer",
+                    borderRadius: 6,
+                  }}
+                  title={`${formatPrBadgeLabel(lanePr)}: ${lanePr.title}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    navigate(`/prs${buildPrsRouteSearch({
+                      activeTab: "normal",
+                      selectedPrId: lanePr.id,
+                      selectedQueueGroupId: null,
+                      selectedRebaseItemId: null,
+                    })}`);
+                  }}
+                  onMouseDown={(event) => event.stopPropagation()}
+                >
+                  <GitPullRequest size={10} weight="bold" />
+                  {formatPrBadgeLabel(lanePr)}
+                </button>
+              ) : null}
 	              {devicesOpen.length > 0 ? (
 	                <span
 	                  style={{

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -173,7 +173,7 @@ function parseLaneIdsParam(value: string | null): string[] {
 }
 
 function normalizeLanePrBranch(ref: string | null | undefined): string {
-  return branchNameFromLaneRef(ref).trim().toLowerCase();
+  return branchNameFromLaneRef(ref).trim();
 }
 
 function prStateRank(state: PrSummary["state"]): number {
@@ -337,6 +337,7 @@ export function LanesPage() {
   const [managedLaneIds, setManagedLaneIds] = useState<string[]>([]);
   const [conflictChipsByLane, setConflictChipsByLane] = useState<Record<string, ConflictChip[]>>({});
   const chipTimersRef = useRef<Map<string, number>>(new Map());
+  const lanePrTagsRequestRef = useRef(0);
   const hasActiveLaneRuntimeRef = useRef(false);
   const [autoRebaseEnabled, setAutoRebaseEnabled] = useState(false);
   const [rebaseSuggestionError, setRebaseSuggestionError] = useState<string | null>(null);
@@ -667,10 +668,16 @@ export function LanesPage() {
   }, []);
 
   const refreshLanePrTags = useCallback(async () => {
+    const requestId = ++lanePrTagsRequestRef.current;
+    const startedRoot = useAppStore.getState().project?.rootPath ?? null;
     try {
       const prs = await window.ade.prs.listAll();
+      if (requestId !== lanePrTagsRequestRef.current) return;
+      if ((useAppStore.getState().project?.rootPath ?? null) !== startedRoot) return;
       setLanePrTags(prs);
     } catch {
+      if (requestId !== lanePrTagsRequestRef.current) return;
+      if ((useAppStore.getState().project?.rootPath ?? null) !== startedRoot) return;
       setLanePrTags([]);
     }
   }, []);
@@ -805,13 +812,17 @@ export function LanesPage() {
 
   useEffect(() => {
     if (!project?.rootPath) {
+      lanePrTagsRequestRef.current += 1;
       setLanePrTags([]);
       return;
     }
     const timer = window.setTimeout(() => {
       void refreshLanePrTags();
     }, 160);
-    return () => window.clearTimeout(timer);
+    return () => {
+      lanePrTagsRequestRef.current += 1;
+      window.clearTimeout(timer);
+    };
   }, [refreshLanePrTags, project?.rootPath]);
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/components/prs/detail/PrDetailPane.issueResolver.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/detail/PrDetailPane.issueResolver.test.tsx
@@ -11,6 +11,7 @@ import type {
   LaneSummary,
   PrActivityEvent,
   PrAiResolutionEventPayload,
+  PrActionRun,
   PrCheck,
   PrConvergenceState,
   PrConvergenceStatePatch,
@@ -47,6 +48,21 @@ import { PrDetailPane } from "./PrDetailPane";
 
 function makeCheck(overrides: Partial<PrCheck> = {}): PrCheck {
   return { name: "ci / unit", status: "completed", conclusion: "failure", detailsUrl: null, startedAt: null, completedAt: null, ...overrides };
+}
+
+function makeActionRun(overrides: Partial<PrActionRun> = {}): PrActionRun {
+  return {
+    id: 25203344014,
+    name: "Path Filtered CI on PR",
+    status: "completed",
+    conclusion: "success",
+    headSha: "a886859",
+    htmlUrl: "https://github.com/arul28/Versic/actions/runs/25203344014",
+    createdAt: "2026-05-01T05:15:24.000Z",
+    updatedAt: "2026-05-01T05:24:41.000Z",
+    jobs: [],
+    ...overrides,
+  };
 }
 
 function makeThread(overrides: Partial<PrReviewThread> = {}): PrReviewThread {
@@ -223,6 +239,7 @@ function makeInventoryItem(overrides: Partial<IssueInventoryItem> = {}): IssueIn
 function renderPane(args: {
   checks: PrCheck[];
   freshChecks?: PrCheck[];
+  actionRuns?: PrActionRun[];
   reviewThreads: PrReviewThread[];
   lanes?: LaneSummary[];
   laneStatusOverrides?: Partial<LaneSummary["status"]>;
@@ -360,7 +377,7 @@ function renderPane(args: {
           linkedIssues: [],
         }),
         getFiles: vi.fn().mockResolvedValue([]),
-        getActionRuns: vi.fn().mockResolvedValue([]),
+        getActionRuns: vi.fn().mockResolvedValue(args.actionRuns ?? []),
         getActivity: vi.fn().mockResolvedValue(args.activity ?? []),
         getReviewThreads,
         issueInventorySync,
@@ -503,6 +520,65 @@ describe("PrDetailPane issue resolver CTA", () => {
       expect(screen.getByText("Some checks failing")).toBeTruthy();
       expect(screen.getByText("1/3 checks passing, 1 still running")).toBeTruthy();
       expect(screen.getAllByLabelText("CI running").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("does not count GitHub Actions jobs twice when check-runs mirror workflow jobs", async () => {
+    const user = userEvent.setup();
+    renderPane({
+      checks: [
+        makeCheck({
+          name: "Fast Checks (Lint, Type, Unit)",
+          conclusion: "success",
+          detailsUrl: "https://github.com/arul28/Versic/actions/runs/25203344014/job/73898654393",
+        }),
+        makeCheck({
+          name: "Coverage Report",
+          conclusion: "success",
+          detailsUrl: "https://github.com/arul28/Versic/actions/runs/25203344014/job/73898654402",
+        }),
+        makeCheck({
+          name: "Greptile Review",
+          conclusion: "success",
+          detailsUrl: "https://greptile.com/",
+        }),
+      ],
+      actionRuns: [
+        makeActionRun({
+          jobs: [
+            {
+              id: 73898654393,
+              name: "Fast Checks (Lint, Type, Unit)",
+              status: "completed",
+              conclusion: "success",
+              startedAt: null,
+              completedAt: null,
+              steps: [],
+            },
+            {
+              id: 73898654402,
+              name: "Coverage Report",
+              status: "completed",
+              conclusion: "success",
+              startedAt: null,
+              completedAt: null,
+              steps: [],
+            },
+          ],
+        }),
+      ],
+      reviewThreads: [],
+    });
+
+    await user.click(screen.getByRole("button", { name: /ci \/ checks/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Path Filtered CI on PR / Fast Checks (Lint, Type, Unit)")).toBeTruthy();
+      expect(screen.getByText("Path Filtered CI on PR / Coverage Report")).toBeTruthy();
+      expect(screen.getByText("Greptile Review")).toBeTruthy();
+      expect(screen.getByText("All 3 checks passing")).toBeTruthy();
+      expect(screen.queryByText("Fast Checks (Lint, Type, Unit)")).toBeNull();
+      expect(screen.queryByText("Coverage Report")).toBeNull();
     });
   });
 

--- a/apps/desktop/src/renderer/components/prs/detail/PrDetailPane.tsx
+++ b/apps/desktop/src/renderer/components/prs/detail/PrDetailPane.tsx
@@ -1071,21 +1071,47 @@ export function PrDetailPane({
     }
   }, [activeTab, refreshDetailSurface]);
 
+  const formatReviewThreadContext = React.useCallback((threadId: string): string | null => {
+    const thread = reviewThreads.find((entry) => `thread:${entry.id}` === threadId || entry.id === threadId);
+    if (!thread) return null;
+    const parts = thread.comments.map((comment, index) => {
+      const author = comment.author || "unknown";
+      const body = (comment.body ?? "").trim() || "(empty comment)";
+      const label = thread.comments.length > 1
+        ? `${author} (${index + 1}/${thread.comments.length})`
+        : author;
+      return `${label}:\n${body}`;
+    });
+    return parts.length > 0 ? parts.join("\n\n") : null;
+  }, [reviewThreads]);
+
   const mapInventoryItems = React.useCallback((snapshot: IssueInventorySnapshot | null): PanelIssueItem[] => {
     if (!snapshot) return [];
-    return snapshot.items.map((item) => ({
-      id: item.id,
-      state: item.state === "sent_to_agent" ? "in_progress" : item.state,
-      severity: item.severity ?? "minor",
-      headline: item.headline,
-      filePath: item.filePath,
-      line: item.line,
-      source: item.source === "unknown" ? "human" : item.source,
-      dismissReason: item.dismissReason,
-      agentSessionId: item.agentSessionId,
-      url: item.url,
-    })) as PanelIssueItem[];
-  }, []);
+    return snapshot.items.map((item) => {
+      const fullThreadContext = item.type === "review_thread"
+        ? formatReviewThreadContext(item.externalId)
+        : null;
+      return {
+        id: item.id,
+        type: item.type,
+        externalId: item.externalId,
+        state: item.state === "sent_to_agent" ? "in_progress" : item.state,
+        severity: item.severity ?? "minor",
+        headline: item.headline,
+        filePath: item.filePath,
+        line: item.line,
+        source: item.source === "unknown" ? "human" : item.source,
+        dismissReason: item.dismissReason,
+        agentSessionId: item.agentSessionId,
+        url: item.url,
+        body: fullThreadContext ?? item.body,
+        author: item.author,
+        threadCommentCount: item.threadCommentCount ?? null,
+        threadLatestCommentAuthor: item.threadLatestCommentAuthor ?? null,
+        threadLatestCommentAt: item.threadLatestCommentAt ?? null,
+      };
+    }) as PanelIssueItem[];
+  }, [formatReviewThreadContext]);
 
   const handleOpenInventorySource = React.useCallback((item: PanelIssueItem) => {
     if (!item.url) return;
@@ -3371,9 +3397,36 @@ type UnifiedCheckItem = {
   workflowName?: string;
 };
 
+function normalizeCheckName(value: string): string {
+  return value.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function normalizeCheckComposite(workflowName: string, jobName: string): string {
+  return `${normalizeCheckName(workflowName)}/${normalizeCheckName(jobName)}`;
+}
+
+function extractActionsJobId(detailsUrl: string | null | undefined): string | null {
+  const match = (detailsUrl ?? "").match(/\/actions\/runs\/\d+\/job\/(\d+)(?:[/?#]|$)/);
+  return match?.[1] ?? null;
+}
+
+function isActionsRunUrl(detailsUrl: string | null | undefined): boolean {
+  return /\/actions\/runs\/\d+(?:[/?#]|\/|$)/.test(detailsUrl ?? "");
+}
+
+function buildActionsJobDetailsUrl(runUrl: string, jobId: number): string | null {
+  const trimmed = runUrl.trim();
+  if (!trimmed) return null;
+  if (jobId > 0 && /\/actions\/runs\/\d+(?:[/?#]|$)/.test(trimmed)) {
+    return `${trimmed.replace(/\/$/, "")}/job/${jobId}`;
+  }
+  return trimmed;
+}
+
 function buildUnifiedChecks(checks: PrCheck[], actionRuns: PrActionRun[]): UnifiedCheckItem[] {
   const items: UnifiedCheckItem[] = [];
   const coveredNames = new Set<string>();
+  const coveredActionJobIds = new Set<string>();
 
   // Collapse reruns: for each workflow name, keep only the newest run
   // (multiple runs with the same name are reruns of the same workflow)
@@ -3386,18 +3439,34 @@ function buildUnifiedChecks(checks: PrCheck[], actionRuns: PrActionRun[]): Unifi
   }
   const dedupedRuns = Array.from(latestRunByWorkflow.values());
 
+  const actionJobNameCounts = new Map<string, number>();
+  for (const run of dedupedRuns) {
+    for (const job of run.jobs) {
+      const normalizedName = normalizeCheckName(job.name);
+      if (!normalizedName) continue;
+      actionJobNameCounts.set(normalizedName, (actionJobNameCounts.get(normalizedName) ?? 0) + 1);
+    }
+  }
+  const uniqueActionJobNames = new Set(
+    Array.from(actionJobNameCounts.entries())
+      .filter(([, count]) => count === 1)
+      .map(([name]) => name),
+  );
+
   // First: add all jobs from the latest action runs (these have the most detail)
   for (const run of dedupedRuns) {
     for (const job of run.jobs) {
       // Build the canonical name to match against checks API
       const canonicalName = `${run.name} / ${job.name}`;
-      coveredNames.add(canonicalName.toLowerCase());
+      coveredNames.add(normalizeCheckName(canonicalName));
       // Use composite key to avoid collisions across workflows (e.g. two workflows both having a "build" job)
-      coveredNames.add(`${run.name}/${job.name}`.toLowerCase());
+      coveredNames.add(normalizeCheckComposite(run.name, job.name));
+      if (job.id > 0) coveredActionJobIds.add(String(job.id));
 
       const duration = job.startedAt && job.completedAt
         ? Math.round((new Date(job.completedAt).getTime() - new Date(job.startedAt).getTime()) / 1000)
         : null;
+      const detailsUrl = buildActionsJobDetailsUrl(run.htmlUrl, job.id);
 
       items.push({
         id: `job-${job.id}`,
@@ -3406,7 +3475,7 @@ function buildUnifiedChecks(checks: PrCheck[], actionRuns: PrActionRun[]): Unifi
         status: job.status,
         conclusion: job.conclusion,
         duration,
-        detailsUrl: run.htmlUrl,
+        detailsUrl,
         source: "actions_job",
         steps: job.steps,
         workflowName: run.name,
@@ -3416,16 +3485,23 @@ function buildUnifiedChecks(checks: PrCheck[], actionRuns: PrActionRun[]): Unifi
 
   // Second: add checks that aren't covered by action run jobs (third-party checks)
   for (const check of checks) {
-    const lowerName = check.name.toLowerCase();
+    const lowerName = normalizeCheckName(check.name);
+    const actionsJobId = extractActionsJobId(check.detailsUrl);
+    if (actionsJobId && coveredActionJobIds.has(actionsJobId)) continue;
     // Skip if this check is already covered by an action run job
     if (coveredNames.has(lowerName)) continue;
+    // GitHub Actions check-runs often expose only the job name, while the
+    // workflow-runs API gives us "{workflow} / {job}". When the job name is
+    // unique, treat the check-run as the same Actions job instead of adding it
+    // as a second CI item.
+    if (isActionsRunUrl(check.detailsUrl) && uniqueActionJobNames.has(lowerName)) continue;
     // Also check if the check name matches "{workflow} / {job}" pattern
     const slashIdx = check.name.indexOf("/");
     if (slashIdx > 0) {
-      const workflowPart = check.name.slice(0, slashIdx).trim().toLowerCase();
-      const jobPart = check.name.slice(slashIdx + 1).trim().toLowerCase();
+      const workflowPart = check.name.slice(0, slashIdx).trim();
+      const jobPart = check.name.slice(slashIdx + 1).trim();
       // Use composite key to match against workflow/job keys stored above
-      if (coveredNames.has(`${workflowPart}/${jobPart}`)) continue;
+      if (coveredNames.has(normalizeCheckComposite(workflowPart, jobPart))) continue;
     }
 
     const duration = check.startedAt && check.completedAt

--- a/apps/desktop/src/renderer/components/prs/shared/PrConvergencePanel.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/shared/PrConvergencePanel.test.tsx
@@ -153,11 +153,67 @@ describe("PrConvergencePanel", () => {
       waitState: { phase: "agent_running", sessionId: "session-123" },
     });
 
-    expect(screen.getByText("Agent working on round 2...")).toBeTruthy();
+    expect(screen.getByText("Agent working on round 1...")).toBeTruthy();
     expect(screen.getByTestId("pipeline-settings").textContent).toContain("auto-converge-settings");
 
     await user.click(screen.getAllByRole("button", { name: /View Session/i })[0]!);
     expect(props.onViewAgentSession).toHaveBeenCalledWith("session-123");
+  });
+
+  it("does not describe a manual agent run as the next round", () => {
+    renderPanel({
+      items: [makeItem()],
+      convergence: makeConvergence({ state: "converging", currentRound: 1 }),
+      waitState: { phase: "agent_running", sessionId: "session-123" },
+    });
+
+    expect(screen.getByText("Agent working on Path to Merge...")).toBeTruthy();
+    expect(screen.queryByText("Agent working on round 1...")).toBeNull();
+    expect(screen.queryByText("Agent working on round 2...")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Stop Auto-Converge" })).toBeNull();
+  });
+
+  it("expands a review item to show the full stored comment context", async () => {
+    const user = userEvent.setup();
+    renderPanel({
+      items: [
+        makeItem({
+          body: "The compact headline is not enough.\nPlease include this second line too.",
+          author: "reviewer",
+          threadCommentCount: 2,
+        }),
+      ],
+    });
+
+    expect(screen.queryByText(/Please include this second line too/i)).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Expand comment context" }));
+
+    expect(screen.getByText(/Please include this second line too/i)).toBeTruthy();
+    expect(screen.getByText("reviewer")).toBeTruthy();
+    expect(screen.getByText("2 comments")).toBeTruthy();
+  });
+
+  it("hides ignored review items until the ignored section is shown", async () => {
+    const user = userEvent.setup();
+    renderPanel({
+      items: [
+        makeItem({
+          id: "ignored-1",
+          state: "dismissed",
+          headline: "Ignore this historical thread",
+          dismissReason: "Ignored from Path to Merge",
+        }),
+      ],
+    });
+
+    expect(screen.queryByText("Ignore this historical thread")).toBeNull();
+    expect(screen.getByText("Ignored comments are hidden.")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Show ignored (1)" }));
+
+    expect(screen.getByText("Ignore this historical thread")).toBeTruthy();
+    expect(screen.getByText("Ignored from Path to Merge")).toBeTruthy();
   });
 
   it("allows dismissing and escalating unresolved review items", async () => {
@@ -168,8 +224,8 @@ describe("PrConvergencePanel", () => {
       ],
     });
 
-    await user.click(screen.getByTitle("Dismiss"));
-    expect(props.onMarkDismissed).toHaveBeenCalledWith(["issue-1"], "Dismissed from UI");
+    await user.click(screen.getByRole("button", { name: "Ignore comment" }));
+    expect(props.onMarkDismissed).toHaveBeenCalledWith(["issue-1"], "Ignored from Path to Merge");
 
     await user.click(screen.getByTitle("Escalate"));
     expect(props.onMarkEscalated).toHaveBeenCalledWith(["issue-1"]);

--- a/apps/desktop/src/renderer/components/prs/shared/PrConvergencePanel.tsx
+++ b/apps/desktop/src/renderer/components/prs/shared/PrConvergencePanel.tsx
@@ -1225,10 +1225,33 @@ export function PrConvergencePanel({
             </div>
           </div>
         </div>
-        {visibleReviewCommentItems.length > 0 ? (
+        {visibleReviewCommentItems.length > 0 || grouped.dismissed.length > 0 ? (
           <div style={{ border: `1px solid ${COLORS.border}`, borderRadius: 10, overflow: "hidden", background: "rgba(255,255,255,0.015)" }}>
-            <div style={{ padding: "10px 14px", borderBottom: `1px solid ${COLORS.border}`, fontFamily: SANS_FONT, fontSize: 11, fontWeight: 700, color: COLORS.textPrimary, textTransform: "uppercase", letterSpacing: "0.05em" }}>
-              Historical review inventory
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8, padding: "10px 14px", borderBottom: `1px solid ${COLORS.border}` }}>
+              <div style={{ fontFamily: SANS_FONT, fontSize: 11, fontWeight: 700, color: COLORS.textPrimary, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                Historical review inventory
+              </div>
+              {grouped.dismissed.length > 0 ? (
+                <button
+                  type="button"
+                  onClick={() => setShowIgnoredItems((value) => !value)}
+                  style={{
+                    height: 24,
+                    padding: "0 8px",
+                    borderRadius: 6,
+                    border: `1px solid ${COLORS.border}`,
+                    background: showIgnoredItems ? "rgba(255,255,255,0.06)" : "rgba(255,255,255,0.02)",
+                    cursor: "pointer",
+                    color: showIgnoredItems ? COLORS.textSecondary : COLORS.textMuted,
+                    fontFamily: SANS_FONT,
+                    fontSize: 10,
+                    fontWeight: 600,
+                    flexShrink: 0,
+                  }}
+                >
+                  {showIgnoredItems ? "Hide ignored" : `Show ignored (${grouped.dismissed.length})`}
+                </button>
+              ) : null}
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 6, padding: 8 }}>
               {visibleReviewCommentItems.map((item) => (

--- a/apps/desktop/src/renderer/components/prs/shared/PrConvergencePanel.tsx
+++ b/apps/desktop/src/renderer/components/prs/shared/PrConvergencePanel.tsx
@@ -8,6 +8,8 @@ import {
   ArrowsClockwise,
   Eye,
   ArrowSquareOut,
+  CaretDown,
+  CaretRight,
   Trash,
   ArrowUp,
   Play,
@@ -33,6 +35,8 @@ export type IssueItemState = "new" | "in_progress" | "fixed" | "dismissed" | "es
 
 export type IssueInventoryItem = {
   id: string;
+  type?: "review_thread" | "check_failure" | "issue_comment";
+  externalId?: string;
   state: IssueItemState;
   severity: IssueItemSeverity;
   headline: string;
@@ -42,6 +46,11 @@ export type IssueInventoryItem = {
   dismissReason: string | null;
   agentSessionId: string | null;
   url?: string | null;
+  body?: string | null;
+  author?: string | null;
+  threadCommentCount?: number | null;
+  threadLatestCommentAuthor?: string | null;
+  threadLatestCommentAt?: string | null;
 };
 
 export type ConvergenceStatus = {
@@ -414,12 +423,16 @@ function SourceTag({ source }: { source: IssueItemSource }) {
 function IssueRow({
   item,
   showAgent,
+  expanded,
+  onToggleExpanded,
   onDismiss,
   onEscalate,
   onOpenSource,
 }: {
   item: IssueInventoryItem;
   showAgent?: boolean;
+  expanded?: boolean;
+  onToggleExpanded?: (itemId: string) => void;
   onDismiss?: (itemId: string) => void;
   onEscalate?: (itemId: string) => void;
   onOpenSource?: (item: IssueInventoryItem) => void;
@@ -428,12 +441,16 @@ function IssueRow({
   if (item.filePath) {
     location = item.line != null ? `${item.filePath}:${item.line}` : item.filePath;
   }
+  const body = (item.body ?? "").trim();
+  const hasDetails = body.length > 0 || Boolean(item.author) || Boolean(item.threadCommentCount) || Boolean(location);
+  const detailAuthor = item.threadLatestCommentAuthor ?? item.author ?? null;
+  const detailCommentCount = item.threadCommentCount ?? null;
 
   return (
     <div
       style={{
         display: "flex",
-        alignItems: "center",
+        alignItems: "flex-start",
         gap: 10,
         padding: "9px 12px",
         borderRadius: 8,
@@ -442,6 +459,30 @@ function IssueRow({
         animation: "convergeFadeIn 0.25s ease-out",
       }}
     >
+      {onToggleExpanded && hasDetails ? (
+        <button
+          type="button"
+          title={expanded ? "Collapse full comment context" : "Expand full comment context"}
+          aria-label={expanded ? "Collapse comment context" : "Expand comment context"}
+          onClick={() => onToggleExpanded(item.id)}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 22,
+            height: 22,
+            borderRadius: 4,
+            border: `1px solid ${COLORS.border}`,
+            background: "rgba(255,255,255,0.03)",
+            cursor: "pointer",
+            color: COLORS.textMuted,
+            padding: 0,
+            flexShrink: 0,
+          }}
+        >
+          {expanded ? <CaretDown size={12} weight="bold" /> : <CaretRight size={12} weight="bold" />}
+        </button>
+      ) : null}
       <SeverityBadge severity={item.severity} />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div
@@ -450,9 +491,11 @@ function IssueRow({
             fontSize: 12,
             fontWeight: 600,
             color: COLORS.textPrimary,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
+            overflow: expanded ? "visible" : "hidden",
+            textOverflow: expanded ? "clip" : "ellipsis",
+            whiteSpace: expanded ? "normal" : "nowrap",
+            overflowWrap: "anywhere",
+            lineHeight: 1.45,
           }}
         >
           {item.headline}
@@ -470,6 +513,50 @@ function IssueRow({
             }}
           >
             {location}
+          </div>
+        ) : null}
+        {expanded ? (
+          <div
+            style={{
+              marginTop: 8,
+              padding: "8px 10px",
+              borderRadius: 6,
+              border: `1px solid ${COLORS.border}`,
+              background: "rgba(0,0,0,0.16)",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                flexWrap: "wrap",
+                marginBottom: body ? 6 : 0,
+                fontFamily: MONO_FONT,
+                fontSize: 10,
+                color: COLORS.textMuted,
+              }}
+            >
+              {detailAuthor ? <span>{detailAuthor}</span> : null}
+              {detailCommentCount != null ? (
+                <span>{detailCommentCount} {detailCommentCount === 1 ? "comment" : "comments"}</span>
+              ) : null}
+              {location ? <span>{location}</span> : null}
+            </div>
+            {body ? (
+              <div
+                style={{
+                  fontFamily: SANS_FONT,
+                  fontSize: 11,
+                  lineHeight: 1.6,
+                  color: COLORS.textSecondary,
+                  whiteSpace: "pre-wrap",
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {body}
+              </div>
+            ) : null}
           </div>
         ) : null}
       </div>
@@ -521,7 +608,8 @@ function IssueRow({
       {onDismiss && item.state !== "fixed" && item.state !== "dismissed" ? (
         <button
           type="button"
-          title="Dismiss"
+          title="Ignore comment"
+          aria-label="Ignore comment"
           onClick={() => onDismiss(item.id)}
           style={{
             display: "inline-flex",
@@ -723,6 +811,7 @@ function CheckRow({ check }: { check: PrCheck }) {
 function WaitingIndicator({
   waitState,
   convergence,
+  showRoundLabels,
   onViewSession,
   onResumePause,
   onDismissPause,
@@ -731,6 +820,7 @@ function WaitingIndicator({
 }: {
   waitState: AutoConvergeWaitState;
   convergence: ConvergenceStatus;
+  showRoundLabels: boolean;
   onViewSession?: (sessionId: string) => void;
   onResumePause?: () => void;
   onDismissPause?: () => void;
@@ -765,6 +855,9 @@ function WaitingIndicator({
   };
 
   if (waitState.phase === "agent_running") {
+    const label = showRoundLabels
+      ? `Agent working on round ${Math.max(1, convergence.currentRound)}...`
+      : "Agent working on Path to Merge...";
     return (
       <div
         style={{
@@ -780,7 +873,7 @@ function WaitingIndicator({
             weight="bold"
             style={{ animation: "convergeSpin 1s linear infinite", flexShrink: 0 }}
           />
-          <span>Agent working on round {convergence.currentRound + 1}...</span>
+          <span>{label}</span>
         </div>
         {onViewSession && (
           <button
@@ -872,6 +965,9 @@ function WaitingIndicator({
   }
 
   if (waitState.phase === "ready") {
+    const label = showRoundLabels
+      ? `Ready to launch round ${convergence.currentRound + 1}`
+      : "Ready to launch another Path to Merge run";
     return (
       <div
         style={{
@@ -891,7 +987,7 @@ function WaitingIndicator({
               flexShrink: 0,
             }}
           />
-          <span>Ready to launch round {convergence.currentRound + 1}</span>
+          <span>{label}</span>
         </div>
       </div>
     );
@@ -1039,6 +1135,8 @@ export function PrConvergencePanel({
 }: PrConvergencePanelProps) {
   const [additionalInstructions, setAdditionalInstructions] = React.useState("");
   const [mode, setMode] = React.useState<"manual" | "auto-converge">(autoConverge ? "auto-converge" : "manual");
+  const [expandedIssueIds, setExpandedIssueIds] = React.useState<Set<string>>(() => new Set());
+  const [showIgnoredItems, setShowIgnoredItems] = React.useState(false);
 
   React.useEffect(() => {
     ensureKeyframes();
@@ -1062,6 +1160,9 @@ export function PrConvergencePanel({
   }
 
   const reviewCommentItems = [...grouped.escalated, ...grouped.new, ...grouped.in_progress, ...grouped.fixed, ...grouped.dismissed];
+  const visibleReviewCommentItems = showIgnoredItems
+    ? reviewCommentItems
+    : reviewCommentItems.filter((item) => item.state !== "dismissed");
   const failingChecks = checks.filter((c) => c.conclusion === "failure");
   const runningChecks = checks.filter((c) => c.status === "in_progress");
   const queuedChecks = checks.filter((c) => c.status === "queued");
@@ -1089,6 +1190,15 @@ export function PrConvergencePanel({
     : null;
 
   const isEmpty = items.length === 0 && checks.length === 0;
+  const showAutoConvergeControls = mode === "auto-converge" || autoConverge;
+  const toggleIssueExpanded = React.useCallback((itemId: string) => {
+    setExpandedIssueIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(itemId)) next.delete(itemId);
+      else next.add(itemId);
+      return next;
+    });
+  }, []);
 
   if (terminalState) {
     return (
@@ -1113,7 +1223,13 @@ export function PrConvergencePanel({
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 6, padding: 8 }}>
               {items.map((item) => (
-                <IssueRow key={item.id} item={item} onOpenSource={onOpenSource} />
+                <IssueRow
+                  key={item.id}
+                  item={item}
+                  expanded={expandedIssueIds.has(item.id)}
+                  onToggleExpanded={toggleIssueExpanded}
+                  onOpenSource={onOpenSource}
+                />
               ))}
             </div>
           </div>
@@ -1313,11 +1429,33 @@ export function PrConvergencePanel({
                       <ArrowsClockwise size={11} />
                     </button>
                   ) : null}
+                  {grouped.dismissed.length > 0 ? (
+                    <button
+                      type="button"
+                      onClick={() => setShowIgnoredItems((value) => !value)}
+                      style={{
+                        height: 24,
+                        padding: "0 8px",
+                        borderRadius: 6,
+                        border: `1px solid ${COLORS.border}`,
+                        background: showIgnoredItems ? "rgba(255,255,255,0.06)" : "rgba(255,255,255,0.02)",
+                        cursor: "pointer",
+                        color: showIgnoredItems ? COLORS.textSecondary : COLORS.textMuted,
+                        fontFamily: SANS_FONT,
+                        fontSize: 10,
+                        fontWeight: 600,
+                        flexShrink: 0,
+                      }}
+                    >
+                      {showIgnoredItems ? "Hide ignored" : `Show ignored (${grouped.dismissed.length})`}
+                    </button>
+                  ) : null}
                 </div>
                 <div style={{ flex: 1, overflow: "auto", padding: "8px" }}>
-                  {reviewCommentItems.length > 0 ? (
+                  {visibleReviewCommentItems.length > 0 ? (
                     <>
                       {STATE_ORDER.map((state) => {
+                        if (state === "dismissed" && !showIgnoredItems) return null;
                         const stateItems = grouped[state];
                         if (stateItems.length === 0) return null;
                         const meta = STATE_META[state];
@@ -1375,7 +1513,9 @@ export function PrConvergencePanel({
                                     key={item.id}
                                     item={item}
                                     showAgent={state === "in_progress"}
-                                    onDismiss={(id) => onMarkDismissed([id], "Dismissed from UI")}
+                                    expanded={expandedIssueIds.has(item.id)}
+                                    onToggleExpanded={toggleIssueExpanded}
+                                    onDismiss={(id) => onMarkDismissed([id], "Ignored from Path to Merge")}
                                     onEscalate={(id) => onMarkEscalated([id])}
                                     onOpenSource={onOpenSource}
                                   />
@@ -1396,7 +1536,9 @@ export function PrConvergencePanel({
                           lineHeight: 1.6,
                         }}
                       >
-                        No issues have been inventoried yet. Run the first round to discover issues from review comments.
+                        {reviewCommentItems.length > 0
+                          ? "Ignored comments are hidden."
+                          : "No issues have been inventoried yet. Run the first round to discover issues from review comments."}
                       </span>
                     </div>
                   )}
@@ -1580,15 +1722,16 @@ export function PrConvergencePanel({
       </div>
 
       {/* ---- Waiting indicator ---- */}
-      {(mode === "auto-converge" || waitState.phase !== "idle") && (
+      {(showAutoConvergeControls || waitState.phase !== "idle") && (
         <WaitingIndicator
           waitState={waitState}
           convergence={convergence}
+          showRoundLabels={showAutoConvergeControls}
           onViewSession={onViewAgentSession}
           onResumePause={onResumePause}
           onDismissPause={onDismissPause}
           onDismissMerged={onDismissMerged}
-          onStop={onStopAutoConverge}
+          onStop={showAutoConvergeControls ? onStopAutoConverge : undefined}
         />
       )}
 
@@ -1607,7 +1750,7 @@ export function PrConvergencePanel({
         }}
       >
         <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-          {(mode === "auto-converge" || waitState.phase !== "idle") && (
+          {showAutoConvergeControls && (
             <button
               type="button"
               onClick={onStopAutoConverge}

--- a/apps/desktop/src/renderer/components/prs/shared/PrConvergencePanel.tsx
+++ b/apps/desktop/src/renderer/components/prs/shared/PrConvergencePanel.tsx
@@ -23,6 +23,7 @@ import {
   outlineButton,
   primaryButton,
 } from "../../lanes/laneDesignTokens";
+import { formatTimeAgoCompact } from "./prFormatters";
 import { PrPipelineSettings } from "./PrPipelineSettings";
 
 // ---------------------------------------------------------------------------
@@ -445,6 +446,9 @@ function IssueRow({
   const hasDetails = body.length > 0 || Boolean(item.author) || Boolean(item.threadCommentCount) || Boolean(location);
   const detailAuthor = item.threadLatestCommentAuthor ?? item.author ?? null;
   const detailCommentCount = item.threadCommentCount ?? null;
+  const detailUpdatedAt = item.threadLatestCommentAt
+    ? formatTimeAgoCompact(item.threadLatestCommentAt)
+    : null;
 
   return (
     <div
@@ -537,7 +541,12 @@ function IssueRow({
                 color: COLORS.textMuted,
               }}
             >
-              {detailAuthor ? <span>{detailAuthor}</span> : null}
+              {detailAuthor ? (
+                <span>
+                  {detailAuthor}
+                  {detailUpdatedAt ? ` (updated ${detailUpdatedAt})` : ""}
+                </span>
+              ) : null}
               {detailCommentCount != null ? (
                 <span>{detailCommentCount} {detailCommentCount === 1 ? "comment" : "comments"}</span>
               ) : null}
@@ -966,7 +975,7 @@ function WaitingIndicator({
 
   if (waitState.phase === "ready") {
     const label = showRoundLabels
-      ? `Ready to launch round ${convergence.currentRound + 1}`
+      ? `Ready to launch round ${Math.min(convergence.maxRounds, convergence.currentRound + 1)}`
       : "Ready to launch another Path to Merge run";
     return (
       <div
@@ -1216,13 +1225,13 @@ export function PrConvergencePanel({
             </div>
           </div>
         </div>
-        {items.length > 0 ? (
+        {visibleReviewCommentItems.length > 0 ? (
           <div style={{ border: `1px solid ${COLORS.border}`, borderRadius: 10, overflow: "hidden", background: "rgba(255,255,255,0.015)" }}>
             <div style={{ padding: "10px 14px", borderBottom: `1px solid ${COLORS.border}`, fontFamily: SANS_FONT, fontSize: 11, fontWeight: 700, color: COLORS.textPrimary, textTransform: "uppercase", letterSpacing: "0.05em" }}>
               Historical review inventory
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: 6, padding: 8 }}>
-              {items.map((item) => (
+              {visibleReviewCommentItems.map((item) => (
                 <IssueRow
                   key={item.id}
                   item={item}

--- a/apps/desktop/src/renderer/components/prs/shared/prFormatters.ts
+++ b/apps/desktop/src/renderer/components/prs/shared/prFormatters.ts
@@ -3,6 +3,20 @@
  * Consolidates duplicated timestamp-formatting and error-formatting logic.
  */
 
+import type { PrState } from "../../../../shared/types";
+
+/** State-aware compact PR badge text for dense toolbars and lane tabs. */
+export function formatPrBadgeLabel(pr: { state: PrState; githubPrNumber: number }): string {
+  const prefix = pr.state === "merged"
+    ? "MERGED"
+    : pr.state === "closed"
+      ? "CLOSED"
+      : pr.state === "draft"
+        ? "DRAFT"
+        : "PR";
+  return `${prefix} #${pr.githubPrNumber}`;
+}
+
 /** Relative "time ago" label: "just now", "3m ago", "2h ago", "5d ago", or a short date. */
 export function formatTimeAgo(iso: string | null): string {
   if (!iso) return "---";

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -76,6 +76,10 @@ struct WorkChatSessionView: View {
     pendingInputs.first
   }
 
+  var hasPendingInputGate: Bool {
+    !pendingInputs.isEmpty || sessionStatus == "awaiting-input"
+  }
+
   var toolCards: [WorkToolCardModel] {
     timelineSnapshot.toolCards
   }
@@ -125,15 +129,16 @@ struct WorkChatSessionView: View {
 
   var canCompose: Bool {
     // Typing stays available so users can draft while disconnected or while
-    // a turn is running. Only Send is gated via `canSend`; the feedback line
-    // below the composer explains why send is disabled.
-    canComposeMessages
+    // a turn is running, except when a blocking pending-input card is open —
+    // those replies must go through the structured card the runtime is awaiting.
+    canComposeMessages && !hasPendingInputGate
   }
 
   var canSend: Bool {
     // Existing chats accept messages while live, and can still accept them
-    // during reconnects when desktop advertised chat.send as queueable.
-    canSendMessages && !sending
+    // during reconnects when desktop advertised chat.send as queueable. Pending
+    // input is gated separately so the host receives a structured answer.
+    canSendMessages && !sending && !hasPendingInputGate
   }
 
   var composerFeedback: String? {
@@ -146,8 +151,8 @@ struct WorkChatSessionView: View {
     if !canSendMessages {
       return "Reconnect to send messages."
     }
-    if sessionStatus == "awaiting-input" {
-      return "Answer the waiting prompt above, or send extra context."
+    if hasPendingInputGate || sessionStatus == "awaiting-input" {
+      return "Answer the waiting prompt above, or decline it before sending another message."
     }
     return nil
   }
@@ -336,6 +341,7 @@ struct WorkChatSessionView: View {
         chatSummary: chatSummary,
         queuedSteerCount: pendingSteers.count,
         pendingInputCount: pendingInputs.count,
+        awaitingInputGate: hasPendingInputGate,
         canCompose: canCompose,
         canSend: canSend,
         sending: sending,
@@ -549,6 +555,7 @@ private struct WorkChatComposerCard: View {
   let chatSummary: AgentChatSessionSummary?
   let queuedSteerCount: Int
   let pendingInputCount: Int
+  let awaitingInputGate: Bool
   let canCompose: Bool
   let canSend: Bool
   let sending: Bool
@@ -574,6 +581,7 @@ private struct WorkChatComposerCard: View {
         chatSummary: chatSummary,
         queuedSteerCount: queuedSteerCount,
       pendingInputCount: pendingInputCount,
+      awaitingInputGate: awaitingInputGate,
       canCompose: canCompose,
       canSend: canSend,
       sending: sending,
@@ -623,6 +631,7 @@ private struct WorkChatComposerDraftInput: View {
   let chatSummary: AgentChatSessionSummary?
   let queuedSteerCount: Int
   let pendingInputCount: Int
+  let awaitingInputGate: Bool
   let canCompose: Bool
   let canSend: Bool
   let sending: Bool
@@ -656,7 +665,8 @@ private struct WorkChatComposerDraftInput: View {
     VStack(alignment: .leading, spacing: 12) {
       WorkChatComposerTextField(
         draftState: draftState,
-        canCompose: canCompose
+        canCompose: canCompose,
+        placeholder: awaitingInputGate ? "Answer the prompt above…" : "Type to vibecode…"
       )
 
       HStack(alignment: .center, spacing: 8) {
@@ -765,10 +775,11 @@ private final class WorkChatComposerDraftState: ObservableObject {
 private struct WorkChatComposerTextField: View {
   @ObservedObject var draftState: WorkChatComposerDraftState
   let canCompose: Bool
+  let placeholder: String
   @FocusState private var composerFocused: Bool
 
   var body: some View {
-    TextField("Type to vibecode…", text: $draftState.text, axis: .vertical)
+    TextField(placeholder, text: $draftState.text, axis: .vertical)
       .textFieldStyle(.plain)
       .lineLimit(1...6)
       .font(.body)

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -577,9 +577,9 @@ private struct WorkChatComposerCard: View {
   let onSent: () -> Void
 
   var body: some View {
-      WorkChatComposerDraftInput(
-        chatSummary: chatSummary,
-        queuedSteerCount: queuedSteerCount,
+    WorkChatComposerDraftInput(
+      chatSummary: chatSummary,
+      queuedSteerCount: queuedSteerCount,
       pendingInputCount: pendingInputCount,
       awaitingInputGate: awaitingInputGate,
       canCompose: canCompose,
@@ -592,13 +592,13 @@ private struct WorkChatComposerCard: View {
       onSelectRuntimeMode: onSelectRuntimeMode,
       onSelectEffort: onSelectEffort,
       artifactCount: artifactCount,
-        latestArtifact: latestArtifact,
-        artifactRefreshInFlight: artifactRefreshInFlight,
-        artifactRefreshError: artifactRefreshError,
-        onOpenProof: onOpenProof,
-        onSend: onSend,
-        onSent: onSent
-      )
+      latestArtifact: latestArtifact,
+      artifactRefreshInFlight: artifactRefreshInFlight,
+      artifactRefreshError: artifactRefreshError,
+      onOpenProof: onOpenProof,
+      onSend: onSend,
+      onSent: onSent
+    )
     .padding(.horizontal, 14)
     .padding(.vertical, 14)
     .background(composerSurface)

--- a/docs/features/chat/composer-and-ui.md
+++ b/docs/features/chat/composer-and-ui.md
@@ -161,12 +161,23 @@ and a footer that contains the composer.
   hidden for non-Claude providers (Codex, OpenCode, Cursor) which only
   support post-turn delivery.
 - **Question answering.** When a question-type pending input is active,
-  pressing Enter submits the draft text as the answer via
-  `onApproval("accept", answer)` rather than sending a new message.
+  the user answers (or declines) it through the inline question card.
   Multi-select questions render a toggle list plus a preview pane
   (sanitised via `ReactMarkdown` + `rehype-raw` + `rehype-sanitize` +
   `remark-gfm`). The per-question draft state (`QuestionDraft`) tracks
   `text`, `selectedValues`, and `activePreviewValue` independently.
+- **Composer lock while pending input is unresolved.** When
+  `pendingInput.blocking` is set, the composer hard-locks: the textarea
+  / rich editor are disabled, attachment, slash-command, and edit
+  affordances are gated, the placeholder switches to a "resolve the
+  pending request above" hint, and Enter is a no-op (Escape cancels
+  the request). The same gate runs server-side: `agentChatService`
+  refuses `sendMessage`, queued steers, and `dispatchSteer` while a
+  live pending input exists, throwing
+  `"Answer or decline the pending request before sending another
+  message."`. `AgentChatPane.submit` mirrors the message into the
+  composer's error banner so a fast double-Enter doesn't silently
+  drop the second send.
 
 ### Layout variants
 

--- a/docs/features/lanes/README.md
+++ b/docs/features/lanes/README.md
@@ -32,7 +32,7 @@ Renderer components:
 
 | File | Responsibility |
 |------|---------------|
-| `renderer/components/lanes/LanesPage.tsx` | 3-pane cockpit, tab management, dialog coordination |
+| `renderer/components/lanes/LanesPage.tsx` | 3-pane cockpit, tab management, dialog coordination. Each lane row in the lane list optionally renders a state-aware PR tag (`PR #N` / `DRAFT #N` / `MERGED #N` / `CLOSED #N`) when the lane's current branch matches an existing PR; the row uses `selectLanePrTag` (open/draft → merged → closed, then most recent) and falls back through the same branch-equality rules as `prService.getDisplayRowForCurrentLaneBranch`, so the badge stays attached to the lane even after the PR merges. |
 | `renderer/components/lanes/laneUtils.ts` | Pure lane list/filter helpers plus default pane trees, including the work-focused tiling tree used by parallel chat launch deep links. |
 | `renderer/components/lanes/laneColorPalette.ts` | Curated 12-swatch lane color palette (`LANE_COLOR_PALETTE`) plus helpers (`getLaneAccent`, `colorsInUse`, `nextAvailableColor`, `laneColorName`). The first 8 hexes form `LANE_FALLBACK_COLORS`, the legacy index-based fallback used for lanes that don't have an explicit color assigned. |
 | `renderer/components/lanes/LaneAccentDot.tsx` | Tiny accent dot used everywhere a lane is mentioned (lane list, tabs, PR rows, AppShell PR toasts). Resolves color via `getLaneAccent` so a lane without an explicit color falls back to a deterministic fallback hex. |

--- a/docs/features/pull-requests/README.md
+++ b/docs/features/pull-requests/README.md
@@ -18,7 +18,7 @@ Main-process services (`apps/desktop/src/main/services/prs/`):
 
 | File | Responsibility |
 |------|---------------|
-| `prService.ts` | PR CRUD, GitHub sync, merge context, draft descriptions, check/review/comment hydration, commit snapshots (`getCommits`), integration proposals, merge-into-existing-lane adoption, merge bypass, post-merge cleanup, standalone PR branch cleanup (`cleanupBranch`), deployment listing, review-thread reply/resolve/react mutations for the timeline, the aggregate `getMobileSnapshot` that powers the iOS PRs tab, and `listOpenPullRequests` — a paginated `/repos/{owner}/{name}/pulls?state=open` fetch returning `BranchPullRequest[]` for the lane-creation branch picker. |
+| `prService.ts` | PR CRUD, GitHub sync, merge context, draft descriptions, check/review/comment hydration, commit snapshots (`getCommits`), integration proposals, merge-into-existing-lane adoption, merge bypass, post-merge cleanup, standalone PR branch cleanup (`cleanupBranch`), deployment listing, review-thread reply/resolve/react mutations for the timeline, the aggregate `getMobileSnapshot` that powers the iOS PRs tab, and `listOpenPullRequests` — a paginated `/repos/{owner}/{name}/pulls?state=open` fetch returning `BranchPullRequest[]` for the lane-creation branch picker. `getForLane(laneId)` resolves through `getDisplayRowForCurrentLaneBranch`: it returns the most recently updated PR whose head branch matches the lane's current branch ref, ranked open/draft → merged → closed, so a freshly merged PR still shows in lane-scoped UI instead of disappearing the moment GitHub flips the state. |
 | `prService.mobileSnapshot.test.ts` | Coverage for the mobile snapshot builder: stack chaining, capability gates, per-lane create eligibility, workflow-card aggregation |
 | `prService.mergeInto.test.ts` | Coverage for integration proposals that preview or adopt an existing merge target lane, including dirty-worktree handling and drift metadata. |
 | `prPollingService.ts` | 60 s polling loop, fingerprint-based change detection, notification emission. Writes `last_polled_at` per PR so callers can run delta polls on the next tick |
@@ -26,7 +26,7 @@ Main-process services (`apps/desktop/src/main/services/prs/`):
 | `queueLandingService.ts` | Merge queue state machine (`ALLOWED_TRANSITIONS`), landing loop, auto-resolve on conflicts |
 | `integrationPlanning.ts` | `buildIntegrationPreflight` — validates source lanes for an integration proposal |
 | `integrationValidation.ts` | `parseGitStatusPorcelain`, `hasMergeConflictMarkers` — shared helpers for integration flows |
-| `issueInventoryService.ts` | Typed issue inventory, per-round convergence status, participant classification, thread re-open logic |
+| `issueInventoryService.ts` | Typed issue inventory, per-round convergence status, participant classification, thread re-open logic. `IssueInventoryItem` carries `type` (`review_thread | check_failure | issue_comment`), `externalId`, `body`, `author`, and `threadCommentCount` / `threadLatestCommentAuthor` / `threadLatestCommentAt` so `PrConvergencePanel` can render expandable rows with the full comment context inline. |
 | `prIssueResolver.ts` | Builds issue-resolution prompts for the agent, launches chat session |
 | `prRebaseResolver.ts` | Builds rebase-resolution prompts, launches chat session |
 | `resolverUtils.ts` | Shared permission-mode mapping, recent commit reading, comment noise filter, and the `looksLikeResolutionAck` heuristic that flags resolved-looking replies on unresolved review threads |
@@ -54,7 +54,7 @@ Renderer components (`apps/desktop/src/renderer/components/prs/`):
 | `shared/PrAiSummaryCard.tsx` | AI summary card above the timeline; dismissible per PR (state in `PrsContext.dismissedAiSummaries`), with a "Regenerate" action wired to `prSummaryService.regenerateSummary` |
 | `shared/PrReviewThreadCard.tsx`, `shared/PrBotReviewCard.tsx` | Rich thread cards for the timeline (bot-review collapse, reply box, resolve/react actions) |
 | `shared/PrDeploymentCard.tsx` | Deployment row used in the status rail and on the timeline |
-| `shared/PrConvergencePanel.tsx` | Auto-converge slide-over panel with issue inventory, agent session embed, pipeline settings |
+| `shared/PrConvergencePanel.tsx` | Auto-converge slide-over panel with issue inventory, agent session embed, pipeline settings. Each issue row is expandable (caret toggles full comment body, author, and thread comment count); a "show ignored" toggle un-hides previously dismissed items. The dismiss button is labelled "Ignore comment" so users understand it removes the item from the round without resolving the thread. The waiting-state copy hides the round number when the panel runs in non-round-aware contexts (`showRoundLabels = false`). |
 | `shared/PrIssueResolverModal.tsx` | Launch issue resolution (checks/comments/both scopes) |
 | `shared/PrAiResolverPanel.tsx` | AI resolver launch controls in Rebase/Integration flows, including additional-instructions passthrough |
 | `shared/PrPipelineSettings.tsx` | Auto-converge pipeline settings per PR |
@@ -64,6 +64,7 @@ Renderer components (`apps/desktop/src/renderer/components/prs/`):
 | `shared/rebaseNeedUtils.ts` | Rebase need dedup, route selection, upstream rebase chain |
 | `shared/rebaseAttentionUtils.ts` | Auto-rebase attention items for the Rebase tab |
 | `shared/lanePrWarnings.ts` | Pre-submit lane-health warnings |
+| `shared/prFormatters.ts` | Formatting helpers shared across PR surfaces. `formatPrBadgeLabel(pr)` returns a state-aware compact badge (`PR #123`, `DRAFT #123`, `MERGED #123`, `CLOSED #123`) used by the chat git toolbar and the lane list PR tag so closed/merged PRs aren't visually identical to open ones. |
 | `shared/laneBranchTargets.ts` | Target branch resolution for PR creation |
 | `ConflictFilePreview.tsx` | File-level conflict marker preview |
 | `PrRebaseBanner.tsx` | Rebase banner on a PR |


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Composer is disabled while a pending input/approval is awaiting answer; sending, steering, and shortcuts are blocked until resolved.
  * CI/checks list deduplicates GitHub Actions entries to avoid duplicate checks.

* **New Features**
  * PR badges now surface merged PRs that still match your branch and show compact labeled badges.
  * Convergence panel shows full review-thread context and lets you expand/hide ignored comments.
  * iOS composer shows a gated placeholder/message when awaiting input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes several PRs-tab and chat-composer regressions: the chat composer now locks while a blocking pending-input card is active (desktop + iOS), merged PRs matching the current lane branch are surfaced in the sidebar badge and chat toolbar, GitHub Actions check-run deduplication is improved by job ID and unique-name matching, and the Convergence panel gains expandable comment context with an ignored-items toggle.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 edge cases with no current data-loss or breakage risk.

No P0/P1 issues found. The two P2 comments cover a narrow Electron IPC race during project switch (prs-updated guard) and a clarification question about whether non-blocking freeform questions still exist in practice. Both are low-probability in a desktop app and do not affect the primary user paths changed by this PR.

apps/desktop/src/renderer/components/lanes/LanesPage.tsx (prs-updated event guard) and apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx (non-blocking question submit removal)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/prs/prService.ts | Renamed rowMatchesCurrentLaneBranch → rowMatchesLaneBranchForDisplay (removed implicit isActivePrState gate); added getDisplayRowForCurrentLaneBranch that accepts merged PRs and removed the rows[0] stray-fallback; getForLane now routes through the new function |
| apps/desktop/src/renderer/components/lanes/LanesPage.tsx | Adds selectLanePrTag / lanePrMatchesCurrentBranch for client-side PR badge display on lane tabs; subscribes to prs-updated / pr-notification events; prs-updated handler sets state directly without a cross-project stale guard |
| apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx | Adds composerInputLocked (blocking pending input) to disable textarea, attachment picker, command menu, and steer button; replaces the old "type in composer to answer" flow with a hard lock; old non-blocking question submit path is removed |
| apps/desktop/src/renderer/components/prs/detail/PrDetailPane.tsx | Adds formatReviewThreadContext to enrich PanelIssueItem.body; improves buildUnifiedChecks to deduplicate check-runs that mirror Actions workflow jobs by job ID and unique name matching |
| apps/desktop/src/renderer/components/prs/shared/PrConvergencePanel.tsx | Adds expandable comment context, show/hide ignored items toggle, and showRoundLabels distinction for manual vs auto-converge agent runs; dismiss reason updated to "Ignored from Path to Merge" |
| apps/ios/ADE/Views/Work/WorkChatSessionView.swift | Adds hasPendingInputGate to block canCompose and canSend when any pending input exists; passes awaitingInputGate to composer card for context-sensitive placeholder |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Adds submit-time guard in submit() that checks pendingInputsBySession and session.awaitingInput before allowing a new message; moves setPromptSuggestion(null) call into submit() |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Renderer as LanesPage / ChatPane
    participant PRSvc as prService (main)
    participant DB as SQLite

    Note over Renderer,DB: Lane PR badge (sidebar)
    Renderer->>PRSvc: window.ade.prs.listAll()
    PRSvc->>DB: SELECT all PRs (lane_id, project_id)
    DB-->>PRSvc: PullRequestRow[]
    PRSvc-->>Renderer: PrSummary[] (all states incl. merged)
    Renderer->>Renderer: selectLanePrTag(lane, prs)<br/>prefer open/draft > merged > closed

    Note over Renderer,DB: Chat toolbar badge
    Renderer->>PRSvc: prs.getForLane(laneId)
    PRSvc->>DB: SELECT ORDER BY state priority + recency
    DB-->>PRSvc: PullRequestRow[]
    PRSvc->>PRSvc: rowMatchesLaneBranchForDisplay()<br/>(branch match, no state filter)
    PRSvc-->>Renderer: PrSummary | null (merged OK)

    Note over Renderer,DB: Live PR event update
    PRSvc-->>Renderer: onEvent(prs-updated, prs)
    Renderer->>Renderer: setLanePrTags(prs) no project guard

    Note over Renderer,DB: Pending input gate
    Renderer->>Renderer: composerInputLocked = pendingInput?.blocking
    Renderer->>PRSvc: sendMessage() blocked if hasLivePendingInput
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Flanes%2FLanesPage.tsx%3A997-1004%0A**%60prs-updated%60%20handler%20sets%20state%20without%20cross-project%20guard**%0A%0A%60refreshLanePrTags%60%20guards%20against%20cross-project%20stale%20responses%20with%20%60startedRoot%60%20%2F%20%60requestId%60%20checks%2C%20but%20the%20%60prs-updated%60%20branch%20calls%20%60setLanePrTags%28event.prs%29%60%20directly.%20If%20a%20%60prs-updated%60%20event%20is%20dispatched%20synchronously%20just%20before%20the%20%60onEvent%60%20cleanup%20runs%20during%20a%20project%20switch%2C%20the%20tags%20for%20the%20old%20project%20will%20briefly%20override%20the%20%60setLanePrTags%28%5B%5D%29%60%20reset%20emitted%20by%20the%20rootPath%20effect%20%E2%80%94%20showing%20wrong%20PR%20badges%20on%20the%20incoming%20project's%20lane%20list%20until%20the%20next%20refresh.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FAgentChatComposer.tsx%3A329-334%0A**Non-blocking%20questions%20no%20longer%20submitted%20via%20the%20composer**%0A%0A%60composerInputLocked%60%20is%20%60false%60%20when%20%60pendingInput%3F.blocking%60%20is%20%60false%60%2C%20so%20the%20composer%20stays%20fully%20editable.%20However%20the%20old%20%60submitComposerDraft%60%20path%20that%20forwarded%20the%20draft%20as%20an%20answer%20%28via%20%60onApproval%28%22accept%22%2C%20answer%29%60%29%20has%20been%20removed%20entirely.%20If%20a%20non-blocking%20question-type%20input%20exists%20today%2C%20a%20user%20can%20type%20in%20the%20composer%20and%20submit%20%E2%80%94%20but%20the%20text%20is%20sent%20as%20a%20normal%20chat%20message%2C%20silently%20bypassing%20the%20pending%20question%20rather%20than%20answering%20it.%20The%20hint%20still%20says%20%22Answer%20in%20the%20inline%20question%20card%2C%20or%20decline%22%20which%20matches%20the%20new%20intent%3B%20just%20confirming%20that%20non-blocking%20freeform%20questions%20are%20no%20longer%20handled%20this%20way%20by%20design.%0A%0A&repo=arul28%2Fade&pr=240&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src/renderer/components/lanes/LanesPage.tsx:997-1004
**`prs-updated` handler sets state without cross-project guard**

`refreshLanePrTags` guards against cross-project stale responses with `startedRoot` / `requestId` checks, but the `prs-updated` branch calls `setLanePrTags(event.prs)` directly. If a `prs-updated` event is dispatched synchronously just before the `onEvent` cleanup runs during a project switch, the tags for the old project will briefly override the `setLanePrTags([])` reset emitted by the rootPath effect — showing wrong PR badges on the incoming project's lane list until the next refresh.

### Issue 2 of 2
apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx:329-334
**Non-blocking questions no longer submitted via the composer**

`composerInputLocked` is `false` when `pendingInput?.blocking` is `false`, so the composer stays fully editable. However the old `submitComposerDraft` path that forwarded the draft as an answer (via `onApproval("accept", answer)`) has been removed entirely. If a non-blocking question-type input exists today, a user can type in the composer and submit — but the text is sent as a normal chat message, silently bypassing the pending question rather than answering it. The hint still says "Answer in the inline question card, or decline" which matches the new intent; just confirming that non-blocking freeform questions are no longer handled this way by design.

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["ship: iter 3 — Show ignored toggle reach..."](https://github.com/arul28/ade/commit/be9654b3d24248384db71b7b51be10e2e6099514) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30624464)</sub>

<!-- /greptile_comment -->