### PR TITLE
ADE-82: Fix CLI registry and browser bridge hot paths

### DIFF
--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -109,8 +109,8 @@ import { createMacosVmService } from "../../desktop/src/main/services/macosVm/ma
 import type { BuiltInBrowserService } from "../../desktop/src/main/services/builtInBrowser/builtInBrowserService";
 import {
   createBuiltInBrowserDesktopBridgeClient,
-  type BuiltInBrowserDesktopBridgeClient,
 } from "./services/builtInBrowser/desktopBridgeClient";
+import type { BuiltInBrowserDesktopBridgeClient } from "./services/builtInBrowser/desktopBridgeMethods";
 import { resolveMachineAdeLayout } from "./services/projects/machineLayout";
 import type { createFileService } from "../../desktop/src/main/services/files/fileService";
 import type { AppNavigationRequest, AppNavigationResult, PortLease } from "../../desktop/src/shared/types";
@@ -225,7 +225,7 @@ export type AdeRuntime = {
   computerUseArtifactBrokerService: ComputerUseArtifactBrokerService;
   iosSimulatorService?: IosSimulatorService | null;
   appControlService?: AppControlService | null;
-  builtInBrowserService?: BuiltInBrowserService | null;
+  builtInBrowserService?: BuiltInBrowserService | BuiltInBrowserDesktopBridgeClient | null;
   macosVmService?: ReturnType<typeof createMacosVmService> | null;
   syncHostService?: ReturnType<typeof createSyncHostService> | null;
   syncService?: ReturnType<typeof createSyncService> | null;
@@ -1204,7 +1204,7 @@ export async function createAdeRuntime(args: {
     computerUseArtifactBrokerService,
     iosSimulatorService,
     appControlService,
-    builtInBrowserService: builtInBrowserBridge as unknown as BuiltInBrowserService | null,
+    builtInBrowserService: builtInBrowserBridge,
     macosVmService,
     eventBuffer,
     dispose: () => {

--- a/apps/ade-cli/src/services/builtInBrowser/desktopBridgeClient.test.ts
+++ b/apps/ade-cli/src/services/builtInBrowser/desktopBridgeClient.test.ts
@@ -27,11 +27,11 @@ type ServerHandle = {
 
 async function startBridgeServer(
   handler: (request: JsonRpcRequest) => Promise<unknown>,
-): Promise<ServerHandle> {
-  const socketPath = path.join(
+  socketPath = path.join(
     fs.mkdtempSync(path.join(os.tmpdir(), "ade-bridge-test-")),
     "bridge.sock",
-  );
+  ),
+): Promise<ServerHandle> {
   const stopHandles = new Set<() => void>();
   const sockets = new Set<net.Socket>();
   const server = net.createServer((conn) => {
@@ -175,6 +175,30 @@ describe("createBuiltInBrowserDesktopBridgeClient", () => {
     const result = await client.getStatus();
     expect(result).toEqual({ ok: true });
     expect(callCount).toBe(2);
+    client.dispose();
+  });
+
+  it("forgets a cached bridge connection when the socket closes", async () => {
+    const socketPath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), "ade-bridge-test-restart-")),
+      "bridge.sock",
+    );
+    let generation = 1;
+    server = await startBridgeServer(async () => ({ generation }), socketPath);
+    const client = createBuiltInBrowserDesktopBridgeClient({
+      socketPath,
+      logger: silentLogger(),
+    });
+
+    await expect(client.getStatus()).resolves.toEqual({ generation: 1 });
+    await server.close();
+    server = null;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    generation = 2;
+    server = await startBridgeServer(async () => ({ generation }), socketPath);
+
+    await expect(client.getStatus()).resolves.toEqual({ generation: 2 });
     client.dispose();
   });
 });

--- a/apps/ade-cli/src/services/builtInBrowser/desktopBridgeClient.test.ts
+++ b/apps/ade-cli/src/services/builtInBrowser/desktopBridgeClient.test.ts
@@ -193,7 +193,6 @@ describe("createBuiltInBrowserDesktopBridgeClient", () => {
     await expect(client.getStatus()).resolves.toEqual({ generation: 1 });
     await server.close();
     server = null;
-    await new Promise((resolve) => setTimeout(resolve, 0));
 
     generation = 2;
     server = await startBridgeServer(async () => ({ generation }), socketPath);

--- a/apps/ade-cli/src/services/builtInBrowser/desktopBridgeClient.ts
+++ b/apps/ade-cli/src/services/builtInBrowser/desktopBridgeClient.ts
@@ -43,6 +43,11 @@ async function raceWithTimeout<T>(
   }
 }
 
+function isClosedSocketError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /(?:socket (?:is )?closed|socket hang up|EPIPE|ECONNRESET|ERR_STREAM_DESTROYED)/i.test(message);
+}
+
 export function createBuiltInBrowserDesktopBridgeClient(args: {
   socketPath: string;
   logger: Logger;
@@ -113,7 +118,7 @@ export function createBuiltInBrowserDesktopBridgeClient(args: {
     }
   }
 
-  async function callBridge(method: string, params?: unknown): Promise<unknown> {
+  async function callBridge(method: string, params?: unknown, retried = false): Promise<unknown> {
     const c = await ensureClient();
     try {
       return await raceWithTimeout(
@@ -124,6 +129,9 @@ export function createBuiltInBrowserDesktopBridgeClient(args: {
     } catch (error) {
       // Drop the connection on any error so the next call reconnects.
       drop(error);
+      if (!retried && isClosedSocketError(error)) {
+        return await callBridge(method, params, true);
+      }
       throw error;
     }
   }

--- a/apps/ade-cli/src/services/builtInBrowser/desktopBridgeClient.ts
+++ b/apps/ade-cli/src/services/builtInBrowser/desktopBridgeClient.ts
@@ -2,6 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { JsonRpcClient } from "../../tuiClient/jsonRpcClient";
 import type { Logger } from "../../../../desktop/src/main/services/logging/logger";
+import {
+  isBuiltInBrowserDesktopBridgeMethod,
+  type BuiltInBrowserDesktopBridgeClient,
+} from "./desktopBridgeMethods";
 
 /**
  * Proxy `built_in_browser` service used by the runtime daemon.
@@ -38,28 +42,6 @@ async function raceWithTimeout<T>(
     if (timeoutId) clearTimeout(timeoutId);
   }
 }
-
-export type BuiltInBrowserDesktopBridgeClient = {
-  getStatus: (args?: unknown) => Promise<unknown>;
-  claim: (args?: unknown) => Promise<unknown>;
-  showPanel: (args?: unknown) => Promise<unknown>;
-  setBounds: (args: unknown) => Promise<unknown>;
-  navigate: (args: unknown) => Promise<unknown>;
-  createTab: (args?: unknown) => Promise<unknown>;
-  switchTab: (args: unknown) => Promise<unknown>;
-  closeTab: (args: unknown) => Promise<unknown>;
-  reload: () => Promise<unknown>;
-  goBack: () => Promise<unknown>;
-  goForward: () => Promise<unknown>;
-  stop: () => Promise<unknown>;
-  startInspect: () => Promise<unknown>;
-  stopInspect: () => Promise<unknown>;
-  captureScreenshot: () => Promise<unknown>;
-  selectPoint: (args: unknown) => Promise<unknown>;
-  selectCurrent: () => Promise<unknown>;
-  clearSelection: () => Promise<unknown>;
-  dispose: () => void;
-};
 
 export function createBuiltInBrowserDesktopBridgeClient(args: {
   socketPath: string;
@@ -101,6 +83,9 @@ export function createBuiltInBrowserDesktopBridgeClient(args: {
             }
             throw new Error("Desktop browser bridge client has been disposed.");
           }
+          c.onClose(() => {
+            if (client === c) client = null;
+          });
           client = c;
           return c;
         })
@@ -143,28 +128,19 @@ export function createBuiltInBrowserDesktopBridgeClient(args: {
     }
   }
 
-  return {
-    getStatus: (args) => callBridge("getStatus", args),
-    claim: (args) => callBridge("claim", args),
-    showPanel: (args) => callBridge("showPanel", args),
-    setBounds: (args) => callBridge("setBounds", args),
-    navigate: (args) => callBridge("navigate", args),
-    createTab: (args) => callBridge("createTab", args),
-    switchTab: (args) => callBridge("switchTab", args),
-    closeTab: (args) => callBridge("closeTab", args),
-    reload: () => callBridge("reload"),
-    goBack: () => callBridge("goBack"),
-    goForward: () => callBridge("goForward"),
-    stop: () => callBridge("stop"),
-    startInspect: () => callBridge("startInspect"),
-    stopInspect: () => callBridge("stopInspect"),
-    captureScreenshot: () => callBridge("captureScreenshot"),
-    selectPoint: (args) => callBridge("selectPoint", args),
-    selectCurrent: () => callBridge("selectCurrent"),
-    clearSelection: () => callBridge("clearSelection"),
+  const bridge = {
     dispose: () => {
       disposed = true;
       drop();
     },
   };
+
+  return new Proxy(bridge, {
+    get(target, property, receiver) {
+      if (typeof property === "string" && isBuiltInBrowserDesktopBridgeMethod(property)) {
+        return (params?: unknown) => callBridge(property, params);
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  }) as BuiltInBrowserDesktopBridgeClient;
 }

--- a/apps/ade-cli/src/services/builtInBrowser/desktopBridgeMethods.ts
+++ b/apps/ade-cli/src/services/builtInBrowser/desktopBridgeMethods.ts
@@ -1,0 +1,63 @@
+import type { BuiltInBrowserService } from "../../../../desktop/src/main/services/builtInBrowser/builtInBrowserService";
+
+type SourceWindowLike = {
+  id: number;
+  isDestroyed(): boolean;
+} | null | undefined;
+
+type BridgeArgs<Args extends unknown[]> =
+  [Args[0]] extends [undefined]
+    ? []
+    : [Args[0]] extends [SourceWindowLike]
+      ? []
+      : undefined extends Args[0]
+        ? [input?: Exclude<Args[0], undefined>]
+        : [input: Args[0]];
+
+type BridgeReturn<Method extends BuiltInBrowserDesktopBridgeMethod> =
+  BuiltInBrowserService[Method] extends (...args: infer _Args) => infer Result
+    ? Awaited<Result>
+    : never;
+
+export const BUILT_IN_BROWSER_DESKTOP_BRIDGE_METHODS = [
+  "getStatus",
+  "claim",
+  "showPanel",
+  "setBounds",
+  "navigate",
+  "createTab",
+  "switchTab",
+  "closeTab",
+  "reload",
+  "goBack",
+  "goForward",
+  "stop",
+  "startInspect",
+  "stopInspect",
+  "captureScreenshot",
+  "selectPoint",
+  "selectCurrent",
+  "clearSelection",
+] as const satisfies readonly (keyof BuiltInBrowserService)[];
+
+export type BuiltInBrowserDesktopBridgeMethod =
+  (typeof BUILT_IN_BROWSER_DESKTOP_BRIDGE_METHODS)[number];
+
+export type BuiltInBrowserDesktopBridgeClient = {
+  [Method in BuiltInBrowserDesktopBridgeMethod]:
+    BuiltInBrowserService[Method] extends (...args: infer Args) => unknown
+      ? (...args: BridgeArgs<Args>) => Promise<BridgeReturn<Method>>
+      : never;
+} & {
+  dispose: () => void;
+};
+
+const BUILT_IN_BROWSER_DESKTOP_BRIDGE_METHOD_SET = new Set<string>(
+  BUILT_IN_BROWSER_DESKTOP_BRIDGE_METHODS,
+);
+
+export function isBuiltInBrowserDesktopBridgeMethod(
+  value: string,
+): value is BuiltInBrowserDesktopBridgeMethod {
+  return BUILT_IN_BROWSER_DESKTOP_BRIDGE_METHOD_SET.has(value);
+}

--- a/apps/ade-cli/src/services/projects/projectRegistry.test.ts
+++ b/apps/ade-cli/src/services/projects/projectRegistry.test.ts
@@ -190,4 +190,32 @@ describe("ProjectRegistry", () => {
     expect(spawnSyncMock).not.toHaveBeenCalled();
     expect(updated.gitOriginUrl).toBe("git@github.com:arul28/ADE.git");
   });
+
+  it("backfills git origin on re-add when the existing record is missing it", () => {
+    const homeDir = makeTempRoot("ade-project-registry-readd-null-");
+    const projectRoot = path.join(homeDir, "ADE");
+    const registryDir = path.join(homeDir, ".ade-runtime");
+    fs.mkdirSync(projectRoot, { recursive: true });
+    const registry = new ProjectRegistry({
+      adeDir: registryDir,
+      projectsPath: path.join(registryDir, "projects.json"),
+      secretsDir: path.join(registryDir, "secrets"),
+      sockDir: path.join(registryDir, "sock"),
+      socketPath: path.join(registryDir, "sock", "ade.sock"),
+      desktopBridgeSocketPath: path.join(registryDir, "sock", "desktop-bridge.sock"),
+      binDir: path.join(registryDir, "bin"),
+      runtimeDir: path.join(registryDir, "runtime"),
+    });
+    registry.add(projectRoot);
+    spawnSyncMock.mockClear();
+    spawnSyncMock.mockReturnValueOnce({
+      status: 0,
+      stdout: "git@github.com:arul28/ADE.git\n",
+    });
+
+    const updated = registry.add(projectRoot);
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    expect(updated.gitOriginUrl).toBe("git@github.com:arul28/ADE.git");
+  });
 });

--- a/apps/ade-cli/src/services/projects/projectRegistry.test.ts
+++ b/apps/ade-cli/src/services/projects/projectRegistry.test.ts
@@ -1,12 +1,18 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ProjectRegistry,
   deriveProjectId,
   isDisallowedProjectRoot,
 } from "./projectRegistry";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  spawnSync: spawnSyncMock,
+}));
 
 const tempRoots = new Set<string>();
 
@@ -25,6 +31,11 @@ afterEach(() => {
 });
 
 describe("ProjectRegistry", () => {
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValue({ status: 1, stdout: "" });
+  });
+
   it("rejects registering the user home directory", () => {
     const homeDir = makeTempRoot("ade-project-registry-home-");
     vi.spyOn(os, "homedir").mockReturnValue(homeDir);
@@ -122,5 +133,61 @@ describe("ProjectRegistry", () => {
     fs.symlinkSync(projectRoot, aliasRoot, "dir");
 
     expect(deriveProjectId(aliasRoot)).toBe(deriveProjectId(projectRoot));
+  });
+
+  it("does not refresh git origin while touching a registered project", () => {
+    const homeDir = makeTempRoot("ade-project-registry-touch-");
+    const projectRoot = path.join(homeDir, "ADE");
+    const registryDir = path.join(homeDir, ".ade-runtime");
+    fs.mkdirSync(projectRoot, { recursive: true });
+    const registry = new ProjectRegistry({
+      adeDir: registryDir,
+      projectsPath: path.join(registryDir, "projects.json"),
+      secretsDir: path.join(registryDir, "secrets"),
+      sockDir: path.join(registryDir, "sock"),
+      socketPath: path.join(registryDir, "sock", "ade.sock"),
+      desktopBridgeSocketPath: path.join(registryDir, "sock", "desktop-bridge.sock"),
+      binDir: path.join(registryDir, "bin"),
+      runtimeDir: path.join(registryDir, "runtime"),
+    });
+    spawnSyncMock.mockReturnValueOnce({
+      status: 0,
+      stdout: "git@github.com:arul28/ADE.git\n",
+    });
+    const registered = registry.add(projectRoot);
+    spawnSyncMock.mockClear();
+
+    const touched = registry.touch(registered.projectId);
+
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+    expect(touched.gitOriginUrl).toBe("git@github.com:arul28/ADE.git");
+  });
+
+  it("preserves git origin when an already-registered project is added again", () => {
+    const homeDir = makeTempRoot("ade-project-registry-readd-");
+    const projectRoot = path.join(homeDir, "ADE");
+    const registryDir = path.join(homeDir, ".ade-runtime");
+    fs.mkdirSync(projectRoot, { recursive: true });
+    const registry = new ProjectRegistry({
+      adeDir: registryDir,
+      projectsPath: path.join(registryDir, "projects.json"),
+      secretsDir: path.join(registryDir, "secrets"),
+      sockDir: path.join(registryDir, "sock"),
+      socketPath: path.join(registryDir, "sock", "ade.sock"),
+      desktopBridgeSocketPath: path.join(registryDir, "sock", "desktop-bridge.sock"),
+      binDir: path.join(registryDir, "bin"),
+      runtimeDir: path.join(registryDir, "runtime"),
+    });
+    spawnSyncMock.mockReturnValueOnce({
+      status: 0,
+      stdout: "git@github.com:arul28/ADE.git\n",
+    });
+    registry.add(projectRoot);
+    spawnSyncMock.mockClear();
+
+    const updated = registry.add(projectRoot);
+
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+    expect(updated.gitOriginUrl).toBe("git@github.com:arul28/ADE.git");
   });
 });

--- a/apps/ade-cli/src/services/projects/projectRegistry.ts
+++ b/apps/ade-cli/src/services/projects/projectRegistry.ts
@@ -155,7 +155,7 @@ export class ProjectRegistry {
       displayName: existing?.displayName ?? path.basename(normalized),
       addedAt: existing?.addedAt ?? now,
       lastOpenedAt: now,
-      gitOriginUrl: readGitOriginUrl(normalized),
+      gitOriginUrl: existing ? existing.gitOriginUrl : readGitOriginUrl(normalized),
     };
     if (existingIndex >= 0) {
       file.projects[existingIndex] = next;
@@ -185,7 +185,6 @@ export class ProjectRegistry {
     const next: ProjectRecord = {
       ...file.projects[index]!,
       lastOpenedAt: Date.now(),
-      gitOriginUrl: readGitOriginUrl(file.projects[index]!.rootPath),
     };
     file.projects[index] = next;
     this.write(file);

--- a/apps/ade-cli/src/services/projects/projectRegistry.ts
+++ b/apps/ade-cli/src/services/projects/projectRegistry.ts
@@ -155,7 +155,7 @@ export class ProjectRegistry {
       displayName: existing?.displayName ?? path.basename(normalized),
       addedAt: existing?.addedAt ?? now,
       lastOpenedAt: now,
-      gitOriginUrl: existing ? existing.gitOriginUrl : readGitOriginUrl(normalized),
+      gitOriginUrl: existing?.gitOriginUrl ?? readGitOriginUrl(normalized),
     };
     if (existingIndex >= 0) {
       file.projects[existingIndex] = next;

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import type { AdeRuntime } from "../../../../../ade-cli/src/bootstrap";
+import { BUILT_IN_BROWSER_DESKTOP_BRIDGE_METHODS } from "../../../../../ade-cli/src/services/builtInBrowser/desktopBridgeMethods";
 import type {
   AutomationManualTriggerRequest,
   AutomationIngressEventRecord,
@@ -679,7 +680,7 @@ export const ADE_ACTION_ALLOWLIST: Partial<Record<AdeActionDomain, readonly stri
   computer_use_artifacts: ["getOwnerSnapshot", "ingest", "listArtifacts", "readArtifactPreview", "routeArtifact", "updateArtifactReview"],
   ios_simulator: ["getStatus", "claim", "listDevices", "listLaunchTargets", "launch", "attachToChatSession", "shutdown", "screenshot", "getScreenSnapshot", "getInspectorSnapshot", "inspectPoint", "getPreviewCapability", "listPreviewTargets", "renderPreview", "openPreviewWorkspace", "startStream", "stopStream", "getStreamStatus", "tap", "typeText", "drag", "swipe", "selectPoint"],
   app_control: ["getStatus", "claim", "launch", "launchInTerminal", "connect", "stop", "focusWindow", "minimizeWindow", "screenshot", "getSnapshot", "inspectPoint", "selectPoint", "click", "typeText", "scroll", "dispatchKey", "listTargets", "attachToTarget", "readTerminal", "writeTerminal", "signalTerminal"],
-  built_in_browser: ["getStatus", "claim", "showPanel", "setBounds", "navigate", "createTab", "switchTab", "closeTab", "reload", "goBack", "goForward", "stop", "startInspect", "stopInspect", "captureScreenshot", "selectPoint", "selectCurrent", "clearSelection"],
+  built_in_browser: [...BUILT_IN_BROWSER_DESKTOP_BRIDGE_METHODS],
   // Note: detachLane is intentionally NOT in this allowlist — it lives on
   // laneService.detachVmLane, not on macosVmService. Wire it through a lane
   // action if/when it needs to be agent-callable.

--- a/apps/desktop/src/main/services/ai/apiKeyStore.ts
+++ b/apps/desktop/src/main/services/ai/apiKeyStore.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import type { SafeStorage } from "electron";
+import type { SyncCredentialStore } from "../../../../../ade-cli/src/services/credentials/credentialStore";
 import { resolveAdeLayout } from "../../../shared/adeLayout";
 
 // electron.safeStorage is only available inside an Electron main process.
@@ -21,14 +22,7 @@ try {
 
 type StoredKeys = Record<string, string>;
 
-export type ApiKeyCredentialStore = {
-  get?: (key: string) => Promise<string | null> | string | null;
-  set?: (key: string, value: string) => Promise<void> | void;
-  delete?: (key: string) => Promise<void> | void;
-  getSync?: (key: string) => string | null;
-  setSync?: (key: string, value: string) => void;
-  deleteSync?: (key: string) => void;
-};
+export type ApiKeyCredentialStore = SyncCredentialStore;
 
 export type InitApiKeyStoreOptions = {
   credentialStore?: ApiKeyCredentialStore | null;
@@ -241,16 +235,8 @@ function credentialProviderKey(provider: string): string {
   return `ai.api_key.${provider}.v1`;
 }
 
-function getSyncCredentialStore(): Required<Pick<ApiKeyCredentialStore, "getSync" | "setSync" | "deleteSync">> | null {
-  if (!credentialStore) return null;
-  if (
-    typeof credentialStore.getSync === "function"
-    && typeof credentialStore.setSync === "function"
-    && typeof credentialStore.deleteSync === "function"
-  ) {
-    return credentialStore as Required<Pick<ApiKeyCredentialStore, "getSync" | "setSync" | "deleteSync">>;
-  }
-  throw new Error("API key credentialStore must provide getSync, setSync, and deleteSync.");
+function getSyncCredentialStore(): SyncCredentialStore | null {
+  return credentialStore;
 }
 
 function readCredentialSecret(key: string): string | null {

--- a/apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.ts
@@ -164,6 +164,9 @@ export function createBuiltInBrowserService(args: {
     getStatus(sourceWindow?: BrowserWindow | null): BuiltInBrowserStatus {
       return serviceFor(sourceWindow).getStatus();
     },
+    claim(input: BuiltInBrowserClaimArgs = {}, sourceWindow?: BrowserWindow | null): BuiltInBrowserStatus {
+      return serviceFor(sourceWindow).claim(input);
+    },
     showPanel(input: BuiltInBrowserOpenPanelArgs = {}, sourceWindow?: BrowserWindow | null): Promise<BuiltInBrowserStatus> {
       return serviceFor(sourceWindow).showPanel(input);
     },

--- a/apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.ts
@@ -9,6 +9,7 @@ import {
   type JsonRpcServerErrorContext,
   type JsonRpcTransport,
 } from "../../../../../ade-cli/src/jsonrpc";
+import { isBuiltInBrowserDesktopBridgeMethod } from "../../../../../ade-cli/src/services/builtInBrowser/desktopBridgeMethods";
 import type { Logger } from "../logging/logger";
 import type { BuiltInBrowserService } from "./builtInBrowserService";
 
@@ -22,27 +23,6 @@ import type { BuiltInBrowserService } from "./builtInBrowserService";
  * outside the allowlist returns `methodNotFound` so a daemon bug or
  * out-of-date desktop doesn't accidentally expose private internals.
  */
-
-const ALLOWED_METHODS = new Set([
-  "getStatus",
-  "claim",
-  "showPanel",
-  "setBounds",
-  "navigate",
-  "createTab",
-  "switchTab",
-  "closeTab",
-  "reload",
-  "goBack",
-  "goForward",
-  "stop",
-  "startInspect",
-  "stopInspect",
-  "captureScreenshot",
-  "selectPoint",
-  "selectCurrent",
-  "clearSelection",
-]);
 
 export type BuiltInBrowserDesktopBridgeServer = {
   socketPath: string;
@@ -174,7 +154,7 @@ export function startBuiltInBrowserDesktopBridgeServer(args: {
       );
     }
     const name = method.slice("built_in_browser.".length);
-    if (!ALLOWED_METHODS.has(name)) {
+    if (!isBuiltInBrowserDesktopBridgeMethod(name)) {
       throw new JsonRpcError(
         JsonRpcErrorCode.methodNotFound,
         `Action 'built_in_browser.${name}' is not exposed by the desktop bridge.`,

--- a/apps/desktop/src/main/services/probeLocalhostPort.test.ts
+++ b/apps/desktop/src/main/services/probeLocalhostPort.test.ts
@@ -26,6 +26,14 @@ async function closeServer(server: Server): Promise<void> {
   await new Promise<void>((resolve) => server.close(() => resolve()));
 }
 
+async function closeAndForgetServer(server: Server): Promise<void> {
+  await closeServer(server);
+  const index = openServers.indexOf(server);
+  if (index >= 0) {
+    openServers.splice(index, 1);
+  }
+}
+
 afterEach(async () => {
   while (openServers.length) {
     const server = openServers.pop()!;
@@ -40,10 +48,15 @@ describe("probeLocalhostPort", () => {
   });
 
   it("returns false when nothing is listening on the port", async () => {
-    const { server, port } = await listenOnLoopback();
-    await closeServer(server);
-    openServers.splice(openServers.indexOf(server), 1);
-    await expect(probeLocalhostPort(port, 250)).resolves.toBe(false);
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const { server, port } = await listenOnLoopback();
+      await closeAndForgetServer(server);
+      if (!(await probeLocalhostPort(port, 250))) {
+        return;
+      }
+    }
+
+    throw new Error("expected at least one closed ephemeral loopback port to reject connections");
   });
 
   it("rejects invalid ports without crashing", async () => {


### PR DESCRIPTION
Fixes ADE-82

## Summary
- Stop ProjectRegistry touch/re-add from synchronously refreshing git origin on daemon RPC hot paths.
- Share the built-in browser bridge method surface from one exported tuple and build the daemon client through a proxy.
- Drop cached desktop bridge clients as soon as the socket closes, and use the canonical SyncCredentialStore in apiKeyStore.

## Validation
- npm --prefix apps/ade-cli run test -- src/services/projects/projectRegistry.test.ts src/services/builtInBrowser/desktopBridgeClient.test.ts
- npm --prefix apps/desktop run test -- src/main/services/ai/apiKeyStore.test.ts src/main/services/builtInBrowser/builtInBrowserService.test.ts
- npm --prefix apps/ade-cli run typecheck
- npm --prefix apps/desktop run typecheck
- npm --prefix apps/desktop run lint (0 errors; existing warnings)
- npm --prefix apps/ade-cli run build
- git diff --check

Open in ADE: https://ade-app.dev/open?type=pr&repo=arul28%2FADE&number=483

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates synchronous git subprocess calls from hot RPC paths in `ProjectRegistry` and centralises the desktop bridge method surface into a single exported tuple, replacing three independent hard-coded lists with one canonical source of truth.

- **ProjectRegistry hot-path fix**: `touch()` no longer calls `readGitOriginUrl`; `add()` now preserves an existing `gitOriginUrl` with `??`, only backfilling when the stored value is `null`. Three new tests cover no-subprocess-on-touch, preserve-on-re-add, and backfill-when-null.
- **Bridge client hardening**: The cached `JsonRpcClient` is now nulled eagerly via an `onClose` callback, and `callBridge` retries once on any closed-socket error, making reconnection after a desktop restart transparent without requiring a manual retry.
- **`ApiKeyCredentialStore` tightened**: The type is now `SyncCredentialStore` directly (all sync methods required), removing the need for a runtime duck-type check in `getSyncCredentialStore()`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all three hot-path changes are well-scoped and backed by targeted tests.

The git-origin and socket-cache changes are narrow and well-tested. The bridge client Proxy correctly delegates to callBridge for known methods, with the retry path covering the onClose timing edge case. Tightening ApiKeyCredentialStore to SyncCredentialStore removes a now-redundant runtime check without changing observable behaviour.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/services/builtInBrowser/desktopBridgeMethods.ts | New canonical module exporting the bridge method list, type-safe BridgeArgs/BridgeReturn helpers, and the BuiltInBrowserDesktopBridgeClient type derived from BuiltInBrowserService. |
| apps/ade-cli/src/services/builtInBrowser/desktopBridgeClient.ts | Adds onClose handler to eagerly null the cached client, adds a one-shot retry on closed-socket errors, and replaces the hardcoded method list with a Proxy backed by isBuiltInBrowserDesktopBridgeMethod. |
| apps/ade-cli/src/services/builtInBrowser/desktopBridgeClient.test.ts | Adds a reconnect test; retry logic in callBridge makes it reliable regardless of onClose callback timing. |
| apps/ade-cli/src/services/projects/projectRegistry.ts | Stops calling readGitOriginUrl on touch(); preserves existing gitOriginUrl on re-add() unless null. |
| apps/ade-cli/src/services/projects/projectRegistry.test.ts | Adds three tests covering no-subprocess-on-touch, preserve-on-re-add, and backfill-when-null. |
| apps/desktop/src/main/services/ai/apiKeyStore.ts | Replaces loose optional-field type with canonical SyncCredentialStore and simplifies getSyncCredentialStore(). |
| apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.ts | Adds the missing claim() method to the outer service object. |
| apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.ts | Replaces local ALLOWED_METHODS set with isBuiltInBrowserDesktopBridgeMethod. |
| apps/desktop/src/main/services/adeActions/registry.ts | Replaces inline built_in_browser allowlist with ...BUILT_IN_BROWSER_DESKTOP_BRIDGE_METHODS. |
| apps/ade-cli/src/bootstrap.ts | Widens builtInBrowserService type and removes the unsafe as unknown cast. |
| apps/desktop/src/main/services/probeLocalhostPort.test.ts | Hardens the port-not-listening test with a 5-attempt retry loop and a closeAndForgetServer helper. |

</details>

<sub>Reviews (8): Last reviewed commit: ["Refs ADE-82: Fix flaky localhost port pr..."](https://github.com/arul28/ade/commit/d7895c8035e3af89312250e3c21653d3f79d351d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34778957)</sub>

<!-- /greptile_comment -->