### PR TITLE
ADE-60: Local runtime: ensureProject() bypasses isClosed()/retry, so first read after daemon recycle still fails raw

### DIFF
--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts
@@ -660,6 +660,166 @@ describe("local runtime connection pool", () => {
     expect(call).toHaveBeenCalledTimes(2);
   });
 
+  it("retries project registration when the cached runtime connection drops before a read action", async () => {
+    const dropped = new Error("Remote ADE service connection closed.");
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const rootPath = path.resolve("/repo");
+    const project = {
+      projectId: "project-1",
+      rootPath,
+      displayName: "repo",
+      addedAt: 1,
+      lastOpenedAt: 1,
+      gitOriginUrl: null,
+    };
+    const firstClient = {
+      call: vi.fn().mockRejectedValue(dropped),
+      close: vi.fn(),
+      isClosed: vi.fn(() => false),
+    };
+    const secondClient = {
+      call: vi.fn(async (method: string) => {
+        if (method === "projects.add") return project;
+        if (method === "ade/actions/call") {
+          return {
+            domain: "lane",
+            action: "list",
+            result: [{ id: "lane-1" }],
+            statusHints: {},
+          };
+        }
+        throw new Error(`Unexpected method ${method}`);
+      }),
+      close: vi.fn(),
+      isClosed: vi.fn(() => false),
+    };
+    const firstEntry = {
+      client: firstClient,
+      child: null,
+      socketPath: "/tmp/ade-stale.sock",
+    };
+    const secondEntry = {
+      client: secondClient,
+      child: null,
+      socketPath: "/tmp/ade-fresh.sock",
+    };
+    const createConnection = vi.fn<[], Promise<unknown>>()
+      .mockResolvedValueOnce(firstEntry)
+      .mockResolvedValueOnce(secondEntry);
+    const pool = new LocalRuntimeConnectionPool("1.2.3", logger as never);
+    (pool as unknown as { createConnection: () => Promise<unknown> }).createConnection = createConnection;
+
+    await expect(pool.callActionForRoot(rootPath, {
+      domain: "lane",
+      action: "list",
+      args: {},
+    })).resolves.toEqual({
+      domain: "lane",
+      action: "list",
+      result: [{ id: "lane-1" }],
+      statusHints: {},
+    });
+
+    expect(createConnection).toHaveBeenCalledTimes(2);
+    expect(firstClient.call).toHaveBeenCalledWith(
+      "projects.add",
+      { rootPath },
+      { timeoutMs: expect.any(Number) },
+    );
+    expect(firstClient.close).toHaveBeenCalledTimes(1);
+    expect(secondClient.call).toHaveBeenNthCalledWith(
+      1,
+      "projects.add",
+      { rootPath },
+      { timeoutMs: expect.any(Number) },
+    );
+    expect(secondClient.call).toHaveBeenNthCalledWith(
+      2,
+      "ade/actions/call",
+      {
+        projectId: "project-1",
+        name: "run_ade_action",
+        arguments: {
+          domain: "lane",
+          action: "list",
+          args: {},
+        },
+      },
+      { timeoutMs: 30_000 },
+    );
+    expect(logger.warn).toHaveBeenCalledWith("local_runtime.ensure_project_connection_dropped", {
+      rootPath,
+      socketPath: "/tmp/ade-stale.sock",
+      attempt: 1,
+      willRetry: true,
+      error: dropped.message,
+    });
+  });
+
+  it("reconnects before project registration when the runtime client is already closed", async () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const rootPath = path.resolve("/repo");
+    const project = {
+      projectId: "project-1",
+      rootPath,
+      displayName: "repo",
+      addedAt: 1,
+      lastOpenedAt: 1,
+      gitOriginUrl: null,
+    };
+    const firstClient = {
+      call: vi.fn(),
+      close: vi.fn(),
+      isClosed: vi.fn(() => true),
+    };
+    const secondClient = {
+      call: vi.fn().mockResolvedValue(project),
+      close: vi.fn(),
+      isClosed: vi.fn(() => false),
+    };
+    const createConnection = vi.fn<[], Promise<unknown>>()
+      .mockResolvedValueOnce({
+        client: firstClient,
+        child: null,
+        socketPath: "/tmp/ade-closed.sock",
+      })
+      .mockResolvedValueOnce({
+        client: secondClient,
+        child: null,
+        socketPath: "/tmp/ade-open.sock",
+      });
+    const pool = new LocalRuntimeConnectionPool("1.2.3", logger as never);
+    (pool as unknown as { createConnection: () => Promise<unknown> }).createConnection = createConnection;
+
+    await expect(pool.ensureProject(rootPath)).resolves.toEqual(project);
+
+    expect(createConnection).toHaveBeenCalledTimes(2);
+    expect(firstClient.call).not.toHaveBeenCalled();
+    expect(firstClient.close).toHaveBeenCalledTimes(1);
+    expect(secondClient.call).toHaveBeenCalledWith(
+      "projects.add",
+      { rootPath },
+      { timeoutMs: expect.any(Number) },
+    );
+    expect(logger.warn).toHaveBeenCalledWith("local_runtime.ensure_project_connection_dropped", {
+      rootPath,
+      socketPath: "/tmp/ade-closed.sock",
+      attempt: 1,
+      willRetry: true,
+      error: "Remote ADE service connection closed.",
+    });
+  });
+
   it("terminates an app-owned fallback runtime when disposed", async () => {
     vi.useFakeTimers();
     const child = {

--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
@@ -701,6 +701,8 @@ export class LocalRuntimeConnectionPool {
       }
     }
 
+    // Unreachable: the loop always returns or throws on the final attempt.
+    // Required here only for TypeScript's control-flow narrowing.
     throw lastError ?? new Error("Local ADE service did not return a project record.");
   }
 

--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
@@ -653,16 +653,55 @@ export class LocalRuntimeConnectionPool {
     const normalizedRoot = path.resolve(rootPath);
     const cached = this.projectsByRoot.get(normalizedRoot);
     if (cached) return cached;
-    const entry = await this.connect();
-    const project = await entry.client.call(
-      "projects.add",
-      { rootPath: normalizedRoot },
-      { timeoutMs: LOCAL_RUNTIME_PROJECT_TIMEOUT_MS },
-    );
-    const record = coerceProjects([project])[0];
-    if (!record) throw new Error("Local ADE service did not return a project record.");
-    this.projectsByRoot.set(normalizedRoot, record);
-    return record;
+
+    let lastError: Error | null = null;
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      const entry = await this.connect();
+      if (entry.client.isClosed()) {
+        const error = new Error("Remote ADE service connection closed.");
+        this.logger.warn("local_runtime.ensure_project_connection_dropped", {
+          rootPath: normalizedRoot,
+          socketPath: entry.socketPath,
+          attempt,
+          willRetry: attempt < 2,
+          error: error.message,
+        });
+        this.resetActiveConnection(entry);
+        lastError = error;
+        if (attempt < 2) continue;
+        throw error;
+      }
+
+      try {
+        const project = await entry.client.call(
+          "projects.add",
+          { rootPath: normalizedRoot },
+          { timeoutMs: LOCAL_RUNTIME_PROJECT_TIMEOUT_MS },
+        );
+        const record = coerceProjects([project])[0];
+        if (!record) throw new Error("Local ADE service did not return a project record.");
+        this.projectsByRoot.set(normalizedRoot, record);
+        return record;
+      } catch (error) {
+        const projectError = error instanceof Error ? error : new Error(String(error));
+        if (!isLocalRuntimeConnectionDropped(projectError)) {
+          throw projectError;
+        }
+        this.logger.warn("local_runtime.ensure_project_connection_dropped", {
+          rootPath: normalizedRoot,
+          socketPath: entry.socketPath,
+          attempt,
+          willRetry: attempt < 2,
+          error: projectError.message,
+        });
+        this.resetActiveConnection(entry);
+        lastError = projectError;
+        if (attempt < 2) continue;
+        throw projectError;
+      }
+    }
+
+    throw lastError ?? new Error("Local ADE service did not return a project record.");
   }
 
   async projects(): Promise<RemoteRuntimeProjectRecord[]> {


### PR DESCRIPTION
Fixes ADE-60

## Summary
- Retry local runtime project registration once when the cached daemon connection is already closed or drops during projects.add.
- Reset the stale connection before retrying so the next connect reaches the live daemon.
- Add regression coverage for both the pre-call isClosed path and the projects.add dropped-connection path before a read action.

## Validation
- npx vitest run src/main/services/localRuntime/localRuntimeConnectionPool.test.ts
- npm --prefix apps/desktop run typecheck
- npx eslint src/main/services/localRuntime/localRuntimeConnectionPool.ts src/main/services/localRuntime/localRuntimeConnectionPool.test.ts

ADE PR: https://ade-app.dev/open?type=pr&repo=arul28%2FADE&number=438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of local runtime connections with automatic reconnection handling. When a cached runtime connection drops or becomes unusable, the system now automatically retries project registration up to two times, ensuring smoother operation during temporary connection interruptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds retry logic to `ensureProject()` so a stale/closed daemon connection detected either before or during the `projects.add` call is transparently recovered from, matching the existing pattern already in `callActionForRootUncoalesced`.

- `ensureProject` now loops up to two times: on the first attempt it checks `isClosed()` before calling `projects.add`, and catches connection-dropped errors thrown during the call itself; on each failure it calls `resetActiveConnection` (which clears `this.connection` and `projectsByRoot`) and retries with a fresh connection.
- Two regression tests are added: one covering the `isClosed()` pre-call path and one covering the mid-`projects.add` drop path that then continues all the way through a successful `callActionForRoot`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the retry logic is narrowly scoped to connection-dropped errors, follows the identical pattern already used in callActionForRootUncoalesced, and both new regression tests pass end-to-end through a successful action call.

The change is a focused two-attempt retry loop that only activates on connection-dropped errors in ensureProject. resetActiveConnection correctly clears all shared state (this.connection, activeConnection, projectsByRoot) before each retry, so no stale data can leak across attempts. The existing callActionForRootUncoalesced retry loop interacts cleanly with this: if ensureProject exhausts its retries it throws immediately, and if ensureProject succeeds the action-call retry path continues to work as before.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts | Adds a 2-attempt retry loop to ensureProject() mirroring the existing isClosed/connection-drop handling in callActionForRootUncoalesced; resetActiveConnection correctly clears connection state and projectsByRoot before each retry. |
| apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts | Two new test cases cover the isClosed() pre-call path and the mid-call connection-drop path; both correctly mock createConnection to return fresh entries on retry and verify call counts, log events, and end-to-end results. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as callActionForRootUncoalesced
    participant EP as ensureProject
    participant Pool as ConnectionPool
    participant D1 as Daemon (stale)
    participant D2 as Daemon (fresh)

    C->>EP: ensureProject(rootPath)
    EP->>Pool: connect() → entry1 (stale)
    alt "isClosed() == true"
        EP->>Pool: resetActiveConnection(entry1)
        Note over EP: clears connection + projectsByRoot
    else projects.add drops
        EP->>D1: projects.add
        D1-->>EP: connection dropped
        EP->>Pool: resetActiveConnection(entry1)
    end
    EP->>Pool: connect() → entry2 (fresh)
    EP->>D2: projects.add
    D2-->>EP: project record
    EP-->>C: project (cached)
    C->>Pool: connect() → entry2 (same cached)
    C->>D2: ade/actions/call (projectId)
    D2-->>C: action result
```

<sub>Reviews (8): Last reviewed commit: ["Refs ADE-60: fix: document unreachable p..."](https://github.com/arul28/ade/commit/d144f9d4300b1c77c5a266f920bb5985d07d29aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34698323)</sub>

<!-- /greptile_comment -->