### PR TITLE
ADE-58: Orchestration claimTask: reject claims against terminal (done/failed) tasks

### DIFF
--- a/apps/desktop/src/main/services/orchestration/orchestrationService.test.ts
+++ b/apps/desktop/src/main/services/orchestration/orchestrationService.test.ts
@@ -1114,6 +1114,127 @@ describe("validation concerns gating", () => {
     await svc.dispose();
   });
 
+  it.each(["done", "failed"] as const)(
+    "rejects claims against %s tasks",
+    async (terminalStatus) => {
+      const svc = createOrchestrationService({ resolveLaneWorktree: () => lane });
+      const { manifest } = await svc.runCreate({
+        laneId: "L-1",
+        leadSessionId: "S-lead",
+        bundleRoot: lane,
+      });
+      const seeded = await svc.manifestPatch(
+        {
+          runId: manifest.runId,
+          ifMatchEtag: manifest.etag,
+          actorRole: "lead",
+          actorSessionId: "S-lead",
+          patches: [
+            {
+              op: "add",
+              path: "/agents/-",
+              value: {
+                sessionId: "S-worker",
+                role: "worker",
+                tag: "impl",
+                goalSummary: "implement",
+                status: "running",
+                spawnedAt: "now",
+              },
+            },
+            {
+              op: "add",
+              path: "/agents/-",
+              value: {
+                sessionId: "S-other-worker",
+                role: "worker",
+                tag: "other",
+                goalSummary: "try to claim terminal work",
+                status: "running",
+                spawnedAt: "now",
+              },
+            },
+            {
+              op: "add",
+              path: "/tasks/-",
+              value: {
+                id: "T-terminal",
+                phaseId: "developing",
+                title: "terminal task",
+                description: "",
+                status: "claimed",
+                validationGate: { required: false, stepIds: [] },
+                assigneeSessionId: "S-worker",
+                claimLeaseUntil: new Date(Date.now() + 60_000).toISOString(),
+              },
+            },
+          ],
+        },
+        manifest.bundlePath,
+      );
+      expect(seeded.ok).toBe(true);
+      if (!seeded.ok) {
+        throw new Error("failed to seed terminal task claim test");
+      }
+
+      const released = await svc.releaseTask(
+        {
+          runId: manifest.runId,
+          taskId: "T-terminal",
+          sessionId: "S-worker",
+          status: terminalStatus,
+        },
+        manifest.bundlePath,
+      );
+      const releasedTask = released.manifest.tasks.find(
+        (task) => task.id === "T-terminal",
+      );
+      expect(releasedTask?.status).toBe(terminalStatus);
+      expect(releasedTask?.claimLeaseUntil).toBeNull();
+
+      const claimed = await svc.claimTask(
+        {
+          runId: manifest.runId,
+          taskId: "T-terminal",
+          sessionId: "S-worker",
+          leaseMs: 30 * 60 * 1000,
+        },
+        manifest.bundlePath,
+      );
+      expect(claimed.ok).toBe(false);
+      if (claimed.ok) {
+        throw new Error("terminal task claim unexpectedly succeeded");
+      }
+      expect(claimed.reason).toContain(`terminal (${terminalStatus})`);
+      const taskAfterClaim = claimed.manifest.tasks.find(
+        (task) => task.id === "T-terminal",
+      );
+      expect(taskAfterClaim?.status).toBe(terminalStatus);
+      expect(taskAfterClaim?.claimLeaseUntil).toBeNull();
+
+      const otherClaim = await svc.claimTask(
+        {
+          runId: manifest.runId,
+          taskId: "T-terminal",
+          sessionId: "S-other-worker",
+          leaseMs: 30 * 60 * 1000,
+        },
+        manifest.bundlePath,
+      );
+      expect(otherClaim.ok).toBe(false);
+      if (otherClaim.ok) {
+        throw new Error("terminal task claim by other worker unexpectedly succeeded");
+      }
+      expect(otherClaim.reason).toContain(`terminal (${terminalStatus})`);
+      const taskAfterOtherClaim = otherClaim.manifest.tasks.find(
+        (task) => task.id === "T-terminal",
+      );
+      expect(taskAfterOtherClaim?.status).toBe(terminalStatus);
+      expect(taskAfterOtherClaim?.claimLeaseUntil).toBeNull();
+      await svc.dispose();
+    },
+  );
+
   it("lead cannot lower validationGate.required without override pair", async () => {
     const svc = createOrchestrationService({ resolveLaneWorktree: () => lane });
     const { manifest } = await svc.runCreate({

--- a/apps/desktop/src/main/services/orchestration/orchestrationService.ts
+++ b/apps/desktop/src/main/services/orchestration/orchestrationService.ts
@@ -1092,6 +1092,14 @@ export function createOrchestrationService(deps: OrchestrationServiceDeps) {
           etag: manifest.etag,
         };
       }
+      if (task.status === "done" || task.status === "failed") {
+        return {
+          ok: false,
+          reason: `task ${req.taskId} is terminal (${task.status}) and cannot be claimed`,
+          manifest,
+          etag: manifest.etag,
+        };
+      }
       const stillClaimed =
         task.claimLeaseUntil && new Date(task.claimLeaseUntil).getTime() > Date.now();
       if (


### PR DESCRIPTION
Refs ADE-58
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-58: Orchestration claimTask: reject claims against terminal (done/failed) tasks](https://linear.app/ade-linear/issue/ADE-58/orchestration-claimtask-reject-claims-against-terminal-donefailed) - referenced
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-58-orchestration-claimtask-reject-claims-against-terminal-done-failed-tasks num=420 -->
<p>
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://ade.app/logo-dark.svg">
    <img src="https://ade.app/logo-light.svg" height="18" align="left" alt="ADE">
  </picture>
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade.app/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-58-orchestration-claimtask-reject-claims-against-terminal-done-failed-tasks&amp;pr=420">ade-58-orchestration-claimtask-reject-claims-against-terminal-done-failed-tasks branch</a>
  &nbsp;·&nbsp; <a href="https://ade.app/open?type=pr&amp;repo=arul28%2FADE&amp;number=420">PR #420</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented claiming of tasks that are already in terminal states (done or failed). The system now rejects claim attempts on completed or failed tasks, ensuring task state integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a guard in `claimTask` to reject claim attempts on tasks that are already in a terminal state (`done` or `failed`), preventing re-assignment of completed work. A comprehensive parameterized test covers both terminal states and verifies rejection from both the original assignee and other workers.

- **`orchestrationService.ts`**: New guard inserted after the task-not-found check; returns `ok: false` with a descriptive reason string (`\"task X is terminal (done|failed) and cannot be claimed\"`) before any lease or assignee mutation is attempted.
- **`orchestrationService.test.ts`**: `it.each` test seeds a task, transitions it to the target terminal state via `releaseTask`, then verifies two separate `claimTask` calls are rejected with the expected reason and that the task's status and `claimLeaseUntil` remain unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the guard is minimal, correctly placed, and well-tested.

The change is a small, focused early-return that prevents state mutation on terminal tasks. It does not alter any existing code paths and is covered by a thorough parameterized test for both terminal states and both claimant types.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/orchestration/orchestrationService.ts | Adds a terminal-state guard (done/failed) in claimTask before the lease-conflict check; logic is correct and well-placed. |
| apps/desktop/src/main/services/orchestration/orchestrationService.test.ts | Parameterized test covers both terminal states and both same-worker and cross-worker claim attempts; releaseTask result is not guarded with ok check before proceeding. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[claimTask request] --> B{Session registered?}
    B -- No --> C[return ok:false\n'session not registered']
    B -- Yes --> D{Task exists?}
    D -- No --> E[return ok:false\n'task not found']
    D -- Yes --> F{Task status is\ndone or failed?}
    F -- Yes --> G[return ok:false\n'task is terminal']
    F -- No --> H{Claimed by another\nsession with active lease?}
    H -- Yes --> I[return ok:false\n'already claimed by X']
    H -- No --> J[Apply claim patches\nstatus=claimed, assignee, lease]
    J --> K[return ok:true]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Forchestration%2ForchestrationService.test.ts%3A1175-1181%0A**Missing%20%60ok%60%20guard%20on%20%60releaseTask%60%20result**%0A%0A%60releaseTask%60%20is%20called%20without%20checking%20whether%20it%20succeeded%20before%20asserting%20on%20its%20manifest.%20If%20%60releaseTask%60%20returns%20%60ok%3A%20false%60%20for%20any%20reason%2C%20the%20task%20remains%20%60claimed%60%2C%20the%20%60expect%28releasedTask%3F.status%29.toBe%28terminalStatus%29%60%20assertion%20fires%20a%20confusing%20mismatch%2C%20and%20subsequent%20%60claimTask%60%20calls%20may%20succeed%20%28for%20%60S-worker%60%2C%20which%20still%20holds%20the%20lease%29%20%E2%80%94%20producing%20a%20misleading%20failure%20rather%20than%20a%20fast%2C%20clear%20one.%20The%20seeding%20step%20above%20uses%20the%20same%20guard%20pattern%20%28%60if%20%28!seeded.ok%29%20throw%20new%20Error%28...%29%60%29%20and%20the%20same%20should%20be%20applied%20here.%0A%0A&repo=arul28%2Fade&pr=420&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/main/services/orchestration/orchestrationService.test.ts:1175-1181
**Missing `ok` guard on `releaseTask` result**

`releaseTask` is called without checking whether it succeeded before asserting on its manifest. If `releaseTask` returns `ok: false` for any reason, the task remains `claimed`, the `expect(releasedTask?.status).toBe(terminalStatus)` assertion fires a confusing mismatch, and subsequent `claimTask` calls may succeed (for `S-worker`, which still holds the lease) — producing a misleading failure rather than a fast, clear one. The seeding step above uses the same guard pattern (`if (!seeded.ok) throw new Error(...)`) and the same should be applied here.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix terminal orchestration task claims"](https://github.com/arul28/ade/commit/ecb24e9103d6b08a95dd81a8098423edbcbe3c5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34685931)</sub>

<!-- /greptile_comment -->