### PR TITLE
ADE-87: README + CONTRIBUTING + CHANGELOG launch-readiness: stale changelog/links, missing Droid/Windows, lane jargon, broken dev setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,128 +7,359 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.12] - 2026-05-06
+
+### Added
+
+- Broadened CLI agent support across cursor-agent, Factory Droid, and OpenCode, including model discovery, launch paths, transcript helpers, and tool-logo coverage.
+- Added Codex Fast Mode plumbing through the JSON-RPC service-tier surface and the `ade chat` CLI.
+- Expanded iOS connection-health presentation, Work session settings, simulator service coverage, and auto-update tests on the existing 1.1.10 TestFlight train.
+
+### Fixed
+
+- Tightened built-in browser UA spoofing, open-panel IPC logging, PTY ADE context env, localhost-link routing, Lanes page state handling, recent-project ordering, lane pack cleanup, and explicit Codex Fast Mode false handling.
+
+## [1.1.11] - 2026-05-04
+
+### Added
+
+- Added the Add Project flow for creating, cloning, and publishing projects from the command palette and top bar.
+- Added the built-in browser and resizable Work sidebar, replacing the old right-edge floating panes.
+- Added persistent Path-to-Merge automation, richer PR issue rows, and state-aware PR badging across desktop and iOS.
+
+### Fixed
+
+- Hardened browser inspect-state resets, drawer persistence, composer pending-input locking, PR refresh races, paste handling, renderer CSP coverage, iOS simulator helpers, and PTY resume scanning.
+
+## [1.1.10] - 2026-05-02
+
+### Added
+
+- Added shared desktop-to-mobile model catalog responses so iOS model choices come from the desktop catalog.
+- Added an `asc`-backed internal TestFlight build path for the iOS companion.
+
+### Fixed
+
+- Improved Cursor SDK model handling, provider status copy, simulator live-view packaging behavior, release artifact checks, and run session title sanitization.
+
+## [1.1.9] - 2026-05-01
+
+### Added
+
+- Added Cursor SDK-backed chat and the next TestFlight build for the iOS companion.
+
+### Fixed
+
+- Strengthened iOS Simulator control, run-tab failure reporting, and desktop-to-mobile sync durability.
+
+## [1.1.8] - 2026-04-30
+
+### Added
+
+- Added the Electron Viewer surface tying app control, sessions, and chat together.
+- Added the mobile models registry, including Droid grouping alongside Claude, Codex, and Cursor.
+
+### Changed
+
+- Shipped a broad desktop performance pass across main-process caching, renderer dedupe, IPC bridge cleanup, and lifecycle correctness.
+
+## [1.1.7] - 2026-04-29
+
+### Added
+
+- Added an in-chat iOS Simulator panel with auto-resolving visual stream.
+- Added full Factory Droid ACP chat support alongside Claude, Cursor SDK, and Codex.
+- Added Windows code-signing and sync parity foundations for the Windows desktop build.
+- Added lane branch switching, Live Activity and Lock Screen widget polish on iOS, and on-demand context doc generation in place of legacy context packs.
+
+## [1.1.6] - 2026-04-26
+
+### Added
+
+- Added first-class automation rule targeting with per-action overrides, explicit lane mode, and preset-to-template helpers.
+- Added explicit proof owner routing in the ADE CLI.
+
+### Fixed
+
+- Locked host-role sync state to avoid stale on-disk demotions, consolidated orchestrator/CTO/PR tests, and cleaned up stale iOS host keys.
+
+## [1.1.5] - 2026-04-25
+
+### Added
+
+- Added the two-way PTY bridge so iOS can drive a desktop shell.
+- Added bulk session select, archive, restore, and markdown export on desktop and iOS.
+- Added a one-shot `ade install` shell PATH setup and broader iOS lane/session parity.
+
+### Fixed
+
+- Recovered orphaned OpenCode listener ports, fixed mobile sync project-switch regressions, and corrected release publishing with explicit GitHub repo targeting.
+
+## [1.1.4] - 2026-04-24
+
+### Added
+
+- Added the multi-pass review engine with adjudicated findings, suppressions, tool evidence, inline diff excerpts, and a Learnings tab.
+- Added PR convergence rails on desktop and iOS, `/shipLane` orchestration, and session archive improvements.
+
+### Fixed
+
+- Fixed doubled assistant bubbles, reworked scroll anchoring, improved assistant thought collapse, and hardened Windows release validation plus mac/Windows asset expectations.
+
+## [1.1.3] - 2026-04-23
+
+### Added
+
+- Added the automations rewrite, URL-routed rebase and merge surface, parallel multi-model Work sessions, tiled Work panes, and Windows port foundations.
+- Added ADE CLI usability from a fresh `gh auth login` without duplicate credential setup.
+
+### Changed
+
+- Polished Files, Lanes, PRs, and Work on iOS and moved the iOS companion to TestFlight build 4.
+
+## [1.1.2] - 2026-04-22
+
+### Fixed
+
+- Fixed chat continuity across project switches, tab closes, and long idle gaps.
+- Improved orphan-lane sessions, sync and discovery cleanup, iOS Work timeline stability, privacy pages, and App Store review preparation.
+
+## [1.1.1] - 2026-04-22
+
+### Added
+
+- Prepared the iOS privacy page, web SPA rewrite, and Work transcript polish release.
+
+### Fixed
+
+- Polished the iOS launch surface and root header, including centered iOS app icon handling.
+
+## [1.1.0] - 2026-04-22
+
+### Added
+
+- Added Tailscale-based multi-device sync, dual-path iOS pairing, saved host routing, and a clearer sync status surface.
+- Added the onboarding tutorial system, simplified computer-use proof flow, Manage Lane dialog, iOS redesign, and updated README/architecture docs.
+
+### Fixed
+
+- Restored plaintext WebSocket trust boundaries, cleaned up provider permission merging, automation lane targeting, and rebase/review suggestion state.
+
+## [1.0.19] - 2026-04-21
+
+### Added
+
+- Added mobile push notifications through APNS, external MCP OAuth, auto-rebase suggestions, PR issue resolver, smart tooltips, and the diagnostics dashboard.
+- Added legacy Cursor integration and OpenCode runtime integration for managed AI backends.
+
+## [1.0.18] - 2026-04-14
+
+### Changed
+
+- Consolidated Lanes, Runs, and Run surfaces into fewer, denser screens.
+- Replaced the dedicated Project Home with the Run page, added Quick Run and stacked-run tabs, and moved per-turn file diffs into the chat transcript.
+- Batched renderer user-preference persistence and paused the event-loop watchdog while hidden.
+
+### Fixed
+
+- Tightened PTY service lifecycle, process registry behavior, agent chat service organization, CTO operator tools, OAuth redirect handling, and test stability.
+
+## [1.0.17] - 2026-04-11
+
+### Fixed
+
+- Reduced Work tab mount thrash, improved pane coordination, added cached renderer discovery for AI/model/project config state, and tightened file, git, main/preload, and error-boundary behavior.
+
 ## [1.0.16] - 2026-04-11
 
 ### Added
 
-- **OpenAI responses-based verification** — `authDetector` now verifies OpenAI keys via `POST /v1/responses` with `gpt-5-nano`/`gpt-5-mini` fallback, distinguishing model-availability errors from invalid keys; secondary model-list fallback check for resilience
-- **Scoped OpenCode tool selection** — `buildFallbackToolSelection`, `buildScopedMcpToolSelection`, and `resolveScopedMcpToolSelection` pipeline ensures sessions get exactly the tools matching current ADE CLI config; `refreshOpenCodeSessionToolSelection` called before every prompt
-- **Isolated OpenCode server launches** — `openCodeServerManager` builds XDG-style isolated launch specs via `child_process.spawn`, sanitizes inherited `OPENCODE_*` env, and resolves binary via `resolveOpenCodeBinaryPath`; new test hooks for launch spec verification
-- **ADE CLI schema sanitization** — `sanitizeToolSchema` recursively normalizes tool JSON Schemas (adds missing `items`/`properties`, ensures `required` completeness, recurses through `anyOf`/`oneOf`/`allOf`) to prevent strict-provider rejections
-- **Provider verification badges** — ProvidersSection shows verification badges, failure state indicators, and auto-refreshes OpenCode inventory on key changes
-
-### Changed
-
-- **OpenAI auth detection** — richer error classification separating invalid keys from model-unavailable errors
-- **Agent chat and coordinator** — both refresh OpenCode tool selection before dispatching prompts
-- **Provider Settings UI** — surfaces OpenCode runtime status; disables API/local model sections when binary is missing; clears verification state after saving
+- Added OpenAI responses-based verification, scoped OpenCode tool selection, isolated OpenCode server launches, ADE CLI schema sanitization, and provider verification badges.
 
 ### Fixed
 
-- **OpenCode key merging** — stored and project API keys now merge correctly (store keys loaded first, project keys overwrite) with safe require fallback
+- Improved OpenAI auth error classification, refreshed OpenCode tool selection before prompts, surfaced OpenCode runtime status in Settings, and fixed OpenCode key merging.
+
+## [1.0.15] - 2026-04-10
+
+### Added
+
+- Added terminal session management overhaul, terminal preferences, ADE CLI standalone chat, PR tab unification with auto bot detection, and sync host resilience.
+
+### Fixed
+
+- Improved file watcher behavior, PTY reattach and transcript resume, and session lifecycle reliability.
+
+## [1.0.14] - 2026-04-09
+
+### Added
+
+- Added a feedback reporter with diagnostics collection and ADE CLI server improvements.
+
+### Fixed
+
+- Polished chat UX and hardened OpenCode runtime behavior after the 1.0.13 architecture overhaul.
 
 ## [1.0.13] - 2026-04-07
 
 ### Added
 
-- **OpenCode runtime integration** — replaced the Vercel AI SDK unified executor with direct OpenCode server integration; all non-CLI providers (API-key, OpenRouter, local) now route through the OpenCode server via `@opencode-ai/sdk`
-- **OpenCode binary manager** — resolves OpenCode binary from user-installed PATH or bundled fallback, with process-lifetime caching (`openCodeBinaryManager.ts`)
-- **OpenCode model catalog** — dynamic model discovery from OpenCode CLI with verbose JSON parsing and plain-text fallback (`openCodeModelCatalog.ts`)
-- **OpenCode provider inventory** — probes connected providers and available models with shared server pooling, idle TTL, and deduped in-flight requests (`openCodeInventory.ts`)
-- **Provider task runner** — unified 306-line task runner dispatching to Claude, Codex, Cursor, and OpenCode paths with timeout enforcement and permission mode mapping (`providerTaskRunner.ts`)
-- **Tool exposure policy** — score-based heuristics for frontend repo discovery tool exposure based on prompt content analysis (`toolExposurePolicy.ts`)
-- **Runtime message types** — provider-agnostic message representation decoupling ADE internals from SDK types (`runtimeMessageTypes.ts`)
-- **CLI ADE CLI config normalization** — normalizes ADE CLI config between Claude (`type`) and Codex (`transport`) field formats (`cliMcpConfig.ts`)
-- **Local provider discovery pipeline** — endpoint probing, model inspection, capability inference, harness profile assignment, and TTL-based caching for Ollama and LM Studio
-- **900+ lines of new tool tests** — `globSearch.test.ts` (219 lines), `grepSearch.test.ts` (276 lines), `readFileRange.test.ts` (197 lines), expanded `universalTools.test.ts` (+364 lines)
-- **Compaction engine tests** — 526-line test suite covering transcript persistence, compaction triggering, and token accounting
-- **Local model discovery tests** — 486-line test suite covering endpoint probing, capability inference, and cache invalidation
+- Added direct OpenCode server integration, dynamic model discovery, local provider probing, provider task routing, CLI MCP config normalization, and expanded universal-tool tests.
 
 ### Changed
 
-- **Model registry** — `ProviderFamily` expanded with `"opencode"`; `ModelProviderGroup` changed from `"claude" | "codex" | "unified" | "cursor"` to `"claude" | "codex" | "opencode" | "cursor"`; new `openCodeProviderId` and `openCodeModelId` fields on `ModelDescriptor`
-- **AI integration service** — uses OpenCode inventory for runtime discovery; dynamic model descriptors replaced via `replaceDynamicOpenCodeModelDescriptors`
-- **Compaction engine** — uses `runOpenCodeTextPrompt` instead of the removed Vercel AI SDK path
-- **Agent chat service** — restructured runtime management per provider group (+2,284/-2,284 lines)
-- **Local model chat** — shared `LOCAL_PROVIDER_LABELS` helpers, merged CLI/local runtime banners, permission mode reset on harness profile change
-
-### Fixed
-
-- **Claude stream idle timeout** — removed entirely (was 75s, then 300s); long tool calls no longer risk timeout
-- **Session list cache cross-tab** — creating a session invalidates the cache in all windows
-- **Local model banner stacking** — CLI and local banners merged instead of stacking
+- Replaced the Vercel AI SDK unified executor with the OpenCode runtime for non-CLI providers.
 
 ### Removed
 
-- Vercel AI SDK packages (`@ai-sdk/anthropic`, `@ai-sdk/google`, `@ai-sdk/openai`, `ai`)
-- `providerResolver.ts`, `unifiedExecutor.ts`, `unifiedSessionProcessor.ts`, `middleware.ts`, `adeProviderRegistry.ts`, `tools/index.ts`, `verify-ai-sdks.cjs` and their test suites
+- Removed Vercel AI SDK packages and the deleted unified executor/provider resolver stack.
+
+## [1.0.12] - 2026-04-02
+
+### Added
+
+- Added the next round of release, desktop, and runtime refinements from the site changelog.
+
+### Fixed
+
+- Improved desktop reliability and test coverage after the 1.0.11 release train.
+
+## [1.0.11] - 2026-04-01
+
+### Added
+
+- Added Cursor as a first-class chat provider, cross-platform CLI executable resolution, and a large agent chat service expansion.
+
+### Changed
+
+- Shipped the largest release to date with 102 commits across 12 merged PRs.
+
+## [1.0.10] - 2026-03-30
+
+### Changed
+
+- Shipped the 1.0.10 release after skipping 1.0.9.
+
+### Fixed
+
+- Folded in follow-up desktop and release fixes from the site changelog.
+
+## [1.0.8] - 2026-03-26
+
+### Added
+
+- Added follow-up app, runtime, and docs improvements from the site changelog.
+
+### Fixed
+
+- Continued early release stabilization across desktop, sync, and tests.
+
+## [1.0.7] - 2026-03-25
+
+### Added
+
+- Added early post-launch desktop and runtime improvements from the site changelog.
+
+### Fixed
+
+- Continued fixing release-train issues found after the initial public launch.
+
+## [1.0.6] - 2026-03-24
+
+### Fixed
+
+- Incorporated all changes from unpublished v1.0.5 and fixed the macOS build path.
+
+## [1.0.5] - 2026-03-24
+
+### Fixed
+
+- Improved lane rebase targeting, PR merge status, cleanup behavior, runtime packaging, MCP binary launch, fallback refs, validation, accessibility, and toast UX.
+
+## [1.0.4] - 2026-03-24
+
+### Added
+
+- Added early Codex, chat, and desktop refinements from the site changelog.
+
+### Fixed
+
+- Fixed text batching across Codex service and renderer paths.
+
+## [1.0.3] - 2026-03-22
+
+### Added
+
+- Added early launch follow-ups from the site changelog.
+
+### Fixed
+
+- Improved first-week desktop and documentation stability.
 
 ## [1.0.2] - 2026-03-15
 
 ### Added
 
-- **Provider health pipeline** — five-module detection system (`authDetector`, `providerCredentialSources`, `providerConnectionStatus`, `providerRuntimeHealth`, `claudeRuntimeProbe`) replaces the single-pass provider check with granular CLI, credential, and runtime health detection
-- **CTO identity presets** — built-in personality presets for the CTO agent with one-click selection in the identity editor
-- **Budget cap editor** — inline budget cap editing in the automations UI
+- Added provider health pipeline, CTO identity presets, budget cap editor, local provider discovery tests, and expanded getting-started coverage.
 
 ### Changed
 
-- **Website overhaul** — complete rewrite of the landing page with accurate feature descriptions, screenshot placeholders, quick-start instructions, and links to docs/GitHub/releases; removed marketing fluff and false claims
-- **README** — docs, website, and download links moved to a prominent position after badges; consolidated redundant sections
-- **Documentation** — updated Mintlify docs and internal architecture docs to match current implementation; removed references to deleted services; fixed inaccurate feature descriptions
-- **Claude runtime probe** — cache is now scoped by project root to prevent cross-project contamination when switching projects
-- **Auth error detection** — deduplicated `isClaudeRuntimeAuthError` and `CLAUDE_RUNTIME_AUTH_ERROR` into a single shared module
-- **GitHub token migration** — added completion flag to skip redundant filesystem checks after first migration
-- **Derived context doc sync** — debounced context-doc writes to avoid write storms during rapid updates
-- **Automation run details** — fixed double DB lookup for ingress events in `getRunDetail`
-- **Chat session comment** — corrected stale "lazy boot" comment to reflect eager pre-warm behavior
-- **Docs site branding** — updated Mintlify config with correct logo paths and canonical URL
+- Reworked the website, README, docs, Claude runtime probe caching, Linear OAuth defaults, orchestrator tuning, and CI permissions.
 
 ### Removed
 
-- `automationRoutingService` (routing logic consolidated into `automationService`)
-- `NightShiftTab` (deprecated automation UI)
-- `PreviewPage` and `TestPage` (unused renderer pages)
-- `infra/` directory (SST cloud infrastructure — ADE is fully local-first)
+- Removed deprecated automation, preview/test, onboarding, settings, and legacy infra surfaces.
 
 ## [1.0.1] - 2026-03-14
 
 ### Added
 
-- **Multimodal chat** — Claude agent chat now supports image attachments via base64 content blocks, with a new file upload picker and clipboard paste support in the composer
-- **CTO daily logs** — CTO persona gains a context protocol and decision framework; daily log utilities (append/read/list) auto-inject recent context into CTO sessions
-- **ADE CLI auth service** — full OAuth and token-based authentication flows for connecting ADE CLI (795-line service with PKCE support)
-- **Onboarding rewrite** — replaced the 1,373-line `OnboardingPage` with a focused 328-line `ProjectSetupPage`
-- **New settings sections** — Lane Behavior, Lane Templates (expanded), Integrations, Workspace Settings, and AI Settings panels
-- **Context doc preferences** — model, effort, and events settings now persist to the backend via new IPC handlers
-- **Release workflow** — tag-triggered (`v*`) GitHub Actions workflow with a verification step ensuring tags point to `main`, concurrency control, and automated draft release creation
-- **Repo protections** — branch protection rulesets for `main` and release tags, `CODEOWNERS` file, and release notes template
-- **Run network panel** — new `RunNetworkPanel` component for the Run page
-- **Computer use panel** — new `ChatComputerUsePanel` for inline computer-use artifacts
-- **Vercel docs proxy** — `/docs` route now rewrites to the Mintlify-hosted documentation site
-- **Expanded getting-started guides** — broader first-run setup coverage
+- Added multimodal chat attachments, CTO daily logs, ADE CLI auth service, settings sections, context doc preferences, release workflow, CODEOWNERS, run network panel, computer-use panel, docs proxy, and onboarding rewrite.
 
 ### Changed
 
-- **Chat composer** — non-blocking async file handling, basename-only display in attachment tray, reworked prompt composition with identity re-injection after compaction
-- **Linear OAuth** — bundled public PKCE client-ID fallback so CTO Linear sync works without manual credential setup; fixed OAuth server to listen on port 19836 and force `prompt=consent`
-- **Orchestrator tuning** — lowered dedupe/retention/pruning thresholds, capped `workerProgressChatState`, pruned config cache, reduced session signal retention and health sweep intervals
-- **Main process** — simplified hardware acceleration logic, narrowed default background task flags in dev stability mode
-- **CI** — tightened permissions, removed old inline release job, added ADE CLI dependency install before desktop typecheck
-- **Homepage & web** — refreshed landing page layout and styles, updated Tailwind config
+- Improved chat composer file handling, Linear OAuth, orchestrator retention, main-process background flags, CI setup, and homepage/docs copy.
 
 ### Removed
 
-- `TerminalProfilesSection` and `TerminalSettingsDialog` (deprecated)
-- `GenerateDocsModal` (functionality moved into `ContextSection`)
-- `OnboardingPage` (replaced by `ProjectSetupPage`)
-- Legacy infra packages (Pulumi binaries, factory configs, scrutiny reviews)
+- Removed deprecated terminal settings, docs modal, legacy onboarding, and infra packages.
 
 ## [1.0.0] - 2026-03-13
 
-Initial public release.
+### Added
 
+- Initial public release.
+
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.1.12...HEAD
+[1.1.12]: https://github.com/arul28/ADE/compare/v1.1.11...v1.1.12
+[1.1.11]: https://github.com/arul28/ADE/compare/v1.1.10...v1.1.11
+[1.1.10]: https://github.com/arul28/ADE/compare/v1.1.9...v1.1.10
+[1.1.9]: https://github.com/arul28/ADE/compare/v1.1.8...v1.1.9
+[1.1.8]: https://github.com/arul28/ADE/compare/v1.1.7...v1.1.8
+[1.1.7]: https://github.com/arul28/ADE/compare/v1.1.6...v1.1.7
+[1.1.6]: https://github.com/arul28/ADE/compare/v1.1.5...v1.1.6
+[1.1.5]: https://github.com/arul28/ADE/compare/v1.1.4...v1.1.5
+[1.1.4]: https://github.com/arul28/ADE/compare/v1.1.3...v1.1.4
+[1.1.3]: https://github.com/arul28/ADE/compare/v1.1.2...v1.1.3
+[1.1.2]: https://github.com/arul28/ADE/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/arul28/ADE/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/arul28/ADE/compare/v1.0.19...v1.1.0
+[1.0.19]: https://github.com/arul28/ADE/compare/v1.0.18...v1.0.19
+[1.0.18]: https://github.com/arul28/ADE/compare/v1.0.17...v1.0.18
+[1.0.17]: https://github.com/arul28/ADE/compare/v1.0.16...v1.0.17
+[1.0.16]: https://github.com/arul28/ADE/compare/v1.0.15...v1.0.16
+[1.0.15]: https://github.com/arul28/ADE/compare/v1.0.14...v1.0.15
+[1.0.14]: https://github.com/arul28/ADE/compare/v1.0.13...v1.0.14
 [1.0.13]: https://github.com/arul28/ADE/compare/v1.0.12...v1.0.13
+[1.0.12]: https://github.com/arul28/ADE/compare/v1.0.11...v1.0.12
+[1.0.11]: https://github.com/arul28/ADE/compare/v1.0.10...v1.0.11
+[1.0.10]: https://github.com/arul28/ADE/compare/v1.0.8...v1.0.10
+[1.0.8]: https://github.com/arul28/ADE/compare/v1.0.7...v1.0.8
+[1.0.7]: https://github.com/arul28/ADE/compare/v1.0.6...v1.0.7
+[1.0.6]: https://github.com/arul28/ADE/compare/v1.0.5...v1.0.6
+[1.0.5]: https://github.com/arul28/ADE/compare/v1.0.4...v1.0.5
+[1.0.4]: https://github.com/arul28/ADE/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/arul28/ADE/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/arul28/ADE/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/arul28/ADE/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/arul28/ADE/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ UI work, see [apps/desktop/README.md](apps/desktop/README.md).
 - Run the smallest relevant checks for your change first
 - Desktop: `npm --prefix apps/desktop run typecheck`, targeted Vitest files, and `npm --prefix apps/desktop run lint` when touching renderer or main-process code
 - ADE CLI: `npm --prefix apps/ade-cli run typecheck` and `npm --prefix apps/ade-cli run test` when touching CLI/runtime code
-- Docs: `node scripts/validate-docs.mjs`
+- Docs: `node scripts/validate-docs.mjs` (fetch tags first if your clone is shallow)
 - TypeScript strict mode is enabled
 - Tests use Vitest
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,16 +4,28 @@ Pull requests are welcome from anyone. Only the maintainer (Arul) can merge or c
 
 ## Development Setup
 
+Install dependencies for each app from the repo root:
+
 ```bash
-cd apps/desktop
-npm install
+npm run setup
+```
+
+Start the normal desktop development flow from the repo root:
+
+```bash
 npm run dev
 ```
 
+This builds the ADE CLI, refreshes the shared dev runtime when needed, launches
+the Electron desktop app, and points desktop at that runtime. For renderer-only
+UI work, see [apps/desktop/README.md](apps/desktop/README.md).
+
 ## Before Submitting
 
-- Run `npm run typecheck` to check for type errors
-- Run `npm test` to ensure all tests pass
+- Run the smallest relevant checks for your change first
+- Desktop: `npm --prefix apps/desktop run typecheck`, targeted Vitest files, and `npm --prefix apps/desktop run lint` when touching renderer or main-process code
+- ADE CLI: `npm --prefix apps/ade-cli run typecheck` and `npm --prefix apps/ade-cli run test` when touching CLI/runtime code
+- Docs: `node scripts/validate-docs.mjs`
 - TypeScript strict mode is enabled
 - Tests use Vitest
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>A single native workspace for every AI coding agent.</strong><br />
-  <em>macOS, iOS, CLI — synced in real time.</em>
+  <em>macOS, Windows, iOS, CLI — synced in real time.</em>
 </p>
 
 <p align="center">
@@ -16,7 +16,7 @@
   &nbsp;·&nbsp;
   <a href="https://github.com/arul28/ADE/releases/latest"><strong>Download</strong></a>
   &nbsp;·&nbsp;
-  <a href="https://ade-app.dev/docs/changelog/v1.1.12"><strong>Changelog</strong></a>
+  <a href="https://www.ade-app.dev/docs/changelog"><strong>Changelog</strong></a>
 </p>
 
 <p align="center">
@@ -33,7 +33,7 @@
   <img src="assets/readme/hero-iphone.png" alt="ADE on iOS" width="180" />
 </p>
 
-ADE runs **Claude Code, Codex, Cursor, opencode** — every major AI coding agent — inside one native workspace. Claude runs through the bundled Claude Agent SDK, while desktop and `ade code` share the same lane-scoped chat runtime. Every task is its own git worktree, so agents ship features in parallel. Review and merge PRs in-app. Approve a diff from your phone while another agent tests on your Mac.
+ADE runs **Claude Code, Codex, Cursor, Factory Droid, OpenCode** — every major AI coding agent — inside one native workspace. Claude runs through the bundled Claude Agent SDK, while desktop and `ade code` share the same worktree-scoped chat runtime. Every task is its own git worktree, so agents ship features in parallel. Review and merge PRs in-app. Approve a diff from your phone while another agent tests on your Mac.
 
 Free, open source, local-first. Bring your own keys or subs.
 
@@ -56,7 +56,7 @@ Every task gets its own git worktree. Branch, edit, test, and commit side by sid
 <td width="45%" valign="middle">
 
 ### Every coding agent. One workspace.
-Claude Code, Codex, Cursor, opencode — pick whichever model fits the task. All run against the same worktree, with live diffs and approval gates.
+Claude Code, Codex, Cursor, Factory Droid, OpenCode — pick whichever model fits the task. All run against the same worktree, with live diffs and approval gates.
 
 </td>
 <td width="55%" valign="middle">
@@ -105,9 +105,19 @@ Plus files, terminals, git history, workspace graph, multi-tasking, Linear sync,
 
 ## Install
 
-Download the DMG from [**GitHub Releases**](https://github.com/arul28/ADE/releases/latest), drag **ADE.app** into `/Applications`, open it on any git repo, and add a provider key (or subscription) in Settings. Runs in Guest Mode without an account.
+Download ADE from [**GitHub Releases**](https://github.com/arul28/ADE/releases/latest), open it on any git repo, and add a provider key (or subscription) in Settings. Runs in Guest Mode without an account.
+
+### macOS
+
+Download the latest `.dmg`, drag **ADE.app** into `/Applications`, and open it.
 
 Requirements: macOS 13+, git on `PATH`, Node 22+ for headless CLI workflows.
+
+### Windows
+
+Download the latest Windows installer (`ADE-*-win-x64.exe`) from [**GitHub Releases**](https://github.com/arul28/ADE/releases/latest) and run it. Windows builds are published from the same release workflow as macOS and include the ADE runtime plus Windows auto-update metadata.
+
+Requirements: Windows x64, git on `PATH`, Node 22+ for headless CLI workflows.
 
 ## CLI
 
@@ -225,7 +235,7 @@ Validate with `npm --prefix apps/desktop run typecheck` and `npm run test:deskto
 
 ## Links
 
-[Quickstart](https://ade-app.dev/docs/quickstart) · [Key concepts](https://ade-app.dev/docs/key-concepts) · [Worktrees](https://ade-app.dev/docs/lanes/overview) · [Computer use](https://ade-app.dev/docs/computer-use/overview) · [Changelog](https://ade-app.dev/docs/changelog/v1.1.12) · [Contributing](CONTRIBUTING.md)
+[Quickstart](https://www.ade-app.dev/docs/quickstart) · [Key concepts](https://www.ade-app.dev/docs/key-concepts) · [Worktrees](https://www.ade-app.dev/docs/lanes/overview) · [Computer use](https://www.ade-app.dev/docs/computer-use/overview) · [Changelog](https://www.ade-app.dev/docs/changelog) · [Contributing](CONTRIBUTING.md)
 
 ## License
 

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -8,4 +8,3 @@ ADE release notes live here in newest-first order. Start with the latest release
 <Card title="Latest release" icon="tag" href="/changelog/v1.1.12">
   v1.1.12 - CLI agent support, Codex Fast Mode, browser and PTY context fixes, Lanes UI polish, and iOS connection-health updates.
 </Card>
-

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -1,0 +1,11 @@
+---
+title: "Changelog"
+description: "Latest ADE release notes and release history."
+---
+
+ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
+
+<Card title="Latest release" icon="tag" href="/changelog/v1.1.12">
+  v1.1.12 - CLI agent support, Codex Fast Mode, browser and PTY context fixes, Lanes UI polish, and iOS connection-health updates.
+</Card>
+

--- a/docs.json
+++ b/docs.json
@@ -198,6 +198,7 @@
             "icon": "tag",
             "expanded": true,
             "pages": [
+              "changelog",
               "changelog/v1.1.12",
               "changelog/v1.1.11",
               "changelog/v1.1.10",
@@ -273,7 +274,7 @@
         "items": [
           { "label": "Features", "href": "/lanes/overview" },
           { "label": "Download", "href": "https://github.com/arul28/ADE/releases" },
-          { "label": "Changelog", "href": "/changelog/v1.1.0" }
+          { "label": "Changelog", "href": "/changelog" }
         ]
       },
       {

--- a/index.mdx
+++ b/index.mdx
@@ -13,7 +13,7 @@ description: "Orchestrate parallel AI coding agents from a unified desktop contr
   <Card title="Settings & Config" icon="gear" href="/configuration/settings" color="#059669">
     AI providers, integrations, permissions, budgets, and project configuration.
   </Card>
-  <Card title="Changelog" icon="clock-rotate-left" href="/changelog/v1.1.0" color="#D97706">
+  <Card title="Changelog" icon="clock-rotate-left" href="/changelog" color="#D97706">
     What's new in ADE — latest features, improvements, and fixes.
   </Card>
 </CardGroup>

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -187,10 +187,15 @@ function compareSemver(a, b) {
 }
 
 function semverGitTags() {
-  const output = execFileSync("git", ["tag", "--list", "v[0-9]*.[0-9]*.[0-9]*"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-  });
+  let output;
+  try {
+    output = execFileSync("git", ["tag", "--list", "v[0-9]*.[0-9]*.[0-9]*"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+  } catch {
+    return null;
+  }
   return output
     .split(/\r?\n/)
     .map(parseSemverTag)
@@ -200,9 +205,19 @@ function semverGitTags() {
 
 async function validateReleaseDocs() {
   const gitTags = semverGitTags();
+  if (gitTags === null) {
+    errors.push("CHANGELOG.md: failed to read git tags; ensure git is installed and this is a git checkout");
+    return;
+  }
+
   const latestTag = gitTags.at(-1) ?? null;
   if (!latestTag) {
-    errors.push("CHANGELOG.md: no vX.Y.Z git tags found; fetch tags before validating release docs");
+    const message = "CHANGELOG.md: no vX.Y.Z git tags found; fetch tags before validating release docs";
+    if (process.env.CI) {
+      errors.push(message);
+    } else {
+      console.warn(`Documentation validation warning: ${message}`);
+    }
     return;
   }
 
@@ -231,6 +246,14 @@ async function validateReleaseDocs() {
 
   if (!(await targetExists({ absolute: `/changelog/${latestTag.raw}`, source: latestTag.raw, fromFile: "CHANGELOG.md" }))) {
     errors.push(`changelog/${latestTag.raw}.mdx: missing docs page for latest git tag ${latestTag.raw}`);
+  }
+
+  const changelogIndex = await fs.readFile(path.join(repoRoot, "changelog/index.mdx"), "utf8");
+  if (!changelogIndex.includes(`/changelog/${latestTag.raw}`)) {
+    errors.push(`changelog/index.mdx: latest release card must link to /changelog/${latestTag.raw}`);
+  }
+  if (!changelogIndex.includes(latestTag.raw)) {
+    errors.push(`changelog/index.mdx: latest release copy must mention ${latestTag.raw}`);
   }
 
   const readme = await fs.readFile(path.join(repoRoot, "README.md"), "utf8");

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -262,12 +262,20 @@ async function validateReleaseDocs() {
     errors.push(`changelog/index.mdx: latest release copy must mention ${latestTag.raw}`);
   }
 
-  const readme = await fs.readFile(path.join(repoRoot, "README.md"), "utf8");
+  let readme;
+  try {
+    readme = await fs.readFile(path.join(repoRoot, "README.md"), "utf8");
+  } catch {
+    errors.push("README.md: file is missing; add it before validating release docs");
+    return;
+  }
+
   const stableChangelogUrl = "https://www.ade-app.dev/docs/changelog";
-  if (!readme.includes(stableChangelogUrl)) {
+  const stableChangelogUrlPattern = /https:\/\/www\.ade-app\.dev\/docs\/changelog\/?(?=$|[\s)"'#?])/;
+  if (!stableChangelogUrlPattern.test(readme)) {
     errors.push(`README.md: missing stable changelog link ${stableChangelogUrl}`);
   }
-  if (/https:\/\/www\.ade-app\.dev\/docs\/changelog\/v\d+\.\d+\.\d+/.test(readme)) {
+  if (/https:\/\/(?:www\.)?ade-app\.dev\/docs\/changelog\/v\d+\.\d+\.\d+(?=$|[/?#)"'\s])/.test(readme)) {
     errors.push("README.md: changelog links must use /docs/changelog, not a version-pinned release page");
   }
 }

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -48,7 +49,11 @@ const routeSet = new Set(
     .filter((file) => file.endsWith(".mdx"))
     .map((file) => {
       const withoutExtension = file.replace(/\.mdx$/, "");
-      return withoutExtension === "index" ? "/" : `/${withoutExtension}`;
+      if (withoutExtension === "index") return "/";
+      if (withoutExtension.endsWith("/index")) {
+        return `/${withoutExtension.slice(0, -"/index".length)}`;
+      }
+      return `/${withoutExtension}`;
     })
 );
 
@@ -162,6 +167,83 @@ for (const file of docFiles) {
     }
   }
 }
+
+function parseSemverTag(tag) {
+  const match = /^v(\d+)\.(\d+)\.(\d+)$/.exec(tag.trim());
+  if (!match) return null;
+  return {
+    raw: tag.trim(),
+    version: `${match[1]}.${match[2]}.${match[3]}`,
+    parts: match.slice(1).map(Number),
+  };
+}
+
+function compareSemver(a, b) {
+  for (let index = 0; index < 3; index += 1) {
+    const diff = a.parts[index] - b.parts[index];
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+function semverGitTags() {
+  const output = execFileSync("git", ["tag", "--list", "v[0-9]*.[0-9]*.[0-9]*"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  return output
+    .split(/\r?\n/)
+    .map(parseSemverTag)
+    .filter(Boolean)
+    .sort(compareSemver);
+}
+
+async function validateReleaseDocs() {
+  const gitTags = semverGitTags();
+  const latestTag = gitTags.at(-1) ?? null;
+  if (!latestTag) {
+    errors.push("CHANGELOG.md: no vX.Y.Z git tags found; fetch tags before validating release docs");
+    return;
+  }
+
+  const changelog = await fs.readFile(path.join(repoRoot, "CHANGELOG.md"), "utf8");
+  const topVersion = changelog.match(/^## \[(\d+\.\d+\.\d+)\]/m)?.[1];
+  if (!topVersion) {
+    errors.push("CHANGELOG.md: missing a released ## [x.y.z] heading after Unreleased");
+  } else if (topVersion !== latestTag.version) {
+    errors.push(`CHANGELOG.md: top release ${topVersion} does not match latest git tag ${latestTag.raw}`);
+  }
+
+  const linkRefs = new Set([...changelog.matchAll(/^\[([^\]]+)\]:\s+\S+/gm)].map((match) => match[1]));
+  const releaseHeadings = new Set();
+  for (const match of changelog.matchAll(/^## \[([^\]]+)\]/gm)) {
+    const heading = match[1];
+    releaseHeadings.add(heading);
+    if (!linkRefs.has(heading)) {
+      errors.push(`CHANGELOG.md: missing link reference for [${heading}]`);
+    }
+  }
+  for (const tag of gitTags) {
+    if (!releaseHeadings.has(tag.version)) {
+      errors.push(`CHANGELOG.md: missing release heading for git tag ${tag.raw}`);
+    }
+  }
+
+  if (!(await targetExists({ absolute: `/changelog/${latestTag.raw}`, source: latestTag.raw, fromFile: "CHANGELOG.md" }))) {
+    errors.push(`changelog/${latestTag.raw}.mdx: missing docs page for latest git tag ${latestTag.raw}`);
+  }
+
+  const readme = await fs.readFile(path.join(repoRoot, "README.md"), "utf8");
+  const stableChangelogUrl = "https://www.ade-app.dev/docs/changelog";
+  if (!readme.includes(stableChangelogUrl)) {
+    errors.push(`README.md: missing stable changelog link ${stableChangelogUrl}`);
+  }
+  if (/https:\/\/www\.ade-app\.dev\/docs\/changelog\/v\d+\.\d+\.\d+/.test(readme)) {
+    errors.push("README.md: changelog links must use /docs/changelog, not a version-pinned release page");
+  }
+}
+
+await validateReleaseDocs();
 
 if (errors.length > 0) {
   console.error("Documentation validation failed:");

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -248,7 +248,13 @@ async function validateReleaseDocs() {
     errors.push(`changelog/${latestTag.raw}.mdx: missing docs page for latest git tag ${latestTag.raw}`);
   }
 
-  const changelogIndex = await fs.readFile(path.join(repoRoot, "changelog/index.mdx"), "utf8");
+  let changelogIndex;
+  try {
+    changelogIndex = await fs.readFile(path.join(repoRoot, "changelog/index.mdx"), "utf8");
+  } catch {
+    errors.push("changelog/index.mdx: file is missing; create it with a latest-release Card");
+    return;
+  }
   if (!changelogIndex.includes(`/changelog/${latestTag.raw}`)) {
     errors.push(`changelog/index.mdx: latest release card must link to /changelog/${latestTag.raw}`);
   }


### PR DESCRIPTION
Fixes ADE-87
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-87: README + CONTRIBUTING + CHANGELOG launch-readiness: stale changelog/links, missing Droid/Windows, lane jargon, broken dev setup](https://linear.app/ade-linear/issue/ADE-87/readme-contributing-changelog-launch-readiness-stale-changeloglinks) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-87-readme-contributing-changelog-launch-readiness-stale-changelog-links-missing-droid-windows-lane-jargon-broken-dev-setup num=482 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-87-readme-contributing-changelog-launch-readiness-stale-changelog-links-missing-droid-windows-lane-jargon-broken-dev-setup&amp;pr=482">ade-87-readme-contributing-changelog-launch-readiness-stale-changelog-links-missing-droid-windows-lane-jargon-broken-dev-setup branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=482">PR #482</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded release documentation validation system to comprehensively cross-check semantic version tags against changelog entries, release documentation pages, and readme files, ensuring consistency and completeness of all release information across documentation sources.
  * Enhanced continuous integration pipeline configuration to retrieve and maintain complete repository history during automated validation, enabling thorough verification of documentation structure, release information accuracy, and documentation requirements throughout the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes launch-readiness gaps across `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and the Mintlify docs site by backfilling missing changelog entries, replacing stale version-pinned links with stable URLs, adding Windows install instructions, and introducing a new `validateReleaseDocs()` script that cross-checks semver git tags against all documentation sources on every CI run.

- **`scripts/validate-docs.mjs`**: Adds `validateReleaseDocs()` — reads semver git tags via `execFileSync`, verifies the top CHANGELOG entry matches the latest tag, checks that every tag has a CHANGELOG heading and link reference, confirms a docs page exists for the latest tag, and validates that `changelog/index.mdx` and `README.md` reference the stable changelog URL. The CI checkout step gains `fetch-depth: 0` so tag history is available.
- **`CHANGELOG.md`**: Backfills all missing entries from v1.0.12 through v1.1.12 with condensed summaries and adds the full set of link references at the bottom.
- **`README.md` / `CONTRIBUTING.md` / `docs.json` / `index.mdx` / `changelog/index.mdx`**: Adds Windows platform support, replaces version-pinned changelog links with `/docs/changelog`, and fixes the broken dev-setup commands.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the one real defect is confined to an edge case in the new validation script and does not affect production code.

The validateReleaseDocs() function introduced in this PR reads CHANGELOG.md without a try/catch, unlike changelog/index.mdx and README.md which are both guarded in the same function. If CHANGELOG.md were ever absent, the script would abort with an uncaught ENOENT instead of appending a structured error and continuing.

scripts/validate-docs.mjs — the CHANGELOG.md file read inside validateReleaseDocs() lacks the try/catch guard used for the other two file reads in the same function.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/validate-docs.mjs | New validateReleaseDocs() function cross-checks semver git tags against CHANGELOG, docs pages, changelog/index.mdx, and README; CHANGELOG.md is read without a try/catch unlike the two other file reads in the same function. |
| .github/workflows/ci.yml | Adds fetch-depth: 0 and persist-credentials: false to the validate-docs checkout step so the new git-tag-based validation has complete tag history available. |
| CHANGELOG.md | Backfills all missing version entries from v1.0.12 to v1.1.12, condenses verbose bullet points into shorter summaries, and adds the complete set of link reference definitions at the bottom. |
| CONTRIBUTING.md | Replaces stale cd apps/desktop && npm install with npm run setup and npm run dev from repo root; updates before-submitting checklist with per-package typecheck/test commands. |
| README.md | Adds Windows platform mention and install section, replaces version-pinned changelog links with stable /docs/changelog URL, and adds Factory Droid to the agent list. |
| changelog/index.mdx | New changelog landing page with a Card pointing to v1.1.12; the new validateReleaseDocs() check now guards this file against going stale. |
| docs.json | Adds changelog index page to navigation and updates the footer Changelog link from version-pinned to stable /changelog route. |
| index.mdx | Updates the homepage Changelog card href from version-pinned /changelog/v1.1.0 to the stable /changelog index. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CI: validate-docs job] -->|fetch-depth: 0| B[checkout full history]
    B --> C[node scripts/validate-docs.mjs]
    C --> D[walkDocs — build routeSet]
    D --> E[validate docs.json links]
    E --> F[validate mdx links]
    F --> G[semverGitTags via git tag --list]
    G -->|null — git failed| H[errors.push structured message]
    G -->|empty — no tags| I{CI?}
    I -->|yes| H
    I -->|no| J[console.warn only]
    G -->|tags found| K[readFile CHANGELOG.md]
    K -->|top version != latest tag| H
    K --> L[check all headings have link refs]
    L --> H
    K --> M[check all git tags in headings]
    M --> H
    K --> N[targetExists changelog/latestTag.raw]
    N -->|missing| H
    N --> O[readFile changelog/index.mdx]
    O -->|missing| H
    O --> P{contains /changelog/latestTag?}
    P -->|no| H
    P --> Q[readFile README.md]
    Q -->|missing| H
    Q --> R{stable changelog URL present?}
    R -->|no| H
    R --> S{version-pinned link found?}
    S -->|yes| H
    S --> T[errors.length == 0 — pass]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fvalidate-docs.mjs%3A224%0A**Unguarded%20%60CHANGELOG.md%60%20read%20crashes%20script%20instead%20of%20reporting%20a%20structured%20error**%0A%0AThe%20%60fs.readFile%60%20call%20for%20%60CHANGELOG.md%60%20has%20no%20%60try%2Fcatch%60%2C%20unlike%20the%20two%20reads%20immediately%20below%20it%20%E2%80%94%20%60changelog%2Findex.mdx%60%20%28lines%20252-257%29%20and%20%60README.md%60%20%28lines%20266-271%29%20%E2%80%94%20which%20are%20both%20wrapped.%20If%20%60CHANGELOG.md%60%20is%20ever%20missing%20or%20unreadable%2C%20this%20line%20throws%20an%20uncaught%20ENOENT%20that%20aborts%20the%20whole%20process%20with%20a%20raw%20stack%20trace%20instead%20of%20pushing%20a%20structured%20message%20to%20%60errors%5B%5D%60%20and%20continuing.%20The%20fix%20is%20the%20same%20pattern%20used%20for%20the%20other%20two%20files.%0A%0A&repo=arul28%2Fade&pr=482&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/validate-docs.mjs:224
**Unguarded `CHANGELOG.md` read crashes script instead of reporting a structured error**

The `fs.readFile` call for `CHANGELOG.md` has no `try/catch`, unlike the two reads immediately below it — `changelog/index.mdx` (lines 252-257) and `README.md` (lines 266-271) — which are both wrapped. If `CHANGELOG.md` is ever missing or unreadable, this line throws an uncaught ENOENT that aborts the whole process with a raw stack trace instead of pushing a structured message to `errors[]` and continuing. The fix is the same pattern used for the other two files.

`````

</details>

<sub>Reviews (8): Last reviewed commit: ["Address docs validation review hardening"](https://github.com/arul28/ade/commit/405807aa707403d947491a1b18a00bc22eb7202d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34778860)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->