### PR TITLE
Opt Pass

### DIFF
--- a/apps/ade-cli/README.md
+++ b/apps/ade-cli/README.md
@@ -75,6 +75,8 @@ ade ios-sim devices --text
 ade --socket ios-sim apps --text
 ade --socket ios-sim launch --target target-id --text
 ade --socket ios-sim preview-render --source apps/ios/ADE/Views/Home.swift --index 0 --text
+ade --socket app-control launch --command "npm run dev" --text
+ade --socket browser open http://localhost:5173 --new-tab --text
 ade --socket update status --text
 ade --socket update check --text
 ade --socket update install --text

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -1829,6 +1829,44 @@ describe("ADE CLI", () => {
     });
   });
 
+  it("update commands map to auto-update actions", () => {
+    const status = buildCliPlan(["update", "status"]);
+    expect(status.kind).toBe("execute");
+    if (status.kind !== "execute") return;
+    expect(status.steps[0]?.params).toMatchObject({
+      arguments: { domain: "update", action: "getSnapshot", args: {} },
+    });
+
+    const check = buildCliPlan(["auto-update", "check"]);
+    expect(check.kind).toBe("execute");
+    if (check.kind !== "execute") return;
+    expect(check.steps[0]?.params).toMatchObject({
+      arguments: { domain: "update", action: "checkForUpdates", args: {} },
+    });
+
+    const install = buildCliPlan(["updates", "install"]);
+    expect(install.kind).toBe("execute");
+    if (install.kind !== "execute") return;
+    expect(install.steps[0]?.params).toMatchObject({
+      arguments: { domain: "update", action: "quitAndInstall", args: {} },
+    });
+
+    const dismiss = buildCliPlan(["update", "dismiss"]);
+    expect(dismiss.kind).toBe("execute");
+    if (dismiss.kind !== "execute") return;
+    expect(dismiss.steps[0]?.params).toMatchObject({
+      arguments: { domain: "update", action: "dismissInstalledNotice", args: {} },
+    });
+
+    const actions = buildCliPlan(["update", "actions"]);
+    expect(actions.kind).toBe("execute");
+    if (actions.kind !== "execute") return;
+    expect(actions.steps[0]?.params).toMatchObject({
+      name: "list_ade_actions",
+      arguments: { domain: "update" },
+    });
+  });
+
   it("attaches a rendered lane graph when the plan has the lanes visualizer", () => {
     const connection = {
       mode: "headless" as const,

--- a/apps/desktop/resources/ade-cli-help.txt
+++ b/apps/desktop/resources/ade-cli-help.txt
@@ -38,6 +38,7 @@ _    ____  _____
     $ ade browser open | tabs | screenshot         Use ADE's built-in browser pane
     $ ade memory add | search | pin                 Use ADE memory
     $ ade settings action <method>                  Call project config actions
+    $ ade update status | check | install | dismiss Read auto-update state and drive install
     $ ade actions list | run | status               Escape hatch for every ADE service action
     $ ade cursor cloud agents | runs | artifacts | repos | models | me
                                                     Drive Cursor Cloud agents via @cursor/sdk
@@ -121,6 +122,7 @@ _    ____  _____
     $ ade browser open | tabs | screenshot         Use ADE's built-in browser pane
     $ ade memory add | search | pin                 Use ADE memory
     $ ade settings action <method>                  Call project config actions
+    $ ade update status | check | install | dismiss Read auto-update state and drive install
     $ ade actions list | run | status               Escape hatch for every ADE service action
     $ ade cursor cloud agents | runs | artifacts | repos | models | me
                                                     Drive Cursor Cloud agents via @cursor/sdk
@@ -204,6 +206,7 @@ _    ____  _____
     $ ade browser open | tabs | screenshot         Use ADE's built-in browser pane
     $ ade memory add | search | pin                 Use ADE memory
     $ ade settings action <method>                  Call project config actions
+    $ ade update status | check | install | dismiss Read auto-update state and drive install
     $ ade actions list | run | status               Escape hatch for every ADE service action
     $ ade cursor cloud agents | runs | artifacts | repos | models | me
                                                     Drive Cursor Cloud agents via @cursor/sdk
@@ -614,6 +617,10 @@ _    ____  _____
     $ ade --socket ios-sim shutdown --force        Force-release a session owned by another chat
     $ ade ios-sim actions --text                   List every callable ios_simulator action
 
+  Project discovery scans root-level .xcodeproj bundles and apps/*/*.xcodeproj
+  projects; do not create symlink shims or fake schemes before checking
+  "ios-sim apps --text" and the build output.
+
   Capture and inspection:
     $ ade ios-sim screenshot --text                One-shot PNG via simctl (screenshot)
     $ ade ios-sim snapshot --text                  Screenshot + selectable elements (getScreenSnapshot)
@@ -791,6 +798,7 @@ _    ____  _____
     $ ade browser open | tabs | screenshot         Use ADE's built-in browser pane
     $ ade memory add | search | pin                 Use ADE memory
     $ ade settings action <method>                  Call project config actions
+    $ ade update status | check | install | dismiss Read auto-update state and drive install
     $ ade actions list | run | status               Escape hatch for every ADE service action
     $ ade cursor cloud agents | runs | artifacts | repos | models | me
                                                     Drive Cursor Cloud agents via @cursor/sdk
@@ -836,6 +844,32 @@ _    ____  _____
     $ ade actions run <domain.action> --input-json '{"key":"value"}'
 
   Start with: ade doctor --text
+
+## ade update --help
+_    ____  _____
+    / \  |  _ \| ____|
+   / _ \ | | | |  _|
+  / ___ \| |_| | |___
+ /_/   \_\____/|_____|
+
+  Auto-update
+
+  Auto-update commands query and drive ADE desktop's auto-updater. The desktop
+  app owns the updater process; CLI parity exists so agents can read state and,
+  when explicitly requested by the user, trigger a check, install, or dismiss
+  the post-install notice. quitAndInstall relaunches the desktop app and only
+  succeeds when status is "ready".
+
+    $ ade --socket update status --text             Read AutoUpdateSnapshot (status, version, progress)
+    $ ade --socket update check --text              Trigger a background update check
+    $ ade --socket update install --text            Refresh latest, then quit and install when ready
+    $ ade --socket update dismiss --text            Clear the recently-installed banner
+    $ ade --socket update actions --text            List callable update actions
+
+  Snapshot status values: idle, checking, downloading, ready, installing, error.
+  "installing" appears between quitAndInstall and the desktop relaunch; if the
+  install fails, status falls back to error and the pending-install record is
+  cleared automatically.
 
 ## ade actions --help
 _    ____  _____

--- a/apps/desktop/scripts/regen-ade-cli-help.cjs
+++ b/apps/desktop/scripts/regen-ade-cli-help.cjs
@@ -30,6 +30,7 @@ const SUBCOMMANDS = [
   "browser",
   "memory",
   "settings",
+  "update",
   "actions",
   "cursor",
 ];

--- a/apps/desktop/src/main/services/memory/embeddingWorkerService.test.ts
+++ b/apps/desktop/src/main/services/memory/embeddingWorkerService.test.ts
@@ -8,6 +8,7 @@ import { createMemoryService } from "./memoryService";
 import {
   createEmbeddingWorkerService,
   DEFAULT_ACTIVE_BATCH_SIZE,
+  DEFAULT_ACTIVE_SESSION_COLD_START_DEFER_MS,
   DEFAULT_IDLE_BATCH_SIZE,
 } from "./embeddingWorkerService";
 import { DEFAULT_EMBEDDING_MODEL_ID, EXPECTED_EMBEDDING_DIMENSIONS } from "./embeddingService";
@@ -35,9 +36,11 @@ function buildVector(seed: string): Float32Array {
 async function createFixture(opts: {
   withActiveSession?: boolean;
   embedImpl?: (text: string) => Promise<Float32Array>;
+  isAvailable?: () => boolean;
   sleep?: (ms: number) => Promise<void>;
   idleBatchSize?: number;
   activeBatchSize?: number;
+  activeSessionColdStartDeferMs?: number;
   attachQueueHook?: boolean;
 } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "ade-embedding-worker-"));
@@ -76,7 +79,7 @@ async function createFixture(opts: {
   const sessionService = createSessionService({ db });
   const embeddingService = {
     embed: vi.fn(opts.embedImpl ?? (async (text: string) => buildVector(text))),
-    isAvailable: vi.fn(() => true),
+    isAvailable: vi.fn(opts.isAvailable ?? (() => true)),
     getModelId: vi.fn(() => DEFAULT_EMBEDDING_MODEL_ID),
   };
 
@@ -98,6 +101,7 @@ async function createFixture(opts: {
     sessionService,
     idleBatchSize: opts.idleBatchSize ?? DEFAULT_IDLE_BATCH_SIZE,
     activeBatchSize: opts.activeBatchSize ?? DEFAULT_ACTIVE_BATCH_SIZE,
+    activeSessionColdStartDeferMs: opts.activeSessionColdStartDeferMs ?? DEFAULT_ACTIVE_SESSION_COLD_START_DEFER_MS,
     sleep: opts.sleep,
   });
 
@@ -266,6 +270,51 @@ describe("embeddingWorkerService", () => {
       }),
     );
     expect(sleep).toHaveBeenCalledWith(100);
+  });
+
+  it("defers a cold embedding model load while sessions are active", async () => {
+    vi.useFakeTimers();
+    try {
+      let modelReady = false;
+      const { db, logger, worker, memoryService, embeddingService } = await createFixture({
+        withActiveSession: true,
+        activeSessionColdStartDeferMs: 25,
+        isAvailable: () => modelReady,
+      });
+
+      memoryService.addMemory({
+        projectId: "project-1",
+        scope: "project",
+        category: "fact",
+        content: "Defer this until the active session is not competing with a cold model load.",
+        importance: "medium",
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(embeddingService.embed).not.toHaveBeenCalled();
+      expect(worker.getStatus()).toEqual(expect.objectContaining({
+        batchesProcessed: 0,
+        queueDepth: 1,
+      }));
+      expect(logger.info).toHaveBeenCalledWith(
+        "memory.embedding_worker.cold_start_deferred",
+        expect.objectContaining({
+          projectId: "project-1",
+          queueDepth: 1,
+          retryInMs: 25,
+        }),
+      );
+
+      modelReady = true;
+      await vi.advanceTimersByTimeAsync(25);
+      await worker.waitForIdle();
+
+      expect(embeddingService.embed).toHaveBeenCalledTimes(1);
+      expect(countEmbeddings(db)).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("logs and skips a failed entry without blocking the rest of the batch", async () => {

--- a/apps/desktop/src/main/services/memory/embeddingWorkerService.ts
+++ b/apps/desktop/src/main/services/memory/embeddingWorkerService.ts
@@ -7,6 +7,7 @@ import type { createEmbeddingService } from "./embeddingService";
 
 export const DEFAULT_IDLE_BATCH_SIZE = 50;
 export const DEFAULT_ACTIVE_BATCH_SIZE = 10;
+export const DEFAULT_ACTIVE_SESSION_COLD_START_DEFER_MS = 60_000;
 const MIN_BATCH_SIZE = 10;
 const MAX_BATCH_SIZE = 50;
 const DEFAULT_YIELD_MS = 100;
@@ -26,6 +27,7 @@ type CreateEmbeddingWorkerServiceOpts = {
   sessionService?: Pick<ReturnType<typeof createSessionService>, "list">;
   idleBatchSize?: number;
   activeBatchSize?: number;
+  activeSessionColdStartDeferMs?: number;
   yieldMs?: number;
   now?: () => Date;
   sleep?: (ms: number) => Promise<void>;
@@ -75,6 +77,10 @@ export function createEmbeddingWorkerService(opts: CreateEmbeddingWorkerServiceO
 
   const idleBatchSize = normalizeBatchSize(opts.idleBatchSize, DEFAULT_IDLE_BATCH_SIZE);
   const activeBatchSize = normalizeBatchSize(opts.activeBatchSize, DEFAULT_ACTIVE_BATCH_SIZE);
+  const activeSessionColdStartDeferMs = Math.max(
+    1,
+    Math.floor(opts.activeSessionColdStartDeferMs ?? DEFAULT_ACTIVE_SESSION_COLD_START_DEFER_MS),
+  );
   const yieldMs = Math.max(0, Math.floor(opts.yieldMs ?? DEFAULT_YIELD_MS));
 
   const queue: string[] = [];
@@ -129,9 +135,15 @@ export function createEmbeddingWorkerService(opts: CreateEmbeddingWorkerServiceO
     return isSessionActive() ? activeBatchSize : idleBatchSize;
   }
 
-  function scheduleProcessing() {
+  function shouldDeferColdStartForActiveSession(): boolean {
+    if (embeddingService.isAvailable()) return false;
+    return isSessionActive();
+  }
+
+  function scheduleProcessing(delayMs = 0) {
     if (scheduled || processingPromise || queue.length === 0) return;
     scheduled = true;
+    const normalizedDelayMs = Math.max(0, Math.floor(delayMs));
     setTimeout(() => {
       scheduled = false;
       void processQueue().catch((error) => {
@@ -140,7 +152,7 @@ export function createEmbeddingWorkerService(opts: CreateEmbeddingWorkerServiceO
           error: getErrorMessage(error),
         });
       });
-    }, 0);
+    }, normalizedDelayMs);
   }
 
   function queueMemory(memoryId: string) {
@@ -227,8 +239,19 @@ export function createEmbeddingWorkerService(opts: CreateEmbeddingWorkerServiceO
   async function processQueue() {
     if (processingPromise) return processingPromise;
 
+    let rescheduleDelayMs = 0;
     processingPromise = (async () => {
       while (queue.length > 0) {
+        if (shouldDeferColdStartForActiveSession()) {
+          rescheduleDelayMs = activeSessionColdStartDeferMs;
+          logger.info("memory.embedding_worker.cold_start_deferred", {
+            projectId,
+            queueDepth: queue.length,
+            retryInMs: activeSessionColdStartDeferMs,
+          });
+          return;
+        }
+
         const batchSize = Math.min(nextBatchSize(), queue.length);
         const batchIds = queue.splice(0, batchSize);
         for (const id of batchIds) {
@@ -272,7 +295,7 @@ export function createEmbeddingWorkerService(opts: CreateEmbeddingWorkerServiceO
       processingPromise = null;
       resolveIdleIfNeeded();
       if (queue.length > 0) {
-        scheduleProcessing();
+        scheduleProcessing(rescheduleDelayMs);
       }
     });
 

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -429,8 +429,27 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       }
     };
 
-    const disposeProjectChanged = window.ade.app.onProjectChanged(() => {
-      void initializeProjectState();
+    const disposeProjectChanged = window.ade.app.onProjectChanged((nextProject) => {
+      const state = useAppStore.getState();
+      const nextRoot = nextProject?.rootPath ?? null;
+      const currentRoot = state.project?.rootPath ?? null;
+      const expectedShowWelcome = !nextProject;
+      const alreadyApplied =
+        state.projectHydrated &&
+        currentRoot === nextRoot &&
+        state.showWelcome === expectedShowWelcome;
+
+      if (state.projectTransition || alreadyApplied) {
+        if (alreadyApplied) {
+          setProject(nextProject);
+          setShowWelcome(expectedShowWelcome);
+        }
+        return;
+      }
+
+      setProjectHydrated(false);
+      applyProjectState(nextProject);
+      setProjectHydrated(true);
     });
 
     void initializeProjectState();

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -439,11 +439,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         currentRoot === nextRoot &&
         state.showWelcome === expectedShowWelcome;
 
-      if (state.projectTransition || alreadyApplied) {
-        if (alreadyApplied) {
-          setProject(nextProject);
-          setShowWelcome(expectedShowWelcome);
-        }
+      if (state.projectTransition) return;
+
+      if (alreadyApplied) {
+        setProject(nextProject);
+        setShowWelcome(expectedShowWelcome);
         return;
       }
 

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -84,6 +84,7 @@ type RebasePushReviewState = {
 };
 
 const ADOPT_HINT_DISMISSED_KEY = "ade.lanes.adoptHintDismissed.v1";
+const LANE_DELETE_REFRESH_DEBOUNCE_MS = 160;
 
 function getDevicePresenceTitle(devicesOpen: LaneSummary["devicesOpen"]): string {
   const names = (devicesOpen ?? [])
@@ -413,6 +414,8 @@ export function LanesPage() {
   const branchSearchInputRef = useRef<HTMLInputElement>(null);
   const branchDropdownRef = useRef<HTMLDivElement>(null);
   const completedLaneDeleteRefreshesRef = useRef<Set<string>>(new Set());
+  const pendingLaneDeleteRefreshIdsRef = useRef<Set<string>>(new Set());
+  const laneDeleteRefreshTimerRef = useRef<number | null>(null);
   const activeLanePresenceSignatureRef = useRef<string | null>(null);
   // Refs for the onDeleteEvent IPC handler. Capturing high-churn values
   // (selectedLaneId, lanesById, managedLaneIds, manageOpen) in refs lets the
@@ -448,6 +451,11 @@ export function LanesPage() {
 
   useEffect(() => {
     completedLaneDeleteRefreshesRef.current.clear();
+    pendingLaneDeleteRefreshIdsRef.current.clear();
+    if (laneDeleteRefreshTimerRef.current != null) {
+      window.clearTimeout(laneDeleteRefreshTimerRef.current);
+      laneDeleteRefreshTimerRef.current = null;
+    }
     setDeleteProgressByLaneId({});
   }, [project?.rootPath]);
 
@@ -789,6 +797,28 @@ export function LanesPage() {
     }
   }, []);
 
+  const scheduleLaneDeleteRefresh = useCallback(() => {
+    if (laneDeleteRefreshTimerRef.current != null) return;
+    laneDeleteRefreshTimerRef.current = window.setTimeout(() => {
+      laneDeleteRefreshTimerRef.current = null;
+      const laneIds = Array.from(pendingLaneDeleteRefreshIdsRef.current);
+      pendingLaneDeleteRefreshIdsRef.current.clear();
+      if (laneIds.length === 0) return;
+
+      void refreshLanes()
+        .then(() => {
+          const selectedId = selectedLaneIdRef.current;
+          const managedIds = managedLaneIdsRef.current;
+          if (manageOpenRef.current && laneIds.some((laneId) => selectedId === laneId || managedIds.includes(laneId))) {
+            setManageOpen(false);
+          }
+        })
+        .catch((err) => {
+          setLaneActionError(`Lane was deleted, but refresh failed: ${err instanceof Error ? err.message : String(err)}`);
+        });
+    }, LANE_DELETE_REFRESH_DEBOUNCE_MS);
+  }, [refreshLanes]);
+
   /* ---- Effects ---- */
 
   // Mirror high-churn values into refs so the IPC subscription below doesn't
@@ -838,22 +868,11 @@ export function LanesPage() {
       setManagedLaneIds((prev) => prev.filter((id) => id !== laneId));
       clearLaneInspectorTab(laneId);
       setLaneActionError(null);
-
-      void refreshLanes()
-        .then(() => {
-          if (
-            manageOpenRef.current
-            && (selectedLaneIdRef.current === laneId || managedLaneIdsRef.current.includes(laneId))
-          ) {
-            setManageOpen(false);
-          }
-        })
-        .catch((err) => {
-          setLaneActionError(`Lane was deleted, but refresh failed: ${err instanceof Error ? err.message : String(err)}`);
-        });
+      pendingLaneDeleteRefreshIdsRef.current.add(laneId);
+      scheduleLaneDeleteRefresh();
     });
     return unsubscribe;
-  }, [clearLaneInspectorTab, refreshLanes, selectLane]);
+  }, [clearLaneInspectorTab, scheduleLaneDeleteRefresh, selectLane]);
 
   useEffect(() => {
     const unsubscribe = window.ade.conflicts.onEvent((event) => {
@@ -1016,9 +1035,15 @@ export function LanesPage() {
   }, [refreshAutoRebaseEnabled]);
 
   useEffect(() => {
+    const pendingLaneDeleteRefreshIds = pendingLaneDeleteRefreshIdsRef.current;
     return () => {
       for (const timer of chipTimersRef.current.values()) window.clearTimeout(timer);
       chipTimersRef.current.clear();
+      if (laneDeleteRefreshTimerRef.current != null) {
+        window.clearTimeout(laneDeleteRefreshTimerRef.current);
+        laneDeleteRefreshTimerRef.current = null;
+      }
+      pendingLaneDeleteRefreshIds.clear();
     };
   }, []);
 
@@ -1226,6 +1251,7 @@ export function LanesPage() {
     fn: () => Promise<void>,
     status: string,
     kind: "delete" | "archive" | "adopt" = "delete",
+    options: { refreshAfter?: boolean } = {},
   ) => {
     setLaneActionBusy(true);
     setLaneActionKind(kind);
@@ -1233,7 +1259,9 @@ export function LanesPage() {
     setLaneActionError(null);
     try {
       await fn();
-      await refreshLanes();
+      if (options.refreshAfter !== false) {
+        await refreshLanes();
+      }
       setManageOpen(false);
     } catch (err) {
       setLaneActionError(err instanceof Error ? err.message : String(err));

--- a/apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx
@@ -30,6 +30,7 @@ const TERMINALS_TILING_TREE: PaneSplit = {
 
 const MIN_WORK_SIDEBAR_WIDTH_PCT = 26;
 const MAX_WORK_SIDEBAR_WIDTH_PCT = 55;
+const BULK_SESSION_DELETE_CONCURRENCY = 4;
 
 function clampWorkSidebarWidthPct(widthPct: number): number {
   return Math.max(MIN_WORK_SIDEBAR_WIDTH_PCT, Math.min(MAX_WORK_SIDEBAR_WIDTH_PCT, widthPct));
@@ -41,6 +42,33 @@ function dispatchWorkSidebarBrowserResizeEvent(type: "start" | "end"): void {
       ? ADE_WORK_SIDEBAR_BROWSER_RESIZE_START_EVENT
       : ADE_WORK_SIDEBAR_BROWSER_RESIZE_END_EVENT,
   ));
+}
+
+async function allSettledWithConcurrency<T>(
+  items: readonly T[],
+  concurrency: number,
+  task: (item: T) => Promise<void>,
+): Promise<PromiseSettledResult<void>[]> {
+  if (items.length === 0) return [];
+  const limit = Math.max(1, Math.min(concurrency, items.length));
+  const results: PromiseSettledResult<void>[] = new Array(items.length);
+  let nextIndex = 0;
+
+  await Promise.all(Array.from({ length: limit }, async () => {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) return;
+      try {
+        await task(items[index] as T);
+        results[index] = { status: "fulfilled", value: undefined };
+      } catch (reason) {
+        results[index] = { status: "rejected", reason };
+      }
+    }
+  }));
+
+  return results;
 }
 
 export function TerminalsPage() {
@@ -280,12 +308,16 @@ export function TerminalsPage() {
 
     setSessionActionError(null);
     setDeletingSessionId("bulk");
-    void Promise.allSettled(
-      ended.map((session) => (
-        isChatToolType(session.toolType)
-          ? window.ade.agentChat.delete({ sessionId: session.id })
-          : window.ade.sessions.delete({ sessionId: session.id })
-      )),
+    void allSettledWithConcurrency(
+      ended,
+      BULK_SESSION_DELETE_CONCURRENCY,
+      async (session) => {
+        if (isChatToolType(session.toolType)) {
+          await window.ade.agentChat.delete({ sessionId: session.id });
+          return;
+        }
+        await window.ade.sessions.delete({ sessionId: session.id });
+      },
     )
       .then(async (results) => {
         const failed = results.filter((result) => result.status === "rejected").length;

--- a/docs/features/chat/agent-routing.md
+++ b/docs/features/chat/agent-routing.md
@@ -15,12 +15,12 @@ where the machinery lives.
 | `apps/desktop/src/main/services/ai/providerRuntimeHealth.ts` | Tracks provider readiness/auth/network failures so the UI can surface degraded states. |
 | `apps/desktop/src/main/services/ai/providerOptions.ts` | Normalises provider-native options (Claude permission mode, Codex approval + sandbox, OpenCode permission). |
 | `apps/desktop/src/main/services/ai/authDetector.ts` | Discovers available credentials (CLI, API key, OAuth) and reports auth status. |
-| `apps/desktop/src/main/services/ai/claudeCodeExecutable.ts` / `codexExecutable.ts` | CLI resolution (looks on PATH, in the app bundle, then in configured install paths). Cursor no longer needs a CLI resolver — it runs through the embedded `@cursor/sdk`. |
+| `apps/desktop/src/main/services/ai/claudeCodeExecutable.ts` / `codexExecutable.ts` / `droidExecutable.ts` | CLI resolution (looks on PATH, in the app bundle, then in configured install paths where supported). Cursor no longer needs a CLI resolver — it runs through the embedded `@cursor/sdk`. |
 | `apps/desktop/src/main/services/ai/tools/systemPrompt.ts` | Adjusts the system prompt per mode (`chat`, `coding`, `planning`) and permission mode. |
 
 ## Supported providers
 
-`AgentChatProvider` is `"codex" | "claude" | "cursor" | "opencode" | (string & {})`.
+`AgentChatProvider` is `"codex" | "claude" | "cursor" | "droid" | "opencode" | (string & {})`.
 The final branch exists so local discovery can populate provider keys
 for vendored runtimes without changing the union.
 
@@ -30,6 +30,7 @@ for vendored runtimes without changing the union.
 | `codex` | `codex app-server` subprocess, JSON-RPC protocol. Spawn failures surface as error events. | `agentChatService.ts` (Codex adapter); config via `codexAppServerConfig.ts`. |
 | `opencode` | OpenCode server runtime: Anthropic/OpenAI/Google/Mistral/DeepSeek/xAI/Groq/Together AI API keys, OpenRouter, and local (Ollama, LM Studio, vLLM). | `agentChatService.ts` (OpenCode adapter); model discovery in `localModelDiscovery.ts` and `modelsDevService.ts`. |
 | `cursor` | Official `@cursor/sdk` running in a Node worker pool. ADE owns permissions, hooks, and the system prompt; the SDK owns the model + tool execution. | `cursorSdkPool.ts`, `cursorSdkWorker.ts`, `cursorSdkProtocol.ts`, `cursorSdkPolicy.ts`, `cursorSdkSystemPrompt.ts`, `cursorSdkEventMapper.ts`. |
+| `droid` | Factory Droid CLI models exposed as dynamic `droid/<modelId>` descriptors and driven through the Droid ACP bridge. | `agentChatService.ts` (Droid adapter); model helpers in `modelRegistry.ts`. |
 
 ## Model registry
 
@@ -219,6 +220,7 @@ translates the abstract value into the correct provider-native fields:
 - `claude`: `claudePermissionMode = "default" | "plan" | "acceptEdits" | "bypassPermissions"`.
 - `codex`: `codexApprovalPolicy` + `codexSandbox` pair.
 - `opencode`: `opencodePermissionMode = "plan" | "edit" | "full-auto"`.
+- `droid`: `droidPermissionMode = "read-only" | "auto-low" | "auto-medium" | "auto-high"`.
 
 The abstract field is persisted alongside the native fields so the UI
 can summarize session state consistently, and so legacy flows that only

--- a/docs/features/memory/README.md
+++ b/docs/features/memory/README.md
@@ -12,7 +12,7 @@ background; agents and the user rarely touch the raw store.
 |---|---|
 | `apps/desktop/src/main/services/memory/memoryService.ts` | Core CRUD, dedup, write gates, tier and status logic. Entry point for all other memory services. |
 | `apps/desktop/src/main/services/memory/hybridSearchService.ts` | BM25 + cosine vector search + MMR re-ranking. Used by `memorySearch` when embeddings are available. |
-| `apps/desktop/src/main/services/memory/embeddingService.ts` / `embeddingWorkerService.ts` | Local embedding model (`Xenova/all-MiniLM-L6-v2`, 384 dims). Generates vectors and queues pending writes. |
+| `apps/desktop/src/main/services/memory/embeddingService.ts` / `embeddingWorkerService.ts` | Local embedding model (`Xenova/all-MiniLM-L6-v2`, 384 dims). Generates vectors and queues pending writes. The worker uses a smaller batch size while sessions are active and defers a cold embedding-model load for 60s when active sessions are running, so a first memory write does not compete with interactive agent work. |
 | `apps/desktop/src/main/services/memory/memoryLifecycleService.ts` | Daily sweep: decay, demotion, promotion, archival by scope limits. |
 | `apps/desktop/src/main/services/memory/batchConsolidationService.ts` | Weekly consolidation: cluster similar entries and merge via AI. |
 | `apps/desktop/src/main/services/memory/knowledgeCaptureService.ts` | Captures conventions/patterns/gotchas from interventions, error clusters, PR feedback, and failures. |
@@ -222,9 +222,12 @@ All channels are invoke-style and prefixed `ade.memory.*`. Defined in
 - **Dedup by Jaccard.** Threshold 0.85 is empirical; lowering it causes
   aggressive merging, raising it causes growth toward limits.
 - **Embedding queue during model load.** When the embedding model is
-  still loading, new memories queue rather than drop. The queue is
-  drained in `embeddingWorkerService.ts` when the model reports ready.
-  Missing the drain causes silent loss of embeddings.
+  still loading, new memories queue rather than drop. If the model has
+  not started and a session is active, `embeddingWorkerService.ts`
+  defers the cold start by
+  `DEFAULT_ACTIVE_SESSION_COLD_START_DEFER_MS` (60s) and reschedules
+  the queue. Missing the drain or reschedule causes silent loss of
+  embeddings.
 - **Evergreen exemption order.** Decay skips evergreen categories
   before checking the importance threshold, so raising an evergreen
   entry's importance does not affect its decay (it is already exempt).
@@ -263,5 +266,3 @@ All channels are invoke-style and prefixed `ade.memory.*`. Defined in
   `memoryAdd` / `memoryPin` / `memoryUpdateCore` tool definitions.
 - [Agents Identity and Personas](../agents/identity-and-personas.md) --
   CTO core memory document, agent core memory.
-</content>
-</invoke>

--- a/docs/features/project-home/README.md
+++ b/docs/features/project-home/README.md
@@ -75,8 +75,8 @@ Main process (the substrate):
   — backs the "Add project → Create" and "Add project → Clone" flows.
   `createLocalProject({ name, parentDir })` makes a new directory, runs
   `git init --initial-branch=main` (with a `git init` + `symbolic-ref`
-  fallback for older git), writes a starter `README.md` + `.gitignore`,
-  and creates an "Initial commit" (retried with an `ADE <ade@local>`
+  fallback for older git), writes a starter `README.md` + `.gitignore`
+  that ignores `.ade/`, and creates an "Initial commit" (retried with an `ADE <ade@local>`
   author when the user has no git identity configured).
   `cloneRepository({ url, parentDir, name })` validates the URL via
   `parseGitHubRepoFromRemoteUrl`, ensures the target is empty, and
@@ -241,7 +241,7 @@ The "Add project" forms live in
 
 - `AddProjectChooser.tsx` — three large tiles (Open / Create / Clone)
   with icon, headline, tagline, and a soft hue-tinted hover state.
-- `CreateProjectForm.tsx` — local-only flow: validates the project
+- `CreateProjectForm.tsx` — create flow: validates the project
   name, debounces an existence check via `browseDirectories`, fetches
   `getDefaultParentDir()` for the parent suggestion, and calls
   `window.ade.project.createLocal({ name, parentDir })`.

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -159,9 +159,9 @@ hydrating cards inside each screen body.
 an inline "Attached to <host>" banner above the open-project button.
 The banner uses the same `SyncConnectionHealth` mapping as
 `ADEConnectionDot` (success when connected and not strained, warning
-when connecting or strained, muted when disconnected/unreachable) and
-routes taps through `syncService.settingsPresented` to the same
-Settings sheet the dot opens.
+when connecting or strained, danger when unreachable, muted when
+disconnected) and routes taps through `syncService.settingsPresented`
+to the same Settings sheet the dot opens.
 
 `SettingsConnectionHeader` distinguishes the four states explicitly:
 


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a targeted optimization pass across several subsystems. The changes replace or debounce expensive/unbounded async patterns: the embedding worker defers cold model loads during active sessions, lane delete IPC events are batched with a 160 ms debounce, bulk session deletion is capped at 4 concurrent IPC calls, and the `onProjectChanged` handler now uses a synchronous fast-path that avoids a redundant `getProject` round-trip when project data is already available.

- **`embeddingWorkerService`**: adds `DEFAULT_ACTIVE_SESSION_COLD_START_DEFER_MS = 60_000` and a `shouldDeferColdStartForActiveSession()` guard inside `processQueue`; the deferred delay is propagated to `scheduleProcessing` via a shared closure variable (`rescheduleDelayMs`), and is fully covered by a new fake-timer test.
- **`LanesPage`**: replaces the immediate per-event `refreshLanes()` call in the delete IPC handler with a debounced, batched scheduler; cleanup and project-switch effects cancel any pending timer.
- **`TerminalsPage`**: introduces a local `allSettledWithConcurrency` helper (concurrency = 4) to replace the unbounded `Promise.allSettled` used during bulk session deletion.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are well-scoped optimizations with no mutations to shared mutable state that could introduce data races, and the core deferral logic is covered by a new fake-timer test.

Each optimization is self-contained: the embedding cold-start deferral uses a closure-captured variable correctly and is exercised end-to-end in the new test; the lane-delete debounce and concurrency cap are straightforward async patterns with proper cleanup; the `onProjectChanged` fast-path mirrors the shape of the existing synchronous `applyProjectState` call. No correctness issues were identified across any of the changed paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/memory/embeddingWorkerService.ts | Adds cold-start deferral (60s default) when embedding model is unavailable and a session is active; `rescheduleDelayMs` is correctly shared via closure between the inner async IIFE and the `.finally()` handler. |
| apps/desktop/src/main/services/memory/embeddingWorkerService.test.ts | New test covers cold-start deferral path end-to-end using fake timers; fixture gains `isAvailable` and `activeSessionColdStartDeferMs` opts. |
| apps/desktop/src/renderer/components/app/AppShell.tsx | Replaces the async `initializeProjectState()` round-trip in `onProjectChanged` with a synchronous fast path that skips the extra IPC `getProject` call; correctly guards on `projectTransition` before the `alreadyApplied` branch. |
| apps/desktop/src/renderer/components/lanes/LanesPage.tsx | Debounces lane-delete refresh events (160 ms) to batch rapid IPC events into one `refreshLanes()` call; cleanup and project-change effects properly cancel the pending timer. |
| apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx | Introduces `allSettledWithConcurrency` (cap 4) for bulk session deletion, replacing unbounded `Promise.allSettled` to avoid flooding the IPC channel. |
| apps/ade-cli/src/cli.test.ts | Adds a test block validating that `update`, `auto-update`, `updates` CLI aliases all route to the correct `domain: "update"` action names. |

</details>

<sub>Reviews (3): Last reviewed commit: ["ship: iteration 1 - address AppShell tra..."](https://github.com/arul28/ade/commit/e0e20571ac543edbeae1acb8f23668929dfd0cda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31275470)</sub>

<!-- /greptile_comment -->