### PR TITLE
Ui Fix For Cli In Grid View

### DIFF
--- a/apps/desktop/src/renderer/components/terminals/CliSessionWorkSurfaceHeader.tsx
+++ b/apps/desktop/src/renderer/components/terminals/CliSessionWorkSurfaceHeader.tsx
@@ -6,6 +6,7 @@ import { openLaneInLanesTabPath } from "../../lib/laneNavigation";
 import { shouldShowClaudeCacheTtl } from "../../lib/claudeCacheTtl";
 import { formatToolTypeLabel, primarySessionLabel, truncateSessionLabel } from "../../lib/sessions";
 import { sessionStatusDot } from "../../lib/terminalAttention";
+import { ChatGitToolbar } from "../chat/ChatGitToolbar";
 import { getLaneAccent } from "../lanes/laneColorPalette";
 import { QuickRunMenu } from "../run/QuickRunMenu";
 import { SmartTooltip } from "../ui/SmartTooltip";
@@ -15,6 +16,11 @@ import {
   WORK_SURFACE_HEADER_ACTION_IDLE,
   WorkSurfaceHeader,
 } from "../work/WorkSurfaceHeader";
+
+type SessionMouseHandler = (
+  session: TerminalSessionSummary,
+  event: ReactMouseEvent<HTMLElement>,
+) => void;
 
 /**
  * Maps a TerminalSessionSummary's toolType onto the "provider" enum
@@ -38,9 +44,117 @@ function statusForCacheBadgeGate(
   };
 }
 
+/** Small runtime-state dot (running / awaiting input / ended) shared across CLI session headers. */
+function SessionStatusDot({ session }: { session: TerminalSessionSummary }) {
+  const dot = sessionStatusDot(session);
+  return (
+    <span
+      aria-hidden
+      title={dot.label}
+      className={cn(
+        "h-1.5 w-1.5 shrink-0 rounded-full",
+        dot.cls,
+        dot.spinning && "animate-spin",
+      )}
+    />
+  );
+}
+
+/** Red stop button — only rendered while a PTY-backed session is actually running. */
+function StopSessionButton({
+  session,
+  stopping = false,
+  onStopRunningSession,
+}: {
+  session: TerminalSessionSummary;
+  stopping?: boolean;
+  onStopRunningSession?: (session: TerminalSessionSummary) => void;
+}) {
+  const canStop = session.status === "running" && Boolean(session.ptyId) && Boolean(onStopRunningSession);
+  if (!canStop) return null;
+  return (
+    <SmartTooltip content={{ label: stopping ? "Stopping…" : "Stop session", description: "Terminate the running session." }}>
+      <button
+        type="button"
+        className={cn(WORK_SURFACE_HEADER_ACTION_BASE, "px-1.5 text-red-300/70 hover:text-red-200")}
+        onClick={() => onStopRunningSession?.(session)}
+        aria-label="Stop session"
+        disabled={stopping}
+      >
+        <StopCircle size={14} weight="regular" />
+      </button>
+    </SmartTooltip>
+  );
+}
+
+/** Lane-scoped Run dropdown — only rendered when the session belongs to a lane. */
+function SessionRunMenu({ session }: { session: TerminalSessionSummary }) {
+  if (!session.laneId) return null;
+  return (
+    <QuickRunMenu
+      laneId={session.laneId}
+      compact
+      label="Run"
+      align="end"
+      triggerStyle={{ height: 24, padding: "0 8px" }}
+    />
+  );
+}
+
+function SessionInfoButton({
+  session,
+  onInfoClick,
+}: {
+  session: TerminalSessionSummary;
+  onInfoClick?: SessionMouseHandler;
+}) {
+  return (
+    <SmartTooltip
+      content={{ label: "Session info", description: "Open metadata and session actions." }}
+    >
+      <button
+        type="button"
+        className={cn(WORK_SURFACE_HEADER_ACTION_BASE, WORK_SURFACE_HEADER_ACTION_IDLE, "px-1.5")}
+        onClick={(event) => onInfoClick?.(session, event)}
+        aria-label="Session info"
+        disabled={!onInfoClick}
+      >
+        <Info size={13} />
+      </button>
+    </SmartTooltip>
+  );
+}
+
+function SessionActionsButton({
+  session,
+  onContextMenu,
+}: {
+  session: TerminalSessionSummary;
+  onContextMenu?: SessionMouseHandler;
+}) {
+  return (
+    <SmartTooltip
+      content={{
+        label: "Session actions",
+        description: "Rename, pin, copy links, archive, or delete this session.",
+      }}
+    >
+      <button
+        type="button"
+        className={cn(WORK_SURFACE_HEADER_ACTION_BASE, WORK_SURFACE_HEADER_ACTION_IDLE, "px-1.5")}
+        onClick={(event) => onContextMenu?.(session, event)}
+        aria-label="Session actions"
+        disabled={!onContextMenu}
+      >
+        <DotsThreeVertical size={14} weight="bold" />
+      </button>
+    </SmartTooltip>
+  );
+}
+
 /**
  * Trailing-action set rendered to the right of every CLI session header. Kept
- * intentionally light: lane-scoped Run dropdown, an Info button, and the
+ * intentionally light: Stop, a lane-scoped Run dropdown, an Info button, and the
  * session kebab. The chat surface owns its much larger action set (Simulator,
  * App Control, Browser, Chat actions, terminal, delete, etc.) inline in
  * AgentChatPane.
@@ -54,65 +168,48 @@ export function CliSurfaceTrailingActions({
 }: {
   session: TerminalSessionSummary;
   stopping?: boolean;
-  onInfoClick?: (session: TerminalSessionSummary, event: ReactMouseEvent<HTMLElement>) => void;
-  onContextMenu?: (session: TerminalSessionSummary, event: ReactMouseEvent<HTMLElement>) => void;
+  onInfoClick?: SessionMouseHandler;
+  onContextMenu?: SessionMouseHandler;
   onStopRunningSession?: (session: TerminalSessionSummary) => void;
 }) {
-  const canStop = session.status === "running" && Boolean(session.ptyId) && Boolean(onStopRunningSession);
   return (
     <>
-      {canStop ? (
-        <SmartTooltip content={{ label: stopping ? "Stopping…" : "Stop session", description: "Terminate the running session." }}>
-          <button
-            type="button"
-            className={cn(WORK_SURFACE_HEADER_ACTION_BASE, "px-1.5 text-red-300/70 hover:text-red-200")}
-            onClick={() => onStopRunningSession?.(session)}
-            aria-label="Stop session"
-            disabled={stopping}
-          >
-            <StopCircle size={14} weight="regular" />
-          </button>
-        </SmartTooltip>
-      ) : null}
-      {session.laneId ? (
-        <QuickRunMenu
-          laneId={session.laneId}
-          compact
-          label="Run"
-          align="end"
-          triggerStyle={{ height: 24, padding: "0 8px" }}
-        />
-      ) : null}
-      <SmartTooltip
-        content={{ label: "Session info", description: "Open metadata and session actions." }}
-      >
-        <button
-          type="button"
-          className={cn(WORK_SURFACE_HEADER_ACTION_BASE, WORK_SURFACE_HEADER_ACTION_IDLE, "px-1.5")}
-          onClick={(event) => onInfoClick?.(session, event)}
-          aria-label="Session info"
-          disabled={!onInfoClick}
-        >
-          <Info size={13} />
-        </button>
-      </SmartTooltip>
-      <SmartTooltip
-        content={{
-          label: "Session actions",
-          description: "Rename, pin, copy links, archive, or delete this session.",
-        }}
-      >
-        <button
-          type="button"
-          className={cn(WORK_SURFACE_HEADER_ACTION_BASE, WORK_SURFACE_HEADER_ACTION_IDLE, "px-1.5")}
-          onClick={(event) => onContextMenu?.(session, event)}
-          aria-label="Session actions"
-          disabled={!onContextMenu}
-        >
-          <DotsThreeVertical size={14} weight="bold" />
-        </button>
-      </SmartTooltip>
+      <StopSessionButton session={session} stopping={stopping} onStopRunningSession={onStopRunningSession} />
+      <SessionRunMenu session={session} />
+      <SessionInfoButton session={session} onInfoClick={onInfoClick} />
+      <SessionActionsButton session={session} onContextMenu={onContextMenu} />
     </>
+  );
+}
+
+/**
+ * Consolidated action cluster for a CLI session's grid tile. The grid tile's
+ * lane-colored FloatingPane header now carries everything the old secondary
+ * header did, so this folds those controls into a single row in order:
+ * PR chip → Stop → status dot → Run → Info → kebab.
+ */
+export function GridTileSessionHeaderActions({
+  session,
+  stopping = false,
+  onInfoClick,
+  onContextMenu,
+  onStopRunningSession,
+}: {
+  session: TerminalSessionSummary;
+  stopping?: boolean;
+  onInfoClick?: SessionMouseHandler;
+  onContextMenu?: SessionMouseHandler;
+  onStopRunningSession?: (session: TerminalSessionSummary) => void;
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      {session.laneId ? <ChatGitToolbar laneId={session.laneId} /> : null}
+      <StopSessionButton session={session} stopping={stopping} onStopRunningSession={onStopRunningSession} />
+      <SessionStatusDot session={session} />
+      <SessionRunMenu session={session} />
+      <SessionInfoButton session={session} onInfoClick={onInfoClick} />
+      <SessionActionsButton session={session} onContextMenu={onContextMenu} />
+    </div>
   );
 }
 
@@ -120,7 +217,9 @@ export function CliSurfaceTrailingActions({
  * Adapts a TerminalSessionSummary into the unified WorkSurfaceHeader. Replaces
  * the legacy WorkCliSessionHeader so CLI surfaces and ADE chats share the same
  * visual shell (title + lane chip + cache badge + git toolbar) and only diverge
- * in their trailing actions.
+ * in their trailing actions. In grid view this header is consolidated into the
+ * tile's FloatingPane header (see GridTileSessionHeaderActions); the standard
+ * (tabs) surface still renders it inline.
  */
 export function CliSessionWorkSurfaceHeader({
   session,
@@ -135,15 +234,14 @@ export function CliSessionWorkSurfaceHeader({
   lanes: LaneSummary[];
   compact?: boolean;
   stopping?: boolean;
-  onInfoClick?: (session: TerminalSessionSummary, event: ReactMouseEvent<HTMLElement>) => void;
-  onContextMenu?: (session: TerminalSessionSummary, event: ReactMouseEvent<HTMLElement>) => void;
+  onInfoClick?: SessionMouseHandler;
+  onContextMenu?: SessionMouseHandler;
   onStopRunningSession?: (session: TerminalSessionSummary) => void;
 }) {
   const navigate = useNavigate();
   const lane = lanes.find((entry) => entry.id === session.laneId) ?? null;
   const laneAccent = getLaneAccent(lane, 0);
   const toolLabel = formatToolTypeLabel(session.toolType);
-  const dot = sessionStatusDot(session);
   const title = truncateSessionLabel(primarySessionLabel(session), compact ? 24 : 44);
   const cacheGate = statusForCacheBadgeGate(session);
   const cacheProvider = providerForCacheBadgeGate(session.toolType);
@@ -173,15 +271,7 @@ export function CliSessionWorkSurfaceHeader({
       showGitToolbar
       trailingActions={
         <>
-          <span
-            aria-hidden
-            title={dot.label}
-            className={cn(
-              "h-1.5 w-1.5 shrink-0 rounded-full",
-              dot.cls,
-              dot.spinning && "animate-spin",
-            )}
-          />
+          <SessionStatusDot session={session} />
           <CliSurfaceTrailingActions
             session={session}
             stopping={stopping}

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.test.tsx
@@ -76,6 +76,9 @@ vi.mock("./CliSessionWorkSurfaceHeader", () => ({
     <div data-testid="work-cli-session-header" data-session-id={session.id} />
   ),
   CliSurfaceTrailingActions: () => null,
+  GridTileSessionHeaderActions: ({ session }: { session: TerminalSessionSummary }) => (
+    <div data-testid="grid-tile-session-header-actions" data-session-id={session.id} />
+  ),
 }));
 
 vi.mock("../chat/AgentChatPane", async () => {

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
@@ -40,7 +40,7 @@ import { AgentChatPane, type AgentChatSessionCreatedOptions } from "../chat/Agen
 import { ChatCommandMenu, handleCommandMenuKeyDown, type ChatCommandMenuHandle, type ChatCommandMenuItem } from "../chat/ChatCommandMenu";
 import { ChatComposerShell } from "../chat/ChatComposerShell";
 import { WorkStartSurface } from "./WorkStartSurface";
-import { CliSessionWorkSurfaceHeader } from "./CliSessionWorkSurfaceHeader";
+import { CliSessionWorkSurfaceHeader, GridTileSessionHeaderActions } from "./CliSessionWorkSurfaceHeader";
 import { isChatToolType, primarySessionLabel, stripTerminalLabelControls, truncateSessionLabel, formatToolTypeLabel } from "../../lib/sessions";
 import { sessionNeedsChatTabHighlight, sessionStatusDot } from "../../lib/terminalAttention";
 import type { WorkTabGroup } from "./useWorkSessions";
@@ -52,7 +52,6 @@ import { launchProfileForTerminalSession, type WorkPtyLaunchArgs, type WorkPtyLa
 import { buildWorkSessionTilingTree, type TilingPreset } from "./workSessionTiling";
 import { laneSurfaceTint } from "../lanes/laneDesignTokens";
 import { useWorkLaneContextMenu } from "./useWorkLaneContextMenu";
-import { branchNameFromRef } from "../prs/shared/laneBranchTargets";
 
 function isSessionAwaitingInput(session: TerminalSessionSummary): boolean {
   return sessionNeedsChatTabHighlight({
@@ -538,13 +537,14 @@ function ClosedCliSessionSurface({
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-card">
-      <CliSessionWorkSurfaceHeader
-        session={session}
-        lanes={lanes}
-        compact={layoutVariant === "grid-tile"}
-        onInfoClick={onInfoClick}
-        onContextMenu={onContextMenu}
-      />
+      {layoutVariant !== "grid-tile" ? (
+        <CliSessionWorkSurfaceHeader
+          session={session}
+          lanes={lanes}
+          onInfoClick={onInfoClick}
+          onContextMenu={onContextMenu}
+        />
+      ) : null}
       <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden px-4 py-3">
         <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-white/[0.06] pb-3">
           <div className="min-w-0">
@@ -638,15 +638,16 @@ function SessionSurface({
     if (isAgentCliSession(session)) {
       return (
         <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
-          <CliSessionWorkSurfaceHeader
-            session={session}
-            lanes={lanes}
-            compact={layoutVariant === "grid-tile"}
-            stopping={stopping}
-            onInfoClick={onInfoClick}
-            onContextMenu={onContextMenu}
-            onStopRunningSession={onStopRunningSession}
-          />
+          {layoutVariant !== "grid-tile" ? (
+            <CliSessionWorkSurfaceHeader
+              session={session}
+              lanes={lanes}
+              stopping={stopping}
+              onInfoClick={onInfoClick}
+              onContextMenu={onContextMenu}
+              onStopRunningSession={onStopRunningSession}
+            />
+          ) : null}
           <TerminalView
             key={session.id}
             ptyId={session.ptyId}
@@ -1311,12 +1312,6 @@ export function WorkViewArea({
     return map;
   }, [lanes]);
 
-  const laneBranchById = useMemo(() => {
-    const map = new Map<string, string | null>();
-    for (const lane of lanes) map.set(lane.id, lane.branchRef);
-    return map;
-  }, [lanes]);
-
   const tabVisibleSessions = useMemo(
     () => (tabVisibleSessionIds ?? visibleSessions.map((session) => session.id))
       .map((sessionId) => sessionsById.get(sessionId))
@@ -1356,6 +1351,7 @@ export function WorkViewArea({
     visibleSessions.map((session) => {
       const dot = sessionStatusDot(session);
       const isBusy = session.ptyId ? closingPtyIds.has(session.ptyId) : false;
+      const isCliAgentSession = isAgentCliSession(session);
       const isActive = activeItemId === session.id;
       const rawLaneColor = laneColorById.get(session.laneId) ?? null;
       const laneAccentColor = rawLaneColor?.trim() ? rawLaneColor.trim() : null;
@@ -1368,7 +1364,6 @@ export function WorkViewArea({
             sessionTitle={truncateSessionLabel(primarySessionLabel(session))}
             laneName={session.laneName}
             laneColor={laneAccentColor}
-            branchLabel={branchNameFromRef(laneBranchById.get(session.laneId) ?? null)}
             onSessionTitleClick={openInTabs}
             onLaneClick={gotoLane}
             onLaneContextMenu={(e) => triggerLaneContextMenu(session.laneId, e)}
@@ -1380,10 +1375,20 @@ export function WorkViewArea({
         bodyClassName: "overflow-hidden",
         headerActions: (
           <>
-            <span
-              title={dot.label}
-              className={`${dot.cls} h-2 w-2 shrink-0${dot.spinning ? " animate-spin" : ""}`}
-            />
+            {isCliAgentSession ? (
+              <GridTileSessionHeaderActions
+                session={session}
+                stopping={isBusy}
+                onInfoClick={onInfoClick}
+                onContextMenu={onContextMenu}
+                onStopRunningSession={onStopRunningSession}
+              />
+            ) : (
+              <span
+                title={dot.label}
+                className={`${dot.cls} h-2 w-2 shrink-0${dot.spinning ? " animate-spin" : ""}`}
+              />
+            )}
             <button
               type="button"
               onClick={() => onCloseItem(session.id)}
@@ -1432,7 +1437,6 @@ export function WorkViewArea({
     handleContextMenu,
     lanes,
     laneColorById,
-    laneBranchById,
     onCloseItem,
     onContextMenu,
     onGoToLane,


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fui-fix-for-cli-in-grid-view-ca71403b num=442 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fui-fix-for-cli-in-grid-view-ca71403b&amp;pr=442">ade/ui-fix-for-cli-in-grid-view-ca71403b branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=442">PR #442</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates the grid-tile CLI session header by suppressing the secondary `CliSessionWorkSurfaceHeader` when `layoutVariant === "grid-tile"` and instead injecting a new `GridTileSessionHeaderActions` component directly into the pane's floating header. The change also replaces the previous `branchLabel` / `laneBranchById` approach with a `ChatGitToolbar` PR chip.

- `CliSessionWorkSurfaceHeader.tsx` extracts five named sub-components (`SessionStatusDot`, `StopSessionButton`, `SessionRunMenu`, `SessionInfoButton`, `SessionActionsButton`) from inline JSX and exports the new `GridTileSessionHeaderActions` which renders them in order: PR chip → Stop → status dot → Run → Info → kebab.
- `WorkViewArea.tsx` removes the `laneBranchById` memo and `branchLabel` prop from `SessionLaneHeaderLabel`, gates `CliSessionWorkSurfaceHeader` behind `layoutVariant !== "grid-tile"`, and wires `GridTileSessionHeaderActions` into `tilingPanes` for CLI agent sessions while keeping a plain status dot for shell/run-shell sessions.
- The test file adds a stub for `GridTileSessionHeaderActions` to keep the existing suite green, but no new behavioral tests were added for the updated grid-tile rendering path.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; header suppression and new action cluster are well-scoped to the grid-tile layout variant and do not affect the existing tab surface.

The refactor is clean and the new component is a direct consolidation of previously scattered inline JSX. The only open item is a cosmetic dead-variable assignment (dot computed but unused for CLI-agent sessions) and the absence of new tests covering the grid-tile header suppression path.

WorkViewArea.tsx around the tilingPanes memo — specifically the conditional dot/GridTileSessionHeaderActions branching logic.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/terminals/CliSessionWorkSurfaceHeader.tsx | Refactors inline JSX in CliSurfaceTrailingActions into named sub-components; adds new GridTileSessionHeaderActions export consolidating PR chip + stop + status dot + run + info + kebab for grid tiles. |
| apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx | Suppresses CliSessionWorkSurfaceHeader for grid-tile; wires GridTileSessionHeaderActions into pane headerActions; removes laneBranchById memo and branchLabel prop; dot variable computed for all sessions but only consumed in the non-CLI-agent branch. |
| apps/desktop/src/renderer/components/terminals/WorkViewArea.test.tsx | Adds mock for GridTileSessionHeaderActions to keep existing suite passing; no new behavioral tests for the updated grid-tile rendering path. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Grid Tile Pane - headerActions] --> B{isCliAgentSession?}
    B -- yes --> C[GridTileSessionHeaderActions]
    B -- no --> D[Plain status dot span]
    C --> E[ChatGitToolbar PR chip - if laneId]
    C --> F[StopSessionButton if running + ptyId]
    C --> G[SessionStatusDot]
    C --> H[SessionRunMenu if laneId]
    C --> I[SessionInfoButton]
    C --> J[SessionActionsButton kebab]
    A --> K[Close button X]

    L[SessionSurface / ClosedCliSessionSurface] --> M{layoutVariant?}
    M -- grid-tile --> N[No CliSessionWorkSurfaceHeader rendered]
    M -- tabs/other --> O[CliSessionWorkSurfaceHeader with CliSurfaceTrailingActions]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fterminals%2FWorkViewArea.tsx%3A1352-1354%0AThe%20%60dot%60%20variable%20is%20computed%20via%20%60sessionStatusDot%28session%29%60%20for%20every%20session%20in%20the%20memo%2C%20but%20when%20%60isCliAgentSession%60%20is%20true%20it%20is%20never%20referenced%20%E2%80%94%20%60SessionStatusDot%60%20inside%20%60GridTileSessionHeaderActions%60%20makes%20its%20own%20internal%20call.%20The%20computation%20is%20cheap%2C%20but%20the%20dead%20assignment%20will%20cause%20linters%20to%20flag%20an%20unused%20variable%20warning%20once%20the%20non-CLI%20path%20is%20no%20longer%20the%20majority%20case.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20isBusy%20%3D%20session.ptyId%20%3F%20closingPtyIds.has%28session.ptyId%29%20%3A%20false%3B%0A%20%20%20%20%20%20const%20isCliAgentSession%20%3D%20isAgentCliSession%28session%29%3B%0A%20%20%20%20%20%20const%20dot%20%3D%20isCliAgentSession%20%3F%20null%20%3A%20sessionStatusDot%28session%29%3B%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=442&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx:1352-1354
The `dot` variable is computed via `sessionStatusDot(session)` for every session in the memo, but when `isCliAgentSession` is true it is never referenced — `SessionStatusDot` inside `GridTileSessionHeaderActions` makes its own internal call. The computation is cheap, but the dead assignment will cause linters to flag an unused variable warning once the non-CLI path is no longer the majority case.

```suggestion
      const isBusy = session.ptyId ? closingPtyIds.has(session.ptyId) : false;
      const isCliAgentSession = isAgentCliSession(session);
      const dot = isCliAgentSession ? null : sessionStatusDot(session);
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Consolidate CLI session grid-tile header..."](https://github.com/arul28/ade/commit/2aa89e42a839b851402c9fe8678232c7eaa17a0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34699345)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->