### PR TITLE
Scope Linear connections to the active project + fix composer model picker

### DIFF
--- a/apps/ade-cli/README.md
+++ b/apps/ade-cli/README.md
@@ -320,7 +320,7 @@ ADE CLI auth is local project access, not a separate cloud login. `ade auth stat
 - Machine socket path, whether the socket exists, and whether this invocation is using `runtime-socket`, `desktop-socket`, or `headless` mode.
 - RPC tool count, ADE action count, and action counts by domain.
 - Git repository readiness and GitHub readiness signals from local remotes, `gh` availability, and token environment presence.
-- Linear readiness from local encrypted token presence or headless environment variables.
+- Linear readiness from the active project's `.ade/secrets` credential store (`linear.token.v1`), the legacy machine-level encrypted token, or headless environment variables.
 - Provider/model readiness from local ADE config, API-key provider references, and provider CLI availability.
 - Computer-use readiness from local platform capabilities.
 - Packaged/PATH status for the `ade` binary and concrete next actions.

--- a/apps/ade-cli/README.md
+++ b/apps/ade-cli/README.md
@@ -320,7 +320,7 @@ ADE CLI auth is local project access, not a separate cloud login. `ade auth stat
 - Machine socket path, whether the socket exists, and whether this invocation is using `runtime-socket`, `desktop-socket`, or `headless` mode.
 - RPC tool count, ADE action count, and action counts by domain.
 - Git repository readiness and GitHub readiness signals from local remotes, `gh` availability, and token environment presence.
-- Linear readiness from the active project's `.ade/secrets` credential store (`linear.token.v1`), the legacy machine-level encrypted token, or headless environment variables.
+- Linear readiness from the active project's `.ade/secrets` credential store (`linear.token.v1`), a legacy project-scoped encrypted token file, or headless environment variables.
 - Provider/model readiness from local ADE config, API-key provider references, and provider CLI availability.
 - Computer-use readiness from local platform capabilities.
 - Packaged/PATH status for the `ade` binary and concrete next actions.

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildAdeCodeArgs,
   buildCliPlan,
+  checkLinearReadiness,
   findProjectRoots,
   formatOutput,
   graphWaitState,
@@ -19,6 +20,7 @@ import {
   summarizeExecution,
   unwrapToolResult,
 } from "./cli";
+import { EncryptedFileCredentialStore } from "./services/credentials/credentialStore";
 
 type ResolveRootsOptions = Parameters<typeof resolveRoots>[0];
 
@@ -989,6 +991,40 @@ describe("ADE CLI", () => {
     expect(output).toContain("cli version");
     expect(output).toContain("service actions");
     expect(output).toContain("Git repository detected");
+  });
+
+  it("detects project-local Linear credentials in doctor readiness", () => {
+    const previousAdeLinearApi = process.env.ADE_LINEAR_API;
+    const previousLinearApiKey = process.env.LINEAR_API_KEY;
+    const previousAdeLinearToken = process.env.ADE_LINEAR_TOKEN;
+    const previousLinearToken = process.env.LINEAR_TOKEN;
+    delete process.env.ADE_LINEAR_API;
+    delete process.env.LINEAR_API_KEY;
+    delete process.env.ADE_LINEAR_TOKEN;
+    delete process.env.LINEAR_TOKEN;
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-cli-linear-readiness-"));
+    const store = new EncryptedFileCredentialStore({
+      secretsDir: path.join(projectRoot, ".ade", "secrets"),
+    });
+    store.setSync("linear.token.v1", "lin_project_token");
+
+    try {
+      const readiness = checkLinearReadiness(projectRoot);
+      expect(readiness.ready).toBe(true);
+      expect(readiness.details).toMatchObject({
+        projectCredentialStoreTokenPresent: true,
+        tokenEnvPresent: false,
+      });
+    } finally {
+      if (previousAdeLinearApi === undefined) delete process.env.ADE_LINEAR_API;
+      else process.env.ADE_LINEAR_API = previousAdeLinearApi;
+      if (previousLinearApiKey === undefined) delete process.env.LINEAR_API_KEY;
+      else process.env.LINEAR_API_KEY = previousLinearApiKey;
+      if (previousAdeLinearToken === undefined) delete process.env.ADE_LINEAR_TOKEN;
+      else process.env.ADE_LINEAR_TOKEN = previousAdeLinearToken;
+      if (previousLinearToken === undefined) delete process.env.LINEAR_TOKEN;
+      else process.env.LINEAR_TOKEN = previousLinearToken;
+    }
   });
 
   it("attempts Windows named-pipe desktop sockets without filesystem existence checks", () => {

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -1016,6 +1016,7 @@ describe("ADE CLI", () => {
         tokenEnvPresent: false,
       });
     } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
       if (previousAdeLinearApi === undefined) delete process.env.ADE_LINEAR_API;
       else process.env.ADE_LINEAR_API = previousAdeLinearApi;
       if (previousLinearApiKey === undefined) delete process.env.LINEAR_API_KEY;

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -48,6 +48,7 @@ import { MACOS_VM_PHASES } from "../../desktop/src/shared/types/macosVm";
 import type { AdeServiceCommand } from "./serviceManager/common";
 import { normalizeAdeRuntimeRole, resolveAdeDefaultRole } from "./runtimeRoles";
 import type { AdeRuntime } from "./bootstrap";
+import { EncryptedFileCredentialStore } from "./services/credentials/credentialStore";
 
 type JsonObject = Record<string, unknown>;
 
@@ -9057,8 +9058,12 @@ function checkGitHubReadiness(projectRoot: string): ReadinessCheck {
 function checkLinearReadiness(projectRoot: string): ReadinessCheck {
   const { resolveAdeLayout } = requireAdeLayout();
   const layout = resolveAdeLayout(projectRoot);
-  const encryptedTokenPresent = fs.existsSync(
+  const legacyEncryptedTokenPresent = fs.existsSync(
     path.join(layout.secretsDir, "linear-token.v1.bin"),
+  );
+  const projectCredentialStoreTokenPresent = hasProjectCredentialStoreValue(
+    layout.secretsDir,
+    "linear.token.v1",
   );
   const envTokenPresent = Boolean(
     process.env.ADE_LINEAR_API?.trim() ||
@@ -9066,7 +9071,10 @@ function checkLinearReadiness(projectRoot: string): ReadinessCheck {
     process.env.ADE_LINEAR_TOKEN?.trim() ||
     process.env.LINEAR_TOKEN?.trim(),
   );
-  const ready = encryptedTokenPresent || envTokenPresent;
+  const ready =
+    legacyEncryptedTokenPresent ||
+    projectCredentialStoreTokenPresent ||
+    envTokenPresent;
   return {
     ready,
     status: ready ? "ready" : "warning",
@@ -9077,10 +9085,33 @@ function checkLinearReadiness(projectRoot: string): ReadinessCheck {
       ? undefined
       : "Configure Linear in ADE desktop or set ADE_LINEAR_API/LINEAR_API_KEY for headless mode.",
     details: {
-      encryptedTokenPresent,
+      encryptedTokenPresent:
+        legacyEncryptedTokenPresent || projectCredentialStoreTokenPresent,
+      legacyEncryptedTokenPresent,
+      projectCredentialStoreTokenPresent,
       tokenEnvPresent: envTokenPresent,
     },
   };
+}
+
+function hasProjectCredentialStoreValue(
+  secretsDir: string,
+  key: string,
+): boolean {
+  const credentialsPath = path.join(secretsDir, "credentials.json.enc");
+  const machineKeyPath = path.join(secretsDir, ".machine-key");
+  if (!fs.existsSync(credentialsPath) || !fs.existsSync(machineKeyPath)) {
+    return false;
+  }
+  try {
+    const credentialStore = new EncryptedFileCredentialStore({
+      credentialsPath,
+      machineKeyPath,
+    });
+    return Boolean(credentialStore.getSync(key)?.trim());
+  } catch {
+    return false;
+  }
 }
 
 function checkProviderReadiness(value: unknown): ReadinessCheck {
@@ -13323,6 +13354,7 @@ if (/(^|[/\\])cli\.(?:ts|js|cjs)$/.test(process.argv[1] ?? "")) {
 export {
   buildCliPlan,
   buildAdeCodeArgs,
+  checkLinearReadiness,
   findProjectRoots,
   formatOutput,
   graphWaitState,

--- a/apps/ade-cli/src/headlessLinearServices.test.ts
+++ b/apps/ade-cli/src/headlessLinearServices.test.ts
@@ -106,25 +106,27 @@ vi.mock("../../desktop/src/main/services/automations/automationSecretService", (
 import { EncryptedFileCredentialStore } from "./services/credentials/credentialStore";
 import { createHeadlessGitHubService, createHeadlessLinearServices } from "./headlessLinearServices";
 
-function createDeps() {
+function createDeps(overrides: Record<string, any> = {}) {
+  const projectRoot = overrides.projectRoot ?? "/tmp/ade-project";
+  const adeDir = overrides.adeDir ?? path.join(projectRoot, ".ade");
   return {
-    projectRoot: "/tmp/ade-project",
-    adeDir: "/tmp/ade-project/.ade",
+    projectRoot,
+    adeDir,
     paths: {
-      adeDir: "/tmp/ade-project/.ade",
-      logsDir: "/tmp/ade-project/.ade/logs",
-      processLogsDir: "/tmp/ade-project/.ade/logs/processes",
-      testLogsDir: "/tmp/ade-project/.ade/logs/tests",
-      transcriptsDir: "/tmp/ade-project/.ade/transcripts",
-      worktreesDir: "/tmp/ade-project/.ade/worktrees",
-      packsDir: "/tmp/ade-project/.ade/packs",
-      dbPath: "/tmp/ade-project/.ade/ade.db",
-      socketPath: "/tmp/ade-project/.ade/ade.sock",
-      cacheDir: "/tmp/ade-project/.ade/cache",
-      artifactsDir: "/tmp/ade-project/.ade/artifacts",
-      chatSessionsDir: "/tmp/ade-project/.ade/chats/sessions",
-      chatTranscriptsDir: "/tmp/ade-project/.ade/chats/transcripts",
-      orchestratorCacheDir: "/tmp/ade-project/.ade/cache/orchestrator",
+      adeDir,
+      logsDir: path.join(adeDir, "logs"),
+      processLogsDir: path.join(adeDir, "logs", "processes"),
+      testLogsDir: path.join(adeDir, "logs", "tests"),
+      transcriptsDir: path.join(adeDir, "transcripts"),
+      worktreesDir: path.join(adeDir, "worktrees"),
+      packsDir: path.join(adeDir, "packs"),
+      dbPath: path.join(adeDir, "ade.db"),
+      socketPath: path.join(adeDir, "ade.sock"),
+      cacheDir: path.join(adeDir, "cache"),
+      artifactsDir: path.join(adeDir, "artifacts"),
+      chatSessionsDir: path.join(adeDir, "chats", "sessions"),
+      chatTranscriptsDir: path.join(adeDir, "chats", "transcripts"),
+      orchestratorCacheDir: path.join(adeDir, "cache", "orchestrator"),
     },
     projectId: "project-1",
     db: {} as any,
@@ -137,6 +139,7 @@ function createDeps() {
     workerBudgetService: {} as any,
     computerUseArtifactBrokerService: {} as any,
     openExternal: async () => {},
+    ...overrides,
   };
 }
 
@@ -503,18 +506,31 @@ describe("headlessLinearServices", () => {
     }
   });
 
-  it("reads Linear and GitHub credentials from the shared machine store", () => {
+  it("reads Linear credentials from the project store and GitHub credentials from the shared machine store", () => {
     const previousAdeHome = process.env.ADE_HOME;
+    const previousAdeLinearApi = process.env.ADE_LINEAR_API;
+    const previousLinearApiKey = process.env.LINEAR_API_KEY;
+    const previousAdeLinearToken = process.env.ADE_LINEAR_TOKEN;
+    const previousLinearToken = process.env.LINEAR_TOKEN;
     process.env.ADE_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "ade-headless-shared-credentials-"));
-    const credentialStore = new EncryptedFileCredentialStore();
-    credentialStore.setSync("linear.token.v1", "lin_shared_token");
-    credentialStore.setSync("github.token.v1", "ghp_shared_token");
+    delete process.env.ADE_LINEAR_API;
+    delete process.env.LINEAR_API_KEY;
+    delete process.env.ADE_LINEAR_TOKEN;
+    delete process.env.LINEAR_TOKEN;
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-headless-linear-project-"));
+    const adeDir = path.join(projectRoot, ".ade");
+    const projectCredentialStore = new EncryptedFileCredentialStore({
+      secretsDir: path.join(adeDir, "secrets"),
+    });
+    projectCredentialStore.setSync("linear.token.v1", "lin_project_token");
+    const machineCredentialStore = new EncryptedFileCredentialStore();
+    machineCredentialStore.setSync("github.token.v1", "ghp_shared_token");
 
-    const services = createHeadlessLinearServices(createDeps());
+    const services = createHeadlessLinearServices(createDeps({ projectRoot, adeDir }));
     try {
-      expect(services.linearCredentialService.getTokenOrThrow()).toBe("lin_shared_token");
+      expect(services.linearCredentialService.getTokenOrThrow()).toBe("lin_project_token");
       const githubService = createHeadlessGitHubService(
-        "/tmp/ade-project",
+        projectRoot,
         { debug() {}, info() {}, warn() {}, error() {} } as any,
       );
       expect(githubService.getTokenOrThrow()).toBe("ghp_shared_token");
@@ -525,6 +541,65 @@ describe("headlessLinearServices", () => {
       } else {
         process.env.ADE_HOME = previousAdeHome;
       }
+      if (previousAdeLinearApi == null) delete process.env.ADE_LINEAR_API;
+      else process.env.ADE_LINEAR_API = previousAdeLinearApi;
+      if (previousLinearApiKey == null) delete process.env.LINEAR_API_KEY;
+      else process.env.LINEAR_API_KEY = previousLinearApiKey;
+      if (previousAdeLinearToken == null) delete process.env.ADE_LINEAR_TOKEN;
+      else process.env.ADE_LINEAR_TOKEN = previousAdeLinearToken;
+      if (previousLinearToken == null) delete process.env.LINEAR_TOKEN;
+      else process.env.LINEAR_TOKEN = previousLinearToken;
+    }
+  });
+
+  it("does not share Linear credentials between headless projects", () => {
+    const previousAdeHome = process.env.ADE_HOME;
+    const previousAdeLinearApi = process.env.ADE_LINEAR_API;
+    const previousLinearApiKey = process.env.LINEAR_API_KEY;
+    const previousAdeLinearToken = process.env.ADE_LINEAR_TOKEN;
+    const previousLinearToken = process.env.LINEAR_TOKEN;
+    process.env.ADE_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "ade-headless-linear-isolation-"));
+    delete process.env.ADE_LINEAR_API;
+    delete process.env.LINEAR_API_KEY;
+    delete process.env.ADE_LINEAR_TOKEN;
+    delete process.env.LINEAR_TOKEN;
+    const projectOneRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-linear-project-one-"));
+    const projectTwoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-linear-project-two-"));
+    const projectOneAdeDir = path.join(projectOneRoot, ".ade");
+    const projectTwoAdeDir = path.join(projectTwoRoot, ".ade");
+
+    const projectOneCredentials = new EncryptedFileCredentialStore({
+      secretsDir: path.join(projectOneAdeDir, "secrets"),
+    });
+    projectOneCredentials.setSync("linear.token.v1", "lin_project_one");
+    const machineCredentials = new EncryptedFileCredentialStore();
+    machineCredentials.setSync("linear.token.v1", "lin_machine_should_not_bleed");
+
+    const projectOne = createHeadlessLinearServices(createDeps({
+      projectRoot: projectOneRoot,
+      adeDir: projectOneAdeDir,
+    }));
+    const projectTwo = createHeadlessLinearServices(createDeps({
+      projectRoot: projectTwoRoot,
+      adeDir: projectTwoAdeDir,
+    }));
+    try {
+      expect(projectOne.linearCredentialService.getTokenOrThrow()).toBe("lin_project_one");
+      expect(projectTwo.linearCredentialService.getStatus().tokenStored).toBe(false);
+      expect(() => projectTwo.linearCredentialService.getTokenOrThrow()).toThrow("Linear token missing");
+    } finally {
+      projectOne.dispose();
+      projectTwo.dispose();
+      if (previousAdeHome == null) delete process.env.ADE_HOME;
+      else process.env.ADE_HOME = previousAdeHome;
+      if (previousAdeLinearApi == null) delete process.env.ADE_LINEAR_API;
+      else process.env.ADE_LINEAR_API = previousAdeLinearApi;
+      if (previousLinearApiKey == null) delete process.env.LINEAR_API_KEY;
+      else process.env.LINEAR_API_KEY = previousLinearApiKey;
+      if (previousAdeLinearToken == null) delete process.env.ADE_LINEAR_TOKEN;
+      else process.env.ADE_LINEAR_TOKEN = previousAdeLinearToken;
+      if (previousLinearToken == null) delete process.env.LINEAR_TOKEN;
+      else process.env.LINEAR_TOKEN = previousLinearToken;
     }
   });
 

--- a/apps/ade-cli/src/headlessLinearServices.ts
+++ b/apps/ade-cli/src/headlessLinearServices.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
+import path from "node:path";
 import type { Logger } from "../../desktop/src/main/services/logging/logger";
 import type { AdeDb } from "../../desktop/src/main/services/state/kvDb";
 import type { createLaneService } from "../../desktop/src/main/services/lanes/laneService";
@@ -1135,8 +1136,12 @@ export function createHeadlessGitHubService(
   return service;
 }
 
-function createHeadlessLinearCredentialService(): HeadlessLinearCredentialService {
-  const credentialStore = new EncryptedFileCredentialStore();
+function createHeadlessLinearCredentialService(args: {
+  adeDir: string;
+}): HeadlessLinearCredentialService {
+  const credentialStore = new EncryptedFileCredentialStore({
+    secretsDir: path.join(args.adeDir, "secrets"),
+  });
   const tokenKey = "linear.token.v1";
   const authModeKey = "linear.authMode.v1";
   const tokenExpiresAtKey = "linear.tokenExpiresAt.v1";
@@ -1638,7 +1643,7 @@ export function createHeadlessLinearServices(
     logger: args.logger,
   });
   const linearCredentialService =
-    createHeadlessLinearCredentialService() as any;
+    createHeadlessLinearCredentialService({ adeDir: args.adeDir }) as any;
   const githubService = createHeadlessGitHubService(
     args.projectRoot,
     args.logger,

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -2704,7 +2704,7 @@ app.whenReady().then(async () => {
       adeDir: adePaths.adeDir,
       logger,
       credentialStore: new EncryptedFileCredentialStore({
-        secretsDir: machineAdeLayout.secretsDir,
+        secretsDir: path.join(adePaths.adeDir, "secrets"),
       }),
     });
     const linearClient = createLinearClient({

--- a/apps/desktop/src/main/services/cto/linearAuth.test.ts
+++ b/apps/desktop/src/main/services/cto/linearAuth.test.ts
@@ -146,7 +146,7 @@ describe("linearCredentialService", () => {
     expect(fs.readFileSync(sentinelPath, "utf8")).toContain("imported");
   });
 
-  it("migrates project-local Linear credentials into the machine credential store once", () => {
+  it("migrates legacy project-local Linear credentials into the injected credential store once", () => {
     const previousAdeLinearApi = process.env.ADE_LINEAR_API;
     const previousLinearApiKey = process.env.LINEAR_API_KEY;
     const previousAdeLinearToken = process.env.ADE_LINEAR_TOKEN;
@@ -200,6 +200,8 @@ describe("linearCredentialService", () => {
         clientId: "client-project",
         clientSecret: "secret-project",
       });
+      expect(fs.existsSync(path.join(secretsDir, "linear-token.v1.bin"))).toBe(false);
+      expect(fs.existsSync(path.join(secretsDir, "linear-oauth-client.v1.bin"))).toBe(false);
 
       service.clearToken();
       const reloaded = createLinearCredentialService({

--- a/apps/desktop/src/main/services/cto/linearCredentialService.ts
+++ b/apps/desktop/src/main/services/cto/linearCredentialService.ts
@@ -73,6 +73,18 @@ export function createLinearCredentialService(args: LinearCredentialServiceArgs)
   const importSentinelPath = path.join(secretsDir, IMPORT_SENTINEL);
   const credentialStore = args.credentialStore ?? null;
 
+  const unlinkIfExists = (filePath: string): void => {
+    try {
+      fs.unlinkSync(filePath);
+    } catch (error: unknown) {
+      if (isEnoentError(error)) return;
+      args.logger?.warn("linear_sync.legacy_credential_cleanup_failed", {
+        filePath,
+        error: getErrorMessage(error),
+      });
+    }
+  };
+
   const readEnvToken = (): string | null => {
     for (const key of ENV_LINEAR_TOKEN_KEYS) {
       const value = (process.env[key] ?? "").trim();
@@ -278,6 +290,7 @@ export function createLinearCredentialService(args: LinearCredentialServiceArgs)
       const legacyToken = readEncryptedToken();
       if (legacyToken) {
         persistMachineToken(legacyToken);
+        unlinkIfExists(tokenPath);
       } else {
         const legacyPath = path.join(args.adeDir, "local.secret.yaml");
         try {
@@ -299,7 +312,10 @@ export function createLinearCredentialService(args: LinearCredentialServiceArgs)
 
     if (!readMachineOAuthClientCredentials()) {
       const legacyOAuth = readStoredOAuthClientCredentials() ?? readOAuthConfigFileCredentials();
-      if (legacyOAuth) persistMachineOAuthClientCredentials(legacyOAuth);
+      if (legacyOAuth) {
+        persistMachineOAuthClientCredentials(legacyOAuth);
+        unlinkIfExists(oauthClientPath);
+      }
     }
 
     if (!hadEncryptedLegacyStore || safeStorage.isEncryptionAvailable()) {
@@ -310,6 +326,7 @@ export function createLinearCredentialService(args: LinearCredentialServiceArgs)
   const persistToken = (record: StoredLinearToken | null): void => {
     if (credentialStore) {
       persistMachineToken(record);
+      unlinkIfExists(tokenPath);
       return;
     }
 
@@ -345,6 +362,7 @@ export function createLinearCredentialService(args: LinearCredentialServiceArgs)
   const persistOAuthClientCredentials = (record: LinearOAuthClientCredentials | null): void => {
     if (credentialStore) {
       persistMachineOAuthClientCredentials(record);
+      unlinkIfExists(oauthClientPath);
       return;
     }
 

--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -100,12 +100,30 @@ const MOCK_LINEAR_CONNECTION = {
   connected: true,
   viewerId: "mock-linear-user",
   viewerName: "Mock Linear User",
+  organizationId: "mock-linear-org",
+  organizationName: "ADE",
+  organizationUrlKey: "ade",
+  organizationLogoUrl: null,
+  projectCount: 1,
+  projectPreview: ["Desktop polish"],
   checkedAt: now,
   authMode: "manual" as const,
   oauthAvailable: true,
   tokenExpiresAt: null,
   message: null,
 };
+
+const MOCK_LINEAR_PROJECTS = [
+  {
+    id: "mock-linear-project",
+    name: "Desktop polish",
+    slug: "desktop-polish",
+    teamName: "ADE",
+    teamKey: "ADE",
+    icon: null,
+    color: "#5E6AD2",
+  },
+];
 
 const MOCK_LINEAR_ISSUES = [
   {
@@ -181,15 +199,7 @@ const MOCK_LINEAR_ISSUES = [
 ];
 
 const MOCK_LINEAR_PICKER = {
-  projects: [
-    {
-      id: "mock-linear-project",
-      name: "Desktop polish",
-      slug: "desktop-polish",
-      teamName: "ADE",
-      teamKey: "ADE",
-    },
-  ],
+  projects: MOCK_LINEAR_PROJECTS,
   users: [
     {
       id: "mock-linear-user",
@@ -4784,7 +4794,7 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
         reconciliation: { enabled: true, intervalSec: 30, lastRunAt: null },
       }),
       onLinearWorkflowEvent: noop,
-      getLinearProjects: resolvedArg([]),
+      getLinearProjects: resolvedArg(MOCK_LINEAR_PROJECTS),
       getLinearQuickView: resolvedArg({
         connection: MOCK_LINEAR_CONNECTION,
         organization: {
@@ -4867,6 +4877,28 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
         pageInfo: { hasNextPage: false, endCursor: null },
       }),
       getLinearConnectionStatus: resolvedArg(MOCK_LINEAR_CONNECTION),
+      setLinearToken: resolvedArg({
+        ...MOCK_LINEAR_CONNECTION,
+        authMode: "manual" as const,
+        message: "Linear token accepted in browser preview.",
+      }),
+      clearLinearToken: resolvedArg({
+        tokenStored: false,
+        connected: false,
+        viewerId: null,
+        viewerName: null,
+        organizationId: null,
+        organizationName: null,
+        organizationUrlKey: null,
+        organizationLogoUrl: null,
+        projectCount: 0,
+        projectPreview: [],
+        checkedAt: now,
+        authMode: null,
+        oauthAvailable: true,
+        tokenExpiresAt: null,
+        message: "Linear disconnected in browser preview.",
+      }),
       setLinearOAuthClient: resolvedArg({
         tokenStored: false,
         connected: false,

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -454,6 +454,10 @@ function composerPermissionLabel(label: string): string {
 }
 
 const COMPOSER_TOOLBAR_PICKER_TRIGGER = "max-w-[min(9.5rem,34vw)] shrink min-w-0";
+// The model name is the priority control: it keeps a readable floor and only
+// shrinks after the permission/fast labels collapse and the reasoning picker
+// has given up its width.
+const COMPOSER_MODEL_TRIGGER = "max-w-[min(9.5rem,34vw)] shrink min-w-[4.5rem]";
 
 const COMPOSER_PERMISSION_TRIGGER_CLASS = cn(
   "ade-chat-composer-permission-trigger",
@@ -3554,7 +3558,7 @@ export function AgentChatComposer({
                   allowCliOnlyModels={allowCliOnlyModels}
                   disabled={parallelLaunchBusy}
                   compact
-                  triggerClassName={COMPOSER_TOOLBAR_PICKER_TRIGGER}
+                  triggerClassName={COMPOSER_MODEL_TRIGGER}
                   fastModeActive={fastModeActive}
                   fastModeSupported={fastModeSupported}
                   onFastModeToggle={(next) => onParallelSlotCodexFastModeChange?.(parallelConfiguringIndex, next)}
@@ -3583,7 +3587,7 @@ export function AgentChatComposer({
                   allowCliOnlyModels={allowCliOnlyModels}
                   disabled={modelSelectionLocked}
                   compact
-                  triggerClassName={COMPOSER_TOOLBAR_PICKER_TRIGGER}
+                  triggerClassName={COMPOSER_MODEL_TRIGGER}
                   fastModeActive={fastModeActive}
                   fastModeSupported={fastModeSupported}
                   onFastModeToggle={onCodexFastModeChange}

--- a/apps/desktop/src/renderer/index.css
+++ b/apps/desktop/src/renderer/index.css
@@ -3421,7 +3421,7 @@ button:active, [role="button"]:active {
   container-name: chat-composer;
 }
 
-@container chat-composer (max-width: 400px) {
+@container chat-composer (max-width: 560px) {
   .ade-chat-composer-permission-trigger {
     min-width: 1.5rem;
     justify-content: center;
@@ -3510,7 +3510,7 @@ button:active, [role="button"]:active {
   }
 }
 
-@container chat-composer (min-width: 401px) {
+@container chat-composer (min-width: 561px) {
   .ade-chat-composer-fast-toggle {
     min-width: 2.75rem;
     padding-inline: 0.375rem;

--- a/cto/linear.mdx
+++ b/cto/linear.mdx
@@ -18,7 +18,7 @@ The CTO owns ADE's bidirectional Linear integration. It monitors your workspace 
   </Step>
   <Step title="Authenticate">
     Click **Connect Linear**. Choose between:
-    - **OAuth** (recommended) — authorizes ADE to access Linear on your behalf with scoped permissions. ADE stores the token securely using Electron's safeStorage.
+    - **OAuth** (recommended) — authorizes ADE to access Linear on your behalf with scoped permissions. ADE stores the token under the active project's `.ade/secrets`, so separate ADE projects can connect to separate Linear workspaces.
     - **Personal Access Token** — paste a token from your Linear account settings (`Settings > API > Personal API keys`)
   </Step>
   <Step title="Select projects and teams">

--- a/docs/features/cto/README.md
+++ b/docs/features/cto/README.md
@@ -15,7 +15,7 @@ The runtime is organized around one contract: the CTO tab should be usable as a 
 - `workerRevisionService.ts` — worker config revision history.
 - `workerTaskSessionService.ts` — task-scoped worker sessions.
 - `workerAdapterRuntimeService.ts` — adapter lifecycle for the three supported worker adapters: `claude-local`, `codex-local`, and `process`.
-- `linearCredentialService.ts` — personal API key + OAuth client + auth-mode storage and token status. Backed by the per-machine credential store (`~/.ade/secrets/`) when injected, with a one-time migration from the legacy project-scoped files. See [Linear integration](../linear-integration/README.md#source-file-map).
+- `linearCredentialService.ts` — personal API key + OAuth client + auth-mode storage and token status. Backed by the active project's `.ade/secrets` store so separate ADE projects can use separate Linear workspaces, with a one-time migration from the legacy project-scoped files. See [Linear integration](../linear-integration/README.md#source-file-map).
 - `linearOAuthService.ts` — PKCE loopback OAuth flow on port 19836.
 - `linearClient.ts` — Linear GraphQL client (shared by desktop and headless ADE CLI). The shared issue fragment fetches cycle metadata, label colors, and enriched child-issue fields. `fetchIssueComments(issueId)` returns the comment thread for the issue detail pane.
 - `linearIssueTracker.ts` / `issueTracker.ts` — Linear issue cache, change detection, and `fetchIssueComments` forwarding.

--- a/docs/features/cto/linear-integration.md
+++ b/docs/features/cto/linear-integration.md
@@ -6,7 +6,7 @@ CTO owns Linear intake, routing, dispatch, sync, and closeout. Automations never
 
 ### Services (apps/desktop/src/main/services/cto/)
 
-- `linearCredentialService.ts` — token store (personal API key). Exposes `getStatus`, `getTokenOrThrow`, `setToken`, `clearToken`.
+- `linearCredentialService.ts` — project-local token store (personal API key) under the active project's `.ade/secrets`. Exposes `getStatus`, `getTokenOrThrow`, `setToken`, `clearToken`.
 - `linearOAuthService.ts` — PKCE loopback OAuth on port 19836. `SESSION_TTL_MS = 10 min`. Authorize at `linear.app/oauth/authorize`, exchange at `api.linear.app/oauth/token`.
 - `linearClient.ts` — GraphQL client; used by both desktop and headless ADE CLI. Surfaces `getQuickView(connection)` (workspace + active project counters consumed by the top-bar quick view), `searchIssues(query)` (paginated issue search consumed by `LinearIssuePicker` and `LinearIssueBrowser`), and `fetchIssueComments(issueId)` (comment thread for the issue detail pane) alongside the existing `fetchIssueById` / `listProjects` / `listLabels` / `listUsers` calls. The shared GraphQL issue fragment also fetches cycle metadata (`id`, `name`, `startsAt`, `endsAt`), label colors, and richer child-issue data (`identifier`, `title`, full state).
 - `linearIssueTracker.ts` + `issueTracker.ts` — issue cache, snapshot hashes, change detection. The `IssueTracker` interface includes the matching `getQuickView(connection)`, `searchIssues(query)`, and `fetchIssueComments(issueId)` shims so renderer-side surfaces have the same entry point as the dispatcher.
@@ -54,7 +54,7 @@ Detailed wiring lives in [`../linear-integration/README.md`](../linear-integrati
 
 Two connection paths:
 
-1. **Personal API key** (recommended first path). Entered in the Connection panel; validated by a `viewer` query; stored via `linearCredentialService`.
+1. **Personal API key** (recommended first path). Entered in the Connection panel; validated by a `viewer` query; stored via `linearCredentialService` in the active project's `.ade/secrets`.
 2. **OAuth** (when `.ade/secrets/linear-oauth.v1.json` is configured). `startOAuth()` boots an ephemeral HTTP server on 19836 with a PKCE pair, returns the authorize URL for the renderer to open, and finalizes on callback. Sessions auto-expire after 10 minutes.
 
 The renderer's `LinearConnectionPanel` auto-surfaces whichever path is available. The CTO onboarding recommends the API key as faster; OAuth is available for customers that prefer SSO.

--- a/docs/features/linear-integration/README.md
+++ b/docs/features/linear-integration/README.md
@@ -168,7 +168,7 @@ queued
 Core Linear services on desktop
 (`apps/desktop/src/main/services/cto/`):
 
-- `linearCredentialService.ts` — token + OAuth client + auth mode storage and health check. Reads/writes through the per-machine `SyncCredentialStore` (`~/.ade/secrets/`) when one is passed in, with a one-time migration from the legacy project-local `linear-token.v1.bin` / `linear-oauth-client.v1.bin` files; falls back to the legacy project-scoped path when the machine store is unavailable. Environment overrides (`ADE_LINEAR_API`, `LINEAR_API_KEY`, `ADE_LINEAR_TOKEN`, `LINEAR_TOKEN`) still take precedence.
+- `linearCredentialService.ts` — token + OAuth client + auth mode storage and health check. Reads/writes through the active project's `.ade/secrets` credential store, with a one-time migration from the legacy project-local `linear-token.v1.bin` / `linear-oauth-client.v1.bin` files. Environment overrides (`ADE_LINEAR_API`, `LINEAR_API_KEY`, `ADE_LINEAR_TOKEN`, `LINEAR_TOKEN`) still take precedence when no project-local token is stored.
 - `linearOAuthService.ts` — OAuth authorization flow
 - `linearClient.ts` — GraphQL client wrapper. The shared issue fragment includes cycle metadata, label colors, and enriched child-issue fields. `fetchIssueComments(issueId)` returns the comment thread for the issue detail pane.
 - `linearIssueTracker.ts` — normalization into `NormalizedLinearIssue`, plus `fetchIssueComments` forwarding

--- a/docs/features/onboarding-and-settings/README.md
+++ b/docs/features/onboarding-and-settings/README.md
@@ -426,7 +426,8 @@ the consolidation that collapsed many top-level tabs into sub-sections.
 | Context doc prefs | `AdeDb` via `context:docs:preferences.v1` | provider, model, reasoning effort, event triggers |
 | Terminal preferences | `localStorage` under `ade.terminalPreferences.v1` | font size, line height, scrollback, font family |
 | Work view state | `localStorage` under `ade.workViewState.v1` | per-project and per-lane-project slices |
-| GitHub/Linear credentials | Keychain via `safeStorage` | tokens encrypted, banner on decryption failure |
+| GitHub credentials | Keychain via `safeStorage` | tokens encrypted, banner on decryption failure |
+| Linear credentials | Active project's `.ade/secrets` | project-local token/OAuth state, encrypted on disk |
 
 ## AI mode and provider behavior
 

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -573,8 +573,9 @@ project scope split.
   during which new pairing requests are rejected without touching the
   PIN store.
 - **Secrets never sync.** `.ade/local.secret.yaml` (provider API keys,
-  ADE CLI configs) is per-machine. Linear tokens, GitHub tokens,
-  and AI provider tokens stay on the host.
+  ADE CLI configs) is per-machine. Linear tokens stay in the active
+  project's host-local `.ade/secrets`; GitHub tokens and AI provider
+  tokens stay on the host.
 - **Transport**: WebSocket auth via PIN / paired secret / bootstrap
   token on every connection. Tailscale WireGuard encryption applies
   when over tailnet; LAN connections rely on pairing token validation.


### PR DESCRIPTION
## Summary
- Migrate Linear credentials from the legacy machine-level encrypted store (`linear-token.v1.bin`) to a project-scoped credential store (`.ade/secrets/credentials.json.enc`, keyed `linear.token.v1`), clean up legacy files after migration, and surface org/project metadata on connection status.
- Headless CLI and `ade doctor` Linear readiness now read the project-scoped store with a legacy fallback (env token still honored).
- Fix the composer model picker so it keeps a readable floor as the composer narrows: permission collapses to a dot, fast mode to a bolt, instead of clipping the model name.

## Test plan
- [x] typecheck (desktop, ade-cli, web) — clean
- [x] desktop lint — 0 errors
- [x] builds (desktop, ade-cli, web) — succeed
- [x] scoped tests: ade-cli `cli` + `headlessLinearServices` (188), desktop `linearAuth` + chat composer (476)
- [ ] CI full sharded suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fproject-scoped-linear-connections-a45c3653 num=392 -->
<p>
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://ade.app/logo-dark.svg">
    <img src="https://ade.app/logo-light.svg" height="18" align="left" alt="ADE">
  </picture>
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade.app/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fproject-scoped-linear-connections-a45c3653&amp;pr=392">ade/project-scoped-linear-connections-a45c3653 branch</a>
  &nbsp;·&nbsp; <a href="https://ade.app/open?type=pr&amp;repo=arul28%2FADE&amp;number=392">PR #392</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linear credentials now stored per-project in `.ade/secrets` for improved isolation
  * Enhanced credential detection for "doctor readiness" checks

* **Bug Fixes**
  * Legacy Linear credential files automatically cleaned up during migration

* **Documentation**
  * Updated Linear authentication documentation to reflect project-local credential storage

* **Style**
  * Improved chat composer responsive layout for various container sizes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR scopes Linear credentials from a shared machine-level store to the active project's `.ade/secrets` directory, allowing separate ADE projects to connect to separate Linear workspaces. It also fixes the composer model picker to maintain a readable minimum width as the container narrows.

- **Credential migration**: `linearCredentialService` and the headless CLI both now point their `EncryptedFileCredentialStore` at `<project>/.ade/secrets` instead of `~/.ade/secrets`. `unlinkIfExists` calls are added to `persistToken`, `persistOAuthClientCredentials`, and the migration routine to clean up legacy `.bin` files on write.
- **Doctor readiness**: `checkLinearReadiness` in the CLI now checks the project-scoped JSON store in addition to legacy binary files and env vars, with `hasProjectCredentialStoreValue` guarded by existence checks to avoid decryption on fresh directories.
- **Composer UI**: A new `COMPOSER_MODEL_TRIGGER` constant adds `min-w-[4.5rem]` so the model name keeps a readable floor, and the container-query breakpoint for icon-only permission/fast labels is raised from 400 px to 560 px.

<h3>Confidence Score: 3/5</h3>

Existing users whose Linear credentials were already in the machine-level store will silently lose their connection with no migration path in the new code.

The credential store destination changes from machine-level (~/.ade/secrets) to project-level (.ade/secrets) but the migration function only reads from project-scoped .bin files. Any user who connected Linear while on the previous build will find both the .bin files gone and the new project store empty, appearing disconnected with no warning or recovery path.

apps/desktop/src/main/services/cto/linearCredentialService.ts — the migration function needs a read-from-old-machine-store step; apps/desktop/src/main/main.ts — the credentialStore path change is what triggers the gap.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/cto/linearCredentialService.ts | Adds unlinkIfExists helper and calls it on every persistToken/persistOAuthClientCredentials write and during migration to clean up legacy .bin files; migration logic is otherwise unchanged but the credentialStore destination is now project-scoped — missing a read-from-old-machine-store step for users who were already on the intermediate machine-level store. |
| apps/desktop/src/main/main.ts | Changes linearCredentialService credential store from machineAdeLayout.secretsDir to path.join(adePaths.adeDir, 'secrets'), scoping Linear credentials to the active project; other services (GitHub, API keys) still correctly use the machine-level store. |
| apps/ade-cli/src/cli.ts | Adds hasProjectCredentialStoreValue helper and exports checkLinearReadiness; checkLinearReadiness now checks both legacy binary and new project-scoped JSON store, returning enriched details. String paths inside hasProjectCredentialStoreValue are hardcoded (noted in a previous thread). |
| apps/ade-cli/src/headlessLinearServices.test.ts | Updates the existing credentials test and adds two new isolation tests; temp directories created by mkdtempSync in the new tests are not cleaned up in their finally blocks. |
| apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx | Introduces COMPOSER_MODEL_TRIGGER with a min-w-[4.5rem] floor so the model name stays readable as the composer narrows, replacing the previous min-w-0 on the shared COMPOSER_TOOLBAR_PICKER_TRIGGER class. |
| apps/desktop/src/renderer/index.css | Widens the container-query breakpoint from 400/401 px to 560/561 px so permission and fast-mode labels collapse to icon-only at a larger composer width. |
| apps/desktop/src/renderer/browserMock.ts | Adds org metadata fields to MOCK_LINEAR_CONNECTION, extracts MOCK_LINEAR_PROJECTS as a named constant, and adds setLinearToken/clearLinearToken mock handlers with the new shape. |
| apps/desktop/src/main/services/cto/linearAuth.test.ts | Adds assertions that legacy .bin files are deleted after migration; clean and correct. |
| apps/ade-cli/src/cli.test.ts | Adds a test verifying checkLinearReadiness detects project-local credentials; correctly creates and removes temp directory in the finally block. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[App startup / linearCredentialService init] --> B{credentialStore injected?}
    B -- No --> C[Legacy path: readEncryptedToken from .bin]
    B -- Yes --> D{Project already migrated?}
    D -- Yes --> E[readMachineToken from project store]
    D -- No --> F{readMachineToken from project store}
    F -- Found --> E
    F -- Not found --> G{linear-token.v1.bin exists?}
    G -- Yes --> H[Migrate .bin → project store\nunlinkIfExists .bin]
    G -- No --> I{local.secret.yaml?}
    I -- Yes --> J[Migrate yaml → project store]
    I -- No --> K[No token found ⚠️]
    H --> L[markProjectMigrated]
    J --> L
    K --> L

    M[OLD machine-level credentials.json.enc\n~/.ade/secrets/] -. never read .-> K

    style M fill:#f99,stroke:#c00
    style K fill:#f99,stroke:#c00
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fcto%2FlinearCredentialService.ts%3A282-323%0A**No%20migration%20path%20from%20the%20old%20machine-level%20credential%20store**%0A%0A%60migrateLegacyProjectCredentialsIfNeeded%60%20only%20looks%20for%20%60linear-token.v1.bin%60%20%28project-level%20binary%29%20and%20then%20falls%20through%20to%20%60local.secret.yaml%60.%20It%20has%20no%20path%20that%20reads%20from%20%60~%2F.ade%2Fsecrets%2Fcredentials.json.enc%60%20%E2%80%94%20the%20machine-level%20%60EncryptedFileCredentialStore%60%20that%20the%20previous%20version%20of%20%60main.ts%60%20was%20writing%20to%20%28%60secretsDir%3A%20machineAdeLayout.secretsDir%60%29.%0A%0AAny%20user%20whose%20credentials%20were%20already%20migrated%20by%20the%20old%20code%20%28project%20%60.bin%60%20%E2%86%92%20machine-level%20JSON%20store%29%20will%20find%20the%20machine-level%20%60credentials.json.enc%60%20unread%2C%20the%20%60.bin%60%20files%20already%20deleted%2C%20and%20the%20new%20project-level%20store%20empty%20%E2%80%94%20silently%20appearing%20disconnected%20after%20upgrading%20to%20this%20build.%20A%20read-and-copy%20step%20from%20the%20old%20machine-level%20store%20%28keyed%20by%20the%20project%20root%20to%20avoid%20cross-project%20bleed%29%20would%20close%20this%20gap.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fade-cli%2Fsrc%2FheadlessLinearServices.test.ts%3A235-267%0A**Temp%20directories%20not%20removed%20in%20new%20tests**%0A%0ABoth%20new%20tests%20%E2%80%94%20%22reads%20Linear%20credentials%20from%20the%20project%20store%E2%80%A6%22%20and%20%22does%20not%20share%20Linear%20credentials%20between%20headless%20projects%22%20%E2%80%94%20create%20%60mkdtemp%60%20directories%20%28%60projectRoot%60%2C%20%60projectOneRoot%60%2C%20%60projectTwoRoot%60%2C%20and%20the%20%60ADE_HOME%60%20temp%20dir%29%20but%20never%20call%20%60fs.rmSync%60%20on%20them%20in%20the%20%60finally%60%20block.%20Since%20credential%20files%20are%20written%20into%20these%20dirs%2C%20they%20accumulate%20encrypted%20data%20in%20%60%2Ftmp%60.%20The%20analogous%20%60cli.test.ts%60%20test%20added%20in%20this%20same%20PR%20does%20clean%20up%20correctly%3B%20the%20same%20pattern%20should%20apply%20here.%0A%0A&repo=arul28%2Fade&pr=392&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src/main/services/cto/linearCredentialService.ts:282-323
**No migration path from the old machine-level credential store**

`migrateLegacyProjectCredentialsIfNeeded` only looks for `linear-token.v1.bin` (project-level binary) and then falls through to `local.secret.yaml`. It has no path that reads from `~/.ade/secrets/credentials.json.enc` — the machine-level `EncryptedFileCredentialStore` that the previous version of `main.ts` was writing to (`secretsDir: machineAdeLayout.secretsDir`).

Any user whose credentials were already migrated by the old code (project `.bin` → machine-level JSON store) will find the machine-level `credentials.json.enc` unread, the `.bin` files already deleted, and the new project-level store empty — silently appearing disconnected after upgrading to this build. A read-and-copy step from the old machine-level store (keyed by the project root to avoid cross-project bleed) would close this gap.

### Issue 2 of 2
apps/ade-cli/src/headlessLinearServices.test.ts:235-267
**Temp directories not removed in new tests**

Both new tests — "reads Linear credentials from the project store…" and "does not share Linear credentials between headless projects" — create `mkdtemp` directories (`projectRoot`, `projectOneRoot`, `projectTwoRoot`, and the `ADE_HOME` temp dir) but never call `fs.rmSync` on them in the `finally` block. Since credential files are written into these dirs, they accumulate encrypted data in `/tmp`. The analogous `cli.test.ts` test added in this same PR does clean up correctly; the same pattern should apply here.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Correct Linear readiness doc and clean u..."](https://github.com/arul28/ade/commit/a2429e1c4e8433826c2cf86ee2389224466b511e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34490126)</sub>

<!-- /greptile_comment -->