### PR TITLE
ADE-81: Linear GraphQL/CLI hardening: non-retryable retries, missing connection precheck, duplicated plumbing, and headless as-any casts

### DIFF
--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -66,7 +66,7 @@ import type { createLinearIngressService } from "../../desktop/src/main/services
 import type { createLinearRoutingService } from "../../desktop/src/main/services/cto/linearRoutingService";
 import type { createLinearSyncService } from "../../desktop/src/main/services/cto/linearSyncService";
 import {
-  publishLinearChatSessionCard,
+  createLinearChatLinkPublisher,
   publishLinearLaneCard,
 } from "../../desktop/src/main/services/cto/linearLaneCardService";
 import { createAiIntegrationService } from "../../desktop/src/main/services/ai/aiIntegrationService";
@@ -436,43 +436,10 @@ export async function createAdeRuntime(args: {
   let autoRebaseServiceRef: ReturnType<typeof createAutoRebaseService> | null = null;
   let linearIssueTrackerRef: ReturnType<typeof createLinearIssueTracker> | null = null;
   let githubServiceRef: ReturnType<typeof createGithubService> | null = null;
-  const linearChatCardPublishKeys = new Set<string>();
-  const publishLinearChatLink = ({
-    laneId,
-    sessionId,
-    sessionTitle,
-    issue,
-    linkedAt,
-  }: {
-    laneId: string;
-    sessionId: string;
-    sessionTitle?: string | null;
-    issue: Parameters<typeof publishLinearChatSessionCard>[0]["issue"];
-    linkedAt: string;
-  }) => {
-    const tracker = linearIssueTrackerRef;
-    if (!tracker) return;
-    const key = `${issue.id}:${sessionId}`;
-    if (linearChatCardPublishKeys.has(key)) return;
-    linearChatCardPublishKeys.add(key);
-    void publishLinearChatSessionCard({
-      issueTracker: tracker,
-      issue,
-      laneId,
-      sessionId,
-      sessionTitle,
-      linkedAt,
-    }).catch((error) => {
-      linearChatCardPublishKeys.delete(key);
-      logger.warn("linear.chat_session_card_publish_failed", {
-        laneId,
-        sessionId,
-        issueId: issue.id,
-        issueIdentifier: issue.identifier,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    });
-  };
+  const publishLinearChatLink = createLinearChatLinkPublisher({
+    getIssueTracker: () => linearIssueTrackerRef,
+    log: (event, fields) => logger.warn(event, fields),
+  });
 
   const laneService = createLaneService({
     db,
@@ -928,7 +895,7 @@ export async function createAdeRuntime(args: {
   linearIssueTrackerRef = headlessLinearServices.linearIssueTracker;
   githubServiceRef = headlessLinearServices.githubService as ReturnType<typeof createGithubService>;
   const linearOAuthService = createLinearOAuthService({
-    credentials: headlessLinearServices.linearCredentialService as never,
+    credentials: headlessLinearServices.linearCredentialService,
     logger,
   });
 
@@ -937,7 +904,7 @@ export async function createAdeRuntime(args: {
     logger,
     projectRoot,
     aiIntegrationService,
-    githubService: headlessLinearServices.githubService as never,
+    githubService: headlessLinearServices.githubService,
     onSubmissionUpdated: (event) => pushEvent("runtime", { type: "feedback_submission_event", event }),
   });
 
@@ -955,7 +922,7 @@ export async function createAdeRuntime(args: {
       flowPolicyService: headlessLinearServices.flowPolicyService,
       getLinearDispatcherService: () => headlessLinearServices.linearDispatcherService,
       linearClient: headlessLinearServices.linearClient,
-      linearCredentials: headlessLinearServices.linearCredentialService as never,
+      linearCredentials: headlessLinearServices.linearCredentialService,
       prService: headlessLinearServices.prService,
       issueInventoryService,
       processService,
@@ -1215,10 +1182,10 @@ export async function createAdeRuntime(args: {
     adeProjectService,
     workerBudgetService,
     workerRevisionService,
-    githubService: headlessLinearServices.githubService as never,
+    githubService: headlessLinearServices.githubService,
     workerTaskSessionService: headlessLinearServices.workerTaskSessionService,
     workerHeartbeatService: headlessLinearServices.workerHeartbeatService,
-    linearCredentialService: headlessLinearServices.linearCredentialService as never,
+    linearCredentialService: headlessLinearServices.linearCredentialService,
     linearOAuthService,
     prService: headlessLinearServices.prService,
     fileService: headlessLinearServices.fileService,

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -2436,6 +2436,8 @@ describe("ADE CLI", () => {
       "Viewer",
       "--variables-json",
       "{\"includeArchived\":false}",
+      "--max-retries",
+      "99",
     ]);
     expect(plan.kind).toBe("execute");
     if (plan.kind !== "execute") return;
@@ -2448,6 +2450,7 @@ describe("ADE CLI", () => {
           query: "query Viewer { viewer { id name } }",
           operationName: "Viewer",
           variables: { includeArchived: false },
+          maxRetries: 10,
         },
       },
     });
@@ -2475,6 +2478,17 @@ describe("ADE CLI", () => {
         "{\"query\":123}",
       ]),
     ).toThrow(/GraphQL query is required/);
+
+    expect(() =>
+      buildCliPlan([
+        "linear",
+        "graphql",
+        "--query",
+        "query Viewer { viewer { id name } }",
+        "--input-json",
+        "{\"maxRetries\":\"many\"}",
+      ]),
+    ).toThrow(/--max-retries must be a number/);
   });
 
   it("attaches an issue to the current session via linear attach --this-session", () => {

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -2466,7 +2466,7 @@ describe("ADE CLI", () => {
         "--arg-json",
         "variables=[]",
       ]),
-    ).toThrow(/--variables-json must be a JSON object/);
+    ).toThrow(/'variables' must be a JSON object/);
 
     expect(() =>
       buildCliPlan([
@@ -2488,7 +2488,7 @@ describe("ADE CLI", () => {
         "--input-json",
         "{\"maxRetries\":\"many\"}",
       ]),
-    ).toThrow(/--max-retries must be a number/);
+    ).toThrow(/'maxRetries' must be a number/);
   });
 
   it("attaches an issue to the current session via linear attach --this-session", () => {

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -18,6 +18,7 @@ import {
   runDeeplinkCommand,
 } from "./commands/deeplinks";
 import { buildDeeplink } from "../../desktop/src/shared/deeplinks";
+import { parseLinearGraphQLInput } from "../../desktop/src/main/services/cto/linearGraphQLInput";
 import { resolveMachineAdeLayout } from "./services/projects/machineLayout";
 import {
   findAdeManagedWorktreeRoot,
@@ -2073,32 +2074,11 @@ function readIssueIdFlag(args: string[]): string | null {
 }
 
 function normalizeLinearGraphQLInput(input: JsonObject): JsonObject {
-  const query = asString(input.query);
-  if (!query) {
-    throw new CliUsageError("GraphQL query is required.");
+  try {
+    return parseLinearGraphQLInput(input) as JsonObject;
+  } catch (error) {
+    throw new CliUsageError(error instanceof Error ? error.message : String(error));
   }
-
-  const variables = input.variables;
-  if (variables != null && !isRecord(variables)) {
-    throw new CliUsageError("--variables-json must be a JSON object.");
-  }
-
-  const maxRetries = input.maxRetries;
-  if (maxRetries != null && (typeof maxRetries !== "number" || !Number.isFinite(maxRetries))) {
-    throw new CliUsageError("--max-retries must be a number.");
-  }
-
-  const normalized: JsonObject = { ...input, query };
-  if (variables == null) {
-    delete normalized.variables;
-  }
-  const operationName = asString(input.operationName);
-  if (operationName) {
-    normalized.operationName = operationName;
-  } else {
-    delete normalized.operationName;
-  }
-  return normalized;
 }
 
 function readLinearGraphQLArgs(args: string[]): JsonObject {

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -2095,9 +2095,6 @@ function readLinearGraphQLArgs(args: string[]): JsonObject {
     ["--variables-file", "--vars-file"],
     "--variables-json",
   );
-  if (variables !== undefined && !isRecord(variables)) {
-    throw new CliUsageError("--variables-json must be a JSON object.");
-  }
   const input: JsonObject = { query };
   if (variables !== undefined) input.variables = variables;
   maybePut(input, "operationName", readValue(args, ["--operation-name", "--operation"]));

--- a/apps/ade-cli/src/headlessLinearServices.ts
+++ b/apps/ade-cli/src/headlessLinearServices.ts
@@ -13,6 +13,7 @@ import type { createFileService } from "../../desktop/src/main/services/files/fi
 import type { createProcessService } from "../../desktop/src/main/services/processes/processService";
 import type { createPrService } from "../../desktop/src/main/services/prs/prService";
 import type { createLinearClient } from "../../desktop/src/main/services/cto/linearClient";
+import type { createLinearCredentialService } from "../../desktop/src/main/services/cto/linearCredentialService";
 import type { createLinearIssueTracker } from "../../desktop/src/main/services/cto/linearIssueTracker";
 import type { createLinearTemplateService } from "../../desktop/src/main/services/cto/linearTemplateService";
 import type { createLinearWorkflowFileService } from "../../desktop/src/main/services/cto/linearWorkflowFileService";
@@ -38,6 +39,19 @@ import {
   getGitHubTokenAccessState,
   parseGitHubScopeHeaders,
 } from "../../desktop/src/shared/githubScopes";
+import type {
+  GitHubStatus,
+  WorkerAgentRun,
+  WorkerAgentWakeupReason,
+} from "../../desktop/src/shared/types";
+import type {
+  GithubService,
+  GitHubIssue,
+  GitHubIssueComment,
+  GitHubLabel,
+  GitHubPullRequest,
+  GitHubPullRequestReview,
+} from "../../desktop/src/main/services/github/githubService";
 import type { AdeRuntimePaths } from "./bootstrap";
 import { createLinearClient as createLinearClientImpl } from "../../desktop/src/main/services/cto/linearClient";
 import { createLinearIssueTracker as createLinearIssueTrackerImpl } from "../../desktop/src/main/services/cto/linearIssueTracker";
@@ -72,129 +86,9 @@ import {
 const BUNDLED_LINEAR_OAUTH_CLIENT_ID =
   process.env.ADE_LINEAR_CLIENT_ID?.trim() || "432fb2ddb16f939ae5d5270e2c86571f";
 
-type HeadlessLinearCredentialService = {
-  getStatus: () => {
-    tokenStored: boolean;
-    tokenDecryptionFailed: boolean;
-    storageScope: "app";
-    repo: { owner: string; name: string } | null;
-    userLogin: string | null;
-    scopes: string[];
-    checkedAt: string | null;
-    authMode?: "manual" | "oauth" | null;
-    tokenExpiresAt?: string | null;
-    refreshTokenStored?: boolean;
-    oauthConfigured?: boolean;
-  };
-  getTokenOrThrow: () => string;
-  setToken: (token: string) => void;
-  setOAuthToken: (args: {
-    accessToken: string;
-    refreshToken?: string | null;
-    expiresAt?: string | null;
-  }) => void;
-  clearToken: () => void;
-  setOAuthClientCredentials: (args: {
-    clientId: string;
-    clientSecret?: string | null;
-  }) => void;
-  clearOAuthClientCredentials: () => void;
-  getOAuthClientCredentials: () => {
-    clientId: string;
-    clientSecret: string | null;
-  } | null;
-  ensureFreshToken: (opts?: { force?: boolean }) => Promise<void>;
-};
-
-type HeadlessGitHubStatus = {
-  tokenStored: boolean;
-  patTokenStored: boolean;
-  tokenDecryptionFailed: boolean;
-  storageScope: "app";
-  authSource: "pat" | "environment" | "gh" | "none";
-  tokenType?: "classic" | "fine-grained" | "oauth" | "unknown";
-  repo: { owner: string; name: string } | null;
-  hasOrigin: boolean;
-  userLogin: string | null;
-  scopes: string[];
-  ghCliPath: string | null;
-  ghAuthError: string | null;
-  checkedAt: string | null;
-  repoAccessOk: boolean | null;
-  repoAccessError: string | null;
-  connected: boolean;
-};
-
-export type HeadlessGitHubService = {
-  getStatus: (opts?: {
-    forceRefresh?: boolean;
-  }) => Promise<HeadlessGitHubStatus>;
-  getRemoteStatus: () => Promise<{
-    repo: { owner: string; name: string } | null;
-    hasOrigin: boolean;
-  }>;
-  detectRepo: () => Promise<{ owner: string; name: string } | null>;
-  getRepoOrThrow: () => Promise<{ owner: string; name: string }>;
-  getTokenOrThrow: () => string;
-  parseGitHubRepoFromRemoteUrl: typeof parseGitHubRepoFromRemoteUrl;
-  apiRequest: <T>(args: {
-    method: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
-    path: string;
-    query?: Record<string, string | number | boolean | undefined | null>;
-    body?: unknown;
-    token?: string;
-  }) => Promise<{ data: T; response: Response | null }>;
-  setToken: (token: string) => void;
-  clearToken: () => void;
-  listRepoAutolinks: (owner: string, name: string) => Promise<unknown[]>;
-  createRepoAutolink: (
-    owner: string,
-    name: string,
-    args: { keyPrefix: string; urlTemplate: string; isAlphanumeric?: boolean },
-  ) => Promise<unknown>;
-  listRepoLabels: (owner: string, name: string) => Promise<unknown[]>;
-  listRepoCollaborators: (owner: string, name: string) => Promise<unknown[]>;
-  publishCurrentProject: (args: {
-    name: string;
-    description?: string;
-    isPrivate: boolean;
-  }) => Promise<{ state: "pushed" | "remote_added"; htmlUrl: string }>;
-  addIssueComment: (
-    owner: string,
-    name: string,
-    number: number,
-    body: string,
-  ) => Promise<unknown>;
-  setIssueLabels: (
-    owner: string,
-    name: string,
-    number: number,
-    labels: string[],
-  ) => Promise<unknown>;
-  closeIssue: (
-    owner: string,
-    name: string,
-    number: number,
-    reason?: "completed" | "not_planned",
-  ) => Promise<unknown>;
-  reopenIssue: (
-    owner: string,
-    name: string,
-    number: number,
-  ) => Promise<unknown>;
-  assignIssue: (
-    owner: string,
-    name: string,
-    number: number,
-    assignees: string[],
-  ) => Promise<unknown>;
-  setIssueTitle: (
-    owner: string,
-    name: string,
-    number: number,
-    title: string,
-  ) => Promise<unknown>;
-};
+type HeadlessLinearCredentialService = ReturnType<typeof createLinearCredentialService>;
+type HeadlessGitHubStatus = GitHubStatus;
+export type HeadlessGitHubService = GithubService;
 
 type HeadlessAgentChatSession = {
   id: string;
@@ -260,7 +154,7 @@ type HeadlessLinearServices = {
   processService: ReturnType<typeof createProcessService>;
   prService: ReturnType<typeof createPrService>;
   agentChatService: {
-    listSessions: () => Promise<Array<Record<string, unknown>>>;
+    listSessions: () => Promise<HeadlessAgentChatSession[]>;
     getSessionSummary: (
       sessionId: string,
     ) => Promise<Record<string, unknown> | null>;
@@ -618,7 +512,13 @@ export function createHeadlessGitHubService(
     }
   };
 
-  const apiRequest: HeadlessGitHubService["apiRequest"] = async (args) => {
+  const apiRequest = async <T>(args: {
+    method: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+    path: string;
+    query?: Record<string, string | number | boolean | undefined | null>;
+    body?: unknown;
+    token?: string;
+  }): Promise<{ data: T; response: Response | null; linkHeader?: string | null }> => {
     const token = (args.token ?? getToken()).trim();
     if (!token) {
       throw new Error(
@@ -657,7 +557,7 @@ export function createHeadlessGitHubService(
           : `GitHub API request failed (HTTP ${response.status})`;
       throw new Error(message);
     }
-    return { data: data as never, response };
+    return { data: data as T, response };
   };
 
   const apiRequestAllPages = async <T>(args: {
@@ -693,6 +593,90 @@ export function createHeadlessGitHubService(
       urlTemplate: asString(record.url_template) || asString(record.urlTemplate),
       isAlphanumeric: Boolean(record.is_alphanumeric ?? record.isAlphanumeric),
     };
+  };
+
+  const listRepoIssues: HeadlessGitHubService["listRepoIssues"] = async (
+    owner,
+    name,
+    opts = {},
+  ): Promise<GitHubIssue[]> => {
+    const data = await apiRequestAllPages<GitHubIssue>({
+      path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues`,
+      query: {
+        state: opts.state ?? "all",
+        sort: opts.sort ?? "updated",
+        per_page: opts.perPage ?? 50,
+        ...(opts.since ? { since: opts.since } : {}),
+      },
+    });
+    return Array.isArray(data) ? data : [];
+  };
+
+  const getIssue: HeadlessGitHubService["getIssue"] = async (
+    owner,
+    name,
+    number,
+  ): Promise<GitHubIssue | null> => {
+    try {
+      const { data } = await apiRequest<GitHubIssue>({
+        method: "GET",
+        path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/${number}`,
+      });
+      return data ?? null;
+    } catch (error) {
+      logger.warn("github.get_issue_failed", {
+        owner,
+        name,
+        number,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  };
+
+  const listIssueComments: HeadlessGitHubService["listIssueComments"] = async (
+    owner,
+    name,
+    number,
+    opts = {},
+  ): Promise<GitHubIssueComment[]> => {
+    const data = await apiRequestAllPages<GitHubIssueComment>({
+      path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/${number}/comments`,
+      query: {
+        per_page: 100,
+        ...(opts.since ? { since: opts.since } : {}),
+      },
+    });
+    return Array.isArray(data) ? data : [];
+  };
+
+  const listRepoPulls: HeadlessGitHubService["listRepoPulls"] = async (
+    owner,
+    name,
+    opts = {},
+  ): Promise<GitHubPullRequest[]> => {
+    const data = await apiRequestAllPages<GitHubPullRequest>({
+      path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/pulls`,
+      query: {
+        state: opts.state ?? "all",
+        sort: opts.sort ?? "updated",
+        direction: "desc",
+        per_page: opts.perPage ?? 50,
+      },
+    });
+    return Array.isArray(data) ? data : [];
+  };
+
+  const listPullRequestReviews: HeadlessGitHubService["listPullRequestReviews"] = async (
+    owner,
+    name,
+    number,
+  ): Promise<GitHubPullRequestReview[]> => {
+    const data = await apiRequestAllPages<GitHubPullRequestReview>({
+      path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/pulls/${number}/reviews`,
+      query: { per_page: 100 },
+    });
+    return Array.isArray(data) ? data : [];
   };
 
   const createRepository = async (args: {
@@ -926,6 +910,7 @@ export function createHeadlessGitHubService(
       return token;
     },
     parseGitHubRepoFromRemoteUrl,
+    parseNextLink: parseNextGitHubLink,
     setToken(nextToken: string) {
       const clean = nextToken.trim();
       tokenOverride = clean || null;
@@ -948,6 +933,8 @@ export function createHeadlessGitHubService(
       emitStatusChanged();
     },
     apiRequest,
+    createRepository,
+    getRepository,
     async listRepoLabels(owner, name) {
       return apiRequestAllPages({
         path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/labels`,
@@ -979,6 +966,11 @@ export function createHeadlessGitHubService(
         query: { per_page: 100 },
       });
     },
+    listRepoIssues,
+    getIssue,
+    listIssueComments,
+    listRepoPulls,
+    listPullRequestReviews,
     async publishCurrentProject(args) {
       const token = getToken();
       if (!token) {
@@ -1087,25 +1079,24 @@ export function createHeadlessGitHubService(
     },
     async addIssueComment(owner, name, number, body) {
       return (
-        await apiRequest({
+        await apiRequest<GitHubIssueComment>({
           method: "POST",
           path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/${number}/comments`,
           body: { body },
         })
-      ).data;
+      ).data ?? null;
     },
     async setIssueLabels(owner, name, number, labels) {
-      return (
-        await apiRequest({
+      const { data } = await apiRequest<GitHubLabel[]>({
           method: "PUT",
           path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/${number}/labels`,
           body: { labels },
-        })
-      ).data;
+      });
+      return Array.isArray(data) ? data : [];
     },
     async closeIssue(owner, name, number, reason) {
       return (
-        await apiRequest({
+        await apiRequest<GitHubIssue>({
           method: "PATCH",
           path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/${number}`,
           body: {
@@ -1113,34 +1104,34 @@ export function createHeadlessGitHubService(
             ...(reason ? { state_reason: reason } : {}),
           },
         })
-      ).data;
+      ).data ?? null;
     },
     async reopenIssue(owner, name, number) {
       return (
-        await apiRequest({
+        await apiRequest<GitHubIssue>({
           method: "PATCH",
           path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/${number}`,
           body: { state: "open" },
         })
-      ).data;
+      ).data ?? null;
     },
     async assignIssue(owner, name, number, assignees) {
       return (
-        await apiRequest({
+        await apiRequest<GitHubIssue>({
           method: "POST",
           path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/${number}/assignees`,
           body: { assignees },
         })
-      ).data;
+      ).data ?? null;
     },
     async setIssueTitle(owner, name, number, title) {
       return (
-        await apiRequest({
+        await apiRequest<GitHubIssue>({
           method: "PATCH",
           path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/${number}`,
           body: { title },
         })
-      ).data;
+      ).data ?? null;
     },
   };
   return service;
@@ -1319,6 +1310,10 @@ function createHeadlessLinearCredentialService(args: {
   };
 
   return {
+    getToken() {
+      const { token } = readToken();
+      return token.trim() || null;
+    },
     getStatus() {
       const { token, source } = readToken();
       const authMode =
@@ -1662,30 +1657,45 @@ function createHeadlessAgentChatService(
 function createHeadlessWorkerHeartbeatService(): ReturnType<
   typeof createWorkerHeartbeatService
 > {
-  const runs: Array<{
-    id: string;
-    agentId: string;
-    status: "failed";
-    wakeupReason: string;
-    taskKey: string | null;
-    issueKey: string | null;
-    context: Record<string, unknown>;
-    errorMessage: string;
-    startedAt: string;
-    finishedAt: string;
-    createdAt: string;
-    updatedAt: string;
-  }> = [];
+  const runs: WorkerAgentRun[] = [];
+  const wakeupReasons = new Set<WorkerAgentWakeupReason>([
+    "timer",
+    "manual",
+    "user_message",
+    "assignment",
+    "api",
+    "deferred_promotion",
+    "startup_recovery",
+  ]);
+  const normalizeWakeupReason = (value: unknown): WorkerAgentWakeupReason => {
+    const reason = typeof value === "string" ? value.trim() : "";
+    return wakeupReasons.has(reason as WorkerAgentWakeupReason)
+      ? reason as WorkerAgentWakeupReason
+      : "api";
+  };
 
-  return {
-    listRuns({ limit }: { limit?: number } = {}) {
+  const service = {
+    syncFromConfig() {
+      return;
+    },
+    listRuns({ agentId, limit, statuses }: { agentId?: string; limit?: number; statuses?: WorkerAgentRun["status"][] } = {}) {
       const safeLimit = Math.max(1, Math.min(200, Math.floor(limit ?? 50)));
-      return runs.slice(0, safeLimit).map((run) => ({
+      return runs
+        .filter((run) => !agentId || run.agentId === agentId)
+        .filter((run) => !statuses?.length || statuses.includes(run.status))
+        .slice(0, safeLimit)
+        .map((run) => ({
         ...run,
         executionRunId: null,
         executionLockedAt: null,
         result: null,
       }));
+    },
+    listAgentSessionLogs() {
+      return [];
+    },
+    async reapOrphansOnStartup() {
+      return;
     },
     async triggerWakeup(args: {
       agentId: string;
@@ -1700,7 +1710,7 @@ function createHeadlessWorkerHeartbeatService(): ReturnType<
         id: runId,
         agentId: args.agentId,
         status: "failed",
-        wakeupReason: args.reason ?? "api",
+        wakeupReason: normalizeWakeupReason(args.reason),
         taskKey: args.taskKey ?? null,
         issueKey: args.issueKey ?? null,
         context: args.context ?? {},
@@ -1713,16 +1723,14 @@ function createHeadlessWorkerHeartbeatService(): ReturnType<
       });
       return { runId, status: "failed" };
     },
-    dispose() {
+    async dispose() {
       runs.length = 0;
     },
     start() {
       return;
     },
-    stop() {
-      return;
-    },
-  } as unknown as ReturnType<typeof createWorkerHeartbeatService>;
+  } satisfies ReturnType<typeof createWorkerHeartbeatService>;
+  return service;
 }
 
 export function createHeadlessLinearServices(
@@ -1736,14 +1744,14 @@ export function createHeadlessLinearServices(
     createHeadlessLinearCredentialService({
       adeDir: args.adeDir,
       logger: args.logger,
-    }) as any;
+    });
   const githubService = createHeadlessGitHubService(
     args.projectRoot,
     args.logger,
     { onStatusChanged: args.onGitHubStatusChanged },
   );
   const linearClient = createLinearClientImpl({
-    credentials: linearCredentialService as any,
+    credentials: linearCredentialService,
     logger: args.logger,
   });
   const issueTracker = createLinearIssueTrackerImpl({ client: linearClient });
@@ -1781,7 +1789,7 @@ export function createHeadlessLinearServices(
   });
   const sessionService = {
     get: () => null,
-  } as any;
+  };
   const ptyService = {
     create: async () => {
       throw new Error(
@@ -1791,7 +1799,7 @@ export function createHeadlessLinearServices(
     dispose: () => {},
     onData: () => () => {},
     onExit: () => () => {},
-  } as any;
+  };
   const processService = createProcessServiceImpl({
     db: args.db,
     projectId: args.projectId,
@@ -1809,25 +1817,17 @@ export function createHeadlessLinearServices(
     projectRoot: args.projectRoot,
     laneService: args.laneService,
     operationService: args.operationService,
-    githubService: githubService as any,
+    githubService,
     projectConfigService: args.projectConfigService,
     conflictService: args.conflictService,
     openExternal: args.openExternal ?? (async () => {}),
-  } as any);
+  });
   const workerTaskSessionService = createWorkerTaskSessionServiceImpl({
     db: args.db,
     projectId: args.projectId,
   });
   const workerHeartbeatService = createHeadlessWorkerHeartbeatService();
   const agentChatService = createHeadlessAgentChatService(args.projectRoot);
-  if (
-    typeof (prService as { setAgentChatService?: (svc: unknown) => void })
-      .setAgentChatService === "function"
-  ) {
-    (
-      prService as { setAgentChatService: (svc: unknown) => void }
-    ).setAgentChatService(agentChatService as never);
-  }
   const closeoutService = createLinearCloseoutServiceImpl({
     issueTracker,
     outboundService,
@@ -1840,7 +1840,7 @@ export function createHeadlessLinearServices(
     issueTracker,
     workerAgentService: args.workerAgentService,
     workerHeartbeatService,
-    agentChatService: agentChatService as never,
+    agentChatService,
     laneService: args.laneService,
     templateService,
     closeoutService,

--- a/apps/ade-cli/src/tuiClient/__tests__/commands.test.ts
+++ b/apps/ade-cli/src/tuiClient/__tests__/commands.test.ts
@@ -481,7 +481,7 @@ describe("linear command routing", () => {
     ).toMatchObject({
       kind: "usage",
       title: "Linear GraphQL",
-      body: expect.stringContaining("--max-retries must be a number"),
+      body: expect.stringContaining("'maxRetries' must be a number"),
     });
   });
 

--- a/apps/ade-cli/src/tuiClient/__tests__/commands.test.ts
+++ b/apps/ade-cli/src/tuiClient/__tests__/commands.test.ts
@@ -447,7 +447,7 @@ describe("linear command routing", () => {
 
   it("routes /linear graphql through the linear_issue_tracker action domain", () => {
     expect(
-      buildLinearToolRequest("graphql --query 'query Viewer { viewer { id } }' --variables-json '{\"first\":10}'"),
+      buildLinearToolRequest("graphql --query 'query Viewer { viewer { id } }' --variables-json '{\"first\":10}' --max-retries 99"),
     ).toEqual({
       kind: "action",
       title: "Linear GraphQL",
@@ -456,6 +456,7 @@ describe("linear command routing", () => {
       args: {
         query: "query Viewer { viewer { id } }",
         variables: { first: 10 },
+        maxRetries: 10,
       },
     });
   });
@@ -474,6 +475,13 @@ describe("linear command routing", () => {
       kind: "usage",
       title: "Linear GraphQL",
       body: expect.stringContaining("--variables-json must be a JSON object"),
+    });
+    expect(
+      buildLinearToolRequest("graphql --query 'query Viewer { viewer { id } }' --max-retries nope"),
+    ).toMatchObject({
+      kind: "usage",
+      title: "Linear GraphQL",
+      body: expect.stringContaining("--max-retries must be a number"),
     });
   });
 

--- a/apps/ade-cli/src/tuiClient/linearCommands.ts
+++ b/apps/ade-cli/src/tuiClient/linearCommands.ts
@@ -1,3 +1,5 @@
+import { parseLinearGraphQLInput } from "../../../desktop/src/main/services/cto/linearGraphQLInput";
+
 export type LinearToolRequest =
   | {
       kind: "tool";
@@ -308,11 +310,19 @@ export function buildLinearToolRequest(input: string): LinearToolRequest {
         `${variables.message}\nUsage: /linear graphql --query 'query { viewer { id name } }' [--variables-json '{\"id\":\"...\"}']`,
       );
     }
-    return action("Linear GraphQL", "linear_issue_tracker", "graphql", {
-      query,
-      variables: variables.variables,
-      operationName: optionString(options, "operationName", "operation") ?? undefined,
-    });
+    try {
+      return action("Linear GraphQL", "linear_issue_tracker", "graphql", parseLinearGraphQLInput({
+        query,
+        variables: variables.variables,
+        operationName: optionString(options, "operationName", "operation") ?? undefined,
+        maxRetries: options.maxRetries,
+      }));
+    } catch (error) {
+      return usage(
+        "Linear GraphQL",
+        `${error instanceof Error ? error.message : String(error)}\nUsage: /linear graphql --query 'query { viewer { id name } }' [--variables-json '{\"id\":\"...\"}']`,
+      );
+    }
   }
 
   if (group === "create-from" || group === "create-from-linear" || group === "create-lane-from") {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -162,7 +162,7 @@ import { createLinearIntakeService } from "./services/cto/linearIntakeService";
 import { createLinearOutboundService } from "./services/cto/linearOutboundService";
 import { createLinearCloseoutService } from "./services/cto/linearCloseoutService";
 import { createLinearDispatcherService } from "./services/cto/linearDispatcherService";
-import { publishLinearChatSessionCard, publishLinearLaneCard } from "./services/cto/linearLaneCardService";
+import { createLinearChatLinkPublisher, publishLinearLaneCard } from "./services/cto/linearLaneCardService";
 import { createLinearIngressService } from "./services/cto/linearIngressService";
 import { createLinearSyncService } from "./services/cto/linearSyncService";
 import { createOrchestrationService } from "./services/orchestration/orchestrationService";
@@ -1792,8 +1792,11 @@ app.whenReady().then(async () => {
       null;
     let linearIssueTrackerRef: LinearIssueTracker | null = null;
     let linearLiveStatusServiceRef: LinearLiveStatusService | null = null;
-    const linearChatCardPublishKeys = new Set<string>();
     const linearLiveStatusLaunchKeys = new Set<string>();
+    const publishLinearChatCard = createLinearChatLinkPublisher({
+      getIssueTracker: () => linearIssueTrackerRef,
+      log: (event, fields) => logger.warn(event, fields),
+    });
     const publishLinearChatLink = ({ laneId, sessionId, sessionTitle, issue, linkedAt }: {
       laneId: string;
       sessionId: string;
@@ -1801,29 +1804,9 @@ app.whenReady().then(async () => {
       issue: LaneLinearIssue;
       linkedAt: string;
     }) => {
-      const tracker = linearIssueTrackerRef;
-      if (!tracker) return;
+      if (!linearIssueTrackerRef) return;
       const key = `${issue.id}:${sessionId}`;
-      if (!linearChatCardPublishKeys.has(key)) {
-        linearChatCardPublishKeys.add(key);
-        void publishLinearChatSessionCard({
-          issueTracker: tracker,
-          issue,
-          laneId,
-          sessionId,
-          sessionTitle,
-          linkedAt,
-        }).catch((error) => {
-          linearChatCardPublishKeys.delete(key);
-          logger.warn("linear.chat_session_card_publish_failed", {
-            laneId,
-            sessionId,
-            issueId: issue.id,
-            issueIdentifier: issue.identifier,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        });
-      }
+      publishLinearChatCard({ laneId, sessionId, sessionTitle, issue, linkedAt });
       // Agent launched against a Linear issue → reflect status into Linear
       // (no-op unless the live round-trip flag is set).
       const liveStatusService = linearLiveStatusServiceRef;

--- a/apps/desktop/src/main/services/adeActions/registry.test.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.test.ts
@@ -406,6 +406,7 @@ describe("runtime Linear issue tracker actions", () => {
       query: "query Viewer { viewer { id } }",
       maxRetries: 10,
     });
+    expect(tracker.getConnectionStatus).toHaveBeenCalledTimes(2);
     await expect(service.getWorkflowCatalog()).resolves.toEqual({ users, labels, states });
     await expect(service.getIssuePickerData()).resolves.toEqual({ projects, users, states });
   });

--- a/apps/desktop/src/main/services/adeActions/registry.test.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.test.ts
@@ -381,13 +381,12 @@ describe("runtime Linear issue tracker actions", () => {
       getIssuePickerData: () => Promise<unknown>;
       listIssues: (args?: Record<string, unknown>) => Promise<unknown>;
       graphql: (args?: Record<string, unknown>) => Promise<unknown>;
-      runGraphQL: (args?: Record<string, unknown>) => Promise<unknown>;
     } & Record<string, unknown>;
 
     expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("getStatus");
     expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("listIssues");
     expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("graphql");
-    expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("runGraphQL");
+    expect(listAllowedAdeActionNames("linear_issue_tracker", service)).not.toContain("runGraphQL");
     expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("getWorkflowCatalog");
     expect(listAllowedAdeActionNames("linear_issue_tracker", service)).toContain("getIssuePickerData");
     await expect(service.getStatus()).resolves.toMatchObject({ connected: true, tokenStored: true });
@@ -400,15 +399,46 @@ describe("runtime Linear issue tracker actions", () => {
       query: "query Viewer { viewer { id } }",
       variables: { first: 1 },
     });
-    await expect(service.runGraphQL({ query: "query Viewer { viewer { id } }", variables: { first: 2 } })).resolves.toEqual({
-      data: { query: "query Viewer { viewer { id } }", variables: { first: 2 } },
+    await expect(service.graphql({ query: "query Viewer { viewer { id } }", maxRetries: 99 })).resolves.toEqual({
+      data: { query: "query Viewer { viewer { id } }", maxRetries: 10 },
     });
     expect(tracker.runGraphQL).toHaveBeenLastCalledWith({
       query: "query Viewer { viewer { id } }",
-      variables: { first: 2 },
+      maxRetries: 10,
     });
     await expect(service.getWorkflowCatalog()).resolves.toEqual({ users, labels, states });
     await expect(service.getIssuePickerData()).resolves.toEqual({ projects, users, states });
+  });
+
+  it("prechecks Linear connection before GraphQL actions", async () => {
+    const tracker = {
+      getConnectionStatus: vi.fn(async () => ({
+        connected: false,
+        viewerId: null,
+        viewerName: null,
+        message: "Linear token not configured.",
+      })),
+      runGraphQL: vi.fn(async () => ({})),
+    };
+    const runtime = {
+      linearCredentialService: {
+        getStatus: vi.fn(() => ({
+          tokenStored: true,
+          authMode: "oauth",
+          oauthConfigured: true,
+          tokenExpiresAt: null,
+        })),
+      },
+      linearIssueTracker: tracker,
+    } as unknown as Parameters<typeof getAdeActionDomainServices>[0];
+    const service = getAdeActionDomainServices(runtime).linear_issue_tracker as {
+      graphql: (args?: Record<string, unknown>) => Promise<unknown>;
+    };
+
+    await expect(service.graphql({ query: "query Viewer { viewer { id } }" })).rejects.toThrow(
+      "Linear is not connected: Linear token not configured.",
+    );
+    expect(tracker.runGraphQL).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -2471,10 +2471,14 @@ function buildGithubDomainService(runtime: AdeRuntime): OpaqueService | null {
 function buildLinearIssueTrackerDomainService(runtime: AdeRuntime): OpaqueService | null {
   const tracker = runtime.linearIssueTracker;
   if (!tracker) return null;
+  const connectionPrecheckCache: LinearConnectionPrecheckCache = {
+    checkedAt: 0,
+    connection: null,
+  };
   return {
     ...(tracker as unknown as OpaqueService),
     async graphql(args?: unknown) {
-      await requireRuntimeLinearConnection(runtime);
+      await requireRuntimeLinearConnection(runtime, connectionPrecheckCache);
       return tracker.runGraphQL(parseLinearGraphQLInput(asActionRecord(args)));
     },
     async getStatus() {
@@ -2596,9 +2600,36 @@ async function buildRuntimeLinearConnectionStatus(runtime: AdeRuntime): Promise<
   }
 }
 
-async function requireRuntimeLinearConnection(runtime: AdeRuntime): Promise<LinearConnectionStatus> {
+const LINEAR_CONNECTION_PRECHECK_TTL_MS = 30_000;
+
+type LinearConnectionPrecheckCache = {
+  checkedAt: number;
+  connection: LinearConnectionStatus | null;
+};
+
+async function requireRuntimeLinearConnection(
+  runtime: AdeRuntime,
+  cache?: LinearConnectionPrecheckCache,
+): Promise<LinearConnectionStatus> {
+  const now = Date.now();
+  if (
+    cache?.connection?.connected
+    && now - cache.checkedAt < LINEAR_CONNECTION_PRECHECK_TTL_MS
+  ) {
+    return cache.connection;
+  }
   const connection = await buildRuntimeLinearConnectionStatus(runtime);
-  if (connection.connected) return connection;
+  if (connection.connected) {
+    if (cache) {
+      cache.connection = connection;
+      cache.checkedAt = now;
+    }
+    return connection;
+  }
+  if (cache) {
+    cache.connection = null;
+    cache.checkedAt = 0;
+  }
   const message = connection.message?.trim();
   const error = new Error(message ? `Linear is not connected: ${message}` : "Linear is not connected.");
   Object.assign(error, { code: "LINEAR_NOT_CONNECTED", connection });

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -77,6 +77,7 @@ import { launchPrIssueResolutionChat, previewPrIssueResolutionPrompt } from "../
 import { launchRebaseResolutionChat } from "../prs/prRebaseResolver";
 import { mapPermissionModeForModelFamily } from "../prs/resolverUtils";
 import { getErrorMessage, isRecord, nowIso } from "../shared/utils";
+import { parseLinearGraphQLInput } from "../cto/linearGraphQLInput";
 import { resolveCodexExecutable } from "../ai/codexExecutable";
 import {
   buildResumeArgv,
@@ -609,7 +610,6 @@ export const ADE_ACTION_ALLOWLIST: Partial<Record<AdeActionDomain, readonly stri
     "listWorkflowStates",
     "listUsers",
     "removeIssueLabel",
-    "runGraphQL",
     "searchIssues",
     "updateComment",
     "updateIssueAssignee",
@@ -2474,10 +2474,8 @@ function buildLinearIssueTrackerDomainService(runtime: AdeRuntime): OpaqueServic
   return {
     ...(tracker as unknown as OpaqueService),
     async graphql(args?: unknown) {
-      return tracker.runGraphQL(readLinearGraphQLActionArgs(args));
-    },
-    async runGraphQL(args?: unknown) {
-      return tracker.runGraphQL(readLinearGraphQLActionArgs(args));
+      await requireRuntimeLinearConnection(runtime);
+      return tracker.runGraphQL(parseLinearGraphQLInput(asActionRecord(args)));
     },
     async getStatus() {
       return buildRuntimeLinearConnectionStatus(runtime);
@@ -2528,34 +2526,6 @@ function buildLinearIssueTrackerDomainService(runtime: AdeRuntime): OpaqueServic
       ]);
       return { projects, users, states };
     },
-  };
-}
-
-function readLinearGraphQLActionArgs(args?: unknown): {
-  query: string;
-  variables?: Record<string, unknown>;
-  operationName?: string | null;
-  maxRetries?: number;
-} {
-  const actionArgs = asActionRecord(args);
-  const query = requireNonEmptyString(actionArgs.query, "query");
-  const variables = actionArgs.variables;
-  if (variables != null && !isRecord(variables)) {
-    throw new Error("Expected 'variables' to be a JSON object when provided.");
-  }
-  const operationName =
-    typeof actionArgs.operationName === "string" && actionArgs.operationName.trim().length
-      ? actionArgs.operationName.trim()
-      : null;
-  const maxRetries =
-    typeof actionArgs.maxRetries === "number" && Number.isFinite(actionArgs.maxRetries)
-      ? Math.max(0, Math.min(10, Math.floor(actionArgs.maxRetries)))
-      : undefined;
-  return {
-    query,
-    ...(variables ? { variables } : {}),
-    ...(operationName ? { operationName } : {}),
-    ...(maxRetries !== undefined ? { maxRetries } : {}),
   };
 }
 
@@ -2624,6 +2594,15 @@ async function buildRuntimeLinearConnectionStatus(runtime: AdeRuntime): Promise<
       ),
     };
   }
+}
+
+async function requireRuntimeLinearConnection(runtime: AdeRuntime): Promise<LinearConnectionStatus> {
+  const connection = await buildRuntimeLinearConnectionStatus(runtime);
+  if (connection.connected) return connection;
+  const message = connection.message?.trim();
+  const error = new Error(message ? `Linear is not connected: ${message}` : "Linear is not connected.");
+  Object.assign(error, { code: "LINEAR_NOT_CONNECTED", connection });
+  throw error;
 }
 
 function formatLinearConnectionMessage(

--- a/apps/desktop/src/main/services/cto/linearAuth.test.ts
+++ b/apps/desktop/src/main/services/cto/linearAuth.test.ts
@@ -781,6 +781,32 @@ describe("linearClient", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  it("does not retry non-retryable GraphQL validation errors", async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          errors: [{ message: "Cannot query field \"wat\" on type \"Query\"." }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    const client = createLinearClient({
+      credentials: {
+        getTokenOrThrow: () => "Bearer test-token",
+        getStatus: () => ({ authMode: "oauth" }),
+      } as any,
+      fetchImpl: fetchImpl as any,
+      logger: null,
+    });
+
+    await expect(client.runGraphQL({
+      query: "query Broken { wat }",
+      maxRetries: 4,
+    })).rejects.toThrow("Cannot query field");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("loads connection identity with the authorized Linear workspace", async () => {
     const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
       expect(init?.headers).toMatchObject({ authorization: "Bearer test-token" });

--- a/apps/desktop/src/main/services/cto/linearClient.ts
+++ b/apps/desktop/src/main/services/cto/linearClient.ts
@@ -224,8 +224,9 @@ export function createLinearClient(args: LinearClientArgs) {
         args.credentials.getTokenOrThrow(),
         args.credentials.getStatus().authMode
       );
+      let res: Response;
       try {
-        const res = await fetchImpl(LINEAR_GRAPHQL_URL, {
+        res = await fetchImpl(LINEAR_GRAPHQL_URL, {
           method: "POST",
           headers: {
             "content-type": "application/json",
@@ -237,50 +238,51 @@ export function createLinearClient(args: LinearClientArgs) {
             ...(params.operationName ? { operationName: params.operationName } : {}),
           }),
         });
-
-        const payload = await res.json().catch(() => ({})) as {
-          data?: TData;
-          errors?: Array<{ message?: string; extensions?: { code?: string } }>;
-        };
-
-        const message = payload.errors?.[0]?.message ?? null;
-        const errorCode = payload.errors?.[0]?.extensions?.code ?? null;
-
-        // Reactive refresh: if the access token was rejected, refresh once and
-        // retry with the new token (covers a token already expired by the time
-        // the request fired, or one with no recorded expiry).
-        const isAuthError =
-          res.status === 401 ||
-          errorCode === "AUTHENTICATION_ERROR" ||
-          (message ? /authentication|unauthor|invalid.*token|token.*expired/i.test(message) : false);
-        if (isAuthError && !didAuthRefresh && args.credentials.getStatus().authMode === "oauth") {
-          didAuthRefresh = true;
-          await ensureFreshAuth({ force: true });
-          continue;
-        }
-
-        const isRateLimited =
-          res.status === 429 ||
-          errorCode === "RATELIMITED" ||
-          (message ? /rate\s*limit|too\s*many\s*requests/i.test(message) : false);
-
-        if ((!res.ok || payload.errors?.length) && (isRateLimited || res.status >= 500) && attempt <= maxRetries) {
-          await sleep(backoffMs);
-          backoffMs = Math.min(15_000, Math.floor(backoffMs * 2));
-          continue;
-        }
-
-        if (!res.ok || payload.errors?.length || !payload.data) {
-          const detail = message ?? `Linear GraphQL request failed (HTTP ${res.status})`;
-          throw new Error(detail);
-        }
-
-        return payload.data;
       } catch (error) {
         if (attempt > maxRetries) throw error;
         await sleep(backoffMs);
         backoffMs = Math.min(15_000, Math.floor(backoffMs * 2));
+        continue;
       }
+
+      const payload = await res.json().catch(() => ({})) as {
+        data?: TData;
+        errors?: Array<{ message?: string; extensions?: { code?: string } }>;
+      };
+
+      const message = payload.errors?.[0]?.message ?? null;
+      const errorCode = payload.errors?.[0]?.extensions?.code ?? null;
+
+      // Reactive refresh: if the access token was rejected, refresh once and
+      // retry with the new token (covers a token already expired by the time
+      // the request fired, or one with no recorded expiry).
+      const isAuthError =
+        res.status === 401 ||
+        errorCode === "AUTHENTICATION_ERROR" ||
+        (message ? /authentication|unauthor|invalid.*token|token.*expired/i.test(message) : false);
+      if (isAuthError && !didAuthRefresh && args.credentials.getStatus().authMode === "oauth") {
+        didAuthRefresh = true;
+        await ensureFreshAuth({ force: true });
+        continue;
+      }
+
+      const isRateLimited =
+        res.status === 429 ||
+        errorCode === "RATELIMITED" ||
+        (message ? /rate\s*limit|too\s*many\s*requests/i.test(message) : false);
+
+      if ((!res.ok || payload.errors?.length) && (isRateLimited || res.status >= 500) && attempt <= maxRetries) {
+        await sleep(backoffMs);
+        backoffMs = Math.min(15_000, Math.floor(backoffMs * 2));
+        continue;
+      }
+
+      if (!res.ok || payload.errors?.length || !payload.data) {
+        const detail = message ?? `Linear GraphQL request failed (HTTP ${res.status})`;
+        throw new Error(detail);
+      }
+
+      return payload.data;
     }
   };
 

--- a/apps/desktop/src/main/services/cto/linearDispatcherService.ts
+++ b/apps/desktop/src/main/services/cto/linearDispatcherService.ts
@@ -23,7 +23,6 @@ import type {
 } from "../../../shared/types";
 import type { AdeDb } from "../state/kvDb";
 import { nowIso, safeJsonParse } from "../shared/utils";
-import type { createAgentChatService } from "../chat/agentChatService";
 import type { createLaneService } from "../lanes/laneService";
 import type { createPrService } from "../prs/prService";
 import type { createWorkerHeartbeatService } from "./workerHeartbeatService";
@@ -109,6 +108,35 @@ type StepRow = {
   started_at: string | null;
   completed_at: string | null;
   payload_json: string | null;
+};
+
+type LinearDispatcherAgentChatSummary = {
+  sessionId: string;
+  laneId: string;
+  identityKey?: string;
+  status: string;
+  lastActivityAt: string;
+};
+
+type LinearDispatcherAgentChatSession = {
+  id: string;
+  laneId: string;
+  identityKey?: string;
+  status: string;
+  lastActivityAt: string;
+};
+
+type LinearDispatcherAgentChatService = {
+  listSessions(): Promise<LinearDispatcherAgentChatSummary[]>;
+  ensureIdentitySession(args: {
+    identityKey: AgentChatIdentityKey;
+    laneId: string;
+    modelId?: string | null;
+    reasoningEffort?: string | null;
+    reuseExisting?: boolean;
+    permissionMode?: string;
+  }): Promise<LinearDispatcherAgentChatSession>;
+  sendMessage(args: { sessionId: string; text: string }): Promise<void>;
 };
 
 type EventRow = {
@@ -227,7 +255,7 @@ export function createLinearDispatcherService(args: {
   issueTracker: IssueTracker;
   workerAgentService: WorkerAgentService;
   workerHeartbeatService: ReturnType<typeof createWorkerHeartbeatService>;
-  agentChatService: ReturnType<typeof createAgentChatService>;
+  agentChatService: LinearDispatcherAgentChatService;
   laneService: ReturnType<typeof createLaneService>;
   templateService: LinearTemplateService;
   closeoutService: LinearCloseoutService;

--- a/apps/desktop/src/main/services/cto/linearGraphQLInput.ts
+++ b/apps/desktop/src/main/services/cto/linearGraphQLInput.ts
@@ -1,0 +1,56 @@
+export const LINEAR_GRAPHQL_MAX_RETRIES = 10;
+
+export type LinearGraphQLInput = {
+  query: string;
+  variables?: Record<string, unknown>;
+  operationName?: string;
+  maxRetries?: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function parseMaxRetries(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim().length > 0
+        ? Number(value)
+        : Number.NaN;
+  if (!Number.isFinite(parsed)) {
+    throw new Error("--max-retries must be a number.");
+  }
+  return Math.max(0, Math.min(LINEAR_GRAPHQL_MAX_RETRIES, Math.floor(parsed)));
+}
+
+export function parseLinearGraphQLInput(raw: unknown): LinearGraphQLInput {
+  if (!isRecord(raw)) {
+    throw new Error("GraphQL input must be a JSON object.");
+  }
+
+  const query = optionalString(raw.query);
+  if (!query) {
+    throw new Error("GraphQL query is required.");
+  }
+
+  const variables = raw.variables;
+  if (variables != null && !isRecord(variables)) {
+    throw new Error("--variables-json must be a JSON object.");
+  }
+
+  const operationName = optionalString(raw.operationName);
+  const maxRetries = parseMaxRetries(raw.maxRetries);
+
+  return {
+    query,
+    ...(variables != null ? { variables } : {}),
+    ...(operationName ? { operationName } : {}),
+    ...(maxRetries !== undefined ? { maxRetries } : {}),
+  };
+}

--- a/apps/desktop/src/main/services/cto/linearGraphQLInput.ts
+++ b/apps/desktop/src/main/services/cto/linearGraphQLInput.ts
@@ -24,7 +24,7 @@ function parseMaxRetries(value: unknown): number | undefined {
         ? Number(value)
         : Number.NaN;
   if (!Number.isFinite(parsed)) {
-    throw new Error("--max-retries must be a number.");
+    throw new Error("'maxRetries' must be a number (--max-retries).");
   }
   return Math.max(0, Math.min(LINEAR_GRAPHQL_MAX_RETRIES, Math.floor(parsed)));
 }
@@ -41,7 +41,7 @@ export function parseLinearGraphQLInput(raw: unknown): LinearGraphQLInput {
 
   const variables = raw.variables;
   if (variables != null && !isRecord(variables)) {
-    throw new Error("--variables-json must be a JSON object.");
+    throw new Error("'variables' must be a JSON object (--variables-json).");
   }
 
   const operationName = optionalString(raw.operationName);

--- a/apps/desktop/src/main/services/cto/linearLaneCardService.test.ts
+++ b/apps/desktop/src/main/services/cto/linearLaneCardService.test.ts
@@ -6,6 +6,7 @@ import {
   buildLinearChatSessionAttachment,
   buildLinearIssueQuickViewAttachment,
   buildLinearPrCardAttachment,
+  createLinearChatLinkPublisher,
   publishLinearChatSessionCard,
   publishLinearIssueQuickViewAttachment,
   publishLinearLaneCard,
@@ -214,6 +215,26 @@ describe("linearLaneCardService", () => {
       title: "Open ADE chat: ABC-42",
       url: "ade://session/session-1?lane=lane-1",
     }));
+  });
+
+  it("dedupes chat session card publishing per issue and session", async () => {
+    const createIssueAttachment = vi.fn(async () => ({ id: "attachment-chat", url: "ade://session/session-1?lane=lane-1" }));
+    const publisher = createLinearChatLinkPublisher({
+      getIssueTracker: () => ({ createIssueAttachment } as any),
+    });
+
+    const args = {
+      issue: makeIssue(),
+      laneId: "lane-1",
+      sessionId: "session-1",
+      sessionTitle: "Investigate sync flakes",
+      linkedAt: "2026-05-12T20:15:00.000Z",
+    };
+    publisher(args);
+    publisher(args);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(createIssueAttachment).toHaveBeenCalledTimes(1);
   });
 
   it("returns null comment when repo is unknown", () => {

--- a/apps/desktop/src/main/services/cto/linearLaneCardService.ts
+++ b/apps/desktop/src/main/services/cto/linearLaneCardService.ts
@@ -422,3 +422,46 @@ export async function publishLinearChatSessionCard(args: {
     }),
   );
 }
+
+export function createLinearChatLinkPublisher(args: {
+  getIssueTracker: () => IssueTracker | null | undefined;
+  log?: (event: string, fields: Record<string, unknown>) => void;
+}) {
+  const publishKeys = new Set<string>();
+  return ({
+    laneId,
+    sessionId,
+    sessionTitle,
+    issue,
+    linkedAt,
+  }: {
+    laneId: string;
+    sessionId: string;
+    sessionTitle?: string | null;
+    issue: LinearIssueCardIssue;
+    linkedAt: string;
+  }): void => {
+    const issueTracker = args.getIssueTracker();
+    if (!issueTracker) return;
+    const key = `${issue.id}:${sessionId}`;
+    if (publishKeys.has(key)) return;
+    publishKeys.add(key);
+    void publishLinearChatSessionCard({
+      issueTracker,
+      issue,
+      laneId,
+      sessionId,
+      sessionTitle,
+      linkedAt,
+    }).catch((error) => {
+      publishKeys.delete(key);
+      args.log?.("linear.chat_session_card_publish_failed", {
+        laneId,
+        sessionId,
+        issueId: issue.id,
+        issueIdentifier: issue.identifier,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  };
+}


### PR DESCRIPTION
Fixes ADE-81

## Summary

Hardens the user-facing Linear GraphQL path and removes duplicated Linear plumbing. GraphQL validation errors now fail fast instead of retrying, disconnected projects get a typed connection precheck, and CLI/TUI/ADE action GraphQL arguments share one parser.

## What Changed

- Added `parseLinearGraphQLInput` with shared query/variables/operationName/maxRetries validation and a 0..10 retry cap.
- Refactored `linearClient` so only network/abort, auth refresh, 429/RATELIMITED, and 5xx paths retry; GraphQL validation errors throw once.
- Added a Linear connection-status precheck before the exposed `linear_issue_tracker.graphql` ADE action and removed the duplicate `runGraphQL` allowlist/action path.
- Extracted `createLinearChatLinkPublisher` to share chat-card publishing/dedupe between desktop and headless bootstrap.
- Narrowed dispatcher/headless service interfaces so the targeted `as any` / `as never` casts are replaced with concrete typed stubs.

## Validation

- `npm --prefix apps/ade-cli run typecheck`
- `npm --prefix apps/desktop run typecheck`
- `cd apps/desktop && npx vitest run src/main/services/cto/linearAuth.test.ts src/main/services/adeActions/registry.test.ts src/main/services/cto/linearLaneCardService.test.ts`
- `cd apps/ade-cli && npx vitest run src/cli.test.ts src/tuiClient/__tests__/commands.test.ts src/headlessLinearServices.test.ts`
- `npm --prefix apps/ade-cli run build`
- `npm --prefix apps/desktop run lint` (passed with existing warnings)
- `npm --prefix apps/desktop run build`
- `git diff --check`

## Risks

External automations using the removed `runGraphQL` ADE action name need to call `graphql` instead. The full CLI monolith remains outside this focused hardening pass; this change removes the duplicated Linear GraphQL parser path introduced by the user-facing command.

<!-- ade:linear-links v=1 -->
## Linear

- [ADE-81](https://linear.app/ade-linear/issue/ADE-81/linear-graphqlcli-hardening-non-retryable-retries-missing-connection)
<!-- /ade:linear-links -->

Open in ADE: https://ade-app.dev/open?type=pr&repo=arul28%2FADE&number=491

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the Linear GraphQL path by extracting shared input validation into `parseLinearGraphQLInput`, refactoring `linearClient` to fail fast on GraphQL validation errors while retrying only on network/auth/rate-limit/5xx conditions, adding a 30-second-TTL connection precheck before GraphQL actions, and eliminating duplicated plumbing (the `runGraphQL` ADE action alias, the inline `publishLinearChatLink` closure, and headless service `as any` / `as never` casts).

- **`linearGraphQLInput.ts`** (new): Centralised parser for query/variables/operationName/maxRetries shared across CLI, TUI, and registry paths; maxRetries is capped at 10.
- **`linearClient.ts`**: Network errors are now caught in a tightly-scoped try/catch around only `fetchImpl`; GraphQL validation errors (200 + `errors[]` with no retryable code) now throw immediately instead of burning retries.
- **`registry.ts` / `linearLaneCardService.ts`**: `runGraphQL` alias removed from the ADE action allowlist; `createLinearChatLinkPublisher` factory extracted so desktop and headless paths share one dedupe set; `LinearDispatcherAgentChatService` narrowed to the three methods actually used.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are well-scoped refactors backed by new tests, and the typecheck/build/vitest suite all pass.

The retry-logic restructuring in linearClient is mechanically correct: only the fetchImpl call is in the inner try/catch, payload.json() is guarded by .catch(() => ({})), and the auth-refresh / rate-limit / 5xx retry paths are preserved. Validation errors now fail fast as intended. The parseLinearGraphQLInput centralisation is consistent across CLI, TUI, and registry call sites. Removing runGraphQL from the allowlist is a breaking change for external callers, but it is explicitly documented in the PR risks section. The satisfies keyword on createHeadlessWorkerHeartbeatService replaces the as unknown as cast with a compile-time-verified stub.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/cto/linearClient.ts | Retry logic refactored: network errors caught in their own inner try/catch; GraphQL validation errors now throw once; rate-limit/5xx still retry with backoff. Logic is correct and a new test verifies the non-retryable path. |
| apps/desktop/src/main/services/cto/linearGraphQLInput.ts | New shared validation module; correctly validates query/variables/maxRetries with type narrowing, caps maxRetries at 10, and is reused across CLI, TUI, and registry paths. |
| apps/desktop/src/main/services/adeActions/registry.ts | Removed duplicate runGraphQL alias, added 30s connection precheck with TTL cache, delegated argument validation to parseLinearGraphQLInput. Clean and well-tested. |
| apps/desktop/src/main/services/cto/linearLaneCardService.ts | Extracted createLinearChatLinkPublisher factory to share chat-card dedupe logic between desktop and headless bootstrap; test covers dedupe behaviour. |
| apps/ade-cli/src/headlessLinearServices.ts | Large cleanup: removed handwritten HeadlessGitHubService/HeadlessLinearCredentialService duplicates in favour of canonical imported types; as any/as never casts replaced by satisfies and proper interface narrowing. |
| apps/desktop/src/main/services/cto/linearDispatcherService.ts | Removed full createAgentChatService import; local LinearDispatcherAgentChatService interface accurately captures the three methods actually called by the dispatcher. |
| apps/desktop/src/main/main.ts | Inline publishLinearChatLink closure replaced by createLinearChatLinkPublisher; outer wrapper preserved to gate the live-status launch on linearIssueTrackerRef. |
| apps/ade-cli/src/bootstrap.ts | Five as never casts removed; publishLinearChatLink closure replaced by the shared factory. Cleaner type surface. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CLI / TUI / Agent calls graphql()"] --> B["parseLinearGraphQLInput()"]
    B -->|invalid| C["throw immediately"]
    B -->|valid| D["requireRuntimeLinearConnection() 30s TTL"]
    D -->|disconnected| E["throw LINEAR_NOT_CONNECTED"]
    D -->|connected| F["tracker.runGraphQL()"]
    F --> G["attempt += 1"]
    G --> H["fetchImpl()"]
    H -->|network error| I{"attempt > maxRetries?"}
    I -->|yes| J["throw"]
    I -->|no| K["backoff + continue"]
    K --> G
    H -->|response| L["parse payload"]
    L --> M{"auth error + oauth?"}
    M -->|yes| N["ensureFreshAuth + continue"]
    N --> G
    M -->|no| O{"429 or 5xx + retries left?"}
    O -->|yes| P["backoff + continue"]
    P --> G
    O -->|no| Q{"ok + data + no errors?"}
    Q -->|yes| R["return data"]
    Q -->|no| S["throw once"]
```

<sub>Reviews (2): Last reviewed commit: ["Refs ADE-81: Address Linear GraphQL revi..."](https://github.com/arul28/ade/commit/ab2fe44df6e3f8368d836919a111f46201da1ff9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34779697)</sub>

<!-- /greptile_comment -->