### PR TITLE
Add PR chat transcript secret gists

### DIFF
--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -491,7 +491,7 @@ describe("ADE CLI", () => {
     const enable = buildCliPlan(["settings", "pr-transcript-gists", "enable"]);
     expect(enable.kind).toBe("execute");
     if (enable.kind !== "execute") return;
-    expect(enable.label).toBe("enable PR transcript gists");
+    expect(enable.label).toBe("enable PR chat transcripts");
     expect(enable.steps).toEqual([
       {
         key: "result",

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -487,6 +487,53 @@ describe("ADE CLI", () => {
     ]);
   });
 
+  it("builds PR transcript gist settings commands", () => {
+    const enable = buildCliPlan(["settings", "pr-transcript-gists", "enable"]);
+    expect(enable.kind).toBe("execute");
+    if (enable.kind !== "execute") return;
+    expect(enable.label).toBe("enable PR transcript gists");
+    expect(enable.steps).toEqual([
+      {
+        key: "result",
+        method: "ade/actions/call",
+        params: {
+          name: "run_ade_action",
+          arguments: {
+            domain: "project_config",
+            action: "setPrTranscriptGists",
+            args: { enabled: true },
+          },
+        },
+        unwrapToolResult: true,
+      },
+    ]);
+
+    const disable = buildCliPlan(["config", "gist-transcripts", "off"]);
+    expect(disable.kind).toBe("execute");
+    if (disable.kind !== "execute") return;
+    expect(disable.steps[0]).toEqual(expect.objectContaining({
+      params: expect.objectContaining({
+        arguments: expect.objectContaining({
+          domain: "project_config",
+          action: "setPrTranscriptGists",
+          args: { enabled: false },
+        }),
+      }),
+    }));
+
+    const status = buildCliPlan(["settings", "transcript-gists", "status"]);
+    expect(status.kind).toBe("execute");
+    if (status.kind !== "execute") return;
+    expect(status.steps[0]).toEqual(expect.objectContaining({
+      params: expect.objectContaining({
+        arguments: expect.objectContaining({
+          domain: "project_config",
+          action: "get",
+        }),
+      }),
+    }));
+  });
+
   it("builds a diff patch invocation with an explicit path flag", () => {
     const parsed = parseCliArgs([
       "diff",

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -408,6 +408,7 @@ const TOP_LEVEL_HELP = `${ADE_BANNER}
                                                     Run ADE's singleton Apple silicon macOS VM
     $ ade browser open | tabs | screenshot         Use ADE's built-in browser pane
     $ ade usage snapshot | refresh | budget         Read provider quota usage and edit automation guardrails
+    $ ade settings pr-transcript-gists enable      Attach secret chat transcript gists to new PRs
     $ ade settings action <method>                  Call project config actions
     $ ade update status | check | install | dismiss Read auto-update state and drive install
     $ ade actions list | run | status | wait        Escape hatch for every ADE service action
@@ -8557,6 +8558,37 @@ function buildBrowserPlan(args: string[]): CliPlan {
 
 function buildSettingsPlan(args: string[]): CliPlan {
   const sub = firstPositional(args) ?? "get";
+  if (sub === "pr-transcript-gists" || sub === "transcript-gists" || sub === "gist-transcripts") {
+    const mode = (firstPositional(args) ?? "status").toLowerCase();
+    if (mode === "status") {
+      return {
+        kind: "execute",
+        label: "settings pr transcript gists",
+        steps: [
+          actionStep("result", "project_config", "get"),
+        ],
+      };
+    }
+    if (mode === "enable" || mode === "on" || mode === "true") {
+      return {
+        kind: "execute",
+        label: "enable PR transcript gists",
+        steps: [
+          actionStep("result", "project_config", "setPrTranscriptGists", { enabled: true }),
+        ],
+      };
+    }
+    if (mode === "disable" || mode === "off" || mode === "false") {
+      return {
+        kind: "execute",
+        label: "disable PR transcript gists",
+        steps: [
+          actionStep("result", "project_config", "setPrTranscriptGists", { enabled: false }),
+        ],
+      };
+    }
+    throw new CliUsageError("settings pr-transcript-gists expects enable, disable, or status.");
+  }
   if (sub === "actions")
     return {
       kind: "execute",

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -408,7 +408,7 @@ const TOP_LEVEL_HELP = `${ADE_BANNER}
                                                     Run ADE's singleton Apple silicon macOS VM
     $ ade browser open | tabs | screenshot         Use ADE's built-in browser pane
     $ ade usage snapshot | refresh | budget         Read provider quota usage and edit automation guardrails
-    $ ade settings pr-transcript-gists enable      Attach secret chat transcript gists to new PRs
+    $ ade settings pr-transcript-gists enable      Attach ADE chat transcript links to new PRs
     $ ade settings action <method>                  Call project config actions
     $ ade update status | check | install | dismiss Read auto-update state and drive install
     $ ade actions list | run | status | wait        Escape hatch for every ADE service action
@@ -8563,7 +8563,7 @@ function buildSettingsPlan(args: string[]): CliPlan {
     if (mode === "status") {
       return {
         kind: "execute",
-        label: "settings pr transcript gists",
+        label: "settings PR chat transcripts",
         steps: [
           actionStep("result", "project_config", "get"),
         ],
@@ -8572,7 +8572,7 @@ function buildSettingsPlan(args: string[]): CliPlan {
     if (mode === "enable" || mode === "on" || mode === "true") {
       return {
         kind: "execute",
-        label: "enable PR transcript gists",
+        label: "enable PR chat transcripts",
         steps: [
           actionStep("result", "project_config", "setPrTranscriptGists", { enabled: true }),
         ],
@@ -8581,7 +8581,7 @@ function buildSettingsPlan(args: string[]): CliPlan {
     if (mode === "disable" || mode === "off" || mode === "false") {
       return {
         kind: "execute",
-        label: "disable PR transcript gists",
+        label: "disable PR chat transcripts",
         steps: [
           actionStep("result", "project_config", "setPrTranscriptGists", { enabled: false }),
         ],

--- a/apps/ade-cli/src/headlessLinearServices.test.ts
+++ b/apps/ade-cli/src/headlessLinearServices.test.ts
@@ -207,6 +207,60 @@ describe("headlessLinearServices", () => {
     }
   });
 
+  it("creates secret gists through the headless GitHub service", async () => {
+    const previousAdeHome = process.env.ADE_HOME;
+    const previousFetch = globalThis.fetch;
+    process.env.ADE_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "ade-headless-github-gist-"));
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 201,
+      headers: new Headers(),
+      text: async () => JSON.stringify({
+        id: "gist-1",
+        html_url: "https://gist.github.com/octocat/gist-1",
+      }),
+    })) as unknown as typeof fetch;
+    globalThis.fetch = fetchImpl;
+    const githubService = createHeadlessGitHubService(
+      "/tmp/ade-project",
+      { debug() {}, info() {}, warn() {}, error() {} } as any,
+    );
+    try {
+      githubService.setToken("ghp_test_token");
+      const result = await githubService.createSecretGist({
+        description: "ADE transcript",
+        files: {
+          "README.md": { content: "# Transcript\n" },
+        },
+      });
+
+      expect(result).toEqual({
+        id: "gist-1",
+        htmlUrl: "https://gist.github.com/octocat/gist-1",
+      });
+      expect(fetchImpl).toHaveBeenCalledWith(
+        expect.objectContaining({ pathname: "/gists" }),
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            description: "ADE transcript",
+            public: false,
+            files: {
+              "README.md": { content: "# Transcript\n" },
+            },
+          }),
+        }),
+      );
+    } finally {
+      globalThis.fetch = previousFetch;
+      if (previousAdeHome == null) {
+        delete process.env.ADE_HOME;
+      } else {
+        process.env.ADE_HOME = previousAdeHome;
+      }
+    }
+  });
+
   it("reuses identity sessions and exposes desktop-compatible session summaries", async () => {
     const services = createHeadlessLinearServices(createDeps());
 

--- a/apps/ade-cli/src/headlessLinearServices.ts
+++ b/apps/ade-cli/src/headlessLinearServices.ts
@@ -935,6 +935,30 @@ export function createHeadlessGitHubService(
     apiRequest,
     createRepository,
     getRepository,
+    async createSecretGist(args) {
+      const files: Record<string, { content: string }> = {};
+      for (const [filename, file] of Object.entries(args.files ?? {})) {
+        const normalizedFilename = filename.trim();
+        if (!normalizedFilename || typeof file?.content !== "string") continue;
+        files[normalizedFilename] = { content: file.content };
+      }
+      if (!Object.keys(files).length) {
+        throw new Error("At least one gist file is required.");
+      }
+      const { data } = await apiRequest<Record<string, unknown>>({
+        method: "POST",
+        path: "/gists",
+        body: {
+          description: args.description?.trim() || "ADE PR chat transcript",
+          public: false,
+          files,
+        },
+      });
+      return {
+        id: asString(data.id),
+        htmlUrl: asString(data.html_url),
+      };
+    },
     async listRepoLabels(owner, name) {
       return apiRequestAllPages({
         path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/labels`,

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -548,7 +548,7 @@ export const ADE_ACTION_ALLOWLIST: Partial<Record<AdeActionDomain, readonly stri
   session: ["backfillDeltas", "deleteSession", "get", "getDelta", "list", "readTranscriptTail", "updateMeta"],
   operation: ["finish", "get", "list", "start"],
   ade_project: ["clearLocalData", "getSnapshot", "initializeOrRepair", "runIntegrityCheck"],
-  project_config: ["confirmTrust", "diffAgainstDisk", "get", "save", "validate"],
+  project_config: ["confirmTrust", "diffAgainstDisk", "get", "save", "setPrTranscriptGists", "validate"],
   issue_inventory: [
     "deletePipelineSettings",
     "getConvergenceRuntime",

--- a/apps/desktop/src/main/services/config/projectConfigService.test.ts
+++ b/apps/desktop/src/main/services/config/projectConfigService.test.ts
@@ -577,6 +577,33 @@ describe("projectConfigService - AI mode migration", () => {
   });
 });
 
+describe("projectConfigService - PR transcript gists", () => {
+  it("defaults off and persists the local secret-gist toggle", () => {
+    const { root, adeDir } = makeProjectFixture("ade-project-config-pr-transcript-gists-");
+    const service = createProjectConfigService({
+      projectRoot: root,
+      adeDir,
+      projectId: "project-1",
+      db: makeDb(),
+      logger: makeLogger(),
+    });
+
+    expect(service.get().effective.github?.prTranscriptGists?.enabled).toBeUndefined();
+
+    const enabled = service.setPrTranscriptGists({ enabled: true });
+    expect(enabled.effective.github?.prTranscriptGists?.enabled).toBe(true);
+
+    const localPath = path.join(adeDir, "local.yaml");
+    let persisted = YAML.parse(fs.readFileSync(localPath, "utf8")) as Record<string, any>;
+    expect(persisted.github?.prTranscriptGists?.enabled).toBe(true);
+
+    const disabled = service.setPrTranscriptGists({ enabled: false });
+    expect(disabled.effective.github?.prTranscriptGists?.enabled).toBe(false);
+    persisted = YAML.parse(fs.readFileSync(localPath, "utf8")) as Record<string, any>;
+    expect(persisted.github?.prTranscriptGists?.enabled).toBe(false);
+  });
+});
+
 describe("projectConfigService - linear sync", () => {
   async function createLinearFixture() {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "ade-project-config-linear-"));

--- a/apps/desktop/src/main/services/config/projectConfigService.ts
+++ b/apps/desktop/src/main/services/config/projectConfigService.ts
@@ -1921,6 +1921,40 @@ function coerceProjectUiConfig(value: unknown): ProjectConfigFile["ui"] {
     : undefined;
 }
 
+function coerceGithubConfig(value: unknown): ProjectConfigFile["github"] {
+  if (!isRecord(value)) return undefined;
+  const prPollingIntervalSeconds = asNumber(value.prPollingIntervalSeconds);
+  const rawTranscriptGists = isRecord(value.prTranscriptGists) ? value.prTranscriptGists : null;
+  const prTranscriptGistsEnabled = rawTranscriptGists
+    ? asBool(rawTranscriptGists.enabled)
+    : null;
+  const github: NonNullable<ProjectConfigFile["github"]> = {};
+  if (prPollingIntervalSeconds != null) {
+    github.prPollingIntervalSeconds = prPollingIntervalSeconds;
+  }
+  if (prTranscriptGistsEnabled != null) {
+    github.prTranscriptGists = { enabled: prTranscriptGistsEnabled };
+  }
+  return Object.keys(github).length ? github : undefined;
+}
+
+function mergeGithubConfig(
+  shared?: ProjectConfigFile["github"],
+  local?: ProjectConfigFile["github"],
+): EffectiveProjectConfig["github"] {
+  if (!shared && !local) return undefined;
+  const github: NonNullable<EffectiveProjectConfig["github"]> = {};
+  const prPollingIntervalSeconds = local?.prPollingIntervalSeconds ?? shared?.prPollingIntervalSeconds;
+  if (prPollingIntervalSeconds != null) {
+    github.prPollingIntervalSeconds = prPollingIntervalSeconds;
+  }
+  const prTranscriptGistsEnabled = local?.prTranscriptGists?.enabled ?? shared?.prTranscriptGists?.enabled;
+  if (prTranscriptGistsEnabled != null) {
+    github.prTranscriptGists = { enabled: prTranscriptGistsEnabled };
+  }
+  return Object.keys(github).length ? github : undefined;
+}
+
 function coerceConfigFile(value: unknown): ProjectConfigFile {
   if (!isRecord(value)) {
     return {
@@ -1963,10 +1997,7 @@ function coerceConfigFile(value: unknown): ProjectConfigFile {
     : undefined;
   const defaultLaneTemplate = typeof value.defaultLaneTemplate === "string" ? value.defaultLaneTemplate.trim() || undefined : undefined;
 
-  const github =
-    isRecord(value.github) && asNumber(value.github.prPollingIntervalSeconds) != null
-      ? { prPollingIntervalSeconds: asNumber(value.github.prPollingIntervalSeconds) }
-      : undefined;
+  const github = coerceGithubConfig(value.github);
 
   const git =
     isRecord(value.git) && asBool(value.git.autoRebaseOnHeadChange) != null
@@ -2410,12 +2441,7 @@ function resolveEffectiveConfig(shared: ProjectConfigFile, local: ProjectConfigF
     }
     : undefined;
 
-  const mergedGithub = shared.github || local.github
-    ? {
-        ...(shared.github ?? {}),
-        ...(local.github ?? {})
-      }
-    : undefined;
+  const mergedGithub = mergeGithubConfig(shared.github, local.github);
 
   const mergedGit = shared.git || local.git
     ? {
@@ -3256,6 +3282,48 @@ export function createProjectConfigService({
     return snapshot.validation;
   };
 
+  const saveCandidate = (candidate: ProjectConfigCandidate): ProjectConfigSnapshot => {
+    const shared = normalizeConfigFilePaths(coerceConfigFile(candidate.shared), projectRoot);
+    const local = normalizeConfigFilePaths(coerceConfigFile(candidate.local), projectRoot);
+    const validation = validateCandidate(shared, local);
+    if (!validation.ok) {
+      throw invalidConfigError(validation);
+    }
+
+    const sharedYaml = toCanonicalYaml(shared);
+    const localYaml = toCanonicalYaml(local);
+    const shouldWriteShared = fs.existsSync(sharedPath) || hasSharedConfigContent(shared);
+
+    if (shouldWriteShared) {
+      ensureSharedAdeProjectScaffold(projectRoot, { logger });
+    } else {
+      initializeOrRepairAdeProject(projectRoot, { logger });
+    }
+    fs.mkdirSync(path.dirname(sharedPath), { recursive: true });
+    if (shouldWriteShared) {
+      fs.writeFileSync(sharedPath, sharedYaml, "utf8");
+    }
+    fs.writeFileSync(localPath, localYaml, "utf8");
+
+    const sharedHash = hashContent(shouldWriteShared ? sharedYaml : "");
+    if (shouldWriteShared) {
+      setTrustedSharedHash(sharedHash);
+    }
+
+    logger.info("projectConfig.save", {
+      sharedPath,
+      localPath,
+      sharedHash,
+      sharedProcesses: shared.processes?.length ?? 0,
+      localProcesses: local.processes?.length ?? 0
+    });
+
+    const snapshot = readSnapshotFromDisk();
+    lastSeenSharedHash = snapshot.trust.sharedHash;
+    lastSeenLocalHash = snapshot.trust.localHash;
+    return snapshot;
+  };
+
   return {
     get(): ProjectConfigSnapshot {
       const snapshot = readSnapshotFromDisk();
@@ -3271,45 +3339,21 @@ export function createProjectConfigService({
     },
 
     save(candidate: ProjectConfigCandidate): ProjectConfigSnapshot {
-      const shared = normalizeConfigFilePaths(coerceConfigFile(candidate.shared), projectRoot);
-      const local = normalizeConfigFilePaths(coerceConfigFile(candidate.local), projectRoot);
-      const validation = validateCandidate(shared, local);
-      if (!validation.ok) {
-        throw invalidConfigError(validation);
-      }
+      return saveCandidate(candidate);
+    },
 
-      const sharedYaml = toCanonicalYaml(shared);
-      const localYaml = toCanonicalYaml(local);
-      const shouldWriteShared = fs.existsSync(sharedPath) || hasSharedConfigContent(shared);
-
-      if (shouldWriteShared) {
-        ensureSharedAdeProjectScaffold(projectRoot, { logger });
-      } else {
-        initializeOrRepairAdeProject(projectRoot, { logger });
-      }
-      fs.mkdirSync(path.dirname(sharedPath), { recursive: true });
-      if (shouldWriteShared) {
-        fs.writeFileSync(sharedPath, sharedYaml, "utf8");
-      }
-      fs.writeFileSync(localPath, localYaml, "utf8");
-
-      const sharedHash = hashContent(shouldWriteShared ? sharedYaml : "");
-      if (shouldWriteShared) {
-        setTrustedSharedHash(sharedHash);
-      }
-
-      logger.info("projectConfig.save", {
-        sharedPath,
-        localPath,
-        sharedHash,
-        sharedProcesses: shared.processes?.length ?? 0,
-        localProcesses: local.processes?.length ?? 0
-      });
-
+    setPrTranscriptGists(args: { enabled?: boolean }): ProjectConfigSnapshot {
       const snapshot = readSnapshotFromDisk();
-      lastSeenSharedHash = snapshot.trust.sharedHash;
-      lastSeenLocalHash = snapshot.trust.localHash;
-      return snapshot;
+      return saveCandidate({
+        shared: snapshot.shared,
+        local: {
+          ...snapshot.local,
+          github: {
+            ...(snapshot.local.github ?? {}),
+            prTranscriptGists: { enabled: args.enabled === true },
+          },
+        },
+      });
     },
 
     diffAgainstDisk(): ProjectConfigDiff {

--- a/apps/desktop/src/main/services/github/githubService.test.ts
+++ b/apps/desktop/src/main/services/github/githubService.test.ts
@@ -897,6 +897,49 @@ describe("githubService.createRepository", () => {
   });
 });
 
+describe("githubService.createSecretGist", () => {
+  beforeEach(() => {
+    resetMocks();
+    process.env.GITHUB_TOKEN = "ghp_env_token";
+  });
+
+  function lastFetchCall() {
+    const calls = mockFetch.mock.calls;
+    return calls[calls.length - 1] as [string, RequestInit];
+  }
+
+  it("POSTs a secret gist with markdown files", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse(201, {
+        id: "gist-1",
+        html_url: "https://gist.github.com/alice/gist-1",
+      }),
+    );
+
+    const result = await makeService().createSecretGist({
+      description: "ADE transcript",
+      files: {
+        "README.md": { content: "# Transcript\n" },
+      },
+    });
+
+    const [url, init] = lastFetchCall();
+    expect(url).toContain("/gists");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      description: "ADE transcript",
+      public: false,
+      files: {
+        "README.md": { content: "# Transcript\n" },
+      },
+    });
+    expect(result).toEqual({
+      id: "gist-1",
+      htmlUrl: "https://gist.github.com/alice/gist-1",
+    });
+  });
+});
+
 // ---------------------------------------------------------------------------
 // publishCurrentProject — orchestrates createRepo + remote add + push
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/main/services/github/githubService.ts
+++ b/apps/desktop/src/main/services/github/githubService.ts
@@ -1014,6 +1014,34 @@ export function createGithubService({
     return Array.isArray(data) ? data : [];
   };
 
+  const createSecretGist = async (args: {
+    description?: string | null;
+    files: Record<string, { content: string }>;
+  }): Promise<{ id: string; htmlUrl: string }> => {
+    const files: Record<string, { content: string }> = {};
+    for (const [filename, file] of Object.entries(args.files)) {
+      const normalizedFilename = filename.trim();
+      if (!normalizedFilename || typeof file?.content !== "string") continue;
+      files[normalizedFilename] = { content: file.content };
+    }
+    if (!Object.keys(files).length) {
+      throw new Error("At least one gist file is required.");
+    }
+    const { data } = await apiRequest<Record<string, unknown>>({
+      method: "POST",
+      path: "/gists",
+      body: {
+        description: args.description?.trim() || "ADE PR chat transcript",
+        public: false,
+        files,
+      },
+    });
+    return {
+      id: asString(data.id),
+      htmlUrl: asString(data.html_url),
+    };
+  };
+
   // Issue-domain action helpers (used by the automations `issue` domain).
   const addIssueComment = async (owner: string, name: string, number: number, body: string): Promise<GitHubIssueComment | null> => {
     const { data } = await apiRequest<GitHubIssueComment>({
@@ -1265,6 +1293,7 @@ export function createGithubService({
     listIssueComments,
     listRepoPulls,
     listPullRequestReviews,
+    createSecretGist,
 
     // Issue-domain action helpers (exposed via `issue` domain in the
     // automations action registry).

--- a/apps/desktop/src/main/services/prs/prService.test.ts
+++ b/apps/desktop/src/main/services/prs/prService.test.ts
@@ -175,6 +175,7 @@ function makeGithubService(overrides?: Record<string, unknown>) {
   return {
     getRepoOrThrow: vi.fn(async () => REPO),
     apiRequest: vi.fn(),
+    createSecretGist: vi.fn(),
     getStatus: vi.fn(),
     setToken: vi.fn(),
     clearToken: vi.fn(),
@@ -237,6 +238,7 @@ interface BuildServiceOpts {
   laneService?: any;
   db?: any;
   conflictService?: any;
+  projectConfigService?: any;
 }
 
 function buildService(opts: BuildServiceOpts = {}) {
@@ -278,7 +280,7 @@ function buildService(opts: BuildServiceOpts = {}) {
     operationService: makeOperationService(),
     githubService,
     conflictService: opts.conflictService,
-    projectConfigService: makeProjectConfigService(),
+    projectConfigService: opts.projectConfigService ?? makeProjectConfigService(),
     openExternal: vi.fn(async () => {}),
   });
 
@@ -2729,6 +2731,222 @@ describe("prService.createFromLane", () => {
     expect(result.githubPrNumber).toBe(99);
     expect(result.headBranch).toBe("my-feature");
     expect(result.baseBranch).toBe("main");
+  });
+
+  it("creates secret chat transcript gists and patches PR body when enabled", async () => {
+    const db = makeMockDb();
+    installPullRequestRowStore(db);
+    const createSecretGist = vi.fn(async () => ({
+      id: "gist-1",
+      htmlUrl: "https://gist.github.com/octocat/gist-1",
+    }));
+    const apiRequest = vi.fn(async (args: any) => {
+      if (args.method === "POST" && args.path.endsWith("/pulls")) {
+        return {
+          data: {
+            number: 99,
+            html_url: "https://github.com/test-owner/test-repo/pull/99",
+            node_id: "PR_node1",
+            title: "My PR",
+            state: "open",
+            draft: false,
+            merged_at: null,
+            body: args.body.body,
+            head: { ref: "my-feature" },
+            base: { ref: "main" },
+            additions: 10,
+            deletions: 2,
+          },
+          response: { status: 201, headers: new Headers() },
+        };
+      }
+      if (args.method === "PATCH" && args.path.endsWith("/pulls/99")) {
+        return { data: {}, response: { status: 200, headers: new Headers() } };
+      }
+      if (args.method === "GET" && args.path.endsWith("/pulls/99")) {
+        return {
+          data: {
+            number: 99,
+            html_url: "https://github.com/test-owner/test-repo/pull/99",
+            title: "My PR",
+            state: "open",
+            draft: false,
+            merged_at: null,
+            head: { ref: "my-feature", sha: "abc123" },
+            base: { ref: "main", sha: "base123" },
+            additions: 10,
+            deletions: 2,
+          },
+          response: { status: 200, headers: new Headers() },
+        };
+      }
+      if (args.path.endsWith("/commits/abc123/status")) {
+        return { data: { state: "success", statuses: [] }, response: { status: 200, headers: new Headers() } };
+      }
+      if (args.path.endsWith("/commits/abc123/check-runs")) {
+        return { data: { check_runs: [] }, response: { status: 200, headers: new Headers() } };
+      }
+      if (args.path.endsWith("/pulls/99/reviews")) {
+        return { data: [], response: { status: 200, headers: new Headers() } };
+      }
+      if (args.path.includes("/compare/")) {
+        return { data: { behind_by: 0 }, response: { status: 200, headers: new Headers() } };
+      }
+      return { data: [], response: { status: 200, headers: new Headers() } };
+    });
+    const ghService = makeGithubService({ apiRequest, createSecretGist });
+    const { service } = buildService({
+      db,
+      githubService: ghService,
+      projectConfigService: {
+        get: vi.fn(() => ({ effective: { github: { prTranscriptGists: { enabled: true } } } })),
+      },
+    });
+    service.setAgentChatService({
+      listSessions: vi.fn(async () => [{
+        sessionId: "chat-1",
+        laneId: LANE_ID,
+        provider: "codex",
+        model: "gpt-5-codex",
+        title: "Ship transcript links",
+        startedAt: "2026-06-01T10:00:00.000Z",
+        lastActivityAt: "2026-06-01T11:00:00.000Z",
+      }]),
+      readTranscript: vi.fn(async () => [
+        { role: "user", text: "Please implement transcript gists.", timestamp: "2026-06-01T10:00:00.000Z" },
+        { role: "assistant", text: "Done.", timestamp: "2026-06-01T10:01:00.000Z" },
+      ]),
+    } as any);
+
+    await service.createFromLane({
+      laneId: LANE_ID,
+      title: "My PR",
+      body: "description",
+      draft: false,
+      allowDirtyWorktree: true,
+    });
+
+    expect(createSecretGist).toHaveBeenCalledWith(expect.objectContaining({
+      description: expect.stringContaining("test-owner/test-repo#99"),
+      files: {
+        "README.md": {
+          content: expect.stringContaining("# Ship transcript links"),
+        },
+      },
+    }));
+    const patchedBodies = apiRequest.mock.calls
+      .map(([call]) => call)
+      .filter((call) => call.method === "PATCH" && call.path.endsWith("/pulls/99"))
+      .map((call) => call.body.body);
+    expect(patchedBodies).toEqual(expect.arrayContaining([
+      expect.stringContaining("https://gist.github.com/octocat/gist-1"),
+    ]));
+    expect(patchedBodies.at(-1)).toContain("ADE chat transcripts");
+  });
+
+  it("does not recreate transcript gists when the PR body already has transcript links", async () => {
+    const db = makeMockDb();
+    installPullRequestRowStore(db);
+    const createSecretGist = vi.fn(async () => ({
+      id: "gist-1",
+      htmlUrl: "https://gist.github.com/octocat/gist-1",
+    }));
+    const apiRequest = vi.fn(async (args: any) => {
+      if (args.method === "POST" && args.path.endsWith("/pulls")) {
+        return {
+          data: {
+            number: 99,
+            html_url: "https://github.com/test-owner/test-repo/pull/99",
+            node_id: "PR_node1",
+            title: "My PR",
+            state: "open",
+            draft: false,
+            merged_at: null,
+            body: args.body.body,
+            head: { ref: "my-feature" },
+            base: { ref: "main" },
+            additions: 10,
+            deletions: 2,
+          },
+          response: { status: 201, headers: new Headers() },
+        };
+      }
+      if (args.method === "GET" && args.path.endsWith("/pulls/99")) {
+        return {
+          data: {
+            number: 99,
+            html_url: "https://github.com/test-owner/test-repo/pull/99",
+            title: "My PR",
+            state: "open",
+            draft: false,
+            merged_at: null,
+            head: { ref: "my-feature", sha: "abc123" },
+            base: { ref: "main", sha: "base123" },
+            additions: 10,
+            deletions: 2,
+          },
+          response: { status: 200, headers: new Headers() },
+        };
+      }
+      if (args.path.endsWith("/commits/abc123/status")) {
+        return { data: { state: "success", statuses: [] }, response: { status: 200, headers: new Headers() } };
+      }
+      if (args.path.endsWith("/commits/abc123/check-runs")) {
+        return { data: { check_runs: [] }, response: { status: 200, headers: new Headers() } };
+      }
+      if (args.path.endsWith("/pulls/99/reviews")) {
+        return { data: [], response: { status: 200, headers: new Headers() } };
+      }
+      if (args.path.includes("/compare/")) {
+        return { data: { behind_by: 0 }, response: { status: 200, headers: new Headers() } };
+      }
+      return { data: [], response: { status: 200, headers: new Headers() } };
+    });
+    const ghService = makeGithubService({ apiRequest, createSecretGist });
+    const { service } = buildService({
+      db,
+      githubService: ghService,
+      projectConfigService: {
+        get: vi.fn(() => ({ effective: { github: { prTranscriptGists: { enabled: true } } } })),
+      },
+    });
+    service.setAgentChatService({
+      listSessions: vi.fn(async () => [{
+        sessionId: "chat-1",
+        laneId: LANE_ID,
+        provider: "codex",
+        model: "gpt-5-codex",
+        title: "Ship transcript links",
+        startedAt: "2026-06-01T10:00:00.000Z",
+        lastActivityAt: "2026-06-01T11:00:00.000Z",
+      }]),
+      readTranscript: vi.fn(async () => [
+        { role: "user", text: "Please implement transcript gists.", timestamp: "2026-06-01T10:00:00.000Z" },
+      ]),
+    } as any);
+
+    await service.createFromLane({
+      laneId: LANE_ID,
+      title: "My PR",
+      body: [
+        "description",
+        "",
+        "<!-- ade:transcript-gists v=1 count=1 -->",
+        "## ADE chat transcripts",
+        "",
+        "- [Existing](https://gist.github.com/octocat/existing)",
+        "<!-- /ade:transcript-gists -->",
+      ].join("\n"),
+      draft: false,
+      allowDirtyWorktree: true,
+    });
+
+    expect(createSecretGist).not.toHaveBeenCalled();
+    const patchedBodies = apiRequest.mock.calls
+      .map(([call]) => call)
+      .filter((call) => call.method === "PATCH" && call.path.endsWith("/pulls/99"))
+      .map((call) => call.body.body);
+    expect(patchedBodies.some((body) => body.includes("https://gist.github.com/octocat/gist-1"))).toBe(false);
   });
 
   it("uses the lane baseRef when legacy primary parent metadata disagrees with the current primary branch", async () => {

--- a/apps/desktop/src/main/services/prs/prService.ts
+++ b/apps/desktop/src/main/services/prs/prService.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import type {
+  AgentChatSessionSummary,
   BranchPullRequest,
   CreateLaneFromPrBranchArgs,
   CreateLaneFromPrBranchBlock,
@@ -161,7 +162,14 @@ import {
   type LinearPrIssueReference,
 } from "../../../shared/linearMagicWords";
 import { ensureAdeDeeplinkFooter } from "../../../shared/adeDeeplinkFooter";
+import { ensureAdePrTranscriptGistLinks, hasAdePrTranscriptGistLinks, type AdePrTranscriptGistLink } from "../../../shared/adePrTranscriptGists";
 import { normalizeEscapedMarkdownNewlines } from "../../../shared/prMarkdownText";
+import {
+  formatPrTranscriptGistMarkdown,
+  MAX_PR_TRANSCRIPT_GIST_SESSIONS,
+  transcriptGistDescription,
+  transcriptGistLinkTitle,
+} from "./prTranscriptGists";
 
 type CreatePrFromLaneInternalArgs = CreatePrFromLaneArgs & {
   skipBranchPush?: boolean;
@@ -942,6 +950,7 @@ export function createPrService({
     github_url, github_node_id, title, state, base_branch, head_branch,
     checks_status, review_status, additions, deletions, last_synced_at,
     created_at, updated_at, creation_strategy, merge_conflicts, behind_base_by`;
+  let agentChatService: ReturnType<typeof createAgentChatService> | null = null;
 
   const acquireLaneMutationLock = (args: {
     lane: LaneSummary;
@@ -1041,6 +1050,113 @@ export function createPrService({
         });
       });
     }
+  };
+
+  const prTranscriptGistsEnabled = (): boolean => {
+    try {
+      return projectConfigService.get().effective.github?.prTranscriptGists?.enabled === true;
+    } catch (error) {
+      logger.warn("prs.transcript_gists_config_read_failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+  };
+
+  const createPrTranscriptGistLinks = async (args: {
+    lane: LaneSummary;
+    repo: GitHubRepoRef;
+    prNumber: number;
+    githubUrl: string;
+  }): Promise<AdePrTranscriptGistLink[]> => {
+    if (!agentChatService || !prTranscriptGistsEnabled()) return [];
+    let sessions: AgentChatSessionSummary[] = [];
+    try {
+      sessions = await agentChatService.listSessions(args.lane.id, { includeArchived: false });
+    } catch (error) {
+      logger.warn("prs.transcript_gists_list_sessions_failed", {
+        laneId: args.lane.id,
+        prNumber: args.prNumber,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
+
+    const candidates = sessions
+      .filter((session) => !session.identityKey)
+      .sort((a, b) => {
+        const aMs = Date.parse(a.lastActivityAt ?? a.startedAt ?? "");
+        const bMs = Date.parse(b.lastActivityAt ?? b.startedAt ?? "");
+        if (Number.isFinite(aMs) && Number.isFinite(bMs) && aMs !== bMs) return bMs - aMs;
+        return a.sessionId.localeCompare(b.sessionId);
+      })
+      .slice(0, MAX_PR_TRANSCRIPT_GIST_SESSIONS);
+
+    const links: AdePrTranscriptGistLink[] = [];
+    for (const session of candidates) {
+      try {
+        const entries = await agentChatService.readTranscript(session.sessionId);
+        if (!entries.length) continue;
+        const exportedAt = nowIso();
+        const markdown = formatPrTranscriptGistMarkdown({
+          repoOwner: args.repo.owner,
+          repoName: args.repo.name,
+          prNumber: args.prNumber,
+          githubUrl: args.githubUrl,
+          laneId: args.lane.id,
+          laneName: args.lane.name,
+          exportedAt,
+          session,
+          entries,
+        });
+        const gist = await githubService.createSecretGist({
+          description: transcriptGistDescription({
+            repoOwner: args.repo.owner,
+            repoName: args.repo.name,
+            prNumber: args.prNumber,
+            session,
+          }),
+          files: {
+            "README.md": { content: markdown },
+          },
+        });
+        if (!gist.htmlUrl) continue;
+        links.push({
+          title: transcriptGistLinkTitle(session),
+          url: gist.htmlUrl,
+          provider: session.provider,
+          entryCount: entries.length,
+        });
+      } catch (error) {
+        logger.warn("prs.transcript_gist_create_failed", {
+          laneId: args.lane.id,
+          prNumber: args.prNumber,
+          sessionId: session.sessionId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    return links;
+  };
+
+  const attachPrTranscriptGistLinks = async (args: {
+    lane: LaneSummary;
+    repo: GitHubRepoRef;
+    prNumber: number;
+    githubUrl: string;
+    currentBody: string;
+  }): Promise<string> => {
+    if (hasAdePrTranscriptGistLinks(args.currentBody)) return args.currentBody;
+    const links = await createPrTranscriptGistLinks(args);
+    if (!links.length) return args.currentBody;
+    const nextBody = ensureAdePrTranscriptGistLinks(args.currentBody, links);
+    if (nextBody === args.currentBody) return args.currentBody;
+    await githubService.apiRequest({
+      method: "PATCH",
+      path: `/repos/${args.repo.owner}/${args.repo.name}/pulls/${args.prNumber}`,
+      body: { body: nextBody },
+    });
+    return nextBody;
   };
 
   const getRowById = (prId: string): PullRequestRow | null =>
@@ -3958,6 +4074,22 @@ export function createPrService({
       });
     });
 
+    await attachPrTranscriptGistLinks({
+      lane,
+      repo,
+      prNumber,
+      githubUrl: summary.githubUrl || `https://github.com/${repo.owner}/${repo.name}/pull/${prNumber}`,
+      currentBody: typeof pr?.body === "string" ? pr.body : enrichedBody,
+    }).then((body) => {
+      if (pr) pr.body = body;
+    }).catch((error) => {
+      logger.warn("prs.transcript_gists_attach_failed", {
+        laneId: lane.id,
+        prNumber,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+
     return await refreshOne(prId);
   };
 
@@ -4065,6 +4197,22 @@ export function createPrService({
       linkedAt: createdAt,
     }).catch((error) => {
       logger.warn("prs.linear_pr_cards_publish_failed", {
+        laneId: lane.id,
+        prNumber: locator.number,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+
+    await attachPrTranscriptGistLinks({
+      lane,
+      repo,
+      prNumber: locator.number,
+      githubUrl: summary.githubUrl || `https://github.com/${repo.owner}/${repo.name}/pull/${locator.number}`,
+      currentBody: typeof pr?.body === "string" ? pr.body : patchedBody,
+    }).then((body) => {
+      if (pr) pr.body = body;
+    }).catch((error) => {
+      logger.warn("prs.transcript_gists_attach_failed", {
         laneId: lane.id,
         prNumber: locator.number,
         error: error instanceof Error ? error.message : String(error),
@@ -7430,8 +7578,8 @@ export function createPrService({
       return markResolutionWorkerActive(proposalId, laneId, workerStepId);
     },
 
-    setAgentChatService(_svc: ReturnType<typeof createAgentChatService>): void {
-      // Reserved for future PR<->chat linking.
+    setAgentChatService(svc: ReturnType<typeof createAgentChatService>): void {
+      agentChatService = svc;
     },
 
     async refreshSnapshots(args: { prId?: string } = {}): Promise<{ refreshedCount: number }> {

--- a/apps/desktop/src/main/services/prs/prTranscriptGists.ts
+++ b/apps/desktop/src/main/services/prs/prTranscriptGists.ts
@@ -1,0 +1,85 @@
+import type { AgentChatSessionSummary, AgentChatTranscriptEntry } from "../../../shared/types";
+
+export const MAX_PR_TRANSCRIPT_GIST_SESSIONS = 20;
+export const MAX_PR_TRANSCRIPT_GIST_CHARS = 240_000;
+
+export type PrTranscriptGistContext = {
+  repoOwner: string;
+  repoName: string;
+  prNumber: number;
+  githubUrl: string;
+  laneId: string;
+  laneName: string;
+  exportedAt: string;
+  session: AgentChatSessionSummary;
+  entries: AgentChatTranscriptEntry[];
+};
+
+export function formatPrTranscriptGistMarkdown(context: PrTranscriptGistContext): string {
+  const sessionTitle = inlineText(context.session.title) || defaultSessionTitle(context.session);
+  const lines: string[] = [
+    `# ${escapeHeading(sessionTitle)}`,
+    "",
+    `- Repository: \`${context.repoOwner}/${context.repoName}\``,
+    `- Pull request: [#${context.prNumber}](${context.githubUrl})`,
+    `- Lane: ${inlineText(context.laneName) || context.laneId} (\`${context.laneId}\`)`,
+    `- Session: \`${context.session.sessionId}\``,
+    `- Provider: ${inlineText(context.session.provider) || "unknown"}`,
+    `- Model: ${inlineText(context.session.model || context.session.modelId) || "unknown"}`,
+    `- Exported: ${context.exportedAt}`,
+    "- Visibility: secret gist (link-accessible)",
+    "",
+    "## Transcript",
+    "",
+  ];
+
+  if (!context.entries.length) {
+    lines.push("_No user or assistant transcript entries were captured for this session._");
+  } else {
+    context.entries.forEach((entry, index) => {
+      const role = entry.role === "user" ? "User" : "Assistant";
+      const timestamp = inlineText(entry.timestamp);
+      lines.push(`### ${role}${timestamp ? ` - ${timestamp}` : ""}`);
+      lines.push("");
+      const text = (entry.displayText || entry.text || "").trim();
+      lines.push(text || "_Empty message._");
+      if (index < context.entries.length - 1) lines.push("");
+    });
+  }
+
+  return truncateMarkdown(lines.join("\n").trimEnd() + "\n");
+}
+
+export function transcriptGistDescription(context: {
+  repoOwner: string;
+  repoName: string;
+  prNumber: number;
+  session: Pick<AgentChatSessionSummary, "title" | "sessionId">;
+}): string {
+  const title = inlineText(context.session.title) || context.session.sessionId;
+  return `ADE chat transcript for ${context.repoOwner}/${context.repoName}#${context.prNumber}: ${title}`;
+}
+
+export function transcriptGistLinkTitle(session: Pick<AgentChatSessionSummary, "title" | "provider" | "sessionId">): string {
+  const title = inlineText(session.title) || defaultSessionTitle(session);
+  const provider = inlineText(session.provider);
+  return provider ? `${title} (${provider})` : title;
+}
+
+function defaultSessionTitle(session: Pick<AgentChatSessionSummary, "provider" | "sessionId">): string {
+  const provider = inlineText(session.provider);
+  return provider ? `${provider} chat ${session.sessionId.slice(0, 8)}` : `ADE chat ${session.sessionId.slice(0, 8)}`;
+}
+
+function inlineText(value: unknown): string {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function escapeHeading(value: string): string {
+  return value.replace(/^#+\s*/g, "").trim() || "ADE chat transcript";
+}
+
+function truncateMarkdown(value: string): string {
+  if (value.length <= MAX_PR_TRANSCRIPT_GIST_CHARS) return value;
+  return `${value.slice(0, MAX_PR_TRANSCRIPT_GIST_CHARS - 96).trimEnd()}\n\n_Transcript truncated by ADE before gist publication._\n`;
+}

--- a/apps/desktop/src/renderer/components/settings/GitHubSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/GitHubSection.tsx
@@ -184,7 +184,7 @@ export function GitHubSection() {
     setActionError(null);
     setSaveNotice(null);
     try {
-      const snapshot = projectConfig ?? await window.ade.projectConfig.get();
+      const snapshot = await window.ade.projectConfig.get();
       const next = await window.ade.projectConfig.save({
         shared: snapshot.shared,
         local: {

--- a/apps/desktop/src/renderer/components/settings/GitHubSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/GitHubSection.tsx
@@ -197,7 +197,7 @@ export function GitHubSection() {
       });
       setProjectConfig(next);
       setTranscriptGistsEnabled(next.effective.github?.prTranscriptGists?.enabled === true);
-      setSaveNotice(enabled ? "PR transcript gists enabled." : "PR transcript gists disabled.");
+      setSaveNotice(enabled ? "PR chat transcripts enabled." : "PR chat transcripts disabled.");
     } catch (error) {
       setActionError(error instanceof Error ? error.message : String(error));
     } finally {
@@ -478,11 +478,11 @@ export function GitHubSection() {
           <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
             <ShieldCheck size={18} color={transcriptGistsEnabled ? COLORS.success : COLORS.textMuted} weight="fill" />
             <span style={{ fontSize: 13, fontWeight: 700, fontFamily: SANS_FONT, color: COLORS.textPrimary }}>
-              PR transcript gists
+              PR chat transcripts
             </span>
           </div>
           <span style={inlineBadge(transcriptGistsEnabled ? COLORS.success : COLORS.textMuted)}>
-            {transcriptGistsEnabled ? "Secret gists" : "Off"}
+            {transcriptGistsEnabled ? "On" : "Off"}
           </span>
         </div>
         <label style={{ display: "flex", alignItems: "flex-start", gap: 10, cursor: configBusy ? "default" : "pointer" }}>
@@ -497,10 +497,10 @@ export function GitHubSection() {
           />
           <span style={{ display: "grid", gap: 6 }}>
             <span style={{ fontSize: 12, fontFamily: SANS_FONT, color: COLORS.textPrimary }}>
-              Attach secret gist links for ADE chat transcripts when creating or linking PRs.
+              Attach ADE chat transcript links when creating or linking PRs.
             </span>
             <span style={{ fontSize: 11, fontFamily: SANS_FONT, color: COLORS.textSecondary, lineHeight: "18px" }}>
-              Secret gists are link-accessible. ADE publishes only structured chat turns, not raw terminal logs.
+              Transcripts are published as secret gists, which are link-accessible. ADE publishes only structured chat turns, not raw terminal logs.
             </span>
           </span>
         </label>

--- a/apps/desktop/src/renderer/components/settings/GitHubSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/GitHubSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type CSSProperties } from "react";
-import type { GitHubStatus } from "../../../shared/types";
+import type { GitHubStatus, ProjectConfigSnapshot } from "../../../shared/types";
 import {
   GithubLogo,
   CheckCircle,
@@ -22,7 +22,10 @@ type TokenType = "classic" | "fine-grained" | "unknown";
 
 const GH_AUTH_LOGIN_COMMAND = "gh auth login -h github.com -s repo -s workflow";
 const GH_AUTH_REFRESH_COMMAND = "gh auth refresh -h github.com -s repo -s workflow";
+const GH_AUTH_LOGIN_WITH_GIST_COMMAND = "gh auth login -h github.com -s repo -s workflow -s gist";
+const GH_AUTH_REFRESH_WITH_GIST_COMMAND = "gh auth refresh -h github.com -s repo -s workflow -s gist";
 const GITHUB_CLASSIC_TOKEN_NEW_URL = "https://github.com/settings/tokens/new?description=ADE%20desktop%20PR%20workflows&scopes=repo,workflow";
+const GITHUB_CLASSIC_TOKEN_WITH_GIST_NEW_URL = "https://github.com/settings/tokens/new?description=ADE%20desktop%20PR%20workflows&scopes=repo,workflow,gist";
 const GITHUB_CLASSIC_TOKENS_URL = "https://github.com/settings/tokens";
 const GITHUB_FINE_GRAINED_TOKEN_NEW_URL = "https://github.com/settings/personal-access-tokens/new?name=ADE&description=ADE%20desktop%20PR%20workflows&contents=write&pull_requests=write&metadata=read&actions=write&workflows=write";
 const GITHUB_FINE_GRAINED_TOKENS_URL = "https://github.com/settings/personal-access-tokens";
@@ -86,8 +89,11 @@ export function GitHubSection() {
   const [githubStatus, setGithubStatus] = useState<GitHubStatus | null>(null);
   const [githubTokenDraft, setGithubTokenDraft] = useState("");
   const [githubBusy, setGithubBusy] = useState(false);
+  const [configBusy, setConfigBusy] = useState(false);
   const [tokenFocused, setTokenFocused] = useState(false);
   const [showPatSetup, setShowPatSetup] = useState(false);
+  const [projectConfig, setProjectConfig] = useState<ProjectConfigSnapshot | null>(null);
+  const [transcriptGistsEnabled, setTranscriptGistsEnabled] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -96,6 +102,14 @@ export function GitHubSection() {
       .getStatus()
       .then((status) => {
         if (!cancelled) setGithubStatus(status);
+      })
+      .catch(() => {});
+    window.ade.projectConfig
+      .get()
+      .then((snapshot) => {
+        if (cancelled) return;
+        setProjectConfig(snapshot);
+        setTranscriptGistsEnabled(snapshot.effective.github?.prTranscriptGists?.enabled === true);
       })
       .catch(() => {});
 
@@ -165,6 +179,32 @@ export function GitHubSection() {
       .finally(() => setGithubBusy(false));
   };
 
+  const handleToggleTranscriptGists = async (enabled: boolean) => {
+    setConfigBusy(true);
+    setActionError(null);
+    setSaveNotice(null);
+    try {
+      const snapshot = projectConfig ?? await window.ade.projectConfig.get();
+      const next = await window.ade.projectConfig.save({
+        shared: snapshot.shared,
+        local: {
+          ...snapshot.local,
+          github: {
+            ...(snapshot.local.github ?? {}),
+            prTranscriptGists: { enabled },
+          },
+        },
+      });
+      setProjectConfig(next);
+      setTranscriptGistsEnabled(next.effective.github?.prTranscriptGists?.enabled === true);
+      setSaveNotice(enabled ? "PR transcript gists enabled." : "PR transcript gists disabled.");
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setConfigBusy(false);
+    }
+  };
+
   const tokenAuthenticated = Boolean(githubStatus?.tokenStored && githubStatus?.userLogin);
   const isConnected = Boolean(githubStatus?.connected);
   const isFineGrainedToken = githubStatus?.tokenType === "fine-grained";
@@ -184,7 +224,10 @@ export function GitHubSection() {
     statusColor = COLORS.textMuted;
     statusLabel = "Not connected";
   }
-  const ghCommand = tokenAuthenticated && githubStatus?.authSource === "gh" ? GH_AUTH_REFRESH_COMMAND : GH_AUTH_LOGIN_COMMAND;
+  const ghCommand = transcriptGistsEnabled
+    ? tokenAuthenticated && githubStatus?.authSource === "gh" ? GH_AUTH_REFRESH_WITH_GIST_COMMAND : GH_AUTH_LOGIN_WITH_GIST_COMMAND
+    : tokenAuthenticated && githubStatus?.authSource === "gh" ? GH_AUTH_REFRESH_COMMAND : GH_AUTH_LOGIN_COMMAND;
+  const classicTokenUrl = transcriptGistsEnabled ? GITHUB_CLASSIC_TOKEN_WITH_GIST_NEW_URL : GITHUB_CLASSIC_TOKEN_NEW_URL;
   const openExternal = (url: string) => {
     void window.ade.app.openExternal(url);
   };
@@ -430,6 +473,44 @@ export function GitHubSection() {
         </div>
       </div>
 
+      <div style={cardStyle()}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, marginBottom: 14 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <ShieldCheck size={18} color={transcriptGistsEnabled ? COLORS.success : COLORS.textMuted} weight="fill" />
+            <span style={{ fontSize: 13, fontWeight: 700, fontFamily: SANS_FONT, color: COLORS.textPrimary }}>
+              PR transcript gists
+            </span>
+          </div>
+          <span style={inlineBadge(transcriptGistsEnabled ? COLORS.success : COLORS.textMuted)}>
+            {transcriptGistsEnabled ? "Secret gists" : "Off"}
+          </span>
+        </div>
+        <label style={{ display: "flex", alignItems: "flex-start", gap: 10, cursor: configBusy ? "default" : "pointer" }}>
+          <input
+            type="checkbox"
+            checked={transcriptGistsEnabled}
+            disabled={configBusy}
+            onChange={(event) => {
+              void handleToggleTranscriptGists(event.currentTarget.checked);
+            }}
+            style={{ marginTop: 2 }}
+          />
+          <span style={{ display: "grid", gap: 6 }}>
+            <span style={{ fontSize: 12, fontFamily: SANS_FONT, color: COLORS.textPrimary }}>
+              Attach secret gist links for ADE chat transcripts when creating or linking PRs.
+            </span>
+            <span style={{ fontSize: 11, fontFamily: SANS_FONT, color: COLORS.textSecondary, lineHeight: "18px" }}>
+              Secret gists are link-accessible. ADE publishes only structured chat turns, not raw terminal logs.
+            </span>
+          </span>
+        </label>
+        {transcriptGistsEnabled ? (
+          <div style={{ ...infoBoxStyle, marginTop: 12 }}>
+            GitHub CLI auth needs the gist scope. Classic PATs need gist, and fine-grained tokens need Gists read/write permission.
+          </div>
+        ) : null}
+      </div>
+
       {showPatSetup ? (
         <div style={cardStyle()}>
           <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14 }}>
@@ -454,7 +535,7 @@ export function GitHubSection() {
                 Generate a classic token with repo and workflow scopes.
               </div>
               <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 12 }}>
-                <button type="button" style={linkButtonStyle} onClick={() => openExternal(GITHUB_CLASSIC_TOKEN_NEW_URL)}>
+                <button type="button" style={linkButtonStyle} onClick={() => openExternal(classicTokenUrl)}>
                   <ArrowSquareOut size={12} weight="bold" /> Create classic token
                 </button>
                 <button type="button" style={linkButtonStyle} onClick={() => openExternal(GITHUB_CLASSIC_TOKENS_URL)}>

--- a/apps/desktop/src/shared/adePrTranscriptGists.test.ts
+++ b/apps/desktop/src/shared/adePrTranscriptGists.test.ts
@@ -11,7 +11,7 @@ describe("renderAdePrTranscriptGistLinks", () => {
     const block = renderAdePrTranscriptGistLinks([
       {
         title: "Chat [review]",
-        url: "https://gist.github.com/octo/gist 1)",
+        url: "https://gist.github.com/octo/gist (1)",
         provider: "codex[cli]",
         entryCount: 2,
       },
@@ -19,7 +19,7 @@ describe("renderAdePrTranscriptGistLinks", () => {
 
     expect(block).toContain("<!-- ade:transcript-gists v=1 count=1 -->");
     expect(block).toContain("## ADE chat transcripts");
-    expect(block).toContain("[ADE chat transcripts](https://gist.github.com/octo/gist%201%29)");
+    expect(block).toContain("[ADE chat transcripts](https://gist.github.com/octo/gist%20%281%29)");
     expect(block).toContain("codex\\[cli\\] | 2 messages");
     expect(block).toContain("<!-- /ade:transcript-gists -->");
   });

--- a/apps/desktop/src/shared/adePrTranscriptGists.test.ts
+++ b/apps/desktop/src/shared/adePrTranscriptGists.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ensureAdePrTranscriptGistLinks,
+  hasAdePrTranscriptGistLinks,
+  renderAdePrTranscriptGistLinks,
+} from "./adePrTranscriptGists";
+
+describe("renderAdePrTranscriptGistLinks", () => {
+  it("renders escaped transcript links with message counts", () => {
+    const block = renderAdePrTranscriptGistLinks([
+      {
+        title: "Chat [review]",
+        url: "https://gist.github.com/octo/gist 1)",
+        provider: "codex[cli]",
+        entryCount: 2,
+      },
+    ]);
+
+    expect(block).toContain("<!-- ade:transcript-gists v=1 count=1 -->");
+    expect(block).toContain("## ADE chat transcripts");
+    expect(block).toContain("[Chat \\[review\\]](https://gist.github.com/octo/gist%201%29)");
+    expect(block).toContain("codex\\[cli\\] | 2 messages");
+    expect(block).toContain("<!-- /ade:transcript-gists -->");
+  });
+});
+
+describe("ensureAdePrTranscriptGistLinks", () => {
+  it("inserts transcript links before the ADE deeplink footer", () => {
+    const body = [
+      "Summary",
+      "",
+      "<!-- ade:link v=1 type=pr repo=a/b branch=f num=1 -->",
+      "Open in ADE",
+      "<!-- /ade:link -->",
+      "",
+    ].join("\n");
+    const next = ensureAdePrTranscriptGistLinks(body, [
+      { title: "Chat", url: "https://gist.github.com/octo/gist-1", provider: "codex", entryCount: 1 },
+    ]);
+
+    expect(next.indexOf("## ADE chat transcripts")).toBeGreaterThan(next.indexOf("Summary"));
+    expect(next.indexOf("## ADE chat transcripts")).toBeLessThan(next.indexOf("<!-- ade:link"));
+  });
+
+  it("replaces an existing transcript block in place", () => {
+    const initial = ensureAdePrTranscriptGistLinks("Summary\n", [
+      { title: "Old", url: "https://gist.github.com/octo/old" },
+    ]);
+    const updated = ensureAdePrTranscriptGistLinks(initial, [
+      { title: "New", url: "https://gist.github.com/octo/new" },
+    ]);
+
+    expect((updated.match(/<!-- ade:transcript-gists v=1/gi) ?? [])).toHaveLength(1);
+    expect(updated).toContain("https://gist.github.com/octo/new");
+    expect(updated).not.toContain("https://gist.github.com/octo/old");
+  });
+});
+
+describe("hasAdePrTranscriptGistLinks", () => {
+  it("detects a present marker", () => {
+    expect(
+      hasAdePrTranscriptGistLinks("body\n\n<!-- ade:transcript-gists v=1 count=1 -->"),
+    ).toBe(true);
+  });
+
+  it("returns false for missing markers", () => {
+    expect(hasAdePrTranscriptGistLinks("body")).toBe(false);
+    expect(hasAdePrTranscriptGistLinks(null)).toBe(false);
+    expect(hasAdePrTranscriptGistLinks(undefined)).toBe(false);
+  });
+});

--- a/apps/desktop/src/shared/adePrTranscriptGists.test.ts
+++ b/apps/desktop/src/shared/adePrTranscriptGists.test.ts
@@ -19,7 +19,7 @@ describe("renderAdePrTranscriptGistLinks", () => {
 
     expect(block).toContain("<!-- ade:transcript-gists v=1 count=1 -->");
     expect(block).toContain("## ADE chat transcripts");
-    expect(block).toContain("[Chat \\[review\\]](https://gist.github.com/octo/gist%201%29)");
+    expect(block).toContain("[ADE chat transcripts](https://gist.github.com/octo/gist%201%29)");
     expect(block).toContain("codex\\[cli\\] | 2 messages");
     expect(block).toContain("<!-- /ade:transcript-gists -->");
   });

--- a/apps/desktop/src/shared/adePrTranscriptGists.ts
+++ b/apps/desktop/src/shared/adePrTranscriptGists.ts
@@ -89,7 +89,7 @@ function escapeMarkdownLinkText(value: string): string {
 }
 
 function escapeMarkdownUrl(value: string): string {
-  return value.replace(/\)/g, "%29").replace(/\s/g, "%20");
+  return value.replace(/\(/g, "%28").replace(/\)/g, "%29").replace(/\s/g, "%20");
 }
 
 function escapeMarkdownInlineText(value: string): string {

--- a/apps/desktop/src/shared/adePrTranscriptGists.ts
+++ b/apps/desktop/src/shared/adePrTranscriptGists.ts
@@ -23,12 +23,15 @@ export function renderAdePrTranscriptGistLinks(links: AdePrTranscriptGistLink[])
     `<!-- ade:transcript-gists v=1 count=${normalized.length} -->`,
     "## ADE chat transcripts",
     "",
-    ...normalized.map((link) => {
+    ...normalized.map((link, index) => {
+      const linkTitle = normalized.length === 1
+        ? "ADE chat transcripts"
+        : `ADE chat transcript ${index + 1}`;
       const details = [
         link.provider,
         link.entryCount != null ? `${link.entryCount} message${link.entryCount === 1 ? "" : "s"}` : null,
       ].filter((value): value is string => Boolean(value));
-      return `- [${escapeMarkdownLinkText(link.title)}](${escapeMarkdownUrl(link.url)})${details.length ? ` - ${details.map(escapeMarkdownInlineText).join(" | ")}` : ""}`;
+      return `- [${escapeMarkdownLinkText(linkTitle)}](${escapeMarkdownUrl(link.url)})${details.length ? ` - ${details.map(escapeMarkdownInlineText).join(" | ")}` : ""}`;
     }),
     MARKER_CLOSE,
   ];

--- a/apps/desktop/src/shared/adePrTranscriptGists.ts
+++ b/apps/desktop/src/shared/adePrTranscriptGists.ts
@@ -1,0 +1,94 @@
+const MARKER_OPEN_RE = /<!--\s*ade:transcript-gists\s+v=\d+[^>]*-->/i;
+const MARKER_CLOSE = "<!-- /ade:transcript-gists -->";
+const MARKER_CLOSE_RE = /<!--\s*\/ade:transcript-gists\s*-->/i;
+const ADE_LINK_MARKER_OPEN_RE = /<!--\s*ade:link\s+v=\d+[^>]*-->/i;
+
+export type AdePrTranscriptGistLink = {
+  title: string;
+  url: string;
+  provider?: string | null;
+  entryCount?: number | null;
+};
+
+export function renderAdePrTranscriptGistLinks(links: AdePrTranscriptGistLink[]): string {
+  const normalized = links
+    .map((link) => ({
+      title: normalizeInline(link.title) || "ADE chat transcript",
+      url: link.url.trim(),
+      provider: normalizeInline(link.provider),
+      entryCount: Number.isFinite(Number(link.entryCount)) ? Math.max(0, Math.floor(Number(link.entryCount))) : null,
+    }))
+    .filter((link) => link.url.length > 0);
+  const lines = [
+    `<!-- ade:transcript-gists v=1 count=${normalized.length} -->`,
+    "## ADE chat transcripts",
+    "",
+    ...normalized.map((link) => {
+      const details = [
+        link.provider,
+        link.entryCount != null ? `${link.entryCount} message${link.entryCount === 1 ? "" : "s"}` : null,
+      ].filter((value): value is string => Boolean(value));
+      return `- [${escapeMarkdownLinkText(link.title)}](${escapeMarkdownUrl(link.url)})${details.length ? ` - ${details.map(escapeMarkdownInlineText).join(" | ")}` : ""}`;
+    }),
+    MARKER_CLOSE,
+  ];
+  return lines.join("\n");
+}
+
+export function ensureAdePrTranscriptGistLinks(body: string, links: AdePrTranscriptGistLink[]): string {
+  const normalizedLinks = links.filter((link) => link.url.trim().length > 0);
+  const safeBody = typeof body === "string" ? body : "";
+  const openIdx = safeBody.search(MARKER_OPEN_RE);
+  if (!normalizedLinks.length) {
+    if (openIdx < 0) return safeBody;
+    const closeMatch = MARKER_CLOSE_RE.exec(safeBody.slice(openIdx));
+    if (!closeMatch) return safeBody;
+    const before = safeBody.slice(0, openIdx).trimEnd();
+    const after = safeBody.slice(openIdx + closeMatch.index + closeMatch[0].length).trimStart();
+    return [before, after].filter(Boolean).join("\n\n").trimEnd() + (before || after ? "\n" : "");
+  }
+
+  const block = renderAdePrTranscriptGistLinks(normalizedLinks);
+  if (openIdx >= 0) {
+    const closeMatch = MARKER_CLOSE_RE.exec(safeBody.slice(openIdx));
+    if (closeMatch) {
+      const before = safeBody.slice(0, openIdx).trimEnd();
+      const after = safeBody.slice(openIdx + closeMatch.index + closeMatch[0].length);
+      let tail: string;
+      if (!after) tail = "";
+      else if (after.startsWith("\n")) tail = after;
+      else tail = `\n${after}`;
+      return `${before}\n\n${block}${tail}`.trimEnd() + "\n";
+    }
+  }
+  const trimmed = safeBody.trimEnd();
+  if (!trimmed) return `${block}\n`;
+  const adeLinkIdx = safeBody.search(ADE_LINK_MARKER_OPEN_RE);
+  if (adeLinkIdx >= 0) {
+    const before = safeBody.slice(0, adeLinkIdx).trimEnd();
+    const after = safeBody.slice(adeLinkIdx).trimStart();
+    return `${before ? `${before}\n\n` : ""}${block}\n\n${after}`.trimEnd() + "\n";
+  }
+  return `${trimmed}\n\n${block}\n`;
+}
+
+export function hasAdePrTranscriptGistLinks(body: string | null | undefined): boolean {
+  if (!body) return false;
+  return MARKER_OPEN_RE.test(body);
+}
+
+function normalizeInline(value: string | null | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function escapeMarkdownLinkText(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+}
+
+function escapeMarkdownUrl(value: string): string {
+  return value.replace(/\)/g, "%29").replace(/\s/g, "%20");
+}
+
+function escapeMarkdownInlineText(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+}

--- a/apps/desktop/src/shared/types/config.ts
+++ b/apps/desktop/src/shared/types/config.ts
@@ -1417,6 +1417,9 @@ export type ProjectConfigFile = {
   environments?: EnvironmentMapping[];
   github?: {
     prPollingIntervalSeconds?: number;
+    prTranscriptGists?: {
+      enabled?: boolean;
+    };
   };
   git?: {
     autoRebaseOnHeadChange?: boolean;
@@ -1454,6 +1457,9 @@ export type EffectiveProjectConfig = {
   environments?: EnvironmentMapping[];
   github?: {
     prPollingIntervalSeconds?: number;
+    prTranscriptGists?: {
+      enabled: boolean;
+    };
   };
   git: {
     autoRebaseOnHeadChange: boolean;


### PR DESCRIPTION
Adds an opt-in PR workflow that publishes each ADE chat transcript as a secret GitHub gist and links those gists from ADE-created PR bodies.\n\nValidation:\n- npm --prefix apps/desktop run typecheck\n- npm --prefix apps/ade-cli run typecheck\n- npx vitest run src/shared/adePrTranscriptGists.test.ts src/main/services/prs/prService.test.ts src/main/services/github/githubService.test.ts src/main/services/config/projectConfigService.test.ts\n- npm --prefix apps/ade-cli run test\n- npm --prefix apps/desktop run build\n- npm --prefix apps/desktop run lint

<!-- ade:transcript-gists v=1 count=1 -->
## ADE chat transcripts

- [ADE chat transcripts](https://gist.github.com/arul28/a0e754cd74d369870aa0bb28f55a3595) - codex | 96 messages
<!-- /ade:transcript-gists -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fpr-chat-gist-transcripts-74551ae1 num=520 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fpr-chat-gist-transcripts-74551ae1&amp;pr=520">ade/pr-chat-gist-transcripts-74551ae1 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=520">PR #520</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an opt-in feature that publishes ADE chat transcripts as secret GitHub gists and links them from PR bodies, controlled via a new settings UI toggle and CLI commands.

- Adds `createSecretGist` to both the desktop and headless GitHub services, with `prTranscriptGists` config wired through `projectConfigService` (`coerceGithubConfig`, `mergeGithubConfig`, `setPrTranscriptGists`), and `attachPrTranscriptGistLinks` integrated into `createFromLane` / `updateFromLink` in `prService`.
- Adds a `GitHubSection` toggle that updates the `gh` CLI command and classic token URL to include the gist scope when the feature is enabled, though the fine-grained token creation URL is left unchanged.
- Adds `buildSettingsPlan` CLI subcommand (`ade settings pr-transcript-gists enable|disable|status`) and comprehensive unit tests for gist rendering, config persistence, and PR body patching.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the fine-grained token URL — all other paths are well-guarded and tested.

The `gh` CLI command and classic token creation URL are correctly updated when gist transcripts are enabled, but the "Create fine-grained token" button in the PAT setup section still uses the static URL without any gist permission. The info box explicitly tells users that fine-grained tokens require Gists read/write permission, making this a real mismatch that would cause token creation failures for fine-grained token users.

apps/desktop/src/renderer/components/settings/GitHubSection.tsx — the fine-grained token URL needs to be conditioned on transcriptGistsEnabled just as classicTokenUrl is.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/settings/GitHubSection.tsx | Adds transcript gist toggle UI; classic token URL and gh CLI command are correctly updated when gists are enabled, but the fine-grained token creation URL is not — users following the in-UI guidance would get a token without Gists permission. |
| apps/desktop/src/main/services/prs/prService.ts | Adds createPrTranscriptGistLinks / attachPrTranscriptGistLinks; gist creation before PATCH means gists can be orphaned if PATCH fails (noted in previous review). Otherwise well-guarded with try/catch and skip-if-already-present check. |
| apps/desktop/src/main/services/config/projectConfigService.ts | Refactors save into saveCandidate, adds coerceGithubConfig/mergeGithubConfig and setPrTranscriptGists; clean DRY improvement with proper field-level merge logic. |
| apps/desktop/src/main/services/github/githubService.ts | Adds createSecretGist with input normalisation and empty-file guard; mirrors the headless implementation correctly. |
| apps/desktop/src/shared/adePrTranscriptGists.ts | New shared module with marker-based PR body insertion/replacement logic; URL and link-text escaping is in place. |
| apps/desktop/src/main/services/prs/prTranscriptGists.ts | New file that formats per-session transcript markdown for gist upload; well-structured with truncation guard and heading-injection prevention. |
| apps/desktop/src/shared/types/config.ts | Adds prTranscriptGists to both ProjectConfigFile and EffectiveProjectConfig with appropriate optional/required semantics. |
| apps/ade-cli/src/cli.ts | Adds settings pr-transcript-gists subcommand with enable/disable/status modes; firstPositional correctly consumes args via splice so the two-call pattern works as tested. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as GitHubSection (renderer)
    participant Config as projectConfigService
    participant PR as prService
    participant Chat as agentChatService
    participant GH as githubService

    UI->>Config: "setPrTranscriptGists({ enabled })"
    Config-->>UI: ProjectConfigSnapshot

    PR->>Config: get() → prTranscriptGists.enabled?
    alt enabled
        PR->>Chat: listSessions(laneId)
        Chat-->>PR: AgentChatSessionSummary[]
        loop per session (max 20)
            PR->>Chat: readTranscript(sessionId)
            Chat-->>PR: AgentChatTranscriptEntry[]
            PR->>GH: "createSecretGist({ description, files })"
            GH-->>PR: "{ id, htmlUrl }"
        end
        PR->>PR: ensureAdePrTranscriptGistLinks(body, links)
        PR->>GH: "PATCH /pulls/:number { body }"
    end
    PR-->>PR: refreshOne(prId)
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/main/services/prs/prService.ts`, line 930-936 ([link](https://github.com/arul28/ade/blob/b57675eee062d15f10ed8085fbf88e86ef824d67/apps/desktop/src/main/services/prs/prService.ts#L930-L936)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Orphaned gists if PR body PATCH fails**

   `createPrTranscriptGistLinks` creates all gists before `attachPrTranscriptGistLinks` attempts to PATCH the PR body. If the PATCH throws (e.g., token lacks `write:pull_request`, transient 5xx), the error is swallowed by the outer `.catch`, but the gists already exist on GitHub and are never linked. On the next `updateFromLink` call `hasAdePrTranscriptGistLinks` returns false (the PR body never got the marker), so a second round of gists is created and the first set becomes permanently orphaned.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/prs/prService.ts
   Line: 930-936

   Comment:
   **Orphaned gists if PR body PATCH fails**

   `createPrTranscriptGistLinks` creates all gists before `attachPrTranscriptGistLinks` attempts to PATCH the PR body. If the PATCH throws (e.g., token lacks `write:pull_request`, transient 5xx), the error is swallowed by the outer `.catch`, but the gists already exist on GitHub and are never linked. On the next `updateFromLink` call `hasAdePrTranscriptGistLinks` returns false (the PR body never got the marker), so a second round of gists is created and the first set becomes permanently orphaned.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fprs%2FprService.ts%0ALine%3A%20930-936%0A%0AComment%3A%0A**Orphaned%20gists%20if%20PR%20body%20PATCH%20fails**%0A%0A%60createPrTranscriptGistLinks%60%20creates%20all%20gists%20before%20%60attachPrTranscriptGistLinks%60%20attempts%20to%20PATCH%20the%20PR%20body.%20If%20the%20PATCH%20throws%20%28e.g.%2C%20token%20lacks%20%60write%3Apull_request%60%2C%20transient%205xx%29%2C%20the%20error%20is%20swallowed%20by%20the%20outer%20%60.catch%60%2C%20but%20the%20gists%20already%20exist%20on%20GitHub%20and%20are%20never%20linked.%20On%20the%20next%20%60updateFromLink%60%20call%20%60hasAdePrTranscriptGistLinks%60%20returns%20false%20%28the%20PR%20body%20never%20got%20the%20marker%29%2C%20so%20a%20second%20round%20of%20gists%20is%20created%20and%20the%20first%20set%20becomes%20permanently%20orphaned.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=520&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fsettings%2FGitHubSection.tsx%3A574-576%0A**Fine-grained%20token%20URL%20not%20updated%20for%20gist%20scope**%0A%0AThe%20%22Create%20fine-grained%20token%22%20button%20always%20uses%20the%20static%20%60GITHUB_FINE_GRAINED_TOKEN_NEW_URL%60%2C%20but%20when%20%60transcriptGistsEnabled%60%20is%20true%20the%20info%20box%20explicitly%20tells%20users%20%22fine-grained%20tokens%20need%20Gists%20read%2Fwrite%20permission.%22%20A%20user%20following%20that%20guidance%2C%20clicking%20this%20button%2C%20and%20saving%20the%20resulting%20token%20will%20end%20up%20with%20a%20token%20that%20has%20no%20Gists%20permission%20%E2%80%94%20causing%20every%20%60createSecretGist%60%20call%20to%20fail.%20The%20classic%20token%20path%20was%20correctly%20updated%20via%20%60classicTokenUrl%60%2C%20but%20the%20fine-grained%20path%20was%20left%20behind.%20A%20%60fineGrainedTokenUrl%60%20variable%20%28analogous%20to%20%60classicTokenUrl%60%29%20that%20conditionally%20appends%20the%20gist%20scope%20parameter%20would%20fix%20the%20inconsistency.%0A%0A&repo=arul28%2Fade&pr=520&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/renderer/components/settings/GitHubSection.tsx:574-576
**Fine-grained token URL not updated for gist scope**

The "Create fine-grained token" button always uses the static `GITHUB_FINE_GRAINED_TOKEN_NEW_URL`, but when `transcriptGistsEnabled` is true the info box explicitly tells users "fine-grained tokens need Gists read/write permission." A user following that guidance, clicking this button, and saving the resulting token will end up with a token that has no Gists permission — causing every `createSecretGist` call to fail. The classic token path was correctly updated via `classicTokenUrl`, but the fine-grained path was left behind. A `fineGrainedTokenUrl` variable (analogous to `classicTokenUrl`) that conditionally appends the gist scope parameter would fix the inconsistency.


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["ship: address transcript gist review com..."](https://github.com/arul28/ade/commit/081c29ba0d256a068f9c67f930033739ebc6cfa3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35230548)</sub>

<!-- /greptile_comment -->