### PR TITLE
Browser Project Tab Isolation

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1334,7 +1334,7 @@ app.whenReady().then(async () => {
   ): void => {
     const win = windowId == null ? null : BrowserWindow.fromId(windowId);
     if (!win || win.isDestroyed()) return;
-    setWindowTitle(win, projectWindowTitle(project));
+    setWindowTitle(win, projectWindowTitle(project, bindingForLocalProject(project)));
     try {
       win.webContents.send(IPC.appProjectChanged, project);
     } catch {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1126,12 +1126,6 @@ app.whenReady().then(async () => {
       );
       if (!selection) return null;
       const targetWindow = candidateWindows.find((win) => win.id === selection.windowId) ?? null;
-      if (targetWindow && selection.activateProjectRoot) {
-        bindWindowToProject(targetWindow.id, normalizedRoot, {
-          emit: true,
-          foreground: false,
-        });
-      }
       return targetWindow;
     },
     onEvent: (payload, targetWindow) => {
@@ -1240,6 +1234,22 @@ app.whenReady().then(async () => {
     return projectContexts.get(projectRoot)?.project ?? null;
   };
 
+  const projectWindowTitle = (project: ProjectInfo | null, binding?: OpenProjectBinding | null): string => {
+    const label =
+      binding?.displayName
+      ?? project?.displayName
+      ?? (project?.rootPath ? path.basename(project.rootPath) : null);
+    return label ? `${label} - ADE` : "ADE";
+  };
+
+  const setWindowTitle = (win: BrowserWindow, title: string): void => {
+    try {
+      win.setTitle(title);
+    } catch {
+      // ignore stale window/title races
+    }
+  };
+
   const projectsForWindowTabs = (windowId: number | null): ProjectInfo[] => {
     if (windowId == null) return [];
     const roots = windowProjectTabRoots.get(windowId) ?? new Set<string>();
@@ -1324,6 +1334,7 @@ app.whenReady().then(async () => {
   ): void => {
     const win = windowId == null ? null : BrowserWindow.fromId(windowId);
     if (!win || win.isDestroyed()) return;
+    setWindowTitle(win, projectWindowTitle(project));
     try {
       win.webContents.send(IPC.appProjectChanged, project);
     } catch {
@@ -1337,6 +1348,9 @@ app.whenReady().then(async () => {
   ): void => {
     const win = windowId == null ? null : BrowserWindow.fromId(windowId);
     if (!win || win.isDestroyed()) return;
+    if (binding?.kind === "remote") {
+      setWindowTitle(win, projectWindowTitle(null, binding));
+    }
     try {
       win.webContents.send(IPC.appProjectBindingChanged, binding);
     } catch {

--- a/apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.test.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.test.ts
@@ -670,6 +670,39 @@ describe("createBuiltInBrowserService — bounds and status dedupe", () => {
     expect(service.getStatus(browserWin).url).toBe("https://beta.example.test/");
   });
 
+  it("routes project-scoped calls to an inactive project tab without activating the window project", async () => {
+    const projectRootByWindow = new Map<number, string>();
+    const windowsByProjectRoot = new Map<string, ReturnType<typeof fakeBrowserWindow>>();
+    const service = createBuiltInBrowserService({
+      onEvent: collector.onEvent,
+      getProjectRootForWindow: (win) => projectRootByWindow.get(win.id) ?? null,
+      getWindowForProjectRoot: (projectRoot) =>
+        (
+          windowsByProjectRoot.get(projectRoot) as unknown as
+            Parameters<ReturnType<typeof createBuiltInBrowserService>["attachToWindow"]>[0] | undefined
+        ) ?? null,
+    });
+    const win = fakeBrowserWindow();
+    projectRootByWindow.set(win.id, "/Users/ade/project-beta");
+    windowsByProjectRoot.set("/Users/ade/project-alpha", win);
+    windowsByProjectRoot.set("/Users/ade/project-beta", win);
+    const browserWin = win as unknown as Parameters<typeof service.attachToWindow>[0];
+
+    service.attachToWindow(browserWin);
+    await service.createTab({ url: "https://beta.example.test", activate: true }, browserWin);
+    await service.navigate({
+      projectRoot: "/Users/ade/project-alpha",
+      url: "https://alpha.example.test",
+      newTab: true,
+    });
+
+    expect(projectRootByWindow.get(win.id)).toBe("/Users/ade/project-beta");
+    expect(service.getStatus(browserWin).profileProjectRoot).toBe("/Users/ade/project-beta");
+    expect(service.getStatus(browserWin).url).toBe("https://beta.example.test/");
+    expect(service.getStatus({ projectRoot: "/Users/ade/project-alpha" }).profileProjectRoot).toBe("/Users/ade/project-alpha");
+    expect(service.getStatus({ projectRoot: "/Users/ade/project-alpha" }).url).toBe("https://alpha.example.test/");
+  });
+
   it("re-resolves the active window profile for bridge-style calls after project switches", async () => {
     const projectRootByWindow = new Map<number, string>();
     const service = createBuiltInBrowserService({

--- a/apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.ts
@@ -276,7 +276,7 @@ export function createBuiltInBrowserService(args: {
     const normalized = normalizedProjectRoot(projectRoot);
     if (!normalized) return null;
     const resolved = args.getWindowForProjectRoot?.(normalized) ?? null;
-    if (isLiveWindow(resolved) && projectRootsMatch(projectRootForWindow(resolved), normalized)) {
+    if (isLiveWindow(resolved)) {
       return resolved;
     }
     for (const { win } of windowClosedListeners.values()) {
@@ -313,12 +313,17 @@ export function createBuiltInBrowserService(args: {
     win.once("closed", listener);
   };
 
-  const serviceForWindow = (win: BrowserWindow): WindowBrowserService => {
-    const profile = profileForWindow(win);
+  const serviceForWindowProfile = (
+    win: BrowserWindow,
+    profile: BrowserProfile,
+    options: { markActive?: boolean } = {},
+  ): WindowBrowserService => {
     const key = serviceKey(win.id, profile);
     const existing = windowServices.get(key);
-    activeServiceKeyByWindow.set(win.id, key);
-    detachInactiveWindowServices(win, key);
+    if (options.markActive) {
+      activeServiceKeyByWindow.set(win.id, key);
+      detachInactiveWindowServices(win, key);
+    }
     if (existing) return existing.service;
 
     fallbackService?.dispose();
@@ -328,6 +333,9 @@ export function createBuiltInBrowserService(args: {
     windowServices.set(key, { win, service });
     return service;
   };
+
+  const serviceForWindow = (win: BrowserWindow): WindowBrowserService =>
+    serviceForWindowProfile(win, profileForWindow(win), { markActive: true });
 
   const activeService = (): WindowBrowserService => {
     if (activeWindowId != null) {
@@ -364,33 +372,33 @@ export function createBuiltInBrowserService(args: {
     if (!win) {
       throw new Error(`No ADE browser window is open for project: ${normalized}`);
     }
-    return serviceForWindow(win);
+    return serviceForWindowProfile(win, profileForProjectRoot(normalized), {
+      markActive: projectRootsMatch(projectRootForWindow(win), normalized),
+    });
   };
 
   const serviceForInput = (
     input?: BuiltInBrowserProjectScopeArgs | null,
     sourceWindow?: BrowserWindow | null,
   ): WindowBrowserService => {
-    if (isLiveWindow(sourceWindow)) return serviceForWindow(sourceWindow);
     const projectRoot = projectRootFromInput(input);
     if (projectRoot) return serviceForProjectRoot(projectRoot);
+    if (isLiveWindow(sourceWindow)) return serviceForWindow(sourceWindow);
     return activeService();
   };
-
-  const serviceForRoutingArg = (
-    inputOrSourceWindow?: BuiltInBrowserProjectScopeArgs | BrowserWindow | null,
-  ): WindowBrowserService =>
-    isLiveWindow(inputOrSourceWindow)
-      ? serviceForWindow(inputOrSourceWindow)
-      : serviceForInput(inputOrSourceWindow);
 
   return {
     attachToWindow(nextWin: BrowserWindow): void {
       activeWindowId = nextWin.id;
       serviceForWindow(nextWin).attachToWindow(nextWin);
     },
-    getStatus(inputOrSourceWindow?: BuiltInBrowserProjectScopeArgs | BrowserWindow | null): BuiltInBrowserStatus {
-      return serviceForRoutingArg(inputOrSourceWindow).getStatus();
+    getStatus(
+      inputOrSourceWindow?: BuiltInBrowserProjectScopeArgs | BrowserWindow | null,
+      sourceWindow?: BrowserWindow | null,
+    ): BuiltInBrowserStatus {
+      const input = isLiveWindow(inputOrSourceWindow) ? null : inputOrSourceWindow ?? null;
+      const win = sourceWindow ?? (isLiveWindow(inputOrSourceWindow) ? inputOrSourceWindow : null);
+      return serviceForInput(input, win).getStatus();
     },
     claim(input: BuiltInBrowserClaimArgs = {}, sourceWindow?: BrowserWindow | null): BuiltInBrowserStatus {
       return serviceForInput(input, sourceWindow).claim(input);
@@ -471,11 +479,21 @@ export function createBuiltInBrowserService(args: {
     wait(input: BuiltInBrowserWaitArgs, sourceWindow?: BrowserWindow | null): Promise<BuiltInBrowserAgentActionResult> {
       return serviceForInput(input, sourceWindow).wait(input);
     },
-    startInspect(inputOrSourceWindow?: BuiltInBrowserProjectScopeArgs | BrowserWindow | null): Promise<BuiltInBrowserStatus> {
-      return serviceForRoutingArg(inputOrSourceWindow).startInspect();
+    startInspect(
+      inputOrSourceWindow?: BuiltInBrowserProjectScopeArgs | BrowserWindow | null,
+      sourceWindow?: BrowserWindow | null,
+    ): Promise<BuiltInBrowserStatus> {
+      const input = isLiveWindow(inputOrSourceWindow) ? null : inputOrSourceWindow ?? null;
+      const win = sourceWindow ?? (isLiveWindow(inputOrSourceWindow) ? inputOrSourceWindow : null);
+      return serviceForInput(input, win).startInspect();
     },
-    stopInspect(inputOrSourceWindow?: BuiltInBrowserProjectScopeArgs | BrowserWindow | null): Promise<BuiltInBrowserStatus> {
-      return serviceForRoutingArg(inputOrSourceWindow).stopInspect();
+    stopInspect(
+      inputOrSourceWindow?: BuiltInBrowserProjectScopeArgs | BrowserWindow | null,
+      sourceWindow?: BrowserWindow | null,
+    ): Promise<BuiltInBrowserStatus> {
+      const input = isLiveWindow(inputOrSourceWindow) ? null : inputOrSourceWindow ?? null;
+      const win = sourceWindow ?? (isLiveWindow(inputOrSourceWindow) ? inputOrSourceWindow : null);
+      return serviceForInput(input, win).stopInspect();
     },
     captureScreenshot(inputOrSourceWindow?: BuiltInBrowserTabTargetArgs | BrowserWindow | null, sourceWindow?: BrowserWindow | null): Promise<BuiltInBrowserScreenshot> {
       const input = isLiveWindow(inputOrSourceWindow) ? {} : inputOrSourceWindow ?? {};
@@ -484,11 +502,21 @@ export function createBuiltInBrowserService(args: {
     selectPoint(input: BuiltInBrowserSelectPointArgs, sourceWindow?: BrowserWindow | null): Promise<BuiltInBrowserSelectResult> {
       return serviceForInput(input, sourceWindow).selectPoint(input);
     },
-    selectCurrent(inputOrSourceWindow?: BuiltInBrowserProjectScopeArgs | BrowserWindow | null): Promise<BuiltInBrowserSelectResult> {
-      return serviceForRoutingArg(inputOrSourceWindow).selectCurrent();
+    selectCurrent(
+      inputOrSourceWindow?: BuiltInBrowserProjectScopeArgs | BrowserWindow | null,
+      sourceWindow?: BrowserWindow | null,
+    ): Promise<BuiltInBrowserSelectResult> {
+      const input = isLiveWindow(inputOrSourceWindow) ? null : inputOrSourceWindow ?? null;
+      const win = sourceWindow ?? (isLiveWindow(inputOrSourceWindow) ? inputOrSourceWindow : null);
+      return serviceForInput(input, win).selectCurrent();
     },
-    clearSelection(inputOrSourceWindow?: BuiltInBrowserProjectScopeArgs | BrowserWindow | null): Promise<{ ok: true }> {
-      return serviceForRoutingArg(inputOrSourceWindow).clearSelection();
+    clearSelection(
+      inputOrSourceWindow?: BuiltInBrowserProjectScopeArgs | BrowserWindow | null,
+      sourceWindow?: BrowserWindow | null,
+    ): Promise<{ ok: true }> {
+      const input = isLiveWindow(inputOrSourceWindow) ? null : inputOrSourceWindow ?? null;
+      const win = sourceWindow ?? (isLiveWindow(inputOrSourceWindow) ? inputOrSourceWindow : null);
+      return serviceForInput(input, win).clearSelection();
     },
     dispose(): void {
       for (const { win, listener } of windowClosedListeners.values()) {

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -69,6 +69,7 @@ import type {
   BuiltInBrowserCreateTabArgs,
   BuiltInBrowserNavigateArgs,
   BuiltInBrowserOpenPanelArgs,
+  BuiltInBrowserProjectScopeArgs,
   BuiltInBrowserSelectPointArgs,
   BuiltInBrowserTabArgs,
   BuiltInBrowserTabTargetArgs,
@@ -2210,6 +2211,7 @@ export function registerIpc({
     const visibleValue = record.visible;
     if (typeof visibleValue !== "boolean") invalidBuiltInBrowserArg(channel, "visible must be a boolean");
     return {
+      ...parseBuiltInBrowserProjectScopeArgs(record, channel),
       x: builtInBrowserNumber(record, "x", channel, { min: 0, max: 100_000 }),
       y: builtInBrowserNumber(record, "y", channel, { min: 0, max: 100_000 }),
       width: builtInBrowserNumber(record, "width", channel, { min: 0, max: 100_000 }),
@@ -2223,7 +2225,7 @@ export function registerIpc({
     const webContentsId = builtInBrowserNumber(record, "webContentsId", channel, { min: 1, max: Number.MAX_SAFE_INTEGER });
     const tabId = optionalBuiltInBrowserString(record, "tabId", channel, 128);
     if (!tabId) return invalidBuiltInBrowserArg(channel, "tabId must be a non-empty string");
-    return { tabId, webContentsId };
+    return { ...parseBuiltInBrowserProjectScopeArgs(record, channel), tabId, webContentsId };
   };
 
   const parseBuiltInBrowserNavigateArgs = (value: unknown, channel: string): BuiltInBrowserNavigateArgs => {
@@ -2263,11 +2265,28 @@ export function registerIpc({
     return undefined;
   }
 
+  const parseBuiltInBrowserProjectScopeArgs = (
+    record: Record<string, unknown>,
+    channel: string,
+  ): BuiltInBrowserProjectScopeArgs => {
+    const projectRoot = optionalBuiltInBrowserString(record, "projectRoot", channel, 4096);
+    return {
+      ...(projectRoot ? { projectRoot } : {}),
+    };
+  };
+
+  const parseBuiltInBrowserProjectScopeInput = (
+    value: unknown,
+    channel: string,
+  ): BuiltInBrowserProjectScopeArgs =>
+    parseBuiltInBrowserProjectScopeArgs(builtInBrowserRecord(value, channel, false), channel);
+
   const parseBuiltInBrowserClaimArgs = (record: Record<string, unknown>, channel: string): BuiltInBrowserClaimArgs => {
     const tabId = optionalBuiltInBrowserString(record, "tabId", channel, 128);
     const laneId = optionalBuiltInBrowserString(record, "laneId", channel, 128);
     const chatSessionId = optionalBuiltInBrowserString(record, "chatSessionId", channel, 128);
     return {
+      ...parseBuiltInBrowserProjectScopeArgs(record, channel),
       ...(tabId ? { tabId } : {}),
       ...(laneId ? { laneId } : {}),
       ...(chatSessionId ? { chatSessionId } : {}),
@@ -2279,6 +2298,7 @@ export function registerIpc({
     const tabId = optionalBuiltInBrowserString(record, "tabId", channel, 128);
     const sessionId = optionalBuiltInBrowserString(record, "sessionId", channel, 128);
     return {
+      ...parseBuiltInBrowserProjectScopeArgs(record, channel),
       ...(tabId ? { tabId } : {}),
       ...(sessionId ? { sessionId } : {}),
     };
@@ -2313,6 +2333,7 @@ export function registerIpc({
     const sessionId = optionalBuiltInBrowserString(record, "sessionId", channel, 128);
     const includeScreenshot = record.includeScreenshot === false ? false : undefined;
     return {
+      ...parseBuiltInBrowserProjectScopeArgs(record, channel),
       ...(tabId ? { tabId } : {}),
       ...(sessionId ? { sessionId } : {}),
       x: builtInBrowserNumber(record, "x", channel, { min: 0, max: 100_000 }),
@@ -7158,9 +7179,9 @@ export function registerIpc({
     });
   });
 
-  ipcMain.handle(IPC.builtInBrowserGetStatus, async (event) => {
+  ipcMain.handle(IPC.builtInBrowserGetStatus, async (event, arg) => {
     const win = guardBuiltInBrowserIpc(event, IPC.builtInBrowserGetStatus, { windowMs: 10_000, max: 120 });
-    return ensureBuiltInBrowser().getStatus(win);
+    return ensureBuiltInBrowser().getStatus(parseBuiltInBrowserProjectScopeInput(arg, IPC.builtInBrowserGetStatus), win);
   });
 
   ipcMain.handle(IPC.builtInBrowserShowPanel, async (event, arg) => {
@@ -7218,14 +7239,14 @@ export function registerIpc({
     return ensureBuiltInBrowser().stop(parseBuiltInBrowserTabTargetArgs(arg, IPC.builtInBrowserStop), win);
   });
 
-  ipcMain.handle(IPC.builtInBrowserStartInspect, async (event) => {
+  ipcMain.handle(IPC.builtInBrowserStartInspect, async (event, arg) => {
     const win = guardBuiltInBrowserIpc(event, IPC.builtInBrowserStartInspect, { windowMs: 10_000, max: 40 });
-    return ensureBuiltInBrowser().startInspect(win);
+    return ensureBuiltInBrowser().startInspect(parseBuiltInBrowserProjectScopeInput(arg, IPC.builtInBrowserStartInspect), win);
   });
 
-  ipcMain.handle(IPC.builtInBrowserStopInspect, async (event) => {
+  ipcMain.handle(IPC.builtInBrowserStopInspect, async (event, arg) => {
     const win = guardBuiltInBrowserIpc(event, IPC.builtInBrowserStopInspect, { windowMs: 10_000, max: 80 });
-    return ensureBuiltInBrowser().stopInspect(win);
+    return ensureBuiltInBrowser().stopInspect(parseBuiltInBrowserProjectScopeInput(arg, IPC.builtInBrowserStopInspect), win);
   });
 
   ipcMain.handle(IPC.builtInBrowserCaptureScreenshot, async (event, arg) => {
@@ -7238,14 +7259,14 @@ export function registerIpc({
     return ensureBuiltInBrowser().selectPoint(parseBuiltInBrowserSelectPointArgs(arg, IPC.builtInBrowserSelectPoint), win);
   });
 
-  ipcMain.handle(IPC.builtInBrowserSelectCurrent, async (event) => {
+  ipcMain.handle(IPC.builtInBrowserSelectCurrent, async (event, arg) => {
     const win = guardBuiltInBrowserIpc(event, IPC.builtInBrowserSelectCurrent, { windowMs: 10_000, max: 80 });
-    return ensureBuiltInBrowser().selectCurrent(win);
+    return ensureBuiltInBrowser().selectCurrent(parseBuiltInBrowserProjectScopeInput(arg, IPC.builtInBrowserSelectCurrent), win);
   });
 
-  ipcMain.handle(IPC.builtInBrowserClearSelection, async (event) => {
+  ipcMain.handle(IPC.builtInBrowserClearSelection, async (event, arg) => {
     const win = guardBuiltInBrowserIpc(event, IPC.builtInBrowserClearSelection, { windowMs: 10_000, max: 80 });
-    return ensureBuiltInBrowser().clearSelection(win);
+    return ensureBuiltInBrowser().clearSelection(parseBuiltInBrowserProjectScopeInput(arg, IPC.builtInBrowserClearSelection), win);
   });
 
   ipcMain.handle(IPC.macosVmGetStatus, async (event, arg = {}): Promise<MacosVmStatus> => {

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -597,6 +597,7 @@ import type {
   BuiltInBrowserEventPayload,
   BuiltInBrowserNavigateArgs,
   BuiltInBrowserOpenPanelArgs,
+  BuiltInBrowserProjectScopeArgs,
   BuiltInBrowserScreenshot,
   BuiltInBrowserSelectPointArgs,
   BuiltInBrowserSelectResult,
@@ -1535,7 +1536,7 @@ declare global {
         onEvent: (cb: (ev: AppControlEventPayload) => void) => () => void;
       };
       builtInBrowser: {
-        getStatus: () => Promise<BuiltInBrowserStatus>;
+        getStatus: (args?: BuiltInBrowserProjectScopeArgs) => Promise<BuiltInBrowserStatus>;
         showPanel: (
           args?: BuiltInBrowserOpenPanelArgs,
         ) => Promise<BuiltInBrowserStatus>;
@@ -1561,16 +1562,16 @@ declare global {
         goBack: (args?: BuiltInBrowserTabTargetArgs) => Promise<BuiltInBrowserStatus>;
         goForward: (args?: BuiltInBrowserTabTargetArgs) => Promise<BuiltInBrowserStatus>;
         stop: (args?: BuiltInBrowserTabTargetArgs) => Promise<BuiltInBrowserStatus>;
-        startInspect: () => Promise<BuiltInBrowserStatus>;
-        stopInspect: () => Promise<BuiltInBrowserStatus>;
+        startInspect: (args?: BuiltInBrowserProjectScopeArgs) => Promise<BuiltInBrowserStatus>;
+        stopInspect: (args?: BuiltInBrowserProjectScopeArgs) => Promise<BuiltInBrowserStatus>;
         captureScreenshot: (
           args?: BuiltInBrowserTabTargetArgs,
         ) => Promise<BuiltInBrowserScreenshot>;
         selectPoint: (
           args: BuiltInBrowserSelectPointArgs,
         ) => Promise<BuiltInBrowserSelectResult>;
-        selectCurrent: () => Promise<BuiltInBrowserSelectResult>;
-        clearSelection: () => Promise<{ ok: true }>;
+        selectCurrent: (args?: BuiltInBrowserProjectScopeArgs) => Promise<BuiltInBrowserSelectResult>;
+        clearSelection: (args?: BuiltInBrowserProjectScopeArgs) => Promise<{ ok: true }>;
         onEvent: (cb: (ev: BuiltInBrowserEventPayload) => void) => () => void;
       };
       macosVm: {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -609,6 +609,7 @@ import type {
   BuiltInBrowserEventPayload,
   BuiltInBrowserNavigateArgs,
   BuiltInBrowserOpenPanelArgs,
+  BuiltInBrowserProjectScopeArgs,
   BuiltInBrowserScreenshot,
   BuiltInBrowserSelectPointArgs,
   BuiltInBrowserSelectResult,
@@ -928,8 +929,11 @@ const appControlStatusCache = createShortIpcCache<AppControlStatus>(
   1_000,
 );
 
-const builtInBrowserStatusCache = createShortIpcCache<BuiltInBrowserStatus>(
-  () => ipcRenderer.invoke(IPC.builtInBrowserGetStatus),
+const builtInBrowserStatusCache = createKeyedShortIpcCache<BuiltInBrowserStatus>(
+  (key) => {
+    const args = parseIpcCacheArgs<BuiltInBrowserProjectScopeArgs>(key, {});
+    return ipcRenderer.invoke(IPC.builtInBrowserGetStatus, args);
+  },
   500,
 );
 
@@ -5603,8 +5607,10 @@ contextBridge.exposeInMainWorld("ade", {
     onEvent: subscribeAppControlEvents,
   },
   builtInBrowser: {
-    getStatus: async (): Promise<BuiltInBrowserStatus> =>
-      builtInBrowserStatusCache.get(),
+    getStatus: async (
+      args: BuiltInBrowserProjectScopeArgs = {},
+    ): Promise<BuiltInBrowserStatus> =>
+      builtInBrowserStatusCache.get(serializeIpcCacheArgs(args)),
     showPanel: async (
       args: BuiltInBrowserOpenPanelArgs = {},
     ): Promise<BuiltInBrowserStatus> =>
@@ -5682,15 +5688,19 @@ contextBridge.exposeInMainWorld("ade", {
         () => builtInBrowserStatusCache.clear(),
         () => ipcRenderer.invoke(IPC.builtInBrowserStop, args),
       ),
-    startInspect: async (): Promise<BuiltInBrowserStatus> =>
+    startInspect: async (
+      args: BuiltInBrowserProjectScopeArgs = {},
+    ): Promise<BuiltInBrowserStatus> =>
       clearAround(
         () => builtInBrowserStatusCache.clear(),
-        () => ipcRenderer.invoke(IPC.builtInBrowserStartInspect),
+        () => ipcRenderer.invoke(IPC.builtInBrowserStartInspect, args),
       ),
-    stopInspect: async (): Promise<BuiltInBrowserStatus> =>
+    stopInspect: async (
+      args: BuiltInBrowserProjectScopeArgs = {},
+    ): Promise<BuiltInBrowserStatus> =>
       clearAround(
         () => builtInBrowserStatusCache.clear(),
-        () => ipcRenderer.invoke(IPC.builtInBrowserStopInspect),
+        () => ipcRenderer.invoke(IPC.builtInBrowserStopInspect, args),
       ),
     captureScreenshot: async (
       args: BuiltInBrowserTabTargetArgs = {},
@@ -5700,12 +5710,16 @@ contextBridge.exposeInMainWorld("ade", {
       args: BuiltInBrowserSelectPointArgs,
     ): Promise<BuiltInBrowserSelectResult> =>
       ipcRenderer.invoke(IPC.builtInBrowserSelectPoint, args),
-    selectCurrent: async (): Promise<BuiltInBrowserSelectResult> =>
-      ipcRenderer.invoke(IPC.builtInBrowserSelectCurrent),
-    clearSelection: async (): Promise<{ ok: true }> =>
+    selectCurrent: async (
+      args: BuiltInBrowserProjectScopeArgs = {},
+    ): Promise<BuiltInBrowserSelectResult> =>
+      ipcRenderer.invoke(IPC.builtInBrowserSelectCurrent, args),
+    clearSelection: async (
+      args: BuiltInBrowserProjectScopeArgs = {},
+    ): Promise<{ ok: true }> =>
       clearAround(
         () => builtInBrowserStatusCache.clear(),
-        () => ipcRenderer.invoke(IPC.builtInBrowserClearSelection),
+        () => ipcRenderer.invoke(IPC.builtInBrowserClearSelection, args),
       ),
     onEvent: builtInBrowserEventFanout,
   },

--- a/apps/desktop/src/renderer/components/app/TopBar.test.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.test.tsx
@@ -7,6 +7,9 @@ import { TopBar } from "./TopBar";
 import { useAppStore } from "../../state/appStore";
 import { requestLinearIssueQuickView } from "../../lib/linearIssueQuickViewNavigation";
 
+const PROJECT_TAB_ROOT_MIME = "application/x-ade-project-root";
+const PROJECT_TAB_WINDOW_MIME = "application/x-ade-window-id";
+
 vi.mock("../settings/SyncDevicesSection", () => ({
   SyncDevicesSection: () => <section data-testid="sync-devices-section">Sync devices panel</section>,
 }));
@@ -133,6 +136,13 @@ function makeDataTransfer(data: Record<string, string>, dropEffect = "move") {
   };
 }
 
+function markHandledProjectTabDrop(rootPath: string, sourceWindowId = "1") {
+  window.localStorage.setItem(
+    `ade.projectTabDropHandled.v1:${sourceWindowId}:${encodeURIComponent(rootPath)}`,
+    String(Date.now()),
+  );
+}
+
 function fireProjectTabDragEnd(
   element: HTMLElement,
   dataTransfer: ReturnType<typeof makeDataTransfer>,
@@ -251,6 +261,7 @@ describe("TopBar", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    globalThis.window.localStorage.clear();
     if (originalAde === undefined) {
       delete (globalThis.window as any).ade;
     } else {
@@ -410,9 +421,38 @@ describe("TopBar", () => {
 
     const tab = await screen.findByTitle("/Users/arul/ADE");
 
-    fireProjectTabDragEnd(tab, makeDataTransfer({}, "move"));
+    markHandledProjectTabDrop("/Users/arul/ADE");
+    fireProjectTabDragEnd(
+      tab,
+      makeDataTransfer(
+        {
+          [PROJECT_TAB_ROOT_MIME]: "/Users/arul/ADE",
+          [PROJECT_TAB_WINDOW_MIME]: "1",
+        },
+        "move",
+      ),
+    );
 
     expect(globalThis.window.ade.app.openProjectInNewWindow).not.toHaveBeenCalled();
+  });
+
+  it("detaches when a project tab is dragged over an ADE window but no ADE tab bar handles it", async () => {
+    render(<TopBar />);
+
+    const tab = await screen.findByTitle("/Users/arul/ADE");
+
+    fireProjectTabDragEnd(
+      tab,
+      makeDataTransfer(
+        {
+          [PROJECT_TAB_ROOT_MIME]: "/Users/arul/ADE",
+          [PROJECT_TAB_WINDOW_MIME]: "1",
+        },
+        "move",
+      ),
+    );
+
+    expect(globalThis.window.ade.app.openProjectInNewWindow).toHaveBeenCalledWith("/Users/arul/ADE");
   });
 
   it("detaches a project tab when it is dragged outside without an ADE drop target", async () => {

--- a/apps/desktop/src/renderer/components/app/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.tsx
@@ -62,6 +62,9 @@ const RUNNING_LANE_PROCESS_STATES: ProcessRuntime["status"][] = [
 ];
 const ADE_PROJECT_TAB_ROOT_MIME = "application/x-ade-project-root";
 const ADE_PROJECT_TAB_WINDOW_MIME = "application/x-ade-window-id";
+const ADE_PROJECT_TAB_DROP_HANDLED_PREFIX =
+  "ade.projectTabDropHandled.v1:";
+const ADE_PROJECT_TAB_DROP_HANDLED_TTL_MS = 5_000;
 
 // Bounded LRU so we don't accumulate icons for every project ever opened in
 // long-lived sessions. 24 entries keeps the working set hot for typical usage
@@ -81,6 +84,46 @@ let recentProjectsCacheSource:
   | (() => Promise<RecentProjectSummary[]>)
   | null = null;
 type RemoteProjectTab = Extract<OpenProjectBinding, { kind: "remote" }>;
+
+function projectTabDropMarkerKey(
+  sourceWindowId: number | null,
+  rootPath: string,
+): string {
+  return `${ADE_PROJECT_TAB_DROP_HANDLED_PREFIX}${sourceWindowId ?? "unknown"}:${encodeURIComponent(rootPath)}`;
+}
+
+function markProjectTabDropHandled(
+  sourceWindowId: number | null,
+  rootPath: string,
+): void {
+  try {
+    window.localStorage.setItem(
+      projectTabDropMarkerKey(sourceWindowId, rootPath),
+      String(Date.now()),
+    );
+  } catch {
+    // localStorage may be unavailable in tests or hardened browser contexts.
+  }
+}
+
+function consumeRecentProjectTabDropHandled(
+  sourceWindowId: number | null,
+  rootPath: string,
+): boolean {
+  const key = projectTabDropMarkerKey(sourceWindowId, rootPath);
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw == null) return false;
+    window.localStorage.removeItem(key);
+    const timestamp = Number(raw);
+    return (
+      Number.isFinite(timestamp) &&
+      Date.now() - timestamp < ADE_PROJECT_TAB_DROP_HANDLED_TTL_MS
+    );
+  } catch {
+    return false;
+  }
+}
 
 function rememberRecentProjects(rows: RecentProjectSummary[]): void {
   recentProjectsCache = { rows, fetchedAtMs: Date.now() };
@@ -1491,6 +1534,8 @@ export function TopBar() {
           : null;
       if (sourceWindowId != null && sourceWindowId === windowId) return;
 
+      markProjectTabDropHandled(sourceWindowId, rootPath);
+
       if (project?.rootPath === rootPath) {
         if (sourceWindowId != null) {
           window.ade.app.closeWindow(sourceWindowId).catch(() => {});
@@ -1519,9 +1564,23 @@ export function TopBar() {
           e.clientY > window.innerHeight);
       const droppedOnAdeTarget =
         e.dataTransfer.dropEffect && e.dataTransfer.dropEffect !== "none";
+      const sourceWindowIdRaw = e.dataTransfer.getData(
+        ADE_PROJECT_TAB_WINDOW_MIME,
+      );
+      const parsedSourceWindowId = sourceWindowIdRaw
+        ? Number(sourceWindowIdRaw)
+        : null;
+      const sourceWindowId =
+        parsedSourceWindowId != null && Number.isFinite(parsedSourceWindowId)
+          ? parsedSourceWindowId
+          : null;
+      const handledByAdeDropTarget =
+        rootPath && droppedOnAdeTarget
+          ? consumeRecentProjectTabDropHandled(sourceWindowId, rootPath)
+          : false;
       setDragIdx(null);
       setDropIdx(null);
-      if (!draggedOutside || droppedOnAdeTarget || !rootPath) return;
+      if (!draggedOutside || handledByAdeDropTarget || !rootPath) return;
 
       void (async () => {
         try {

--- a/apps/desktop/src/renderer/components/chat/ChatBuiltInBrowserPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatBuiltInBrowserPanel.tsx
@@ -19,6 +19,7 @@ import type { AgentChatFileRef } from "../../../shared/types";
 import { inferAttachmentType } from "../../../shared/types";
 import type { BuiltInBrowserTab } from "../../../shared/types/builtInBrowser";
 import { consumePendingBuiltInBrowserNavigation } from "../../lib/openExternal";
+import { useAppStore } from "../../state/appStore";
 import {
   ADE_WORK_SIDEBAR_BROWSER_RESIZE_END_EVENT,
   ADE_WORK_SIDEBAR_BROWSER_RESIZE_START_EVENT,
@@ -104,7 +105,12 @@ type BuiltInBrowserStatus = {
 };
 
 type BrowserTabTargetArgs = {
+  projectRoot?: string | null;
   tabId?: string | null;
+};
+
+type BrowserProjectScopeArgs = {
+  projectRoot?: string | null;
 };
 
 type BuiltInBrowserEventPayload = {
@@ -126,23 +132,23 @@ type BuiltInBrowserEventPayload = {
 };
 
 type BuiltInBrowserApi = {
-  getStatus: () => Promise<unknown>;
-  setBounds: (bounds: BrowserBounds) => Promise<void>;
-  attachWebview?: (args: { tabId: string; webContentsId: number }) => Promise<unknown>;
-  navigate: (args: { url: string; tabId?: string | null; newTab?: boolean }) => Promise<unknown>;
-  createTab?: (args?: { url?: string | null; activate?: boolean }) => Promise<unknown>;
-  switchTab?: (args: { tabId: string }) => Promise<unknown>;
-  closeTab?: (args: { tabId: string }) => Promise<unknown>;
+  getStatus: (args?: BrowserProjectScopeArgs) => Promise<unknown>;
+  setBounds: (bounds: BrowserBounds & BrowserProjectScopeArgs) => Promise<void>;
+  attachWebview?: (args: { tabId: string; webContentsId: number } & BrowserProjectScopeArgs) => Promise<unknown>;
+  navigate: (args: { url: string; tabId?: string | null; newTab?: boolean } & BrowserProjectScopeArgs) => Promise<unknown>;
+  createTab?: (args?: { url?: string | null; activate?: boolean } & BrowserProjectScopeArgs) => Promise<unknown>;
+  switchTab?: (args: { tabId: string } & BrowserProjectScopeArgs) => Promise<unknown>;
+  closeTab?: (args: { tabId: string } & BrowserProjectScopeArgs) => Promise<unknown>;
   reload: (args?: BrowserTabTargetArgs) => Promise<unknown>;
   goBack: (args?: BrowserTabTargetArgs) => Promise<unknown>;
   goForward: (args?: BrowserTabTargetArgs) => Promise<unknown>;
   stop: (args?: BrowserTabTargetArgs) => Promise<unknown>;
-  startInspect: () => Promise<void>;
-  stopInspect: () => Promise<void>;
+  startInspect: (args?: BrowserProjectScopeArgs) => Promise<void>;
+  stopInspect: (args?: BrowserProjectScopeArgs) => Promise<void>;
   captureScreenshot: (args?: BrowserTabTargetArgs) => Promise<unknown>;
-  selectPoint?: (args: { x: number; y: number; includeScreenshot?: boolean; tabId?: string | null }) => Promise<unknown>;
-  selectCurrent: () => Promise<unknown>;
-  clearSelection: () => Promise<void>;
+  selectPoint?: (args: { x: number; y: number; includeScreenshot?: boolean; tabId?: string | null } & BrowserProjectScopeArgs) => Promise<unknown>;
+  selectCurrent: (args?: BrowserProjectScopeArgs) => Promise<unknown>;
+  clearSelection: (args?: BrowserProjectScopeArgs) => Promise<void>;
   onEvent: (cb: (event: BuiltInBrowserEventPayload) => void) => () => void;
 };
 
@@ -391,6 +397,26 @@ function normalizeStatus(value: unknown, previous: BuiltInBrowserStatus | null):
   };
 }
 
+function eventProjectRoot(value: unknown): string | null | undefined {
+  if (!isRecord(value)) return undefined;
+  if ("profileProjectRoot" in value) {
+    const root = value.profileProjectRoot;
+    return typeof root === "string" && root.trim().length > 0 ? root : null;
+  }
+  if (isRecord(value.status)) return eventProjectRoot(value.status);
+  return undefined;
+}
+
+function browserEventMatchesProject(
+  event: BuiltInBrowserEventPayload,
+  projectRoot: string | null,
+): boolean {
+  const root = eventProjectRoot(event);
+  if (root === undefined) return true;
+  if (!projectRoot) return root === null;
+  return root === projectRoot;
+}
+
 function buildStatusInfo(apiAvailable: boolean, status: BuiltInBrowserStatus | null): StatusInfo {
   if (!apiAvailable) {
     return { label: "Unavailable", detail: "The built-in browser API is not exposed on window.ade.", tone: "error" };
@@ -595,6 +621,7 @@ export function ChatBuiltInBrowserPanel({
   onAddAttachment,
   onInsertDraft,
 }: ChatBuiltInBrowserPanelProps) {
+  const projectRoot = useAppStore((s) => s.project?.rootPath ?? null);
   const browserSurfaceRef = useRef<HTMLDivElement | null>(null);
   const browserWebviewsRef = useRef<Map<string, BrowserWebviewElement>>(new Map());
   const browserWebviewAttachCleanupRef = useRef<Map<string, () => void>>(new Map());
@@ -622,6 +649,13 @@ export function ChatBuiltInBrowserPanel({
   const [captureSelection, setCaptureSelection] = useState<BrowserCaptureSelection | null>(null);
   const [browserInputSuppressed, setBrowserInputSuppressed] = useState(false);
   const [webviewNavigationNonce, setWebviewNavigationNonce] = useState(0);
+  const browserScope = useMemo<BrowserProjectScopeArgs>(
+    () => (projectRoot ? { projectRoot } : {}),
+    [projectRoot],
+  );
+  const withBrowserScope = useCallback(<T extends Record<string, unknown>>(args: T): T & BrowserProjectScopeArgs => (
+    (projectRoot ? { ...args, projectRoot } : args) as T & BrowserProjectScopeArgs
+  ), [projectRoot]);
 
   const statusInfo = useMemo(() => buildStatusInfo(apiAvailable, status), [apiAvailable, status]);
   const browserTabs = useMemo(() => status?.tabs ?? [], [status?.tabs]);
@@ -675,9 +709,9 @@ export function ChatBuiltInBrowserPanel({
 
   const refreshStatus = useCallback(async () => {
     const api = requireBrowserApi();
-    const nextStatus = await api.getStatus();
+    const nextStatus = await api.getStatus(browserScope);
     applyStatus(nextStatus);
-  }, [applyStatus]);
+  }, [applyStatus, browserScope]);
 
   const attachBrowserContextItem = useCallback(async (
     item: BuiltInBrowserContextItem,
@@ -739,7 +773,7 @@ export function ChatBuiltInBrowserPanel({
       const hidden: BrowserBounds = { x: 0, y: 0, width: 0, height: 0, visible: false };
       if (boundsEqual(latestBoundsRef.current, hidden)) return;
       latestBoundsRef.current = hidden;
-      api.setBounds(hidden).catch((error: unknown) => {
+      api.setBounds(withBrowserScope(hidden)).catch((error: unknown) => {
         setMessage({ tone: "error", text: `Could not hide browser fallback: ${errorMessage(error)}` });
       });
       return;
@@ -751,10 +785,10 @@ export function ChatBuiltInBrowserPanel({
     };
     if (boundsEqual(latestBoundsRef.current, next)) return;
     latestBoundsRef.current = next;
-    api.setBounds(next).catch((error: unknown) => {
+    api.setBounds(withBrowserScope(next)).catch((error: unknown) => {
       setMessage({ tone: "error", text: `Could not position browser: ${errorMessage(error)}` });
     });
-  }, []);
+  }, [withBrowserScope]);
 
   const hideNativeBrowserView = useCallback(async () => {
     const api = getBrowserApi();
@@ -768,9 +802,9 @@ export function ChatBuiltInBrowserPanel({
       visible: false,
     };
     latestBoundsRef.current = hidden;
-    await api.stopInspect().catch(() => {});
-    await api.setBounds(hidden).catch(() => {});
-  }, []);
+    await api.stopInspect(browserScope).catch(() => {});
+    await api.setBounds(withBrowserScope(hidden)).catch(() => {});
+  }, [browserScope, withBrowserScope]);
 
   useEffect(() => {
     let restoreFrame: number | null = null;
@@ -851,12 +885,12 @@ export function ChatBuiltInBrowserPanel({
       const last = latestBoundsRef.current;
       const api = getBrowserApi();
       if (api && last) {
-        api.stopInspect().catch(() => {});
+        api.stopInspect(browserScope).catch(() => {});
         latestBoundsRef.current = { ...last, visible: false };
-        api.setBounds({ ...last, visible: false }).catch(() => {});
+        api.setBounds(withBrowserScope({ ...last, visible: false })).catch(() => {});
       }
     };
-  }, [reportBounds]);
+  }, [browserScope, reportBounds, withBrowserScope]);
 
   useEffect(() => {
     const api = getBrowserApi();
@@ -865,7 +899,7 @@ export function ChatBuiltInBrowserPanel({
       return undefined;
     }
     let cancelled = false;
-    api.getStatus()
+    api.getStatus(browserScope)
       .then((nextStatus) => {
         if (!cancelled) applyStatus(nextStatus);
       })
@@ -873,6 +907,7 @@ export function ChatBuiltInBrowserPanel({
         if (!cancelled) setMessage({ tone: "error", text: errorMessage(error) });
       });
     const unsubscribe = api.onEvent((event) => {
+      if (!browserEventMatchesProject(event, projectRoot)) return;
       const eventType = typeof event.type === "string" ? event.type : "";
       if (event.status) {
         applyStatus(event.status);
@@ -924,7 +959,7 @@ export function ChatBuiltInBrowserPanel({
       cancelled = true;
       unsubscribe();
     };
-  }, [applyStatus, attachBrowserContextItem, onAddContext]);
+  }, [applyStatus, attachBrowserContextItem, browserScope, onAddContext, projectRoot]);
 
   useEffect(() => () => {
     for (const cleanup of browserWebviewAttachCleanupRef.current.values()) cleanup();
@@ -963,7 +998,7 @@ export function ChatBuiltInBrowserPanel({
       const attachKey = `${tabId}:${webContentsId}`;
       if (browserWebviewAttachKeysRef.current.get(tabId) === attachKey) return;
       browserWebviewAttachKeysRef.current.set(tabId, attachKey);
-      void api.attachWebview?.({ tabId, webContentsId })
+      void api.attachWebview?.(withBrowserScope({ tabId, webContentsId }))
         .then((nextStatus) => applyStatus(nextStatus))
         .catch((error: unknown) => {
           browserWebviewAttachKeysRef.current.delete(tabId);
@@ -1013,7 +1048,7 @@ export function ChatBuiltInBrowserPanel({
       webview.style.pointerEvents = isActive && !captureBase && !browserInputSuppressed ? "auto" : "none";
       webview.setAttribute("aria-hidden", isActive ? "false" : "true");
     }
-  }, [activeTabId, applyStatus, browserInputSuppressed, browserTabs, tabIdsSignature, captureBase, webviewNavigationNonce]);
+  }, [activeTabId, applyStatus, browserInputSuppressed, browserTabs, tabIdsSignature, captureBase, webviewNavigationNonce, withBrowserScope]);
 
   const runBusy = useCallback(async (label: string, action: () => Promise<void>) => {
     setBusy(label);
@@ -1063,11 +1098,11 @@ export function ChatBuiltInBrowserPanel({
     const attachKey = `${activeTabId}:${webContentsId}`;
     if (browserWebviewAttachKeysRef.current.get(activeTabId) !== attachKey) {
       browserWebviewAttachKeysRef.current.set(activeTabId, attachKey);
-      const nextStatus = await api.attachWebview({ tabId: activeTabId, webContentsId });
+      const nextStatus = await api.attachWebview(withBrowserScope({ tabId: activeTabId, webContentsId }));
       applyStatus(nextStatus);
     }
     return true;
-  }, [activeTabId, applyStatus]);
+  }, [activeTabId, applyStatus, withBrowserScope]);
 
   const captureActiveRendererWebview = useCallback(async (): Promise<BuiltInBrowserScreenshot | null> => {
     if (!activeTabId) return null;
@@ -1117,7 +1152,7 @@ export function ChatBuiltInBrowserPanel({
     void (async () => {
       try {
         if (shouldUseRendererBrowserWebviews(api) && api.createTab) {
-          const nextStatus = normalizeStatus(await api.createTab({ activate: true }), statusRef.current);
+          const nextStatus = normalizeStatus(await api.createTab(withBrowserScope({ activate: true })), statusRef.current);
           applyStatus(nextStatus);
           const tabId = nextStatus.activeTabId;
           if (!tabId) throw new Error("ADE browser could not create a tab.");
@@ -1126,8 +1161,8 @@ export function ChatBuiltInBrowserPanel({
           return;
         }
         const nextStatus = api.createTab
-          ? await api.createTab({ url: DEFAULT_BROWSER_URL, activate: true })
-          : await api.navigate({ url: DEFAULT_BROWSER_URL, newTab: true });
+          ? await api.createTab(withBrowserScope({ url: DEFAULT_BROWSER_URL, activate: true }))
+          : await api.navigate(withBrowserScope({ url: DEFAULT_BROWSER_URL, newTab: true }));
         applyStatus(nextStatus);
         setUrlInput(DEFAULT_BROWSER_URL);
       } catch (error) {
@@ -1135,7 +1170,7 @@ export function ChatBuiltInBrowserPanel({
         setMessage({ tone: "error", text: errorMessage(error) });
       }
     })();
-  }, [apiAvailable, applyStatus, browserTabs.length, navigateRendererWebview, hasStatus]);
+  }, [apiAvailable, applyStatus, browserTabs.length, navigateRendererWebview, hasStatus, withBrowserScope]);
 
   const handleNavigate = useCallback(
     (event?: FormEvent<HTMLFormElement>) => {
@@ -1154,7 +1189,7 @@ export function ChatBuiltInBrowserPanel({
           let tabId: string | null = activeTabId;
           if (!tabId) {
             if (!api.createTab) throw new Error("This ADE build does not support browser tab creation.");
-            const nextStatus = normalizeStatus(await api.createTab({ activate: true }), statusRef.current);
+            const nextStatus = normalizeStatus(await api.createTab(withBrowserScope({ activate: true })), statusRef.current);
             applyStatus(nextStatus);
             tabId = nextStatus.activeTabId;
           }
@@ -1163,12 +1198,12 @@ export function ChatBuiltInBrowserPanel({
           setUrlInput(nextUrl);
           return;
         }
-        await api.navigate({ url: nextUrl });
+        await api.navigate(withBrowserScope({ url: nextUrl }));
         setUrlInput(nextUrl);
         await refreshStatus();
       });
     },
-    [activeTabId, applyStatus, navigateRendererWebview, refreshStatus, restoreLiveBrowserView, runBusy, urlInput],
+    [activeTabId, applyStatus, navigateRendererWebview, refreshStatus, restoreLiveBrowserView, runBusy, urlInput, withBrowserScope],
   );
 
   const handleNewTab = useCallback(() => {
@@ -1176,7 +1211,7 @@ export function ChatBuiltInBrowserPanel({
       if (captureModeRef.current) restoreLiveBrowserView();
       const api = requireBrowserApi();
       if (shouldUseRendererBrowserWebviews(api) && api.createTab) {
-        const nextStatus = normalizeStatus(await api.createTab({ activate: true }), statusRef.current);
+        const nextStatus = normalizeStatus(await api.createTab(withBrowserScope({ activate: true })), statusRef.current);
         applyStatus(nextStatus);
         const tabId = nextStatus.activeTabId;
         if (!tabId) throw new Error("ADE browser could not create a tab.");
@@ -1185,101 +1220,101 @@ export function ChatBuiltInBrowserPanel({
         return;
       }
       if (api.createTab) {
-        const nextStatus = await api.createTab({ url: DEFAULT_BROWSER_URL, activate: true });
+        const nextStatus = await api.createTab(withBrowserScope({ url: DEFAULT_BROWSER_URL, activate: true }));
         applyStatus(nextStatus);
       } else {
-        const nextStatus = await api.navigate({ url: DEFAULT_BROWSER_URL, newTab: true });
+        const nextStatus = await api.navigate(withBrowserScope({ url: DEFAULT_BROWSER_URL, newTab: true }));
         applyStatus(nextStatus);
       }
       setUrlInput(DEFAULT_BROWSER_URL);
     });
-  }, [applyStatus, navigateRendererWebview, restoreLiveBrowserView, runBusy]);
+  }, [applyStatus, navigateRendererWebview, restoreLiveBrowserView, runBusy, withBrowserScope]);
 
   const handleSwitchTab = useCallback((tabId: string) => {
     void runBusy("switch-tab", async () => {
       if (captureModeRef.current) restoreLiveBrowserView();
       const api = requireBrowserApi();
       if (api.switchTab) {
-        await api.switchTab({ tabId });
+        await api.switchTab(withBrowserScope({ tabId }));
       } else {
         throw new Error("This ADE build does not support browser tab switching.");
       }
       await refreshStatus();
     });
-  }, [refreshStatus, restoreLiveBrowserView, runBusy]);
+  }, [refreshStatus, restoreLiveBrowserView, runBusy, withBrowserScope]);
 
   const handleCloseTab = useCallback((tabId: string) => {
     void runBusy("close-tab", async () => {
       if (captureModeRef.current) restoreLiveBrowserView();
       const api = requireBrowserApi();
       if (api.closeTab) {
-        await api.closeTab({ tabId });
+        await api.closeTab(withBrowserScope({ tabId }));
       } else {
         throw new Error("This ADE build does not support closing browser tabs.");
       }
       await refreshStatus();
     });
-  }, [refreshStatus, restoreLiveBrowserView, runBusy]);
+  }, [refreshStatus, restoreLiveBrowserView, runBusy, withBrowserScope]);
 
   const handleBack = useCallback(() => {
     void runBusy("back", async () => {
       const api = requireBrowserApi();
-      await api.goBack();
+      await api.goBack(browserScope);
       await refreshStatus();
     });
-  }, [refreshStatus, runBusy]);
+  }, [browserScope, refreshStatus, runBusy]);
 
   const handleForward = useCallback(() => {
     void runBusy("forward", async () => {
       const api = requireBrowserApi();
-      await api.goForward();
+      await api.goForward(browserScope);
       await refreshStatus();
     });
-  }, [refreshStatus, runBusy]);
+  }, [browserScope, refreshStatus, runBusy]);
 
   const handleReload = useCallback(() => {
     void runBusy("reload", async () => {
       const api = requireBrowserApi();
-      await api.reload();
+      await api.reload(browserScope);
       await refreshStatus();
     });
-  }, [refreshStatus, runBusy]);
+  }, [browserScope, refreshStatus, runBusy]);
 
   const handleStop = useCallback(() => {
     void runBusy("stop", async () => {
       const api = requireBrowserApi();
-      await api.stop();
+      await api.stop(browserScope);
       await refreshStatus();
     });
-  }, [refreshStatus, runBusy]);
+  }, [browserScope, refreshStatus, runBusy]);
 
   const handleInspectToggle = useCallback(() => {
     void runBusy(inspecting ? "inspect-off" : "inspect-on", async () => {
       const api = requireBrowserApi();
       if (inspecting) {
-        await api.stopInspect();
+        await api.stopInspect(browserScope);
       } else {
-        await api.startInspect();
+        await api.startInspect(browserScope);
       }
       await refreshStatus();
     });
-  }, [inspecting, refreshStatus, runBusy]);
+  }, [browserScope, inspecting, refreshStatus, runBusy]);
 
   const handleClearSelection = useCallback(() => {
     void runBusy("clear-selection", async () => {
       const api = requireBrowserApi();
-      await api.clearSelection();
+      await api.clearSelection(browserScope);
       selectedItemRef.current = null;
       setSelectedItem(null);
       setStatus((current) => current ? { ...current, selectedItem: null } : current);
       setAttachmentAck(null);
     });
-  }, [runBusy]);
+  }, [browserScope, runBusy]);
 
   const handleAttachSelection = useCallback(() => {
     void runBusy("select", async () => {
       const api = requireBrowserApi();
-      const result = await api.selectCurrent();
+      const result = await api.selectCurrent(browserScope);
       const item =
         normalizeSelectionResult(result, statusRef.current)
         ?? selectedItemRef.current
@@ -1288,7 +1323,7 @@ export function ChatBuiltInBrowserPanel({
       if (!item) throw new Error("Select an element in Inspect mode first.");
       await attachBrowserContextItem(item, { force: true, label: "Browser context attached." });
     });
-  }, [attachBrowserContextItem, runBusy]);
+  }, [attachBrowserContextItem, browserScope, runBusy]);
 
   const handleAttachScreenshot = useCallback(() => {
     void runBusy("screenshot", async () => {
@@ -1302,7 +1337,7 @@ export function ChatBuiltInBrowserPanel({
       await attachActiveRendererWebview();
       let screenshot: BuiltInBrowserScreenshot | null = null;
       try {
-        const result = await api.captureScreenshot();
+        const result = await api.captureScreenshot(browserScope);
         screenshot = normalizeScreenshot(result, statusRef.current);
       } catch (error) {
         screenshot = await captureActiveRendererWebview();
@@ -1319,7 +1354,7 @@ export function ChatBuiltInBrowserPanel({
       await hideNativeBrowserView();
       setMessage({ tone: "info", text: "Drag a browser region to attach the screenshot crop and nearby page context." });
     });
-  }, [attachActiveRendererWebview, captureActiveRendererWebview, hideNativeBrowserView, onAddContext, restoreLiveBrowserView, runBusy]);
+  }, [attachActiveRendererWebview, browserScope, captureActiveRendererWebview, hideNativeBrowserView, onAddContext, restoreLiveBrowserView, runBusy]);
 
   const addBrowserCaptureContext = useCallback(async (frame: BrowserFrame) => {
     if (!captureBase) return;
@@ -1350,7 +1385,7 @@ export function ChatBuiltInBrowserPanel({
     let domItem: BuiltInBrowserContextItem | null = null;
     if (api?.selectPoint) {
       try {
-        const pointResult = await api.selectPoint({ x: domPoint.x, y: domPoint.y, includeScreenshot: false });
+        const pointResult = await api.selectPoint(withBrowserScope({ x: domPoint.x, y: domPoint.y, includeScreenshot: false }));
         domItem = normalizeSelectionResult(pointResult, statusRef.current);
       } catch (error) {
         setMessage({ tone: "error", text: `Captured region, but DOM point context failed: ${errorMessage(error)}` });
@@ -1420,7 +1455,7 @@ export function ChatBuiltInBrowserPanel({
       label: domItem ? "Browser capture + DOM attached." : "Browser capture attached.",
     });
     restoreLiveBrowserView();
-  }, [attachBrowserContextItem, captureBase, onAddAttachment, onAddContext, restoreLiveBrowserView, sessionId]);
+  }, [attachBrowserContextItem, captureBase, onAddAttachment, onAddContext, restoreLiveBrowserView, sessionId, withBrowserScope]);
 
   const handleBrowserCapturePointerDown = useCallback((event: PointerEvent<HTMLDivElement>) => {
     if (!captureImageDataUrl || !captureBase?.width || !captureBase.height) return;

--- a/apps/desktop/src/renderer/components/terminals/TerminalsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalsPage.test.tsx
@@ -147,6 +147,7 @@ const workMocks = vi.hoisted(() => {
     foregroundSession: makeChatSession("chat-foreground", "lane-primary"),
     baseWork,
     currentWork: baseWork as any,
+    projectRoot: null as string | null,
     fns,
     makeTerminalSession,
   };
@@ -161,8 +162,13 @@ const sidebarProps = vi.hoisted(() => ({
 }));
 
 vi.mock("../../state/appStore", () => ({
-  useAppStore: <T,>(selector: (state: { selectedLaneId: string }) => T): T =>
-    selector({ selectedLaneId: "lane-primary" }),
+  useAppStore: <T,>(selector: (state: { selectedLaneId: string; project: { rootPath: string } | null }) => T): T =>
+    selector({
+      selectedLaneId: "lane-primary",
+      project: workMocks.projectRoot
+        ? { rootPath: workMocks.projectRoot }
+        : null,
+    }),
 }));
 
 vi.mock("./useWorkSessions", () => ({
@@ -230,6 +236,7 @@ describe("TerminalsPage chat session activation", () => {
   afterEach(() => {
     cleanup();
     workMocks.currentWork = { ...workMocks.baseWork, closingPtyIds: new Set<string>() };
+    workMocks.projectRoot = null;
     sidebarProps.latest = null;
     vi.clearAllMocks();
   });
@@ -269,6 +276,42 @@ describe("TerminalsPage chat session activation", () => {
       expect(workMocks.fns.focusSession).toHaveBeenCalledWith("chat-foreground");
       expect(workMocks.fns.openSessionTab).toHaveBeenCalledWith("chat-foreground");
     });
+  });
+
+  it("opens the Browser sidebar only for matching project open requests", async () => {
+    workMocks.projectRoot = "/repo-one";
+    const browserEventListener: {
+      current: ((event: { type?: string; status?: unknown }) => void) | null;
+    } = { current: null };
+    Object.defineProperty(window, "ade", {
+      configurable: true,
+      value: {
+        builtInBrowser: {
+          onEvent: vi.fn((listener) => {
+            browserEventListener.current = listener;
+            return vi.fn();
+          }),
+        },
+      },
+    });
+
+    render(<TerminalsPage />);
+
+    await waitFor(() => expect(browserEventListener.current).not.toBeNull());
+    browserEventListener.current?.({ type: "open-request" });
+    browserEventListener.current?.({
+      type: "open-request",
+      status: { profileProjectRoot: "/repo-two" },
+    });
+    expect(workMocks.currentWork.setViewMode).not.toHaveBeenCalled();
+    expect(workMocks.currentWork.setWorkSidebarTab).not.toHaveBeenCalled();
+
+    browserEventListener.current?.({
+      type: "open-request",
+      status: { profileProjectRoot: "/repo-one" },
+    });
+    expect(workMocks.currentWork.setViewMode).toHaveBeenCalledWith("tabs");
+    expect(workMocks.currentWork.setWorkSidebarTab).toHaveBeenCalledWith("browser");
   });
 
   it("targets the visible Work draft when no saved session is active", async () => {

--- a/apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx
@@ -45,6 +45,23 @@ function dispatchWorkSidebarBrowserResizeEvent(type: "start" | "end"): void {
   ));
 }
 
+function browserEventProjectRoot(value: unknown): string | null | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if ("profileProjectRoot" in record) {
+    const root = record.profileProjectRoot;
+    return typeof root === "string" && root.trim().length > 0 ? root : null;
+  }
+  return browserEventProjectRoot(record.status);
+}
+
+function browserEventMatchesProject(event: unknown, projectRoot: string | null): boolean {
+  const root = browserEventProjectRoot(event);
+  if (root === undefined) return projectRoot == null;
+  if (!projectRoot) return root === null;
+  return root === projectRoot;
+}
+
 function isPtyContextInsertableToolType(toolType: TerminalSessionSummary["toolType"]): boolean {
   return toolType === "claude"
     || toolType === "codex"
@@ -86,6 +103,7 @@ async function allSettledWithConcurrency<T>(
 
 export function TerminalsPage({ active = true }: { active?: boolean }) {
   const work = useWorkSessions({ active });
+  const projectRoot = useAppStore((s) => s.project?.rootPath ?? null);
   const selectedLaneId = useAppStore((s) => s.selectedLaneId);
   const sortedLanes = useMemo(() => sortLanesForTabs(work.lanes), [work.lanes]);
 
@@ -541,7 +559,7 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
     };
     window.addEventListener(ADE_OPEN_BUILT_IN_BROWSER_EVENT, openBrowserSidebar);
     const unsubscribeBrowserEvents = window.ade?.builtInBrowser?.onEvent?.((event) => {
-      if (event.type === "open-request") openBrowserSidebar();
+      if (event.type === "open-request" && browserEventMatchesProject(event, projectRoot)) openBrowserSidebar();
     }) ?? null;
     // The composer's "+" menu fires `ade:work:start-orchestrator-chat` to
     // ask TerminalsPage to switch to the orchestrator-lead draft (parallel
@@ -560,7 +578,7 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
       window.removeEventListener("ade:work:stop-orchestrator-chat", stopOrchestratorChat);
       unsubscribeBrowserEvents?.();
     };
-  }, [active, setViewMode, setWorkSidebarTab, showDraftKind]);
+  }, [active, projectRoot, setViewMode, setWorkSidebarTab, showDraftKind]);
 
   const toggleSessionsPane = useCallback(() => {
     work.setWorkFocusSessionsHidden(!work.workFocusSessionsHidden);

--- a/apps/desktop/src/renderer/components/terminals/WorkSidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkSidebar.test.tsx
@@ -13,6 +13,7 @@ import type {
   TerminalSessionSummary,
 } from "../../../shared/types";
 import { ADE_WORK_PTY_CONTEXT_INSERTED_EVENT } from "../../lib/workPtyContextEvents";
+import { useAppStore } from "../../state/appStore";
 import { WorkSidebar, type WorkSidebarContextTarget } from "./WorkSidebar";
 
 vi.mock("../chat/ChatIosSimulatorPanel", async () => {
@@ -341,6 +342,7 @@ describe("WorkSidebar context targets", () => {
 
   afterEach(() => {
     cleanup();
+    useAppStore.setState({ project: null } as any);
     delete (window as unknown as { ade?: unknown }).ade;
     vi.restoreAllMocks();
   });
@@ -525,5 +527,44 @@ describe("WorkSidebar context targets", () => {
 
     await waitFor(() => expect(screen.queryByText(/This Browser view is claimed/)).toBeNull());
     expect((screen.getByText("Add Browser context") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("scopes Browser sidebar status to the current project and ignores malformed open events", async () => {
+    installAdeMock({
+      browserStatus: {
+        ...defaultBrowserStatus,
+        profileProjectRoot: "/repo-one",
+      },
+    });
+    useAppStore.setState({
+      project: { rootPath: "/repo-one", name: "Repo One" },
+    } as any);
+    const browserEventListener: {
+      current: ((event: { type?: string; status?: unknown }) => void) | null;
+    } = { current: null };
+    const browser = window.ade.builtInBrowser;
+    vi.mocked(browser.onEvent).mockImplementation((listener) => {
+      browserEventListener.current = (event) => listener(event as Parameters<typeof listener>[0]);
+      return () => {};
+    });
+
+    renderSidebar({
+      tab: "browser",
+      contextTarget: { kind: "chat", sessionId: "chat-1" },
+    });
+
+    await waitFor(() => {
+      expect(browser.getStatus).toHaveBeenCalledWith({
+        projectRoot: "/repo-one",
+      });
+    });
+    expect(() => browserEventListener.current?.({ type: "open-request" })).not.toThrow();
+    expect(() => browserEventListener.current?.({
+      type: "status",
+      status: {
+        ...defaultBrowserStatus,
+        profileProjectRoot: "/repo-two",
+      },
+    })).not.toThrow();
   });
 });

--- a/apps/desktop/src/renderer/components/terminals/WorkSidebar.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkSidebar.tsx
@@ -21,7 +21,7 @@ import type {
   TerminalSessionSummary,
   TerminalToolType,
 } from "../../../shared/types";
-import type { WorkDraftKind, WorkSidebarTab } from "../../state/appStore";
+import { useAppStore, type WorkDraftKind, type WorkSidebarTab } from "../../state/appStore";
 import {
   formatAppControlContextForPrompt,
   formatBuiltInBrowserContextForPrompt,
@@ -142,11 +142,33 @@ function formatAttachmentForPty(attachment: AgentChatFileRef): string {
   ].join("\n");
 }
 
-function hideBuiltInBrowserView(): void {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function browserEventProjectRoot(value: unknown): string | null | undefined {
+  if (!isRecord(value)) return undefined;
+  if ("profileProjectRoot" in value) {
+    const root = value.profileProjectRoot;
+    return typeof root === "string" && root.trim().length > 0 ? root : null;
+  }
+  return browserEventProjectRoot(value.status);
+}
+
+function browserEventMatchesProject(event: unknown, projectRoot: string | null): boolean {
+  const root = browserEventProjectRoot(event);
+  if (root === undefined) return projectRoot == null;
+  if (!projectRoot) return root === null;
+  return root === projectRoot;
+}
+
+function hideBuiltInBrowserView(projectRoot: string | null): void {
   const browser = window.ade?.builtInBrowser;
   if (!browser) return;
-  void browser.stopInspect().catch(() => {});
+  const scope = projectRoot ? { projectRoot } : {};
+  void browser.stopInspect(scope).catch(() => {});
   void browser.setBounds({
+    ...scope,
     x: 0,
     y: 0,
     width: 0,
@@ -191,6 +213,7 @@ export function WorkSidebar({
   const [appControlSession, setAppControlSession] = useState<AppControlSession | null>(null);
   const [iosSession, setIosSession] = useState<IosSimulatorSession | null>(null);
   const [browserStatus, setBrowserStatus] = useState<BuiltInBrowserStatus | null>(null);
+  const projectRoot = useAppStore((s) => s.project?.rootPath ?? null);
   const sidebarRef = useRef<HTMLElement | null>(null);
   const [compactTabs, setCompactTabs] = useState(false);
 
@@ -223,12 +246,12 @@ export function WorkSidebar({
   useEffect(() => {
     const wasBrowser = previousBrowserTabRef.current;
     const isBrowser = active && tab === "browser";
-    if (wasBrowser && !isBrowser) hideBuiltInBrowserView();
+    if (wasBrowser && !isBrowser) hideBuiltInBrowserView(projectRoot);
     previousBrowserTabRef.current = isBrowser;
     return () => {
-      if (previousBrowserTabRef.current) hideBuiltInBrowserView();
+      if (previousBrowserTabRef.current) hideBuiltInBrowserView(projectRoot);
     };
-  }, [active, tab]);
+  }, [active, projectRoot, tab]);
 
   useEffect(() => {
     if (!active) return undefined;
@@ -236,7 +259,8 @@ export function WorkSidebar({
     const browser = window.ade?.builtInBrowser;
     if (!browser?.getStatus || !browser.onEvent) return undefined;
     let cancelled = false;
-    void browser.getStatus()
+    const scope = projectRoot ? { projectRoot } : {};
+    void browser.getStatus(scope)
       .then((status) => {
         if (!cancelled) setBrowserStatus(status);
       })
@@ -245,14 +269,16 @@ export function WorkSidebar({
       });
     const unsubscribe = browser.onEvent((event) => {
       if (event.type === "status" || event.type === "open-request") {
-        setBrowserStatus(event.status);
+        if (!isRecord(event.status)) return;
+        if (!browserEventMatchesProject(event, projectRoot)) return;
+        setBrowserStatus(event.status as BuiltInBrowserStatus);
       }
     });
     return () => {
       cancelled = true;
       unsubscribe();
     };
-  }, [active, tab]);
+  }, [active, projectRoot, tab]);
 
   useEffect(() => {
     if (!active) return undefined;
@@ -568,7 +594,7 @@ export function WorkSidebar({
           activeItem={tab}
           compact={compactTabs}
           onItemClick={(nextTab) => {
-            if (tab === "browser" && nextTab !== "browser") hideBuiltInBrowserView();
+            if (tab === "browser" && nextTab !== "browser") hideBuiltInBrowserView(projectRoot);
             onTabChange(nextTab);
           }}
         />
@@ -577,7 +603,7 @@ export function WorkSidebar({
           className="ade-shell-control inline-flex w-9 shrink-0 items-center justify-center self-stretch rounded-none border-l border-white/[0.08] text-muted-fg/70 transition-colors hover:bg-white/[0.04] hover:text-fg"
           data-variant="ghost"
           onClick={() => {
-            if (tab === "browser") hideBuiltInBrowserView();
+            if (tab === "browser") hideBuiltInBrowserView(projectRoot);
             onClose();
           }}
           title="Close Tools sidebar"


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fbrowser-project-tab-isolation-87974291 num=518 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fbrowser-project-tab-isolation-87974291&amp;pr=518">ade/browser-project-tab-isolation-87974291 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=518">PR #518</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces project tab isolation for the built-in browser, ensuring that each project's browser state is independently scoped and events/API calls are routed to the correct project even in multi-project tab windows.

- **Browser service routing**: `serviceForWindowProfile` is refactored to support routing to an inactive project's browser service without marking it as the active service; `serviceForInput` is reordered to prefer explicit `projectRoot` over source-window routing.
- **IPC pipeline**: Project scope (`projectRoot`) is threaded through all browser IPC parsers (navigate, createTab, switchTab, closeTab via `parseBuiltInBrowserClaimArgs`; setBounds, attachWebview, claim, wait, selectPoint, getStatus, startInspect, stopInspect, selectCurrent, clearSelection explicitly), and the preload switches to a keyed cache for `getStatus`.
- **Renderer-side scoping**: `ChatBuiltInBrowserPanel`, `WorkSidebar`, and `TerminalsPage` each read `projectRoot` from the app store and pass it as scope to all browser API calls; `browserEventMatchesProject` guards are added in all three components to filter cross-project events.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness of one open inconsistency in browser event handling.

The IPC pipeline correctly threads projectRoot through all parser chains. The service routing, preload cache keying, and renderer-side event filtering are internally consistent. One confirmed behavioural gap (noted in a prior review comment that remains open): ChatBuiltInBrowserPanel's browserEventMatchesProject returns true for events carrying no profileProjectRoot regardless of whether a project is open, while TerminalsPage and WorkSidebar accept those same events only when no project is active.

apps/desktop/src/renderer/components/chat/ChatBuiltInBrowserPanel.tsx — the browserEventMatchesProject guard diverges from the other two components for legacy/fallback events.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.ts | Core routing refactor: serviceForWindowProfile adds markActive option; serviceForProjectRoot no longer forces active; serviceForInput reordered to prefer projectRoot over sourceWindow; windowForProjectRoot drops active-project match guard — all intentional for tab isolation. |
| apps/desktop/src/renderer/components/chat/ChatBuiltInBrowserPanel.tsx | Adds browserScope/withBrowserScope helpers and passes projectRoot to all browser API calls; browserEventMatchesProject accepts events without profileProjectRoot unconditionally (unlike TerminalsPage/WorkSidebar which gate on projectRoot == null). |
| apps/desktop/src/renderer/components/app/TopBar.tsx | Adds localStorage-based cross-window drag-drop coordination: markProjectTabDropHandled is written on successful drop, consumeRecentProjectTabDropHandled (with 5s TTL) replaces the old droppedOnAdeTarget guard for deciding whether to call openProjectInNewWindow. |
| apps/desktop/src/main/services/ipc/registerIpc.ts | Adds parseBuiltInBrowserProjectScopeArgs/parseBuiltInBrowserProjectScopeInput helpers; propagates projectRoot into all relevant parsers (navigate/createTab/switchTab/closeTab via the existing parseBuiltInBrowserClaimArgs cascade); updates six IPC handlers to accept and forward the new arg. |
| apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx | Adds browserEventMatchesProject filter on open-request events — correctly rejects events without profileProjectRoot when a project is open, consistent with WorkSidebar semantics. |
| apps/desktop/src/renderer/components/terminals/WorkSidebar.tsx | Scopes getStatus and browser event subscription to the active project; hideBuiltInBrowserView now accepts projectRoot for scoped stopInspect/setBounds calls; isRecord guard prevents setBrowserStatus(undefined) from open-request events. |
| apps/desktop/src/preload/preload.ts | Switches builtInBrowserStatusCache from a plain to a keyed cache (serialised by projectRoot); updates getStatus, startInspect, stopInspect, selectCurrent, clearSelection in the contextBridge to forward the new scope args. |
| apps/desktop/src/main/main.ts | Adds projectWindowTitle and setWindowTitle helpers; emitProjectChangedToWindow now sets the window title via bindingForLocalProject; emitProjectBindingChangedToWindow sets title only for remote bindings; removes automatic project activation on window selection. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Renderer (ChatPanel/WorkSidebar)
    participant P as Preload (contextBridge)
    participant IPC as IPC Layer (registerIpc)
    participant SVC as BuiltInBrowserService
    participant WIN as Target Window (BrowserWindow)

    R->>P: "getStatus({ projectRoot })"
    P->>P: serializeIpcCacheArgs → keyed cache lookup
    P->>IPC: "invoke(builtInBrowserGetStatus, { projectRoot })"
    IPC->>IPC: parseBuiltInBrowserProjectScopeInput
    IPC->>SVC: getStatus(scopeArgs, sourceWin)
    SVC->>SVC: serviceForInput: projectRoot → serviceForProjectRoot
    SVC->>WIN: profileForProjectRoot(projectRoot) → service
    WIN-->>SVC: status (profileProjectRoot scoped)
    SVC-->>IPC: BuiltInBrowserStatus
    IPC-->>P: status
    P-->>R: status

    Note over SVC,WIN: markActive=false when win active project ≠ requested project

    R->>P: "navigate({ url, projectRoot })"
    P->>IPC: "invoke(builtInBrowserNavigate, { url, projectRoot })"
    IPC->>IPC: parseBuiltInBrowserNavigateArgs → parseBuiltInBrowserClaimArgs → projectRoot extracted
    IPC->>SVC: navigate(args, sourceWin)
    SVC->>SVC: serviceForInput: projectRoot wins over sourceWin
    SVC->>WIN: route to correct project WindowBrowserService
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/desktop/src/renderer/components/chat/ChatBuiltInBrowserPanel.tsx`, line 748-753 ([link](https://github.com/arul28/ade/blob/cb58f9cb4ab3a7b05acd00110677e15dc4780172/apps/desktop/src/renderer/components/chat/ChatBuiltInBrowserPanel.tsx#L748-L753)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Inconsistent `undefined`-root guard vs. `TerminalsPage` / `WorkSidebar`**

   `browserEventMatchesProject` here returns `true` when `eventProjectRoot` yields `undefined` (i.e. the event carries no `profileProjectRoot`), so every project-less browser event — status updates, navigate, etc. — will always be applied to this panel regardless of the active project. `TerminalsPage.tsx` and `WorkSidebar.tsx` both use `return projectRoot == null` for the same case, meaning they only accept such events when no project is open. In a multi-window setup an event emitted without `profileProjectRoot` (e.g. from the fallback service or an older code path) will update this panel's status even when the event belongs to a different project context, whereas the sidebar panels correctly ignore it.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/chat/ChatBuiltInBrowserPanel.tsx
   Line: 748-753

   Comment:
   **Inconsistent `undefined`-root guard vs. `TerminalsPage` / `WorkSidebar`**

   `browserEventMatchesProject` here returns `true` when `eventProjectRoot` yields `undefined` (i.e. the event carries no `profileProjectRoot`), so every project-less browser event — status updates, navigate, etc. — will always be applied to this panel regardless of the active project. `TerminalsPage.tsx` and `WorkSidebar.tsx` both use `return projectRoot == null` for the same case, meaning they only accept such events when no project is open. In a multi-window setup an event emitted without `profileProjectRoot` (e.g. from the fallback service or an older code path) will update this panel's status even when the event belongs to a different project context, whereas the sidebar panels correctly ignore it.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FChatBuiltInBrowserPanel.tsx%0ALine%3A%20748-753%0A%0AComment%3A%0A**Inconsistent%20%60undefined%60-root%20guard%20vs.%20%60TerminalsPage%60%20%2F%20%60WorkSidebar%60**%0A%0A%60browserEventMatchesProject%60%20here%20returns%20%60true%60%20when%20%60eventProjectRoot%60%20yields%20%60undefined%60%20%28i.e.%20the%20event%20carries%20no%20%60profileProjectRoot%60%29%2C%20so%20every%20project-less%20browser%20event%20%E2%80%94%20status%20updates%2C%20navigate%2C%20etc.%20%E2%80%94%20will%20always%20be%20applied%20to%20this%20panel%20regardless%20of%20the%20active%20project.%20%60TerminalsPage.tsx%60%20and%20%60WorkSidebar.tsx%60%20both%20use%20%60return%20projectRoot%20%3D%3D%20null%60%20for%20the%20same%20case%2C%20meaning%20they%20only%20accept%20such%20events%20when%20no%20project%20is%20open.%20In%20a%20multi-window%20setup%20an%20event%20emitted%20without%20%60profileProjectRoot%60%20%28e.g.%20from%20the%20fallback%20service%20or%20an%20older%20code%20path%29%20will%20update%20this%20panel's%20status%20even%20when%20the%20event%20belongs%20to%20a%20different%20project%20context%2C%20whereas%20the%20sidebar%20panels%20correctly%20ignore%20it.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=518&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `apps/desktop/src/renderer/components/app/TopBar.tsx`, line 1657-1667 ([link](https://github.com/arul28/ade/blob/cb58f9cb4ab3a7b05acd00110677e15dc4780172/apps/desktop/src/renderer/components/app/TopBar.tsx#L1657-L1667)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`droppedOnAdeTarget` guard removed — non-tab-bar ADE drop targets now trigger `openProjectInNewWindow`**

   The previous guard `if (!draggedOutside || droppedOnAdeTarget || !rootPath) return` exited early for any accepted ADE drop. The new code substitutes `handledByAdeDropTarget`, which is only `true` when the target window's tab bar explicitly wrote the localStorage marker. If a project tab is dropped onto any other ADE drop target in a second window (one that never calls `markProjectTabDropHandled`), `droppedOnAdeTarget` will be truthy but `handledByAdeDropTarget` will be false, so `openProjectInNewWindow` will still be called — a regression from the previous behaviour. If the only valid drop target for project tabs is the tab bar this is safe, but it is worth confirming there are no other accepting elements.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/app/TopBar.tsx
   Line: 1657-1667

   Comment:
   **`droppedOnAdeTarget` guard removed — non-tab-bar ADE drop targets now trigger `openProjectInNewWindow`**

   The previous guard `if (!draggedOutside || droppedOnAdeTarget || !rootPath) return` exited early for any accepted ADE drop. The new code substitutes `handledByAdeDropTarget`, which is only `true` when the target window's tab bar explicitly wrote the localStorage marker. If a project tab is dropped onto any other ADE drop target in a second window (one that never calls `markProjectTabDropHandled`), `droppedOnAdeTarget` will be truthy but `handledByAdeDropTarget` will be false, so `openProjectInNewWindow` will still be called — a regression from the previous behaviour. If the only valid drop target for project tabs is the tab bar this is safe, but it is worth confirming there are no other accepting elements.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fapp%2FTopBar.tsx%0ALine%3A%201657-1667%0A%0AComment%3A%0A**%60droppedOnAdeTarget%60%20guard%20removed%20%E2%80%94%20non-tab-bar%20ADE%20drop%20targets%20now%20trigger%20%60openProjectInNewWindow%60**%0A%0AThe%20previous%20guard%20%60if%20%28!draggedOutside%20%7C%7C%20droppedOnAdeTarget%20%7C%7C%20!rootPath%29%20return%60%20exited%20early%20for%20any%20accepted%20ADE%20drop.%20The%20new%20code%20substitutes%20%60handledByAdeDropTarget%60%2C%20which%20is%20only%20%60true%60%20when%20the%20target%20window's%20tab%20bar%20explicitly%20wrote%20the%20localStorage%20marker.%20If%20a%20project%20tab%20is%20dropped%20onto%20any%20other%20ADE%20drop%20target%20in%20a%20second%20window%20%28one%20that%20never%20calls%20%60markProjectTabDropHandled%60%29%2C%20%60droppedOnAdeTarget%60%20will%20be%20truthy%20but%20%60handledByAdeDropTarget%60%20will%20be%20false%2C%20so%20%60openProjectInNewWindow%60%20will%20still%20be%20called%20%E2%80%94%20a%20regression%20from%20the%20previous%20behaviour.%20If%20the%20only%20valid%20drop%20target%20for%20project%20tabs%20is%20the%20tab%20bar%20this%20is%20safe%2C%20but%20it%20is%20worth%20confirming%20there%20are%20no%20other%20accepting%20elements.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=518&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: include local binding in window tit..."](https://github.com/arul28/ade/commit/65fea00b4fcf91def64cdf1d1fb774bc220d7099) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35228476)</sub>

<!-- /greptile_comment -->