### PR TITLE
Orchestrator Mode Guardrails

### DIFF
--- a/apps/desktop/src/main/services/chat/agentChatCliLaunch.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatCliLaunch.test.ts
@@ -125,6 +125,21 @@ describe("launchAgentChatCli worktree-path resolution", () => {
   });
 });
 
+describe("launchAgentChatCli orchestration policy", () => {
+  it("lets an orchestration role override stricter requested CLI permissions", async () => {
+    const deps = makeDeps();
+
+    await launchAgentChatCli(
+      makeArgs({ permissionMode: "plan", orchestrationRole: "worker" }),
+      deps,
+    );
+
+    const createArg = deps.create.mock.calls[0]?.[0] as PtyCreateArgs;
+    expect(createArg.args).toEqual(expect.arrayContaining(["--dangerously-bypass-approvals-and-sandbox"]));
+    expect(createArg.args).not.toEqual(expect.arrayContaining(["--sandbox", "read-only"]));
+  });
+});
+
 describe("launchAgentChatCli attached issue ids", () => {
   it("returns the durable terminal session before delayed kickoff input readiness", async () => {
     const deps = makeDeps();

--- a/apps/desktop/src/main/services/chat/agentChatCliLaunch.ts
+++ b/apps/desktop/src/main/services/chat/agentChatCliLaunch.ts
@@ -91,6 +91,7 @@ export async function launchAgentChatCli(
   const launch = buildTrackedCliLaunchCommand({
     provider,
     permissionMode,
+    orchestrationRole: arg.orchestrationRole ?? null,
     ...(provider === "claude" ? { sessionId } : {}),
     model: arg.model ?? null,
     reasoningEffort: arg.reasoningEffort ?? null,

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -2290,10 +2290,82 @@ describe("createAgentChatService", () => {
         expect(opts?.managedSettings?.allowedMcpServers).toEqual(
           expect.arrayContaining([expect.objectContaining({ serverName: "ade-orchestration" })]),
         );
-        expect(opts?.disallowedTools).toEqual(expect.arrayContaining(["Bash", "Edit", "Write"]));
+        expect(opts?.disallowedTools).toEqual(expect.arrayContaining(["Agent", "Bash", "Edit", "Task", "TodoWrite", "Write"]));
       } finally {
         await orchestrationService.dispose();
       }
+    });
+
+    it("keeps Claude lead sessions read-only even before an orchestration bundle is allocated", async () => {
+      vi.mocked(claudeSdkCreateSessionCompat).mockReturnValue({
+        send: vi.fn(),
+        stream: vi.fn(async function* () {
+          return;
+        }),
+        close: vi.fn(),
+        sessionId: "sdk-session-orchestrator-draft",
+      } as any);
+
+      const { service } = createService();
+      await service.createSession({
+        laneId: "lane-1",
+        provider: "claude",
+        model: "sonnet",
+        modelId: "anthropic/claude-sonnet-4-6",
+        interactionMode: "orchestrator-lead",
+      });
+
+      await vi.waitFor(() => {
+        expect(claudeSdkCreateSessionCompat).toHaveBeenCalled();
+      });
+
+      const opts = vi.mocked(claudeSdkCreateSessionCompat).mock.calls[0]?.[0] as any;
+      expect(opts?.mcpServers?.["ade-orchestration"]).toBeUndefined();
+      expect(opts?.disallowedTools).toEqual(expect.arrayContaining([
+        "Agent",
+        "Bash",
+        "Edit",
+        "MultiEdit",
+        "NotebookEdit",
+        "Task",
+        "TodoRead",
+        "TodoWrite",
+        "Write",
+      ]));
+    });
+
+    it("keeps Claude role-marked lead sessions read-only even when interaction mode is absent", async () => {
+      vi.mocked(claudeSdkCreateSessionCompat).mockReturnValue({
+        send: vi.fn(),
+        stream: vi.fn(async function* () {
+          return;
+        }),
+        close: vi.fn(),
+        sessionId: "sdk-session-role-lead",
+      } as any);
+
+      const { service } = createService();
+      await service.createSession({
+        laneId: "lane-1",
+        provider: "claude",
+        model: "sonnet",
+        modelId: "anthropic/claude-sonnet-4-6",
+        orchestrationRole: "lead",
+      });
+
+      await vi.waitFor(() => {
+        expect(claudeSdkCreateSessionCompat).toHaveBeenCalled();
+      });
+
+      const opts = vi.mocked(claudeSdkCreateSessionCompat).mock.calls[0]?.[0] as any;
+      expect(opts?.disallowedTools).toEqual(expect.arrayContaining([
+        "Agent",
+        "Bash",
+        "Edit",
+        "Task",
+        "TodoWrite",
+        "Write",
+      ]));
     });
 
     it("passes Claude subprocess spawns through the reaper", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -355,7 +355,15 @@ import { mapStopReasonToTerminalEvents } from "./stopReasonEvents";
 import { CURSOR_AVAILABLE_MODE_IDS } from "../../../shared/cursorModes";
 import { getApiKey } from "../ai/apiKeyStore";
 import type { createOrchestrationService } from "../orchestration/orchestrationService";
-import { applyOrchestrationPermissionProfile } from "../orchestration/runtimeProfile";
+import {
+  ORCHESTRATION_LEAD_DENIED_CLAUDE_TOOLS,
+  applyOrchestrationPermissionProfile,
+  isOrchestrationInteractionMode,
+  isOrchestrationLeadSession,
+  lockedOrchestrationPermissionMode,
+  orchestrationInteractionModeForRole,
+  orchestrationRoleForInteractionMode,
+} from "../../../shared/orchestrationRuntimePolicy";
 import type { ProcessRegistryService } from "../runtime/processRegistryService";
 
 const CLAUDE_AGENT_SDK_VERSION = "0.2.139";
@@ -4288,43 +4296,6 @@ function toHarnessPermissionMode(
   return "edit";
 }
 
-function isOrchestrationInteractionMode(
-  mode: AgentChatInteractionMode | null | undefined,
-): mode is OrchestrationInteractionMode {
-  return mode === "orchestrator-lead"
-    || mode === "orchestrator-worker"
-    || mode === "orchestrator-validator";
-}
-
-function orchestrationRoleForMode(
-  mode: OrchestrationInteractionMode,
-): OrchestrationSessionContext["role"] {
-  if (mode === "orchestrator-lead") return "lead";
-  if (mode === "orchestrator-validator") return "validator";
-  return "worker";
-}
-
-function orchestrationInteractionModeForRole(
-  role: OrchestrationSessionContext["role"],
-): OrchestrationInteractionMode {
-  if (role === "lead") return "orchestrator-lead";
-  if (role === "validator") return "orchestrator-validator";
-  return "orchestrator-worker";
-}
-
-function lockedOrchestrationPermissionMode(
-  session: Pick<AgentChatSession, "interactionMode" | "orchestrationRole">,
-): AgentChatSession["permissionMode"] | null {
-  const role = session.orchestrationRole
-    ?? (isOrchestrationInteractionMode(session.interactionMode)
-      ? orchestrationRoleForMode(session.interactionMode)
-      : null);
-  // All orchestration roles use full-auto (bypassPermissions). The lead's
-  // security comes from the tool-set restriction (no write tools), not the
-  // permission mode. Plan mode would block orchestration tools.
-  return role ? "full-auto" : null;
-}
-
 function enforceOrchestrationLockedPermissionMode(
   session: Pick<
     AgentChatSession,
@@ -4423,13 +4394,6 @@ function collectOrchestrationFields(
 
 const ORCHESTRATION_CLAUDE_SERVER_NAME = "ade-orchestration";
 const ORCHESTRATION_CODEX_TOOL_NAMESPACE = "ade_orchestration";
-const ORCHESTRATION_LEAD_DENIED_CLAUDE_TOOLS = new Set([
-  "Bash",
-  "Edit",
-  "MultiEdit",
-  "Write",
-  "NotebookEdit",
-]);
 
 function stripJsonSchemaMeta(schema: unknown): unknown {
   if (!schema || typeof schema !== "object" || Array.isArray(schema)) return schema;
@@ -5536,12 +5500,14 @@ export function createAgentChatService(args: {
     managed: ManagedChatSession,
   ): ClaudeSDKOptions["canUseTool"] => async (toolName, input, sdkOptions): Promise<ClaudePermissionResult> => {
     if (
-      managed.session.interactionMode === "orchestrator-lead"
-      && ORCHESTRATION_LEAD_DENIED_CLAUDE_TOOLS.has(toolName)
+      isOrchestrationLeadSession(managed.session)
+      && ORCHESTRATION_LEAD_DENIED_CLAUDE_TOOLS.includes(
+        toolName as (typeof ORCHESTRATION_LEAD_DENIED_CLAUDE_TOOLS)[number],
+      )
     ) {
       return {
         behavior: "deny",
-        message: "Orchestrator lead sessions cannot edit files or run bash directly. Spawn a worker with spawnAgent instead.",
+        message: "Orchestrator lead sessions cannot use Claude's direct coding tools. Use orchestration tools like spawnAgent instead.",
       };
     }
 
@@ -8934,7 +8900,7 @@ export function createAgentChatService(args: {
       sessionContext: {
         sessionId: managed.session.id,
         runId,
-        role: managed.session.orchestrationRole ?? orchestrationRoleForMode(interactionMode),
+        role: managed.session.orchestrationRole ?? orchestrationRoleForInteractionMode(interactionMode),
         bundlePath,
         laneId: managed.session.laneId,
         ...(managed.session.orchestrationParentSessionId
@@ -15851,6 +15817,12 @@ export function createAgentChatService(args: {
         cwd: managed.laneWorktreePath,
       }),
     };
+    if (isOrchestrationLeadSession(managed.session)) {
+      opts.disallowedTools = Array.from(new Set([
+        ...(opts.disallowedTools ?? []),
+        ...ORCHESTRATION_LEAD_DENIED_CLAUDE_TOOLS,
+      ]));
+    }
     const orchestrationMcpServer = buildClaudeOrchestrationMcpServer(managed);
     if (orchestrationMcpServer) {
       opts.mcpServers = {
@@ -15869,12 +15841,6 @@ export function createAgentChatService(args: {
         allowManagedMcpServersOnly: true,
         strictPluginOnlyCustomization: ["mcp"],
       };
-      if (managed.session.interactionMode === "orchestrator-lead") {
-        opts.disallowedTools = Array.from(new Set([
-          ...(opts.disallowedTools ?? []),
-          ...ORCHESTRATION_LEAD_DENIED_CLAUDE_TOOLS,
-        ]));
-      }
     }
     logger.debug("agent_chat.claude_executable_resolved", {
       sessionId: managed.session.id,

--- a/apps/desktop/src/main/services/orchestration/runtimeProfile.ts
+++ b/apps/desktop/src/main/services/orchestration/runtimeProfile.ts
@@ -1,17 +1,8 @@
 import type {
-  AgentChatClaudePermissionMode,
-  AgentChatCodexApprovalPolicy,
-  AgentChatCodexConfigSource,
-  AgentChatCodexSandbox,
-  AgentChatCreateArgs,
-  AgentChatDroidPermissionMode,
-  AgentChatOpenCodePermissionMode,
-  AgentChatProvider,
-} from "../../../shared/types";
-import type {
   ModelSelection,
   OrchestrationManifest,
 } from "../../../shared/types/orchestration";
+export { applyOrchestrationPermissionProfile } from "../../../shared/orchestrationRuntimePolicy";
 
 export type OrchestrationRoutingResult = ModelSelection & {
   routingKey: "byRoleTag" | "byTag" | "byRole" | "default" | "fallback" | "override";
@@ -39,44 +30,6 @@ export function resolveOrchestrationModel(
     codexFastMode: false,
     routingKey: "fallback",
   };
-}
-
-export function applyOrchestrationPermissionProfile(
-  provider: AgentChatProvider | string,
-): Partial<Pick<
-  AgentChatCreateArgs,
-  | "claudePermissionMode"
-  | "codexApprovalPolicy"
-  | "codexSandbox"
-  | "codexConfigSource"
-  | "cursorModeId"
-  | "droidPermissionMode"
-  | "opencodePermissionMode"
->> {
-  switch (provider) {
-    case "claude":
-      return {
-        claudePermissionMode: "bypassPermissions" satisfies AgentChatClaudePermissionMode,
-      };
-    case "codex":
-      return {
-        codexSandbox: "danger-full-access" satisfies AgentChatCodexSandbox,
-        codexApprovalPolicy: "never" satisfies AgentChatCodexApprovalPolicy,
-        codexConfigSource: "flags" satisfies AgentChatCodexConfigSource,
-      };
-    case "cursor":
-      return { cursorModeId: "full-auto" };
-    case "droid":
-      return {
-        droidPermissionMode: "auto-high" satisfies AgentChatDroidPermissionMode,
-      };
-    case "opencode":
-      return {
-        opencodePermissionMode: "full-auto" satisfies AgentChatOpenCodePermissionMode,
-      };
-    default:
-      return {};
-  }
 }
 
 export function isOrchestrationPlanApproved(

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -3358,6 +3358,43 @@ describe("AgentChatPane submit recovery", () => {
     });
   });
 
+  it("does not send an orchestrator draft prompt when bundle allocation fails", async () => {
+    const { send, create, deleteChat } = installAdeMocks({ sessions: [], includeClaudeModel: true });
+    vi.mocked(window.ade.orchestration.runCreate).mockRejectedValueOnce(new Error("disk full"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      renderAutoCreateDraftPane({ workDraftKind: "chat-orchestrator" });
+
+      const modelTrigger = await screen.findByRole("button", { name: /^Select model/ });
+      const claudeLabel = getModelById("anthropic/claude-sonnet-4-6")?.displayName ?? "Claude Sonnet 4.6";
+      fireEvent.pointerDown(modelTrigger, { button: 0 });
+      fireEvent.click(modelTrigger);
+      fireEvent.click(await screen.findByRole("tab", { name: /^Anthropic$/i }));
+      await clickEnabledModelOption(new RegExp(escapeRegExp(claudeLabel), "i"));
+
+      const textbox = await screen.findByRole("textbox");
+      fireEvent.change(textbox, { target: { value: "Coordinate the release checklist." } });
+      fireEvent.click(await screen.findByRole("button", { name: "Send" }));
+
+      await waitFor(() => {
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({
+          interactionMode: "orchestrator-lead",
+          provider: "claude",
+        }));
+        expect(window.ade.orchestration.runCreate).toHaveBeenCalledWith({
+          laneId: "lane-1",
+          leadSessionId: "created-session",
+        });
+      });
+      expect(send).not.toHaveBeenCalled();
+      expect(deleteChat).toHaveBeenCalledWith({ sessionId: "created-session" });
+      expect(await screen.findByText("Orchestration bundle could not be allocated: disk full")).toBeTruthy();
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("background auto-create reports the new chat without stealing focus and shows a dismissible notice", async () => {
     const onSessionCreated = vi.fn();
     const { createLane, suggestLaneName } = installAdeMocks({ sessions: [] });

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -5580,8 +5580,8 @@ export function AgentChatPane({
       });
       // Follow-up: allocate the orchestration bundle. We do this immediately
       // so the bundle path is persisted alongside the new chat (workers will
-      // pick it up from the manifest). If it fails the chat is still usable;
-      // we surface the error so the user can retry.
+      // pick it up from the manifest). If it fails, stop before sending the
+      // first prompt so a half-created lead chat cannot start working.
       if (workDraftKind === "chat-orchestrator") {
         try {
           const runCreate = await window.ade.orchestration.runCreate({
@@ -5600,9 +5600,14 @@ export function AgentChatPane({
             "[AgentChatPane] orchestration.runCreate failed; lead chat created without bundle",
             runCreateError,
           );
-          setError(runCreateError instanceof Error
+          await window.ade.agentChat.delete({ sessionId: created.id }).catch((cleanupError: unknown) => {
+            console.warn("[AgentChatPane] orchestration lead cleanup failed", cleanupError);
+          });
+          const message = runCreateError instanceof Error
             ? `Orchestration bundle could not be allocated: ${runCreateError.message}`
-            : "Orchestration bundle could not be allocated.");
+            : "Orchestration bundle could not be allocated.";
+          setError(message);
+          throw new Error(message);
         }
       }
       const launchConfig = buildLastLaunchConfig({

--- a/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.test.ts
@@ -840,6 +840,31 @@ describe("useLaneWorkSessions — refresh-before-focus ordering", () => {
     expect((window as any).ade.pty.create.mock.calls.at(-1)?.[0]).not.toHaveProperty("awaitInitialInput");
   });
 
+  it("launchPtySession applies orchestration role policy in lane work panes", async () => {
+    const { result } = renderHook(() => useLaneWorkSessions("lane-1"));
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    await act(async () => {
+      await result.current.launchPtySession({
+        laneId: "lane-1",
+        profile: "codex",
+        permissionMode: "plan",
+        orchestrationRole: "worker",
+      });
+    });
+
+    expect((window as any).ade.pty.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        laneId: "lane-1",
+        toolType: "codex",
+        startupCommand: expect.stringContaining("--dangerously-bypass-approvals-and-sandbox"),
+      }),
+    );
+  });
+
   it("continues an ended agent CLI session from lane work panes", async () => {
     const closedCliSession = {
       ...makeSession("session-ended", "lane-1", "Ended Codex"),

--- a/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
@@ -634,6 +634,7 @@ export function useLaneWorkSessions(laneId: string | null) {
       const launchFields = resolveLaunchFields({
         profile: args.profile,
         ...(args.permissionMode !== undefined ? { permissionMode: args.permissionMode } : {}),
+        ...(args.orchestrationRole !== undefined ? { orchestrationRole: args.orchestrationRole } : {}),
         ...(args.startupCommand !== undefined ? { startupCommand: args.startupCommand } : {}),
         ...(args.command !== undefined ? { command: args.command } : {}),
         ...(args.args !== undefined ? { args: args.args } : {}),

--- a/apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts
@@ -69,6 +69,50 @@ describe("defaultTrackedCliStartupCommand", () => {
   });
 });
 
+describe("orchestration CLI launch policy", () => {
+  it("forces orchestration roles to full-auto for every tracked CLI runtime", () => {
+    const claude = buildTrackedCliLaunchCommand({
+      provider: "claude",
+      permissionMode: "plan",
+      orchestrationRole: "worker",
+    });
+    expect(claude.args).toContain("--dangerously-skip-permissions");
+    expect(claude.args).not.toEqual(expect.arrayContaining(["--permission-mode", "plan"]));
+
+    const codex = buildTrackedCliLaunchCommand({
+      provider: "codex",
+      permissionMode: "plan",
+      orchestrationRole: "worker",
+    });
+    expect(codex.args).toEqual(expect.arrayContaining(["--dangerously-bypass-approvals-and-sandbox"]));
+    expect(codex.args).not.toEqual(expect.arrayContaining(["--sandbox", "read-only"]));
+
+    const cursor = buildTrackedCliLaunchCommand({
+      provider: "cursor",
+      permissionMode: "plan",
+      orchestrationRole: "validator",
+    });
+    expect(cursor.args).toContain("--force");
+    expect(cursor.args).not.toEqual(expect.arrayContaining(["--mode", "plan"]));
+
+    const droid = buildTrackedCliLaunchCommand({
+      provider: "droid",
+      permissionMode: "plan",
+      orchestrationRole: "worker",
+    });
+    expect(droid.startupCommand).toContain('\\"autonomyLevel\\":\\"high\\"');
+    expect(droid.startupCommand).not.toContain('\\"interactionMode\\":\\"spec\\"');
+
+    const opencode = buildTrackedCliLaunchCommand({
+      provider: "opencode",
+      permissionMode: "plan",
+      orchestrationRole: "validator",
+    });
+    expect(opencode.args).not.toEqual(expect.arrayContaining(["--agent", "plan"]));
+    expect(opencode.env?.OPENCODE_CONFIG_CONTENT).toContain('"permission":"allow"');
+  });
+});
+
 describe("resolveCleanShellLaunchFields", () => {
   it("starts zsh without reading user startup files", () => {
     expect(resolveCleanShellLaunchFields({ platform: "darwin", shell: "/bin/zsh" })).toEqual({

--- a/apps/desktop/src/renderer/components/terminals/cliLaunch.ts
+++ b/apps/desktop/src/renderer/components/terminals/cliLaunch.ts
@@ -2,6 +2,7 @@ import type { LaunchProfile } from "../../../shared/cliLaunch";
 import type { AgentChatPermissionMode } from "../../../shared/types";
 import type { LaneLinearIssue } from "../../../shared/types";
 import type { PtyCreateResult } from "../../../shared/types";
+import type { OrchestrationRole } from "../../../shared/types/orchestration";
 
 export * from "../../../shared/cliLaunch";
 
@@ -12,6 +13,7 @@ export type WorkPtyLaunchArgs = {
   profile: LaunchProfile;
   title?: string;
   permissionMode?: AgentChatPermissionMode;
+  orchestrationRole?: OrchestrationRole | null;
   startupCommand?: string;
   startupDelayMs?: number;
   initialInput?: string;

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -1312,6 +1312,7 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
       const launchFields = resolveLaunchFields({
         profile: args.profile,
         ...(args.permissionMode !== undefined ? { permissionMode: args.permissionMode } : {}),
+        ...(args.orchestrationRole !== undefined ? { orchestrationRole: args.orchestrationRole } : {}),
         ...(args.startupCommand !== undefined ? { startupCommand: args.startupCommand } : {}),
         ...(args.command !== undefined ? { command: args.command } : {}),
         ...(args.args !== undefined ? { args: args.args } : {}),

--- a/apps/desktop/src/shared/cliLaunch.ts
+++ b/apps/desktop/src/shared/cliLaunch.ts
@@ -14,7 +14,9 @@ import { buildAdeCliAgentGuidance, buildAdeCliInlineGuidance } from "./adeCliGui
 import { isProviderSlashCommandInput } from "./chatSlashCommands";
 import { resolveClaudeCliModelAlias } from "./claudeCliModels";
 import { decodeOpenCodeRegistryId } from "./modelRegistry";
+import { effectiveOrchestrationPermissionMode } from "./orchestrationRuntimePolicy";
 import { commandArrayToLine, quoteShellArg } from "./shell";
+import type { OrchestrationRole } from "./types/orchestration";
 
 export type CliProvider = "claude" | "codex" | "cursor" | "droid" | "opencode";
 export type LaunchProfile = CliProvider | "shell";
@@ -279,6 +281,7 @@ function withAdeAgentSkillEnv(
 export function buildTrackedCliStartupCommand(args: {
   provider: CliProvider;
   permissionMode: AgentChatPermissionMode;
+  orchestrationRole?: OrchestrationRole | null;
   /** Pre-assigned session ID for Claude CLI (enables reliable resume). */
   sessionId?: string;
   /** Optional runtime model for fresh launches. Continuation commands intentionally ignore it. */
@@ -296,6 +299,7 @@ export function buildTrackedCliStartupCommand(args: {
 export function buildTrackedCliLaunchCommand(args: {
   provider: CliProvider;
   permissionMode: AgentChatPermissionMode;
+  orchestrationRole?: OrchestrationRole | null;
   /** Pre-assigned session ID for Claude CLI (enables reliable resume). */
   sessionId?: string;
   /** Optional runtime model for fresh launches. Continuation commands intentionally ignore it. */
@@ -307,7 +311,8 @@ export function buildTrackedCliLaunchCommand(args: {
   /** Active lane worktree used to make ADE skill roots lane-aware. */
   laneWorktreePath?: string | null;
 }): TrackedCliLaunchCommand {
-  validateLaunchProfilePermissionMode(args.provider, args.permissionMode);
+  const permissionMode = effectiveOrchestrationPermissionMode(args);
+  validateLaunchProfilePermissionMode(args.provider, permissionMode);
   const initialPrompt = normalizeInitialPrompt(args.initialPrompt);
   const skillRoots = args.laneWorktreePath
     ? getAgentSkillRootCandidates({ cwd: args.laneWorktreePath })
@@ -330,7 +335,7 @@ export function buildTrackedCliLaunchCommand(args: {
     }
     const guidance = buildAdeCliAgentGuidance(skillRoots);
     commandArgs.push("--append-system-prompt", guidance);
-    commandArgs.push(...permissionModeToClaudeFlag(args.permissionMode));
+    commandArgs.push(...permissionModeToClaudeFlag(permissionMode));
     if (initialPrompt) {
       commandArgs.push(initialPrompt);
     }
@@ -355,7 +360,7 @@ export function buildTrackedCliLaunchCommand(args: {
       "--no-alt-screen",
       ...modelToCliFlag(codexModel),
       ...codexReasoningEffortFlags(args.reasoningEffort),
-      ...permissionModeToCodexFlags(args.permissionMode),
+      ...permissionModeToCodexFlags(permissionMode),
     ];
     const usePromptArg = codexModel === "gpt-5.3-codex";
     if (usePromptArg) commandArgs.push(initialInput);
@@ -372,7 +377,7 @@ export function buildTrackedCliLaunchCommand(args: {
     const prompt = workTabCliPrompt(initialPrompt, skillRoots);
     const cursorModel = resolveCursorCliModelForLaunch(args.model);
     const commandArgs = [
-      ...permissionModeToCursorFlags(args.permissionMode),
+      ...permissionModeToCursorFlags(permissionMode),
       ...modelToCliFlag(cursorModel),
       prompt,
     ];
@@ -389,7 +394,7 @@ export function buildTrackedCliLaunchCommand(args: {
     const platform = typeof process !== "undefined" && typeof process.platform === "string" ? process.platform : "";
     if (platform === "win32") {
       const startupCommand = droidPowerShellCommand({
-        permissionMode: args.permissionMode,
+        permissionMode,
         model: args.model,
         reasoningEffort: args.reasoningEffort,
         prompt,
@@ -402,7 +407,7 @@ export function buildTrackedCliLaunchCommand(args: {
       };
     }
     const startupCommand = buildDroidCommandLine({
-      permissionMode: args.permissionMode,
+      permissionMode,
       model: args.model,
       reasoningEffort: args.reasoningEffort,
       prompt,
@@ -416,7 +421,7 @@ export function buildTrackedCliLaunchCommand(args: {
   }
 
   const opencode = buildOpenCodeCommandParts({
-    permissionMode: args.permissionMode,
+    permissionMode,
     model: args.model,
     prompt: workTabCliPrompt(initialPrompt, skillRoots),
   });
@@ -782,6 +787,7 @@ export function resolveTrackedCliResumeCommand(session: Pick<TerminalSessionSumm
 export function resolveLaunchFields<P extends LaunchProfile>(args: {
   profile: P;
   permissionMode?: AgentChatPermissionMode;
+  orchestrationRole?: OrchestrationRole | null;
   startupCommand?: string;
   command?: string;
   args?: string[];
@@ -796,7 +802,8 @@ export function resolveLaunchFields<P extends LaunchProfile>(args: {
   initialInput?: string;
   initialInputDelayMs?: number;
 } {
-  validateLaunchProfilePermissionMode(args.profile, args.permissionMode);
+  const permissionMode = effectiveOrchestrationPermissionMode(args);
+  validateLaunchProfilePermissionMode(args.profile, permissionMode);
 
   const callerHasOverride =
     args.startupCommand !== undefined
@@ -821,7 +828,8 @@ export function resolveLaunchFields<P extends LaunchProfile>(args: {
 
   const defaultLaunch = buildTrackedCliLaunchCommand({
     provider: args.profile,
-    permissionMode: args.permissionMode ?? "default",
+    permissionMode,
+    orchestrationRole: args.orchestrationRole,
   });
   return {
     startupCommand: defaultLaunch.startupCommand,

--- a/apps/desktop/src/shared/orchestrationRuntimePolicy.test.ts
+++ b/apps/desktop/src/shared/orchestrationRuntimePolicy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  ORCHESTRATION_LEAD_DENIED_CLAUDE_TOOLS,
+  applyOrchestrationPermissionProfile,
+  effectiveOrchestrationPermissionMode,
+  isOrchestrationInteractionMode,
+  isOrchestrationLeadSession,
+  lockedOrchestrationPermissionMode,
+  orchestrationInteractionModeForRole,
+  orchestrationRoleForInteractionMode,
+} from "./orchestrationRuntimePolicy";
+import type { AgentChatCliLaunchProvider } from "./types/chat";
+import type { OrchestrationRole } from "./types/orchestration";
+
+const PROVIDER_PROFILE_EXPECTATIONS: Record<AgentChatCliLaunchProvider, Record<string, unknown>> = {
+  claude: { claudePermissionMode: "bypassPermissions" },
+  codex: {
+    codexApprovalPolicy: "never",
+    codexSandbox: "danger-full-access",
+    codexConfigSource: "flags",
+  },
+  cursor: { cursorModeId: "full-auto" },
+  droid: { droidPermissionMode: "auto-high" },
+  opencode: { opencodePermissionMode: "full-auto" },
+};
+
+describe("orchestrationRuntimePolicy", () => {
+  it("maps orchestration roles and interaction modes consistently", () => {
+    const roles: OrchestrationRole[] = ["lead", "worker", "validator"];
+    for (const role of roles) {
+      const mode = orchestrationInteractionModeForRole(role);
+      expect(isOrchestrationInteractionMode(mode)).toBe(true);
+      expect(orchestrationRoleForInteractionMode(mode)).toBe(role);
+      expect(lockedOrchestrationPermissionMode({ orchestrationRole: role })).toBe("full-auto");
+      expect(lockedOrchestrationPermissionMode({ interactionMode: mode })).toBe("full-auto");
+      expect(isOrchestrationLeadSession({ orchestrationRole: role })).toBe(role === "lead");
+    }
+
+    expect(isOrchestrationInteractionMode("default")).toBe(false);
+    expect(lockedOrchestrationPermissionMode({ interactionMode: "plan" })).toBeNull();
+  });
+
+  it("forces orchestration launches to full-auto before provider-specific adapters run", () => {
+    expect(effectiveOrchestrationPermissionMode({
+      permissionMode: "plan",
+      orchestrationRole: "lead",
+    })).toBe("full-auto");
+    expect(effectiveOrchestrationPermissionMode({
+      permissionMode: "edit",
+      interactionMode: "orchestrator-worker",
+    })).toBe("full-auto");
+    expect(effectiveOrchestrationPermissionMode({ permissionMode: "plan" })).toBe("plan");
+    expect(effectiveOrchestrationPermissionMode({})).toBe("default");
+  });
+
+  it("defines a permission profile for every chat and CLI provider ADE launches", () => {
+    for (const [provider, expected] of Object.entries(PROVIDER_PROFILE_EXPECTATIONS)) {
+      expect(applyOrchestrationPermissionProfile(provider)).toEqual(expected);
+    }
+  });
+
+  it("denies Claude-native direct-work tools for orchestrator leads", () => {
+    expect(ORCHESTRATION_LEAD_DENIED_CLAUDE_TOOLS).toEqual(expect.arrayContaining([
+      "Agent",
+      "Bash",
+      "Edit",
+      "MultiEdit",
+      "NotebookEdit",
+      "Task",
+      "TodoRead",
+      "TodoWrite",
+      "Write",
+    ]));
+  });
+});

--- a/apps/desktop/src/shared/orchestrationRuntimePolicy.ts
+++ b/apps/desktop/src/shared/orchestrationRuntimePolicy.ts
@@ -1,0 +1,138 @@
+import type {
+  AgentChatClaudePermissionMode,
+  AgentChatCodexApprovalPolicy,
+  AgentChatCodexConfigSource,
+  AgentChatCodexSandbox,
+  AgentChatCreateArgs,
+  AgentChatDroidPermissionMode,
+  AgentChatInteractionMode,
+  AgentChatOpenCodePermissionMode,
+  AgentChatPermissionMode,
+  AgentChatProvider,
+} from "./types";
+import type { OrchestrationRole } from "./types/orchestration";
+
+export type OrchestrationInteractionMode = Extract<
+  AgentChatInteractionMode,
+  "orchestrator-lead" | "orchestrator-worker" | "orchestrator-validator"
+>;
+
+export type OrchestrationRuntimeSessionRef = {
+  interactionMode?: AgentChatInteractionMode | null;
+  orchestrationRole?: OrchestrationRole | null;
+};
+
+export type OrchestrationPermissionProfile = Partial<Pick<
+  AgentChatCreateArgs,
+  | "claudePermissionMode"
+  | "codexApprovalPolicy"
+  | "codexSandbox"
+  | "codexConfigSource"
+  | "cursorModeId"
+  | "droidPermissionMode"
+  | "opencodePermissionMode"
+>>;
+
+export const ORCHESTRATION_LOCKED_PERMISSION_MODE = "full-auto" satisfies AgentChatPermissionMode;
+
+export const ORCHESTRATION_LEAD_DENIED_CLAUDE_TOOLS = [
+  "Agent",
+  "Bash",
+  "Edit",
+  "MultiEdit",
+  "Task",
+  "TodoRead",
+  "TodoWrite",
+  "Write",
+  "NotebookEdit",
+] as const;
+
+const ORCHESTRATION_INTERACTION_MODE_TO_ROLE: Record<OrchestrationInteractionMode, OrchestrationRole> = {
+  "orchestrator-lead": "lead",
+  "orchestrator-worker": "worker",
+  "orchestrator-validator": "validator",
+};
+
+const ORCHESTRATION_ROLE_TO_INTERACTION_MODE: Record<OrchestrationRole, OrchestrationInteractionMode> = {
+  lead: "orchestrator-lead",
+  worker: "orchestrator-worker",
+  validator: "orchestrator-validator",
+};
+
+export function isOrchestrationInteractionMode(
+  mode: AgentChatInteractionMode | null | undefined,
+): mode is OrchestrationInteractionMode {
+  return mode === "orchestrator-lead"
+    || mode === "orchestrator-worker"
+    || mode === "orchestrator-validator";
+}
+
+export function orchestrationRoleForInteractionMode(
+  mode: OrchestrationInteractionMode,
+): OrchestrationRole {
+  return ORCHESTRATION_INTERACTION_MODE_TO_ROLE[mode];
+}
+
+export function orchestrationInteractionModeForRole(
+  role: OrchestrationRole,
+): OrchestrationInteractionMode {
+  return ORCHESTRATION_ROLE_TO_INTERACTION_MODE[role];
+}
+
+export function resolveOrchestrationRole(
+  session: OrchestrationRuntimeSessionRef,
+): OrchestrationRole | null {
+  if (session.orchestrationRole) return session.orchestrationRole;
+  return isOrchestrationInteractionMode(session.interactionMode)
+    ? orchestrationRoleForInteractionMode(session.interactionMode)
+    : null;
+}
+
+export function lockedOrchestrationPermissionMode(
+  session: OrchestrationRuntimeSessionRef,
+): AgentChatPermissionMode | null {
+  return resolveOrchestrationRole(session) ? ORCHESTRATION_LOCKED_PERMISSION_MODE : null;
+}
+
+export function isOrchestrationLeadSession(
+  session: OrchestrationRuntimeSessionRef,
+): boolean {
+  return resolveOrchestrationRole(session) === "lead";
+}
+
+export function effectiveOrchestrationPermissionMode(args: {
+  permissionMode?: AgentChatPermissionMode | null;
+  orchestrationRole?: OrchestrationRole | null;
+  interactionMode?: AgentChatInteractionMode | null;
+}): AgentChatPermissionMode {
+  return lockedOrchestrationPermissionMode(args) ?? args.permissionMode ?? "default";
+}
+
+export function applyOrchestrationPermissionProfile(
+  provider: AgentChatProvider | string,
+): OrchestrationPermissionProfile {
+  switch (provider) {
+    case "claude":
+      return {
+        claudePermissionMode: "bypassPermissions" satisfies AgentChatClaudePermissionMode,
+      };
+    case "codex":
+      return {
+        codexSandbox: "danger-full-access" satisfies AgentChatCodexSandbox,
+        codexApprovalPolicy: "never" satisfies AgentChatCodexApprovalPolicy,
+        codexConfigSource: "flags" satisfies AgentChatCodexConfigSource,
+      };
+    case "cursor":
+      return { cursorModeId: "full-auto" };
+    case "droid":
+      return {
+        droidPermissionMode: "auto-high" satisfies AgentChatDroidPermissionMode,
+      };
+    case "opencode":
+      return {
+        opencodePermissionMode: "full-auto" satisfies AgentChatOpenCodePermissionMode,
+      };
+    default:
+      return {};
+  }
+}

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -6,6 +6,7 @@ import type { ModelId } from "./core";
 import type { CtoCapabilityMode } from "./cto";
 import type { FileDiff } from "./git";
 import type { LaneLinearIssue, SessionLinearIssueLink } from "./lanes";
+import type { OrchestrationContextItem, OrchestrationRole } from "./orchestration";
 
 export type AgentChatProvider = "codex" | "claude" | "cursor" | "droid" | "opencode" | (string & {});
 
@@ -218,7 +219,7 @@ export type AgentChatLinearIssueContextAttachment = {
  */
 export type AgentChatOrchestrationAnnotationContextAttachment = {
   type: "orchestration_annotation";
-  item: import("./orchestration").OrchestrationContextItem;
+  item: OrchestrationContextItem;
   source?: "manual";
   attachedAt?: string;
 };
@@ -786,7 +787,7 @@ export type AgentChatInteractionMode =
  */
 export type OrchestrationSessionFields = {
   orchestrationRunId?: string;
-  orchestrationRole?: import("./orchestration").OrchestrationRole;
+  orchestrationRole?: OrchestrationRole;
   orchestrationParentSessionId?: string;
   orchestrationTag?: string;
   orchestrationStepId?: string;
@@ -1221,7 +1222,7 @@ export type AgentChatCreateArgs = {
   goal?: string | null;
   // Orchestration-mode fields — set when spawning into an orchestration run.
   orchestrationRunId?: string;
-  orchestrationRole?: import("./orchestration").OrchestrationRole;
+  orchestrationRole?: OrchestrationRole;
   orchestrationParentSessionId?: string;
   orchestrationTag?: string;
   orchestrationStepId?: string;
@@ -1264,6 +1265,8 @@ export type AgentChatLaunchCliArgs = {
   model?: string | null;
   reasoningEffort?: string | null;
   permissionMode?: AgentChatPermissionMode;
+  /** Optional orchestration role; when present, role policy overrides the requested permission mode. */
+  orchestrationRole?: OrchestrationRole | null;
   /** Prompt submitted to the CLI agent once it starts. */
   kickoffPrompt: string;
   /** Linear issues to attach to the new session before spawn. */


### PR DESCRIPTION
## Summary

Harden orchestrator mode so a lead chat cannot quietly act like a normal full-auto coding session, and centralize orchestration runtime policy across chat and CLI launches.

## What changed

- Added a shared orchestration runtime policy for role/mode mapping, locked full-auto orchestration permissions, provider-specific profiles, and Claude-native tool deny lists.
- Made Claude orchestrator leads deny direct coding tools even before an orchestration bundle/MCP server exists, including role-marked lead sessions.
- Made new orchestrator chats fail closed: if bundle allocation fails, the empty lead chat is cleaned up and the first prompt is not sent.
- Routed orchestration role policy through chat-launched CLI sessions, Work terminal launches, and lane Work panes for Claude, Codex, Cursor, Droid, and OpenCode.

## Validation

- `npm install` in `apps/desktop`, `apps/ade-cli`, and `apps/web`; no lockfile drift.
- `npm run typecheck` in `apps/desktop`, `apps/ade-cli`, and `apps/web`.
- `npm run lint` in `apps/desktop` passed with existing warnings only; targeted lint for touched files passed cleanly.
- `npx vitest run src/shared/orchestrationRuntimePolicy.test.ts src/main/services/chat/agentChatService.test.ts src/main/services/chat/agentChatCliLaunch.test.ts src/renderer/components/chat/AgentChatPane.test.tsx src/renderer/components/terminals/cliLaunch.test.ts src/renderer/components/lanes/useLaneWorkSessions.test.ts` passed before and after rebase; rebased run passed 593 tests.
- Full desktop shard sweep ran; transient unrelated runner/test flakes were narrowed and the exact failing files passed on rerun.
- `npm test` in `apps/ade-cli` initially hit unrelated transient TUI/RPC failures; the exact failing files passed on rerun.
- `npm run build` in `apps/desktop`, `apps/ade-cli`, and `apps/web`; desktop build was rerun after final production-code edits and again after rebase.
- `node scripts/validate-docs.mjs`.
- `git diff --check` and staged diff check.

## Risks

- Orchestrator lead sessions now fail closed if bundle creation fails; this is intentional, but it changes the old behavior where a half-created lead chat could still proceed.

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Forchestrator-mode-guardrails-072a106f num=519 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Forchestrator-mode-guardrails-072a106f&amp;pr=519">ade/orchestrator-mode-guardrails-072a106f branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=519">PR #519</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens orchestrator mode by centralizing orchestration runtime policy into a new shared module (`orchestrationRuntimePolicy.ts`) and enforcing guardrails consistently across chat, CLI, and terminal launch paths. It expands the lead-session tool deny list from 5 to 9 tools, applies that deny list even before a bundle/MCP server is allocated, and makes bundle-allocation failure fail-closed (deleting the orphaned lead session rather than letting it continue).

- **New `orchestrationRuntimePolicy.ts` module**: Moves `applyOrchestrationPermissionProfile`, `lockedOrchestrationPermissionMode`, and related helpers from `runtimeProfile.ts` into a shared module, expanding the lead deny list to include `Agent`, `Task`, `TodoRead`, and `TodoWrite` on top of the previous 5.
- **Fail-closed orchestrator creation** (`AgentChatPane.tsx`): When `runCreate` fails, the created lead chat is now deleted via `agentChat.delete` before surfacing the error and throwing, preventing a half-created lead session from accepting prompts.
- **Consistent CLI policy**: `orchestrationRole` is threaded into all launch paths, and `effectiveOrchestrationPermissionMode` enforces `full-auto` before any provider-specific adapters run.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all production code paths are well-tested, the fail-closed bundle-allocation change is intentional and covered by a new integration test, and the shared policy module correctly enforces full-auto permissions across every launch path.

The orchestration guardrails are applied consistently: disallowedTools is set before MCP server allocation so leads are restricted even without a bundle, effectiveOrchestrationPermissionMode enforces full-auto for all CLI runtimes, and the new AgentChatPane behavior deletes orphaned lead sessions on allocation failure. Tests cover the interactionMode path, the orchestrationRole path, the CLI policy across all five providers, and the fail-closed creation flow.

No files require special attention. The cliLaunch.ts callerHasOverride path and the incomplete deny-list assertion in agentChatService.test.ts were flagged in a previous review and are tracked there.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/shared/orchestrationRuntimePolicy.ts | New shared policy module; cleanly centralizes role/mode mapping, locked permission mode, and provider profiles. |
| apps/desktop/src/shared/cliLaunch.ts | Adds orchestrationRole to buildTrackedCliLaunchCommand and resolveLaunchFields. The callerHasOverride path returns caller-provided fields verbatim — a pre-existing gap flagged in a previous review. |
| apps/desktop/src/main/services/chat/agentChatService.ts | Moves disallowedTools assignment earlier so lead-session restrictions apply even without a bundle; uses isOrchestrationLeadSession to cover both interactionMode and orchestrationRole paths. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Adds fail-closed bundle allocation: deletes created session on runCreate failure before throwing. |
| apps/desktop/src/main/services/orchestration/runtimeProfile.ts | Now a thin re-export shim; all policy logic moved to the shared module. |
| apps/desktop/src/main/services/chat/agentChatService.test.ts | Adds two new lead-session tests; the role-based path assertion only checks 6 of 9 deny-listed tools — noted in a prior review. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `apps/desktop/src/shared/cliLaunch.ts`, line 816-825 ([link](https://github.com/arul28/ade/blob/79480c4bb369d0520a3391237b28b896259f9867/apps/desktop/src/shared/cliLaunch.ts#L816-L825)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`orchestrationRole` silently ignored on caller-override path**

   When a caller provides any explicit launch field (`startupCommand`, `command`, `args`, `env`, `initialInput`, or `initialInputDelayMs`), `resolveLaunchFields` returns those fields as-is without applying the orchestration role policy. A caller that supplies both `orchestrationRole: "worker"` and an explicit `startupCommand` will get their custom command back untouched — with no bypass flag injected — even though the PR's intent is to enforce full-auto for every orchestration launch. The validation above passes (because `permissionMode` is resolved correctly), but the returned command does not match the validated effective mode. In practice this is unlikely today, but the mismatch between what is validated and what is returned is a latent guardrail gap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/shared/cliLaunch.ts
   Line: 816-825

   Comment:
   **`orchestrationRole` silently ignored on caller-override path**

   When a caller provides any explicit launch field (`startupCommand`, `command`, `args`, `env`, `initialInput`, or `initialInputDelayMs`), `resolveLaunchFields` returns those fields as-is without applying the orchestration role policy. A caller that supplies both `orchestrationRole: "worker"` and an explicit `startupCommand` will get their custom command back untouched — with no bypass flag injected — even though the PR's intent is to enforce full-auto for every orchestration launch. The validation above passes (because `permissionMode` is resolved correctly), but the returned command does not match the validated effective mode. In practice this is unlikely today, but the mismatch between what is validated and what is returned is a latent guardrail gap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fshared%2FcliLaunch.ts%0ALine%3A%20816-825%0A%0AComment%3A%0A**%60orchestrationRole%60%20silently%20ignored%20on%20caller-override%20path**%0A%0AWhen%20a%20caller%20provides%20any%20explicit%20launch%20field%20%28%60startupCommand%60%2C%20%60command%60%2C%20%60args%60%2C%20%60env%60%2C%20%60initialInput%60%2C%20or%20%60initialInputDelayMs%60%29%2C%20%60resolveLaunchFields%60%20returns%20those%20fields%20as-is%20without%20applying%20the%20orchestration%20role%20policy.%20A%20caller%20that%20supplies%20both%20%60orchestrationRole%3A%20%22worker%22%60%20and%20an%20explicit%20%60startupCommand%60%20will%20get%20their%20custom%20command%20back%20untouched%20%E2%80%94%20with%20no%20bypass%20flag%20injected%20%E2%80%94%20even%20though%20the%20PR's%20intent%20is%20to%20enforce%20full-auto%20for%20every%20orchestration%20launch.%20The%20validation%20above%20passes%20%28because%20%60permissionMode%60%20is%20resolved%20correctly%29%2C%20but%20the%20returned%20command%20does%20not%20match%20the%20validated%20effective%20mode.%20In%20practice%20this%20is%20unlikely%20today%2C%20but%20the%20mismatch%20between%20what%20is%20validated%20and%20what%20is%20returned%20is%20a%20latent%20guardrail%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=519&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `apps/desktop/src/main/services/chat/agentChatService.test.ts`, line 115-124 ([link](https://github.com/arul28/ade/blob/79480c4bb369d0520a3391237b28b896259f9867/apps/desktop/src/main/services/chat/agentChatService.test.ts#L115-L124)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Incomplete deny-list assertion for role-based lead path**

   The assertion for "role-marked lead sessions" checks only 6 of the 9 tools in `ORCHESTRATION_LEAD_DENIED_CLAUDE_TOOLS` — `MultiEdit`, `NotebookEdit`, and `TodoRead` are absent. Both the `interactionMode`-based and `orchestrationRole`-based paths reach the same `isOrchestrationLeadSession` branch, so they should produce identical deny lists. A future change that accidentally splits the two paths would not be caught by this test.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/chat/agentChatService.test.ts
   Line: 115-124

   Comment:
   **Incomplete deny-list assertion for role-based lead path**

   The assertion for "role-marked lead sessions" checks only 6 of the 9 tools in `ORCHESTRATION_LEAD_DENIED_CLAUDE_TOOLS` — `MultiEdit`, `NotebookEdit`, and `TodoRead` are absent. Both the `interactionMode`-based and `orchestrationRole`-based paths reach the same `isOrchestrationLeadSession` branch, so they should produce identical deny lists. A future change that accidentally splits the two paths would not be caught by this test.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fchat%2FagentChatService.test.ts%0ALine%3A%20115-124%0A%0AComment%3A%0A**Incomplete%20deny-list%20assertion%20for%20role-based%20lead%20path**%0A%0AThe%20assertion%20for%20%22role-marked%20lead%20sessions%22%20checks%20only%206%20of%20the%209%20tools%20in%20%60ORCHESTRATION_LEAD_DENIED_CLAUDE_TOOLS%60%20%E2%80%94%20%60MultiEdit%60%2C%20%60NotebookEdit%60%2C%20and%20%60TodoRead%60%20are%20absent.%20Both%20the%20%60interactionMode%60-based%20and%20%60orchestrationRole%60-based%20paths%20reach%20the%20same%20%60isOrchestrationLeadSession%60%20branch%2C%20so%20they%20should%20produce%20identical%20deny%20lists.%20A%20future%20change%20that%20accidentally%20splits%20the%20two%20paths%20would%20not%20be%20caught%20by%20this%20test.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=519&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

3. `apps/desktop/src/renderer/components/chat/AgentChatPane.tsx`, line 5598-5611 ([link](https://github.com/arul28/ade/blob/79480c4bb369d0520a3391237b28b896259f9867/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx#L5598-L5611)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Redundant `setError` call from outer submit-handler catch**

   When bundle allocation fails, `setError(message)` is called here before the `throw`. The thrown `Error` carries the same message string, and the outer submit-handler `catch` at line 6963 calls `setError(message)` again. The net result is the same UI error, but the dual call is non-obvious: the outer catch restores composer state (draft/attachments) under the assumption a message was not delivered. For a bundle allocation failure the session was already deleted, so restoring and allowing retry is correct — but a comment noting this intentional interaction would help maintainers avoid removing the `throw` in a future refactor.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
   Line: 5598-5611

   Comment:
   **Redundant `setError` call from outer submit-handler catch**

   When bundle allocation fails, `setError(message)` is called here before the `throw`. The thrown `Error` carries the same message string, and the outer submit-handler `catch` at line 6963 calls `setError(message)` again. The net result is the same UI error, but the dual call is non-obvious: the outer catch restores composer state (draft/attachments) under the assumption a message was not delivered. For a bundle allocation failure the session was already deleted, so restoring and allowing retry is correct — but a comment noting this intentional interaction would help maintainers avoid removing the `throw` in a future refactor.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FAgentChatPane.tsx%0ALine%3A%205598-5611%0A%0AComment%3A%0A**Redundant%20%60setError%60%20call%20from%20outer%20submit-handler%20catch**%0A%0AWhen%20bundle%20allocation%20fails%2C%20%60setError%28message%29%60%20is%20called%20here%20before%20the%20%60throw%60.%20The%20thrown%20%60Error%60%20carries%20the%20same%20message%20string%2C%20and%20the%20outer%20submit-handler%20%60catch%60%20at%20line%206963%20calls%20%60setError%28message%29%60%20again.%20The%20net%20result%20is%20the%20same%20UI%20error%2C%20but%20the%20dual%20call%20is%20non-obvious%3A%20the%20outer%20catch%20restores%20composer%20state%20%28draft%2Fattachments%29%20under%20the%20assumption%20a%20message%20was%20not%20delivered.%20For%20a%20bundle%20allocation%20failure%20the%20session%20was%20already%20deleted%2C%20so%20restoring%20and%20allowing%20retry%20is%20correct%20%E2%80%94%20but%20a%20comment%20noting%20this%20intentional%20interaction%20would%20help%20maintainers%20avoid%20removing%20the%20%60throw%60%20in%20a%20future%20refactor.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=519&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Guard orchestration runtime permissions"](https://github.com/arul28/ade/commit/de072852ba77624107ff1b13096c9f465adbaadd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35230114)</sub>

<!-- /greptile_comment -->