### PR TITLE
ADE-61: Avoid building APNs bridge service on every getAdeActionDomainServices call

### DIFF
--- a/apps/desktop/src/main/services/adeActions/registry.test.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.test.ts
@@ -245,6 +245,75 @@ describe("ADE_ACTION_ALLOWLIST shape", () => {
   });
 });
 
+describe("runtime APNs action service", () => {
+  it("does not read APNs dependencies when resolving an unrelated domain", () => {
+    const runtime = {
+      laneService: {
+        list: vi.fn(),
+      },
+      projectConfigService: {
+        get: vi.fn(),
+      },
+      get apnsService() {
+        throw new Error("apnsService should not be read for lane actions");
+      },
+      get apnsKeyStore() {
+        throw new Error("apnsKeyStore should not be read for lane actions");
+      },
+    } as unknown as Parameters<typeof getAdeActionDomainServices>[0];
+
+    const services = getAdeActionDomainServices(runtime);
+    const laneService = services.lane as Record<string, unknown>;
+
+    expect(Object.keys(services)).toContain("notifications_apns");
+    expect(laneService.list).toEqual(expect.any(Function));
+  });
+
+  it("reuses the APNs bridge for repeated lookups on a stable runtime", () => {
+    const runtime = {
+      projectConfigService: {
+        get: vi.fn(() => ({ effective: {}, shared: {}, local: {} })),
+      },
+      apnsService: {
+        isConfigured: vi.fn(() => false),
+      },
+      apnsKeyStore: {
+        has: vi.fn(() => false),
+      },
+    } as unknown as Parameters<typeof getAdeActionDomainServices>[0];
+
+    const first = getAdeActionDomainServices(runtime).notifications_apns;
+    const second = getAdeActionDomainServices(runtime).notifications_apns;
+
+    expect(second).toBe(first);
+  });
+
+  it("refreshes the cached APNs bridge when late-bound dependencies change", async () => {
+    const runtime = {
+      projectConfigService: {
+        get: vi.fn(() => ({ effective: {}, shared: {}, local: {} })),
+      },
+      apnsService: {
+        isConfigured: vi.fn(() => false),
+      },
+      apnsKeyStore: {
+        has: vi.fn(() => false),
+      },
+    } as any as Parameters<typeof getAdeActionDomainServices>[0];
+
+    const first = getAdeActionDomainServices(runtime).notifications_apns;
+    (runtime as any).apnsService = {
+      isConfigured: vi.fn(() => true),
+    };
+    const second = getAdeActionDomainServices(runtime).notifications_apns as {
+      getStatus: () => Promise<{ configured: boolean }>;
+    };
+
+    expect(second).not.toBe(first);
+    await expect(second.getStatus()).resolves.toMatchObject({ configured: true });
+  });
+});
+
 describe("runtime Linear issue tracker actions", () => {
   it("builds catalog and picker payloads from tracker reads", async () => {
     const projects = [{ id: "project-1", name: "ADE" }];

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -804,6 +804,44 @@ function toService(value: unknown): OpaqueService | null {
   return (value ?? null) as OpaqueService | null;
 }
 
+type CachedApnsBridgeDomainService = {
+  projectConfigService: AdeRuntime["projectConfigService"];
+  apnsService: AdeRuntime["apnsService"];
+  apnsKeyStore: AdeRuntime["apnsKeyStore"];
+  service: OpaqueService;
+};
+
+const apnsBridgeDomainServices = new WeakMap<AdeRuntime, CachedApnsBridgeDomainService>();
+
+function getApnsBridgeDomainService(runtime: AdeRuntime): OpaqueService {
+  const projectConfigService = runtime.projectConfigService;
+  const apnsService = runtime.apnsService;
+  const apnsKeyStore = runtime.apnsKeyStore;
+  const cached = apnsBridgeDomainServices.get(runtime);
+  if (
+    cached &&
+    cached.projectConfigService === projectConfigService &&
+    cached.apnsService === apnsService &&
+    cached.apnsKeyStore === apnsKeyStore
+  ) {
+    return cached.service;
+  }
+  const service = createApnsBridgeService({
+    projectConfigService,
+    apnsService,
+    apnsKeyStore,
+    getDeviceRegistryService: () =>
+      runtime.syncService?.getDeviceRegistryService?.() ?? null,
+  }) as OpaqueService;
+  apnsBridgeDomainServices.set(runtime, {
+    projectConfigService,
+    apnsService,
+    apnsKeyStore,
+    service,
+  });
+  return service;
+}
+
 const MAX_TEMP_ATTACHMENT_BYTES = 10 * 1024 * 1024;
 
 function agentChatParallelLaunchStateKey(projectRoot: string, parentLaneId: string): string {
@@ -2723,15 +2761,9 @@ export function getAdeActionDomainServices(
     automations: toService(buildAutomationsDomainService(runtime)),
     review: toService(runtime.reviewService),
     issue: toService(buildIssueDomainService(runtime)),
-    notifications_apns: toService(
-      createApnsBridgeService({
-        projectConfigService: runtime.projectConfigService,
-        apnsService: runtime.apnsService,
-        apnsKeyStore: runtime.apnsKeyStore,
-        getDeviceRegistryService: () =>
-          runtime.syncService?.getDeviceRegistryService?.() ?? null,
-      }),
-    ),
+    get notifications_apns() {
+      return toService(getApnsBridgeDomainService(runtime));
+    },
   };
 }
 


### PR DESCRIPTION
Fixes ADE-61
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-61: Avoid building APNs bridge service on every getAdeActionDomainServices call](https://linear.app/ade-linear/issue/ADE-61/avoid-building-apns-bridge-service-on-every-getadeactiondomainservices) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-61-avoid-building-apns-bridge-service-on-every-getadeactiondomainservices-call num=437 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-61-avoid-building-apns-bridge-service-on-every-getadeactiondomainservices-call&amp;pr=437">ade-61-avoid-building-apns-bridge-service-on-every-getadeactiondomainservices-call branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=437">PR #437</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR avoids rebuilding the APNs bridge service on every `getAdeActionDomainServices` call by introducing a `WeakMap`-based cache keyed by `AdeRuntime` and converting `notifications_apns` from an eagerly-computed value to a lazy getter.

- A module-level `WeakMap<AdeRuntime, CachedApnsBridgeDomainService>` stores the bridge instance and the three dependency references (`projectConfigService`, `apnsService`, `apnsKeyStore`) used to detect staleness; the cache is invalidated when any of those references change.
- `notifications_apns` is now a getter in the returned object so APNs dependencies are not read at all when an unrelated domain is accessed, and three new tests cover the lazy initialisation, cache reuse, and cache invalidation paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted performance optimisation with no behavioural regressions.

The WeakMap cache is keyed on the runtime object and invalidated whenever any of the three tracked dependency references change. The lazy getter correctly defers APNs dependency access, and the toService wrapper in the getter handles any falsy return from createApnsBridgeService. The getDeviceRegistryService closure captures runtime directly so it stays current even when syncService is replaced without a cache miss. All three critical paths (lazy skip, cache hit, cache invalidation) are covered by the new tests.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/adeActions/registry.ts | Introduces WeakMap cache and lazy getter for notifications_apns; logic is correct and cache invalidation covers all tracked dependencies. |
| apps/desktop/src/main/services/adeActions/registry.test.ts | Adds three focused tests covering lazy evaluation, cache reuse across calls, and invalidation on dependency change; all cases look correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getAdeActionDomainServices(runtime)"] --> B["Return object with getter\nnotifications_apns"]
    B --> C{"Caller accesses\nnotifications_apns?"}
    C -- No --> D["APNs deps never read\n(lazy evaluation)"]
    C -- Yes --> E["getApnsBridgeDomainService(runtime)"]
    E --> F{"WeakMap cache hit?\n(runtime key exists)"}
    F -- No --> G["createApnsBridgeService(...)"]
    G --> H["Store in WeakMap\n{projectConfigService, apnsService,\napnsKeyStore, service}"]
    H --> I["Return service"]
    F -- Yes --> J{"Dependency refs equal?\n(projectConfigService ===\napnsService === apnsKeyStore)"}
    J -- Yes --> K["Return cached service"]
    J -- No --> G
    I --> L["toService(service)\nOpaqueService | null"]
    K --> L
```

<sub>Reviews (5): Last reviewed commit: ["fix: memoize APNs ADE action bridge"](https://github.com/arul28/ade/commit/c01f36fc1d3f5f96a8dbc39ac0f0c2b925b01d19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34698269)</sub>

<!-- /greptile_comment -->