### PR TITLE
ADE-78: Sync host security & lifecycle: spoofable hello (read-only/write auth), read-only RPC teardown, and dual host-election ownership

### DIFF
--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -11879,7 +11879,7 @@ async function runServe(
             };
           }
           try {
-            const scope = await scopeRegistry.ensureSyncHost(record.projectId);
+            const scope = await scopeRegistry.switchSyncHost(record.projectId);
             const syncService = scope?.runtime.syncService ?? null;
             if (!scope || !syncService) {
               return {
@@ -12026,13 +12026,14 @@ async function runServe(
   }
 
   if (syncEnabled) {
-    void scopeRegistry
-      .ensureSyncHost(preferredSyncProjectId ?? undefined)
-      .catch((error: unknown) => {
-        process.stderr.write(
-          `ade serve sync host failed: ${error instanceof Error ? error.message : String(error)}\n`,
-        );
-      });
+    const syncHostStartup = preferredSyncProjectId
+      ? scopeRegistry.switchSyncHost(preferredSyncProjectId)
+      : scopeRegistry.resolveActiveSyncHost();
+    void syncHostStartup.catch((error: unknown) => {
+      process.stderr.write(
+        `ade serve sync host failed: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+    });
   }
 
   process.stderr.write(

--- a/apps/ade-cli/src/multiProjectRpcServer.test.ts
+++ b/apps/ade-cli/src/multiProjectRpcServer.test.ts
@@ -40,6 +40,7 @@ function makeRuntime(label: string) {
     },
     syncService: {
       getStatus: vi.fn(async () => ({ role: "brain", label })),
+      listDevices: vi.fn(async () => [{ deviceId: `${label}-device` }]),
     },
     eventBuffer: createEventBuffer(),
     dispose: vi.fn(),
@@ -171,7 +172,7 @@ describe("multi-project RPC server", () => {
     handler.dispose();
   });
 
-  it("exposes runtime sync PIN methods through the selected sync host scope", async () => {
+  it("exposes runtime sync PIN methods through the active sync host scope", async () => {
     const { projectRoot, registry } = createRegistry();
     const added = registry.add(projectRoot);
     const syncService = {
@@ -188,7 +189,9 @@ describe("multi-project RPC server", () => {
     };
     const scopeRegistry = {
       get: vi.fn(),
-      ensureSyncHost: vi.fn(async () => ({
+      ensureSyncHost: vi.fn(),
+      switchSyncHost: vi.fn(),
+      resolveActiveSyncHost: vi.fn(async () => ({
         registryProjectId: added.projectId,
         record: added,
         runtime: { syncService },
@@ -259,13 +262,116 @@ describe("multi-project RPC server", () => {
       params: { projectId: added.projectId, laneIds: ["lane-1", 42, "lane-2"] },
     })).toBeNull();
 
-    expect(scopeRegistry.ensureSyncHost).toHaveBeenCalledWith(added.projectId);
+    expect(scopeRegistry.resolveActiveSyncHost).toHaveBeenCalled();
+    expect(scopeRegistry.switchSyncHost).not.toHaveBeenCalled();
     expect(syncService.setPin).toHaveBeenCalledWith("654321");
     expect(syncService.generatePin).toHaveBeenCalledTimes(1);
     expect(syncService.clearPin).toHaveBeenCalledTimes(1);
     expect(syncService.updateLocalDevice).toHaveBeenCalledWith({ name: "Mac Studio" });
     expect(syncService.forgetDevice).toHaveBeenCalledWith("phone-1");
     expect(syncService.setActiveLanePresence).toHaveBeenCalledWith(["lane-1", "lane-2"]);
+
+    handler.dispose();
+  });
+
+  it("does not switch the active sync host for read-only sync polls with a projectId", async () => {
+    const { root, projectRoot, registry } = createRegistry();
+    const active = registry.add(projectRoot);
+    const otherRoot = path.join(root, "other-project");
+    fs.mkdirSync(otherRoot, { recursive: true });
+    const other = registry.add(otherRoot);
+    const activeRuntime = makeRuntime("active");
+    const scopeRegistry = {
+      get: vi.fn(),
+      ensureSyncHost: vi.fn(),
+      switchSyncHost: vi.fn(),
+      resolveActiveSyncHost: vi.fn(async () => ({
+        registryProjectId: active.projectId,
+        record: active,
+        runtime: activeRuntime,
+        dispose: vi.fn(),
+      })),
+      dispose: vi.fn(),
+      disposeAll: vi.fn(),
+    } as unknown as ProjectScopeRegistry;
+    const handler = createMultiProjectRpcRequestHandler({
+      serverVersion: "test",
+      projectRegistry: registry,
+      scopeRegistry,
+    });
+
+    await handler({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "ade/initialize",
+      params: {},
+    });
+
+    expect(await handler({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "sync.getStatus",
+      params: { projectId: other.projectId },
+    })).toEqual({ role: "brain", label: "active" });
+
+    expect(await handler({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "sync.listDevices",
+      params: { projectId: other.projectId },
+    })).toEqual([{ deviceId: "active-device" }]);
+
+    expect(scopeRegistry.resolveActiveSyncHost).toHaveBeenCalledTimes(2);
+    expect(scopeRegistry.switchSyncHost).not.toHaveBeenCalled();
+    expect(scopeRegistry.ensureSyncHost).not.toHaveBeenCalled();
+
+    handler.dispose();
+  });
+
+  it("switches the active sync host only through the explicit switch RPC", async () => {
+    const { root, projectRoot, registry } = createRegistry();
+    const first = registry.add(projectRoot);
+    const secondRoot = path.join(root, "second-project");
+    fs.mkdirSync(secondRoot, { recursive: true });
+    const second = registry.add(secondRoot);
+    const secondRuntime = makeRuntime("second");
+    const scopeRegistry = {
+      get: vi.fn(),
+      ensureSyncHost: vi.fn(),
+      switchSyncHost: vi.fn(async () => ({
+        registryProjectId: second.projectId,
+        record: second,
+        runtime: secondRuntime,
+        dispose: vi.fn(),
+      })),
+      resolveActiveSyncHost: vi.fn(),
+      dispose: vi.fn(),
+      disposeAll: vi.fn(),
+    } as unknown as ProjectScopeRegistry;
+    const handler = createMultiProjectRpcRequestHandler({
+      serverVersion: "test",
+      projectRegistry: registry,
+      scopeRegistry,
+    });
+
+    await handler({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "ade/initialize",
+      params: {},
+    });
+
+    await expect(handler({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "sync.switchHost",
+      params: { projectId: second.projectId },
+    })).resolves.toEqual({ switched: true });
+
+    expect(scopeRegistry.switchSyncHost).toHaveBeenCalledWith(second.projectId);
+    expect(scopeRegistry.resolveActiveSyncHost).not.toHaveBeenCalled();
+    expect(scopeRegistry.ensureSyncHost).not.toHaveBeenCalled();
+    expect(first.projectId).not.toBe(second.projectId);
 
     handler.dispose();
   });
@@ -284,15 +390,14 @@ describe("multi-project RPC server", () => {
         runtime: getCount++ === 0 ? firstRuntime : secondRuntime,
         dispose: vi.fn(),
       })),
-      ensureSyncHost: vi.fn(async () => {
-        disposeListener?.(added.projectId);
-        return {
-          registryProjectId: added.projectId,
-          record: added,
-          runtime: secondRuntime,
-          dispose: vi.fn(),
-        };
-      }),
+      ensureSyncHost: vi.fn(),
+      switchSyncHost: vi.fn(),
+      resolveActiveSyncHost: vi.fn(async () => ({
+        registryProjectId: added.projectId,
+        record: added,
+        runtime: firstRuntime,
+        dispose: vi.fn(),
+      })),
       dispose: vi.fn(),
       disposeAll: vi.fn(),
       onDispose: vi.fn((listener: (projectId: string) => void) => {
@@ -327,12 +432,7 @@ describe("multi-project RPC server", () => {
     }) as { result: Array<{ id: string }> };
     expect(first.result[0]?.id).toBe("first-lane");
 
-    await handler({
-      jsonrpc: "2.0",
-      id: 3,
-      method: "sync.getStatus",
-      params: { projectId: added.projectId },
-    });
+    (disposeListener as ((projectId: string) => void) | null)?.(added.projectId);
 
     const second = await handler({
       jsonrpc: "2.0",

--- a/apps/ade-cli/src/multiProjectRpcServer.ts
+++ b/apps/ade-cli/src/multiProjectRpcServer.ts
@@ -72,6 +72,7 @@ const RUNTIME_METHODS = new Set([
   "projects.listMyGitHubRepos",
   "runtimeEvents.subscribe",
   "runtimeEvents.unsubscribe",
+  "sync.switchHost",
   "sync.getStatus",
   "sync.refreshDiscovery",
   "sync.listDevices",
@@ -365,14 +366,32 @@ export function createMultiProjectRpcRequestHandler(
     return { removed: true };
   };
 
-  const getSyncService = async (params: Record<string, unknown>) => {
-    const projectId = readProjectId(params);
-    const scope = await scopeRegistry.ensureSyncHost(projectId ?? undefined);
+  const getSyncService = async () => {
+    const scope = await scopeRegistry.resolveActiveSyncHost();
     const syncService = scope?.runtime.syncService ?? null;
     if (!syncService) {
       throw new JsonRpcError(
         JsonRpcErrorCode.invalidRequest,
         "Sync service is not available. Register a project first.",
+      );
+    }
+    return syncService;
+  };
+
+  const switchSyncService = async (params: Record<string, unknown>) => {
+    const projectId = readProjectId(params);
+    if (!projectId) {
+      throw new JsonRpcError(
+        JsonRpcErrorCode.invalidParams,
+        "sync.switchHost requires params.projectId.",
+      );
+    }
+    const scope = await scopeRegistry.switchSyncHost(projectId);
+    const syncService = scope?.runtime.syncService ?? null;
+    if (!syncService) {
+      throw new JsonRpcError(
+        JsonRpcErrorCode.invalidRequest,
+        "Sync service is not available for that project.",
       );
     }
     return syncService;
@@ -566,8 +585,13 @@ export function createMultiProjectRpcRequestHandler(
       return unsubscribeRuntimeEvents(params);
     }
 
+    if (method === "sync.switchHost") {
+      await switchSyncService(params);
+      return { switched: true };
+    }
+
     if (method === "sync.getStatus") {
-      const syncService = await getSyncService(params);
+      const syncService = await getSyncService();
       return await syncService.getStatus({
         includeTransferReadiness: params.includeTransferReadiness === true,
         forceTransferReadiness: params.forceTransferReadiness === true,
@@ -575,11 +599,11 @@ export function createMultiProjectRpcRequestHandler(
     }
 
     if (method === "sync.refreshDiscovery") {
-      return await (await getSyncService(params)).refreshDiscovery();
+      return await (await getSyncService()).refreshDiscovery();
     }
 
     if (method === "sync.listDevices") {
-      return await (await getSyncService(params)).listDevices();
+      return await (await getSyncService()).listDevices();
     }
 
     if (method === "sync.updateLocalDevice") {
@@ -589,7 +613,7 @@ export function createMultiProjectRpcRequestHandler(
           ? (params.deviceType as SyncPeerDeviceType)
           : undefined;
       return await (
-        await getSyncService(params)
+        await getSyncService()
       ).updateLocalDevice({
         ...(name !== undefined ? { name } : {}),
         ...(deviceType !== undefined ? { deviceType } : {}),
@@ -597,7 +621,7 @@ export function createMultiProjectRpcRequestHandler(
     }
 
     if (method === "sync.connectToBrain") {
-      const syncService = await getSyncService(params);
+      const syncService = await getSyncService();
       return await syncService.connectToBrain(
         omitProjectId(params) as Parameters<
           typeof syncService.connectToBrain
@@ -606,38 +630,38 @@ export function createMultiProjectRpcRequestHandler(
     }
 
     if (method === "sync.disconnectFromBrain") {
-      return await (await getSyncService(params)).disconnectFromBrain();
+      return await (await getSyncService()).disconnectFromBrain();
     }
 
     if (method === "sync.forgetDevice") {
       const deviceId =
         typeof params.deviceId === "string" ? params.deviceId : "";
-      return await (await getSyncService(params)).forgetDevice(deviceId);
+      return await (await getSyncService()).forgetDevice(deviceId);
     }
 
     if (method === "sync.getTransferReadiness") {
-      return await (await getSyncService(params)).getTransferReadiness();
+      return await (await getSyncService()).getTransferReadiness();
     }
 
     if (method === "sync.transferBrainToLocal") {
-      return await (await getSyncService(params)).transferBrainToLocal();
+      return await (await getSyncService()).transferBrainToLocal();
     }
 
     if (method === "sync.getPin") {
-      return { pin: (await getSyncService(params)).getPin() };
+      return { pin: (await getSyncService()).getPin() };
     }
 
     if (method === "sync.setPin") {
       const pin = typeof params.pin === "string" ? params.pin : "";
-      return await (await getSyncService(params)).setPin(pin);
+      return await (await getSyncService()).setPin(pin);
     }
 
     if (method === "sync.generatePin") {
-      return await (await getSyncService(params)).generatePin();
+      return await (await getSyncService()).generatePin();
     }
 
     if (method === "sync.clearPin") {
-      return await (await getSyncService(params)).clearPin();
+      return await (await getSyncService()).clearPin();
     }
 
     if (method === "sync.setActiveLanePresence") {
@@ -646,7 +670,7 @@ export function createMultiProjectRpcRequestHandler(
             (laneId): laneId is string => typeof laneId === "string",
           )
         : [];
-      await (await getSyncService(params)).setActiveLanePresence(laneIds);
+      await (await getSyncService()).setActiveLanePresence(laneIds);
       return null;
     }
 

--- a/apps/ade-cli/src/services/projects/projectScope.test.ts
+++ b/apps/ade-cli/src/services/projects/projectScope.test.ts
@@ -45,7 +45,7 @@ describe("ProjectScopeRegistry", () => {
     }));
   });
 
-  it("starts sync discovery only for the first opened daemon project scope", async () => {
+  it("does not elect a sync host while opening ordinary daemon project scopes", async () => {
     const { registry, first, second } = createRegistry();
     const scopeRegistry = new ProjectScopeRegistry(registry, {
       syncRuntime: {
@@ -68,8 +68,8 @@ describe("ProjectScopeRegistry", () => {
       projectRoot: first.rootPath,
       syncRuntime: {
         enabled: true,
-        hostStartupEnabled: true,
-        hostDiscoveryEnabled: true,
+        hostStartupEnabled: false,
+        hostDiscoveryEnabled: false,
         initializeInBackground: true,
         runtimeKind: "daemon",
       },

--- a/apps/ade-cli/src/services/projects/projectScope.ts
+++ b/apps/ade-cli/src/services/projects/projectScope.ts
@@ -58,7 +58,10 @@ export class ProjectScopeRegistry {
 
     const pending = (async () => {
       this.projectRegistry.touch(projectId);
-      const syncRuntime = this.buildSyncRuntimeOptions(projectId);
+      const syncRuntime = this.buildSyncRuntimeOptions(
+        projectId,
+        this.syncHostProjectId === projectId,
+      );
       const { createAdeRuntime } = await import("../../bootstrap");
       const runtime = await createAdeRuntime({
         projectRoot: record.rootPath,
@@ -106,25 +109,11 @@ export class ProjectScopeRegistry {
   }
 
   async ensureSyncHost(projectId?: ProjectId): Promise<ProjectScope | null> {
-    if (!this.options.syncRuntime?.enabled) return null;
-    if (projectId) {
-      const existingHostId = this.syncHostProjectId;
-      if (existingHostId && existingHostId !== projectId) {
-        await this.configureCachedSyncHost(existingHostId, false);
-      }
-      this.syncHostProjectId = projectId;
-      try {
-        const scope = await this.get(projectId);
-        await this.configureSyncHost(scope, true);
-        return scope;
-      } catch (error) {
-        if (this.syncHostProjectId === projectId) {
-          this.syncHostProjectId = null;
-        }
-        throw error;
-      }
-    }
+    return projectId ? this.switchSyncHost(projectId) : this.resolveActiveSyncHost();
+  }
 
+  async resolveActiveSyncHost(): Promise<ProjectScope | null> {
+    if (!this.options.syncRuntime?.enabled) return null;
     const existingHostId = this.syncHostProjectId;
     if (existingHostId) {
       try {
@@ -141,7 +130,26 @@ export class ProjectScopeRegistry {
         const openedDelta = right.lastOpenedAt - left.lastOpenedAt;
         return openedDelta !== 0 ? openedDelta : right.addedAt - left.addedAt;
       })[0];
-    return record ? this.ensureSyncHost(record.projectId) : null;
+    return record ? this.switchSyncHost(record.projectId) : null;
+  }
+
+  async switchSyncHost(projectId: ProjectId): Promise<ProjectScope | null> {
+    if (!this.options.syncRuntime?.enabled) return null;
+    const existingHostId = this.syncHostProjectId;
+    if (existingHostId && existingHostId !== projectId) {
+      await this.configureCachedSyncHost(existingHostId, false);
+    }
+    this.syncHostProjectId = projectId;
+    try {
+      const scope = await this.get(projectId);
+      await this.configureSyncHost(scope, true);
+      return scope;
+    } catch (error) {
+      if (this.syncHostProjectId === projectId) {
+        this.syncHostProjectId = null;
+      }
+      throw error;
+    }
   }
 
   private async configureCachedSyncHost(
@@ -165,13 +173,9 @@ export class ProjectScopeRegistry {
     if (enabled) await syncService.initialize();
   }
 
-  private buildSyncRuntimeOptions(projectId: ProjectId): AdeRuntimeSyncOptions | null {
+  private buildSyncRuntimeOptions(projectId: ProjectId, isHost: boolean): AdeRuntimeSyncOptions | null {
     const base = this.options.syncRuntime;
     if (!base?.enabled) return null;
-    const isHost = this.syncHostProjectId === null || this.syncHostProjectId === projectId;
-    if (isHost && this.syncHostProjectId === null) {
-      this.syncHostProjectId = projectId;
-    }
     return {
       ...base,
       enabled: true,

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -321,27 +321,6 @@ function publishedAnnouncements(): BonjourPublishArgs[] {
   return publishMock.mock.calls.map(([payload]) => payload as BonjourPublishArgs);
 }
 
-type NativeDiscoveryProcess = {
-  child: {
-    kill: ReturnType<typeof vi.fn>;
-    once: ReturnType<typeof vi.fn<[string, (...args: unknown[]) => void], NativeDiscoveryProcess["child"]>>;
-    unref: ReturnType<typeof vi.fn>;
-  };
-  handlers: Map<string, (...args: unknown[]) => void>;
-};
-
-function createNativeDiscoveryProcess(): NativeDiscoveryProcess {
-  const handlers = new Map<string, (...args: unknown[]) => void>();
-  const child = {} as NativeDiscoveryProcess["child"];
-  child.kill = vi.fn();
-  child.once = vi.fn<[string, (...args: unknown[]) => void], NativeDiscoveryProcess["child"]>((event, handler) => {
-    handlers.set(event, handler);
-    return child;
-  });
-  child.unref = vi.fn();
-  return { child, handlers };
-}
-
 function createHostArgs(projectRoot: string, projects: SyncMobileProjectSummary[]) {
   return {
     db: {
@@ -461,7 +440,7 @@ describe("createSyncHostService LAN discovery", () => {
     vi.restoreAllMocks();
   });
 
-  it("publishes headless runtime project metadata in Bonjour TXT records", async () => {
+  it("does not publish LAN Bonjour metadata when the sync host is loopback-bound", async () => {
     const { projectRoot, cleanup } = createTempProjectRoot();
     const projects = [
       createDiscoveryProject({ id: "project-1", displayName: "API, Server\nOne", rootPath: "/srv/api" }),
@@ -472,44 +451,18 @@ describe("createSyncHostService LAN discovery", () => {
     );
 
     try {
-      const port = await host.waitUntilListening();
-      await vi.waitFor(() => {
-        expect(publishedAnnouncements().some((announcement) => announcement.txt.projectCount === "2")).toBe(true);
-      });
-
-      const announcement = publishedAnnouncements()
-        .find((candidate) => candidate.txt.projectCount === "2");
-      expect(announcement).toBeDefined();
-      expect(announcement).toMatchObject({
-        name: `ADE Sync ADE Build Host ${port}`,
-        type: "ade-sync",
-        protocol: "tcp",
-        port,
-        disableIPv6: true,
-      });
-      expect(announcement?.txt).toEqual({
-        version: "1",
-        runtimeKind: "headless",
-        runtimeVersion: "2.0.0",
-        projects: "project-1,project-2",
-        projectNames: "API Server One,Worker",
-        projectCount: "2",
-        deviceId: "host-device-1",
-        siteId: "host-site-1",
-        deviceName: "ADE Build Host",
-        port: String(port),
-        host: "192.168.1.50",
-        addresses: "192.168.1.50,100.64.0.10",
-        tailscaleIp: "100.64.0.10",
-        tailscaleDnsName: "ade-build.tailnet.ts.net",
-      });
+      await host.waitUntilListening();
+      host.refreshLanDiscovery({ forceLan: true });
+      expect(publishedAnnouncements()).toEqual([]);
+      expect(bonjourConstructorMock).not.toHaveBeenCalled();
+      expect(spawnMock).not.toHaveBeenCalled();
     } finally {
       await host.dispose();
       cleanup();
     }
   });
 
-  it("forces a fresh LAN Bonjour announcement when discovery is explicitly refreshed", async () => {
+  it("keeps LAN discovery unpublished when discovery is explicitly refreshed", async () => {
     const { projectRoot, cleanup } = createTempProjectRoot();
     const publishedServices: Array<{ on: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> }> = [];
     publishMock.mockImplementation(() => {
@@ -525,31 +478,22 @@ describe("createSyncHostService LAN discovery", () => {
 
     try {
       await host.waitUntilListening();
-      await vi.waitFor(() => {
-        expect(publishedAnnouncements().some((announcement) => announcement.txt.projectCount === "1")).toBe(true);
-      });
-
-      const activeAnnouncement = publishedServices[publishedServices.length - 1];
       publishMock.mockClear();
 
       host.refreshLanDiscovery();
       expect(publishMock).not.toHaveBeenCalled();
-      expect(activeAnnouncement.stop).not.toHaveBeenCalled();
 
       host.refreshLanDiscovery({ forceLan: true });
 
-      expect(activeAnnouncement.stop).toHaveBeenCalledTimes(1);
-      await vi.waitFor(() => {
-        expect(publishMock).toHaveBeenCalledTimes(1);
-      });
-      expect(publishedAnnouncements()[0]?.txt.projectCount).toBe("1");
+      expect(publishMock).not.toHaveBeenCalled();
+      expect(publishedServices).toEqual([]);
     } finally {
       await host.dispose();
       cleanup();
     }
   });
 
-  it("publishes LAN discovery through native dns-sd when running under Electron on macOS", async () => {
+  it("does not publish native LAN discovery when running under Electron on macOS", async () => {
     Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
     Object.defineProperty(process.versions, "electron", {
       value: "35.0.0",
@@ -570,68 +514,11 @@ describe("createSyncHostService LAN discovery", () => {
 
     try {
       await host.waitUntilListening();
-      await vi.waitFor(() => {
-        expect(spawnMock.mock.calls.some(([, args]) => Array.isArray(args) && args.includes("projectCount=1"))).toBe(true);
-      });
 
       expect(bonjourConstructorMock).not.toHaveBeenCalled();
       expect(publishMock).not.toHaveBeenCalled();
-      const [, args] = spawnMock.mock.calls.find(([, candidateArgs]) =>
-        Array.isArray(candidateArgs) && candidateArgs.includes("projectCount=1")
-      )!;
-      const publishedPort = String(args[4]);
-      expect(args).toEqual(expect.arrayContaining([
-        "-R",
-        `ADE Sync ADE Build Host ${publishedPort}`,
-        "_ade-sync._tcp",
-        "local",
-        publishedPort,
-        "projects=project-1",
-        "projectNames=Project",
-        "addresses=192.168.1.50,100.64.0.10",
-      ]));
-      expect(nativeProcesses.at(-1)?.unref).toHaveBeenCalledTimes(1);
-    } finally {
-      await host.dispose();
-      cleanup();
-    }
-    expect(nativeProcesses.at(-1)?.kill).toHaveBeenCalledWith("SIGTERM");
-  });
-
-  it("falls back to Bonjour when the native dns-sd publisher exits", async () => {
-    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
-    Object.defineProperty(process.versions, "electron", {
-      value: "35.0.0",
-      configurable: true,
-    });
-    const { projectRoot, cleanup } = createTempProjectRoot();
-    const nativeProcesses: ReturnType<typeof createNativeDiscoveryProcess>[] = [];
-    spawnMock.mockImplementation(() => {
-      const nativeProcess = createNativeDiscoveryProcess();
-      nativeProcesses.push(nativeProcess);
-      return nativeProcess.child;
-    });
-    const host = createSyncHostService(
-      createHostArgs(projectRoot, [createDiscoveryProject({ id: "project-1" })]) as unknown as Parameters<
-        typeof createSyncHostService
-      >[0],
-    );
-
-    try {
-      await host.waitUntilListening();
-      await vi.waitFor(() => {
-        expect(spawnMock.mock.calls.some(([, args]) => Array.isArray(args) && args.includes("projectCount=1"))).toBe(true);
-      });
-
-      const nativeSpawnCount = spawnMock.mock.calls.length;
-      publishMock.mockClear();
-      nativeProcesses.at(-1)?.handlers.get("exit")?.(1, null);
-
-      await vi.waitFor(() => {
-        expect(publishMock).toHaveBeenCalledTimes(1);
-      }, { timeout: 2_000 });
-      expect(spawnMock).toHaveBeenCalledTimes(nativeSpawnCount);
-      expect(publishedAnnouncements()[0]?.txt.projectCount).toBe("1");
+      expect(spawnMock).not.toHaveBeenCalled();
+      expect(nativeProcesses).toEqual([]);
     } finally {
       await host.dispose();
       cleanup();

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import { createHash, randomBytes } from "node:crypto";
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import { Bonjour, type Service as BonjourService } from "bonjour-service";
 import { WebSocketServer, WebSocket, type RawData } from "ws";
 import { resolveAdeLayout } from "../../../../desktop/src/shared/adeLayout";
@@ -83,7 +83,7 @@ import type { createComputerUseArtifactBrokerService } from "../../../../desktop
 import type { AdeDb } from "../../../../desktop/src/main/services/state/kvDb";
 import { hasNullByte, normalizeRelative, nowIso, resolvePathWithinRoot, safeJsonParse, toOptionalString, uniqueStrings, writeTextAtomic } from "../../../../desktop/src/main/services/shared/utils";
 import type { DeviceRegistryService } from "./deviceRegistryService";
-import { createSyncPairingStore } from "./syncPairingStore";
+import { createSyncPairingStore, type SyncPairingRecord } from "./syncPairingStore";
 import type { NotificationEventBus } from "../../../../desktop/src/main/services/notifications/notificationEventBus";
 import type {
   ApnsEnvironment,
@@ -124,6 +124,7 @@ const SYNC_MDNS_SERVICE_TYPE = "ade-sync";
 const MAX_PROJECT_CATALOG_ENVELOPE_BYTES = 768 * 1024;
 const BONJOUR_PROJECT_TXT_ENTRY_LIMIT = 24;
 const BONJOUR_PROJECT_NAME_MAX_LENGTH = 48;
+const SYNC_HOST_BIND_HOST: string = "127.0.0.1";
 export const SYNC_TAILNET_DISCOVERY_SERVICE_NAME = "svc:ade-sync";
 export const SYNC_TAILNET_DISCOVERY_SERVICE_PORT = DEFAULT_SYNC_HOST_PORT;
 export type SyncRuntimeKind = "desktop-embedded" | "headless" | "remote-stdio" | "desktop" | "daemon" | "remote";
@@ -152,6 +153,7 @@ type PeerState = {
   authenticated: boolean;
   authKind: "bootstrap" | "paired" | null;
   pairedDeviceId: string | null;
+  pairingRecord: SyncPairingRecord | null;
   connectedAt: string;
   lastSeenAt: string;
   lastAppliedAt: string | null;
@@ -635,6 +637,20 @@ function parseHelloPayload(payload: unknown): SyncHelloPayload | null {
   };
 }
 
+function safeStringEquals(expected: string, actual: string): boolean {
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  const actualBuffer = Buffer.from(actual, "utf8");
+  if (expectedBuffer.length !== actualBuffer.length) {
+    timingSafeEqual(expectedBuffer, Buffer.alloc(expectedBuffer.length));
+    return false;
+  }
+  return timingSafeEqual(expectedBuffer, actualBuffer);
+}
+
+function isMobilePairingRecord(record: SyncPairingRecord | null): boolean {
+  return record?.peerPlatform === "iOS" || record?.peerDeviceType === "phone";
+}
+
 function parsePairingRequestPayload(payload: unknown): SyncPairingRequestPayload | null {
   const value = payload as SyncPairingRequestPayload | null;
   const code = toOptionalString(value?.code);
@@ -924,46 +940,62 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
   const PAIR_FAILURE_THRESHOLD = 5;
   const PAIR_COOLDOWN_MS = 10 * 60_000;
   const PAIR_FAILURE_WINDOW_MS = 10 * 60_000;
-  const pairFailures = new Map<string, { count: number; cooldownUntilMs: number; updatedAtMs: number }>();
+  type PairFailureEntry = { count: number; cooldownUntilMs: number; updatedAtMs: number };
+  const pairFailures = new Map<string, PairFailureEntry>();
+  const globalPairFailures: PairFailureEntry = { count: 0, cooldownUntilMs: 0, updatedAtMs: 0 };
+  const resetPairFailureEntry = (entry: PairFailureEntry): void => {
+    entry.count = 0;
+    entry.cooldownUntilMs = 0;
+    entry.updatedAtMs = 0;
+  };
+  const isPairFailureEntryExpired = (entry: PairFailureEntry, now: number): boolean => {
+    if (entry.updatedAtMs <= 0) return false;
+    return (entry.cooldownUntilMs > 0 && entry.cooldownUntilMs <= now)
+      || entry.updatedAtMs + PAIR_FAILURE_WINDOW_MS <= now;
+  };
   const pruneExpiredPairFailures = (now = Date.now()): boolean => {
     let changed = false;
     for (const [ip, entry] of pairFailures) {
-      const cooldownExpired = entry.cooldownUntilMs > 0 && entry.cooldownUntilMs <= now;
-      const failureWindowExpired = entry.updatedAtMs + PAIR_FAILURE_WINDOW_MS <= now;
-      if (cooldownExpired || failureWindowExpired) {
+      if (isPairFailureEntryExpired(entry, now)) {
         pairFailures.delete(ip);
         changed = true;
       }
     }
+    if (isPairFailureEntryExpired(globalPairFailures, now)) {
+      resetPairFailureEntry(globalPairFailures);
+      changed = true;
+    }
     return changed;
   };
-  const registerPairFailure = (ip: string | null): void => {
-    if (!ip) return;
-    const now = Date.now();
-    pruneExpiredPairFailures(now);
-    const entry = pairFailures.get(ip) ?? { count: 0, cooldownUntilMs: 0, updatedAtMs: now };
+  const incrementPairFailureEntry = (entry: PairFailureEntry, now: number): void => {
     entry.count += 1;
     entry.updatedAtMs = now;
     if (entry.count >= PAIR_FAILURE_THRESHOLD) {
       entry.cooldownUntilMs = now + PAIR_COOLDOWN_MS;
       entry.count = 0;
     }
-    pairFailures.set(ip, entry);
+  };
+  const registerPairFailure = (ip: string | null): void => {
+    const now = Date.now();
+    pruneExpiredPairFailures(now);
+    incrementPairFailureEntry(globalPairFailures, now);
+    if (ip) {
+      const entry = pairFailures.get(ip) ?? { count: 0, cooldownUntilMs: 0, updatedAtMs: now };
+      incrementPairFailureEntry(entry, now);
+      pairFailures.set(ip, entry);
+    }
   };
   const pairingCooldownMsRemaining = (ip: string | null): number => {
-    if (!ip) return 0;
-    const entry = pairFailures.get(ip);
-    if (!entry) return 0;
     const now = Date.now();
-    const remaining = entry.cooldownUntilMs - now;
-    if (remaining > 0) return remaining;
-    if (
-      (entry.cooldownUntilMs > 0 && remaining <= 0)
-      || entry.updatedAtMs + PAIR_FAILURE_WINDOW_MS <= now
-    ) {
-      pairFailures.delete(ip);
-    }
-    return 0;
+    pruneExpiredPairFailures(now);
+    const globalRemaining = Math.max(0, globalPairFailures.cooldownUntilMs - now);
+    const ipEntry = ip ? pairFailures.get(ip) ?? null : null;
+    const ipRemaining = ipEntry ? Math.max(0, ipEntry.cooldownUntilMs - now) : 0;
+    return Math.max(globalRemaining, ipRemaining);
+  };
+  const clearPairFailuresAfterSuccessfulPair = (ip: string | null): void => {
+    resetPairFailureEntry(globalPairFailures);
+    if (ip) pairFailures.delete(ip);
   };
 
   const normalizeLaneId = (laneId: string | null | undefined): string | null => {
@@ -1172,7 +1204,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     }
   };
   const server = new WebSocketServer({
-    host: "0.0.0.0",
+    host: SYNC_HOST_BIND_HOST,
     port: args.port ?? DEFAULT_SYNC_HOST_PORT,
     maxPayload: 25 * 1024 * 1024,
   });
@@ -1296,6 +1328,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       authenticated: false,
       authKind: null,
       pairedDeviceId: null,
+      pairingRecord: null,
       connectedAt: nowIso(),
       lastSeenAt: nowIso(),
       lastAppliedAt: null,
@@ -1424,6 +1457,10 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
 
   const publishLanDiscovery = (port: number, options?: { force?: boolean }): void => {
     if (disposed) return;
+    if (SYNC_HOST_BIND_HOST !== "0.0.0.0" && SYNC_HOST_BIND_HOST !== "::") {
+      unpublishLanDiscovery();
+      return;
+    }
     if (!discoveryEnabled) {
       unpublishLanDiscovery();
       return;
@@ -1799,6 +1836,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       peer.metadata = null;
       peer.authKind = null;
       peer.pairedDeviceId = null;
+      peer.pairingRecord = null;
       try {
         peer.ws.close(4000, "Superseded by a newer connection for this device");
       } catch {
@@ -2262,28 +2300,37 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
   }
 
   function isMobilePeer(peer: PeerState): boolean {
+    if (peer.authKind === "paired") {
+      return isMobilePairingRecord(peer.pairingRecord);
+    }
     return peer.metadata?.platform === "iOS" || peer.metadata?.deviceType === "phone";
   }
 
-  function assertMobileFileMutationAllowed(peer: PeerState, payload: SyncFileRequest): void {
-    if (!MOBILE_MUTATING_FILE_ACTIONS.has(payload.action)) return;
-    if (!isMobilePeer(peer)) return;
+  function workspaceForId(workspaceId: string | null): FilesWorkspace | null {
+    if (!workspaceId) return null;
+    return args.fileService.listWorkspaces({ includeArchived: true })
+      .find((entry) => entry.id === workspaceId) ?? null;
+  }
 
-    const workspaceId = toOptionalString((payload as { args?: { workspaceId?: unknown } }).args?.workspaceId);
-    if (!workspaceId) return;
-    const workspace = args.fileService.listWorkspaces({ includeArchived: true })
-      .find((entry) => entry.id === workspaceId);
+  function assertWriteAllowed(peer: PeerState, workspace: FilesWorkspace | null): void {
+    if (!isMobilePeer(peer)) return;
     if (!workspace || workspace.mobileReadOnly === true || workspace.isReadOnlyByDefault) {
       throw new Error("Mobile file access is read-only for this workspace.");
     }
   }
 
-  function isMobileLaneFileMutationBlocked(payload: SyncCommandPayload): boolean {
+  function assertFileMutationAllowed(peer: PeerState, payload: SyncFileRequest): void {
+    if (!MOBILE_MUTATING_FILE_ACTIONS.has(payload.action)) return;
+    const workspaceId = toOptionalString((payload as { args?: { workspaceId?: unknown } }).args?.workspaceId);
+    assertWriteAllowed(peer, workspaceForId(workspaceId));
+  }
+
+  function assertLaneFileMutationAllowed(peer: PeerState, payload: SyncCommandPayload): void {
     const laneId = toOptionalString((payload.args as Record<string, unknown> | null | undefined)?.laneId);
-    if (!laneId) return false;
+    if (!laneId) return;
     const workspace = args.fileService.listWorkspaces({ includeArchived: true })
-      .find((entry) => entry.laneId === laneId);
-    return workspace ? workspace.mobileReadOnly === true || workspace.isReadOnlyByDefault : true;
+      .find((entry) => entry.laneId === laneId) ?? null;
+    assertWriteAllowed(peer, workspace);
   }
 
   async function handleFileRequest(peer: PeerState, requestId: string | null, payload: SyncFileRequest): Promise<void> {
@@ -2292,7 +2339,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     };
 
     try {
-      assertMobileFileMutationAllowed(peer, payload);
+      assertFileMutationAllowed(peer, payload);
       let result:
         | FilesWorkspace[]
         | FileTreeNode[]
@@ -2560,9 +2607,13 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       reject(`Remote command ${payload.action} is not available to paired controller devices.`, "forbidden_command");
       return;
     }
-    if (payload.action === "files.writeTextAtomic" && isMobilePeer(peer) && isMobileLaneFileMutationBlocked(payload)) {
-      reject("Mobile file access is read-only for this workspace.", "mobile_read_only");
-      return;
+    if (payload.action === "files.writeTextAtomic") {
+      try {
+        assertLaneFileMutationAllowed(peer, payload);
+      } catch (error) {
+        reject(error instanceof Error ? error.message : String(error), "mobile_read_only");
+        return;
+      }
     }
     if (policy.localOnly || policy.requiresApproval) {
       reject(`Remote command ${payload.action} requires approval on this machine.`, "approval_required");
@@ -2693,9 +2744,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         }
         try {
           const result = pairingStore.pairPeer(pairing.peer, pairing.code);
-          if (peer.remoteAddress) {
-            pairFailures.delete(peer.remoteAddress);
-          }
+          clearPairFailuresAfterSuccessfulPair(peer.remoteAddress);
           args.deviceRegistryService?.upsertPeerMetadata(pairing.peer, {
             lastSeenAt: nowIso(),
             lastHost: peer.remoteAddress,
@@ -2743,13 +2792,17 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         }
         return;
       }
+      let authenticatedPairingRecord: SyncPairingRecord | null = null;
       const authFailed = (() => {
         if (hello.auth?.kind === "bootstrap") {
-          return hello.auth.token !== bootstrapToken;
+          if (!safeStringEquals(bootstrapToken, hello.auth.token)) return true;
+          return pairingStore.hasPairingRecord(hello.peer.deviceId);
         }
         if (hello.auth?.kind === "paired") {
           if (hello.auth.deviceId !== hello.peer.deviceId) return true;
-          return !pairingStore.authenticate(hello.auth.deviceId, hello.auth.secret);
+          if (!pairingStore.authenticate(hello.auth.deviceId, hello.auth.secret)) return true;
+          authenticatedPairingRecord = pairingStore.getPairingRecord(hello.auth.deviceId);
+          return !authenticatedPairingRecord;
         }
         return true;
       })();
@@ -2772,6 +2825,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       const auth = hello.auth ?? { kind: "bootstrap", token: "" };
       peer.authKind = auth.kind;
       peer.pairedDeviceId = auth.kind === "paired" ? auth.deviceId : null;
+      peer.pairingRecord = auth.kind === "paired" ? authenticatedPairingRecord : null;
       peer.lastKnownServerDbVersion = Math.max(0, Math.floor(hello.peer.dbVersion));
       args.deviceRegistryService?.upsertPeerMetadata(hello.peer, {
         lastSeenAt: nowIso(),
@@ -3277,6 +3331,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         peer.metadata = null;
         peer.authKind = null;
         peer.pairedDeviceId = null;
+        peer.pairingRecord = null;
         try {
           peer.ws.close(4003, "Pairing revoked");
         } catch {

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -1457,6 +1457,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
 
   const publishLanDiscovery = (port: number, options?: { force?: boolean }): void => {
     if (disposed) return;
+    // Loopback-bound hosts are intentionally not advertised on the LAN; remote reachability is handled by explicit/tailnet paths.
     if (SYNC_HOST_BIND_HOST !== "0.0.0.0" && SYNC_HOST_BIND_HOST !== "::") {
       unpublishLanDiscovery();
       return;

--- a/apps/ade-cli/src/services/sync/syncPairingStore.ts
+++ b/apps/ade-cli/src/services/sync/syncPairingStore.ts
@@ -5,7 +5,7 @@ import type { SyncPeerMetadata } from "../../../../desktop/src/shared/types";
 import { nowIso, safeJsonParse, writeTextAtomic } from "../../../../desktop/src/main/services/shared/utils";
 import type { SyncPinStore } from "./syncPinStore";
 
-type PairingRecord = {
+export type SyncPairingRecord = {
   secretHash: string;
   createdAt: string;
   lastUsedAt: string | null;
@@ -14,7 +14,7 @@ type PairingRecord = {
   peerDeviceType: string;
 };
 
-type PairingSecretsFile = Record<string, PairingRecord>;
+type PairingSecretsFile = Record<string, SyncPairingRecord>;
 
 type SyncPairingStoreArgs = {
   filePath: string;
@@ -94,6 +94,18 @@ export function createSyncPairingStore(args: SyncPairingStoreArgs) {
       entry.lastUsedAt = nowIso();
       writeRecords(records);
       return true;
+    },
+
+    getPairingRecord(deviceId: string): SyncPairingRecord | null {
+      const normalized = deviceId.trim();
+      if (!normalized) return null;
+      return readRecords()[normalized] ?? null;
+    },
+
+    hasPairingRecord(deviceId: string): boolean {
+      const normalized = deviceId.trim();
+      if (!normalized) return false;
+      return readRecords()[normalized] != null;
     },
 
     revoke(deviceId: string): void {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1400,7 +1400,10 @@ app.whenReady().then(async () => {
         persistRecentProject(ctx.project, { recordLastProject: false, preserveRecentOrder: true });
       }
       if (!shouldUseInProcessProjectRuntime()) {
-        void localRuntimePool.ensureProject(normalizedRoot).catch((error) => {
+        const projectRegistration = (options.foreground ?? true)
+          ? localRuntimePool.switchSyncHostForRoot(normalizedRoot)
+          : localRuntimePool.ensureProject(normalizedRoot);
+        void projectRegistration.catch((error) => {
           localRuntimeLogger.warn("local_runtime.project_registration_failed", {
             rootPath: normalizedRoot,
             error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts
@@ -1610,6 +1610,36 @@ describe("local runtime connection pool", () => {
     });
   });
 
+  it("switches the active local runtime sync host explicitly for a project root", async () => {
+    const call = vi.fn().mockResolvedValue({ switched: true });
+    const pool = new LocalRuntimeConnectionPool("1.2.3", {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as never);
+    const rootPath = path.resolve("/repo");
+    (pool as unknown as { projectsByRoot: Map<string, unknown> }).projectsByRoot.set(rootPath, {
+      projectId: "project-1",
+      rootPath,
+      displayName: "repo",
+      addedAt: 1,
+      lastOpenedAt: 1,
+      gitOriginUrl: null,
+    });
+    (pool as unknown as { connection: Promise<unknown> }).connection = Promise.resolve({
+      client: { call, isClosed: () => false },
+      child: null,
+      socketPath: "/tmp/ade.sock",
+    });
+
+    await pool.switchSyncHostForRoot(rootPath);
+
+    expect(call).toHaveBeenCalledWith("sync.switchHost", {
+      projectId: "project-1",
+    });
+  });
+
   it("subscribes to local runtime event notifications", async () => {
     const notificationListeners = new Map<string, Set<(params: unknown) => void>>();
     const call = vi.fn(async (method: string) => {

--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
@@ -986,6 +986,12 @@ export class LocalRuntimeConnectionPool {
     }) as T;
   }
 
+  async switchSyncHostForRoot(rootPath: string): Promise<void> {
+    const project = await this.ensureProject(rootPath);
+    const entry = await this.connect();
+    await entry.client.call("sync.switchHost", { projectId: project.projectId });
+  }
+
   dispose(): void {
     const pending = this.connection;
     this.connection = null;

--- a/apps/desktop/src/main/services/sync/syncHostService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncHostService.test.ts
@@ -631,13 +631,14 @@ describe.skipIf(!isCrsqliteAvailable())("syncHostService", () => {
     const blocker = net.createServer();
     await new Promise<void>((resolve, reject) => {
       blocker.once("error", reject);
-      blocker.listen(0, () => resolve());
+      blocker.listen(0, "127.0.0.1", () => resolve());
     });
     const blockedPort = (blocker.address() as net.AddressInfo).port;
 
     const host = createSyncHostService({
       db,
       logger: createLogger() as any,
+      projectId: "project-1",
       projectRoot,
       port: blockedPort,
       pinStore: createStubPinStore(),
@@ -2190,15 +2191,17 @@ describe.skipIf(!isCrsqliteAvailable())("syncHostService", () => {
     expect(chatService.service.deleteSession).toHaveBeenCalledWith({ sessionId: "session-1" });
   }, 15_000);
 
-  it("pairs a phone peer using the desktop PIN and allows paired reconnect auth", async () => {
+  it("pairs a phone peer and keeps paired reconnects read-only even if hello metadata is spoofed", async () => {
     const brainDb = await openKvDb(makeDbPath("ade-sync-pairing-"), createLogger() as any);
     const projectRoot = makeProjectRoot("ade-sync-pairing-project-");
     const workspaceRoot = path.join(projectRoot, "workspace");
     fs.mkdirSync(workspaceRoot, { recursive: true });
+    fs.writeFileSync(path.join(workspaceRoot, "notes.txt"), "original", "utf8");
 
     const host = createSyncHostService({
       db: brainDb,
       logger: createLogger() as any,
+      projectId: "project-1",
       projectRoot,
       port: 0,
       pinStore: createStubPinStore("428193"),
@@ -2269,6 +2272,34 @@ describe.skipIf(!isCrsqliteAvailable())("syncHostService", () => {
     pairWs.close();
     await new Promise((resolve) => pairWs.once("close", resolve));
 
+    const bootstrapSpoofWs = new WebSocket(`ws://127.0.0.1:${port}`);
+    await new Promise<void>((resolve, reject) => {
+      bootstrapSpoofWs.once("open", () => resolve());
+      bootstrapSpoofWs.once("error", reject);
+    });
+    const bootstrapSpoofQueue = createMessageQueue(bootstrapSpoofWs);
+    bootstrapSpoofWs.send(encodeSyncEnvelope({
+      type: "hello",
+      requestId: "hello-bootstrap-spoof",
+      payload: {
+        token: host.getBootstrapToken(),
+        peer: {
+          deviceId: "ios-phone-1",
+          deviceName: "Spoofed Mac",
+          platform: "macOS",
+          deviceType: "desktop",
+          siteId: "spoofed-mac-site",
+          dbVersion: 0,
+        },
+      },
+    }));
+    const bootstrapSpoofError = await bootstrapSpoofQueue.next("hello_error");
+    expect((bootstrapSpoofError.payload as { code: string }).code).toBe("auth_failed");
+    if (bootstrapSpoofWs.readyState !== WebSocket.CLOSED) {
+      bootstrapSpoofWs.close();
+      await new Promise((resolve) => bootstrapSpoofWs.once("close", resolve));
+    }
+
     const authWs = new WebSocket(`ws://127.0.0.1:${port}`);
     await new Promise<void>((resolve, reject) => {
       authWs.once("open", () => resolve());
@@ -2281,9 +2312,9 @@ describe.skipIf(!isCrsqliteAvailable())("syncHostService", () => {
       payload: {
         peer: {
           deviceId: "ios-phone-1",
-          deviceName: "Arul iPhone",
-          platform: "iOS",
-          deviceType: "phone",
+          deviceName: "Spoofed Mac",
+          platform: "macOS",
+          deviceType: "desktop",
           siteId: "ios-site-1",
           dbVersion: 0,
         },
@@ -2339,6 +2370,24 @@ describe.skipIf(!isCrsqliteAvailable())("syncHostService", () => {
       ]),
     );
     expect(host.getPeerStates().map((peer) => peer.deviceId)).toContain("ios-phone-1");
+
+    authWs.send(encodeSyncEnvelope({
+      type: "file_request",
+      requestId: "paired-spoofed-write",
+      payload: {
+        action: "writeText",
+        args: {
+          workspaceId: "workspace-1",
+          path: "notes.txt",
+          text: "spoofed update",
+        },
+      },
+    }));
+    const spoofedWriteResponse = await authQueue.next("file_response");
+    const spoofedWritePayload = spoofedWriteResponse.payload as { ok: boolean; error?: { message: string } };
+    expect(spoofedWritePayload.ok).toBe(false);
+    expect(spoofedWritePayload.error?.message).toMatch(/read-only/i);
+    expect(fs.readFileSync(path.join(workspaceRoot, "notes.txt"), "utf8")).toBe("original");
 
     host.revokePairedDevice("ios-phone-1");
     if (authWs.readyState !== WebSocket.CLOSED) {

--- a/apps/desktop/src/main/services/sync/syncPairingStore.test.ts
+++ b/apps/desktop/src/main/services/sync/syncPairingStore.test.ts
@@ -149,6 +149,21 @@ describe("syncPairingStore", () => {
       expect(typeof after[deviceId].lastUsedAt).toBe("string");
       expect(after[deviceId].lastUsedAt.length).toBeGreaterThan(0);
     });
+
+    it("returns stored pairing metadata for authorization decisions", () => {
+      const { store, pinStore } = makeHarness("ade-pairing-auth-record-");
+      pinStore.setPin("101010");
+      const { deviceId, secret } = store.pairPeer(samplePeer, "101010");
+
+      expect(store.authenticate(deviceId, secret)).toBe(true);
+      expect(store.getPairingRecord(deviceId)).toMatchObject({
+        peerName: samplePeer.deviceName,
+        peerPlatform: "iOS",
+        peerDeviceType: "phone",
+      });
+      expect(store.hasPairingRecord(deviceId)).toBe(true);
+      expect(store.getPairingRecord("missing")).toBeNull();
+    });
   });
 
   describe("revoke", () => {


### PR DESCRIPTION
Fixes ADE-78

## Summary

- Derive paired mobile read-only enforcement from the stored pairing record instead of spoofable hello metadata.
- Gate file mutations through shared write authorization for both `file_request` and command RPC paths.
- Harden bootstrap auth by rejecting paired-device ID reuse, using timing-safe token comparison, binding the sync WebSocket to loopback, suppressing LAN discovery on loopback, and adding a global pairing-attempt ceiling.
- Split sync host election into passive active-host resolution and explicit host switching, including a foreground desktop switch path and read-only sync polls that do not move the host.

## Validation

- Verified the issue still applied on `origin/main`/this lane before edits.
- Ran `/audit` style source-command audit across the touched auth, file mutation, host election, and RPC paths.
- `npm --prefix apps/ade-cli run test -- src/services/projects/projectScope.test.ts src/multiProjectRpcServer.test.ts src/services/sync/syncHostService.test.ts`
- `npm --prefix apps/desktop run test -- src/main/services/sync/syncPairingStore.test.ts src/main/services/sync/syncHostService.test.ts src/main/services/localRuntime/localRuntimeConnectionPool.test.ts`
- `npm --prefix apps/ade-cli run typecheck`
- `npm --prefix apps/desktop run typecheck`
- `npm --prefix apps/ade-cli run build`
- `npm --prefix apps/desktop run build`
- `npm --prefix apps/desktop run lint` exited 0 with the repo's existing warning backlog.
- `git diff --check`

## Notes

Per the lane instruction, I did not run the full desktop sharded test suite locally because this machine has many parallel agents; CI should cover the broader matrix.

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-78: Sync host security & lifecycle: spoofable hello (read-only/write auth), read-only RPC teardown, and dual host-election ownership](https://linear.app/ade-linear/issue/ADE-78/sync-host-security-and-lifecycle-spoofable-hello-read-onlywrite-auth) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-78-sync-host-security-lifecycle-spoofable-hello-read-only-write-auth-read-only-rpc-teardown-and-dual-host-election-ownership num=489 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-78-sync-host-security-lifecycle-spoofable-hello-read-only-write-auth-read-only-rpc-teardown-and-dual-host-election-ownership&amp;pr=489">ade-78-sync-host-security-lifecycle-spoofable-hello-read-only-write-auth-read-only-rpc-teardown-and-dual-host-election-ownership branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=489">PR #489</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the sync host's security and lifecycle by fixing a spoofable-hello vulnerability, consolidating write authorization, binding the WebSocket server to loopback, and splitting host election into passive resolution and explicit switching.

- **Auth hardening**: Bootstrap auth now rejects paired-device ID reuse; `safeStringEquals` (timing-safe) replaces plain equality; a new global pairing-attempt ceiling (`globalPairFailures`) supplements the per-IP rate limiter; the WebSocket server binds to `127.0.0.1` only and LAN discovery is suppressed on loopback hosts.
- **Mobile identity fix**: `isMobilePeer` now derives identity from the stored `SyncPairingRecord` for paired peers, not from spoofable hello metadata.
- **Host-election split**: `ensureSyncHost` is decomposed into `resolveActiveSyncHost` (passive) and `switchSyncHost` (explicit).

<h3>Confidence Score: 5/5</h3>

Safe to merge. The security fixes are well-scoped, all changed paths are covered by integration tests, and no regressions were found.

The three main changes are all correctly implemented. Tests cover the spoofed-hello reconnect path, bootstrap ID-reuse rejection, loopback-only LAN suppression, and the explicit host-switch RPC endpoint.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/services/sync/syncHostService.ts | Core auth hardening: loopback binding, timing-safe token comparison, bootstrap ID-reuse rejection, global rate limiting, and pairing-record-backed mobile identity. |
| apps/ade-cli/src/services/projects/projectScope.ts | Splits ensureSyncHost into resolveActiveSyncHost and switchSyncHost. buildSyncRuntimeOptions no longer implicitly elects the first project as host. |
| apps/ade-cli/src/multiProjectRpcServer.ts | Adds sync.switchHost RPC endpoint; all other sync methods now call resolveActiveSyncHost(). |
| apps/ade-cli/src/services/sync/syncPairingStore.ts | Exports SyncPairingRecord type and adds getPairingRecord/hasPairingRecord methods. |
| apps/desktop/src/main/main.ts | Foreground project opens now call switchSyncHostForRoot; background opens fall back to ensureProject only. |
| apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts | Adds switchSyncHostForRoot: registers project, connects, then issues sync.switchHost RPC. |
| apps/desktop/src/main/services/sync/syncHostService.test.ts | Adds assertions that bootstrap reuse is rejected and that a spoofed-desktop paired mobile peer still has file writes blocked. |
| apps/ade-cli/src/cli.ts | Startup path now calls switchSyncHost when a preferredSyncProjectId is configured, and resolveActiveSyncHost otherwise. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/ade-cli/src/services/sync/syncHostService.ts`, line 731-743 ([link](https://github.com/arul28/ade/blob/fcf77ba85b073a1c36f2a23eb32ddd9f4f874a6f/apps/ade-cli/src/services/sync/syncHostService.ts#L731-L743)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Bootstrap auth timing oracle after correct token**

   `safeStringEquals` runs in constant time, but when it succeeds the code immediately calls `pairingStore.hasPairingRecord`, which performs a file-system read (`readRecords()`). That I/O is only executed on the correct-token path, so an attacker with localhost access can distinguish a wrong-token response (~microseconds) from a correct-token-but-already-paired response (~milliseconds of disk I/O). Over a loopback socket this difference is large enough to be statistically reliable, and it lets a local attacker confirm a token guess before the `hello_error` response arrives.

   Consider reading the pairing record unconditionally (or using a dummy read for the wrong-token path) so the I/O overhead is present on all code paths.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ade-cli/src/services/sync/syncHostService.ts
   Line: 731-743

   Comment:
   **Bootstrap auth timing oracle after correct token**

   `safeStringEquals` runs in constant time, but when it succeeds the code immediately calls `pairingStore.hasPairingRecord`, which performs a file-system read (`readRecords()`). That I/O is only executed on the correct-token path, so an attacker with localhost access can distinguish a wrong-token response (~microseconds) from a correct-token-but-already-paired response (~milliseconds of disk I/O). Over a loopback socket this difference is large enough to be statistically reliable, and it lets a local attacker confirm a token guess before the `hello_error` response arrives.

   Consider reading the pairing record unconditionally (or using a dummy read for the wrong-token path) so the I/O overhead is present on all code paths.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fade-cli%2Fsrc%2Fservices%2Fsync%2FsyncHostService.ts%0ALine%3A%20731-743%0A%0AComment%3A%0A**Bootstrap%20auth%20timing%20oracle%20after%20correct%20token**%0A%0A%60safeStringEquals%60%20runs%20in%20constant%20time%2C%20but%20when%20it%20succeeds%20the%20code%20immediately%20calls%20%60pairingStore.hasPairingRecord%60%2C%20which%20performs%20a%20file-system%20read%20%28%60readRecords%28%29%60%29.%20That%20I%2FO%20is%20only%20executed%20on%20the%20correct-token%20path%2C%20so%20an%20attacker%20with%20localhost%20access%20can%20distinguish%20a%20wrong-token%20response%20%28~microseconds%29%20from%20a%20correct-token-but-already-paired%20response%20%28~milliseconds%20of%20disk%20I%2FO%29.%20Over%20a%20loopback%20socket%20this%20difference%20is%20large%20enough%20to%20be%20statistically%20reliable%2C%20and%20it%20lets%20a%20local%20attacker%20confirm%20a%20token%20guess%20before%20the%20%60hello_error%60%20response%20arrives.%0A%0AConsider%20reading%20the%20pairing%20record%20unconditionally%20%28or%20using%20a%20dummy%20read%20for%20the%20wrong-token%20path%29%20so%20the%20I%2FO%20overhead%20is%20present%20on%20all%20code%20paths.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=489&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["Address sync host review note"](https://github.com/arul28/ade/commit/7aa77a707649ca58a3a0f1f9fed0028ab5733d1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34779538)</sub>

<!-- /greptile_comment -->