### PR TITLE
ADE-57: Handle port 19836 collision in Linear OAuth (detect EADDRINUSE, surface actionable error / reuse holder)

### DIFF
--- a/apps/desktop/src/main/services/chat/cursorSdkHooks.test.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkHooks.test.ts
@@ -99,7 +99,6 @@ describe("Cursor SDK hook installation", () => {
     try {
       ensureCursorSdkUserHook({ userHomeDir: home });
       const stdout = execFileSync("/bin/sh", [cursorSdkHookShellCommandPath(home)], {
-        input: "{}",
         env: {
           PATH: "",
           HOME: home,
@@ -300,7 +299,6 @@ describe("Cursor SDK hook installation", () => {
       expect(content).toContain("script_path='/tmp/ADE Hooks/ade-tool-gate.cjs'");
       expect(content).toContain("configured_node='/tmp/node'\\''s/bin/node'");
       const stdout = execFileSync("/bin/sh", [commandPath, `--socket=${path.join(home, "missing.sock")}`], {
-        input: "{}",
         env: {
           PATH: "",
           HOME: home,

--- a/apps/desktop/src/main/services/cto/linearAuth.test.ts
+++ b/apps/desktop/src/main/services/cto/linearAuth.test.ts
@@ -397,6 +397,43 @@ describe("linearOAuthService", () => {
     expect(session.error).toBeNull();
   });
 
+  it("throws an actionable error when another service instance holds the callback port", async () => {
+    const firstService = createLinearOAuthService({
+      credentials: createCredentialsMock() as any,
+      logger: createLogger(),
+    });
+    activeServices.push(firstService);
+    await firstService.startSession();
+
+    const logger = createLogger();
+    const secondService = createLinearOAuthService({
+      credentials: createCredentialsMock() as any,
+      logger,
+    });
+    activeServices.push(secondService);
+
+    let caught: unknown;
+    try {
+      await secondService.startSession();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const error = caught as Error & { code?: string };
+    expect(error.code).toBe("EADDRINUSE");
+    expect(error.message).toContain("callback port 19836 is already in use");
+    expect(error.message).toContain("Stop the other ADE process or local app");
+    expect(error.message).not.toContain("listen EADDRINUSE");
+    expect(logger.warn).toHaveBeenCalledWith(
+      "linear_sync.oauth_callback_port_in_use",
+      expect.objectContaining({
+        host: "127.0.0.1",
+        port: 19836,
+      }),
+    );
+  });
+
   it("getSession returns expired for unknown session id", () => {
     const credentials = createCredentialsMock();
     const service = createLinearOAuthService({

--- a/apps/desktop/src/main/services/cto/linearOAuthService.ts
+++ b/apps/desktop/src/main/services/cto/linearOAuthService.ts
@@ -12,6 +12,7 @@ import { createPkcePair } from "../shared/utils";
 const LINEAR_AUTHORIZE_URL = "https://linear.app/oauth/authorize";
 const LINEAR_TOKEN_URL = "https://api.linear.app/oauth/token";
 const CALLBACK_PATH = "/oauth/callback";
+const OAUTH_HOST = "127.0.0.1";
 const OAUTH_PORT = 19836;
 const SESSION_TTL_MS = 10 * 60 * 1000;
 
@@ -26,6 +27,23 @@ type LinearOAuthSessionState = {
   error: string | null;
   server: http.Server;
 };
+
+function isAddressInUseError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  if ("code" in error && error.code === "EADDRINUSE") return true;
+  return error instanceof Error && (
+    error.message.includes("EADDRINUSE") || error.message.includes("address already in use")
+  );
+}
+
+function createOAuthPortInUseError(): Error {
+  const error = new Error(
+    `Linear OAuth cannot start because callback port ${OAUTH_PORT} is already in use on ${OAUTH_HOST}. ` +
+    `Stop the other ADE process or local app using that port, then try Sign in with Linear again.`,
+  ) as Error & { code?: string };
+  error.code = "EADDRINUSE";
+  return error;
+}
 
 
 export function createLinearOAuthService(args: {
@@ -194,13 +212,31 @@ export function createLinearOAuthService(args: {
       }
     });
 
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(OAUTH_PORT, "127.0.0.1", () => {
-        server.off("error", reject);
-        resolve();
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(OAUTH_PORT, OAUTH_HOST, () => {
+          server.off("error", reject);
+          resolve();
+        });
       });
-    });
+    } catch (error) {
+      try {
+        server.close();
+      } catch {
+        // best effort
+      }
+
+      if (isAddressInUseError(error)) {
+        args.logger?.warn("linear_sync.oauth_callback_port_in_use", {
+          host: OAUTH_HOST,
+          port: OAUTH_PORT,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw createOAuthPortInUseError();
+      }
+      throw error;
+    }
 
     const address = server.address();
     if (!address || typeof address === "string") {


### PR DESCRIPTION
Fixes ADE-57
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-57: Handle port 19836 collision in Linear OAuth (detect EADDRINUSE, surface actionable error / reuse holder)](https://linear.app/ade-linear/issue/ADE-57/handle-port-19836-collision-in-linear-oauth-detect-eaddrinuse-surface) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-57-handle-port-19836-collision-in-linear-oauth-detect-eaddrinuse-surface-actionable-error-reuse-holder num=433 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-57-handle-port-19836-collision-in-linear-oauth-detect-eaddrinuse-surface-actionable-error-reuse-holder&amp;pr=433">ade-57-handle-port-19836-collision-in-linear-oauth-detect-eaddrinuse-surface-actionable-error-reuse-holder branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=433">PR #433</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves resilience in the Linear OAuth flow by detecting `EADDRINUSE` when port `19836` is already occupied, replacing the raw Node.js error with a clear, actionable message, and logging a structured warning. It also extracts a named `OAUTH_HOST` constant to centralise the loopback address.

- **`linearOAuthService.ts`**: Wraps `server.listen` in a try/catch; `isAddressInUseError` detects the collision and `createOAuthPortInUseError` produces a user-facing message with `code: \"EADDRINUSE\"` so callers can still distinguish the error type.
- **`linearAuth.test.ts`**: Adds an integration-style test that spins up two service instances against the real port, asserting the correct error shape, message text, and warning log.
- **`cursorSdkHooks.test.ts`**: Removes the `input: \"{}\"` option from two `execFileSync` calls in an otherwise unrelated test file.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to port-collision handling and does not touch the happy-path OAuth flow.

The error-handling logic is correct: EADDRINUSE is detected reliably, the raw system error is replaced with a user-friendly message that preserves the error code, and the new integration test exercises the full failure path end-to-end. No regressions to existing behaviour were introduced.

No files require special attention beyond the already-tracked redirectUri hardcoding in linearOAuthService.ts.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/cto/linearOAuthService.ts | Adds OAUTH_HOST constant, EADDRINUSE detection helpers, and a try/catch around server.listen with friendly error surfacing; redirectUri still hardcodes 127.0.0.1 (tracked in prior comment). |
| apps/desktop/src/main/services/cto/linearAuth.test.ts | Adds a port-collision integration test that verifies error shape, message text, and structured warning log; well-scoped and covers the new code path thoroughly. |
| apps/desktop/src/main/services/chat/cursorSdkHooks.test.ts | Removes input: "{}" from two execFileSync calls — unrelated drive-by change; functionally fine if the tested shell scripts do not consume stdin, but the intent is not documented. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/main/services/cto/linearOAuthService.ts`, line 247 ([link](https://github.com/arul28/ade/blob/64c7237b6d50562cd7d2c87ed6f747311cc085d1/apps/desktop/src/main/services/cto/linearOAuthService.ts#L247)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> This PR introduces the `OAUTH_HOST` constant specifically to centralise the `127.0.0.1` literal, but `redirectUri` is still constructed with the string hardcoded. If `OAUTH_HOST` is ever changed (e.g. to `::1` for IPv6-only environments), the `redirectUri` would silently diverge from the actual listening address, causing the OAuth callback to fail.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/cto/linearOAuthService.ts
   Line: 247

   Comment:
   This PR introduces the `OAUTH_HOST` constant specifically to centralise the `127.0.0.1` literal, but `redirectUri` is still constructed with the string hardcoded. If `OAUTH_HOST` is ever changed (e.g. to `::1` for IPv6-only environments), the `redirectUri` would silently diverge from the actual listening address, causing the OAuth callback to fail.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fcto%2FlinearOAuthService.ts%0ALine%3A%20247%0A%0AComment%3A%0AThis%20PR%20introduces%20the%20%60OAUTH_HOST%60%20constant%20specifically%20to%20centralise%20the%20%60127.0.0.1%60%20literal%2C%20but%20%60redirectUri%60%20is%20still%20constructed%20with%20the%20string%20hardcoded.%20If%20%60OAUTH_HOST%60%20is%20ever%20changed%20%28e.g.%20to%20%60%3A%3A1%60%20for%20IPv6-only%20environments%29%2C%20the%20%60redirectUri%60%20would%20silently%20diverge%20from%20the%20actual%20listening%20address%2C%20causing%20the%20OAuth%20callback%20to%20fail.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20redirectUri%20%3D%20%60http%3A%2F%2F%24%7BOAUTH_HOST%7D%3A%24%7Baddress.port%7D%24%7BCALLBACK_PATH%7D%60%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=433&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (8): Last reviewed commit: ["test: avoid stdin EPIPE in Cursor shell ..."](https://github.com/arul28/ade/commit/f08e1a055853b2ab3c88bfab85414fd8f72bb0a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34698221)</sub>

<!-- /greptile_comment -->