### PR TITLE
ADE-47: CRR sync drops changes when a changeset batch splits in the middle of a single db_version

### DIFF
--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
+  CrsqlChangeRow,
   SyncMobileProjectSummary,
   SyncPeerMetadata,
   SyncRemoteCommandDescriptor,
@@ -11,6 +12,7 @@ import {
   buildSyncHostHelloOkPayload,
   createSyncHostService,
   resolveSyncHostInboundProjectScope,
+  selectChangesetBatchChunk,
 } from "./syncHostService";
 
 const publishMock = vi.hoisted(() => vi.fn());
@@ -165,6 +167,88 @@ describe("buildSyncHostHelloOkPayload", () => {
       supportedActions: [remoteCommand.action, localPresenceCommand.action],
       actions: [remoteCommand, localPresenceCommand],
     });
+  });
+});
+
+function makeChange(dbVersion: number, seq: number, value = `value-${seq}`): CrsqlChangeRow {
+  return {
+    table: "kv",
+    pk: `key-${seq}`,
+    cid: "value",
+    val: value,
+    col_version: dbVersion,
+    db_version: dbVersion,
+    site_id: "site-host",
+    cl: 1,
+    seq,
+  };
+}
+
+describe("selectChangesetBatchChunk", () => {
+  it("keeps a single db_version together when the row limit would split it", () => {
+    const changes = [
+      ...Array.from({ length: 400 }, (_, seq) => makeChange(7, seq)),
+      makeChange(8, 400),
+    ];
+
+    const chunk = selectChangesetBatchChunk({
+      changes,
+      fromDbVersion: 0,
+      toDbVersion: 8,
+      maxRows: 250,
+      maxBytes: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(chunk?.changes).toHaveLength(400);
+    expect(chunk?.changes.every((change) => change.db_version === 7)).toBe(true);
+    expect(chunk?.toDbVersion).toBe(7);
+  });
+
+  it("does not spread an unbounded same-db_version chunk to compute the watermark", () => {
+    const changes = Array.from({ length: 70_000 }, (_, seq) => makeChange(9, seq));
+
+    const chunk = selectChangesetBatchChunk({
+      changes,
+      fromDbVersion: 0,
+      toDbVersion: 9,
+      maxRows: 250,
+      maxBytes: Number.MAX_SAFE_INTEGER,
+    });
+
+    expect(chunk?.changes).toHaveLength(70_000);
+    expect(chunk?.toDbVersion).toBe(9);
+  });
+
+  it("keeps a single db_version together when the byte limit would split it", () => {
+    const largeValue = "x".repeat(180_000);
+    const changes = [
+      makeChange(4, 0, largeValue),
+      makeChange(4, 1, largeValue),
+      makeChange(5, 2, "next-version"),
+    ];
+
+    const chunk = selectChangesetBatchChunk({
+      changes,
+      fromDbVersion: 0,
+      toDbVersion: 5,
+      maxRows: 250,
+      maxBytes: 256 * 1024,
+    });
+
+    expect(chunk?.changes).toEqual(changes.slice(0, 2));
+    expect(chunk?.toDbVersion).toBe(4);
+  });
+
+  it("can advance an empty changeset when all changes were filtered locally", () => {
+    const chunk = selectChangesetBatchChunk({
+      changes: [],
+      fromDbVersion: 3,
+      toDbVersion: 4,
+      maxRows: 250,
+      maxBytes: 256 * 1024,
+    });
+
+    expect(chunk).toEqual({ changes: [], toDbVersion: 4 });
   });
 });
 

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -202,6 +202,43 @@ type PersistedMobileCommand = {
   completedAtMs: number;
 };
 
+export function selectChangesetBatchChunk(args: {
+  changes: CrsqlChangeRow[];
+  fromDbVersion: number;
+  toDbVersion: number;
+  maxRows: number;
+  maxBytes: number;
+}): { changes: CrsqlChangeRow[]; toDbVersion: number } | null {
+  let chunk: CrsqlChangeRow[] = [];
+  let chunkBytes = 0;
+  let lastIncludedDbVersion: number | null = null;
+
+  for (const change of args.changes) {
+    const changeDbVersion = Number(change.db_version ?? args.fromDbVersion);
+    const changeBytes = Buffer.byteLength(JSON.stringify(change), "utf8");
+    // The host watermark is db_version-only, so rows sharing a db_version must ack together.
+    if (
+      chunk.length > 0
+      && changeDbVersion !== lastIncludedDbVersion
+      && (chunk.length >= args.maxRows || chunkBytes + changeBytes > args.maxBytes)
+    ) {
+      break;
+    }
+    chunk.push(change);
+    chunkBytes += changeBytes;
+    lastIncludedDbVersion = changeDbVersion;
+  }
+
+  if (chunk.length === 0 && args.changes.length > 0) {
+    chunk = [args.changes[0]!];
+    lastIncludedDbVersion = Number(chunk[0]!.db_version ?? args.fromDbVersion);
+  }
+  if (chunk.length === 0 && args.toDbVersion <= args.fromDbVersion) return null;
+
+  const chunkToDbVersion = lastIncludedDbVersion ?? args.toDbVersion;
+  return { changes: chunk, toDbVersion: chunkToDbVersion };
+}
+
 const PERSISTED_MOBILE_COMMAND_ACTIONS = new Set<string>([
   "lanes.presence.announce",
   "lanes.presence.release",
@@ -1817,34 +1854,21 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     toDbVersion: number,
     changes: CrsqlChangeRow[],
   ): PendingChangesetBatch | null {
-    let chunk: CrsqlChangeRow[] = [];
-    let chunkBytes = 0;
-
-    for (const change of changes) {
-      const changeBytes = Buffer.byteLength(JSON.stringify(change), "utf8");
-      if (
-        chunk.length > 0
-        && (chunk.length >= maxChangesetBatchRows || chunkBytes + changeBytes > maxChangesetBatchBytes)
-      ) {
-        break;
-      }
-      chunk.push(change);
-      chunkBytes += changeBytes;
-    }
-    if (chunk.length === 0 && changes.length > 0) {
-      chunk = [changes[0]!];
-    }
-    if (chunk.length === 0 && toDbVersion <= fromDbVersion) return null;
-
-    const chunkToDbVersion = chunk.length > 0
-      ? Math.max(...chunk.map((change) => Number(change.db_version ?? fromDbVersion)))
-      : toDbVersion;
+    const selected = selectChangesetBatchChunk({
+      changes,
+      fromDbVersion,
+      toDbVersion,
+      maxRows: maxChangesetBatchRows,
+      maxBytes: maxChangesetBatchBytes,
+    });
+    if (!selected) return null;
+    const chunkToDbVersion = selected.toDbVersion;
     const batch: PendingChangesetBatch = {
       batchId: makeChangesetBatchId(peer, fromDbVersion, chunkToDbVersion),
       reason,
       fromDbVersion,
       toDbVersion: chunkToDbVersion,
-      changes: chunk,
+      changes: selected.changes,
       sentAtMs: Date.now(),
       retryCount: 0,
     };
@@ -1853,7 +1877,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       reason,
       fromDbVersion,
       toDbVersion: chunkToDbVersion,
-      changes: chunk,
+      changes: selected.changes,
     });
     return sent ? batch : null;
   }

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -487,6 +487,9 @@ consecutive missed heartbeats; mobile peers get a wider grace window
 (`MOBILE_SYNC_HEARTBEAT_MISS_LIMIT = 6`) because iOS can briefly suspend
 foreground networking during app and route transitions. Reconnection
 resumes from the last-known `db_version` so no changesets are lost.
+Host-side batching keeps every row for a given `db_version` in the same
+`changeset_batch`; otherwise an ack for a partial transaction would
+advance the receiver past unsent rows.
 
 `changeset_batch` envelopes carry a `batchId`; legacy batches without
 one are decoded with a deterministic fallback so older desktops can

--- a/docs/features/sync-and-multi-device/crdt-model.md
+++ b/docs/features/sync-and-multi-device/crdt-model.md
@@ -284,7 +284,9 @@ SELECT * FROM crsql_changes WHERE db_version > ?;
 
 Wrapped in `AdeDb.sync.exportChangesSince(version)`. Returns an array
 of `CrsqlChangeRow` objects; the transport layer batches them into
-`changeset_batch` envelopes.
+`changeset_batch` envelopes. Because the replication watermark is the
+integer `db_version`, the transport must not split rows that share one
+`db_version` across separate host batches.
 
 ### Apply
 


### PR DESCRIPTION
Fixes ADE-47
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-47: CRR sync drops changes when a changeset batch splits in the middle of a single db_version](https://linear.app/ade-linear/issue/ADE-47/crr-sync-drops-changes-when-a-changeset-batch-splits-in-the-middle-of) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-47-crr-sync-drops-changes-when-a-changeset-batch-splits-in-the-middle-of-a-single-db-version num=435 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-47-crr-sync-drops-changes-when-a-changeset-batch-splits-in-the-middle-of-a-single-db-version&amp;pr=435">ade-47-crr-sync-drops-changes-when-a-changeset-batch-splits-in-the-middle-of-a-single-db-version branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=435">PR #435</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes ADE-47, where CRR sync silently dropped rows when a changeset batch was cut in the middle of a `db_version` group. It also removes the prior `Math.max(...spread)` call that could throw a `RangeError` on large `db_version` groups.

- **Core fix** (`syncHostService.ts`): Extracts a new exported `selectChangesetBatchChunk` function that delays the chunk boundary until a `db_version` transition, ensuring all rows sharing one `db_version` are sent together. `toDbVersion` is now tracked directly via `lastIncludedDbVersion` rather than a spread into `Math.max`.
- **Tests** (`syncHostService.test.ts`): Four new unit tests cover row-limit splitting, byte-limit splitting, 70k-row single-version batches, and empty-changeset advancement.
- **Docs**: Two doc files receive short prose notes explaining the invariant that rows within a `db_version` must not be split across separate host batches.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core fix is correct and well-tested, with one unreachable fallback branch that can be cleaned up post-merge.

The chunk-selection logic correctly defers breaks to db_version boundaries and tracks the watermark directly via `lastIncludedDbVersion`. The only issue is a now-unreachable three-line fallback (lines 232–234) that was a safety valve in the old code but can never trigger under the new loop invariant.

apps/ade-cli/src/services/sync/syncHostService.ts — minor dead-code cleanup around the single-row fallback.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/services/sync/syncHostService.ts | Extracts chunk-selection logic into the exported `selectChangesetBatchChunk` function, which fixes the split-db_version bug by deferring the break to the next db_version boundary; contains one unreachable fallback branch (lines 232–234). |
| apps/ade-cli/src/services/sync/syncHostService.test.ts | Adds four targeted unit tests for `selectChangesetBatchChunk` covering row-limit splitting, byte-limit splitting, the 70k-row no-spread case, and empty-changeset advancement. |
| docs/features/sync-and-multi-device/README.md | Adds a short prose paragraph documenting the host-side batching invariant (all rows for a db_version must travel together) to the sync feature overview. |
| docs/features/sync-and-multi-device/crdt-model.md | Adds a one-sentence note to the CRDT model doc clarifying that the transport must not split rows sharing a db_version across separate batches. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["selectChangesetBatchChunk(changes, fromDbVersion, toDbVersion, maxRows, maxBytes)"] --> B{changes empty?}
    B -- yes --> C{toDbVersion > fromDbVersion?}
    C -- no --> D["return null"]
    C -- yes --> E["return { changes: [], toDbVersion }"]
    B -- no --> F["Iterate over sorted changes"]
    F --> G{chunk.length > 0\nAND new db_version\nAND row/byte limit hit?}
    G -- yes --> H["break — db_version boundary respected"]
    G -- no --> I["push row to chunk\nupdate lastIncludedDbVersion"]
    I --> F
    H --> J["return { changes: chunk, toDbVersion: lastIncludedDbVersion }"]
    I --> J
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fade-cli%2Fsrc%2Fservices%2Fsync%2FsyncHostService.ts%3A232-236%0AThe%20fallback%20at%20lines%20232%E2%80%93234%20is%20unreachable.%20The%20loop's%20break%20condition%20requires%20%60chunk.length%20%3E%200%60%2C%20so%20the%20first%20element%20of%20%60args.changes%60%20is%20unconditionally%20pushed%20on%20the%20first%20iteration%20%E2%80%94%20%60chunk%60%20can%20never%20be%20empty%20after%20the%20loop%20when%20%60args.changes%60%20is%20non-empty.%0A%0A%60%60%60suggestion%0A%20%20if%20%28chunk.length%20%3D%3D%3D%200%20%26%26%20args.toDbVersion%20%3C%3D%20args.fromDbVersion%29%20return%20null%3B%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=435&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/ade-cli/src/services/sync/syncHostService.ts:232-236
The fallback at lines 232–234 is unreachable. The loop's break condition requires `chunk.length > 0`, so the first element of `args.changes` is unconditionally pushed on the first iteration — `chunk` can never be empty after the loop when `args.changes` is non-empty.

```suggestion
  if (chunk.length === 0 && args.toDbVersion <= args.fromDbVersion) return null;
```

`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(sync): keep changeset batches on db ..."](https://github.com/arul28/ade/commit/9dccf9e45e0ac509237e4fda25d8556e182fa395) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34698233)</sub>

<!-- /greptile_comment -->