### PR TITLE
Cursor Broken Again

### DIFF
--- a/apps/desktop/src/main/services/chat/cursorSdkHooks.test.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkHooks.test.ts
@@ -42,18 +42,26 @@ describe("Cursor SDK hook installation", () => {
         nodePath: "/node path/bin/node",
       });
       expect(first.changed).toBe(true);
-      expect(first.command).toContain("/bin/sh");
-      expect(first.command).toContain("ade-tool-gate.sh");
+      if (process.platform === "win32") {
+        expect(first.command).toContain("ade-tool-gate.cjs");
+      } else {
+        expect(first.command).toContain("/bin/sh");
+        expect(first.command).toContain("ade-tool-gate.sh");
+      }
 
       const config = readJson(hooksPath);
       expect(config.version).toBe(2);
       expect(config.hooks.postToolUse).toEqual([{ command: "node post-hook.cjs" }]);
       expect(config.hooks.preToolUse).toHaveLength(2);
-      expect(config.hooks.preToolUse[0].command).toContain("ade-tool-gate.sh");
+      expect(config.hooks.preToolUse[0].command).toContain(
+        process.platform === "win32" ? "ade-tool-gate.cjs" : "ade-tool-gate.sh",
+      );
       expect(config.hooks.preToolUse[0].failClosed).toBe(true);
       expect(config.hooks.preToolUse[1]).toEqual({ command: "node existing-hook.cjs", failClosed: false });
       expect(fs.existsSync(cursorSdkHookScriptPath(home))).toBe(true);
-      expect(fs.existsSync(cursorSdkHookShellCommandPath(home))).toBe(true);
+      if (process.platform !== "win32") {
+        expect(fs.existsSync(cursorSdkHookShellCommandPath(home))).toBe(true);
+      }
 
       const second = ensureCursorSdkUserHook({
         userHomeDir: home,

--- a/apps/desktop/src/main/services/chat/cursorSdkHooks.test.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkHooks.test.ts
@@ -6,10 +6,12 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   __buildCursorSdkHookCommandForTests,
+  cursorSdkHookShellCommandPath,
   cursorSdkHookScriptPath,
   cursorSdkHookWindowsCommandPath,
   cursorSdkHooksJsonPath,
   ensureCursorSdkUserHook,
+  writeCursorSdkHookShellCommandScript,
   writeCursorSdkHookWindowsCommandScript,
 } from "./cursorSdkHooks";
 
@@ -40,17 +42,18 @@ describe("Cursor SDK hook installation", () => {
         nodePath: "/node path/bin/node",
       });
       expect(first.changed).toBe(true);
-      expect(first.command).toContain("\"/node path/bin/node\"");
-      expect(first.command).toContain("\"");
+      expect(first.command).toContain("/bin/sh");
+      expect(first.command).toContain("ade-tool-gate.sh");
 
       const config = readJson(hooksPath);
       expect(config.version).toBe(2);
       expect(config.hooks.postToolUse).toEqual([{ command: "node post-hook.cjs" }]);
       expect(config.hooks.preToolUse).toHaveLength(2);
-      expect(config.hooks.preToolUse[0].command).toContain("ade-tool-gate.cjs");
+      expect(config.hooks.preToolUse[0].command).toContain("ade-tool-gate.sh");
       expect(config.hooks.preToolUse[0].failClosed).toBe(true);
       expect(config.hooks.preToolUse[1]).toEqual({ command: "node existing-hook.cjs", failClosed: false });
       expect(fs.existsSync(cursorSdkHookScriptPath(home))).toBe(true);
+      expect(fs.existsSync(cursorSdkHookShellCommandPath(home))).toBe(true);
 
       const second = ensureCursorSdkUserHook({
         userHomeDir: home,
@@ -77,6 +80,51 @@ describe("Cursor SDK hook installation", () => {
         encoding: "utf8",
       });
       expect(JSON.parse(stdout)).toEqual({ permission: "allow" });
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("uses a shell wrapper that allows non-ADE Cursor when Node is unavailable", () => {
+    if (process.platform === "win32") return;
+    const home = tempHome();
+    try {
+      ensureCursorSdkUserHook({ userHomeDir: home });
+      const stdout = execFileSync("/bin/sh", [cursorSdkHookShellCommandPath(home)], {
+        input: "{}",
+        env: {
+          PATH: "",
+          HOME: home,
+          USERPROFILE: home,
+        },
+        encoding: "utf8",
+      });
+      expect(JSON.parse(stdout)).toEqual({ permission: "allow" });
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for ADE Cursor hook invocations when no Node runner is available", () => {
+    if (process.platform === "win32") return;
+    const home = tempHome();
+    try {
+      ensureCursorSdkUserHook({ userHomeDir: home });
+      const stdout = execFileSync("/bin/sh", [cursorSdkHookShellCommandPath(home)], {
+        input: "{}",
+        env: {
+          PATH: "",
+          HOME: home,
+          USERPROFILE: home,
+          ADE_CURSOR_SDK_SOCKET: path.join(home, "missing.sock"),
+          ADE_CURSOR_SDK_SESSION_ID: "session-1",
+          ADE_CURSOR_SDK_LANE_ROOT: "/tmp/lane",
+        },
+        encoding: "utf8",
+      });
+      const decision = JSON.parse(stdout);
+      expect(decision.permission).toBe("deny");
+      expect(decision.user_message).toContain("requires Node.js");
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }
@@ -126,6 +174,22 @@ describe("Cursor SDK hook installation", () => {
       const decision = JSON.parse(stdout);
       expect(decision.permission).toBe("deny");
       expect(decision.user_message).toContain("ENOENT");
+
+      const equalsStdout = execFileSync(process.execPath, [
+        cursorSdkHookScriptPath(home),
+        `--socket=${path.join(home, "missing.sock")}`,
+      ], {
+        input: "{}",
+        env: {
+          PATH: process.env.PATH ?? "",
+          HOME: home,
+          USERPROFILE: home,
+        },
+        encoding: "utf8",
+      });
+      const equalsDecision = JSON.parse(equalsStdout);
+      expect(equalsDecision.permission).toBe("deny");
+      expect(equalsDecision.user_message).toContain("ENOENT");
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
     }
@@ -201,6 +265,7 @@ describe("Cursor SDK hook installation", () => {
         undefined,
         String.raw`C:\Users\Ada Lovelace\.cursor\hooks\ade-tool-gate.cjs`,
         String.raw`C:\Users\Ada Lovelace\.cursor\hooks\ade-tool-gate.cmd`,
+        undefined,
       );
       expect(command).toBe(`cmd /d /c "C:\\Users\\Ada Lovelace\\.cursor\\hooks\\ade-tool-gate.cmd"`);
     } finally {
@@ -210,6 +275,36 @@ describe("Cursor SDK hook installation", () => {
       } else {
         Object.defineProperty(process.versions, "electron", { value: originalElectron, configurable: true });
       }
+    }
+  });
+
+  it("writes the POSIX shell wrapper with escaped paths", () => {
+    if (process.platform === "win32") return;
+    const home = tempHome();
+    try {
+      const commandPath = cursorSdkHookShellCommandPath(home);
+      writeCursorSdkHookShellCommandScript({
+        commandPath,
+        nodePath: "/tmp/node's/bin/node",
+        scriptPath: "/tmp/ADE Hooks/ade-tool-gate.cjs",
+      });
+      const content = fs.readFileSync(commandPath, "utf8");
+      expect(content).toContain("script_path='/tmp/ADE Hooks/ade-tool-gate.cjs'");
+      expect(content).toContain("configured_node='/tmp/node'\\''s/bin/node'");
+      const stdout = execFileSync("/bin/sh", [commandPath, `--socket=${path.join(home, "missing.sock")}`], {
+        input: "{}",
+        env: {
+          PATH: "",
+          HOME: home,
+          USERPROFILE: home,
+        },
+        encoding: "utf8",
+      });
+      const decision = JSON.parse(stdout);
+      expect(decision.permission).toBe("deny");
+      expect(decision.user_message).toContain("requires Node.js");
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
     }
   });
 

--- a/apps/desktop/src/main/services/chat/cursorSdkHooks.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkHooks.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 const ADE_HOOK_SCRIPT_NAME = "ade-tool-gate.cjs";
+const ADE_HOOK_SHELL_COMMAND_NAME = "ade-tool-gate.sh";
 const ADE_HOOK_WINDOWS_COMMAND_NAME = "ade-tool-gate.cmd";
 
 type CursorHooksConfig = {
@@ -26,6 +27,13 @@ function shellQuote(value: string): string {
   return `"${value.replace(/(["\\$`])/g, "\\$1")}"`;
 }
 
+function shellSingleQuote(value: string): string {
+  if (/[\0\r\n]/.test(value)) {
+    throw new Error("Cursor hook command paths cannot contain control characters.");
+  }
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
 function windowsCmdQuote(value: string): string {
   if (/[\0\r\n"%]/.test(value)) {
     throw new Error("Cursor hook command paths cannot contain control characters or Windows cmd expansion characters.");
@@ -48,8 +56,12 @@ function buildHookCommand(
   nodePath: string | undefined,
   scriptPath: string,
   windowsCommandPath?: string,
+  shellCommandPath?: string,
 ): string {
   const explicitNode = nodePath?.trim();
+  if (process.platform !== "win32" && shellCommandPath) {
+    return `/bin/sh ${shellQuote(shellCommandPath)}`;
+  }
   if (explicitNode) return `${commandPathQuote(explicitNode)} ${commandPathQuote(scriptPath)}`;
   if (process.versions.electron) {
     if (process.platform === "win32") {
@@ -97,11 +109,17 @@ function readHooksFile(filePath: string): CursorHooksConfig {
 function isAdeHookEntry(value: unknown): boolean {
   const entry = readObject(value);
   const command = typeof entry?.command === "string" ? entry.command : "";
-  return command.includes(ADE_HOOK_SCRIPT_NAME);
+  return command.includes(ADE_HOOK_SCRIPT_NAME)
+    || command.includes(ADE_HOOK_SHELL_COMMAND_NAME)
+    || command.includes(ADE_HOOK_WINDOWS_COMMAND_NAME);
 }
 
 export function cursorSdkHookScriptPath(userHomeDir: string): string {
   return path.join(userHomeDir, ".cursor", "hooks", ADE_HOOK_SCRIPT_NAME);
+}
+
+export function cursorSdkHookShellCommandPath(userHomeDir: string): string {
+  return path.join(userHomeDir, ".cursor", "hooks", ADE_HOOK_SHELL_COMMAND_NAME);
 }
 
 export function cursorSdkHookWindowsCommandPath(userHomeDir: string): string {
@@ -128,8 +146,12 @@ function readStdin() {
 }
 
 function parseArg(name) {
-  const index = process.argv.indexOf(name);
-  return index >= 0 ? process.argv[index + 1] : null;
+  for (let i = 0; i < process.argv.length; i += 1) {
+    const arg = process.argv[i];
+    if (arg === name) return process.argv[i + 1] || null;
+    if (arg.startsWith(name + "=")) return arg.slice(name.length + 1) || null;
+  }
+  return null;
 }
 
 function writeDecision(decision) {
@@ -241,6 +263,60 @@ main().catch((error) => {
   fs.writeFileSync(scriptPath, source, { mode: 0o755 });
 }
 
+function stableElectronHookRunnerPath(): string {
+  if (!process.versions.electron) return "";
+  const execPath = process.execPath?.trim();
+  if (!execPath) return "";
+  if (execPath.includes(`${path.sep}node_modules${path.sep}electron${path.sep}`)) return "";
+  if (execPath.includes(`${path.sep}.ade${path.sep}worktrees${path.sep}`)) return "";
+  return execPath;
+}
+
+export function writeCursorSdkHookShellCommandScript(args: {
+  commandPath: string;
+  scriptPath: string;
+  nodePath?: string;
+  electronPath?: string;
+}): void {
+  ensureDir(path.dirname(args.commandPath));
+const source = `#!/bin/sh
+has_socket_arg=0
+for arg in "$@"; do
+  case "$arg" in
+    --socket|--socket=*) has_socket_arg=1 ;;
+  esac
+done
+
+if [ "$has_socket_arg" -eq 0 ] && [ -z "\${ADE_CURSOR_SDK_SOCKET:-}" ] && [ -z "\${ADE_CURSOR_SDK_SESSION_ID:-}" ] && [ -z "\${ADE_CURSOR_SDK_LANE_ROOT:-}" ]; then
+  printf '%s' '{"permission":"allow"}'
+  exit 0
+fi
+
+script_path=${shellSingleQuote(args.scriptPath)}
+configured_node=${shellSingleQuote(args.nodePath?.trim() ?? "")}
+configured_electron=${shellSingleQuote(args.electronPath?.trim() ?? "")}
+
+if [ -n "\${ADE_CURSOR_SDK_NODE:-}" ] && [ -x "$ADE_CURSOR_SDK_NODE" ]; then
+  exec "$ADE_CURSOR_SDK_NODE" "$script_path" "$@"
+fi
+
+if [ -n "$configured_node" ] && [ -x "$configured_node" ]; then
+  exec "$configured_node" "$script_path" "$@"
+fi
+
+if command -v node >/dev/null 2>&1; then
+  exec node "$script_path" "$@"
+fi
+
+if [ -n "$configured_electron" ] && [ -x "$configured_electron" ]; then
+  ELECTRON_RUN_AS_NODE=1 exec "$configured_electron" "$script_path" "$@"
+fi
+
+printf '%s' '{"permission":"deny","user_message":"ADE Cursor policy gate requires Node.js for ADE-managed Cursor sessions.","agent_message":"ADE Cursor policy gate requires Node.js for ADE-managed Cursor sessions."}'
+`;
+  fs.writeFileSync(args.commandPath, source, { mode: 0o755 });
+}
+
 export function writeCursorSdkHookWindowsCommandScript(args: {
   commandPath: string;
   electronPath: string;
@@ -264,21 +340,31 @@ export function ensureCursorSdkUserHook(args: {
   nodePath?: string;
 }): { hooksPath: string; scriptPath: string; command: string; changed: boolean } {
   const scriptPath = cursorSdkHookScriptPath(args.userHomeDir);
+  const shellCommandPath = cursorSdkHookShellCommandPath(args.userHomeDir);
   const windowsCommandPath = cursorSdkHookWindowsCommandPath(args.userHomeDir);
   const hooksPath = cursorSdkHooksJsonPath(args.userHomeDir);
   writeCursorSdkHookBridgeScript(scriptPath);
-  if (!args.nodePath?.trim() && process.versions.electron && process.platform === "win32") {
-    writeCursorSdkHookWindowsCommandScript({
-      commandPath: windowsCommandPath,
-      electronPath: process.execPath,
+  if (process.platform === "win32") {
+    if (!args.nodePath?.trim() && process.versions.electron) {
+      writeCursorSdkHookWindowsCommandScript({
+        commandPath: windowsCommandPath,
+        electronPath: process.execPath,
+        scriptPath,
+      });
+    }
+  } else {
+    writeCursorSdkHookShellCommandScript({
+      commandPath: shellCommandPath,
       scriptPath,
+      nodePath: args.nodePath,
+      electronPath: stableElectronHookRunnerPath(),
     });
   }
 
   const config = readHooksFile(hooksPath);
   const hooks = readObject(config.hooks) ?? {};
   const existingPreToolUse = Array.isArray(hooks.preToolUse) ? hooks.preToolUse : [];
-  const command = buildHookCommand(args.nodePath, scriptPath, windowsCommandPath);
+  const command = buildHookCommand(args.nodePath, scriptPath, windowsCommandPath, shellCommandPath);
   const adeEntry = { command, failClosed: true };
   const nextPreToolUse = [
     adeEntry,

--- a/apps/desktop/src/main/services/chat/cursorSdkHooks.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkHooks.ts
@@ -58,10 +58,12 @@ function buildHookCommand(
   windowsCommandPath?: string,
   shellCommandPath?: string,
 ): string {
-  const explicitNode = nodePath?.trim();
   if (process.platform !== "win32" && shellCommandPath) {
+    // The POSIX wrapper embeds node/electron paths and can allow normal Cursor
+    // sessions through before Node is needed.
     return `/bin/sh ${shellQuote(shellCommandPath)}`;
   }
+  const explicitNode = nodePath?.trim();
   if (explicitNode) return `${commandPathQuote(explicitNode)} ${commandPathQuote(scriptPath)}`;
   if (process.versions.electron) {
     if (process.platform === "win32") {
@@ -279,7 +281,7 @@ export function writeCursorSdkHookShellCommandScript(args: {
   electronPath?: string;
 }): void {
   ensureDir(path.dirname(args.commandPath));
-const source = `#!/bin/sh
+  const source = `#!/bin/sh
 has_socket_arg=0
 for arg in "$@"; do
   case "$arg" in

--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts
@@ -476,6 +476,66 @@ describe("local runtime connection pool", () => {
     }
   });
 
+  it("does not let a stale dropped connection clear an in-flight reconnect", () => {
+    const pool = new LocalRuntimeConnectionPool("1.2.3", {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as never, { disableSync: true });
+    const reconnect = new Promise<unknown>(() => {});
+    const staleClient = { close: vi.fn() };
+    const staleEntry = {
+      client: staleClient,
+      child: null,
+      socketPath: "/tmp/old-ade.sock",
+    };
+    (pool as unknown as {
+      connection: Promise<unknown>;
+      activeClient: unknown;
+      activeConnection: unknown;
+    }).connection = reconnect;
+    (pool as unknown as { activeClient: unknown }).activeClient = null;
+    (pool as unknown as { activeConnection: unknown }).activeConnection = null;
+
+    (pool as unknown as {
+      resetActiveConnection: (entry: typeof staleEntry) => void;
+    }).resetActiveConnection(staleEntry);
+
+    expect((pool as unknown as { connection: Promise<unknown> | null }).connection).toBe(reconnect);
+    expect(staleClient.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let a stale timed-out action clear an in-flight reconnect", () => {
+    const pool = new LocalRuntimeConnectionPool("1.2.3", {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as never, { disableSync: true });
+    const reconnect = new Promise<unknown>(() => {});
+    const staleClient = { close: vi.fn() };
+    const staleEntry = {
+      client: staleClient,
+      child: null,
+      socketPath: "/tmp/old-ade.sock",
+    };
+    (pool as unknown as {
+      connection: Promise<unknown>;
+      activeClient: unknown;
+      activeConnection: unknown;
+    }).connection = reconnect;
+    (pool as unknown as { activeClient: unknown }).activeClient = null;
+    (pool as unknown as { activeConnection: unknown }).activeConnection = null;
+
+    (pool as unknown as {
+      resetConnectionAfterActionTimeout: (entry: typeof staleEntry) => void;
+    }).resetConnectionAfterActionTimeout(staleEntry);
+
+    expect((pool as unknown as { connection: Promise<unknown> | null }).connection).toBe(reconnect);
+    expect(staleClient.close).toHaveBeenCalledTimes(1);
+  });
+
   it("normalizes local action registry entries from runtime action names", async () => {
     const pool = new LocalRuntimeConnectionPool("1.2.3", {
       debug: vi.fn(),
@@ -545,7 +605,7 @@ describe("local runtime connection pool", () => {
       gitOriginUrl: null,
     });
     (pool as unknown as { connection: Promise<unknown> }).connection = Promise.resolve({
-      client: { call },
+      client: { call, isClosed: vi.fn(() => false) },
       child: null,
       socketPath: "/tmp/ade.sock",
     });
@@ -1201,7 +1261,7 @@ describe("local runtime connection pool", () => {
       gitOriginUrl: null,
     });
     (pool as unknown as { connection: Promise<unknown> }).connection = Promise.resolve({
-      client: { call },
+      client: { call, isClosed: vi.fn(() => false) },
       child: null,
       socketPath: "/tmp/ade.sock",
     });
@@ -1262,7 +1322,7 @@ describe("local runtime connection pool", () => {
       gitOriginUrl: null,
     });
     (pool as unknown as { connection: Promise<unknown> }).connection = Promise.resolve({
-      client: { call },
+      client: { call, isClosed: vi.fn(() => false) },
       child: null,
       socketPath: "/tmp/ade.sock",
     });
@@ -1315,11 +1375,15 @@ describe("local runtime connection pool", () => {
       lastOpenedAt: 1,
       gitOriginUrl: null,
     });
-    (pool as unknown as { connection: Promise<unknown> }).connection = Promise.resolve({
-      client: { call, close },
+    const client = { call, close, isClosed: vi.fn(() => false) };
+    const entry = {
+      client,
       child,
       socketPath: "/tmp/ade.sock",
-    });
+    };
+    (pool as unknown as { connection: Promise<unknown> }).connection = Promise.resolve(entry);
+    (pool as unknown as { activeConnection: unknown; activeClient: unknown }).activeConnection = entry;
+    (pool as unknown as { activeClient: unknown }).activeClient = client;
     (pool as unknown as { ownedRuntimeChild: unknown }).ownedRuntimeChild = child;
 
     await expect(pool.callActionForRoot(rootPath, {

--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
@@ -489,6 +489,7 @@ function serviceHealthState(
 
 export class LocalRuntimeConnectionPool {
   private connection: Promise<LocalRuntimeConnection> | null = null;
+  private activeConnection: LocalRuntimeConnection | null = null;
   private activeClient: RuntimeRpcClient | null = null;
   private ownedRuntimeChild: ChildProcess | null = null;
   private readonly coalescedActionCalls = new Map<string, Promise<RemoteRuntimeActionResult>>();
@@ -944,6 +945,7 @@ export class LocalRuntimeConnectionPool {
   dispose(): void {
     const pending = this.connection;
     this.connection = null;
+    this.activeConnection = null;
     this.activeClient = null;
     this.ownedRuntimeChild = null;
     this.projectsByRoot.clear();
@@ -955,19 +957,38 @@ export class LocalRuntimeConnectionPool {
 
   private async connect(): Promise<LocalRuntimeConnection> {
     if (this.connection) return this.connection;
-    this.connection = this.createConnection().catch((error) => {
-      this.connection = null;
+    const connection = this.createConnection().then((entry) => {
+      if (this.connection === connection) {
+        this.activeConnection = entry;
+      }
+      return entry;
+    }).catch((error) => {
+      if (this.connection === connection) {
+        this.connection = null;
+        this.activeConnection = null;
+        this.activeClient = null;
+      }
       throw error;
     });
-    return this.connection;
+    this.connection = connection;
+    return connection;
+  }
+
+  private isCurrentConnection(entry: LocalRuntimeConnection): boolean {
+    return this.activeClient === entry.client || this.activeConnection?.client === entry.client;
+  }
+
+  private clearConnectionIfCurrent(entry: LocalRuntimeConnection): boolean {
+    if (!this.isCurrentConnection(entry)) return false;
+    this.connection = null;
+    this.activeConnection = null;
+    this.activeClient = null;
+    this.projectsByRoot.clear();
+    return true;
   }
 
   private resetConnectionAfterActionTimeout(entry: LocalRuntimeConnection): void {
-    if (!this.activeClient || this.activeClient === entry.client) {
-      this.connection = null;
-      this.activeClient = null;
-      this.projectsByRoot.clear();
-    }
+    this.clearConnectionIfCurrent(entry);
     if (entry.child && this.ownedRuntimeChild === entry.child) {
       this.ownedRuntimeChild = null;
     }
@@ -981,11 +1002,7 @@ export class LocalRuntimeConnectionPool {
   // replaced (e.g. build-hash recycle), and a fresh daemon may have rebound the
   // same socket — tearing it down would kill the healthy replacement.
   private resetActiveConnection(entry: LocalRuntimeConnection): void {
-    if (!this.activeClient || this.activeClient === entry.client) {
-      this.connection = null;
-      this.activeClient = null;
-      this.projectsByRoot.clear();
-    }
+    this.clearConnectionIfCurrent(entry);
     closeRuntimeClient(entry.client);
   }
 
@@ -1133,12 +1150,13 @@ export class LocalRuntimeConnectionPool {
     }
     this.activeClient = client;
     client.onDisconnect((error) => {
-      if (this.activeClient !== client) return;
+      if (this.activeClient !== client && this.activeConnection?.client !== client) return;
       this.logger.warn("local_runtime.disconnected", {
         socketPath,
         error: error.message,
       });
       this.connection = null;
+      this.activeConnection = null;
       this.activeClient = null;
       this.projectsByRoot.clear();
     });
@@ -1180,6 +1198,7 @@ export class LocalRuntimeConnectionPool {
       const client = this.activeClient;
       this.ownedRuntimeChild = null;
       this.connection = null;
+      this.activeConnection = null;
       this.activeClient = null;
       this.projectsByRoot.clear();
       if (client) closeRuntimeClient(client);

--- a/apps/desktop/src/main/utils/terminalSessionSignals.test.ts
+++ b/apps/desktop/src/main/utils/terminalSessionSignals.test.ts
@@ -167,6 +167,13 @@ describe("terminalSessionSignals", () => {
     })).toBe("cursor-agent --mode ask --model auto --resume chat-1");
 
     expect(buildTrackedCliResumeCommand({
+      provider: "cursor",
+      targetKind: "session",
+      targetId: "chat-2",
+      launch: { permissionMode: "full-auto", model: "cursor/composer-2.5" },
+    })).toBe("cursor-agent --force --trust --model composer-2.5 --resume chat-2");
+
+    expect(buildTrackedCliResumeCommand({
       provider: "opencode",
       targetKind: "session",
       targetId: "ses_1",

--- a/apps/desktop/src/main/utils/terminalSessionSignals.ts
+++ b/apps/desktop/src/main/utils/terminalSessionSignals.ts
@@ -37,7 +37,13 @@ function commandArrayToLine(parts: string[]): string {
 export const sanitizeResumeTargetId = sanitizeTrackedCliResumeTargetId;
 
 function resolveCursorCliModelForLaunch(model: string | null | undefined): string {
-  return normalizeCliFlagValue(model) ?? "auto";
+  const normalized = normalizeCliFlagValue(model);
+  if (!normalized) return "auto";
+  const slash = normalized.indexOf("/");
+  if (slash > 0 && normalized.slice(0, slash).toLowerCase() === "cursor") {
+    return normalized.slice(slash + 1).trim() || "auto";
+  }
+  return normalized;
 }
 
 function normalizeDroidCliModel(model: string | null | undefined): string | null {
@@ -156,7 +162,7 @@ function permissionModeToCodexFlags(permissionMode: AgentChatPermissionMode | nu
 }
 
 function permissionModeToCursorFlags(permissionMode: AgentChatPermissionMode | null | undefined): string[] {
-  if (permissionMode === "full-auto") return ["--force"];
+  if (permissionMode === "full-auto") return ["--force", "--trust"];
   if (permissionMode === "plan") return ["--mode", "plan"];
   if (permissionMode === "edit") return ["--mode", "ask"];
   return [];

--- a/apps/desktop/src/main/utils/terminalSessionSignals.ts
+++ b/apps/desktop/src/main/utils/terminalSessionSignals.ts
@@ -14,6 +14,7 @@ import {
   modelToCliFlag,
   normalizeCliFlagValue,
   resolveClaudeCliModelForLaunch,
+  resolveCursorCliModelForLaunch,
   sanitizeTrackedCliResumeTargetId,
 } from "../../shared/cliLaunch";
 import { decodeOpenCodeRegistryId } from "../../shared/modelRegistry";
@@ -35,16 +36,6 @@ function commandArrayToLine(parts: string[]): string {
 }
 
 export const sanitizeResumeTargetId = sanitizeTrackedCliResumeTargetId;
-
-function resolveCursorCliModelForLaunch(model: string | null | undefined): string {
-  const normalized = normalizeCliFlagValue(model);
-  if (!normalized) return "auto";
-  const slash = normalized.indexOf("/");
-  if (slash > 0 && normalized.slice(0, slash).toLowerCase() === "cursor") {
-    return normalized.slice(slash + 1).trim() || "auto";
-  }
-  return normalized;
-}
 
 function normalizeDroidCliModel(model: string | null | undefined): string | null {
   const normalized = normalizeCliFlagValue(model);

--- a/apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts
@@ -293,6 +293,18 @@ describe("buildTrackedCliStartupCommand", () => {
       expect(launch.env?.[ADE_AGENT_SKILLS_DIRS_ENV]).toContain("agent-skills");
     });
 
+    it("normalizes Cursor registry model ids and trusts full-auto workspaces", () => {
+      const launch = buildTrackedCliLaunchCommand({
+        provider: "cursor",
+        permissionMode: "full-auto",
+        model: "cursor/composer-2.5",
+        initialPrompt: "Review this lane.",
+      });
+
+      expect(launch.startupCommand).toContain("cursor-agent --force --trust --model composer-2.5 --resume \"$ADE_CURSOR_CHAT_ID\"");
+      expect(launch.startupCommand).not.toContain("--model cursor/composer-2.5");
+    });
+
     it("launches Cursor through a Windows-safe pre-created resumable chat", () => {
       withProcessPlatform("win32", () => {
         const launch = buildTrackedCliLaunchCommand({ provider: "cursor", permissionMode: "plan", model: "cursor-fast", initialPrompt: "Review this lane." });
@@ -456,7 +468,14 @@ describe("tracked CLI resume helpers", () => {
       targetKind: "session",
       targetId: "chat-99",
       launch: { permissionMode: "full-auto" },
-    })).toBe("cursor-agent --force --model auto --resume chat-99");
+    })).toBe("cursor-agent --force --trust --model auto --resume chat-99");
+
+    expect(buildTrackedCliResumeCommand({
+      provider: "cursor",
+      targetKind: "session",
+      targetId: "chat-99",
+      launch: { permissionMode: "default", model: "cursor/composer-2.5" },
+    })).toBe("cursor-agent --model composer-2.5 --resume chat-99");
 
     expect(buildTrackedCliResumeCommand({
       provider: "opencode",

--- a/apps/desktop/src/shared/cliLaunch.ts
+++ b/apps/desktop/src/shared/cliLaunch.ts
@@ -462,7 +462,7 @@ function normalizeDroidCliModel(model: string | null | undefined): string | null
   return normalized;
 }
 
-function resolveCursorCliModelForLaunch(model: string | null | undefined): string {
+export function resolveCursorCliModelForLaunch(model: string | null | undefined): string {
   const normalized = normalizeCliFlagValue(model);
   if (!normalized) return "auto";
   const slash = normalized.indexOf("/");

--- a/apps/desktop/src/shared/cliLaunch.ts
+++ b/apps/desktop/src/shared/cliLaunch.ts
@@ -463,7 +463,13 @@ function normalizeDroidCliModel(model: string | null | undefined): string | null
 }
 
 function resolveCursorCliModelForLaunch(model: string | null | undefined): string {
-  return normalizeCliFlagValue(model) ?? "auto";
+  const normalized = normalizeCliFlagValue(model);
+  if (!normalized) return "auto";
+  const slash = normalized.indexOf("/");
+  if (slash > 0 && normalized.slice(0, slash).toLowerCase() === "cursor") {
+    return normalized.slice(slash + 1).trim() || "auto";
+  }
+  return normalized;
 }
 
 export function resolveCodexCliModelForLaunch(model: string | null | undefined): string | null {
@@ -513,7 +519,7 @@ function permissionModeToCodexFlags(permissionMode: AgentChatPermissionMode | nu
 }
 
 function permissionModeToCursorFlags(permissionMode: AgentChatPermissionMode | null | undefined): string[] {
-  if (permissionMode === "full-auto") return ["--force"];
+  if (permissionMode === "full-auto") return ["--force", "--trust"];
   if (permissionMode === "plan") return ["--mode", "plan"];
   if (permissionMode === "edit") return ["--mode", "ask"];
   return [];


### PR DESCRIPTION
Fixes ADE-64

## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fcursor-broken-again-028b6df6 num=401 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fcursor-broken-again-028b6df6&amp;pr=401">ade/cursor-broken-again-028b6df6 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=401">PR #401</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Unix shell-based Cursor hook command support for non-Windows platforms.
  * Improved CLI model normalization for Cursor (e.g., `cursor/composer-2.5` → `composer-2.5`).

* **Bug Fixes**
  * Fixed race condition preventing reconnection attempts when stale connections are cleared.
  * Enhanced connection state tracking to prevent stale connection usage.

* **Tests**
  * Added tests for shell wrapper behavior under Unix environments.
  * Added reconnection race prevention coverage.
  * Enhanced CLI command generation test cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Cursor integration that had broken in multiple ways: a race condition in the connection pool that could clobber in-flight reconnects, missing POSIX shell wrapper for non-Windows hook installs, an unstripped `cursor/` model-ID prefix being passed to the CLI, and a missing `--trust` flag for full-auto Cursor sessions.

- **Connection pool race fix**: adds `activeConnection` tracking so `clearConnectionIfCurrent` can distinguish between a stale disconnected client and a fresh in-flight reconnect; previously the `!this.activeClient` guard would clear `this.connection` even when a new promise was already pending.
- **POSIX shell wrapper** (`ade-tool-gate.sh`): lets non-ADE Cursor sessions pass through immediately with `{\"permission\":\"allow\"}` when no ADE env vars are present, while failing closed for ADE sessions if Node.js cannot be located.
- **CLI improvements**: `resolveCursorCliModelForLaunch` now strips the `cursor/` registry prefix, and `permissionModeToCursorFlags` adds `--trust` in both `cliLaunch.ts` and `terminalSessionSignals.ts`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three broken areas (connection pool race, non-Windows hook install, CLI model/flag correctness) have targeted fixes with matching tests.

The connection pool race fix correctly introduces activeConnection as a second anchor point so stale reset callbacks can no longer clobber an in-flight reconnect promise. The POSIX shell wrapper uses proper single-quote escaping and the allow/deny logic is well-guarded. Model normalization and the --trust flag are straightforward with full test coverage. No regressions were found in the changed paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts | Adds activeConnection tracking to close the race where a stale dropped-connection reset could null out an in-flight reconnect promise; guard logic is correct and symmetrical across all reset paths |
| apps/desktop/src/main/services/chat/cursorSdkHooks.ts | Adds POSIX shell wrapper for non-Windows Cursor hook installs with correct single-quote escaping; buildHookCommand correctly delegates to the wrapper on non-Windows |
| apps/desktop/src/shared/cliLaunch.ts | resolveCursorCliModelForLaunch now exported and strips cursor/ prefix; --trust added for full-auto permission mode |
| apps/desktop/src/main/utils/terminalSessionSignals.ts | Removes local resolveCursorCliModelForLaunch in favor of the shared export; adds --trust flag symmetrically with cliLaunch.ts |
| apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts | New tests cover the stale-reset/in-flight-reconnect race for both resetActiveConnection and resetConnectionAfterActionTimeout; existing action tests updated with isClosed mock and activeConnection/activeClient initialization |
| apps/desktop/src/main/services/chat/cursorSdkHooks.test.ts | Adds shell wrapper execution tests covering pass-through for non-ADE sessions, fail-closed without Node, and path escaping; updates existing assertions for cross-platform behavior |
| apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts | New test confirms cursor/ prefix stripping and --trust injection in full-auto mode; expectation for existing full-auto test updated to include --trust |
| apps/desktop/src/main/utils/terminalSessionSignals.test.ts | Adds resume-command test for cursor/composer-2.5 model to verify prefix stripping on the terminal session signals path |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[connect called] --> B{connection set?}
    B -- Yes --> C[Return existing promise]
    B -- No --> D[createConnection starts]
    D --> E[connectClient sets activeClient]
    E --> F[.then fires: sets activeConnection]
    F --> G[Callers get entry]

    H[Stale reset or disconnect fires] --> I{isCurrentConnection?}
    I -- Match --> J[Clear connection + activeConnection + activeClient]
    I -- No match: reconnect in-flight --> K[Skip clear, reconnect preserved]
    J --> L[Close stale client]
    K --> L
```

<sub>Reviews (2): Last reviewed commit: ["Address Cursor hook review feedback"](https://github.com/arul28/ade/commit/52a7149b2484de4af19db02b016dc35d670f2602) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34636735)</sub>

<!-- /greptile_comment -->