### PR TITLE
ADE-49: applyChanges rejects composite-PK CRR table changes, causing a permanent sync-wedge reconnect loop

### DIFF
--- a/apps/desktop/src/main/services/state/kvDb.sync.test.ts
+++ b/apps/desktop/src/main/services/state/kvDb.sync.test.ts
@@ -170,6 +170,70 @@ describe.skipIf(!isCrsqliteAvailable())("kvDb sync foundation", () => {
     db2.close();
   });
 
+  it("applies CRDT changes for composite primary-key tables", async () => {
+    const db1 = await openKvDb(makeDbPath("ade-kvdb-sync-composite-pk-a-"), createLogger() as any);
+    const db2 = await openKvDb(makeDbPath("ade-kvdb-sync-composite-pk-b-"), createLogger() as any);
+    const now = "2026-03-15T00:00:00.000Z";
+
+    db1.run(
+      `insert into projects(id, root_path, display_name, default_base_ref, created_at, last_opened_at)
+       values (?, ?, ?, ?, ?, ?)`,
+      ["project-composite", "/repo/composite", "Composite", "main", now, now],
+    );
+    db1.run(
+      `insert into lanes(
+        id, project_id, name, description, lane_type, base_ref, branch_ref, worktree_path, attached_root_path,
+        is_edit_protected, parent_lane_id, color, icon, tags_json, folder, status, created_at, archived_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        "lane-composite",
+        "project-composite",
+        "Composite Lane",
+        null,
+        "worktree",
+        "main",
+        "feature/composite",
+        "/repo/composite/.ade/worktrees/lane-composite",
+        null,
+        0,
+        null,
+        null,
+        null,
+        null,
+        null,
+        "active",
+        now,
+        null,
+      ],
+    );
+
+    const baselineChanges = db1.sync.exportChangesSince(0);
+    db2.sync.applyChanges(baselineChanges);
+
+    const versionBeforeRuntime = db1.sync.getDbVersion();
+    db1.run(
+      `insert into process_runtime(project_id, lane_id, process_key, status, readiness, updated_at)
+       values (?, ?, ?, ?, ?, ?)`,
+      ["project-composite", "lane-composite", "dev", "running", "ready", "2026-03-15T00:01:00.000Z"],
+    );
+
+    const runtimeChanges = db1.sync.exportChangesSince(versionBeforeRuntime);
+    expect(runtimeChanges.some((change) => change.table === "process_runtime")).toBe(true);
+
+    const result = db2.sync.applyChanges(runtimeChanges);
+    expect(result.appliedCount).toBe(runtimeChanges.length);
+    expect(result.touchedTables).toContain("process_runtime");
+    expect(
+      db2.get<{ status: string }>(
+        "select status from process_runtime where project_id = ? and lane_id = ? and process_key = ?",
+        ["project-composite", "lane-composite", "dev"],
+      )?.status,
+    ).toBe("running");
+
+    db1.close();
+    db2.close();
+  });
+
   it("repairs a legacy projects unique constraint before CRR marking", async () => {
     const dbPath = makeDbPath("ade-kvdb-sync-projects-legacy-");
     const { DatabaseSync } = require("node:sqlite") as { DatabaseSync: new (path: string) => { exec: (sql: string) => void; close: () => void } };

--- a/apps/desktop/src/main/services/state/kvDb.ts
+++ b/apps/desktop/src/main/services/state/kvDb.ts
@@ -1048,17 +1048,20 @@ function normalizeIncomingCrsqlChange(db: DatabaseSyncType, change: CrsqlChangeR
     `pragma table_info('${change.table.replace(/'/g, "''")}')`
   );
   const primaryKeyColumns = tableInfo.filter((column) => Number(column.pk) > 0);
+  if (isSyncScalarBytes(change.pk)) {
+    if (primaryKeyColumns.length === 0) {
+      throw new Error(`Unsupported incoming CRSQL primary key for ${change.table}.${change.cid}: no primary key.`);
+    }
+    const packedPk = packedCrsqlPrimaryKey(change.pk);
+    if (packedPk) return change;
+    throw new Error(`Unsupported incoming CRSQL primary key for ${change.table}.${change.cid}: invalid packed key.`);
+  }
+
   if (primaryKeyColumns.length !== 1) {
     const shape = primaryKeyColumns.length === 0
       ? "no primary key"
       : `${primaryKeyColumns.length} primary key columns`;
     throw new Error(`Unsupported incoming CRSQL primary key for ${change.table}.${change.cid}: ${shape}.`);
-  }
-
-  if (isSyncScalarBytes(change.pk)) {
-    const packedPk = packedCrsqlPrimaryKey(change.pk);
-    if (packedPk) return change;
-    throw new Error(`Unsupported incoming CRSQL primary key for ${change.table}.${change.cid}: invalid packed key.`);
   }
 
   const packedPk = packedCrsqlPrimaryKey(change.pk);


### PR DESCRIPTION
Fixes ADE-49
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-49: applyChanges rejects composite-PK CRR table changes, causing a permanent sync-wedge reconnect loop](https://linear.app/ade-linear/issue/ADE-49/applychanges-rejects-composite-pk-crr-table-changes-causing-a) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-49-applychanges-rejects-composite-pk-crr-table-changes-causing-a-permanent-sync-wedge-reconnect-loop num=432 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-49-applychanges-rejects-composite-pk-crr-table-changes-causing-a-permanent-sync-wedge-reconnect-loop&amp;pr=432">ade-49-applychanges-rejects-composite-pk-crr-table-changes-causing-a-permanent-sync-wedge-reconnect-loop branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=432">PR #432</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a permanent sync-wedge caused by `normalizeIncomingCrsqlChange` throwing for composite-PK CRR tables before it could recognize a packed-bytes PK. The fix reorders the guard so that `isSyncScalarBytes` is checked first, allowing composite-PK table changes to pass through correctly.

- **`kvDb.ts`**: Moves the `isSyncScalarBytes` branch before the `primaryKeyColumns.length !== 1` gate so that composite-PK tables (e.g. `process_runtime` with `(project_id, lane_id, process_key)`) no longer cause an immediate throw; the no-primary-key guard is preserved inside the bytes branch.
- **`kvDb.sync.test.ts`**: Adds an end-to-end test that inserts a `process_runtime` row on `db1`, exports the changes since that version, applies them to `db2`, and verifies the row is present — directly exercising the fixed code path.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted guard reordering with no behavior change for the existing single-PK path and a direct fix for the composite-PK rejection.

The reordering is minimal and correct: bytes-format PKs are handled first regardless of how many PK columns the table has, the no-primary-key guard is preserved inside the bytes branch, and single-PK non-bytes behavior is entirely unchanged. The new integration test directly exercises the previously failing composite-PK round-trip.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/state/kvDb.ts | Guard reordering in normalizeIncomingCrsqlChange — bytes-PK check now runs before the single-column assertion, fixing the composite-PK rejection bug; no behavior change for single-PK or zero-PK tables. |
| apps/desktop/src/main/services/state/kvDb.sync.test.ts | New integration test covering the composite-PK sync round-trip; covers the exact failure scenario described in ADE-49. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Fix composite PK CRR change apply"](https://github.com/arul28/ade/commit/ef074f86eeb85cd9e515c17881243a17fd987597) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34698208)</sub>

<!-- /greptile_comment -->