### PR TITLE
docs: add Cursor Cloud Linux dev environment notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,3 +111,7 @@ Desktop release:
 - The `ADE_PROJECT_ROOT=/workspace` env var tells the main process to auto-open a project at startup. However, there is a timing race: the renderer's initial `getProject()` call may return null before the async project switch completes, causing the welcome screen to appear even though the backend loaded the project. A workaround is to open the project manually via the "Open a project" button in the top bar.
 - Computer-use features (screenshot, video capture, GUI automation) are macOS-only (`screencapture`, `osascript`). On Linux these gracefully degrade — the app returns `blocked_by_capability`.
 - `electron-builder` config only defines a `mac` target. Distributable Linux builds (deb/AppImage) are not configured, but dev mode works fine.
+- The `test:unit` script (`npm --prefix apps/desktop run test:unit`) uses `--project unit` which the pinned vitest 0.34.6 doesn't support. Use `npx vitest run <specific-test-file>` in `apps/desktop` for targeted tests, or `npm --prefix apps/desktop run test` for the full suite.
+- In the Cursor Cloud VM the active X display is `:1`, not `:99`. When launching Electron set `DISPLAY=:1`.
+- To launch the desktop dev app quickly when the CLI is already built: `npm run dev:desktop -- --skip-runtime-build`.
+- To launch the TUI against an already-running dev runtime: `npm run dev:code -- --skip-runtime-build --attach --project-root <path> --workspace-root <path>`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds practical notes to the "Cursor Cloud specific instructions" section of AGENTS.md based on environment setup and testing:

- `test:unit` script uses `--project unit` which vitest 0.34.6 doesn't support; documents the workaround
- The active X display in Cursor Cloud VM is `:1`, not `:99`
- Documents fast launch commands (`--skip-runtime-build`, `--attach`) for desktop and TUI

### Evidence of working environment

**Full demo: Codex GPT-5.5 chat with auto-create lane, then lane deletion**
[ade_full_demo_chat_lanes_delete.mp4](https://cursor.com/agents/bc-e65e4033-3997-4e3d-a5de-5c6cfc72ce7c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fade_full_demo_chat_lanes_delete.mp4)

**Codex GPT-5.5 response to test message:**
[Codex GPT-5.5 response](https://cursor.com/agents/bc-e65e4033-3997-4e3d-a5de-5c6cfc72ce7c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcodex_response_final.webp)

**Lanes tab showing auto-created lane:**
[Lanes tab with auto-created lane](https://cursor.com/agents/bc-e65e4033-3997-4e3d-a5de-5c6cfc72ce7c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanes_with_autocreated_final.webp)

**Lane successfully deleted:**
[Lane deleted successfully](https://cursor.com/agents/bc-e65e4033-3997-4e3d-a5de-5c6cfc72ce7c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flane_deleted_final.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e65e4033-3997-4e3d-a5de-5c6cfc72ce7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e65e4033-3997-4e3d-a5de-5c6cfc72ce7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds four bullet points to the "Running the Electron desktop app on Linux" section of `AGENTS.md`, documenting practical Cursor Cloud VM gotchas: a broken `test:unit` script workaround, the correct `DISPLAY=:1` value, and fast-launch flags for the desktop and TUI dev scripts.

- Documents that `npm --prefix apps/desktop run test:unit` is broken under vitest 0.34.6 and provides the correct workarounds (`npx vitest run <file>` or `npm run test`).
- Notes `DISPLAY=:1` for Electron on the Cursor Cloud VM and documents `--skip-runtime-build` / `--attach` flags for `dev:desktop` and `dev:code` (both flags are confirmed valid in their respective scripts).

<h3>Confidence Score: 4/5</h3>

Documentation-only change; the new notes are accurate but one existing line directly contradicts the new test:unit warning.

The four new bullets are factually correct and the --skip-runtime-build/--attach flags exist in both dev scripts. However, line 84 still recommends `npm --prefix apps/desktop run test:unit` as the canonical targeted-test example, while line 114 (added in this PR) documents that the exact same command is broken. A developer following the overview section will hit the broken command without realising a workaround exists two sections later.

AGENTS.md — the existing line 84 example should be updated to match the workaround described in the new line 114.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds four Cursor Cloud Linux dev environment notes; introduces a direct contradiction with the existing `test:unit` recommendation in the Environment overview section |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer on Cursor Cloud Linux VM] --> B{What to run?}
    B --> C[Unit tests]
    B --> D[Desktop dev app]
    B --> E[TUI / ade-code]

    C --> C1["❌ npm run test:unit\n(--project unit unsupported\nin vitest 0.34.6)"]
    C --> C2["✅ npx vitest run <file>\n(inside apps/desktop)"]
    C --> C3["✅ npm run test\n(full suite)"]

    D --> D1{CLI already built?}
    D1 -- No --> D2["npm run dev:desktop\n(builds CLI first)"]
    D1 -- Yes --> D3["npm run dev:desktop --\n--skip-runtime-build\n(fast path)"]
    D2 --> D4["Set DISPLAY=:1\nbefore launching Electron"]
    D3 --> D4

    E --> E1{Runtime already running?}
    E1 -- No --> E2["npm run dev:code --\n--skip-runtime-build --auto\n(starts runtime)"]
    E1 -- Yes --> E3["npm run dev:code --\n--skip-runtime-build --attach\n--project-root p --workspace-root w"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `AGENTS.md`, line 84 ([link](https://github.com/arul28/ade/blob/4baba069ad0e93133657d5e3a099d36749f9c64d/AGENTS.md#L84)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> The example command is the same one documented as broken three lines below (line 114). Use the working alternative so the two notes are consistent.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: AGENTS.md
   Line: 84

   Comment:
   The example command is the same one documented as broken three lines below (line 114). Use the working alternative so the two notes are consistent.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20AGENTS.md%0ALine%3A%2084%0A%0AComment%3A%0AThe%20example%20command%20is%20the%20same%20one%20documented%20as%20broken%20three%20lines%20below%20%28line%20114%29.%20Use%20the%20working%20alternative%20so%20the%20two%20notes%20are%20consistent.%0A%0A%60%60%60suggestion%0A-%20The%20desktop%20test%20suite%20%28265%20test%20files%29%20is%20large%3B%20CI%20shards%20it.%20For%20local%20iteration%2C%20run%20targeted%20tests%20%28e.g.%20%60npx%20vitest%20run%20%3Cspecific-test-file%3E%60%20inside%20%60apps%2Fdesktop%60%29%20or%20%60npm%20--prefix%20apps%2Fdesktop%20run%20test%60%20for%20the%20full%20suite.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=310&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AAGENTS.md%3A84%0AThe%20example%20command%20is%20the%20same%20one%20documented%20as%20broken%20three%20lines%20below%20%28line%20114%29.%20Use%20the%20working%20alternative%20so%20the%20two%20notes%20are%20consistent.%0A%0A%60%60%60suggestion%0A-%20The%20desktop%20test%20suite%20%28265%20test%20files%29%20is%20large%3B%20CI%20shards%20it.%20For%20local%20iteration%2C%20run%20targeted%20tests%20%28e.g.%20%60npx%20vitest%20run%20%3Cspecific-test-file%3E%60%20inside%20%60apps%2Fdesktop%60%29%20or%20%60npm%20--prefix%20apps%2Fdesktop%20run%20test%60%20for%20the%20full%20suite.%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=310&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
AGENTS.md:84
The example command is the same one documented as broken three lines below (line 114). Use the working alternative so the two notes are consistent.

```suggestion
- The desktop test suite (265 test files) is large; CI shards it. For local iteration, run targeted tests (e.g. `npx vitest run <specific-test-file>` inside `apps/desktop`) or `npm --prefix apps/desktop run test` for the full suite.
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Cursor Cloud Linux dev environ..."](https://github.com/arul28/ade/commit/4baba069ad0e93133657d5e3a099d36749f9c64d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32227576)</sub>

<!-- /greptile_comment -->