### PR TITLE
ADE-51: Guard agentChatList IPC handler against null agentChatService in runtime-backed mode

### DIFF
--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -5600,9 +5600,18 @@ export function registerIpc({
   });
 
   ipcMain.handle(IPC.agentChatList, async (_event, arg: AgentChatListArgs = {}): Promise<AgentChatSessionSummary[]> => {
-    const ctx = ensureAgentChatContext();
+    const ctx = getCtx();
+    const service = ctx.agentChatService;
+    if (!service || typeof (service as unknown as { listSessions?: unknown }).listSessions !== "function") {
+      return [];
+    }
     const laneId = typeof arg?.laneId === "string" ? arg.laneId.trim() : "";
-    return ctx.agentChatService.listSessions(laneId || undefined, { includeAutomation: Boolean(arg?.includeAutomation) });
+    return await (service as unknown as {
+      listSessions: (
+        laneId?: string,
+        options?: { includeAutomation?: boolean },
+      ) => Promise<AgentChatSessionSummary[]>;
+    }).listSessions(laneId || undefined, { includeAutomation: Boolean(arg?.includeAutomation) });
   });
 
   ipcMain.handle(IPC.agentChatGetSummary, async (_event, arg: AgentChatGetSummaryArgs): Promise<AgentChatSessionSummary | null> => {

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
@@ -840,6 +840,58 @@ describe("registerIpc sync bridge", () => {
     });
   });
 
+  it("returns an empty agent chat list when the service is unavailable", async () => {
+    registerIpc({
+      getCtx: () => ({
+        agentChatService: null,
+      }) as any,
+      getWindowSession: () => ({
+        windowId: 7,
+        project: { rootPath: "/repo", displayName: "Repo" } as any,
+        binding: localBinding("/repo"),
+      }),
+      switchProjectFromDialog: vi.fn(),
+      closeCurrentProject: vi.fn(),
+      closeProjectByPath: vi.fn(),
+      globalStatePath: "/tmp/ade-state.json",
+    });
+
+    await expect(
+      ipcHandlers.get(IPC.agentChatList)?.(
+        eventForSender(),
+        { laneId: " lane-1 ", includeAutomation: true },
+      ),
+    ).resolves.toEqual([]);
+  });
+
+  it("forwards agent chat list arguments when the service is available", async () => {
+    const sessions = [{ sessionId: "chat-1" }];
+    const listSessions = vi.fn(async () => sessions);
+    registerIpc({
+      getCtx: () => ({
+        agentChatService: { listSessions },
+      }) as any,
+      getWindowSession: () => ({
+        windowId: 7,
+        project: { rootPath: "/repo", displayName: "Repo" } as any,
+        binding: localBinding("/repo"),
+      }),
+      switchProjectFromDialog: vi.fn(),
+      closeCurrentProject: vi.fn(),
+      closeProjectByPath: vi.fn(),
+      globalStatePath: "/tmp/ade-state.json",
+    });
+
+    await expect(
+      ipcHandlers.get(IPC.agentChatList)?.(
+        eventForSender(),
+        { laneId: " lane-1 ", includeAutomation: true },
+      ),
+    ).resolves.toBe(sessions);
+
+    expect(listSessions).toHaveBeenCalledWith("lane-1", { includeAutomation: true });
+  });
+
   it("disposes a live terminal runtime before deleting the session", async () => {
     const terminalSession = {
       id: "terminal-1",


### PR DESCRIPTION
Fixes ADE-51
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-51: Guard agentChatList IPC handler against null agentChatService in runtime-backed mode](https://linear.app/ade-linear/issue/ADE-51/guard-agentchatlist-ipc-handler-against-null-agentchatservice-in) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-51-guard-agentchatlist-ipc-handler-against-null-agentchatservice-in-runtime-backed-mode num=427 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-51-guard-agentchatlist-ipc-handler-against-null-agentchatservice-in-runtime-backed-mode&amp;pr=427">ade-51-guard-agentchatlist-ipc-handler-against-null-agentchatservice-in-runtime-backed-mode branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=427">PR #427</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR guards the `agentChatList` IPC handler against a null `agentChatService` in runtime-backed mode, returning an empty array instead of throwing when the service is unavailable.

- Replaces `ensureAgentChatContext()` with `getCtx()` in the `agentChatList` handler and adds an explicit null + duck-type guard (`!service || typeof service.listSessions !== \"function\"`) that returns `[]` early.
- Adds two new tests in `runtimeBridge.test.ts` covering the null-service case and the happy path with argument forwarding.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to one handler and the new early-return path is well-tested.

The null guard and early return are correct and directly address the crash scenario. Both new tests exercise the changed code paths. The only nit is an unnecessary `as unknown as` cast that could be simplified without affecting behavior.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/ipc/registerIpc.ts | Replaces `ensureAgentChatContext()` with `getCtx()` in the `agentChatList` handler and adds a null + duck-type guard that returns `[]` when the service is unavailable; uses an unnecessary `as unknown as` cast for the subsequent call site. |
| apps/desktop/src/main/services/ipc/runtimeBridge.test.ts | Adds two focused tests: one verifying `[]` is returned when `agentChatService` is null, and one verifying the arguments are correctly forwarded when the service is available. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["IPC: agentChatList"] --> B["getCtx()"]
    B --> C{"service === null\nor !listSessions?"}
    C -- yes --> D["return []"]
    C -- no --> E["service.listSessions(laneId, options)"]
    E --> F["return AgentChatSessionSummary[]"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/desktop/src/main/services/ipc/registerIpc.ts`, line 671 ([link](https://github.com/arul28/ade/blob/649aa40935b529c74248747699c4754d2547118b/apps/desktop/src/main/services/ipc/registerIpc.ts#L671)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Type definition doesn't reflect nullable reality**

   `agentChatService` is typed as `ReturnType<typeof createAgentChatService>` (non-nullable), yet runtime null-checks appear at lines 6129, 8922, and now in this PR. Because the type doesn't include `| null`, TypeScript silently allows direct accesses like `ctx.agentChatService.getSessionSummary(...)` at line 5521 without a null guard — exactly the class of error ADE-51 was meant to fix. Marking the property as `ReturnType<typeof createAgentChatService> | null` would surface all unguarded call sites as compile-time errors.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/ipc/registerIpc.ts
   Line: 671

   Comment:
   **Type definition doesn't reflect nullable reality**

   `agentChatService` is typed as `ReturnType<typeof createAgentChatService>` (non-nullable), yet runtime null-checks appear at lines 6129, 8922, and now in this PR. Because the type doesn't include `| null`, TypeScript silently allows direct accesses like `ctx.agentChatService.getSessionSummary(...)` at line 5521 without a null guard — exactly the class of error ADE-51 was meant to fix. Marking the property as `ReturnType<typeof createAgentChatService> | null` would surface all unguarded call sites as compile-time errors.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fipc%2FregisterIpc.ts%0ALine%3A%20671%0A%0AComment%3A%0A**Type%20definition%20doesn't%20reflect%20nullable%20reality**%0A%0A%60agentChatService%60%20is%20typed%20as%20%60ReturnType%3Ctypeof%20createAgentChatService%3E%60%20%28non-nullable%29%2C%20yet%20runtime%20null-checks%20appear%20at%20lines%206129%2C%208922%2C%20and%20now%20in%20this%20PR.%20Because%20the%20type%20doesn't%20include%20%60%7C%20null%60%2C%20TypeScript%20silently%20allows%20direct%20accesses%20like%20%60ctx.agentChatService.getSessionSummary%28...%29%60%20at%20line%205521%20without%20a%20null%20guard%20%E2%80%94%20exactly%20the%20class%20of%20error%20ADE-51%20was%20meant%20to%20fix.%20Marking%20the%20property%20as%20%60ReturnType%3Ctypeof%20createAgentChatService%3E%20%7C%20null%60%20would%20surface%20all%20unguarded%20call%20sites%20as%20compile-time%20errors.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=427&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `apps/desktop/src/main/services/ipc/registerIpc.ts`, line 5519-5531 ([link](https://github.com/arul28/ade/blob/649aa40935b529c74248747699c4754d2547118b/apps/desktop/src/main/services/ipc/registerIpc.ts#L5519-L5531)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Adjacent handlers still call agentChatService without a null guard**

   `agentChatGetSummary` (line 5521), `agentChatCreate` (line 5526), and `agentChatSuggestLaneName` (line 5531) call `ctx.agentChatService` directly. If the renderer can invoke `agentChatList` before the service is ready (the scenario this PR fixes), it may also invoke these handlers under the same conditions — for example, if a cached `sessionId` triggers an auto-refresh of a session summary on startup. The same `return []` or `throw` guard added here would prevent silent crashes on those paths too.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/ipc/registerIpc.ts
   Line: 5519-5531

   Comment:
   **Adjacent handlers still call agentChatService without a null guard**

   `agentChatGetSummary` (line 5521), `agentChatCreate` (line 5526), and `agentChatSuggestLaneName` (line 5531) call `ctx.agentChatService` directly. If the renderer can invoke `agentChatList` before the service is ready (the scenario this PR fixes), it may also invoke these handlers under the same conditions — for example, if a cached `sessionId` triggers an auto-refresh of a session summary on startup. The same `return []` or `throw` guard added here would prevent silent crashes on those paths too.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fipc%2FregisterIpc.ts%0ALine%3A%205519-5531%0A%0AComment%3A%0A**Adjacent%20handlers%20still%20call%20agentChatService%20without%20a%20null%20guard**%0A%0A%60agentChatGetSummary%60%20%28line%205521%29%2C%20%60agentChatCreate%60%20%28line%205526%29%2C%20and%20%60agentChatSuggestLaneName%60%20%28line%205531%29%20call%20%60ctx.agentChatService%60%20directly.%20If%20the%20renderer%20can%20invoke%20%60agentChatList%60%20before%20the%20service%20is%20ready%20%28the%20scenario%20this%20PR%20fixes%29%2C%20it%20may%20also%20invoke%20these%20handlers%20under%20the%20same%20conditions%20%E2%80%94%20for%20example%2C%20if%20a%20cached%20%60sessionId%60%20triggers%20an%20auto-refresh%20of%20a%20session%20summary%20on%20startup.%20The%20same%20%60return%20%5B%5D%60%20or%20%60throw%60%20guard%20added%20here%20would%20prevent%20silent%20crashes%20on%20those%20paths%20too.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=427&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fipc%2FregisterIpc.ts%3A5609-5614%0AUnnecessary%20double-cast%20bypasses%20TypeScript's%20type%20safety.%20Before%20this%20PR%2C%20the%20call%20site%20used%20%60ctx.agentChatService.listSessions%28...%29%60%20directly%20%28after%20%60ensureAgentChatContext%60%20narrowed%20the%20type%29.%20After%20the%20%60!service%60%20null%20guard%2C%20TypeScript%20narrows%20%60service%60%20to%20%60ReturnType%3Ctypeof%20createAgentChatService%3E%60%2C%20which%20already%20declares%20%60listSessions%60%20%E2%80%94%20so%20the%20%60as%20unknown%20as%20%7B%20listSessions%3A%20...%20%7D%60%20cast%20is%20redundant%20and%20detaches%20this%20call%20site%20from%20the%20canonical%20type.%20If%20%60listSessions%60's%20signature%20changes%2C%20the%20compiler%20won't%20catch%20the%20mismatch%20here.%0A%0A%60%60%60suggestion%0A%20%20%20%20return%20await%20service.listSessions%28laneId%20%7C%7C%20undefined%2C%20%7B%20includeAutomation%3A%20Boolean%28arg%3F.includeAutomation%29%20%7D%29%3B%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=427&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/main/services/ipc/registerIpc.ts:5609-5614
Unnecessary double-cast bypasses TypeScript's type safety. Before this PR, the call site used `ctx.agentChatService.listSessions(...)` directly (after `ensureAgentChatContext` narrowed the type). After the `!service` null guard, TypeScript narrows `service` to `ReturnType<typeof createAgentChatService>`, which already declares `listSessions` — so the `as unknown as { listSessions: ... }` cast is redundant and detaches this call site from the canonical type. If `listSessions`'s signature changes, the compiler won't catch the mismatch here.

```suggestion
    return await service.listSessions(laneId || undefined, { includeAutomation: Boolean(arg?.includeAutomation) });
```


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: guard agent chat list IPC service"](https://github.com/arul28/ade/commit/3579e0de0b1fa441503bdca5cd141ee42f38fbe1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34695359)</sub>

<!-- /greptile_comment -->