### PR TITLE
ADE-79: Sync engine internals & mega-module decomposition: peer batch chunking, empty-batch ack cycles, and the two sync god-modules

### DIFF
--- a/apps/ade-cli/src/services/sync/changesetPump.ts
+++ b/apps/ade-cli/src/services/sync/changesetPump.ts
@@ -1,0 +1,98 @@
+import { randomBytes } from "node:crypto";
+import type {
+  CrsqlChangeRow,
+  SyncChangesetBatchPayload,
+} from "../../../../desktop/src/shared/types";
+
+export const DEFAULT_MAX_CHANGESET_BATCH_BYTES = 256 * 1024;
+export const DEFAULT_MAX_CHANGESET_BATCH_ROWS = 250;
+
+export type SelectedChangesetBatchChunk = {
+  changes: CrsqlChangeRow[];
+  toDbVersion: number;
+};
+
+export function selectChangesetBatchChunk(args: {
+  changes: CrsqlChangeRow[];
+  fromDbVersion: number;
+  toDbVersion: number;
+  maxRows: number;
+  maxBytes: number;
+}): SelectedChangesetBatchChunk | null {
+  let chunk: CrsqlChangeRow[] = [];
+  let chunkBytes = 0;
+  let lastIncludedDbVersion: number | null = null;
+
+  for (const change of args.changes) {
+    const changeDbVersion = Number(change.db_version ?? args.fromDbVersion);
+    const changeBytes = Buffer.byteLength(JSON.stringify(change), "utf8");
+    // The watermark is db_version-only, so rows sharing a db_version must ack together.
+    if (
+      chunk.length > 0
+      && changeDbVersion !== lastIncludedDbVersion
+      && (chunk.length >= args.maxRows || chunkBytes + changeBytes > args.maxBytes)
+    ) {
+      break;
+    }
+    chunk.push(change);
+    chunkBytes += changeBytes;
+    lastIncludedDbVersion = changeDbVersion;
+  }
+
+  if (chunk.length === 0 && args.changes.length > 0) {
+    chunk = [args.changes[0]!];
+    lastIncludedDbVersion = Number(chunk[0]!.db_version ?? args.fromDbVersion);
+  }
+  if (chunk.length === 0 && args.toDbVersion <= args.fromDbVersion) return null;
+
+  const chunkToDbVersion = lastIncludedDbVersion ?? args.toDbVersion;
+  return { changes: chunk, toDbVersion: chunkToDbVersion };
+}
+
+export function makeChangesetBatchId(args: {
+  deviceId: string;
+  fromDbVersion: number;
+  toDbVersion: number;
+  nowMs?: number;
+  entropyHex?: string;
+}): string {
+  const nowMs = args.nowMs ?? Date.now();
+  const entropyHex = args.entropyHex ?? randomBytes(4).toString("hex");
+  return `changeset:${args.deviceId}:${args.fromDbVersion}:${args.toDbVersion}:${nowMs}:${entropyHex}`;
+}
+
+export function buildChangesetBatchPayload(args: {
+  deviceId: string;
+  reason: SyncChangesetBatchPayload["reason"];
+  fromDbVersion: number;
+  toDbVersion: number;
+  changes: CrsqlChangeRow[];
+  maxRows?: number;
+  maxBytes?: number;
+  nowMs?: number;
+  entropyHex?: string;
+}): SyncChangesetBatchPayload | null {
+  const selected = selectChangesetBatchChunk({
+    changes: args.changes,
+    fromDbVersion: args.fromDbVersion,
+    toDbVersion: args.toDbVersion,
+    maxRows: args.maxRows ?? DEFAULT_MAX_CHANGESET_BATCH_ROWS,
+    maxBytes: args.maxBytes ?? DEFAULT_MAX_CHANGESET_BATCH_BYTES,
+  });
+  if (!selected) return null;
+
+  const batchId = makeChangesetBatchId({
+    deviceId: args.deviceId,
+    fromDbVersion: args.fromDbVersion,
+    toDbVersion: selected.toDbVersion,
+    nowMs: args.nowMs,
+    entropyHex: args.entropyHex,
+  });
+  return {
+    batchId,
+    reason: args.reason,
+    fromDbVersion: args.fromDbVersion,
+    toDbVersion: selected.toDbVersion,
+    changes: selected.changes,
+  };
+}

--- a/apps/ade-cli/src/services/sync/changesetPump.ts
+++ b/apps/ade-cli/src/services/sync/changesetPump.ts
@@ -26,6 +26,7 @@ export function selectChangesetBatchChunk(args: {
   for (const change of args.changes) {
     const changeDbVersion = Number(change.db_version ?? args.fromDbVersion);
     const changeBytes = Buffer.byteLength(JSON.stringify(change), "utf8");
+    // maxBytes is a split target, not a hard per-row cap; one CRR row cannot be split safely.
     // The watermark is db_version-only, so rows sharing a db_version must ack together.
     if (
       chunk.length > 0
@@ -39,10 +40,6 @@ export function selectChangesetBatchChunk(args: {
     lastIncludedDbVersion = changeDbVersion;
   }
 
-  if (chunk.length === 0 && args.changes.length > 0) {
-    chunk = [args.changes[0]!];
-    lastIncludedDbVersion = Number(chunk[0]!.db_version ?? args.fromDbVersion);
-  }
   if (chunk.length === 0 && args.toDbVersion <= args.fromDbVersion) return null;
 
   const chunkToDbVersion = lastIncludedDbVersion ?? args.toDbVersion;
@@ -79,7 +76,7 @@ export function buildChangesetBatchPayload(args: {
     maxRows: args.maxRows ?? DEFAULT_MAX_CHANGESET_BATCH_ROWS,
     maxBytes: args.maxBytes ?? DEFAULT_MAX_CHANGESET_BATCH_BYTES,
   });
-  if (!selected) return null;
+  if (!selected || selected.changes.length === 0) return null;
 
   const batchId = makeChangesetBatchId({
     deviceId: args.deviceId,

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -14,6 +14,7 @@ import {
   resolveSyncHostInboundProjectScope,
   selectChangesetBatchChunk,
 } from "./syncHostService";
+import { buildChangesetBatchPayload } from "./changesetPump";
 
 const publishMock = vi.hoisted(() => vi.fn());
 const bonjourDestroyMock = vi.hoisted(() => vi.fn());
@@ -239,6 +240,22 @@ describe("selectChangesetBatchChunk", () => {
     expect(chunk?.toDbVersion).toBe(4);
   });
 
+  it("includes one oversized row so sync can keep making progress", () => {
+    const oversizedChange = makeChange(4, 0, "x".repeat(1024));
+    const nextChange = makeChange(5, 1, "next-version");
+
+    const chunk = selectChangesetBatchChunk({
+      changes: [oversizedChange, nextChange],
+      fromDbVersion: 0,
+      toDbVersion: 5,
+      maxRows: 250,
+      maxBytes: 16,
+    });
+
+    expect(chunk?.changes).toEqual([oversizedChange]);
+    expect(chunk?.toDbVersion).toBe(4);
+  });
+
   it("can advance an empty changeset when all changes were filtered locally", () => {
     const chunk = selectChangesetBatchChunk({
       changes: [],
@@ -249,6 +266,22 @@ describe("selectChangesetBatchChunk", () => {
     });
 
     expect(chunk).toEqual({ changes: [], toDbVersion: 4 });
+  });
+});
+
+describe("buildChangesetBatchPayload", () => {
+  it("does not build sendable payloads with empty changes", () => {
+    const payload = buildChangesetBatchPayload({
+      deviceId: "device-1",
+      reason: "broadcast",
+      fromDbVersion: 3,
+      toDbVersion: 4,
+      changes: [],
+      maxRows: 250,
+      maxBytes: 256 * 1024,
+    });
+
+    expect(payload).toBeNull();
   });
 });
 

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -99,6 +99,12 @@ import type { SyncPinStore } from "./syncPinStore";
 import { DEFAULT_SYNC_COMPRESSION_THRESHOLD_BYTES, DEFAULT_SYNC_HOST_PORT, encodeSyncEnvelope, mapPlatform, parseSyncEnvelope, wsDataToText } from "./syncProtocol";
 import { resolveTailscaleCliPath } from "./resolveTailscaleCliPath";
 import { createSyncRemoteCommandService, type SyncRemoteCommandService } from "./syncRemoteCommandService";
+import {
+  buildChangesetBatchPayload,
+  DEFAULT_MAX_CHANGESET_BATCH_BYTES,
+  DEFAULT_MAX_CHANGESET_BATCH_ROWS,
+} from "./changesetPump";
+export { selectChangesetBatchChunk } from "./changesetPump";
 const execFileAsync = promisify(execFile);
 const DEFAULT_SYNC_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_SYNC_HEARTBEAT_MISS_LIMIT = 2;
@@ -201,43 +207,6 @@ type PersistedMobileCommand = {
   acceptedAtMs: number;
   completedAtMs: number;
 };
-
-export function selectChangesetBatchChunk(args: {
-  changes: CrsqlChangeRow[];
-  fromDbVersion: number;
-  toDbVersion: number;
-  maxRows: number;
-  maxBytes: number;
-}): { changes: CrsqlChangeRow[]; toDbVersion: number } | null {
-  let chunk: CrsqlChangeRow[] = [];
-  let chunkBytes = 0;
-  let lastIncludedDbVersion: number | null = null;
-
-  for (const change of args.changes) {
-    const changeDbVersion = Number(change.db_version ?? args.fromDbVersion);
-    const changeBytes = Buffer.byteLength(JSON.stringify(change), "utf8");
-    // The host watermark is db_version-only, so rows sharing a db_version must ack together.
-    if (
-      chunk.length > 0
-      && changeDbVersion !== lastIncludedDbVersion
-      && (chunk.length >= args.maxRows || chunkBytes + changeBytes > args.maxBytes)
-    ) {
-      break;
-    }
-    chunk.push(change);
-    chunkBytes += changeBytes;
-    lastIncludedDbVersion = changeDbVersion;
-  }
-
-  if (chunk.length === 0 && args.changes.length > 0) {
-    chunk = [args.changes[0]!];
-    lastIncludedDbVersion = Number(chunk[0]!.db_version ?? args.fromDbVersion);
-  }
-  if (chunk.length === 0 && args.toDbVersion <= args.fromDbVersion) return null;
-
-  const chunkToDbVersion = lastIncludedDbVersion ?? args.toDbVersion;
-  return { changes: chunk, toDbVersion: chunkToDbVersion };
-}
 
 const PERSISTED_MOBILE_COMMAND_ACTIONS = new Set<string>([
   "lanes.presence.announce",
@@ -794,8 +763,8 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
   const pollIntervalMs = Math.max(100, Math.floor(args.pollIntervalMs ?? DEFAULT_SYNC_POLL_INTERVAL_MS));
   const brainStatusIntervalMs = Math.max(1_000, Math.floor(args.brainStatusIntervalMs ?? DEFAULT_BRAIN_STATUS_INTERVAL_MS));
   const compressionThresholdBytes = Math.max(256, Math.floor(args.compressionThresholdBytes ?? DEFAULT_SYNC_COMPRESSION_THRESHOLD_BYTES));
-  const maxChangesetBatchBytes = 256 * 1024;
-  const maxChangesetBatchRows = 250;
+  const maxChangesetBatchBytes = DEFAULT_MAX_CHANGESET_BATCH_BYTES;
+  const maxChangesetBatchRows = DEFAULT_MAX_CHANGESET_BATCH_ROWS;
   const maxProjectCatalogEnvelopeBytes = MAX_PROJECT_CATALOG_ENVELOPE_BYTES;
   const maxProjectCatalogChunkBytes = 192 * 1024;
   const localPresenceCommandDescriptors: SyncRemoteCommandDescriptor[] = [
@@ -1838,11 +1807,6 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     }
   }
 
-  function makeChangesetBatchId(peer: PeerState, fromDbVersion: number, toDbVersion: number): string {
-    const deviceId = peer.metadata?.deviceId ?? peer.pairedDeviceId ?? "peer";
-    return `changeset:${deviceId}:${fromDbVersion}:${toDbVersion}:${Date.now()}:${randomBytes(4).toString("hex")}`;
-  }
-
   function peerSupportsChangesetAck(peer: PeerState): boolean {
     return Array.isArray(peer.metadata?.capabilities) && peer.metadata.capabilities.includes("changesetAck");
   }
@@ -1854,31 +1818,26 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     toDbVersion: number,
     changes: CrsqlChangeRow[],
   ): PendingChangesetBatch | null {
-    const selected = selectChangesetBatchChunk({
-      changes,
+    const payload = buildChangesetBatchPayload({
+      deviceId: peer.metadata?.deviceId ?? peer.pairedDeviceId ?? "peer",
+      reason,
       fromDbVersion,
       toDbVersion,
+      changes,
       maxRows: maxChangesetBatchRows,
       maxBytes: maxChangesetBatchBytes,
     });
-    if (!selected) return null;
-    const chunkToDbVersion = selected.toDbVersion;
+    if (!payload) return null;
     const batch: PendingChangesetBatch = {
-      batchId: makeChangesetBatchId(peer, fromDbVersion, chunkToDbVersion),
+      batchId: payload.batchId,
       reason,
       fromDbVersion,
-      toDbVersion: chunkToDbVersion,
-      changes: selected.changes,
+      toDbVersion: payload.toDbVersion,
+      changes: payload.changes,
       sentAtMs: Date.now(),
       retryCount: 0,
     };
-    const sent = send(peer, "changeset_batch", {
-      batchId: batch.batchId,
-      reason,
-      fromDbVersion,
-      toDbVersion: chunkToDbVersion,
-      changes: selected.changes,
-    });
+    const sent = send(peer, "changeset_batch", payload);
     return sent ? batch : null;
   }
 
@@ -2190,6 +2149,17 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       const changes = args.db.sync
         .exportChangesSince(peer.lastKnownServerDbVersion)
         .filter((change: CrsqlChangeRow) => change.site_id !== peer.metadata?.siteId);
+      if (changes.length === 0) {
+        const previousDbVersion = peer.lastKnownServerDbVersion;
+        peer.lastKnownServerDbVersion = currentDbVersion;
+        args.logger.debug("sync_host.changeset_advanced_without_send", {
+          peerDeviceId: peer.metadata?.deviceId ?? null,
+          fromDbVersion: previousDbVersion,
+          toDbVersion: currentDbVersion,
+          reason: "peer_owned_changes_only",
+        });
+        continue;
+      }
       const pending = sendNextChangesetBatch(peer, "broadcast", peer.lastKnownServerDbVersion, currentDbVersion, changes);
       if (pending) {
         if (peerSupportsChangesetAck(peer)) {

--- a/apps/ade-cli/src/services/sync/syncPeerService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncPeerService.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer, type RawData, type WebSocket as ServerWebSocket } from "ws";
+import type { CrsqlChangeRow, SyncChangesetAckPayload, SyncChangesetBatchPayload, SyncPeerMetadata } from "../../../../desktop/src/shared/types";
+import type { AdeDb } from "../../../../desktop/src/main/services/state/kvDb";
+import { createSyncPeerService } from "./syncPeerService";
+import { encodeSyncEnvelope, parseSyncEnvelope } from "./syncProtocol";
+import type { ParsedSyncEnvelope } from "./syncProtocol";
+
+const servers: WebSocketServer[] = [];
+const disposers: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  while (disposers.length > 0) {
+    await disposers.pop()?.();
+  }
+  while (servers.length > 0) {
+    const server = servers.pop()!;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+function toText(raw: RawData): string {
+  if (Buffer.isBuffer(raw)) return raw.toString("utf8");
+  if (Array.isArray(raw)) return Buffer.concat(raw).toString("utf8");
+  return Buffer.from(raw).toString("utf8");
+}
+
+async function nextEnvelope(ws: ServerWebSocket, type: ParsedSyncEnvelope["type"], timeoutMs = 1_000): Promise<ParsedSyncEnvelope> {
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      ws.off("message", onMessage);
+      reject(new Error(`Timed out waiting for ${type}`));
+    }, timeoutMs);
+    const onMessage = (raw: RawData) => {
+      const envelope = parseSyncEnvelope(toText(raw));
+      if (envelope.type !== type) return;
+      clearTimeout(timer);
+      ws.off("message", onMessage);
+      resolve(envelope);
+    };
+    ws.on("message", onMessage);
+  });
+}
+
+function makeChange(dbVersion: number, siteId: string): CrsqlChangeRow {
+  return {
+    table: "kv",
+    pk: `key-${dbVersion}`,
+    cid: "value",
+    val: `value-${dbVersion}`,
+    col_version: dbVersion,
+    db_version: dbVersion,
+    site_id: siteId,
+    cl: 1,
+    seq: dbVersion,
+  };
+}
+
+describe("createSyncPeerService", () => {
+  it("chunks peer outbound changesets and advances after each ack", async () => {
+    const localSiteId = "site-peer";
+    const localDeviceId = "peer-device";
+    const changes: CrsqlChangeRow[] = [];
+    let currentDbVersion = 0;
+    const db = {
+      sync: {
+        getDbVersion: () => currentDbVersion,
+        exportChangesSince: (fromDbVersion: number) => changes.filter((change) => Number(change.db_version) > fromDbVersion),
+        applyChanges: vi.fn(() => ({ appliedCount: 0 })),
+      },
+    } as unknown as AdeDb;
+    const peerService = createSyncPeerService({
+      db,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      } as any,
+      deviceRegistryService: {
+        getLocalSiteId: () => localSiteId,
+        getLocalDeviceId: () => localDeviceId,
+        ensureLocalDevice: () => ({
+          deviceId: localDeviceId,
+          name: "Peer Device",
+          platform: "macOS",
+          deviceType: "desktop",
+          siteId: localSiteId,
+          createdAt: "2026-05-31T00:00:00.000Z",
+          updatedAt: "2026-05-31T00:00:00.000Z",
+          lastSeenAt: "2026-05-31T00:00:00.000Z",
+          lastHost: null,
+          lastPort: null,
+          tailscaleIp: null,
+          ipAddresses: [],
+          metadata: {},
+        }),
+      } as any,
+    });
+    disposers.push(async () => peerService.dispose());
+
+    const server = new WebSocketServer({ port: 0 });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.once("listening", () => resolve()));
+    const port = (server.address() as { port: number }).port;
+    const serverSocketPromise = new Promise<ServerWebSocket>((resolve) => server.once("connection", resolve));
+    const connectPromise = peerService.connect({
+      host: "127.0.0.1",
+      port,
+      token: "bootstrap-token",
+      authKind: "bootstrap",
+    });
+    const serverSocket = await serverSocketPromise;
+    const hello = await nextEnvelope(serverSocket, "hello");
+    const brain: SyncPeerMetadata = {
+      deviceId: "host-device",
+      deviceName: "Host Device",
+      platform: "macOS",
+      deviceType: "desktop",
+      siteId: "site-host",
+      dbVersion: 0,
+    };
+    serverSocket.send(encodeSyncEnvelope({
+      type: "hello_ok",
+      requestId: hello.requestId,
+      payload: {
+        peer: brain,
+        brain,
+        serverDbVersion: 0,
+        heartbeatIntervalMs: 30_000,
+        pollIntervalMs: 400,
+        features: {},
+      },
+    }));
+    await connectPromise;
+
+    changes.push(...Array.from({ length: 300 }, (_, index) => makeChange(index + 1, localSiteId)));
+    currentDbVersion = 300;
+    peerService.flushLocalChanges();
+
+    const firstBatch = await nextEnvelope(serverSocket, "changeset_batch");
+    const firstPayload = firstBatch.payload as SyncChangesetBatchPayload;
+    expect(firstPayload.fromDbVersion).toBe(0);
+    expect(firstPayload.toDbVersion).toBe(250);
+    expect(firstPayload.changes).toHaveLength(250);
+
+    serverSocket.send(encodeSyncEnvelope({
+      type: "changeset_ack",
+      requestId: firstPayload.batchId,
+      payload: {
+        batchId: firstPayload.batchId,
+        fromDbVersion: firstPayload.fromDbVersion,
+        toDbVersion: firstPayload.toDbVersion,
+        appliedDbVersion: firstPayload.toDbVersion,
+        appliedCount: firstPayload.changes.length,
+        ok: true,
+      } satisfies SyncChangesetAckPayload,
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    peerService.flushLocalChanges();
+
+    const secondBatch = await nextEnvelope(serverSocket, "changeset_batch");
+    const secondPayload = secondBatch.payload as SyncChangesetBatchPayload;
+    expect(secondPayload.fromDbVersion).toBe(250);
+    expect(secondPayload.toDbVersion).toBe(300);
+    expect(secondPayload.changes).toHaveLength(50);
+  });
+});

--- a/apps/ade-cli/src/services/sync/syncPeerService.ts
+++ b/apps/ade-cli/src/services/sync/syncPeerService.ts
@@ -16,6 +16,11 @@ import type { AdeDb } from "../../../../desktop/src/main/services/state/kvDb";
 import { nowIso } from "../../../../desktop/src/main/services/shared/utils";
 import type { DeviceRegistryService } from "./deviceRegistryService";
 import { DEFAULT_SYNC_COMPRESSION_THRESHOLD_BYTES, encodeSyncEnvelope, parseSyncEnvelope, wsDataToText } from "./syncProtocol";
+import {
+  buildChangesetBatchPayload,
+  DEFAULT_MAX_CHANGESET_BATCH_BYTES,
+  DEFAULT_MAX_CHANGESET_BATCH_ROWS,
+} from "./changesetPump";
 
 type SyncPeerServiceArgs = {
   db: AdeDb;
@@ -42,6 +47,8 @@ type PendingChangesetBatch = {
 
 const CHANGESET_ACK_TIMEOUT_MS = 10_000;
 const MAX_CHANGESET_ACK_RETRIES = 6;
+const MAX_OUTBOUND_CHANGESET_BATCH_BYTES = DEFAULT_MAX_CHANGESET_BATCH_BYTES;
+const MAX_OUTBOUND_CHANGESET_BATCH_ROWS = DEFAULT_MAX_CHANGESET_BATCH_ROWS;
 
 export function createSyncPeerService(args: SyncPeerServiceArgs) {
   let ws: WebSocket | null = null;
@@ -204,16 +211,19 @@ export function createSyncPeerService(args: SyncPeerServiceArgs) {
       outboundLocalDbVersion = currentDbVersion;
       return;
     }
-    const batchId = `changeset:${currentLocalPeerMetadata().deviceId}:${previousDbVersion}:${currentDbVersion}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+    const payload = buildChangesetBatchPayload({
+      deviceId: currentLocalPeerMetadata().deviceId,
+      reason: "relay",
+      fromDbVersion: previousDbVersion,
+      toDbVersion: currentDbVersion,
+      changes,
+      maxRows: MAX_OUTBOUND_CHANGESET_BATCH_ROWS,
+      maxBytes: MAX_OUTBOUND_CHANGESET_BATCH_BYTES,
+    });
+    if (!payload) return;
     pendingOutboundChangeset = {
-      batchId,
-      payload: {
-        batchId,
-        reason: "relay",
-        fromDbVersion: previousDbVersion,
-        toDbVersion: currentDbVersion,
-        changes,
-      },
+      batchId: payload.batchId,
+      payload,
       sentAtMs: nowMs,
       retryCount: 0,
     };

--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
@@ -1949,21 +1949,19 @@ async function buildLaneDetailPayload(args: SyncRemoteCommandServiceArgs, laneId
   };
 }
 
-export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArgs) {
-  const registry = new Map<SyncRemoteCommandAction, RegisteredRemoteCommand>();
+type RemoteCommandRegistrar = (
+  action: SyncRemoteCommandAction,
+  policy: SyncRemoteCommandPolicy,
+  handler: (payload: Record<string, unknown>) => Promise<unknown>,
+  scope?: SyncRemoteCommandDescriptor["scope"],
+) => void;
 
-  const register = (
-    action: SyncRemoteCommandAction,
-    policy: SyncRemoteCommandPolicy,
-    handler: (payload: Record<string, unknown>) => Promise<unknown>,
-    scope: SyncRemoteCommandDescriptor["scope"] = "project",
-  ) => {
-    registry.set(action, {
-      descriptor: { action, scope, policy },
-      handler,
-    });
-  };
+type RemoteCommandRegistrationDeps = {
+  args: SyncRemoteCommandServiceArgs;
+  register: RemoteCommandRegistrar;
+};
 
+function registerLaneRemoteCommands({ args, register }: RemoteCommandRegistrationDeps): void {
   register("lanes.list", { viewerAllowed: true }, async (payload) => args.laneService.list(parseListLanesArgs(payload)));
   register("lanes.refreshSnapshots", { viewerAllowed: true }, async (payload) => {
     const refreshed = await args.laneService.refreshSnapshots(parseListLanesArgs(payload));
@@ -2082,7 +2080,9 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
     const mergedEnvInitConfig = mergeLaneEnvInitConfig(context.envInitConfig, templateEnvInit) ?? templateEnvInit;
     return await laneEnvironmentService.initLaneEnvironment(context.lane, mergedEnvInitConfig, mergedOverrides);
   });
+}
 
+function registerWorkRemoteCommands({ args, register }: RemoteCommandRegistrationDeps): void {
   register("work.listSessions", { viewerAllowed: true }, async (payload) => listRemoteWorkSessions(args, parseListSessionsArgs(payload)));
   register("work.updateSessionMeta", { viewerAllowed: true, queueable: true }, async (payload) => {
     args.sessionService.updateMeta(parseUpdateSessionMetaArgs(payload));
@@ -2185,6 +2185,9 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
     }
     return { ok: true };
   });
+}
+
+function registerProcessRemoteCommands({ args, register }: RemoteCommandRegistrationDeps): void {
   register("processes.listDefinitions", { viewerAllowed: true }, async () =>
     requireService(args.processService, "Process service not available.").listDefinitions());
   register("processes.listRuntime", { viewerAllowed: true }, async (payload) =>
@@ -2203,7 +2206,9 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
     requireService(args.processService, "Process service not available.").kill(
       parseProcessActionArgs(payload, "processes.kill"),
     ));
+}
 
+function registerChatRemoteCommands({ args, register }: RemoteCommandRegistrationDeps): void {
   register("chat.listSessions", { viewerAllowed: true }, async (payload) => {
     const agentChatService = requireService(args.agentChatService, "Agent chat service not available.");
     const parsed = parseAgentChatListArgs(payload);
@@ -2295,6 +2300,9 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
   register("chat.modelCatalog", { viewerAllowed: true }, async (payload) =>
     requireService(args.agentChatService, "Agent chat service not available.").getModelCatalog(parseChatModelCatalogArgs(payload)));
 
+}
+
+function registerModelPickerRemoteCommands({ args, register }: RemoteCommandRegistrationDeps): void {
   // Cross-surface ModelPicker favorites + recents — see modelPickerStore.ts.
   // Mirrors the direct JSON-RPC `modelPicker.*` methods on adeRpcServer so iOS
   // (which routes through the WebSocket sync command envelope) shares the
@@ -2304,6 +2312,7 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
   // having to thread the accessor explicitly.
   const requireModelPickerStore = (): ModelPickerStore =>
     args.getModelPickerStore?.() ?? getSharedModelPickerStore();
+
   register("modelPicker.getFavorites", { viewerAllowed: true }, async () => ({
     favorites: requireModelPickerStore().getFavorites(),
   }), "runtime");
@@ -2329,7 +2338,9 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
       : "";
     return { recents: requireModelPickerStore().pushRecent(modelId) };
   }, "runtime");
+}
 
+function registerCtoRemoteCommands({ args, register }: RemoteCommandRegistrationDeps): void {
   register("cto.getRoster", { viewerAllowed: true }, async () => {
     const agentChatService = requireService(args.agentChatService, "Agent chat service not available.");
     const workerAgentService = requireService(args.workerAgentService, "Worker agent service not available.");
@@ -2655,7 +2666,9 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
     await workerRevisionService.rollbackAgentRevision(agentId, revisionId, "user");
     return {};
   });
+}
 
+function registerGitAndFileRemoteCommands({ args, register }: RemoteCommandRegistrationDeps): void {
   register("git.getChanges", { viewerAllowed: true }, async (payload) =>
     requireService(args.diffService, "Diff service not available.").getChanges(parseGetDiffChangesArgs(payload).laneId));
   register("git.getFile", { viewerAllowed: true }, async (payload) => {
@@ -2742,14 +2755,18 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
     requireService(args.gitService, "Git service not available.").listBranches(parseGitListBranchesArgs(payload)));
   register("git.checkoutBranch", { viewerAllowed: true, queueable: true }, async (payload) =>
     requireService(args.gitService, "Git service not available.").checkoutBranch(parseGitCheckoutBranchArgs(payload)));
+}
 
+function registerConflictRemoteCommands({ args, register }: RemoteCommandRegistrationDeps): void {
   register("conflicts.getLaneStatus", { viewerAllowed: true }, async (payload) =>
     requireService(args.conflictService, "Conflict service not available.").getLaneStatus(parseConflictLaneArgs(payload, "conflicts.getLaneStatus")));
   register("conflicts.listOverlaps", { viewerAllowed: true }, async (payload) =>
     requireService(args.conflictService, "Conflict service not available.").listOverlaps(parseConflictLaneArgs(payload, "conflicts.listOverlaps")));
   register("conflicts.getBatchAssessment", { viewerAllowed: true }, async () =>
     requireService(args.conflictService, "Conflict service not available.").getBatchAssessment());
+}
 
+function registerPrAndDeeplinkRemoteCommands({ args, register }: RemoteCommandRegistrationDeps): void {
   register("prs.list", { viewerAllowed: true }, async () => args.prService.listAll());
   register("prs.refresh", { viewerAllowed: true }, async (payload) => {
     const prId = asTrimmedString(payload.prId);
@@ -3005,7 +3022,32 @@ export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArg
     return args.pathToMergeOrchestrator.stopPathToMerge({ prId, reason });
   });
   register("prs.getMobileSnapshot", { viewerAllowed: true }, async () => args.prService.getMobileSnapshot());
+}
 
+export function createSyncRemoteCommandService(args: SyncRemoteCommandServiceArgs) {
+  const registry = new Map<SyncRemoteCommandAction, RegisteredRemoteCommand>();
+
+  const register = (
+    action: SyncRemoteCommandAction,
+    policy: SyncRemoteCommandPolicy,
+    handler: (payload: Record<string, unknown>) => Promise<unknown>,
+    scope: SyncRemoteCommandDescriptor["scope"] = "project",
+  ) => {
+    registry.set(action, {
+      descriptor: { action, scope, policy },
+      handler,
+    });
+  };
+
+  registerLaneRemoteCommands({ args, register });
+  registerWorkRemoteCommands({ args, register });
+  registerProcessRemoteCommands({ args, register });
+  registerChatRemoteCommands({ args, register });
+  registerModelPickerRemoteCommands({ args, register });
+  registerCtoRemoteCommands({ args, register });
+  registerGitAndFileRemoteCommands({ args, register });
+  registerConflictRemoteCommands({ args, register });
+  registerPrAndDeeplinkRemoteCommands({ args, register });
   return {
     getSupportedActions(): SyncRemoteCommandAction[] {
       return [...registry.keys()];

--- a/apps/desktop/src/main/services/chat/cursorSdkHooks.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkHooks.ts
@@ -282,6 +282,12 @@ export function writeCursorSdkHookShellCommandScript(args: {
 }): void {
   ensureDir(path.dirname(args.commandPath));
   const source = `#!/bin/sh
+drain_stdin() {
+  if [ ! -t 0 ]; then
+    cat >/dev/null 2>/dev/null || true
+  fi
+}
+
 has_socket_arg=0
 for arg in "$@"; do
   case "$arg" in
@@ -290,6 +296,7 @@ for arg in "$@"; do
 done
 
 if [ "$has_socket_arg" -eq 0 ] && [ -z "\${ADE_CURSOR_SDK_SOCKET:-}" ] && [ -z "\${ADE_CURSOR_SDK_SESSION_ID:-}" ] && [ -z "\${ADE_CURSOR_SDK_LANE_ROOT:-}" ]; then
+  drain_stdin
   printf '%s' '{"permission":"allow"}'
   exit 0
 fi
@@ -314,6 +321,7 @@ if [ -n "$configured_electron" ] && [ -x "$configured_electron" ]; then
   ELECTRON_RUN_AS_NODE=1 exec "$configured_electron" "$script_path" "$@"
 fi
 
+drain_stdin
 printf '%s' '{"permission":"deny","user_message":"ADE Cursor policy gate requires Node.js for ADE-managed Cursor sessions.","agent_message":"ADE Cursor policy gate requires Node.js for ADE-managed Cursor sessions."}'
 `;
   fs.writeFileSync(args.commandPath, source, { mode: 0o755 });

--- a/apps/desktop/src/main/services/sync/syncHostService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncHostService.test.ts
@@ -1115,6 +1115,8 @@ describe.skipIf(!isCrsqliteAvailable())("syncHostService", () => {
     const sourceAck = await clientA.queue.next("changeset_ack");
     expect((sourceAck.payload as { ok: boolean; batchId?: string }).ok).toBe(true);
     expect((sourceAck.payload as { ok: boolean; batchId?: string }).batchId).toBe("changes-a");
+    await waitFor(() => host.getPeerStates().find((peer) => peer.deviceId === "peer-a")?.syncLag === 0);
+    await expect(clientA.queue.next("changeset_batch", 250)).rejects.toThrow(/Timed out waiting for changeset_batch/);
 
     const rebroadcast = await clientB.queue.next("changeset_batch");
     const payload = rebroadcast.payload as {


### PR DESCRIPTION
Fixes ADE-79

## Summary
- Share changeset batch selection/payload construction between host and peer sync paths.
- Chunk peer outbound changeset relay with the same row/byte targets as host catch-up/broadcast batches.
- Advance peer watermarks without sending empty self-owned batches, avoiding empty batch/ack cycles.
- Split sync remote command registration into domain-scoped helpers.
- Address Greptile review feedback by making empty payloads non-sendable at the helper boundary and documenting the oversized-row progress behavior.

## Validation
- npm --prefix apps/ade-cli run test -- src/services/sync/syncPeerService.test.ts src/services/sync/syncHostService.test.ts
- npm --prefix apps/desktop exec vitest run src/main/services/sync/syncRemoteCommandService.test.ts src/main/services/sync/syncHostService.test.ts
- npm --prefix apps/ade-cli run test -- src/services/sync/syncHostService.test.ts
- npm --prefix apps/ade-cli run typecheck
- npm --prefix apps/desktop run typecheck
- npm --prefix apps/ade-cli run build
- npm --prefix apps/desktop run lint
- npm --prefix apps/desktop run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented changeset batching with configurable size and row limits for more efficient sync operations.

* **Bug Fixes**
  * Improved handling of edge cases when no changes require syncing.

* **Tests**
  * Added comprehensive test coverage for peer synchronization and changeset batching behavior.

* **Refactor**
  * Reorganized sync service code for better maintainability and separation of concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts shared changeset batch selection/construction into a new `changesetPump.ts` module, wires it into both the host and peer sync paths, and fixes two correctness issues: peer outbound changesets are now chunked at the same 250-row / 256 KB targets used by the host, and the host broadcast loop no longer emits empty batches (and their wasteful ack cycles) when all DB changes since the last watermark are owned by the receiving peer.

- **`changesetPump.ts` (new):** `selectChangesetBatchChunk`, `makeChangesetBatchId`, and `buildChangesetBatchPayload` extracted from `syncHostService.ts`; `buildChangesetBatchPayload` returns `null` for empty-changes inputs, closing the empty-batch footgun surfaced in the previous review.
- **`syncHostService.ts`:** Broadcast loop short-circuits with a watermark advance and a debug log when post-filter changes are empty, replacing the old empty-send-then-ack cycle; `sendNextChangesetBatch` delegates to `buildChangesetBatchPayload`.
- **`syncPeerService.ts`:** `sendLocalChanges` now uses `buildChangesetBatchPayload` to chunk outbound relay batches; after each ack, `outboundLocalDbVersion` advances to the chunk boundary so the next relay timer tick picks up the remainder.
- **`syncRemoteCommandService.ts`:** Registration of ~80 remote commands split into 9 domain-scoped `register*` helpers; no behavioural change.
- **`cursorSdkHooks.ts`:** Shell hook wrapper gains a `drain_stdin` helper that discards piped stdin before exiting in the early-allow and final-deny paths, preventing broken-pipe errors when the caller writes a large JSON payload.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three behavioural fixes (chunked peer relay, empty-batch avoidance, stdin drain) are well-targeted, unit- and integration-tested, and the syncRemoteCommandService refactor is purely structural with preserved registration order.

The changeset-pump extraction is a clean, tested refactor. The empty-batch short-circuit correctly advances the watermark while avoiding the ack round-trip. Peer chunking is validated end-to-end by the new syncPeerService.test.ts. The one non-blocking observation (next chunk waits for the relay timer instead of being self-pipelining after ack) does not cause incorrect behaviour, only adds up to 400 ms per chunk of latency on large multi-chunk syncs.

No files require special attention; syncPeerService.ts has the relay-timer latency note but no defect.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/services/sync/changesetPump.ts | New shared module extracting selectChangesetBatchChunk, makeChangesetBatchId, and buildChangesetBatchPayload; buildChangesetBatchPayload correctly returns null for empty-changes inputs, closing the footgun flagged in the previous review. |
| apps/ade-cli/src/services/sync/syncPeerService.ts | Peer service now chunks outbound changesets via buildChangesetBatchPayload; correctly uses payload.toDbVersion as the new watermark after each ack, but the next chunk is only queued when the relay timer (≤400ms) fires — not immediately after the ack clears pendingOutboundChangeset. |
| apps/ade-cli/src/services/sync/syncHostService.ts | Broadcast loop now short-circuits when post-filter changes are empty, advancing the peer watermark in-place and skipping the send/ack round-trip that caused the empty-batch cycles; delegation to buildChangesetBatchPayload replaces inline logic cleanly. |
| apps/ade-cli/src/services/sync/syncRemoteCommandService.ts | Pure structural refactor: splits one giant createSyncRemoteCommandService function into domain-scoped register* helpers; registration order and scope defaults are preserved, no behavioural change. |
| apps/desktop/src/main/services/chat/cursorSdkHooks.ts | Adds drain_stdin() to the shell hook wrapper: correctly consumes stdin before printing the decision in both the early-allow and final-deny exit paths, preventing broken-pipe noise when the caller has written a large payload and the shell script exits without Node. |
| apps/ade-cli/src/services/sync/syncPeerService.test.ts | New integration test exercises 300-change dataset chunked into two batches (250+50), validating ack-driven watermark advancement; relies on manual flushLocalChanges() call after ack to avoid a 400ms relay timer wait. |
| apps/ade-cli/src/services/sync/syncHostService.test.ts | Adds tests for the oversized-row progress guarantee and buildChangesetBatchPayload null-on-empty; new desktop test asserts the host does not re-broadcast an empty batch to peer-a after ack. |
| apps/desktop/src/main/services/sync/syncHostService.test.ts | Adds waitFor assertion that peer-a syncLag reaches 0 and a timeout expectation that no empty changeset_batch is forwarded back to peer-a after it has been acked. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant DB as Local DB
    participant PS as syncPeerService
    participant HS as syncHostService

    Note over PS: flushLocalChanges() — 300 local changes
    PS->>DB: exportChangesSince(0), filter localSiteId
    DB-->>PS: 300 changes
    PS->>PS: buildChangesetBatchPayload (max 250 rows)
    PS->>HS: "changeset_batch(from=0, to=250, 250 changes)"
    HS-->>PS: "changeset_ack(batchId, ok=true, toDbVersion=250)"
    Note over PS: outboundLocalDbVersion=250, pendingOutboundChangeset=null
    Note over PS: relay timer fires (up to 400ms)
    PS->>DB: exportChangesSince(250), filter localSiteId
    DB-->>PS: 50 changes
    PS->>HS: "changeset_batch(from=250, to=300, 50 changes)"
    HS-->>PS: "changeset_ack(batchId, ok=true, toDbVersion=300)"
    Note over PS: outboundLocalDbVersion=300

    Note over HS: broadcast loop — all changes owned by peer-a
    HS->>DB: "exportChangesSince(lastKnown), filter != peer-a siteId"
    DB-->>HS: 0 changes
    Note over HS: advance watermark directly, no changeset_batch sent
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fade-cli%2Fsrc%2Fservices%2Fsync%2FsyncPeerService.ts%3A363-376%0A**Next%20chunk%20waits%20for%20relay%20timer%20after%20each%20ack**%0A%0AAfter%20clearing%20%60pendingOutboundChangeset%60%20and%20advancing%20%60outboundLocalDbVersion%60%20to%20the%20chunk%20boundary%2C%20nothing%20triggers%20the%20next%20%60sendLocalChanges%60%20call%20immediately.%20The%20relay%20timer%20fires%20at%20most%20400%20ms%20later.%20For%20a%20dataset%20that%20requires%20N%20chunks%2C%20full%20sync%20takes%20N%20%C3%97%20%28ack%20round-trip%20%2B%20up%20to%20400%20ms%20relay%20delay%29.%20Before%20this%20PR%20there%20was%20no%20chunking%20on%20the%20peer%20path%2C%20so%20a%20single%20relay%20tick%20was%20always%20enough%3B%20now%20each%20chunk%20after%20the%20first%20incurs%20an%20extra%20sleep.%0A%0AA%20direct%20call%20to%20%60sendLocalChanges%28%29%60%20at%20the%20end%20of%20the%20%60changeset_ack%60%20handler%20%28after%20%60pendingOutboundChangeset%20%3D%20null%60%29%20would%20make%20multi-chunk%20relays%20self-pipelining%20without%20changing%20any%20other%20behaviour.%0A%0A&repo=arul28%2Fade&pr=486&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/ade-cli/src/services/sync/syncPeerService.ts:363-376
**Next chunk waits for relay timer after each ack**

After clearing `pendingOutboundChangeset` and advancing `outboundLocalDbVersion` to the chunk boundary, nothing triggers the next `sendLocalChanges` call immediately. The relay timer fires at most 400 ms later. For a dataset that requires N chunks, full sync takes N × (ack round-trip + up to 400 ms relay delay). Before this PR there was no chunking on the peer path, so a single relay tick was always enough; now each chunk after the first incurs an extra sleep.

A direct call to `sendLocalChanges()` at the end of the `changeset_ack` handler (after `pendingOutboundChangeset = null`) would make multi-chunk relays self-pipelining without changing any other behaviour.

`````

</details>

<sub>Reviews (6): Last reviewed commit: ["Fix Cursor hook stdin fallback"](https://github.com/arul28/ade/commit/9e51e19a5534f7a7cdfa5826afbb3e67345aad77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34779075)</sub>

<!-- /greptile_comment -->