### PR TITLE
Improve ADE responsiveness under large workloads

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, desktopCapturer, dialog, Menu, nativeImage, protocol, safeStorage, shell } from "electron";
+import { app, BrowserWindow, desktopCapturer, dialog, ipcMain, Menu, nativeImage, protocol, safeStorage, shell } from "electron";
 import { AsyncLocalStorage } from "node:async_hooks";
 import os from "node:os";
 import path from "node:path";
@@ -42,6 +42,11 @@ import { createSessionService } from "./services/sessions/sessionService";
 import { createSessionDeltaService } from "./services/sessions/sessionDeltaService";
 import { createPtyService } from "./services/pty/ptyService";
 import { createSupervisedPtyLoader } from "./services/pty/supervisedPtyHost";
+import {
+  normalizePtyDataSubscriptions,
+  setPtyDataSubscriptionsForSender,
+  shouldSendPtyDataToWebContents,
+} from "./services/pty/ptyDataSubscriptions";
 import {
   createProcessRegistryService,
   DEFAULT_PROCESS_REGISTRY_LIVENESS_WINDOW_MS,
@@ -91,6 +96,7 @@ import type {
   PortLease,
   PrEventPayload,
   ProjectInfo,
+  PtyDataEvent,
   SyncMobileProjectSummary,
   SyncProjectConnectionPayload,
   SyncProjectSwitchRequestPayload,
@@ -1012,6 +1018,24 @@ app.whenReady().then(async () => {
         win.webContents.send(channel, payload);
       } catch {
         // ignore
+      }
+    }
+  };
+
+  ipcMain.handle(IPC.ptyDataSubscriptions, (event, arg: { ptyIds?: unknown } | undefined) => {
+    setPtyDataSubscriptionsForSender(
+      event.sender,
+      normalizePtyDataSubscriptions(arg?.ptyIds),
+    );
+  });
+
+  const broadcastPtyData = (payload: PtyDataEvent) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!shouldSendPtyDataToWebContents(win.webContents, payload.ptyId)) continue;
+      try {
+        win.webContents.send(IPC.ptyData, payload);
+      } catch {
+        // ignore stale window sends
       }
     }
   };
@@ -2606,7 +2630,7 @@ app.whenReady().then(async () => {
       getAdeCliAgentEnv: adeCliService.agentEnv,
       logger,
       broadcastData: (ev) => {
-        broadcast(IPC.ptyData, ev);
+        broadcastPtyData(ev);
         const { projectRoot: _projectRoot, ...syncEvent } = ev;
         syncServiceRef?.handlePtyData(syncEvent);
       },

--- a/apps/desktop/src/main/services/chat/cursorSdkHooks.test.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkHooks.test.ts
@@ -118,7 +118,6 @@ describe("Cursor SDK hook installation", () => {
     try {
       ensureCursorSdkUserHook({ userHomeDir: home });
       const stdout = execFileSync("/bin/sh", [cursorSdkHookShellCommandPath(home)], {
-        input: "{}",
         env: {
           PATH: "",
           HOME: home,

--- a/apps/desktop/src/main/services/config/projectConfigService.test.ts
+++ b/apps/desktop/src/main/services/config/projectConfigService.test.ts
@@ -663,6 +663,37 @@ describe("projectConfigService - linear sync", () => {
   });
 });
 
+describe("projectConfigService - project UI", () => {
+  it("persists and merges the Linear batch launch default prompt", () => {
+    const { root, adeDir } = makeProjectFixture("ade-project-config-ui-");
+    const service = createProjectConfigService({
+      projectRoot: root,
+      adeDir,
+      projectId: "project-ui",
+      db: makeDb(),
+      logger: makeLogger(),
+    });
+
+    service.save({
+      shared: {
+        ui: {
+          linearBatchLaunchDefaultPrompt: "Shared prompt",
+        },
+      },
+      local: {
+        ui: {
+          linearBatchLaunchDefaultPrompt: "Local prompt",
+        },
+      },
+    });
+
+    const snapshot = service.get();
+    expect(snapshot.shared.ui?.linearBatchLaunchDefaultPrompt).toBe("Shared prompt");
+    expect(snapshot.local.ui?.linearBatchLaunchDefaultPrompt).toBe("Local prompt");
+    expect(snapshot.effective.ui?.linearBatchLaunchDefaultPrompt).toBe("Local prompt");
+  });
+});
+
 describe("projectConfigService - automation execution", () => {
   it("preserves lane creation fields from config", () => {
     const { root, adeDir } = makeProjectFixture("ade-project-config-automation-execution-");

--- a/apps/desktop/src/main/services/config/projectConfigService.ts
+++ b/apps/desktop/src/main/services/config/projectConfigService.ts
@@ -1897,6 +1897,14 @@ export function mergeAiConfig(sharedAi?: AiConfig, localAi?: Partial<AiConfig>):
   return Object.keys(out).length ? out : undefined;
 }
 
+function coerceProjectUiConfig(value: unknown): ProjectConfigFile["ui"] {
+  if (!isRecord(value)) return undefined;
+  const linearBatchLaunchDefaultPrompt = asString(value.linearBatchLaunchDefaultPrompt)?.trim();
+  return linearBatchLaunchDefaultPrompt
+    ? { linearBatchLaunchDefaultPrompt }
+    : undefined;
+}
+
 function coerceConfigFile(value: unknown): ProjectConfigFile {
   if (!isRecord(value)) {
     return {
@@ -1954,6 +1962,7 @@ function coerceConfigFile(value: unknown): ProjectConfigFile {
     : undefined;
   const ai = coerceAiConfig(value.ai);
   const linearSync = coerceLinearSync(value.linearSync);
+  const ui = coerceProjectUiConfig(value.ui);
 
   if (providersRaw) {
     delete providersRaw.mode;
@@ -1980,6 +1989,7 @@ function coerceConfigFile(value: unknown): ProjectConfigFile {
     ...(ai ? { ai } : {}),
     ...(providersRaw && Object.keys(providersRaw).length ? { providers: providersRaw } : {}),
     ...(linearSync ? { linearSync } : {}),
+    ...(ui ? { ui } : {}),
     ...(notifications ? { notifications } : {})
   };
 }
@@ -2059,6 +2069,7 @@ function toCanonicalYaml(config: ProjectConfigFile): string {
     ...(config.ai ? { ai: config.ai } : {}),
     ...(config.providers ? { providers: config.providers } : {}),
     ...(config.linearSync ? { linearSync: config.linearSync } : {}),
+    ...(config.ui ? { ui: config.ui } : {}),
     ...(config.notifications ? { notifications: config.notifications } : {})
   };
   return YAML.stringify(normalized, { indent: 2 });
@@ -2086,6 +2097,7 @@ function hasSharedConfigContent(config: ProjectConfigFile): boolean {
     || config.defaultLaneTemplate
     || (config.providers && Object.keys(config.providers).length > 0)
     || config.linearSync
+    || config.ui
     || config.notifications
   );
 }
@@ -2398,6 +2410,12 @@ function resolveEffectiveConfig(shared: ProjectConfigFile, local: ProjectConfigF
 
   const mergedAi = mergeAiConfig(shared.ai, local.ai);
   const mergedLinearSync = mergeLinearSync(shared.linearSync, local.linearSync);
+  const mergedUi = shared.ui || local.ui
+    ? {
+        ...(shared.ui ?? {}),
+        ...(local.ui ?? {}),
+      }
+    : undefined;
   const mergedNotifications = mergeNotificationsConfig(shared.notifications, local.notifications);
 
   const environments = [...(shared.environments ?? []), ...(local.environments ?? [])];
@@ -2450,6 +2468,7 @@ function resolveEffectiveConfig(shared: ProjectConfigFile, local: ProjectConfigF
     ...(effectiveAi ? { ai: effectiveAi } : {}),
     ...(mergedProviders ? { providers: mergedProviders } : {}),
     ...(mergedLinearSync ? { linearSync: mergedLinearSync } : {}),
+    ...(mergedUi ? { ui: mergedUi } : {}),
     ...(mergedNotifications ? { notifications: mergedNotifications } : {})
   };
 }

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -25,7 +25,7 @@ import {
 import { launchAgentChatCli } from "../chat/agentChatCliLaunch";
 import { runGit } from "../git/git";
 import type { AdeCleanupResult, AdeProjectSnapshot, IosSimulatorWindowState } from "../../../shared/types";
-import { toRecentProjectSummary } from "../projects/recentProjectSummary";
+import { toShallowRecentProjectSummary } from "../projects/recentProjectSummary";
 import type {
   ApplyConflictProposalArgs,
   BatchAssessmentResult,
@@ -3574,7 +3574,7 @@ export function registerIpc({
     ) {
       return recentProjectSummaryCache.rows;
     }
-    const rows = entries.map(toRecentProjectSummary);
+    const rows = entries.map(toShallowRecentProjectSummary);
     recentProjectSummaryCache = {
       signature,
       rows,

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.ts
@@ -36,6 +36,7 @@ import { RemoteTargetRegistry } from "../remoteRuntime/remoteTargetRegistry";
 import { runGit } from "../git/git";
 import { getProjectWorkSummary } from "../projects/projectDetailService";
 import { readGlobalState } from "../state/globalState";
+import { shouldSendPtyDataToWebContents } from "../pty/ptyDataSubscriptions";
 
 type RuntimeBridgeArgs = {
   appVersion: string;
@@ -321,6 +322,21 @@ export function registerRuntimeBridge({
     });
   };
 
+  const shouldForwardRuntimeEvent = (
+    sender: WebContents,
+    event: RemoteRuntimeBufferedEvent,
+  ): boolean => {
+    if (event.category !== "pty") return true;
+    if (event.payload.type !== "pty_data") return true;
+    const ptyEvent = isObjectRecord(event.payload.event)
+      ? event.payload.event
+      : null;
+    const ptyId = typeof ptyEvent?.ptyId === "string"
+      ? ptyEvent.ptyId
+      : "";
+    return !ptyId || shouldSendPtyDataToWebContents(sender, ptyId);
+  };
+
   const sendRuntimeEvent = (
     sender: WebContents,
     bindingKey: string,
@@ -335,6 +351,7 @@ export function registerRuntimeBridge({
       sender.isDestroyed()
     )
       return;
+    if (!shouldForwardRuntimeEvent(sender, event)) return;
     const payload: RemoteRuntimeEventNotificationPayload = {
       bindingKey,
       event,

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.ts
@@ -35,7 +35,6 @@ import { discoverLanRuntimes } from "../remoteRuntime/runtimeDiscovery";
 import { RemoteTargetRegistry } from "../remoteRuntime/remoteTargetRegistry";
 import { runGit } from "../git/git";
 import { getProjectWorkSummary } from "../projects/projectDetailService";
-import { toRecentProjectSummary } from "../projects/recentProjectSummary";
 import { readGlobalState } from "../state/globalState";
 
 type RuntimeBridgeArgs = {
@@ -963,7 +962,7 @@ export function registerRuntimeBridge({
         .slice(0, 100)
         .map((entry) => ({
           rootPath: entry.rootPath,
-          displayName: toRecentProjectSummary(entry).displayName,
+          displayName: entry.displayName,
         }));
       const localRuntimeProjects = localRuntimeConnectionPool
         ? await localRuntimeConnectionPool

--- a/apps/desktop/src/main/services/projects/projectLifecycle.test.ts
+++ b/apps/desktop/src/main/services/projects/projectLifecycle.test.ts
@@ -8,7 +8,7 @@ import { buildAdeGitignore, resolveAdeLayout } from "../../../shared/adeLayout";
 import { createAdeProjectService, initializeOrRepairAdeProject } from "./adeProjectService";
 import { browseProjectDirectories } from "./projectBrowserService";
 import { __internal, getProjectDetail } from "./projectDetailService";
-import { inspectRecentProject, toRecentProjectSummary } from "./recentProjectSummary";
+import { inspectRecentProject, toRecentProjectSummary, toShallowRecentProjectSummary } from "./recentProjectSummary";
 import { openKvDb } from "../state/kvDb";
 import { createProjectConfigService } from "../config/projectConfigService";
 
@@ -516,6 +516,25 @@ describe("getProjectDetail", () => {
 // ---------------------------------------------------------------------------
 
 describe("toRecentProjectSummary", () => {
+  it("keeps shallow recent-project rows free of lane scans", () => {
+    const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-recent-project-shallow-"));
+    tempDirs.push(projectRoot);
+    fs.mkdirSync(path.join(projectRoot, ".git", "worktrees", "lane-a"), { recursive: true });
+
+    const summary = toShallowRecentProjectSummary({
+      rootPath: projectRoot,
+      displayName: "demo",
+      lastOpenedAt: "2026-04-02T12:00:00.000Z",
+    });
+
+    expect(summary).toEqual({
+      rootPath: projectRoot,
+      displayName: "demo",
+      lastOpenedAt: "2026-04-02T12:00:00.000Z",
+      exists: true,
+    });
+  });
+
   it("prefers active ADE lanes over raw git worktree metadata", async () => {
     const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-recent-project-summary-"));
     tempDirs.push(projectRoot);

--- a/apps/desktop/src/main/services/projects/recentProjectSummary.ts
+++ b/apps/desktop/src/main/services/projects/recentProjectSummary.ts
@@ -169,6 +169,15 @@ export function inspectRecentProject(entry: RecentProjectEntry): RecentProjectIn
   };
 }
 
+export function toShallowRecentProjectSummary(entry: RecentProjectEntry): RecentProjectSummary {
+  return {
+    rootPath: entry.rootPath,
+    displayName: entry.displayName,
+    lastOpenedAt: entry.lastOpenedAt,
+    exists: fs.existsSync(entry.rootPath),
+  };
+}
+
 export function toRecentProjectSummary(entry: RecentProjectEntry): RecentProjectSummary {
   return inspectRecentProject(entry).summary;
 }

--- a/apps/desktop/src/main/services/pty/ptyDataSubscriptions.test.ts
+++ b/apps/desktop/src/main/services/pty/ptyDataSubscriptions.test.ts
@@ -1,0 +1,43 @@
+import type { WebContents } from "electron";
+import { describe, expect, it } from "vitest";
+
+import {
+  setPtyDataSubscriptionsForSender,
+  shouldSendPtyDataToWebContents,
+} from "./ptyDataSubscriptions";
+
+type TestWebContents = {
+  id: number;
+  once(event: string, listener: () => void): TestWebContents;
+  destroyForTest(): void;
+};
+
+function createWebContents(id: number): WebContents & { destroyForTest(): void } {
+  let onDestroyed: (() => void) | null = null;
+  const sender: TestWebContents = {
+    id,
+    once(event: string, listener: () => void): TestWebContents {
+      if (event === "destroyed") onDestroyed = listener;
+      return sender;
+    },
+    destroyForTest(): void {
+      onDestroyed?.();
+    },
+  };
+  return sender as unknown as WebContents & { destroyForTest(): void };
+}
+
+describe("ptyDataSubscriptions", () => {
+  it("filters registered subscribers without blocking unregistered windows", () => {
+    const subscribed = createWebContents(9001);
+    const unregistered = createWebContents(9002);
+
+    setPtyDataSubscriptionsForSender(subscribed, new Set(["pty-visible"]));
+
+    expect(shouldSendPtyDataToWebContents(subscribed, "pty-visible")).toBe(true);
+    expect(shouldSendPtyDataToWebContents(subscribed, "pty-hidden")).toBe(false);
+    expect(shouldSendPtyDataToWebContents(unregistered, "pty-hidden")).toBe(true);
+
+    subscribed.destroyForTest();
+  });
+});

--- a/apps/desktop/src/main/services/pty/ptyDataSubscriptions.ts
+++ b/apps/desktop/src/main/services/pty/ptyDataSubscriptions.ts
@@ -32,7 +32,7 @@ export function shouldSendPtyDataToWebContents(
   sender: WebContents,
   ptyId: string,
 ): boolean {
-  if (subscriptionsByWebContentsId.size === 0) return true;
   const subscriptions = subscriptionsByWebContentsId.get(sender.id);
+  if (!subscriptions) return true;
   return Boolean(subscriptions?.has(ptyId));
 }

--- a/apps/desktop/src/main/services/pty/ptyDataSubscriptions.ts
+++ b/apps/desktop/src/main/services/pty/ptyDataSubscriptions.ts
@@ -1,0 +1,38 @@
+import type { WebContents } from "electron";
+
+const subscriptionsByWebContentsId = new Map<number, Set<string>>();
+const cleanupRegistered = new Set<number>();
+
+export function normalizePtyDataSubscriptions(value: unknown): Set<string> {
+  const ids = new Set<string>();
+  if (!Array.isArray(value)) return ids;
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const id = item.trim();
+    if (id) ids.add(id);
+  }
+  return ids;
+}
+
+export function setPtyDataSubscriptionsForSender(
+  sender: WebContents,
+  ptyIds: Set<string>,
+): void {
+  const webContentsId = sender.id;
+  subscriptionsByWebContentsId.set(webContentsId, ptyIds);
+  if (cleanupRegistered.has(webContentsId)) return;
+  cleanupRegistered.add(webContentsId);
+  sender.once("destroyed", () => {
+    cleanupRegistered.delete(webContentsId);
+    subscriptionsByWebContentsId.delete(webContentsId);
+  });
+}
+
+export function shouldSendPtyDataToWebContents(
+  sender: WebContents,
+  ptyId: string,
+): boolean {
+  if (subscriptionsByWebContentsId.size === 0) return true;
+  const subscriptions = subscriptionsByWebContentsId.get(sender.id);
+  return Boolean(subscriptions?.has(ptyId));
+}

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -1651,6 +1651,7 @@ declare global {
           rows: number;
         }) => Promise<void>;
         dispose: (args: { ptyId: string; sessionId?: string }) => Promise<void>;
+        setDataSubscriptions: (args: { ptyIds: string[] }) => Promise<void>;
         onData: (cb: (ev: PtyDataEvent) => void) => () => void;
         onExit: (cb: (ev: PtyExitEvent) => void) => () => void;
       };

--- a/apps/desktop/src/preload/preload.test.ts
+++ b/apps/desktop/src/preload/preload.test.ts
@@ -3634,6 +3634,90 @@ describe("preload OAuth bridge", () => {
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
+  it("filters remote PTY data notifications to subscribed terminal ids", async () => {
+    const binding = {
+      kind: "remote",
+      key: "remote:target-1:project-1",
+      targetId: "target-1",
+      runtimeName: "Remote",
+      projectId: "project-1",
+      rootPath: "/remote/project",
+      displayName: "Project",
+    };
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === IPC.appGetWindowSession) {
+        return { windowId: 1, project: null, binding };
+      }
+      if (channel === IPC.remoteRuntimeStreamEvents) {
+        return { events: [], nextCursor: 0, hasMore: false };
+      }
+      return undefined;
+    });
+    const on = vi.fn();
+    const removeListener = vi.fn();
+    const exposeInMainWorld = vi.fn((name: string, value: unknown) => {
+      (globalThis as any).__bridgeName = name;
+      (globalThis as any).__adeBridge = value;
+    });
+
+    vi.doMock("electron", () => ({
+      contextBridge: { exposeInMainWorld },
+      ipcRenderer: { invoke, on, removeListener },
+      webFrame: {
+        getZoomLevel: vi.fn(() => 0),
+        setZoomLevel: vi.fn(),
+        getZoomFactor: vi.fn(() => 1),
+      },
+    }));
+
+    await import("./preload");
+
+    const bridge = (globalThis as any).__adeBridge;
+    await bridge.app.getWindowSession();
+
+    const callback = vi.fn();
+    bridge.pty.onData(callback);
+    await bridge.pty.setDataSubscriptions({ ptyIds: ["pty-visible"] });
+
+    expect(invoke).toHaveBeenCalledWith(IPC.ptyDataSubscriptions, {
+      ptyIds: ["pty-visible"],
+    });
+
+    const runtimeListener = on.mock.calls.find(([channel]) => channel === IPC.runtimeEvent)?.[1];
+    expect(typeof runtimeListener).toBe("function");
+    runtimeListener({}, {
+      bindingKey: binding.key,
+      event: {
+        id: 1,
+        timestamp: "2026-05-10T12:00:01.000Z",
+        category: "pty",
+        payload: {
+          type: "pty_data",
+          event: { ptyId: "pty-hidden", sessionId: "session-hidden", data: "hidden" },
+        },
+      },
+    });
+    runtimeListener({}, {
+      bindingKey: binding.key,
+      event: {
+        id: 2,
+        timestamp: "2026-05-10T12:00:02.000Z",
+        category: "pty",
+        payload: {
+          type: "pty_data",
+          event: { ptyId: "pty-visible", sessionId: "session-visible", data: "visible" },
+        },
+      },
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith({
+      ptyId: "pty-visible",
+      sessionId: "session-visible",
+      data: "visible",
+    });
+  });
+
   it("fans out remote macOS VM notifications from the live runtime event stream", async () => {
     const binding = {
       kind: "remote",

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1436,6 +1436,8 @@ const remoteLaneDiagnosticsEventCallbacks = new Set<
 >();
 const remotePtyDataEventCallbacks = new Set<(payload: PtyDataEvent) => void>();
 const remotePtyExitEventCallbacks = new Set<(payload: PtyExitEvent) => void>();
+let ptyDataSubscriptionsConfigured = false;
+let subscribedPtyDataIds = new Set<string>();
 const remoteProcessEventCallbacks = new Set<(payload: ProcessEvent) => void>();
 const remoteTestEventCallbacks = new Set<(payload: TestEvent) => void>();
 const remoteFileChangeEventCallbacks = new Set<
@@ -1622,6 +1624,31 @@ function hasRemoteRuntimeEventSubscribers(): boolean {
     remoteAppControlEventCallbacks.size > 0 ||
     remotePrAiResolutionEventCallbacks.size > 0
   );
+}
+
+function normalizePtyDataSubscriptionIds(value: unknown): Set<string> {
+  const ids = new Set<string>();
+  if (!Array.isArray(value)) return ids;
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const id = item.trim();
+    if (id) ids.add(id);
+  }
+  return ids;
+}
+
+function shouldDispatchPtyDataEvent(payload: PtyDataEvent): boolean {
+  if (!ptyDataSubscriptionsConfigured) return true;
+  return subscribedPtyDataIds.has(payload.ptyId);
+}
+
+async function setPtyDataSubscriptions(args: { ptyIds?: string[] }): Promise<void> {
+  ptyDataSubscriptionsConfigured = true;
+  subscribedPtyDataIds = normalizePtyDataSubscriptionIds(args?.ptyIds);
+  ensureRemoteRuntimeEventPump();
+  await ipcRenderer.invoke(IPC.ptyDataSubscriptions, {
+    ptyIds: [...subscribedPtyDataIds],
+  });
 }
 
 function ensureRemoteRuntimeEventPump(): void {
@@ -2110,6 +2137,7 @@ function dispatchRemoteRuntimeEventPayload(
 
   const ptyDataEvent = toWrappedEvent<PtyDataEvent>(payload, "pty_data");
   if (ptyDataEvent) {
+    if (!shouldDispatchPtyDataEvent(ptyDataEvent)) return;
     for (const cb of [...remotePtyDataEventCallbacks]) {
       try {
         cb(ptyDataEvent);
@@ -2543,8 +2571,11 @@ function subscribeAgentChatEvents(
 function subscribePtyDataEvents(
   cb: (payload: PtyDataEvent) => void,
 ): () => void {
-  const removeLocal = ptyDataEventFanout(cb);
-  const removeRemote = subscribeRemotePtyDataEvents(cb);
+  const filteredCb = (payload: PtyDataEvent) => {
+    if (shouldDispatchPtyDataEvent(payload)) cb(payload);
+  };
+  const removeLocal = ptyDataEventFanout(filteredCb);
+  const removeRemote = subscribeRemotePtyDataEvents(filteredCb);
   return () => {
     removeRemote();
     removeLocal();
@@ -5964,6 +5995,7 @@ contextBridge.exposeInMainWorld("ade", {
       );
       if (!runtime.handled) await ipcRenderer.invoke(IPC.ptyDispose, arg);
     },
+    setDataSubscriptions: setPtyDataSubscriptions,
     onData: subscribePtyDataEvents,
     onExit: subscribePtyExitEvents,
   },

--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -5080,6 +5080,7 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
       write: resolvedArg(undefined),
       resize: resolvedArg(undefined),
       dispose: resolvedArg(undefined),
+      setDataSubscriptions: resolvedArg(undefined),
       onData: noop,
       onExit: noop,
     },

--- a/apps/desktop/src/renderer/components/app/BatchLaunchModal.tsx
+++ b/apps/desktop/src/renderer/components/app/BatchLaunchModal.tsx
@@ -169,10 +169,46 @@ function safeSaveDefaultPrompt(projectRoot: string | null | undefined, prompt: s
       window.localStorage.removeItem(key);
       return;
     }
-    window.localStorage.setItem(key, prompt);
+    window.localStorage.setItem(key, value);
   } catch {
     // Best effort only; failing to persist a prompt should never block launch.
   }
+}
+
+async function loadProjectDefaultPrompt(projectRoot: string | null | undefined): Promise<string | null> {
+  const localFallback = safeLoadDefaultPrompt(projectRoot);
+  if (!projectRoot?.trim() || typeof window === "undefined" || !window.ade?.projectConfig?.get) {
+    return localFallback;
+  }
+  try {
+    const snapshot = await window.ade.projectConfig.get();
+    const prompt = snapshot.effective.ui?.linearBatchLaunchDefaultPrompt?.trim();
+    return prompt || localFallback;
+  } catch {
+    return localFallback;
+  }
+}
+
+async function persistProjectDefaultPrompt(projectRoot: string | null | undefined, prompt: string): Promise<void> {
+  const value = prompt.trim();
+  safeSaveDefaultPrompt(projectRoot, value);
+  if (!projectRoot?.trim() || typeof window === "undefined" || !window.ade?.projectConfig?.get || !window.ade?.projectConfig?.save) {
+    return;
+  }
+  const snapshot = await window.ade.projectConfig.get();
+  const nextUi = { ...(snapshot.local.ui ?? {}) };
+  if (value) {
+    nextUi.linearBatchLaunchDefaultPrompt = value;
+  } else {
+    delete nextUi.linearBatchLaunchDefaultPrompt;
+  }
+  const nextLocal = { ...snapshot.local };
+  if (Object.keys(nextUi).length > 0) {
+    nextLocal.ui = nextUi;
+  } else {
+    delete nextLocal.ui;
+  }
+  await window.ade.projectConfig.save({ shared: snapshot.shared, local: nextLocal });
 }
 
 function makeInitialConfig(defaultModelId: string, kickoffPrompt: string): PerIssueState {
@@ -289,10 +325,10 @@ export function BatchLaunchModal({
   // control the user still sees.
   useEffect(() => {
     if (!open) return;
-    const savedPrompt = safeLoadDefaultPrompt(projectRoot);
-    const kickoffPrompt = savedPrompt ?? defaultKickoffPrompt();
+    const fallbackPrompt = safeLoadDefaultPrompt(projectRoot);
+    const kickoffPrompt = fallbackPrompt ?? defaultKickoffPrompt();
     const seedModel = defaultModel || defaultModelId;
-    setProjectDefaultPrompt(savedPrompt);
+    setProjectDefaultPrompt(fallbackPrompt);
     setDefaultModel(seedModel);
     setPerIssue((current) => {
       const next: Record<string, PerIssueState> = {};
@@ -318,6 +354,36 @@ export function BatchLaunchModal({
     defaultFast,
     defaultPermission,
   ]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const fallbackPrompt = safeLoadDefaultPrompt(projectRoot);
+    const initialPrompt = fallbackPrompt ?? defaultKickoffPrompt();
+
+    void loadProjectDefaultPrompt(projectRoot).then((savedPrompt) => {
+      if (cancelled) return;
+      setProjectDefaultPrompt(savedPrompt);
+      if (!savedPrompt || savedPrompt === initialPrompt) return;
+      setPerIssue((current) => {
+        let changed = false;
+        const next: Record<string, PerIssueState> = {};
+        for (const [id, state] of Object.entries(current)) {
+          if (state.kickoffPrompt === initialPrompt || (fallbackPrompt != null && state.kickoffPrompt === fallbackPrompt)) {
+            next[id] = { ...state, kickoffPrompt: savedPrompt };
+            changed = true;
+          } else {
+            next[id] = state;
+          }
+        }
+        return changed ? next : current;
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, projectRoot]);
 
   useEffect(() => {
     if (open) return;
@@ -399,8 +465,9 @@ export function BatchLaunchModal({
   }, []);
 
   const savePromptAsDefault = useCallback((prompt: string) => {
-    safeSaveDefaultPrompt(projectRoot, prompt);
-    setProjectDefaultPrompt(prompt.trim() ? prompt : null);
+    const value = prompt.trim();
+    setProjectDefaultPrompt(value || null);
+    void persistProjectDefaultPrompt(projectRoot, value).catch(() => {});
   }, [projectRoot]);
 
   const includedIssues = useMemo(

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -4694,6 +4694,7 @@ export function AgentChatPane({
   }, []);
 
   useEffect(() => {
+    if (!isTileVisible) return undefined;
     const unsubscribe = window.ade.agentChat.onEvent((envelope) => {
       const optimistic = optimisticOutgoingMessageRef.current;
       if (

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -165,6 +165,7 @@ function installWindowAde() {
     pty: {
       resize: vi.fn().mockResolvedValue(undefined),
       write: vi.fn().mockResolvedValue(undefined),
+      setDataSubscriptions: vi.fn().mockResolvedValue(undefined),
       onData: vi.fn((listener: (event: { ptyId: string; sessionId?: string; projectRoot?: string; data: string }) => void) => {
         mockState.ptyDataListeners.add(listener);
         return () => {
@@ -432,6 +433,29 @@ describe("TerminalView", () => {
     expect((window as any).ade.pty.onExit).toHaveBeenCalledTimes(1);
     expect(mockState.ptyDataListeners.size).toBe(1);
     expect(mockState.ptyExitListeners.size).toBe(1);
+  });
+
+  it("subscribes PTY data only for visible mounted runtimes", async () => {
+    const setDataSubscriptions = (window as any).ade.pty.setDataSubscriptions as ReturnType<typeof vi.fn>;
+    const view = render(<TerminalView ptyId="pty-visible-sub" sessionId="session-visible-sub" isActive />);
+
+    expect(setDataSubscriptions).toHaveBeenLastCalledWith({ ptyIds: ["pty-visible-sub"] });
+
+    view.rerender(
+      <TerminalView
+        ptyId="pty-visible-sub"
+        sessionId="session-visible-sub"
+        isActive={false}
+        isVisible={false}
+      />,
+    );
+    expect(setDataSubscriptions).toHaveBeenLastCalledWith({ ptyIds: [] });
+
+    view.rerender(<TerminalView ptyId="pty-visible-sub" sessionId="session-visible-sub" isActive />);
+    expect(setDataSubscriptions).toHaveBeenLastCalledWith({ ptyIds: ["pty-visible-sub"] });
+
+    view.unmount();
+    expect(setDataSubscriptions).toHaveBeenLastCalledWith({ ptyIds: [] });
   });
 
   it("uses the DOM renderer on Linux when localStorage is unavailable", async () => {
@@ -1046,11 +1070,12 @@ describe("TerminalView", () => {
     expect(terminal?.dispose).not.toHaveBeenCalled();
   });
 
-  it("keeps live parked runtimes current across project switches", async () => {
+  it("keeps live parked runtimes available across project switches without rendering background output", async () => {
     const view = render(<TerminalView ptyId="pty-switch" sessionId="session-switch" isActive />);
     await flushAllTimers();
 
     const readTranscriptTailMock = window.ade.sessions.readTranscriptTail as unknown as { mock: { calls: unknown[][] } };
+    const previewMock = window.ade.terminal.preview as unknown as ReturnType<typeof vi.fn>;
     const firstTerminal = mockState.terminalInstances.at(-1) as {
       dispose: ReturnType<typeof vi.fn>;
       write: ReturnType<typeof vi.fn>;
@@ -1085,10 +1110,19 @@ describe("TerminalView", () => {
 
     mockState.projectRoot = "/project/a";
     mockState.projectRevision += 1;
+    previewMock.mockResolvedValueOnce({
+      terminalId: "session-switch",
+      session: null,
+      source: "transcript",
+      snapshot: null,
+      transcript: "snapshot after remount\n",
+      capturedAt: new Date().toISOString(),
+    });
 
     render(<TerminalView ptyId="pty-switch" sessionId="session-switch" isActive />);
     await flushAllTimers();
-    expect(firstTerminal?.write).toHaveBeenCalledWith("still running in project a\n");
+    expect(firstTerminal?.write).not.toHaveBeenCalledWith("still running in project a\n");
+    expect(firstTerminal?.write).toHaveBeenCalledWith("snapshot after remount\n");
 
     const secondTerminal = mockState.terminalInstances.at(-1) as {
       dispose: ReturnType<typeof vi.fn>;
@@ -1819,9 +1853,10 @@ describe("TerminalView", () => {
     expect(view.queryByTestId("terminal-startup-loading")).toBeNull();
   });
 
-  it("buffers PTY output for parked runtimes and flushes it on remount", async () => {
+  it("refreshes parked runtimes from preview instead of buffering background PTY output", async () => {
     const firstView = render(<TerminalView ptyId="pty-buffered" sessionId="session-buffered" isActive />);
     await flushAllTimers();
+    const previewMock = window.ade.terminal.preview as unknown as ReturnType<typeof vi.fn>;
 
     const terminal = mockState.terminalInstances.at(-1) as {
       write: ReturnType<typeof vi.fn>;
@@ -1840,12 +1875,21 @@ describe("TerminalView", () => {
     expect(terminal?.write).not.toHaveBeenCalledWith("hello from background\n");
 
     terminal?.write.mockClear();
+    previewMock.mockResolvedValueOnce({
+      terminalId: "session-buffered",
+      session: null,
+      source: "transcript",
+      snapshot: null,
+      transcript: "fresh preview after park\n",
+      capturedAt: new Date().toISOString(),
+    });
     render(<TerminalView ptyId="pty-buffered" sessionId="session-buffered" isActive />);
-    await flushAnimationFrame();
-    expect(terminal?.write).toHaveBeenCalledWith("hello from background\n");
+    await flushAllTimers();
+    expect(terminal?.write).not.toHaveBeenCalledWith("hello from background\n");
+    expect(terminal?.write).toHaveBeenCalledWith("fresh preview after park\n");
   });
 
-  it("keeps parked runtime output buffered while the document is hidden", async () => {
+  it("does not buffer parked runtime output while the document is hidden", async () => {
     const rafSpy = vi.spyOn(globalThis, "requestAnimationFrame");
     const firstView = render(<TerminalView ptyId="pty-hidden" sessionId="session-hidden" isActive />);
     await flushAllTimers();

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -458,6 +458,21 @@ describe("TerminalView", () => {
     expect(setDataSubscriptions).toHaveBeenLastCalledWith({ ptyIds: [] });
   });
 
+  it("configures an empty PTY data subscription when the first runtime is hidden", async () => {
+    const setDataSubscriptions = (window as any).ade.pty.setDataSubscriptions as ReturnType<typeof vi.fn>;
+
+    render(
+      <TerminalView
+        ptyId="pty-hidden-first"
+        sessionId="session-hidden-first"
+        isActive={false}
+        isVisible={false}
+      />,
+    );
+
+    expect(setDataSubscriptions).toHaveBeenLastCalledWith({ ptyIds: [] });
+  });
+
   it("uses the DOM renderer on Linux when localStorage is unavailable", async () => {
     vi.useRealTimers();
     const platformDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "platform");

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -2144,8 +2144,8 @@ export function TerminalView({
         parkRuntime(runtime);
       }
 
-      setRuntimeVisibilityState(runtime, false);
       const wasReceivingBeforeUnref = shouldRuntimeReceivePtyData(runtime);
+      setRuntimeVisibilityState(runtime, false);
       runtime.refs = Math.max(0, runtime.refs - 1);
       syncRuntimePtyDataStreaming(runtime, wasReceivingBeforeUnref);
       // Keep live runtimes parked until the PTY exits so switching away from a

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -1046,7 +1046,9 @@ function shouldDeliverPtyEvent(runtime: CachedRuntime, projectRoot: string | und
 
 function handleRuntimePtyData(runtime: CachedRuntime, ev: PtyDataEvent) {
   if (!shouldDeliverPtyEvent(runtime, ev.projectRoot)) return;
-  updateTerminalMouseTrackingModes(runtime, ev.data);
+  if (runtime.visible && runtime.refs > 0) {
+    updateTerminalMouseTrackingModes(runtime, ev.data);
+  }
 
   if (!runtime.hydrationCompleted) {
     runtime.pendingHydrationChunks.push(ev.data);

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -83,6 +83,7 @@ type CachedRuntime = {
   pendingHydrationBytes: number;
   frameWriteChunks: string[];
   frameWriteBytes: number;
+  liveStreamPaused: boolean;
   flushRafId: number | null;
   flushTimer: ReturnType<typeof setTimeout> | null;
   disposeTimer: ReturnType<typeof setTimeout> | null;
@@ -136,6 +137,7 @@ const ptyDataRuntimesByPtyId = new Map<string, Set<CachedRuntime>>();
 const ptyExitRuntimesByPtyId = new Map<string, Set<CachedRuntime>>();
 let sharedPtyDataUnsub: (() => void) | null = null;
 let sharedPtyExitUnsub: (() => void) | null = null;
+let ptyDataSubscriptionSignature = "";
 
 function terminalRuntimeKey(args: {
   sessionId: string;
@@ -641,8 +643,82 @@ function setRuntimeInteractionState(runtime: CachedRuntime, active: boolean) {
   }
 }
 
+function shouldRuntimeReceivePtyData(runtime: CachedRuntime): boolean {
+  return !runtime.disposed && runtime.refs > 0 && runtime.visible;
+}
+
+function updatePtyDataSubscriptions(): void {
+  const ptyIds = new Set<string>();
+  for (const [ptyId, runtimes] of ptyDataRuntimesByPtyId) {
+    for (const runtime of runtimes) {
+      if (shouldRuntimeReceivePtyData(runtime)) {
+        ptyIds.add(ptyId);
+        break;
+      }
+    }
+  }
+
+  const next = [...ptyIds].sort();
+  const signature = next.join("\0");
+  if (signature === ptyDataSubscriptionSignature) return;
+  ptyDataSubscriptionSignature = signature;
+
+  const setDataSubscriptions = window.ade.pty.setDataSubscriptions;
+  if (typeof setDataSubscriptions !== "function") return;
+  setDataSubscriptions({ ptyIds: next }).catch(() => {});
+}
+
+function clearRuntimeHydrationTimers(runtime: CachedRuntime): void {
+  if (runtime.hydrateTimer) {
+    clearTimeout(runtime.hydrateTimer);
+    runtime.hydrateTimer = null;
+  }
+  if (runtime.hydrateRetryTimer) {
+    clearTimeout(runtime.hydrateRetryTimer);
+    runtime.hydrateRetryTimer = null;
+  }
+  if (runtime.hydrationBackfillTimer) {
+    clearTimeout(runtime.hydrationBackfillTimer);
+    runtime.hydrationBackfillTimer = null;
+  }
+}
+
+function pauseRuntimePtyStream(runtime: CachedRuntime): void {
+  if (runtime.liveStreamPaused) return;
+  runtime.liveStreamPaused = true;
+  runtime.pendingHydrationChunks.length = 0;
+  runtime.pendingHydrationBytes = 0;
+  discardScheduledFrameWrites(runtime);
+}
+
+function resumeRuntimePtyStream(runtime: CachedRuntime): void {
+  if (!runtime.liveStreamPaused || !shouldRuntimeReceivePtyData(runtime)) return;
+  runtime.liveStreamPaused = false;
+  runtime.displayedLiveDataBeforeHydration = false;
+  runtime.hydrationStarted = false;
+  runtime.hydrationCompleted = false;
+  runtime.hydrationBackfillAttempts = 0;
+  runtime.pendingHydrationChunks.length = 0;
+  runtime.pendingHydrationBytes = 0;
+  clearRuntimeHydrationTimers(runtime);
+  discardScheduledFrameWrites(runtime);
+  startHydration(runtime);
+}
+
+function syncRuntimePtyDataStreaming(runtime: CachedRuntime, wasReceiving: boolean): void {
+  const isReceiving = shouldRuntimeReceivePtyData(runtime);
+  if (wasReceiving && !isReceiving) {
+    pauseRuntimePtyStream(runtime);
+  } else if (!wasReceiving && isReceiving) {
+    resumeRuntimePtyStream(runtime);
+  }
+  updatePtyDataSubscriptions();
+}
+
 function setRuntimeVisibilityState(runtime: CachedRuntime, visible: boolean) {
+  const wasReceiving = shouldRuntimeReceivePtyData(runtime);
   runtime.visible = visible;
+  syncRuntimePtyDataStreaming(runtime, wasReceiving);
 }
 
 function writePtyInput(runtime: CachedRuntime, data: string) {
@@ -1046,9 +1122,11 @@ function shouldDeliverPtyEvent(runtime: CachedRuntime, projectRoot: string | und
 
 function handleRuntimePtyData(runtime: CachedRuntime, ev: PtyDataEvent) {
   if (!shouldDeliverPtyEvent(runtime, ev.projectRoot)) return;
-  if (runtime.visible && runtime.refs > 0) {
-    updateTerminalMouseTrackingModes(runtime, ev.data);
+  if (!shouldRuntimeReceivePtyData(runtime)) {
+    pauseRuntimePtyStream(runtime);
+    return;
   }
+  updateTerminalMouseTrackingModes(runtime, ev.data);
 
   if (!runtime.hydrationCompleted) {
     runtime.pendingHydrationChunks.push(ev.data);
@@ -1101,6 +1179,7 @@ function subscribeRuntimePtyData(runtime: CachedRuntime): () => void {
     ptyDataRuntimesByPtyId.set(runtime.ptyId, runtimes);
   }
   runtimes.add(runtime);
+  updatePtyDataSubscriptions();
   if (!sharedPtyDataUnsub) {
     sharedPtyDataUnsub = window.ade.pty.onData((ev) => {
       const targets = ptyDataRuntimesByPtyId.get(ev.ptyId);
@@ -1110,6 +1189,7 @@ function subscribeRuntimePtyData(runtime: CachedRuntime): () => void {
   }
   return () => {
     removeRuntimePtySubscription(ptyDataRuntimesByPtyId, runtime);
+    updatePtyDataSubscriptions();
     if (ptyDataRuntimesByPtyId.size === 0 && sharedPtyDataUnsub) {
       sharedPtyDataUnsub();
       sharedPtyDataUnsub = null;
@@ -1604,6 +1684,7 @@ function createRuntime(args: {
     pendingHydrationBytes: 0,
     frameWriteChunks: [],
     frameWriteBytes: 0,
+    liveStreamPaused: false,
     flushRafId: null,
     flushTimer: null,
     disposeTimer: null,
@@ -1870,7 +1951,9 @@ export function TerminalView({
       preferences: mountConfig.preferences,
     });
     runtimeRef.current = runtime;
+    const wasReceivingBeforeRef = shouldRuntimeReceivePtyData(runtime);
     runtime.refs += 1;
+    syncRuntimePtyDataStreaming(runtime, wasReceivingBeforeRef);
     clearDisposeTimer(runtime);
     setRuntimeInteractionState(runtime, mountConfig.isActive);
     setRuntimeVisibilityState(runtime, mountConfig.isVisible);
@@ -2059,7 +2142,10 @@ export function TerminalView({
         parkRuntime(runtime);
       }
 
+      setRuntimeVisibilityState(runtime, false);
+      const wasReceivingBeforeUnref = shouldRuntimeReceivePtyData(runtime);
       runtime.refs = Math.max(0, runtime.refs - 1);
+      syncRuntimePtyDataStreaming(runtime, wasReceivingBeforeUnref);
       // Keep live runtimes parked until the PTY exits so switching away from a
       // running terminal does not discard in-memory TUI state.
       if (runtime.refs === 0 && runtime.exitCode != null) {

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -137,7 +137,7 @@ const ptyDataRuntimesByPtyId = new Map<string, Set<CachedRuntime>>();
 const ptyExitRuntimesByPtyId = new Map<string, Set<CachedRuntime>>();
 let sharedPtyDataUnsub: (() => void) | null = null;
 let sharedPtyExitUnsub: (() => void) | null = null;
-let ptyDataSubscriptionSignature = "";
+let ptyDataSubscriptionSignature: string | null = null;
 
 function terminalRuntimeKey(args: {
   sessionId: string;
@@ -1191,6 +1191,7 @@ function subscribeRuntimePtyData(runtime: CachedRuntime): () => void {
     removeRuntimePtySubscription(ptyDataRuntimesByPtyId, runtime);
     updatePtyDataSubscriptions();
     if (ptyDataRuntimesByPtyId.size === 0 && sharedPtyDataUnsub) {
+      ptyDataSubscriptionSignature = null;
       sharedPtyDataUnsub();
       sharedPtyDataUnsub = null;
     }
@@ -1880,6 +1881,7 @@ export function __resetTerminalRuntimesForTests(): void {
     teardownRuntime(runtime);
   }
   runtimeCache.clear();
+  ptyDataSubscriptionSignature = null;
 }
 
 export function TerminalView({

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.test.tsx
@@ -1553,7 +1553,7 @@ describe("WorkViewArea", () => {
     expect(chatPaneLifecycle.unmounts.get("chat-1")).toBeUndefined();
   });
 
-  it("keeps open chat tabs mounted while switching the active tab", () => {
+  it("parks hidden chat tabs while switching the active tab", () => {
     vi.mocked(isChatToolType).mockImplementation((toolType) => toolType === "codex-chat");
     const first = makeChatSession("chat-1");
     const second = makeChatSession("chat-2");
@@ -1597,9 +1597,13 @@ describe("WorkViewArea", () => {
       />,
     );
 
-    expect(within(view.container).getAllByTestId("agent-chat-pane")).toHaveLength(2);
+    let panes = within(view.container).getAllByTestId("agent-chat-pane");
+    expect(panes).toHaveLength(1);
+    expect(panes[0]?.getAttribute("data-session-id")).toBe("chat-1");
+    expect(panes[0]?.getAttribute("data-tile-active")).toBe("true");
+    expect(panes[0]?.getAttribute("data-tile-visible")).toBe("true");
     expect(chatPaneLifecycle.mounts.get("chat-1")).toBe(1);
-    expect(chatPaneLifecycle.mounts.get("chat-2")).toBe(1);
+    expect(chatPaneLifecycle.mounts.get("chat-2")).toBeUndefined();
 
     view.rerender(
       <WorkViewArea
@@ -1640,9 +1644,14 @@ describe("WorkViewArea", () => {
       />,
     );
 
+    panes = within(view.container).getAllByTestId("agent-chat-pane");
+    expect(panes).toHaveLength(1);
+    expect(panes[0]?.getAttribute("data-session-id")).toBe("chat-2");
+    expect(panes[0]?.getAttribute("data-tile-active")).toBe("true");
+    expect(panes[0]?.getAttribute("data-tile-visible")).toBe("true");
     expect(chatPaneLifecycle.mounts.get("chat-1")).toBe(1);
     expect(chatPaneLifecycle.mounts.get("chat-2")).toBe(1);
-    expect(chatPaneLifecycle.unmounts.get("chat-1")).toBeUndefined();
+    expect(chatPaneLifecycle.unmounts.get("chat-1")).toBe(1);
     expect(chatPaneLifecycle.unmounts.get("chat-2")).toBeUndefined();
   });
 
@@ -1702,7 +1711,7 @@ describe("WorkViewArea", () => {
     expect(chatPaneLifecycle.unmounts.get("chat-1")).toBeUndefined();
   });
 
-  it("keeps every running terminal tile mounted in tabs mode while switching active tab", () => {
+  it("parks hidden terminal tiles in tabs mode while switching active tab", () => {
     const first = makeRunningSession("session-1", "pty-1");
     const second = makeRunningSession("session-2", "pty-2");
 
@@ -1745,14 +1754,9 @@ describe("WorkViewArea", () => {
       />,
     );
 
-    const terminals = within(view.container).getAllByTestId("terminal-view");
-    expect(terminals).toHaveLength(2);
-    const firstTerminal = terminals.find((el) => el.getAttribute("data-session-id") === "session-1");
-    const secondTerminal = terminals.find((el) => el.getAttribute("data-session-id") === "session-2");
-    expect(firstTerminal?.getAttribute("data-active")).toBe("true");
-    expect(secondTerminal?.getAttribute("data-active")).toBe("false");
-    expect(firstTerminal?.closest("[hidden]")).toBeNull();
-    expect(secondTerminal?.closest("[hidden]")).not.toBeNull();
+    let terminal = within(view.container).getByTestId("terminal-view");
+    expect(terminal.getAttribute("data-session-id")).toBe("session-1");
+    expect(terminal.getAttribute("data-active")).toBe("true");
 
     view.rerender(
       <WorkViewArea
@@ -1793,14 +1797,9 @@ describe("WorkViewArea", () => {
       />,
     );
 
-    const terminalsAfter = within(view.container).getAllByTestId("terminal-view");
-    expect(terminalsAfter).toHaveLength(2);
-    const firstAfter = terminalsAfter.find((el) => el.getAttribute("data-session-id") === "session-1");
-    const secondAfter = terminalsAfter.find((el) => el.getAttribute("data-session-id") === "session-2");
-    expect(firstAfter?.getAttribute("data-active")).toBe("false");
-    expect(secondAfter?.getAttribute("data-active")).toBe("true");
-    expect(firstAfter?.closest("[hidden]")).not.toBeNull();
-    expect(secondAfter?.closest("[hidden]")).toBeNull();
+    terminal = within(view.container).getByTestId("terminal-view");
+    expect(terminal.getAttribute("data-session-id")).toBe("session-2");
+    expect(terminal.getAttribute("data-active")).toBe("true");
   });
 
   it("preserves unusual session ids when building the grid tiling tree", () => {

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
@@ -308,10 +308,6 @@ function canContinueAgentCliSession(session: TerminalSessionSummary): boolean {
   return Boolean(session.tracked && continuationProviderForSession(session) && (session.resumeMetadata || session.resumeCommand));
 }
 
-function shouldKeepMountedInHiddenTab(session: TerminalSessionSummary): boolean {
-  return isChatToolType(session.toolType) || isRunningPtySession(session);
-}
-
 function continuationProviderLabel(provider: TerminalResumeProvider | null): string {
   if (provider === "claude") return "Claude Code";
   if (provider === "codex") return "Codex";
@@ -1765,7 +1761,7 @@ export function WorkViewArea({
     <div className="relative min-h-0 flex-1" style={{ background: "var(--color-bg)" }}>
       {visibleSessions.map((session) => {
         const isActive = activeSession?.id === session.id;
-        if (!isActive && !shouldKeepMountedInHiddenTab(session)) return null;
+        if (!isActive) return null;
 
         return (
           <div

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -343,6 +343,7 @@ export const IPC = {
   ptyWrite: "ade.pty.write",
   ptyResize: "ade.pty.resize",
   ptyDispose: "ade.pty.dispose",
+  ptyDataSubscriptions: "ade.pty.dataSubscriptions",
   ptyData: "ade.pty.data",
   ptyExit: "ade.pty.exit",
   terminalList: "ade.terminal.list",

--- a/apps/desktop/src/shared/types/config.ts
+++ b/apps/desktop/src/shared/types/config.ts
@@ -1401,6 +1401,10 @@ export type AiIntegrationStatus = {
   availableModelIds?: ModelId[];
 };
 
+export type ProjectUiConfig = {
+  linearBatchLaunchDefaultPrompt?: string;
+};
+
 export type ProjectConfigFile = {
   version?: number;
   project?: ProjectIdentityConfig;
@@ -1428,6 +1432,7 @@ export type ProjectConfigFile = {
   laneCleanup?: LaneCleanupConfig;
   providers?: Record<string, unknown>;
   linearSync?: LinearSyncConfig;
+  ui?: ProjectUiConfig;
   /** Mobile push notification configuration (APNs). */
   notifications?: NotificationsConfig;
 };
@@ -1465,6 +1470,7 @@ export type EffectiveProjectConfig = {
   providerMode?: ProviderMode;
   providers?: Record<string, unknown>;
   linearSync?: LinearSyncConfig;
+  ui?: ProjectUiConfig;
   cto?: {
     companyBudgetMonthlyCents?: number;
     budgetTelemetry?: {


### PR DESCRIPTION
Summary:
- speed up project picker/recent project loading by avoiding per-project DB/lane scans
- park hidden Work tabs and stop hidden chat/terminal panes from processing live event streams
- filter PTY data delivery to visible mounted terminals and hydrate parked terminals from preview on return
- persist Linear batch launch default prompts in project config

Validation:
- npm --prefix apps/desktop exec -- vitest run src/renderer/components/terminals/TerminalView.test.tsx
- npm --prefix apps/desktop exec -- vitest run src/preload/preload.test.ts
- npm --prefix apps/desktop exec -- vitest run src/main/services/ipc/runtimeBridge.test.ts
- npm --prefix apps/desktop run typecheck
- npm --prefix apps/desktop run build
- npm --prefix apps/desktop run lint (0 errors, existing warnings)

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fcodex-goal-ui-issue-b84be16a num=492 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fcodex-goal-ui-issue-b84be16a&amp;pr=492">ade/codex-goal-ui-issue-b84be16a branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=492">PR #492</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves ADE responsiveness under large workloads through four coordinated changes: filtering PTY data delivery to only visible terminals via a new per-WebContents subscription system, parking hidden Work tabs (unmounting instead of hiding) to stop background event processing, speeding up the project picker by skipping per-project DB/lane scans, and persisting the Linear batch launch default prompt to project config.

- **PTY subscription filtering**: A new `ptyDataSubscriptions` module tracks which PTY IDs each `WebContents` wants to receive; `broadcastPtyData` in main and `shouldForwardRuntimeEvent` in `runtimeBridge` both consult it, while `TerminalView` drives subscriptions via `updatePtyDataSubscriptions` based on which runtimes are currently visible.
- **Hidden-tab parking**: `WorkViewArea` now returns `null` for all inactive sessions instead of keeping them mounted under a `hidden` div; `TerminalView` responds by pausing the PTY stream (via `pauseRuntimePtyStream`) on unmount and restoring from a fresh `terminal.preview` snapshot on remount, while `AgentChatPane` adds an `isTileVisible` guard to its chat event subscription.
- **Config + project picker**: `toShallowRecentProjectSummary` replaces `toRecentProjectSummary` in the picker hot path to avoid lane scans, and a new `ui` section in `ProjectConfigFile` persists the batch launch prompt alongside a fix for a pre-existing bug where `safeSaveDefaultPrompt` stored the untrimmed value.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changes are well-scoped and covered by targeted tests

The PTY subscription filtering and tab-parking logic are thoroughly tested, and the project-config ui field has correct coercion, merge, and serialisation paths. The one subtle edge case — pauseRuntimePtyStream not cancelling in-flight hydration async requests, risking a brief stale-content flash if a slow IPC resolves after resumeRuntimePtyStream starts a fresh hydration — is a transient visual artefact that backfill polling corrects and does not affect data correctness.

apps/desktop/src/renderer/components/terminals/TerminalView.tsx — the pauseRuntimePtyStream / resumeRuntimePtyStream interaction around in-flight hydration requests warrants a second look

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/pty/ptyDataSubscriptions.ts | New module managing per-WebContents PTY data subscriptions; correctly returns true (allow-all) for unregistered senders and cleans up on WebContents destroy |
| apps/desktop/src/main/main.ts | Registers the new ptyDataSubscriptions IPC handler and routes broadcastPtyData through shouldSendPtyDataToWebContents filter instead of unconditional broadcast |
| apps/desktop/src/renderer/components/terminals/TerminalView.tsx | Adds liveStreamPaused flag, pause/resume/sync helpers, and updatePtyDataSubscriptions; the pauseRuntimePtyStream helper omits clearRuntimeHydrationTimers, leaving in-flight async hydration requests unguarded across pause/resume cycles |
| apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx | Removes shouldKeepMountedInHiddenTab and now always returns null for inactive sessions; the lingering hidden={!isActive} on the container div is unreachable dead code |
| apps/desktop/src/renderer/components/app/BatchLaunchModal.tsx | Adds async project-config-backed loading/persisting of the Linear batch launch default prompt with localStorage fallback; fixes a pre-existing bug where safeSaveDefaultPrompt stored the untrimmed prompt string |
| apps/desktop/src/main/services/config/projectConfigService.ts | Adds coerceProjectUiConfig and wires ui field through coercion, serialization, canonical YAML, and resolveEffectiveConfig with correct local-over-shared merge semantics |
| apps/desktop/src/preload/preload.ts | Adds client-side PTY subscription filtering via ptyDataSubscriptionsConfigured/subscribedPtyDataIds; filters both local and remote PTY data events before dispatching to registered callbacks |
| apps/desktop/src/main/services/ipc/runtimeBridge.ts | Adds shouldForwardRuntimeEvent to filter remote pty_data events through the per-sender subscription check before forwarding to the renderer |
| apps/desktop/src/main/services/projects/recentProjectSummary.ts | Adds toShallowRecentProjectSummary which skips per-project DB/lane scans for faster project picker loading |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer (TerminalView)
    participant PL as Preload
    participant M as Main Process
    participant PTY as PTY Service

    Note over R,PTY: Tab switch — terminal becomes hidden
    R->>R: pauseRuntimePtyStream()
    R->>PL: "pty.setDataSubscriptions({ptyIds:[]})"
    PL->>M: IPC ptyDataSubscriptions (empty)
    M->>M: "subscriptionsByWebContentsId.set(id, {})"

    PTY->>M: PTY data arrives
    M->>M: shouldSendPtyDataToWebContents → false
    Note over M: Data dropped — not forwarded

    Note over R,PTY: Tab switch back — terminal becomes visible
    R->>R: resumeRuntimePtyStream() + startHydration()
    R->>PL: "pty.setDataSubscriptions({ptyIds:[pty-1]})"
    PL->>M: IPC ptyDataSubscriptions ([pty-1])
    M->>M: "subscriptionsByWebContentsId.set(id, {pty-1})"

    R->>PL: terminal.preview(sessionId)
    PL-->>R: snapshot / transcript
    R->>R: flushHydrationData() — terminal restored

    PTY->>M: PTY data arrives
    M->>M: shouldSendPtyDataToWebContents → true
    M->>PL: IPC ptyData
    PL->>R: onData callback — live stream resumes
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fterminals%2FTerminalView.tsx%3A686-694%0A**%60pauseRuntimePtyStream%60%20leaves%20in-flight%20hydration%20requests%20unguarded**%0A%0A%60pauseRuntimePtyStream%60%20clears%20%60pendingHydrationChunks%60%20and%20discards%20frame%20writes%2C%20but%20does%20not%20call%20%60clearRuntimeHydrationTimers%60.%20If%20%60hydrateTimer%60%20has%20already%20fired%20and%20%60readInitialHydrationData%60%20is%20awaiting%20an%20IPC%20round-trip%2C%20the%20stale%20%60finalizeHydration%60%20closure%20will%20still%20write%20to%20the%20terminal%20buffer%20once%20it%20resolves%20%E2%80%94%20even%20after%20%60resumeRuntimePtyStream%60%20has%20launched%20a%20fresh%20hydration.%20If%20the%20stale%20request%20completes%20*after*%20the%20fresh%20one%2C%20the%20terminal%20is%20left%20showing%20older%20content%20and%20only%20the%20backfill%20polling%20will%20eventually%20correct%20it.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fterminals%2FWorkViewArea.tsx%3A1766-1771%0ASince%20inactive%20sessions%20now%20return%20%60null%60%20on%20the%20line%20above%2C%20%60isActive%60%20is%20always%20%60true%60%20in%20this%20branch%2C%20making%20%60hidden%3D%7B!isActive%7D%60%20always%20%60hidden%3D%7Bfalse%7D%60%20%E2%80%94%20the%20attribute%20is%20now%20dead%20code.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20return%20%28%0A%20%20%20%20%20%20%20%20%20%20%3Cdiv%0A%20%20%20%20%20%20%20%20%20%20%20%20key%3D%7Bsession.id%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20className%3D%22absolute%20inset-0%22%0A%20%20%20%20%20%20%20%20%20%20%3E%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=492&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src/renderer/components/terminals/TerminalView.tsx:686-694
**`pauseRuntimePtyStream` leaves in-flight hydration requests unguarded**

`pauseRuntimePtyStream` clears `pendingHydrationChunks` and discards frame writes, but does not call `clearRuntimeHydrationTimers`. If `hydrateTimer` has already fired and `readInitialHydrationData` is awaiting an IPC round-trip, the stale `finalizeHydration` closure will still write to the terminal buffer once it resolves — even after `resumeRuntimePtyStream` has launched a fresh hydration. If the stale request completes *after* the fresh one, the terminal is left showing older content and only the backfill polling will eventually correct it.

### Issue 2 of 2
apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx:1766-1771
Since inactive sessions now return `null` on the line above, `isActive` is always `true` in this branch, making `hidden={!isActive}` always `hidden={false}` — the attribute is now dead code.

```suggestion
        return (
          <div
            key={session.id}
            className="absolute inset-0"
          >
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Fix PTY subscription edge cases"](https://github.com/arul28/ade/commit/e3a25af962bf98716a917c8f66ffd935b2c0f2aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34780515)</sub>

<!-- /greptile_comment -->