### PR TITLE
Optimize chat and mission summary scans

### DIFF
--- a/apps/desktop/src/main/services/orchestrator/aiOrchestratorService.ts
+++ b/apps/desktop/src/main/services/orchestrator/aiOrchestratorService.ts
@@ -2682,13 +2682,29 @@ Check all worker statuses and continue managing the mission from here. Read work
 
   const buildMissionStateProgressFromGraph = (graph: OrchestratorRunGraph): MissionStateProgress => {
     const relevantSteps = filterExecutionSteps(graph.steps);
+    let completedSteps = 0;
+    const activeWorkers: string[] = [];
+    const blockedSteps: string[] = [];
+    const failedSteps: string[] = [];
+    for (const step of relevantSteps) {
+      if (MISSION_STATE_TERMINAL_STEP_STATUSES.has(step.status)) {
+        completedSteps += 1;
+      }
+      if (step.status === "running") {
+        activeWorkers.push(step.stepKey);
+      } else if (step.status === "blocked") {
+        blockedSteps.push(step.stepKey);
+      } else if (step.status === "failed") {
+        failedSteps.push(step.stepKey);
+      }
+    }
     return {
       currentPhase: currentPhaseFromGraph(graph),
-      completedSteps: relevantSteps.filter((step) => MISSION_STATE_TERMINAL_STEP_STATUSES.has(step.status)).length,
+      completedSteps,
       totalSteps: relevantSteps.length,
-      activeWorkers: relevantSteps.filter((step) => step.status === "running").map((step) => step.stepKey),
-      blockedSteps: relevantSteps.filter((step) => step.status === "blocked").map((step) => step.stepKey),
-      failedSteps: relevantSteps.filter((step) => step.status === "failed").map((step) => step.stepKey),
+      activeWorkers,
+      blockedSteps,
+      failedSteps,
     };
   };
 

--- a/apps/desktop/src/main/services/orchestrator/coordinatorTools.ts
+++ b/apps/desktop/src/main/services/orchestrator/coordinatorTools.ts
@@ -391,14 +391,29 @@ function resolveCurrentPhase(graph: OrchestratorRunGraph): string {
 
 function buildMissionStateProgress(graph: OrchestratorRunGraph): MissionStateProgress {
   const relevantSteps = filterExecutionSteps(graph.steps);
-  const completedSteps = relevantSteps.filter((step) => TERMINAL_STEP_STATUSES.has(step.status)).length;
+  let completedSteps = 0;
+  const activeWorkers: string[] = [];
+  const blockedSteps: string[] = [];
+  const failedSteps: string[] = [];
+  for (const step of relevantSteps) {
+    if (TERMINAL_STEP_STATUSES.has(step.status)) {
+      completedSteps += 1;
+    }
+    if (step.status === "running") {
+      activeWorkers.push(step.stepKey);
+    } else if (step.status === "blocked") {
+      blockedSteps.push(step.stepKey);
+    } else if (step.status === "failed") {
+      failedSteps.push(step.stepKey);
+    }
+  }
   return {
     currentPhase: resolveCurrentPhase(graph),
     completedSteps,
     totalSteps: relevantSteps.length,
-    activeWorkers: relevantSteps.filter((step) => step.status === "running").map((step) => step.stepKey),
-    blockedSteps: relevantSteps.filter((step) => step.status === "blocked").map((step) => step.stepKey),
-    failedSteps: relevantSteps.filter((step) => step.status === "failed").map((step) => step.stepKey),
+    activeWorkers,
+    blockedSteps,
+    failedSteps,
   };
 }
 

--- a/apps/desktop/src/main/services/orchestrator/orchestratorService.ts
+++ b/apps/desktop/src/main/services/orchestrator/orchestratorService.ts
@@ -4125,12 +4125,26 @@ export function createOrchestratorService({
 
     const runSteps = listStepRows(args.run.id).map(toStep);
     const frontier = {
-      pending: runSteps.filter((step) => step.status === "pending").length,
-      ready: runSteps.filter((step) => step.status === "ready").length,
-      running: runSteps.filter((step) => step.status === "running").length,
-      blocked: runSteps.filter((step) => step.status === "blocked").length,
-      terminal: runSteps.filter((step) => TERMINAL_STEP_STATUSES.has(step.status)).length
+      pending: 0,
+      ready: 0,
+      running: 0,
+      blocked: 0,
+      terminal: 0
     };
+    for (const step of runSteps) {
+      if (TERMINAL_STEP_STATUSES.has(step.status)) {
+        frontier.terminal += 1;
+      }
+      if (step.status === "pending") {
+        frontier.pending += 1;
+      } else if (step.status === "ready") {
+        frontier.ready += 1;
+      } else if (step.status === "running") {
+        frontier.running += 1;
+      } else if (step.status === "blocked") {
+        frontier.blocked += 1;
+      }
+    }
     const openQuestions = Number(
       db.get<{ count: number }>(
         `
@@ -11350,7 +11364,13 @@ export function createOrchestratorService({
     checkFanOutCompletion(args: { runId: string; completedStepKey: string }): boolean {
       const { runId, completedStepKey } = args;
       const allSteps = listStepRows(runId).map(toStep);
-      const completedStep = allSteps.find((s) => s.stepKey === completedStepKey);
+      const stepByKey = new Map<string, OrchestratorStep>();
+      for (const step of allSteps) {
+        if (!stepByKey.has(step.stepKey)) {
+          stepByKey.set(step.stepKey, step);
+        }
+      }
+      const completedStep = stepByKey.get(completedStepKey);
       if (!completedStep) return false;
 
       // Find the parent via fanOutParent in metadata
@@ -11358,7 +11378,7 @@ export function createOrchestratorService({
       const parentStepKey = meta.fanOutParent as string | undefined;
       if (!parentStepKey) return false;
 
-      const parentStep = allSteps.find((s) => s.stepKey === parentStepKey);
+      const parentStep = stepByKey.get(parentStepKey);
       if (!parentStep) return false;
 
       const parentMeta = (parentStep.metadata ?? {}) as Record<string, unknown>;
@@ -11368,15 +11388,23 @@ export function createOrchestratorService({
       // Check if all children are in a terminal state
       const terminalStatuses = new Set<string>(["succeeded", "failed", "skipped", "superseded", "canceled"]);
       const allDone = childKeys.every((key) => {
-        const child = allSteps.find((s) => s.stepKey === key);
+        const child = stepByKey.get(key);
         return child && terminalStatuses.has(child.status);
       });
 
       if (allDone && parentMeta.fanOutComplete !== true) {
         const updatedMeta = { ...parentMeta, fanOutComplete: true };
         const now = nowIso();
-        const succeededCount = childKeys.filter((key) => allSteps.find((s) => s.stepKey === key)?.status === "succeeded").length;
-        const failedCount = childKeys.filter((key) => allSteps.find((s) => s.stepKey === key)?.status === "failed").length;
+        let succeededCount = 0;
+        let failedCount = 0;
+        for (const key of childKeys) {
+          const child = stepByKey.get(key);
+          if (child?.status === "succeeded") {
+            succeededCount += 1;
+          } else if (child?.status === "failed") {
+            failedCount += 1;
+          }
+        }
 
         // VAL-STATE-002: Update parent step status to reflect variant outcomes.
         // If any child succeeded → parent succeeded; if all failed → parent failed.

--- a/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
@@ -47,7 +47,7 @@ import type {
 import { getModelById, resolveModelDescriptor, type ModelDescriptor } from "../../../shared/modelRegistry";
 import { cn } from "../ui/cn";
 import { formatTime } from "../../lib/format";
-import { openExternalUrl, openUrlInAdeBrowser } from "../../lib/openExternal";
+import { openUrlInAdeBrowser } from "../../lib/openExternal";
 import { isPathEqualOrDescendant, isWindowsAbsolutePath, normalizePath } from "../../lib/pathUtils";
 import { describeToolIdentifier, replaceInternalToolNames } from "./toolPresentation";
 import { chatChipToneClass } from "./chatSurfaceTheme";
@@ -552,13 +552,6 @@ function StatusIcon({ status }: { status: "running" | "completed" | "failed" | "
   if (status === "interrupted") return <ChatStatusGlyph status="waiting" size={13} />;
   if (status === "completed" || status === "failed") return <ChatStatusGlyph status={status} size={13} />;
   return <ChatStatusGlyph status="working" size={13} />;
-}
-
-function PlanStepIcon({ status }: { status: string }) {
-  if (status === "completed") return <Checks size={13} weight="bold" className="text-emerald-400" />;
-  if (status === "failed") return <XCircle size={13} weight="bold" className="text-red-400" />;
-  if (status === "in_progress") return <Circle size={11} weight="fill" className="text-sky-400/80" />;
-  return <Circle size={11} weight="regular" className="text-muted-fg/40" />;
 }
 
 function todoItemStatusClass(status: string): string {
@@ -3176,26 +3169,11 @@ function renderEvent(
   );
 }
 
-type TurnSummaryTask = {
-  id: string;
-  description: string;
-  status: string;
-};
-
-type TurnSummaryFile = {
-  path: string;
-  kind: Extract<AgentChatEvent, { type: "file_change" }>["kind"];
-  status?: Extract<AgentChatEvent, { type: "file_change" }>["status"];
-  additions: number;
-  deletions: number;
-};
-
 type TurnSummary = {
   turnId: string;
-  tasks: TurnSummaryTask[];
-  files: TurnSummaryFile[];
-  totalAdditions: number;
-  totalDeletions: number;
+  taskCount: number;
+  completedTaskCount: number;
+  changedFileCount: number;
   backgroundAgentCount: number;
   activeBackgroundAgentCount: number;
   turnModel: { label: string; modelId?: string; model?: string } | null;
@@ -3207,10 +3185,11 @@ function deriveTurnSummary(
   events: AgentChatEventEnvelope[],
   turnModelState: DerivedTurnModelState | null,
 ): TurnSummary | null {
-  const latestTurnId = [...events]
-    .reverse()
-    .map((envelope) => getEventTurnId(envelope.event))
-    .find((turnId): turnId is string => Boolean(turnId));
+  let latestTurnId: string | null = null;
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    latestTurnId = getEventTurnId(events[i]!.event);
+    if (latestTurnId) break;
+  }
   if (!latestTurnId) return null;
 
   let latestTodoUpdate: Extract<AgentChatEvent, { type: "todo_update" }> | null = null;
@@ -3218,7 +3197,7 @@ function deriveTurnSummary(
   let turnStartedAt: number | null = null;
   let turnEndedAt: number | null = null;
   let ended = false;
-  const files = new Map<string, TurnSummaryFile>();
+  const changedFilePaths = new Set<string>();
   const subagents = new Map<string, { background: boolean; status: ChatSubagentSnapshot["status"] }>();
 
   for (const envelope of events) {
@@ -3245,14 +3224,7 @@ function deriveTurnSummary(
     }
 
     if (event.type === "file_change") {
-      const stats = summarizeDiffStats(event.diff);
-      files.set(event.path, {
-        path: event.path,
-        kind: event.kind,
-        status: event.status,
-        additions: stats.additions,
-        deletions: stats.deletions,
-      });
+      changedFilePaths.add(event.path);
       continue;
     }
 
@@ -3283,26 +3255,25 @@ function deriveTurnSummary(
     }
   }
 
-  const tasks: TurnSummaryTask[] = latestTodoUpdate
-    ? latestTodoUpdate.items.map((item) => ({
-        id: item.id,
-        description: item.description,
-        status: item.status,
-      }))
-    : latestPlan
-      ? latestPlan.steps.map((step, index) => ({
-          id: `plan-${index}`,
-          description: step.text,
-          status: step.status,
-        }))
-      : [];
-  const changedFiles = [...files.values()];
-  const totalAdditions = changedFiles.reduce((sum, file) => sum + file.additions, 0);
-  const totalDeletions = changedFiles.reduce((sum, file) => sum + file.deletions, 0);
-  const backgroundAgentCount = [...subagents.values()].filter((entry) => entry.background).length;
-  const activeBackgroundAgentCount = [...subagents.values()].filter((entry) => entry.background && entry.status === "running").length;
+  let taskCount = 0;
+  let completedTaskCount = 0;
+  const taskSource = latestTodoUpdate?.items ?? latestPlan?.steps ?? [];
+  for (const task of taskSource) {
+    taskCount += 1;
+    if (task.status === "completed") completedTaskCount += 1;
+  }
+  const changedFileCount = changedFilePaths.size;
+  let backgroundAgentCount = 0;
+  let activeBackgroundAgentCount = 0;
+  for (const entry of subagents.values()) {
+    if (!entry.background) continue;
+    backgroundAgentCount += 1;
+    if (entry.status === "running") {
+      activeBackgroundAgentCount += 1;
+    }
+  }
 
-  if (!tasks.length && !changedFiles.length && !backgroundAgentCount) {
+  if (!taskCount && !changedFileCount && !backgroundAgentCount) {
     return null;
   }
 
@@ -3313,12 +3284,11 @@ function deriveTurnSummary(
 
   return {
     turnId: latestTurnId,
-    tasks,
-    files: changedFiles,
+    taskCount,
+    completedTaskCount,
+    changedFileCount,
     durationMs,
     ended,
-    totalAdditions,
-    totalDeletions,
     backgroundAgentCount,
     activeBackgroundAgentCount,
     turnModel: turnModelState?.map.get(latestTurnId) ?? null,
@@ -3336,9 +3306,7 @@ function formatTurnDuration(durationMs: number): string {
 
 function TurnDivider({ summary }: { summary: TurnSummary }) {
   if (!summary.ended) return null;
-  const completedCount = summary.tasks.filter((task) => task.status === "completed").length;
-  const totalCount = summary.tasks.length;
-  const taskLine = totalCount ? `${completedCount}/${totalCount} tasks complete` : null;
+  const taskLine = summary.taskCount ? `${summary.completedTaskCount}/${summary.taskCount} tasks complete` : null;
   const agentLine = summary.backgroundAgentCount
     ? `${summary.backgroundAgentCount} background ${summary.backgroundAgentCount === 1 ? "agent" : "agents"}${
         summary.activeBackgroundAgentCount > 0 ? ` · ${summary.activeBackgroundAgentCount} still running` : " finished"
@@ -3831,7 +3799,7 @@ export function AgentChatMessageList({
   const turnSummary = useMemo(() => deriveTurnSummary(events, turnModelState), [events, turnModelState]);
 
   const handleReviewChanges = useCallback(() => {
-    if (!turnSummary?.files.length) return;
+    if (!turnSummary?.changedFileCount) return;
     const state = currentLaneId ? { laneId: currentLaneId } : undefined;
     navigate("/files", state ? { state } : undefined);
   }, [currentLaneId, navigate, turnSummary]);


### PR DESCRIPTION
## Summary
- reduce chat turn-summary allocation and repeated scans
- collapse mission progress summary filter/map passes into single scans
- index fan-out completion lookups while preserving first-match behavior

## Validation
- npx vitest run src/renderer/components/chat/AgentChatMessageList.test.tsx src/main/services/orchestrator/orchestratorService.test.ts src/main/services/orchestrator/aiOrchestratorService.test.ts src/main/services/orchestrator/coordinatorTools.test.ts
- npx vitest run src/renderer/components/chat/AgentChatMessageList.test.tsx
- npx vitest run src/main/services/orchestrator/orchestratorService.test.ts
- npm --prefix apps/desktop run typecheck
- git diff --check
- eslint on touched files: 0 errors, pre-existing warnings remain in orchestrator files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated mission state computation logic across orchestrator services.
  * Improved task tracking data model in chat messages.
  * Simplified URL handling in chat interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pure performance refactor replacing repeated `filter`/`map`/`find` passes with single-loop accumulations and a Map index across the orchestrator and chat layers. No behavioural changes are intended.

- `orchestratorService.ts`: frontier step counts now computed in one loop; `checkFanOutCompletion` replaces per-child `Array.find` calls (O(n × m)) with a pre-built `Map` for O(1) lookups, including succeeded/failed tallying.
- `aiOrchestratorService.ts` + `coordinatorTools.ts`: mission-state progress (completed, active, blocked, failed) collapsed from four independent filter passes into a single iteration over `relevantSteps`.
- `AgentChatMessageList.tsx`: `TurnSummary` slimmed to integer counts (`taskCount`, `completedTaskCount`, `changedFileCount`), removing the per-file diff-stat and per-task detail arrays that were only ever consumed as aggregates; dead `PlanStepIcon` component and unused `openExternalUrl` import removed.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are equivalent rewrites of existing logic with no altered outputs.

Every loop replacement produces the same results as its predecessor. The only non-trivial subtlety is the first-match guard in the checkFanOutCompletion Map build, which correctly mirrors Array.find but would benefit from a short comment to protect against future edits.

The checkFanOutCompletion section of orchestratorService.ts is worth a quick read to confirm first-match Map behaviour matches expectations for duplicate step keys in the DB result set.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/orchestrator/orchestratorService.ts | Two optimizations: frontier counts consolidated from 5 separate filter passes into one loop; checkFanOutCompletion replaced 3 O(n) Array.find calls per child key with a single upfront Map build. First-match semantics are preserved but implicit. |
| apps/desktop/src/main/services/orchestrator/aiOrchestratorService.ts | buildMissionStateProgressFromGraph consolidated from 4 filter/map passes into one loop. Semantics are identical to the original. |
| apps/desktop/src/main/services/orchestrator/coordinatorTools.ts | buildMissionStateProgress consolidated from 4 filter/map passes into one loop, mirroring the change in aiOrchestratorService. No behavioral difference. |
| apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx | TurnSummary simplified: per-task and per-file detail arrays replaced with integer counts; latestTurnId scan avoids array copy+reverse; dead PlanStepIcon component and unused openExternalUrl import removed. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Forchestrator%2ForchestratorService.ts%3A11367-11372%0AAdding%20a%20brief%20comment%20here%20would%20make%20the%20first-match%20intent%20explicit%20and%20prevent%20a%20well-meaning%20refactor%20from%20accidentally%20switching%20to%20last-match%20semantics.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%2F%2F%20Build%20index%20keyed%20by%20stepKey%3B%20keep%20the%20first%20occurrence%20to%20match%20prior%20Array.find%20semantics.%0A%20%20%20%20%20%20const%20stepByKey%20%3D%20new%20Map%3Cstring%2C%20OrchestratorStep%3E%28%29%3B%0A%20%20%20%20%20%20for%20%28const%20step%20of%20allSteps%29%20%7B%0A%20%20%20%20%20%20%20%20if%20%28!stepByKey.has%28step.stepKey%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20stepByKey.set%28step.stepKey%2C%20step%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=316&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/main/services/orchestrator/orchestratorService.ts:11367-11372
Adding a brief comment here would make the first-match intent explicit and prevent a well-meaning refactor from accidentally switching to last-match semantics.

```suggestion
      // Build index keyed by stepKey; keep the first occurrence to match prior Array.find semantics.
      const stepByKey = new Map<string, OrchestratorStep>();
      for (const step of allSteps) {
        if (!stepByKey.has(step.stepKey)) {
          stepByKey.set(step.stepKey, step);
        }
      }
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Optimize chat and mission summary scans"](https://github.com/arul28/ade/commit/0924d0ecc6c88a5994141d5b46c7aff0c59415c1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32537734)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->