### PR TITLE
ADE-84: iOS CTO/attention state accuracy: fabricated Heartbeat/MCP rows and a wake-up notice that never auto-dismisses

### DIFF
--- a/apps/ios/ADE/Views/Cto/CtoSettingsScreen.swift
+++ b/apps/ios/ADE/Views/Cto/CtoSettingsScreen.swift
@@ -81,17 +81,13 @@ struct CtoSettingsScreen: View {
     }
   }
 
-  // MARK: - Heartbeat (read-only placeholders)
+  // MARK: - Heartbeat
 
   private var heartbeatSection: some View {
     VStack(alignment: .leading, spacing: 6) {
       SectionHeader(title: "Heartbeat")
       VStack(spacing: 0) {
-        RowItem(label: "Mode", value: "Combined", disabled: true)
-        Sep()
-        RowItem(label: "Interval", value: "every 15 min", disabled: true)
-        Sep()
-        RowItem(label: "Event triggers", value: "—", disabled: true)
+        RowItem(label: "Policy", value: "Managed in ADE on your machine", disabled: true)
       }
       .adeListCard(padding: 0)
     }
@@ -229,7 +225,7 @@ struct CtoSettingsScreen: View {
           .accessibilityLabel("Sync Linear now")
         }
         Sep()
-        IntegrationRow(name: "External MCP", subtitle: "off", connected: false)
+        RowItem(label: "External MCP", value: "Managed in ADE", disabled: true)
       }
       .adeListCard(padding: 0)
     }

--- a/apps/ios/ADE/Views/Cto/CtoTeamScreen.swift
+++ b/apps/ios/ADE/Views/Cto/CtoTeamScreen.swift
@@ -16,6 +16,7 @@ struct CtoTeamScreen: View {
   @State private var showHireSheet = false
   @State private var pendingWakeup: Set<String> = []
   @State private var wakeupNotice: String?
+  @State private var wakeupNoticeGeneration = 0
   @State private var lastLiveReloadAt: Date?
 
   var body: some View {
@@ -101,8 +102,8 @@ struct CtoTeamScreen: View {
     .sheet(isPresented: $showHireSheet) {
       CtoWorkerHireSheet(existingAgents: displayAgents) { saved in
         showHireSheet = false
-        wakeupNotice = "Hired \(saved.name)."
         await load(force: true)
+        flashWakeupNotice("Hired \(saved.name).")
       }
       .environmentObject(syncService)
       .presentationDetents([.large])
@@ -304,6 +305,7 @@ struct CtoTeamScreen: View {
     if isLoading { return }
     if !force && !displayAgents.isEmpty { return }
     isLoading = true
+    clearWakeupNotice()
     defer { isLoading = false }
 
     async let agentsR = CtoTeamAsyncResult { try await syncService.fetchCtoAgents() }
@@ -380,10 +382,31 @@ struct CtoTeamScreen: View {
     defer { pendingWakeup.remove(agent.id) }
     do {
       _ = try await syncService.triggerAgentWakeup(agentId: agent.id)
-      wakeupNotice = "Woke \(agent.name)."
+      flashWakeupNotice("Woke \(agent.name).")
     } catch {
-      wakeupNotice = "Wake failed: \(error.localizedDescription)"
+      flashWakeupNotice("Wake failed: \(error.localizedDescription)")
     }
+  }
+
+  @MainActor
+  private func flashWakeupNotice(_ text: String) {
+    wakeupNoticeGeneration += 1
+    let generation = wakeupNoticeGeneration
+    withAnimation(.easeInOut(duration: 0.2)) { wakeupNotice = text }
+    Task {
+      try? await Task.sleep(nanoseconds: 4_000_000_000)
+      await MainActor.run {
+        guard wakeupNoticeGeneration == generation else { return }
+        withAnimation(.easeInOut(duration: 0.2)) { wakeupNotice = nil }
+      }
+    }
+  }
+
+  @MainActor
+  private func clearWakeupNotice() {
+    guard wakeupNotice != nil else { return }
+    wakeupNoticeGeneration += 1
+    withAnimation(.easeInOut(duration: 0.2)) { wakeupNotice = nil }
   }
 }
 

--- a/apps/ios/ADE/Views/Cto/CtoTeamScreen.swift
+++ b/apps/ios/ADE/Views/Cto/CtoTeamScreen.swift
@@ -395,10 +395,8 @@ struct CtoTeamScreen: View {
     withAnimation(.easeInOut(duration: 0.2)) { wakeupNotice = text }
     Task {
       try? await Task.sleep(nanoseconds: 4_000_000_000)
-      await MainActor.run {
-        guard wakeupNoticeGeneration == generation else { return }
-        withAnimation(.easeInOut(duration: 0.2)) { wakeupNotice = nil }
-      }
+      guard wakeupNoticeGeneration == generation else { return }
+      withAnimation(.easeInOut(duration: 0.2)) { wakeupNotice = nil }
     }
   }
 


### PR DESCRIPTION
Fixes ADE-84
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-84: iOS CTO/attention state accuracy: fabricated Heartbeat/MCP rows and a wake-up notice that never auto-dismisses](https://linear.app/ade-linear/issue/ADE-84/ios-ctoattention-state-accuracy-fabricated-heartbeatmcp-rows-and-a) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-84-ios-cto-attention-state-accuracy-fabricated-heartbeat-mcp-rows-and-a-wake-up-notice-that-never-auto-dismisses num=480 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-84-ios-cto-attention-state-accuracy-fabricated-heartbeat-mcp-rows-and-a-wake-up-notice-that-never-auto-dismisses&amp;pr=480">ade-84-ios-cto-attention-state-accuracy-fabricated-heartbeat-mcp-rows-and-a-wake-up-notice-that-never-auto-dismisses branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=480">PR #480</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notifications for wake-up and hire operations with enhanced concurrent update handling and automatic message dismissal functionality

* **UI/UX Improvements**
  * Simplified Heartbeat settings display to clearly show on-device policy management status
  * Enhanced External MCP integration view to clarify application-based management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses two accuracy problems in the iOS CTO view: fabricated read-only Heartbeat and External MCP rows that implied configuration details the iOS client cannot know, and a wake-up/hire notice that would display indefinitely because it was never cleared.

- **CtoSettingsScreen**: Replaces three fabricated Heartbeat rows (Mode, Interval, Event triggers) and a misleading `IntegrationRow` for External MCP with single honest "Managed in ADE on your machine" / "Managed in ADE" labels.
- **CtoTeamScreen**: Introduces a generation-counter (`wakeupNoticeGeneration`) and `flashWakeupNotice` / `clearWakeupNotice` helpers so notices auto-dismiss after 4 seconds, are superseded by newer notices, and are cleared at the start of every forced load.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are isolated to two UI files with no network, persistence, or auth side-effects.

The settings screen removes hardcoded placeholder rows and replaces them with honest read-only labels; no data flow is affected. The team screen's generation-counter pattern correctly handles rapid successive notices and ensures the auto-dismiss task never fires against a superseded notice. The ordering fix (flash after load) prevents clearWakeupNotice inside load from immediately erasing the hire confirmation. No regressions identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Views/Cto/CtoSettingsScreen.swift | Removes three fabricated Heartbeat rows and a misleading IntegrationRow; replaces them with honest read-only labels — straightforward and correct. |
| apps/ios/ADE/Views/Cto/CtoTeamScreen.swift | Adds generation-counter auto-dismiss for wakeup notices via flashWakeupNotice/clearWakeupNotice; hire callback now shows notice after load() to avoid it being cleared immediately — logic is sound. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CtoTeamScreen
    participant SyncService
    participant Timer as "Task.sleep (4 s)"

    User->>CtoTeamScreen: Tap "Wake" / confirm Hire
    CtoTeamScreen->>SyncService: triggerAgentWakeup / load(force:true)
    SyncService-->>CtoTeamScreen: success / failure
    CtoTeamScreen->>CtoTeamScreen: "flashWakeupNotice(text)<br/>wakeupNoticeGeneration += 1<br/>wakeupNotice = text"
    CtoTeamScreen->>Timer: Task.sleep(4s) [captures generation]
    Timer-->>CtoTeamScreen: wake up
    alt generation matches
        CtoTeamScreen->>CtoTeamScreen: "wakeupNotice = nil (animate out)"
    else newer notice shown
        CtoTeamScreen->>CtoTeamScreen: guard fails → no-op
    end

    User->>CtoTeamScreen: pull-to-refresh / live-reload
    CtoTeamScreen->>CtoTeamScreen: "clearWakeupNotice()<br/>wakeupNoticeGeneration += 1<br/>wakeupNotice = nil (animate out)"
```

<sub>Reviews (5): Last reviewed commit: ["Address CTO notice review cleanup"](https://github.com/arul28/ade/commit/99cc5899fc6064c0a8f9a8833fa4bc3fee3c0812) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34778222)</sub>

<!-- /greptile_comment -->