### PR TITLE
ADE-71: State/sync/config persistence & kvDb hardening: crash-safe writes, migration versioning, and god-file/dedup decomposition

### DIFF
--- a/apps/desktop/src/main/services/config/projectConfigService.ts
+++ b/apps/desktop/src/main/services/config/projectConfigService.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import YAML from "yaml";
 import cron from "node-cron";
+import { z } from "zod";
 import type {
   AiConfig,
   AiFeatureKey,
@@ -91,6 +92,27 @@ const AUTOMATION_ACTION_TYPE_SET = new Set<string>([
   "run-command",
   "ade-action",
 ]);
+const OPTIONAL_STRING_SCHEMA = z.string().optional().catch(undefined);
+const OPTIONAL_NUMBER_SCHEMA = z.number().finite().optional().catch(undefined);
+const OPTIONAL_BOOL_SCHEMA = z.boolean().optional().catch(undefined);
+const STRING_ARRAY_SCHEMA = z.array(z.unknown())
+  .transform((values) => values
+    .filter((value): value is string => typeof value === "string")
+    .map((value) => value.trim())
+    .filter(Boolean))
+  .optional()
+  .catch(() => undefined);
+const STRING_MAP_SCHEMA = z.record(z.string(), z.unknown())
+  .transform((value) => {
+    const out: Record<string, string> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      if (typeof entry === "string") out[key] = entry;
+    }
+    return out;
+  })
+  .optional()
+  .catch(() => undefined);
+const COMPUTE_BACKEND_SCHEMA = z.enum(["local", "vps", "daytona"]).optional().catch(undefined);
 
 function isPathWithinProjectRoot(projectRoot: string, candidate: string, opts: { allowMissing?: boolean } = {}): boolean {
   try {
@@ -102,12 +124,11 @@ function isPathWithinProjectRoot(projectRoot: string, candidate: string, opts: {
 }
 
 function asString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
+  return OPTIONAL_STRING_SCHEMA.parse(value);
 }
 
 function asStringArray(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-  return value.filter((v): v is string => typeof v === "string").map((v) => v.trim()).filter(Boolean);
+  return STRING_ARRAY_SCHEMA.parse(value);
 }
 
 function asLaneTypeArray(value: unknown): LaneType[] | undefined {
@@ -120,15 +141,15 @@ function asLaneTypeArray(value: unknown): LaneType[] | undefined {
 }
 
 function asNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  return OPTIONAL_NUMBER_SCHEMA.parse(value);
 }
 
 function asBool(value: unknown): boolean | undefined {
-  return typeof value === "boolean" ? value : undefined;
+  return OPTIONAL_BOOL_SCHEMA.parse(value);
 }
 
 function asComputeBackend(value: unknown): "local" | "vps" | "daytona" | undefined {
-  return value === "local" || value === "vps" || value === "daytona" ? value : undefined;
+  return COMPUTE_BACKEND_SCHEMA.parse(value);
 }
 
 function coerceOrchestratorHookConfig(value: unknown): { command: string; timeoutMs?: number } | null {
@@ -147,12 +168,7 @@ function coerceOrchestratorHookConfig(value: unknown): { command: string; timeou
 }
 
 function asStringMap(value: unknown): Record<string, string> | undefined {
-  if (!isRecord(value)) return undefined;
-  const out: Record<string, string> = {};
-  for (const [k, v] of Object.entries(value)) {
-    if (typeof v === "string") out[k] = v;
-  }
-  return out;
+  return STRING_MAP_SCHEMA.parse(value);
 }
 
 function normalizeConfigPath(value: string): string {

--- a/apps/desktop/src/main/services/history/operationService.ts
+++ b/apps/desktop/src/main/services/history/operationService.ts
@@ -8,6 +8,19 @@ type OperationStatus = "running" | "succeeded" | "failed" | "canceled";
 type OperationMetadata = Record<string, unknown>;
 type HeadChangeOperationRecord = OperationRecord & { preHeadSha: string; postHeadSha: string };
 
+const OPERATION_COLUMNS = `
+  o.id as id,
+  o.lane_id as laneId,
+  l.name as laneName,
+  o.kind as kind,
+  o.started_at as startedAt,
+  o.ended_at as endedAt,
+  o.status as status,
+  o.pre_head_sha as preHeadSha,
+  o.post_head_sha as postHeadSha,
+  o.metadata_json as metadataJson
+`;
+
 function safeParseMetadata(raw: string | null | undefined): OperationMetadata {
   const parsed = safeJsonParse(raw, null);
   return isRecord(parsed) ? parsed : {};
@@ -96,17 +109,7 @@ export function createOperationService({
       if (!operationId.trim()) return null;
       const row = db.get<OperationRecord>(
         `
-          select
-            o.id as id,
-            o.lane_id as laneId,
-            l.name as laneName,
-            o.kind as kind,
-            o.started_at as startedAt,
-            o.ended_at as endedAt,
-            o.status as status,
-            o.pre_head_sha as preHeadSha,
-            o.post_head_sha as postHeadSha,
-            o.metadata_json as metadataJson
+          select ${OPERATION_COLUMNS}
           from operations o
           left join lanes l on l.id = o.lane_id
           where o.project_id = ? and o.id = ?
@@ -144,17 +147,7 @@ export function createOperationService({
       const limit = typeof args.limit === "number" ? Math.max(1, Math.min(1000, Math.floor(args.limit))) : 100;
       return db.all<HeadChangeOperationRecord>(
         `
-          select
-            o.id as id,
-            o.lane_id as laneId,
-            l.name as laneName,
-            o.kind as kind,
-            o.started_at as startedAt,
-            o.ended_at as endedAt,
-            o.status as status,
-            o.pre_head_sha as preHeadSha,
-            o.post_head_sha as postHeadSha,
-            o.metadata_json as metadataJson
+          select ${OPERATION_COLUMNS}
           from operations o
           left join lanes l on l.id = o.lane_id
           where o.project_id = ?
@@ -197,17 +190,7 @@ export function createOperationService({
 
       const rows = db.all<OperationRecord>(
         `
-          select
-            o.id as id,
-            o.lane_id as laneId,
-            l.name as laneName,
-            o.kind as kind,
-            o.started_at as startedAt,
-            o.ended_at as endedAt,
-            o.status as status,
-            o.pre_head_sha as preHeadSha,
-            o.post_head_sha as postHeadSha,
-            o.metadata_json as metadataJson
+          select ${OPERATION_COLUMNS}
           from operations o
           left join lanes l on l.id = o.lane_id
           where ${where.join(" and ")}

--- a/apps/desktop/src/main/services/sessions/sessionService.ts
+++ b/apps/desktop/src/main/services/sessions/sessionService.ts
@@ -532,9 +532,13 @@ export function createSessionService({ db }: { db: AdeDb }) {
             .map((toolType) => normalizeToolType(toolType))
             .filter((toolType): toolType is TerminalToolType => toolType != null)
         : [];
-      const exclusionSql = normalizedExcludedToolTypes.length
-        ? ` and (tool_type is null or tool_type not in (${normalizedExcludedToolTypes.map(() => "?").join(", ")}))`
-        : "";
+      type SqlClause = { sql: string; params: Array<string | number> };
+      const exclusionClause: SqlClause = normalizedExcludedToolTypes.length
+        ? {
+            sql: ` and (tool_type is null or tool_type not in (${normalizedExcludedToolTypes.map(() => "?").join(", ")}))`,
+            params: normalizedExcludedToolTypes,
+          }
+        : { sql: "", params: [] };
       const ownerParams = liveOwnerPids
         ? Array.from(liveOwnerPids)
             .map((pid) => normalizeOwnerPid(pid))
@@ -577,25 +581,33 @@ export function createSessionService({ db }: { db: AdeDb }) {
         identity.pid,
         identity.startedAt,
       ]);
-      const ownerGuardSql = (() => {
-        if (liveOwnerPids === undefined) return " and owner_pid is null";
+      const ownerGuardClause = ((): SqlClause => {
+        if (liveOwnerPids === undefined) return { sql: " and owner_pid is null", params: [] };
         const hasKnownOwnerScope = knownOwnerPids !== undefined || knownOwnerIdentities !== undefined;
         if (!hasKnownOwnerScope) {
           if (ownerIdentities.length) {
-            return ` and (owner_pid is null or owner_process_started_at is null or not (${ownerIdentities.map(() => "(owner_pid = ? and owner_process_started_at = ?)").join(" or ")}))`;
+            return {
+              sql: ` and (owner_pid is null or owner_process_started_at is null or not (${ownerIdentities.map(() => "(owner_pid = ? and owner_process_started_at = ?)").join(" or ")}))`,
+              params: ownerIdentityParams,
+            };
           }
           return ownerParams.length
-            ? ` and (owner_pid is null or owner_pid not in (${ownerParams.map(() => "?").join(", ")}))`
-            : "";
+            ? {
+                sql: ` and (owner_pid is null or owner_pid not in (${ownerParams.map(() => "?").join(", ")}))`,
+                params: ownerParams,
+              }
+            : { sql: "", params: [] };
         }
 
         const staleKnownClauses = ["owner_pid is null"];
+        const params: Array<string | number> = [];
         if (knownOwnerIdentityRows.length) {
           const knownIdentitySql = knownOwnerIdentityRows.map(() => "(owner_pid = ? and owner_process_started_at = ?)").join(" or ");
           const liveIdentitySql = ownerIdentities.length
             ? ownerIdentities.map(() => "(owner_pid = ? and owner_process_started_at = ?)").join(" or ")
             : "0";
           staleKnownClauses.push(`(owner_process_started_at is not null and (${knownIdentitySql}) and not (${liveIdentitySql}))`);
+          params.push(...knownOwnerIdentityParams, ...ownerIdentityParams);
         }
         if (knownOwnerParams.length) {
           const knownPidSql = knownOwnerParams.map(() => "?").join(", ");
@@ -603,21 +615,9 @@ export function createSessionService({ db }: { db: AdeDb }) {
             ? ` and owner_pid not in (${ownerParams.map(() => "?").join(", ")})`
             : "";
           staleKnownClauses.push(`(owner_process_started_at is null and owner_pid in (${knownPidSql})${livePidSql})`);
+          params.push(...knownOwnerParams, ...ownerParams);
         }
-        return ` and (${staleKnownClauses.join(" or ")})`;
-      })();
-      const ownerGuardParams = (() => {
-        if (liveOwnerPids === undefined) return [];
-        const hasKnownOwnerScope = knownOwnerPids !== undefined || knownOwnerIdentities !== undefined;
-        if (!hasKnownOwnerScope) {
-          return ownerIdentities.length ? ownerIdentityParams : ownerParams;
-        }
-        return [
-          ...knownOwnerIdentityParams,
-          ...(knownOwnerIdentityRows.length ? ownerIdentityParams : []),
-          ...knownOwnerParams,
-          ...(knownOwnerParams.length ? ownerParams : []),
-        ];
+        return { sql: ` and (${staleKnownClauses.join(" or ")})`, params };
       })();
       const graceMs = typeof freshActivityGraceMs === "number" && Number.isFinite(freshActivityGraceMs)
         ? Math.max(0, freshActivityGraceMs)
@@ -627,16 +627,15 @@ export function createSessionService({ db }: { db: AdeDb }) {
       const activityCutoff = graceMs > 0 && Number.isFinite(cutoffMs)
         ? new Date(cutoffMs).toISOString()
         : null;
-      const activityGuardSql = activityCutoff
-        ? " and started_at < ? and (last_output_at is null or last_output_at < ?)"
-        : "";
-      const activityParams = activityCutoff ? [activityCutoff, activityCutoff] : [];
-      const whereSql = `status = 'running'${exclusionSql}${ownerGuardSql}${activityGuardSql}`;
-      const params = [
-        ...normalizedExcludedToolTypes,
-        ...ownerGuardParams,
-        ...activityParams,
-      ];
+      const activityClause: SqlClause = activityCutoff
+        ? {
+            sql: " and started_at < ? and (last_output_at is null or last_output_at < ?)",
+            params: [activityCutoff, activityCutoff],
+          }
+        : { sql: "", params: [] };
+      const clauses = [exclusionClause, ownerGuardClause, activityClause];
+      const whereSql = `status = 'running'${clauses.map((clause) => clause.sql).join("")}`;
+      const params = clauses.flatMap((clause) => clause.params);
       const rows = db.all<{ id: string }>(
         `select id from terminal_sessions where ${whereSql}`,
         params,

--- a/apps/desktop/src/main/services/state/globalState.test.ts
+++ b/apps/desktop/src/main/services/state/globalState.test.ts
@@ -1,6 +1,9 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { upsertRecentProject, type GlobalState } from "./globalState";
+import { readGlobalState, upsertRecentProject, writeGlobalState, type GlobalState } from "./globalState";
 
 describe("upsertRecentProject", () => {
   it("keeps an existing project in place when preserving recent order", () => {
@@ -60,5 +63,23 @@ describe("upsertRecentProject", () => {
     );
 
     expect(next.lastProjectRoot).toBe("/projects/a");
+  });
+});
+
+describe("writeGlobalState", () => {
+  it("persists state through an atomic temp-file rename", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ade-global-state-"));
+    const filePath = path.join(dir, "global-state.json");
+    const state: GlobalState = {
+      lastProjectRoot: "/repo/ade",
+      recentProjects: [
+        { rootPath: "/repo/ade", displayName: "ADE", lastOpenedAt: "2026-05-31T00:00:00.000Z" },
+      ],
+    };
+
+    writeGlobalState(filePath, state);
+
+    expect(readGlobalState(filePath)).toEqual(state);
+    expect(fs.readdirSync(dir).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
   });
 });

--- a/apps/desktop/src/main/services/state/globalState.ts
+++ b/apps/desktop/src/main/services/state/globalState.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 import type { OpenProjectBinding, RecentlyInstalledUpdate } from "../../../shared/types";
 
 export type RecentProject = {
@@ -36,10 +37,37 @@ export function readGlobalState(filePath: string): GlobalState {
 }
 
 export function writeGlobalState(filePath: string, state: GlobalState): void {
+  let tempPath: string | null = null;
+  let fd: number | null = null;
   try {
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(filePath, JSON.stringify(state, null, 2), "utf8");
+    const dir = path.dirname(filePath);
+    fs.mkdirSync(dir, { recursive: true });
+    tempPath = path.join(dir, `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`);
+    const serialized = `${JSON.stringify(state, null, 2)}\n`;
+    fd = fs.openSync(tempPath, "w");
+    fs.writeFileSync(fd, serialized, "utf8");
+    fs.fsyncSync(fd);
+    fs.closeSync(fd);
+    fd = null;
+    fs.renameSync(tempPath, filePath);
+    tempPath = null;
+    try {
+      const dirFd = fs.openSync(dir, "r");
+      try {
+        fs.fsyncSync(dirFd);
+      } finally {
+        fs.closeSync(dirFd);
+      }
+    } catch {
+      // Directory fsync is best effort across filesystems/platforms.
+    }
   } catch {
+    if (fd != null) {
+      try { fs.closeSync(fd); } catch {}
+    }
+    if (tempPath) {
+      try { fs.unlinkSync(tempPath); } catch {}
+    }
     // Non-fatal; global state is a convenience.
   }
 }

--- a/apps/desktop/src/main/services/state/kvDb.test.ts
+++ b/apps/desktop/src/main/services/state/kvDb.test.ts
@@ -216,6 +216,17 @@ describe("openKvDb SQL binding", () => {
       db.all("select flag from db_value_test where flag = ?", [{} as any]),
     ).toThrow(/Unsupported database value at parameter 1: object .*sql=select flag from db_value_test/i);
   });
+
+  it("checkpoints pending writes when flushed", async () => {
+    const projectRoot = makeProjectRoot("ade-kvdb-flush-");
+    const dbPath = path.join(projectRoot, ".ade", "ade.db");
+    const db = await openKvDb(dbPath, createLogger() as any);
+    activeDisposers.push(async () => db.close());
+
+    db.setJson("flush:probe", { ok: true });
+    expect(() => db.flushNow()).not.toThrow();
+    expect(db.getJson<{ ok: boolean }>("flush:probe")).toEqual({ ok: true });
+  });
 });
 
 describe("lane_linear_issue_links schema", () => {

--- a/apps/desktop/src/main/services/state/kvDb.ts
+++ b/apps/desktop/src/main/services/state/kvDb.ts
@@ -212,6 +212,19 @@ function quoteIdentifier(value: string): string {
   return `"${value.replace(/"/g, "\"\"")}"`;
 }
 
+function unquoteSqlIdentifier(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith("\"") && trimmed.endsWith("\""))
+    || (trimmed.startsWith("'") && trimmed.endsWith("'"))
+    || (trimmed.startsWith("`") && trimmed.endsWith("`"))
+    || (trimmed.startsWith("[") && trimmed.endsWith("]"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
 function rewriteCreateTableName(sql: string, fromName: string, toName: string): string {
   const pattern = new RegExp(
     `^(\\s*create\\s+table\\s+(?:if\\s+not\\s+exists\\s+)?)((?:["'\`\\[])?${escapeRegExp(fromName)}(?:["'\`\\]])?)`,
@@ -862,7 +875,7 @@ function rebuildCrrTableWithBackfill(db: DatabaseSyncType, tableName: string): v
     .filter((sql) => sql.length > 0);
 
   runStatement(db, "pragma foreign_keys = off");
-  runStatement(db, "begin");
+  runStatement(db, "BEGIN IMMEDIATE");
   try {
     runStatement(
       db,
@@ -1081,7 +1094,85 @@ type MigrationDb = {
 function parseAlterTableTarget(sql: string): string | null {
   const match = sql.match(/^\s*alter\s+table\s+([`"'[\]A-Za-z0-9_]+)\s+add\s+column\s+/i);
   if (!match?.[1]) return null;
-  return match[1].replace(/^["'`[]|["'`\]]$/g, "");
+  return unquoteSqlIdentifier(match[1]);
+}
+
+function parseAlterTableAddColumn(sql: string): { tableName: string; columnName: string } | null {
+  const identifier = String.raw`(?:"[^"]+"|'[^']+'|` + "`[^`]+`" + String.raw`|\[[^\]]+\]|[A-Za-z0-9_]+)`;
+  const match = sql.match(new RegExp(String.raw`^\s*alter\s+table\s+(${identifier})\s+add\s+column\s+(${identifier})\b`, "i"));
+  if (!match?.[1] || !match[2]) return null;
+  return {
+    tableName: unquoteSqlIdentifier(match[1]),
+    columnName: unquoteSqlIdentifier(match[2]),
+  };
+}
+
+function migrationHasColumn(db: MigrationDb, tableName: string, columnName: string): boolean {
+  return db.all<{ name: string }>(`pragma table_info('${tableName.replace(/'/g, "''")}')`)
+    .some((column) => column.name === columnName);
+}
+
+function isDuplicateColumnError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /duplicate column name/i.test(message);
+}
+
+function safeAddColumn(db: MigrationDb, sql: string): void {
+  const parsed = parseAlterTableAddColumn(sql);
+  if (!parsed) {
+    db.run(sql);
+    return;
+  }
+  if (migrationHasColumn(db, parsed.tableName, parsed.columnName)) return;
+  try {
+    db.run(sql);
+  } catch (error) {
+    if (isDuplicateColumnError(error) && migrationHasColumn(db, parsed.tableName, parsed.columnName)) {
+      return;
+    }
+    console.warn("kvDb.migrate.add_column_failed", {
+      tableName: parsed.tableName,
+      columnName: parsed.columnName,
+      sql: sql.replace(/\s+/g, " ").trim(),
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}
+
+function makeCrrAwareDb({
+  getDb,
+  isCrsqliteLoaded,
+}: {
+  getDb: () => DatabaseSyncType;
+  isCrsqliteLoaded: () => boolean;
+}): MigrationDb {
+  return {
+    run: (sql: string, params: SqlValue[] = []) => {
+      const db = getDb();
+      const alterTable = parseAlterTableTarget(sql);
+      if (alterTable && isCrsqliteLoaded() && rawHasTable(db, `${alterTable}__crsql_clock`)) {
+        getRow(db, "select crsql_begin_alter(?) as ok", [alterTable]);
+        try {
+          runStatement(db, sql, params);
+        } catch (error) {
+          // Commit the alter even on failure so the CRR state stays consistent,
+          // then re-throw so callers can handle duplicate-column upgrades.
+          getRow(db, "select crsql_commit_alter(?) as ok", [alterTable]);
+          throw error;
+        }
+        getRow(db, "select crsql_commit_alter(?) as ok", [alterTable]);
+        return;
+      }
+      runStatement(db, sql, params);
+    },
+    get: <T extends Record<string, unknown> = Record<string, unknown>>(sql: string, params: SqlValue[] = []) => {
+      return getRow<T>(getDb(), sql, params);
+    },
+    all: <T extends Record<string, unknown> = Record<string, unknown>>(sql: string, params: SqlValue[] = []) => {
+      return allRows<T>(getDb(), sql, params);
+    },
+  };
 }
 
 function migrate(db: MigrationDb) {
@@ -1135,7 +1226,7 @@ function migrate(db: MigrationDb) {
       foreign key(parent_lane_id) references lanes(id)
     )
   `);
-  try { db.run("alter table lanes add column runtime_placement text not null default 'local'"); } catch {}
+  safeAddColumn(db, "alter table lanes add column runtime_placement text not null default 'local'");
   db.run("create index if not exists idx_lanes_project_id on lanes(project_id)");
   db.run("create index if not exists idx_lanes_project_type on lanes(project_id, lane_type)");
   db.run("create index if not exists idx_lanes_project_parent on lanes(project_id, parent_lane_id)");
@@ -1408,20 +1499,20 @@ function migrate(db: MigrationDb) {
   db.run("create index if not exists idx_terminal_sessions_lane_started_at on terminal_sessions(lane_id, started_at desc)");
 
   // Migration: add resume_command to existing databases that pre-date this column.
-  try { db.run("alter table terminal_sessions add column resume_command text"); } catch {}
-  try { db.run("alter table terminal_sessions add column resume_metadata_json text"); } catch {}
-  try { db.run("alter table terminal_sessions add column manually_named integer not null default 0"); } catch {}
-  try { db.run("alter table terminal_sessions add column archived_at text"); } catch {}
-  try { db.run("alter table terminal_sessions add column chat_session_id text"); } catch {}
+  safeAddColumn(db, "alter table terminal_sessions add column resume_command text");
+  safeAddColumn(db, "alter table terminal_sessions add column resume_metadata_json text");
+  safeAddColumn(db, "alter table terminal_sessions add column manually_named integer not null default 0");
+  safeAddColumn(db, "alter table terminal_sessions add column archived_at text");
+  safeAddColumn(db, "alter table terminal_sessions add column chat_session_id text");
   try { db.run("create index if not exists idx_terminal_sessions_chat_session_id on terminal_sessions(chat_session_id)"); } catch {}
   // owner_pid identifies the ADE OS process that owns this row's runtime
   // (the one with the live PTY or SDK session). Cross-process dispose /
   // reconcile must check it before sweeping or every concurrent surface
   // would happily mark each other's live sessions dead. Nullable because
   // pre-migration rows pre-date ownership tracking.
-  try { db.run("alter table terminal_sessions add column owner_pid integer"); } catch {}
+  safeAddColumn(db, "alter table terminal_sessions add column owner_pid integer");
   try { db.run("create index if not exists idx_terminal_sessions_owner_pid on terminal_sessions(owner_pid)"); } catch {}
-  try { db.run("alter table terminal_sessions add column owner_process_started_at text"); } catch {}
+  safeAddColumn(db, "alter table terminal_sessions add column owner_process_started_at text");
   try { db.run("create index if not exists idx_terminal_sessions_owner_process on terminal_sessions(owner_pid, owner_process_started_at)"); } catch {}
 
   // Machine-local process liveness registry. Every ADE process (desktop main,
@@ -1756,11 +1847,11 @@ function migrate(db: MigrationDb) {
   `);
   db.run("create index if not exists idx_pull_requests_lane_id on pull_requests(lane_id)");
   db.run("create index if not exists idx_pull_requests_project_id on pull_requests(project_id)");
-  try { db.run("alter table pull_requests add column last_polled_at text"); } catch {}
-  try { db.run("alter table pull_requests add column head_sha text"); } catch {}
-  try { db.run("alter table pull_requests add column creation_strategy text"); } catch {}
-  try { db.run("alter table pull_requests add column merge_conflicts integer"); } catch {}
-  try { db.run("alter table pull_requests add column behind_base_by integer"); } catch {}
+  safeAddColumn(db, "alter table pull_requests add column last_polled_at text");
+  safeAddColumn(db, "alter table pull_requests add column head_sha text");
+  safeAddColumn(db, "alter table pull_requests add column creation_strategy text");
+  safeAddColumn(db, "alter table pull_requests add column merge_conflicts integer");
+  safeAddColumn(db, "alter table pull_requests add column behind_base_by integer");
 
   db.run("drop table if exists github_pr_cache");
 
@@ -1807,7 +1898,7 @@ function migrate(db: MigrationDb) {
     )
   `);
   db.run("create index if not exists idx_pull_request_snapshots_updated_at on pull_request_snapshots(updated_at)");
-  try { db.run("alter table pull_request_snapshots add column commits_json text"); } catch {}
+  safeAddColumn(db, "alter table pull_request_snapshots add column commits_json text");
 
   db.run(`
     create table if not exists files_workspaces (
@@ -2028,17 +2119,17 @@ function migrate(db: MigrationDb) {
     )
   `);
   db.run("create index if not exists idx_integration_proposals_project on integration_proposals(project_id)");
-  try { db.run("alter table integration_proposals add column linked_group_id text"); } catch {}
-  try { db.run("alter table integration_proposals add column linked_pr_id text"); } catch {}
-  try { db.run("alter table integration_proposals add column workflow_display_state text not null default 'active'"); } catch {}
-  try { db.run("alter table integration_proposals add column cleanup_state text not null default 'none'"); } catch {}
-  try { db.run("alter table integration_proposals add column closed_at text"); } catch {}
-  try { db.run("alter table integration_proposals add column merged_at text"); } catch {}
-  try { db.run("alter table integration_proposals add column completed_at text"); } catch {}
-  try { db.run("alter table integration_proposals add column cleanup_declined_at text"); } catch {}
-  try { db.run("alter table integration_proposals add column cleanup_completed_at text"); } catch {}
-  try { db.run("alter table integration_proposals add column preferred_integration_lane_id text"); } catch {}
-  try { db.run("alter table integration_proposals add column merge_into_head_sha text"); } catch {}
+  safeAddColumn(db, "alter table integration_proposals add column linked_group_id text");
+  safeAddColumn(db, "alter table integration_proposals add column linked_pr_id text");
+  safeAddColumn(db, "alter table integration_proposals add column workflow_display_state text not null default 'active'");
+  safeAddColumn(db, "alter table integration_proposals add column cleanup_state text not null default 'none'");
+  safeAddColumn(db, "alter table integration_proposals add column closed_at text");
+  safeAddColumn(db, "alter table integration_proposals add column merged_at text");
+  safeAddColumn(db, "alter table integration_proposals add column completed_at text");
+  safeAddColumn(db, "alter table integration_proposals add column cleanup_declined_at text");
+  safeAddColumn(db, "alter table integration_proposals add column cleanup_completed_at text");
+  safeAddColumn(db, "alter table integration_proposals add column preferred_integration_lane_id text");
+  safeAddColumn(db, "alter table integration_proposals add column merge_into_head_sha text");
 
   // Queue landing state table (crash recovery for sequential landing)
   db.run(`
@@ -2062,12 +2153,12 @@ function migrate(db: MigrationDb) {
     )
   `);
   db.run("create index if not exists idx_queue_landing_state_group on queue_landing_state(group_id)");
-  try { db.run("alter table queue_landing_state add column config_json text not null default '{}'"); } catch {}
-  try { db.run("alter table queue_landing_state add column active_pr_id text"); } catch {}
-  try { db.run("alter table queue_landing_state add column active_resolver_run_id text"); } catch {}
-  try { db.run("alter table queue_landing_state add column last_error text"); } catch {}
-  try { db.run("alter table queue_landing_state add column wait_reason text"); } catch {}
-  try { db.run("alter table queue_landing_state add column updated_at text"); } catch {}
+  safeAddColumn(db, "alter table queue_landing_state add column config_json text not null default '{}'");
+  safeAddColumn(db, "alter table queue_landing_state add column active_pr_id text");
+  safeAddColumn(db, "alter table queue_landing_state add column active_resolver_run_id text");
+  safeAddColumn(db, "alter table queue_landing_state add column last_error text");
+  safeAddColumn(db, "alter table queue_landing_state add column wait_reason text");
+  safeAddColumn(db, "alter table queue_landing_state add column updated_at text");
 
   // Rebase dismiss/defer persistence
   db.run(`
@@ -2252,7 +2343,7 @@ function migrate(db: MigrationDb) {
       deleted_at text
     )
   `);
-  try { db.run("alter table worker_agents add column linear_identity_json text not null default '{}'"); } catch {}
+  safeAddColumn(db, "alter table worker_agents add column linear_identity_json text not null default '{}'");
   db.run("create index if not exists idx_worker_agents_project on worker_agents(project_id)");
   db.run("create index if not exists idx_worker_agents_project_active on worker_agents(project_id, deleted_at)");
 
@@ -2514,15 +2605,15 @@ function migrate(db: MigrationDb) {
       updated_at text not null
     )
   `);
-  try { db.run("alter table linear_workflow_runs add column execution_lane_id text"); } catch {}
-  try { db.run("alter table linear_workflow_runs add column supervisor_identity_key text"); } catch {}
-  try { db.run("alter table linear_workflow_runs add column review_ready_reason text"); } catch {}
-  try { db.run("alter table linear_workflow_runs add column pr_state text"); } catch {}
-  try { db.run("alter table linear_workflow_runs add column pr_checks_status text"); } catch {}
-  try { db.run("alter table linear_workflow_runs add column pr_review_status text"); } catch {}
-  try { db.run("alter table linear_workflow_runs add column latest_review_note text"); } catch {}
-  try { db.run("alter table linear_workflow_runs add column route_context_json text"); } catch {}
-  try { db.run("alter table linear_workflow_runs add column execution_context_json text"); } catch {}
+  safeAddColumn(db, "alter table linear_workflow_runs add column execution_lane_id text");
+  safeAddColumn(db, "alter table linear_workflow_runs add column supervisor_identity_key text");
+  safeAddColumn(db, "alter table linear_workflow_runs add column review_ready_reason text");
+  safeAddColumn(db, "alter table linear_workflow_runs add column pr_state text");
+  safeAddColumn(db, "alter table linear_workflow_runs add column pr_checks_status text");
+  safeAddColumn(db, "alter table linear_workflow_runs add column pr_review_status text");
+  safeAddColumn(db, "alter table linear_workflow_runs add column latest_review_note text");
+  safeAddColumn(db, "alter table linear_workflow_runs add column route_context_json text");
+  safeAddColumn(db, "alter table linear_workflow_runs add column execution_context_json text");
   db.run("create index if not exists idx_linear_workflow_runs_project_status on linear_workflow_runs(project_id, status, updated_at)");
   db.run("create index if not exists idx_linear_workflow_runs_issue on linear_workflow_runs(project_id, issue_id, updated_at)");
 
@@ -2736,11 +2827,11 @@ function migrate(db: MigrationDb) {
   `);
   db.run("create index if not exists idx_review_candidate_findings_run on review_candidate_findings(run_id)");
   db.run("create index if not exists idx_review_candidate_findings_reviewer on review_candidate_findings(reviewer_run_id)");
-  try { db.run("alter table review_findings add column finding_class text"); } catch {}
-  try { db.run("alter table review_findings add column originating_passes_json text"); } catch {}
-  try { db.run("alter table review_findings add column adjudication_json text"); } catch {}
-  try { db.run("alter table review_findings add column diff_context_json text"); } catch {}
-  try { db.run("alter table review_findings add column suppression_match_json text"); } catch {}
+  safeAddColumn(db, "alter table review_findings add column finding_class text");
+  safeAddColumn(db, "alter table review_findings add column originating_passes_json text");
+  safeAddColumn(db, "alter table review_findings add column adjudication_json text");
+  safeAddColumn(db, "alter table review_findings add column diff_context_json text");
+  safeAddColumn(db, "alter table review_findings add column suppression_match_json text");
 
   // Per-finding feedback — powers the learning loop.
   db.run(`
@@ -2808,17 +2899,17 @@ function migrate(db: MigrationDb) {
       foreign key(pr_id) references pull_requests(id) on delete cascade
     )
   `);
-  try { db.run("alter table pr_issue_inventory add column thread_comment_count integer"); } catch {}
-  try { db.run("alter table pr_issue_inventory add column thread_latest_comment_id text"); } catch {}
-  try { db.run("alter table pr_issue_inventory add column thread_latest_comment_author text"); } catch {}
-  try { db.run("alter table pr_issue_inventory add column thread_latest_comment_at text"); } catch {}
-  try { db.run("alter table pr_issue_inventory add column thread_latest_comment_source text"); } catch {}
+  safeAddColumn(db, "alter table pr_issue_inventory add column thread_comment_count integer");
+  safeAddColumn(db, "alter table pr_issue_inventory add column thread_latest_comment_id text");
+  safeAddColumn(db, "alter table pr_issue_inventory add column thread_latest_comment_author text");
+  safeAddColumn(db, "alter table pr_issue_inventory add column thread_latest_comment_at text");
+  safeAddColumn(db, "alter table pr_issue_inventory add column thread_latest_comment_source text");
   db.run("create index if not exists idx_inventory_pr_state on pr_issue_inventory(pr_id, state)");
 
   // PR pipeline settings: per-PR auto-converge / auto-merge configuration.
   // Newer fields (conflict_strategy, force_finalize_*, early_merge_on_green,
-  // auto_agent_*) are added via try-catch ALTER below so existing DBs upgrade
-  // in place. The legacy `on_rebase_needed` column is retained for back-compat.
+  // auto_agent_*) are added with safeAddColumn so existing DBs upgrade in
+  // place. The legacy `on_rebase_needed` column is retained for back-compat.
   db.run(`
     create table if not exists pr_pipeline_settings (
       pr_id text primary key,
@@ -2830,20 +2921,20 @@ function migrate(db: MigrationDb) {
       foreign key(pr_id) references pull_requests(id) on delete cascade
     )
   `);
-  try { db.run("alter table pr_pipeline_settings add column conflict_strategy text not null default 'pause'"); } catch {}
-  try { db.run("alter table pr_pipeline_settings add column force_finalize_mode text not null default 'conditional'"); } catch {}
-  try { db.run("alter table pr_pipeline_settings add column force_finalize_require_no_ci_failures integer not null default 1"); } catch {}
-  try { db.run("alter table pr_pipeline_settings add column early_merge_on_green integer not null default 1"); } catch {}
-  try { db.run("alter table pr_pipeline_settings add column auto_agent_provider text"); } catch {}
-  try { db.run("alter table pr_pipeline_settings add column auto_agent_model text"); } catch {}
-  try { db.run("alter table pr_pipeline_settings add column auto_agent_reasoning_effort text"); } catch {}
-  try { db.run("alter table pr_pipeline_settings add column auto_agent_permission_mode text"); } catch {}
-  try { db.run("alter table pr_pipeline_settings add column auto_agent_confidence_threshold real"); } catch {}
-  try { db.run("alter table pr_pipeline_settings add column at_cap_policy text default 'ci_retry_once'"); } catch {}
-  try { db.run("alter table pr_pipeline_settings add column at_cap_wait_minutes integer"); } catch {}
-  try { db.run("alter table pr_pipeline_settings add column at_cap_ci_retry_max integer"); } catch {}
-  try { db.run("alter table pr_pipeline_settings add column force_merge_requires_confirmation integer"); } catch {}
-  try { db.run("alter table pr_pipeline_settings add column ptm_defaults_backfilled_version text"); } catch {}
+  safeAddColumn(db, "alter table pr_pipeline_settings add column conflict_strategy text not null default 'pause'");
+  safeAddColumn(db, "alter table pr_pipeline_settings add column force_finalize_mode text not null default 'conditional'");
+  safeAddColumn(db, "alter table pr_pipeline_settings add column force_finalize_require_no_ci_failures integer not null default 1");
+  safeAddColumn(db, "alter table pr_pipeline_settings add column early_merge_on_green integer not null default 1");
+  safeAddColumn(db, "alter table pr_pipeline_settings add column auto_agent_provider text");
+  safeAddColumn(db, "alter table pr_pipeline_settings add column auto_agent_model text");
+  safeAddColumn(db, "alter table pr_pipeline_settings add column auto_agent_reasoning_effort text");
+  safeAddColumn(db, "alter table pr_pipeline_settings add column auto_agent_permission_mode text");
+  safeAddColumn(db, "alter table pr_pipeline_settings add column auto_agent_confidence_threshold real");
+  safeAddColumn(db, "alter table pr_pipeline_settings add column at_cap_policy text default 'ci_retry_once'");
+  safeAddColumn(db, "alter table pr_pipeline_settings add column at_cap_wait_minutes integer");
+  safeAddColumn(db, "alter table pr_pipeline_settings add column at_cap_ci_retry_max integer");
+  safeAddColumn(db, "alter table pr_pipeline_settings add column force_merge_requires_confirmation integer");
+  safeAddColumn(db, "alter table pr_pipeline_settings add column ptm_defaults_backfilled_version text");
   try {
     db.run(`
       update pr_pipeline_settings
@@ -2900,16 +2991,16 @@ function migrate(db: MigrationDb) {
   // PtM-specific run args (modelId, reasoning, scope, additionalInstructions)
   // serialized as JSON. Persisted so resumeFromPersistedState can re-dispatch
   // the fix agent after a desktop restart instead of pausing on missing modelId.
-  try { db.run("alter table pr_convergence_state add column ptm_args_json text"); } catch {}
-  try { db.run("alter table pr_convergence_state add column force_finalize_used integer not null default 0"); } catch {}
-  try { db.run("alter table pr_convergence_state add column ci_retry_attempts_used integer not null default 0"); } catch {}
-  try { db.run("alter table pr_convergence_state add column wait_for_ci_started_at text"); } catch {}
-  try { db.run("alter table pr_convergence_state add column last_dispatch_head_sha text"); } catch {}
-  try { db.run("alter table pr_convergence_state add column last_bot_ping_head_sha text"); } catch {}
-  try { db.run("alter table pr_convergence_state add column last_bot_ping_at text"); } catch {}
-  try { db.run("alter table pr_convergence_state add column merge_wait_kind text"); } catch {}
-  try { db.run("alter table pr_convergence_state add column pause_repeat_count integer not null default 0"); } catch {}
-  try { db.run("alter table pr_convergence_state add column last_pause_reason_hash text"); } catch {}
+  safeAddColumn(db, "alter table pr_convergence_state add column ptm_args_json text");
+  safeAddColumn(db, "alter table pr_convergence_state add column force_finalize_used integer not null default 0");
+  safeAddColumn(db, "alter table pr_convergence_state add column ci_retry_attempts_used integer not null default 0");
+  safeAddColumn(db, "alter table pr_convergence_state add column wait_for_ci_started_at text");
+  safeAddColumn(db, "alter table pr_convergence_state add column last_dispatch_head_sha text");
+  safeAddColumn(db, "alter table pr_convergence_state add column last_bot_ping_head_sha text");
+  safeAddColumn(db, "alter table pr_convergence_state add column last_bot_ping_at text");
+  safeAddColumn(db, "alter table pr_convergence_state add column merge_wait_kind text");
+  safeAddColumn(db, "alter table pr_convergence_state add column pause_repeat_count integer not null default 0");
+  safeAddColumn(db, "alter table pr_convergence_state add column last_pause_reason_hash text");
 
   // Machine-local runtime guard for PR automation. This table intentionally
   // has no PRIMARY KEY so cr-sqlite does not register it as a CRR table.
@@ -3002,6 +3093,10 @@ export async function openKvDb(dbPath: string, logger: Logger): Promise<AdeDb> {
     }
     return crsqliteLoaded;
   };
+  const crrAwareDb = makeCrrAwareDb({
+    getDb: () => db,
+    isCrsqliteLoaded: () => crsqliteLoaded,
+  });
 
   try {
     // Existing CRR tables install triggers that call cr-sqlite functions on
@@ -3013,38 +3108,7 @@ export async function openKvDb(dbPath: string, logger: Logger): Promise<AdeDb> {
       disableCrrTriggersForUnavailableRuntime(db, logger);
     }
 
-    // Build a CRR-aware run wrapper: when crsqlite is loaded and a table has
-    // been converted to a CRR, ALTER TABLE statements must be wrapped with
-    // crsql_begin_alter / crsql_commit_alter so the clock tables stay in sync.
-    const makeMigrateDb = () => ({
-      run: (sql: string, params: SqlValue[] = []) => {
-        const alterTable = parseAlterTableTarget(sql);
-        if (alterTable && crsqliteLoaded && rawHasTable(db, `${alterTable}__crsql_clock`)) {
-          getRow(db, "select crsql_begin_alter(?) as ok", [alterTable]);
-          try {
-            runStatement(db, sql, params);
-          } catch (error) {
-            // Commit the alter even on failure so the CRR state stays consistent,
-            // then re-throw so the caller's try/catch can handle it (e.g. column
-            // already exists on upgrade).
-            getRow(db, "select crsql_commit_alter(?) as ok", [alterTable]);
-            throw error;
-          }
-          getRow(db, "select crsql_commit_alter(?) as ok", [alterTable]);
-          return;
-        }
-        runStatement(db, sql, params);
-      },
-      get: <T extends Record<string, unknown> = Record<string, unknown>>(sql: string, params: SqlValue[] = []) => {
-        return getRow<T>(db, sql, params);
-      },
-      all: <T extends Record<string, unknown> = Record<string, unknown>>(sql: string, params: SqlValue[] = []) => {
-        return allRows<T>(db, sql, params);
-      },
-    });
-
-    const migrateDb = makeMigrateDb();
-    migrate(migrateDb);
+    migrate(crrAwareDb);
     removeExcludedCrrMetadata(db, logger);
     // Tear down the legacy `unified_memories` schema (removed in #329) before
     // any retrofit pass runs — the FTS4 shadow tables cannot be dropped
@@ -3073,8 +3137,7 @@ export async function openKvDb(dbPath: string, logger: Logger): Promise<AdeDb> {
       if (hasCrsqlMetadata(db) && !crsqliteLoaded) {
         disableCrrTriggersForUnavailableRuntime(db, logger);
       }
-      const remigrateDb = makeMigrateDb();
-      migrate(remigrateDb);
+      migrate(crrAwareDb);
       removeExcludedCrrMetadata(db, logger);
     }
 
@@ -3092,8 +3155,7 @@ export async function openKvDb(dbPath: string, logger: Logger): Promise<AdeDb> {
       if (hasCrsqlMetadata(db) && !crsqliteLoaded) {
         disableCrrTriggersForUnavailableRuntime(db, logger);
       }
-      const remigrateDb = makeMigrateDb();
-      migrate(remigrateDb);
+      migrate(crrAwareDb);
       removeExcludedCrrMetadata(db, logger);
     }
 
@@ -3141,31 +3203,9 @@ export async function openKvDb(dbPath: string, logger: Logger): Promise<AdeDb> {
     runStatement(db, "insert into kv(key, value) values (?, ?) on conflict(key) do update set value = excluded.value", [key, value]);
   };
 
-  const run = (sql: string, params: SqlValue[] = []) => {
-    const alterTable = parseAlterTableTarget(sql);
-    if (crsqliteLoaded && alterTable && rawHasTable(db, `${alterTable}__crsql_clock`)) {
-      getRow(db, "select crsql_begin_alter(?) as ok", [alterTable]);
-      try {
-        runStatement(db, sql, params);
-      } catch (error) {
-        // Commit the alter even on failure so the CRR state stays consistent,
-        // then re-throw so callers (e.g. safeAlter) can handle duplicate columns.
-        getRow(db, "select crsql_commit_alter(?) as ok", [alterTable]);
-        throw error;
-      }
-      getRow(db, "select crsql_commit_alter(?) as ok", [alterTable]);
-      return;
-    }
-    runStatement(db, sql, params);
-  };
-
-  const all = <T extends Record<string, unknown> = Record<string, unknown>>(sql: string, params: SqlValue[] = []): T[] => {
-    return allRows<T>(db, sql, params);
-  };
-
-  const get = <T extends Record<string, unknown> = Record<string, unknown>>(sql: string, params: SqlValue[] = []): T | null => {
-    return getRow<T>(db, sql, params);
-  };
+  const run = crrAwareDb.run;
+  const all = crrAwareDb.all;
+  const get = crrAwareDb.get;
 
   const sync: AdeDbSyncApi = {
     isAvailable: () => crsqliteLoaded,
@@ -3239,7 +3279,7 @@ export async function openKvDb(dbPath: string, logger: Logger): Promise<AdeDb> {
       if (!crsqliteLoaded) return { appliedCount: 0, dbVersion: 0, touchedTables: [], rebuiltFts: false };
       let appliedCount = 0;
       const touchedTables = new Set<string>();
-      runStatement(db, "begin");
+      runStatement(db, "BEGIN IMMEDIATE");
       try {
         for (const rawChange of changes) {
           if (isLocalOnlyQueueWipeMarkerChange(rawChange)) continue;
@@ -3283,10 +3323,10 @@ export async function openKvDb(dbPath: string, logger: Logger): Promise<AdeDb> {
     discardUnpublishedChangesForTables: (tableNames: string[]) => {
       const normalizedTableNames = Array.from(new Set(tableNames.map((tableName) => tableName.trim()).filter(Boolean)));
       if (!crsqliteLoaded || normalizedTableNames.length === 0) return;
-      const throughDbVersion = sync.getDbVersion();
-      const createdAt = new Date().toISOString();
-      runStatement(db, "begin");
+      runStatement(db, "BEGIN IMMEDIATE");
       try {
+        const throughDbVersion = sync.getDbVersion();
+        const createdAt = new Date().toISOString();
         for (const tableName of normalizedTableNames) {
           runStatement(
             db,
@@ -3319,7 +3359,9 @@ export async function openKvDb(dbPath: string, logger: Logger): Promise<AdeDb> {
     all,
     get,
     sync,
-    flushNow: () => {},
+    flushNow: () => {
+      getRow(db, "pragma wal_checkpoint(TRUNCATE)");
+    },
     close: () => {
       db.close();
     },

--- a/apps/desktop/src/main/services/state/kvDb.ts
+++ b/apps/desktop/src/main/services/state/kvDb.ts
@@ -76,6 +76,12 @@ export type AdeDb = {
   all: <T extends Record<string, unknown> = Record<string, unknown>>(sql: string, params?: SqlValue[]) => T[];
 
   sync: AdeDbSyncApi;
+
+  /**
+   * Force pending WAL frames onto the main database before shutdown. This uses a
+   * TRUNCATE checkpoint and can wait for active readers, so keep calls on
+   * final-persistence paths instead of latency-sensitive request handling.
+   */
   flushNow: () => void;
   close: () => void;
 };


### PR DESCRIPTION
Refs ADE-71
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-71: State/sync/config persistence & kvDb hardening: crash-safe writes, migration versioning, and god-file/dedup decomposition](https://linear.app/ade-linear/issue/ADE-71/statesyncconfig-persistence-and-kvdb-hardening-crash-safe-writes) - referenced
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-71-state-sync-config-persistence-kvdb-hardening-crash-safe-writes-migration-versioning-and-god-file-dedup-decomposition num=495 -->
<p>
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://ade.app/logo-dark.svg">
    <img src="https://ade.app/logo-light.svg" height="18" align="left" alt="ADE">
  </picture>
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade.app/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-71-state-sync-config-persistence-kvdb-hardening-crash-safe-writes-migration-versioning-and-god-file-dedup-decomposition&amp;pr=495">ade-71-state-sync-config-persistence-kvdb-hardening-crash-safe-writes-migration-versioning-and-god-file-dedup-decomposition branch</a>
  &nbsp;·&nbsp; <a href="https://ade.app/open?type=pr&amp;repo=arul28%2FADE&amp;number=495">PR #495</a>
</p>
<!-- /ade:link -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data persistence with atomic write operations to prevent state file corruption.
  * Improved database transaction handling for better concurrent access reliability.

* **Improvements**
  * Strengthened configuration validation with centralized parsing logic.
  * Enhanced database migration stability with safer transaction management and idempotent column operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens state and database persistence across three areas: `globalState.ts` gains a crash-safe atomic write (temp file → fsync → rename → dir-fsync); `kvDb.ts` replaces ~40 silent bare `try/catch` migration blocks with an idempotent `safeAddColumn` helper, extracts `makeCrrAwareDb` to remove duplicated CRR-wrap code, upgrades two deferred `BEGIN` transactions to `BEGIN IMMEDIATE`, and implements the previously no-op `flushNow` via `pragma wal_checkpoint(TRUNCATE)`.

- **`globalState.ts`**: atomic write with fd tracking and cleanup on error; test verifies no `.tmp` files survive a successful write.
- **`kvDb.ts`**: `safeAddColumn` guards every `ALTER TABLE … ADD COLUMN` migration with a pre-check + TOCTOU catch, and `throughDbVersion`/`createdAt` are now captured inside the `discardUnpublishedChangesForTables` transaction for consistency.
- **`sessionService.ts` / `operationService.ts` / `projectConfigService.ts`**: SQL-clause coupling, column-list deduplication, and Zod-backed config coercion with no behavioural change.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive hardening with no altered public contracts, and the migration path is protected by the new idempotency guards.

The atomic-write change in globalState and the safeAddColumn migration refactor are both well-implemented with appropriate error handling. The BEGIN IMMEDIATE upgrades and the discardUnpublishedChangesForTables fix are correctness improvements. The sessionService SQL-clause refactoring preserves parameter ordering exactly. The only observation is a defensive gap in safeAddColumn's fallback path for unparseable SQL, which cannot be triggered by any current migration string.

apps/desktop/src/main/services/state/kvDb.ts — the safeAddColumn fallback path warrants a second look if new migrations with unusual identifier syntax are ever added.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/state/kvDb.ts | Extracts `makeCrrAwareDb` factory to remove ~30 lines of duplicated CRR-wrap logic, introduces `safeAddColumn` for idempotent ADD COLUMN migrations replacing ~40 bare try/catch blocks, upgrades `begin` to `BEGIN IMMEDIATE` in two write transactions, implements `flushNow` via `pragma wal_checkpoint(TRUNCATE)`, and moves `throughDbVersion`/`createdAt` inside the `discardUnpublishedChangesForTables` transaction for correctness. |
| apps/desktop/src/main/services/state/globalState.ts | Replaces direct `fs.writeFileSync` with a crash-safe temp-file-then-rename pattern (open → writeFileSync → fsync → close → rename → optional dir-fsync) with proper fd/tempPath cleanup on error. |
| apps/desktop/src/main/services/sessions/sessionService.ts | Refactors parallel SQL-string + params-array tracking into a `SqlClause = { sql, params }` type, joining them at the call site; parameter ordering is semantically identical to the original. |
| apps/desktop/src/main/services/config/projectConfigService.ts | Centralises config-field coercion behind module-level Zod schemas, replacing five inline type-check functions with schema-backed equivalents whose behaviour is identical for all expected inputs. |
| apps/desktop/src/main/services/history/operationService.ts | Extracts repeated column list into a single `OPERATION_COLUMNS` constant used in three queries; no logic change. |
| apps/desktop/src/main/services/state/globalState.test.ts | Adds a test that round-trips `writeGlobalState` → `readGlobalState` and asserts no `.tmp` files are left behind after a successful write. |
| apps/desktop/src/main/services/state/kvDb.test.ts | Adds a test verifying that `flushNow()` does not throw and that a previously written key survives the checkpoint. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller
    participant K as openKvDb
    participant CR as makeCrrAwareDb
    participant M as migrate()
    participant DB as SQLite

    C->>K: openKvDb(dbPath, logger)
    K->>DB: open WAL database
    K->>CR: "makeCrrAwareDb({ getDb, isCrsqliteLoaded })"
    CR-->>K: crrAwareDb (run/get/all with CRR-alter wrapping)
    K->>DB: load crsqlite extension
    K->>M: migrate(crrAwareDb) — initial pass
    M->>CR: safeAddColumn(db, sql) × N
    CR->>DB: pragma table_info / ALTER TABLE / crsql_begin_alter+commit
    alt CRR table retrofit needed
        K->>M: migrate(crrAwareDb) — retrofit pass (idempotent via safeAddColumn)
    end
    K->>DB: pragma wal_checkpoint on flushNow()
    K-->>C: "AdeDb { run, get, all, sync, flushNow, close }"
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/main/services/state/kvDb.ts`, line 464-471 ([link](https://github.com/arul28/ade/blob/782a7c3ebd269f2e524a49381906f5c073413ba3/apps/desktop/src/main/services/state/kvDb.ts#L464-L471)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Migration failure warning bypasses structured logger**

   `console.warn` is used here, but the rest of `kvDb.ts` uses the `logger` instance (a `Logger` injected via `openKvDb`). A migration column-add failure logged via `console.warn` will be invisible to Sentry and to any file/structured log sink the app attaches to the `Logger`, making it hard to diagnose schema upgrade problems in production builds. Consider threading `logger` into `safeAddColumn` as a parameter, or moving the warn call to a site where `logger` is in scope.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/state/kvDb.ts
   Line: 464-471

   Comment:
   **Migration failure warning bypasses structured logger**

   `console.warn` is used here, but the rest of `kvDb.ts` uses the `logger` instance (a `Logger` injected via `openKvDb`). A migration column-add failure logged via `console.warn` will be invisible to Sentry and to any file/structured log sink the app attaches to the `Logger`, making it hard to diagnose schema upgrade problems in production builds. Consider threading `logger` into `safeAddColumn` as a parameter, or moving the warn call to a site where `logger` is in scope.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fstate%2FkvDb.ts%0ALine%3A%20464-471%0A%0AComment%3A%0A**Migration%20failure%20warning%20bypasses%20structured%20logger**%0A%0A%60console.warn%60%20is%20used%20here%2C%20but%20the%20rest%20of%20%60kvDb.ts%60%20uses%20the%20%60logger%60%20instance%20%28a%20%60Logger%60%20injected%20via%20%60openKvDb%60%29.%20A%20migration%20column-add%20failure%20logged%20via%20%60console.warn%60%20will%20be%20invisible%20to%20Sentry%20and%20to%20any%20file%2Fstructured%20log%20sink%20the%20app%20attaches%20to%20the%20%60Logger%60%2C%20making%20it%20hard%20to%20diagnose%20schema%20upgrade%20problems%20in%20production%20builds.%20Consider%20threading%20%60logger%60%20into%20%60safeAddColumn%60%20as%20a%20parameter%2C%20or%20moving%20the%20warn%20call%20to%20a%20site%20where%20%60logger%60%20is%20in%20scope.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=495&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fstate%2FkvDb.ts%3A1126-1131%0A**%60safeAddColumn%60%20parse-failure%20fallback%20is%20not%20idempotent%20across%20migration%20passes**%0A%0AWhen%20%60parseAlterTableAddColumn%60%20returns%20%60null%60%2C%20%60safeAddColumn%60%20falls%20through%20to%20a%20bare%20%60db.run%28sql%29%60%20with%20no%20duplicate-column%20guard.%20Since%20%60migrate%28%29%60%20can%20be%20called%20up%20to%20three%20times%20per%20%60openKvDb%60%20invocation%20%28initial%20pass%20%2B%20up%20to%20two%20CRR-retrofit%20passes%29%2C%20any%20%60ALTER%20TABLE%20%E2%80%A6%20ADD%20COLUMN%60%20statement%20that%20fails%20to%20match%20the%20regex%20on%20a%20second%20pass%20would%20throw%20%22duplicate%20column%20name%22%20and%20abort%20database%20initialisation%20entirely.%20All%20current%20migration%20strings%20are%20simple%20identifiers%20that%20the%20regex%20handles%20correctly%2C%20but%20a%20future%20maintainer%20adding%20a%20migration%20whose%20table%20or%20column%20name%20uses%20an%20unusual%20format%20would%20hit%20this%20silently%20broken%20path.%20A%20minimal%20safeguard%20%E2%80%94%20rethrowing%20only%20when%20the%20error%20is%20not%20a%20duplicate-column%20error%20%E2%80%94%20would%20prevent%20the%20initialisation%20failure.%0A%0A&repo=arul28%2Fade&pr=495&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/main/services/state/kvDb.ts:1126-1131
**`safeAddColumn` parse-failure fallback is not idempotent across migration passes**

When `parseAlterTableAddColumn` returns `null`, `safeAddColumn` falls through to a bare `db.run(sql)` with no duplicate-column guard. Since `migrate()` can be called up to three times per `openKvDb` invocation (initial pass + up to two CRR-retrofit passes), any `ALTER TABLE … ADD COLUMN` statement that fails to match the regex on a second pass would throw "duplicate column name" and abort database initialisation entirely. All current migration strings are simple identifiers that the regex handles correctly, but a future maintainer adding a migration whose table or column name uses an unusual format would hit this silently broken path. A minimal safeguard — rethrowing only when the error is not a duplicate-column error — would prevent the initialisation failure.


`````

</details>

<sub>Reviews (7): Last reviewed commit: ["Document kvDb flush checkpoint semantics"](https://github.com/arul28/ade/commit/ab42bc6167b4bce37229c32b0bb21bcabf9a0471) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34829401)</sub>

<!-- /greptile_comment -->