### PR TITLE
Fix Manage Lane Tabs

### DIFF
--- a/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx
+++ b/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx
@@ -1,0 +1,129 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LaneDeleteRisk, LaneSummary } from "../../../shared/types";
+import { ManageLaneDialog } from "./ManageLaneDialog";
+
+afterEach(cleanup);
+
+const deleteRisk: LaneDeleteRisk = {
+  laneId: "lane-1",
+  branchRef: "feature/manage-tabs",
+  dirty: false,
+  hasUnpushedCommits: false,
+  unpushedCommitCount: 0,
+  remoteBranchExists: true,
+  runningProcessCount: 0,
+  activePtyCount: 0,
+  activeWatcherCount: 0,
+  envInitialized: true,
+};
+
+function makeLane(overrides: Partial<LaneSummary> = {}): LaneSummary {
+  return {
+    id: "lane-1",
+    name: "Manage tabs",
+    description: null,
+    laneType: "worktree",
+    baseRef: "main",
+    branchRef: "feature/manage-tabs",
+    worktreePath: "/tmp/ade/manage-tabs",
+    attachedRootPath: null,
+    parentLaneId: null,
+    childCount: 0,
+    stackDepth: 0,
+    parentStatus: null,
+    isEditProtected: false,
+    status: { dirty: false, ahead: 0, behind: 0, remoteBehind: -1, rebaseInProgress: false },
+    color: null,
+    icon: null,
+    tags: [],
+    folder: null,
+    createdAt: "2026-05-27T12:00:00.000Z",
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+type DialogProps = Parameters<typeof ManageLaneDialog>[0];
+
+function makeProps(overrides: Partial<DialogProps> = {}): DialogProps {
+  const lane = makeLane();
+  return {
+    open: true,
+    onOpenChange: vi.fn(),
+    managedLane: lane,
+    managedLanes: undefined,
+    allLanes: [lane],
+    deleteMode: "worktree",
+    setDeleteMode: vi.fn(),
+    deleteRemoteName: "origin",
+    setDeleteRemoteName: vi.fn(),
+    deleteForce: false,
+    setDeleteForce: vi.fn(),
+    deleteConfirmText: "delete Manage tabs",
+    setDeleteConfirmText: vi.fn(),
+    deletePhrase: "delete Manage tabs",
+    laneActionBusy: false,
+    laneActionStatus: null,
+    laneActionError: null,
+    laneActionKind: null,
+    onAdoptAttached: vi.fn(),
+    onArchive: vi.fn(),
+    onDelete: vi.fn(),
+    onAppearanceChanged: vi.fn(),
+    onStackReorganized: vi.fn(),
+    ...overrides,
+  };
+}
+
+function selectedTabLabel(): string | null {
+  return screen
+    .getAllByRole("tab")
+    .find((tab) => tab.getAttribute("aria-selected") === "true")
+    ?.textContent ?? null;
+}
+
+describe("ManageLaneDialog tabs", () => {
+  const originalAde = (globalThis.window as any).ade;
+
+  beforeEach(() => {
+    (globalThis.window as any).ade = {
+      lanes: {
+        getDeleteRisk: vi.fn().mockResolvedValue(deleteRisk),
+        onDeleteEvent: vi.fn(() => vi.fn()),
+        updateAppearance: vi.fn().mockResolvedValue(undefined),
+        reparent: vi.fn().mockResolvedValue(undefined),
+      },
+    };
+  });
+
+  afterEach(() => {
+    (globalThis.window as any).ade = originalAde;
+    vi.clearAllMocks();
+  });
+
+  it("opens on the first available tab", () => {
+    render(<ManageLaneDialog {...makeProps()} />);
+
+    expect(selectedTabLabel()).toBe("Delete");
+  });
+
+  it("does not reset the selected tab when the lane object refreshes", () => {
+    const lane = makeLane();
+    const { rerender } = render(
+      <ManageLaneDialog {...makeProps({ managedLane: lane, allLanes: [lane] })} />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Archive" }));
+    expect(selectedTabLabel()).toBe("Archive");
+
+    const refreshedLane = { ...lane, color: "#5eead4" };
+    rerender(
+      <ManageLaneDialog {...makeProps({ managedLane: refreshedLane, allLanes: [refreshedLane] })} />,
+    );
+
+    expect(selectedTabLabel()).toBe("Archive");
+  });
+});

--- a/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx
+++ b/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx
@@ -104,10 +104,27 @@ describe("ManageLaneDialog tabs", () => {
     vi.clearAllMocks();
   });
 
-  it("opens on the first available tab", () => {
+  it("opens on the first non-destructive tab for a single lane", () => {
     render(<ManageLaneDialog {...makeProps()} />);
 
-    expect(selectedTabLabel()).toBe("Delete");
+    expect(selectedTabLabel()).toBe("Appearance");
+  });
+
+  it("opens on archive for batch lane management", () => {
+    const firstLane = makeLane({ id: "lane-1", name: "First lane" });
+    const secondLane = makeLane({ id: "lane-2", name: "Second lane" });
+
+    render(
+      <ManageLaneDialog
+        {...makeProps({
+          managedLane: null,
+          managedLanes: [firstLane, secondLane],
+          allLanes: [firstLane, secondLane],
+        })}
+      />,
+    );
+
+    expect(selectedTabLabel()).toBe("Archive");
   });
 
   it("does not reset the selected tab when the lane object refreshes", () => {

--- a/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx
+++ b/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx
@@ -241,6 +241,8 @@ export function ManageLaneDialog({
   const isAttached = !isBatch && lanes[0]?.laneType === "attached";
   const hasNonAttached = lanes.some((l) => l.laneType !== "attached" && l.laneType !== "primary");
   const isMixed = hasAttached && hasNonAttached;
+  const singleLaneId = singleLane?.id ?? null;
+  const singleLaneType = singleLane?.laneType ?? null;
   let worktreeDeleteLabel: string;
   let localDeleteLabel: string;
   let remoteDeleteLabel: string;
@@ -263,17 +265,15 @@ export function ManageLaneDialog({
   const [activeTab, setActiveTab] = useState<ManageLaneTab>("delete");
 
   const tabDefs = React.useMemo((): ManageLaneTabDef[] => {
-    const defs: ManageLaneTabDef[] = [];
-    defs.push({ id: "delete", label: "Delete", icon: Trash });
-    if (singleLane) {
-      defs.push({ id: "appearance", label: "Appearance", icon: Palette });
-    }
-    if (singleLane && singleLane.laneType !== "primary") {
-      defs.push({ id: "stack", label: "Restack", icon: TreeStructure });
-    }
-    defs.push({ id: "archive", label: "Archive", icon: Archive });
-    return defs;
-  }, [singleLane]);
+    return [
+      { id: "delete" as const, label: "Delete", icon: Trash, show: true },
+      { id: "appearance" as const, label: "Appearance", icon: Palette, show: !!singleLaneType },
+      { id: "stack" as const, label: "Restack", icon: TreeStructure, show: !!singleLaneType && singleLaneType !== "primary" },
+      { id: "archive" as const, label: "Archive", icon: Archive, show: true },
+    ]
+      .filter((t) => t.show)
+      .map(({ show: _, ...tab }) => tab);
+  }, [singleLaneType]);
 
   // Reset transient state when dialog closes or active lane changes.
   useEffect(() => {
@@ -282,22 +282,18 @@ export function ManageLaneDialog({
       setDeleteProgress(null);
       return;
     }
-    // Land users on a non-destructive tab by default. Explicit "delete"/"archive"
-    // intent is handled by the laneActionKind effect below.
-    const preferredOrder: ManageLaneTab[] = ["appearance", "stack", "archive", "delete"];
-    const firstAvailable = preferredOrder.find((id) => tabDefs.some((tab) => tab.id === id));
-    setActiveTab(firstAvailable ?? tabDefs[0]?.id ?? "archive");
-  }, [open, singleLane?.id, isBatch, tabDefs]);
+    setActiveTab(tabDefs[0]?.id ?? "archive");
+  }, [open, singleLaneId, isBatch, tabDefs]);
 
   // Fetch pre-flight risk for the single-lane case.
   useEffect(() => {
-    if (!open || !singleLane || singleLane.laneType === "primary") {
+    if (!open || !singleLaneId || singleLaneType === "primary") {
       setDeleteRisk(null);
       return;
     }
     let cancelled = false;
     void window.ade.lanes
-      .getDeleteRisk({ laneId: singleLane.id })
+      .getDeleteRisk({ laneId: singleLaneId })
       .then((risk) => {
         if (!cancelled) setDeleteRisk(risk);
       })
@@ -307,19 +303,19 @@ export function ManageLaneDialog({
     return () => {
       cancelled = true;
     };
-  }, [open, singleLane?.id]);
+  }, [open, singleLaneId, singleLaneType]);
 
   // Stream live delete progress for the active lane.
   useEffect(() => {
-    if (!open || !singleLane) return;
+    if (!open || !singleLaneId) return;
     const unsubscribe = window.ade.lanes.onDeleteEvent((event) => {
-      if (event.progress.laneId !== singleLane.id) return;
+      if (event.progress.laneId !== singleLaneId) return;
       setDeleteProgress(event.progress);
     });
     return () => {
       unsubscribe?.();
     };
-  }, [open, singleLane?.id]);
+  }, [open, singleLaneId]);
 
   const requiresTypeConfirm =
     isBatch ||

--- a/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx
+++ b/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx
@@ -274,6 +274,10 @@ export function ManageLaneDialog({
       .filter((t) => t.show)
       .map(({ show: _, ...tab }) => tab);
   }, [singleLaneType]);
+  const defaultTab = React.useMemo((): ManageLaneTab => {
+    const preferredOrder: ManageLaneTab[] = ["appearance", "stack", "archive", "delete"];
+    return preferredOrder.find((id) => tabDefs.some((tab) => tab.id === id)) ?? tabDefs[0]?.id ?? "archive";
+  }, [tabDefs]);
 
   // Reset transient state when dialog closes or active lane changes.
   useEffect(() => {
@@ -282,8 +286,8 @@ export function ManageLaneDialog({
       setDeleteProgress(null);
       return;
     }
-    setActiveTab(tabDefs[0]?.id ?? "archive");
-  }, [open, singleLaneId, isBatch, tabDefs]);
+    setActiveTab(defaultTab);
+  }, [open, singleLaneId, isBatch, defaultTab]);
 
   // Fetch pre-flight risk for the single-lane case.
   useEffect(() => {
@@ -330,8 +334,8 @@ export function ManageLaneDialog({
 
   useEffect(() => {
     if (tabDefs.some((tab) => tab.id === activeTab)) return;
-    setActiveTab(tabDefs[0]?.id ?? "archive");
-  }, [activeTab, tabDefs]);
+    setActiveTab(defaultTab);
+  }, [activeTab, defaultTab, tabDefs]);
 
   useEffect(() => {
     if (laneActionKind === "delete") setActiveTab("delete");


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Ffix-manage-lane-tabs-dfec9940 num=380 -->
<p>
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://ade.app/logo-dark.svg">
    <img src="https://ade.app/logo-light.svg" height="18" align="left" alt="ADE">
  </picture>
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade.app/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Ffix-manage-lane-tabs-dfec9940&amp;pr=380">ade/fix-manage-lane-tabs-dfec9940 branch</a>
  &nbsp;·&nbsp; <a href="https://ade.app/open?type=pr&amp;repo=arul28%2FADE&amp;number=380">PR #380</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for ManageLaneDialog tab behavior and state persistence.

* **Refactor**
  * Improved ManageLaneDialog tab selection stability and optimized delete risk checks for lanes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors `ManageLaneDialog` tab state management to fix spurious tab resets when the lane object refreshes (e.g., after a property like `color` changes). It does so by extracting `singleLane?.id` and `singleLane?.laneType` into primitive variables used as effect dependencies, and by memoizing `defaultTab` as a string rather than depending on the `tabDefs` array reference.

- **Tab reset fix**: Replacing `tabDefs` (array reference) with `defaultTab` (string primitive) in the reset effect's dependency array prevents unnecessary resets when `singleLane`'s identity doesn't change but its object reference does.
- **`defaultTab` memo**: Centralizes the non-destructive tab preference logic (`["appearance", "stack", "archive", "delete"]`), eliminating duplication between the main reset effect and the fallback guard.
- **Tests**: A new test suite verifies all three behaviors — single-lane default, batch-mode default, and stability across lane refreshes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the refactor correctly uses primitive dependency values to eliminate spurious tab resets, and the new test suite validates all key tab-selection scenarios.

The change is narrowly scoped to dependency-array hygiene and memoization: swapping the tabDefs array reference for the defaultTab string primitive is the right fix for the refresh-triggered reset bug. The defaultTab memo faithfully reproduces the original preferred-order logic, and the fallback guard was updated consistently. All three affected behaviors are now covered by tests.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx | Tab state refactored to use primitive dependency values and a memoized defaultTab; logic is correct and the fallback guard also updated to use defaultTab. |
| apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx | New test suite covers single-lane default tab, batch-mode default tab, and stability across lane object refreshes; all scenarios correctly modelled. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Dialog opens or lane changes"] --> B{open?}
    B -- No --> C["Clear deleteRisk and deleteProgress"]
    B -- Yes --> D["setActiveTab(defaultTab)"]

    subgraph Memos
        E["tabDefs memo - depends on singleLaneType"] --> F["Filtered list: delete, appearance, stack, archive"]
        G["defaultTab memo - depends on tabDefs"] --> H["preferredOrder: appearance, stack, archive, delete"]
        H --> I["Return first match found in tabDefs"]
    end

    D -.-> G

    J["Fallback guard effect"] --> K{activeTab in tabDefs?}
    K -- Yes --> L["no-op"]
    K -- No --> M["setActiveTab(defaultTab)"]
```

<sub>Reviews (2): Last reviewed commit: ["ship: iteration 1 - address tab default ..."](https://github.com/arul28/ade/commit/86e1bb6c277a8f6061927c0ac6d1b567df57ce0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34231072)</sub>

<!-- /greptile_comment -->