### PR TITLE
Scope Codex planner approvals by turn

### DIFF
--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -9413,6 +9413,16 @@ describe("createAgentChatService", () => {
         expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(true);
       });
 
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        method: "turn/started",
+        params: {
+          turn: {
+            id: "turn-1",
+          },
+        },
+      });
+
       await service.updateSession({
         sessionId: session.id,
         permissionMode: "full-auto",
@@ -9483,6 +9493,68 @@ describe("createAgentChatService", () => {
         && event.event.turnId === "turn-2"
         && event.event.message.includes("PLANNER CONTRACT VIOLATION")
       )).toBe(false);
+    });
+
+    it("carries Codex planner approval guard through async turn/started when turn/start has no id", async () => {
+      vi.mocked(mapPermissionToCodex).mockImplementation((mode) => {
+        if (mode === "full-auto") {
+          return { approvalPolicy: "never", sandbox: "danger-full-access" };
+        }
+        return { approvalPolicy: "on-request", sandbox: "read-only" };
+      });
+      mockState.codexResponseOverrides.set("turn/start", { turn: {} });
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+        permissionMode: "plan",
+      });
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Plan the investigation.",
+      }, { awaitDispatch: true });
+
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        method: "turn/started",
+        params: {
+          turn: {
+            id: "turn-async-1",
+          },
+        },
+      });
+
+      await service.updateSession({
+        sessionId: session.id,
+        permissionMode: "full-auto",
+      });
+
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        id: "cmd-plan-async-1",
+        method: "item/commandExecution/requestApproval",
+        params: {
+          itemId: "cmd-plan-async-1",
+          turnId: "turn-async-1",
+          command: "/bin/zsh -lc 'ade --socket lanes list --text'",
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(events.some((event) =>
+          event.event.type === "error"
+          && event.event.turnId === "turn-async-1"
+          && event.event.message.includes("PLANNER CONTRACT VIOLATION")
+        )).toBe(true);
+      });
+      expect(mockState.codexRequestPayloads.find((payload) => payload.id === "cmd-plan-async-1")).toMatchObject({
+        result: { decision: "decline" },
+      });
     });
 
     it("uses each updated Codex reasoning effort on the next post-turn send", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -7788,7 +7788,9 @@ describe("createAgentChatService", () => {
         expect(mockState.codexRequestPayloads.some((payload) => payload.method === "collaborationMode/list")).toBe(true);
         expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(true);
       });
+      const threadStartRequest = mockState.codexRequestPayloads.find((payload) => payload.method === "thread/start");
       const turnStartRequest = mockState.codexRequestPayloads.find((payload) => payload.method === "turn/start");
+      const threadParams = threadStartRequest?.params as { developerInstructions?: unknown } | undefined;
       const params = turnStartRequest?.params as {
         approvalPolicy?: unknown;
         sandboxPolicy?: { type?: unknown; networkAccess?: unknown; access?: { type?: unknown } };
@@ -7801,13 +7803,14 @@ describe("createAgentChatService", () => {
         | undefined;
       const textInputs = (params?.input ?? []).filter((item) => item.type === "text");
 
+      expect(threadParams?.developerInstructions).toBe("system prompt");
       expect(params?.approvalPolicy).toBe("untrusted");
       expect(params?.sandboxPolicy?.type).toBe("readOnly");
       expect(params?.effort).toBe("medium");
       expect(collaborationMode?.mode).toBe("plan");
       expect(collaborationMode?.settings?.model).toBe("gpt-5.4");
       expect(collaborationMode?.settings?.reasoning_effort).toBe("medium");
-      expect(collaborationMode?.settings?.developer_instructions).toBe("system prompt");
+      expect(collaborationMode?.settings?.developer_instructions).toBeNull();
       expect(textInputs).toHaveLength(1);
       expect(textInputs.at(-1)?.text).toContain("User request:");
       expect(textInputs.at(-1)?.text).toContain("Ask one planning question before coding.");

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -9383,6 +9383,105 @@ describe("createAgentChatService", () => {
       expect(turnStartParams?.effort).toBe("medium");
     });
 
+    it("keeps Codex planner approval guard scoped to the turn that started in plan mode", async () => {
+      vi.mocked(mapPermissionToCodex).mockImplementation((mode) => {
+        if (mode === "full-auto") {
+          return { approvalPolicy: "never", sandbox: "danger-full-access" };
+        }
+        return { approvalPolicy: "on-request", sandbox: "read-only" };
+      });
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+        permissionMode: "plan",
+      });
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Plan the investigation.",
+      }, { awaitDispatch: true });
+
+      await vi.waitFor(() => {
+        expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(true);
+      });
+
+      await service.updateSession({
+        sessionId: session.id,
+        permissionMode: "full-auto",
+      });
+
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        id: "cmd-plan-1",
+        method: "item/commandExecution/requestApproval",
+        params: {
+          itemId: "cmd-plan-1",
+          turnId: "turn-1",
+          command: "/bin/zsh -lc 'ade --socket lanes list --text'",
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(events.some((event) =>
+          event.event.type === "error"
+          && event.event.turnId === "turn-1"
+          && event.event.message.includes("PLANNER CONTRACT VIOLATION")
+        )).toBe(true);
+      });
+      expect(mockState.codexRequestPayloads.find((payload) => payload.id === "cmd-plan-1")).toMatchObject({
+        result: { decision: "decline" },
+      });
+
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        method: "turn/completed",
+        params: {
+          turn: {
+            id: "turn-1",
+            status: "completed",
+          },
+        },
+      });
+
+      await vi.waitFor(async () => {
+        expect((await service.getSessionSummary(session.id))?.status).toBe("idle");
+      });
+      mockState.codexRequestPayloads = [];
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Now inspect with the updated permissions.",
+      }, { awaitDispatch: true });
+
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        id: "cmd-full-auto-1",
+        method: "item/commandExecution/requestApproval",
+        params: {
+          itemId: "cmd-full-auto-1",
+          turnId: "turn-2",
+          command: "/bin/zsh -lc 'ade --socket chat list --text'",
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(events.some((event) =>
+          event.event.type === "approval_request"
+          && event.event.itemId === "cmd-full-auto-1"
+        )).toBe(true);
+      });
+      expect(events.some((event) =>
+        event.event.type === "error"
+        && event.event.turnId === "turn-2"
+        && event.event.message.includes("PLANNER CONTRACT VIOLATION")
+      )).toBe(false);
+    });
+
     it("uses each updated Codex reasoning effort on the next post-turn send", async () => {
       const { service } = createService();
       const session = await service.createSession({

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -460,6 +460,8 @@ type CodexRuntime = {
   manualCompactionItemIds: Set<string>;
   manualCompactionPending: boolean;
   webSearchActionsByItemId: Map<string, CodexWebSearchAction[]>;
+  planningApprovalGuardByTurnId: Map<string, boolean>;
+  pendingTurnPlanningApprovalGuarded: boolean | null;
   activeSubagents: Map<string, { taskId: string; description: string; background: boolean }>;
   interruptedTurnIds: Set<string>;
   ignoredTurnIds: Set<string>;
@@ -926,6 +928,7 @@ function rememberTerminalCodexTurn(
   const normalizedTurnId = turnId?.trim() || null;
   if (!normalizedTurnId) return;
   rememberBoundedId(runtime.terminalTurnIds, normalizedTurnId);
+  runtime.planningApprovalGuardByTurnId.delete(normalizedTurnId);
   if (managed) rememberBoundedId(managed.codexTerminalTurnIds, normalizedTurnId);
 }
 
@@ -2370,7 +2373,33 @@ function mapApprovalDecisionForCodex(decision: AgentChatApprovalDecision): "acce
   return "decline";
 }
 
-function isPlanningApprovalGuarded(managed: ManagedChatSession): boolean {
+function rememberCodexPlanningApprovalGuard(
+  runtime: CodexRuntime,
+  turnId: string | null | undefined,
+  guarded: boolean | null | undefined,
+): void {
+  const normalizedTurnId = turnId?.trim() || null;
+  if (!normalizedTurnId) return;
+  runtime.planningApprovalGuardByTurnId.set(normalizedTurnId, guarded === true);
+  if (runtime.planningApprovalGuardByTurnId.size > MAX_SESSION_MAP_ENTRIES) {
+    const [first] = runtime.planningApprovalGuardByTurnId.keys();
+    if (first) runtime.planningApprovalGuardByTurnId.delete(first);
+  }
+}
+
+function isPlanningApprovalGuarded(
+  managed: ManagedChatSession,
+  runtime: CodexRuntime,
+  turnId?: string | null,
+): boolean {
+  const normalizedTurnId = turnId?.trim()
+    || runtime.activeTurnId
+    || runtime.startedTurnId
+    || null;
+  if (normalizedTurnId) {
+    const guarded = runtime.planningApprovalGuardByTurnId.get(normalizedTurnId);
+    if (guarded !== undefined) return guarded;
+  }
   return managed.session.permissionMode === "plan";
 }
 
@@ -8791,7 +8820,9 @@ export function createAgentChatService(args: {
       const name = path.basename(attachment.path) || attachment.path;
       input.push({ type: "mention", name, path: stagedPath });
     }
+    const planningApprovalGuarded = managed.session.permissionMode === "plan";
     managed.runtime.awaitingTurnStart = true;
+    managed.runtime.pendingTurnPlanningApprovalGuarded = planningApprovalGuarded;
     let result: { turn?: { id?: string } };
     try {
       result = await managed.runtime.request<{ turn?: { id?: string } }>("turn/start", {
@@ -8809,6 +8840,7 @@ export function createAgentChatService(args: {
       });
     } catch (error) {
       managed.runtime.awaitingTurnStart = false;
+      managed.runtime.pendingTurnPlanningApprovalGuarded = null;
       throw error;
     }
     markDispatched();
@@ -8817,6 +8849,8 @@ export function createAgentChatService(args: {
     const turnId = typeof result?.turn?.id === "string" ? result.turn.id : null;
     if (turnId) {
       managed.runtime.awaitingTurnStart = false;
+      rememberCodexPlanningApprovalGuard(managed.runtime, turnId, planningApprovalGuarded);
+      managed.runtime.pendingTurnPlanningApprovalGuarded = null;
       if (isTerminalCodexTurn(managed.runtime, turnId, managed)) {
         managed.runtime.activeTurnId = null;
         managed.runtime.startedTurnId = null;
@@ -8838,6 +8872,8 @@ export function createAgentChatService(args: {
           turnId,
         });
       }
+    } else {
+      managed.runtime.pendingTurnPlanningApprovalGuarded = null;
     }
     persistChatState(managed);
   };
@@ -11233,12 +11269,13 @@ export function createAgentChatService(args: {
     if (id == null) return;
 
     if (method === "item/commandExecution/requestApproval") {
-      const params = (payload.params as { itemId?: string; command?: string; cwd?: string; reason?: string } | null) ?? {};
-      if (isPlanningApprovalGuarded(managed)) {
+      const params = (payload.params as { itemId?: string; command?: string; cwd?: string; reason?: string; turnId?: string } | null) ?? {};
+      const requestTurnId = typeof params.turnId === "string" ? params.turnId : runtime.activeTurnId ?? runtime.startedTurnId ?? null;
+      if (isPlanningApprovalGuarded(managed, runtime, requestTurnId)) {
         emitChatEvent(managed, {
           type: "error",
           message: buildPlanningApprovalViolation(params.command?.trim() || "command"),
-          turnId: runtime.activeTurnId ?? undefined,
+          turnId: requestTurnId ?? undefined,
         });
         runtime.sendResponse(id, { decision: "decline" });
         return;
@@ -11260,7 +11297,7 @@ export function createAgentChatService(args: {
           cwd: params.cwd ?? null,
           reason: params.reason ?? null,
         },
-        turnId: runtime.activeTurnId ?? null,
+        turnId: requestTurnId,
       };
       runtime.approvals.set(itemId, { requestId: id, kind: "command", request });
       emitPendingInputRequest(managed, request, {
@@ -11276,12 +11313,13 @@ export function createAgentChatService(args: {
     }
 
     if (method === "item/fileChange/requestApproval") {
-      const params = (payload.params as { itemId?: string; reason?: string; grantRoot?: string } | null) ?? {};
-      if (isPlanningApprovalGuarded(managed)) {
+      const params = (payload.params as { itemId?: string; reason?: string; grantRoot?: string; turnId?: string } | null) ?? {};
+      const requestTurnId = typeof params.turnId === "string" ? params.turnId : runtime.activeTurnId ?? runtime.startedTurnId ?? null;
+      if (isPlanningApprovalGuarded(managed, runtime, requestTurnId)) {
         emitChatEvent(managed, {
           type: "error",
           message: buildPlanningApprovalViolation(params.reason?.trim() || "file change"),
-          turnId: runtime.activeTurnId ?? undefined,
+          turnId: requestTurnId ?? undefined,
         });
         runtime.sendResponse(id, { decision: "decline" });
         return;
@@ -11302,7 +11340,7 @@ export function createAgentChatService(args: {
           grantRoot: params.grantRoot ?? null,
           reason: params.reason ?? null,
         },
-        turnId: runtime.activeTurnId ?? null,
+        turnId: requestTurnId,
       };
       runtime.approvals.set(itemId, { requestId: id, kind: "file_change", request });
       emitPendingInputRequest(managed, request, {
@@ -12369,6 +12407,8 @@ export function createAgentChatService(args: {
       runtime.awaitingTurnStart = false;
       runtime.canAttachResumedTurnStart = false;
       runtime.activeTurnId = turnId;
+      rememberCodexPlanningApprovalGuard(runtime, turnId, runtime.pendingTurnPlanningApprovalGuarded);
+      runtime.pendingTurnPlanningApprovalGuarded = null;
       resetAssistantMessageStream(managed);
       runtime.agentMessageScopeByTurn.clear();
       runtime.agentMessageTextByTurn.clear();
@@ -12413,6 +12453,7 @@ export function createAgentChatService(args: {
       runtime.canAttachResumedTurnStart = false;
       runtime.activeTurnId = null;
       runtime.startedTurnId = null;
+      runtime.pendingTurnPlanningApprovalGuarded = null;
       runtime.ignoredTurnIds.delete(turnId);
       resetAssistantMessageStream(managed);
       const status = mapCodexTurnStatus(turn?.status);
@@ -12681,6 +12722,7 @@ export function createAgentChatService(args: {
       runtime.canAttachResumedTurnStart = false;
       runtime.activeTurnId = null;
       runtime.startedTurnId = null;
+      runtime.pendingTurnPlanningApprovalGuarded = null;
       runtime.ignoredTurnIds.delete(turnId);
       resetAssistantMessageStream(managed);
       runtime.itemTurnIdByItemId.clear();
@@ -13009,6 +13051,8 @@ export function createAgentChatService(args: {
       manualCompactionItemIds: new Set<string>(),
       manualCompactionPending: false,
       webSearchActionsByItemId: new Map<string, CodexWebSearchAction[]>(),
+      planningApprovalGuardByTurnId: new Map<string, boolean>(),
+      pendingTurnPlanningApprovalGuarded: null,
       activeSubagents: new Map<string, { taskId: string; description: string; background: boolean }>(),
       interruptedTurnIds: new Set<string>(),
       ignoredTurnIds: new Set<string>(),

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -8878,8 +8878,6 @@ export function createAgentChatService(args: {
           turnId,
         });
       }
-    } else {
-      managed.runtime.pendingTurnPlanningApprovalGuarded = null;
     }
     persistChatState(managed);
   };
@@ -12413,8 +12411,10 @@ export function createAgentChatService(args: {
       runtime.awaitingTurnStart = false;
       runtime.canAttachResumedTurnStart = false;
       runtime.activeTurnId = turnId;
-      rememberCodexPlanningApprovalGuard(runtime, turnId, runtime.pendingTurnPlanningApprovalGuarded);
-      runtime.pendingTurnPlanningApprovalGuarded = null;
+      if (runtime.pendingTurnPlanningApprovalGuarded !== null) {
+        rememberCodexPlanningApprovalGuard(runtime, turnId, runtime.pendingTurnPlanningApprovalGuarded);
+        runtime.pendingTurnPlanningApprovalGuarded = null;
+      }
       resetAssistantMessageStream(managed);
       runtime.agentMessageScopeByTurn.clear();
       runtime.agentMessageTextByTurn.clear();

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -3525,6 +3525,10 @@ type CodexCollaborationModePayload = {
   settings: {
     model: string;
     reasoning_effort: string | null;
+    // For native Codex plan mode, null means "use the app-server's built-in
+    // plan-mode instructions." ADE still sends its lane/runtime guidance via
+    // thread developerInstructions; overriding this field suppresses the
+    // upstream Plan Mode handoff that emits <proposed_plan>.
     developer_instructions: string | null;
   };
 };
@@ -3585,11 +3589,13 @@ function buildCodexCollaborationMode(
     settings: {
       model: session.model,
       reasoning_effort: session.reasoningEffort ?? DEFAULT_REASONING_EFFORT,
-      developer_instructions: buildCodexDeveloperInstructions({
-        laneWorktreePath,
-        session,
-        collaborationMode: mode,
-      }),
+      developer_instructions: mode === "plan"
+        ? null
+        : buildCodexDeveloperInstructions({
+            laneWorktreePath,
+            session,
+            collaborationMode: mode,
+          }),
     },
   };
 }


### PR DESCRIPTION
## Summary

Scope Codex planner approval enforcement to the turn that started in plan mode, so mode changes between plan and full access are deterministic.

## What Changed

- Snapshot whether each Codex turn started under ADE planner approval guard.
- Use the app-server approval request turn id when deciding whether command/file approvals should be rejected as planner violations.
- Clear the guard snapshot when turns finish or abort.
- Add a regression test covering plan-to-full-auto mode changes across turns.

## Validation

- npm --prefix apps/desktop run test -- src/main/services/chat/agentChatService.test.ts
- npm --prefix apps/desktop run typecheck currently fails on pre-existing missing type declarations: builder-util-runtime and mdast.

## Risks

Low. The change only affects Codex command/file approval handling and preserves the old session-level fallback when a turn snapshot is unavailable.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test case for planner approval guard behavior when switching from plan to full-auto mode mid-flow

* **Bug Fixes**
  * Improved approval request tracking across turns to prevent contract violations during permission mode transitions
  * Enhanced error handling for misaligned approval requests in planner mode

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/301)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes Codex planner approval enforcement to the specific turn that started in plan mode, replacing the previous session-level `permissionMode` check with a per-turn map (`planningApprovalGuardByTurnId`) and a `pendingTurnPlanningApprovalGuarded` staging field. It also sets `developer_instructions: null` for plan-mode collaboration payloads so that Codex uses its own built-in plan-mode instructions rather than the ADE-supplied ones.

- **Per-turn guard capture**: `pendingTurnPlanningApprovalGuarded` is snapshotted at `turn/start` dispatch time and consumed by either the sync return path or the async `turn/started` handler. Both previous overwrite/premature-clear races are correctly fixed.
- **Approval handler update**: Both approval handlers now extract `turnId` from request params and pass it to `isPlanningApprovalGuarded`, ensuring the guard check uses the originating turn.
- **Two new regression tests** covering the sync and async `turn/start` paths, validating that switching to `full-auto` mid-session does not bypass the planner guard.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core per-turn guard logic is correct and both previously identified races are resolved.

The fix is well-scoped and both races are addressed with good test coverage. One edge case remains: if turn/started arrives with a null turn ID while a pending guard is set, the guard is discarded unconditionally.

The turn/started handler in agentChatService.ts around the pendingTurnPlanningApprovalGuarded clear deserves a second look for the null-turnId edge case.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/chat/agentChatService.ts | Scopes Codex planner approval guard per-turn via a new map and pending field; fixes two prior overwrite/premature-clear races. Minor edge case: null turnId in turn/started discards the pending guard unconditionally. |
| apps/desktop/src/main/services/chat/agentChatService.test.ts | Adds two regression tests: one for plan→full-auto mode transitions (sync turn/start path) and one for the async path where turn/start returns no ID. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/main/services/chat/agentChatService.test.ts`, line 9385-9488 ([link](https://github.com/arul28/ade/blob/cd0e4ca7894e5b50483e3e80a6bf6cd5c263773f/apps/desktop/src/main/services/chat/agentChatService.test.ts#L9385-L9488)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Test doesn't emit `turn/started`, so the overwrite bug goes undetected**

   The new test never emits a `turn/started` event for `turn-1`. In production, Codex always fires this event, which is the trigger for the guard-overwrite bug described above. As written, the test passes because it exercises only the scenario where the sync `turn/start` response provides the `turnId` — without the subsequent `turn/started` round-trip that would clobber the guard. Adding a `mockState.emitCodexPayload({ method: "turn/started", params: { turn: { id: "turn-1" } } })` call before the `item/commandExecution/requestApproval` emission would reproduce the production failure.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/chat/agentChatService.test.ts
   Line: 9385-9488

   Comment:
   **Test doesn't emit `turn/started`, so the overwrite bug goes undetected**

   The new test never emits a `turn/started` event for `turn-1`. In production, Codex always fires this event, which is the trigger for the guard-overwrite bug described above. As written, the test passes because it exercises only the scenario where the sync `turn/start` response provides the `turnId` — without the subsequent `turn/started` round-trip that would clobber the guard. Adding a `mockState.emitCodexPayload({ method: "turn/started", params: { turn: { id: "turn-1" } } })` call before the `item/commandExecution/requestApproval` emission would reproduce the production failure.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fchat%2FagentChatService.test.ts%0ALine%3A%209385-9488%0A%0AComment%3A%0A**Test%20doesn't%20emit%20%60turn%2Fstarted%60%2C%20so%20the%20overwrite%20bug%20goes%20undetected**%0A%0AThe%20new%20test%20never%20emits%20a%20%60turn%2Fstarted%60%20event%20for%20%60turn-1%60.%20In%20production%2C%20Codex%20always%20fires%20this%20event%2C%20which%20is%20the%20trigger%20for%20the%20guard-overwrite%20bug%20described%20above.%20As%20written%2C%20the%20test%20passes%20because%20it%20exercises%20only%20the%20scenario%20where%20the%20sync%20%60turn%2Fstart%60%20response%20provides%20the%20%60turnId%60%20%E2%80%94%20without%20the%20subsequent%20%60turn%2Fstarted%60%20round-trip%20that%20would%20clobber%20the%20guard.%20Adding%20a%20%60mockState.emitCodexPayload%28%7B%20method%3A%20%22turn%2Fstarted%22%2C%20params%3A%20%7B%20turn%3A%20%7B%20id%3A%20%22turn-1%22%20%7D%20%7D%20%7D%29%60%20call%20before%20the%20%60item%2FcommandExecution%2FrequestApproval%60%20emission%20would%20reproduce%20the%20production%20failure.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=301&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fchat%2FagentChatService.ts%3A12414-12417%0A**Pending%20guard%20silently%20discarded%20when%20%60turn%2Fstarted%60%20carries%20a%20null%20turn%20ID**%0A%0AIf%20%60turnId%60%20is%20null%20here%2C%20%60rememberCodexPlanningApprovalGuard%60%20returns%20early%20%28%60if%20%28!normalizedTurnId%29%20return%60%29%20without%20storing%20anything%2C%20yet%20%60pendingTurnPlanningApprovalGuarded%60%20is%20unconditionally%20cleared%20to%20%60null%60%20on%20the%20next%20line.%20The%20captured%20plan-guard%20is%20lost%20with%20no%20fallback.%20Any%20subsequent%20approval%20request%20that%20carries%20an%20actual%20turn%20ID%20will%20miss%20the%20map%20entry%20and%20fall%20back%20to%20the%20current%20%60permissionMode%60%2C%20which%20may%20already%20have%20been%20switched%20to%20%60full-auto%60%2C%20allowing%20a%20command%20to%20execute%20unguarded%20inside%20what%20was%20a%20plan-mode%20turn.%0A%0AGuarding%20the%20clear%20with%20a%20null-check%20%E2%80%94%20only%20clearing%20when%20%60turnId%60%20is%20non-null%20%E2%80%94%20would%20preserve%20the%20pending%20value%20for%20a%20hypothetical%20re-try%20while%20keeping%20the%20happy%20path%20unchanged.%0A%0A&repo=arul28%2Fade&pr=301&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/main/services/chat/agentChatService.ts:12414-12417
**Pending guard silently discarded when `turn/started` carries a null turn ID**

If `turnId` is null here, `rememberCodexPlanningApprovalGuard` returns early (`if (!normalizedTurnId) return`) without storing anything, yet `pendingTurnPlanningApprovalGuarded` is unconditionally cleared to `null` on the next line. The captured plan-guard is lost with no fallback. Any subsequent approval request that carries an actual turn ID will miss the map entry and fall back to the current `permissionMode`, which may already have been switched to `full-auto`, allowing a command to execute unguarded inside what was a plan-mode turn.

Guarding the clear with a null-check — only clearing when `turnId` is non-null — would preserve the pending value for a hypothetical re-try while keeping the happy path unchanged.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Preserve planner guard across turn-start..."](https://github.com/arul28/ade/commit/fde13c3f5187b1c83f9de3e173a082e85b98aa3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32184506)</sub>

<!-- /greptile_comment -->