### PR TITLE
ADE-54: Runtime ALTER wrapper leaves CRR table mid-alter on failure (missing commit_alter in catch)

### DIFF
--- a/apps/desktop/src/main/services/state/kvDb.test.ts
+++ b/apps/desktop/src/main/services/state/kvDb.test.ts
@@ -1,12 +1,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { createRequire } from "node:module";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { openKvDb } from "./kvDb";
 import { isCrsqliteAvailable } from "./crsqliteExtension";
-
-const require = createRequire(path.join(process.cwd(), "ade-runtime.cjs"));
 
 function createLogger() {
   return {
@@ -388,5 +385,47 @@ describe.skipIf(!isCrsqliteAvailable())("openKvDb CRR repair", () => {
         "select 1 as present from sqlite_master where type = 'index' and name = 'idx_terminal_sessions_started_at' limit 1",
       )?.present,
     ).toBe(1);
+  });
+
+  it("keeps CRR change capture enabled after failed runtime ALTER TABLE", async () => {
+    const projectRoot = makeProjectRoot("ade-kvdb-crr-alter-failure-");
+    const dbPath = path.join(projectRoot, ".ade", "ade.db");
+    const db = await openKvDb(dbPath, createLogger() as any);
+    activeDisposers.push(async () => db.close());
+
+    expect(
+      db.get<{ present: number }>(
+        "select 1 as present from sqlite_master where type = 'table' and name = 'automation_runs__crsql_clock' limit 1",
+      )?.present,
+    ).toBe(1);
+
+    const alterSql = "alter table automation_runs add column ade_crr_alter_failure_probe text";
+    db.run(alterSql);
+    expect(() => db.run(alterSql)).toThrow();
+
+    insertProjectGraph(db);
+    const countAutomationRunChanges = () =>
+      db.get<{ count: number }>("select count(1) as count from crsql_changes where [table] = ?", ["automation_runs"])
+        ?.count ?? 0;
+    const changesBeforeInsert = countAutomationRunChanges();
+    db.run(
+      `insert into automation_runs(
+         id, project_id, automation_id, trigger_type, started_at, status, actions_total
+       ) values (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        "run-probe",
+        "project-1",
+        "automation-probe",
+        "manual",
+        "2026-05-26T00:00:00.000Z",
+        "queued",
+        0,
+      ],
+    );
+
+    expect(
+      db.get<{ id: string }>("select id from automation_runs where id = ? limit 1", ["run-probe"])?.id,
+    ).toBe("run-probe");
+    expect(countAutomationRunChanges()).toBeGreaterThan(changesBeforeInsert);
   });
 });

--- a/apps/desktop/src/main/services/state/kvDb.ts
+++ b/apps/desktop/src/main/services/state/kvDb.ts
@@ -3062,6 +3062,9 @@ export async function openKvDb(dbPath: string, logger: Logger): Promise<AdeDb> {
       try {
         runStatement(db, sql, params);
       } catch (error) {
+        // Commit the alter even on failure so the CRR state stays consistent,
+        // then re-throw so callers (e.g. safeAlter) can handle duplicate columns.
+        getRow(db, "select crsql_commit_alter(?) as ok", [alterTable]);
         throw error;
       }
       getRow(db, "select crsql_commit_alter(?) as ok", [alterTable]);


### PR DESCRIPTION
Fixes ADE-54
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-54: Runtime ALTER wrapper leaves CRR table mid-alter on failure (missing commit_alter in catch)](https://linear.app/ade-linear/issue/ADE-54/runtime-alter-wrapper-leaves-crr-table-mid-alter-on-failure-missing) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-54-runtime-alter-wrapper-leaves-crr-table-mid-alter-on-failure-missing-commit-alter-in-catch num=429 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-54-runtime-alter-wrapper-leaves-crr-table-mid-alter-on-failure-missing-commit-alter-in-catch&amp;pr=429">ade-54-runtime-alter-wrapper-leaves-crr-table-mid-alter-on-failure-missing-commit-alter-in-catch branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=429">PR #429</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the CRR (change-replication record) table being left in a mid-alter state when the runtime `run` wrapper's inner `ALTER TABLE` statement fails — the same `crsql_begin_alter` / `crsql_commit_alter` bracket that was already present in `makeMigrateDb` is now applied consistently in the public `run` method.

- **`kvDb.ts`**: Inserts a `crsql_commit_alter` call inside the `catch` block of the `run` wrapper (lines 3065-3067), mirroring the identical pattern already at line 2944 in `makeMigrateDb`, so any failure (e.g. duplicate-column error) always closes the open alter bracket before re-throwing.
- **`kvDb.test.ts`**: Adds an integration test that deliberately triggers a duplicate-column failure via `db.run`, then asserts that `crsql_changes` still records subsequent inserts into `automation_runs`; also removes the now-unused `createRequire` and `vi` imports.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the one-line catch-block addition directly closes an open `crsql_begin_alter` bracket on failure, and the integration test confirms CRR change tracking survives a failed ALTER.

The change is minimal and surgical: a single `crsql_commit_alter` call is inserted into an existing catch block, mirroring the identical pattern that already existed in `makeMigrateDb`. The accompanying integration test exercises the exact failure path (duplicate-column ALTER) and verifies end-to-end that `crsql_changes` still captures subsequent writes. No new logic is introduced and no previously-working paths are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/state/kvDb.ts | Adds `crsql_commit_alter` call inside the catch block of the runtime `run` wrapper so a failed ALTER TABLE (e.g. duplicate column) always exits the CRR begin/commit bracket, matching the identical pattern already present in `makeMigrateDb`. |
| apps/desktop/src/main/services/state/kvDb.test.ts | New integration test triggers a duplicate-column ALTER failure at runtime, then verifies the CRR clock table still tracks inserts; also removes unused `createRequire` and `vi` imports. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant run
    participant crsqlite

    Caller->>run: db.run(alterSql)
    run->>crsqlite: crsql_begin_alter(table)
    run->>run: runStatement(sql) — throws
    Note over run: catch(error)
    run->>crsqlite: crsql_commit_alter(table) ← NEW
    run-->>Caller: re-throw original error

    Note over Caller,crsqlite: Happy path (no error)
    Caller->>run: db.run(alterSql)
    run->>crsqlite: crsql_begin_alter(table)
    run->>run: runStatement(sql) — ok
    run->>crsqlite: crsql_commit_alter(table)
    run-->>Caller: return
```

<sub>Reviews (2): Last reviewed commit: ["fix(kvDb): commit CRR alter after runtim..."](https://github.com/arul28/ade/commit/0d3f64c92de02fd83425c2f553b1563c433c0854) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34695400)</sub>

<!-- /greptile_comment -->