### PR TITLE
Optimize ADE terminal runtime load under heavy sessions

### DIFF
--- a/apps/ade-cli/src/jsonrpc.test.ts
+++ b/apps/ade-cli/src/jsonrpc.test.ts
@@ -33,6 +33,12 @@ class MemoryTransport implements JsonRpcTransport {
       callback(Buffer.from(`${line}\n`, "utf8"));
     }
   }
+
+  pushChunk(chunk: string): void {
+    for (const callback of this.callbacks) {
+      callback(Buffer.from(chunk, "utf8"));
+    }
+  }
 }
 
 async function waitForDrain(): Promise<void> {
@@ -48,6 +54,38 @@ function jsonlResponses(transport: MemoryTransport): unknown[] {
 }
 
 describe("startJsonRpcServer", () => {
+  it("waits for more data instead of re-entering drain on partial frames", async () => {
+    const transport = new MemoryTransport();
+    const onError = vi.fn();
+    const handler: JsonRpcHandler = vi.fn(async (request) => ({ ok: true, method: request.method }));
+
+    const stop = startJsonRpcServer(handler, transport, {
+      nonFatal: true,
+      onError,
+    });
+
+    transport.pushChunk('{"jsonrpc":"2.0","id":1,"method":"ping"');
+    await waitForDrain();
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(transport.closed).toBe(false);
+    expect(transport.writes).toEqual([]);
+
+    transport.pushChunk("}\n");
+    await waitForDrain();
+
+    expect(jsonlResponses(transport)).toEqual([
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { ok: true, method: "ping" },
+      },
+    ]);
+
+    stop();
+  });
+
   it("contains notification handler failures without closing the connection", async () => {
     const transport = new MemoryTransport();
     const onError = vi.fn();

--- a/apps/ade-cli/src/jsonrpc.ts
+++ b/apps/ade-cli/src/jsonrpc.ts
@@ -422,9 +422,6 @@ export function startJsonRpcServer(handler: JsonRpcHandler, transport: JsonRpcTr
       closeTransport();
     } finally {
       draining = false;
-      if (!stopped && buffer.length) {
-        void drain();
-      }
     }
   };
 

--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts
@@ -522,6 +522,82 @@ describe("local runtime connection pool", () => {
     pool.dispose();
   });
 
+  it("coalesces matching local runtime action calls while the first call is in flight", async () => {
+    let resolveCall!: (value: unknown) => void;
+    const call = vi.fn(() => new Promise<unknown>((resolve) => {
+      resolveCall = resolve;
+    }));
+    const pool = new LocalRuntimeConnectionPool("1.2.3", {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as never);
+    const rootPath = path.resolve("/repo");
+    (pool as unknown as { projectsByRoot: Map<string, unknown> }).projectsByRoot.set(rootPath, {
+      projectId: "project-1",
+      rootPath,
+      displayName: "repo",
+      addedAt: 1,
+      lastOpenedAt: 1,
+      gitOriginUrl: null,
+    });
+    (pool as unknown as { connection: Promise<unknown> }).connection = Promise.resolve({
+      client: { call },
+      child: null,
+      socketPath: "/tmp/ade.sock",
+    });
+
+    const first = pool.callActionForRoot(rootPath, {
+      domain: "session",
+      action: "list",
+      args: { limit: 500, laneId: "lane-1" },
+    });
+    const second = pool.callActionForRoot(rootPath, {
+      domain: "session",
+      action: "list",
+      args: { laneId: "lane-1", limit: 500 },
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(call).toHaveBeenCalledTimes(1);
+
+    resolveCall({
+      domain: "session",
+      action: "list",
+      result: [{ id: "session-1" }],
+      statusHints: {},
+    });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      {
+        domain: "session",
+        action: "list",
+        result: [{ id: "session-1" }],
+        statusHints: {},
+      },
+      {
+        domain: "session",
+        action: "list",
+        result: [{ id: "session-1" }],
+        statusHints: {},
+      },
+    ]);
+
+    call.mockResolvedValueOnce({
+      domain: "session",
+      action: "list",
+      result: [{ id: "session-1" }],
+      statusHints: {},
+    });
+    await pool.callActionForRoot(rootPath, {
+      domain: "session",
+      action: "list",
+      args: { limit: 500, laneId: "lane-1" },
+    });
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+
   it("terminates an app-owned fallback runtime when disposed", async () => {
     vi.useFakeTimers();
     const child = {

--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
@@ -65,6 +65,43 @@ const LOCAL_RUNTIME_EVENT_POLL_TIMEOUT_MS = 2_000;
 const PLACEHOLDER_RUNTIME_VERSION = "0.0.0";
 const LOCAL_RUNTIME_OUTPUT_LINE_MAX_CHARS = 4_000;
 const LOCAL_RUNTIME_OUTPUT_BUFFER_MAX_CHARS = 16_000;
+const COALESCED_LOCAL_RUNTIME_ACTIONS = new Set([
+  "chat.listSessions",
+  "layout.get",
+  "project_config.get",
+  "pty.resize",
+  "session.list",
+  "tiling_tree.get",
+]);
+
+function stableActionValue(value: unknown): unknown {
+  if (!value || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(stableActionValue);
+  const record = value as Record<string, unknown>;
+  return Object.keys(record)
+    .sort()
+    .reduce<Record<string, unknown>>((next, key) => {
+      const item = record[key];
+      if (item !== undefined) next[key] = stableActionValue(item);
+      return next;
+    }, {});
+}
+
+function coalescedLocalRuntimeActionKey(
+  rootPath: string,
+  request: RemoteRuntimeActionRequest,
+): string | null {
+  const actionKey = `${request.domain}.${request.action}`;
+  if (!COALESCED_LOCAL_RUNTIME_ACTIONS.has(actionKey)) return null;
+  return JSON.stringify({
+    rootPath: path.resolve(rootPath),
+    domain: request.domain,
+    action: request.action,
+    arg: stableActionValue(request.arg),
+    args: stableActionValue(request.args),
+    argsList: stableActionValue(request.argsList),
+  });
+}
 
 export function buildLocalRuntimeServeArgs(
   cliPath: string,
@@ -408,6 +445,7 @@ export class LocalRuntimeConnectionPool {
   private connection: Promise<LocalRuntimeConnection> | null = null;
   private activeClient: RuntimeRpcClient | null = null;
   private ownedRuntimeChild: ChildProcess | null = null;
+  private readonly coalescedActionCalls = new Map<string, Promise<RemoteRuntimeActionResult>>();
   private readonly projectsByRoot = new Map<string, RemoteRuntimeProjectRecord>();
   private serviceInstallStatus: LocalRuntimeStatus["serviceInstall"] = {
     state: "not_attempted",
@@ -628,6 +666,26 @@ export class LocalRuntimeConnectionPool {
   }
 
   async callActionForRoot(
+    rootPath: string,
+    request: RemoteRuntimeActionRequest,
+  ): Promise<RemoteRuntimeActionResult> {
+    const coalescedKey = coalescedLocalRuntimeActionKey(rootPath, request);
+    if (!coalescedKey) return await this.callActionForRootUncoalesced(rootPath, request);
+
+    const existing = this.coalescedActionCalls.get(coalescedKey);
+    if (existing) return await existing;
+
+    const actionCall = this.callActionForRootUncoalesced(rootPath, request)
+      .finally(() => {
+        if (this.coalescedActionCalls.get(coalescedKey) === actionCall) {
+          this.coalescedActionCalls.delete(coalescedKey);
+        }
+      });
+    this.coalescedActionCalls.set(coalescedKey, actionCall);
+    return await actionCall;
+  }
+
+  private async callActionForRootUncoalesced(
     rootPath: string,
     request: RemoteRuntimeActionRequest,
   ): Promise<RemoteRuntimeActionResult> {

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -418,6 +418,22 @@ describe("TerminalView", () => {
     }
   });
 
+  it("shares PTY event subscriptions across terminal runtimes", async () => {
+    render(
+      <>
+        <TerminalView ptyId="pty-shared-a" sessionId="session-shared-a" isActive />
+        <TerminalView ptyId="pty-shared-b" sessionId="session-shared-b" isActive />
+      </>,
+    );
+
+    await flushAnimationFrame();
+
+    expect((window as any).ade.pty.onData).toHaveBeenCalledTimes(1);
+    expect((window as any).ade.pty.onExit).toHaveBeenCalledTimes(1);
+    expect(mockState.ptyDataListeners.size).toBe(1);
+    expect(mockState.ptyExitListeners.size).toBe(1);
+  });
+
   it("uses the DOM renderer on Linux when localStorage is unavailable", async () => {
     vi.useRealTimers();
     const platformDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "platform");
@@ -519,6 +535,97 @@ describe("TerminalView", () => {
       rows: 44,
     });
     expect(terminal?.focus).not.toHaveBeenCalled();
+  });
+
+  it("coalesces PTY resize calls while a previous resize is still in flight", async () => {
+    let resolveResize: (() => void) | null = null;
+    const pendingResize = new Promise<void>((resolve) => {
+      resolveResize = resolve;
+    });
+    const resizeSpy = vi.fn(() => pendingResize);
+    (window as any).ade.pty.resize = resizeSpy;
+
+    render(<TerminalView ptyId="pty-coalesce" sessionId="session-coalesce" isActive />);
+    await flushAnimationFrame();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(resizeSpy).toHaveBeenCalledTimes(1);
+    expect(resizeSpy).toHaveBeenLastCalledWith({
+      ptyId: "pty-coalesce",
+      cols: 120,
+      rows: 40,
+    });
+
+    mockState.nextFitDims = { cols: 130, rows: 41 };
+    triggerResizeObserver();
+    await flushAnimationFrame();
+    mockState.nextFitDims = { cols: 140, rows: 42 };
+    triggerResizeObserver();
+    await flushAnimationFrame();
+
+    expect(resizeSpy).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveResize?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(resizeSpy).toHaveBeenCalledTimes(2);
+    expect(resizeSpy).toHaveBeenLastCalledWith({
+      ptyId: "pty-coalesce",
+      cols: 140,
+      rows: 42,
+    });
+  });
+
+  it("retries a forced PTY resize when the in-flight resize rejects", async () => {
+    let rejectResize: ((reason?: unknown) => void) | null = null;
+    const pendingResize = new Promise<void>((_resolve, reject) => {
+      rejectResize = reject;
+    });
+    const resizeSpy = vi.fn()
+      .mockReturnValueOnce(pendingResize)
+      .mockResolvedValue(undefined);
+    (window as any).ade.pty.resize = resizeSpy;
+
+    render(<TerminalView ptyId="pty-retry-rejected" sessionId="session-retry-rejected" isActive />);
+    await flushAnimationFrame();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(resizeSpy).toHaveBeenCalledTimes(1);
+    expect(resizeSpy).toHaveBeenLastCalledWith({
+      ptyId: "pty-retry-rejected",
+      cols: 120,
+      rows: 40,
+    });
+
+    window.dispatchEvent(new Event(WORK_SURFACE_REVEALED_EVENT));
+    await flushAnimationFrame();
+    await flushAnimationFrame();
+
+    expect(resizeSpy).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      rejectResize?.(new Error("resize failed"));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(resizeSpy).toHaveBeenCalledTimes(2);
+    expect(resizeSpy).toHaveBeenLastCalledWith({
+      ptyId: "pty-retry-rejected",
+      cols: 120,
+      rows: 40,
+    });
   });
 
   it("falls back to the DOM renderer when webgl initialization fails", async () => {

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -12,7 +12,14 @@ import {
 } from "../../state/appStore";
 import { WORK_SURFACE_REVEALED_EVENT } from "./workSurfaceVisibility";
 import { openUrlInAdeBrowser } from "../../lib/openExternal";
-import type { TerminalSerializedSnapshot, TerminalSnapshotCell, TerminalSnapshotRow, TerminalSessionStatus } from "../../../shared/types";
+import type {
+  PtyDataEvent,
+  PtyExitEvent,
+  TerminalSerializedSnapshot,
+  TerminalSnapshotCell,
+  TerminalSnapshotRow,
+  TerminalSessionStatus,
+} from "../../../shared/types";
 
 type XtermTheme = NonNullable<ConstructorParameters<typeof Terminal>[0]>["theme"];
 type TerminalRendererMode = "webgl" | "dom";
@@ -54,7 +61,11 @@ type CachedRuntime = {
   rendererResetInFlight: boolean;
   lastRendererResetAt: number;
   health: TerminalHealthCounters;
-  lastDims: { cols: number; rows: number } | null;
+  lastDims: TerminalDims | null;
+  lastPtyResizeDims: TerminalDims | null;
+  ptyResizeInFlight: boolean;
+  inFlightPtyResizeDims: TerminalDims | null;
+  queuedPtyResizeDims: TerminalDims | null;
   pendingForceResize: boolean;
   fitRafId: number | null;
   settleTimer1: ReturnType<typeof setTimeout> | null;
@@ -121,6 +132,10 @@ const TERMINAL_CTRL_V = "\x16";
 const TERMINAL_LINK_PATTERN = /(?:https?:\/\/[^\s<>"'`]+|(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?(?:\/[^\s<>"'`]*)?)/gi;
 const TERMINAL_MOUSE_TRACKING_EVENT_MODES = new Set([1000, 1002, 1003]);
 const runtimeCache = new Map<string, CachedRuntime>();
+const ptyDataRuntimesByPtyId = new Map<string, Set<CachedRuntime>>();
+const ptyExitRuntimesByPtyId = new Map<string, Set<CachedRuntime>>();
+let sharedPtyDataUnsub: (() => void) | null = null;
+let sharedPtyExitUnsub: (() => void) | null = null;
 
 function terminalRuntimeKey(args: {
   sessionId: string;
@@ -439,6 +454,52 @@ function hasValidDims(dims: TerminalDims | null | undefined): dims is TerminalDi
     && dims.cols >= MIN_VALID_COLS
     && dims.rows >= MIN_VALID_ROWS
   );
+}
+
+function sameDims(left: TerminalDims | null | undefined, right: TerminalDims | null | undefined): boolean {
+  return Boolean(left && right && left.cols === right.cols && left.rows === right.rows);
+}
+
+function flushQueuedPtyResize(runtime: CachedRuntime): void {
+  if (runtime.disposed || runtime.ptyResizeInFlight) return;
+  const next = runtime.queuedPtyResizeDims;
+  runtime.queuedPtyResizeDims = null;
+  if (!next || sameDims(runtime.lastPtyResizeDims, next)) return;
+  sendPtyResize(runtime, next);
+}
+
+function sendPtyResize(runtime: CachedRuntime, dims: TerminalDims): void {
+  if (runtime.disposed) return;
+  runtime.ptyResizeInFlight = true;
+  runtime.inFlightPtyResizeDims = dims;
+  window.ade.pty.resize({ ptyId: runtime.ptyId, cols: dims.cols, rows: dims.rows })
+    .then(
+      () => {
+        runtime.lastPtyResizeDims = dims;
+      },
+      () => {
+        if (sameDims(runtime.lastPtyResizeDims, dims)) {
+          runtime.lastPtyResizeDims = null;
+        }
+      },
+    )
+    .finally(() => {
+      runtime.ptyResizeInFlight = false;
+      runtime.inFlightPtyResizeDims = null;
+      flushQueuedPtyResize(runtime);
+    });
+}
+
+function requestPtyResize(runtime: CachedRuntime, dims: TerminalDims, force = false): void {
+  if (runtime.disposed) return;
+  if (!force && sameDims(runtime.lastPtyResizeDims, dims) && !runtime.ptyResizeInFlight) return;
+  if (runtime.ptyResizeInFlight) {
+    if (force || !sameDims(runtime.inFlightPtyResizeDims, dims)) {
+      runtime.queuedPtyResizeDims = dims;
+    }
+    return;
+  }
+  sendPtyResize(runtime, dims);
 }
 
 function clearTextureAtlas(runtime: CachedRuntime) {
@@ -833,7 +894,7 @@ function doFit(runtime: CachedRuntime, forcePtyResize = false) {
   const prev = previousDims;
   if (!prev || prev.cols !== next.cols || prev.rows !== next.rows || forcePtyResize) {
     runtime.lastDims = next;
-    window.ade.pty.resize({ ptyId: runtime.ptyId, cols: next.cols, rows: next.rows }).catch(() => {});
+    requestPtyResize(runtime, next, forcePtyResize);
   }
 
   // Safety pass for right-edge clipping and stale col counts.
@@ -976,6 +1037,105 @@ function scheduleFrameWriteFlush(runtime: CachedRuntime) {
     return;
   }
   runtime.flushRafId = requestAnimationFrame(flush);
+}
+
+function shouldDeliverPtyEvent(runtime: CachedRuntime, projectRoot: string | undefined): boolean {
+  if (runtime.disposed) return false;
+  return !(projectRoot && runtime.projectRoot && projectRoot !== runtime.projectRoot);
+}
+
+function handleRuntimePtyData(runtime: CachedRuntime, ev: PtyDataEvent) {
+  if (!shouldDeliverPtyEvent(runtime, ev.projectRoot)) return;
+  updateTerminalMouseTrackingModes(runtime, ev.data);
+
+  if (!runtime.hydrationCompleted) {
+    runtime.pendingHydrationChunks.push(ev.data);
+    runtime.pendingHydrationBytes += ev.data.length;
+    while (runtime.pendingHydrationBytes > MAX_PENDING_HYDRATION_BYTES && runtime.pendingHydrationChunks.length > 1) {
+      const dropped = runtime.pendingHydrationChunks.shift();
+      runtime.pendingHydrationBytes -= dropped?.length ?? 0;
+      incrementHealth(runtime, "droppedChunks");
+    }
+    if (hasRenderableTerminalText(ev.data)) {
+      runtime.displayedLiveDataBeforeHydration = true;
+      if (runtime.visible && runtime.active && !terminalDomHasRenderableText(runtime)) {
+        scheduleHydrationBackfill(runtime, {
+          delayMs: HYDRATION_VISIBLE_BLANK_BACKFILL_RETRY_MS,
+          replaceExistingTimer: true,
+          snapshotOnly: true,
+        });
+      }
+    }
+    enqueueFrameWrite(runtime, ev.data);
+    return;
+  }
+
+  enqueueFrameWrite(runtime, ev.data);
+}
+
+function handleRuntimePtyExit(runtime: CachedRuntime, ev: PtyExitEvent) {
+  if (!shouldDeliverPtyEvent(runtime, ev.projectRoot)) return;
+  runtime.exitCode = ev.exitCode ?? 0;
+  notifyRuntime(runtime);
+  if (runtime.refs === 0) {
+    scheduleRuntimeDispose(runtime, EXITED_RUNTIME_KEEPALIVE_MS);
+  }
+}
+
+function removeRuntimePtySubscription(
+  map: Map<string, Set<CachedRuntime>>,
+  runtime: CachedRuntime,
+) {
+  const runtimes = map.get(runtime.ptyId);
+  if (!runtimes) return;
+  runtimes.delete(runtime);
+  if (runtimes.size === 0) map.delete(runtime.ptyId);
+}
+
+function subscribeRuntimePtyData(runtime: CachedRuntime): () => void {
+  let runtimes = ptyDataRuntimesByPtyId.get(runtime.ptyId);
+  if (!runtimes) {
+    runtimes = new Set();
+    ptyDataRuntimesByPtyId.set(runtime.ptyId, runtimes);
+  }
+  runtimes.add(runtime);
+  if (!sharedPtyDataUnsub) {
+    sharedPtyDataUnsub = window.ade.pty.onData((ev) => {
+      const targets = ptyDataRuntimesByPtyId.get(ev.ptyId);
+      if (!targets) return;
+      for (const target of [...targets]) handleRuntimePtyData(target, ev);
+    });
+  }
+  return () => {
+    removeRuntimePtySubscription(ptyDataRuntimesByPtyId, runtime);
+    if (ptyDataRuntimesByPtyId.size === 0 && sharedPtyDataUnsub) {
+      sharedPtyDataUnsub();
+      sharedPtyDataUnsub = null;
+    }
+  };
+}
+
+function subscribeRuntimePtyExit(runtime: CachedRuntime): () => void {
+  let runtimes = ptyExitRuntimesByPtyId.get(runtime.ptyId);
+  if (!runtimes) {
+    runtimes = new Set();
+    ptyExitRuntimesByPtyId.set(runtime.ptyId, runtimes);
+  }
+  runtimes.add(runtime);
+  if (!sharedPtyExitUnsub) {
+    sharedPtyExitUnsub = window.ade.pty.onExit((ev) => {
+      const targets = ptyExitRuntimesByPtyId.get(ev.ptyId);
+      if (!targets) return;
+      for (const target of [...targets]) handleRuntimePtyExit(target, ev);
+    });
+  }
+  return () => {
+    removeRuntimePtySubscription(ptyExitRuntimesByPtyId, runtime);
+    if (ptyExitRuntimesByPtyId.size === 0 && sharedPtyExitUnsub) {
+      sharedPtyExitUnsub();
+      sharedPtyExitUnsub = null;
+    }
+  };
 }
 
 function flushHydrationData(
@@ -1421,6 +1581,10 @@ function createRuntime(args: {
     lastRendererResetAt: 0,
     health: { fitFailures: 0, zeroDimFits: 0, rendererFallbacks: 0, droppedChunks: 0, fitRecoveries: 0 },
     lastDims: null,
+    lastPtyResizeDims: null,
+    ptyResizeInFlight: false,
+    inFlightPtyResizeDims: null,
+    queuedPtyResizeDims: null,
     pendingForceResize: false,
     fitRafId: null,
     settleTimer1: null,
@@ -1575,47 +1739,8 @@ function createRuntime(args: {
     }
   });
 
-  runtime.ptyDataUnsub = window.ade.pty.onData((ev) => {
-    if (runtime.disposed) return;
-    if (ev.projectRoot && runtime.projectRoot && ev.projectRoot !== runtime.projectRoot) return;
-    if (ev.ptyId !== runtime.ptyId) return;
-    updateTerminalMouseTrackingModes(runtime, ev.data);
-
-    if (!runtime.hydrationCompleted) {
-      runtime.pendingHydrationChunks.push(ev.data);
-      runtime.pendingHydrationBytes += ev.data.length;
-      while (runtime.pendingHydrationBytes > MAX_PENDING_HYDRATION_BYTES && runtime.pendingHydrationChunks.length > 1) {
-        const dropped = runtime.pendingHydrationChunks.shift();
-        runtime.pendingHydrationBytes -= dropped?.length ?? 0;
-        incrementHealth(runtime, "droppedChunks");
-      }
-      if (hasRenderableTerminalText(ev.data)) {
-        runtime.displayedLiveDataBeforeHydration = true;
-        if (runtime.visible && runtime.active && !terminalDomHasRenderableText(runtime)) {
-          scheduleHydrationBackfill(runtime, {
-            delayMs: HYDRATION_VISIBLE_BLANK_BACKFILL_RETRY_MS,
-            replaceExistingTimer: true,
-            snapshotOnly: true,
-          });
-        }
-      }
-      enqueueFrameWrite(runtime, ev.data);
-      return;
-    }
-
-    enqueueFrameWrite(runtime, ev.data);
-  });
-
-  runtime.ptyExitUnsub = window.ade.pty.onExit((ev) => {
-    if (runtime.disposed) return;
-    if (ev.projectRoot && runtime.projectRoot && ev.projectRoot !== runtime.projectRoot) return;
-    if (ev.ptyId !== runtime.ptyId) return;
-    runtime.exitCode = ev.exitCode ?? 0;
-    notifyRuntime(runtime);
-    if (runtime.refs === 0) {
-      scheduleRuntimeDispose(runtime, EXITED_RUNTIME_KEEPALIVE_MS);
-    }
-  });
+  runtime.ptyDataUnsub = subscribeRuntimePtyData(runtime);
+  runtime.ptyExitUnsub = subscribeRuntimePtyExit(runtime);
 
   void initRendererChain(runtime);
 


### PR DESCRIPTION
## Summary\n- Coalesce duplicate PTY resize IPC while preserving the latest dimensions and retrying forced resize failures\n- Share renderer PTY data/exit subscriptions across terminal runtimes to reduce per-chunk callback fanout\n- Coalesce exact in-flight high-frequency local runtime actions in the desktop main process\n- Stop ADE CLI JSON-RPC from recursively re-entering drain on partial frames\n\n## Validation\n- npm --prefix apps/desktop run test -- --run src/renderer/components/terminals/TerminalView.test.tsx\n- npm --prefix apps/desktop run test -- --run src/main/services/localRuntime/localRuntimeConnectionPool.test.ts\n- npm --prefix apps/ade-cli run test -- --run src/jsonrpc.test.ts\n- npm --prefix apps/desktop run typecheck\n- npm --prefix apps/ade-cli run typecheck\n- npm --prefix apps/desktop run lint (existing warnings only)\n- npm --prefix apps/desktop run build\n- npm --prefix apps/ade-cli run test\n- npm run test:desktop:sharded

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces four targeted optimizations to reduce redundant IPC and CPU work during heavy terminal sessions: a shared PTY data/exit subscription layer in the renderer, a resize-coalescing state machine per `CachedRuntime`, in-flight action-call deduplication in the local runtime connection pool, and a fix to the JSON-RPC drain loop that previously spun synchronously on partial frames.

- **`jsonrpc.ts`**: Removes the `finally` re-entry that caused an unbounded synchronous spin whenever a partial frame arrived.
- **`TerminalView.tsx`**: Replaces N per-runtime subscriptions with a single shared subscription and adds a proper resize state machine.
- **`localRuntimeConnectionPool.ts`**: Adds a `coalescedActionCalls` map keyed by stable-sorted JSON so identical in-flight read-only calls share a single RPC round-trip.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all four optimizations are independently testable, well-covered by new tests, and touch only the performance path.

The jsonrpc.ts drain fix and action-coalescing layer are small and well-contained. TerminalView.tsx carries more moving parts: a five-field resize state machine whose force-flag behavior (queued forced resize dropped after successful in-flight to same dims) is tested only in the rejection branch.

apps/desktop/src/renderer/components/terminals/TerminalView.tsx — the five-field resize state machine and shared-subscription cleanup path are the highest-complexity additions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/jsonrpc.ts | Removes the recursive self-call inside drain()'s finally block that caused an infinite synchronous spin when the buffer held a partial frame. |
| apps/desktop/src/renderer/components/terminals/TerminalView.tsx | Replaces per-runtime onData/onExit subscriptions with a single shared subscription dispatched via ptyId-keyed maps, and adds a full PTY-resize state machine. |
| apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts | Adds an in-flight coalescing layer for a fixed whitelist of read-only actions using a stable-sorted JSON key. |
| apps/ade-cli/src/jsonrpc.test.ts | Adds a split-chunk test verifying the partial-frame fix. |
| apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx | Adds three new tests covering shared-subscription counting, resize coalescing, and forced-resize retry on rejection. |
| apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts | New coalesce test verifies in-flight deduplication and fresh RPC after settlement. |

</details>

<sub>Reviews (1): Last reviewed commit: ["perf(work): reduce terminal runtime load"](https://github.com/arul28/ade/commit/aec21f64874a9c1d7a4069c5d3b94849a9761459) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34488723)</sub>

<!-- /greptile_comment -->