### PR TITLE
ADE-53: Orchestration watcher: separate debounce timers per file (manifest change dropped when plan changes too)

### DIFF
--- a/apps/desktop/src/main/services/orchestration/orchestrationService.test.ts
+++ b/apps/desktop/src/main/services/orchestration/orchestrationService.test.ts
@@ -1536,4 +1536,62 @@ describe("orchestration watcher resilience", () => {
     off();
     await svc.dispose();
   });
+
+  it("reloads manifest and plan when both external files change inside the debounce window", async () => {
+    const creator = createOrchestrationService({ resolveLaneWorktree: () => lane });
+    const { manifest } = await creator.runCreate({
+      laneId: "L-1",
+      leadSessionId: "S-lead",
+      bundleRoot: lane,
+      title: "Initial",
+    });
+    await creator.dispose();
+
+    const svc = createOrchestrationService({ resolveLaneWorktree: () => lane });
+    const events: Array<{
+      kind?: string;
+      manifest?: { title?: string };
+      planMd?: string;
+    }> = [];
+    const off = svc.on("event", (payload) => events.push(payload));
+    try {
+      await svc.subscribe(manifest.runId, manifest.bundlePath);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      const manifestPath = path.join(manifest.bundlePath, "manifest.json");
+      const planPath = path.join(manifest.bundlePath, "plan.md");
+      const currentManifest = JSON.parse(
+        await fsp.readFile(manifestPath, "utf-8"),
+      ) as typeof manifest;
+      const externalManifest = {
+        ...currentManifest,
+        title: "Externally updated manifest",
+        serverGeneration: currentManifest.serverGeneration + 1,
+        etag: `g${currentManifest.serverGeneration + 1}-external`,
+      };
+      const externalPlan = "# Externally updated plan\n\nBoth files changed in one batch.\n";
+
+      await Promise.all([
+        fsp.writeFile(manifestPath, JSON.stringify(externalManifest, null, 2)),
+        fsp.writeFile(planPath, externalPlan),
+      ]);
+
+      await vi.waitFor(() => {
+        expect(events.some((event) =>
+          event.kind === "manifest"
+          && event.manifest?.title === externalManifest.title,
+        )).toBe(true);
+        expect(events.some((event) =>
+          event.kind === "plan" && event.planMd === externalPlan,
+        )).toBe(true);
+      }, { timeout: 2_000 });
+
+      const bundle = await svc.bundleRead(manifest.runId, manifest.bundlePath);
+      expect(bundle.manifest.title).toBe(externalManifest.title);
+      expect(bundle.planMd).toBe(externalPlan);
+    } finally {
+      off();
+      await svc.dispose();
+    }
+  });
 });

--- a/apps/desktop/src/main/services/orchestration/orchestrationService.ts
+++ b/apps/desktop/src/main/services/orchestration/orchestrationService.ts
@@ -82,6 +82,8 @@ const RUN_LIST_DEFAULT_LIMIT = 100;
 const RUN_LIST_MAX_LIMIT = 250;
 const RUN_SUSPENDED_MESSAGE =
   "orchestration run is suspended (bundle changed externally); re-open the run or restore the correct branch";
+type WatcherFileKind = "manifest" | "plan";
+type WatcherDebounceTimers = Partial<Record<WatcherFileKind, NodeJS.Timeout>>;
 
 class OrchestrationRunSuspendedError extends Error {
   constructor() {
@@ -103,7 +105,7 @@ type RunRuntime = {
   watcher: FSWatcher | null;
   refCount: number;
   recentSelfWriteUntil: number;
-  watcherDebounceTimer: NodeJS.Timeout | null;
+  watcherDebounceTimers: WatcherDebounceTimers;
   watcherIdleTimer: NodeJS.Timeout | null;
   suspended: boolean;
 };
@@ -443,10 +445,7 @@ export function createOrchestrationService(deps: OrchestrationServiceDeps) {
       void runtime.watcher.close().catch(() => undefined);
       runtime.watcher = null;
     }
-    if (runtime.watcherDebounceTimer) {
-      clearTimeout(runtime.watcherDebounceTimer);
-      runtime.watcherDebounceTimer = null;
-    }
+    clearWatcherDebounceTimers(runtime);
     if (runtime.watcherIdleTimer) {
       clearTimeout(runtime.watcherIdleTimer);
       runtime.watcherIdleTimer = null;
@@ -473,7 +472,7 @@ export function createOrchestrationService(deps: OrchestrationServiceDeps) {
         watcher: null,
         refCount: 0,
         recentSelfWriteUntil: 0,
-        watcherDebounceTimer: null,
+        watcherDebounceTimers: {},
         watcherIdleTimer: null,
         suspended: false,
       };
@@ -545,6 +544,13 @@ export function createOrchestrationService(deps: OrchestrationServiceDeps) {
     runtime.recentSelfWriteUntil = Date.now() + SELF_WRITE_WINDOW_MS;
   }
 
+  function clearWatcherDebounceTimers(runtime: RunRuntime): void {
+    for (const timer of Object.values(runtime.watcherDebounceTimers)) {
+      if (timer) clearTimeout(timer);
+    }
+    runtime.watcherDebounceTimers = {};
+  }
+
   async function startWatcher(runtime: RunRuntime): Promise<void> {
     if (runtime.watcherIdleTimer) {
       clearTimeout(runtime.watcherIdleTimer);
@@ -564,12 +570,13 @@ export function createOrchestrationService(deps: OrchestrationServiceDeps) {
       },
     );
     runtime.watcher = watcher;
-    const debouncedReload = (kind: "manifest" | "plan"): void => {
-      if (runtime.watcherDebounceTimer) {
-        clearTimeout(runtime.watcherDebounceTimer);
+    const debouncedReload = (kind: WatcherFileKind): void => {
+      const existingTimer = runtime.watcherDebounceTimers[kind];
+      if (existingTimer) {
+        clearTimeout(existingTimer);
       }
-      runtime.watcherDebounceTimer = setTimeout(() => {
-        runtime.watcherDebounceTimer = null;
+      runtime.watcherDebounceTimers[kind] = setTimeout(() => {
+        delete runtime.watcherDebounceTimers[kind];
         void runtime.mutex.run(async () => {
           if (Date.now() < runtime.recentSelfWriteUntil) {
             return; // suppress self-emitted events
@@ -1513,10 +1520,7 @@ export function createOrchestrationService(deps: OrchestrationServiceDeps) {
     if (!runtime) return;
     runtime.refCount = Math.max(0, runtime.refCount - 1);
     if (runtime.refCount === 0) {
-      if (runtime.watcherDebounceTimer) {
-        clearTimeout(runtime.watcherDebounceTimer);
-        runtime.watcherDebounceTimer = null;
-      }
+      clearWatcherDebounceTimers(runtime);
       if (runtime.watcher) {
         if (runtime.watcherIdleTimer) clearTimeout(runtime.watcherIdleTimer);
         runtime.watcherIdleTimer = setTimeout(() => {
@@ -1538,7 +1542,7 @@ export function createOrchestrationService(deps: OrchestrationServiceDeps) {
   async function dispose(): Promise<void> {
     for (const runtime of runs.values()) {
       if (runtime.watcher) await runtime.watcher.close();
-      if (runtime.watcherDebounceTimer) clearTimeout(runtime.watcherDebounceTimer);
+      clearWatcherDebounceTimers(runtime);
       if (runtime.watcherIdleTimer) clearTimeout(runtime.watcherIdleTimer);
     }
     runs.clear();


### PR DESCRIPTION
Fixes ADE-53
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-53: Orchestration watcher: separate debounce timers per file (manifest change dropped when plan changes too)](https://linear.app/ade-linear/issue/ADE-53/orchestration-watcher-separate-debounce-timers-per-file-manifest) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-53-orchestration-watcher-separate-debounce-timers-per-file-manifest-change-dropped-when-plan-changes-too num=428 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-53-orchestration-watcher-separate-debounce-timers-per-file-manifest-change-dropped-when-plan-changes-too&amp;pr=428">ade-53-orchestration-watcher-separate-debounce-timers-per-file-manifest-change-dropped-when-plan-changes-too branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=428">PR #428</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where a manifest change event was silently dropped whenever both `manifest.json` and `plan.md` changed within the same debounce window. The root cause was a single shared `watcherDebounceTimer` whose `clearTimeout` call on the first file event cancelled the pending reload for the second, so only one file reload ever fired per debounce cycle.

- **Core fix**: `watcherDebounceTimer: NodeJS.Timeout | null` is replaced by `watcherDebounceTimers: Partial<Record<WatcherFileKind, NodeJS.Timeout>>`, giving each watched file its own independent timer. A new `clearWatcherDebounceTimers` helper consolidates cleanup and is used in all three call sites (soft-unsubscribe, hard `disposeRuntime`, and `dispose`).
- **Test coverage**: A new integration test writes both files concurrently via `Promise.all`, then asserts that both a `\"manifest\"` event (with the updated title) and a `\"plan\"` event (with the updated content) are emitted, closing the regression gap.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the debounce timer data structure and all three cleanup call sites are updated consistently.

The fix is minimal and mechanical: a single shared timer becomes a two-entry map, and a small helper centralises the cleanup logic. The mutex-based serialisation of the reload callbacks is unchanged, so there is no new concurrency exposure. The new integration test exercises the exact failure scenario (both files changed inside one debounce window) and confirms both events are emitted. No pre-existing paths are altered beyond the timer bookkeeping.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/orchestration/orchestrationService.ts | Replaces the single shared debounce timer with per-file timers (manifest/plan) using a Partial<Record<WatcherFileKind, NodeJS.Timeout>> map; all call sites updated correctly via the new clearWatcherDebounceTimers helper. |
| apps/desktop/src/main/services/orchestration/orchestrationService.test.ts | Adds a regression test that writes both manifest.json and plan.md concurrently and asserts both events are emitted independently within the debounce window. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant FS as FileSystem
    participant W as chokidar Watcher
    participant D as debouncedReload()
    participant T as watcherDebounceTimers
    participant M as mutex.run()
    participant H as handleExternalChange()

    FS->>W: change(manifest.json)
    W->>D: debouncedReload("manifest")
    D->>T: "set timers["manifest"] = setTimeout(50ms)"

    FS->>W: change(plan.md)  [within debounce window]
    W->>D: debouncedReload("plan")
    D->>T: "set timers["plan"] = setTimeout(50ms)"

    Note over T: Each file has its own timer — neither cancels the other

    T-->>M: timers["manifest"] fires → mutex.run()
    T-->>M: timers["plan"] fires → mutex.run() [queued]

    M->>H: handleExternalChange(runtime, "manifest")
    H-->>M: emits "manifest" event

    M->>H: handleExternalChange(runtime, "plan")
    H-->>M: emits "plan" event
```

<sub>Reviews (1): Last reviewed commit: ["Fix orchestration watcher debounce by fi..."](https://github.com/arul28/ade/commit/66e1bd3d9ebd726d6a22b272324dc10f200d4176) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34695364)</sub>

<!-- /greptile_comment -->