### PR TITLE
Preserve planner guard on null turn-start notifications

### DIFF
--- a/apps/desktop/src/main/packagedRuntimeSmoke.ts
+++ b/apps/desktop/src/main/packagedRuntimeSmoke.ts
@@ -7,7 +7,7 @@ import {
   type ClaudeStartupProbeResult,
 } from "./packagedRuntimeSmokeShared";
 
-const PTY_PROBE_TIMEOUT_MS = 4_000;
+const PTY_PROBE_TIMEOUT_MS = process.platform === "win32" ? 15_000 : 4_000;
 const CLAUDE_PROBE_TIMEOUT_MS = 20_000;
 
 async function probePty(): Promise<{ ok: true; output: string }> {
@@ -32,7 +32,7 @@ async function probePty(): Promise<{ ok: true; output: string }> {
       } catch {
         // ignore best-effort cleanup
       }
-      reject(new Error("PTY probe timed out"));
+      reject(new Error(`PTY probe timed out after ${PTY_PROBE_TIMEOUT_MS}ms`));
     }, PTY_PROBE_TIMEOUT_MS);
 
     term.onData((chunk) => {

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -9548,6 +9548,14 @@ describe("createAgentChatService", () => {
         jsonrpc: "2.0",
         method: "turn/started",
         params: {
+          turn: {},
+        },
+      });
+
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        method: "turn/started",
+        params: {
           turn: {
             id: "turn-async-1",
           },

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -12408,6 +12408,10 @@ export function createAgentChatService(args: {
     if (method === "turn/started") {
       const turn = startedTurn;
       const turnId = typeof turn?.id === "string" ? turn.id : null;
+      if (!turnId && runtime.pendingTurnPlanningApprovalGuarded !== null) {
+        logger.warn(`[codex] deferring turn/started without turnId for session ${managed.session.id}`);
+        return;
+      }
       if (!runtime.awaitingTurnStart && !runtime.activeTurnId && !runtime.startedTurnId && !isResumedInProgressTurnStart) {
         logger.warn(`[codex] ignoring unsolicited turn/started for session ${managed.session.id}`);
         if (turnId) {

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -12409,7 +12409,7 @@ export function createAgentChatService(args: {
       const turn = startedTurn;
       const turnId = typeof turn?.id === "string" ? turn.id : null;
       if (!turnId && runtime.pendingTurnPlanningApprovalGuarded !== null) {
-        logger.warn(`[codex] deferring turn/started without turnId for session ${managed.session.id}`);
+        logger.warn(`[codex] ignoring turn/started without turnId (pending planning guard preserved) for session ${managed.session.id}`);
         return;
       }
       if (!runtime.awaitingTurnStart && !runtime.activeTurnId && !runtime.startedTurnId && !isResumedInProgressTurnStart) {


### PR DESCRIPTION
## Summary

Fixes the remaining Greptile review issue from #301: a malformed Codex `turn/started` notification without a turn id no longer consumes the pending planner approval guard before the real turn id arrives.

## Validation

- cd apps/desktop && npx vitest run src/main/services/chat/agentChatService.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of agent chat events when turn identifiers are missing, with appropriate warning logging to facilitate debugging of edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/305)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where a malformed Codex `turn/started` notification (missing `turn.id`) would consume the pending planner approval guard before the real notification arrived, causing the guard to be silently bound to a `null` turn id. A focused early-return is added when the null-id case arrives while a guard is pending, and the fix is covered by a new regression test.

- **`agentChatService.ts`**: Adds a guard that discards a `turn/started` with no turn id when `pendingTurnPlanningApprovalGuarded` is non-null, logging a warning and returning without modifying runtime state.
- **`agentChatService.test.ts`**: Injects the malformed notification before the real one and asserts the planner contract violation still fires correctly on the subsequent command approval.
- **`packagedRuntimeSmoke.ts`**: Extends the PTY probe timeout to 15 s on Windows (4 s elsewhere) and includes the timeout value in the error message.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrow, well-tested guard that only fires when both conditions are true simultaneously.

The fix is minimal and targeted: one early-return behind a two-condition check, backed by a regression test that exercises the exact sequence. The packagedRuntimeSmoke.ts change is an unrelated timeout widening for Windows and carries no correctness risk.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/chat/agentChatService.ts | Adds an early-return guard: when a turn/started arrives with no turn id and a pending planning approval guard exists, the notification is discarded and the guard is preserved for the real turn id. |
| apps/desktop/src/main/services/chat/agentChatService.test.ts | Adds a regression test that injects a malformed turn/started (no id) before the real one and asserts the planner contract violation guard still fires correctly. |
| apps/desktop/src/main/packagedRuntimeSmoke.ts | Widens PTY probe timeout to 15 s on Windows (was 4 s for all platforms) and includes the timeout duration in the error message for easier debugging. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Codex
    participant Handler as turn/started handler
    participant Runtime

    Note over Codex,Runtime: Malformed notification (no turn id)
    Codex->>Handler: "turn/started { turn: {} }"
    Handler->>Runtime: "pendingTurnPlanningApprovalGuarded !== null?"
    Runtime-->>Handler: yes
    Handler->>Handler: warn + return (guard preserved)

    Note over Codex,Runtime: Real notification (with turn id)
    Codex->>Handler: "turn/started { turn: { id: "turn-1" } }"
    Handler->>Runtime: rememberCodexPlanningApprovalGuard(runtime, "turn-1", guard)
    Runtime-->>Runtime: "pendingTurnPlanningApprovalGuarded = null"
    Handler->>Runtime: "activeTurnId = "turn-1""

    Note over Codex,Runtime: Planner guard is active for "turn-1"
```

<sub>Reviews (4): Last reviewed commit: ["Harden Windows packaged PTY smoke timeou..."](https://github.com/arul28/ade/commit/ef4ce5d4abb747af4a0d54874e6a1052d879e640) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32200781)</sub>

<!-- /greptile_comment -->