### PR TITLE
ADE-59: PR mergeable/conflict state read once without poll-until-known; conflicts-with-main is stale-clean right after a push

### DIFF
--- a/apps/desktop/src/main/services/prs/prService.test.ts
+++ b/apps/desktop/src/main/services/prs/prService.test.ts
@@ -110,6 +110,8 @@ function makePrRow(overrides?: Partial<Record<string, unknown>>) {
     review_status: "none",
     additions: 1,
     deletions: 1,
+    merge_conflicts: null,
+    behind_base_by: null,
     last_synced_at: null,
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-02T00:00:00Z",
@@ -366,6 +368,8 @@ function installPullRequestRowStore(db: ReturnType<typeof makeMockDb>, initialRo
       created_at: params[17],
       updated_at: params[18],
       creation_strategy: params[19] ?? null,
+      merge_conflicts: params[20] ?? null,
+      behind_base_by: params[21] ?? null,
     });
     return undefined;
   });
@@ -1310,6 +1314,94 @@ describe("prService.listWithConflicts", () => {
 
     expect(rows[0]?.conflictAnalysis).toBeNull();
     expect(conflictService.getBatchAssessment).not.toHaveBeenCalled();
+  });
+
+  it("includes cached GitHub mergeability fields in list rows", async () => {
+    const db = makeMockDb();
+    db.all.mockImplementation((sql: string) => {
+      if (String(sql).includes("from pull_requests")) {
+        return [makePrRow({ id: "pr-1", lane_id: "lane-pr", merge_conflicts: 1, behind_base_by: 3 })];
+      }
+      return [];
+    });
+    const { service } = buildService({ db });
+
+    const rows = await service.listWithConflicts();
+
+    expect(rows[0]).toEqual(expect.objectContaining({
+      mergeConflicts: true,
+      behindBaseBy: 3,
+      conflictAnalysis: null,
+    }));
+  });
+});
+
+describe("prService.getStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("polls unknown GitHub mergeability before reporting and caching conflicts", async () => {
+    vi.useFakeTimers();
+    try {
+      const row = makePrRow({ id: "pr-status", github_pr_number: 90 });
+      const db = makeMockDb();
+      installPullRequestRowStore(db, [row]);
+      let pullFetches = 0;
+      const githubService = makeGithubService({
+        apiRequest: vi.fn(async (args: { path: string }) => {
+          if (args.path === "/repos/test-owner/test-repo/pulls/90") {
+            pullFetches += 1;
+            return {
+              data: makeGitHubPull({
+                number: 90,
+                html_url: row.github_url,
+                title: row.title,
+                mergeable: pullFetches === 1 ? null : false,
+                mergeable_state: pullFetches === 1 ? "unknown" : "dirty",
+                head: { ref: "my-feature", sha: "head-sha" },
+                base: { ref: "main", sha: "base-sha" },
+              }),
+            };
+          }
+          if (args.path === "/repos/test-owner/test-repo/commits/head-sha/status") {
+            return { data: { state: "success", statuses: [] } };
+          }
+          if (args.path === "/repos/test-owner/test-repo/commits/head-sha/check-runs") {
+            return { data: { check_runs: [] } };
+          }
+          if (args.path === "/repos/test-owner/test-repo/pulls/90/reviews") {
+            return { data: [] };
+          }
+          if (args.path === "/repos/test-owner/test-repo/compare/base-sha...head-sha") {
+            return { data: { behind_by: 2 } };
+          }
+          throw new Error(`Unexpected GitHub API path: ${args.path}`);
+        }),
+      });
+      const { service } = buildService({ db, githubService });
+
+      const statusPromise = service.getStatus("pr-status");
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(500);
+      const status = await statusPromise;
+
+      expect(pullFetches).toBe(2);
+      expect(status).toEqual(expect.objectContaining({
+        mergeConflicts: true,
+        behindBaseBy: 2,
+        isMergeable: false,
+      }));
+      const updateCall = db.run.mock.calls.find(([sql]: [unknown]) =>
+        String(sql).includes("update pull_requests")
+        && String(sql).includes("merge_conflicts")
+        && String(sql).includes("behind_base_by")
+      );
+      const updateParams = updateCall?.[1] as unknown[] | undefined;
+      expect(updateParams?.slice(-6)).toEqual([1, 1, 1, 2, "pr-status", "proj-1"]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/apps/desktop/src/main/services/prs/prService.test.ts
+++ b/apps/desktop/src/main/services/prs/prService.test.ts
@@ -1456,6 +1456,63 @@ describe("prService.refresh", () => {
     });
   }
 
+  it("logs and caches pending mergeability when retries are exhausted", async () => {
+    vi.useFakeTimers();
+    try {
+      const row = makePrRow({ id: "pr-stale", github_pr_number: 90, merge_conflicts: 0 });
+      const db = makeMockDb();
+      installPullRequestRowStore(db, [row]);
+      const githubService = makeGithubService({
+        apiRequest: vi.fn(async (args: { path: string }) => {
+          if (args.path === "/repos/test-owner/test-repo/pulls/90") {
+            return {
+              data: makeGitHubPull({
+                number: 90,
+                html_url: row.github_url,
+                title: row.title,
+                mergeable: null,
+                mergeable_state: "unknown",
+                head: { ref: "my-feature", sha: "head-sha" },
+              }),
+            };
+          }
+          if (args.path === "/repos/test-owner/test-repo/commits/head-sha/status") {
+            return { data: { state: "success", statuses: [] } };
+          }
+          if (args.path === "/repos/test-owner/test-repo/commits/head-sha/check-runs") {
+            return { data: { check_runs: [] } };
+          }
+          if (args.path === "/repos/test-owner/test-repo/pulls/90/reviews") {
+            return { data: [] };
+          }
+          throw new Error(`Unexpected GitHub API path: ${args.path}`);
+        }),
+      });
+      const { service, logger } = buildService({ db, githubService });
+
+      const refreshPromise = service.refresh({ prId: "pr-stale" });
+      await flushMicrotasks();
+      await vi.advanceTimersByTimeAsync(3_500);
+      await refreshPromise;
+
+      expect(logger.warn).toHaveBeenCalledWith("prs.mergeability_poll_exhausted", {
+        repo: "test-owner/test-repo",
+        prNumber: 90,
+        attempts: 4,
+        mergeableState: "unknown",
+      });
+      const updateCall = db.run.mock.calls.find(([sql]: [unknown]) =>
+        String(sql).includes("update pull_requests")
+        && String(sql).includes("merge_conflicts")
+        && String(sql).includes("behind_base_by")
+      );
+      const updateParams = updateCall?.[1] as unknown[] | undefined;
+      expect(updateParams?.slice(-6)).toEqual([1, null, 0, null, "pr-stale", "proj-1"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps successful explicit PR refreshes when a sibling fails", async () => {
     const okRow = makePrRow({ id: "pr-ok", github_pr_number: 90 });
     const failingRow = makePrRow({ id: "pr-bad", github_pr_number: 91 });

--- a/apps/desktop/src/main/services/prs/prService.ts
+++ b/apps/desktop/src/main/services/prs/prService.ts
@@ -181,6 +181,8 @@ type PullRequestRow = {
   review_status: string | null;
   additions: number | null;
   deletions: number | null;
+  merge_conflicts?: number | null;
+  behind_base_by?: number | null;
   last_synced_at: string | null;
   created_at: string;
   updated_at: string;
@@ -607,6 +609,8 @@ function rowToSummary(row: PullRequestRow): PrSummary {
     reviewStatus: (row.review_status as PrReviewStatus) ?? "none",
     additions: Number(row.additions ?? 0),
     deletions: Number(row.deletions ?? 0),
+    mergeConflicts: rowMergeConflicts(row),
+    behindBaseBy: normalizeBehindBaseBy(row.behind_base_by),
     lastSyncedAt: row.last_synced_at ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -618,6 +622,44 @@ const BACKGROUND_REFRESH_MAX_PRS = 4;
 const REFRESH_CONCURRENCY = 4;
 const BACKGROUND_REFRESH_MIN_STALE_MS = 2 * 60_000;
 const BACKGROUND_REFRESH_CLOSED_STALE_MS = 15 * 60_000;
+const MERGEABILITY_POLL_DELAYS_MS = [500, 1_000, 2_000] as const;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function hasMergeabilityFields(pr: any): boolean {
+  return Boolean(pr) && ("mergeable" in pr || "mergeable_state" in pr);
+}
+
+function isMergeabilityPending(pr: any): boolean {
+  if (!hasMergeabilityFields(pr)) return false;
+  const mergeableState = asString(pr?.mergeable_state).trim().toLowerCase();
+  return mergeableState === "unknown" || (!mergeableState && pr?.mergeable == null);
+}
+
+function mergeConflictsFromPull(pr: any): boolean | null {
+  if (!hasMergeabilityFields(pr)) return null;
+  if (isMergeabilityPending(pr)) return null;
+  return asString(pr?.mergeable_state).trim().toLowerCase() === "dirty";
+}
+
+function rowMergeConflicts(row: PullRequestRow): boolean | null {
+  if (row.merge_conflicts == null) return null;
+  return Number(row.merge_conflicts) !== 0;
+}
+
+function normalizeMergeConflictsValue(value: boolean | null | undefined): number | null {
+  if (typeof value !== "boolean") return null;
+  return value ? 1 : 0;
+}
+
+function normalizeBehindBaseBy(value: number | null | undefined): number | null {
+  if (value == null) return null;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return null;
+  return Math.max(0, Math.trunc(numeric));
+}
 
 function parseIsoMs(value: string | null | undefined): number {
   if (!value) return 0;
@@ -657,7 +699,9 @@ function hasMaterialSummaryChange(row: PullRequestRow, summary: PrSummary): bool
     || row.github_url !== summary.githubUrl
     || (row.github_node_id ?? "") !== (summary.githubNodeId ?? "")
     || Number(row.additions ?? 0) !== Number(summary.additions ?? 0)
-    || Number(row.deletions ?? 0) !== Number(summary.deletions ?? 0);
+    || Number(row.deletions ?? 0) !== Number(summary.deletions ?? 0)
+    || (Object.prototype.hasOwnProperty.call(summary, "mergeConflicts") && rowMergeConflicts(row) !== (summary.mergeConflicts ?? null))
+    || (Object.prototype.hasOwnProperty.call(summary, "behindBaseBy") && normalizeBehindBaseBy(row.behind_base_by) !== normalizeBehindBaseBy(summary.behindBaseBy));
 }
 
 function parsePrLocator(raw: string): { owner?: string; repo?: string; number: number } {
@@ -886,7 +930,7 @@ export function createPrService({
   const PR_COLUMNS = `id, lane_id, project_id, repo_owner, repo_name, github_pr_number,
     github_url, github_node_id, title, state, base_branch, head_branch,
     checks_status, review_status, additions, deletions, last_synced_at,
-    created_at, updated_at, creation_strategy`;
+    created_at, updated_at, creation_strategy, merge_conflicts, behind_base_by`;
 
   const acquireLaneMutationLock = (args: {
     lane: LaneSummary;
@@ -1543,6 +1587,10 @@ export function createPrService({
     options?: { allowRepoPrAdoption?: boolean },
   ): string => {
     const now = nowIso();
+    const hasMergeConflicts = Object.prototype.hasOwnProperty.call(summary, "mergeConflicts");
+    const mergeConflictsValue = normalizeMergeConflictsValue(summary.mergeConflicts);
+    const hasBehindBaseBy = Object.prototype.hasOwnProperty.call(summary, "behindBaseBy");
+    const behindBaseByValue = normalizeBehindBaseBy(summary.behindBaseBy);
     // By default we only adopt an existing row that is already associated with
     // this lane. Callers like `linkToLane`/`refreshOne` must not silently
     // reassign an existing PR row from another lane just because the repo/PR
@@ -1580,7 +1628,9 @@ export function createPrService({
                  deletions = ?,
                  last_synced_at = ?,
                  updated_at = ?,
-                 creation_strategy = coalesce(?, creation_strategy)
+                 creation_strategy = coalesce(?, creation_strategy),
+                 merge_conflicts = case when ? then ? else merge_conflicts end,
+                 behind_base_by = case when ? then ? else behind_base_by end
            where id = ? and project_id = ?
         `,
         [
@@ -1601,6 +1651,10 @@ export function createPrService({
           summary.lastSyncedAt,
           summary.updatedAt ?? now,
           summary.creationStrategy ?? null,
+          hasMergeConflicts ? 1 : 0,
+          mergeConflictsValue,
+          hasBehindBaseBy ? 1 : 0,
+          behindBaseByValue,
           existing.id,
           projectId,
         ]
@@ -1630,8 +1684,10 @@ export function createPrService({
           last_synced_at,
           created_at,
           updated_at,
-          creation_strategy
-        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          creation_strategy,
+          merge_conflicts,
+          behind_base_by
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
       [
         summary.id,
@@ -1653,7 +1709,9 @@ export function createPrService({
         summary.lastSyncedAt,
         summary.createdAt ?? now,
         summary.updatedAt ?? now,
-        summary.creationStrategy ?? null
+        summary.creationStrategy ?? null,
+        mergeConflictsValue,
+        behindBaseByValue
       ]
     );
     return summary.id;
@@ -2072,12 +2130,29 @@ export function createPrService({
     throw new Error(`Push failed for "${headBranch}".${detail ? ` ${detail}` : ""}`);
   };
 
-  const fetchPr = async (repo: GitHubRepoRef, prNumber: number): Promise<any> => {
+  const fetchPr = async (
+    repo: GitHubRepoRef,
+    prNumber: number,
+    options: { waitForKnownMergeability?: boolean } = {},
+  ): Promise<any> => {
     const { data } = await githubService.apiRequest<any>({
       method: "GET",
       path: `/repos/${repo.owner}/${repo.name}/pulls/${prNumber}`
     });
-    return data;
+    if (!options.waitForKnownMergeability || !isMergeabilityPending(data)) {
+      return data;
+    }
+    let latest = data;
+    for (const delayMs of MERGEABILITY_POLL_DELAYS_MS) {
+      await delay(delayMs);
+      const next = await githubService.apiRequest<any>({
+        method: "GET",
+        path: `/repos/${repo.owner}/${repo.name}/pulls/${prNumber}`
+      });
+      latest = next.data;
+      if (!isMergeabilityPending(latest)) break;
+    }
+    return latest;
   };
 
   const createLaneFromPrBranchBlock = (
@@ -2845,14 +2920,17 @@ export function createPrService({
     if (!row) throw new Error(`PR not found: ${prId}`);
     const repo = { owner: row.repo_owner, name: row.repo_name };
 
-    const pr = await fetchPr(repo, Number(row.github_pr_number));
+    const pr = await fetchPr(repo, Number(row.github_pr_number), { waitForKnownMergeability: true });
     const headSha = asString(pr?.head?.sha);
+    const baseSha = asString(pr?.base?.sha);
+    const mergeConflicts = mergeConflictsFromPull(pr);
     const requestedReviewers = Array.isArray(pr?.requested_reviewers) ? pr.requested_reviewers.map((u: any) => asString(u?.login)).filter(Boolean) : [];
 
-    const [combinedStatus, checkRuns, reviews] = await Promise.all([
+    const [combinedStatus, checkRuns, reviews, compare] = await Promise.all([
       headSha ? fetchCombinedStatus(repo, headSha) : Promise.resolve({ state: "", statuses: [] }),
       headSha ? fetchCheckRuns(repo, headSha).catch((err) => { console.warn("[prService] fetchCheckRuns failed in refreshOne:", err?.message ?? err); return []; }) : Promise.resolve([]),
-      fetchReviews(repo, Number(row.github_pr_number)).catch(() => [])
+      fetchReviews(repo, Number(row.github_pr_number)).catch(() => []),
+      baseSha && headSha ? fetchCompare(repo, baseSha, headSha).catch(() => ({ behindBy: null as number | null })) : Promise.resolve({ behindBy: null as number | null })
     ]);
     const reviewStatesByUser = new Map<string, string>();
     for (const review of reviews) {
@@ -2891,11 +2969,15 @@ export function createPrService({
       reviewStatus,
       additions,
       deletions,
+      mergeConflicts,
       lastSyncedAt: nowIso(),
       createdAt: row.created_at,
       updatedAt: asString(pr?.updated_at) || row.updated_at || nowIso(),
       creationStrategy: normalizePrCreationStrategy(row.creation_strategy)
     };
+    if (compare.behindBy != null) {
+      updated.behindBaseBy = compare.behindBy;
+    }
 
     if (hasMaterialSummaryChange(row, updated)) {
       invalidateGithubSnapshotCache();
@@ -2961,11 +3043,10 @@ export function createPrService({
 
   const computeStatus = async (summary: PrSummary): Promise<PrStatus> => {
     const repo: GitHubRepoRef = { owner: summary.repoOwner, name: summary.repoName };
-    const pr = await fetchPr(repo, summary.githubPrNumber);
+    const pr = await fetchPr(repo, summary.githubPrNumber, { waitForKnownMergeability: true });
     const headSha = asString(pr?.head?.sha);
     const baseSha = asString(pr?.base?.sha);
-    const mergeableState = asString(pr?.mergeable_state);
-    const mergeConflicts = mergeableState.toLowerCase() === "dirty";
+    const mergeConflicts = mergeConflictsFromPull(pr);
 
     const [combinedStatus, checkRuns, reviews, compare] = await Promise.all([
       headSha ? fetchCombinedStatus(repo, headSha) : Promise.resolve({ state: "", statuses: [] }),
@@ -2989,6 +3070,7 @@ export function createPrService({
     const checksStatus = toChecksStatusFromCheckRuns(checkRuns) ?? toChecksStatus(combinedStatus.state);
     const reviewStatus = computeReviewStatus({ requestedReviewers, reviewStatesByUser });
     const isMergeable = Boolean(pr?.mergeable) && checksStatus !== "failing" && reviewStatus !== "changes_requested";
+    const behindBaseBy = compare.behindBy;
 
     const refreshed: PrSummary = {
       ...summary,
@@ -2997,6 +3079,8 @@ export function createPrService({
       reviewStatus,
       additions: Number(pr?.additions ?? summary.additions),
       deletions: Number(pr?.deletions ?? summary.deletions),
+      mergeConflicts,
+      behindBaseBy,
       lastSyncedAt: nowIso(),
       updatedAt: nowIso()
     };
@@ -3008,8 +3092,8 @@ export function createPrService({
       checksStatus,
       reviewStatus,
       isMergeable,
-      mergeConflicts,
-      behindBaseBy: compare.behindBy
+      mergeConflicts: mergeConflicts === true,
+      behindBaseBy
     };
   };
 

--- a/apps/desktop/src/main/services/prs/prService.ts
+++ b/apps/desktop/src/main/services/prs/prService.ts
@@ -2152,6 +2152,14 @@ export function createPrService({
       latest = next.data;
       if (!isMergeabilityPending(latest)) break;
     }
+    if (isMergeabilityPending(latest)) {
+      logger.warn("prs.mergeability_poll_exhausted", {
+        repo: `${repo.owner}/${repo.name}`,
+        prNumber,
+        attempts: MERGEABILITY_POLL_DELAYS_MS.length + 1,
+        mergeableState: asString(latest?.mergeable_state) || null,
+      });
+    }
     return latest;
   };
 
@@ -2969,6 +2977,8 @@ export function createPrService({
       reviewStatus,
       additions,
       deletions,
+      // Unknown mergeability is cached as null so list views show pending
+      // instead of stale clean/dirty status after GitHub times out.
       mergeConflicts,
       lastSyncedAt: nowIso(),
       createdAt: row.created_at,

--- a/apps/desktop/src/main/services/state/kvDb.ts
+++ b/apps/desktop/src/main/services/state/kvDb.ts
@@ -1701,6 +1701,8 @@ function migrate(db: MigrationDb) {
   try { db.run("alter table pull_requests add column last_polled_at text"); } catch {}
   try { db.run("alter table pull_requests add column head_sha text"); } catch {}
   try { db.run("alter table pull_requests add column creation_strategy text"); } catch {}
+  try { db.run("alter table pull_requests add column merge_conflicts integer"); } catch {}
+  try { db.run("alter table pull_requests add column behind_base_by integer"); } catch {}
 
   db.run("drop table if exists github_pr_cache");
 

--- a/apps/desktop/src/shared/types/prs.ts
+++ b/apps/desktop/src/shared/types/prs.ts
@@ -36,6 +36,8 @@ export type PrSummary = {
   reviewStatus: PrReviewStatus;
   additions: number;
   deletions: number;
+  mergeConflicts?: boolean | null;
+  behindBaseBy?: number | null;
   lastSyncedAt: string | null;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
Fixes ADE-59
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-59: PR mergeable/conflict state read once without poll-until-known; conflicts-with-main is stale-clean right after a push](https://linear.app/ade-linear/issue/ADE-59/pr-mergeableconflict-state-read-once-without-poll-until-known) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-59-pr-mergeable-conflict-state-read-once-without-poll-until-known-conflicts-with-main-is-stale-clean-right-after-a-push num=440 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-59-pr-mergeable-conflict-state-read-once-without-poll-until-known-conflicts-with-main-is-stale-clean-right-after-a-push&amp;pr=440">ade-59-pr-mergeable-conflict-state-read-once-without-poll-until-known-conflicts-with-main-is-stale-clean-right-after-a-push branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=440">PR #440</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes ADE-59 by adding a poll-until-known loop inside `fetchPr` so that mergeability state is resolved before being cached, preventing stale \"clean\" status immediately after a push. It also persists `merge_conflicts` and `behind_base_by` in the database for the first time, so list views can show a cached conflict state without waiting for a live API call.

- Added `isMergeabilityPending`/`mergeConflictsFromPull` helpers and a 3-attempt poll loop (500 ms → 1 s → 2 s) with `logger.warn(\"prs.mergeability_poll_exhausted\")` when retries are exhausted; null is stored so list views show \"pending\" rather than stale data.
- Two new DB columns (`merge_conflicts`, `behind_base_by`) are added via additive `ALTER TABLE` migration; the upsert uses a `CASE WHEN` flag pattern so fields are only overwritten when the caller explicitly supplies them.
- `refreshOne` and `computeStatus` both now pass `waitForKnownMergeability: true`; targeted tests cover the poll-resolved path and the retry-exhaustion path.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the polling and null-caching behavior; one outstanding write-path asymmetry between refreshOne and computeStatus in how a fetchCompare failure is persisted has been called out in a prior review and remains unaddressed.

The poll loop, warn logging, DB migration, and CASE WHEN upsert pattern are all correct and well-tested. The one concern is that computeStatus's fetchCompare error catch still returns {behindBy: 0} — now that behind_base_by is unconditionally written to the DB from that path, a transient compare failure during a user-triggered status check silently zeros out whatever was previously cached, while the equivalent background path (refreshOne) correctly skips the write on failure.

apps/desktop/src/main/services/prs/prService.ts — the fetchCompare catch value in computeStatus and how behindBaseBy is unconditionally written to the DB from that path.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/prs/prService.ts | Core logic: adds poll-until-known loop in fetchPr, caches merge_conflicts/behind_base_by via CASE WHEN SQL, and propagates mergeConflictsFromPull through refreshOne and computeStatus. The refreshOne catch correctly uses {behindBy: null} to preserve cached values, but computeStatus's fetchCompare catch still returns {behindBy: 0} while behindBaseBy is now unconditionally written to DB. |
| apps/desktop/src/main/services/prs/prService.test.ts | Adds three new test cases: cached fields in listWithConflicts, poll-resolved path in getStatus, and retry-exhaustion path in refresh. Test timer handling with vi.useFakeTimers/advanceTimersByTimeAsync is correct. |
| apps/desktop/src/main/services/state/kvDb.ts | Adds two additive ALTER TABLE migrations for merge_conflicts and behind_base_by inside try/catch blocks, consistent with the existing migration pattern. |
| apps/desktop/src/shared/types/prs.ts | Adds optional mergeConflicts?: boolean | null and behindBaseBy?: number | null to PrSummary. PrStatus fields remain non-optional, preserving existing consumers. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/main/services/prs/prService.ts`, line 3065 ([link](https://github.com/arul28/ade/blob/9ec82117fd287b05055dac40ad67888c5d62feff/apps/desktop/src/main/services/prs/prService.ts#L3065)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`fetchCompare` failure overwrites `behind_base_by` with 0 in DB**

   When `fetchCompare` throws in `computeStatus`, the catch returns `{ behindBy: 0 }`. Since `behindBaseBy` is then an explicit key in the `refreshed` object literal, `upsertRow` always treats it as a write — the `CASE WHEN` guard fires with flag `1`, and whatever was previously cached in `behind_base_by` (e.g. 5) gets overwritten with 0.

   `refreshOne` handles this correctly by using `null` as the catch value and conditionally setting the field only when it's non-null. A user opening the PR status panel during a transient GitHub compare failure would silently zero out the behind-by count in the DB, making the list view show "up to date" until the next successful background refresh.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/prs/prService.ts
   Line: 3065

   Comment:
   **`fetchCompare` failure overwrites `behind_base_by` with 0 in DB**

   When `fetchCompare` throws in `computeStatus`, the catch returns `{ behindBy: 0 }`. Since `behindBaseBy` is then an explicit key in the `refreshed` object literal, `upsertRow` always treats it as a write — the `CASE WHEN` guard fires with flag `1`, and whatever was previously cached in `behind_base_by` (e.g. 5) gets overwritten with 0.

   `refreshOne` handles this correctly by using `null` as the catch value and conditionally setting the field only when it's non-null. A user opening the PR status panel during a transient GitHub compare failure would silently zero out the behind-by count in the DB, making the list view show "up to date" until the next successful background refresh.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fprs%2FprService.ts%0ALine%3A%203065%0A%0AComment%3A%0A**%60fetchCompare%60%20failure%20overwrites%20%60behind_base_by%60%20with%200%20in%20DB**%0A%0AWhen%20%60fetchCompare%60%20throws%20in%20%60computeStatus%60%2C%20the%20catch%20returns%20%60%7B%20behindBy%3A%200%20%7D%60.%20Since%20%60behindBaseBy%60%20is%20then%20an%20explicit%20key%20in%20the%20%60refreshed%60%20object%20literal%2C%20%60upsertRow%60%20always%20treats%20it%20as%20a%20write%20%E2%80%94%20the%20%60CASE%20WHEN%60%20guard%20fires%20with%20flag%20%601%60%2C%20and%20whatever%20was%20previously%20cached%20in%20%60behind_base_by%60%20%28e.g.%205%29%20gets%20overwritten%20with%200.%0A%0A%60refreshOne%60%20handles%20this%20correctly%20by%20using%20%60null%60%20as%20the%20catch%20value%20and%20conditionally%20setting%20the%20field%20only%20when%20it's%20non-null.%20A%20user%20opening%20the%20PR%20status%20panel%20during%20a%20transient%20GitHub%20compare%20failure%20would%20silently%20zero%20out%20the%20behind-by%20count%20in%20the%20DB%2C%20making%20the%20list%20view%20show%20%22up%20to%20date%22%20until%20the%20next%20successful%20background%20refresh.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20baseSha%20%26%26%20headSha%20%3F%20fetchCompare%28repo%2C%20baseSha%2C%20headSha%29.catch%28%28%29%20%3D%3E%20%28%7B%20behindBy%3A%20null%20as%20number%20%7C%20null%20%7D%29%29%20%3A%20Promise.resolve%28%7B%20behindBy%3A%20null%20as%20number%20%7C%20null%20%7D%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=440&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["fix: log exhausted PR mergeability polli..."](https://github.com/arul28/ade/commit/501d4bbf04247eb5f6803bf0f1f56e77af01d2fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34698404)</sub>

<!-- /greptile_comment -->