### PR TITLE
ADE-56: Guard agentChatGetEventHistory IPC handler against null agentChatService in runtime-backed mode

### DIFF
--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -5859,9 +5859,16 @@ export function registerIpc({
     _event,
     arg: { sessionId?: string; maxEvents?: number },
   ): Promise<AgentChatEventHistorySnapshot> => {
-    const ctx = ensureAgentChatContext();
+    const ctx = getCtx();
     const sessionId = typeof arg?.sessionId === "string" ? arg.sessionId.trim() : "";
     if (!sessionId) return { sessionId: "", events: [], truncated: false, sessionFound: false };
+    const service = ctx.agentChatService;
+    if (
+      !service ||
+      typeof (service as unknown as { getChatEventHistory?: unknown }).getChatEventHistory !== "function"
+    ) {
+      return { sessionId, events: [], truncated: false, sessionFound: false };
+    }
     // Only forward maxEvents when it is a finite positive number; the service
     // layer applies its own clamp but guarding here avoids ambiguous NaN/0
     // inputs from untrusted renderer IPC.
@@ -5870,7 +5877,7 @@ export function registerIpc({
       rawMaxEvents != null && Number.isFinite(rawMaxEvents) && rawMaxEvents > 0
         ? rawMaxEvents
         : undefined;
-    return ctx.agentChatService.getChatEventHistory(sessionId, maxEvents != null ? { maxEvents } : undefined);
+    return service.getChatEventHistory(sessionId, maxEvents != null ? { maxEvents } : undefined);
   });
 
   ipcMain.handle(IPC.agentChatReadTranscript, async (

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
@@ -892,6 +892,99 @@ describe("registerIpc sync bridge", () => {
     expect(listSessions).toHaveBeenCalledWith("lane-1", { includeAutomation: true });
   });
 
+  it("returns an empty chat event history when the agent chat service is unavailable", async () => {
+    registerIpc({
+      getCtx: () => ({
+        agentChatService: null,
+      }) as any,
+      getWindowSession: () => ({
+        windowId: 7,
+        project: { rootPath: "/repo", displayName: "Repo" } as any,
+        binding: localBinding("/repo"),
+      }),
+      switchProjectFromDialog: vi.fn(),
+      closeCurrentProject: vi.fn(),
+      closeProjectByPath: vi.fn(),
+      globalStatePath: "/tmp/ade-state.json",
+    });
+
+    await expect(
+      ipcHandlers.get(IPC.agentChatGetEventHistory)?.(
+        eventForSender(),
+        { sessionId: " chat-1 ", maxEvents: 10 },
+      ),
+    ).resolves.toEqual({
+      sessionId: "chat-1",
+      events: [],
+      truncated: false,
+      sessionFound: false,
+    });
+  });
+
+  it("returns an empty chat event history when the agent chat service lacks event history support", async () => {
+    registerIpc({
+      getCtx: () => ({
+        agentChatService: {},
+      }) as any,
+      getWindowSession: () => ({
+        windowId: 7,
+        project: { rootPath: "/repo", displayName: "Repo" } as any,
+        binding: localBinding("/repo"),
+      }),
+      switchProjectFromDialog: vi.fn(),
+      closeCurrentProject: vi.fn(),
+      closeProjectByPath: vi.fn(),
+      globalStatePath: "/tmp/ade-state.json",
+    });
+
+    await expect(
+      ipcHandlers.get(IPC.agentChatGetEventHistory)?.(
+        eventForSender(),
+        { sessionId: " chat-1 ", maxEvents: 10 },
+      ),
+    ).resolves.toEqual({
+      sessionId: "chat-1",
+      events: [],
+      truncated: false,
+      sessionFound: false,
+    });
+  });
+
+  it("forwards chat event history requests when the agent chat service is available", async () => {
+    const snapshot = {
+      sessionId: "chat-1",
+      events: [],
+      truncated: false,
+      sessionFound: true,
+    };
+    const getChatEventHistory = vi.fn(() => snapshot);
+    registerIpc({
+      getCtx: () => ({
+        agentChatService: {
+          getChatEventHistory,
+        },
+      }) as any,
+      getWindowSession: () => ({
+        windowId: 7,
+        project: { rootPath: "/repo", displayName: "Repo" } as any,
+        binding: localBinding("/repo"),
+      }),
+      switchProjectFromDialog: vi.fn(),
+      closeCurrentProject: vi.fn(),
+      closeProjectByPath: vi.fn(),
+      globalStatePath: "/tmp/ade-state.json",
+    });
+
+    await expect(
+      ipcHandlers.get(IPC.agentChatGetEventHistory)?.(
+        eventForSender(),
+        { sessionId: " chat-1 ", maxEvents: 25 },
+      ),
+    ).resolves.toBe(snapshot);
+
+    expect(getChatEventHistory).toHaveBeenCalledWith("chat-1", { maxEvents: 25 });
+  });
+
   it("disposes a live terminal runtime before deleting the session", async () => {
     const terminalSession = {
       id: "terminal-1",


### PR DESCRIPTION
Fixes ADE-56
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-56: Guard agentChatGetEventHistory IPC handler against null agentChatService in runtime-backed mode](https://linear.app/ade-linear/issue/ADE-56/guard-agentchatgeteventhistory-ipc-handler-against-null) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-56-guard-agentchatgeteventhistory-ipc-handler-against-null-agentchatservice-in-runtime-backed-mode num=431 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-56-guard-agentchatgeteventhistory-ipc-handler-against-null-agentchatservice-in-runtime-backed-mode&amp;pr=431">ade-56-guard-agentchatgeteventhistory-ipc-handler-against-null-agentchatservice-in-runtime-backed-mode branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=431">PR #431</a>
</p>
<!-- /ade:link -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust chat event history handling: when the chat service or its history method is unavailable, the app now returns a safe empty history snapshot instead of failing; requests also normalize session IDs and only forward valid maxEvents.

* **Tests**
  * Added unit tests covering missing service, missing history support, and successful history retrieval scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Guards the `agentChatGetEventHistory` IPC handler against a null `agentChatService`, which occurs in runtime-backed mode where the service isn't instantiated. Instead of calling `ensureAgentChatContext()` (which throws), the handler now calls `getCtx()` directly and returns an empty history snapshot when the service is absent or lacks the method.

- **`registerIpc.ts`**: Replaces `ensureAgentChatContext()` with `getCtx()` + a two-condition guard (`!service || typeof service.getChatEventHistory !== "function"`), consistent with the existing pattern in `agentChatReadTranscript`.
- **`runtimeBridge.test.ts`**: Adds tests for null service, service missing the method (duck-type branch), and the successful forwarding path — full branch coverage for the new guard.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change adds a well-tested null guard that prevents a crash in runtime-backed mode and is consistent with the existing pattern used by the adjacent `agentChatReadTranscript` handler.

The guard logic is straightforward, the change is isolated to a single handler, all three new code paths have direct unit-test coverage, and the implementation mirrors an existing pattern in the same file.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/ipc/registerIpc.ts | Switches agentChatGetEventHistory from ensureAgentChatContext() (throws on null) to getCtx() + explicit null/duck-type guard, returning an empty snapshot instead of throwing when agentChatService is unavailable. |
| apps/desktop/src/main/services/ipc/runtimeBridge.test.ts | Adds three unit tests covering: null service, service without getChatEventHistory (duck-type branch), and happy path — fully covering all new guard branches. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[IPC: agentChatGetEventHistory] --> B[getCtx]
    B --> C{sessionId valid?}
    C -- No --> D[return empty snapshot\nsessionId: '']
    C -- Yes --> E{service present AND\ngetChatEventHistory is function?}
    E -- No --> F[return empty snapshot\nsessionId: trimmed]
    E -- Yes --> G{maxEvents valid\nfinite positive number?}
    G -- No --> H[maxEvents = undefined]
    G -- Yes --> I[maxEvents = rawMaxEvents]
    H --> J[service.getChatEventHistory\nsessionId, undefined]
    I --> K[service.getChatEventHistory\nsessionId, maxEvents]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/main/services/ipc/registerIpc.ts`, line 671 ([link](https://github.com/arul28/ade/blob/a17fbe9c5ebc1207f6188e3df48119c77bc2e8e3/apps/desktop/src/main/services/ipc/registerIpc.ts#L671)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`AppContext` type doesn't reflect nullable `agentChatService`**

   `main.ts` explicitly sets `agentChatService: null` for the runtime-backed context (line 4304), so the field is null at runtime in that mode. However, `AppContext` still declares it as `ReturnType<typeof createAgentChatService>` — non-optional, non-nullable. As a result, TypeScript won't flag any future call sites that access the service without a null guard, meaning the pattern this PR protects against can silently recur. Updating the type to `ReturnType<typeof createAgentChatService> | null` (matching the treatment of other nullable services like `devToolsService`) would make the type system enforce the guard everywhere.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/ipc/registerIpc.ts
   Line: 671

   Comment:
   **`AppContext` type doesn't reflect nullable `agentChatService`**

   `main.ts` explicitly sets `agentChatService: null` for the runtime-backed context (line 4304), so the field is null at runtime in that mode. However, `AppContext` still declares it as `ReturnType<typeof createAgentChatService>` — non-optional, non-nullable. As a result, TypeScript won't flag any future call sites that access the service without a null guard, meaning the pattern this PR protects against can silently recur. Updating the type to `ReturnType<typeof createAgentChatService> | null` (matching the treatment of other nullable services like `devToolsService`) would make the type system enforce the guard everywhere.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fipc%2FregisterIpc.ts%0ALine%3A%20671%0A%0AComment%3A%0A**%60AppContext%60%20type%20doesn't%20reflect%20nullable%20%60agentChatService%60**%0A%0A%60main.ts%60%20explicitly%20sets%20%60agentChatService%3A%20null%60%20for%20the%20runtime-backed%20context%20%28line%204304%29%2C%20so%20the%20field%20is%20null%20at%20runtime%20in%20that%20mode.%20However%2C%20%60AppContext%60%20still%20declares%20it%20as%20%60ReturnType%3Ctypeof%20createAgentChatService%3E%60%20%E2%80%94%20non-optional%2C%20non-nullable.%20As%20a%20result%2C%20TypeScript%20won't%20flag%20any%20future%20call%20sites%20that%20access%20the%20service%20without%20a%20null%20guard%2C%20meaning%20the%20pattern%20this%20PR%20protects%20against%20can%20silently%20recur.%20Updating%20the%20type%20to%20%60ReturnType%3Ctypeof%20createAgentChatService%3E%20%7C%20null%60%20%28matching%20the%20treatment%20of%20other%20nullable%20services%20like%20%60devToolsService%60%29%20would%20make%20the%20type%20system%20enforce%20the%20guard%20everywhere.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=431&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix: guard chat event history IPC servic..."](https://github.com/arul28/ade/commit/97252642764240a1cc9e5c6271af8105cfed6762) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34698207)</sub>

<!-- /greptile_comment -->