### PR TITLE
ADE-90: Desktop/CLI security hardening: production renderer CSP, OS-bind the credential-store key, chmod the built-in-browser bridge socket

### DIFF
--- a/apps/ade-cli/src/services/credentials/credentialStore.test.ts
+++ b/apps/ade-cli/src/services/credentials/credentialStore.test.ts
@@ -41,6 +41,47 @@ describe("EncryptedFileCredentialStore", () => {
     expect(await store.get("agent.token")).toBeNull();
     expect(fs.existsSync(path.join(tempDir, ".machine-key"))).toBe(true);
   });
+
+  it("derives file encryption from OS-bound key material when available", async () => {
+    const osMaterial = Buffer.from("test-os-material");
+    const store = new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterialProvider: () => osMaterial,
+    });
+
+    store.setSync("linear.token.v1", "lin_secret");
+
+    const reloaded = new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterialProvider: () => osMaterial,
+    });
+    expect(reloaded.getSync("linear.token.v1")).toBe("lin_secret");
+
+    const unbound = new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterialProvider: () => null,
+    });
+    expect(() => unbound.getSync("linear.token.v1")).toThrow();
+  });
+
+  it("can read legacy machine-key ciphertext before rewriting with OS-bound key material", async () => {
+    const legacy = new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterialProvider: () => null,
+    });
+    legacy.setSync("agent.token", "legacy_secret");
+
+    const upgraded = new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterialProvider: () => Buffer.from("test-os-material"),
+    });
+    expect(upgraded.getSync("agent.token")).toBe("legacy_secret");
+    expect(() => legacy.getSync("agent.token")).toThrow();
+
+    upgraded.setSync("agent.token", "bound_secret");
+
+    expect(upgraded.getSync("agent.token")).toBe("bound_secret");
+  });
 });
 
 describe("ElectronSafeStorageCredentialStore", () => {
@@ -56,6 +97,37 @@ describe("ElectronSafeStorageCredentialStore", () => {
 
     expect(await store.get("openai")).toBe("sk-test");
     expect(fs.readFileSync(path.join(tempDir, "credentials.json.enc"), "utf8")).toContain("enc:");
+  });
+
+  it("reads legacy file-store credentials before rewriting with safeStorage", async () => {
+    const legacyStore = new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterialProvider: () => null,
+    });
+    legacyStore.setSync("github.token.v1", "ghp_legacy");
+    const safeStorage = {
+      isEncryptionAvailable: () => true,
+      encryptString: (value: string) => Buffer.from(`safe:${value}`, "utf8"),
+      decryptString: (value: Buffer) => {
+        const raw = value.toString("utf8");
+        if (!raw.startsWith("safe:")) throw new Error("not safeStorage ciphertext");
+        return raw.slice("safe:".length);
+      },
+    };
+    const store = new ElectronSafeStorageCredentialStore({
+      secretsDir: tempDir,
+      safeStorage,
+      legacyStore,
+    });
+
+    expect(store.getSync("github.token.v1")).toBe("ghp_legacy");
+    expect(fs.readFileSync(path.join(tempDir, "credentials.json.enc"), "utf8")).toContain("safe:");
+
+    store.setSync("github.token.v1", "ghp_safe");
+
+    expect(fs.readFileSync(path.join(tempDir, "credentials.json.enc"), "utf8")).toContain("safe:");
+    expect(store.getSync("github.token.v1")).toBe("ghp_safe");
+    expect(() => legacyStore.getSync("github.token.v1")).toThrow();
   });
 });
 

--- a/apps/ade-cli/src/services/credentials/credentialStore.test.ts
+++ b/apps/ade-cli/src/services/credentials/credentialStore.test.ts
@@ -97,6 +97,7 @@ describe("ElectronSafeStorageCredentialStore", () => {
 
     expect(await store.get("openai")).toBe("sk-test");
     expect(fs.readFileSync(path.join(tempDir, "credentials.json.enc"), "utf8")).toContain("enc:");
+    expect(fs.readFileSync(path.join(tempDir, "credentials.json.enc"), "utf8")).toContain("ADE_SAFE_STORAGE_CREDENTIALS_V1");
   });
 
   it("reads legacy file-store credentials before rewriting with safeStorage", async () => {
@@ -128,6 +129,42 @@ describe("ElectronSafeStorageCredentialStore", () => {
     expect(fs.readFileSync(path.join(tempDir, "credentials.json.enc"), "utf8")).toContain("safe:");
     expect(store.getSync("github.token.v1")).toBe("ghp_safe");
     expect(() => legacyStore.getSync("github.token.v1")).toThrow();
+  });
+
+  it("does not fall back to legacy AES when a safeStorage-marked file fails to decrypt", async () => {
+    const legacyStore = new EncryptedFileCredentialStore({
+      secretsDir: tempDir,
+      keyMaterialProvider: () => null,
+    });
+    const safeStorage = {
+      isEncryptionAvailable: () => true,
+      encryptString: (value: string) => Buffer.from(`safe:${value}`, "utf8"),
+      decryptString: (value: Buffer) => {
+        const raw = value.toString("utf8");
+        if (!raw.startsWith("safe:")) throw new Error("safeStorage decrypt failed");
+        return raw.slice("safe:".length);
+      },
+    };
+    const store = new ElectronSafeStorageCredentialStore({
+      secretsDir: tempDir,
+      safeStorage,
+      legacyStore,
+    });
+    store.setSync("github.token.v1", "ghp_safe");
+
+    const failingStore = new ElectronSafeStorageCredentialStore({
+      secretsDir: tempDir,
+      safeStorage: {
+        isEncryptionAvailable: () => true,
+        encryptString: safeStorage.encryptString,
+        decryptString: () => {
+          throw new Error("safeStorage decrypt failed");
+        },
+      },
+      legacyStore,
+    });
+
+    expect(() => failingStore.getSync("github.token.v1")).toThrow("safeStorage decrypt failed");
   });
 });
 

--- a/apps/ade-cli/src/services/credentials/credentialStore.ts
+++ b/apps/ade-cli/src/services/credentials/credentialStore.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { resolveMachineAdeLayout } from "../projects/machineLayout";
@@ -29,9 +30,17 @@ type SafeStorageLike = {
   decryptString(value: Buffer): string;
 };
 
+type CredentialStoreMigrationSource = {
+  readAllForMigration(): Record<string, string>;
+};
+
 const DEFAULT_CREDENTIALS_FILE = "credentials.json.enc";
 const DEFAULT_MACHINE_KEY_FILE = ".machine-key";
 const STORE_AAD = Buffer.from("ade.credentials.v1");
+const OS_BOUND_KEY_INFO = Buffer.from("ade.credentials.file-store.v2");
+const MACOS_KEYCHAIN_SERVICE = "com.ade.runtime.credentials.file-store-key.v1";
+const MACOS_KEYCHAIN_ACCOUNT = "machine";
+let cachedDefaultOsBoundKeyMaterial: Buffer | null = null;
 
 function normalizeKey(key: string): string {
   const normalized = key.trim();
@@ -132,14 +141,82 @@ function readOrCreateMachineKey(machineKeyPath: string): Buffer {
   return key;
 }
 
+function readCredentialPassphraseFromEnv(): Buffer | null {
+  const passphrase = process.env.ADE_CREDENTIAL_STORE_PASSPHRASE?.trim();
+  return passphrase ? Buffer.from(passphrase, "utf8") : null;
+}
+
+function readOrCreateMacKeychainMaterial(): Buffer | null {
+  if (process.platform !== "darwin") return null;
+  try {
+    const raw = execFileSync("security", [
+      "find-generic-password",
+      "-a",
+      MACOS_KEYCHAIN_ACCOUNT,
+      "-s",
+      MACOS_KEYCHAIN_SERVICE,
+      "-w",
+    ], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const decoded = Buffer.from(raw, "base64");
+    return decoded.length >= 32 ? decoded : Buffer.from(raw, "utf8");
+  } catch {
+    // Missing item or locked keychain; try to create once below.
+  }
+
+  const secret = crypto.randomBytes(32).toString("base64");
+  try {
+    execFileSync("security", [
+      "add-generic-password",
+      "-a",
+      MACOS_KEYCHAIN_ACCOUNT,
+      "-s",
+      MACOS_KEYCHAIN_SERVICE,
+      "-w",
+      secret,
+      "-U",
+    ], {
+      stdio: "ignore",
+    });
+    return Buffer.from(secret, "base64");
+  } catch {
+    return null;
+  }
+}
+
+function readDefaultOsBoundKeyMaterial(): Buffer | null {
+  const envMaterial = readCredentialPassphraseFromEnv();
+  if (envMaterial) return envMaterial;
+  if (process.env.ADE_CREDENTIAL_STORE_DISABLE_OS_BINDING === "1") return null;
+  if (process.env.VITEST === "true" || process.env.NODE_ENV === "test") return null;
+  if (cachedDefaultOsBoundKeyMaterial) return cachedDefaultOsBoundKeyMaterial;
+  const material = readOrCreateMacKeychainMaterial();
+  if (material) cachedDefaultOsBoundKeyMaterial = material;
+  return material;
+}
+
+function deriveOsBoundCredentialKey(machineKey: Buffer, osMaterial: Buffer | null): Buffer {
+  if (!osMaterial || osMaterial.length === 0) return machineKey;
+  return Buffer.from(crypto.hkdfSync("sha256", osMaterial, machineKey, OS_BOUND_KEY_INFO, 32));
+}
+
 export class EncryptedFileCredentialStore implements SyncCredentialStore {
   private readonly credentialsPath: string;
   private readonly machineKeyPath: string;
+  private readonly keyMaterialProvider: () => Buffer | null;
 
-  constructor(args: { secretsDir?: string; credentialsPath?: string; machineKeyPath?: string } = {}) {
+  constructor(args: {
+    secretsDir?: string;
+    credentialsPath?: string;
+    machineKeyPath?: string;
+    keyMaterialProvider?: () => Buffer | null;
+  } = {}) {
     const secretsDir = args.secretsDir ?? resolveMachineAdeLayout().secretsDir;
     this.credentialsPath = args.credentialsPath ?? path.join(secretsDir, DEFAULT_CREDENTIALS_FILE);
     this.machineKeyPath = args.machineKeyPath ?? path.join(secretsDir, DEFAULT_MACHINE_KEY_FILE);
+    this.keyMaterialProvider = args.keyMaterialProvider ?? readDefaultOsBoundKeyMaterial;
   }
 
   async get(key: string): Promise<string | null> {
@@ -179,13 +256,31 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
     this.writeAll(values);
   }
 
+  readAllForMigration(): Record<string, string> {
+    return this.readAll();
+  }
+
   private readAll(): Record<string, string> {
-    const key = readOrCreateMachineKey(this.machineKeyPath);
-    return deserializeStore(readJsonObject(this.credentialsPath), key);
+    const raw = readJsonObject(this.credentialsPath);
+    const machineKey = readOrCreateMachineKey(this.machineKeyPath);
+    const key = deriveOsBoundCredentialKey(machineKey, this.keyMaterialProvider());
+    try {
+      return deserializeStore(raw, key);
+    } catch (error) {
+      if (key.equals(machineKey)) throw error;
+      const values = deserializeStore(raw, machineKey);
+      try {
+        this.writeAll(values);
+      } catch {
+        // Preserve read compatibility if migration cannot rewrite right now.
+      }
+      return values;
+    }
   }
 
   private writeAll(values: Record<string, string>): void {
-    const key = readOrCreateMachineKey(this.machineKeyPath);
+    const machineKey = readOrCreateMachineKey(this.machineKeyPath);
+    const key = deriveOsBoundCredentialKey(machineKey, this.keyMaterialProvider());
     writeFileAtomic(this.credentialsPath, `${JSON.stringify(serializeStore(values, key), null, 2)}\n`);
   }
 }
@@ -193,11 +288,18 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
 export class ElectronSafeStorageCredentialStore implements SyncCredentialStore {
   private readonly safeStorage: SafeStorageLike;
   private readonly credentialsPath: string;
+  private readonly legacyStore: CredentialStoreMigrationSource | null;
 
-  constructor(args: { safeStorage: SafeStorageLike; credentialsPath?: string; secretsDir?: string }) {
+  constructor(args: {
+    safeStorage: SafeStorageLike;
+    credentialsPath?: string;
+    secretsDir?: string;
+    legacyStore?: CredentialStoreMigrationSource | null;
+  }) {
     this.safeStorage = args.safeStorage;
     const secretsDir = args.secretsDir ?? resolveMachineAdeLayout().secretsDir;
     this.credentialsPath = args.credentialsPath ?? path.join(secretsDir, DEFAULT_CREDENTIALS_FILE);
+    this.legacyStore = args.legacyStore ?? null;
   }
 
   async get(key: string): Promise<string | null> {
@@ -253,8 +355,23 @@ export class ElectronSafeStorageCredentialStore implements SyncCredentialStore {
       return out;
     } catch (error: unknown) {
       if (isEnoent(error)) return {};
+      if (this.legacyStore) {
+        const values = this.readLegacyAll();
+        try {
+          this.writeAll(values);
+        } catch {
+          // Preserve read compatibility if migration cannot rewrite right now.
+        }
+        return values;
+      }
       throw error;
     }
+  }
+
+  private readLegacyAll(): Record<string, string> {
+    const legacy = this.legacyStore;
+    if (legacy) return legacy.readAllForMigration();
+    throw new Error("Legacy credential store cannot be migrated.");
   }
 
   private writeAll(values: Record<string, string>): void {

--- a/apps/ade-cli/src/services/credentials/credentialStore.ts
+++ b/apps/ade-cli/src/services/credentials/credentialStore.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { resolveMachineAdeLayout } from "../projects/machineLayout";
@@ -40,6 +40,7 @@ const STORE_AAD = Buffer.from("ade.credentials.v1");
 const OS_BOUND_KEY_INFO = Buffer.from("ade.credentials.file-store.v2");
 const MACOS_KEYCHAIN_SERVICE = "com.ade.runtime.credentials.file-store-key.v1";
 const MACOS_KEYCHAIN_ACCOUNT = "machine";
+const SAFE_STORAGE_FILE_MAGIC = Buffer.from("ADE_SAFE_STORAGE_CREDENTIALS_V1\n");
 let cachedDefaultOsBoundKeyMaterial: Buffer | null = null;
 
 function normalizeKey(key: string): string {
@@ -86,6 +87,47 @@ function readJsonObject(filePath: string): Record<string, unknown> | null {
   }
 }
 
+function isStoredCredentialEnvelope(value: unknown): value is StoredCredentialEnvelope {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const candidate = value as Partial<Record<keyof StoredCredentialEnvelope, unknown>>;
+  return candidate.version === 1
+    && candidate.alg === "aes-256-gcm"
+    && typeof candidate.iv === "string"
+    && typeof candidate.tag === "string"
+    && typeof candidate.ciphertext === "string";
+}
+
+function isStoredCredentialEnvelopeBuffer(value: Buffer): boolean {
+  try {
+    return isStoredCredentialEnvelope(JSON.parse(value.toString("utf8")) as unknown);
+  } catch {
+    return false;
+  }
+}
+
+function readSafeStoragePayload(filePath: string): { encrypted: Buffer; hasMagic: boolean } {
+  const raw = fs.readFileSync(filePath);
+  if (raw.subarray(0, SAFE_STORAGE_FILE_MAGIC.length).equals(SAFE_STORAGE_FILE_MAGIC)) {
+    return { encrypted: raw.subarray(SAFE_STORAGE_FILE_MAGIC.length), hasMagic: true };
+  }
+  return { encrypted: raw, hasMagic: false };
+}
+
+export function isElectronSafeStorageCredentialFile(credentialsPath: string): boolean {
+  try {
+    const fd = fs.openSync(credentialsPath, "r");
+    try {
+      const buf = Buffer.alloc(SAFE_STORAGE_FILE_MAGIC.length);
+      const bytesRead = fs.readSync(fd, buf, 0, buf.length, 0);
+      return bytesRead === SAFE_STORAGE_FILE_MAGIC.length && buf.equals(SAFE_STORAGE_FILE_MAGIC);
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return false;
+  }
+}
+
 function serializeStore(values: Record<string, string>, machineKey: Buffer): StoredCredentialEnvelope {
   const iv = crypto.randomBytes(12);
   const cipher = crypto.createCipheriv("aes-256-gcm", machineKey, iv);
@@ -105,11 +147,8 @@ function serializeStore(values: Record<string, string>, machineKey: Buffer): Sto
 
 function deserializeStore(raw: Record<string, unknown> | null, machineKey: Buffer): Record<string, string> {
   if (!raw || Object.keys(raw).length === 0) return {};
-  if (raw.version !== 1 || raw.alg !== "aes-256-gcm") {
+  if (!isStoredCredentialEnvelope(raw)) {
     throw new Error("Unsupported ADE credential store format.");
-  }
-  if (typeof raw.iv !== "string" || typeof raw.tag !== "string" || typeof raw.ciphertext !== "string") {
-    throw new Error("ADE credential store is malformed.");
   }
   const decipher = crypto.createDecipheriv("aes-256-gcm", machineKey, Buffer.from(raw.iv, "base64"));
   decipher.setAAD(STORE_AAD);
@@ -168,18 +207,19 @@ function readOrCreateMacKeychainMaterial(): Buffer | null {
 
   const secret = crypto.randomBytes(32).toString("base64");
   try {
-    execFileSync("security", [
+    const result = spawnSync("security", [
       "add-generic-password",
       "-a",
       MACOS_KEYCHAIN_ACCOUNT,
       "-s",
       MACOS_KEYCHAIN_SERVICE,
-      "-w",
-      secret,
       "-U",
+      "-w",
     ], {
-      stdio: "ignore",
+      input: `${secret}\n`,
+      stdio: ["pipe", "ignore", "ignore"],
     });
+    if (result.status !== 0) return null;
     return Buffer.from(secret, "base64");
   } catch {
     return null;
@@ -343,9 +383,15 @@ export class ElectronSafeStorageCredentialStore implements SyncCredentialStore {
     if (!this.safeStorage.isEncryptionAvailable()) {
       throw new Error("Electron safeStorage is unavailable.");
     }
+    let payload: { encrypted: Buffer; hasMagic: boolean };
     try {
-      const encrypted = fs.readFileSync(this.credentialsPath);
-      const decrypted = this.safeStorage.decryptString(encrypted);
+      payload = readSafeStoragePayload(this.credentialsPath);
+    } catch (error: unknown) {
+      if (isEnoent(error)) return {};
+      throw error;
+    }
+    try {
+      const decrypted = this.safeStorage.decryptString(payload.encrypted);
       const parsed = JSON.parse(decrypted) as unknown;
       if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
       const out: Record<string, string> = {};
@@ -354,8 +400,7 @@ export class ElectronSafeStorageCredentialStore implements SyncCredentialStore {
       }
       return out;
     } catch (error: unknown) {
-      if (isEnoent(error)) return {};
-      if (this.legacyStore) {
+      if (!payload.hasMagic && this.legacyStore && isStoredCredentialEnvelopeBuffer(payload.encrypted)) {
         const values = this.readLegacyAll();
         try {
           this.writeAll(values);
@@ -378,7 +423,13 @@ export class ElectronSafeStorageCredentialStore implements SyncCredentialStore {
     if (!this.safeStorage.isEncryptionAvailable()) {
       throw new Error("Electron safeStorage is unavailable.");
     }
-    writeFileAtomic(this.credentialsPath, this.safeStorage.encryptString(JSON.stringify(values)));
+    writeFileAtomic(
+      this.credentialsPath,
+      Buffer.concat([
+        SAFE_STORAGE_FILE_MAGIC,
+        this.safeStorage.encryptString(JSON.stringify(values)),
+      ]),
+    );
   }
 }
 

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -117,6 +117,7 @@ import { normalizeProjectRootPath } from "../../../ade-cli/src/services/projects
 import {
   ElectronSafeStorageCredentialStore,
   EncryptedFileCredentialStore,
+  isElectronSafeStorageCredentialFile,
   type SyncCredentialStore,
 } from "../../../ade-cli/src/services/credentials/credentialStore";
 import { createKeybindingsService } from "./services/keybindings/keybindingsService";
@@ -375,6 +376,7 @@ function getRendererUrl(): string {
 
 function createDesktopCredentialStore(secretsDir: string): SyncCredentialStore {
   const legacyStore = new EncryptedFileCredentialStore({ secretsDir });
+  const credentialsPath = path.join(secretsDir, "credentials.json.enc");
   try {
     if (safeStorage.isEncryptionAvailable()) {
       return new ElectronSafeStorageCredentialStore({
@@ -385,6 +387,29 @@ function createDesktopCredentialStore(secretsDir: string): SyncCredentialStore {
     }
   } catch {
     // Fall through to the file store when Electron cannot reach the OS keychain.
+  }
+  if (isElectronSafeStorageCredentialFile(credentialsPath)) {
+    const message = "Electron safeStorage is unavailable; unlock the OS credential store to read ADE credentials.";
+    return {
+      get: async () => {
+        throw new Error(message);
+      },
+      set: async () => {
+        throw new Error(message);
+      },
+      delete: async () => {
+        throw new Error(message);
+      },
+      getSync: () => {
+        throw new Error(message);
+      },
+      setSync: () => {
+        throw new Error(message);
+      },
+      deleteSync: () => {
+        throw new Error(message);
+      },
+    };
   }
   return legacyStore;
 }

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -114,7 +114,11 @@ import {
 } from "../../../ade-cli/src/jsonrpc";
 import { resolveMachineAdeLayout } from "../../../ade-cli/src/services/projects/machineLayout";
 import { normalizeProjectRootPath } from "../../../ade-cli/src/services/projects/projectRoots";
-import { EncryptedFileCredentialStore } from "../../../ade-cli/src/services/credentials/credentialStore";
+import {
+  ElectronSafeStorageCredentialStore,
+  EncryptedFileCredentialStore,
+  type SyncCredentialStore,
+} from "../../../ade-cli/src/services/credentials/credentialStore";
 import { createKeybindingsService } from "./services/keybindings/keybindingsService";
 import { createAgentToolsService } from "./services/agentTools/agentToolsService";
 import { createAdeCliService } from "./services/cli/adeCliService";
@@ -367,6 +371,22 @@ function getRendererUrl(): string {
     return "http://localhost:5173";
   }
   return pathToFileURL(path.join(__dirname, "../renderer/index.html")).toString();
+}
+
+function createDesktopCredentialStore(secretsDir: string): SyncCredentialStore {
+  const legacyStore = new EncryptedFileCredentialStore({ secretsDir });
+  try {
+    if (safeStorage.isEncryptionAvailable()) {
+      return new ElectronSafeStorageCredentialStore({
+        secretsDir,
+        safeStorage,
+        legacyStore,
+      });
+    }
+  } catch {
+    // Fall through to the file store when Electron cannot reach the OS keychain.
+  }
+  return legacyStore;
 }
 
 function isAllowedAdeBrowserWebviewSource(rawSrc: string): boolean {
@@ -1699,9 +1719,7 @@ app.whenReady().then(async () => {
     const adePaths = ensureAdeDirs(projectRoot);
     const { initApiKeyStore } = await import("./services/ai/apiKeyStore");
     initApiKeyStore(projectRoot, {
-      credentialStore: new EncryptedFileCredentialStore({
-        secretsDir: machineAdeLayout.secretsDir,
-      }),
+      credentialStore: createDesktopCredentialStore(machineAdeLayout.secretsDir),
     });
     const logger = createFileLogger(path.join(adePaths.logsDir, "main.jsonl"));
     const packagedFirstOpenStabilityMode =
@@ -2170,9 +2188,7 @@ app.whenReady().then(async () => {
       logger,
       projectRoot,
       appDataDir: app.getPath("userData"),
-      credentialStore: new EncryptedFileCredentialStore({
-        secretsDir: machineAdeLayout.secretsDir,
-      }),
+      credentialStore: createDesktopCredentialStore(machineAdeLayout.secretsDir),
     });
 
     const projectScaffoldService = createProjectScaffoldService({
@@ -2746,9 +2762,7 @@ app.whenReady().then(async () => {
     const linearCredentialService = createLinearCredentialService({
       adeDir: adePaths.adeDir,
       logger,
-      credentialStore: new EncryptedFileCredentialStore({
-        secretsDir: path.join(adePaths.adeDir, "secrets"),
-      }),
+      credentialStore: createDesktopCredentialStore(path.join(adePaths.adeDir, "secrets")),
     });
     const linearClient = createLinearClient({
       credentials: linearCredentialService,
@@ -4283,9 +4297,7 @@ app.whenReady().then(async () => {
       logger,
       projectRoot: normalizedRoot,
       appDataDir: app.getPath("userData"),
-      credentialStore: new EncryptedFileCredentialStore({
-        secretsDir: machineAdeLayout.secretsDir,
-      }),
+      credentialStore: createDesktopCredentialStore(machineAdeLayout.secretsDir),
     });
     const dormantProjectScaffoldService = createProjectScaffoldService({
       logger,

--- a/apps/desktop/src/main/rendererCsp.test.ts
+++ b/apps/desktop/src/main/rendererCsp.test.ts
@@ -2,16 +2,31 @@ import { describe, expect, it } from "vitest";
 import { buildRendererCspPolicy } from "./rendererCsp";
 
 describe("buildRendererCspPolicy", () => {
-  it("allows packaged renderer fetches to local simulator stream URLs", () => {
+  it("allows packaged renderer fetches to local simulator stream URLs without blanket HTTPS", () => {
     const policy = buildRendererCspPolicy(false);
 
-    expect(policy).toContain("connect-src 'self' file: app: http://localhost:* http://127.0.0.1:* https:");
+    expect(policy).toContain("connect-src 'self' file: app: http://localhost:* http://127.0.0.1:*");
+    expect(policy).not.toContain("connect-src 'self' file: app: http://localhost:* http://127.0.0.1:* https:");
   });
 
   it("keeps dev websocket sources for Vite while allowing local fetches", () => {
     const policy = buildRendererCspPolicy(true);
 
-    expect(policy).toContain("connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* https:");
+    expect(policy).toContain("connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*");
+    expect(policy).not.toContain("connect-src 'self' http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* https:");
+  });
+
+  it("drops inline script permission from packaged renderer policy", () => {
+    const policy = buildRendererCspPolicy(false);
+
+    expect(policy).toContain("script-src 'self' file: app:");
+    expect(policy).not.toContain("script-src 'self' file: app: 'unsafe-inline'");
+  });
+
+  it("keeps inline script permission only for Vite dev preambles", () => {
+    const policy = buildRendererCspPolicy(true);
+
+    expect(policy).toContain("script-src 'self' http://localhost:* http://127.0.0.1:* 'unsafe-inline'");
   });
 
   it("frames built-in browser content from local servers and about:blank in packaged builds", () => {

--- a/apps/desktop/src/main/rendererCsp.ts
+++ b/apps/desktop/src/main/rendererCsp.ts
@@ -6,18 +6,19 @@ export function buildRendererCspPolicy(isDevMode: boolean): string {
   const cspLocalSources = " http://localhost:* http://127.0.0.1:*";
   const cspConnectLocalSources = isDevMode ? "" : cspLocalSources;
   const cspImageSources = `${cspSources}${cspLocalSources} https://avatars.githubusercontent.com https://*.githubusercontent.com https://github.githubassets.com https://opengraph.githubassets.com https://github.com https://vercel.com https://*.vercel.com https://img.shields.io https://*.s3.amazonaws.com`;
+  const cspScriptSources = isDevMode ? `${cspSources} 'unsafe-inline'` : cspSources;
   return [
     `default-src ${cspSources}`,
     `base-uri 'self'`,
     `form-action 'self'`,
     `object-src 'none'`,
     `frame-src ${cspSources}${cspLocalSources} about:`,
-    `script-src ${cspSources} 'unsafe-inline'`,
+    `script-src ${cspScriptSources}`,
     `style-src ${cspSources} 'unsafe-inline'`,
     `img-src ${cspImageSources} ade-artifact: data: blob:`,
     `media-src ${cspSources}${cspLocalSources} ade-artifact: blob: data:`,
     `font-src ${cspSources} data:`,
-    `connect-src ${cspSources}${cspConnectLocalSources}${cspWsSources} https:`,
+    `connect-src ${cspSources}${cspConnectLocalSources}${cspWsSources}`,
     `worker-src 'self' blob:`,
   ].join("; ");
 }

--- a/apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.test.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { startBuiltInBrowserDesktopBridgeServer } from "./desktopBridgeServer";
+import type { Logger } from "../logging/logger";
+import type { BuiltInBrowserService } from "./builtInBrowserService";
+
+let tempDir = "";
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ade-browser-bridge-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function createLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+async function waitForPath(filePath: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath)) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for ${filePath}`);
+}
+
+async function waitForMode(filePath: string, expectedMode: number): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath) && (fs.statSync(filePath).mode & 0o777) === expectedMode) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  const actual = fs.existsSync(filePath) ? fs.statSync(filePath).mode & 0o777 : null;
+  throw new Error(`Timed out waiting for ${filePath} mode ${expectedMode.toString(8)}; got ${actual?.toString(8) ?? "missing"}`);
+}
+
+describe("startBuiltInBrowserDesktopBridgeServer", () => {
+  it("creates private Unix socket directories and socket files", async () => {
+    if (process.platform === "win32") return;
+
+    const socketPath = path.join(tempDir, "sock", "desktop-bridge.sock");
+    const server = startBuiltInBrowserDesktopBridgeServer({
+      socketPath,
+      service: { getStatus: async () => ({ ok: true }) } as unknown as BuiltInBrowserService,
+      logger: createLogger(),
+    });
+    try {
+      await waitForPath(socketPath);
+      await waitForMode(socketPath, 0o600);
+
+      expect(fs.statSync(path.dirname(socketPath)).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(socketPath).mode & 0o777).toBe(0o600);
+    } finally {
+      server.dispose();
+    }
+  });
+});

--- a/apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.test.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.test.ts
@@ -58,7 +58,10 @@ describe("startBuiltInBrowserDesktopBridgeServer", () => {
       }
       return previous;
     };
-    const socketPath = path.join(tempDir, "sock", "desktop-bridge.sock");
+    const socketDir = path.join(tempDir, "sock");
+    fs.mkdirSync(socketDir, { mode: 0o755 });
+    fs.chmodSync(socketDir, 0o755);
+    const socketPath = path.join(socketDir, "desktop-bridge.sock");
     let server: ReturnType<typeof startBuiltInBrowserDesktopBridgeServer> | null = null;
     try {
       server = startBuiltInBrowserDesktopBridgeServer({
@@ -72,7 +75,7 @@ describe("startBuiltInBrowserDesktopBridgeServer", () => {
 
       expect(umaskCalls).toEqual([0o177, 0o000]);
       expect(currentUmask).toBe(0o000);
-      expect(fs.statSync(path.dirname(socketPath)).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(socketDir).mode & 0o777).toBe(0o700);
       expect(fs.statSync(socketPath).mode & 0o777).toBe(0o600);
     } finally {
       server?.dispose();

--- a/apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.test.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.test.ts
@@ -48,20 +48,34 @@ describe("startBuiltInBrowserDesktopBridgeServer", () => {
   it("creates private Unix socket directories and socket files", async () => {
     if (process.platform === "win32") return;
 
+    let currentUmask = 0o000;
+    const umaskCalls: number[] = [];
+    const umask = (mask?: number): number => {
+      const previous = currentUmask;
+      if (mask != null) {
+        umaskCalls.push(mask);
+        currentUmask = mask;
+      }
+      return previous;
+    };
     const socketPath = path.join(tempDir, "sock", "desktop-bridge.sock");
-    const server = startBuiltInBrowserDesktopBridgeServer({
-      socketPath,
-      service: { getStatus: async () => ({ ok: true }) } as unknown as BuiltInBrowserService,
-      logger: createLogger(),
-    });
+    let server: ReturnType<typeof startBuiltInBrowserDesktopBridgeServer> | null = null;
     try {
+      server = startBuiltInBrowserDesktopBridgeServer({
+        socketPath,
+        service: { getStatus: async () => ({ ok: true }) } as unknown as BuiltInBrowserService,
+        logger: createLogger(),
+        umask,
+      });
       await waitForPath(socketPath);
       await waitForMode(socketPath, 0o600);
 
+      expect(umaskCalls).toEqual([0o177, 0o000]);
+      expect(currentUmask).toBe(0o000);
       expect(fs.statSync(path.dirname(socketPath)).mode & 0o777).toBe(0o700);
       expect(fs.statSync(socketPath).mode & 0o777).toBe(0o600);
     } finally {
-      server.dispose();
+      server?.dispose();
     }
   });
 });

--- a/apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.ts
@@ -53,6 +53,7 @@ export function startBuiltInBrowserDesktopBridgeServer(args: {
   socketPath: string;
   service: BuiltInBrowserService;
   logger: Logger;
+  umask?: (mask?: number) => number;
 }): BuiltInBrowserDesktopBridgeServer {
   const { socketPath, service, logger } = args;
   const isNamedPipe = socketPath.startsWith("\\\\");
@@ -109,26 +110,58 @@ export function startBuiltInBrowserDesktopBridgeServer(args: {
     });
   });
 
+  let restoreSocketUmask: (() => void) | null = null;
+  if (!isNamedPipe && process.platform !== "win32") {
+    const setUmask = args.umask ?? process.umask.bind(process);
+    try {
+      const previousUmask = setUmask(0o177);
+      let restored = false;
+      restoreSocketUmask = () => {
+        if (restored) return;
+        restored = true;
+        setUmask(previousUmask);
+      };
+    } catch (error) {
+      logger.warn("built_in_browser_bridge.sock_umask_failed", {
+        socketPath,
+        reason: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   server.on("error", (error) => {
+    restoreSocketUmask?.();
     logger.error("built_in_browser_bridge.server_error", {
       socketPath,
       reason: error instanceof Error ? error.message : String(error),
     });
   });
 
-  server.listen(socketPath, () => {
-    if (!isNamedPipe) {
-      try {
-        fs.chmodSync(socketPath, 0o600);
-      } catch (error) {
-        logger.warn("built_in_browser_bridge.sock_chmod_failed", {
-          socketPath,
-          reason: error instanceof Error ? error.message : String(error),
-        });
+  try {
+    server.listen(socketPath, () => {
+      restoreSocketUmask?.();
+      if (!isNamedPipe) {
+        try {
+          fs.chmodSync(socketPath, 0o600);
+        } catch (error) {
+          logger.warn("built_in_browser_bridge.sock_chmod_failed", {
+            socketPath,
+            reason: error instanceof Error ? error.message : String(error),
+          });
+          try {
+            server.close();
+          } catch {
+            // ignore close failures after chmod failure
+          }
+          return;
+        }
       }
-    }
-    logger.info("built_in_browser_bridge.listening", { socketPath });
-  });
+      logger.info("built_in_browser_bridge.listening", { socketPath });
+    });
+  } catch (error) {
+    restoreSocketUmask?.();
+    throw error;
+  }
 
   async function handleRequest(request: JsonRpcRequest): Promise<unknown> {
     const method = request.method ?? "";

--- a/apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.ts
@@ -59,8 +59,10 @@ export function startBuiltInBrowserDesktopBridgeServer(args: {
   const isNamedPipe = socketPath.startsWith("\\\\");
 
   if (!isNamedPipe) {
+    const socketDir = path.dirname(socketPath);
     try {
-      fs.mkdirSync(path.dirname(socketPath), { recursive: true, mode: 0o700 });
+      fs.mkdirSync(socketDir, { recursive: true, mode: 0o700 });
+      fs.chmodSync(socketDir, 0o700);
     } catch (error) {
       logger.warn("built_in_browser_bridge.sockdir_create_failed", {
         socketPath,

--- a/apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.ts
@@ -59,7 +59,7 @@ export function startBuiltInBrowserDesktopBridgeServer(args: {
 
   if (!isNamedPipe) {
     try {
-      fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+      fs.mkdirSync(path.dirname(socketPath), { recursive: true, mode: 0o700 });
     } catch (error) {
       logger.warn("built_in_browser_bridge.sockdir_create_failed", {
         socketPath,
@@ -117,6 +117,16 @@ export function startBuiltInBrowserDesktopBridgeServer(args: {
   });
 
   server.listen(socketPath, () => {
+    if (!isNamedPipe) {
+      try {
+        fs.chmodSync(socketPath, 0o600);
+      } catch (error) {
+        logger.warn("built_in_browser_bridge.sock_chmod_failed", {
+          socketPath,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
     logger.info("built_in_browser_bridge.listening", { socketPath });
   });
 


### PR DESCRIPTION
Fixes ADE-90

## Summary

- Tighten packaged renderer CSP by removing production `script-src 'unsafe-inline'` and the blanket `connect-src https:` allowance while keeping the dev-only Vite inline-script allowance.
- OS-bind the encrypted file credential store key with macOS Keychain-derived material, add legacy ciphertext migration, and route desktop credentials through Electron `safeStorage` when available.
- Harden the built-in browser bridge Unix socket by enforcing private directory/socket modes, covering pre-existing directories, tightening umask during listen, and failing closed if socket chmod fails.

## Validation

- `npm --prefix apps/desktop run test -- src/main/rendererCsp.test.ts src/main/services/builtInBrowser/desktopBridgeServer.test.ts`
- `npm --prefix apps/ade-cli run test -- src/services/credentials/credentialStore.test.ts`
- `npm --prefix apps/ade-cli run typecheck`
- `npm --prefix apps/desktop run typecheck`
- `git diff --check`

## Risks

- Existing legacy credential files are migrated opportunistically on successful reads; if OS-bound material is unavailable for a migrated file, ADE now surfaces a clear unlock/credential-store availability error instead of silently falling back to the wrong format.
- `style-src 'unsafe-inline'` intentionally remains unchanged for existing renderer styling behavior.

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-90: Desktop/CLI security hardening: production renderer CSP, OS-bind the credential-store key, chmod the built-in-browser bridge socket](https://linear.app/ade-linear/issue/ADE-90/desktopcli-security-hardening-production-renderer-csp-os-bind-the) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-90-desktop-cli-security-hardening-production-renderer-csp-os-bind-the-credential-store-key-chmod-the-built-in-browser-bridge-socket num=490 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-90-desktop-cli-security-hardening-production-renderer-csp-os-bind-the-credential-store-key-chmod-the-built-in-browser-bridge-socket&amp;pr=490">lane branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=490">PR #490</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies three hardening changes to the ADE desktop and CLI: (1) the packaged renderer CSP drops `script-src 'unsafe-inline'` and the blanket `connect-src https:` in production, (2) the file-based credential store derives its encryption key by HKDF-mixing the machine key with macOS Keychain-retrieved material, and (3) the built-in browser bridge Unix socket directory is chmod'd unconditionally and a restrictive umask is applied before `server.listen()`.

- **CSP tightening** – removes `'unsafe-inline'` from `script-src` in packaged builds and drops `https:` from `connect-src` in both prod and dev; dev mode retains `'unsafe-inline'` for Vite preambles.
- **Credential-store OS binding** – introduces `EncryptedFileCredentialStore.keyMaterialProvider`, a macOS Keychain round-trip via `security(1)` using stdin (avoiding CLI argument exposure), HKDF derivation, and a transparent in-place migration from legacy machine-key-only files.
- **Socket hardening** – `chmodSync(socketDir, 0o700)` now runs unconditionally after `mkdirSync` to harden pre-existing directories, and `process.umask(0o177)` is set before `listen()` so the socket file itself is created restricted from the start.

<h3>Confidence Score: 4/5</h3>

Safe to merge with minor follow-up; the three previously flagged issues are all addressed, and no new blocking problems were found.

The credential-store migration logic is complex (two independent fallback chains that interact), and the `keyMaterialProvider` can be called twice within a single `readAll`→`writeAll` round-trip via the migration path. For the default in-process provider this is harmless due to the module-level cache, but the pattern is fragile for injected providers. The socket and CSP changes are clean and well-tested.

apps/ade-cli/src/services/credentials/credentialStore.ts — the migration write path in `readAll()` re-invokes `keyMaterialProvider` through `writeAll`, and the keychain bootstrap doesn't validate the round-trip after `spawnSync` succeeds.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/services/credentials/credentialStore.ts | Adds OS-bound key derivation, macOS Keychain bootstrap via stdin pipe (addressing prior CLI-arg-exposure comment), and safeStorage migration with `hasMagic` guard; previously flagged fallback-on-any-error is resolved. |
| apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.ts | Socket hardening: unconditional `chmodSync(socketDir, 0o700)` fixes pre-existing-directory gap, umask 0o177 before listen mitigates TOCTOU, and chmod failure now closes the server (fail-closed). |
| apps/desktop/src/main/rendererCsp.ts | Removes `'unsafe-inline'` from production `script-src` and drops blanket `https:` from `connect-src`; dev-mode retains `'unsafe-inline'` for Vite. |
| apps/desktop/src/main/main.ts | Replaces four hardcoded `EncryptedFileCredentialStore` instantiations with `createDesktopCredentialStore`, which prefers `ElectronSafeStorageCredentialStore` and fails closed if safeStorage is unavailable but a safeStorage-format file exists. |
| apps/ade-cli/src/services/credentials/credentialStore.test.ts | Adds tests for OS-bound key derivation, legacy migration paths, and the safeStorage no-fallback-after-magic guarantee; coverage is solid for the new paths. |
| apps/desktop/src/main/rendererCsp.test.ts | Adds assertions for the tightened production CSP (no `unsafe-inline` in script-src, no `https:` in connect-src) and updates existing tests accordingly. |
| apps/desktop/src/main/services/builtInBrowser/desktopBridgeServer.test.ts | New test file; exercises socket directory chmod on pre-existing 0o755 dirs and verifies umask is set before listen and restored after. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fade-cli%2Fsrc%2Fservices%2Fcredentials%2FcredentialStore.ts%3A303-325%0A%60readAll%28%29%60%20migration%20silently%20writes%20with%20OS-bound%20key%2C%20but%20%60writeAll%28%29%60%20internally%20calls%20%60readOrCreateMachineKey%60%20again.%20More%20importantly%2C%20%60writeAll%28%29%60%20could%20silently%20fail%20%28%60catch%20%7B%7D%60%29%20and%20the%20values%20are%20returned%20%E2%80%94%20fine.%20But%20there's%20a%20different%20subtle%20problem%3A%20the%20migration%20write%20re-reads%20the%20%60keyMaterialProvider%28%29%60.%20If%20the%20provider%20returns%20a%20different%20buffer%20on%20the%20second%20call%20%28e.g.%2C%20a%20one-shot%20env%20passphrase%20that%20gets%20consumed%2C%20or%20a%20cache%20miss%20returning%20a%20fresh%20Keychain%20read%29%2C%20the%20written%20key%20would%20differ%20from%20the%20one%20used%20on%20the%20first%20%60readAll%28%29%60%20call%20inside%20%60writeAll%28%29%60.%20The%20%60cachedDefaultOsBoundKeyMaterial%60%20prevents%20this%20for%20the%20default%20provider%2C%20but%20an%20externally-supplied%20%60keyMaterialProvider%60%20has%20no%20such%20guarantee.%20Capturing%20the%20resolved%20material%20once%20at%20the%20start%20of%20%60readAll%60%20and%20reusing%20it%20in%20the%20same%20invocation%20is%20safer.%0A%0A%60%60%60suggestion%0A%20%20private%20readAll%28%29%3A%20Record%3Cstring%2C%20string%3E%20%7B%0A%20%20%20%20const%20raw%20%3D%20readJsonObject%28this.credentialsPath%29%3B%0A%20%20%20%20const%20machineKey%20%3D%20readOrCreateMachineKey%28this.machineKeyPath%29%3B%0A%20%20%20%20const%20osMaterial%20%3D%20this.keyMaterialProvider%28%29%3B%0A%20%20%20%20const%20key%20%3D%20deriveOsBoundCredentialKey%28machineKey%2C%20osMaterial%29%3B%0A%20%20%20%20try%20%7B%0A%20%20%20%20%20%20return%20deserializeStore%28raw%2C%20key%29%3B%0A%20%20%20%20%7D%20catch%20%28error%29%20%7B%0A%20%20%20%20%20%20if%20%28key.equals%28machineKey%29%29%20throw%20error%3B%0A%20%20%20%20%20%20const%20values%20%3D%20deserializeStore%28raw%2C%20machineKey%29%3B%0A%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20this.writeAllWithKey%28values%2C%20key%29%3B%0A%20%20%20%20%20%20%7D%20catch%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20Preserve%20read%20compatibility%20if%20migration%20cannot%20rewrite%20right%20now.%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20return%20values%3B%0A%20%20%20%20%7D%0A%20%20%7D%0A%0A%20%20private%20writeAll%28values%3A%20Record%3Cstring%2C%20string%3E%29%3A%20void%20%7B%0A%20%20%20%20const%20machineKey%20%3D%20readOrCreateMachineKey%28this.machineKeyPath%29%3B%0A%20%20%20%20const%20key%20%3D%20deriveOsBoundCredentialKey%28machineKey%2C%20this.keyMaterialProvider%28%29%29%3B%0A%20%20%20%20this.writeAllWithKey%28values%2C%20key%29%3B%0A%20%20%7D%0A%0A%20%20private%20writeAllWithKey%28values%3A%20Record%3Cstring%2C%20string%3E%2C%20key%3A%20Buffer%29%3A%20void%20%7B%0A%20%20%20%20writeFileAtomic%28this.credentialsPath%2C%20%60%24%7BJSON.stringify%28serializeStore%28values%2C%20key%29%2C%20null%2C%202%29%7D%5Cn%60%29%3B%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fade-cli%2Fsrc%2Fservices%2Fcredentials%2FcredentialStore.ts%3A222-223%0AWhen%20%60readOrCreateMacKeychainMaterial%28%29%60%20creates%20a%20new%20keychain%20entry%2C%20it%20reads%20the%20secret%20back%20indirectly%20by%20reusing%20the%20generated%20%60secret%60%20string.%20But%20if%20%60spawnSync%60%20succeeds%20%28status%200%29%20and%20the%20tool%20did%20not%20actually%20consume%20stdin%20as%20the%20password%20%28e.g.%2C%20a%20future%20macOS%20version%20changes%20%60-w%60%20stdin%20behaviour%29%2C%20the%20stored%20value%20could%20silently%20be%20empty.%20The%20subsequent%20call%20to%20%60execFileSync%28%22security%20find-generic-password%20...%20-w%22%29%60%20would%20then%20return%20an%20empty%20string%2C%20causing%20%60decoded.length%20%3E%3D%2032%60%20to%20be%20false%20and%20falling%20to%20%60Buffer.from%28%22%22%2C%20%22utf8%22%29%60%2C%20which%20triggers%20the%20%60osMaterial.length%20%3D%3D%3D%200%60%20guard%20and%20silently%20disables%20OS%20binding.%20Consider%20adding%20an%20explicit%20%60decoded.length%20%3C%2032%60%20guard%20on%20the%20stored-value%20path%20so%20that%20an%20unexpectedly%20short%20round-trip%20throws%20rather%20than%20silently%20falling%20back%20to%20no%20OS%20binding.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28result.status%20!%3D%3D%200%29%20return%20null%3B%0A%20%20%20%20const%20decoded%20%3D%20Buffer.from%28secret%2C%20%22base64%22%29%3B%0A%20%20%20%20if%20%28decoded.length%20%3C%2032%29%20return%20null%3B%0A%20%20%20%20return%20decoded%3B%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=490&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/ade-cli/src/services/credentials/credentialStore.ts:303-325
`readAll()` migration silently writes with OS-bound key, but `writeAll()` internally calls `readOrCreateMachineKey` again. More importantly, `writeAll()` could silently fail (`catch {}`) and the values are returned — fine. But there's a different subtle problem: the migration write re-reads the `keyMaterialProvider()`. If the provider returns a different buffer on the second call (e.g., a one-shot env passphrase that gets consumed, or a cache miss returning a fresh Keychain read), the written key would differ from the one used on the first `readAll()` call inside `writeAll()`. The `cachedDefaultOsBoundKeyMaterial` prevents this for the default provider, but an externally-supplied `keyMaterialProvider` has no such guarantee. Capturing the resolved material once at the start of `readAll` and reusing it in the same invocation is safer.

```suggestion
  private readAll(): Record<string, string> {
    const raw = readJsonObject(this.credentialsPath);
    const machineKey = readOrCreateMachineKey(this.machineKeyPath);
    const osMaterial = this.keyMaterialProvider();
    const key = deriveOsBoundCredentialKey(machineKey, osMaterial);
    try {
      return deserializeStore(raw, key);
    } catch (error) {
      if (key.equals(machineKey)) throw error;
      const values = deserializeStore(raw, machineKey);
      try {
        this.writeAllWithKey(values, key);
      } catch {
        // Preserve read compatibility if migration cannot rewrite right now.
      }
      return values;
    }
  }

  private writeAll(values: Record<string, string>): void {
    const machineKey = readOrCreateMachineKey(this.machineKeyPath);
    const key = deriveOsBoundCredentialKey(machineKey, this.keyMaterialProvider());
    this.writeAllWithKey(values, key);
  }

  private writeAllWithKey(values: Record<string, string>, key: Buffer): void {
    writeFileAtomic(this.credentialsPath, `${JSON.stringify(serializeStore(values, key), null, 2)}\n`);
  }
```

### Issue 2 of 2
apps/ade-cli/src/services/credentials/credentialStore.ts:222-223
When `readOrCreateMacKeychainMaterial()` creates a new keychain entry, it reads the secret back indirectly by reusing the generated `secret` string. But if `spawnSync` succeeds (status 0) and the tool did not actually consume stdin as the password (e.g., a future macOS version changes `-w` stdin behaviour), the stored value could silently be empty. The subsequent call to `execFileSync("security find-generic-password ... -w")` would then return an empty string, causing `decoded.length >= 32` to be false and falling to `Buffer.from("", "utf8")`, which triggers the `osMaterial.length === 0` guard and silently disables OS binding. Consider adding an explicit `decoded.length < 32` guard on the stored-value path so that an unexpectedly short round-trip throws rather than silently falling back to no OS binding.

```suggestion
    if (result.status !== 0) return null;
    const decoded = Buffer.from(secret, "base64");
    if (decoded.length < 32) return null;
    return decoded;
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Harden existing browser bridge socket di..."](https://github.com/arul28/ade/commit/acb6163479cfb0de4a0ed6deee27cddaa6c0da41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34779629)</sub>

<!-- /greptile_comment -->