### PR TITLE
Fix macOS release launch entitlement

### DIFF
--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -6,9 +6,5 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
-    <key>keychain-access-groups</key>
-    <array>
-      <string>VQ372F39G6.com.ade.desktop.webauthn</string>
-    </array>
   </dict>
 </plist>

--- a/apps/desktop/src/main/services/builtInBrowser/builtInBrowserWebAuthn.test.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/builtInBrowserWebAuthn.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fakes = vi.hoisted(() => {
   type WebAuthnAccount = {
@@ -71,9 +71,20 @@ async function flushPromises(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+const originalTouchIdWebAuthnEnv = process.env.ADE_ENABLE_TOUCH_ID_WEBAUTHN;
+
 describe("configureBuiltInBrowserWebAuthn", () => {
   beforeEach(() => {
     fakes.reset();
+    delete process.env.ADE_ENABLE_TOUCH_ID_WEBAUTHN;
+  });
+
+  afterEach(() => {
+    if (originalTouchIdWebAuthnEnv === undefined) {
+      delete process.env.ADE_ENABLE_TOUCH_ID_WEBAUTHN;
+    } else {
+      process.env.ADE_ENABLE_TOUCH_ID_WEBAUTHN = originalTouchIdWebAuthnEnv;
+    }
   });
 
   it("configures the browser session once", async () => {
@@ -85,6 +96,15 @@ describe("configureBuiltInBrowserWebAuthn", () => {
     expect(fakes.session.fromPartition).toHaveBeenCalledTimes(1);
     expect(fakes.session.fromPartition).toHaveBeenCalledWith("persist:ade-browser");
     expect(fakes.handlers["select-webauthn-account"]).toHaveLength(1);
+    expect(fakes.app.configureWebAuthn).not.toHaveBeenCalled();
+  });
+
+  it("configures Touch ID WebAuthn only when explicitly enabled", async () => {
+    process.env.ADE_ENABLE_TOUCH_ID_WEBAUTHN = "1";
+    const { configureBuiltInBrowserWebAuthn } = await loadModule();
+
+    configureBuiltInBrowserWebAuthn();
+
     if (process.platform === "darwin") {
       expect(fakes.app.configureWebAuthn).toHaveBeenCalledWith({
         touchID: { keychainAccessGroup: "VQ372F39G6.com.ade.desktop.webauthn" },

--- a/apps/desktop/src/main/services/builtInBrowser/builtInBrowserWebAuthn.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/builtInBrowserWebAuthn.ts
@@ -8,6 +8,11 @@ import {
 
 let configured = false;
 
+function isTouchIdWebAuthnEnabled(): boolean {
+  const value = process.env.ADE_ENABLE_TOUCH_ID_WEBAUTHN?.trim().toLowerCase();
+  return value === "1" || value === "true";
+}
+
 export function configureBuiltInBrowserWebAuthn(args: {
   getLogger?: () => Logger | null;
 } = {}): void {
@@ -22,7 +27,7 @@ export function configureBuiltInBrowserWebAuthn(args: {
     }
   };
 
-  if (process.platform === "darwin") {
+  if (process.platform === "darwin" && isTouchIdWebAuthnEnabled()) {
     try {
       app.configureWebAuthn({
         touchID: {
@@ -38,6 +43,11 @@ export function configureBuiltInBrowserWebAuthn(args: {
         keychainAccessGroup: BUILT_IN_BROWSER_WEBAUTHN_KEYCHAIN_ACCESS_GROUP,
       });
     }
+  } else if (process.platform === "darwin") {
+    logger()?.debug("built_in_browser.webauthn_touchid_disabled", {
+      reason: "missing_provisioned_keychain_access_group",
+      keychainAccessGroup: BUILT_IN_BROWSER_WEBAUTHN_KEYCHAIN_ACCESS_GROUP,
+    });
   }
 
   const browserSession = session.fromPartition(BUILT_IN_BROWSER_PARTITION);


### PR DESCRIPTION
## Summary
- remove the unprovisioned macOS keychain-access-groups entitlement from the Developer ID app
- leave Touch ID WebAuthn disabled by default unless ADE_ENABLE_TOUCH_ID_WEBAUTHN is explicitly set
- keep the built-in browser session WebAuthn account chooser registration intact

## Validation
- npm --prefix apps/desktop run test -- src/main/services/builtInBrowser/builtInBrowserWebAuthn.test.ts --reporter=verbose
- npm --prefix apps/desktop run typecheck
- npm --prefix apps/desktop run release:mac:local -- v1.1.11 --zip-only
- npm --prefix apps/desktop run lint (0 errors, existing warnings only)

## Release note
Desktop release pipeline fix only; no changelog update needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added and updated Touch ID WebAuthn configuration tests.
* **Chores**
  * Updated macOS security entitlements.
  * Added conditional gating for Touch ID WebAuthn support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the macOS Developer ID release pipeline by removing an unprovisioned `keychain-access-groups` entitlement from the plist and gating the `app.configureWebAuthn()` Touch ID call behind an explicit `ADE_ENABLE_TOUCH_ID_WEBAUTHN` env var. The built-in browser session WebAuthn account-chooser (the `select-webauthn-account` handler) is preserved unchanged.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all findings are P2; the fix is targeted and the core WebAuthn session handler is untouched.

No P0 or P1 issues found. Three P2 observations: a misleading debug log reason string, a silent-failure risk when the env flag is set in a build without the entitlement, and a platform-guarded test assertion that is skipped on Linux CI. None of these block the stated release-pipeline fix.

Minor attention to the env-var/entitlement pairing across entitlements.mac.plist and builtInBrowserWebAuthn.ts.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/build/entitlements.mac.plist | Removes unprovisioned keychain-access-groups entitlement; correct fix for the release-pipeline failure, but the env-var escape hatch silently fails without the entitlement. |
| apps/desktop/src/main/services/builtInBrowser/builtInBrowserWebAuthn.ts | Adds isTouchIdWebAuthnEnabled() flag and gates app.configureWebAuthn behind it; debug log reason string is misleading. |
| apps/desktop/src/main/services/builtInBrowser/builtInBrowserWebAuthn.test.ts | Adds env-var setup/teardown and a new test for the enabled case; Darwin-specific guard means the key assertion is skipped on Linux CI. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[configureBuiltInBrowserWebAuthn called] --> B{already configured?}
    B -- yes --> Z[return]
    B -- no --> C[set configured = true]
    C --> D{platform === darwin?}
    D -- no --> G
    D -- yes --> E{ADE_ENABLE_TOUCH_ID_WEBAUTHN set?}
    E -- yes --> F[app.configureWebAuthn with keychainAccessGroup]
    F --> F1{success?}
    F1 -- yes --> G
    F1 -- no --> F2[log warn: webauthn_configure_failed] --> G
    E -- no --> H[log debug: webauthn_touchid_disabled] --> G
    G[session.fromPartition 'persist:ade-browser']
    G --> I[register select-webauthn-account handler]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/desktop/src/main/services/builtInBrowser/builtInBrowserWebAuthn.test.ts`, line 102-115 ([link](https://github.com/arul28/ade/blob/02f2abf06379cf15b560a7c77dbfd322d413c9e7/apps/desktop/src/main/services/builtInBrowser/builtInBrowserWebAuthn.test.ts#L102-L115)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Darwin-specific assertion never runs on Linux CI**

   The `expect(fakes.app.configureWebAuthn).toHaveBeenCalledWith(…)` assertion is inside `if (process.platform === "darwin")`, so on any Linux runner only the `else` branch executes — the critical check that the right `keychainAccessGroup` is passed is skipped. The module mock already stubs `electron`, so the assertion is safe to run unconditionally on all platforms. Removing the platform guard would give full coverage everywhere.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/builtInBrowser/builtInBrowserWebAuthn.test.ts
   Line: 102-115

   Comment:
   **Darwin-specific assertion never runs on Linux CI**

   The `expect(fakes.app.configureWebAuthn).toHaveBeenCalledWith(…)` assertion is inside `if (process.platform === "darwin")`, so on any Linux runner only the `else` branch executes — the critical check that the right `keychainAccessGroup` is passed is skipped. The module mock already stubs `electron`, so the assertion is safe to run unconditionally on all platforms. Removing the platform guard would give full coverage everywhere.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2FbuiltInBrowser%2FbuiltInBrowserWebAuthn.test.ts%0ALine%3A%20102-115%0A%0AComment%3A%0A**Darwin-specific%20assertion%20never%20runs%20on%20Linux%20CI**%0A%0AThe%20%60expect%28fakes.app.configureWebAuthn%29.toHaveBeenCalledWith%28%E2%80%A6%29%60%20assertion%20is%20inside%20%60if%20%28process.platform%20%3D%3D%3D%20%22darwin%22%29%60%2C%20so%20on%20any%20Linux%20runner%20only%20the%20%60else%60%20branch%20executes%20%E2%80%94%20the%20critical%20check%20that%20the%20right%20%60keychainAccessGroup%60%20is%20passed%20is%20skipped.%20The%20module%20mock%20already%20stubs%20%60electron%60%2C%20so%20the%20assertion%20is%20safe%20to%20run%20unconditionally%20on%20all%20platforms.%20Removing%20the%20platform%20guard%20would%20give%20full%20coverage%20everywhere.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>


2. `apps/desktop/build/entitlements.mac.plist`, line 1-10 ([link](https://github.com/arul28/ade/blob/02f2abf06379cf15b560a7c77dbfd322d413c9e7/apps/desktop/build/entitlements.mac.plist#L1-L10)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Env-var opt-in silently fails without the entitlement**

   The `keychain-access-groups` entitlement was removed, but the runtime code still accepts the env flag to call `app.configureWebAuthn()`. In a Developer ID-signed build the OS will reject the keychain access group request because the entitlement is absent; the try/catch swallows the error and only logs a warning, so a developer who sets the flag expecting Touch ID to work will see silent failure. Consider adding a comment in the plist (or in the source) noting that the entitlement must be re-added alongside the feature flag, or remove the env-var path entirely until the entitlement is properly provisioned.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/build/entitlements.mac.plist
   Line: 1-10

   Comment:
   **Env-var opt-in silently fails without the entitlement**

   The `keychain-access-groups` entitlement was removed, but the runtime code still accepts the env flag to call `app.configureWebAuthn()`. In a Developer ID-signed build the OS will reject the keychain access group request because the entitlement is absent; the try/catch swallows the error and only logs a warning, so a developer who sets the flag expecting Touch ID to work will see silent failure. Consider adding a comment in the plist (or in the source) noting that the entitlement must be re-added alongside the feature flag, or remove the env-var path entirely until the entitlement is properly provisioned.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fbuild%2Fentitlements.mac.plist%0ALine%3A%201-10%0A%0AComment%3A%0A**Env-var%20opt-in%20silently%20fails%20without%20the%20entitlement**%0A%0AThe%20%60keychain-access-groups%60%20entitlement%20was%20removed%2C%20but%20the%20runtime%20code%20still%20accepts%20the%20env%20flag%20to%20call%20%60app.configureWebAuthn%28%29%60.%20In%20a%20Developer%20ID-signed%20build%20the%20OS%20will%20reject%20the%20keychain%20access%20group%20request%20because%20the%20entitlement%20is%20absent%3B%20the%20try%2Fcatch%20swallows%20the%20error%20and%20only%20logs%20a%20warning%2C%20so%20a%20developer%20who%20sets%20the%20flag%20expecting%20Touch%20ID%20to%20work%20will%20see%20silent%20failure.%20Consider%20adding%20a%20comment%20in%20the%20plist%20%28or%20in%20the%20source%29%20noting%20that%20the%20entitlement%20must%20be%20re-added%20alongside%20the%20feature%20flag%2C%20or%20remove%20the%20env-var%20path%20entirely%20until%20the%20entitlement%20is%20properly%20provisioned.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2FbuiltInBrowser%2FbuiltInBrowserWebAuthn.ts%3A46-51%0A**Misleading%20debug%20log%20reason%20string**%0A%0AThe%20%60reason%60%20field%20says%20%60%22missing_provisioned_keychain_access_group%22%60%2C%20but%20the%20access%20group%20constant%20is%20still%20defined%20in%20the%20code%20%E2%80%94%20the%20feature%20is%20disabled%20intentionally%20via%20the%20absent%20env%20var.%20A%20reader%20looking%20at%20this%20log%20in%20production%20would%20search%20for%20a%20provisioning%20issue%20that%20doesn't%20exist.%20A%20value%20like%20%60%22touch_id_not_enabled%22%60%20or%20%60%22env_var_not_set%22%60%20more%20accurately%20describes%20why%20this%20path%20was%20taken.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2FbuiltInBrowser%2FbuiltInBrowserWebAuthn.test.ts%3A102-115%0A**Darwin-specific%20assertion%20never%20runs%20on%20Linux%20CI**%0A%0AThe%20%60expect%28fakes.app.configureWebAuthn%29.toHaveBeenCalledWith%28%E2%80%A6%29%60%20assertion%20is%20inside%20%60if%20%28process.platform%20%3D%3D%3D%20%22darwin%22%29%60%2C%20so%20on%20any%20Linux%20runner%20only%20the%20%60else%60%20branch%20executes%20%E2%80%94%20the%20critical%20check%20that%20the%20right%20%60keychainAccessGroup%60%20is%20passed%20is%20skipped.%20The%20module%20mock%20already%20stubs%20%60electron%60%2C%20so%20the%20assertion%20is%20safe%20to%20run%20unconditionally%20on%20all%20platforms.%20Removing%20the%20platform%20guard%20would%20give%20full%20coverage%20everywhere.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fdesktop%2Fbuild%2Fentitlements.mac.plist%3A1-10%0A**Env-var%20opt-in%20silently%20fails%20without%20the%20entitlement**%0A%0AThe%20%60keychain-access-groups%60%20entitlement%20was%20removed%2C%20but%20the%20runtime%20code%20still%20accepts%20the%20env%20flag%20to%20call%20%60app.configureWebAuthn%28%29%60.%20In%20a%20Developer%20ID-signed%20build%20the%20OS%20will%20reject%20the%20keychain%20access%20group%20request%20because%20the%20entitlement%20is%20absent%3B%20the%20try%2Fcatch%20swallows%20the%20error%20and%20only%20logs%20a%20warning%2C%20so%20a%20developer%20who%20sets%20the%20flag%20expecting%20Touch%20ID%20to%20work%20will%20see%20silent%20failure.%20Consider%20adding%20a%20comment%20in%20the%20plist%20%28or%20in%20the%20source%29%20noting%20that%20the%20entitlement%20must%20be%20re-added%20alongside%20the%20feature%20flag%2C%20or%20remove%20the%20env-var%20path%20entirely%20until%20the%20entitlement%20is%20properly%20provisioned.%0A%0A&repo=arul28%2Fade&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/desktop/src/main/services/builtInBrowser/builtInBrowserWebAuthn.ts:46-51
**Misleading debug log reason string**

The `reason` field says `"missing_provisioned_keychain_access_group"`, but the access group constant is still defined in the code — the feature is disabled intentionally via the absent env var. A reader looking at this log in production would search for a provisioning issue that doesn't exist. A value like `"touch_id_not_enabled"` or `"env_var_not_set"` more accurately describes why this path was taken.

### Issue 2 of 3
apps/desktop/src/main/services/builtInBrowser/builtInBrowserWebAuthn.test.ts:102-115
**Darwin-specific assertion never runs on Linux CI**

The `expect(fakes.app.configureWebAuthn).toHaveBeenCalledWith(…)` assertion is inside `if (process.platform === "darwin")`, so on any Linux runner only the `else` branch executes — the critical check that the right `keychainAccessGroup` is passed is skipped. The module mock already stubs `electron`, so the assertion is safe to run unconditionally on all platforms. Removing the platform guard would give full coverage everywhere.

### Issue 3 of 3
apps/desktop/build/entitlements.mac.plist:1-10
**Env-var opt-in silently fails without the entitlement**

The `keychain-access-groups` entitlement was removed, but the runtime code still accepts the env flag to call `app.configureWebAuthn()`. In a Developer ID-signed build the OS will reject the keychain access group request because the entitlement is absent; the try/catch swallows the error and only logs a warning, so a developer who sets the flag expecting Touch ID to work will see silent failure. Consider adding a comment in the plist (or in the source) noting that the entitlement must be re-added alongside the feature flag, or remove the env-var path entirely until the entitlement is properly provisioned.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove unprovisioned mac keychain e..."](https://github.com/arul28/ade/commit/02f2abf06379cf15b560a7c77dbfd322d413c9e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30779174)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->