### PR TITLE
ADE-94: Linear multi-agent launch can create untracked CLI sessions

### DIFF
--- a/apps/desktop/src/main/services/chat/agentChatCliLaunch.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatCliLaunch.test.ts
@@ -126,14 +126,15 @@ describe("launchAgentChatCli worktree-path resolution", () => {
 });
 
 describe("launchAgentChatCli attached issue ids", () => {
-  it("awaits delayed kickoff input so slow CLI readiness cannot silently drop the prompt", async () => {
+  it("returns the durable terminal session before delayed kickoff input readiness", async () => {
     const deps = makeDeps();
-    await launchAgentChatCli(makeArgs(), deps);
+    const result = await launchAgentChatCli(makeArgs(), deps);
 
     const createArg = deps.create.mock.calls[0]?.[0] as PtyCreateArgs;
     expect(createArg.initialInput).toContain("Resolve the attached issue");
-    expect(createArg.awaitInitialInput).toBe(true);
-    expect(createArg.initialInputReadyTimeoutMs).toBe(120_000);
+    expect(createArg).not.toHaveProperty("awaitInitialInput");
+    expect(createArg).not.toHaveProperty("initialInputReadyTimeoutMs");
+    expect(result.sessionId).toBe(createArg.sessionId);
   });
 
   it("returns only well-formed attached issue ids and drops malformed entries", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatCliLaunch.ts
+++ b/apps/desktop/src/main/services/chat/agentChatCliLaunch.ts
@@ -23,8 +23,6 @@ type LoggerForCliLaunch = {
   info: (message: string, meta?: Record<string, unknown>) => void;
 };
 
-const AGENT_CHAT_CLI_KICKOFF_READY_TIMEOUT_MS = 120_000;
-
 export type AgentChatCliLaunchDeps = {
   laneService: LaneServiceForCliLaunch;
   ptyService: PtyServiceForCliLaunch;
@@ -119,12 +117,6 @@ export async function launchAgentChatCli(
       : {}),
     ...(launch.initialInputDelayMs !== undefined
       ? { initialInputDelayMs: launch.initialInputDelayMs }
-      : {}),
-    ...(launch.initialInput !== undefined
-      ? {
-          awaitInitialInput: true,
-          initialInputReadyTimeoutMs: AGENT_CHAT_CLI_KICKOFF_READY_TIMEOUT_MS,
-        }
       : {}),
     ...(launch.env ? { env: launch.env } : {}),
   });

--- a/apps/desktop/src/main/services/pty/ptyService.test.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.test.ts
@@ -1084,7 +1084,7 @@ describe("ptyService", () => {
     it("rejects awaited initialInput when the agent CLI never becomes ready", async () => {
       vi.useFakeTimers();
       try {
-        const { service, mockPty, logger } = createHarness();
+        const { service, mockPty, logger, sessionService } = createHarness();
 
         const pending = service.create({
           laneId: "lane-1",
@@ -1120,6 +1120,15 @@ describe("ptyService", () => {
           "pty.initial_input_skipped_not_ready",
           expect.objectContaining({ provider: "codex" }),
         );
+        expect(logger.warn).toHaveBeenCalledWith(
+          "pty.initial_input_await_failed_closing",
+          expect.objectContaining({ toolType: "codex" }),
+        );
+        expect(mockPty.kill).toHaveBeenCalledWith("SIGTERM");
+        expect(sessionService.end).toHaveBeenCalledWith(expect.objectContaining({
+          exitCode: 1,
+          status: "failed",
+        }));
       } finally {
         vi.useRealTimers();
       }

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -3857,6 +3857,15 @@ export function createPtyService({
             if (initialInputDelayMs > 0) await delay(initialInputDelayMs);
             await writeInitialInput();
           } catch (err) {
+            logger.warn("pty.initial_input_await_failed_closing", {
+              ptyId,
+              sessionId,
+              cwd,
+              toolType: toolTypeHint,
+              err: String(err),
+            });
+            terminatePtyProcessTree(entry, "SIGTERM", logger);
+            closeEntry(ptyId, 1);
             throw err;
           }
         } else if (initialInputDelayMs > 0) {

--- a/apps/desktop/src/renderer/lib/linearBatchLaunch.test.ts
+++ b/apps/desktop/src/renderer/lib/linearBatchLaunch.test.ts
@@ -315,6 +315,58 @@ describe("runBatchLaunch", () => {
     expect(result.createdSessionIds).toEqual(["cli-1"]);
   });
 
+  it("records every concurrent delayed CLI launch by its returned terminal session id", async () => {
+    type LaunchCliArgs = Parameters<NonNullable<BatchLaunchDeps["launchCli"]>>[0];
+    const createDeferred = () => {
+      let resolve!: (value: { sessionId: string }) => void;
+      const promise = new Promise<{ sessionId: string }>((done) => {
+        resolve = done;
+      });
+      return { promise, resolve };
+    };
+    const deferredByIssue = new Map([
+      ["a", createDeferred()],
+      ["b", createDeferred()],
+      ["c", createDeferred()],
+    ]);
+    const createLane = vi.fn(async (args: { linearIssue: { id: string } }) => ({ id: `lane-${args.linearIssue.id}` }));
+    const launch = vi.fn(async () => ({ id: "chat-sess" }));
+    const launchCli = vi.fn(async (args: LaunchCliArgs) => {
+      const issueId = args.linearIssues[0]?.id;
+      const deferred = issueId ? deferredByIssue.get(issueId) : null;
+      if (!deferred) throw new Error(`missing deferred for ${issueId ?? "unknown issue"}`);
+      return deferred.promise;
+    });
+    const onItem = vi.fn();
+    const entries = ["a", "b", "c"].map((id) => ({
+      issue: makeIssue({ id, identifier: `ENG-${id.toUpperCase()}` }),
+      config: makeConfig({ sessionType: "cli" }),
+    }));
+
+    const launched = runBatchLaunch(
+      entries,
+      { createLane, launch, launchCli },
+      { onItem, concurrency: 3 },
+    );
+    for (let i = 0; i < 5 && launchCli.mock.calls.length < 3; i += 1) {
+      await Promise.resolve();
+    }
+    expect(launchCli).toHaveBeenCalledTimes(3);
+
+    deferredByIssue.get("b")?.resolve({ sessionId: "cli-b" });
+    deferredByIssue.get("c")?.resolve({ sessionId: "cli-c" });
+    deferredByIssue.get("a")?.resolve({ sessionId: "cli-a" });
+
+    const result = await launched;
+    expect(launch).not.toHaveBeenCalled();
+    expect(result.failedIssueIds).toHaveLength(0);
+    expect(result.createdSessionIds).toEqual(expect.arrayContaining(["cli-a", "cli-b", "cli-c"]));
+    expect(result.createdSessionIds).toHaveLength(3);
+    expect(onItem).toHaveBeenCalledWith("a", expect.objectContaining({ sessionId: "cli-a", status: "done" }));
+    expect(onItem).toHaveBeenCalledWith("b", expect.objectContaining({ sessionId: "cli-b", status: "done" }));
+    expect(onItem).toHaveBeenCalledWith("c", expect.objectContaining({ sessionId: "cli-c", status: "done" }));
+  });
+
   it("launches into an existing lane without creating or rolling one back", async () => {
     const createLane = vi.fn(async () => ({ id: "lane-new" }));
     const launch = vi.fn(async (args: { laneId: string }) => {

--- a/apps/desktop/src/renderer/lib/linearBatchLaunch.test.ts
+++ b/apps/desktop/src/renderer/lib/linearBatchLaunch.test.ts
@@ -329,12 +329,19 @@ describe("runBatchLaunch", () => {
       ["b", createDeferred()],
       ["c", createDeferred()],
     ]);
+    let resolveAllLaunchesStarted!: () => void;
+    const allLaunchesStarted = new Promise<void>((resolve) => {
+      resolveAllLaunchesStarted = resolve;
+    });
     const createLane = vi.fn(async (args: { linearIssue: { id: string } }) => ({ id: `lane-${args.linearIssue.id}` }));
     const launch = vi.fn(async () => ({ id: "chat-sess" }));
     const launchCli = vi.fn(async (args: LaunchCliArgs) => {
       const issueId = args.linearIssues[0]?.id;
       const deferred = issueId ? deferredByIssue.get(issueId) : null;
       if (!deferred) throw new Error(`missing deferred for ${issueId ?? "unknown issue"}`);
+      if (launchCli.mock.calls.length === deferredByIssue.size) {
+        resolveAllLaunchesStarted();
+      }
       return deferred.promise;
     });
     const onItem = vi.fn();
@@ -348,9 +355,7 @@ describe("runBatchLaunch", () => {
       { createLane, launch, launchCli },
       { onItem, concurrency: 3 },
     );
-    for (let i = 0; i < 5 && launchCli.mock.calls.length < 3; i += 1) {
-      await Promise.resolve();
-    }
+    await allLaunchesStarted;
     expect(launchCli).toHaveBeenCalledTimes(3);
 
     deferredByIssue.get("b")?.resolve({ sessionId: "cli-b" });

--- a/docs/features/terminals-and-sessions/pty-and-processes.md
+++ b/docs/features/terminals-and-sessions/pty-and-processes.md
@@ -240,7 +240,10 @@ Each live PTY has an entry in the `ptys` map keyed by `ptyId` with:
     was disposed in the meantime. When `awaitInitialInput` is false, a
     readiness/write failure is logged and the PTY is preserved; ADE no
     longer kills or ends the session just because the first input could
-    not be delivered. Returns `{ ptyId, sessionId, pid }`.
+    not be delivered. When a caller explicitly sets `awaitInitialInput`,
+    readiness/write failure is treated as startup failure: the process
+    tree is terminated and the session is ended as `failed`. Returns
+    `{ ptyId, sessionId, pid }`.
 
 The launch env is built layer by layer: `process.env`, the lane
 runtime env (from `getLaneRuntimeEnv`), the caller's `args.env`, then


### PR DESCRIPTION
## Summary
- Create and return the tracked Agent Chat CLI PTY/session before kickoff input readiness, so Linear multi-agent launches immediately record durable terminal session IDs.
- Keep asynchronous kickoff input delivery for normal launches, while making explicit `awaitInitialInput` failures terminate the PTY and end the session as failed.
- Add regression coverage for concurrent delayed CLI launches and document the explicit awaited-initial-input cleanup behavior.

## Verification
- Verified the issue still applied on latest `origin/main` (`0f2e5518c2d67de8c3a51ad2b846f9f901e79638`) and on this lane before patching.
- Ran `/audit`; fixed the discovered explicit `awaitInitialInput` cleanup gap.
- Ran `/automate`: docs parity updated; iOS, ADE CLI, and TUI parity required no product changes. ADE CLI typecheck/tests passed; focused TUI tests passed.
- Targeted desktop tests passed:
  - `npm --prefix apps/desktop run test -- src/main/services/chat/agentChatCliLaunch.test.ts`
  - `npm --prefix apps/desktop run test -- src/main/services/pty/ptyService.test.ts`
  - `npm --prefix apps/desktop run test -- src/renderer/lib/linearBatchLaunch.test.ts`
- Full `/finalize` local gates passed:
  - `npm install` in `apps/desktop`, `apps/ade-cli`, and `apps/web`
  - `npm --prefix apps/desktop run typecheck`
  - `npm --prefix apps/ade-cli run typecheck`
  - `npm --prefix apps/web run typecheck`
  - `npm --prefix apps/desktop run lint` (0 errors; existing warnings only)
  - desktop Vitest shards 1/8 through 8/8 plus `apps/ade-cli npm test`; shard 4 had a Vitest IPC timeout while running `linearSync.test.ts`, and the targeted rerun passed (`46` tests)
  - `npm --prefix apps/desktop run build`
  - `npm --prefix apps/ade-cli run build`
  - `npm --prefix apps/web run build`
  - `node scripts/validate-docs.mjs`
  - internal docs checks for feature `Source file map` sections and `PRD.md` relative links
  - `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition in Linear multi-agent batch launches where `launchCli` could start an untracked PTY session because the caller waited for CLI input-readiness before returning the durable session record. The fix decouples session creation from CLI readiness by removing `awaitInitialInput` from the `agentChatCliLaunch` path (making kickoff prompt injection fully asynchronous) and adds explicit teardown — SIGTERM + `closeEntry` with `status: "failed"` — for any caller that does explicitly opt in to `awaitInitialInput` and encounters a timeout.

- **`agentChatCliLaunch.ts`**: Drops `awaitInitialInput: true` and the `AGENT_CHAT_CLI_KICKOFF_READY_TIMEOUT_MS` constant so `ptyService.create` resolves as soon as the tracked PTY record is committed, not when the Codex CLI signals readiness.
- **`ptyService.ts`**: The `awaitInitialInput` catch block now calls `terminatePtyProcessTree` + `closeEntry(ptyId, 1)` before re-throwing, ensuring a hidden live process is never left behind when an explicitly-awaited prompt injection fails.
- **Tests**: A new concurrent-launch test uses a deferred-promise pattern for reliable synchronization, and the existing timeout-failure test is extended to assert the new SIGTERM kill and `sessionService.end(failed)` calls.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to decoupling session-record creation from CLI readiness, with no regressions to the non-awaited path.

The removal of awaitInitialInput in agentChatCliLaunch is the exact minimal fix for the untracked-session bug: the durable record is committed before the caller returns, so batch launch state is always consistent. The new teardown path in ptyService is gated behind the awaitInitialInput flag and protected by the existing entry.disposed guard in closeEntry, preventing any double-end of a session.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/chat/agentChatCliLaunch.ts | Removes awaitInitialInput and its timeout constant so ptyService.create returns as soon as the tracked session is created; Codex prompt is now injected asynchronously. |
| apps/desktop/src/main/services/pty/ptyService.ts | Adds explicit cleanup (warn log, SIGTERM process-tree kill, closeEntry with exitCode 1/status failed) when an explicitly-awaited initial input fails; existing entry.disposed guard in closeEntry prevents double-end. |
| apps/desktop/src/main/services/chat/agentChatCliLaunch.test.ts | Test updated to assert that awaitInitialInput and initialInputReadyTimeoutMs are no longer passed, and that sessionId is returned immediately. |
| apps/desktop/src/main/services/pty/ptyService.test.ts | Extends timeout-failure test to assert the new warn log, SIGTERM kill, and sessionService.end(failed) are all triggered when awaitInitialInput times out. |
| apps/desktop/src/renderer/lib/linearBatchLaunch.test.ts | New concurrent-launch test uses a promise-based synchronization (allLaunchesStarted) rather than a polling loop, reliably confirming all three launchCli calls start before resolving deferrals. |
| docs/features/terminals-and-sessions/pty-and-processes.md | Doc update accurately describes the new awaitInitialInput failure behavior (terminate + end as failed) versus the non-awaited path (log and preserve). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant BL as linearBatchLaunch
    participant LC as launchAgentChatCli
    participant PS as ptyService.create
    participant CLI as Codex CLI

    BL->>LC: launchCli(args)
    LC->>PS: create with initialInput and initialInputDelayMs
    Note over PS: Creates durable PTY/session record
    PS-->>LC: ptyId, sessionId, pid
    LC-->>BL: sessionId returned immediately
    Note over BL: Session is tracked and batch state updated

    PS->>CLI: async fire-and-forget writeInitialInput
    alt CLI becomes ready in time
        CLI-->>PS: ready signal
        PS->>CLI: write kickoff prompt
    else awaitInitialInput true and timeout
        PS->>PS: terminatePtyProcessTree SIGTERM
        PS->>PS: closeEntry exitCode 1 status failed
        PS-->>LC: throws error
    else awaitInitialInput false and timeout
        PS->>PS: log warning and preserve session
    end
```

<sub>Reviews (2): Last reviewed commit: ["test: finalize Linear CLI launch coverag..."](https://github.com/arul28/ade/commit/05dec451f9751ca915c6dfd464c85a8f45967f8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35077941)</sub>

<!-- /greptile_comment -->