### PR TITLE
ADE-95: Pulling main from Git actions pane can kill active sessions

### DIFF
--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -996,6 +996,13 @@ export async function createAdeRuntime(args: {
     };
   }
   autoRebaseActivityReady = true;
+  void autoRebaseService
+    .refreshActiveRebaseNeeds("activity_services_ready")
+    .catch((error) => {
+      logger.warn("autoRebase.activity_ready_refresh_failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
   if (resolvedArgs.chatRuntime === "agent" && !agentChatService) {
     throw new Error("Agent chat runtime was requested but the agent chat service was not initialized.");
   }

--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -441,6 +441,7 @@ export async function createAdeRuntime(args: {
     log: (event, fields) => logger.warn(event, fields),
   });
   const laneTeardownDeps: LaneDeleteTeardownDeps = {};
+  let autoRebaseActivityReady = false;
 
   const laneService = createLaneService({
     db,
@@ -673,6 +674,17 @@ export async function createAdeRuntime(args: {
     laneService,
     conflictService,
     projectConfigService,
+    getLaneActivity: (laneId) => {
+      if (!autoRebaseActivityReady) {
+        throw new Error("Session activity services are not ready.");
+      }
+      return {
+        activeChatCount:
+          laneTeardownDeps.agentChatService?.countActiveForLane(laneId) ?? 0,
+        activePtyCount:
+          laneTeardownDeps.ptyService?.countActiveForLane(laneId) ?? 0,
+      };
+    },
     onEvent: (event) => pushEvent("runtime", { type: "lane_auto_rebase_event", event }),
   });
   autoRebaseServiceRef = autoRebaseService;
@@ -983,6 +995,7 @@ export async function createAdeRuntime(args: {
       disposeForLane: (laneId) => agentChatService.disposeForLane(laneId),
     };
   }
+  autoRebaseActivityReady = true;
   if (resolvedArgs.chatRuntime === "agent" && !agentChatService) {
     throw new Error("Agent chat runtime was requested but the agent chat service was not initialized.");
   }

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -2992,6 +2992,13 @@ app.whenReady().then(async () => {
       disposeForLane: (laneId) => agentChatService.disposeForLane(laneId),
     };
     autoRebaseActivityReady = true;
+    void autoRebaseService
+      ?.refreshActiveRebaseNeeds("activity_services_ready")
+      .catch((error) => {
+        logger.warn("autoRebase.activity_ready_refresh_failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
     setImmediate(() => {
       void Promise.resolve()
         .then(() => agentChatService.cleanupStaleAttachments())

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1996,6 +1996,7 @@ app.whenReady().then(async () => {
     };
 
     const laneTeardownDeps: LaneDeleteTeardownDeps = {};
+    let autoRebaseActivityReady = false;
     let macosVmLaunchProviderForProject: MacosVmLaunchProvider | null = null;
     const laneService = createLaneService({
       db,
@@ -2337,6 +2338,17 @@ app.whenReady().then(async () => {
       laneService,
       conflictService,
       projectConfigService,
+      getLaneActivity: (laneId) => {
+        if (!autoRebaseActivityReady) {
+          throw new Error("Session activity services are not ready.");
+        }
+        return {
+          activeChatCount:
+            laneTeardownDeps.agentChatService?.countActiveForLane(laneId) ?? 0,
+          activePtyCount:
+            laneTeardownDeps.ptyService?.countActiveForLane(laneId) ?? 0,
+        };
+      },
       onEvent: (event) =>
         emitProjectEvent(projectRoot, IPC.lanesAutoRebaseEvent, event),
     });
@@ -2979,6 +2991,7 @@ app.whenReady().then(async () => {
       countActiveForLane: (laneId) => agentChatService.countActiveForLane(laneId),
       disposeForLane: (laneId) => agentChatService.disposeForLane(laneId),
     };
+    autoRebaseActivityReady = true;
     setImmediate(() => {
       void Promise.resolve()
         .then(() => agentChatService.cleanupStaleAttachments())

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -2993,7 +2993,7 @@ app.whenReady().then(async () => {
     };
     autoRebaseActivityReady = true;
     void autoRebaseService
-      ?.refreshActiveRebaseNeeds("activity_services_ready")
+      .refreshActiveRebaseNeeds("activity_services_ready")
       .catch((error) => {
         logger.warn("autoRebase.activity_ready_refresh_failed", {
           error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/services/lanes/autoRebaseService.test.ts
+++ b/apps/desktop/src/main/services/lanes/autoRebaseService.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, describe, expect, it, beforeEach, vi } from "vitest";
 import { createAutoRebaseService } from "./autoRebaseService";
 import type { AutoRebaseEventPayload, AutoRebaseLaneStatus, LaneSummary, RebaseNeed } from "../../../shared/types";
+import type * as SharedUtils from "../shared/utils";
 
 vi.mock("../git/git", () => ({
   getHeadSha: vi.fn().mockResolvedValue("abc123"),
 }));
 
 vi.mock("../shared/utils", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../shared/utils")>();
+  const actual = await importOriginal<typeof SharedUtils>();
   return {
     ...actual,
     nowIso: vi.fn(() => "2026-03-25T12:00:00.000Z"),
@@ -104,6 +105,8 @@ describe("autoRebaseService", () => {
   let events: AutoRebaseEventPayload[];
   let laneList: LaneSummary[];
   let rebaseNeedOverrides: Map<string, Partial<RebaseNeed> | null>;
+  let laneActivityById: Map<string, { activeChatCount?: number; activePtyCount?: number }>;
+  let laneActivityFailures: Set<string>;
   let laneService: any;
   let conflictService: any;
   let projectConfigService: any;
@@ -114,6 +117,8 @@ describe("autoRebaseService", () => {
     events = [];
     laneList = [];
     rebaseNeedOverrides = new Map();
+    laneActivityById = new Map();
+    laneActivityFailures = new Set();
 
     const resolveNeed = (laneId: string): RebaseNeed | null => {
       const lane = laneList.find((entry) => entry.id === laneId);
@@ -151,6 +156,10 @@ describe("autoRebaseService", () => {
       laneService,
       conflictService,
       projectConfigService,
+      getLaneActivity: (laneId) => {
+        if (laneActivityFailures.has(laneId)) throw new Error("activity unavailable");
+        return laneActivityById.get(laneId) ?? {};
+      },
       onEvent: (event) => events.push(event),
     });
   }
@@ -1038,6 +1047,132 @@ describe("autoRebaseService", () => {
           reason: "auto_rebase",
         }),
       );
+    });
+
+    it("pauses auto-rebase for a lane with active chat or terminal sessions", async () => {
+      const service = createService();
+      const root = makeLane("root");
+      const child = makeLane("child-1", {
+        parentLaneId: "root",
+        status: { dirty: false, ahead: 0, behind: 1, remoteBehind: 0, rebaseInProgress: false },
+        createdAt: "2026-03-10T01:00:00.000Z",
+      });
+      laneList = [root, child];
+      rebaseNeedOverrides.set("child-1", { behindBy: 4, conflictPredicted: false, conflictingFiles: [] });
+      laneActivityById.set("child-1", { activeChatCount: 1, activePtyCount: 2 });
+
+      await service.onHeadChanged({
+        laneId: "root",
+        preHeadSha: "aaa",
+        postHeadSha: "bbb",
+        reason: "pull_ff_only",
+      });
+
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(laneService.rebaseStart).not.toHaveBeenCalled();
+      expect(laneService.rebasePush).not.toHaveBeenCalled();
+      expect(db.getJson("auto_rebase:status:child-1")).toMatchObject({
+        laneId: "child-1",
+        parentLaneId: "root",
+        parentHeadSha: "abc123",
+        state: "rebasePending",
+        conflictCount: 0,
+        message: expect.stringContaining("Auto-rebase paused"),
+      });
+    });
+
+    it("pauses auto-rebase when session activity lookup fails", async () => {
+      const service = createService();
+      const root = makeLane("root");
+      const child = makeLane("child-1", {
+        parentLaneId: "root",
+        status: { dirty: false, ahead: 0, behind: 1, remoteBehind: 0, rebaseInProgress: false },
+        createdAt: "2026-03-10T01:00:00.000Z",
+      });
+      laneList = [root, child];
+      rebaseNeedOverrides.set("child-1", { behindBy: 3, conflictPredicted: false, conflictingFiles: [] });
+      laneActivityFailures.add("child-1");
+
+      await service.onHeadChanged({
+        laneId: "root",
+        preHeadSha: "aaa",
+        postHeadSha: "bbb",
+        reason: "pull_ff_only",
+      });
+
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(laneService.rebaseStart).not.toHaveBeenCalled();
+      expect(db.getJson("auto_rebase:status:child-1")).toMatchObject({
+        laneId: "child-1",
+        state: "rebasePending",
+        message: expect.stringContaining("could not verify"),
+      });
+    });
+
+    it("ignores malformed or negative activity counts", async () => {
+      const service = createService();
+      const root = makeLane("root");
+      const child = makeLane("child-1", {
+        parentLaneId: "root",
+        status: { dirty: false, ahead: 0, behind: 1, remoteBehind: 0, rebaseInProgress: false },
+        createdAt: "2026-03-10T01:00:00.000Z",
+      });
+      laneList = [root, child];
+      rebaseNeedOverrides.set("child-1", { behindBy: 3, conflictPredicted: false, conflictingFiles: [] });
+      laneActivityById.set("child-1", { activeChatCount: Number.NaN, activePtyCount: -2 });
+
+      await service.onHeadChanged({
+        laneId: "root",
+        preHeadSha: "aaa",
+        postHeadSha: "bbb",
+        reason: "pull_ff_only",
+      });
+
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(laneService.rebaseStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          laneId: "child-1",
+          reason: "auto_rebase",
+        }),
+      );
+    });
+
+    it("marks descendants pending when an ancestor auto-rebase is paused for active sessions", async () => {
+      const service = createService();
+      const root = makeLane("root");
+      const child = makeLane("child-1", {
+        parentLaneId: "root",
+        status: { dirty: false, ahead: 0, behind: 2, remoteBehind: 0, rebaseInProgress: false },
+        createdAt: "2026-03-10T01:00:00.000Z",
+      });
+      const grandchild = makeLane("grandchild-1", {
+        parentLaneId: "child-1",
+        status: { dirty: false, ahead: 0, behind: 1, remoteBehind: 0, rebaseInProgress: false },
+        createdAt: "2026-03-10T02:00:00.000Z",
+      });
+      laneList = [root, child, grandchild];
+      rebaseNeedOverrides.set("child-1", { behindBy: 2, conflictPredicted: false, conflictingFiles: [] });
+      rebaseNeedOverrides.set("grandchild-1", { behindBy: 1, conflictPredicted: false, conflictingFiles: [] });
+      laneActivityById.set("child-1", { activeChatCount: 1 });
+
+      await service.onHeadChanged({
+        laneId: "root",
+        preHeadSha: "aaa",
+        postHeadSha: "bbb",
+        reason: "sync_rebase",
+      });
+
+      await vi.advanceTimersByTimeAsync(1500);
+
+      expect(laneService.rebaseStart).not.toHaveBeenCalled();
+      expect(db.getJson("auto_rebase:status:grandchild-1")).toMatchObject({
+        laneId: "grandchild-1",
+        state: "rebasePending",
+        message: expect.stringContaining("active sessions"),
+      });
     });
 
     it("skips legacy parent links when the lane baseRef no longer matches the parent branch", async () => {

--- a/apps/desktop/src/main/services/lanes/autoRebaseService.ts
+++ b/apps/desktop/src/main/services/lanes/autoRebaseService.ts
@@ -30,6 +30,10 @@ type AttentionStatusInput = {
   message?: string | null;
   source?: "auto" | "manual";
 };
+type LaneActivity = {
+  activeChatCount?: number | null;
+  activePtyCount?: number | null;
+};
 
 export type AutoRebaseService = {
   listStatuses: (options?: ListStatusesOptions) => Promise<AutoRebaseLaneStatus[]>;
@@ -110,11 +114,23 @@ function byCreatedAtAsc(a: LaneSummary, b: LaneSummary): number {
   return a.name.localeCompare(b.name);
 }
 
+function normalizeActivityCount(value: unknown): number {
+  const numeric = Number(value ?? 0);
+  if (!Number.isFinite(numeric) || numeric <= 0) return 0;
+  return Math.floor(numeric);
+}
+
 function blockedMessage(
   laneId: string | null,
-  reason: "conflict" | "manual" | "lookup" | "failed" | "unavailable" | null,
+  reason: "conflict" | "manual" | "lookup" | "failed" | "unavailable" | "active_session" | "activity_lookup" | null,
 ): string {
   if (!laneId) return "Pending: auto-rebase stopped at an earlier lane. Open the Rebase/Merge tab to continue.";
+  if (reason === "active_session") {
+    return `Pending: ancestor lane '${laneId}' has active sessions. Finish, stop, or resume those sessions before rebasing descendants.`;
+  }
+  if (reason === "activity_lookup") {
+    return `Pending: ADE could not verify whether ancestor lane '${laneId}' has active sessions. Open the Rebase/Merge tab to retry manually.`;
+  }
   if (reason === "manual") {
     return `Pending: ancestor lane '${laneId}' has a fixed PR base. Rebase that lane manually from the Rebase/Merge tab before descendants can continue.`;
   }
@@ -158,6 +174,7 @@ export function createAutoRebaseService(args: {
   laneService: ReturnType<typeof createLaneService>;
   conflictService: ReturnType<typeof createConflictService>;
   projectConfigService: ReturnType<typeof createProjectConfigService>;
+  getLaneActivity?: (laneId: string) => LaneActivity | Promise<LaneActivity>;
   onEvent?: (event: AutoRebaseEventPayload) => void;
 }): AutoRebaseService {
   const {
@@ -166,6 +183,7 @@ export function createAutoRebaseService(args: {
     laneService,
     conflictService,
     projectConfigService,
+    getLaneActivity,
     onEvent
   } = args;
 
@@ -225,6 +243,32 @@ export function createAutoRebaseService(args: {
         error: error instanceof Error ? error.message : String(error),
       });
       return null;
+    }
+  };
+
+  const getAutoRebaseActivityBlock = async (laneId: string): Promise<{ reason: "active_session" | "activity_lookup"; message: string } | null> => {
+    if (!getLaneActivity) return null;
+    try {
+      const activity = await getLaneActivity(laneId);
+      const activeChatCount = normalizeActivityCount(activity?.activeChatCount);
+      const activePtyCount = normalizeActivityCount(activity?.activePtyCount);
+      if (activeChatCount <= 0 && activePtyCount <= 0) return null;
+      const parts: string[] = [];
+      if (activeChatCount > 0) parts.push(`${activeChatCount} active ${activeChatCount === 1 ? "chat" : "chats"}`);
+      if (activePtyCount > 0) parts.push(`${activePtyCount} active ${activePtyCount === 1 ? "terminal session" : "terminal sessions"}`);
+      return {
+        reason: "active_session",
+        message: `Auto-rebase paused: ${parts.join(" and ")} in this lane. Rebase manually from the Rebase/Merge tab when those sessions are stopped or safely resumable.`,
+      };
+    } catch (error) {
+      logger.warn("autoRebase.activity_lookup_failed", {
+        laneId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        reason: "activity_lookup",
+        message: "Auto-rebase paused: ADE could not verify whether this lane has active sessions. Open the Rebase/Merge tab to retry manually.",
+      };
     }
   };
 
@@ -459,7 +503,7 @@ export function createAutoRebaseService(args: {
 
     let blocked = false;
     let blockedLaneId: string | null = null;
-    let blockedReason: "conflict" | "manual" | "lookup" | "failed" | "unavailable" | null = null;
+    let blockedReason: "conflict" | "manual" | "lookup" | "failed" | "unavailable" | "active_session" | "activity_lookup" | null = null;
     let blockedByLookupFailure = false;
     for (const laneId of cascadeOrder) {
       lanes = await laneService.list({ includeArchived: false });
@@ -567,6 +611,23 @@ export function createAutoRebaseService(args: {
           state: "rebasePending",
           conflictCount: 0,
           message: "PR carries an immutable base — drift detected. Rebase manually from the Rebase/Merge tab when ready."
+        });
+        continue;
+      }
+
+      const activityBlock = await getAutoRebaseActivityBlock(lane.id);
+      if (disposed) return;
+      if (activityBlock) {
+        blocked = true;
+        blockedLaneId = lane.id;
+        blockedReason = activityBlock.reason;
+        setStatus({
+          laneId: lane.id,
+          parentLaneId: parent?.id ?? null,
+          parentHeadSha,
+          state: "rebasePending",
+          conflictCount: 0,
+          message: activityBlock.message
         });
         continue;
       }


### PR DESCRIPTION
Fixes ADE-95
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:linear-links v=1 -->
### Linked Linear issues

- [ADE-95: Pulling main from Git actions pane can kill active sessions](https://linear.app/ade-linear/issue/ADE-95/pulling-main-from-git-actions-pane-can-kill-active-sessions) - closes on merge
<!-- /ade:linear-links -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade-95-pulling-main-from-git-actions-pane-can-kill-active-sessions num=511 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade-95-pulling-main-from-git-actions-pane-can-kill-active-sessions&amp;pr=511">ade-95-pulling-main-from-git-actions-pane-can-kill-active-sessions branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=511">PR #511</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-rebase now pauses when lanes have active chat or terminal sessions, preventing operations during user interaction.
  * Auto-rebase blocks descendant lanes when ancestor lanes have active sessions.
  * Added fallback handling for activity status verification failures.

* **Tests**
  * Added test coverage for auto-rebase session-activity gating and blocking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates the auto-rebase cascade on active chat and terminal session counts, preventing a git pull from silently rebasing a lane while a user is interacting with it. When sessions are present, the lane is set to `rebasePending` with an informational message, and all descendants are similarly blocked.

- **`autoRebaseService.ts`**: Adds `getLaneActivity` hook (optional), `normalizeActivityCount` helper, and `getAutoRebaseActivityBlock` to pause or surface lookup errors; both new `blockedMessage` reasons (`active_session`, `activity_lookup`) propagate the block to descendant lanes.
- **`bootstrap.ts` / `main.ts`**: Wire the activity providers behind an `autoRebaseActivityReady` flag, then call `refreshActiveRebaseNeeds(\"activity_services_ready\")` to re-evaluate any lanes that were gated during startup.
- **Tests**: Four new scenarios cover session-present blocking, lookup failures, malformed/negative counts, and multi-level ancestor propagation.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge; new session-activity gating is additive and the service falls back gracefully when the activity provider is absent or throws.

The activity-gating logic is well-isolated behind an optional callback, error paths are caught and converted to a safe pending state rather than allowing an unguarded rebase, edge-case inputs (NaN, negative counts) are normalised correctly, and four targeted test cases verify each new code path. No data loss or incorrect rebase can result from this change.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/lanes/autoRebaseService.ts | Core logic for session-activity gating; normalizeActivityCount correctly handles NaN/negative/float inputs; blockedMessage extended with two new reasons used for descendant propagation; getAutoRebaseActivityBlock is well-guarded with error fallback. |
| apps/desktop/src/main/services/lanes/autoRebaseService.test.ts | Four new test cases cover active-session pause, lookup failure, malformed counts (NaN/-2), and ancestor-to-descendant propagation; assertions match expected message substrings correctly. |
| apps/desktop/src/main/main.ts | getLaneActivity wired with autoRebaseActivityReady guard; refreshActiveRebaseNeeds called after flag is set; optional chaining on laneTeardownDeps providers is safe as ?? 0 handles the undefined case. |
| apps/ade-cli/src/bootstrap.ts | Mirrors main.ts wiring with the same autoRebaseActivityReady flag and post-ready refresh; consistent with desktop implementation. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[onHeadChanged / refreshActiveRebaseNeeds] --> B[processRoot: build cascadeOrder]
    B --> C{For each lane in cascade}
    C --> D{blocked flag set?}
    D -- Yes --> E[setStatus rebasePending\nblockedMessage ancestor reason]
    D -- No --> F{rebaseMode === manual?}
    F -- Yes --> G[blocked=true, reason=manual]
    G --> C
    F -- No --> H{getLaneActivity provided?}
    H -- No --> K[proceed to rebase]
    H -- Yes --> I[getAutoRebaseActivityBlock]
    I --> J{activity lookup}
    J -- Throws --> L[blocked=true\nreason=activity_lookup\n'could not verify']
    J -- activeSessions > 0 --> M[blocked=true\nreason=active_session\n'Auto-rebase paused']
    J -- No sessions --> K
    L --> C
    M --> C
    K --> N[laneService.rebaseStart]
    N --> O{Error?}
    O -- Yes --> P[blocked=true\nconflict or failed]
    O -- No --> Q[laneService.rebasePush → autoRebased]
    P --> C
    Q --> C
```

<sub>Reviews (4): Last reviewed commit: ["Refs ADE-95: Fix activity refresh promis..."](https://github.com/arul28/ade/commit/f714d15099f493ddfc9d3742962f0ac17c811bf9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35078087)</sub>

<!-- /greptile_comment -->