### PR TITLE
ADE-86: Docs accuracy pass: strip tool-call XML artifacts, fix fabricated lane shortcuts, wrong config schema, and fake CTO heartbeat/cto-route schema (+ docs lint)

### DIFF
--- a/computer-use/config.mdx
+++ b/computer-use/config.mdx
@@ -68,5 +68,3 @@ Proofs linked to closed PRs and completed Linear issues remain on disk until exp
     Pass `--verbose` to see the ingestion result line-by-line, including which entries were dropped.
   </Accordion>
 </AccordionGroup>
-</content>
-</invoke>

--- a/computer-use/overview.mdx
+++ b/computer-use/overview.mdx
@@ -70,5 +70,3 @@ Agents attach proofs to owners when they capture them, or later via `ade proof` 
     Storage paths, retention, and troubleshooting common capture issues.
   </Card>
 </CardGroup>
-</content>
-</invoke>

--- a/computer-use/proofs.mdx
+++ b/computer-use/proofs.mdx
@@ -103,5 +103,3 @@ capture → pending / evidence_only
 ```
 
 Every state transition is append-only: the original record is never overwritten. The History tab on each worker run reflects every review and publish action, giving you a full audit trail.
-</content>
-</invoke>

--- a/computer-use/setup.mdx
+++ b/computer-use/setup.mdx
@@ -82,5 +82,3 @@ ADE normalizes each entry into a proof record of the declared kind and links it 
 ```
 
 Each artifact has a row in ADE's SQLite database with pointers to the file, the owners, the review state, and the workflow state. See [Configuration](/computer-use/config) for retention settings.
-</content>
-</invoke>

--- a/configuration/ai-providers.mdx
+++ b/configuration/ai-providers.mdx
@@ -237,25 +237,25 @@ OpenCode follows its own internal permission scheme. Set it to `full-auto` for t
 
 ## Model Selection by Context
 
-ADE lets you assign different models to different agent roles. This is the recommended approach for cost efficiency: use Opus for planning and architecture, Sonnet for execution, and Haiku for automation runs.
+ADE lets you assign different models to AI task categories. This is the recommended approach for cost efficiency: use larger models for planning and review, and cheaper models for routine generation tasks.
 
 ```yaml
 # .ade/ade.yaml
 ai:
   defaultModel: "claude-sonnet-4-6"      # Fallback for all agents
-  routingRules:
-    - role: "orchestrator"               # Worker run planning agent
+  taskRouting:
+    planning:
       model: "claude-opus-4-7"
-    - role: "worker"                     # Worker run execution agents
+    implementation:
       model: "claude-sonnet-4-6"
-    - role: "automation"                 # Automation runs (cost-sensitive)
+    review:
       model: "claude-haiku-4-5"
-    - role: "validator"                  # Worker run validation agent
+    commit_message:
       model: "claude-sonnet-4-6"
 ```
 
 <Tip>
-For solo developers running many automations, routing automation runs to `claude-haiku-4-5` and reserving `claude-opus-4-7` for worker run planning can reduce monthly spend by 60–80% with minimal quality impact on routine tasks.
+For solo developers running many automations, routing routine review or text-generation tasks to a cheaper model and reserving `claude-opus-4-7` for planning can reduce monthly spend with minimal quality impact on routine tasks.
 </Tip>
 
 ---
@@ -267,24 +267,27 @@ Budget caps prevent runaway spend from long-running agents or automation loops. 
 ```yaml
 # .ade/ade.yaml
 ai:
-  defaultBudgetPerSession: 1.00         # USD per chat session
-  defaultBudgetPerWorkerRun: 10.00     # USD per delegated worker run
-  defaultBudgetPerAutomation: 0.50      # USD per automation trigger
-  monthlyBudgetCap: 100.00              # Hard monthly ceiling across all agents
+  budgets:
+    commit_messages:
+      dailyLimit: 20
+    pr_descriptions:
+      dailyLimit: 10
+  chat:
+    sessionBudgetUsd: 1.00
 ```
 
 <AccordionGroup>
   <Accordion title="Per-session budget" icon="message">
-    Applied to chat sessions in the Agent Chat pane. When the session's cumulative cost reaches this value, the agent receives a stop signal. You can raise the cap for the current session in the chat header without editing config.
+    `ai.chat.sessionBudgetUsd` sets the default budget for chat sessions that read project config. You can still adjust the current session from chat controls when available.
   </Accordion>
-  <Accordion title="Per-worker run budget" icon="bullseye">
-    Applied to the entire delegated worker run, summing across all workers. If the combined worker spend reaches the cap during execution, the orchestrator suspends remaining tasks and surfaces an intervention request asking whether to extend the budget or abandon the worker run.
+  <Accordion title="Feature daily limits" icon="bullseye">
+    `ai.budgets` is keyed by ADE feature, such as `commit_messages`, `pr_descriptions`, `terminal_summaries`, `narratives`, and `initial_context`. Each entry supports `dailyLimit`.
   </Accordion>
-  <Accordion title="Per-automation budget" icon="bolt">
-    Applied per automation trigger event. Each time an automation fires, it gets a fresh budget for that run. Useful for keeping PR review automations economical.
+  <Accordion title="Worker budgets" icon="bolt">
+    Worker monthly budgets are edited in CTO > Team. They are stored with the worker identity, not as `defaultBudgetPerWorkerRun` in `ade.yaml`.
   </Accordion>
   <Accordion title="Monthly cap" icon="calendar">
-    A hard ceiling across all providers, all agents, all sessions. Once reached, all agent activity pauses. ADE shows a banner and sends a notification. The cap resets on the first day of each calendar month. You can raise or reset it in Settings → Budget.
+    Usage-wide monthly caps are managed from Settings → Usage. They are not configured with `ai.monthlyBudgetCap` in `ade.yaml`.
   </Accordion>
 </AccordionGroup>
 

--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration Overview"
-description: "ADE stores all project configuration in a .ade/ directory at your repository root. Three layered config files give you shared team settings, personal overrides, and secret management — all with a SHA-based trust model."
+description: "ADE stores project configuration in a .ade/ directory at your repository root. Shared team settings, personal overrides, and local secret references stay separated by a SHA-based trust model."
 icon: "folder-tree"
 ---
 ## The `.ade/` Directory
@@ -11,7 +11,8 @@ ADE initializes a `.ade/` directory at the project root on first open. It is the
 .ade/
   ade.yaml              # Shared team config — commit this to git
   local.yaml            # Personal preferences — gitignored
-  local.secret.yaml     # API keys and tokens — ALWAYS gitignored
+  local.secret.yaml     # Automation secret references — ALWAYS gitignored
+  secrets/              # Encrypted machine-local credentials and tokens
   worktrees/            # Git worktrees for each lane (auto-managed by ADE)
   artifacts/
     packs/              # Compatibility snapshots and audit artifacts
@@ -30,21 +31,21 @@ The `worktrees/` and `artifacts/` subdirectories are ADE-managed. Do not edit th
 
 ## Configuration Layering
 
-ADE resolves configuration through three layers applied in order. Lower layers override higher ones.
+ADE resolves project configuration from two files, then reads secret references separately when a service needs them.
 
 <CardGroup cols={3}>
   <Card title="ade.yaml" icon="users">
-    **Shared team config.** Committed to git. Contains project defaults, AI model settings, lane profiles, automation definitions, and trust rules. Every team member reads this file.
+    **Shared team config.** Committed to git. Contains project defaults, AI model settings, lane templates, automation definitions, and trusted command definitions. Every team member reads this file.
   </Card>
   <Card title="local.yaml" icon="user">
-    **Personal preferences.** Gitignored. Overrides any value in `ade.yaml` for your machine only. Contains preferred model, theme, editor settings, and notification preferences.
+    **Personal overrides.** Gitignored. Overrides the same parsed config fields in `ade.yaml` for your machine only.
   </Card>
   <Card title="local.secret.yaml" icon="key">
-    **Secrets.** Always gitignored. Contains API keys, OAuth tokens, and other credentials. Only the main process reads this file — the renderer UI never has access to its contents.
+    **Secret references.** Always gitignored. Used by automation/webhook services when config points at a `secretRef`. AI provider keys saved from Settings live in the encrypted key store under `.ade/secrets` or the OS credential store, not in committed config.
   </Card>
 </CardGroup>
 
-When resolving a value, ADE checks `local.secret.yaml` first, then `local.yaml`, then `ade.yaml`. A value in `local.yaml` shadows the same key in `ade.yaml` for that machine only.
+When resolving project config, ADE loads `ade.yaml` first and overlays `local.yaml` for that machine only. `local.secret.yaml` is not a third config layer; services read it only when a `secretRef` points at a path inside that file.
 
 ---
 
@@ -63,7 +64,7 @@ When resolving a value, ADE checks `local.secret.yaml` first, then `local.yaml`,
     Review the diff in the approval dialog (Settings → Config → Pending Approval, or the banner that appears automatically). If the changes are expected and safe, click **Approve**.
   </Step>
   <Step title="ADE records the approved SHA">
-    The SHA of the approved `ade.yaml` is written to your `local.yaml`. Commands from this version of the config are now permitted to execute.
+    The SHA of the approved `ade.yaml` is recorded in local ADE state. Commands from this version of the config are now permitted to execute.
   </Step>
 </Steps>
 <Warning>
@@ -76,91 +77,99 @@ To re-approve the currently loaded config (e.g., after a manual edit): **Setting
 
 ## `ade.yaml` — Full Schema Reference
 
-Shared team config — commit this file. Every field is optional except `name`.
+Shared team config — commit this file. Every field is optional.
 
 ```yaml
 # .ade/ade.yaml
 
-name: "My Project"
-description: "Optional project description shown in ADE's title bar"
+version: 1
+project:
+  iconPath: null
 
 # ── AI Defaults ───────────────────────────────────────────────────────────────
 ai:
-  defaultModel: "claude-opus-4-7"       # or "claude-sonnet-4-6", "gpt-4o", etc.
-  defaultBudgetPerSession: 1.00         # USD cap per chat session
-  defaultBudgetPerWorkerRun: 5.00      # USD cap per delegated worker run
-  defaultBudgetPerAutomation: 0.50      # USD cap per automation execution
-  monthlyBudgetCap: 100.00              # Hard monthly cap across all agents
+  defaultModel: "claude-sonnet-4-6"
+  budgets:
+    commit_messages:
+      dailyLimit: 20
+    pr_descriptions:
+      dailyLimit: 10
 
 # ── Process Definitions ───────────────────────────────────────────────────────
+processGroups:
+  - id: "app"
+    name: "App"
+
 processes:
-  - name: "Frontend"
-    command: "npm run dev"
+  - id: "frontend"
+    name: "Frontend"
+    command: ["npm", "run", "dev"]
     cwd: "."
-    port: 3000
-    group: "App"
-  - name: "API"
-    command: "npm run api"
-    cwd: "."
-    port: 4000
-    group: "App"
+    groupIds: ["app"]
+    readiness:
+      type: "port"
+      port: 3000
 
 # ── Test Suites ───────────────────────────────────────────────────────────────
 testSuites:
-  - name: "Unit Tests"
-    run: "npm test"
-    watch: "npm test -- --watch"
-    ci: "npm test -- --ci --coverage"
-  - name: "E2E Tests"
-    run: "npm run test:e2e"
-    ci: "npm run test:e2e -- --headless"
+  - id: "unit"
+    name: "Unit Tests"
+    command: ["npm", "test"]
+    cwd: "."
+    timeoutMs: 600000
+    tags: ["unit"]
 
-# ── Lane Profiles ─────────────────────────────────────────────────────────────
-lanes:
-  profiles:
-    - name: "feature"
-      basePort: 3001
-      env:
-        NODE_ENV: "development"
-      startCommands: ["npm install"]
-    - name: "hotfix"
-      basePort: 4001
-      env:
-        NODE_ENV: "production"
+# ── Lane Templates ────────────────────────────────────────────────────────────
+laneTemplates:
+  - id: "web-feature"
+    name: "Web feature"
+    description: "Copy local env and install dependencies for a web lane."
+    envFiles:
+      - source: ".env.example"
+        dest: ".env"
+    dependencies:
+      - command: ["npm", "install"]
+    envVars:
+      NODE_ENV: "development"
+
+defaultLaneTemplate: "web-feature"
 
 # ── Automation Definitions ────────────────────────────────────────────────────
 automations:
-  - name: "PR Reviewer"
+  - id: "pr-reviewer"
+    name: "PR Reviewer"
+    mode: "review"
+    enabled: true
     trigger:
-      type: "git.pr_opened"
-    executor: "automation-bot"
+      type: "github.pr_opened"
+    execution:
+      kind: "agent-session"
+      laneMode: "reuse"
+    executor:
+      mode: "automation-bot"
     prompt: "Review this PR for code quality, security issues, and adherence to project conventions."
-    toolPalette: "read-only"
-    budgetCap: 0.50
+    toolPalette: ["repo", "git", "github", "tests"]
 
-# ── Trust (managed automatically — do not edit manually) ─────────────────────
-trust:
-  approvedSha: "abc123..."
 ```
 
 <AccordionGroup>
   <Accordion title="ai — AI defaults" icon="robot">
-    All `ai.*` values are defaults. They can be overridden per-worker run, per-worker, or per-automation at creation time. The `monthlyBudgetCap` is a hard ceiling — once reached, all agent activity pauses until the next billing period or you manually raise the cap in Settings → Budget.
+    `ai.defaultModel` sets the default runtime model. `ai.budgets` is a map keyed by ADE feature (`commit_messages`, `pr_descriptions`, `terminal_summaries`, etc.); each entry currently supports `dailyLimit`.
   </Accordion>
   <Accordion title="processes — Dev server definitions" icon="server">
-    Process definitions describe how to start development servers. ADE uses these to populate the lane startup commands and to generate the process panel in the Lanes view. The `group` field organizes processes visually in the UI.
+    Process definitions describe how to start development servers. Use `id`, `command` arrays, `cwd`, optional `groupIds`, and optional readiness checks. `processGroups` defines the visual groups referenced by `groupIds`.
   </Accordion>
   <Accordion title="testSuites — Test runner config" icon="vial">
-    ADE uses the `run` command in agent contexts when a worker needs to execute tests. The `watch` command is used in lane terminal sessions for continuous testing. The `ci` command is used during Worker run validation phases and automation triggers.
+    Test suites use `id`, `command` arrays, `cwd`, optional `timeoutMs`, and `tags`. ADE uses these definitions when agents or automations need a known validation command.
   </Accordion>
-  <Accordion title="lanes.profiles — Lane environment templates" icon="code-branch">
-    Lane profiles are templates applied when creating new lanes. A profile sets the base port offset, environment variables, and startup commands. When you create a lane and select a profile, all profile values are applied as the lane's initial configuration.
+  <Accordion title="laneTemplates — Lane environment templates" icon="code-branch">
+    Lane templates are top-level `laneTemplates` entries. `defaultLaneTemplate` names the template applied by default. Templates can copy env files, install dependencies, define mount points, copy paths, reserve a port range, and set lane env vars.
   </Accordion>
   <Accordion title="automations — Event-driven automation rules" icon="bolt">
-    Automation definitions are shared team-wide. Each automation specifies a trigger event, the executor agent identity, a prompt, the tool palette the agent is allowed to use, and a per-run budget cap. See [Automations](/automations/overview) for the full automation reference.
+    Automation definitions are shared team-wide. Each automation has an `id`, triggers, an `execution` mode, an `executor` object, and optional built-in `actions` such as `agent-session`, `run-tests`, `run-command`, and `ade-action`. See [Automations](/automations/overview) for the full automation reference.
   </Accordion>
-  <Accordion title="trust.approvedSha — Do not edit" icon="shield">
-    ADE manages the `trust.approvedSha` field automatically as part of the approval workflow. Editing it manually will cause ADE to treat the config as unapproved and pause all commands until you complete the approval flow again.
+  <Accordion title="Config trust — Managed by ADE" icon="shield">
+    ADE hashes `ade.yaml` and stores the approved shared hash in local ADE state. There is no `trust.approvedSha` field to author in project config.
   </Accordion>
 </AccordionGroup>
 
@@ -168,66 +177,44 @@ trust:
 
 ## `local.yaml` — Full Schema Reference
 
-Personal preferences — gitignored, never shared. Overrides `ade.yaml` values for your machine only.
+Personal overrides — gitignored, never shared. Uses the same parsed schema as `ade.yaml` and overrides shared values for your machine only.
 
 ```yaml
 # .ade/local.yaml
 
 ai:
-  preferredModel: "claude-sonnet-4-6"   # Override the team's default model
+  defaultModel: "claude-sonnet-4-6"
+  chat:
+    defaultProvider: "last_used"
+    sendOnEnter: true
+    codexSandbox: "workspace-write"
 
-editor:
-  theme: "dark"                          # dark | light | monokai | solarized-dark | solarized-light | one-dark
-  fontSize: 14
-  tabSize: 2
+git:
+  autoRebaseOnHeadChange: false
 
-terminal:
-  shell: "/bin/zsh"
-  fontFamily: "JetBrains Mono"
-  fontSize: 13
-
-notifications:
-  workerRunComplete: true
-  conflictDetected: true
-  budgetWarning: true
-  prStatusChange: false
-
-# Approval state — managed automatically
-trust:
-  approvedSha: "abc123..."              # Your machine's approved ade.yaml SHA
+github:
+  prPollingIntervalSeconds: 60
 ```
 
 ---
 
 ## `local.secret.yaml` — Full Schema Reference
 
-API keys and service credentials. Always gitignored. Only the Electron main process reads it — the renderer never has access to its raw contents.
+Automation secret values addressed by `secretRef`. Always gitignored. Only main-process services read this file; the renderer UI never has access to its raw contents.
 
 ```yaml
 # .ade/local.secret.yaml
 
-anthropic:
-  apiKey: "sk-ant-..."
+webhooks:
+  github: "${env:GITHUB_WEBHOOK_SECRET}"
+  linear: "${env:LINEAR_WEBHOOK_SECRET}"
 
-openai:
-  apiKey: "sk-..."
-
-openrouter:
-  apiKey: "sk-or-..."
-
-github:
-  token: "ghp_..."
-
-linear:
-  apiKey: "lin_api_..."
-
-# Optional: local model endpoint (no key needed for Ollama)
-localModels:
-  baseUrl: "http://localhost:11434/v1"
+release:
+  npmToken: "${env:NPM_TOKEN}"
 ```
 
 <Warning>
-`local.secret.yaml` must never be committed to git. ADE adds it to `.gitignore` automatically, but also add it manually if your project has nested `.gitignore` files. Run `git check-ignore -v .ade/local.secret.yaml` to verify it is excluded.
+`local.secret.yaml` must never be committed to git. ADE adds it to `.gitignore` automatically, but also add it manually if your project has nested `.gitignore` files. Run `git check-ignore -v .ade/local.secret.yaml` to verify it is excluded. Store AI provider API keys with Settings → AI Providers whenever possible; ADE persists those credentials in the OS credential store or encrypted `.ade/secrets/api-keys.v1.bin`.
 </Warning>
 
 ---
@@ -240,10 +227,10 @@ ADE watches all three config files using filesystem events (debounced 500ms). Ch
 |------|------------------------|
 | `ade.yaml` | ADE detects the change, diffs against the approved SHA, and suspends commands until you approve the new version |
 | `local.yaml` | Applied immediately; UI reflects changes (theme, font, notification preferences) within one render cycle |
-| `local.secret.yaml` | API key changes take effect on the next agent call; GitHub and Linear token changes trigger a refresh of the affected integration |
+| `local.secret.yaml` | Automation secret refs reload for services that watch or request secrets; provider keys managed in Settings use the encrypted credential store |
 
 <Tip>
-If you update an API key in `local.secret.yaml` while an agent is mid-session, the new key is used on the next API call. The in-flight request completes with the old key. No session restart is needed.
+If you update a value in `local.secret.yaml`, automation code that resolves the related `secretRef` uses the new value on its next read. In-flight work keeps the value it already loaded.
 </Tip>
 
 ---
@@ -252,20 +239,20 @@ If you update an API key in `local.secret.yaml` while an agent is mid-session, t
 
 <AccordionGroup>
   <Accordion title="What to commit" icon="check">
-    **Commit `ade.yaml`.** It contains the team's shared AI model defaults, lane profiles, automation definitions, test suite config, and process definitions. Committing it ensures all team members use the same baseline configuration.
+    **Commit `ade.yaml`.** It contains the team's shared AI model defaults, lane templates, automation definitions, test suite config, and process definitions. Committing it ensures all team members use the same baseline configuration.
 
     Do not commit `local.yaml` or `local.secret.yaml`. ADE's `.gitignore` entries cover these, but double-check when initializing new repositories.
   </Accordion>
   <Accordion title="Rotating API keys" icon="rotate">
-    To rotate an API key: update the value in `local.secret.yaml` and save. ADE hot-reloads the file and uses the new key on the next API call. The old key is never cached — once the file is saved, the old value is gone from memory.
+    To rotate an AI provider API key, use Settings → AI Providers. ADE writes the new value to the encrypted credential store and uses it on the next provider call. Do not put provider keys in committed `ade.yaml`.
 
     Never commit the old or new key values to git during rotation. If a key was accidentally committed, revoke it at the provider immediately regardless of whether you have since removed it from the file.
   </Accordion>
   <Accordion title="Reviewing ade.yaml changes from teammates" icon="users">
-    When you `git pull` and `ade.yaml` has changed, ADE shows the approval dialog before resuming any command execution. Read the diff carefully — pay particular attention to changes in `automations[*].executor`, `processes[*].command`, and `testSuites[*].ci`. These fields define commands that will run on your machine.
+    When you `git pull` and `ade.yaml` has changed, ADE shows the approval dialog before resuming any command execution. Read the diff carefully — pay particular attention to changes in `automations[*].executor`, `processes[*].command`, and `testSuites[*].command`. These fields define commands that will run on your machine.
   </Accordion>
   <Accordion title="Using environment variables instead of file values" icon="terminal">
-    For CI environments or machines where you cannot write files, ADE supports supplying API keys via environment variables. Set `ADE_ANTHROPIC_API_KEY`, `ADE_OPENAI_API_KEY`, etc. in the process environment before launching ADE. Environment variable values take precedence over `local.secret.yaml`.
+    For CI environments or machines where you cannot write credential-store values, provider runtimes can read standard provider variables such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`, `GOOGLE_API_KEY`, and `CURSOR_API_KEY`. Automation secrets can also reference environment values from `local.secret.yaml` with `${env:NAME}`.
   </Accordion>
   <Accordion title="Multiple projects on the same machine" icon="folder-open">
     Each project has its own `.ade/` directory with its own `local.yaml` and `local.secret.yaml`. You can use different API keys or different preferred models for different projects. Settings in one project's `.ade/` never affect another project.

--- a/configuration/overview.mdx
+++ b/configuration/overview.mdx
@@ -226,7 +226,7 @@ ADE watches all three config files using filesystem events (debounced 500ms). Ch
 | File | What happens on change |
 |------|------------------------|
 | `ade.yaml` | ADE detects the change, diffs against the approved SHA, and suspends commands until you approve the new version |
-| `local.yaml` | Applied immediately; UI reflects changes (theme, font, notification preferences) within one render cycle |
+| `local.yaml` | Parsed project-config overrides, such as `ai`, `git`, `github`, lane templates, and automations, are reloaded for this machine |
 | `local.secret.yaml` | Automation secret refs reload for services that watch or request secrets; provider keys managed in Settings use the encrypted credential store |
 
 <Tip>

--- a/configuration/permissions.mdx
+++ b/configuration/permissions.mdx
@@ -70,20 +70,20 @@ ADE is built on a **local-first, trust boundary model**. Your source code, API k
     All command execution sourced from `ade.yaml` pauses. This includes: automation triggers, process startup commands, test suite runs, and worker run executors defined in the config. Agents that are mid-session continue their current operation but cannot launch new commands from the updated config.
   </Step>
   <Step title="Diff presented">
-    ADE shows a structured diff of every changed field in `ade.yaml`. Fields that define commands (`processes[*].command`, `automations[*].executor`, `testSuites[*].run`, `testSuites[*].ci`) are highlighted with a distinct visual treatment — these are the fields that matter most for security review.
+    ADE shows a structured diff of every changed field in `ade.yaml`. Fields that define commands (`processes[*].command`, `automations[*].executor`, `testSuites[*].command`) are highlighted with a distinct visual treatment — these are the fields that matter most for security review.
   </Step>
   <Step title="User reviews and decides">
     You choose one of three actions:
-    - **Approve** — the new SHA is recorded in `local.yaml` and command execution resumes
+    - **Approve** — the new SHA is recorded in local ADE state and command execution resumes
     - **Reject** — ADE reverts to the last-approved version (runs `git checkout .ade/ade.yaml` against the approved SHA)
     - **Dismiss** — the diff dialog closes but commands remain suspended until you approve or reject
   </Step>
   <Step title="SHA recorded">
-    On approval, ADE writes the SHA of the approved file to `local.yaml` under `trust.approvedSha`. This is machine-specific — teammates must approve the same change on their own machines.
+    On approval, ADE records the SHA of the approved file in local ADE state. This is machine-specific — teammates must approve the same change on their own machines.
   </Step>
 </Steps>
 <Warning>
-Do not edit `trust.approvedSha` manually. ADE treats any mismatch between the stored SHA and the current file as an unapproved change and will suspend commands until the approval flow completes. If `local.yaml` becomes inconsistent, use Settings → Config → Re-approve current config.
+Do not try to bypass the trust record manually. ADE treats any mismatch between the stored SHA and the current file as an unapproved change and will suspend commands until the approval flow completes. Use Settings → Config → Re-approve current config when you need to approve the current file again.
 </Warning>
 
 ---
@@ -372,7 +372,7 @@ Every agent action that touches sensitive resources is logged to `.ade/artifacts
     Set restrictive defaults in `ade.yaml` — blocked commands, protected branches, conservative automation permissions. Individual developers can grant themselves additional permissions via `local.yaml` for their machine. It is easier to relax restrictions than to discover that an agent did something unexpected on everyone's machine.
   </Accordion>
   <Accordion title="Review ade.yaml changes in PRs explicitly" icon="eye">
-    Treat `ade.yaml` changes in PRs with the same scrutiny as `Dockerfile` or CI pipeline changes. Any new `processes[*].command`, `automations[*].executor`, or `testSuites[*].ci` entry is a new command that will run on every team member's machine after they pull and approve.
+    Treat `ade.yaml` changes in PRs with the same scrutiny as `Dockerfile` or CI pipeline changes. Any new `processes[*].command`, `automations[*].executor`, or `testSuites[*].command` entry is a new command that will run on every team member's machine after they pull and approve.
 
     Consider adding a CI lint step that fails if `ade.yaml` changes without a review from a designated security reviewer.
   </Accordion>

--- a/configuration/settings.mdx
+++ b/configuration/settings.mdx
@@ -21,7 +21,7 @@ Settings are organized into nine sections in the left navigation panel. Changes 
   <Card title="AI" icon="brain" href="#ai">Providers, per-role models, context management.</Card>
   <Card title="Mobile Push" icon="mobile" href="#mobile-push">iPhone pairing, tailnet discovery, and push notifications.</Card>
   <Card title="Integrations" icon="plug" href="#integrations">GitHub, Linear, and proof backends.</Card>
-  <Card title="Lane Templates" icon="layer-group" href="#lane-templates">Reusable lane profiles and defaults.</Card>
+  <Card title="Lane Templates" icon="layer-group" href="#lane-templates">Reusable lane templates and defaults.</Card>
   <Card title="Usage" icon="bolt" href="#usage">Spend graphs and monthly totals across providers.</Card>
 </CardGroup>
 
@@ -344,8 +344,6 @@ The monthly cap is a hard stop. Once reached, all agent activity (chat, worker r
     Understand the full trust boundary model and configure per-agent access rules.
   </Card>
   <Card title="Configuration Overview" icon="gear" href="/configuration/overview">
-    Review the .ade/ directory structure and the three config file layers.
+    Review the .ade/ directory structure, project config overlays, and local secret references.
   </Card>
 </CardGroup>
-</content>
-</invoke>

--- a/cto/overview.mdx
+++ b/cto/overview.mdx
@@ -1,16 +1,16 @@
 ---
 title: "CTO Agent Overview"
-description: "The CTO is ADE's always-on, project-aware AI agent — the top of an intelligent org chart that watches your project, delegates work, syncs with Linear, and answers questions about your codebase."
+description: "The CTO is ADE's project-aware AI surface — the top of an intelligent org chart for delegating work, syncing with Linear, and answering questions about your codebase."
 icon: "crown"
 ---
 
 ## What is the CTO Agent?
 
-The **CTO** (Chief Technical Officer) is ADE's persistent, project-scoped AI agent — always running in the background watching commits, monitoring lane status, tracking PR progress, and coordinating worker agents. Its system prompt includes a **Daily Context** routine (check recent decisions and worker activity at each activation) and a **Decision Framework** (act autonomously when safe, escalate when risky). These protocols survive compaction.
+The **CTO** (Chief Technical Officer) is ADE's persistent, project-scoped AI surface for coordinating worker agents. Its system prompt includes a **Daily Context** routine (check recent decisions and worker activity at each activation) and a **Decision Framework** (act autonomously when safe, escalate when risky). These protocols survive compaction.
 
 <CardGroup cols={2}>
-  <Card title="Always-On Awareness" icon="eye">
-    Runs on a configurable heartbeat, checking for new commits, PR status changes, Linear issue updates, and stuck lanes — even when you are not looking.
+  <Card title="Worker Wakeups" icon="eye">
+    Workers can be woken on demand or by per-worker timer settings from CTO > Team.
   </Card>
   <Card title="Org Chart Model" icon="sitemap">
     The CTO sits at the top of an agent hierarchy. It spawns and coordinates specialized Worker agents (Employees) to handle specific tasks.
@@ -34,10 +34,10 @@ Understanding how the CTO differs from the agents you spawn manually (in chat se
 
 | | **CTO Agent** | **Regular / Worker Agent** |
 |--|---------------|---------------------------|
-| **Lifecycle** | Always on; persistent across sessions | Ephemeral; lives for one task or session |
+| **Lifecycle** | Persistent project-scoped chat and coordination context | Ephemeral or persistent worker identity |
 | **Scope** | Entire project | Specific lane, task, or worker run |
 | **Context** | Project, lane, PR, Linear, and worker run state | Current session or assigned lane |
-| **Triggers** | Heartbeat schedule + events + manual chat | Explicit user action or automation trigger |
+| **Triggers** | Manual chat, Linear/PR workflows, and worker wakeups | Explicit user action, automation trigger, or per-worker timer |
 | **Authority** | Can spawn lanes, create worker runs, delegate to workers, drive PR convergence | Operates within its assigned lane/context |
 | **Linear access** | Full bidirectional sync (owner) | Read-only via ADE CLI tools, if granted |
 | **Primary UI** | CTO tab | Lane terminal, Chat pane, Workers tab |
@@ -50,17 +50,17 @@ The CTO implements an **org chart model** for AI work delegation.
 
 ```
 CTO (always-on, project-scoped)
-├── Worker: "auth-specialist"   (assigned to lane/auth-refactor)
+├── Worker: "auth-specialist"   (specialized for auth work)
 ├── Worker: "test-writer"       (ephemeral, created for one task)
 └── Worker: "pr-reviewer"       (persistent, reviews all new PRs)
 ```
 
 The CTO sits at the top. Below it are **Worker agents** (also called Employees) — specialized sub-agents the CTO creates and assigns to specific tasks or lanes. Workers have:
 
-- A **name** and **specialization prompt** that defines their role and constraints
-- An **assigned lane** (optional; some workers operate across lanes)
-- A **tool palette** — a subset of ADE CLI tools they are permitted to use
-- A **budget limit** — a token/cost cap enforced by the CTO
+- A **name**, **role**, **title**, and **capabilities** that define their focus
+- Optional **Linear identity matching** fields so incoming Linear work can map back to the right worker
+- An **adapter** and model/process command for the runtime that will execute work
+- A **monthly budget** and optional heartbeat settings
 
 The CTO coordinates workers: it assigns tasks, monitors their output, routes their results back to Linear or PRs, and intervenes if a worker is stuck or over budget.
 
@@ -70,7 +70,7 @@ The CTO coordinates workers: it assigns tasks, monitors their output, routes the
 
 <CardGroup cols={2}>
   <Card title="Setting Up the CTO" icon="wand-magic-sparkles" href="/cto/setup">
-    Walk through onboarding, heartbeat configuration, and verifying the CTO is active.
+    Walk through onboarding, worker heartbeat configuration, and verifying the CTO team is active.
   </Card>
   <Card title="Linear Integration" icon="arrow-right-arrow-left" href="/cto/linear">
     Connect Linear for bidirectional issue sync, status updates, and intelligent triage.

--- a/cto/setup.mdx
+++ b/cto/setup.mdx
@@ -56,7 +56,7 @@ This also applies to worker agents that have an identity key assigned.
 
 ### Manual activation
 
-You can trigger the CTO immediately from the UI:
-- Click **Run Heartbeat Now** in the CTO Status panel
-- Type a message in the CTO Chat — this activates the CTO in conversational mode
+You can trigger CTO work immediately from the UI:
+- Select a worker in **CTO > Team** and click **Wake** to create a manual worker wakeup
+- Type a message in the CTO Chat to activate the CTO in conversational mode
 - Via Automations using a real action such as `agent-session` for worker sessions or `ade-action` for a registered ADE action

--- a/cto/setup.mdx
+++ b/cto/setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Setting Up the CTO"
-description: "Walk through the CTO onboarding wizard, configure heartbeat schedules, and verify the CTO is active and monitoring your project."
+description: "Walk through the CTO onboarding wizard, configure worker heartbeat schedules, and verify the CTO team is active."
 icon: "wand-magic-sparkles"
 ---
 
@@ -14,76 +14,39 @@ icon: "wand-magic-sparkles"
     The wizard walks through three steps:
     1. **Identity creation** — give the CTO a name and an initial persona prompt. This shapes how it communicates and what it prioritizes.
     2. **Project scanning** — the CTO reads your repository structure, existing PRD/architecture docs, recent git history, and `.ade/` state to build its initial Project Pack. This takes 30–90 seconds on a typical project.
-    3. **Integration handoff** — optionally connect Linear (OAuth or manual token) and configure the heartbeat schedule.
+    3. **Integration handoff** — optionally connect Linear (OAuth or manual token) and review the CTO team setup.
 
   </Step>
-  <Step title="Configure the heartbeat">
-    In **CTO > Settings**, set the heartbeat interval. The default is every 15 minutes. You can also configure event-based triggers (e.g., "run when a PR is opened", "run when a lane enters conflict status").
+  <Step title="Configure worker heartbeats">
+    In **CTO > Team**, edit a worker and enable **Timer-based heartbeat**. The interval is stored per worker in seconds; the UI defaults to `300`.
   </Step>
   <Step title="Verify the CTO is active">
-    The CTO Status panel (top of the CTO > Chat sub-tab) shows the last heartbeat time, next scheduled heartbeat, and a green "Active" badge. If it shows "Inactive", check that at least one AI provider is configured in Settings > AI Providers.
+    The CTO surfaces worker state from the Team and Chat views. If a worker cannot run, check that at least one AI provider is configured in Settings > AI Providers.
   </Step>
 </Steps>
 
 ---
 
-## Heartbeat Configuration
+## Worker Heartbeat Configuration
 
-The CTO's heartbeat is its core activation mechanism. On each heartbeat, the CTO runs a full project scan and takes any warranted actions.
+Worker heartbeats are per-agent runtime settings. When enabled, ADE wakes that worker on a timer and runs the worker heartbeat service for that agent.
 
-### What the CTO checks on each heartbeat
+### What happens on each heartbeat
 
-1. **New commits** — compares HEAD SHAs across all lanes to its last-known state
-2. **PR status changes** — checks for newly opened, approved, merged, or failed PRs
-3. **Linear issue updates** — polls for new comments, status transitions, and assignments in connected projects
-4. **Stuck lanes** — identifies lanes in `blocked` or `conflict` status longer than a configurable threshold
-5. **Budget overruns** — flags workers that have exceeded or are approaching their token/cost budgets
-6. **Stale Lane Packs** — identifies packs that have not been regenerated after recent commits
+ADE creates a worker wakeup request with reason `timer`, reconstructs the worker's recent context, and asks the worker to respond with `HEARTBEAT_OK` when no action is required. Wakeups with explicit prompts, events, changes, or task context are escalated into worker work; quiet timer wakeups can complete without action.
 
 ### Heartbeat schedule options
 
-<Tabs>
-  <Tab title="Interval-based">
-    Run every N minutes. Suitable for active development days where you want frequent check-ins.
+Configure heartbeats in **CTO > Team** on each worker:
 
-    ```yaml
-    # .ade/ade.yaml
-    cto:
-      heartbeat:
-        mode: interval
-        interval_minutes: 15
-    ```
-  </Tab>
-  <Tab title="Event-based">
-    Run when specific events occur. Lower noise; triggers only when something notable happens.
+| Setting | Meaning |
+|---|---|
+| Timer-based heartbeat | Enables scheduled wakeups for that worker |
+| Interval (seconds) | Number of seconds between wakeups; the UI default is `300` |
+| Wake on demand | Allows ADE to wake the worker immediately for matching work |
+| Active hours | Restricts wakeups to a start/end window and timezone |
 
-    ```yaml
-    cto:
-      heartbeat:
-        mode: events
-        triggers:
-          - pr_opened
-          - pr_merged
-          - lane_blocked
-          - lane_conflict
-          - linear_issue_assigned
-    ```
-  </Tab>
-  <Tab title="Combined">
-    Both interval and events — interval provides a regular health check while events provide immediate response to important changes.
-
-    ```yaml
-    cto:
-      heartbeat:
-        mode: combined
-        interval_minutes: 30
-        triggers:
-          - pr_opened
-          - lane_blocked
-          - linear_issue_assigned
-    ```
-  </Tab>
-</Tabs>
+This state is stored on the worker identity as `runtimeConfig.heartbeat`. ADE does not parse a project-level `.ade/ade.yaml` `cto.heartbeat` block.
 
 ### Identity Restoration After Compaction
 
@@ -96,4 +59,4 @@ This also applies to worker agents that have an identity key assigned.
 You can trigger the CTO immediately from the UI:
 - Click **Run Heartbeat Now** in the CTO Status panel
 - Type a message in the CTO Chat — this activates the CTO in conversational mode
-- Via Automations using the `cto-route` executor mode
+- Via Automations using a real action such as `agent-session` for worker sessions or `ade-action` for a registered ADE action

--- a/cto/workers.mdx
+++ b/cto/workers.mdx
@@ -12,14 +12,14 @@ Workers are the CTO's execution arms. The CTO plans and delegates; workers imple
 
 <AccordionGroup>
   <Accordion title="Persistent Workers" icon="person">
-    Persistent workers are assigned to a lane or a role and stay active across heartbeat cycles. Use them for ongoing responsibilities like "always review PRs in this repository" or "monitor the auth module and flag regressions".
+    Persistent workers are assigned to a role and can stay available across wakeups. Use them for ongoing responsibilities like "review PRs in this repository" or "monitor the auth module and flag regressions".
 
-    A persistent worker has a standing assignment and a defined tool palette. It activates when its trigger condition is met (e.g., a new PR opens) and returns to idle when the task is complete.
+    A persistent worker has a standing identity, capabilities, runtime settings, and optional heartbeat configuration. It returns to idle when the task is complete.
   </Accordion>
   <Accordion title="Ephemeral Workers" icon="person-running">
     Ephemeral workers are created for a single task and dissolved when that task is complete. The CTO creates ephemeral workers automatically when it decides a task needs dedicated execution — for example, when it receives a complex request in chat or when a Linear issue comes in that requires implementation.
 
-    Ephemeral workers clean up their lane (or operate in an existing lane) and report results back to the CTO before dissolving.
+    Ephemeral workers report results back to the CTO before dissolving.
   </Accordion>
 </AccordionGroup>
 
@@ -34,14 +34,14 @@ You can create a worker from the **Team sub-tab** without going through the CTO 
   <Step title="Configure the worker">
     Fill in:
     - **Name** — a human-readable identifier (e.g., "test-writer", "pr-reviewer")
-    - **Specialization prompt** — describes the worker's role, constraints, and focus area
-    - **Assigned lane** — the lane this worker operates in (leave blank for cross-lane workers)
-    - **Tool palette** — which ADE CLI tools this worker can use (defaults to a safe read/write subset)
-    - **Budget limit** — maximum token/cost for this worker per activation
-    - **Type** — Persistent or Ephemeral
+    - **Role, title, and capabilities** — describe the worker's focus area
+    - **Linear identity matching** — user IDs, display names, or aliases that map Linear assignments to this worker
+    - **Adapter and model/process command** — the runtime configuration used for work
+    - **Budget** — monthly dollar budget tracked for this worker
+    - **Heartbeat** — optional timer-based wakeups, wake-on-demand, active hours, and max concurrency
   </Step>
   <Step title="Activate the worker">
-    Click **Hire**. The worker appears in the Team org chart with `idle` status. The CTO will use it on the next applicable heartbeat or task delegation.
+    Click **Hire**. The worker appears in the Team org chart with `idle` status. The CTO can use it on the next applicable task delegation or worker wakeup.
   </Step>
 </Steps>
 
@@ -55,41 +55,26 @@ Worker activity is visible in two places:
 
 ## Budget Management
 
-Every agent in ADE — including the CTO itself and all workers — has a configurable token/cost budget. The CTO enforces these limits.
+Workers have configurable monthly budgets for tracking and routing decisions. Provider/session caps are configured separately under AI provider settings.
 
 ### Budget hierarchy
 
 ```
-Project Budget (global cap)
-└── CTO Budget (per heartbeat cycle)
-    ├── Worker: auth-specialist Budget
-    ├── Worker: test-writer Budget
-    └── Ephemeral Worker Budget (inherited from CTO settings)
+AI provider/session caps
+└── Worker monthly budgets
+    ├── Worker: auth-specialist
+    ├── Worker: test-writer
+    └── Ephemeral worker runtime settings
 ```
 
 ### How budget enforcement works
 
-- **Subscription users**: Budgets are tracked internally for visibility and reported as informational. ADE reads session logs from `~/.claude/` to compute accurate token usage. Budget alerts fire when thresholds are hit, but agents are not hard-stopped.
-- **API key users**: Budgets are strictly enforced. When a worker reaches its budget cap, it pauses and the CTO is notified. The CTO decides whether to extend the budget, hand the task to a different worker, or escalate to you.
+- **Worker budgets**: CTO > Team stores a monthly dollar budget on each worker identity.
+- **Provider/session caps**: Settings > AI Providers and chat/session settings control runtime provider budgets and usage display.
 
 ### Configuring budgets
 
-<Tabs>
-  <Tab title="In Settings UI">
-    Go to **Settings > CTO > Budget**. Set the per-heartbeat CTO budget, default worker budget, and the global project cap. These apply to all workers unless overridden at the worker level.
-  </Tab>
-  <Tab title="In ade.yaml">
-    ```yaml
-    # .ade/ade.yaml
-    cto:
-      budget:
-        per_heartbeat_tokens: 50000
-        default_worker_tokens: 20000
-        alert_threshold: 0.8   # alert at 80% of cap
-        hard_stop_api_only: true
-    ```
-  </Tab>
-</Tabs>
+Configure worker budgets in **CTO > Team** when hiring or editing a worker. The value is stored on the worker identity; ADE does not parse a project-level `.ade/ade.yaml` `cto.budget` block.
 
 ---
 
@@ -117,53 +102,45 @@ You can ask the CTO for a narrative summary of recent activity at any time:
 
 _"Summarize what changed in the project since yesterday morning. What's blocked? What shipped? What's at risk?"_
 
-The CTO draws from recent checkpoint history, lane state, and PR status to produce a structured summary. This can also be generated automatically as part of each heartbeat cycle.
+The CTO draws from available project context, recent lane state, and PR status to produce a structured summary.
 
 ### Routing an incoming request via Automations
 
-To have external webhooks or scheduled triggers route to the CTO automatically, configure an Automation with executor mode `cto-route`:
+To have external webhooks or scheduled triggers start work automatically, configure an Automation with real action types such as `agent-session` or `ade-action`:
 
 ```yaml
-# Example: route all new Linear issues to the CTO
-trigger:
-  type: linear-issue-created
-  filter:
-    project: "Backend API"
-executor:
-  mode: cto-route
-  message: "A new Linear issue has been created. Triage it and decide whether to create a worker run, assign to a worker, or flag for human review."
+# Example: start an agent session for new Linear issues
+automations:
+  - id: "linear-triage"
+    name: "Linear triage"
+    trigger:
+      type: "linear.issue_created"
+    execution:
+      kind: "agent-session"
+      laneMode: "reuse"
+    executor:
+      mode: "automation-bot"
+    prompt: "Triage the new Linear issue and recommend whether to create a lane, assign a worker, or flag it for human review."
 ```
 
 ---
 
-## CTO Configuration Reference
+## CTO Worker Configuration Reference
 
-All CTO configuration lives under `cto:` in `.ade/ade.yaml`, with a UI mirror in **Settings > CTO**.
+Worker identity and heartbeat settings are managed in **CTO > Team** and stored in ADE's local worker identity state. Project automation rules still live in `.ade/ade.yaml`.
 
 ```yaml
-cto:
-  name: "CTO"                          # Display name in UI
-  persona: |                            # Initial identity prompt
-    You are a senior engineer who
-    knows this codebase deeply...
+# Worker runtime state shape, shown for reference only.
+runtimeConfig:
   heartbeat:
-    mode: combined                      # interval | events | combined
-    interval_minutes: 15
-    triggers:
-      - pr_opened
-      - lane_blocked
-      - linear_issue_assigned
-  workers:
-    default_budget_tokens: 20000
-    default_tool_palette: standard      # standard | minimal | full
-    auto_dissolve_ephemeral: true
-  linear:
-    sync_enabled: true
-    auto_create_issues: true
-    auto_close_on_merge: true
-  budget:
-    per_heartbeat_tokens: 50000
-    alert_threshold: 0.8
+    enabled: true
+    intervalSec: 300
+    wakeOnDemand: true
+    activeHours:
+      start: "09:00"
+      end: "22:00"
+      timezone: "local"
+  maxConcurrentRuns: 1
 ```
 
 ---
@@ -174,18 +151,13 @@ cto:
   <Accordion title="CTO shows 'Inactive' status" icon="circle-xmark">
     The CTO requires at least one AI provider to be configured. Check **Settings > AI Providers** and verify that a provider is active and its credentials are valid. The CTO also needs the ADE RPC socket to be ready — if you see socket or RPC errors in the main process log, restart ADE.
   </Accordion>
-  <Accordion title="Heartbeat runs but the CTO takes no action" icon="clock">
-    This is usually expected — the CTO only acts when it detects something actionable. Check the **Recent Actions Log** in the CTO Status panel to confirm the heartbeat ran. If the log shows "No actions needed", the CTO saw no changes worth acting on. You can lower the action threshold in Settings > CTO > Heartbeat Sensitivity.
+  <Accordion title="Worker heartbeat runs but takes no action" icon="clock">
+    This is usually expected. Timer wakeups can complete with `HEARTBEAT_OK` when no action is required. Check the worker run history or logs for the heartbeat result.
 
-    If the heartbeat log is empty despite visible project changes, verify that the lane's git history is accessible and that ADE's main process has read access to the `.git` directory.
+    If no heartbeat appears, verify that the worker has **Timer-based heartbeat** enabled, a positive interval in seconds, and active hours that include the current time.
   </Accordion>
   <Accordion title="Budget exhausted — CTO or worker paused" icon="gauge">
-    When a budget is exhausted, the affected agent pauses and an alert appears in the CTO Status panel. For API key users, you can:
-    - Click **Extend Budget** in the alert to increase the cap for this run
-    - Click **Resume with Different Model** to switch to a more cost-efficient model
-    - Click **Dismiss** to cancel the current task
-
-    For subscription users, budget exhaustion is informational. The agent will not be hard-stopped.
+    Review the worker's monthly budget in CTO > Team and the active provider/session budget in Settings > AI Providers or the chat/session controls. Increase the relevant cap or route the work to a cheaper model when needed.
   </Accordion>
   <Accordion title="Linear sync is not updating issues" icon="arrow-right-arrow-left">
     Check the **Linear sub-tab** for the sync status indicator. Common causes:

--- a/getting-started/first-lane.mdx
+++ b/getting-started/first-lane.mdx
@@ -18,7 +18,7 @@ The **Primary Lane** is your main repository checkout. It always exists and cann
 
 <Steps>
   <Step title="Open the Lanes view">
-    Click the **Lanes** icon (branch icon) in the left sidebar, or press `Cmd+Shift+L` to jump directly to the new lane dialog.
+    Click the **Lanes** icon (branch icon) in the left sidebar. You can also open the command palette with `Cmd/Ctrl+K` and choose **Create Lane**.
   </Step>
   <Step title="Click New Lane">
     Click the **+ New Lane** button at the top of the lane list. The creation dialog opens.

--- a/lanes/creating.mdx
+++ b/lanes/creating.mdx
@@ -10,7 +10,7 @@ The New Lane dialog walks you through three ways to start, selected by tabs at t
 
 <Steps>
   <Step title="Open the dialog">
-    Click **+ New Lane** at the top of the lane list, or press `Cmd+Shift+L`. The dialog description reads *"Create a lane from Primary, an existing branch, or another lane."*
+    Click **+ New Lane** at the top of the lane list, or open the command palette with `Cmd/Ctrl+K` and choose **Create Lane**. The dialog description reads *"Create a lane from Primary, an existing branch, or another lane."*
   </Step>
   <Step title="Name the lane">
     The name is used for both the lane identifier and the worktree directory name. Keep it task-oriented (`add-health-endpoint`, `fix-auth-redirect`) rather than generic.
@@ -68,15 +68,16 @@ Deleted lane history (packs, checkpoints, sessions) stays in ADE's local databas
 
 | Action | Shortcut |
 |---|---|
-| New Lane | `Cmd+Shift+L` |
-| Focus lane list | `Cmd+1` |
-| Next lane | `Cmd+]` |
-| Previous lane | `Cmd+[` |
-| Open lane in Graph | `Cmd+G` |
-| Commit staged changes | `Cmd+Enter` |
-| Stage all changes | `Cmd+Shift+A` |
-| Archive lane | `Cmd+Shift+W` |
-| Regenerate Lane Pack | `Cmd+Shift+P` |
+| Open command palette | `Cmd/Ctrl+K` |
+| Focus lane filter | `/` or `Cmd/Ctrl+F` |
+| Select next lane | `J` or `Down Arrow` |
+| Select previous lane | `K` or `Up Arrow` |
+| Select next lane tab | `]` |
+| Select previous lane tab | `[` |
+| Pin selected lane tab | `Enter` |
+| Commit staged changes | `Cmd/Ctrl+Enter` in the commit message field |
+
+Create Lane is available from the command palette and the **+ New Lane** button; it does not have a dedicated keyboard shortcut.
 
 ---
 

--- a/lanes/packs.mdx
+++ b/lanes/packs.mdx
@@ -65,7 +65,6 @@ ADE regenerates the Lane Pack automatically after each committed checkpoint. The
 
 Lane Packs refresh automatically on commit. You can also trigger a manual refresh:
 
-- **Keyboard shortcut** — press `Cmd+Shift+P` from any view in the lane
 - **Packs sub-tab** — click the **Regenerate** button in the right inspector's Packs sub-tab
 - **Agent request** — ask the agent: *"Regenerate the lane pack"* (the agent calls the pack refresh ADE CLI tool)
 
@@ -140,7 +139,7 @@ This means an agent working in a child lane knows:
 
 <AccordionGroup>
   <Accordion title="Pack shows amber freshness but I just committed" icon="clock">
-    Pack regeneration runs asynchronously after a commit. Wait a few seconds, then check again. If it stays amber, trigger a manual refresh with `Cmd+Shift+P`.
+    Pack regeneration runs asynchronously after a commit. Wait a few seconds, then check again. If it stays amber, trigger a manual refresh from the Packs sub-tab.
   </Accordion>
   <Accordion title="Agent is ignoring the lane context" icon="robot">
     Verify the pack exists and is fresh in the Packs sub-tab. If the pack is empty or missing, the agent may have started without lane-specific context. Regenerate the pack and start a new session.

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -123,10 +123,27 @@ for (const target of collectConfigTargets(docsConfig)) {
 
 const inlineHrefPattern = /\b(?:href|src)=["']([^"']+)["']/g;
 const markdownLinkPattern = /!?\[[^\]]*\]\(([^)]+)\)/g;
+const leakedAgentMarkupPattern = /<\/(?:invoke|content)>|<parameter\b|antml:/g;
+
+function lineNumberForIndex(content, index) {
+  let line = 1;
+  for (let i = 0; i < index; i += 1) {
+    if (content.charCodeAt(i) === 10) line += 1;
+  }
+  return line;
+}
 
 for (const file of docFiles) {
   const content = await fs.readFile(path.join(repoRoot, file), "utf8");
   const seenTargets = new Set();
+
+  if (file.endsWith(".mdx")) {
+    leakedAgentMarkupPattern.lastIndex = 0;
+    let artifactMatch;
+    while ((artifactMatch = leakedAgentMarkupPattern.exec(content)) !== null) {
+      errors.push(`${file}:${lineNumberForIndex(content, artifactMatch.index)}: remove leaked agent tool-call markup ${artifactMatch[0]}`);
+    }
+  }
 
   for (const pattern of [inlineHrefPattern, markdownLinkPattern]) {
     pattern.lastIndex = 0;

--- a/tools/workspace-graph.mdx
+++ b/tools/workspace-graph.mdx
@@ -24,7 +24,7 @@ The Workspace Graph is ADE's spatial view of your project — every Lane, PR, br
 
 ## Opening the Graph
 
-Press `Cmd+G` from anywhere in ADE, or click the **Graph** icon (sixth icon) in the left sidebar. The graph opens as a full-screen tab in the main panel.
+Click the **Graph** icon in the left sidebar. The graph opens as a full-screen tab in the main panel.
 
 <Tip>
 The graph updates live. If an agent commits code or a PR changes review status while the graph is open, the relevant node refreshes automatically — no manual reload needed.
@@ -249,13 +249,10 @@ ELK layout runs automatically when new lanes are added or when lanes are archive
 
 | Shortcut | Action |
 |----------|--------|
-| `Cmd+G` | Open the Workspace Graph |
-| `Cmd+A` | Select all nodes |
-| `Cmd+0` | Fit all nodes into view |
-| `Cmd+Shift+M` | Run merge simulation |
-| `Shift+Click` | Add node to selection |
-| `Escape` | Deselect all / cancel drag |
-| `Delete` | Archive selected lane(s) (shows confirmation dialog) |
+| `Shift+Enter` | Open the context menu for the selected lane |
+| `Arrow Up` / `Arrow Left` | Move selection to the selected lane's parent |
+| `Arrow Down` / `Arrow Right` | Move selection to the selected lane's first child |
+| `Escape` | Close open menus or panels |
 | `Cmd++` / `Cmd+-` | Zoom in / zoom out |
 
 ---

--- a/tools/workspace-graph.mdx
+++ b/tools/workspace-graph.mdx
@@ -131,7 +131,7 @@ The merge simulation feature predicts what would happen if each lane's branch we
 
 <Steps>
   <Step title="Click 'Simulate Merges'">
-    Click the **Simulate Merges** button in the graph toolbar (or press `Cmd+Shift+M`). ADE queues merge simulation jobs for all visible lanes.
+    Click the **Simulate Merges** button in the graph toolbar. ADE queues merge simulation jobs for all visible lanes.
   </Step>
   <Step title="Wait for results">
     The simulation runs in the background. Individual edge annotations appear as each lane's simulation completes — you do not need to wait for all lanes. Typically 2-5 seconds per lane depending on diff size.
@@ -192,7 +192,6 @@ Select multiple nodes to perform bulk operations across lanes.
 **Selecting multiple nodes:**
 - **Shift+click**: Add individual nodes to the selection
 - **Drag-select**: Click and drag on empty canvas space to draw a selection rectangle
-- **Cmd+A**: Select all visible nodes
 
 Once nodes are selected, the batch operations toolbar appears at the bottom of the screen:
 
@@ -209,7 +208,7 @@ Once nodes are selected, the batch operations toolbar appears at the bottom of t
 
 <CardGroup cols={2}>
   <Card title="Zoom" icon="magnifying-glass">
-    Scroll (trackpad pinch or mouse wheel) to zoom in and out. `Cmd+0` fits all nodes into view. `Cmd++` and `Cmd+-` zoom in/out in steps.
+    Scroll (trackpad pinch or mouse wheel) to zoom in and out. Use the graph zoom controls to zoom in, zoom out, or fit the graph.
   </Card>
   <Card title="Pan" icon="hand">
     Click and drag on empty canvas space to pan. On a trackpad, two-finger scroll pans the canvas without zooming.
@@ -272,7 +271,7 @@ ELK layout runs automatically when new lanes are added or when lanes are archive
     `git merge-tree` works best on linear histories. On branches with merge commits, ADE uses the branch tip as the simulation target. The simulation may report false negatives (fewer conflicts than will actually occur) in complex octopus-merge scenarios.
   </Accordion>
   <Accordion title="Graph not updating" icon="rotate">
-    If the graph appears stale, press `Cmd+R` to force a full refresh from the database. This is rare — the graph subscribes to live IPC events from the main process. If the issue persists, check that the ADE main process is running and the IPC bridge is healthy (visible in `Settings → Diagnostics`).
+    The graph subscribes to live IPC events from the main process. If it appears stale, use the visible refresh controls in the graph surface. If the issue persists, check that the ADE main process is running and the IPC bridge is healthy (visible in `Settings → Diagnostics`).
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
Fixes ADE-86
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-86: Docs accuracy pass: strip tool-call XML artifacts, fix fabricated lane shortcuts, wrong config schema, and fake CTO heartbeat/cto-route schema (+ docs lint)](https://linear.app/ade-linear/issue/ADE-86/docs-accuracy-pass-strip-tool-call-xml-artifacts-fix-fabricated-lane) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-86-docs-accuracy-pass-strip-tool-call-xml-artifacts-fix-fabricated-lane-shortcuts-wrong-config-schema-and-fake-cto-heartbeat-cto-route-schema-docs-lint num=485 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-86-docs-accuracy-pass-strip-tool-call-xml-artifacts-fix-fabricated-lane-shortcuts-wrong-config-schema-and-fake-cto-heartbeat-cto-route-schema-docs-lint&amp;pr=485">ade-86-docs-accuracy-pass-strip-tool-call-xml-artifacts-fix-fabricated-lane-shortcuts-wrong-config-schema-and-fake-cto-heartbeat-cto-route-schema-docs-lint branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=485">PR #485</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a documentation accuracy pass that removes tool-call XML artifacts (`</invoke>`, `</content>`) left at the ends of several `.mdx` files, corrects fabricated keyboard shortcuts across lanes, graph, and CTO docs, and replaces entirely fabricated config schemas (wrong `routingRules`, `lanes.profiles`, `cto.heartbeat`/`cto.budget` ade.yaml blocks) with the real schemas.

- **Leaked markup cleanup**: Four `computer-use/*.mdx` files and `configuration/settings.mdx` had trailing `</content>`/`</invoke>` tags stripped; `scripts/validate-docs.mjs` gains a lint rule to prevent recurrence.
- **Fabricated shortcut removal**: `lanes/creating.mdx`, `tools/workspace-graph.mdx`, `lanes/packs.mdx`, `getting-started/first-lane.mdx` replace non-existent shortcuts (e.g. `Cmd+Shift+L`, `Cmd+G`, `Cmd+Shift+P`) with correct ones or prose alternatives.
- **Config schema correction**: `configuration/overview.mdx` and `configuration/ai-providers.mdx` replace fabricated `ade.yaml` and `local.yaml` schemas with the real field shapes; `cto/setup.mdx` and `cto/workers.mdx` remove the fabricated `cto:` ade.yaml block, replacing it with the correct per-worker UI-managed heartbeat model.

<h3>Confidence Score: 5/5</h3>

Documentation-only changes plus a lint script addition; no runtime code paths are affected.

Every change is either stripping stale XML artifacts from MDX files, removing shortcuts and config schema examples that were never real, or adding a regex-based lint check to prevent future leaks. The validate-docs.mjs logic correctly resets global regex state per file and computes line numbers accurately. No application code is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/validate-docs.mjs | Adds a leaked-agent-markup detector: module-scope global regex correctly resets `lastIndex` before each file, `lineNumberForIndex` computes 1-based line numbers accurately, and the check is properly scoped to `.mdx` files only. |
| configuration/overview.mdx | Replaces the fabricated `ade.yaml` schema (wrong `lanes.profiles`, wrong budget keys, wrong `testSuites` shape) with the real schema using `laneTemplates`, `processGroups`, array `command` fields, and correct `ai.budgets` map. |
| configuration/ai-providers.mdx | Replaces the fabricated `routingRules` list with the real `taskRouting` map and replaces per-session/per-run/automation/monthly budget keys with the real `ai.budgets` + `ai.chat.sessionBudgetUsd` schema. |
| cto/setup.mdx | Removes the fabricated project-level `cto.heartbeat` ade.yaml block and replaces with correct per-worker heartbeat config in CTO > Team; removes fabricated "Run Heartbeat Now" in CTO Status panel flow. |
| cto/workers.mdx | Removes fabricated `cto.budget` ade.yaml block and the fake per-heartbeat/subscription-vs-API-key budget hierarchy; replaces with correct worker monthly budget and provider/session caps model. |
| lanes/creating.mdx | Replaces fabricated keyboard shortcuts table (Cmd+Shift+L, Cmd+1, Cmd+], etc.) with correct lane navigation shortcuts and explicitly documents that Create Lane has no dedicated shortcut. |
| tools/workspace-graph.mdx | Removes fabricated shortcuts (Cmd+G, Cmd+A, Cmd+0, Cmd+Shift+M, Delete) from the graph shortcut table and prose; retains Cmd++/Cmd+- and introduces correct navigation shortcuts. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validate-docs.mjs iterates docFiles] --> B{file ends with .mdx?}
    B -- Yes --> C[Reset leakedAgentMarkupPattern.lastIndex = 0]
    C --> D["exec(content) loop"]
    D --> E{match found?}
    E -- Yes --> F["Compute line via lineNumberForIndex(content, index)"]
    F --> G[Push error: 'remove leaked agent tool-call markup']
    G --> D
    E -- No --> H[Continue to link checks]
    B -- No --> H
    H --> I[Check inlineHrefPattern & markdownLinkPattern]
    I --> J{All files processed?}
    J -- No --> A
    J -- Yes --> K{errors.length > 0?}
    K -- Yes --> L[Exit 1: print errors]
    K -- No --> M[Exit 0: docs clean]
```

<sub>Reviews (2): Last reviewed commit: ["Refs ADE-86: Address docs review accurac..."](https://github.com/arul28/ade/commit/ca13ea3ff01b0fef735fc76ad272fb33e3ab3129) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34779010)</sub>

<!-- /greptile_comment -->