### PR TITLE
ADE-92: Copy user-launched chat and CLI prompts to clipboard

### DIFF
--- a/apps/desktop/src/renderer/components/app/App.tsx
+++ b/apps/desktop/src/renderer/components/app/App.tsx
@@ -588,6 +588,7 @@ function ProjectTabHost() {
     smartTooltipsEnabled: s.smartTooltipsEnabled,
     onboardingEnabled: s.onboardingEnabled,
     didYouKnowEnabled: s.didYouKnowEnabled,
+    launchPromptClipboardEnabled: s.launchPromptClipboardEnabled,
   })));
   const storesRef = React.useRef(new Map<string, AppStoreApi>());
   const lruRef = React.useRef<string[]>([]);

--- a/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
+++ b/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
@@ -25,6 +25,8 @@ import {
 import { BatchLaunchModal, type BatchLaunchSubmit } from "./BatchLaunchModal";
 import { BatchLaunchStatusToast } from "./BatchLaunchStatusToast";
 import {
+  defaultKickoffIntro,
+  defaultKickoffPrompt,
   findIssueConflicts,
   runBatchLaunch,
   type BatchLaunchIssueConfig,
@@ -35,6 +37,7 @@ import {
   rememberCreatingIssues,
   rememberLaunchedLanes,
 } from "../../lib/launchedLanesHighlight";
+import { copyLaunchPromptToClipboard } from "../../lib/launchPromptClipboard";
 
 const INITIAL_VISIBILITY_CHECK_DELAY_MS = 2_000;
 const VISIBILITY_RETRY_INTERVAL_MS = 3_000;
@@ -105,6 +108,7 @@ export function LinearQuickViewButton({
   const lanes = useAppStore((s) => s.lanes);
   const refreshLanes = useAppStore((s) => s.refreshLanes);
   const selectLane = useAppStore((s) => s.selectLane);
+  const launchPromptClipboardEnabled = useAppStore((s) => s.launchPromptClipboardEnabled);
   const [visible, setVisible] = useState(false);
   const [open, setOpen] = useState(false);
   const [quickView, setQuickView] = useState<CtoLinearQuickView | null>(null);
@@ -305,6 +309,14 @@ export function LinearQuickViewButton({
 
   const launchBatch = useCallback(async (entries: BatchLaunchSubmit[]) => {
     if (!entries.length) return;
+    if (launchPromptClipboardEnabled) {
+      const lastLaunchEntry = [...entries].reverse().find(({ config }) => !config.laneOnly);
+      const lastPrompt = lastLaunchEntry
+        ? lastLaunchEntry.config.kickoffPrompt.trim()
+          || (lastLaunchEntry.config.sessionType === "cli" ? defaultKickoffIntro() : defaultKickoffPrompt())
+        : "";
+      void copyLaunchPromptToClipboard(lastPrompt);
+    }
     // Record optimistic "creating lane" placeholders for issues that mint a NEW
     // lane (existing-lane targets already have a lane), keyed by issue id. The
     // Lanes tab renders these as spinner tabs immediately on reroute and clears
@@ -386,7 +398,7 @@ export function LinearQuickViewButton({
         sessionIds: result.createdSessionIds,
       });
     }
-  }, [refreshLanes]);
+  }, [launchPromptClipboardEnabled, refreshLanes]);
 
   const handleBatchLaunch = useCallback((entries: BatchLaunchSubmit[]) => {
     // Close + reroute synchronously; the orchestrator runs detached so the

--- a/apps/desktop/src/renderer/components/app/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/components/app/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect } from "react";
-import { useSearchParams, useLocation } from "react-router-dom";
+import { useSearchParams, useLocation, useNavigate } from "react-router-dom";
 import { Brain, ChartLineUp, GearSix, Stack, Plugs, Palette, DeviceMobile, Robot } from "@phosphor-icons/react";
 import { GeneralSection } from "../settings/GeneralSection";
 import { AppearanceSection } from "../settings/AppearanceSection";
@@ -46,6 +46,11 @@ const TAB_ALIASES: Record<string, SectionId> = {
   "ade-usage": "ade-usage",
 };
 
+const HASH_TARGET_SECTIONS: Partial<Record<string, SectionId>> = {
+  "ai-providers": "ai",
+  "chat-launch-clipboard": "appearance",
+};
+
 function padIndex(i: number): string {
   return String(i + 1).padStart(2, "0");
 }
@@ -54,6 +59,7 @@ function padIndex(i: number): string {
 
 export function SettingsPage({ active = true }: { active?: boolean } = {}) {
   const location = useLocation();
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const tabParam = searchParams.get("tab");
   const canonicalTab = tabParam && SECTIONS.some((s) => s.id === tabParam)
@@ -85,14 +91,22 @@ export function SettingsPage({ active = true }: { active?: boolean } = {}) {
     setSection(next);
     const nextParams = new URLSearchParams(searchParams);
     nextParams.set("tab", next);
-    setSearchParams(nextParams, { replace: true });
-  }, [searchParams, setSearchParams]);
+    navigate({ pathname: location.pathname, search: `?${nextParams.toString()}`, hash: "" }, { replace: true });
+  }, [location.pathname, navigate, searchParams]);
 
   useEffect(() => {
     if (!active) return;
-    if (section !== "ai" || location.hash !== "#ai-providers") return;
+    if (!location.hash) return;
+    let targetId = location.hash.slice(1);
+    try {
+      targetId = decodeURIComponent(targetId);
+    } catch {
+      // A malformed hash should not break the settings page.
+    }
+    if (!targetId) return;
+    if (HASH_TARGET_SECTIONS[targetId] !== section) return;
     const id = window.requestAnimationFrame(() => {
-      document.getElementById("ai-providers")?.scrollIntoView({ block: "start", behavior: "smooth" });
+      document.getElementById(targetId)?.scrollIntoView({ block: "start", behavior: "smooth" });
     });
     return () => window.cancelAnimationFrame(id);
   }, [active, section, location.hash]);

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
@@ -1367,6 +1367,45 @@ describe("AgentChatComposer", () => {
     })).toBeTruthy();
   });
 
+  it("shows the launch clipboard helper only while typing in the prompt", () => {
+    const onOpenLaunchPromptClipboardSettings = vi.fn();
+    renderComposer({
+      draft: "Recoverable launch prompt",
+      turnActive: false,
+      launchPromptClipboardEnabled: true,
+      onOpenLaunchPromptClipboardSettings,
+    });
+
+    expect(screen.queryByText(/Prompt will be copied to clipboard after Send\./)).toBeNull();
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.focus(textarea);
+
+    expect(screen.getByText(/Prompt will be copied to clipboard after Send\./)).toBeTruthy();
+    const settingButton = screen.getByRole("button", { name: "Setting" });
+    fireEvent.blur(textarea, { relatedTarget: settingButton });
+    fireEvent.focus(settingButton);
+    expect(screen.getByText(/Prompt will be copied to clipboard after Send\./)).toBeTruthy();
+
+    fireEvent.click(settingButton);
+    expect(onOpenLaunchPromptClipboardSettings).toHaveBeenCalledTimes(1);
+
+    fireEvent.blur(settingButton);
+    expect(screen.queryByText(/Prompt will be copied to clipboard after Send\./)).toBeNull();
+  });
+
+  it("hides the launch clipboard helper when the setting is disabled", () => {
+    renderComposer({
+      draft: "No helper",
+      turnActive: false,
+      launchPromptClipboardEnabled: false,
+    });
+
+    fireEvent.focus(screen.getByRole("textbox"));
+
+    expect(screen.queryByText(/Prompt will be copied to clipboard after Send\./)).toBeNull();
+  });
+
   it("focuses the grid composer when the tile becomes active", () => {
     const props = buildComposerProps({
       layoutVariant: "grid-tile",

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -813,6 +813,8 @@ export function AgentChatComposer({
   onDispatchSteerInterrupt,
   onOpenAiSettings,
   onOpenLinearSettings,
+  launchPromptClipboardEnabled = false,
+  onOpenLaunchPromptClipboardSettings,
   onStartOrchestratorChat,
   onStopOrchestratorChat,
   orchestratorModeActive = false,
@@ -962,6 +964,8 @@ export function AgentChatComposer({
   onDispatchSteerInterrupt?: (steerId: string) => void;
   onOpenAiSettings?: () => void;
   onOpenLinearSettings?: () => void;
+  launchPromptClipboardEnabled?: boolean;
+  onOpenLaunchPromptClipboardSettings?: () => void;
   /**
    * Open the "New orchestrator chat" flow from the visible composer mode
    * button (see `goal.md` §10.1). Hosts that don't want the entry simply
@@ -1015,6 +1019,8 @@ export function AgentChatComposer({
 }) {
   const [attachmentPickerOpen, setAttachmentPickerOpen] = useState(false);
   const [attachmentQuery, setAttachmentQuery] = useState("");
+  const [composerFocused, setComposerFocused] = useState(false);
+  const composerFocusRegionRef = useRef<HTMLDivElement | null>(null);
   const [attachmentBusy, setAttachmentBusy] = useState(false);
   const [attachmentResults, setAttachmentResults] = useState<AgentChatFileRef[]>([]);
   const [attachmentCursor, setAttachmentCursor] = useState(0);
@@ -1091,6 +1097,11 @@ export function AgentChatComposer({
   const canAttachIssueContext = !composerInputLocked && typeof onAddContextAttachment === "function";
   const showOrchestratorModeButton = Boolean(onStartOrchestratorChat && !sessionId && !parallelChatMode);
   const orchestratorModeButtonDisabled = composerInputLocked || busy || turnActive;
+  const showLaunchClipboardHelper =
+    launchPromptClipboardEnabled
+    && composerFocused
+    && !composerInputLocked
+    && draft.trim().length > 0;
 
   const resizeTextarea = useCallback(() => {
     if (useRichComposer) return;
@@ -3901,7 +3912,16 @@ export function AgentChatComposer({
           </div>
         ) : null}
 
-        <div className="relative">
+        <div
+          ref={composerFocusRegionRef}
+          className="relative"
+          onFocusCapture={() => setComposerFocused(true)}
+          onBlurCapture={(event) => {
+            const nextTarget = event.relatedTarget as Node | null;
+            if (nextTarget && composerFocusRegionRef.current?.contains(nextTarget)) return;
+            setComposerFocused(false);
+          }}
+        >
           {/* Ghost suggestion overlay */}
           {promptSuggestion && !draft.length && !turnActive ? (
             <div
@@ -4081,6 +4101,18 @@ export function AgentChatComposer({
               onPaste={handlePaste}
             />
           )}
+          {showLaunchClipboardHelper ? (
+            <div className="px-4 pb-2 font-sans text-[10.5px] leading-snug text-muted-fg/55">
+              Prompt will be copied to clipboard after Send.{" "}
+              <button
+                type="button"
+                className="text-fg/70 underline decoration-white/20 underline-offset-2 transition-colors hover:text-fg"
+                onClick={onOpenLaunchPromptClipboardSettings}
+              >
+                Setting
+              </button>
+            </div>
+          ) : null}
         </div>
       </div>
       </ChatComposerShell>

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -464,10 +464,14 @@ function installAdeMocks(options?: {
   const archive = vi.fn().mockResolvedValue(undefined);
   const unarchive = vi.fn().mockResolvedValue(undefined);
   const deleteLane = vi.fn().mockResolvedValue(undefined);
+  const writeClipboardText = vi.fn().mockResolvedValue(undefined);
   const chatEventListeners = new Set<(event: AgentChatEventEnvelope) => void>();
   const sessionChangeListeners = new Set<(event: TerminalSessionChangedEvent) => void>();
 
   globalThis.window.ade = {
+    app: {
+      writeClipboardText,
+    },
     projectConfig: {
       get: vi.fn().mockResolvedValue({
         effective: {
@@ -617,6 +621,7 @@ function installAdeMocks(options?: {
     parallelLaunchStateGet,
     parallelLaunchStateSet,
     handoff,
+    writeClipboardText,
     emitChatEvent: (event: AgentChatEventEnvelope) => {
       for (const listener of chatEventListeners) {
         listener(event);
@@ -639,6 +644,7 @@ function resetChatTestStore() {
     focusedSessionId: null,
     projectTransition: null,
     laneInspectorTabs: {},
+    launchPromptClipboardEnabled: true,
     workViewByProject: {},
     laneWorkViewByScope: {},
   });
@@ -2951,7 +2957,7 @@ describe("AgentChatPane submit recovery", () => {
 
   it("does not wait for onSessionCreated before sending the first message in a new chat", async () => {
     const onSessionCreated = vi.fn().mockImplementation(() => new Promise<void>(() => {}));
-    const { send, create } = installAdeMocks({ sessions: [] });
+    const { send, create, writeClipboardText } = installAdeMocks({ sessions: [] });
 
     render(
       <MemoryRouter>
@@ -2983,7 +2989,72 @@ describe("AgentChatPane submit recovery", () => {
         text: "Ship the instant route fix.",
         displayText: "Ship the instant route fix.",
       }));
+      expect(writeClipboardText).toHaveBeenCalledWith("Ship the instant route fix.");
     });
+  });
+
+  it("copies a new chat prompt before session creation failures can lose it", async () => {
+    const { writeClipboardText } = installAdeMocks({
+      sessions: [],
+      createError: new Error("create exploded"),
+    });
+
+    render(
+      <MemoryRouter>
+        <AgentChatPane
+          laneId="lane-1"
+          forceNewSession
+        />
+      </MemoryRouter>,
+    );
+
+    const trigger = await screen.findByRole("button", { name: /^Select model/ });
+    const codexLabel = getModelById("openai/gpt-5.4")?.displayName ?? "GPT-5.4";
+    fireEvent.pointerDown(trigger, { button: 0 });
+    fireEvent.click(trigger);
+    fireEvent.click(await screen.findByRole("tab", { name: /^OpenAI$/i }));
+    await clickEnabledModelOption(new RegExp(escapeRegExp(codexLabel), "i"));
+
+    const textbox = await screen.findByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "Recover this prompt if launch fails." } });
+    fireEvent.click(await screen.findByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(writeClipboardText).toHaveBeenCalledWith("Recover this prompt if launch fails.");
+      expect(screen.getByText("create exploded")).toBeTruthy();
+    });
+  });
+
+  it("does not copy submitted prompts when the launch clipboard setting is disabled", async () => {
+    useAppStore.setState({ launchPromptClipboardEnabled: false });
+    const { send, writeClipboardText } = installAdeMocks({ sessions: [] });
+
+    render(
+      <MemoryRouter>
+        <AgentChatPane
+          laneId="lane-1"
+          forceNewSession
+        />
+      </MemoryRouter>,
+    );
+
+    const trigger = await screen.findByRole("button", { name: /^Select model/ });
+    const codexLabel = getModelById("openai/gpt-5.4")?.displayName ?? "GPT-5.4";
+    fireEvent.pointerDown(trigger, { button: 0 });
+    fireEvent.click(trigger);
+    fireEvent.click(await screen.findByRole("tab", { name: /^OpenAI$/i }));
+    await clickEnabledModelOption(new RegExp(escapeRegExp(codexLabel), "i"));
+
+    const textbox = await screen.findByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "Do not copy this prompt." } });
+    fireEvent.click(await screen.findByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(send).toHaveBeenCalledWith(expect.objectContaining({
+        text: "Do not copy this prompt.",
+      }));
+    });
+    expect(writeClipboardText).not.toHaveBeenCalled();
   });
 
   it("logs synchronous session-created callback failures without blocking the first send", async () => {
@@ -3033,7 +3104,7 @@ describe("AgentChatPane submit recovery", () => {
 
   it("foreground auto-create opens the new chat in Work instead of routing to Lanes", async () => {
     const onSessionCreated = vi.fn();
-    const { send, create, createLane, suggestLaneName } = installAdeMocks({ sessions: [] });
+    const { send, create, createLane, suggestLaneName, writeClipboardText } = installAdeMocks({ sessions: [] });
     suggestLaneName.mockResolvedValue("fix-auto-create-flow");
     createLane.mockResolvedValue({
       id: "lane-created",
@@ -3076,6 +3147,7 @@ describe("AgentChatPane submit recovery", () => {
         sessionId: "created-session",
         text: "Fix auto create lane routing.",
       }));
+      expect(writeClipboardText).toHaveBeenCalledWith("Fix auto create lane routing.");
       expect(onSessionCreated).toHaveBeenCalledWith(
         expect.objectContaining({ id: "created-session", laneId: "lane-created" }),
         { activate: false, source: "draft-launch" },
@@ -4047,7 +4119,7 @@ describe("AgentChatPane submit recovery", () => {
   });
 
   it("auto-creates a lane for a foreground CLI session draft", async () => {
-    const { send, create, createLane, suggestLaneName } = installAdeMocks({ sessions: [] });
+    const { send, create, createLane, suggestLaneName, writeClipboardText } = installAdeMocks({ sessions: [] });
     const onLaunchCliSession = vi.fn().mockResolvedValue({ sessionId: "terminal-created", ptyId: "pty-created" });
     suggestLaneName.mockResolvedValue("cli-auto-lane");
     createLane.mockResolvedValue({
@@ -4093,6 +4165,7 @@ describe("AgentChatPane submit recovery", () => {
         tracked: true,
         disposition: "foreground",
       }));
+      expect(writeClipboardText).toHaveBeenCalledWith("Launch a CLI agent on a new lane.");
     });
     const launchArgs = onLaunchCliSession.mock.calls[0]?.[0];
     expect(launchArgs.startupCommand).not.toContain("Launch a CLI agent on a new lane.");
@@ -4639,7 +4712,7 @@ describe("AgentChatPane submit recovery", () => {
 
   it("launches one child lane per parallel model and opens work-focus tiling", async () => {
     const createdLanes: Array<Record<string, unknown>> = [];
-    const { send, suggestLaneName, parallelLaunchStateSet } = installAdeMocks({ sessions: [], includeClaudeModel: true });
+    const { send, suggestLaneName, parallelLaunchStateSet, writeClipboardText } = installAdeMocks({ sessions: [], includeClaudeModel: true });
     const createChild = vi.fn().mockImplementation(async ({ name, parentLaneId }: { name: string; parentLaneId: string }) => {
       const lane = {
         id: `lane-child-${createdLanes.length + 1}`,
@@ -4721,6 +4794,8 @@ describe("AgentChatPane submit recovery", () => {
       expect(create).toHaveBeenCalledTimes(2);
       expect(send).toHaveBeenCalledTimes(2);
     });
+    expect(writeClipboardText).toHaveBeenCalledTimes(1);
+    expect(writeClipboardText).toHaveBeenCalledWith("Fix the login bug");
     expect(create).toHaveBeenNthCalledWith(1, expect.objectContaining({
       laneId: "lane-child-1",
       provider: "codex",

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -123,6 +123,7 @@ import { ConfirmDialog, useConfirmDialog } from "../shared/InlineDialogs";
 import { ChatActionsDrawerPanel, type ChatActionsTab } from "./ChatActionsDrawerPanel";
 import { useAppStore } from "../../state/appStore";
 import { buildChatAppearanceRootStyle } from "./chatAppearance";
+import { copyLaunchPromptToClipboard } from "../../lib/launchPromptClipboard";
 import { LaneAccentDot } from "../lanes/LaneAccentDot";
 import { LaneCombobox, AUTO_CREATE_LANE_OPTION_ID } from "../terminals/LaneCombobox";
 import {
@@ -2311,6 +2312,7 @@ export function AgentChatPane({
   const chatTranscriptDensity = useAppStore((s) => s.chatTranscriptDensity);
   const chatChromeTint = useAppStore((s) => s.chatChromeTint);
   const chatShellGeometry = useAppStore((s) => s.chatShellGeometry);
+  const launchPromptClipboardEnabled = useAppStore((s) => s.launchPromptClipboardEnabled);
   const chatAppearanceRootStyle = useMemo(
     () => buildChatAppearanceRootStyle({ chatFontSizePx, transcriptDensity: chatTranscriptDensity }),
     [chatFontSizePx, chatTranscriptDensity],
@@ -2323,6 +2325,13 @@ export function AgentChatPane({
   const openLinearSettings = useCallback(() => {
     navigate("/settings?tab=integrations&integration=linear");
   }, [navigate]);
+  const openLaunchPromptClipboardSettings = useCallback(() => {
+    navigate("/settings?tab=appearance#chat-launch-clipboard");
+  }, [navigate]);
+  const copyPromptForLaunch = useCallback(async (promptText: string) => {
+    if (!launchPromptClipboardEnabled) return;
+    await copyLaunchPromptToClipboard(promptText);
+  }, [launchPromptClipboardEnabled]);
   const setWorkViewState = useAppStore((s) => s.setWorkViewState);
   const setLaneWorkViewState = useAppStore((s) => s.setLaneWorkViewState);
   const refreshLanesStore = useAppStore((s) => s.refreshLanes);
@@ -5968,6 +5977,7 @@ export function AgentChatPane({
       return;
     }
     draftLaunchInFlightKeysRef.current.add(requestKey);
+    void copyPromptForLaunch(snapshot.text);
 
     const jobId = createDraftLaunchJobId();
     if (mode === "foreground") {
@@ -6073,6 +6083,7 @@ export function AgentChatPane({
     parallelLaunchBusy,
     prepareDraftLaunchForSend,
     projectTransitionBlocksChat,
+    copyPromptForLaunch,
     refreshLanesStore,
     refreshSessions,
     resolveDraftLaunchLane,
@@ -6282,6 +6293,7 @@ export function AgentChatPane({
           return;
         }
         setPromptSuggestion(null);
+        void copyPromptForLaunch(draftText);
         const resolved = await handleApproval(planReadyGate.itemId, "decline", draftText);
         if (resolved) setDraft("");
         return;
@@ -6334,6 +6346,7 @@ export function AgentChatPane({
         setError(`Parallel launch allows at most ${PARALLEL_CHAT_MAX_ATTACHMENTS} attachments. Remove some files or send in batches.`);
         return;
       }
+      void copyPromptForLaunch(text);
 
       const draftSnapshot = draft;
       const attachmentsSnapshot = [...attachments];
@@ -6585,6 +6598,7 @@ export function AgentChatPane({
         return;
       }
     }
+    void copyPromptForLaunch(text);
     if (
       text === "/context"
       && selectedSessionId
@@ -6873,6 +6887,7 @@ export function AgentChatPane({
     busy,
     codexFastMode,
     constrainedModelSelectionError,
+    copyPromptForLaunch,
     createSession,
     currentNativeControls,
     contextAttachments,
@@ -8060,6 +8075,8 @@ export function AgentChatPane({
             onRemoveMacosVmContext={removeMacosVmContext}
             onOpenAiSettings={openAiProvidersSettings}
             onOpenLinearSettings={openLinearSettings}
+            launchPromptClipboardEnabled={launchPromptClipboardEnabled}
+            onOpenLaunchPromptClipboardSettings={openLaunchPromptClipboardSettings}
             onStartOrchestratorChat={() => {
               // Switch the lane to a fresh orchestrator-lead draft. The
               // submit path will then call `agentChat.create` +
@@ -8296,6 +8313,7 @@ export function AgentChatPane({
               setCursorCloudPaneOpen(true);
             }}
             onSubmitToCloud={async (promptText) => {
+              void copyPromptForLaunch(promptText);
               if (cursorCloudLaunchModeOpen) {
                 const result = await cursorCloudInlineLaunchRef.current?.launchWithPrompt(promptText);
                 return Boolean(result);

--- a/apps/desktop/src/renderer/components/settings/AppearanceSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/AppearanceSection.tsx
@@ -193,6 +193,7 @@ export function AppearanceSection() {
   const agentSoundSelectId = useId();
   const volumeSliderId = useId();
   const quietToggleId = useId();
+  const launchPromptClipboardToggleId = useId();
   const terminalFieldId = useId();
 
   const theme = useAppStore((s) => s.theme);
@@ -209,6 +210,8 @@ export function AppearanceSection() {
   const setChatShellGeometry = useAppStore((s) => s.setChatShellGeometry);
   const chatUserMinimapEnabled = useAppStore((s) => s.chatUserMinimapEnabled);
   const setChatUserMinimapEnabled = useAppStore((s) => s.setChatUserMinimapEnabled);
+  const launchPromptClipboardEnabled = useAppStore((s) => s.launchPromptClipboardEnabled);
+  const setLaunchPromptClipboardEnabled = useAppStore((s) => s.setLaunchPromptClipboardEnabled);
 
   const codeBlockCopyButtonPosition = useAppStore((s) => s.codeBlockCopyButtonPosition);
   const setCodeBlockCopyButtonPosition = useAppStore((s) => s.setCodeBlockCopyButtonPosition);
@@ -429,6 +432,30 @@ export function AppearanceSection() {
                 );
               })}
             </div>
+          </div>
+
+          <div>
+            <label
+              id="chat-launch-clipboard"
+              htmlFor={launchPromptClipboardToggleId}
+              style={{ display: "flex", alignItems: "center", gap: 10, cursor: "pointer" }}
+            >
+              <input
+                id={launchPromptClipboardToggleId}
+                type="checkbox"
+                checked={launchPromptClipboardEnabled}
+                onChange={(e) => setLaunchPromptClipboardEnabled(e.target.checked)}
+                style={{ accentColor: COLORS.accent, width: 14, height: 14 }}
+              />
+              <span style={{ display: "flex", flexDirection: "column" }}>
+                <span style={{ fontSize: 11, fontWeight: 600, color: COLORS.textPrimary }}>
+                  Copy launch prompts to clipboard
+                </span>
+                <span style={{ fontSize: 10, fontFamily: MONO_FONT, color: COLORS.textMuted, lineHeight: 1.5 }}>
+                  Saves chat, CLI, and agent launch prompts before ADE sends them.
+                </span>
+              </span>
+            </label>
           </div>
 
           <div>

--- a/apps/desktop/src/renderer/lib/launchPromptClipboard.ts
+++ b/apps/desktop/src/renderer/lib/launchPromptClipboard.ts
@@ -1,0 +1,21 @@
+export async function copyLaunchPromptToClipboard(promptText: string): Promise<void> {
+  const text = promptText.trim();
+  if (!text) return;
+
+  try {
+    if (typeof window !== "undefined" && window.ade?.app?.writeClipboardText) {
+      await window.ade.app.writeClipboardText(text);
+      return;
+    }
+  } catch {
+    // Fall back to the browser clipboard API below.
+  }
+
+  try {
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+    }
+  } catch {
+    // Clipboard recovery is best-effort; never block the launch.
+  }
+}

--- a/apps/desktop/src/renderer/state/appStore.test.ts
+++ b/apps/desktop/src/renderer/state/appStore.test.ts
@@ -79,6 +79,7 @@ function resetStore() {
     smartTooltipsEnabled: true,
     onboardingEnabled: true,
     didYouKnowEnabled: true,
+    launchPromptClipboardEnabled: true,
     laneInspectorTabs: {},
     workViewByProject: {},
     laneWorkViewByScope: {},
@@ -235,6 +236,18 @@ describe("appStore", () => {
       expect(JSON.parse(latest![1])).toMatchObject({ chatUserMinimapEnabled: false });
       useAppStore.getState().setChatUserMinimapEnabled(true);
       expect(useAppStore.getState().chatUserMinimapEnabled).toBe(true);
+    });
+
+    it("persists the launch prompt clipboard toggle", () => {
+      expect(useAppStore.getState().launchPromptClipboardEnabled).toBe(true);
+      useAppStore.getState().setLaunchPromptClipboardEnabled(false);
+      expect(useAppStore.getState().launchPromptClipboardEnabled).toBe(false);
+      const calls = mockLocalStorage.setItem.mock.calls.filter(
+        ([key]) => key === "ade.userPreferences.v1",
+      );
+      const latest = calls[calls.length - 1];
+      expect(latest).toBeTruthy();
+      expect(JSON.parse(latest![1])).toMatchObject({ launchPromptClipboardEnabled: false });
     });
 
     it("persists transcript density and shell geometry prefs", () => {

--- a/apps/desktop/src/renderer/state/appStore.ts
+++ b/apps/desktop/src/renderer/state/appStore.ts
@@ -430,6 +430,7 @@ type PersistedUserPreferences = {
   smartTooltipsEnabled: boolean;
   onboardingEnabled: boolean;
   didYouKnowEnabled: boolean;
+  launchPromptClipboardEnabled: boolean;
   codeBlockCopyButtonPosition: CodeBlockCopyButtonPosition;
   agentTurnCompletionSound: AgentTurnCompletionSound;
   agentTurnCompletionSoundVolume: number;
@@ -459,6 +460,7 @@ function readUnifiedUserPreferences(): PersistedUserPreferences | null {
       smartTooltipsEnabled: parsed.smartTooltipsEnabled !== false,
       onboardingEnabled: parsed.onboardingEnabled !== false,
       didYouKnowEnabled: parsed.didYouKnowEnabled !== false,
+      launchPromptClipboardEnabled: parsed.launchPromptClipboardEnabled !== false,
       codeBlockCopyButtonPosition: normalizeCodeBlockCopyButtonPosition(parsed.codeBlockCopyButtonPosition),
       agentTurnCompletionSound: normalizeAgentTurnCompletionSound(parsed.agentTurnCompletionSound),
       agentTurnCompletionSoundVolume: normalizeAgentTurnCompletionSoundVolume(parsed.agentTurnCompletionSoundVolume),
@@ -500,6 +502,7 @@ function readLegacyUserPreferences(): PersistedUserPreferences {
     smartTooltipsEnabled,
     onboardingEnabled: true,
     didYouKnowEnabled: true,
+    launchPromptClipboardEnabled: true,
     codeBlockCopyButtonPosition: "top",
     agentTurnCompletionSound: "off",
     agentTurnCompletionSoundVolume: DEFAULT_AGENT_TURN_COMPLETION_SOUND_VOLUME,
@@ -527,6 +530,7 @@ function persistUserPreferencesFrom(state: {
   smartTooltipsEnabled: boolean;
   onboardingEnabled: boolean;
   didYouKnowEnabled: boolean;
+  launchPromptClipboardEnabled: boolean;
   codeBlockCopyButtonPosition: CodeBlockCopyButtonPosition;
   agentTurnCompletionSound: AgentTurnCompletionSound;
   agentTurnCompletionSoundVolume: number;
@@ -543,6 +547,7 @@ function persistUserPreferencesFrom(state: {
     smartTooltipsEnabled: state.smartTooltipsEnabled,
     onboardingEnabled: state.onboardingEnabled,
     didYouKnowEnabled: state.didYouKnowEnabled,
+    launchPromptClipboardEnabled: state.launchPromptClipboardEnabled,
     codeBlockCopyButtonPosition: state.codeBlockCopyButtonPosition,
     agentTurnCompletionSound: state.agentTurnCompletionSound,
     agentTurnCompletionSoundVolume: state.agentTurnCompletionSoundVolume,
@@ -649,6 +654,7 @@ export type AppState = {
   smartTooltipsEnabled: boolean;
   onboardingEnabled: boolean;
   didYouKnowEnabled: boolean;
+  launchPromptClipboardEnabled: boolean;
   workViewByProject: Record<string, WorkProjectViewState>;
   laneWorkViewByScope: Record<string, WorkProjectViewState>;
   /**
@@ -721,6 +727,7 @@ export type AppState = {
   setSmartTooltipsEnabled: (enabled: boolean) => void;
   setOnboardingEnabled: (enabled: boolean) => void;
   setDidYouKnowEnabled: (enabled: boolean) => void;
+  setLaunchPromptClipboardEnabled: (enabled: boolean) => void;
   getWorkViewState: (projectRoot: string | null | undefined) => WorkProjectViewState;
   setWorkViewState: (
     projectRoot: string | null | undefined,
@@ -890,6 +897,7 @@ const createAppState: StateCreator<AppState> = (set, get) => {
   smartTooltipsEnabled: initialUserPreferences.smartTooltipsEnabled,
   onboardingEnabled: initialUserPreferences.onboardingEnabled,
   didYouKnowEnabled: initialUserPreferences.didYouKnowEnabled,
+  launchPromptClipboardEnabled: initialUserPreferences.launchPromptClipboardEnabled,
   workViewByProject: initialPersistedWorkViews.workViewByProject,
   laneWorkViewByScope: initialPersistedWorkViews.laneWorkViewByScope,
   laneSelectionByProject: {},
@@ -1113,6 +1121,11 @@ const createAppState: StateCreator<AppState> = (set, get) => {
     set((prev) => {
       persistUserPreferencesFrom({ ...prev, didYouKnowEnabled: enabled });
       return { didYouKnowEnabled: enabled };
+    }),
+  setLaunchPromptClipboardEnabled: (enabled) =>
+    set((prev) => {
+      persistUserPreferencesFrom({ ...prev, launchPromptClipboardEnabled: enabled });
+      return { launchPromptClipboardEnabled: enabled };
     }),
   openNewTab: () => set({ isNewTabOpen: true, showWelcome: true }),
   cancelNewTab: () => {
@@ -1743,6 +1756,7 @@ export function createProjectAppStore(project: ProjectInfo): AppStoreApi {
     smartTooltipsEnabled: rootState.smartTooltipsEnabled,
     onboardingEnabled: rootState.onboardingEnabled,
     didYouKnowEnabled: rootState.didYouKnowEnabled,
+    launchPromptClipboardEnabled: rootState.launchPromptClipboardEnabled,
     setTheme: rootState.setTheme,
     setTerminalPreferences: rootState.setTerminalPreferences,
     setCodeBlockCopyButtonPosition: rootState.setCodeBlockCopyButtonPosition,
@@ -1758,6 +1772,7 @@ export function createProjectAppStore(project: ProjectInfo): AppStoreApi {
     setSmartTooltipsEnabled: rootState.setSmartTooltipsEnabled,
     setOnboardingEnabled: rootState.setOnboardingEnabled,
     setDidYouKnowEnabled: rootState.setDidYouKnowEnabled,
+    setLaunchPromptClipboardEnabled: rootState.setLaunchPromptClipboardEnabled,
   });
   return store;
 }


### PR DESCRIPTION
Fixes ADE-92
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-92: Copy user-launched chat and CLI prompts to clipboard](https://linear.app/ade-linear/issue/ADE-92/copy-user-launched-chat-and-cli-prompts-to-clipboard) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-92-copy-user-launched-chat-and-cli-prompts-to-clipboard num=506 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-92-copy-user-launched-chat-and-cli-prompts-to-clipboard&amp;pr=506">ade-92-copy-user-launched-chat-and-cli-prompts-to-clipboard branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=506">PR #506</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Copy launch prompts to clipboard" toggle in Chat & notifications settings
  * Launch prompts automatically copy to clipboard when sending (when enabled)
  * Chat composer displays helper message indicating clipboard copy behavior

* **Improvements**
  * Enhanced Settings page navigation with hash-based smooth scrolling to target sections

* **Tests**
  * Added test coverage for launch prompt clipboard functionality and copyable behavior in chat workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements ADE-92, adding a user-controlled toggle to copy chat, CLI, and agent launch prompts to the system clipboard before ADE sends them. The feature spans a new `launchPromptClipboard.ts` utility, a persisted `launchPromptClipboardEnabled` preference, a settings checkbox with hash-based deep-linking, and a contextual hint bar in the chat composer.

- **New utility** (`launchPromptClipboard.ts`) writes to clipboard via the IPC bridge first, falling back to the browser Clipboard API, swallowing all errors so clipboard failures never block a launch.
- **State & UI**: the toggle is persisted in user preferences (defaulting on), propagated into per-project stores, and wired to every send path in `AgentChatPane` and `LinearQuickViewButton`.
- **Settings navigation**: `SettingsPage` is generalised to support any hash-targeted section and now clears the hash on tab change to prevent spurious re-scrolls.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the clipboard write is entirely best-effort and cannot block any send path; the feature defaults on but is easily toggled off.

All changed paths have solid test coverage, the new utility defensively catches every error, and the preference is correctly round-tripped through localStorage. The one finding is a cosmetic silent no-op on the Setting link when the callback prop is omitted, which cannot occur in the current production wiring.

No files require special attention; the most complex changes are in AgentChatPane.tsx and AgentChatComposer.tsx, both of which are well-covered by the accompanying tests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/lib/launchPromptClipboard.ts | New utility that wraps clipboard write with IPC-first, browser-fallback strategy; errors are intentionally swallowed as best-effort. |
| apps/desktop/src/renderer/state/appStore.ts | Adds launchPromptClipboardEnabled to persisted user preferences with correct read/write/default (true) handling; mirrors existing boolean preference flags. |
| apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx | Adds focus-region tracking and launch-clipboard hint bar; the Setting button silently no-ops when onOpenLaunchPromptClipboardSettings is undefined. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Wires copyPromptForLaunch at all submit call-sites; overall plumbing is correct and tests cover key paths. |
| apps/desktop/src/renderer/components/app/SettingsPage.tsx | Generalises hash-based scroll navigation and clears the hash on tab change to prevent re-scrolling. |
| apps/desktop/src/renderer/components/settings/AppearanceSection.tsx | Adds the launch-prompt clipboard toggle checkbox with the scroll-anchor id on the label element. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User types prompt & clicks Send] --> B{launchPromptClipboardEnabled?}
    B -- No --> G[Normal send flow]
    B -- Yes --> C[copyLaunchPromptToClipboard]
    C --> D{window.ade.app.writeClipboardText?}
    D -- Yes --> E[IPC clipboard write]
    D -- No --> F{navigator.clipboard.writeText?}
    F -- Yes --> H[Browser clipboard write]
    F -- No --> I[Silent no-op]
    E --> G
    H --> G
    I --> G
    G --> J{New session?}
    J -- Yes --> K[Create session + send]
    J -- No --> L[Send to existing session]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FAgentChatComposer.tsx%3A4101-4116%0A**Silent%20no-op%20%22Setting%22%20link%20when%20callback%20is%20not%20provided**%0A%0A%60onOpenLaunchPromptClipboardSettings%60%20is%20an%20optional%20prop%20that%20defaults%20to%20%60undefined%60.%20When%20%60launchPromptClipboardEnabled%60%20is%20%60true%60%20but%20the%20callback%20is%20omitted%2C%20the%20%22Setting%22%20button%20renders%20and%20is%20visually%20interactive%20%28underline%2C%20hover%20state%29%20but%20%60onClick%3D%7Bundefined%7D%60%20means%20clicking%20it%20silently%20does%20nothing.%20The%20two%20props%20should%20be%20treated%20as%20a%20logical%20pair%20%E2%80%94%20the%20helper%20bar%20should%20either%20not%20render%20the%20link%20or%20disable%20it%20when%20the%20callback%20is%20absent.%0A%0A&repo=arul28%2Fade&pr=506&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx:4101-4116
**Silent no-op "Setting" link when callback is not provided**

`onOpenLaunchPromptClipboardSettings` is an optional prop that defaults to `undefined`. When `launchPromptClipboardEnabled` is `true` but the callback is omitted, the "Setting" button renders and is visually interactive (underline, hover state) but `onClick={undefined}` means clicking it silently does nothing. The two props should be treated as a logical pair — the helper bar should either not render the link or disable it when the callback is absent.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["ADE-92 copy launch prompts to clipboard"](https://github.com/arul28/ade/commit/3c10b460704f5a24fbc7ce6ef1c28b1416254ebf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35033636)</sub>

<!-- /greptile_comment -->