### PR TITLE
Harden Mac VM screenshots against blank VNC frames

### DIFF
--- a/apps/desktop/src/main/services/macosVm/macosVmService.ts
+++ b/apps/desktop/src/main/services/macosVm/macosVmService.ts
@@ -1446,7 +1446,10 @@ export function createMacosVmService(args: CreateMacosVmServiceArgs) {
       const screenshot = await directVncClient.captureScreenshot(directVnc, 15_000);
       fs.writeFileSync(outputPath, screenshot.pngData);
       const target = directVncTargetForRecord(lane, record, screenshot);
-      emitOperation("screenshot", "completed", lane.id, record.name, "Captured macOS VM screenshot through headless VNC.");
+      const retryDetail = screenshot.blankFrameAttempts && screenshot.blankFrameAttempts > 0
+        ? ` after waiting through ${screenshot.blankFrameAttempts} black frame${screenshot.blankFrameAttempts === 1 ? "" : "s"}`
+        : "";
+      emitOperation("screenshot", "completed", lane.id, record.name, `Captured macOS VM screenshot through headless VNC${retryDetail}.`);
       return {
         ok: true,
         laneId: lane.id,

--- a/apps/desktop/src/main/services/macosVm/rfbDirectClient.test.ts
+++ b/apps/desktop/src/main/services/macosVm/rfbDirectClient.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { isLikelyBlankRgbaFrame } from "./rfbDirectClient";
+
+function rgbaFrame(width: number, height: number, fill: [number, number, number, number]): Buffer {
+  const buffer = Buffer.alloc(width * height * 4);
+  for (let offset = 0; offset < buffer.length; offset += 4) {
+    buffer[offset] = fill[0];
+    buffer[offset + 1] = fill[1];
+    buffer[offset + 2] = fill[2];
+    buffer[offset + 3] = fill[3];
+  }
+  return buffer;
+}
+
+describe("isLikelyBlankRgbaFrame", () => {
+  it("treats all-black and transparent VNC frames as blank", () => {
+    expect(isLikelyBlankRgbaFrame(64, 64, rgbaFrame(64, 64, [0, 0, 0, 255]))).toBe(true);
+    expect(isLikelyBlankRgbaFrame(64, 64, rgbaFrame(64, 64, [0, 0, 0, 0]))).toBe(true);
+  });
+
+  it("still treats a black frame with only a tiny cursor-sized patch as blank", () => {
+    const frame = rgbaFrame(320, 200, [0, 0, 0, 255]);
+    for (let y = 0; y < 6; y += 1) {
+      for (let x = 0; x < 6; x += 1) {
+        const offset = ((y * 320) + x) * 4;
+        frame[offset] = 255;
+        frame[offset + 1] = 255;
+        frame[offset + 2] = 255;
+        frame[offset + 3] = 255;
+      }
+    }
+
+    expect(isLikelyBlankRgbaFrame(320, 200, frame)).toBe(true);
+  });
+
+  it("treats transparent black frames with only a noisy pixel as blank", () => {
+    const frame = rgbaFrame(1440, 900, [0, 0, 0, 0]);
+    frame[0] = 13;
+    frame[1] = 14;
+    frame[2] = 4;
+    frame[3] = 255;
+
+    expect(isLikelyBlankRgbaFrame(1440, 900, frame)).toBe(true);
+  });
+
+  it("keeps dark real content once enough non-black pixels are present", () => {
+    const frame = rgbaFrame(320, 200, [0, 0, 0, 255]);
+    for (let y = 20; y < 60; y += 1) {
+      for (let x = 30; x < 220; x += 1) {
+        const offset = ((y * 320) + x) * 4;
+        frame[offset] = 18;
+        frame[offset + 1] = 21;
+        frame[offset + 2] = 27;
+        frame[offset + 3] = 255;
+      }
+    }
+
+    expect(isLikelyBlankRgbaFrame(320, 200, frame)).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/services/macosVm/rfbDirectClient.ts
+++ b/apps/desktop/src/main/services/macosVm/rfbDirectClient.ts
@@ -208,32 +208,35 @@ export async function captureVncScreenshot(
       const suffix = blankFrameAttempts > 0
         ? ` VNC returned ${blankFrameAttempts} black frame${blankFrameAttempts === 1 ? "" : "s"} while ADE waited, so ADE skipped attaching the unusable frame. The VM display may be asleep or still booting; try the screenshot again in a few seconds.`
         : "";
-      finish(new Error(`Timed out capturing VNC screenshot from ${connection.host}:${connection.port}.${suffix}`));
+      finishWithError(new Error(`Timed out capturing VNC screenshot from ${connection.host}:${connection.port}.${suffix}`));
     }, timeoutMs);
     const cleanup = (): void => {
       clearTimeout(timeout);
       if (retryTimer) clearTimeout(retryTimer);
+      client.removeListener("firstFrameUpdate", onFrame);
       client.removeListener("frameUpdated", onFrame);
       client.removeListener("connectError", onError);
       client.removeListener("authError", onAuthError);
       client.removeListener("closed", onClosed);
     };
-    const finish = (error: Error | null, screenshot?: DirectVncScreenshot): void => {
+    const finishWithError = (error: Error): void => {
       if (settled) return;
       settled = true;
       cleanup();
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve(screenshot!);
+      reject(error);
+    };
+    const finishWithScreenshot = (screenshot: DirectVncScreenshot): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(screenshot);
     };
     function onFrame(): void {
       const width = Math.max(1, client.clientWidth);
       const height = Math.max(1, client.clientHeight);
       const rgba = Buffer.from(client.fb);
       if (!isLikelyBlankRgbaFrame(width, height, rgba)) {
-        finish(null, {
+        finishWithScreenshot({
           width,
           height,
           pngData: encodeRgbaPng(width, height, makeOpaqueRgba(width, height, rgba)),
@@ -258,14 +261,15 @@ export async function captureVncScreenshot(
       }
     }
     function onError(error: unknown): void {
-      finish(error instanceof Error ? error : new Error(String(error)));
+      finishWithError(error instanceof Error ? error : new Error(String(error)));
     }
     function onAuthError(): void {
-      finish(new Error(`VNC authentication failed for ${connection.host}:${connection.port}.`));
+      finishWithError(new Error(`VNC authentication failed for ${connection.host}:${connection.port}.`));
     }
     function onClosed(): void {
-      finish(new Error(`VNC connection closed before a screenshot was captured from ${connection.host}:${connection.port}.`));
+      finishWithError(new Error(`VNC connection closed before a screenshot was captured from ${connection.host}:${connection.port}.`));
     }
+    client.on("firstFrameUpdate", onFrame);
     client.on("frameUpdated", onFrame);
     client.once("connectError", onError);
     client.once("authError", onAuthError);

--- a/apps/desktop/src/main/services/macosVm/rfbDirectClient.ts
+++ b/apps/desktop/src/main/services/macosVm/rfbDirectClient.ts
@@ -11,10 +11,15 @@ export type DirectVncScreenshot = {
   width: number;
   height: number;
   pngData: Buffer;
+  blankFrameAttempts?: number;
 };
 
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const MOUSE_LEFT_BUTTON = 1;
+const KEYSYM_SHIFT_LEFT = 0xffe1;
+const MAX_FRAME_ANALYSIS_SAMPLES = 4096;
+const BLANK_FRAME_NON_BLACK_RATIO = 0.003;
+const BLANK_FRAME_RETRY_MS = 250;
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -75,6 +80,33 @@ function encodeRgbaPng(width: number, height: number, rgba: Buffer): Buffer {
   ]);
 }
 
+function makeOpaqueRgba(width: number, height: number, rgba: Buffer): Buffer {
+  const length = Math.max(0, Math.floor(width) * Math.floor(height) * 4);
+  const opaque = Buffer.from(rgba.subarray(0, length));
+  for (let offset = 3; offset < opaque.length; offset += 4) {
+    opaque[offset] = 255;
+  }
+  return opaque;
+}
+
+export function isLikelyBlankRgbaFrame(width: number, height: number, rgba: Buffer): boolean {
+  const pixelCount = Math.max(0, Math.floor(width) * Math.floor(height));
+  if (pixelCount <= 0 || rgba.length < pixelCount * 4) return true;
+  const stride = Math.max(1, Math.floor(pixelCount / MAX_FRAME_ANALYSIS_SAMPLES));
+  let sampled = 0;
+  let nonBlack = 0;
+  for (let pixel = 0; pixel < pixelCount; pixel += stride) {
+    const offset = pixel * 4;
+    const red = rgba[offset] ?? 0;
+    const green = rgba[offset + 1] ?? 0;
+    const blue = rgba[offset + 2] ?? 0;
+    sampled += 1;
+    if (red > 12 || green > 12 || blue > 12) nonBlack += 1;
+  }
+  if (sampled === 0) return true;
+  return nonBlack / sampled < BLANK_FRAME_NON_BLACK_RATIO;
+}
+
 function createClient(): VncClient {
   const client = new VncClient({
     debug: false,
@@ -98,6 +130,16 @@ function createClient(): VncClient {
     // See sendAudio above.
   };
   return client;
+}
+
+function wakeVncDisplay(client: VncClient, width: number, height: number): void {
+  try {
+    client.sendPointerEvent(Math.floor(width / 2), Math.floor(height / 2), 0);
+    client.sendKeyEvent(KEYSYM_SHIFT_LEFT, true);
+    client.sendKeyEvent(KEYSYM_SHIFT_LEFT, false);
+  } catch {
+    // Display wake-up is best-effort; screenshot capture still retries frames.
+  }
 }
 
 function connectVnc(connection: DirectVncConnection, timeoutMs: number): Promise<VncClient> {
@@ -157,16 +199,26 @@ export async function captureVncScreenshot(
 ): Promise<DirectVncScreenshot> {
   return await withVncClient(connection, timeoutMs, async (client) => new Promise<DirectVncScreenshot>((resolve, reject) => {
     let settled = false;
-    const timeout = setTimeout(() => finish(new Error(`Timed out capturing VNC screenshot from ${connection.host}:${connection.port}.`)), timeoutMs);
+    let blankFrameAttempts = 0;
+    let retryTimer: NodeJS.Timeout | null = null;
+    const requestFullFrame = (): void => {
+      client.requestFrameUpdate(true, 0, 0, 0, Math.max(1, client.clientWidth), Math.max(1, client.clientHeight));
+    };
+    const timeout = setTimeout(() => {
+      const suffix = blankFrameAttempts > 0
+        ? ` VNC returned ${blankFrameAttempts} black frame${blankFrameAttempts === 1 ? "" : "s"} while ADE waited, so ADE skipped attaching the unusable frame. The VM display may be asleep or still booting; try the screenshot again in a few seconds.`
+        : "";
+      finish(new Error(`Timed out capturing VNC screenshot from ${connection.host}:${connection.port}.${suffix}`));
+    }, timeoutMs);
     const cleanup = (): void => {
       clearTimeout(timeout);
-      client.removeListener("firstFrameUpdate", onFrame);
+      if (retryTimer) clearTimeout(retryTimer);
       client.removeListener("frameUpdated", onFrame);
       client.removeListener("connectError", onError);
       client.removeListener("authError", onAuthError);
       client.removeListener("closed", onClosed);
     };
-    const finish = (error?: Error): void => {
+    const finish = (error: Error | null, screenshot?: DirectVncScreenshot): void => {
       if (settled) return;
       settled = true;
       cleanup();
@@ -174,16 +226,36 @@ export async function captureVncScreenshot(
         reject(error);
         return;
       }
-      const width = Math.max(1, client.clientWidth);
-      const height = Math.max(1, client.clientHeight);
-      resolve({
-        width,
-        height,
-        pngData: encodeRgbaPng(width, height, Buffer.from(client.fb)),
-      });
+      resolve(screenshot!);
     };
     function onFrame(): void {
-      finish();
+      const width = Math.max(1, client.clientWidth);
+      const height = Math.max(1, client.clientHeight);
+      const rgba = Buffer.from(client.fb);
+      if (!isLikelyBlankRgbaFrame(width, height, rgba)) {
+        finish(null, {
+          width,
+          height,
+          pngData: encodeRgbaPng(width, height, makeOpaqueRgba(width, height, rgba)),
+          blankFrameAttempts,
+        });
+        return;
+      }
+
+      blankFrameAttempts += 1;
+      if (blankFrameAttempts === 1 || blankFrameAttempts % 3 === 0) {
+        wakeVncDisplay(client, width, height);
+      }
+      if (!retryTimer) {
+        retryTimer = setTimeout(() => {
+          retryTimer = null;
+          try {
+            requestFullFrame();
+          } catch (error) {
+            onError(error);
+          }
+        }, BLANK_FRAME_RETRY_MS);
+      }
     }
     function onError(error: unknown): void {
       finish(error instanceof Error ? error : new Error(String(error)));
@@ -194,12 +266,11 @@ export async function captureVncScreenshot(
     function onClosed(): void {
       finish(new Error(`VNC connection closed before a screenshot was captured from ${connection.host}:${connection.port}.`));
     }
-    client.once("firstFrameUpdate", onFrame);
-    client.once("frameUpdated", onFrame);
+    client.on("frameUpdated", onFrame);
     client.once("connectError", onError);
     client.once("authError", onAuthError);
     client.once("closed", onClosed);
-    client.requestFrameUpdate(true, 0, 0, 0, Math.max(1, client.clientWidth), Math.max(1, client.clientHeight));
+    requestFullFrame();
   }));
 }
 

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
@@ -285,6 +285,32 @@ describe("useWorkSessions — refresh-before-focus ordering", () => {
     expect(refreshLanesSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("does not retry lane recovery on every session refresh after a failure", async () => {
+    fakeAppStoreState = {
+      ...fakeAppStoreState,
+      lanes: [],
+    };
+    refreshLanesSpy.mockRejectedValue(new Error("IPC unavailable"));
+    listSessionsCachedMock.mockResolvedValue([
+      makeSession("session-1", "lane-1"),
+    ]);
+
+    const { result } = renderHook(() => useWorkSessions());
+
+    await waitFor(() => {
+      expect(refreshLanesSpy).toHaveBeenCalledTimes(1);
+    });
+
+    listSessionsCachedMock.mockResolvedValue([
+      makeSession("session-2", "lane-1"),
+    ]);
+    await act(async () => {
+      await result.current.refresh({ force: true });
+    });
+
+    expect(refreshLanesSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("launchPtySession keeps the new terminal visible when the forced refresh is stale", async () => {
     const workState = {
       openItemIds: [] as string[],

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
@@ -9,6 +9,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 const focusSessionSpy = vi.fn();
 const selectLaneSpy = vi.fn();
 const setWorkViewStateSpy = vi.fn();
+const refreshLanesSpy = vi.fn();
 const navigateSpy = vi.fn();
 let fakeAppStoreState: Record<string, unknown>;
 const routerLocation = {
@@ -24,6 +25,7 @@ function resetFakeAppStoreState() {
     focusSession: focusSessionSpy,
     focusedSessionId: null,
     selectLane: selectLaneSpy,
+    refreshLanes: refreshLanesSpy.mockResolvedValue(undefined),
     workViewByProject: {},
     setWorkViewState: setWorkViewStateSpy,
   };
@@ -258,6 +260,29 @@ describe("useWorkSessions — refresh-before-focus ordering", () => {
     expect(openTabIdx).toBeGreaterThanOrEqual(0);
     expect(refreshDoneIdx).toBeLessThan(focusIdx);
     expect(refreshDoneIdx).toBeLessThan(openTabIdx);
+  });
+
+  it("lightly refreshes lanes when Work sessions load before lane state recovers", async () => {
+    fakeAppStoreState = {
+      ...fakeAppStoreState,
+      lanes: [],
+    };
+    listSessionsCachedMock.mockResolvedValue([
+      makeSession("session-1", "lane-1"),
+    ]);
+
+    renderHook(() => useWorkSessions());
+
+    await waitFor(() => {
+      expect(refreshLanesSpy).toHaveBeenCalledWith({
+        includeStatus: false,
+        includeSnapshots: false,
+        includeConflictStatus: false,
+        includeRebaseSuggestions: false,
+        includeAutoRebaseStatus: false,
+      });
+    });
+    expect(refreshLanesSpy).toHaveBeenCalledTimes(1);
   });
 
   it("launchPtySession keeps the new terminal visible when the forced refresh is stale", async () => {

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -322,6 +322,7 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
   const lanes = useAppStore((s) => s.lanes);
   const focusSession = useAppStore((s) => s.focusSession);
   const selectLane = useAppStore((s) => s.selectLane);
+  const refreshLanes = useAppStore((s) => s.refreshLanes);
   const workViewByProject = useAppStore((s) => s.workViewByProject);
   const setWorkViewState = useAppStore((s) => s.setWorkViewState);
 
@@ -338,6 +339,7 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
   const partiallyAppliedUrlFilterKeyRef = useRef<string | null>(null);
   const hasLoadedOnceRef = useRef(false);
   const projectRootRef = useRef<string | null>(projectRoot);
+  const laneRecoveryRefreshProjectRef = useRef<string | null>(null);
   const isWorkRoute = active && (location.pathname === "/work" || location.pathname.startsWith("/work/"));
 
   useEffect(() => {
@@ -794,11 +796,34 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
     }
     hasLoadedOnceRef.current = false;
     hasRunningSessionsRef.current = false;
+    laneRecoveryRefreshProjectRef.current = null;
     appliedQuerySessionIdRef.current = null;
     appliedUrlFilterKeyRef.current = null;
     partiallyAppliedUrlFilterKeyRef.current = null;
     pendingOptimisticSessionsRef.current.clear();
   }, [projectRoot]);
+
+  useEffect(() => {
+    if (!projectRoot || !isWorkRoute) return;
+    if (lanes.length > 0) {
+      laneRecoveryRefreshProjectRef.current = null;
+      return;
+    }
+    if (!sessions.some((session) => session.laneId)) return;
+    if (laneRecoveryRefreshProjectRef.current === projectRoot) return;
+    laneRecoveryRefreshProjectRef.current = projectRoot;
+    void refreshLanes({
+      includeStatus: false,
+      includeSnapshots: false,
+      includeConflictStatus: false,
+      includeRebaseSuggestions: false,
+      includeAutoRebaseStatus: false,
+    }).catch(() => {
+      if (laneRecoveryRefreshProjectRef.current === projectRoot) {
+        laneRecoveryRefreshProjectRef.current = null;
+      }
+    });
+  }, [isWorkRoute, lanes.length, projectRoot, refreshLanes, sessions]);
 
   useEffect(() => {
     if (!projectRoot || !isWorkRoute) return;

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -388,6 +388,10 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
     for (const session of sessions) map.set(session.id, session);
     return map;
   }, [sessions]);
+  const hasLaneBackedSessions = useMemo(
+    () => sessions.some((session) => Boolean(session.laneId)),
+    [sessions],
+  );
 
   const selectLaneForActiveTab = useCallback(
     (sessionId: string | null) => {
@@ -809,7 +813,7 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
       laneRecoveryRefreshProjectRef.current = null;
       return;
     }
-    if (!sessions.some((session) => session.laneId)) return;
+    if (!hasLaneBackedSessions) return;
     if (laneRecoveryRefreshProjectRef.current === projectRoot) return;
     laneRecoveryRefreshProjectRef.current = projectRoot;
     void refreshLanes({
@@ -818,12 +822,8 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
       includeConflictStatus: false,
       includeRebaseSuggestions: false,
       includeAutoRebaseStatus: false,
-    }).catch(() => {
-      if (laneRecoveryRefreshProjectRef.current === projectRoot) {
-        laneRecoveryRefreshProjectRef.current = null;
-      }
-    });
-  }, [isWorkRoute, lanes.length, projectRoot, refreshLanes, sessions]);
+    }).catch(() => {});
+  }, [hasLaneBackedSessions, isWorkRoute, lanes.length, projectRoot, refreshLanes]);
 
   useEffect(() => {
     if (!projectRoot || !isWorkRoute) return;

--- a/docs/features/computer-use/README.md
+++ b/docs/features/computer-use/README.md
@@ -138,7 +138,10 @@ Control flows through `ade.macosVm.*` IPC and the `macos_vm` ADE action domain:
 `getSharePolicy`, `focusWindow`, `captureScreenshot`, `selectPoint`, `click`,
 and `typeText`. The Work sidebar's Mac VM tab renders the desktop panel, while
 `ade --socket macos-vm ...` gives agents the same status/start/screenshot/select
-and click/type controls from the CLI.
+and click/type controls from the CLI. Headless screenshot capture uses direct
+VNC first; ADE waits through transient black framebuffer updates, wakes the
+display with a pointer move plus a Shift key tap, and refuses to attach a
+persistent black frame as review context.
 
 ## Cross-links
 

--- a/docs/features/terminals-and-sessions/README.md
+++ b/docs/features/terminals-and-sessions/README.md
@@ -344,7 +344,13 @@ Renderer surfaces:
 - `apps/desktop/src/main/services/macosVm/rfbDirectClient.ts` —
   headless VNC bridge for screenshot, click, and type operations. It
   disables unsupported audio negotiation for Lume VNC sessions and
-  encodes captured RGBA frames as PNGs for proof/context flows.
+  encodes captured RGBA frames as PNGs for proof/context flows. Screenshot
+  capture waits through transient black frames, wakes the VNC display with a
+  pointer move plus a Shift key tap, and fails instead of returning a persistent
+  black frame as usable context.
+- `apps/desktop/src/main/services/macosVm/rfbDirectClient.test.ts` —
+  focused coverage for direct-VNC blank-frame detection so boot/sleep frames
+  do not become misleading screenshot proof.
 - `apps/desktop/src/main/services/macosVm/macosVmService.test.ts` —
   macOS VM provider, share-policy, lifecycle, guidance, and direct-VNC
   control tests.


### PR DESCRIPTION
## Summary
- detect blank/transparent-black VNC frame updates before encoding Mac VM screenshots
- wake the VM display with pointer movement plus a Shift tap and retry full-frame updates
- refresh Work lanes lightly when session state loads before lane state, so Mac VM tools keep the active lane/root

## Verification
- live VNC probe: first capture reproduced a black PNG; after the fix, capture waited through 1 blank frame and produced a real 1440x900 login-screen screenshot
- npm install in apps/desktop, apps/ade-cli, apps/web; lockfiles stayed clean
- npm run typecheck in apps/desktop, apps/ade-cli, apps/web
- npm run lint in apps/desktop (0 errors, existing warnings)
- npx vitest run --shard=1/8 through --shard=8/8 in apps/desktop
- npm test in apps/ade-cli
- npm run build in apps/desktop, apps/ade-cli, apps/web
- node scripts/validate-docs.mjs plus internal docs map/link checks
- git diff --check

ADE PR creation note: attempted the ADE CLI path first, but this renamed branch could not be imported/attached to the existing worktree lane; using gh fallback per shipLane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced VNC screenshot capture to better handle and recover from blank frames on macOS VMs, including automatic retries with wake actions and improved reporting.
  * Improved lane data recovery when lane information is temporarily unavailable.

* **Tests**
  * Added comprehensive test coverage for blank frame detection across various scenarios.
  * Added test coverage for lane refresh behavior during work session loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens Mac VM VNC screenshot capture against blank/black framebuffer responses, adding retry logic with display-wake actions, and fixes a race where Work sessions load before lane state is available.

- **VNC blank-frame detection and retry**: `rfbDirectClient.ts` gains `isLikelyBlankRgbaFrame` (sampled RGBA analysis at 0.3% threshold) and a retry loop that wakes the display with a pointer move and Shift tap every 1–3 blank frames, then re-requests a full frame every 250 ms until a real frame or the outer timeout arrives.
- **Lane recovery on session load**: `useWorkSessions.ts` adds a one-shot `refreshLanes` call when sessions reference a lane but `lanes[]` is still empty, gated by a ref so failures and subsequent session refreshes don't trigger additional calls.

<h3>Confidence Score: 5/5</h3>

The changes are well-scoped and the retry/gating logic is correctly structured; no paths introduce data loss or incorrect state.

Both the VNC retry loop and the lane-recovery effect are correctly guarded: `settled` prevents double-resolution, `cleanup()` always cancels the retry timer before the promise settles, and the lane-recovery ref gate survives errors without enabling rapid re-fires. Tests exercise the key edge cases (cursor-only patch, failure gating). The one timing nuance (retryTimer nulled before requestFullFrame) is extremely unlikely to manifest in production and has no safety impact.

No files require special attention; `rfbDirectClient.ts` carries the most logic density and warrants a second read, but all paths are covered by the new tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/macosVm/rfbDirectClient.ts | Core VNC capture rewritten with persistent `on` listeners, blank-frame detection loop, display-wake side effects, and proper cleanup; logic is sound with one minor timing nuance around retryTimer nulling. |
| apps/desktop/src/main/services/macosVm/rfbDirectClient.test.ts | New unit tests cover all-black, transparent, cursor-patch, and dark-real-content frames; threshold and sampling logic are well validated. |
| apps/desktop/src/main/services/macosVm/macosVmService.ts | Minor log-message enhancement to include retry count in the success message; no logic changes to the capture path itself. |
| apps/desktop/src/renderer/components/terminals/useWorkSessions.ts | Adds a gated one-shot lane-recovery effect; ref guard correctly prevents duplicate calls; failure path intentionally keeps the gate closed to avoid retry loops. |
| apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts | Two new tests confirm the one-shot recovery fires on empty lanes and that a failed call does not repeat on subsequent session refreshes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant captureVncScreenshot
    participant VncClient
    participant retryTimer

    Caller->>captureVncScreenshot: captureVncScreenshot(connection, 15s)
    captureVncScreenshot->>VncClient: connect + authenticate
    captureVncScreenshot->>VncClient: requestFullFrame()
    captureVncScreenshot->>captureVncScreenshot: register on(firstFrameUpdate, frameUpdated)

    VncClient-->>captureVncScreenshot: frameUpdated (blank frame)
    captureVncScreenshot->>captureVncScreenshot: isLikelyBlankRgbaFrame → true
    captureVncScreenshot->>captureVncScreenshot: blankFrameAttempts++
    captureVncScreenshot->>VncClient: wakeVncDisplay (pointer + Shift)
    captureVncScreenshot->>retryTimer: setTimeout(250ms)

    retryTimer-->>captureVncScreenshot: fires
    captureVncScreenshot->>VncClient: requestFullFrame()

    VncClient-->>captureVncScreenshot: frameUpdated (real frame)
    captureVncScreenshot->>captureVncScreenshot: isLikelyBlankRgbaFrame → false
    captureVncScreenshot->>captureVncScreenshot: makeOpaqueRgba + encodeRgbaPng
    captureVncScreenshot->>captureVncScreenshot: cleanup() — remove listeners, clear timers
    captureVncScreenshot-->>Caller: "DirectVncScreenshot { pngData, blankFrameAttempts }"

    note over captureVncScreenshot: If outer timeout fires first → finishWithError with retry count in message
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2FmacosVm%2FrfbDirectClient.ts%3A253-260%0AThe%20retry%20timer%20clears%20%60retryTimer%60%20to%20%60null%60%20before%20calling%20%60requestFullFrame%28%29%60.%20In%20JavaScript's%20single-threaded%20event%20loop%20this%20is%20safe%20against%20true%20races%2C%20but%20a%20spontaneous%20%60frameUpdated%60%20event%20that%20arrives%20between%20when%20the%20timer%20callback%20starts%20and%20when%20%60requestFullFrame%28%29%60%20completes%20would%20find%20%60retryTimer%20%3D%3D%3D%20null%60%20and%20schedule%20an%20extra%20timer%20%E2%80%94%20resulting%20in%20two%20outstanding%20full-frame%20requests%20instead%20of%20one.%20Setting%20%60retryTimer%20%3D%20null%60%20after%20%60requestFullFrame%28%29%60%20eliminates%20that%20window%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20retryTimer%20%3D%20setTimeout%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20requestFullFrame%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%7D%20catch%20%28error%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20onError%28error%29%3B%0A%20%20%20%20%20%20%20%20%20%20%7D%20finally%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20retryTimer%20%3D%20null%3B%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%2C%20BLANK_FRAME_RETRY_MS%29%3B%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=315&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/main/services/macosVm/rfbDirectClient.ts:253-260
The retry timer clears `retryTimer` to `null` before calling `requestFullFrame()`. In JavaScript's single-threaded event loop this is safe against true races, but a spontaneous `frameUpdated` event that arrives between when the timer callback starts and when `requestFullFrame()` completes would find `retryTimer === null` and schedule an extra timer — resulting in two outstanding full-frame requests instead of one. Setting `retryTimer = null` after `requestFullFrame()` eliminates that window entirely.

```suggestion
        retryTimer = setTimeout(() => {
          try {
            requestFullFrame();
          } catch (error) {
            onError(error);
          } finally {
            retryTimer = null;
          }
        }, BLANK_FRAME_RETRY_MS);
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["ship: iteration 1 - address Greptile fee..."](https://github.com/arul28/ade/commit/b5aff70870e2a8935e4da9547883abe368aa7be4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32486554)</sub>

<!-- /greptile_comment -->