### PR TITLE
Fix AI provider banner freshness

### DIFF
--- a/apps/desktop/src/renderer/components/app/AppShell.aiStatus.test.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.aiStatus.test.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { act, cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AiSettingsStatus } from "../../../shared/types";
+import type { AgentChatEventEnvelope, AiSettingsStatus } from "../../../shared/types";
 import { getAiStatusCached, invalidateAiDiscoveryCache } from "../../lib/aiDiscoveryCache";
 import { useAppStore } from "../../state/appStore";
 import { AppShell } from "./AppShell";
@@ -82,6 +82,7 @@ function resetStore() {
 
 describe("AppShell AI provider status", () => {
   const getStatusMock = vi.fn();
+  let chatEventListener: ((envelope: AgentChatEventEnvelope) => void) | null = null;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -89,6 +90,7 @@ describe("AppShell AI provider status", () => {
     resetStore();
     invalidateAiDiscoveryCache();
     getStatusMock.mockReset();
+    chatEventListener = null;
     Object.defineProperty(window, "ade", {
       configurable: true,
       value: {
@@ -98,7 +100,12 @@ describe("AppShell AI provider status", () => {
           onProjectBindingChanged: vi.fn(() => () => {}),
         },
         agentChat: {
-          onEvent: vi.fn(() => () => {}),
+          onEvent: vi.fn((listener: (envelope: AgentChatEventEnvelope) => void) => {
+            chatEventListener = listener;
+            return () => {
+              if (chatEventListener === listener) chatEventListener = null;
+            };
+          }),
         },
         ai: {
           getStatus: getStatusMock,
@@ -175,6 +182,43 @@ describe("AppShell AI provider status", () => {
     });
 
     expect(screen.queryByText(/No AI provider is configured yet/i)).toBeNull();
+    expect(getStatusMock).toHaveBeenLastCalledWith({
+      force: true,
+      refreshOpenCodeInventory: false,
+    });
+  });
+
+  it("refreshes provider status on auth-related chat failures after a provider was known", async () => {
+    getStatusMock
+      .mockResolvedValueOnce(makeAiStatus(true))
+      .mockResolvedValueOnce(makeAiStatus(false));
+    await getAiStatusCached({ projectRoot: project.rootPath });
+
+    render(
+      <MemoryRouter initialEntries={["/work"]}>
+        <AppShell>
+          <div>Work content</div>
+        </AppShell>
+      </MemoryRouter>,
+    );
+
+    await act(async () => {});
+    expect(screen.queryByText(/No AI provider is configured yet/i)).toBeNull();
+
+    await act(async () => {
+      chatEventListener?.({
+        sessionId: "session-1",
+        timestamp: "2026-05-28T12:00:00.000Z",
+        event: {
+          type: "error",
+          message: "Invalid API key.",
+        },
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText(/No AI provider is configured yet/i)).toBeTruthy();
     expect(getStatusMock).toHaveBeenLastCalledWith({
       force: true,
       refreshOpenCodeInventory: false,

--- a/apps/desktop/src/renderer/components/app/AppShell.aiStatus.test.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.aiStatus.test.tsx
@@ -1,0 +1,183 @@
+/* @vitest-environment jsdom */
+
+import type { ReactNode } from "react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AiSettingsStatus } from "../../../shared/types";
+import { getAiStatusCached, invalidateAiDiscoveryCache } from "../../lib/aiDiscoveryCache";
+import { useAppStore } from "../../state/appStore";
+import { AppShell } from "./AppShell";
+
+vi.mock("./CommandPalette", () => ({
+  CommandPalette: () => null,
+}));
+
+vi.mock("./TabNav", () => ({
+  TabNav: () => <nav data-testid="tab-nav" />,
+}));
+
+vi.mock("./TopBar", () => ({
+  TopBar: () => <div data-testid="top-bar" />,
+}));
+
+vi.mock("../ui/TabBackground", () => ({
+  TabBackground: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../lanes/LaneAccentDot", () => ({
+  LaneAccentDot: () => <span data-testid="lane-accent-dot" />,
+}));
+
+vi.mock("../terminals/TerminalView", () => ({
+  disposeTerminalRuntimesForProjectChange: vi.fn(),
+}));
+
+vi.mock("../../lib/debugLog", () => ({
+  logRendererDebugEvent: vi.fn(),
+}));
+
+vi.mock("../../lib/sessionListCache", () => ({
+  listSessionsCached: vi.fn(async () => []),
+}));
+
+const project = { rootPath: "/tmp/ai-project", displayName: "AI Project", baseRef: "main" } as any;
+
+function makeAiStatus(hasProvider: boolean): AiSettingsStatus {
+  return {
+    mode: "guest",
+    availableProviders: {
+      claude: {
+        binary: { present: false, source: "missing", path: null },
+        auth: { ready: false, mode: "none", detail: null },
+      },
+      codex: hasProvider,
+      cursor: false,
+      droid: false,
+    },
+    models: { claude: [], codex: [], cursor: [], droid: [] },
+    features: [],
+  };
+}
+
+function resetStore() {
+  useAppStore.setState({
+    project: null,
+    projectBinding: null,
+    projectHydrated: false,
+    showWelcome: true,
+    projectTransition: null,
+    lanes: [],
+    laneSnapshots: [],
+    lanesLoading: false,
+    selectedLaneId: null,
+    focusedSessionId: null,
+    providerMode: "guest",
+    keybindings: null,
+    dismissedMissingAiBannerRoots: {},
+    dismissedGithubBannerRoots: {},
+    isNewTabOpen: false,
+  } as any);
+}
+
+describe("AppShell AI provider status", () => {
+  const getStatusMock = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    cleanup();
+    resetStore();
+    invalidateAiDiscoveryCache();
+    getStatusMock.mockReset();
+    Object.defineProperty(window, "ade", {
+      configurable: true,
+      value: {
+        app: {
+          getWindowSession: vi.fn(async () => ({ project, binding: null })),
+          onProjectChanged: vi.fn(() => () => {}),
+          onProjectBindingChanged: vi.fn(() => () => {}),
+        },
+        agentChat: {
+          onEvent: vi.fn(() => () => {}),
+        },
+        ai: {
+          getStatus: getStatusMock,
+        },
+        cto: {
+          onLinearWorkflowEvent: vi.fn(() => () => {}),
+        },
+        feedback: {
+          onUpdate: vi.fn(() => () => {}),
+        },
+        github: {
+          getStatus: vi.fn(async () => null),
+          onStatusChanged: vi.fn(() => () => {}),
+        },
+        keybindings: {
+          get: vi.fn(async () => null),
+        },
+        lanes: {
+          listSnapshots: vi.fn(async () => []),
+        },
+        onboarding: {
+          getStatus: vi.fn(async () => ({ freshProject: false, completedAt: null, dismissedAt: null })),
+        },
+        project: {
+          onMissing: vi.fn(() => () => {}),
+          forgetRecent: vi.fn(async () => []),
+        },
+        projectConfig: {
+          get: vi.fn(async () => ({ effective: { providerMode: "guest" } })),
+        },
+        prs: {
+          onEvent: vi.fn(() => () => {}),
+        },
+        pty: {
+          onData: vi.fn(() => () => {}),
+          onExit: vi.fn(() => () => {}),
+        },
+        sync: {
+          onEvent: vi.fn(() => () => {}),
+        },
+        zoom: {
+          setLevel: vi.fn(),
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("refreshes the missing-provider banner when AI status cache is invalidated", async () => {
+    getStatusMock
+      .mockResolvedValueOnce(makeAiStatus(false))
+      .mockResolvedValueOnce(makeAiStatus(true));
+    await getAiStatusCached({ projectRoot: project.rootPath });
+
+    render(
+      <MemoryRouter initialEntries={["/work"]}>
+        <AppShell>
+          <div>Work content</div>
+        </AppShell>
+      </MemoryRouter>,
+    );
+
+    await act(async () => {});
+    expect(screen.getByText(/No AI provider is configured yet/i)).toBeTruthy();
+
+    await act(async () => {
+      invalidateAiDiscoveryCache(project.rootPath);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText(/No AI provider is configured yet/i)).toBeNull();
+    expect(getStatusMock).toHaveBeenLastCalledWith({
+      force: true,
+      refreshOpenCodeInventory: false,
+    });
+  });
+});

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -38,6 +38,13 @@ import {
   getEffectiveBinding,
 } from "../../lib/keybindings";
 import { listSessionsCached } from "../../lib/sessionListCache";
+import {
+  AI_STATUS_CACHE_INVALIDATED_EVENT,
+  getAiStatusCached,
+  peekAiStatusCached,
+  type AiStatusCacheInvalidatedEventDetail,
+} from "../../lib/aiDiscoveryCache";
+import { hasConfiguredAiProvider } from "../../lib/aiProviderStatus";
 import { getStaleRunningCliSessionAgeHours, isRunOwnedSession } from "../../lib/sessions";
 import { summarizeTerminalAttention } from "../../lib/terminalAttention";
 import { getStoredZoomLevel, displayZoomToLevel } from "../../lib/zoom";
@@ -58,6 +65,9 @@ function primaryTabPath(pathname: string): string {
 }
 
 const PROJECT_ROUTE_STORAGE_PREFIX = "ade:project-route:";
+const AI_STATUS_STARTUP_DELAY_MS = 1_000;
+const AI_STATUS_REFRESH_INTERVAL_MS = 300_000;
+const AI_STATUS_CHAT_EVENT_REFRESH_MIN_GAP_MS = 30_000;
 const GITHUB_STATUS_STARTUP_DELAY_MS = 12_000;
 const GITHUB_STATUS_DISMISSED_BANNER_DELAY_MS = 30_000;
 
@@ -751,22 +761,65 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       setAiStatusLoaded(false);
       return;
     }
-    setAiStatusLoaded(false);
-    const aiTimer = window.setTimeout(() => {
-      void window.ade.ai.getStatus().then((status) => {
+    const cachedStatus = peekAiStatusCached(currentProjectRoot);
+    setAiStatus(cachedStatus);
+    setAiStatusLoaded(Boolean(cachedStatus));
+
+    let refreshSerial = 0;
+    let lastChatEventRefreshAt = 0;
+    let lastKnownHasProvider = hasConfiguredAiProvider(cachedStatus);
+    const refreshAiStatus = (options: { force?: boolean } = {}) => {
+      if (document.visibilityState !== "visible") return;
+      const serial = ++refreshSerial;
+      void getAiStatusCached({ projectRoot: currentProjectRoot, force: options.force === true }).then((status) => {
         if (cancelled) return;
+        if (serial !== refreshSerial) return;
+        lastKnownHasProvider = hasConfiguredAiProvider(status);
         setAiStatus(status);
       }).catch(() => {
         if (cancelled) return;
+        if (serial !== refreshSerial) return;
+        lastKnownHasProvider = false;
         setAiStatus(null);
       }).finally(() => {
         if (cancelled) return;
+        if (serial !== refreshSerial) return;
         setAiStatusLoaded(true);
       });
-    }, 1_000);
+    };
+
+    const aiTimer = window.setTimeout(
+      refreshAiStatus,
+      cachedStatus ? 0 : AI_STATUS_STARTUP_DELAY_MS,
+    );
+    const aiInterval = window.setInterval(refreshAiStatus, AI_STATUS_REFRESH_INTERVAL_MS);
+    const onFocus = () => refreshAiStatus();
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") refreshAiStatus();
+    };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    const unsubscribeChatEvents = window.ade.agentChat.onEvent(() => {
+      if (lastKnownHasProvider) return;
+      const now = Date.now();
+      if (now - lastChatEventRefreshAt < AI_STATUS_CHAT_EVENT_REFRESH_MIN_GAP_MS) return;
+      lastChatEventRefreshAt = now;
+      refreshAiStatus({ force: true });
+    });
+    const onAiStatusCacheInvalidated = (event: Event) => {
+      const detail = (event as CustomEvent<AiStatusCacheInvalidatedEventDetail>).detail;
+      if (detail && !detail.allProjects && detail.projectRoot !== currentProjectRoot) return;
+      refreshAiStatus({ force: true });
+    };
+    window.addEventListener(AI_STATUS_CACHE_INVALIDATED_EVENT, onAiStatusCacheInvalidated);
     return () => {
       cancelled = true;
       window.clearTimeout(aiTimer);
+      window.clearInterval(aiInterval);
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener(AI_STATUS_CACHE_INVALIDATED_EVENT, onAiStatusCacheInvalidated);
+      unsubscribeChatEvents();
     };
   }, [currentProjectRoot]);
 
@@ -847,12 +900,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   }, [providerMode]);
 
   const hasAnyAiProvider = useMemo(() => {
-    if (!aiStatus) return false;
-    const runtimeOrLocal =
-      aiStatus.providerConnections?.claude.authAvailable ||
-      aiStatus.providerConnections?.codex.authAvailable ||
-      aiStatus.providerConnections?.cursor?.authAvailable;
-    return Boolean(runtimeOrLocal || (aiStatus.detectedAuth?.length ?? 0) > 0);
+    return hasConfiguredAiProvider(aiStatus);
   }, [aiStatus]);
 
   const commandPaletteBinding = useMemo(

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -44,7 +44,10 @@ import {
   peekAiStatusCached,
   type AiStatusCacheInvalidatedEventDetail,
 } from "../../lib/aiDiscoveryCache";
-import { hasConfiguredAiProvider } from "../../lib/aiProviderStatus";
+import {
+  hasConfiguredAiProvider,
+  shouldRefreshAiStatusForChatEvent,
+} from "../../lib/aiProviderStatus";
 import { getStaleRunningCliSessionAgeHours, isRunOwnedSession } from "../../lib/sessions";
 import { summarizeTerminalAttention } from "../../lib/terminalAttention";
 import { getStoredZoomLevel, displayZoomToLevel } from "../../lib/zoom";
@@ -66,7 +69,6 @@ function primaryTabPath(pathname: string): string {
 
 const PROJECT_ROUTE_STORAGE_PREFIX = "ade:project-route:";
 const AI_STATUS_STARTUP_DELAY_MS = 1_000;
-const AI_STATUS_REFRESH_INTERVAL_MS = 300_000;
 const AI_STATUS_CHAT_EVENT_REFRESH_MIN_GAP_MS = 30_000;
 const GITHUB_STATUS_STARTUP_DELAY_MS = 12_000;
 const GITHUB_STATUS_DISMISSED_BANNER_DELAY_MS = 30_000;
@@ -792,15 +794,14 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       refreshAiStatus,
       cachedStatus ? 0 : AI_STATUS_STARTUP_DELAY_MS,
     );
-    const aiInterval = window.setInterval(refreshAiStatus, AI_STATUS_REFRESH_INTERVAL_MS);
     const onFocus = () => refreshAiStatus();
     const onVisibilityChange = () => {
       if (document.visibilityState === "visible") refreshAiStatus();
     };
     window.addEventListener("focus", onFocus);
     document.addEventListener("visibilitychange", onVisibilityChange);
-    const unsubscribeChatEvents = window.ade.agentChat.onEvent(() => {
-      if (lastKnownHasProvider) return;
+    const unsubscribeChatEvents = window.ade.agentChat.onEvent((envelope) => {
+      if (lastKnownHasProvider && !shouldRefreshAiStatusForChatEvent(envelope)) return;
       const now = Date.now();
       if (now - lastChatEventRefreshAt < AI_STATUS_CHAT_EVENT_REFRESH_MIN_GAP_MS) return;
       lastChatEventRefreshAt = now;
@@ -815,7 +816,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     return () => {
       cancelled = true;
       window.clearTimeout(aiTimer);
-      window.clearInterval(aiInterval);
       window.removeEventListener("focus", onFocus);
       document.removeEventListener("visibilitychange", onVisibilityChange);
       window.removeEventListener(AI_STATUS_CACHE_INVALIDATED_EVENT, onAiStatusCacheInvalidated);

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -680,6 +680,8 @@ function renderDrawerSessionPane(
 function renderParallelDraftPane(args?: {
   laneId?: string;
   availableModelIdsOverride?: string[];
+  initialEntry?: string;
+  suppressDraftLaunchNavigation?: boolean;
 }) {
   const laneId = args?.laneId ?? "lane-1";
   useAppStore.setState({
@@ -695,7 +697,7 @@ function renderParallelDraftPane(args?: {
   });
 
   return render(
-    <MemoryRouter initialEntries={["/work"]}>
+    <MemoryRouter initialEntries={[args?.initialEntry ?? "/work"]}>
       <Routes>
         <Route
           path="*"
@@ -705,6 +707,7 @@ function renderParallelDraftPane(args?: {
                 laneId={laneId}
                 forceDraftMode
                 embeddedWorkLayout
+                suppressDraftLaunchNavigation={args?.suppressDraftLaunchNavigation}
                 availableModelIdsOverride={args?.availableModelIdsOverride}
               />
               <LocationProbe />
@@ -2875,6 +2878,55 @@ describe("AgentChatPane submit recovery", () => {
     await waitFor(() => {
       expect(screen.getByTestId("location").textContent).toBe("/work?laneId=lane-created&sessionId=created-session");
     });
+  });
+
+  it("can keep foreground draft launches inside an embedded Lanes work pane", async () => {
+    const { send, create } = installAdeMocks({ sessions: [] });
+    const launchConfigKey = [
+      "ade.chat.lastLaunchConfig.v1",
+      "/tmp/project-under-test",
+      "lane-1",
+      "standard",
+      "chat",
+    ].map(encodeURIComponent).join(":");
+    window.localStorage.setItem(launchConfigKey, JSON.stringify({
+      version: 1,
+      modelId: "openai/gpt-5.4",
+      updatedAt: "2026-05-28T12:00:00.000Z",
+      controls: {
+        interactionMode: "default",
+        claudePermissionMode: "default",
+        codexApprovalPolicy: "on-request",
+        codexSandbox: "workspace-write",
+        codexConfigSource: "flags",
+        opencodePermissionMode: "edit",
+        droidPermissionMode: "auto-low",
+        cursorModeId: "agent",
+        cursorConfigValues: {},
+      },
+    }));
+
+    renderParallelDraftPane({
+      initialEntry: "/lanes?laneId=lane-1",
+      suppressDraftLaunchNavigation: true,
+      availableModelIdsOverride: ["openai/gpt-5.4"],
+    });
+
+    const textbox = await screen.findByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "Stay in the lane work pane." } });
+    fireEvent.click(await screen.findByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledWith(expect.objectContaining({
+        laneId: "lane-1",
+        modelId: "openai/gpt-5.4",
+      }));
+      expect(send).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: "created-session",
+        text: "Stay in the lane work pane.",
+      }));
+    });
+    expect(screen.getByTestId("location").textContent).toBe("/lanes?laneId=lane-1");
   });
 
   it("routes Work sidebar draft insertions into the visible draft composer", async () => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -2205,6 +2205,7 @@ export function AgentChatPane({
   permissionModeLocked = false,
   presentation,
   embeddedWorkLayout = false,
+  suppressDraftLaunchNavigation = false,
   layoutVariant = "standard",
   isTileActive = true,
   isTileVisible = isTileActive,
@@ -2239,6 +2240,8 @@ export function AgentChatPane({
   presentation?: ChatSurfacePresentation;
   /** Work tab draft: flatter shell, no duplicate header chrome above the composer. */
   embeddedWorkLayout?: boolean;
+  /** Embedded Lanes work pane owns selection in place; don't route after draft launch. */
+  suppressDraftLaunchNavigation?: boolean;
   layoutVariant?: "standard" | "grid-tile";
   isTileActive?: boolean;
   /** Visible grid tiles hydrate transcripts even when they are not the focused tile. */
@@ -5691,12 +5694,15 @@ export function AgentChatPane({
         viewMode: "tabs",
       }));
     }
+    if (suppressDraftLaunchNavigation) {
+      return;
+    }
     if (embeddedWorkLayout) {
       navigate(`/work?laneId=${encodeURIComponent(launch.laneId)}&sessionId=${encodeURIComponent(launch.sessionId)}`);
       return;
     }
     navigate(`/lanes?laneId=${encodeURIComponent(launch.laneId)}&sessionId=${encodeURIComponent(launch.sessionId)}&focus=single`);
-  }, [embeddedWorkLayout, navigate, projectRoot, setLaneWorkViewState, setWorkViewState]);
+  }, [embeddedWorkLayout, navigate, projectRoot, setLaneWorkViewState, setWorkViewState, suppressDraftLaunchNavigation]);
 
   const resolveDraftLaunchLane = useCallback(async (snapshot: DraftLaunchSnapshot): Promise<DraftLaunchLaneTarget> => {
     if (draftLaunchTargetIsAutoCreate) {

--- a/apps/desktop/src/renderer/components/lanes/LaneWorkPane.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneWorkPane.tsx
@@ -69,6 +69,7 @@ export function LaneWorkPane({
           onLaunchPtySession={work.launchPtySession}
           onContinueCliSession={work.continueCliSession}
           onShowDraftKind={work.showDraftKind}
+          suppressDraftLaunchNavigation
           closingPtyIds={work.closingPtyIds}
           initialLinearIssueContext={initialLinearIssueContext}
           onInitialLinearIssueContextConsumed={onInitialLinearIssueContextConsumed}

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
-  AgentChatEventEnvelope,
   AiConfig,
   AiApiKeyVerificationResult,
   AiClaudeAvailability,
@@ -38,6 +37,7 @@ import {
 } from "../lanes/laneDesignTokens";
 import { deriveConfiguredModelIds } from "../../lib/modelOptions";
 import { invalidateAiDiscoveryCache } from "../../lib/aiDiscoveryCache";
+import { shouldRefreshAiStatusForChatEvent } from "../../lib/aiProviderStatus";
 
 type CliName = "claude" | "codex" | "cursor" | "droid";
 type ApiKeySource = "config" | "env" | "store";
@@ -211,39 +211,6 @@ function formatLocalModelLabel(modelId: string): string {
   return String(modelId ?? "").trim();
 }
 
-const AUTH_ERROR_SIGNALS = [
-  "invalid authentication credentials",
-  "authentication error",
-  "authentication_error",
-  "authentication failed",
-  "not authenticated",
-  "not logged in",
-  "login required",
-  "sign in",
-  "invalid api key",
-  "api error: 401",
-  "status 401",
-  "claude auth login",
-  "codex login",
-  "/login",
-];
-
-function isAuthRelatedChatMessage(message: string | null | undefined): boolean {
-  const normalized = String(message ?? "").trim().toLowerCase();
-  if (!normalized.length) return false;
-  return AUTH_ERROR_SIGNALS.some((signal) => normalized.includes(signal));
-}
-
-function shouldRefreshProvidersForChatEvent(envelope: AgentChatEventEnvelope): boolean {
-  const event = envelope.event;
-  if (event.type === "system_notice" && event.noticeKind === "auth") return true;
-  if (event.type === "error") return isAuthRelatedChatMessage(event.message);
-  if (event.type === "status" && event.turnStatus === "failed") {
-    return isAuthRelatedChatMessage(event.message);
-  }
-  return false;
-}
-
 function buildLocalProviderDrafts(
   snapshot: ProjectConfigSnapshot | null | undefined,
   status: (AiSettingsStatus & { runtimeConnections?: Record<string, AiRuntimeConnectionStatus> }) | null | undefined,
@@ -322,7 +289,7 @@ export function ProvidersSection({ forceRefreshOnMount = false }: { forceRefresh
 
   useEffect(() => {
     const unsubscribe = window.ade.agentChat.onEvent((envelope) => {
-      if (!shouldRefreshProvidersForChatEvent(envelope)) return;
+      if (!shouldRefreshAiStatusForChatEvent(envelope)) return;
       if (pendingRefreshTimerRef.current != null) return;
       pendingRefreshTimerRef.current = window.setTimeout(() => {
         pendingRefreshTimerRef.current = null;

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.test.tsx
@@ -118,6 +118,46 @@ describe("SessionListPane", () => {
     expect(setSessionListOrganization).toHaveBeenCalledWith("by-time");
   });
 
+  it("shows an active marker only when the lane filter restricts lanes", () => {
+    const { rerender } = renderPane({ filterLaneId: "all" });
+
+    expect(screen.queryByTestId("work-lane-filter-active-indicator")).toBeNull();
+
+    const session = makeSession();
+    rerender(
+      <MemoryRouter>
+        <SessionListPane
+          lanes={[makeLane()]}
+          runningFiltered={[session]}
+          awaitingInputFiltered={[]}
+          endedFiltered={[]}
+          loading={false}
+          filterLaneId="lane-known"
+          setFilterLaneId={vi.fn()}
+          q=""
+          setQ={vi.fn()}
+          selectedSessionId={null}
+          draftKind="chat"
+          showingDraft={false}
+          onShowDraftKind={vi.fn()}
+          onSelectSession={vi.fn()}
+          onInfoClick={vi.fn()}
+          onContextMenu={vi.fn()}
+          sessionListOrganization="by-lane"
+          setSessionListOrganization={vi.fn()}
+          workCollapsedLaneIds={[]}
+          toggleWorkLaneCollapsed={vi.fn()}
+          workCollapsedSectionIds={[]}
+          toggleWorkSectionCollapsed={vi.fn()}
+          sessionsGroupedByLane={new Map([[session.laneId, [session]]])}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("button", { name: "Filters, lane filter active" })).toBeTruthy();
+    expect(screen.getByTestId("work-lane-filter-active-indicator")).toBeTruthy();
+  });
+
   it("bolds only the session name in sidebar cards", () => {
     const session = makeSession({
       id: "session-style",

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
@@ -224,6 +224,8 @@ export const SessionListPane = React.memo(function SessionListPane({
 
   const isByLane = sessionListOrganization === "by-lane";
   const isByTime = sessionListOrganization === "by-time";
+  const normalizedFilterLaneId = filterLaneId.trim();
+  const laneFilterActive = normalizedFilterLaneId.length > 0 && normalizedFilterLaneId !== "all";
   const [filterOpen, setFilterOpen] = useState(false);
 
   const allSessions = useMemo(
@@ -609,17 +611,23 @@ export const SessionListPane = React.memo(function SessionListPane({
           <SmartTooltip content={{ label: "Filters", description: "Toggle the filter panel to organize sessions by lane or time." }}>
             <button
               type="button"
-              className="ade-session-list-toolbar-filter inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg transition-colors"
+              className="ade-session-list-toolbar-filter relative inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg transition-colors"
               style={{
                 border: "1px solid rgba(255,255,255,0.06)",
-                background: filterOpen ? "rgba(255,255,255,0.06)" : "rgba(255,255,255,0.03)",
-                color: filterOpen ? "var(--color-fg)" : "var(--color-muted-fg)",
+                background: filterOpen || laneFilterActive ? "rgba(255,255,255,0.06)" : "rgba(255,255,255,0.03)",
+                color: filterOpen || laneFilterActive ? "var(--color-fg)" : "var(--color-muted-fg)",
               }}
               onClick={() => setFilterOpen(!filterOpen)}
-              aria-label="Filters"
+              aria-label={laneFilterActive ? "Filters, lane filter active" : "Filters"}
               data-tour="work.laneFilter"
             >
               <Funnel size={12} weight={filterOpen ? "fill" : "regular"} />
+              {laneFilterActive ? (
+                <span
+                  data-testid="work-lane-filter-active-indicator"
+                  className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-[var(--color-accent)] shadow-[0_0_8px_var(--color-accent)]"
+                />
+              ) : null}
             </button>
           </SmartTooltip>
         </div>

--- a/apps/desktop/src/renderer/components/terminals/WorkStartSurface.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkStartSurface.test.tsx
@@ -13,6 +13,7 @@ const agentChatPaneProps = vi.hoisted(() => ({
     draftContextTargetId?: string | null;
     onOpenShellSession?: (laneId: string) => void | Promise<void>;
     onLaunchCliSession?: unknown;
+    suppressDraftLaunchNavigation?: boolean;
   },
 }));
 
@@ -28,6 +29,7 @@ vi.mock("../chat/AgentChatPane", () => ({
     draftContextTargetId?: string | null;
     onOpenShellSession?: (laneId: string) => void | Promise<void>;
     onLaunchCliSession?: unknown;
+    suppressDraftLaunchNavigation?: boolean;
   }) => {
     agentChatPaneProps.latest = props;
     return (
@@ -118,11 +120,13 @@ describe("WorkStartSurface", () => {
         lanes={[{ id: "lane-local", name: "Local", runtimePlacement: "local" } as any]}
         onOpenChatSession={vi.fn()}
         onLaunchPtySession={vi.fn()}
+        suppressDraftLaunchNavigation
       />,
     );
 
     expect(await screen.findByTestId("agent-chat-pane")).toBeTruthy();
     expect(agentChatPaneProps.latest?.draftContextTargetId).toBe("work:draft:lane-local:chat");
+    expect(agentChatPaneProps.latest?.suppressDraftLaunchNavigation).toBe(true);
     expect(screen.queryByTestId("work-vm-banner")).toBeNull();
     expect(screen.queryByTestId("work-vm-not-ready")).toBeNull();
   });

--- a/apps/desktop/src/renderer/components/terminals/WorkStartSurface.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkStartSurface.tsx
@@ -22,6 +22,7 @@ type WorkStartSurfaceProps = {
   initialLinearIssueContextSource?: "manual" | "lane_link";
   initialModelId?: string | null;
   onInitialLinearIssueContextConsumed?: () => void;
+  suppressDraftLaunchNavigation?: boolean;
 };
 
 export function WorkStartSurface({
@@ -36,6 +37,7 @@ export function WorkStartSurface({
   initialLinearIssueContextSource = "lane_link",
   initialModelId = null,
   onInitialLinearIssueContextConsumed,
+  suppressDraftLaunchNavigation = false,
 }: WorkStartSurfaceProps) {
   const globallySelectedLaneId = useAppStore((s) => s.selectedLaneId);
   const lanesLoading = useAppStore((s) => s.lanesLoading);
@@ -129,6 +131,7 @@ export function WorkStartSurface({
           forceDraftMode
           draftContextTargetId={draftContextTargetId}
           embeddedWorkLayout
+          suppressDraftLaunchNavigation={suppressDraftLaunchNavigation}
           workDraftKind={draftKind}
           initialLinearIssueContext={initialLinearIssueContext}
           initialLinearIssueContextSource={initialLinearIssueContextSource}

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
@@ -1226,6 +1226,7 @@ export function WorkViewArea({
   initialLinearIssueContextSource = "lane_link",
   initialModelId = null,
   onInitialLinearIssueContextConsumed,
+  suppressDraftLaunchNavigation = false,
   onReorderLaneSessions,
   onOpenSessionInTabsView,
   onGoToLane,
@@ -1273,6 +1274,7 @@ export function WorkViewArea({
   initialLinearIssueContextSource?: "manual" | "lane_link";
   initialModelId?: string | null;
   onInitialLinearIssueContextConsumed?: () => void;
+  suppressDraftLaunchNavigation?: boolean;
   onInfoClick?: (session: TerminalSessionSummary, event: React.MouseEvent<HTMLElement>) => void;
   onStopRunningSession?: (session: TerminalSessionSummary) => void;
 }) {
@@ -1727,6 +1729,7 @@ export function WorkViewArea({
                 initialLinearIssueContextSource={initialLinearIssueContextSource}
                 initialModelId={initialModelId}
                 onInitialLinearIssueContextConsumed={onInitialLinearIssueContextConsumed}
+                suppressDraftLaunchNavigation={suppressDraftLaunchNavigation}
               />
             </div>
           </div>
@@ -1793,6 +1796,7 @@ export function WorkViewArea({
               initialLinearIssueContextSource={initialLinearIssueContextSource}
               initialModelId={initialModelId}
               onInitialLinearIssueContextConsumed={onInitialLinearIssueContextConsumed}
+              suppressDraftLaunchNavigation={suppressDraftLaunchNavigation}
             />
           </div>
         </div>

--- a/apps/desktop/src/renderer/lib/aiDiscoveryCache.test.ts
+++ b/apps/desktop/src/renderer/lib/aiDiscoveryCache.test.ts
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getAgentChatModelsCached, getAiStatusCached, invalidateAiDiscoveryCache, peekAiStatusCached } from "./aiDiscoveryCache";
+import {
+  AI_STATUS_CACHE_INVALIDATED_EVENT,
+  getAgentChatModelsCached,
+  getAiStatusCached,
+  invalidateAiDiscoveryCache,
+  peekAiStatusCached,
+  type AiStatusCacheInvalidatedEventDetail,
+} from "./aiDiscoveryCache";
 
 const getStatusMock = vi.fn();
 const modelsMock = vi.fn();
@@ -17,9 +24,13 @@ describe("aiDiscoveryCache", () => {
     invalidateAiDiscoveryCache();
     getStatusMock.mockReset();
     modelsMock.mockReset();
+    const windowEvents = new EventTarget();
     Object.defineProperty(globalThis, "window", {
       configurable: true,
       value: {
+        addEventListener: windowEvents.addEventListener.bind(windowEvents),
+        removeEventListener: windowEvents.removeEventListener.bind(windowEvents),
+        dispatchEvent: windowEvents.dispatchEvent.bind(windowEvents),
         ade: {
           ai: {
             getStatus: getStatusMock,
@@ -174,5 +185,25 @@ describe("aiDiscoveryCache", () => {
       force: false,
       refreshOpenCodeInventory: true,
     });
+  });
+
+  it("emits project-scoped invalidation events", () => {
+    const events: AiStatusCacheInvalidatedEventDetail[] = [];
+    const listener = (event: Event) => {
+      events.push((event as CustomEvent<AiStatusCacheInvalidatedEventDetail>).detail);
+    };
+    window.addEventListener(AI_STATUS_CACHE_INVALIDATED_EVENT, listener);
+
+    try {
+      invalidateAiDiscoveryCache("/project/a");
+      invalidateAiDiscoveryCache();
+    } finally {
+      window.removeEventListener(AI_STATUS_CACHE_INVALIDATED_EVENT, listener);
+    }
+
+    expect(events).toEqual([
+      { projectRoot: "/project/a", allProjects: false },
+      { projectRoot: null, allProjects: true },
+    ]);
   });
 });

--- a/apps/desktop/src/renderer/lib/aiDiscoveryCache.ts
+++ b/apps/desktop/src/renderer/lib/aiDiscoveryCache.ts
@@ -16,6 +16,12 @@ type ModelsCacheEntry = {
 
 const DEFAULT_AI_STATUS_TTL_MS = 10_000;
 const DEFAULT_MODELS_TTL_MS = 30_000;
+export const AI_STATUS_CACHE_INVALIDATED_EVENT = "ade:ai-status-cache-invalidated";
+
+export type AiStatusCacheInvalidatedEventDetail = {
+  projectRoot: string | null;
+  allProjects: boolean;
+};
 
 const aiStatusCache = new Map<string, StatusCacheEntry>();
 const providerModelsCache = new Map<string, ModelsCacheEntry>();
@@ -26,6 +32,15 @@ function normalizeProjectRoot(projectRoot: string | null | undefined): string {
 
 function statusCacheKey(projectRoot: string | null | undefined): string {
   return normalizeProjectRoot(projectRoot);
+}
+
+function emitAiStatusCacheInvalidated(detail: AiStatusCacheInvalidatedEventDetail): void {
+  if (typeof window === "undefined" || typeof window.dispatchEvent !== "function") return;
+  if (typeof CustomEvent === "undefined") return;
+  window.dispatchEvent(new CustomEvent<AiStatusCacheInvalidatedEventDetail>(
+    AI_STATUS_CACHE_INVALIDATED_EVENT,
+    { detail },
+  ));
 }
 
 function modelsCacheKey(
@@ -181,6 +196,7 @@ export function invalidateAiDiscoveryCache(projectRoot?: string | null): void {
   if (projectRoot == null) {
     aiStatusCache.clear();
     providerModelsCache.clear();
+    emitAiStatusCacheInvalidated({ projectRoot: null, allProjects: true });
     return;
   }
 
@@ -191,4 +207,8 @@ export function invalidateAiDiscoveryCache(projectRoot?: string | null): void {
       providerModelsCache.delete(key);
     }
   }
+  emitAiStatusCacheInvalidated({
+    projectRoot: projectRoot.trim() || null,
+    allProjects: false,
+  });
 }

--- a/apps/desktop/src/renderer/lib/aiProviderStatus.test.ts
+++ b/apps/desktop/src/renderer/lib/aiProviderStatus.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from "vitest";
+import type { AiSettingsStatus } from "../../shared/types";
+import { hasConfiguredAiProvider } from "./aiProviderStatus";
+
+function makeStatus(overrides: Partial<AiSettingsStatus> = {}): AiSettingsStatus {
+  return {
+    mode: "guest",
+    availableProviders: {
+      claude: {
+        binary: {
+          present: false,
+          source: "missing",
+          path: null,
+        },
+        auth: {
+          ready: false,
+          mode: "none",
+          detail: null,
+        },
+      },
+      codex: false,
+      cursor: false,
+      droid: false,
+    },
+    models: {
+      claude: [],
+      codex: [],
+      cursor: [],
+      droid: [],
+    },
+    features: [],
+    ...overrides,
+  };
+}
+
+describe("hasConfiguredAiProvider", () => {
+  it("returns false without a provider status", () => {
+    expect(hasConfiguredAiProvider(null)).toBe(false);
+    expect(hasConfiguredAiProvider(undefined)).toBe(false);
+  });
+
+  it("returns false for an empty provider status", () => {
+    expect(hasConfiguredAiProvider(makeStatus())).toBe(false);
+  });
+
+  it("recognizes all provider connection families", () => {
+    expect(
+      hasConfiguredAiProvider(
+        makeStatus({
+          providerConnections: {
+            claude: {
+              provider: "claude",
+              authAvailable: false,
+              runtimeDetected: false,
+              runtimeAvailable: false,
+              usageAvailable: false,
+              path: null,
+              blocker: null,
+              lastCheckedAt: "2026-05-28T00:00:00.000Z",
+              sources: [],
+            },
+            codex: {
+              provider: "codex",
+              authAvailable: false,
+              runtimeDetected: false,
+              runtimeAvailable: false,
+              usageAvailable: false,
+              path: null,
+              blocker: null,
+              lastCheckedAt: "2026-05-28T00:00:00.000Z",
+              sources: [],
+            },
+            cursor: {
+              provider: "cursor",
+              authAvailable: false,
+              runtimeDetected: false,
+              runtimeAvailable: false,
+              usageAvailable: false,
+              path: null,
+              blocker: null,
+              lastCheckedAt: "2026-05-28T00:00:00.000Z",
+              sources: [],
+            },
+            droid: {
+              provider: "droid",
+              authAvailable: true,
+              runtimeDetected: true,
+              runtimeAvailable: true,
+              usageAvailable: true,
+              path: "/bin/droid",
+              blocker: null,
+              lastCheckedAt: "2026-05-28T00:00:00.000Z",
+              sources: [],
+            },
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("recognizes available provider and model signals even without providerConnections", () => {
+    expect(
+      hasConfiguredAiProvider(
+        makeStatus({
+          availableProviders: {
+            claude: {
+              binary: {
+                present: true,
+                source: "bundled",
+                path: "/bundle/claude",
+              },
+              auth: {
+                ready: false,
+                mode: "none",
+                detail: null,
+              },
+            },
+            codex: true,
+            cursor: false,
+            droid: false,
+          },
+        }),
+      ),
+    ).toBe(true);
+
+    expect(
+      hasConfiguredAiProvider(
+        makeStatus({
+          availableModelIds: ["opencode/openai/gpt-5.4-mini"],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat a bundled Claude binary as configured without auth", () => {
+    expect(
+      hasConfiguredAiProvider(
+        makeStatus({
+          availableProviders: {
+            claude: {
+              binary: {
+                present: true,
+                source: "bundled",
+                path: "/bundle/claude",
+              },
+              auth: {
+                ready: false,
+                mode: "none",
+                detail: null,
+              },
+            },
+            codex: false,
+            cursor: false,
+            droid: false,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("recognizes usable runtime connections", () => {
+    expect(
+      hasConfiguredAiProvider(
+        makeStatus({
+          runtimeConnections: {
+            lmstudio: {
+              provider: "lmstudio",
+              label: "LM Studio",
+              kind: "local",
+              configured: true,
+              authAvailable: true,
+              runtimeDetected: true,
+              runtimeAvailable: true,
+              health: "ready",
+              endpoint: "http://localhost:1234",
+              blocker: null,
+              loadedModelIds: ["lmstudio/local-model"],
+              lastCheckedAt: "2026-05-28T00:00:00.000Z",
+            },
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not recognize unusable provider or runtime connections", () => {
+    expect(
+      hasConfiguredAiProvider(
+        makeStatus({
+          providerConnections: {
+            claude: {
+              provider: "claude",
+              authAvailable: false,
+              runtimeDetected: false,
+              runtimeAvailable: false,
+              usageAvailable: false,
+              path: null,
+              blocker: "Claude is not configured.",
+              lastCheckedAt: "2026-05-28T00:00:00.000Z",
+              sources: [],
+            },
+            codex: {
+              provider: "codex",
+              authAvailable: false,
+              runtimeDetected: false,
+              runtimeAvailable: false,
+              usageAvailable: false,
+              path: null,
+              blocker: "Codex is not configured.",
+              lastCheckedAt: "2026-05-28T00:00:00.000Z",
+              sources: [],
+            },
+            cursor: {
+              provider: "cursor",
+              authAvailable: false,
+              runtimeDetected: false,
+              runtimeAvailable: false,
+              usageAvailable: false,
+              path: null,
+              blocker: "Cursor is not configured.",
+              lastCheckedAt: "2026-05-28T00:00:00.000Z",
+              sources: [],
+            },
+            droid: {
+              provider: "droid",
+              authAvailable: false,
+              runtimeDetected: false,
+              runtimeAvailable: false,
+              usageAvailable: false,
+              path: null,
+              blocker: "Factory Droid is not configured.",
+              lastCheckedAt: "2026-05-28T00:00:00.000Z",
+              sources: [],
+            },
+          },
+          runtimeConnections: {
+            lmstudio: {
+              provider: "lmstudio",
+              label: "LM Studio",
+              kind: "local",
+              configured: true,
+              authAvailable: false,
+              runtimeDetected: true,
+              runtimeAvailable: false,
+              health: "reachable_no_models",
+              endpoint: "http://localhost:1234",
+              blocker: "LM Studio has no loaded models.",
+              loadedModelIds: [],
+              lastCheckedAt: "2026-05-28T00:00:00.000Z",
+            },
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("recognizes usable detected auth and ignores verified failed CLI auth", () => {
+    expect(
+      hasConfiguredAiProvider(
+        makeStatus({
+          detectedAuth: [{ type: "cli-subscription", cli: "claude", authenticated: false, verified: true }],
+        }),
+      ),
+    ).toBe(false);
+
+    expect(
+      hasConfiguredAiProvider(
+        makeStatus({
+          detectedAuth: [{ type: "cli-subscription", cli: "claude", authenticated: false, verified: false }],
+        }),
+      ),
+    ).toBe(true);
+
+    expect(
+      hasConfiguredAiProvider(
+        makeStatus({
+          detectedAuth: [{ type: "api-key", provider: "openai", source: "store", verified: true }],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("recognizes connected OpenCode providers", () => {
+    expect(
+      hasConfiguredAiProvider(
+        makeStatus({
+          opencodeProviders: [
+            { id: "openai", name: "OpenAI", connected: false, modelCount: 1 },
+            { id: "anthropic", name: "Anthropic", connected: true, modelCount: 1 },
+          ],
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/lib/aiProviderStatus.test.ts
+++ b/apps/desktop/src/renderer/lib/aiProviderStatus.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import type { AiSettingsStatus } from "../../shared/types";
-import { hasConfiguredAiProvider } from "./aiProviderStatus";
+import type { AgentChatEventEnvelope, AiSettingsStatus } from "../../shared/types";
+import { hasConfiguredAiProvider, shouldRefreshAiStatusForChatEvent } from "./aiProviderStatus";
 
 function makeStatus(overrides: Partial<AiSettingsStatus> = {}): AiSettingsStatus {
   return {
@@ -30,6 +30,14 @@ function makeStatus(overrides: Partial<AiSettingsStatus> = {}): AiSettingsStatus
     },
     features: [],
     ...overrides,
+  };
+}
+
+function chatEvent(event: AgentChatEventEnvelope["event"]): AgentChatEventEnvelope {
+  return {
+    sessionId: "session-1",
+    timestamp: "2026-05-28T00:00:00.000Z",
+    event,
   };
 }
 
@@ -291,5 +299,38 @@ describe("hasConfiguredAiProvider", () => {
         }),
       ),
     ).toBe(true);
+  });
+
+  it("detects auth-related chat events that should refresh provider status", () => {
+    expect(
+      shouldRefreshAiStatusForChatEvent(chatEvent({
+        type: "system_notice",
+        noticeKind: "auth",
+        message: "Please sign in again.",
+      })),
+    ).toBe(true);
+
+    expect(
+      shouldRefreshAiStatusForChatEvent(chatEvent({
+        type: "error",
+        message: "Invalid API key.",
+      })),
+    ).toBe(true);
+
+    expect(
+      shouldRefreshAiStatusForChatEvent(chatEvent({
+        type: "status",
+        turnStatus: "failed",
+        message: "Authentication failed.",
+      })),
+    ).toBe(true);
+
+    expect(
+      shouldRefreshAiStatusForChatEvent(chatEvent({
+        type: "status",
+        turnStatus: "failed",
+        message: "The command exited with status 1.",
+      })),
+    ).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/lib/aiProviderStatus.ts
+++ b/apps/desktop/src/renderer/lib/aiProviderStatus.ts
@@ -1,0 +1,69 @@
+import type {
+  AiDetectedAuth,
+  AiProviderConnectionStatus,
+  AiRuntimeConnectionStatus,
+  AiSettingsStatus,
+} from "../../shared/types";
+
+function hasUsableDetectedAuth(entry: AiDetectedAuth): boolean {
+  if (entry.type === "cli-subscription") {
+    return entry.authenticated === true || entry.verified !== true;
+  }
+  return true;
+}
+
+function hasUsableProviderConnection(
+  connection: AiProviderConnectionStatus | null | undefined,
+): boolean {
+  return Boolean(connection?.authAvailable || connection?.runtimeAvailable);
+}
+
+function hasUsableRuntimeConnection(
+  connection: AiRuntimeConnectionStatus | null | undefined,
+): boolean {
+  return Boolean(
+    connection?.authAvailable ||
+    connection?.runtimeAvailable ||
+    (connection?.loadedModelIds?.length ?? 0) > 0,
+  );
+}
+
+export function hasConfiguredAiProvider(
+  status: AiSettingsStatus | null | undefined,
+): boolean {
+  if (!status) return false;
+
+  const providerConnections = status.providerConnections;
+  if (
+    hasUsableProviderConnection(providerConnections?.claude) ||
+    hasUsableProviderConnection(providerConnections?.codex) ||
+    hasUsableProviderConnection(providerConnections?.cursor) ||
+    hasUsableProviderConnection(providerConnections?.droid)
+  ) {
+    return true;
+  }
+
+  const availableProviders = status.availableProviders;
+  if (
+    availableProviders?.claude?.auth?.ready === true ||
+    availableProviders?.codex === true ||
+    availableProviders?.cursor === true ||
+    availableProviders?.droid === true
+  ) {
+    return true;
+  }
+
+  if (status.detectedAuth?.some(hasUsableDetectedAuth)) {
+    return true;
+  }
+
+  if (status.availableModelIds?.some((id) => String(id ?? "").trim().length > 0)) {
+    return true;
+  }
+
+  if (Object.values(status.runtimeConnections ?? {}).some(hasUsableRuntimeConnection)) {
+    return true;
+  }
+
+  return Boolean(status.opencodeProviders?.some((provider) => provider.connected));
+}

--- a/apps/desktop/src/renderer/lib/aiProviderStatus.ts
+++ b/apps/desktop/src/renderer/lib/aiProviderStatus.ts
@@ -1,9 +1,27 @@
 import type {
+  AgentChatEventEnvelope,
   AiDetectedAuth,
   AiProviderConnectionStatus,
   AiRuntimeConnectionStatus,
   AiSettingsStatus,
 } from "../../shared/types";
+
+const AUTH_ERROR_SIGNALS = [
+  "invalid authentication credentials",
+  "authentication error",
+  "authentication_error",
+  "authentication failed",
+  "not authenticated",
+  "not logged in",
+  "login required",
+  "sign in",
+  "invalid api key",
+  "api error: 401",
+  "status 401",
+  "claude auth login",
+  "codex login",
+  "/login",
+];
 
 function hasUsableDetectedAuth(entry: AiDetectedAuth): boolean {
   if (entry.type === "cli-subscription") {
@@ -66,4 +84,20 @@ export function hasConfiguredAiProvider(
   }
 
   return Boolean(status.opencodeProviders?.some((provider) => provider.connected));
+}
+
+export function isAuthRelatedChatMessage(message: string | null | undefined): boolean {
+  const normalized = String(message ?? "").trim().toLowerCase();
+  if (!normalized.length) return false;
+  return AUTH_ERROR_SIGNALS.some((signal) => normalized.includes(signal));
+}
+
+export function shouldRefreshAiStatusForChatEvent(envelope: AgentChatEventEnvelope): boolean {
+  const event = envelope.event;
+  if (event.type === "system_notice" && event.noticeKind === "auth") return true;
+  if (event.type === "error") return isAuthRelatedChatMessage(event.message);
+  if (event.type === "status" && event.turnStatus === "failed") {
+    return isAuthRelatedChatMessage(event.message);
+  }
+  return false;
 }

--- a/apps/desktop/src/renderer/state/appStore.test.ts
+++ b/apps/desktop/src/renderer/state/appStore.test.ts
@@ -289,6 +289,46 @@ describe("appStore", () => {
       expect(useAppStore.getState().projectHydrated).toBe(false);
     });
 
+    it("refreshProviderMode auto-elevates when runtime provider signals exist", async () => {
+      useAppStore.setState({
+        project: { rootPath: "/tmp/provider-mode", displayName: "Provider mode", baseRef: "main" } as any,
+        providerMode: "guest",
+      });
+      (window.ade.projectConfig.get as any).mockResolvedValueOnce({ effective: { providerMode: "guest" } });
+      (window.ade.ai.getStatus as any).mockResolvedValueOnce({
+        mode: "guest",
+        availableProviders: {
+          claude: {
+            binary: { present: false, source: "missing", path: null },
+            auth: { ready: false, mode: "none", detail: null },
+          },
+          codex: false,
+          cursor: false,
+          droid: false,
+        },
+        models: { claude: [], codex: [], cursor: [], droid: [] },
+        features: [],
+        runtimeConnections: {
+          openrouter: {
+            provider: "openrouter",
+            label: "OpenRouter",
+            kind: "openrouter",
+            configured: true,
+            authAvailable: true,
+            runtimeDetected: true,
+            runtimeAvailable: true,
+            health: "ready",
+            blocker: null,
+            lastCheckedAt: "2026-05-28T00:00:00.000Z",
+          },
+        },
+      });
+
+      await useAppStore.getState().refreshProviderMode();
+
+      expect(useAppStore.getState().providerMode).toBe("subscription");
+    });
+
     it("setShowWelcome toggles the welcome screen flag", () => {
       useAppStore.getState().setShowWelcome(false);
       expect(useAppStore.getState().showWelcome).toBe(false);

--- a/apps/desktop/src/renderer/state/appStore.ts
+++ b/apps/desktop/src/renderer/state/appStore.ts
@@ -6,6 +6,7 @@ import type { KeybindingsSnapshot, LaneDeleteProgress, LaneListSnapshot, LaneSum
 import { MODEL_REGISTRY, type ModelDescriptor } from "../../shared/modelRegistry";
 import { extractError } from "../lib/format";
 import { getAiStatusCached, invalidateAiDiscoveryCache } from "../lib/aiDiscoveryCache";
+import { hasConfiguredAiProvider } from "../lib/aiProviderStatus";
 import { getProjectConfigCached, invalidateProjectConfigCache } from "../lib/projectConfigCache";
 
 export type ThemeId = "dark" | "light";
@@ -1333,15 +1334,7 @@ const createAppState: StateCreator<AppState> = (set, get) => {
     ]);
     const configMode = snapshot.effective.providerMode ?? "guest";
     // Auto-elevate to subscription if any AI provider is configured
-    const hasProvider =
-      aiStatus != null &&
-      (aiStatus.providerConnections?.claude.authAvailable ||
-        aiStatus.providerConnections?.codex.authAvailable ||
-        aiStatus.providerConnections?.cursor.authAvailable ||
-        aiStatus.availableProviders?.claude?.auth.ready ||
-        aiStatus.availableProviders?.codex ||
-        aiStatus.availableProviders?.cursor ||
-        (aiStatus.detectedAuth != null && aiStatus.detectedAuth.length > 0));
+    const hasProvider = hasConfiguredAiProvider(aiStatus);
     set({ providerMode: configMode === "subscription" || hasProvider ? "subscription" : "guest" });
   },
 


### PR DESCRIPTION
## Summary

Fixes the missing-AI-provider banner so it refreshes when provider settings change, and keeps embedded Lanes draft launches in place instead of navigating away from the lane work pane.

## What changed

- Added a shared `hasConfiguredAiProvider` predicate for AppShell and provider-mode refresh.
- Emitted project-scoped AI discovery cache invalidation events and taught AppShell to force-refresh from them.
- Added a `suppressDraftLaunchNavigation` path for embedded lane work panes.
- Added an active marker to the Work session lane filter button.

## Validation

- `npm --prefix apps/desktop run typecheck`
- `npm --prefix apps/ade-cli run typecheck`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/desktop run lint` (passes with existing warnings)
- `npm --prefix apps/desktop run build`
- `npm --prefix apps/ade-cli run build`
- `npm --prefix apps/web run build`
- Targeted desktop Vitest coverage for AppShell AI status, AI discovery cache, provider status helper, AppStore provider mode, AgentChatPane, WorkStartSurface, and SessionListPane
- Isolated reruns passed for broad-suite flakes seen under heavy parallel local load: cursor model discovery, local runtime connection pool, App.workKeepAlive, ade-cli statusline, appPolling, and stdioRpcDaemon
- `node scripts/validate-docs.mjs`

## Risks

Low. The main behavior change is cache/event-driven refresh timing around provider status, with the shared provider predicate covering the existing and newly recognized provider signals.

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fai-provider-error-banner-9c19c61d num=387 -->
<p>
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://ade.app/logo-dark.svg">
    <img src="https://ade.app/logo-light.svg" height="18" align="left" alt="ADE">
  </picture>
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade.app/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fai-provider-error-banner-9c19c61d&amp;pr=387">ade/ai-provider-error-banner-9c19c61d branch</a>
  &nbsp;·&nbsp; <a href="https://ade.app/open?type=pr&amp;repo=arul28%2FADE&amp;number=387">PR #387</a>
</p>
<!-- /ade:link -->
