### PR TITLE
Fix stuck lane delete and Codex resume recovery

### DIFF
--- a/apps/ade-cli/README.md
+++ b/apps/ade-cli/README.md
@@ -230,6 +230,7 @@ ade lanes list --text
 ade lanes create "fix-checkout-flow" --parent main
 ade lanes create "lin-123" --linear-issue-json '{"id":"...","identifier":"LIN-123","title":"...","projectId":"...","projectSlug":"...","teamId":"...","teamKey":"...","stateId":"...","stateName":"Todo","stateType":"unstarted","priority":2,"priorityLabel":"high","labels":[],"assigneeId":null,"assigneeName":null,"createdAt":"...","updatedAt":"..."}'
 ade lanes reparent lane-child --parent lane-parent --stack-base-branch main
+ade lanes delete lane-id --force --delete-branch
 ade lanes create-from-linear --issue-id ENG-431 --start-chat --provider codex --model <model>
 ade lanes batch-create-from-linear --linear-issues-json '[{"id":"...","identifier":"ENG-431"},{"id":"...","identifier":"ENG-440"}]'
 ade chat attach-linear-issue <session> --issue-id ENG-431

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -1362,6 +1362,33 @@ describe("ADE CLI", () => {
     });
   });
 
+  it("maps lane delete flags to the shared lane action", () => {
+    const plan = buildCliPlan([
+      "lanes",
+      "delete",
+      "lane-old",
+      "--force",
+      "--delete-branch",
+      "--delete-remote-branch",
+    ]);
+    expect(plan.kind).toBe("execute");
+    if (plan.kind !== "execute") throw new Error(`expected execute plan, got ${plan.kind}`);
+    expect(plan.label).toBe("lane delete");
+    expect(plan.steps[0]?.params).toEqual({
+      name: "run_ade_action",
+      arguments: {
+        domain: "lane",
+        action: "delete",
+        args: {
+          laneId: "lane-old",
+          force: true,
+          deleteBranch: true,
+          deleteRemoteBranch: true,
+        },
+      },
+    });
+  });
+
   it("forwards PR GitHub snapshot full-history flag to the runtime action", () => {
     const snapshot = buildCliPlan([
       "prs",

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -937,6 +937,7 @@ const HELP_BY_COMMAND: Record<string, string> = {
     $ ade lanes import --branch <branch>            Register an existing branch/worktree
     $ ade lanes archive <lane>                      Archive a lane in ADE
     $ ade lanes unarchive <lane>                    Restore an archived lane
+    $ ade lanes delete <lane> --force               Delete a lane and clean up its worktree
     $ ade lanes attach --path <worktree> --name <n> Attach an external worktree
     $ ade lanes reparent <lane> --parent <parent>   Move lane onto a new parent (runs git rebase)
     $ ade lanes reparent <lane> --parent <parent> --stack-base-branch <branch>

--- a/apps/ade-cli/src/tuiClient/__tests__/appInput.test.ts
+++ b/apps/ade-cli/src/tuiClient/__tests__/appInput.test.ts
@@ -1,3 +1,7 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   CLAUDE_TERMINAL_SUBMIT_CONFIRM_DELAY_MS,
@@ -21,6 +25,7 @@ import {
   isPromptLineBackspace,
   isPromptWordBackspace,
   isTerminalSessionFastPollActive,
+  isLaneWorktreeAvailable,
   isTerminalSessionWorking,
   isTerminalSessionResumable,
   shouldToggleLatestFailedLineOnBlankEnter,
@@ -307,6 +312,48 @@ describe("lane delete form helpers", () => {
     expect(formFieldUsesPromptInput("lane-delete", "force")).toBe(false);
     expect(formFieldUsesPromptInput("lane-delete", "confirm")).toBe(true);
     expect(formFieldUsesPromptInput("feedback", "body")).toBe(true);
+  });
+});
+
+describe("lane worktree availability", () => {
+  function laneAt(worktreePath: string): LaneSummary {
+    return {
+      id: "lane-1",
+      name: "Lane one",
+      laneType: "worktree",
+      baseRef: "main",
+      branchRef: "feature/lane-one",
+      worktreePath,
+      parentLaneId: null,
+      childCount: 0,
+      stackDepth: 0,
+      parentStatus: null,
+      isEditProtected: false,
+      status: { dirty: false, ahead: 0, behind: 0, remoteBehind: 0, rebaseInProgress: false },
+      color: null,
+      icon: null,
+      tags: [],
+      createdAt: "2026-05-20T00:00:00.000Z",
+    };
+  }
+
+  it("rejects an existing stale directory that resolves to another git root", () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-tui-stale-lane-"));
+    try {
+      const init = spawnSync("git", ["init"], { cwd: repoRoot, encoding: "utf8" });
+      const staleLanePath = path.join(repoRoot, ".ade", "worktrees", "stale-lane");
+      fs.mkdirSync(staleLanePath, { recursive: true });
+
+      if (init.status === 0) {
+        expect(isLaneWorktreeAvailable(laneAt(repoRoot))).toBe(true);
+      } else {
+        fs.mkdirSync(path.join(repoRoot, ".git"), { recursive: true });
+        expect(isLaneWorktreeAvailable(laneAt(repoRoot))).toBe(true);
+      }
+      expect(isLaneWorktreeAvailable(laneAt(staleLanePath))).toBe(false);
+    } finally {
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/apps/ade-cli/src/tuiClient/app.tsx
+++ b/apps/ade-cli/src/tuiClient/app.tsx
@@ -1009,14 +1009,56 @@ function formatGoalBannerLine(goal: CodexThreadGoal | null): string | null {
 import { subagentSnapshotsFromEvents } from "../../../desktop/src/shared/chatSubagents";
 export { subagentSnapshotsFromEvents };
 
-function isLaneWorktreeAvailable(lane: LaneSummary | null | undefined): boolean {
+const LANE_WORKTREE_AVAILABILITY_CACHE_TTL_MS = 2_000;
+const laneWorktreeAvailabilityCache = new Map<string, { checkedAt: number; mtimeMs: number; available: boolean }>();
+
+function cacheLaneWorktreeAvailability(root: string, stat: fs.Stats, checkedAt: number, available: boolean): boolean {
+  laneWorktreeAvailabilityCache.set(root, { checkedAt, mtimeMs: stat.mtimeMs, available });
+  return available;
+}
+
+function normalizeWorktreePath(root: string): string {
+  const resolved = path.resolve(root);
+  try {
+    return fs.realpathSync.native(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+export function isLaneWorktreeAvailable(lane: LaneSummary | null | undefined): boolean {
   const root = lane?.worktreePath?.trim();
   if (!root) return false;
+  const resolvedRoot = normalizeWorktreePath(root);
+  let stat: fs.Stats;
   try {
-    return fs.statSync(root).isDirectory();
+    stat = fs.statSync(resolvedRoot);
+    if (!stat.isDirectory()) return false;
   } catch {
     return false;
   }
+  const cached = laneWorktreeAvailabilityCache.get(resolvedRoot);
+  const now = Date.now();
+  if (cached && cached.mtimeMs === stat.mtimeMs && now - cached.checkedAt < LANE_WORKTREE_AVAILABILITY_CACHE_TTL_MS) {
+    return cached.available;
+  }
+  const markerExists = fs.existsSync(path.join(resolvedRoot, ".git"));
+  if (!markerExists) {
+    return cacheLaneWorktreeAvailability(resolvedRoot, stat, now, false);
+  }
+  const probe = spawnSync("git", ["rev-parse", "--path-format=absolute", "--show-toplevel"], {
+    cwd: resolvedRoot,
+    encoding: "utf8",
+    timeout: 8_000,
+  });
+  let available: boolean;
+  if (probe.status === 0) {
+    const topLevel = probe.stdout.trim();
+    available = topLevel ? normalizeWorktreePath(topLevel) === resolvedRoot : true;
+  } else {
+    available = false;
+  }
+  return cacheLaneWorktreeAvailability(resolvedRoot, stat, now, available);
 }
 
 function laneWorktreeUnavailableMessage(lane: LaneSummary | null | undefined): string | null {

--- a/apps/desktop/src/main/services/ai/tools/systemPrompt.test.ts
+++ b/apps/desktop/src/main/services/ai/tools/systemPrompt.test.ts
@@ -5,6 +5,8 @@ describe("buildCodingAgentSystemPrompt", () => {
   it("returns a prompt containing the cwd", () => {
     const result = buildCodingAgentSystemPrompt({ cwd: "/my/project" });
     expect(result).toContain("/my/project");
+    expect(result).toContain("Read-only inspection outside this path is allowed");
+    expect(result).toContain("mutating commands only inside this path");
   });
 
   it("defaults to coding mode and edit permission mode", () => {

--- a/apps/desktop/src/main/services/ai/tools/systemPrompt.ts
+++ b/apps/desktop/src/main/services/ai/tools/systemPrompt.ts
@@ -219,7 +219,7 @@ export function buildCodingAgentSystemPrompt(args: {
 
   return [
     `You are ADE's software engineering agent working in ${args.cwd}.`,
-    "This session is bound to that worktree. Read, edit, and run commands only inside this path unless ADE explicitly relaunches you in a different lane.",
+    "This session is bound to that worktree for writes and mutations. Read-only inspection outside this path is allowed when needed, but edit files and run mutating commands only inside this path unless ADE explicitly relaunches you in a different lane.",
     ...(orchestrationDirective ? [orchestrationDirective] : []),
     ...(runtime
       ? [

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -3200,7 +3200,8 @@ describe("createAgentChatService", () => {
       }));
       expect(firstUserContent).toContain("[ADE launch directive]");
       expect(firstUserContent).toContain(tmpRoot);
-      expect(firstUserContent).toContain("only inside that worktree");
+      expect(firstUserContent).toContain("Read-only inspection outside that worktree is allowed");
+      expect(firstUserContent).toContain("mutating commands only inside that worktree");
       expect(firstUserContent).toContain("only normal reason to skip ADE CLI");
       expect(firstUserContent).toContain("ade actions list --text");
       expect(secondUserContent).not.toContain("[ADE launch directive]");

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -3532,7 +3532,7 @@ function buildLaneWorktreeDirective(args: { laneId: string; laneWorktreePath: st
   return [
     "[ADE launch directive]",
     `ADE launched this session in lane '${laneId}' at worktree '${laneWorktreePath}'.`,
-    "Read, edit, and run commands only inside that worktree. Do not switch to project root, another lane, or another repo unless ADE explicitly relaunches you there.",
+    "Read-only inspection outside that worktree is allowed when needed. Edit files and run mutating commands only inside that worktree unless ADE explicitly relaunches you elsewhere.",
   ].join("\n");
 }
 
@@ -11928,7 +11928,7 @@ export function createAgentChatService(args: {
       "",
       "## ADE Workspace",
       `ADE launched this session in lane worktree: ${managed.laneWorktreePath}.`,
-      "Read, edit, and run commands only inside that worktree. Do not switch to project root, another lane, or another repo unless ADE explicitly relaunches you there.",
+      "Read-only inspection outside that worktree is allowed when needed. Edit files and run mutating commands only inside that worktree unless ADE explicitly relaunches you elsewhere.",
       "",
       ...slashCommandsSection,
       "",
@@ -15933,7 +15933,7 @@ export function createAgentChatService(args: {
           "",
           "## ADE Workspace",
           `ADE launched this session in lane worktree: ${managed.laneWorktreePath}.`,
-          "Read, edit, and run commands only inside that worktree. Do not switch to project root, another lane, or another repo unless ADE explicitly relaunches you there.",
+          "Read-only inspection outside that worktree is allowed when needed. Edit files and run mutating commands only inside that worktree unless ADE explicitly relaunches you elsewhere.",
           "",
           ...(linearDirective ? [linearDirective, ""] : []),
           ...slashCommandsSection,

--- a/apps/desktop/src/main/services/git/gitOperationsService.test.ts
+++ b/apps/desktop/src/main/services/git/gitOperationsService.test.ts
@@ -223,6 +223,9 @@ describe("gitOperationsService.getSyncStatus", () => {
 
   it("marks a configured upstream as missing when the remote branch was deleted", async () => {
     mockGit.runGit.mockImplementation(async (args: string[]) => {
+      if (args[0] === "rev-parse" && args[1] === "--path-format=absolute" && args[2] === "--show-toplevel") {
+        return { exitCode: 0, stdout: "/tmp/ade-lane\n", stderr: "" };
+      }
       if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
         return { exitCode: 128, stdout: "", stderr: "upstream gone" };
       }
@@ -985,11 +988,65 @@ describe("gitOperationsService.generateCommitMessage", () => {
     vi.clearAllMocks();
   });
 
+  it("does not read main diffs when a stale lane path resolves to the main worktree", async () => {
+    const generateCommitMessage = vi.fn();
+    mockGit.runGit.mockImplementation(async (args: string[]) => {
+      if (args[0] === "rev-parse" && args[1] === "--path-format=absolute" && args[2] === "--show-toplevel") {
+        return { exitCode: 0, stdout: "/tmp/main\n", stderr: "" };
+      }
+      return { exitCode: 1, stdout: "", stderr: `unexpected git command: ${args.join(" ")}` };
+    });
+
+    const service = createGitOperationsService({
+      laneService: {
+        getLaneBaseAndBranch: () => ({
+          baseRef: "main",
+          branchRef: "feature/stale",
+          worktreePath: "/tmp/main/.ade/worktrees/feature-stale-12345678",
+          laneType: "worktree",
+        }),
+      } as any,
+      operationService: {
+        start: vi.fn(),
+        finish: vi.fn(),
+      } as any,
+      projectConfigService: {
+        get: () => ({
+          effective: {
+            ai: {
+              featureModelOverrides: {
+                commit_messages: "anthropic/claude-haiku-4-5",
+              },
+            },
+          },
+        }),
+      } as any,
+      aiIntegrationService: {
+        getFeatureFlag: () => true,
+        getStatus: vi.fn(async () => ({
+          availableModelIds: ["anthropic/claude-haiku-4-5"],
+        })),
+        generateCommitMessage,
+      } as any,
+      logger: makeStubLogger(),
+    });
+
+    await expect(service.generateCommitMessage({ laneId: "lane-1" })).rejects.toThrow(
+      "Lane worktree is missing. Restore or recreate the lane worktree at /tmp/main/.ade/worktrees/feature-stale-12345678 before viewing history.",
+    );
+
+    expect(mockGit.runGit).toHaveBeenCalledTimes(1);
+    expect(generateCommitMessage).not.toHaveBeenCalled();
+  });
+
   it("uses the configured model and sends a lightweight changed-files prompt", async () => {
     let capturedPrompt = "";
     let capturedModel = "";
 
     mockGit.runGit.mockImplementation(async (args: string[]) => {
+      if (args[0] === "rev-parse" && args[1] === "--path-format=absolute" && args[2] === "--show-toplevel") {
+        return { exitCode: 0, stdout: "/tmp/ade-lane\n", stderr: "" };
+      }
       if (args[0] === "diff") {
         return {
           exitCode: 0,
@@ -1079,6 +1136,7 @@ describe("gitOperationsService.generateCommitMessage", () => {
     expect(capturedPrompt).not.toContain("Branch:");
     expect(capturedPrompt).toContain("Diff:");
     expect(mockGit.runGit.mock.calls.map((call) => call[0])).toEqual([
+      ["rev-parse", "--path-format=absolute", "--show-toplevel"],
       ["diff", "--cached", "--name-status", "--find-renames"],
       ["show", "--name-status", "--format=", "--find-renames", "HEAD"],
       ["diff", "--cached", "--no-color", "-U2", "--find-renames"],
@@ -1087,6 +1145,9 @@ describe("gitOperationsService.generateCommitMessage", () => {
 
   it("prefixes generated commit messages with a Linear reference for linked lanes", async () => {
     mockGit.runGit.mockImplementation(async (args: string[]) => {
+      if (args[0] === "rev-parse" && args[1] === "--path-format=absolute" && args[2] === "--show-toplevel") {
+        return { exitCode: 0, stdout: "/tmp/ade-lane\n", stderr: "" };
+      }
       if (args[0] === "diff") {
         return {
           exitCode: 0,
@@ -1190,6 +1251,9 @@ describe("gitOperationsService cached lane reads", () => {
     });
 
     mockGit.runGit.mockImplementation(async (args: string[]) => {
+      if (args[0] === "rev-parse" && args[1] === "--path-format=absolute" && args[2] === "--show-toplevel") {
+        return { exitCode: 0, stdout: "/tmp/ade-lane\n", stderr: "" };
+      }
       if (args[0] === "rev-parse") {
         await upstreamLookupGate;
         return { exitCode: 0, stdout: "origin/main\n", stderr: "" };
@@ -1214,14 +1278,19 @@ describe("gitOperationsService cached lane reads", () => {
     const [firstResult, secondResult] = await Promise.all([first, second]);
 
     expect(firstResult).toEqual(secondResult);
-    expect(mockGit.runGit).toHaveBeenCalledTimes(2);
+    expect(mockGit.runGit).toHaveBeenCalledTimes(3);
     expect(mockGit.runGit).toHaveBeenNthCalledWith(
       1,
-      ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+      ["rev-parse", "--path-format=absolute", "--show-toplevel"],
       expect.objectContaining({ cwd: "/tmp/ade-lane" }),
     );
     expect(mockGit.runGit).toHaveBeenNthCalledWith(
       2,
+      ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+      expect.objectContaining({ cwd: "/tmp/ade-lane" }),
+    );
+    expect(mockGit.runGit).toHaveBeenNthCalledWith(
+      3,
       ["rev-list", "--left-right", "--count", "origin/main...HEAD"],
       expect.objectContaining({ cwd: "/tmp/ade-lane" }),
     );

--- a/apps/desktop/src/main/services/git/gitOperationsService.test.ts
+++ b/apps/desktop/src/main/services/git/gitOperationsService.test.ts
@@ -1,10 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockGit = vi.hoisted(() => ({
   runGit: vi.fn(),
   runGitOrThrow: vi.fn(),
   getHeadSha: vi.fn(),
 }));
+
+afterEach(() => {
+  mockGit.runGit.mockReset();
+  mockGit.runGitOrThrow.mockReset();
+  mockGit.getHeadSha.mockReset();
+});
 
 vi.mock("./git", () => ({
   runGit: (...args: unknown[]) => mockGit.runGit(...args),
@@ -69,6 +75,36 @@ function createTestGitOperationsService(
     mockLogger,
   };
 }
+
+describe("gitOperationsService lane worktree guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mockGit.runGit.mockReset();
+  });
+
+  it("rejects mutating actions when a stale lane path resolves to the main worktree", async () => {
+    mockGit.runGit.mockImplementation(async (args: string[]) => {
+      if (args[0] === "rev-parse" && args[1] === "--path-format=absolute" && args[2] === "--show-toplevel") {
+        return { exitCode: 0, stdout: "/tmp/main\n", stderr: "" };
+      }
+      return { exitCode: 1, stdout: "", stderr: `unexpected git command: ${args.join(" ")}` };
+    });
+    const { service, mockStart } = createTestGitOperationsService("feature/stale", {
+      worktreePath: "/tmp/main/.ade/worktrees/feature-stale-12345678",
+    });
+
+    await expect(service.stageAll({ laneId: "lane-1", paths: [".ade/cto/identity.yaml"] })).rejects.toThrow(
+      "Lane worktree is missing. Restore or recreate the lane worktree at /tmp/main/.ade/worktrees/feature-stale-12345678 before viewing history.",
+    );
+
+    expect(mockGit.getHeadSha).not.toHaveBeenCalled();
+    expect(mockGit.runGitOrThrow).not.toHaveBeenCalled();
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+});
 
 describe("gitOperationsService.stashClear", () => {
   beforeEach(() => {
@@ -1195,10 +1231,11 @@ describe("gitOperationsService cached lane reads", () => {
     mockGit.runGitOrThrow.mockResolvedValue(
       "abc123\u001fab\u001fparent123\u001fArul\u001f2026-04-11T21:00:00.000Z\u001fInitial commit",
     );
-    mockGit.runGit.mockResolvedValue({
-      exitCode: 1,
-      stdout: "",
-      stderr: "no upstream",
+    mockGit.runGit.mockImplementation(async (args: string[]) => {
+      if (args[0] === "rev-parse" && args[1] === "--path-format=absolute" && args[2] === "--show-toplevel") {
+        return { exitCode: 0, stdout: "/tmp/ade-lane\n", stderr: "" };
+      }
+      return { exitCode: 1, stdout: "", stderr: "no upstream" };
     });
 
     const { service } = createTestGitOperationsService();
@@ -1208,11 +1245,13 @@ describe("gitOperationsService cached lane reads", () => {
 
     expect(first).toEqual(second);
     expect(mockGit.runGitOrThrow).toHaveBeenCalledTimes(1);
-    expect(mockGit.runGit).toHaveBeenCalledTimes(1);
+    expect(mockGit.runGit).toHaveBeenCalledTimes(2);
   });
 
   it("checks whether a commit is reachable from the lane head", async () => {
-    mockGit.runGit.mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
+    mockGit.runGit
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "/tmp/ade-lane\n", stderr: "" })
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "", stderr: "" });
     const { service } = createTestGitOperationsService();
 
     await expect(
@@ -1226,7 +1265,9 @@ describe("gitOperationsService cached lane reads", () => {
   });
 
   it("reports commits outside the lane head history as not reachable", async () => {
-    mockGit.runGit.mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "" });
+    mockGit.runGit
+      .mockResolvedValueOnce({ exitCode: 0, stdout: "/tmp/ade-lane\n", stderr: "" })
+      .mockResolvedValueOnce({ exitCode: 1, stdout: "", stderr: "" });
     const { service } = createTestGitOperationsService();
 
     await expect(
@@ -1246,7 +1287,28 @@ describe("gitOperationsService cached lane reads", () => {
     await expect(service.listRecentCommits({ laneId: "lane-1", limit: 20 })).rejects.toThrow(
       "Lane worktree is missing. Restore or recreate the lane worktree at /tmp/missing-lane before viewing history.",
     );
-    expect(mockGit.runGit).not.toHaveBeenCalled();
+    expect(mockGit.runGit).toHaveBeenCalledWith(
+      ["rev-parse", "--path-format=absolute", "--show-toplevel"],
+      { cwd: "/tmp/missing-lane", timeoutMs: 8_000 },
+    );
+  });
+
+  it("does not read main history when a stale lane path resolves to the main worktree", async () => {
+    mockGit.runGit.mockImplementation(async (args: string[]) => {
+      if (args[0] === "rev-parse" && args[1] === "--path-format=absolute" && args[2] === "--show-toplevel") {
+        return { exitCode: 0, stdout: "/tmp/main\n", stderr: "" };
+      }
+      return { exitCode: 1, stdout: "", stderr: `unexpected git command: ${args.join(" ")}` };
+    });
+
+    const { service } = createTestGitOperationsService("feature/stale", {
+      worktreePath: "/tmp/main/.ade/worktrees/feature-stale-12345678",
+    });
+
+    await expect(service.listRecentCommits({ laneId: "lane-1", limit: 20 })).rejects.toThrow(
+      "Lane worktree is missing. Restore or recreate the lane worktree at /tmp/main/.ade/worktrees/feature-stale-12345678 before viewing history.",
+    );
+    expect(mockGit.runGitOrThrow).not.toHaveBeenCalled();
   });
 
   it("parses file history entries for modified and renamed files", async () => {

--- a/apps/desktop/src/main/services/git/gitOperationsService.ts
+++ b/apps/desktop/src/main/services/git/gitOperationsService.ts
@@ -433,7 +433,7 @@ export function createGitOperationsService({
 
   function isMissingWorktreeError(error: unknown): boolean {
     const message = error instanceof Error ? error.message : String(error);
-    return /git working directory not found:/i.test(message);
+    return /git working directory not found:|Lane worktree is missing\./i.test(message);
   }
 
   function laneWorktreeMissingError(lane: LaneInfo): Error {
@@ -457,8 +457,7 @@ export function createGitOperationsService({
         throw laneWorktreeMissingError(lane);
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      if (message.includes("Lane worktree is missing.")) throw error;
+      if (isMissingWorktreeError(error)) throw error;
       throw laneWorktreeMissingError(lane);
     }
   }
@@ -786,6 +785,7 @@ export function createGitOperationsService({
     async generateCommitMessage(args: GitGenerateCommitMessageArgs): Promise<GitGenerateCommitMessageResult> {
       const model = await assertCommitMessageGenerationEnabled();
       const lane = laneService.getLaneBaseAndBranch(args.laneId);
+      await assertLaneWorktreeRoot(lane);
       const promptContext = await loadCommitMessagePromptContext(lane);
       if (!promptContext.hasStagedChanges && !args.amend) {
         throw new Error("Stage changes before generating a commit message.");
@@ -1042,6 +1042,7 @@ export function createGitOperationsService({
       const laneId = args.laneId.trim();
       return readLaneCached(`sync-status:${laneId}:default`, 2_000, async () => {
         const lane = laneService.getLaneBaseAndBranch(laneId);
+        await assertLaneWorktreeRoot(lane);
         const readConfiguredUpstream = async (): Promise<string | null> => {
           const branchName = localBranchNameForConfig(lane.branchRef);
           if (!branchName) return null;
@@ -1150,6 +1151,7 @@ export function createGitOperationsService({
 
     async listCommitFiles(args: GitListCommitFilesArgs): Promise<string[]> {
       const lane = laneService.getLaneBaseAndBranch(args.laneId);
+      await assertLaneWorktreeRoot(lane);
       const sha = args.commitSha.trim();
       if (!sha.length) throw new Error("commitSha is required");
       const res = await runGitOrThrow(["show", "--pretty=format:", "--name-only", sha], {
@@ -1164,6 +1166,7 @@ export function createGitOperationsService({
 
     async getCommitMessage(args: GitGetCommitMessageArgs): Promise<string> {
       const lane = laneService.getLaneBaseAndBranch(args.laneId);
+      await assertLaneWorktreeRoot(lane);
       const sha = args.commitSha.trim();
       if (!sha.length) throw new Error("commitSha is required");
       const res = await runGitOrThrow(["show", "-s", "--format=%B", sha], {
@@ -1277,6 +1280,7 @@ export function createGitOperationsService({
       const laneId = args.laneId.trim();
       return readLaneCached(`stashes:${laneId}:default`, 1_500, async () => {
         const lane = laneService.getLaneBaseAndBranch(laneId);
+        await assertLaneWorktreeRoot(lane);
         return (await listBranchStashes(lane)).map(toPublicStash);
       });
     },
@@ -1511,6 +1515,7 @@ export function createGitOperationsService({
       if (!laneId) throw new Error("laneId is required");
       return readLaneCached(`conflict-state:${laneId}:default`, 1_500, async () => {
         const lane = laneService.getLaneBaseAndBranch(laneId);
+        await assertLaneWorktreeRoot(lane);
         const gitDir = await getAbsoluteGitDir(lane.worktreePath);
         const kind = gitDir ? detectConflictKind(gitDir) : null;
 
@@ -1588,6 +1593,7 @@ export function createGitOperationsService({
 
     async listBranches(args: { laneId: string }): Promise<GitBranchSummary[]> {
       const lane = laneService.getLaneBaseAndBranch(args.laneId);
+      await assertLaneWorktreeRoot(lane);
       // Subject goes last so a tab inside a commit subject doesn't desync the
       // parser — anything after index 7 is rejoined.
       const FORMAT = [
@@ -1687,6 +1693,7 @@ export function createGitOperationsService({
 
     async getUserIdentity(args: { laneId: string }): Promise<GitUserIdentity> {
       const lane = laneService.getLaneBaseAndBranch(args.laneId);
+      await assertLaneWorktreeRoot(lane);
       const readConfig = async (key: string): Promise<string> => {
         const result = await runGit(["config", "--get", key], {
           cwd: lane.worktreePath,
@@ -1703,6 +1710,7 @@ export function createGitOperationsService({
       const laneId = args.laneId.trim();
       if (!laneId) return fallback;
       const lane = laneService.getLaneBaseAndBranch(laneId);
+      await assertLaneWorktreeRoot(lane);
       const [remoteRes, branchRes] = await Promise.all([
         runGit(["remote", "get-url", "origin"], { cwd: lane.worktreePath, timeoutMs: 8_000 }).catch(() => null),
         lane.branchRef?.trim()
@@ -1737,6 +1745,7 @@ export function createGitOperationsService({
       const laneId = args.laneId.trim();
       if (!laneId) return fallback;
       const lane = laneService.getLaneBaseAndBranch(laneId);
+      await assertLaneWorktreeRoot(lane);
       const branch = args.branch?.trim() || lane.branchRef?.trim() || "";
       if (!branch) return fallback;
 

--- a/apps/desktop/src/main/services/git/gitOperationsService.ts
+++ b/apps/desktop/src/main/services/git/gitOperationsService.ts
@@ -64,6 +64,10 @@ type CommitMessagePromptContext = {
   diffSnippet: string;
 };
 
+function normAbs(p: string): string {
+  return path.resolve(p);
+}
+
 type CachedReadEntry<T> = {
   expiresAt: number;
   value?: T;
@@ -438,6 +442,27 @@ export function createGitOperationsService({
     );
   }
 
+  async function assertLaneWorktreeRoot(lane: LaneInfo): Promise<void> {
+    try {
+      const topLevelRes = await runGit(
+        ["rev-parse", "--path-format=absolute", "--show-toplevel"],
+        { cwd: lane.worktreePath, timeoutMs: 8_000 },
+      );
+      if (!topLevelRes || typeof topLevelRes.exitCode !== "number") return;
+      if (topLevelRes.exitCode !== 0) {
+        throw laneWorktreeMissingError(lane);
+      }
+      const topLevel = topLevelRes.stdout.trim();
+      if (topLevel && normAbs(topLevel) !== normAbs(lane.worktreePath)) {
+        throw laneWorktreeMissingError(lane);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes("Lane worktree is missing.")) throw error;
+      throw laneWorktreeMissingError(lane);
+    }
+  }
+
   const runLaneOperation = async <T>({
     laneId,
     kind,
@@ -453,6 +478,7 @@ export function createGitOperationsService({
   }): Promise<{ result: T; action: GitActionResult }> => {
     invalidateLaneReadCache(laneId);
     const lane = laneService.getLaneBaseAndBranch(laneId);
+    await assertLaneWorktreeRoot(lane);
     const preHeadSha = await getHeadSha(lane.worktreePath);
     const operation = operationService.start({
       laneId,
@@ -787,6 +813,7 @@ export function createGitOperationsService({
       const limit = typeof args.limit === "number" ? Math.max(1, Math.min(500, Math.floor(args.limit))) : 30;
       return readLaneCached(`recent-commits:${laneId}:${limit}`, 2_000, async () => {
         const lane = laneService.getLaneBaseAndBranch(laneId);
+        await assertLaneWorktreeRoot(lane);
         let out: string;
         try {
           out = await runGitOrThrow(
@@ -851,6 +878,7 @@ export function createGitOperationsService({
       const commitSha = normalizeCommitShaArg(args.commitSha);
       return readLaneCached(`commit:${laneId}:${commitSha}`, 2_000, async () => {
         const lane = laneService.getLaneBaseAndBranch(laneId);
+        await assertLaneWorktreeRoot(lane);
         let out: string;
         try {
           out = await runGitOrThrow(
@@ -911,6 +939,7 @@ export function createGitOperationsService({
       const commitSha = normalizeCommitShaArg(args.commitSha);
       return readLaneCached(`commit-in-lane-history:${laneId}:${commitSha}`, 2_000, async () => {
         const lane = laneService.getLaneBaseAndBranch(laneId);
+        await assertLaneWorktreeRoot(lane);
         const result = await runGit(
           ["merge-base", "--is-ancestor", commitSha, "HEAD"],
           { cwd: lane.worktreePath, timeoutMs: 10_000 },
@@ -930,6 +959,7 @@ export function createGitOperationsService({
       const limit = typeof args.limit === "number" ? Math.max(1, Math.min(100, Math.floor(args.limit))) : 20;
       return readLaneCached(`file-history:${laneId}:${relPath}:${limit}`, 2_000, async () => {
         const lane = laneService.getLaneBaseAndBranch(laneId);
+        await assertLaneWorktreeRoot(lane);
         const out = await runGitOrThrow(
           [
             "log",

--- a/apps/desktop/src/main/services/lanes/laneService.test.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.test.ts
@@ -2768,6 +2768,53 @@ describe("laneService updateAppearance color uniqueness", () => {
   });
 });
 
+describe("laneService stale worktree status", () => {
+  beforeEach(() => {
+    vi.mocked(getHeadSha).mockReset();
+    vi.mocked(runGit).mockReset();
+    vi.mocked(runGitOrThrow).mockReset();
+  });
+
+  it("does not report main checkout status for a stale lane directory inside the repo", async () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-lane-stale-status-"));
+    const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
+    await seedProjectAndStack(db, { projectId: "proj-stale-status", repoRoot });
+    const childPath = path.join(repoRoot, "child");
+    fs.mkdirSync(childPath, { recursive: true });
+
+    vi.mocked(runGit).mockImplementation(async (args: string[], opts?: { cwd?: string }) => {
+      if (args[0] === "rev-parse" && args[1] === "--path-format=absolute" && args[2] === "--show-toplevel") {
+        expect(opts?.cwd).toBe(childPath);
+        return { exitCode: 0, stdout: `${repoRoot}\n`, stderr: "" } as any;
+      }
+      if (args[0] === "status") return { exitCode: 0, stdout: " M main-only-file\n", stderr: "" } as any;
+      if (args[0] === "rev-list") return { exitCode: 0, stdout: "0\t5\n", stderr: "" } as any;
+      return { exitCode: 1, stdout: "", stderr: "" } as any;
+    });
+
+    const service = createLaneService({
+      db,
+      projectRoot: repoRoot,
+      projectId: "proj-stale-status",
+      defaultBaseRef: "main",
+      worktreesDir: path.join(repoRoot, "worktrees"),
+    });
+
+    const lanes = await service.list({ includeStatus: true });
+    const child = lanes.find((lane) => lane.id === "lane-child");
+    expect(child?.status).toEqual({
+      dirty: false,
+      ahead: 0,
+      behind: 0,
+      remoteBehind: -1,
+      rebaseInProgress: false,
+    });
+    expect(vi.mocked(runGit).mock.calls.some(([args, opts]) =>
+      args[0] === "status" && (opts as { cwd?: string } | undefined)?.cwd === childPath
+    )).toBe(false);
+  });
+});
+
 describe("laneService delete teardown + cancellation + streaming", () => {
   beforeEach(() => {
     vi.mocked(getHeadSha).mockReset();
@@ -2915,7 +2962,7 @@ describe("laneService delete teardown + cancellation + streaming", () => {
 
     expect(fs.existsSync(childPath)).toBe(false);
     expect(db.get<{ id: string }>("select id from lanes where id = ?", ["lane-child"])).toBeNull();
-    expect(vi.mocked(runGitOrThrow).mock.calls.some(([args]) => args[0] === "worktree" && args[1] === "prune")).toBe(true);
+    expect(vi.mocked(runGit).mock.calls.some(([args]) => args[0] === "worktree" && args[1] === "prune")).toBe(true);
     const last = events[events.length - 1];
     expect(last.progress.steps.find((s: any) => s.name === "git_worktree_remove")?.detail).toContain("removed residual files");
   });
@@ -2954,6 +3001,62 @@ describe("laneService delete teardown + cancellation + streaming", () => {
     const last = events[events.length - 1];
     expect(last.progress.overallStatus).toBe("completed");
     expect(last.progress.steps.find((s: any) => s.name === "git_worktree_remove")?.detail).toContain("recovered from stale state");
+  });
+
+  it("deletes the lane row with a warning when only unregistered residual files remain", async () => {
+    const events: any[] = [];
+    const fake = makeFakeServices();
+    const { service, db, repoRoot } = await setupWithLane({ teardown: fake, events });
+    const childPath = path.join(repoRoot, "child");
+    fs.writeFileSync(path.join(childPath, "residual.log"), "left behind by git\n", "utf8");
+    const realRm = fs.promises.rm.bind(fs.promises);
+    const rmSpy = vi.spyOn(fs.promises, "rm").mockImplementation(async (target: fs.PathLike, options?: Parameters<typeof fs.promises.rm>[1]) => {
+      if (path.resolve(String(target)) === childPath) {
+        const error = new Error(`ENOTEMPTY: directory not empty, rmdir '${childPath}'`) as NodeJS.ErrnoException;
+        error.code = "ENOTEMPTY";
+        throw error;
+      }
+      return realRm(target, options);
+    });
+
+    vi.mocked(runGit).mockImplementation(async (args: string[], opts?: { cwd?: string }) => {
+      const laneBranchGitStub = defaultLaneBranchGitStub(args);
+      if (laneBranchGitStub) return laneBranchGitStub;
+      if (args[0] === "rev-parse" && args[1] === "--path-format=absolute" && args[2] === "--show-toplevel") {
+        return { exitCode: 0, stdout: `${repoRoot}\n`, stderr: "" } as any;
+      }
+      if (args[0] === "worktree" && args[1] === "remove") {
+        expect(opts?.cwd).toBe(repoRoot);
+        return {
+          exitCode: 128,
+          stdout: "",
+          stderr: `fatal: '${childPath}' is not a working tree`,
+        } as any;
+      }
+      if (args[0] === "worktree" && args[1] === "prune") {
+        return { exitCode: 0, stdout: "", stderr: "" } as any;
+      }
+      if (args[0] === "show-ref") return { exitCode: 1, stdout: "", stderr: "" } as any;
+      return { exitCode: 0, stdout: "", stderr: "" } as any;
+    });
+    vi.mocked(runGitOrThrow).mockImplementation(async (args: string[]) => {
+      if (args[0] === "worktree" && args[1] === "list") return "";
+      return "";
+    });
+
+    try {
+      await service.delete({ laneId: "lane-child", deleteBranch: false, force: true });
+    } finally {
+      rmSpy.mockRestore();
+    }
+
+    expect(db.get<{ id: string }>("select id from lanes where id = ?", ["lane-child"])).toBeNull();
+    expect(fs.existsSync(childPath)).toBe(true);
+    const last = events[events.length - 1];
+    expect(last.progress.overallStatus).toBe("completed_with_warnings");
+    const wtStep = last.progress.steps.find((s: any) => s.name === "git_worktree_remove");
+    expect(wtStep?.status).toBe("completed");
+    expect(wtStep?.detail).toContain("manual cleanup failed");
   });
 
   it("keeps recent delete progress queryable for remounted renderers", async () => {

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -257,6 +257,8 @@ function normAbs(p: string): string {
   return path.resolve(p);
 }
 
+const STALE_WORKTREE_ROOT_MESSAGE = "Lane worktree is missing or no longer points at its Git worktree root.";
+
 async function isExpectedGitWorktreeRoot(worktreePath: string): Promise<boolean> {
   if (!worktreePath) return false;
   try {
@@ -275,6 +277,12 @@ async function isExpectedGitWorktreeRoot(worktreePath: string): Promise<boolean>
     // returns a GitRunResult for normal git failures, so keep those tests on
     // their existing path without weakening production validation.
     return /^Unexpected git call:/i.test(message);
+  }
+}
+
+async function assertExpectedGitWorktreeRoot(worktreePath: string): Promise<void> {
+  if (!(await isExpectedGitWorktreeRoot(worktreePath))) {
+    throw new Error(STALE_WORKTREE_ROOT_MESSAGE);
   }
 }
 
@@ -802,9 +810,7 @@ type WorktreeChangeState = {
 };
 
 async function inspectWorktreeChanges(worktreePath: string): Promise<WorktreeChangeState> {
-  if (!(await isExpectedGitWorktreeRoot(worktreePath))) {
-    throw new Error("Lane worktree is missing or no longer points at its Git worktree root.");
-  }
+  await assertExpectedGitWorktreeRoot(worktreePath);
 
   const statusRes = await runGit(["status", "--porcelain=v1"], { cwd: worktreePath, timeoutMs: 8_000 });
   if (statusRes.exitCode !== 0) {
@@ -835,9 +841,7 @@ type GitStashEntry = {
 };
 
 async function listGitStashes(worktreePath: string): Promise<GitStashEntry[]> {
-  if (!(await isExpectedGitWorktreeRoot(worktreePath))) {
-    throw new Error("Lane worktree is missing or no longer points at its Git worktree root.");
-  }
+  await assertExpectedGitWorktreeRoot(worktreePath);
 
   const stashRes = await runGit(["stash", "list", "--format=%gd%x1f%gs"], {
     cwd: worktreePath,

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -257,6 +257,27 @@ function normAbs(p: string): string {
   return path.resolve(p);
 }
 
+async function isExpectedGitWorktreeRoot(worktreePath: string): Promise<boolean> {
+  if (!worktreePath) return false;
+  try {
+    const topLevelRes = await runGit(
+      ["rev-parse", "--path-format=absolute", "--show-toplevel"],
+      { cwd: worktreePath, timeoutMs: 8_000 },
+    );
+    if (!topLevelRes || typeof topLevelRes.exitCode !== "number") return true;
+    if (topLevelRes.exitCode !== 0) return false;
+    const topLevel = topLevelRes.stdout.trim();
+    if (!topLevel) return true;
+    return normAbs(topLevel) === normAbs(worktreePath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // Test mocks can throw for unhandled git probes. The real runGit helper
+    // returns a GitRunResult for normal git failures, so keep those tests on
+    // their existing path without weakening production validation.
+    return /^Unexpected git call:/i.test(message);
+  }
+}
+
 type GitWorktreeInfo = UnregisteredLaneCandidate & {
   isBare: boolean;
 };
@@ -500,6 +521,7 @@ function toLaneSummary(args: {
 }
 
 async function detectBranchRef(worktreePath: string, fallback: string): Promise<string> {
+  if (!(await isExpectedGitWorktreeRoot(worktreePath))) return fallback;
   const branchRes = await runGit(["rev-parse", "--abbrev-ref", "HEAD"], { cwd: worktreePath, timeoutMs: 8_000 });
   if (branchRes.exitCode === 0) {
     const value = branchRes.stdout.trim();
@@ -509,6 +531,10 @@ async function detectBranchRef(worktreePath: string, fallback: string): Promise<
 }
 
 async function computeLaneStatus(worktreePath: string, baseRef: string, branchRef: string): Promise<LaneStatus> {
+  if (!(await isExpectedGitWorktreeRoot(worktreePath))) {
+    return cloneLaneStatus(DEFAULT_LANE_STATUS);
+  }
+
   const dirtyRes = await runGit(["status", "--porcelain=v1"], { cwd: worktreePath, timeoutMs: 8_000 });
   const dirty = dirtyRes.exitCode === 0 && dirtyRes.stdout.trim().length > 0;
 
@@ -776,6 +802,10 @@ type WorktreeChangeState = {
 };
 
 async function inspectWorktreeChanges(worktreePath: string): Promise<WorktreeChangeState> {
+  if (!(await isExpectedGitWorktreeRoot(worktreePath))) {
+    throw new Error("Lane worktree is missing or no longer points at its Git worktree root.");
+  }
+
   const statusRes = await runGit(["status", "--porcelain=v1"], { cwd: worktreePath, timeoutMs: 8_000 });
   if (statusRes.exitCode !== 0) {
     throw new Error("Unable to inspect lane worktree state.");
@@ -805,6 +835,10 @@ type GitStashEntry = {
 };
 
 async function listGitStashes(worktreePath: string): Promise<GitStashEntry[]> {
+  if (!(await isExpectedGitWorktreeRoot(worktreePath))) {
+    throw new Error("Lane worktree is missing or no longer points at its Git worktree root.");
+  }
+
   const stashRes = await runGit(["stash", "list", "--format=%gd%x1f%gs"], {
     cwd: worktreePath,
     timeoutMs: 15_000,
@@ -4612,6 +4646,10 @@ export function createLaneService({
         progress.steps.find((s) => s.name === name);
 
       const nonFatalFailures: Array<{ step: LaneDeleteStepName; message: string }> = [];
+      const recordNonFatalFailure = (step: LaneDeleteStepName, message: string): void => {
+        nonFatalFailures.push({ step, message });
+        logger.warn("lane.delete.non_fatal_step_failed", { laneId, step, error: message });
+      };
 
       const runStep = async (
         name: LaneDeleteStepName,
@@ -4637,8 +4675,7 @@ export function createLaneService({
           step.completedAt = new Date().toISOString();
           step.durationMs = Date.now() - t0;
           if (!fatal) {
-            nonFatalFailures.push({ step: name, message: errorMessage });
-            logger.warn("lane.delete.non_fatal_step_failed", { laneId, step: name, error: errorMessage });
+            recordNonFatalFailure(name, errorMessage);
           }
           broadcastDeleteEvent(progress);
           if (fatal) throw error;
@@ -4669,6 +4706,9 @@ export function createLaneService({
       try {
         if (hasWorktree) {
           await runStep("git_status", async () => {
+            if (!(await isExpectedGitWorktreeRoot(row.worktree_path))) {
+              return { detail: fs.existsSync(row.worktree_path) ? "stale worktree directory" : "missing worktree directory" };
+            }
             const dirtyRes = await runGit(["status", "--porcelain=v1"], { cwd: row.worktree_path, timeoutMs: 8_000 });
             const dirty = dirtyRes.exitCode === 0 && dirtyRes.stdout.trim().length > 0;
             if (dirty && !force) {
@@ -4748,17 +4788,46 @@ export function createLaneService({
               const removeArgs = ["worktree", "remove"];
               if (force) removeArgs.push("--force");
               removeArgs.push(row.worktree_path);
+              const isStillRegisteredWorktree = async (): Promise<boolean> => {
+                try {
+                  const worktrees = await listGitWorktrees();
+                  const target = normAbs(row.worktree_path);
+                  return worktrees.some((wt) => wt.path === target);
+                } catch {
+                  return fs.existsSync(worktreeMetadataPath);
+                }
+              };
+              const pruneWorktreesBestEffort = async (): Promise<string | null> => {
+                const pruneRes = await runGit(["worktree", "prune"], { cwd: projectRoot, timeoutMs: 30_000 });
+                if (pruneRes.exitCode === 0) return null;
+                return (pruneRes.stderr || pruneRes.stdout || "git worktree prune failed").trim();
+              };
               const removeResidualDirectory = async (detail: string, failurePrefix?: string) => {
                 try {
                   await removeWorktreeDirectoryWithRecovery(row.worktree_path);
                 } catch (rmError) {
-                  throw new Error(
-                    `${failurePrefix ? `${failurePrefix}; ` : ""}manual cleanup failed: ${
-                      rmError instanceof Error ? rmError.message : String(rmError)
-                    }`
-                  );
+                  const cleanupMessage = `${failurePrefix ? `${failurePrefix}; ` : ""}manual cleanup failed: ${
+                    rmError instanceof Error ? rmError.message : String(rmError)
+                  }`;
+                  const pruneFailure = await pruneWorktreesBestEffort();
+                  const fullMessage = pruneFailure
+                    ? `${cleanupMessage}; git worktree prune failed: ${pruneFailure}`
+                    : cleanupMessage;
+                  if (await isStillRegisteredWorktree()) {
+                    throw new Error(fullMessage);
+                  }
+                  recordNonFatalFailure("git_worktree_remove", fullMessage);
+                  return { detail: `${detail}; warning: ${fullMessage}` };
                 }
-                await runGitOrThrow(["worktree", "prune"], { cwd: projectRoot, timeoutMs: 30_000 });
+                const pruneFailure = await pruneWorktreesBestEffort();
+                if (pruneFailure) {
+                  const message = `git worktree prune failed: ${pruneFailure}`;
+                  if (await isStillRegisteredWorktree()) {
+                    throw new Error(message);
+                  }
+                  recordNonFatalFailure("git_worktree_remove", message);
+                  return { detail: `${detail}; warning: ${message}` };
+                }
                 return { detail };
               };
               // 60s — large worktrees (e.g. with node_modules) can take longer than 15s
@@ -4886,8 +4955,9 @@ export function createLaneService({
       const row = getLaneRow(laneId);
       if (!row) throw new Error(`Lane not found: ${laneId}`);
       const worktreeExists = Boolean(row.worktree_path) && fs.existsSync(row.worktree_path);
+      const worktreeUsable = worktreeExists && await isExpectedGitWorktreeRoot(row.worktree_path);
       let dirty = false;
-      if (worktreeExists) {
+      if (worktreeUsable) {
         const dirtyRes = await runGit(["status", "--porcelain=v1"], { cwd: row.worktree_path, timeoutMs: 6_000 });
         dirty = dirtyRes.exitCode === 0 && dirtyRes.stdout.trim().length > 0;
       }
@@ -4899,7 +4969,7 @@ export function createLaneService({
       // ref like "origin/feature" must probe "feature").
       const riskBranchName = row.branch_ref ? branchNameForDelete(row.branch_ref, "origin") : "";
       if (riskBranchName) {
-        const cwd = worktreeExists ? row.worktree_path : projectRoot;
+        const cwd = worktreeUsable ? row.worktree_path : projectRoot;
         const unpushed = await runGit(
           ["rev-list", "--count", riskBranchName, "--not", "--remotes"],
           { cwd, timeoutMs: 8_000 }

--- a/apps/desktop/src/main/services/pty/ptyService.test.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.test.ts
@@ -2152,7 +2152,7 @@ describe("ptyService", () => {
         exitCode: 0,
         status: "completed",
       });
-      sessionService.readTranscriptTail.mockResolvedValueOnce([
+      sessionService.readTranscriptTail.mockResolvedValue([
         "Update available! 0.130.0 -> 0.134.0\n",
         "Update ran successfully! Please restart Codex.\n",
       ].join(""));
@@ -2163,6 +2163,73 @@ describe("ptyService", () => {
         text: "continue",
       })).rejects.toThrow(/before ADE could create a resumable thread/i);
       expect(loadPty).not.toHaveBeenCalled();
+    });
+
+    it("sendToSession backfills a Codex storage target before launching resume", async () => {
+      vi.useFakeTimers();
+      try {
+        const fakeNow = new Date("2026-04-15T22:00:00.000Z");
+        vi.setSystemTime(fakeNow);
+
+        const homedir = os.homedir();
+        const sessionsBase = path.join(homedir, ".codex", "sessions");
+        const dirPath = path.join(sessionsBase, "2026", "04", "15");
+        const filePath = path.join(dirPath, "rollout-2026-04-15T21-30-00-thread-storage.jsonl");
+        const startedAt = "2026-04-15T21:30:00.000Z";
+        const firstLine = JSON.stringify({
+          timestamp: startedAt,
+          type: "session_meta",
+          payload: {
+            id: "thread-storage",
+            timestamp: startedAt,
+            cwd: "/tmp/worktree",
+          },
+        });
+
+        mocks.existsSyncResults.set(sessionsBase, true);
+        mocks.existsSyncResults.set(dirPath, true);
+        mocks.dirEntries.set(dirPath, [path.basename(filePath)]);
+        mocks.fileContents.set(filePath, `${firstLine}\n`);
+        mocks.fileStats.set(filePath, { size: firstLine.length, mtimeMs: fakeNow.getTime() - 30_000, isDirectory: false });
+
+        const { service, sessionService, loadPty } = createHarness();
+        sessionService.readTranscriptTail.mockResolvedValue("OpenAI Codex\nmodel: gpt-5\n› ");
+        sessionService.create({
+          sessionId: "session-codex-storage-send",
+          laneId: "lane-1",
+          ptyId: null,
+          tracked: true,
+          title: "Codex CLI",
+          startedAt,
+          transcriptPath: "/tmp/worktree/.ade/transcripts/session-codex-storage-send.log",
+          toolType: "codex",
+          resumeCommand: "codex --no-alt-screen resume",
+        });
+        sessionService.end({
+          sessionId: "session-codex-storage-send",
+          endedAt: "2026-04-15T21:45:00.000Z",
+          exitCode: 0,
+          status: "completed",
+        });
+
+        await service.sendToSession({
+          sessionId: "session-codex-storage-send",
+          text: "continue",
+        });
+
+        expect(sessionService.setResumeCommand).toHaveBeenCalledWith(
+          "session-codex-storage-send",
+          "codex resume thread-storage",
+        );
+        const spawn = (loadPty.mock.results[0]?.value as any).spawn;
+        expect(spawn).toHaveBeenCalledWith(
+          "/bin/bash",
+          ["--noprofile", "--norc", "-lc", "codex --no-alt-screen resume thread-storage continue"],
+          expect.any(Object),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("sendToSession resumes an ended tracked CLI session with the message in the launch command", async () => {
@@ -2791,6 +2858,9 @@ describe("ptyService", () => {
         service.sendToSession({ sessionId: "session-concurrent-send", text: "first" }),
         service.sendToSession({ sessionId: "session-concurrent-send", text: "second" }),
       ]);
+      for (let i = 0; i < 10 && loadPty.mock.calls.length === 0; i += 1) {
+        await Promise.resolve();
+      }
       await Promise.resolve();
       mockPty._emitter.emit("data", "OpenAI Codex\n› ");
       const [first, second] = await pending;

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -3101,10 +3101,10 @@ export function createPtyService({
     }
   };
 
-  const resolveEndedResumeSession = (
+  const resolveEndedResumeSession = async (
     sessionId: string,
     session: TerminalSessionSummary | null,
-  ): { session: TerminalSessionSummary; provider: TerminalResumeProvider } | Promise<{ session: TerminalSessionSummary; provider: TerminalResumeProvider }> => {
+  ): Promise<{ session: TerminalSessionSummary; provider: TerminalResumeProvider }> => {
     if (!session) throw new Error(`Terminal session '${sessionId}' was not found.`);
 
     const provider = session.resumeMetadata?.provider ?? providerFromTool(session.toolType);
@@ -3117,31 +3117,43 @@ export function createPtyService({
       );
     };
 
-    const parsedResumeCommand = parseTrackedCliResumeCommand(session.resumeCommand, session.toolType);
-    const storedResumeTargetId = sanitizeResumeTargetId(session.resumeMetadata?.targetId ?? null)
+    let resolvedSession = session;
+    let parsedResumeCommand = parseTrackedCliResumeCommand(resolvedSession.resumeCommand, resolvedSession.toolType);
+    let storedResumeTargetId = sanitizeResumeTargetId(resolvedSession.resumeMetadata?.targetId ?? null)
       ?? (parsedResumeCommand?.provider === provider
         ? sanitizeResumeTargetId(parsedResumeCommand.targetId ?? null)
         : null);
+    if (!storedResumeTargetId && provider !== "cursor" && isTrackedCliToolType(resolvedSession.toolType)) {
+      const cwd = inferSessionCwdFromTranscriptPath(resolvedSession.transcriptPath);
+      const backfilled = await tryBackfillResumeTarget(sessionId, resolvedSession.toolType, "resume-launch", cwd);
+      const updatedSession = backfilled ? sessionService.get(sessionId) : null;
+      if (updatedSession) {
+        resolvedSession = updatedSession;
+        parsedResumeCommand = parseTrackedCliResumeCommand(resolvedSession.resumeCommand, resolvedSession.toolType);
+        storedResumeTargetId = sanitizeResumeTargetId(resolvedSession.resumeMetadata?.targetId ?? null)
+          ?? (parsedResumeCommand?.provider === provider
+            ? sanitizeResumeTargetId(parsedResumeCommand.targetId ?? null)
+            : null);
+      }
+    }
     if (
       provider === "codex"
-      && isCodexTrackedCliToolType(session.toolType)
+      && isCodexTrackedCliToolType(resolvedSession.toolType)
       && !storedResumeTargetId
     ) {
-      return sessionService.readTranscriptTail(session.transcriptPath, 220_000)
-        .then((transcript) => {
-          if (isCodexCliUpdateTranscript(transcript)) {
-            throw new Error(
-              "Codex updated and exited before ADE could create a resumable thread. Start a new Codex session.",
-            );
-          }
-          return throwMissingResumeTarget();
-        });
+      const transcript = await sessionService.readTranscriptTail(resolvedSession.transcriptPath, 220_000);
+      if (isCodexCliUpdateTranscript(transcript)) {
+        throw new Error(
+          "Codex updated and exited before ADE could create a resumable thread. Start a new Codex session.",
+        );
+      }
+      return throwMissingResumeTarget();
     }
     if (!storedResumeTargetId && provider !== "cursor") {
       throwMissingResumeTarget();
     }
 
-    return { session, provider };
+    return { session: resolvedSession, provider };
   };
 
   const resumeLaunchOverrides = (
@@ -4005,10 +4017,7 @@ export function createPtyService({
         );
       }
 
-      const resolvedResume = resolveEndedResumeSession(sessionId, session);
-      const { session: resumableSession, provider } = resolvedResume instanceof Promise
-        ? await resolvedResume
-        : resolvedResume;
+      const { session: resumableSession, provider } = await resolveEndedResumeSession(sessionId, session);
       const overrides = resumeLaunchOverrides(args);
       const openCodeReplayCommand = provider === "opencode"
         && resumableSession.resumeMetadata?.provider === "opencode"
@@ -4068,10 +4077,7 @@ export function createPtyService({
         );
       }
 
-      const resolvedResume = resolveEndedResumeSession(sessionId, session);
-      const { session: resumableSession, provider } = resolvedResume instanceof Promise
-        ? await resolvedResume
-        : resolvedResume;
+      const { session: resumableSession, provider } = await resolveEndedResumeSession(sessionId, session);
       const { command: resumeCommand } = buildResumeCommandForSession(resumableSession, provider, resumeLaunchOverrides(args));
       if (!resumeCommand) {
         throw new Error(`Terminal session '${sessionId}' does not have a resume command.`);

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -3116,24 +3116,23 @@ export function createPtyService({
         `${displayName} exited before ADE could capture a concrete resume target. Start a new ${displayName} session.`,
       );
     };
+    const resumeTargetIdFor = (candidate: TerminalSessionSummary): string | null => {
+      const parsedResumeCommand = parseTrackedCliResumeCommand(candidate.resumeCommand, candidate.toolType);
+      return sanitizeResumeTargetId(candidate.resumeMetadata?.targetId ?? null)
+        ?? (parsedResumeCommand?.provider === provider
+          ? sanitizeResumeTargetId(parsedResumeCommand.targetId ?? null)
+          : null);
+    };
 
     let resolvedSession = session;
-    let parsedResumeCommand = parseTrackedCliResumeCommand(resolvedSession.resumeCommand, resolvedSession.toolType);
-    let storedResumeTargetId = sanitizeResumeTargetId(resolvedSession.resumeMetadata?.targetId ?? null)
-      ?? (parsedResumeCommand?.provider === provider
-        ? sanitizeResumeTargetId(parsedResumeCommand.targetId ?? null)
-        : null);
+    let storedResumeTargetId = resumeTargetIdFor(resolvedSession);
     if (!storedResumeTargetId && provider !== "cursor" && isTrackedCliToolType(resolvedSession.toolType)) {
       const cwd = inferSessionCwdFromTranscriptPath(resolvedSession.transcriptPath);
       const backfilled = await tryBackfillResumeTarget(sessionId, resolvedSession.toolType, "resume-launch", cwd);
       const updatedSession = backfilled ? sessionService.get(sessionId) : null;
       if (updatedSession) {
         resolvedSession = updatedSession;
-        parsedResumeCommand = parseTrackedCliResumeCommand(resolvedSession.resumeCommand, resolvedSession.toolType);
-        storedResumeTargetId = sanitizeResumeTargetId(resolvedSession.resumeMetadata?.targetId ?? null)
-          ?? (parsedResumeCommand?.provider === provider
-            ? sanitizeResumeTargetId(parsedResumeCommand.targetId ?? null)
-            : null);
+        storedResumeTargetId = resumeTargetIdFor(resolvedSession);
       }
     }
     if (

--- a/docs/features/agents/tool-registration.md
+++ b/docs/features/agents/tool-registration.md
@@ -278,6 +278,12 @@ task. `buildAdeCliAgentGuidance()` and `buildAdeCliInlineGuidance()`
 currently share the same compact guidance body so system prompts,
 worker launches, and inline Work-tab preambles stay aligned.
 
+Lane launch directives pair this ADE CLI guidance with worktree write
+boundaries. Agents may inspect files outside the launched lane when they
+need read-only context, but edits and mutating shell commands are only
+allowed inside the lane worktree unless ADE relaunches the session in a
+different lane.
+
 ## Fragile and tricky wiring
 
 - **Identity must come from env or trusted CLI flags.** A rogue client

--- a/docs/features/chat/README.md
+++ b/docs/features/chat/README.md
@@ -117,7 +117,11 @@ render them, but neither one *runs* them.
   `acpEventMapper.ts` for terminal lifecycle parity.
 - **Lane-scoped.** Every session carries `laneId`; lane context (branch,
   worktree path) is injected into the system prompt, and working-directory
-  resolution runs through `resolveLaneLaunchContext`.
+  resolution runs through `resolveLaneLaunchContext`. The injected ADE
+  workspace directive treats the lane worktree as the boundary for
+  writes and mutations: read-only inspection outside the worktree is
+  allowed when needed, but file edits and mutating commands must stay
+  inside the launched lane unless ADE relaunches the session elsewhere.
 - **Event stream first.** All transcript content is a JSON-lines stream of
   `AgentChatEventEnvelope` values. Renderer components derive UI state
   entirely from this stream.

--- a/docs/features/chat/agent-routing.md
+++ b/docs/features/chat/agent-routing.md
@@ -174,6 +174,13 @@ over a stale persisted pair. Turns use the Codex-native `effort` key
 (`turn/start({ threadId, input, effort?, serviceTier? })`) instead of
 the lifecycle `reasoningEffort` name.
 
+For Codex and the other coding-agent paths, ADE's worktree guidance is
+write-scoped rather than read-scoped: the launched lane worktree is the
+only place the agent should edit files or run mutating commands, while
+read-only inspection outside that path is allowed when it needs context.
+This wording appears in both the system prompt and the first-turn launch
+directive so resumed/continued sessions keep the same boundary.
+
 #### Provider service tiers (Fast Mode)
 
 `ModelDescriptor.serviceTiers?: string[]` advertises the optional

--- a/docs/features/history/README.md
+++ b/docs/features/history/README.md
@@ -48,7 +48,7 @@ Main process / runtime services:
 |---|---|
 | `apps/desktop/src/main/services/history/operationService.ts` | CRUD for `operations` rows; the canonical entry point for `record`, `start`, `finish`, `list`, `get`, and `listHeadChanges`. Same source backs the runtime daemon and the desktop fallback path. |
 | `apps/desktop/src/main/services/state/kvDb.ts` | Schema for `operations`, `checkpoints`, `pack_events`, `pack_versions`, `pack_heads`, `terminal_sessions`, and orchestration-related tables. |
-| `apps/desktop/src/main/services/git/gitOperationsService.ts` | Brackets every git operation with `operationService.start` / `finish`, captures pre/post HEAD SHAs, and owns the per-lane undo/redo head-change pipeline (`undoLastHeadChange`, `redoLastHeadChange`, `createTag`, `resetToCommit`, `pull` with `ff-only` / `rebase` / `merge` modes). Undo selection is branch-aware: it ignores checkout/undo rows, requires the recorded operation's `metadata.branchRef` to match the lane's current branch, and rechecks the branch before running `reset --hard`. |
+| `apps/desktop/src/main/services/git/gitOperationsService.ts` | Brackets every git operation with `operationService.start` / `finish`, captures pre/post HEAD SHAs, and owns the per-lane undo/redo head-change pipeline (`undoLastHeadChange`, `redoLastHeadChange`, `createTag`, `resetToCommit`, `pull` with `ff-only` / `rebase` / `merge` modes). Before lane git mutations or lane git reads, it verifies that the saved `worktreePath` is still the Git top-level for that lane; stale paths that resolve to the primary checkout are rejected as missing lane worktrees so History and Git Actions do not read or mutate the wrong branch. Undo selection is branch-aware: it ignores checkout/undo rows, requires the recorded operation's `metadata.branchRef` to match the lane's current branch, and rechecks the branch before running `reset --hard`. |
 | `apps/desktop/src/main/services/lanes/laneService.ts` | Lane CRUD now accepts `CreateLaneArgs.startPoint`, used by the Commits view's "Create lane here" affordance to fork a new lane from a specific commit. |
 | `apps/desktop/src/main/services/prs/prService.ts` | Records PR creation as an operation. |
 | `apps/desktop/src/main/services/conflicts/conflictService.ts` | Records rebase operations. |
@@ -323,6 +323,12 @@ Defined in `apps/desktop/src/shared/ipc.ts`, handled in
 | `ade.git.pull` | `GitPullArgs` (`{ laneId, mode?: "ff-only" \| "rebase" \| "merge" }`) | Default `ff-only`. Records `git_pull` with `metadata.mode`. |
 | `ade.git.undoLastHeadChange` | `GitHeadChangeActionArgs` (`{ laneId }`) | Resets HEAD to the previous successful head-changing op's `preHeadSha`. Fails if HEAD has moved since. Records `git_undo_head_change`. |
 | `ade.git.redoLastHeadChange` | `GitHeadChangeActionArgs` (`{ laneId }`) | Restores HEAD to the most recent undo's `redoHeadSha`. Fails if HEAD has moved since the undo. Records `git_redo_head_change`. |
+
+All lane-scoped `ade.git.*` reads and mutations validate the lane
+worktree root before running provider Git commands. A missing or stale
+worktree path throws the same "restore or recreate the lane worktree"
+error for history reads, commit-message generation, branch/stash/sync
+metadata, and mutating Git actions.
 
 The conflict-resume channels (`gitRebaseContinue`, `gitRebaseAbort`,
 `gitMergeContinue`, `gitMergeAbort`) accept either a bare `string`

--- a/docs/features/lanes/worktree-isolation.md
+++ b/docs/features/lanes/worktree-isolation.md
@@ -84,8 +84,10 @@ auto-clean it.
 the directory first:
 
 1. Fetch the row; reject if `is_edit_protected = 1` (primary).
-2. Check worktree dirtiness when a managed worktree exists; dirty
-   lanes require the caller's force acknowledgement.
+2. Check worktree dirtiness only when the saved path still resolves to
+   that exact Git worktree root. If the directory is missing, or a stale
+   path under the repo now resolves to the primary checkout, ADE treats
+   the lane as stale instead of reading the primary worktree's status.
 3. Cancel auto-rebase and dismiss rebase suggestions for the lane.
 4. Stop ADE-managed processes, PTYs, and file watchers for the lane,
    then run any lane-environment cleanup supplied by the runtime.
@@ -93,7 +95,12 @@ the directory first:
    run `git worktree remove --force <path>`. If Git reports success
    but residual files remain, ADE removes the directory with
    `fs.promises.rm` and runs `git worktree prune` before continuing.
-   If attached: skip.
+   If Git already considers the path unregistered, ADE still prunes the
+   worktree registry and attempts manual residual cleanup. If the path
+   is no longer registered and manual cleanup or prune fails, the lane
+   delete can complete with warnings so the stale row and lane-owned
+   metadata are still removed; the warning tells the user what residual
+   directory or registry cleanup remains manual. If attached: skip.
 6. If caller requested `deleteBranch`: `git branch -D <branch>`.
    Optional remote branch cleanup uses `git push <remote> --delete
    <branch>` and is non-fatal.
@@ -111,6 +118,12 @@ unrelated process, PTY, watcher, or environment cleanup.
 
 A worktree that has been manually removed from disk but still has a
 row is repaired by `laneService.removeStaleWorktrees()` at startup.
+Status/read paths also verify the saved `worktree_path` with
+`git rev-parse --path-format=absolute --show-toplevel` before running
+lane-local Git reads. When the top-level is missing or differs from
+the saved path, ADE returns the default clean lane status and avoids
+probing `git status`, branch detection, stashes, or change inspection
+from the wrong checkout.
 
 ## Per-lane state directories
 
@@ -139,6 +152,13 @@ present. This matters because:
 
 - Stashes, rebases, merges, and cherry-picks are worktree-local —
   nothing bleeds into other lanes.
+- Before mutating a lane or reading history/diff metadata for a lane,
+  `gitOperationsService` validates that `worktree_path` is still the
+  Git top-level for that lane. A stale path that now resolves to the
+  primary repo checkout is treated as a missing lane worktree, so ADE
+  does not stage, commit, generate commit messages, list commits,
+  inspect branches/stashes/conflicts, or compute sync state from the
+  wrong worktree.
 - `git worktree` detects in-progress merge/rebase state via files in
   the worktree's gitdir (`rebase-apply/`, `rebase-merge/`,
   `MERGE_HEAD`). `detectConflictKind` in

--- a/docs/features/terminals-and-sessions/README.md
+++ b/docs/features/terminals-and-sessions/README.md
@@ -592,9 +592,11 @@ See `apps/desktop/src/shared/types/sessions.ts` for the full shape.
    when the user sends text to an ended agent CLI session and the PTY
    service opens the transcript in append mode. When the runtime is still
    live, it submits to that PTY directly. When the PTY is gone, it rebuilds
-   the provider resume command, creates a new PTY bound to the same durable
-   session id, and includes the new prompt in that launch command when
-   resume metadata is available. If another send arrives while the resume
+   the provider resume command, backfills a missing resume target on
+   demand when possible (including Codex rollout storage during an active
+   resume launch), creates a new PTY bound to the same durable session id,
+   and includes the new prompt in that launch command when resume metadata
+   is available. If another send arrives while the resume
    flight is already in progress, that later text is serialized and
    written after the PTY is attached. This keeps identity, lane
    association, and transcript history intact without killing the resumed
@@ -668,8 +670,8 @@ PTY:
 | Channel | Purpose |
 |---|---|
 | `ade.pty.create` | create or reattach; returns `{ ptyId, sessionId, pid }`. Accepts an optional `chatSessionId` to mark the terminal as chat-owned. |
-| `ade.pty.resumeSession` | prompt-free tracked CLI relaunch. Args: `{ sessionId, cols?, rows?, model?, reasoningEffort?, permissionMode? }`. Reuses a live PTY when attached; otherwise validates the row, rebuilds the provider resume command, and spawns a continuation PTY in the same `terminal_sessions` row without writing a prompt. Returns `PtyResumeSessionResult` (`{ ptyId, sessionId, pid, session, resumed, reusedExistingRuntime }`). |
-| `ade.pty.sendToSession` | send-or-continue. Args: `{ sessionId, text, cols?, rows?, model?, reasoningEffort?, permissionMode? }`. Submits text into the live PTY when one is attached; otherwise validates that the row is a tracked agent CLI session, rebuilds the resume command via `buildTrackedCliResumeCommand` (honouring runtime overrides), spawns the continuation PTY in the same `terminal_sessions` row, and includes the user's text in the launch command when resume metadata is available. Later sends that land after a resume flight has started are serialized through the agent CLI input protocol: line clear, bracketed paste envelope, chunked 64-byte writes with 5 ms inter-chunk delay, then carriage return with a provider-specific submit delay. Returns `PtySendToSessionResult` (`{ ptyId, sessionId, pid, session, resumed, reusedExistingRuntime }`). |
+| `ade.pty.resumeSession` | prompt-free tracked CLI relaunch. Args: `{ sessionId, cols?, rows?, model?, reasoningEffort?, permissionMode? }`. Reuses a live PTY when attached; otherwise validates the row, backfills a missing resume target when possible, rebuilds the provider resume command, and spawns a continuation PTY in the same `terminal_sessions` row without writing a prompt. Returns `PtyResumeSessionResult` (`{ ptyId, sessionId, pid, session, resumed, reusedExistingRuntime }`). |
+| `ade.pty.sendToSession` | send-or-continue. Args: `{ sessionId, text, cols?, rows?, model?, reasoningEffort?, permissionMode? }`. Submits text into the live PTY when one is attached; otherwise validates that the row is a tracked agent CLI session, backfills a missing resume target when possible, rebuilds the resume command via `buildTrackedCliResumeCommand` (honouring runtime overrides), spawns the continuation PTY in the same `terminal_sessions` row, and includes the user's text in the launch command when resume metadata is available. Later sends that land after a resume flight has started are serialized through the agent CLI input protocol: line clear, bracketed paste envelope, chunked 64-byte writes with 5 ms inter-chunk delay, then carriage return with a provider-specific submit delay. Returns `PtySendToSessionResult` (`{ ptyId, sessionId, pid, session, resumed, reusedExistingRuntime }`). |
 | `ade.pty.write` | write bytes to PTY |
 | `ade.pty.resize` | cols/rows resize |
 | `ade.pty.dispose` | close PTY; optional `sessionId` used for logging |

--- a/docs/features/terminals-and-sessions/pty-and-processes.md
+++ b/docs/features/terminals-and-sessions/pty-and-processes.md
@@ -395,7 +395,11 @@ write paths into one call:
 2. Otherwise require a tracked agent CLI row (Claude, Codex, Cursor,
    OpenCode, Droid; chats and shells are rejected with a clear error).
    Resolve the provider from `resumeMetadata.provider`, fall back to
-   `providerFromTool(toolType)`.
+   `providerFromTool(toolType)`. If a Claude/Codex/Droid/OpenCode row
+   has no concrete target yet, the service runs the same on-demand
+   resume-target backfill used by `ensureResumeTargets`; Codex can scan
+   rollout storage during this resume-launch path before ADE reports a
+   missing target.
 3. Rebuild the resume command via
    `buildTrackedCliResumeCommand(metadata, overrides)` — runtime
    `model` / `reasoningEffort` / `permissionMode` overrides flow into
@@ -567,9 +571,9 @@ resolved. Strategies, in order:
    drift window. The recovered id becomes `opencode --session <id>`.
 
 The Droid storage scan and the OpenCode `session list` invocation only
-fire on the `close` / `dispose` reasons (and on demand), not on
-`session-list` or `resume-launch`, so renderer list refreshes don't
-spawn a `spawnSync` or hit external storage on every render.
+fire on the `close` / `dispose` reasons and explicit on-demand
+continuation paths, not on `session-list`, so renderer list refreshes
+don't spawn a `spawnSync` or hit external storage on every render.
 
 Any found ID updates the row's `resumeMetadata.targetId` through
 `sessionService.updateMeta`. A resume command is always written even
@@ -583,15 +587,16 @@ single `pty.resume_target_backfill_failed` warn per failing ID; it
 never throws.
 
 The Codex storage scan is gated by the `reason` argument that the
-backfill runs under: `"close"` and `"dispose"` (the regular end-of-
-session paths) consult `~/.codex/sessions` with the 10-minute drift
-window; `"session-list"` and `"resume-launch"` skip the storage
-lookup entirely. Lazy hydration over `sessions.list` therefore relies
-only on transcript regex matches, which keeps the list-render hot path
-off the disk and prevents one renderer's idle list refresh from
-adopting another lane's Codex rollout. Live Codex sessions still get
-their resume target through the live capture path, which uses the
-strict `requiredText: "ADE session guidance"` gate.
+backfill runs under: `"close"` and `"dispose"` consult
+`~/.codex/sessions` with the 10-minute drift window; `"session-list"`
+skips the storage lookup entirely; `"resume-launch"` is allowed to use
+the storage lookup because the user is actively trying to continue that
+specific session. Lazy hydration over `sessions.list` therefore relies
+only on transcript regex matches, keeping the list-render hot path off
+the disk and preventing one renderer's idle refresh from adopting
+another lane's Codex rollout. Live Codex sessions still get their
+resume target through the live capture path, which uses the strict
+`requiredText: "ADE session guidance"` gate.
 
 ### Live Codex session-id capture
 


### PR DESCRIPTION
## Summary
- allow lane deletion to finish when the worktree is already unregistered or stale, while preserving cleanup warnings for partial filesystem removal
- guard git reads and mutations against stale lane directories resolving to the main checkout
- backfill missing Codex resume targets and add CLI/TUI parity for stale lane worktree detection
- update feature docs for the lane, history, chat, agent tooling, and terminal/session flows

## Validation
- npm --prefix apps/desktop run typecheck
- npm --prefix apps/desktop run lint
- npm --prefix apps/desktop run build
- npm --prefix apps/ade-cli run typecheck
- npm --prefix apps/ade-cli run test (full run had transient failures; affected files passed isolated reruns)
- npm --prefix apps/ade-cli run build
- npm --prefix apps/web run typecheck
- npm --prefix apps/web run build
- npm run test:desktop:sharded equivalent via all 8 shards (transient shard failures passed isolated reruns)
- node scripts/validate-docs.mjs
- docs feature README source-map check
- PRD markdown link check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ade lanes delete` command with `--force`, `--delete-branch`, and `--delete-remote-branch` options.

* **Bug Fixes**
  * Enhanced detection and handling of missing or stale lane worktrees.
  * Improved lane deletion robustness with better error recovery.

* **Improvements**
  * Updated AI agent permissions to allow read-only inspection outside lane boundaries.
  * Enhanced resume session handling with local backfill capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds stale-worktree guards across ADE: before any lane-scoped git mutation or read, the service verifies that the saved `worktreePath` is still the actual Git worktree root (via `git rev-parse --show-toplevel`), preventing operations from silently running against the primary checkout when a lane directory has been removed or orphaned. It also relaxes the agent system-prompt boundary to allow read-only inspection outside the worktree while keeping writes/mutations lane-scoped, exposes `ade lanes delete` through the CLI, and fixes Codex session resume by backfilling storage targets on demand.

- **Stale-worktree guard**: `assertLaneWorktreeRoot` (git service) and `isExpectedGitWorktreeRoot` (lane service) are added and called before every lane-scoped git operation; `isLaneWorktreeAvailable` in the TUI is similarly hardened with a cached `spawnSync` probe.
- **Agent boundary clarification**: Three copies of the lane-directive text are updated to explicitly permit read-only inspection outside the worktree while restricting file edits and mutating commands to the lane path.
- **PTY / Codex resume**: `resolveEndedResumeSession` is made fully `async` and attempts an on-demand resume-target backfill (including Codex rollout storage) before declaring a missing target.

<h3>Confidence Score: 3/5</h3>

The stale-worktree guard is a valuable safety feature but two defects can cause valid worktrees to be falsely rejected on macOS, and the TUI now blocks the event loop during rendering.

Both service files compare git rev-parse output using path.resolve without symlink resolution, which fails on macOS where /tmp resolves to /private/tmp. The TUI adds a spawnSync with an 8-second timeout in the synchronous render path. These affect the core lane-git path and TUI responsiveness.

apps/desktop/src/main/services/git/gitOperationsService.ts and apps/desktop/src/main/services/lanes/laneService.ts (normAbs symlink resolution); apps/ade-cli/src/tuiClient/app.tsx (spawnSync in render path)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/tuiClient/app.tsx | Enhanced `isLaneWorktreeAvailable` with a TTL-cached `.git` marker check and a `spawnSync` git probe — but the 8-second synchronous timeout runs in the Ink TUI render path, which can block the event loop on every cache miss. |
| apps/desktop/src/main/services/git/gitOperationsService.ts | Added `assertLaneWorktreeRoot` guard to every lane-scoped git operation; `normAbs` uses `path.resolve` rather than `fs.realpathSync.native`, which can produce false stale-worktree rejections on macOS where /tmp is a symlink. |
| apps/desktop/src/main/services/lanes/laneService.ts | Added `isExpectedGitWorktreeRoot` / `assertExpectedGitWorktreeRoot` helpers guarding status reads, stash listing, and change inspection; contains the same symlink issue in `normAbs` and a test-specific error-message bypass in production code. |
| apps/desktop/src/main/services/pty/ptyService.ts | `resolveEndedResumeSession` refactored to `async`, eliminating the `instanceof Promise` dual-path. On-demand resume-target backfill attempted during `resume-launch` before reporting a missing target. |
| apps/desktop/src/main/services/chat/agentChatService.ts | Worktree directive updated in three places to allow read-only inspection outside the lane worktree while restricting mutating operations — straightforward text change with no logic issues. |
| apps/ade-cli/src/cli.ts | Added `lanes delete` to the CLI help text and `buildCliPlan` handler with `--force`, `--delete-branch`, and `--delete-remote-branch` flags. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/main/services/lanes/laneService.ts`, line 256-258 ([link](https://github.com/arul28/ade/blob/163172db9bd235e841cdd7f37833e4810b6f941f/apps/desktop/src/main/services/lanes/laneService.ts#L256-L258)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> Same symlink-resolution gap as `gitOperationsService.ts`: `normAbs` uses only `path.resolve`, so the `normAbs(topLevel) === normAbs(worktreePath)` comparison in `isExpectedGitWorktreeRoot` can fail on macOS when the worktree path was stored without resolving `/tmp` to `/private/tmp`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/lanes/laneService.ts
   Line: 256-258

   Comment:
   Same symlink-resolution gap as `gitOperationsService.ts`: `normAbs` uses only `path.resolve`, so the `normAbs(topLevel) === normAbs(worktreePath)` comparison in `isExpectedGitWorktreeRoot` can fail on macOS when the worktree path was stored without resolving `/tmp` to `/private/tmp`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Flanes%2FlaneService.ts%0ALine%3A%20256-258%0A%0AComment%3A%0ASame%20symlink-resolution%20gap%20as%20%60gitOperationsService.ts%60%3A%20%60normAbs%60%20uses%20only%20%60path.resolve%60%2C%20so%20the%20%60normAbs%28topLevel%29%20%3D%3D%3D%20normAbs%28worktreePath%29%60%20comparison%20in%20%60isExpectedGitWorktreeRoot%60%20can%20fail%20on%20macOS%20when%20the%20worktree%20path%20was%20stored%20without%20resolving%20%60%2Ftmp%60%20to%20%60%2Fprivate%2Ftmp%60.%0A%0A%60%60%60suggestion%0Afunction%20normAbs%28p%3A%20string%29%3A%20string%20%7B%0A%20%20const%20resolved%20%3D%20path.resolve%28p%29%3B%0A%20%20try%20%7B%0A%20%20%20%20return%20fs.realpathSync.native%28resolved%29%3B%0A%20%20%7D%20catch%20%7B%0A%20%20%20%20return%20resolved%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=508&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Aapps%2Fade-cli%2Fsrc%2FtuiClient%2Fapp.tsx%3A1049-1052%0A**%60spawnSync%60%20with%208-second%20timeout%20in%20UI%20render%20path**%0A%0A%60isLaneWorktreeAvailable%60%20is%20called%20synchronously%20from%20%60laneWorktreeUnavailableMessage%60%20during%20TUI%20rendering.%20After%20the%202-second%20cache%20TTL%20expires%2C%20any%20lane%20whose%20directory%20has%20a%20%60.git%60%20marker%20will%20trigger%20%60spawnSync%28%22git%22%2C%20...%29%60%20with%20%60timeout%3A%208_000%60.%20This%20blocks%20the%20Node.js%20event%20loop%20and%20the%20entire%20Ink%20TUI%20for%20up%20to%208%20seconds%20on%20each%20cache%20miss.%20The%20original%20code%20did%20only%20an%20%60fs.statSync%60.%20With%20git%20lock%20contention%20or%20a%20slow%20filesystem%20this%20becomes%20a%20hard%20freeze.%0A%0A%23%23%23%20Issue%202%20of%205%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fgit%2FgitOperationsService.ts%3A67-69%0A%60normAbs%60%20uses%20%60path.resolve%60%2C%20which%20does%20**not**%20resolve%20symlinks.%20On%20macOS%20%60%2Ftmp%60%20is%20a%20symlink%20to%20%60%2Fprivate%2Ftmp%60%2C%20so%20if%20%60lane.worktreePath%60%20is%20stored%20as%20%60%2Ftmp%2Fade-worktrees%2Fmy-lane%60%20but%20%60git%20rev-parse%20--show-toplevel%60%20returns%20%60%2Fprivate%2Ftmp%2Fade-worktrees%2Fmy-lane%60%2C%20the%20equality%20check%20fails%20and%20a%20valid%20worktree%20is%20rejected%20as%20stale.%20%60normalizeWorktreePath%60%20in%20%60app.tsx%60%20explicitly%20uses%20%60fs.realpathSync.native%60%20for%20this%20reason.%0A%0A%60%60%60suggestion%0Afunction%20normAbs%28p%3A%20string%29%3A%20string%20%7B%0A%20%20const%20resolved%20%3D%20path.resolve%28p%29%3B%0A%20%20try%20%7B%0A%20%20%20%20return%20fs.realpathSync.native%28resolved%29%3B%0A%20%20%7D%20catch%20%7B%0A%20%20%20%20return%20resolved%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%205%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Flanes%2FlaneService.ts%3A256-258%0ASame%20symlink-resolution%20gap%20as%20%60gitOperationsService.ts%60%3A%20%60normAbs%60%20uses%20only%20%60path.resolve%60%2C%20so%20the%20%60normAbs%28topLevel%29%20%3D%3D%3D%20normAbs%28worktreePath%29%60%20comparison%20in%20%60isExpectedGitWorktreeRoot%60%20can%20fail%20on%20macOS%20when%20the%20worktree%20path%20was%20stored%20without%20resolving%20%60%2Ftmp%60%20to%20%60%2Fprivate%2Ftmp%60.%0A%0A%60%60%60suggestion%0Afunction%20normAbs%28p%3A%20string%29%3A%20string%20%7B%0A%20%20const%20resolved%20%3D%20path.resolve%28p%29%3B%0A%20%20try%20%7B%0A%20%20%20%20return%20fs.realpathSync.native%28resolved%29%3B%0A%20%20%7D%20catch%20%7B%0A%20%20%20%20return%20resolved%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%205%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Flanes%2FlaneService.ts%3A274-280%0AThis%20catch%20branch%20returns%20%60true%60%20when%20the%20error%20message%20matches%20%60%22Unexpected%20git%20call%3A%22%60%20%E2%80%94%20a%20pattern%20that%20only%20originates%20from%20test%20mocks.%20Embedding%20test-fixture%20bypass%20logic%20in%20production%20code%20means%20any%20future%20mock%20refactor%20could%20silently%20disable%20the%20guard%2C%20and%20any%20production%20error%20starting%20with%20that%20phrase%20would%20also%20bypass%20validation.%0A%0A%60%60%60suggestion%0A%20%20%7D%20catch%20%7B%0A%20%20%20%20return%20false%3B%0A%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fgit%2FgitOperationsService.ts%3A451%0A%60assertLaneWorktreeRoot%60%20silently%20returns%20%28passes%20validation%29%20when%20%60runGit%60%20yields%20%60null%60%2C%20%60undefined%60%2C%20or%20an%20object%20without%20a%20numeric%20%60exitCode%60.%20In%20those%20cases%20the%20guard%20is%20skipped%20and%20the%20caller%20proceeds%20to%20mutate%20an%20unverified%20path.%20The%20same%20silent-pass%20pattern%20exists%20in%20%60isExpectedGitWorktreeRoot%60%20in%20%60laneService.ts%60%20%28line%20269%29.%20Treating%20an%20unrecognised%20response%20as%20valid%20inverts%20the%20safe-default%20principle.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28!topLevelRes%20%7C%7C%20typeof%20topLevelRes.exitCode%20!%3D%3D%20%22number%22%29%20%7B%0A%20%20%20%20%20%20%20%20throw%20laneWorktreeMissingError%28lane%29%3B%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=508&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
apps/ade-cli/src/tuiClient/app.tsx:1049-1052
**`spawnSync` with 8-second timeout in UI render path**

`isLaneWorktreeAvailable` is called synchronously from `laneWorktreeUnavailableMessage` during TUI rendering. After the 2-second cache TTL expires, any lane whose directory has a `.git` marker will trigger `spawnSync("git", ...)` with `timeout: 8_000`. This blocks the Node.js event loop and the entire Ink TUI for up to 8 seconds on each cache miss. The original code did only an `fs.statSync`. With git lock contention or a slow filesystem this becomes a hard freeze.

### Issue 2 of 5
apps/desktop/src/main/services/git/gitOperationsService.ts:67-69
`normAbs` uses `path.resolve`, which does **not** resolve symlinks. On macOS `/tmp` is a symlink to `/private/tmp`, so if `lane.worktreePath` is stored as `/tmp/ade-worktrees/my-lane` but `git rev-parse --show-toplevel` returns `/private/tmp/ade-worktrees/my-lane`, the equality check fails and a valid worktree is rejected as stale. `normalizeWorktreePath` in `app.tsx` explicitly uses `fs.realpathSync.native` for this reason.

```suggestion
function normAbs(p: string): string {
  const resolved = path.resolve(p);
  try {
    return fs.realpathSync.native(resolved);
  } catch {
    return resolved;
  }
}
```

### Issue 3 of 5
apps/desktop/src/main/services/lanes/laneService.ts:256-258
Same symlink-resolution gap as `gitOperationsService.ts`: `normAbs` uses only `path.resolve`, so the `normAbs(topLevel) === normAbs(worktreePath)` comparison in `isExpectedGitWorktreeRoot` can fail on macOS when the worktree path was stored without resolving `/tmp` to `/private/tmp`.

```suggestion
function normAbs(p: string): string {
  const resolved = path.resolve(p);
  try {
    return fs.realpathSync.native(resolved);
  } catch {
    return resolved;
  }
}
```

### Issue 4 of 5
apps/desktop/src/main/services/lanes/laneService.ts:274-280
This catch branch returns `true` when the error message matches `"Unexpected git call:"` — a pattern that only originates from test mocks. Embedding test-fixture bypass logic in production code means any future mock refactor could silently disable the guard, and any production error starting with that phrase would also bypass validation.

```suggestion
  } catch {
    return false;
  }
```

### Issue 5 of 5
apps/desktop/src/main/services/git/gitOperationsService.ts:451
`assertLaneWorktreeRoot` silently returns (passes validation) when `runGit` yields `null`, `undefined`, or an object without a numeric `exitCode`. In those cases the guard is skipped and the caller proceeds to mutate an unverified path. The same silent-pass pattern exists in `isExpectedGitWorktreeRoot` in `laneService.ts` (line 269). Treating an unrecognised response as valid inverts the safe-default principle.

```suggestion
      if (!topLevelRes || typeof topLevelRes.exitCode !== "number") {
        throw laneWorktreeMissingError(lane);
      }
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ship: prepare lane for review"](https://github.com/arul28/ade/commit/163172db9bd235e841cdd7f37833e4810b6f941f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35071968)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->