### PR TITLE
Fix Linear issue deeplink attachment race

### DIFF
--- a/apps/desktop/src/main/services/cto/linearSync.test.ts
+++ b/apps/desktop/src/main/services/cto/linearSync.test.ts
@@ -176,6 +176,58 @@ describe("linearSyncService (file group)", () => {
       db.close();
     });
 
+    it("shares one Linear-pane deeplink attachment across concurrent ensure calls", async () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "ade-linear-sync-issue-link-race-"));
+      const db = await openKvDb(path.join(root, "ade.db"), { debug() {}, info() {}, warn() {}, error() {} } as any);
+      const createIssueAttachment = vi.fn(async (attachment: any) => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return { id: "attachment-1", url: attachment.url };
+      });
+      const fetchIssueById = vi.fn(async () => issueFixture);
+
+      const service = createLinearSyncService({
+        db,
+        projectId: "project-1",
+        flowPolicyService: { getPolicy: () => policy } as any,
+        routingService: { routeIssue: vi.fn() } as any,
+        intakeService: {
+          fetchCandidates: vi.fn(async () => []),
+          persistSnapshot: vi.fn(() => {}),
+          issueHash: vi.fn(() => "hash-current"),
+        } as any,
+        issueTracker: {
+          fetchIssueById,
+          createIssueAttachment,
+        } as any,
+        dispatcherService: {
+          hasActiveRuns: vi.fn(() => false),
+          findActiveRunForIssue: vi.fn(() => null),
+          createRun: vi.fn(),
+          advanceRun: vi.fn(),
+          listActiveRuns: vi.fn(() => []),
+          listQueue: vi.fn(() => []),
+          resolveRunAction: vi.fn(),
+        } as any,
+        autoStart: false,
+      });
+
+      const first = service.ensureAdeIssueLinkForIssue("issue-1", "linear_issue_created");
+      const second = service.ensureAdeIssueLinkForIssue("issue-1", "linear_issue_created");
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        {
+          id: "attachment-1",
+          url: "https://ade-app.dev/open?type=linear-issue&issue=ABC-42",
+        },
+        {
+          id: "attachment-1",
+          url: "https://ade-app.dev/open?type=linear-issue&issue=ABC-42",
+        },
+      ]);
+      expect(createIssueAttachment).toHaveBeenCalledTimes(1);
+      expect(service.getDashboard().recentEvents.filter((entry) => entry.eventType === "ade_issue_link_attached")).toHaveLength(1);
+      db.close();
+    });
+
     it("retries the ADE Linear-pane deeplink during later issue processing", async () => {
       const root = fs.mkdtempSync(path.join(os.tmpdir(), "ade-linear-sync-issue-link-retry-"));
       const db = await openKvDb(path.join(root, "ade.db"), { debug() {}, info() {}, warn() {}, error() {} } as any);

--- a/apps/desktop/src/main/services/cto/linearSyncService.ts
+++ b/apps/desktop/src/main/services/cto/linearSyncService.ts
@@ -22,6 +22,8 @@ import { buildLinearIssueQuickViewAttachment } from "./linearLaneCardService";
 const DEFAULT_TERMINAL_STATE_TYPES = ["completed", "canceled"] as const;
 const ADE_ISSUE_LINK_EVENT_TYPE = "ade_issue_link_attached";
 
+const inFlightAdeIssueLinkAttachments = new Map<string, Promise<{ url: string; id?: string } | null>>();
+
 type ProcessIssueUpdateOptions = {
   adeIssueLinkCause?: string | null;
 };
@@ -149,45 +151,56 @@ export function createLinearSyncService(args: {
   ): Promise<{ url: string; id?: string } | null> => {
     const trimmedIssueId = issue.id.trim();
     if (!trimmedIssueId) return null;
-    if (hasAdeIssueLinkAttachment(trimmedIssueId)) return null;
-    const createIssueAttachment = (args.issueTracker as Partial<IssueTracker>).createIssueAttachment;
-    if (typeof createIssueAttachment !== "function") return null;
+    const inFlightKey = `${args.projectId}:${trimmedIssueId}`;
+    const existingInFlight = inFlightAdeIssueLinkAttachments.get(inFlightKey);
+    if (existingInFlight) return existingInFlight;
 
-    const linkedAt = nowIso();
-    const attachment = buildLinearIssueQuickViewAttachment({
-      issue,
-      linkedAt,
+    const promise = (async (): Promise<{ url: string; id?: string } | null> => {
+      if (hasAdeIssueLinkAttachment(trimmedIssueId)) return null;
+      const createIssueAttachment = (args.issueTracker as Partial<IssueTracker>).createIssueAttachment;
+      if (typeof createIssueAttachment !== "function") return null;
+
+      const linkedAt = nowIso();
+      const attachment = buildLinearIssueQuickViewAttachment({
+        issue,
+        linkedAt,
+      });
+      try {
+        const result = await createIssueAttachment.call(args.issueTracker, attachment);
+        appendSyncEvent({
+          issueId: trimmedIssueId,
+          eventType: ADE_ISSUE_LINK_EVENT_TYPE,
+          status: "linked",
+          message: `ADE issue deeplink attached to ${issue.identifier}`,
+          payload: {
+            issueIdentifier: issue.identifier,
+            cause,
+            adeUrl: attachment.url,
+            attachmentId: result.id ?? null,
+            resultUrl: result.url,
+          },
+        });
+        return result;
+      } catch (error) {
+        appendSyncEvent({
+          issueId: trimmedIssueId,
+          eventType: "ade_issue_link_attach_failed",
+          status: "failed",
+          message: getErrorMessage(error),
+          payload: {
+            issueIdentifier: issue.identifier,
+            cause,
+            adeUrl: attachment.url,
+          },
+        });
+        throw error;
+      }
+    })().finally(() => {
+      inFlightAdeIssueLinkAttachments.delete(inFlightKey);
     });
-    try {
-      const result = await createIssueAttachment.call(args.issueTracker, attachment);
-      appendSyncEvent({
-        issueId: trimmedIssueId,
-        eventType: ADE_ISSUE_LINK_EVENT_TYPE,
-        status: "linked",
-        message: `ADE issue deeplink attached to ${issue.identifier}`,
-        payload: {
-          issueIdentifier: issue.identifier,
-          cause,
-          adeUrl: attachment.url,
-          attachmentId: result.id ?? null,
-          resultUrl: result.url,
-        },
-      });
-      return result;
-    } catch (error) {
-      appendSyncEvent({
-        issueId: trimmedIssueId,
-        eventType: "ade_issue_link_attach_failed",
-        status: "failed",
-        message: getErrorMessage(error),
-        payload: {
-          issueIdentifier: issue.identifier,
-          cause,
-          adeUrl: attachment.url,
-        },
-      });
-      throw error;
-    }
+
+    inFlightAdeIssueLinkAttachments.set(inFlightKey, promise);
+    return promise;
   };
 
   const ensureAdeIssueLinkForIssue = async (


### PR DESCRIPTION
## Summary
- Serialize concurrent ADE Linear issue deeplink attachment attempts per project/issue
- Keep failed attachment attempts retryable after the in-flight guard clears
- Add a regression test for overlapping ensure calls creating only one Linear attachment/event

## Validation
- npx vitest run src/main/services/cto/linearSync.test.ts
- npm --prefix apps/desktop run typecheck

## Context
Follow-up from the deeplink audit after PR #398: this closes the remaining duplicate attachment race noted during review without changing the public deeplink contract.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a duplicate-attachment race in the Linear deeplink flow by wrapping `createIssueAttachment` in a per-`projectId:issueId` in-flight promise that concurrent callers share, and keeping failed attempts retryable once the guard clears.

- **`linearSyncService.ts`**: Introduces a module-level `inFlightAdeIssueLinkAttachments` Map and restructures `attachAdeIssueLinkForIssue` so concurrent callers join one shared promise rather than each creating their own attachment; the `.finally()` handler always removes the key so transient failures remain retryable.
- **`linearSync.test.ts`**: Adds a regression test that fires two overlapping `ensureAdeIssueLinkForIssue` calls and asserts that `createIssueAttachment` and the `ade_issue_link_attached` event are each emitted exactly once.

<h3>Confidence Score: 3/5</h3>

The deduplication logic works for the common single-instance case, but the module-scoped guard Map creates cross-instance coupling that dispose() cannot clean up.

The race fix is sound, but placing inFlightAdeIssueLinkAttachments at module scope means a recreated service instance silently joins an in-flight promise from the old instance, potentially against a partially-closed DB. Moving the Map inside the factory closure would eliminate this with no behavioural downside.

apps/desktop/src/main/services/cto/linearSyncService.ts — module-level map declaration and missing cleanup in dispose().

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/cto/linearSyncService.ts | Adds module-level inFlightAdeIssueLinkAttachments Map to deduplicate concurrent deeplink attachment calls; scoped outside the factory closure so all instances share it — dispose() does not clean up in-flight entries, creating cross-instance coupling. |
| apps/desktop/src/main/services/cto/linearSync.test.ts | Adds a regression test for the concurrent-ensure race; verifies createIssueAttachment and the ade_issue_link_attached event are each emitted exactly once when two ensureAdeIssueLinkForIssue calls overlap. Does not assert fetchIssueById call count. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C1 as Caller 1
    participant C2 as Caller 2
    participant E as ensureAdeIssueLinkForIssue
    participant A as attachAdeIssueLinkForIssue
    participant M as inFlightAdeIssueLinkAttachments
    participant LT as issueTracker fetchIssueById
    participant LA as issueTracker createIssueAttachment
    participant DB as DB appendSyncEvent
    C1->>E: ensureAdeIssueLinkForIssue issue-1
    C2->>E: ensureAdeIssueLinkForIssue issue-1
    E->>DB: hasAdeIssueLinkAttachment false C1
    E->>DB: hasAdeIssueLinkAttachment false C2
    E->>LT: fetchIssueById C1 first fetch
    E->>LT: fetchIssueById C2 redundant fetch
    LT-->>E: issue C1
    E->>A: attachAdeIssueLinkForIssue C1
    A->>M: get project-1 issue-1 undefined
    A->>M: set project-1 issue-1 promise
    LT-->>E: issue C2
    E->>A: attachAdeIssueLinkForIssue C2
    A->>M: get project-1 issue-1 existing promise
    A-->>C2: return existing promise
    A->>LA: createIssueAttachment once
    LA-->>A: result
    A->>DB: appendSyncEvent linked
    A->>M: delete project-1 issue-1 via finally
    A-->>C1: result
    A-->>C2: same result
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/main/services/cto/linearSyncService.ts`, line 206-217 ([link](https://github.com/arul28/ade/blob/1493210559355c398fb5ccbc7a7ce1ca123e7088/apps/desktop/src/main/services/cto/linearSyncService.ts#L206-L217)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Two concurrent `ensureAdeIssueLinkForIssue` calls still trigger two `fetchIssueById` network calls**

   Both concurrent callers pass the `hasAdeIssueLinkAttachment` guard at line 212 before either has registered anything in the in-flight map, then both independently call `fetchIssueById`. Deduplication only fires when `attachAdeIssueLinkForIssue` is reached. For most deployments this is invisible (the mock resolves synchronously in tests), but against a real Linear API this means two outbound requests per race rather than one. The outer guard could be extended to also check the in-flight map before fetching.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/cto/linearSyncService.ts
   Line: 206-217

   Comment:
   **Two concurrent `ensureAdeIssueLinkForIssue` calls still trigger two `fetchIssueById` network calls**

   Both concurrent callers pass the `hasAdeIssueLinkAttachment` guard at line 212 before either has registered anything in the in-flight map, then both independently call `fetchIssueById`. Deduplication only fires when `attachAdeIssueLinkForIssue` is reached. For most deployments this is invisible (the mock resolves synchronously in tests), but against a real Linear API this means two outbound requests per race rather than one. The outer guard could be extended to also check the in-flight map before fetching.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fcto%2FlinearSyncService.ts%0ALine%3A%20206-217%0A%0AComment%3A%0A**Two%20concurrent%20%60ensureAdeIssueLinkForIssue%60%20calls%20still%20trigger%20two%20%60fetchIssueById%60%20network%20calls**%0A%0ABoth%20concurrent%20callers%20pass%20the%20%60hasAdeIssueLinkAttachment%60%20guard%20at%20line%20212%20before%20either%20has%20registered%20anything%20in%20the%20in-flight%20map%2C%20then%20both%20independently%20call%20%60fetchIssueById%60.%20Deduplication%20only%20fires%20when%20%60attachAdeIssueLinkForIssue%60%20is%20reached.%20For%20most%20deployments%20this%20is%20invisible%20%28the%20mock%20resolves%20synchronously%20in%20tests%29%2C%20but%20against%20a%20real%20Linear%20API%20this%20means%20two%20outbound%20requests%20per%20race%20rather%20than%20one.%20The%20outer%20guard%20could%20be%20extended%20to%20also%20check%20the%20in-flight%20map%20before%20fetching.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=399&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fcto%2FlinearSyncService.ts%3A25%0A**Module-level%20map%20couples%20all%20service%20instances%20in%20the%20process**%0A%0A%60inFlightAdeIssueLinkAttachments%60%20lives%20at%20module%20scope%20and%20is%20therefore%20shared%20across%20every%20%60createLinearSyncService%60%20instance%20%28e.g.%2C%20on%20service%20reload%20or%20reconnect%29.%20When%20%60dispose%28%29%60%20is%20called%20on%20instance%20A%2C%20its%20in-flight%20key%20%28%60projectId%3AissueId%60%29%20is%20never%20removed.%20If%20instance%20B%20is%20created%20for%20the%20same%20project%20before%20the%20old%20promise%20settles%2C%20B%20joins%20A's%20in-flight%20promise%20%E2%80%94%20which%20may%20be%20writing%20to%20A's%20now-closing%20DB%2C%20causing%20the%20shared%20promise%20to%20fail%20or%20produce%20results%20that%20land%20in%20the%20wrong%20DB.%20The%20key%20should%20be%20created%20inside%20the%20%60createLinearSyncService%60%20closure%20%28like%20%60pendingIssueIds%60%20and%20%60inFlight%60%29%20so%20each%20instance%20owns%20its%20own%20map%2C%20and%20%60dispose%28%29%60%20can%20clear%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fcto%2FlinearSyncService.ts%3A206-217%0A**Two%20concurrent%20%60ensureAdeIssueLinkForIssue%60%20calls%20still%20trigger%20two%20%60fetchIssueById%60%20network%20calls**%0A%0ABoth%20concurrent%20callers%20pass%20the%20%60hasAdeIssueLinkAttachment%60%20guard%20at%20line%20212%20before%20either%20has%20registered%20anything%20in%20the%20in-flight%20map%2C%20then%20both%20independently%20call%20%60fetchIssueById%60.%20Deduplication%20only%20fires%20when%20%60attachAdeIssueLinkForIssue%60%20is%20reached.%20For%20most%20deployments%20this%20is%20invisible%20%28the%20mock%20resolves%20synchronously%20in%20tests%29%2C%20but%20against%20a%20real%20Linear%20API%20this%20means%20two%20outbound%20requests%20per%20race%20rather%20than%20one.%20The%20outer%20guard%20could%20be%20extended%20to%20also%20check%20the%20in-flight%20map%20before%20fetching.%0A%0A&repo=arul28%2Fade&pr=399&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src/main/services/cto/linearSyncService.ts:25
**Module-level map couples all service instances in the process**

`inFlightAdeIssueLinkAttachments` lives at module scope and is therefore shared across every `createLinearSyncService` instance (e.g., on service reload or reconnect). When `dispose()` is called on instance A, its in-flight key (`projectId:issueId`) is never removed. If instance B is created for the same project before the old promise settles, B joins A's in-flight promise — which may be writing to A's now-closing DB, causing the shared promise to fail or produce results that land in the wrong DB. The key should be created inside the `createLinearSyncService` closure (like `pendingIssueIds` and `inFlight`) so each instance owns its own map, and `dispose()` can clear it.

### Issue 2 of 2
apps/desktop/src/main/services/cto/linearSyncService.ts:206-217
**Two concurrent `ensureAdeIssueLinkForIssue` calls still trigger two `fetchIssueById` network calls**

Both concurrent callers pass the `hasAdeIssueLinkAttachment` guard at line 212 before either has registered anything in the in-flight map, then both independently call `fetchIssueById`. Deduplication only fires when `attachAdeIssueLinkForIssue` is reached. For most deployments this is invisible (the mock resolves synchronously in tests), but against a real Linear API this means two outbound requests per race rather than one. The outer guard could be extended to also check the in-flight map before fetching.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Linear issue deeplink attachment rac..."](https://github.com/arul28/ade/commit/1493210559355c398fb5ccbc7a7ce1ca123e7088) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34545724)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->