### PR TITLE
ADE-75: Automations & graph UX polish: false-warning Simulate, dead-end lane-required Run-now, reparent-undo double-click rollback order

### DIFF
--- a/apps/desktop/src/renderer/components/automations/RulesTab.tsx
+++ b/apps/desktop/src/renderer/components/automations/RulesTab.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   ArrowClockwise,
   BookOpen,
@@ -308,6 +309,7 @@ export function RulesTab({
   onDraftConsumed: () => void;
   onOpenTemplates: () => void;
 }) {
+  const navigate = useNavigate();
   const [detailView, setDetailView] = useState<DetailView>("editor");
   const [rules, setRules] = useState<AutomationRuleSummary[]>([]);
   const [lanes, setLanes] = useState<LaneSummary[]>([]);
@@ -315,6 +317,7 @@ export function RulesTab({
   const [selectedRuleId, setSelectedRuleId] = useState<string | null>(null);
   const [draft, setDraft] = useState<AutomationRuleDraft | null>(null);
   const [issues, setIssues] = useState<AutomationDraftIssue[]>([]);
+  const [simulationNotes, setSimulationNotes] = useState<string[]>([]);
   const [requiredConfirmations, setRequiredConfirmations] = useState<AutomationDraftConfirmationRequirement[]>([]);
   const [acceptedConfirmations, setAcceptedConfirmations] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState("");
@@ -346,6 +349,7 @@ export function RulesTab({
       try {
         setDraft(JSON.parse(savedSnapshotRef.current) as AutomationRuleDraft);
         setIssues([]);
+        setSimulationNotes([]);
       } catch {
         // Snapshot was malformed — leave the draft as-is rather than crashing.
       }
@@ -404,6 +408,7 @@ export function RulesTab({
     // isDirty stays false until the user edits.
     savedSnapshotRef.current = JSON.stringify(pendingDraft);
     setIssues([]);
+    setSimulationNotes([]);
     setRequiredConfirmations([]);
     setAcceptedConfirmations(new Set());
     onDraftConsumed();
@@ -417,9 +422,15 @@ export function RulesTab({
     setDraft(nextDraft);
     savedSnapshotRef.current = JSON.stringify(nextDraft);
     setIssues([]);
+    setSimulationNotes([]);
     setRequiredConfirmations([]);
     setAcceptedConfirmations(new Set());
   }, [rules, selectedRuleId]);
+
+  const updateDraft = useCallback((nextDraft: AutomationRuleDraft) => {
+    setSimulationNotes([]);
+    setDraft(nextDraft);
+  }, []);
 
   const filteredRules = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -452,6 +463,7 @@ export function RulesTab({
     setError(null);
     try {
       const validation = await validateDraft(draft);
+      setSimulationNotes([]);
       if (!validation.ok) return;
       const saved = await window.ade.automations.saveDraft({
         draft,
@@ -464,6 +476,7 @@ export function RulesTab({
       setDraft(nextDraft);
       savedSnapshotRef.current = JSON.stringify(nextDraft);
       setIssues([]);
+      setSimulationNotes([]);
     } catch (err) {
       setError(extractError(err));
     } finally {
@@ -475,17 +488,15 @@ export function RulesTab({
     if (!draft) return;
     setSimulating(true);
     setError(null);
+    setSimulationNotes([]);
     try {
       const result = await window.ade.automations.simulate({ draft });
+      const notes = result.notes.map((note) => note.trim()).filter(Boolean);
       setIssues(result.issues);
       if (!result.issues.length) {
-        setIssues([
-          {
-            level: "warning",
-            path: "simulate",
-            message: result.notes.join(" · ") || "Simulation completed with no blocking issues.",
-          },
-        ]);
+        setSimulationNotes(notes.length ? notes : ["Simulation completed with no blocking issues."]);
+      } else {
+        setSimulationNotes([]);
       }
     } catch (err) {
       setError(extractError(err));
@@ -501,6 +512,7 @@ export function RulesTab({
     setDraft(blank);
     savedSnapshotRef.current = JSON.stringify(blank);
     setIssues([]);
+    setSimulationNotes([]);
     setRequiredConfirmations([]);
     setAcceptedConfirmations(new Set());
     setDetailView("editor");
@@ -670,10 +682,11 @@ export function RulesTab({
           ) : draft ? (
             <RuleEditorPanel
               draft={draft}
-              setDraft={setDraft}
+              setDraft={updateDraft}
               lanes={lanes.map((lane) => ({ id: lane.id, name: lane.name }))}
               suites={suites}
               issues={issues}
+              simulationNotes={simulationNotes}
               requiredConfirmations={requiredConfirmations}
               acceptedConfirmations={acceptedConfirmations}
               onToggleConfirmation={(key, checked) => {
@@ -729,6 +742,7 @@ export function RulesTab({
               <select
                 className={inputCls}
                 value={manualRunLaneId}
+                disabled={!lanes.length}
                 onChange={(event) => setManualRunLaneId(event.target.value)}
               >
                 {lanes.map((lane) => (
@@ -740,7 +754,35 @@ export function RulesTab({
             </label>
             {!lanes.length ? (
               <div className="mt-3 rounded-md border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-200">
-                No active lanes are available for this automation run.
+                <div>No active lanes are available for this automation run.</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="primary"
+                    onClick={() => {
+                      setManualRunRule(null);
+                      setManualRunLaneId("");
+                      navigate("/lanes?action=create");
+                    }}
+                  >
+                    <Plus size={12} weight="regular" />
+                    Create lane
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      if (!confirmDiscardIfDirty()) return;
+                      setSelectedRuleId(manualRunRule.id);
+                      setDetailView("editor");
+                      setManualRunRule(null);
+                      setManualRunLaneId("");
+                    }}
+                  >
+                    <PencilSimple size={12} weight="regular" />
+                    Change lane mode
+                  </Button>
+                </div>
               </div>
             ) : null}
             <div className="mt-4 flex justify-end gap-2">

--- a/apps/desktop/src/renderer/components/automations/components/RuleEditorPanel.tsx
+++ b/apps/desktop/src/renderer/components/automations/components/RuleEditorPanel.tsx
@@ -569,6 +569,7 @@ export function RuleEditorPanel({
   lanes,
   suites,
   issues,
+  simulationNotes,
   requiredConfirmations,
   acceptedConfirmations,
   onToggleConfirmation,
@@ -582,6 +583,7 @@ export function RuleEditorPanel({
   lanes: Array<{ id: string; name: string }>;
   suites: TestSuiteDefinition[];
   issues: AutomationDraftIssue[];
+  simulationNotes?: string[];
   requiredConfirmations: AutomationDraftConfirmationRequirement[];
   acceptedConfirmations: Set<string>;
   onToggleConfirmation: (key: string, checked: boolean) => void;
@@ -737,6 +739,7 @@ export function RuleEditorPanel({
           <div className="flex flex-col gap-4">
             {errors.length ? <IssueList title="Errors" issues={errors} tone="error" /> : null}
             {warnings.length ? <IssueList title="Notes" issues={warnings} tone="warning" /> : null}
+            <SimulationNotes notes={simulationNotes ?? []} />
             <ConfirmationsChecklist
               required={requiredConfirmations}
               accepted={acceptedConfirmations}
@@ -1438,6 +1441,20 @@ function IssueList({
           <li key={`${issue.path}-${index}`}>
             <span className="font-mono text-[10px] text-fg/80">{issue.path}</span>: {issue.message}
           </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function SimulationNotes({ notes }: { notes: string[] }) {
+  if (!notes.length) return null;
+  return (
+    <div className="rounded-xl border border-emerald-500/25 bg-emerald-500/10 px-3 py-2 text-[11px] text-emerald-100">
+      <div className="font-semibold">Simulation complete</div>
+      <ul className="mt-1 space-y-0.5">
+        {notes.map((note, index) => (
+          <li key={`${note}-${index}`}>{note}</li>
         ))}
       </ul>
     </div>

--- a/apps/desktop/src/renderer/components/graph/WorkspaceGraphPage.tsx
+++ b/apps/desktop/src/renderer/components/graph/WorkspaceGraphPage.tsx
@@ -378,6 +378,8 @@ function GraphInner({ active = true }: { active?: boolean }) {
     message: string;
     undoAction: () => Promise<void>;
   } | null>(null);
+  const [undoToastBusy, setUndoToastBusy] = React.useState(false);
+  const undoToastPendingRef = React.useRef(false);
   const [activityScoreByLaneId, setActivityScoreByLaneId] = React.useState<Record<string, number>>({});
   const [activeSessionsByLaneId, setActiveSessionsByLaneId] = React.useState<Record<string, number>>({});
   const activeGraphSessionsRef = React.useRef(0);
@@ -2216,7 +2218,7 @@ function GraphInner({ active = true }: { active?: boolean }) {
         const result = await window.ade.lanes.reparent({ laneId, newParentLaneId: target.id });
         completed.push({ laneId, previousParentLaneId: result.previousParentLaneId });
       } catch (error) {
-        for (const rollback of completed.reverse()) {
+        for (const rollback of [...completed].reverse()) {
           if (!rollback.previousParentLaneId) continue;
           try {
             await window.ade.lanes.reparent({ laneId: rollback.laneId, newParentLaneId: rollback.previousParentLaneId });
@@ -2231,10 +2233,12 @@ function GraphInner({ active = true }: { active?: boolean }) {
       }
     }
 
+    undoToastPendingRef.current = false;
+    setUndoToastBusy(false);
     setUndoToast({
       message: `Reparented ${orderedLaneIds.length === 1 ? `'${laneById.get(orderedLaneIds[0]!)?.name ?? orderedLaneIds[0]}'` : `${orderedLaneIds.length} lanes`} under '${target.name}'`,
       undoAction: async () => {
-        for (const rollback of completed.reverse()) {
+        for (const rollback of [...completed].reverse()) {
           if (!rollback.previousParentLaneId) continue;
           await window.ade.lanes.reparent({ laneId: rollback.laneId, newParentLaneId: rollback.previousParentLaneId });
         }
@@ -4411,21 +4415,35 @@ function GraphInner({ active = true }: { active?: boolean }) {
         <div className="absolute bottom-3 right-3 z-[90] rounded bg-white/[0.03] backdrop-blur-xl px-3 py-2 text-xs shadow-float">
           <div className="mb-1">{undoToast.message}</div>
           <div className="flex justify-end gap-2">
-            <Button size="sm" variant="outline" className="h-6 px-2 text-[11px]" onClick={() => setUndoToast(null)}>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-6 px-2 text-[11px]"
+              disabled={undoToastBusy}
+              onClick={() => setUndoToast(null)}
+            >
               Close
             </Button>
             <Button
               size="sm"
               variant="primary"
               className="h-6 px-2 text-[11px]"
+              disabled={undoToastBusy}
               onClick={() => {
+                if (undoToastPendingRef.current) return;
+                undoToastPendingRef.current = true;
+                setUndoToastBusy(true);
                 void undoToast
                   .undoAction()
                   .catch((error) => setErrorBanner(error instanceof Error ? error.message : String(error)))
-                  .finally(() => setUndoToast(null));
+                  .finally(() => {
+                    undoToastPendingRef.current = false;
+                    setUndoToastBusy(false);
+                    setUndoToast(null);
+                  });
               }}
             >
-              Undo
+              {undoToastBusy ? "Undoing..." : "Undo"}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
Fixes ADE-75
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-75: Automations & graph UX polish: false-warning Simulate, dead-end lane-required Run-now, reparent-undo double-click rollback order](https://linear.app/ade-linear/issue/ADE-75/automations-and-graph-ux-polish-false-warning-simulate-dead-end-lane) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-75-automations-graph-ux-polish-false-warning-simulate-dead-end-lane-required-run-now-reparent-undo-double-click-rollback-order num=481 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-75-automations-graph-ux-polish-false-warning-simulate-dead-end-lane-required-run-now-reparent-undo-double-click-rollback-order&amp;pr=481">ade-75-automations-graph-ux-polish-false-warning-simulate-dead-end-lane-required-run-now-reparent-undo-double-click-rollback-order branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=481">PR #481</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses three distinct UX bugs in the automations and graph views. Simulation results that had no blocking issues were incorrectly surfaced as yellow warnings; they now render as a separate green `SimulationNotes` component. The manual-run dialog now handles the no-lanes dead-end with explicit "Create lane" and "Change lane mode" actions. The graph undo toast adds a busy-state guard and fixes an array-mutation bug in the reparent rollback path.

- **False-warning simulate fix**: a new `simulationNotes` state (cleared on every draft edit, save, or rule switch) separates informational simulation output from real `AutomationDraftIssue` warnings, eliminating the spurious yellow warning on a clean simulation run.
- **Dead-end Run-now fix**: when no lanes exist the select is disabled and two escape-hatch buttons are shown — one navigates to lane creation, the other returns the user to the rule editor to change the lane mode.
- **Reparent undo polish**: `[...completed].reverse()` replaces the in-place `completed.reverse()` so the closure array isn't mutated between calls; `undoToastBusy` + `undoToastPendingRef` prevent the undo action from firing twice on a double-click.

<h3>Confidence Score: 4/5</h3>

Changes are localised, well-scoped bug fixes with no data-loss paths; the one edge case (stale undo toast on rapid successive reparents) only loses a toast, not data.

All three fixes are straightforward and match the described symptoms. There is one theoretical race in WorkspaceGraphPage where a new reparent completing while an in-flight undo is running can cause the old `.finally()` to dismiss the new undo toast, but this requires unusually rapid concurrent interactions and results in a cosmetic loss rather than data corruption. The automations changes are clean with no logic issues.

WorkspaceGraphPage.tsx — specifically the `undoToastPendingRef` / `undoToastBusy` reset ordering around the new `setUndoToast` call.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/automations/RulesTab.tsx | Adds separate simulationNotes state so successful simulation results render as green info instead of yellow warnings; adds dead-end "no lanes" UX with navigate/change-lane-mode buttons; wraps setDraft in an updateDraft callback that clears notes on every draft edit. |
| apps/desktop/src/renderer/components/automations/components/RuleEditorPanel.tsx | Adds optional simulationNotes prop and new SimulationNotes component that renders an emerald-toned success card; no logic issues. |
| apps/desktop/src/renderer/components/graph/WorkspaceGraphPage.tsx | Fixes completed.reverse() mutation in both rollback paths; adds undoToastBusy + undoToastPendingRef double-click guard on the undo button; introduces a minor race if a new reparent completes while a previous undo action is still in-flight. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Simulate] --> B[window.ade.automations.simulate]
    B --> C{result.issues.length?}
    C -- "yes (blocking issues)" --> D[setIssues — shown as red/yellow IssueList]
    C -- "no" --> E[setSimulationNotes — shown as green SimulationNotes card]
    D --> F[Draft edited?]
    E --> F
    F -- yes --> G[updateDraft clears simulationNotes + issues]
    F -- no --> H[Notes/issues remain visible]

    subgraph Run-now dead-end
        R1[User clicks Run now] --> R2{lanes.length > 0?}
        R2 -- yes --> R3[User picks lane → runRuleNow]
        R2 -- no --> R4[Select disabled, error shown]
        R4 --> R5[Create lane → navigate /lanes?action=create]
        R4 --> R6[Change lane mode → open rule editor]
    end

    subgraph Reparent Undo
        U1[reparentCommit completes] --> U2[setUndoToast shown]
        U2 --> U3{User clicks Undo?}
        U3 -- double-click --> U4[undoToastPendingRef guards second call]
        U3 -- single click --> U5[undoAction runs with immutable completed snapshot]
        U5 --> U6[.finally → setUndoToast null]
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fgraph%2FWorkspaceGraphPage.tsx%3A2236-2238%0AStale%20undo%20toast%20cleared%20by%20an%20older%20in-flight%20undo%3A%20if%20a%20user%20clicks%20%22Undo%22%20%28sets%20%60undoToastPendingRef.current%20%3D%20true%60%29%20and%20a%20new%20reparent%20completes%20before%20the%20undo's%20%60.finally%28%29%60%20runs%2C%20%60undoToastPendingRef.current%20%3D%20false%60%20here%20resets%20the%20guard.%20The%20old%20%60.finally%28%29%60%20will%20then%20call%20%60setUndoToast%28null%29%60%2C%20silently%20dismissing%20the%20new%20toast%20and%20leaving%20the%20second%20reparent%20non-undoable.%20Resetting%20these%20flags%20only%20when%20the%20undo%20ref%20is%20not%20active%20avoids%20the%20interference.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28!undoToastPendingRef.current%29%20%7B%0A%20%20%20%20%20%20setUndoToastBusy%28false%29%3B%0A%20%20%20%20%7D%0A%20%20%20%20undoToastPendingRef.current%20%3D%20false%3B%0A%20%20%20%20setUndoToast%28%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fautomations%2FRulesTab.tsx%3A742-746%0AEmpty%20%60%3Cselect%3E%60%20with%20no%20fallback%20placeholder%20option%3A%20when%20%60lanes.length%20%3D%3D%3D%200%60%2C%20the%20%60%3Cselect%3E%60%20is%20disabled%20and%20renders%20zero%20%60%3Coption%3E%60%20elements.%20Most%20browsers%20leave%20the%20select%20control%20blank%20or%20empty%2C%20which%20looks%20broken%20before%20the%20user%20sees%20the%20red%20error%20message%20below.%20Adding%20a%20disabled%20placeholder%20option%20%28e.g.%20%22No%20lanes%20available%22%29%20would%20keep%20the%20control%20visually%20coherent.%0A%0A&repo=arul28%2Fade&pr=481&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src/renderer/components/graph/WorkspaceGraphPage.tsx:2236-2238
Stale undo toast cleared by an older in-flight undo: if a user clicks "Undo" (sets `undoToastPendingRef.current = true`) and a new reparent completes before the undo's `.finally()` runs, `undoToastPendingRef.current = false` here resets the guard. The old `.finally()` will then call `setUndoToast(null)`, silently dismissing the new toast and leaving the second reparent non-undoable. Resetting these flags only when the undo ref is not active avoids the interference.

```suggestion
    if (!undoToastPendingRef.current) {
      setUndoToastBusy(false);
    }
    undoToastPendingRef.current = false;
    setUndoToast({
```

### Issue 2 of 2
apps/desktop/src/renderer/components/automations/RulesTab.tsx:742-746
Empty `<select>` with no fallback placeholder option: when `lanes.length === 0`, the `<select>` is disabled and renders zero `<option>` elements. Most browsers leave the select control blank or empty, which looks broken before the user sees the red error message below. Adding a disabled placeholder option (e.g. "No lanes available") would keep the control visually coherent.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix automation run UX and graph undo"](https://github.com/arul28/ade/commit/1da34731432081f4d7bc9840b24fc640d1f6568c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34778681)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->