### PR TITLE
Linear quick-view caching, OAuth token refresh, and project-scoped autolinks

### DIFF
--- a/apps/ade-cli/src/headlessLinearServices.ts
+++ b/apps/ade-cli/src/headlessLinearServices.ts
@@ -57,6 +57,10 @@ import { createProcessService as createProcessServiceImpl } from "../../desktop/
 import { createPrService as createPrServiceImpl } from "../../desktop/src/main/services/prs/prService";
 import { createAutomationSecretService as createAutomationSecretServiceImpl } from "../../desktop/src/main/services/automations/automationSecretService";
 import { EncryptedFileCredentialStore } from "./services/credentials/credentialStore";
+import {
+  linearTokenNeedsRefresh,
+  refreshLinearOAuthAccessToken,
+} from "../../desktop/src/main/services/cto/linearTokenRefresh";
 
 // Keep headless runtimes aligned with the desktop credential service so packaged
 // alpha builds can offer the same PKCE-based Linear sign-in flow.
@@ -94,6 +98,7 @@ type HeadlessLinearCredentialService = {
     clientId: string;
     clientSecret: string | null;
   } | null;
+  ensureFreshToken: (opts?: { force?: boolean }) => Promise<void>;
 };
 
 type HeadlessGitHubStatus = {
@@ -1229,6 +1234,46 @@ function createHeadlessLinearCredentialService(args: {
     }
   };
 
+  // Refresh an OAuth access token near expiry (parity with the desktop service)
+  // so headless `ade serve` Linear connections survive past Linear's ~24h token
+  // lifetime. No-op for manual tokens / env tokens / when no refresh token.
+  let refreshInFlight: Promise<void> | null = null;
+  const ensureFreshToken = async (opts?: { force?: boolean }): Promise<void> => {
+    if (readCredential(authModeKey) !== "oauth") return;
+    const refreshToken = readCredential(refreshTokenKey);
+    if (!refreshToken) return;
+    if (!opts?.force && !linearTokenNeedsRefresh(readCredential(tokenExpiresAtKey), Date.now())) return;
+    if (refreshInFlight) {
+      await refreshInFlight;
+      return;
+    }
+    const client = readOAuthClientCredentials();
+    if (!client) return;
+    refreshInFlight = (async () => {
+      const result = await refreshLinearOAuthAccessToken({
+        refreshToken,
+        clientId: client.clientId,
+        clientSecret: client.clientSecret,
+      });
+      if (result.ok) {
+        tokenOverride = result.accessToken;
+        writeCredential(tokenKey, result.accessToken);
+        writeCredential(authModeKey, "oauth");
+        writeCredential(refreshTokenKey, result.refreshToken ?? refreshToken);
+        writeCredential(tokenExpiresAtKey, result.expiresAt);
+      } else if (result.invalidGrant) {
+        tokenOverride = "";
+        writeCredential(tokenKey, null);
+        writeCredential(authModeKey, null);
+        writeCredential(refreshTokenKey, null);
+        writeCredential(tokenExpiresAtKey, null);
+      }
+    })().finally(() => {
+      refreshInFlight = null;
+    });
+    await refreshInFlight;
+  };
+
   return {
     getStatus() {
       const { token, source } = readToken();
@@ -1310,6 +1355,7 @@ function createHeadlessLinearCredentialService(args: {
     getOAuthClientCredentials() {
       return readOAuthClientCredentials();
     },
+    ensureFreshToken,
   };
 }
 

--- a/apps/desktop/src/main/services/cto/linearAuth.test.ts
+++ b/apps/desktop/src/main/services/cto/linearAuth.test.ts
@@ -1181,3 +1181,113 @@ describe("linearClient", () => {
     await expect(client.getViewer()).resolves.toEqual({ id: "viewer-1", name: "Alex" });
   });
 });
+
+describe("linearCredentialService OAuth token refresh", () => {
+  const ENV_KEYS = ["ADE_LINEAR_API", "LINEAR_API_KEY", "ADE_LINEAR_TOKEN", "LINEAR_TOKEN"] as const;
+  let savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  function makeService(fetchImpl: unknown) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ade-linear-refresh-"));
+    return createLinearCredentialService({
+      adeDir: path.join(root, ".ade"),
+      logger: createLogger(),
+      credentialStore: new MemoryCredentialStore(),
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+  }
+
+  function okResponse(payload: unknown) {
+    return { ok: true, status: 200, json: async () => payload };
+  }
+
+  it("refreshes an OAuth access token near expiry and rotates the refresh token", async () => {
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
+      okResponse({ access_token: "at_refreshed", refresh_token: "rt_rotated", expires_in: 86399 }),
+    );
+    const service = makeService(fetchImpl);
+    // 30s from expiry -> inside the refresh buffer.
+    service.setOAuthToken({
+      accessToken: "at_old",
+      refreshToken: "rt_old",
+      expiresAt: new Date(Date.now() + 30_000).toISOString(),
+    });
+
+    await service.ensureFreshToken();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(String(fetchImpl.mock.calls[0][1]?.body ?? "")).toContain("grant_type=refresh_token");
+    expect(service.getToken()).toBe("at_refreshed");
+    expect(service.getStatus()).toMatchObject({ authMode: "oauth", refreshTokenStored: true });
+  });
+
+  it("does not refresh a manual token or a still-fresh OAuth token", async () => {
+    const fetchImpl = vi.fn(async () => okResponse({}));
+    const service = makeService(fetchImpl);
+
+    service.setToken("lin_api_manual");
+    await service.ensureFreshToken();
+
+    service.setOAuthToken({
+      accessToken: "at_fresh",
+      refreshToken: "rt",
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    });
+    await service.ensureFreshToken();
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(service.getToken()).toBe("at_fresh");
+  });
+
+  it("clears the connection when the refresh token is rejected (invalid_grant)", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "invalid_grant" }),
+    }));
+    const service = makeService(fetchImpl);
+    service.setOAuthToken({
+      accessToken: "at_old",
+      refreshToken: "rt_dead",
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    });
+
+    await service.ensureFreshToken();
+
+    expect(service.getToken()).toBeNull();
+    expect(service.getStatus().tokenStored).toBe(false);
+  });
+
+  it("keeps the existing token on a transient refresh failure", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    }));
+    const service = makeService(fetchImpl);
+    service.setOAuthToken({
+      accessToken: "at_keep",
+      refreshToken: "rt",
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    });
+
+    await service.ensureFreshToken();
+
+    expect(service.getToken()).toBe("at_keep");
+    expect(service.getStatus().tokenStored).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/services/cto/linearClient.ts
+++ b/apps/desktop/src/main/services/cto/linearClient.ts
@@ -195,21 +195,34 @@ export function createLinearClient(args: LinearClientArgs) {
     throw new Error("Linear credential auth mode is missing or unknown.");
   };
 
+  const ensureFreshAuth = async (opts?: { force?: boolean }): Promise<void> => {
+    try {
+      await args.credentials.ensureFreshToken?.(opts);
+    } catch {
+      // Best effort: a refresh failure must not block the request. If the token
+      // is truly dead, the request below surfaces its own auth error.
+    }
+  };
+
   const request = async <TData = Record<string, unknown>>(params: {
     query: string;
     variables?: Record<string, unknown>;
     maxRetries?: number;
   }): Promise<TData> => {
-    const token = toAuthorizationHeaderValue(
-      args.credentials.getTokenOrThrow(),
-      args.credentials.getStatus().authMode
-    );
+    // Proactively refresh an OAuth token that is at/near expiry before sending.
+    await ensureFreshAuth();
     const maxRetries = Math.max(0, Math.floor(params.maxRetries ?? 3));
     let attempt = 0;
     let backoffMs = 500;
+    let didAuthRefresh = false;
 
     while (true) {
       attempt += 1;
+      // Re-read per attempt so a refresh between attempts uses the new token.
+      const token = toAuthorizationHeaderValue(
+        args.credentials.getTokenOrThrow(),
+        args.credentials.getStatus().authMode
+      );
       try {
         const res = await fetchImpl(LINEAR_GRAPHQL_URL, {
           method: "POST",
@@ -227,6 +240,20 @@ export function createLinearClient(args: LinearClientArgs) {
 
         const message = payload.errors?.[0]?.message ?? null;
         const errorCode = payload.errors?.[0]?.extensions?.code ?? null;
+
+        // Reactive refresh: if the access token was rejected, refresh once and
+        // retry with the new token (covers a token already expired by the time
+        // the request fired, or one with no recorded expiry).
+        const isAuthError =
+          res.status === 401 ||
+          errorCode === "AUTHENTICATION_ERROR" ||
+          (message ? /authentication|unauthor|invalid.*token|token.*expired/i.test(message) : false);
+        if (isAuthError && !didAuthRefresh && args.credentials.getStatus().authMode === "oauth") {
+          didAuthRefresh = true;
+          await ensureFreshAuth({ force: true });
+          continue;
+        }
+
         const isRateLimited =
           res.status === 429 ||
           errorCode === "RATELIMITED" ||
@@ -663,6 +690,7 @@ export function createLinearClient(args: LinearClientArgs) {
   };
 
   const getQuickView = async (connection: CtoLinearQuickView["connection"]): Promise<CtoLinearQuickView> => {
+    await ensureFreshAuth();
     const sdk = createSdkClient();
     // Recent issues fetched via raw GraphQL (single request with ISSUE_FIELDS_FRAGMENT)
     // to avoid the lazy-relation fan-out that the SDK normalizer triggers.

--- a/apps/desktop/src/main/services/cto/linearCredentialService.ts
+++ b/apps/desktop/src/main/services/cto/linearCredentialService.ts
@@ -5,6 +5,10 @@ import { safeStorage } from "electron";
 import type { Logger } from "../logging/logger";
 import { isRecord, getErrorMessage, isEnoentError } from "../shared/utils";
 import type { SyncCredentialStore } from "../../../../../ade-cli/src/services/credentials/credentialStore";
+import {
+  linearTokenNeedsRefresh,
+  refreshLinearOAuthAccessToken,
+} from "./linearTokenRefresh";
 
 // Bundled OAuth client ID — ships with ADE so users get "Sign in with Linear"
 // out of the box without configuring their own OAuth app.
@@ -34,6 +38,7 @@ type LinearCredentialServiceArgs = {
   adeDir: string;
   logger?: Logger | null;
   credentialStore?: SyncCredentialStore | null;
+  fetchImpl?: typeof fetch;
 };
 
 type StoredLinearToken = {
@@ -507,6 +512,63 @@ export function createLinearCredentialService(args: LinearCredentialServiceArgs)
     return null;
   };
 
+  // Refresh the OAuth access token via grant_type=refresh_token when it is at or
+  // near expiry (Linear tokens expire ~24h after sign-in). Concurrent callers
+  // share one in-flight refresh. No-op for manual tokens / API keys (they don't
+  // expire) and when no refresh token is stored.
+  let refreshInFlight: Promise<void> | null = null;
+
+  const ensureFreshToken = async (opts?: { force?: boolean }): Promise<void> => {
+    const stored = getStoredToken();
+    if (!stored || stored.authMode !== "oauth" || !stored.refreshToken) return;
+    if (!opts?.force && !linearTokenNeedsRefresh(stored.expiresAt, Date.now())) return;
+    if (refreshInFlight) {
+      await refreshInFlight;
+      return;
+    }
+    const client = readOAuthClientCredentials();
+    if (!client) return;
+    const refreshToken = stored.refreshToken;
+    refreshInFlight = (async () => {
+      const result = await refreshLinearOAuthAccessToken({
+        refreshToken,
+        clientId: client.clientId,
+        clientSecret: client.clientSecret,
+        fetchImpl: args.fetchImpl,
+      });
+      if (result.ok) {
+        persistToken({
+          token: result.accessToken,
+          authMode: "oauth",
+          refreshToken: result.refreshToken ?? refreshToken,
+          expiresAt: result.expiresAt,
+        });
+        invalidateCache();
+        args.logger?.info("linear_sync.oauth_token_refreshed", {
+          expiresAt: result.expiresAt,
+        });
+      } else if (result.invalidGrant) {
+        // Refresh token revoked/expired — clear the connection so the UI prompts
+        // the user to reconnect rather than retrying a dead token forever.
+        persistToken(null);
+        invalidateCache();
+        args.logger?.warn("linear_sync.oauth_refresh_invalid_grant", {
+          status: result.status,
+          message: result.message,
+        });
+      } else {
+        // Transient (network / 5xx): keep the token and let the caller retry.
+        args.logger?.warn("linear_sync.oauth_refresh_failed", {
+          status: result.status,
+          message: result.message,
+        });
+      }
+    })().finally(() => {
+      refreshInFlight = null;
+    });
+    await refreshInFlight;
+  };
+
   return {
     getToken(): string | null {
       return getStoredToken()?.token ?? null;
@@ -582,6 +644,8 @@ export function createLinearCredentialService(args: LinearCredentialServiceArgs)
     getOAuthClientCredentials(): LinearOAuthClientCredentials | null {
       return readOAuthClientCredentials();
     },
+
+    ensureFreshToken,
   };
 }
 

--- a/apps/desktop/src/main/services/cto/linearTokenRefresh.test.ts
+++ b/apps/desktop/src/main/services/cto/linearTokenRefresh.test.ts
@@ -80,4 +80,16 @@ describe("refreshLinearOAuthAccessToken", () => {
     expect(await refreshLinearOAuthAccessToken({ ...base, fetchImpl: net as unknown as typeof fetch }))
       .toMatchObject({ ok: false, invalidGrant: false, status: 0, message: "ECONNRESET" });
   });
+
+  it("does not flag client-config / non-invalid_grant 4xx as invalidGrant (keeps the token)", async () => {
+    // invalid_client (wrong/misconfigured client) must NOT delete the refresh token.
+    const badClient = vi.fn(async () => errResponse(401, { error: "invalid_client", error_description: "bad client" }));
+    expect(await refreshLinearOAuthAccessToken({ ...base, fetchImpl: badClient as unknown as typeof fetch }))
+      .toMatchObject({ ok: false, invalidGrant: false, status: 401 });
+
+    // invalid_request (malformed) is our bug, not a dead token.
+    const malformed = vi.fn(async () => errResponse(400, { error: "invalid_request" }));
+    expect(await refreshLinearOAuthAccessToken({ ...base, fetchImpl: malformed as unknown as typeof fetch }))
+      .toMatchObject({ ok: false, invalidGrant: false, status: 400 });
+  });
 });

--- a/apps/desktop/src/main/services/cto/linearTokenRefresh.test.ts
+++ b/apps/desktop/src/main/services/cto/linearTokenRefresh.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  LINEAR_OAUTH_TOKEN_URL,
+  linearTokenNeedsRefresh,
+  refreshLinearOAuthAccessToken,
+} from "./linearTokenRefresh";
+
+const NOW = Date.parse("2026-05-29T12:00:00.000Z");
+
+function okResponse(payload: unknown) {
+  return { ok: true, status: 200, json: async () => payload } as unknown as Response;
+}
+function errResponse(status: number, payload: unknown) {
+  return { ok: false, status, json: async () => payload } as unknown as Response;
+}
+
+describe("linearTokenNeedsRefresh", () => {
+  it("returns false when there is no usable expiry", () => {
+    expect(linearTokenNeedsRefresh(null, NOW)).toBe(false);
+    expect(linearTokenNeedsRefresh(undefined, NOW)).toBe(false);
+    expect(linearTokenNeedsRefresh("not-a-date", NOW)).toBe(false);
+  });
+
+  it("returns false when the token is comfortably fresh", () => {
+    expect(linearTokenNeedsRefresh(new Date(NOW + 60 * 60 * 1000).toISOString(), NOW)).toBe(false);
+  });
+
+  it("returns true at or within the refresh buffer of expiry", () => {
+    // 60s out is inside the 2-minute buffer.
+    expect(linearTokenNeedsRefresh(new Date(NOW + 60 * 1000).toISOString(), NOW)).toBe(true);
+    // already expired.
+    expect(linearTokenNeedsRefresh(new Date(NOW - 1000).toISOString(), NOW)).toBe(true);
+  });
+});
+
+describe("refreshLinearOAuthAccessToken", () => {
+  const base = { refreshToken: "rt_old", clientId: "client-123" };
+
+  it("exchanges the refresh token, rotates it, and computes the new expiry", async () => {
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
+      okResponse({ access_token: "at_new", refresh_token: "rt_new", expires_in: 86399 }),
+    );
+    const result = await refreshLinearOAuthAccessToken({ ...base, fetchImpl: fetchImpl as unknown as typeof fetch, nowMs: NOW });
+
+    expect(result).toEqual({
+      ok: true,
+      accessToken: "at_new",
+      refreshToken: "rt_new",
+      expiresAt: new Date(NOW + 86399 * 1000).toISOString(),
+    });
+    const call = fetchImpl.mock.calls[0];
+    expect(call[0]).toBe(LINEAR_OAUTH_TOKEN_URL);
+    const body = String(call[1]?.body ?? "");
+    expect(body).toContain("grant_type=refresh_token");
+    expect(body).toContain("refresh_token=rt_old");
+    expect(body).toContain("client_id=client-123");
+    expect(body).not.toContain("client_secret");
+  });
+
+  it("includes client_secret only for a confidential client", async () => {
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
+      okResponse({ access_token: "at", expires_in: 100 }),
+    );
+    await refreshLinearOAuthAccessToken({ ...base, clientSecret: "shh", fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(String(fetchImpl.mock.calls[0][1]?.body ?? "")).toContain("client_secret=shh");
+  });
+
+  it("flags invalid_grant as a dead refresh token (caller should reconnect)", async () => {
+    const fetchImpl = vi.fn(async () => errResponse(400, { error: "invalid_grant", error_description: "expired" }));
+    const result = await refreshLinearOAuthAccessToken({ ...base, fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(result).toMatchObject({ ok: false, invalidGrant: true, status: 400, message: "expired" });
+  });
+
+  it("treats 5xx and network errors as transient, not invalid_grant", async () => {
+    const five = vi.fn(async () => errResponse(503, {}));
+    expect(await refreshLinearOAuthAccessToken({ ...base, fetchImpl: five as unknown as typeof fetch }))
+      .toMatchObject({ ok: false, invalidGrant: false, status: 503 });
+
+    const net = vi.fn(async () => { throw new Error("ECONNRESET"); });
+    expect(await refreshLinearOAuthAccessToken({ ...base, fetchImpl: net as unknown as typeof fetch }))
+      .toMatchObject({ ok: false, invalidGrant: false, status: 0, message: "ECONNRESET" });
+  });
+});

--- a/apps/desktop/src/main/services/cto/linearTokenRefresh.ts
+++ b/apps/desktop/src/main/services/cto/linearTokenRefresh.ts
@@ -102,13 +102,13 @@ export async function refreshLinearOAuthAccessToken(params: {
     typeof payload.access_token !== "string" ||
     !payload.access_token.trim()
   ) {
-    // 400/401 or an explicit invalid_grant means the refresh token is dead;
-    // 5xx / network failures are transient and should be retried later.
-    const invalidGrant =
-      payload.error === "invalid_grant" ||
-      payload.error === "invalid_request" ||
-      res.status === 400 ||
-      res.status === 401;
+    // Only an explicit `invalid_grant` reliably means the refresh token itself
+    // is dead (expired / revoked) and the user must reconnect — see RFC 6749
+    // §5.2. `invalid_client` (wrong or misconfigured client → 400/401),
+    // `invalid_request` (malformed), other 4xx, and 5xx/network failures are
+    // NOT the token's fault: keep the token so a client-config or transient
+    // error never silently deletes a still-valid refresh token; retry later.
+    const invalidGrant = payload.error === "invalid_grant";
     return {
       ok: false,
       status: res.status,

--- a/apps/desktop/src/main/services/cto/linearTokenRefresh.ts
+++ b/apps/desktop/src/main/services/cto/linearTokenRefresh.ts
@@ -1,0 +1,138 @@
+// Shared Linear OAuth token-refresh helper used by both the desktop credential
+// service and the headless (ade serve) credential service.
+//
+// Linear OAuth access tokens expire after ~24h ("expires_in": 86399) and Linear
+// issues a rotating refresh_token. Without refreshing, an OAuth connection
+// silently breaks a day after sign-in. This helper performs the
+// grant_type=refresh_token exchange; the credential services decide when to call
+// it (proactively near expiry, or reactively on a 401).
+
+export const LINEAR_OAUTH_TOKEN_URL = "https://api.linear.app/oauth/token";
+
+// Refresh this far before the recorded expiry so an in-flight request never
+// races the expiry boundary.
+export const LINEAR_TOKEN_REFRESH_BUFFER_MS = 2 * 60 * 1000;
+
+/**
+ * True when an OAuth access token with the given ISO `expiresAt` is at or within
+ * the refresh buffer of expiry. Returns false when there is no usable expiry
+ * (nothing to refresh proactively — the reactive 401 path still applies).
+ */
+export function linearTokenNeedsRefresh(
+  expiresAt: string | null | undefined,
+  nowMs: number,
+  bufferMs: number = LINEAR_TOKEN_REFRESH_BUFFER_MS,
+): boolean {
+  if (!expiresAt) return false;
+  const expMs = Date.parse(expiresAt);
+  if (!Number.isFinite(expMs)) return false;
+  return nowMs >= expMs - bufferMs;
+}
+
+export type LinearTokenRefreshResult =
+  | {
+      ok: true;
+      accessToken: string;
+      refreshToken: string | null;
+      expiresAt: string | null;
+    }
+  | {
+      ok: false;
+      /** HTTP status (0 for a network/transport error). */
+      status: number;
+      /**
+       * The refresh token is no longer valid (revoked / expired / already
+       * rotated). The caller should clear the connection and prompt re-auth.
+       * Distinguished from transient failures, which should leave the token in
+       * place and be retried later.
+       */
+      invalidGrant: boolean;
+      message: string;
+    };
+
+/**
+ * Exchange a Linear refresh token for a new access token via
+ * grant_type=refresh_token. Public (PKCE) clients omit the secret; confidential
+ * clients pass it when present.
+ */
+export async function refreshLinearOAuthAccessToken(params: {
+  refreshToken: string;
+  clientId: string;
+  clientSecret?: string | null;
+  fetchImpl?: typeof fetch;
+  tokenUrl?: string;
+  nowMs?: number;
+}): Promise<LinearTokenRefreshResult> {
+  const fetchImpl = params.fetchImpl ?? fetch;
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: params.refreshToken,
+    client_id: params.clientId,
+  });
+  if (params.clientSecret?.trim()) {
+    body.set("client_secret", params.clientSecret.trim());
+  }
+
+  let res: Response;
+  try {
+    res = await fetchImpl(params.tokenUrl ?? LINEAR_OAUTH_TOKEN_URL, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    });
+  } catch (error: unknown) {
+    return {
+      ok: false,
+      status: 0,
+      invalidGrant: false,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const payload = (await res.json().catch(() => ({}))) as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+    error?: string;
+    error_description?: string;
+  };
+
+  if (
+    !res.ok ||
+    typeof payload.access_token !== "string" ||
+    !payload.access_token.trim()
+  ) {
+    // 400/401 or an explicit invalid_grant means the refresh token is dead;
+    // 5xx / network failures are transient and should be retried later.
+    const invalidGrant =
+      payload.error === "invalid_grant" ||
+      payload.error === "invalid_request" ||
+      res.status === 400 ||
+      res.status === 401;
+    return {
+      ok: false,
+      status: res.status,
+      invalidGrant,
+      message:
+        payload.error_description ??
+        payload.error ??
+        `Linear token refresh failed (HTTP ${res.status}).`,
+    };
+  }
+
+  const nowMs = params.nowMs ?? Date.now();
+  const expiresAt =
+    typeof payload.expires_in === "number" && Number.isFinite(payload.expires_in)
+      ? new Date(nowMs + payload.expires_in * 1000).toISOString()
+      : null;
+
+  return {
+    ok: true,
+    accessToken: payload.access_token.trim(),
+    refreshToken:
+      typeof payload.refresh_token === "string" && payload.refresh_token.trim()
+        ? payload.refresh_token.trim()
+        : null,
+    expiresAt,
+  };
+}

--- a/apps/desktop/src/renderer/components/app/LinearIssueBrowser.tsx
+++ b/apps/desktop/src/renderer/components/app/LinearIssueBrowser.tsx
@@ -22,6 +22,8 @@ import type {
   CtoLinearProject,
   CtoLinearQuickView,
   CtoLinearQuickViewProject,
+  CtoSearchLinearIssuesArgs,
+  CtoSearchLinearIssuesResult,
   LaneLinearIssue,
   NormalizedLinearIssue,
 } from "../../../shared/types";
@@ -34,7 +36,7 @@ import {
   linearPriorityLabel,
   toLaneLinearIssue,
 } from "../lanes/LinearIssuePicker";
-import { LinearPriorityIcon, LinearStateIcon, LINEAR_BRAND } from "../lanes/linearBrand";
+import { LinearPriorityIcon, LinearStateIcon } from "../lanes/linearBrand";
 import { LinearProjectIcon } from "../lanes/linearProjectIcon";
 import { LinearIssueOpenLink, type LinearIssueResolveModalKind } from "./LinearIssueResolveModals";
 
@@ -59,6 +61,8 @@ const STATE_TABS = [
 const ACTIVE_LINEAR_STATE_TYPES = ["backlog", "unstarted", "started"];
 const STATE_GROUP_ORDER = ["started", "unstarted", "backlog", "triage", "completed", "canceled", "duplicate"] as const;
 const FILTER_STORAGE_PREFIX = "ade.linear.quickView.filters.v1:";
+const LINEAR_BROWSER_CACHE_STALE_MS = 90_000;
+const LINEAR_BROWSER_CACHE_MAX_SEARCHES = 16;
 
 const DEFAULT_FILTERS: LinearIssueBrowserFilters = {
   projectId: "",
@@ -85,6 +89,119 @@ const SORT_OPTIONS: ReadonlyArray<{ value: IssueSort; label: string }> = [
   { value: "due_soon", label: "Due soon" },
   { value: "identifier_asc", label: "Issue key" },
 ];
+
+type LinearIssueSearchCacheEntry = {
+  result: CtoSearchLinearIssuesResult | null;
+  fetchedAt: number;
+  promise: Promise<CtoSearchLinearIssuesResult> | null;
+};
+
+type LinearIssueBrowserCacheEntry = {
+  quickView: CtoLinearQuickView | null;
+  quickViewFetchedAt: number;
+  quickViewPromise: Promise<CtoLinearQuickView> | null;
+  catalog: CtoGetLinearIssuePickerDataResult | null;
+  catalogFetchedAt: number;
+  catalogPromise: Promise<CtoGetLinearIssuePickerDataResult> | null;
+  searches: Map<string, LinearIssueSearchCacheEntry>;
+};
+
+const linearIssueBrowserCache = new Map<string, LinearIssueBrowserCacheEntry>();
+const ctoCacheScopes = new WeakMap<object, number>();
+let nextCtoCacheScope = 1;
+
+function getCtoCacheScope(cto: unknown): string {
+  if (!cto || (typeof cto !== "object" && typeof cto !== "function")) return "none";
+  const target = cto as object;
+  const current = ctoCacheScopes.get(target);
+  if (current) return String(current);
+  const next = nextCtoCacheScope++;
+  ctoCacheScopes.set(target, next);
+  return String(next);
+}
+
+function browserCacheKey(projectRoot: string | null | undefined): string {
+  const root = projectRoot?.trim() || "__project__";
+  const cto = typeof window === "undefined" ? null : window.ade?.cto;
+  return `${root}::cto:${getCtoCacheScope(cto)}`;
+}
+
+function emptyCatalog(): CtoGetLinearIssuePickerDataResult {
+  return { projects: [], users: [], states: [] };
+}
+
+function emptyPageInfo(): CtoSearchLinearIssuesResult["pageInfo"] {
+  return { hasNextPage: false, endCursor: null };
+}
+
+function getBrowserCacheEntry(key: string): LinearIssueBrowserCacheEntry {
+  const existing = linearIssueBrowserCache.get(key);
+  if (existing) return existing;
+  const next: LinearIssueBrowserCacheEntry = {
+    quickView: null,
+    quickViewFetchedAt: 0,
+    quickViewPromise: null,
+    catalog: null,
+    catalogFetchedAt: 0,
+    catalogPromise: null,
+    searches: new Map(),
+  };
+  linearIssueBrowserCache.set(key, next);
+  return next;
+}
+
+function cacheIsFresh(fetchedAt: number): boolean {
+  return fetchedAt > 0 && Date.now() - fetchedAt < LINEAR_BROWSER_CACHE_STALE_MS;
+}
+
+function buildIssueSearchArgs(
+  filters: LinearIssueBrowserFilters,
+  after: string | null,
+): CtoSearchLinearIssuesArgs {
+  return {
+    projectId: filters.projectId || null,
+    stateTypes: stateTypesForPreset(filters.statePreset),
+    assigneeId: filters.assigneeId || null,
+    priority: filters.priority ? Number(filters.priority) : null,
+    query: filters.query.trim() || null,
+    first: 50,
+    after,
+    includeArchived: false,
+  };
+}
+
+function searchCacheKey(args: CtoSearchLinearIssuesArgs): string {
+  return JSON.stringify({
+    projectId: args.projectId ?? null,
+    stateTypes: [...(args.stateTypes ?? [])].sort(),
+    assigneeId: args.assigneeId ?? null,
+    priority: args.priority ?? null,
+    query: args.query ?? null,
+    first: args.first ?? 50,
+    after: args.after ?? null,
+    includeArchived: args.includeArchived ?? false,
+  });
+}
+
+function readCachedSearch(
+  key: string,
+  filters: LinearIssueBrowserFilters,
+): CtoSearchLinearIssuesResult | null {
+  return getBrowserCacheEntry(key).searches.get(searchCacheKey(buildIssueSearchArgs(filters, null)))?.result ?? null;
+}
+
+function rememberSearchResult(
+  entry: LinearIssueBrowserCacheEntry,
+  key: string,
+  result: CtoSearchLinearIssuesResult,
+): void {
+  entry.searches.set(key, { result, fetchedAt: Date.now(), promise: null });
+  while (entry.searches.size > LINEAR_BROWSER_CACHE_MAX_SEARCHES) {
+    const oldestKey = entry.searches.keys().next().value as string | undefined;
+    if (!oldestKey) break;
+    entry.searches.delete(oldestKey);
+  }
+}
 
 function storageKey(projectRoot: string | null | undefined): string | null {
   const root = projectRoot?.trim();
@@ -277,12 +394,12 @@ export function LinearIssueBrowser({
     batchProgress: { completed: number; total: number; action: string } | null;
   };
 }) {
-  const [quickView, setQuickView] = useState<CtoLinearQuickView | null>(null);
-  const quickViewRef = useRef<CtoLinearQuickView | null>(null);
-  const [catalog, setCatalog] = useState<CtoGetLinearIssuePickerDataResult>({ projects: [], users: [], states: [] });
+  const cacheKey = browserCacheKey(projectRoot);
+  const [quickView, setQuickView] = useState<CtoLinearQuickView | null>(() => getBrowserCacheEntry(cacheKey).quickView);
+  const [catalog, setCatalog] = useState<CtoGetLinearIssuePickerDataResult>(() => getBrowserCacheEntry(cacheKey).catalog ?? emptyCatalog());
   const [filters, setFilters] = useState<LinearIssueBrowserFilters>(() => safeLoadFilters(projectRoot));
-  const [issues, setIssues] = useState<NormalizedLinearIssue[]>([]);
-  const [pageInfo, setPageInfo] = useState<{ hasNextPage: boolean; endCursor: string | null }>({ hasNextPage: false, endCursor: null });
+  const [issues, setIssues] = useState<NormalizedLinearIssue[]>(() => readCachedSearch(cacheKey, safeLoadFilters(projectRoot))?.issues ?? []);
+  const [pageInfo, setPageInfo] = useState<{ hasNextPage: boolean; endCursor: string | null }>(() => readCachedSearch(cacheKey, safeLoadFilters(projectRoot))?.pageInfo ?? emptyPageInfo());
   const pageInfoRef = useRef(pageInfo);
   const [loadingQuickView, setLoadingQuickView] = useState(false);
   const [loadingCatalog, setLoadingCatalog] = useState(false);
@@ -295,10 +412,10 @@ export function LinearIssueBrowser({
   const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>({});
   const [error, setError] = useState<string | null>(null);
   const quickViewRequestIdRef = useRef(0);
+  const catalogRequestIdRef = useRef(0);
   const searchRequestIdRef = useRef(0);
 
   useEffect(() => {
-    quickViewRef.current = quickView;
     onQuickViewChange?.(quickView);
   }, [onQuickViewChange, quickView]);
 
@@ -307,10 +424,15 @@ export function LinearIssueBrowser({
   }, [pageInfo]);
 
   useEffect(() => {
-    setFilters(safeLoadFilters(projectRoot));
-    setIssues([]);
-    setPageInfo({ hasNextPage: false, endCursor: null });
-  }, [projectRoot]);
+    const nextFilters = safeLoadFilters(projectRoot);
+    const entry = getBrowserCacheEntry(cacheKey);
+    const cachedSearch = readCachedSearch(cacheKey, nextFilters);
+    setFilters(nextFilters);
+    setQuickView(entry.quickView);
+    setCatalog(entry.catalog ?? emptyCatalog());
+    setIssues(cachedSearch?.issues ?? []);
+    setPageInfo(cachedSearch?.pageInfo ?? emptyPageInfo());
+  }, [cacheKey, projectRoot]);
 
   useEffect(() => {
     if (featuredIssue && !selectedIssueId) {
@@ -324,42 +446,83 @@ export function LinearIssueBrowser({
   }, [loading, onLoadingChange]);
 
   const loadQuickView = useCallback((force = false) => {
+    const entry = getBrowserCacheEntry(cacheKey);
     if (!window.ade.cto?.getLinearQuickView) return;
-    if (!force && quickViewRef.current) return;
+    if (!force && entry.quickView && cacheIsFresh(entry.quickViewFetchedAt)) {
+      setQuickView(entry.quickView);
+      onConnectionVisibilityChange?.(entry.quickView.connection.connected === true);
+      return;
+    }
+    if (entry.quickView) {
+      setQuickView(entry.quickView);
+      onConnectionVisibilityChange?.(entry.quickView.connection.connected === true);
+    }
     const requestId = quickViewRequestIdRef.current + 1;
     quickViewRequestIdRef.current = requestId;
-    setLoadingQuickView(true);
+    setLoadingQuickView(force || !entry.quickView);
     setError(null);
-    void window.ade.cto.getLinearQuickView()
+    const promise = entry.quickViewPromise ?? window.ade.cto.getLinearQuickView();
+    entry.quickViewPromise = promise;
+    void promise
       .then((data) => {
+        entry.quickView = data;
+        entry.quickViewFetchedAt = Date.now();
+        entry.quickViewPromise = null;
         if (quickViewRequestIdRef.current !== requestId) return;
         setQuickView(data);
         onConnectionVisibilityChange?.(data.connection.connected === true);
       })
       .catch((err) => {
+        entry.quickViewPromise = null;
         if (quickViewRequestIdRef.current !== requestId) return;
-        setError(err instanceof Error ? err.message : "Unable to load Linear.");
+        if (!entry.quickView || force) {
+          setError(err instanceof Error ? err.message : "Unable to load Linear.");
+        }
       })
       .finally(() => {
         if (quickViewRequestIdRef.current === requestId) setLoadingQuickView(false);
       });
-  }, [onConnectionVisibilityChange]);
+  }, [cacheKey, onConnectionVisibilityChange]);
 
-  const loadCatalog = useCallback(() => {
+  const loadCatalog = useCallback((force = false) => {
+    const entry = getBrowserCacheEntry(cacheKey);
     const cto = window.ade.cto;
     if (!cto?.getLinearIssuePickerData) {
       setError("Linear controls are not available in this ADE surface.");
       return;
     }
-    setLoadingCatalog(true);
+    if (!force && entry.catalog && cacheIsFresh(entry.catalogFetchedAt)) {
+      setCatalog(entry.catalog);
+      return;
+    }
+    if (entry.catalog) setCatalog(entry.catalog);
+    const requestId = catalogRequestIdRef.current + 1;
+    catalogRequestIdRef.current = requestId;
+    setLoadingCatalog(force || !entry.catalog);
     setError(null);
-    void cto.getLinearIssuePickerData()
-      .then((data) => setCatalog(data))
-      .catch((err) => setError(err instanceof Error ? err.message : "Unable to load Linear filters."))
-      .finally(() => setLoadingCatalog(false));
-  }, []);
+    const promise = entry.catalogPromise ?? cto.getLinearIssuePickerData();
+    entry.catalogPromise = promise;
+    void promise
+      .then((data) => {
+        entry.catalog = data;
+        entry.catalogFetchedAt = Date.now();
+        entry.catalogPromise = null;
+        if (catalogRequestIdRef.current !== requestId) return;
+        setCatalog(data);
+      })
+      .catch((err) => {
+        entry.catalogPromise = null;
+        if (catalogRequestIdRef.current !== requestId) return;
+        if (!entry.catalog || force) {
+          setError(err instanceof Error ? err.message : "Unable to load Linear filters.");
+        }
+      })
+      .finally(() => {
+        if (catalogRequestIdRef.current === requestId) setLoadingCatalog(false);
+      });
+  }, [cacheKey]);
 
-  const searchIssues = useCallback((append: boolean) => {
+  const searchIssues = useCallback((append: boolean, force = false) => {
     const cto = window.ade.cto;
     if (!cto?.searchLinearIssues) {
       setError("Linear issue search is not available in this ADE surface.");
@@ -367,45 +530,61 @@ export function LinearIssueBrowser({
     }
     const requestId = searchRequestIdRef.current + 1;
     searchRequestIdRef.current = requestId;
-    setLoadingIssues(true);
+    const entry = getBrowserCacheEntry(cacheKey);
+    const args = buildIssueSearchArgs(filters, append ? pageInfoRef.current.endCursor : null);
+    const key = searchCacheKey(args);
+    const cached = entry.searches.get(key);
+    const cachedResult = cached?.result ?? null;
+    if (cachedResult && !force && cacheIsFresh(cached?.fetchedAt ?? 0)) {
+      setIssues((current) => append ? mergeIssuePages(current, cachedResult.issues) : cachedResult.issues);
+      setPageInfo(cachedResult.pageInfo);
+      return;
+    }
+    if (cachedResult && !append) {
+      setIssues(cachedResult.issues);
+      setPageInfo(cachedResult.pageInfo);
+    }
+    setLoadingIssues(force || append || !cachedResult);
     setError(null);
-    void cto.searchLinearIssues({
-      projectId: filters.projectId || null,
-      stateTypes: stateTypesForPreset(filters.statePreset),
-      assigneeId: filters.assigneeId || null,
-      priority: filters.priority ? Number(filters.priority) : null,
-      query: filters.query.trim() || null,
-      first: 50,
-      after: append ? pageInfoRef.current.endCursor : null,
-      includeArchived: false,
-    })
+    const promise = cached?.promise ?? cto.searchLinearIssues(args);
+    entry.searches.set(key, {
+      result: cachedResult,
+      fetchedAt: cached?.fetchedAt ?? 0,
+      promise,
+    });
+    void promise
       .then((result) => {
+        rememberSearchResult(entry, key, result);
         if (searchRequestIdRef.current !== requestId) return;
         setIssues((current) => append ? mergeIssuePages(current, result.issues) : result.issues);
         setPageInfo(result.pageInfo);
       })
       .catch((err) => {
+        entry.searches.set(key, { result: cachedResult, fetchedAt: cached?.fetchedAt ?? 0, promise: null });
         if (searchRequestIdRef.current !== requestId) return;
-        setError(err instanceof Error ? err.message : "Unable to search Linear issues.");
+        if (!cachedResult || force) {
+          setError(err instanceof Error ? err.message : "Unable to search Linear issues.");
+        }
       })
       .finally(() => {
         if (searchRequestIdRef.current === requestId) setLoadingIssues(false);
       });
-  }, [filters]);
+  }, [cacheKey, filters]);
 
   useEffect(() => {
-    loadQuickView(true);
-    loadCatalog();
+    const force = refreshKey > 0;
+    loadQuickView(force);
+    loadCatalog(force);
   }, [loadCatalog, loadQuickView, refreshKey]);
 
   useEffect(() => {
-    const timer = window.setTimeout(() => searchIssues(false), 220);
+    const timer = window.setTimeout(() => searchIssues(false, false), 220);
     return () => window.clearTimeout(timer);
   }, [filters, searchIssues]);
 
   useEffect(() => {
     if (refreshKey === 0) return;
-    searchIssues(false);
+    searchIssues(false, true);
   }, [refreshKey, searchIssues]);
 
   const updateFilters = useCallback((patch: Partial<LinearIssueBrowserFilters>) => {
@@ -534,7 +713,7 @@ export function LinearIssueBrowser({
         </div>
       ) : null}
 
-      <div className="grid min-h-0 flex-1 overflow-hidden md:grid-cols-[232px_minmax(0,1fr)_334px]">
+      <div className="grid min-h-0 flex-1 overflow-hidden md:grid-cols-[220px_minmax(0,1fr)_360px] lg:grid-cols-[260px_minmax(360px,1fr)_420px]">
         <aside className="flex min-h-0 flex-col overflow-hidden border-r border-white/10 bg-black/10">
           <div className="shrink-0 border-b border-white/[0.06] px-3 py-2">
             <ScopeNavButton
@@ -560,7 +739,7 @@ export function LinearIssueBrowser({
               ) : null}
             </div>
 
-            <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+            <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain" data-linear-pane="projects">
               {loadingCatalog && projectFilters.length === 0 ? (
                 <div className="rounded-lg border border-white/[0.06] px-3 py-6 text-center text-[12px] text-muted-fg/50">
                   Loading projects...
@@ -676,7 +855,7 @@ export function LinearIssueBrowser({
             </div>
           )}
 
-          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain" data-linear-pane="issues">
             {loadingQuickView && !quickView && displayIssues.length === 0 ? (
               <div className="grid h-44 place-items-center text-[12px] text-muted-fg/55">
                 <CircleNotch size={16} className="animate-spin" />
@@ -990,36 +1169,57 @@ function IssueDetails({
   const normalizedIssue = "raw" in issue ? issue : null;
   const description = issue.description?.trim() ?? "";
   return (
-    <aside className="flex min-h-0 flex-col overflow-hidden">
-      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-        <div className="flex items-center gap-2">
-          <LinearPriorityIcon priority={issue.priority} size={12} />
-          <LinearStateIcon stateType={issue.stateType} size={12} />
-          {issue.url ? (
-            <a
-              href={issue.url}
-              onClick={(e) => { e.preventDefault(); window.ade?.app?.openExternal?.(issue.url!); }}
-              className="cursor-pointer rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[10px] text-fg/80 hover:bg-white/[0.1] transition-colors"
-              title="Open in Linear"
-            >
-              {issue.identifier}
-            </a>
-          ) : (
-            <span className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[10px] text-fg/80">
-              {issue.identifier}
+    <aside className="flex min-h-0 flex-col overflow-hidden bg-black/[0.08]">
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-4 py-4" data-linear-pane="issue-details">
+        <div className="rounded-xl border border-white/[0.07] bg-white/[0.03] p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <LinearPriorityIcon priority={issue.priority} size={12} />
+                <LinearStateIcon stateType={issue.stateType} size={12} />
+                {issue.url ? (
+                  <a
+                    href={issue.url}
+                    onClick={(e) => { e.preventDefault(); window.ade?.app?.openExternal?.(issue.url!); }}
+                    className="cursor-pointer rounded bg-white/[0.07] px-1.5 py-0.5 font-mono text-[10px] text-fg/82 transition-colors hover:bg-white/[0.12]"
+                    title="Open in Linear"
+                  >
+                    {issue.identifier}
+                  </a>
+                ) : (
+                  <span className="rounded bg-white/[0.07] px-1.5 py-0.5 font-mono text-[10px] text-fg/82">
+                    {issue.identifier}
+                  </span>
+                )}
+              </div>
+              <div className="mt-2 text-[15px] font-semibold leading-snug text-fg/95">{issue.title}</div>
+            </div>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            <span className="rounded-full border border-white/[0.07] bg-white/[0.035] px-2 py-0.5 text-[10.5px] text-muted-fg/75">
+              {issue.stateName}
             </span>
-          )}
+            <span className="rounded-full border border-white/[0.07] bg-white/[0.035] px-2 py-0.5 text-[10.5px] text-muted-fg/75">
+              {linearPriorityLabel(issue)}
+            </span>
+            <span className="rounded-full border border-white/[0.07] bg-white/[0.035] px-2 py-0.5 text-[10.5px] text-muted-fg/75">
+              {issue.assigneeName ?? "Unassigned"}
+            </span>
+          </div>
         </div>
-        <div className="mt-2 text-[14px] font-semibold leading-snug">{issue.title}</div>
+
         {showBranchPreview ? (
-          <div className="mt-2 rounded-md bg-black/25 px-2 py-1.5 font-mono text-[10.5px] text-fg/80">
-            <BranchIcon size={11} className="mr-1 inline" />
-            {branchName}
+          <div className="mt-3 rounded-lg border border-white/[0.06] bg-black/25 px-3 py-2">
+            <div className="text-[10px] font-medium uppercase tracking-[0.10em] text-muted-fg/45">Branch</div>
+            <div className="mt-1 flex min-w-0 items-center gap-1.5 font-mono text-[10.5px] text-fg/82">
+              <BranchIcon size={11} className="shrink-0" />
+              <span className="truncate" title={branchName}>{branchName}</span>
+            </div>
           </div>
         ) : null}
 
         {description ? (
-          <div className="mt-3 overflow-y-auto rounded-lg border border-white/[0.06] bg-white/[0.025] px-3 py-2 text-[12px] leading-relaxed text-muted-fg/80">
+          <div className="mt-3 rounded-xl border border-white/[0.06] bg-white/[0.025] px-3 py-2.5 text-[12px] leading-relaxed text-muted-fg/80">
             <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
               {description}
             </ReactMarkdown>
@@ -1028,7 +1228,7 @@ function IssueDetails({
 
         <IssueLabels issue={issue} normalizedIssue={normalizedIssue} />
 
-        <div className="mt-3 grid gap-1.5 text-[11px] text-muted-fg/65">
+        <div className="mt-3 grid grid-cols-2 gap-2 text-[11px] text-muted-fg/65">
           <InfoRow label="Project" value={issueProjectLabel(issue)} />
           <InfoRow label="Team" value={issue.teamName ?? issue.teamKey} />
           {normalizedIssue?.cycleName && (
@@ -1059,10 +1259,21 @@ function IssueDetails({
         <ActivitySection issueId={issue.id} />
       </div>
 
-      <div className="shrink-0 max-h-[280px] overflow-y-auto border-t border-white/10 px-4 py-3">
+      <div
+        className="shrink-0 max-h-[42%] overflow-y-auto overscroll-contain border-t border-white/10 bg-[color:color-mix(in_srgb,var(--ade-shell-surface,#121019)_92%,black_8%)] px-4 py-3 shadow-[0_-18px_36px_rgba(0,0,0,0.22)] backdrop-blur-md"
+        data-linear-action-dock="true"
+      >
+        <div className="mb-2 flex min-w-0 items-center gap-2">
+          <span className="shrink-0 rounded bg-white/[0.07] px-1.5 py-0.5 font-mono text-[10px] text-fg/80">
+            {issue.identifier}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-[11.5px] font-medium text-fg/82" title={issue.title}>
+            {issue.title}
+          </span>
+        </div>
         {resolveActions ? (
           <div className="space-y-2">
-            <div className="space-y-1.5">
+            <div className="grid gap-1.5">
               {RESOLVE_ACTIONS.map((action) => {
                 const busy = resolveActions.busyModal === action.kind;
                 const disabled = resolveActions.disabled || Boolean(resolveActions.busyModal && !busy);
@@ -1071,11 +1282,11 @@ function IssueDetails({
                     key={action.kind}
                     type="button"
                     disabled={disabled}
-                    className="flex w-full items-start gap-2.5 rounded-lg border border-white/[0.07] bg-white/[0.02] px-2.5 py-2 text-left transition-colors hover:border-white/[0.12] hover:bg-white/[0.05] disabled:cursor-not-allowed disabled:opacity-45"
+                    className="grid w-full grid-cols-[28px_minmax(0,1fr)] items-start gap-2.5 rounded-lg border border-white/[0.075] bg-white/[0.025] px-2.5 py-2 text-left transition-colors hover:border-white/[0.16] hover:bg-white/[0.055] disabled:cursor-not-allowed disabled:opacity-45"
                     onClick={() => resolveActions.onOpenModal(action.kind, issue)}
                   >
                     <span
-                      className="mt-0.5 grid h-6 w-6 shrink-0 place-items-center rounded-md text-[color:var(--color-accent,#A78BFA)]"
+                      className="grid h-7 w-7 shrink-0 place-items-center rounded-md text-[color:var(--color-accent,#A78BFA)]"
                       style={{ background: "rgba(167, 139, 250, 0.12)" }}
                     >
                       {busy ? <CircleNotch size={13} className="animate-spin" /> : action.icon}
@@ -1091,7 +1302,7 @@ function IssueDetails({
             <LinearIssueOpenLink url={issue.url} />
           </div>
         ) : (
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
             <Button
               variant="primary"
               disabled={actionBusy || actionDisabled}
@@ -1132,9 +1343,9 @@ function IssueLabels({ issue, normalizedIssue }: { issue: BrowserIssue; normaliz
 
 function InfoRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex items-baseline justify-between gap-2">
-      <span className="text-muted-fg/45">{label}</span>
-      <span className="truncate text-right text-fg/80" title={value}>{value}</span>
+    <div className="min-w-0 rounded-lg border border-white/[0.05] bg-white/[0.025] px-2.5 py-2">
+      <div className="text-[9.5px] font-medium uppercase tracking-[0.10em] text-muted-fg/40">{label}</div>
+      <div className="mt-1 truncate text-[11.5px] text-fg/82" title={value}>{value}</div>
     </div>
   );
 }
@@ -1258,7 +1469,7 @@ function BatchActionView({
 
   return (
     <aside className="flex min-h-0 flex-col overflow-hidden">
-      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3" data-linear-pane="issue-details">
         <div className="flex items-center justify-between">
           <span className="text-[13px] font-semibold text-fg/90">{selectedIssues.length} issues selected</span>
           <button type="button" className="text-[10px] text-muted-fg/50 hover:text-fg/80 transition-colors" onClick={onClearSelection}>
@@ -1274,7 +1485,7 @@ function BatchActionView({
           ))}
         </div>
       </div>
-      <div className="shrink-0 border-t border-white/10 px-4 py-3">
+      <div className="shrink-0 border-t border-white/10 px-4 py-3" data-linear-action-dock="true">
         <div className="space-y-1.5">
           {BATCH_ACTIONS_CONFIG.map((action) => (
             <button

--- a/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
+++ b/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
@@ -420,7 +420,7 @@ export function LinearQuickViewButton({
             type="button"
             aria-label="Close Linear quick view backdrop"
             data-linear-quick-view-backdrop="true"
-            className="fixed inset-0 z-[9998] cursor-default bg-black/30 backdrop-blur-sm"
+            className="fixed inset-0 z-[9998] cursor-default bg-black/55 backdrop-blur-md"
             onClick={close}
             tabIndex={-1}
           />
@@ -429,7 +429,7 @@ export function LinearQuickViewButton({
             role="dialog"
             aria-modal="true"
             aria-label="Linear quick view"
-            className="fixed left-1/2 top-1/2 z-[9999] flex max-h-[min(760px,calc(100vh-64px))] w-[min(1040px,calc(100vw-24px))] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl border bg-[color:var(--ade-shell-surface,#121019)] text-fg shadow-2xl shadow-black/50"
+            className="fixed left-1/2 top-1/2 z-[9999] flex h-[min(900px,calc(100dvh-28px))] w-[min(1380px,calc(100vw-28px))] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-xl border bg-[color:var(--ade-shell-surface,#121019)] text-fg shadow-2xl shadow-black/50"
             style={{
               borderColor: "rgba(123, 138, 240, 0.55)",
               boxShadow: "0 24px 70px rgba(0, 0, 0, 0.58), 0 0 0 1px rgba(123, 138, 240, 0.18)",

--- a/apps/desktop/src/renderer/components/settings/LinearSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/LinearSection.tsx
@@ -57,6 +57,7 @@ export function LinearSection() {
   const oauthStartingRef = useRef(false);
   const oauthSessionIdRef = useRef<string | null>(null);
   const requestEpochRef = useRef(0);
+  const autolinksRequestIdRef = useRef(0);
 
   const invalidateLoadRequests = useCallback(() => {
     requestEpochRef.current += 1;
@@ -155,10 +156,16 @@ export function LinearSection() {
   const loadGithubAutolinks = useCallback(async () => {
     const github = window.ade?.github;
     if (!github) return;
+    // Guard against stale responses: if the active project changes while a
+    // detectRepo()/listRepoAutolinks() call is in flight, an older response
+    // must not repopulate the repo/autolinks (which would make the displayed
+    // repo and generated `gh repo autolink` commands wrong for the new project).
+    const requestId = ++autolinksRequestIdRef.current;
     setAutolinksLoading(true);
     setAutolinkError(null);
     try {
       const repo = await github.detectRepo();
+      if (autolinksRequestIdRef.current !== requestId) return;
       setGithubRepo(repo);
       if (!repo) {
         setGithubAutolinks([]);
@@ -166,12 +173,16 @@ export function LinearSection() {
         return;
       }
       const autolinks = await github.listRepoAutolinks(repo);
+      if (autolinksRequestIdRef.current !== requestId) return;
       setGithubAutolinks(autolinks);
     } catch (err) {
+      if (autolinksRequestIdRef.current !== requestId) return;
       setGithubAutolinks([]);
       setAutolinkError(err instanceof Error ? err.message : "Unable to load GitHub autolinks.");
     } finally {
-      setAutolinksLoading(false);
+      if (autolinksRequestIdRef.current === requestId) {
+        setAutolinksLoading(false);
+      }
     }
   }, []);
 

--- a/apps/desktop/src/renderer/components/settings/LinearSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/LinearSection.tsx
@@ -13,6 +13,7 @@ import {
 import type { CtoLinearProject, GitHubAutolink, LinearConnectionStatus } from "../../../shared/types";
 import { COLORS, SANS_FONT, MONO_FONT, LABEL_STYLE } from "../lanes/laneDesignTokens";
 import { Button } from "../ui/Button";
+import { useAppStore } from "../../state/appStore";
 
 const LINEAR_BRAND = "#5E6AD2";
 const LINEAR_API_SETTINGS_URL = "https://linear.app/settings/api";
@@ -35,6 +36,11 @@ const FEATURES = [
 ];
 
 export function LinearSection() {
+  // Linear connection, GitHub repo, and team keys are all scoped to the active
+  // project (credentials are project-scoped). Re-run the loaders whenever the
+  // active project changes so the autolink commands target the right repo and
+  // Linear workspace instead of a stale previously-loaded project.
+  const projectRoot = useAppStore((s) => s.project?.rootPath ?? null);
   const [connection, setConnection] = useState<LinearConnectionStatus | null>(null);
   const [projects, setProjects] = useState<CtoLinearProject[]>([]);
   const [githubRepo, setGithubRepo] = useState<{ owner: string; name: string } | null>(null);
@@ -190,14 +196,14 @@ export function LinearSection() {
     }
   }, [invalidateLoadRequests, isCurrentLoadRequest, loadProjects]);
 
-  /* ── Initial load ── */
+  /* ── Initial load + reload on active-project change ── */
   useEffect(() => {
     void loadStatus();
-  }, [loadStatus]);
+  }, [loadStatus, projectRoot]);
 
   useEffect(() => {
     void loadGithubAutolinks();
-  }, [loadGithubAutolinks]);
+  }, [loadGithubAutolinks, projectRoot]);
 
   /* ── OAuth polling ── */
   useEffect(() => {
@@ -652,7 +658,7 @@ export function LinearSection() {
               GITHUB REFERENCE LINKS
             </div>
             <div style={{ fontSize: 12, fontFamily: SANS_FONT, color: COLORS.textMuted, lineHeight: "17px" }}>
-              Configure this GitHub repo so Linear issue keys and ADE PR references stay clickable in comments, PR descriptions, and commits.
+              GitHub autolinks make Linear issue keys (like ENG-123) and ADE PR refs clickable wherever they appear in PRs, commits, and comments — no full URLs needed. Applies to the repo below for this project.
             </div>
           </div>
           <Button
@@ -683,6 +689,9 @@ export function LinearSection() {
           <div style={{ fontSize: 11, fontFamily: MONO_FONT, color: COLORS.textMuted, minWidth: 0, overflowWrap: "anywhere" }}>
             {githubRepoSlug ?? "No GitHub origin detected"}
           </div>
+        </div>
+        <div style={{ fontSize: 10, fontFamily: SANS_FONT, color: COLORS.textDim, lineHeight: "15px", marginBottom: 8 }}>
+          Click <strong style={{ color: COLORS.textSecondary, fontWeight: 600 }}>Create</strong> to add a link to this repo automatically, or copy the <code style={{ fontFamily: MONO_FONT }}>gh</code> command below it to run it yourself.
         </div>
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           {autolinkCandidates.map((candidate) => {

--- a/docs/features/cto/linear-integration.md
+++ b/docs/features/cto/linear-integration.md
@@ -55,9 +55,9 @@ Detailed wiring lives in [`../linear-integration/README.md`](../linear-integrati
 Two connection paths:
 
 1. **Personal API key** (recommended first path). Entered in the Connection panel; validated by a `viewer` query; stored via `linearCredentialService` in the active project's `.ade/secrets`.
-2. **OAuth** (when `.ade/secrets/linear-oauth.v1.json` is configured). `startOAuth()` boots an ephemeral HTTP server on 19836 with a PKCE pair, returns the authorize URL for the renderer to open, and finalizes on callback. Sessions auto-expire after 10 minutes.
+2. **OAuth** (the primary "Sign in with Linear" path; uses a bundled public client with PKCE). `startOAuth()` boots an ephemeral HTTP server on 19836 with a PKCE pair, returns the authorize URL for the renderer to open, and finalizes on callback. The *sign-in session* auto-expires after 10 minutes. The resulting **access token, which Linear expires ~24h after sign-in, is refreshed automatically**: `linearCredentialService.ensureFreshToken()` exchanges the stored `refresh_token` (via `linearTokenRefresh.ts`) when the token is at/near expiry — proactively before each GraphQL request and reactively on a 401 — rotating the refresh token on success. A rejected refresh token (`invalid_grant`) clears the connection so the user re-authorizes; transient failures leave the token in place. The headless `ade serve` credential service has the same refresh behavior.
 
-The renderer's `LinearConnectionPanel` auto-surfaces whichever path is available. The CTO onboarding recommends the API key as faster; OAuth is available for customers that prefer SSO.
+The renderer's `LinearConnectionPanel` auto-surfaces whichever path is available. Most users connect via OAuth; the personal API key (which does not expire) is the alternative for headless/automation use.
 
 ## Workflow definition
 


### PR DESCRIPTION
## Summary
Three Linear improvements across the issue browser and connection layer.

### 1. Quick-view caching — `LinearIssueBrowser.tsx`, `LinearQuickViewButton.tsx`
Per-project stale-while-revalidate cache so the top-bar quick view opens instantly and survives reopen. Quick view, filter catalog, and issue search each render cached data immediately, dedupe in-flight requests, and guard against stale responses with per-loader request-id checks — including `loadCatalog`, which previously had none. Larger modal + redesigned issue-detail pane.

### 2. OAuth token refresh — `linearTokenRefresh.ts`, credential services, `linearClient.ts`
Linear OAuth access tokens expire ~24h after sign-in and Linear issues a **rotating refresh token**, but ADE never refreshed — so OAuth connections (the primary sign-in path) silently broke after a day. Now:
- `ensureFreshToken()` on both the desktop and headless (`ade serve`) credential services refreshes via `grant_type=refresh_token` when at/near expiry, rotates the refresh token, clears the connection on `invalid_grant` (prompts reconnect), and keeps the token on transient failures. Concurrency-deduped.
- `linearClient` refreshes proactively before each GraphQL request + the quick-view SDK call, and reactively once on a 401 (re-reading the token per attempt).
- Grounded in Linear's OAuth docs (`expires_in: 86399`; the refresh-token system has been mandatory since 2026-04-01).

### 3. Project-scoped autolink setup — `LinearSection.tsx`
Settings → Linear "GitHub reference links" now reloads connection / repo / team-keys when the **active project** changes, so the generated `gh repo autolink` commands target the current project's repo + Linear workspace (previously stale on project switch). Clearer copy: explains what autolinks do, that they apply to this project's repo, and that **Create** configures it automatically while the shown `gh` command is the manual equivalent.

## Verification
- Typecheck (desktop + ade-cli) clean; ESLint clean on changed files.
- New tests: `linearTokenRefresh` helper (7) + `linearAuth` OAuth-refresh cases (4: near-expiry rotation, no-refresh for manual/fresh, invalid_grant→clear, transient→keep).
- Full cto suite (151) + renderer suite (1916) green; headless (22).

> Note: project-scoped Linear **credentials** shipped separately in #392; this PR carries no credential-storage changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic OAuth token refresh for Linear connections (keeps sessions valid and retries requests when needed).

* **Improvements**
  * In-memory caching in the Linear browser for snappier navigation and reduced load times.
  * Quick view overlay styling made more responsive and visually consistent.
  * Linear settings now reload per-project and autolinks copy/creation guidance clarified.

* **Bug Fixes**
  * Stale/invalid OAuth connections are properly cleared when refresh is rejected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a real-world session expiry bug (OAuth tokens silently dying after ~24 h), adds stale-while-revalidate caching to the Linear issue browser, and makes the Settings → Linear autolink section project-aware. All three changes are well-scoped and correctly guarded.

- **Token refresh** (`linearTokenRefresh.ts`, `linearCredentialService.ts`, `linearClient.ts`): shared `refreshLinearOAuthAccessToken` helper correctly narrows `invalidGrant` to `error === "invalid_grant"` only (per RFC 6749 §5.2); proactive + reactive refresh paths in `linearClient` deduplicate in-flight refreshes via `refreshInFlight` and prevent infinite loops with the `didAuthRefresh` flag.
- **Browser caching** (`LinearIssueBrowser.tsx`): module-level `linearIssueBrowserCache` implements stale-while-revalidate for quick-view, catalog, and search results with per-loader request-ID guards and in-flight deduplication; state is pre-seeded from cache on mount.
- **Project-scoped autolinks** (`LinearSection.tsx`): subscribes to `useAppStore` for `projectRoot` and wires it into both load effects, with an `autolinksRequestIdRef` guard preventing stale detectRepo/listRepoAutolinks responses from populating the wrong project.

<h3>Confidence Score: 5/5</h3>

The PR is safe to merge. The token-refresh logic correctly handles all error cases (invalid_grant vs. transient), the cache uses request-ID guards to prevent stale data from crossing project boundaries, and the existing test suite was extended to cover the new refresh paths.

All three change areas are logically sound: the invalidGrant detection was narrowed to only error === invalid_grant (fixing the previously flagged overly-broad 400/401 check), the React caching is properly scoped per project root and CTO bridge instance, and the project-switch reload in LinearSection is guarded against in-flight race conditions. No data-loss or incorrect-auth paths were found in the new code.

No files require special attention. The headless credential service's ensureFreshToken does not support fetchImpl injection (flagged as a suggestion), but this does not affect correctness in production.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/cto/linearTokenRefresh.ts | New shared helper implementing the RFC 6749 refresh-token exchange; correctly restricts invalidGrant to error === invalid_grant only, handles missing expires_in gracefully, and is fully unit-tested. |
| apps/desktop/src/main/services/cto/linearCredentialService.ts | Adds ensureFreshToken with concurrency deduplication via refreshInFlight; correctly guards against invalid_grant, calls invalidateCache() after persistence, and injects fetchImpl for testability. |
| apps/desktop/src/main/services/cto/linearClient.ts | Adds proactive token refresh before each GraphQL request and getQuickView, and a one-shot reactive refresh on isAuthError; didAuthRefresh flag prevents infinite retry loops, token is re-read per attempt after a refresh. |
| apps/ade-cli/src/headlessLinearServices.ts | Mirrors desktop ensureFreshToken with correct credential-write semantics, but unlike the desktop service the implementation does not accept a fetchImpl parameter, so the headless refresh path always uses the global fetch and cannot be unit-tested without mocking globals. |
| apps/desktop/src/renderer/components/app/LinearIssueBrowser.tsx | Adds module-level stale-while-revalidate cache with per-loader request-ID guards and in-flight deduplication; project-switch effect correctly populates from cache before fresh fetches; redesigned issue-detail pane with responsive column sizing. |
| apps/desktop/src/renderer/components/settings/LinearSection.tsx | Adds projectRoot from useAppStore and wires it into both load effects so autolinks and connection status reload on project switch; autolinksRequestIdRef correctly discards stale in-flight responses. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer
    participant LC as linearClient
    participant CS as CredentialService
    participant TR as linearTokenRefresh
    participant LA as Linear API

    R->>LC: getQuickView() / request()
    LC->>CS: ensureFreshToken() [proactive]
    CS-->>CS: check expiresAt vs now - 2min buffer
    alt token near expiry
        CS->>TR: refreshLinearOAuthAccessToken()
        TR->>LA: POST /oauth/token (refresh_token)
        LA-->>TR: "{access_token, refresh_token, expires_in}"
        TR-->>CS: "{ok:true, accessToken, refreshToken, expiresAt}"
        CS-->>CS: persistToken() + invalidateCache()
    else token fresh or manual
        CS-->>LC: (no-op)
    end
    LC->>LA: GraphQL / SDK request
    alt 401 received
        LA-->>LC: 401 Unauthorized
        LC->>CS: "ensureFreshToken({force:true}) [reactive, once]"
        alt invalid_grant
            CS-->>CS: persistToken(null) — clear connection
            LC-->>R: throw token missing error
        else transient failure
            CS-->>CS: keep existing token
            LC->>LA: retry with same token
        else success
            CS-->>CS: persistToken(newToken)
            LC->>LA: retry with new token
            LA-->>LC: 200 OK
            LC-->>R: data
        end
    else success
        LA-->>LC: 200 OK
        LC-->>R: data
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fade-cli%2Fsrc%2FheadlessLinearServices.ts%3A1144-1146%0AThe%20headless%20%60ensureFreshToken%60%20always%20falls%20through%20to%20the%20global%20%60fetch%60%20because%20%60createHeadlessLinearCredentialService%60%20accepts%20no%20%60fetchImpl%60%20parameter.%20The%20desktop%20service%20accepts%20one%20%E2%80%94%20tests%20inject%20a%20%60vi.fn%28%29%60%20and%20validate%20the%20full%20refresh%20cycle.%20Without%20injection%2C%20testing%20the%20headless%20path%20requires%20mocking%20the%20global%20%60fetch%60%2C%20and%20the%20four%20%60linearAuth.test.ts%60%20cases%20only%20exercise%20the%20desktop%20service.%20Consider%20threading%20%60fetchImpl%60%20through%20so%20the%20headless%20refresh%20is%20testable%20on%20the%20same%20terms.%0A%0A%60%60%60suggestion%0Afunction%20createHeadlessLinearCredentialService%28args%3A%20%7B%0A%20%20adeDir%3A%20string%3B%0A%20%20fetchImpl%3F%3A%20typeof%20fetch%3B%0A%7D%29%3A%20HeadlessLinearCredentialService%20%7B%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=395&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/ade-cli/src/headlessLinearServices.ts:1144-1146
The headless `ensureFreshToken` always falls through to the global `fetch` because `createHeadlessLinearCredentialService` accepts no `fetchImpl` parameter. The desktop service accepts one — tests inject a `vi.fn()` and validate the full refresh cycle. Without injection, testing the headless path requires mocking the global `fetch`, and the four `linearAuth.test.ts` cases only exercise the desktop service. Consider threading `fetchImpl` through so the headless refresh is testable on the same terms.

```suggestion
function createHeadlessLinearCredentialService(args: {
  adeDir: string;
  fetchImpl?: typeof fetch;
}): HeadlessLinearCredentialService {
```

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["Only treat invalid\_grant as a dead Linea..."](https://github.com/arul28/ade/commit/b015eac7741734c97d50c163ed378bbb6bfc5a96) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34525268)</sub>

<!-- /greptile_comment -->