### PR TITLE
ADE-91: Lane lifecycle operations crash active CLI sessions and chats

### DIFF
--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -12,7 +12,7 @@ import {
 } from "../../desktop/src/main/services/projects/adeProjectService";
 import { createConfigReloadService } from "../../desktop/src/main/services/projects/configReloadService";
 import { createOperationService } from "../../desktop/src/main/services/history/operationService";
-import { createLaneService } from "../../desktop/src/main/services/lanes/laneService";
+import { createLaneService, type LaneDeleteTeardownDeps } from "../../desktop/src/main/services/lanes/laneService";
 import {
   createSessionService,
   STALE_RUNNING_SESSION_FRESH_ACTIVITY_GRACE_MS,
@@ -440,6 +440,7 @@ export async function createAdeRuntime(args: {
     getIssueTracker: () => linearIssueTrackerRef,
     log: (event, fields) => logger.warn(event, fields),
   });
+  const laneTeardownDeps: LaneDeleteTeardownDeps = {};
 
   const laneService = createLaneService({
     db,
@@ -498,6 +499,7 @@ export async function createAdeRuntime(args: {
         });
     },
     onLinearIssueSessionLinked: publishLinearChatLink,
+    teardownDeps: laneTeardownDeps,
     logger,
   });
   await laneService.ensurePrimaryLane();
@@ -752,6 +754,20 @@ export async function createAdeRuntime(args: {
     getLaneRuntimeEnv: getHeadlessLaneRuntimeEnv,
     broadcastEvent: (event) => pushEvent("runtime", event as unknown as Record<string, unknown>),
   });
+  laneTeardownDeps.processService = {
+    listRuntime: (laneId) => processService.listRuntime(laneId),
+    stopAll: (args) => processService.stopAll(args),
+  };
+  laneTeardownDeps.ptyService = {
+    countActiveForLane: (laneId) => ptyService.countActiveForLane(laneId),
+    disposeForLane: (laneId) => ptyService.disposeForLane(laneId),
+  };
+  laneTeardownDeps.autoRebaseService = {
+    cancelForLane: (laneId) => autoRebaseService.cancelForLane(laneId),
+  };
+  laneTeardownDeps.rebaseSuggestionService = {
+    dismiss: (args) => rebaseSuggestionService.dismiss(args),
+  };
 
   const ctoStateService = createCtoStateService({
     db,
@@ -894,6 +910,10 @@ export async function createAdeRuntime(args: {
   });
   linearIssueTrackerRef = headlessLinearServices.linearIssueTracker;
   githubServiceRef = headlessLinearServices.githubService as ReturnType<typeof createGithubService>;
+  laneTeardownDeps.fileWatcherService = {
+    countActiveForWorkspace: (id) => headlessLinearServices.fileService.countActiveWatchersForWorkspace(id),
+    stopAllForWorkspace: (id) => headlessLinearServices.fileService.stopAllWatchersForWorkspace(id),
+  };
   const linearOAuthService = createLinearOAuthService({
     credentials: headlessLinearServices.linearCredentialService,
     logger,
@@ -956,6 +976,12 @@ export async function createAdeRuntime(args: {
     }
   }
   agentChatServiceHolder.current = agentChatService;
+  if (agentChatService) {
+    laneTeardownDeps.agentChatService = {
+      countActiveForLane: (laneId) => agentChatService.countActiveForLane(laneId),
+      disposeForLane: (laneId) => agentChatService.disposeForLane(laneId),
+    };
+  }
   if (resolvedArgs.chatRuntime === "agent" && !agentChatService) {
     throw new Error("Agent chat runtime was requested but the agent chat service was not initialized.");
   }

--- a/apps/ade-cli/src/tuiClient/__tests__/appInput.test.ts
+++ b/apps/ade-cli/src/tuiClient/__tests__/appInput.test.ts
@@ -737,6 +737,7 @@ describe("formatLaneDeleteRisk", () => {
     unpushedCommitCount: 0,
     remoteBranchExists: false,
     runningProcessCount: 0,
+    activeChatCount: 0,
     activePtyCount: 0,
     activeWatcherCount: 0,
     envInitialized: false,
@@ -749,6 +750,7 @@ describe("formatLaneDeleteRisk", () => {
       hasUnpushedCommits: true,
       unpushedCommitCount: 1,
       runningProcessCount: 2,
+      activeChatCount: 1,
       activePtyCount: 1,
       remoteBranchExists: true,
     });
@@ -756,6 +758,7 @@ describe("formatLaneDeleteRisk", () => {
     expect(summary).toContain("1 unpushed commit");
     expect(summary).not.toContain("1 unpushed commits");
     expect(summary).toContain("2 running processes");
+    expect(summary).toContain("1 chat session");
     expect(summary).toContain("1 terminal");
     expect(summary).toContain("remote branch exists");
     expect(summary.startsWith("⚠")).toBe(true);

--- a/apps/ade-cli/src/tuiClient/app.tsx
+++ b/apps/ade-cli/src/tuiClient/app.tsx
@@ -309,6 +309,9 @@ export function formatLaneDeleteRisk(risk: LaneDeleteRisk): string {
   if (risk.runningProcessCount > 0) {
     parts.push(`${risk.runningProcessCount} running process${risk.runningProcessCount === 1 ? "" : "es"}`);
   }
+  if (risk.activeChatCount > 0) {
+    parts.push(`${risk.activeChatCount} chat session${risk.activeChatCount === 1 ? "" : "s"}`);
+  }
   if (risk.activePtyCount > 0) parts.push(`${risk.activePtyCount} terminal${risk.activePtyCount === 1 ? "" : "s"}`);
   if (risk.remoteBranchExists) parts.push("remote branch exists");
   return parts.length ? `⚠ ${parts.join(" · ")}` : "Clean — no unpushed work or running processes.";

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -2932,6 +2932,10 @@ app.whenReady().then(async () => {
       },
     });
     agentChatServiceRef = agentChatService;
+    laneTeardownDeps.agentChatService = {
+      countActiveForLane: (laneId) => agentChatService.countActiveForLane(laneId),
+      disposeForLane: (laneId) => agentChatService.disposeForLane(laneId),
+    };
     setImmediate(() => {
       void Promise.resolve()
         .then(() => agentChatService.cleanupStaleAttachments())

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -21832,11 +21832,33 @@ export function createAgentChatService(args: {
   const managedSessionBelongsToLane = (managed: ManagedChatSession, laneId: string): boolean => {
     const normalizedLaneId = laneId.trim();
     if (!normalizedLaneId) return false;
+    // Include execution-routing lane ids so a chat homed elsewhere but actively
+    // using this lane cannot keep a runtime pointed at a deleted worktree.
     return [
       trimLine(managed.session.laneId),
       trimLine(managed.selectedExecutionLaneId),
       trimLine(managed.preferredExecutionLaneId),
     ].some((candidate) => candidate === normalizedLaneId);
+  };
+
+  const forceDisposeManagedSession = (managed: ManagedChatSession, reason: string): void => {
+    const sessionId = managed.session.id;
+    rejectActiveSessionTurnCollector(sessionId, reason);
+    clearSubagentSnapshots(sessionId);
+    for (const pending of managed.localPendingInputs.values()) {
+      pending.resolve({ decision: "cancel" });
+    }
+    managed.localPendingInputs.clear();
+    abortActiveBashControllers(managed, reason);
+    managed.closed = true;
+    managed.endedNotified = true;
+    managed.ctoSessionStartedAt = null;
+    teardownRuntime(managed, "ended_session");
+    managed.deleted = true;
+    flushQueuedTranscriptWrite(managed.transcriptPath);
+    flushQueuedTranscriptWrite(path.join(chatTranscriptsDir, `${sessionId}.jsonl`));
+    managedSessions.delete(sessionId);
+    eventHistoryBySession.delete(sessionId);
   };
 
   const countActiveForLane = (laneId: string): number => {
@@ -21861,6 +21883,15 @@ export function createAgentChatService(args: {
         await dispose({ sessionId });
         disposed += 1;
       } catch (error) {
+        const managed = managedSessions.get(sessionId);
+        if (managed) {
+          try {
+            forceDisposeManagedSession(managed, "Session force-closed during lane deletion.");
+            disposed += 1;
+          } catch (forceError) {
+            errors.push(`${sessionId}: force close failed: ${forceError instanceof Error ? forceError.message : String(forceError)}`);
+          }
+        }
         errors.push(`${sessionId}: ${error instanceof Error ? error.message : String(error)}`);
       }
     }

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -21829,6 +21829,47 @@ export function createAgentChatService(args: {
     return false;
   };
 
+  const managedSessionBelongsToLane = (managed: ManagedChatSession, laneId: string): boolean => {
+    const normalizedLaneId = laneId.trim();
+    if (!normalizedLaneId) return false;
+    return [
+      trimLine(managed.session.laneId),
+      trimLine(managed.selectedExecutionLaneId),
+      trimLine(managed.preferredExecutionLaneId),
+    ].some((candidate) => candidate === normalizedLaneId);
+  };
+
+  const countActiveForLane = (laneId: string): number => {
+    let count = 0;
+    for (const managed of managedSessions.values()) {
+      if (managed.closed || managed.deleted) continue;
+      if (managedSessionBelongsToLane(managed, laneId)) count += 1;
+    }
+    return count;
+  };
+
+  const disposeForLane = async (laneId: string): Promise<number> => {
+    const sessionIds = Array.from(new Set(
+      [...managedSessions.values()]
+        .filter((managed) => !managed.closed && !managed.deleted && managedSessionBelongsToLane(managed, laneId))
+        .map((managed) => managed.session.id),
+    ));
+    let disposed = 0;
+    const errors: string[] = [];
+    for (const sessionId of sessionIds) {
+      try {
+        await dispose({ sessionId });
+        disposed += 1;
+      } catch (error) {
+        errors.push(`${sessionId}: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+    if (errors.length > 0) {
+      throw new Error(`Failed to close ${errors.length} chat session${errors.length === 1 ? "" : "s"}: ${errors.join("; ")}`);
+    }
+    return disposed;
+  };
+
   const ensureIdentitySession = async (args: {
     identityKey: AgentChatIdentityKey;
     laneId: string;
@@ -25294,6 +25335,8 @@ export function createAgentChatService(args: {
     getSessionSummary,
     hasActiveWorkloads,
     hasRetainableSessions,
+    countActiveForLane,
+    disposeForLane,
     getChatTranscript,
     getCodexResumeContext,
     getChatEventHistory,

--- a/apps/desktop/src/main/services/lanes/laneService.test.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.test.ts
@@ -2785,6 +2785,13 @@ describe("laneService delete teardown + cancellation + streaming", () => {
         calls.push("stop_processes");
       }),
     };
+    const agentChatService = {
+      countActiveForLane: vi.fn(() => 0),
+      disposeForLane: vi.fn(async () => {
+        calls.push("stop_chats");
+        return 0;
+      }),
+    };
     const ptyService = {
       countActiveForLane: vi.fn(() => 2),
       disposeForLane: vi.fn(() => {
@@ -2809,7 +2816,7 @@ describe("laneService delete teardown + cancellation + streaming", () => {
         // already counted by cancel_auto_rebase step; do not duplicate
       }),
     };
-    return { calls, processService, ptyService, fileWatcherService, autoRebaseService, rebaseSuggestionService };
+    return { calls, processService, agentChatService, ptyService, fileWatcherService, autoRebaseService, rebaseSuggestionService };
   }
 
   async function setupWithLane(opts: { teardown: ReturnType<typeof makeFakeServices>; events: any[]; createWorktree?: boolean }) {
@@ -2829,6 +2836,7 @@ describe("laneService delete teardown + cancellation + streaming", () => {
       onDeleteEvent: (event) => opts.events.push(event),
       teardownDeps: {
         processService: opts.teardown.processService,
+        agentChatService: opts.teardown.agentChatService,
         ptyService: opts.teardown.ptyService,
         fileWatcherService: opts.teardown.fileWatcherService,
         autoRebaseService: opts.teardown.autoRebaseService,
@@ -2842,6 +2850,11 @@ describe("laneService delete teardown + cancellation + streaming", () => {
   it("runs teardown steps before git_worktree_remove and broadcasts per-step progress", async () => {
     const events: any[] = [];
     const fake = makeFakeServices();
+    fake.agentChatService.countActiveForLane.mockReturnValue(1);
+    fake.agentChatService.disposeForLane.mockImplementation(async () => {
+      fake.calls.push("stop_chats");
+      return 1;
+    });
     const { service } = await setupWithLane({ teardown: fake, events });
     // git status: clean. git_worktree_remove: succeeds. branch ref check: not found (skip branch delete).
     vi.mocked(runGit).mockImplementation(async (args: string[]) => {
@@ -2864,6 +2877,7 @@ describe("laneService delete teardown + cancellation + streaming", () => {
     // Teardown happens before the git destructive step.
     const wtIdx = fake.calls.indexOf("git_worktree_remove");
     expect(fake.calls.indexOf("stop_processes")).toBeLessThan(wtIdx);
+    expect(fake.calls.indexOf("stop_chats")).toBeLessThan(wtIdx);
     expect(fake.calls.indexOf("stop_ptys")).toBeLessThan(wtIdx);
     expect(fake.calls.indexOf("stop_watchers")).toBeLessThan(wtIdx);
     expect(fake.calls.indexOf("cancel_auto_rebase")).toBeLessThan(wtIdx);
@@ -3303,6 +3317,31 @@ describe("laneService delete teardown + cancellation + streaming", () => {
     );
     db.run(
       `
+        insert into claude_sessions(session_id, lane_id, chat_session_id, title, tags_json, created_at, updated_at)
+        values (?, ?, ?, ?, ?, ?, ?)
+      `,
+      ["chat-child", "lane-child", null, "Child chat", null, now, now],
+    );
+    db.run(
+      `
+        insert into session_linear_issues(
+          id, project_id, session_id, lane_id, issue_id, issue_json, role, source,
+          include_in_pr, close_on_merge, evidence_json, created_at, updated_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      ["session-link-terminal", projectId, "session-child", "lane-child", "issue-child", JSON.stringify(makeLinearIssue()), "worked", "chat_attach", 1, 0, null, now, now],
+    );
+    db.run(
+      `
+        insert into session_linear_issues(
+          id, project_id, session_id, lane_id, issue_id, issue_json, role, source,
+          include_in_pr, close_on_merge, evidence_json, created_at, updated_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      ["session-link-chat", projectId, "chat-child", "lane-child", "issue-child", JSON.stringify(makeLinearIssue()), "worked", "chat_attach", 1, 0, null, now, now],
+    );
+    db.run(
+      `
         insert into session_deltas(
           session_id, project_id, lane_id, started_at, files_changed, insertions, deletions,
           touched_files_json, failure_lines_json, computed_at
@@ -3433,6 +3472,8 @@ describe("laneService delete teardown + cancellation + streaming", () => {
     expect(count("review_runs", "id = ?", ["review-run-child"])).toBe(0);
     expect(count("review_reviewer_runs", "id = ?", ["reviewer-run-child"])).toBe(0);
     expect(count("review_candidate_findings", "id = ?", ["candidate-child"])).toBe(0);
+    expect(count("claude_sessions", "lane_id = ?", ["lane-child"])).toBe(0);
+    expect(count("session_linear_issues", "lane_id = ? or session_id in (?, ?)", ["lane-child", "session-child", "chat-child"])).toBe(0);
     expect(count("terminal_sessions", "lane_id = ?", ["lane-child"])).toBe(0);
     expect(count("session_deltas", "lane_id = ?", ["lane-child"])).toBe(0);
     expect(count("checkpoints", "lane_id = ?", ["lane-child"])).toBe(0);
@@ -3444,6 +3485,23 @@ describe("laneService delete teardown + cancellation + streaming", () => {
     expect(count("rebase_deferred", "lane_id = ?", ["lane-child"])).toBe(0);
     expect(count("rebase_dismissed", "lane_id = ?", ["lane-child"])).toBe(0);
     expect(count("lane_worktree_locks", "lane_id = ?", ["lane-child"])).toBe(0);
+  });
+
+  it("keeps the lane intact when active chat teardown fails", async () => {
+    const events: any[] = [];
+    const fake = makeFakeServices();
+    fake.agentChatService.countActiveForLane.mockReturnValue(1);
+    fake.agentChatService.disposeForLane.mockRejectedValue(new Error("chat refused to close"));
+    const { service, db } = await setupWithLane({ teardown: fake, events, createWorktree: false });
+    vi.mocked(runGit).mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" } as any);
+    vi.mocked(runGitOrThrow).mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" } as any);
+
+    await expect(service.delete({ laneId: "lane-child", deleteBranch: false })).rejects.toThrow("chat refused to close");
+
+    expect(db.get<{ id: string }>("select id from lanes where id = ?", ["lane-child"])?.id).toBe("lane-child");
+    const last = events[events.length - 1];
+    expect(last.progress.overallStatus).toBe("failed");
+    expect(last.progress.steps.find((s: any) => s.name === "stop_chats")?.status).toBe("failed");
   });
 
   it("does not cancel a lane delete after it starts", async () => {
@@ -3471,9 +3529,10 @@ describe("laneService delete teardown + cancellation + streaming", () => {
     expect(last.progress.steps.find((step: any) => step.name === "git_worktree_remove")?.status).toBe("completed");
   });
 
-  it("getDeleteRisk reports running processes, ptys, watchers, and unpushed commits", async () => {
+  it("getDeleteRisk reports running processes, chats, ptys, watchers, and unpushed commits", async () => {
     const events: any[] = [];
     const fake = makeFakeServices();
+    fake.agentChatService.countActiveForLane.mockReturnValue(1);
     const { service } = await setupWithLane({ teardown: fake, events });
     // 3 unpushed commits + remote branch exists.
     vi.mocked(runGit).mockImplementation(async (args: string[]) => {
@@ -3487,6 +3546,7 @@ describe("laneService delete teardown + cancellation + streaming", () => {
 
     const risk = await service.getDeleteRisk("lane-child");
     expect(risk.runningProcessCount).toBe(1);
+    expect(risk.activeChatCount).toBe(1);
     expect(risk.activePtyCount).toBe(2);
     expect(risk.activeWatcherCount).toBe(1);
     expect(risk.hasUnpushedCommits).toBe(true);

--- a/apps/desktop/src/main/services/lanes/laneService.test.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.test.ts
@@ -3487,7 +3487,7 @@ describe("laneService delete teardown + cancellation + streaming", () => {
     expect(count("lane_worktree_locks", "lane_id = ?", ["lane-child"])).toBe(0);
   });
 
-  it("keeps the lane intact when active chat teardown fails", async () => {
+  it("continues lane delete with a warning when active chat teardown fails", async () => {
     const events: any[] = [];
     const fake = makeFakeServices();
     fake.agentChatService.countActiveForLane.mockReturnValue(1);
@@ -3496,12 +3496,12 @@ describe("laneService delete teardown + cancellation + streaming", () => {
     vi.mocked(runGit).mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" } as any);
     vi.mocked(runGitOrThrow).mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" } as any);
 
-    await expect(service.delete({ laneId: "lane-child", deleteBranch: false })).rejects.toThrow("chat refused to close");
+    await service.delete({ laneId: "lane-child", deleteBranch: false });
 
-    expect(db.get<{ id: string }>("select id from lanes where id = ?", ["lane-child"])?.id).toBe("lane-child");
+    expect(db.get<{ id: string }>("select id from lanes where id = ?", ["lane-child"])).toBeNull();
     const last = events[events.length - 1];
-    expect(last.progress.overallStatus).toBe("failed");
-    expect(last.progress.steps.find((s: any) => s.name === "stop_chats")?.status).toBe("failed");
+    expect(last.progress.overallStatus).toBe("completed_with_warnings");
+    expect(last.progress.steps.find((s: any) => s.name === "stop_chats")?.status).toBe("warning");
   });
 
   it("does not cancel a lane delete after it starts", async () => {

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -886,6 +886,10 @@ export type LaneDeleteTeardownDeps = {
     listRuntime: (laneId: string) => ProcessRuntime[];
     stopAll: (args: { laneId: string }) => Promise<void>;
   };
+  agentChatService?: {
+    countActiveForLane: (laneId: string) => number;
+    disposeForLane: (laneId: string) => Promise<number>;
+  };
   ptyService?: {
     countActiveForLane: (laneId: string) => number;
     disposeForLane: (laneId: string) => number;
@@ -2583,6 +2587,19 @@ export function createLaneService({
     db.run("delete from conflict_predictions where project_id = ? and (lane_a_id = ? or lane_b_id = ?)", [projectId, laneId, laneId]);
     db.run("delete from checkpoints where lane_id = ? and project_id = ?", [laneId, projectId]);
     db.run("delete from session_deltas where lane_id = ? and project_id = ?", [laneId, projectId]);
+    db.run(
+      `
+        delete from session_linear_issues
+        where project_id = ?
+          and (
+            lane_id = ?
+            or session_id in (select id from terminal_sessions where lane_id = ?)
+            or session_id in (select session_id from claude_sessions where lane_id = ?)
+          )
+      `,
+      [projectId, laneId, laneId, laneId],
+    );
+    db.run("delete from claude_sessions where lane_id = ?", [laneId]);
     db.run("delete from terminal_sessions where lane_id = ?", [laneId]);
     db.run("delete from operations where lane_id = ? and project_id = ?", [laneId, projectId]);
     db.run("delete from packs_index where lane_id = ? and project_id = ?", [laneId, projectId]);
@@ -4578,7 +4595,7 @@ export function createLaneService({
         (fs.existsSync(row.worktree_path) || worktreeRegistered);
       const stepNames: LaneDeleteStepName[] = [];
       if (hasWorktree) stepNames.push("git_status");
-      stepNames.push("cancel_auto_rebase", "stop_processes", "stop_ptys", "stop_watchers", "cleanup_env");
+      stepNames.push("cancel_auto_rebase", "stop_processes", "stop_chats", "stop_ptys", "stop_watchers", "cleanup_env");
       if (hasWorktree) stepNames.push("git_worktree_remove");
       if (deleteBranch && row.branch_ref) stepNames.push("git_branch_delete");
       if (deleteRemoteBranch && row.branch_ref) stepNames.push("git_remote_branch_delete");
@@ -4681,6 +4698,15 @@ export function createLaneService({
             logger.warn("lane.delete.stop_processes_failed", { laneId, error: err instanceof Error ? err.message : String(err) });
           }
           return { detail: `stopped ${active.length} ${active.length === 1 ? "process" : "processes"}` };
+        });
+
+        await runStep("stop_chats", async () => {
+          const svc = teardownDeps?.agentChatService;
+          if (!svc) return { detail: "no service" };
+          const before = svc.countActiveForLane(laneId);
+          if (before === 0) return { detail: "none active" };
+          const disposed = await svc.disposeForLane(laneId);
+          return { detail: `closed ${disposed} ${disposed === 1 ? "chat" : "chats"}` };
         });
 
         await runStep("stop_ptys", async () => {
@@ -4891,6 +4917,7 @@ export function createLaneService({
       const runningProcessCount = teardownDeps?.processService
         ? teardownDeps.processService.listRuntime(laneId).filter(isActiveProcess).length
         : 0;
+      const activeChatCount = teardownDeps?.agentChatService?.countActiveForLane(laneId) ?? 0;
       const activePtyCount = teardownDeps?.ptyService?.countActiveForLane(laneId) ?? 0;
       const activeWatcherCount = teardownDeps?.fileWatcherService?.countActiveForWorkspace(laneId) ?? 0;
       return {
@@ -4901,6 +4928,7 @@ export function createLaneService({
         unpushedCommitCount,
         remoteBranchExists,
         runningProcessCount,
+        activeChatCount,
         activePtyCount,
         activeWatcherCount,
         envInitialized: false

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -4707,7 +4707,7 @@ export function createLaneService({
           if (before === 0) return { detail: "none active" };
           const disposed = await svc.disposeForLane(laneId);
           return { detail: `closed ${disposed} ${disposed === 1 ? "chat" : "chats"}` };
-        });
+        }, { fatal: false });
 
         await runStep("stop_ptys", async () => {
           const svc = teardownDeps?.ptyService;

--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -4319,6 +4319,7 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
         unpushedCommitCount: 0,
         remoteBranchExists: false,
         runningProcessCount: 0,
+        activeChatCount: 0,
         activePtyCount: 0,
         activeWatcherCount: 0,
         envInitialized: false,

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -3620,6 +3620,38 @@ describe("AgentChatPane submit recovery", () => {
     });
   });
 
+  it("ignores duplicate auto-create submits for the same draft while lane naming is pending", async () => {
+    const { suggestLaneName } = installAdeMocks({ sessions: [] });
+    suggestLaneName.mockImplementation(() => new Promise<string>(() => {
+      // Keep the first launch in-flight so duplicate clicks race the same snapshot.
+    }));
+
+    renderAutoCreateDraftPane();
+
+    const modelTrigger = await screen.findByRole("button", { name: /^Select model/ });
+    const codexLabel = getModelById("openai/gpt-5.4")?.displayName ?? "GPT-5.4";
+    fireEvent.pointerDown(modelTrigger, { button: 0 });
+    fireEvent.click(modelTrigger);
+    fireEvent.click(await screen.findByRole("tab", { name: /^OpenAI$/i }));
+    await clickEnabledModelOption(new RegExp(escapeRegExp(codexLabel), "i"));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Select lane" }));
+    fireEvent.click(await screen.findByRole("button", { name: /Auto-create lane/i }));
+
+    const textbox = await screen.findByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "Launch once even if clicked twice." } });
+    const launchButton = await screen.findByRole("button", { name: "Auto-create in background" });
+    await act(async () => {
+      launchButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      launchButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    await waitFor(() => {
+      expect(suggestLaneName).toHaveBeenCalledTimes(1);
+      expect(screen.getAllByText(/Creating lane for chat/i)).toHaveLength(1);
+    });
+  });
+
   it("keeps every in-flight background draft launch visible past the completed-notice cap", async () => {
     const { suggestLaneName } = installAdeMocks({ sessions: [] });
     suggestLaneName.mockImplementation(() => new Promise<string>(() => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -331,6 +331,20 @@ function pruneDraftLaunchJobs(jobs: DraftLaunchJob[]): DraftLaunchJob[] {
   ];
 }
 
+function draftLaunchRequestKey(args: {
+  kind: DraftLaunchKind;
+  mode: DraftLaunchMode;
+  autoCreate: boolean;
+  snapshot: DraftLaunchSnapshot;
+}): string {
+  return JSON.stringify({
+    kind: args.kind,
+    mode: args.mode,
+    autoCreate: args.autoCreate,
+    snapshot: args.snapshot,
+  });
+}
+
 function createTemporaryAutoLaneName(date = new Date()): string {
   const pad = (value: number) => String(value).padStart(2, "0");
   return [
@@ -2586,6 +2600,7 @@ export function AgentChatPane({
   const pendingSelectedSessionIdRef = useRef<string | null>(null);
   const submitInFlightRef = useRef(false);
   const latestForegroundDraftLaunchJobIdRef = useRef<string | null>(null);
+  const draftLaunchInFlightKeysRef = useRef<Set<string>>(new Set());
   const createSessionPromiseRef = useRef<Promise<string | null> | null>(null);
   const pendingNativeControlUpdateRef = useRef<{
     sessionId: string;
@@ -5943,6 +5958,16 @@ export function AgentChatPane({
         : "Add a message before sending.");
       return;
     }
+    const requestKey = draftLaunchRequestKey({
+      kind,
+      mode,
+      autoCreate: draftLaunchTargetIsAutoCreate,
+      snapshot,
+    });
+    if (draftLaunchInFlightKeysRef.current.has(requestKey)) {
+      return;
+    }
+    draftLaunchInFlightKeysRef.current.add(requestKey);
 
     const jobId = createDraftLaunchJobId();
     if (mode === "foreground") {
@@ -6032,6 +6057,8 @@ export function AgentChatPane({
         autoOpen: false,
       });
       setError(message);
+    } finally {
+      draftLaunchInFlightKeysRef.current.delete(requestKey);
     }
   }, [
     buildDraftLaunchSnapshotForCurrentState,

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -337,6 +337,7 @@ const LANE_DELETE_STEP_LABELS: Record<string, string> = {
   git_status: "dirty-state check",
   cancel_auto_rebase: "auto-rebase cancellation",
   stop_processes: "process shutdown",
+  stop_chats: "chat shutdown",
   stop_ptys: "terminal shutdown",
   stop_watchers: "file watcher shutdown",
   cleanup_env: "environment cleanup",

--- a/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx
+++ b/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LaneDeleteRisk, LaneSummary } from "../../../shared/types";
 import { ManageLaneDialog } from "./ManageLaneDialog";
@@ -15,6 +15,7 @@ const deleteRisk: LaneDeleteRisk = {
   unpushedCommitCount: 0,
   remoteBranchExists: true,
   runningProcessCount: 0,
+  activeChatCount: 0,
   activePtyCount: 0,
   activeWatcherCount: 0,
   envInitialized: true,
@@ -142,5 +143,20 @@ describe("ManageLaneDialog tabs", () => {
     );
 
     expect(selectedTabLabel()).toBe("Archive");
+  });
+
+  it("shows active chat sessions in the delete preflight", async () => {
+    (window as any).ade.lanes.getDeleteRisk.mockResolvedValueOnce({
+      ...deleteRisk,
+      activeChatCount: 1,
+    });
+
+    render(<ManageLaneDialog {...makeProps()} />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("1 chat session")).toBeTruthy();
+    });
   });
 });

--- a/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx
+++ b/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx
@@ -7,6 +7,7 @@ import {
   CircleNotch,
   Palette,
   Terminal,
+  ChatCircle,
   Cpu,
   Eye,
   Cube,
@@ -37,6 +38,7 @@ const STEP_LABELS: Record<LaneDeleteStepName, string> = {
   git_status: "Checking dirty state",
   cancel_auto_rebase: "Cancelling auto-rebase",
   stop_processes: "Stopping processes",
+  stop_chats: "Closing chat sessions",
   stop_ptys: "Closing terminal sessions",
   stop_watchers: "Stopping file watchers",
   cleanup_env: "Cleaning environment",
@@ -614,6 +616,12 @@ function PreflightPanel({
     willStop.push({
       icon: <Cpu size={12} className="text-accent" />,
       label: `${risk.runningProcessCount} running ${risk.runningProcessCount === 1 ? "process" : "processes"}`
+    });
+  }
+  if (risk && risk.activeChatCount > 0) {
+    willStop.push({
+      icon: <ChatCircle size={12} className="text-accent" />,
+      label: `${risk.activeChatCount} chat ${risk.activeChatCount === 1 ? "session" : "sessions"}`
     });
   }
   if (risk && risk.activePtyCount > 0) {

--- a/apps/desktop/src/shared/types/lanes.ts
+++ b/apps/desktop/src/shared/types/lanes.ts
@@ -347,6 +347,7 @@ export type DeleteLaneArgs = {
 
 export type LaneDeleteStepName =
   | "stop_processes"
+  | "stop_chats"
   | "stop_ptys"
   | "stop_watchers"
   | "cancel_auto_rebase"
@@ -400,6 +401,7 @@ export type LaneDeleteRisk = {
   unpushedCommitCount: number;
   remoteBranchExists: boolean;
   runningProcessCount: number;
+  activeChatCount: number;
   activePtyCount: number;
   activeWatcherCount: number;
   envInitialized: boolean;


### PR DESCRIPTION
Fixes ADE-91
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-91: Lane lifecycle operations crash active CLI sessions and chats](https://linear.app/ade-linear/issue/ADE-91/lane-lifecycle-operations-crash-active-cli-sessions-and-chats) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-91-lane-lifecycle-operations-crash-active-cli-sessions-and-chats num=505 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-91-lane-lifecycle-operations-crash-active-cli-sessions-and-chats&amp;pr=505">ade-91-lane-lifecycle-operations-crash-active-cli-sessions-and-chats branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=505">PR #505</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lane deletion process now identifies and warns users about active chat sessions that will be lost
  * Chat sessions are automatically closed during lane deletion cleanup

* **Bug Fixes**
  * Prevented duplicate background auto-create submit actions for chat drafts while lane naming is in progress

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes ADE-91 by adding chat session lifecycle management to the lane deletion pipeline. When a lane is deleted, active chat sessions belonging to that lane (or routing execution through it) are now identified, warned about in the preflight UI, and closed during teardown.

- **Lane teardown extended**: A new `stop_chats` step (with `{ fatal: false }`) is injected between `stop_processes` and `stop_ptys`; `claude_sessions` and their associated `session_linear_issues` rows are also cleaned up in the DB teardown.
- **UI preflight updated**: `LaneDeleteRisk` gains `activeChatCount`, surfaced with a `ChatCircle` icon in `ManageLaneDialog` and in the CLI `formatLaneDeleteRisk` formatter.
- **Duplicate submit guard**: `AgentChatPane` gains a `draftLaunchInFlightKeysRef` set to suppress duplicate auto-create background submits while a lane-naming round-trip is still in flight.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: the error-accounting bug in disposeForLane causes misleading warning messages when a session is successfully force-closed after a failed graceful close.

The teardown pipeline and DB cleanup are well-structured and the non-fatal guard ensures deletion always completes. The one defect is in agentChatService.disposeForLane: when dispose() fails but forceDisposeManagedSession() succeeds, the original error is still pushed to errors and the function throws — reporting a failure for sessions that were actually cleaned up. When both paths fail, two strings are pushed for one session, so the count in the thrown message is off. Everything else in the PR — the stop_chats step ordering, the DB delete ordering, the duplicate-submit guard, and the preflight UI — looks correct.

apps/desktop/src/main/services/chat/agentChatService.ts — specifically the error-accumulation logic in disposeForLane

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/chat/agentChatService.ts | Adds countActiveForLane, disposeForLane, managedSessionBelongsToLane, and forceDisposeManagedSession. The error-accounting in disposeForLane has a defect: the original dispose error is pushed to errors even when force-close succeeds, so the function throws and reports failure for sessions that were actually cleaned up. |
| apps/desktop/src/main/services/lanes/laneService.ts | Adds stop_chats teardown step (correctly marked non-fatal), agentChatService to LaneDeleteTeardownDeps, activeChatCount to risk reporting, and DB cleanup for claude_sessions and session_linear_issues. Delete order is correct. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Adds draftLaunchInFlightKeysRef dedup guard using a JSON-serialized snapshot key to prevent duplicate background auto-create submits; key is deleted in finally to allow retries after completion. |
| apps/ade-cli/src/bootstrap.ts | Wires agentChatService into laneTeardownDeps using the established lazy-population pattern; the stop_chats step gracefully skips when the service is not yet populated. |
| apps/desktop/src/main/main.ts | Desktop entry point registers agentChatService into laneTeardownDeps after service construction, mirroring the CLI bootstrap pattern. |
| apps/desktop/src/shared/types/lanes.ts | Adds stop_chats to LaneDeleteStepName union and activeChatCount: number to LaneDeleteRisk; straightforward type extension with no issues. |
| apps/desktop/src/main/services/lanes/laneService.test.ts | Adds agentChatService mock to teardown fixture, extends the happy-path ordering test, adds a non-fatal-failure test, and covers getDeleteRisk reporting activeChatCount. |
| apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx | Extends preflight panel to display active chat count with a ChatCircle icon; label copy and icon choice are consistent with existing process/PTY rows. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as UI / CLI
    participant LS as laneService.delete()
    participant ACS as agentChatService
    participant DB as SQLite

    UI->>LS: getDeleteRisk(laneId)
    LS->>ACS: countActiveForLane(laneId)
    ACS-->>LS: activeChatCount
    LS-->>UI: "LaneDeleteRisk { activeChatCount, ... }"

    UI->>LS: delete(laneId)
    LS->>LS: runStep(cancel_auto_rebase)
    LS->>LS: runStep(stop_processes)
    LS->>ACS: "runStep(stop_chats) [fatal=false]"
    ACS->>ACS: disposeForLane(laneId)
    alt dispose succeeds
        ACS-->>LS: disposed count
    else dispose fails then forceDispose
        ACS->>ACS: forceDisposeManagedSession()
        ACS-->>LS: warning (non-fatal)
    end
    LS->>LS: runStep(stop_ptys)
    LS->>LS: runStep(stop_watchers)
    LS->>LS: runStep(git_worktree_remove)
    LS->>DB: DELETE claude_sessions WHERE lane_id
    LS->>DB: DELETE session_linear_issues (lane + sessions)
    LS->>DB: DELETE terminal_sessions WHERE lane_id
    LS->>DB: DELETE lanes WHERE id
    LS-->>UI: completed / completed_with_warnings
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fchat%2FagentChatService.ts%3A21882-21896%0AThe%20original%20%60dispose%60%20error%20is%20unconditionally%20pushed%20to%20%60errors%60%20even%20when%20%60forceDisposeManagedSession%60%20succeeds.%20This%20means%20a%20session%20that%20was%20actually%20cleaned%20up%20via%20force-close%20is%20counted%20as%20a%20failure%2C%20so%20%60disposeForLane%60%20throws%20%22Failed%20to%20close%201%20chat%20session%3A%20%E2%80%A6%22%20for%20sessions%20that%20were%20in%20fact%20disposed.%20A%20second%20issue%3A%20when%20both%20%60dispose%60%20and%20%60forceDispose%60%20both%20fail%2C%20two%20error%20strings%20are%20pushed%20for%20a%20single%20session%2C%20causing%20the%20message%20to%20say%20%22Failed%20to%20close%202%20chat%20sessions%22%20for%20one%20session.%20Since%20%60stop_chats%60%20runs%20with%20%60%7B%20fatal%3A%20false%20%7D%60%2C%20the%20warning%20text%20surfaced%20to%20the%20user%20is%20the%20only%20observable%20output%20%E2%80%94%20getting%20it%20wrong%20undermines%20the%20diagnostic%20value.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20await%20dispose%28%7B%20sessionId%20%7D%29%3B%0A%20%20%20%20%20%20%20%20disposed%20%2B%3D%201%3B%0A%20%20%20%20%20%20%7D%20catch%20%28error%29%20%7B%0A%20%20%20%20%20%20%20%20const%20managed%20%3D%20managedSessions.get%28sessionId%29%3B%0A%20%20%20%20%20%20%20%20let%20forceClosed%20%3D%20false%3B%0A%20%20%20%20%20%20%20%20if%20%28managed%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20forceDisposeManagedSession%28managed%2C%20%22Session%20force-closed%20during%20lane%20deletion.%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20disposed%20%2B%3D%201%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20forceClosed%20%3D%20true%3B%0A%20%20%20%20%20%20%20%20%20%20%7D%20catch%20%28forceError%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20errors.push%28%60%24%7BsessionId%7D%3A%20force%20close%20failed%3A%20%24%7BforceError%20instanceof%20Error%20%3F%20forceError.message%20%3A%20String%28forceError%29%7D%60%29%3B%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20if%20%28!forceClosed%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20errors.push%28%60%24%7BsessionId%7D%3A%20%24%7Berror%20instanceof%20Error%20%3F%20error.message%20%3A%20String%28error%29%7D%60%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=505&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/main/services/chat/agentChatService.ts:21882-21896
The original `dispose` error is unconditionally pushed to `errors` even when `forceDisposeManagedSession` succeeds. This means a session that was actually cleaned up via force-close is counted as a failure, so `disposeForLane` throws "Failed to close 1 chat session: …" for sessions that were in fact disposed. A second issue: when both `dispose` and `forceDispose` both fail, two error strings are pushed for a single session, causing the message to say "Failed to close 2 chat sessions" for one session. Since `stop_chats` runs with `{ fatal: false }`, the warning text surfaced to the user is the only observable output — getting it wrong undermines the diagnostic value.

```suggestion
      try {
        await dispose({ sessionId });
        disposed += 1;
      } catch (error) {
        const managed = managedSessions.get(sessionId);
        let forceClosed = false;
        if (managed) {
          try {
            forceDisposeManagedSession(managed, "Session force-closed during lane deletion.");
            disposed += 1;
            forceClosed = true;
          } catch (forceError) {
            errors.push(`${sessionId}: force close failed: ${forceError instanceof Error ? forceError.message : String(forceError)}`);
          }
        }
        if (!forceClosed) {
          errors.push(`${sessionId}: ${error instanceof Error ? error.message : String(error)}`);
        }
      }
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Address lane delete chat teardown review"](https://github.com/arul28/ade/commit/1e1917a96cf75604b84edcab22d31f32c4422410) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35033475)</sub>

<!-- /greptile_comment -->