### PR TITLE
Mobile App Parity Pass

### DIFF
--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -420,6 +420,10 @@ function fileContentToBlob(filePath: string, content: FileContent): SyncFileBlob
     isBinary: content.isBinary,
     content: content.content,
     languageId: content.languageId,
+    ...(content.previewKind ? { previewKind: content.previewKind } : {}),
+    ...(content.dataUrl ? { dataUrl: content.dataUrl } : {}),
+    ...(typeof content.contentOmitted === "boolean" ? { contentOmitted: content.contentOmitted } : {}),
+    ...(content.omittedReason ? { omittedReason: content.omittedReason } : {}),
   };
 }
 
@@ -433,6 +437,7 @@ function createBlobFromBuffer(filePath: string, buf: Buffer): SyncFileBlob {
     isBinary,
     content: isBinary ? buf.toString("base64") : buf.toString("utf8"),
     languageId: null,
+    previewKind: isBinary ? "binary" : "text",
   };
 }
 

--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
@@ -22,6 +22,7 @@ import type {
   AgentChatInterruptArgs,
   AgentChatUpdateSessionArgs,
   AgentStatus,
+  AgentUpsertInput,
   AddPrCommentArgs,
   AiReviewSummaryArgs,
   ApplyLaneTemplateArgs,
@@ -265,9 +266,29 @@ function asConfidenceThreshold(value: unknown): number | undefined {
   return numeric;
 }
 
+function asNullableTrimmedString(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  if (value === undefined) return undefined;
+  return asTrimmedString(value) ?? undefined;
+}
+
 function asStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.map((entry) => asTrimmedString(entry)).filter((entry): entry is string => Boolean(entry));
+}
+
+function emptyLinearQuickView(connection: Record<string, unknown>) {
+  return {
+    connection,
+    organization: null,
+    viewer: null,
+    projects: [],
+    teams: [],
+    assignedIssues: [],
+    recentIssues: [],
+    fetchedAt: new Date().toISOString(),
+    sdk: { packageName: "@linear/sdk", surfaces: [] },
+  };
 }
 
 function asStringRecord(value: unknown): Record<string, string> | undefined {
@@ -402,6 +423,10 @@ function parseCreateLaneArgs(value: Record<string, unknown>): CreateLaneArgs {
     ...(asTrimmedString(value.description) ? { description: asTrimmedString(value.description)! } : {}),
     ...(asTrimmedString(value.parentLaneId) ? { parentLaneId: asTrimmedString(value.parentLaneId)! } : {}),
     ...(asTrimmedString(value.baseBranch) ? { baseBranch: asTrimmedString(value.baseBranch)! } : {}),
+    ...(asTrimmedString(value.branchName) ? { branchName: asTrimmedString(value.branchName)! } : {}),
+    ...(asTrimmedString(value.startPoint) ? { startPoint: asTrimmedString(value.startPoint)! } : {}),
+    ...(isRecord(value.linearIssue) ? { linearIssue: value.linearIssue as CreateLaneArgs["linearIssue"] } : {}),
+    ...(asTrimmedString(value.runtimePlacement) ? { runtimePlacement: asTrimmedString(value.runtimePlacement)! as CreateLaneArgs["runtimePlacement"] } : {}),
   };
 }
 
@@ -411,6 +436,10 @@ function parseCreateChildLaneArgs(value: Record<string, unknown>): CreateChildLa
     parentLaneId: requireString(value.parentLaneId, "lanes.createChild requires parentLaneId."),
     ...(asTrimmedString(value.description) ? { description: asTrimmedString(value.description)! } : {}),
     ...(asTrimmedString(value.folder) ? { folder: asTrimmedString(value.folder)! } : {}),
+    ...(asTrimmedString(value.baseBranchRef) ? { baseBranchRef: asTrimmedString(value.baseBranchRef)! } : {}),
+    ...(asTrimmedString(value.branchName) ? { branchName: asTrimmedString(value.branchName)! } : {}),
+    ...(isRecord(value.linearIssue) ? { linearIssue: value.linearIssue as CreateChildLaneArgs["linearIssue"] } : {}),
+    ...(asTrimmedString(value.runtimePlacement) ? { runtimePlacement: asTrimmedString(value.runtimePlacement)! as CreateChildLaneArgs["runtimePlacement"] } : {}),
   };
 }
 
@@ -2418,9 +2447,102 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
       message: status.message,
     };
   });
+  register("cto.getLinearQuickView", { viewerAllowed: true }, async () => {
+    const credentialStatus = args.linearCredentialService?.getStatus() ?? {
+      tokenStored: false,
+      authMode: null,
+      tokenExpiresAt: null,
+      oauthConfigured: false,
+    };
+    const tokenStored = Boolean(credentialStatus.tokenStored);
+    const checkedAt = new Date().toISOString();
+    const linearIssueTracker = args.getLinearIssueTracker?.() ?? null;
+    const unavailableConnection = {
+      tokenStored,
+      connected: false,
+      viewerId: null,
+      viewerName: null,
+      checkedAt,
+      authMode: credentialStatus.authMode,
+      oauthAvailable: credentialStatus.oauthConfigured,
+      tokenExpiresAt: credentialStatus.tokenExpiresAt,
+      message: tokenStored ? "Linear tracker service unavailable." : "Linear token not configured.",
+    };
+    if (!linearIssueTracker || !tokenStored) return emptyLinearQuickView(unavailableConnection);
+    const status = await linearIssueTracker.getConnectionStatus();
+    const connection = {
+      tokenStored,
+      connected: status.connected,
+      viewerId: status.viewerId,
+      viewerName: status.viewerName,
+      organizationId: status.organizationId,
+      organizationName: status.organizationName,
+      organizationUrlKey: status.organizationUrlKey,
+      organizationLogoUrl: status.organizationLogoUrl,
+      checkedAt,
+      authMode: credentialStatus.authMode,
+      oauthAvailable: credentialStatus.oauthConfigured,
+      tokenExpiresAt: credentialStatus.tokenExpiresAt,
+      message: status.message,
+    };
+    if (!status.connected) return emptyLinearQuickView(connection);
+    return linearIssueTracker.getQuickView(connection);
+  });
+  register("cto.getLinearIssuePickerData", { viewerAllowed: true }, async () => {
+    const linearIssueTracker = args.getLinearIssueTracker?.() ?? null;
+    if (!linearIssueTracker) {
+      return { projects: [], users: [], states: [] };
+    }
+    const [projects, users, states] = await Promise.all([
+      linearIssueTracker.listProjects().catch(() => []),
+      linearIssueTracker.listUsers().catch(() => []),
+      linearIssueTracker.listWorkflowStates().catch(() => []),
+    ]);
+    return { projects, users, states };
+  });
+  register("cto.searchLinearIssues", { viewerAllowed: true }, async (payload) => {
+    const linearIssueTracker = args.getLinearIssueTracker?.() ?? null;
+    if (!linearIssueTracker) {
+      return { issues: [], pageInfo: { hasNextPage: false, endCursor: null } };
+    }
+    const projectId = asNullableTrimmedString(payload.projectId);
+    const projectSlug = asNullableTrimmedString(payload.projectSlug);
+    const teamKey = asNullableTrimmedString(payload.teamKey);
+    const stateTypes = asStringArray(payload.stateTypes);
+    const assigneeId = asNullableTrimmedString(payload.assigneeId);
+    const priority = asOptionalNumber(payload.priority);
+    const searchQuery = asNullableTrimmedString(payload.query);
+    const first = asOptionalNumber(payload.first);
+    const after = asNullableTrimmedString(payload.after);
+    const includeArchived = asOptionalBoolean(payload.includeArchived);
+    const query = {
+      ...(projectId !== undefined ? { projectId } : {}),
+      ...(projectSlug !== undefined ? { projectSlug } : {}),
+      ...(teamKey !== undefined ? { teamKey } : {}),
+      ...(stateTypes.length ? { stateTypes } : {}),
+      ...(assigneeId !== undefined ? { assigneeId } : {}),
+      ...(priority !== undefined ? { priority } : {}),
+      ...(searchQuery !== undefined ? { query: searchQuery } : {}),
+      ...(first !== undefined ? { first } : {}),
+      ...(after !== undefined ? { after } : {}),
+      ...(includeArchived !== undefined ? { includeArchived } : {}),
+    };
+    return linearIssueTracker.searchIssues(query);
+  });
+  register("cto.getLinearIssueComments", { viewerAllowed: true }, async (payload) => {
+    const issueId = asTrimmedString(payload.issueId);
+    if (!issueId) return [];
+    const linearIssueTracker = args.getLinearIssueTracker?.() ?? null;
+    if (!linearIssueTracker) return [];
+    return linearIssueTracker.fetchIssueComments(issueId);
+  });
   register("cto.getLinearSyncDashboard", { viewerAllowed: true }, async () => {
     const linearSyncService = requireService(args.getLinearSyncService?.() ?? null, "Linear sync service not available.");
     return linearSyncService.getDashboard();
+  });
+  register("cto.runLinearSyncNow", { viewerAllowed: true, queueable: true }, async () => {
+    const linearSyncService = requireService(args.getLinearSyncService?.() ?? null, "Linear sync service not available.");
+    return linearSyncService.runSyncNow();
   });
   register("cto.listLinearSyncQueue", { viewerAllowed: true }, async () => {
     const linearSyncService = requireService(args.getLinearSyncService?.() ?? null, "Linear sync service not available.");
@@ -2435,6 +2557,18 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
     const ctoStateService = requireService(args.ctoStateService, "CTO state service not available.");
     const patch = isRecord(payload.patch) ? (payload.patch as Partial<CtoIdentity>) : {};
     return ctoStateService.updateIdentity(patch);
+  });
+  register("cto.saveAgent", { viewerAllowed: true, queueable: true }, async (payload) => {
+    const workerRevisionService = requireService(args.workerRevisionService, "Worker revision service not available.");
+    if (!isRecord(payload.agent)) {
+      throw new Error("cto.saveAgent requires agent object.");
+    }
+    const saved = workerRevisionService.saveAgent(
+      payload.agent as AgentUpsertInput,
+      asTrimmedString(payload.actor) ?? "user",
+    );
+    (args.workerHeartbeatService as { syncFromConfig?: () => void } | null | undefined)?.syncFromConfig?.();
+    return saved;
   });
   register("cto.removeAgent", { viewerAllowed: true, queueable: true }, async (payload) => {
     const workerAgentService = requireService(args.workerAgentService, "Worker agent service not available.");

--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
@@ -291,6 +291,19 @@ function emptyLinearQuickView(connection: Record<string, unknown>) {
   };
 }
 
+async function getConnectedLinearIssueTracker(
+  args: SyncRemoteCommandServiceArgs,
+): Promise<ReturnType<typeof createLinearIssueTracker> | null> {
+  const credentialStatus = args.linearCredentialService?.getStatus() ?? {
+    tokenStored: false,
+  };
+  if (!credentialStatus.tokenStored) return null;
+  const linearIssueTracker = args.getLinearIssueTracker?.() ?? null;
+  if (!linearIssueTracker) return null;
+  const status = await linearIssueTracker.getConnectionStatus().catch(() => null);
+  return status?.connected ? linearIssueTracker : null;
+}
+
 function asStringRecord(value: unknown): Record<string, string> | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
   const entries = Object.entries(value)
@@ -2489,7 +2502,7 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
     return linearIssueTracker.getQuickView(connection);
   });
   register("cto.getLinearIssuePickerData", { viewerAllowed: true }, async () => {
-    const linearIssueTracker = args.getLinearIssueTracker?.() ?? null;
+    const linearIssueTracker = await getConnectedLinearIssueTracker(args);
     if (!linearIssueTracker) {
       return { projects: [], users: [], states: [] };
     }
@@ -2501,7 +2514,7 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
     return { projects, users, states };
   });
   register("cto.searchLinearIssues", { viewerAllowed: true }, async (payload) => {
-    const linearIssueTracker = args.getLinearIssueTracker?.() ?? null;
+    const linearIssueTracker = await getConnectedLinearIssueTracker(args);
     if (!linearIssueTracker) {
       return { issues: [], pageInfo: { hasNextPage: false, endCursor: null } };
     }
@@ -2532,7 +2545,7 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
   register("cto.getLinearIssueComments", { viewerAllowed: true }, async (payload) => {
     const issueId = asTrimmedString(payload.issueId);
     if (!issueId) return [];
-    const linearIssueTracker = args.getLinearIssueTracker?.() ?? null;
+    const linearIssueTracker = await getConnectedLinearIssueTracker(args);
     if (!linearIssueTracker) return [];
     return linearIssueTracker.fetchIssueComments(issueId);
   });
@@ -2563,10 +2576,7 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
     if (!isRecord(payload.agent)) {
       throw new Error("cto.saveAgent requires agent object.");
     }
-    const saved = workerRevisionService.saveAgent(
-      payload.agent as AgentUpsertInput,
-      asTrimmedString(payload.actor) ?? "user",
-    );
+    const saved = workerRevisionService.saveAgent(payload.agent as AgentUpsertInput, "user");
     (args.workerHeartbeatService as { syncFromConfig?: () => void } | null | undefined)?.syncFromConfig?.();
     return saved;
   });

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -413,7 +413,7 @@ function buildLinearAutomationDispatch(event: LinearIngressEventRecord): {
   const payload = event.payload ?? null;
   const data = readNested(payload, "data");
   const prevData = readNested(payload, "updatedFrom");
-  const mapping = mapLinearActionToTriggerType(event.action, data, prevData);
+  const mapping = mapLinearActionToTriggerType(event.action ?? null, data, prevData);
 
   const teamName = readString(readNested(data, "team"), "name") ?? readString(data, "teamName");
   const projectName = readString(readNested(data, "project"), "name") ?? readString(data, "projectName");

--- a/apps/desktop/src/main/services/cto/linearIngressService.ts
+++ b/apps/desktop/src/main/services/cto/linearIngressService.ts
@@ -5,6 +5,10 @@ import type {
   LinearIngressSource,
   LinearIngressStatus,
 } from "../../../shared/types";
+import {
+  linearIngressKindFromParts,
+  normalizeLinearIngressEventKind,
+} from "../../../shared/types";
 import type { Logger } from "../logging/logger";
 import type { AdeDb } from "../state/kvDb";
 import { nowIso, safeJsonParse } from "../shared/utils";
@@ -158,10 +162,12 @@ export function createLinearIngressService(args: LinearIngressServiceArgs) {
 
   const persistEvent = (event: Omit<LinearIngressEventRecord, "id" | "createdAt"> & { createdAt?: string }): LinearIngressEventRecord => {
     const createdAt = event.createdAt ?? nowIso();
+    const kindParts = normalizeLinearIngressEventKind(event);
     const record: LinearIngressEventRecord = {
       id: randomUUID(),
       createdAt,
       ...event,
+      ...kindParts,
     };
     try {
       args.db.run(
@@ -177,7 +183,7 @@ export function createLinearIngressService(args: LinearIngressServiceArgs) {
           record.source,
           record.deliveryId,
           record.eventId,
-          record.entityType,
+          record.entityType ?? "issue",
           record.action ?? null,
           record.issueId ?? null,
           record.issueIdentifier ?? null,
@@ -213,6 +219,7 @@ export function createLinearIngressService(args: LinearIngressServiceArgs) {
         eventId: existing.event_id,
         entityType: existing.entity_type,
         action: existing.action,
+        kind: linearIngressKindFromParts(existing.entity_type, existing.action),
         issueId: existing.issue_id,
         issueIdentifier: existing.issue_identifier,
         summary: existing.summary,
@@ -253,6 +260,7 @@ export function createLinearIngressService(args: LinearIngressServiceArgs) {
       eventId: row.event_id,
       entityType: row.entity_type,
       action: row.action,
+      kind: linearIngressKindFromParts(row.entity_type, row.action),
       issueId: row.issue_id,
       issueIdentifier: row.issue_identifier,
       summary: row.summary,
@@ -398,7 +406,8 @@ export function createLinearIngressService(args: LinearIngressServiceArgs) {
         source: "relay",
         deliveryId: typeof entry.deliveryId === "string" ? entry.deliveryId : randomUUID(),
         eventId: typeof entry.eventId === "string" ? entry.eventId : `${Date.now()}-${randomUUID()}`,
-        entityType: typeof entry.entityType === "string" ? entry.entityType : "issue",
+        kind: typeof entry.kind === "string" ? entry.kind : null,
+        entityType: typeof entry.entityType === "string" ? entry.entityType : null,
         action: typeof entry.action === "string" ? entry.action : null,
         issueId: typeof entry.issueId === "string" ? entry.issueId : null,
         issueIdentifier: typeof entry.issueIdentifier === "string" ? entry.issueIdentifier : null,

--- a/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
@@ -2873,10 +2873,10 @@ describe("createSyncRemoteCommandService", () => {
 
       const result = await service.execute(makePayload("cto.saveAgent", {
         agent,
-        actor: "mobile",
+        actor: "system",
       }));
 
-      expect(workerRevisionService.saveAgent).toHaveBeenCalledWith(agent, "mobile");
+      expect(workerRevisionService.saveAgent).toHaveBeenCalledWith(agent, "user");
       expect(workerHeartbeatService.syncFromConfig).toHaveBeenCalledOnce();
       expect(result).toBe(savedWorker);
     });
@@ -2920,6 +2920,29 @@ describe("createSyncRemoteCommandService", () => {
       const dashboard = await service.execute(makePayload("cto.runLinearSyncNow", {}));
       expect(linearSyncService.runSyncNow).toHaveBeenCalledOnce();
       expect(dashboard).toMatchObject({ lastSuccessAt: "2026-05-28T00:00:00.000Z" });
+    });
+
+    it("cto Linear search surfaces return empty data when Linear is disconnected", async () => {
+      linearIssueTracker.getConnectionStatus.mockResolvedValue({
+        connected: false,
+        viewerId: null,
+        viewerName: null,
+        message: "Linear credentials need reconnecting.",
+      });
+
+      const picker = await service.execute(makePayload("cto.getLinearIssuePickerData", {}));
+      expect(picker).toEqual({ projects: [], users: [], states: [] });
+      expect(linearIssueTracker.listProjects).not.toHaveBeenCalled();
+
+      const search = await service.execute(makePayload("cto.searchLinearIssues", {
+        query: "parity",
+      }));
+      expect(search).toEqual({ issues: [], pageInfo: { hasNextPage: false, endCursor: null } });
+      expect(linearIssueTracker.searchIssues).not.toHaveBeenCalled();
+
+      const comments = await service.execute(makePayload("cto.getLinearIssueComments", { issueId: "issue-1" }));
+      expect(comments).toEqual([]);
+      expect(linearIssueTracker.fetchIssueComments).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
@@ -101,6 +101,12 @@ const IOS_REMOTE_COMMAND_ACTIONS = [
   "cto.getRoster",
   "cto.ensureSession",
   "cto.ensureAgentSession",
+  "cto.getLinearQuickView",
+  "cto.getLinearIssuePickerData",
+  "cto.searchLinearIssues",
+  "cto.getLinearIssueComments",
+  "cto.runLinearSyncNow",
+  "cto.saveAgent",
   "prs.createFromLane",
   "prs.createQueue",
   "prs.land",
@@ -495,6 +501,67 @@ function createMockWorkerAgentService() {
   } as any;
 }
 
+function createMockWorkerRevisionService() {
+  return {
+    saveAgent: vi.fn(),
+    listAgentRevisions: vi.fn().mockReturnValue([]),
+    rollbackAgentRevision: vi.fn(),
+  } as any;
+}
+
+function createMockWorkerHeartbeatService() {
+  return {
+    syncFromConfig: vi.fn(),
+    triggerWakeup: vi.fn(),
+    listRuns: vi.fn().mockReturnValue([]),
+    listAgentSessionLogs: vi.fn().mockReturnValue([]),
+  } as any;
+}
+
+function createMockLinearIssueTracker() {
+  return {
+    listProjects: vi.fn().mockResolvedValue([{ id: "project-1", name: "Mobile", slug: "MOB" }]),
+    listUsers: vi.fn().mockResolvedValue([{ id: "user-1", name: "Ada" }]),
+    listWorkflowStates: vi.fn().mockResolvedValue([{ id: "state-1", name: "Todo", type: "todo" }]),
+    searchIssues: vi.fn().mockResolvedValue({
+      issues: [{ id: "issue-1", identifier: "ADE-42", title: "Mobile parity" }],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    }),
+    fetchIssueComments: vi.fn().mockResolvedValue([{ id: "comment-1", body: "Needs mobile", createdAt: "2026-05-28T00:00:00.000Z" }]),
+    getConnectionStatus: vi.fn().mockResolvedValue({ connected: true, viewerId: "user-1", viewerName: "Ada", message: null }),
+    getQuickView: vi.fn().mockResolvedValue({
+      connection: { connected: true, viewerId: "user-1", viewerName: "Ada" },
+      organization: null,
+      viewer: { id: "user-1", name: "Ada", displayName: "Ada", email: null, avatarUrl: null, admin: null, guest: null, url: null },
+      projects: [],
+      teams: [],
+      assignedIssues: [{ id: "issue-1", identifier: "ADE-42", title: "Mobile parity" }],
+      recentIssues: [{ id: "issue-2", identifier: "ADE-43", title: "Recent parity" }],
+      fetchedAt: "2026-05-28T00:00:00.000Z",
+      sdk: { packageName: "@linear/sdk", surfaces: ["assignedIssues", "recentIssues"] },
+    }),
+  } as any;
+}
+
+function createMockLinearSyncService() {
+  return {
+    getDashboard: vi.fn().mockReturnValue({ enabled: true, running: false }),
+    runSyncNow: vi.fn().mockResolvedValue({ enabled: true, running: false, lastSuccessAt: "2026-05-28T00:00:00.000Z" }),
+    listQueue: vi.fn().mockReturnValue([]),
+  } as any;
+}
+
+function createMockLinearCredentialService() {
+  return {
+    getStatus: vi.fn().mockReturnValue({
+      tokenStored: true,
+      authMode: "oauth",
+      tokenExpiresAt: null,
+      oauthConfigured: true,
+    }),
+  } as any;
+}
+
 function createMockProcessService() {
   return {
     listDefinitions: vi.fn().mockReturnValue([
@@ -533,6 +600,11 @@ describe("createSyncRemoteCommandService", () => {
   let diffService: ReturnType<typeof createMockDiffService>;
   let agentChatService: ReturnType<typeof createMockAgentChatService>;
   let workerAgentService: ReturnType<typeof createMockWorkerAgentService>;
+  let workerRevisionService: ReturnType<typeof createMockWorkerRevisionService>;
+  let workerHeartbeatService: ReturnType<typeof createMockWorkerHeartbeatService>;
+  let linearIssueTracker: ReturnType<typeof createMockLinearIssueTracker>;
+  let linearSyncService: ReturnType<typeof createMockLinearSyncService>;
+  let linearCredentialService: ReturnType<typeof createMockLinearCredentialService>;
   let conflictService: ReturnType<typeof createMockConflictService>;
   let processService: ReturnType<typeof createMockProcessService>;
   let issueInventoryService: ReturnType<typeof createMockIssueInventoryService>;
@@ -549,6 +621,11 @@ describe("createSyncRemoteCommandService", () => {
     diffService = createMockDiffService();
     agentChatService = createMockAgentChatService();
     workerAgentService = createMockWorkerAgentService();
+    workerRevisionService = createMockWorkerRevisionService();
+    workerHeartbeatService = createMockWorkerHeartbeatService();
+    linearIssueTracker = createMockLinearIssueTracker();
+    linearSyncService = createMockLinearSyncService();
+    linearCredentialService = createMockLinearCredentialService();
     conflictService = createMockConflictService();
     processService = createMockProcessService();
     issueInventoryService = createMockIssueInventoryService();
@@ -565,6 +642,11 @@ describe("createSyncRemoteCommandService", () => {
       diffService,
       agentChatService,
       workerAgentService,
+      workerRevisionService,
+      workerHeartbeatService,
+      linearCredentialService,
+      getLinearIssueTracker: () => linearIssueTracker,
+      getLinearSyncService: () => linearSyncService,
       conflictService,
       processService,
       logger: createLogger() as any,
@@ -2763,6 +2845,81 @@ describe("createSyncRemoteCommandService", () => {
 
       expect(result).toEqual({});
       expect(workerAgentService.removeAgent).toHaveBeenCalledWith("worker-42");
+    });
+
+    it("cto.saveAgent saves the worker through the revision service and returns the saved worker", async () => {
+      const agent = {
+        id: "worker-42",
+        name: "Mobile Worker",
+        role: "engineer",
+        title: "Build engineer",
+        reportsTo: "cto",
+        capabilities: ["mobile"],
+        status: "idle",
+        adapterType: "codex-local",
+        adapterConfig: { model: "gpt-5" },
+        runtimeConfig: { heartbeat: { enabled: true, intervalSec: 300, wakeOnDemand: true } },
+        budgetMonthlyCents: 10000,
+      };
+      const savedWorker = {
+        ...agent,
+        slug: "mobile-worker",
+        spentMonthlyCents: 0,
+        createdAt: "2026-04-01T00:00:00.000Z",
+        updatedAt: "2026-04-01T00:00:00.000Z",
+        deletedAt: null,
+      };
+      workerRevisionService.saveAgent.mockReturnValue(savedWorker);
+
+      const result = await service.execute(makePayload("cto.saveAgent", {
+        agent,
+        actor: "mobile",
+      }));
+
+      expect(workerRevisionService.saveAgent).toHaveBeenCalledWith(agent, "mobile");
+      expect(workerHeartbeatService.syncFromConfig).toHaveBeenCalledOnce();
+      expect(result).toBe(savedWorker);
+    });
+
+    it("cto exposes Linear quick view, issue picker, search, comments, and sync-now through mobile sync", async () => {
+      const quickView = await service.execute(makePayload("cto.getLinearQuickView", {}));
+      expect(linearIssueTracker.getQuickView).toHaveBeenCalledWith(expect.objectContaining({
+        connected: true,
+        viewerId: "user-1",
+      }));
+      expect(quickView).toMatchObject({
+        assignedIssues: [{ identifier: "ADE-42" }],
+        recentIssues: [{ identifier: "ADE-43" }],
+      });
+
+      const picker = await service.execute(makePayload("cto.getLinearIssuePickerData", {}));
+      expect(picker).toMatchObject({
+        projects: [{ id: "project-1" }],
+        users: [{ id: "user-1" }],
+        states: [{ id: "state-1" }],
+      });
+
+      const search = await service.execute(makePayload("cto.searchLinearIssues", {
+        projectSlug: "MOB",
+        query: "parity",
+        stateTypes: ["todo"],
+        first: 10,
+      }));
+      expect(linearIssueTracker.searchIssues).toHaveBeenCalledWith({
+        projectSlug: "MOB",
+        stateTypes: ["todo"],
+        query: "parity",
+        first: 10,
+      });
+      expect(search).toMatchObject({ issues: [{ identifier: "ADE-42" }] });
+
+      const comments = await service.execute(makePayload("cto.getLinearIssueComments", { issueId: "issue-1" }));
+      expect(linearIssueTracker.fetchIssueComments).toHaveBeenCalledWith("issue-1");
+      expect(comments).toMatchObject([{ id: "comment-1" }]);
+
+      const dashboard = await service.execute(makePayload("cto.runLinearSyncNow", {}));
+      expect(linearSyncService.runSyncNow).toHaveBeenCalledOnce();
+      expect(dashboard).toMatchObject({ lastSuccessAt: "2026-05-28T00:00:00.000Z" });
     });
   });
 

--- a/apps/desktop/src/shared/linearSync.test.ts
+++ b/apps/desktop/src/shared/linearSync.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  linearIngressKindFromParts,
+  normalizeLinearIngressEventKind,
+} from "./types/linearSync";
+
+describe("linear ingress event kind normalization", () => {
+  it("derives desktop entity and action fields from iOS kind-only records", () => {
+    expect(normalizeLinearIngressEventKind({
+      kind: "issue.created",
+      entityType: null,
+      action: null,
+    })).toEqual({
+      kind: "issue.created",
+      entityType: "issue",
+      action: "create",
+    });
+  });
+
+  it("keeps explicit desktop entity/action fields authoritative", () => {
+    expect(normalizeLinearIngressEventKind({
+      kind: "issue.created",
+      entityType: "Issue",
+      action: "update",
+    })).toEqual({
+      kind: "issue.created",
+      entityType: "Issue",
+      action: "update",
+    });
+  });
+
+  it("builds a kind string when desktop records omit one", () => {
+    expect(linearIngressKindFromParts("issue", "updated")).toBe("issue.update");
+    expect(normalizeLinearIngressEventKind({
+      kind: null,
+      entityType: "issue",
+      action: "remove",
+    })).toEqual({
+      kind: "issue.remove",
+      entityType: "issue",
+      action: "remove",
+    });
+  });
+});

--- a/apps/desktop/src/shared/types/linearSync.ts
+++ b/apps/desktop/src/shared/types/linearSync.ts
@@ -418,14 +418,68 @@ export type LinearIngressEventRecord = {
   source: LinearIngressSource;
   deliveryId: string;
   eventId: string;
-  entityType: string;
-  action: string | null;
+  kind?: string | null;
+  entityType?: string | null;
+  action?: string | null;
   issueId: string | null;
   issueIdentifier: string | null;
   summary: string;
   payload?: Record<string, unknown> | null;
   createdAt: string;
 };
+
+function normalizeLinearIngressString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normalizeLinearIngressAction(value: unknown): string | null {
+  const action = normalizeLinearIngressString(value);
+  if (!action) return null;
+  switch (action) {
+    case "created":
+      return "create";
+    case "updated":
+      return "update";
+    case "deleted":
+    case "removed":
+      return "remove";
+    default:
+      return action;
+  }
+}
+
+export function linearIngressKindFromParts(entityType: unknown, action: unknown): string {
+  const entity = normalizeLinearIngressString(entityType) ?? "issue";
+  const normalizedAction = normalizeLinearIngressAction(action);
+  return normalizedAction ? `${entity}.${normalizedAction}` : entity;
+}
+
+export function normalizeLinearIngressEventKind(
+  event: Pick<LinearIngressEventRecord, "kind" | "entityType" | "action">
+): { kind: string; entityType: string; action: string | null } {
+  const explicitEntityType = normalizeLinearIngressString(event.entityType);
+  const explicitAction = normalizeLinearIngressAction(event.action);
+  if (explicitEntityType) {
+    return {
+      entityType: explicitEntityType,
+      action: explicitAction,
+      kind: normalizeLinearIngressString(event.kind) ?? linearIngressKindFromParts(explicitEntityType, explicitAction),
+    };
+  }
+
+  const kind = normalizeLinearIngressString(event.kind);
+  if (!kind) {
+    return { kind: "issue", entityType: "issue", action: null };
+  }
+  const [entityType, ...actionParts] = kind.split(".");
+  const derivedEntityType = normalizeLinearIngressString(entityType) ?? "issue";
+  const derivedAction = normalizeLinearIngressAction(actionParts.join("."));
+  return {
+    kind,
+    entityType: derivedEntityType,
+    action: explicitAction ?? derivedAction,
+  };
+}
 
 export type LinearIngressEndpointStatus = {
   configured: boolean;

--- a/apps/desktop/src/shared/types/sync.ts
+++ b/apps/desktop/src/shared/types/sync.ts
@@ -371,6 +371,10 @@ export type SyncFileBlob = {
   isBinary: boolean;
   content: string;
   languageId?: string | null;
+  previewKind?: "text" | "image" | "binary";
+  dataUrl?: string;
+  contentOmitted?: boolean;
+  omittedReason?: "too_large" | "unsupported_binary";
 };
 
 export type SyncFileRequest =
@@ -601,10 +605,16 @@ export type SyncRemoteCommandAction =
   | "cto.listAgentRevisions"
   | "cto.getFlowPolicy"
   | "cto.getLinearConnectionStatus"
+  | "cto.getLinearQuickView"
+  | "cto.getLinearIssuePickerData"
+  | "cto.searchLinearIssues"
+  | "cto.getLinearIssueComments"
   | "cto.getLinearSyncDashboard"
+  | "cto.runLinearSyncNow"
   | "cto.listLinearSyncQueue"
   | "cto.listLinearIngressEvents"
   | "cto.updateIdentity"
+  | "cto.saveAgent"
   | "cto.removeAgent"
   | "cto.setAgentStatus"
   | "cto.triggerAgentWakeup"

--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -224,6 +224,54 @@ struct LaneStatus: Codable, Equatable {
   var rebaseInProgress: Bool
 }
 
+struct LaneLinearIssue: Codable, Identifiable, Equatable, Hashable {
+  var id: String
+  var identifier: String
+  var title: String
+  var description: String?
+  var url: String?
+  var projectId: String?
+  var projectSlug: String?
+  var projectName: String?
+  var teamId: String?
+  var teamKey: String?
+  var teamName: String?
+  var stateId: String?
+  var stateName: String?
+  var stateType: String?
+  var priority: Int?
+  var priorityLabel: String?
+  var labels: [String]?
+  var assigneeId: String?
+  var assigneeName: String?
+  var creatorId: String?
+  var creatorName: String?
+  var dueDate: String?
+  var estimate: Double?
+  var branchName: String?
+  var createdAt: String?
+  var updatedAt: String?
+}
+
+struct LaneLinearIssueLinkEvidence: Codable, Equatable, Hashable {
+  var chatSessionId: String?
+  var commitSha: String?
+  var prId: String?
+}
+
+struct LaneLinearIssueLink: Codable, Identifiable, Equatable, Hashable {
+  var id: String
+  var laneId: String
+  var issue: LaneLinearIssue
+  var role: String
+  var source: String
+  var includeInPr: Bool
+  var closeOnMerge: Bool
+  var evidence: LaneLinearIssueLinkEvidence?
+  var createdAt: String
+  var updatedAt: String
+}
+
 enum LaneIcon: String, Codable, Equatable {
   case star
   case flag
@@ -251,6 +299,9 @@ struct LaneSummary: Codable, Identifiable, Equatable {
   var icon: LaneIcon?
   var tags: [String]
   var folder: String?
+  var runtimePlacement: String?
+  var linearIssue: LaneLinearIssue?
+  var linearIssueLinks: [LaneLinearIssueLink]?
   var createdAt: String
   var archivedAt: String?
   var devicesOpen: [DeviceMarker]?
@@ -751,6 +802,50 @@ struct AgentAdapterConfig: Codable, Hashable {
   }
 }
 
+struct AgentActiveHoursConfig: Codable {
+  var start: String
+  var end: String
+  var timezone: String
+}
+
+struct AgentHeartbeatConfig: Codable {
+  var enabled: Bool
+  var intervalSec: Int
+  var wakeOnDemand: Bool
+  var activeHours: AgentActiveHoursConfig?
+}
+
+struct AgentRuntimeConfigPatch: Codable {
+  var heartbeat: AgentHeartbeatConfig?
+  var maxConcurrentRuns: Int?
+}
+
+struct AgentLinearIdentityPatch: Codable {
+  var userIds: [String]?
+  var displayNames: [String]?
+  var aliases: [String]?
+}
+
+struct AgentUpsertInput: Codable {
+  var id: String?
+  var name: String
+  var role: String
+  var title: String?
+  var reportsTo: String?
+  var capabilities: [String]?
+  var status: String?
+  var adapterType: String
+  var adapterConfig: [String: RemoteJSONValue]?
+  var runtimeConfig: AgentRuntimeConfigPatch?
+  var linearIdentity: AgentLinearIdentityPatch?
+  var budgetMonthlyCents: Int?
+}
+
+struct CtoSaveAgentPayload: Codable {
+  var agent: AgentUpsertInput
+  var actor: String?
+}
+
 /// Mirrors desktop `AgentIdentity`. `model` and `provider` are pulled from
 /// `adapterConfig` by the computed properties below for display.
 struct AgentIdentity: Codable, Hashable, Identifiable {
@@ -886,6 +981,195 @@ struct LinearConnectionStatus: Codable, Hashable {
   var lastSyncAt: String? { checkedAt }
 }
 
+struct LinearCatalogProject: Codable, Hashable, Identifiable {
+  var id: String
+  var name: String
+  var slug: String?
+  var key: String?
+  var description: String?
+  var url: String?
+  var icon: String?
+  var color: String?
+}
+
+struct LinearCatalogUser: Codable, Hashable, Identifiable {
+  var id: String
+  var name: String?
+  var displayName: String?
+  var email: String?
+  var avatarUrl: String?
+}
+
+struct LinearCatalogState: Codable, Hashable, Identifiable {
+  var id: String
+  var name: String
+  var type: String?
+  var teamId: String?
+  var teamKey: String?
+}
+
+struct LinearIssuePickerData: Codable, Hashable {
+  var projects: [LinearCatalogProject]
+  var users: [LinearCatalogUser]
+  var states: [LinearCatalogState]
+}
+
+struct LinearQuickViewOrganization: Codable, Hashable {
+  var id: String
+  var name: String
+  var urlKey: String?
+  var logoUrl: String?
+  var gitBranchFormat: String?
+  var createdIssueCount: Int?
+  var roadmapEnabled: Bool?
+  var customersEnabled: Bool?
+  var releasesEnabled: Bool?
+}
+
+struct LinearQuickViewViewer: Codable, Hashable {
+  var id: String
+  var name: String
+  var displayName: String
+  var email: String?
+  var avatarUrl: String?
+  var admin: Bool?
+  var guest: Bool?
+  var url: String?
+}
+
+struct LinearQuickViewProject: Codable, Hashable, Identifiable {
+  var id: String
+  var name: String
+  var slug: String
+  var teamName: String
+  var teamKey: String?
+  var url: String?
+  var color: String?
+  var icon: String?
+  var description: String?
+  var statusName: String?
+  var statusType: String?
+  var health: String?
+  var progress: Double?
+  var scope: Double?
+  var priority: Int?
+  var priorityLabel: String?
+  var issueCount: Int?
+  var completedIssueCount: Int?
+  var startDate: String?
+  var targetDate: String?
+  var leadName: String?
+  var teamKeys: [String]
+}
+
+struct LinearQuickViewTeam: Codable, Hashable, Identifiable {
+  var id: String
+  var key: String
+  var name: String
+  var displayName: String
+  var color: String?
+  var issueCount: Int?
+  var cyclesEnabled: Bool?
+  var `private`: Bool?
+}
+
+struct LinearQuickViewSdk: Codable, Hashable {
+  var packageName: String
+  var surfaces: [String]
+}
+
+struct LinearQuickView: Codable, Hashable {
+  var connection: LinearConnectionStatus
+  var organization: LinearQuickViewOrganization?
+  var viewer: LinearQuickViewViewer?
+  var projects: [LinearQuickViewProject]
+  var teams: [LinearQuickViewTeam]
+  var assignedIssues: [NormalizedLinearIssue]
+  var recentIssues: [NormalizedLinearIssue]
+  var fetchedAt: String
+  var sdk: LinearQuickViewSdk?
+}
+
+struct NormalizedLinearIssueChild: Codable, Hashable, Identifiable {
+  var id: String
+  var identifier: String
+  var title: String
+  var stateId: String?
+  var stateName: String?
+  var stateType: String?
+}
+
+struct NormalizedLinearIssue: Codable, Hashable, Identifiable {
+  var id: String
+  var identifier: String
+  var title: String
+  var description: String?
+  var url: String?
+  var projectId: String?
+  var projectSlug: String?
+  var projectName: String?
+  var teamId: String?
+  var teamKey: String?
+  var teamName: String?
+  var stateId: String?
+  var stateName: String?
+  var stateType: String?
+  var previousStateId: String?
+  var previousStateName: String?
+  var previousStateType: String?
+  var priority: Int?
+  var priorityLabel: String?
+  var labels: [String]?
+  var metadataTags: [String]?
+  var assigneeId: String?
+  var assigneeName: String?
+  var ownerId: String?
+  var creatorId: String?
+  var creatorName: String?
+  var blockerIssueIds: [String]?
+  var hasOpenBlockers: Bool?
+  var dueDate: String?
+  var estimate: Double?
+  var archivedAt: String?
+  var completedAt: String?
+  var canceledAt: String?
+  var startedAt: String?
+  var createdAt: String?
+  var updatedAt: String?
+  var childIssues: [NormalizedLinearIssueChild]?
+}
+
+struct LinearIssueSearchResultPageInfo: Codable, Hashable {
+  var hasNextPage: Bool
+  var endCursor: String?
+}
+
+struct LinearIssueSearchResult: Codable, Hashable {
+  var issues: [NormalizedLinearIssue]
+  var pageInfo: LinearIssueSearchResultPageInfo
+}
+
+struct LinearIssueSearchArgs: Codable, Hashable {
+  var projectId: String? = nil
+  var projectSlug: String? = nil
+  var teamKey: String? = nil
+  var stateTypes: [String]? = nil
+  var assigneeId: String? = nil
+  var priority: Int? = nil
+  var query: String? = nil
+  var first: Int? = nil
+  var after: String? = nil
+  var includeArchived: Bool? = nil
+}
+
+struct LinearIssueComment: Codable, Hashable, Identifiable {
+  var id: String
+  var body: String
+  var createdAt: String
+  var userName: String?
+  var userDisplayName: String?
+}
+
 /// Flattens the desktop `LinearWorkflowTrigger` / `LinearWorkflowTarget`
 /// objects into short display strings. Keeps the raw JSON around so a
 /// re-encode doesn't destroy unknown fields.
@@ -950,11 +1234,19 @@ struct LinearWorkflowDefinition: Codable, Hashable, Identifiable {
 
   private static func describeTarget(_ value: Any?) -> String {
     guard let dict = value as? [String: Any] else { return "—" }
-    // LinearWorkflowTarget typically has: { kind: "worker_run" | ...,
-    // workerId?, ... }
-    if let kind = dict["kind"] as? String {
-      if let workerId = dict["workerId"] as? String, kind == "worker_run" {
-        return "worker run · \(workerId)"
+    let kind = (dict["type"] as? String) ?? (dict["kind"] as? String)
+    if let kind {
+      if kind == "worker_run" {
+        if let workerId = dict["workerId"] as? String, !workerId.isEmpty {
+          return "worker run · \(workerId)"
+        }
+        if let selector = dict["workerSelector"] as? [String: Any],
+           let mode = selector["mode"] as? String,
+           mode != "none",
+           let value = selector["value"] as? String,
+           !value.isEmpty {
+          return "worker run · \(mode): \(value)"
+        }
       }
       return kind.replacingOccurrences(of: "_", with: " ")
     }
@@ -1008,16 +1300,59 @@ struct LinearSyncQueueItem: Codable, Hashable, Identifiable {
 struct LinearIngressEventRecord: Codable, Hashable, Identifiable {
   var id: String
   var issueId: String?
+  var issueIdentifier: String?
   /// Raw ingress event kind (e.g. "issue.created", "issue.updated").
   var kind: String
   var summary: String?
   var timestamp: String?
   var receivedAt: String?
+  var createdAt: String?
 
   /// UI-friendly timestamp preferring the most explicit field available.
-  var displayTimestamp: String? { timestamp ?? receivedAt }
+  var displayTimestamp: String? { timestamp ?? receivedAt ?? createdAt }
   /// Issue ID is optional on desktop — fall back to "—" for display.
-  var displayIssueId: String { issueId ?? "—" }
+  var displayIssueId: String { issueIdentifier ?? issueId ?? "—" }
+
+  private enum CodingKeys: String, CodingKey {
+    case id, issueId, issueIdentifier, kind, entityType, action, summary, timestamp, receivedAt, createdAt
+  }
+
+  init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    id = try c.decode(String.self, forKey: .id)
+    issueId = try c.decodeIfPresent(String.self, forKey: .issueId)
+    issueIdentifier = try c.decodeIfPresent(String.self, forKey: .issueIdentifier)
+    let explicitKind = try c.decodeIfPresent(String.self, forKey: .kind)
+    let entityType = try c.decodeIfPresent(String.self, forKey: .entityType)
+    let action = try c.decodeIfPresent(String.self, forKey: .action)
+    if let explicitKind, !explicitKind.isEmpty {
+      kind = explicitKind
+    } else if let entityType, let action, !entityType.isEmpty, !action.isEmpty {
+      kind = "\(entityType).\(action)"
+    } else if let entityType, !entityType.isEmpty {
+      kind = entityType
+    } else if let action, !action.isEmpty {
+      kind = action
+    } else {
+      kind = "event"
+    }
+    summary = try c.decodeIfPresent(String.self, forKey: .summary)
+    timestamp = try c.decodeIfPresent(String.self, forKey: .timestamp)
+    receivedAt = try c.decodeIfPresent(String.self, forKey: .receivedAt)
+    createdAt = try c.decodeIfPresent(String.self, forKey: .createdAt)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(id, forKey: .id)
+    try c.encodeIfPresent(issueId, forKey: .issueId)
+    try c.encodeIfPresent(issueIdentifier, forKey: .issueIdentifier)
+    try c.encode(kind, forKey: .kind)
+    try c.encodeIfPresent(summary, forKey: .summary)
+    try c.encodeIfPresent(timestamp, forKey: .timestamp)
+    try c.encodeIfPresent(receivedAt, forKey: .receivedAt)
+    try c.encodeIfPresent(createdAt, forKey: .createdAt)
+  }
 }
 
 struct CtoTriggerAgentWakeupResult: Codable, Hashable {
@@ -2140,6 +2475,10 @@ struct SyncFileBlob: Codable, Equatable {
   var isBinary: Bool
   var content: String
   var languageId: String?
+  var previewKind: String? = nil
+  var dataUrl: String? = nil
+  var contentOmitted: Bool? = nil
+  var omittedReason: String? = nil
 }
 
 struct ComputerUseArtifactSummary: Codable, Identifiable, Equatable {

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -3425,7 +3425,7 @@ final class SyncService: ObservableObject {
     }
     if let linearIssue {
       args["linearIssue"] = try jsonObject(from: linearIssue)
-      if let branchName = linearIssue.branchName, !branchName.isEmpty {
+      if args["branchName"] == nil, let branchName = linearIssue.branchName, !branchName.isEmpty {
         args["branchName"] = branchName
       }
     }
@@ -3495,7 +3495,7 @@ final class SyncService: ObservableObject {
     }
     if let linearIssue {
       args["linearIssue"] = try jsonObject(from: linearIssue)
-      if let branchName = linearIssue.branchName, !branchName.isEmpty {
+      if args["branchName"] == nil, let branchName = linearIssue.branchName, !branchName.isEmpty {
         args["branchName"] = branchName
       }
     }

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -2724,6 +2724,30 @@ final class SyncService: ObservableObject {
     try await sendDecodableCommand(action: "cto.getLinearConnectionStatus", as: LinearConnectionStatus.self)
   }
 
+  func fetchLinearQuickView() async throws -> LinearQuickView {
+    try await sendDecodableCommand(action: "cto.getLinearQuickView", as: LinearQuickView.self)
+  }
+
+  func fetchLinearIssuePickerData() async throws -> LinearIssuePickerData {
+    try await sendDecodableCommand(action: "cto.getLinearIssuePickerData", as: LinearIssuePickerData.self)
+  }
+
+  func searchLinearIssues(_ args: LinearIssueSearchArgs = LinearIssueSearchArgs()) async throws -> LinearIssueSearchResult {
+    try await sendDecodableCommand(
+      action: "cto.searchLinearIssues",
+      args: try encodedCommandArgs(from: args),
+      as: LinearIssueSearchResult.self
+    )
+  }
+
+  func fetchLinearIssueComments(issueId: String) async throws -> [LinearIssueComment] {
+    try await sendDecodableCommand(
+      action: "cto.getLinearIssueComments",
+      args: ["issueId": issueId],
+      as: [LinearIssueComment].self
+    )
+  }
+
   func fetchLinearSyncDashboard() async throws -> LinearSyncDashboard {
     try await sendDecodableCommand(action: "cto.getLinearSyncDashboard", as: LinearSyncDashboard.self)
   }
@@ -2734,6 +2758,15 @@ final class SyncService: ObservableObject {
 
   func removeAgent(agentId: String) async throws {
     _ = try await sendCommand(action: "cto.removeAgent", args: ["agentId": agentId])
+  }
+
+  func saveAgent(_ agent: AgentUpsertInput, actor: String = "mobile") async throws -> AgentIdentity {
+    let payload = CtoSaveAgentPayload(agent: agent, actor: actor)
+    return try await sendDecodableCommand(
+      action: "cto.saveAgent",
+      args: try encodedCommandArgs(from: payload),
+      as: AgentIdentity.self
+    )
   }
 
   func listLinearSyncQueue() async throws -> [LinearSyncQueueItem] {
@@ -3158,9 +3191,14 @@ final class SyncService: ObservableObject {
     )
   }
 
-  func searchText(workspaceId: String, query: String) async throws -> [FilesSearchTextMatch] {
+  func searchText(workspaceId: String, query: String, includeIgnored: Bool = true) async throws -> [FilesSearchTextMatch] {
     try decode(
-      try await sendFileRequest(action: "searchText", args: ["workspaceId": workspaceId, "query": query]),
+      try await sendFileRequest(action: "searchText", args: [
+        "workspaceId": workspaceId,
+        "query": query,
+        "limit": 200,
+        "includeIgnored": includeIgnored,
+      ]),
       as: [FilesSearchTextMatch].self
     )
   }
@@ -3363,7 +3401,11 @@ final class SyncService: ObservableObject {
     name: String,
     description: String,
     parentLaneId: String? = nil,
-    baseBranch: String? = nil
+    baseBranch: String? = nil,
+    branchName: String? = nil,
+    startPoint: String? = nil,
+    linearIssue: LaneLinearIssue? = nil,
+    runtimePlacement: String? = nil
   ) async throws -> LaneSummary {
     var args: [String: Any] = [
       "name": name,
@@ -3374,6 +3416,21 @@ final class SyncService: ObservableObject {
     }
     if let baseBranch, !baseBranch.isEmpty {
       args["baseBranch"] = baseBranch
+    }
+    if let branchName, !branchName.isEmpty {
+      args["branchName"] = branchName
+    }
+    if let startPoint, !startPoint.isEmpty {
+      args["startPoint"] = startPoint
+    }
+    if let linearIssue {
+      args["linearIssue"] = try jsonObject(from: linearIssue)
+      if let branchName = linearIssue.branchName, !branchName.isEmpty {
+        args["branchName"] = branchName
+      }
+    }
+    if let runtimePlacement, !runtimePlacement.isEmpty {
+      args["runtimePlacement"] = runtimePlacement
     }
     return try await sendDecodableCommand(action: "lanes.create", args: args, as: LaneSummary.self)
   }
@@ -3412,7 +3469,16 @@ final class SyncService: ObservableObject {
     return try await sendDecodableCommand(action: "lanes.importBranch", args: args, as: LaneSummary.self)
   }
 
-  func createChildLane(name: String, parentLaneId: String, description: String = "", folder: String? = nil) async throws -> LaneSummary {
+  func createChildLane(
+    name: String,
+    parentLaneId: String,
+    description: String = "",
+    folder: String? = nil,
+    baseBranchRef: String? = nil,
+    branchName: String? = nil,
+    linearIssue: LaneLinearIssue? = nil,
+    runtimePlacement: String? = nil
+  ) async throws -> LaneSummary {
     var args: [String: Any] = [
       "name": name,
       "parentLaneId": parentLaneId,
@@ -3420,6 +3486,21 @@ final class SyncService: ObservableObject {
     ]
     if let folder, !folder.isEmpty {
       args["folder"] = folder
+    }
+    if let baseBranchRef, !baseBranchRef.isEmpty {
+      args["baseBranchRef"] = baseBranchRef
+    }
+    if let branchName, !branchName.isEmpty {
+      args["branchName"] = branchName
+    }
+    if let linearIssue {
+      args["linearIssue"] = try jsonObject(from: linearIssue)
+      if let branchName = linearIssue.branchName, !branchName.isEmpty {
+        args["branchName"] = branchName
+      }
+    }
+    if let runtimePlacement, !runtimePlacement.isEmpty {
+      args["runtimePlacement"] = runtimePlacement
     }
     return try await sendDecodableCommand(action: "lanes.createChild", args: args, as: LaneSummary.self)
   }

--- a/apps/ios/ADE/Views/Cto/CtoTeamScreen.swift
+++ b/apps/ios/ADE/Views/Cto/CtoTeamScreen.swift
@@ -99,11 +99,13 @@ struct CtoTeamScreen: View {
       await load(force: true)
     }
     .sheet(isPresented: $showHireSheet) {
-      CtoMachineOnlyNotice(
-        title: "Hire worker",
-        message: "Hire workers from ADE on your machine. Mobile support is coming soon."
-      )
-      .presentationDetents([.fraction(0.3), .medium])
+      CtoWorkerHireSheet(existingAgents: displayAgents) { saved in
+        showHireSheet = false
+        wakeupNotice = "Hired \(saved.name)."
+        await load(force: true)
+      }
+      .environmentObject(syncService)
+      .presentationDetents([.large])
     }
   }
 
@@ -135,7 +137,7 @@ struct CtoTeamScreen: View {
       }
       .buttonStyle(.plain)
       .accessibilityLabel("Hire worker")
-      .accessibilityHint("Opens a sheet explaining hire is available from ADE on your machine for now.")
+      .accessibilityHint("Opens the worker creation form.")
     }
   }
 
@@ -594,6 +596,309 @@ private struct MiniActionButton: View {
 private func CtoTeamAsyncResult<T>(_ body: @escaping () async throws -> T) async -> Result<T, Error> {
   do { return .success(try await body()) }
   catch { return .failure(error) }
+}
+
+private struct CtoWorkerTemplate: Identifiable, Hashable {
+  let id: String
+  let name: String
+  let role: String
+  let title: String
+  let capabilities: [String]
+  let model: String
+  let description: String
+  let systemImage: String
+}
+
+private let ctoWorkerTemplates: [CtoWorkerTemplate] = [
+  CtoWorkerTemplate(
+    id: "backend-engineer",
+    name: "Backend Engineer",
+    role: "engineer",
+    title: "Backend Engineer",
+    capabilities: ["backend", "api", "database", "testing"],
+    model: "claude-sonnet-4-6",
+    description: "Services, persistence, integrations, and tests.",
+    systemImage: "server.rack"
+  ),
+  CtoWorkerTemplate(
+    id: "frontend-engineer",
+    name: "Frontend Engineer",
+    role: "engineer",
+    title: "Frontend Engineer",
+    capabilities: ["frontend", "ui", "accessibility", "testing"],
+    model: "claude-sonnet-4-6",
+    description: "Interfaces, state, polish, and browser validation.",
+    systemImage: "rectangle.on.rectangle.angled"
+  ),
+  CtoWorkerTemplate(
+    id: "qa-tester",
+    name: "QA Tester",
+    role: "qa",
+    title: "QA Tester",
+    capabilities: ["qa", "regression", "edge-cases", "automation"],
+    model: "claude-sonnet-4-6",
+    description: "Regression passes, edge cases, and proof capture.",
+    systemImage: "checkmark.shield"
+  ),
+  CtoWorkerTemplate(
+    id: "devops",
+    name: "DevOps Engineer",
+    role: "devops",
+    title: "DevOps Engineer",
+    capabilities: ["ci", "release", "infra", "observability"],
+    model: "claude-sonnet-4-6",
+    description: "Builds, CI, releases, and operational fixes.",
+    systemImage: "gearshape.2"
+  ),
+  CtoWorkerTemplate(
+    id: "researcher",
+    name: "Researcher",
+    role: "researcher",
+    title: "Researcher",
+    capabilities: ["research", "analysis", "planning", "docs"],
+    model: "claude-sonnet-4-6",
+    description: "Investigations, comparisons, and written findings.",
+    systemImage: "book"
+  ),
+  CtoWorkerTemplate(
+    id: "custom",
+    name: "Custom Worker",
+    role: "general",
+    title: "",
+    capabilities: [],
+    model: "claude-sonnet-4-6",
+    description: "Start blank and define the role yourself.",
+    systemImage: "wand.and.stars"
+  ),
+]
+
+private struct CtoWorkerHireSheet: View {
+  @Environment(\.dismiss) private var dismiss
+  @EnvironmentObject private var syncService: SyncService
+
+  let existingAgents: [AgentIdentity]
+  let onSaved: (AgentIdentity) async -> Void
+
+  @State private var selectedTemplateId = ctoWorkerTemplates.first?.id ?? "custom"
+  @State private var name = ""
+  @State private var title = ""
+  @State private var role = "engineer"
+  @State private var capabilitiesText = ""
+  @State private var adapterType = "claude-local"
+  @State private var model = "claude-sonnet-4-6"
+  @State private var budgetText = ""
+  @State private var maxConcurrentRuns = 1
+  @State private var wakeOnDemand = true
+  @State private var saving = false
+  @State private var errorMessage: String?
+
+  private let roleOptions = [
+    ("engineer", "Engineer"),
+    ("qa", "QA"),
+    ("designer", "Designer"),
+    ("devops", "DevOps"),
+    ("researcher", "Researcher"),
+    ("general", "General"),
+  ]
+
+  private let adapterOptions = [
+    ("claude-local", "Claude local"),
+    ("codex-local", "Codex local"),
+  ]
+
+  private var canSave: Bool {
+    !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !saving
+  }
+
+  var body: some View {
+    NavigationStack {
+      Form {
+        if let errorMessage {
+          Section {
+            Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+              .foregroundStyle(ADEColor.danger)
+          }
+        }
+
+        Section("Template") {
+          ForEach(ctoWorkerTemplates) { template in
+            Button {
+              apply(template)
+            } label: {
+              HStack(alignment: .top, spacing: 10) {
+                Image(systemName: template.systemImage)
+                  .foregroundStyle(ADEColor.ctoAccent)
+                  .frame(width: 22)
+                VStack(alignment: .leading, spacing: 2) {
+                  Text(template.name)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(ADEColor.textPrimary)
+                  Text(template.description)
+                    .font(.caption)
+                    .foregroundStyle(ADEColor.textSecondary)
+                }
+                Spacer(minLength: 8)
+                if selectedTemplateId == template.id {
+                  Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(ADEColor.ctoAccent)
+                }
+              }
+            }
+            .buttonStyle(.plain)
+          }
+        }
+
+        Section("Identity") {
+          TextField("Name", text: $name)
+            .textInputAutocapitalization(.words)
+          TextField("Title", text: $title)
+            .textInputAutocapitalization(.words)
+          Picker("Role", selection: $role) {
+            ForEach(roleOptions, id: \.0) { value, label in
+              Text(label).tag(value)
+            }
+          }
+          TextField("Capabilities", text: $capabilitiesText, axis: .vertical)
+            .lineLimit(2...4)
+            .textInputAutocapitalization(.never)
+        }
+
+        Section("Runtime") {
+          Picker("Adapter", selection: $adapterType) {
+            ForEach(adapterOptions, id: \.0) { value, label in
+              Text(label).tag(value)
+            }
+          }
+          TextField("Model", text: $model)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+          Stepper("Max concurrent runs: \(maxConcurrentRuns)", value: $maxConcurrentRuns, in: 1...10)
+          Toggle("Wake on demand", isOn: $wakeOnDemand)
+        }
+
+        Section("Budget") {
+          TextField("Monthly cap in dollars", text: $budgetText)
+            .keyboardType(.decimalPad)
+          Text("Leave empty or use 0 for no monthly cap.")
+            .font(.caption)
+            .foregroundStyle(ADEColor.textSecondary)
+        }
+
+        if !existingAgents.isEmpty {
+          Section {
+            Text("The worker will appear in the CTO roster after the paired machine saves it.")
+              .font(.caption)
+              .foregroundStyle(ADEColor.textSecondary)
+          }
+        }
+      }
+      .scrollContentBackground(.hidden)
+      .adeScreenBackground()
+      .navigationTitle("Hire worker")
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .topBarLeading) {
+          Button("Cancel") { dismiss() }
+        }
+        ToolbarItem(placement: .topBarTrailing) {
+          Button {
+            Task { await save() }
+          } label: {
+            if saving {
+              ProgressView()
+            } else {
+              Text("Save")
+                .fontWeight(.semibold)
+            }
+          }
+          .disabled(!canSave)
+        }
+      }
+    }
+    .tint(ADEColor.ctoAccent)
+    .onAppear {
+      guard name.isEmpty, let first = ctoWorkerTemplates.first else { return }
+      apply(first)
+    }
+  }
+
+  @MainActor
+  private func apply(_ template: CtoWorkerTemplate) {
+    selectedTemplateId = template.id
+    name = template.id == "custom" ? "" : template.name
+    title = template.title
+    role = template.role
+    capabilitiesText = template.capabilities.joined(separator: ", ")
+    model = template.model
+    if adapterType != "claude-local" && adapterType != "codex-local" {
+      adapterType = "claude-local"
+    }
+  }
+
+  @MainActor
+  private func save() async {
+    let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedName.isEmpty else { return }
+    saving = true
+    errorMessage = nil
+    defer { saving = false }
+
+    do {
+      let saved = try await syncService.saveAgent(makeAgentInput(name: trimmedName))
+      await onSaved(saved)
+      dismiss()
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private func makeAgentInput(name: String) -> AgentUpsertInput {
+    let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
+    var adapterConfig: [String: RemoteJSONValue] = [:]
+    if !trimmedModel.isEmpty {
+      adapterConfig["model"] = .string(trimmedModel)
+    }
+
+    return AgentUpsertInput(
+      id: nil,
+      name: name,
+      role: role,
+      title: trimmedTitle.isEmpty ? nil : trimmedTitle,
+      reportsTo: nil,
+      capabilities: parsedCapabilities,
+      status: "active",
+      adapterType: adapterType,
+      adapterConfig: adapterConfig.isEmpty ? nil : adapterConfig,
+      runtimeConfig: AgentRuntimeConfigPatch(
+        heartbeat: AgentHeartbeatConfig(
+          enabled: false,
+          intervalSec: 0,
+          wakeOnDemand: wakeOnDemand,
+          activeHours: nil
+        ),
+        maxConcurrentRuns: maxConcurrentRuns
+      ),
+      linearIdentity: nil,
+      budgetMonthlyCents: parsedBudgetCents
+    )
+  }
+
+  private var parsedCapabilities: [String] {
+    capabilitiesText
+      .split(separator: ",")
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+  }
+
+  private var parsedBudgetCents: Int? {
+    let normalized = budgetText
+      .replacingOccurrences(of: "$", with: "")
+      .replacingOccurrences(of: ",", with: "")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !normalized.isEmpty, let dollars = Double(normalized), dollars > 0 else { return 0 }
+    return max(0, Int((dollars * 100).rounded()))
+  }
 }
 
 struct CtoMachineOnlyNotice: View {

--- a/apps/ios/ADE/Views/Cto/CtoTeamScreen.swift
+++ b/apps/ios/ADE/Views/Cto/CtoTeamScreen.swift
@@ -896,8 +896,8 @@ private struct CtoWorkerHireSheet: View {
       .replacingOccurrences(of: "$", with: "")
       .replacingOccurrences(of: ",", with: "")
       .trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !normalized.isEmpty, let dollars = Double(normalized), dollars > 0 else { return 0 }
-    return max(0, Int((dollars * 100).rounded()))
+    guard !normalized.isEmpty, let dollars = Double(normalized), dollars > 0 else { return nil }
+    return max(1, Int((dollars * 100).rounded()))
   }
 }
 

--- a/apps/ios/ADE/Views/Cto/CtoWorkflowsScreen.swift
+++ b/apps/ios/ADE/Views/Cto/CtoWorkflowsScreen.swift
@@ -7,6 +7,13 @@ struct CtoWorkflowsScreen: View {
   @State private var dashboard: LinearSyncDashboard?
   @State private var policy: LinearWorkflowConfig?
   @State private var events: [LinearIngressEventRecord] = []
+  @State private var pickerData: LinearIssuePickerData?
+  @State private var quickView: LinearQuickView?
+  @State private var issues: [NormalizedLinearIssue] = []
+  @State private var issueQuery = ""
+  @State private var issueSearchError: String?
+  @State private var isLoadingIssues = false
+  @State private var selectedIssue: NormalizedLinearIssue?
   @State private var isLoading = false
   @State private var isSyncing = false
   @State private var errorMessage: String?
@@ -74,6 +81,12 @@ struct CtoWorkflowsScreen: View {
       EditOnMachineSheet()
         .presentationDetents([.fraction(0.3), .medium])
     }
+    .sheet(item: $selectedIssue) { issue in
+      LinearIssueDetailSheet(issue: issue)
+        .environmentObject(syncService)
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
   }
 
   @ViewBuilder
@@ -124,6 +137,8 @@ struct CtoWorkflowsScreen: View {
           .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 12, trailing: 16))
       }
     }
+
+    issueBrowserSection
 
     Section {
       SectionHeader(
@@ -194,6 +209,58 @@ struct CtoWorkflowsScreen: View {
     }
   }
 
+  @ViewBuilder
+  private var issueBrowserSection: some View {
+    Section {
+      SectionHeader(
+        title: "Linear issues",
+        rightLabel: issueBrowserRightLabel
+      )
+      .listRowBackground(Color.clear)
+      .listRowSeparator(.hidden)
+      .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 6, trailing: 16))
+
+      LinearIssueSearchCard(
+        query: $issueQuery,
+        pickerSummary: pickerDataSummary,
+        errorMessage: issueSearchError,
+        isLoading: isLoadingIssues,
+        onSearch: { Task { await loadIssues() } }
+      )
+      .listRowBackground(Color.clear)
+      .listRowSeparator(.hidden)
+      .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 6, trailing: 16))
+
+      if isLoadingIssues && issues.isEmpty {
+        ADECardSkeleton(rows: 2)
+          .listRowBackground(Color.clear)
+          .listRowSeparator(.hidden)
+          .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+      } else if issues.isEmpty {
+        Text("No matching issues.")
+          .font(.subheadline)
+          .foregroundStyle(ADEColor.textSecondary)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .adeListCard()
+          .listRowBackground(Color.clear)
+          .listRowSeparator(.hidden)
+          .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+      } else {
+        ForEach(issues) { issue in
+          Button {
+            selectedIssue = issue
+          } label: {
+            LinearIssueRow(issue: issue)
+          }
+          .buttonStyle(.plain)
+          .listRowBackground(Color.clear)
+          .listRowSeparator(.hidden)
+          .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+        }
+      }
+    }
+  }
+
   private var loadingSkeleton: some View {
     VStack(spacing: 12) {
       ADECardSkeleton(rows: 2)
@@ -236,6 +303,7 @@ struct CtoWorkflowsScreen: View {
       let updated = try await syncService.runLinearSyncNow()
       dashboard = updated
       syncNotice = "Sync completed · \(updated.queuedCount) queued, \(updated.runningCount) running."
+      await loadIssues()
       Task {
         try? await Task.sleep(nanoseconds: 4_000_000_000)
         await MainActor.run { syncNotice = nil }
@@ -273,12 +341,86 @@ struct CtoWorkflowsScreen: View {
       self.events = value
     }
 
+    let pickerResult = await CtoWorkflowsResult { try await syncService.fetchLinearIssuePickerData() }
+    if case .success(let value) = pickerResult {
+      self.pickerData = value
+    }
+
+    let queryIsEmpty = issueQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    var didLoadQuickView = false
+    let quickResult = await CtoWorkflowsResult { try await syncService.fetchLinearQuickView() }
+    if case .success(let value) = quickResult {
+      didLoadQuickView = true
+      self.quickView = value
+      if queryIsEmpty {
+        self.issues = quickViewIssueList(value)
+        self.issueSearchError = nil
+      }
+    }
+
+    if !didLoadQuickView || !queryIsEmpty {
+      await loadIssues()
+    }
+
     // Only surface a top-level error if the connection fetch itself failed —
     // once we know Linear isn't connected, dashboard/policy failures are
     // expected (the services aren't initialized) and shouldn't render as an
     // error card.
     if case .failure(let err) = connResult, self.connection == nil {
       self.errorMessage = (err as? LocalizedError)?.errorDescription ?? String(describing: err)
+    }
+  }
+
+  private var pickerDataSummary: String? {
+    guard let pickerData else { return nil }
+    let parts = [
+      pickerData.projects.isEmpty ? nil : "\(pickerData.projects.count) projects",
+      pickerData.states.isEmpty ? nil : "\(pickerData.states.count) states",
+      pickerData.users.isEmpty ? nil : "\(pickerData.users.count) users",
+    ].compactMap { $0 }
+    return parts.isEmpty ? nil : parts.joined(separator: " · ")
+  }
+
+  private var issueBrowserRightLabel: String? {
+    if !issues.isEmpty { return "\(issues.count) shown" }
+    if let quickView {
+      let assigned = quickView.assignedIssues.count
+      let recent = quickView.recentIssues.count
+      if assigned > 0 || recent > 0 {
+        return "\(assigned) assigned · \(recent) recent"
+      }
+    }
+    return pickerDataSummary
+  }
+
+  private func quickViewIssueList(_ quickView: LinearQuickView) -> [NormalizedLinearIssue] {
+    var seen: Set<String> = []
+    var result: [NormalizedLinearIssue] = []
+    for issue in quickView.assignedIssues + quickView.recentIssues {
+      guard !seen.contains(issue.id) else { continue }
+      seen.insert(issue.id)
+      result.append(issue)
+    }
+    return result
+  }
+
+  private func loadIssues() async {
+    guard !isLoadingIssues else { return }
+    isLoadingIssues = true
+    defer { isLoadingIssues = false }
+    do {
+      let query = issueQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+      let result = try await syncService.searchLinearIssues(
+        LinearIssueSearchArgs(
+          query: query.isEmpty ? nil : query,
+          first: 20,
+          includeArchived: false
+        )
+      )
+      issues = result.issues
+      issueSearchError = nil
+    } catch {
+      issueSearchError = error.localizedDescription
     }
   }
 }
@@ -419,6 +561,266 @@ private struct QueueCounter: View {
       RoundedRectangle(cornerRadius: 11, style: .continuous)
         .stroke(ADEColor.glassBorder, lineWidth: 0.5)
     )
+  }
+}
+
+// MARK: - Linear issues
+
+private struct LinearIssueSearchCard: View {
+  @Binding var query: String
+  let pickerSummary: String?
+  let errorMessage: String?
+  let isLoading: Bool
+  let onSearch: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 9) {
+      HStack(spacing: 8) {
+        Image(systemName: "magnifyingglass")
+          .font(.system(size: 13, weight: .semibold))
+          .foregroundStyle(ADEColor.purpleAccent)
+        TextField("Search title, ID, label, or assignee", text: $query)
+          .font(.system(size: 13))
+          .textInputAutocapitalization(.never)
+          .autocorrectionDisabled()
+          .submitLabel(.search)
+          .onSubmit(onSearch)
+        Button(action: onSearch) {
+          if isLoading {
+            ProgressView().controlSize(.mini)
+          } else {
+            Image(systemName: "arrow.right.circle.fill")
+              .font(.system(size: 17, weight: .semibold))
+          }
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(ADEColor.purpleAccent)
+        .accessibilityLabel("Search Linear issues")
+      }
+      .padding(.horizontal, 12)
+      .padding(.vertical, 10)
+      .background(ADEColor.glassBackground, in: RoundedRectangle(cornerRadius: 11, style: .continuous))
+      .overlay(
+        RoundedRectangle(cornerRadius: 11, style: .continuous)
+          .stroke(ADEColor.glassBorder, lineWidth: 0.5)
+      )
+
+      if let errorMessage {
+        Text(errorMessage)
+          .font(.caption)
+          .foregroundStyle(ADEColor.warning)
+          .fixedSize(horizontal: false, vertical: true)
+      } else if let pickerSummary {
+        Text(pickerSummary)
+          .font(.system(size: 10.5, design: .monospaced))
+          .foregroundStyle(ADEColor.textMuted)
+      }
+    }
+    .adeListCard()
+  }
+}
+
+private struct LinearIssueRow: View {
+  let issue: NormalizedLinearIssue
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(alignment: .firstTextBaseline, spacing: 8) {
+        Text(issue.identifier)
+          .font(.system(size: 11, design: .monospaced).weight(.bold))
+          .foregroundStyle(ADEColor.purpleAccent)
+        Text(issue.title)
+          .font(.system(size: 13.5, weight: .semibold))
+          .foregroundStyle(ADEColor.textPrimary)
+          .lineLimit(2)
+        Spacer(minLength: 0)
+        Image(systemName: "chevron.right")
+          .font(.system(size: 11, weight: .semibold))
+          .foregroundStyle(ADEColor.textMuted)
+      }
+
+      HStack(spacing: 6) {
+        if let state = issue.stateName, !state.isEmpty {
+          ADEStatusPill(text: state, tint: linearIssueStateTint(issue.stateType))
+        }
+        if let project = issue.projectName ?? issue.projectSlug, !project.isEmpty {
+          MetaChip(text: project, symbol: "folder")
+        }
+        if let assignee = issue.assigneeName, !assignee.isEmpty {
+          MetaChip(text: assignee, symbol: "person.crop.circle")
+        }
+        if issue.hasOpenBlockers == true {
+          MetaChip(text: "blocked", symbol: "exclamationmark.triangle.fill", tint: ADEColor.warning)
+        }
+      }
+    }
+    .adeListCard()
+  }
+}
+
+private struct MetaChip: View {
+  let text: String
+  let symbol: String
+  var tint: Color = ADEColor.textSecondary
+
+  var body: some View {
+    Label(text, systemImage: symbol)
+      .font(.system(size: 10.5, weight: .medium))
+      .foregroundStyle(tint)
+      .lineLimit(1)
+      .padding(.horizontal, 7)
+      .padding(.vertical, 4)
+      .background(tint.opacity(0.10), in: Capsule())
+  }
+}
+
+private struct LinearIssueDetailSheet: View {
+  @Environment(\.dismiss) private var dismiss
+  @EnvironmentObject private var syncService: SyncService
+
+  let issue: NormalizedLinearIssue
+
+  @State private var comments: [LinearIssueComment] = []
+  @State private var isLoadingComments = false
+  @State private var commentsError: String?
+
+  var body: some View {
+    NavigationStack {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 16) {
+          VStack(alignment: .leading, spacing: 8) {
+            Text(issue.identifier)
+              .font(.system(size: 12, design: .monospaced).weight(.bold))
+              .foregroundStyle(ADEColor.purpleAccent)
+            Text(issue.title)
+              .font(.title3.weight(.bold))
+              .foregroundStyle(ADEColor.textPrimary)
+              .fixedSize(horizontal: false, vertical: true)
+            if let description = issue.description, !description.isEmpty {
+              Text(description)
+                .font(.subheadline)
+                .foregroundStyle(ADEColor.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+          }
+          .adeListCard()
+
+          VStack(alignment: .leading, spacing: 8) {
+            MetaRow(key: "state", value: issue.stateName ?? issue.stateType ?? "Unknown")
+            if let project = issue.projectName ?? issue.projectSlug {
+              MetaRow(key: "project", value: project)
+            }
+            if let assignee = issue.assigneeName {
+              MetaRow(key: "assignee", value: assignee)
+            }
+            if let priority = issue.priorityLabel ?? issue.priority.map({ "P\($0)" }) {
+              MetaRow(key: "priority", value: priority)
+            }
+            if let updatedAt = issue.updatedAt, let relative = CtoWorkflowsRelativeTime.format(iso: updatedAt) {
+              MetaRow(key: "updated", value: relative)
+            }
+          }
+          .adeListCard()
+
+          VStack(alignment: .leading, spacing: 10) {
+            Text("Comments")
+              .font(.caption.weight(.semibold))
+              .foregroundStyle(ADEColor.textMuted)
+              .textCase(.uppercase)
+              .tracking(0.4)
+
+            if isLoadingComments && comments.isEmpty {
+              ADECardSkeleton(rows: 2)
+            } else if let commentsError {
+              Text(commentsError)
+                .font(.subheadline)
+                .foregroundStyle(ADEColor.warning)
+            } else if comments.isEmpty {
+              Text("No comments.")
+                .font(.subheadline)
+                .foregroundStyle(ADEColor.textSecondary)
+            } else {
+              VStack(spacing: 0) {
+                ForEach(Array(comments.enumerated()), id: \.element.id) { idx, comment in
+                  LinearIssueCommentRow(comment: comment)
+                  if idx < comments.count - 1 {
+                    Divider().background(ADEColor.glassBorder)
+                  }
+                }
+              }
+            }
+          }
+          .adeListCard()
+        }
+        .padding(16)
+      }
+      .adeScreenBackground()
+      .navigationTitle(issue.identifier)
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .topBarLeading) {
+          Button("Done") { dismiss() }
+        }
+        if let urlString = issue.url, let url = URL(string: urlString) {
+          ToolbarItem(placement: .topBarTrailing) {
+            Link(destination: url) {
+              Image(systemName: "arrow.up.right.square")
+            }
+            .accessibilityLabel("Open in Linear")
+          }
+        }
+      }
+      .task(id: issue.id) {
+        await loadComments()
+      }
+    }
+  }
+
+  private func loadComments() async {
+    guard !isLoadingComments else { return }
+    isLoadingComments = true
+    defer { isLoadingComments = false }
+    do {
+      comments = try await syncService.fetchLinearIssueComments(issueId: issue.id)
+      commentsError = nil
+    } catch {
+      commentsError = error.localizedDescription
+    }
+  }
+}
+
+private struct LinearIssueCommentRow: View {
+  let comment: LinearIssueComment
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 5) {
+      HStack(alignment: .firstTextBaseline, spacing: 8) {
+        Text(comment.userDisplayName ?? comment.userName ?? "Linear")
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(ADEColor.textPrimary)
+        Spacer(minLength: 0)
+        if let relative = CtoWorkflowsRelativeTime.format(iso: comment.createdAt) {
+          Text(relative)
+            .font(.system(size: 10, design: .monospaced))
+            .foregroundStyle(ADEColor.textMuted)
+        }
+      }
+      Text(comment.body)
+        .font(.subheadline)
+        .foregroundStyle(ADEColor.textSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+    .padding(.vertical, 10)
+  }
+}
+
+private func linearIssueStateTint(_ stateType: String?) -> Color {
+  switch stateType?.lowercased() {
+  case "completed", "done": return ADEColor.success
+  case "started", "unstarted": return ADEColor.info
+  case "backlog", "triage": return ADEColor.textSecondary
+  case "canceled", "cancelled": return ADEColor.danger
+  default: return ADEColor.purpleAccent
   }
 }
 

--- a/apps/ios/ADE/Views/Files/FilesDetailComponents.swift
+++ b/apps/ios/ADE/Views/Files/FilesDetailComponents.swift
@@ -446,6 +446,26 @@ struct SyntaxHighlightedCodeView: View {
   }
 }
 
+struct FilesMarkdownPreview: View {
+  let text: String
+
+  private var renderedText: AttributedString {
+    (try? AttributedString(markdown: text)) ?? AttributedString(text)
+  }
+
+  var body: some View {
+    ScrollView(.vertical) {
+      Text(renderedText)
+        .font(.body)
+        .foregroundStyle(ADEColor.textPrimary)
+        .textSelection(.enabled)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+    }
+    .adeInsetField(cornerRadius: 16, padding: 0)
+  }
+}
+
 struct FilesInlineDiffView: View {
   let lines: [FilesInlineDiffLine]
   let language: FilesLanguage

--- a/apps/ios/ADE/Views/Files/FilesDetailComponents.swift
+++ b/apps/ios/ADE/Views/Files/FilesDetailComponents.swift
@@ -450,7 +450,10 @@ struct FilesMarkdownPreview: View {
   let text: String
 
   private var renderedText: AttributedString {
-    (try? AttributedString(markdown: text)) ?? AttributedString(text)
+    (try? AttributedString(
+      markdown: text,
+      options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+    )) ?? AttributedString(text)
   }
 
   var body: some View {

--- a/apps/ios/ADE/Views/Files/FilesDetailScreen+Actions.swift
+++ b/apps/ios/ADE/Views/Files/FilesDetailScreen+Actions.swift
@@ -30,7 +30,8 @@ extension FilesDetailScreen {
         encoding: "base64",
         isBinary: true,
         content: cachedData.base64EncodedString(),
-        languageId: nil
+        languageId: nil,
+        previewKind: "image"
       )
       cachedImageBlob = cachedBlob
       blob = cachedBlob

--- a/apps/ios/ADE/Views/Files/FilesDetailScreen.swift
+++ b/apps/ios/ADE/Views/Files/FilesDetailScreen.swift
@@ -204,7 +204,7 @@ struct FilesDetailScreen: View {
   private func showsCodeLayoutControl(blob: SyncFileBlob) -> Bool {
     switch mode {
     case .preview:
-      return !blob.isBinary
+      return !blob.isBinary && !filesIsMarkdown(blob: blob, path: relativePath)
     case .diff:
       return workspace.laneId != nil
     }
@@ -232,7 +232,13 @@ struct FilesDetailScreen: View {
 
   @ViewBuilder
   private func filesPreviewContent(blob: SyncFileBlob) -> some View {
-    if blob.isBinary {
+    if let limit = filesOmittedPreviewLimit(blob: blob) {
+      FilesContentFallback(
+        symbol: "doc.text.magnifyingglass",
+        title: limit.title,
+        message: limit.message
+      )
+    } else if blob.isBinary {
       if isImagePreviewable, let data = imageData, let image = UIImage(data: data) {
         ZoomableImageView(image: image)
           .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -256,6 +262,8 @@ struct FilesDetailScreen: View {
           title: limit.title,
           message: limit.message
         )
+      } else if filesIsMarkdown(blob: blob, path: relativePath) {
+        FilesMarkdownPreview(text: blob.content)
       } else {
         SyntaxHighlightedCodeView(
           text: blob.content,

--- a/apps/ios/ADE/Views/Files/FilesModels.swift
+++ b/apps/ios/ADE/Views/Files/FilesModels.swift
@@ -136,6 +136,25 @@ func filesTextPreviewLimit(blob: SyncFileBlob) -> FilesPreviewLimit? {
   )
 }
 
+func filesOmittedPreviewLimit(blob: SyncFileBlob) -> FilesPreviewLimit? {
+  guard blob.contentOmitted == true else { return nil }
+  let title = blob.omittedReason == "too_large" ? "Preview paused" : "Preview unavailable"
+  let message: String
+  if blob.omittedReason == "too_large" {
+    message = "This content is \(formattedFileSize(blob.size)). Open it from ADE on your machine to inspect the full file."
+  } else {
+    message = "The machine marked this file as unsupported for inline mobile preview. Open it from ADE on your machine."
+  }
+  return FilesPreviewLimit(title: title, message: message)
+}
+
+func filesIsMarkdown(blob: SyncFileBlob, path: String) -> Bool {
+  let ext = (path.lowercased() as NSString).pathExtension
+  if ["md", "markdown", "mdx"].contains(ext) { return true }
+  if blob.mimeType?.lowercased() == "text/markdown" { return true }
+  return blob.languageId?.lowercased() == "markdown"
+}
+
 func filesDiffPreviewLimit(diff: FileDiff) -> FilesPreviewLimit? {
   if diff.original.isTruncated == true || diff.modified.isTruncated == true {
     return FilesPreviewLimit(

--- a/apps/ios/ADE/Views/Lanes/LaneComponents.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneComponents.swift
@@ -70,6 +70,56 @@ struct LaneOpenChip: View {
   }
 }
 
+// MARK: - Linear issue
+
+struct LaneLinearIssueBadge: View {
+  @Environment(\.openURL) private var openURL
+
+  let issue: LaneLinearIssue
+  var compact = false
+
+  var body: some View {
+    Button {
+      if let urlString = issue.url,
+         let url = URL(string: urlString),
+         url.scheme == "http" || url.scheme == "https" {
+        openURL(url)
+      }
+    } label: {
+      HStack(spacing: 6) {
+        Image(systemName: "link")
+          .font(.system(size: compact ? 9 : 11, weight: .bold))
+        Text(issue.identifier)
+          .font(.caption2.monospaced().weight(.bold))
+          .lineLimit(1)
+        if !compact {
+          Text(issue.title)
+            .font(.caption.weight(.semibold))
+            .lineLimit(1)
+            .truncationMode(.tail)
+        }
+        if let state = issue.stateName, !state.isEmpty, !compact {
+          Text(state)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(ADEColor.textMuted)
+            .lineLimit(1)
+        }
+      }
+      .foregroundStyle(ADEColor.textPrimary)
+      .padding(.horizontal, compact ? 7 : 9)
+      .padding(.vertical, compact ? 4 : 7)
+      .background(ADEColor.accent.opacity(0.10), in: RoundedRectangle(cornerRadius: compact ? 9 : 11, style: .continuous))
+      .overlay(
+        RoundedRectangle(cornerRadius: compact ? 9 : 11, style: .continuous)
+          .stroke(ADEColor.accent.opacity(0.28), lineWidth: 0.7)
+      )
+    }
+    .buttonStyle(.plain)
+    .disabled(issue.url?.isEmpty ?? true)
+    .accessibilityLabel("\(issue.identifier): \(issue.title)")
+  }
+}
+
 // MARK: - Launch tile
 
 struct LaneLaunchTile: View {
@@ -321,6 +371,11 @@ struct LaneListRow: View, Equatable {
           }
           if snapshot.lane.childCount > 0 {
             LaneMicroChip(icon: "square.stack.3d.up", text: "\(snapshot.lane.childCount)", tint: ADEColor.textMuted)
+          }
+          if let issue = primaryLaneLinearIssue(for: snapshot.lane) {
+            LaneMicroChip(icon: "link", text: issue.identifier, tint: ADEColor.accent)
+          } else if laneLinearIssueLinkCount(for: snapshot.lane) > 0 {
+            LaneMicroChip(icon: "link", text: "\(laneLinearIssueLinkCount(for: snapshot.lane))", tint: ADEColor.accent)
           }
           if isPinned {
             LaneMicroChip(icon: "pin.fill", text: nil, tint: ADEColor.accent)
@@ -590,6 +645,11 @@ struct LaneStackCard: View, Equatable {
           }
           if snapshot.lane.childCount > 0 {
             LaneMicroChip(icon: "square.stack.3d.up", text: "\(snapshot.lane.childCount)", tint: ADEColor.textMuted)
+          }
+          if let issue = primaryLaneLinearIssue(for: snapshot.lane) {
+            LaneMicroChip(icon: "link", text: issue.identifier, tint: ADEColor.accent)
+          } else if laneLinearIssueLinkCount(for: snapshot.lane) > 0 {
+            LaneMicroChip(icon: "link", text: "\(laneLinearIssueLinkCount(for: snapshot.lane))", tint: ADEColor.accent)
           }
           if isPinned {
             LaneMicroChip(icon: "pin.fill", text: nil, tint: ADEColor.accent)

--- a/apps/ios/ADE/Views/Lanes/LaneDetailContentSections.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneDetailContentSections.swift
@@ -25,6 +25,9 @@ struct LaneDetailHeaderCard<Footer: View>: View {
     VStack(alignment: .leading, spacing: 12) {
       headerTopRow
       detailMetadataRow
+      if let issue = primaryLaneLinearIssue(for: detail?.lane ?? snapshot.lane) {
+        LaneLinearIssueBadge(issue: issue)
+      }
       statusRow
       if let summary = headerSummaryText {
         Text(summary)

--- a/apps/ios/ADE/Views/Lanes/LaneHelpers.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneHelpers.swift
@@ -28,6 +28,35 @@ func laneActivitySummary(_ snapshot: LaneListSnapshot) -> String? {
   return nil
 }
 
+func primaryLaneLinearIssue(for lane: LaneSummary) -> LaneLinearIssue? {
+  if let issue = lane.linearIssue {
+    return issue
+  }
+  return lane.linearIssueLinks?
+    .sorted { lhs, rhs in
+      let lhsRank = laneLinearIssueLinkRoleRank(lhs.role)
+      let rhsRank = laneLinearIssueLinkRoleRank(rhs.role)
+      if lhsRank != rhsRank { return lhsRank < rhsRank }
+      return lhs.updatedAt > rhs.updatedAt
+    }
+    .first?
+    .issue
+}
+
+func laneLinearIssueLinkCount(for lane: LaneSummary) -> Int {
+  lane.linearIssueLinks?.count ?? (lane.linearIssue == nil ? 0 : 1)
+}
+
+private func laneLinearIssueLinkRoleRank(_ role: String) -> Int {
+  switch role {
+  case "primary": return 0
+  case "worked": return 1
+  case "referenced": return 2
+  case "inferred": return 3
+  default: return 4
+  }
+}
+
 func laneListFilteredSnapshots(
   _ snapshots: [LaneListSnapshot],
   scope: LaneListScope,
@@ -150,6 +179,8 @@ func matchesLaneToken(snapshot: LaneListSnapshot, isPinned: Bool, token: String)
     snapshot.lane.laneType,
     snapshot.lane.description ?? "",
     snapshot.lane.worktreePath,
+    primaryLaneLinearIssue(for: snapshot.lane).map { "\($0.identifier) \($0.title) \($0.projectName ?? "") \($0.teamKey ?? "") \($0.stateName ?? "")" } ?? "",
+    snapshot.lane.linearIssueLinks?.map { "\($0.issue.identifier) \($0.issue.title) \($0.role) \($0.source)" }.joined(separator: " ") ?? "",
     snapshot.lane.archivedAt == nil ? "active" : "archived",
     snapshot.lane.status.dirty ? "dirty modified changed" : "clean",
     "ahead \(snapshot.lane.status.ahead)",

--- a/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
+++ b/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
@@ -795,7 +795,9 @@ struct PrDetailView: View {
 
   private var stickyActionBar: some View {
     let gate = mergeGateInfo
-    let needsRebase = gate.tone == .amber || behindBaseBy > 0
+    let canRebaseFromGate = gate.tone == .amber
+      && gate.target == .overview
+      && (behindBaseBy > 0 || snapshot?.status?.isMergeable == false)
 
     // Single full-width action — matches the mocks. The pre-merge "needs
     // rebase" / "merge blocked" states surface as inline body cards (Merge
@@ -817,12 +819,23 @@ struct PrDetailView: View {
       enabled = canRunPrActions && (capabilities?.canMerge ?? actionAvailability.mergeEnabled)
       action = { presentMergeMethodPicker() }
     case .amber:
-      label = needsRebase ? (behindBaseBy > 0 ? "Rebase · \(behindBaseBy) behind" : "Rebase") : "Needs rebase"
-      symbol = "arrow.triangle.2.circlepath"
+      if canRebaseFromGate {
+        label = behindBaseBy > 0 ? "Rebase · \(behindBaseBy) behind" : "Rebase"
+        symbol = "arrow.triangle.2.circlepath"
+      } else if gate.target == .checks {
+        label = "Checks pending"
+        symbol = "clock.badge.checkmark"
+      } else if gate.target == .reviews {
+        label = "Review needed"
+        symbol = "person.crop.circle.badge.exclamationmark"
+      } else {
+        label = "Waiting for status"
+        symbol = "clock"
+      }
       isPrimary = false
       isAmber = true
-      enabled = canRunPrActions && !currentPr.laneId.isEmpty
-      action = { triggerRebase() }
+      enabled = canRebaseFromGate && canRunPrActions && !currentPr.laneId.isEmpty
+      action = { if canRebaseFromGate { triggerRebase() } }
     case .red where canAttemptBlockedMerge:
       label = "Attempt merge"
       symbol = "arrow.triangle.merge"
@@ -1227,6 +1240,7 @@ struct PrDetailView: View {
       maxRounds: 5,
       onRebaseNeeded: "pause",
       conflictStrategy: "pause",
+      autoAgentSettings: defaultAutoConflictAgentSettings(),
       forceFinalizeMode: "off",
       forceFinalizeRequireNoCiFailures: true,
       atCapPolicy: "ci_retry_once",
@@ -1286,7 +1300,41 @@ struct PrDetailView: View {
     updatePipelineSettings("Updating conflict strategy") { settings in
       settings.conflictStrategy = strategy
       settings.onRebaseNeeded = strategy == "rebase" ? "auto_rebase" : "pause"
+      if strategy == "auto" {
+        settings.autoAgentSettings = resolvedAutoConflictAgentSettings(from: settings.autoAgentSettings)
+      }
     }
+  }
+
+  private func defaultAutoConflictAgentSettings() -> AutoConflictAgentSettings {
+    AutoConflictAgentSettings(
+      provider: nil,
+      model: nil,
+      reasoningEffort: nil,
+      permissionMode: nil,
+      confidenceThreshold: nil
+    )
+  }
+
+  private func resolvedAutoConflictAgentSettings(from current: AutoConflictAgentSettings?) -> AutoConflictAgentSettings {
+    let model = trimmedNonEmpty(current?.model)
+    return AutoConflictAgentSettings(
+      provider: trimmedNonEmpty(current?.provider) ?? prAutoConflictAgentProvider(for: model) ?? "codex",
+      model: model,
+      reasoningEffort: trimmedNonEmpty(current?.reasoningEffort),
+      permissionMode: trimmedNonEmpty(current?.permissionMode),
+      confidenceThreshold: current?.confidenceThreshold
+    )
+  }
+
+  private func trimmedNonEmpty(_ value: String?) -> String? {
+    let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return trimmed.isEmpty ? nil : trimmed
+  }
+
+  private func prAutoConflictAgentProvider(for model: String?) -> String? {
+    let provider = workModelCatalogGroupKey(for: model ?? "", currentProvider: "")
+    return provider == "claude" || provider == "codex" ? provider : nil
   }
 
   private func setPipelineAtCapPolicy(_ policy: String) {

--- a/apps/ios/ADE/Views/PRs/PrMergeGateCard.swift
+++ b/apps/ios/ADE/Views/PRs/PrMergeGateCard.swift
@@ -161,8 +161,8 @@ struct PrMergeGateInfo: Equatable {
 
 /// Derives the merge-gate summary from the hydrated PR status + capabilities.
 ///
-/// Precedence (worst wins): conflicts/failing/blockedReason → red;
-/// clean but behind base or needs rebase → amber; otherwise green.
+/// Precedence (worst wins): conflicts/failing/blockedReason/unresolved review
+/// threads → red; pending checks/reviews or rebase-needed → amber; otherwise green.
 func prComputeMergeGate(
   status: PrStatus?,
   checks: [PrCheck],
@@ -174,9 +174,9 @@ func prComputeMergeGate(
   isDraft: Bool = false
 ) -> PrMergeGateInfo {
   let normalizedSummaryChecksStatus = summaryChecksStatus?.lowercased()
-  let summarySaysFailing = checks.isEmpty && ["failing", "failure", "failed"].contains(normalizedSummaryChecksStatus ?? "")
-  let summarySaysPending = checks.isEmpty && ["pending", "running", "in_progress"].contains(normalizedSummaryChecksStatus ?? "")
-  let summarySaysPassing = checks.isEmpty && ["passing", "success", "passed"].contains(normalizedSummaryChecksStatus ?? "")
+  let summarySaysFailing = ["failing", "failure", "failed"].contains(normalizedSummaryChecksStatus ?? "")
+  let summarySaysPending = ["pending", "running", "in_progress", "queued"].contains(normalizedSummaryChecksStatus ?? "")
+  let summarySaysPassing = ["passing", "success", "passed"].contains(normalizedSummaryChecksStatus ?? "")
   let failingChecks = checks.filter { check in
     check.status == "completed" &&
       check.conclusion != nil &&
@@ -184,12 +184,19 @@ func prComputeMergeGate(
       check.conclusion != "neutral" &&
       check.conclusion != "skipped"
   }.count
+  let pendingChecks = checks.filter { check in
+    let status = check.status.lowercased()
+    if status != "completed" { return true }
+    return check.conclusion == nil
+  }.count
   let failing = failingChecks + (summarySaysFailing ? 1 : 0)
+  let pending = pendingChecks + (summarySaysPending && pendingChecks == 0 ? 1 : 0)
   let conflicts = status?.mergeConflicts ?? false
   let blockedReason = capabilities?.mergeBlockedReason?.trimmingCharacters(in: .whitespacesAndNewlines)
   let hasBlockedReason = !(blockedReason?.isEmpty ?? true)
   let behind = status?.behindBaseBy ?? 0
   let mergeable = status?.isMergeable ?? true
+  let missingApprovals = max(reviewsNeeded - reviewsHave, 0)
 
   let approvalsText: String = {
     let have = max(reviewsHave, 0)
@@ -205,7 +212,7 @@ func prComputeMergeGate(
     )
   }
 
-  if conflicts || failing > 0 || hasBlockedReason {
+  if conflicts || failing > 0 || reviewThreadsUnresolved > 0 || hasBlockedReason {
     var parts: [String] = []
     if summarySaysFailing {
       parts.append("checks failing")
@@ -215,7 +222,9 @@ func prComputeMergeGate(
     if conflicts {
       parts.append("merge conflicts")
     }
-    if reviewsNeeded > 0 || reviewsHave > 0 {
+    if missingApprovals > 0 {
+      parts.append("\(missingApprovals) approval\(missingApprovals == 1 ? "" : "s") needed")
+    } else if reviewsNeeded > 0 || reviewsHave > 0 {
       parts.append(approvalsText)
     }
     if reviewThreadsUnresolved > 0 {
@@ -227,6 +236,16 @@ func prComputeMergeGate(
     let subline = parts.isEmpty ? (blockedReason ?? "Merge blocked by machine") : parts.joined(separator: " · ")
     let target: PrMergeGateTarget = (failing > 0 || conflicts) ? .checks : .reviews
     return PrMergeGateInfo(tone: .red, subline: subline, target: target)
+  }
+
+  if pending > 0 {
+    let subline = pending == 1 ? "1 check pending" : "\(pending) checks pending"
+    return PrMergeGateInfo(tone: .amber, subline: subline, target: .checks)
+  }
+
+  if missingApprovals > 0 {
+    let subline = "\(approvalsText) · \(missingApprovals) approval\(missingApprovals == 1 ? "" : "s") needed"
+    return PrMergeGateInfo(tone: .amber, subline: subline, target: .reviews)
   }
 
   if status == nil && checks.isEmpty && !summarySaysPassing {

--- a/apps/ios/ADE/Views/PRs/PrMergeGateCard.swift
+++ b/apps/ios/ADE/Views/PRs/PrMergeGateCard.swift
@@ -174,8 +174,8 @@ func prComputeMergeGate(
   isDraft: Bool = false
 ) -> PrMergeGateInfo {
   let normalizedSummaryChecksStatus = summaryChecksStatus?.lowercased()
-  let summarySaysFailing = ["failing", "failure", "failed"].contains(normalizedSummaryChecksStatus ?? "")
-  let summarySaysPending = ["pending", "running", "in_progress", "queued"].contains(normalizedSummaryChecksStatus ?? "")
+  let summarySaysFailing = checks.isEmpty && ["failing", "failure", "failed"].contains(normalizedSummaryChecksStatus ?? "")
+  let summarySaysPending = checks.isEmpty && ["pending", "running", "in_progress", "queued"].contains(normalizedSummaryChecksStatus ?? "")
   let summarySaysPassing = ["passing", "success", "passed"].contains(normalizedSummaryChecksStatus ?? "")
   let failingChecks = checks.filter { check in
     check.status == "completed" &&

--- a/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
@@ -1126,6 +1126,217 @@ private struct WorkStructuredQuestionMetaRow: View {
   }
 }
 
+struct WorkModelSelectionPendingCard: View {
+  @EnvironmentObject private var syncService: SyncService
+
+  let request: WorkPendingModelSelectionModel
+  let busy: Bool
+  let onConfirm: @MainActor (String) async -> Void
+  let onCancel: @MainActor () async -> Void
+
+  @State private var selectedModelId: String
+  @State private var selectedProvider: String
+  @State private var selectedReasoningEffort: String
+  @State private var selectedCodexFastMode: Bool
+  @State private var selectedModel: WorkModelOption?
+  @State private var pickerPresented = false
+
+  init(
+    request: WorkPendingModelSelectionModel,
+    busy: Bool,
+    onConfirm: @escaping @MainActor (String) async -> Void,
+    onCancel: @escaping @MainActor () async -> Void
+  ) {
+    self.request = request
+    self.busy = busy
+    self.onConfirm = onConfirm
+    self.onCancel = onCancel
+    let suggested = request.suggested
+    _selectedModelId = State(initialValue: suggested?.modelId ?? "")
+    _selectedProvider = State(initialValue: suggested?.provider ?? "claude")
+    _selectedReasoningEffort = State(initialValue: suggested?.reasoningEffort ?? "")
+    _selectedCodexFastMode = State(initialValue: suggested?.codexFastMode ?? false)
+    _selectedModel = State(initialValue: nil)
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      header
+      selectedModelSummary
+      if shouldShowFastModeToggle {
+        fastModeToggle
+      }
+      footer
+    }
+    .adeGlassCard(cornerRadius: 18, padding: 14)
+    .sheet(isPresented: $pickerPresented) {
+      WorkModelPickerSheet(
+        currentModelId: selectedModelId,
+        currentProvider: selectedProvider,
+        currentReasoningEffort: selectedReasoningEffort,
+        availableModelIds: request.availableModelIds,
+        isBusy: busy,
+        onSelect: { option, pickedReasoning, provider in
+          selectedModel = option
+          selectedModelId = option.id
+          selectedProvider = provider
+          selectedReasoningEffort = pickedReasoning ?? ""
+          if !option.supportsCodexFastMode {
+            selectedCodexFastMode = false
+          }
+          pickerPresented = false
+        }
+      )
+      .environmentObject(syncService)
+    }
+  }
+
+  @ViewBuilder
+  private var header: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(spacing: 8) {
+        Image(systemName: "cpu")
+          .font(.system(size: 15, weight: .semibold))
+          .foregroundStyle(ADEColor.accent)
+        Text(request.title)
+          .font(.headline)
+          .foregroundStyle(ADEColor.textPrimary)
+      }
+      if let workDescription = request.workDescription, !workDescription.isEmpty {
+        Text(workDescription)
+          .font(.subheadline)
+          .foregroundStyle(ADEColor.textSecondary)
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var selectedModelSummary: some View {
+    HStack(alignment: .center, spacing: 10) {
+      WorkProviderLogo(provider: selectedProvider, size: 30)
+      VStack(alignment: .leading, spacing: 4) {
+        Text(selectedModelDisplayName)
+          .font(.subheadline.weight(.semibold))
+          .foregroundStyle(selectedModelId.isEmpty ? ADEColor.textMuted : ADEColor.textPrimary)
+          .lineLimit(1)
+        HStack(spacing: 6) {
+          Text(selectedProvider.isEmpty ? "provider" : selectedProvider)
+          if !selectedModelId.isEmpty {
+            Text("·")
+            Text(selectedModelId)
+          }
+          if !selectedReasoningEffort.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            Text("·")
+            Text(selectedReasoningEffort.capitalized)
+          }
+        }
+        .font(.caption.monospaced())
+        .foregroundStyle(ADEColor.textSecondary)
+        .lineLimit(1)
+      }
+      Spacer(minLength: 8)
+      Button {
+        pickerPresented = true
+      } label: {
+        Image(systemName: selectedModelId.isEmpty ? "plus.circle" : "arrow.triangle.2.circlepath")
+          .font(.subheadline.weight(.semibold))
+      }
+      .buttonStyle(.glass)
+      .tint(ADEColor.accent)
+      .disabled(busy)
+      .accessibilityLabel(selectedModelId.isEmpty ? "Choose model" : "Change model")
+    }
+    .padding(12)
+    .background(ADEColor.surfaceBackground.opacity(0.55), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    .overlay(
+      RoundedRectangle(cornerRadius: 14, style: .continuous)
+        .stroke(ADEColor.glassBorder, lineWidth: 0.5)
+    )
+  }
+
+  @ViewBuilder
+  private var fastModeToggle: some View {
+    Toggle(isOn: $selectedCodexFastMode) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text("Fast mode")
+          .font(.subheadline.weight(.semibold))
+          .foregroundStyle(ADEColor.textPrimary)
+        Text("Use the Codex fast service tier for this worker.")
+          .font(.caption)
+          .foregroundStyle(ADEColor.textSecondary)
+      }
+    }
+    .tint(ADEColor.accent)
+    .disabled(busy)
+  }
+
+  @ViewBuilder
+  private var footer: some View {
+    HStack(spacing: 10) {
+      Button("Cancel") {
+        Task { await onCancel() }
+      }
+      .buttonStyle(.glass)
+      .tint(ADEColor.danger)
+      .disabled(busy)
+
+      Spacer(minLength: 8)
+
+      Button(selectedModelId.isEmpty ? "Choose model" : "Confirm") {
+        if selectedModelId.isEmpty {
+          pickerPresented = true
+        } else {
+          Task { await confirmSelection() }
+        }
+      }
+      .buttonStyle(.glassProminent)
+      .tint(ADEColor.accent)
+      .disabled(busy)
+    }
+  }
+
+  private var selectedModelDisplayName: String {
+    if let selectedModel {
+      return selectedModel.displayName
+    }
+    if let known = workKnownModelDisplayName(selectedModelId) {
+      return known
+    }
+    return selectedModelId.isEmpty ? "No model selected" : selectedModelId
+  }
+
+  private var shouldShowFastModeToggle: Bool {
+    selectedCodexFastMode || selectedModel?.supportsCodexFastMode == true
+  }
+
+  @MainActor
+  private func confirmSelection() async {
+    let trimmedModelId = selectedModelId.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedModelId.isEmpty else {
+      pickerPresented = true
+      return
+    }
+    let trimmedProvider = selectedProvider.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedEffort = selectedReasoningEffort.trimmingCharacters(in: .whitespacesAndNewlines)
+    let answer = WorkModelSelectionChoice(
+      provider: trimmedProvider.isEmpty ? "claude" : trimmedProvider,
+      modelId: trimmedModelId,
+      reasoningEffort: trimmedEffort.isEmpty ? nil : trimmedEffort,
+      codexFastMode: selectedCodexFastMode ? true : nil
+    )
+    guard let json = workModelSelectionJSONString(answer) else { return }
+    await onConfirm(json)
+  }
+
+  private func workModelSelectionJSONString(_ answer: WorkModelSelectionChoice) -> String? {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    guard let data = try? encoder.encode(answer) else { return nil }
+    return String(data: data, encoding: .utf8)
+  }
+}
+
 struct WorkPermissionCard: View {
   let permission: WorkPendingPermissionModel
   let busy: Bool

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
@@ -99,6 +99,25 @@ extension WorkChatSessionView {
           }
         }
       )
+    case .pendingModelSelection(let request):
+      WorkModelSelectionPendingCard(
+        request: request,
+        busy: actionInFlight || !isLive,
+        onConfirm: { selectionJSON in
+          await runSessionAction {
+            await onSubmitQuestionAnswers(
+              request.id,
+              ["selection": .string(selectionJSON)],
+              nil
+            )
+          }
+        },
+        onCancel: {
+          await runSessionAction {
+            await onDeclineQuestion(request.id)
+          }
+        }
+      )
     }
   }
 

--- a/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
@@ -337,6 +337,7 @@ enum WorkPendingInputItem: Identifiable, Equatable {
   /// Plan-approval gate — agent finished planning and is waiting for
   /// Approve & Implement or Reject & Revise before acting.
   case planApproval(WorkPendingPlanApprovalModel)
+  case modelSelection(WorkPendingModelSelectionModel)
 
   var id: String {
     switch self {
@@ -344,6 +345,7 @@ enum WorkPendingInputItem: Identifiable, Equatable {
     case .question(let model): return "question:\(model.id)"
     case .permission(let model): return "permission:\(model.id)"
     case .planApproval(let model): return "plan-approval:\(model.id)"
+    case .modelSelection(let model): return "model-selection:\(model.id)"
     }
   }
 
@@ -353,6 +355,7 @@ enum WorkPendingInputItem: Identifiable, Equatable {
     case .question(let model): return model.id
     case .permission(let model): return model.id
     case .planApproval(let model): return model.id
+    case .modelSelection(let model): return model.id
     }
   }
 }
@@ -405,6 +408,12 @@ func workPendingQuestionOption(from value: Any?) -> WorkPendingQuestionOption? {
     preview: optionalString(object["preview"]),
     previewFormat: optionalString(object["previewFormat"])
   )
+}
+
+func workStringArrayValue(_ value: Any?) -> [String]? {
+  guard let array = value as? [Any] else { return nil }
+  let strings = array.compactMap { optionalString($0) }
+  return strings.isEmpty ? nil : strings
 }
 
 /// Map a single question dictionary (one entry in the request's `questions` array,
@@ -629,6 +638,45 @@ func pendingWorkPlanApprovalFromApproval(
   )
 }
 
+func workModelSelectionChoice(from value: Any?) -> WorkModelSelectionChoice? {
+  guard let object = value as? [String: Any] else { return nil }
+  guard let provider = optionalString(object["provider"]),
+        let modelId = optionalString(object["modelId"])
+  else { return nil }
+  return WorkModelSelectionChoice(
+    provider: provider,
+    modelId: modelId,
+    reasoningEffort: optionalString(object["reasoningEffort"]),
+    codexFastMode: workBoolValue(object["codexFastMode"])
+  )
+}
+
+func pendingWorkModelSelectionFromApproval(
+  description: String,
+  detail: String?,
+  itemId: String
+) -> WorkPendingModelSelectionModel? {
+  guard let detailObject = workJSONObject(from: detail) else { return nil }
+  let request = detailObject["request"] as? [String: Any] ?? [:]
+  let kind = (optionalString(request["kind"]) ?? "").lowercased()
+  guard kind == "model_selection" else { return nil }
+  let metadata = request["providerMetadata"] as? [String: Any] ?? [:]
+  let role = optionalString(metadata["role"]) ?? "worker"
+  let tag = optionalString(metadata["tag"]) ?? ""
+  let workDescription = (optionalString(metadata["workDescription"])
+    ?? optionalString(request["description"])
+    ?? description)
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  return WorkPendingModelSelectionModel(
+    id: itemId,
+    role: role,
+    tag: tag,
+    workDescription: workDescription.isEmpty ? nil : workDescription,
+    suggested: workModelSelectionChoice(from: metadata["suggested"]),
+    availableModelIds: workStringArrayValue(metadata["availableModels"])
+  )
+}
+
 /// Ordered list of still-open pending inputs (approvals + structured questions + permission
 /// gates) in the order they were requested. Mirrors the desktop `derivePendingInputRequests`
 /// helper — resolved items are filtered out using the same predicate as `pendingWorkInputItemIds`.
@@ -641,7 +689,9 @@ func derivePendingWorkInputs(from transcript: [WorkChatEnvelope]) -> [WorkPendin
     case .approvalRequest(let description, let detail, let itemId, _):
       guard openIds.contains(itemId), !seen.contains(itemId) else { continue }
       seen.insert(itemId)
-      if let planApproval = pendingWorkPlanApprovalFromApproval(description: description, detail: detail, itemId: itemId) {
+      if let modelSelection = pendingWorkModelSelectionFromApproval(description: description, detail: detail, itemId: itemId) {
+        results.append(.modelSelection(modelSelection))
+      } else if let planApproval = pendingWorkPlanApprovalFromApproval(description: description, detail: detail, itemId: itemId) {
         results.append(.planApproval(planApproval))
       } else if let question = pendingWorkQuestionFromApproval(description: description, detail: detail, itemId: itemId) {
         results.append(.question(question))

--- a/apps/ios/ADE/Views/Work/WorkModelPickerSheet.swift
+++ b/apps/ios/ADE/Views/Work/WorkModelPickerSheet.swift
@@ -17,6 +17,7 @@ struct WorkModelPickerSheet: View {
   let currentModelId: String
   let currentProvider: String
   let currentReasoningEffort: String
+  let availableModelIds: [String]?
   let isBusy: Bool
   let onSelect: (WorkModelOption, String?, String) -> Void
 
@@ -24,12 +25,14 @@ struct WorkModelPickerSheet: View {
     currentModelId: String,
     currentProvider: String,
     currentReasoningEffort: String = "",
+    availableModelIds: [String]? = nil,
     isBusy: Bool,
     onSelect: @escaping (WorkModelOption, String?, String) -> Void
   ) {
     self.currentModelId = currentModelId
     self.currentProvider = currentProvider
     self.currentReasoningEffort = currentReasoningEffort
+    self.availableModelIds = availableModelIds
     self.isBusy = isBusy
     self.onSelect = onSelect
   }
@@ -44,7 +47,7 @@ struct WorkModelPickerSheet: View {
 
 	  private var catalog: [WorkModelCatalogGroup] {
 	    if let liveCatalog {
-	      return liveCatalog
+	      return scopedCatalog(liveCatalog)
 	    }
 	    return []
 	  }
@@ -178,6 +181,25 @@ struct WorkModelPickerSheet: View {
   private func firstProviderSelection() -> ModelPickerRailSelection? {
     guard let first = catalog.first else { return nil }
     return .providerGroup(key: first.key, label: groupLabel(first))
+  }
+
+  private func scopedCatalog(_ groups: [WorkModelCatalogGroup]) -> [WorkModelCatalogGroup] {
+    guard let availableModelIds else { return groups }
+    let scopedIds = availableModelIds
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+    guard !scopedIds.isEmpty else { return [] }
+    return groups.compactMap { group -> WorkModelCatalogGroup? in
+      let providers = group.providers.compactMap { provider -> WorkModelProvider? in
+        let models = provider.models.filter { model in
+          scopedIds.contains { workModelIdsEquivalent($0, model.id) }
+        }
+        guard !models.isEmpty else { return nil }
+        return WorkModelProvider(key: provider.key, displayName: provider.displayName, models: models)
+      }
+      guard !providers.isEmpty else { return nil }
+      return WorkModelCatalogGroup(key: group.key, displayName: group.displayName, providers: providers)
+    }
   }
 
   private func pickInitialSelectionIfNeeded() {

--- a/apps/ios/ADE/Views/Work/WorkModels.swift
+++ b/apps/ios/ADE/Views/Work/WorkModels.swift
@@ -108,6 +108,30 @@ struct WorkPendingPlanApprovalModel: Identifiable, Equatable {
   let title: String
 }
 
+struct WorkModelSelectionChoice: Codable, Equatable {
+  let provider: String
+  let modelId: String
+  let reasoningEffort: String?
+  let codexFastMode: Bool?
+}
+
+struct WorkPendingModelSelectionModel: Identifiable, Equatable {
+  let id: String
+  let role: String
+  let tag: String
+  let workDescription: String?
+  let suggested: WorkModelSelectionChoice?
+  let availableModelIds: [String]?
+
+  var title: String {
+    guard !role.isEmpty else { return "Pick a model" }
+    if !tag.isEmpty {
+      return "Pick a model for the \"\(tag)\" \(role)"
+    }
+    return "Pick a model for the \(role)"
+  }
+}
+
 struct WorkUsageSummary: Equatable {
   var turnCount: Int
   var inputTokens: Int
@@ -169,6 +193,9 @@ enum WorkTimelinePayload: Equatable {
   /// Plan-approval gate: agent has finished planning and is waiting for the
   /// user to Approve & Implement or Reject & Revise before it acts.
   case pendingPlanApproval(WorkPendingPlanApprovalModel)
+  /// Orchestration model routing gate: desktop asks the user to choose a
+  /// provider/model/reasoning tuple before workers can be spawned.
+  case pendingModelSelection(WorkPendingModelSelectionModel)
 }
 
 /// One member of a `WorkToolGroupModel`. Carries enough context for the

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -231,6 +231,14 @@ func buildWorkTimeline(
         rank: 1_600 + index,
         payload: .pendingPlanApproval(model)
       )
+    case .modelSelection(let model):
+      let ts = pendingTimestamps[model.id] ?? fallbackPendingTimestamp
+      return WorkTimelineEntry(
+        id: "pending-model-selection-\(model.id)",
+        timestamp: ts,
+        rank: 1_600 + index,
+        payload: .pendingModelSelection(model)
+      )
     case .approval:
       return nil
     }
@@ -1072,7 +1080,7 @@ func visibleWorkTimelineEntries(from entries: [WorkTimelineEntry], visibleCount:
 private extension WorkTimelineEntry {
   var isPendingInput: Bool {
     switch payload {
-    case .pendingQuestion, .pendingPermission, .pendingPlanApproval:
+    case .pendingQuestion, .pendingPermission, .pendingPlanApproval, .pendingModelSelection:
       return true
     default:
       return false

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -4903,6 +4903,41 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(gate.target, .checks)
   }
 
+  func testPrMergeGatePrefersSyncedCheckRowsOverStaleSummaryStatus() {
+    let checks = [
+      PrCheck(
+        name: "unit",
+        status: "completed",
+        conclusion: "success",
+        detailsUrl: nil,
+        startedAt: nil,
+        completedAt: nil
+      ),
+    ]
+    let status = PrStatus(
+      prId: "pr-1",
+      state: "open",
+      checksStatus: "failing",
+      reviewStatus: "approved",
+      isMergeable: true,
+      mergeConflicts: false,
+      behindBaseBy: 0
+    )
+
+    let gate = prComputeMergeGate(
+      status: status,
+      checks: checks,
+      summaryChecksStatus: "failing",
+      reviewThreadsUnresolved: 0,
+      reviewsNeeded: 1,
+      reviewsHave: 1,
+      capabilities: nil
+    )
+
+    XCTAssertEqual(gate.tone, .green)
+    XCTAssertEqual(gate.target, .overview)
+  }
+
   func testPrLinkLanePreselectionRequiresExactBranchMatch() {
     func lane(id: String, name: String, branchRef: String) -> LaneSummary {
       LaneSummary(


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fmobile-app-parity-pass-46a99420 num=394 -->
<p>
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://ade.app/logo-dark.svg">
    <img src="https://ade.app/logo-light.svg" height="18" align="left" alt="ADE">
  </picture>
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade.app/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fmobile-app-parity-pass-46a99420&amp;pr=394">ade/mobile-app-parity-pass-46a99420 branch</a>
  &nbsp;·&nbsp; <a href="https://ade.app/open?type=pr&amp;repo=arul28%2FADE&amp;number=394">PR #394</a>
</p>
<!-- /ade:link -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linear issues integration: browse, search, and link issues to lanes
  * Worker hiring interface with pre-built templates and configuration options
  * Markdown file preview support
  * Display Linear issue links on lanes and lane cards
  * Pending worker model selection workflow

* **Improvements**
  * Enhanced file preview handling with omission metadata
  * Refined merge gate status logic for improved accuracy
  * Extended lane creation with Linear issue and branch configuration options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers a broad mobile parity pass: Linear issues browsing/search/linking, a functional worker-hire sheet replacing the old placeholder, markdown file preview, pending-model-selection UI for orchestration routing, and several merge-gate logic improvements.

- **Linear integration**: new `LaneLinearIssueBadge`, issue browser in `CtoWorkflowsScreen`, issue picker in lane creation, and six new desktop CTO RPC commands (`getLinearQuickView`, `searchLinearIssues`, `getLinearIssuePickerData`, `getLinearIssueComments`, `runLinearSyncNow`, `saveAgent`) all backed by fresh test coverage.
- **Merge-gate fixes**: `PrMergeGateCard` now tracks unresolved review threads as a red-gate condition, adds a standalone amber gate for missing approvals, and counts in-flight checks separately; a new test confirms that a stale summary-status "failing" string is correctly overridden by live passing check rows.
- **Previous P1s addressed**: `branchName` from a `linearIssue` is now used as a *default* (not an override) when the caller also passes an explicit branch, and `parsedBudgetCents` now returns `nil` for blank/invalid input rather than `0`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; changes are well-scoped additive features with good test coverage and no regressions in core paths.

All changes are additive — new RPC handlers, new UI components, and merge-gate refinements. Both previously flagged defects (branchName priority inversion, parsedBudgetCents returning 0) are correctly resolved. The TypeScript saveAgent handler ignores payload.actor in favour of a hardcoded string, but this is a minor audit-trail inconsistency rather than a behavioural defect on the critical path. No data loss, auth, or crash risk identified.

No files require special attention; syncRemoteCommandService.ts has the minor actor-field inconsistency noted in the inline comment.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Views/PRs/PrMergeGateCard.swift | Gate logic improved: adds pending-check and unresolved-thread tracking; summarySaysFailing retains its checks.isEmpty guard; new test covers the stale-summary vs live-check-row scenario. |
| apps/ios/ADE/Services/SyncService.swift | Adds Linear quick-view, issue picker, search, comments, and saveAgent RPC wrappers; branchName priority fix (linearIssue.branchName is now a default, not an override) addresses the previous P1. |
| apps/ios/ADE/Views/Cto/CtoTeamScreen.swift | Replaces machine-only placeholder with a functional CtoWorkerHireSheet; parsedBudgetCents now correctly returns nil for empty/invalid input, addressing the previous P1. |
| apps/ade-cli/src/services/sync/syncRemoteCommandService.ts | Adds six new CTO command handlers (Linear quick view, search, issue picker, comments, runSyncNow, saveAgent); saveAgent ignores payload.actor and hardcodes "user". |
| apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift | New WorkModelSelectionPendingCard renders the orchestration model-routing gate; correctly scopes the picker to available model IDs and serialises the choice as JSON before submitting. |
| apps/ios/ADE/Models/RemoteModels.swift | Large model additions: LaneLinearIssue/IssueLink, AgentUpsertInput, LinearQuickView hierarchy, NormalizedLinearIssue, and a custom LinearIngressEventRecord decoder that synthesises kind from entityType+action. |
| apps/ios/ADE/Views/Cto/CtoWorkflowsScreen.swift | Adds Linear issue browser with quick-view seeding, live search, and a detail sheet; isLoadingIssues guard prevents concurrent searches. |
| apps/desktop/src/shared/types/linearSync.ts | Makes entityType/action optional-nullable and adds normalizeLinearIngressEventKind/linearIngressKindFromParts helpers to unify iOS kind-only records with desktop entityType+action records. |
| apps/ios/ADE/Views/Lanes/LaneComponents.swift | Adds LaneLinearIssueBadge and shows Linear issue chips in LaneListRow and LaneStackCard; URL scheme validated before opening. |
| apps/ios/ADE/Views/Files/FilesDetailScreen.swift | Adds omitted-content fallback before binary check, and markdown preview path; showsCodeLayoutControl correctly excludes markdown files. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant iOS as iOS App
  participant SS as SyncService (Swift)
  participant RCS as syncRemoteCommandService (TS)
  participant LIT as LinearIssueTracker
  participant WRS as WorkerRevisionService

  iOS->>SS: fetchLinearQuickView()
  SS->>RCS: cto.getLinearQuickView
  RCS->>LIT: getConnectionStatus()
  LIT-->>RCS: connected true
  RCS->>LIT: getQuickView(connection)
  LIT-->>RCS: LinearQuickView
  RCS-->>iOS: LinearQuickView

  iOS->>SS: searchLinearIssues(args)
  SS->>RCS: cto.searchLinearIssues
  RCS->>LIT: searchIssues(query)
  LIT-->>RCS: issues and pageInfo
  RCS-->>iOS: LinearIssueSearchResult

  iOS->>SS: saveAgent(agent, actor mobile)
  SS->>RCS: cto.saveAgent agent actor mobile
  note over RCS: actor ignored hardcoded to user
  RCS->>WRS: saveAgent(agent, user)
  WRS-->>RCS: AgentIdentity
  RCS-->>iOS: AgentIdentity
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/ios/ADE/Views/PRs/PrMergeGateCard.swift`, line 2186-2202 ([link](https://github.com/arul28/ade/blob/c132df6c67eda2e1a70c402aef2f5699d49f413b/apps/ios/ADE/Views/PRs/PrMergeGateCard.swift#L2186-L2202)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **False-positive red gate when individual checks pass**

   Removing the `checks.isEmpty` guard from `summarySaysFailing` means the formula is now `failing = failingChecks + (summarySaysFailing ? 1 : 0)` regardless of whether individual check objects are available. When the individual `checks` array is populated and all entries are passing (`failingChecks == 0`), but `summaryChecksStatus` holds a stale "failing" string (common with combined-commit-status APIs that lag behind per-check updates), `failing` evaluates to `1` and the gate returns `.red`, blocking the merge button incorrectly.

   By contrast, the parallel `pending` logic deliberately guards against this double-count: `summarySaysPending && pendingChecks == 0`. The inconsistency strongly suggests `summarySaysFailing` should have the same guard. Without it, a PR where all visible checks have since turned green will keep showing a red merge gate until the summary status also refreshes.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ios/ADE/Views/PRs/PrMergeGateCard.swift
   Line: 2186-2202

   Comment:
   **False-positive red gate when individual checks pass**

   Removing the `checks.isEmpty` guard from `summarySaysFailing` means the formula is now `failing = failingChecks + (summarySaysFailing ? 1 : 0)` regardless of whether individual check objects are available. When the individual `checks` array is populated and all entries are passing (`failingChecks == 0`), but `summaryChecksStatus` holds a stale "failing" string (common with combined-commit-status APIs that lag behind per-check updates), `failing` evaluates to `1` and the gate returns `.red`, blocking the merge button incorrectly.

   By contrast, the parallel `pending` logic deliberately guards against this double-count: `summarySaysPending && pendingChecks == 0`. The inconsistency strongly suggests `summarySaysFailing` should have the same guard. Without it, a PR where all visible checks have since turned green will keep showing a red merge gate until the summary status also refreshes.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fios%2FADE%2FViews%2FPRs%2FPrMergeGateCard.swift%0ALine%3A%202186-2202%0A%0AComment%3A%0A**False-positive%20red%20gate%20when%20individual%20checks%20pass**%0A%0ARemoving%20the%20%60checks.isEmpty%60%20guard%20from%20%60summarySaysFailing%60%20means%20the%20formula%20is%20now%20%60failing%20%3D%20failingChecks%20%2B%20%28summarySaysFailing%20%3F%201%20%3A%200%29%60%20regardless%20of%20whether%20individual%20check%20objects%20are%20available.%20When%20the%20individual%20%60checks%60%20array%20is%20populated%20and%20all%20entries%20are%20passing%20%28%60failingChecks%20%3D%3D%200%60%29%2C%20but%20%60summaryChecksStatus%60%20holds%20a%20stale%20%22failing%22%20string%20%28common%20with%20combined-commit-status%20APIs%20that%20lag%20behind%20per-check%20updates%29%2C%20%60failing%60%20evaluates%20to%20%601%60%20and%20the%20gate%20returns%20%60.red%60%2C%20blocking%20the%20merge%20button%20incorrectly.%0A%0ABy%20contrast%2C%20the%20parallel%20%60pending%60%20logic%20deliberately%20guards%20against%20this%20double-count%3A%20%60summarySaysPending%20%26%26%20pendingChecks%20%3D%3D%200%60.%20The%20inconsistency%20strongly%20suggests%20%60summarySaysFailing%60%20should%20have%20the%20same%20guard.%20Without%20it%2C%20a%20PR%20where%20all%20visible%20checks%20have%20since%20turned%20green%20will%20keep%20showing%20a%20red%20merge%20gate%20until%20the%20summary%20status%20also%20refreshes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=394&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `apps/ios/ADE/Views/Cto/CtoTeamScreen.swift`, line 1334-1342 ([link](https://github.com/arul28/ade/blob/c132df6c67eda2e1a70c402aef2f5699d49f413b/apps/ios/ADE/Views/Cto/CtoTeamScreen.swift#L1334-L1342)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`parsedBudgetCents` never returns `nil`, making the optional return type misleading**

   The computed property is declared `Int?` but the `guard` clause falls through to `return 0` for every non-positive or invalid input (empty string, non-numeric text, zero or negative value). The optional is therefore never exercised — `AgentUpsertInput.budgetMonthlyCents` always receives `0`, not `nil`. If the server distinguishes between "field absent (nil)" and "budget explicitly set to zero", creating an agent with a blank budget field will silently send `0` rather than omitting the key. Consider returning `nil` for the empty/invalid case so the field can be omitted, and returning only truly positive values as non-nil cents.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ios/ADE/Views/Cto/CtoTeamScreen.swift
   Line: 1334-1342

   Comment:
   **`parsedBudgetCents` never returns `nil`, making the optional return type misleading**

   The computed property is declared `Int?` but the `guard` clause falls through to `return 0` for every non-positive or invalid input (empty string, non-numeric text, zero or negative value). The optional is therefore never exercised — `AgentUpsertInput.budgetMonthlyCents` always receives `0`, not `nil`. If the server distinguishes between "field absent (nil)" and "budget explicitly set to zero", creating an agent with a blank budget field will silently send `0` rather than omitting the key. Consider returning `nil` for the empty/invalid case so the field can be omitted, and returning only truly positive values as non-nil cents.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fios%2FADE%2FViews%2FCto%2FCtoTeamScreen.swift%0ALine%3A%201334-1342%0A%0AComment%3A%0A**%60parsedBudgetCents%60%20never%20returns%20%60nil%60%2C%20making%20the%20optional%20return%20type%20misleading**%0A%0AThe%20computed%20property%20is%20declared%20%60Int%3F%60%20but%20the%20%60guard%60%20clause%20falls%20through%20to%20%60return%200%60%20for%20every%20non-positive%20or%20invalid%20input%20%28empty%20string%2C%20non-numeric%20text%2C%20zero%20or%20negative%20value%29.%20The%20optional%20is%20therefore%20never%20exercised%20%E2%80%94%20%60AgentUpsertInput.budgetMonthlyCents%60%20always%20receives%20%600%60%2C%20not%20%60nil%60.%20If%20the%20server%20distinguishes%20between%20%22field%20absent%20%28nil%29%22%20and%20%22budget%20explicitly%20set%20to%20zero%22%2C%20creating%20an%20agent%20with%20a%20blank%20budget%20field%20will%20silently%20send%20%600%60%20rather%20than%20omitting%20the%20key.%20Consider%20returning%20%60nil%60%20for%20the%20empty%2Finvalid%20case%20so%20the%20field%20can%20be%20omitted%2C%20and%20returning%20only%20truly%20positive%20values%20as%20non-nil%20cents.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=394&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fade-cli%2Fsrc%2Fservices%2Fsync%2FsyncRemoteCommandService.ts%3A2579-2580%0A%60payload.actor%60%20from%20%60CtoSaveAgentPayload%60%20is%20silently%20discarded%20%E2%80%94%20the%20revision%20service%20always%20receives%20%60%22user%22%60.%20The%20iOS%20client%20passes%20%60actor%3A%20%22mobile%22%60%2C%20and%20the%20payload%20struct%20exists%20to%20carry%20this%20information.%20If%20the%20actor%20is%20used%20for%20audit%20logging%20or%20access%20control%20downstream%2C%20all%20mobile%20saves%20will%20be%20misattributed.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20actor%20%3D%20typeof%20payload.actor%20%3D%3D%3D%20%22string%22%20%26%26%20payload.actor.trim%28%29%20%3F%20payload.actor.trim%28%29%20%3A%20%22user%22%3B%0A%20%20%20%20const%20saved%20%3D%20workerRevisionService.saveAgent%28payload.agent%20as%20AgentUpsertInput%2C%20actor%29%3B%0A%20%20%20%20%28args.workerHeartbeatService%20as%20%7B%20syncFromConfig%3F%3A%20%28%29%20%3D%3E%20void%20%7D%20%7C%20null%20%7C%20undefined%29%3F.syncFromConfig%3F.%28%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fios%2FADE%2FViews%2FLanes%2FLaneComponents.swift%3A375-387%0A%60laneLinearIssueLinkCount%28for%3A%29%60%20is%20called%20twice%20in%20the%20%60else%20if%60%20branch%20%E2%80%94%20once%20for%20the%20condition%20and%20once%20inside%20the%20label%20text.%20Both%20calls%20are%20consistent%20%28no%20mutation%20between%20them%29%2C%20but%20binding%20the%20value%20once%20is%20cleaner.%20The%20same%20pattern%20appears%20in%20%60LaneStackCard%60%20around%20line%20651.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20if%20let%20issue%20%3D%20primaryLaneLinearIssue%28for%3A%20snapshot.lane%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20LaneMicroChip%28icon%3A%20%22link%22%2C%20text%3A%20issue.identifier%2C%20tint%3A%20ADEColor.accent%29%0A%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20let%20linkCount%20%3D%20laneLinearIssueLinkCount%28for%3A%20snapshot.lane%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20linkCount%20%3E%200%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20LaneMicroChip%28icon%3A%20%22link%22%2C%20text%3A%20%22%5C%28linkCount%29%22%2C%20tint%3A%20ADEColor.accent%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20if%20isPinned%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20LaneMicroChip%28icon%3A%20%22pin.fill%22%2C%20text%3A%20nil%2C%20tint%3A%20ADEColor.accent%29%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20.frame%28maxWidth%3A%20.infinity%2C%20alignment%3A%20.leading%29%0A%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20Spacer%28minLength%3A%208%29%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=394&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/ade-cli/src/services/sync/syncRemoteCommandService.ts:2579-2580
`payload.actor` from `CtoSaveAgentPayload` is silently discarded — the revision service always receives `"user"`. The iOS client passes `actor: "mobile"`, and the payload struct exists to carry this information. If the actor is used for audit logging or access control downstream, all mobile saves will be misattributed.

```suggestion
    const actor = typeof payload.actor === "string" && payload.actor.trim() ? payload.actor.trim() : "user";
    const saved = workerRevisionService.saveAgent(payload.agent as AgentUpsertInput, actor);
    (args.workerHeartbeatService as { syncFromConfig?: () => void } | null | undefined)?.syncFromConfig?.();
```

### Issue 2 of 2
apps/ios/ADE/Views/Lanes/LaneComponents.swift:375-387
`laneLinearIssueLinkCount(for:)` is called twice in the `else if` branch — once for the condition and once inside the label text. Both calls are consistent (no mutation between them), but binding the value once is cleaner. The same pattern appears in `LaneStackCard` around line 651.

```suggestion
          if let issue = primaryLaneLinearIssue(for: snapshot.lane) {
            LaneMicroChip(icon: "link", text: issue.identifier, tint: ADEColor.accent)
          } else {
            let linkCount = laneLinearIssueLinkCount(for: snapshot.lane)
            if linkCount > 0 {
              LaneMicroChip(icon: "link", text: "\(linkCount)", tint: ADEColor.accent)
            }
          }
          if isPinned {
            LaneMicroChip(icon: "pin.fill", text: nil, tint: ADEColor.accent)
          }
        }
        .frame(maxWidth: .infinity, alignment: .leading)
      }

      Spacer(minLength: 8)
```


`````

</details>

<sub>Reviews (5): Last reviewed commit: ["Address mobile parity review hardening"](https://github.com/arul28/ade/commit/cb72db307bcdd733d51c78fda5ade8d2b57ae7d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34507033)</sub>

<!-- /greptile_comment -->