### PR TITLE
ADE-48: Orchestration: reject duplicate task IDs (shadow task deadlocks phase completion)

### DIFF
--- a/apps/desktop/src/main/services/orchestration/manifestNormalization.ts
+++ b/apps/desktop/src/main/services/orchestration/manifestNormalization.ts
@@ -286,31 +286,37 @@ export function validateManifestShape(manifest: OrchestrationManifest): string |
 }
 
 function validateTasks(tasks: OrchestrationManifest["tasks"]): string | null {
+  const seenIds = new Set<string>();
   for (const task of tasks ?? []) {
     if (!task || typeof task !== "object") return "manifest.tasks entries must be objects";
     if (typeof task.id !== "string" || !task.id.trim()) {
       return "manifest.tasks entries must include a non-empty id";
     }
+    const taskId = task.id.trim();
+    if (seenIds.has(taskId)) {
+      return `manifest.tasks contains duplicate id ${taskId}`;
+    }
+    seenIds.add(taskId);
     if (!isPhaseId((task as { phaseId?: unknown }).phaseId)) {
-      return `manifest task ${task.id} must include phaseId; use phaseId, not phase`;
+      return `manifest task ${taskId} must include phaseId; use phaseId, not phase`;
     }
     if (typeof task.title !== "string" || !task.title.trim()) {
-      return `manifest task ${task.id} must include a non-empty title`;
+      return `manifest task ${taskId} must include a non-empty title`;
     }
     if (typeof task.description !== "string") {
-      return `manifest task ${task.id} must include description`;
+      return `manifest task ${taskId} must include description`;
     }
     if (!isTaskStatus(task.status)) {
-      return `manifest task ${task.id} has invalid status`;
+      return `manifest task ${taskId} has invalid status`;
     }
     if (!task.validationGate || typeof task.validationGate !== "object") {
-      return `manifest task ${task.id} must include validationGate`;
+      return `manifest task ${taskId} must include validationGate`;
     }
     if (typeof task.validationGate.required !== "boolean") {
-      return `manifest task ${task.id} validationGate.required must be boolean`;
+      return `manifest task ${taskId} validationGate.required must be boolean`;
     }
     if (!Array.isArray(task.validationGate.stepIds)) {
-      return `manifest task ${task.id} validationGate.stepIds must be an array`;
+      return `manifest task ${taskId} validationGate.stepIds must be an array`;
     }
   }
   return null;

--- a/apps/desktop/src/main/services/orchestration/orchestrationService.test.ts
+++ b/apps/desktop/src/main/services/orchestration/orchestrationService.test.ts
@@ -20,6 +20,7 @@ import type {
 import type {
   ModelRouting,
   ModelSelection,
+  OrchestrationTask,
 } from "../../../shared/types/orchestration";
 
 async function makeTempLane(): Promise<string> {
@@ -29,6 +30,17 @@ async function makeTempLane(): Promise<string> {
 
 async function rmTree(p: string): Promise<void> {
   await fsp.rm(p, { recursive: true, force: true });
+}
+
+function makeTask(id: string): OrchestrationTask {
+  return {
+    id,
+    phaseId: "developing",
+    title: `Task ${id}`,
+    description: "",
+    status: "pending",
+    validationGate: { required: false, stepIds: [] },
+  };
 }
 
 describe("orchestrationService", () => {
@@ -718,6 +730,91 @@ describe("orchestrationService", () => {
     expect(() =>
       applyPatches(initial, [{ op: "replace", path: "/tasks/0/status", value: "x" }]),
     ).toThrow(/numeric/i);
+  });
+
+  it("rejects duplicate task ids appended in one manifest patch", async () => {
+    const svc = createOrchestrationService({
+      resolveLaneWorktree: () => lane,
+    });
+    const { manifest } = await svc.runCreate({
+      laneId: "L-1",
+      leadSessionId: "S-lead",
+      bundleRoot: lane,
+    });
+
+    const result = await svc.manifestPatch(
+      {
+        runId: manifest.runId,
+        ifMatchEtag: manifest.etag,
+        actorRole: "lead",
+        actorSessionId: "S-lead",
+        patches: [
+          { op: "add", path: "/tasks/-", value: makeTask("T-1") },
+          { op: "add", path: "/tasks/-", value: makeTask("T-1") },
+        ],
+      },
+      manifest.bundlePath,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("validation_failed");
+    if (!("message" in result)) throw new Error("expected validation failure message");
+    expect(result.message).toMatch(/duplicate id T-1/);
+
+    const onDisk = JSON.parse(
+      await fsp.readFile(path.join(manifest.bundlePath, "manifest.json"), "utf-8"),
+    ) as { tasks: unknown[] };
+    expect(onDisk.tasks).toHaveLength(0);
+    await svc.dispose();
+  });
+
+  it("rejects re-adding an existing task id through manifestPatch", async () => {
+    const svc = createOrchestrationService({
+      resolveLaneWorktree: () => lane,
+    });
+    const { manifest } = await svc.runCreate({
+      laneId: "L-1",
+      leadSessionId: "S-lead",
+      bundleRoot: lane,
+    });
+
+    const first = await svc.manifestPatch(
+      {
+        runId: manifest.runId,
+        ifMatchEtag: manifest.etag,
+        actorRole: "lead",
+        actorSessionId: "S-lead",
+        patches: [{ op: "add", path: "/tasks/-", value: makeTask("T-1") }],
+      },
+      manifest.bundlePath,
+    );
+
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+
+    const duplicate = await svc.manifestPatch(
+      {
+        runId: manifest.runId,
+        ifMatchEtag: first.etag,
+        actorRole: "lead",
+        actorSessionId: "S-lead",
+        patches: [{ op: "add", path: "/tasks/-", value: makeTask("T-1") }],
+      },
+      manifest.bundlePath,
+    );
+
+    expect(duplicate.ok).toBe(false);
+    if (duplicate.ok) return;
+    expect(duplicate.error).toBe("validation_failed");
+    if (!("message" in duplicate)) throw new Error("expected validation failure message");
+    expect(duplicate.message).toMatch(/duplicate id T-1/);
+
+    const onDisk = JSON.parse(
+      await fsp.readFile(path.join(manifest.bundlePath, "manifest.json"), "utf-8"),
+    ) as { tasks: unknown[] };
+    expect(onDisk.tasks).toHaveLength(1);
+    await svc.dispose();
   });
 
   it("validates spawn-brief required sections", () => {


### PR DESCRIPTION
Fixes ADE-48
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-48: Orchestration: reject duplicate task IDs (shadow task deadlocks phase completion)](https://linear.app/ade-linear/issue/ADE-48/orchestration-reject-duplicate-task-ids-shadow-task-deadlocks-phase) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-48-orchestration-reject-duplicate-task-ids-shadow-task-deadlocks-phase-completion num=436 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-48-orchestration-reject-duplicate-task-ids-shadow-task-deadlocks-phase-completion&amp;pr=436">ade-48-orchestration-reject-duplicate-task-ids-shadow-task-deadlocks-phase-completion branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=436">PR #436</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds duplicate-task-ID rejection to the manifest validation layer so that a shadow task can no longer silently occupy an ID and prevent phase completion. The guard runs at validation time, before any write is committed, and works across both same-patch and cross-patch duplication scenarios.

- `validateTasks` now maintains a `Set<string>` of trimmed IDs and returns an early error on the first duplicate found, preventing the poisoned manifest from ever reaching disk.
- Two new integration tests verify that `manifestPatch` returns `validation_failed` and leaves on-disk state unchanged (or at the pre-duplicate length) for both scenarios.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, additive validation guard with no side effects on the happy path.

The implementation is a minimal, focused addition: a Set is allocated once per validateTasks call, the duplicate check fires before any write, and the existing validation chain is otherwise untouched. Both same-patch and cross-patch duplicate scenarios are covered by integration tests that also verify on-disk state. No regressions were introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/orchestration/manifestNormalization.ts | Adds duplicate task ID detection to validateTasks using a Set; trims IDs consistently across all error messages in the loop. |
| apps/desktop/src/main/services/orchestration/orchestrationService.test.ts | Adds makeTask helper and two integration tests covering same-patch duplicates and cross-patch duplicates; on-disk state verified after each rejection. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[manifestPatch called] --> B[Apply JSON patches in memory]
    B --> C[validateManifestShape]
    C --> D[validateTasks]
    D --> E{task.id empty?}
    E -- yes --> F[return error: non-empty id required]
    E -- no --> G[taskId = task.id.trim]
    G --> H{seenIds.has taskId?}
    H -- yes --> I[return error: duplicate id]
    H -- no --> J[seenIds.add taskId]
    J --> K[validate phaseId, title, description, status, validationGate]
    K --> L{more tasks?}
    L -- yes --> E
    L -- no --> M[return null — valid]
    M --> N[Persist manifest to disk]
    I --> O[Reject patch — no write]
    F --> O
```

<sub>Reviews (5): Last reviewed commit: ["Fix duplicate orchestration task id reje..."](https://github.com/arul28/ade/commit/29391cb36b20173dc3104c929561ddc4f818c766) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34698267)</sub>

<!-- /greptile_comment -->