### PR TITLE
Linear issue browser enhancements and usage tracking improvements

### DIFF
--- a/apps/ade-cli/README.md
+++ b/apps/ade-cli/README.md
@@ -234,6 +234,7 @@ ade lanes create "lin-123" --linear-issue-json '{"id":"...","identifier":"LIN-12
 ade lanes reparent lane-child --parent lane-parent --stack-base-branch main
 ade --role cto linear quick-view --text
 ade --role cto linear search-issues --query "auth" --state-type started,unstarted --first 50
+ade --role cto linear issue-comments --issue-id <linear-issue-uuid>
 ade git commit --lane lane-id
 ade git push --lane lane-id
 ade git pull --lane lane-id --rebase

--- a/apps/ade-cli/src/adeRpcServer.test.ts
+++ b/apps/ade-cli/src/adeRpcServer.test.ts
@@ -654,6 +654,9 @@ function createRuntime() {
         issues: [{ id: "issue-1", identifier: "ADE-123", title: "Test", _query: query }],
         pageInfo: { hasNextPage: false, endCursor: null },
       })),
+      fetchIssueComments: vi.fn(async (issueId: string) => [
+        { id: "comment-1", body: "First comment", createdAt: "2026-03-17T19:00:00.000Z", userName: "arul", userDisplayName: "Arul" },
+      ]),
     } as any,
     linearSyncService: {
       getDashboard: vi.fn(() => ({ enabled: true, running: false, ingressMode: "webhook-first", reconciliationIntervalSec: 60, lastPollAt: null, lastSuccessAt: null, lastError: null, queue: { queued: 1, blocked: 0, failed: 0 }, workflowRuns: { active: 1, waiting: 0 }, recentIssues: [] })),
@@ -1582,6 +1585,21 @@ describe("adeRpcServer", () => {
         pageInfo: expect.objectContaining({ hasNextPage: false }),
       }),
     );
+  });
+
+  it("fetches Linear issue comments via getLinearIssueComments", async () => {
+    const { runtime } = createRuntime();
+    const handler = createAdeRpcRequestHandler({ runtime, serverVersion: "test" });
+
+    await initialize(handler, { callerId: "cto-1", role: "cto" });
+    const result = await callTool(handler, "getLinearIssueComments", {
+      issueId: "issue-1",
+    });
+
+    expect((runtime.linearIssueTracker as any).fetchIssueComments).toHaveBeenCalledWith("issue-1");
+    expect(result.structuredContent).toEqual([
+      expect.objectContaining({ id: "comment-1", body: "First comment" }),
+    ]);
   });
 
   it("forwards employeeOverride and laneId when resuming a Linear sync queue item", async () => {

--- a/apps/ade-cli/src/adeRpcServer.ts
+++ b/apps/ade-cli/src/adeRpcServer.ts
@@ -1534,6 +1534,18 @@ const CTO_LINEAR_SYNC_TOOL_SPECS: ToolSpec[] = [
     }
   },
   {
+    name: "getLinearIssueComments",
+    description: "Fetch comments on a Linear issue by its ID.",
+    inputSchema: {
+      type: "object",
+      required: ["issueId"],
+      additionalProperties: false,
+      properties: {
+        issueId: { type: "string", minLength: 1 }
+      }
+    }
+  },
+  {
     name: "getLinearSyncDashboard",
     description: "Read the ADE Linear sync dashboard.",
     inputSchema: { type: "object", additionalProperties: false, properties: {} }
@@ -1692,6 +1704,7 @@ const READ_ONLY_TOOLS = new Set([
   "getLinearQuickView",
   "getLinearIssuePickerData",
   "searchLinearIssues",
+  "getLinearIssueComments",
   "listLinearWorkflows",
   "getLinearRunStatus",
   "getLinearSyncDashboard",
@@ -3475,6 +3488,12 @@ async function runTool(args: {
         after: assertOptionalStringOrNull(toolArgs.after ?? null, "after"),
         includeArchived: asBoolean(toolArgs.includeArchived, false),
       });
+    }
+
+    if (name === "getLinearIssueComments") {
+      const issueId = assertNonEmptyString(toolArgs.issueId, "issueId");
+      const tracker = requireLinearIssueTracker(runtime);
+      return await tracker.fetchIssueComments(issueId);
     }
 
     if (name === "getLinearSyncDashboard") {

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -1392,6 +1392,8 @@ const HELP_BY_COMMAND: Record<string, string> = {
     $ ade --role cto linear picker-data --text     Read projects/users/states for the issue picker
     $ ade --role cto linear search-issues --query "auth" --state-type started,unstarted --first 50
                                                     Search issues for the lane Linear-issue picker
+    $ ade --role cto linear issue-comments --issue-id <id>
+                                                    Fetch comments on a Linear issue
     $ ade linear workflows --text                   List configured workflows
     $ ade linear sync dashboard --text              Show sync dashboard
     $ ade linear sync run                           Trigger a sync run
@@ -8018,6 +8020,21 @@ function buildLinearPlan(args: string[]): CliPlan {
           "result",
           "searchLinearIssues",
           collectGenericObjectArgs(args, input),
+        ),
+      ],
+    };
+  }
+  if (sub === "issue-comments" || sub === "comments") {
+    const issueId = readValue(args, ["--issue-id", "--issue"]) ?? firstPositional(args);
+    if (!issueId) throw new CliUsageError("linear issue-comments requires --issue-id <id> or a positional issue ID.");
+    return {
+      kind: "execute",
+      label: "Linear issue comments",
+      steps: [
+        actionCallStep(
+          "result",
+          "getLinearIssueComments",
+          collectGenericObjectArgs(args, { issueId }),
         ),
       ],
     };

--- a/apps/ade-cli/src/tuiClient/app.tsx
+++ b/apps/ade-cli/src/tuiClient/app.tsx
@@ -6120,12 +6120,13 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath }
       return;
     }
     if (name === "/linear comments") {
-      if (!args) {
+      const issueId = args?.trim();
+      if (!issueId) {
         setRightPane({ kind: "details", title: "Linear comments", body: "Usage: /linear comments <issue-id>" });
         return;
       }
-      const comments = await conn.tool("getLinearIssueComments", { issueId: args.trim() });
-      setRightPane({ kind: "details", title: `Linear comments · ${args.trim()}`, body: formatLinearIssueComments(comments) });
+      const comments = await conn.tool("getLinearIssueComments", { issueId });
+      setRightPane({ kind: "details", title: `Linear comments · ${issueId}`, body: formatLinearIssueComments(comments) });
       return;
     }
     if (name === "/linear assign") {

--- a/apps/ade-cli/src/tuiClient/app.tsx
+++ b/apps/ade-cli/src/tuiClient/app.tsx
@@ -127,6 +127,7 @@ import { loadAdeCodeState, saveAdeCodeProjectState, scopedAdeCodeState } from ".
 import { SpinTickProvider } from "./spinTick";
 import { buildLinearToolRequest } from "./linearCommands";
 import {
+  formatLinearIssueComments,
   formatLinearStatus,
   formatPrChecks,
   formatPrComments,
@@ -6116,6 +6117,15 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath }
       const result = await conn.actionList("linear_issue_tracker", "createComment", [parsed.first, parsed.rest]);
       setRightPane({ kind: "details", title: "Linear comment", body: renderObject(result, 12) });
       addNotice(`Commented on ${parsed.first}.`, "success");
+      return;
+    }
+    if (name === "/linear comments") {
+      if (!args) {
+        setRightPane({ kind: "details", title: "Linear comments", body: "Usage: /linear comments <issue-id>" });
+        return;
+      }
+      const comments = await conn.tool("getLinearIssueComments", { issueId: args.trim() });
+      setRightPane({ kind: "details", title: `Linear comments · ${args.trim()}`, body: formatLinearIssueComments(comments) });
       return;
     }
     if (name === "/linear assign") {

--- a/apps/ade-cli/src/tuiClient/commands.ts
+++ b/apps/ade-cli/src/tuiClient/commands.ts
@@ -61,6 +61,7 @@ export const BUILTIN_COMMANDS: BuiltinCommand[] = [
   { name: "/linear ingress", description: "Inspect Linear ingress", placement: "right", argumentHint: "<status|events|webhook>" },
   { name: "/linear pull", description: "Pull a Linear ticket into chat context", placement: "right", argumentHint: "<id>" },
   { name: "/linear comment", description: "Comment on a Linear ticket", placement: "right", argumentHint: "<id> <text>" },
+  { name: "/linear comments", description: "Show comments on a Linear ticket", placement: "right", argumentHint: "<id>" },
   { name: "/linear status", description: "Show Linear sync status", placement: "right" },
   { name: "/linear assign", description: "Assign a Linear ticket", placement: "right", argumentHint: "<id> <user>" },
   { name: "/feedback", description: "Submit ADE feedback to GitHub issues", placement: "right" },

--- a/apps/ade-cli/src/tuiClient/rightPaneFormatters.ts
+++ b/apps/ade-cli/src/tuiClient/rightPaneFormatters.ts
@@ -282,3 +282,17 @@ export function formatLinearStatus(value: unknown): string {
   ];
   return rows.map(([key, rowValue]) => `${key.padEnd(10)} ${rowValue}`).join("\n");
 }
+
+export function formatLinearIssueComments(value: unknown): string {
+  const items = Array.isArray(value) ? value.filter(isRecord) : [];
+  if (!items.length) return "No comments on this issue.";
+  const lines = [`${items.length} comment${items.length === 1 ? "" : "s"}`];
+  for (const item of items.slice(0, 20)) {
+    const who = pickString(item, ["userDisplayName", "userName"]) ?? "unknown";
+    const when = shortIso(item.createdAt);
+    const body = truncate(item.body, 80);
+    lines.push("", `${who}${when ? `  ${when}` : ""}`, body || "(empty)");
+  }
+  if (items.length > 20) lines.push("", `… and ${items.length - 20} more`);
+  return lines.join("\n");
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -197,7 +197,9 @@ const THRESHOLD_DEDUP_TTL_MS = 10 * 60_000; // 10 minutes
 
 /** Returns true if the event should be emitted (not a duplicate). Prunes stale entries. */
 function shouldEmitThresholdEvent(event: { provider: string; threshold: number; resetsAt: string }): boolean {
-  const dedupKey = `${event.provider}:${event.threshold}:${new Date(event.resetsAt).getTime()}`;
+  const parsedTime = new Date(event.resetsAt).getTime();
+  const resetsAtKey = Number.isNaN(parsedTime) ? event.resetsAt : parsedTime;
+  const dedupKey = `${event.provider}:${event.threshold}:${resetsAtKey}`;
   const now = Date.now();
   const lastEmitted = thresholdEventDedup.get(dedupKey);
   if (lastEmitted && now - lastEmitted < THRESHOLD_DEDUP_TTL_MS) return false;

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -194,6 +194,20 @@ const ADE_BROWSER_WEBVIEW_PARTITION = "persist:ade-browser";
 // shared state is written back.  This map acts as a final IPC gate.
 const thresholdEventDedup = new Map<string, number>();
 const THRESHOLD_DEDUP_TTL_MS = 10 * 60_000; // 10 minutes
+
+/** Returns true if the event should be emitted (not a duplicate). Prunes stale entries. */
+function shouldEmitThresholdEvent(event: { provider: string; threshold: number; resetsAt: string }): boolean {
+  const dedupKey = `${event.provider}:${event.threshold}:${new Date(event.resetsAt).getTime()}`;
+  const now = Date.now();
+  const lastEmitted = thresholdEventDedup.get(dedupKey);
+  if (lastEmitted && now - lastEmitted < THRESHOLD_DEDUP_TTL_MS) return false;
+  thresholdEventDedup.set(dedupKey, now);
+  for (const [k, t] of thresholdEventDedup) {
+    if (now - t > THRESHOLD_DEDUP_TTL_MS) thresholdEventDedup.delete(k);
+  }
+  return true;
+}
+
 type AdePackageChannel = "alpha" | "beta";
 
 function normalizeAdePackageChannel(value: unknown): AdePackageChannel | null {
@@ -3500,14 +3514,7 @@ app.whenReady().then(async () => {
         emitProjectEvent(projectRoot, IPC.usageEvent, snapshot);
       },
       onThresholdEvent: (event) => {
-        const dedupKey = `${event.provider}:${event.threshold}:${new Date(event.resetsAt).getTime()}`;
-        const now = Date.now();
-        const lastEmitted = thresholdEventDedup.get(dedupKey);
-        if (lastEmitted && now - lastEmitted < THRESHOLD_DEDUP_TTL_MS) return;
-        thresholdEventDedup.set(dedupKey, now);
-        for (const [k, t] of thresholdEventDedup) {
-          if (now - t > THRESHOLD_DEDUP_TTL_MS) thresholdEventDedup.delete(k);
-        }
+        if (!shouldEmitThresholdEvent(event)) return;
         emitProjectEvent(projectRoot, IPC.usageThresholdEvent, event);
       },
     });
@@ -4178,14 +4185,7 @@ app.whenReady().then(async () => {
         emitProjectEvent(projectRoot, IPC.usageEvent, snapshot);
       },
       onThresholdEvent: (event) => {
-        const dedupKey = `${event.provider}:${event.threshold}:${new Date(event.resetsAt).getTime()}`;
-        const now = Date.now();
-        const lastEmitted = thresholdEventDedup.get(dedupKey);
-        if (lastEmitted && now - lastEmitted < THRESHOLD_DEDUP_TTL_MS) return;
-        thresholdEventDedup.set(dedupKey, now);
-        for (const [k, t] of thresholdEventDedup) {
-          if (now - t > THRESHOLD_DEDUP_TTL_MS) thresholdEventDedup.delete(k);
-        }
+        if (!shouldEmitThresholdEvent(event)) return;
         emitProjectEvent(projectRoot, IPC.usageThresholdEvent, event);
       },
     });

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -187,6 +187,13 @@ type RemoteOpenProjectBinding = Extract<OpenProjectBinding, { kind: "remote" }>;
 
 const AUTO_UPDATER_CACHE_DIR_NAME = "ade-desktop-updater";
 const ADE_BROWSER_WEBVIEW_PARTITION = "persist:ade-browser";
+
+// ── Usage threshold IPC-level dedup ─────────────────────────────
+// Even with the shared module-level ThresholdState in usageTrackingService,
+// a small race window exists where two service instances could fire before the
+// shared state is written back.  This map acts as a final IPC gate.
+const thresholdEventDedup = new Map<string, number>();
+const THRESHOLD_DEDUP_TTL_MS = 10 * 60_000; // 10 minutes
 type AdePackageChannel = "alpha" | "beta";
 
 function normalizeAdePackageChannel(value: unknown): AdePackageChannel | null {
@@ -3493,6 +3500,14 @@ app.whenReady().then(async () => {
         emitProjectEvent(projectRoot, IPC.usageEvent, snapshot);
       },
       onThresholdEvent: (event) => {
+        const dedupKey = `${event.provider}:${event.threshold}:${new Date(event.resetsAt).getTime()}`;
+        const now = Date.now();
+        const lastEmitted = thresholdEventDedup.get(dedupKey);
+        if (lastEmitted && now - lastEmitted < THRESHOLD_DEDUP_TTL_MS) return;
+        thresholdEventDedup.set(dedupKey, now);
+        for (const [k, t] of thresholdEventDedup) {
+          if (now - t > THRESHOLD_DEDUP_TTL_MS) thresholdEventDedup.delete(k);
+        }
         emitProjectEvent(projectRoot, IPC.usageThresholdEvent, event);
       },
     });
@@ -4163,6 +4178,14 @@ app.whenReady().then(async () => {
         emitProjectEvent(projectRoot, IPC.usageEvent, snapshot);
       },
       onThresholdEvent: (event) => {
+        const dedupKey = `${event.provider}:${event.threshold}:${new Date(event.resetsAt).getTime()}`;
+        const now = Date.now();
+        const lastEmitted = thresholdEventDedup.get(dedupKey);
+        if (lastEmitted && now - lastEmitted < THRESHOLD_DEDUP_TTL_MS) return;
+        thresholdEventDedup.set(dedupKey, now);
+        for (const [k, t] of thresholdEventDedup) {
+          if (now - t > THRESHOLD_DEDUP_TTL_MS) thresholdEventDedup.delete(k);
+        }
         emitProjectEvent(projectRoot, IPC.usageThresholdEvent, event);
       },
     });

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -583,6 +583,7 @@ export const ADE_ACTION_ALLOWLIST: Partial<Record<AdeActionDomain, readonly stri
     "createComment",
     "fetchIssueById",
     "fetchIssuesByIds",
+    "fetchIssueComments",
     "getIssuePickerData",
     "getConnectionStatus",
     "getQuickView",

--- a/apps/desktop/src/main/services/cto/issueTracker.ts
+++ b/apps/desktop/src/main/services/cto/issueTracker.ts
@@ -87,6 +87,13 @@ export type IssueTracker = {
   addLabel(issueId: string, labelName: string): Promise<void>;
   uploadAttachment(args: { issueId: string; filePath: string; title?: string }): Promise<{ url: string; id?: string }>;
   createIssueAttachment(args: IssueTrackerIssueAttachmentInput): Promise<{ url: string; id?: string }>;
+  fetchIssueComments(issueId: string): Promise<Array<{
+    id: string;
+    body: string;
+    createdAt: string;
+    userName: string;
+    userDisplayName: string;
+  }>>;
   getConnectionStatus(): Promise<{
     connected: boolean;
     viewerId: string | null;

--- a/apps/desktop/src/main/services/cto/linearAuth.test.ts
+++ b/apps/desktop/src/main/services/cto/linearAuth.test.ts
@@ -971,6 +971,189 @@ describe("linearClient", () => {
     expect(result.issues[0]?.identifier).toBe("ABC-7");
   });
 
+  it("normalizes label colors, cycle info, and child issues from GraphQL response", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          data: {
+            issues: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [
+                {
+                  id: "issue-rich",
+                  identifier: "ABC-99",
+                  title: "Rich issue",
+                  description: "",
+                  url: null,
+                  priority: 1,
+                  createdAt: "2026-03-05T00:00:00.000Z",
+                  updatedAt: "2026-03-05T00:00:00.000Z",
+                  project: { id: "proj-1", slug: "acme-platform" },
+                  team: { id: "team-1", key: "ACME" },
+                  state: { id: "state-1", name: "In Progress", type: "started" },
+                  assignee: null,
+                  creator: { id: "user-1" },
+                  labels: {
+                    nodes: [
+                      { id: "l1", name: "Bug", color: "#EF4444" },
+                      { id: "l2", name: "P0", color: null },
+                    ],
+                  },
+                  cycle: {
+                    id: "cycle-1",
+                    name: "Sprint 42",
+                    startsAt: "2026-03-01",
+                    endsAt: "2026-03-14",
+                  },
+                  children: {
+                    nodes: [
+                      {
+                        id: "child-1",
+                        identifier: "ABC-100",
+                        title: "Sub-task A",
+                        state: { id: "s-done", name: "Done", type: "completed" },
+                      },
+                      {
+                        id: "child-2",
+                        identifier: "ABC-101",
+                        title: "Sub-task B",
+                        state: { id: "s-ip", name: "In Progress", type: "started" },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    });
+
+    const client = createLinearClient({
+      credentials: {
+        getTokenOrThrow: () => "Bearer test-token",
+        getStatus: () => ({ authMode: "oauth" }),
+      } as any,
+      fetchImpl: fetchImpl as any,
+      logger: null,
+    });
+
+    const issues = await client.fetchCandidateIssues({
+      projectSlugs: ["acme-platform"],
+      stateTypes: ["started"],
+    });
+
+    expect(issues).toHaveLength(1);
+    const issue = issues[0]!;
+    expect(issue.labelColors).toEqual([
+      { name: "Bug", color: "#EF4444" },
+      { name: "P0", color: null },
+    ]);
+    expect(issue.cycleId).toBe("cycle-1");
+    expect(issue.cycleName).toBe("Sprint 42");
+    expect(issue.cycleStartsAt).toBe("2026-03-01");
+    expect(issue.cycleEndsAt).toBe("2026-03-14");
+    expect(issue.childIssues).toEqual([
+      { id: "child-1", identifier: "ABC-100", title: "Sub-task A", stateId: "s-done", stateName: "Done", stateType: "completed" },
+      { id: "child-2", identifier: "ABC-101", title: "Sub-task B", stateId: "s-ip", stateName: "In Progress", stateType: "started" },
+    ]);
+    expect(issue.hasOpenBlockers).toBe(true);
+  });
+
+  it("returns null cycle fields when issue has no cycle", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          data: {
+            issues: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [makeIssueNode("no-cycle", "2026-03-05T00:00:00.000Z")],
+            },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    });
+
+    const client = createLinearClient({
+      credentials: {
+        getTokenOrThrow: () => "Bearer test-token",
+        getStatus: () => ({ authMode: "oauth" }),
+      } as any,
+      fetchImpl: fetchImpl as any,
+      logger: null,
+    });
+
+    const issues = await client.fetchCandidateIssues({
+      projectSlugs: ["acme-platform"],
+      stateTypes: ["unstarted"],
+    });
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]!.cycleId).toBeNull();
+    expect(issues[0]!.cycleName).toBeNull();
+    expect(issues[0]!.childIssues).toEqual([]);
+    expect(issues[0]!.labelColors).toEqual([{ name: "bug", color: null }]);
+  });
+
+  it("fetches issue comments with user attribution", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          data: {
+            issue: {
+              comments: {
+                nodes: [
+                  {
+                    id: "comment-1",
+                    body: "Looks good",
+                    createdAt: "2026-03-05T12:00:00.000Z",
+                    user: { id: "u1", name: "alex", displayName: "Alex M" },
+                  },
+                  {
+                    id: "comment-2",
+                    body: "Merged",
+                    createdAt: "2026-03-05T13:00:00.000Z",
+                    user: { id: "u2", name: "bot", displayName: null },
+                  },
+                  { id: null, body: null, createdAt: null, user: null },
+                ],
+              },
+            },
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    });
+
+    const client = createLinearClient({
+      credentials: {
+        getTokenOrThrow: () => "Bearer test-token",
+        getStatus: () => ({ authMode: "oauth" }),
+      } as any,
+      fetchImpl: fetchImpl as any,
+      logger: null,
+    });
+
+    const comments = await client.fetchIssueComments("issue-1");
+    expect(comments).toHaveLength(2);
+    expect(comments[0]).toEqual({
+      id: "comment-1",
+      body: "Looks good",
+      createdAt: "2026-03-05T12:00:00.000Z",
+      userName: "alex",
+      userDisplayName: "Alex M",
+    });
+    expect(comments[1]).toEqual({
+      id: "comment-2",
+      body: "Merged",
+      createdAt: "2026-03-05T13:00:00.000Z",
+      userName: "bot",
+      userDisplayName: "bot",
+    });
+  });
+
   it("strips a pasted bearer prefix from manual API keys", async () => {
     const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
       expect(init?.headers).toMatchObject({ authorization: "lin_api_test" });

--- a/apps/desktop/src/main/services/cto/linearClient.ts
+++ b/apps/desktop/src/main/services/cto/linearClient.ts
@@ -77,6 +77,17 @@ function toNormalizedIssue(node: Record<string, unknown>): NormalizedLinearIssue
     .filter((entry): entry is string => entry != null)
     .map((entry) => entry.toLowerCase());
 
+  const labelColors: Array<{ name: string; color: string | null }> = labelsNodes.map((ln: unknown) => ({
+    name: isRecord(ln) ? asString(ln.name) ?? "" : "",
+    color: isRecord(ln) ? asString(ln.color) ?? null : null,
+  }));
+
+  const cycle = isRecord(node.cycle) ? node.cycle : null;
+  const cycleId = cycle ? asString(cycle.id) ?? null : null;
+  const cycleName = cycle ? asString(cycle.name) ?? null : null;
+  const cycleStartsAt = cycle ? asString(cycle.startsAt) ?? null : null;
+  const cycleEndsAt = cycle ? asString(cycle.endsAt) ?? null : null;
+
   const blockersNodes = isRecord(node.children) ? asArray(node.children.nodes) : [];
   const blockerIssueIds = blockersNodes
     .map((entry) => (isRecord(entry) ? asString(entry.id) : null))
@@ -87,6 +98,25 @@ function toNormalizedIssue(node: Record<string, unknown>): NormalizedLinearIssue
     const childState = isRecord(entry.state) ? asString(entry.state.type) : null;
     return childState != null && childState !== "completed" && childState !== "canceled";
   });
+
+  const childIssues: Array<{
+    id: string;
+    identifier: string;
+    title: string;
+    stateId: string;
+    stateName: string;
+    stateType: string;
+  }> = blockersNodes
+    .filter((c: unknown): c is Record<string, unknown> => isRecord(c))
+    .map((c) => ({
+      id: asString(c.id) ?? "",
+      identifier: asString(c.identifier) ?? "",
+      title: asString(c.title) ?? "",
+      stateId: isRecord(c.state) ? asString(c.state.id) ?? "" : "",
+      stateName: isRecord(c.state) ? asString(c.state.name) ?? "" : "",
+      stateType: isRecord(c.state) ? asString(c.state.type) ?? "" : "",
+    }))
+    .filter((c) => c.id);
 
   const assignee = isRecord(node.assignee) ? node.assignee : null;
   const owner = isRecord(node.creator) ? node.creator : null;
@@ -115,6 +145,12 @@ function toNormalizedIssue(node: Record<string, unknown>): NormalizedLinearIssue
     priority: Number.isFinite(priority) ? priority : 0,
     priorityLabel: mapPriorityLabel(Number.isFinite(priority) ? priority : 0),
     labels,
+    labelColors,
+    cycleId,
+    cycleName,
+    cycleStartsAt,
+    cycleEndsAt,
+    childIssues,
     metadataTags,
     assigneeId: assignee ? asString(assignee.id) : null,
     assigneeName: assignee ? (asString(assignee.displayName) ?? asString(assignee.name)) : null,
@@ -455,11 +491,14 @@ export function createLinearClient(args: LinearClientArgs) {
     state { id name type }
     assignee { id name displayName }
     creator { id name displayName }
-    labels { nodes { id name } }
+    labels { nodes { id name color } }
+    cycle { id name startsAt endsAt }
     children {
       nodes {
         id
-        state { type }
+        identifier
+        title
+        state { id name type }
       }
     }
   `;
@@ -1258,6 +1297,65 @@ export function createLinearClient(args: LinearClientArgs) {
     };
   };
 
+  const fetchIssueComments = async (issueId: string): Promise<Array<{
+    id: string;
+    body: string;
+    createdAt: string;
+    userName: string;
+    userDisplayName: string;
+  }>> => {
+    const data = await request<{
+      issue?: {
+        comments?: {
+          nodes?: Array<Record<string, unknown>>;
+        };
+      };
+    }>({
+      query: `
+        query IssueComments($issueId: String!) {
+          issue(id: $issueId) {
+            comments(first: 50, orderBy: createdAt) {
+              nodes {
+                id
+                body
+                createdAt
+                user {
+                  id
+                  name
+                  displayName
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { issueId },
+      maxRetries: 2,
+    });
+
+    const nodes = isRecord(data.issue) && isRecord(data.issue.comments)
+      ? asArray(data.issue.comments.nodes)
+      : [];
+
+    return nodes
+      .map((node) => {
+        if (!isRecord(node)) return null;
+        const id = asString(node.id);
+        const body = asString(node.body);
+        const createdAt = asString(node.createdAt);
+        if (!id || !body || !createdAt) return null;
+        const user = isRecord(node.user) ? node.user : null;
+        return {
+          id,
+          body,
+          createdAt,
+          userName: user ? asString(user.name) ?? "" : "",
+          userDisplayName: user ? asString(user.displayName) ?? asString(user.name) ?? "" : "",
+        };
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => entry != null);
+  };
+
   return {
     request,
     getViewer,
@@ -1281,6 +1379,7 @@ export function createLinearClient(args: LinearClientArgs) {
     addLabel,
     uploadAttachment,
     createIssueAttachment,
+    fetchIssueComments,
   };
 }
 

--- a/apps/desktop/src/main/services/cto/linearClient.ts
+++ b/apps/desktop/src/main/services/cto/linearClient.ts
@@ -77,16 +77,18 @@ function toNormalizedIssue(node: Record<string, unknown>): NormalizedLinearIssue
     .filter((entry): entry is string => entry != null)
     .map((entry) => entry.toLowerCase());
 
-  const labelColors: Array<{ name: string; color: string | null }> = labelsNodes.map((ln: unknown) => ({
-    name: isRecord(ln) ? asString(ln.name) ?? "" : "",
-    color: isRecord(ln) ? asString(ln.color) ?? null : null,
-  }));
+  const labelColors = labelsNodes
+    .filter((ln: unknown): ln is Record<string, unknown> => isRecord(ln))
+    .map((ln) => ({
+      name: asString(ln.name) ?? "",
+      color: asString(ln.color) ?? null,
+    }));
 
   const cycle = isRecord(node.cycle) ? node.cycle : null;
-  const cycleId = cycle ? asString(cycle.id) ?? null : null;
-  const cycleName = cycle ? asString(cycle.name) ?? null : null;
-  const cycleStartsAt = cycle ? asString(cycle.startsAt) ?? null : null;
-  const cycleEndsAt = cycle ? asString(cycle.endsAt) ?? null : null;
+  const cycleId = cycle ? asString(cycle.id) : null;
+  const cycleName = cycle ? asString(cycle.name) : null;
+  const cycleStartsAt = cycle ? asString(cycle.startsAt) : null;
+  const cycleEndsAt = cycle ? asString(cycle.endsAt) : null;
 
   const blockersNodes = isRecord(node.children) ? asArray(node.children.nodes) : [];
   const blockerIssueIds = blockersNodes
@@ -99,23 +101,19 @@ function toNormalizedIssue(node: Record<string, unknown>): NormalizedLinearIssue
     return childState != null && childState !== "completed" && childState !== "canceled";
   });
 
-  const childIssues: Array<{
-    id: string;
-    identifier: string;
-    title: string;
-    stateId: string;
-    stateName: string;
-    stateType: string;
-  }> = blockersNodes
+  const childIssues = blockersNodes
     .filter((c: unknown): c is Record<string, unknown> => isRecord(c))
-    .map((c) => ({
-      id: asString(c.id) ?? "",
-      identifier: asString(c.identifier) ?? "",
-      title: asString(c.title) ?? "",
-      stateId: isRecord(c.state) ? asString(c.state.id) ?? "" : "",
-      stateName: isRecord(c.state) ? asString(c.state.name) ?? "" : "",
-      stateType: isRecord(c.state) ? asString(c.state.type) ?? "" : "",
-    }))
+    .map((c) => {
+      const cs = isRecord(c.state) ? c.state : null;
+      return {
+        id: asString(c.id) ?? "",
+        identifier: asString(c.identifier) ?? "",
+        title: asString(c.title) ?? "",
+        stateId: cs ? asString(cs.id) ?? "" : "",
+        stateName: cs ? asString(cs.name) ?? "" : "",
+        stateType: cs ? asString(cs.type) ?? "" : "",
+      };
+    })
     .filter((c) => c.id);
 
   const assignee = isRecord(node.assignee) ? node.assignee : null;

--- a/apps/desktop/src/main/services/cto/linearIssueTracker.ts
+++ b/apps/desktop/src/main/services/cto/linearIssueTracker.ts
@@ -72,6 +72,10 @@ export function createLinearIssueTracker(args: { client: LinearClient }): IssueT
       return args.client.createIssueAttachment(params);
     },
 
+    fetchIssueComments(issueId) {
+      return args.client.fetchIssueComments(issueId);
+    },
+
     async getConnectionStatus() {
       try {
         const identity = await args.client.getConnectionIdentity();

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -9317,6 +9317,7 @@ export function registerIpc({
   ipcMain.handle(
     IPC.ctoGetLinearIssueComments,
     async (_event, arg: { issueId: string }): Promise<CtoLinearIssueComment[]> => {
+      if (typeof arg?.issueId !== "string" || !arg.issueId.trim()) return [];
       const ctx = getCtx();
       if (!ctx.linearIssueTracker) return [];
       return ctx.linearIssueTracker.fetchIssueComments(arg.issueId);

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -446,6 +446,7 @@ import type {
   CtoGetLinearOAuthSessionArgs,
   CtoGetLinearOAuthSessionResult,
   CtoGetLinearIssuePickerDataResult,
+  CtoLinearIssueComment,
   CtoLinearQuickView,
   CtoSearchLinearIssuesArgs,
   CtoSearchLinearIssuesResult,
@@ -9315,13 +9316,7 @@ export function registerIpc({
 
   ipcMain.handle(
     IPC.ctoGetLinearIssueComments,
-    async (_event, arg: { issueId: string }): Promise<Array<{
-      id: string;
-      body: string;
-      createdAt: string;
-      userName: string;
-      userDisplayName: string;
-    }>> => {
+    async (_event, arg: { issueId: string }): Promise<CtoLinearIssueComment[]> => {
       const ctx = getCtx();
       if (!ctx.linearIssueTracker) return [];
       return ctx.linearIssueTracker.fetchIssueComments(arg.issueId);

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -9313,6 +9313,21 @@ export function registerIpc({
     }
   );
 
+  ipcMain.handle(
+    IPC.ctoGetLinearIssueComments,
+    async (_event, arg: { issueId: string }): Promise<Array<{
+      id: string;
+      body: string;
+      createdAt: string;
+      userName: string;
+      userDisplayName: string;
+    }>> => {
+      const ctx = getCtx();
+      if (!ctx.linearIssueTracker) return [];
+      return ctx.linearIssueTracker.fetchIssueComments(arg.issueId);
+    }
+  );
+
   ipcMain.handle(IPC.ctoRunProjectScan, async (): Promise<CtoRunProjectScanResult> => {
     const ctx = getCtx();
     const detection = await ctx.onboardingService.detectDefaults().catch(() => null);

--- a/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
@@ -831,8 +831,8 @@ describe("createUsageTrackingService", () => {
 
   it("shares threshold state across instances so the same event does not fire twice", async () => {
     const logger = createLogger();
-    const onUpdate1 = vi.fn();
-    const onUpdate2 = vi.fn();
+    const onThreshold1 = vi.fn();
+    const onThreshold2 = vi.fn();
 
     const highUsageWindows: UsageWindow[] = [
       {
@@ -853,22 +853,22 @@ describe("createUsageTrackingService", () => {
 
     const service1 = createUsageTrackingService({
       logger,
-      onUpdate: onUpdate1,
+      onThresholdEvent: onThreshold1,
       dependencies: makeDeps(highUsageWindows),
     });
     const service2 = createUsageTrackingService({
       logger,
-      onUpdate: onUpdate2,
+      onThresholdEvent: onThreshold2,
       dependencies: makeDeps(highUsageWindows),
     });
 
     await service1.poll();
     await service2.poll();
 
-    const allEvents1 = onUpdate1.mock.calls.flatMap(([snap]) => snap.thresholdEvents ?? []);
-    const allEvents2 = onUpdate2.mock.calls.flatMap(([snap]) => snap.thresholdEvents ?? []);
-    const totalEvents = allEvents1.length + allEvents2.length;
-    expect(totalEvents).toBeLessThanOrEqual(allEvents1.length > 0 ? allEvents1.length : allEvents2.length > 0 ? allEvents2.length : 0);
+    // The first service should fire threshold events for 75% crossing
+    expect(onThreshold1.mock.calls.length).toBeGreaterThan(0);
+    // The second service should NOT fire because shared state already recorded the crossing
+    expect(onThreshold2.mock.calls.length).toBe(0);
 
     service1.dispose();
     service2.dispose();

--- a/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
@@ -836,14 +836,11 @@ describe("createUsageTrackingService", () => {
 
     const highUsageWindows: UsageWindow[] = [
       {
-        name: "claude",
         provider: "claude",
-        startAt: new Date(Date.now() - 3600_000).toISOString(),
-        endAt: new Date(Date.now() + 3600_000).toISOString(),
-        resetAt: new Date(Date.now() + 3600_000).toISOString(),
-        usageLimit: 1000,
-        usageCurrent: 800,
-        planTier: "pro",
+        windowType: "weekly",
+        percentUsed: 80,
+        resetsAt: new Date(Date.now() + 3600_000).toISOString(),
+        resetsInMs: 3600_000,
       },
     ];
 

--- a/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
@@ -828,6 +828,54 @@ describe("createUsageTrackingService", () => {
 
     service.dispose();
   });
+
+  it("shares threshold state across instances so the same event does not fire twice", async () => {
+    const logger = createLogger();
+    const onUpdate1 = vi.fn();
+    const onUpdate2 = vi.fn();
+
+    const highUsageWindows: UsageWindow[] = [
+      {
+        name: "claude",
+        provider: "claude",
+        startAt: new Date(Date.now() - 3600_000).toISOString(),
+        endAt: new Date(Date.now() + 3600_000).toISOString(),
+        resetAt: new Date(Date.now() + 3600_000).toISOString(),
+        usageLimit: 1000,
+        usageCurrent: 800,
+        planTier: "pro",
+      },
+    ];
+
+    const makeDeps = (windows: UsageWindow[]) => ({
+      pollClaudeUsage: vi.fn(async () => ({ windows, extraUsage: null, errors: [] as never[] })),
+      pollCodexUsage: vi.fn(async () => ({ windows: [] as never[], errors: [] as never[] })),
+      scanClaudeLogs: vi.fn(async () => [] as never[]),
+      scanCodexLogs: vi.fn(async () => [] as never[]),
+    });
+
+    const service1 = createUsageTrackingService({
+      logger,
+      onUpdate: onUpdate1,
+      dependencies: makeDeps(highUsageWindows),
+    });
+    const service2 = createUsageTrackingService({
+      logger,
+      onUpdate: onUpdate2,
+      dependencies: makeDeps(highUsageWindows),
+    });
+
+    await service1.poll();
+    await service2.poll();
+
+    const allEvents1 = onUpdate1.mock.calls.flatMap(([snap]) => snap.thresholdEvents ?? []);
+    const allEvents2 = onUpdate2.mock.calls.flatMap(([snap]) => snap.thresholdEvents ?? []);
+    const totalEvents = allEvents1.length + allEvents2.length;
+    expect(totalEvents).toBeLessThanOrEqual(allEvents1.length > 0 ? allEvents1.length : allEvents2.length > 0 ? allEvents2.length : 0);
+
+    service1.dispose();
+    service2.dispose();
+  });
 });
 
 // ── Local Cost Scanning with real files ──────────────────────────

--- a/apps/desktop/src/main/services/usage/usageTrackingService.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.ts
@@ -886,6 +886,11 @@ function calculatePacingByProvider(windows: UsageWindow[]): UsageSnapshot["pacin
 
 // ── Service Factory ──────────────────────────────────────────────
 
+// Module-level shared state — all createUsageTrackingService instances reference this
+// so that threshold firings from one project don't re-fire from another project's copy.
+let sharedThresholdState: ThresholdState | null = null;
+let sharedThresholdStore: ThresholdStore | null = null;
+
 export type UsageTrackingService = ReturnType<typeof createUsageTrackingService>;
 
 type UsageTrackingDependencies = {
@@ -1003,13 +1008,24 @@ export function createUsageTrackingService({
   const scanClaudeCostLogs = dependencies?.scanClaudeLogs ?? scanClaudeLogs;
   const scanCodexCostLogs = dependencies?.scanCodexLogs ?? scanCodexLogs;
 
-  const resolvedThresholdStore: ThresholdStore =
-    thresholdStore ??
-    createFileThresholdStore(
-      thresholdStatePath ?? path.join(os.homedir(), ".ade", "usage-thresholds.json"),
-      logger,
-    );
-  let thresholdState: ThresholdState = resolvedThresholdStore.load();
+  // If a test passes a custom store, use that directly (no singleton sharing).
+  // Otherwise, share a single store + state across all service instances to prevent
+  // multiple projects from firing the same threshold event.
+  const isTestInjected = thresholdStore != null;
+  let resolvedThresholdStore: ThresholdStore;
+  if (isTestInjected) {
+    resolvedThresholdStore = thresholdStore;
+  } else {
+    if (!sharedThresholdStore) {
+      sharedThresholdStore = createFileThresholdStore(
+        thresholdStatePath ?? path.join(os.homedir(), ".ade", "usage-thresholds.json"),
+        logger,
+      );
+      sharedThresholdState = sharedThresholdStore.load();
+    }
+    resolvedThresholdStore = sharedThresholdStore;
+  }
+  let localThresholdState: ThresholdState | null = isTestInjected ? resolvedThresholdStore.load() : null;
 
   const emptySnapshot = (): UsageSnapshot => ({
     windows: [],
@@ -1098,9 +1114,14 @@ export function createUsageTrackingService({
         lastSnapshot = snapshot;
 
         try {
-          const { events, nextState } = detectThresholdCrossings(allWindows, thresholdState);
-          if (events.length > 0 || JSON.stringify(nextState) !== JSON.stringify(thresholdState)) {
-            thresholdState = nextState;
+          const currentState = isTestInjected ? localThresholdState! : sharedThresholdState!;
+          const { events, nextState } = detectThresholdCrossings(allWindows, currentState);
+          if (events.length > 0 || JSON.stringify(nextState) !== JSON.stringify(currentState)) {
+            if (isTestInjected) {
+              localThresholdState = nextState;
+            } else {
+              sharedThresholdState = nextState;
+            }
             resolvedThresholdStore.save(nextState);
           }
           for (const event of events) {

--- a/apps/desktop/src/main/services/usage/usageTrackingService.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.ts
@@ -1013,8 +1013,10 @@ export function createUsageTrackingService({
   // multiple projects from firing the same threshold event.
   const isTestInjected = thresholdStore != null;
   let resolvedThresholdStore: ThresholdStore;
+  let localThresholdState: ThresholdState | null = null;
   if (isTestInjected) {
     resolvedThresholdStore = thresholdStore;
+    localThresholdState = resolvedThresholdStore.load();
   } else {
     if (!sharedThresholdStore) {
       sharedThresholdStore = createFileThresholdStore(
@@ -1025,7 +1027,18 @@ export function createUsageTrackingService({
     }
     resolvedThresholdStore = sharedThresholdStore;
   }
-  let localThresholdState: ThresholdState | null = isTestInjected ? resolvedThresholdStore.load() : null;
+
+  function getThresholdState(): ThresholdState {
+    return isTestInjected ? localThresholdState! : sharedThresholdState!;
+  }
+
+  function setThresholdState(next: ThresholdState): void {
+    if (isTestInjected) {
+      localThresholdState = next;
+    } else {
+      sharedThresholdState = next;
+    }
+  }
 
   const emptySnapshot = (): UsageSnapshot => ({
     windows: [],
@@ -1114,14 +1127,10 @@ export function createUsageTrackingService({
         lastSnapshot = snapshot;
 
         try {
-          const currentState = isTestInjected ? localThresholdState! : sharedThresholdState!;
+          const currentState = getThresholdState();
           const { events, nextState } = detectThresholdCrossings(allWindows, currentState);
           if (events.length > 0 || JSON.stringify(nextState) !== JSON.stringify(currentState)) {
-            if (isTestInjected) {
-              localThresholdState = nextState;
-            } else {
-              sharedThresholdState = nextState;
-            }
+            setThresholdState(nextState);
             resolvedThresholdStore.save(nextState);
           }
           for (const event of events) {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -8405,6 +8405,23 @@ contextBridge.exposeInMainWorld("ade", {
         { args },
         () => ipcRenderer.invoke(IPC.ctoSearchLinearIssues, args),
       ),
+    getLinearIssueComments: async (
+      args: { issueId: string },
+    ): Promise<
+      Array<{
+        id: string;
+        body: string;
+        createdAt: string;
+        userName: string;
+        userDisplayName: string;
+      }>
+    > =>
+      callProjectRuntimeActionOr(
+        "linear_issue_tracker",
+        "fetchIssueComments",
+        { args },
+        () => ipcRenderer.invoke(IPC.ctoGetLinearIssueComments, args),
+      ),
     setLinearOAuthClient: async (
       args: CtoSetLinearOAuthClientArgs,
     ): Promise<LinearConnectionStatus> => {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -112,6 +112,7 @@ import type {
   CtoListAgentSessionLogsArgs,
   CtoOnboardingState,
   CtoSystemPromptPreview,
+  CtoLinearIssueComment,
   CtoLinearProject,
   CtoLinearQuickView,
   CtoGetLinearIssuePickerDataResult,
@@ -8407,15 +8408,7 @@ contextBridge.exposeInMainWorld("ade", {
       ),
     getLinearIssueComments: async (
       args: { issueId: string },
-    ): Promise<
-      Array<{
-        id: string;
-        body: string;
-        createdAt: string;
-        userName: string;
-        userDisplayName: string;
-      }>
-    > =>
+    ): Promise<CtoLinearIssueComment[]> =>
       callProjectRuntimeActionOr(
         "linear_issue_tracker",
         "fetchIssueComments",

--- a/apps/desktop/src/renderer/browserRuntimeBridge.ts
+++ b/apps/desktop/src/renderer/browserRuntimeBridge.ts
@@ -93,6 +93,8 @@ function patchLinearMethods(ade: any) {
     bridgePost("/action", { domain: "linear_issue_tracker", action: "getIssuePickerData" });
   ade.cto.searchLinearIssues = async (args: Record<string, unknown> = {}) =>
     bridgePost("/action", { domain: "linear_issue_tracker", action: "searchIssues", args });
+  ade.cto.getLinearIssueComments = async (args: Record<string, unknown> = {}) =>
+    bridgePost("/action", { domain: "linear_issue_tracker", action: "fetchIssueComments", args });
   ade.cto.getLinearProjects = async () =>
     bridgePost("/action", { domain: "linear_issue_tracker", action: "listProjects" });
   ade.cto.setLinearToken = async (args: { token: string }) => {

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -133,17 +133,19 @@ function shortId(id: string): string {
   return trimmed.length <= 8 ? trimmed : trimmed.slice(0, 8);
 }
 
-function usageThresholdToneColor(threshold: number): string {
-  if (threshold >= 100) return "#EF4444";
-  if (threshold >= 75) return "#F59E0B";
-  return "#22C55E";
-}
-
 function usageProviderLabel(provider: UsageThresholdEvent["provider"]): string {
   switch (provider) {
     case "claude": return "Claude";
     case "codex": return "Codex";
-    default: return provider;
+    default: return provider.charAt(0).toUpperCase() + provider.slice(1);
+  }
+}
+
+function usageProviderColor(provider: string): string {
+  switch (provider) {
+    case "claude": return "#A78BFA";
+    case "codex": return "#22C55E";
+    default: return "#60A5FA";
   }
 }
 
@@ -169,11 +171,21 @@ function usageAlertKey(event: UsageThresholdEvent): string {
 
 function readDismissedUsageAlerts(): Set<string> {
   try {
-    const raw = window.sessionStorage.getItem(USAGE_ALERT_DISMISS_STORAGE_KEY);
+    const raw = window.localStorage.getItem(USAGE_ALERT_DISMISS_STORAGE_KEY);
     if (!raw) return new Set();
     const parsed = JSON.parse(raw) as unknown;
     if (!Array.isArray(parsed)) return new Set();
-    return new Set(parsed.filter((value): value is string => typeof value === "string"));
+    const now = Date.now();
+    return new Set(
+      parsed.filter((value): value is string => {
+        if (typeof value !== "string") return false;
+        const parts = value.split(":");
+        const resetMs = Number(parts[2]);
+        // Drop entries whose reset cycle has already passed
+        if (Number.isFinite(resetMs) && resetMs < now) return false;
+        return true;
+      }),
+    );
   } catch {
     return new Set();
   }
@@ -181,9 +193,9 @@ function readDismissedUsageAlerts(): Set<string> {
 
 function persistDismissedUsageAlerts(keys: Set<string>): void {
   try {
-    window.sessionStorage.setItem(USAGE_ALERT_DISMISS_STORAGE_KEY, JSON.stringify([...keys]));
+    window.localStorage.setItem(USAGE_ALERT_DISMISS_STORAGE_KEY, JSON.stringify([...keys]));
   } catch {
-    // sessionStorage can be unavailable in private/test environments.
+    // localStorage can be unavailable in private/test environments.
   }
 }
 
@@ -192,8 +204,12 @@ function markUsageAlertDismissed(
   event: UsageThresholdEvent,
 ): void {
   const normalizedReset = normalizeResetsAt(event.resetsAt);
+  // Only dismiss thresholds up to and including the current one so that higher
+  // thresholds (e.g. 50%, 75%, 100%) can still fire later in the same cycle.
   for (const threshold of [25, 50, 75, 100] as const) {
-    dismissed.add(`${event.provider}:${threshold}:${normalizedReset}`);
+    if (threshold <= event.threshold) {
+      dismissed.add(`${event.provider}:${threshold}:${normalizedReset}`);
+    }
   }
   persistDismissedUsageAlerts(dismissed);
 }
@@ -1050,7 +1066,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         }
         return [{ id, event }, ...withoutLowerSameProvider].slice(0, 4);
       });
-      const timer = window.setTimeout(() => dismissUsageToast(id, event), 6_000);
+      const timer = window.setTimeout(() => dismissUsageToast(id, event), 30_000);
       usageToastTimersRef.current.set(id, timer);
     });
     return () => {
@@ -1264,52 +1280,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
         <main className={cn("relative flex flex-col min-h-0 min-w-0 flex-1", tintClass)}>
           <TabBackground />
-          {usageThresholdToasts.length > 0 ? (
-            <div className="shrink-0 z-[2] flex flex-col">
-              {usageThresholdToasts.map(({ id, event }) => {
-                const tone = usageThresholdToneColor(event.threshold);
-                const providerLabel = usageProviderLabel(event.provider);
-                const countdown = formatUsageResetCountdown(event.resetsAt, Date.now());
-                return (
-                  <button
-                    key={id}
-                    type="button"
-                    className="group relative flex h-6 w-full items-center overflow-hidden text-[11px] transition-colors hover:brightness-110"
-                    style={{ background: `${tone}12` }}
-                    onClick={() => {
-                      window.dispatchEvent(new CustomEvent(OPEN_USAGE_EVENT));
-                      dismissUsageToast(id, event);
-                    }}
-                    title="Open usage"
-                  >
-                    <div
-                      className="absolute inset-y-0 left-0 transition-all"
-                      style={{
-                        width: `${Math.min(100, event.threshold)}%`,
-                        background: `${tone}25`,
-                      }}
-                    />
-                    <div className="relative z-[1] flex w-full items-center justify-center gap-2 px-3">
-                      <span className="font-medium" style={{ color: tone }}>
-                        {providerLabel} {event.threshold}%
-                      </span>
-                      <span style={{ color: `${tone}99` }}>·</span>
-                      <span style={{ color: `${tone}88` }}>{countdown}</span>
-                    </div>
-                    <div
-                      className="absolute inset-y-0 right-0 z-[2] flex items-center pr-2 opacity-0 group-hover:opacity-100 transition-opacity"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        dismissUsageToast(id, event);
-                      }}
-                    >
-                      <span className="text-[10px] text-muted-fg hover:text-fg cursor-pointer">✕</span>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-          ) : null}
           <div
             className="relative z-[1] min-h-0 flex-1 w-full"
             data-tab-revisit={!isFirstVisit || undefined}
@@ -1324,8 +1294,52 @@ export function AppShell({ children }: { children: React.ReactNode }) {
               children
             )}
           </div>
-          {staleCliNotice || prToasts.length > 0 ? (
+          {staleCliNotice || prToasts.length > 0 || usageThresholdToasts.length > 0 ? (
             <div className="pointer-events-none absolute bottom-2 right-2 z-[95] flex w-[min(380px,calc(100vw-20px))] flex-col gap-1.5">
+              {usageThresholdToasts.map(({ id, event }) => {
+                const providerColor = usageProviderColor(event.provider);
+                const providerLabel = usageProviderLabel(event.provider);
+                const countdown = formatUsageResetCountdown(event.resetsAt, Date.now());
+                return (
+                  <div
+                    key={id}
+                    className="pointer-events-auto flex w-72 overflow-hidden rounded-lg border border-white/[0.08] bg-[color:var(--ade-shell-surface,#1A1830)] shadow-xl shadow-black/40"
+                  >
+                    <div className="w-1 shrink-0" style={{ backgroundColor: providerColor }} />
+                    <div className="flex min-w-0 flex-1 flex-col gap-1 px-3 py-2.5">
+                      <div className="flex items-center justify-between gap-2">
+                        <button
+                          type="button"
+                          className="text-[12px] font-medium text-fg/90 hover:underline"
+                          onClick={() => {
+                            window.dispatchEvent(new CustomEvent(OPEN_USAGE_EVENT));
+                            dismissUsageToast(id, event);
+                          }}
+                          title="Open usage"
+                        >
+                          {providerLabel} usage at {event.threshold}%
+                        </button>
+                        <button
+                          type="button"
+                          className="shrink-0 rounded p-0.5 text-muted-fg transition-colors hover:bg-fg/[0.05] hover:text-fg"
+                          onClick={() => dismissUsageToast(id, event)}
+                          aria-label="Dismiss usage notification"
+                          title="Dismiss"
+                        >
+                          <span className="text-[11px]">&times;</span>
+                        </button>
+                      </div>
+                      <span className="text-[11px] text-muted-fg/55">{countdown}</span>
+                      <div className="h-1 overflow-hidden rounded-full bg-white/[0.06]">
+                        <div
+                          className="h-full rounded-full"
+                          style={{ width: `${Math.min(100, event.percent ?? event.threshold)}%`, backgroundColor: providerColor }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
               {staleCliNotice ? (
                 <div className="pointer-events-auto overflow-hidden rounded-xl border border-amber-500/25 bg-card/95 px-3 py-3 shadow-float backdrop-blur">
                   <div className="flex items-start gap-3">

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -141,7 +141,7 @@ function usageProviderLabel(provider: UsageThresholdEvent["provider"]): string {
   }
 }
 
-function usageProviderColor(provider: string): string {
+function usageProviderColor(provider: UsageThresholdEvent["provider"]): string {
   switch (provider) {
     case "claude": return "#A78BFA";
     case "codex": return "#22C55E";
@@ -207,9 +207,8 @@ function markUsageAlertDismissed(
   // Only dismiss thresholds up to and including the current one so that higher
   // thresholds (e.g. 50%, 75%, 100%) can still fire later in the same cycle.
   for (const threshold of [25, 50, 75, 100] as const) {
-    if (threshold <= event.threshold) {
-      dismissed.add(`${event.provider}:${threshold}:${normalizedReset}`);
-    }
+    if (threshold > event.threshold) break;
+    dismissed.add(`${event.provider}:${threshold}:${normalizedReset}`);
   }
   persistDismissedUsageAlerts(dismissed);
 }

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -350,14 +350,19 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   >([]);
   const usageToastTimersRef = useRef<Map<string, number>>(new Map());
   const dismissedUsageAlertsRef = useRef(readDismissedUsageAlerts());
-  const dismissUsageToast = (id: string, event?: UsageThresholdEvent) => {
-    if (event) {
-      markUsageAlertDismissed(dismissedUsageAlertsRef.current, event);
-    }
+  /** Remove a usage toast from the in-memory list without persisting to localStorage. */
+  const expireUsageToast = (id: string) => {
     setUsageThresholdToasts((prev) => prev.filter((t) => t.id !== id));
     const timer = usageToastTimersRef.current.get(id);
     if (timer != null) window.clearTimeout(timer);
     usageToastTimersRef.current.delete(id);
+  };
+  /** Explicitly dismiss a usage toast (user clicked "X") — persists to localStorage. */
+  const dismissUsageToast = (id: string, event?: UsageThresholdEvent) => {
+    if (event) {
+      markUsageAlertDismissed(dismissedUsageAlertsRef.current, event);
+    }
+    expireUsageToast(id);
   };
   const [staleCliNotice, setStaleCliNotice] =
     useState<StaleCliNotice | null>(null);
@@ -1065,7 +1070,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         }
         return [{ id, event }, ...withoutLowerSameProvider].slice(0, 4);
       });
-      const timer = window.setTimeout(() => dismissUsageToast(id, event), 30_000);
+      const timer = window.setTimeout(() => expireUsageToast(id), 30_000);
       usageToastTimersRef.current.set(id, timer);
     });
     return () => {

--- a/apps/desktop/src/renderer/components/app/LinearIssueBrowser.tsx
+++ b/apps/desktop/src/renderer/components/app/LinearIssueBrowser.tsx
@@ -18,6 +18,7 @@ import { BranchIcon } from "../ui/vcsIcons";
 
 import type {
   CtoGetLinearIssuePickerDataResult,
+  CtoLinearIssueComment,
   CtoLinearProject,
   CtoLinearQuickView,
   CtoLinearQuickViewProject,
@@ -1018,26 +1019,7 @@ function IssueDetails({
           </div>
         ) : null}
 
-        {(() => {
-          const coloredLabels = normalizedIssue?.labelColors ?? issue.labels.map((l) => ({ name: l, color: null as string | null }));
-          return coloredLabels.length > 0 ? (
-            <div className="mt-3 flex flex-wrap gap-1.5">
-              {coloredLabels.map((label) => (
-                <span
-                  key={label.name}
-                  className="rounded-full border px-2 py-0.5 text-[10px]"
-                  style={{
-                    borderColor: label.color ? `${label.color}44` : "rgba(255,255,255,0.07)",
-                    backgroundColor: label.color ? `${label.color}18` : "rgba(255,255,255,0.035)",
-                    color: label.color ?? "rgba(255,255,255,0.75)",
-                  }}
-                >
-                  {label.name}
-                </span>
-              ))}
-            </div>
-          ) : null;
-        })()}
+        <IssueLabels issue={issue} normalizedIssue={normalizedIssue} />
 
         <div className="mt-3 grid gap-1.5 text-[11px] text-muted-fg/65">
           <InfoRow label="Project" value={issueProjectLabel(issue)} />
@@ -1119,6 +1101,28 @@ function IssueDetails({
   );
 }
 
+function IssueLabels({ issue, normalizedIssue }: { issue: BrowserIssue; normalizedIssue: NormalizedLinearIssue | null }) {
+  const labels = normalizedIssue?.labelColors ?? issue.labels.map((l) => ({ name: l, color: null as string | null }));
+  if (labels.length === 0) return null;
+  return (
+    <div className="mt-3 flex flex-wrap gap-1.5">
+      {labels.map((label) => (
+        <span
+          key={label.name}
+          className="rounded-full border px-2 py-0.5 text-[10px]"
+          style={{
+            borderColor: label.color ? `${label.color}44` : "rgba(255,255,255,0.07)",
+            backgroundColor: label.color ? `${label.color}18` : "rgba(255,255,255,0.035)",
+            color: label.color ?? "rgba(255,255,255,0.75)",
+          }}
+        >
+          {label.name}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 function InfoRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex items-baseline justify-between gap-2">
@@ -1157,7 +1161,7 @@ function SubIssuesList({ issues }: { issues: NonNullable<NormalizedLinearIssue["
 
 function ActivitySection({ issueId }: { issueId: string }) {
   const [expanded, setExpanded] = useState(false);
-  const [comments, setComments] = useState<Array<{ id: string; body: string; createdAt: string; userName: string; userDisplayName: string }> | null>(null);
+  const [comments, setComments] = useState<CtoLinearIssueComment[] | null>(null);
   const [loading, setLoading] = useState(false);
   const prevIssueIdRef = useRef(issueId);
 
@@ -1172,7 +1176,7 @@ function ActivitySection({ issueId }: { issueId: string }) {
     let cancelled = false;
     setLoading(true);
     const cto = window.ade?.cto as Record<string, unknown> | undefined;
-    const fn = cto?.getLinearIssueComments as ((args: { issueId: string }) => Promise<Array<{ id: string; body: string; createdAt: string; userName: string; userDisplayName: string }>>) | undefined;
+    const fn = cto?.getLinearIssueComments as ((args: { issueId: string }) => Promise<CtoLinearIssueComment[]>) | undefined;
     if (!fn) { setLoading(false); setComments([]); return; }
     void fn({ issueId })
       .then((result) => { if (!cancelled) setComments(result ?? []); })
@@ -1216,6 +1220,12 @@ function ActivitySection({ issueId }: { issueId: string }) {
   );
 }
 
+const BATCH_ACTIONS_CONFIG = [
+  { key: "create", icon: <Plus size={13} />, label: "Create lanes for", sublabel: "New lane per issue" },
+  { key: "resolve-new", icon: <Sparkle size={13} />, label: "Resolve all in new lanes", sublabel: "Lane + chat per issue" },
+  { key: "resolve-existing", icon: <GitBranch size={13} />, label: "Assign all to one lane", sublabel: "Pick lane, chat per issue" },
+] as const;
+
 function BatchActionView({
   selectedIssues,
   onClearSelection,
@@ -1225,6 +1235,16 @@ function BatchActionView({
   onClearSelection: () => void;
   batchActions: NonNullable<Parameters<typeof LinearIssueBrowser>[0]["batchActions"]>;
 }) {
+  const busy = Boolean(batchActions.batchProgress);
+
+  function handleAction(key: string): void {
+    switch (key) {
+      case "create": void batchActions.onBatchCreateLanes(selectedIssues); break;
+      case "resolve-new": void batchActions.onBatchResolveNewLanes(selectedIssues, ""); break;
+      case "resolve-existing": void batchActions.onBatchResolveExistingLane(selectedIssues, "", ""); break;
+    }
+  }
+
   return (
     <aside className="flex min-h-0 flex-col overflow-hidden">
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
@@ -1245,48 +1265,25 @@ function BatchActionView({
       </div>
       <div className="shrink-0 border-t border-white/10 px-4 py-3">
         <div className="space-y-1.5">
-          <button
-            type="button"
-            disabled={Boolean(batchActions.batchProgress)}
-            className="flex w-full items-start gap-2.5 rounded-lg border border-white/[0.07] bg-white/[0.02] px-2.5 py-2 text-left transition-colors hover:border-white/[0.12] hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-45"
-            onClick={() => void batchActions.onBatchCreateLanes(selectedIssues)}
-          >
-            <span className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-md text-[color:var(--color-accent,#A78BFA)]" style={{ background: "rgba(167, 139, 250, 0.12)" }}>
-              <Plus size={13} />
-            </span>
-            <span className="min-w-0 flex-1">
-              <span className="block text-[11.5px] font-medium leading-snug text-fg/90">Create lanes for {selectedIssues.length} issues</span>
-              <span className="mt-0.5 block text-[10.5px] leading-relaxed text-muted-fg/55">New lane per issue</span>
-            </span>
-          </button>
-          <button
-            type="button"
-            disabled={Boolean(batchActions.batchProgress)}
-            className="flex w-full items-start gap-2.5 rounded-lg border border-white/[0.07] bg-white/[0.02] px-2.5 py-2 text-left transition-colors hover:border-white/[0.12] hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-45"
-            onClick={() => void batchActions.onBatchResolveNewLanes(selectedIssues, "")}
-          >
-            <span className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-md text-[color:var(--color-accent,#A78BFA)]" style={{ background: "rgba(167, 139, 250, 0.12)" }}>
-              <Sparkle size={13} />
-            </span>
-            <span className="min-w-0 flex-1">
-              <span className="block text-[11.5px] font-medium leading-snug text-fg/90">Resolve all in new lanes</span>
-              <span className="mt-0.5 block text-[10.5px] leading-relaxed text-muted-fg/55">Lane + chat per issue</span>
-            </span>
-          </button>
-          <button
-            type="button"
-            disabled={Boolean(batchActions.batchProgress)}
-            className="flex w-full items-start gap-2.5 rounded-lg border border-white/[0.07] bg-white/[0.02] px-2.5 py-2 text-left transition-colors hover:border-white/[0.12] hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-45"
-            onClick={() => void batchActions.onBatchResolveExistingLane(selectedIssues, "", "")}
-          >
-            <span className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-md text-[color:var(--color-accent,#A78BFA)]" style={{ background: "rgba(167, 139, 250, 0.12)" }}>
-              <GitBranch size={13} />
-            </span>
-            <span className="min-w-0 flex-1">
-              <span className="block text-[11.5px] font-medium leading-snug text-fg/90">Assign all to one lane</span>
-              <span className="mt-0.5 block text-[10.5px] leading-relaxed text-muted-fg/55">Pick lane, chat per issue</span>
-            </span>
-          </button>
+          {BATCH_ACTIONS_CONFIG.map((action) => (
+            <button
+              key={action.key}
+              type="button"
+              disabled={busy}
+              className="flex w-full items-start gap-2.5 rounded-lg border border-white/[0.07] bg-white/[0.02] px-2.5 py-2 text-left transition-colors hover:border-white/[0.12] hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-45"
+              onClick={() => handleAction(action.key)}
+            >
+              <span className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-md text-[color:var(--color-accent,#A78BFA)]" style={{ background: "rgba(167, 139, 250, 0.12)" }}>
+                {action.icon}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-[11.5px] font-medium leading-snug text-fg/90">
+                  {action.key === "create" ? `${action.label} ${selectedIssues.length} issues` : action.label}
+                </span>
+                <span className="mt-0.5 block text-[10.5px] leading-relaxed text-muted-fg/55">{action.sublabel}</span>
+              </span>
+            </button>
+          ))}
         </div>
         {batchActions.batchProgress && (
           <div className="mt-2">

--- a/apps/desktop/src/renderer/components/app/LinearIssueBrowser.tsx
+++ b/apps/desktop/src/renderer/components/app/LinearIssueBrowser.tsx
@@ -2,12 +2,18 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   CaretDown,
   CaretRight,
+  Check,
   CircleNotch,
+  GitBranch,
   MagnifyingGlass,
+  Minus,
   Plus,
   Sparkle,
   Warning,
 } from "@phosphor-icons/react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeSanitize from "rehype-sanitize";
 import { BranchIcon } from "../ui/vcsIcons";
 
 import type {
@@ -241,6 +247,7 @@ export function LinearIssueBrowser({
   onQuickViewChange,
   onLoadingChange,
   resolveActions,
+  batchActions,
 }: {
   projectRoot?: string | null;
   featuredIssue?: LaneLinearIssue | null;
@@ -262,6 +269,12 @@ export function LinearIssueBrowser({
     busyModal?: LinearIssueResolveModalKind | null;
     disabled?: boolean;
   };
+  batchActions?: {
+    onBatchCreateLanes: (issues: BrowserIssue[]) => void | Promise<void>;
+    onBatchResolveNewLanes: (issues: BrowserIssue[], modelId: string) => void | Promise<void>;
+    onBatchResolveExistingLane: (issues: BrowserIssue[], laneId: string, modelId: string) => void | Promise<void>;
+    batchProgress: { completed: number; total: number; action: string } | null;
+  };
 }) {
   const [quickView, setQuickView] = useState<CtoLinearQuickView | null>(null);
   const quickViewRef = useRef<CtoLinearQuickView | null>(null);
@@ -275,6 +288,9 @@ export function LinearIssueBrowser({
   const [loadingIssues, setLoadingIssues] = useState(false);
   const [localActionIssueId, setLocalActionIssueId] = useState<string | null>(null);
   const [selectedIssueId, setSelectedIssueId] = useState<string | null>(featuredIssue?.id ?? null);
+  const [selectedIssueIds, setSelectedIssueIds] = useState<Set<string>>(new Set());
+  const [lastCheckedId, setLastCheckedId] = useState<string | null>(null);
+  const anyChecked = selectedIssueIds.size > 0;
   const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>({});
   const [error, setError] = useState<string | null>(null);
   const quickViewRequestIdRef = useRef(0);
@@ -419,6 +435,47 @@ export function LinearIssueBrowser({
   }, [displayIssues, selectedIssueId]);
 
   const selectedIssue = displayIssues.find((issue) => issue.id === selectedIssueId) ?? displayIssues[0] ?? null;
+
+  const handleToggleCheck = useCallback((issueId: string, event: React.MouseEvent) => {
+    setSelectedIssueIds((prev) => {
+      const next = new Set(prev);
+      if (event.shiftKey && lastCheckedId) {
+        const startIdx = displayIssues.findIndex((i) => i.id === lastCheckedId);
+        const endIdx = displayIssues.findIndex((i) => i.id === issueId);
+        if (startIdx !== -1 && endIdx !== -1) {
+          const [lo, hi] = startIdx < endIdx ? [startIdx, endIdx] : [endIdx, startIdx];
+          for (let i = lo; i <= hi; i++) next.add(displayIssues[i].id);
+        }
+      } else {
+        if (next.has(issueId)) next.delete(issueId);
+        else next.add(issueId);
+      }
+      return next;
+    });
+    setLastCheckedId(issueId);
+  }, [displayIssues, lastCheckedId]);
+
+  const handleSelectAll = useCallback(() => {
+    setSelectedIssueIds((prev) => {
+      if (prev.size === displayIssues.length) return new Set();
+      return new Set(displayIssues.map((i) => i.id));
+    });
+  }, [displayIssues]);
+
+  // Clear selection when filters change
+  useEffect(() => {
+    setSelectedIssueIds(new Set());
+    setLastCheckedId(null);
+  }, [filters]);
+
+  // Prune stale selections when issues change
+  useEffect(() => {
+    const validIds = new Set(displayIssues.map((i) => i.id));
+    setSelectedIssueIds((prev) => {
+      const pruned = new Set([...prev].filter((id) => validIds.has(id)));
+      return pruned.size === prev.size ? prev : pruned;
+    });
+  }, [displayIssues]);
 
   const assigneeOptions = useMemo(
     () => [
@@ -575,6 +632,42 @@ export function LinearIssueBrowser({
             </div>
           </div>
 
+          {displayIssues.length > 0 && (
+            <div className="flex shrink-0 items-center gap-2 border-b border-white/[0.05] px-3 py-1.5">
+              <span
+                role="checkbox"
+                aria-checked={selectedIssueIds.size === displayIssues.length && displayIssues.length > 0}
+                onClick={handleSelectAll}
+                className={cn(
+                  "flex h-[14px] w-[14px] shrink-0 cursor-pointer items-center justify-center rounded-[3px] border transition-all",
+                  selectedIssueIds.size === displayIssues.length
+                    ? "border-[color:var(--color-accent,#A78BFA)] bg-[color:var(--color-accent,#A78BFA)]"
+                    : selectedIssueIds.size > 0
+                      ? "border-[color:var(--color-accent,#A78BFA)] bg-[color:var(--color-accent,#A78BFA)]/50"
+                      : "border-white/[0.15] bg-transparent hover:border-white/30",
+                )}
+              >
+                {selectedIssueIds.size === displayIssues.length && displayIssues.length > 0 ? (
+                  <Check size={10} weight="bold" className="text-[#0F0D14]" />
+                ) : selectedIssueIds.size > 0 ? (
+                  <Minus size={10} weight="bold" className="text-[#0F0D14]" />
+                ) : null}
+              </span>
+              <span className="text-[11px] text-muted-fg/55">
+                {selectedIssueIds.size > 0 ? `${selectedIssueIds.size} selected` : `${displayIssues.length} issues`}
+              </span>
+              {selectedIssueIds.size > 0 && (
+                <button
+                  type="button"
+                  className="ml-auto text-[10px] text-muted-fg/50 hover:text-fg/80 transition-colors"
+                  onClick={() => setSelectedIssueIds(new Set())}
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+          )}
+
           <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
             {loadingQuickView && !quickView && displayIssues.length === 0 ? (
               <div className="grid h-44 place-items-center text-[12px] text-muted-fg/55">
@@ -603,6 +696,9 @@ export function LinearIssueBrowser({
                           active={selectedIssue?.id === issue.id}
                           eyebrow={featuredIssue?.id === issue.id ? featuredIssueLabel : undefined}
                           busy={busyIssueId === issue.id}
+                          checked={selectedIssueIds.has(issue.id)}
+                          anyChecked={anyChecked}
+                          onToggleCheck={(e) => handleToggleCheck(issue.id, e)}
                           onClick={() => setSelectedIssueId(issue.id)}
                         />
                       )) : null}
@@ -629,17 +725,25 @@ export function LinearIssueBrowser({
           </div>
         </section>
 
-        <IssueDetails
-          issue={selectedIssue}
-          actionLabel={actionLabel}
-          actionBusyLabel={actionBusyLabel}
-          actionIcon={actionIcon}
-          actionBusy={selectedIssue ? busyIssueId === selectedIssue.id : false}
-          actionDisabled={actionDisabled || Boolean(busyIssueId && busyIssueId !== selectedIssue?.id)}
-          showBranchPreview={showBranchPreview}
-          onIssueAction={handleIssueAction}
-          resolveActions={resolveActions}
-        />
+        {selectedIssueIds.size > 1 && batchActions ? (
+          <BatchActionView
+            selectedIssues={displayIssues.filter((i) => selectedIssueIds.has(i.id))}
+            onClearSelection={() => setSelectedIssueIds(new Set())}
+            batchActions={batchActions}
+          />
+        ) : (
+          <IssueDetails
+            issue={selectedIssue}
+            actionLabel={actionLabel}
+            actionBusyLabel={actionBusyLabel}
+            actionIcon={actionIcon}
+            actionBusy={selectedIssue ? busyIssueId === selectedIssue.id : false}
+            actionDisabled={actionDisabled || Boolean(busyIssueId && busyIssueId !== selectedIssue?.id)}
+            showBranchPreview={showBranchPreview}
+            onIssueAction={handleIssueAction}
+            resolveActions={resolveActions}
+          />
+        )}
       </div>
     </div>
   );
@@ -725,12 +829,18 @@ function LinearBrowserIssueRow({
   active,
   eyebrow,
   busy,
+  checked,
+  anyChecked: anyRowChecked,
+  onToggleCheck,
   onClick,
 }: {
   issue: BrowserIssue;
   active: boolean;
   eyebrow?: string;
   busy?: boolean;
+  checked: boolean;
+  anyChecked: boolean;
+  onToggleCheck: (event: React.MouseEvent) => void;
   onClick: () => void;
 }) {
   const listDate = linearIssueListDate(issue);
@@ -739,12 +849,26 @@ function LinearBrowserIssueRow({
     <button
       type="button"
       className={cn(
-        "group flex h-[34px] w-full items-center gap-3 border-b border-white/[0.04] px-3 text-left transition-colors disabled:opacity-50",
+        "group/row flex h-[34px] w-full items-center gap-3 border-b border-white/[0.04] px-3 text-left transition-colors disabled:opacity-50",
         active ? "bg-white/[0.06]" : "hover:bg-white/[0.03]",
       )}
       onClick={onClick}
       disabled={busy}
     >
+      <span
+        role="checkbox"
+        aria-checked={checked}
+        onClick={(e) => { e.stopPropagation(); onToggleCheck(e); }}
+        className={cn(
+          "flex h-[14px] w-[14px] shrink-0 items-center justify-center rounded-[3px] border transition-all cursor-pointer",
+          checked
+            ? "border-[color:var(--color-accent,#A78BFA)] bg-[color:var(--color-accent,#A78BFA)]"
+            : "border-white/[0.15] bg-transparent hover:border-white/30",
+          !anyRowChecked && !checked && "opacity-0 group-hover/row:opacity-100",
+        )}
+      >
+        {checked ? <Check size={10} weight="bold" className="text-[#0F0D14]" /> : null}
+      </span>
       <span className="w-[54px] shrink-0 truncate font-mono text-[11px] text-muted-fg/50">
         {issue.identifier}
       </span>
@@ -863,9 +987,20 @@ function IssueDetails({
         <div className="flex items-center gap-2">
           <LinearPriorityIcon priority={issue.priority} size={12} />
           <LinearStateIcon stateType={issue.stateType} size={12} />
-          <span className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[10px] text-fg/80">
-            {issue.identifier}
-          </span>
+          {issue.url ? (
+            <a
+              href={issue.url}
+              onClick={(e) => { e.preventDefault(); window.ade?.app?.openExternal?.(issue.url!); }}
+              className="cursor-pointer rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[10px] text-fg/80 hover:bg-white/[0.1] transition-colors"
+              title="Open in Linear"
+            >
+              {issue.identifier}
+            </a>
+          ) : (
+            <span className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[10px] text-fg/80">
+              {issue.identifier}
+            </span>
+          )}
         </div>
         <div className="mt-2 text-[14px] font-semibold leading-snug">{issue.title}</div>
         {showBranchPreview ? (
@@ -876,24 +1011,40 @@ function IssueDetails({
         ) : null}
 
         {description ? (
-          <div className="mt-3 max-h-28 overflow-y-auto rounded-lg border border-white/[0.06] bg-white/[0.025] px-3 py-2 text-[12px] leading-relaxed text-muted-fg/80 whitespace-pre-wrap">
-            {description}
+          <div className="mt-3 overflow-y-auto rounded-lg border border-white/[0.06] bg-white/[0.025] px-3 py-2 text-[12px] leading-relaxed text-muted-fg/80">
+            <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
+              {description}
+            </ReactMarkdown>
           </div>
         ) : null}
 
-        {issue.labels.length > 0 ? (
-          <div className="mt-3 flex flex-wrap gap-1.5">
-            {issue.labels.map((label) => (
-              <span key={label} className="rounded-full border border-white/[0.07] bg-white/[0.035] px-2 py-0.5 text-[10px] text-muted-fg/75">
-                {label}
-              </span>
-            ))}
-          </div>
-        ) : null}
+        {(() => {
+          const coloredLabels = normalizedIssue?.labelColors ?? issue.labels.map((l) => ({ name: l, color: null as string | null }));
+          return coloredLabels.length > 0 ? (
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {coloredLabels.map((label) => (
+                <span
+                  key={label.name}
+                  className="rounded-full border px-2 py-0.5 text-[10px]"
+                  style={{
+                    borderColor: label.color ? `${label.color}44` : "rgba(255,255,255,0.07)",
+                    backgroundColor: label.color ? `${label.color}18` : "rgba(255,255,255,0.035)",
+                    color: label.color ?? "rgba(255,255,255,0.75)",
+                  }}
+                >
+                  {label.name}
+                </span>
+              ))}
+            </div>
+          ) : null;
+        })()}
 
         <div className="mt-3 grid gap-1.5 text-[11px] text-muted-fg/65">
           <InfoRow label="Project" value={issueProjectLabel(issue)} />
           <InfoRow label="Team" value={issue.teamName ?? issue.teamKey} />
+          {normalizedIssue?.cycleName && (
+            <InfoRow label="Cycle" value={normalizedIssue.cycleName} />
+          )}
           <InfoRow label="Status" value={issue.stateName} />
           <InfoRow label="Priority" value={linearPriorityLabel(issue)} />
           <InfoRow label="Assignee" value={issue.assigneeName ?? "Unassigned"} />
@@ -911,9 +1062,15 @@ function IssueDetails({
             </>
           ) : null}
         </div>
+
+        {normalizedIssue?.childIssues && normalizedIssue.childIssues.length > 0 ? (
+          <SubIssuesList issues={normalizedIssue.childIssues} />
+        ) : null}
+
+        <ActivitySection issueId={issue.id} />
       </div>
 
-      <div className="border-t border-white/10 px-4 py-3">
+      <div className="shrink-0 max-h-[280px] overflow-y-auto border-t border-white/10 px-4 py-3">
         {resolveActions ? (
           <div className="space-y-2">
             <div className="space-y-1.5">
@@ -968,5 +1125,184 @@ function InfoRow({ label, value }: { label: string; value: string }) {
       <span className="text-muted-fg/45">{label}</span>
       <span className="truncate text-right text-fg/80" title={value}>{value}</span>
     </div>
+  );
+}
+
+function SubIssuesList({ issues }: { issues: NonNullable<NormalizedLinearIssue["childIssues"]> }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="mt-3">
+      <button
+        type="button"
+        className="flex items-center gap-1.5 text-[11px] font-medium text-muted-fg/65 hover:text-fg/80 transition-colors"
+        onClick={() => setExpanded(!expanded)}
+      >
+        {expanded ? <CaretDown size={10} /> : <CaretRight size={10} />}
+        Sub-issues ({issues.length})
+      </button>
+      {expanded && (
+        <div className="mt-1.5 space-y-1 pl-1">
+          {issues.map((child) => (
+            <div key={child.id} className="flex items-center gap-2 py-0.5">
+              <LinearStateIcon stateType={child.stateType} size={10} />
+              <span className="font-mono text-[10px] text-fg/60">{child.identifier}</span>
+              <span className="min-w-0 flex-1 truncate text-[11px] text-muted-fg/70">{child.title}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ActivitySection({ issueId }: { issueId: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const [comments, setComments] = useState<Array<{ id: string; body: string; createdAt: string; userName: string; userDisplayName: string }> | null>(null);
+  const [loading, setLoading] = useState(false);
+  const prevIssueIdRef = useRef(issueId);
+
+  if (prevIssueIdRef.current !== issueId) {
+    prevIssueIdRef.current = issueId;
+    setComments(null);
+    setExpanded(false);
+  }
+
+  useEffect(() => {
+    if (!expanded || comments) return;
+    let cancelled = false;
+    setLoading(true);
+    const cto = window.ade?.cto as Record<string, unknown> | undefined;
+    const fn = cto?.getLinearIssueComments as ((args: { issueId: string }) => Promise<Array<{ id: string; body: string; createdAt: string; userName: string; userDisplayName: string }>>) | undefined;
+    if (!fn) { setLoading(false); setComments([]); return; }
+    void fn({ issueId })
+      .then((result) => { if (!cancelled) setComments(result ?? []); })
+      .catch(() => { if (!cancelled) setComments([]); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [expanded, issueId, comments]);
+
+  return (
+    <div className="mt-3">
+      <button
+        type="button"
+        className="flex items-center gap-1.5 text-[11px] font-medium text-muted-fg/65 hover:text-fg/80 transition-colors"
+        onClick={() => setExpanded(!expanded)}
+      >
+        {expanded ? <CaretDown size={10} /> : <CaretRight size={10} />}
+        Activity
+      </button>
+      {expanded && (
+        <div className="mt-1.5 space-y-2 pl-1">
+          {loading ? (
+            <div className="text-[10px] text-muted-fg/40">Loading...</div>
+          ) : comments && comments.length > 0 ? (
+            comments.map((comment) => (
+              <div key={comment.id} className="rounded-md border border-white/[0.05] bg-white/[0.02] px-2.5 py-2">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-[11px] font-medium text-fg/80">{comment.userDisplayName || comment.userName}</span>
+                  <span className="text-[10px] text-muted-fg/40">{formatDate(comment.createdAt)}</span>
+                </div>
+                <div className="mt-1 text-[11px] leading-relaxed text-muted-fg/70 whitespace-pre-wrap">
+                  {comment.body}
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="text-[10px] text-muted-fg/40">No comments</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BatchActionView({
+  selectedIssues,
+  onClearSelection,
+  batchActions,
+}: {
+  selectedIssues: BrowserIssue[];
+  onClearSelection: () => void;
+  batchActions: NonNullable<Parameters<typeof LinearIssueBrowser>[0]["batchActions"]>;
+}) {
+  return (
+    <aside className="flex min-h-0 flex-col overflow-hidden">
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+        <div className="flex items-center justify-between">
+          <span className="text-[13px] font-semibold text-fg/90">{selectedIssues.length} issues selected</span>
+          <button type="button" className="text-[10px] text-muted-fg/50 hover:text-fg/80 transition-colors" onClick={onClearSelection}>
+            Clear
+          </button>
+        </div>
+        <div className="mt-2 space-y-1">
+          {selectedIssues.map((issue) => (
+            <div key={issue.id} className="flex items-center gap-2 rounded-md bg-white/[0.03] px-2 py-1">
+              <span className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[10px] text-fg/80">{issue.identifier}</span>
+              <span className="min-w-0 flex-1 truncate text-[11px] text-muted-fg/70">{issue.title}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="shrink-0 border-t border-white/10 px-4 py-3">
+        <div className="space-y-1.5">
+          <button
+            type="button"
+            disabled={Boolean(batchActions.batchProgress)}
+            className="flex w-full items-start gap-2.5 rounded-lg border border-white/[0.07] bg-white/[0.02] px-2.5 py-2 text-left transition-colors hover:border-white/[0.12] hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-45"
+            onClick={() => void batchActions.onBatchCreateLanes(selectedIssues)}
+          >
+            <span className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-md text-[color:var(--color-accent,#A78BFA)]" style={{ background: "rgba(167, 139, 250, 0.12)" }}>
+              <Plus size={13} />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block text-[11.5px] font-medium leading-snug text-fg/90">Create lanes for {selectedIssues.length} issues</span>
+              <span className="mt-0.5 block text-[10.5px] leading-relaxed text-muted-fg/55">New lane per issue</span>
+            </span>
+          </button>
+          <button
+            type="button"
+            disabled={Boolean(batchActions.batchProgress)}
+            className="flex w-full items-start gap-2.5 rounded-lg border border-white/[0.07] bg-white/[0.02] px-2.5 py-2 text-left transition-colors hover:border-white/[0.12] hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-45"
+            onClick={() => void batchActions.onBatchResolveNewLanes(selectedIssues, "")}
+          >
+            <span className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-md text-[color:var(--color-accent,#A78BFA)]" style={{ background: "rgba(167, 139, 250, 0.12)" }}>
+              <Sparkle size={13} />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block text-[11.5px] font-medium leading-snug text-fg/90">Resolve all in new lanes</span>
+              <span className="mt-0.5 block text-[10.5px] leading-relaxed text-muted-fg/55">Lane + chat per issue</span>
+            </span>
+          </button>
+          <button
+            type="button"
+            disabled={Boolean(batchActions.batchProgress)}
+            className="flex w-full items-start gap-2.5 rounded-lg border border-white/[0.07] bg-white/[0.02] px-2.5 py-2 text-left transition-colors hover:border-white/[0.12] hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-45"
+            onClick={() => void batchActions.onBatchResolveExistingLane(selectedIssues, "", "")}
+          >
+            <span className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-md text-[color:var(--color-accent,#A78BFA)]" style={{ background: "rgba(167, 139, 250, 0.12)" }}>
+              <GitBranch size={13} />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block text-[11.5px] font-medium leading-snug text-fg/90">Assign all to one lane</span>
+              <span className="mt-0.5 block text-[10.5px] leading-relaxed text-muted-fg/55">Pick lane, chat per issue</span>
+            </span>
+          </button>
+        </div>
+        {batchActions.batchProgress && (
+          <div className="mt-2">
+            <div className="flex items-center justify-between text-[10px] text-muted-fg/55">
+              <span>{batchActions.batchProgress.action}</span>
+              <span>{batchActions.batchProgress.completed}/{batchActions.batchProgress.total}</span>
+            </div>
+            <div className="mt-1 h-1 overflow-hidden rounded-full bg-white/[0.06]">
+              <div
+                className="h-full rounded-full bg-[color:var(--color-accent,#A78BFA)] transition-all"
+                style={{ width: `${batchActions.batchProgress.total > 0 ? (batchActions.batchProgress.completed / batchActions.batchProgress.total) * 100 : 0}%` }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </aside>
   );
 }

--- a/apps/desktop/src/renderer/components/app/LinearIssueBrowser.tsx
+++ b/apps/desktop/src/renderer/components/app/LinearIssueBrowser.tsx
@@ -272,8 +272,8 @@ export function LinearIssueBrowser({
   };
   batchActions?: {
     onBatchCreateLanes: (issues: BrowserIssue[]) => void | Promise<void>;
-    onBatchResolveNewLanes: (issues: BrowserIssue[], modelId: string) => void | Promise<void>;
-    onBatchResolveExistingLane: (issues: BrowserIssue[], laneId: string, modelId: string) => void | Promise<void>;
+    onBatchResolveNewLanes: (issues: BrowserIssue[]) => void | Promise<void>;
+    onBatchResolveExistingLane: (issues: BrowserIssue[]) => void | Promise<void>;
     batchProgress: { completed: number; total: number; action: string } | null;
   };
 }) {
@@ -446,6 +446,10 @@ export function LinearIssueBrowser({
         if (startIdx !== -1 && endIdx !== -1) {
           const [lo, hi] = startIdx < endIdx ? [startIdx, endIdx] : [endIdx, startIdx];
           for (let i = lo; i <= hi; i++) next.add(displayIssues[i].id);
+        } else {
+          // Anchor is stale (no longer in display list) — fall back to toggling clicked row
+          if (next.has(issueId)) next.delete(issueId);
+          else next.add(issueId);
         }
       } else {
         if (next.has(issueId)) next.delete(issueId);
@@ -637,8 +641,11 @@ export function LinearIssueBrowser({
             <div className="flex shrink-0 items-center gap-2 border-b border-white/[0.05] px-3 py-1.5">
               <span
                 role="checkbox"
-                aria-checked={selectedIssueIds.size === displayIssues.length && displayIssues.length > 0}
+                tabIndex={0}
+                aria-checked={selectedIssueIds.size === 0 ? false : selectedIssueIds.size === displayIssues.length ? true : "mixed"}
+                aria-label="Select all issues"
                 onClick={handleSelectAll}
+                onKeyDown={(e) => { if (e.key === " " || e.key === "Enter") { e.preventDefault(); handleSelectAll(); } }}
                 className={cn(
                   "flex h-[14px] w-[14px] shrink-0 cursor-pointer items-center justify-center rounded-[3px] border transition-all",
                   selectedIssueIds.size === displayIssues.length
@@ -1162,17 +1169,19 @@ function SubIssuesList({ issues }: { issues: NonNullable<NormalizedLinearIssue["
 function ActivitySection({ issueId }: { issueId: string }) {
   const [expanded, setExpanded] = useState(false);
   const [comments, setComments] = useState<CtoLinearIssueComment[] | null>(null);
+  const [commentError, setCommentError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const prevIssueIdRef = useRef(issueId);
 
   if (prevIssueIdRef.current !== issueId) {
     prevIssueIdRef.current = issueId;
     setComments(null);
+    setCommentError(null);
     setExpanded(false);
   }
 
   useEffect(() => {
-    if (!expanded || comments) return;
+    if (!expanded || comments || commentError) return;
     let cancelled = false;
     setLoading(true);
     const cto = window.ade?.cto as Record<string, unknown> | undefined;
@@ -1180,10 +1189,10 @@ function ActivitySection({ issueId }: { issueId: string }) {
     if (!fn) { setLoading(false); setComments([]); return; }
     void fn({ issueId })
       .then((result) => { if (!cancelled) setComments(result ?? []); })
-      .catch(() => { if (!cancelled) setComments([]); })
+      .catch(() => { if (!cancelled) setCommentError("Failed to load comments"); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [expanded, issueId, comments]);
+  }, [expanded, issueId, comments, commentError]);
 
   return (
     <div className="mt-3">
@@ -1199,6 +1208,8 @@ function ActivitySection({ issueId }: { issueId: string }) {
         <div className="mt-1.5 space-y-2 pl-1">
           {loading ? (
             <div className="text-[10px] text-muted-fg/40">Loading...</div>
+          ) : commentError ? (
+            <div className="text-[10px] text-red-400/70">{commentError}</div>
           ) : comments && comments.length > 0 ? (
             comments.map((comment) => (
               <div key={comment.id} className="rounded-md border border-white/[0.05] bg-white/[0.02] px-2.5 py-2">
@@ -1240,8 +1251,8 @@ function BatchActionView({
   function handleAction(key: string): void {
     switch (key) {
       case "create": void batchActions.onBatchCreateLanes(selectedIssues); break;
-      case "resolve-new": void batchActions.onBatchResolveNewLanes(selectedIssues, ""); break;
-      case "resolve-existing": void batchActions.onBatchResolveExistingLane(selectedIssues, "", ""); break;
+      case "resolve-new": void batchActions.onBatchResolveNewLanes(selectedIssues); break;
+      case "resolve-existing": void batchActions.onBatchResolveExistingLane(selectedIssues); break;
     }
   }
 

--- a/apps/desktop/src/renderer/components/app/LinearIssueResolveModals.tsx
+++ b/apps/desktop/src/renderer/components/app/LinearIssueResolveModals.tsx
@@ -277,6 +277,194 @@ export function ResolveInExistingLaneModal({
   );
 }
 
+function BatchIssueList({ issues }: { issues: LaneLinearIssue[] }) {
+  return (
+    <div className="max-h-48 overflow-y-auto rounded-lg border border-white/[0.06] bg-black/20">
+      {issues.map((issue) => (
+        <div key={issue.id} className="flex items-center gap-2 border-b border-white/[0.04] px-3 py-1.5 last:border-b-0">
+          <LinearPriorityIcon priority={issue.priority} size={11} />
+          <LinearStateIcon stateType={issue.stateType} size={11} />
+          <span className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[10px] text-fg/80">{issue.identifier}</span>
+          <span className="min-w-0 flex-1 truncate text-[12px] text-fg/85">{issue.title}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function BatchCreateLanesModal({
+  open,
+  issues,
+  busy,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  issues: LaneLinearIssue[];
+  busy?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  if (!issues.length) return null;
+
+  return (
+    <LaneDialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title={`Create ${issues.length} lanes`}
+      description="Creates a new lane for each selected issue with the issue linked as the primary lane attachment."
+      icon={Plus}
+      widthClassName="w-[min(560px,calc(100vw-24px))]"
+      busy={busy}
+    >
+      <div className="space-y-1.5">
+        <div className="text-[11px] font-medium text-muted-fg/70">{issues.length} issues selected</div>
+        <BatchIssueList issues={issues} />
+      </div>
+      <ModalFooter
+        busy={busy}
+        confirmLabel={`Create ${issues.length} lanes`}
+        onCancel={() => onOpenChange(false)}
+        onConfirm={onConfirm}
+      />
+    </LaneDialogShell>
+  );
+}
+
+export function BatchResolveInNewLanesModal({
+  open,
+  issues,
+  busy,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  issues: LaneLinearIssue[];
+  busy?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (modelId: string) => void;
+}) {
+  const { recents } = useModelRecents();
+  const [modelId, setModelId] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    setModelId((current) => current || recents[0] || "");
+  }, [open, recents]);
+
+  if (!issues.length) return null;
+
+  return (
+    <LaneDialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title={`Create ${issues.length} lanes and open chats`}
+      description="Creates a lane for each selected issue, then opens Work with a new chat for each."
+      icon={Sparkle}
+      widthClassName="w-[min(560px,calc(100vw-24px))]"
+      busy={busy}
+    >
+      <div className="space-y-1.5">
+        <div className="text-[11px] font-medium text-muted-fg/70">{issues.length} issues selected</div>
+        <BatchIssueList issues={issues} />
+      </div>
+      <div className="mt-4">
+        <ModelPickerField modelId={modelId} onModelChange={setModelId} />
+      </div>
+      <ModalFooter
+        busy={busy}
+        confirmLabel="Create lanes and open chats"
+        onCancel={() => onOpenChange(false)}
+        onConfirm={() => {
+          if (!modelId.trim()) return;
+          void onConfirm(modelId.trim());
+        }}
+      />
+    </LaneDialogShell>
+  );
+}
+
+export function BatchResolveInExistingLaneModal({
+  open,
+  issues,
+  lanes,
+  busy,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  issues: LaneLinearIssue[];
+  lanes: LaneSummary[];
+  busy?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (laneId: string, modelId: string) => void;
+}) {
+  const { recents } = useModelRecents();
+  const selectableLanes = useMemo(
+    () => lanes.filter((lane) => lane.laneType !== "primary"),
+    [lanes],
+  );
+  const [laneId, setLaneId] = useState("");
+  const [modelId, setModelId] = useState("");
+
+  useEffect(() => {
+    if (!open) return;
+    setLaneId((current) => (
+      current && selectableLanes.some((lane) => lane.id === current)
+        ? current
+        : selectableLanes[0]?.id ?? ""
+    ));
+    setModelId((current) => current || recents[0] || "");
+  }, [open, recents, selectableLanes]);
+
+  if (!issues.length) return null;
+
+  return (
+    <LaneDialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title={`Open ${issues.length} chats in existing lane`}
+      description="Opens Work with a new chat for each selected issue in the lane you choose."
+      icon={GitBranch}
+      widthClassName="w-[min(560px,calc(100vw-24px))]"
+      busy={busy}
+    >
+      <div className="space-y-1.5">
+        <div className="text-[11px] font-medium text-muted-fg/70">{issues.length} issues selected</div>
+        <BatchIssueList issues={issues} />
+      </div>
+      <div className="mt-4 space-y-4">
+        <div className="space-y-1.5">
+          <div className="text-[11px] font-medium text-muted-fg/70">Lane</div>
+          {selectableLanes.length > 0 ? (
+            <LaneCombobox
+              lanes={selectableLanes}
+              value={laneId}
+              onChange={setLaneId}
+              fullWidth
+              aria-label="Select lane"
+            />
+          ) : (
+            <div className="rounded-lg border border-amber-500/20 bg-amber-500/[0.06] px-3 py-2 text-[11px] text-amber-100/90">
+              No lanes available yet. Create a lane first or use the new-lane option.
+            </div>
+          )}
+        </div>
+        <ModelPickerField modelId={modelId} onModelChange={setModelId} />
+      </div>
+      <ModalFooter
+        busy={busy}
+        confirmLabel="Open chats in lane"
+        onCancel={() => onOpenChange(false)}
+        onConfirm={() => {
+          if (!laneId.trim() || !modelId.trim() || !selectableLanes.length) return;
+          void onConfirm(laneId.trim(), modelId.trim());
+        }}
+      />
+    </LaneDialogShell>
+  );
+}
+
 export function openLinearIssueExternalUrl(url: string | null | undefined): void {
   if (!url) return;
   void window.ade.app.openExternal(url);

--- a/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
+++ b/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
@@ -313,6 +313,9 @@ export function LinearQuickViewButton({
       setBatchModal(null);
       close();
       window.location.hash = "#/lanes";
+    } catch (err) {
+      console.error("[Linear] Batch create lanes failed:", err);
+      setBatchModal(null);
     } finally {
       setBusyModal(null);
       setBatchProgress(null);
@@ -329,6 +332,9 @@ export function LinearQuickViewButton({
         setBatchProgress({ completed: i + 1, total: batchIssues.length, action: "Creating lanes + chats" });
       }
       setBatchModal(null);
+    } catch (err) {
+      console.error("[Linear] Batch resolve (new lanes) failed:", err);
+      setBatchModal(null);
     } finally {
       setBusyModal(null);
       setBatchProgress(null);
@@ -343,6 +349,9 @@ export function LinearQuickViewButton({
         openWorkDraft(laneId, batchIssues[i], "manual", modelId);
         setBatchProgress({ completed: i + 1, total: batchIssues.length, action: "Assigning to lane" });
       }
+      setBatchModal(null);
+    } catch (err) {
+      console.error("[Linear] Batch resolve (existing lane) failed:", err);
       setBatchModal(null);
     } finally {
       setBusyModal(null);

--- a/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
+++ b/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
@@ -284,26 +284,24 @@ export function LinearQuickViewButton({
     [openModal],
   );
 
-  const handleBatchCreateLanes = useCallback(async (issues: Array<NormalizedLinearIssue | LaneLinearIssue>) => {
-    const laneIssues = issues.map((i) => "raw" in i ? linearBrowserIssueToLaneIssue(i) : i as LaneLinearIssue);
-    setBatchIssues(laneIssues);
+  const openBatchModal = useCallback((modal: NonNullable<typeof batchModal>, issues: Array<NormalizedLinearIssue | LaneLinearIssue>) => {
+    setBatchIssues(issues.map((i) => "raw" in i ? linearBrowserIssueToLaneIssue(i) : i as LaneLinearIssue));
     setOpen(false);
-    setBatchModal("batch-create-lanes");
+    setBatchModal(modal);
   }, []);
 
-  const handleBatchResolveNewLanes = useCallback(async (issues: Array<NormalizedLinearIssue | LaneLinearIssue>, _modelId: string) => {
-    const laneIssues = issues.map((i) => "raw" in i ? linearBrowserIssueToLaneIssue(i) : i as LaneLinearIssue);
-    setBatchIssues(laneIssues);
-    setOpen(false);
-    setBatchModal("batch-resolve-new");
-  }, []);
-
-  const handleBatchResolveExistingLane = useCallback(async (issues: Array<NormalizedLinearIssue | LaneLinearIssue>, _laneId: string, _modelId: string) => {
-    const laneIssues = issues.map((i) => "raw" in i ? linearBrowserIssueToLaneIssue(i) : i as LaneLinearIssue);
-    setBatchIssues(laneIssues);
-    setOpen(false);
-    setBatchModal("batch-resolve-existing");
-  }, []);
+  const handleBatchCreateLanes = useCallback(
+    (issues: Array<NormalizedLinearIssue | LaneLinearIssue>) => openBatchModal("batch-create-lanes", issues),
+    [openBatchModal],
+  );
+  const handleBatchResolveNewLanes = useCallback(
+    (issues: Array<NormalizedLinearIssue | LaneLinearIssue>) => openBatchModal("batch-resolve-new", issues),
+    [openBatchModal],
+  );
+  const handleBatchResolveExistingLane = useCallback(
+    (issues: Array<NormalizedLinearIssue | LaneLinearIssue>) => openBatchModal("batch-resolve-existing", issues),
+    [openBatchModal],
+  );
 
   const confirmBatchCreateLanes = useCallback(async () => {
     setBusyModal("create-lane");

--- a/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
+++ b/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
@@ -26,8 +26,6 @@ import {
 
 const INITIAL_VISIBILITY_CHECK_DELAY_MS = 2_000;
 
-let cachedQuickView: CtoLinearQuickView | null = null;
-
 const HEADER_STATUS_MENU_ROW_CLASS =
   "flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left text-[11px] font-medium text-muted-fg/80 transition-colors duration-150 hover:bg-white/[0.06] hover:text-fg/90";
 
@@ -89,6 +87,7 @@ export function LinearQuickViewButton({
   const [batchIssues, setBatchIssues] = useState<LaneLinearIssue[]>([]);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
+  const cachedQuickViewRef = useRef<CtoLinearQuickView | null>(null);
 
   const loadVisibility = useCallback(async (): Promise<boolean> => {
     if (!project?.rootPath || !window.ade.cto?.getLinearConnectionStatus) {
@@ -170,8 +169,8 @@ export function LinearQuickViewButton({
   }, [loadVisibility, visible, project?.rootPath]);
 
   const openQuickView = useCallback(() => {
-    if (cachedQuickView) {
-      setQuickView(cachedQuickView);
+    if (cachedQuickViewRef.current) {
+      setQuickView(cachedQuickViewRef.current);
     }
     setOpen(true);
   }, []);
@@ -485,7 +484,7 @@ export function LinearQuickViewButton({
                 }}
                 onConnectionVisibilityChange={setVisible}
                 onQuickViewChange={(data) => {
-                  cachedQuickView = data;
+                  cachedQuickViewRef.current = data;
                   setQuickView(data);
                 }}
                 onLoadingChange={setBrowserLoading}

--- a/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
+++ b/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
@@ -14,6 +14,9 @@ import { cn } from "../ui/cn";
 import { LinearMark, LINEAR_BRAND } from "../lanes/linearBrand";
 import { LinearIssueBrowser, linearBrowserIssueToLaneIssue } from "./LinearIssueBrowser";
 import {
+  BatchCreateLanesModal,
+  BatchResolveInExistingLaneModal,
+  BatchResolveInNewLanesModal,
   CreateLaneAttachedModal,
   ResolveInExistingLaneModal,
   ResolveInNewLaneModal,
@@ -21,7 +24,9 @@ import {
   type LinearIssueResolveModalKind,
 } from "./LinearIssueResolveModals";
 
-const INITIAL_VISIBILITY_CHECK_DELAY_MS = 8_000;
+const INITIAL_VISIBILITY_CHECK_DELAY_MS = 2_000;
+
+let cachedQuickView: CtoLinearQuickView | null = null;
 
 const HEADER_STATUS_MENU_ROW_CLASS =
   "flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left text-[11px] font-medium text-muted-fg/80 transition-colors duration-150 hover:bg-white/[0.06] hover:text-fg/90";
@@ -74,7 +79,14 @@ export function LinearQuickViewButton({
   const [refreshKey, setRefreshKey] = useState(0);
   const [browserLoading, setBrowserLoading] = useState(false);
   const [busyModal, setBusyModal] = useState<LinearIssueResolveModalKind | null>(null);
+  const [batchProgress, setBatchProgress] = useState<{
+    completed: number;
+    total: number;
+    action: string;
+  } | null>(null);
   const { activeModal, activeIssue, openModal, closeModal } = useLinearIssueResolveModalState();
+  const [batchModal, setBatchModal] = useState<"batch-create-lanes" | "batch-resolve-new" | "batch-resolve-existing" | null>(null);
+  const [batchIssues, setBatchIssues] = useState<LaneLinearIssue[]>([]);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
 
@@ -112,6 +124,10 @@ export function LinearQuickViewButton({
         .then(setVisible)
         .catch(() => setVisible(false));
     };
+    // If bridge already fired before this effect registered, check now
+    if ((window as any).__adeRuntimeBridge) {
+      onBridge();
+    }
     window.addEventListener("ade:runtime-bridge-ready", onBridge);
     return () => window.removeEventListener("ade:runtime-bridge-ready", onBridge);
   }, [loadVisibility]);
@@ -135,7 +151,28 @@ export function LinearQuickViewButton({
     };
   }, [loadVisibility, project?.rootPath]);
 
+  useEffect(() => {
+    if (visible) return;
+    if (!project?.rootPath) return;
+    let cancelled = false;
+    const interval = window.setInterval(() => {
+      void loadVisibility().then((v) => {
+        if (!cancelled && v) {
+          setVisible(true);
+          window.clearInterval(interval);
+        }
+      }).catch(() => {});
+    }, 3_000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [loadVisibility, visible, project?.rootPath]);
+
   const openQuickView = useCallback(() => {
+    if (cachedQuickView) {
+      setQuickView(cachedQuickView);
+    }
     setOpen(true);
   }, []);
 
@@ -239,9 +276,82 @@ export function LinearQuickViewButton({
     }
   }, [activeIssue, closeModal, openWorkDraft]);
 
-  const handleResolveModalOpen = useCallback((kind: LinearIssueResolveModalKind, issue: NormalizedLinearIssue | LaneLinearIssue) => {
-    openModal(kind, linearBrowserIssueToLaneIssue(issue));
-  }, [openModal]);
+  const handleResolveModalOpen = useCallback(
+    (kind: LinearIssueResolveModalKind, issue: NormalizedLinearIssue | LaneLinearIssue) => {
+      openModal(kind, linearBrowserIssueToLaneIssue(issue));
+      setOpen(false); // Close the Linear pane so the modal is visible
+    },
+    [openModal],
+  );
+
+  const handleBatchCreateLanes = useCallback(async (issues: Array<NormalizedLinearIssue | LaneLinearIssue>) => {
+    const laneIssues = issues.map((i) => "raw" in i ? linearBrowserIssueToLaneIssue(i) : i as LaneLinearIssue);
+    setBatchIssues(laneIssues);
+    setOpen(false);
+    setBatchModal("batch-create-lanes");
+  }, []);
+
+  const handleBatchResolveNewLanes = useCallback(async (issues: Array<NormalizedLinearIssue | LaneLinearIssue>, _modelId: string) => {
+    const laneIssues = issues.map((i) => "raw" in i ? linearBrowserIssueToLaneIssue(i) : i as LaneLinearIssue);
+    setBatchIssues(laneIssues);
+    setOpen(false);
+    setBatchModal("batch-resolve-new");
+  }, []);
+
+  const handleBatchResolveExistingLane = useCallback(async (issues: Array<NormalizedLinearIssue | LaneLinearIssue>, _laneId: string, _modelId: string) => {
+    const laneIssues = issues.map((i) => "raw" in i ? linearBrowserIssueToLaneIssue(i) : i as LaneLinearIssue);
+    setBatchIssues(laneIssues);
+    setOpen(false);
+    setBatchModal("batch-resolve-existing");
+  }, []);
+
+  const confirmBatchCreateLanes = useCallback(async () => {
+    setBusyModal("create-lane");
+    setBatchProgress({ completed: 0, total: batchIssues.length, action: "Creating lanes" });
+    try {
+      for (let i = 0; i < batchIssues.length; i++) {
+        await createLaneForIssue(batchIssues[i]);
+        setBatchProgress({ completed: i + 1, total: batchIssues.length, action: "Creating lanes" });
+      }
+      setBatchModal(null);
+      close();
+      window.location.hash = "#/lanes";
+    } finally {
+      setBusyModal(null);
+      setBatchProgress(null);
+    }
+  }, [batchIssues, close, createLaneForIssue]);
+
+  const confirmBatchResolveNewLanes = useCallback(async (modelId: string) => {
+    setBusyModal("resolve-new-lane");
+    setBatchProgress({ completed: 0, total: batchIssues.length, action: "Creating lanes + chats" });
+    try {
+      for (let i = 0; i < batchIssues.length; i++) {
+        const lane = await createLaneForIssue(batchIssues[i]);
+        openWorkDraft(lane.id, batchIssues[i], "lane_link", modelId);
+        setBatchProgress({ completed: i + 1, total: batchIssues.length, action: "Creating lanes + chats" });
+      }
+      setBatchModal(null);
+    } finally {
+      setBusyModal(null);
+      setBatchProgress(null);
+    }
+  }, [batchIssues, createLaneForIssue, openWorkDraft]);
+
+  const confirmBatchResolveExistingLane = useCallback(async (laneId: string, modelId: string) => {
+    setBusyModal("resolve-existing-lane");
+    setBatchProgress({ completed: 0, total: batchIssues.length, action: "Assigning to lane" });
+    try {
+      for (let i = 0; i < batchIssues.length; i++) {
+        openWorkDraft(laneId, batchIssues[i], "manual", modelId);
+        setBatchProgress({ completed: i + 1, total: batchIssues.length, action: "Assigning to lane" });
+      }
+      setBatchModal(null);
+    } finally {
+      setBusyModal(null);
+      setBatchProgress(null);
+    }
+  }, [batchIssues, openWorkDraft]);
 
   if (!visible) return null;
 
@@ -376,8 +486,17 @@ export function LinearQuickViewButton({
                   disabled: Boolean(busyModal),
                 }}
                 onConnectionVisibilityChange={setVisible}
-                onQuickViewChange={setQuickView}
+                onQuickViewChange={(data) => {
+                  cachedQuickView = data;
+                  setQuickView(data);
+                }}
                 onLoadingChange={setBrowserLoading}
+                batchActions={{
+                  onBatchCreateLanes: handleBatchCreateLanes,
+                  onBatchResolveNewLanes: handleBatchResolveNewLanes,
+                  onBatchResolveExistingLane: handleBatchResolveExistingLane,
+                  batchProgress,
+                }}
               />
             </div>
           </div>
@@ -406,6 +525,29 @@ export function LinearQuickViewButton({
         busy={busyModal === "resolve-existing-lane"}
         onOpenChange={(next) => { if (!next) closeModal(); }}
         onConfirm={handleResolveInExistingLane}
+      />
+
+      <BatchCreateLanesModal
+        open={batchModal === "batch-create-lanes"}
+        issues={batchIssues}
+        busy={Boolean(busyModal)}
+        onOpenChange={(next) => { if (!next) setBatchModal(null); }}
+        onConfirm={() => void confirmBatchCreateLanes()}
+      />
+      <BatchResolveInNewLanesModal
+        open={batchModal === "batch-resolve-new"}
+        issues={batchIssues}
+        busy={Boolean(busyModal)}
+        onOpenChange={(next) => { if (!next) setBatchModal(null); }}
+        onConfirm={(modelId) => void confirmBatchResolveNewLanes(modelId)}
+      />
+      <BatchResolveInExistingLaneModal
+        open={batchModal === "batch-resolve-existing"}
+        issues={batchIssues}
+        lanes={lanes}
+        busy={Boolean(busyModal)}
+        onOpenChange={(next) => { if (!next) setBatchModal(null); }}
+        onConfirm={(laneId, modelId) => void confirmBatchResolveExistingLane(laneId, modelId)}
       />
     </>
   );

--- a/apps/desktop/src/renderer/components/app/TopBar.test.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.test.tsx
@@ -721,7 +721,7 @@ describe("TopBar", () => {
     expect(await screen.findByRole("button", { name: /linear quick view/i })).toBeTruthy();
   });
 
-  it("does not poll Linear quick view visibility while it remains hidden", async () => {
+  it("keeps button hidden while disconnected but retries on a 3s interval", async () => {
     vi.useFakeTimers();
     const getLinearConnectionStatus = vi.fn(async () => ({
       tokenStored: true,
@@ -745,14 +745,16 @@ describe("TopBar", () => {
         vi.advanceTimersByTime(8_000);
         await flushMicrotasks(2);
       });
-      expect(getLinearConnectionStatus).toHaveBeenCalledTimes(1);
+      expect(getLinearConnectionStatus).toHaveBeenCalled();
       expect(screen.queryByRole("button", { name: /linear quick view/i })).toBeNull();
 
+      const callsBefore = getLinearConnectionStatus.mock.calls.length;
       await act(async () => {
-        vi.advanceTimersByTime(60_000);
+        vi.advanceTimersByTime(6_000);
         await flushMicrotasks(2);
       });
-      expect(getLinearConnectionStatus).toHaveBeenCalledTimes(1);
+      expect(getLinearConnectionStatus.mock.calls.length).toBeGreaterThan(callsBefore);
+      expect(screen.queryByRole("button", { name: /linear quick view/i })).toBeNull();
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -734,6 +734,7 @@ export const IPC = {
   ctoGetLinearQuickView: "ade.cto.getLinearQuickView",
   ctoGetLinearIssuePickerData: "ade.cto.getLinearIssuePickerData",
   ctoSearchLinearIssues: "ade.cto.searchLinearIssues",
+  ctoGetLinearIssueComments: "ade.cto.getLinearIssueComments",
   ctoSetLinearOAuthClient: "ade.cto.setLinearOAuthClient",
   ctoClearLinearOAuthClient: "ade.cto.clearLinearOAuthClient",
   ctoStartLinearOAuth: "ade.cto.startLinearOAuth",

--- a/apps/desktop/src/shared/types/cto.ts
+++ b/apps/desktop/src/shared/types/cto.ts
@@ -150,6 +150,18 @@ export type CtoSearchLinearIssuesResult = {
   };
 };
 
+export type CtoGetLinearIssueCommentsArgs = {
+  issueId: string;
+};
+
+export type CtoLinearIssueComment = {
+  id: string;
+  body: string;
+  createdAt: string;
+  userName: string;
+  userDisplayName: string;
+};
+
 export type CtoGetLinearIssuePickerDataResult = {
   projects: CtoLinearProject[];
   users: LinearCatalogUser[];

--- a/apps/desktop/src/shared/types/linearSync.ts
+++ b/apps/desktop/src/shared/types/linearSync.ts
@@ -545,6 +545,19 @@ export type NormalizedLinearIssue = {
   priority: number;
   priorityLabel: LinearPriorityLabel;
   labels: string[];
+  labelColors?: Array<{ name: string; color: string | null }>;
+  cycleId?: string | null;
+  cycleName?: string | null;
+  cycleStartsAt?: string | null;
+  cycleEndsAt?: string | null;
+  childIssues?: Array<{
+    id: string;
+    identifier: string;
+    title: string;
+    stateId: string;
+    stateName: string;
+    stateType: string;
+  }>;
   metadataTags?: string[];
   assigneeId: string | null;
   assigneeName: string | null;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -499,7 +499,7 @@ Most services described here live under `apps/desktop/src/main/services/<domain>
 | `notifications/` | `apnsService.ts`, `apnsBridgeService.ts`, `notificationMapper.ts`, `notificationEventBus.ts` | APNs HTTP/2 client (ES256 JWT, key persisted via Electron `safeStorage` on the desktop or `EncryptedFileCredentialStore` under `.ade/secrets/` in the headless daemon), pure domain-event → `MappedNotification` mapping (13 categories / 4 families), event bus routing to APNs alert pushes + Live Activity update pushes + in-app WS delivery, filtered by per-device `NotificationPreferences`. `apnsBridgeService.ts` is the `notifications_apns` ADE action domain (`getStatus`, `saveConfig`, `uploadKey`, `clearKey`, `sendTestPush`) so the same Settings flow works whether the active project is local-bound or SSH-bound. |
 | `tests/` | `testService.ts` | Test-suite execution + run history. |
 | `updates/` | `autoUpdateService.ts` | Electron auto-update wrapper around `electron-updater`. Owns the renderer-visible `AutoUpdateSnapshot` (`idle \| checking \| downloading \| ready \| installing \| error`), uses `compareUpdateVersions` (SemVer-aware) to dedupe / supersede staged installers and to reconcile `pendingInstallUpdate` against the running version on next boot. `quitAndInstall()` is async: it re-runs `checkForUpdates({ allowReady: true })` to confirm the staged build is still latest, and only then flips to `installing` and calls `updater.quitAndInstall(false, true)`. |
-| `usage/` | `usageTrackingService.ts`, `budgetCapService.ts` | Token/cost accounting, budget enforcement. Local cost scans stream bounded recent Claude/Codex JSONL files instead of loading the whole history into memory. |
+| `usage/` | `usageTrackingService.ts`, `budgetCapService.ts` | Token/cost accounting, budget enforcement. Local cost scans stream bounded recent Claude/Codex JSONL files instead of loading the whole history into memory. Threshold state is shared at module level across all `createUsageTrackingService` instances so multiple project contexts don't fire duplicate threshold events; `main.ts` adds a final IPC-level dedup gate with a 10-minute TTL per `provider:threshold:resetCycle` key. |
 | `perf/` | `perfLog.ts`, `perfIpc.ts`, `metricsSampler.ts`, `aggregator.ts` | Opt-in local performance harness. `ADE_PERF_RUN_ID` opens a JSONL event log, samples Electron process metrics, records IPC durations, accepts renderer perf marks/web-vitals, and aggregates each run into `summary.json`. |
 
 Startup sequencing: every background service goes through `scheduleBackgroundProjectTask()` in `main.ts`, which provides explicit labels, `ADE_ENABLE_*` env gates, `project.startup_task_begin`/`_done`/`_enabled`/`_skipped` telemetry, and per-task delays. Integrations stay **dormant-until-configured**.
@@ -555,7 +555,7 @@ Domain stores co-located with their pages follow the same factory + context patt
 Feature-grouped under `apps/desktop/src/renderer/components/`:
 
 ```
-app/            # shell, App.tsx, TopBar, TabNav, LinearIssueBrowser, LinearIssueResolveModals, startup, splash
+app/            # shell, App.tsx, TopBar, TabNav, LinearIssueBrowser (multi-select + batch actions), LinearIssueResolveModals (single + batch), LinearQuickViewButton, startup, splash
 project/        # Play tab, run/test/process controls
 lanes/          # list/detail/inspector, stacks, laneDesignTokens.ts
 files/          # tree, editor, diffs

--- a/docs/features/cto/README.md
+++ b/docs/features/cto/README.md
@@ -17,8 +17,8 @@ The runtime is organized around one contract: the CTO tab should be usable as a 
 - `workerAdapterRuntimeService.ts` — adapter lifecycle for the three supported worker adapters: `claude-local`, `codex-local`, and `process`.
 - `linearCredentialService.ts` — personal API key + OAuth client + auth-mode storage and token status. Backed by the per-machine credential store (`~/.ade/secrets/`) when injected, with a one-time migration from the legacy project-scoped files. See [Linear integration](../linear-integration/README.md#source-file-map).
 - `linearOAuthService.ts` — PKCE loopback OAuth flow on port 19836.
-- `linearClient.ts` — Linear GraphQL client (shared by desktop and headless ADE CLI).
-- `linearIssueTracker.ts` / `issueTracker.ts` — Linear issue cache and change detection.
+- `linearClient.ts` — Linear GraphQL client (shared by desktop and headless ADE CLI). The shared issue fragment fetches cycle metadata, label colors, and enriched child-issue fields. `fetchIssueComments(issueId)` returns the comment thread for the issue detail pane.
+- `linearIssueTracker.ts` / `issueTracker.ts` — Linear issue cache, change detection, and `fetchIssueComments` forwarding.
 - `flowPolicyService.ts` — canonical `LinearWorkflowConfig` (intake, workflows, migration), file-backed via `linearWorkflowFileService`.
 - `linearWorkflowFileService.ts` — repo YAML persistence for workflows.
 - `linearTemplateService.ts` — workflow template metadata.
@@ -56,7 +56,8 @@ The runtime is organized around one contract: the CTO tab should be usable as a 
 
 - `apps/desktop/src/shared/ctoPersonalityPresets.ts` — `CTO_PERSONALITY_PRESETS` (strategic, professional, hands_on, casual, minimal, custom) with label, description, and `systemOverlay` body.
 - `apps/desktop/src/shared/linearWorkflowPresets.ts` — `LinearWorkflowVisualPlan` type, `deriveVisualPlan`, `rebuildWorkflowSteps`, completion contract tables, step synthesis.
-- `apps/desktop/src/shared/types/linearSync.ts` — `LinearWorkflowDefinition`, `LinearWorkflowTarget`, trigger groups, step types, closeout types.
+- `apps/desktop/src/shared/types/linearSync.ts` — `LinearWorkflowDefinition`, `LinearWorkflowTarget`, trigger groups, step types, closeout types. `NormalizedLinearIssue` carries cycle metadata, per-label colors, and structured child issues.
+- `apps/desktop/src/shared/types/cto.ts` — `CtoGetLinearIssueCommentsArgs` and `CtoLinearIssueComment` types for the issue detail comment thread.
 - `apps/desktop/src/main/services/ai/tools/ctoOperatorTools.ts` — complete operator tool surface registered for CTO chat sessions.
 
 ### iOS companion (apps/ios/ADE/Views/Cto/)

--- a/docs/features/cto/linear-integration.md
+++ b/docs/features/cto/linear-integration.md
@@ -8,8 +8,8 @@ CTO owns Linear intake, routing, dispatch, sync, and closeout. Automations never
 
 - `linearCredentialService.ts` — token store (personal API key). Exposes `getStatus`, `getTokenOrThrow`, `setToken`, `clearToken`.
 - `linearOAuthService.ts` — PKCE loopback OAuth on port 19836. `SESSION_TTL_MS = 10 min`. Authorize at `linear.app/oauth/authorize`, exchange at `api.linear.app/oauth/token`.
-- `linearClient.ts` — GraphQL client; used by both desktop and headless ADE CLI. Surfaces `getQuickView(connection)` (workspace + active project counters consumed by the top-bar quick view) and `searchIssues(query)` (paginated issue search consumed by `LinearIssuePicker` and `LinearIssueBrowser`) alongside the existing `fetchIssueById` / `listProjects` / `listLabels` / `listUsers` calls.
-- `linearIssueTracker.ts` + `issueTracker.ts` — issue cache, snapshot hashes, change detection. The `IssueTracker` interface includes the matching `getQuickView(connection)` and `searchIssues(query)` shims so renderer-side surfaces have the same entry point as the dispatcher.
+- `linearClient.ts` — GraphQL client; used by both desktop and headless ADE CLI. Surfaces `getQuickView(connection)` (workspace + active project counters consumed by the top-bar quick view), `searchIssues(query)` (paginated issue search consumed by `LinearIssuePicker` and `LinearIssueBrowser`), and `fetchIssueComments(issueId)` (comment thread for the issue detail pane) alongside the existing `fetchIssueById` / `listProjects` / `listLabels` / `listUsers` calls. The shared GraphQL issue fragment also fetches cycle metadata (`id`, `name`, `startsAt`, `endsAt`), label colors, and richer child-issue data (`identifier`, `title`, full state).
+- `linearIssueTracker.ts` + `issueTracker.ts` — issue cache, snapshot hashes, change detection. The `IssueTracker` interface includes the matching `getQuickView(connection)`, `searchIssues(query)`, and `fetchIssueComments(issueId)` shims so renderer-side surfaces have the same entry point as the dispatcher.
 - `flowPolicyService.ts` — canonical `LinearWorkflowConfig` aggregate: intake rules, workflows, files, migration info, legacy config. File-backed via `linearWorkflowFileService`.
 - `linearWorkflowFileService.ts` — persists workflows as YAML under the project's ADE config area.
 - `linearTemplateService.ts` — template metadata registry.
@@ -27,7 +27,7 @@ CTO owns Linear intake, routing, dispatch, sync, and closeout. Automations never
 - `renderer/components/cto/LinearSyncPanel.tsx` — workflow list (via `WorkflowListSidebar`), pipeline builder, sync dashboard, run timeline, "Watch It Live" monitor.
 - `renderer/components/cto/pipeline/` — the visual builder (see `pipeline-builder.md`).
 - `renderer/components/lanes/LinearIssuePicker.tsx`, `LinearIssueBadge.tsx`, `linearBrand.tsx` — shared issue picker, lane-list badge, and brand-token / icon family used by every Linear surface in the app.
-- `renderer/components/app/LinearQuickViewButton.tsx`, `LinearIssueBrowser.tsx` — top-bar quick view that opens the full filter/search browser, lets the user create a lane straight from a Linear issue (`lanes.create` with `linearIssue` set), and persists per-project filter state under `ade.linear.quickView.filters.v1:<projectRoot>`.
+- `renderer/components/app/LinearQuickViewButton.tsx`, `LinearIssueBrowser.tsx`, `LinearIssueResolveModals.tsx` — top-bar quick view that opens the full filter/search browser, lets the user create a lane straight from a Linear issue (`lanes.create` with `linearIssue` set), and persists per-project filter state under `ade.linear.quickView.filters.v1:<projectRoot>`. The issue browser supports multi-select with checkboxes (including shift-click range selection and select-all), batch lane creation, batch agent-resolve in new lanes, and batch resolve into an existing lane via dedicated batch modals in `LinearIssueResolveModals.tsx`. The issue detail pane renders the comment thread (via `getLinearIssueComments`) with markdown, and displays cycle and child-issue metadata. The quick-view button caches the last-fetched workspace summary for instant popover open and polls for Linear connection visibility on a 3-second interval until connected.
 - `renderer/components/settings/LinearSection.tsx` — Settings > Integrations panel for managing the Linear token / OAuth session and surfacing the connected workspace.
 
 ### Lane / commit / PR integration (developer-driven path)
@@ -42,7 +42,8 @@ Detailed wiring lives in [`../linear-integration/README.md`](../linear-integrati
 
 ### Shared
 
-- `apps/desktop/src/shared/types/linearSync.ts` — `LinearWorkflowDefinition`, `LinearWorkflowTarget`, `LinearWorkflowTrigger`, `LinearWorkflowStep`, run status, closeout types.
+- `apps/desktop/src/shared/types/linearSync.ts` — `LinearWorkflowDefinition`, `LinearWorkflowTarget`, `LinearWorkflowTrigger`, `LinearWorkflowStep`, run status, closeout types. `NormalizedLinearIssue` carries cycle metadata (`cycleId`, `cycleName`, `cycleStartsAt`, `cycleEndsAt`), per-label colors (`labelColors`), and structured child issues (`childIssues[]` with `identifier`, `title`, and full state).
+- `apps/desktop/src/shared/types/cto.ts` — `CtoGetLinearIssueCommentsArgs` and `CtoLinearIssueComment` types for the issue-comment thread surface.
 - `apps/desktop/src/shared/linearWorkflowPresets.ts` — visual plan translation.
 
 ### Runtime daemon

--- a/docs/features/linear-integration/README.md
+++ b/docs/features/linear-integration/README.md
@@ -170,8 +170,8 @@ Core Linear services on desktop
 
 - `linearCredentialService.ts` — token + OAuth client + auth mode storage and health check. Reads/writes through the per-machine `SyncCredentialStore` (`~/.ade/secrets/`) when one is passed in, with a one-time migration from the legacy project-local `linear-token.v1.bin` / `linear-oauth-client.v1.bin` files; falls back to the legacy project-scoped path when the machine store is unavailable. Environment overrides (`ADE_LINEAR_API`, `LINEAR_API_KEY`, `ADE_LINEAR_TOKEN`, `LINEAR_TOKEN`) still take precedence.
 - `linearOAuthService.ts` — OAuth authorization flow
-- `linearClient.ts` — GraphQL client wrapper
-- `linearIssueTracker.ts` — normalization into `NormalizedLinearIssue`
+- `linearClient.ts` — GraphQL client wrapper. The shared issue fragment includes cycle metadata, label colors, and enriched child-issue fields. `fetchIssueComments(issueId)` returns the comment thread for the issue detail pane.
+- `linearIssueTracker.ts` — normalization into `NormalizedLinearIssue`, plus `fetchIssueComments` forwarding
 - `linearTemplateService.ts` — session template resolution
 - `linearWorkflowFileService.ts` — YAML workflow files under
   `.ade/workflows/linear/**`. Every `save(config)` call invokes
@@ -197,10 +197,14 @@ Shared types and helpers:
   types, run statuses, event payloads, catalog types, the
   `NormalizedLinearIssue` shape (extended with `projectName`,
   `teamName`, `dueDate`, `estimate`, `archivedAt`, `completedAt`,
-  `canceledAt`, `startedAt`), `LinearConnectionStatus` (extended with
-  `organizationId` / `organizationName` / `organizationUrlKey` /
+  `canceledAt`, `startedAt`, `cycleId`, `cycleName`,
+  `cycleStartsAt`, `cycleEndsAt`, `labelColors`, and `childIssues`
+  with identifier/title/state), `LinearConnectionStatus` (extended
+  with `organizationId` / `organizationName` / `organizationUrlKey` /
   `organizationLogoUrl` so controllers can render the workspace
   brand), and the legacy `LinearSyncConfig` kept for migration reads.
+- `apps/desktop/src/shared/types/cto.ts` — `CtoGetLinearIssueCommentsArgs`
+  and `CtoLinearIssueComment` types for the issue detail comment thread.
 - `apps/desktop/src/shared/types/lanes.ts` — `LaneLinearIssue` (the
   lane-attached subset of a Linear issue that gets persisted with
   the lane row) plus the optional `linearIssue` field on
@@ -267,17 +271,31 @@ Renderer wiring:
   `LinearConnectionStatus.connected === true`). Opens a popover
   hosting the shared `LinearIssueBrowser`; selecting an issue
   creates a new lane via `lanes.create` with `linearIssue` set,
-  refreshes the lane store, and selects the new lane.
+  refreshes the lane store, and selects the new lane. Supports
+  batch flows: multi-select in the browser dispatches to batch
+  create lanes, batch resolve in new lanes, or batch resolve into
+  an existing lane. Caches the last-fetched workspace summary for
+  instant popover open and polls for Linear connection visibility
+  on a 3-second interval until connected.
 - `apps/desktop/src/renderer/components/app/LinearIssueBrowser.tsx`
-  — full filter/search surface. Reads `ade.cto.getLinearQuickView`
-  for the workspace summary and `ade.cto.searchLinearIssues` for
-  paginated results. Persists per-project filter state in
-  `localStorage` under `ade.linear.quickView.filters.v1:<projectRoot>`.
+  — full filter/search surface with multi-select. Reads
+  `ade.cto.getLinearQuickView` for the workspace summary,
+  `ade.cto.searchLinearIssues` for paginated results, and
+  `ade.cto.getLinearIssueComments` for the issue detail comment
+  thread (rendered with markdown). Supports checkbox selection
+  with shift-click range, select-all, and batch action dispatch.
+  Persists per-project filter state in `localStorage` under
+  `ade.linear.quickView.filters.v1:<projectRoot>`. The issue
+  detail pane displays cycle metadata and child-issue status.
 - `apps/desktop/src/renderer/components/app/LinearIssueResolveModals.tsx`
   — modal dialogs for resolving Linear issues directly from the
   quick-view or issue browser: create a new lane from the issue,
   attach to an existing lane, or launch an agent chat to work on the
-  issue with model selection and branch preview.
+  issue with model selection and branch preview. Also provides
+  batch modals: `BatchCreateLanesModal` (create one lane per
+  selected issue), `BatchResolveInNewLanesModal` (create lanes and
+  launch agents), and `BatchResolveInExistingLaneModal` (resolve
+  multiple issues into a single existing lane).
 - `apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx`
   — the composer's Linear attach affordance opens a
   `LinearIssueContextDialog` that hosts the same
@@ -318,14 +336,17 @@ IPC wiring (`apps/desktop/src/main/services/ipc/registerIpc.ts`):
   `ctoGetLinearQuickView` (workspace summary used by the top-bar
   quick view), `ctoGetLinearIssuePickerData` (one-shot
   projects + states + assignees catalog for `LinearIssuePicker`),
-  and `ctoSearchLinearIssues` (paginated issue search consumed by
-  both `LinearIssuePicker` and `LinearIssueBrowser`).
+  `ctoSearchLinearIssues` (paginated issue search consumed by
+  both `LinearIssuePicker` and `LinearIssueBrowser`), and
+  `ctoGetLinearIssueComments` (comment thread for the issue detail
+  pane in the browser).
 - `IssueTracker` (`apps/desktop/src/main/services/cto/issueTracker.ts`)
-  grew matching `getQuickView(connection)` and
-  `searchIssues(query)` methods, both forwarded to `linearClient`
-  by `linearIssueTracker.ts`. `IssueTrackerIssueSearchQuery` covers
-  project / state-types / assignee / priority / free-text / cursor
-  pagination filters; the result is `{ issues, pageInfo }`.
+  exposes `getQuickView(connection)`, `searchIssues(query)`, and
+  `fetchIssueComments(issueId)` methods, all forwarded to
+  `linearClient` by `linearIssueTracker.ts`.
+  `IssueTrackerIssueSearchQuery` covers project / state-types /
+  assignee / priority / free-text / cursor pagination filters; the
+  result is `{ issues, pageInfo }`.
 
 Headless ADE CLI mode:
 
@@ -437,7 +458,11 @@ exposes that path in three places that all share the same primitives:
   active project counters) plus the shared
   `LinearIssueBrowser`; clicking an issue creates a fresh lane via
   `lanes.create`, refreshes the lane store, and selects the new
-  lane.
+  lane. Multi-select in the browser enables batch flows: create one
+  lane per selected issue, create lanes and launch agents, or resolve
+  multiple issues into an existing lane. The issue detail pane renders
+  the comment thread (via `getLinearIssueComments`) with markdown and
+  shows cycle and child-issue metadata.
 
 ## Database tables (selected)
 

--- a/docs/features/linear-integration/dispatch-and-sync.md
+++ b/docs/features/linear-integration/dispatch-and-sync.md
@@ -47,7 +47,10 @@ Source file: `apps/desktop/src/main/services/cto/linearIssueTracker.ts`.
 - `previousStateId`, `previousStateName`, `previousStateType` — populated
   from the stored snapshot row so `stateTransitions` triggers can match
 - `priority`, `priorityLabel` (`urgent|high|normal|low|none`)
-- `labels`, `metadataTags`
+- `labels`, `labelColors` (per-label `{ name, color }`)
+- `cycleId`, `cycleName`, `cycleStartsAt`, `cycleEndsAt`
+- `childIssues` (`id`, `identifier`, `title`, `stateId`, `stateName`, `stateType`)
+- `metadataTags`
 - `assigneeId`, `assigneeName`, `ownerId`, `creatorId`, `creatorName`
 - `blockerIssueIds`, `hasOpenBlockers`
 - `raw._snapshotHash`, `raw._previousSnapshotHash` — used to skip
@@ -338,6 +341,8 @@ Desktop IPC (renderer → main), from `apps/desktop/src/shared/ipc.ts`:
 - Sync: `ctoGetLinearSyncDashboard`, `ctoRunLinearSyncNow`,
   `ctoListLinearSyncQueue`, `ctoResolveLinearSyncQueueItem`,
   `ctoGetLinearWorkflowRunDetail`
+- Issue detail: `ctoGetLinearIssueComments` (comment thread for
+  the issue browser detail pane)
 - Ingress: `ctoGetLinearIngressStatus`, `ctoListLinearIngressEvents`,
   `ctoEnsureLinearWebhook`
 - Broadcast: `ctoLinearWorkflowEvent` (main → renderer)


### PR DESCRIPTION
## Summary
- Enrich Linear issue data model with label colors, cycle info (id/name/start/end), and structured child issues
- Add `fetchIssueComments` API to Linear client, IPC handler, and preload bridge
- Enhance LinearIssueBrowser with multi-select, batch lane creation, markdown comment rendering, cycle/label display
- Add LinearIssueResolveModals for batch resolve flows and LinearQuickViewButton batch actions
- Improve usage tracking with shared module-level threshold state to prevent duplicate firings across projects
- Switch usage alert dismissals from sessionStorage to localStorage with expiry-aware cleanup
- CLI parity: `ade linear issue-comments` subcommand + `getLinearIssueComments` RPC action
- TUI parity: `/linear comments` slash command with formatter
- Docs updated: ARCHITECTURE.md, cto/, linear-integration/

## Test plan
- [x] 4 new tests for Linear client (labelColors, cycles, childIssues normalization, fetchIssueComments)
- [x] 1 new test for shared usage threshold singleton
- [x] Updated TopBar test for new 3s visibility retry interval
- [x] Full desktop sharded test suite: 5467 tests PASS
- [x] CLI tests: 810 tests PASS
- [x] Typecheck all 3 apps: PASS
- [x] Lint: PASS (0 errors)
- [x] Build all 3 apps: PASS
- [x] Doc validation: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linear issue comments viewing in CLI, TUI, and desktop app.
  * Enabled multi-select and batch operations for Linear issues (create lanes, resolve multiple issues at once).
  * Enhanced issue details display with Markdown rendering, external links, and child issue visibility.

* **Bug Fixes**
  * Prevented duplicate usage threshold notifications from firing repeatedly.
  * Improved usage alert persistence and dismissal behavior.

* **Documentation**
  * Updated CLI command reference with new Linear comments example.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enriches the Linear data model (label colours, cycle metadata, child issues), adds a `fetchIssueComments` API across all three surfaces (desktop IPC, CLI, TUI), and ships multi-select + batch lane-creation flows in `LinearIssueBrowser`. On the usage-tracking side it introduces a shared module-level `ThresholdState` singleton to prevent duplicate threshold events from multiple project service instances, adds an IPC-level dedup gate in `main.ts`, and migrates usage-alert dismissals from `sessionStorage` to `localStorage` with expiry-aware cleanup.

- **Linear enrichment & comments**: `linearClient.ts` now fetches label colours, cycle fields, and full child-issue state; a new `fetchIssueComments` function (capped at 50) powers `ActivitySection` in the issue browser and the new CLI/TUI `linear issue-comments` subcommand.
- **Batch operations**: `LinearIssueBrowser` gains shift-select and a `BatchActionView` pane; `LinearIssueResolveModals` adds three new batch modals; `LinearQuickViewButton` wires up the end-to-end confirm flows with per-item progress tracking.
- **Usage tracking**: The `sharedThresholdState` singleton plus the `shouldEmitThresholdEvent` IPC gate provide two independent dedup layers; dismissal keys are now expiry-aware and only cover thresholds up to and including the fired level.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core logic changes are well-guarded with tests, the two-layer threshold dedup is conservative, and the batch flows handle the error path by closing modals.

All new code paths are covered by tests (Linear client normalization, fetchIssueComments, shared threshold singleton, TopBar interval), the dual-layer dedup (module singleton + IPC gate) is a robust approach, and the localStorage migration preserves existing keys via expiry-aware parsing. The only open items are quality-of-life gaps — comment pagination cap and a missing disabled state on batch-confirm buttons — neither of which causes incorrect behavior.

No files require special attention. LinearIssueBrowser.tsx and LinearQuickViewButton.tsx are the largest changes but both carry good test coverage for their critical paths.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/cto/linearClient.ts | Adds labelColors, cycle fields, enriched childIssues, and fetchIssueComments; comment fetch hardcaps at first:50 with no pagination signal to the UI |
| apps/desktop/src/renderer/components/app/LinearIssueBrowser.tsx | Large multi-select, batch-action, ActivitySection, and rich-issue-details additions; ActivitySection renders comment bodies as plain text (not markdown) and includes comments in useEffect deps causing an unnecessary re-run after fetch |
| apps/desktop/src/renderer/components/app/LinearIssueResolveModals.tsx | New batch modals (BatchCreateLanes, BatchResolveInNewLanes, BatchResolveInExistingLane); confirm callbacks silently no-op when required fields are empty without disabling the confirm button |
| apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx | Adds batch action handlers, cachedQuickViewRef (replacing module-level cache), 3s visibility polling, and INITIAL_VISIBILITY_CHECK_DELAY_MS reduction; batch error paths close modal but provide no user-visible error feedback |
| apps/desktop/src/main/services/usage/usageTrackingService.ts | Introduces shared module-level ThresholdStore singleton to prevent duplicate threshold firings across project service instances; test-injected stores bypass the singleton cleanly |
| apps/desktop/src/renderer/components/app/AppShell.tsx | Usage alert UI redesigned as bottom-right toast; switches dismissal from sessionStorage to localStorage with expiry-aware cleanup; markUsageAlertDismissed now only dismisses thresholds up to the current level; auto-expire timer changed from 6s to 30s without persisting to localStorage |
| apps/desktop/src/main/main.ts | Adds IPC-level shouldEmitThresholdEvent dedup (10-minute TTL map) as a secondary guard on top of the shared ThresholdState singleton; both call sites gated correctly |
| apps/ade-cli/src/adeRpcServer.ts | Adds getLinearIssueComments RPC tool spec, marks it read-only, and routes execution to tracker.fetchIssueComments; well-guarded with assertNonEmptyString |
| apps/desktop/src/main/services/usage/usageTrackingService.test.ts | New test for shared threshold singleton; test relies on module-level state not being pre-populated, which can be fragile in watch/re-run scenarios |
| apps/desktop/src/shared/types/linearSync.ts | New optional fields for labelColors, cycle*, and childIssues added to NormalizedLinearIssue; all optional to preserve backward compatibility |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fapp%2FLinearIssueBrowser.tsx%3A1195-1200%0A**%60comments%60%20in%20%60useEffect%60%20deps%20triggers%20a%20redundant%20effect%20run%20after%20fetch**%0A%0A%60comments%60%20is%20listed%20as%20a%20dependency%20of%20the%20fetch%20effect%2C%20but%20the%20guard%20%60if%20%28!expanded%20%7C%7C%20comments%20%7C%7C%20commentError%29%20return%60%20means%20the%20effect%20immediately%20exits%20after%20the%20state%20is%20set.%20This%20creates%20a%20no-op%20second%20invocation%20on%20every%20successful%20fetch.%20Removing%20%60comments%60%20from%20the%20dep%20array%20%28and%20keeping%20only%20%60expanded%60%20and%20%60issueId%60%29%20is%20sufficient%20%E2%80%94%20the%20guard%20already%20prevents%20double-fetching%20because%20%60comments%60%20is%20always%20%60null%60%20when%20a%20real%20fetch%20should%20start%20%28reset%20by%20the%20render-phase%20prop-change%20check%29.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fapp%2FLinearIssueResolveModals.tsx%3A380-385%0A**Confirm%20button%20not%20visually%20disabled%20when%20required%20fields%20are%20empty**%0A%0AIn%20%60BatchResolveInNewLanesModal%60%2C%20if%20%60recents%60%20is%20empty%20on%20first%20use%2C%20%60modelId%60%20stays%20%60%22%22%60%20and%20clicking%20Confirm%20silently%20returns%20without%20opening%20any%20chats.%20The%20same%20pattern%20appears%20in%20%60BatchResolveInExistingLaneModal%60%20%28empty%20%60laneId%60%20or%20%60modelId%60%20silently%20aborts%29.%20The%20%60ModalFooter%60%20does%20not%20receive%20a%20%60disabled%60%20prop%20tied%20to%20field%20validity%2C%20so%20users%20can%20click%20Confirm%20and%20see%20nothing%20happen.%20Passing%20%60confirmDisabled%3D%7B!modelId.trim%28%29%7D%60%20%28or%20equivalent%29%20to%20%60ModalFooter%60%20would%20make%20the%20empty-field%20guard%20visible.%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fcto%2FlinearClient.ts%3A1315%0AThe%20comment%20fetch%20is%20capped%20at%20%60first%3A%2050%60%20with%20no%20pagination.%20Issues%20with%20active%20discussion%20can%20easily%20exceed%2050%20comments%3B%20those%20beyond%20the%20cap%20are%20silently%20dropped%20with%20no%20indicator%20in%20the%20UI.%20Consider%20raising%20the%20limit%20or%20adding%20a%20%60pageInfo%60%20check%20and%20a%20follow-up%20fetch%2C%20or%20at%20minimum%20exposing%20a%20%60hasMore%60%20flag%20so%20%60ActivitySection%60%20can%20offer%20a%20%22load%20more%22%20prompt.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20comments%28first%3A%20100%2C%20orderBy%3A%20createdAt%29%20%7B%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=373&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/desktop/src/renderer/components/app/LinearIssueBrowser.tsx:1195-1200
**`comments` in `useEffect` deps triggers a redundant effect run after fetch**

`comments` is listed as a dependency of the fetch effect, but the guard `if (!expanded || comments || commentError) return` means the effect immediately exits after the state is set. This creates a no-op second invocation on every successful fetch. Removing `comments` from the dep array (and keeping only `expanded` and `issueId`) is sufficient — the guard already prevents double-fetching because `comments` is always `null` when a real fetch should start (reset by the render-phase prop-change check).

### Issue 2 of 3
apps/desktop/src/renderer/components/app/LinearIssueResolveModals.tsx:380-385
**Confirm button not visually disabled when required fields are empty**

In `BatchResolveInNewLanesModal`, if `recents` is empty on first use, `modelId` stays `""` and clicking Confirm silently returns without opening any chats. The same pattern appears in `BatchResolveInExistingLaneModal` (empty `laneId` or `modelId` silently aborts). The `ModalFooter` does not receive a `disabled` prop tied to field validity, so users can click Confirm and see nothing happen. Passing `confirmDisabled={!modelId.trim()}` (or equivalent) to `ModalFooter` would make the empty-field guard visible.

### Issue 3 of 3
apps/desktop/src/main/services/cto/linearClient.ts:1315
The comment fetch is capped at `first: 50` with no pagination. Issues with active discussion can easily exceed 50 comments; those beyond the cap are silently dropped with no indicator in the UI. Consider raising the limit or adding a `pageInfo` check and a follow-up fetch, or at minimum exposing a `hasMore` flag so `ActivitySection` can offer a "load more" prompt.

```suggestion
            comments(first: 100, orderBy: createdAt) {
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["ship: iteration 2 — add catch blocks to ..."](https://github.com/arul28/ade/commit/d84a25c0eecc8a4bc00f8c027ada5ab51b2b4ae1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34114163)</sub>

<!-- /greptile_comment -->