### PR TITLE
Fix OpenCode and LM Studio model refresh

### DIFF
--- a/apps/desktop/src/main/services/ai/aiIntegrationService.test.ts
+++ b/apps/desktop/src/main/services/ai/aiIntegrationService.test.ts
@@ -19,6 +19,7 @@ const mockState = vi.hoisted(() => ({
   clearOpenCodeInventoryCache: vi.fn(),
   peekOpenCodeInventoryCache: vi.fn(),
   probeOpenCodeProviderInventory: vi.fn(),
+  clearOpenCodeBinaryCache: vi.fn(),
   resolveOpenCodeBinary: vi.fn(),
 }));
 
@@ -68,6 +69,7 @@ vi.mock("../opencode/openCodeInventory", () => ({
 }));
 
 vi.mock("../opencode/openCodeBinaryManager", () => ({
+  clearOpenCodeBinaryCache: (...args: unknown[]) => mockState.clearOpenCodeBinaryCache(...args),
   resolveOpenCodeBinary: (...args: unknown[]) => mockState.resolveOpenCodeBinary(...args),
 }));
 
@@ -276,6 +278,7 @@ beforeEach(() => {
     error: null,
     descriptors: [],
   });
+  mockState.clearOpenCodeBinaryCache.mockImplementation(() => undefined);
   mockState.resolveOpenCodeBinary.mockReturnValue({
     path: "/Users/admin/.opencode/bin/opencode",
     source: "user-installed",
@@ -450,6 +453,14 @@ describe("aiIntegrationService", () => {
       { id: "openai", name: "OpenAI", connected: true, modelCount: 1 },
     ]);
     expect(status.availableModelIds).toContain("opencode/openai/gpt-5.4-mini");
+  });
+
+  it("clears the OpenCode binary cache on forced status refresh", async () => {
+    const { service } = makeService();
+
+    await service.getStatus({ force: true });
+
+    expect(mockState.clearOpenCodeBinaryCache).toHaveBeenCalledTimes(1);
   });
 
   it("keeps forced status refresh non-interactive for Claude", async () => {

--- a/apps/desktop/src/main/services/ai/aiIntegrationService.test.ts
+++ b/apps/desktop/src/main/services/ai/aiIntegrationService.test.ts
@@ -432,18 +432,18 @@ describe("aiIntegrationService", () => {
           }]
         : [],
     }));
-    mockState.probeOpenCodeProviderInventory.mockImplementation(async (args: any) => {
-      expect(args.discoveredLocalModels).toContainEqual({ provider: "lmstudio", modelId });
-      return {
+    mockState.probeOpenCodeProviderInventory.mockResolvedValue({
         modelIds: [`opencode/lmstudio/${modelId}`],
         providers: [{ id: "lmstudio", name: "LM Studio", connected: true, modelCount: 1 }],
         error: null,
         descriptors: [],
-      };
     });
 
     const status = await service.getStatus({ refreshOpenCodeInventory: true });
 
+    expect(mockState.probeOpenCodeProviderInventory).toHaveBeenCalledWith(expect.objectContaining({
+      discoveredLocalModels: expect.arrayContaining([{ provider: "lmstudio", modelId }]),
+    }));
     expect(status.runtimeConnections?.lmstudio?.loadedModelIds).toContain(`lmstudio/${modelId}`);
     expect(status.availableModelIds).toContain(`opencode/lmstudio/${modelId}`);
   });

--- a/apps/desktop/src/main/services/ai/aiIntegrationService.test.ts
+++ b/apps/desktop/src/main/services/ai/aiIntegrationService.test.ts
@@ -406,6 +406,48 @@ describe("aiIntegrationService", () => {
     expect(ollama?.blocker).toBe(`Ollama did not respond at ${getLocalProviderDefaultEndpoint("ollama")}.`);
   });
 
+  it("surfaces LM Studio OpenAI-compatible models as loaded local runtime models", async () => {
+    const modelId = "qwen3.5-9b-claude-4.6-opus-reasoning-distilled-v2";
+    const endpoint = getLocalProviderDefaultEndpoint("lmstudio");
+    const { service } = makeService({
+      providerMode: "guest",
+      availability: { claude: false, codex: false, cursor: false, droid: false },
+    });
+
+    mockState.detectAllAuth.mockResolvedValue([
+      { type: "local", provider: "lmstudio", endpoint, endpointSource: "auto" },
+    ]);
+    mockState.inspectLocalProvider.mockImplementation(async (provider: string, inspectedEndpoint: string) => ({
+      provider,
+      endpoint: inspectedEndpoint,
+      reachable: provider === "lmstudio",
+      health: provider === "lmstudio" ? "ready" : "unreachable",
+      loadedModels: provider === "lmstudio"
+        ? [{
+            provider: "lmstudio",
+            modelId,
+            displayName: modelId,
+            discoverySource: "lmstudio-openai",
+            loaded: true,
+          }]
+        : [],
+    }));
+    mockState.probeOpenCodeProviderInventory.mockImplementation(async (args: any) => {
+      expect(args.discoveredLocalModels).toContainEqual({ provider: "lmstudio", modelId });
+      return {
+        modelIds: [`opencode/lmstudio/${modelId}`],
+        providers: [{ id: "lmstudio", name: "LM Studio", connected: true, modelCount: 1 }],
+        error: null,
+        descriptors: [],
+      };
+    });
+
+    const status = await service.getStatus({ refreshOpenCodeInventory: true });
+
+    expect(status.runtimeConnections?.lmstudio?.loadedModelIds).toContain(`lmstudio/${modelId}`);
+    expect(status.availableModelIds).toContain(`opencode/lmstudio/${modelId}`);
+  });
+
   it("coalesces concurrent getStatus calls for the same request shape", async () => {
     const { service } = makeService();
     let resolveAuth: ((value: Array<Record<string, unknown>>) => void) | null = null;

--- a/apps/desktop/src/main/services/ai/aiIntegrationService.ts
+++ b/apps/desktop/src/main/services/ai/aiIntegrationService.ts
@@ -47,7 +47,11 @@ import {
   probeOpenCodeProviderInventory,
 } from "../opencode/openCodeInventory";
 import type { DiscoveredLocalModelEntry } from "../opencode/openCodeRuntime";
-import { resolveOpenCodeBinary, type OpenCodeBinarySource } from "../opencode/openCodeBinaryManager";
+import {
+  clearOpenCodeBinaryCache,
+  resolveOpenCodeBinary,
+  type OpenCodeBinarySource,
+} from "../opencode/openCodeBinaryManager";
 import { initialize as initModelsDevService } from "./modelsDevService";
 import { updateModelPricing } from "../../../shared/modelProfiles";
 import { isRecord } from "../shared/utils";
@@ -1637,6 +1641,7 @@ export function createAiIntegrationService(args: {
     resetLocalProviderDetectionCache();
     clearCursorCliModelsCache();
     clearDroidCliModelsCache();
+    clearOpenCodeBinaryCache();
     clearOpenCodeInventoryCache();
     replaceDynamicOpenCodeModelDescriptors([]);
   };

--- a/apps/desktop/src/main/services/ai/localModelDiscovery.test.ts
+++ b/apps/desktop/src/main/services/ai/localModelDiscovery.test.ts
@@ -325,7 +325,34 @@ describe("inspectLocalProvider — lmstudio (OpenAI-compat fallback)", () => {
     expect(result.health).toBe("ready");
     expect(result.loadedModels).toHaveLength(2);
     expect(result.loadedModels[0]!.discoverySource).toBe("lmstudio-openai");
+    expect(result.loadedModels[0]!.loaded).toBe(true);
     expect(result.loadedModels[0]!.harnessProfile).toBe("verified"); // llama 3.1
+  });
+
+  it("falls back to /v1/models when REST API returns an unexpected object shape", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        data: [
+          { id: "qwen3.5-9b-claude-4.6-opus-reasoning-distilled-v2" },
+        ],
+      }),
+    );
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        data: [
+          { id: "qwen3.5-9b-claude-4.6-opus-reasoning-distilled-v2" },
+        ],
+      }),
+    );
+
+    const result = await inspectLocalProvider("lmstudio", "http://localhost:1234");
+
+    expect(result.reachable).toBe(true);
+    expect(result.health).toBe("ready");
+    expect(result.loadedModels).toHaveLength(1);
+    expect(result.loadedModels[0]!.modelId).toBe("qwen3.5-9b-claude-4.6-opus-reasoning-distilled-v2");
+    expect(result.loadedModels[0]!.discoverySource).toBe("lmstudio-openai");
+    expect(result.loadedModels[0]!.loaded).toBe(true);
   });
 
   it("returns unreachable when both REST and OpenAI endpoints fail", async () => {

--- a/apps/desktop/src/main/services/ai/localModelDiscovery.ts
+++ b/apps/desktop/src/main/services/ai/localModelDiscovery.ts
@@ -174,10 +174,12 @@ async function inspectLmStudioProvider(endpoint: string, timeoutMs: number): Pro
   const base = endpoint.replace(/\/+$/, "");
   const restPayload = await fetchJson(`${base}/api/v1/models`, timeoutMs);
 
-  if (restPayload && typeof restPayload === "object") {
-    const models = Array.isArray((restPayload as { models?: unknown[] }).models)
-      ? (restPayload as { models: Array<Record<string, unknown>> }).models
-      : [];
+  if (
+    restPayload
+    && typeof restPayload === "object"
+    && Array.isArray((restPayload as { models?: unknown[] }).models)
+  ) {
+    const models = (restPayload as { models: Array<Record<string, unknown>> }).models;
 
     const discovered: DiscoveredLocalModel[] = [];
 
@@ -249,7 +251,7 @@ async function inspectLmStudioProvider(endpoint: string, timeoutMs: number): Pro
         capabilities: fallback.capabilities,
         harnessProfile: fallback.harnessProfile,
         discoverySource: "lmstudio-openai" as const,
-        loaded: false,
+        loaded: true,
       } satisfies DiscoveredLocalModel;
     });
 
@@ -340,4 +342,3 @@ export function clearLocalProviderInspectionCache(): void {
   inspectionCacheGeneration += 1;
   inspectionCache = new Map<string, { generation: number; cachedAt: number; inspection: LocalProviderInspection }>();
 }
-


### PR DESCRIPTION
## Summary
- clear the cached OpenCode binary lookup when provider status is force-refreshed
- fall back to LM Studio's OpenAI-compatible `/v1/models` response when `/api/v1/models` returns an unexpected object shape
- treat LM Studio OpenAI-compatible model listings as loaded so they surface in runtime/OpenCode model discovery

## Tests
- `npx vitest run src/main/services/ai/localModelDiscovery.test.ts src/main/services/ai/aiIntegrationService.test.ts src/main/services/ai/authDetector.test.ts src/renderer/lib/modelOptions.test.ts`
- `npm --prefix apps/desktop run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced LM Studio OpenAI-compatible model discovery and status reporting (discovered models now appear as loaded).

* **Bug Fixes**
  * Improved fallback when LM Studio REST responses are unexpected.
  * Models from local LM Studio instances are correctly reported as available/loaded.
  * Cache invalidation now clears local binary cache to keep model inventory consistent.

* **Tests**
  * Added tests covering LM Studio discovery, model mapping, and cache invalidation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two LM Studio model-discovery bugs and clears the OpenCode binary cache on forced refresh. The changes are targeted and well-tested, with new unit and integration tests covering each behaviour.

- **`localModelDiscovery.ts`**: The REST-path guard is tightened to only handle responses that include a `.models` array; anything else now falls through to the OpenAI-compatible `/v1/models` endpoint. Models discovered via that endpoint have their `loaded` flag corrected from `false` to `true`, so they surface correctly in runtime and OpenCode model discovery.
- **`aiIntegrationService.ts`**: `clearOpenCodeBinaryCache()` is added to `invalidateProviderReadinessCaches()`, ensuring a forced status refresh doesn't re-use a stale binary path.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are surgical, fully covered by new tests, and the only known trade-off (reachability signal when REST returns an unexpected shape) was already discussed in a prior review.

All three changed behaviours (binary cache invalidation, `loaded: true` for OpenAI-compat models, REST-path guard tightening) have dedicated test coverage. No new defects are introduced; the one edge-case behaviour change was flagged and acknowledged in the previous review round.

No files require special attention beyond the already-discussed reachability edge case in `localModelDiscovery.ts`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/ai/localModelDiscovery.ts | Tightens the REST-path guard so only properly-shaped responses are handled there, and correctly flips `loaded` to `true` for OpenAI-compat models. The guard change was flagged in a prior review (reachable LM Studio instances that return an unexpected `/api/v1/models` body now report "unreachable" if `/v1/models` also fails). |
| apps/desktop/src/main/services/ai/aiIntegrationService.ts | Adds `clearOpenCodeBinaryCache()` to `invalidateProviderReadinessCaches()` and imports the new export — a straightforward, low-risk cache-invalidation fix. |
| apps/desktop/src/main/services/ai/localModelDiscovery.test.ts | Adds two new test cases for the unexpected-shape fallback and the `loaded: true` assertion; also pins the `loaded: true` assertion on the existing OpenAI-compat test. Coverage is complete for the changed paths. |
| apps/desktop/src/main/services/ai/aiIntegrationService.test.ts | Adds mocks and two new integration tests: one verifying that OpenAI-compat LM Studio models surface through the full pipeline, and one confirming the binary cache is cleared on forced refresh. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant S as aiIntegrationService
    participant D as localModelDiscovery
    participant R as LM Studio /api/v1/models
    participant O as LM Studio /v1/models

    S->>D: inspectLocalProvider("lmstudio", endpoint)
    D->>R: GET /api/v1/models
    alt REST response has .models array
        R-->>D: "{ models: [...] } (REST shape)"
        D-->>S: "{ reachable: true, loaded: true, discoverySource: "lmstudio-rest" }"
    else REST response has unexpected shape (or null)
        R-->>D: "{ data: [...] } or null/404"
        D->>O: GET /v1/models
        alt OpenAI endpoint responds
            O-->>D: "{ data: [...] }"
            D-->>S: "{ reachable: true, loaded: true, discoverySource: "lmstudio-openai" }"
        else OpenAI endpoint also fails
            O-->>D: null / error
            D-->>S: "{ reachable: false, health: "unreachable" }"
        end
    end

    S->>S: "getStatus({ force: true })"
    note over S: invalidateProviderReadinessCaches() now includes clearOpenCodeBinaryCache()
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/main/services/ai/localModelDiscovery.ts`, line 177-235 ([link](https://github.com/arul28/ade/blob/046a243276a95ae95d900a47869a19d3c153b1ac/apps/desktop/src/main/services/ai/localModelDiscovery.ts#L177-L235)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Behavior change: "reachable_no_models" can become "unreachable"**

   Before this PR, any 200 OK response from `/api/v1/models` guaranteed `reachable: true`. Now, if that response has an unexpected shape (no `.models` array) and `/v1/models` also fails or is unreachable, the returned inspection will have `reachable: false` and `health: "unreachable"`. A running LM Studio instance that returns an unexpected `/api/v1/models` body during startup would briefly appear completely unreachable in the UI instead of "reachable with no loaded models".

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/ai/localModelDiscovery.ts
   Line: 177-235

   Comment:
   **Behavior change: "reachable_no_models" can become "unreachable"**

   Before this PR, any 200 OK response from `/api/v1/models` guaranteed `reachable: true`. Now, if that response has an unexpected shape (no `.models` array) and `/v1/models` also fails or is unreachable, the returned inspection will have `reachable: false` and `health: "unreachable"`. A running LM Studio instance that returns an unexpected `/api/v1/models` body during startup would briefly appear completely unreachable in the UI instead of "reachable with no loaded models".

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fai%2FlocalModelDiscovery.ts%0ALine%3A%20177-235%0A%0AComment%3A%0A**Behavior%20change%3A%20%22reachable_no_models%22%20can%20become%20%22unreachable%22**%0A%0ABefore%20this%20PR%2C%20any%20200%20OK%20response%20from%20%60%2Fapi%2Fv1%2Fmodels%60%20guaranteed%20%60reachable%3A%20true%60.%20Now%2C%20if%20that%20response%20has%20an%20unexpected%20shape%20%28no%20%60.models%60%20array%29%20and%20%60%2Fv1%2Fmodels%60%20also%20fails%20or%20is%20unreachable%2C%20the%20returned%20inspection%20will%20have%20%60reachable%3A%20false%60%20and%20%60health%3A%20%22unreachable%22%60.%20A%20running%20LM%20Studio%20instance%20that%20returns%20an%20unexpected%20%60%2Fapi%2Fv1%2Fmodels%60%20body%20during%20startup%20would%20briefly%20appear%20completely%20unreachable%20in%20the%20UI%20instead%20of%20%22reachable%20with%20no%20loaded%20models%22.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=317&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22arul28%2Fade%22%20on%20the%20existing%20branch%20%22codex-fix-opencode-refresh-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex-fix-opencode-refresh-cache%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fai%2FlocalModelDiscovery.ts%0ALine%3A%20177-235%0A%0AComment%3A%0A**Behavior%20change%3A%20%22reachable_no_models%22%20can%20become%20%22unreachable%22**%0A%0ABefore%20this%20PR%2C%20any%20200%20OK%20response%20from%20%60%2Fapi%2Fv1%2Fmodels%60%20guaranteed%20%60reachable%3A%20true%60.%20Now%2C%20if%20that%20response%20has%20an%20unexpected%20shape%20%28no%20%60.models%60%20array%29%20and%20%60%2Fv1%2Fmodels%60%20also%20fails%20or%20is%20unreachable%2C%20the%20returned%20inspection%20will%20have%20%60reachable%3A%20false%60%20and%20%60health%3A%20%22unreachable%22%60.%20A%20running%20LM%20Studio%20instance%20that%20returns%20an%20unexpected%20%60%2Fapi%2Fv1%2Fmodels%60%20body%20during%20startup%20would%20briefly%20appear%20completely%20unreachable%20in%20the%20UI%20instead%20of%20%22reachable%20with%20no%20loaded%20models%22.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fai%2FlocalModelDiscovery.ts%0ALine%3A%20177-235%0A%0AComment%3A%0A**Behavior%20change%3A%20%22reachable_no_models%22%20can%20become%20%22unreachable%22**%0A%0ABefore%20this%20PR%2C%20any%20200%20OK%20response%20from%20%60%2Fapi%2Fv1%2Fmodels%60%20guaranteed%20%60reachable%3A%20true%60.%20Now%2C%20if%20that%20response%20has%20an%20unexpected%20shape%20%28no%20%60.models%60%20array%29%20and%20%60%2Fv1%2Fmodels%60%20also%20fails%20or%20is%20unreachable%2C%20the%20returned%20inspection%20will%20have%20%60reachable%3A%20false%60%20and%20%60health%3A%20%22unreachable%22%60.%20A%20running%20LM%20Studio%20instance%20that%20returns%20an%20unexpected%20%60%2Fapi%2Fv1%2Fmodels%60%20body%20during%20startup%20would%20briefly%20appear%20completely%20unreachable%20in%20the%20UI%20instead%20of%20%22reachable%20with%20no%20loaded%20models%22.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=317&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test: harden LM Studio status assertion"](https://github.com/arul28/ade/commit/a7cb143b3740f81ce60e5f40f6553091c41b93ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32552329)</sub>

<!-- /greptile_comment -->