### PR TITLE
ADE-83: iOS offline & deep-link reliability: false 'Sent', PR deep-link dead-ends, stuck 'Thinking', attention bell re-badge, PR-wizard dup-submit, temp-video leak

### DIFF
--- a/apps/ios/ADE/App/DeepLinkRouter.swift
+++ b/apps/ios/ADE/App/DeepLinkRouter.swift
@@ -147,8 +147,13 @@ final class DeepLinkRouter {
     if kind == "session" {
       SyncService.shared?.requestedWorkSessionNavigation = WorkSessionNavigationRequest(sessionId: identifier)
     }
-    if kind == "pr", let prId = resolvePrId(from: identifier) {
-      SyncService.shared?.requestedPrNavigation = PrNavigationRequest(prId: prId)
+    if kind == "pr" {
+      let trimmed = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+      if let prId = resolvePrId(from: identifier) {
+        SyncService.shared?.requestedPrNavigation = PrNavigationRequest(prId: prId, prNumber: Int(trimmed))
+      } else if let prNumber = Int(trimmed), prNumber > 0 {
+        SyncService.shared?.requestedPrNavigation = PrNavigationRequest(prNumber: prNumber)
+      }
     }
   }
 

--- a/apps/ios/ADE/App/DeepLinkRouter.swift
+++ b/apps/ios/ADE/App/DeepLinkRouter.swift
@@ -149,7 +149,7 @@ final class DeepLinkRouter {
     }
     if kind == "pr" {
       let trimmed = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
-      if let prId = resolvePrId(from: identifier) {
+      if let prId = resolvePrId(from: trimmed) {
         SyncService.shared?.requestedPrNavigation = PrNavigationRequest(prId: prId, prNumber: Int(trimmed))
       } else if let prNumber = Int(trimmed), prNumber > 0 {
         SyncService.shared?.requestedPrNavigation = PrNavigationRequest(prNumber: prNumber)

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -7652,7 +7652,34 @@ extension SyncService {
       }
       return .dispatched
     } catch {
-      return .dropped(error.localizedDescription)
+      return .dropped(remoteCommandDroppedMessage(for: kind, error: error))
+    }
+  }
+
+  private func remoteCommandDroppedMessage(for kind: RemoteCommandKind, error: Error) -> String {
+    if error is CancellationError {
+      return "This command was canceled."
+    }
+
+    let nsError = error as NSError
+    if isRemoteCommandApplicationError(error) {
+      let message = nsError.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+      return message.isEmpty ? "This command could not be sent." : message
+    }
+
+    if connectionState.isHostUnreachable || nsError.domain == NSURLErrorDomain {
+      return "Reconnect to your Mac and try again."
+    }
+
+    if nsError.domain == "ADE", nsError.code == 15 {
+      return "Reconnect to your Mac and try again."
+    }
+
+    switch kind {
+    case .openDeeplink:
+      return "This ADE link could not be sent. Try again."
+    default:
+      return "This command could not be sent. Try again."
     }
   }
 

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -818,9 +818,8 @@ enum SyncRemoteCommandDelivery: Equatable {
   case queued
   case dropped(String)
 
-  init(commandResult: Any) {
-    if let dict = commandResult as? [String: Any],
-       dict["queued"] as? Bool == true {
+  init(commandResult: [String: Any]) {
+    if commandResult["queued"] as? Bool == true {
       self = .queued
     } else {
       self = .dispatched
@@ -7648,7 +7647,10 @@ extension SyncService {
     // may still ignore the result, while interactive surfaces can render it.
     do {
       let result = try await performCommandRequestSafe(action: action, args: args)
-      return SyncRemoteCommandDelivery(commandResult: result)
+      if let result = result as? [String: Any] {
+        return SyncRemoteCommandDelivery(commandResult: result)
+      }
+      return .dispatched
     } catch {
       return .dropped(error.localizedDescription)
     }

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -795,12 +795,36 @@ struct WorkSessionNavigationRequest: Equatable, Identifiable {
 struct PrNavigationRequest: Equatable, Identifiable {
   let id: String
   let prId: String
+  let prNumber: Int?
   let laneId: String?
 
-  init(prId: String, laneId: String? = nil) {
+  init(prId: String, prNumber: Int? = nil, laneId: String? = nil) {
     self.id = UUID().uuidString
     self.prId = prId
+    self.prNumber = prNumber
     self.laneId = laneId
+  }
+
+  init(prNumber: Int) {
+    self.id = UUID().uuidString
+    self.prId = "github-pr-number:\(prNumber)"
+    self.prNumber = prNumber
+    self.laneId = nil
+  }
+}
+
+enum SyncRemoteCommandDelivery: Equatable {
+  case dispatched
+  case queued
+  case dropped(String)
+
+  init(commandResult: Any) {
+    if let dict = commandResult as? [String: Any],
+       dict["queued"] as? Bool == true {
+      self = .queued
+    } else {
+      self = .dispatched
+    }
   }
 }
 
@@ -7539,7 +7563,8 @@ extension SyncService {
   /// (sessionId, prNumber, text, ...) can be forwarded without defining one
   /// envelope per variant. Never logs the payload in plaintext because `text`
   /// for `.replyToSession` is user-authored content.
-  func sendRemoteCommand(_ kind: RemoteCommandKind, payload: [String: Any]) async {
+  @discardableResult
+  func sendRemoteCommand(_ kind: RemoteCommandKind, payload: [String: Any]) async -> SyncRemoteCommandDelivery {
     let action: String
     switch kind {
     case .approveSession: action = "chat.approve"
@@ -7613,20 +7638,19 @@ extension SyncService {
             ADEDeepLinkURLParsing.isADEWebHost(components.host) &&
             components.path == "/open"
           ) else {
-        return
+        return .dropped("This ADE link is not valid.")
       }
       args["url"] = url
     }
 
     // For now we send via the opaque command envelope — the desktop's
-    // `syncRemoteCommandService` dispatches on `action`. Failures are
-    // swallowed: notification actions are fire-and-forget and do not report
-    // errors back to the user through this surface.
+    // `syncRemoteCommandService` dispatches on `action`. Notification actions
+    // may still ignore the result, while interactive surfaces can render it.
     do {
-      _ = try await performCommandRequestSafe(action: action, args: args)
+      let result = try await performCommandRequestSafe(action: action, args: args)
+      return SyncRemoteCommandDelivery(commandResult: result)
     } catch {
-      // Intentionally silent — the host will retry once the user re-opens
-      // the affected surface.
+      return .dropped(error.localizedDescription)
     }
   }
 
@@ -7792,7 +7816,8 @@ extension SyncService {
             mergeReady: (item.reviewStatus == "approved")
               && (item.checksStatus == "passing")
               && item.state == "open",
-            branch: item.headBranch.isEmpty ? nil : item.headBranch
+            branch: item.headBranch.isEmpty ? nil : item.headBranch,
+            updatedAt: Self.parseIso8601(item.updatedAt)
           )
         }
       // Header label = focused (most-recently-active) running chat's lane.
@@ -7838,7 +7863,8 @@ extension SyncService {
         review: item.reviewStatus,
         state: item.state,
         mergeReady: (item.reviewStatus == "approved") && (item.checksStatus == "passing") && item.state == "open",
-        branch: item.headBranch.isEmpty ? nil : item.headBranch
+        branch: item.headBranch.isEmpty ? nil : item.headBranch,
+        updatedAt: Self.parseIso8601(item.updatedAt)
       )
     }
 

--- a/apps/ios/ADE/Shared/ADESharedModels.swift
+++ b/apps/ios/ADE/Shared/ADESharedModels.swift
@@ -110,6 +110,10 @@ public struct PrSnapshot: Codable, Hashable, Identifiable, Sendable {
     /// Source branch (headRef), e.g. "feat/auth-refactor". Optional so older
     /// snapshots written before the field was added still decode cleanly.
     public let branch: String?
+    /// PR update timestamp from the host. Attention surfaces use this instead
+    /// of the snapshot write time so a still-open PR does not re-badge every
+    /// time the App Group snapshot is regenerated.
+    public let updatedAt: Date?
 
     public init(
         id: String,
@@ -119,7 +123,8 @@ public struct PrSnapshot: Codable, Hashable, Identifiable, Sendable {
         review: String,
         state: String,
         mergeReady: Bool,
-        branch: String? = nil
+        branch: String? = nil,
+        updatedAt: Date? = nil
     ) {
         self.id = id
         self.number = number
@@ -129,6 +134,7 @@ public struct PrSnapshot: Codable, Hashable, Identifiable, Sendable {
         self.state = state
         self.mergeReady = mergeReady
         self.branch = branch
+        self.updatedAt = updatedAt
     }
 }
 

--- a/apps/ios/ADE/Views/AttentionDrawer/AttentionDrawerModel.swift
+++ b/apps/ios/ADE/Views/AttentionDrawer/AttentionDrawerModel.swift
@@ -147,6 +147,7 @@ public final class AttentionDrawerModel: ObservableObject {
         }
 
         for pr in snapshot.prs where pr.state == "open" {
+            let prTimestamp = pr.updatedAt ?? generated
             if pr.checks == "failing" {
                 result.append(
                     AttentionItem(
@@ -157,7 +158,7 @@ public final class AttentionDrawerModel: ObservableObject {
                         prId: pr.id,
                         prNumber: pr.number,
                         deepLink: URL(string: "ade://pr/\(pr.number)"),
-                        timestamp: generated
+                        timestamp: prTimestamp
                     )
                 )
             } else if pr.mergeReady {
@@ -170,7 +171,7 @@ public final class AttentionDrawerModel: ObservableObject {
                         prId: pr.id,
                         prNumber: pr.number,
                         deepLink: URL(string: "ade://pr/\(pr.number)"),
-                        timestamp: generated
+                        timestamp: prTimestamp
                     )
                 )
             } else if pr.review == "pending" || pr.review == "changes_requested" {
@@ -185,7 +186,7 @@ public final class AttentionDrawerModel: ObservableObject {
                         prId: pr.id,
                         prNumber: pr.number,
                         deepLink: URL(string: "ade://pr/\(pr.number)"),
-                        timestamp: generated
+                        timestamp: prTimestamp
                     )
                 )
             }

--- a/apps/ios/ADE/Views/Deeplinks/SendToMacCard.swift
+++ b/apps/ios/ADE/Views/Deeplinks/SendToMacCard.swift
@@ -164,6 +164,7 @@ struct SendToMacCard: View {
   @EnvironmentObject private var syncService: SyncService
   @State private var isSending = false
   @State private var sendCompleted = false
+  @State private var sendOutcome: SyncRemoteCommandDelivery?
 
   var body: some View {
     VStack(spacing: 20) {
@@ -291,7 +292,7 @@ struct SendToMacCard: View {
     case .error:
       return "Last seen offline"
     case .disconnected:
-      return "Offline — we'll deliver when it's back"
+      return "Offline"
     }
   }
 
@@ -333,6 +334,14 @@ struct SendToMacCard: View {
       .buttonStyle(.plain)
       .disabled(isSending || sendCompleted)
 
+      if let sendStatusMessage {
+        Text(sendStatusMessage)
+          .font(.system(.footnote, design: .rounded))
+          .foregroundStyle(sendStatusTint)
+          .multilineTextAlignment(.center)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+
       Button(action: onDismiss) {
         Text(sendCompleted ? "Done" : "Cancel")
           .font(.system(.body, design: .rounded).weight(.medium))
@@ -351,25 +360,50 @@ struct SendToMacCard: View {
 
   private var sendButtonTitle: String {
     if isSending { return "Sending…" }
-    if sendCompleted { return "Sent" }
+    if sendCompleted {
+      if case .queued = sendOutcome { return "Queued" }
+      return "Sent"
+    }
+    if case .dropped = sendOutcome { return "Try again" }
     return "Send to Mac"
+  }
+
+  private var sendStatusMessage: String? {
+    guard let sendOutcome else { return nil }
+    switch sendOutcome {
+    case .dispatched:
+      return "Sent to your Mac."
+    case .queued:
+      return "Queued for when your Mac reconnects."
+    case .dropped(let message):
+      return message.isEmpty ? "This command could not be sent." : message
+    }
+  }
+
+  private var sendStatusTint: Color {
+    guard let sendOutcome else { return ADEColor.textSecondary }
+    switch sendOutcome {
+    case .dispatched, .queued: return ADEColor.success
+    case .dropped: return ADEColor.danger
+    }
   }
 
   @MainActor
   private func sendToMac() async {
-    guard let sync = SyncService.shared else {
-      // Without a SyncService singleton there's nothing to dispatch to;
-      // collapse to the dismiss path so the user isn't stuck.
-      onDismiss()
-      return
-    }
     isSending = true
-    await sync.sendRemoteCommand(.openDeeplink, payload: ["url": target.url.absoluteString])
+    sendOutcome = nil
+    let delivery = await syncService.sendRemoteCommand(.openDeeplink, payload: ["url": target.url.absoluteString])
     isSending = false
-    sendCompleted = true
-    // Brief confirmation pause so the user sees the "Sent" state before the
-    // sheet collapses; 0.6s is short enough not to feel sluggish.
-    try? await Task.sleep(nanoseconds: 600_000_000)
-    onDismiss()
+    sendOutcome = delivery
+    switch delivery {
+    case .dispatched, .queued:
+      sendCompleted = true
+      // Brief confirmation pause so the user sees the outcome before the
+      // sheet collapses; 0.8s is short enough not to feel sluggish.
+      try? await Task.sleep(nanoseconds: 800_000_000)
+      onDismiss()
+    case .dropped:
+      sendCompleted = false
+    }
   }
 }

--- a/apps/ios/ADE/Views/PRs/CreatePrWizardView.swift
+++ b/apps/ios/ADE/Views/PRs/CreatePrWizardView.swift
@@ -41,18 +41,18 @@ struct CreatePrWizardView: View {
   /// `lanes` list so cached/offline flows still work.
   let createCapabilities: PrCreateCapabilities?
   /// Single-PR submit: (laneId, title, body, draft, baseBranch, labels, reviewers, strategy).
-  let onCreateSingle: (String, String, String, Bool, String, [String], [String], String?) -> Void
+  let onCreateSingle: (String, String, String, Bool, String, [String], [String], String?) async -> Bool
   /// Queue PR batch submit.
-  let onCreateQueue: (CreateQueuePrsRequest) -> Void
+  let onCreateQueue: (CreateQueuePrsRequest) async -> Bool
   /// Integration PR submit (caller runs simulateIntegration → commitIntegration).
-  let onCreateIntegration: (CreateIntegrationRequest) -> Void
+  let onCreateIntegration: (CreateIntegrationRequest) async -> Bool
 
   init(
     lanes: [LaneSummary],
     createCapabilities: PrCreateCapabilities? = nil,
-    onCreateSingle: @escaping (String, String, String, Bool, String, [String], [String], String?) -> Void,
-    onCreateQueue: @escaping (CreateQueuePrsRequest) -> Void,
-    onCreateIntegration: @escaping (CreateIntegrationRequest) -> Void
+    onCreateSingle: @escaping (String, String, String, Bool, String, [String], [String], String?) async -> Bool,
+    onCreateQueue: @escaping (CreateQueuePrsRequest) async -> Bool,
+    onCreateIntegration: @escaping (CreateIntegrationRequest) async -> Bool
   ) {
     self.lanes = lanes
     self.createCapabilities = createCapabilities
@@ -1069,7 +1069,7 @@ struct CreatePrWizardView: View {
 
   private var submitButton: some View {
     Button {
-      submit()
+      Task { await submit() }
     } label: {
       HStack(spacing: 6) {
         if isSubmitting {
@@ -1121,9 +1121,11 @@ struct CreatePrWizardView: View {
     }
   }
 
-  private func submit() {
+  @MainActor
+  private func submit() async {
     guard canSubmit else { return }
     isSubmitting = true
+    errorMessage = nil
     let parsedLabels = labelsInput
       .split(separator: ",")
       .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
@@ -1139,7 +1141,7 @@ struct CreatePrWizardView: View {
         isSubmitting = false
         return
       }
-      onCreateSingle(
+      let completed = await onCreateSingle(
         option.id,
         title.trimmingCharacters(in: .whitespacesAndNewlines),
         bodyText,
@@ -1149,12 +1151,16 @@ struct CreatePrWizardView: View {
         parsedReviewers,
         /* strategy */ strategy.rawValue
       )
+      isSubmitting = false
+      if !completed {
+        errorMessage = "The pull request was not created."
+      }
     case .queue:
       let laneIds = orderedSelectedLaneIds
       let trimmedName = queueName.trimmingCharacters(in: .whitespacesAndNewlines)
       let baseTrim = baseBranch.trimmingCharacters(in: .whitespacesAndNewlines)
       let targetBranch = baseTrim.isEmpty ? defaultTargetBranch : baseTrim
-      onCreateQueue(
+      let completed = await onCreateQueue(
         CreateQueuePrsRequest(
           laneIds: laneIds,
           queueName: trimmedName.isEmpty ? nil : trimmedName,
@@ -1166,13 +1172,17 @@ struct CreatePrWizardView: View {
           baseBranch: targetBranch
         )
       )
+      isSubmitting = false
+      if !completed {
+        errorMessage = "The queue PRs were not created."
+      }
     case .integration:
       let laneIds = orderedSelectedLaneIds
       let trimmedName = integrationLaneName.trimmingCharacters(in: .whitespacesAndNewlines)
       let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
       let baseTrim = baseBranch.trimmingCharacters(in: .whitespacesAndNewlines)
       let targetBranch = baseTrim.isEmpty ? defaultTargetBranch : baseTrim
-      onCreateIntegration(
+      let completed = await onCreateIntegration(
         CreateIntegrationRequest(
           sourceLaneIds: laneIds,
           integrationLaneName: trimmedName,
@@ -1182,12 +1192,10 @@ struct CreatePrWizardView: View {
           baseBranch: targetBranch
         )
       )
-    }
-    // Re-enable the button after a short delay so the spinner clears if the
-    // host keeps the sheet open (e.g. on an error toast). The parent sheet
-    // controller is responsible for dismissing on success.
-    DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
       isSubmitting = false
+      if !completed {
+        errorMessage = "The integration PR was not created."
+      }
     }
   }
 

--- a/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
+++ b/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
@@ -38,6 +38,7 @@ struct PrDetailView: View {
   @State private var aiResolverSheetPresented: Bool = false
   @State private var actionsSheetPresented: Bool = false
   @State private var hasLoadedLiveSidecars = false
+  @State private var hasAttemptedInitialLoad = false
   /// True while a `prs.pathToMerge.start` or `prs.pathToMerge.stop` round-trip
   /// is in flight. Used to disable the convergence toggle and show a spinner.
   @State private var isPathToMergeBusy: Bool = false
@@ -51,7 +52,7 @@ struct PrDetailView: View {
   }
 
   private var canRunPrActions: Bool {
-    isLive && busyAction == nil
+    isLive && busyAction == nil && hasActionablePrId
   }
 
   private var canOpenCurrentPrInGitHub: Bool {
@@ -87,6 +88,37 @@ struct PrDetailView: View {
     return state == "open" && !status.isMergeable && !status.mergeConflicts
   }
 
+  private var routedPrNumber: Int? {
+    Self.prNumber(fromRouteId: prId)
+  }
+
+  private var hasPrDetailData: Bool {
+    pr != nil || githubItem != nil || snapshot != nil
+  }
+
+  private var effectivePrId: String {
+    pr?.id ?? githubItem?.linkedPrId ?? prId
+  }
+
+  private var hasActionablePrId: Bool {
+    pr != nil || snapshot != nil || githubItem?.linkedPrId != nil
+  }
+
+  private var isAwaitingInitialPrDetail: Bool {
+    !hasAttemptedInitialLoad && !hasPrDetailData
+  }
+
+  private var isPrDetailUnavailable: Bool {
+    hasAttemptedInitialLoad && !hasPrDetailData
+  }
+
+  private var unavailablePrLabel: String {
+    if let routedPrNumber {
+      return "#\(routedPrNumber)"
+    }
+    return "this pull request"
+  }
+
   private var currentPr: PullRequestListItem {
     if let pr { return pr }
     let detail = snapshot?.detail
@@ -101,9 +133,9 @@ struct PrDetailView: View {
       projectId: "",
       repoOwner: githubItem?.repoOwner ?? "",
       repoName: githubItem?.repoName ?? "",
-      githubPrNumber: githubItem?.githubPrNumber ?? 0,
+      githubPrNumber: githubItem?.githubPrNumber ?? routedPrNumber ?? 0,
       githubUrl: githubItem?.githubUrl ?? "",
-      title: githubItem?.title ?? "Pull request",
+      title: githubItem?.title ?? routedPrNumber.map { "Pull request #\($0)" } ?? "Pull request",
       state:
         detail?.isDraft == true || githubItem?.isDraft == true
           ? "draft"
@@ -175,7 +207,7 @@ struct PrDetailView: View {
     // The Activity tab has its own comment/reply composer at the end of the
     // content. A global merge bar in the same bottom slot hides that composer
     // on phone-sized screens.
-    selectedTab != .activity
+    hasPrDetailData && selectedTab != .activity
   }
 
   private var behindBaseBy: Int {
@@ -262,22 +294,38 @@ struct PrDetailView: View {
         .prListRow()
       }
 
-      heroCard
+      if isAwaitingInitialPrDetail {
+        ADECardSkeleton(rows: 4)
+          .prListRow()
+      } else if isPrDetailUnavailable {
+        ADENoticeCard(
+          title: "Pull request unavailable",
+          message: isLive
+            ? "ADE could not find \(unavailablePrLabel). Refresh the PR list and try again."
+            : "Reconnect to your Mac to load \(unavailablePrLabel).",
+          icon: "arrow.triangle.merge",
+          tint: ADEColor.warning,
+          actionTitle: "Retry",
+          action: { Task { await reload(refreshRemote: true) } }
+        )
         .prListRow()
+      } else {
+        heroCard
+          .prListRow()
 
-      PrMergeGateCard(info: mergeGateInfo) {
-        switch mergeGateInfo.target {
-        case .checks: selectedTab = .checks
-        case .reviews: selectedTab = .activity
-        case .overview: selectedTab = .overview
+        PrMergeGateCard(info: mergeGateInfo) {
+          switch mergeGateInfo.target {
+          case .checks: selectedTab = .checks
+          case .reviews: selectedTab = .activity
+          case .overview: selectedTab = .overview
+          }
         }
-      }
-      .prListRow()
-
-      subTabPicker
         .prListRow()
 
-      switch selectedTab {
+        subTabPicker
+          .prListRow()
+
+        switch selectedTab {
       case .overview:
         PrOverviewTab(
           pr: currentPr,
@@ -392,6 +440,7 @@ struct PrDetailView: View {
         )
         .prListRow()
       }
+      }
     }
     .listStyle(.plain)
     .listRowSpacing(12)
@@ -482,7 +531,7 @@ struct PrDetailView: View {
           submitTitle: "Save"
         ) { value in
           runPrAction("Updating PR title") {
-            try await syncService.updatePullRequestTitle(prId: prId, title: value)
+            try await syncService.updatePullRequestTitle(prId: effectivePrId, title: value)
           } onSuccess: {
             editorSheet = nil
           }
@@ -494,7 +543,7 @@ struct PrDetailView: View {
           submitTitle: "Save"
         ) { value in
           runPrAction("Updating PR description") {
-            try await syncService.updatePullRequestBody(prId: prId, body: value)
+            try await syncService.updatePullRequestBody(prId: effectivePrId, body: value)
           } onSuccess: {
             editorSheet = nil
           }
@@ -511,7 +560,7 @@ struct PrDetailView: View {
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
           runPrAction("Updating labels") {
-            try await syncService.setPullRequestLabels(prId: prId, labels: labels)
+            try await syncService.setPullRequestLabels(prId: effectivePrId, labels: labels)
           } onSuccess: {
             editorSheet = nil
           }
@@ -519,7 +568,7 @@ struct PrDetailView: View {
       case .review:
         PrSubmitReviewSheet { event, body in
           runPrAction("Submitting review") {
-            try await syncService.submitPullRequestReview(prId: prId, event: event.rawValue, body: body)
+            try await syncService.submitPullRequestReview(prId: effectivePrId, event: event.rawValue, body: body)
           } onSuccess: {
             editorSheet = nil
           }
@@ -935,43 +984,44 @@ struct PrDetailView: View {
 
   // MARK: - Data loading
 
+  private static func prNumber(fromRouteId routeId: String) -> Int? {
+    let prefix = "github-pr-number:"
+    guard routeId.hasPrefix(prefix) else { return nil }
+    return Int(routeId.dropFirst(prefix.count))
+  }
+
   @MainActor
   private func reload(refreshRemote: Bool = false, includeLiveSidecars: Bool? = nil) async {
-    let shouldFetchLiveSidecars = isLive && (includeLiveSidecars ?? refreshRemote)
-    let capabilitiesTask: Task<PrActionCapabilities?, Never>? = shouldFetchLiveSidecars
-      ? Task {
-          do {
-            let mobileSnapshot = try await syncService.fetchPrMobileSnapshot()
-            return mobileSnapshot.capabilities[prId]
-          } catch {
-            return nil
-          }
-        }
-      : nil
+    let requestedPrNumber = routedPrNumber
+    let shouldFetchLiveSidecars = isLive && ((includeLiveSidecars ?? refreshRemote) || requestedPrNumber != nil)
 
     do {
       var refreshError: Error?
       if refreshRemote {
         do {
-          try await syncService.refreshPullRequestSnapshots(prId: prId)
+          if requestedPrNumber == nil {
+            try await syncService.refreshPullRequestSnapshots(prId: effectivePrId)
+          } else {
+            try await syncService.refreshPullRequestSnapshots()
+          }
         } catch {
           refreshError = error
         }
       }
-      async let listItemsTask = syncService.fetchPullRequestListItems()
-      async let snapshotTask = syncService.fetchPullRequestSnapshot(prId: prId)
-      let reviewThreadsTask = shouldFetchLiveSidecars ? Task { try? await syncService.fetchPullRequestReviewThreads(prId: prId) } : nil
-      let actionRunsTask = shouldFetchLiveSidecars ? Task { try? await syncService.fetchPullRequestActionRuns(prId: prId) } : nil
-      let activityTask = shouldFetchLiveSidecars ? Task { try? await syncService.fetchPullRequestActivity(prId: prId) } : nil
-      let deploymentsTask = shouldFetchLiveSidecars ? Task { try? await syncService.fetchPullRequestDeployments(prId: prId) } : nil
-      let aiSummaryTask = shouldFetchLiveSidecars ? Task { try? await syncService.fetchPullRequestAiSummary(prId: prId) } : nil
-      let issueInventoryTask = shouldFetchLiveSidecars ? Task { try? await syncService.fetchIssueInventory(prId: prId) } : nil
-      let pipelineSettingsTask = shouldFetchLiveSidecars ? Task { try? await syncService.fetchPipelineSettings(prId: prId) } : nil
+      let listItems = try await syncService.fetchPullRequestListItems()
 
-      let listItems = try await listItemsTask
-      pr = listItems.first(where: { $0.id == prId })
-      snapshot = try await snapshotTask
-
+      pr = listItems.first { item in
+        if let requestedPrNumber {
+          return item.githubPrNumber == requestedPrNumber
+        }
+        return item.id == prId
+      }
+      let snapshotPrId = pr?.id ?? (requestedPrNumber == nil ? prId : nil)
+      if let snapshotPrId {
+        snapshot = try await syncService.fetchPullRequestSnapshot(prId: snapshotPrId)
+      } else {
+        snapshot = nil
+      }
       // Fall back to the repo-scoped GitHub snapshot when the PR isn't in the
       // lane-PR list. This keeps the hero card from collapsing into
       // "Pull request / @unknown" placeholders without resurrecting legacy
@@ -979,9 +1029,31 @@ struct PrDetailView: View {
       if pr == nil && shouldFetchLiveSidecars {
         if let github = try? await syncService.fetchGitHubPullRequestSnapshot() {
           githubItem = repoScopedGitHubPullRequests(from: github)
-            .first { $0.linkedPrId == prId || $0.id == prId }
+            .first {
+              $0.linkedPrId == prId ||
+                $0.id == prId ||
+                (requestedPrNumber != nil && $0.githubPrNumber == requestedPrNumber)
+            }
         }
+      } else if pr != nil {
+        githubItem = nil
       }
+      let sidecarPrId = snapshotPrId ?? githubItem?.linkedPrId ?? prId
+      let capabilitiesTask: Task<PrActionCapabilities?, Never>? = shouldFetchLiveSidecars ? Task {
+        do {
+          let mobileSnapshot = try await syncService.fetchPrMobileSnapshot()
+          return mobileSnapshot.capabilities[sidecarPrId]
+        } catch {
+          return nil
+        }
+      } : nil
+      let reviewThreadsTask = shouldFetchLiveSidecars ? Task { try? await syncService.fetchPullRequestReviewThreads(prId: sidecarPrId) } : nil
+      let actionRunsTask = shouldFetchLiveSidecars ? Task { try? await syncService.fetchPullRequestActionRuns(prId: sidecarPrId) } : nil
+      let activityTask = shouldFetchLiveSidecars ? Task { try? await syncService.fetchPullRequestActivity(prId: sidecarPrId) } : nil
+      let deploymentsTask = shouldFetchLiveSidecars ? Task { try? await syncService.fetchPullRequestDeployments(prId: sidecarPrId) } : nil
+      let aiSummaryTask = shouldFetchLiveSidecars ? Task { try? await syncService.fetchPullRequestAiSummary(prId: sidecarPrId) } : nil
+      let issueInventoryTask = shouldFetchLiveSidecars ? Task { try? await syncService.fetchIssueInventory(prId: sidecarPrId) } : nil
+      let pipelineSettingsTask = shouldFetchLiveSidecars ? Task { try? await syncService.fetchPipelineSettings(prId: sidecarPrId) } : nil
       if let reviewThreadsTask {
         reviewThreads = await reviewThreadsTask.value ?? []
       }
@@ -1003,6 +1075,9 @@ struct PrDetailView: View {
       if let settings = await pipelineSettingsTask?.value {
         pipelineSettings = settings
       }
+      if let capabilitiesTask {
+        capabilities = await capabilitiesTask.value
+      }
       if let groupId = pr?.linkedGroupId {
         groupMembers = try await syncService.fetchPullRequestGroupMembers(groupId: groupId)
       } else {
@@ -1016,9 +1091,7 @@ struct PrDetailView: View {
     if shouldFetchLiveSidecars {
       hasLoadedLiveSidecars = true
     }
-    if let capabilitiesTask {
-      capabilities = await capabilitiesTask.value
-    }
+    hasAttemptedInitialLoad = true
   }
 
   @MainActor
@@ -1042,15 +1115,15 @@ struct PrDetailView: View {
   }
 
   private func mergeCurrentPr() {
-    runPrAction("Merging pull request") { try await syncService.mergePullRequest(prId: prId, method: mergeMethod.rawValue) }
+    runPrAction("Merging pull request") { try await syncService.mergePullRequest(prId: effectivePrId, method: mergeMethod.rawValue) }
   }
 
   private func closeCurrentPr() {
-    runPrAction("Closing pull request") { try await syncService.closePullRequest(prId: prId) }
+    runPrAction("Closing pull request") { try await syncService.closePullRequest(prId: effectivePrId) }
   }
 
   private func reopenCurrentPr() {
-    runPrAction("Reopening pull request") { try await syncService.reopenPullRequest(prId: prId) }
+    runPrAction("Reopening pull request") { try await syncService.reopenPullRequest(prId: effectivePrId) }
   }
 
   private func requestReviewers() {
@@ -1063,13 +1136,13 @@ struct PrDetailView: View {
 
     runPrAction(
       "Requesting reviewers",
-      action: { try await syncService.requestReviewers(prId: prId, reviewers: reviewers) },
+      action: { try await syncService.requestReviewers(prId: effectivePrId, reviewers: reviewers) },
       onSuccess: { reviewerInput = "" }
     )
   }
 
   private func rerunChecks() {
-    runPrAction("Re-running checks") { try await syncService.rerunPullRequestChecks(prId: prId) }
+    runPrAction("Re-running checks") { try await syncService.rerunPullRequestChecks(prId: effectivePrId) }
   }
 
   private var aiResolverRunning: Bool {
@@ -1084,7 +1157,7 @@ struct PrDetailView: View {
       defer { isAiResolverBusy = false }
       do {
         let state = try await syncService.startPrAiResolution(
-          prId: prId,
+          prId: effectivePrId,
           model: model,
           reasoningEffort: reasoningEffort
         )
@@ -1102,7 +1175,7 @@ struct PrDetailView: View {
       isAiResolverBusy = true
       defer { isAiResolverBusy = false }
       do {
-        try await syncService.stopPrAiResolution(prId: prId)
+        try await syncService.stopPrAiResolution(prId: effectivePrId)
         if let current = aiResolution {
           aiResolution = AiResolutionState(
             prId: current.prId,
@@ -1131,7 +1204,7 @@ struct PrDetailView: View {
       isPathToMergeBusy = true
       defer { isPathToMergeBusy = false }
       do {
-        let result = try await syncService.startPathToMerge(prId: prId)
+        let result = try await syncService.startPathToMerge(prId: effectivePrId)
         applyConvergenceRuntime(result.runtime)
         if !result.scheduled {
           errorMessage = result.blockedBy?.message ?? "Path to Merge is blocked by another lane task."
@@ -1153,7 +1226,7 @@ struct PrDetailView: View {
       isPathToMergeBusy = true
       defer { isPathToMergeBusy = false }
       do {
-        let result = try await syncService.stopPathToMerge(prId: prId, reason: "Stopped from iOS.")
+        let result = try await syncService.stopPathToMerge(prId: effectivePrId, reason: "Stopped from iOS.")
         if let runtime = result.runtime {
           applyConvergenceRuntime(runtime)
         }
@@ -1182,7 +1255,7 @@ struct PrDetailView: View {
       isAiSummaryLoading = true
       defer { isAiSummaryLoading = false }
       do {
-        let summary = try await syncService.fetchPullRequestAiSummary(prId: prId)
+        let summary = try await syncService.fetchPullRequestAiSummary(prId: effectivePrId)
         aiSummary = summary
       } catch {
         errorMessage = error.localizedDescription
@@ -1192,7 +1265,7 @@ struct PrDetailView: View {
 
   private func syncIssueInventory() {
     runPrAction("Syncing issue inventory") {
-      let inventory = try await syncService.syncIssueInventory(prId: prId)
+      let inventory = try await syncService.syncIssueInventory(prId: effectivePrId)
       await MainActor.run {
         issueInventory = inventory
       }
@@ -1215,18 +1288,18 @@ struct PrDetailView: View {
     runPrAction(label) {
       switch action {
       case .fixed:
-        try await syncService.markIssueInventoryFixed(prId: prId, itemIds: [itemId])
+        try await syncService.markIssueInventoryFixed(prId: effectivePrId, itemIds: [itemId])
       case .dismissed:
-        try await syncService.markIssueInventoryDismissed(prId: prId, itemIds: [itemId], reason: "Dismissed from iOS")
+        try await syncService.markIssueInventoryDismissed(prId: effectivePrId, itemIds: [itemId], reason: "Dismissed from iOS")
       case .escalated:
-        try await syncService.markIssueInventoryEscalated(prId: prId, itemIds: [itemId])
+        try await syncService.markIssueInventoryEscalated(prId: effectivePrId, itemIds: [itemId])
       }
     }
   }
 
   private func resetIssueInventory() {
     runPrAction("Resetting issue inventory") {
-      try await syncService.resetIssueInventory(prId: prId)
+      try await syncService.resetIssueInventory(prId: effectivePrId)
       await MainActor.run {
         issueInventory = nil
       }
@@ -1256,14 +1329,14 @@ struct PrDetailView: View {
       var next: PipelineSettings
       if let current = pipelineSettings {
         next = current
-      } else if let fetched = try? await syncService.fetchPipelineSettings(prId: prId) {
+      } else if let fetched = try? await syncService.fetchPipelineSettings(prId: effectivePrId) {
         next = fetched
       } else {
         next = defaultPipelineSettings()
       }
       mutate(&next)
-      try await syncService.savePipelineSettings(prId: prId, settings: next)
-      let settings = try await syncService.fetchPipelineSettings(prId: prId)
+      try await syncService.savePipelineSettings(prId: effectivePrId, settings: next)
+      let settings = try await syncService.fetchPipelineSettings(prId: effectivePrId)
       await MainActor.run {
         pipelineSettings = settings
       }
@@ -1384,7 +1457,7 @@ struct PrDetailView: View {
 
     runPrAction(
       "Posting comment",
-      action: { try await syncService.addPullRequestComment(prId: prId, body: trimmed) },
+      action: { try await syncService.addPullRequestComment(prId: effectivePrId, body: trimmed) },
       onSuccess: { commentInput = "" }
     )
   }
@@ -1393,13 +1466,13 @@ struct PrDetailView: View {
     let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmed.isEmpty else { return }
     runPrAction("Replying to review thread") {
-      try await syncService.replyToPullRequestReviewThread(prId: prId, threadId: threadId, body: trimmed)
+      try await syncService.replyToPullRequestReviewThread(prId: effectivePrId, threadId: threadId, body: trimmed)
     }
   }
 
   private func setThreadResolved(threadId: String, resolved: Bool) {
     runPrAction(resolved ? "Resolving review thread" : "Reopening review thread") {
-      try await syncService.setPullRequestReviewThreadResolved(prId: prId, threadId: threadId, resolved: resolved)
+      try await syncService.setPullRequestReviewThreadResolved(prId: effectivePrId, threadId: threadId, resolved: resolved)
     }
   }
 

--- a/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
+++ b/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
@@ -119,6 +119,20 @@ struct PrDetailView: View {
     return "this pull request"
   }
 
+  private var displayedPrNumber: Int? {
+    if let pr { return pr.githubPrNumber }
+    if let githubItem { return githubItem.githubPrNumber }
+    if let routedPrNumber { return routedPrNumber }
+    return nil
+  }
+
+  private var detailHeaderAccessibilityLabel: String {
+    if let displayedPrNumber {
+      return "Pull request \(displayedPrNumber), \(currentPr.title)"
+    }
+    return "Pull request, \(currentPr.title)"
+  }
+
   private var currentPr: PullRequestListItem {
     if let pr { return pr }
     let detail = snapshot?.detail
@@ -289,7 +303,7 @@ struct PrDetailView: View {
           icon: "exclamationmark.triangle.fill",
           tint: ADEColor.danger,
           actionTitle: "Retry",
-          action: { Task { await reload(refreshRemote: true) } }
+          action: { Task { await retryPrDetailLoad() } }
         )
         .prListRow()
       }
@@ -306,7 +320,7 @@ struct PrDetailView: View {
           icon: "arrow.triangle.merge",
           tint: ADEColor.warning,
           actionTitle: "Retry",
-          action: { Task { await reload(refreshRemote: true) } }
+          action: { Task { await retryPrDetailLoad() } }
         )
         .prListRow()
       } else {
@@ -590,9 +604,11 @@ struct PrDetailView: View {
       .accessibilityLabel("Back to PRs")
 
       VStack(alignment: .leading, spacing: 2) {
-        Text("#\(currentPr.githubPrNumber)")
-          .font(.system(size: 11, weight: .bold, design: .monospaced))
-          .foregroundStyle(prStateTint(currentPr.state))
+        if let displayedPrNumber {
+          Text("#\(displayedPrNumber)")
+            .font(.system(size: 11, weight: .bold, design: .monospaced))
+            .foregroundStyle(prStateTint(currentPr.state))
+        }
         Text(currentPr.title)
           .font(.headline.weight(.semibold))
           .foregroundStyle(ADEColor.textPrimary)
@@ -600,7 +616,7 @@ struct PrDetailView: View {
           .truncationMode(.tail)
       }
       .accessibilityElement(children: .combine)
-      .accessibilityLabel("Pull request \(currentPr.githubPrNumber), \(currentPr.title)")
+      .accessibilityLabel(detailHeaderAccessibilityLabel)
 
       Spacer(minLength: 0)
 
@@ -1009,13 +1025,17 @@ struct PrDetailView: View {
         }
       }
       let listItems = try await syncService.fetchPullRequestListItems()
-
-      pr = listItems.first { item in
-        if let requestedPrNumber {
-          return item.githubPrNumber == requestedPrNumber
-        }
-        return item.id == prId
+      var fallbackGitHubItem: GitHubPrListItem?
+      if shouldFetchLiveSidecars && requestedPrNumber != nil {
+        fallbackGitHubItem = await fetchGitHubFallbackItem(requestedPrNumber: requestedPrNumber)
       }
+
+      pr = prDetailRouteListItem(
+        from: listItems,
+        prId: prId,
+        requestedPrNumber: requestedPrNumber,
+        githubItem: fallbackGitHubItem
+      )
       let snapshotPrId = pr?.id ?? (requestedPrNumber == nil ? prId : nil)
       if let snapshotPrId {
         snapshot = try await syncService.fetchPullRequestSnapshot(prId: snapshotPrId)
@@ -1027,14 +1047,10 @@ struct PrDetailView: View {
       // "Pull request / @unknown" placeholders without resurrecting legacy
       // cross-repo snapshot items.
       if pr == nil && shouldFetchLiveSidecars {
-        if let github = try? await syncService.fetchGitHubPullRequestSnapshot() {
-          githubItem = repoScopedGitHubPullRequests(from: github)
-            .first {
-              $0.linkedPrId == prId ||
-                $0.id == prId ||
-                (requestedPrNumber != nil && $0.githubPrNumber == requestedPrNumber)
-            }
+        if fallbackGitHubItem == nil {
+          fallbackGitHubItem = await fetchGitHubFallbackItem(requestedPrNumber: requestedPrNumber)
         }
+        githubItem = fallbackGitHubItem
       } else if pr != nil {
         githubItem = nil
       }
@@ -1092,6 +1108,24 @@ struct PrDetailView: View {
       hasLoadedLiveSidecars = true
     }
     hasAttemptedInitialLoad = true
+  }
+
+  @MainActor
+  private func retryPrDetailLoad() async {
+    hasAttemptedInitialLoad = false
+    errorMessage = nil
+    await reload(refreshRemote: true)
+  }
+
+  @MainActor
+  private func fetchGitHubFallbackItem(requestedPrNumber: Int?) async -> GitHubPrListItem? {
+    guard let github = try? await syncService.fetchGitHubPullRequestSnapshot() else { return nil }
+    return repoScopedGitHubPullRequests(from: github)
+      .first {
+        $0.linkedPrId == prId ||
+          $0.id == prId ||
+          (requestedPrNumber != nil && $0.githubPrNumber == requestedPrNumber)
+      }
   }
 
   @MainActor

--- a/apps/ios/ADE/Views/PRs/PrHelpers.swift
+++ b/apps/ios/ADE/Views/PRs/PrHelpers.swift
@@ -258,6 +258,42 @@ func repoScopedGitHubPullRequests(from snapshot: GitHubPrSnapshot?) -> [GitHubPr
   snapshot?.repoPullRequests ?? []
 }
 
+func prDetailRouteListItem(
+  from items: [PullRequestListItem],
+  prId: String,
+  requestedPrNumber: Int?,
+  githubItem: GitHubPrListItem?
+) -> PullRequestListItem? {
+  guard let requestedPrNumber else {
+    return items.first { $0.id == prId }
+  }
+
+  let candidates = items.filter { $0.githubPrNumber == requestedPrNumber }
+  guard !candidates.isEmpty else { return nil }
+
+  if let linkedPrId = githubItem?.linkedPrId,
+     let match = candidates.first(where: { $0.id == linkedPrId }) {
+    return match
+  }
+
+  if let linkedLaneId = githubItem?.linkedLaneId,
+     let match = candidates.first(where: { $0.laneId == linkedLaneId }) {
+    return match
+  }
+
+  if let githubItem {
+    let repoMatches = candidates.filter {
+      $0.repoOwner.caseInsensitiveCompare(githubItem.repoOwner) == .orderedSame
+        && $0.repoName.caseInsensitiveCompare(githubItem.repoName) == .orderedSame
+    }
+    if repoMatches.count == 1 {
+      return repoMatches[0]
+    }
+  }
+
+  return candidates.count == 1 ? candidates[0] : nil
+}
+
 func matchesPullRequestListItemStatus(_ item: PullRequestListItem, state: PrGitHubStatusFilter) -> Bool {
   switch state {
   case .all:

--- a/apps/ios/ADE/Views/PRs/PrsRootScreen.swift
+++ b/apps/ios/ADE/Views/PRs/PrsRootScreen.swift
@@ -34,6 +34,7 @@ struct PRsTabView: View {
   @State private var selectedPrTransitionId: String?
   @State private var laneContextLaneId: String?
   @State private var rootActionTask: Task<Void, Never>?
+  @State private var rootActionRunId: String?
   @State private var githubDetailRequest: PrGitHubLaneLinkRequest?
   @State private var laneLinkRequest: PrGitHubLaneLinkRequest?
   @State private var pendingLaneLinkRequest: PrGitHubLaneLinkRequest?
@@ -1321,6 +1322,7 @@ struct PRsTabView: View {
     .presentationContentInteraction(.scrolls)
   }
 
+  @MainActor
   private func handleCreateSinglePr(
     laneId: String,
     title: String,
@@ -1330,9 +1332,10 @@ struct PRsTabView: View {
     labels: [String],
     reviewers: [String],
     strategy: String?
-  ) {
-    runPrRootAction(
+  ) async -> Bool {
+    await performPrRootAction(
       "Creating pull request",
+      cancelExisting: true,
       operation: {
         try await syncService.createPullRequest(
           laneId: laneId,
@@ -1351,9 +1354,11 @@ struct PRsTabView: View {
     )
   }
 
-  private func handleCreateQueuePrs(_ request: CreateQueuePrsRequest) {
-    runPrRootAction(
+  @MainActor
+  private func handleCreateQueuePrs(_ request: CreateQueuePrsRequest) async -> Bool {
+    await performPrRootAction(
       "Creating queue PRs",
+      cancelExisting: true,
       operation: {
         _ = try await syncService.createQueuePrs(
           laneIds: request.laneIds,
@@ -1372,9 +1377,11 @@ struct PRsTabView: View {
     )
   }
 
-  private func handleCreateIntegrationPr(_ request: CreateIntegrationRequest) {
-    runPrRootAction(
+  @MainActor
+  private func handleCreateIntegrationPr(_ request: CreateIntegrationRequest) async -> Bool {
+    await performPrRootAction(
       "Creating integration PR",
+      cancelExisting: true,
       operation: {
         let proposal = try await syncService.simulateIntegration(
           sourceLaneIds: request.sourceLaneIds,
@@ -1413,42 +1420,69 @@ struct PRsTabView: View {
   ) {
     rootActionTask?.cancel()
     let task = Task { @MainActor in
-      busyAction = label
-      errorMessage = nil
-      actionMessage = nil
-      do {
-        try await operation()
-        guard !Task.isCancelled else {
-          busyAction = nil
-          return
-        }
-        onSuccess()
-        guard !Task.isCancelled else {
-          busyAction = nil
-          return
-        }
-        await reload(refreshRemote: true)
-        guard !Task.isCancelled else {
-          busyAction = nil
-          return
-        }
-        actionMessage = "\(label) finished."
-      } catch {
-        guard !Task.isCancelled else {
-          busyAction = nil
-          return
-        }
-        let message = error.localizedDescription
-        await reload(refreshRemote: false)
-        guard !Task.isCancelled else {
-          busyAction = nil
-          return
-        }
-        errorMessage = message
-      }
-      busyAction = nil
+      _ = await performPrRootAction(label, operation: operation, onSuccess: onSuccess)
     }
     rootActionTask = task
+  }
+
+  @MainActor
+  @discardableResult
+  private func performPrRootAction(
+    _ label: String,
+    cancelExisting: Bool = false,
+    operation: @escaping () async throws -> Void,
+    onSuccess: @escaping @MainActor () -> Void = {}
+  ) async -> Bool {
+    if cancelExisting {
+      rootActionTask?.cancel()
+      rootActionTask = nil
+    }
+    let runId = UUID().uuidString
+    rootActionRunId = runId
+    busyAction = label
+    errorMessage = nil
+    actionMessage = nil
+    do {
+      try await operation()
+      guard rootActionRunId == runId, !Task.isCancelled else {
+        clearPrRootActionIfCurrent(runId)
+        return false
+      }
+      onSuccess()
+      guard rootActionRunId == runId, !Task.isCancelled else {
+        clearPrRootActionIfCurrent(runId)
+        return false
+      }
+      await reload(refreshRemote: true)
+      guard rootActionRunId == runId, !Task.isCancelled else {
+        clearPrRootActionIfCurrent(runId)
+        return false
+      }
+      actionMessage = "\(label) finished."
+      clearPrRootActionIfCurrent(runId)
+      return true
+    } catch {
+      guard rootActionRunId == runId, !Task.isCancelled else {
+        clearPrRootActionIfCurrent(runId)
+        return false
+      }
+      let message = error.localizedDescription
+      await reload(refreshRemote: false)
+      guard rootActionRunId == runId, !Task.isCancelled else {
+        clearPrRootActionIfCurrent(runId)
+        return false
+      }
+      errorMessage = message
+      clearPrRootActionIfCurrent(runId)
+      return false
+    }
+  }
+
+  @MainActor
+  private func clearPrRootActionIfCurrent(_ runId: String) {
+    guard rootActionRunId == runId else { return }
+    busyAction = nil
+    rootActionRunId = nil
   }
 
   private func openGitHub(urlString: String) {

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -282,7 +282,11 @@ struct WorkChatSessionView: View {
   var streamingStatusSection: some View {
     WorkActivityIndicator(
       transcript: transcript,
-      isStreaming: (sessionStatus == "active" && isLive) || timelineSnapshot.transcriptIndicatesActiveTurn
+      isStreaming: workChatIsStreaming(
+        sessionStatus: sessionStatus,
+        isLive: isLive,
+        transcriptIndicatesActiveTurn: timelineSnapshot.transcriptIndicatesActiveTurn
+      )
     )
   }
 

--- a/apps/ios/ADE/Views/Work/WorkModels.swift
+++ b/apps/ios/ADE/Views/Work/WorkModels.swift
@@ -410,6 +410,15 @@ enum WorkLoadedArtifactContent {
   case error(String)
 }
 
+func workRemoveLoadedArtifactTempFile(_ content: WorkLoadedArtifactContent?) {
+  guard case .video(let url) = content,
+        url.isFileURL,
+        url.lastPathComponent.hasPrefix("ade-work-artifact-") else {
+    return
+  }
+  try? FileManager.default.removeItem(at: url)
+}
+
 struct WorkChatEnvelope: Identifiable, Equatable {
   var id: String { "\(sessionId):\(sequence ?? -1):\(timestamp):\(event.typeKey)" }
   let sessionId: String

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -256,6 +256,7 @@ struct WorkSessionDestinationView: View {
           syncService.releaseLaneOpen(laneId: announcedLaneId)
           self.announcedLaneId = nil
         }
+        cleanupLoadedArtifactContent()
         Task {
           try? await syncService.unsubscribeFromChatEvents(sessionId: sessionId)
         }
@@ -483,6 +484,13 @@ struct WorkSessionDestinationView: View {
   }
 
   @MainActor
+  func cleanupLoadedArtifactContent() {
+    artifactContent.values.forEach { workRemoveLoadedArtifactTempFile($0) }
+    artifactContent.removeAll()
+    artifactContentLoadsInFlight.removeAll()
+  }
+
+  @MainActor
   func refreshArtifacts(force: Bool) async {
     guard let currentSession = session ?? initialSession,
           isChatSession(currentSession)
@@ -502,10 +510,14 @@ struct WorkSessionDestinationView: View {
       let refreshed = try await syncService.fetchComputerUseArtifacts(ownerKind: "chat_session", ownerId: sessionId)
       let validArtifactIds = Set(refreshed.map(\.id))
 
+      for (artifactId, content) in artifactContent where !validArtifactIds.contains(artifactId) {
+        workRemoveLoadedArtifactTempFile(content)
+      }
       artifactContent = artifactContent.filter { validArtifactIds.contains($0.key) }
       artifactContentLoadsInFlight = Set(artifactContentLoadsInFlight.filter { validArtifactIds.contains($0) })
 
       for artifact in refreshed where previousURIs[artifact.id] != nil && previousURIs[artifact.id] != artifact.uri {
+        workRemoveLoadedArtifactTempFile(artifactContent[artifact.id])
         artifactContent.removeValue(forKey: artifact.id)
       }
 

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -76,6 +76,14 @@ func workTranscriptIndicatesActiveTurn(_ transcript: [WorkChatEnvelope]) -> Bool
   return bootstrapStartOpen || !activeTurnIds.isEmpty
 }
 
+func workChatIsStreaming(
+  sessionStatus: String,
+  isLive: Bool,
+  transcriptIndicatesActiveTurn: Bool
+) -> Bool {
+  isLive && (sessionStatus == "active" || transcriptIndicatesActiveTurn)
+}
+
 /// Collapse `subagent_*` events into one snapshot per taskId. Preserves host
 /// order via a first-seen index so completed subagents don't jump around when
 /// a later progress event lands.

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -139,6 +139,31 @@ final class ADETests: XCTestCase {
   }
 
   @MainActor
+  func testDeepLinkRouterRequestsPrNavigationByNumberWhenSnapshotMisses() throws {
+    let previousShared = SyncService.shared
+    let previousSnapshotData = ADESharedContainer.defaults.data(forKey: ADESharedContainer.workspaceSnapshotKey)
+    defer {
+      SyncService.shared = previousShared
+      if let previousSnapshotData {
+        ADESharedContainer.defaults.set(previousSnapshotData, forKey: ADESharedContainer.workspaceSnapshotKey)
+      } else {
+        ADESharedContainer.defaults.removeObject(forKey: ADESharedContainer.workspaceSnapshotKey)
+      }
+    }
+
+    ADESharedContainer.defaults.removeObject(forKey: ADESharedContainer.workspaceSnapshotKey)
+    let database = makeDatabase(baseURL: makeTemporaryDirectory())
+    defer { database.close() }
+    let service = SyncService(database: database)
+    SyncService.shared = service
+
+    DeepLinkRouter.shared.handleNotificationUserInfo(["prNumber": 9876])
+
+    XCTAssertEqual(service.requestedPrNavigation?.prNumber, 9876)
+    XCTAssertEqual(service.requestedPrNavigation?.prId, "github-pr-number:9876")
+  }
+
+  @MainActor
   func testDeepLinkRouterSendsHttpsAdePrLinksToMac() throws {
     let expected = "https://ade-app.dev/open?type=pr&repo=arul/ADE&number=42"
     let received = expectation(description: "send to Mac request posted")
@@ -4675,11 +4700,12 @@ final class ADETests: XCTestCase {
     UserDefaults.standard.set(try JSONEncoder().encode(descriptors), forKey: remoteCommandDescriptorsKey)
 
     let service = SyncService(database: makeDatabase(baseURL: makeTemporaryDirectory()))
-    await service.sendRemoteCommand(.approveSession, payload: [
+    let delivery = await service.sendRemoteCommand(.approveSession, payload: [
       "sessionId": "session-1",
       "itemId": "approval-1",
     ])
 
+    XCTAssertEqual(delivery, .queued)
     let queued = service.pendingOperationsForTesting()
     XCTAssertEqual(service.pendingOperationCount, 1)
     XCTAssertEqual(queued.count, 1)
@@ -8165,6 +8191,30 @@ final class ADETests: XCTestCase {
     XCTAssertFalse(completedSnapshot.transcriptIndicatesActiveTurn)
   }
 
+  func testWorkChatStreamingRequiresLiveConnectionForTranscriptActiveTurn() {
+    XCTAssertFalse(
+      workChatIsStreaming(
+        sessionStatus: "idle",
+        isLive: false,
+        transcriptIndicatesActiveTurn: true
+      )
+    )
+    XCTAssertTrue(
+      workChatIsStreaming(
+        sessionStatus: "idle",
+        isLive: true,
+        transcriptIndicatesActiveTurn: true
+      )
+    )
+    XCTAssertTrue(
+      workChatIsStreaming(
+        sessionStatus: "active",
+        isLive: true,
+        transcriptIndicatesActiveTurn: false
+      )
+    )
+  }
+
   func testWorkSessionEmptyStateMessagingExplainsSearchAndArchiveFallbacks() {
     XCTAssertEqual(
       workSessionEmptyStateTitle(status: .all, searchText: "deploy", hasFilters: true),
@@ -8193,6 +8243,17 @@ final class ADETests: XCTestCase {
 
     XCTAssertEqual(cache.cachedData(for: "artifact-1"), data)
     XCTAssertTrue(FileManager.default.fileExists(atPath: directory.appendingPathComponent(cache.diskFilename(for: "artifact-1")).path))
+  }
+
+  func testWorkArtifactVideoTempCleanupRemovesLocalPreviewFile() throws {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("ade-work-artifact-\(UUID().uuidString)")
+      .appendingPathExtension("mp4")
+    try Data([0x00, 0x00, 0x00, 0x18]).write(to: url)
+
+    workRemoveLoadedArtifactTempFile(.video(url))
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
   }
 
   func testParseANSISegmentsTracksForegroundColors() {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -4879,6 +4879,125 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(repoScopedGitHubPullRequests(from: snapshot).map(\.id), ["repo-pr"])
   }
 
+  func testPrDetailRouteListItemUsesRepoContextForDuplicatePrNumbers() {
+    func item(id: String, owner: String, repo: String, laneId: String) -> PullRequestListItem {
+      PullRequestListItem(
+        id: id,
+        laneId: laneId,
+        laneName: nil,
+        projectId: "project-1",
+        repoOwner: owner,
+        repoName: repo,
+        githubPrNumber: 42,
+        githubUrl: "https://github.com/\(owner)/\(repo)/pull/42",
+        title: "PR 42",
+        state: "open",
+        baseBranch: "main",
+        headBranch: "feature/42",
+        checksStatus: "pending",
+        reviewStatus: "requested",
+        additions: 1,
+        deletions: 0,
+        lastSyncedAt: nil,
+        createdAt: "2026-05-14T00:00:00.000Z",
+        updatedAt: "2026-05-14T00:00:00.000Z",
+        adeKind: nil,
+        linkedGroupId: nil,
+        linkedGroupType: nil,
+        linkedGroupName: nil,
+        linkedGroupPosition: nil,
+        linkedGroupCount: 0,
+        workflowDisplayState: nil,
+        cleanupState: nil
+      )
+    }
+
+    let githubItem = GitHubPrListItem(
+      id: "repo-pr",
+      scope: "repo",
+      repoOwner: "arul",
+      repoName: "ADE",
+      githubPrNumber: 42,
+      githubUrl: "https://github.com/arul/ADE/pull/42",
+      title: "Repo PR",
+      state: "open",
+      isDraft: false,
+      baseBranch: "main",
+      headBranch: "feature/42",
+      author: "octocat",
+      createdAt: "2026-05-14T00:00:00.000Z",
+      updatedAt: "2026-05-14T00:00:00.000Z",
+      linkedPrId: nil,
+      linkedGroupId: nil,
+      linkedLaneId: nil,
+      linkedLaneName: nil,
+      adeKind: nil,
+      workflowDisplayState: nil,
+      cleanupState: nil,
+      labels: [],
+      isBot: false,
+      commentCount: 0
+    )
+
+    let match = prDetailRouteListItem(
+      from: [
+        item(id: "wrong-repo", owner: "elsewhere", repo: "other", laneId: "lane-other"),
+        item(id: "right-repo", owner: "ARUL", repo: "ade", laneId: "lane-ade"),
+      ],
+      prId: "github-pr-number:42",
+      requestedPrNumber: 42,
+      githubItem: githubItem
+    )
+
+    XCTAssertEqual(match?.id, "right-repo")
+  }
+
+  func testPrDetailRouteListItemRejectsAmbiguousNumberRouteWithoutContext() {
+    func item(id: String, owner: String, repo: String) -> PullRequestListItem {
+      PullRequestListItem(
+        id: id,
+        laneId: "lane-\(id)",
+        laneName: nil,
+        projectId: "project-1",
+        repoOwner: owner,
+        repoName: repo,
+        githubPrNumber: 42,
+        githubUrl: "https://github.com/\(owner)/\(repo)/pull/42",
+        title: "PR 42",
+        state: "open",
+        baseBranch: "main",
+        headBranch: "feature/42",
+        checksStatus: "pending",
+        reviewStatus: "requested",
+        additions: 1,
+        deletions: 0,
+        lastSyncedAt: nil,
+        createdAt: "2026-05-14T00:00:00.000Z",
+        updatedAt: "2026-05-14T00:00:00.000Z",
+        adeKind: nil,
+        linkedGroupId: nil,
+        linkedGroupType: nil,
+        linkedGroupName: nil,
+        linkedGroupPosition: nil,
+        linkedGroupCount: 0,
+        workflowDisplayState: nil,
+        cleanupState: nil
+      )
+    }
+
+    let match = prDetailRouteListItem(
+      from: [
+        item(id: "first", owner: "arul", repo: "ade"),
+        item(id: "second", owner: "elsewhere", repo: "other"),
+      ],
+      prId: "github-pr-number:42",
+      requestedPrNumber: 42,
+      githubItem: nil
+    )
+
+    XCTAssertNil(match)
+  }
+
   func testPrParsedDateHandlesFractionalAndFallbackIsoDates() {
     let fractional = prParsedDate("2026-05-14T00:00:00.123Z")
     let fallback = prParsedDate("2026-05-14T00:00:00Z")

--- a/apps/ios/ADETests/AttentionDrawerModelTests.swift
+++ b/apps/ios/ADETests/AttentionDrawerModelTests.swift
@@ -370,6 +370,43 @@ final class AttentionDrawerModelTests: XCTestCase {
         XCTAssertEqual(model.unreadCount, 0, "all items are older than a future lastSeenAt")
     }
 
+    func testViewedOpenPrDoesNotRebadgeWhenSnapshotRegenerates() {
+        let model = AttentionDrawerModel(defaults: defaults)
+        let prUpdatedAt = Date().addingTimeInterval(-60)
+        let firstSnapshot = WorkspaceSnapshot(
+            generatedAt: Date(),
+            agents: [],
+            prs: [
+                PrSnapshot(
+                    id: "pr-still-open",
+                    number: 83,
+                    title: "Still open",
+                    checks: "failing",
+                    review: "approved",
+                    state: "open",
+                    mergeReady: false,
+                    updatedAt: prUpdatedAt
+                )
+            ],
+            connection: "connected"
+        )
+
+        model.rebuild(from: firstSnapshot)
+        XCTAssertEqual(model.unreadCount, 1)
+
+        model.markAllSeen()
+        model.rebuild(from: WorkspaceSnapshot(
+            generatedAt: Date().addingTimeInterval(2),
+            agents: [],
+            prs: firstSnapshot.prs,
+            connection: "connected"
+        ))
+
+        XCTAssertEqual(model.items.map(\.id), ["ci:pr-still-open"])
+        XCTAssertEqual(model.unreadCount, 0)
+        XCTAssertNil(model.badgeLabel)
+    }
+
     // MARK: - Inline summary
 
     func testInlineSummaryIgnoresClosedPrsWhenPickingFocus() {


### PR DESCRIPTION
Fixes ADE-83
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-83: iOS offline & deep-link reliability: false 'Sent', PR deep-link dead-ends, stuck 'Thinking', attention bell re-badge, PR-wizard dup-submit, temp-video leak](https://linear.app/ade-linear/issue/ADE-83/ios-offline-and-deep-link-reliability-false-sent-pr-deep-link-dead) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-83-ios-offline-deep-link-reliability-false-sent-pr-deep-link-dead-ends-stuck-thinking-attention-bell-re-badge-pr-wizard-dup-submit-temp-video-leak num=488 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-83-ios-offline-deep-link-reliability-false-sent-pr-deep-link-dead-ends-stuck-thinking-attention-bell-re-badge-pr-wizard-dup-submit-temp-video-leak&amp;pr=488">ade-83-ios-offline-deep-link-reliability-false-sent-pr-deep-link-dead-ends-stuck-thinking-attention-bell-re-badge-pr-wizard-dup-submit-temp-video-leak branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=488">PR #488</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses six distinct iOS reliability issues: false "Sent" confirmation on offline remote commands, PR deep-link dead-ends when deep-linked by number rather than ADE internal ID, stuck "Thinking" indicator when offline, attention-bell re-badging on snapshot regeneration, duplicate PR-wizard submissions, and temporary video file leaks on session close.

- **Deep-link & PR detail**: `DeepLinkRouter` now falls back to a number-based `PrNavigationRequest` when `resolvePrId` misses; `PrDetailScreen` gains a skeleton/unavailable state, a `fetchGitHubFallbackItem` helper, and uses `effectivePrId` for all mutation actions so number-routed PRs can still be acted on once resolved.
- **Remote command delivery**: `sendRemoteCommand` is promoted to `async -> SyncRemoteCommandDelivery` (dispatched/queued/dropped), enabling `SendToMacCard` to render outcome-aware UI and a retry path instead of always auto-dismissing.
- **Duplicate-submit & stuck spinner**: `CreatePrWizardView` callbacks are now `async -> Bool`; `submit()` awaits each callback and clears `isSubmitting` immediately on return, eliminating both the 1.2s timer workaround and the dup-submit window.
- **Attention bell stability**: `PrSnapshot.updatedAt` is now forwarded from the host; `AttentionDrawerModel` uses it as the item timestamp so a still-open PR with unchanged `updatedAt` doesn't re-badge on every snapshot refresh.
- **Temp video leak**: `workRemoveLoadedArtifactTempFile` is called on session disappear and on artifact URI change inside `refreshArtifacts`, cleaning up `ade-work-artifact-*` temp files.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all six targeted fixes are well-scoped and covered by new unit tests with no changes to shared data models that could break existing callers.

The changes are incremental and defensive: new fields on `PrSnapshot` and `PrNavigationRequest` are optional with nil defaults so older snapshots decode cleanly; `sendRemoteCommand` return value is `@discardableResult` so existing call sites need no updates; the `workChatIsStreaming` extraction is purely additive with a direct test. The one efficiency gap (a possible duplicate GitHub snapshot fetch in the number-route error path) is a no-op in terms of correctness.

`PrDetailScreen.swift` has the most logic density with the new number-based routing and sidecar ID resolution — worth a second read if the PR deep-link feature sees edge-case reports post-deploy.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/ios/ADE/App/DeepLinkRouter.swift | Adds number-based PR deep-link fallback: trims whitespace, tries resolvePrId first, falls back to Int(trimmed) > 0 route that creates a synthetic github-pr-number:N prId. |
| apps/ios/ADE/Services/SyncService.swift | Adds prNumber field and a number-only init to PrNavigationRequest; introduces SyncRemoteCommandDelivery enum; promotes sendRemoteCommand from fire-and-forget to return a delivery result; adds remoteCommandDroppedMessage for user-facing error strings. |
| apps/ios/ADE/Shared/ADESharedModels.swift | Adds optional updatedAt: Date? to PrSnapshot for attention-badge stability; default nil preserves backwards compatibility with older snapshots. |
| apps/ios/ADE/Views/AttentionDrawer/AttentionDrawerModel.swift | Uses pr.updatedAt ?? generated as the attention item timestamp, so a still-open PR with unchanged updatedAt no longer re-badges after snapshot regeneration. |
| apps/ios/ADE/Views/Deeplinks/SendToMacCard.swift | Replaces fire-and-forget send with an outcome-aware flow: shows Sent/Queued/Try again based on SyncRemoteCommandDelivery, tinted status text, and re-enables the button on .dropped for retry. |
| apps/ios/ADE/Views/PRs/CreatePrWizardView.swift | Promotes create callbacks to async -> Bool; converts submit() to @MainActor async, immediately clearing isSubmitting after each awaited callback and surfacing errorMessage on failure instead of the old 1.2s timer. |
| apps/ios/ADE/Views/PRs/PrDetailScreen.swift | Major deep-link reliability refactor: adds skeleton/unavailable states for number-routed PRs, effectivePrId for actions, fetchGitHubFallbackItem helper, and a retryPrDetailLoad path. One minor redundant network call possible in an error path. |
| apps/ios/ADE/Views/PRs/PrHelpers.swift | Adds prDetailRouteListItem to resolve a number-routed PR against lane-list candidates using linked IDs, lane IDs, and repo-owner disambiguation as fallback tiers. |
| apps/ios/ADE/Views/PRs/PrsRootScreen.swift | Extracts performPrRootAction (async, returns Bool, run-ID guard for stale-cancel safety) from the old Task-wrapping runPrRootAction; create handlers become async -> Bool to propagate success/failure back to the wizard. |
| apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift | Extracts workChatIsStreaming; new logic gates transcriptIndicatesActiveTurn behind isLive, fixing the stuck Thinking indicator when offline. |
| apps/ios/ADE/Views/Work/WorkModels.swift | Adds workRemoveLoadedArtifactTempFile to safely delete ade-work-artifact-* temp video files when an artifact is evicted or the session closes. |
| apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift | Adds cleanupLoadedArtifactContent on session disappear; also removes temp files for stale/changed artifact URIs inside refreshArtifacts. |
| apps/ios/ADETests/ADETests.swift | Adds tests for number-based deep-link routing, prDetailRouteListItem disambiguation, workChatIsStreaming logic, and temp-video cleanup. |
| apps/ios/ADETests/AttentionDrawerModelTests.swift | Adds testViewedOpenPrDoesNotRebadgeWhenSnapshotRegenerates covering the attention-bell stabilisation fix. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Deep-link / Push: kind=pr] --> B{resolvePrId\nfrom trimmed?}
    B -- yes --> C[PrNavigationRequest\nprId + prNumber]
    B -- no --> D{Int trimmed\n> 0?}
    D -- yes --> E[PrNavigationRequest\nprNumber only\nprId = github-pr-number:N]
    D -- no --> F[No navigation]
    C --> G[PrDetailScreen.reload]
    E --> G
    G --> H{requestedPrNumber != nil?}
    H -- yes --> I[fetchGitHubFallbackItem by number]
    H -- no --> J[prDetailRouteListItem by prId]
    I --> K[prDetailRouteListItem: disambiguate by linkedPrId → laneId → repo]
    K --> L{pr found?}
    J --> L
    L -- yes --> M[fetchPullRequestSnapshot by pr.id]
    L -- no --> N{isLive?}
    N -- yes --> O[ADENoticeCard: PR unavailable]
    N -- no --> P[ADENoticeCard: Reconnect to load]
    M --> Q[Render hero card + sidecars]
    subgraph SyncRemoteCommandDelivery
      R[sendRemoteCommand] --> S{server queued?}
      S -- yes --> T[.queued]
      S -- no --> U[.dispatched]
      R --> V{error?}
      V -- CancellationError --> W[.dropped: canceled]
      V -- NSURLError --> X[.dropped: reconnect]
      V -- app error --> Y[.dropped: server msg]
    end
    T --> Z[SendToMacCard: Queued / green]
    U --> AA[SendToMacCard: Sent / green]
    W --> BB[SendToMacCard: Try again / red]
    X --> BB
    Y --> BB
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/ios/ADE/Views/Deeplinks/SendToMacCard.swift`, line 249-251 ([link](https://github.com/arul28/ade/blob/a98de7674fb6c30b146330fcca059ece2745ddd7/apps/ios/ADE/Views/Deeplinks/SendToMacCard.swift#L249-L251)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`error.localizedDescription` surfaced verbatim in UI**

   `SyncRemoteCommandDelivery.dropped` is constructed with `error.localizedDescription` from the network layer and displayed directly via `sendStatusMessage`. System framework errors (e.g. `NSURLErrorDomain`) can produce messages that are technically accurate but confusing in context. Consider mapping known error domains to user-friendly strings before passing them into the `.dropped` case, or capping the fallback at a generic "Could not send — check your connection."

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ios/ADE/Views/Deeplinks/SendToMacCard.swift
   Line: 249-251

   Comment:
   **`error.localizedDescription` surfaced verbatim in UI**

   `SyncRemoteCommandDelivery.dropped` is constructed with `error.localizedDescription` from the network layer and displayed directly via `sendStatusMessage`. System framework errors (e.g. `NSURLErrorDomain`) can produce messages that are technically accurate but confusing in context. Consider mapping known error domains to user-friendly strings before passing them into the `.dropped` case, or capping the fallback at a generic "Could not send — check your connection."

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fios%2FADE%2FViews%2FDeeplinks%2FSendToMacCard.swift%0ALine%3A%20249-251%0A%0AComment%3A%0A**%60error.localizedDescription%60%20surfaced%20verbatim%20in%20UI**%0A%0A%60SyncRemoteCommandDelivery.dropped%60%20is%20constructed%20with%20%60error.localizedDescription%60%20from%20the%20network%20layer%20and%20displayed%20directly%20via%20%60sendStatusMessage%60.%20System%20framework%20errors%20%28e.g.%20%60NSURLErrorDomain%60%29%20can%20produce%20messages%20that%20are%20technically%20accurate%20but%20confusing%20in%20context.%20Consider%20mapping%20known%20error%20domains%20to%20user-friendly%20strings%20before%20passing%20them%20into%20the%20%60.dropped%60%20case%2C%20or%20capping%20the%20fallback%20at%20a%20generic%20%22Could%20not%20send%20%E2%80%94%20check%20your%20connection.%22%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=488&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fios%2FADE%2FViews%2FPRs%2FPrDetailScreen.swift%3A1049-1052%0ARedundant%20%60fetchGitHubFallbackItem%60%20call%20in%20the%20number-based%20error%20path.%20When%20%60requestedPrNumber%20!%3D%20nil%60%2C%20the%20first%20fetch%20at%20line%201030%20has%20already%20run%20%28and%20returned%20%60nil%60%29.%20The%20second%20fetch%20at%20line%201051%20passes%20the%20same%20%60requestedPrNumber%60%2C%20so%20it%20will%20issue%20an%20identical%20%60fetchGitHubPullRequestSnapshot%28%29%60%20network%20request%20and%20return%20%60nil%60%20again.%20Adding%20%60%26%26%20requestedPrNumber%20%3D%3D%20nil%60%20restricts%20the%20fallback%20fetch%20to%20the%20%60prId%60-based%20routing%20case%2C%20which%20is%20the%20only%20one%20that%20hasn't%20already%20attempted%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20pr%20%3D%3D%20nil%20%26%26%20shouldFetchLiveSidecars%20%7B%0A%20%20%20%20%20%20%20%20if%20fallbackGitHubItem%20%3D%3D%20nil%20%26%26%20requestedPrNumber%20%3D%3D%20nil%20%7B%0A%20%20%20%20%20%20%20%20%20%20fallbackGitHubItem%20%3D%20await%20fetchGitHubFallbackItem%28requestedPrNumber%3A%20requestedPrNumber%29%0A%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=488&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/ios/ADE/Views/PRs/PrDetailScreen.swift:1049-1052
Redundant `fetchGitHubFallbackItem` call in the number-based error path. When `requestedPrNumber != nil`, the first fetch at line 1030 has already run (and returned `nil`). The second fetch at line 1051 passes the same `requestedPrNumber`, so it will issue an identical `fetchGitHubPullRequestSnapshot()` network request and return `nil` again. Adding `&& requestedPrNumber == nil` restricts the fallback fetch to the `prId`-based routing case, which is the only one that hasn't already attempted it.

```suggestion
      if pr == nil && shouldFetchLiveSidecars {
        if fallbackGitHubItem == nil && requestedPrNumber == nil {
          fallbackGitHubItem = await fetchGitHubFallbackItem(requestedPrNumber: requestedPrNumber)
        }
```


`````

</details>

<sub>Reviews (5): Last reviewed commit: ["Address iOS PR review edge cases"](https://github.com/arul28/ade/commit/5f5604176877fd64e6c15195b58ab6ea77332f10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34779484)</sub>

<!-- /greptile_comment -->