### PR TITLE
Work + PR tab perf audit: defer cold-start probes and idle polls

### DIFF
--- a/.ade/.gitignore
+++ b/.ade/.gitignore
@@ -1,32 +1,19 @@
-# Machine-local ADE state
-local.yaml
-local.secret.yaml
-ade.db
-ade.db-*
-ade.db-wal
-embeddings.db
-ade.sock
-artifacts/
-transcripts/
-cache/
-worktrees/
-secrets/
+# ADE ignores local runtime state by default.
+*
 
-# Local-only generated runtime docs/state
-agents/
-cto/CURRENT.md
-cto/MEMORY.md
-cto/core-memory.json
-cto/daily/
-cto/sessions.jsonl
-cto/subordinate-activity.jsonl
-cto/openclaw-history.json
-cto/openclaw-idempotency.json
-cto/openclaw-outbox.json
-cto/openclaw-routes.json
-cto/openclaw-device.json
-context/
-memory/
-history/
-reflections/
-context/*.ade.md
+# Shared ADE project config
+!.gitignore
+!ade.yaml
+!cto/
+!cto/identity.yaml
+
+# Shared user-authored ADE assets
+!templates/
+!templates/**
+!skills/
+!skills/**
+!workflows/
+!workflows/linear/
+!workflows/linear/**
+!project-icons/
+!project-icons/**

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -1515,6 +1515,43 @@ describe("ADE CLI", () => {
     });
   });
 
+  it("automations create accepts require-on-trigger lane mode without a target lane", () => {
+    const plan = buildCliPlan([
+      "automations",
+      "create",
+      "--text",
+      "id: r1\n",
+      "--lane-mode",
+      "require-on-trigger",
+    ]);
+    expect(plan.kind).toBe("execute");
+    if (plan.kind !== "execute") return;
+    expect(plan.steps[0]?.params).toMatchObject({
+      arguments: {
+        args: {
+          draft: {
+            execution: { laneMode: "require-on-trigger" },
+          },
+        },
+      },
+    });
+  });
+
+  it("automations create rejects --lane with --lane-mode require-on-trigger", () => {
+    expect(() =>
+      buildCliPlan([
+        "automations",
+        "create",
+        "--text",
+        "id: r1\n",
+        "--lane-mode",
+        "require-on-trigger",
+        "--lane",
+        "lane-1",
+      ]),
+    ).toThrow(/--lane is only valid with --lane-mode reuse/);
+  });
+
   it("automations create with --lane-name-preset custom accepts --lane-name-template", () => {
     const plan = buildCliPlan([
       "automations",
@@ -1602,7 +1639,7 @@ describe("ADE CLI", () => {
         "--lane-mode",
         "bogus",
       ]),
-    ).toThrow(/--lane-mode must be one of create, reuse/);
+    ).toThrow(/--lane-mode must be one of create, reuse, require-on-trigger/);
   });
 
   it("automations runs accepts a --status filter", () => {
@@ -1728,6 +1765,19 @@ describe("ADE CLI", () => {
     if (plan.kind !== "execute") return;
     expect(plan.steps[0]?.params).toMatchObject({
       arguments: { args: { id: "rule-42", laneId: "lane-7" } },
+    });
+  });
+
+  it("automations trigger aliases run and forwards --lane as laneId", () => {
+    const plan = buildCliPlan(["automations", "trigger", "rule-42", "--lane", "lane-7"]);
+    expect(plan.kind).toBe("execute");
+    if (plan.kind !== "execute") return;
+    expect(plan.steps[0]?.params).toMatchObject({
+      arguments: {
+        domain: "automations",
+        action: "triggerManually",
+        args: { id: "rule-42", laneId: "lane-7" },
+      },
     });
   });
 

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -1515,6 +1515,28 @@ describe("ADE CLI", () => {
     });
   });
 
+  it("automations create with implicit reuse accepts --lane", () => {
+    const plan = buildCliPlan([
+      "automations",
+      "create",
+      "--text",
+      "id: r1\n",
+      "--lane",
+      "lane-99",
+    ]);
+    expect(plan.kind).toBe("execute");
+    if (plan.kind !== "execute") return;
+    expect(plan.steps[0]?.params).toMatchObject({
+      arguments: {
+        args: {
+          draft: {
+            execution: { targetLaneId: "lane-99" },
+          },
+        },
+      },
+    });
+  });
+
   it("automations create accepts require-on-trigger lane mode without a target lane", () => {
     const plan = buildCliPlan([
       "automations",

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -3744,7 +3744,7 @@ function applyLaneFlagsToDraft(draft: JsonObject, args: string[]): JsonObject {
     laneMode
     ?? (asString(existingExecution.laneMode) as AutomationLaneModeFlag | null);
 
-  if (laneId != null && effectiveLaneMode !== "reuse") {
+  if (laneId != null && effectiveLaneMode != null && effectiveLaneMode !== "reuse") {
     throw new CliUsageError("--lane is only valid with --lane-mode reuse.");
   }
   if (preset != null && effectiveLaneMode !== "create") {

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -1210,7 +1210,7 @@ const HELP_BY_COMMAND: Record<string, string> = {
     $ ade automations delete <id>                   Remove a local rule
     $ ade automations toggle <id> --enabled true|false
     $ ade automations run <id> [--lane <id>] [--dry-run]
-    $ ade automations trigger <id> --lane <id>
+    $ ade automations trigger <id> [--lane <id>]
                                                      Trigger a rule manually
     $ ade automations runs [--rule <id>] [--status <s>] [--limit 50]
     $ ade automations run-show <runId> [--json]     Inspect a run
@@ -3739,20 +3739,24 @@ function applyLaneFlagsToDraft(draft: JsonObject, args: string[]): JsonObject {
     return draft;
   }
 
-  if (laneId != null && laneMode != null && laneMode !== "reuse") {
+  const existingExecution = isRecord(draft.execution) ? draft.execution : {};
+  const effectiveLaneMode =
+    laneMode
+    ?? (asString(existingExecution.laneMode) as AutomationLaneModeFlag | null);
+
+  if (laneId != null && effectiveLaneMode !== "reuse") {
     throw new CliUsageError("--lane is only valid with --lane-mode reuse.");
   }
-  if (preset != null && laneMode != null && laneMode !== "create") {
+  if (preset != null && effectiveLaneMode !== "create") {
     throw new CliUsageError("--lane-name-preset is only valid with --lane-mode create.");
   }
   if (template != null && preset != null && preset !== "custom") {
     throw new CliUsageError("--lane-name-template is only valid with --lane-name-preset custom.");
   }
-  if (template != null && preset == null && laneMode !== "create") {
+  if (template != null && preset == null && effectiveLaneMode !== "create") {
     throw new CliUsageError("--lane-name-template requires --lane-mode create (with --lane-name-preset custom).");
   }
 
-  const existingExecution = isRecord(draft.execution) ? draft.execution : {};
   const execution: JsonObject = { ...existingExecution };
   if (laneMode != null) execution.laneMode = laneMode;
   if (laneId != null) execution.targetLaneId = laneId;

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -1209,13 +1209,15 @@ const HELP_BY_COMMAND: Record<string, string> = {
     $ ade automations update <id> --from-file <path>
     $ ade automations delete <id>                   Remove a local rule
     $ ade automations toggle <id> --enabled true|false
-    $ ade automations run <id> [--dry-run]          Trigger a rule manually
+    $ ade automations run <id> [--lane <id>] [--dry-run]
+    $ ade automations trigger <id> --lane <id>
+                                                     Trigger a rule manually
     $ ade automations runs [--rule <id>] [--status <s>] [--limit 50]
     $ ade automations run-show <runId> [--json]     Inspect a run
     $ ade automations example                       Print an example rule (stdout)
 
   Lane mode flags (apply to create/update on top of --from-file/--stdin/--text):
-    --lane-mode <create|reuse>                      Spawn a new lane per run, or reuse one
+    --lane-mode <create|reuse|require-on-trigger>   Create, reuse, or require lane at trigger time
     --lane <id>                                     Target lane (only with --lane-mode reuse)
     --lane-name-preset <issue-title|issue-num-title|pr-title-author|custom>
     --lane-name-template <string>                   Template (only with preset custom)
@@ -3706,7 +3708,7 @@ function parseDraftInput(args: string[]): JsonObject {
   return parsed;
 }
 
-const AUTOMATION_LANE_MODES = ["create", "reuse"] as const;
+const AUTOMATION_LANE_MODES = ["create", "reuse", "require-on-trigger"] as const;
 const AUTOMATION_LANE_NAME_PRESETS = ["issue-title", "issue-num-title", "pr-title-author", "custom"] as const;
 const AUTOMATION_RUN_STATUSES = ["queued", "running", "succeeded", "failed", "cancelled", "paused", "all"] as const;
 
@@ -3737,10 +3739,10 @@ function applyLaneFlagsToDraft(draft: JsonObject, args: string[]): JsonObject {
     return draft;
   }
 
-  if (laneId != null && laneMode === "create") {
+  if (laneId != null && laneMode != null && laneMode !== "reuse") {
     throw new CliUsageError("--lane is only valid with --lane-mode reuse.");
   }
-  if (preset != null && laneMode === "reuse") {
+  if (preset != null && laneMode != null && laneMode !== "create") {
     throw new CliUsageError("--lane-name-preset is only valid with --lane-mode create.");
   }
   if (template != null && preset != null && preset !== "custom") {
@@ -3867,7 +3869,7 @@ function buildAutomationsPlan(args: string[]): CliPlan {
     };
   }
 
-  if (sub === "run") {
+  if (sub === "run" || sub === "trigger") {
     const id = requireValue(readValue(args, ["--id"]) ?? firstPositional(args), "rule id");
     const dryRun = readFlag(args, ["--dry-run"]);
     const laneId = readLaneId(args);

--- a/apps/desktop/src/main/services/automations/automationPlannerService.test.ts
+++ b/apps/desktop/src/main/services/automations/automationPlannerService.test.ts
@@ -363,6 +363,86 @@ describe("automationPlannerService.validateDraft", () => {
     expect((res.normalized?.actions[2] as any).targetLaneId).toBe("lane-conflict");
   });
 
+  it("preserves require-on-trigger lane mode without requiring a target lane", () => {
+    const { planner } = getPlanner({ suites: [] });
+    const draft = createDraft({
+      name: "Require trigger lane",
+      execution: { kind: "agent-session", laneMode: "require-on-trigger" } as any,
+      prompt: "Use the lane supplied by the caller.",
+    });
+
+    const res = planner.validateDraft({ draft, confirmations: [] });
+    expect(res.ok).toBe(true);
+    expect(res.normalized?.execution).toMatchObject({
+      kind: "agent-session",
+      laneMode: "require-on-trigger",
+    });
+  });
+
+  it("normalizes legacy prompt-at-run lane mode to require-on-trigger", () => {
+    const { planner } = getPlanner({ suites: [] });
+    const draft = createDraft({
+      name: "Legacy prompt at run",
+      execution: { kind: "agent-session", laneMode: "prompt-at-run" } as any,
+      prompt: "Use the selected lane.",
+    });
+
+    const res = planner.validateDraft({ draft, confirmations: [] });
+    expect(res.ok).toBe(true);
+    expect(res.normalized?.execution).toMatchObject({
+      kind: "agent-session",
+      laneMode: "require-on-trigger",
+    });
+  });
+
+  it("rejects targetLaneId when lane mode requires the trigger lane", () => {
+    const { planner } = getPlanner({ suites: [] });
+    const draft = createDraft({
+      name: "Conflicting trigger lane",
+      execution: {
+        kind: "agent-session",
+        laneMode: "require-on-trigger",
+        targetLaneId: "lane-fixed",
+      } as any,
+      prompt: "This should choose at trigger time.",
+    });
+
+    const res = planner.validateDraft({ draft, confirmations: [] });
+    expect(res.ok).toBe(false);
+    expect(res.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: "error",
+          path: "execution.targetLaneId",
+        }),
+      ]),
+    );
+  });
+
+  it("rejects per-action targetLaneId when lane mode requires the trigger lane", () => {
+    const { planner } = getPlanner({ suites: [] });
+    const draft = createDraft({
+      name: "Conflicting step lane",
+      execution: {
+        kind: "built-in",
+        laneMode: "require-on-trigger",
+      } as any,
+      actions: [{ type: "run-command", command: "pwd", targetLaneId: "lane-fixed" } as any],
+      legacyActions: [{ type: "run-command", command: "pwd", targetLaneId: "lane-fixed" } as any],
+    });
+
+    const res = planner.validateDraft({ draft, confirmations: ["confirm.run-command"] });
+    expect(res.ok).toBe(false);
+    expect(res.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: "error",
+          path: "actions[0].targetLaneId",
+        }),
+      ]),
+    );
+  });
+
   it("validates run-command cwd against the per-action targetLaneId before draft execution lane", () => {
     const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-automation-planner-action-lane-"));
     const actionLane = fs.mkdtempSync(path.join(os.tmpdir(), "ade-automation-planner-action-lane-target-"));
@@ -395,6 +475,36 @@ describe("automationPlannerService.validateDraft", () => {
       fs.rmSync(actionLane, { recursive: true, force: true });
       fs.rmSync(draftLane, { recursive: true, force: true });
     }
+  });
+
+  it("preserves output disposition and verification settings", () => {
+    const { planner } = getPlanner({ suites: [] });
+    const draft = createDraft({
+      name: "Publish settings",
+      execution: { kind: "agent-session" } as any,
+      prompt: "Prepare a draft PR.",
+      outputs: {
+        disposition: "open-pr-draft",
+        createArtifact: false,
+        notificationChannel: "automation-alerts",
+      },
+      verification: {
+        verifyBeforePublish: true,
+        mode: "dry-run",
+      },
+    });
+
+    const res = planner.validateDraft({ draft, confirmations: [] });
+    expect(res.ok).toBe(true);
+    expect(res.normalized?.outputs).toMatchObject({
+      disposition: "open-pr-draft",
+      createArtifact: false,
+      notificationChannel: "automation-alerts",
+    });
+    expect(res.normalized?.verification).toMatchObject({
+      verifyBeforePublish: true,
+      mode: "dry-run",
+    });
   });
 });
  

--- a/apps/desktop/src/main/services/automations/automationPlannerService.ts
+++ b/apps/desktop/src/main/services/automations/automationPlannerService.ts
@@ -78,6 +78,34 @@ function safeTrim(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function normalizeLaneMode(value: unknown): NonNullable<AutomationRule["execution"]>["laneMode"] | undefined {
+  const raw = safeTrim(value);
+  if (raw === "provided" || raw === "prompt-at-run") return "require-on-trigger";
+  return raw === "create" || raw === "reuse" || raw === "require-on-trigger" ? raw : undefined;
+}
+
+function normalizeLaneNamePreset(value: unknown): NonNullable<AutomationRule["execution"]>["laneNamePreset"] | undefined {
+  const raw = safeTrim(value);
+  return raw === "issue-title" || raw === "issue-num-title" || raw === "pr-title-author" || raw === "custom"
+    ? raw
+    : undefined;
+}
+
+function normalizeOutputDisposition(value: unknown): AutomationRule["outputs"]["disposition"] {
+  const raw = safeTrim(value);
+  return raw === "open-task" ||
+    raw === "open-lane" ||
+    raw === "prepare-patch" ||
+    raw === "open-pr-draft" ||
+    raw === "comment-only"
+      ? raw
+      : "comment-only";
+}
+
+function normalizeVerificationMode(value: unknown): NonNullable<AutomationRule["verification"]["mode"]> {
+  return safeTrim(value) === "dry-run" ? "dry-run" : "intervention";
+}
+
 function extractFirstJsonObject(text: string): string | null {
   const raw = text.trim();
   if (!raw) return null;
@@ -797,10 +825,40 @@ function normalizeDraft(args: {
   }
 
   const requestedExecution = args.draft.execution;
+  const requestedLaneMode = normalizeLaneMode(requestedExecution?.laneMode);
+  const requestedLaneNamePreset = normalizeLaneNamePreset(requestedExecution?.laneNamePreset);
+  const requestedLaneNameTemplate = requestedLaneNamePreset === "custom"
+    ? safeTrim(requestedExecution?.laneNameTemplate)
+    : "";
+  if (requestedLaneMode === "require-on-trigger" && safeTrim(requestedExecution?.targetLaneId)) {
+    issues.push({
+      level: "error",
+      path: "execution.targetLaneId",
+      message: "targetLaneId is not allowed when lane must be supplied at trigger time.",
+    });
+  }
+  if (requestedLaneMode === "require-on-trigger") {
+    normalizedActions.forEach((action, index) => {
+      if (!safeTrim(action.targetLaneId)) return;
+      issues.push({
+        level: "error",
+        path: `actions[${index}].targetLaneId`,
+        message: "Step lane overrides are ignored when lane must be supplied at trigger time.",
+      });
+    });
+  }
+  const laneExecutionFields = {
+    ...(requestedLaneMode ? { laneMode: requestedLaneMode } : {}),
+    ...(requestedLaneMode === "create" && requestedLaneNamePreset ? { laneNamePreset: requestedLaneNamePreset } : {}),
+    ...(requestedLaneMode === "create" && requestedLaneNamePreset === "custom" && requestedLaneNameTemplate
+      ? { laneNameTemplate: requestedLaneNameTemplate }
+      : {}),
+  };
   const execution =
     requestedExecution?.kind === "agent-session" || requestedExecution?.kind === "mission" || requestedExecution?.kind === "built-in"
       ? {
           kind: requestedExecution.kind,
+          ...laneExecutionFields,
           ...(safeTrim(requestedExecution.targetLaneId) ? { targetLaneId: safeTrim(requestedExecution.targetLaneId) } : {}),
           ...(requestedExecution.kind === "agent-session"
             ? {
@@ -822,8 +880,8 @@ function normalizeDraft(args: {
           ...(requestedExecution.kind === "built-in" ? { builtIn: { actions: normalizedActions } } : {}),
         }
       : normalizedActions.length > 0
-        ? { kind: "built-in" as const, builtIn: { actions: normalizedActions } }
-        : { kind: "agent-session" as const, session: {} };
+        ? { kind: "built-in" as const, ...laneExecutionFields, builtIn: { actions: normalizedActions } }
+        : { kind: "agent-session" as const, ...laneExecutionFields, session: {} };
 
   if (execution.kind === "built-in" && normalizedActions.length === 0) {
     issues.push({
@@ -903,13 +961,13 @@ function normalizeDraft(args: {
       ...(args.draft.guardrails?.activeHours ? { activeHours: args.draft.guardrails.activeHours } : {}),
     },
     outputs: {
-      disposition: "comment-only",
+      disposition: normalizeOutputDisposition(args.draft.outputs?.disposition),
       ...(typeof args.draft.outputs?.createArtifact === "boolean" ? { createArtifact: args.draft.outputs.createArtifact } : { createArtifact: true }),
       ...(safeTrim(args.draft.outputs?.notificationChannel) ? { notificationChannel: safeTrim(args.draft.outputs?.notificationChannel) } : {}),
     },
     verification: {
-      verifyBeforePublish: false,
-      mode: "intervention",
+      verifyBeforePublish: Boolean(args.draft.verification?.verifyBeforePublish),
+      mode: normalizeVerificationMode(args.draft.verification?.mode),
     },
     billingCode: safeTrim(args.draft.billingCode) || `auto:${slugify(name)}`,
     includeProjectContext,
@@ -1348,6 +1406,9 @@ export function createAutomationPlannerService({
       }
       if (execution.kind === "built-in") {
         notes.push("Built-in tasks run directly without launching a mission or chat thread.");
+      }
+      if (execution.laneMode === "require-on-trigger") {
+        notes.push("Lane resolution: trigger caller must supply a lane.");
       }
 
       return { normalized, actions, notes, issues };

--- a/apps/desktop/src/main/services/automations/automationService.test.ts
+++ b/apps/desktop/src/main/services/automations/automationService.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { createRequire } from "node:module";
 import initSqlJs from "sql.js";
 import type { Database, SqlJsStatic } from "sql.js";
-import { createAutomationService, presetToTemplate, triggerMatches } from "./automationService";
+import { createAutomationService, normalizeRuntimeRule, presetToTemplate, triggerMatches } from "./automationService";
 
 type SqlValue = string | number | null | Uint8Array;
 
@@ -78,6 +78,33 @@ describe("triggerMatches", () => {
   });
 });
 
+describe("normalizeRuntimeRule", () => {
+  it("normalizes legacy prompt-at-run lane mode to require-on-trigger", () => {
+    const normalized = normalizeRuntimeRule({
+      id: "legacy-prompt-at-run",
+      name: "Legacy prompt at run",
+      enabled: true,
+      mode: "review",
+      triggers: [{ type: "manual" }],
+      trigger: { type: "manual" },
+      execution: { kind: "agent-session", laneMode: "prompt-at-run" } as any,
+      executor: { mode: "automation-bot" },
+      prompt: "Run in the supplied lane.",
+      reviewProfile: "quick",
+      toolPalette: ["repo"],
+      contextSources: [],
+      memory: { mode: "none" },
+      guardrails: {},
+      outputs: { disposition: "comment-only", createArtifact: true },
+      verification: { verifyBeforePublish: false, mode: "intervention" },
+      billingCode: "auto:test",
+      actions: [],
+    });
+
+    expect(normalized.execution?.laneMode).toBe("require-on-trigger");
+  });
+});
+
 function createInMemoryAdeDb(): { db: AdeDb; raw: Database } {
   const raw = new SQL.Database();
   raw.run(`
@@ -123,6 +150,32 @@ function createInMemoryAdeDb(): { db: AdeDb; raw: Database } {
       status text not null,
       error_message text,
       output text
+    )
+  `);
+  raw.run(`
+    create table automation_ingress_events(
+      id text primary key,
+      project_id text not null,
+      source text not null,
+      event_key text not null,
+      automation_ids_json text not null,
+      trigger_type text not null,
+      event_name text,
+      status text not null,
+      summary text,
+      error_message text,
+      cursor text,
+      raw_payload_json text,
+      received_at text not null
+    )
+  `);
+  raw.run(`
+    create table automation_ingress_cursors(
+      project_id text not null,
+      source text not null,
+      cursor text,
+      updated_at text not null,
+      primary key(project_id, source)
     )
   `);
 
@@ -294,6 +347,171 @@ describe("automationService integration", () => {
     }
   });
 
+  it("requires manual triggers to pass laneId when laneMode is require-on-trigger", async () => {
+    const { db } = createInMemoryAdeDb();
+    const logger = createLogger();
+    const projectId = "proj";
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-automation-require-lane-"));
+
+    const rule = {
+      id: "manual-require-lane",
+      name: "Manual require lane",
+      trigger: { type: "manual" as const },
+      triggers: [{ type: "manual" as const }],
+      execution: {
+        kind: "built-in" as const,
+        laneMode: "require-on-trigger" as const,
+        builtIn: { actions: [{ type: "run-command" as const, command: "pwd", timeoutMs: 10_000 }] },
+      },
+      actions: [{ type: "run-command" as const, command: "pwd", timeoutMs: 10_000 }],
+      enabled: true
+    };
+
+    const projectConfigService = {
+      get: () => ({
+        trust: { requiresSharedTrust: false },
+        effective: { automations: [rule], providerMode: "guest" }
+      })
+    } as any;
+
+    const laneService = {
+      list: async () => [{ id: "lane-primary", laneType: "primary" }],
+      getLaneWorktreePath: () => projectRoot,
+      getLaneBaseAndBranch: () => ({ baseRef: "main", branchRef: "main", worktreePath: projectRoot })
+    } as any;
+
+    const service = createAutomationService({
+      db: db as any,
+      logger,
+      projectId,
+      projectRoot,
+      laneService,
+      projectConfigService
+    });
+
+    try {
+      await expect(service.triggerManually({ id: "manual-require-lane" })).rejects.toThrow(/requires a lane/);
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the supplied laneId for require-on-trigger manual runs", async () => {
+    const { db, raw } = createInMemoryAdeDb();
+    const logger = createLogger();
+    const projectId = "proj";
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-automation-require-project-"));
+    const suppliedLaneRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-automation-require-supplied-"));
+    const actionLaneRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-automation-require-action-"));
+
+    const rule = {
+      id: "manual-supplied-lane",
+      name: "Manual supplied lane",
+      trigger: { type: "manual" as const },
+      triggers: [{ type: "manual" as const }],
+      execution: {
+        kind: "built-in" as const,
+        laneMode: "require-on-trigger" as const,
+        builtIn: { actions: [{ type: "run-command" as const, command: "pwd", targetLaneId: "lane-action", timeoutMs: 10_000 }] },
+      },
+      actions: [{ type: "run-command" as const, command: "pwd", targetLaneId: "lane-action", timeoutMs: 10_000 }],
+      enabled: true
+    };
+
+    const projectConfigService = {
+      get: () => ({
+        trust: { requiresSharedTrust: false },
+        effective: { automations: [rule], providerMode: "guest" }
+      })
+    } as any;
+
+    const laneService = {
+      list: async () => [{ id: "lane-primary", laneType: "primary" }, { id: "lane-supplied", laneType: "worktree" }, { id: "lane-action", laneType: "worktree" }],
+      getLaneWorktreePath: (laneId: string) => laneId === "lane-supplied" ? suppliedLaneRoot : laneId === "lane-action" ? actionLaneRoot : projectRoot,
+      getLaneBaseAndBranch: () => ({ baseRef: "main", branchRef: "main", worktreePath: projectRoot })
+    } as any;
+
+    const service = createAutomationService({
+      db: db as any,
+      logger,
+      projectId,
+      projectRoot,
+      laneService,
+      projectConfigService
+    });
+
+    try {
+      const run = await service.triggerManually({ id: "manual-supplied-lane", laneId: "lane-supplied" });
+      expect(run.status).toBe("succeeded");
+      const mapped = mapExecRows(raw.exec("select output from automation_action_results"));
+      expect(String(mapped[0]?.output ?? "")).toContain(suppliedLaneRoot);
+      expect(String(mapped[0]?.output ?? "")).not.toContain(actionLaneRoot);
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+      fs.rmSync(suppliedLaneRoot, { recursive: true, force: true });
+      fs.rmSync(actionLaneRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("fails non-manual require-on-trigger runs when the event has no lane", async () => {
+    const { db, raw } = createInMemoryAdeDb();
+    const logger = createLogger();
+    const projectId = "proj";
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-automation-require-event-"));
+
+    const rule = {
+      id: "event-require-lane",
+      name: "Event require lane",
+      trigger: { type: "github.issue_opened" as const },
+      triggers: [{ type: "github.issue_opened" as const }],
+      execution: {
+        kind: "built-in" as const,
+        laneMode: "require-on-trigger" as const,
+        builtIn: { actions: [{ type: "run-command" as const, command: "pwd", timeoutMs: 10_000 }] },
+      },
+      actions: [{ type: "run-command" as const, command: "pwd", timeoutMs: 10_000 }],
+      enabled: true
+    };
+
+    const projectConfigService = {
+      get: () => ({
+        trust: { requiresSharedTrust: false },
+        effective: { automations: [rule], providerMode: "guest" }
+      })
+    } as any;
+
+    const laneService = {
+      list: async () => [{ id: "lane-primary", laneType: "primary" }],
+      getLaneWorktreePath: () => projectRoot,
+      getLaneBaseAndBranch: () => ({ baseRef: "main", branchRef: "main", worktreePath: projectRoot })
+    } as any;
+
+    const service = createAutomationService({
+      db: db as any,
+      logger,
+      projectId,
+      projectRoot,
+      laneService,
+      projectConfigService
+    });
+
+    try {
+      const event = await service.dispatchIngressTrigger({
+        source: "github-polling",
+        eventKey: "issue:require-lane",
+        triggerType: "github.issue_opened",
+        eventName: "github.issue_opened",
+        issue: { number: 1, title: "No lane", labels: [] },
+      } as any);
+      expect(event?.status).toBe("dispatched");
+      const runs = mapExecRows(raw.exec("select status, error_message from automation_runs where automation_id = 'event-require-lane'"));
+      expect(runs[0]?.status).toBe("failed");
+      expect(String(runs[0]?.error_message ?? "")).toContain("trigger payload to include a laneId");
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   it("launches mission automations on the configured target lane", async () => {
     const { db } = createInMemoryAdeDb();
     const logger = createLogger();
@@ -450,6 +668,163 @@ describe("automationService integration", () => {
       expect(actions).toHaveLength(1);
       expect(actions[0]?.action_type).toBe("launch-mission");
       expect(String(actions[0]?.output ?? "")).toContain("mission-built-in");
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the step lane override when a built-in action launches a mission", async () => {
+    const { db } = createInMemoryAdeDb();
+    const logger = createLogger();
+    const projectId = "proj";
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-automation-built-in-mission-lane-"));
+    const createMission = vi.fn(() => ({
+      id: "mission-built-in-lane",
+      status: "in_progress",
+      outcomeSummary: null,
+      completedAt: null,
+      lastError: null,
+    }));
+
+    const rule = {
+      id: "built-in-mission-lane",
+      name: "Built-in mission lane",
+      enabled: true,
+      mode: "review",
+      reviewProfile: "quick",
+      trigger: { type: "manual" as const },
+      triggers: [{ type: "manual" as const }],
+      executor: { mode: "automation-bot", targetId: null },
+      toolPalette: [] as const,
+      contextSources: [],
+      memory: { mode: "project" as const },
+      guardrails: { maxDurationMin: 5 },
+      outputs: { disposition: "comment-only" as const, createArtifact: true },
+      verification: { verifyBeforePublish: false, mode: "intervention" as const },
+      billingCode: "auto:test",
+      execution: {
+        kind: "built-in" as const,
+        targetLaneId: "lane-rule",
+        builtIn: { actions: [{ type: "launch-mission" as const, sessionTitle: "Follow-up mission", targetLaneId: "lane-action" }] },
+      },
+      actions: [{ type: "launch-mission" as const, sessionTitle: "Follow-up mission", targetLaneId: "lane-action" }],
+      prompt: "Run a mission from a built-in action.",
+    };
+
+    const projectConfigService = {
+      get: () => ({
+        trust: { requiresSharedTrust: false },
+        effective: { automations: [rule], providerMode: "guest" }
+      })
+    } as any;
+
+    const laneService = {
+      list: async () => [
+        { id: "lane-primary", laneType: "primary" },
+        { id: "lane-rule", laneType: "worktree" },
+        { id: "lane-action", laneType: "worktree" },
+      ],
+      getLaneWorktreePath: () => projectRoot,
+      getLaneBaseAndBranch: () => ({ baseRef: "main", branchRef: "main", worktreePath: projectRoot })
+    } as any;
+
+    const service = createAutomationService({
+      db: db as any,
+      logger,
+      projectId,
+      projectRoot,
+      laneService,
+      projectConfigService,
+      missionService: {
+        create: createMission,
+        patchMetadata: vi.fn(),
+      } as any,
+      aiOrchestratorService: {
+        startMissionRun: vi.fn(async () => undefined),
+      } as any,
+    });
+
+    try {
+      await service.triggerManually({ id: "built-in-mission-lane" });
+      expect(createMission).toHaveBeenCalledWith(expect.objectContaining({ laneId: "lane-action" }));
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("fails built-in launch-mission actions when required trigger lane is missing", async () => {
+    const { db, raw } = createInMemoryAdeDb();
+    const logger = createLogger();
+    const projectId = "proj";
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-automation-built-in-mission-require-lane-"));
+    const createMission = vi.fn();
+
+    const rule = {
+      id: "built-in-mission-require-lane",
+      name: "Built-in mission require lane",
+      enabled: true,
+      mode: "review",
+      reviewProfile: "quick",
+      trigger: { type: "github.issue_opened" as const },
+      triggers: [{ type: "github.issue_opened" as const }],
+      executor: { mode: "automation-bot", targetId: null },
+      toolPalette: [] as const,
+      contextSources: [],
+      memory: { mode: "project" as const },
+      guardrails: { maxDurationMin: 5 },
+      outputs: { disposition: "comment-only" as const, createArtifact: true },
+      verification: { verifyBeforePublish: false, mode: "intervention" as const },
+      billingCode: "auto:test",
+      execution: {
+        kind: "built-in" as const,
+        laneMode: "require-on-trigger" as const,
+        builtIn: { actions: [{ type: "launch-mission" as const, sessionTitle: "Follow-up mission" }] },
+      },
+      actions: [{ type: "launch-mission" as const, sessionTitle: "Follow-up mission" }],
+      prompt: "Run a mission from a built-in action.",
+    };
+
+    const projectConfigService = {
+      get: () => ({
+        trust: { requiresSharedTrust: false },
+        effective: { automations: [rule], providerMode: "guest" }
+      })
+    } as any;
+
+    const laneService = {
+      list: async () => [{ id: "lane-primary", laneType: "primary" }],
+      getLaneWorktreePath: () => projectRoot,
+      getLaneBaseAndBranch: () => ({ baseRef: "main", branchRef: "main", worktreePath: projectRoot })
+    } as any;
+
+    const service = createAutomationService({
+      db: db as any,
+      logger,
+      projectId,
+      projectRoot,
+      laneService,
+      projectConfigService,
+      missionService: {
+        create: createMission,
+        patchMetadata: vi.fn(),
+      } as any,
+      aiOrchestratorService: {
+        startMissionRun: vi.fn(async () => undefined),
+      } as any,
+    });
+
+    try {
+      await service.dispatchIngressTrigger({
+        source: "github-polling",
+        eventKey: "issue:built-in-mission-require-lane",
+        triggerType: "github.issue_opened",
+        eventName: "github.issue_opened",
+        issue: { number: 1, title: "No lane", labels: [] },
+      } as any);
+      expect(createMission).not.toHaveBeenCalled();
+      const runs = mapExecRows(raw.exec("select status, error_message from automation_runs where automation_id = 'built-in-mission-require-lane'"));
+      expect(runs[0]?.status).toBe("failed");
+      expect(String(runs[0]?.error_message ?? "")).toContain("trigger payload to include a laneId");
     } finally {
       fs.rmSync(projectRoot, { recursive: true, force: true });
     }
@@ -1373,6 +1748,82 @@ describe("automationService integration", () => {
         expect(setupRows[0]?.status).toBe("succeeded");
       } finally {
         fs.rmSync(projectRoot, { recursive: true, force: true });
+      }
+    });
+
+    it("reuses the created lane for every built-in step in the run", async () => {
+      const { db, raw, logger, projectId, projectRoot } = buildLaneModeFixtures();
+      const laneRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-automation-lane-mode-created-"));
+      const createLane = vi.fn(async ({ name }: { name: string }) => ({
+        id: "lane-fresh",
+        name,
+        branchRef: name.replace(/\s+/g, "-").toLowerCase(),
+        laneType: "feature",
+        worktreePath: laneRoot,
+      }));
+
+      const rule = {
+        id: "built-in-create-lane",
+        name: "Built-in create lane",
+        enabled: true,
+        mode: "review",
+        reviewProfile: "quick",
+        trigger: { type: "manual" as const },
+        triggers: [{ type: "manual" as const }],
+        executor: { mode: "automation-bot", targetId: null },
+        toolPalette: [] as const,
+        contextSources: [],
+        memory: { mode: "project" as const },
+        guardrails: { maxDurationMin: 5 },
+        outputs: { disposition: "comment-only" as const, createArtifact: true },
+        verification: { verifyBeforePublish: false, mode: "intervention" as const },
+        billingCode: "auto:test",
+        execution: {
+          kind: "built-in" as const,
+          laneMode: "create" as const,
+          laneNamePreset: "issue-title" as const,
+          builtIn: {
+            actions: [
+              { type: "run-command" as const, command: "pwd", timeoutMs: 10_000 },
+              { type: "run-command" as const, command: "pwd", timeoutMs: 10_000 },
+            ],
+          },
+        },
+        actions: [],
+      };
+
+      const projectConfigService = {
+        get: () => ({ trust: { requiresSharedTrust: false }, effective: { automations: [rule], providerMode: "guest" } })
+      } as any;
+      const laneService = {
+        create: createLane,
+        list: async () => [{ id: "lane-primary", name: "primary", laneType: "primary" }],
+        getLaneWorktreePath: (laneId: string) => laneId === "lane-fresh" ? laneRoot : projectRoot,
+        getLaneBaseAndBranch: () => ({ baseRef: "main", branchRef: "main", worktreePath: projectRoot })
+      } as any;
+
+      const service = createAutomationService({
+        db: db as any,
+        logger,
+        projectId,
+        projectRoot,
+        laneService,
+        projectConfigService,
+      });
+
+      try {
+        const run = await service.triggerManually({ id: "built-in-create-lane" });
+        expect(run.status).toBe("succeeded");
+        expect(createLane).toHaveBeenCalledTimes(1);
+        const commandRows = mapExecRows(raw.exec("select output from automation_action_results where action_type = 'run-command' order by action_index asc"));
+        expect(commandRows).toHaveLength(2);
+        expect(String(commandRows[0]?.output ?? "")).toContain(laneRoot);
+        expect(String(commandRows[1]?.output ?? "")).toContain(laneRoot);
+        const setupRows = mapExecRows(raw.exec("select status from automation_action_results where action_type = 'lane-setup'"));
+        expect(setupRows).toHaveLength(1);
+      } finally {
+        fs.rmSync(projectRoot, { recursive: true, force: true });
+        fs.rmSync(laneRoot, { recursive: true, force: true });
       }
     });
 

--- a/apps/desktop/src/main/services/automations/automationService.ts
+++ b/apps/desktop/src/main/services/automations/automationService.ts
@@ -618,6 +618,11 @@ function deriveIncludeProjectContext(rule: AutomationRule): boolean {
   return false;
 }
 
+function normalizeAutomationLaneMode(mode: unknown): AutomationExecution["laneMode"] | undefined {
+  if (mode === "provided" || mode === "prompt-at-run") return "require-on-trigger";
+  return mode === "create" || mode === "reuse" || mode === "require-on-trigger" ? mode : undefined;
+}
+
 export function normalizeRuntimeRule(rule: AutomationRule): AutomationRule {
   const triggers = normalizedRuleTriggers(rule).map(canonicalizeTriggerForRuntime);
   const legacyActions = Array.isArray(rule.legacy?.actions)
@@ -630,8 +635,9 @@ export function normalizeRuntimeRule(rule: AutomationRule): AutomationRule {
   const rawExecution = rule.execution ?? (legacyActions.length > 0
     ? { kind: "built-in" as const, builtIn: { actions: legacyActions } }
     : { kind: "mission" as const });
+  const laneMode = normalizeAutomationLaneMode(rawExecution.laneMode);
   const sharedLaneFields = {
-    ...(rawExecution.laneMode ? { laneMode: rawExecution.laneMode } : {}),
+    ...(laneMode ? { laneMode } : {}),
     ...(rawExecution.laneNamePreset ? { laneNamePreset: rawExecution.laneNamePreset } : {}),
     ...(rawExecution.laneNamePreset === "custom" && rawExecution.laneNameTemplate
       ? { laneNameTemplate: rawExecution.laneNameTemplate }
@@ -660,9 +666,9 @@ export function normalizeRuntimeRule(rule: AutomationRule): AutomationRule {
           ...(rawExecution.mission ? { mission: rawExecution.mission } : {}),
         };
   const outputDisposition = rule.outputs?.disposition ?? "comment-only";
-  // Silently drop per-rule budget/review fields that are no longer surfaced
-  // in the UI. We keep them in the on-disk YAML so a downgrade doesn't lose
-  // data, but the in-memory runtime shape zeroes them out.
+  // Per-rule budget fields are deprecated in favor of global usage caps. We
+  // keep them in YAML for downgrade compatibility, but do not let runtime
+  // consume them.
   const sanitizedGuardrails = { ...(rule.guardrails ?? {}) } as AutomationRule["guardrails"] & {
     budgetCapUsd?: number;
     maxSpendUsd?: number;
@@ -1405,6 +1411,26 @@ export function createAutomationService({
     );
   };
 
+  const loadLaneSetupLaneId = (runId: string | null | undefined): string | null => {
+    if (!runId) return null;
+    const row = db.get<{ output: string | null }>(
+      `
+        select output
+        from automation_action_results
+        where project_id = ?
+          and run_id = ?
+          and action_type = 'lane-setup'
+          and status = 'succeeded'
+        order by started_at asc
+        limit 1
+      `,
+      [projectId, runId]
+    );
+    const parsed = safeJsonParse<Record<string, unknown> | null>(row?.output, null);
+    if (!isRecord(parsed)) return null;
+    return trimToNull(parsed.laneId);
+  };
+
   const loadRunRow = (runId: string): AutomationRunRow | null => db.get<AutomationRunRow>(
     `
       select
@@ -1693,6 +1719,14 @@ export function createAutomationService({
     return trimToNull(action?.targetLaneId) ?? trimToNull(rule.execution?.targetLaneId);
   };
 
+  const requiresTriggerLane = (rule: AutomationRule): boolean =>
+    rule.execution?.laneMode === "require-on-trigger";
+
+  const missingTriggerLaneMessage = (trigger: Pick<TriggerContext, "triggerType">): string =>
+    trigger.triggerType === "manual"
+      ? "This automation requires a lane when triggered manually. Pass laneId / --lane."
+      : "This automation requires the trigger payload to include a laneId.";
+
   const dispatchAdeAction = async (
     config: RunAdeActionConfig,
     trigger: TriggerContext,
@@ -1761,7 +1795,10 @@ export function createAutomationService({
     }
     if (action.type === "predict-conflicts") {
       if (!conflictService) throw new Error("Conflict service unavailable");
-      await conflictService.runPrediction(trigger.laneId ? { laneId: trigger.laneId } : {});
+      const laneId = requiresTriggerLane(rule) || rule.execution?.laneMode === "create"
+        ? await resolveExecutionLaneId(rule, trigger, action, runId)
+        : trigger.laneId;
+      await conflictService.runPrediction(laneId ? { laneId } : {});
       return { status: "succeeded" };
     }
     if (action.type === "create-lane") {
@@ -1802,11 +1839,13 @@ export function createAutomationService({
       if (!testService) throw new Error("Test service unavailable");
       const activeLanes = await laneService.list({ includeArchived: false });
       const configuredLaneId = getConfiguredTargetLaneId(rule, action);
-      const laneId = configuredLaneId
-        ?? trigger.laneId
-        ?? activeLanes.find((lane) => lane.laneType === "primary")?.id
-        ?? activeLanes[0]?.id
-        ?? null;
+      const laneId = requiresTriggerLane(rule) || rule.execution?.laneMode === "create"
+        ? await resolveExecutionLaneId(rule, trigger, action, runId)
+        : configuredLaneId
+          ?? trigger.laneId
+          ?? activeLanes.find((lane) => lane.laneType === "primary")?.id
+          ?? activeLanes[0]?.id
+          ?? null;
       if (!laneId) throw new Error("No lane available to run tests");
       await testService.run({ laneId, suiteId });
       return { status: "succeeded" };
@@ -1881,11 +1920,19 @@ export function createAutomationService({
       }
     }
     if (action.type === "launch-mission") {
+      const laneMode = rule.execution?.laneMode;
+      const actionTargetLaneId = trimToNull(action.targetLaneId);
+      const ruleTargetLaneId = trimToNull(rule.execution?.targetLaneId);
       const missionRule: AutomationRule = {
         ...rule,
         execution: {
           kind: "mission",
-          ...(rule.execution?.targetLaneId ? { targetLaneId: rule.execution.targetLaneId } : {}),
+          ...(laneMode ? { laneMode } : {}),
+          ...(laneMode === "create" && rule.execution?.laneNamePreset ? { laneNamePreset: rule.execution.laneNamePreset } : {}),
+          ...(laneMode === "create" && rule.execution?.laneNameTemplate ? { laneNameTemplate: rule.execution.laneNameTemplate } : {}),
+          ...(laneMode !== "require-on-trigger" && (actionTargetLaneId ?? ruleTargetLaneId)
+            ? { targetLaneId: actionTargetLaneId ?? ruleTargetLaneId }
+            : {}),
           mission: { title: action.sessionTitle?.trim() || rule.execution?.mission?.title || null },
         },
       };
@@ -1905,7 +1952,9 @@ export function createAutomationService({
     if (action.type === "run-command") {
       const command = (action.command ?? "").trim();
       if (!command) throw new Error("run-command requires command");
-      const laneId = getConfiguredTargetLaneId(rule, action) ?? trigger.laneId;
+      const laneId = requiresTriggerLane(rule) || rule.execution?.laneMode === "create"
+        ? await resolveExecutionLaneId(rule, trigger, action, runId)
+        : getConfiguredTargetLaneId(rule, action) ?? trigger.laneId;
       const baseCwd = laneId ? laneService.getLaneWorktreePath(laneId) : projectRoot;
       const configuredCwd = (action.cwd ?? "").trim();
       const cwdCandidate = configuredCwd.length
@@ -2123,9 +2172,18 @@ export function createAutomationService({
     runId?: string | null,
   ): Promise<string | null> => {
     const actionLaneId = trimToNull(action?.targetLaneId);
+    if (requiresTriggerLane(rule)) {
+      const triggerLaneId = trimToNull(trigger.laneId);
+      if (triggerLaneId) return triggerLaneId;
+      throw new Error(missingTriggerLaneMessage(trigger));
+    }
+
     if (actionLaneId) return actionLaneId;
 
     if (rule.execution?.laneMode === "create") {
+      const existingCreatedLaneId = loadLaneSetupLaneId(runId);
+      if (existingCreatedLaneId) return existingCreatedLaneId;
+
       const setupActionId = runId ? insertAction(runId, -1, "lane-setup") : null;
       try {
         const { laneId, laneName } = await createLaneForRun(rule, trigger);
@@ -3278,9 +3336,13 @@ export function createAutomationService({
       if (!id) throw new Error("Automation id is required");
       const rule = findRule(id);
       if (!rule) throw new Error(`Automation not found: ${id}`);
+      const laneId = typeof args.laneId === "string" && args.laneId.trim().length ? args.laneId.trim() : undefined;
+      if (requiresTriggerLane(rule) && !laneId) {
+        throw new Error(missingTriggerLaneMessage({ triggerType: "manual" }));
+      }
       return await runRule(rule, {
         triggerType: "manual",
-        laneId: typeof args.laneId === "string" && args.laneId.trim().length ? args.laneId.trim() : undefined,
+        laneId,
         reason: id,
         scheduledAt: nowIso(),
         reviewProfileOverride: args.reviewProfileOverride ?? null,

--- a/apps/desktop/src/main/services/automations/automationService.ts
+++ b/apps/desktop/src/main/services/automations/automationService.ts
@@ -1797,7 +1797,7 @@ export function createAutomationService({
       if (!conflictService) throw new Error("Conflict service unavailable");
       const laneId = requiresTriggerLane(rule) || rule.execution?.laneMode === "create"
         ? await resolveExecutionLaneId(rule, trigger, action, runId)
-        : trigger.laneId;
+        : getConfiguredTargetLaneId(rule, action) ?? trigger.laneId;
       await conflictService.runPrediction(laneId ? { laneId } : {});
       return { status: "succeeded" };
     }

--- a/apps/desktop/src/main/services/config/projectConfigService.automationExecution.test.ts
+++ b/apps/desktop/src/main/services/config/projectConfigService.automationExecution.test.ts
@@ -73,6 +73,22 @@ describe("projectConfigService automation execution normalization", () => {
               laneNameTemplate: "Should be dropped",
             },
           },
+          {
+            id: "require-trigger-lane-rule",
+            trigger: { type: "manual" },
+            execution: {
+              kind: "agent-session",
+              laneMode: "require-on-trigger",
+            },
+          },
+          {
+            id: "legacy-prompt-at-run-rule",
+            trigger: { type: "manual" },
+            execution: {
+              kind: "agent-session",
+              laneMode: "prompt-at-run",
+            },
+          },
         ],
       }),
       "utf8",
@@ -86,7 +102,7 @@ describe("projectConfigService automation execution normalization", () => {
       logger: makeLogger(),
     });
 
-    const [customRule, presetRule] = service.get().effective.automations;
+    const [customRule, presetRule, requireTriggerLaneRule, legacyPromptAtRunRule] = service.get().effective.automations;
 
     expect(customRule.execution).toMatchObject({
       kind: "mission",
@@ -101,5 +117,108 @@ describe("projectConfigService automation execution normalization", () => {
       laneNamePreset: "issue-title",
     });
     expect(presetRule.execution?.laneNameTemplate).toBeUndefined();
+    expect(requireTriggerLaneRule.execution).toMatchObject({
+      kind: "agent-session",
+      laneMode: "require-on-trigger",
+    });
+    expect(legacyPromptAtRunRule.execution).toMatchObject({
+      kind: "agent-session",
+      laneMode: "require-on-trigger",
+    });
+  });
+
+  it("flags fixed target lanes on require-on-trigger automation execution", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ade-project-config-automation-execution-"));
+    tempDirs.push(root);
+
+    const adeDir = path.join(root, ".ade");
+    fs.mkdirSync(adeDir, { recursive: true });
+
+    const service = createProjectConfigService({
+      projectRoot: root,
+      adeDir,
+      projectId: "project-automation-execution-validation",
+      db: makeDb(),
+      logger: makeLogger(),
+    });
+
+    const validation = service.validate({
+      shared: {
+        version: 1,
+        processes: [],
+        stackButtons: [],
+        testSuites: [],
+        laneOverlayPolicies: [],
+        automations: [],
+      },
+      local: {
+        version: 1,
+        processes: [],
+        stackButtons: [],
+        testSuites: [],
+        laneOverlayPolicies: [],
+        automations: [
+          {
+            id: "bad-trigger-lane",
+            name: "Bad trigger lane",
+            enabled: true,
+            mode: "review",
+            trigger: { type: "manual" },
+            triggers: [{ type: "manual" }],
+            execution: {
+              kind: "agent-session",
+              laneMode: "require-on-trigger",
+              targetLaneId: "lane-fixed",
+            },
+            executor: { mode: "automation-bot" },
+            prompt: "Run.",
+            reviewProfile: "quick",
+            toolPalette: ["repo"],
+            contextSources: [],
+            memory: { mode: "none" },
+            guardrails: {},
+            outputs: { disposition: "comment-only", createArtifact: true },
+            verification: { verifyBeforePublish: false, mode: "intervention" },
+            billingCode: "auto:test",
+          },
+          {
+            id: "bad-step-lane",
+            name: "Bad step lane",
+            enabled: true,
+            mode: "review",
+            trigger: { type: "manual" },
+            triggers: [{ type: "manual" }],
+            execution: {
+              kind: "built-in",
+              laneMode: "require-on-trigger",
+              builtIn: {
+                actions: [{ type: "run-command", command: "pwd", targetLaneId: "lane-fixed" }],
+              },
+            },
+            executor: { mode: "automation-bot" },
+            reviewProfile: "quick",
+            toolPalette: ["repo"],
+            contextSources: [],
+            memory: { mode: "none" },
+            guardrails: {},
+            outputs: { disposition: "comment-only", createArtifact: true },
+            verification: { verifyBeforePublish: false, mode: "intervention" },
+            billingCode: "auto:test",
+          },
+        ],
+      },
+    } as any);
+
+    expect(validation.ok).toBe(false);
+    expect(validation.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "effective.automations[0].execution.targetLaneId",
+        }),
+        expect.objectContaining({
+          path: "effective.automations[1].execution.builtIn.actions[0].targetLaneId",
+        }),
+      ]),
+    );
   });
 });

--- a/apps/desktop/src/main/services/config/projectConfigService.ts
+++ b/apps/desktop/src/main/services/config/projectConfigService.ts
@@ -477,6 +477,7 @@ function coerceAutomationAction(value: unknown): AutomationAction | null {
   if (!type) return null;
 
   const out: AutomationAction = { type };
+  const targetLaneId = asString(value.targetLaneId)?.trim();
   const suiteId = asString(value.suiteId);
   const command = asString(value.command);
   const cwd = asString(value.cwd);
@@ -488,6 +489,7 @@ function coerceAutomationAction(value: unknown): AutomationAction | null {
   const prompt = asString(value.prompt);
   const sessionTitle = asString(value.sessionTitle);
 
+  if (targetLaneId) out.targetLaneId = targetLaneId;
   if (suiteId != null) out.suiteId = suiteId;
   if (command != null) out.command = command;
   if (cwd != null) out.cwd = cwd;
@@ -527,8 +529,10 @@ function coerceAutomationExecution(value: unknown): AutomationExecution | undefi
 
   const targetLaneId = asString(value.targetLaneId)?.trim() || undefined;
   const laneModeRaw = asString(value.laneMode)?.trim();
-  const laneMode: AutomationExecution["laneMode"] = laneModeRaw === "create" || laneModeRaw === "reuse"
+  const laneMode: AutomationExecution["laneMode"] = laneModeRaw === "create" || laneModeRaw === "reuse" || laneModeRaw === "require-on-trigger"
     ? laneModeRaw
+    : laneModeRaw === "provided" || laneModeRaw === "prompt-at-run"
+      ? "require-on-trigger"
     : undefined;
   const laneNamePresetRaw = asString(value.laneNamePreset)?.trim();
   const laneNamePreset: AutomationExecution["laneNamePreset"] = laneNamePresetRaw === "issue-title" ||
@@ -2348,6 +2352,7 @@ function resolveEffectiveConfig(shared: ProjectConfigFile, local: ProjectConfigF
       ...(typeof entry.includeProjectContext === "boolean" ? { includeProjectContext: entry.includeProjectContext } : {}),
       actions: (entry.actions ?? []).map((action) => ({
         type: action.type,
+        ...(action.targetLaneId ? { targetLaneId: action.targetLaneId.trim() } : {}),
         ...(action.suiteId ? { suiteId: action.suiteId.trim() } : {}),
         ...(action.command ? { command: action.command } : {}),
         ...(action.cwd ? { cwd: action.cwd.trim() } : {}),
@@ -2364,6 +2369,7 @@ function resolveEffectiveConfig(shared: ProjectConfigFile, local: ProjectConfigF
         ...(entry.actions ? {
           actions: entry.actions.map((action) => ({
             type: action.type,
+            ...(action.targetLaneId ? { targetLaneId: action.targetLaneId.trim() } : {}),
             ...(action.suiteId ? { suiteId: action.suiteId.trim() } : {}),
             ...(action.command ? { command: action.command } : {}),
             ...(action.cwd ? { cwd: action.cwd.trim() } : {}),
@@ -2920,6 +2926,29 @@ function validateEffectiveConfig(
       issues.push({ path: `${p}.execution.kind`, message: `Unknown execution kind '${String((rule.execution as { kind?: unknown }).kind)}'` });
     } else if (rule.execution.kind === "built-in" && !(rule.execution.builtIn?.actions?.length ?? 0)) {
       issues.push({ path: `${p}.execution.builtIn.actions`, message: "Built-in automations need at least one task." });
+    }
+    if (
+      rule.execution?.laneMode
+      && rule.execution.laneMode !== "create"
+      && rule.execution.laneMode !== "reuse"
+      && rule.execution.laneMode !== "require-on-trigger"
+    ) {
+      issues.push({ path: `${p}.execution.laneMode`, message: `Unknown lane mode '${String(rule.execution.laneMode)}'` });
+    }
+    if (rule.execution?.laneMode === "require-on-trigger" && (rule.execution.targetLaneId ?? "").trim()) {
+      issues.push({
+        path: `${p}.execution.targetLaneId`,
+        message: "targetLaneId is not allowed when lane must be supplied at trigger time.",
+      });
+    }
+    if (rule.execution?.laneMode === "require-on-trigger" && rule.execution.kind === "built-in") {
+      rule.execution.builtIn?.actions.forEach((action, actionIndex) => {
+        if (!(action.targetLaneId ?? "").trim()) return;
+        issues.push({
+          path: `${p}.execution.builtIn.actions[${actionIndex}].targetLaneId`,
+          message: "Step lane overrides are not allowed when lane must be supplied at trigger time.",
+        });
+      });
     }
 
     if (

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -370,9 +370,15 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       const currentProjectRoot =
         useAppStore.getState().project?.rootPath ?? null;
       const currentShowWelcome = useAppStore.getState().showWelcome;
+      const currentIsNewTabOpen = useAppStore.getState().isNewTabOpen;
       const hasStoredProject = Boolean(nextProject);
       const projectChanged = nextProjectRoot !== currentProjectRoot;
       const welcomeChanged = currentShowWelcome === hasStoredProject;
+
+      if (currentIsNewTabOpen && nextProject && !projectChanged) {
+        setProject(nextProject);
+        return;
+      }
 
       if (nextProject) {
         setProject(nextProject);

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -377,6 +377,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
       if (currentIsNewTabOpen && nextProject && !projectChanged) {
         setProject(nextProject);
+        if (currentShowWelcome) setShowWelcome(false);
         return;
       }
 

--- a/apps/desktop/src/renderer/components/app/TopBar.test.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.test.tsx
@@ -220,6 +220,49 @@ describe("TopBar", () => {
     expect(await screen.findByText("1 phone connected")).toBeTruthy();
   });
 
+  it("does not refresh phone sync status on an idle interval", async () => {
+    vi.useFakeTimers();
+    try {
+      const getStatus = vi.fn(async () => makeSyncSnapshot());
+      globalThis.window.ade.sync.getStatus = getStatus as any;
+
+      render(<TopBar />);
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(getStatus).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(15_000);
+        await Promise.resolve();
+      });
+
+      expect(getStatus).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("refreshes phone sync status when the window regains focus", async () => {
+    const getStatus = vi.fn()
+      .mockResolvedValueOnce(makeSyncSnapshot({ connectedPeers: [] }))
+      .mockResolvedValueOnce(makeSyncSnapshot());
+    globalThis.window.ade.sync.getStatus = getStatus as any;
+
+    render(<TopBar />);
+
+    expect(await screen.findByText("Phone sync ready")).toBeTruthy();
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(await screen.findByText("1 phone connected")).toBeTruthy();
+    expect(getStatus).toHaveBeenCalledTimes(2);
+  });
+
   it("shows project icon replacement errors", async () => {
     globalThis.window.ade.project.chooseIcon = vi.fn(async () => {
       throw new Error("Failed to set project icon: Project icon must be 10 MB or smaller.");

--- a/apps/desktop/src/renderer/components/app/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.tsx
@@ -540,6 +540,7 @@ export function TopBar() {
 
   useEffect(() => {
     let cancelled = false;
+    let statusRequestVersion = 0;
     if (!project?.rootPath) {
       setSyncSnapshot(null);
       setPhoneSyncOpen(false);
@@ -548,31 +549,31 @@ export function TopBar() {
       };
     }
     const refreshSyncStatus = () => {
+      const requestVersion = ++statusRequestVersion;
       void window.ade.sync.getStatus({ includeTransferReadiness: false }).then((snapshot) => {
-        if (!cancelled) setSyncSnapshot(snapshot);
+        if (!cancelled && requestVersion === statusRequestVersion) setSyncSnapshot(snapshot);
       }).catch(() => {
-        if (!cancelled) setSyncSnapshot(null);
+        if (!cancelled && requestVersion === statusRequestVersion) setSyncSnapshot(null);
       });
     };
     setSyncSnapshot(null);
     refreshSyncStatus();
-    const interval = window.setInterval(refreshSyncStatus, 5_000);
     window.addEventListener("focus", refreshSyncStatus);
     const dispose = window.ade.sync.onEvent((event) => {
       if (!cancelled && event.type === "sync-status") {
+        statusRequestVersion += 1;
         setSyncSnapshot(event.snapshot);
       }
     });
     return () => {
       cancelled = true;
-      window.clearInterval(interval);
       window.removeEventListener("focus", refreshSyncStatus);
       dispose();
     };
     // Background projects don't broadcast sync-status events (main.ts filters
-    // them to the active project), so we re-run this effect on rootPath
-    // change to force an immediate refetch instead of waiting up to 5s for
-    // the next polling tick.
+    // them to the active project), so we re-run this effect on rootPath change
+    // to force an immediate refetch. Focus refresh covers state changes that
+    // happen while ADE is not active.
   }, [project?.rootPath]);
 
   const checkForActiveWorkloads = useCallback(async (projectRootPath: string): Promise<boolean> => {

--- a/apps/desktop/src/renderer/components/app/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.tsx
@@ -846,7 +846,7 @@ export function TopBar() {
                   onDrop={(e) => handleDrop(e, idx)}
                   onDragEnd={handleDragEnd}
                   className={cn(
-                    "ade-shell-project-tab group inline-flex w-[clamp(128px,16vw,220px)] max-w-[220px] shrink-0 items-center gap-2 px-3 py-0.5",
+                    "ade-shell-project-tab group inline-flex w-[clamp(128px,16vw,220px)] max-w-[220px] min-w-0 shrink-0 items-center gap-2 px-3 py-0.5",
                     "transition-[background-color,color,border-color,box-shadow,opacity] duration-150",
                     !isMissing && "cursor-pointer",
                     isCurrent && "font-semibold",
@@ -895,14 +895,14 @@ export function TopBar() {
                   ) : null}
                   <span
                     className={cn(
-                      "truncate",
+                      "min-w-0 flex-1 truncate",
                       isMissing && "line-through"
                     )}
                   >
                     {rp.displayName}
                   </span>
                   {isMissing ? (
-                    <span className="inline-flex items-center gap-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-150">
+                    <span className="ml-auto inline-flex shrink-0 items-center gap-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-150">
                       <button
                         type="button"
                         className="ade-shell-control inline-flex h-5 w-5 items-center justify-center text-current transition-[background-color,color,border-color,box-shadow] duration-100"
@@ -937,7 +937,7 @@ export function TopBar() {
                     <button
                       type="button"
                       className={cn(
-                        "ade-shell-control inline-flex h-5 w-5 items-center justify-center text-current",
+                        "ade-shell-control ml-auto inline-flex h-5 w-5 shrink-0 items-center justify-center text-current",
                         "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-150"
                       )}
                       data-variant="ghost"
@@ -958,7 +958,7 @@ export function TopBar() {
             {isNewTabOpen && (
               <div
                 className={cn(
-                  "ade-shell-project-tab group inline-flex w-[clamp(128px,16vw,220px)] max-w-[220px] items-center gap-2 px-3 py-0.5",
+                  "ade-shell-project-tab group inline-flex w-[clamp(128px,16vw,220px)] max-w-[220px] min-w-0 items-center gap-2 px-3 py-0.5",
                   "transition-[background-color,color,border-color,box-shadow] duration-150",
                   "font-semibold"
                 )}
@@ -970,13 +970,13 @@ export function TopBar() {
                 ) : (
                   <img src="./logo.png" alt="" style={{ height: 16, width: 34, objectFit: "contain" }} draggable={false} />
                 )}
-                <span className="truncate text-[12px]">
+                <span className="min-w-0 flex-1 truncate text-[12px]">
                   {projectTransition?.kind === "opening" ? "Opening…" : "New Tab"}
                 </span>
                 <button
                   type="button"
                   className={cn(
-                    "ade-shell-control inline-flex h-4 w-4 items-center justify-center rounded-sm",
+                    "ade-shell-control ml-auto inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm",
                     "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-150"
                   )}
                   data-variant="ghost"

--- a/apps/desktop/src/renderer/components/automations/ActionList.tsx
+++ b/apps/desktop/src/renderer/components/automations/ActionList.tsx
@@ -71,8 +71,6 @@ const ADD_OPTIONS: readonly AddOption[] = [
     icon: Rocket,
     accent: "#94A3B8",
     description: "Spin up a multi-step mission for this rule.",
-    disabled: true,
-    hint: "Soon",
   },
 ];
 
@@ -111,6 +109,7 @@ export function ActionList({
   lanes,
   suites,
   fallbackModel,
+  executionLaneMode,
   onChange,
   onOpenAiSettings,
 }: {
@@ -118,6 +117,7 @@ export function ActionList({
   lanes: Array<{ id: string; name: string }>;
   suites: TestSuiteDefinition[];
   fallbackModel: ModelConfig;
+  executionLaneMode?: string | null;
   onChange: (next: ActionRowValue[]) => void;
   onOpenAiSettings?: () => void;
 }) {
@@ -175,6 +175,7 @@ export function ActionList({
               lanes={lanes}
               suites={suites}
               fallbackModel={fallbackModel}
+              executionLaneMode={executionLaneMode}
               onChange={(next) => updateAction(index, next)}
               onRemove={() => removeAction(index)}
               onMove={(direction) => moveAction(index, direction)}

--- a/apps/desktop/src/renderer/components/automations/ActionRow.tsx
+++ b/apps/desktop/src/renderer/components/automations/ActionRow.tsx
@@ -351,7 +351,11 @@ export function ActionRow({
 }
 
 function supportsLaneOverride(kind: ActionRowKind): boolean {
-  return kind === "agent-session" || kind === "run-tests" || kind === "run-command";
+  return kind === "agent-session"
+    || kind === "run-tests"
+    || kind === "run-command"
+    || kind === "predict-conflicts"
+    || kind === "launch-mission";
 }
 
 function secondsFromMs(ms: number | undefined): number | "" {

--- a/apps/desktop/src/renderer/components/automations/ActionRow.tsx
+++ b/apps/desktop/src/renderer/components/automations/ActionRow.tsx
@@ -34,10 +34,15 @@ export type ActionRowKind =
 
 export type ActionRowValue = {
   kind: ActionRowKind;
+  // Runtime
+  targetLaneId?: string | null;
+  condition?: string;
+  continueOnFailure?: boolean;
+  timeoutMs?: number;
+  retry?: number;
   // Agent-session
   prompt?: string;
   sessionTitle?: string;
-  targetLaneId?: string | null;
   modelConfig?: ModelConfig;
   permissionConfig?: MissionPermissionConfig;
   // Create lane
@@ -72,6 +77,7 @@ export function ActionRow({
   lanes,
   suites,
   fallbackModel,
+  executionLaneMode,
   onChange,
   onRemove,
   onMove,
@@ -83,6 +89,7 @@ export function ActionRow({
   lanes: Array<{ id: string; name: string }>;
   suites: TestSuiteDefinition[];
   fallbackModel: ModelConfig;
+  executionLaneMode?: string | null;
   onChange: (next: ActionRowValue) => void;
   onRemove: () => void;
   onMove: (direction: -1 | 1) => void;
@@ -90,11 +97,23 @@ export function ActionRow({
 }) {
   const meta = KIND_META[value.kind];
   const Icon = meta.icon;
+  const triggerSuppliesLane = executionLaneMode === "require-on-trigger"
+    || executionLaneMode === "provided"
+    || executionLaneMode === "prompt-at-run";
   const activeModel = value.modelConfig ?? fallbackModel;
   const permissionMeta = permissionControlsForModel(activeModel.modelId);
   const currentPermission = permissionMeta
     ? value.permissionConfig?.providers?.[permissionMeta.key] ?? ""
     : "";
+  const patchValue = (patch: Partial<ActionRowValue>) => {
+    const next = { ...value, ...patch };
+    if ("condition" in patch && !patch.condition?.trim()) delete next.condition;
+    if ("targetLaneId" in patch && !patch.targetLaneId) delete next.targetLaneId;
+    if ("timeoutMs" in patch && patch.timeoutMs == null) delete next.timeoutMs;
+    if ("retry" in patch && patch.retry == null) delete next.retry;
+    if ("continueOnFailure" in patch && !patch.continueOnFailure) delete next.continueOnFailure;
+    onChange(next);
+  };
 
   return (
     <div
@@ -308,16 +327,184 @@ export function ActionRow({
         {value.kind === "launch-mission" ? (
           <div className="space-y-2">
             <input
-              className={cn(inputCls, "opacity-60")}
+              className={inputCls}
               value={value.missionTitle ?? ""}
               onChange={(event) => onChange({ ...value, missionTitle: event.target.value })}
               placeholder="Mission title"
-              disabled
             />
-            <Chip className="text-[9px] text-[#B6B2C9]">Mission launches are coming soon.</Chip>
+            <Chip className="text-[9px] text-[#B6B2C9]">Starts a mission and records the mission id in run history.</Chip>
           </div>
         ) : null}
+
+        {value.kind !== "create-lane" ? (
+          <RuntimeControls
+            value={value}
+            lanes={lanes}
+            showLaneOverride={supportsLaneOverride(value.kind)}
+            triggerSuppliesLane={triggerSuppliesLane}
+            onChange={patchValue}
+          />
+        ) : null}
       </div>
+    </div>
+  );
+}
+
+function supportsLaneOverride(kind: ActionRowKind): boolean {
+  return kind === "agent-session" || kind === "run-tests" || kind === "run-command";
+}
+
+function secondsFromMs(ms: number | undefined): number | "" {
+  if (!Number.isFinite(ms)) return "";
+  return Math.max(1, Math.round((ms ?? 0) / 1000));
+}
+
+function RuntimeControls({
+  value,
+  lanes,
+  showLaneOverride,
+  triggerSuppliesLane,
+  onChange,
+}: {
+  value: ActionRowValue;
+  lanes: Array<{ id: string; name: string }>;
+  showLaneOverride: boolean;
+  triggerSuppliesLane: boolean;
+  onChange: (patch: Partial<ActionRowValue>) => void;
+}) {
+  const condition = value.condition?.trim() ?? "";
+  const conditionMode =
+    condition === ""
+      ? "always"
+      : condition === "provider-enabled"
+        ? "provider-enabled"
+        : condition === "false"
+          ? "false"
+          : "custom";
+  const sortedLanes = [...lanes].sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <div className="mt-3 border-t border-white/[0.06] pt-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className={labelCls}>Runtime</div>
+        <div className="text-[10px] text-[#7E8A9A]">Controls how this step runs</div>
+      </div>
+      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+        <label className="block space-y-1.5">
+          <div className={labelCls}>Condition</div>
+          <select
+            className={selectCls}
+            value={conditionMode}
+            onChange={(event) => {
+              const next = event.target.value;
+              if (next === "always") onChange({ condition: undefined });
+              else if (next === "provider-enabled") onChange({ condition: "provider-enabled" });
+              else if (next === "false") onChange({ condition: "false" });
+              else onChange({ condition: condition || "provider-enabled" });
+            }}
+          >
+            <option value="always">Always run</option>
+            <option value="provider-enabled">Only when providers are enabled</option>
+            <option value="false">Always skip</option>
+            <option value="custom">Stored expression</option>
+          </select>
+        </label>
+
+        <label className="block space-y-1.5">
+          <div className={labelCls}>On failure</div>
+          <select
+            className={selectCls}
+            value={value.continueOnFailure ? "continue" : "stop"}
+            onChange={(event) => onChange({ continueOnFailure: event.target.value === "continue" })}
+          >
+            <option value="stop">Stop workflow</option>
+            <option value="continue">Continue to next step</option>
+          </select>
+        </label>
+
+        <label className="block space-y-1.5">
+          <div className={labelCls}>Timeout (sec)</div>
+          <input
+            className={inputCls}
+            type="number"
+            min={1}
+            value={secondsFromMs(value.timeoutMs)}
+            onChange={(event) => {
+              const raw = event.target.value.trim();
+              if (!raw) {
+                onChange({ timeoutMs: undefined });
+                return;
+              }
+              const parsed = Number(raw);
+              onChange({ timeoutMs: Number.isFinite(parsed) ? Math.max(1, Math.floor(parsed)) * 1000 : undefined });
+            }}
+            placeholder="Default"
+          />
+        </label>
+
+        <label className="block space-y-1.5">
+          <div className={labelCls}>Retries</div>
+          <input
+            className={inputCls}
+            type="number"
+            min={0}
+            max={5}
+            value={Number.isFinite(value.retry) ? value.retry : ""}
+            onChange={(event) => {
+              const raw = event.target.value.trim();
+              if (!raw) {
+                onChange({ retry: undefined });
+                return;
+              }
+              const parsed = Number(raw);
+              onChange({ retry: Number.isFinite(parsed) ? Math.max(0, Math.min(5, Math.floor(parsed))) : undefined });
+            }}
+            placeholder="0"
+          />
+        </label>
+      </div>
+
+      {conditionMode === "custom" ? (
+        <label className="mt-2 block space-y-1.5">
+          <div className={labelCls}>Stored condition</div>
+          <input
+            className={inputCls}
+            value={value.condition ?? ""}
+            onChange={(event) => onChange({ condition: event.target.value })}
+            placeholder="provider-enabled"
+          />
+          <div className="text-[10px] leading-snug text-[#7E8A9A]">
+            Runtime currently treats <span className="font-mono text-[#A7B7CA]">false</span> and{" "}
+            <span className="font-mono text-[#A7B7CA]">provider-enabled</span> specially.
+          </div>
+        </label>
+      ) : null}
+
+      {triggerSuppliesLane ? (
+        <div className="mt-2 rounded-md border border-[#2DD4BF]/20 bg-[#2DD4BF]/[0.06] px-2.5 py-2 text-[10.5px] leading-snug text-[#9BE7D8]">
+          This rule uses the lane supplied at run time for every step. Saved step lane overrides are ignored and removed on save.
+        </div>
+      ) : showLaneOverride ? (
+        <label className="mt-2 block space-y-1.5">
+          <div className={labelCls}>Lane override</div>
+          <select
+            className={selectCls}
+            value={value.targetLaneId ?? ""}
+            onChange={(event) => onChange({ targetLaneId: event.target.value || null })}
+          >
+            <option value="">Use execution lane</option>
+            {sortedLanes.map((lane) => (
+              <option key={lane.id} value={lane.id}>
+                {lane.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : value.targetLaneId ? (
+        <div className="mt-2 rounded-md border border-warning/20 bg-warning/[0.06] px-2.5 py-2 text-[10.5px] text-warning">
+          This saved step has a lane override, but this action type does not use it at runtime.
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/automations/GitHubTriggerFilters.tsx
+++ b/apps/desktop/src/renderer/components/automations/GitHubTriggerFilters.tsx
@@ -21,6 +21,10 @@ function parseRepoSlug(value: string | null | undefined): { owner: string; name:
   return match ? { owner: match[1]!, name: match[2]! } : null;
 }
 
+function parseList(value: string): string[] {
+  return value.split(",").map((entry) => entry.trim()).filter(Boolean);
+}
+
 export function GitHubTriggerFilters({
   trigger,
   onPatch,
@@ -168,6 +172,33 @@ export function GitHubTriggerFilters({
             placeholder="needs reproduction|security"
             onChange={(value) => onPatch({ bodyRegex: value })}
           />
+          <LabeledInput
+            label="Keywords"
+            value={(trigger.keywords ?? []).join(", ")}
+            placeholder="security, regression"
+            onChange={(value) => onPatch({ keywords: parseList(value) })}
+          />
+          <LabeledInput
+            label="Changed fields"
+            value={(trigger.changedFields ?? []).join(", ")}
+            placeholder="title, body, labels"
+            onChange={(value) => onPatch({ changedFields: parseList(value) })}
+          />
+          {isPr ? (
+            <label className="space-y-1 block">
+              <span className="text-[10px] uppercase tracking-[1px] text-[#8FA1B8]">Draft state</span>
+              <select
+                className={INPUT_CLS}
+                style={INPUT_STYLE}
+                value={trigger.draftState ?? "any"}
+                onChange={(event) => onPatch({ draftState: event.target.value as AutomationTrigger["draftState"] })}
+              >
+                <option value="any">Any</option>
+                <option value="draft">Draft</option>
+                <option value="ready">Ready</option>
+              </select>
+            </label>
+          ) : null}
         </div>
       ) : null}
 

--- a/apps/desktop/src/renderer/components/automations/GitHubTriggerFilters.tsx
+++ b/apps/desktop/src/renderer/components/automations/GitHubTriggerFilters.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { AutomationTrigger } from "../../../shared/types";
 import { cn } from "../ui/cn";
-import { INPUT_CLS, INPUT_STYLE } from "./shared";
+import { INPUT_CLS, INPUT_STYLE, parseList } from "./shared";
 
 type GitHubApi = {
   listRepoLabels?: (args: { owner: string; name: string }) => Promise<Array<{ name: string; color?: string }>>;
@@ -19,10 +19,6 @@ function parseRepoSlug(value: string | null | undefined): { owner: string; name:
   const trimmed = (value ?? "").trim();
   const match = /^([^/\s]+)\/([^/\s]+)$/.exec(trimmed);
   return match ? { owner: match[1]!, name: match[2]! } : null;
-}
-
-function parseList(value: string): string[] {
-  return value.split(",").map((entry) => entry.trim()).filter(Boolean);
 }
 
 export function GitHubTriggerFilters({

--- a/apps/desktop/src/renderer/components/automations/LinearTriggerFilters.tsx
+++ b/apps/desktop/src/renderer/components/automations/LinearTriggerFilters.tsx
@@ -1,6 +1,10 @@
 import type { AutomationTrigger } from "../../../shared/types";
 import { INPUT_CLS, INPUT_STYLE } from "./shared";
 
+function parseList(value: string): string[] {
+  return value.split(",").map((entry) => entry.trim()).filter(Boolean);
+}
+
 export function LinearTriggerFilters({
   trigger,
   onPatch,
@@ -43,14 +47,23 @@ export function LinearTriggerFilters({
           placeholder="bug, priority"
           onChange={(value) =>
             onPatch({
-              labels: value
-                .split(",")
-                .map((l) => l.trim())
-                .filter(Boolean),
+              labels: parseList(value),
             })
           }
         />
       )}
+      <LabeledInput
+        label="Changed fields"
+        value={(trigger.changedFields ?? []).join(", ")}
+        placeholder="title, description, labels"
+        onChange={(value) => onPatch({ changedFields: parseList(value) })}
+      />
+      <LabeledInput
+        label="Keywords"
+        value={(trigger.keywords ?? []).join(", ")}
+        placeholder="escalated, customer"
+        onChange={(value) => onPatch({ keywords: parseList(value) })}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/automations/LinearTriggerFilters.tsx
+++ b/apps/desktop/src/renderer/components/automations/LinearTriggerFilters.tsx
@@ -1,9 +1,5 @@
 import type { AutomationTrigger } from "../../../shared/types";
-import { INPUT_CLS, INPUT_STYLE } from "./shared";
-
-function parseList(value: string): string[] {
-  return value.split(",").map((entry) => entry.trim()).filter(Boolean);
-}
+import { INPUT_CLS, INPUT_STYLE, parseList } from "./shared";
 
 export function LinearTriggerFilters({
   trigger,

--- a/apps/desktop/src/renderer/components/automations/RulesTab.tsx
+++ b/apps/desktop/src/renderer/components/automations/RulesTab.tsx
@@ -11,6 +11,7 @@ import {
 import { motion } from "motion/react";
 import { getDefaultModelDescriptor } from "../../../shared/modelRegistry";
 import type {
+  AutomationAction,
   AutomationDraftConfirmationRequirement,
   AutomationDraftIssue,
   AutomationRuleDraft,
@@ -68,6 +69,16 @@ function createBlankDraft(): AutomationRuleDraft {
   };
 }
 
+function runtimeActionFields(action: AutomationAction) {
+  return {
+    ...(action.targetLaneId ? { targetLaneId: action.targetLaneId } : {}),
+    ...(action.condition ? { condition: action.condition } : {}),
+    ...(typeof action.continueOnFailure === "boolean" ? { continueOnFailure: action.continueOnFailure } : {}),
+    ...(Number.isFinite(action.timeoutMs) ? { timeoutMs: action.timeoutMs } : {}),
+    ...(Number.isFinite(action.retry) ? { retry: action.retry } : {}),
+  };
+}
+
 function toDraftFromRule(rule: AutomationRuleSummary): AutomationRuleDraft {
   const builtInActions = rule.execution?.kind === "built-in"
     ? rule.execution.builtIn?.actions ?? []
@@ -76,20 +87,27 @@ function toDraftFromRule(rule: AutomationRuleSummary): AutomationRuleDraft {
     if (action.type === "create-lane") {
       return {
         type: action.type,
+        ...runtimeActionFields(action),
         ...(action.laneNameTemplate ? { laneNameTemplate: action.laneNameTemplate } : {}),
         ...(action.laneDescriptionTemplate ? { laneDescriptionTemplate: action.laneDescriptionTemplate } : {}),
         ...(action.parentLaneId ? { parentLaneId: action.parentLaneId } : {}),
       } as any;
     }
     if (action.type === "run-tests") {
-      return { type: action.type, suite: action.suiteId ?? "" } as any;
+      return { type: action.type, ...runtimeActionFields(action), suite: action.suiteId ?? "" } as any;
     }
     if (action.type === "run-command") {
-      return { type: action.type, command: action.command ?? "", ...(action.cwd ? { cwd: action.cwd } : {}) } as any;
+      return {
+        type: action.type,
+        ...runtimeActionFields(action),
+        command: action.command ?? "",
+        ...(action.cwd ? { cwd: action.cwd } : {}),
+      } as any;
     }
     if (action.type === "ade-action") {
       return {
         type: action.type,
+        ...runtimeActionFields(action),
         adeAction: action.adeAction
           ? {
               domain: action.adeAction.domain ?? "",
@@ -103,7 +121,7 @@ function toDraftFromRule(rule: AutomationRuleSummary): AutomationRuleDraft {
     if (action.type === "agent-session") {
       return {
         type: action.type,
-        ...(action.targetLaneId ? { targetLaneId: action.targetLaneId } : {}),
+        ...runtimeActionFields(action),
         ...(action.modelConfig ? { modelConfig: structuredClone(action.modelConfig) } : {}),
         ...(action.permissionConfig ? { permissionConfig: structuredClone(action.permissionConfig) } : {}),
         ...(action.prompt ? { prompt: action.prompt } : {}),
@@ -113,10 +131,11 @@ function toDraftFromRule(rule: AutomationRuleSummary): AutomationRuleDraft {
     if (action.type === "launch-mission") {
       return {
         type: action.type,
+        ...runtimeActionFields(action),
         ...(action.sessionTitle ? { missionTitle: action.sessionTitle } : {}),
       } as any;
     }
-    return { type: action.type } as any;
+    return { type: action.type, ...runtimeActionFields(action) } as any;
   });
   return {
     id: rule.id,
@@ -314,6 +333,8 @@ export function RulesTab({
   const [saving, setSaving] = useState(false);
   const [simulating, setSimulating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [manualRunRule, setManualRunRule] = useState<AutomationRuleSummary | null>(null);
+  const [manualRunLaneId, setManualRunLaneId] = useState<string>("");
   const [configTrustRequired, setConfigTrustRequired] = useState(false);
   const loadRef = useRef<(() => Promise<void>) | null>(null);
   // Snapshot of the last-saved (or last-loaded-from-rule) draft, used to detect
@@ -492,15 +513,26 @@ export function RulesTab({
     setDetailView("editor");
   };
 
-  const runRuleNow = useCallback(async (ruleId: string) => {
+  const runRuleNow = useCallback(async (ruleId: string, laneId?: string | null) => {
     setError(null);
     try {
-      await window.ade.automations.triggerManually({ id: ruleId });
+      await window.ade.automations.triggerManually({ id: ruleId, ...(laneId ? { laneId } : {}) });
       await refresh();
+      setManualRunRule(null);
+      setManualRunLaneId("");
     } catch (err) {
       setError(extractError(err));
     }
   }, [refresh]);
+
+  const beginRunRule = useCallback((rule: AutomationRuleSummary) => {
+    if (rule.execution?.laneMode === "require-on-trigger") {
+      setManualRunRule(rule);
+      setManualRunLaneId(lanes[0]?.id ?? "");
+      return;
+    }
+    void runRuleNow(rule.id);
+  }, [lanes, runRuleNow]);
 
   const deleteRule = useCallback(async (ruleId: string) => {
     setError(null);
@@ -601,7 +633,7 @@ export function RulesTab({
                   onToggle={(enabled) => {
                     window.ade.automations.toggle({ id: rule.id, enabled }).then(setRules).catch((err) => setError(extractError(err)));
                   }}
-                  onRunNow={() => void runRuleNow(rule.id)}
+                  onRunNow={() => beginRunRule(rule)}
                   onDelete={() => void deleteRule(rule.id)}
                 />
               ))}
@@ -687,6 +719,56 @@ export function RulesTab({
           )}
         </div>
       </div>
+      {manualRunRule ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4">
+          <div className="w-full max-w-md rounded-xl border border-white/[0.12] bg-[#0B121A] p-4 shadow-2xl">
+            <div className="text-sm font-semibold text-[#F5FAFF]">Select lane for this run</div>
+            <div className="mt-1 text-xs leading-relaxed text-[#93A4B8]">
+              {manualRunRule.name} requires a lane when triggered.
+            </div>
+            <label className="mt-4 block space-y-1.5">
+              <span className="text-[10px] uppercase tracking-[1px] text-[#8FA1B8]">Lane</span>
+              <select
+                className={inputCls}
+                value={manualRunLaneId}
+                onChange={(event) => setManualRunLaneId(event.target.value)}
+              >
+                {lanes.map((lane) => (
+                  <option key={lane.id} value={lane.id}>
+                    {lane.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            {!lanes.length ? (
+              <div className="mt-3 rounded-md border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-200">
+                No active lanes are available for this automation run.
+              </div>
+            ) : null}
+            <div className="mt-4 flex justify-end gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setManualRunRule(null);
+                  setManualRunLaneId("");
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                variant="primary"
+                disabled={!manualRunLaneId}
+                onClick={() => void runRuleNow(manualRunRule.id, manualRunLaneId)}
+              >
+                <Play size={12} weight="regular" />
+                Run
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </motion.div>
   );
 }

--- a/apps/desktop/src/renderer/components/automations/RulesTab.tsx
+++ b/apps/desktop/src/renderer/components/automations/RulesTab.tsx
@@ -336,6 +336,7 @@ export function RulesTab({
   const [manualRunRule, setManualRunRule] = useState<AutomationRuleSummary | null>(null);
   const [manualRunLaneId, setManualRunLaneId] = useState<string>("");
   const [manualRunPending, setManualRunPending] = useState(false);
+  const manualRunPendingRef = useRef(false);
   const [configTrustRequired, setConfigTrustRequired] = useState(false);
   const loadRef = useRef<(() => Promise<void>) | null>(null);
   // Snapshot of the last-saved (or last-loaded-from-rule) draft, used to detect
@@ -515,7 +516,8 @@ export function RulesTab({
   };
 
   const runRuleNow = useCallback(async (ruleId: string, laneId?: string | null) => {
-    if (manualRunPending) return;
+    if (manualRunPendingRef.current) return;
+    manualRunPendingRef.current = true;
     setManualRunPending(true);
     setError(null);
     try {
@@ -526,9 +528,10 @@ export function RulesTab({
     } catch (err) {
       setError(extractError(err));
     } finally {
+      manualRunPendingRef.current = false;
       setManualRunPending(false);
     }
-  }, [manualRunPending, refresh]);
+  }, [refresh]);
 
   const beginRunRule = useCallback((rule: AutomationRuleSummary) => {
     if (rule.execution?.laneMode === "require-on-trigger") {

--- a/apps/desktop/src/renderer/components/automations/RulesTab.tsx
+++ b/apps/desktop/src/renderer/components/automations/RulesTab.tsx
@@ -335,6 +335,7 @@ export function RulesTab({
   const [error, setError] = useState<string | null>(null);
   const [manualRunRule, setManualRunRule] = useState<AutomationRuleSummary | null>(null);
   const [manualRunLaneId, setManualRunLaneId] = useState<string>("");
+  const [manualRunPending, setManualRunPending] = useState(false);
   const [configTrustRequired, setConfigTrustRequired] = useState(false);
   const loadRef = useRef<(() => Promise<void>) | null>(null);
   // Snapshot of the last-saved (or last-loaded-from-rule) draft, used to detect
@@ -514,16 +515,20 @@ export function RulesTab({
   };
 
   const runRuleNow = useCallback(async (ruleId: string, laneId?: string | null) => {
+    if (manualRunPending) return;
+    setManualRunPending(true);
     setError(null);
     try {
       await window.ade.automations.triggerManually({ id: ruleId, ...(laneId ? { laneId } : {}) });
-      await refresh();
       setManualRunRule(null);
       setManualRunLaneId("");
+      await refresh();
     } catch (err) {
       setError(extractError(err));
+    } finally {
+      setManualRunPending(false);
     }
-  }, [refresh]);
+  }, [manualRunPending, refresh]);
 
   const beginRunRule = useCallback((rule: AutomationRuleSummary) => {
     if (rule.execution?.laneMode === "require-on-trigger") {
@@ -759,7 +764,7 @@ export function RulesTab({
               <Button
                 size="sm"
                 variant="primary"
-                disabled={!manualRunLaneId}
+                disabled={!manualRunLaneId || manualRunPending}
                 onClick={() => void runRuleNow(manualRunRule.id, manualRunLaneId)}
               >
                 <Play size={12} weight="regular" />

--- a/apps/desktop/src/renderer/components/automations/components/RuleEditorPanel.tsx
+++ b/apps/desktop/src/renderer/components/automations/components/RuleEditorPanel.tsx
@@ -29,7 +29,11 @@ import type {
   AutomationDraftIssue,
   AutomationLaneMode,
   AutomationLaneNamePreset,
+  AutomationMode,
+  AutomationOutputDisposition,
+  AutomationReviewProfile,
   AutomationRuleDraft,
+  AutomationToolFamily,
   AutomationTrigger,
   TestSuiteDefinition,
 } from "../../../../shared/types";
@@ -124,6 +128,40 @@ const SCHEDULE_PRESETS: Array<{ label: string; cron: string }> = [
   { label: "Fridays at 4 PM", cron: "0 16 * * 5" },
 ];
 
+const REVIEW_PROFILES: Array<{ value: AutomationReviewProfile; label: string }> = [
+  { value: "quick", label: "Quick" },
+  { value: "incremental", label: "Incremental" },
+  { value: "full", label: "Full" },
+  { value: "security", label: "Security" },
+  { value: "release-risk", label: "Release risk" },
+  { value: "cross-repo-contract", label: "Cross-repo contract" },
+];
+
+const RULE_MODES: Array<{ value: AutomationMode; label: string }> = [
+  { value: "review", label: "Review" },
+  { value: "fix", label: "Fix" },
+  { value: "monitor", label: "Monitor" },
+];
+
+const TOOL_FAMILIES: Array<{ value: AutomationToolFamily; label: string }> = [
+  { value: "repo", label: "Repo" },
+  { value: "git", label: "Git" },
+  { value: "tests", label: "Tests" },
+  { value: "github", label: "GitHub" },
+  { value: "linear", label: "Linear" },
+  { value: "browser", label: "Browser" },
+  { value: "memory", label: "Memory" },
+  { value: "mission", label: "Mission" },
+];
+
+const OUTPUT_DISPOSITIONS: Array<{ value: AutomationOutputDisposition; label: string }> = [
+  { value: "comment-only", label: "Comment only" },
+  { value: "open-task", label: "Open task" },
+  { value: "open-lane", label: "Open lane" },
+  { value: "prepare-patch", label: "Prepare patch" },
+  { value: "open-pr-draft", label: "Open PR draft" },
+];
+
 const LANE_NAME_PRESETS: Array<{
   value: AutomationLaneNamePreset;
   label: string;
@@ -135,6 +173,8 @@ const LANE_NAME_PRESETS: Array<{
   { value: "pr-title-author", label: "PR title – Author", template: "{{trigger.pr.title}} – {{trigger.pr.author}}", helpEvent: "pr" },
   { value: "custom", label: "Custom template…", template: "", helpEvent: "any" },
 ];
+
+type DraftLaneMode = AutomationLaneMode | (string & {});
 
 function presetTemplate(preset: AutomationLaneNamePreset, customTemplate: string | undefined): string {
   if (preset === "custom") return customTemplate ?? "";
@@ -225,6 +265,23 @@ function triggerFamilyForType(type: AutomationTrigger["type"]): TriggerFamily {
   return "manual";
 }
 
+function readLaneMode(draft: AutomationRuleDraft): DraftLaneMode {
+  const raw = (draft.execution as { laneMode?: unknown } | undefined)?.laneMode;
+  return typeof raw === "string" && raw.trim() ? (raw.trim() as DraftLaneMode) : "reuse";
+}
+
+function isRequireLaneAtRunTimeMode(mode: DraftLaneMode | null | undefined): boolean {
+  return mode === "require-on-trigger" || mode === "provided" || mode === "prompt-at-run";
+}
+
+function humanizeLaneMode(mode: string): string {
+  return mode
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
 function defaultTriggerForFamily(family: TriggerFamily): AutomationTrigger {
   switch (family) {
     case "github":
@@ -268,6 +325,60 @@ function computeIncludeProjectContext(draft: AutomationRuleDraft): boolean {
 
 // --- draft <-> ActionRow[] bridge ---
 
+type ActionRowRuntimeOptions = Pick<ActionRowValue, "targetLaneId" | "condition" | "continueOnFailure" | "timeoutMs" | "retry">;
+type AutomationActionRuntimeOptions = Pick<AutomationAction, "targetLaneId" | "condition" | "continueOnFailure" | "timeoutMs" | "retry">;
+
+function actionRuntimeOptions(action: AutomationAction): Partial<ActionRowRuntimeOptions> {
+  return {
+    ...(action.targetLaneId ? { targetLaneId: action.targetLaneId } : {}),
+    ...(action.condition ? { condition: action.condition } : {}),
+    ...(typeof action.continueOnFailure === "boolean" ? { continueOnFailure: action.continueOnFailure } : {}),
+    ...(Number.isFinite(action.timeoutMs) ? { timeoutMs: action.timeoutMs } : {}),
+    ...(Number.isFinite(action.retry) ? { retry: action.retry } : {}),
+  };
+}
+
+function rowRuntimeOptions(row: ActionRowValue): Partial<AutomationActionRuntimeOptions> {
+  return {
+    ...(row.targetLaneId ? { targetLaneId: row.targetLaneId } : {}),
+    ...(row.condition?.trim() ? { condition: row.condition.trim() } : {}),
+    ...(row.continueOnFailure ? { continueOnFailure: true } : {}),
+    ...(Number.isFinite(row.timeoutMs) ? { timeoutMs: row.timeoutMs } : {}),
+    ...(Number.isFinite(row.retry) ? { retry: row.retry } : {}),
+  };
+}
+
+function rowHasRuntimeOptions(row: ActionRowValue): boolean {
+  return Boolean(
+    row.targetLaneId
+      || row.condition?.trim()
+      || row.continueOnFailure
+      || Number.isFinite(row.timeoutMs)
+      || Number.isFinite(row.retry),
+  );
+}
+
+function stripActionTargetLaneId<T extends { targetLaneId?: string | null }>(action: T): Omit<T, "targetLaneId"> {
+  const { targetLaneId: _targetLaneId, ...rest } = action;
+  return rest;
+}
+
+function stripActionTargetLaneIdsFromDraft(draft: AutomationRuleDraft): AutomationRuleDraft {
+  const execution = draft.execution ? { ...draft.execution } : undefined;
+  if (execution) delete execution.targetLaneId;
+  if (execution?.kind === "built-in") {
+    execution.builtIn = {
+      actions: (execution.builtIn?.actions ?? []).map((action) => stripActionTargetLaneId(action) as AutomationAction),
+    };
+  }
+  return {
+    ...draft,
+    ...(execution ? { execution } : {}),
+    actions: draft.actions.map((action) => stripActionTargetLaneId(action) as AutomationRuleDraft["actions"][number]),
+    legacyActions: draft.legacyActions?.map((action) => stripActionTargetLaneId(action) as AutomationRuleDraft["actions"][number]),
+  };
+}
+
 function draftToActionRows(draft: AutomationRuleDraft): ActionRowValue[] {
   const rows: ActionRowValue[] = [];
   const execution = draft.execution;
@@ -290,15 +401,16 @@ function draftToActionRows(draft: AutomationRuleDraft): ActionRowValue[] {
           laneNameTemplate: action.laneNameTemplate ?? "",
           laneDescriptionTemplate: action.laneDescriptionTemplate ?? "",
           parentLaneId: action.parentLaneId ?? null,
+          ...actionRuntimeOptions(action),
         });
       } else if (action.type === "run-tests") {
-        rows.push({ kind: "run-tests", suiteId: action.suiteId ?? "" });
+        rows.push({ kind: "run-tests", suiteId: action.suiteId ?? "", ...actionRuntimeOptions(action) });
       } else if (action.type === "run-command") {
-        rows.push({ kind: "run-command", command: action.command ?? "", cwd: action.cwd ?? "" });
+        rows.push({ kind: "run-command", command: action.command ?? "", cwd: action.cwd ?? "", ...actionRuntimeOptions(action) });
       } else if (action.type === "predict-conflicts") {
-        rows.push({ kind: "predict-conflicts" });
+        rows.push({ kind: "predict-conflicts", ...actionRuntimeOptions(action) });
       } else if (action.type === "ade-action") {
-        rows.push({ kind: "ade-action", adeAction: action.adeAction ?? { domain: "", action: "" } });
+        rows.push({ kind: "ade-action", adeAction: action.adeAction ?? { domain: "", action: "" }, ...actionRuntimeOptions(action) });
       } else if (action.type === "agent-session") {
         rows.push({
           kind: "agent-session",
@@ -306,9 +418,10 @@ function draftToActionRows(draft: AutomationRuleDraft): ActionRowValue[] {
           sessionTitle: action.sessionTitle ?? "",
           modelConfig: action.modelConfig,
           permissionConfig: action.permissionConfig,
+          ...actionRuntimeOptions(action),
         });
       } else if (action.type === "launch-mission") {
-        rows.push({ kind: "launch-mission", missionTitle: action.sessionTitle ?? "" });
+        rows.push({ kind: "launch-mission", missionTitle: action.sessionTitle ?? "", ...actionRuntimeOptions(action) });
       }
     }
   }
@@ -316,17 +429,20 @@ function draftToActionRows(draft: AutomationRuleDraft): ActionRowValue[] {
 }
 
 function applyActionRowsToDraft(draft: AutomationRuleDraft, rows: ActionRowValue[]): AutomationRuleDraft {
-  const soloAgent = rows.length === 1 && rows[0]!.kind === "agent-session";
-  const soloMission = rows.length === 1 && rows[0]!.kind === "launch-mission";
+  const rowsForSave = isRequireLaneAtRunTimeMode(readLaneMode(draft))
+    ? rows.map((row) => stripActionTargetLaneId(row) as ActionRowValue)
+    : rows;
+  const soloAgent = rowsForSave.length === 1 && rowsForSave[0]!.kind === "agent-session" && !rowHasRuntimeOptions(rowsForSave[0]!);
+  const soloMission = rowsForSave.length === 1 && rowsForSave[0]!.kind === "launch-mission" && !rowHasRuntimeOptions(rowsForSave[0]!);
 
   if (soloAgent) {
-    const first = rows[0]!;
+    const first = rowsForSave[0]!;
     return {
       ...draft,
       execution: {
         ...(draft.execution ?? { kind: "agent-session" }),
         kind: "agent-session",
-        session: { title: first.sessionTitle || null },
+        session: { ...(draft.execution?.kind === "agent-session" ? draft.execution.session : {}), title: first.sessionTitle || null },
       },
       ...(first.modelConfig ? { modelConfig: { orchestratorModel: first.modelConfig } } : {}),
       ...(first.permissionConfig ? { permissionConfig: first.permissionConfig } : {}),
@@ -337,20 +453,20 @@ function applyActionRowsToDraft(draft: AutomationRuleDraft, rows: ActionRowValue
   }
 
   if (soloMission) {
-    const first = rows[0]!;
+    const first = rowsForSave[0]!;
     return {
       ...draft,
       execution: {
         ...(draft.execution ?? { kind: "mission" }),
         kind: "mission",
-        mission: { title: first.missionTitle || null },
+        mission: { ...(draft.execution?.kind === "mission" ? draft.execution.mission : {}), title: first.missionTitle || null },
       },
       actions: [],
       legacyActions: [],
     };
   }
 
-  const builtInActions: AutomationAction[] = rows.map((row) => rowToAutomationAction(row));
+  const builtInActions: AutomationAction[] = rowsForSave.map((row) => rowToAutomationAction(row));
   const legacyDraftActions: AutomationRuleDraft["actions"] = builtInActions
     .map((action) => automationActionToDraftAction(action))
     .filter((entry): entry is AutomationRuleDraft["actions"][number] => entry != null);
@@ -373,28 +489,32 @@ function rowToAutomationAction(row: ActionRowValue): AutomationAction {
     case "create-lane":
       return {
         type: "create-lane",
+        ...rowRuntimeOptions(row),
         ...(row.laneNameTemplate ? { laneNameTemplate: row.laneNameTemplate } : {}),
         ...(row.laneDescriptionTemplate ? { laneDescriptionTemplate: row.laneDescriptionTemplate } : {}),
         ...(row.parentLaneId ? { parentLaneId: row.parentLaneId } : {}),
       };
     case "run-tests":
-      return { type: "run-tests", suiteId: row.suiteId ?? "" };
+      return { type: "run-tests", ...rowRuntimeOptions(row), suiteId: row.suiteId ?? "" };
     case "run-command":
       return {
         type: "run-command",
+        ...rowRuntimeOptions(row),
         command: row.command ?? "",
         ...(row.cwd ? { cwd: row.cwd } : {}),
       };
     case "predict-conflicts":
-      return { type: "predict-conflicts" };
+      return { type: "predict-conflicts", ...rowRuntimeOptions(row) };
     case "ade-action":
       return {
         type: "ade-action",
+        ...rowRuntimeOptions(row),
         adeAction: row.adeAction ?? { domain: "", action: "" },
       };
     case "agent-session":
       return {
         type: "agent-session",
+        ...rowRuntimeOptions(row),
         ...(row.modelConfig ? { modelConfig: row.modelConfig } : {}),
         ...(row.permissionConfig ? { permissionConfig: row.permissionConfig } : {}),
         ...(row.prompt ? { prompt: row.prompt } : {}),
@@ -403,6 +523,7 @@ function rowToAutomationAction(row: ActionRowValue): AutomationAction {
     case "launch-mission":
       return {
         type: "launch-mission",
+        ...rowRuntimeOptions(row),
         ...(row.missionTitle ? { sessionTitle: row.missionTitle } : {}),
       };
   }
@@ -415,28 +536,32 @@ function automationActionToDraftAction(
     case "create-lane":
       return {
         type: "create-lane",
+        ...rowRuntimeOptions(actionToRow(action)),
         ...(action.laneNameTemplate ? { laneNameTemplate: action.laneNameTemplate } : {}),
         ...(action.laneDescriptionTemplate ? { laneDescriptionTemplate: action.laneDescriptionTemplate } : {}),
         ...(action.parentLaneId ? { parentLaneId: action.parentLaneId } : {}),
       };
     case "run-tests":
-      return { type: "run-tests", suite: action.suiteId ?? "" };
+      return { type: "run-tests", ...rowRuntimeOptions(actionToRow(action)), suite: action.suiteId ?? "" };
     case "run-command":
       return {
         type: "run-command",
+        ...rowRuntimeOptions(actionToRow(action)),
         command: action.command ?? "",
         ...(action.cwd ? { cwd: action.cwd } : {}),
       };
     case "predict-conflicts":
-      return { type: "predict-conflicts" };
+      return { type: "predict-conflicts", ...rowRuntimeOptions(actionToRow(action)) };
     case "ade-action":
       return {
         type: "ade-action",
+        ...rowRuntimeOptions(actionToRow(action)),
         adeAction: action.adeAction ?? { domain: "", action: "" },
       };
     case "agent-session":
       return {
         type: "agent-session",
+        ...rowRuntimeOptions(actionToRow(action)),
         ...(action.modelConfig ? { modelConfig: action.modelConfig } : {}),
         ...(action.permissionConfig ? { permissionConfig: action.permissionConfig } : {}),
         ...(action.prompt ? { prompt: action.prompt } : {}),
@@ -445,6 +570,7 @@ function automationActionToDraftAction(
     case "launch-mission":
       return {
         type: "launch-mission",
+        ...rowRuntimeOptions(actionToRow(action)),
         ...(action.sessionTitle ? { missionTitle: action.sessionTitle } : {}),
       };
     case "lane-setup":
@@ -452,6 +578,10 @@ function automationActionToDraftAction(
       // "create"; never authored by the user, so it has no draft form.
       return null;
   }
+}
+
+function actionToRow(action: AutomationAction): ActionRowValue {
+  return { kind: action.type === "lane-setup" ? "predict-conflicts" : action.type, ...actionRuntimeOptions(action) } as ActionRowValue;
 }
 
 // --- component ---
@@ -496,6 +626,8 @@ export function RuleEditorPanel({
   const actionRows = useMemo(() => draftToActionRows(draft), [draft]);
   const includeProjectContext = computeIncludeProjectContext(draft);
   const modelValue = draft.modelConfig?.orchestratorModel ?? { modelId: DEFAULT_MODEL_ID, thinkingLevel: "medium" as const };
+  const outputs = draft.outputs ?? { disposition: "comment-only" as const, createArtifact: true };
+  const verification = draft.verification ?? { verifyBeforePublish: false, mode: "intervention" as const };
   const permissionMeta = permissionControlsForModel(modelValue.modelId);
   const currentPermission = permissionMeta
     ? draft.permissionConfig?.providers?.[permissionMeta.key] ?? ""
@@ -503,7 +635,7 @@ export function RuleEditorPanel({
 
   // laneMode resolution: missing → "reuse" (server-side migration handles
   // legacy create-lane-as-first-action collapse).
-  const laneMode: AutomationLaneMode = draft.execution?.laneMode ?? "reuse";
+  const laneMode = readLaneMode(draft);
   const lanePreset: AutomationLaneNamePreset = draft.execution?.laneNamePreset ?? "issue-title";
   const laneCustomTemplate = draft.execution?.laneNameTemplate ?? "";
   const laneTargetLaneId = draft.execution?.targetLaneId ?? null;
@@ -530,7 +662,7 @@ export function RuleEditorPanel({
 
   const patchExecution = (
     patch: Partial<{
-      laneMode: AutomationLaneMode;
+      laneMode: DraftLaneMode;
       targetLaneId: string | null;
       laneNamePreset: AutomationLaneNamePreset;
       laneNameTemplate: string;
@@ -538,14 +670,15 @@ export function RuleEditorPanel({
   ) => {
     const current = draft.execution ?? { kind: "agent-session" as const };
     const next = { ...current };
-    if (patch.laneMode !== undefined) next.laneMode = patch.laneMode;
+    if (patch.laneMode !== undefined) (next as { laneMode?: string }).laneMode = patch.laneMode;
     if (patch.laneNamePreset !== undefined) next.laneNamePreset = patch.laneNamePreset;
     if (patch.laneNameTemplate !== undefined) next.laneNameTemplate = patch.laneNameTemplate;
     if (patch.targetLaneId !== undefined) {
       if (patch.targetLaneId == null) delete next.targetLaneId;
       else next.targetLaneId = patch.targetLaneId;
     }
-    setDraft({ ...draft, execution: next });
+    const nextDraft = { ...draft, execution: next };
+    setDraft(isRequireLaneAtRunTimeMode(next.laneMode) ? stripActionTargetLaneIdsFromDraft(nextDraft) : nextDraft);
   };
 
   // Smart defaults: when the trigger event changes and the user hasn't yet
@@ -640,6 +773,20 @@ export function RuleEditorPanel({
                   checked={draft.enabled}
                   onChange={(next) => setDraft({ ...draft, enabled: next })}
                 />
+                <label className="block space-y-1.5">
+                  <SmallLabel>Mode</SmallLabel>
+                  <select
+                    className={selectCls}
+                    value={draft.mode}
+                    onChange={(event) => setDraft({ ...draft, mode: event.target.value as AutomationMode })}
+                  >
+                    {RULE_MODES.map((mode) => (
+                      <option key={mode.value} value={mode.value}>
+                        {mode.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
               </div>
             </Section>
 
@@ -767,6 +914,55 @@ export function RuleEditorPanel({
                   }}
                 />
                 <div className="space-y-1.5">
+                  <SmallLabel>Review profile</SmallLabel>
+                  <select
+                    className={selectCls}
+                    value={draft.reviewProfile}
+                    onChange={(event) =>
+                      setDraft({ ...draft, reviewProfile: event.target.value as AutomationReviewProfile })
+                    }
+                  >
+                    {REVIEW_PROFILES.map((profile) => (
+                      <option key={profile.value} value={profile.value}>
+                        {profile.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="space-y-1.5">
+                  <SmallLabel>Tool palette</SmallLabel>
+                  <div className="grid grid-cols-2 gap-1.5">
+                    {TOOL_FAMILIES.map((tool) => {
+                      const checked = draft.toolPalette.includes(tool.value);
+                      const wouldEmptyPalette = checked && draft.toolPalette.length === 1;
+                      return (
+                        <label
+                          key={tool.value}
+                          className={cn(
+                            "flex items-center gap-2 rounded-md border border-white/[0.08] bg-black/15 px-2 py-1.5 text-[11px] text-[#D8E3F2]",
+                            wouldEmptyPalette && "opacity-60",
+                          )}
+                          title={wouldEmptyPalette ? "At least one tool family is required." : undefined}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            disabled={wouldEmptyPalette}
+                            onChange={(event) => {
+                              const next = event.target.checked
+                                ? [...new Set([...draft.toolPalette, tool.value])]
+                                : draft.toolPalette.filter((entry) => entry !== tool.value);
+                              setDraft({ ...draft, toolPalette: next });
+                            }}
+                            className="accent-[#7DD3FC]"
+                          />
+                          {tool.label}
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+                <div className="space-y-1.5">
                   <SmallLabel>Model</SmallLabel>
                   <ModelSelector
                     value={modelValue}
@@ -823,6 +1019,47 @@ export function RuleEditorPanel({
                   placeholder="20"
                   icon={Clock}
                 />
+                <div className="grid gap-2 md:grid-cols-2">
+                  <label className="block space-y-1">
+                    <SmallLabel>Confidence threshold</SmallLabel>
+                    <input
+                      className={inputCls}
+                      type="number"
+                      min={0}
+                      max={1}
+                      step={0.05}
+                      value={draft.guardrails.confidenceThreshold ?? ""}
+                      onChange={(event) => {
+                        const raw = event.target.value.trim();
+                        const parsed = Number(raw);
+                        setDraft({
+                          ...draft,
+                          guardrails: {
+                            ...draft.guardrails,
+                            confidenceThreshold: raw && Number.isFinite(parsed)
+                              ? Math.max(0, Math.min(1, parsed))
+                              : undefined,
+                          },
+                        });
+                      }}
+                      placeholder="Default"
+                    />
+                  </label>
+                  <LabeledNumber
+                    label="Max findings"
+                    value={draft.guardrails.maxFindings ?? null}
+                    onChange={(n) =>
+                      setDraft({
+                        ...draft,
+                        guardrails: {
+                          ...draft.guardrails,
+                          maxFindings: n == null ? undefined : Math.max(1, Math.floor(n)),
+                        },
+                      })
+                    }
+                    placeholder="Default"
+                  />
+                </div>
                 <ActiveHoursFields
                   hours={primaryTrigger.activeHours ?? null}
                   onChange={(next) => patchTrigger({ activeHours: next ?? undefined })}
@@ -830,6 +1067,86 @@ export function RuleEditorPanel({
                 <div className="rounded-md border border-[#35506B]/40 bg-[#0F1B2A]/60 px-2.5 py-2 text-[10px] leading-relaxed text-[#9FB2C7]">
                   <CloudArrowUp size={10} weight="regular" className="mr-1 inline-block align-text-bottom" />
                   Budget caps live in <span className="text-[#D8E3F2]">Settings → Usage</span> and apply to every rule.
+                </div>
+              </div>
+            </Section>
+
+            {/* Output */}
+            <Section icon={Flag} accent="#34D399" title="Output" hint="Artifacts and publish gates">
+              <div className="space-y-3">
+                <label className="block space-y-1.5">
+                  <SmallLabel>Disposition</SmallLabel>
+                  <select
+                    className={selectCls}
+                    value={outputs.disposition}
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        outputs: { ...outputs, disposition: event.target.value as AutomationOutputDisposition },
+                      })
+                    }
+                  >
+                    {OUTPUT_DISPOSITIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <Toggle
+                  label="Create artifact"
+                  hint={outputs.createArtifact === false ? "Run stores history only" : "Run stores an artifact"}
+                  checked={outputs.createArtifact !== false}
+                  onChange={(next) => setDraft({ ...draft, outputs: { ...outputs, createArtifact: next } })}
+                />
+                <label className="block space-y-1.5">
+                  <SmallLabel>Notification channel</SmallLabel>
+                  <input
+                    className={inputCls}
+                    value={outputs.notificationChannel ?? ""}
+                    onChange={(event) =>
+                      setDraft({
+                        ...draft,
+                        outputs: {
+                          ...outputs,
+                          notificationChannel: event.target.value.trim() || null,
+                        },
+                      })
+                    }
+                    placeholder="Optional"
+                  />
+                </label>
+                <div className="grid gap-2 md:grid-cols-2">
+                  <label className="block space-y-1.5">
+                    <SmallLabel>Verification mode</SmallLabel>
+                    <select
+                      className={selectCls}
+                      value={verification.mode ?? "intervention"}
+                      onChange={(event) =>
+                        setDraft({
+                          ...draft,
+                          verification: {
+                            ...verification,
+                            mode: event.target.value as "intervention" | "dry-run",
+                          },
+                        })
+                      }
+                    >
+                      <option value="intervention">Intervention</option>
+                      <option value="dry-run">Dry run</option>
+                    </select>
+                  </label>
+                  <Toggle
+                    label="Verify before publish"
+                    hint={verification.verifyBeforePublish ? "Publish waits for review" : "Publish can complete automatically"}
+                    checked={verification.verifyBeforePublish}
+                    onChange={(next) =>
+                      setDraft({
+                        ...draft,
+                        verification: { ...verification, verifyBeforePublish: next },
+                      })
+                    }
+                  />
                 </div>
               </div>
             </Section>
@@ -850,6 +1167,7 @@ export function RuleEditorPanel({
                 lanes={lanes}
                 suites={suites}
                 fallbackModel={modelValue}
+                executionLaneMode={laneMode}
                 onChange={setActionRows}
                 onOpenAiSettings={openAiSettings}
               />
@@ -869,13 +1187,23 @@ function LaneModeControl({
   lanes,
   onChange,
 }: {
-  laneMode: AutomationLaneMode;
+  laneMode: DraftLaneMode;
   targetLaneId: string | null;
   lanes: Array<{ id: string; name: string }>;
-  onChange: (patch: { laneMode?: AutomationLaneMode; targetLaneId?: string | null }) => void;
+  onChange: (patch: { laneMode?: DraftLaneMode; targetLaneId?: string | null }) => void;
 }) {
-  // Compose a single value: "create", "reuse:" (primary), or "reuse:<laneId>".
-  const selectValue = laneMode === "create" ? "create" : `reuse:${targetLaneId ?? ""}`;
+  const knownMode = laneMode === "create"
+    || laneMode === "reuse"
+    || laneMode === "provided"
+    || laneMode === "prompt-at-run"
+    || laneMode === "require-on-trigger";
+  const selectValue = laneMode === "create"
+    ? "create"
+    : laneMode === "provided" || laneMode === "prompt-at-run" || laneMode === "require-on-trigger"
+      ? "require-on-trigger"
+      : laneMode === "reuse"
+        ? `reuse:${targetLaneId ?? ""}`
+        : `unknown:${laneMode}`;
   const sortedLanes = useMemo(() => [...lanes].sort((a, b) => a.name.localeCompare(b.name)), [lanes]);
 
   return (
@@ -890,6 +1218,10 @@ function LaneModeControl({
             onChange({ laneMode: "create", targetLaneId: null });
             return;
           }
+          if (v === "require-on-trigger") {
+            onChange({ laneMode: "require-on-trigger", targetLaneId: null });
+            return;
+          }
           if (v === "reuse:") {
             onChange({ laneMode: "reuse", targetLaneId: null });
             return;
@@ -900,11 +1232,17 @@ function LaneModeControl({
         }}
       >
         <option value="create">Create new lane per run</option>
+        <option value="require-on-trigger">Require lane at run time</option>
         <option value="__sep__" disabled>──────</option>
         <option value="reuse:">Reuse primary lane</option>
         {sortedLanes.map((lane) => (
           <option key={lane.id} value={`reuse:${lane.id}`}>{lane.name}</option>
         ))}
+        {!knownMode ? (
+          <option value={`unknown:${laneMode}`} disabled>
+            Backend mode: {humanizeLaneMode(laneMode)}
+          </option>
+        ) : null}
       </select>
     </label>
   );
@@ -1366,4 +1704,3 @@ function ActiveHoursFields({
     </div>
   );
 }
-

--- a/apps/desktop/src/renderer/components/automations/components/RuleEditorPanel.tsx
+++ b/apps/desktop/src/renderer/components/automations/components/RuleEditorPanel.tsx
@@ -628,6 +628,7 @@ export function RuleEditorPanel({
   const modelValue = draft.modelConfig?.orchestratorModel ?? { modelId: DEFAULT_MODEL_ID, thinkingLevel: "medium" as const };
   const outputs = draft.outputs ?? { disposition: "comment-only" as const, createArtifact: true };
   const verification = draft.verification ?? { verifyBeforePublish: false, mode: "intervention" as const };
+  const toolPalette: AutomationToolFamily[] = draft.toolPalette ?? ["repo", "memory", "mission"];
   const permissionMeta = permissionControlsForModel(modelValue.modelId);
   const currentPermission = permissionMeta
     ? draft.permissionConfig?.providers?.[permissionMeta.key] ?? ""
@@ -933,8 +934,8 @@ export function RuleEditorPanel({
                   <SmallLabel>Tool palette</SmallLabel>
                   <div className="grid grid-cols-2 gap-1.5">
                     {TOOL_FAMILIES.map((tool) => {
-                      const checked = draft.toolPalette.includes(tool.value);
-                      const wouldEmptyPalette = checked && draft.toolPalette.length === 1;
+                      const checked = toolPalette.includes(tool.value);
+                      const wouldEmptyPalette = checked && toolPalette.length === 1;
                       return (
                         <label
                           key={tool.value}
@@ -950,8 +951,8 @@ export function RuleEditorPanel({
                             disabled={wouldEmptyPalette}
                             onChange={(event) => {
                               const next = event.target.checked
-                                ? [...new Set([...draft.toolPalette, tool.value])]
-                                : draft.toolPalette.filter((entry) => entry !== tool.value);
+                                ? [...new Set([...toolPalette, tool.value])]
+                                : toolPalette.filter((entry) => entry !== tool.value);
                               setDraft({ ...draft, toolPalette: next });
                             }}
                             className="accent-[#7DD3FC]"

--- a/apps/desktop/src/renderer/components/automations/shared.ts
+++ b/apps/desktop/src/renderer/components/automations/shared.ts
@@ -16,3 +16,8 @@ export const CARD_STYLE: React.CSSProperties = {};
 export function extractError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
+
+/** Parse a comma-separated input into a trimmed, non-empty string list. */
+export function parseList(value: string): string[] {
+  return value.split(",").map((entry) => entry.trim()).filter(Boolean);
+}

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -626,6 +626,7 @@ export function AgentChatComposer({
   hideNativeControls = false,
   messagePlaceholder,
   onModelChange,
+  onModelCatalogOpen,
   onReasoningEffortChange,
   onCodexFastModeChange,
   onDraftChange,
@@ -735,6 +736,7 @@ export function AgentChatComposer({
   hideNativeControls?: boolean;
   messagePlaceholder?: string;
   onModelChange: (modelId: string) => void;
+  onModelCatalogOpen?: () => void;
   onReasoningEffortChange: (reasoningEffort: string | null) => void;
   onCodexFastModeChange?: (enabled: boolean) => void;
   onDraftChange: (value: string) => void;
@@ -2870,6 +2872,7 @@ export function AgentChatComposer({
               <ProviderModelSelector
                 value={parallelModelSlots[parallelConfiguringIndex]!.modelId}
                 onChange={(next) => onParallelSlotModelChange?.(parallelConfiguringIndex, next)}
+                onOpen={onModelCatalogOpen}
                 availableModelIds={availableModelIds}
                 disabled={parallelLaunchBusy}
                 showReasoning
@@ -2890,6 +2893,7 @@ export function AgentChatComposer({
               <ProviderModelSelector
                 value={modelId}
                 onChange={onModelChange}
+                onOpen={onModelCatalogOpen}
                 availableModelIds={availableModelIds}
                 disabled={modelSelectionLocked}
                 showReasoning

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.submit.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.submit.test.tsx
@@ -1060,12 +1060,11 @@ describe("AgentChatPane submit recovery", () => {
     });
   });
 
-  it("does not block chat boot on Cursor model inventory after AI status resolves", async () => {
+  it("does not auto-fetch Cursor inventory on chat boot", async () => {
     let resolveProjectConfig: (value: unknown) => void = () => {};
     const projectConfig = new Promise((resolve) => {
       resolveProjectConfig = resolve;
     });
-    const cursorModels = new Promise(() => {});
     installAdeMocks({
       sessions: [],
     });
@@ -1092,10 +1091,7 @@ describe("AgentChatPane submit recovery", () => {
       ],
       availableModelIds: [],
     }) as any;
-    window.ade.agentChat.models = vi.fn().mockImplementation(({ provider }: { provider: string }) => {
-      if (provider === "cursor") return cursorModels;
-      return Promise.resolve([]);
-    }) as any;
+    window.ade.agentChat.models = vi.fn().mockResolvedValue([]) as any;
 
     render(
       <MemoryRouter>
@@ -1121,10 +1117,10 @@ describe("AgentChatPane submit recovery", () => {
       expect(screen.queryByText("Loading sessions")).toBeNull();
     });
     expect(await screen.findByText("Start a new conversation")).toBeTruthy();
-    expect(window.ade.agentChat.models).toHaveBeenCalledWith({
-      provider: "cursor",
-      activateRuntime: true,
-    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(window.ade.agentChat.models).not.toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "cursor" }),
+    );
   });
 
   it("uses Cursor model IDs from AI status without probing Cursor inventory", async () => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.submit.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.submit.test.tsx
@@ -1060,6 +1060,73 @@ describe("AgentChatPane submit recovery", () => {
     });
   });
 
+  it("does not block chat boot on Cursor model inventory after AI status resolves", async () => {
+    let resolveProjectConfig: (value: unknown) => void = () => {};
+    const projectConfig = new Promise((resolve) => {
+      resolveProjectConfig = resolve;
+    });
+    const cursorModels = new Promise(() => {});
+    installAdeMocks({
+      sessions: [],
+    });
+    useAppStore.setState({
+      project: { rootPath: "/tmp/project-under-test" } as any,
+      lanes: [{
+        id: "lane-1",
+        name: "Lane 1",
+        laneType: "worktree",
+        branchRef: "refs/heads/lane-1",
+        worktreePath: "/tmp/project-under-test/lane-1",
+      } as any],
+      selectedLaneId: "lane-1",
+    });
+    window.ade.projectConfig.get = vi.fn().mockReturnValue(projectConfig) as any;
+    window.ade.ai.getStatus = vi.fn().mockResolvedValue({
+      mode: "subscription",
+      availableProviders: { claude: false, codex: true, cursor: true, droid: false },
+      models: { claude: [], codex: [], cursor: [], droid: [] },
+      features: [],
+      detectedAuth: [
+        { type: "cli-subscription", cli: "codex", authenticated: true },
+        { type: "api-key", provider: "cursor" },
+      ],
+      availableModelIds: ["cursor/auto"],
+    }) as any;
+    window.ade.agentChat.models = vi.fn().mockImplementation(({ provider }: { provider: string }) => {
+      if (provider === "cursor") return cursorModels;
+      return Promise.resolve([]);
+    }) as any;
+
+    render(
+      <MemoryRouter>
+        <AgentChatPane laneId="lane-1" />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Loading sessions")).toBeTruthy();
+
+    await act(async () => {
+      resolveProjectConfig({
+        effective: {
+          ai: {
+            chat: {
+              sendOnEnter: true,
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Loading sessions")).toBeNull();
+    });
+    expect(await screen.findByText("Start a new conversation")).toBeTruthy();
+    expect(window.ade.agentChat.models).toHaveBeenCalledWith({
+      provider: "cursor",
+      activateRuntime: true,
+    });
+  });
+
   it("keeps the committed model visible until the backend confirms the switch", async () => {
     const session = buildSession("session-1", { status: "idle" });
     const sessions = [session];

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.submit.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.submit.test.tsx
@@ -1090,7 +1090,7 @@ describe("AgentChatPane submit recovery", () => {
         { type: "cli-subscription", cli: "codex", authenticated: true },
         { type: "api-key", provider: "cursor" },
       ],
-      availableModelIds: ["cursor/auto"],
+      availableModelIds: [],
     }) as any;
     window.ade.agentChat.models = vi.fn().mockImplementation(({ provider }: { provider: string }) => {
       if (provider === "cursor") return cursorModels;
@@ -1125,6 +1125,48 @@ describe("AgentChatPane submit recovery", () => {
       provider: "cursor",
       activateRuntime: true,
     });
+  });
+
+  it("uses Cursor model IDs from AI status without probing Cursor inventory", async () => {
+    installAdeMocks({
+      sessions: [],
+    });
+    useAppStore.setState({
+      project: { rootPath: "/tmp/project-under-test" } as any,
+      lanes: [{
+        id: "lane-1",
+        name: "Lane 1",
+        laneType: "worktree",
+        branchRef: "refs/heads/lane-1",
+        worktreePath: "/tmp/project-under-test/lane-1",
+      } as any],
+      selectedLaneId: "lane-1",
+    });
+    window.ade.ai.getStatus = vi.fn().mockResolvedValue({
+      mode: "subscription",
+      availableProviders: { claude: false, codex: true, cursor: true, droid: false },
+      models: { claude: [], codex: [], cursor: [], droid: [] },
+      features: [],
+      detectedAuth: [
+        { type: "cli-subscription", cli: "codex", authenticated: true },
+        { type: "api-key", provider: "cursor" },
+      ],
+      availableModelIds: ["cursor/auto"],
+    }) as any;
+    window.ade.agentChat.models = vi.fn().mockResolvedValue([]) as any;
+
+    render(
+      <MemoryRouter>
+        <AgentChatPane laneId="lane-1" />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Start a new conversation")).toBeTruthy();
+    await waitFor(() => {
+      expect(window.ade.ai.getStatus).toHaveBeenCalled();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(window.ade.agentChat.models).not.toHaveBeenCalled();
   });
 
   it("keeps the committed model visible until the backend confirms the switch", async () => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -2739,7 +2739,8 @@ export function AgentChatPane({
       setAvailableModelIds(orderedAvailable);
       const cursorReady = status.availableProviders?.cursor === true
         || status.providerConnections?.cursor?.runtimeAvailable === true;
-      if (!cursorReady) return orderedAvailable;
+      const hasCursorModelIds = orderedAvailable.some(isCursorModelId);
+      if (!cursorReady || hasCursorModelIds) return orderedAvailable;
 
       void getAgentChatModelsCached({
         projectRoot,

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -1505,6 +1505,25 @@ function chatSessionTitle(session: AgentChatSessionSummary): string {
   return descriptor?.displayName ?? `${session.provider}/${session.model}`;
 }
 
+function orderAvailableModelIds(ids: Iterable<string>): string[] {
+  const available = new Set(ids);
+  const ordered = MODEL_REGISTRY
+    .filter((model) => !model.deprecated && available.has(model.id))
+    .map((model) => model.id);
+  const extra = [...available].filter((modelId) => !ordered.includes(modelId));
+  extra.sort((left, right) => {
+    const leftLabel = getModelById(left)?.displayName ?? left;
+    const rightLabel = getModelById(right)?.displayName ?? right;
+    return leftLabel.localeCompare(rightLabel, undefined, { sensitivity: "base" });
+  });
+  return [...ordered, ...extra];
+}
+
+function isCursorModelId(id: string): boolean {
+  return id.startsWith("cursor/")
+    || getModelById(id)?.family === "cursor";
+}
+
 function completionBadgeClass(status: NonNullable<AgentChatSessionSummary["completion"]>["status"]): string {
   switch (status) {
     case "completed": return "border-emerald-400/20 bg-emerald-400/[0.08] text-emerald-300";
@@ -2694,25 +2713,7 @@ export function AgentChatPane({
   });
 
   const refreshAvailableModels = useCallback(async () => {
-    const refreshSeq = ++availableModelsRefreshSeqRef.current;
-    const orderModelIds = (ids: Iterable<string>): string[] => {
-      const available = new Set(ids);
-      const ordered = MODEL_REGISTRY
-        .filter((model) => !model.deprecated && available.has(model.id))
-        .map((model) => model.id);
-      const extra = [...available].filter((modelId) => !ordered.includes(modelId));
-      extra.sort((left, right) => {
-        const leftLabel = getModelById(left)?.displayName ?? left;
-        const rightLabel = getModelById(right)?.displayName ?? right;
-        return leftLabel.localeCompare(rightLabel, undefined, { sensitivity: "base" });
-      });
-      return [...ordered, ...extra];
-    };
-    const isCursorModelId = (id: string): boolean => (
-      id.startsWith("cursor/")
-      || getModelById(id)?.family === "cursor"
-    );
-
+    ++availableModelsRefreshSeqRef.current;
     const selectedModelProvider = modelId.trim()
       ? resolveChatRuntimeProvider(getModelById(modelId))
       : null;
@@ -2735,34 +2736,8 @@ export function AgentChatPane({
         droid: status.providerConnections?.droid ?? null,
       });
       const available = deriveConfiguredModelIds(status, { includeDroid: true });
-      const orderedAvailable = orderModelIds(available);
+      const orderedAvailable = orderAvailableModelIds(available);
       setAvailableModelIds(orderedAvailable);
-      const cursorReady = status.availableProviders?.cursor === true
-        || status.providerConnections?.cursor?.runtimeAvailable === true;
-      const hasCursorModelIds = orderedAvailable.some(isCursorModelId);
-      if (!cursorReady || hasCursorModelIds) return orderedAvailable;
-
-      void getAgentChatModelsCached({
-        projectRoot,
-        provider: "cursor",
-        activateRuntime: true,
-      }).then((cursorModels) => {
-        if (availableModelsRefreshSeqRef.current !== refreshSeq) return;
-        if (!cursorModels.length) {
-          const withoutCursor = orderedAvailable.filter((id) => !isCursorModelId(id));
-          setAvailableModelIds(withoutCursor);
-          return;
-        }
-
-        const merged = new Set<string>(available);
-        for (const model of cursorModels) {
-          const resolved = resolveCliRegistryModelId("cursor", model.id);
-          if (resolved) merged.add(resolved);
-        }
-        const withCursor = orderModelIds(merged);
-        setAvailableModelIds(withCursor);
-      }).catch(() => undefined);
-
       return orderedAvailable;
     } catch {
       setAiStatus(null);
@@ -2809,7 +2784,7 @@ export function AgentChatPane({
         }
       }
 
-      const allAvailable = orderModelIds(available);
+      const allAvailable = orderAvailableModelIds(available);
       setAvailableModelIds(allAvailable);
       return allAvailable;
     } catch {
@@ -2817,6 +2792,38 @@ export function AgentChatPane({
       return [];
     }
   }, [modelId, projectRoot, selectedSession?.provider, sessionProvider]);
+
+  const refreshCursorModelInventory = useCallback(async () => {
+    const status = aiStatus;
+    const cursorReady = status?.availableProviders?.cursor === true
+      || status?.providerConnections?.cursor?.runtimeAvailable === true;
+    if (!cursorReady) return;
+    if (availableModelIds.some(isCursorModelId)) return;
+    const refreshSeq = availableModelsRefreshSeqRef.current;
+    let cursorModels: Awaited<ReturnType<typeof getAgentChatModelsCached>>;
+    try {
+      cursorModels = await getAgentChatModelsCached({
+        projectRoot,
+        provider: "cursor",
+        activateRuntime: true,
+      });
+    } catch {
+      return;
+    }
+    if (availableModelsRefreshSeqRef.current !== refreshSeq) return;
+    if (!cursorModels.length) {
+      setAvailableModelIds((prev) => prev.filter((id) => !isCursorModelId(id)));
+      return;
+    }
+    setAvailableModelIds((prev) => {
+      const merged = new Set<string>(prev);
+      for (const model of cursorModels) {
+        const resolved = resolveCliRegistryModelId("cursor", model.id);
+        if (resolved) merged.add(resolved);
+      }
+      return orderAvailableModelIds(merged);
+    });
+  }, [aiStatus, availableModelIds, projectRoot]);
 
   const touchSession = useCallback((sessionId: string | null | undefined, touchedAt = new Date().toISOString()) => {
     if (!sessionId) return;
@@ -5271,6 +5278,7 @@ export function AgentChatPane({
                     <ProviderModelSelector
                       value={handoffModelId}
                       onChange={setHandoffModelId}
+                      onOpen={refreshCursorModelInventory}
                       availableModelIds={handoffAvailableModelIds}
                       showReasoning
                       reasoningEffort={handoffReasoningEffort}
@@ -5595,6 +5603,7 @@ export function AgentChatPane({
             hideNativeControls={hideNativeControls}
             messagePlaceholder={messagePlaceholder}
             onExecutionModeChange={setExecutionMode}
+            onModelCatalogOpen={refreshCursorModelInventory}
             onInteractionModeChange={(value) => { void updateNativeControls({ interactionMode: value }); }}
             onClaudeModeChange={handleClaudeModeChange}
             onClaudePermissionModeChange={(value) => { void updateNativeControls({ claudePermissionMode: value }); }}

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -2795,9 +2795,11 @@ export function AgentChatPane({
 
   const refreshCursorModelInventory = useCallback(async () => {
     const status = aiStatus;
-    const cursorReady = status?.availableProviders?.cursor === true
-      || status?.providerConnections?.cursor?.runtimeAvailable === true;
-    if (!cursorReady) return;
+    const cursorExplicitlyUnavailable =
+      status != null
+      && status.availableProviders?.cursor !== true
+      && status.providerConnections?.cursor?.runtimeAvailable !== true;
+    if (cursorExplicitlyUnavailable) return;
     if (availableModelIds.some(isCursorModelId)) return;
     const refreshSeq = availableModelsRefreshSeqRef.current;
     let cursorModels: Awaited<ReturnType<typeof getAgentChatModelsCached>>;

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -1710,6 +1710,7 @@ export function AgentChatPane({
   );
   const availableModelIdsRef = useRef(availableModelIds);
   const availableModelsRefreshSeqRef = useRef(0);
+  const cursorInventoryRefreshSeqRef = useRef(0);
   useEffect(() => {
     availableModelIdsRef.current = availableModelIds;
   }, [availableModelIds]);
@@ -2798,6 +2799,7 @@ export function AgentChatPane({
   }, [modelId, projectRoot, selectedSession?.provider, sessionProvider]);
 
   const refreshCursorModelInventory = useCallback(async () => {
+    const cursorRefreshSeq = ++cursorInventoryRefreshSeqRef.current;
     const status = aiStatus;
     const cursorExplicitlyUnavailable =
       status != null
@@ -2816,7 +2818,12 @@ export function AgentChatPane({
     } catch {
       return;
     }
-    if (availableModelsRefreshSeqRef.current !== refreshSeq) return;
+    if (
+      availableModelsRefreshSeqRef.current !== refreshSeq
+      || cursorInventoryRefreshSeqRef.current !== cursorRefreshSeq
+    ) {
+      return;
+    }
     if (!cursorModels.length) {
       setAvailableModelIds((prev) => prev.filter((id) => !isCursorModelId(id)));
       return;

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -1708,7 +1708,11 @@ export function AgentChatPane({
   const [availableModelIds, setAvailableModelIds] = useState<string[]>(() =>
     seedAiStatus ? deriveConfiguredModelIds(seedAiStatus, { includeDroid: true }) : [],
   );
+  const availableModelIdsRef = useRef(availableModelIds);
   const availableModelsRefreshSeqRef = useRef(0);
+  useEffect(() => {
+    availableModelIdsRef.current = availableModelIds;
+  }, [availableModelIds]);
   const [claudePermissionMode, setClaudePermissionMode] = useState<AgentChatClaudePermissionMode>(initialNativeControls.claudePermissionMode);
   const [codexApprovalPolicy, setCodexApprovalPolicy] = useState<AgentChatCodexApprovalPolicy>(initialNativeControls.codexApprovalPolicy);
   const [codexSandbox, setCodexSandbox] = useState<AgentChatCodexSandbox>(initialNativeControls.codexSandbox);
@@ -2800,7 +2804,7 @@ export function AgentChatPane({
       && status.availableProviders?.cursor !== true
       && status.providerConnections?.cursor?.runtimeAvailable !== true;
     if (cursorExplicitlyUnavailable) return;
-    if (availableModelIds.some(isCursorModelId)) return;
+    if (availableModelIdsRef.current.some(isCursorModelId)) return;
     const refreshSeq = availableModelsRefreshSeqRef.current;
     let cursorModels: Awaited<ReturnType<typeof getAgentChatModelsCached>>;
     try {
@@ -2825,7 +2829,7 @@ export function AgentChatPane({
       }
       return orderAvailableModelIds(merged);
     });
-  }, [aiStatus, availableModelIds, projectRoot]);
+  }, [aiStatus, projectRoot]);
 
   const touchSession = useCallback((sessionId: string | null | undefined, touchedAt = new Date().toISOString()) => {
     if (!sessionId) return;

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -1689,6 +1689,7 @@ export function AgentChatPane({
   const [availableModelIds, setAvailableModelIds] = useState<string[]>(() =>
     seedAiStatus ? deriveConfiguredModelIds(seedAiStatus, { includeDroid: true }) : [],
   );
+  const availableModelsRefreshSeqRef = useRef(0);
   const [claudePermissionMode, setClaudePermissionMode] = useState<AgentChatClaudePermissionMode>(initialNativeControls.claudePermissionMode);
   const [codexApprovalPolicy, setCodexApprovalPolicy] = useState<AgentChatCodexApprovalPolicy>(initialNativeControls.codexApprovalPolicy);
   const [codexSandbox, setCodexSandbox] = useState<AgentChatCodexSandbox>(initialNativeControls.codexSandbox);
@@ -2693,6 +2694,7 @@ export function AgentChatPane({
   });
 
   const refreshAvailableModels = useCallback(async () => {
+    const refreshSeq = ++availableModelsRefreshSeqRef.current;
     const orderModelIds = (ids: Iterable<string>): string[] => {
       const available = new Set(ids);
       const ordered = MODEL_REGISTRY
@@ -2739,30 +2741,28 @@ export function AgentChatPane({
         || status.providerConnections?.cursor?.runtimeAvailable === true;
       if (!cursorReady) return orderedAvailable;
 
-      let cursorModels: Awaited<ReturnType<typeof getAgentChatModelsCached>>;
-      try {
-        cursorModels = await getAgentChatModelsCached({
-          projectRoot,
-          provider: "cursor",
-          activateRuntime: true,
-        });
-      } catch {
-        return orderedAvailable;
-      }
-      if (!cursorModels.length) {
-        const withoutCursor = orderedAvailable.filter((id) => !isCursorModelId(id));
-        setAvailableModelIds(withoutCursor);
-        return withoutCursor;
-      }
+      void getAgentChatModelsCached({
+        projectRoot,
+        provider: "cursor",
+        activateRuntime: true,
+      }).then((cursorModels) => {
+        if (availableModelsRefreshSeqRef.current !== refreshSeq) return;
+        if (!cursorModels.length) {
+          const withoutCursor = orderedAvailable.filter((id) => !isCursorModelId(id));
+          setAvailableModelIds(withoutCursor);
+          return;
+        }
 
-      const merged = new Set<string>(available);
-      for (const model of cursorModels) {
-        const resolved = resolveCliRegistryModelId("cursor", model.id);
-        if (resolved) merged.add(resolved);
-      }
-      const withCursor = orderModelIds(merged);
-      setAvailableModelIds(withCursor);
-      return withCursor;
+        const merged = new Set<string>(available);
+        for (const model of cursorModels) {
+          const resolved = resolveCliRegistryModelId("cursor", model.id);
+          if (resolved) merged.add(resolved);
+        }
+        const withCursor = orderModelIds(merged);
+        setAvailableModelIds(withCursor);
+      }).catch(() => undefined);
+
+      return orderedAvailable;
     } catch {
       setAiStatus(null);
       setProviderConnections(null);

--- a/apps/desktop/src/renderer/components/graph/WorkspaceGraphPage.tsx
+++ b/apps/desktop/src/renderer/components/graph/WorkspaceGraphPage.tsx
@@ -259,6 +259,7 @@ function GraphInner() {
   const [viewMode, setViewMode] = React.useState<GraphViewMode>("all");
   const [sessionState, setSessionState] = React.useState(createSessionState);
   const [loadedGraphPreferences, setLoadedGraphPreferences] = React.useState(false);
+  const skipNextGraphPreferencePersistRootRef = React.useRef<string | null>(null);
   const [nodes, setNodes] = React.useState<Array<Node<GraphNodeData>>>([]);
   const [edges, setEdges] = React.useState<Array<Edge<GraphEdgeData>>>([]);
 
@@ -871,14 +872,20 @@ function GraphInner() {
   }, [refreshIntegrationProposals, reportGraphIssue]);
 
   React.useEffect(() => {
-    if (!project?.rootPath) return;
+    if (!project?.rootPath) {
+      setLoadedGraphPreferences(false);
+      skipNextGraphPreferencePersistRootRef.current = null;
+      return;
+    }
     const rootPath = project.rootPath;
     let cancelled = false;
+    setLoadedGraphPreferences(false);
     void window.ade.graphState
       .get(rootPath)
       .then((state) => {
         if (cancelled) return;
         const normalized = normalizeGraphPreferences(state);
+        skipNextGraphPreferencePersistRootRef.current = rootPath;
         setViewMode(normalized.preferences.lastViewMode);
         if (normalized.migrated) {
           void window.ade.graphState.set(rootPath, normalized.preferences).catch(() => {});
@@ -887,6 +894,7 @@ function GraphInner() {
       .catch((err) => {
         console.warn("[Graph] Failed to load graph state:", err);
         if (cancelled) return;
+        skipNextGraphPreferencePersistRootRef.current = rootPath;
         setViewMode(createGraphPreferences().lastViewMode);
       })
       .finally(() => {
@@ -899,6 +907,10 @@ function GraphInner() {
 
   React.useEffect(() => {
     if (!project?.rootPath || !loadedGraphPreferences) return;
+    if (skipNextGraphPreferencePersistRootRef.current === project.rootPath) {
+      skipNextGraphPreferencePersistRootRef.current = null;
+      return;
+    }
     void window.ade.graphState.set(project.rootPath, createGraphPreferences(viewMode)).catch(() => {});
   }, [loadedGraphPreferences, project?.rootPath, viewMode]);
 

--- a/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.test.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.test.tsx
@@ -226,6 +226,7 @@ describe("LaneGitActionsPane rescue action", () => {
     expect(window.ade.diff.getChanges).toHaveBeenCalledWith({ laneId: "lane-1" });
     expect(window.ade.git.getSyncStatus).toHaveBeenCalledWith({ laneId: "lane-1" });
     expect(window.ade.git.getSyncStatus).toHaveBeenCalledTimes(1);
+    expect(window.ade.lanes.listAutoRebaseStatuses).not.toHaveBeenCalled();
   });
 
   it("blocks pull and surfaces merge recovery actions when a merge is in progress", async () => {
@@ -399,7 +400,10 @@ describe("LaneGitActionsPane rescue action", () => {
       },
     ];
 
-    renderPane({ onResolveRebaseConflict: resolveRebaseConflict });
+    renderPane({
+      autoRebaseStatusSnapshot: mockAutoRebaseStatuses[0] ?? null,
+      onResolveRebaseConflict: resolveRebaseConflict,
+    });
 
     const rebaseTabButton = await screen.findByRole("button", { name: /open rebase\/merge tab/i });
     screen.getByText("AUTO-REBASE FAILED");

--- a/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx
@@ -452,6 +452,7 @@ function ActionButton({
 export function LaneGitActionsPane({
   laneId,
   autoRebaseEnabled,
+  autoRebaseStatusSnapshot,
   onOpenSettings,
   onRebaseNowLocal,
   onRebaseAndPush,
@@ -467,6 +468,7 @@ export function LaneGitActionsPane({
 }: {
   laneId: string | null;
   autoRebaseEnabled: boolean;
+  autoRebaseStatusSnapshot?: AutoRebaseLaneStatus | null;
   onOpenSettings: () => void;
   onRebaseNowLocal?: (laneId: string) => Promise<void> | void;
   onRebaseAndPush?: (laneId: string) => Promise<void> | void;
@@ -517,7 +519,8 @@ export function LaneGitActionsPane({
   const [commitTimelineKey, setCommitTimelineKey] = useState(0);
   const [amendCommit, setAmendCommit] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
-  const [autoRebaseStatus, setAutoRebaseStatus] = useState<AutoRebaseLaneStatus | null>(null);
+  const [autoRebaseStatus, setAutoRebaseStatus] = useState<AutoRebaseLaneStatus | null>(autoRebaseStatusSnapshot ?? null);
+  const autoRebaseStatusSnapshotRef = useRef<AutoRebaseLaneStatus | null | undefined>(autoRebaseStatusSnapshot);
   const [conflictState, setConflictState] = useState<GitConflictState | null>(null);
   const [stuckRebase, setStuckRebase] = useState<GitConflictState | null>(null);
   const laneGitActionRuntime = useLaneGitActionRuntimeState(laneId);
@@ -709,6 +712,13 @@ export function LaneGitActionsPane({
     }
   }, [projectRoot]);
 
+  useEffect(() => {
+    autoRebaseStatusSnapshotRef.current = autoRebaseStatusSnapshot;
+    if (autoRebaseStatusSnapshot !== undefined) {
+      setAutoRebaseStatus(autoRebaseStatusSnapshot);
+    }
+  }, [autoRebaseStatusSnapshot]);
+
   const isNonFastForwardError = useCallback((rawMessage: string): boolean => {
     const lower = rawMessage.toLowerCase();
     return lower.includes("non-fast-forward") || lower.includes("failed to push some refs");
@@ -838,7 +848,7 @@ export function LaneGitActionsPane({
     setForcePushSuggested(false);
     setAmendCommit(false);
     setCommitMessageAi({ enabled: false, modelId: null });
-    setAutoRebaseStatus(null);
+    setAutoRebaseStatus(autoRebaseStatusSnapshotRef.current ?? null);
     setConflictState(null);
     setStuckRebase(null);
     if (!laneId) return;
@@ -848,9 +858,20 @@ export function LaneGitActionsPane({
         error: err instanceof Error ? err.message : String(err),
       });
     });
-    void refreshAutoRebaseStatus(laneId);
     void refreshCommitMessageAiState();
-  }, [laneId, lane?.branchRef, refreshAutoRebaseStatus, refreshCommitMessageAiState]);
+  }, [laneId, lane?.branchRef, refreshCommitMessageAiState]);
+
+  useEffect(() => {
+    if (!laneId) return;
+    if (autoRebaseStatusSnapshotRef.current !== undefined) return;
+    const targetLaneId = laneId;
+    const timer = window.setTimeout(() => {
+      if (document.visibilityState !== "visible") return;
+      if (autoRebaseStatusSnapshotRef.current !== undefined) return;
+      void refreshAutoRebaseStatus(targetLaneId);
+    }, 3_500);
+    return () => window.clearTimeout(timer);
+  }, [laneId, lane?.branchRef, refreshAutoRebaseStatus]);
 
   useEffect(() => {
     if (!laneId) return;

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -2147,6 +2147,7 @@ export function LanesPage() {
 
   const getPaneConfigs = useCallback((laneId: string | null) => {
     const laneDetail = laneId ? lanePaneDetails[laneId] ?? EMPTY_LANE_PANE_DETAIL : EMPTY_LANE_PANE_DETAIL;
+    const laneSnapshot = laneId ? laneSnapshotByLaneId.get(laneId) ?? null : null;
     return {
       "git-actions": {
         title: "Git Actions",
@@ -2180,6 +2181,7 @@ export function LanesPage() {
             <LaneGitActionsPane
               laneId={laneId}
               autoRebaseEnabled={autoRebaseEnabled}
+              autoRebaseStatusSnapshot={laneSnapshot?.autoRebaseStatus ?? null}
               onOpenSettings={openAutoRebaseSettings}
               onRebaseNowLocal={(targetLaneId) => runRebaseFlow(targetLaneId, "local_only")}
               onRebaseAndPush={(targetLaneId) => runRebaseFlow(targetLaneId, "local_and_remote")}
@@ -2211,6 +2213,7 @@ export function LanesPage() {
     };
   }, [
     lanePaneDetails,
+    laneSnapshotByLaneId,
     expandedGitActionsLaneId,
     autoRebaseEnabled,
     openAutoRebaseSettings,

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -2181,7 +2181,7 @@ export function LanesPage() {
             <LaneGitActionsPane
               laneId={laneId}
               autoRebaseEnabled={autoRebaseEnabled}
-              autoRebaseStatusSnapshot={laneSnapshot?.autoRebaseStatus ?? null}
+              autoRebaseStatusSnapshot={laneSnapshot?.autoRebaseStatus}
               onOpenSettings={openAutoRebaseSettings}
               onRebaseNowLocal={(targetLaneId) => runRebaseFlow(targetLaneId, "local_only")}
               onRebaseAndPush={(targetLaneId) => runRebaseFlow(targetLaneId, "local_and_remote")}

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
@@ -50,6 +50,8 @@ function TabSwitchHarness() {
 
 describe("PrsContext refresh", () => {
   beforeEach(() => {
+    window.history.replaceState(null, "", "/");
+    window.location.hash = "";
     const refreshedNeed: RebaseNeed = {
       laneId: "lane-1",
       laneName: "Lane 1",
@@ -82,19 +84,11 @@ describe("PrsContext refresh", () => {
       },
       lanes: {
         list: vi.fn().mockResolvedValue([]),
-        listAutoRebaseStatuses: vi
-          .fn()
-          .mockResolvedValueOnce([])
-          .mockResolvedValueOnce([])
-          .mockResolvedValue([refreshedAutoStatus]),
+        listAutoRebaseStatuses: vi.fn().mockResolvedValue([refreshedAutoStatus]),
         onAutoRebaseEvent: vi.fn(() => () => {}),
       },
       rebase: {
-        scanNeeds: vi
-          .fn()
-          .mockResolvedValueOnce([])
-          .mockResolvedValueOnce([])
-          .mockResolvedValue([refreshedNeed]),
+        scanNeeds: vi.fn().mockResolvedValue([refreshedNeed]),
         onEvent: vi.fn(() => () => {}),
       },
     } as any;
@@ -104,10 +98,25 @@ describe("PrsContext refresh", () => {
     cleanup();
     globalThis.window.ade = originalAde;
     window.location.hash = "";
+    window.history.replaceState(null, "", "/");
   });
 
-  it("refreshes rebase needs and auto-rebase statuses without waiting for events", async () => {
-    const user = userEvent.setup();
+  it("skips rebase scans for the plain GitHub PR list", async () => {
+    render(
+      <PrsProvider>
+        <Harness />
+      </PrsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("idle");
+    });
+    expect(window.ade.rebase.scanNeeds).not.toHaveBeenCalled();
+    expect(window.ade.lanes.listAutoRebaseStatuses).not.toHaveBeenCalled();
+  });
+
+  it("refreshes rebase needs and auto-rebase statuses for workflow routes without waiting for events", async () => {
+    window.location.hash = "#/prs?tab=workflows&workflow=rebase&laneId=lane-1";
 
     render(
       <PrsProvider>
@@ -118,8 +127,6 @@ describe("PrsContext refresh", () => {
     await waitFor(() => {
       expect(screen.getByTestId("loading").textContent).toBe("idle");
     });
-
-    await user.click(screen.getByRole("button", { name: "refresh" }));
 
     await waitFor(() => {
       expect(screen.getByTestId("needs-count").textContent).toBe("1");

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
@@ -113,6 +113,7 @@ describe("PrsContext refresh", () => {
     });
     expect(window.ade.rebase.scanNeeds).not.toHaveBeenCalled();
     expect(window.ade.lanes.listAutoRebaseStatuses).not.toHaveBeenCalled();
+    expect(window.ade.lanes.list).toHaveBeenCalledWith({ includeStatus: false });
     expect(window.ade.prs.refresh).not.toHaveBeenCalled();
   });
 
@@ -133,6 +134,7 @@ describe("PrsContext refresh", () => {
       expect(screen.getByTestId("needs-count").textContent).toBe("1");
       expect(screen.getByTestId("auto-count").textContent).toBe("1");
     });
+    expect(window.ade.lanes.list).toHaveBeenCalledWith({ includeStatus: true });
     expect(window.ade.prs.refresh).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
@@ -113,6 +113,7 @@ describe("PrsContext refresh", () => {
     });
     expect(window.ade.rebase.scanNeeds).not.toHaveBeenCalled();
     expect(window.ade.lanes.listAutoRebaseStatuses).not.toHaveBeenCalled();
+    expect(window.ade.prs.refresh).not.toHaveBeenCalled();
   });
 
   it("refreshes rebase needs and auto-rebase statuses for workflow routes without waiting for events", async () => {
@@ -132,6 +133,28 @@ describe("PrsContext refresh", () => {
       expect(screen.getByTestId("needs-count").textContent).toBe("1");
       expect(screen.getByTestId("auto-count").textContent).toBe("1");
     });
+    expect(window.ade.prs.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs a GitHub PR refresh for explicit refresh actions", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <PrsProvider>
+        <Harness />
+      </PrsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("idle");
+    });
+    expect(window.ade.prs.refresh).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "refresh" }));
+
+    await waitFor(() => {
+      expect(window.ade.prs.refresh).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("does not run a GitHub PR refresh just because the local PR tab changes", async () => {
@@ -146,14 +169,14 @@ describe("PrsContext refresh", () => {
     await waitFor(() => {
       expect(screen.getByTestId("loading").textContent).toBe("idle");
     });
-    expect(window.ade.prs.refresh).toHaveBeenCalledTimes(1);
+    expect(window.ade.prs.refresh).not.toHaveBeenCalled();
 
     await user.click(screen.getByRole("button", { name: "queue" }));
 
     await waitFor(() => {
       expect(screen.getByTestId("active-tab").textContent).toBe("queue");
     });
-    expect(window.ade.prs.refresh).toHaveBeenCalledTimes(1);
+    expect(window.ade.prs.refresh).not.toHaveBeenCalled();
   });
 
   it("hydrates the Rebase/Merge workflow selection from the initial hash route", async () => {

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
@@ -795,7 +795,12 @@ export function PrsProvider({ children }: { children: React.ReactNode }) {
 
   // Initial load
   useEffect(() => {
-    void refreshCore({ skipFreshWarmCache: true, githubRefreshMode: "background" });
+    const shouldRefreshFromGithub =
+      activeTabRef.current !== "normal" || selectedPrIdRef.current !== null;
+    void refreshCore({
+      skipFreshWarmCache: true,
+      githubRefreshMode: shouldRefreshFromGithub ? "background" : undefined,
+    });
   }, [refreshCore]);
 
   // Silently refresh detail data for the given PR (no loading state).

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
@@ -1141,8 +1141,12 @@ export function PrsProvider({ children }: { children: React.ReactNode }) {
   // The plain GitHub PR list does not render rebase workflow state, so avoid
   // doing that git work until a workflow tab or selected PR detail can use it.
   useEffect(() => {
-    if (activeTab === "normal" && selectedPrId == null) return;
     let cancelled = false;
+    if (activeTab === "normal" && selectedPrId == null) {
+      return () => {
+        cancelled = true;
+      };
+    }
     const scan = () => {
       window.ade.rebase.scanNeeds().then((needs) => {
         if (!cancelled) setRebaseNeeds(needs);

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
@@ -674,20 +674,25 @@ export function PrsProvider({ children }: { children: React.ReactNode }) {
   // kicks off another refresh instead of silently dropping the request.
   const applyLocalPrState = useCallback(async () => {
     const shouldLoadWorkflowState = activeTabRef.current !== "normal";
+    const shouldLoadRebaseState = shouldLoadWorkflowState || selectedPrIdRef.current !== null;
     const [prList, laneList, queueStateList, refreshedRebaseNeeds, refreshedAutoRebaseStatuses] = await Promise.all([
       window.ade.prs.listWithConflicts(),
       window.ade.lanes.list({ includeStatus: true }),
       shouldLoadWorkflowState
         ? window.ade.prs.listQueueStates({ includeCompleted: true, limit: 50 })
         : Promise.resolve([] as QueueLandingState[]),
-      window.ade.rebase.scanNeeds().catch((err) => {
-        console.warn("[PrsContext] Failed to refresh rebase needs:", err);
-        return rebaseNeedsRef.current;
-      }),
-      window.ade.lanes.listAutoRebaseStatuses().catch((err) => {
-        console.warn("[PrsContext] Failed to refresh auto-rebase statuses:", err);
-        return autoRebaseStatusesRef.current;
-      }),
+      shouldLoadRebaseState
+        ? window.ade.rebase.scanNeeds().catch((err) => {
+            console.warn("[PrsContext] Failed to refresh rebase needs:", err);
+            return rebaseNeedsRef.current;
+          })
+        : Promise.resolve(rebaseNeedsRef.current),
+      shouldLoadRebaseState
+        ? window.ade.lanes.listAutoRebaseStatuses().catch((err) => {
+            console.warn("[PrsContext] Failed to refresh auto-rebase statuses:", err);
+            return autoRebaseStatusesRef.current;
+          })
+        : Promise.resolve(autoRebaseStatusesRef.current),
     ]);
     const changedPrIds = diffPrIds(prsRef.current, prList);
 
@@ -1127,8 +1132,11 @@ export function PrsProvider({ children }: { children: React.ReactNode }) {
     return unsub;
   }, []);
 
-  // Periodic rebase needs scan (cancelled flag guards against setState after unmount)
+  // Periodic rebase needs scan (cancelled flag guards against setState after unmount).
+  // The plain GitHub PR list does not render rebase workflow state, so avoid
+  // doing that git work until a workflow tab or selected PR detail can use it.
   useEffect(() => {
+    if (activeTab === "normal" && selectedPrId == null) return;
     let cancelled = false;
     const scan = () => {
       window.ade.rebase.scanNeeds().then((needs) => {
@@ -1143,13 +1151,10 @@ export function PrsProvider({ children }: { children: React.ReactNode }) {
       cancelled = true;
       clearInterval(timer);
     };
-  }, []);
+  }, [activeTab, selectedPrId]);
 
   // Subscribe to auto-rebase events
   useEffect(() => {
-    window.ade.lanes.listAutoRebaseStatuses().then(setAutoRebaseStatuses).catch((err) => {
-      console.warn("[PrsContext] Failed to list auto-rebase statuses:", err);
-    });
     const unsub = window.ade.lanes.onAutoRebaseEvent((event: AutoRebaseEventPayload) => {
       if (event.type === "auto-rebase-updated") {
         setAutoRebaseStatuses(event.statuses);
@@ -1157,6 +1162,19 @@ export function PrsProvider({ children }: { children: React.ReactNode }) {
     });
     return unsub;
   }, []);
+
+  useEffect(() => {
+    if (activeTab === "normal" && selectedPrId == null) return;
+    let cancelled = false;
+    window.ade.lanes.listAutoRebaseStatuses().then((statuses) => {
+      if (!cancelled) setAutoRebaseStatuses(statuses);
+    }).catch((err) => {
+      console.warn("[PrsContext] Failed to list auto-rebase statuses:", err);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, selectedPrId]);
 
   useEffect(() => {
     if (PRS_CONTEXT_CACHE_DISABLED) return;

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
@@ -675,9 +675,10 @@ export function PrsProvider({ children }: { children: React.ReactNode }) {
   const applyLocalPrState = useCallback(async () => {
     const shouldLoadWorkflowState = activeTabRef.current !== "normal";
     const shouldLoadRebaseState = shouldLoadWorkflowState || selectedPrIdRef.current !== null;
+    const shouldLoadDecoratedLaneStatus = shouldLoadWorkflowState || selectedPrIdRef.current !== null;
     const [prList, laneList, queueStateList, refreshedRebaseNeeds, refreshedAutoRebaseStatuses] = await Promise.all([
       window.ade.prs.listWithConflicts(),
-      window.ade.lanes.list({ includeStatus: true }),
+      window.ade.lanes.list({ includeStatus: shouldLoadDecoratedLaneStatus }),
       shouldLoadWorkflowState
         ? window.ade.prs.listQueueStates({ includeCompleted: true, limit: 50 })
         : Promise.resolve([] as QueueLandingState[]),

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
@@ -675,10 +675,9 @@ export function PrsProvider({ children }: { children: React.ReactNode }) {
   const applyLocalPrState = useCallback(async () => {
     const shouldLoadWorkflowState = activeTabRef.current !== "normal";
     const shouldLoadRebaseState = shouldLoadWorkflowState || selectedPrIdRef.current !== null;
-    const shouldLoadDecoratedLaneStatus = shouldLoadWorkflowState || selectedPrIdRef.current !== null;
     const [prList, laneList, queueStateList, refreshedRebaseNeeds, refreshedAutoRebaseStatuses] = await Promise.all([
       window.ade.prs.listWithConflicts(),
-      window.ade.lanes.list({ includeStatus: shouldLoadDecoratedLaneStatus }),
+      window.ade.lanes.list({ includeStatus: shouldLoadRebaseState }),
       shouldLoadWorkflowState
         ? window.ade.prs.listQueueStates({ includeCompleted: true, limit: 50 })
         : Promise.resolve([] as QueueLandingState[]),

--- a/apps/desktop/src/renderer/components/settings/UsageGuardrailsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/UsageGuardrailsSection.test.tsx
@@ -70,7 +70,8 @@ describe("UsageGuardrailsSection", () => {
     render(<UsageGuardrailsSection />);
 
     await waitFor(() => {
-      expect(window.ade.usage.getSnapshot).toHaveBeenCalledTimes(1);
+      const refreshButton = screen.getByRole("button", { name: /refresh/i }) as HTMLButtonElement;
+      expect(refreshButton.disabled).toBe(false);
     });
 
     fireEvent.click(screen.getByRole("button", { name: /refresh/i }));

--- a/apps/desktop/src/renderer/components/settings/UsageGuardrailsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/UsageGuardrailsSection.test.tsx
@@ -1,0 +1,82 @@
+/* @vitest-environment jsdom */
+
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UsageSnapshot } from "../../../shared/types";
+import { UsageGuardrailsSection } from "./UsageGuardrailsSection";
+
+function makeSnapshot(): UsageSnapshot {
+  return {
+    windows: [],
+    pacing: {
+      status: "on-track",
+      projectedWeeklyPercent: 0,
+      weekElapsedPercent: 0,
+      expectedPercent: 0,
+      deltaPercent: 0,
+      etaHours: null,
+      willLastToReset: true,
+      resetsInHours: 0,
+    },
+    costs: [],
+    extraUsage: [],
+    lastPolledAt: "2026-05-08T07:00:00.000Z",
+    errors: [],
+  };
+}
+
+describe("UsageGuardrailsSection", () => {
+  const originalAde = globalThis.window.ade;
+
+  beforeEach(() => {
+    globalThis.window.ade = {
+      usage: {
+        getSnapshot: vi.fn().mockResolvedValue(makeSnapshot()),
+        refresh: vi.fn().mockResolvedValue(makeSnapshot()),
+        getBudgetConfig: vi.fn().mockResolvedValue({}),
+        saveBudgetConfig: vi.fn().mockResolvedValue({}),
+        onUpdate: vi.fn(() => () => {}),
+      },
+      ai: {
+        getStatus: vi.fn().mockResolvedValue({
+          providerConnections: {
+            claude: null,
+            codex: null,
+            cursor: null,
+            droid: null,
+          },
+        }),
+      },
+    } as any;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.window.ade = originalAde;
+  });
+
+  it("hydrates from the cached snapshot on mount instead of forcing a live usage poll", async () => {
+    render(<UsageGuardrailsSection />);
+
+    await waitFor(() => {
+      expect(window.ade.usage.getSnapshot).toHaveBeenCalledTimes(1);
+      expect(window.ade.usage.getBudgetConfig).toHaveBeenCalledTimes(1);
+    });
+    expect(window.ade.usage.refresh).not.toHaveBeenCalled();
+  });
+
+  it("keeps live provider polling available through the manual refresh button", async () => {
+    render(<UsageGuardrailsSection />);
+
+    await waitFor(() => {
+      expect(window.ade.usage.getSnapshot).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /refresh/i }));
+
+    await waitFor(() => {
+      expect(window.ade.usage.refresh).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/desktop/src/renderer/components/settings/UsageGuardrailsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/UsageGuardrailsSection.tsx
@@ -74,7 +74,7 @@ export function UsageGuardrailsSection({
     setError(null);
     try {
       const [nextSnapshot, nextBudgetConfig] = await Promise.all([
-        window.ade.usage.refresh(),
+        window.ade.usage.getSnapshot(),
         window.ade.usage.getBudgetConfig(),
       ]);
       setSnapshot(nextSnapshot);

--- a/apps/desktop/src/renderer/components/shared/ProviderModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/shared/ProviderModelSelector.tsx
@@ -12,6 +12,7 @@ import { SmartTooltip } from "../ui/SmartTooltip";
 type ProviderModelSelectorProps = {
   value: string;
   onChange: (modelId: string) => void;
+  onOpen?: () => void;
   filter?: (model: ModelDescriptor) => boolean;
   availableModelIds?: string[];
   catalogMode?: "all" | "available-only";
@@ -48,6 +49,7 @@ function tierLabel(tier: string): string {
 export function ProviderModelSelector({
   value,
   onChange,
+  onOpen,
   filter,
   availableModelIds,
   catalogMode = "all",
@@ -210,6 +212,7 @@ export function ProviderModelSelector({
         disabled={disabled}
         onClick={() => {
           if (disabled) return;
+          if (!open) onOpen?.();
           setOpen((current) => !current);
         }}
         className={cn(

--- a/apps/desktop/src/shared/types/automations.ts
+++ b/apps/desktop/src/shared/types/automations.ts
@@ -215,6 +215,7 @@ export type AutomationPlannerConfig =
 
 export type AutomationDraftActionBase = {
   type: AutomationActionType;
+  targetLaneId?: string | null;
   condition?: string;
   continueOnFailure?: boolean;
   timeoutMs?: number;

--- a/apps/desktop/src/shared/types/config.ts
+++ b/apps/desktop/src/shared/types/config.ts
@@ -746,7 +746,7 @@ export type AutomationAction = {
 
 export type AutomationExecutionKind = "agent-session" | "mission" | "built-in";
 
-export type AutomationLaneMode = "create" | "reuse";
+export type AutomationLaneMode = "create" | "reuse" | "require-on-trigger";
 
 export type AutomationLaneNamePreset =
   | "issue-title"
@@ -758,7 +758,8 @@ export type AutomationExecution = {
   kind: AutomationExecutionKind;
   /**
    * Whether each run should spawn a fresh lane (`"create"`) or reuse the
-   * configured / trigger / primary lane (`"reuse"`). Defaults to `"reuse"`.
+   * configured / trigger / primary lane (`"reuse"`), or require the trigger
+   * caller/event to supply a lane (`"require-on-trigger"`). Defaults to `"reuse"`.
    */
   laneMode?: AutomationLaneMode;
   /**
@@ -837,8 +838,6 @@ export type AutomationOutputs = {
   notificationChannel?: string | null;
 };
 
-/** @deprecated Review/verification gate is no longer surfaced in the UI; kept
- * for YAML compatibility so existing rules still load. */
 export type AutomationVerification = {
   verifyBeforePublish: boolean;
   mode?: "intervention" | "dry-run";
@@ -858,9 +857,7 @@ export type AutomationRule = {
   permissionConfig?: MissionPermissionConfig;
   templateId?: string;
   prompt?: string;
-  /** @deprecated Review profile is no longer surfaced in the UI. */
   reviewProfile: AutomationReviewProfile;
-  /** @deprecated Tool palette is no longer surfaced in the UI. */
   toolPalette: AutomationToolFamily[];
   /** @deprecated Replaced by `includeProjectContext` in the UI. */
   contextSources: AutomationContextSource[];

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -571,10 +571,14 @@ Enforced rules (from the stability overhaul):
 2. New integrations are dormant-until-configured.
 3. Feature pages stage data: cheapest (list/summary/topology) first, heavy (dashboard/settings/model metadata/overlays) on delay.
 4. Never mount expensive trees eagerly — settings dialogs, advanced launcher sections unmount when closed.
-5. Renderer polling is route-scoped; terminal attention only polls on terminal routes; lane panels only poll while live sessions exist.
+5. Renderer polling is route-scoped; terminal attention only polls on terminal routes; lane panels only poll while live sessions exist. The plain PR list does not fire a GitHub refresh on mount and skips rebase-needs / auto-rebase polling until the user opens a workflow tab or selects a PR. The Lanes page reuses the `LaneSummary.autoRebaseStatus` snapshot already in the lane list instead of probing per-lane on `LaneGitActionsPane` mount; a fallback probe runs only when the snapshot is missing and after a visibility-gated 3.5 s delay. The Work top-bar sync chip refreshes on focus and on `sync-status` events instead of a 5 s interval. The chat composer's Cursor model inventory is fetched lazily — `ProviderModelSelector` calls `onOpen` on first open of the model catalog, and `AgentChatPane.refreshCursorModelInventory` is the only entry point that hits `cursor` with `activateRuntime: true`.
 6. Shared caches for high-frequency calls (`sessionListCache`, GitHub fingerprint-based snapshots).
 7. Memoize expensive renderer computations (`useMemo`, `React.memo`); isolate frequently-refreshing subtrees (e.g., budget footers).
 8. `Promise.allSettled` over `Promise.all` for parallel startup — one failing service must not block others.
+9. Settings sections that surface a snapshot read the cached snapshot on mount (`ade.usage.getSnapshot`) instead of forcing a refresh; an explicit Refresh button drives recompute.
+10. Persistence callbacks dedupe against the last-saved value: the workspace-graph view-mode persister tracks the last-loaded preference root and skips the immediate write that the load handler's `setViewMode` would otherwise fire.
+
+CLI-launcher and shell-quoting helpers (`cliLaunch.ts`, `shell.ts`) live under `apps/desktop/src/renderer/` only — the prior `apps/desktop/src/shared/` copies were renderer-only in practice and have been removed. The mobile-launcher path (`work.startCliSession`) was retired with them; iOS launches CLI sessions through host-side actions that don't share renderer modules.
 
 Themes: six shipped themes (`e-paper`, `bloomberg`, `github`, `rainbow`, `sky`, `pats`), persisted in `localStorage.ade.theme`, applied via `data-theme` on root. Token-based palettes in `apps/desktop/src/renderer/index.css`.
 

--- a/docs/features/chat/composer-and-ui.md
+++ b/docs/features/chat/composer-and-ui.md
@@ -98,7 +98,14 @@ and a footer that contains the composer.
 - **Model selection.** `ProviderModelSelector` is embedded and filters
   the registry via `filterChatModelIdsForSession`. Switching within the
   allowed family is a normal update; crossing families triggers a
-  handoff.
+  handoff. The Cursor model inventory (`getAgentChatModelsCached` with
+  `provider: "cursor"`, `activateRuntime: true`) is no longer fetched
+  on chat boot — the selector exposes an `onOpen` callback that fires
+  the first time the user actually opens the model catalog, and
+  `AgentChatPane.refreshCursorModelInventory` is the only path that
+  performs the active probe. It also no-ops when the latest
+  `availableModelIds` already contains a Cursor entry, so re-opening
+  the catalog after a successful inventory does not refire the probe.
 - **Reasoning effort.** Dropdown for models that support reasoning
   tiers.
 - **Fast mode (Codex).** A yellow Lightning chip next to the model

--- a/docs/features/lanes/README.md
+++ b/docs/features/lanes/README.md
@@ -40,7 +40,7 @@ Renderer components:
 | `renderer/components/lanes/LaneContextMenu.tsx` | Right-click menu on the lane list. Hosts the inline color swatch row that calls `lanes.updateAppearance` directly, "Reveal/Copy path", manage/adopt/open-in-Run actions, split-tab actions, and batch manage. |
 | `renderer/components/lanes/LaneStackPane.tsx` | Stack graph sidebar, integration source chips, canvas jump |
 | `renderer/components/lanes/LaneDiffPane.tsx` | Diff viewer, per-file stage/unstage/discard |
-| `renderer/components/lanes/LaneGitActionsPane.tsx` | Commit, stash, fetch, sync, push, recent commits |
+| `renderer/components/lanes/LaneGitActionsPane.tsx` | Commit, stash, fetch, sync, push, recent commits. Seeds its `autoRebaseStatus` from the `autoRebaseStatusSnapshot` prop that `LanesPage` passes from the lane list (`laneSnapshot.autoRebaseStatus`), so opening a lane does not trigger a per-lane probe. A fallback `refreshAutoRebaseStatus` runs only when the snapshot is `undefined`, after a 3.5 s delay, and only while the document is visible. |
 | `renderer/components/lanes/LaneWorkPane.tsx` | Terminal/chat toggle work surface |
 | `renderer/components/lanes/LaneRebaseBanner.tsx` | Inline banner driven by `rebaseSuggestionService` |
 | `renderer/components/lanes/LaneEnvInitProgress.tsx` | Env init step progress inside create dialog |

--- a/docs/features/onboarding-and-settings/README.md
+++ b/docs/features/onboarding-and-settings/README.md
@@ -181,7 +181,11 @@ Renderer — settings:
   via `tailscale serve`), and the per-device connection panel used to
   forget paired phones.
 - `apps/desktop/src/renderer/components/settings/SettingsUsageSection.tsx`
-  and `UsageGuardrailsSection.tsx` — cost and usage.
+  and `UsageGuardrailsSection.tsx` — cost and usage. The guardrails
+  section's mount-time hydrate calls `ade.usage.getSnapshot` (cached
+  read), not `ade.usage.refresh` (which forces a recompute); the user
+  still gets the live numbers via the section's explicit Refresh
+  control.
 - `apps/desktop/src/renderer/components/settings/ProxyAndPreviewSection.tsx`
   — proxy/preview configuration UI.
 - `apps/desktop/src/renderer/components/settings/DiagnosticsDashboardSection.tsx`

--- a/docs/features/pull-requests/README.md
+++ b/docs/features/pull-requests/README.md
@@ -531,6 +531,7 @@ best-effort — failures log a warning and do not abort the tick.
 - `PRsPage` parses URL state via `parsePrsRouteState` and writes it
   back with `buildPrsRouteSearch`. Active tab, workflow sub-tab,
   selected PR, queue group, lane, and rebase item are all encoded.
+- `PrsContext` mounts cheaply on the plain GitHub PR list. The initial `refreshCore` only kicks a background GitHub refresh when the active tab is a workflow tab (`queue` / `integration` / `rebase`) or a PR is selected; otherwise `githubRefreshMode` is left undefined so the renderer paints from the existing snapshot. `applyLocalPrState` calls `lanes.list({ includeStatus: false })` and skips `rebase.scanNeeds` / `lanes.listAutoRebaseStatuses` on the plain list — those legs hydrate the moment a workflow tab opens or a PR is selected, and the periodic 60 s rebase scan + auto-rebase listener also no-op while the user is on the plain list.
 - `PrsContext` owns PR list, queue states, rebase needs, proposals,
   convergence runtime state, and the Timeline+Rails UI state
   (`prsTimelineRailsEnabled`, `timelineFiltersByPrId`,

--- a/docs/features/terminals-and-sessions/README.md
+++ b/docs/features/terminals-and-sessions/README.md
@@ -258,10 +258,13 @@ Renderer surfaces:
 
 iOS Work surfaces:
 
-- `apps/ios/ADE/Views/Work/WorkRootScreen.swift` and
-  `WorkRootScreen+Actions.swift` — mobile Work list, filters,
-  grouped session rows, live-count/status pills, and the resume
-  flow that re-uses `work.startCliSession` for ended PTY rows.
+- `apps/ios/ADE/Views/Work/WorkRootScreen.swift`,
+  `WorkRootScreen+Actions.swift`, `WorkRootScreen+Selection.swift`, and
+  `WorkRootComponents.swift` — mobile Work list, filters, grouped
+  session rows, and live-count/status pills, plus the resume flow that
+  re-uses `work.startCliSession` for ended PTY rows. The earlier
+  in-list activity feed is gone — running chats surface through the
+  session list and the live-count chip.
 - `apps/ios/ADE/Views/Work/WorkArtifactTerminalViews.swift` —
   terminal artifact/output views and the compact input bar that sends
   `terminal_input` bytes and Ctrl-C to the subscribed host PTY. Hosts

--- a/docs/features/workspace-graph/README.md
+++ b/docs/features/workspace-graph/README.md
@@ -105,6 +105,13 @@ returns to their preferred view across sessions.
 `normalizeGraphPreferences(state)` migrates legacy schemas (including
 the older `presets: […]` shape) to the current format.
 
+The persistence callback dedupes against the value just loaded:
+`GraphInner` keeps a `skipNextGraphPreferencePersistRootRef` set to the
+project root that was just hydrated. The next `viewMode`-watcher run
+skips its `graphState.set` because the load handler's `setViewMode`
+would otherwise echo the loaded preference straight back to disk on
+every project switch.
+
 ## Node data (`GraphNodeData`)
 
 Every lane node carries enough derived state to render without


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "require-on-trigger" lane mode (select lane at trigger time) and CLI support for it (including a `trigger` alias for manual runs)
  * Enabled launching missions as an automation step
  * Added GitHub trigger filters (Keywords, Draft state) and Linear filters (Keywords, Changed fields)
  * Model catalog now loads provider-specific inventory on demand when opened; phone sync refreshes on window focus

* **Bug Fixes**
  * Strengthened lane-targeting validation and runtime behavior to prevent incompatible mode/target combos

* **Tests**
  * Expanded coverage for lane modes, manual triggers, and multi-step lane reuse
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches automation execution/lane resolution and several renderer refresh paths (PRs, lanes, chat models), so regressions could affect when/where work runs or when UI data refreshes. Changes are mostly additive/gated but span multiple critical workflows.
> 
> **Overview**
> **Defers several renderer cold-start/polling behaviors** to reduce idle IPC/work: PRs tab skips GitHub refresh plus rebase/auto-rebase scanning until a workflow tab/PR detail needs it; TopBar sync status stops 5s polling in favor of focus + event-driven refresh with stale-response protection; lane auto-rebase status is seeded from the lane list snapshot and only probed later (visibility-gated) when missing; chat no longer probes Cursor model inventory on boot and instead fetches it lazily when the model catalog is opened.
> 
> **Expands Automations lane handling and editing**: introduces `execution.laneMode: require-on-trigger` (with legacy `prompt-at-run/provided` normalization), adds CLI support including `automations trigger` alias and stricter flag validation, and enforces that trigger-time lane mode cannot set per-rule/per-step `targetLaneId`. The automation runtime now reuses a single created lane across all built-in steps (persisted via a `lane-setup` action result) and supports `launch-mission` as a built-in step with correct lane selection. UI/editor updates expose rule mode, review profile, tool palette, outputs/verification, and per-step runtime controls (condition, retries, timeout, lane override) plus a lane-picker modal for manual runs that require a lane.
> 
> Also updates ADE project `.gitignore` to ignore everything by default while whitelisting shared config/assets, and adds tests covering the new lane mode, runtime normalization, and the deferred refresh behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7da2de8a4d8f47e7990dbee42ac2845eeae411c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR defers several cold-start and idle IPC operations across the PRs tab, TopBar sync status, lane auto-rebase probes, and chat model inventory to reduce unnecessary work on mount. It also introduces a `require-on-trigger` lane mode for automations (with legacy alias migration), adds a `trigger` CLI alias, and wires `launch-mission` as a supported built-in step with correct lane resolution.

- **Performance deferrals**: PRs tab skips rebase/auto-rebase scans until a workflow tab or PR detail is active; TopBar drops 5-second polling in favour of focus + event-driven refresh with stale-response versioning; Cursor model inventory is fetched lazily on catalog open instead of at boot.
- **`require-on-trigger` lane mode**: Runtime enforcement validates that a `laneId` is present in the trigger payload, normalises legacy `provided`/`prompt-at-run` aliases, and blocks `targetLaneId` at the planner and config validation layers.
- **Lane reuse for built-in steps**: The `create` lane mode persists the created lane via a `lane-setup` action result so all subsequent steps reuse it.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all new behaviour is additive or gated, and the deferred refresh paths have event-driven fallbacks that prevent stale UI state.

The deferred probe changes are well-guarded with ref-based sequence counters and explicit cleanup functions. The `require-on-trigger` enforcement is validated at all three entry points (config load, planner draft, runtime dispatch), backed by integration tests. The one structural note about `normalizeDraft` returning non-null with invalid state is a maintenance concern, not an active runtime bug that current callers would hit.

`automationPlannerService.ts` — the post-construction error push pattern diverges from the early-return guard used for action errors; callers should treat any error-level issue as invalidating `normalized`, not just a null check.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/automations/automationService.ts | Adds `require-on-trigger` enforcement, lane-setup result caching, and lane-resolution for built-in action types. Normalization function for legacy aliases introduced but duplicated elsewhere. |
| apps/desktop/src/main/services/automations/automationPlannerService.ts | Adds normalization helpers and `require-on-trigger` validation. Post-construction error push means `normalized` can be non-null with invalid state; inconsistent with the earlier early-return pattern. |
| apps/desktop/src/renderer/components/prs/state/PrsContext.tsx | Defers rebase scan and auto-rebase status fetch to workflow tab or selected PR. Cleanup and stale-fetch guards are correct. |
| apps/desktop/src/renderer/components/app/TopBar.tsx | Replaces 5-second polling with focus + event-driven refresh. Stale-response protection via `statusRequestVersion` counter is correct. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Cursor model inventory probe moved to lazy callback on catalog open. Sequence-ref guards prevent stale writes. |
| apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx | Seeds `autoRebaseStatus` from parent snapshot; deferred probe fires after 3.5s only when snapshot is still `undefined`, guarded by visibility state. |
| apps/ade-cli/src/cli.ts | Adds `require-on-trigger` to lane-mode constants, `trigger` alias for `run`, and extends flag validations to use effective mode. |
| apps/desktop/src/main/services/config/projectConfigService.ts | Adds `require-on-trigger` coercion for legacy aliases, per-action `targetLaneId` round-tripping, and `validateEffectiveConfig` checks. Additive and well-guarded. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/desktop/src/renderer/components/chat/AgentChatPane.tsx`, line 2793-2831 ([link](https://github.com/arul28/ade/blob/ca8ad67fb8f91e53be875f2ef1a725bae916c86c/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx#L2793-L2831)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`availableModelIds` in `refreshCursorModelInventory` deps causes frequent recreation**

   `availableModelIds` is a state array that changes each time any model list update occurs, so `refreshCursorModelInventory` is recreated on every such change. This callback is passed as a prop to `AgentChatComposer` and `ProviderModelSelector`, so both components will see a new function reference on every model refresh — potentially triggering extra renders on the exact path this PR is trying to make lighter. Accessing the current model list via a `useRef` instead (updated in a separate effect) would keep the callback stable.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
   Line: 2793-2831

   Comment:
   **`availableModelIds` in `refreshCursorModelInventory` deps causes frequent recreation**

   `availableModelIds` is a state array that changes each time any model list update occurs, so `refreshCursorModelInventory` is recreated on every such change. This callback is passed as a prop to `AgentChatComposer` and `ProviderModelSelector`, so both components will see a new function reference on every model refresh — potentially triggering extra renders on the exact path this PR is trying to make lighter. Accessing the current model list via a `useRef` instead (updated in a separate effect) would keep the callback stable.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FAgentChatPane.tsx%0ALine%3A%202793-2831%0A%0AComment%3A%0A**%60availableModelIds%60%20in%20%60refreshCursorModelInventory%60%20deps%20causes%20frequent%20recreation**%0A%0A%60availableModelIds%60%20is%20a%20state%20array%20that%20changes%20each%20time%20any%20model%20list%20update%20occurs%2C%20so%20%60refreshCursorModelInventory%60%20is%20recreated%20on%20every%20such%20change.%20This%20callback%20is%20passed%20as%20a%20prop%20to%20%60AgentChatComposer%60%20and%20%60ProviderModelSelector%60%2C%20so%20both%20components%20will%20see%20a%20new%20function%20reference%20on%20every%20model%20refresh%20%E2%80%94%20potentially%20triggering%20extra%20renders%20on%20the%20exact%20path%20this%20PR%20is%20trying%20to%20make%20lighter.%20Accessing%20the%20current%20model%20list%20via%20a%20%60useRef%60%20instead%20%28updated%20in%20a%20separate%20effect%29%20would%20keep%20the%20callback%20stable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=259&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>

2. `apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx`, line 868-879 ([link](https://github.com/arul28/ade/blob/ca8ad67fb8f91e53be875f2ef1a725bae916c86c/apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx#L868-L879)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Deferred probe is always bypassed when `LanesPage` is the parent**

   The probe fires only when `autoRebaseStatusSnapshotRef.current === undefined`. But `LanesPage` always passes `autoRebaseStatusSnapshot={laneSnapshot?.autoRebaseStatus ?? null}` — coercing `undefined` to `null` via `?? null` — so the ref initialises as `null` for every lane opened through `LanesPage`. If `laneSnapshot` hasn't arrived yet at mount time, the component receives `null`, skips the probe, and will only get auto-rebase status once an event fires.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx
   Line: 868-879

   Comment:
   **Deferred probe is always bypassed when `LanesPage` is the parent**

   The probe fires only when `autoRebaseStatusSnapshotRef.current === undefined`. But `LanesPage` always passes `autoRebaseStatusSnapshot={laneSnapshot?.autoRebaseStatus ?? null}` — coercing `undefined` to `null` via `?? null` — so the ref initialises as `null` for every lane opened through `LanesPage`. If `laneSnapshot` hasn't arrived yet at mount time, the component receives `null`, skips the probe, and will only get auto-rebase status once an event fires.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Flanes%2FLaneGitActionsPane.tsx%0ALine%3A%20868-879%0A%0AComment%3A%0A**Deferred%20probe%20is%20always%20bypassed%20when%20%60LanesPage%60%20is%20the%20parent**%0A%0AThe%20probe%20fires%20only%20when%20%60autoRebaseStatusSnapshotRef.current%20%3D%3D%3D%20undefined%60.%20But%20%60LanesPage%60%20always%20passes%20%60autoRebaseStatusSnapshot%3D%7BlaneSnapshot%3F.autoRebaseStatus%20%3F%3F%20null%7D%60%20%E2%80%94%20coercing%20%60undefined%60%20to%20%60null%60%20via%20%60%3F%3F%20null%60%20%E2%80%94%20so%20the%20ref%20initialises%20as%20%60null%60%20for%20every%20lane%20opened%20through%20%60LanesPage%60.%20If%20%60laneSnapshot%60%20hasn't%20arrived%20yet%20at%20mount%20time%2C%20the%20component%20receives%20%60null%60%2C%20skips%20the%20probe%2C%20and%20will%20only%20get%20auto-rebase%20status%20once%20an%20event%20fires.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=259&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fautomations%2FautomationPlannerService.ts%3A833-862%0A**Inconsistent%20error%20handling%3A%20%60normalized%60%20returned%20non-null%20with%20%60require-on-trigger%60%20%2B%20%60targetLaneId%60%20errors**%0A%0AThe%20earlier%20guard%20at%20line%20823%20returns%20%60%7B%20normalized%3A%20null%2C%20issues%20%7D%60%20when%20any%20action-processing%20error%20is%20found.%20But%20the%20%60require-on-trigger%60%20%2B%20%60targetLaneId%60%20validation%20errors%20are%20pushed%20AFTER%20that%20guard%2C%20and%20the%20execution%20object%20is%20still%20constructed%20with%20%60targetLaneId%60%20included%20%28line%20862%29.%20This%20means%20%60normalizeDraft%60%20can%20return%20a%20non-null%20%60normalized%60%20rule%20that%20has%20both%20%60laneMode%3A%20%22require-on-trigger%22%60%20and%20%60targetLaneId%60%20set%20%E2%80%94%20an%20invalid%20state%20%E2%80%94%20while%20also%20reporting%20an%20error%20in%20%60issues%60.%20Callers%20that%20check%20%60normalized%20!%3D%20null%60%20instead%20of%20%60issues.some%28i%20%3D%3E%20i.level%20%3D%3D%3D%20%22error%22%29%60%20would%20silently%20accept%20the%20inconsistent%20rule.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fautomations%2FautomationService.ts%3A620-624%0A**Lane-mode%20normalization%20logic%20duplicated%20across%20three%20files**%0A%0A%60normalizeAutomationLaneMode%60%20here%2C%20%60normalizeLaneMode%60%20in%20%60automationPlannerService.ts%60%2C%20and%20the%20inline%20coercion%20inside%20%60coerceAutomationExecution%60%20in%20%60projectConfigService.ts%60%20all%20implement%20the%20same%20%60provided%60%2F%60prompt-at-run%60%20%E2%86%92%20%60require-on-trigger%60%20mapping%20independently.%20If%20a%20new%20legacy%20alias%20needs%20to%20be%20added%20in%20the%20future%2C%20all%20three%20sites%20must%20be%20updated%20in%20lockstep.%20Centralising%20this%20into%20a%20shared%20utility%20would%20eliminate%20the%20drift%20risk.%0A%0A&repo=arul28%2Fade&pr=259&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src/main/services/automations/automationPlannerService.ts:833-862
**Inconsistent error handling: `normalized` returned non-null with `require-on-trigger` + `targetLaneId` errors**

The earlier guard at line 823 returns `{ normalized: null, issues }` when any action-processing error is found. But the `require-on-trigger` + `targetLaneId` validation errors are pushed AFTER that guard, and the execution object is still constructed with `targetLaneId` included (line 862). This means `normalizeDraft` can return a non-null `normalized` rule that has both `laneMode: "require-on-trigger"` and `targetLaneId` set — an invalid state — while also reporting an error in `issues`. Callers that check `normalized != null` instead of `issues.some(i => i.level === "error")` would silently accept the inconsistent rule.

### Issue 2 of 2
apps/desktop/src/main/services/automations/automationService.ts:620-624
**Lane-mode normalization logic duplicated across three files**

`normalizeAutomationLaneMode` here, `normalizeLaneMode` in `automationPlannerService.ts`, and the inline coercion inside `coerceAutomationExecution` in `projectConfigService.ts` all implement the same `provided`/`prompt-at-run` → `require-on-trigger` mapping independently. If a new legacy alias needs to be added in the future, all three sites must be updated in lockstep. Centralising this into a shared utility would eliminate the drift risk.


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Guard concurrent Cursor inventory refres..."](https://github.com/arul28/ade/commit/9bef991f09fd2145662b28aee20eeb19b720ec9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31344490)</sub>

<!-- /greptile_comment -->