### PR TITLE
Fix iOS Simulator live view window capture context

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -6081,6 +6081,8 @@ app.whenReady().then(async () => {
     runWithIpcWindow: (event, fn) =>
       ipcWindowScope.run(BrowserWindow.fromWebContents(event.sender)?.id ?? null, fn),
     getWindowSession,
+    getProjectContext: (projectRoot) =>
+      projectContexts.get(normalizeProjectRoot(projectRoot)) ?? null,
     setWindowProjectTabs: rememberWindowProjectTabs,
     bindRemoteProject: bindWindowToRemoteProject,
     localRuntimeConnectionPool: shouldUseInProcessProjectRuntime()

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -1981,28 +1981,38 @@ export function registerIpc({
     return typeof value === "string" && value.trim() ? value.trim() : null;
   };
   const getIosSimulatorContextForEvent = (event: IpcMainInvokeEvent, arg?: unknown): AppContext | null => {
-    const explicitRoot = readProjectRootArg(arg);
-    if (explicitRoot) return getProjectContext?.(explicitRoot) ?? null;
     const windowId = BrowserWindow.fromWebContents(event.sender)?.id ?? null;
     const session = getWindowSession?.(windowId) ?? null;
-    const sessionRoot = session?.binding?.kind === "local"
+    const boundLocalRoot = session?.binding?.kind === "local"
       ? session.binding.rootPath
-      : session?.project?.rootPath ?? null;
-    if (sessionRoot) return getProjectContext?.(sessionRoot) ?? null;
+      : null;
+    const explicitRoot = readProjectRootArg(arg);
+    const resolveProjectContext = (projectRoot: string) =>
+      getProjectContext ? getProjectContext(projectRoot) ?? null : getCtx();
+    if (explicitRoot) {
+      if (!boundLocalRoot || explicitRoot !== boundLocalRoot) {
+        throw new Error("iOS Simulator access is only allowed for the window's bound local project.");
+      }
+      return resolveProjectContext(explicitRoot);
+    }
+    const sessionRoot = boundLocalRoot ?? session?.project?.rootPath ?? null;
+    if (sessionRoot) return resolveProjectContext(sessionRoot);
     return getCtx();
   };
   const ensureIosSimulatorForEvent = (
     event: IpcMainInvokeEvent,
     arg?: unknown,
+    channel = IPC.iosSimulatorListWindowSources,
   ): NonNullable<AppContext["iosSimulatorService"]> => {
     const ctx = getIosSimulatorContextForEvent(event, arg);
     const service = ctx?.iosSimulatorService;
     if (!service) {
-      const projectRoot = readProjectRootArg(arg) ?? ctx?.project?.rootPath ?? null;
+      const requestedProjectRoot = readProjectRootArg(arg);
+      const projectRoot = requestedProjectRoot ?? ctx?.project?.rootPath ?? null;
       const logger = ctx?.logger ?? getCtx().logger;
       logger.warn("ios_simulator.service_unavailable", {
-        channel: IPC.iosSimulatorListWindowSources,
-        requestedProjectRoot: readProjectRootArg(arg),
+        channel,
+        requestedProjectRoot,
         contextProjectRoot: ctx?.project?.rootPath ?? null,
         hasUserSelectedProject: ctx?.hasUserSelectedProject ?? false,
       });
@@ -7054,7 +7064,7 @@ export function registerIpc({
   ipcMain.handle(IPC.iosSimulatorGetWindowState, async () => getSimulatorWindowState());
 
   ipcMain.handle(IPC.iosSimulatorListWindowSources, async (event, arg = {}) => {
-    const status = await ensureIosSimulatorForEvent(event, arg).getStatus();
+    const status = await ensureIosSimulatorForEvent(event, arg, IPC.iosSimulatorListWindowSources).getStatus();
     if (!status.supported) return [];
     const readSources = async () => desktopCapturer.getSources({
       types: ["window"],

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -1548,6 +1548,7 @@ export function registerIpc({
   resolveSyncService,
   runWithIpcWindow,
   getWindowSession,
+  getProjectContext,
   setWindowProjectTabs,
   bindRemoteProject,
   localRuntimeConnectionPool,
@@ -1565,6 +1566,7 @@ export function registerIpc({
   resolveSyncService?: () => Promise<ReturnType<typeof createSyncService> | null | undefined>;
   runWithIpcWindow?: <T>(event: { sender: Electron.WebContents }, fn: () => T | Promise<T>) => T | Promise<T>;
   getWindowSession?: (windowId: number | null) => { windowId: number | null; project: ProjectInfo | null; binding: OpenProjectBinding | null; openProjectTabs?: ProjectInfo[]; pendingLocalProjectRoots?: string[] };
+  getProjectContext?: (projectRoot: string) => AppContext | null | undefined;
   setWindowProjectTabs?: (windowId: number | null, rootPaths: string[]) => ProjectInfo[];
   bindRemoteProject?: (windowId: number | null, binding: OpenProjectBinding & { kind: "remote" }) => void;
   localRuntimeConnectionPool?: LocalRuntimeConnectionPool | null;
@@ -1970,6 +1972,45 @@ export function registerIpc({
     const service = getCtx().iosSimulatorService;
     if (!service) {
       throw new Error("iOS Simulator service is not available.");
+    }
+    return service;
+  };
+  const readProjectRootArg = (arg: unknown): string | null => {
+    if (!arg || typeof arg !== "object" || Array.isArray(arg)) return null;
+    const value = (arg as { projectRoot?: unknown }).projectRoot;
+    return typeof value === "string" && value.trim() ? value.trim() : null;
+  };
+  const getIosSimulatorContextForEvent = (event: IpcMainInvokeEvent, arg?: unknown): AppContext | null => {
+    const explicitRoot = readProjectRootArg(arg);
+    if (explicitRoot) return getProjectContext?.(explicitRoot) ?? null;
+    const windowId = BrowserWindow.fromWebContents(event.sender)?.id ?? null;
+    const session = getWindowSession?.(windowId) ?? null;
+    const sessionRoot = session?.binding?.kind === "local"
+      ? session.binding.rootPath
+      : session?.project?.rootPath ?? null;
+    if (sessionRoot) return getProjectContext?.(sessionRoot) ?? null;
+    return getCtx();
+  };
+  const ensureIosSimulatorForEvent = (
+    event: IpcMainInvokeEvent,
+    arg?: unknown,
+  ): NonNullable<AppContext["iosSimulatorService"]> => {
+    const ctx = getIosSimulatorContextForEvent(event, arg);
+    const service = ctx?.iosSimulatorService;
+    if (!service) {
+      const projectRoot = readProjectRootArg(arg) ?? ctx?.project?.rootPath ?? null;
+      const logger = ctx?.logger ?? getCtx().logger;
+      logger.warn("ios_simulator.service_unavailable", {
+        channel: IPC.iosSimulatorListWindowSources,
+        requestedProjectRoot: readProjectRootArg(arg),
+        contextProjectRoot: ctx?.project?.rootPath ?? null,
+        hasUserSelectedProject: ctx?.hasUserSelectedProject ?? false,
+      });
+      throw new Error(
+        projectRoot
+          ? `iOS Simulator service is not available for ${projectRoot}.`
+          : "iOS Simulator service is not available because no local project is bound to this window.",
+      );
     }
     return service;
   };
@@ -7012,8 +7053,8 @@ export function registerIpc({
 
   ipcMain.handle(IPC.iosSimulatorGetWindowState, async () => getSimulatorWindowState());
 
-  ipcMain.handle(IPC.iosSimulatorListWindowSources, async (event) => {
-    const status = await ensureIosSimulator().getStatus();
+  ipcMain.handle(IPC.iosSimulatorListWindowSources, async (event, arg = {}) => {
+    const status = await ensureIosSimulatorForEvent(event, arg).getStatus();
     if (!status.supported) return [];
     const readSources = async () => desktopCapturer.getSources({
       types: ["window"],

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
@@ -838,6 +838,114 @@ describe("registerIpc sync bridge", () => {
     vi.useRealTimers();
   });
 
+  it("uses the sender window's bound local project for iOS Simulator window sources", async () => {
+    const repoGetStatus = vi.fn(async () => ({ supported: false }));
+    const otherGetStatus = vi.fn(async () => ({ supported: false }));
+    const contexts = new Map<string, any>([
+      ["/repo", {
+        project: { rootPath: "/repo" },
+        logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+        iosSimulatorService: { getStatus: repoGetStatus },
+      }],
+      ["/other", {
+        project: { rootPath: "/other" },
+        logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+        iosSimulatorService: { getStatus: otherGetStatus },
+      }],
+    ]);
+    const getProjectContext = vi.fn((root: string) => contexts.get(root) ?? null);
+    registerIpc({
+      getCtx: () => ({
+        project: { rootPath: "/fallback" },
+        logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+        iosSimulatorService: { getStatus: vi.fn(async () => ({ supported: false })) },
+      }) as any,
+      getWindowSession: () => ({
+        windowId: 7,
+        project: { rootPath: "/repo", displayName: "Repo" } as any,
+        binding: localBinding("/repo"),
+      }),
+      getProjectContext,
+      switchProjectFromDialog: vi.fn(),
+      closeCurrentProject: vi.fn(),
+      closeProjectByPath: vi.fn(),
+      globalStatePath: "/tmp/ade-state.json",
+    });
+
+    await expect(
+      ipcHandlers.get(IPC.iosSimulatorListWindowSources)?.(
+        eventForSender(),
+        { projectRoot: "/repo" },
+      ),
+    ).resolves.toEqual([]);
+
+    expect(getProjectContext).toHaveBeenCalledWith("/repo");
+    expect(repoGetStatus).toHaveBeenCalledTimes(1);
+    expect(otherGetStatus).not.toHaveBeenCalled();
+  });
+
+  it("rejects iOS Simulator window-source requests for an unbound project root", async () => {
+    const getProjectContext = vi.fn(() => ({
+      project: { rootPath: "/other" },
+      logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+      iosSimulatorService: { getStatus: vi.fn(async () => ({ supported: false })) },
+    }) as any);
+    registerIpc({
+      getCtx: () => ({
+        project: { rootPath: "/fallback" },
+        logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+      }) as any,
+      getWindowSession: () => ({
+        windowId: 7,
+        project: { rootPath: "/repo", displayName: "Repo" } as any,
+        binding: localBinding("/repo"),
+      }),
+      getProjectContext,
+      switchProjectFromDialog: vi.fn(),
+      closeCurrentProject: vi.fn(),
+      closeProjectByPath: vi.fn(),
+      globalStatePath: "/tmp/ade-state.json",
+    });
+
+    await expect(
+      ipcHandlers.get(IPC.iosSimulatorListWindowSources)?.(
+        eventForSender(),
+        { projectRoot: "/other" },
+      ),
+    ).rejects.toThrow("bound local project");
+
+    expect(getProjectContext).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the active context for matching iOS Simulator roots when no project context lookup is registered", async () => {
+    const getStatus = vi.fn(async () => ({ supported: false }));
+    registerIpc({
+      getCtx: () => ({
+        project: { rootPath: "/repo" },
+        logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+        iosSimulatorService: { getStatus },
+      }) as any,
+      getWindowSession: () => ({
+        windowId: 7,
+        project: { rootPath: "/repo", displayName: "Repo" } as any,
+        binding: localBinding("/repo"),
+      }),
+      switchProjectFromDialog: vi.fn(),
+      closeCurrentProject: vi.fn(),
+      closeProjectByPath: vi.fn(),
+      globalStatePath: "/tmp/ade-state.json",
+    });
+
+    await expect(
+      ipcHandlers.get(IPC.iosSimulatorListWindowSources)?.(
+        eventForSender(),
+        { projectRoot: "/repo" },
+      ),
+    ).resolves.toEqual([]);
+
+    expect(getStatus).toHaveBeenCalledTimes(1);
+  });
+
   it("surfaces missing sync service for active lane presence when no runtime pool is bound", async () => {
     const resolveSyncService = vi.fn(async () => null);
     registerIpc({

--- a/apps/desktop/src/preload/preload.test.ts
+++ b/apps/desktop/src/preload/preload.test.ts
@@ -419,6 +419,83 @@ describe("preload OAuth bridge", () => {
     expect(invoke).not.toHaveBeenCalledWith(IPC.iosSimulatorListWindowSources);
   });
 
+  it("rejects iOS Simulator window sources when no local project is bound", async () => {
+    const invoke = vi.fn(async (channel: string, _payload?: unknown) => {
+      if (channel === IPC.appGetWindowSession) {
+        return { windowId: 1, project: null, binding: null };
+      }
+      throw new Error(`unexpected IPC: ${channel}`);
+    });
+    const on = vi.fn();
+    const removeListener = vi.fn();
+    const exposeInMainWorld = vi.fn((name: string, value: unknown) => {
+      (globalThis as any).__bridgeName = name;
+      (globalThis as any).__adeBridge = value;
+    });
+
+    vi.doMock("electron", () => ({
+      contextBridge: { exposeInMainWorld },
+      ipcRenderer: { invoke, on, removeListener },
+      webFrame: {
+        getZoomLevel: vi.fn(() => 0),
+        setZoomLevel: vi.fn(),
+        getZoomFactor: vi.fn(() => 1),
+      },
+    }));
+
+    await import("./preload");
+
+    const bridge = (globalThis as any).__adeBridge;
+    await expect(bridge.iosSimulator.listSimulatorWindowSources()).rejects.toThrow(/open local project/i);
+
+    expect(invoke).toHaveBeenCalledWith(IPC.appGetWindowSession);
+    expect(invoke).not.toHaveBeenCalledWith(IPC.iosSimulatorListWindowSources, expect.anything());
+  });
+
+  it("passes the bound local project root when reading iOS Simulator window sources", async () => {
+    const binding = {
+      kind: "local",
+      key: "local:/repo",
+      rootPath: "/repo",
+      displayName: "Project",
+    };
+    const sources = [{ id: "window:1", name: "Simulator", thumbnailDataUrl: null }];
+    const invoke = vi.fn(async (channel: string, payload?: unknown) => {
+      if (channel === IPC.appGetWindowSession) {
+        return { windowId: 1, project: { rootPath: "/repo", displayName: "Project" }, binding };
+      }
+      if (channel === IPC.iosSimulatorListWindowSources) {
+        expect(payload).toEqual({ projectRoot: "/repo" });
+        return sources;
+      }
+      throw new Error(`unexpected IPC: ${channel} ${JSON.stringify(payload)}`);
+    });
+    const on = vi.fn();
+    const removeListener = vi.fn();
+    const exposeInMainWorld = vi.fn((name: string, value: unknown) => {
+      (globalThis as any).__bridgeName = name;
+      (globalThis as any).__adeBridge = value;
+    });
+
+    vi.doMock("electron", () => ({
+      contextBridge: { exposeInMainWorld },
+      ipcRenderer: { invoke, on, removeListener },
+      webFrame: {
+        getZoomLevel: vi.fn(() => 0),
+        setZoomLevel: vi.fn(),
+        getZoomFactor: vi.fn(() => 1),
+      },
+    }));
+
+    await import("./preload");
+
+    const bridge = (globalThis as any).__adeBridge;
+    await expect(bridge.iosSimulator.listSimulatorWindowSources()).resolves.toEqual(sources);
+
+    expect(invoke).toHaveBeenCalledWith(IPC.appGetWindowSession);
+    expect(invoke).toHaveBeenCalledWith(IPC.iosSimulatorListWindowSources, { projectRoot: "/repo" });
+  });
+
   it("routes local macOS VM deletion through direct IPC when a local project runtime is bound", async () => {
     const binding = {
       kind: "local",

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1099,6 +1099,18 @@ async function assertLocalProjectHostAction(action: string): Promise<void> {
   throw new Error(`${action} is only available on the local project host.`);
 }
 
+async function requireLocalProjectHostBinding(action: string): Promise<Extract<
+  OpenProjectBinding,
+  { kind: "local" }
+>> {
+  const binding = await getProjectRuntimeBinding({ fresh: true });
+  if (binding?.kind === "local") return binding;
+  if (binding?.kind === "remote") {
+    throw new Error(`${action} is only available on the local project host.`);
+  }
+  throw new Error(`${action} requires an open local project.`);
+}
+
 async function callRemoteProjectActionIfBound<T>(
   domain: string,
   action: string,
@@ -5445,8 +5457,10 @@ contextBridge.exposeInMainWorld("ade", {
     listSimulatorWindowSources: async (): Promise<
       IosSimulatorWindowSource[]
     > => {
-      await assertLocalProjectHostAction("iOS Simulator window sources");
-      return ipcRenderer.invoke(IPC.iosSimulatorListWindowSources);
+      const binding = await requireLocalProjectHostBinding("iOS Simulator window sources");
+      return ipcRenderer.invoke(IPC.iosSimulatorListWindowSources, {
+        projectRoot: binding.rootPath,
+      });
     },
     tap: async (args: {
       deviceUdid?: string | null;

--- a/docs/features/ios-simulator/README.md
+++ b/docs/features/ios-simulator/README.md
@@ -56,7 +56,9 @@ force shutdown is requested.
    `simulator-window-capture`; there is no separate ADE-managed streaming
    backend. The service records running status and opens Simulator.app with
    `open -g -a Simulator`. The renderer asks IPC for capturable Simulator window
-   sources and attaches a desktop-capture stream to a `<video>`.
+   sources, passing the bound local project root so Electron-only window capture
+   uses the same project context as the runtime stream state, then attaches a
+   desktop-capture stream to a `<video>`.
 
 5. **Window parking.** `prepareSimulatorWindowForCapture()` opens Simulator.app,
    unhides/unminimizes its windows, sizes the simulator window, and places it


### PR DESCRIPTION
## Summary
- Bind Simulator window-source capture requests to the renderer's current local project root.
- Resolve the main-process iOS Simulator service from that project context instead of an unrelated active context.
- Add preload coverage for missing local bindings and bound local roots, plus docs for the live-view path.

## Verification
- npm --prefix apps/desktop run typecheck
- npm --prefix apps/ade-cli run typecheck
- npm --prefix apps/web run typecheck
- npm --prefix apps/desktop run lint
- Desktop sharded sweep attempted; load-related failures were isolated and passing in targeted reruns.
- npm --prefix apps/desktop exec vitest run src/preload/preload.test.ts
- npx vitest run src/main/services/localRuntime/localRuntimeConnectionPool.test.ts (from apps/desktop)
- npx vitest run src/renderer/components/files/FilesPage.test.tsx (from apps/desktop)
- npx vitest run src/renderer/components/app/App.workKeepAlive.test.tsx (from apps/desktop)
- npx vitest run src/main/services/cto/ctoWorkerLifecycle.test.ts (from apps/desktop)
- npx vitest run src/main/services/cto/linearSync.test.ts (from apps/desktop)
- ADE CLI targeted reruns: TerminalPane, appPolling, statusline, credentialStore, stdioRpcDaemon
- npm run build (apps/desktop, apps/ade-cli, apps/web)
- node scripts/validate-docs.mjs
- Internal docs source-map and PRD-link checks
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Renderers can now query whether a project context is loaded in the main process.

* **Bug Fixes**
  * Improved error handling and clearer messages for iOS Simulator operations when project context is unavailable.
  * Stronger validation to ensure local project bindings are established before iOS Simulator actions.

* **Tests**
  * Added tests covering iOS Simulator behavior with and without local project bindings and context lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a context-routing bug where iOS Simulator live-view window capture could accidentally resolve its service from the wrong (globally active) project context. The renderer now reads the bound local project root before sending the IPC request, and the main process validates that the requested root matches the window's session binding before looking up the correct `AppContext`.

- **`registerIpc.ts`**: Introduces `getIosSimulatorContextForEvent` and `ensureIosSimulatorForEvent` helpers that resolve the iOS Simulator service from the project context that matches the window's bound local root, replacing the unguarded `ensureIosSimulator()` / `getCtx()` call.
- **`preload.ts`**: Replaces `assertLocalProjectHostAction` (which silently passed when no binding existed) with `requireLocalProjectHostBinding`, which also rejects when the window has no local project open at all, and passes the binding's `rootPath` as an explicit argument in the IPC payload.
- **Tests**: New tests in both `runtimeBridge.test.ts` and `preload.test.ts` cover the happy path, the unbound-root rejection, and the fallback to the active context when `getProjectContext` is not registered.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change tightens context isolation for iOS Simulator IPC without touching unrelated code paths.

The fix is well-scoped: a narrow security boundary added in both the preload (reject no-binding / remote-binding before the IPC call) and the main process (validate the explicit root against the window's session binding, then resolve the right AppContext). The fallback to getCtx() when getProjectContext is absent is intentional and tested. New tests cover the happy path, the unbound rejection, and the legacy fallback.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/ipc/registerIpc.ts | Adds getIosSimulatorContextForEvent and ensureIosSimulatorForEvent helpers; updates iosSimulatorListWindowSources handler to use context-aware project resolution instead of global getCtx(). Logic is sound; security boundary correctly enforced. |
| apps/desktop/src/preload/preload.ts | Adds requireLocalProjectHostBinding, which correctly rejects no-binding and remote-binding cases; passes binding.rootPath in the IPC payload. Stricter than the old assertLocalProjectHostAction which silently allowed calls when no binding existed. |
| apps/desktop/src/main/main.ts | Adds getProjectContext callback to the registerIpc call, looking up AppContext from projectContexts via normalizeProjectRoot(path.resolve). Small, correct change. |
| apps/desktop/src/main/services/ipc/runtimeBridge.test.ts | Three new test cases covering: correct context routing by bound project root, rejection of mismatched project roots, and getCtx() fallback when getProjectContext is unregistered. Good coverage. |
| apps/desktop/src/preload/preload.test.ts | Two new preload tests verifying no-binding rejection and correct projectRoot forwarding in the IPC payload. Uses existing vi.resetModules() pattern correctly. |
| docs/features/ios-simulator/README.md | Minor doc update describing that the renderer now passes the bound local project root with the window-source IPC request. Accurate and concise. |

</details>

<sub>Reviews (6): Last reviewed commit: ["ci: rerun desktop shard"](https://github.com/arul28/ade/commit/2a35b2c9f7d228de5cf70f4998dc683a1cf8ce42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35222615)</sub>

<!-- /greptile_comment -->