### PR TITLE
ADE-37: Add Stats settings dashboard

### DIFF
--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -662,7 +662,15 @@ export async function createAdeRuntime(args: {
     logger,
     broadcastData: (event) => pushEvent("pty", { type: "pty_data", event }),
     broadcastExit: (event) => pushEvent("pty", { type: "pty_exit", event }),
-    onSessionEnded: () => {},
+    onSessionEnded: (event) => {
+      void sessionDeltaService.computeSessionDelta(event.sessionId).catch((error) => {
+        logger.warn("runtime.session_delta_compute_failed", {
+          laneId: event.laneId,
+          sessionId: event.sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    },
     getAdeCliAgentEnv: createHeadlessAdeCliAgentEnv,
     loadPty: ptyBackend ?? (() => nodePty),
     disposePtyBackend: ptyBackend?.dispose
@@ -984,6 +992,7 @@ export async function createAdeRuntime(args: {
     logger,
     pollIntervalMs: 120_000,
     onUpdate: (snapshot) => pushEvent("runtime", { type: "usage", snapshot }),
+    projectRoot,
   });
   const budgetCapService = createBudgetCapService({
     db,

--- a/apps/desktop/scripts/export-browser-mock-ade-snapshot.mjs
+++ b/apps/desktop/scripts/export-browser-mock-ade-snapshot.mjs
@@ -10,7 +10,9 @@
  *   node ./scripts/export-browser-mock-ade-snapshot.mjs --optional
  */
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { DatabaseSync } from "node:sqlite";
@@ -23,6 +25,8 @@ const OUT_FILE = path.join(
   "browser-mock-ade-snapshot.generated.json",
 );
 const REPO_ROOT_FROM_SCRIPT = path.resolve(__dirname, "../../..");
+const USAGE_SNAPSHOT_CACHE_VERSION = 2;
+const USAGE_SNAPSHOT_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
 const args = process.argv.slice(2);
 const optional = args.includes("--optional");
@@ -986,26 +990,7 @@ function buildProcessRuntime(projectId) {
   }));
 }
 
-function buildUsageSnapshot() {
-  const rows = maybeAll(
-    "ai_usage_log",
-    "select * from ai_usage_log order by timestamp desc limit 200",
-  );
-  const byModel = new Map();
-  for (const row of rows) {
-    const key = `${row.provider ?? "unknown"}:${row.model ?? "unknown"}`;
-    const item = byModel.get(key) ?? {
-      provider: row.provider ?? "unknown",
-      model: row.model ?? "unknown",
-      inputTokens: 0,
-      outputTokens: 0,
-      calls: 0,
-    };
-    item.inputTokens += Number(row.input_tokens ?? 0);
-    item.outputTokens += Number(row.output_tokens ?? 0);
-    item.calls += 1;
-    byModel.set(key, item);
-  }
+function emptyUsageSnapshot() {
   return {
     windows: [],
     pacing: {
@@ -1018,11 +1003,88 @@ function buildUsageSnapshot() {
       willLastToReset: true,
       resetsInHours: 168,
     },
-    costs: [...byModel.values()],
+    costs: [],
+    adeCosts: [],
     extraUsage: [],
     lastPolledAt: new Date().toISOString(),
     errors: [],
   };
+}
+
+function buildUsageSnapshot() {
+  const cachePath = path.join(os.homedir(), ".ade", "cache", "usage-snapshot.json");
+  try {
+    const parsed = JSON.parse(readFileSync(cachePath, "utf8"));
+    if (parsed?.version === USAGE_SNAPSHOT_CACHE_VERSION && parsed?.snapshot && Array.isArray(parsed.snapshot.costs)) {
+      const lastPolledAt = Date.parse(parsed.snapshot.lastPolledAt ?? "");
+      if (!Number.isFinite(lastPolledAt) || Date.now() - lastPolledAt > USAGE_SNAPSHOT_CACHE_TTL_MS) {
+        return emptyUsageSnapshot();
+      }
+      return parsed.snapshot;
+    }
+  } catch {
+    // The native app will fill this cache after the first local scan.
+  }
+  return emptyUsageSnapshot();
+}
+
+function usageRangeForPreset(preset) {
+  const now = new Date();
+  const until = now.toISOString();
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+  if (preset === "today") return { preset, since: startOfToday.toISOString(), until };
+  if (preset === "7d") {
+    const since = new Date(startOfToday);
+    since.setDate(since.getDate() - 6);
+    return { preset, since: since.toISOString(), until };
+  }
+  if (preset === "30d") {
+    const since = new Date(startOfToday);
+    since.setDate(since.getDate() - 29);
+    return { preset, since: since.toISOString(), until };
+  }
+  return { preset: "all", since: null, until };
+}
+
+function nonNegativeInt(value) {
+  const numberValue = Number(value ?? 0);
+  return Number.isFinite(numberValue) ? Math.max(0, Math.floor(numberValue)) : 0;
+}
+
+function roundUsd(value) {
+  const numberValue = Number(value ?? 0);
+  return Number.isFinite(numberValue) ? Math.round(Math.max(0, numberValue) * 100) / 100 : 0;
+}
+
+function makeBrowserDailySkeleton(range) {
+  const until = new Date(range.until);
+  const untilMs = Number.isFinite(until.getTime()) ? until.getTime() : Date.now();
+  const maxDays = range.preset === "today" ? 1 : range.preset === "7d" ? 7 : range.preset === "all" ? 90 : 30;
+  const startMs = range.since
+    ? Math.max(Date.parse(range.since), untilMs - (maxDays - 1) * 86_400_000)
+    : untilMs - (maxDays - 1) * 86_400_000;
+  const start = new Date(startMs);
+  start.setHours(0, 0, 0, 0);
+
+  const points = [];
+  for (let index = 0; index < maxDays; index += 1) {
+    const date = new Date(start.getTime() + index * 86_400_000);
+    if (date.getTime() > untilMs + 86_400_000) break;
+    points.push({
+      date: date.toISOString().slice(0, 10),
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      commits: 0,
+      prs: 0,
+      insertions: 0,
+      deletions: 0,
+      filesChanged: 0,
+      sessions: 0,
+    });
+  }
+  return points;
 }
 
 function getCtoState(projectId) {
@@ -1032,6 +1094,323 @@ function getCtoState(projectId) {
   return {
     identity: safeJson(identityRow?.payload_json, null),
     recentSessions: [],
+  };
+}
+
+function runGhJson(args) {
+  return execFileSync("gh", args, {
+    cwd: projectRoot,
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+    timeout: 60_000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function inUsageRange(iso, range) {
+  const timestamp = Date.parse(iso ?? "");
+  if (!Number.isFinite(timestamp)) return false;
+  if (range.since && timestamp < Date.parse(range.since)) return false;
+  return timestamp <= Date.parse(range.until);
+}
+
+function commitRangeArgs(range) {
+  const args = [];
+  if (range.since) args.push("-F", `since=${range.since}`);
+  args.push("-F", `until=${range.until}`);
+  return args;
+}
+
+function pullRequestGraphqlQuery() {
+  return [
+    "query($owner: String!, $name: String!, $endCursor: String) {",
+    "  repository(owner: $owner, name: $name) {",
+    "    pullRequests(first: 100, after: $endCursor, orderBy: { field: CREATED_AT, direction: DESC }) {",
+    "      pageInfo { hasNextPage endCursor }",
+    "      nodes {",
+    "        number state createdAt closedAt mergedAt additions deletions changedFiles",
+    "        author { login }",
+    "      }",
+    "    }",
+    "  }",
+    "}",
+  ].join("\n");
+}
+
+function parsePullRequestRows(raw, viewer) {
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => safeJson(line, null))
+    .filter((row) => row && typeof row === "object")
+    .filter((row) => row.author?.login === viewer);
+}
+
+function addStatsDaily(points, dateIso, patch) {
+  const date = Number.isFinite(Date.parse(dateIso ?? "")) ? new Date(Date.parse(dateIso)).toISOString().slice(0, 10) : null;
+  if (!date) return;
+  const point = points.find((candidate) => candidate.date === date);
+  if (!point) return;
+  point.commits += nonNegativeInt(patch.commits);
+  point.prs += nonNegativeInt(patch.prs);
+  point.insertions += nonNegativeInt(patch.insertions);
+  point.deletions += nonNegativeInt(patch.deletions);
+  point.filesChanged += nonNegativeInt(patch.filesChanged);
+}
+
+function buildGithubStatsForBrowser(range) {
+  try {
+    const repoInfo = JSON.parse(runGhJson(["repo", "view", "--json", "owner,name"]));
+    const owner = typeof repoInfo.owner === "string" ? repoInfo.owner : repoInfo.owner?.login;
+    const repo = owner && repoInfo.name ? `${owner}/${repoInfo.name}` : null;
+    if (!repo) throw new Error("Unable to resolve GitHub repo.");
+    const viewer = JSON.parse(runGhJson(["api", "user", "--cache", "10m"])).login;
+    if (typeof viewer !== "string" || !viewer) throw new Error("Unable to resolve GitHub user.");
+
+    const prRows = parsePullRequestRows(runGhJson([
+      "api",
+      "graphql",
+      "--paginate",
+      "-F",
+      `owner=${owner}`,
+      "-F",
+      `name=${repoInfo.name}`,
+      "-f",
+      `query=${pullRequestGraphqlQuery()}`,
+      "--jq",
+      ".data.repository.pullRequests.nodes[] | @json",
+    ]), viewer);
+    const mergedPrs = prRows.filter((pr) => inUsageRange(pr.mergedAt, range));
+    const closedPrs = prRows.filter((pr) => inUsageRange(pr.closedAt, range));
+    const commitRows = runGhJson([
+      "api",
+      `repos/${repo}/commits`,
+      "--method",
+      "GET",
+      "--cache",
+      "10m",
+      "-F",
+      `author=${viewer}`,
+      ...commitRangeArgs(range),
+      "--paginate",
+      "--jq",
+      ".[] | [.sha, .commit.author.date] | @tsv",
+    ])
+      .split(/\r?\n/)
+      .map((line) => line.trim().split("\t")[1])
+      .filter(Boolean);
+    const createdPrs = prRows.filter((pr) => inUsageRange(pr.createdAt, range));
+    const commits = commitRows.filter((date) => inUsageRange(date, range));
+    const daily = makeBrowserDailySkeleton(range);
+    for (const date of commits) addStatsDaily(daily, date, { commits: 1 });
+    for (const pr of createdPrs) {
+      addStatsDaily(daily, pr.createdAt, {
+        prs: 1,
+      });
+    }
+    for (const pr of mergedPrs) {
+      addStatsDaily(daily, pr.mergedAt, {
+        insertions: pr.additions,
+        deletions: pr.deletions,
+        filesChanged: pr.changedFiles,
+      });
+    }
+    return {
+      repo,
+      available: true,
+      lastFetchedAt: new Date().toISOString(),
+      error: null,
+      commitsCreated: commits.length,
+      prsTracked: createdPrs.length,
+      prsOpen: createdPrs.filter((pr) => String(pr.state ?? "").toUpperCase() === "OPEN").length,
+      prsMerged: mergedPrs.length,
+      prsClosed: closedPrs.filter((pr) => String(pr.state ?? "").toUpperCase() === "CLOSED").length,
+      prAdditions: mergedPrs.reduce((sum, pr) => sum + nonNegativeInt(pr.additions), 0),
+      prDeletions: mergedPrs.reduce((sum, pr) => sum + nonNegativeInt(pr.deletions), 0),
+      filesChanged: mergedPrs.reduce((sum, pr) => sum + nonNegativeInt(pr.changedFiles), 0),
+      daily,
+    };
+  } catch (error) {
+    return {
+      repo: null,
+      available: false,
+      lastFetchedAt: null,
+      error: error instanceof Error ? error.message : String(error),
+      commitsCreated: 0,
+      prsTracked: 0,
+      prsOpen: 0,
+      prsMerged: 0,
+      prsClosed: 0,
+      prAdditions: 0,
+      prDeletions: 0,
+      filesChanged: 0,
+      daily: makeBrowserDailySkeleton(range),
+    };
+  }
+}
+
+function buildUsageStatsFromSnapshot(usageSnapshot, preset) {
+  const providerMap = new Map();
+  const modelMap = new Map();
+  const dailyTokens = new Map();
+  const costs = Array.isArray(usageSnapshot?.costs) ? usageSnapshot.costs : [];
+  for (const cost of costs) {
+    if (!cost || typeof cost.provider !== "string") continue;
+    const breakdown = cost.tokenBreakdownByPreset?.[preset] ?? cost.tokenBreakdown;
+    if (!breakdown || typeof breakdown !== "object") continue;
+    const rangeCost = Number(cost.costUsdByPreset?.[preset] ?? (preset === "today" ? cost.todayCostUsd : cost.last30dCostUsd) ?? 0);
+    const providerTotal = Object.values(breakdown).reduce((sum, entry) => (
+      sum + nonNegativeInt(entry?.input) + nonNegativeInt(entry?.output) + nonNegativeInt(entry?.cached) + nonNegativeInt(entry?.cacheWrite)
+    ), 0);
+    const provider = providerMap.get(cost.provider) ?? {
+      provider: cost.provider,
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedTokens: 0,
+      totalTokens: 0,
+      rangeCostUsd: 0,
+      todayCostUsd: Number(cost.todayCostUsd ?? 0),
+      last30dCostUsd: Number(cost.last30dCostUsd ?? 0),
+    };
+    provider.rangeCostUsd += Number.isFinite(rangeCost) ? rangeCost : 0;
+    for (const [model, entry] of Object.entries(breakdown)) {
+      const input = nonNegativeInt(entry?.input);
+      const output = nonNegativeInt(entry?.output);
+      const cached = nonNegativeInt(entry?.cached) + nonNegativeInt(entry?.cacheWrite);
+      const total = input + output + cached;
+      const share = providerTotal > 0 ? total / providerTotal : 0;
+      const modelCost = Number(entry?.costUsd ?? rangeCost * share) || 0;
+      provider.inputTokens += input;
+      provider.outputTokens += output;
+      provider.cachedTokens += cached;
+      provider.totalTokens += total;
+      const modelKey = `${cost.provider}\u0000${model}`;
+      const modelSummary = modelMap.get(modelKey) ?? {
+        provider: cost.provider,
+        model,
+        calls: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedTokens: 0,
+        totalTokens: 0,
+        costUsd: 0,
+      };
+      modelSummary.inputTokens += input;
+      modelSummary.outputTokens += output;
+      modelSummary.cachedTokens += cached;
+      modelSummary.totalTokens += total;
+      modelSummary.costUsd += modelCost;
+      modelMap.set(modelKey, modelSummary);
+    }
+    providerMap.set(cost.provider, provider);
+
+    const daily = cost.dailyTokensByPreset?.[preset] ?? {};
+    for (const [date, value] of Object.entries(daily)) {
+      dailyTokens.set(date, (dailyTokens.get(date) ?? 0) + nonNegativeInt(value));
+    }
+  }
+  const providers = Array.from(providerMap.values())
+    .map((provider) => ({ ...provider, rangeCostUsd: roundUsd(provider.rangeCostUsd) }))
+    .sort((a, b) => b.totalTokens - a.totalTokens || b.rangeCostUsd - a.rangeCostUsd);
+  const models = Array.from(modelMap.values())
+    .map((model) => ({ ...model, costUsd: roundUsd(model.costUsd) }))
+    .sort((a, b) => b.totalTokens - a.totalTokens || b.costUsd - a.costUsd);
+  return {
+    providers,
+    models,
+    inputTokens: providers.reduce((sum, provider) => sum + provider.inputTokens, 0),
+    outputTokens: providers.reduce((sum, provider) => sum + provider.outputTokens, 0),
+    cachedTokens: providers.reduce((sum, provider) => sum + provider.cachedTokens, 0),
+    costRangeUsd: roundUsd(providers.reduce((sum, provider) => sum + provider.rangeCostUsd, 0)),
+    cost30dUsd: roundUsd(providers.reduce((sum, provider) => sum + provider.last30dCostUsd, 0)),
+    costTodayUsd: roundUsd(providers.reduce((sum, provider) => sum + provider.todayCostUsd, 0)),
+    dailyTokens,
+  };
+}
+
+function mergeUsageTokensIntoDaily(points, dailyTokens) {
+  for (const point of points) {
+    const tokens = nonNegativeInt(dailyTokens.get(point.date));
+    point.inputTokens += tokens;
+    point.totalTokens += tokens;
+  }
+}
+
+function buildStatsDashboardStats(preset, usageSnapshot) {
+  const range = usageRangeForPreset(preset);
+  const github = buildGithubStatsForBrowser(range);
+  const usage = buildUsageStatsFromSnapshot(usageSnapshot, preset);
+  mergeUsageTokensIntoDaily(github.daily, usage.dailyTokens);
+  const totalTokens = usage.inputTokens + usage.outputTokens + usage.cachedTokens;
+  return {
+    generatedAt: new Date().toISOString(),
+    range,
+    summary: {
+      totalTokens,
+      tokenTotalSource: "provider_logs",
+      observedProviderTokens: totalTokens,
+      observedProviderInputTokens: usage.inputTokens,
+      observedProviderOutputTokens: usage.outputTokens,
+      observedProviderCachedTokens: usage.cachedTokens,
+      observedProviderCostRangeUsd: usage.costRangeUsd,
+      observedProviderCost30dUsd: usage.cost30dUsd,
+      observedProviderCostTodayUsd: usage.costTodayUsd,
+      adeRuntimeTokens: 0,
+      adeRuntimeInputTokens: 0,
+      adeRuntimeOutputTokens: 0,
+      adeRuntimeCachedTokens: 0,
+      adeRuntimeCostRangeUsd: 0,
+      adeRuntimeCost30dUsd: 0,
+      adeRuntimeCostTodayUsd: 0,
+      adeTotalTokens: 0,
+      adeTotalCostRangeUsd: 0,
+      trackedAdeTokens: 0,
+      trackedAdeInputTokens: 0,
+      trackedAdeOutputTokens: 0,
+      trackedAdeCalls: 0,
+      trackedAdeDurationMs: 0,
+      workerTokens: 0,
+      workerCostUsd: 0,
+      chatSessions: 0,
+      terminalSessions: 0,
+      activeLanes: 0,
+      lanesCreated: 0,
+      lanesArchived: 0,
+      lanesDeleted: 0,
+      commitsCreated: github.commitsCreated,
+      pushOperations: 0,
+      prLandings: github.prsMerged,
+      prsTracked: github.prsTracked,
+      prsOpen: github.prsOpen,
+      prsMerged: github.prsMerged,
+      prsClosed: github.prsClosed,
+      prAdditions: github.prAdditions,
+      prDeletions: github.prDeletions,
+      filesChanged: github.filesChanged,
+      insertions: github.prAdditions,
+      deletions: github.prDeletions,
+      artifactsCaptured: 0,
+      automationRuns: 0,
+      workerRuns: 0,
+    },
+    providers: usage.providers,
+    models: usage.models,
+    adeProviders: [],
+    adeModels: [],
+    agentProviders: [],
+    agentModels: [],
+    features: [],
+    lanes: [],
+    activities: [],
+    daily: github.daily,
+    github: {
+      repo: github.repo,
+      available: github.available,
+      lastFetchedAt: github.lastFetchedAt,
+      error: github.error,
+    },
+    sourceNotes: [],
   };
 }
 
@@ -1245,6 +1624,9 @@ processRuntime = ensureDemoProcessRuntime(processRuntime, lanes, processDefiniti
 
 const automations = buildAutomations(projectId);
 const usageSnapshot = buildUsageSnapshot();
+const adeUsageStatsByPreset = Object.fromEntries(
+  ["today", "7d", "30d", "all"].map((preset) => [preset, buildStatsDashboardStats(preset, usageSnapshot)]),
+);
 const ctoState = getCtoState(projectId);
 
 db.close();
@@ -1264,6 +1646,7 @@ const filesContentEntryCount = Object.values(filesContentsByWorkspace).reduce(
 
 const snapshot = {
   version: 2,
+  statsDashboardVersion: 1,
   exportedAt: new Date().toISOString(),
   project: {
     id: String(projectRow.id),
@@ -1290,6 +1673,7 @@ const snapshot = {
   stackButtons,
   processGroups,
   usageSnapshot,
+  adeUsageStatsByPreset,
   ctoState,
   automations,
   filesTreeByWorkspace,

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -2474,6 +2474,7 @@ app.whenReady().then(async () => {
       }
     };
 
+    let sessionDeltaServiceRef: ReturnType<typeof createSessionDeltaService> | null = null;
     const onTrackedSessionEnded = ({
       laneId,
       sessionId,
@@ -2507,6 +2508,13 @@ app.whenReady().then(async () => {
           error: error instanceof Error ? error.message : String(error),
         });
       }
+      void sessionDeltaServiceRef?.computeSessionDelta(sessionId).catch((error) => {
+        logger.warn("main.session_delta_compute_failed", {
+          laneId,
+          sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
       void linearSyncServiceRef?.processActiveRunsNow().catch(() => {});
     };
 
@@ -2592,6 +2600,7 @@ app.whenReady().then(async () => {
       laneService,
       sessionService,
     });
+    sessionDeltaServiceRef = sessionDeltaService;
 
     const ctoStateService = createCtoStateService({
       db,
@@ -3527,6 +3536,7 @@ app.whenReady().then(async () => {
       onUpdate: (snapshot) => {
         emitProjectEvent(projectRoot, IPC.usageEvent, snapshot);
       },
+      projectRoot,
     });
     scheduleBackgroundProjectTask(
       "usage.start",
@@ -4202,6 +4212,7 @@ app.whenReady().then(async () => {
       onUpdate: (snapshot) => {
         emitProjectEvent(projectRoot, IPC.usageEvent, snapshot);
       },
+      projectRoot,
     });
     usageTrackingService.start();
 

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -543,7 +543,7 @@ export const ADE_ACTION_ALLOWLIST: Partial<Record<AdeActionDomain, readonly stri
     "setAgentStatus",
     "triggerWakeup",
   ],
-  session: ["deleteSession", "get", "getDelta", "list", "readTranscriptTail", "updateMeta"],
+  session: ["backfillDeltas", "deleteSession", "get", "getDelta", "list", "readTranscriptTail", "updateMeta"],
   operation: ["finish", "get", "list", "start"],
   ade_project: ["clearLocalData", "getSnapshot", "initializeOrRepair", "runIntegrityCheck"],
   project_config: ["confirmTrust", "diffAgainstDisk", "get", "save", "validate"],
@@ -630,7 +630,7 @@ export const ADE_ACTION_ALLOWLIST: Partial<Record<AdeActionDomain, readonly stri
     "setToken",
   ],
   feedback: ["list", "prepareDraft", "submitPreparedDraft"],
-  usage: ["forceRefresh", "getUsageSnapshot", "poll", "start", "stop"],
+  usage: ["forceRefresh", "getAdeUsageStats", "getUsageSnapshot", "poll", "start", "stop"],
   budget: ["checkBudget", "getConfig", "getCumulativeUsage", "recordUsage", "updateConfig"],
   update: ["checkForUpdates", "dismissInstalledNotice", "getSnapshot", "quitAndInstall"],
   file: [
@@ -1134,6 +1134,20 @@ function buildSessionDomainService(runtime: AdeRuntime): OpaqueService | null {
         ? requireNonEmptyString(args, "sessionId")
         : requireNonEmptyString(args?.sessionId, "sessionId");
       return runtime.sessionDeltaService?.getSessionDelta(sessionId) ?? null;
+    },
+    backfillDeltas: (args?: { limit?: number; since?: string | null }) => {
+      const limit = typeof args?.limit === "number" && Number.isFinite(args.limit)
+        ? Math.max(1, Math.min(1_000, Math.floor(args.limit)))
+        : 500;
+      const since = typeof args?.since === "string" && args.since.trim()
+        ? args.since.trim()
+        : null;
+      return runtime.sessionDeltaService?.backfillMissingSessionDeltas({ limit, since }) ?? {
+        scanned: 0,
+        computed: 0,
+        skipped: 0,
+        failed: 0,
+      };
     },
   };
 }

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -483,6 +483,8 @@ import type {
   LinearWorkflowRunDetail,
   LinearWorkflowConfig,
   NormalizedLinearIssue,
+  AdeUsageStats,
+  GetAdeUsageStatsArgs,
   UsageSnapshot,
   BudgetCheckResult,
   BudgetCapScope,
@@ -4547,6 +4549,11 @@ export function registerIpc({
 
 
   // ── Usage tracking + budget cap IPC ──────────────────────────
+  ipcMain.handle(IPC.usageGetAdeStats, async (_event, arg: GetAdeUsageStatsArgs | undefined): Promise<AdeUsageStats | null> => {
+    const ctx = getCtx();
+    return ctx.usageTrackingService?.getAdeUsageStats(arg ?? {}) ?? null;
+  });
+
   ipcMain.handle(IPC.usageGetSnapshot, async (): Promise<UsageSnapshot | null> => {
     const ctx = getCtx();
     return ctx.usageTrackingService?.getUsageSnapshot() ?? null;

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -4449,8 +4449,44 @@ export function createLaneService({
       if (row.lane_type === "primary") {
         throw new Error("Primary lane cannot be deleted");
       }
+      const deleteOperation = (() => {
+        try {
+          return operationService?.start({
+            laneId: null,
+            kind: "lane_delete",
+            metadata: {
+              laneId,
+              laneName: row.name,
+              laneType: row.lane_type,
+              branchRef: row.branch_ref,
+              deleteBranch,
+              deleteRemoteBranch,
+              force,
+            },
+          }) ?? null;
+        } catch (error) {
+          logger.warn("lane.delete.operation_start_failed", { laneId, error: error instanceof Error ? error.message : String(error) });
+          return null;
+        }
+      })();
+      const finishDeleteOperation = (
+        status: "succeeded" | "failed",
+        metadataPatch: Record<string, unknown>,
+      ): void => {
+        if (!deleteOperation?.operationId) return;
+        try {
+          operationService?.finish({
+            operationId: deleteOperation.operationId,
+            status,
+            metadataPatch,
+          });
+        } catch (error) {
+          logger.warn("lane.delete.operation_finish_failed", { laneId, status, error: error instanceof Error ? error.message : String(error) });
+        }
+      };
       const childRows = getChildrenRows(laneId, false);
       if (childRows.length > 0) {
+        finishDeleteOperation("failed", { error: "Lane has active child lanes." });
         throw new Error("Cannot delete a lane with active child lanes. Delete or rebase/archive children first.");
       }
 
@@ -4714,6 +4750,11 @@ export function createLaneService({
 
         invalidateLaneListCache();
         finalize(nonFatalFailures.length > 0 ? "completed_with_warnings" : "completed");
+        finishDeleteOperation("succeeded", {
+          overallStatus: progress.overallStatus,
+          warnings: nonFatalFailures,
+          completedAt: progress.completedAt ?? new Date().toISOString(),
+        });
         const totalMs = Date.now() - new Date(progress.startedAt).getTime();
         if (totalMs >= 1_000) {
           logger.info("lane.delete.completed", {
@@ -4728,6 +4769,7 @@ export function createLaneService({
         }
       } catch (error) {
         finalize("failed");
+        finishDeleteOperation("failed", { error: error instanceof Error ? error.message : String(error) });
         throw error;
       }
     },

--- a/apps/desktop/src/main/services/sessions/sessionDeltaService.test.ts
+++ b/apps/desktop/src/main/services/sessions/sessionDeltaService.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSessionDeltaService } from "./sessionDeltaService";
+
+const gitMocks = vi.hoisted(() => ({
+  runGit: vi.fn(),
+}));
+
+vi.mock("../git/git", () => ({
+  runGit: (...args: unknown[]) => gitMocks.runGit(...args),
+}));
+
+function createHarness(session: Record<string, unknown>) {
+  const db = {
+    get: vi.fn((sql: string) => {
+      if (sql.includes("from terminal_sessions")) return session;
+      return null;
+    }),
+    all: vi.fn(() => []),
+    run: vi.fn(),
+  };
+  const laneService = {
+    getLaneBaseAndBranch: vi.fn(() => ({ worktreePath: "/tmp/ade-test-worktree" })),
+  };
+  const sessionService = {
+    readTranscriptTail: vi.fn(async () => ""),
+  };
+  const service = createSessionDeltaService({
+    db: db as any,
+    projectId: "project-1",
+    laneService: laneService as any,
+    sessionService: sessionService as any,
+  });
+  return { db, laneService, service, sessionService };
+}
+
+describe("createSessionDeltaService", () => {
+  beforeEach(() => {
+    gitMocks.runGit.mockReset();
+  });
+
+  it("skips ended sessions that do not have an end SHA", async () => {
+    const { db, laneService, service, sessionService } = createHarness({
+      id: "session-1",
+      lane_id: "lane-1",
+      tracked: 1,
+      started_at: "2026-05-29T12:00:00.000Z",
+      ended_at: "2026-05-29T12:10:00.000Z",
+      head_sha_start: "abc123",
+      head_sha_end: null,
+      transcript_path: "/tmp/session.log",
+    });
+
+    await expect(service.computeSessionDelta("session-1")).resolves.toBeNull();
+
+    expect(laneService.getLaneBaseAndBranch).not.toHaveBeenCalled();
+    expect(gitMocks.runGit).not.toHaveBeenCalled();
+    expect(sessionService.readTranscriptTail).not.toHaveBeenCalled();
+    expect(db.run).not.toHaveBeenCalled();
+  });
+
+  it("records a zero diff for completed sessions whose start and end SHA match", async () => {
+    const { db, service } = createHarness({
+      id: "session-2",
+      lane_id: "lane-1",
+      tracked: 1,
+      started_at: "2026-05-29T12:00:00.000Z",
+      ended_at: "2026-05-29T12:10:00.000Z",
+      head_sha_start: "abc123",
+      head_sha_end: "abc123",
+      transcript_path: "/tmp/session.log",
+    });
+
+    const delta = await service.computeSessionDelta("session-2");
+
+    expect(gitMocks.runGit).not.toHaveBeenCalled();
+    expect(delta).toMatchObject({
+      filesChanged: 0,
+      insertions: 0,
+      deletions: 0,
+      touchedFiles: [],
+    });
+    expect(db.run).toHaveBeenCalledWith(
+      expect.stringContaining("insert into session_deltas"),
+      expect.arrayContaining(["session-2", "project-1", "lane-1", 0, 0, 0]),
+    );
+  });
+});

--- a/apps/desktop/src/main/services/sessions/sessionDeltaService.ts
+++ b/apps/desktop/src/main/services/sessions/sessionDeltaService.ts
@@ -21,6 +21,8 @@ export function createSessionDeltaService(args: {
 }) {
   const { db, projectId, laneService, sessionService } = args;
 
+  type BackfillSessionRow = LaneSessionRow & { status: string | null };
+
   const getSessionRow = (sessionId: string): LaneSessionRow | null =>
     db.get<LaneSessionRow>(
       `
@@ -98,12 +100,22 @@ export function createSessionDeltaService(args: {
     const session = getSessionRow(sessionId);
     if (!session || session.tracked !== 1) return null;
 
-    const lane = laneService.getLaneBaseAndBranch(session.lane_id);
-    const diffRef = session.head_sha_start?.trim() || "HEAD";
+    const startSha = session.head_sha_start?.trim() ?? "";
+    const endSha = session.head_sha_end?.trim() ?? "";
+    if (session.ended_at && !endSha) return null;
 
-    const numStatRes = await runGit(["diff", "--numstat", diffRef], { cwd: lane.worktreePath, timeoutMs: 20_000 });
-    const nameRes = await runGit(["diff", "--name-only", diffRef], { cwd: lane.worktreePath, timeoutMs: 20_000 });
-    const statusRes = await runGit(["status", "--porcelain=v1"], { cwd: lane.worktreePath, timeoutMs: 8_000 });
+    const lane = laneService.getLaneBaseAndBranch(session.lane_id);
+    const hasCompletedRange = Boolean(startSha && endSha);
+    const completedWithoutCommitDelta = Boolean(session.ended_at && hasCompletedRange && startSha === endSha);
+    const useCommitRange = hasCompletedRange && startSha !== endSha;
+    const diffArgs = completedWithoutCommitDelta ? null : useCommitRange ? [startSha, endSha] : [startSha || "HEAD"];
+
+    const numStatRes = diffArgs
+      ? await runGit(["diff", "--numstat", ...diffArgs], { cwd: lane.worktreePath, timeoutMs: 20_000 })
+      : { stdout: "", exitCode: 0 };
+    const nameRes = diffArgs
+      ? await runGit(["diff", "--name-only", ...diffArgs], { cwd: lane.worktreePath, timeoutMs: 20_000 })
+      : { stdout: "", exitCode: 0 };
 
     const parsedStat = parseNumStat(numStatRes.stdout);
     const touched = new Set<string>([...parsedStat.files]);
@@ -114,9 +126,12 @@ export function createSessionDeltaService(args: {
       }
     }
 
-    if (statusRes.exitCode === 0) {
-      for (const rel of parsePorcelainPaths(statusRes.stdout)) {
-        touched.add(rel);
+    if (!useCommitRange && !completedWithoutCommitDelta) {
+      const statusRes = await runGit(["status", "--porcelain=v1"], { cwd: lane.worktreePath, timeoutMs: 8_000 });
+      if (statusRes.exitCode === 0) {
+        for (const rel of parsePorcelainPaths(statusRes.stdout)) {
+          touched.add(rel);
+        }
       }
     }
 
@@ -223,9 +238,76 @@ export function createSessionDeltaService(args: {
     };
   };
 
+  const backfillMissingSessionDeltas = async (options: {
+    limit?: number;
+    since?: string | null;
+  } = {}): Promise<{
+    scanned: number;
+    computed: number;
+    skipped: number;
+    failed: number;
+  }> => {
+    const limit = Math.max(1, Math.min(1_000, Math.floor(options.limit ?? 500)));
+    const where = [
+      "s.tracked = 1",
+      "s.ended_at is not null",
+      "s.head_sha_end is not null",
+      "s.head_sha_end != ''",
+      "d.session_id is null",
+    ];
+    const params: Array<string | number> = [];
+    if (options.since?.trim()) {
+      where.push("s.started_at >= ?");
+      params.push(options.since.trim());
+    }
+    params.push(limit);
+    const rows = db.all<BackfillSessionRow>(
+      `
+        select
+          s.id,
+          s.lane_id,
+          s.tracked,
+          s.started_at,
+          s.ended_at,
+          s.head_sha_start,
+          s.head_sha_end,
+          s.transcript_path,
+          s.status
+        from terminal_sessions s
+        left join session_deltas d on d.session_id = s.id
+        join lanes l on l.id = s.lane_id
+        where ${where.join(" and ")}
+          and l.project_id = ?
+        order by s.started_at desc
+        limit ?
+      `,
+      [...params.slice(0, -1), projectId, params[params.length - 1]],
+    );
+
+    let computed = 0;
+    let skipped = 0;
+    let failed = 0;
+    for (const row of rows) {
+      try {
+        const delta = await computeSessionDelta(row.id);
+        if (delta) computed += 1;
+        else skipped += 1;
+      } catch {
+        failed += 1;
+      }
+    }
+    return {
+      scanned: rows.length,
+      computed,
+      skipped,
+      failed,
+    };
+  };
+
   return {
     getSessionDelta,
     computeSessionDelta,
+    backfillMissingSessionDeltas,
     listRecentLaneSessionDeltas,
   };
 }

--- a/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
@@ -2135,6 +2135,7 @@ describe("createSyncRemoteCommandService", () => {
           laneId: "lane-1",
           title: "test run",
           startupCommand: "npm test",
+          tracked: true,
           toolType: "run-shell",
         }),
       );
@@ -2200,6 +2201,7 @@ describe("createSyncRemoteCommandService", () => {
         expect.objectContaining({
           laneId: "lane-1",
           title: "Fix the tests",
+          tracked: true,
           toolType: "codex",
           cols: 70,
           rows: 24,

--- a/apps/desktop/src/main/services/usage/usagePricing.ts
+++ b/apps/desktop/src/main/services/usage/usagePricing.ts
@@ -1,0 +1,445 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export type TokenPrice = {
+  input: number;
+  output: number;
+  cacheWrite: number;
+  cacheRead: number;
+};
+
+type PricingLogger = {
+  debug?: (event: string, data?: Record<string, unknown>) => void;
+  warn?: (event: string, data?: Record<string, unknown>) => void;
+};
+
+const LITELLM_PRICING_URL = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+const PRICING_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const ADE_PRICING_CACHE_PATH = path.join(os.homedir(), ".ade", "litellm-pricing.json");
+const CODEBURN_PRICING_CACHE_PATH = path.join(os.homedir(), ".cache", "codeburn", "litellm-pricing.json");
+
+export const WEB_SEARCH_COST_USD = 0.01;
+export const ONE_HOUR_CACHE_WRITE_MULTIPLIER = 1.6;
+
+const ZERO_PRICE: TokenPrice = Object.freeze({ input: 0, output: 0, cacheWrite: 0, cacheRead: 0 });
+
+export function tokenPrice(inputPer1M: number, outputPer1M: number, cacheReadPer1M = inputPer1M * 0.1, cacheWritePer1M = inputPer1M * 1.25): TokenPrice {
+  return {
+    input: inputPer1M / 1_000_000,
+    output: outputPer1M / 1_000_000,
+    cacheWrite: cacheWritePer1M / 1_000_000,
+    cacheRead: cacheReadPer1M / 1_000_000,
+  };
+}
+
+const STATIC_TOKEN_PRICES: Record<string, TokenPrice> = {
+  "claude-3-opus": tokenPrice(15, 75, 1.5, 18.75),
+  "claude-3-5-haiku": tokenPrice(0.8, 4, 0.08, 1),
+  "claude-3-5-sonnet": tokenPrice(3, 15, 0.3, 3.75),
+  "claude-3-7-sonnet": tokenPrice(3, 15, 0.3, 3.75),
+  "claude-3-haiku": tokenPrice(0.25, 1.25, 0.03, 0.3),
+  "claude-opus-4-1": tokenPrice(15, 75, 1.5, 18.75),
+  "claude-opus-4": tokenPrice(15, 75, 1.5, 18.75),
+  "claude-opus-4-8": tokenPrice(5, 25, 0.5, 6.25),
+  "claude-opus-4-7": tokenPrice(5, 25, 0.5, 6.25),
+  "claude-opus-4-6": tokenPrice(5, 25, 0.5, 6.25),
+  "claude-opus-4-5": tokenPrice(5, 25, 0.5, 6.25),
+  "claude-sonnet-4-6": tokenPrice(3, 15, 0.3, 3.75),
+  "claude-sonnet-4-5": tokenPrice(3, 15, 0.3, 3.75),
+  "claude-sonnet-4": tokenPrice(3, 15, 0.3, 3.75),
+  "claude-haiku-4-5": tokenPrice(1, 5, 0.1, 1.25),
+  "claude-opus": tokenPrice(5, 25),
+  "claude-sonnet": tokenPrice(3, 15),
+  "claude-haiku": tokenPrice(1, 5),
+  "gpt-5.5-pro": tokenPrice(30, 180, 3),
+  "gpt-5.5": tokenPrice(5, 30, 0.5),
+  "gpt-5.4-pro": tokenPrice(30, 180, 3),
+  "gpt-5.4-mini": tokenPrice(0.75, 4.5, 0.075),
+  "gpt-5.4-nano": tokenPrice(0.2, 1.25, 0.02),
+  "gpt-5.4": tokenPrice(2.5, 15, 0.25),
+  "gpt-5.3-codex": tokenPrice(1.75, 14, 0.175),
+  "gpt-5.2-pro": tokenPrice(21, 168),
+  "gpt-5.1-codex-mini": tokenPrice(0.25, 2, 0.025),
+  "gpt-5.1-codex": tokenPrice(1.25, 10, 0.125),
+  "gpt-5.1": tokenPrice(1.25, 10, 0.125),
+  "gpt-5.2": tokenPrice(1.75, 14, 0.175),
+  "gpt-5-pro": tokenPrice(15, 120),
+  "gpt-5-mini": tokenPrice(0.25, 2, 0.025),
+  "gpt-5-nano": tokenPrice(0.05, 0.4, 0.005),
+  "gpt-5": tokenPrice(1.25, 10, 0.125),
+  "gpt-4.1-nano": tokenPrice(0.1, 0.4, 0.025),
+  "gpt-4.1-mini": tokenPrice(0.4, 1.6, 0.1),
+  "gpt-4.1": tokenPrice(2, 8, 0.5),
+  "gpt-4o-mini": tokenPrice(0.15, 0.6, 0.075),
+  "gpt-4o": tokenPrice(2.5, 10, 1.25),
+  "o4-mini": tokenPrice(1.1, 4.4, 0.275),
+  "o3": tokenPrice(2, 8, 0.5),
+  "codex-mini-latest": tokenPrice(1.5, 6, 0.375),
+  "gemini-2.5-pro": tokenPrice(1.25, 10, 0.125),
+  "gemini-2.5-flash": tokenPrice(0.3, 2.5, 0.03),
+  "gemini-3-pro-preview": tokenPrice(2, 12, 0.2),
+  "gemini-3.1-pro-preview": tokenPrice(2, 12, 0.2),
+  "gemini-3-flash-preview": tokenPrice(0.5, 3, 0.05),
+  "gemini-3.5-flash": tokenPrice(1.5, 9, 0.15),
+  "gemini-3.1-flash-image-preview": tokenPrice(0.5, 3, 0.05),
+  "gemini-3.1-flash-lite-preview": tokenPrice(0.25, 1.5, 0.025),
+  "grok-code-fast-1": tokenPrice(0.2, 1.5, 0.02),
+  "grok-code-fast": tokenPrice(0.2, 1.5, 0.02),
+  "kimi-k2.5": tokenPrice(0.6, 3, 0.06),
+  "kimi-k2-thinking": tokenPrice(0.6, 2.5, 0.15),
+  "codex": tokenPrice(1.25, 10, 0.125),
+};
+
+const BUILTIN_PRICING_ALIASES: Record<string, string> = {
+  auto: "claude-sonnet-4-5",
+  "anthropic--claude-4.6-opus": "claude-opus-4-6",
+  "anthropic--claude-4.6-sonnet": "claude-sonnet-4-6",
+  "anthropic--claude-4.5-opus": "claude-opus-4-5",
+  "anthropic--claude-4.5-sonnet": "claude-sonnet-4-5",
+  "anthropic--claude-4.5-haiku": "claude-haiku-4-5",
+  "claude-sonnet-4.6": "claude-sonnet-4-6",
+  "claude-sonnet-4.5": "claude-sonnet-4-5",
+  "claude-opus-4.7": "claude-opus-4-7",
+  "claude-opus-4.6": "claude-opus-4-6",
+  "claude-opus-4.5": "claude-opus-4-5",
+  "cursor-auto": "claude-sonnet-4-5",
+  "cursor-agent-auto": "claude-sonnet-4-5",
+  "copilot-auto": "claude-sonnet-4-5",
+  "copilot-openai-auto": "gpt-5.3-codex",
+  "copilot-anthropic-auto": "claude-sonnet-4-5",
+  "ibm-bob-auto": "claude-sonnet-4-5",
+  "kiro-auto": "claude-sonnet-4-5",
+  "cline-auto": "claude-sonnet-4-5",
+  "openclaw-auto": "claude-sonnet-4-5",
+  "qwen-auto": "claude-sonnet-4-5",
+  "kimi-auto": "kimi-k2-thinking",
+  "kimi-code": "kimi-k2-thinking",
+  "kimi-for-coding": "kimi-k2-thinking",
+  "claude-4-sonnet": "claude-sonnet-4",
+  "claude-4-sonnet-1m": "claude-sonnet-4",
+  "claude-4-sonnet-thinking": "claude-sonnet-4-5",
+  "claude-4.5-sonnet": "claude-sonnet-4-5",
+  "claude-4.5-sonnet-thinking": "claude-sonnet-4-5",
+  "claude-4.6-sonnet": "claude-sonnet-4-6",
+  "claude-4.6-sonnet-high": "claude-sonnet-4-6",
+  "claude-4.6-sonnet-low": "claude-sonnet-4-6",
+  "claude-4.6-sonnet-thinking": "claude-sonnet-4-6",
+  "claude-4.6-sonnet-high-thinking": "claude-sonnet-4-6",
+  "claude-4-opus": "claude-opus-4",
+  "claude-4.5-opus": "claude-opus-4-5",
+  "claude-4.5-opus-high": "claude-opus-4-5",
+  "claude-4.5-opus-low": "claude-opus-4-5",
+  "claude-4.5-opus-medium": "claude-opus-4-5",
+  "claude-4.5-opus-high-thinking": "claude-opus-4-5",
+  "claude-4.6-opus": "claude-opus-4-6",
+  "claude-4.6-opus-fast-mode": "claude-opus-4-6",
+  "claude-4.6-opus-high": "claude-opus-4-6",
+  "claude-4.6-opus-low": "claude-opus-4-6",
+  "claude-4.6-opus-medium": "claude-opus-4-6",
+  "claude-4.6-opus-high-thinking": "claude-opus-4-6",
+  "claude-4.7-opus": "claude-opus-4-7",
+  "claude-opus-4-7-thinking-high": "claude-opus-4-7",
+  "claude-4.5-haiku": "claude-haiku-4-5",
+  "claude-4.6-haiku": "claude-haiku-4-5",
+  "composer-1": "claude-sonnet-4-5",
+  "composer-1.5": "claude-sonnet-4-5",
+  "composer-2": "claude-sonnet-4-6",
+  "composer-2.5": "claude-sonnet-4-6",
+  "composer-latest": "claude-sonnet-4-6",
+  "gpt-5-fast": "gpt-5",
+  "gpt-5.2-low": "gpt-5",
+  "gpt-5.1-codex-high": "gpt-5.3-codex",
+  "gpt-5.3": "gpt-5.3-codex",
+  "gpt-5.3-spark": "gpt-5.3-codex",
+  "codex-spark": "gpt-5.3-codex",
+  spark: "gpt-5.3-codex",
+  "gemini-3.1-pro": "gemini-3.1-pro-preview",
+  "gemini-auto": "gemini-3.1-pro-preview",
+  "gemini-3-flash": "gemini-3-flash-preview",
+  "gemini-3.1-pro-high": "gemini-3.1-pro-preview",
+  "gemini-3.1-pro-low": "gemini-3.1-pro-preview",
+  "gemini-3-flash-agent": "gemini-3-flash-preview",
+  "gemini-3-pro": "gemini-3-pro-preview",
+  "gemini-3.1-flash-image": "gemini-3.1-flash-image-preview",
+  "gemini-3.1-flash-lite": "gemini-3.1-flash-lite-preview",
+};
+
+const CURSOR_VARIANT_SUFFIXES = [
+  "-high-thinking",
+  "-medium-thinking",
+  "-low-thinking",
+  "-thinking-high",
+  "-thinking-medium",
+  "-thinking-low",
+  "-fast-mode",
+  "-thinking",
+  "-medium",
+  "-high",
+  "-low",
+  "-fast",
+] as const;
+
+let dynamicTokenPricingLoaded = false;
+let dynamicTokenPricingTimestamp = 0;
+let dynamicTokenPricing = new Map<string, TokenPrice>();
+let sortedDynamicPricingKeys: string[] | null = null;
+let sortedStaticPricingKeys: string[] | null = null;
+let refreshInFlight: Promise<number> | null = null;
+let disableDiskCacheForTest = false;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeModelVersion(model: string): string {
+  return model.trim().replace(/@.*$/, "").replace(/-\d{8}$/, "");
+}
+
+function canonicalPricingName(model: string): string {
+  return normalizeModelVersion(model).replace(/^[^/]+\//, "").toLowerCase();
+}
+
+function withProviderPricingName(model: string): string {
+  return normalizeModelVersion(model).toLowerCase();
+}
+
+function resolveAlias(model: string): string {
+  let current = model;
+  for (let i = 0; i < 4; i++) {
+    const alias = BUILTIN_PRICING_ALIASES[current];
+    if (alias) return alias;
+    const stripped = stripKnownVariantSuffix(current);
+    if (!stripped || stripped === current) break;
+    current = stripped;
+  }
+  return current;
+}
+
+function stripKnownVariantSuffix(model: string): string | null {
+  for (const suffix of CURSOR_VARIANT_SUFFIXES) {
+    if (model.endsWith(suffix) && model.length > suffix.length) {
+      return model.slice(0, -suffix.length);
+    }
+  }
+  return null;
+}
+
+function safePerTokenRate(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return null;
+  if (value > 1) return 1;
+  return value;
+}
+
+function parseLiteLlmEntry(entry: unknown): TokenPrice | null {
+  if (!isRecord(entry)) return null;
+  const input = safePerTokenRate(entry.input_cost_per_token);
+  const output = safePerTokenRate(entry.output_cost_per_token);
+  if (input == null || output == null) return null;
+  const cacheWrite = safePerTokenRate(entry.cache_creation_input_token_cost) ?? input * 1.25;
+  const cacheRead = safePerTokenRate(entry.cache_read_input_token_cost) ?? input * 0.1;
+  return { input, output, cacheWrite, cacheRead };
+}
+
+function parseCachedTokenPrice(entry: unknown): TokenPrice | null {
+  if (!isRecord(entry)) return null;
+  const input = safePerTokenRate(entry.inputCostPerToken ?? entry.input);
+  const output = safePerTokenRate(entry.outputCostPerToken ?? entry.output);
+  if (input == null || output == null) return null;
+  const cacheWrite = safePerTokenRate(entry.cacheWriteCostPerToken ?? entry.cacheWrite) ?? input * 1.25;
+  const cacheRead = safePerTokenRate(entry.cacheReadCostPerToken ?? entry.cacheRead) ?? input * 0.1;
+  return { input, output, cacheWrite, cacheRead };
+}
+
+function parsePricingMap(data: unknown): Map<string, TokenPrice> | null {
+  if (!isRecord(data)) return null;
+  const pricing = new Map<string, TokenPrice>();
+  for (const [modelName, rawEntry] of Object.entries(data)) {
+    const price = parseCachedTokenPrice(rawEntry) ?? parseLiteLlmEntry(rawEntry);
+    if (!price) continue;
+    const withPrefix = withProviderPricingName(modelName);
+    pricing.set(withPrefix, price);
+
+    const canonical = canonicalPricingName(modelName);
+    if (canonical !== withPrefix && !pricing.has(canonical)) {
+      pricing.set(canonical, price);
+    }
+  }
+  return pricing.size > 0 ? pricing : null;
+}
+
+function readPricingCacheFile(cachePath: string): { timestamp: number; pricing: Map<string, TokenPrice> } | null {
+  try {
+    const raw = fs.readFileSync(cachePath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed)) return null;
+    const timestamp = typeof parsed.timestamp === "number" && Number.isFinite(parsed.timestamp) ? parsed.timestamp : 0;
+    const pricing = parsePricingMap(parsed.data);
+    if (!pricing) return null;
+    return { timestamp, pricing };
+  } catch {
+    return null;
+  }
+}
+
+function installDynamicTokenPricing(pricing: Map<string, TokenPrice>, timestamp: number): number {
+  dynamicTokenPricing = pricing;
+  dynamicTokenPricingTimestamp = timestamp;
+  dynamicTokenPricingLoaded = true;
+  sortedDynamicPricingKeys = null;
+  return dynamicTokenPricing.size;
+}
+
+function loadDynamicTokenPricingFromDisk(): number {
+  if (disableDiskCacheForTest) {
+    dynamicTokenPricingLoaded = true;
+    return 0;
+  }
+
+  const caches = [readPricingCacheFile(ADE_PRICING_CACHE_PATH), readPricingCacheFile(CODEBURN_PRICING_CACHE_PATH)]
+    .filter((cache): cache is { timestamp: number; pricing: Map<string, TokenPrice> } => !!cache)
+    .sort((a, b) => b.timestamp - a.timestamp);
+
+  if (caches.length === 0) {
+    dynamicTokenPricingLoaded = true;
+    return 0;
+  }
+
+  return installDynamicTokenPricing(caches[0]!.pricing, caches[0]!.timestamp);
+}
+
+function ensureDynamicTokenPricingLoaded(): void {
+  if (!dynamicTokenPricingLoaded) {
+    loadDynamicTokenPricingFromDisk();
+  }
+}
+
+async function fetchLiteLlmPricing(): Promise<Map<string, TokenPrice>> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10_000);
+  try {
+    const response = await fetch(LITELLM_PRICING_URL, { signal: controller.signal });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const payload = (await response.json()) as unknown;
+    const pricing = parsePricingMap(payload);
+    if (!pricing) throw new Error("empty pricing payload");
+    return pricing;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function writeAdePricingCache(pricing: Map<string, TokenPrice>, timestamp: number): Promise<void> {
+  await fs.promises.mkdir(path.dirname(ADE_PRICING_CACHE_PATH), { recursive: true });
+  await fs.promises.writeFile(ADE_PRICING_CACHE_PATH, JSON.stringify({ timestamp, data: Object.fromEntries(pricing) }));
+}
+
+export async function refreshDynamicTokenPricing(logger?: PricingLogger): Promise<number> {
+  ensureDynamicTokenPricingLoaded();
+  if (dynamicTokenPricing.size > 0 && Date.now() - dynamicTokenPricingTimestamp < PRICING_CACHE_TTL_MS) {
+    return dynamicTokenPricing.size;
+  }
+  if (refreshInFlight) return await refreshInFlight;
+
+  refreshInFlight = (async () => {
+    try {
+      const pricing = await fetchLiteLlmPricing();
+      const timestamp = Date.now();
+      await writeAdePricingCache(pricing, timestamp).catch((error: unknown) => {
+        logger?.debug?.("usage.pricing.cache_write_failed", { error: error instanceof Error ? error.message : String(error) });
+      });
+      return installDynamicTokenPricing(pricing, timestamp);
+    } catch (error) {
+      logger?.debug?.("usage.pricing.refresh_failed", { error: error instanceof Error ? error.message : String(error) });
+      return dynamicTokenPricing.size;
+    } finally {
+      refreshInFlight = null;
+    }
+  })();
+
+  return await refreshInFlight;
+}
+
+function sortedKeysFor(pricing: Map<string, TokenPrice>, kind: "dynamic" | "static"): string[] {
+  if (kind === "dynamic") {
+    sortedDynamicPricingKeys ??= Array.from(pricing.keys()).sort((a, b) => b.length - a.length);
+    return sortedDynamicPricingKeys;
+  }
+  sortedStaticPricingKeys ??= Array.from(pricing.keys()).sort((a, b) => b.length - a.length);
+  return sortedStaticPricingKeys;
+}
+
+function findPriceInMap(pricing: Map<string, TokenPrice>, model: string, kind: "dynamic" | "static"): TokenPrice | null {
+  const withPrefix = withProviderPricingName(model);
+  const exactWithPrefix = pricing.get(withPrefix);
+  if (exactWithPrefix) return exactWithPrefix;
+
+  const rawCanonical = canonicalPricingName(model);
+  const exactRawCanonical = pricing.get(rawCanonical);
+  if (exactRawCanonical) return exactRawCanonical;
+
+  const canonical = resolveAlias(rawCanonical);
+  const exactCanonical = pricing.get(canonical);
+  if (exactCanonical) return exactCanonical;
+
+  for (const key of sortedKeysFor(pricing, kind)) {
+    if (canonical === key || canonical.startsWith(`${key}-`)) {
+      return pricing.get(key) ?? null;
+    }
+  }
+  return null;
+}
+
+function getStaticPricingMap(): Map<string, TokenPrice> {
+  return new Map(Object.entries(STATIC_TOKEN_PRICES));
+}
+
+export function resolveTokenPrice(model: string): TokenPrice {
+  ensureDynamicTokenPricingLoaded();
+  const dynamicPrice = findPriceInMap(dynamicTokenPricing, model ?? "", "dynamic");
+  if (dynamicPrice) return dynamicPrice;
+
+  const staticPrice = findPriceInMap(getStaticPricingMap(), model ?? "", "static");
+  if (staticPrice) return staticPrice;
+
+  const canonical = canonicalPricingName(model ?? "");
+  if (canonical.includes("opus")) return STATIC_TOKEN_PRICES["claude-opus"] ?? ZERO_PRICE;
+  if (canonical.includes("sonnet")) return STATIC_TOKEN_PRICES["claude-sonnet"] ?? ZERO_PRICE;
+  if (canonical.includes("haiku")) return STATIC_TOKEN_PRICES["claude-haiku"] ?? ZERO_PRICE;
+  if (canonical.includes("codex") || canonical.includes("gpt") || canonical.includes("o3") || canonical.includes("o4")) {
+    return STATIC_TOKEN_PRICES.codex ?? ZERO_PRICE;
+  }
+
+  return ZERO_PRICE;
+}
+
+export function isZeroTokenPrice(price: TokenPrice): boolean {
+  return price.input === 0 && price.output === 0 && price.cacheWrite === 0 && price.cacheRead === 0;
+}
+
+export function resetDynamicTokenPricingForTest(options?: { disableDiskCache?: boolean }): void {
+  dynamicTokenPricingLoaded = false;
+  dynamicTokenPricingTimestamp = 0;
+  dynamicTokenPricing = new Map();
+  sortedDynamicPricingKeys = null;
+  refreshInFlight = null;
+  disableDiskCacheForTest = options?.disableDiskCache ?? false;
+}
+
+export function setDynamicTokenPricingForTest(entries: Record<string, TokenPrice>): void {
+  disableDiskCacheForTest = true;
+  const pricing = new Map<string, TokenPrice>();
+  for (const [modelName, price] of Object.entries(entries)) {
+    pricing.set(withProviderPricingName(modelName), price);
+    pricing.set(canonicalPricingName(modelName), price);
+  }
+  installDynamicTokenPricing(pricing, Date.now());
+}
+
+export const _testing = {
+  canonicalPricingName,
+  parseLiteLlmEntry,
+  parsePricingMap,
+  resetDynamicTokenPricingForTest,
+  setDynamicTokenPricingForTest,
+};

--- a/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
@@ -3,12 +3,20 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { createRequire } from "node:module";
+import {
+  createDynamicCursorCliModelDescriptor,
+  MODEL_REGISTRY,
+  type ModelDescriptor,
+} from "../../../shared/modelRegistry";
 
 const mockState = vi.hoisted(() => ({
   spawn: vi.fn(),
   spawnSync: vi.fn(),
   resolveCodexExecutable: vi.fn(),
 }));
+
+const requireForTest = createRequire(path.join(process.cwd(), "usage-test.cjs"));
 
 vi.mock("node:child_process", () => ({
   spawn: (...args: unknown[]) => mockState.spawn(...args),
@@ -31,8 +39,21 @@ const {
   parseClaudeWindows,
   parseCodexRateLimitWindows,
   calculatePacingByProvider,
+  collectAdeUsageStats,
   pollCodexViaCliRpc,
   resolveTokenPrice,
+  resetDynamicTokenPricingForTest,
+  setDynamicTokenPricingForTest,
+  discoverClaudeProjectDirs,
+  scanClaudeLogs,
+  scanCodexLogs,
+  scanCursorLogs,
+  scanCursorAgentLogs,
+  scanOpenClawLogs,
+  scanOpenCodeLogs,
+  scanDroidLogs,
+  scanCopilotLogs,
+  scanGeminiLogs,
 } = _testing;
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -103,6 +124,7 @@ beforeEach(() => {
   mockState.spawnSync.mockReset();
   mockState.spawnSync.mockReturnValue({ status: 0, stdout: Buffer.alloc(0), stderr: Buffer.alloc(0) });
   mockState.resolveCodexExecutable.mockReset();
+  resetDynamicTokenPricingForTest({ disableDiskCache: true });
 });
 
 // ── calculatePacing ──────────────────────────────────────────────
@@ -241,10 +263,31 @@ describe("aggregateCosts", () => {
     expect(result.provider).toBe("claude");
     expect(result.last30dCostUsd).toBeGreaterThan(0);
     expect(result.todayCostUsd).toBeGreaterThan(0);
+    expect(result.costUsdByPreset?.today).toBe(result.todayCostUsd);
+    expect(result.costUsdByPreset?.["30d"]).toBe(result.last30dCostUsd);
     expect(result.tokenBreakdown["claude-3-5-sonnet"]).toBeDefined();
     expect(result.tokenBreakdown["claude-3-5-sonnet"]!.input).toBe(3000);
     expect(result.tokenBreakdown["claude-3-5-sonnet"]!.output).toBe(1500);
     expect(result.tokenBreakdown["claude-3-5-sonnet"]!.cached).toBe(200);
+  });
+
+  it("charges cache read and cache write tokens", () => {
+    const now = Date.now();
+    const result = aggregateCosts([
+      {
+        messageId: "cached:1",
+        model: "gpt-5.5",
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+        cachedTokens: 1_000_000,
+        cacheWriteTokens: 1_000_000,
+        timestamp: now - 1000,
+      },
+    ], "codex");
+
+    expect(result.last30dCostUsd).toBe(41.75);
+    expect(result.costUsdByPreset?.today).toBe(41.75);
+    expect(result.tokenBreakdown["gpt-5.5"]!.cacheWrite).toBe(1_000_000);
   });
 
   it("excludes entries older than 30 days", () => {
@@ -290,16 +333,136 @@ describe("aggregateCosts", () => {
     const result = aggregateCosts(entries, "claude");
     expect(result.last30dCostUsd).toBeGreaterThan(result.todayCostUsd);
     expect(result.todayCostUsd).toBeGreaterThan(0);
+    expect(result.costUsdByPreset?.today).toBe(result.todayCostUsd);
+    expect(result.costUsdByPreset?.["7d"]).toBe(result.last30dCostUsd);
+    expect(result.tokenBreakdownByPreset?.today?.["claude-3-5-sonnet"]?.input).toBe(1000);
+    expect(result.tokenBreakdownByPreset?.["7d"]?.["claude-3-5-sonnet"]?.input).toBe(2000);
+    expect(result.tokenBreakdownByPreset?.["30d"]?.["claude-3-5-sonnet"]?.input).toBe(2000);
+  });
+});
+
+// ── collectAdeUsageStats ─────────────────────────────────────────
+
+describe("collectAdeUsageStats", () => {
+  it("uses local runtime scans and GitHub activity without ADE database counting", () => {
+    const nowMs = Date.parse("2026-05-29T12:00:00.000Z");
+    const snapshot = {
+      windows: [],
+      pacing: calculatePacing([]),
+      pacingByProvider: {},
+      costs: [
+        {
+          provider: "codex",
+          todayCostUsd: 1.25,
+          last30dCostUsd: 5.5,
+          costUsdByPreset: {
+            today: 1.25,
+            "7d": 2.75,
+            "30d": 5.5,
+            all: 5.5,
+          },
+          tokenBreakdown: {
+            "gpt-5-codex": { input: 100, output: 50, cached: 20 },
+          },
+          tokenBreakdownByPreset: {
+            "7d": {
+              "gpt-5-codex": { input: 100, output: 50, cached: 20 },
+            },
+          },
+        },
+      ],
+      adeCosts: [],
+      extraUsage: [],
+      lastPolledAt: new Date(nowMs).toISOString(),
+      errors: [],
+    } as any;
+    const githubStats = {
+      repo: "arul28/ADE",
+      available: true,
+      fetchedAt: new Date(nowMs).toISOString(),
+      error: null,
+      commitsCreated: 9,
+      prsTracked: 7,
+      prsOpen: 3,
+      prsMerged: 6,
+      prsClosed: 1,
+      prAdditions: 9_106,
+      prDeletions: 1_313,
+      filesChanged: 86,
+      daily: [
+        {
+          date: "2026-05-29",
+          commits: 9,
+          prs: 7,
+          insertions: 9_106,
+          deletions: 1_313,
+          filesChanged: 86,
+        },
+      ],
+    };
+
+    const stats = collectAdeUsageStats({
+      snapshot,
+      githubStats,
+      args: { preset: "7d" },
+      nowMs,
+    });
+
+    expect(stats.summary.tokenTotalSource).toBe("provider_logs");
+    expect(stats.summary.totalTokens).toBe(170);
+    expect(stats.summary.observedProviderCostRangeUsd).toBe(2.75);
+    expect(stats.summary.adeRuntimeTokens).toBe(0);
+    expect(stats.summary.adeTotalTokens).toBe(0);
+    expect(stats.summary.trackedAdeTokens).toBe(0);
+    expect(stats.summary.workerTokens).toBe(0);
+    expect(stats.summary.activeLanes).toBe(0);
+    expect(stats.summary.prsTracked).toBe(7);
+    expect(stats.summary.prsOpen).toBe(3);
+    expect(stats.summary.prsMerged).toBe(6);
+    expect(stats.summary.prsClosed).toBe(1);
+    expect(stats.summary.commitsCreated).toBe(9);
+    expect(stats.summary.prAdditions).toBe(9_106);
+    expect(stats.summary.prDeletions).toBe(1_313);
+    expect(stats.github.repo).toBe("arul28/ADE");
+    expect(stats.providers.map((provider) => provider.provider)).toEqual(["codex"]);
+    expect(stats.adeProviders).toEqual([]);
+    expect(stats.agentProviders).toEqual([]);
+    expect(stats.daily.find((point) => point.date === "2026-05-29")).toMatchObject({
+      commits: 9,
+      prs: 7,
+      insertions: 9_106,
+      deletions: 1_313,
+      filesChanged: 86,
+    });
   });
 });
 
 // ── resolveTokenPrice ────────────────────────────────────────────
 
 describe("resolveTokenPrice", () => {
+  function missingPricedRefsForDescriptors(descriptors: ModelDescriptor[]): string[] {
+    const missing: string[] = [];
+    for (const descriptor of descriptors) {
+      const refs = [
+        descriptor.id,
+        descriptor.providerModelId,
+        descriptor.shortId,
+        ...(descriptor.aliases ?? []),
+      ];
+      for (const ref of refs) {
+        const price = resolveTokenPrice(ref);
+        if (price.input <= 0 || price.output <= 0) {
+          missing.push(`${descriptor.id} -> ${ref}`);
+        }
+      }
+    }
+    return missing;
+  }
+
   it("returns opus pricing for opus models", () => {
     const price = resolveTokenPrice("claude-opus-4");
-    expect(price.input).toBe(5 / 1_000_000);
-    expect(price.output).toBe(25 / 1_000_000);
+    expect(price.input).toBe(15 / 1_000_000);
+    expect(price.output).toBe(75 / 1_000_000);
   });
 
   it("returns sonnet pricing for sonnet models", () => {
@@ -309,29 +472,133 @@ describe("resolveTokenPrice", () => {
 
   it("returns haiku pricing for haiku models", () => {
     const price = resolveTokenPrice("claude-haiku-3");
-    expect(price.input).toBe(0.8 / 1_000_000);
+    expect(price.input).toBe(1 / 1_000_000);
   });
 
   it("returns codex pricing for GPT/codex models", () => {
     const price = resolveTokenPrice("gpt-4o");
-    expect(price.input).toBe(2 / 1_000_000);
+    expect(price.input).toBe(2.5 / 1_000_000);
+    expect(price.cacheRead).toBe(1.25 / 1_000_000);
   });
 
   it("returns mini pricing for mini OpenAI models", () => {
     const price = resolveTokenPrice("gpt-5.4-mini");
-    expect(price.input).toBe(0.3 / 1_000_000);
-    expect(price.output).toBe(1.2 / 1_000_000);
+    expect(price.input).toBe(0.75 / 1_000_000);
+    expect(price.output).toBe(4.5 / 1_000_000);
   });
 
   it("does not treat Gemini as a mini OpenAI model", () => {
     const price = resolveTokenPrice("gemini-2.5-pro");
-    expect(price.input).toBe(3 / 1_000_000);
-    expect(price.output).toBe(15 / 1_000_000);
+    expect(price.input).toBe(1.25 / 1_000_000);
+    expect(price.output).toBe(10 / 1_000_000);
   });
 
-  it("returns default pricing for unknown models", () => {
+  it("returns zero pricing for unknown models", () => {
     const price = resolveTokenPrice("unknown-model");
+    expect(price.input).toBe(0);
+    expect(price.output).toBe(0);
+  });
+
+  it("prefers Codeburn-style dynamic pricing with provider and date normalization", () => {
+    setDynamicTokenPricingForTest({
+      "openai/gpt-dynamic": {
+        input: 9 / 1_000_000,
+        output: 27 / 1_000_000,
+        cacheWrite: 11.25 / 1_000_000,
+        cacheRead: 0.9 / 1_000_000,
+      },
+    });
+
+    const price = resolveTokenPrice("openai/gpt-dynamic-20260101");
+    expect(price.input).toBe(9 / 1_000_000);
+    expect(price.output).toBe(27 / 1_000_000);
+  });
+
+  it("uses Codeburn-compatible aliases for runtime auto models", () => {
+    const price = resolveTokenPrice("cursor-auto");
     expect(price.input).toBe(3 / 1_000_000);
+    expect(price.output).toBe(15 / 1_000_000);
+    expect(resolveTokenPrice("composer-2.5").input).toBe(3 / 1_000_000);
+  });
+
+  it("prices every ADE Claude and Codex registry id and alias without dynamic pricing", () => {
+    const required = MODEL_REGISTRY.filter(
+      (descriptor) => descriptor.isCliWrapped && (descriptor.family === "anthropic" || descriptor.family === "openai"),
+    );
+
+    expect(missingPricedRefsForDescriptors(required)).toEqual([]);
+  });
+
+  it("prices known Cursor model families and variants without dynamic pricing", () => {
+    const cursorModelIds = [
+      "auto",
+      "cursor-auto",
+      "cursor-agent-auto",
+      "composer-1",
+      "composer-1.5",
+      "composer-2",
+      "composer-2.5",
+      "composer-2.5-fast",
+      "composer-latest",
+      "claude-4-sonnet",
+      "claude-4-sonnet-1m",
+      "claude-4-sonnet-thinking",
+      "claude-4.5-sonnet",
+      "claude-4.5-sonnet-thinking",
+      "claude-4.6-sonnet",
+      "claude-4.6-sonnet-medium",
+      "claude-4.6-sonnet-high",
+      "claude-4.6-sonnet-low",
+      "claude-4.6-sonnet-thinking",
+      "claude-4.6-sonnet-high-thinking",
+      "claude-4-opus",
+      "claude-4.5-opus",
+      "claude-4.5-opus-high",
+      "claude-4.5-opus-low",
+      "claude-4.5-opus-medium",
+      "claude-4.5-opus-high-thinking",
+      "claude-4.6-opus",
+      "claude-4.6-opus-fast-mode",
+      "claude-4.6-opus-high",
+      "claude-4.6-opus-low",
+      "claude-4.6-opus-medium",
+      "claude-4.6-opus-high-thinking",
+      "claude-4.7-opus",
+      "claude-opus-4-7-thinking-high",
+      "claude-4.5-haiku",
+      "claude-4.6-haiku",
+      "gpt-5-fast",
+      "gpt-5.2-low",
+      "gpt-5.1-codex-high",
+      "gpt-5",
+      "gpt-5.1",
+      "gpt-5.2",
+      "gpt-5.3",
+      "gpt-5.3-codex",
+      "gpt-5.3-spark",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+      "gpt-5.5",
+      "gpt-4.1",
+      "gpt-4.1-mini",
+      "gpt-4.1-nano",
+      "o3",
+      "o4-mini",
+      "gemini-3.1-pro",
+      "gemini-3-flash",
+      "gemini-3.1-pro-high",
+      "gemini-3.1-pro-low",
+      "gemini-3-flash-agent",
+      "gemini-3-pro",
+      "gemini-3.1-flash-image",
+      "gemini-3.1-flash-lite",
+      "grok-code-fast-1",
+      "kimi-k2.5",
+      "kimi-k2-thinking",
+    ];
+    const descriptors = cursorModelIds.map((modelId) => createDynamicCursorCliModelDescriptor(modelId));
+
+    expect(missingPricedRefsForDescriptors(descriptors)).toEqual([]);
   });
 });
 
@@ -601,6 +868,13 @@ describe("createUsageTrackingService", () => {
     pollCodexUsage: vi.fn(async () => ({ windows: [] as never[], errors: [] as never[] })),
     scanClaudeLogs: vi.fn(async () => [] as never[]),
     scanCodexLogs: vi.fn(async () => [] as never[]),
+    scanCursorLogs: vi.fn(async () => [] as never[]),
+    scanCursorAgentLogs: vi.fn(async () => [] as never[]),
+    scanOpenClawLogs: vi.fn(async () => [] as never[]),
+    scanOpenCodeLogs: vi.fn(async () => [] as never[]),
+    scanDroidLogs: vi.fn(async () => [] as never[]),
+    scanCopilotLogs: vi.fn(async () => [] as never[]),
+    scanGeminiLogs: vi.fn(async () => [] as never[]),
   });
 
   it("returns an empty snapshot before polling", () => {
@@ -678,6 +952,139 @@ describe("createUsageTrackingService", () => {
     expect(s1.lastPolledAt).toBeTruthy();
     expect(dependencies.scanClaudeLogs).toHaveBeenCalledTimes(1);
     expect(dependencies.scanCodexLogs).toHaveBeenCalledTimes(1);
+    expect(dependencies.scanCursorLogs).toHaveBeenCalledTimes(1);
+    expect(dependencies.scanCursorAgentLogs).toHaveBeenCalledTimes(1);
+    expect(dependencies.scanOpenClawLogs).toHaveBeenCalledTimes(1);
+    expect(dependencies.scanOpenCodeLogs).toHaveBeenCalledTimes(1);
+    expect(dependencies.scanDroidLogs).toHaveBeenCalledTimes(1);
+    expect(dependencies.scanCopilotLogs).toHaveBeenCalledTimes(1);
+    expect(dependencies.scanGeminiLogs).toHaveBeenCalledTimes(1);
+
+    service.dispose();
+  });
+
+  it("keeps GitHub stats cache entries precise for same-day custom ranges", async () => {
+    const logger = createLogger();
+    const scanGitHubStats = vi.fn(async (range: any) => ({
+      repo: "arul28/ADE",
+      available: true,
+      fetchedAt: range.until,
+      error: null,
+      commitsCreated: new Date(range.until).getUTCHours(),
+      prsTracked: 0,
+      prsOpen: 0,
+      prsMerged: 0,
+      prsClosed: 0,
+      prAdditions: 0,
+      prDeletions: 0,
+      filesChanged: 0,
+      daily: [],
+    }));
+    const service = createUsageTrackingService({
+      logger,
+      dependencies: {
+        ...createFastDependencies(),
+        scanGitHubStats,
+      },
+    });
+
+    const first = await service.getAdeUsageStats({
+      preset: "today",
+      since: "2026-05-30T00:00:00.000Z",
+      until: "2026-05-30T10:00:00.000Z",
+    });
+    const second = await service.getAdeUsageStats({
+      preset: "today",
+      since: "2026-05-30T00:00:00.000Z",
+      until: "2026-05-30T11:00:00.000Z",
+    });
+
+    expect(first.summary.commitsCreated).toBe(10);
+    expect(second.summary.commitsCreated).toBe(11);
+    expect(scanGitHubStats).toHaveBeenCalledTimes(2);
+
+    service.dispose();
+  });
+
+  it("clamps inverted custom ranges before scanning GitHub stats", async () => {
+    const logger = createLogger();
+    const scanGitHubStats = vi.fn(async () => ({
+      repo: "arul28/ADE",
+      available: true,
+      fetchedAt: null,
+      error: null,
+      commitsCreated: 0,
+      prsTracked: 0,
+      prsOpen: 0,
+      prsMerged: 0,
+      prsClosed: 0,
+      prAdditions: 0,
+      prDeletions: 0,
+      filesChanged: 0,
+      daily: [],
+    }));
+    const service = createUsageTrackingService({
+      logger,
+      dependencies: {
+        ...createFastDependencies(),
+        scanGitHubStats,
+      },
+    });
+
+    await service.getAdeUsageStats({
+      preset: "7d",
+      since: "2026-05-31T00:00:00.000Z",
+      until: "2026-05-30T00:00:00.000Z",
+    });
+
+    expect(scanGitHubStats).toHaveBeenCalledWith(expect.objectContaining({
+      since: "2026-05-30T00:00:00.000Z",
+      until: "2026-05-30T00:00:00.000Z",
+    }));
+
+    service.dispose();
+  });
+
+  it("counts all Codex ledger entries in the full Codex runtime total", async () => {
+    const logger = createLogger();
+    const now = Date.now();
+    const dependencies = {
+      ...createFastDependencies(),
+      scanCodexLogs: vi.fn(async () => [
+        {
+          messageId: "codex-local",
+          model: "gpt-5.5",
+          originator: "codex_cli_rs",
+          inputTokens: 100,
+          outputTokens: 20,
+          cachedTokens: 40,
+          billableCachedTokens: 20,
+          cacheWriteTokens: 0,
+          timestamp: now,
+        },
+        {
+          messageId: "codex-ade",
+          model: "gpt-5.5",
+          originator: "ade",
+          inputTokens: 50,
+          outputTokens: 10,
+          cachedTokens: 20,
+          billableCachedTokens: 10,
+          cacheWriteTokens: 0,
+          timestamp: now,
+        },
+      ] as any),
+    };
+    const service = createUsageTrackingService({ logger, dependencies });
+
+    const snapshot = await service.forceRefresh();
+
+    expect(snapshot.costs.find((cost) => cost.provider === "codex")?.tokenBreakdownByPreset?.today?.["gpt-5.5"]).toMatchObject({
+      input: 150,
+      output: 30,
+      cached: 60,
+    });
+    expect(snapshot.adeCosts).toEqual([]);
 
     service.dispose();
   });
@@ -748,6 +1155,586 @@ describe("scanClaudeLogs (via aggregateCosts)", () => {
     expect(cost.tokenBreakdown["claude-opus-4"]!.output).toBe(1500);
     expect(cost.last30dCostUsd).toBeGreaterThan(0);
   });
+
+  it("discovers Claude projects from CLAUDE_CONFIG_DIRS", async () => {
+    const tmpDir = makeTmpDir();
+    const staleDir = path.join(tmpDir, "missing");
+    const configDir = path.join(tmpDir, "claude-config");
+    const projectDir = path.join(configDir, "projects", "project-a");
+    const originalConfigDirs = process.env.CLAUDE_CONFIG_DIRS;
+    const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    try {
+      fs.mkdirSync(projectDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectDir, "session-1.jsonl"),
+        [
+          JSON.stringify({
+            type: "assistant",
+            timestamp: "2026-05-29T12:00:00.000Z",
+            message: {
+              id: "msg-1",
+              model: "claude-opus-4-6",
+              usage: {
+                input_tokens: 100,
+                output_tokens: 20,
+                cache_read_input_tokens: 30,
+                cache_creation_input_tokens: 5,
+              },
+            },
+          }),
+          "",
+        ].join("\n"),
+      );
+
+      process.env.CLAUDE_CONFIG_DIRS = [staleDir, configDir].join(path.delimiter);
+      delete process.env.CLAUDE_CONFIG_DIR;
+
+      const discoveredProjectDirs = await discoverClaudeProjectDirs();
+      expect(discoveredProjectDirs.map((value) => path.resolve(value))).toContain(path.resolve(projectDir));
+
+      const entries = await scanClaudeLogs([projectDir]);
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        messageId: "msg-1",
+        model: "claude-opus-4-6",
+        inputTokens: 100,
+        outputTokens: 20,
+        cachedTokens: 30,
+        cacheWriteTokens: 5,
+      });
+    } finally {
+      if (originalConfigDirs === undefined) {
+        delete process.env.CLAUDE_CONFIG_DIRS;
+      } else {
+        process.env.CLAUDE_CONFIG_DIRS = originalConfigDirs;
+      }
+      if (originalConfigDir === undefined) {
+        delete process.env.CLAUDE_CONFIG_DIR;
+      } else {
+        process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+      }
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("scanCodexLogs", () => {
+  it("parses modern token_count events from Codex session logs", async () => {
+    const tmpDir = makeTmpDir();
+    const originalCodexHome = process.env.CODEX_HOME;
+    try {
+      process.env.CODEX_HOME = tmpDir;
+      const sessionDir = path.join(tmpDir, "sessions", "2026", "05", "29");
+      fs.mkdirSync(sessionDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sessionDir, "rollout-2026-05-29T12-00-00-test.jsonl"),
+        [
+          JSON.stringify({
+            timestamp: "2026-05-29T12:00:00.000Z",
+            type: "session_meta",
+            payload: {
+              id: "session-1",
+              originator: "codex_cli_rs",
+              cwd: "/repo",
+              model: "gpt-5.5",
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-05-29T12:00:01.000Z",
+            type: "turn_context",
+            payload: { model: "gpt-5.5" },
+          }),
+          JSON.stringify({
+            timestamp: "2026-05-29T12:00:02.000Z",
+            type: "event_msg",
+            payload: {
+              type: "token_count",
+              info: {
+                total_token_usage: {
+                  input_tokens: 1200,
+                  cached_input_tokens: 300,
+                  output_tokens: 80,
+                  reasoning_output_tokens: 20,
+                  total_tokens: 1300,
+                },
+                last_token_usage: {
+                  input_tokens: 1200,
+                  cached_input_tokens: 300,
+                  output_tokens: 80,
+                  reasoning_output_tokens: 20,
+                  total_tokens: 1300,
+                },
+              },
+            },
+          }),
+          "",
+        ].join("\n"),
+      );
+
+      const entries = await scanCodexLogs();
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        model: "gpt-5.5",
+        inputTokens: 1200,
+        billableInputTokens: 900,
+        outputTokens: 100,
+        cachedTokens: 300,
+        billableCachedTokens: 300,
+      });
+    } finally {
+      if (originalCodexHome === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = originalCodexHome;
+      }
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("counts Codex-owned session files while skipping ADE-originated launcher files", async () => {
+    const tmpDir = makeTmpDir();
+    const originalCodexHome = process.env.CODEX_HOME;
+    try {
+      process.env.CODEX_HOME = tmpDir;
+      const sessionDir = path.join(tmpDir, "sessions", "2026", "05", "29");
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const writeSession = (originator: string, file: string) => {
+        fs.writeFileSync(
+          path.join(sessionDir, file),
+          [
+            JSON.stringify({
+              timestamp: "2026-05-29T12:00:00.000Z",
+              type: "session_meta",
+              payload: { id: file, originator, cwd: "/repo", model: "gpt-5.5" },
+            }),
+            JSON.stringify({
+              timestamp: "2026-05-29T12:00:01.000Z",
+              type: "event_msg",
+              payload: {
+                type: "token_count",
+                info: {
+                  total_token_usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+                  last_token_usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+                },
+              },
+            }),
+            "",
+          ].join("\n"),
+        );
+      };
+      writeSession("codex_cli_rs", "rollout-2026-05-29T12-00-00-codex.jsonl");
+      writeSession("Codex Desktop", "rollout-2026-05-29T12-00-02-desktop.jsonl");
+      writeSession("ade", "rollout-2026-05-29T12-00-01-ade.jsonl");
+      writeSession("ade_desktop", "rollout-2026-05-29T12-00-03-ade-desktop.jsonl");
+
+      const entries = await scanCodexLogs();
+
+      expect(entries).toHaveLength(2);
+      expect(entries.map((entry) => entry.originator).sort()).toEqual(["Codex Desktop", "codex_cli_rs"]);
+    } finally {
+      if (originalCodexHome === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = originalCodexHome;
+      }
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("scanOpenClawLogs", () => {
+  it("parses assistant usage from OpenClaw session logs", async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const sessionDir = path.join(tmpDir, ".openclaw", "agents", "director", "sessions");
+      fs.mkdirSync(sessionDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sessionDir, "session-1.jsonl"),
+        [
+          JSON.stringify({
+            type: "session",
+            id: "session-1",
+            timestamp: "2026-05-29T12:00:00.000Z",
+          }),
+          JSON.stringify({
+            type: "model_change",
+            modelId: "gpt-5.4",
+            timestamp: "2026-05-29T12:00:01.000Z",
+          }),
+          JSON.stringify({
+            type: "message",
+            id: "message-1",
+            timestamp: "2026-05-29T12:00:02.000Z",
+            message: {
+              role: "assistant",
+              model: "gpt-5.4",
+              usage: {
+                input: 100,
+                output: 20,
+                cacheRead: 30,
+                cacheWrite: 40,
+                cost: { total: 0.12 },
+              },
+            },
+          }),
+          "",
+        ].join("\n"),
+      );
+
+      const entries = await scanOpenClawLogs([path.join(tmpDir, ".openclaw", "agents")]);
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        model: "gpt-5.4",
+        inputTokens: 100,
+        outputTokens: 20,
+        cachedTokens: 30,
+        billableCachedTokens: 30,
+        cacheWriteTokens: 40,
+        costOverrideUsd: 0.12,
+      });
+      expect(aggregateCosts(entries, "openclaw").last30dCostUsd).toBe(0.12);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("scanDroidLogs", () => {
+  it("distributes Droid settings token totals across assistant calls", async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const sessionDir = path.join(tmpDir, "sessions", "project-a");
+      fs.mkdirSync(sessionDir, { recursive: true });
+      const sessionPath = path.join(sessionDir, "session-1.jsonl");
+      fs.writeFileSync(
+        sessionPath,
+        [
+          JSON.stringify({ type: "session_start", id: "session-1", cwd: "/repo" }),
+          JSON.stringify({
+            type: "message",
+            id: "assistant-1",
+            timestamp: "2026-05-29T12:00:00.000Z",
+            message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+          }),
+          JSON.stringify({
+            type: "message",
+            id: "assistant-2",
+            timestamp: "2026-05-29T12:01:00.000Z",
+            message: { role: "assistant", content: [{ type: "tool_use", name: "Execute" }] },
+          }),
+          "",
+        ].join("\n"),
+      );
+      fs.writeFileSync(
+        sessionPath.replace(/\.jsonl$/, ".settings.json"),
+        JSON.stringify({
+          model: "custom:[anthropic]-claude-sonnet-4-6-20260501",
+          tokenUsage: {
+            inputTokens: 101,
+            outputTokens: 41,
+            thinkingTokens: 2,
+            cacheCreationTokens: 5,
+            cacheReadTokens: 9,
+          },
+        }),
+      );
+
+      const entries = await scanDroidLogs(path.join(tmpDir, "sessions"));
+
+      expect(entries).toHaveLength(2);
+      expect(entries[0]).toMatchObject({
+        model: "claude-sonnet-4-6",
+        inputTokens: 50,
+        outputTokens: 21,
+        cachedTokens: 4,
+        billableCachedTokens: 4,
+        cacheWriteTokens: 2,
+      });
+      expect(entries[1]).toMatchObject({
+        inputTokens: 51,
+        outputTokens: 22,
+        cachedTokens: 5,
+        billableCachedTokens: 5,
+        cacheWriteTokens: 3,
+      });
+      expect(aggregateCosts(entries, "droid").tokenBreakdownByPreset?.all?.["claude-sonnet-4-6"]?.costUsd).toBeGreaterThan(0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("scanCopilotLogs", () => {
+  it("parses Copilot legacy session state events", async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const sessionDir = path.join(tmpDir, "session-1");
+      fs.mkdirSync(sessionDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(sessionDir, "events.jsonl"),
+        [
+          JSON.stringify({
+            type: "session.model_change",
+            timestamp: "2026-05-29T12:00:00.000Z",
+            data: { newModel: "gpt-5.4" },
+          }),
+          JSON.stringify({
+            type: "user.message",
+            timestamp: "2026-05-29T12:00:01.000Z",
+            data: { content: "please edit file" },
+          }),
+          JSON.stringify({
+            type: "assistant.message",
+            timestamp: "2026-05-29T12:00:02.000Z",
+            data: { messageId: "assistant-1", outputTokens: 42 },
+          }),
+          "",
+        ].join("\n"),
+      );
+
+      const entries = await scanCopilotLogs(tmpDir, []);
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        messageId: "copilot:session-1:assistant-1",
+        model: "gpt-5.4",
+        inputTokens: 4,
+        outputTokens: 42,
+        cachedTokens: 0,
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("matches Copilot transcript token accounting when output tokens are recorded", async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const transcriptsDir = path.join(tmpDir, "workspace-a", "GitHub.copilot-chat", "transcripts");
+      fs.mkdirSync(transcriptsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(transcriptsDir, "session-1.jsonl"),
+        [
+          JSON.stringify({
+            type: "session.start",
+            timestamp: "2026-05-29T12:00:00.000Z",
+            data: { sessionId: "session-1", producer: "copilot-agent" },
+          }),
+          JSON.stringify({
+            type: "tool.execution_complete",
+            timestamp: "2026-05-29T12:00:01.000Z",
+            data: { model: "gpt-5.4" },
+          }),
+          JSON.stringify({
+            type: "user.message",
+            timestamp: "2026-05-29T12:00:02.000Z",
+            data: { content: "hello" },
+          }),
+          JSON.stringify({
+            type: "assistant.message",
+            timestamp: "2026-05-29T12:00:03.000Z",
+            data: {
+              messageId: "assistant-1",
+              content: "done",
+              reasoningText: "hidden reasoning text that should not be added when outputTokens exists",
+              outputTokens: 12,
+            },
+          }),
+          "",
+        ].join("\n"),
+      );
+
+      const entries = await scanCopilotLogs(path.join(tmpDir, "missing-session-state"), [tmpDir]);
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        model: "gpt-5.4",
+        inputTokens: 2,
+        outputTokens: 12,
+        billableOutputTokens: 12,
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("scanGeminiLogs", () => {
+  it("parses Gemini JSONL session token rows", async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const chatsDir = path.join(tmpDir, "project-a", "chats");
+      fs.mkdirSync(chatsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(chatsDir, "session-1.jsonl"),
+        [
+          JSON.stringify({
+            sessionId: "session-1",
+            startTime: "2026-05-29T12:00:00.000Z",
+            projectHash: "project-a",
+          }),
+          JSON.stringify({
+            id: "user-1",
+            type: "user",
+            timestamp: "2026-05-29T12:00:01.000Z",
+            content: "build thing",
+          }),
+          JSON.stringify({
+            id: "gemini-1",
+            type: "gemini",
+            timestamp: "2026-05-29T12:00:02.000Z",
+            model: "gemini-3.1-pro-preview",
+            content: "done",
+            tokens: { input: 120, output: 30, cached: 20, thoughts: 5 },
+          }),
+          "",
+        ].join("\n"),
+      );
+
+      const entries = await scanGeminiLogs(tmpDir);
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        messageId: "gemini:session-1:gemini-1",
+        model: "gemini-3.1-pro-preview",
+        inputTokens: 100,
+        outputTokens: 35,
+        cachedTokens: 20,
+        billableCachedTokens: 20,
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("scanOpenCodeLogs", () => {
+  it("parses assistant token rows from OpenCode SQLite databases", async () => {
+    const tmpDir = makeTmpDir();
+    const { DatabaseSync } = requireForTest("node:sqlite") as { DatabaseSync: new (dbPath: string, options?: Record<string, unknown>) => any };
+    try {
+      const dbPath = path.join(tmpDir, "opencode.db");
+      const db = new DatabaseSync(dbPath);
+      db.exec(`
+        create table message (
+          id text,
+          session_id text,
+          time_created integer,
+          data text
+        );
+      `);
+      db.prepare("insert into message values (?, ?, ?, ?)").run(
+        "msg-1",
+        "session-1",
+        Date.parse("2026-05-29T12:00:00.000Z"),
+        JSON.stringify({
+          role: "assistant",
+          modelID: "openai/gpt-5.4",
+          cost: 0.42,
+          tokens: {
+            input: 100,
+            output: 20,
+            reasoning: 3,
+            cache: { read: 40, write: 5 },
+          },
+        }),
+      );
+      db.close();
+
+      const entries = await scanOpenCodeLogs(tmpDir);
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        messageId: "opencode:session-1:msg-1",
+        model: "openai/gpt-5.4",
+        inputTokens: 100,
+        outputTokens: 23,
+        cachedTokens: 40,
+        billableCachedTokens: 40,
+        cacheWriteTokens: 5,
+        costOverrideUsd: 0.42,
+      });
+      expect(aggregateCosts(entries, "opencode").last30dCostUsd).toBe(0.42);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("scanCursorLogs", () => {
+  it("parses Cursor bubble token rows from state.vscdb", async () => {
+    const tmpDir = makeTmpDir();
+    const { DatabaseSync } = requireForTest("node:sqlite") as { DatabaseSync: new (dbPath: string, options?: Record<string, unknown>) => any };
+    try {
+      const dbPath = path.join(tmpDir, "state.vscdb");
+      const db = new DatabaseSync(dbPath);
+      db.exec("create table cursorDiskKV (key text, value text);");
+      db.prepare("insert into cursorDiskKV values (?, ?)").run(
+        "bubbleId:conversation-1:bubble-1",
+        JSON.stringify({
+          tokenCount: { inputTokens: 120, outputTokens: 30 },
+          modelInfo: { modelName: "cursor-auto" },
+          createdAt: "2026-05-29T12:00:00.000Z",
+          conversationId: "conversation-1",
+          text: "hello",
+          type: 1,
+        }),
+      );
+      db.close();
+
+      const entries = await scanCursorLogs(dbPath);
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        messageId: "cursor:bubble:bubbleId:conversation-1:bubble-1",
+        model: "cursor-auto",
+        inputTokens: 120,
+        outputTokens: 30,
+        cachedTokens: 0,
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("scanCursorAgentLogs", () => {
+  it("estimates Cursor Agent transcript turns from local transcript files", async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const transcriptDir = path.join(tmpDir, "project-a", "agent-transcripts", "00000000-0000-4000-8000-000000000001");
+      fs.mkdirSync(transcriptDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(transcriptDir, "00000000-0000-4000-8000-000000000001.jsonl"),
+        [
+          JSON.stringify({
+            role: "user",
+            message: { content: [{ type: "text", text: "<user_query>write code</user_query>" }] },
+          }),
+          JSON.stringify({
+            role: "assistant",
+            message: { content: [{ type: "text", text: "here is code" }] },
+          }),
+          "",
+        ].join("\n"),
+      );
+
+      const entries = await scanCursorAgentLogs(tmpDir);
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        model: "cursor-agent-auto",
+        inputTokens: 3,
+        outputTokens: 3,
+        cachedTokens: 0,
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("findJsonlFiles", () => {
@@ -789,7 +1776,8 @@ describe("findJsonlFiles", () => {
     const smallPath = path.join(tmpDir, "small.jsonl");
     const bigPath = path.join(tmpDir, "large.jsonl");
     fs.writeFileSync(smallPath, '{"test": true}\n');
-    fs.writeFileSync(bigPath, Buffer.alloc(9 * 1024 * 1024, "x"));
+    fs.writeFileSync(bigPath, "");
+    fs.truncateSync(bigPath, 769 * 1024 * 1024);
 
     const files = await _testing.findJsonlFiles(tmpDir, 30);
 

--- a/apps/desktop/src/main/services/usage/usageTrackingService.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.ts
@@ -2,7 +2,7 @@
  * usageTrackingService.ts
  *
  * Polls live usage data from Claude and Codex providers.
- * Scans local JSONL logs for cost/token aggregation.
+ * Scans local provider ledgers for ADE-supported runtime cost/token aggregation.
  * Computes pacing relative to provider reset windows.
  */
 
@@ -10,17 +10,34 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
 import { createInterface } from "node:readline";
 import type { Logger } from "../logging/logger";
 import type {
+  AdeUsageDailyPoint,
+  AdeUsageModelSummary,
+  AdeUsageProviderSummary,
+  AdeUsageRangePreset,
+  AdeUsageStats,
+  GetAdeUsageStatsArgs,
   UsageProvider,
   UsageWindow,
   UsagePacing,
   CostSnapshot,
+  CostTokenBreakdown,
   ExtraUsage,
   UsageSnapshot,
 } from "../../../shared/types";
+import type { SqlValue } from "../state/kvDb";
 import { isRecord, nowIso, getErrorMessage, safeJsonParse } from "../shared/utils";
+import {
+  decodeOpenCodeRegistryId,
+  getModelById,
+  parseLocalProviderFromModelId,
+  resolveModelAlias,
+  type ModelDescriptor,
+} from "../../../shared/modelRegistry";
 import {
   clearClaudeCredentialCache,
   isClaudeTokenExpiredOrExpiring,
@@ -32,17 +49,50 @@ import {
 } from "../ai/providerCredentialSources";
 import { resolveCodexExecutable } from "../ai/codexExecutable";
 import { resolveCliSpawnInvocation, terminateProcessTree } from "../shared/processExecution";
+import {
+  ONE_HOUR_CACHE_WRITE_MULTIPLIER,
+  refreshDynamicTokenPricing,
+  resetDynamicTokenPricingForTest,
+  resolveTokenPrice,
+  setDynamicTokenPricingForTest,
+  WEB_SEARCH_COST_USD,
+} from "./usagePricing";
 
 // ── Constants ────────────────────────────────────────────────────
 
 const DEFAULT_POLL_INTERVAL_MS = 2 * 60_000; // 2 min
 const MIN_POLL_INTERVAL_MS = 60_000;          // 1 min
 const MAX_POLL_INTERVAL_MS = 15 * 60_000;     // 15 min
-const COST_CACHE_TTL_MS = 60_000;             // 60s
+const COST_CACHE_TTL_MS = 10 * 60_000;        // 10 min
 const CODEX_CLI_RPC_TIMEOUT_MS = 10_000;
-const LOCAL_COST_SCAN_MAX_FILES = 200;
-const LOCAL_COST_SCAN_MAX_FILE_BYTES = 8 * 1024 * 1024;
-const LOCAL_COST_SCAN_MAX_ENTRIES = 20_000;
+const LOCAL_COST_SCAN_MAX_FILES = 5_000;
+const LOCAL_COST_SCAN_MAX_FILE_BYTES = 768 * 1024 * 1024;
+const LOCAL_COST_SCAN_MAX_ENTRIES = 1_000_000;
+const LOCAL_COST_SCAN_ALL_DAYS = 3650;
+const LOCAL_SQLITE_SCAN_MAX_ROWS = 250_000;
+const LOCAL_CURSOR_SQLITE_RECENT_ROWS = 250_000;
+const CURSOR_CHARS_PER_TOKEN = 4;
+const FORCE_REFRESH_RESPONSE_TIMEOUT_MS = 60_000;
+const USAGE_SNAPSHOT_CACHE_VERSION = 2;
+const USAGE_SNAPSHOT_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const USAGE_SNAPSHOT_CACHE_PATH = path.join(os.homedir(), ".ade", "cache", "usage-snapshot.json");
+const GITHUB_STATS_CACHE_TTL_MS = 10 * 60_000;
+const GITHUB_STATS_COMMAND_TIMEOUT_MS = 60_000;
+const GITHUB_STATS_FAST_RESPONSE_TIMEOUT_MS = 2_500;
+const GITHUB_STATS_MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
+
+type UsageSqliteStatement = {
+  all: (...params: SqlValue[]) => Record<string, unknown>[];
+};
+type UsageSqliteDatabase = {
+  prepare: (sql: string) => UsageSqliteStatement;
+  exec?: (sql: string) => void;
+  close: () => void;
+};
+type UsageSqliteConstructor = new (dbPath: string, options?: { readOnly?: boolean }) => UsageSqliteDatabase;
+
+const requireForUsageSqlite = createRequire(path.join(process.cwd(), "ade-runtime.cjs"));
+let usageSqliteConstructor: UsageSqliteConstructor | null | undefined;
 
 function isBenignStdinCloseError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
@@ -50,18 +100,55 @@ function isBenignStdinCloseError(error: unknown): boolean {
   return code === "EPIPE" || code === "ERR_STREAM_DESTROYED";
 }
 
+function shouldUseSnapshotCache(): boolean {
+  return process.env.VITEST !== "true" && process.env.NODE_ENV !== "test";
+}
+
+function isCostSnapshotArray(value: unknown): value is CostSnapshot[] {
+  return Array.isArray(value) && value.every((entry) => isRecord(entry) && typeof entry.provider === "string");
+}
+
+function isUsageSnapshot(value: unknown): value is UsageSnapshot {
+  return isRecord(value)
+    && Array.isArray(value.windows)
+    && isCostSnapshotArray(value.costs)
+    && isCostSnapshotArray(value.adeCosts)
+    && typeof value.lastPolledAt === "string"
+    && Array.isArray(value.errors);
+}
+
+function readCachedUsageSnapshot(logger: Logger): UsageSnapshot | null {
+  if (!shouldUseSnapshotCache()) return null;
+  try {
+    const raw = fs.readFileSync(USAGE_SNAPSHOT_CACHE_PATH, "utf8");
+    const parsed = safeJsonParse<unknown>(raw, null);
+    if (!isRecord(parsed) || parsed.version !== USAGE_SNAPSHOT_CACHE_VERSION || !isUsageSnapshot(parsed.snapshot)) return null;
+    const generatedAt = Date.parse(parsed.snapshot.lastPolledAt);
+    if (!Number.isFinite(generatedAt) || Date.now() - generatedAt > USAGE_SNAPSHOT_CACHE_TTL_MS) return null;
+    return parsed.snapshot;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      logger.debug("usage.snapshot_cache_read_failed", { error: getErrorMessage(error) });
+    }
+    return null;
+  }
+}
+
+async function writeCachedUsageSnapshot(snapshot: UsageSnapshot, logger: Logger): Promise<void> {
+  if (!shouldUseSnapshotCache()) return;
+  try {
+    await fs.promises.mkdir(path.dirname(USAGE_SNAPSHOT_CACHE_PATH), { recursive: true });
+    await fs.promises.writeFile(
+      USAGE_SNAPSHOT_CACHE_PATH,
+      JSON.stringify({ version: USAGE_SNAPSHOT_CACHE_VERSION, snapshot }),
+    );
+  } catch (error) {
+    logger.debug("usage.snapshot_cache_write_failed", { error: getErrorMessage(error) });
+  }
+}
+
 const CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
 const CODEX_USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
-
-// Per-million token prices for cost estimation
-const TOKEN_PRICES: Record<string, { input: number; output: number }> = {
-  "claude-opus":   { input: 5 / 1_000_000, output: 25 / 1_000_000 },
-  "claude-sonnet": { input: 3 / 1_000_000, output: 15 / 1_000_000 },
-  "claude-haiku":  { input: 0.8 / 1_000_000, output: 4 / 1_000_000 },
-  "codex":         { input: 2 / 1_000_000, output: 8 / 1_000_000 },
-  "openai-mini":   { input: 0.3 / 1_000_000, output: 1.2 / 1_000_000 },
-  "default":       { input: 3 / 1_000_000, output: 15 / 1_000_000 },
-};
 
 // ── HTTP Helper ──────────────────────────────────────────────────
 
@@ -511,39 +598,227 @@ async function pollCodexViaCliRpc(logger: Logger): Promise<{ windows: UsageWindo
 interface TokenEntry {
   messageId: string;
   model: string;
+  originator?: string;
   inputTokens: number;
+  billableInputTokens?: number;
   outputTokens: number;
+  billableOutputTokens?: number;
   cachedTokens: number;
+  billableCachedTokens?: number;
+  cacheWriteTokens?: number;
+  oneHourCacheWriteTokens?: number;
+  webSearchRequests?: number;
+  costOverrideUsd?: number;
   timestamp: number;
 }
 
-function resolveTokenPrice(model: string): { input: number; output: number } {
-  const lower = (model ?? "").toLowerCase();
-  const isMiniModel = /(?:^|[\/._-])mini(?:$|[\/._-])/.test(lower);
-  if (lower.includes("opus")) return TOKEN_PRICES["claude-opus"]!;
-  if (lower.includes("sonnet")) return TOKEN_PRICES["claude-sonnet"]!;
-  if (lower.includes("haiku")) return TOKEN_PRICES["claude-haiku"]!;
-  if (isMiniModel) return TOKEN_PRICES["openai-mini"]!;
-  if (lower.includes("codex") || lower.includes("gpt") || lower.includes("o3") || lower.includes("o4"))
-    return TOKEN_PRICES["codex"]!;
-  return TOKEN_PRICES["default"]!;
+function optionalNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-async function scanClaudeLogs(): Promise<TokenEntry[]> {
-  const entries: TokenEntry[] = [];
-  const seen = new Set<string>();
-  const claudeDir = path.join(os.homedir(), ".claude", "projects");
+function numberFromRecord(record: Record<string, unknown> | undefined, ...keys: string[]): number {
+  if (!record) return 0;
+  for (const key of keys) {
+    const value = optionalNumber(record[key]);
+    if (value != null) return value;
+  }
+  return 0;
+}
 
+function timestampMsFromValue(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const ms = Date.parse(value);
+    if (Number.isFinite(ms)) return ms;
+  }
+  return Date.now();
+}
+
+function timestampMsFromUnixish(value: unknown): number {
+  const numeric = optionalNumber(value);
+  if (numeric != null) return numeric < 1_000_000_000_000 ? numeric * 1_000 : numeric;
+  return timestampMsFromValue(value);
+}
+
+function estimateTokensFromText(value: string): number {
+  if (!value) return 0;
+  return Math.ceil(value.length / CURSOR_CHARS_PER_TOKEN);
+}
+
+function textFromSqliteValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Uint8Array) return Buffer.from(value).toString("utf8");
+  if (value == null) return "";
+  return String(value);
+}
+
+function loadUsageSqliteConstructor(): UsageSqliteConstructor | null {
+  if (usageSqliteConstructor !== undefined) return usageSqliteConstructor;
   try {
-    await fs.promises.access(claudeDir);
+    const sqlite = requireForUsageSqlite("node:sqlite") as { DatabaseSync?: UsageSqliteConstructor };
+    usageSqliteConstructor = sqlite.DatabaseSync ?? null;
   } catch {
-    return entries;
+    usageSqliteConstructor = null;
+  }
+  return usageSqliteConstructor;
+}
+
+function openReadonlyUsageDatabase(dbPath: string): UsageSqliteDatabase | null {
+  if (!fs.existsSync(dbPath)) return null;
+  const DatabaseSync = loadUsageSqliteConstructor();
+  if (!DatabaseSync) return null;
+  try {
+    const db = new DatabaseSync(dbPath, { readOnly: true });
+    try {
+      db.exec?.("PRAGMA busy_timeout = 1000");
+    } catch {
+      // Best-effort only; read-only scans should still work without it.
+    }
+    return db;
+  } catch {
+    return null;
+  }
+}
+
+function usageSqliteAll<T extends Record<string, unknown>>(
+  db: UsageSqliteDatabase,
+  sql: string,
+  params: SqlValue[] = [],
+): T[] {
+  return db.prepare(sql).all(...params) as T[];
+}
+
+function claudeCacheCreationTokens(usage: Record<string, unknown>): { total: number; oneHour: number } {
+  const legacyTotal = numberFromRecord(usage, "cache_creation_input_tokens");
+  const cacheCreation = isRecord(usage.cache_creation) ? usage.cache_creation : undefined;
+  const fiveMinute = numberFromRecord(cacheCreation, "ephemeral_5m_input_tokens");
+  const oneHour = numberFromRecord(cacheCreation, "ephemeral_1h_input_tokens");
+  const splitTotal = fiveMinute + oneHour;
+  if (splitTotal === 0) return { total: legacyTotal, oneHour: 0 };
+  const total = Math.max(legacyTotal, splitTotal);
+  return { total, oneHour: Math.min(oneHour, total) };
+}
+
+function expandUsageHome(value: string): string {
+  if (value === "~") return os.homedir();
+  if (value.startsWith("~/") || value.startsWith("~\\")) return path.join(os.homedir(), value.slice(2));
+  return value;
+}
+
+function dedupeResolvedPaths(paths: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const rawPath of paths) {
+    const resolved = path.resolve(expandUsageHome(rawPath));
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    out.push(resolved);
+  }
+  return out;
+}
+
+function getClaudeConfigDirs(): string[] {
+  const multi = process.env.CLAUDE_CONFIG_DIRS;
+  if (multi?.trim()) {
+    const dirs = multi
+      .split(path.delimiter)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    if (dirs.length > 0) return dedupeResolvedPaths(dirs);
   }
 
-  const jsonlFiles = await findJsonlFiles(claudeDir, 30);
+  const single = process.env.CLAUDE_CONFIG_DIR;
+  if (single?.trim()) return dedupeResolvedPaths([single]);
+
+  return [path.join(os.homedir(), ".claude")];
+}
+
+function getClaudeDesktopSessionsDir(): string {
+  if (process.platform === "darwin") {
+    return path.join(os.homedir(), "Library", "Application Support", "Claude", "local-agent-mode-sessions");
+  }
+  if (process.platform === "win32") {
+    return path.join(os.homedir(), "AppData", "Roaming", "Claude", "local-agent-mode-sessions");
+  }
+  return path.join(os.homedir(), ".config", "Claude", "local-agent-mode-sessions");
+}
+
+async function addClaudeProjectsFromProjectsDir(projectsDir: string, seen: Set<string>, out: string[]): Promise<void> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(projectsDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const projectDir = path.join(projectsDir, entry.name);
+    const resolved = path.resolve(projectDir);
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    out.push(projectDir);
+  }
+}
+
+async function findClaudeDesktopProjectDirs(base: string): Promise<string[]> {
+  const results: string[] = [];
+  async function walk(dir: string, depth: number): Promise<void> {
+    if (depth > 8) return;
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    await Promise.all(entries.map(async (entry) => {
+      if (!entry.isDirectory() || entry.name === "node_modules" || entry.name === ".git") return;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.name === "projects") {
+        await addClaudeProjectsFromProjectsDir(fullPath, new Set(results.map((value) => path.resolve(value))), results);
+        return;
+      }
+      await walk(fullPath, depth + 1);
+    }));
+  }
+
+  await walk(base, 0);
+  return dedupeResolvedPaths(results);
+}
+
+async function discoverClaudeProjectDirs(): Promise<string[]> {
+  const seen = new Set<string>();
+  const projectDirs: string[] = [];
+
+  for (const claudeDir of getClaudeConfigDirs()) {
+    await addClaudeProjectsFromProjectsDir(path.join(claudeDir, "projects"), seen, projectDirs);
+  }
+
+  for (const desktopProjectDir of await findClaudeDesktopProjectDirs(getClaudeDesktopSessionsDir())) {
+    const resolved = path.resolve(desktopProjectDir);
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    projectDirs.push(desktopProjectDir);
+  }
+
+  return projectDirs;
+}
+
+async function scanClaudeLogs(projectDirsOverride?: string[]): Promise<TokenEntry[]> {
+  const entries: TokenEntry[] = [];
+  const seenMessageIds = new Set<string>();
+  const projectDirs = projectDirsOverride ?? await discoverClaudeProjectDirs();
+  if (projectDirs.length === 0) return [];
+
+  const jsonlFiles = await findClaudeJsonlFilesInProjectDirs(projectDirs, LOCAL_COST_SCAN_ALL_DAYS);
 
   for (const filePath of jsonlFiles) {
     try {
+      const firstTimestampByMessageId = new Map<string, number>();
+      const lastEntryByMessageId = new Map<string, TokenEntry>();
+      const messageOrder: string[] = [];
+
       for await (const line of readJsonlLines(filePath)) {
         if (!line.trim()) continue;
         const record = safeJsonParse<Record<string, unknown>>(line, {});
@@ -557,14 +832,23 @@ async function scanClaudeLogs(): Promise<TokenEntry[]> {
 
         const messageId = typeof message.id === "string" ? message.id : "";
         const requestId = typeof record.requestId === "string" ? record.requestId : "";
-        const dedupeKey = `${messageId}:${requestId}`;
-        if (seen.has(dedupeKey)) continue;
-        seen.add(dedupeKey);
+        const dedupeKey = messageId || `claude:${record.timestamp ?? ""}:${requestId}`;
+        const timestamp = typeof record.timestamp === "number" ? record.timestamp :
+          typeof record.timestamp === "string" ? new Date(record.timestamp).getTime() : Date.now();
 
         const model = typeof message.model === "string" ? message.model :
                       typeof record.model === "string" ? record.model : "unknown";
+        const cacheCreation = claudeCacheCreationTokens(usage);
+        const webSearchRequests = isRecord(usage.server_tool_use)
+          ? numberFromRecord(usage.server_tool_use, "web_search_requests")
+          : 0;
 
-        entries.push({
+        if (!firstTimestampByMessageId.has(dedupeKey)) {
+          firstTimestampByMessageId.set(dedupeKey, timestamp);
+          messageOrder.push(dedupeKey);
+        }
+
+        lastEntryByMessageId.set(dedupeKey, {
           messageId: dedupeKey,
           model,
           inputTokens: typeof usage.input_tokens === "number" ? usage.input_tokens : 0,
@@ -572,9 +856,20 @@ async function scanClaudeLogs(): Promise<TokenEntry[]> {
           cachedTokens: typeof usage.cache_read_input_tokens === "number"
             ? usage.cache_read_input_tokens
             : typeof usage.cached_tokens === "number" ? usage.cached_tokens : 0,
-          timestamp: typeof record.timestamp === "number" ? record.timestamp :
-                     typeof record.timestamp === "string" ? new Date(record.timestamp).getTime() : Date.now(),
+          cacheWriteTokens: cacheCreation.total,
+          oneHourCacheWriteTokens: cacheCreation.oneHour,
+          webSearchRequests,
+          timestamp,
         });
+      }
+
+      for (const dedupeKey of messageOrder) {
+        if (seenMessageIds.has(dedupeKey)) continue;
+        const entry = lastEntryByMessageId.get(dedupeKey);
+        if (!entry) continue;
+        seenMessageIds.add(dedupeKey);
+        entry.timestamp = firstTimestampByMessageId.get(dedupeKey) ?? entry.timestamp;
+        entries.push(entry);
         if (entries.length >= LOCAL_COST_SCAN_MAX_ENTRIES) return entries;
       }
     } catch {
@@ -597,13 +892,113 @@ async function scanCodexLogs(): Promise<TokenEntry[]> {
     return entries;
   }
 
-  const jsonlFiles = await findJsonlFiles(sessionsDir, 30);
+  const jsonlFiles = await findJsonlFiles(sessionsDir, LOCAL_COST_SCAN_ALL_DAYS);
 
   for (const filePath of jsonlFiles) {
     try {
+      if (!await isSupportedCodexUsageSession(filePath)) continue;
+      let sessionId = path.basename(filePath, ".jsonl");
+      let sessionModel = "codex";
+      let sessionOriginator = "";
+      let previousTotals: { input: number; cached: number; output: number; reasoning: number; total: number } | null = null;
+
       for await (const line of readJsonlLines(filePath)) {
-        if (!line.trim()) continue;
-        const record = safeJsonParse<Record<string, unknown>>(line, {});
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        const mayContainUsage =
+          trimmed.includes("\"token_count\"") ||
+          trimmed.includes("\"session_meta\"") ||
+          trimmed.includes("\"turn_context\"") ||
+          trimmed.includes("\"input_tokens\"") ||
+          trimmed.includes("\"prompt_tokens\"") ||
+          trimmed.includes("\"token_count\"");
+        if (!mayContainUsage) continue;
+        const record = safeJsonParse<Record<string, unknown>>(trimmed, {});
+
+        const payload = isRecord(record.payload) ? record.payload : undefined;
+        if (record.type === "session_meta" && payload) {
+          const payloadSessionId = typeof payload.id === "string"
+            ? payload.id
+            : typeof payload.session_id === "string"
+              ? payload.session_id
+              : null;
+          if (payloadSessionId) sessionId = payloadSessionId;
+          if (typeof payload.model === "string" && payload.model.trim()) sessionModel = payload.model;
+          if (typeof payload.originator === "string" && payload.originator.trim()) sessionOriginator = payload.originator;
+          continue;
+        }
+
+        if (record.type === "turn_context" && payload) {
+          if (typeof payload.model === "string" && payload.model.trim()) sessionModel = payload.model;
+          continue;
+        }
+
+        if (record.type === "event_msg" && payload?.type === "token_count") {
+          const info = isRecord(payload.info) ? payload.info : undefined;
+          if (!info) continue;
+
+          const totalUsage = isRecord(info.total_token_usage) ? info.total_token_usage : undefined;
+          const lastUsage = isRecord(info.last_token_usage) ? info.last_token_usage : undefined;
+          const cumulativeTotal = numberFromRecord(totalUsage, "total_tokens");
+          if (previousTotals && cumulativeTotal > 0 && cumulativeTotal === previousTotals.total) continue;
+
+          let rawInputTokens = 0;
+          let cachedTokens = 0;
+          let outputTokens = 0;
+          let reasoningTokens = 0;
+
+          if (lastUsage) {
+            rawInputTokens = numberFromRecord(lastUsage, "input_tokens");
+            cachedTokens = numberFromRecord(lastUsage, "cached_input_tokens", "cache_read_input_tokens");
+            outputTokens = numberFromRecord(lastUsage, "output_tokens");
+            reasoningTokens = numberFromRecord(lastUsage, "reasoning_output_tokens");
+          } else if (totalUsage) {
+            rawInputTokens = numberFromRecord(totalUsage, "input_tokens") - (previousTotals?.input ?? 0);
+            cachedTokens = numberFromRecord(totalUsage, "cached_input_tokens", "cache_read_input_tokens") - (previousTotals?.cached ?? 0);
+            outputTokens = numberFromRecord(totalUsage, "output_tokens") - (previousTotals?.output ?? 0);
+            reasoningTokens = numberFromRecord(totalUsage, "reasoning_output_tokens") - (previousTotals?.reasoning ?? 0);
+          }
+
+          if (totalUsage) {
+            previousTotals = {
+              input: numberFromRecord(totalUsage, "input_tokens"),
+              cached: numberFromRecord(totalUsage, "cached_input_tokens", "cache_read_input_tokens"),
+              output: numberFromRecord(totalUsage, "output_tokens"),
+              reasoning: numberFromRecord(totalUsage, "reasoning_output_tokens"),
+              total: cumulativeTotal,
+            };
+          }
+
+          rawInputTokens = Math.max(0, rawInputTokens);
+          cachedTokens = Math.max(0, cachedTokens);
+          outputTokens = Math.max(0, outputTokens) + Math.max(0, reasoningTokens);
+          const billableInputTokens = Math.max(0, rawInputTokens - cachedTokens);
+          const inputTokens = Math.max(0, rawInputTokens);
+          if (inputTokens + outputTokens + cachedTokens === 0) continue;
+
+          const timestamp = timestampMsFromValue(record.timestamp);
+          const model = typeof payload.model === "string" && payload.model.trim()
+            ? payload.model
+            : sessionModel;
+          const dedupeKey = `${sessionId}:${record.timestamp ?? timestamp}:${cumulativeTotal || entries.length}`;
+          if (seen.has(dedupeKey)) continue;
+          seen.add(dedupeKey);
+
+          entries.push({
+            messageId: dedupeKey,
+            model,
+            originator: sessionOriginator,
+            inputTokens,
+            billableInputTokens,
+            outputTokens,
+            cachedTokens,
+            billableCachedTokens: cachedTokens,
+            cacheWriteTokens: 0,
+            timestamp,
+          });
+          if (entries.length >= LOCAL_COST_SCAN_MAX_ENTRIES) return entries;
+          continue;
+        }
 
         // Codex uses event_msg format
         const eventType = typeof record.type === "string" ? record.type :
@@ -635,9 +1030,12 @@ async function scanCodexLogs(): Promise<TokenEntry[]> {
         entries.push({
           messageId: dedupeKey,
           model,
+          originator: sessionOriginator,
           inputTokens: inputTokens || Math.floor(tokenCount * 0.4),
           outputTokens: outputTokens || Math.ceil(tokenCount * 0.6),
           cachedTokens: typeof record.cached_tokens === "number" ? record.cached_tokens : 0,
+          billableCachedTokens: typeof record.cached_tokens === "number" ? record.cached_tokens : 0,
+          cacheWriteTokens: 0,
           timestamp: typeof record.timestamp === "number" ? record.timestamp :
                      typeof record.timestamp === "string" ? new Date(record.timestamp).getTime() : Date.now(),
         });
@@ -651,7 +1049,822 @@ async function scanCodexLogs(): Promise<TokenEntry[]> {
   return entries;
 }
 
-async function findJsonlFiles(dir: string, maxAgeDays: number): Promise<string[]> {
+function defaultOpenClawAgentRoots(): string[] {
+  return [
+    path.join(os.homedir(), ".openclaw", "agents"),
+    path.join(os.homedir(), ".clawdbot", "agents"),
+    path.join(os.homedir(), ".moltbot", "agents"),
+    path.join(os.homedir(), ".moldbot", "agents"),
+  ];
+}
+
+async function scanOpenClawLogs(agentRoots = defaultOpenClawAgentRoots()): Promise<TokenEntry[]> {
+  const entries: TokenEntry[] = [];
+  const seen = new Set<string>();
+
+  const jsonlFiles: string[] = [];
+  for (const root of agentRoots) {
+    jsonlFiles.push(...await findJsonlFiles(root, LOCAL_COST_SCAN_ALL_DAYS));
+  }
+
+  for (const filePath of jsonlFiles.slice(0, LOCAL_COST_SCAN_MAX_FILES)) {
+    try {
+      let sessionId = path.basename(filePath, ".jsonl");
+      let currentModel = "openclaw-auto";
+      let sessionTimestamp = "";
+
+      for await (const line of readJsonlLines(filePath)) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        const record = safeJsonParse<Record<string, unknown>>(trimmed, {});
+        const type = normalizeUsageLabel(record.type, "");
+
+        if (type === "session") {
+          if (typeof record.id === "string" && record.id.trim()) sessionId = record.id;
+          if (typeof record.timestamp === "string") sessionTimestamp = record.timestamp;
+          continue;
+        }
+
+        if (type === "model_change") {
+          if (typeof record.modelId === "string" && record.modelId.trim()) currentModel = record.modelId;
+          continue;
+        }
+
+        if (type === "custom" && record.customType === "model-snapshot" && isRecord(record.data)) {
+          if (typeof record.data.modelId === "string" && record.data.modelId.trim()) {
+            currentModel = record.data.modelId;
+          }
+          continue;
+        }
+
+        if (type !== "message" || !isRecord(record.message)) continue;
+        const message = record.message;
+        if (message.role !== "assistant" || !isRecord(message.usage)) continue;
+
+        const usage = message.usage;
+        const inputTokens = numberFromRecord(usage, "input");
+        const outputTokens = numberFromRecord(usage, "output");
+        const cachedTokens = numberFromRecord(usage, "cacheRead");
+        const cacheWriteTokens = numberFromRecord(usage, "cacheWrite");
+        if (inputTokens + outputTokens + cachedTokens + cacheWriteTokens === 0) continue;
+
+        const timestamp = timestampMsFromValue(record.timestamp ?? sessionTimestamp);
+        const cost = isRecord(usage.cost) ? optionalNumber(usage.cost.total) : null;
+        const model = typeof message.model === "string" && message.model.trim()
+          ? message.model
+          : currentModel;
+        const dedupeKey = `openclaw:${sessionId}:${typeof record.id === "string" && record.id ? record.id : `${record.timestamp ?? timestamp}:${entries.length}`}`;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+
+        entries.push({
+          messageId: dedupeKey,
+          model,
+          inputTokens,
+          outputTokens,
+          cachedTokens,
+          billableCachedTokens: cachedTokens,
+          cacheWriteTokens,
+          costOverrideUsd: cost != null && cost > 0 ? cost : undefined,
+          timestamp,
+        });
+        if (entries.length >= LOCAL_COST_SCAN_MAX_ENTRIES) return entries;
+      }
+    } catch {
+      // Skip unreadable or malformed session files.
+    }
+  }
+
+  return entries;
+}
+
+function defaultDroidSessionsDir(): string {
+  return path.join(process.env.FACTORY_DIR ?? path.join(os.homedir(), ".factory"), "sessions");
+}
+
+function stripDroidModelPrefix(raw: string): string {
+  return raw
+    .replace(/^custom:/, "")
+    .replace(/\[.*?\]/g, "")
+    .replace(/-\d+$/, "")
+    .replace(/-+$/, "")
+    .replace(/^-/, "");
+}
+
+async function scanDroidLogs(sessionsDir = defaultDroidSessionsDir()): Promise<TokenEntry[]> {
+  const entries: TokenEntry[] = [];
+  const seen = new Set<string>();
+  const jsonlFiles = await findJsonlFiles(sessionsDir, LOCAL_COST_SCAN_ALL_DAYS);
+
+  for (const filePath of jsonlFiles) {
+    try {
+      const settings = safeJsonParse<Record<string, unknown>>(
+        await fs.promises.readFile(filePath.replace(/\.jsonl$/, ".settings.json"), "utf8").catch(() => "{}"),
+        {},
+      );
+      const tokenUsage = isRecord(settings.tokenUsage) ? settings.tokenUsage : null;
+      if (!tokenUsage) continue;
+
+      let sessionId = path.basename(filePath, ".jsonl");
+      const model = typeof settings.model === "string" && settings.model.trim()
+        ? stripDroidModelPrefix(settings.model)
+        : "droid-auto";
+      const assistantCalls: Array<{ id: string; timestamp: number }> = [];
+
+      for await (const line of readJsonlLines(filePath)) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        const record = safeJsonParse<Record<string, unknown>>(trimmed, {});
+        if (record.type === "session_start" && typeof record.id === "string" && record.id.trim()) {
+          sessionId = record.id;
+          continue;
+        }
+        if (record.type !== "message" || !isRecord(record.message)) continue;
+        const message = record.message;
+        if (message.role !== "assistant") continue;
+        const content = Array.isArray(message.content) ? message.content : [];
+        const hasAssistantActivity = content.some((block) => (
+          isRecord(block) &&
+          ((block.type === "text" && typeof block.text === "string" && block.text.trim()) || block.type === "tool_use")
+        ));
+        if (!hasAssistantActivity) continue;
+        assistantCalls.push({
+          id: typeof record.id === "string" && record.id ? record.id : `msg-${assistantCalls.length}`,
+          timestamp: timestampMsFromValue(record.timestamp),
+        });
+      }
+
+      if (assistantCalls.length === 0) continue;
+      const totalInput = numberFromRecord(tokenUsage, "inputTokens");
+      const totalOutput = numberFromRecord(tokenUsage, "outputTokens");
+      const totalCacheWrite = numberFromRecord(tokenUsage, "cacheCreationTokens");
+      const totalCacheRead = numberFromRecord(tokenUsage, "cacheReadTokens");
+      const totalThinking = numberFromRecord(tokenUsage, "thinkingTokens");
+      if (totalInput + totalOutput + totalCacheWrite + totalCacheRead + totalThinking === 0) continue;
+
+      const inputPerCall = Math.floor(totalInput / assistantCalls.length);
+      const outputPerCall = Math.floor(totalOutput / assistantCalls.length);
+      const cacheWritePerCall = Math.floor(totalCacheWrite / assistantCalls.length);
+      const cacheReadPerCall = Math.floor(totalCacheRead / assistantCalls.length);
+      const thinkingPerCall = Math.floor(totalThinking / assistantCalls.length);
+
+      for (let i = 0; i < assistantCalls.length; i++) {
+        const call = assistantCalls[i]!;
+        const isLast = i === assistantCalls.length - 1;
+        const dedupeKey = `droid:${sessionId}:${call.id}`;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+        entries.push({
+          messageId: dedupeKey,
+          model,
+          inputTokens: isLast ? totalInput - inputPerCall * i : inputPerCall,
+          outputTokens: (isLast ? totalOutput - outputPerCall * i : outputPerCall) +
+            (isLast ? totalThinking - thinkingPerCall * i : thinkingPerCall),
+          cachedTokens: isLast ? totalCacheRead - cacheReadPerCall * i : cacheReadPerCall,
+          billableCachedTokens: isLast ? totalCacheRead - cacheReadPerCall * i : cacheReadPerCall,
+          cacheWriteTokens: isLast ? totalCacheWrite - cacheWritePerCall * i : cacheWritePerCall,
+          timestamp: call.timestamp,
+        });
+        if (entries.length >= LOCAL_COST_SCAN_MAX_ENTRIES) return entries;
+      }
+    } catch {
+      // Skip unreadable or malformed Droid sessions.
+    }
+  }
+
+  return entries;
+}
+
+function defaultCopilotSessionStateDir(): string {
+  return path.join(os.homedir(), ".copilot", "session-state");
+}
+
+function defaultVSCodeWorkspaceStorageDirs(): string[] {
+  if (process.platform === "darwin") {
+    return [
+      path.join(os.homedir(), "Library", "Application Support", "Code", "User", "workspaceStorage"),
+      path.join(os.homedir(), "Library", "Application Support", "Code - Insiders", "User", "workspaceStorage"),
+    ];
+  }
+  if (process.platform === "win32") {
+    return [
+      path.join(os.homedir(), "AppData", "Roaming", "Code", "User", "workspaceStorage"),
+      path.join(os.homedir(), "AppData", "Roaming", "Code - Insiders", "User", "workspaceStorage"),
+    ];
+  }
+  return [
+    path.join(os.homedir(), ".config", "Code", "User", "workspaceStorage"),
+    path.join(os.homedir(), ".config", "Code - Insiders", "User", "workspaceStorage"),
+    path.join(os.homedir(), ".vscode-server", "data", "User", "workspaceStorage"),
+  ];
+}
+
+function inferCopilotModelFromToolCalls(events: Record<string, unknown>[]): string {
+  const modelCounts = new Map<string, number>();
+  const bump = (model: string, weight: number) => {
+    if (!model.trim()) return;
+    modelCounts.set(model, (modelCounts.get(model) ?? 0) + weight);
+  };
+
+  for (const event of events) {
+    const data = isRecord(event.data) ? event.data : {};
+    if (typeof data.model === "string" && data.model.trim()) bump(data.model, 100);
+    if (event.type !== "assistant.message") continue;
+    const toolRequests = Array.isArray(data.toolRequests) ? data.toolRequests : [];
+    for (const tool of toolRequests) {
+      if (!isRecord(tool) || typeof tool.toolCallId !== "string") continue;
+      const toolCallId = tool.toolCallId;
+      if (toolCallId.startsWith("call_")) bump("copilot-openai-auto", 1);
+      if (toolCallId.startsWith("toolu_") || toolCallId.startsWith("tooluse_")) bump("copilot-anthropic-auto", 1);
+    }
+  }
+
+  return [...modelCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? "copilot-auto";
+}
+
+function parseCopilotEvents(raw: string, sourcePath: string): TokenEntry[] {
+  const entries: TokenEntry[] = [];
+  const records = raw
+    .split(/\r?\n/)
+    .filter((line) => line.trim())
+    .map((line) => safeJsonParse<Record<string, unknown>>(line, {}))
+    .filter((record) => isRecord(record));
+  const first = records[0];
+  const isTranscript = first?.type === "session.start" && isRecord(first.data) && first.data.producer === "copilot-agent";
+  const sessionId = path.basename(sourcePath, ".jsonl").length === 36
+    ? path.basename(sourcePath, ".jsonl")
+    : path.basename(path.dirname(sourcePath));
+  let currentModel = "";
+  let pendingUserMessage = "";
+
+  if (isTranscript) {
+    const inferredModel = inferCopilotModelFromToolCalls(records);
+    for (const record of records) {
+      const data = isRecord(record.data) ? record.data : {};
+      if (record.type === "user.message") {
+        pendingUserMessage = typeof data.content === "string" ? data.content.slice(0, 500) : "";
+        continue;
+      }
+      if (record.type !== "assistant.message") continue;
+      const messageId = typeof data.messageId === "string" && data.messageId ? data.messageId : `${record.timestamp ?? entries.length}`;
+      const content = typeof data.content === "string" ? data.content : "";
+      const reasoning = typeof data.reasoningText === "string" ? data.reasoningText : "";
+      const toolRequests = Array.isArray(data.toolRequests) ? data.toolRequests : [];
+      if (!content && !reasoning && toolRequests.length === 0) continue;
+      let outputTokens = numberFromRecord(data, "outputTokens");
+      let reasoningTokens = 0;
+      if (outputTokens === 0) {
+        outputTokens = estimateTokensFromText(content);
+        reasoningTokens = estimateTokensFromText(reasoning);
+      }
+      entries.push({
+        messageId: `copilot:${sessionId}:${messageId}`,
+        model: typeof data.model === "string" && data.model.trim() ? data.model : inferredModel,
+        inputTokens: estimateTokensFromText(pendingUserMessage),
+        outputTokens,
+        billableOutputTokens: outputTokens + reasoningTokens,
+        cachedTokens: 0,
+        cacheWriteTokens: 0,
+        timestamp: timestampMsFromValue(record.timestamp),
+      });
+      pendingUserMessage = "";
+    }
+    return entries;
+  }
+
+  for (const record of records) {
+    const data = isRecord(record.data) ? record.data : {};
+    if (typeof data.model === "string" && data.model.trim()) currentModel = data.model;
+    if (record.type === "session.model_change") {
+      if (typeof data.newModel === "string" && data.newModel.trim()) currentModel = data.newModel;
+      continue;
+    }
+    if (record.type === "user.message") {
+      pendingUserMessage = typeof data.content === "string" ? data.content : "";
+      continue;
+    }
+    if (record.type !== "assistant.message") continue;
+    const outputTokens = numberFromRecord(data, "outputTokens");
+    if (outputTokens === 0 || !currentModel) continue;
+    const messageId = typeof data.messageId === "string" && data.messageId ? data.messageId : `${record.timestamp ?? entries.length}`;
+    entries.push({
+      messageId: `copilot:${sessionId}:${messageId}`,
+      model: currentModel,
+      inputTokens: estimateTokensFromText(pendingUserMessage),
+      outputTokens,
+      cachedTokens: 0,
+      cacheWriteTokens: 0,
+      timestamp: timestampMsFromValue(record.timestamp),
+    });
+    pendingUserMessage = "";
+  }
+
+  return entries;
+}
+
+async function discoverCopilotTranscriptFiles(
+  sessionStateDir = defaultCopilotSessionStateDir(),
+  workspaceStorageDirs = defaultVSCodeWorkspaceStorageDirs(),
+): Promise<string[]> {
+  const files: string[] = [];
+  try {
+    const sessionDirs = await fs.promises.readdir(sessionStateDir);
+    await Promise.all(sessionDirs.map(async (sessionId) => {
+      const eventsPath = path.join(sessionStateDir, sessionId, "events.jsonl");
+      const stat = await fs.promises.stat(eventsPath).catch(() => null);
+      if (stat?.isFile() && stat.size <= LOCAL_COST_SCAN_MAX_FILE_BYTES) files.push(eventsPath);
+    }));
+  } catch {
+    // Missing Copilot legacy state is expected for users who never used it.
+  }
+
+  await Promise.all(workspaceStorageDirs.map(async (workspaceStorageDir) => {
+    let workspaceDirs: string[];
+    try {
+      workspaceDirs = await fs.promises.readdir(workspaceStorageDir);
+    } catch {
+      return;
+    }
+    await Promise.all(workspaceDirs.map(async (workspaceDir) => {
+      const transcriptsDir = path.join(workspaceStorageDir, workspaceDir, "GitHub.copilot-chat", "transcripts");
+      let transcriptFiles: string[];
+      try {
+        transcriptFiles = await fs.promises.readdir(transcriptsDir);
+      } catch {
+        return;
+      }
+      await Promise.all(transcriptFiles
+        .filter((file) => file.endsWith(".jsonl"))
+        .map(async (file) => {
+          const filePath = path.join(transcriptsDir, file);
+          const stat = await fs.promises.stat(filePath).catch(() => null);
+          if (stat?.isFile() && stat.size <= LOCAL_COST_SCAN_MAX_FILE_BYTES) files.push(filePath);
+        }));
+    }));
+  }));
+
+  return files.slice(0, LOCAL_COST_SCAN_MAX_FILES);
+}
+
+async function scanCopilotLogs(
+  sessionStateDir = defaultCopilotSessionStateDir(),
+  workspaceStorageDirs = defaultVSCodeWorkspaceStorageDirs(),
+): Promise<TokenEntry[]> {
+  const entries: TokenEntry[] = [];
+  const seen = new Set<string>();
+  const files = await discoverCopilotTranscriptFiles(sessionStateDir, workspaceStorageDirs);
+  for (const filePath of files) {
+    try {
+      const raw = await fs.promises.readFile(filePath, "utf8");
+      for (const entry of parseCopilotEvents(raw, filePath)) {
+        if (entry.inputTokens + entry.outputTokens + entry.cachedTokens + toNonNegativeInt(entry.cacheWriteTokens) === 0) continue;
+        if (seen.has(entry.messageId)) continue;
+        seen.add(entry.messageId);
+        entries.push(entry);
+        if (entries.length >= LOCAL_COST_SCAN_MAX_ENTRIES) return entries;
+      }
+    } catch {
+      // Skip unreadable Copilot logs.
+    }
+  }
+  return entries;
+}
+
+function defaultGeminiTmpDir(): string {
+  return path.join(os.homedir(), ".gemini", "tmp");
+}
+
+function parseGeminiSession(raw: string): { sessionId: string; startTime: string; messages: Record<string, unknown>[] } | null {
+  const parsed = safeJsonParse<Record<string, unknown>>(raw, {});
+  if (isRecord(parsed) && typeof parsed.sessionId === "string" && Array.isArray(parsed.messages)) {
+    return {
+      sessionId: parsed.sessionId,
+      startTime: typeof parsed.startTime === "string" ? parsed.startTime : "",
+      messages: parsed.messages.filter((message): message is Record<string, unknown> => isRecord(message)),
+    };
+  }
+
+  let sessionId = "";
+  let startTime = "";
+  const messages: Record<string, unknown>[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const record = safeJsonParse<Record<string, unknown>>(line, {});
+    if (record.$set !== undefined) continue;
+    if (!sessionId && typeof record.sessionId === "string" && typeof record.startTime === "string") {
+      sessionId = record.sessionId;
+      startTime = record.startTime;
+      continue;
+    }
+    if (typeof record.id === "string" && typeof record.type === "string") {
+      messages.push(record);
+    }
+  }
+  return sessionId ? { sessionId, startTime, messages } : null;
+}
+
+function parseGeminiEntries(raw: string, sourcePath: string): TokenEntry[] {
+  const session = parseGeminiSession(raw);
+  if (!session) return [];
+  const entries: TokenEntry[] = [];
+  let ordinal = 0;
+
+  for (const message of session.messages) {
+    if (message.type === "user") continue;
+    if (message.type !== "gemini" || !isRecord(message.tokens)) continue;
+    const model = typeof message.model === "string" && message.model.trim() ? message.model : "gemini-auto";
+    const tokens = message.tokens;
+    const totalInput = numberFromRecord(tokens, "input");
+    const totalOutput = numberFromRecord(tokens, "output");
+    const totalCached = numberFromRecord(tokens, "cached");
+    const totalThoughts = numberFromRecord(tokens, "thoughts");
+    if (totalInput + totalOutput + totalCached + totalThoughts === 0) continue;
+    const freshInput = Math.max(0, totalInput - totalCached);
+    const timestamp = timestampMsFromValue(message.timestamp ?? session.startTime);
+    if (timestamp < 1_000_000_000_000) continue;
+    const messageId = typeof message.id === "string" && message.id ? message.id : `${path.basename(sourcePath)}:${ordinal}`;
+    ordinal += 1;
+    entries.push({
+      messageId: `gemini:${session.sessionId}:${messageId}`,
+      model,
+      inputTokens: freshInput,
+      outputTokens: totalOutput + totalThoughts,
+      cachedTokens: totalCached,
+      billableCachedTokens: totalCached,
+      cacheWriteTokens: 0,
+      timestamp,
+    });
+  }
+  return entries;
+}
+
+async function discoverGeminiSessionFiles(tmpDir = defaultGeminiTmpDir()): Promise<string[]> {
+  const files: string[] = [];
+  let projectDirs: fs.Dirent[];
+  try {
+    projectDirs = await fs.promises.readdir(tmpDir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+
+  await Promise.all(projectDirs
+    .filter((entry) => entry.isDirectory())
+    .map(async (projectDir) => {
+      const chatsDir = path.join(tmpDir, projectDir.name, "chats");
+      let chatFiles: string[];
+      try {
+        chatFiles = await fs.promises.readdir(chatsDir);
+      } catch {
+        return;
+      }
+      await Promise.all(chatFiles
+        .filter((file) => file.startsWith("session-") && (file.endsWith(".json") || file.endsWith(".jsonl")))
+        .map(async (file) => {
+          const filePath = path.join(chatsDir, file);
+          const stat = await fs.promises.stat(filePath).catch(() => null);
+          if (stat?.isFile() && stat.size <= LOCAL_COST_SCAN_MAX_FILE_BYTES) files.push(filePath);
+        }));
+    }));
+
+  return files.slice(0, LOCAL_COST_SCAN_MAX_FILES);
+}
+
+async function scanGeminiLogs(tmpDir = defaultGeminiTmpDir()): Promise<TokenEntry[]> {
+  const entries: TokenEntry[] = [];
+  const seen = new Set<string>();
+  const files = await discoverGeminiSessionFiles(tmpDir);
+  for (const filePath of files) {
+    try {
+      const raw = await fs.promises.readFile(filePath, "utf8");
+      for (const entry of parseGeminiEntries(raw, filePath)) {
+        if (seen.has(entry.messageId)) continue;
+        seen.add(entry.messageId);
+        entries.push(entry);
+        if (entries.length >= LOCAL_COST_SCAN_MAX_ENTRIES) return entries;
+      }
+    } catch {
+      // Skip unreadable Gemini logs.
+    }
+  }
+  return entries;
+}
+
+function defaultOpenCodeDataDir(): string {
+  return path.join(process.env.XDG_DATA_HOME ?? path.join(os.homedir(), ".local", "share"), "opencode");
+}
+
+async function scanOpenCodeLogs(dataDir = defaultOpenCodeDataDir()): Promise<TokenEntry[]> {
+  const entries: TokenEntry[] = [];
+  const seen = new Set<string>();
+  let dbFiles: string[] = [];
+  try {
+    dbFiles = (await fs.promises.readdir(dataDir))
+      .filter((name) => name.startsWith("opencode") && name.endsWith(".db"))
+      .map((name) => path.join(dataDir, name));
+  } catch {
+    return entries;
+  }
+
+  const sinceMs = 0;
+  for (const dbPath of dbFiles) {
+    const db = openReadonlyUsageDatabase(dbPath);
+    if (!db) continue;
+    try {
+      const rows = usageSqliteAll<{ id: string; sessionId: string; timeCreated: number; data: string }>(
+        db,
+        `
+          select id, session_id as sessionId, time_created as timeCreated, cast(data as blob) as data
+          from message
+          where time_created >= ?
+          order by time_created desc, id desc
+          limit ?
+        `,
+        [sinceMs, LOCAL_SQLITE_SCAN_MAX_ROWS],
+      );
+      for (const row of rows) {
+        const data = safeJsonParse<Record<string, unknown>>(textFromSqliteValue(row.data), {});
+        if (data.role !== "assistant") continue;
+        const tokens = isRecord(data.tokens) ? data.tokens : {};
+        const cache = isRecord(tokens.cache) ? tokens.cache : {};
+        const inputTokens = numberFromRecord(tokens, "input");
+        const outputTokens = numberFromRecord(tokens, "output") + numberFromRecord(tokens, "reasoning");
+        const cachedTokens = numberFromRecord(cache, "read");
+        const cacheWriteTokens = numberFromRecord(cache, "write");
+        const cost = optionalNumber(data.cost);
+        if (inputTokens + outputTokens + cachedTokens + cacheWriteTokens === 0 && !(cost && cost > 0)) continue;
+
+        const sessionId = typeof row.sessionId === "string" && row.sessionId ? row.sessionId : "unknown";
+        const dedupeKey = `opencode:${sessionId}:${row.id}`;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+        entries.push({
+          messageId: dedupeKey,
+          model: typeof data.modelID === "string" && data.modelID.trim() ? data.modelID : "opencode-auto",
+          inputTokens,
+          outputTokens,
+          cachedTokens,
+          billableCachedTokens: cachedTokens,
+          cacheWriteTokens,
+          costOverrideUsd: cost != null && cost > 0 ? cost : undefined,
+          timestamp: timestampMsFromUnixish(row.timeCreated),
+        });
+        if (entries.length >= LOCAL_COST_SCAN_MAX_ENTRIES) return entries;
+      }
+    } catch {
+      // Skip unrecognized OpenCode DB schemas.
+    } finally {
+      db.close();
+    }
+  }
+
+  return entries;
+}
+
+function defaultCursorDbPath(): string {
+  if (process.platform === "darwin") {
+    return path.join(os.homedir(), "Library", "Application Support", "Cursor", "User", "globalStorage", "state.vscdb");
+  }
+  if (process.platform === "win32") {
+    return path.join(os.homedir(), "AppData", "Roaming", "Cursor", "User", "globalStorage", "state.vscdb");
+  }
+  return path.join(os.homedir(), ".config", "Cursor", "User", "globalStorage", "state.vscdb");
+}
+
+async function scanCursorLogs(dbPath = defaultCursorDbPath()): Promise<TokenEntry[]> {
+  const entries: TokenEntry[] = [];
+  const seen = new Set<string>();
+  const db = openReadonlyUsageDatabase(dbPath);
+  if (!db) return entries;
+
+  try {
+    const cursorRows = usageSqliteAll<{
+      key: string;
+      value: string | Uint8Array | null;
+    }>(
+      db,
+      `
+        select
+          key,
+          cast(value as blob) as value
+        from cursorDiskKV
+        order by rowid desc
+        limit ?
+      `,
+      [LOCAL_CURSOR_SQLITE_RECENT_ROWS],
+    );
+
+    for (const row of cursorRows) {
+      if (!row.key.startsWith("bubbleId:")) continue;
+      const value = safeJsonParse<Record<string, unknown>>(textFromSqliteValue(row.value), {});
+      const createdAt = typeof value.createdAt === "string" ? value.createdAt : "";
+      if (!createdAt) continue;
+      const tokenCount = isRecord(value.tokenCount) ? value.tokenCount : {};
+      let inputTokens = numberFromRecord(tokenCount, "inputTokens");
+      let outputTokens = numberFromRecord(tokenCount, "outputTokens");
+      if (inputTokens + outputTokens === 0) {
+        const estimated = typeof value.text === "string" ? estimateTokensFromText(value.text) : 0;
+        if (value.type === 1) inputTokens = estimated;
+        else outputTokens = estimated;
+      }
+      if (inputTokens + outputTokens === 0) continue;
+      const dedupeKey = `cursor:bubble:${row.key}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      const modelInfo = isRecord(value.modelInfo) ? value.modelInfo : {};
+      const rawModel = typeof modelInfo.modelName === "string" ? modelInfo.modelName.trim() : "";
+      const model = rawModel && rawModel !== "default"
+        ? rawModel
+        : "cursor-auto";
+      entries.push({
+        messageId: dedupeKey,
+        model,
+        inputTokens,
+        outputTokens,
+        cachedTokens: 0,
+        cacheWriteTokens: 0,
+        timestamp: timestampMsFromValue(createdAt),
+      });
+      if (entries.length >= LOCAL_COST_SCAN_MAX_ENTRIES) return entries;
+    }
+
+    // Cursor's bubble rows contain the real token counts surfaced by Cursor's
+    // UI. The agentKv rows are text blobs that require estimation and have
+    // proven noisy in parity checks, so ADE leaves them out and relies on the
+    // separate Cursor Agent transcript scanner for cursor-agent sessions.
+  } catch {
+    return entries;
+  } finally {
+    db.close();
+  }
+
+  return entries;
+}
+
+function extractCursorAgentUserQuery(text: string): string {
+  const matches = Array.from(text.matchAll(/<user_query>([\s\S]*?)<\/user_query>/g))
+    .map((match) => (match[1] ?? "").trim())
+    .filter(Boolean);
+  return (matches.length > 0 ? matches.join(" ") : text).replace(/\s+/g, " ").trim().slice(0, 500);
+}
+
+function parseCursorAgentJsonlTranscript(raw: string): Array<{ inputText: string; outputText: string; reasoningText: string }> {
+  const turns: Array<{ inputText: string; outputText: string; reasoningText: string }> = [];
+  let currentUser = "";
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    const record = safeJsonParse<Record<string, unknown>>(line, {});
+    if (record.role === "user" && isRecord(record.message)) {
+      const content = Array.isArray(record.message.content) ? record.message.content : [];
+      const text = content
+        .map((block) => isRecord(block) && typeof block.text === "string" ? block.text : "")
+        .filter(Boolean)
+        .join(" ");
+      currentUser = extractCursorAgentUserQuery(text);
+      continue;
+    }
+    if (record.role === "assistant" && currentUser && isRecord(record.message)) {
+      const content = Array.isArray(record.message.content) ? record.message.content : [];
+      const outputText = content
+        .map((block) => isRecord(block) && block.type === "text" && typeof block.text === "string" ? block.text : "")
+        .filter(Boolean)
+        .join("\n");
+      turns.push({ inputText: currentUser, outputText, reasoningText: "" });
+      currentUser = "";
+    }
+  }
+  return turns;
+}
+
+function parseCursorAgentTextTranscript(raw: string): Array<{ inputText: string; outputText: string; reasoningText: string }> {
+  const turns: Array<{ inputText: string; outputText: string; reasoningText: string }> = [];
+  const pendingUsers: string[] = [];
+  let active: "none" | "user" | "assistant" = "none";
+  let userLines: string[] = [];
+  let assistantLines: string[] = [];
+
+  const flushUser = () => {
+    if (userLines.length === 0) return;
+    const inputText = extractCursorAgentUserQuery(userLines.join("\n"));
+    if (inputText) pendingUsers.push(inputText);
+    userLines = [];
+  };
+
+  const flushAssistant = () => {
+    if (assistantLines.length === 0) return;
+    let outputText = "";
+    let reasoningText = "";
+    for (const line of assistantLines) {
+      if (/^\s*\[Tool result\]\b/i.test(line)) continue;
+      const thinkingMatch = line.match(/^\s*\[Thinking\]\s*/);
+      if (thinkingMatch) {
+        const body = line.replace(/^\s*\[Thinking\]\s*/, "").trim();
+        if (body) reasoningText += `${body}\n`;
+        continue;
+      }
+      if (/^\s*\[Tool call\]\s*(.+?)\s*$/i.test(line)) continue;
+      outputText += `${line}\n`;
+    }
+    if (pendingUsers.length > 0) {
+      turns.push({
+        inputText: pendingUsers.shift()!,
+        outputText: outputText.trim(),
+        reasoningText: reasoningText.trim(),
+      });
+    }
+    assistantLines = [];
+  };
+
+  for (const line of raw.split(/\r?\n/)) {
+    if (/^\s*user:\s*/i.test(line)) {
+      if (active === "user") flushUser();
+      if (active === "assistant") flushAssistant();
+      active = "user";
+      userLines = [line.replace(/^\s*user:\s*/i, "")];
+      continue;
+    }
+    if (/^\s*A:\s*/.test(line)) {
+      if (active === "user") flushUser();
+      if (active === "assistant") flushAssistant();
+      active = "assistant";
+      assistantLines = [line.replace(/^\s*A:\s*/, "")];
+      continue;
+    }
+    if (active === "user") userLines.push(line);
+    if (active === "assistant") assistantLines.push(line);
+  }
+  if (active === "user") flushUser();
+  if (active === "assistant") flushAssistant();
+  return turns;
+}
+
+function cursorAgentConversationId(filePath: string): string {
+  return createHash("sha1").update(filePath).digest("hex").slice(0, 16);
+}
+
+async function scanCursorAgentLogs(projectsDir = path.join(os.homedir(), ".cursor", "projects")): Promise<TokenEntry[]> {
+  const entries: TokenEntry[] = [];
+  const seen = new Set<string>();
+  const files = await findRecentFiles(projectsDir, LOCAL_COST_SCAN_ALL_DAYS, [".jsonl", ".txt"]);
+
+  for (const filePath of files) {
+    if (!filePath.includes(`${path.sep}agent-transcripts${path.sep}`)) continue;
+    try {
+      const raw = await fs.promises.readFile(filePath, "utf8");
+      const turns = filePath.endsWith(".jsonl")
+        ? parseCursorAgentJsonlTranscript(raw)
+        : parseCursorAgentTextTranscript(raw);
+      if (turns.length === 0) continue;
+      const stat = await fs.promises.stat(filePath);
+      const sessionId = cursorAgentConversationId(filePath);
+      for (let i = 0; i < turns.length; i++) {
+        const turn = turns[i]!;
+        const inputTokens = estimateTokensFromText(turn.inputText);
+        const outputTokens = estimateTokensFromText(turn.outputText);
+        const reasoningTokens = estimateTokensFromText(turn.reasoningText);
+        if (inputTokens + outputTokens === 0) continue;
+        const dedupeKey = `cursor-agent:${sessionId}:${i}`;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+        entries.push({
+          messageId: dedupeKey,
+          model: "cursor-agent-auto",
+          inputTokens,
+          outputTokens,
+          billableOutputTokens: outputTokens + reasoningTokens,
+          cachedTokens: 0,
+          cacheWriteTokens: 0,
+          timestamp: stat.mtimeMs,
+        });
+        if (entries.length >= LOCAL_COST_SCAN_MAX_ENTRIES) return entries;
+      }
+    } catch {
+      // Skip unreadable Cursor Agent transcripts.
+    }
+  }
+
+  return entries;
+}
+
+async function isSupportedCodexUsageSession(filePath: string): Promise<boolean> {
+  let file: fs.promises.FileHandle | null = null;
+  try {
+    file = await fs.promises.open(filePath, "r");
+    const buffer = Buffer.alloc(1024 * 1024);
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+    const firstLine = buffer.subarray(0, bytesRead).toString("utf8").split(/\r?\n/, 1)[0]?.trim();
+    if (!firstLine) return false;
+    const entry = safeJsonParse<Record<string, unknown>>(firstLine, {});
+    if (entry.type !== "session_meta" || !isRecord(entry.payload)) return false;
+    const originator = normalizeUsageLabel(entry.payload.originator, "").toLowerCase();
+    return !originator.startsWith("ade");
+  } catch {
+    return false;
+  } finally {
+    await file?.close().catch(() => {});
+  }
+}
+
+async function findRecentFiles(dir: string, maxAgeDays: number, suffixes: string[]): Promise<string[]> {
   const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
   const files: Array<{ path: string; mtimeMs: number }> = [];
 
@@ -665,7 +1878,7 @@ async function findJsonlFiles(dir: string, maxAgeDays: number): Promise<string[]
         const fullPath = path.join(current, entry.name);
         if (entry.isDirectory()) {
           dirPromises.push(walk(fullPath, depth + 1));
-        } else if (entry.name.endsWith(".jsonl")) {
+        } else if (suffixes.some((suffix) => entry.name.endsWith(suffix))) {
           fileStatPromises.push(
             fs.promises.stat(fullPath).then((stat) => {
               if (stat.mtimeMs >= cutoff && stat.size <= LOCAL_COST_SCAN_MAX_FILE_BYTES) {
@@ -686,6 +1899,57 @@ async function findJsonlFiles(dir: string, maxAgeDays: number): Promise<string[]
   await walk(dir, 0);
   return files
     .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .slice(0, LOCAL_COST_SCAN_MAX_FILES)
+    .map((file) => file.path);
+}
+
+async function findJsonlFiles(dir: string, maxAgeDays: number): Promise<string[]> {
+  return findRecentFiles(dir, maxAgeDays, [".jsonl"]);
+}
+
+async function findClaudeJsonlFilesInProjectDirs(projectDirs: string[], maxAgeDays: number): Promise<string[]> {
+  const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+  const files = new Map<string, { path: string; mtimeMs: number }>();
+
+  async function addJsonlFilesInDir(dir: string): Promise<void> {
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    await Promise.all(entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+      .map(async (entry) => {
+        const filePath = path.join(dir, entry.name);
+        try {
+          const stat = await fs.promises.stat(filePath);
+          if (stat.mtimeMs >= cutoff && stat.size <= LOCAL_COST_SCAN_MAX_FILE_BYTES) {
+            files.set(filePath, { path: filePath, mtimeMs: stat.mtimeMs });
+          }
+        } catch {
+          // Skip files we can't stat
+        }
+      }));
+  }
+
+  for (const projectDir of projectDirs) {
+    const projectPath = projectDir;
+    await addJsonlFilesInDir(projectPath);
+    await addJsonlFilesInDir(path.join(projectPath, "subagents"));
+
+    let childEntries: fs.Dirent[];
+    try {
+      childEntries = await fs.promises.readdir(projectPath, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    await Promise.all(childEntries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => addJsonlFilesInDir(path.join(projectPath, entry.name, "subagents"))));
+  }
+
+  return Array.from(files.values())
     .slice(0, LOCAL_COST_SCAN_MAX_FILES)
     .map((file) => file.path);
 }
@@ -714,51 +1978,922 @@ function bucketDaily7d(entries: TokenEntry[], nowMs: number): number[] {
     if (entry.timestamp > nowMs) continue;
     const dayIndex = Math.floor((entry.timestamp - oldestStart) / 86_400_000);
     const bucketIndex = Math.min(6, Math.max(0, dayIndex));
-    buckets[bucketIndex] += entry.inputTokens + entry.outputTokens;
+    buckets[bucketIndex] += entry.inputTokens + entry.outputTokens + entry.cachedTokens + toNonNegativeInt(entry.cacheWriteTokens);
   }
   return buckets;
 }
 
+type TokenBreakdown = Record<string, CostTokenBreakdown & { cacheWrite: number; costUsd: number }>;
+type DailyTokenBreakdown = Record<string, number>;
+type DailyModelTokenBreakdown = Record<string, TokenBreakdown>;
+
+function addTokenBreakdownEntry(breakdown: TokenBreakdown, entry: TokenEntry): void {
+  const modelKey = entry.model || "unknown";
+  if (!breakdown[modelKey]) {
+    breakdown[modelKey] = { input: 0, output: 0, cached: 0, cacheWrite: 0, costUsd: 0 };
+  }
+  breakdown[modelKey].input += entry.inputTokens;
+  breakdown[modelKey].output += entry.outputTokens;
+  breakdown[modelKey].cached += entry.cachedTokens;
+  breakdown[modelKey].cacheWrite += toNonNegativeInt(entry.cacheWriteTokens);
+  breakdown[modelKey].costUsd += calculateTokenEntryCost(entry);
+}
+
+function addDailyTokenEntry(breakdown: DailyTokenBreakdown, entry: TokenEntry): void {
+  const date = new Date(entry.timestamp).toISOString().slice(0, 10);
+  const tokens = entry.inputTokens + entry.outputTokens + entry.cachedTokens + toNonNegativeInt(entry.cacheWriteTokens);
+  breakdown[date] = (breakdown[date] ?? 0) + tokens;
+}
+
+function addDailyModelTokenEntry(breakdown: DailyModelTokenBreakdown, entry: TokenEntry): void {
+  const date = new Date(entry.timestamp).toISOString().slice(0, 10);
+  if (!breakdown[date]) breakdown[date] = {};
+  addTokenBreakdownEntry(breakdown[date]!, entry);
+}
+
+function calculateTokenEntryCost(entry: TokenEntry): number {
+  const override = optionalNumber(entry.costOverrideUsd);
+  if (override != null && override >= 0) return override;
+  const price = resolveTokenPrice(entry.model);
+  const billableInputTokens = toNonNegativeInt(entry.billableInputTokens ?? entry.inputTokens);
+  const cacheWriteTokens = toNonNegativeInt(entry.cacheWriteTokens);
+  const oneHourCacheWriteTokens = Math.min(toNonNegativeInt(entry.oneHourCacheWriteTokens), cacheWriteTokens);
+  const fiveMinuteCacheWriteTokens = Math.max(0, cacheWriteTokens - oneHourCacheWriteTokens);
+  const billableOutputTokens = toNonNegativeInt(entry.billableOutputTokens ?? entry.outputTokens);
+  const billableCachedTokens = toNonNegativeInt(entry.billableCachedTokens ?? entry.cachedTokens);
+  const webSearchRequests = toNonNegativeInt(entry.webSearchRequests);
+  return (
+    billableInputTokens * price.input +
+    billableOutputTokens * price.output +
+    fiveMinuteCacheWriteTokens * price.cacheWrite +
+    oneHourCacheWriteTokens * price.cacheWrite * ONE_HOUR_CACHE_WRITE_MULTIPLIER +
+    billableCachedTokens * price.cacheRead +
+    webSearchRequests * WEB_SEARCH_COST_USD
+  );
+}
+
 function aggregateCosts(
   entries: TokenEntry[],
-  provider: UsageProvider
+  provider: string,
 ): CostSnapshot {
   const now = Date.now();
-  const thirtyDaysAgo = now - 30 * 24 * 60 * 60 * 1000;
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
   const todayStartMs = todayStart.getTime();
+  const sevenDayStart = new Date(todayStart);
+  sevenDayStart.setDate(sevenDayStart.getDate() - 6);
+  const sevenDaysAgo = sevenDayStart.getTime();
+  const thirtyDayStart = new Date(todayStart);
+  thirtyDayStart.setDate(thirtyDayStart.getDate() - 29);
+  const thirtyDaysAgo = thirtyDayStart.getTime();
 
   let last30dCostUsd = 0;
   let todayCostUsd = 0;
-  const breakdown: Record<string, { input: number; output: number; cached: number }> = {};
+  let sevenDayCostUsd = 0;
+  let allCostUsd = 0;
+  const allBreakdown: TokenBreakdown = {};
+  const thirtyDayBreakdown: TokenBreakdown = {};
+  const todayBreakdown: TokenBreakdown = {};
+  const sevenDayBreakdown: TokenBreakdown = {};
+  const allDailyTokens: DailyTokenBreakdown = {};
+  const thirtyDayDailyTokens: DailyTokenBreakdown = {};
+  const todayDailyTokens: DailyTokenBreakdown = {};
+  const sevenDayDailyTokens: DailyTokenBreakdown = {};
+  const allDailyModelTokens: DailyModelTokenBreakdown = {};
+  const thirtyDayDailyModelTokens: DailyModelTokenBreakdown = {};
+  const todayDailyModelTokens: DailyModelTokenBreakdown = {};
+  const sevenDayDailyModelTokens: DailyModelTokenBreakdown = {};
 
   for (const entry of entries) {
-    if (entry.timestamp < thirtyDaysAgo) continue;
+    const cost = calculateTokenEntryCost(entry);
+    allCostUsd += cost;
+    addTokenBreakdownEntry(allBreakdown, entry);
+    addDailyTokenEntry(allDailyTokens, entry);
+    addDailyModelTokenEntry(allDailyModelTokens, entry);
 
-    const price = resolveTokenPrice(entry.model);
-    const cost = entry.inputTokens * price.input + entry.outputTokens * price.output;
-    last30dCostUsd += cost;
-
+    if (entry.timestamp >= thirtyDaysAgo) {
+      last30dCostUsd += cost;
+      addTokenBreakdownEntry(thirtyDayBreakdown, entry);
+      addDailyTokenEntry(thirtyDayDailyTokens, entry);
+      addDailyModelTokenEntry(thirtyDayDailyModelTokens, entry);
+    }
     if (entry.timestamp >= todayStartMs) {
       todayCostUsd += cost;
+      addTokenBreakdownEntry(todayBreakdown, entry);
+      addDailyTokenEntry(todayDailyTokens, entry);
+      addDailyModelTokenEntry(todayDailyModelTokens, entry);
     }
 
-    const modelKey = entry.model || "unknown";
-    if (!breakdown[modelKey]) {
-      breakdown[modelKey] = { input: 0, output: 0, cached: 0 };
+    if (entry.timestamp >= sevenDaysAgo) {
+      sevenDayCostUsd += cost;
+      addTokenBreakdownEntry(sevenDayBreakdown, entry);
+      addDailyTokenEntry(sevenDayDailyTokens, entry);
+      addDailyModelTokenEntry(sevenDayDailyModelTokens, entry);
     }
-    breakdown[modelKey].input += entry.inputTokens;
-    breakdown[modelKey].output += entry.outputTokens;
-    breakdown[modelKey].cached += entry.cachedTokens;
   }
 
   return {
     provider,
     last30dCostUsd: Math.round(last30dCostUsd * 100) / 100,
     todayCostUsd: Math.round(todayCostUsd * 100) / 100,
-    tokenBreakdown: breakdown,
+    costUsdByPreset: {
+      today: Math.round(todayCostUsd * 100) / 100,
+      "7d": Math.round(sevenDayCostUsd * 100) / 100,
+      "30d": Math.round(last30dCostUsd * 100) / 100,
+      all: Math.round(allCostUsd * 100) / 100,
+    },
+    tokenBreakdown: thirtyDayBreakdown,
+    tokenBreakdownByPreset: {
+      today: todayBreakdown,
+      "7d": sevenDayBreakdown,
+      "30d": thirtyDayBreakdown,
+      all: allBreakdown,
+    },
+    dailyTokenBreakdownByPreset: {
+      today: todayDailyModelTokens,
+      "7d": sevenDayDailyModelTokens,
+      "30d": thirtyDayDailyModelTokens,
+      all: allDailyModelTokens,
+    },
+    dailyTokensByPreset: {
+      today: todayDailyTokens,
+      "7d": sevenDayDailyTokens,
+      "30d": thirtyDayDailyTokens,
+      all: allDailyTokens,
+    },
   };
+}
+
+// ── Stats Aggregation ────────────────────────────────────────────
+
+type ResolvedAdeUsageRange = {
+  preset: AdeUsageRangePreset;
+  since: string | null;
+  until: string;
+};
+
+function toFiniteNumber(value: unknown): number {
+  const numberValue = Number(value ?? 0);
+  return Number.isFinite(numberValue) ? numberValue : 0;
+}
+
+function toNonNegativeInt(value: unknown): number {
+  return Math.max(0, Math.floor(toFiniteNumber(value)));
+}
+
+function startOfLocalDayIso(nowMs: number): string {
+  const date = new Date(nowMs);
+  date.setHours(0, 0, 0, 0);
+  return date.toISOString();
+}
+
+function startOfLocalDayOffsetIso(nowMs: number, daysBack: number): string {
+  const date = new Date(nowMs);
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() - Math.max(0, daysBack));
+  return date.toISOString();
+}
+
+function normalizePreset(value: unknown): AdeUsageRangePreset {
+  if (value === "today" || value === "7d" || value === "30d" || value === "all") {
+    return value;
+  }
+  return "7d";
+}
+
+function validIsoOrNull(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
+}
+
+function resolveAdeUsageRange(args: GetAdeUsageStatsArgs | undefined, nowMs: number): ResolvedAdeUsageRange {
+  const preset = normalizePreset(args?.preset);
+  const until = validIsoOrNull(args?.until ?? null) ?? new Date(nowMs).toISOString();
+  const untilMs = Date.parse(until);
+  const explicitSince = validIsoOrNull(args?.since ?? null);
+  if (explicitSince) {
+    return {
+      preset,
+      since: Date.parse(explicitSince) > untilMs ? until : explicitSince,
+      until,
+    };
+  }
+
+  switch (preset) {
+    case "today":
+      return { preset, since: startOfLocalDayIso(untilMs), until };
+    case "30d":
+      return { preset, since: startOfLocalDayOffsetIso(untilMs, 29), until };
+    case "all":
+      return { preset, since: null, until };
+    case "7d":
+    default:
+      return { preset: "7d", since: startOfLocalDayOffsetIso(untilMs, 6), until };
+  }
+}
+
+type ProviderModelAggregation = {
+  providers: Map<string, AdeUsageProviderSummary>;
+  models: Map<string, AdeUsageModelSummary>;
+};
+
+function normalizeUsageLabel(value: unknown, fallback: string): string {
+  const text = typeof value === "string" ? value.trim() : "";
+  return text.length > 0 ? text : fallback;
+}
+
+function resolveUsageModelDescriptor(model: unknown): ModelDescriptor | null {
+  const text = normalizeUsageLabel(model, "");
+  if (!text) return null;
+  return getModelById(text) ?? resolveModelAlias(text) ?? null;
+}
+
+function displayModelName(model: unknown): string {
+  const modelText = normalizeUsageLabel(model, "unknown");
+  const descriptor = resolveUsageModelDescriptor(modelText);
+  if (descriptor) return descriptor.displayName || descriptor.providerModelId || descriptor.id;
+
+  const decodedOpenCode = decodeOpenCodeRegistryId(modelText);
+  if (decodedOpenCode) return decodedOpenCode.openCodeModelId;
+
+  const localProvider = parseLocalProviderFromModelId(modelText);
+  if (localProvider) return modelText.slice(localProvider.length + 1) || modelText;
+
+  return modelText;
+}
+
+function createProviderModelAggregation(): ProviderModelAggregation {
+  return { providers: new Map(), models: new Map() };
+}
+
+function addProviderModelUsage(
+  aggregation: ProviderModelAggregation,
+  args: {
+    provider: string;
+    model?: string | null;
+    inputTokens?: number;
+    outputTokens?: number;
+    cachedTokens?: number;
+    calls?: number;
+    costUsd?: number;
+    rangeCostUsd?: number;
+    todayCostUsd?: number;
+    last30dCostUsd?: number;
+  },
+): void {
+  const provider = normalizeUsageLabel(args.provider, "unknown");
+  const inputTokens = toNonNegativeInt(args.inputTokens);
+  const outputTokens = toNonNegativeInt(args.outputTokens);
+  const cachedTokens = toNonNegativeInt(args.cachedTokens);
+  const totalTokens = inputTokens + outputTokens + cachedTokens;
+  const costUsd = Math.max(0, toFiniteNumber(args.costUsd));
+  const rangeCostUsd = Math.max(0, toFiniteNumber(args.rangeCostUsd ?? args.costUsd));
+  const todayCostUsd = Math.max(0, toFiniteNumber(args.todayCostUsd));
+  const last30dCostUsd = Math.max(0, toFiniteNumber(args.last30dCostUsd));
+  if (inputTokens + outputTokens + cachedTokens === 0 && costUsd + rangeCostUsd + todayCostUsd + last30dCostUsd === 0) {
+    return;
+  }
+
+  let providerSummary = aggregation.providers.get(provider);
+  if (!providerSummary) {
+    providerSummary = {
+      provider,
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedTokens: 0,
+      totalTokens: 0,
+      rangeCostUsd: 0,
+      todayCostUsd: 0,
+      last30dCostUsd: 0,
+    };
+    aggregation.providers.set(provider, providerSummary);
+  }
+  providerSummary.inputTokens += inputTokens;
+  providerSummary.outputTokens += outputTokens;
+  providerSummary.cachedTokens += cachedTokens;
+  providerSummary.totalTokens += totalTokens;
+  providerSummary.rangeCostUsd = Math.round((providerSummary.rangeCostUsd + rangeCostUsd) * 100) / 100;
+  providerSummary.todayCostUsd = Math.round((providerSummary.todayCostUsd + todayCostUsd) * 100) / 100;
+  providerSummary.last30dCostUsd = Math.round((providerSummary.last30dCostUsd + last30dCostUsd + costUsd) * 100) / 100;
+
+  const model = normalizeUsageLabel(args.model, "");
+  if (!model) return;
+
+  const modelKey = `${provider}\u0000${model}`;
+  let modelSummary = aggregation.models.get(modelKey);
+  if (!modelSummary) {
+    modelSummary = {
+      provider,
+      model,
+      calls: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedTokens: 0,
+      totalTokens: 0,
+      costUsd: 0,
+    };
+    aggregation.models.set(modelKey, modelSummary);
+  }
+  modelSummary.calls += toNonNegativeInt(args.calls);
+  modelSummary.inputTokens += inputTokens;
+  modelSummary.outputTokens += outputTokens;
+  modelSummary.cachedTokens += cachedTokens;
+  modelSummary.totalTokens += totalTokens;
+  modelSummary.costUsd = Math.round((modelSummary.costUsd + rangeCostUsd) * 100) / 100;
+}
+
+function sortedProviderModelSummaries(aggregation: ProviderModelAggregation): {
+  providers: AdeUsageProviderSummary[];
+  models: AdeUsageModelSummary[];
+} {
+  const providers = Array.from(aggregation.providers.values())
+    .sort((a, b) => (b.totalTokens - a.totalTokens) || (b.last30dCostUsd - a.last30dCostUsd) || a.provider.localeCompare(b.provider));
+  const models = Array.from(aggregation.models.values())
+    .sort((a, b) => (b.totalTokens - a.totalTokens) || (b.costUsd - a.costUsd) || a.model.localeCompare(b.model));
+  return { providers, models };
+}
+
+function addSnapshotProviderUsage(
+  aggregation: ProviderModelAggregation,
+  snapshot: UsageSnapshot,
+  range: ResolvedAdeUsageRange,
+  exactRange: boolean,
+): void {
+  addCostSnapshotsProviderUsage(aggregation, snapshot.costs, range, exactRange);
+}
+
+function addCostSnapshotsProviderUsage(
+  aggregation: ProviderModelAggregation,
+  costs: CostSnapshot[],
+  range: ResolvedAdeUsageRange,
+  exactRange: boolean,
+): void {
+  for (const cost of costs) {
+    const tokenBreakdown = exactRange
+      ? tokenBreakdownForExactRange(cost, range)
+      : cost.tokenBreakdownByPreset?.[range.preset] ?? cost.tokenBreakdown;
+    const providerTotalTokens = Object.values(tokenBreakdown).reduce((sum, entry) => (
+      sum + toNonNegativeInt(entry.input) + toNonNegativeInt(entry.output) + toNonNegativeInt(entry.cached) + toNonNegativeInt(entry.cacheWrite)
+    ), 0);
+    const rangeCostUsd = Math.max(0, toFiniteNumber(
+      exactRange
+        ? sumTokenBreakdownCost(tokenBreakdown)
+        : cost.costUsdByPreset?.[range.preset] ??
+          (range.preset === "today" ? cost.todayCostUsd : cost.last30dCostUsd),
+    ));
+    for (const [model, tokens] of Object.entries(tokenBreakdown)) {
+      const modelInput = toNonNegativeInt(tokens.input);
+      const modelOutput = toNonNegativeInt(tokens.output);
+      const modelCached = toNonNegativeInt(tokens.cached) + toNonNegativeInt(tokens.cacheWrite);
+      const share = providerTotalTokens > 0 ? (modelInput + modelOutput + modelCached) / providerTotalTokens : 0;
+      const modelCostUsd = Math.max(0, toFiniteNumber(tokens.costUsd ?? rangeCostUsd * share));
+      addProviderModelUsage(aggregation, {
+        provider: cost.provider,
+        model: displayModelName(model),
+        inputTokens: modelInput,
+        outputTokens: modelOutput,
+        cachedTokens: modelCached,
+        rangeCostUsd: modelCostUsd,
+        todayCostUsd: cost.todayCostUsd * share,
+        last30dCostUsd: cost.last30dCostUsd * share,
+      });
+    }
+  }
+}
+
+function tokenBreakdownForExactRange(cost: CostSnapshot, range: ResolvedAdeUsageRange): Record<string, CostTokenBreakdown> {
+  const dailyBreakdown = cost.dailyTokenBreakdownByPreset?.all;
+  if (!dailyBreakdown) return {};
+  const selected: TokenBreakdown = {};
+  for (const [date, breakdown] of Object.entries(dailyBreakdown)) {
+    if (!dateIntersectsRange(date, range)) continue;
+    for (const [model, entry] of Object.entries(breakdown)) {
+      if (!selected[model]) selected[model] = { input: 0, output: 0, cached: 0, cacheWrite: 0, costUsd: 0 };
+      selected[model].input += toNonNegativeInt(entry.input);
+      selected[model].output += toNonNegativeInt(entry.output);
+      selected[model].cached += toNonNegativeInt(entry.cached);
+      selected[model].cacheWrite += toNonNegativeInt(entry.cacheWrite);
+      selected[model].costUsd += Math.max(0, toFiniteNumber(entry.costUsd));
+    }
+  }
+  return selected;
+}
+
+function sumTokenBreakdownCost(breakdown: Record<string, CostTokenBreakdown>): number {
+  return Math.round(Object.values(breakdown).reduce((sum, entry) => sum + Math.max(0, toFiniteNumber(entry.costUsd)), 0) * 100) / 100;
+}
+
+function dateIntersectsRange(date: string, range: ResolvedAdeUsageRange): boolean {
+  const dayStart = Date.parse(`${date}T00:00:00.000Z`);
+  if (!Number.isFinite(dayStart)) return false;
+  const dayEnd = dayStart + 86_400_000 - 1;
+  if (range.since && dayEnd < Date.parse(range.since)) return false;
+  return dayStart <= Date.parse(range.until);
+}
+
+function makeDailySkeleton(range: ResolvedAdeUsageRange, nowMs: number): AdeUsageDailyPoint[] {
+  const until = new Date(range.until);
+  const untilMs = Number.isFinite(until.getTime()) ? until.getTime() : nowMs;
+  const maxDays =
+    range.preset === "today" ? 1 :
+    range.preset === "7d" ? 7 :
+    range.preset === "all" ? 90 :
+    30;
+  const startMs = range.since
+    ? Math.max(Date.parse(range.since), untilMs - (maxDays - 1) * 86_400_000)
+    : untilMs - (maxDays - 1) * 86_400_000;
+  const start = new Date(startMs);
+  start.setHours(0, 0, 0, 0);
+
+  const points: AdeUsageDailyPoint[] = [];
+  for (let index = 0; index < maxDays; index += 1) {
+    const date = new Date(start.getTime() + index * 86_400_000);
+    if (date.getTime() > untilMs + 86_400_000) break;
+    points.push({
+      date: date.toISOString().slice(0, 10),
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      commits: 0,
+      prs: 0,
+      insertions: 0,
+      deletions: 0,
+      filesChanged: 0,
+      sessions: 0,
+    });
+  }
+  return points;
+}
+
+function mergeSnapshotDailyTokens(
+  points: AdeUsageDailyPoint[],
+  costs: CostSnapshot[],
+  range: ResolvedAdeUsageRange,
+  exactRange: boolean,
+): void {
+  const byDate = new Map(points.map((point) => [point.date, point]));
+  for (const cost of costs) {
+    const dailyTokens = exactRange
+      ? cost.dailyTokensByPreset?.all ?? {}
+      : cost.dailyTokensByPreset?.[range.preset] ?? {};
+    for (const [date, value] of Object.entries(dailyTokens)) {
+      if (exactRange && !dateIntersectsRange(date, range)) continue;
+      const point = byDate.get(date);
+      if (!point) continue;
+      const tokens = toNonNegativeInt(value);
+      point.inputTokens += tokens;
+      point.totalTokens += tokens;
+    }
+  }
+}
+
+function summarizeObservedProviderUsage(providers: AdeUsageProviderSummary[]): {
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens: number;
+  totalTokens: number;
+  costRangeUsd: number;
+  cost30dUsd: number;
+  costTodayUsd: number;
+} {
+  const inputTokens = providers.reduce((sum, provider) => sum + provider.inputTokens, 0);
+  const outputTokens = providers.reduce((sum, provider) => sum + provider.outputTokens, 0);
+  const cachedTokens = providers.reduce((sum, provider) => sum + provider.cachedTokens, 0);
+  return {
+    inputTokens,
+    outputTokens,
+    cachedTokens,
+    totalTokens: inputTokens + outputTokens + cachedTokens,
+    costRangeUsd: Math.round(providers.reduce((sum, provider) => sum + provider.rangeCostUsd, 0) * 100) / 100,
+    cost30dUsd: Math.round(providers.reduce((sum, provider) => sum + provider.last30dCostUsd, 0) * 100) / 100,
+    costTodayUsd: Math.round(providers.reduce((sum, provider) => sum + provider.todayCostUsd, 0) * 100) / 100,
+  };
+}
+
+type GitHubDailyPoint = {
+  date: string;
+  commits: number;
+  prs: number;
+  insertions: number;
+  deletions: number;
+  filesChanged: number;
+};
+
+type GitHubActivityStats = {
+  repo: string | null;
+  available: boolean;
+  fetchedAt: string | null;
+  error: string | null;
+  commitsCreated: number;
+  prsTracked: number;
+  prsOpen: number;
+  prsMerged: number;
+  prsClosed: number;
+  prAdditions: number;
+  prDeletions: number;
+  filesChanged: number;
+  daily: GitHubDailyPoint[];
+};
+
+type GitHubPullRequestRow = {
+  number?: number;
+  state?: string | null;
+  createdAt?: string | null;
+  closedAt?: string | null;
+  mergedAt?: string | null;
+  additions?: number | null;
+  deletions?: number | null;
+  changedFiles?: number | null;
+  author?: { login?: string | null } | null;
+};
+
+const EMPTY_GITHUB_STATS: GitHubActivityStats = {
+  repo: null,
+  available: false,
+  fetchedAt: null,
+  error: null,
+  commitsCreated: 0,
+  prsTracked: 0,
+  prsOpen: 0,
+  prsMerged: 0,
+  prsClosed: 0,
+  prAdditions: 0,
+  prDeletions: 0,
+  filesChanged: 0,
+  daily: [],
+};
+
+function makeEmptyGithubStats(error: string | null = null, repo: string | null = null): GitHubActivityStats {
+  return {
+    ...EMPTY_GITHUB_STATS,
+    repo,
+    error,
+  };
+}
+
+function runBufferedCommand(
+  command: string,
+  args: string[],
+  options: { cwd?: string; timeoutMs?: number; maxOutputBytes?: number } = {},
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let stdout = "";
+    let stderr = "";
+    const maxOutputBytes = options.maxOutputBytes ?? GITHUB_STATS_MAX_OUTPUT_BYTES;
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      fn();
+    };
+    timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish(() => reject(new Error(`${command} timed out`)));
+    }, options.timeoutMs ?? GITHUB_STATS_COMMAND_TIMEOUT_MS);
+    timeout.unref?.();
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+      if (Buffer.byteLength(stdout, "utf8") > maxOutputBytes) {
+        child.kill("SIGTERM");
+        finish(() => reject(new Error(`${command} produced too much output`)));
+      }
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", (error) => finish(() => reject(error)));
+    child.on("close", (code) => {
+      finish(() => {
+        if (code === 0) {
+          resolve(stdout);
+          return;
+        }
+        reject(new Error(stderr.trim() || `${command} exited with code ${code ?? "unknown"}`));
+      });
+    });
+  });
+}
+
+function parseGithubRepoJson(raw: string): string | null {
+  const parsed = safeJsonParse<unknown>(raw.trim(), null);
+  if (!isRecord(parsed)) return null;
+  const owner = isRecord(parsed.owner) ? parsed.owner.login : parsed.owner;
+  const name = parsed.name;
+  if (typeof owner !== "string" || typeof name !== "string" || !owner || !name) return null;
+  return `${owner}/${name}`;
+}
+
+function parseGithubViewerLogin(raw: string): string | null {
+  const parsed = safeJsonParse<unknown>(raw.trim(), null);
+  if (!isRecord(parsed) || typeof parsed.login !== "string" || !parsed.login.trim()) return null;
+  return parsed.login.trim();
+}
+
+function parseGithubPullRequestRows(raw: string, viewer: string): GitHubPullRequestRow[] {
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => safeJsonParse<unknown>(line, null))
+    .filter(isRecord)
+    .filter((row) => isRecord(row.author) && row.author.login === viewer) as GitHubPullRequestRow[];
+}
+
+function parseGithubCommitDates(raw: string): string[] {
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split("\t")[1] ?? "")
+    .filter((date) => Number.isFinite(Date.parse(date)));
+}
+
+function timestampInRange(value: string | null | undefined, range: ResolvedAdeUsageRange): boolean {
+  if (!value) return false;
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return false;
+  if (range.since && timestamp < Date.parse(range.since)) return false;
+  return timestamp <= Date.parse(range.until);
+}
+
+function githubCommitDateArgs(range: ResolvedAdeUsageRange): string[] {
+  const args: string[] = [];
+  if (range.since) args.push("-F", `since=${range.since}`);
+  args.push("-F", `until=${range.until}`);
+  return args;
+}
+
+function githubRepoParts(repo: string): { owner: string; name: string } | null {
+  const [owner, name] = repo.split("/", 2);
+  if (!owner || !name) return null;
+  return { owner, name };
+}
+
+function githubPullRequestGraphqlQuery(): string {
+  return [
+    "query($owner: String!, $name: String!, $endCursor: String) {",
+    "  repository(owner: $owner, name: $name) {",
+    "    pullRequests(first: 100, after: $endCursor, orderBy: { field: CREATED_AT, direction: DESC }) {",
+    "      pageInfo { hasNextPage endCursor }",
+    "      nodes {",
+    "        number state createdAt closedAt mergedAt additions deletions changedFiles",
+    "        author { login }",
+    "      }",
+    "    }",
+    "  }",
+    "}",
+  ].join("\n");
+}
+
+function dateKeyFromIso(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return null;
+  return new Date(timestamp).toISOString().slice(0, 10);
+}
+
+function addGithubDaily(
+  byDate: Map<string, GitHubDailyPoint>,
+  date: string | null,
+  patch: Partial<Omit<GitHubDailyPoint, "date">>,
+): void {
+  if (!date) return;
+  const point = byDate.get(date) ?? {
+    date,
+    commits: 0,
+    prs: 0,
+    insertions: 0,
+    deletions: 0,
+    filesChanged: 0,
+  };
+  point.commits += toNonNegativeInt(patch.commits);
+  point.prs += toNonNegativeInt(patch.prs);
+  point.insertions += toNonNegativeInt(patch.insertions);
+  point.deletions += toNonNegativeInt(patch.deletions);
+  point.filesChanged += toNonNegativeInt(patch.filesChanged);
+  byDate.set(date, point);
+}
+
+async function scanGithubActivityStats(projectRoot: string | null | undefined, range: ResolvedAdeUsageRange): Promise<GitHubActivityStats> {
+  if (!projectRoot) return makeEmptyGithubStats("No project root is available.");
+  try {
+    const repoRaw = await runBufferedCommand("gh", ["repo", "view", "--json", "owner,name"], {
+      cwd: projectRoot,
+      timeoutMs: 10_000,
+    });
+    const repo = parseGithubRepoJson(repoRaw);
+    if (!repo) return makeEmptyGithubStats("Unable to resolve the GitHub repository.", null);
+
+	    const viewerRaw = await runBufferedCommand("gh", ["api", "user", "--cache", "10m"], {
+	      cwd: projectRoot,
+	      timeoutMs: 10_000,
+	    });
+	    const viewer = parseGithubViewerLogin(viewerRaw);
+	    if (!viewer) return makeEmptyGithubStats("Unable to resolve the GitHub user.", repo);
+	    const repoParts = githubRepoParts(repo);
+	    if (!repoParts) return makeEmptyGithubStats("Unable to resolve the GitHub repository.", repo);
+
+	    const [prRaw, commitRaw] = await Promise.all([
+	      runBufferedCommand(
+	        "gh",
+	        [
+	          "api",
+	          "graphql",
+	          "--paginate",
+	          "-F",
+	          `owner=${repoParts.owner}`,
+	          "-F",
+	          `name=${repoParts.name}`,
+	          "-f",
+	          `query=${githubPullRequestGraphqlQuery()}`,
+	          "--jq",
+	          ".data.repository.pullRequests.nodes[] | @json",
+	        ],
+	        { cwd: projectRoot },
+	      ),
+	      runBufferedCommand(
+	        "gh",
+	        [
+	          "api",
+	          `repos/${repo}/commits`,
+	          "--method",
+	          "GET",
+	          "--cache",
+	          "10m",
+	          "-F",
+	          `author=${viewer}`,
+	          ...githubCommitDateArgs(range),
+	          "--paginate",
+	          "--jq",
+	          ".[] | [.sha, .commit.author.date] | @tsv",
+	        ],
+	        { cwd: projectRoot },
+	      ),
+	    ]);
+
+	    const dailyByDate = new Map<string, GitHubDailyPoint>();
+	    const prs = parseGithubPullRequestRows(prRaw, viewer);
+	    const mergedPrs = prs.filter((pr) => timestampInRange(pr.mergedAt, range));
+	    const closedPrs = prs.filter((pr) => timestampInRange(pr.closedAt, range));
+	    const prsCreatedInRange = prs.filter((pr) => timestampInRange(pr.createdAt, range));
+    const commitsInRange = parseGithubCommitDates(commitRaw).filter((date) => timestampInRange(date, range));
+    for (const date of commitsInRange) {
+      addGithubDaily(dailyByDate, dateKeyFromIso(date), { commits: 1 });
+    }
+
+    for (const pr of prsCreatedInRange) {
+      addGithubDaily(dailyByDate, dateKeyFromIso(pr.createdAt), {
+        prs: 1,
+      });
+    }
+
+    for (const pr of mergedPrs) {
+      addGithubDaily(dailyByDate, dateKeyFromIso(pr.mergedAt), {
+        insertions: pr.additions ?? 0,
+        deletions: pr.deletions ?? 0,
+        filesChanged: pr.changedFiles ?? 0,
+      });
+    }
+
+    const prsMerged = mergedPrs.length;
+    const prsClosed = closedPrs.filter((pr) => String(pr.state ?? "").toUpperCase() === "CLOSED").length;
+    return {
+      repo,
+      available: true,
+      fetchedAt: nowIso(),
+      error: null,
+      commitsCreated: commitsInRange.length,
+      prsTracked: prsCreatedInRange.length,
+      prsOpen: prsCreatedInRange.filter((pr) => String(pr.state ?? "").toUpperCase() === "OPEN").length,
+      prsMerged,
+      prsClosed,
+      prAdditions: mergedPrs.reduce((sum, pr) => sum + toNonNegativeInt(pr.additions), 0),
+      prDeletions: mergedPrs.reduce((sum, pr) => sum + toNonNegativeInt(pr.deletions), 0),
+      filesChanged: mergedPrs.reduce((sum, pr) => sum + toNonNegativeInt(pr.changedFiles), 0),
+      daily: Array.from(dailyByDate.values()).sort((a, b) => a.date.localeCompare(b.date)),
+    };
+  } catch (error) {
+    return makeEmptyGithubStats(getErrorMessage(error), null);
+  }
+}
+
+function mergeGithubDaily(points: AdeUsageDailyPoint[], githubStats: GitHubActivityStats | null | undefined): void {
+  if (!githubStats) return;
+  const byDate = new Map(points.map((point) => [point.date, point]));
+  for (const row of githubStats.daily) {
+    const point = byDate.get(row.date);
+    if (!point) continue;
+    point.commits += toNonNegativeInt(row.commits);
+    point.prs += toNonNegativeInt(row.prs);
+    point.insertions += toNonNegativeInt(row.insertions);
+    point.deletions += toNonNegativeInt(row.deletions);
+    point.filesChanged += toNonNegativeInt(row.filesChanged);
+  }
+}
+
+function collectAdeUsageStats({
+  snapshot,
+  githubStats,
+  args,
+  nowMs = Date.now(),
+}: {
+  snapshot: UsageSnapshot;
+  githubStats?: GitHubActivityStats | null;
+  args?: GetAdeUsageStatsArgs;
+  nowMs?: number;
+}): AdeUsageStats {
+  const range = resolveAdeUsageRange(args, nowMs);
+  const exactProviderRange = Boolean(args?.since || args?.until);
+  const providerModelAggregation = createProviderModelAggregation();
+  addSnapshotProviderUsage(providerModelAggregation, snapshot, range, exactProviderRange);
+  const { providers, models } = sortedProviderModelSummaries(providerModelAggregation);
+  const fallbackObserved = summarizeObservedProviderUsage(providers);
+  const runtimeDaily = makeDailySkeleton(range, nowMs);
+  mergeSnapshotDailyTokens(runtimeDaily, snapshot.costs, range, exactProviderRange);
+  const resolvedGithubStats = githubStats ?? EMPTY_GITHUB_STATS;
+  mergeGithubDaily(runtimeDaily, resolvedGithubStats);
+
+  const fallback: AdeUsageStats = {
+    generatedAt: new Date(nowMs).toISOString(),
+    range,
+    summary: {
+      totalTokens: fallbackObserved.totalTokens,
+      tokenTotalSource: "provider_logs",
+      observedProviderTokens: fallbackObserved.totalTokens,
+      observedProviderInputTokens: fallbackObserved.inputTokens,
+      observedProviderOutputTokens: fallbackObserved.outputTokens,
+      observedProviderCachedTokens: fallbackObserved.cachedTokens,
+      observedProviderCostRangeUsd: fallbackObserved.costRangeUsd,
+      observedProviderCost30dUsd: fallbackObserved.cost30dUsd,
+      observedProviderCostTodayUsd: fallbackObserved.costTodayUsd,
+      adeRuntimeTokens: 0,
+      adeRuntimeInputTokens: 0,
+      adeRuntimeOutputTokens: 0,
+      adeRuntimeCachedTokens: 0,
+      adeRuntimeCostRangeUsd: 0,
+      adeRuntimeCost30dUsd: 0,
+      adeRuntimeCostTodayUsd: 0,
+      adeTotalTokens: 0,
+      adeTotalCostRangeUsd: 0,
+      trackedAdeTokens: 0,
+      trackedAdeInputTokens: 0,
+      trackedAdeOutputTokens: 0,
+      trackedAdeCalls: 0,
+      trackedAdeDurationMs: 0,
+      workerTokens: 0,
+      workerCostUsd: 0,
+      chatSessions: 0,
+      terminalSessions: 0,
+      activeLanes: 0,
+      lanesCreated: 0,
+      lanesArchived: 0,
+      lanesDeleted: 0,
+      commitsCreated: resolvedGithubStats.commitsCreated,
+      pushOperations: 0,
+      prLandings: resolvedGithubStats.prsMerged,
+      prsTracked: resolvedGithubStats.prsTracked,
+      prsOpen: resolvedGithubStats.prsOpen,
+      prsMerged: resolvedGithubStats.prsMerged,
+      prsClosed: resolvedGithubStats.prsClosed,
+      prAdditions: resolvedGithubStats.prAdditions,
+      prDeletions: resolvedGithubStats.prDeletions,
+      filesChanged: resolvedGithubStats.filesChanged,
+      insertions: resolvedGithubStats.prAdditions,
+      deletions: resolvedGithubStats.prDeletions,
+      artifactsCaptured: 0,
+      automationRuns: 0,
+      workerRuns: 0,
+    },
+    providers,
+    models,
+    adeProviders: [],
+    adeModels: [],
+    agentProviders: [],
+    agentModels: [],
+    features: [],
+    lanes: [],
+    activities: [],
+    daily: runtimeDaily,
+    github: {
+      repo: resolvedGithubStats.repo,
+      available: resolvedGithubStats.available,
+      lastFetchedAt: resolvedGithubStats.fetchedAt,
+      error: resolvedGithubStats.error,
+    },
+    sourceNotes: [],
+  };
+
+  return fallback;
 }
 
 // ── Pacing Calculation ───────────────────────────────────────────
@@ -889,6 +3024,14 @@ type UsageTrackingDependencies = {
   pollCodexUsage?: () => Promise<{ windows: UsageWindow[]; errors: string[] }>;
   scanClaudeLogs?: () => Promise<TokenEntry[]>;
   scanCodexLogs?: () => Promise<TokenEntry[]>;
+  scanCursorLogs?: () => Promise<TokenEntry[]>;
+  scanCursorAgentLogs?: () => Promise<TokenEntry[]>;
+  scanOpenClawLogs?: () => Promise<TokenEntry[]>;
+  scanOpenCodeLogs?: () => Promise<TokenEntry[]>;
+  scanDroidLogs?: () => Promise<TokenEntry[]>;
+  scanCopilotLogs?: () => Promise<TokenEntry[]>;
+  scanGeminiLogs?: () => Promise<TokenEntry[]>;
+  scanGitHubStats?: (range: ResolvedAdeUsageRange) => Promise<GitHubActivityStats>;
 };
 
 export function createUsageTrackingService({
@@ -896,45 +3039,77 @@ export function createUsageTrackingService({
   pollIntervalMs: configuredInterval,
   onUpdate,
   dependencies,
+  projectRoot,
 }: {
   logger: Logger;
   pollIntervalMs?: number;
   onUpdate?: (snapshot: UsageSnapshot) => void;
   dependencies?: UsageTrackingDependencies;
+  projectRoot?: string | null;
 }) {
   const pollIntervalMs = Math.max(
     MIN_POLL_INTERVAL_MS,
     Math.min(MAX_POLL_INTERVAL_MS, configuredInterval ?? DEFAULT_POLL_INTERVAL_MS)
   );
 
-  let lastSnapshot: UsageSnapshot | null = null;
+  let lastSnapshot: UsageSnapshot | null = readCachedUsageSnapshot(logger);
   let costCacheTimestamp = 0;
   let cachedCosts: CostSnapshot[] = [];
+  let cachedAdeCosts: CostSnapshot[] = [];
   let cachedDaily7d: Partial<Record<UsageProvider, number[]>> = {};
+  const githubStatsCache = new Map<string, { fetchedAtMs: number; stats: GitHubActivityStats }>();
+  const githubStatsInFlight = new Map<string, Promise<GitHubActivityStats>>();
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let inFlightPoll: Promise<UsageSnapshot> | null = null;
   const runClaudeUsagePoll = dependencies?.pollClaudeUsage ?? (() => pollClaudeUsage(logger));
   const runCodexUsagePoll = dependencies?.pollCodexUsage ?? (() => pollCodexUsage(logger));
   const scanClaudeCostLogs = dependencies?.scanClaudeLogs ?? scanClaudeLogs;
   const scanCodexCostLogs = dependencies?.scanCodexLogs ?? scanCodexLogs;
+  const scanCursorCostLogs = dependencies?.scanCursorLogs ?? scanCursorLogs;
+  const scanCursorAgentCostLogs = dependencies?.scanCursorAgentLogs ?? scanCursorAgentLogs;
+  const scanOpenClawCostLogs = dependencies?.scanOpenClawLogs ?? scanOpenClawLogs;
+  const scanOpenCodeCostLogs = dependencies?.scanOpenCodeLogs ?? scanOpenCodeLogs;
+  const scanDroidCostLogs = dependencies?.scanDroidLogs ?? scanDroidLogs;
+  const scanCopilotCostLogs = dependencies?.scanCopilotLogs ?? scanCopilotLogs;
+  const scanGeminiCostLogs = dependencies?.scanGeminiLogs ?? scanGeminiLogs;
+  const scanGitHubStatsForRange = dependencies?.scanGitHubStats
+    ?? ((range: ResolvedAdeUsageRange) => scanGithubActivityStats(projectRoot, range));
 
   const emptySnapshot = (): UsageSnapshot => ({
     windows: [],
     pacing: emptyPacing(),
     pacingByProvider: {},
     costs: [],
+    adeCosts: [],
     extraUsage: [],
     lastPolledAt: nowIso(),
     errors: [],
   });
 
-  async function pollCosts(): Promise<CostSnapshot[]> {
+  async function pollCosts(): Promise<{ costs: CostSnapshot[]; adeCosts: CostSnapshot[] }> {
     const now = Date.now();
     if (now - costCacheTimestamp < COST_CACHE_TTL_MS && cachedCosts.length > 0) {
-      return cachedCosts;
+      return { costs: cachedCosts, adeCosts: cachedAdeCosts };
     }
 
-    const [claudeEntries, codexEntries] = await Promise.all([
+    if (process.env.VITEST !== "true") {
+      await refreshDynamicTokenPricing(logger).catch((error) => {
+        logger.debug("usage.pricing_refresh_failed", { error: getErrorMessage(error) });
+        return 0;
+      });
+    }
+
+    const [
+      claudeEntries,
+      codexEntries,
+      cursorEntries,
+      cursorAgentEntries,
+      openClawEntries,
+      openCodeEntries,
+      droidEntries,
+      copilotEntries,
+      geminiEntries,
+    ] = await Promise.all([
       scanClaudeCostLogs().catch((err) => {
         logger.warn("usage.cost_scan.claude_failed", { error: getErrorMessage(err) });
         return [] as TokenEntry[];
@@ -943,20 +3118,56 @@ export function createUsageTrackingService({
         logger.warn("usage.cost_scan.codex_failed", { error: getErrorMessage(err) });
         return [] as TokenEntry[];
       }),
+      scanCursorCostLogs().catch((err) => {
+        logger.warn("usage.cost_scan.cursor_failed", { error: getErrorMessage(err) });
+        return [] as TokenEntry[];
+      }),
+      scanCursorAgentCostLogs().catch((err) => {
+        logger.warn("usage.cost_scan.cursor_agent_failed", { error: getErrorMessage(err) });
+        return [] as TokenEntry[];
+      }),
+      scanOpenClawCostLogs().catch((err) => {
+        logger.warn("usage.cost_scan.openclaw_failed", { error: getErrorMessage(err) });
+        return [] as TokenEntry[];
+      }),
+      scanOpenCodeCostLogs().catch((err) => {
+        logger.warn("usage.cost_scan.opencode_failed", { error: getErrorMessage(err) });
+        return [] as TokenEntry[];
+      }),
+      scanDroidCostLogs().catch((err) => {
+        logger.warn("usage.cost_scan.droid_failed", { error: getErrorMessage(err) });
+        return [] as TokenEntry[];
+      }),
+      scanCopilotCostLogs().catch((err) => {
+        logger.warn("usage.cost_scan.copilot_failed", { error: getErrorMessage(err) });
+        return [] as TokenEntry[];
+      }),
+      scanGeminiCostLogs().catch((err) => {
+        logger.warn("usage.cost_scan.gemini_failed", { error: getErrorMessage(err) });
+        return [] as TokenEntry[];
+      }),
     ]);
 
     const costs: CostSnapshot[] = [];
     if (claudeEntries.length > 0) costs.push(aggregateCosts(claudeEntries, "claude"));
     if (codexEntries.length > 0) costs.push(aggregateCosts(codexEntries, "codex"));
+    if (cursorEntries.length > 0) costs.push(aggregateCosts(cursorEntries, "cursor"));
+    if (cursorAgentEntries.length > 0) costs.push(aggregateCosts(cursorAgentEntries, "cursor-agent"));
+    if (openClawEntries.length > 0) costs.push(aggregateCosts(openClawEntries, "openclaw"));
+    if (openCodeEntries.length > 0) costs.push(aggregateCosts(openCodeEntries, "opencode"));
+    if (droidEntries.length > 0) costs.push(aggregateCosts(droidEntries, "droid"));
+    if (copilotEntries.length > 0) costs.push(aggregateCosts(copilotEntries, "copilot"));
+    if (geminiEntries.length > 0) costs.push(aggregateCosts(geminiEntries, "gemini"));
 
     const daily7d: Partial<Record<UsageProvider, number[]>> = {};
     if (claudeEntries.length > 0) daily7d.claude = bucketDaily7d(claudeEntries, now);
     if (codexEntries.length > 0) daily7d.codex = bucketDaily7d(codexEntries, now);
 
     cachedCosts = costs;
+    cachedAdeCosts = [];
     cachedDaily7d = daily7d;
     costCacheTimestamp = now;
-    return costs;
+    return { costs, adeCosts: [] };
   }
 
   async function poll(): Promise<UsageSnapshot> {
@@ -969,7 +3180,7 @@ export function createUsageTrackingService({
       let allWindows: UsageWindow[] = [];
 
       try {
-        const [claudeResult, codexResult, costs] = await Promise.all([
+        const [claudeResult, codexResult, costResult] = await Promise.all([
           runClaudeUsagePoll().catch((err) => {
             const msg = `claude: poll failed: ${getErrorMessage(err)}`;
             logger.warn("usage.poll.claude_failed", { error: msg });
@@ -995,7 +3206,8 @@ export function createUsageTrackingService({
           windows: allWindows,
           pacing,
           pacingByProvider,
-          costs,
+          costs: costResult.costs,
+          adeCosts: costResult.adeCosts,
           extraUsage,
           dailyUsage7d: { ...cachedDaily7d },
           lastPolledAt: nowIso(),
@@ -1003,6 +3215,7 @@ export function createUsageTrackingService({
         };
 
         lastSnapshot = snapshot;
+        void writeCachedUsageSnapshot(snapshot, logger);
 
         try {
           onUpdate?.(snapshot);
@@ -1057,7 +3270,77 @@ export function createUsageTrackingService({
 
   async function forceRefresh(): Promise<UsageSnapshot> {
     costCacheTimestamp = 0; // Invalidate cost cache
-    return await poll();
+    githubStatsCache.clear();
+    githubStatsInFlight.clear();
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const timeoutSnapshot = new Promise<UsageSnapshot>((resolve) => {
+      timeout = setTimeout(() => {
+        logger.warn("usage.force_refresh_returning_cached_snapshot", {
+          timeoutMs: FORCE_REFRESH_RESPONSE_TIMEOUT_MS,
+        });
+        resolve(lastSnapshot ?? emptySnapshot());
+      }, FORCE_REFRESH_RESPONSE_TIMEOUT_MS).unref?.();
+    });
+    try {
+      return await Promise.race([poll(), timeoutSnapshot]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  }
+
+  async function getAdeUsageStats(args: GetAdeUsageStatsArgs = {}): Promise<AdeUsageStats> {
+    let snapshot = lastSnapshot;
+    if (inFlightPoll) {
+      snapshot = await inFlightPoll.catch(() => lastSnapshot ?? emptySnapshot());
+    }
+    const lastPolledMs = snapshot ? Date.parse(snapshot.lastPolledAt) : Number.NaN;
+    const staleSnapshot = snapshot
+      ? !Number.isFinite(lastPolledMs) || Date.now() - lastPolledMs > COST_CACHE_TTL_MS
+      : false;
+    if (!snapshot || snapshot.costs.length === 0 || staleSnapshot) {
+      snapshot = await poll().catch(() => lastSnapshot ?? emptySnapshot());
+    }
+    const range = resolveAdeUsageRange(args, Date.now());
+    const githubStats = await getGithubStatsForRange(range);
+    return collectAdeUsageStats({
+      snapshot,
+      githubStats,
+      args,
+    });
+  }
+
+  async function getGithubStatsForRange(range: ResolvedAdeUsageRange): Promise<GitHubActivityStats> {
+    const cacheKey = `${range.preset}:${range.since ?? "all"}:${range.until}`;
+    const cached = githubStatsCache.get(cacheKey);
+    if (cached && Date.now() - cached.fetchedAtMs < GITHUB_STATS_CACHE_TTL_MS) {
+      return cached.stats;
+    }
+    let inFlight = githubStatsInFlight.get(cacheKey);
+    if (!inFlight) {
+      inFlight = scanGitHubStatsForRange(range)
+        .catch((error) => makeEmptyGithubStats(getErrorMessage(error)))
+        .then((statsForRange) => {
+          githubStatsCache.set(cacheKey, { fetchedAtMs: Date.now(), stats: statsForRange });
+          return statsForRange;
+        })
+        .finally(() => {
+          githubStatsInFlight.delete(cacheKey);
+        });
+      githubStatsInFlight.set(cacheKey, inFlight);
+    }
+
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const loadingFallback = new Promise<GitHubActivityStats>((resolve) => {
+      timeout = setTimeout(() => {
+        resolve(makeEmptyGithubStats("GitHub activity is still loading."));
+      }, GITHUB_STATS_FAST_RESPONSE_TIMEOUT_MS);
+      timeout.unref?.();
+    });
+    try {
+      return await Promise.race([inFlight, loadingFallback]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
   }
 
   return {
@@ -1065,6 +3348,7 @@ export function createUsageTrackingService({
     stop,
     getUsageSnapshot,
     forceRefresh,
+    getAdeUsageStats,
     poll,
     dispose: stop,
   };
@@ -1084,15 +3368,30 @@ export const _testing = {
   parseCodexRateLimitWindows,
   pollClaudeUsage,
   pollCodexUsage,
+  discoverClaudeProjectDirs,
   scanClaudeLogs,
   scanCodexLogs,
+  scanCursorLogs,
+  scanCursorAgentLogs,
+  scanOpenClawLogs,
+  scanOpenCodeLogs,
+  scanDroidLogs,
+  scanCopilotLogs,
+  scanGeminiLogs,
+  parseCopilotEvents,
+  parseGeminiEntries,
   aggregateCosts,
   bucketDaily7d,
+  collectAdeUsageStats,
   calculatePacing,
   calculatePacingByProvider,
   calculatePacingForWindow,
   fetchJson,
+  findRecentFiles,
   findJsonlFiles,
   resolveTokenPrice,
+  refreshDynamicTokenPricing,
+  resetDynamicTokenPricingForTest,
+  setDynamicTokenPricingForTest,
   pollCodexViaCliRpc,
 };

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -151,6 +151,8 @@ import type {
   ReviewRunDetail,
   ReviewStartRunArgs,
   AdeActionRegistryEntry,
+  AdeUsageStats,
+  GetAdeUsageStatsArgs,
   UsageSnapshot,
   BudgetCheckResult,
   BudgetCapScope,
@@ -1015,6 +1017,7 @@ declare global {
         listRegistry: () => Promise<AdeActionRegistryEntry[]>;
       };
       usage: {
+        getAdeStats: (args?: GetAdeUsageStatsArgs) => Promise<AdeUsageStats | null>;
         getSnapshot: () => Promise<UsageSnapshot | null>;
         refresh: () => Promise<UsageSnapshot | null>;
         checkBudget: (args: {

--- a/apps/desktop/src/preload/preload.test.ts
+++ b/apps/desktop/src/preload/preload.test.ts
@@ -83,7 +83,7 @@ describe("preload OAuth bridge", () => {
       project,
       { rootPath: "/repo/b", displayName: "B", baseRef: "main" },
     ];
-    const invoke = vi.fn(async (channel: string) => {
+    const invoke = vi.fn(async (channel: string, _payload?: unknown) => {
       if (channel === IPC.appGetWindowSession) {
         return { windowId: 7, project, binding: null, openProjectTabs };
       }
@@ -378,7 +378,7 @@ describe("preload OAuth bridge", () => {
       rootPath: "/remote/project",
       displayName: "Project",
     };
-    const invoke = vi.fn(async (channel: string) => {
+    const invoke = vi.fn(async (channel: string, _payload?: unknown) => {
       if (channel === IPC.appGetWindowSession) {
         return { windowId: 1, project: null, binding };
       }
@@ -1856,7 +1856,7 @@ describe("preload OAuth bridge", () => {
     }
   });
 
-  it("uses desktop usage IPC directly for local project usage reads", async () => {
+  it("routes local project usage reads through the shared project runtime when bound", async () => {
     const binding = {
       kind: "local",
       key: "local:/repo",
@@ -1883,14 +1883,23 @@ describe("preload OAuth bridge", () => {
       errors: [],
     };
     const refreshed = { ...snapshot, lastPolledAt: "2026-05-14T14:01:00.000Z" };
-    const invoke = vi.fn(async (channel: string) => {
+    const invoke = vi.fn(async (channel: string, payload?: unknown) => {
       if (channel === IPC.appGetWindowSession) {
         return { windowId: 1, project: { rootPath: "/repo", displayName: "Project" }, binding };
       }
-      if (channel === IPC.usageGetSnapshot) return snapshot;
-      if (channel === IPC.usageRefresh) return refreshed;
       if (channel === IPC.localRuntimeCallAction) {
-        throw new Error("usage should not call the local runtime daemon");
+        const request = (payload as { request?: { domain?: string; action?: string } } | undefined)?.request;
+        if (request?.domain !== "usage") throw new Error("unexpected local runtime domain");
+        return {
+          ok: true,
+          domain: request.domain,
+          action: request.action,
+          result: request.action === "forceRefresh" ? refreshed : snapshot,
+          statusHints: {},
+        };
+      }
+      if (channel === IPC.usageGetSnapshot || channel === IPC.usageRefresh) {
+        throw new Error("local bound usage should not fall back to desktop usage IPC");
       }
       return undefined;
     });
@@ -1917,12 +1926,16 @@ describe("preload OAuth bridge", () => {
     await expect(bridge.usage.getSnapshot()).resolves.toEqual(snapshot);
     await expect(bridge.usage.refresh()).resolves.toEqual(refreshed);
 
-    expect(invoke).toHaveBeenCalledWith(IPC.usageGetSnapshot);
-    expect(invoke).toHaveBeenCalledWith(IPC.usageRefresh);
-    expect(invoke).not.toHaveBeenCalledWith(
-      IPC.localRuntimeCallAction,
-      expect.anything(),
-    );
+    expect(invoke).toHaveBeenCalledWith(IPC.localRuntimeCallAction, {
+      rootPath: "/repo",
+      request: { domain: "usage", action: "getUsageSnapshot" },
+    });
+    expect(invoke).toHaveBeenCalledWith(IPC.localRuntimeCallAction, {
+      rootPath: "/repo",
+      request: { domain: "usage", action: "forceRefresh" },
+    });
+    expect(invoke).not.toHaveBeenCalledWith(IPC.usageGetSnapshot);
+    expect(invoke).not.toHaveBeenCalledWith(IPC.usageRefresh);
   });
 
   it("routes usage reads through a remote project runtime when bound", async () => {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -525,6 +525,8 @@ import type {
   TestRunSummary,
   TestSuiteDefinition,
   WriteTextAtomicArgs,
+  AdeUsageStats,
+  GetAdeUsageStatsArgs,
   UsageSnapshot,
   BudgetCheckResult,
   BudgetCapScope,
@@ -4004,12 +4006,16 @@ contextBridge.exposeInMainWorld("ade", {
     },
   },
   usage: {
+    getAdeStats: async (args: GetAdeUsageStatsArgs = {}): Promise<AdeUsageStats | null> =>
+      callProjectRuntimeActionOr("usage", "getAdeUsageStats", { args }, () =>
+        ipcRenderer.invoke(IPC.usageGetAdeStats, args),
+      ),
     getSnapshot: async (): Promise<UsageSnapshot | null> =>
-      callRemoteProjectRuntimeActionOr("usage", "getUsageSnapshot", {}, () =>
+      callProjectRuntimeActionOr("usage", "getUsageSnapshot", {}, () =>
         ipcRenderer.invoke(IPC.usageGetSnapshot),
       ),
     refresh: async (): Promise<UsageSnapshot | null> =>
-      callRemoteProjectRuntimeActionOr("usage", "forceRefresh", {}, () =>
+      callProjectRuntimeActionOr("usage", "forceRefresh", {}, () =>
         ipcRenderer.invoke(IPC.usageRefresh),
       ),
     checkBudget: async (args: {
@@ -4017,7 +4023,7 @@ contextBridge.exposeInMainWorld("ade", {
       scopeId?: string;
       provider: BudgetCapProvider;
     }): Promise<BudgetCheckResult> =>
-      callRemoteProjectRuntimeActionOr("budget", "checkBudget", { args }, () =>
+      callProjectRuntimeActionOr("budget", "checkBudget", { args }, () =>
         ipcRenderer.invoke(IPC.usageCheckBudget, args),
       ),
     getCumulativeUsage: async (args: {
@@ -4029,17 +4035,17 @@ contextBridge.exposeInMainWorld("ade", {
       totalCostUsd: number;
       weekKey: string;
     }> =>
-      callRemoteProjectRuntimeActionOr("budget", "getCumulativeUsage", { args }, () =>
+      callProjectRuntimeActionOr("budget", "getCumulativeUsage", { args }, () =>
         ipcRenderer.invoke(IPC.usageGetCumulativeUsage, args),
       ),
     getBudgetConfig: async (): Promise<BudgetCapConfig> =>
-      callRemoteProjectRuntimeActionOr("budget", "getConfig", {}, () =>
+      callProjectRuntimeActionOr("budget", "getConfig", {}, () =>
         ipcRenderer.invoke(IPC.usageGetBudgetConfig),
       ),
     saveBudgetConfig: async (
       config: BudgetCapConfig,
     ): Promise<BudgetCapConfig> =>
-      callRemoteProjectRuntimeActionOr(
+      callProjectRuntimeActionOr(
         "budget",
         "updateConfig",
         { args: config },

--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -75,6 +75,7 @@ const adeDbSnapshotByPath = import.meta.glob<any>(
 const ADE_DB_SNAPSHOT =
   adeDbSnapshotByPath["./browser-mock-ade-snapshot.generated.json"] ?? null;
 const USE_ADE_DB_SNAPSHOT = Boolean(ADE_DB_SNAPSHOT?.project);
+const USE_STATS_DASHBOARD_SNAPSHOT = USE_ADE_DB_SNAPSHOT && ADE_DB_SNAPSHOT?.statsDashboardVersion === 1;
 
 const MOCK_PROJECT =
   USE_ADE_DB_SNAPSHOT && ADE_DB_SNAPSHOT?.project
@@ -2908,6 +2909,7 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
       resetsInHours: 168,
     },
     costs: [],
+    adeCosts: [],
     extraUsage: [],
     lastPolledAt: now,
     errors: [],
@@ -2916,6 +2918,125 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
     USE_ADE_DB_SNAPSHOT && ADE_DB_SNAPSHOT?.usageSnapshot
       ? ADE_DB_SNAPSHOT.usageSnapshot
       : BROWSER_MOCK_USAGE_SNAPSHOT;
+
+  const browserStatsRangeForPreset = (preset: "today" | "7d" | "30d" | "all") => {
+    const until = new Date();
+    const start = new Date(until);
+    start.setHours(0, 0, 0, 0);
+    if (preset === "7d") start.setDate(start.getDate() - 6);
+    if (preset === "30d") start.setDate(start.getDate() - 29);
+    return {
+      preset,
+      since: preset === "all" ? null : start.toISOString(),
+      until: until.toISOString(),
+    };
+  };
+  const makeBrowserStatsDailySkeleton = (range: { preset: "today" | "7d" | "30d" | "all"; since: string | null; until: string }) => {
+    const maxDays = range.preset === "today" ? 1 : range.preset === "7d" ? 7 : range.preset === "all" ? 90 : 30;
+    const untilMs = Date.parse(range.until);
+    const start = new Date(range.since ?? untilMs - (maxDays - 1) * 86_400_000);
+    start.setHours(0, 0, 0, 0);
+    return Array.from({ length: maxDays }, (_, index) => {
+      const date = new Date(start.getTime() + index * 86_400_000);
+      return {
+        date: date.toISOString().slice(0, 10),
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        commits: 0,
+        prs: 0,
+        insertions: 0,
+        deletions: 0,
+        filesChanged: 0,
+        sessions: 0,
+      };
+    });
+  };
+  const makeBrowserEmptyAdeUsageStats = (preset: "today" | "7d" | "30d" | "all"): any => {
+    const range = browserStatsRangeForPreset(preset);
+    return {
+    generatedAt: now,
+    range,
+    summary: {
+      totalTokens: 0,
+      tokenTotalSource: "provider_logs",
+      observedProviderTokens: 0,
+      observedProviderInputTokens: 0,
+      observedProviderOutputTokens: 0,
+      observedProviderCachedTokens: 0,
+      observedProviderCostRangeUsd: 0,
+      observedProviderCost30dUsd: 0,
+      observedProviderCostTodayUsd: 0,
+      adeRuntimeTokens: 0,
+      adeRuntimeInputTokens: 0,
+      adeRuntimeOutputTokens: 0,
+      adeRuntimeCachedTokens: 0,
+      adeRuntimeCostRangeUsd: 0,
+      adeRuntimeCost30dUsd: 0,
+      adeRuntimeCostTodayUsd: 0,
+      adeTotalTokens: 0,
+      adeTotalCostRangeUsd: 0,
+      trackedAdeTokens: 0,
+      trackedAdeInputTokens: 0,
+      trackedAdeOutputTokens: 0,
+      trackedAdeCalls: 0,
+      trackedAdeDurationMs: 0,
+      workerTokens: 0,
+      workerCostUsd: 0,
+      chatSessions: 0,
+      terminalSessions: 0,
+      activeLanes: 0,
+      lanesCreated: 0,
+      lanesArchived: 0,
+      lanesDeleted: 0,
+      commitsCreated: 0,
+      pushOperations: 0,
+      prLandings: 0,
+      prsTracked: 0,
+      prsOpen: 0,
+      prsMerged: 0,
+      prsClosed: 0,
+      prAdditions: 0,
+      prDeletions: 0,
+      filesChanged: 0,
+      insertions: 0,
+      deletions: 0,
+      artifactsCaptured: 0,
+      automationRuns: 0,
+      workerRuns: 0,
+    },
+    providers: [],
+    models: [],
+    adeProviders: [],
+    adeModels: [],
+    agentProviders: [],
+    agentModels: [],
+    features: [],
+    lanes: [],
+    activities: [],
+    daily: makeBrowserStatsDailySkeleton(range),
+    github: {
+      repo: "Browser preview",
+      available: true,
+      lastFetchedAt: null,
+      error: null,
+    },
+    sourceNotes: [],
+  };
+  };
+  const BROWSER_ADE_USAGE_STATS_BY_PRESET: Record<string, any> =
+    USE_STATS_DASHBOARD_SNAPSHOT &&
+    ADE_DB_SNAPSHOT?.adeUsageStatsByPreset &&
+    typeof ADE_DB_SNAPSHOT.adeUsageStatsByPreset === "object"
+      ? ADE_DB_SNAPSHOT.adeUsageStatsByPreset
+      : {};
+  const getBrowserAdeUsageStats = async (args?: { preset?: string }) => {
+    const preset =
+      args?.preset === "today" || args?.preset === "7d" || args?.preset === "30d" || args?.preset === "all"
+        ? args.preset
+        : "7d";
+    return BROWSER_ADE_USAGE_STATS_BY_PRESET[preset] ?? makeBrowserEmptyAdeUsageStats(preset);
+  };
 
   const BROWSER_MOCK_BUDGET_CONFIG: any = {
     refreshIntervalMin: 15,
@@ -3390,6 +3511,7 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
       detect: resolved(BROWSER_MOCK_DEVTOOLS_CHECK),
     },
     usage: {
+      getAdeStats: getBrowserAdeUsageStats,
       getSnapshot: resolved(BROWSER_USAGE_SNAPSHOT),
       refresh: resolved(BROWSER_USAGE_SNAPSHOT),
       checkBudget: resolvedArg({

--- a/apps/desktop/src/renderer/components/app/CommandPalette.tsx
+++ b/apps/desktop/src/renderer/components/app/CommandPalette.tsx
@@ -553,10 +553,10 @@ export function CommandPalette({
       },
       {
         id: "go-settings-usage",
-        title: "Go to Usage",
-        hint: "Token usage, cost breakdown",
+        title: "Go to Stats",
+        hint: "AI usage, cost breakdown, GitHub activity",
         group: "Settings",
-        run: () => navigate("/settings?tab=usage"),
+        run: () => navigate("/settings?tab=stats"),
       },
       {
         id: "action-create-lane",

--- a/apps/desktop/src/renderer/components/app/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/components/app/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect } from "react";
 import { useSearchParams, useLocation } from "react-router-dom";
-import { Brain, GearSix, Stack, Plugs, Palette, DeviceMobile, Robot } from "@phosphor-icons/react";
+import { Brain, ChartLineUp, GearSix, Stack, Plugs, Palette, DeviceMobile, Robot } from "@phosphor-icons/react";
 import { GeneralSection } from "../settings/GeneralSection";
 import { AppearanceSection } from "../settings/AppearanceSection";
 import { LaneTemplatesSection } from "../settings/LaneTemplatesSection";
@@ -9,6 +9,7 @@ import { ProvidersSection } from "../settings/ProvidersSection";
 import { AiFeaturesSection } from "../settings/AiFeaturesSection";
 import { IntegrationsSettingsSection } from "../settings/IntegrationsSettingsSection";
 import { MobilePushPanel } from "../settings/MobilePushPanel";
+import { AdeUsageSection } from "../settings/AdeUsageSection";
 import { COLORS, SANS_FONT, LABEL_STYLE } from "../lanes/laneDesignTokens";
 
 const SECTIONS = [
@@ -19,6 +20,7 @@ const SECTIONS = [
   { id: "mobile-push", label: "Mobile Push", icon: DeviceMobile },
   { id: "integrations", label: "Integrations", icon: Plugs },
   { id: "lane-templates", label: "Lane Templates", icon: Stack },
+  { id: "ade-usage", label: "Stats", icon: ChartLineUp },
 ] as const;
 
 type SectionId = (typeof SECTIONS)[number]["id"];
@@ -39,7 +41,9 @@ const TAB_ALIASES: Record<string, SectionId> = {
   onboarding: "general",
   help: "general",
   tours: "general",
-  usage: "general",
+  usage: "ade-usage",
+  stats: "ade-usage",
+  "ade-usage": "ade-usage",
 };
 
 function padIndex(i: number): string {
@@ -172,6 +176,7 @@ export function SettingsPage({ active = true }: { active?: boolean } = {}) {
         {section === "appearance" && <AppearanceSection />}
         {section === "ai" && <ProvidersSection />}
         {section === "background-jobs" && <AiFeaturesSection />}
+        {section === "ade-usage" && <AdeUsageSection />}
         {section === "mobile-push" && <MobilePushPanel />}
         {section === "integrations" && <IntegrationsSettingsSection />}
         {section === "lane-templates" && (

--- a/apps/desktop/src/renderer/components/app/settingsSections.ts
+++ b/apps/desktop/src/renderer/components/app/settingsSections.ts
@@ -1,5 +1,5 @@
 import type { Icon as PhosphorIcon } from "@phosphor-icons/react";
-import { Brain, DeviceMobile, FolderSimple, GearSix, Lightning, Palette, Plugs, Stack } from "@phosphor-icons/react";
+import { Brain, ChartLineUp, DeviceMobile, FolderSimple, GearSix, Palette, Plugs, Stack } from "@phosphor-icons/react";
 
 type SettingsSectionDefinition = {
   id: string;
@@ -16,7 +16,7 @@ export const SETTINGS_SECTIONS = [
   { id: "mobile-push", label: "Mobile Push", icon: DeviceMobile, localOnly: true },
   { id: "integrations", label: "Integrations", icon: Plugs },
   { id: "lane-templates", label: "Lane Templates", icon: Stack },
-  { id: "usage", label: "Usage", icon: Lightning },
+  { id: "ade-usage", label: "Stats", icon: ChartLineUp },
 ] as const satisfies readonly SettingsSectionDefinition[];
 
 export type SettingsSection = (typeof SETTINGS_SECTIONS)[number];
@@ -38,6 +38,8 @@ const TAB_ALIASES: Record<string, SectionId> = {
   onboarding: "general",
   help: "general",
   tours: "general",
+  usage: "ade-usage",
+  stats: "ade-usage",
 };
 
 export function getVisibleSettingsSections(showLocalOnlySections: boolean): SettingsSection[] {

--- a/apps/desktop/src/renderer/components/settings/AdeUsageSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/AdeUsageSection.tsx
@@ -1,0 +1,618 @@
+import React from "react";
+import {
+  ArrowClockwise,
+  ChartLineUp,
+  GitBranch,
+  GitPullRequest,
+  Robot,
+  WarningCircle,
+} from "@phosphor-icons/react";
+import type {
+  AdeUsageDailyPoint,
+  AdeUsageModelSummary,
+  AdeUsageProviderSummary,
+  AdeUsageRangePreset,
+  AdeUsageStats,
+} from "../../../shared/types";
+import { formatCost, formatTokens, relativeTimeCompact } from "../../lib/format";
+import {
+  COLORS,
+  LABEL_STYLE,
+  MONO_FONT,
+  SANS_FONT,
+  outlineButton,
+} from "../lanes/laneDesignTokens";
+
+const ACCENT = {
+  tokens: "#60A5FA",
+  code: "#63D471",
+  pr: "#A78BFA",
+  cost: "#FBBF24",
+} as const;
+
+const RANGE_OPTIONS: Array<{ preset: AdeUsageRangePreset; label: string }> = [
+  { preset: "today", label: "Today" },
+  { preset: "7d", label: "7 days" },
+  { preset: "30d", label: "30 days" },
+  { preset: "all", label: "All time" },
+];
+
+const PANEL_STYLE: React.CSSProperties = {
+  background: "color-mix(in srgb, var(--color-card) 88%, var(--color-bg) 12%)",
+  border: "1px solid color-mix(in srgb, var(--color-border) 82%, transparent)",
+  borderRadius: 8,
+  padding: 16,
+};
+
+const usageStatsCache = new Map<string, AdeUsageStats>();
+
+function statsCacheKey(scope: string, preset: AdeUsageRangePreset): string {
+  return `${scope}:${preset}`;
+}
+
+function cacheScopeFromProject(project: { rootPath?: string | null } | null | undefined): string {
+  return project?.rootPath?.trim() || "browser-preview";
+}
+
+function formatWhole(value: number): string {
+  return Math.max(0, Math.floor(value || 0)).toLocaleString();
+}
+
+function formatUsd(value: number): string {
+  return value > 0 ? formatCost(value) : "$0.00";
+}
+
+function humanizeProvider(provider: string): string {
+  const known: Record<string, string> = {
+    anthropic: "Anthropic",
+    claude: "Claude",
+    codex: "Codex",
+    copilot: "Copilot",
+    cursor: "Cursor",
+    "cursor-agent": "Cursor Agent",
+    deepseek: "DeepSeek",
+    droid: "Droid",
+    gemini: "Gemini",
+    google: "Google",
+    lmstudio: "LM Studio",
+    mistral: "Mistral",
+    ollama: "Ollama",
+    opencode: "OpenCode",
+    openai: "OpenAI",
+    openclaw: "OpenClaw",
+    openrouter: "OpenRouter",
+    xai: "xAI",
+  };
+  const normalized = provider.trim().toLowerCase();
+  return known[normalized] ?? provider
+    .split(/[-_/\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function compactRange(stats: AdeUsageStats | null): string {
+  if (!stats) return "";
+  const since = stats.range.since ? new Date(stats.range.since) : null;
+  const until = new Date(stats.range.until);
+  if (!since || Number.isNaN(since.getTime())) return "All time";
+  if (Number.isNaN(until.getTime())) return "";
+  return `${since.toLocaleDateString([], { month: "short", day: "numeric" })} - ${until.toLocaleDateString([], { month: "short", day: "numeric" })}`;
+}
+
+function rowTotal(point: AdeUsageDailyPoint): number {
+  return point.insertions + point.deletions;
+}
+
+type ChartPoint = AdeUsageDailyPoint & {
+  label: string;
+  title: string;
+};
+
+function compactDailyChartPoints(points: AdeUsageDailyPoint[], maxColumns = 45): ChartPoint[] {
+  if (points.length <= maxColumns) {
+    return points.map((point) => ({
+      ...point,
+      label: point.date.slice(5),
+      title: point.date,
+    }));
+  }
+
+  const chunkSize = Math.ceil(points.length / maxColumns);
+  const compacted: ChartPoint[] = [];
+  for (let index = 0; index < points.length; index += chunkSize) {
+    const chunk = points.slice(index, index + chunkSize);
+    const first = chunk[0];
+    const last = chunk[chunk.length - 1];
+    if (!first || !last) continue;
+    compacted.push({
+      date: last.date,
+      label: last.date.slice(5),
+      title: `${first.date} - ${last.date}`,
+      inputTokens: chunk.reduce((sum, point) => sum + point.inputTokens, 0),
+      outputTokens: chunk.reduce((sum, point) => sum + point.outputTokens, 0),
+      totalTokens: chunk.reduce((sum, point) => sum + point.totalTokens, 0),
+      commits: chunk.reduce((sum, point) => sum + point.commits, 0),
+      prs: chunk.reduce((sum, point) => sum + point.prs, 0),
+      insertions: chunk.reduce((sum, point) => sum + point.insertions, 0),
+      deletions: chunk.reduce((sum, point) => sum + point.deletions, 0),
+      filesChanged: chunk.reduce((sum, point) => sum + point.filesChanged, 0),
+      sessions: chunk.reduce((sum, point) => sum + point.sessions, 0),
+    });
+  }
+  return compacted;
+}
+
+function StatCard({
+  label,
+  value,
+  detail,
+  accent,
+  icon,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  accent: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <div style={{ ...PANEL_STYLE, minHeight: 112, display: "flex", flexDirection: "column", justifyContent: "space-between" }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10 }}>
+        <div style={{ ...LABEL_STYLE, textTransform: "uppercase", letterSpacing: 0.8 }}>{label}</div>
+        <div style={{ color: accent, display: "flex" }}>{icon}</div>
+      </div>
+      <div>
+        <div style={{ fontFamily: MONO_FONT, fontSize: 24, fontWeight: 700, color: COLORS.textPrimary, lineHeight: 1.05 }}>
+          {value}
+        </div>
+        <div style={{ marginTop: 8, fontFamily: SANS_FONT, fontSize: 11, color: COLORS.textMuted, lineHeight: 1.35 }}>
+          {detail}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SectionHeader({ label, detail }: { label: string; detail?: string }) {
+  return (
+    <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 16 }}>
+      <h2 style={{ margin: 0, fontFamily: SANS_FONT, fontSize: 14, fontWeight: 700, color: COLORS.textPrimary }}>
+        {label}
+      </h2>
+      {detail ? (
+        <span style={{ ...LABEL_STYLE, fontFamily: MONO_FONT, letterSpacing: 0.6, textAlign: "right" }}>
+          {detail}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function EmptyState({ text }: { text: string }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, color: COLORS.textMuted, fontFamily: SANS_FONT, fontSize: 12, padding: "8px 0" }}>
+      <WarningCircle size={14} />
+      <span>{text}</span>
+    </div>
+  );
+}
+
+function Bar({ value, max, color }: { value: number; max: number; color: string }) {
+  const pct = max > 0 ? Math.max(2, Math.min(100, (value / max) * 100)) : 0;
+  return (
+    <div style={{ height: 6, background: "color-mix(in srgb, var(--color-fg) 8%, transparent)", borderRadius: 3, overflow: "hidden" }}>
+      <div style={{ width: `${pct}%`, height: "100%", background: color, borderRadius: 3 }} />
+    </div>
+  );
+}
+
+function ProviderBreakdown({
+  providers,
+  models,
+}: {
+  providers: AdeUsageProviderSummary[];
+  models: AdeUsageModelSummary[];
+}) {
+  const topModels = models.slice(0, 8);
+  const maxProvider = Math.max(1, ...providers.map((provider) => provider.totalTokens));
+  const maxModel = Math.max(1, ...topModels.map((model) => model.totalTokens));
+
+  return (
+    <section style={PANEL_STYLE}>
+      <SectionHeader label="AI usage" detail="Providers and models" />
+      <div style={{ display: "flex", flexDirection: "column", gap: 14, marginTop: 14 }}>
+        {providers.length === 0 ? (
+          <EmptyState text="No local AI usage found for this range." />
+        ) : providers.map((provider) => (
+          <div key={provider.provider} style={{ display: "grid", gridTemplateColumns: "112px minmax(0, 1fr) 92px", gap: 12, alignItems: "center" }}>
+            <div style={{ minWidth: 0 }}>
+              <div style={{ fontFamily: SANS_FONT, fontSize: 12, fontWeight: 650, color: COLORS.textPrimary, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {humanizeProvider(provider.provider)}
+              </div>
+              <div style={{ fontFamily: MONO_FONT, fontSize: 9, color: COLORS.textMuted }}>
+                {formatUsd(provider.rangeCostUsd)}
+              </div>
+            </div>
+            <Bar value={provider.totalTokens} max={maxProvider} color={provider.provider === "claude" ? "#D97757" : ACCENT.tokens} />
+            <div style={{ fontFamily: MONO_FONT, fontSize: 11, color: COLORS.textSecondary, textAlign: "right" }}>
+              {formatTokens(provider.totalTokens)}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {topModels.length > 0 ? (
+        <div style={{ marginTop: 18, paddingTop: 14, borderTop: `1px solid ${COLORS.borderMuted}`, display: "flex", flexDirection: "column", gap: 10 }}>
+          <div style={{ ...LABEL_STYLE, textTransform: "uppercase", letterSpacing: 0.8 }}>Top models</div>
+          {topModels.map((model) => (
+            <div key={`${model.provider}:${model.model}`} style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) 96px", gap: 12, alignItems: "center" }}>
+              <div style={{ minWidth: 0 }}>
+                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10 }}>
+                  <span style={{ fontFamily: MONO_FONT, fontSize: 10, color: COLORS.textSecondary, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {model.model}
+                  </span>
+                  <span style={{ fontFamily: MONO_FONT, fontSize: 10, color: COLORS.textMuted, flexShrink: 0 }}>
+                    {formatTokens(model.totalTokens)}
+                  </span>
+                </div>
+                <div style={{ marginTop: 5 }}>
+                  <Bar value={model.totalTokens} max={maxModel} color={model.provider === "claude" ? "#D97757" : ACCENT.tokens} />
+                </div>
+              </div>
+              <div style={{ fontFamily: MONO_FONT, fontSize: 9, color: COLORS.textMuted, textAlign: "right" }}>
+                {formatUsd(model.costUsd)}<br />
+                {formatTokens(model.inputTokens)} in / {formatTokens(model.outputTokens)} out
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function GithubBreakdown({ stats }: { stats: AdeUsageStats }) {
+  const summary = stats.summary;
+  const totalCode = summary.insertions + summary.deletions;
+  const maxLine = Math.max(1, summary.insertions, summary.deletions, summary.filesChanged);
+  const repoLabel = stats.github.repo ?? "GitHub";
+  const githubLoading = stats.github.error === "GitHub activity is still loading.";
+
+  return (
+    <section style={PANEL_STYLE}>
+      <SectionHeader label="Code activity" detail={stats.github.available ? repoLabel : githubLoading ? "Loading GitHub" : "GitHub unavailable"} />
+      {!stats.github.available ? (
+        <EmptyState text={githubLoading ? "GitHub activity is still loading." : "No GitHub activity is available for this range."} />
+      ) : (
+        <>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 10, marginTop: 14 }}>
+            <MiniMetric label="Commits" value={formatWhole(summary.commitsCreated)} accent={ACCENT.cost} />
+            <MiniMetric label="PRs" value={formatWhole(summary.prsTracked)} accent={ACCENT.pr} />
+            <MiniMetric label="Merged" value={formatWhole(summary.prsMerged)} accent={ACCENT.pr} />
+          </div>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: 12, marginTop: 18 }}>
+            <ChangeRow label="Additions" value={summary.insertions} max={maxLine} color={ACCENT.code} />
+            <ChangeRow label="Deletions" value={summary.deletions} max={maxLine} color="#F87171" />
+            <ChangeRow label="Files changed" value={summary.filesChanged} max={maxLine} color={ACCENT.tokens} />
+          </div>
+
+          <div style={{ marginTop: 16, paddingTop: 14, borderTop: `1px solid ${COLORS.borderMuted}`, display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: 12 }}>
+            <Fact label="Open PRs" value={formatWhole(summary.prsOpen)} />
+            <Fact label="Code movement" value={formatWhole(totalCode)} />
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+function MiniMetric({ label, value, accent }: { label: string; value: string; accent: string }) {
+  return (
+    <div style={{ border: `1px solid ${COLORS.borderMuted}`, borderRadius: 8, padding: 12, background: "color-mix(in srgb, var(--color-card) 70%, transparent)" }}>
+      <div style={{ ...LABEL_STYLE, textTransform: "uppercase", letterSpacing: 0.7 }}>{label}</div>
+      <div style={{ marginTop: 8, fontFamily: MONO_FONT, fontSize: 18, fontWeight: 700, color: accent }}>{value}</div>
+    </div>
+  );
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div style={{ fontFamily: MONO_FONT, fontSize: 15, color: COLORS.textPrimary, fontWeight: 700 }}>{value}</div>
+      <div style={{ marginTop: 3, fontFamily: SANS_FONT, fontSize: 11, color: COLORS.textMuted }}>{label}</div>
+    </div>
+  );
+}
+
+function ChangeRow({ label, value, max, color }: { label: string; value: number; max: number; color: string }) {
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "104px minmax(0, 1fr) 78px", gap: 12, alignItems: "center" }}>
+      <span style={{ fontFamily: SANS_FONT, fontSize: 12, color: COLORS.textSecondary }}>{label}</span>
+      <Bar value={value} max={max} color={color} />
+      <span style={{ fontFamily: MONO_FONT, fontSize: 11, color: COLORS.textSecondary, textAlign: "right" }}>{formatWhole(value)}</span>
+    </div>
+  );
+}
+
+function DailyChart({ points, loading = false }: { points: AdeUsageDailyPoint[]; loading?: boolean }) {
+  const visiblePoints = compactDailyChartPoints(points.length > 0 ? points : []);
+  const maxTokens = Math.max(1, ...visiblePoints.map((point) => point.totalTokens));
+  const maxCode = Math.max(1, ...visiblePoints.map(rowTotal));
+  const hasData = visiblePoints.some((point) => point.totalTokens > 0 || rowTotal(point) > 0 || point.commits > 0 || point.prs > 0);
+
+  return (
+    <section style={{ ...PANEL_STYLE, minHeight: 238 }}>
+      <SectionHeader label="Recent daily activity" detail="Tokens and GitHub movement" />
+      {loading ? (
+        <EmptyState text="Loading daily activity." />
+      ) : !hasData ? (
+        <EmptyState text="No activity found for this range." />
+      ) : (
+        <>
+          <div style={{ display: "grid", gridTemplateColumns: `repeat(${visiblePoints.length}, minmax(9px, 1fr))`, alignItems: "end", gap: 5, height: 142, marginTop: 18 }}>
+            {visiblePoints.map((point) => {
+              const tokenHeight = point.totalTokens > 0 ? Math.max(4, (point.totalTokens / maxTokens) * 118) : 0;
+              const codeHeight = rowTotal(point) > 0 ? Math.max(4, (rowTotal(point) / maxCode) * 118) : 0;
+              return (
+                <div key={`${point.title}:${point.date}`} title={`${point.title}: ${formatTokens(point.totalTokens)} tokens, ${formatWhole(rowTotal(point))} changed lines`} style={{ height: 132, display: "flex", alignItems: "end", justifyContent: "center", gap: 2 }}>
+                  <div style={{ width: 4, height: tokenHeight, borderRadius: 2, background: ACCENT.tokens }} />
+                  <div style={{ width: 4, height: codeHeight, borderRadius: 2, background: ACCENT.code }} />
+                </div>
+              );
+            })}
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: `repeat(${visiblePoints.length}, minmax(9px, 1fr))`, gap: 5, marginTop: 8 }}>
+            {visiblePoints.map((point, index) => (
+              <div key={`${point.title}:${point.date}`} style={{ fontFamily: MONO_FONT, fontSize: 9, color: COLORS.textMuted, textAlign: "center" }}>
+                {visiblePoints.length <= 14 || index % 2 === 0 ? point.label : ""}
+              </div>
+            ))}
+          </div>
+          <div style={{ display: "flex", gap: 16, marginTop: 16, fontFamily: SANS_FONT, fontSize: 11, color: COLORS.textMuted }}>
+            <Legend color={ACCENT.tokens} label="Tokens" />
+            <Legend color={ACCENT.code} label="Changed lines" />
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+function Legend({ color, label }: { color: string; label: string }) {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+      <span style={{ width: 8, height: 8, borderRadius: 2, background: color }} />
+      {label}
+    </span>
+  );
+}
+
+export function AdeUsageSection() {
+  const [preset, setPreset] = React.useState<AdeUsageRangePreset>("7d");
+  const [cacheScope, setCacheScope] = React.useState<string | null>(null);
+  const [stats, setStats] = React.useState<AdeUsageStats | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [refreshing, setRefreshing] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const loadSeqRef = React.useRef(0);
+
+  const loadStats = React.useCallback(async (nextPreset: AdeUsageRangePreset, scope: string, force = false) => {
+    const loadSeq = loadSeqRef.current + 1;
+    loadSeqRef.current = loadSeq;
+    const key = statsCacheKey(scope, nextPreset);
+    const cached = usageStatsCache.get(key);
+    if (cached) {
+      setStats(cached);
+      setLoading(false);
+    } else {
+      setStats(null);
+      setLoading(true);
+    }
+
+    try {
+      setError(null);
+      if (force) {
+        setRefreshing(true);
+        await window.ade?.usage?.refresh?.();
+      }
+      const result = await window.ade?.usage?.getAdeStats?.({ preset: nextPreset });
+      if (!result) {
+        throw new Error("Stats are unavailable.");
+      }
+      if (loadSeqRef.current === loadSeq) {
+        usageStatsCache.set(key, result);
+        setStats(result);
+      }
+    } catch (err) {
+      if (loadSeqRef.current === loadSeq) {
+        if (cached && !force) {
+          setError(null);
+          setStats(cached);
+        } else {
+          usageStatsCache.delete(key);
+          setError(err instanceof Error ? err.message : String(err));
+          setStats(null);
+        }
+      }
+    } finally {
+      if (loadSeqRef.current === loadSeq) {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    }
+  }, []);
+
+  React.useEffect(() => {
+    let mounted = true;
+    const applyProject = (project: { rootPath?: string | null } | null) => {
+      if (!mounted) return;
+      loadSeqRef.current += 1;
+      setCacheScope(cacheScopeFromProject(project));
+      setStats(null);
+      setLoading(true);
+      setError(null);
+    };
+
+    if (!window.ade?.app?.getProject) {
+      applyProject(null);
+      return () => {
+        mounted = false;
+      };
+    }
+
+    void window.ade.app.getProject()
+      .then(applyProject)
+      .catch(() => applyProject(null));
+    const unsubscribe = window.ade.app.onProjectChanged?.(applyProject);
+    return () => {
+      mounted = false;
+      unsubscribe?.();
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (!cacheScope) return;
+    void loadStats(preset, cacheScope, false);
+  }, [cacheScope, loadStats, preset]);
+
+  React.useEffect(() => {
+    if (!cacheScope) return;
+    if (stats?.github.error !== "GitHub activity is still loading.") return;
+    const timeout = window.setTimeout(() => {
+      void loadStats(preset, cacheScope, false);
+    }, 3_500);
+    return () => window.clearTimeout(timeout);
+  }, [cacheScope, loadStats, preset, stats?.github.error, stats?.generatedAt]);
+
+  const summary = stats?.summary;
+  const providerCount = stats?.providers.length ?? 0;
+  const modelCount = stats?.models.length ?? 0;
+  const topProvider = stats?.providers[0] ? humanizeProvider(stats.providers[0].provider) : "No providers";
+  const updatedLabel = stats?.generatedAt ? relativeTimeCompact(stats.generatedAt) : "";
+  const githubAvailable = stats?.github.available ?? false;
+  const githubUnavailableLabel = stats?.github.error === "GitHub activity is still loading." ? "Loading" : "Unavailable";
+  const rangeLabel = compactRange(stats);
+  const loadingEmpty = loading && !stats;
+  const headerDetail = [
+    "Local AI usage and GitHub activity",
+    rangeLabel,
+    updatedLabel ? `updated ${updatedLabel}` : "",
+  ].filter(Boolean).join(" / ");
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <header style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "flex-start", flexWrap: "wrap" }}>
+        <div>
+          <div style={{ ...LABEL_STYLE, textTransform: "uppercase", letterSpacing: 1.3, marginBottom: 8 }}>Settings</div>
+          <h1 style={{ margin: 0, fontFamily: SANS_FONT, fontSize: 26, lineHeight: 1.1, color: COLORS.textPrimary }}>
+            Stats
+          </h1>
+          <div style={{ marginTop: 8, fontFamily: SANS_FONT, fontSize: 12, color: COLORS.textMuted }}>
+            {headerDetail}
+          </div>
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap", justifyContent: "flex-end", maxWidth: "100%" }}>
+          <div style={{ display: "flex", flexWrap: "wrap", border: `1px solid ${COLORS.borderMuted}`, borderRadius: 8, overflow: "hidden", maxWidth: "100%" }}>
+            {RANGE_OPTIONS.map((option) => {
+              const active = preset === option.preset;
+              return (
+                <button
+                  key={option.preset}
+                  type="button"
+                  onClick={() => setPreset(option.preset)}
+                  style={{
+                    border: "none",
+                    borderRight: option.preset === "all" ? "none" : `1px solid ${COLORS.borderMuted}`,
+                    background: active ? COLORS.textPrimary : "transparent",
+                    color: active ? COLORS.pageBg : COLORS.textSecondary,
+                    fontFamily: SANS_FONT,
+                    fontSize: 12,
+                    fontWeight: 650,
+                    padding: "9px 14px",
+                    cursor: "pointer",
+                  }}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => cacheScope && loadStats(preset, cacheScope, true)}
+            disabled={refreshing || !cacheScope}
+            style={{ ...outlineButton, height: 37, display: "inline-flex", alignItems: "center", gap: 8, opacity: refreshing ? 0.7 : 1 }}
+          >
+            <ArrowClockwise size={14} />
+            {refreshing ? "Refreshing" : "Refresh"}
+          </button>
+        </div>
+      </header>
+
+      {error ? <EmptyState text={error} /> : null}
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(210px, 1fr))", gap: 14 }}>
+        <StatCard
+          label="AI tokens"
+          value={summary ? formatTokens(summary.totalTokens) : loading ? "..." : "0"}
+          detail={summary ? `${formatTokens(summary.observedProviderInputTokens)} input / ${formatTokens(summary.observedProviderOutputTokens)} output / ${formatTokens(summary.observedProviderCachedTokens)} cached` : "Waiting for local scans"}
+          accent={ACCENT.tokens}
+          icon={<ChartLineUp size={18} />}
+        />
+        <StatCard
+          label="Estimated cost"
+          value={summary ? formatUsd(summary.observedProviderCostRangeUsd) : loading ? "..." : "$0.00"}
+          detail={summary ? `${formatUsd(summary.observedProviderCostTodayUsd)} today / ${formatUsd(summary.observedProviderCost30dUsd)} 30d` : "Provider pricing registry"}
+          accent={ACCENT.cost}
+          icon={<Robot size={18} />}
+        />
+        <StatCard
+          label="Code movement"
+          value={summary ? githubAvailable ? formatWhole(summary.insertions + summary.deletions) : githubUnavailableLabel : "0"}
+          detail={summary ? githubAvailable ? `${formatWhole(summary.insertions)} added / ${formatWhole(summary.deletions)} deleted / ${formatWhole(summary.filesChanged)} files` : (stats?.github.error ?? "GitHub activity unavailable") : "GitHub activity"}
+          accent={ACCENT.code}
+          icon={<GitBranch size={18} />}
+        />
+        <StatCard
+          label="Pull requests"
+          value={summary ? githubAvailable ? formatWhole(summary.prsTracked) : githubUnavailableLabel : "0"}
+          detail={summary ? githubAvailable ? `${formatWhole(summary.prsMerged)} merged / ${formatWhole(summary.prsOpen)} open / ${formatWhole(summary.commitsCreated)} commits` : (stats?.github.error ?? "GitHub activity unavailable") : "GitHub activity"}
+          accent={ACCENT.pr}
+          icon={<GitPullRequest size={18} />}
+        />
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))", gap: 14 }}>
+        {loadingEmpty ? (
+          <section style={PANEL_STYLE}><EmptyState text="Loading local AI usage." /></section>
+        ) : (
+          <ProviderBreakdown providers={stats?.providers ?? []} models={stats?.models ?? []} />
+        )}
+        {stats ? <GithubBreakdown stats={stats} /> : <section style={PANEL_STYLE}><EmptyState text="Loading GitHub activity." /></section>}
+      </div>
+
+      <DailyChart points={stats?.daily ?? []} loading={loadingEmpty} />
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(210px, 1fr))", gap: 14 }}>
+        <StatCard
+          label="Providers"
+          value={formatWhole(providerCount)}
+          detail={topProvider}
+          accent={ACCENT.tokens}
+          icon={<Robot size={18} />}
+        />
+        <StatCard
+          label="Models"
+          value={formatWhole(modelCount)}
+          detail={stats?.models[0]?.model ?? "No model usage in range"}
+          accent={ACCENT.pr}
+          icon={<ChartLineUp size={18} />}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/lib/format.ts
+++ b/apps/desktop/src/renderer/lib/format.ts
@@ -69,11 +69,13 @@ export function formatElapsedSince(startIso: string): string {
   return `${secs}s`;
 }
 
-/** Format a token count with K/M suffixes. */
+/** Format a token count with K/M/B suffixes. */
 export function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return String(n);
+  const value = Number.isFinite(n) ? Math.max(0, n) : 0;
+  if (value >= 999_950_000) return `${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 999_950) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return String(Math.floor(value));
 }
 
 /** Format a USD cost value. */

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -692,6 +692,7 @@ export const IPC = {
   orchestratorDeliverMessage: "ade.orchestrator.deliverMessage",
   orchestratorGetActiveAgents: "ade.orchestrator.getActiveAgents",
   getAggregatedUsage: "ade.usage.getAggregated",
+  usageGetAdeStats: "ade.usage.getAdeStats",
   usageGetSnapshot: "ade.usage.getSnapshot",
   usageRefresh: "ade.usage.refresh",
   usageCheckBudget: "ade.usage.checkBudget",

--- a/apps/desktop/src/shared/modelRegistry.ts
+++ b/apps/desktop/src/shared/modelRegistry.ts
@@ -240,8 +240,8 @@ export const MODEL_REGISTRY: ModelDescriptor[] = [
     providerModelId: "haiku",
     cliCommand: "claude",
     isCliWrapped: true,
-    inputPricePer1M: 0.8,
-    outputPricePer1M: 4,
+    inputPricePer1M: 1,
+    outputPricePer1M: 5,
     costTier: "low",
   },
 
@@ -266,6 +266,8 @@ export const MODEL_REGISTRY: ModelDescriptor[] = [
     providerModelId: "gpt-5.5",
     cliCommand: "codex",
     isCliWrapped: true,
+    inputPricePer1M: 5,
+    outputPricePer1M: 30,
     costTier: "high",
   },
   {
@@ -285,6 +287,8 @@ export const MODEL_REGISTRY: ModelDescriptor[] = [
     providerModelId: "gpt-5.4",
     cliCommand: "codex",
     isCliWrapped: true,
+    inputPricePer1M: 2.5,
+    outputPricePer1M: 15,
     costTier: "high",
   },
   {
@@ -303,8 +307,8 @@ export const MODEL_REGISTRY: ModelDescriptor[] = [
     providerModelId: "gpt-5.4-mini",
     cliCommand: "codex",
     isCliWrapped: true,
-    inputPricePer1M: 0.25,
-    outputPricePer1M: 2,
+    inputPricePer1M: 0.75,
+    outputPricePer1M: 4.5,
     costTier: "low",
   },
   {
@@ -323,8 +327,8 @@ export const MODEL_REGISTRY: ModelDescriptor[] = [
     providerModelId: "gpt-5.3-codex",
     cliCommand: "codex",
     isCliWrapped: true,
-    inputPricePer1M: 1.5,
-    outputPricePer1M: 6,
+    inputPricePer1M: 1.75,
+    outputPricePer1M: 14,
     costTier: "high",
   },
   {
@@ -343,6 +347,8 @@ export const MODEL_REGISTRY: ModelDescriptor[] = [
     providerModelId: "gpt-5.3-codex-spark",
     cliCommand: "codex",
     isCliWrapped: true,
+    inputPricePer1M: 1.75,
+    outputPricePer1M: 14,
     costTier: "low",
   },
   {
@@ -361,6 +367,8 @@ export const MODEL_REGISTRY: ModelDescriptor[] = [
     providerModelId: "gpt-5.2",
     cliCommand: "codex",
     isCliWrapped: true,
+    inputPricePer1M: 1.75,
+    outputPricePer1M: 14,
     costTier: "medium",
   },
 

--- a/apps/desktop/src/shared/types/usage.ts
+++ b/apps/desktop/src/shared/types/usage.ts
@@ -52,8 +52,163 @@ export type GetAggregatedUsageArgs = {
   limit?: number;
 };
 
+export type AdeUsageRangePreset = "today" | "7d" | "30d" | "all";
+
+export type GetAdeUsageStatsArgs = {
+  preset?: AdeUsageRangePreset;
+  since?: string | null;
+  until?: string | null;
+};
+
+export type AdeUsageProviderSummary = {
+  provider: string;
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens: number;
+  totalTokens: number;
+  rangeCostUsd: number;
+  todayCostUsd: number;
+  last30dCostUsd: number;
+};
+
+export type AdeUsageModelSummary = {
+  provider: string;
+  model: string;
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens: number;
+  totalTokens: number;
+  costUsd: number;
+};
+
+export type AdeUsageAgentProviderSummary = {
+  provider: string;
+  sessions: number;
+  models: number;
+  latestAt: string | null;
+};
+
+export type AdeUsageAgentModelSummary = {
+  provider: string;
+  model: string;
+  sessions: number;
+  latestAt: string | null;
+};
+
+export type AdeUsageFeatureSummary = {
+  feature: string;
+  provider: string;
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  successRate: number;
+};
+
+export type AdeUsageLaneSummary = {
+  laneId: string;
+  laneName: string;
+  sessions: number;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+};
+
+export type AdeUsageActivitySummary = {
+  kind: string;
+  count: number;
+};
+
+export type AdeUsageDailyPoint = {
+  date: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  commits: number;
+  prs: number;
+  insertions: number;
+  deletions: number;
+  filesChanged: number;
+  sessions: number;
+};
+
+export type AdeUsageStats = {
+  generatedAt: string;
+  range: {
+    preset: AdeUsageRangePreset;
+    since: string | null;
+    until: string;
+  };
+  summary: {
+    totalTokens: number;
+    tokenTotalSource: "provider_logs" | "ade_db" | "combined";
+    observedProviderTokens: number;
+    observedProviderInputTokens: number;
+    observedProviderOutputTokens: number;
+    observedProviderCachedTokens: number;
+    observedProviderCostRangeUsd: number;
+    observedProviderCost30dUsd: number;
+    observedProviderCostTodayUsd: number;
+    adeRuntimeTokens?: number;
+    adeRuntimeInputTokens?: number;
+    adeRuntimeOutputTokens?: number;
+    adeRuntimeCachedTokens?: number;
+    adeRuntimeCostRangeUsd?: number;
+    adeRuntimeCost30dUsd?: number;
+    adeRuntimeCostTodayUsd?: number;
+    adeTotalTokens?: number;
+    adeTotalCostRangeUsd?: number;
+    trackedAdeTokens?: number;
+    trackedAdeInputTokens?: number;
+    trackedAdeOutputTokens?: number;
+    trackedAdeCalls?: number;
+    trackedAdeDurationMs?: number;
+    workerTokens?: number;
+    workerCostUsd?: number;
+    chatSessions?: number;
+    terminalSessions?: number;
+    activeLanes?: number;
+    lanesCreated?: number;
+    lanesArchived?: number;
+    lanesDeleted?: number;
+    commitsCreated: number;
+    pushOperations: number;
+    prLandings: number;
+    prsTracked: number;
+    prsOpen: number;
+    prsMerged: number;
+    prsClosed: number;
+    prAdditions: number;
+    prDeletions: number;
+    filesChanged: number;
+    insertions: number;
+    deletions: number;
+    artifactsCaptured?: number;
+    automationRuns?: number;
+    workerRuns?: number;
+  };
+  providers: AdeUsageProviderSummary[];
+  models: AdeUsageModelSummary[];
+  adeProviders?: AdeUsageProviderSummary[];
+  adeModels?: AdeUsageModelSummary[];
+  agentProviders?: AdeUsageAgentProviderSummary[];
+  agentModels?: AdeUsageAgentModelSummary[];
+  features?: AdeUsageFeatureSummary[];
+  lanes?: AdeUsageLaneSummary[];
+  activities?: AdeUsageActivitySummary[];
+  daily: AdeUsageDailyPoint[];
+  github: {
+    repo: string | null;
+    available: boolean;
+    lastFetchedAt: string | null;
+    error: string | null;
+  };
+  sourceNotes?: string[];
+};
+
 // ---------------------------------------------------------------------------
-// Live usage tracking types (Claude, Codex, and Cursor provider polling)
+// Live quota tracking types (Claude/Codex API windows plus local runtime cost scans)
 // ---------------------------------------------------------------------------
 
 export type UsageProvider = "claude" | "codex" | "cursor";
@@ -99,11 +254,23 @@ export type UsagePacing = {
 
 export type UsagePacingByProvider = Partial<Record<UsageProvider, UsagePacing>>;
 
+export type CostTokenBreakdown = {
+  input: number;
+  output: number;
+  cached: number;
+  cacheWrite?: number;
+  costUsd?: number;
+};
+
 export type CostSnapshot = {
-  provider: UsageProvider;
+  provider: string;
   last30dCostUsd: number;
   todayCostUsd: number;
-  tokenBreakdown: Record<string, { input: number; output: number; cached: number }>;
+  costUsdByPreset?: Partial<Record<AdeUsageRangePreset, number>>;
+  tokenBreakdown: Record<string, CostTokenBreakdown>;
+  tokenBreakdownByPreset?: Partial<Record<AdeUsageRangePreset, Record<string, CostTokenBreakdown>>>;
+  dailyTokenBreakdownByPreset?: Partial<Record<AdeUsageRangePreset, Record<string, Record<string, CostTokenBreakdown>>>>;
+  dailyTokensByPreset?: Partial<Record<AdeUsageRangePreset, Record<string, number>>>;
 };
 
 export type ExtraUsage = {
@@ -120,6 +287,8 @@ export type UsageSnapshot = {
   pacing: UsagePacing;
   pacingByProvider?: UsagePacingByProvider;
   costs: CostSnapshot[];
+  /** Local runtime usage that can be attributed specifically to ADE-originated sessions. */
+  adeCosts?: CostSnapshot[];
   extraUsage: ExtraUsage[];
   /** Per-provider daily token usage for the last 7 calendar days, oldest first. */
   dailyUsage7d?: Partial<Record<UsageProvider, number[]>>;

--- a/docs/features/automations/README.md
+++ b/docs/features/automations/README.md
@@ -38,7 +38,7 @@ These services are loaded by the runtime daemon's project scope (and by the desk
   - `RuleHistoryPanel.tsx` — per-rule run history (replaces the old cross-rule `HistoryTab`).
   - `TemplatesTab.tsx` / `AutomationsTemplatesPage.tsx` — template picker that seeds a new draft on `/automations` via router state.
   - `EmptyStateHint.tsx` — empty-state copy shared across tabs.
-- `apps/desktop/src/renderer/components/usage/` — header Usage popup (`HeaderUsageControl`, `UsageQuotaPanel`) that hosts live provider quotas + the collapsible automation guardrails. `BudgetCapEditor`, `UsageMeter`, `UsagePacingBadge`, and `CostSummaryCard` continue to live under `components/settings/` but are rendered from the popup; Settings no longer has a Usage tab.
+- `apps/desktop/src/renderer/components/usage/` — header Usage popup (`HeaderUsageControl`, `UsageQuotaPanel`) that hosts live provider quotas + the collapsible automation guardrails. `BudgetCapEditor`, `UsageMeter`, `UsagePacingBadge`, and `CostSummaryCard` continue to live under `components/settings/` but are rendered from the popup. Settings > Stats is a separate retrospective local AI + GitHub activity tab and does not host automation guardrails.
 - `apps/desktop/src/renderer/components/chat/AgentChatPane.tsx` — agent-session execution surfaces as a chat thread filtered by automation owner.
 
 ### IPC and runtime RPC

--- a/docs/features/automations/guardrails.md
+++ b/docs/features/automations/guardrails.md
@@ -137,7 +137,7 @@ Agent-session rules run inside the ADE chat service's permission model (per-sess
 
 ## Budget caps
 
-Shared via the top-bar Usage popup. The popup (`HeaderUsageControl`, `UsageQuotaPanel`) renders the live provider quotas plus a collapsible Automation guardrails section that mounts `BudgetCapEditor`. Supporting widgets (`CostSummaryCard`, `UsageMeter`, `UsagePacingBadge`) still live under `apps/desktop/src/renderer/components/settings/` but are reused from the popup. Settings no longer has a Usage tab; the Automations page continues to focus on rules, history, and ingress.
+Shared via the top-bar Usage popup. The popup (`HeaderUsageControl`, `UsageQuotaPanel`) renders the live provider quotas plus a collapsible Automation guardrails section that mounts `BudgetCapEditor`. Supporting widgets (`CostSummaryCard`, `UsageMeter`, `UsagePacingBadge`) still live under `apps/desktop/src/renderer/components/settings/` but are reused from the popup. Settings > Stats is a separate retrospective local AI + GitHub activity tab; the Automations page continues to focus on rules, history, and ingress.
 
 Automations also support rule-level caps:
 

--- a/docs/features/onboarding-and-settings/README.md
+++ b/docs/features/onboarding-and-settings/README.md
@@ -228,9 +228,9 @@ Renderer — settings:
 - `apps/desktop/src/renderer/components/usage/HeaderUsageControl.tsx`
   and `UsageQuotaPanel.tsx` — header usage popup. Live provider quotas
   for Claude and Codex (tracked providers) and the automation budget
-  guardrails are now consolidated here; Settings no longer has a
-  Usage tab. The header renders one compact chip per detected tracked
-  provider with the 5-hour window and the plan window (`wk` when a
+  guardrails are consolidated here. The header renders one compact
+  chip per detected tracked provider with the 5-hour window and the
+  plan window (`wk` when a
   weekly window is present, otherwise `mo`). Percent values are clamped
   to 0-100, color through the green/amber/red thresholds at 75% /
   100%, and show an ellipsis while missing. On mount, the button reads
@@ -250,6 +250,13 @@ Renderer — settings:
   caps round-trip through `ade.usage.getBudgetConfig` /
   `saveBudgetConfig`. Threshold crossings (25 / 50 / 75 / 100 %) emit
   `UsageThresholdEvent`s the notification bus turns into APNs alerts.
+- `apps/desktop/src/renderer/components/settings/AdeUsageSection.tsx`
+  — Settings > Stats. Reads `window.ade.usage.getAdeStats({ preset })`
+  for today / 7d / 30d / all-time stats and calls
+  `window.ade.usage.refresh()` for explicit refresh. This is a read-only
+  stats dashboard: local AI runtime token and estimated-cost scans plus
+  GitHub-backed PR, commit, and code movement totals. It does not write
+  new usage records.
 - `apps/desktop/src/renderer/components/settings/ProxyAndPreviewSection.tsx`
   — proxy/preview configuration UI.
 - `apps/desktop/src/renderer/components/settings/DiagnosticsDashboardSection.tsx`
@@ -407,8 +414,9 @@ changing rather than which service backs it:
 | Mobile Push | `MobilePushPanel.tsx` | APNs registration, paired-device push tokens, per-category preferences |
 | Integrations | `IntegrationsSettingsSection.tsx`, `GitHubSection.tsx`, `LinearSection.tsx` | GitHub, Linear, and computer-use backend readiness. The GitHub section reads `status.connected` (the backend's single "GitHub is usable" gate) to decide between CONNECTED / LIMITED ACCESS / NOT CONNECTED, surfaces a dedicated repo-probe error when a fine-grained token authenticates as a user but cannot access the active repo, and the REFRESH button calls `getStatus({ forceRefresh: true })` so users who fix permissions on github.com see the change immediately. See [`pull-requests/README.md`](../pull-requests/README.md#github-connectivity-model) for the full status-shape and `connected` derivation. |
 | Lane Templates | `LaneTemplatesSection.tsx`, `LaneBehaviorSection.tsx` | Lane init recipes and lane lifecycle policy |
+| Stats | `AdeUsageSection.tsx` | Local runtime token / cost summaries and GitHub-backed PR, commit, and code movement totals. Deep links from `?tab=usage` and `?tab=stats` land here. |
 
-> Live provider usage and automation guardrails moved out of Settings. They are now in the top-bar Usage popup (`HeaderUsageControl.tsx` → `UsageQuotaPanel.tsx` + collapsible `BudgetCapEditor`).
+> Live provider quota windows and automation guardrails live in the top-bar Usage popup (`HeaderUsageControl.tsx` → `UsageQuotaPanel.tsx` + collapsible `BudgetCapEditor`). Settings > Stats is the retrospective local AI + GitHub activity dashboard.
 
 
 The Settings page itself (`SettingsPage.tsx`) has a legacy alias


### PR DESCRIPTION
Refs ADE-37

## Summary
- Replace the ADE usage settings tab with a bottom-positioned Stats tab focused on full local AI usage across supported runtimes.
- Scan provider ledgers read-only, align Codex token accounting with codeburn-style totals, add model-aware pricing from a LiteLLM/codeburn-compatible pricing registry, and keep snapshots cached/refreshing without adding usage-log bloat.
- Pull GitHub activity from `gh` for commits, PRs, merged PRs, and code movement, with paginated PR queries and range-aware daily chart data.
- Clean up the Stats UI: no explanatory coverage panel, no fake browser mock data, better loading/cache states, B-token formatting, compact all-time chart buckets, and GitHub/code widgets with real-empty states.

## Validation
- Compared local Stats scan against `codeburn models` for today, 7 days, 30 days, and all time. Codex all-time is aligned at ~114.4B vs codeburn ~114.2B; total differences are explained by ADE additionally scanning Droid/local ledgers that codeburn does not include.
- Cross-checked GitHub PR/code movement logic with direct `gh` GraphQL pagination for the current date ranges.
- `npm --prefix apps/desktop run typecheck`
- `npm --prefix apps/desktop run lint -- --quiet`
- `npm --prefix apps/ade-cli run typecheck`
- `npm --prefix apps/ade-cli run test`
- `npm --prefix apps/ade-cli run build`
- `npm --prefix apps/desktop run build`
- `npm run test:desktop:sharded`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Stats dashboard displaying token usage, costs by provider/model, and GitHub code activity metrics with selectable time presets (today, 7d, 30d, all).
  * Replaced Usage settings tab with new Stats section in settings.
  * Added usage statistics API for retrieving aggregated AI usage data.

* **Improvements**
  * Enhanced session tracking and delta computation for accurate usage metrics.
  * Improved pricing data resolution with dynamic LiteLLM pricing support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arul28/ADE/pull/447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new "Stats" tab to the ADE settings page (`AdeUsageSection.tsx`) that aggregates local AI provider logs (Claude, Codex, Cursor, Copilot, Gemini, and others), GitHub activity via `gh` CLI, and per-session git deltas into a unified usage dashboard with preset time-range filtering.

- **New `usagePricing.ts`** introduces dynamic token pricing fetched from LiteLLM (cached on disk) with a comprehensive static fallback table covering Claude, GPT, Gemini, and other models.
- **`usageTrackingService.ts`** expanded significantly: seven new provider scanners, GitHub stats polling with per-preset caching, a 24-hour disk cache for `UsageSnapshot`, and the new `getAdeUsageStats` method.
- **`sessionDeltaService.ts`** gained `backfillMissingSessionDeltas` for retroactively computing git diffs for sessions that ended before the feature existed, plus improved `computeSessionDelta` to use exact SHA ranges.
- **`laneService.ts`** added `operation` tracking to `deleteLane` so lane-delete history is now recorded.

<h3>Confidence Score: 4/5</h3>

The new stats tab is additive and behind a new settings route; the core session/lane/usage services receive targeted, well-tested additions.

The most notable concern is the parallel memory consumption during an initial provider log scan — each of the seven new scanner calls can now read up to 768 MB per file, and they all run concurrently. The renderer-side hardcoded error string for detecting the GitHub loading state could silently misclassify a real error as a spinner (or vice versa) if the message is ever tweaked.

apps/desktop/src/main/services/usage/usageTrackingService.ts (scan-limit constants and parallel scanner orchestration), apps/desktop/src/renderer/components/settings/AdeUsageSection.tsx (GitHub loading-state detection), apps/desktop/scripts/export-browser-mock-ade-snapshot.mjs (unbounded GitHub PR pagination)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/usage/usageTrackingService.ts | Major expansion: adds 7 new provider log scanners (Cursor, Copilot, Gemini, etc.), GitHub stats polling, per-preset cost aggregation, snapshot disk caching, and `getAdeUsageStats`. Scan limits were significantly increased (files: 200→5,000; bytes/file: 8MB→768MB) which could cause memory pressure during first-run scans. |
| apps/desktop/src/main/services/usage/usagePricing.ts | New file introducing dynamic token pricing via a cached LiteLLM fetch with static fallbacks. Module-level mutable state is used intentionally as a singleton. `getStaticPricingMap()` allocates a new Map on every `resolveTokenPrice` call instead of caching the static Map. |
| apps/desktop/src/renderer/components/settings/AdeUsageSection.tsx | New 618-line stats dashboard component with preset picker, stat cards, provider/model breakdowns, GitHub activity panel, and a daily bar chart. Uses a module-level cache and loadSeq guard for async race prevention. Loading state detection via hardcoded string match against github.error is fragile. |
| apps/desktop/scripts/export-browser-mock-ade-snapshot.mjs | Refactored to read usage snapshot from a disk cache rather than computing from the database; adds live GitHub stats fetching via `gh` CLI with per-preset aggregation. GraphQL PR pagination lacks a server-side date filter. |
| apps/desktop/src/main/services/sessions/sessionDeltaService.ts | Added `backfillMissingSessionDeltas` for retroactively computing git diffs, and improved `computeSessionDelta` to use exact SHA ranges when both start/end SHAs are known. |
| apps/desktop/src/main/services/lanes/laneService.ts | Added operation tracking to `deleteLane`: a `lane_delete` operation is started before deletion and finished (succeeded/failed) after. |
| apps/desktop/src/shared/types/usage.ts | Added `AdeUsageStats`, `GetAdeUsageStatsArgs`, and supporting types. Extended `CostSnapshot` with per-preset breakdowns and added `adeCosts` to `UsageSnapshot`. |
| apps/desktop/src/preload/preload.ts | Added `usage.getAdeStats` IPC bridge; renamed existing usage/budget calls from `callRemoteProjectRuntimeActionOr` to `callProjectRuntimeActionOr` for consistency. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as AdeUsageSection (renderer)
    participant PL as preload.ts
    participant IPC as registerIpc.ts
    participant UTS as usageTrackingService
    participant UP as usagePricing
    participant GH as gh CLI
    participant Logs as Provider Logs (Claude/Codex/Cursor…)

    UI->>PL: "usage.getAdeStats({ preset })"
    PL->>IPC: ipcRenderer.invoke(usageGetAdeStats, args)
    IPC->>UTS: getAdeUsageStats(args)
    UTS->>UTS: resolveAdeUsageRange(args)
    UTS->>Logs: pollCosts() — scan all provider logs in parallel
    Logs-->>UP: resolveTokenPrice(model)
    UP-->>Logs: TokenPrice
    Logs-->>UTS: "{ costs, adeCosts }"
    UTS->>GH: scanGithubActivityStats(range) via gh CLI
    GH-->>UTS: GitHubActivityStats (commits, PRs, additions…)
    UTS->>UTS: collectAdeUsageStats(snapshot, githubStats, args)
    UTS-->>IPC: AdeUsageStats
    IPC-->>PL: AdeUsageStats
    PL-->>UI: AdeUsageStats
    UI->>UI: render StatCards, ProviderBreakdown, DailyChart
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/desktop/src/main/services/usage/usagePricing.ts`, line 1354-1356 ([link](https://github.com/arul28/ade/blob/3618bf0858aa899bf3defe112b8efa4de902c493/apps/desktop/src/main/services/usage/usagePricing.ts#L1354-L1356)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`getStaticPricingMap()` allocates a new `Map` on every price lookup**

   `resolveTokenPrice` calls `findPriceInMap(getStaticPricingMap(), model, "static")`, which creates a fresh `new Map(Object.entries(STATIC_TOKEN_PRICES))` on each invocation. The sorted-keys cache (`sortedStaticPricingKeys`) avoids re-sorting, but the Map object itself is re-allocated and then immediately discarded on every call. Given that `resolveTokenPrice` is used for every token-log scan entry (potentially millions of calls during a full scan), the repeated allocation adds GC pressure. Caching the static Map alongside `sortedStaticPricingKeys` at module level would eliminate the allocation entirely.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/usage/usagePricing.ts
   Line: 1354-1356

   Comment:
   **`getStaticPricingMap()` allocates a new `Map` on every price lookup**

   `resolveTokenPrice` calls `findPriceInMap(getStaticPricingMap(), model, "static")`, which creates a fresh `new Map(Object.entries(STATIC_TOKEN_PRICES))` on each invocation. The sorted-keys cache (`sortedStaticPricingKeys`) avoids re-sorting, but the Map object itself is re-allocated and then immediately discarded on every call. Given that `resolveTokenPrice` is used for every token-log scan entry (potentially millions of calls during a full scan), the repeated allocation adds GC pressure. Caching the static Map alongside `sortedStaticPricingKeys` at module level would eliminate the allocation entirely.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fusage%2FusagePricing.ts%0ALine%3A%201354-1356%0A%0AComment%3A%0A**%60getStaticPricingMap%28%29%60%20allocates%20a%20new%20%60Map%60%20on%20every%20price%20lookup**%0A%0A%60resolveTokenPrice%60%20calls%20%60findPriceInMap%28getStaticPricingMap%28%29%2C%20model%2C%20%22static%22%29%60%2C%20which%20creates%20a%20fresh%20%60new%20Map%28Object.entries%28STATIC_TOKEN_PRICES%29%29%60%20on%20each%20invocation.%20The%20sorted-keys%20cache%20%28%60sortedStaticPricingKeys%60%29%20avoids%20re-sorting%2C%20but%20the%20Map%20object%20itself%20is%20re-allocated%20and%20then%20immediately%20discarded%20on%20every%20call.%20Given%20that%20%60resolveTokenPrice%60%20is%20used%20for%20every%20token-log%20scan%20entry%20%28potentially%20millions%20of%20calls%20during%20a%20full%20scan%29%2C%20the%20repeated%20allocation%20adds%20GC%20pressure.%20Caching%20the%20static%20Map%20alongside%20%60sortedStaticPricingKeys%60%20at%20module%20level%20would%20eliminate%20the%20allocation%20entirely.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=447&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `apps/desktop/scripts/export-browser-mock-ade-snapshot.mjs`, line 248-260 ([link](https://github.com/arul28/ade/blob/3618bf0858aa899bf3defe112b8efa4de902c493/apps/desktop/scripts/export-browser-mock-ade-snapshot.mjs#L248-L260)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **GraphQL PR query paginates without a date boundary, fetching the full PR history**

   The `buildGithubStatsForBrowser` function fetches PRs with `--paginate` and `orderBy: { field: CREATED_AT, direction: DESC }` but applies no `createdAt` filter in the GraphQL query itself. Range filtering happens client-side in `inUsageRange`. For repos with thousands of PRs (a reasonable ADE user scenario) this exhausts every page before anything is filtered, resulting in many API round-trips and potential `gh` CLI rate limiting during the export. Adding a `filterBy: { since: range.since }` argument to the `pullRequests` field—or a `createdAt: {after: range.since}` filter—would allow GitHub to return only the relevant window and terminate pagination early.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/scripts/export-browser-mock-ade-snapshot.mjs
   Line: 248-260

   Comment:
   **GraphQL PR query paginates without a date boundary, fetching the full PR history**

   The `buildGithubStatsForBrowser` function fetches PRs with `--paginate` and `orderBy: { field: CREATED_AT, direction: DESC }` but applies no `createdAt` filter in the GraphQL query itself. Range filtering happens client-side in `inUsageRange`. For repos with thousands of PRs (a reasonable ADE user scenario) this exhausts every page before anything is filtered, resulting in many API round-trips and potential `gh` CLI rate limiting during the export. Adding a `filterBy: { since: range.since }` argument to the `pullRequests` field—or a `createdAt: {after: range.since}` filter—would allow GitHub to return only the relevant window and terminate pagination early.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fscripts%2Fexport-browser-mock-ade-snapshot.mjs%0ALine%3A%20248-260%0A%0AComment%3A%0A**GraphQL%20PR%20query%20paginates%20without%20a%20date%20boundary%2C%20fetching%20the%20full%20PR%20history**%0A%0AThe%20%60buildGithubStatsForBrowser%60%20function%20fetches%20PRs%20with%20%60--paginate%60%20and%20%60orderBy%3A%20%7B%20field%3A%20CREATED_AT%2C%20direction%3A%20DESC%20%7D%60%20but%20applies%20no%20%60createdAt%60%20filter%20in%20the%20GraphQL%20query%20itself.%20Range%20filtering%20happens%20client-side%20in%20%60inUsageRange%60.%20For%20repos%20with%20thousands%20of%20PRs%20%28a%20reasonable%20ADE%20user%20scenario%29%20this%20exhausts%20every%20page%20before%20anything%20is%20filtered%2C%20resulting%20in%20many%20API%20round-trips%20and%20potential%20%60gh%60%20CLI%20rate%20limiting%20during%20the%20export.%20Adding%20a%20%60filterBy%3A%20%7B%20since%3A%20range.since%20%7D%60%20argument%20to%20the%20%60pullRequests%60%20field%E2%80%94or%20a%20%60createdAt%3A%20%7Bafter%3A%20range.since%7D%60%20filter%E2%80%94would%20allow%20GitHub%20to%20return%20only%20the%20relevant%20window%20and%20terminate%20pagination%20early.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=447&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fsettings%2FAdeUsageSection.tsx%3A348%0A**Fragile%20loading-state%20detection%20via%20exact%20string%20match**%0A%0AThe%20component%20infers%20whether%20GitHub%20stats%20are%20%22still%20loading%22%20by%20comparing%20%60stats.github.error%60%20to%20the%20literal%20string%20%60%22GitHub%20activity%20is%20still%20loading.%22%60.%20This%20string%20is%20produced%20deep%20inside%20%60usageTrackingService.ts%60%20as%20a%20%60GITHUB_STATS_FAST_RESPONSE_TIMEOUT_MS%60%20fallback.%20If%20that%20message%20is%20ever%20rephrased%20%28a%20spelling%20fix%2C%20a%20trailing%20period%20change%2C%20etc.%29%20the%20renderer%20will%20silently%20treat%20the%20timeout%20as%20a%20hard%20error%20and%20hide%20the%20loading%20indicator%20instead%20of%20showing%20it.%20A%20structured%20discriminant%20%28e.g.%2C%20a%20boolean%20%60github.loading%60%20field%20on%20%60AdeUsageStats%60%2C%20or%20an%20error-code%20enum%29%20would%20make%20this%20coupling%20explicit%20and%20type-safe.%0A%0A%23%23%23%20Issue%202%20of%204%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fusage%2FusagePricing.ts%3A1354-1356%0A**%60getStaticPricingMap%28%29%60%20allocates%20a%20new%20%60Map%60%20on%20every%20price%20lookup**%0A%0A%60resolveTokenPrice%60%20calls%20%60findPriceInMap%28getStaticPricingMap%28%29%2C%20model%2C%20%22static%22%29%60%2C%20which%20creates%20a%20fresh%20%60new%20Map%28Object.entries%28STATIC_TOKEN_PRICES%29%29%60%20on%20each%20invocation.%20The%20sorted-keys%20cache%20%28%60sortedStaticPricingKeys%60%29%20avoids%20re-sorting%2C%20but%20the%20Map%20object%20itself%20is%20re-allocated%20and%20then%20immediately%20discarded%20on%20every%20call.%20Given%20that%20%60resolveTokenPrice%60%20is%20used%20for%20every%20token-log%20scan%20entry%20%28potentially%20millions%20of%20calls%20during%20a%20full%20scan%29%2C%20the%20repeated%20allocation%20adds%20GC%20pressure.%20Caching%20the%20static%20Map%20alongside%20%60sortedStaticPricingKeys%60%20at%20module%20level%20would%20eliminate%20the%20allocation%20entirely.%0A%0A%23%23%23%20Issue%203%20of%204%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fusage%2FusageTrackingService.ts%3A62-66%0A**Scan-limit%20increase%20could%20exhaust%20renderer-process%20memory%20on%20first%20run**%0A%0A%60LOCAL_COST_SCAN_MAX_FILE_BYTES%60%20was%20raised%20from%208%20MB%20to%20768%20MB%20and%20%60LOCAL_COST_SCAN_MAX_FILES%60%20from%20200%20to%205%2C000.%20On%20a%20first-run%20or%20after%20cache%20expiry%2C%20the%20service%20could%20read%20up%20to%20768%20MB%20of%20raw%20JSON%20per%20file%20across%20up%20to%205%2C000%20files%20simultaneously%20%28since%20all%20scanner%20calls%20are%20run%20in%20parallel%20via%20%60Promise.all%60%29.%20For%20a%20user%20with%20a%20large%20Cursor%20or%20Copilot%20log%20history%20this%20could%20spike%20memory%20well%20above%20what%20Electron's%20main%20process%20can%20comfortably%20hold.%20Consider%20a%20total-bytes%20budget%20across%20all%20files%2C%20or%20process%20files%20sequentially%20with%20early%20exit.%0A%0A%23%23%23%20Issue%204%20of%204%0Aapps%2Fdesktop%2Fscripts%2Fexport-browser-mock-ade-snapshot.mjs%3A248-260%0A**GraphQL%20PR%20query%20paginates%20without%20a%20date%20boundary%2C%20fetching%20the%20full%20PR%20history**%0A%0AThe%20%60buildGithubStatsForBrowser%60%20function%20fetches%20PRs%20with%20%60--paginate%60%20and%20%60orderBy%3A%20%7B%20field%3A%20CREATED_AT%2C%20direction%3A%20DESC%20%7D%60%20but%20applies%20no%20%60createdAt%60%20filter%20in%20the%20GraphQL%20query%20itself.%20Range%20filtering%20happens%20client-side%20in%20%60inUsageRange%60.%20For%20repos%20with%20thousands%20of%20PRs%20%28a%20reasonable%20ADE%20user%20scenario%29%20this%20exhausts%20every%20page%20before%20anything%20is%20filtered%2C%20resulting%20in%20many%20API%20round-trips%20and%20potential%20%60gh%60%20CLI%20rate%20limiting%20during%20the%20export.%20Adding%20a%20%60filterBy%3A%20%7B%20since%3A%20range.since%20%7D%60%20argument%20to%20the%20%60pullRequests%60%20field%E2%80%94or%20a%20%60createdAt%3A%20%7Bafter%3A%20range.since%7D%60%20filter%E2%80%94would%20allow%20GitHub%20to%20return%20only%20the%20relevant%20window%20and%20terminate%20pagination%20early.%0A%0A&repo=arul28%2Fade&pr=447&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
apps/desktop/src/renderer/components/settings/AdeUsageSection.tsx:348
**Fragile loading-state detection via exact string match**

The component infers whether GitHub stats are "still loading" by comparing `stats.github.error` to the literal string `"GitHub activity is still loading."`. This string is produced deep inside `usageTrackingService.ts` as a `GITHUB_STATS_FAST_RESPONSE_TIMEOUT_MS` fallback. If that message is ever rephrased (a spelling fix, a trailing period change, etc.) the renderer will silently treat the timeout as a hard error and hide the loading indicator instead of showing it. A structured discriminant (e.g., a boolean `github.loading` field on `AdeUsageStats`, or an error-code enum) would make this coupling explicit and type-safe.

### Issue 2 of 4
apps/desktop/src/main/services/usage/usagePricing.ts:1354-1356
**`getStaticPricingMap()` allocates a new `Map` on every price lookup**

`resolveTokenPrice` calls `findPriceInMap(getStaticPricingMap(), model, "static")`, which creates a fresh `new Map(Object.entries(STATIC_TOKEN_PRICES))` on each invocation. The sorted-keys cache (`sortedStaticPricingKeys`) avoids re-sorting, but the Map object itself is re-allocated and then immediately discarded on every call. Given that `resolveTokenPrice` is used for every token-log scan entry (potentially millions of calls during a full scan), the repeated allocation adds GC pressure. Caching the static Map alongside `sortedStaticPricingKeys` at module level would eliminate the allocation entirely.

### Issue 3 of 4
apps/desktop/src/main/services/usage/usageTrackingService.ts:62-66
**Scan-limit increase could exhaust renderer-process memory on first run**

`LOCAL_COST_SCAN_MAX_FILE_BYTES` was raised from 8 MB to 768 MB and `LOCAL_COST_SCAN_MAX_FILES` from 200 to 5,000. On a first-run or after cache expiry, the service could read up to 768 MB of raw JSON per file across up to 5,000 files simultaneously (since all scanner calls are run in parallel via `Promise.all`). For a user with a large Cursor or Copilot log history this could spike memory well above what Electron's main process can comfortably hold. Consider a total-bytes budget across all files, or process files sequentially with early exit.

### Issue 4 of 4
apps/desktop/scripts/export-browser-mock-ade-snapshot.mjs:248-260
**GraphQL PR query paginates without a date boundary, fetching the full PR history**

The `buildGithubStatsForBrowser` function fetches PRs with `--paginate` and `orderBy: { field: CREATED_AT, direction: DESC }` but applies no `createdAt` filter in the GraphQL query itself. Range filtering happens client-side in `inUsageRange`. For repos with thousands of PRs (a reasonable ADE user scenario) this exhausts every page before anything is filtered, resulting in many API round-trips and potential `gh` CLI rate limiting during the export. Adding a `filterBy: { since: range.since }` argument to the `pullRequests` field—or a `createdAt: {after: range.since}` filter—would allow GitHub to return only the relevant window and terminate pagination early.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add full usage stats dashboard"](https://github.com/arul28/ade/commit/3618bf0858aa899bf3defe112b8efa4de902c493) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34745964)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->