### PR TITLE
Expose Linear GraphQL through ADE CLI

### DIFF
--- a/apps/ade-cli/src/adeRpcServer.test.ts
+++ b/apps/ade-cli/src/adeRpcServer.test.ts
@@ -667,6 +667,7 @@ function createRuntime() {
         labels: [],
         assigneeName: null,
       })),
+      runGraphQL: vi.fn(async (args: unknown) => ({ viewer: { id: "user-1" }, _args: args })),
       createComment: vi.fn(async () => ({ id: "comment-1" })),
       fetchWorkflowStates: vi.fn(async () => [{ id: "state-done", name: "Done" }]),
       updateIssueState: vi.fn(async () => {}),
@@ -2951,6 +2952,18 @@ describe("adeRpcServer", () => {
     });
     expect(setState?.isError).toBeUndefined();
     expect(fixture.runtime.linearIssueTracker.updateIssueState).toHaveBeenCalledWith("ENG-431", "state-done");
+
+    const graphql = await callTool(handler, "run_ade_action", {
+      domain: "linear_issue_tracker",
+      action: "graphql",
+      args: { query: "query Viewer { viewer { id } }", variables: { first: 1 } },
+    });
+    expect(graphql?.isError).toBeUndefined();
+    expect(fixture.runtime.linearIssueTracker.runGraphQL).toHaveBeenCalledWith({
+      query: "query Viewer { viewer { id } }",
+      variables: { first: 1 },
+    });
+    expect(graphql.structuredContent.result).toMatchObject({ viewer: { id: "user-1" } });
   });
 
   it("invokes review.startRun through ADE actions without dropping unlimited budgets", async () => {

--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -65,6 +65,10 @@ import type { createLinearIssueTracker } from "../../desktop/src/main/services/c
 import type { createLinearIngressService } from "../../desktop/src/main/services/cto/linearIngressService";
 import type { createLinearRoutingService } from "../../desktop/src/main/services/cto/linearRoutingService";
 import type { createLinearSyncService } from "../../desktop/src/main/services/cto/linearSyncService";
+import {
+  publishLinearChatSessionCard,
+  publishLinearLaneCard,
+} from "../../desktop/src/main/services/cto/linearLaneCardService";
 import { createAiIntegrationService } from "../../desktop/src/main/services/ai/aiIntegrationService";
 import { initApiKeyStore } from "../../desktop/src/main/services/ai/apiKeyStore";
 import type { createSyncService } from "./services/sync/syncService";
@@ -430,6 +434,9 @@ export async function createAdeRuntime(args: {
   let conflictServiceRef: ReturnType<typeof createConflictService> | null = null;
   let rebaseSuggestionServiceRef: ReturnType<typeof createRebaseSuggestionService> | null = null;
   let autoRebaseServiceRef: ReturnType<typeof createAutoRebaseService> | null = null;
+  let linearIssueTrackerRef: ReturnType<typeof createLinearIssueTracker> | null = null;
+  let githubServiceRef: ReturnType<typeof createGithubService> | null = null;
+  const linearChatCardPublishKeys = new Set<string>();
 
   const laneService = createLaneService({
     db,
@@ -461,6 +468,55 @@ export async function createAdeRuntime(args: {
           });
         });
       }
+    },
+    onLinearIssueLinked: ({ lane, issue, linkedAt }) => {
+      const tracker = linearIssueTrackerRef;
+      if (!tracker) return;
+      void githubServiceRef?.getRepoOrThrow()
+        .catch(() => null)
+        .then((repo) => publishLinearLaneCard({
+          issueTracker: tracker,
+          lane,
+          issue,
+          projectRoot,
+          linkedAt,
+          repoOwner: repo?.owner ?? null,
+          repoName: repo?.name ?? null,
+          postInitialComment: true,
+          log: (event, fields) => logger.warn(event, fields),
+        }))
+        .catch((error) => {
+          logger.warn("linear.lane_card_publish_failed", {
+            laneId: lane.id,
+            issueId: issue.id,
+            issueIdentifier: issue.identifier,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+    },
+    onLinearIssueSessionLinked: ({ laneId, sessionId, sessionTitle, issue, linkedAt }) => {
+      const tracker = linearIssueTrackerRef;
+      if (!tracker) return;
+      const key = `${issue.id}:${sessionId}`;
+      if (linearChatCardPublishKeys.has(key)) return;
+      linearChatCardPublishKeys.add(key);
+      void publishLinearChatSessionCard({
+        issueTracker: tracker,
+        issue,
+        laneId,
+        sessionId,
+        sessionTitle,
+        linkedAt,
+      }).catch((error) => {
+        linearChatCardPublishKeys.delete(key);
+        logger.warn("linear.chat_session_card_publish_failed", {
+          laneId,
+          sessionId,
+          issueId: issue.id,
+          issueIdentifier: issue.identifier,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
     },
     logger,
   });
@@ -856,6 +912,8 @@ export async function createAdeRuntime(args: {
     onLinearWorkflowEvent: (event) =>
       pushEvent("runtime", { type: "linear_workflow_event", event }),
   });
+  linearIssueTrackerRef = headlessLinearServices.linearIssueTracker;
+  githubServiceRef = headlessLinearServices.githubService as ReturnType<typeof createGithubService>;
   const linearOAuthService = createLinearOAuthService({
     credentials: headlessLinearServices.linearCredentialService as never,
     logger,
@@ -904,6 +962,30 @@ export async function createAdeRuntime(args: {
       logger,
       appVersion: "ade-cli",
       getAdeCliAgentEnv: createHeadlessAdeCliAgentEnv,
+      onLinearIssueChatLinked: ({ laneId, sessionId, sessionTitle, issue, linkedAt }) => {
+        const tracker = linearIssueTrackerRef;
+        if (!tracker) return;
+        const key = `${issue.id}:${sessionId}`;
+        if (linearChatCardPublishKeys.has(key)) return;
+        linearChatCardPublishKeys.add(key);
+        void publishLinearChatSessionCard({
+          issueTracker: tracker,
+          issue,
+          laneId,
+          sessionId,
+          sessionTitle,
+          linkedAt,
+        }).catch((error) => {
+          linearChatCardPublishKeys.delete(key);
+          logger.warn("linear.chat_session_card_publish_failed", {
+            laneId,
+            sessionId,
+            issueId: issue.id,
+            issueIdentifier: issue.identifier,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      },
       onEvent: (event) => {
         pushEvent("runtime", event as unknown as Record<string, unknown>);
       },

--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -437,6 +437,42 @@ export async function createAdeRuntime(args: {
   let linearIssueTrackerRef: ReturnType<typeof createLinearIssueTracker> | null = null;
   let githubServiceRef: ReturnType<typeof createGithubService> | null = null;
   const linearChatCardPublishKeys = new Set<string>();
+  const publishLinearChatLink = ({
+    laneId,
+    sessionId,
+    sessionTitle,
+    issue,
+    linkedAt,
+  }: {
+    laneId: string;
+    sessionId: string;
+    sessionTitle?: string | null;
+    issue: Parameters<typeof publishLinearChatSessionCard>[0]["issue"];
+    linkedAt: string;
+  }) => {
+    const tracker = linearIssueTrackerRef;
+    if (!tracker) return;
+    const key = `${issue.id}:${sessionId}`;
+    if (linearChatCardPublishKeys.has(key)) return;
+    linearChatCardPublishKeys.add(key);
+    void publishLinearChatSessionCard({
+      issueTracker: tracker,
+      issue,
+      laneId,
+      sessionId,
+      sessionTitle,
+      linkedAt,
+    }).catch((error) => {
+      linearChatCardPublishKeys.delete(key);
+      logger.warn("linear.chat_session_card_publish_failed", {
+        laneId,
+        sessionId,
+        issueId: issue.id,
+        issueIdentifier: issue.identifier,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  };
 
   const laneService = createLaneService({
     db,
@@ -494,30 +530,7 @@ export async function createAdeRuntime(args: {
           });
         });
     },
-    onLinearIssueSessionLinked: ({ laneId, sessionId, sessionTitle, issue, linkedAt }) => {
-      const tracker = linearIssueTrackerRef;
-      if (!tracker) return;
-      const key = `${issue.id}:${sessionId}`;
-      if (linearChatCardPublishKeys.has(key)) return;
-      linearChatCardPublishKeys.add(key);
-      void publishLinearChatSessionCard({
-        issueTracker: tracker,
-        issue,
-        laneId,
-        sessionId,
-        sessionTitle,
-        linkedAt,
-      }).catch((error) => {
-        linearChatCardPublishKeys.delete(key);
-        logger.warn("linear.chat_session_card_publish_failed", {
-          laneId,
-          sessionId,
-          issueId: issue.id,
-          issueIdentifier: issue.identifier,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      });
-    },
+    onLinearIssueSessionLinked: publishLinearChatLink,
     logger,
   });
   await laneService.ensurePrimaryLane();
@@ -962,30 +975,7 @@ export async function createAdeRuntime(args: {
       logger,
       appVersion: "ade-cli",
       getAdeCliAgentEnv: createHeadlessAdeCliAgentEnv,
-      onLinearIssueChatLinked: ({ laneId, sessionId, sessionTitle, issue, linkedAt }) => {
-        const tracker = linearIssueTrackerRef;
-        if (!tracker) return;
-        const key = `${issue.id}:${sessionId}`;
-        if (linearChatCardPublishKeys.has(key)) return;
-        linearChatCardPublishKeys.add(key);
-        void publishLinearChatSessionCard({
-          issueTracker: tracker,
-          issue,
-          laneId,
-          sessionId,
-          sessionTitle,
-          linkedAt,
-        }).catch((error) => {
-          linearChatCardPublishKeys.delete(key);
-          logger.warn("linear.chat_session_card_publish_failed", {
-            laneId,
-            sessionId,
-            issueId: issue.id,
-            issueIdentifier: issue.identifier,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        });
-      },
+      onLinearIssueChatLinked: publishLinearChatLink,
       onEvent: (event) => {
         pushEvent("runtime", event as unknown as Record<string, unknown>);
       },

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -2453,6 +2453,30 @@ describe("ADE CLI", () => {
     });
   });
 
+  it("revalidates linear graphql payloads after generic argument overrides", () => {
+    expect(() =>
+      buildCliPlan([
+        "linear",
+        "graphql",
+        "--query",
+        "query Viewer { viewer { id name } }",
+        "--arg-json",
+        "variables=[]",
+      ]),
+    ).toThrow(/--variables-json must be a JSON object/);
+
+    expect(() =>
+      buildCliPlan([
+        "linear",
+        "graphql",
+        "--query",
+        "query Viewer { viewer { id name } }",
+        "--input-json",
+        "{\"query\":123}",
+      ]),
+    ).toThrow(/GraphQL query is required/);
+  });
+
   it("attaches an issue to the current session via linear attach --this-session", () => {
     const prev = process.env.ADE_CHAT_SESSION_ID;
     process.env.ADE_CHAT_SESSION_ID = "current-session";

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -2253,7 +2253,7 @@ describe("ADE CLI", () => {
     });
   });
 
-  it("chains create_lane -> chat createSession -> kickoff for create-from-linear --start-chat", () => {
+  it("chains create_lane -> chat createSession -> attach Linear issue -> kickoff for create-from-linear --start-chat", () => {
     const plan = buildCliPlan([
       "lanes",
       "create-from-linear",
@@ -2267,7 +2267,7 @@ describe("ADE CLI", () => {
     ]);
     expect(plan.kind).toBe("execute");
     if (plan.kind !== "execute") return;
-    expect(plan.steps).toHaveLength(3);
+    expect(plan.steps).toHaveLength(4);
     expect(plan.steps[0]?.key).toBe("lane");
 
     // Step 2 derives laneId from the create_lane result.
@@ -2285,8 +2285,26 @@ describe("ADE CLI", () => {
       },
     });
 
-    // Step 3 derives sessionId from the createSession result and sends a kickoff.
-    const sendStep = plan.steps[2]!;
+    // Step 3 attaches the issue to the chat so the runtime posts chat/lane cards.
+    const attachStep = plan.steps[2]!;
+    const attachParams = (attachStep.params as (v: Record<string, unknown>) => Record<string, unknown>)({
+      chat: { domain: "chat", action: "createSession", result: { id: "session-new" } },
+    });
+    expect(attachParams).toMatchObject({
+      arguments: {
+        domain: "lane",
+        action: "attachLinearIssueToSession",
+        args: {
+          chatSessionId: "session-new",
+          issues: [{ id: "issue-1", identifier: "ENG-431", title: "Fix OAuth", url: "https://linear.app/x/ENG-431" }],
+          role: "worked",
+          source: "chat_attach",
+        },
+      },
+    });
+
+    // Step 4 derives sessionId from the createSession result and sends a kickoff.
+    const sendStep = plan.steps[3]!;
     const sendParams = (sendStep.params as (v: Record<string, unknown>) => Record<string, unknown>)({
       chat: { domain: "chat", action: "createSession", result: { id: "session-new" } },
     });

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -2408,6 +2408,33 @@ describe("ADE CLI", () => {
     }
   });
 
+  it("routes linear graphql through the runtime-owned Linear connection", () => {
+    const plan = buildCliPlan([
+      "linear",
+      "graphql",
+      "--query",
+      "query Viewer { viewer { id name } }",
+      "--operation-name",
+      "Viewer",
+      "--variables-json",
+      "{\"includeArchived\":false}",
+    ]);
+    expect(plan.kind).toBe("execute");
+    if (plan.kind !== "execute") return;
+    expect(plan.steps[0]?.params).toEqual({
+      name: "run_ade_action",
+      arguments: {
+        domain: "linear_issue_tracker",
+        action: "graphql",
+        args: {
+          query: "query Viewer { viewer { id name } }",
+          operationName: "Viewer",
+          variables: { includeArchived: false },
+        },
+      },
+    });
+  });
+
   it("attaches an issue to the current session via linear attach --this-session", () => {
     const prev = process.env.ADE_CHAT_SESSION_ID;
     process.env.ADE_CHAT_SESSION_ID = "current-session";

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -1417,6 +1417,8 @@ const HELP_BY_COMMAND: Record<string, string> = {
     $ ade linear label ENG-431 "needs-review"       Add a label to an issue
     $ ade linear graphql --query 'query { viewer { id name } }'
                                                     Run Linear GraphQL through the project connection
+    $ ade linear graphql --query-file query.graphql --variables-file vars.json
+                                                    Use files for larger GraphQL operations
     $ ade linear detach --this-session [--issue-id ENG-431]
                                                     Detach one issue (or all) from this session
 
@@ -3112,6 +3114,25 @@ function buildCreateLaneFromLinearPlan(args: string[], issue: JsonObject): CliPl
             domain: "chat",
             action: "createSession",
             args: { laneId, surface, ...launchConfig },
+          },
+        };
+      },
+      unwrapToolResult: true,
+    });
+    steps.push({
+      key: "attach",
+      method: "ade/actions/call",
+      params: (values) => {
+        const sessionId = sessionIdFromCreateChatValue(values.chat);
+        if (!sessionId) {
+          throw new CliUsageError("create-from-linear launched a chat but could not resolve its session id to attach the issue.");
+        }
+        return {
+          name: "run_ade_action",
+          arguments: {
+            domain: LINEAR_ATTACH_ACTIONS.domain,
+            action: LINEAR_ATTACH_ACTIONS.attachSession,
+            args: { chatSessionId: sessionId, issues: [issue], role: "worked", source: "chat_attach" },
           },
         };
       },

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -392,7 +392,7 @@ const TOP_LEVEL_HELP = `${ADE_BANNER}
     $ ade chat list | create | send | interrupt     Work with ADE agent chats
     $ ade agent spawn --lane <id> --prompt <text>   Launch an agent session in ADE
     $ ade cto state | chats                         Operate CTO state and Work chats
-    $ ade linear workflows | run | sync             Operate Linear routing and sync workflows
+    $ ade linear graphql | workflows | run | sync   Operate Linear GraphQL, routing, and sync workflows
     $ ade automations list | create | run | runs    Manage automation rules
     $ ade coordinator <tool>                        Call coordinator runtime tools
     $ ade tests list | run | stop | runs | logs     Run configured test suites
@@ -1415,6 +1415,8 @@ const HELP_BY_COMMAND: Record<string, string> = {
     $ ade linear set-state ENG-431 <state-id>       Move an issue to a workflow state
     $ ade linear assign ENG-431 <user-id|none>      Assign or clear an issue assignee
     $ ade linear label ENG-431 "needs-review"       Add a label to an issue
+    $ ade linear graphql --query 'query { viewer { id name } }'
+                                                    Run Linear GraphQL through the project connection
     $ ade linear detach --this-session [--issue-id ENG-431]
                                                     Detach one issue (or all) from this session
 
@@ -1910,6 +1912,18 @@ function readJsonFileOption(
   return parseJson(text, label);
 }
 
+function readTextFileOption(args: string[], names: string[], label: string): string | null {
+  const filePath = readValue(args, names);
+  if (filePath == null) return null;
+  const resolvedPath = path.resolve(filePath);
+  try {
+    return fs.readFileSync(resolvedPath, "utf8");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CliUsageError(`Could not read ${label} file '${filePath}': ${message}`);
+  }
+}
+
 function readJsonPayloadOption(
   args: string[],
   jsonNames: string[],
@@ -2054,6 +2068,31 @@ function sessionLinearIssueId(): string | null {
 /** Consume the single-issue-id flag (`--issue-id`/`--linear-issue-id`/`--issue`) from args. */
 function readIssueIdFlag(args: string[]): string | null {
   return readValue(args, ["--issue-id", "--linear-issue-id", "--issue"]);
+}
+
+function readLinearGraphQLArgs(args: string[]): JsonObject {
+  const inlineQuery = readValue(args, ["--query", "--graphql", "--gql"]);
+  const fileQuery = readTextFileOption(args, ["--query-file", "--graphql-file", "--gql-file"], "--query-file");
+  if (inlineQuery != null && fileQuery != null) {
+    throw new CliUsageError("Use either --query or --query-file, not both.");
+  }
+  const positionalQuery = inlineQuery == null && fileQuery == null ? firstPositional(args) : null;
+  const query = requireValue(inlineQuery ?? fileQuery ?? positionalQuery, "GraphQL query");
+  const variables = readJsonPayloadOption(
+    args,
+    ["--variables-json", "--vars-json"],
+    ["--variables-file", "--vars-file"],
+    "--variables-json",
+  );
+  if (variables !== undefined && !isRecord(variables)) {
+    throw new CliUsageError("--variables-json must be a JSON object.");
+  }
+  const input: JsonObject = { query };
+  if (variables !== undefined) input.variables = variables;
+  maybePut(input, "operationName", readValue(args, ["--operation-name", "--operation"]));
+  const maxRetries = readNumberOption(args, ["--max-retries"]);
+  if (maxRetries !== undefined) input.maxRetries = maxRetries;
+  return collectGenericObjectArgs(args, input);
 }
 
 /**
@@ -8774,6 +8813,13 @@ function buildLinearPlan(args: string[]): CliPlan {
       kind: "execute",
       label: "linear issue",
       steps: [actionArgsListStep("result", "linear_issue_tracker", "fetchIssueById", [issueId])],
+    };
+  }
+  if (sub === "graphql" || sub === "gql") {
+    return {
+      kind: "execute",
+      label: "Linear GraphQL",
+      steps: [actionStep("result", "linear_issue_tracker", "graphql", readLinearGraphQLArgs(args))],
     };
   }
   if (sub === "quick-view" || sub === "quick" || sub === "overview") {

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -2072,6 +2072,35 @@ function readIssueIdFlag(args: string[]): string | null {
   return readValue(args, ["--issue-id", "--linear-issue-id", "--issue"]);
 }
 
+function normalizeLinearGraphQLInput(input: JsonObject): JsonObject {
+  const query = asString(input.query);
+  if (!query) {
+    throw new CliUsageError("GraphQL query is required.");
+  }
+
+  const variables = input.variables;
+  if (variables != null && !isRecord(variables)) {
+    throw new CliUsageError("--variables-json must be a JSON object.");
+  }
+
+  const maxRetries = input.maxRetries;
+  if (maxRetries != null && (typeof maxRetries !== "number" || !Number.isFinite(maxRetries))) {
+    throw new CliUsageError("--max-retries must be a number.");
+  }
+
+  const normalized: JsonObject = { ...input, query };
+  if (variables == null) {
+    delete normalized.variables;
+  }
+  const operationName = asString(input.operationName);
+  if (operationName) {
+    normalized.operationName = operationName;
+  } else {
+    delete normalized.operationName;
+  }
+  return normalized;
+}
+
 function readLinearGraphQLArgs(args: string[]): JsonObject {
   const inlineQuery = readValue(args, ["--query", "--graphql", "--gql"]);
   const fileQuery = readTextFileOption(args, ["--query-file", "--graphql-file", "--gql-file"], "--query-file");
@@ -2094,7 +2123,7 @@ function readLinearGraphQLArgs(args: string[]): JsonObject {
   maybePut(input, "operationName", readValue(args, ["--operation-name", "--operation"]));
   const maxRetries = readNumberOption(args, ["--max-retries"]);
   if (maxRetries !== undefined) input.maxRetries = maxRetries;
-  return collectGenericObjectArgs(args, input);
+  return normalizeLinearGraphQLInput(collectGenericObjectArgs(args, input));
 }
 
 /**

--- a/apps/ade-cli/src/tuiClient/__tests__/commands.test.ts
+++ b/apps/ade-cli/src/tuiClient/__tests__/commands.test.ts
@@ -445,6 +445,21 @@ describe("linear command routing", () => {
     });
   });
 
+  it("routes /linear graphql through the linear_issue_tracker action domain", () => {
+    expect(
+      buildLinearToolRequest("graphql --query 'query Viewer { viewer { id } }' --variables-json '{\"first\":10}'"),
+    ).toEqual({
+      kind: "action",
+      title: "Linear GraphQL",
+      domain: "linear_issue_tracker",
+      action: "graphql",
+      args: {
+        query: "query Viewer { viewer { id } }",
+        variables: { first: 10 },
+      },
+    });
+  });
+
   it("routes sync dashboard and queue resolution", () => {
     expect(buildLinearToolRequest("sync dashboard")).toEqual({
       kind: "tool",

--- a/apps/ade-cli/src/tuiClient/__tests__/commands.test.ts
+++ b/apps/ade-cli/src/tuiClient/__tests__/commands.test.ts
@@ -460,6 +460,23 @@ describe("linear command routing", () => {
     });
   });
 
+  it("rejects malformed /linear graphql variables", () => {
+    expect(
+      buildLinearToolRequest("graphql --query 'query Viewer { viewer { id } }' --variables-json nope"),
+    ).toMatchObject({
+      kind: "usage",
+      title: "Linear GraphQL",
+      body: expect.stringContaining("--variables-json must be valid JSON"),
+    });
+    expect(
+      buildLinearToolRequest("graphql --query 'query Viewer { viewer { id } }' --variables-json '[1]'"),
+    ).toMatchObject({
+      kind: "usage",
+      title: "Linear GraphQL",
+      body: expect.stringContaining("--variables-json must be a JSON object"),
+    });
+  });
+
   it("routes sync dashboard and queue resolution", () => {
     expect(buildLinearToolRequest("sync dashboard")).toEqual({
       kind: "tool",

--- a/apps/ade-cli/src/tuiClient/__tests__/commands.test.ts
+++ b/apps/ade-cli/src/tuiClient/__tests__/commands.test.ts
@@ -477,6 +477,14 @@ describe("linear command routing", () => {
     });
   });
 
+  it("keeps fallback usage in sync with /linear graphql", () => {
+    expect(buildLinearToolRequest("unknown")).toMatchObject({
+      kind: "usage",
+      title: "Linear",
+      body: expect.stringContaining("graphql"),
+    });
+  });
+
   it("routes sync dashboard and queue resolution", () => {
     expect(buildLinearToolRequest("sync dashboard")).toEqual({
       kind: "tool",

--- a/apps/ade-cli/src/tuiClient/linearCommands.ts
+++ b/apps/ade-cli/src/tuiClient/linearCommands.ts
@@ -161,18 +161,22 @@ function attachmentFlags(options: Record<string, unknown>): Record<string, unkno
   });
 }
 
-function parseGraphQLVariables(options: Record<string, unknown>): Record<string, unknown> | undefined {
+type GraphQLVariablesParseResult =
+  | { ok: true; variables?: Record<string, unknown> }
+  | { ok: false; message: string };
+
+function parseGraphQLVariables(options: Record<string, unknown>): GraphQLVariablesParseResult {
   const value = optionString(options, "variablesJson", "varsJson");
-  if (!value) return undefined;
+  if (!value) return { ok: true };
   try {
     const parsed = JSON.parse(value) as unknown;
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as Record<string, unknown>;
+      return { ok: true, variables: parsed as Record<string, unknown> };
     }
+    return { ok: false, message: "--variables-json must be a JSON object." };
   } catch {
-    return undefined;
+    return { ok: false, message: "--variables-json must be valid JSON." };
   }
-  return undefined;
 }
 
 export function buildLinearToolRequest(input: string): LinearToolRequest {
@@ -297,9 +301,16 @@ export function buildLinearToolRequest(input: string): LinearToolRequest {
         "Usage: /linear graphql --query 'query { viewer { id name } }' [--variables-json '{\"id\":\"...\"}']",
       );
     }
+    const variables = parseGraphQLVariables(options);
+    if (!variables.ok) {
+      return usage(
+        "Linear GraphQL",
+        `${variables.message}\nUsage: /linear graphql --query 'query { viewer { id name } }' [--variables-json '{\"id\":\"...\"}']`,
+      );
+    }
     return action("Linear GraphQL", "linear_issue_tracker", "graphql", {
       query,
-      variables: parseGraphQLVariables(options),
+      variables: variables.variables,
       operationName: optionString(options, "operationName", "operation") ?? undefined,
     });
   }

--- a/apps/ade-cli/src/tuiClient/linearCommands.ts
+++ b/apps/ade-cli/src/tuiClient/linearCommands.ts
@@ -438,6 +438,6 @@ export function buildLinearToolRequest(input: string): LinearToolRequest {
 
   return usage(
     "Linear",
-    "Usage: /linear <attach|detach|issues|comment|set-state|assign|label|issue|create-from|workflows|run|route|sync|ingress> ...",
+    "Usage: /linear <attach|detach|issues|comment|set-state|assign|label|issue|graphql|create-from|workflows|run|route|sync|ingress> ...",
   );
 }

--- a/apps/ade-cli/src/tuiClient/linearCommands.ts
+++ b/apps/ade-cli/src/tuiClient/linearCommands.ts
@@ -161,6 +161,20 @@ function attachmentFlags(options: Record<string, unknown>): Record<string, unkno
   });
 }
 
+function parseGraphQLVariables(options: Record<string, unknown>): Record<string, unknown> | undefined {
+  const value = optionString(options, "variablesJson", "varsJson");
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
 export function buildLinearToolRequest(input: string): LinearToolRequest {
   const parsed = parseLinearArgs(input);
   const [group, modeArg, ...rest] = parsed.positionals;
@@ -169,7 +183,7 @@ export function buildLinearToolRequest(input: string): LinearToolRequest {
   if (!group) {
     return usage(
       "Linear",
-      "Usage: /linear <attach|detach|issues|comment|set-state|assign|label|issue|create-from|workflows|run|route|sync|ingress> ...",
+      "Usage: /linear <attach|detach|issues|comment|set-state|assign|label|issue|graphql|create-from|workflows|run|route|sync|ingress> ...",
     );
   }
 
@@ -271,6 +285,23 @@ export function buildLinearToolRequest(input: string): LinearToolRequest {
     const issueId = writeCommandIssueId(options, modeArg);
     if (!issueId) return usage("Linear issue", "Usage: /linear issue <issue-id>");
     return actionList("Linear issue", "linear_issue_tracker", "fetchIssueById", [issueId]);
+  }
+
+  if (group === "graphql" || group === "gql") {
+    const query =
+      optionString(options, "query", "graphql", "gql") ??
+      [modeArg, ...rest].filter(Boolean).join(" ").trim();
+    if (!query) {
+      return usage(
+        "Linear GraphQL",
+        "Usage: /linear graphql --query 'query { viewer { id name } }' [--variables-json '{\"id\":\"...\"}']",
+      );
+    }
+    return action("Linear GraphQL", "linear_issue_tracker", "graphql", {
+      query,
+      variables: parseGraphQLVariables(options),
+      operationName: optionString(options, "operationName", "operation") ?? undefined,
+    });
   }
 
   if (group === "create-from" || group === "create-from-linear" || group === "create-lane-from") {

--- a/apps/desktop/resources/agent-skills/ade-deeplinks/SKILL.md
+++ b/apps/desktop/resources/agent-skills/ade-deeplinks/SKILL.md
@@ -125,6 +125,24 @@ cross-machine link to any Linear issue linked to the lane (Linear attachment
 + one-time comment). Agents do not need to call `ade link` for those flows —
 they fire on PR creation / Linear-link events.
 
+Linear card/comment matrix:
+
+| Linear-related action | Who adds the ADE link |
+| --- | --- |
+| `ade lanes create --linear-issue-json` / `ade lanes create-from-linear` | ADE posts the lane attachment/comment |
+| `ade lanes link-linear-issue` / `ade chat attach-linear-issue` / `ade linear attach --this-session` | ADE posts lane/chat attachments when a lane/session is known |
+| `ade chat create --from-linear-issue` or `ade lanes create-from-linear --start-chat` | ADE posts the chat attachment after the issue is attached |
+| `ade prs create` on a linked lane | ADE posts the PR attachment/footer |
+| `ade linear comment`, `set-state`, `assign`, `label`, or `graphql` | The agent should include the relevant ADE link in any Linear comment it writes |
+
+If you create new Linear state directly (for example with `ade linear graphql`),
+mint the Linear-pane link yourself and comment it back to the issue:
+
+```bash
+ade link linear-issue ADE-123 --no-clipboard
+ade linear comment ADE-123 "Created via ADE. Open in ADE: <paste link>"
+```
+
 Agents should still include a user-facing ADE PR link when handing off a newly
 created or adopted PR. Use the GitHub PR URL for the browser link and the
 `adeUrl` printed by `ade prs create`. If the PR came from another path, mint

--- a/apps/desktop/resources/agent-skills/ade-linear/SKILL.md
+++ b/apps/desktop/resources/agent-skills/ade-linear/SKILL.md
@@ -65,6 +65,8 @@ ade linear issues --text                         # list issues attached to this 
 ade linear issue --text                          # read your attached issue (full detail)
 ade linear issue ENG-431 --text                  # read a specific issue
 ade linear issue-comments --issue-id ENG-431 --text   # read an issue's comment thread
+ade linear graphql --query 'query { viewer { id name } }'  # advanced Linear API via ADE credentials
+ade linear graphql --query-file query.graphql --variables-file vars.json
 ```
 
 Use `--text` for human-readable output; omit it for JSON when you want to parse.
@@ -93,6 +95,40 @@ Notes:
 - `comment`, `set-state`, `assign`, and `label` all accept the value via a flag
   too (`--message/-m`, `--state-id`, `--assignee`, `--label`) if a positional is
   ambiguous.
+- Use `ade linear graphql` for Linear operations not covered by the typed
+  commands. It still routes through ADE's saved Linear OAuth/API key; do not ask
+  for or print token material.
+
+## ADE deeplinks in Linear comments
+
+ADE posts deterministic Linear attachments/cards for these flows when the
+runtime owns the Linear connection:
+
+| Flow | ADE handles it |
+| --- | --- |
+| Create a lane from a Linear issue | Lane attachment + one-time ADE branch comment |
+| Attach a Linear issue to an existing lane | Lane attachment + one-time ADE branch comment |
+| Create or attach a chat/CLI session with a Linear issue | ADE chat attachment |
+| Open/create a PR from a linked lane | ADE PR attachment/footer |
+
+For direct issue actions (`comment`, `set-state`, `assign`, `label`, `graphql`)
+include the relevant ADE link in any user-facing Linear comment you write,
+especially when the action creates new Linear state or hands work to a human.
+Use the **ade-deeplinks** skill to mint links:
+
+```bash
+ade link linear-issue ENG-431 --no-clipboard
+ade link branch <owner/repo> <branch> --no-clipboard
+ade link session "$ADE_CHAT_SESSION_ID" --lane <lane-id> --no-clipboard
+ade link pr <owner/repo> <number> --no-clipboard
+```
+
+Example when creating a new Linear issue via GraphQL:
+
+```bash
+ade linear graphql --query-file create-issue.graphql --variables-file vars.json
+ade linear comment NEW-123 "Created via ADE. Open in ADE: $(ade link linear-issue NEW-123 --no-clipboard)"
+```
 
 ## Attaching / detaching this session
 
@@ -107,8 +143,10 @@ ade linear detach --this-session                      # detach every issue from 
 1. When you start real work on the issue, move it to **In Progress**
    (`ade linear set-state <state-id>`), so watchers see it's being worked.
 2. As you make progress, **comment** what you did and link the PR
-   (`ade linear comment "..."`). That comment is how reviewers and the issue's
-   watchers see status — report what you actually did, not what you intend to do.
+   (`ade linear comment "..."`). Include ADE branch/session/PR links when a card
+   was not already posted automatically. That comment is how reviewers and the
+   issue's watchers see status — report what you actually did, not what you
+   intend to do.
 3. When you finish, set the **appropriate final state** (e.g. Done / In Review).
    Defer the exact final-state policy to the user's workflow — if you're unsure
    whether to mark Done vs. In Review, comment your result and ask rather than

--- a/apps/desktop/scripts/validate-mac-artifacts.mjs
+++ b/apps/desktop/scripts/validate-mac-artifacts.mjs
@@ -22,6 +22,7 @@ const bundledAgentSkills = [
   "ade-browser",
   "ade-pr-workflows",
   "ade-lanes-git",
+  "ade-linear",
   "ade-proof-artifacts",
   "ade-macos-vm",
   "ade-deeplinks",

--- a/apps/desktop/scripts/validate-win-artifacts.mjs
+++ b/apps/desktop/scripts/validate-win-artifacts.mjs
@@ -24,6 +24,7 @@ const bundledAgentSkills = [
   "ade-browser",
   "ade-pr-workflows",
   "ade-lanes-git",
+  "ade-linear",
   "ade-proof-artifacts",
   "ade-macos-vm",
   "ade-deeplinks",

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1763,6 +1763,7 @@ app.whenReady().then(async () => {
     let linearIssueTrackerRef: LinearIssueTracker | null = null;
     let linearLiveStatusServiceRef: LinearLiveStatusService | null = null;
     const linearChatCardPublishKeys = new Set<string>();
+    const linearLiveStatusLaunchKeys = new Set<string>();
     const publishLinearChatLink = ({ laneId, sessionId, sessionTitle, issue, linkedAt }: {
       laneId: string;
       sessionId: string;
@@ -1795,11 +1796,15 @@ app.whenReady().then(async () => {
       }
       // Agent launched against a Linear issue → reflect status into Linear
       // (no-op unless the live round-trip flag is set).
-      void linearLiveStatusServiceRef?.onAgentLaunched({
+      const liveStatusService = linearLiveStatusServiceRef;
+      if (!liveStatusService || linearLiveStatusLaunchKeys.has(key)) return;
+      linearLiveStatusLaunchKeys.add(key);
+      void liveStatusService.onAgentLaunched({
         issue,
         branchName: issue.branchName,
         laneName: sessionTitle ?? null,
       }).catch((error) => {
+        linearLiveStatusLaunchKeys.delete(key);
         logger.warn("linear.live_status_launch_failed", {
           laneId,
           sessionId,

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -86,6 +86,7 @@ import type {
   OpenProjectBinding,
   AppNavigationRequest,
   LaneDeleteProgress,
+  LaneLinearIssue,
   LaneSummary,
   PortLease,
   PrEventPayload,
@@ -1761,6 +1762,51 @@ app.whenReady().then(async () => {
       null;
     let linearIssueTrackerRef: LinearIssueTracker | null = null;
     let linearLiveStatusServiceRef: LinearLiveStatusService | null = null;
+    const linearChatCardPublishKeys = new Set<string>();
+    const publishLinearChatLink = ({ laneId, sessionId, sessionTitle, issue, linkedAt }: {
+      laneId: string;
+      sessionId: string;
+      sessionTitle?: string | null;
+      issue: LaneLinearIssue;
+      linkedAt: string;
+    }) => {
+      const tracker = linearIssueTrackerRef;
+      if (!tracker) return;
+      const key = `${issue.id}:${sessionId}`;
+      if (linearChatCardPublishKeys.has(key)) return;
+      linearChatCardPublishKeys.add(key);
+      void publishLinearChatSessionCard({
+        issueTracker: tracker,
+        issue,
+        laneId,
+        sessionId,
+        sessionTitle,
+        linkedAt,
+      }).catch((error) => {
+        linearChatCardPublishKeys.delete(key);
+        logger.warn("linear.chat_session_card_publish_failed", {
+          laneId,
+          sessionId,
+          issueId: issue.id,
+          issueIdentifier: issue.identifier,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+      // Agent launched against a Linear issue → reflect status into Linear
+      // (no-op unless the live round-trip flag is set).
+      void linearLiveStatusServiceRef?.onAgentLaunched({
+        issue,
+        branchName: issue.branchName,
+        laneName: sessionTitle ?? null,
+      }).catch((error) => {
+        logger.warn("linear.live_status_launch_failed", {
+          laneId,
+          sessionId,
+          issueId: issue.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    };
 
     const lastHeadByLaneId = new Map<string, string>();
 
@@ -1897,6 +1943,7 @@ app.whenReady().then(async () => {
             });
           });
       },
+      onLinearIssueSessionLinked: publishLinearChatLink,
       teardownDeps: laneTeardownDeps,
       logger,
     });
@@ -2380,7 +2427,6 @@ app.whenReady().then(async () => {
       null;
     let orchestrationServiceRef: ReturnType<typeof createOrchestrationService> | null =
       null;
-    const linearChatCardPublishKeys = new Set<string>();
     const queueLandingService = createQueueLandingService({
       db,
       logger,
@@ -2758,44 +2804,7 @@ app.whenReady().then(async () => {
       logger,
       appVersion: app.getVersion(),
       getAdeCliAgentEnv: adeCliService.agentEnv,
-      onLinearIssueChatLinked: ({ laneId, sessionId, sessionTitle, issue, linkedAt }) => {
-        const tracker = linearIssueTrackerRef;
-        if (!tracker) return;
-        const key = `${issue.id}:${sessionId}`;
-        if (linearChatCardPublishKeys.has(key)) return;
-        linearChatCardPublishKeys.add(key);
-        void publishLinearChatSessionCard({
-          issueTracker: tracker,
-          issue,
-          laneId,
-          sessionId,
-          sessionTitle,
-          linkedAt,
-        }).catch((error) => {
-          linearChatCardPublishKeys.delete(key);
-          logger.warn("linear.chat_session_card_publish_failed", {
-            laneId,
-            sessionId,
-            issueId: issue.id,
-            issueIdentifier: issue.identifier,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        });
-        // Agent launched against a Linear issue → reflect status into Linear
-        // (no-op unless the live round-trip flag is set).
-        void linearLiveStatusServiceRef?.onAgentLaunched({
-          issue,
-          branchName: issue.branchName,
-          laneName: sessionTitle,
-        }).catch((error) => {
-          logger.warn("linear.live_status_launch_failed", {
-            laneId,
-            sessionId,
-            issueId: issue.id,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        });
-      },
+      onLinearIssueChatLinked: publishLinearChatLink,
       onEvent: (event) => {
         emitProjectEvent(projectRoot, IPC.agentChatEvent, event);
       },

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1773,25 +1773,26 @@ app.whenReady().then(async () => {
       const tracker = linearIssueTrackerRef;
       if (!tracker) return;
       const key = `${issue.id}:${sessionId}`;
-      if (linearChatCardPublishKeys.has(key)) return;
-      linearChatCardPublishKeys.add(key);
-      void publishLinearChatSessionCard({
-        issueTracker: tracker,
-        issue,
-        laneId,
-        sessionId,
-        sessionTitle,
-        linkedAt,
-      }).catch((error) => {
-        linearChatCardPublishKeys.delete(key);
-        logger.warn("linear.chat_session_card_publish_failed", {
+      if (!linearChatCardPublishKeys.has(key)) {
+        linearChatCardPublishKeys.add(key);
+        void publishLinearChatSessionCard({
+          issueTracker: tracker,
+          issue,
           laneId,
           sessionId,
-          issueId: issue.id,
-          issueIdentifier: issue.identifier,
-          error: error instanceof Error ? error.message : String(error),
+          sessionTitle,
+          linkedAt,
+        }).catch((error) => {
+          linearChatCardPublishKeys.delete(key);
+          logger.warn("linear.chat_session_card_publish_failed", {
+            laneId,
+            sessionId,
+            issueId: issue.id,
+            issueIdentifier: issue.identifier,
+            error: error instanceof Error ? error.message : String(error),
+          });
         });
-      });
+      }
       // Agent launched against a Linear issue → reflect status into Linear
       // (no-op unless the live round-trip flag is set).
       void linearLiveStatusServiceRef?.onAgentLaunched({

--- a/apps/desktop/src/main/services/adeActions/registry.test.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.test.ts
@@ -362,6 +362,7 @@ describe("runtime Linear issue tracker actions", () => {
       listUsers: vi.fn(async () => users),
       listLabels: vi.fn(async () => labels),
       listWorkflowStates: vi.fn(async () => states),
+      runGraphQL: vi.fn(async (args: unknown) => ({ data: args })),
     };
     const runtime = {
       linearCredentialService: {
@@ -379,15 +380,24 @@ describe("runtime Linear issue tracker actions", () => {
       getWorkflowCatalog: () => Promise<unknown>;
       getIssuePickerData: () => Promise<unknown>;
       listIssues: (args?: Record<string, unknown>) => Promise<unknown>;
+      graphql: (args?: Record<string, unknown>) => Promise<unknown>;
     } & Record<string, unknown>;
 
     expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("getStatus");
     expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("listIssues");
+    expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("graphql");
     expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("getWorkflowCatalog");
     expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("getIssuePickerData");
     await expect(service.getStatus()).resolves.toMatchObject({ connected: true, tokenStored: true });
     await expect(service.listIssues({ project: "desktop,cli", state: ["open"], limit: 2 })).resolves.toEqual(issues.slice(0, 2));
     expect(fetchCandidateIssues).toHaveBeenCalledWith({ projectSlugs: ["desktop", "cli"], stateTypes: ["open"] });
+    await expect(service.graphql({ query: "query Viewer { viewer { id } }", variables: { first: 1 } })).resolves.toEqual({
+      data: { query: "query Viewer { viewer { id } }", variables: { first: 1 } },
+    });
+    expect(tracker.runGraphQL).toHaveBeenCalledWith({
+      query: "query Viewer { viewer { id } }",
+      variables: { first: 1 },
+    });
     await expect(service.getWorkflowCatalog()).resolves.toEqual({ users, labels, states });
     await expect(service.getIssuePickerData()).resolves.toEqual({ projects, users, states });
   });

--- a/apps/desktop/src/main/services/adeActions/registry.test.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.test.ts
@@ -381,11 +381,13 @@ describe("runtime Linear issue tracker actions", () => {
       getIssuePickerData: () => Promise<unknown>;
       listIssues: (args?: Record<string, unknown>) => Promise<unknown>;
       graphql: (args?: Record<string, unknown>) => Promise<unknown>;
+      runGraphQL: (args?: Record<string, unknown>) => Promise<unknown>;
     } & Record<string, unknown>;
 
     expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("getStatus");
     expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("listIssues");
     expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("graphql");
+    expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("runGraphQL");
     expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("getWorkflowCatalog");
     expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("getIssuePickerData");
     await expect(service.getStatus()).resolves.toMatchObject({ connected: true, tokenStored: true });
@@ -397,6 +399,13 @@ describe("runtime Linear issue tracker actions", () => {
     expect(tracker.runGraphQL).toHaveBeenCalledWith({
       query: "query Viewer { viewer { id } }",
       variables: { first: 1 },
+    });
+    await expect(service.runGraphQL({ query: "query Viewer { viewer { id } }", variables: { first: 2 } })).resolves.toEqual({
+      data: { query: "query Viewer { viewer { id } }", variables: { first: 2 } },
+    });
+    expect(tracker.runGraphQL).toHaveBeenLastCalledWith({
+      query: "query Viewer { viewer { id } }",
+      variables: { first: 2 },
     });
     await expect(service.getWorkflowCatalog()).resolves.toEqual({ users, labels, states });
     await expect(service.getIssuePickerData()).resolves.toEqual({ projects, users, states });

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -597,6 +597,7 @@ export const ADE_ACTION_ALLOWLIST: Partial<Record<AdeActionDomain, readonly stri
     "fetchIssueById",
     "fetchIssuesByIds",
     "fetchIssueComments",
+    "graphql",
     "getIssuePickerData",
     "getConnectionStatus",
     "getQuickView",
@@ -608,6 +609,7 @@ export const ADE_ACTION_ALLOWLIST: Partial<Record<AdeActionDomain, readonly stri
     "listWorkflowStates",
     "listUsers",
     "removeIssueLabel",
+    "runGraphQL",
     "searchIssues",
     "updateComment",
     "updateIssueAssignee",
@@ -2471,6 +2473,12 @@ function buildLinearIssueTrackerDomainService(runtime: AdeRuntime): OpaqueServic
   if (!tracker) return null;
   return {
     ...(tracker as unknown as OpaqueService),
+    async graphql(args?: unknown) {
+      return tracker.runGraphQL(readLinearGraphQLActionArgs(args));
+    },
+    async runGraphQL(args?: unknown) {
+      return tracker.runGraphQL(readLinearGraphQLActionArgs(args));
+    },
     async getStatus() {
       return buildRuntimeLinearConnectionStatus(runtime);
     },
@@ -2520,6 +2528,34 @@ function buildLinearIssueTrackerDomainService(runtime: AdeRuntime): OpaqueServic
       ]);
       return { projects, users, states };
     },
+  };
+}
+
+function readLinearGraphQLActionArgs(args?: unknown): {
+  query: string;
+  variables?: Record<string, unknown>;
+  operationName?: string | null;
+  maxRetries?: number;
+} {
+  const actionArgs = asActionRecord(args);
+  const query = requireNonEmptyString(actionArgs.query, "query");
+  const variables = actionArgs.variables;
+  if (variables != null && !isRecord(variables)) {
+    throw new Error("Expected 'variables' to be a JSON object when provided.");
+  }
+  const operationName =
+    typeof actionArgs.operationName === "string" && actionArgs.operationName.trim().length
+      ? actionArgs.operationName.trim()
+      : null;
+  const maxRetries =
+    typeof actionArgs.maxRetries === "number" && Number.isFinite(actionArgs.maxRetries)
+      ? Math.max(0, Math.min(10, Math.floor(actionArgs.maxRetries)))
+      : undefined;
+  return {
+    query,
+    ...(variables ? { variables } : {}),
+    ...(operationName ? { operationName } : {}),
+    ...(maxRetries !== undefined ? { maxRetries } : {}),
   };
 }
 

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -1718,6 +1718,7 @@ describe("buildLinearSessionDirective", () => {
     expect(directive).toContain("ade linear");
     expect(directive).toContain("Prefer `ade linear`");
     expect(directive).toContain("ade-linear");
+    expect(directive).toContain("ade-deeplinks");
   });
 });
 
@@ -2071,6 +2072,7 @@ describe("createAgentChatService", () => {
       expect(appended).toContain("ADE-123");
       expect(appended).toContain("ade linear");
       expect(appended).toContain("Prefer `ade linear`");
+      expect(appended).toContain("ade-deeplinks");
     });
 
     it("keeps ADE tooling guidance out of Claude SDK user turns", async () => {
@@ -2415,6 +2417,7 @@ describe("createAgentChatService", () => {
       expect(opts?.systemPrompt?.append).toBeTruthy();
       expect(opts?.systemPrompt?.append).toContain("## Project slash commands and skills");
       expect(opts?.systemPrompt?.append).toContain("/ade-cli-control-plane");
+      expect(opts?.systemPrompt?.append).toContain("/ade-linear");
       expect(opts?.systemPrompt?.append).not.toContain("Commands (file-backed prompts):");
     });
 

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -3593,6 +3593,7 @@ export function buildLinearSessionDirective(
     "## Linear-tracked work",
     `This work is tracked by Linear issue(s) ${idList}. You have ADE's Linear connection — read and update them with the \`ade linear\` CLI (issue, comment, set-state, assign, label; run \`ade linear --help\` or see the bundled **ade-linear** skill for exact syntax).`,
     "Prefer `ade linear` over any Linear MCP or direct Linear API — those are not authenticated in this environment.",
+    "When you comment on Linear directly, include relevant ADE deeplinks unless ADE already posted a lane/chat/PR card; see the bundled **ade-deeplinks** skill.",
   ].join("\n");
 }
 

--- a/apps/desktop/src/main/services/cto/issueTracker.ts
+++ b/apps/desktop/src/main/services/cto/issueTracker.ts
@@ -70,6 +70,12 @@ export type IssueTrackerWorkflowState = {
 };
 
 export type IssueTracker = {
+  runGraphQL(args: {
+    query: string;
+    variables?: Record<string, unknown>;
+    operationName?: string | null;
+    maxRetries?: number;
+  }): Promise<unknown>;
   listProjects(): Promise<CtoLinearProject[]>;
   getQuickView(connection: CtoLinearQuickView["connection"]): Promise<CtoLinearQuickView>;
   listUsers(): Promise<LinearCatalogUser[]>;

--- a/apps/desktop/src/main/services/cto/linearClient.ts
+++ b/apps/desktop/src/main/services/cto/linearClient.ts
@@ -207,6 +207,7 @@ export function createLinearClient(args: LinearClientArgs) {
   const request = async <TData = Record<string, unknown>>(params: {
     query: string;
     variables?: Record<string, unknown>;
+    operationName?: string | null;
     maxRetries?: number;
   }): Promise<TData> => {
     // Proactively refresh an OAuth token that is at/near expiry before sending.
@@ -230,7 +231,11 @@ export function createLinearClient(args: LinearClientArgs) {
             "content-type": "application/json",
             authorization: token,
           },
-          body: JSON.stringify({ query: params.query, variables: params.variables ?? {} }),
+          body: JSON.stringify({
+            query: params.query,
+            variables: params.variables ?? {},
+            ...(params.operationName ? { operationName: params.operationName } : {}),
+          }),
         });
 
         const payload = await res.json().catch(() => ({})) as {
@@ -288,6 +293,20 @@ export function createLinearClient(args: LinearClientArgs) {
       id: asString(data.viewer?.id),
       name: asString(data.viewer?.displayName) ?? asString(data.viewer?.name),
     };
+  };
+
+  const runGraphQL = async (params: {
+    query: string;
+    variables?: Record<string, unknown>;
+    operationName?: string | null;
+    maxRetries?: number;
+  }): Promise<unknown> => {
+    return request({
+      query: params.query,
+      variables: params.variables,
+      operationName: params.operationName,
+      maxRetries: params.maxRetries,
+    });
   };
 
   const getConnectionIdentity = async (): Promise<{
@@ -1429,6 +1448,7 @@ export function createLinearClient(args: LinearClientArgs) {
 
   return {
     request,
+    runGraphQL,
     getViewer,
     getConnectionIdentity,
     listProjects,

--- a/apps/desktop/src/main/services/cto/linearIssueTracker.ts
+++ b/apps/desktop/src/main/services/cto/linearIssueTracker.ts
@@ -4,6 +4,10 @@ import { getErrorMessage } from "../shared/utils";
 
 export function createLinearIssueTracker(args: { client: LinearClient }): IssueTracker {
   return {
+    runGraphQL(params) {
+      return args.client.runGraphQL(params);
+    },
+
     listProjects() {
       return args.client.listProjects();
     },

--- a/apps/desktop/src/main/services/lanes/laneService.test.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.test.ts
@@ -203,12 +203,14 @@ describe("laneService createFromUnstaged", () => {
     const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
     await seedProjectAndStack(db, { projectId: "proj-linear-projectless", repoRoot });
 
+    const onLinearIssueLinked = vi.fn();
     const service = createLaneService({
       db,
       projectRoot: repoRoot,
       projectId: "proj-linear-projectless",
       defaultBaseRef: "main",
       worktreesDir: path.join(repoRoot, "worktrees"),
+      onLinearIssueLinked,
     });
 
     const issue = {
@@ -253,6 +255,10 @@ describe("laneService createFromUnstaged", () => {
         }),
       }),
     ]));
+    expect(onLinearIssueLinked).toHaveBeenCalledWith(expect.objectContaining({
+      lane: expect.objectContaining({ id: "lane-child" }),
+      issue: expect.objectContaining({ identifier: "ADE-45" }),
+    }));
   });
 
   it("moves unstaged and untracked changes into a new child lane", async () => {
@@ -4091,14 +4097,14 @@ describe("laneService - branchSwitch", () => {
 });
 
 describe("laneService session-scoped Linear issue links", () => {
-  function seedClaudeSession(db: any, args: { sessionId: string; laneId: string }) {
+  function seedClaudeSession(db: any, args: { sessionId: string; laneId: string; title?: string | null }) {
     const now = "2026-05-20T10:00:00.000Z";
     db.run(
       `
         insert into claude_sessions(session_id, lane_id, chat_session_id, title, tags_json, created_at, updated_at)
         values (?, ?, ?, ?, ?, ?, ?)
       `,
-      [args.sessionId, args.laneId, null, null, null, now, now],
+      [args.sessionId, args.laneId, null, args.title ?? null, null, now, now],
     );
   }
 
@@ -4177,13 +4183,17 @@ describe("laneService session-scoped Linear issue links", () => {
     const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
     try {
       await seedProjectAndStack(db, { projectId: "proj-session-laned", repoRoot });
-      seedClaudeSession(db, { sessionId: "chat-on-child", laneId: "lane-child" });
+      seedClaudeSession(db, { sessionId: "chat-on-child", laneId: "lane-child", title: "Fix flaky sync run" });
+      const onLinearIssueLinked = vi.fn();
+      const onLinearIssueSessionLinked = vi.fn();
       const service = createLaneService({
         db,
         projectRoot: repoRoot,
         projectId: "proj-session-laned",
         defaultBaseRef: "main",
         worktreesDir: path.join(repoRoot, "worktrees"),
+        onLinearIssueLinked,
+        onLinearIssueSessionLinked,
       });
 
       const links = service.attachLinearIssueToSession({
@@ -4206,6 +4216,16 @@ describe("laneService session-scoped Linear issue links", () => {
       const laneSessionLinks = service.listLinearIssuesForLaneSessions({ laneId: "lane-child" });
       expect(laneSessionLinks).toHaveLength(1);
       expect(laneSessionLinks[0]?.sessionId).toBe("chat-on-child");
+      expect(onLinearIssueLinked).toHaveBeenCalledWith(expect.objectContaining({
+        lane: expect.objectContaining({ id: "lane-child" }),
+        issue: expect.objectContaining({ identifier: "ABC-42" }),
+      }));
+      expect(onLinearIssueSessionLinked).toHaveBeenCalledWith(expect.objectContaining({
+        laneId: "lane-child",
+        sessionId: "chat-on-child",
+        sessionTitle: "Fix flaky sync run",
+        issue: expect.objectContaining({ identifier: "ABC-42" }),
+      }));
     } finally {
       db.close();
       fs.rmSync(repoRoot, { recursive: true, force: true });

--- a/apps/desktop/src/main/services/lanes/laneService.test.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.test.ts
@@ -4226,6 +4226,17 @@ describe("laneService session-scoped Linear issue links", () => {
         sessionTitle: "Fix flaky sync run",
         issue: expect.objectContaining({ identifier: "ABC-42" }),
       }));
+
+      onLinearIssueLinked.mockClear();
+      const mirroredAgain = service.linkLinearIssues({
+        laneId: "lane-child",
+        issues: [makeLinearIssue()],
+        role: "worked",
+        source: "chat_attach",
+        evidence: { chatSessionId: "chat-on-child" },
+      });
+      expect(mirroredAgain).toHaveLength(1);
+      expect(onLinearIssueLinked).not.toHaveBeenCalled();
     } finally {
       db.close();
       fs.rmSync(repoRoot, { recursive: true, force: true });

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -913,6 +913,7 @@ export function createLaneService({
   onDeleteEvent,
   onPlacementChanged,
   onLinearIssueLinked,
+  onLinearIssueSessionLinked,
   teardownDeps,
   macosVmHooks,
   logger: injectedLogger
@@ -928,6 +929,13 @@ export function createLaneService({
   onDeleteEvent?: (event: LaneDeleteEvent) => void;
   onPlacementChanged?: (event: LanePlacementChangedEvent) => void | Promise<void>;
   onLinearIssueLinked?: (args: { lane: LaneSummary; issue: LaneLinearIssue; linkedAt: string }) => void | Promise<void>;
+  onLinearIssueSessionLinked?: (args: {
+    laneId: string;
+    sessionId: string;
+    sessionTitle: string | null;
+    issue: LaneLinearIssue;
+    linkedAt: string;
+  }) => void | Promise<void>;
   teardownDeps?: LaneDeleteTeardownDeps;
   macosVmHooks?: LaneMacosVmHooks | null;
   logger?: Logger;
@@ -964,6 +972,32 @@ export function createLaneService({
     };
     try {
       const result = onLinearIssueLinked({ lane, issue, linkedAt: lane.createdAt });
+      if (result && typeof (result as Promise<void>).catch === "function") {
+        void (result as Promise<void>).catch(logFailure);
+      }
+    } catch (error) {
+      logFailure(error);
+    }
+  };
+
+  const notifyLinearIssueSessionLinked = (link: SessionLinearIssueLink): void => {
+    if (!onLinearIssueSessionLinked || !link.laneId) return;
+    const logFailure = (error: unknown): void => {
+      logger.warn("laneService.linear_issue_session_link_notify_failed", {
+        laneId: link.laneId,
+        sessionId: link.sessionId,
+        issueId: link.issue.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    };
+    try {
+      const result = onLinearIssueSessionLinked({
+        laneId: link.laneId,
+        sessionId: link.sessionId,
+        sessionTitle: resolveSessionTitle(link.sessionId),
+        issue: link.issue,
+        linkedAt: link.createdAt,
+      });
       if (result && typeof (result as Promise<void>).catch === "function") {
         void (result as Promise<void>).catch(logFailure);
       }
@@ -1175,6 +1209,48 @@ export function createLaneService({
     }
     return null;
   };
+
+  const resolveSessionTitle = (sessionId: string): string | null => {
+    const id = sessionId.trim();
+    if (!id) return null;
+    try {
+      const chat = db.get<{ title: string | null }>(
+        "select title from claude_sessions where session_id = ? limit 1",
+        [id],
+      );
+      if (chat?.title?.trim()) return chat.title.trim();
+    } catch {
+      // Fall through to terminal session lookup.
+    }
+    try {
+      const terminal = db.get<{ title: string | null }>(
+        "select title from terminal_sessions where id = ? limit 1",
+        [id],
+      );
+      if (terminal?.title?.trim()) return terminal.title.trim();
+    } catch {
+      // No title is fine; card builders fall back to the session id.
+    }
+    return null;
+  };
+
+  const laneSummaryForLinearNotification = (row: LaneRow): LaneSummary =>
+    toLaneSummary({
+      row,
+      status: {
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        remoteBehind: -1,
+        rebaseInProgress: false,
+      },
+      parentStatus: null,
+      childCount: 0,
+      stackDepth: 0,
+      activeBranchProfile: ensureBranchProfileForRow(row),
+      linearIssue: getLaneLinearIssue(row.id),
+      linearIssueLinks: getLaneLinearIssueLinks(row.id),
+    });
 
   const getSessionLinearIssueLinks = (sessionId: string): SessionLinearIssueLink[] => {
     const id = sessionId.trim();
@@ -2689,7 +2765,13 @@ export function createLaneService({
           evidence: args.evidence ?? null,
         }));
       }
-      if (links.length) invalidateLaneListCache();
+      if (links.length) {
+        invalidateLaneListCache();
+        const summary = laneSummaryForLinearNotification(row);
+        for (const link of links) {
+          notifyLinearIssueLinked(summary, link.issue);
+        }
+      }
       return links;
     },
 
@@ -2722,6 +2804,7 @@ export function createLaneService({
       const closeOnMerge = args.closeOnMerge ?? false;
       const evidence = args.evidence ?? { chatSessionId };
       const links: SessionLinearIssueLink[] = [];
+      const mirroredLaneLinks: LaneLinearIssueLink[] = [];
       const seen = new Set<string>();
       let mirrored = false;
       for (const issue of args.issues) {
@@ -2748,7 +2831,7 @@ export function createLaneService({
           try {
             const primary = getLaneLinearIssue(laneId);
             if (!primary || (primary.id !== normalized.id && primary.identifier !== normalized.identifier)) {
-              upsertLaneLinearIssueLink({
+              const laneLink = upsertLaneLinearIssueLink({
                 laneId,
                 issue: normalized,
                 role: role === "primary" ? "worked" : role,
@@ -2757,6 +2840,7 @@ export function createLaneService({
                 closeOnMerge,
                 evidence: { chatSessionId },
               });
+              mirroredLaneLinks.push(laneLink);
               mirrored = true;
             }
           } catch (error) {
@@ -2769,7 +2853,18 @@ export function createLaneService({
           }
         }
       }
-      if (mirrored) invalidateLaneListCache();
+      if (mirrored) {
+        invalidateLaneListCache();
+        if (laneRow) {
+          const summary = laneSummaryForLinearNotification(laneRow);
+          for (const link of mirroredLaneLinks) {
+            notifyLinearIssueLinked(summary, link.issue);
+          }
+        }
+      }
+      for (const link of links) {
+        notifyLinearIssueSessionLinked(link);
+      }
       return links;
     },
 

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -2767,9 +2767,11 @@ export function createLaneService({
       }
       if (links.length) {
         invalidateLaneListCache();
-        const summary = laneSummaryForLinearNotification(row);
-        for (const link of links) {
-          notifyLinearIssueLinked(summary, link.issue);
+        if ((args.source ?? "manual") !== "chat_attach") {
+          const summary = laneSummaryForLinearNotification(row);
+          for (const link of links) {
+            notifyLinearIssueLinked(summary, link.issue);
+          }
         }
       }
       return links;

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -961,6 +961,30 @@ export function createLaneService({
     }
   };
 
+  const resolveSessionTitle = (sessionId: string): string | null => {
+    const id = sessionId.trim();
+    if (!id) return null;
+    try {
+      const chat = db.get<{ title: string | null }>(
+        "select title from claude_sessions where session_id = ? limit 1",
+        [id],
+      );
+      if (chat?.title?.trim()) return chat.title.trim();
+    } catch {
+      // Fall through to terminal session lookup.
+    }
+    try {
+      const terminal = db.get<{ title: string | null }>(
+        "select title from terminal_sessions where id = ? limit 1",
+        [id],
+      );
+      if (terminal?.title?.trim()) return terminal.title.trim();
+    } catch {
+      // No title is fine; card builders fall back to the session id.
+    }
+    return null;
+  };
+
   const notifyLinearIssueLinked = (lane: LaneSummary, issue: LaneLinearIssue): void => {
     if (!onLinearIssueLinked) return;
     const logFailure = (error: unknown): void => {
@@ -1206,30 +1230,6 @@ export function createLaneService({
       if (terminal?.lane_id && getLaneRow(terminal.lane_id)) return terminal.lane_id;
     } catch {
       // terminal_sessions may be unavailable in some runtime modes.
-    }
-    return null;
-  };
-
-  const resolveSessionTitle = (sessionId: string): string | null => {
-    const id = sessionId.trim();
-    if (!id) return null;
-    try {
-      const chat = db.get<{ title: string | null }>(
-        "select title from claude_sessions where session_id = ? limit 1",
-        [id],
-      );
-      if (chat?.title?.trim()) return chat.title.trim();
-    } catch {
-      // Fall through to terminal session lookup.
-    }
-    try {
-      const terminal = db.get<{ title: string | null }>(
-        "select title from terminal_sessions where id = ? limit 1",
-        [id],
-      );
-      if (terminal?.title?.trim()) return terminal.title.trim();
-    } catch {
-      // No title is fine; card builders fall back to the session id.
     }
     return null;
   };

--- a/apps/desktop/src/shared/adeCliGuidance.ts
+++ b/apps/desktop/src/shared/adeCliGuidance.ts
@@ -7,6 +7,7 @@ export const adeBundledAgentSkills = [
   "ade-browser",
   "ade-pr-workflows",
   "ade-lanes-git",
+  "ade-linear",
   "ade-orchestrator",
   "ade-proof-artifacts",
   "ade-macos-vm",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Route `ade linear graphql` and `/linear graphql` through the runtime-owned Linear issue tracker so agents can use the saved project Linear OAuth/API key without receiving token material.
- Add deterministic Linear lane/chat card publishing for CLI-created lane links, session attachments, headless runtime lane cards, and `lanes create-from-linear --start-chat`.
- Promote and update the bundled `ade-linear` / `ade-deeplinks` skills so agents know when ADE posts cards automatically and when direct Linear actions should include ADE deeplinks in comments.
- Cover CLI planning, TUI routing, ADE action registry, RPC action execution, lane/session card hooks, and agent prompt guidance with tests.

### Testing
- `npm --prefix apps/ade-cli run test -- src/cli.test.ts src/tuiClient/__tests__/commands.test.ts src/adeRpcServer.test.ts`
- `npm --prefix apps/desktop run test -- src/main/services/lanes/laneService.test.ts src/main/services/chat/agentChatService.test.ts src/main/services/adeActions/registry.test.ts src/main/services/cto/linearLaneCardService.test.ts`
- `npm --prefix apps/desktop run test -- src/main/services/adeActions/registry.test.ts src/main/services/cto/linearAuth.test.ts`
- `npm --prefix apps/ade-cli run typecheck`
- `npm --prefix apps/desktop run typecheck`
- `npm --prefix apps/ade-cli run build`
- `npm --prefix apps/desktop run lint` (passes with existing warnings)
- `npm --prefix apps/desktop run build` (passes with existing Vite chunk-size warnings)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61fdb4e2-fec4-46d6-8409-d3543dba0819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61fdb4e2-fec4-46d6-8409-d3543dba0819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `ade linear graphql` command for executing GraphQL queries directly against Linear
  * Linear cards now automatically publish when issues are linked to lanes or chat sessions
  * Linear issues automatically attach to newly created chat sessions

* **Documentation**
  * Enhanced Linear skill documentation with GraphQL usage examples
  * Added guidance on including ADE deeplinks in Linear comments for better traceability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `ade linear graphql` / `/linear graphql` commands that proxy raw GraphQL through the runtime-owned Linear OAuth connection, wires deterministic Linear lane/chat card publishing to `laneService.onLinearIssueLinked` and `onLinearIssueSessionLinked` (headless and desktop), inserts an explicit `attachLinearIssueToSession` step into the `create-from-linear --start-chat` plan so the runtime posts chat cards, and promotes the `ade-linear` / `ade-deeplinks` skills to the bundled set.

- **GraphQL passthrough**: new `readLinearGraphQLArgs` / `parseGraphQLVariables` with full validation (inline, file, positional query; variables must be a JSON object; re-validated after `--arg-json` overrides); both CLI and TUI paths tested.
- **Lane/session card hooks**: `notifyLinearIssueLinked` wired into `linkLinearIssues` (guarded by `source !== \"chat_attach\"`) and `attachLinearIssueToSession` (for newly mirrored lane links); independent dedup sets prevent duplicate cards and duplicate `onAgentLaunched` calls.
- **Skill bundles & guidance**: `ade-linear` added to the bundled agent skills manifest on Mac, Windows, and the shared guidance list; both skill docs updated with GraphQL examples and the ADE-deeplinks matrix."

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the `linkedAt` timestamp passed to Linear lane card attachments.

The new `notifyLinearIssueLinked` call sites in both `linkLinearIssues` and `attachLinearIssueToSession` pass `lane.createdAt` as the `linkedAt` metadata written to Linear, instead of the actual link-creation timestamp. For new lanes this difference is negligible, but for issues linked to an existing lane the attachment in Linear will show the wrong date. The GraphQL passthrough, dedup guards, and skill bundles are well-structured and thoroughly tested.

apps/desktop/src/main/services/lanes/laneService.ts — the `notifyLinearIssueLinked` call sites should pass the link's own `createdAt` rather than relying on `lane.createdAt`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/lanes/laneService.ts | Adds `onLinearIssueSessionLinked` callback, `resolveSessionTitle`, `notifyLinearIssueSessionLinked`, and `laneSummaryForLinearNotification`; wires `notifyLinearIssueLinked` into `linkLinearIssues` and `attachLinearIssueToSession`. The new call sites use `lane.createdAt` as `linkedAt` instead of the link's own `createdAt`. |
| apps/desktop/src/main/main.ts | Refactors chat-session card publishing and live-status launch into a shared `publishLinearChatLink` closure with independent dedup sets for cards and for `onAgentLaunched`; subscribes it to both `laneService.onLinearIssueSessionLinked` and the existing `agentChatService.onLinearIssueChatLinked`. |
| apps/ade-cli/src/bootstrap.ts | Adds `onLinearIssueLinked` (lane cards) and `onLinearIssueSessionLinked` (session cards) subscribers to `laneService`; initialises `linearIssueTrackerRef` / `githubServiceRef` refs after `createHeadlessLinearServices` so callbacks safely guard via the refs. |
| apps/ade-cli/src/cli.ts | Adds `ade linear graphql` sub-command with `readLinearGraphQLArgs` (inline, file, and positional query; variables validation; post-override re-validation); inserts an `attachLinearIssueToSession` step into `create-from-linear --start-chat` plan. |
| apps/ade-cli/src/tuiClient/linearCommands.ts | Adds `/linear graphql` TUI routing with `parseGraphQLVariables` returning a typed result union; correctly surfaces parse errors back to the user and updates both usage strings to include `graphql`. |
| apps/desktop/src/main/services/adeActions/registry.ts | Exposes `graphql` and `runGraphQL` aliases in the `linear_issue_tracker` domain service and allowlist, both validated through `readLinearGraphQLActionArgs` before forwarding to `tracker.runGraphQL`. |
| apps/desktop/src/main/services/cto/linearClient.ts | Adds public `runGraphQL` wrapper and threads `operationName` through the existing `request` helper's JSON body. |
| apps/desktop/src/main/services/cto/issueTracker.ts | Adds `runGraphQL` to the `IssueTracker` interface, cleanly extending the contract for all implementors. |
| apps/desktop/src/main/services/chat/agentChatService.ts | Appends an `ade-deeplinks` skill reference to `buildLinearSessionDirective` so agents are guided to include ADE deeplinks in Linear comments. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as ade CLI / TUI
    participant RPC as ADE RPC Server
    participant Reg as Action Registry
    participant Tracker as LinearIssueTracker
    participant Linear as Linear API

    Note over CLI,Linear: ade linear graphql
    CLI->>RPC: "run_ade_action(linear_issue_tracker, graphql, {query, variables})"
    RPC->>Reg: dispatch(graphql, args)
    Reg->>Reg: readLinearGraphQLActionArgs(args)
    Reg->>Tracker: "runGraphQL({query, variables, operationName})"
    Tracker->>Linear: POST /graphql (Bearer token)
    Linear-->>Tracker: response data
    Tracker-->>CLI: result

    Note over CLI,Linear: create-from-linear --start-chat
    CLI->>RPC: Step 1 - create_lane (with Linear issue)
    RPC-->>CLI: "{laneId}"
    CLI->>RPC: Step 2 - chat createSession
    RPC-->>CLI: "{sessionId}"
    CLI->>RPC: "Step 3 - attachLinearIssueToSession(sessionId, issue, source=chat_attach)"
    RPC->>Tracker: onLinearIssueSessionLinked → publishLinearChatSessionCard
    Tracker->>Linear: create attachment (chat card)
    CLI->>RPC: Step 4 - send kickoff message
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/ade-cli/src/tuiClient/linearCommands.ts`, line 395-399 ([link](https://github.com/arul28/ade/blob/cbb020a0a11253bfdc3dcda0193c066a0442b946/apps/ade-cli/src/tuiClient/linearCommands.ts#L395-L399)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Silent variable drop on invalid `--variables-json`**

   `parseGraphQLVariables` swallows both JSON parse failures and non-object values, returning `undefined` without any diagnostic. A user who mistypes `'{first:10}'` (unquoted key) or passes an array `'[1,2]'` will silently get a request with no variables. The CLI path (`readLinearGraphQLArgs`) correctly throws a `CliUsageError` in both cases. The TUI path should give the same feedback so the author can fix the input instead of debugging a mysteriously missing parameter.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ade-cli/src/tuiClient/linearCommands.ts
   Line: 395-399

   Comment:
   **Silent variable drop on invalid `--variables-json`**

   `parseGraphQLVariables` swallows both JSON parse failures and non-object values, returning `undefined` without any diagnostic. A user who mistypes `'{first:10}'` (unquoted key) or passes an array `'[1,2]'` will silently get a request with no variables. The CLI path (`readLinearGraphQLArgs`) correctly throws a `CliUsageError` in both cases. The TUI path should give the same feedback so the author can fix the input instead of debugging a mysteriously missing parameter.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fade-cli%2Fsrc%2FtuiClient%2FlinearCommands.ts%0ALine%3A%20395-399%0A%0AComment%3A%0A**Silent%20variable%20drop%20on%20invalid%20%60--variables-json%60**%0A%0A%60parseGraphQLVariables%60%20swallows%20both%20JSON%20parse%20failures%20and%20non-object%20values%2C%20returning%20%60undefined%60%20without%20any%20diagnostic.%20A%20user%20who%20mistypes%20%60'%7Bfirst%3A10%7D'%60%20%28unquoted%20key%29%20or%20passes%20an%20array%20%60'%5B1%2C2%5D'%60%20will%20silently%20get%20a%20request%20with%20no%20variables.%20The%20CLI%20path%20%28%60readLinearGraphQLArgs%60%29%20correctly%20throws%20a%20%60CliUsageError%60%20in%20both%20cases.%20The%20TUI%20path%20should%20give%20the%20same%20feedback%20so%20the%20author%20can%20fix%20the%20input%20instead%20of%20debugging%20a%20mysteriously%20missing%20parameter.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=451&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `apps/ade-cli/src/tuiClient/linearCommands.ts`, line 428-431 ([link](https://github.com/arul28/ade/blob/cbb020a0a11253bfdc3dcda0193c066a0442b946/apps/ade-cli/src/tuiClient/linearCommands.ts#L428-L431)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The final fallthrough usage string was not updated when `graphql` was added, so a user who mistypes the subcommand gets a help message that omits the new command.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ade-cli/src/tuiClient/linearCommands.ts
   Line: 428-431

   Comment:
   The final fallthrough usage string was not updated when `graphql` was added, so a user who mistypes the subcommand gets a help message that omits the new command.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fade-cli%2Fsrc%2FtuiClient%2FlinearCommands.ts%0ALine%3A%20428-431%0A%0AComment%3A%0AThe%20final%20fallthrough%20usage%20string%20was%20not%20updated%20when%20%60graphql%60%20was%20added%2C%20so%20a%20user%20who%20mistypes%20the%20subcommand%20gets%20a%20help%20message%20that%20omits%20the%20new%20command.%0A%0A%60%60%60suggestion%0A%20%20return%20usage%28%0A%20%20%20%20%22Linear%22%2C%0A%20%20%20%20%22Usage%3A%20%2Flinear%20%3Cattach%7Cdetach%7Cissues%7Ccomment%7Cset-state%7Cassign%7Clabel%7Cissue%7Cgraphql%7Ccreate-from%7Cworkflows%7Crun%7Croute%7Csync%7Cingress%3E%20...%22%2C%0A%20%20%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=451&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Flanes%2FlaneService.ts%3A988-1004%0A**%60linkedAt%60%20uses%20lane%20creation%20date%2C%20not%20issue-link%20creation%20date**%0A%0A%60notifyLinearIssueLinked%60%20hard-codes%20%60lane.createdAt%60%20as%20the%20%60linkedAt%60%20value%20sent%20to%20%60onLinearIssueLinked%60%20%28and%20ultimately%20to%20%60publishLinearLaneCard%60%29.%20This%20is%20the%20lane's%20own%20creation%20timestamp%20%E2%80%94%20not%20when%20the%20Linear%20issue%20was%20actually%20linked.%20For%20the%20%60create-from-linear%60%20case%20both%20timestamps%20are%20nearly%20identical%2C%20but%20for%20%60ade%20lanes%20link-linear-issue%60%20%28or%20the%20mirror%20path%20in%20%60attachLinearIssueToSession%60%29%20applied%20to%20an%20existing%20lane%2C%20the%20card%20timestamp%20in%20Linear%20will%20be%20wrong%20by%20however%20old%20the%20lane%20is.%0A%0ABoth%20new%20call%20sites%20in%20this%20PR%20have%20the%20correct%20value%20available%20%28%60link.createdAt%60%20from%20the%20returned%20%60LaneLinearIssueLink%60%29%2C%20but%20the%20function%20signature%20doesn't%20accept%20it.%20Adding%20an%20optional%20third%20parameter%20%E2%80%94%20e.g.%20%60linkedAt%3F%3A%20string%60%20%E2%80%94%20and%20defaulting%20to%20%60lane.createdAt%60%20is%20a%20backwards-compatible%20fix%3B%20the%20call%20sites%20in%20this%20PR%20can%20then%20pass%20%60link.createdAt%60.%0A%0A&repo=arul28%2Fade&pr=451&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/main/services/lanes/laneService.ts:988-1004
**`linkedAt` uses lane creation date, not issue-link creation date**

`notifyLinearIssueLinked` hard-codes `lane.createdAt` as the `linkedAt` value sent to `onLinearIssueLinked` (and ultimately to `publishLinearLaneCard`). This is the lane's own creation timestamp — not when the Linear issue was actually linked. For the `create-from-linear` case both timestamps are nearly identical, but for `ade lanes link-linear-issue` (or the mirror path in `attachLinearIssueToSession`) applied to an existing lane, the card timestamp in Linear will be wrong by however old the lane is.

Both new call sites in this PR have the correct value available (`link.createdAt` from the returned `LaneLinearIssueLink`), but the function signature doesn't accept it. Adding an optional third parameter — e.g. `linkedAt?: string` — and defaulting to `lane.createdAt` is a backwards-compatible fix; the call sites in this PR can then pass `link.createdAt`.


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["ship: dedupe Linear live-status updates"](https://github.com/arul28/ade/commit/acc9ebe4087ea0956280e8db5e7ecf3357b8c635) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34769799)</sub>

<!-- /greptile_comment -->