### PR TITLE
Optimize Work tab runtime and tools pane

### DIFF
--- a/.agents/skills/ade-autoresearch/SKILL.md
+++ b/.agents/skills/ade-autoresearch/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: ade-autoresearch
 description: Iteratively optimize an ADE tab's CPU/memory/IPC/render performance.
-  Runs predefined scenarios, identifies bottlenecks from JSONL metrics, makes ONE
-  targeted code change per iteration, gates on tests + smoke, keeps wins on a
-  branch, and distills patterns into per-tab perf skills. Invoke when the user
-  says "optimize <tab>", "autoresearch <tab>", or "perf pass on <tab>". Drives
-  ADE pointed at the perf-pass throwaway repo; full liberty inside that repo.
-  Uses Codex/GPT models for any in-ADE AI activity unless a scenario opts into
-  Claude.
+  Drives the real UI, builds tab-specific probes from the visible product and
+  perf-pass repo, identifies bottlenecks from JSONL metrics, makes ONE targeted
+  code change per iteration, gates on tests + smoke, keeps wins on a branch, and
+  distills patterns into per-tab perf skills. Invoke when the user says
+  "optimize <tab>", "autoresearch <tab>", or "perf pass on <tab>". Drives ADE
+  pointed at the perf-pass throwaway repo; full liberty inside that repo. Uses
+  Codex/GPT models for in-ADE AI activity unless the run explicitly opts into
+  another configured provider for comparison.
 metadata:
   author: ADE
-  version: 0.2.0
+  version: 0.3.0
 ---
 
 # ade-autoresearch
@@ -24,7 +25,12 @@ A Karpathy-style autoresearch loop for ADE perf. You (the agent) ARE the loop ru
 
 ## Real UI audit is the primary loop
 
-The job is to find what a person actually feels in the tab. Deterministic scenarios are guardrails and regression checks, not a substitute for driving the product.
+The job is to find what a person actually feels in the tab. Fixed canned
+scenario suites are optional guardrails, not the contract and not a constraint on
+the run. Build the measurement plan from the live UI, source, and perf-pass repo;
+then create whatever repeatable probes, scripts, seeded repo states, or tests are
+needed to show load-time, CPU, heap, IPC, render, and interaction deltas for the
+surfaces the user actually exercises.
 
 Use this order:
 
@@ -49,12 +55,19 @@ Use this order:
 
 4. **Use direct IPC only for setup, cleanup, and analysis.** It is fine to create fixture data, reset a throwaway repo, query status, or extract metrics through IPC/shell. Do not replace a UI audit action with `window.ade.*` unless the UI is genuinely impossible to drive; if you must, say so in the run notes.
 
-5. **Run deterministic scenarios after UI findings.** Scenarios catch regressions and quantify broad fitness. They do not prove the tab is clean unless the UI action inventory was also covered.
+5. **Create UI-derived probes after findings.** If existing scenarios cover a
+   surface, you may run them. If they do not, write a tab-specific probe,
+   scenario, fixture, or test that reproduces the measured workflow against the
+   perf-pass repo. The probe is evidence, not a product requirement: it exists to
+   quantify a real UI bottleneck and compare before/after behavior.
 
 ## Setup (do once at start of run)
 
 1. **Read prior wins** at `.agents/skills/ade-perf-<tab>/SKILL.md` if it exists. These are optional best-practice notes from earlier audits, not prerequisites. If no per-tab skill exists, derive the checklist from the tab UI and source and create the per-tab skill only during codification after you have measured real behavior.
-2. **Read scenario definitions** at `apps/desktop/src/renderer/perf/scenarios/<tab>.ts`. These are the *contract*. Do NOT edit them.
+2. **Inspect existing perf probes** under `apps/desktop/src/renderer/perf/scenarios/`,
+   scripts, and tab tests. Reuse what matches the tab, but do not treat missing or
+   incomplete scenarios as a blocker. It is acceptable to add new tab-specific
+   scenarios/probes when they help quantify a real UI workflow.
 3. **Verify perf-pass repo** exists, has a seed tag, and can exercise real GitHub paths when needed:
    ```bash
    scripts/reset-perf-pass.sh
@@ -68,32 +81,29 @@ Use this order:
 
 ## Baseline (iteration 0)
 
-Start with one deterministic scenario sweep so you know the existing guardrail fitness, then do the real UI inventory. The baseline is not complete until both exist.
+Start with the real UI inventory. The baseline is complete when every safe tab
+surface has been exercised or explicitly marked unsafe/external/destructive, and
+each measured segment has corresponding perf evidence.
 
-Run all scenarios for the tab. For lanes that's:
+For each important workflow, capture at least one of:
 
-```bash
-node scripts/run-perf-scenario.mjs lanes.cold-list   baseline-cold
-node scripts/run-perf-scenario.mjs lanes.switch-rapid baseline-switch
-node scripts/run-perf-scenario.mjs lanes.idle-at-rest baseline-idle
-node scripts/run-perf-scenario.mjs lanes.scroll-list  baseline-scroll
-node scripts/run-perf-scenario.mjs lanes.stress-poll  baseline-stress
-```
+- A real UI perf-launch run with `manualStep` markers in
+  `~/.ade/perf-runs/<runId>/events.jsonl`
+- A purpose-built probe or scenario that drives the workflow against the
+  perf-pass repo and writes `summary.json` / `events.jsonl`
+- A focused unit/component/integration test that reproduces the expensive derive,
+  mount, or IPC behavior
+- A shell/IPC setup script only for fixture creation and cleanup
 
-For boot (which has a mix of project-loaded and no-project scenarios):
+Record `baseline_metrics` as a small table, not a single mandatory fitness
+score. Include the metrics that matter to the surface: route/load time, segment
+duration, main CPU p95, renderer CPU or long tasks, heap growth, IPC count/p95,
+render-on-scroll time, or panel mount cost. If an existing scenario reports a
+fitness score, keep it as one data point; do not let it override real UI evidence.
 
-```bash
-node scripts/run-perf-scenario.mjs boot.cold-paint     baseline-paint   --no-project
-node scripts/run-perf-scenario.mjs boot.recent-projects baseline-recent --no-project
-node scripts/run-perf-scenario.mjs boot.open-project    baseline-open   --no-project
-node scripts/run-perf-scenario.mjs boot.remote-runtime  baseline-remote
-node scripts/run-perf-scenario.mjs boot.idle-welcome    baseline-idle   --no-project
-node scripts/run-perf-scenario.mjs boot.stress-launch   baseline-stress --no-project
-```
-
-Each writes `~/.ade/perf-runs/<runId>/summary.json`. Read all summaries. Compute the **per-tab fitness** as the sum of all scenario fitness scores. Record this as `baseline_fitness`. Also record per-component breakdown so you can target the worst component.
-
-Then launch the real tab with `perf-launch`, drive the action inventory, and analyze `~/.ade/perf-runs/<runId>/events.jsonl` by manualStep segments. Record the worst UI segment, the slow IPC channels inside it, and whether the cost is expected work (for example network push/fetch) or avoidable tab work.
+Then analyze `events.jsonl` by manualStep segment. Record the worst UI segment,
+the slow IPC channels inside it, and whether the cost is expected work (for
+example network push/fetch) or avoidable tab work.
 
 Tag the baseline commit:
 ```bash
@@ -102,20 +112,25 @@ git tag perf-baseline-<tab>-$(date +%Y%m%d)
 
 ## Iteration loop
 
-Stop conditions: **no fitness improvement for 10 consecutive iterations** OR user kills the run OR 50 iterations OR 4 hours wall-clock.
+Stop conditions: **no measurable improvement on the current bottleneck for 10
+consecutive attempts** OR user kills the run OR 50 iterations OR 4 hours
+wall-clock.
 
 For each iteration:
 
 ### 1. Analyze
-- Read the latest scenario summaries and the latest real-UI `events.jsonl`.
-- Pick the **#1 bottleneck**: the avoidable cost that appears in real UI segments or scenario summaries. Tie-break by user-visible workflow first, then reproducibility across scenarios.
+- Read the latest real-UI `events.jsonl`, probe outputs, scenario summaries, and
+  focused test results.
+- Pick the **#1 bottleneck**: the avoidable cost that appears in real UI segments
+  or repeatable probes. Tie-break by user-visible workflow first, then
+  reproducibility and metric severity.
 - Common bottleneck categories:
   - **Slow IPC channel**: a channel in `summary.ipc.slowChannels` with p95 ≥ 120ms
   - **Long task spam**: `webVitals.longTaskCount` > 5 per minute
-  - **Memory growth**: `process.rendererHeapGrowthMB` > 10 over a scenario
+  - **Memory growth**: `process.rendererHeapGrowthMB` > 10 over a measured workflow
   - **Render-on-scroll cost**: `marks.scroll.*` p95 high
   - **Route transition cost**: `marks.nav.*` or `marks.switch.*` p95 high
-  - **Main CPU**: `process.mainCpuPercentP95` > 30 during idle scenarios → background pollers
+  - **Main CPU**: `process.mainCpuPercentP95` > 30 during idle or panel-open probes → background pollers
 - UI segment waste: heavy refreshes, duplicate mounted panes, hidden pollers, repeated global status checks, or expensive dialog prefetches that are not needed for the action the user took
 - Read the code that owns the bottleneck. Form a hypothesis.
 
@@ -136,12 +151,23 @@ Legal moves (examples — not exhaustive):
 
 **Forbidden moves:**
 - Editing anything under `apps/desktop/src/main/services/perf/**`
-- Editing anything under `apps/desktop/src/renderer/perf/**`
-- Editing `scripts/run-perf-scenario.mjs` or `scripts/reset-perf-pass.sh`
+- Editing metrics plumbing under `apps/desktop/src/renderer/perf/harness/**`,
+  `apps/desktop/src/renderer/perf/markers.ts`, or
+  `apps/desktop/src/renderer/perf/webVitals.ts` to make results look better
+- Editing `scripts/run-perf-scenario.mjs` or `scripts/reset-perf-pass.sh` to
+  weaken measurement or setup
 - Editing test files to make them pass
 - Disabling polling/sync features outright (only debounce/throttle)
-- Removing UI features or hiding elements to bypass scenarios
-- Changing fitness weights or scenario definitions
+- Removing UI features or hiding elements to bypass measured workflows
+- Changing metric weights, summaries, or existing probes to mask a regression
+
+Allowed measurement moves:
+- Add new tab-specific scenarios/probes under `apps/desktop/src/renderer/perf/scenarios/`
+  when they drive a real UI-derived workflow.
+- Add scripts under `scripts/` or tests under the touched feature area to seed the
+  perf-pass repo or reproduce an expensive UI path.
+- Expand a probe to cover a newly discovered tab surface, provided it remains
+  honest about what it measures.
 
 ### 3. Apply the change
 One commit, focused. Conventional message: `perf(<tab>): <one-line description>`.
@@ -155,14 +181,27 @@ npm --prefix apps/desktop run test -- --run path/to/affected.test.ts
 If tests fail: **revert** the commit (`git reset --hard HEAD~1`), do NOT count toward plateau, try a different change targeting the same or next bottleneck.
 
 ### 5. Measure
-First re-drive the same UI segment with the same markers and compare the IPC/render/memory delta. Then re-run the smallest scenario subset that covers the changed surface. Re-run all scenarios before declaring the run done.
+First re-drive the same UI segment with the same markers and compare the
+IPC/render/memory/load/CPU delta. Then re-run the smallest probe, scenario, or
+test that covers the changed surface. Before declaring the run done, re-run the
+final measured sweep that covers the audited surfaces; this can be a mix of real
+UI markers, custom probes, and existing scenarios.
 
 ### 6. Smoke gate
-For each scenario's summary, check `summary.scenarios.<id>.ok === true` and `smokeFailures.length === 0`. If any scenario failed smoke: **revert**, increment plateau counter.
+For each probe or scenario that writes a summary, check
+`summary.scenarios.<id>.ok === true` when present and `smokeFailures.length === 0`.
+For tests, require the targeted tests to pass. If the workflow breaks or smoke
+fails because of the code change: **revert**, increment the missed-attempt
+counter.
 
 ### 7. Decide
-- Improvement threshold: `new_fitness < best_fitness * 0.98` (≥2% better)
-- If improvement: **keep**. Update best. Reset plateau to 0. Amend the commit message with `fitness <old> → <new>`.
+- Improvement threshold: at least one primary metric for the bottleneck improves
+  by ≥2% without regressing the surrounding smoke metrics. Use the most relevant
+  metric for the workflow (duration, CPU p95, heap, long tasks, IPC count/p95,
+  render cost), not a mandatory global fitness score.
+- If improvement: **keep**. Update best. Reset plateau to 0. Amend the commit
+  message with the metric delta, e.g. `work open 1840ms → 1210ms` or
+  `ipc p95 160ms → 70ms`.
 - Else: **revert** (`git reset --hard HEAD~1`). Plateau += 1.
 
 ### 8. Soft iteration cap
@@ -171,7 +210,8 @@ If this iteration has been running >15 minutes wall clock (build loops, scenario
 ## Termination
 
 When stop condition hits:
-1. Print run summary: starting fitness, final fitness, %-improvement, list of kept commits (sha + message + fitness delta).
+1. Print run summary: baseline metrics, final metrics, %-improvement for each
+   kept bottleneck, and list of kept commits (sha + message + metric delta).
 2. Suggest the user merge the working branch into main via PR.
 3. Proceed to codification (next section).
 
@@ -185,13 +225,22 @@ Read all kept commits (`git log --oneline perf-baseline-<tab>-... HEAD`). For ea
   - **Why it helped**: which bottleneck it addressed, with the metric delta from the summary.
   - **How to recognize when to apply**: signs in future code that the same pattern is needed.
   - **Anti-pattern to avoid**: what NOT to do.
-  - **Verification**: which scenario + metric this affected.
+  - **Verification**: which UI segment, probe, scenario, or test metric this affected.
 - Preserve proven history, but keep the top of the file readable as best practices for future code changes.
 
 ## Notes on agent behavior
 
 - **Stay focused.** One bottleneck at a time. Resist the urge to "while I'm here also fix..." — that breaks attribution.
-- **Trust the metric.** If fitness went up but you "feel" the code is better, revert anyway. The metric is the contract.
-- **The perf-pass repo is your sandbox.** Inside it, you may create lanes, open chats, push/pull throwaway branches, run automations, stash changes, and delete fixtures when needed to exercise ADE. Scenarios are guardrails; real UI audit coverage is required before you call the tab optimized. You may extend scenarios ONLY by adding new scenarios in `apps/desktop/src/renderer/perf/scenarios/<tab>.ts` — never by editing existing ones.
-- **Codex model only.** If a scenario invokes an in-ADE chat, that chat uses the `ADE_MODEL_OVERRIDE` model (gpt-5-codex by default). Scenarios opting into Claude must declare `requiresClaude: true` and you must set `ADE_PERF_ALLOW_CLAUDE=1` for them.
+- **Trust the metric.** If the relevant measured workflow does not improve, revert
+  even when the code feels cleaner. The metric-backed user workflow is the
+  contract.
+- **The perf-pass repo is your sandbox.** Inside it, you may create lanes, open
+  chats, push/pull throwaway branches, run automations, stash changes, and delete
+  fixtures when needed to exercise ADE. Purpose-built probes are encouraged when
+  fixed scenarios do not cover the tab. Real UI audit coverage is required before
+  you call the tab optimized.
+- **Codex model preference.** If a probe or in-ADE action invokes chat/agent work,
+  use the `ADE_MODEL_OVERRIDE` model (gpt-5-codex by default) for the majority of
+  chat work and for deep performance-fix work. Other configured providers may be
+  sampled for comparison when the user asks for broad coverage.
 - **Concurrency**: only one perf run on the machine at a time. If `~/.ade/perf-runs/` contains a `<runId>/lock` file with a live pid, refuse to start.

--- a/.agents/skills/ade-autoresearch/SKILL.md
+++ b/.agents/skills/ade-autoresearch/SKILL.md
@@ -10,7 +10,7 @@ description: Iteratively optimize an ADE tab's CPU/memory/IPC/render performance
   Claude.
 metadata:
   author: ADE
-  version: 0.1.0
+  version: 0.2.0
 ---
 
 # ade-autoresearch
@@ -22,44 +22,44 @@ A Karpathy-style autoresearch loop for ADE perf. You (the agent) ARE the loop ru
 - `<tab>`: the tab to optimize. Must be one of: `boot`, `lanes`, `missions`, `prs`, `work`, `files`, `run`, `graph`, `review`, `history`, `automations`, `cto`, `settings`. (`boot` = cold launch + welcome + project open + remote runtime + iOS pairing — the "main ADE screen" surface above any specific tab.)
 - `<perf-pass-dir>`: throwaway git repo path. Defaults to `/Users/admin/Projects/perf pass` (note the space — quote it). Must exist, must be a git repo, must have a `perf-pass-seed` tag (or you create one on first run). Override via `ADE_PERF_PASS_DIR` env var.
 
-## Shortcuts — prefer IPC and direct launch over computer use
+## Real UI audit is the primary loop
 
-Computer use (screenshots + clicks) is slow and noisy. Always prefer these in this order:
+The job is to find what a person actually feels in the tab. Deterministic scenarios are guardrails and regression checks, not a substitute for driving the product.
 
-1. **Direct IPC calls** in scenarios. Most ADE actions are exposed on `window.ade.*` — call them directly instead of clicking buttons. Examples:
+Use this order:
+
+1. **Warm launch the real Electron UI on the target tab** and keep it open while auditing:
+   ```bash
+   NO_DEVTOOLS=1 ADE_DISABLE_LOCAL_RUNTIME_DAEMON=1 ADE_LOCAL_RUNTIME_FALLBACK=1 ADE_MODEL_OVERRIDE=gpt-5-codex \
+     node scripts/perf-launch.mjs --tab <tab> --run-id <tab>-ui-audit-$(date +%Y%m%d-%H%M)
+   ```
+   Confirm the Electron surface is on the requested tab. The visible active tab must match `<tab>`; do not audit a related embedded surface from another tab.
+
+2. **Build an action inventory from the visible UI and source.** Start with the tab's actual first screen, then cover every safe user action, subpane, menu, picker, dialog, mode switch, list interaction, empty state, error/preflight state, expand/minimize/fullscreen state, keyboard/search/filter path, and tab-specific destructive/external preflight. For destructive or externally visible actions, open and measure the prompt/preflight unless the user has explicitly allowed final execution.
+
+   The inventory must be tab-derived. For example, a Work pass should cover Work sidebar/session list, chat/CLI/shell start surfaces, session tabs/grid/layout controls, running/ended session actions, model/attachment/command/parallel pickers, terminal/chat panes, context menus, filters/search, and ADE tools drawers because those are Work-tab surfaces. A Lanes pass should cover lane list, stack graph, lane dialogs, Git Actions, and lane Work panes because those are Lanes-tab surfaces.
+
+3. **Mark each UI segment in the perf log** before and after exercising it:
    ```ts
-   await window.ade.project.openRepo({ rootPath: "/some/repo" });
-   await window.ade.lanes.create({ name: "x", ... });
-   await window.ade.project.listRecent();
-   await window.ade.remoteRuntime.listTargets();
+   window.ade.perf.recordEvent({ kind: "manualStep", ts: Date.now(), name: "git-actions-stage", phase: "start" });
+   // drive the visible UI
+   window.ade.perf.recordEvent({ kind: "manualStep", ts: Date.now(), name: "git-actions-stage", phase: "end" });
    ```
-   Read `apps/desktop/src/preload/global.d.ts` for the full IPC surface.
+   Segment names should describe the workflow, not the implementation detail.
 
-2. **Warm launch on a specific tab** without running any scenario:
-   ```bash
-   node scripts/perf-launch.mjs --tab lanes
-   node scripts/perf-launch.mjs --tab boot --no-project
-   node scripts/perf-launch.mjs --route /settings/integrations
-   ```
-   This boots ADE with perf instrumentation, navigates to the target route, and stays open. Ideal for hands-on inspection of metrics as they stream into `~/.ade/perf-runs/<runId>/events.jsonl`.
+4. **Use direct IPC only for setup, cleanup, and analysis.** It is fine to create fixture data, reset a throwaway repo, query status, or extract metrics through IPC/shell. Do not replace a UI audit action with `window.ade.*` unless the UI is genuinely impossible to drive; if you must, say so in the run notes.
 
-3. **Single-scenario run** for a measured cycle:
-   ```bash
-   node scripts/run-perf-scenario.mjs lanes.cold-list run-id
-   node scripts/run-perf-scenario.mjs boot.idle-welcome run-id --no-project
-   ```
-
-4. **Computer use is the last resort.** Use only when no IPC exists and a click is unavoidable. Even then, prefer adding a `data-testid` and a `clickTestId` step in the scenario instead of pixel coordinates.
+5. **Run deterministic scenarios after UI findings.** Scenarios catch regressions and quantify broad fitness. They do not prove the tab is clean unless the UI action inventory was also covered.
 
 ## Setup (do once at start of run)
 
-1. **Read prior wins** at `.agents/skills/ade-perf-<tab>/SKILL.md` if it exists. These are patterns past runs discovered — do not redo them, and prefer NOT to undo them. If conflict, prefer the prior win unless your new change strictly improves on it.
+1. **Read prior wins** at `.agents/skills/ade-perf-<tab>/SKILL.md` if it exists. These are optional best-practice notes from earlier audits, not prerequisites. If no per-tab skill exists, derive the checklist from the tab UI and source and create the per-tab skill only during codification after you have measured real behavior.
 2. **Read scenario definitions** at `apps/desktop/src/renderer/perf/scenarios/<tab>.ts`. These are the *contract*. Do NOT edit them.
-3. **Verify perf-pass repo** is clean and on its seed tag:
+3. **Verify perf-pass repo** exists, has a seed tag, and can exercise real GitHub paths when needed:
    ```bash
    scripts/reset-perf-pass.sh
    ```
-   Refuse to start if perf-pass doesn't exist — instruct the user to create it.
+   Refuse to start if perf-pass doesn't exist. If the tab uses GitHub behavior, publish the repo as a private `perf-pass` remote before measuring push/pull/fetch UI.
 4. **Create a working branch** off main:
    ```bash
    git checkout -b autoresearch/<tab>-$(date +%Y%m%d-%H%M)
@@ -67,6 +67,8 @@ Computer use (screenshots + clicks) is slow and noisy. Always prefer these in th
 5. **Set the model override** for all in-ADE AI activity: export `ADE_MODEL_OVERRIDE=gpt-5-codex` (or another GPT/Codex model id available in ADE). Don't touch this during the run.
 
 ## Baseline (iteration 0)
+
+Start with one deterministic scenario sweep so you know the existing guardrail fitness, then do the real UI inventory. The baseline is not complete until both exist.
 
 Run all scenarios for the tab. For lanes that's:
 
@@ -91,6 +93,8 @@ node scripts/run-perf-scenario.mjs boot.stress-launch   baseline-stress --no-pro
 
 Each writes `~/.ade/perf-runs/<runId>/summary.json`. Read all summaries. Compute the **per-tab fitness** as the sum of all scenario fitness scores. Record this as `baseline_fitness`. Also record per-component breakdown so you can target the worst component.
 
+Then launch the real tab with `perf-launch`, drive the action inventory, and analyze `~/.ade/perf-runs/<runId>/events.jsonl` by manualStep segments. Record the worst UI segment, the slow IPC channels inside it, and whether the cost is expected work (for example network push/fetch) or avoidable tab work.
+
 Tag the baseline commit:
 ```bash
 git tag perf-baseline-<tab>-$(date +%Y%m%d)
@@ -103,8 +107,8 @@ Stop conditions: **no fitness improvement for 10 consecutive iterations** OR use
 For each iteration:
 
 ### 1. Analyze
-- Read the latest set of `summary.json` files for this tab.
-- Pick the **#1 bottleneck**: the component contributing most to fitness. Tie-break by reproducibility (the bottleneck that appears across multiple scenarios > single-scenario).
+- Read the latest scenario summaries and the latest real-UI `events.jsonl`.
+- Pick the **#1 bottleneck**: the avoidable cost that appears in real UI segments or scenario summaries. Tie-break by user-visible workflow first, then reproducibility across scenarios.
 - Common bottleneck categories:
   - **Slow IPC channel**: a channel in `summary.ipc.slowChannels` with p95 ≥ 120ms
   - **Long task spam**: `webVitals.longTaskCount` > 5 per minute
@@ -112,6 +116,7 @@ For each iteration:
   - **Render-on-scroll cost**: `marks.scroll.*` p95 high
   - **Route transition cost**: `marks.nav.*` or `marks.switch.*` p95 high
   - **Main CPU**: `process.mainCpuPercentP95` > 30 during idle scenarios → background pollers
+- UI segment waste: heavy refreshes, duplicate mounted panes, hidden pollers, repeated global status checks, or expensive dialog prefetches that are not needed for the action the user took
 - Read the code that owns the bottleneck. Form a hypothesis.
 
 ### 2. Propose ONE change
@@ -150,7 +155,7 @@ npm --prefix apps/desktop run test -- --run path/to/affected.test.ts
 If tests fail: **revert** the commit (`git reset --hard HEAD~1`), do NOT count toward plateau, try a different change targeting the same or next bottleneck.
 
 ### 5. Measure
-Re-run all scenarios for the tab. Compute new per-tab fitness.
+First re-drive the same UI segment with the same markers and compare the IPC/render/memory delta. Then re-run the smallest scenario subset that covers the changed surface. Re-run all scenarios before declaring the run done.
 
 ### 6. Smoke gate
 For each scenario's summary, check `summary.scenarios.<id>.ok === true` and `smokeFailures.length === 0`. If any scenario failed smoke: **revert**, increment plateau counter.
@@ -174,19 +179,19 @@ When stop condition hits:
 
 Read all kept commits (`git log --oneline perf-baseline-<tab>-... HEAD`). For each, extract the **pattern** (the technique used, not the literal change). Update `.agents/skills/ade-perf-<tab>/SKILL.md`:
 
-- One entry per pattern. If a similar pattern already exists, append a refinement instead of duplicating.
+- Write this as future engineering guidance for agents editing that tab, not as an audit transcript. One entry per pattern. If a similar pattern already exists, append a refinement instead of duplicating.
 - Each entry:
   - **Pattern**: one-line name (e.g. "Debounce git-status pollers behind window visibility").
   - **Why it helped**: which bottleneck it addressed, with the metric delta from the summary.
   - **How to recognize when to apply**: signs in future code that the same pattern is needed.
   - **Anti-pattern to avoid**: what NOT to do.
   - **Verification**: which scenario + metric this affected.
-- Append-only. Do not delete prior entries.
+- Preserve proven history, but keep the top of the file readable as best practices for future code changes.
 
 ## Notes on agent behavior
 
 - **Stay focused.** One bottleneck at a time. Resist the urge to "while I'm here also fix..." — that breaks attribution.
 - **Trust the metric.** If fitness went up but you "feel" the code is better, revert anyway. The metric is the contract.
-- **The perf-pass repo is your sandbox.** Inside it, you may create lanes, open chats, run automations, anything that exercises ADE. The scenarios already drive this; you may extend them ONLY by adding new scenarios in `apps/desktop/src/renderer/perf/scenarios/<tab>.ts` — never by editing existing ones.
+- **The perf-pass repo is your sandbox.** Inside it, you may create lanes, open chats, push/pull throwaway branches, run automations, stash changes, and delete fixtures when needed to exercise ADE. Scenarios are guardrails; real UI audit coverage is required before you call the tab optimized. You may extend scenarios ONLY by adding new scenarios in `apps/desktop/src/renderer/perf/scenarios/<tab>.ts` — never by editing existing ones.
 - **Codex model only.** If a scenario invokes an in-ADE chat, that chat uses the `ADE_MODEL_OVERRIDE` model (gpt-5-codex by default). Scenarios opting into Claude must declare `requiresClaude: true` and you must set `ADE_PERF_ALLOW_CLAUDE=1` for them.
 - **Concurrency**: only one perf run on the machine at a time. If `~/.ade/perf-runs/` contains a `<runId>/lock` file with a live pid, refuse to start.

--- a/.agents/skills/ade-autoresearch/SKILL.md
+++ b/.agents/skills/ade-autoresearch/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: ade-autoresearch
+description: Iteratively optimize an ADE tab's CPU/memory/IPC/render performance.
+  Runs predefined scenarios, identifies bottlenecks from JSONL metrics, makes ONE
+  targeted code change per iteration, gates on tests + smoke, keeps wins on a
+  branch, and distills patterns into per-tab perf skills. Invoke when the user
+  says "optimize <tab>", "autoresearch <tab>", or "perf pass on <tab>". Drives
+  ADE pointed at the perf-pass throwaway repo; full liberty inside that repo.
+  Uses Codex/GPT models for any in-ADE AI activity unless a scenario opts into
+  Claude.
+metadata:
+  author: ADE
+  version: 0.1.0
+---
+
+# ade-autoresearch
+
+A Karpathy-style autoresearch loop for ADE perf. You (the agent) ARE the loop runner — there is no hidden script. Follow this algorithm exactly.
+
+## Inputs
+
+- `<tab>`: the tab to optimize. Must be one of: `boot`, `lanes`, `missions`, `prs`, `work`, `files`, `run`, `graph`, `review`, `history`, `automations`, `cto`, `settings`. (`boot` = cold launch + welcome + project open + remote runtime + iOS pairing — the "main ADE screen" surface above any specific tab.)
+- `<perf-pass-dir>`: throwaway git repo path. Defaults to `/Users/admin/Projects/perf pass` (note the space — quote it). Must exist, must be a git repo, must have a `perf-pass-seed` tag (or you create one on first run). Override via `ADE_PERF_PASS_DIR` env var.
+
+## Shortcuts — prefer IPC and direct launch over computer use
+
+Computer use (screenshots + clicks) is slow and noisy. Always prefer these in this order:
+
+1. **Direct IPC calls** in scenarios. Most ADE actions are exposed on `window.ade.*` — call them directly instead of clicking buttons. Examples:
+   ```ts
+   await window.ade.project.openRepo({ rootPath: "/some/repo" });
+   await window.ade.lanes.create({ name: "x", ... });
+   await window.ade.project.listRecent();
+   await window.ade.remoteRuntime.listTargets();
+   ```
+   Read `apps/desktop/src/preload/global.d.ts` for the full IPC surface.
+
+2. **Warm launch on a specific tab** without running any scenario:
+   ```bash
+   node scripts/perf-launch.mjs --tab lanes
+   node scripts/perf-launch.mjs --tab boot --no-project
+   node scripts/perf-launch.mjs --route /settings/integrations
+   ```
+   This boots ADE with perf instrumentation, navigates to the target route, and stays open. Ideal for hands-on inspection of metrics as they stream into `~/.ade/perf-runs/<runId>/events.jsonl`.
+
+3. **Single-scenario run** for a measured cycle:
+   ```bash
+   node scripts/run-perf-scenario.mjs lanes.cold-list run-id
+   node scripts/run-perf-scenario.mjs boot.idle-welcome run-id --no-project
+   ```
+
+4. **Computer use is the last resort.** Use only when no IPC exists and a click is unavoidable. Even then, prefer adding a `data-testid` and a `clickTestId` step in the scenario instead of pixel coordinates.
+
+## Setup (do once at start of run)
+
+1. **Read prior wins** at `.agents/skills/ade-perf-<tab>/SKILL.md` if it exists. These are patterns past runs discovered — do not redo them, and prefer NOT to undo them. If conflict, prefer the prior win unless your new change strictly improves on it.
+2. **Read scenario definitions** at `apps/desktop/src/renderer/perf/scenarios/<tab>.ts`. These are the *contract*. Do NOT edit them.
+3. **Verify perf-pass repo** is clean and on its seed tag:
+   ```bash
+   scripts/reset-perf-pass.sh
+   ```
+   Refuse to start if perf-pass doesn't exist — instruct the user to create it.
+4. **Create a working branch** off main:
+   ```bash
+   git checkout -b autoresearch/<tab>-$(date +%Y%m%d-%H%M)
+   ```
+5. **Set the model override** for all in-ADE AI activity: export `ADE_MODEL_OVERRIDE=gpt-5-codex` (or another GPT/Codex model id available in ADE). Don't touch this during the run.
+
+## Baseline (iteration 0)
+
+Run all scenarios for the tab. For lanes that's:
+
+```bash
+node scripts/run-perf-scenario.mjs lanes.cold-list   baseline-cold
+node scripts/run-perf-scenario.mjs lanes.switch-rapid baseline-switch
+node scripts/run-perf-scenario.mjs lanes.idle-at-rest baseline-idle
+node scripts/run-perf-scenario.mjs lanes.scroll-list  baseline-scroll
+node scripts/run-perf-scenario.mjs lanes.stress-poll  baseline-stress
+```
+
+For boot (which has a mix of project-loaded and no-project scenarios):
+
+```bash
+node scripts/run-perf-scenario.mjs boot.cold-paint     baseline-paint   --no-project
+node scripts/run-perf-scenario.mjs boot.recent-projects baseline-recent --no-project
+node scripts/run-perf-scenario.mjs boot.open-project    baseline-open   --no-project
+node scripts/run-perf-scenario.mjs boot.remote-runtime  baseline-remote
+node scripts/run-perf-scenario.mjs boot.idle-welcome    baseline-idle   --no-project
+node scripts/run-perf-scenario.mjs boot.stress-launch   baseline-stress --no-project
+```
+
+Each writes `~/.ade/perf-runs/<runId>/summary.json`. Read all summaries. Compute the **per-tab fitness** as the sum of all scenario fitness scores. Record this as `baseline_fitness`. Also record per-component breakdown so you can target the worst component.
+
+Tag the baseline commit:
+```bash
+git tag perf-baseline-<tab>-$(date +%Y%m%d)
+```
+
+## Iteration loop
+
+Stop conditions: **no fitness improvement for 10 consecutive iterations** OR user kills the run OR 50 iterations OR 4 hours wall-clock.
+
+For each iteration:
+
+### 1. Analyze
+- Read the latest set of `summary.json` files for this tab.
+- Pick the **#1 bottleneck**: the component contributing most to fitness. Tie-break by reproducibility (the bottleneck that appears across multiple scenarios > single-scenario).
+- Common bottleneck categories:
+  - **Slow IPC channel**: a channel in `summary.ipc.slowChannels` with p95 ≥ 120ms
+  - **Long task spam**: `webVitals.longTaskCount` > 5 per minute
+  - **Memory growth**: `process.rendererHeapGrowthMB` > 10 over a scenario
+  - **Render-on-scroll cost**: `marks.scroll.*` p95 high
+  - **Route transition cost**: `marks.nav.*` or `marks.switch.*` p95 high
+  - **Main CPU**: `process.mainCpuPercentP95` > 30 during idle scenarios → background pollers
+- Read the code that owns the bottleneck. Form a hypothesis.
+
+### 2. Propose ONE change
+
+Legal moves (examples — not exhaustive):
+- Memoize a hot selector with `useMemo` / `useCallback`
+- Batch IPC calls (collapse N independent invokes into one)
+- Debounce / throttle a poller
+- Virtualize a long list (`@tanstack/react-virtual` or similar)
+- Lazy-load a heavy component (`React.lazy`)
+- Replace `O(n²)` work with a Map lookup
+- Hoist a stable callback out of render
+- Skip re-renders with `React.memo` + stable props
+- Move work off the render thread (`requestIdleCallback`, microtask deferral)
+- Replace a polling interval with an event-driven subscription
+- Cache an expensive derive (only invalidate on deps change)
+
+**Forbidden moves:**
+- Editing anything under `apps/desktop/src/main/services/perf/**`
+- Editing anything under `apps/desktop/src/renderer/perf/**`
+- Editing `scripts/run-perf-scenario.mjs` or `scripts/reset-perf-pass.sh`
+- Editing test files to make them pass
+- Disabling polling/sync features outright (only debounce/throttle)
+- Removing UI features or hiding elements to bypass scenarios
+- Changing fitness weights or scenario definitions
+
+### 3. Apply the change
+One commit, focused. Conventional message: `perf(<tab>): <one-line description>`.
+
+### 4. Test gate
+Run **only the affected test files**. Never the full suite. Use the per-tab Vitest projects.
+```bash
+npm --prefix apps/desktop run typecheck
+npm --prefix apps/desktop run test -- --run path/to/affected.test.ts
+```
+If tests fail: **revert** the commit (`git reset --hard HEAD~1`), do NOT count toward plateau, try a different change targeting the same or next bottleneck.
+
+### 5. Measure
+Re-run all scenarios for the tab. Compute new per-tab fitness.
+
+### 6. Smoke gate
+For each scenario's summary, check `summary.scenarios.<id>.ok === true` and `smokeFailures.length === 0`. If any scenario failed smoke: **revert**, increment plateau counter.
+
+### 7. Decide
+- Improvement threshold: `new_fitness < best_fitness * 0.98` (≥2% better)
+- If improvement: **keep**. Update best. Reset plateau to 0. Amend the commit message with `fitness <old> → <new>`.
+- Else: **revert** (`git reset --hard HEAD~1`). Plateau += 1.
+
+### 8. Soft iteration cap
+If this iteration has been running >15 minutes wall clock (build loops, scenario flakes, etc.), abort it: revert any in-progress change, mark as a missed iteration (don't count toward plateau), move on.
+
+## Termination
+
+When stop condition hits:
+1. Print run summary: starting fitness, final fitness, %-improvement, list of kept commits (sha + message + fitness delta).
+2. Suggest the user merge the working branch into main via PR.
+3. Proceed to codification (next section).
+
+## Codify (after the run ends)
+
+Read all kept commits (`git log --oneline perf-baseline-<tab>-... HEAD`). For each, extract the **pattern** (the technique used, not the literal change). Update `.agents/skills/ade-perf-<tab>/SKILL.md`:
+
+- One entry per pattern. If a similar pattern already exists, append a refinement instead of duplicating.
+- Each entry:
+  - **Pattern**: one-line name (e.g. "Debounce git-status pollers behind window visibility").
+  - **Why it helped**: which bottleneck it addressed, with the metric delta from the summary.
+  - **How to recognize when to apply**: signs in future code that the same pattern is needed.
+  - **Anti-pattern to avoid**: what NOT to do.
+  - **Verification**: which scenario + metric this affected.
+- Append-only. Do not delete prior entries.
+
+## Notes on agent behavior
+
+- **Stay focused.** One bottleneck at a time. Resist the urge to "while I'm here also fix..." — that breaks attribution.
+- **Trust the metric.** If fitness went up but you "feel" the code is better, revert anyway. The metric is the contract.
+- **The perf-pass repo is your sandbox.** Inside it, you may create lanes, open chats, run automations, anything that exercises ADE. The scenarios already drive this; you may extend them ONLY by adding new scenarios in `apps/desktop/src/renderer/perf/scenarios/<tab>.ts` — never by editing existing ones.
+- **Codex model only.** If a scenario invokes an in-ADE chat, that chat uses the `ADE_MODEL_OVERRIDE` model (gpt-5-codex by default). Scenarios opting into Claude must declare `requiresClaude: true` and you must set `ADE_PERF_ALLOW_CLAUDE=1` for them.
+- **Concurrency**: only one perf run on the machine at a time. If `~/.ade/perf-runs/` contains a `<runId>/lock` file with a live pid, refuse to start.

--- a/.agents/skills/ade-perf-boot/SKILL.md
+++ b/.agents/skills/ade-perf-boot/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: ade-perf-boot
+description: Performance patterns discovered for ADE's cold launch and "main
+  screen" surfaces — welcome / project picker, recent projects list, project
+  open flow, remote runtime connect, iOS pairing. Read before editing files in
+  apps/desktop/src/main/main.ts, the App shell (apps/desktop/src/renderer/components/app/**),
+  project bootstrap services (apps/desktop/src/main/services/projects/**, lanes/**),
+  remote runtime services, or anything in the app's pre-tab boot path.
+  Append-only knowledge base populated by ade-autoresearch runs.
+metadata:
+  author: ade-autoresearch
+  version: 0.1.0
+  status: seed
+---
+
+# ade-perf-boot
+
+Patterns discovered for ADE's cold launch and main-screen surfaces. Each entry has run-traced provenance — do not delete entries without explicit user approval.
+
+## Scope
+
+This tab covers the code paths that run before any per-tab UI is mounted, plus the project-level chrome that appears regardless of which tab is open:
+
+- **Cold launch** — process spawn → main process bootstrap → renderer first paint → first interactive.
+- **Welcome / project picker** — when no project is loaded.
+- **Recent projects** — listing, rendering, icon resolution.
+- **Project open flow** — `project.openRepo` IPC, the load + bind path.
+- **Remote runtime** — `remoteRuntime.listTargets`, snapshot, connection lifecycle.
+- **iOS / phone pairing** — pairing status, auth, etc.
+- **App shell chrome** — sidebar, header, route transitions (the AppShell wrapping all tabs).
+
+Use `ade-autoresearch boot` to run an optimization cycle against this surface.
+
+## Scenarios this tab is benchmarked against
+
+Defined in `apps/desktop/src/renderer/perf/scenarios/boot.ts`:
+
+- `boot.cold-paint` — measures FCP / LCP / INP during cold launch (no driving).
+- `boot.recent-projects` — `project.listRecent` IPC + welcome render.
+- `boot.open-project` — `project.openRepo` round-trip for perf-pass.
+- `boot.remote-runtime` — `remoteRuntime.listTargets` cost.
+- `boot.idle-welcome` — 20s idle on welcome (no project) — catches background pollers.
+- `boot.stress-launch` — 2min idle from cold — catches startup leaks.
+
+The "no project" scenarios should be run with `--no-project` so the welcome screen renders:
+
+```bash
+node scripts/run-perf-scenario.mjs boot.idle-welcome run-id --no-project
+```
+
+## Patterns
+
+_No patterns recorded yet — populated by the first `ade-autoresearch boot` run._
+
+<!--
+Template for new entries (the autoresearch skill appends these — don't edit by hand):
+
+### Pattern: <one-line name>
+- **Why it helped**: <bottleneck + metric delta>
+- **How to recognize when to apply**: <signs in code that same pattern fits>
+- **Anti-pattern**: <what NOT to do>
+- **Verification**: <scenario + metric affected>
+- **Provenance**: run `<runId>`, commit `<sha>`, fitness `<old> → <new>`
+-->

--- a/.agents/skills/ade-perf-lanes/SKILL.md
+++ b/.agents/skills/ade-perf-lanes/SKILL.md
@@ -1,47 +1,91 @@
 ---
 name: ade-perf-lanes
-description: Performance patterns discovered for ADE's Lanes tab. Read before
-  editing files under apps/desktop/src/renderer/components/lanes/** or
-  apps/desktop/src/main/services/lanes/**. Append-only knowledge base populated
-  by ade-autoresearch runs. Skip patterns that contradict the current scenario
-  contract.
+description: Performance practices for ADE's Lanes tab. Read before editing
+  files under apps/desktop/src/renderer/components/lanes/**,
+  apps/desktop/src/renderer/state/appStore.ts, or
+  apps/desktop/src/main/services/lanes/**. Preserve these patterns unless a new
+  measured UI audit proves a better one.
 metadata:
   author: ade-autoresearch
-  version: 0.1.0
-  status: seed
+  version: 0.2.0
+  status: active
 ---
 
 # ade-perf-lanes
 
-Patterns discovered for the Lanes tab. Each entry has run-traced provenance — do not delete entries without explicit user approval.
+Use this as engineering guidance for keeping the Lanes tab fast while adding features. The Lanes tab is a dense workspace: lane list, branch selector, stack graph, Work pane, Git Actions, dialogs, history, diff viewer, and runtime/session state all coexist. Small refresh choices can easily multiply into visible UI noise.
 
-## How to use this file
+## Testing posture
 
-- Read all entries before making any change in lanes code.
-- If a proposed change conflicts with an entry: prefer the entry. If you believe you can do better, run `ade-autoresearch lanes` and prove it with metrics.
-- New entries are appended by `ade-autoresearch` at the end of each run.
+- Test the actual `/lanes` route in the Electron dev app. Do not treat the Work tab with a lane selector as Lanes parity.
+- Drive visible UI actions and mark each segment with `window.ade.perf.recordEvent({ kind: "manualStep", ... })`. Deterministic scenarios are regression guards, not a substitute for clicking through the tab.
+- Keep a private `perf-pass` GitHub repo available for real fetch/push/pull behavior. It is safe to create throwaway lanes, commits, stashes, and branches there.
+- When an action is destructive or externally visible, exercise the prompt/preflight by default. Execute the final action only when the user has allowed it or the target is clearly disposable.
 
-## Scenarios this tab is benchmarked against
+## Refresh rules
 
-Defined in `apps/desktop/src/renderer/perf/scenarios/lanes.ts`:
+- Use full decorated snapshots only when runtime decorations, conflict status, rebase suggestions, or auto-rebase state are truly needed.
+- For Git Actions local operations such as stage, commit, fetch, push, pull, and history refresh, prefer `refreshLanes({ includeStatus: true, includeSnapshots: false })`. This updates lane Git status without rebuilding runtime/rebase/conflict snapshot decorations.
+- For runtime-only updates from Work pane sessions, use `refreshLanes({ includeStatus: false, includeSnapshots: true, includeConflictStatus: false, includeRebaseSuggestions: false, includeAutoRebaseStatus: false })`. Preserve prior lane Git status while refreshing runtime buckets.
+- For metadata-only updates such as lane color/appearance, use `refreshLanes({ includeStatus: false })` and preserve prior `status` / `parentStatus` in the store. A color change must not recompute Git status.
+- Avoid calling bare `refreshLanes()` from new Lanes UI handlers. Treat it as the expensive path and document why a full refresh is required.
 
-- `lanes.cold-list` — cold open of /lanes route.
-- `lanes.switch-rapid` — fast route switching to/from /lanes.
-- `lanes.idle-at-rest` — 30s on /lanes, measures background polling cost.
-- `lanes.stress-poll` — 2min on /lanes, catches leaks.
-- `lanes.scroll-list` — scroll the lanes list repeatedly.
+## Pane and poller rules
 
-## Patterns
+- Expanded/fullscreen panes must unmount the corresponding inline pane body when the duplicate would keep effects alive. CSS hiding is not enough.
+- Git Actions should have at most one active polling/effect owner per visible lane. Timers must clean up on lane switch, pane minimize, and fullscreen transitions.
+- Poll only visible or active surfaces. Hidden lanes, hidden panes, minimized panes, and closed dialogs should not keep expensive Git, PR, Linear, AI, or runtime status requests alive.
+- Background sync/local-runtime failures should be fast-pathed in disabled perf/dev modes at the IPC boundary. Do not make every renderer caller catch slow "service unavailable" failures.
+- Presence updates should be idempotent and de-duped by lane/signature so filter changes, layout switches, and tab clicks do not spam sync IPC.
 
-_No patterns recorded yet — populated by the first `ade-autoresearch lanes` run._
+## Dialog and menu rules
 
-<!--
-Template for new entries (the autoresearch skill appends these — don't edit by hand):
+- Fetch heavy dialog data on open, not on page load. Branch lists, Linear issues, unregistered worktrees, delete-risk preflights, and PR metadata should be lazy and cancelable.
+- Do not precompute delete, rebase, merge, force-push, or cherry-pick risk for every lane. Compute it only when the user opens that flow.
+- Color/appearance changes should update cheaply. They are not a reason to rebuild snapshots or rerun Git status.
+- Create-lane flows may be expensive because they create worktrees and initialize environment state. Keep that cost isolated to submit; opening and editing the dialog should stay light.
 
-### Pattern: <one-line name>
-- **Why it helped**: <bottleneck + metric delta>
-- **How to recognize when to apply**: <signs in code that same pattern fits>
-- **Anti-pattern**: <what NOT to do>
-- **Verification**: <scenario + metric affected>
-- **Provenance**: run `<runId>`, commit `<sha>`, fitness `<old> → <new>`
--->
+## Git Actions rules
+
+- Keep local change operations scoped. Stage, unstage, commit, stash, and discard should refresh the active lane's change model and lane Git status, not all snapshot decorations.
+- History and diff controls should fetch only the selected commit/file data. Split/unified, wrap, line-number, and copy-path controls should be renderer-local after the file/patch is loaded.
+- Network actions are allowed to cost real time. `fetch`, `push`, and child-lane creation can dominate a trace; do not optimize them by hiding progress or skipping correctness checks.
+- Save Changes currently stashes tracked changes and can leave untracked files visible. If changing that behavior, treat it as functionality work and add tests before using it as a perf cleanup.
+
+## Proven patterns
+
+### Skip disabled local runtime bridge calls
+- **Why it helped**: When `ADE_DISABLE_LOCAL_RUNTIME_DAEMON=1`, preload still attempted local-runtime action/sync/event IPC before falling back to desktop IPC. Real `/lanes` runs showed slow `ade.localRuntime.*` spans and `lanes.idle-at-rest` hit V8 OOM before summary.
+- **Apply when**: Perf/dev launches disable the daemon but traces show slow `ade.localRuntime.callAction`, `ade.localRuntime.callSync`, or `ade.localRuntime.streamEvents`.
+- **Avoid**: Renderer-only caches that hide the symptom while the unavailable transport still burns time.
+- **Verification**: Baseline `lanes-20260511-1721-real-baseline-*` had local-runtime slow channels and idle OOM. Post-change `lanes-20260511-1725-real-optimized-{cold,switch,idle,scroll,stress}` passed with total fitness `7028.82` and no `ade.localRuntime.*` channels.
+
+### Suppress hidden duplicate fullscreen pane bodies
+- **Why it helped**: Expanding Git Actions mounted the fullscreen pane while leaving the inline `LaneGitActionsPane` body alive, producing duplicate toolbars and duplicated effects.
+- **Apply when**: A Lanes expanded/fullscreen overlay reuses pane configs and a DOM snapshot shows duplicate pane bodies or repeated test regions while only one is visible.
+- **Avoid**: CSS-only hiding for duplicate pane bodies.
+- **Verification**: Git Actions expand went from 2 toolbars to 1. IPC dropped from 30 calls / 223 ms in `lanes-expand-prefix-20260511` to 29 calls / 192 ms in `lanes-expand-postfix-20260511`.
+
+### Fast-path disabled sync status and presence
+- **Why it helped**: Perf-mode Lanes traces hit `ade.sync.getStatus` and `ade.sync.setActiveLanePresence` even though the local runtime daemon and in-process sync service were unavailable. Failed calls cost about 250-370 ms each.
+- **Apply when**: `ADE_DISABLE_LOCAL_RUNTIME_DAEMON=1` and traces show failed `ade.sync.*` calls with "Sync service is not available."
+- **Avoid**: Removing Lanes presence calls globally or catching every failure in the renderer.
+- **Verification**: `lanes-expand-postfix-20260511` had 4 failed sync IPC calls totaling 1145 ms. `lanes-sync-postfix-20260511` had 3 successful sync IPC calls totaling 2 ms.
+
+### Scope Git Actions refreshes to lane status
+- **Why it helped**: Stage/commit/fetch used to call full `listSnapshots`, rebuilding runtime and decoration state for local Git actions. The scoped path keeps status fresh and skips snapshot decorations.
+- **Apply when**: A Git Actions handler finishes local Git work and calls bare `refreshLanes()`.
+- **Avoid**: Recomputing runtime/rebase/conflict decorations after every stage, commit, stash, fetch, or history refresh.
+- **Verification**: Before the change, `lanes-full-ui-audit-20260511-01` stage cycle spent 551 ms in `ade.lanes.listSnapshots`; commit spent 278 ms in `listSnapshots`. After the change, `lanes-refresh-light-20260511` stage used `ade.lanes.list` at 40 ms with no `listSnapshots`, and typed commit used `ade.lanes.list` at 213 ms with no `listSnapshots`.
+
+### Split runtime refresh from Git status refresh
+- **Why it helped**: Work pane pty/chat updates need runtime buckets, not fresh Git status for every lane. Runtime-only snapshot refresh avoids Git-status recompute while preserving prior status in store.
+- **Apply when**: A session/runtime event updates running/awaiting/ended counts.
+- **Avoid**: Calling full snapshots with `includeStatus:true` for runtime-only changes.
+- **Verification**: `lanes-refresh-light-20260511` runtime snapshot refresh used `ade.lanes.listSnapshots` with `includeStatus:false`; the only runtime snapshot call was 76 ms while prior Git status stayed intact.
+
+### Keep appearance refresh metadata-only
+- **Why it helped**: Lane color changes in manage/context flows previously refreshed full decorated snapshots. Appearance is metadata and should use the statusless list path while preserving previous Git status in the store.
+- **Apply when**: New lane metadata or appearance handlers update color/name/description without changing branch state.
+- **Avoid**: Bare `refreshLanes()` after appearance-only updates.
+- **Verification**: Real UI manage-dialog trace `lanes-refresh-light-20260511` showed `ade.lanes.updateAppearance` at 1 ms followed by an unnecessary `ade.lanes.listSnapshots` at 308 ms. The lightweight path uses `refreshLanes({ includeStatus: false })` instead.

--- a/.agents/skills/ade-perf-lanes/SKILL.md
+++ b/.agents/skills/ade-perf-lanes/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: ade-perf-lanes
+description: Performance patterns discovered for ADE's Lanes tab. Read before
+  editing files under apps/desktop/src/renderer/components/lanes/** or
+  apps/desktop/src/main/services/lanes/**. Append-only knowledge base populated
+  by ade-autoresearch runs. Skip patterns that contradict the current scenario
+  contract.
+metadata:
+  author: ade-autoresearch
+  version: 0.1.0
+  status: seed
+---
+
+# ade-perf-lanes
+
+Patterns discovered for the Lanes tab. Each entry has run-traced provenance — do not delete entries without explicit user approval.
+
+## How to use this file
+
+- Read all entries before making any change in lanes code.
+- If a proposed change conflicts with an entry: prefer the entry. If you believe you can do better, run `ade-autoresearch lanes` and prove it with metrics.
+- New entries are appended by `ade-autoresearch` at the end of each run.
+
+## Scenarios this tab is benchmarked against
+
+Defined in `apps/desktop/src/renderer/perf/scenarios/lanes.ts`:
+
+- `lanes.cold-list` — cold open of /lanes route.
+- `lanes.switch-rapid` — fast route switching to/from /lanes.
+- `lanes.idle-at-rest` — 30s on /lanes, measures background polling cost.
+- `lanes.stress-poll` — 2min on /lanes, catches leaks.
+- `lanes.scroll-list` — scroll the lanes list repeatedly.
+
+## Patterns
+
+_No patterns recorded yet — populated by the first `ade-autoresearch lanes` run._
+
+<!--
+Template for new entries (the autoresearch skill appends these — don't edit by hand):
+
+### Pattern: <one-line name>
+- **Why it helped**: <bottleneck + metric delta>
+- **How to recognize when to apply**: <signs in code that same pattern fits>
+- **Anti-pattern**: <what NOT to do>
+- **Verification**: <scenario + metric affected>
+- **Provenance**: run `<runId>`, commit `<sha>`, fitness `<old> → <new>`
+-->

--- a/.agents/skills/ade-perf-work/SKILL.md
+++ b/.agents/skills/ade-perf-work/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: ade-perf-work
+description: Performance and UX patterns discovered for ADE's Work tab, including chat/CLI/shell launch surfaces, the Work tools pane, Git/Files/iOS/App Control/Browser/Mac VM panels, and local-runtime-disabled perf runs. Read before editing Work tab code.
+metadata:
+  author: ADE
+  version: 0.1.0
+---
+
+# ade-perf-work
+
+Read this before editing Work tab surfaces:
+
+- `apps/desktop/src/renderer/components/terminals/**`
+- `apps/desktop/src/renderer/components/chat/**` when mounted from Work
+- `apps/desktop/src/renderer/components/lanes/LaneGitActionsPane.tsx`
+- `apps/desktop/src/renderer/components/lanes/CommitTimeline.tsx`
+- `apps/desktop/src/renderer/components/files/FilesPage.tsx` when embedded
+- `apps/desktop/src/preload/preload.ts`
+- `apps/desktop/src/main/services/ipc/registerIpc.ts`
+- Work-facing tool services for iOS Simulator, App Control, built-in browser, and macOS VM
+
+## Measurement pattern
+
+Use the real Work tab first. For local perf runs, reset and open the perf-pass repo:
+
+```bash
+scripts/reset-perf-pass.sh
+NO_DEVTOOLS=1 ADE_DISABLE_LOCAL_RUNTIME_DAEMON=1 ADE_LOCAL_RUNTIME_FALLBACK=1 ADE_MODEL_OVERRIDE=gpt-5-codex \
+  node scripts/perf-launch.mjs --tab work --run-id work-ui-audit-<date>-<n>
+```
+
+Drive actual Work UI actions and record `work.audit.*` markers for:
+
+- session search/filter, tab/grid, Chat/CLI/Shell mode switches
+- model picker, attachment picker, slash command picker, parallel model configuration
+- Work tools pane open/close
+- Git: status, More menu, history refresh, diff selection
+- Files: mount and path filtering
+- iOS Sim, App Control, Browser, Mac VM panel mounts
+
+Fixed scenario files are optional evidence. The important proof is a UI-derived run over `~/.ade/perf-runs/<runId>/events.jsonl` plus focused tests for any fixed behavior.
+
+## Current known wins
+
+### Skip the local runtime bridge when the local daemon is disabled
+
+In Work perf runs with `ADE_DISABLE_LOCAL_RUNTIME_DAEMON=1`, the preload bridge must not try `ade.localRuntime.callAction`, `ade.localRuntime.callSync`, or `ade.localRuntime.streamEvents` for local project bindings.
+
+Measured Work cold run:
+
+- Before: `67` failed `ade.localRuntime.*` IPC calls, `19,427ms` aggregate failed IPC time.
+- After: `0` failed `ade.localRuntime.*` IPC calls.
+
+Keep the preload guard in `apps/desktop/src/preload/preload.ts` intact. If changing project binding or remote runtime event pump logic, re-run a local-runtime-disabled Work audit and confirm local runtime IPC remains zero.
+
+### Fast-path sync status when the local runtime daemon is disabled
+
+`ade.sync.getStatus` is called during Work startup and periodically from shell chrome. In local-runtime-disabled runs it must not spawn the disabled runtime or fail before falling back.
+
+Measured Work run:
+
+- Before sync fix: `ade.sync.getStatus` failed and consumed `606ms` across two calls in the startup window.
+- After: the same status path returned successfully in `0-1ms`.
+
+Keep the unavailable sync snapshot in `apps/desktop/src/main/services/ipc/registerIpc.ts`. It is a perf-mode/status fallback, not a replacement for real sync service behavior.
+
+### Work tools pane must remain operable when narrow
+
+The Work tools pane can be narrow after the session list, chat surface, and tools pane are all visible. Do not assume all tab labels fit. The tab strip should collapse to icon buttons under narrow widths while preserving `aria-label`, tooltips, and stable hit targets.
+
+Measured UI pass after compact tabs:
+
+- Git, Files, iOS Sim, App Control, Browser, and Mac VM tabs were all visible and clickable in the narrow tools pane.
+- No tools tab had a bounding rect beyond the renderer viewport.
+
+If changing `WorkSidebar`, verify with a small Work pane and a larger audit window. The target is no clipped or unreachable tool tabs, not merely no TypeScript errors.
+
+### Missing lane worktrees are lane state, not raw Git errors
+
+The perf-pass repo can contain lane records and branches while the physical `.ade/worktrees/<lane>` directory is missing. The Git history panel previously surfaced raw messages like `git working directory not found: ...` through Electron IPC.
+
+Work UI should show an operational lane-state message:
+
+```text
+Lane worktree is missing. Restore or recreate the lane worktree at <path> before viewing history.
+```
+
+Do not expose the raw `Error invoking remote method ...` prefix in Work Git history. When reproducing, remove a lane worktree directory from perf-pass, open Work > Git > History, and refresh.
+
+## Watch list
+
+- `ade.github.getStatus` remains the largest Work startup IPC in measured runs, around `630-700ms`. Treat it as the next likely target, but verify whether it is shell-wide status work or Git-pane-specific before changing it.
+- Browser panel mount creates built-in browser tabs and can cost about `400-500ms` per tab creation in UI probes. Optimize only after checking that tab reuse and hidden WebContentsView bounds behavior remain correct.
+- iOS Simulator and macOS VM status calls are visible costs when those panels mount. Keep them lazy to the active tools tab.
+- Avoid hidden panel polling. App Control, iOS Simulator, Browser, and Mac VM should subscribe or poll only while their tab is active, unless a feature explicitly needs background state.

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -8,6 +8,9 @@ type NodePtyType = typeof NodePty;
 import { isAdeMcpNamedPipePath } from "../shared/adeMcpIpc";
 import { registerIpc } from "./services/ipc/registerIpc";
 import { createFileLogger } from "./services/logging/logger";
+import { initPerfRunFromEnv } from "./services/perf/perfLog";
+import { startMetricsSampler } from "./services/perf/metricsSampler";
+import { registerPerfIpcHandlers } from "./services/perf/perfIpc";
 import { openKvDb } from "./services/state/kvDb";
 import { ensureAdeDirs } from "./services/state/projectState";
 import {
@@ -790,6 +793,12 @@ app.on("open-file", (event, filePath) => {
 });
 
 app.whenReady().then(async () => {
+  // Perf run init — must come first so subsequent IPC + sampler hooks can see the active run.
+  const perfRun = initPerfRunFromEnv();
+  if (perfRun) {
+    startMetricsSampler();
+  }
+
   /** Canonical artifacts dir for the active project; ade-artifact:// only serves under this path. */
   let adeArtifactAllowedDir: string | null = null;
 
@@ -5543,6 +5552,8 @@ app.whenReady().then(async () => {
     globalStatePath,
     builtInBrowserService,
   });
+
+  registerPerfIpcHandlers();
 
   // Restore the startup project before the renderer boots so packaged launches
   // do not flash into the welcome state and lose the previous project context.

--- a/apps/desktop/src/main/services/git/gitOperationsService.test.ts
+++ b/apps/desktop/src/main/services/git/gitOperationsService.test.ts
@@ -14,7 +14,10 @@ vi.mock("./git", () => ({
 
 import { createGitOperationsService } from "./gitOperationsService";
 
-function createTestGitOperationsService(branchRef = "feature/stash-test") {
+function createTestGitOperationsService(
+  branchRef = "feature/stash-test",
+  overrides: { worktreePath?: string } = {},
+) {
   const mockStart = vi.fn().mockReturnValue({ operationId: "op-1" });
   const mockFinish = vi.fn();
 
@@ -23,7 +26,7 @@ function createTestGitOperationsService(branchRef = "feature/stash-test") {
       getLaneBaseAndBranch: vi.fn().mockReturnValue({
         baseRef: "main",
         branchRef,
-        worktreePath: "/tmp/ade-lane",
+        worktreePath: overrides.worktreePath ?? "/tmp/ade-lane",
         laneType: "worktree",
       }),
     } as any,
@@ -529,6 +532,21 @@ describe("gitOperationsService cached lane reads", () => {
     expect(first).toEqual(second);
     expect(mockGit.runGitOrThrow).toHaveBeenCalledTimes(1);
     expect(mockGit.runGit).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a missing lane worktree as lane state for commit history", async () => {
+    mockGit.runGitOrThrow.mockRejectedValue(
+      new Error("git working directory not found: /tmp/missing-lane"),
+    );
+
+    const { service } = createTestGitOperationsService("feature/stash-test", {
+      worktreePath: "/tmp/missing-lane",
+    });
+
+    await expect(service.listRecentCommits({ laneId: "lane-1", limit: 20 })).rejects.toThrow(
+      "Lane worktree is missing. Restore or recreate the lane worktree at /tmp/missing-lane before viewing history.",
+    );
+    expect(mockGit.runGit).not.toHaveBeenCalled();
   });
 
   it("parses file history entries for modified and renamed files", async () => {

--- a/apps/desktop/src/main/services/git/gitOperationsService.ts
+++ b/apps/desktop/src/main/services/git/gitOperationsService.ts
@@ -303,6 +303,17 @@ export function createGitOperationsService({
     return error instanceof Error ? error : new Error(message);
   }
 
+  function isMissingWorktreeError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return /git working directory not found:/i.test(message);
+  }
+
+  function laneWorktreeMissingError(lane: LaneInfo): Error {
+    return new Error(
+      `Lane worktree is missing. Restore or recreate the lane worktree at ${lane.worktreePath} before viewing history.`,
+    );
+  }
+
   const runLaneOperation = async <T>({
     laneId,
     kind,
@@ -582,10 +593,16 @@ export function createGitOperationsService({
       const limit = typeof args.limit === "number" ? Math.max(1, Math.min(200, Math.floor(args.limit))) : 30;
       return readLaneCached(`recent-commits:${laneId}:${limit}`, 2_000, async () => {
         const lane = laneService.getLaneBaseAndBranch(laneId);
-        const out = await runGitOrThrow(
-          ["log", `-n${limit}`, "--date=iso-strict", "--pretty=format:%H%x1f%h%x1f%P%x1f%an%x1f%aI%x1f%s"],
-          { cwd: lane.worktreePath, timeoutMs: 15_000 }
-        );
+        let out: string;
+        try {
+          out = await runGitOrThrow(
+            ["log", `-n${limit}`, "--date=iso-strict", "--pretty=format:%H%x1f%h%x1f%P%x1f%an%x1f%aI%x1f%s"],
+            { cwd: lane.worktreePath, timeoutMs: 15_000 }
+          );
+        } catch (error) {
+          if (isMissingWorktreeError(error)) throw laneWorktreeMissingError(lane);
+          throw error;
+        }
 
         // Determine which commits are unpushed by comparing with upstream.
         let unpushedShas: Set<string> | null = null;

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -1765,14 +1765,88 @@ export function registerIpc({
     if (getSyncService) return getSyncService() ?? null;
     return getCtx().syncService ?? null;
   };
+  const resolveOptionalSyncService = async (): Promise<ReturnType<typeof createSyncService> | null> =>
+    resolveSyncService
+      ? (await resolveSyncService()) ?? null
+      : getOptionalSyncService();
+  const localRuntimeDaemonDisabled =
+    process.env.ADE_DISABLE_LOCAL_RUNTIME_DAEMON === "1";
   const allowLocalRuntimeFallback =
     process.env.ADE_LOCAL_RUNTIME_FALLBACK === "1" ||
-    process.env.ADE_DISABLE_LOCAL_RUNTIME_DAEMON === "1";
+    localRuntimeDaemonDisabled;
+
+  const buildUnavailableSyncSnapshot = (): SyncRoleSnapshot => {
+    const now = new Date().toISOString();
+    const platform =
+      process.platform === "darwin"
+        ? "macOS"
+        : process.platform === "win32"
+          ? "windows"
+          : process.platform === "linux"
+            ? "linux"
+            : "unknown";
+    const localDevice: SyncDeviceRecord = {
+      deviceId: "local-runtime-disabled",
+      siteId: "local-runtime-disabled",
+      name: "Local desktop",
+      platform,
+      deviceType: "desktop",
+      createdAt: now,
+      updatedAt: now,
+      lastSeenAt: now,
+      lastHost: null,
+      lastPort: null,
+      tailscaleIp: null,
+      ipAddresses: [],
+      metadata: { unavailableReason: "local_runtime_daemon_disabled" },
+    };
+    return {
+      mode: "standalone",
+      role: "brain",
+      localDevice,
+      currentBrain: localDevice,
+      clusterState: null,
+      bootstrapToken: null,
+      pairingPin: null,
+      pairingPinConfigured: false,
+      pairingConnectInfo: null,
+      connectedPeers: [],
+      tailnetDiscovery: {
+        state: "disabled",
+        serviceName: "ade-sync",
+        servicePort: 0,
+        target: null,
+        updatedAt: null,
+        error: null,
+        stderr: null,
+      },
+      client: {
+        state: "disconnected",
+        host: null,
+        port: null,
+        connectedAt: null,
+        lastSeenAt: null,
+        latencyMs: null,
+        syncLag: null,
+        lastRemoteDbVersion: 0,
+        brainDeviceId: localDevice.deviceId,
+        hostName: localDevice.name,
+        error: null,
+        message: "Sync service unavailable in local runtime disabled mode.",
+        savedDraft: null,
+      },
+      transferReadiness: {
+        ready: true,
+        blockers: [],
+        survivableState: [],
+      },
+      survivableStateText: "Sync service unavailable in local runtime disabled mode.",
+      blockingStateText: "",
+    };
+  };
 
   const requireSyncService = async (): Promise<ReturnType<typeof createSyncService>> => {
-    const service = resolveSyncService
-      ? await resolveSyncService()
-      : getOptionalSyncService();
+    const service = await resolveOptionalSyncService();
     if (!service) {
       throw new Error("Sync service is not available.");
     }
@@ -1792,6 +1866,7 @@ export function registerIpc({
     event: { sender: Electron.WebContents },
     action: (pool: LocalRuntimeConnectionPool, rootPath: string) => Promise<T>,
   ): Promise<T | null> => {
+    if (localRuntimeDaemonDisabled) return null;
     if (!localRuntimeConnectionPool) return null;
     const rootPath = getLocalRuntimeRootForEvent(event);
     if (!rootPath) return null;
@@ -4076,7 +4151,12 @@ export function registerIpc({
       pool.syncStatusForRoot(rootPath, arg ?? {})
     );
     if (runtimeStatus) return runtimeStatus;
-    return await (await requireSyncService()).getStatus({
+    const service = await resolveOptionalSyncService();
+    if (!service) {
+      if (localRuntimeDaemonDisabled) return buildUnavailableSyncSnapshot();
+      throw new Error("Sync service is not available.");
+    }
+    return await service.getStatus({
       includeTransferReadiness: arg?.includeTransferReadiness,
       forceTransferReadiness: arg?.forceTransferReadiness,
     });
@@ -4204,7 +4284,7 @@ export function registerIpc({
     async (event, arg: { laneIds?: string[] | null }): Promise<void> => {
       const laneIds = Array.isArray(arg?.laneIds) ? arg.laneIds : [];
       const rootPath = getLocalRuntimeRootForEvent(event);
-      if (localRuntimeConnectionPool && rootPath) {
+      if (!localRuntimeDaemonDisabled && localRuntimeConnectionPool && rootPath) {
         try {
           await localRuntimeConnectionPool.callSyncForRoot(rootPath, "sync.setActiveLanePresence", { laneIds });
           return;
@@ -4214,9 +4294,12 @@ export function registerIpc({
           }
         }
       }
-      await (await requireSyncService()).setActiveLanePresence(
-        laneIds,
-      );
+      const service = await resolveOptionalSyncService();
+      if (!service) {
+        if (localRuntimeDaemonDisabled) return;
+        throw new Error("Sync service is not available.");
+      }
+      await service.setActiveLanePresence(laneIds);
     },
   );
 

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { IPC } from "../../../shared/ipc";
 import { getModelById } from "../../../shared/modelRegistry";
+import { appendEvent as perfAppend, isRunActive as isPerfRunActive } from "../perf/perfLog";
 import { buildPrAiResolutionContextKey } from "../../../shared/types";
 import { launchPrIssueResolutionChat, previewPrIssueResolutionPrompt } from "../prs/prIssueResolver";
 import { launchRebaseResolutionChat } from "../prs/prRebaseResolver";
@@ -2041,6 +2042,16 @@ export function registerIpc({
     durationMs: number;
     failed: boolean;
   }) => {
+    if (isPerfRunActive()) {
+      perfAppend({
+        ts: Date.now(),
+        kind: "ipcInvoke",
+        channel: input.channel,
+        winId: input.winId,
+        durationMs: input.durationMs,
+        failed: input.failed,
+      });
+    }
     const key = `${input.winId ?? "none"}:${input.channel}`;
     const existing = ipcInvokeAggregates.get(key) ?? {
       channel: input.channel,

--- a/apps/desktop/src/main/services/perf/aggregator.ts
+++ b/apps/desktop/src/main/services/perf/aggregator.ts
@@ -1,0 +1,378 @@
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+type Event = { ts: number; kind: string; [key: string]: unknown };
+
+type ProcessMetricSample = {
+  ts: number;
+  processes: Array<{
+    pid: number;
+    type: string;
+    cpuPercent: number;
+    workingSetSizeKb: number;
+  }>;
+  mainRss: number;
+  mainHeapUsed: number;
+};
+
+type RendererMemSample = { ts: number; usedMB: number };
+
+type WebVitalSample = {
+  ts: number;
+  metric: "INP" | "FCP" | "CLS" | "LCP";
+  value: number;
+  scenario: string | null;
+};
+
+type IpcSample = {
+  ts: number;
+  channel: string;
+  durationMs: number;
+  failed: boolean;
+  scenario: string | null;
+};
+
+type MeasureSample = {
+  ts: number;
+  name: string;
+  durationMs: number;
+  scenario: string | null;
+};
+
+type LongTaskSample = { ts: number; durationMs: number; scenario: string | null };
+
+type Summary = {
+  runId: string;
+  startedAt: number;
+  endedAt: number;
+  durationMs: number;
+  scenarios: Record<
+    string,
+    {
+      startedAt: number;
+      endedAt: number;
+      durationMs: number;
+      ok: boolean;
+      smokeFailures: string[];
+    }
+  >;
+  fitness: {
+    score: number;
+    components: {
+      interactionLatencyP95: number;
+      inpP95: number;
+      rendererHeapGrowthMB: number;
+      mainCpuSeconds: number;
+      ipcP95TopChannels: number;
+      longTaskCount: number;
+    };
+  };
+  ipc: {
+    perChannel: Array<{
+      channel: string;
+      count: number;
+      p50: number;
+      p95: number;
+      max: number;
+      failedCount: number;
+    }>;
+    slowChannels: Array<{ channel: string; p95: number; count: number }>;
+  };
+  marks: Array<{ name: string; count: number; p50: number; p95: number; max: number }>;
+  webVitals: {
+    inpP95: number;
+    inpSamples: number;
+    fcp: number | null;
+    cls: number;
+    longTaskCount: number;
+    longTaskTotalMs: number;
+  };
+  process: {
+    mainCpuPercentP95: number;
+    mainCpuSecondsApprox: number;
+    rendererPeakRssKb: number;
+    gpuPeakRssKb: number;
+    rendererHeapGrowthMB: number;
+    rendererHeapPeakMB: number;
+  };
+};
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.floor((sorted.length - 1) * p)));
+  return sorted[idx]!;
+}
+
+function readEvents(path: string): Event[] {
+  if (!existsSync(path)) return [];
+  const text = readFileSync(path, "utf8");
+  const out: Event[] = [];
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      out.push(JSON.parse(line) as Event);
+    } catch {
+      // skip malformed line
+    }
+  }
+  return out;
+}
+
+export function aggregate(runId: string): Summary {
+  const dir = join(homedir(), ".ade", "perf-runs", runId);
+  const eventsPath = join(dir, "events.jsonl");
+  const events = readEvents(eventsPath);
+
+  if (events.length === 0) {
+    throw new Error(`No events found at ${eventsPath}`);
+  }
+
+  const startedAt = events[0]!.ts;
+  const endedAt = events[events.length - 1]!.ts;
+
+  // Group scenarios.
+  type ScenarioState = {
+    startedAt: number;
+    endedAt: number;
+    ok: boolean;
+    smokeFailures: string[];
+  };
+  const scenarios: Record<string, ScenarioState> = {};
+  let currentScenario: string | null = null;
+
+  const processSamples: ProcessMetricSample[] = [];
+  const rendererMem: RendererMemSample[] = [];
+  const webVitals: WebVitalSample[] = [];
+  const longTasks: LongTaskSample[] = [];
+  const ipcCalls: IpcSample[] = [];
+  const measures: MeasureSample[] = [];
+
+  for (const ev of events) {
+    switch (ev.kind) {
+      case "scenarioStart": {
+        const name = String(ev.scenario ?? "unknown");
+        scenarios[name] = {
+          startedAt: ev.ts,
+          endedAt: ev.ts,
+          ok: false,
+          smokeFailures: [],
+        };
+        currentScenario = name;
+        break;
+      }
+      case "scenarioEnd": {
+        const name = String(ev.scenario ?? currentScenario ?? "unknown");
+        const state = scenarios[name];
+        if (state) {
+          state.endedAt = ev.ts;
+          state.ok = ev.ok === true;
+          if (Array.isArray(ev.smokeFailures)) {
+            state.smokeFailures = ev.smokeFailures.map(String);
+          }
+        }
+        currentScenario = null;
+        break;
+      }
+      case "processMetrics": {
+        processSamples.push(ev as unknown as ProcessMetricSample);
+        break;
+      }
+      case "rendererMemory": {
+        rendererMem.push({ ts: ev.ts, usedMB: Number(ev.usedMB ?? 0) });
+        break;
+      }
+      case "webVital": {
+        webVitals.push({
+          ts: ev.ts,
+          metric: ev.metric as WebVitalSample["metric"],
+          value: Number(ev.value ?? 0),
+          scenario: currentScenario,
+        });
+        break;
+      }
+      case "longTask": {
+        longTasks.push({
+          ts: ev.ts,
+          durationMs: Number(ev.durationMs ?? 0),
+          scenario: currentScenario,
+        });
+        break;
+      }
+      case "ipcInvoke": {
+        ipcCalls.push({
+          ts: ev.ts,
+          channel: String(ev.channel ?? "unknown"),
+          durationMs: Number(ev.durationMs ?? 0),
+          failed: ev.failed === true,
+          scenario: currentScenario,
+        });
+        break;
+      }
+      case "measure": {
+        measures.push({
+          ts: ev.ts,
+          name: String(ev.name ?? "unknown"),
+          durationMs: Number(ev.durationMs ?? 0),
+          scenario: currentScenario,
+        });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  // IPC per-channel stats.
+  const ipcByChannel = new Map<string, number[]>();
+  const ipcFailed = new Map<string, number>();
+  for (const c of ipcCalls) {
+    const arr = ipcByChannel.get(c.channel) ?? [];
+    arr.push(c.durationMs);
+    ipcByChannel.set(c.channel, arr);
+    if (c.failed) ipcFailed.set(c.channel, (ipcFailed.get(c.channel) ?? 0) + 1);
+  }
+  const ipcPerChannel = [...ipcByChannel.entries()].map(([channel, durations]) => {
+    const sorted = [...durations].sort((a, b) => a - b);
+    return {
+      channel,
+      count: sorted.length,
+      p50: Math.round(percentile(sorted, 0.5)),
+      p95: Math.round(percentile(sorted, 0.95)),
+      max: Math.round(Math.max(...sorted)),
+      failedCount: ipcFailed.get(channel) ?? 0,
+    };
+  });
+  ipcPerChannel.sort((a, b) => b.p95 - a.p95);
+  const slowChannels = ipcPerChannel.filter((c) => c.p95 >= 120).map((c) => ({
+    channel: c.channel,
+    p95: c.p95,
+    count: c.count,
+  }));
+  const ipcP95TopChannels = ipcPerChannel
+    .slice(0, 5)
+    .reduce((sum, c) => sum + c.p95, 0);
+
+  // Marks per-name stats.
+  const measureByName = new Map<string, number[]>();
+  for (const m of measures) {
+    const arr = measureByName.get(m.name) ?? [];
+    arr.push(m.durationMs);
+    measureByName.set(m.name, arr);
+  }
+  const marks = [...measureByName.entries()].map(([name, durations]) => {
+    const sorted = [...durations].sort((a, b) => a - b);
+    return {
+      name,
+      count: sorted.length,
+      p50: Math.round(percentile(sorted, 0.5)),
+      p95: Math.round(percentile(sorted, 0.95)),
+      max: Math.round(Math.max(...sorted)),
+    };
+  });
+  marks.sort((a, b) => b.p95 - a.p95);
+  const interactionLatencyP95 = marks.slice(0, 3).reduce((sum, m) => sum + m.p95, 0);
+
+  // Web Vitals stats.
+  const inpValues = webVitals.filter((w) => w.metric === "INP").map((w) => w.value);
+  const inpSorted = [...inpValues].sort((a, b) => a - b);
+  const inpP95 = Math.round(percentile(inpSorted, 0.95));
+  const fcpVals = webVitals.filter((w) => w.metric === "FCP").map((w) => w.value);
+  const fcp = fcpVals.length > 0 ? Math.round(fcpVals[0]!) : null;
+  const cls = webVitals
+    .filter((w) => w.metric === "CLS")
+    .reduce((max, w) => Math.max(max, w.value), 0);
+  const longTaskCount = longTasks.length;
+  const longTaskTotalMs = Math.round(longTasks.reduce((sum, t) => sum + t.durationMs, 0));
+
+  // Process stats.
+  const mainCpu = processSamples.map(
+    (s) => s.processes.find((p) => p.type === "Browser")?.cpuPercent ?? 0
+  );
+  const mainCpuSorted = [...mainCpu].sort((a, b) => a - b);
+  const mainCpuPercentP95 = percentile(mainCpuSorted, 0.95);
+  // Approximate CPU-seconds: avg percent * total run seconds * 0.01.
+  const runSeconds = (endedAt - startedAt) / 1000;
+  const mainCpuAvg =
+    mainCpu.length > 0 ? mainCpu.reduce((a, b) => a + b, 0) / mainCpu.length : 0;
+  const mainCpuSecondsApprox = Math.round(mainCpuAvg * runSeconds * 0.01 * 100) / 100;
+
+  const rendererPeakRssKb = processSamples.reduce((peak, s) => {
+    const r = s.processes
+      .filter((p) => p.type !== "Browser" && p.type !== "GPU" && p.type !== "Utility")
+      .reduce((m, p) => Math.max(m, p.workingSetSizeKb), 0);
+    return Math.max(peak, r);
+  }, 0);
+  const gpuPeakRssKb = processSamples.reduce((peak, s) => {
+    const g = s.processes
+      .filter((p) => p.type === "GPU")
+      .reduce((m, p) => Math.max(m, p.workingSetSizeKb), 0);
+    return Math.max(peak, g);
+  }, 0);
+
+  const rendererHeapPeakMB = rendererMem.reduce((m, s) => Math.max(m, s.usedMB), 0);
+  const rendererHeapStartMB = rendererMem.length > 0 ? rendererMem[0]!.usedMB : 0;
+  const rendererHeapEndMB =
+    rendererMem.length > 0 ? rendererMem[rendererMem.length - 1]!.usedMB : 0;
+  const rendererHeapGrowthMB = Math.max(0, rendererHeapEndMB - rendererHeapStartMB);
+
+  // Fitness (lower = better).
+  const fitnessScore =
+    1.0 * interactionLatencyP95 +
+    0.8 * inpP95 +
+    0.5 * rendererHeapGrowthMB +
+    0.3 * mainCpuSecondsApprox +
+    0.2 * ipcP95TopChannels +
+    0.2 * longTaskCount;
+
+  const summary: Summary = {
+    runId,
+    startedAt,
+    endedAt,
+    durationMs: endedAt - startedAt,
+    scenarios: Object.fromEntries(
+      Object.entries(scenarios).map(([name, s]) => [
+        name,
+        {
+          startedAt: s.startedAt,
+          endedAt: s.endedAt,
+          durationMs: s.endedAt - s.startedAt,
+          ok: s.ok,
+          smokeFailures: s.smokeFailures,
+        },
+      ])
+    ),
+    fitness: {
+      score: Math.round(fitnessScore * 100) / 100,
+      components: {
+        interactionLatencyP95,
+        inpP95,
+        rendererHeapGrowthMB,
+        mainCpuSeconds: mainCpuSecondsApprox,
+        ipcP95TopChannels,
+        longTaskCount,
+      },
+    },
+    ipc: { perChannel: ipcPerChannel, slowChannels },
+    marks,
+    webVitals: {
+      inpP95,
+      inpSamples: inpValues.length,
+      fcp,
+      cls: Math.round(cls * 1000) / 1000,
+      longTaskCount,
+      longTaskTotalMs,
+    },
+    process: {
+      mainCpuPercentP95: Math.round(mainCpuPercentP95 * 100) / 100,
+      mainCpuSecondsApprox,
+      rendererPeakRssKb,
+      gpuPeakRssKb,
+      rendererHeapGrowthMB,
+      rendererHeapPeakMB,
+    },
+  };
+
+  writeFileSync(join(dir, "summary.json"), JSON.stringify(summary, null, 2));
+  return summary;
+}

--- a/apps/desktop/src/main/services/perf/metricsSampler.ts
+++ b/apps/desktop/src/main/services/perf/metricsSampler.ts
@@ -1,0 +1,43 @@
+import { app } from "electron";
+import { appendEvent, isRunActive } from "./perfLog";
+
+const SAMPLE_INTERVAL_MS = 1000;
+
+let timer: NodeJS.Timeout | null = null;
+
+export function startMetricsSampler(): void {
+  if (!isRunActive() || timer) return;
+  timer = setInterval(() => {
+    const ts = Date.now();
+    try {
+      const metrics = app.getAppMetrics().map((m) => ({
+        pid: m.pid,
+        type: m.type,
+        cpuPercent: m.cpu?.percentCPUUsage ?? 0,
+        cpuIdleWakeups: m.cpu?.idleWakeupsPerSecond ?? 0,
+        workingSetSizeKb: m.memory?.workingSetSize ?? 0,
+        peakWorkingSetSizeKb: m.memory?.peakWorkingSetSize ?? 0,
+      }));
+      const mem = process.memoryUsage();
+      appendEvent({
+        ts,
+        kind: "processMetrics",
+        processes: metrics,
+        mainRss: mem.rss,
+        mainHeapUsed: mem.heapUsed,
+        mainHeapTotal: mem.heapTotal,
+        mainExternal: mem.external,
+      });
+    } catch {
+      // Ignore — metrics are best effort.
+    }
+  }, SAMPLE_INTERVAL_MS);
+  timer.unref?.();
+}
+
+export function stopMetricsSampler(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}

--- a/apps/desktop/src/main/services/perf/perfIpc.ts
+++ b/apps/desktop/src/main/services/perf/perfIpc.ts
@@ -1,0 +1,64 @@
+import { ipcMain } from "electron";
+import { IPC } from "../../../shared/ipc";
+import { aggregate } from "./aggregator";
+import { appendEvent, getActiveRun, isRunActive } from "./perfLog";
+
+export type PerfRunConfigForRenderer = {
+  active: boolean;
+  runId: string | null;
+  scenario: string | null;
+  initialRoute: string | null;
+  allowClaude: boolean;
+  modelOverride: string | null;
+};
+
+export type PerfRecordEventArgs = {
+  ts?: number;
+  kind: string;
+  [key: string]: unknown;
+};
+
+export function registerPerfIpcHandlers(): void {
+  ipcMain.handle(IPC.perfGetConfig, (): PerfRunConfigForRenderer => {
+    const run = getActiveRun();
+    return {
+      active: run !== null,
+      runId: run?.runId ?? null,
+      scenario: run?.scenario ?? null,
+      initialRoute: run?.initialRoute ?? null,
+      allowClaude: run?.allowClaude ?? false,
+      modelOverride: run?.modelOverride ?? null,
+    };
+  });
+
+  ipcMain.handle(IPC.perfRecordEvent, (_event, args: PerfRecordEventArgs) => {
+    if (!isRunActive()) return { ok: false, reason: "no-active-run" };
+    const ts = typeof args.ts === "number" ? args.ts : Date.now();
+    const { kind, ts: _ignored, ...rest } = args;
+    appendEvent({ ts, kind: kind as never, ...rest });
+    return { ok: true };
+  });
+
+  ipcMain.handle(IPC.perfScenarioComplete, (_event, args: {
+    scenario: string;
+    ok: boolean;
+    smokeFailures?: string[];
+  }) => {
+    if (!isRunActive()) return { ok: false, reason: "no-active-run" };
+    appendEvent({
+      ts: Date.now(),
+      kind: "scenarioEnd",
+      scenario: args.scenario,
+      ok: args.ok,
+      smokeFailures: args.smokeFailures ?? [],
+    });
+    return { ok: true };
+  });
+
+  ipcMain.handle(IPC.perfFinalize, () => {
+    const run = getActiveRun();
+    if (!run) return { ok: false, reason: "no-active-run" };
+    const summary = aggregate(run.runId);
+    return { ok: true, summary };
+  });
+}

--- a/apps/desktop/src/main/services/perf/perfLog.ts
+++ b/apps/desktop/src/main/services/perf/perfLog.ts
@@ -1,0 +1,95 @@
+import { appendFileSync, mkdirSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type PerfEventKind =
+  | "scenarioStart"
+  | "scenarioEnd"
+  | "mark"
+  | "measure"
+  | "webVital"
+  | "longTask"
+  | "ipcInvoke"
+  | "processMetrics"
+  | "rendererMemory"
+  | "note";
+
+export type PerfEvent = {
+  ts: number;
+  kind: PerfEventKind;
+} & Record<string, unknown>;
+
+type PerfRunConfig = {
+  runId: string;
+  scenario: string | null;
+  initialRoute: string | null;
+  allowClaude: boolean;
+  modelOverride: string | null;
+  startedAt: number;
+  dir: string;
+  eventsPath: string;
+  summaryPath: string;
+};
+
+let active: PerfRunConfig | null = null;
+
+function readEnvRunId(): string | null {
+  const raw = process.env.ADE_PERF_RUN_ID;
+  return raw && raw.length > 0 ? raw : null;
+}
+
+function readEnvScenario(): string | null {
+  const raw = process.env.ADE_PERF_SCENARIO;
+  return raw && raw.length > 0 ? raw : null;
+}
+
+function ensureDir(path: string): void {
+  if (!existsSync(path)) mkdirSync(path, { recursive: true });
+}
+
+export function initPerfRunFromEnv(): PerfRunConfig | null {
+  if (active) return active;
+  const runId = readEnvRunId();
+  if (!runId) return null;
+  const dir = join(homedir(), ".ade", "perf-runs", runId);
+  ensureDir(dir);
+  active = {
+    runId,
+    scenario: readEnvScenario(),
+    initialRoute: process.env.ADE_PERF_INITIAL_ROUTE ?? null,
+    allowClaude: process.env.ADE_PERF_ALLOW_CLAUDE === "1",
+    modelOverride: process.env.ADE_MODEL_OVERRIDE ?? null,
+    startedAt: Date.now(),
+    dir,
+    eventsPath: join(dir, "events.jsonl"),
+    summaryPath: join(dir, "summary.json"),
+  };
+  appendEvent({
+    kind: "note",
+    ts: active.startedAt,
+    note: "perfRunStarted",
+    runId: active.runId,
+    scenario: active.scenario,
+    initialRoute: active.initialRoute,
+    allowClaude: active.allowClaude,
+    modelOverride: active.modelOverride,
+  });
+  return active;
+}
+
+export function getActiveRun(): PerfRunConfig | null {
+  return active;
+}
+
+export function isRunActive(): boolean {
+  return active !== null;
+}
+
+export function appendEvent(event: PerfEvent): void {
+  if (!active) return;
+  try {
+    appendFileSync(active.eventsPath, JSON.stringify(event) + "\n");
+  } catch {
+    // Swallow — perf logging never breaks the app.
+  }
+}

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -2339,6 +2339,27 @@ declare global {
       updateQuitAndInstall: () => Promise<boolean>;
       updateDismissInstalledNotice: () => Promise<void>;
       onUpdateEvent: (cb: (snapshot: AutoUpdateSnapshot) => void) => () => void;
+      perf: {
+        getConfig: () => Promise<{
+          active: boolean;
+          runId: string | null;
+          scenario: string | null;
+          initialRoute: string | null;
+          allowClaude: boolean;
+          modelOverride: string | null;
+        }>;
+        recordEvent: (event: {
+          kind: string;
+          ts?: number;
+          [key: string]: unknown;
+        }) => Promise<{ ok: boolean; reason?: string }>;
+        scenarioComplete: (args: {
+          scenario: string;
+          ok: boolean;
+          smokeFailures?: string[];
+        }) => Promise<{ ok: boolean; reason?: string }>;
+        finalize: () => Promise<{ ok: boolean; reason?: string; summary?: unknown }>;
+      };
     };
   }
 }

--- a/apps/desktop/src/preload/preload.test.ts
+++ b/apps/desktop/src/preload/preload.test.ts
@@ -10,6 +10,7 @@ describe("preload OAuth bridge", () => {
   afterEach(() => {
     vi.resetModules();
     vi.doUnmock("electron");
+    delete process.env.ADE_DISABLE_LOCAL_RUNTIME_DAEMON;
     delete (globalThis as any).__adeBridge;
   });
 
@@ -315,6 +316,51 @@ describe("preload OAuth bridge", () => {
 
     expect(invoke).toHaveBeenCalledWith(IPC.appGetWindowSession);
     expect(invoke).toHaveBeenCalledWith(IPC.lanesOpenFolder, { laneId: "lane-1" });
+  });
+
+  it("skips local runtime IPC when the local runtime daemon is disabled", async () => {
+    process.env.ADE_DISABLE_LOCAL_RUNTIME_DAEMON = "1";
+    const binding = {
+      kind: "local",
+      key: "local:/repo",
+      rootPath: "/repo",
+      displayName: "Project",
+    };
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === IPC.appGetWindowSession) {
+        return { windowId: 1, project: { rootPath: "/repo", displayName: "Project" }, binding };
+      }
+      if (channel === IPC.lanesList) return [];
+      throw new Error(`unexpected IPC: ${channel}`);
+    });
+    const on = vi.fn();
+    const removeListener = vi.fn();
+    const exposeInMainWorld = vi.fn((name: string, value: unknown) => {
+      (globalThis as any).__bridgeName = name;
+      (globalThis as any).__adeBridge = value;
+    });
+
+    vi.doMock("electron", () => ({
+      contextBridge: { exposeInMainWorld },
+      ipcRenderer: { invoke, on, removeListener },
+      webFrame: {
+        getZoomLevel: vi.fn(() => 0),
+        setZoomLevel: vi.fn(),
+        getZoomFactor: vi.fn(() => 1),
+      },
+    }));
+
+    await import("./preload");
+
+    const bridge = (globalThis as any).__adeBridge;
+    await expect(bridge.lanes.list()).resolves.toEqual([]);
+
+    expect(invoke).toHaveBeenCalledWith(IPC.appGetWindowSession);
+    expect(invoke).toHaveBeenCalledWith(IPC.lanesList, {});
+    expect(invoke).not.toHaveBeenCalledWith(
+      IPC.localRuntimeCallAction,
+      expect.anything(),
+    );
   });
 
   it("routes project local-data cleanup through a remote project runtime when bound", async () => {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -8302,4 +8302,15 @@ contextBridge.exposeInMainWorld("ade", {
     ipcRenderer.on(IPC.updateEvent, listener);
     return () => ipcRenderer.removeListener(IPC.updateEvent, listener);
   },
+  perf: {
+    getConfig: () => ipcRenderer.invoke(IPC.perfGetConfig),
+    recordEvent: (event: { kind: string; ts?: number; [k: string]: unknown }) =>
+      ipcRenderer.invoke(IPC.perfRecordEvent, event),
+    scenarioComplete: (args: {
+      scenario: string;
+      ok: boolean;
+      smokeFailures?: string[];
+    }) => ipcRenderer.invoke(IPC.perfScenarioComplete, args),
+    finalize: () => ipcRenderer.invoke(IPC.perfFinalize),
+  },
 });

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1029,11 +1029,14 @@ const gitBranchesCache = createKeyedShortIpcCache<GitBranchSummary[]>(
   2_000,
 );
 
+const localRuntimeDaemonDisabled =
+  process.env.ADE_DISABLE_LOCAL_RUNTIME_DAEMON === "1";
+
 const allowLocalRuntimeFallback =
   process.env.ADE_LOCAL_RUNTIME_FALLBACK !== "0" &&
   (
     process.env.ADE_LOCAL_RUNTIME_FALLBACK === "1" ||
-    process.env.ADE_DISABLE_LOCAL_RUNTIME_DAEMON === "1" ||
+    localRuntimeDaemonDisabled ||
     process.env.ADE_PACKAGE_CHANNEL === "alpha"
   );
 
@@ -1062,7 +1065,10 @@ function rememberProjectBinding(binding: OpenProjectBinding | null): void {
     projectBindingGeneration += 1;
     resetRemoteRuntimeEventDedup(nextKey);
   }
-  if (binding?.kind === "remote" || binding?.kind === "local") {
+  if (
+    binding?.kind === "remote" ||
+    (binding?.kind === "local" && !localRuntimeDaemonDisabled)
+  ) {
     ensureRemoteRuntimeEventPump();
   }
 }
@@ -1128,6 +1134,7 @@ async function callLocalProjectActionIfBound<T>(
   action: string,
   request: Omit<RemoteRuntimeActionRequest, "domain" | "action"> = {},
 ): Promise<{ handled: true; result: T } | { handled: false }> {
+  if (localRuntimeDaemonDisabled) return { handled: false };
   const binding = await getLocalProjectBinding();
   if (!binding) return { handled: false };
   try {
@@ -1194,6 +1201,7 @@ async function callLocalProjectSyncIfBound<T>(
   method: string,
   params: Record<string, unknown> = {},
 ): Promise<{ handled: true; result: T } | { handled: false }> {
+  if (localRuntimeDaemonDisabled) return { handled: false };
   const binding = await getLocalProjectBinding();
   if (!binding) return { handled: false };
   try {
@@ -1377,6 +1385,14 @@ async function pollRemoteRuntimeEvents(): Promise<void> {
   try {
     const binding = await getProjectRuntimeBinding();
     if (!binding || (binding.kind !== "remote" && binding.kind !== "local")) {
+      remoteRuntimeEventCursor = 0;
+      remoteRuntimeEventBindingKey = null;
+      remoteRuntimeEventGeneration = projectBindingGeneration;
+      remoteRuntimeEventStartedAtMs = 0;
+      resetRemoteRuntimeEventDedup(null);
+      return;
+    }
+    if (binding.kind === "local" && localRuntimeDaemonDisabled) {
       remoteRuntimeEventCursor = 0;
       remoteRuntimeEventBindingKey = null;
       remoteRuntimeEventGeneration = projectBindingGeneration;

--- a/apps/desktop/src/renderer/components/lanes/CommitTimeline.test.tsx
+++ b/apps/desktop/src/renderer/components/lanes/CommitTimeline.test.tsx
@@ -1,0 +1,38 @@
+/* @vitest-environment jsdom */
+
+import React from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CommitTimeline } from "./CommitTimeline";
+
+describe("CommitTimeline", () => {
+  afterEach(() => {
+    cleanup();
+    delete (window as any).ade;
+  });
+
+  it("shows a lane-state message when the lane worktree is missing", async () => {
+    (window as any).ade = {
+      git: {
+        listRecentCommits: vi.fn(async () => {
+          throw new Error(
+            "Error invoking remote method 'ade.git.listRecentCommits': Lane worktree is missing. Restore or recreate the lane worktree at /tmp/missing before viewing history.",
+          );
+        }),
+      },
+    };
+
+    render(
+      <CommitTimeline
+        laneId="lane-1"
+        selectedSha={null}
+        onSelectCommit={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Lane worktree is missing\./)).toBeTruthy();
+    });
+    expect(screen.getByText(/Restore or recreate the lane worktree at \/tmp\/missing before viewing history\./)).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/renderer/components/lanes/CommitTimeline.tsx
+++ b/apps/desktop/src/renderer/components/lanes/CommitTimeline.tsx
@@ -24,6 +24,16 @@ function formatRelative(ts: string): string {
   return date.toLocaleDateString();
 }
 
+function formatTimelineError(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const message = raw.replace(/^Error invoking remote method '[^']+':\s*/i, "").trim();
+  if (/^Lane worktree is missing\./i.test(message)) return message;
+  if (/git working directory not found:/i.test(message)) {
+    return "Lane worktree is missing. Restore or recreate the lane worktree before viewing history.";
+  }
+  return message || "Unable to load commit history.";
+}
+
 type CommitMeta = {
   fileCount: number | null;
   message: string | null;
@@ -65,7 +75,7 @@ export function CommitTimeline({
       const rows = await window.ade.git.listRecentCommits({ laneId, limit });
       setCommits([...rows].reverse());
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(formatTimelineError(err));
       setCommits([]);
     } finally {
       setLoading(false);

--- a/apps/desktop/src/renderer/components/terminals/WorkSidebar.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkSidebar.tsx
@@ -104,6 +104,8 @@ export function WorkSidebar({
   const [selectedCommit, setSelectedCommit] = useState<GitCommitSummary | null>(null);
   const [appControlSession, setAppControlSession] = useState<AppControlSession | null>(null);
   const [iosSession, setIosSession] = useState<IosSimulatorSession | null>(null);
+  const sidebarRef = useRef<HTMLElement | null>(null);
+  const [compactTabs, setCompactTabs] = useState(false);
 
   const activeLane = useMemo(
     () => (laneId ? lanes.find((lane) => lane.id === laneId) ?? null : null),
@@ -116,6 +118,19 @@ export function WorkSidebar({
     setSelectedMode(null);
     setSelectedCommit(null);
   }, [laneId]);
+
+  useEffect(() => {
+    const el = sidebarRef.current;
+    if (!el) return undefined;
+    const update = () => {
+      setCompactTabs(el.getBoundingClientRect().width < 460);
+    };
+    update();
+    if (typeof ResizeObserver === "undefined") return undefined;
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
   const previousBrowserTabRef = useRef(tab === "browser");
   useEffect(() => {
@@ -357,7 +372,10 @@ export function WorkSidebar({
     : activeLane?.name ?? "No active session";
 
   return (
-    <aside className="flex h-full min-h-0 min-w-[280px] flex-col border-l border-white/[0.08] bg-surface/85">
+    <aside
+      ref={sidebarRef}
+      className="flex h-full min-h-0 min-w-[280px] flex-col border-l border-white/[0.08] bg-surface/85"
+    >
       <div className="flex min-h-[42px] shrink-0 items-center gap-2 border-b border-white/[0.08] px-2 py-1.5">
         <div className="ade-liquid-glass-pill flex min-w-0 flex-1 items-center gap-0.5 rounded-full p-0.5">
           {WORK_SIDEBAR_TABS.map(({ id, label, Icon }) => {
@@ -373,7 +391,8 @@ export function WorkSidebar({
                 <button
                   type="button"
                   className={cn(
-                    "inline-flex h-7 min-w-0 shrink-0 cursor-pointer items-center gap-1.5 rounded-full border-none bg-transparent px-2 text-[10px] font-medium transition-all",
+                    "inline-flex h-7 min-w-0 shrink-0 cursor-pointer items-center rounded-full border-none bg-transparent text-[10px] font-medium transition-all",
+                    compactTabs ? "w-8 justify-center px-0" : "gap-1.5 px-2",
                     active ? "ade-work-tab-active text-fg" : "text-muted-fg",
                   )}
                   onClick={() => {
@@ -381,9 +400,11 @@ export function WorkSidebar({
                     onTabChange(id);
                   }}
                   aria-pressed={active}
+                  aria-label={label}
+                  title={label}
                 >
                   <Icon size={12} weight={active ? "fill" : "regular"} className="shrink-0" />
-                  <span className="truncate">{label}</span>
+                  <span className={compactTabs ? "sr-only" : "truncate"}>{label}</span>
                 </button>
               </SmartTooltip>
             );

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -8,6 +8,7 @@ import geistMonoVariableUrl from "../../node_modules/geist/dist/fonts/geist-mono
 import { App } from "./components/app/App";
 import { RendererErrorBoundary } from "./components/app/RendererErrorBoundary";
 import { logRendererDebugEvent } from "./lib/debugLog";
+import { initPerfRuntime } from "./perf/harness";
 
 (function injectFontFaces() {
   const style = document.createElement("style");
@@ -161,3 +162,5 @@ createRoot(document.getElementById("root")!).render(
     </RendererErrorBoundary>
   </RootWrapper>
 );
+
+void initPerfRuntime();

--- a/apps/desktop/src/renderer/perf/harness/index.ts
+++ b/apps/desktop/src/renderer/perf/harness/index.ts
@@ -1,0 +1,44 @@
+import { setPerfActive, startRendererMemorySampler } from "../markers";
+import { installWebVitalsObservers } from "../webVitals";
+import { runScenario } from "../scenarios";
+
+export async function initPerfRuntime(): Promise<void> {
+  const cfg = await window.ade?.perf?.getConfig?.();
+  if (!cfg?.active) return;
+
+  setPerfActive(true);
+  installWebVitalsObservers();
+  startRendererMemorySampler();
+
+  window.ade?.perf?.recordEvent({
+    kind: "note",
+    ts: Date.now(),
+    note: "rendererPerfReady",
+    initialRoute: cfg.initialRoute ?? null,
+    scenario: cfg.scenario ?? null,
+  });
+
+  if (cfg.initialRoute) {
+    // Navigate immediately so the warm-mode shortcut lands on the requested tab.
+    const target = cfg.initialRoute.startsWith("/")
+      ? `#${cfg.initialRoute}`
+      : cfg.initialRoute.startsWith("#")
+        ? cfg.initialRoute
+        : `#/${cfg.initialRoute}`;
+    if (window.location.hash !== target) {
+      window.location.hash = target;
+    }
+  }
+
+  if (!cfg.scenario) return;
+
+  // Defer scenario kick-off until after first paint so we measure realistic cold flows.
+  const start = () => {
+    setTimeout(() => runScenario(cfg.scenario as string), 1500);
+  };
+  if (document.readyState === "complete") {
+    start();
+  } else {
+    window.addEventListener("load", start, { once: true });
+  }
+}

--- a/apps/desktop/src/renderer/perf/markers.ts
+++ b/apps/desktop/src/renderer/perf/markers.ts
@@ -1,0 +1,81 @@
+let perfActive = false;
+
+export function setPerfActive(active: boolean): void {
+  perfActive = active;
+}
+
+export function isPerfActive(): boolean {
+  return perfActive;
+}
+
+export function perfMark(name: string, extra?: Record<string, unknown>): void {
+  if (!perfActive) return;
+  try {
+    performance.mark(name);
+  } catch {
+    // best effort
+  }
+  window.ade?.perf?.recordEvent({
+    kind: "mark",
+    ts: Date.now(),
+    name,
+    extra: extra ?? null,
+  });
+}
+
+export function perfMeasure(name: string, startMark: string, endMark?: string): number | null {
+  if (!perfActive) return null;
+  try {
+    const entry = endMark
+      ? performance.measure(name, startMark, endMark)
+      : performance.measure(name, startMark);
+    const durationMs = Math.round(entry.duration * 100) / 100;
+    window.ade?.perf?.recordEvent({
+      kind: "measure",
+      ts: Date.now(),
+      name,
+      durationMs,
+      startMark,
+      endMark: endMark ?? null,
+    });
+    return durationMs;
+  } catch {
+    return null;
+  }
+}
+
+const memoryReader = () => {
+  const perf = performance as Performance & {
+    memory?: { usedJSHeapSize?: number; totalJSHeapSize?: number };
+  };
+  if (!perf.memory) return null;
+  return {
+    usedMB: Math.round((perf.memory.usedJSHeapSize ?? 0) / 1024 / 1024),
+    totalMB: Math.round((perf.memory.totalJSHeapSize ?? 0) / 1024 / 1024),
+  };
+};
+
+let memorySamplerId: number | null = null;
+
+export function startRendererMemorySampler(): void {
+  if (memorySamplerId !== null || !perfActive) return;
+  const sample = () => {
+    const mem = memoryReader();
+    if (!mem) return;
+    window.ade?.perf?.recordEvent({
+      kind: "rendererMemory",
+      ts: Date.now(),
+      usedMB: mem.usedMB,
+      totalMB: mem.totalMB,
+    });
+  };
+  sample();
+  memorySamplerId = window.setInterval(sample, 1000);
+}
+
+export function stopRendererMemorySampler(): void {
+  if (memorySamplerId !== null) {
+    window.clearInterval(memorySamplerId);
+    memorySamplerId = null;
+  }
+}

--- a/apps/desktop/src/renderer/perf/scenarios/boot.ts
+++ b/apps/desktop/src/renderer/perf/scenarios/boot.ts
@@ -1,0 +1,101 @@
+import { registerScenario } from "./index";
+
+/**
+ * Boot-tab scenarios. These exercise the "main ADE screen" — cold launch,
+ * project picker, opening projects, remote runtime status, iOS pairing.
+ * Most of these prefer direct IPC calls over DOM clicks so they are fast
+ * and reproducible. Scenarios that need a no-project state should be launched
+ * with `--no-project` on the runner so the welcome screen renders.
+ */
+
+registerScenario({
+  id: "boot.cold-paint",
+  description: "Cold launch — measures time-to-first-paint and to-interactive without driving any UI.",
+  run: async (ctx) => {
+    ctx.mark("boot.cold-paint.tick");
+    await ctx.idle(8_000);
+    // FCP/LCP/INP samples accumulate in webVitals during this idle window.
+    ctx.assert(document.body.children.length > 0, "no body content after cold launch");
+  },
+});
+
+registerScenario({
+  id: "boot.recent-projects",
+  description: "Measures recent-projects IPC + welcome list render.",
+  run: async (ctx) => {
+    ctx.mark("recent.fetch.start");
+    const recent = await window.ade?.project?.listRecent();
+    ctx.mark("recent.fetch.done");
+    ctx.measure("recent.fetch", "recent.fetch.start", "recent.fetch.done");
+    ctx.assert(Array.isArray(recent), "project.listRecent did not return an array");
+    await ctx.idle(1_500);
+  },
+});
+
+registerScenario({
+  id: "boot.open-project",
+  description: "Times opening the perf-pass project via IPC openRepo.",
+  run: async (ctx) => {
+    const perfPass = "/Users/admin/Projects/perf pass";
+    ctx.mark("openRepo.start");
+    try {
+      // openRepo opens a directory chooser in some flows; we call with a path arg if supported,
+      // otherwise the IPC errors and we record that.
+      // The renderer-side preload signature varies; record what we got.
+      const result = await (window.ade?.project as unknown as {
+        openRepo?: (args?: { rootPath?: string }) => Promise<unknown>;
+      })?.openRepo?.({ rootPath: perfPass });
+      ctx.mark("openRepo.done");
+      ctx.measure("openRepo", "openRepo.start", "openRepo.done");
+      ctx.assert(result !== undefined, "openRepo returned undefined");
+    } catch (err) {
+      ctx.mark("openRepo.done");
+      ctx.measure("openRepo", "openRepo.start", "openRepo.done");
+      ctx.assert(false, `openRepo threw: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    await ctx.idle(3_000);
+  },
+});
+
+registerScenario({
+  id: "boot.remote-runtime",
+  description: "Times the remote runtime list-targets + snapshot path.",
+  run: async (ctx) => {
+    ctx.mark("remote.list.start");
+    try {
+      const targets = await (window.ade as unknown as {
+        remoteRuntime?: { listTargets?: () => Promise<unknown[]> };
+      }).remoteRuntime?.listTargets?.();
+      ctx.mark("remote.list.done");
+      ctx.measure("remote.list", "remote.list.start", "remote.list.done");
+      ctx.assert(targets === undefined || Array.isArray(targets), "remote.listTargets returned a non-array");
+    } catch (err) {
+      ctx.mark("remote.list.done");
+      ctx.measure("remote.list", "remote.list.start", "remote.list.done");
+      ctx.assert(false, `remote.listTargets threw: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    await ctx.idle(1_500);
+  },
+});
+
+registerScenario({
+  id: "boot.idle-welcome",
+  description: "Sit on the welcome screen for 20s — measures at-rest CPU and background pollers when no project is loaded.",
+  run: async (ctx) => {
+    // The harness skips ADE_PERF_INITIAL_ROUTE for this scenario by not setting it.
+    await ctx.idle(20_000);
+    ctx.assert(document.body.children.length > 0, "body emptied during idle");
+  },
+});
+
+registerScenario({
+  id: "boot.stress-launch",
+  description: "Long-tail at boot — 2 minutes of cold-launched idle to catch leaks in startup pollers.",
+  run: async (ctx) => {
+    for (let i = 0; i < 6; i++) {
+      await ctx.idle(20_000);
+      ctx.mark(`boot.stress.tick.${i}`);
+    }
+    ctx.assert(document.body.children.length > 0, "body emptied during boot stress");
+  },
+});

--- a/apps/desktop/src/renderer/perf/scenarios/index.ts
+++ b/apps/desktop/src/renderer/perf/scenarios/index.ts
@@ -1,0 +1,164 @@
+import { perfMark, perfMeasure } from "../markers";
+
+export type ScenarioContext = {
+  mark: (name: string) => void;
+  measure: (name: string, startMark: string, endMark?: string) => number | null;
+  /** Wait until the test condition returns truthy, or timeoutMs elapses. Returns true if found. */
+  waitFor: (testFn: () => boolean, timeoutMs?: number) => Promise<boolean>;
+  /** Wait until a DOM element with [data-testid=id] appears. */
+  waitForTestId: (id: string, timeoutMs?: number) => Promise<HTMLElement | null>;
+  /** Click an element by testid. Throws if not found within timeout. */
+  clickTestId: (id: string, timeoutMs?: number) => Promise<void>;
+  /** Navigate (hash-router style). */
+  navigate: (route: string) => Promise<void>;
+  /** Idle for ms, lets the event loop breathe and metrics samplers tick. */
+  idle: (ms: number) => Promise<void>;
+  /** Assert an invariant; pushes failure to smokeFailures if false. */
+  assert: (condition: boolean, message: string) => void;
+};
+
+export type Scenario = {
+  id: string;
+  description: string;
+  requiresClaude?: boolean;
+  run: (ctx: ScenarioContext) => Promise<void>;
+};
+
+const registry = new Map<string, Scenario>();
+
+export function registerScenario(scenario: Scenario): void {
+  if (registry.has(scenario.id)) {
+    throw new Error(`Duplicate perf scenario id: ${scenario.id}`);
+  }
+  registry.set(scenario.id, scenario);
+}
+
+export function getScenario(id: string): Scenario | null {
+  return registry.get(id) ?? null;
+}
+
+export function listScenarios(): string[] {
+  return [...registry.keys()];
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(testFn: () => boolean, timeoutMs = 10_000): Promise<boolean> {
+  const deadline = performance.now() + timeoutMs;
+  while (performance.now() < deadline) {
+    if (testFn()) return true;
+    await delay(50);
+  }
+  return false;
+}
+
+async function waitForTestId(id: string, timeoutMs = 10_000): Promise<HTMLElement | null> {
+  const deadline = performance.now() + timeoutMs;
+  while (performance.now() < deadline) {
+    const el = document.querySelector<HTMLElement>(`[data-testid="${id}"]`);
+    if (el && el.offsetParent !== null) return el;
+    await delay(50);
+  }
+  return null;
+}
+
+function makeContext(smokeFailures: string[]): ScenarioContext {
+  return {
+    mark: (name) => perfMark(name),
+    measure: (name, startMark, endMark) => perfMeasure(name, startMark, endMark),
+    waitFor,
+    waitForTestId,
+    clickTestId: async (id, timeoutMs = 5_000) => {
+      const el = await waitForTestId(id, timeoutMs);
+      if (!el) {
+        throw new Error(`clickTestId timeout: ${id}`);
+      }
+      el.click();
+    },
+    navigate: async (route) => {
+      window.location.hash = route.startsWith("#") ? route : `#${route}`;
+      await delay(50);
+    },
+    idle: (ms) => delay(ms),
+    assert: (condition, message) => {
+      if (!condition) smokeFailures.push(message);
+    },
+  };
+}
+
+async function loadScenarioModule(scenarioId: string): Promise<void> {
+  const prefix = scenarioId.split(".", 1)[0] ?? scenarioId;
+  switch (prefix) {
+    case "lanes":
+      await import("./lanes");
+      return;
+    case "boot":
+      await import("./boot");
+      return;
+    default:
+      // Best-effort: try direct import. If it fails, the scenario lookup will report not-found.
+      try {
+        await import(/* @vite-ignore */ `./${prefix}`);
+      } catch {
+        // ignore — handled by caller
+      }
+  }
+}
+
+export async function runScenario(scenarioId: string): Promise<void> {
+  await loadScenarioModule(scenarioId);
+
+  const scenario = getScenario(scenarioId);
+  if (!scenario) {
+    window.ade?.perf?.recordEvent({
+      kind: "note",
+      ts: Date.now(),
+      note: "scenarioNotFound",
+      scenario: scenarioId,
+    });
+    return;
+  }
+
+  const cfg = await window.ade?.perf?.getConfig?.();
+  if (scenario.requiresClaude && !cfg?.allowClaude) {
+    await window.ade?.perf?.scenarioComplete({
+      scenario: scenarioId,
+      ok: false,
+      smokeFailures: ["requiresClaude but ADE_PERF_ALLOW_CLAUDE not set"],
+    });
+    return;
+  }
+
+  const smokeFailures: string[] = [];
+  const ctx = makeContext(smokeFailures);
+
+  window.ade?.perf?.recordEvent({
+    kind: "scenarioStart",
+    ts: Date.now(),
+    scenario: scenarioId,
+    description: scenario.description,
+  });
+
+  let ok = true;
+  try {
+    await scenario.run(ctx);
+  } catch (err) {
+    ok = false;
+    smokeFailures.push(err instanceof Error ? err.message : String(err));
+  }
+
+  await window.ade?.perf?.scenarioComplete({
+    scenario: scenarioId,
+    ok: ok && smokeFailures.length === 0,
+    smokeFailures,
+  });
+
+  // Auto-finalize so the harness script can detect summary.json appearing.
+  try {
+    await window.ade?.perf?.finalize();
+  } catch {
+    // ignore
+  }
+}

--- a/apps/desktop/src/renderer/perf/scenarios/lanes.ts
+++ b/apps/desktop/src/renderer/perf/scenarios/lanes.ts
@@ -1,0 +1,94 @@
+import { registerScenario, type ScenarioContext } from "./index";
+
+async function navigateToLanes(ctx: ScenarioContext): Promise<void> {
+  ctx.mark("nav.lanes.start");
+  await ctx.navigate("/lanes");
+  const present = await ctx.waitFor(
+    () => document.querySelector("[data-route='lanes'], main") !== null,
+    8_000
+  );
+  ctx.mark("nav.lanes.done");
+  ctx.measure("nav.lanes", "nav.lanes.start", "nav.lanes.done");
+  ctx.assert(present, "lanes route did not render main content");
+}
+
+registerScenario({
+  id: "lanes.cold-list",
+  description: "Cold open of /lanes — measures route mount, first render, settle.",
+  run: async (ctx) => {
+    await navigateToLanes(ctx);
+    await ctx.idle(5_000);
+    // Smoke: at least one heading-like element exists.
+    const hasHeading = !!document.querySelector("h1, h2, [role='heading']");
+    ctx.assert(hasHeading, "no heading visible after lanes mount");
+  },
+});
+
+registerScenario({
+  id: "lanes.switch-rapid",
+  description: "Rapid route switching to/from lanes — measures route transition cost.",
+  run: async (ctx) => {
+    const routes = ["/lanes", "/work", "/lanes", "/files", "/lanes", "/prs", "/lanes"];
+    for (let i = 0; i < routes.length; i++) {
+      const route = routes[i]!;
+      const tag = route.replace(/\W+/g, "_") + "_" + i;
+      ctx.mark(`switch.${tag}.start`);
+      await ctx.navigate(route);
+      await ctx.waitFor(() => document.querySelector("main") !== null, 5_000);
+      ctx.mark(`switch.${tag}.done`);
+      ctx.measure(`switch.${tag}`, `switch.${tag}.start`, `switch.${tag}.done`);
+      await ctx.idle(300);
+    }
+    ctx.assert(
+      window.location.hash.includes("lanes") || window.location.pathname.includes("lanes"),
+      "final route is not /lanes"
+    );
+  },
+});
+
+registerScenario({
+  id: "lanes.idle-at-rest",
+  description: "Sit on /lanes for 30s — measures at-rest CPU/memory and background polling.",
+  run: async (ctx) => {
+    await navigateToLanes(ctx);
+    await ctx.idle(30_000);
+    ctx.assert(document.querySelector("main") !== null, "main vanished during idle");
+  },
+});
+
+registerScenario({
+  id: "lanes.stress-poll",
+  description: "Sit on /lanes for 2 minutes — catches memory leaks and polling regressions.",
+  run: async (ctx) => {
+    await navigateToLanes(ctx);
+    // Force window focus loops to exercise visibility-driven pollers.
+    for (let i = 0; i < 6; i++) {
+      await ctx.idle(20_000);
+      ctx.mark(`stress.tick.${i}`);
+    }
+    ctx.assert(document.querySelector("main") !== null, "main vanished during stress");
+  },
+});
+
+registerScenario({
+  id: "lanes.scroll-list",
+  description: "Scroll the lanes list rapidly — measures render-on-scroll cost.",
+  run: async (ctx) => {
+    await navigateToLanes(ctx);
+    await ctx.idle(2_000);
+    const scrollable =
+      document.querySelector<HTMLElement>("[data-scrollable], main [class*='overflow']") ||
+      document.querySelector<HTMLElement>("main");
+    if (!scrollable) {
+      ctx.assert(false, "no scrollable container found in lanes");
+      return;
+    }
+    ctx.mark("scroll.start");
+    for (let i = 0; i < 20; i++) {
+      scrollable.scrollTop = (i % 2 === 0 ? scrollable.scrollHeight : 0);
+      await ctx.idle(150);
+    }
+    ctx.mark("scroll.done");
+    ctx.measure("scroll.20-cycles", "scroll.start", "scroll.done");
+  },
+});

--- a/apps/desktop/src/renderer/perf/webVitals.ts
+++ b/apps/desktop/src/renderer/perf/webVitals.ts
@@ -1,0 +1,81 @@
+import { isPerfActive } from "./markers";
+
+const LONG_TASK_THRESHOLD_MS = 50;
+
+let installed = false;
+
+function send(kind: string, payload: Record<string, unknown>): void {
+  if (!isPerfActive()) return;
+  window.ade?.perf?.recordEvent({
+    kind,
+    ts: Date.now(),
+    ...payload,
+  });
+}
+
+function observe(type: string, callback: (entries: PerformanceEntryList) => void): void {
+  try {
+    const po = new PerformanceObserver((list) => callback(list.getEntries()));
+    po.observe({ type, buffered: true } as PerformanceObserverInit);
+  } catch {
+    // observer type not supported in this runtime — ignore.
+  }
+}
+
+export function installWebVitalsObservers(): void {
+  if (installed) return;
+  installed = true;
+
+  observe("longtask", (entries) => {
+    for (const entry of entries) {
+      if (entry.duration < LONG_TASK_THRESHOLD_MS) continue;
+      send("longTask", {
+        durationMs: Math.round(entry.duration),
+        startTime: Math.round(entry.startTime),
+      });
+    }
+  });
+
+  observe("paint", (entries) => {
+    for (const entry of entries) {
+      if (entry.name === "first-contentful-paint") {
+        send("webVital", {
+          metric: "FCP",
+          value: Math.round(entry.startTime),
+        });
+      }
+    }
+  });
+
+  observe("largest-contentful-paint", (entries) => {
+    for (const entry of entries) {
+      send("webVital", {
+        metric: "LCP",
+        value: Math.round(entry.startTime),
+      });
+    }
+  });
+
+  observe("layout-shift", (entries) => {
+    let total = 0;
+    for (const entry of entries as unknown as Array<PerformanceEntry & { value: number; hadRecentInput: boolean }>) {
+      if (entry.hadRecentInput) continue;
+      total += entry.value;
+    }
+    if (total > 0) {
+      send("webVital", { metric: "CLS", value: total });
+    }
+  });
+
+  observe("event", (entries) => {
+    for (const entry of entries as unknown as Array<PerformanceEntry & { interactionId?: number; duration: number }>) {
+      if (!entry.interactionId) continue;
+      if (entry.duration < 16) continue;
+      send("webVital", {
+        metric: "INP",
+        value: Math.round(entry.duration),
+        eventName: entry.name,
+      });
+    }
+  });
+}

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -761,6 +761,10 @@ export const IPC = {
   notificationsApnsUploadKey: "ade.notifications.apns.uploadKey",
   notificationsApnsClearKey: "ade.notifications.apns.clearKey",
   notificationsApnsSendTestPush: "ade.notifications.apns.sendTestPush",
+  perfGetConfig: "ade.perf.getConfig",
+  perfRecordEvent: "ade.perf.recordEvent",
+  perfFinalize: "ade.perf.finalize",
+  perfScenarioComplete: "ade.perf.scenarioComplete",
 } as const;
 
 export type IpcChannel = (typeof IPC)[keyof typeof IPC];

--- a/scripts/perf-launch.mjs
+++ b/scripts/perf-launch.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Warm-launch ADE in perf mode pointing at perf-pass on a specific tab.
+ * Perf instrumentation is ON but no scenario auto-runs — for Codex to inspect
+ * and drive interactively. Quits when you SIGINT/kill it.
+ *
+ * Usage:
+ *   scripts/perf-launch.mjs --tab lanes
+ *   scripts/perf-launch.mjs --tab missions --run-id manual
+ *   scripts/perf-launch.mjs --tab boot --no-project
+ *   scripts/perf-launch.mjs --route /settings --project "/path/to/repo"
+ */
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+const argv = process.argv.slice(2);
+const args = {
+  tab: null,
+  route: null,
+  runId: null,
+  projectRoot: null,
+  noProject: false,
+};
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (a === "--tab") args.tab = argv[++i] ?? null;
+  else if (a === "--route") args.route = argv[++i] ?? null;
+  else if (a === "--run-id") args.runId = argv[++i] ?? null;
+  else if (a === "--project") args.projectRoot = argv[++i] ?? null;
+  else if (a === "--no-project") args.noProject = true;
+  else if (a === "--help" || a === "-h") {
+    console.log(`Usage: perf-launch.mjs --tab <name> [--run-id <id>] [--project <path>] [--no-project]
+       perf-launch.mjs --route /<path> [--run-id <id>] [--project <path>] [--no-project]`);
+    process.exit(0);
+  }
+}
+
+const route = args.route ?? (args.tab ? `/${args.tab}` : null);
+if (!route) {
+  console.error("perf-launch: must pass --tab <name> or --route /<path>");
+  process.exit(2);
+}
+
+const runId = args.runId ?? `warm-${Date.now()}`;
+mkdirSync(join(homedir(), ".ade", "perf-runs", runId), { recursive: true });
+
+const defaultPerfPass = "/Users/admin/Projects/perf pass";
+const projectRoot = args.noProject
+  ? mkdtempSync(join(tmpdir(), "ade-perf-no-project-"))
+  : (args.projectRoot ?? process.env.ADE_PERF_PASS_DIR ?? defaultPerfPass);
+
+console.log(`[perf-launch] tab=${args.tab ?? "(route)"} route=${route} runId=${runId}`);
+console.log(`[perf-launch] project=${projectRoot}${args.noProject ? " (no-project mode)" : ""}`);
+console.log(`[perf-launch] events → ${join(homedir(), ".ade", "perf-runs", runId, "events.jsonl")}`);
+console.log(`[perf-launch] press Ctrl-C to quit`);
+
+const env = {
+  ...process.env,
+  ADE_PERF_RUN_ID: runId,
+  ADE_PERF_INITIAL_ROUTE: route,
+  ADE_PERF_PASS_DIR: projectRoot,
+  ADE_TRACE_IPC: "verbose",
+  ADE_MODEL_OVERRIDE: process.env.ADE_MODEL_OVERRIDE ?? "gpt-5-codex",
+  ELECTRON_ENABLE_LOGGING: "1",
+};
+delete env.ADE_PERF_SCENARIO;
+
+const child = spawn(
+  "npm",
+  ["run", "dev:desktop", "--", "--project-root", projectRoot],
+  {
+    stdio: ["ignore", "inherit", "inherit"],
+    env,
+    detached: false,
+  }
+);
+
+const stop = (code) => {
+  try {
+    if (!child.killed) {
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (!child.killed) child.kill("SIGKILL");
+      }, 5_000).unref();
+    }
+  } catch {
+    // ignore
+  }
+  process.exit(code);
+};
+
+process.on("SIGINT", () => stop(130));
+process.on("SIGTERM", () => stop(143));
+child.on("exit", (code) => process.exit(code ?? 0));

--- a/scripts/reset-perf-pass.sh
+++ b/scripts/reset-perf-pass.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Reset the perf-pass throwaway repo to a known seed state.
+# Usage: scripts/reset-perf-pass.sh [path-to-perf-pass-repo]
+set -euo pipefail
+
+PERF_PASS="${1:-${ADE_PERF_PASS_DIR:-/Users/admin/Projects/perf pass}}"
+SEED_TAG="${ADE_PERF_PASS_SEED_TAG:-perf-pass-seed}"
+
+if [[ ! -d "$PERF_PASS/.git" ]]; then
+  echo "[perf-pass] $PERF_PASS is not a git repo" >&2
+  exit 2
+fi
+
+cd "$PERF_PASS"
+
+if ! git rev-parse --verify "$SEED_TAG" >/dev/null 2>&1; then
+  echo "[perf-pass] tagging current HEAD as $SEED_TAG"
+  git tag "$SEED_TAG"
+fi
+
+echo "[perf-pass] resetting to $SEED_TAG"
+git reset --hard "$SEED_TAG"
+
+echo "[perf-pass] clearing untracked"
+git clean -fdx
+
+if [[ -d "$PERF_PASS/.ade" ]]; then
+  echo "[perf-pass] clearing .ade/"
+  rm -rf "$PERF_PASS/.ade"
+fi
+
+echo "[perf-pass] ready at $PERF_PASS ($(git rev-parse --short HEAD))"

--- a/scripts/run-perf-scenario.mjs
+++ b/scripts/run-perf-scenario.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Run a single perf scenario end-to-end:
+ *  1. Set ADE_PERF_RUN_ID + ADE_PERF_SCENARIO
+ *  2. Launch `npm run dev:desktop` as a child process
+ *  3. Poll for ~/.ade/perf-runs/<runId>/summary.json to appear
+ *  4. Print summary + kill the dev process
+ *
+ * Usage:
+ *   scripts/run-perf-scenario.mjs <scenarioId> [runId]
+ *   scripts/run-perf-scenario.mjs lanes.cold-list
+ *   scripts/run-perf-scenario.mjs lanes.stress-poll my-baseline
+ */
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync, rmSync, mkdirSync, mkdtempSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+const positional = [];
+let noProject = false;
+let initialRoute = null;
+for (const arg of process.argv.slice(2)) {
+  if (arg === "--no-project") noProject = true;
+  else if (arg.startsWith("--route=")) initialRoute = arg.slice("--route=".length);
+  else positional.push(arg);
+}
+const scenarioId = positional[0];
+if (!scenarioId) {
+  console.error("Usage: run-perf-scenario.mjs <scenarioId> [runId] [--no-project] [--route=/path]");
+  process.exit(2);
+}
+const runId = positional[1] ?? `run-${Date.now()}`;
+const dir = join(homedir(), ".ade", "perf-runs", runId);
+const summaryPath = join(dir, "summary.json");
+const timeoutMs = Number(process.env.ADE_PERF_TIMEOUT_MS ?? 300_000);
+
+mkdirSync(dir, { recursive: true });
+if (existsSync(summaryPath)) rmSync(summaryPath);
+
+console.log(`[perf] scenario=${scenarioId} runId=${runId}`);
+console.log(`[perf] events → ${join(dir, "events.jsonl")}`);
+console.log(`[perf] summary → ${summaryPath}`);
+
+const defaultPerfPass = "/Users/admin/Projects/perf pass";
+const perfPassDir = noProject
+  ? mkdtempSync(join(tmpdir(), "ade-perf-no-project-"))
+  : (process.env.ADE_PERF_PASS_DIR ?? defaultPerfPass);
+
+const env = {
+  ...process.env,
+  ADE_PERF_RUN_ID: runId,
+  ADE_PERF_SCENARIO: scenarioId,
+  ADE_PERF_PASS_DIR: perfPassDir,
+  ADE_TRACE_IPC: "verbose",
+  ADE_MODEL_OVERRIDE: process.env.ADE_MODEL_OVERRIDE ?? "gpt-5-codex",
+  ELECTRON_ENABLE_LOGGING: "1",
+};
+if (initialRoute) env.ADE_PERF_INITIAL_ROUTE = initialRoute;
+
+const child = spawn(
+  "npm",
+  ["run", "dev:desktop", "--", "--project-root", perfPassDir],
+  {
+    stdio: ["ignore", "inherit", "inherit"],
+    env,
+    detached: false,
+  }
+);
+
+const deadline = Date.now() + timeoutMs;
+const cleanup = (code) => {
+  try {
+    if (!child.killed) {
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (!child.killed) child.kill("SIGKILL");
+      }, 5_000).unref();
+    }
+  } catch {
+    // ignore
+  }
+  process.exit(code);
+};
+
+process.on("SIGINT", () => cleanup(130));
+process.on("SIGTERM", () => cleanup(143));
+
+(async function pollForSummary() {
+  while (Date.now() < deadline) {
+    if (existsSync(summaryPath)) {
+      try {
+        const text = readFileSync(summaryPath, "utf8");
+        const summary = JSON.parse(text);
+        console.log("\n[perf] summary:");
+        console.log(JSON.stringify(summary, null, 2));
+        cleanup(0);
+        return;
+      } catch (err) {
+        console.error(`[perf] failed to parse summary: ${err.message}`);
+        cleanup(1);
+        return;
+      }
+    }
+    await new Promise((r) => setTimeout(r, 1_000));
+  }
+  console.error(`[perf] timed out waiting for ${summaryPath}`);
+  cleanup(1);
+})();


### PR DESCRIPTION
## Summary
- avoid disabled local-runtime bridge churn during Work perf runs
- fast-path sync status when local runtime daemon is disabled
- keep Work tools tabs reachable in narrow panes
- show lane-state messaging for missing Git worktrees
- codify Work perf findings and loosen autoresearch guidance away from fixed canned scenarios

## Measured proof
- Baseline Work run: 67 failed ade.localRuntime.* IPC calls / 19,427ms aggregate failed IPC time
- After preload/runtime guards: 0 ade.localRuntime.* calls in local-runtime-disabled Work run
- Sync status path: failed 258-348ms runtime spawns -> successful 0-1ms snapshot path
- Post-fix UI pass: Git, Files, iOS Sim, App Control, Browser, and Mac VM tabs all visible/clickable with no tab clipped

## Validation
- npm --prefix apps/desktop run test -- --run src/preload/preload.test.ts
- npm --prefix apps/desktop run test -- --run src/main/services/git/gitOperationsService.test.ts
- npm --prefix apps/desktop run test -- --run src/renderer/components/lanes/CommitTimeline.test.tsx
- npm --prefix apps/desktop run typecheck
