### PR TITLE
ADE-55: prs-updated event preserves stale conflictAnalysis; workflow-tab conflict badges never refresh between manual refreshes

### DIFF
--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
@@ -4,7 +4,19 @@ import React from "react";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AutoRebaseLaneStatus, PrAiSummary, PrConvergenceState, PrConvergenceStatePatch, PrDeployment, PrSnapshotHydration, PrSummary, PrWithConflicts, RebaseNeed } from "../../../../shared/types";
+import type {
+  AutoRebaseLaneStatus,
+  PrAiSummary,
+  PrConflictAnalysis,
+  PrConvergenceState,
+  PrConvergenceStatePatch,
+  PrDeployment,
+  PrEventPayload,
+  PrSnapshotHydration,
+  PrSummary,
+  PrWithConflicts,
+  RebaseNeed,
+} from "../../../../shared/types";
 import { PrsProvider, usePrs } from "./PrsContext";
 
 const originalAde = globalThis.window.ade;
@@ -71,6 +83,22 @@ function TabSwitchHarness() {
       </button>
       <div data-testid="loading">{loading ? "loading" : "idle"}</div>
       <div data-testid="active-tab">{activeTab}</div>
+    </div>
+  );
+}
+
+function ConflictRefreshHarness() {
+  const { activeTab, prs, setActiveTab, loading } = usePrs();
+  return (
+    <div>
+      <button type="button" onClick={() => setActiveTab("integration")}>
+        integration
+      </button>
+      <div data-testid="loading">{loading ? "loading" : "idle"}</div>
+      <div data-testid="active-tab">{activeTab}</div>
+      <div data-testid="conflict-risk">
+        {prs.map((pr) => `${pr.id}:${pr.conflictAnalysis?.riskLevel ?? "none"}`).join(",")}
+      </div>
     </div>
   );
 }
@@ -1196,6 +1224,72 @@ describe("PrsContext refresh", () => {
     expect(window.ade.prs.getMergeContext).toHaveBeenCalledWith("pr-2");
   });
 
+  it("refreshes workflow conflict analysis after prs-updated events", async () => {
+    const user = userEvent.setup();
+    let emitPrEvent: ((event: PrEventPayload) => void) | null = null;
+    const stalePr = makeFakePr("pr-1", {
+      conflictAnalysis: makeFakeConflictAnalysis("pr-1", {
+        riskLevel: "high",
+        overlapCount: 2,
+        conflictPredicted: true,
+      }),
+    });
+    const clearedPr = makeFakePr("pr-1", {
+      conflictAnalysis: makeFakeConflictAnalysis("pr-1", {
+        riskLevel: "none",
+        overlapCount: 0,
+        conflictPredicted: false,
+      }),
+    });
+    const eventPr = toPrSummary(makeFakePr("pr-1", { title: "Updated PR pr-1" }));
+    const conflictRefreshes = [[stalePr], [clearedPr]];
+    const listWithConflicts = vi.fn(async (args?: { includeConflictAnalysis?: boolean }) => {
+      if (args?.includeConflictAnalysis === true) {
+        return conflictRefreshes.shift() ?? [clearedPr];
+      }
+      return [makeFakePr("pr-1")];
+    });
+    Object.assign(window.ade.prs, {
+      listWithConflicts,
+      onEvent: vi.fn((cb: (event: PrEventPayload) => void) => {
+        emitPrEvent = cb;
+        return () => {};
+      }),
+    });
+
+    render(
+      <PrsProvider>
+        <ConflictRefreshHarness />
+      </PrsProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("idle");
+    });
+    expect(screen.getByTestId("conflict-risk").textContent).toBe("pr-1:none");
+
+    await user.click(screen.getByRole("button", { name: "integration" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-tab").textContent).toBe("integration");
+      expect(screen.getByTestId("conflict-risk").textContent).toBe("pr-1:high");
+    });
+
+    await act(async () => {
+      emitPrEvent?.({
+        type: "prs-updated",
+        polledAt: "2026-05-30T12:00:00.000Z",
+        prs: [eventPr],
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("conflict-risk").textContent).toBe("pr-1:none");
+    });
+    expect(listWithConflicts.mock.calls.filter(([args]) => args?.includeConflictAnalysis === true)).toHaveLength(2);
+  });
+
   it("hydrates the Rebase/Merge workflow selection from the initial hash route", async () => {
     window.location.hash = "#/prs?tab=workflows&workflow=rebase&laneId=lane-1";
 
@@ -1295,7 +1389,28 @@ function makeFakeConvergenceState(prId: string, overrides?: Partial<PrConvergenc
   };
 }
 
-function makeFakePr(id: string): PrWithConflicts {
+function makeFakeConflictAnalysis(
+  prId: string,
+  overrides: Partial<PrConflictAnalysis> = {},
+): PrConflictAnalysis {
+  return {
+    prId,
+    laneId: `lane-${prId}`,
+    riskLevel: "none",
+    overlapCount: 0,
+    conflictPredicted: false,
+    peerConflicts: [],
+    analyzedAt: "2026-05-30T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function toPrSummary(pr: PrWithConflicts): PrSummary {
+  const { conflictAnalysis: _conflictAnalysis, ...summary } = pr;
+  return summary;
+}
+
+function makeFakePr(id: string, overrides: Partial<PrWithConflicts> = {}): PrWithConflicts {
   return {
     id,
     laneId: `lane-${id}`,
@@ -1317,6 +1432,7 @@ function makeFakePr(id: string): PrWithConflicts {
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     conflictAnalysis: null,
+    ...overrides,
   };
 }
 

--- a/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
+++ b/apps/desktop/src/renderer/components/prs/state/PrsContext.tsx
@@ -750,6 +750,29 @@ export function PrsProvider({ active = true, children }: { active?: boolean; chi
     });
   }, []);
 
+  const conflictAnalysisRefreshSeq = React.useRef(0);
+  const refreshConflictAnalyses = useCallback(async () => {
+    const shouldRefreshConflictAnalysis = () => activeTabRef.current !== "normal";
+    if (!active || !shouldRefreshConflictAnalysis()) return;
+    const requestSeq = ++conflictAnalysisRefreshSeq.current;
+    try {
+      const refreshedPrs = await window.ade.prs.listWithConflicts({ includeConflictAnalysis: true });
+      if (requestSeq !== conflictAnalysisRefreshSeq.current || !shouldRefreshConflictAnalysis()) return;
+      const conflictAnalysisByPrId = new Map(
+        refreshedPrs.map((pr) => [pr.id, pr.conflictAnalysis] as const),
+      );
+      const next = prsRef.current.map((pr) => (
+        conflictAnalysisByPrId.has(pr.id)
+          ? { ...pr, conflictAnalysis: conflictAnalysisByPrId.get(pr.id) ?? null }
+          : pr
+      ));
+      prsRef.current = next;
+      setPrs((prev) => (jsonEqual(prev, next) ? prev : next));
+    } catch (err) {
+      console.warn("[PrsContext] Failed to refresh PR conflict analysis:", err);
+    }
+  }, [active]);
+
   // Track whether the initial data load has completed
   const initialLoadDone = React.useRef(Boolean(warmCache));
 
@@ -1462,6 +1485,12 @@ export function PrsProvider({ active = true, children }: { active?: boolean; chi
     void refreshMergeContexts(prIds);
   }, [active, activeTab, prs, refreshMergeContexts]);
 
+  const prsConflictRefreshKey = useMemo(() => prs.map((pr) => pr.id).sort().join("|"), [prs]);
+  useEffect(() => {
+    if (!active || activeTab === "normal" || prsConflictRefreshKey.length === 0) return;
+    void refreshConflictAnalyses();
+  }, [active, activeTab, prsConflictRefreshKey, refreshConflictAnalyses]);
+
   useEffect(() => {
     if (!active || activeTab === "normal") return;
     let cancelled = false;
@@ -1512,6 +1541,9 @@ export function PrsProvider({ active = true, children }: { active?: boolean; chi
 
         if (changedPrIds.length > 0) {
           void refreshMergeContexts(changedPrIds);
+          if (activeTabRef.current !== "normal") {
+            void refreshConflictAnalyses();
+          }
           const affectedQueueGroupIds = new Set<string>();
           for (const prId of changedPrIds) {
             const context = mergeContextByPrIdRef.current[prId];
@@ -1540,7 +1572,7 @@ export function PrsProvider({ active = true, children }: { active?: boolean; chi
     return () => {
       unsub();
     };
-  }, [active, refreshDetailSilently, refreshMergeContexts, refreshQueueStates]);
+  }, [active, refreshConflictAnalyses, refreshDetailSilently, refreshMergeContexts, refreshQueueStates]);
 
   // Subscribe to rebase events
   useEffect(() => {


### PR DESCRIPTION
Fixes ADE-55

## Summary
- Refresh PR conflict analysis when the PRs workflow tabs are active instead of preserving stale analysis from `prs-updated` summaries.
- Re-fetch conflict analysis after changed `prs-updated` events so Integration conflict badges can clear or update after peer PR state changes.
- Add a renderer regression test that emits a conflict-free `prs-updated` payload and verifies the workflow model refreshes from `listWithConflicts({ includeConflictAnalysis: true })`.

## Validation
- `npx vitest run src/renderer/components/prs/state/PrsContext.test.tsx`
- `npm --prefix apps/desktop run typecheck`
- `npx eslint src/renderer/components/prs/state/PrsContext.tsx src/renderer/components/prs/state/PrsContext.test.tsx` (passes with existing warnings in `PrsContext.tsx`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes stale conflict-analysis badges in the workflow/integration tabs by introducing `refreshConflictAnalyses` — a dedicated async refresh that re-fetches the full PR list with `includeConflictAnalysis: true` and surgically applies the new analyses to `prsRef.current`. A sequence counter guards against out-of-order responses.

- **Tab-switch refresh**: a `prsConflictRefreshKey` effect (keyed on sorted PR IDs) re-runs `refreshConflictAnalyses` whenever the active tab is non-normal or the PR-ID set changes, replacing the previous approach of relying solely on the last `applyLocalPrState` call.
- **Event-driven refresh**: the `prs-updated` handler now calls `refreshConflictAnalyses` when `changedPrIds.length > 0` and the current tab is non-normal, so peer-PR state changes clear or update conflict badges without a manual refresh.
- **Regression test**: a new renderer test emits a `prs-updated` payload after a tab switch and asserts that `listWithConflicts({ includeConflictAnalysis: true })` is called exactly twice and the badge transitions correctly from `high` → `none`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are narrowly scoped to conflict-analysis refresh logic and do not touch any data-mutation or auth paths.

The sequence-counter pattern correctly drops out-of-order responses; `prsRef.current` is always read after the await so the latest PR list is used; the `shouldRefreshConflictAnalysis()` guard prevents applying stale results after a tab switch back to normal; and the new test covers the primary scenario end-to-end.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/prs/state/PrsContext.tsx | Adds `refreshConflictAnalyses` with a monotonic sequence guard to prevent stale responses, wires it into the `prs-updated` event handler and a key-based effect; logic is correct and race-safe. |
| apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx | Adds `ConflictRefreshHarness`, helper factories (`makeFakeConflictAnalysis`, `toPrSummary`), and a new test that exercises the tab-switch and prs-updated refresh path end-to-end; flow-of-mocks is consistent with the implementation. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx`, line 1300-1304 ([link](https://github.com/arul28/ade/blob/8210586e81342fd122d2b090100c302d12912506/apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx#L1300-L1304)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Initial conflict-risk assertion is potentially order-dependent**

   After `waitFor(() => loading === "idle")`, the test immediately asserts `conflict-risk` is `"pr-1:none"`. At this point the initial `refreshCore` call has finished, but the `prsConflictRefreshKey` effect (with `active` and `refreshConflictAnalyses` in deps) will also fire on mount while `activeTab` is `"normal"`, so the guard returns early — that is safe. However, if the initial `applyLocalPrState` call were ever changed to load conflict analysis (e.g., `shouldLoadWorkflowState` becomes true at start), the mock's first `shift()` would be consumed here instead of on the tab-switch, and the subsequent `waitFor` for `"high"` would use the already-cleared PR. Pinning the assertion to the mock call count would make this more resilient.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/prs/state/PrsContext.test.tsx
   Line: 1300-1304

   Comment:
   **Initial conflict-risk assertion is potentially order-dependent**

   After `waitFor(() => loading === "idle")`, the test immediately asserts `conflict-risk` is `"pr-1:none"`. At this point the initial `refreshCore` call has finished, but the `prsConflictRefreshKey` effect (with `active` and `refreshConflictAnalyses` in deps) will also fire on mount while `activeTab` is `"normal"`, so the guard returns early — that is safe. However, if the initial `applyLocalPrState` call were ever changed to load conflict analysis (e.g., `shouldLoadWorkflowState` becomes true at start), the mock's first `shift()` would be consumed here instead of on the tab-switch, and the subsequent `waitFor` for `"high"` would use the already-cleared PR. Pinning the assertion to the mock call count would make this more resilient.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fprs%2Fstate%2FPrsContext.test.tsx%0ALine%3A%201300-1304%0A%0AComment%3A%0A**Initial%20conflict-risk%20assertion%20is%20potentially%20order-dependent**%0A%0AAfter%20%60waitFor%28%28%29%20%3D%3E%20loading%20%3D%3D%3D%20%22idle%22%29%60%2C%20the%20test%20immediately%20asserts%20%60conflict-risk%60%20is%20%60%22pr-1%3Anone%22%60.%20At%20this%20point%20the%20initial%20%60refreshCore%60%20call%20has%20finished%2C%20but%20the%20%60prsConflictRefreshKey%60%20effect%20%28with%20%60active%60%20and%20%60refreshConflictAnalyses%60%20in%20deps%29%20will%20also%20fire%20on%20mount%20while%20%60activeTab%60%20is%20%60%22normal%22%60%2C%20so%20the%20guard%20returns%20early%20%E2%80%94%20that%20is%20safe.%20However%2C%20if%20the%20initial%20%60applyLocalPrState%60%20call%20were%20ever%20changed%20to%20load%20conflict%20analysis%20%28e.g.%2C%20%60shouldLoadWorkflowState%60%20becomes%20true%20at%20start%29%2C%20the%20mock's%20first%20%60shift%28%29%60%20would%20be%20consumed%20here%20instead%20of%20on%20the%20tab-switch%2C%20and%20the%20subsequent%20%60waitFor%60%20for%20%60%22high%22%60%20would%20use%20the%20already-cleared%20PR.%20Pinning%20the%20assertion%20to%20the%20mock%20call%20count%20would%20make%20this%20more%20resilient.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=439&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Fix stale PR conflict badge refresh"](https://github.com/arul28/ade/commit/8d6acf81ff80a51e785a9b45c363c51e0ad7de1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34698324)</sub>

<!-- /greptile_comment -->