### PR TITLE
ADE-72: Chat/AI runtime: Keychain key in argv + SDK pool ref-count race, plus chat/AI/ade-action god-file & typed-dispatch decomposition

### DIFF
--- a/apps/desktop/src/main/services/ai/apiKeyStore.test.ts
+++ b/apps/desktop/src/main/services/ai/apiKeyStore.test.ts
@@ -248,19 +248,19 @@ describe("apiKeyStore", () => {
     expect(securityCommandCalls("add-generic-password")).toEqual([]);
   });
 
-  it("prefers an existing Keychain value over an older encrypted blob during migration", async () => {
-    keychain.set("cursor", "crsr_current_key");
+  it("preserves an existing encrypted-store value over a stale Keychain migration fallback", async () => {
+    keychain.set("cursor", "crsr_stale_key");
     const secretsDir = path.join(tempRoot, ".ade", "secrets");
     fs.mkdirSync(secretsDir, { recursive: true });
     fs.writeFileSync(path.join(secretsDir, "api-keys.v1.bin"), Buffer.from("old-encrypted"));
     safeStorageState.available = true;
-    safeStorageState.decrypted = JSON.stringify({ cursor: "crsr_stale_key" });
+    safeStorageState.decrypted = JSON.stringify({ cursor: "crsr_current_key" });
 
     const store = await loadStoreModule();
     store.initApiKeyStore(tempRoot);
 
     expect(store.getApiKey("cursor")).toBe("crsr_current_key");
-    expect(keychain.get("cursor")).toBe("crsr_current_key");
+    expect(keychain.get("cursor")).toBe("crsr_stale_key");
     expect(securityCommandCalls("add-generic-password")).toEqual([]);
   });
 
@@ -413,6 +413,21 @@ describe("apiKeyStore", () => {
 
     expect(store.listStoredProviders()).toEqual(["openai"]);
     expect(JSON.parse(credentialStore.values.get("ai.api_key.index.v1") ?? "[]")).toEqual(["openai"]);
+  });
+
+  it("deletes from memory without throwing when persistent secure storage is unavailable", async () => {
+    safeStorageState.available = true;
+    safeStorageState.decrypted = "{}";
+    const store = await loadStoreModule();
+    store.initApiKeyStore(tempRoot);
+    store.storeApiKey("cursor", "crsr_test_key");
+
+    safeStorageState.available = false;
+    process.env.ADE_API_KEY_STORE_DISABLE_KEYCHAIN = "1";
+
+    expect(() => store.deleteApiKey("cursor")).not.toThrow();
+    expect(store.getApiKey("cursor")).toBeNull();
+    expect(store.listStoredProviders()).toEqual([]);
   });
 
   it("can use the ADE CLI encrypted credential store without persisting the raw key", async () => {

--- a/apps/desktop/src/main/services/ai/apiKeyStore.test.ts
+++ b/apps/desktop/src/main/services/ai/apiKeyStore.test.ts
@@ -51,6 +51,12 @@ function securityAccountsFor(command: string): string[] {
     .map((args) => securityArg(args, "-a"));
 }
 
+function securityCommandCalls(command: string): string[][] {
+  return spawnSyncMock.mock.calls
+    .map((call) => (call[1] as string[]).map(String))
+    .filter((args) => args[0] === command);
+}
+
 function installSecurityMock(
   keychain: Map<string, string>,
   options: { failProviderIndexWrites?: boolean } = {},
@@ -159,7 +165,9 @@ describe("apiKeyStore", () => {
     vi.resetModules();
   });
 
-  it("stores Cursor keys in macOS Keychain without creating a safeStorage blob", async () => {
+  it("stores Cursor keys in safeStorage without writing secrets to macOS Keychain argv", async () => {
+    safeStorageState.available = true;
+    safeStorageState.decrypted = "{}";
     const store = await loadStoreModule();
     store.initApiKeyStore(tempRoot);
 
@@ -167,44 +175,46 @@ describe("apiKeyStore", () => {
 
     expect(store.getApiKey("cursor")).toBe("crsr_test_key");
     expect(store.listStoredProviders()).toContain("cursor");
-    expect(keychain.get("cursor")).toBe("crsr_test_key");
-    expect(keychain.get("__ade_provider_index__")).toContain("cursor");
-    expect(fs.existsSync(path.join(tempRoot, ".ade", "secrets", "api-keys.v1.bin"))).toBe(false);
+    expect(keychain.has("cursor")).toBe(false);
+    expect(securityCommandCalls("add-generic-password")).toEqual([]);
+    expect(fs.existsSync(path.join(tempRoot, ".ade", "secrets", "api-keys.v1.bin"))).toBe(true);
   });
 
-  it("keeps a stored Keychain key usable when the provider index write fails", async () => {
-    installSecurityMock(keychain, { failProviderIndexWrites: true });
+  it("migrates legacy Keychain keys into safeStorage without writing back to Keychain", async () => {
+    safeStorageState.available = true;
+    safeStorageState.decrypted = "{}";
+    keychain.set("__ade_provider_index__", JSON.stringify(["cursor"]));
+    keychain.set("cursor", "crsr_keychain_key");
     const store = await loadStoreModule();
     store.initApiKeyStore(tempRoot);
 
-    store.storeApiKey("cursor", "crsr_test_key");
-
-    expect(store.getApiKey("cursor")).toBe("crsr_test_key");
+    expect(store.getApiKey("cursor")).toBe("crsr_keychain_key");
     expect(store.listStoredProviders()).toContain("cursor");
-    expect(keychain.get("cursor")).toBe("crsr_test_key");
-    expect(keychain.has("__ade_provider_index__")).toBe(false);
-    expect(store.getApiKeyStoreStatus().macosKeychainError).toContain("provider index write failed");
+    expect(securityCommandCalls("add-generic-password")).toEqual([]);
+    expect(fs.existsSync(path.join(tempRoot, ".ade", "secrets", "api-keys.v1.bin"))).toBe(true);
   });
 
-  it("clears provider index write errors after a later successful Keychain write", async () => {
-    installSecurityMock(keychain, { failProviderIndexWrites: true });
+  it("updates safeStorage and deletes any stale legacy Keychain copy", async () => {
+    safeStorageState.available = true;
+    safeStorageState.decrypted = "{}";
+    keychain.set("__ade_provider_index__", JSON.stringify(["cursor"]));
+    keychain.set("cursor", "crsr_old_key");
     const store = await loadStoreModule();
     store.initApiKeyStore(tempRoot);
 
-    store.storeApiKey("cursor", "crsr_test_key");
-    expect(store.getApiKeyStoreStatus().macosKeychainError).toContain("provider index write failed");
+    store.storeApiKey("cursor", "crsr_new_key");
 
-    installSecurityMock(keychain);
-    store.storeApiKey("openai", "openai_test_key");
-
-    expect(store.getApiKey("openai")).toBe("openai_test_key");
+    expect(store.getApiKey("cursor")).toBe("crsr_new_key");
+    expect(keychain.has("cursor")).toBe(false);
+    expect(securityCommandCalls("add-generic-password")).toEqual([]);
     expect(store.getApiKeyStoreStatus().macosKeychainError).toBeNull();
   });
 
-  it("removes a deleted Keychain key from memory when the provider index write fails", async () => {
+  it("removes a deleted legacy Keychain key from memory and the active encrypted store", async () => {
+    safeStorageState.available = true;
+    safeStorageState.decrypted = "{}";
     keychain.set("__ade_provider_index__", JSON.stringify(["cursor"]));
     keychain.set("cursor", "crsr_test_key");
-    installSecurityMock(keychain, { failProviderIndexWrites: true });
     const store = await loadStoreModule();
     store.initApiKeyStore(tempRoot);
 
@@ -215,11 +225,10 @@ describe("apiKeyStore", () => {
     expect(store.getApiKey("cursor")).toBeNull();
     expect(store.listStoredProviders()).not.toContain("cursor");
     expect(keychain.has("cursor")).toBe(false);
-    expect(keychain.get("__ade_provider_index__")).toContain("cursor");
-    expect(store.getApiKeyStoreStatus().macosKeychainError).toContain("provider index write failed");
+    expect(securityCommandCalls("add-generic-password")).toEqual([]);
   });
 
-  it("migrates a decryptable legacy safeStorage blob into macOS Keychain", async () => {
+  it("keeps a decryptable legacy safeStorage blob as the active store", async () => {
     const secretsDir = path.join(tempRoot, ".ade", "secrets");
     fs.mkdirSync(secretsDir, { recursive: true });
     fs.writeFileSync(path.join(secretsDir, "api-keys.v1.bin"), Buffer.from("old-encrypted"));
@@ -234,8 +243,9 @@ describe("apiKeyStore", () => {
 
     expect(store.getApiKey("cursor")).toBe("crsr_old_key");
     expect(store.getApiKey("openai")).toBe("openai_old_key");
-    expect(keychain.get("cursor")).toBe("crsr_old_key");
-    expect(keychain.get("openai")).toBe("openai_old_key");
+    expect(keychain.has("cursor")).toBe(false);
+    expect(keychain.has("openai")).toBe(false);
+    expect(securityCommandCalls("add-generic-password")).toEqual([]);
   });
 
   it("prefers an existing Keychain value over an older encrypted blob during migration", async () => {
@@ -251,6 +261,7 @@ describe("apiKeyStore", () => {
 
     expect(store.getApiKey("cursor")).toBe("crsr_current_key");
     expect(keychain.get("cursor")).toBe("crsr_current_key");
+    expect(securityCommandCalls("add-generic-password")).toEqual([]);
   });
 
   it("keeps Keychain keys usable when the old encrypted blob cannot be decrypted", async () => {
@@ -266,7 +277,7 @@ describe("apiKeyStore", () => {
 
     expect(store.getApiKey("cursor")).toBe("crsr_keychain_key");
     expect(store.getApiKeyStoreStatus()).toMatchObject({
-      secureStorageAvailable: true,
+      secureStorageAvailable: false,
       macosKeychainAvailable: true,
       decryptionFailed: true,
     });
@@ -283,7 +294,6 @@ describe("apiKeyStore", () => {
     expect(store.listStoredProviders()).toEqual(["cursor"]);
     expect(securityAccountsFor("find-generic-password")).toEqual([
       "__ade_provider_index__",
-      "__ade_provider_index__",
       "cursor",
     ]);
   });
@@ -298,11 +308,9 @@ describe("apiKeyStore", () => {
     expect(store.listStoredProviders()).toEqual(["cursor"]);
     expect(securityAccountsFor("find-generic-password")).toEqual([
       "__ade_provider_index__",
-      "__ade_provider_index__",
       "cursor",
-      "__ade_provider_index__",
     ]);
-    expect(securityAccountsFor("add-generic-password")).toContain("__ade_provider_index__");
+    expect(securityCommandCalls("add-generic-password")).toEqual([]);
   });
 
   it("migrates legacy safeStorage API keys into a provided credential store once", async () => {

--- a/apps/desktop/src/main/services/ai/apiKeyStore.ts
+++ b/apps/desktop/src/main/services/ai/apiKeyStore.ts
@@ -93,7 +93,7 @@ function isMacosKeychainAvailable(): boolean {
 
 function isPersistentSecureStorageAvailable(): boolean {
   if (credentialStore) return true;
-  return isMacosKeychainAvailable() || isSecureStorageAvailable();
+  return isSecureStorageAvailable();
 }
 
 function normalizeProvider(provider: string): string {
@@ -177,30 +177,6 @@ function readMacosKeychainSecret(account: string): string | null {
     rememberKeychainError("read", result);
   }
   return null;
-}
-
-function writeMacosKeychainSecret(account: string, value: string): void {
-  if (!isMacosKeychainAvailable()) {
-    throw new Error("macOS Keychain is unavailable. Cannot persist API keys.");
-  }
-  // `/usr/bin/security add-generic-password` does not support a non-interactive
-  // stdin password sentinel: `-w -` stores a literal dash. Keep this path
-  // synchronous and tightly scoped until we replace it with a native binding.
-  const result = runSecurity([
-    "add-generic-password",
-    "-a",
-    account,
-    "-s",
-    MACOS_KEYCHAIN_SERVICE,
-    "-w",
-    value,
-    "-U",
-  ]);
-  if (!result.ok) {
-    rememberKeychainError("write", result);
-    throw new Error(macosKeychainError ?? "macOS Keychain write failed.");
-  }
-  clearKeychainError();
 }
 
 function deleteMacosKeychainSecret(account: string): void {
@@ -402,22 +378,6 @@ function readMacosKeychainProviderIndex(): { exists: boolean; providers: string[
   }
 }
 
-function writeMacosKeychainProviderIndex(providers: Iterable<string>): void {
-  writeMacosKeychainSecret(
-    MACOS_KEYCHAIN_PROVIDER_INDEX_ACCOUNT,
-    JSON.stringify(normalizeProviderList(Array.from(providers))),
-  );
-}
-
-function tryWriteMacosKeychainProviderIndex(providers: Iterable<string>): void {
-  try {
-    writeMacosKeychainProviderIndex(providers);
-  } catch {
-    // The provider index only powers discovery/listing. Keep the just-written
-    // secret usable in this process even if the secondary index write fails.
-  }
-}
-
 function readMacosKeychainStore(providerCandidates: Iterable<string>): StoredKeys {
   const out: StoredKeys = {};
   if (!isMacosKeychainAvailable()) return out;
@@ -427,6 +387,10 @@ function readMacosKeychainStore(providerCandidates: Iterable<string>): StoredKey
     if (value) out[provider] = value;
   }
   return out;
+}
+
+function canPersistEncryptedStore(): boolean {
+  return Boolean(storePath) && isSecureStorageAvailable();
 }
 
 function loadEncryptedStore(): StoredKeys {
@@ -457,29 +421,29 @@ function loadEncryptedStore(): StoredKeys {
   }
 }
 
-function migrateEncryptedStoreToMacosKeychain(encryptedStore: StoredKeys): void {
-  if (!isMacosKeychainAvailable()) return;
-  const providers = Object.keys(encryptedStore);
-  if (!providers.length) return;
-
-  const existingIndex = readMacosKeychainProviderIndex();
-  const nextProviders = new Set<string>(existingIndex.providers);
-  let changed = false;
-
-  for (const provider of providers) {
-    const value = encryptedStore[provider]?.trim();
-    if (!value) continue;
-    const existingValue = readMacosKeychainSecret(provider);
-    if (!existingValue) {
-      writeMacosKeychainSecret(provider, value);
-    }
-    nextProviders.add(provider);
-    changed = true;
+function deleteMacosKeychainSecretBestEffort(account: string): void {
+  try {
+    deleteMacosKeychainSecret(account);
+  } catch {
+    // Legacy Keychain cleanup should not block writes to the active encrypted
+    // store. A stale Keychain copy is still superseded by the encrypted value.
   }
+}
 
-  if (changed) {
-    writeMacosKeychainProviderIndex(nextProviders);
-  }
+function migrateLegacyMacosKeychainIntoEncryptedStore(encryptedStore: StoredKeys): StoredKeys {
+  if (!canPersistEncryptedStore() || !isMacosKeychainAvailable()) return encryptedStore;
+
+  const index = readMacosKeychainProviderIndex();
+  const providerCandidates = index.exists ? index.providers : Object.keys(encryptedStore);
+  if (providerCandidates.length === 0) return encryptedStore;
+
+  const keychainStore = readMacosKeychainStore(providerCandidates);
+  if (Object.keys(keychainStore).length === 0) return encryptedStore;
+
+  const nextStore = { ...encryptedStore, ...keychainStore };
+  persistEncryptedStore(nextStore);
+  decryptionFailed = false;
+  return nextStore;
 }
 
 function ensureStore(): StoredKeys {
@@ -495,26 +459,13 @@ function ensureStore(): StoredKeys {
 
   const encryptedStore = loadEncryptedStore();
   if (isMacosKeychainAvailable()) {
-    const indexBeforeMigration = readMacosKeychainProviderIndex();
-    if (!indexBeforeMigration.exists) {
-      try {
-        migrateEncryptedStoreToMacosKeychain(encryptedStore);
-      } catch {
-        // If Keychain migration is blocked, keep the decryptable encrypted
-        // store as the active fallback instead of dropping existing keys.
-      }
-    }
-
-    const index = readMacosKeychainProviderIndex();
-    if (index.exists) {
-      cache = readMacosKeychainStore(index.providers);
+    if (canPersistEncryptedStore()) {
+      cache = migrateLegacyMacosKeychainIntoEncryptedStore(encryptedStore);
       return cache;
     }
 
-    // Without an index, avoid probing every known provider synchronously on the
-    // Electron main thread. The old encrypted store remains the migration
-    // source of truth; direct Keychain reads happen on-demand by provider.
-    cache = encryptedStore;
+    const index = readMacosKeychainProviderIndex();
+    cache = index.exists ? readMacosKeychainStore(index.providers) : encryptedStore;
     return cache;
   }
 
@@ -590,16 +541,10 @@ export function storeApiKey(provider: string, key: string): void {
     writeCredentialProviderIndex(new Set([...index.providers, normalizedProvider]));
     return;
   }
-  if (isMacosKeychainAvailable()) {
-    writeMacosKeychainSecret(normalizedProvider, normalizedKey);
-    store[normalizedProvider] = normalizedKey;
-    missingMacosKeychainProviders.delete(normalizedProvider);
-    const index = readMacosKeychainProviderIndex();
-    tryWriteMacosKeychainProviderIndex(new Set([...index.providers, normalizedProvider]));
-    return;
-  }
   const nextStore = { ...store, [normalizedProvider]: normalizedKey };
   persistEncryptedStore(nextStore);
+  deleteMacosKeychainSecretBestEffort(normalizedProvider);
+  missingMacosKeychainProviders.add(normalizedProvider);
   cache = nextStore;
 }
 
@@ -625,8 +570,13 @@ export function getApiKey(provider: string): string | null {
     const keychainValue = readMacosKeychainSecret(normalizedProvider);
     if (keychainValue) {
       store[normalizedProvider] = keychainValue;
-      const index = readMacosKeychainProviderIndex();
-      tryWriteMacosKeychainProviderIndex(new Set([...index.providers, normalizedProvider]));
+      if (credentialStore) {
+        writeCredentialSecret(credentialProviderKey(normalizedProvider), keychainValue);
+        const index = readCredentialProviderIndex();
+        writeCredentialProviderIndex(new Set([...index.providers, normalizedProvider]));
+      } else if (canPersistEncryptedStore()) {
+        persistEncryptedStore(store);
+      }
       return keychainValue;
     }
     missingMacosKeychainProviders.add(normalizedProvider);
@@ -651,17 +601,17 @@ export function deleteApiKey(provider: string): void {
     writeCredentialProviderIndex(index.providers.filter((entry) => entry !== normalizedProvider));
     return;
   }
-  if (isMacosKeychainAvailable()) {
-    deleteMacosKeychainSecret(normalizedProvider);
-    delete store[normalizedProvider];
-    missingMacosKeychainProviders.add(normalizedProvider);
-    const index = readMacosKeychainProviderIndex();
-    tryWriteMacosKeychainProviderIndex(index.providers.filter((entry) => entry !== normalizedProvider));
-    return;
-  }
   const nextStore = { ...store };
   delete nextStore[normalizedProvider];
-  persistEncryptedStore(nextStore);
+  if (canPersistEncryptedStore()) {
+    persistEncryptedStore(nextStore);
+  } else if (isMacosKeychainAvailable()) {
+    deleteMacosKeychainSecret(normalizedProvider);
+  } else {
+    persistEncryptedStore(nextStore);
+  }
+  deleteMacosKeychainSecretBestEffort(normalizedProvider);
+  missingMacosKeychainProviders.add(normalizedProvider);
   cache = nextStore;
 }
 

--- a/apps/desktop/src/main/services/ai/apiKeyStore.ts
+++ b/apps/desktop/src/main/services/ai/apiKeyStore.ts
@@ -440,7 +440,7 @@ function migrateLegacyMacosKeychainIntoEncryptedStore(encryptedStore: StoredKeys
   const keychainStore = readMacosKeychainStore(providerCandidates);
   if (Object.keys(keychainStore).length === 0) return encryptedStore;
 
-  const nextStore = { ...encryptedStore, ...keychainStore };
+  const nextStore = { ...keychainStore, ...encryptedStore };
   persistEncryptedStore(nextStore);
   decryptionFailed = false;
   return nextStore;
@@ -604,10 +604,6 @@ export function deleteApiKey(provider: string): void {
   const nextStore = { ...store };
   delete nextStore[normalizedProvider];
   if (canPersistEncryptedStore()) {
-    persistEncryptedStore(nextStore);
-  } else if (isMacosKeychainAvailable()) {
-    deleteMacosKeychainSecret(normalizedProvider);
-  } else {
     persistEncryptedStore(nextStore);
   }
   deleteMacosKeychainSecretBestEffort(normalizedProvider);

--- a/apps/desktop/src/main/services/chat/cursorSdkPool.test.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkPool.test.ts
@@ -1,11 +1,55 @@
+import { EventEmitter } from "node:events";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  acquireCursorSdkConnection,
   buildCursorSdkPaths,
   buildCursorSdkWorkerEnv,
+  releaseCursorSdkConnection,
   resolveCursorSdkUserHome,
 } from "./cursorSdkPool";
+
+const forkMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  fork: (...args: unknown[]) => forkMock(...args),
+}));
+
+class FakeSdkChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  exitCode: number | null = null;
+  killed = false;
+  disposeCount = 0;
+
+  send(message: { type?: string; requestId?: string }): boolean {
+    if (message.type === "init" && message.requestId) {
+      queueMicrotask(() => {
+        this.emit("message", {
+          type: "response",
+          requestId: message.requestId,
+          ok: true,
+          result: { agentId: "agent-1" },
+        });
+      });
+    }
+    if (message.type === "dispose") {
+      this.disposeCount += 1;
+    }
+    return true;
+  }
+
+  kill(signal?: NodeJS.Signals): boolean {
+    this.killed = true;
+    this.emit("exit", null, signal ?? "SIGTERM");
+    return true;
+  }
+}
+
+afterEach(() => {
+  forkMock.mockReset();
+});
 
 describe("Cursor SDK pool paths", () => {
   it("uses the real user home while keeping ADE runtime state under the project cache", () => {
@@ -60,5 +104,40 @@ describe("Cursor SDK pool paths", () => {
       USERPROFILE: "C:\\Users\\admin",
     });
     expect(resolved).toBe(process.platform === "win32" ? "C:\\Users\\admin" : "/posix-home");
+  });
+
+  it("retains a ref for each concurrent waiter on a shared initialization", async () => {
+    const child = new FakeSdkChild();
+    forkMock.mockReturnValue(child);
+    const poolKey = `test:${Date.now()}:${Math.random()}`;
+    const args = {
+      poolKey,
+      projectRoot: path.join(os.tmpdir(), "ade-project"),
+      workspacePath: path.join(os.tmpdir(), "ade-workspace"),
+      modelSdkId: "cursor-model",
+      sessionId: "session-1",
+      policy: {
+        chatMode: "agent" as const,
+        approvalPolicy: "on-request" as const,
+        sandbox: "ade" as const,
+        force: false,
+        hardGuards: true,
+      },
+    };
+
+    const [first, second] = await Promise.all([
+      acquireCursorSdkConnection(args),
+      acquireCursorSdkConnection(args),
+    ]);
+
+    expect(forkMock).toHaveBeenCalledTimes(1);
+    expect(second.pooled).toBe(first.pooled);
+    expect(second.generation).toBe(first.generation);
+
+    releaseCursorSdkConnection(poolKey, first.generation);
+    expect(child.disposeCount).toBe(0);
+
+    releaseCursorSdkConnection(poolKey, second.generation);
+    expect(child.disposeCount).toBe(1);
   });
 });

--- a/apps/desktop/src/main/services/chat/cursorSdkPool.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkPool.ts
@@ -224,14 +224,16 @@ export async function acquireCursorSdkConnection(args: {
   }
 
   const pooled = await init;
-  if (!initOwner) {
-    const live = pools.get(args.poolKey);
-    if (live?.pooled === pooled) {
-      live.ref += 1;
-    }
-  }
   const entry = pools.get(args.poolKey);
-  return { pooled, generation: entry?.generation ?? 0 };
+  const live = entry?.pooled === pooled
+    && pooled.process.exitCode == null
+    && !pooled.process.killed;
+  if (!entry || !live) {
+    if (!initOwner) return acquireCursorSdkConnection(args);
+    throw new Error("Cursor SDK worker was disposed during initialization.");
+  }
+  if (!initOwner) entry.ref += 1;
+  return { pooled: entry.pooled, generation: entry.generation };
 }
 
 async function createCursorSdkConnection(args: Parameters<typeof acquireCursorSdkConnection>[0]): Promise<CursorSdkPooled> {

--- a/apps/desktop/src/main/services/chat/cursorSdkPool.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkPool.ts
@@ -82,6 +82,7 @@ const pools = new Map<string, {
   cleanupStateRoot: boolean;
 }>();
 const pendingInits = new Map<string, Promise<CursorSdkPooled>>();
+const STALE_INIT_RETRY_LIMIT = 2;
 
 function hashKey(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 16);
@@ -203,37 +204,44 @@ export async function acquireCursorSdkConnection(args: {
   cleanupStateRoot?: boolean;
   logger?: Logger;
 }): Promise<{ pooled: CursorSdkPooled; generation: number }> {
-  const existing = pools.get(args.poolKey);
-  if (existing && existing.pooled.process.exitCode == null && !existing.pooled.process.killed) {
-    existing.ref += 1;
-    return { pooled: existing.pooled, generation: existing.generation };
-  }
-  if (existing) {
-    pools.delete(args.poolKey);
-    cleanupCursorSdkRuntimePaths(existing);
-  }
+  for (let staleInitRetries = 0; ; staleInitRetries += 1) {
+    const existing = pools.get(args.poolKey);
+    if (existing && existing.pooled.process.exitCode == null && !existing.pooled.process.killed) {
+      existing.ref += 1;
+      return { pooled: existing.pooled, generation: existing.generation };
+    }
+    if (existing) {
+      pools.delete(args.poolKey);
+      cleanupCursorSdkRuntimePaths(existing);
+    }
 
-  let initOwner = false;
-  let init = pendingInits.get(args.poolKey);
-  if (!init) {
-    initOwner = true;
-    init = createCursorSdkConnection(args).finally(() => {
-      pendingInits.delete(args.poolKey);
-    });
-    pendingInits.set(args.poolKey, init);
-  }
+    let initOwner = false;
+    let init = pendingInits.get(args.poolKey);
+    if (!init) {
+      initOwner = true;
+      init = createCursorSdkConnection(args).finally(() => {
+        pendingInits.delete(args.poolKey);
+      });
+      pendingInits.set(args.poolKey, init);
+    }
 
-  const pooled = await init;
-  const entry = pools.get(args.poolKey);
-  const live = entry?.pooled === pooled
-    && pooled.process.exitCode == null
-    && !pooled.process.killed;
-  if (!entry || !live) {
-    if (!initOwner) return acquireCursorSdkConnection(args);
-    throw new Error("Cursor SDK worker was disposed during initialization.");
+    const pooled = await init;
+    const entry = pools.get(args.poolKey);
+    const live = entry?.pooled === pooled
+      && pooled.process.exitCode == null
+      && !pooled.process.killed;
+    if (!entry || !live) {
+      if (initOwner) {
+        throw new Error("Cursor SDK worker was disposed during initialization.");
+      }
+      if (staleInitRetries >= STALE_INIT_RETRY_LIMIT) {
+        throw new Error("Cursor SDK worker initialization did not settle after retries.");
+      }
+      continue;
+    }
+    if (!initOwner) entry.ref += 1;
+    return { pooled: entry.pooled, generation: entry.generation };
   }
-  if (!initOwner) entry.ref += 1;
-  return { pooled: entry.pooled, generation: entry.generation };
 }
 
 async function createCursorSdkConnection(args: Parameters<typeof acquireCursorSdkConnection>[0]): Promise<CursorSdkPooled> {

--- a/apps/desktop/src/main/services/chat/droidSdkPool.test.ts
+++ b/apps/desktop/src/main/services/chat/droidSdkPool.test.ts
@@ -1,0 +1,87 @@
+import { EventEmitter } from "node:events";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  acquireDroidSdkConnection,
+  releaseDroidSdkConnection,
+} from "./droidSdkPool";
+
+const forkMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  fork: (...args: unknown[]) => forkMock(...args),
+}));
+
+class FakeSdkChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  exitCode: number | null = null;
+  killed = false;
+  disposeCount = 0;
+
+  send(message: { type?: string; requestId?: string }): boolean {
+    if (message.type === "init" && message.requestId) {
+      queueMicrotask(() => {
+        this.emit("message", {
+          type: "response",
+          requestId: message.requestId,
+          ok: true,
+          result: {
+            sessionId: "sdk-session-1",
+            currentModelId: "droid-model",
+            availableModels: [{ id: "droid-model" }],
+          },
+        });
+      });
+    }
+    if (message.type === "dispose") {
+      this.disposeCount += 1;
+    }
+    return true;
+  }
+
+  kill(signal?: NodeJS.Signals): boolean {
+    this.killed = true;
+    this.emit("exit", null, signal ?? "SIGTERM");
+    return true;
+  }
+}
+
+afterEach(() => {
+  forkMock.mockReset();
+});
+
+describe("Droid SDK pool", () => {
+  it("retains a ref for each concurrent waiter on a shared initialization", async () => {
+    const child = new FakeSdkChild();
+    forkMock.mockReturnValue(child);
+    const poolKey = `test:${Date.now()}:${Math.random()}`;
+    const args = {
+      poolKey,
+      droidPath: "/usr/local/bin/droid",
+      workspacePath: path.join(os.tmpdir(), "ade-workspace"),
+      sessionId: "session-1",
+      settings: {
+        modelId: "droid-model",
+        autonomyLevel: "medium" as const,
+        interactionMode: "auto" as const,
+      },
+    };
+
+    const [first, second] = await Promise.all([
+      acquireDroidSdkConnection(args),
+      acquireDroidSdkConnection(args),
+    ]);
+
+    expect(forkMock).toHaveBeenCalledTimes(1);
+    expect(second.pooled).toBe(first.pooled);
+    expect(second.generation).toBe(first.generation);
+
+    releaseDroidSdkConnection(poolKey, first.generation);
+    expect(child.disposeCount).toBe(0);
+
+    releaseDroidSdkConnection(poolKey, second.generation);
+    expect(child.disposeCount).toBe(1);
+  });
+});

--- a/apps/desktop/src/main/services/chat/droidSdkPool.ts
+++ b/apps/desktop/src/main/services/chat/droidSdkPool.ts
@@ -87,12 +87,16 @@ export async function acquireDroidSdkConnection(args: {
   }
 
   const pooled = await init;
-  if (!initOwner) {
-    const live = pools.get(args.poolKey);
-    if (live?.pooled === pooled) live.ref += 1;
-  }
   const entry = pools.get(args.poolKey);
-  return { pooled, generation: entry?.generation ?? 0 };
+  const live = entry?.pooled === pooled
+    && pooled.process.exitCode == null
+    && !pooled.process.killed;
+  if (!entry || !live) {
+    if (!initOwner) return acquireDroidSdkConnection(args);
+    throw new Error("Droid SDK worker was disposed during initialization.");
+  }
+  if (!initOwner) entry.ref += 1;
+  return { pooled: entry.pooled, generation: entry.generation };
 }
 
 async function createDroidSdkConnection(args: Parameters<typeof acquireDroidSdkConnection>[0]): Promise<DroidSdkPooled> {

--- a/apps/desktop/src/main/services/chat/droidSdkPool.ts
+++ b/apps/desktop/src/main/services/chat/droidSdkPool.ts
@@ -45,6 +45,7 @@ export type DroidSdkPooled = {
 let droidSdkGenCounter = 0;
 const pools = new Map<string, { ref: number; generation: number; pooled: DroidSdkPooled }>();
 const pendingInits = new Map<string, Promise<DroidSdkPooled>>();
+const STALE_INIT_RETRY_LIMIT = 2;
 
 function resolveWorkerPath(): string {
   const candidates = [
@@ -71,32 +72,39 @@ export async function acquireDroidSdkConnection(args: {
   mcpServers?: unknown[];
   logger?: Logger;
 }): Promise<{ pooled: DroidSdkPooled; generation: number }> {
-  const existing = pools.get(args.poolKey);
-  if (existing && existing.pooled.process.exitCode == null && !existing.pooled.process.killed) {
-    existing.ref += 1;
-    return { pooled: existing.pooled, generation: existing.generation };
-  }
-  if (existing) pools.delete(args.poolKey);
+  for (let staleInitRetries = 0; ; staleInitRetries += 1) {
+    const existing = pools.get(args.poolKey);
+    if (existing && existing.pooled.process.exitCode == null && !existing.pooled.process.killed) {
+      existing.ref += 1;
+      return { pooled: existing.pooled, generation: existing.generation };
+    }
+    if (existing) pools.delete(args.poolKey);
 
-  let initOwner = false;
-  let init = pendingInits.get(args.poolKey);
-  if (!init) {
-    initOwner = true;
-    init = createDroidSdkConnection(args).finally(() => pendingInits.delete(args.poolKey));
-    pendingInits.set(args.poolKey, init);
-  }
+    let initOwner = false;
+    let init = pendingInits.get(args.poolKey);
+    if (!init) {
+      initOwner = true;
+      init = createDroidSdkConnection(args).finally(() => pendingInits.delete(args.poolKey));
+      pendingInits.set(args.poolKey, init);
+    }
 
-  const pooled = await init;
-  const entry = pools.get(args.poolKey);
-  const live = entry?.pooled === pooled
-    && pooled.process.exitCode == null
-    && !pooled.process.killed;
-  if (!entry || !live) {
-    if (!initOwner) return acquireDroidSdkConnection(args);
-    throw new Error("Droid SDK worker was disposed during initialization.");
+    const pooled = await init;
+    const entry = pools.get(args.poolKey);
+    const live = entry?.pooled === pooled
+      && pooled.process.exitCode == null
+      && !pooled.process.killed;
+    if (!entry || !live) {
+      if (initOwner) {
+        throw new Error("Droid SDK worker was disposed during initialization.");
+      }
+      if (staleInitRetries >= STALE_INIT_RETRY_LIMIT) {
+        throw new Error("Droid SDK worker initialization did not settle after retries.");
+      }
+      continue;
+    }
+    if (!initOwner) entry.ref += 1;
+    return { pooled: entry.pooled, generation: entry.generation };
   }
-  if (!initOwner) entry.ref += 1;
-  return { pooled: entry.pooled, generation: entry.generation };
 }
 
 async function createDroidSdkConnection(args: Parameters<typeof acquireDroidSdkConnection>[0]): Promise<DroidSdkPooled> {


### PR DESCRIPTION
Refs ADE-72
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-72: Chat/AI runtime: Keychain key in argv + SDK pool ref-count race, plus chat/AI/ade-action god-file & typed-dispatch decomposition](https://linear.app/ade-linear/issue/ADE-72/chatai-runtime-keychain-key-in-argv-sdk-pool-ref-count-race-plus) - referenced
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-72-chat-ai-runtime-keychain-key-in-argv-sdk-pool-ref-count-race-plus-chat-ai-ade-action-god-file-typed-dispatch-decomposition num=494 -->
<p>
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://ade.app/logo-dark.svg">
    <img src="https://ade.app/logo-light.svg" height="18" align="left" alt="ADE">
  </picture>
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade.app/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-72-chat-ai-runtime-keychain-key-in-argv-sdk-pool-ref-count-race-plus-chat-ai-ade-action-god-file-typed-dispatch-decomposition&amp;pr=494">ade-72-chat-ai-runtime-keychain-key-in-argv-sdk-pool-ref-count-race-plus-chat-ai-ade-action-god-file-typed-dispatch-decomposition branch</a>
  &nbsp;·&nbsp; <a href="https://ade.app/open?type=pr&amp;repo=arul28%2FADE&amp;number=494">PR #494</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two distinct runtime bugs: (1) API keys were being passed as clear-text CLI arguments to `/usr/bin/security` (visible in `ps` output), replaced now by writing exclusively to Electron `safeStorage`; (2) concurrent `acquireSdkConnection` callers shared a single init promise but only the non-`initOwner` caller incremented the ref-count — a race that could produce a premature dispose. The migration direction is also inverted (Keychain → encrypted store instead of encrypted store → Keychain), and the provider-index write path is removed entirely.

- **apiKeyStore**: `writeMacosKeychainSecret` and its provider-index helpers are deleted; `storeApiKey` and `deleteApiKey` now always target `safeStorage`; a new `migrateLegacyMacosKeychainIntoEncryptedStore` runs on first cold start to absorb any pre-existing Keychain entries into the encrypted store, with encrypted-store values taking precedence over Keychain values in the merge.
- **cursorSdkPool / droidSdkPool**: Unbounded tail-recursion replaced by a bounded `for` loop (`STALE_INIT_RETRY_LIMIT = 2`); both `initOwner` and non-`initOwner` callers check process liveness after `await init`; `initOwner` throws immediately on post-init worker exit; non-`initOwner` retries up to the limit before throwing.
- **Tests**: New pool tests assert that two concurrent acquires share one `fork` call and each hold an independent ref that must be released before dispose fires; `apiKeyStore` tests updated to assert zero `add-generic-password` calls and verify the new merge semantics.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the security fix and ref-count corrections are sound, and the two noted observations are edge-case quality improvements.

All three core changes (removing Keychain argv writes, inverting migration direction, bounding SDK pool retries) are implemented correctly and are covered by new tests. The two flagged items are resilience and cleanup concerns that surface only under unusual conditions — a transient disk-write failure during startup migration, and repeated but idempotent migration writes for users who upgrade without changing their keys. Neither represents incorrect behaviour under normal operating conditions.

apps/desktop/src/main/services/ai/apiKeyStore.ts — the migration path in ensureStore deserves a second look for error-handling resilience.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/ai/apiKeyStore.ts | Security fix removing `writeMacosKeychainSecret` (which passed keys as `-w key` CLI args visible in process list); rewrites migration direction (Keychain to encrypted store); `migrateLegacyMacosKeychainIntoEncryptedStore` lacks the try/catch that guarded the old migration path. |
| apps/desktop/src/main/services/ai/apiKeyStore.test.ts | Tests updated to reflect new behaviour: no Keychain writes, encrypted-store wins merge, deleteApiKey soft-fails gracefully when storage is unavailable; covers the new migration direction and stale-Keychain cleanup. |
| apps/desktop/src/main/services/chat/cursorSdkPool.ts | Converts unbounded recursive retry into a bounded for-loop with STALE_INIT_RETRY_LIMIT=2; correctly increments ref only for non-initOwner callers after a shared init settles; initOwner now throws immediately on post-init worker exit. |
| apps/desktop/src/main/services/chat/cursorSdkPool.test.ts | New test validates the ref-count race fix: two concurrent acquires share one fork, each acquire holds an independent ref, and dispose fires only after both refs are released. |
| apps/desktop/src/main/services/chat/droidSdkPool.ts | Mirrors the cursorSdkPool bounded-retry pattern; same ref-count race fix applied consistently. |
| apps/desktop/src/main/services/chat/droidSdkPool.test.ts | New test file, mirrors the cursorSdkPool ref-count test; FakeSdkChild correctly simulates the init RPC response and dispose accounting. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant ensureStore
    participant loadEncryptedStore
    participant migrateLegacyKeychain
    participant Keychain
    participant safeStorage

    App->>ensureStore: "first call (cache=null)"
    ensureStore->>loadEncryptedStore: read encrypted store
    loadEncryptedStore->>safeStorage: decryptString(blob)
    safeStorage-->>loadEncryptedStore: stored keys map
    loadEncryptedStore-->>ensureStore: encryptedStore
    alt canPersistEncryptedStore() and isMacosKeychainAvailable()
        ensureStore->>migrateLegacyKeychain: encryptedStore
        migrateLegacyKeychain->>Keychain: readProviderIndex and readStore
        Keychain-->>migrateLegacyKeychain: legacy entries
        Note over migrateLegacyKeychain: merge keychainStore then encryptedStore encrypted store wins on conflict
        migrateLegacyKeychain->>safeStorage: persistEncryptedStore(merged)
        migrateLegacyKeychain-->>ensureStore: mergedStore becomes cache
    else safeStorage unavailable and Keychain available
        ensureStore->>Keychain: readProviderIndex and readStore read-only
        Keychain-->>ensureStore: cached keys
    end

    App->>storeApiKey: provider and new value
    storeApiKey->>safeStorage: persistEncryptedStore
    storeApiKey->>Keychain: deleteMacosKeychainSecretBestEffort
    Note over storeApiKey: mark provider in missingMacosKeychainProviders

    App->>releaseSdkConnection: poolKey and generation
    Note over releaseSdkConnection: ref minus 1 if zero then dispose and cleanup
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fai%2FapiKeyStore.ts%3A461-465%0AMissing%20error%20resilience%20around%20%60persistEncryptedStore%60%20in%20migration.%20The%20old%20%60ensureStore%60%20path%20that%20called%20%60migrateEncryptedStoreToMacosKeychain%60%20was%20wrapped%20in%20a%20%60try%2Fcatch%60%20so%20that%20a%20transient%20disk-write%20failure%20would%20silently%20fall%20back%20to%20the%20encrypted%20store%20as-is.%20The%20new%20path%20calls%20%60migrateLegacyMacosKeychainIntoEncryptedStore%60%20without%20any%20guard%2C%20so%20any%20%60persistEncryptedStore%60%20failure%20%28full%20disk%2C%20permission%20error%2C%20brief%20safeStorage%20blip%29%20propagates%20out%20of%20%60ensureStore%28%29%60%20and%20breaks%20every%20subsequent%20%60getApiKey%60%20%2F%20%60storeApiKey%60%20%2F%20%60deleteApiKey%60%20call%20for%20users%20who%20have%20legacy%20Keychain%20entries%20at%20startup.%0A%0A%60%60%60suggestion%0A%20%20if%20%28isMacosKeychainAvailable%28%29%29%20%7B%0A%20%20%20%20if%20%28canPersistEncryptedStore%28%29%29%20%7B%0A%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20cache%20%3D%20migrateLegacyMacosKeychainIntoEncryptedStore%28encryptedStore%29%3B%0A%20%20%20%20%20%20%7D%20catch%20%7B%0A%20%20%20%20%20%20%20%20%2F%2F%20A%20transient%20write%20failure%20during%20migration%20should%20not%20break%20all%0A%20%20%20%20%20%20%20%20%2F%2F%20API%20key%20operations%20%E2%80%94%20fall%20back%20to%20the%20in-memory%20encrypted%20store.%0A%20%20%20%20%20%20%20%20cache%20%3D%20encryptedStore%3B%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20return%20cache%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fai%2FapiKeyStore.ts%3A433-447%0A**Migration%20reruns%20on%20every%20startup%20until%20Keychain%20entries%20are%20manually%20evicted**%0A%0A%60migrateLegacyMacosKeychainIntoEncryptedStore%60%20calls%20%60persistEncryptedStore%60%20on%20every%20cold%20%60ensureStore%28%29%60%20%28i.e.%20every%20app%20restart%29%20for%20as%20long%20as%20any%20legacy%20Keychain%20entry%20survives.%20Keychain%20entries%20are%20only%20deleted%20by%20a%20subsequent%20%60storeApiKey%60%20call%20via%20%60deleteMacosKeychainSecretBestEffort%60.%20A%20user%20who%20upgrades%20but%20never%20re-saves%20their%20API%20keys%20will%20trigger%20an%20unnecessary%20safeStorage%20disk-write%20on%20every%20launch.%20Consider%20deleting%20each%20migrated%20provider's%20Keychain%20entry%20inside%20the%20migration%20itself%20%28or%20recording%20a%20completion%20flag%20in%20the%20encrypted%20store%29%20to%20make%20the%20migration%20a%20true%20one-shot%20operation.%0A%0A&repo=arul28%2Fade&pr=494&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src/main/services/ai/apiKeyStore.ts:461-465
Missing error resilience around `persistEncryptedStore` in migration. The old `ensureStore` path that called `migrateEncryptedStoreToMacosKeychain` was wrapped in a `try/catch` so that a transient disk-write failure would silently fall back to the encrypted store as-is. The new path calls `migrateLegacyMacosKeychainIntoEncryptedStore` without any guard, so any `persistEncryptedStore` failure (full disk, permission error, brief safeStorage blip) propagates out of `ensureStore()` and breaks every subsequent `getApiKey` / `storeApiKey` / `deleteApiKey` call for users who have legacy Keychain entries at startup.

```suggestion
  if (isMacosKeychainAvailable()) {
    if (canPersistEncryptedStore()) {
      try {
        cache = migrateLegacyMacosKeychainIntoEncryptedStore(encryptedStore);
      } catch {
        // A transient write failure during migration should not break all
        // API key operations — fall back to the in-memory encrypted store.
        cache = encryptedStore;
      }
      return cache;
    }
```

### Issue 2 of 2
apps/desktop/src/main/services/ai/apiKeyStore.ts:433-447
**Migration reruns on every startup until Keychain entries are manually evicted**

`migrateLegacyMacosKeychainIntoEncryptedStore` calls `persistEncryptedStore` on every cold `ensureStore()` (i.e. every app restart) for as long as any legacy Keychain entry survives. Keychain entries are only deleted by a subsequent `storeApiKey` call via `deleteMacosKeychainSecretBestEffort`. A user who upgrades but never re-saves their API keys will trigger an unnecessary safeStorage disk-write on every launch. Consider deleting each migrated provider's Keychain entry inside the migration itself (or recording a completion flag in the encrypted store) to make the migration a true one-shot operation.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address chat runtime review finding..."](https://github.com/arul28/ade/commit/e62d38cc7e8de2caf25c5aa2cc0ad4e6a4996813) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34829270)</sub>

<!-- /greptile_comment -->