### PR TITLE
Gate Automations and VM in production builds

### DIFF
--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -74,7 +74,8 @@ import { initApiKeyStore } from "../../desktop/src/main/services/ai/apiKeyStore"
 import type { createSyncService } from "./services/sync/syncService";
 import type { createSyncHostService, SyncRuntimeKind } from "./services/sync/syncHostService";
 import { getSharedModelPickerStore } from "./services/modelPickerStore";
-import type { createAutomationIngressService } from "../../desktop/src/main/services/automations/automationIngressService";
+import { createAutomationIngressService } from "../../desktop/src/main/services/automations/automationIngressService";
+import { createAutomationSecretService } from "../../desktop/src/main/services/automations/automationSecretService";
 import type { createGithubService } from "../../desktop/src/main/services/github/githubService";
 import { createFeedbackReporterService } from "../../desktop/src/main/services/feedback/feedbackReporterService";
 import {
@@ -129,6 +130,10 @@ import { createLaneWorktreeLockService, type LaneWorktreeLockService } from "../
 import { createHeadlessLinearServices } from "./headlessLinearServices";
 import { EncryptedFileCredentialStore } from "./services/credentials/credentialStore";
 import { createEventBuffer, type BufferedEvent, type EventBuffer } from "./eventBuffer";
+import {
+  readAutomationsEnvOverride,
+  readMacosVmEnvOverride,
+} from "../../desktop/src/shared/automationAvailability";
 
 export { createEventBuffer, type BufferedEvent, type EventBuffer };
 
@@ -242,6 +247,7 @@ export type AdeRuntime = {
     navigate(args: AppNavigationRequest): Promise<AppNavigationResult>;
   } | null;
   eventBuffer: EventBuffer;
+  isPackaged?: boolean;
   dispose: () => void;
 };
 
@@ -263,6 +269,22 @@ export function ensureAdePaths(projectRoot: string): AdeRuntimePaths {
     chatTranscriptsDir: paths.chatTranscriptsDir,
     orchestratorCacheDir: paths.orchestratorCacheDir,
   };
+}
+
+function isSourceCheckoutRuntimeModule(modulePath: string): boolean {
+  return /[/\\]apps[/\\]ade-cli[/\\](?:src|dist)[/\\]bootstrap\.(?:ts|js|cjs)$/i.test(modulePath);
+}
+
+function automationsEnabledForHeadlessRuntime(): boolean {
+  const override = readAutomationsEnvOverride(process.env);
+  if (override !== null) return override;
+  return isSourceCheckoutRuntimeModule(__filename);
+}
+
+function macosVmEnabledForHeadlessRuntime(): boolean {
+  const override = readMacosVmEnvOverride(process.env);
+  if (override !== null) return override;
+  return isSourceCheckoutRuntimeModule(__filename);
 }
 
 function resolveCurrentAdeCliEntry(): string | null {
@@ -861,7 +883,8 @@ export async function createAdeRuntime(args: {
           return matchingLane?.id ?? lanes[0]?.id ?? null;
         },
       });
-  const macosVmService = chatOnlyRuntime
+  const macosVmFeatureEnabled = macosVmEnabledForHeadlessRuntime();
+  const macosVmService = chatOnlyRuntime || !macosVmFeatureEnabled
     ? null
     : createMacosVmService({
         projectRoot,
@@ -920,6 +943,7 @@ export async function createAdeRuntime(args: {
       pushEvent("runtime", { type: "github_status_changed", event: status }),
     onLinearWorkflowEvent: (event) =>
       pushEvent("runtime", { type: "linear_workflow_event", event }),
+    getAutomationService: () => automationServiceRef,
   });
   linearIssueTrackerRef = headlessLinearServices.linearIssueTracker;
   githubServiceRef = headlessLinearServices.githubService as ReturnType<typeof createGithubService>;
@@ -1037,19 +1061,36 @@ export async function createAdeRuntime(args: {
     defaultModelId: null,
     defaultReasoningEffort: null,
   });
-  const automationService = createAutomationService({
-    db,
-    logger,
-    projectId,
-    projectRoot,
-    laneService,
-    projectConfigService,
-    conflictService,
-    testService,
-    agentChatService: agentChatService ?? undefined,
-    onEvent: (event) => pushEvent("runtime", { ...event, source: "automations" }),
-  });
+  const automationFeatureEnabled = automationsEnabledForHeadlessRuntime();
+  const automationService = automationFeatureEnabled
+    ? createAutomationService({
+        db,
+        logger,
+        projectId,
+        projectRoot,
+        laneService,
+        projectConfigService,
+        conflictService,
+        testService,
+        agentChatService: agentChatService ?? undefined,
+        onEvent: (event) => pushEvent("runtime", { ...event, source: "automations" }),
+      })
+    : null;
   automationServiceRef = automationService;
+  const automationSecretService = automationFeatureEnabled
+    ? createAutomationSecretService({
+        adeDir: paths.adeDir,
+        logger,
+      })
+    : null;
+  const automationIngressService = automationFeatureEnabled && automationService && automationSecretService
+    ? createAutomationIngressService({
+        logger,
+        automationService,
+        secretService: automationSecretService,
+        listRules: () => projectConfigService.get().effective.automations ?? [],
+      })
+    : null;
   const configReloadService = createConfigReloadService({
     paths: {
       sharedPath: adeProjectService.paths.sharedConfigPath,
@@ -1067,13 +1108,15 @@ export async function createAdeRuntime(args: {
       error: error instanceof Error ? error.message : String(error),
     });
   });
-  const automationPlannerService = createAutomationPlannerService({
-    logger,
-    projectRoot,
-    projectConfigService,
-    laneService,
-    automationService,
-  });
+  const automationPlannerService = automationFeatureEnabled && automationService
+    ? createAutomationPlannerService({
+        logger,
+        projectRoot,
+        projectConfigService,
+        laneService,
+        automationService,
+      })
+    : null;
   const usageTrackingService = createUsageTrackingService({
     logger,
     pollIntervalMs: 120_000,
@@ -1247,6 +1290,7 @@ export async function createAdeRuntime(args: {
     usageTrackingService,
     budgetCapService,
     automationService,
+    automationIngressService,
     automationPlannerService,
     computerUseArtifactBrokerService,
     iosSimulatorService,
@@ -1254,13 +1298,15 @@ export async function createAdeRuntime(args: {
     builtInBrowserService: builtInBrowserBridge,
     macosVmService,
     eventBuffer,
+    isPackaged: !isSourceCheckoutRuntimeModule(__filename),
     dispose: () => {
       const swallow = (fn: () => void) => { try { fn(); } catch { /* ignore */ } };
       if (staleSessionReconcileTimer) {
         clearTimeout(staleSessionReconcileTimer);
       }
       void configReloadService.dispose().catch(() => {});
-      swallow(() => automationService.dispose());
+      swallow(() => automationIngressService?.dispose());
+      swallow(() => automationService?.dispose());
       swallow(() => usageTrackingService.dispose());
       swallow(() => apnsService.dispose());
       swallow(() => syncService?.dispose());
@@ -1302,7 +1348,7 @@ export async function createAdeRuntime(args: {
       return [...(ADE_ACTION_ALLOWLIST[domain as AdeActionDomain] ?? [])];
     },
   };
-  automationService.bindAdeActionRegistry(adeActionLookup);
+  automationService?.bindAdeActionRegistry(adeActionLookup);
 
   usageTrackingService.start();
   runtimeCreated = true;

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -26,6 +26,33 @@ import { EncryptedFileCredentialStore } from "./services/credentials/credentialS
 
 type ResolveRootsOptions = Parameters<typeof resolveRoots>[0];
 
+process.env.ADE_ENABLE_AUTOMATIONS = "1";
+process.env.ADE_ENABLE_MACOS_VM = "1";
+
+function withEnv<T>(updates: Record<string, string | undefined>, run: () => T): T {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(updates)) {
+    previous.set(key, process.env[key]);
+    const value = updates[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    return run();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 function baseResolveOpts(): Omit<
   ResolveRootsOptions,
   "projectRoot" | "workspaceRoot"
@@ -146,6 +173,52 @@ describe("ADE CLI", () => {
   it("keeps global help on the help surface", () => {
     const plan = buildCliPlan(["--help"]);
     expect(plan.kind).toBe("help");
+  });
+
+  it("hides internal Automations and macOS VM commands when disabled", () => {
+    withEnv(
+      {
+        ADE_DISABLE_AUTOMATIONS: "1",
+        ADE_DISABLE_MACOS_VM: "1",
+        ADE_ENABLE_AUTOMATIONS: undefined,
+        ADE_ENABLE_MACOS_VM: undefined,
+      },
+      () => {
+        const plan = buildCliPlan(["--help"]);
+        expect(plan.kind).toBe("help");
+        if (plan.kind !== "help") return;
+        expect(plan.text).not.toContain("ade automations");
+        expect(plan.text).not.toContain("ade macos-vm");
+      },
+    );
+  });
+
+  it("reports internal feature availability instead of planning production-only commands", () => {
+    withEnv(
+      {
+        ADE_DISABLE_AUTOMATIONS: "1",
+        ADE_DISABLE_MACOS_VM: "1",
+        ADE_ENABLE_AUTOMATIONS: undefined,
+        ADE_ENABLE_MACOS_VM: undefined,
+      },
+      () => {
+        expect(() => buildCliPlan(["automations", "list"])).toThrow(/coming soon/);
+        expect(() => buildCliPlan(["linear", "ingress", "status"])).toThrow(/coming soon/);
+        expect(() => buildCliPlan(["macos-vm", "status"])).toThrow(/coming soon/);
+
+        const automationHelp = buildCliPlan(["help", "automations"]);
+        expect(automationHelp.kind).toBe("help");
+        if (automationHelp.kind === "help") {
+          expect(automationHelp.text).toContain("ADE_ENABLE_AUTOMATIONS=1");
+        }
+
+        const vmHelp = buildCliPlan(["help", "macos-vm"]);
+        expect(vmHelp.kind).toBe("help");
+        if (vmHelp.kind === "help") {
+          expect(vmHelp.text).toContain("ADE_ENABLE_MACOS_VM=1");
+        }
+      },
+    );
   });
 
   it("keeps global version on the version surface", () => {
@@ -3503,6 +3576,106 @@ describe("ADE CLI", () => {
     expect(plan.formatter).toBe("automation-run-detail");
   });
 
+  it("automations ingress status, start, and refresh use the webhook gateway runtime actions", () => {
+    const status = buildCliPlan(["automations", "ingress", "status"]);
+    expect(status.kind).toBe("execute");
+    if (status.kind !== "execute") return;
+    expect(status.formatter).toBe("automation-ingress");
+    expect(status.steps[0]?.params).toEqual({
+      name: "run_ade_action",
+      arguments: {
+        domain: "automations",
+        action: "getIngressStatus",
+        args: {},
+      },
+    });
+
+    const start = buildCliPlan(["automations", "ingress", "start"]);
+    expect(start.kind).toBe("execute");
+    if (start.kind !== "execute") return;
+    expect(start.formatter).toBe("automation-ingress");
+    expect(start.steps[0]?.params).toEqual({
+      name: "run_ade_action",
+      arguments: {
+        domain: "automations",
+        action: "startIngress",
+        args: {},
+      },
+    });
+
+    const refresh = buildCliPlan(["automations", "ingress", "refresh"]);
+    expect(refresh.kind).toBe("execute");
+    if (refresh.kind !== "execute") return;
+    expect(refresh.formatter).toBe("automation-ingress");
+    expect(refresh.steps[0]?.params).toEqual({
+      name: "run_ade_action",
+      arguments: {
+        domain: "automations",
+        action: "refreshWebhookGatewayStatus",
+        args: {},
+      },
+    });
+  });
+
+  it("automations ingress set-url and clear-url update the public gateway URL", () => {
+    const set = buildCliPlan([
+      "automations",
+      "ingress",
+      "set-url",
+      "https://ade.example.com/ade-webhooks",
+    ]);
+    expect(set.kind).toBe("execute");
+    if (set.kind !== "execute") return;
+    expect(set.formatter).toBe("automation-ingress");
+    expect(set.steps[0]?.params).toEqual({
+      name: "run_ade_action",
+      arguments: {
+        domain: "automations",
+        action: "setWebhookGatewayPublicUrl",
+        args: { publicUrl: "https://ade.example.com/ade-webhooks" },
+      },
+    });
+
+    const clear = buildCliPlan(["automations", "ingress", "clear-url"]);
+    expect(clear.kind).toBe("execute");
+    if (clear.kind !== "execute") return;
+    expect(clear.steps[0]?.params).toMatchObject({
+      arguments: {
+        domain: "automations",
+        action: "setWebhookGatewayPublicUrl",
+        args: { publicUrl: null },
+      },
+    });
+  });
+
+  it("linear ingress start-local starts the runtime local webhook listener", () => {
+    const plan = buildCliPlan(["linear", "ingress", "start-local"]);
+    expect(plan.kind).toBe("execute");
+    if (plan.kind !== "execute") return;
+    expect(plan.steps[0]?.params).toEqual({
+      name: "run_ade_action",
+      arguments: {
+        domain: "linear_ingress",
+        action: "startLocalWebhook",
+        args: {},
+      },
+    });
+  });
+
+  it("linear ingress start ensures the provider webhook and relay loop", () => {
+    const plan = buildCliPlan(["linear", "ingress", "start"]);
+    expect(plan.kind).toBe("execute");
+    if (plan.kind !== "execute") return;
+    expect(plan.steps[0]?.params).toEqual({
+      name: "run_ade_action",
+      arguments: {
+        domain: "linear_ingress",
+        action: "ensureRelayWebhook",
+        args: {},
+      },
+    });
+  });
+
   it("automations toggle errors when --enabled is omitted", () => {
     expect(() => buildCliPlan(["automations", "toggle", "rule-42"])).toThrow(
       /--enabled <true\|false>/,
@@ -3624,7 +3797,7 @@ describe("ADE CLI", () => {
 
   it("automations rejects unknown subcommands with a usage error", () => {
     expect(() => buildCliPlan(["automations", "nope"])).toThrow(
-      /list, show, create, update, delete, toggle, run, runs/,
+      /list, show, create, update, delete, toggle, run, ingress, runs/,
     );
   });
 

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -18,6 +18,12 @@ import {
   runDeeplinkCommand,
 } from "./commands/deeplinks";
 import { buildDeeplink } from "../../desktop/src/shared/deeplinks";
+import {
+  AUTOMATIONS_COMING_SOON_MESSAGE,
+  MACOS_VM_COMING_SOON_MESSAGE,
+  readAutomationsEnvOverride,
+  readMacosVmEnvOverride,
+} from "../../desktop/src/shared/automationAvailability";
 import { parseLinearGraphQLInput } from "../../desktop/src/main/services/cto/linearGraphQLInput";
 import { resolveMachineAdeLayout } from "./services/projects/machineLayout";
 import {
@@ -130,7 +136,8 @@ type FormatterId =
   | "history-show"
   | "actions-list"
   | "action-result"
-  | "automation-run-detail";
+  | "automation-run-detail"
+  | "automation-ingress";
 
 type CliPlan =
   | { kind: "help"; text: string }
@@ -236,6 +243,48 @@ function resolveCliPackageRoot(entryPath: string): string {
 
 function isSourceCliEntryPath(modulePath: string): boolean {
   return /[/\\]src[/\\]cli\.ts$/i.test(modulePath);
+}
+
+function isSourceCheckoutCliEntryPath(modulePath: string): boolean {
+  return (
+    isSourceCliEntryPath(modulePath) ||
+    /[/\\]apps[/\\]ade-cli[/\\]dist[/\\]cli\.cjs$/i.test(modulePath)
+  );
+}
+
+function automationsCliEnabled(): boolean {
+  const override = readAutomationsEnvOverride(process.env);
+  if (override !== null) return override;
+  return isSourceCheckoutCliEntryPath(CLI_ENTRY_PATH);
+}
+
+function macosVmCliEnabled(): boolean {
+  const override = readMacosVmEnvOverride(process.env);
+  if (override !== null) return override;
+  return isSourceCheckoutCliEntryPath(CLI_ENTRY_PATH);
+}
+
+function internalFeatureUnavailableHelp(title: string, message: string, enableEnv: string): string {
+  return `${ADE_BANNER}
+  ${title}
+
+  ${message}
+  Internal testing can opt in with ${enableEnv}=1.
+`;
+}
+
+function assertAutomationsCliEnabled(): void {
+  if (automationsCliEnabled()) return;
+  throw new CliUsageError(
+    `${AUTOMATIONS_COMING_SOON_MESSAGE} Internal testing can opt in with ADE_ENABLE_AUTOMATIONS=1.`,
+  );
+}
+
+function assertMacosVmCliEnabled(): void {
+  if (macosVmCliEnabled()) return;
+  throw new CliUsageError(
+    `${MACOS_VM_COMING_SOON_MESSAGE} Internal testing can opt in with ADE_ENABLE_MACOS_VM=1.`,
+  );
 }
 
 function isSourceRuntimeInteropError(value: unknown): boolean {
@@ -407,7 +456,7 @@ const TOP_LEVEL_HELP = `${ADE_BANNER}
     $ ade macos-vm status | start | restart | wipe | install-runtime | set-credentials | get-credentials | storage | display-session | detach
                                                     Run ADE's singleton Apple silicon macOS VM
     $ ade browser open | tabs | screenshot         Use ADE's built-in browser pane
-    $ ade usage snapshot | refresh | budget         Read provider quota usage and edit automation guardrails
+    $ ade usage snapshot | refresh | budget         Read provider quota usage and budget guardrails
     $ ade settings pr-transcript-gists enable      Attach ADE chat transcript links to new PRs
     $ ade settings action <method>                  Call project config actions
     $ ade update status | check | install | dismiss Read auto-update state and drive install
@@ -458,6 +507,50 @@ const TOP_LEVEL_HELP = `${ADE_BANNER}
 
   Start with: ade doctor --text
 `;
+
+function topLevelHelpText(): string {
+  let text = TOP_LEVEL_HELP;
+  if (!automationsCliEnabled()) {
+    text = text.replace(
+      /    \$ ade automations list \| create \| run \| runs    Manage automation rules\n/,
+      "",
+    );
+  }
+  if (!macosVmCliEnabled()) {
+    text = text
+      .replace(
+        /    \$ ade macos-vm status \| start \| restart \| wipe \| install-runtime \| set-credentials \| get-credentials \| storage \| display-session \| detach\n\s+Run ADE's singleton Apple silicon macOS VM\n/,
+        "",
+      )
+      .replace(/    \$ ade macos-vm start --lane <lane> --create --text\n/, "")
+      .replace(/    \$ ade macos-vm guide --lane <lane> --text\n/, "");
+  }
+  return text;
+}
+
+function commandHelpText(key: string): string | undefined {
+  if (key === "automations" && !automationsCliEnabled()) {
+    return internalFeatureUnavailableHelp(
+      "Automations",
+      AUTOMATIONS_COMING_SOON_MESSAGE,
+      "ADE_ENABLE_AUTOMATIONS",
+    );
+  }
+  if (key === "macos-vm" && !macosVmCliEnabled()) {
+    return internalFeatureUnavailableHelp(
+      "macOS VM",
+      MACOS_VM_COMING_SOON_MESSAGE,
+      "ADE_ENABLE_MACOS_VM",
+    );
+  }
+  if (key === "linear" && !automationsCliEnabled()) {
+    return HELP_BY_COMMAND.linear
+      .replace(/    \$ ade linear ingress status --text\s+Show Linear ingress status\n/, "")
+      .replace(/    \$ ade linear ingress start --text\s+Ensure Linear webhook and start relay ingress\n/, "")
+      .replace(/    \$ ade linear ingress start-local --text\s+Start only the local Linear webhook listener\n/, "");
+  }
+  return HELP_BY_COMMAND[key];
+}
 
 const IOS_SIMULATOR_SUBCOMMAND_HELP: Record<string, string> = {
   status: `${ADE_BANNER}
@@ -1452,8 +1545,8 @@ const HELP_BY_COMMAND: Record<string, string> = {
 
     $ ade usage snapshot --text                     Cached snapshot (windows, pacing, costs, errors)
     $ ade usage refresh --text                      Force a fresh poll (invalidates cost cache)
-    $ ade usage budget get --text                   Read automation guardrail config
-    $ ade usage budget set --from-file budget.json  Save automation guardrail config
+    $ ade usage budget get --text                   Read budget guardrail config
+    $ ade usage budget set --from-file budget.json  Save budget guardrail config
     $ ade usage budget check --provider claude --scope global
     $ ade usage budget cumulative --scope global    Cumulative spend for the current week
 
@@ -1506,6 +1599,9 @@ const HELP_BY_COMMAND: Record<string, string> = {
     $ ade linear sync run                           Trigger a sync run
     $ ade linear sync queue --text                  List sync queue items
     $ ade linear sync resolve --queue-item <id> --action approve
+    $ ade linear ingress status --text              Show Linear ingress status
+    $ ade linear ingress start --text               Ensure Linear webhook and start relay ingress
+    $ ade linear ingress start-local --text         Start only the local Linear webhook listener
     $ ade linear route worker --input-json '{"issueId":"LIN-123","workerId":"worker-1"}'
     $ ade linear install                            Register ADE as the "Open in coding tool" target
     $ ade linear install --dry-run                  Preview the ~/.linear/coding-tools.json write
@@ -1560,6 +1656,12 @@ const HELP_BY_COMMAND: Record<string, string> = {
     $ ade automations run <id> [--lane <id>] [--dry-run]
     $ ade automations trigger <id> [--lane <id>]
                                                      Trigger a rule manually
+    $ ade automations ingress status [--text]        Show webhook gateway status
+    $ ade automations ingress start [--text]         Start the local webhook listener
+    $ ade automations ingress refresh [--text]       Re-detect Tailscale/gateway status
+    $ ade --role cto automations ingress set-url <https-url>
+                                                     Save the public gateway URL
+    $ ade --role cto automations ingress clear-url   Clear the public gateway URL
     $ ade automations runs [--rule <id>] [--status <s>] [--limit 50]
     $ ade automations run-show <runId> [--json]     Inspect a run
     $ ade automations example                       Print an example rule (stdout)
@@ -9171,6 +9273,69 @@ function buildAutomationsPlan(args: string[]): CliPlan {
     return { kind: "help", text: automationsExampleText() };
   }
 
+  if (sub === "ingress" || sub === "webhook" || sub === "webhook-gateway") {
+    const mode = firstPositional(args) ?? "status";
+    if (mode === "status" || mode === "show") {
+      return {
+        kind: "execute",
+        label: "automations ingress status",
+        formatter: "automation-ingress",
+        steps: [actionStep("result", "automations", "getIngressStatus")],
+      };
+    }
+    if (mode === "start" || mode === "listen") {
+      return {
+        kind: "execute",
+        label: "automations ingress start",
+        formatter: "automation-ingress",
+        steps: [actionStep("result", "automations", "startIngress")],
+      };
+    }
+    if (mode === "refresh" || mode === "detect") {
+      return {
+        kind: "execute",
+        label: "automations ingress refresh",
+        formatter: "automation-ingress",
+        steps: [actionStep("result", "automations", "refreshWebhookGatewayStatus")],
+      };
+    }
+    if (mode === "set-url" || mode === "set" || mode === "configure") {
+      const publicUrl = requireValue(
+        readValue(args, ["--url", "--public-url", "--webhook-url"]) ?? firstPositional(args),
+        "public webhook gateway URL",
+      );
+      return {
+        kind: "execute",
+        label: "automations ingress set-url",
+        formatter: "automation-ingress",
+        steps: [actionStep("result", "automations", "setWebhookGatewayPublicUrl", { publicUrl })],
+      };
+    }
+    if (mode === "clear-url" || mode === "clear" || mode === "disable") {
+      return {
+        kind: "execute",
+        label: "automations ingress clear-url",
+        formatter: "automation-ingress",
+        steps: [actionStep("result", "automations", "setWebhookGatewayPublicUrl", { publicUrl: null })],
+      };
+    }
+    if (mode === "events") {
+      const limit = readIntOption(args, ["--limit"]);
+      return {
+        kind: "execute",
+        label: "automations ingress events",
+        steps: [
+          actionStep("result", "automations", "listIngressEvents", {
+            ...(typeof limit === "number" ? { limit } : {}),
+          }),
+        ],
+      };
+    }
+    throw new CliUsageError(
+      "automations ingress supports status, start, refresh, set-url, clear-url, or events.",
+    );
+  }
+
   if (sub === "create") {
     const allowLegacy = readFlag(args, ["--allow-legacy"]);
     const raw = parseDraftInput(args);
@@ -9301,7 +9466,7 @@ function buildAutomationsPlan(args: string[]): CliPlan {
   }
 
   throw new CliUsageError(
-    "automations supports list, show, create, update, delete, toggle, run, runs, run-show, or example.",
+    "automations supports list, show, create, update, delete, toggle, run, ingress, runs, run-show, or example.",
   );
 }
 
@@ -9627,16 +9792,31 @@ function buildLinearPlan(args: string[]): CliPlan {
     };
   }
   if (sub === "ingress") {
+    assertAutomationsCliEnabled();
     const mode = firstPositional(args) ?? "status";
     const toolByMode: Record<string, string> = {
       status: "getLinearIngressStatus",
       events: "listLinearIngressEvents",
       webhook: "ensureLinearWebhook",
     };
+    if (mode === "start" || mode === "listen" || mode === "ensure") {
+      return {
+        kind: "execute",
+        label: "Linear ingress start",
+        steps: [actionStep("result", "linear_ingress", "ensureRelayWebhook")],
+      };
+    }
+    if (mode === "start-local" || mode === "local-webhook") {
+      return {
+        kind: "execute",
+        label: "Linear ingress local webhook",
+        steps: [actionStep("result", "linear_ingress", "startLocalWebhook")],
+      };
+    }
     const tool = toolByMode[mode];
     if (!tool)
       throw new CliUsageError(
-        "linear ingress supports status, events, or webhook.",
+        "linear ingress supports status, events, webhook, start, or start-local.",
       );
     return {
       kind: "execute",
@@ -10027,10 +10207,10 @@ function buildCliPlan(command: string[]): CliPlan {
   }
   const primary = firstPositional(args);
   if (!primary) {
-    return { kind: "help", text: TOP_LEVEL_HELP };
+    return { kind: "help", text: topLevelHelpText() };
   }
   if (primary === "-h" || primary === "--help") {
-    return { kind: "help", text: TOP_LEVEL_HELP };
+    return { kind: "help", text: topLevelHelpText() };
   }
   const aliases: Record<string, string> = {
     lane: "lanes",
@@ -10086,7 +10266,7 @@ function buildCliPlan(command: string[]): CliPlan {
     }
     return {
       kind: "help",
-      text: HELP_BY_COMMAND[primaryHelpKey] ?? TOP_LEVEL_HELP,
+      text: commandHelpText(primaryHelpKey) ?? topLevelHelpText(),
     };
   }
   if (primary === "help") {
@@ -10103,7 +10283,7 @@ function buildCliPlan(command: string[]): CliPlan {
     }
     return {
       kind: "help",
-      text: key && HELP_BY_COMMAND[key] ? HELP_BY_COMMAND[key] : TOP_LEVEL_HELP,
+      text: key ? commandHelpText(key) ?? topLevelHelpText() : topLevelHelpText(),
     };
   }
   if (primary === "version" || primary === "--version" || primary === "-v") {
@@ -10211,8 +10391,10 @@ function buildCliPlan(command: string[]): CliPlan {
   if (primary === "agent" || primary === "agents") return buildAgentPlan(args);
   if (primary === "cto") return buildCtoPlan(args);
   if (primary === "linear") return buildLinearPlan(args);
-  if (primary === "automations" || primary === "automation")
+  if (primary === "automations" || primary === "automation") {
+    assertAutomationsCliEnabled();
     return buildAutomationsPlan(args);
+  }
   if (primary === "flow") return buildFlowPlan(args);
   if (primary === "coordinator" || primary === "coord")
     return buildCoordinatorPlan(args);
@@ -10255,8 +10437,10 @@ function buildCliPlan(command: string[]): CliPlan {
     primary === "macos" ||
     primary === "mac-vm" ||
     primary === "macvm"
-  )
+  ) {
+    assertMacosVmCliEnabled();
     return buildMacosVmPlan(args);
+  }
   if (
     primary === "browser" ||
     primary === "ade-browser" ||
@@ -10286,7 +10470,7 @@ function buildCursorPlan(args: string[]): CliPlan {
   // ade cursor <surface> <group> <sub> ... — only "cloud" is wired today.
   const surface = firstPositional(args);
   if (!surface || surface === "help" || hasHelpFlag([surface])) {
-    return { kind: "help", text: HELP_BY_COMMAND.cursor ?? TOP_LEVEL_HELP };
+    return { kind: "help", text: HELP_BY_COMMAND.cursor ?? topLevelHelpText() };
   }
   if (surface !== "cloud") {
     throw new CliUsageError(
@@ -10298,7 +10482,7 @@ function buildCursorPlan(args: string[]): CliPlan {
     if (group && CURSOR_CLOUD_HELP[group]) {
       return { kind: "help", text: `${ADE_BANNER}${CURSOR_CLOUD_HELP[group]}` };
     }
-    return { kind: "help", text: HELP_BY_COMMAND.cursor ?? TOP_LEVEL_HELP };
+    return { kind: "help", text: HELP_BY_COMMAND.cursor ?? topLevelHelpText() };
   }
   return { kind: "cursor-cloud", rest: args };
 }
@@ -13131,6 +13315,45 @@ function formatAutomationRunDetail(value: unknown): string {
   return [header, "", "Actions", table].join("\n");
 }
 
+function formatAutomationIngress(value: unknown): string {
+  const result = unwrapActionEnvelope(value);
+  if (!isRecord(result)) return JSON.stringify(result, null, 2);
+  const gateway = isRecord(result.webhookGateway) ? result.webhookGateway : result;
+  const tailscale = isRecord(gateway.tailscale) ? gateway.tailscale : {};
+  const localWebhook = isRecord(result.localWebhook) ? result.localWebhook : null;
+  const githubRelay = isRecord(result.githubRelay) ? result.githubRelay : null;
+  const gatewayLines = renderKeyValues("ADE automation ingress", [
+    ["gateway", gateway.ready === true ? "online" : asString(gateway.status) ?? "not ready"],
+    ["publicUrl", gateway.publicUrl],
+    ["localUrl", gateway.localUrl],
+    ["provider", gateway.provider],
+    ["tailscale", tailscale.available === true ? "available" : "not available"],
+    ["tailscaleHost", tailscale.hostname],
+    ["lastCheckedAt", gateway.lastCheckedAt],
+    ["error", gateway.lastError],
+  ]);
+  const localLines = localWebhook
+    ? renderKeyValues("Local webhook", [
+        ["status", localWebhook.status],
+        ["url", localWebhook.url],
+        ["githubUrl", localWebhook.githubUrl],
+        ["port", localWebhook.port],
+        ["lastDeliveryAt", localWebhook.lastDeliveryAt],
+        ["error", localWebhook.lastError],
+      ])
+    : "";
+  const relayLines = githubRelay
+    ? renderKeyValues("Legacy GitHub relay", [
+        ["status", githubRelay.status],
+        ["configured", githubRelay.configured],
+        ["healthy", githubRelay.healthy],
+        ["lastDeliveryAt", githubRelay.lastDeliveryAt],
+        ["error", githubRelay.lastError],
+      ])
+    : "";
+  return [gatewayLines, localLines, relayLines].filter(Boolean).join("\n\n");
+}
+
 function renderKeyValues(
   title: string,
   entries: Array<[string, unknown]>,
@@ -14569,6 +14792,8 @@ function formatTextOutput(
       return formatActionsList(value);
     case "automation-run-detail":
       return formatAutomationRunDetail(value);
+    case "automation-ingress":
+      return formatAutomationIngress(value);
     case "action-result":
     default:
       if (isRecord(value))

--- a/apps/ade-cli/src/headlessLinearServices.ts
+++ b/apps/ade-cli/src/headlessLinearServices.ts
@@ -28,6 +28,8 @@ import type { createLinearIngressService } from "../../desktop/src/main/services
 import type { createWorkerTaskSessionService } from "../../desktop/src/main/services/cto/workerTaskSessionService";
 import type { createWorkerHeartbeatService } from "../../desktop/src/main/services/cto/workerHeartbeatService";
 import type { createAutomationSecretService } from "../../desktop/src/main/services/automations/automationSecretService";
+import type { createAutomationService } from "../../desktop/src/main/services/automations/automationService";
+import { buildLinearAutomationDispatches } from "../../desktop/src/main/services/automations/linearAutomationDispatch";
 import type { ComputerUseArtifactBrokerService } from "../../desktop/src/main/services/computerUse/computerUseArtifactBrokerService";
 import type { LinearWorkflowEventPayload } from "../../desktop/src/shared/types/linearSync";
 import {
@@ -41,6 +43,7 @@ import {
 } from "../../desktop/src/shared/githubScopes";
 import type {
   GitHubStatus,
+  LinearIngressEventRecord,
   WorkerAgentRun,
   WorkerAgentWakeupReason,
 } from "../../desktop/src/shared/types";
@@ -133,6 +136,7 @@ type HeadlessLinearDeps = {
   openExternal?: (url: string) => Promise<void>;
   onGitHubStatusChanged?: (status: HeadlessGitHubStatus) => void;
   onLinearWorkflowEvent?: (event: LinearWorkflowEventPayload) => void;
+  getAutomationService?: () => ReturnType<typeof createAutomationService> | null;
 };
 
 type HeadlessLinearServices = {
@@ -1885,11 +1889,23 @@ export function createHeadlessLinearServices(
     autoStart: false,
     hasCredentials: () => linearCredentialService.getStatus().tokenStored,
   });
-  const handleIngressEvent = async (event: { issueId?: string | null }) => {
+  const handleIngressEvent = async (event: LinearIngressEventRecord) => {
     const issueId =
       typeof event.issueId === "string" ? event.issueId.trim() : "";
     if (!issueId) return;
     await syncService.processIssueUpdate(issueId);
+    const automationService = args.getAutomationService?.() ?? null;
+    if (!automationService) return;
+    try {
+      for (const dispatched of buildLinearAutomationDispatches(event)) {
+        await automationService.dispatchIngressTrigger(dispatched);
+      }
+    } catch (error) {
+      args.logger.warn("linear.headless_automation_dispatch_failed", {
+        issueId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   };
   const ingressService = createLinearIngressServiceImpl({
     db: args.db,
@@ -1899,6 +1915,7 @@ export function createHeadlessLinearServices(
     secretService: automationSecretService as ReturnType<
       typeof createAutomationSecretService
     >,
+    projectConfigService: args.projectConfigService,
     onEvent: handleIngressEvent,
   });
 

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -7,6 +7,10 @@ import type * as NodePty from "node-pty";
 type NodePtyType = typeof NodePty;
 import { isAdeRuntimeNamedPipePath } from "../shared/adeRuntimeIpc";
 import {
+  areAutomationsEnabledForPackagedState,
+  isMacosVmEnabledForPackagedState,
+} from "../shared/automationAvailability";
+import {
   handleDeeplinkUrl,
   registerAdeProtocolHandler,
 } from "./services/deeplinks/protocolHandler";
@@ -1905,6 +1909,8 @@ app.whenReady().then(async () => {
     });
 
     const operationService = createOperationService({ db, projectId });
+    const automationsEnabled = areAutomationsEnabledForPackagedState(app.isPackaged);
+    const macosVmEnabled = isMacosVmEnabledForPackagedState(app.isPackaged);
 
     let jobEngine: ReturnType<typeof createJobEngine> | null = null;
     let automationService: ReturnType<typeof createAutomationService> | null =
@@ -3074,19 +3080,21 @@ app.whenReady().then(async () => {
     testServiceRef = testService;
     gitServiceRef = gitService;
 
-    automationService = createAutomationService({
-      db,
-      logger,
-      projectId,
-      projectRoot,
-      laneService,
-      projectConfigService,
-      conflictService,
-      testService,
-      agentChatService,
-      onEvent: (event) =>
-        emitProjectEvent(projectRoot, IPC.automationsEvent, event),
-    });
+    if (automationsEnabled) {
+      automationService = createAutomationService({
+        db,
+        logger,
+        projectId,
+        projectRoot,
+        laneService,
+        projectConfigService,
+        conflictService,
+        testService,
+        agentChatService,
+        onEvent: (event) =>
+          emitProjectEvent(projectRoot, IPC.automationsEvent, event),
+      });
+    }
     const reviewService = createReviewService({
       db,
       logger,
@@ -3103,18 +3111,22 @@ app.whenReady().then(async () => {
       prService,
       onEvent: (event) => emitProjectEvent(projectRoot, IPC.reviewEvent, event),
     });
-    const automationIngressService = createAutomationIngressService({
-      logger,
-      automationService,
-      secretService: automationSecretService,
-      listRules: () => projectConfigService.get().effective.automations ?? [],
-    });
+    const automationIngressService = automationService
+      ? createAutomationIngressService({
+          logger,
+          automationService,
+          secretService: automationSecretService,
+          listRules: () => projectConfigService.get().effective.automations ?? [],
+        })
+      : null;
 
-    const githubPollingService = createGithubPollingService({
-      logger,
-      githubService,
-      automationService,
-    });
+    const githubPollingService = automationService
+      ? createGithubPollingService({
+          logger,
+          githubService,
+          automationService,
+        })
+      : null;
 
     const deferredProjectStartCancels = new Set<() => void>();
     const scheduleDeferredProjectStart = (
@@ -3358,99 +3370,103 @@ app.whenReady().then(async () => {
       onEvent: (payload) =>
         emitProjectEvent(projectRoot, IPC.appControlEvent, payload),
     });
-    const macosVmService = createMacosVmService({
-      projectRoot,
-      logger,
-      resolveLanes: async () => laneService.list({ includeArchived: false }),
-      onEvent: (payload) => {
-        syncMacosVmLaunchCacheFromEvent(payload, (event, fields) => {
-          logger.warn(event, fields);
-        }, {
+    const macosVmService = macosVmEnabled
+      ? createMacosVmService({
           projectRoot,
-          provider: macosVmLaunchProviderForProject,
-        });
-        emitProjectEvent(projectRoot, IPC.macosVmEvent, payload);
-      },
-      captureWindowSources: async () => {
-        const sources = await desktopCapturer.getSources({
-          types: ["window"],
-          thumbnailSize: { width: 1280, height: 1280 },
-        });
-        return sources.map((source) => ({
-          id: source.id,
-          name: source.name,
-          thumbnailDataUrl: source.thumbnail.isEmpty() ? null : source.thumbnail.toDataURL(),
-        }));
-      },
-      // TODO: once the in-guest ade-runtime install lands, route this to
-      // RemoteConnectionPool.registerMacosVmTarget so chat exec can RPC into
-      // the VM. The pool currently lives inside registerRuntimeBridge; this
-      // wire-up needs the pool/registry to be lifted into a shared scope.
-      onRuntimeReady: ({ vmName, ipAddress, username }) => {
-        logger.info("macos_vm.runtime_ready", { vmName, ipAddress, username });
-        const vmLane = laneService.findExistingVmLane();
-        if (!vmLane) return;
-        invalidateVmLaneLaunchCache(vmLane.id, projectRoot);
-        void refreshVmLaneLaunchCache({
-          laneId: vmLane.id,
-          projectRoot,
-          provider: macosVmLaunchProviderForProject,
-        }).catch((error) => {
-          logger.warn("macos_vm.runtime_ready_cache_refresh_failed", {
-            laneId: vmLane.id,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        });
-      },
-    });
+          logger,
+          resolveLanes: async () => laneService.list({ includeArchived: false }),
+          onEvent: (payload) => {
+            syncMacosVmLaunchCacheFromEvent(payload, (event, fields) => {
+              logger.warn(event, fields);
+            }, {
+              projectRoot,
+              provider: macosVmLaunchProviderForProject,
+            });
+            emitProjectEvent(projectRoot, IPC.macosVmEvent, payload);
+          },
+          captureWindowSources: async () => {
+            const sources = await desktopCapturer.getSources({
+              types: ["window"],
+              thumbnailSize: { width: 1280, height: 1280 },
+            });
+            return sources.map((source) => ({
+              id: source.id,
+              name: source.name,
+              thumbnailDataUrl: source.thumbnail.isEmpty() ? null : source.thumbnail.toDataURL(),
+            }));
+          },
+          // TODO: once the in-guest ade-runtime install lands, route this to
+          // RemoteConnectionPool.registerMacosVmTarget so chat exec can RPC into
+          // the VM. The pool currently lives inside registerRuntimeBridge; this
+          // wire-up needs the pool/registry to be lifted into a shared scope.
+          onRuntimeReady: ({ vmName, ipAddress, username }) => {
+            logger.info("macos_vm.runtime_ready", { vmName, ipAddress, username });
+            const vmLane = laneService.findExistingVmLane();
+            if (!vmLane) return;
+            invalidateVmLaneLaunchCache(vmLane.id, projectRoot);
+            void refreshVmLaneLaunchCache({
+              laneId: vmLane.id,
+              projectRoot,
+              provider: macosVmLaunchProviderForProject,
+            }).catch((error) => {
+              logger.warn("macos_vm.runtime_ready_cache_refresh_failed", {
+                laneId: vmLane.id,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            });
+          },
+        })
+      : null;
     // Wire macosVmService into laneService now that both exist. The hooks let
     // detachVmLane / attachLaneToVm trigger share-stale + mirror-sync teardown
     // without laneService importing the macosVm barrel.
-    const macosVmSvcAny = macosVmService as unknown as {
-      markShareStale?: (args: { laneId: string }) => Promise<void> | void;
-      stopMirrorSyncForLane?: (args: { laneId: string }) => Promise<void> | void;
-      startMirrorSyncForLane?: (args: { laneId: string }) => Promise<void> | void;
-      linkLaneToCurrentVm?: (args: { laneId: string }) => Promise<void> | void;
-      getStatus?: typeof macosVmService.getStatus;
-      getCredentials?: (args: { vmName: string }) => Promise<{
-        vmName: string;
-        username: string | null;
-        hasPassword: boolean;
-      }>;
-    };
-    if (typeof laneService.setMacosVmHooks === "function" && typeof macosVmSvcAny.getStatus === "function") {
-      laneService.setMacosVmHooks({
-        getStatus: macosVmSvcAny.getStatus.bind(macosVmService),
-        markShareStale: async ({ laneId }) => {
-          if (typeof macosVmSvcAny.markShareStale === "function") {
-            await macosVmSvcAny.markShareStale({ laneId });
-          }
-        },
-        stopMirrorSyncForLane: async ({ laneId }) => {
-          if (typeof macosVmSvcAny.stopMirrorSyncForLane === "function") {
-            await macosVmSvcAny.stopMirrorSyncForLane({ laneId });
-          }
-        },
-        startMirrorSyncForLane: async ({ laneId }) => {
-          if (typeof macosVmSvcAny.startMirrorSyncForLane === "function") {
-            await macosVmSvcAny.startMirrorSyncForLane({ laneId });
-          }
-        },
-        linkLaneToCurrentVm: async ({ laneId }) => {
-          if (typeof macosVmSvcAny.linkLaneToCurrentVm === "function") {
-            await macosVmSvcAny.linkLaneToCurrentVm({ laneId });
-          }
-        },
-      });
-    }
-    // Register the launch-context provider so resolveLaneLaunchContext can
-    // synthesize an SSH launch context for VM lanes.
-    if (typeof macosVmSvcAny.getStatus === "function" && typeof macosVmSvcAny.getCredentials === "function") {
-      macosVmLaunchProviderForProject = {
-        getStatus: macosVmSvcAny.getStatus.bind(macosVmService),
-        getCredentials: macosVmSvcAny.getCredentials.bind(macosVmService),
+    if (macosVmService) {
+      const macosVmSvcAny = macosVmService as unknown as {
+        markShareStale?: (args: { laneId: string }) => Promise<void> | void;
+        stopMirrorSyncForLane?: (args: { laneId: string }) => Promise<void> | void;
+        startMirrorSyncForLane?: (args: { laneId: string }) => Promise<void> | void;
+        linkLaneToCurrentVm?: (args: { laneId: string }) => Promise<void> | void;
+        getStatus?: ReturnType<typeof createMacosVmService>["getStatus"];
+        getCredentials?: (args: { vmName: string }) => Promise<{
+          vmName: string;
+          username: string | null;
+          hasPassword: boolean;
+        }>;
       };
-      setMacosVmLaunchProvider(macosVmLaunchProviderForProject);
+      if (typeof laneService.setMacosVmHooks === "function" && typeof macosVmSvcAny.getStatus === "function") {
+        laneService.setMacosVmHooks({
+          getStatus: macosVmSvcAny.getStatus.bind(macosVmService),
+          markShareStale: async ({ laneId }) => {
+            if (typeof macosVmSvcAny.markShareStale === "function") {
+              await macosVmSvcAny.markShareStale({ laneId });
+            }
+          },
+          stopMirrorSyncForLane: async ({ laneId }) => {
+            if (typeof macosVmSvcAny.stopMirrorSyncForLane === "function") {
+              await macosVmSvcAny.stopMirrorSyncForLane({ laneId });
+            }
+          },
+          startMirrorSyncForLane: async ({ laneId }) => {
+            if (typeof macosVmSvcAny.startMirrorSyncForLane === "function") {
+              await macosVmSvcAny.startMirrorSyncForLane({ laneId });
+            }
+          },
+          linkLaneToCurrentVm: async ({ laneId }) => {
+            if (typeof macosVmSvcAny.linkLaneToCurrentVm === "function") {
+              await macosVmSvcAny.linkLaneToCurrentVm({ laneId });
+            }
+          },
+        });
+      }
+      // Register the launch-context provider so resolveLaneLaunchContext can
+      // synthesize an SSH launch context for VM lanes.
+      if (typeof macosVmSvcAny.getStatus === "function" && typeof macosVmSvcAny.getCredentials === "function") {
+        macosVmLaunchProviderForProject = {
+          getStatus: macosVmSvcAny.getStatus.bind(macosVmService),
+          getCredentials: macosVmSvcAny.getCredentials.bind(macosVmService),
+        };
+        setMacosVmLaunchProvider(macosVmLaunchProviderForProject);
+      }
     }
     // Phone sync is owned by the per-machine ADE service. The desktop
     // keeps a non-host sync service for legacy viewer state and explicit
@@ -3641,74 +3657,81 @@ app.whenReady().then(async () => {
       projectRoot,
       stage: "linear_ingress_init",
     });
-    const linearIngressService = createLinearIngressService({
-      db,
-      logger,
-      projectId,
-      linearClient,
-      secretService: automationSecretService,
-      onEvent: async (event) => {
-        emitProjectEvent(projectRoot, IPC.ctoLinearWorkflowEvent, {
-          type: "linear-workflow-ingress",
+    const linearIngressService = automationsEnabled && automationService
+      ? createLinearIngressService({
+          db,
+          logger,
           projectId,
-          source: event.source,
-          issueId: event.issueId,
-          issueIdentifier: event.issueIdentifier,
-          summary: event.summary,
-          createdAt: event.createdAt,
-        });
-        if (event.issueId) {
-          const isCreatedIssueEvent =
-            event.entityType?.trim().toLowerCase() === "issue"
-            && /^(create|created)$/i.test(event.action?.trim() ?? "");
-          await linearSyncService.processIssueUpdate(event.issueId, {
-            adeIssueLinkCause: isCreatedIssueEvent ? "linear_issue_created" : "linear_issue_ingress",
-          });
-          try {
-            for (const dispatched of buildLinearAutomationDispatches(event)) {
-              await automationService.dispatchIngressTrigger(dispatched);
-            }
-          } catch (error) {
-            logger.warn("linear.automation_dispatch_failed", {
+          linearClient,
+          secretService: automationSecretService,
+          projectConfigService,
+          onEvent: async (event) => {
+            emitProjectEvent(projectRoot, IPC.ctoLinearWorkflowEvent, {
+              type: "linear-workflow-ingress",
+              projectId,
+              source: event.source,
               issueId: event.issueId,
-              eventId: event.eventId,
-              error: error instanceof Error ? error.message : String(error),
+              issueIdentifier: event.issueIdentifier,
+              summary: event.summary,
+              createdAt: event.createdAt,
             });
-          }
-        }
-      },
-    });
+            if (event.issueId) {
+              const isCreatedIssueEvent =
+                event.entityType?.trim().toLowerCase() === "issue"
+                && /^(create|created)$/i.test(event.action?.trim() ?? "");
+              await linearSyncService.processIssueUpdate(event.issueId, {
+                adeIssueLinkCause: isCreatedIssueEvent ? "linear_issue_created" : "linear_issue_ingress",
+              });
+              try {
+                for (const dispatched of buildLinearAutomationDispatches(event)) {
+                  await automationService.dispatchIngressTrigger(dispatched);
+                }
+              } catch (error) {
+                logger.warn("linear.automation_dispatch_failed", {
+                  issueId: event.issueId,
+                  eventId: event.eventId,
+                  error: error instanceof Error ? error.message : String(error),
+                });
+              }
+            }
+          },
+        })
+      : null;
     linearIngressServiceRef = linearIngressService;
-    scheduleBackgroundProjectTask(
-      "linear.ingress_start",
-      () => {
-        if (!linearIngressService.canAutoStart()) {
-          logger.info("project.startup_task_skipped", {
-            projectRoot,
-            task: "linear.ingress_start",
-            reason: "not_configured",
-            enableFlag: "ADE_ENABLE_LINEAR_INGRESS",
+    if (linearIngressService) {
+      scheduleBackgroundProjectTask(
+        "linear.ingress_start",
+        () => {
+          if (!linearIngressService.canAutoStart()) {
+            logger.info("project.startup_task_skipped", {
+              projectRoot,
+              task: "linear.ingress_start",
+              reason: "not_configured",
+              enableFlag: "ADE_ENABLE_LINEAR_INGRESS",
+            });
+            return;
+          }
+          return linearIngressService.start();
+        },
+        (error) => {
+          logger.warn("linear.ingress_start_failed", {
+            error: error instanceof Error ? error.message : String(error),
           });
-          return;
-        }
-        return linearIngressService.start();
-      },
-      (error) => {
-        logger.warn("linear.ingress_start_failed", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      },
-      0,
-      "ADE_ENABLE_LINEAR_INGRESS",
-    );
+        },
+        0,
+        "ADE_ENABLE_LINEAR_INGRESS",
+      );
+    }
 
-    const automationPlannerService = createAutomationPlannerService({
-      logger,
-      projectRoot,
-      projectConfigService,
-      laneService,
-      automationService,
-    });
+    const automationPlannerService = automationService
+      ? createAutomationPlannerService({
+          logger,
+          projectRoot,
+          projectConfigService,
+          laneService,
+          automationService,
+        })
+      : null;
 
     const usageTrackingService = createUsageTrackingService({
       logger,
@@ -3736,29 +3759,33 @@ app.whenReady().then(async () => {
       projectConfigService,
       usageTrackingService,
     });
-    scheduleBackgroundProjectTask(
-      "automations.ingress_start",
-      () => automationIngressService.start(),
-      (error) => {
-        logger.warn("automations.ingress_start_failed", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      },
-      0,
-      "ADE_ENABLE_AUTOMATION_INGRESS",
-    );
+    if (automationIngressService) {
+      scheduleBackgroundProjectTask(
+        "automations.ingress_start",
+        () => automationIngressService.start(),
+        (error) => {
+          logger.warn("automations.ingress_start_failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        },
+        0,
+        "ADE_ENABLE_AUTOMATION_INGRESS",
+      );
+    }
 
-    scheduleBackgroundProjectTask(
-      "automations.github_polling_start",
-      () => githubPollingService.start(),
-      (error) => {
-        logger.warn("automations.github_polling_start_failed", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      },
-      0,
-      "ADE_ENABLE_AUTOMATION_INGRESS",
-    );
+    if (githubPollingService) {
+      scheduleBackgroundProjectTask(
+        "automations.github_polling_start",
+        () => githubPollingService.start(),
+        (error) => {
+          logger.warn("automations.github_polling_start_failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        },
+        0,
+        "ADE_ENABLE_AUTOMATION_INGRESS",
+      );
+    }
 
     const configReloadService = createConfigReloadService({
       paths: {
@@ -4205,6 +4232,7 @@ app.whenReady().then(async () => {
         usageTrackingService,
         budgetCapService,
         autoUpdateService,
+        isPackaged: app.isPackaged,
       } as unknown as AdeRuntime;
     }
 
@@ -4308,83 +4336,87 @@ app.whenReady().then(async () => {
     const runtimeProject = await localRuntimePool.ensureProject(projectRoot);
     const shellContext = createDormantProjectContext(projectRoot);
     let macosVmLaunchProviderForProject: MacosVmLaunchProvider | null = null;
-    const macosVmService = createMacosVmService({
-      projectRoot,
-      logger,
-      resolveLanes: async () => {
-        const response = await localRuntimePool.callActionForRoot(projectRoot, {
-          domain: "lane",
-          action: "list",
-          args: { includeArchived: false, includeStatus: false },
-        });
-        const lanes = Array.isArray(response.result) ? response.result as LaneSummary[] : [];
-        return lanes.map((lane) => ({
-          id: lane.id,
-          name: lane.name,
-          worktreePath: lane.worktreePath,
-        }));
-      },
-      onEvent: (payload) => {
-        syncMacosVmLaunchCacheFromEvent(payload, (event, fields) => {
-          logger.warn(event, fields);
-        }, {
+    const macosVmService = isMacosVmEnabledForPackagedState(app.isPackaged)
+      ? createMacosVmService({
           projectRoot,
-          provider: macosVmLaunchProviderForProject,
-        });
-        emitProjectEvent(projectRoot, IPC.macosVmEvent, payload);
-      },
-      captureWindowSources: async () => {
-        const sources = await desktopCapturer.getSources({
-          types: ["window"],
-          thumbnailSize: { width: 1280, height: 1280 },
-        });
-        return sources.map((source) => ({
-          id: source.id,
-          name: source.name,
-          thumbnailDataUrl: source.thumbnail.isEmpty() ? null : source.thumbnail.toDataURL(),
-        }));
-      },
-      // TODO: route to RemoteConnectionPool.registerMacosVmTarget once the
-      // in-guest ade-runtime bootstrap installs the binary (today the
-      // bootstrap script only writes a marker file).
-      onRuntimeReady: ({ vmName, ipAddress, username }) => {
-        logger.info("macos_vm.runtime_ready", { vmName, ipAddress, username });
-        void (async () => {
-          const response = await localRuntimePool.callActionForRoot(projectRoot, {
-            domain: "lane",
-            action: "list",
-            args: { includeArchived: false, includeStatus: false },
-          });
-          const lanes = Array.isArray(response.result) ? response.result as LaneSummary[] : [];
-          const vmLane = lanes.find((lane) => lane.runtimePlacement === "macos-vm") ?? null;
-          if (!vmLane) return;
-          invalidateVmLaneLaunchCache(vmLane.id, projectRoot);
-          await refreshVmLaneLaunchCache({
-            laneId: vmLane.id,
-            projectRoot,
-            provider: macosVmLaunchProviderForProject,
-          });
-        })().catch((error) => {
-          logger.warn("macos_vm.runtime_ready_cache_refresh_failed", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        });
-      },
-    });
-    const macosVmSvcAny = macosVmService as unknown as {
-      getStatus?: typeof macosVmService.getStatus;
-      getCredentials?: (args: { vmName: string }) => Promise<{
-        vmName: string;
-        username: string | null;
-        hasPassword: boolean;
-      }>;
-    };
-    if (typeof macosVmSvcAny.getStatus === "function" && typeof macosVmSvcAny.getCredentials === "function") {
-      macosVmLaunchProviderForProject = {
-        getStatus: macosVmSvcAny.getStatus.bind(macosVmService),
-        getCredentials: macosVmSvcAny.getCredentials.bind(macosVmService),
+          logger,
+          resolveLanes: async () => {
+            const response = await localRuntimePool.callActionForRoot(projectRoot, {
+              domain: "lane",
+              action: "list",
+              args: { includeArchived: false, includeStatus: false },
+            });
+            const lanes = Array.isArray(response.result) ? response.result as LaneSummary[] : [];
+            return lanes.map((lane) => ({
+              id: lane.id,
+              name: lane.name,
+              worktreePath: lane.worktreePath,
+            }));
+          },
+          onEvent: (payload) => {
+            syncMacosVmLaunchCacheFromEvent(payload, (event, fields) => {
+              logger.warn(event, fields);
+            }, {
+              projectRoot,
+              provider: macosVmLaunchProviderForProject,
+            });
+            emitProjectEvent(projectRoot, IPC.macosVmEvent, payload);
+          },
+          captureWindowSources: async () => {
+            const sources = await desktopCapturer.getSources({
+              types: ["window"],
+              thumbnailSize: { width: 1280, height: 1280 },
+            });
+            return sources.map((source) => ({
+              id: source.id,
+              name: source.name,
+              thumbnailDataUrl: source.thumbnail.isEmpty() ? null : source.thumbnail.toDataURL(),
+            }));
+          },
+          // TODO: route to RemoteConnectionPool.registerMacosVmTarget once the
+          // in-guest ade-runtime bootstrap installs the binary (today the
+          // bootstrap script only writes a marker file).
+          onRuntimeReady: ({ vmName, ipAddress, username }) => {
+            logger.info("macos_vm.runtime_ready", { vmName, ipAddress, username });
+            void (async () => {
+              const response = await localRuntimePool.callActionForRoot(projectRoot, {
+                domain: "lane",
+                action: "list",
+                args: { includeArchived: false, includeStatus: false },
+              });
+              const lanes = Array.isArray(response.result) ? response.result as LaneSummary[] : [];
+              const vmLane = lanes.find((lane) => lane.runtimePlacement === "macos-vm") ?? null;
+              if (!vmLane) return;
+              invalidateVmLaneLaunchCache(vmLane.id, projectRoot);
+              await refreshVmLaneLaunchCache({
+                laneId: vmLane.id,
+                projectRoot,
+                provider: macosVmLaunchProviderForProject,
+              });
+            })().catch((error) => {
+              logger.warn("macos_vm.runtime_ready_cache_refresh_failed", {
+                error: error instanceof Error ? error.message : String(error),
+              });
+            });
+          },
+        })
+      : null;
+    if (macosVmService) {
+      const macosVmSvcAny = macosVmService as unknown as {
+        getStatus?: ReturnType<typeof createMacosVmService>["getStatus"];
+        getCredentials?: (args: { vmName: string }) => Promise<{
+          vmName: string;
+          username: string | null;
+          hasPassword: boolean;
+        }>;
       };
-      setMacosVmLaunchProvider(macosVmLaunchProviderForProject);
+      if (typeof macosVmSvcAny.getStatus === "function" && typeof macosVmSvcAny.getCredentials === "function") {
+        macosVmLaunchProviderForProject = {
+          getStatus: macosVmSvcAny.getStatus.bind(macosVmService),
+          getCredentials: macosVmSvcAny.getCredentials.bind(macosVmService),
+        };
+        setMacosVmLaunchProvider(macosVmLaunchProviderForProject);
+      }
     }
     const usageTrackingService = createUsageTrackingService({
       logger,

--- a/apps/desktop/src/main/services/adeActions/registry.test.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.test.ts
@@ -9,6 +9,30 @@ import {
   type AdeActionDomain,
 } from "./registry";
 
+function withEnv<T>(updates: Record<string, string | undefined>, run: () => T): T {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(updates)) {
+    previous.set(key, process.env[key]);
+    const value = updates[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    return run();
+  } finally {
+    for (const [key, value] of previous) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 describe("isAllowedAdeAction", () => {
   it("accepts a canonical action from the allowlist", () => {
     expect(isAllowedAdeAction("git", "commit")).toBe(true);
@@ -68,6 +92,57 @@ describe("isAllowedAdeAction", () => {
         expect(isAllowedAdeAction(domain, action)).toBe(true);
       }
     }
+  });
+});
+
+describe("getAdeActionDomainServices feature gates", () => {
+  it("hides Automations, Linear ingress, and macOS VM domains in packaged builds", () => {
+    withEnv(
+      {
+        ADE_ENABLE_AUTOMATIONS: undefined,
+        ADE_DISABLE_AUTOMATIONS: undefined,
+        ADE_ENABLE_MACOS_VM: undefined,
+        ADE_DISABLE_MACOS_VM: undefined,
+      },
+      () => {
+        const services = getAdeActionDomainServices({
+          isPackaged: true,
+          automationService: {},
+          automationPlannerService: {},
+          automationIngressService: {},
+          linearIngressService: {},
+          macosVmService: {},
+        } as never);
+
+        expect(services.automation_planner).toBeNull();
+        expect(services.automations).toBeNull();
+        expect(services.linear_ingress).toBeNull();
+        expect(services.macos_vm).toBeNull();
+      },
+    );
+  });
+
+  it("keeps internal domains available in dev builds", () => {
+    withEnv(
+      {
+        ADE_ENABLE_AUTOMATIONS: undefined,
+        ADE_DISABLE_AUTOMATIONS: undefined,
+        ADE_ENABLE_MACOS_VM: undefined,
+        ADE_DISABLE_MACOS_VM: undefined,
+      },
+      () => {
+        const services = getAdeActionDomainServices({
+          isPackaged: false,
+          automationPlannerService: { parseNaturalLanguage: () => undefined },
+          linearIngressService: { getStatus: () => undefined },
+          macosVmService: { getStatus: () => undefined },
+        } as never);
+
+        expect(services.automation_planner).not.toBeNull();
+        expect(services.linear_ingress).not.toBeNull();
+        expect(services.macos_vm).not.toBeNull();
+      },
+    );
   });
 });
 
@@ -163,9 +238,15 @@ describe("ADE_ACTION_ALLOWLIST shape", () => {
       "triggerManually",
       "listRuns",
       "getRunDetail",
+      "getIngressStatus",
+      "startIngress",
+      "refreshWebhookGatewayStatus",
+      "setWebhookGatewayPublicUrl",
     ]) {
       expect(actions).toContain(name);
     }
+    expect(isCtoOnlyAdeAction("automations", "setWebhookGatewayPublicUrl")).toBe(true);
+    expect(isCtoOnlyAdeAction("automations", "refreshWebhookGatewayStatus")).toBe(false);
   });
 
   it("exposes the issue domain with GitHub issue mutation helpers", () => {

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -28,6 +28,10 @@ import type {
   AgentChatTurnFileDiff,
 } from "../../../shared/types/chat";
 import type { AutomationRule } from "../../../shared/types/config";
+import {
+  areAutomationsEnabledForPackagedState,
+  isMacosVmEnabledForPackagedState,
+} from "../../../shared/automationAvailability";
 import { buildPrAiResolutionContextKey } from "../../../shared/types";
 import type {
   AiConfig,
@@ -165,6 +169,7 @@ export const ADE_ACTION_CTO_ONLY: Partial<Record<AdeActionDomain, readonly strin
   flow_policy: ["savePolicy", "rollbackRevision"],
   linear_sync: ["runSyncNow", "resolveQueueItem"],
   linear_ingress: ["ensureRelayWebhook"],
+  automations: ["setWebhookGatewayPublicUrl"],
   ai: ["updateConfig", "storeApiKey", "deleteApiKey"],
   budget: ["updateConfig"],
   feedback: ["submitPreparedDraft"],
@@ -617,7 +622,7 @@ export const ADE_ACTION_ALLOWLIST: Partial<Record<AdeActionDomain, readonly stri
     "updateIssueState",
   ],
   linear_sync: ["getDashboard", "getRunDetail", "listQueue", "resolveQueueItem", "runSyncNow"],
-  linear_ingress: ["ensureRelayWebhook", "getStatus", "listRecentEvents"],
+  linear_ingress: ["ensureRelayWebhook", "getStatus", "listRecentEvents", "startLocalWebhook"],
   linear_routing: ["simulateRoute"],
   github: [
     "clearToken",
@@ -703,6 +708,9 @@ export const ADE_ACTION_ALLOWLIST: Partial<Record<AdeActionDomain, readonly stri
     "listRuns",
     "getRunDetail",
     "getIngressStatus",
+    "startIngress",
+    "refreshWebhookGatewayStatus",
+    "setWebhookGatewayPublicUrl",
     "listIngressEvents",
   ],
   review: [
@@ -745,6 +753,9 @@ type AutomationsDomainService = {
   listRuns(args?: AutomationRunListArgs): AutomationRun[];
   getRunDetail(args: { runId: string }): Promise<AutomationRunDetail | null>;
   getIngressStatus(): AutomationIngressStatus;
+  startIngress(): Promise<AutomationIngressStatus>;
+  refreshWebhookGatewayStatus(): Promise<AutomationIngressStatus["webhookGateway"]>;
+  setWebhookGatewayPublicUrl(args?: { publicUrl?: string | null }): Promise<AutomationIngressStatus["webhookGateway"]>;
   listIngressEvents(args?: { limit?: number }): AutomationIngressEventRecord[];
 };
 
@@ -768,6 +779,13 @@ function buildAutomationsDomainService(runtime: AdeRuntime): AutomationsDomainSe
     listRuns: (args = {}) => automationService.listRuns(args),
     getRunDetail: ({ runId }) => automationService.getRunDetail({ runId }),
     getIngressStatus: () => automationService.getIngressStatus(),
+    startIngress: async () => {
+      if (!runtime.automationIngressService) throw new Error("Automation ingress service is not available.");
+      await runtime.automationIngressService.start();
+      return automationService.getIngressStatus();
+    },
+    refreshWebhookGatewayStatus: () => automationService.refreshWebhookGatewayStatus(),
+    setWebhookGatewayPublicUrl: (args = {}) => automationService.setWebhookGatewayPublicUrl(args),
     listIngressEvents: (args = {}) => automationService.listIngressEvents(args.limit),
   };
 }
@@ -2806,6 +2824,8 @@ function buildTerminalDomainService(runtime: AdeRuntime): TerminalDomainService 
 export function getAdeActionDomainServices(
   runtime: AdeRuntime,
 ): Partial<Record<AdeActionDomain, OpaqueService | null | undefined>> {
+  const automationsEnabled = areAutomationsEnabledForPackagedState(Boolean(runtime.isPackaged));
+  const macosVmEnabled = isMacosVmEnabledForPackagedState(Boolean(runtime.isPackaged));
   return {
     lane: toService(buildLaneDomainService(runtime)),
     git: toService(runtime.gitService),
@@ -2817,7 +2837,7 @@ export function getAdeActionDomainServices(
     keybindings: toService(runtime.keybindingsService),
     ai: toService(buildAiDomainService(runtime)),
     onboarding: toService(runtime.onboardingService),
-    automation_planner: toService(runtime.automationPlannerService),
+    automation_planner: automationsEnabled ? toService(runtime.automationPlannerService) : null,
     cto_state: toService(buildCtoStateDomainService(runtime)),
     worker_agent: toService(buildWorkerAgentDomainService(runtime)),
     session: toService(buildSessionDomainService(runtime)),
@@ -2832,7 +2852,7 @@ export function getAdeActionDomainServices(
     linear_dispatcher: toService(runtime.linearDispatcherService),
     linear_issue_tracker: toService(buildLinearIssueTrackerDomainService(runtime)),
     linear_sync: toService(runtime.linearSyncService),
-    linear_ingress: toService(runtime.linearIngressService),
+    linear_ingress: automationsEnabled ? toService(runtime.linearIngressService) : null,
     linear_routing: toService(buildLinearRoutingDomainService(runtime)),
     github: buildGithubDomainService(runtime),
     feedback: toService(runtime.feedbackReporterService),
@@ -2850,8 +2870,8 @@ export function getAdeActionDomainServices(
     ios_simulator: toService(runtime.iosSimulatorService),
     app_control: toService(runtime.appControlService),
     built_in_browser: toService(runtime.builtInBrowserService),
-    macos_vm: toService(runtime.macosVmService),
-    automations: toService(buildAutomationsDomainService(runtime)),
+    macos_vm: macosVmEnabled ? toService(runtime.macosVmService) : null,
+    automations: automationsEnabled ? toService(buildAutomationsDomainService(runtime)) : null,
     review: toService(runtime.reviewService),
     issue: toService(buildIssueDomainService(runtime)),
     get notifications_apns() {

--- a/apps/desktop/src/main/services/automations/automationIngressService.test.ts
+++ b/apps/desktop/src/main/services/automations/automationIngressService.test.ts
@@ -1,0 +1,104 @@
+import { createHmac } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AutomationIngressEventRecord } from "../../../shared/types";
+import { createAutomationIngressService, type AutomationIngressService } from "./automationIngressService";
+
+const receivedAt = "2026-06-02T00:00:00.000Z";
+
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+describe("automationIngressService", () => {
+  let service: AutomationIngressService | null = null;
+
+  afterEach(() => {
+    service?.dispose();
+    service = null;
+  });
+
+  it("accepts signed GitHub issue label webhooks and dispatches canonical issue triggers", async () => {
+    const updates: Array<Record<string, unknown>> = [];
+    const dispatchIngressTrigger = vi.fn(async (args: Record<string, unknown>): Promise<AutomationIngressEventRecord> => ({
+      id: "ingress-event-1",
+      source: "local-webhook",
+      eventKey: String(args.eventKey),
+      automationIds: ["smoke-github-label-webhook-gate"],
+      triggerType: "github.issue_labeled",
+      eventName: "issues",
+      status: "dispatched",
+      summary: typeof args.summary === "string" ? args.summary : null,
+      errorMessage: null,
+      cursor: null,
+      receivedAt,
+    }));
+
+    service = createAutomationIngressService({
+      logger: makeLogger() as never,
+      automationService: {
+        updateIngressStatus: (patch: Record<string, unknown>) => updates.push(patch),
+        dispatchIngressTrigger,
+        getIngressStatus: () => ({}),
+      } as never,
+      secretService: {
+        getSecret: (ref: string) => ref === "automations.githubWebhook.secret" ? "github-secret" : null,
+      } as never,
+      listRules: () => [],
+    });
+
+    await service.start();
+    const localStatus = updates
+      .map((entry) => entry.localWebhook)
+      .find((entry): entry is { port: number } => Boolean(entry && typeof (entry as { port?: unknown }).port === "number"));
+    expect(localStatus?.port).toBeGreaterThan(0);
+
+    const body = JSON.stringify({
+      action: "labeled",
+      repository: { full_name: "arul28/ADE" },
+      sender: { login: "octocat" },
+      label: { name: "ade-webhook-smoke" },
+      issue: {
+        number: 75,
+        title: "Smoke webhook issue",
+        body: "Webhook body",
+        html_url: "https://github.com/arul28/ADE/issues/75",
+        user: { login: "octocat" },
+        labels: [{ name: "ade-webhook-smoke" }],
+      },
+    });
+    const signature = `sha256=${createHmac("sha256", "github-secret").update(Buffer.from(body)).digest("hex")}`;
+
+    const response = await fetch(`http://127.0.0.1:${localStatus!.port}/github-webhooks`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-github-event": "issues",
+        "x-github-delivery": "delivery-1",
+        "x-hub-signature-256": signature,
+      },
+      body,
+    });
+
+    expect(response.status).toBe(202);
+    expect(dispatchIngressTrigger).toHaveBeenCalledWith(expect.objectContaining({
+      source: "local-webhook",
+      eventKey: "github:delivery-1:github.issue_labeled",
+      triggerType: "github.issue_labeled",
+      eventName: "issues",
+      repo: "arul28/ADE",
+      labels: ["ade-webhook-smoke"],
+      author: "octocat",
+      issue: expect.objectContaining({
+        number: 75,
+        title: "Smoke webhook issue",
+        repo: "arul28/ADE",
+        labels: ["ade-webhook-smoke"],
+      }),
+    }));
+  });
+});

--- a/apps/desktop/src/main/services/automations/automationIngressService.ts
+++ b/apps/desktop/src/main/services/automations/automationIngressService.ts
@@ -1,7 +1,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import http from "node:http";
 import { URL } from "node:url";
-import type { AutomationIngressEventRecord, AutomationIngressSource, AutomationRule } from "../../../shared/types";
+import type { AutomationIngressEventRecord, AutomationIngressSource, AutomationRule, AutomationTriggerType } from "../../../shared/types";
 import type { Logger } from "../logging/logger";
 import type { createAutomationService } from "./automationService";
 import type { AutomationSecretService } from "./automationSecretService";
@@ -17,6 +17,7 @@ type AutomationIngressServiceArgs = {
 const GITHUB_RELAY_API_BASE_REF = "automations.githubRelay.apiBaseUrl";
 const GITHUB_RELAY_PROJECT_REF = "automations.githubRelay.remoteProjectId";
 const GITHUB_RELAY_TOKEN_REF = "automations.githubRelay.accessToken";
+const GITHUB_WEBHOOK_SECRET_REF = "automations.githubWebhook.secret";
 
 function safeCompareSignature(expected: string, actual: string): boolean {
   const a = Buffer.from(expected, "utf8");
@@ -40,6 +41,188 @@ function normalizeLabels(value: unknown): string[] {
       return "";
     })
     .filter(Boolean);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function normalizeHeader(headers: Record<string, string | string[] | undefined>, key: string): string {
+  const needle = key.toLowerCase();
+  for (const [headerKey, headerValue] of Object.entries(headers)) {
+    if (headerKey.toLowerCase() !== needle) continue;
+    if (Array.isArray(headerValue)) return headerValue[0]?.trim() ?? "";
+    return typeof headerValue === "string" ? headerValue.trim() : "";
+  }
+  return "";
+}
+
+function readString(source: Record<string, unknown> | null | undefined, key: string): string | undefined {
+  const value = source?.[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readNumber(source: Record<string, unknown> | null | undefined, key: string): number | undefined {
+  const value = source?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readNested(source: Record<string, unknown> | null | undefined, key: string): Record<string, unknown> | null {
+  const value = source?.[key];
+  return isRecord(value) ? value : null;
+}
+
+function readRepoName(payload: Record<string, unknown>): string | null {
+  const repo = readNested(payload, "repository");
+  return readString(repo, "full_name") ?? null;
+}
+
+function readUserLogin(source: Record<string, unknown> | null): string | undefined {
+  return readString(readNested(source, "user"), "login");
+}
+
+function readLogin(source: Record<string, unknown> | null): string | undefined {
+  return readString(source, "login") ?? readUserLogin(source);
+}
+
+function readHtmlUrl(source: Record<string, unknown> | null): string | undefined {
+  return readString(source, "html_url");
+}
+
+function buildIssueContext(issue: Record<string, unknown> | null, repo: string | null) {
+  const number = readNumber(issue, "number");
+  const title = readString(issue, "title");
+  if (!number || !title) return null;
+  return {
+    number,
+    title,
+    body: readString(issue, "body"),
+    author: readUserLogin(issue),
+    labels: normalizeLabels(issue?.labels),
+    repo: repo ?? undefined,
+    url: readHtmlUrl(issue),
+  };
+}
+
+function buildPrContext(pr: Record<string, unknown> | null, repo: string | null) {
+  const number = readNumber(pr, "number");
+  const title = readString(pr, "title");
+  if (!number || !title) return null;
+  return {
+    number,
+    title,
+    body: readString(pr, "body"),
+    author: readUserLogin(pr),
+    labels: normalizeLabels(pr?.labels),
+    repo: repo ?? undefined,
+    url: readHtmlUrl(pr),
+    baseBranch: readString(readNested(pr, "base"), "ref"),
+    headBranch: readString(readNested(pr, "head"), "ref"),
+    draft: pr?.draft === true,
+    merged: pr?.merged === true,
+  };
+}
+
+function mapGithubWebhookToTrigger(githubEvent: string, payload: Record<string, unknown>): {
+  triggerType: AutomationTriggerType;
+  summary: string;
+  author?: string;
+  labels?: string[];
+  branch?: string | null;
+  targetBranch?: string | null;
+  draftState?: "draft" | "ready" | "any";
+  issue?: ReturnType<typeof buildIssueContext>;
+  pr?: ReturnType<typeof buildPrContext>;
+} | null {
+  const action = readString(payload, "action") ?? "";
+  const repo = readRepoName(payload);
+  if (githubEvent === "issues") {
+    const issue = buildIssueContext(readNested(payload, "issue"), repo);
+    if (!issue) return null;
+    const labeled = action === "labeled";
+    const triggerType: AutomationTriggerType | null =
+      action === "opened"
+        ? "github.issue_opened"
+        : action === "edited"
+          ? "github.issue_edited"
+          : action === "closed"
+            ? "github.issue_closed"
+            : labeled
+              ? "github.issue_labeled"
+              : null;
+    if (!triggerType) return null;
+    const addedLabel = readString(readNested(payload, "label"), "name");
+    return {
+      triggerType,
+      summary: `GitHub issue #${issue.number} ${action}: ${issue.title}`,
+      author: readLogin(readNested(payload, "sender")),
+      labels: labeled && addedLabel ? [addedLabel] : issue.labels,
+      issue,
+    };
+  }
+
+  if (githubEvent === "issue_comment") {
+    if (action && action !== "created") return null;
+    const rawIssue = readNested(payload, "issue");
+    const comment = readNested(payload, "comment");
+    const issueIsPr = Boolean(readNested(rawIssue, "pull_request"));
+    const issue = buildIssueContext(rawIssue, repo);
+    if (!issue) return null;
+    return {
+      triggerType: issueIsPr ? "github.pr_commented" : "github.issue_commented",
+      summary: `GitHub ${issueIsPr ? "PR" : "issue"} #${issue.number} commented: ${issue.title}`,
+      author: readUserLogin(comment) ?? readLogin(readNested(payload, "sender")),
+      labels: issue.labels,
+      issue: issueIsPr ? null : issue,
+      pr: issueIsPr
+        ? { ...issue, baseBranch: undefined, headBranch: undefined, draft: false, merged: false }
+        : null,
+    };
+  }
+
+  if (githubEvent === "pull_request") {
+    const pr = buildPrContext(readNested(payload, "pull_request"), repo);
+    if (!pr) return null;
+    const triggerType: AutomationTriggerType | null =
+      action === "opened" || action === "reopened"
+        ? "github.pr_opened"
+        : action === "closed" && pr.merged
+          ? "github.pr_merged"
+          : action === "closed"
+            ? "github.pr_closed"
+            : ["edited", "synchronize", "ready_for_review", "converted_to_draft", "labeled", "unlabeled"].includes(action)
+              ? "github.pr_updated"
+              : null;
+    if (!triggerType) return null;
+    return {
+      triggerType,
+      summary: `GitHub PR #${pr.number} ${action}: ${pr.title}`,
+      author: readLogin(readNested(payload, "sender")) ?? pr.author,
+      labels: pr.labels,
+      branch: pr.headBranch ?? null,
+      targetBranch: pr.baseBranch ?? null,
+      draftState: pr.draft ? "draft" : "ready",
+      pr,
+    };
+  }
+
+  if (githubEvent === "pull_request_review") {
+    if (action && action !== "submitted") return null;
+    const pr = buildPrContext(readNested(payload, "pull_request"), repo);
+    if (!pr) return null;
+    return {
+      triggerType: "github.pr_review_submitted",
+      summary: `GitHub PR #${pr.number} review submitted: ${pr.title}`,
+      author: readUserLogin(readNested(payload, "review")) ?? readLogin(readNested(payload, "sender")),
+      labels: pr.labels,
+      branch: pr.headBranch ?? null,
+      targetBranch: pr.baseBranch ?? null,
+      draftState: pr.draft ? "draft" : "ready",
+      pr,
+    };
+  }
+
+  return null;
 }
 
 export function createAutomationIngressService(args: AutomationIngressServiceArgs) {
@@ -69,6 +252,55 @@ export function createAutomationIngressService(args: AutomationIngressServiceArg
     args.listRules()
       .find((rule) => rule.id === automationId)
       ?.triggers.find((trigger) => trigger.type === type);
+
+  const verifyGithubWebhookSignature = (rawBody: Buffer, signature: string): void => {
+    const secret = args.secretService.getSecret(GITHUB_WEBHOOK_SECRET_REF);
+    if (!secret) {
+      throw new Error(`GitHub webhook secret '${GITHUB_WEBHOOK_SECRET_REF}' could not be resolved.`);
+    }
+    if (!signature.startsWith("sha256=")) {
+      throw new Error("Missing x-hub-signature-256 header.");
+    }
+    const expected = `sha256=${createHmac("sha256", secret).update(rawBody).digest("hex")}`;
+    if (!safeCompareSignature(expected, signature)) {
+      throw new Error("GitHub webhook signature mismatch.");
+    }
+  };
+
+  const dispatchGithubWebhook = async (
+    githubEvent: string,
+    deliveryId: string,
+    payload: Record<string, unknown>,
+  ): Promise<AutomationIngressEventRecord | null> => {
+    const mapped = mapGithubWebhookToTrigger(githubEvent, payload);
+    if (!mapped) {
+      return await args.automationService.dispatchIngressTrigger({
+        source: "local-webhook",
+        eventKey: `github:${deliveryId || Date.now()}:${githubEvent}:unsupported`,
+        triggerType: "github-webhook",
+        eventName: githubEvent,
+        summary: `GitHub ${githubEvent} webhook received`,
+        rawPayload: payload,
+      });
+    }
+    const repo = mapped.issue?.repo ?? mapped.pr?.repo ?? readRepoName(payload);
+    return await args.automationService.dispatchIngressTrigger({
+      source: "local-webhook",
+      eventKey: `github:${deliveryId || Date.now()}:${mapped.triggerType}`,
+      triggerType: mapped.triggerType,
+      eventName: githubEvent,
+      summary: mapped.summary,
+      author: mapped.author ?? readLogin(readNested(payload, "sender")) ?? null,
+      labels: mapped.labels,
+      branch: mapped.branch,
+      targetBranch: mapped.targetBranch,
+      draftState: mapped.draftState,
+      rawPayload: payload,
+      repo,
+      issue: mapped.issue,
+      pr: mapped.pr,
+    });
+  };
 
   const dispatchLocalWebhook = async (automationId: string, payload: Record<string, unknown>, rawBody: Buffer): Promise<AutomationIngressEventRecord | null> => {
     const trigger = findTrigger(automationId, "webhook");
@@ -113,22 +345,41 @@ export function createAutomationIngressService(args: AutomationIngressServiceArg
     });
   };
 
+  const normalizeWebhookPath = (pathname: string): string =>
+    pathname.startsWith("/ade-webhooks/")
+      ? pathname.slice("/ade-webhooks".length)
+      : pathname;
+
   const handleWebhookRequest = async (request: http.IncomingMessage, response: http.ServerResponse) => {
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
-    const match = /^\/automation-webhooks\/([^/]+)$/.exec(url.pathname);
-    if (request.method !== "POST" || !match?.[1]) {
+    const pathname = normalizeWebhookPath(url.pathname);
+    const match = /^\/automation-webhooks\/([^/]+)$/.exec(pathname);
+    const isGithubWebhook = pathname === "/github-webhooks";
+    if (request.method !== "POST" || (!match?.[1] && !isGithubWebhook)) {
       response.writeHead(404).end("not found");
       return;
     }
-    const automationId = decodeURIComponent(match[1]);
+    const automationId = match?.[1] ? decodeURIComponent(match[1]) : null;
     const chunks: Buffer[] = [];
     request.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
     request.on("end", async () => {
       const body = Buffer.concat(chunks);
       try {
         const payload = JSON.parse(body.toString("utf8")) as Record<string, unknown>;
-        payload.signatureHeader = request.headers["x-ade-signature"] ?? "";
-        const record = await dispatchLocalWebhook(automationId, payload, body);
+        const record = isGithubWebhook
+          ? await (async () => {
+              verifyGithubWebhookSignature(body, normalizeHeader(request.headers, "x-hub-signature-256"));
+              return await dispatchGithubWebhook(
+                normalizeHeader(request.headers, "x-github-event"),
+                normalizeHeader(request.headers, "x-github-delivery"),
+                payload,
+              );
+            })()
+          : await (async () => {
+              if (!automationId) throw new Error("Automation id is required.");
+              payload.signatureHeader = request.headers["x-ade-signature"] ?? "";
+              return await dispatchLocalWebhook(automationId, payload, body);
+            })();
         updateStatus("local-webhook", {
           healthy: true,
           status: "listening",
@@ -138,7 +389,7 @@ export function createAutomationIngressService(args: AutomationIngressServiceArg
         response.writeHead(202, { "content-type": "application/json" }).end(JSON.stringify({ ok: true, eventId: record?.id ?? null }));
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        args.logger.warn("automations.local_webhook_failed", { automationId, error: message });
+        args.logger.warn("automations.local_webhook_failed", { automationId, path: url.pathname, error: message });
         updateStatus("local-webhook", {
           healthy: false,
           status: "error",
@@ -235,6 +486,7 @@ export function createAutomationIngressService(args: AutomationIngressServiceArg
           status: "listening",
           port,
           url: port ? `http://127.0.0.1:${port}/automation-webhooks/:automationId` : null,
+          githubUrl: port ? `http://127.0.0.1:${port}/github-webhooks` : null,
           lastError: null,
         });
       }

--- a/apps/desktop/src/main/services/automations/automationPlannerService.test.ts
+++ b/apps/desktop/src/main/services/automations/automationPlannerService.test.ts
@@ -9,6 +9,11 @@ function createPlannerForTests(args: {
   suites: Array<{ id: string; name: string }>;
   projectRoot?: string;
   laneWorktrees?: Record<string, string>;
+  automationService?: {
+    list: () => { id: string }[];
+    syncFromConfig: () => void;
+    assertWebhookGatewayReadyForRule?: (rule: any) => void;
+  };
 }) {
   const logger = {
     debug: () => {},
@@ -53,7 +58,7 @@ function createPlannerForTests(args: {
   const laneService = {
     getLaneWorktreePath: (laneId: string) => args.laneWorktrees?.[laneId] ?? projectRoot,
   } as any;
-  const automationService = { list: () => [], syncFromConfig: () => {} } as any;
+  const automationService = args.automationService ?? { list: () => [], syncFromConfig: () => {} };
 
   return {
     planner: createAutomationPlannerService({
@@ -71,6 +76,11 @@ function getPlanner(args: {
   suites: Array<{ id: string; name: string }>;
   projectRoot?: string;
   laneWorktrees?: Record<string, string>;
+  automationService?: {
+    list: () => { id: string }[];
+    syncFromConfig: () => void;
+    assertWebhookGatewayReadyForRule?: (rule: any) => void;
+  };
 }) {
   const harness = createPlannerForTests(args);
   return harness;
@@ -255,6 +265,30 @@ describe("automationPlannerService.validateDraft", () => {
     });
     expect(saved.rule.includeProjectContext).toBe(false);
     expect(getSnapshot().local.automations[0]?.includeProjectContext).toBe(false);
+  });
+
+  it("checks the webhook gateway before saving enabled external event automations", () => {
+    const calls: any[] = [];
+    const { planner } = getPlanner({
+      suites: [],
+      automationService: {
+        list: () => [],
+        syncFromConfig: () => {},
+        assertWebhookGatewayReadyForRule: (rule: any) => {
+          calls.push(rule);
+          throw new Error("Gateway missing");
+        },
+      },
+    } as any);
+    const draft = createDraft({
+      name: "Linear label",
+      triggers: [{ type: "linear.issue_labeled" }],
+      trigger: { type: "linear.issue_labeled" },
+      prompt: "Run a smoke triage.",
+    });
+
+    expect(() => planner.saveDraft({ draft, confirmations: [] })).toThrow(/Gateway missing/);
+    expect(calls[0]?.name).toBe("Linear label");
   });
 
   it("normalizes issue-to-lane pipelines with per-step agent settings", () => {

--- a/apps/desktop/src/main/services/automations/automationPlannerService.ts
+++ b/apps/desktop/src/main/services/automations/automationPlannerService.ts
@@ -1039,7 +1039,11 @@ export function createAutomationPlannerService({
   projectRoot: string;
   projectConfigService: ReturnType<typeof createProjectConfigService>;
   laneService: ReturnType<typeof createLaneService>;
-  automationService: { list: () => { id: string }[]; syncFromConfig: () => void };
+  automationService: {
+    list: () => { id: string }[];
+    syncFromConfig: () => void;
+    assertWebhookGatewayReadyForRule?: (rule: Pick<AutomationRule, "name" | "triggers" | "trigger">) => void;
+  };
 }) {
   const readSuites = (): TestSuiteDefinition[] => {
     try {
@@ -1244,6 +1248,13 @@ export function createAutomationPlannerService({
       }
 
       const normalized = validation.normalized;
+      if (normalized.enabled) {
+        automationService.assertWebhookGatewayReadyForRule?.({
+          name: normalized.name,
+          triggers: normalized.triggers,
+          trigger: normalized.triggers[0] ?? { type: "manual" },
+        });
+      }
       const execution = normalized.execution ?? {
         kind: normalized.actions.length ? "built-in" : "agent-session",
         ...(normalized.actions.length ? { builtIn: { actions: normalized.actions } } : { session: {} }),

--- a/apps/desktop/src/main/services/automations/automationService.test.ts
+++ b/apps/desktop/src/main/services/automations/automationService.test.ts
@@ -158,6 +158,197 @@ describe("normalizeRuntimeRule", () => {
   });
 });
 
+describe("webhook gateway gating", () => {
+  function makeProjectConfigHarness(rule: any, ui: Record<string, unknown> = {}) {
+    let snapshot: any = {
+      trust: { requiresSharedTrust: false },
+      shared: {},
+      local: { automations: [{ id: rule.id, enabled: rule.enabled }] },
+      effective: { automations: [rule], providerMode: "guest", ui },
+    };
+    return {
+      service: {
+        get: () => snapshot,
+        save: (next: any) => {
+          const nextLocal = next.local ?? snapshot.local;
+          snapshot = {
+            ...snapshot,
+            ...next,
+            effective: {
+              ...snapshot.effective,
+              ui: nextLocal.ui ?? snapshot.effective.ui,
+              automations: nextLocal.automations?.map((entry: any) => ({ ...rule, ...entry })) ?? snapshot.effective.automations,
+            },
+          };
+          return snapshot;
+        },
+      } as any,
+      getSnapshot: () => snapshot,
+    };
+  }
+
+  function createServiceForRule(rule: any, ui: Record<string, unknown> = {}) {
+    const { db } = createInMemoryAdeDb();
+    const logger = createLogger();
+    const projectConfig = makeProjectConfigHarness(rule, ui);
+    const service = createAutomationService({
+      db: db as any,
+      logger,
+      projectId: "proj",
+      projectRoot: "/tmp",
+      laneService: {
+        getLaneBaseAndBranch: () => ({ baseRef: "main", branchRef: "main", worktreePath: "/tmp" }),
+        getLaneWorktreePath: () => "/tmp",
+      } as any,
+      projectConfigService: projectConfig.service,
+    });
+    return { service, projectConfig };
+  }
+
+  it("blocks enabling external event automations until the webhook gateway is ready", () => {
+    const rule = normalizeRuntimeRule({
+      id: "linear-label",
+      name: "Linear label",
+      enabled: false,
+      mode: "review",
+      triggers: [{ type: "linear.issue_labeled" }],
+      trigger: { type: "linear.issue_labeled" },
+      execution: { kind: "agent-session", session: {} },
+      executor: { mode: "automation-bot" },
+      prompt: "Smoke test",
+      reviewProfile: "quick",
+      toolPalette: ["linear"],
+      contextSources: [],
+      guardrails: {},
+      outputs: { disposition: "comment-only", createArtifact: true },
+      verification: { verifyBeforePublish: false, mode: "intervention" },
+      billingCode: "auto:linear-label",
+      actions: [],
+    });
+    const { service } = createServiceForRule(rule);
+
+    expect(() => service.toggle({ id: rule.id, enabled: true })).toThrow(/Webhook Gateway/);
+  });
+
+  it("allows external event automations when a public gateway URL is configured", () => {
+    const rule = normalizeRuntimeRule({
+      id: "github-label",
+      name: "GitHub label",
+      enabled: false,
+      mode: "review",
+      triggers: [{ type: "github.issue_labeled" }],
+      trigger: { type: "github.issue_labeled" },
+      execution: { kind: "agent-session", session: {} },
+      executor: { mode: "automation-bot" },
+      prompt: "Smoke test",
+      reviewProfile: "quick",
+      toolPalette: ["github"],
+      contextSources: [],
+      guardrails: {},
+      outputs: { disposition: "comment-only", createArtifact: true },
+      verification: { verifyBeforePublish: false, mode: "intervention" },
+      billingCode: "auto:github-label",
+      actions: [],
+    });
+    const { service, projectConfig } = createServiceForRule(rule, {
+      webhookGatewayPublicUrl: "https://ade.example.com/ade-webhooks",
+    });
+
+    expect(() => service.toggle({ id: rule.id, enabled: true })).not.toThrow();
+    expect(projectConfig.getSnapshot().local.automations[0]?.enabled).toBe(true);
+  });
+
+  it("does not treat a saved Tailscale URL as ready before Funnel is verified", () => {
+    const rule = normalizeRuntimeRule({
+      id: "github-label",
+      name: "GitHub label",
+      enabled: false,
+      mode: "review",
+      triggers: [{ type: "github.issue_labeled" }],
+      trigger: { type: "github.issue_labeled" },
+      execution: { kind: "agent-session", session: {} },
+      executor: { mode: "automation-bot" },
+      prompt: "Smoke test",
+      reviewProfile: "quick",
+      toolPalette: ["github"],
+      contextSources: [],
+      guardrails: {},
+      outputs: { disposition: "comment-only", createArtifact: true },
+      verification: { verifyBeforePublish: false, mode: "intervention" },
+      billingCode: "auto:github-label",
+      actions: [],
+    });
+    const { service } = createServiceForRule(rule, {
+      webhookGatewayPublicUrl: "https://ade-dev.tail000000.ts.net/ade-webhooks",
+    });
+
+    const status = service.getIngressStatus().webhookGateway;
+    expect(status.publicUrl).toBe("https://ade-dev.tail000000.ts.net/ade-webhooks");
+    expect(status.ready).toBe(false);
+    expect(status.status).toBe("pending-approval");
+    expect(() => service.toggle({ id: rule.id, enabled: true })).toThrow(/Webhook Gateway/);
+  });
+
+  it("saves and clears the public gateway URL through the automation runtime", async () => {
+    const rule = normalizeRuntimeRule({
+      id: "manual-smoke",
+      name: "Manual smoke",
+      enabled: true,
+      mode: "review",
+      triggers: [{ type: "manual" }],
+      trigger: { type: "manual" },
+      execution: { kind: "agent-session", session: {} },
+      executor: { mode: "automation-bot" },
+      prompt: "Smoke test",
+      reviewProfile: "quick",
+      toolPalette: ["repo"],
+      contextSources: [],
+      guardrails: {},
+      outputs: { disposition: "comment-only", createArtifact: true },
+      verification: { verifyBeforePublish: false, mode: "intervention" },
+      billingCode: "auto:manual-smoke",
+      actions: [],
+    });
+    const { service, projectConfig } = createServiceForRule(rule);
+
+    const saved = await service.setWebhookGatewayPublicUrl({
+      publicUrl: "https://ade.example.com/ade-webhooks/",
+    });
+    expect(saved.publicUrl).toBe("https://ade.example.com/ade-webhooks");
+    expect(saved.ready).toBe(true);
+    expect(projectConfig.getSnapshot().local.ui.webhookGatewayPublicUrl).toBe("https://ade.example.com/ade-webhooks");
+
+    const cleared = await service.setWebhookGatewayPublicUrl({ publicUrl: null });
+    expect(cleared.publicUrl).toBeNull();
+    expect(projectConfig.getSnapshot().local.ui.webhookGatewayPublicUrl).toBeUndefined();
+  });
+
+  it("rejects non-HTTPS public gateway URLs", async () => {
+    const rule = normalizeRuntimeRule({
+      id: "manual-smoke",
+      name: "Manual smoke",
+      enabled: true,
+      mode: "review",
+      triggers: [{ type: "manual" }],
+      trigger: { type: "manual" },
+      execution: { kind: "agent-session", session: {} },
+      executor: { mode: "automation-bot" },
+      prompt: "Smoke test",
+      reviewProfile: "quick",
+      toolPalette: ["repo"],
+      contextSources: [],
+      guardrails: {},
+      outputs: { disposition: "comment-only", createArtifact: true },
+      verification: { verifyBeforePublish: false, mode: "intervention" },
+      billingCode: "auto:manual-smoke",
+      actions: [],
+    });
+    const { service } = createServiceForRule(rule);
+
+    await expect(service.setWebhookGatewayPublicUrl({ publicUrl: "http://localhost:3000" })).rejects.toThrow(/HTTPS/);
+  });
+});
+
 function createInMemoryAdeDb(): { db: AdeDb; raw: Database } {
   const raw = new SQL.Database();
   raw.run(`

--- a/apps/desktop/src/main/services/automations/automationService.ts
+++ b/apps/desktop/src/main/services/automations/automationService.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from "node:crypto";
-import { spawn } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { promisify } from "node:util";
 import cron from "node-cron";
 import chokidar, { type FSWatcher } from "chokidar";
 import type {
@@ -13,6 +14,7 @@ import type {
   AutomationIngressEventRecord,
   AutomationIngressSource,
   AutomationIngressStatus,
+  AutomationWebhookGatewayStatus,
   AutomationManualTriggerRequest,
   AutomationRule,
   AutomationRuleSummary,
@@ -28,6 +30,7 @@ import type {
   PrSummary,
   RunAdeActionConfig,
 } from "../../../shared/types";
+import { isWebhookGatewayTriggerType } from "../../../shared/types";
 import type { Logger } from "../logging/logger";
 import type { AdeDb, SqlValue } from "../state/kvDb";
 import type { createLaneService } from "../lanes/laneService";
@@ -43,10 +46,96 @@ import type { createWorkerHeartbeatService } from "../cto/workerHeartbeatService
 import { isRecord, matchesGlob, normalizeSet, nowIso, resolvePathWithinRoot, safeJsonParse } from "../shared/utils";
 import { terminateProcessTree } from "../shared/processExecution";
 import { getDefaultModelDescriptor, getModelById, modelSupportsFastMode, resolveChatProviderForDescriptor, resolveProviderGroupForModel } from "../../../shared/modelRegistry";
+import { resolveTailscaleCliPath } from "../sync/resolveTailscaleCliPath";
+
+const execFileAsync = promisify(execFile);
 
 type CronTask = {
   stop: () => void;
 };
+
+function firstEnvValue(keys: readonly string[]): string | null {
+  for (const key of keys) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+  return null;
+}
+
+function normalizePublicWebhookUrl(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "https:") return null;
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return null;
+  }
+}
+
+function buildWebhookGatewayPublicUrl(): string | null {
+  return normalizePublicWebhookUrl(firstEnvValue([
+    "ADE_WEBHOOK_GATEWAY_PUBLIC_URL",
+    "ADE_PUBLIC_WEBHOOK_URL",
+    "ADE_AUTOMATION_WEBHOOK_PUBLIC_URL",
+  ]));
+}
+
+function inferWebhookGatewayProvider(publicUrl: string | null, tailscaleAvailable = false): AutomationWebhookGatewayStatus["provider"] {
+  if (publicUrl?.includes(".ts.net")) return "tailscale";
+  if (publicUrl) return "custom";
+  return tailscaleAvailable ? "tailscale" : null;
+}
+
+function defaultWebhookGatewayStatus(localUrl: string | null = null, configuredPublicUrl?: string | null): AutomationWebhookGatewayStatus {
+  const publicUrl = configuredPublicUrl ?? buildWebhookGatewayPublicUrl();
+  const forcedReady = firstEnvValue(["ADE_WEBHOOK_GATEWAY_READY", "ADE_AUTOMATION_WEBHOOK_READY"]) === "1";
+  const provider = inferWebhookGatewayProvider(publicUrl);
+  const ready = forcedReady || Boolean(publicUrl && provider === "custom");
+  return {
+    enabled: ready || Boolean(publicUrl),
+    ready,
+    status: ready ? "online" : publicUrl && provider === "tailscale" ? "pending-approval" : "needs-public-url",
+    publicUrl,
+    localUrl,
+    provider,
+    tailscale: {
+      available: false,
+      hostname: null,
+      message: null,
+    },
+    lastCheckedAt: null,
+    lastError: null,
+  };
+}
+
+function extractTailscaleHostname(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const self = (payload as { Self?: unknown }).Self;
+  if (!self || typeof self !== "object") return null;
+  const dnsName = typeof (self as { DNSName?: unknown }).DNSName === "string"
+    ? (self as { DNSName: string }).DNSName.trim().replace(/\.$/, "")
+    : "";
+  if (dnsName) return dnsName;
+  const hostName = typeof (self as { HostName?: unknown }).HostName === "string"
+    ? (self as { HostName: string }).HostName.trim()
+    : "";
+  return hostName || null;
+}
+
+function hasTailscaleFunnelConfig(payload: unknown): boolean {
+  return isRecord(payload) && Object.keys(payload).length > 0;
+}
+
+function ruleNeedsWebhookGateway(rule: Pick<AutomationRule, "triggers" | "trigger">): boolean {
+  const triggers = Array.isArray(rule.triggers) && rule.triggers.length > 0
+    ? rule.triggers
+    : rule.trigger
+      ? [rule.trigger]
+      : [];
+  return triggers.some((trigger) => isWebhookGatewayTriggerType(trigger.type));
+}
 
 /**
  * Contract for the shared ADE-action registry. Implementations bridge to the
@@ -863,6 +952,7 @@ export function createAutomationService({
   }) => void;
 }) {
   type AutomationIngressStatusPatch = {
+    webhookGateway?: Partial<AutomationIngressStatus["webhookGateway"]>;
     githubRelay?: Partial<AutomationIngressStatus["githubRelay"]>;
     localWebhook?: Partial<AutomationIngressStatus["localWebhook"]>;
   };
@@ -870,7 +960,16 @@ export function createAutomationService({
   let budgetCapServiceRef = budgetCapService;
   let workerHeartbeatServiceRef: ReturnType<typeof createWorkerHeartbeatService> | null = null;
   let adeActionRegistryRef: AutomationAdeActionRegistry | null = adeActionRegistry ?? null;
+  const readWebhookGatewayPublicUrl = (): string | null => {
+    try {
+      return normalizePublicWebhookUrl(projectConfigService.get().effective.ui?.webhookGatewayPublicUrl ?? null)
+        ?? buildWebhookGatewayPublicUrl();
+    } catch {
+      return buildWebhookGatewayPublicUrl();
+    }
+  };
   let ingressStatusRef: AutomationIngressStatus = {
+    webhookGateway: defaultWebhookGatewayStatus(null, readWebhookGatewayPublicUrl()),
     githubRelay: {
       configured: false,
       healthy: false,
@@ -887,6 +986,7 @@ export function createAutomationService({
       listening: false,
       status: "disabled",
       url: null,
+      githubUrl: null,
       port: null,
       lastDeliveryAt: null,
       lastError: null,
@@ -1070,11 +1170,102 @@ export function createAutomationService({
   const findRule = (automationId: string): AutomationRule | null => listRules().find((rule) => rule.id === automationId) ?? null;
 
   const updateIngressStatus = (patch: AutomationIngressStatusPatch) => {
+    const localWebhook = { ...ingressStatusRef.localWebhook, ...(patch.localWebhook ?? {}) };
+    const gatewayPatch = patch.webhookGateway ?? {};
+    const publicUrl = (gatewayPatch.publicUrl !== undefined
+      ? gatewayPatch.publicUrl
+      : ingressStatusRef.webhookGateway.publicUrl) ?? null;
+    const gatewayReady = gatewayPatch.ready !== undefined
+      ? gatewayPatch.ready
+      : ingressStatusRef.webhookGateway.ready;
     ingressStatusRef = {
+      webhookGateway: {
+        ...ingressStatusRef.webhookGateway,
+        localUrl: localWebhook.url ?? ingressStatusRef.webhookGateway.localUrl,
+        ...(patch.webhookGateway ?? {}),
+        publicUrl,
+        ready: gatewayReady,
+        enabled: gatewayReady || Boolean(publicUrl),
+      },
       githubRelay: { ...ingressStatusRef.githubRelay, ...(patch.githubRelay ?? {}) },
-      localWebhook: { ...ingressStatusRef.localWebhook, ...(patch.localWebhook ?? {}) },
+      localWebhook,
     };
     emit({ type: "ingress-updated" });
+  };
+
+  const refreshWebhookGatewayStatus = async (): Promise<AutomationWebhookGatewayStatus> => {
+    const publicUrl = readWebhookGatewayPublicUrl();
+    const localUrl = ingressStatusRef.localWebhook.url ?? ingressStatusRef.webhookGateway.localUrl;
+    const forcedReady = firstEnvValue(["ADE_WEBHOOK_GATEWAY_READY", "ADE_AUTOMATION_WEBHOOK_READY"]) === "1";
+    let tailscaleAvailable = false;
+    let tailscaleHostname: string | null = null;
+    let tailscaleMessage: string | null = null;
+    let tailscaleFunnelConfigured = false;
+    let lastError: string | null = null;
+    try {
+      const { stdout } = await execFileAsync(resolveTailscaleCliPath(), ["status", "--json"], { timeout: 4_000 });
+      const payload = JSON.parse(stdout) as unknown;
+      tailscaleAvailable = true;
+      tailscaleHostname = extractTailscaleHostname(payload);
+      tailscaleMessage = tailscaleHostname
+        ? `Tailscale is available on ${tailscaleHostname}.`
+        : "Tailscale is available.";
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException | null | undefined)?.code ?? null;
+      const message = error instanceof Error ? error.message : String(error);
+      tailscaleMessage = code === "ENOENT" ? "Tailscale CLI was not found." : message;
+      lastError = publicUrl || forcedReady ? null : tailscaleMessage;
+    }
+    const provider = inferWebhookGatewayProvider(publicUrl, tailscaleAvailable);
+    if (publicUrl && provider === "tailscale" && tailscaleAvailable) {
+      try {
+        const { stdout } = await execFileAsync(resolveTailscaleCliPath(), ["funnel", "status", "--json"], { timeout: 4_000 });
+        tailscaleFunnelConfigured = hasTailscaleFunnelConfig(JSON.parse(stdout) as unknown);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        tailscaleMessage = message;
+      }
+    }
+    const ready = forcedReady || Boolean(publicUrl && (provider === "custom" || tailscaleFunnelConfigured));
+    const status: AutomationWebhookGatewayStatus["status"] = ready
+      ? "online"
+      : publicUrl && provider === "tailscale"
+        ? "pending-approval"
+      : tailscaleAvailable
+        ? "needs-public-url"
+        : "needs-tailscale";
+    if (!ready && publicUrl && provider === "tailscale") {
+      lastError = tailscaleAvailable
+        ? "Tailscale Funnel is not enabled for this machine. Enable Funnel, then refresh Webhooks."
+        : tailscaleMessage;
+      tailscaleMessage = tailscaleAvailable
+        ? "Tailscale is available, but Funnel is not exposing the ADE webhook gateway yet."
+        : tailscaleMessage;
+    }
+    const next: AutomationWebhookGatewayStatus = {
+      enabled: ready || Boolean(publicUrl),
+      ready,
+      status,
+      publicUrl,
+      localUrl,
+      provider,
+      tailscale: {
+        available: tailscaleAvailable,
+        hostname: tailscaleHostname,
+        message: tailscaleMessage,
+      },
+      lastCheckedAt: nowIso(),
+      lastError,
+    };
+    updateIngressStatus({ webhookGateway: next });
+    return next;
+  };
+
+  const assertWebhookGatewayReadyForRule = (rule: Pick<AutomationRule, "name" | "triggers" | "trigger">): void => {
+    if (!ruleNeedsWebhookGateway(rule)) return;
+    if (ingressStatusRef.webhookGateway.ready) return;
+    const ruleName = rule.name?.trim() || "This automation";
+    throw new Error(`${ruleName} needs ADE Webhook Gateway before it can be enabled.`);
   };
 
   const getNextNightShiftPosition = (): number => {
@@ -2525,6 +2716,14 @@ export function createAutomationService({
     const desired = new Set<string>();
     for (const rule of rules) {
       if (!rule.enabled) continue;
+      if (ruleNeedsWebhookGateway(rule) && !ingressStatusRef.webhookGateway.ready) {
+        logger.warn("automations.external_trigger_waiting_for_gateway", {
+          automationId: rule.id,
+          publicUrl: ingressStatusRef.webhookGateway.publicUrl,
+          status: ingressStatusRef.webhookGateway.status,
+        });
+        continue;
+      }
       rule.triggers.forEach((trigger, index) => {
         if (trigger.type !== "schedule") return;
         const cronExpr = (trigger.cron ?? "").trim();
@@ -2785,6 +2984,11 @@ export function createAutomationService({
   };
 
   syncFromConfig();
+  void refreshWebhookGatewayStatus().catch((error) => {
+    logger.warn("automations.webhook_gateway_status_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
 
   return {
     syncFromConfig,
@@ -2861,6 +3065,10 @@ export function createAutomationService({
     toggle(args: { id: string; enabled: boolean }): AutomationRuleSummary[] {
       const id = args.id.trim();
       if (!id) return this.list();
+      if (args.enabled) {
+        const existingRule = findRule(id);
+        if (existingRule) assertWebhookGatewayReadyForRule(existingRule);
+      }
       const snapshot = projectConfigService.get();
       const local = { ...(snapshot.local ?? {}) };
       const automations = Array.isArray(local.automations) ? [...local.automations] : [];
@@ -2995,6 +3203,31 @@ export function createAutomationService({
     },
 
     getIngressStatus(): AutomationIngressStatus {
+      const publicUrl = readWebhookGatewayPublicUrl();
+      const forcedReady = firstEnvValue(["ADE_WEBHOOK_GATEWAY_READY", "ADE_AUTOMATION_WEBHOOK_READY"]) === "1";
+      const provider = inferWebhookGatewayProvider(publicUrl, ingressStatusRef.webhookGateway.tailscale.available);
+      const ready = forcedReady || Boolean(publicUrl && provider === "custom") || (
+        Boolean(publicUrl)
+        && publicUrl === ingressStatusRef.webhookGateway.publicUrl
+        && ingressStatusRef.webhookGateway.ready
+      );
+      ingressStatusRef = {
+        ...ingressStatusRef,
+        webhookGateway: {
+          ...ingressStatusRef.webhookGateway,
+          publicUrl,
+          ready,
+          enabled: ready || Boolean(publicUrl),
+          provider,
+          status: ready
+            ? "online"
+            : publicUrl && provider === "tailscale"
+              ? "pending-approval"
+            : ingressStatusRef.webhookGateway.status === "online"
+              ? "needs-public-url"
+              : ingressStatusRef.webhookGateway.status,
+        },
+      };
       return {
         ...ingressStatusRef,
       };
@@ -3005,6 +3238,29 @@ export function createAutomationService({
     },
 
     updateIngressStatus,
+
+    async refreshWebhookGatewayStatus(): Promise<AutomationWebhookGatewayStatus> {
+      return await refreshWebhookGatewayStatus();
+    },
+
+    async setWebhookGatewayPublicUrl(args: { publicUrl?: string | null } = {}): Promise<AutomationWebhookGatewayStatus> {
+      const raw = args.publicUrl?.trim() ?? "";
+      const publicUrl = normalizePublicWebhookUrl(raw);
+      if (raw && !publicUrl) {
+        throw new Error("Webhook gateway URL must be a public HTTPS URL.");
+      }
+      const snapshot = projectConfigService.get();
+      const local = { ...(snapshot.local ?? {}) };
+      local.ui = { ...(local.ui ?? {}) };
+      if (publicUrl) local.ui.webhookGatewayPublicUrl = publicUrl;
+      else delete local.ui.webhookGatewayPublicUrl;
+      projectConfigService.save({ shared: snapshot.shared, local });
+      return await refreshWebhookGatewayStatus();
+    },
+
+    assertWebhookGatewayReadyForRule(rule: Pick<AutomationRule, "name" | "triggers" | "trigger">): void {
+      assertWebhookGatewayReadyForRule(rule);
+    },
 
     getIngressCursor(source: AutomationIngressSource): string | null {
       return getIngressCursor(source);

--- a/apps/desktop/src/main/services/config/projectConfigService.test.ts
+++ b/apps/desktop/src/main/services/config/projectConfigService.test.ts
@@ -705,19 +705,24 @@ describe("projectConfigService - project UI", () => {
       shared: {
         ui: {
           linearBatchLaunchDefaultPrompt: "Shared prompt",
+          webhookGatewayPublicUrl: "https://shared.example.com/ade-webhooks",
         },
       },
       local: {
         ui: {
           linearBatchLaunchDefaultPrompt: "Local prompt",
+          webhookGatewayPublicUrl: "https://local.example.com/ade-webhooks",
         },
       },
     });
 
     const snapshot = service.get();
     expect(snapshot.shared.ui?.linearBatchLaunchDefaultPrompt).toBe("Shared prompt");
+    expect(snapshot.shared.ui?.webhookGatewayPublicUrl).toBe("https://shared.example.com/ade-webhooks");
     expect(snapshot.local.ui?.linearBatchLaunchDefaultPrompt).toBe("Local prompt");
+    expect(snapshot.local.ui?.webhookGatewayPublicUrl).toBe("https://local.example.com/ade-webhooks");
     expect(snapshot.effective.ui?.linearBatchLaunchDefaultPrompt).toBe("Local prompt");
+    expect(snapshot.effective.ui?.webhookGatewayPublicUrl).toBe("https://local.example.com/ade-webhooks");
   });
 });
 

--- a/apps/desktop/src/main/services/config/projectConfigService.ts
+++ b/apps/desktop/src/main/services/config/projectConfigService.ts
@@ -1916,9 +1916,11 @@ export function mergeAiConfig(sharedAi?: AiConfig, localAi?: Partial<AiConfig>):
 function coerceProjectUiConfig(value: unknown): ProjectConfigFile["ui"] {
   if (!isRecord(value)) return undefined;
   const linearBatchLaunchDefaultPrompt = asString(value.linearBatchLaunchDefaultPrompt)?.trim();
-  return linearBatchLaunchDefaultPrompt
-    ? { linearBatchLaunchDefaultPrompt }
-    : undefined;
+  const webhookGatewayPublicUrl = asString(value.webhookGatewayPublicUrl)?.trim();
+  const out: NonNullable<ProjectConfigFile["ui"]> = {};
+  if (linearBatchLaunchDefaultPrompt) out.linearBatchLaunchDefaultPrompt = linearBatchLaunchDefaultPrompt;
+  if (webhookGatewayPublicUrl) out.webhookGatewayPublicUrl = webhookGatewayPublicUrl;
+  return Object.keys(out).length ? out : undefined;
 }
 
 function coerceGithubConfig(value: unknown): ProjectConfigFile["github"] {

--- a/apps/desktop/src/main/services/cto/linearIngressService.ts
+++ b/apps/desktop/src/main/services/cto/linearIngressService.ts
@@ -18,6 +18,11 @@ import type { LinearClient } from "./linearClient";
 const RELAY_API_BASE_REF = "linearRelay.apiBaseUrl";
 const RELAY_PROJECT_REF = "linearRelay.remoteProjectId";
 const RELAY_TOKEN_REF = "linearRelay.accessToken";
+const RELAY_API_BASE_ENV_KEYS = ["ADE_LINEAR_RELAY_API_BASE_URL", "LINEAR_RELAY_API_BASE_URL"] as const;
+const RELAY_PROJECT_ENV_KEYS = ["ADE_LINEAR_RELAY_REMOTE_PROJECT_ID", "LINEAR_RELAY_REMOTE_PROJECT_ID"] as const;
+const RELAY_TOKEN_ENV_KEYS = ["ADE_LINEAR_RELAY_ACCESS_TOKEN", "LINEAR_RELAY_ACCESS_TOKEN"] as const;
+const DIRECT_WEBHOOK_SECRET_REF = "linearWebhook.signingSecret";
+const DIRECT_WEBHOOK_SECRET_ENV_KEYS = ["ADE_LINEAR_WEBHOOK_SIGNING_SECRET", "LINEAR_WEBHOOK_SIGNING_SECRET"] as const;
 
 type LinearIngressServiceArgs = {
   db: AdeDb;
@@ -25,6 +30,9 @@ type LinearIngressServiceArgs = {
   logger?: Logger | null;
   linearClient: LinearClient;
   secretService: AutomationSecretService;
+  projectConfigService?: {
+    get: () => { effective?: { ui?: { webhookGatewayPublicUrl?: string | null } } };
+  } | null;
   onEvent?: (event: LinearIngressEventRecord) => Promise<void> | void;
   reconciliationIntervalSec?: number;
 };
@@ -41,6 +49,12 @@ type RelayEnsureWebhookResponse = {
   webhookUrl: string;
   signingSecret: string;
   lastDeliveredAt: string | null;
+};
+
+type DirectWebhookConfig = {
+  webhookUrl: string | null;
+  signingSecret: string | null;
+  configured: boolean;
 };
 
 type RelayEventResponse = {
@@ -64,6 +78,29 @@ function normalizeHeader(headers: Record<string, string | string[] | undefined>,
 
 function createSecret(): string {
   return randomBytes(32).toString("hex");
+}
+
+function normalizePublicWebhookUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "https:") return null;
+    url.hash = "";
+    url.search = "";
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
+}
+
+function appendWebhookPath(baseUrl: string, routePath: string): string {
+  const normalizedBase = baseUrl.replace(/\/+$/, "");
+  const normalizedRoute = routePath.startsWith("/") ? routePath : `/${routePath}`;
+  return normalizedBase.endsWith(normalizedRoute)
+    ? normalizedBase
+    : `${normalizedBase}${normalizedRoute}`;
 }
 
 function safeCompare(expected: string, actual: string): boolean {
@@ -91,6 +128,14 @@ function readIssueDetails(payload: Record<string, unknown>): {
   const action = typeof payload.action === "string" ? payload.action.trim() : null;
   const summary = [entityType, action, issueIdentifier, title].filter(Boolean).join(" · ") || "Linear webhook received";
   return { issueId, issueIdentifier, summary };
+}
+
+function firstEnvValue(keys: readonly string[]): string | null {
+  for (const key of keys) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+  return null;
 }
 
 export function createLinearIngressService(args: LinearIngressServiceArgs) {
@@ -270,14 +315,28 @@ export function createLinearIngressService(args: LinearIngressServiceArgs) {
   };
 
   const buildRelayConfig = (): RelayConfig => {
-    const apiBaseUrl = args.secretService.getSecret(RELAY_API_BASE_REF)?.trim() ?? null;
-    const remoteProjectId = args.secretService.getSecret(RELAY_PROJECT_REF)?.trim() ?? null;
-    const accessToken = args.secretService.getSecret(RELAY_TOKEN_REF)?.trim() ?? null;
+    const apiBaseUrl = args.secretService.getSecret(RELAY_API_BASE_REF)?.trim() || firstEnvValue(RELAY_API_BASE_ENV_KEYS);
+    const remoteProjectId = args.secretService.getSecret(RELAY_PROJECT_REF)?.trim() || firstEnvValue(RELAY_PROJECT_ENV_KEYS);
+    const accessToken = args.secretService.getSecret(RELAY_TOKEN_REF)?.trim() || firstEnvValue(RELAY_TOKEN_ENV_KEYS);
     return {
       apiBaseUrl,
       remoteProjectId,
       accessToken,
       configured: Boolean(apiBaseUrl && remoteProjectId && accessToken),
+    };
+  };
+
+  const buildDirectWebhookConfig = (): DirectWebhookConfig => {
+    const publicUrl = normalizePublicWebhookUrl(
+      args.projectConfigService?.get().effective?.ui?.webhookGatewayPublicUrl ?? null,
+    );
+    const signingSecret =
+      args.secretService.getSecret(DIRECT_WEBHOOK_SECRET_REF)?.trim()
+      || firstEnvValue(DIRECT_WEBHOOK_SECRET_ENV_KEYS);
+    return {
+      webhookUrl: publicUrl ? appendWebhookPath(publicUrl, "/linear-webhooks") : null,
+      signingSecret: signingSecret || null,
+      configured: Boolean(publicUrl && signingSecret),
     };
   };
 
@@ -291,16 +350,68 @@ export function createLinearIngressService(args: LinearIngressServiceArgs) {
   const ensureRelayEndpoint = async (force = false): Promise<RelayEnsureWebhookResponse | null> => {
     const config = buildRelayConfig();
     if (!config.configured) {
-      updateStatus({
-        relay: {
-          configured: false,
-          healthy: false,
-          status: "disabled",
-          webhookUrl: null,
-          endpointId: null,
-        },
-      });
-      return null;
+      const direct = buildDirectWebhookConfig();
+      if (!direct.configured) {
+        updateStatus({
+          relay: {
+            configured: false,
+            healthy: false,
+            status: "disabled",
+            webhookUrl: direct.webhookUrl,
+            endpointId: null,
+            lastError: direct.webhookUrl
+              ? `Missing ${DIRECT_WEBHOOK_SECRET_REF}.`
+              : "Missing webhook gateway public URL.",
+          },
+        });
+        return null;
+      }
+      try {
+        localSigningSecret = direct.signingSecret!;
+        const existing = await args.linearClient.listWebhooks();
+        if (!existing.some((entry) => entry.url === direct.webhookUrl)) {
+          await args.linearClient.createWebhook({
+            url: direct.webhookUrl!,
+            secret: direct.signingSecret!,
+            label: `ADE ${args.projectId} workflow ingress`,
+            resourceTypes: ["Issue", "IssueLabel"],
+            allPublicTeams: true,
+          });
+        }
+        const payload: RelayEnsureWebhookResponse = {
+          endpointId: "direct",
+          webhookUrl: direct.webhookUrl!,
+          signingSecret: direct.signingSecret!,
+          lastDeliveredAt: null,
+        };
+        relayWebhook = payload;
+        updateStatus({
+          relay: {
+            configured: true,
+            healthy: true,
+            status: "ready",
+            webhookUrl: payload.webhookUrl,
+            endpointId: payload.endpointId,
+            lastDeliveryAt: null,
+            lastError: null,
+          },
+        });
+        return payload;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        args.logger?.warn("linear_ingress.ensure_direct_webhook_failed", { error: message });
+        updateStatus({
+          relay: {
+            configured: true,
+            healthy: false,
+            status: "error",
+            webhookUrl: direct.webhookUrl,
+            endpointId: "direct",
+            lastError: `Linear direct webhook registration failed: ${message}`,
+          },
+        });
+        throw new Error(`Linear direct webhook registration failed: ${message}`);
+      }
     }
 
     if (relayWebhook && !force) return relayWebhook;
@@ -334,9 +445,20 @@ export function createLinearIngressService(args: LinearIngressServiceArgs) {
         });
       }
     } catch (error) {
-      args.logger?.warn("linear_ingress.ensure_linear_webhook_failed", {
-        error: error instanceof Error ? error.message : String(error),
+      const message = error instanceof Error ? error.message : String(error);
+      args.logger?.warn("linear_ingress.ensure_linear_webhook_failed", { error: message });
+      updateStatus({
+        relay: {
+          configured: true,
+          healthy: false,
+          status: "error",
+          webhookUrl: payload.webhookUrl,
+          endpointId: payload.endpointId,
+          lastDeliveryAt: payload.lastDeliveredAt,
+          lastError: `Linear webhook registration failed: ${message}`,
+        },
       });
+      throw new Error(`Linear webhook registration failed: ${message}`);
     }
 
     updateStatus({
@@ -465,6 +587,10 @@ export function createLinearIngressService(args: LinearIngressServiceArgs) {
 
   const startLocalWebhook = async (): Promise<void> => {
     if (localServer) return;
+    const direct = buildDirectWebhookConfig();
+    if (direct.signingSecret) {
+      localSigningSecret = direct.signingSecret;
+    }
     updateStatus({
       localWebhook: {
         configured: true,
@@ -473,7 +599,11 @@ export function createLinearIngressService(args: LinearIngressServiceArgs) {
       },
     });
     localServer = http.createServer((request, response) => {
-      if (request.method !== "POST" || request.url !== "/linear-webhooks") {
+      const url = new URL(request.url ?? "/", "http://127.0.0.1");
+      const pathname = url.pathname.startsWith("/ade-webhooks/")
+        ? url.pathname.slice("/ade-webhooks".length)
+        : url.pathname;
+      if (request.method !== "POST" || pathname !== "/linear-webhooks") {
         response.writeHead(404).end("not found");
         return;
       }
@@ -565,12 +695,18 @@ export function createLinearIngressService(args: LinearIngressServiceArgs) {
       await ensureRealtimeIngressStarted();
     },
 
-    async ensureRelayWebhook(force = false): Promise<void> {
+    async ensureRelayWebhook(force = false): Promise<LinearIngressStatus> {
       await ensureRelayEndpoint(force);
       await startLocalWebhook();
       if (hasRelayConfiguration() && !relayAbortController) {
         void startRelayLoop();
       }
+      return loadStatus();
+    },
+
+    async startLocalWebhook(): Promise<LinearIngressStatus> {
+      await startLocalWebhook();
+      return loadStatus();
     },
 
     getStatus(): LinearIngressStatus {

--- a/apps/desktop/src/main/services/cto/linearIntake.test.ts
+++ b/apps/desktop/src/main/services/cto/linearIntake.test.ts
@@ -365,6 +365,116 @@ describe("linearIngressService (file group)", () => {
       db.close();
     });
 
+    it("can read relay configuration from runtime environment variables", async () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "ade-linear-ingress-"));
+      const db = await openKvDb(path.join(root, "ade.db"), { debug() {}, info() {}, warn() {}, error() {} } as any);
+      const previousApiBase = process.env.ADE_LINEAR_RELAY_API_BASE_URL;
+      const previousProject = process.env.ADE_LINEAR_RELAY_REMOTE_PROJECT_ID;
+      const previousToken = process.env.ADE_LINEAR_RELAY_ACCESS_TOKEN;
+
+      process.env.ADE_LINEAR_RELAY_API_BASE_URL = "https://relay-env.example.com";
+      process.env.ADE_LINEAR_RELAY_REMOTE_PROJECT_ID = "remote-project-env";
+      process.env.ADE_LINEAR_RELAY_ACCESS_TOKEN = "token-env";
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          endpointId: "endpoint-env",
+          webhookUrl: "https://relay-env.example.com/linear/webhooks/endpoint-env",
+          signingSecret: "relay-secret-env",
+          lastDeliveredAt: null,
+        }),
+      } as Response);
+      fetchMock.mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) {
+            resolve();
+            return;
+          }
+          signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        throw new Error("aborted");
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      try {
+        const service = createLinearIngressService({
+          db,
+          projectId: "project-1",
+          linearClient: {
+            listWebhooks: vi.fn(async () => []),
+            createWebhook: vi.fn(async () => ({ id: "webhook-env" })),
+          } as any,
+          secretService: {
+            getSecret: () => null,
+          } as any,
+        });
+
+        await service.ensureRelayWebhook(true);
+
+        expect(service.getStatus().relay.status).toBe("ready");
+        expect(fetchMock.mock.calls[0]?.[0]).toContain("relay-env.example.com");
+
+        service.dispose();
+      } finally {
+        if (previousApiBase === undefined) delete process.env.ADE_LINEAR_RELAY_API_BASE_URL;
+        else process.env.ADE_LINEAR_RELAY_API_BASE_URL = previousApiBase;
+        if (previousProject === undefined) delete process.env.ADE_LINEAR_RELAY_REMOTE_PROJECT_ID;
+        else process.env.ADE_LINEAR_RELAY_REMOTE_PROJECT_ID = previousProject;
+        if (previousToken === undefined) delete process.env.ADE_LINEAR_RELAY_ACCESS_TOKEN;
+        else process.env.ADE_LINEAR_RELAY_ACCESS_TOKEN = previousToken;
+        db.close();
+      }
+    });
+
+    it("reports an error when Linear webhook registration fails", async () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "ade-linear-ingress-"));
+      const db = await openKvDb(path.join(root, "ade.db"), { debug() {}, info() {}, warn() {}, error() {} } as any);
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          endpointId: "endpoint-1",
+          webhookUrl: "https://relay.example.com/linear/webhooks/endpoint-1",
+          signingSecret: "relay-secret",
+          lastDeliveredAt: null,
+        }),
+      } as Response);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const service = createLinearIngressService({
+        db,
+        projectId: "project-1",
+        linearClient: {
+          listWebhooks: vi.fn(async () => {
+            throw new Error("Invalid role: admin required");
+          }),
+          createWebhook: vi.fn(async () => ({ id: "webhook-1" })),
+        } as any,
+        secretService: {
+          getSecret: (key: string) =>
+            key === "linearRelay.apiBaseUrl"
+              ? "https://relay.example.com"
+              : key === "linearRelay.remoteProjectId"
+                ? "remote-project-1"
+                : key === "linearRelay.accessToken"
+                  ? "token-1"
+                  : null,
+        } as any,
+      });
+
+      await expect(service.ensureRelayWebhook(true)).rejects.toThrow("Linear webhook registration failed");
+      const status = service.getStatus();
+
+      expect(status.relay.status).toBe("error");
+      expect(status.relay.healthy).toBe(false);
+      expect(status.relay.lastError).toContain("admin required");
+
+      service.dispose();
+      db.close();
+    });
+
     it("accepts local webhook deliveries signed with the relay secret", async () => {
       const root = fs.mkdtempSync(path.join(os.tmpdir(), "ade-linear-ingress-"));
       const db = await openKvDb(path.join(root, "ade.db"), { debug() {}, info() {}, warn() {}, error() {} } as any);

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -4811,6 +4811,16 @@ export function registerIpc({
     return ctx.automationService.getIngressStatus();
   });
 
+  ipcMain.handle(IPC.automationsRefreshWebhookGatewayStatus, async (): Promise<AutomationIngressStatus["webhookGateway"]> => {
+    const ctx = ensureAutomationContext();
+    return await ctx.automationService.refreshWebhookGatewayStatus();
+  });
+
+  ipcMain.handle(IPC.automationsSetWebhookGatewayPublicUrl, async (_event, arg: { publicUrl?: string | null } | undefined): Promise<AutomationIngressStatus["webhookGateway"]> => {
+    const ctx = ensureAutomationContext();
+    return await ctx.automationService.setWebhookGatewayPublicUrl(arg ?? {});
+  });
+
   ipcMain.handle(IPC.automationsListIngressEvents, async (_event, arg: { limit?: number } | undefined): Promise<AutomationIngressEventRecord[]> => {
     const ctx = ensureAutomationContext();
     return ctx.automationService.listIngressEvents(arg?.limit);

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -22,6 +22,7 @@ import type {
   AutomationDeleteRuleRequest,
   AutomationIngressEventRecord,
   AutomationIngressStatus,
+  AutomationWebhookGatewayStatus,
   ConflictProposal,
   ConflictExternalResolverRunSummary,
   ConflictProposalPreview,
@@ -995,6 +996,10 @@ declare global {
         listRuns: (args?: AutomationRunListArgs) => Promise<AutomationRun[]>;
         getRunDetail: (runId: string) => Promise<AutomationRunDetail | null>;
         getIngressStatus: () => Promise<AutomationIngressStatus>;
+        refreshWebhookGatewayStatus: () => Promise<AutomationWebhookGatewayStatus>;
+        setWebhookGatewayPublicUrl: (args: {
+          publicUrl?: string | null;
+        }) => Promise<AutomationWebhookGatewayStatus>;
         listIngressEvents: (args?: {
           limit?: number;
         }) => Promise<AutomationIngressEventRecord[]>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -27,6 +27,7 @@ import type {
   AutomationDeleteRuleRequest,
   AutomationIngressEventRecord,
   AutomationIngressStatus,
+  AutomationWebhookGatewayStatus,
   AutomationManualTriggerRequest,
   AutomationRuleSummary,
   AutomationRun,
@@ -3943,6 +3944,19 @@ contextBridge.exposeInMainWorld("ade", {
     getIngressStatus: async (): Promise<AutomationIngressStatus> =>
       callProjectRuntimeActionOr("automations", "getIngressStatus", {}, () =>
         ipcRenderer.invoke(IPC.automationsGetIngressStatus),
+      ),
+    refreshWebhookGatewayStatus: async (): Promise<AutomationWebhookGatewayStatus> =>
+      callProjectRuntimeActionOr("automations", "refreshWebhookGatewayStatus", {}, () =>
+        ipcRenderer.invoke(IPC.automationsRefreshWebhookGatewayStatus),
+      ),
+    setWebhookGatewayPublicUrl: async (args: {
+      publicUrl?: string | null;
+    }): Promise<AutomationWebhookGatewayStatus> =>
+      callProjectRuntimeActionOr(
+        "automations",
+        "setWebhookGatewayPublicUrl",
+        { args },
+        () => ipcRenderer.invoke(IPC.automationsSetWebhookGatewayPublicUrl, args),
       ),
     listIngressEvents: async (args?: {
       limit?: number;

--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -3934,6 +3934,21 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
             ],
       ),
       getIngressStatus: resolved({
+        webhookGateway: {
+          enabled: true,
+          ready: true,
+          status: "online",
+          publicUrl: "https://ade-mock.tailnet.ts.net/ade-webhooks",
+          localUrl: "http://127.0.0.1:4319/automations/webhook",
+          provider: "tailscale",
+          tailscale: {
+            available: true,
+            hostname: "ade-mock.tailnet.ts.net",
+            message: "Tailscale is available on ade-mock.tailnet.ts.net.",
+          },
+          lastCheckedAt: now,
+          lastError: null,
+        },
         githubRelay: {
           configured: true,
           healthy: true,
@@ -3950,10 +3965,41 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
           listening: true,
           status: "listening",
           url: "http://127.0.0.1:4319/automations/webhook",
+          githubUrl: "http://127.0.0.1:4319/github-webhooks",
           port: 4319,
           lastDeliveryAt: now,
           lastError: null,
         },
+      }),
+      refreshWebhookGatewayStatus: resolved({
+        enabled: true,
+        ready: true,
+        status: "online",
+        publicUrl: "https://ade-mock.tailnet.ts.net/ade-webhooks",
+        localUrl: "http://127.0.0.1:4319/automations/webhook",
+        provider: "tailscale",
+        tailscale: {
+          available: true,
+          hostname: "ade-mock.tailnet.ts.net",
+          message: "Tailscale is available on ade-mock.tailnet.ts.net.",
+        },
+        lastCheckedAt: now,
+        lastError: null,
+      }),
+      setWebhookGatewayPublicUrl: resolvedArg({
+        enabled: true,
+        ready: true,
+        status: "online",
+        publicUrl: "https://ade-mock.tailnet.ts.net/ade-webhooks",
+        localUrl: "http://127.0.0.1:4319/automations/webhook",
+        provider: "tailscale",
+        tailscale: {
+          available: true,
+          hostname: "ade-mock.tailnet.ts.net",
+          message: "Tailscale is available on ade-mock.tailnet.ts.net.",
+        },
+        lastCheckedAt: now,
+        lastError: null,
       }),
       listIngressEvents: resolvedArg(
         USE_ADE_DB_SNAPSHOT && Array.isArray(ADE_DB_AUTOMATIONS?.ingressEvents)

--- a/apps/desktop/src/renderer/components/app/TabNav.tsx
+++ b/apps/desktop/src/renderer/components/app/TabNav.tsx
@@ -188,9 +188,9 @@ export function TabNav({ githubStatus }: { githubStatus?: GitHubStatus | null })
                 )}
               />
             ) : null}
-            {it.to === "/vm" && isPackaged ? (
+            {(it.to === "/vm" || it.to === "/automations") && isPackaged ? (
               <span
-                title="Mac VM is coming soon in production builds"
+                title={`${it.label} is coming soon in production builds`}
                 className="absolute -right-2 -top-1 rounded border border-emerald-300/40 bg-emerald-400 px-1 font-mono text-[7px] font-bold uppercase leading-[10px] text-[#07110B]"
               >
                 Soon

--- a/apps/desktop/src/renderer/components/automations/ActionList.tsx
+++ b/apps/desktop/src/renderer/components/automations/ActionList.tsx
@@ -9,7 +9,7 @@ import {
   Warning,
 } from "@phosphor-icons/react";
 import type { ElementType } from "react";
-import type { ModelConfig, TestSuiteDefinition } from "../../../shared/types";
+import type { TestSuiteDefinition } from "../../../shared/types";
 import { useClickOutside } from "../../hooks/useClickOutside";
 import { cn } from "../ui/cn";
 import { ActionRow, type ActionRowKind, type ActionRowValue } from "./ActionRow";
@@ -98,18 +98,12 @@ export function ActionList({
   actions,
   lanes,
   suites,
-  fallbackModel,
-  executionLaneMode,
   onChange,
-  onOpenAiSettings,
 }: {
   actions: ActionRowValue[];
   lanes: Array<{ id: string; name: string }>;
   suites: TestSuiteDefinition[];
-  fallbackModel: ModelConfig;
-  executionLaneMode?: string | null;
   onChange: (next: ActionRowValue[]) => void;
-  onOpenAiSettings?: () => void;
 }) {
   // Stable per-row keys that survive reorders so React preserves focus/DOM
   // identity when the user clicks up/down arrows. Keys are regenerated only
@@ -164,12 +158,9 @@ export function ActionList({
               value={action}
               lanes={lanes}
               suites={suites}
-              fallbackModel={fallbackModel}
-              executionLaneMode={executionLaneMode}
               onChange={(next) => updateAction(index, next)}
               onRemove={() => removeAction(index)}
               onMove={(direction) => moveAction(index, direction)}
-              onOpenAiSettings={onOpenAiSettings}
             />
           ))}
         </div>
@@ -201,7 +192,7 @@ function AddStepBar({ onAdd }: { onAdd: (kind: ActionRowKind) => void }) {
           "group flex w-full items-center justify-between gap-2 rounded-xl border px-3 py-2.5 text-[12px] font-semibold transition-colors",
           open
             ? "border-[#5FA0E0]/50 bg-[#13263A] text-[#F5FAFF]"
-            : "border-white/[0.08] bg-black/15 text-[#D8E3F2] hover:border-[#5FA0E0]/40 hover:bg-[#13263A]/60",
+            : "border-white/[0.12] bg-[#162235] text-[#E6EEF8] hover:border-[#5FA0E0]/40 hover:bg-[#1B2A40]",
         )}
       >
         <span className="flex items-center gap-2">
@@ -217,7 +208,7 @@ function AddStepBar({ onAdd }: { onAdd: (kind: ActionRowKind) => void }) {
 
       {open ? (
         <div
-          className="absolute left-0 right-0 z-30 mt-1.5 grid gap-1 rounded-xl border border-white/[0.1] bg-[#0B121A] p-1.5 shadow-2xl"
+          className="mt-1.5 grid gap-1 rounded-xl border border-white/[0.12] bg-[#162235] p-1.5 shadow-2xl"
           role="menu"
         >
           {ADD_OPTIONS.map((option) => {
@@ -237,7 +228,7 @@ function AddStepBar({ onAdd }: { onAdd: (kind: ActionRowKind) => void }) {
                   "flex items-start gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors",
                   option.disabled
                     ? "cursor-not-allowed opacity-50"
-                    : "hover:bg-white/[0.05]",
+                    : "hover:bg-[#1E2D42]",
                 )}
               >
                 <span
@@ -259,7 +250,7 @@ function AddStepBar({ onAdd }: { onAdd: (kind: ActionRowKind) => void }) {
                       </span>
                     ) : null}
                   </span>
-                  <span className="mt-0.5 block text-[10.5px] leading-snug text-[#93A4B8]">
+                  <span className="mt-0.5 block text-[10.5px] leading-snug text-[#AFC0D4]">
                     {option.description}
                   </span>
                 </span>
@@ -274,7 +265,7 @@ function AddStepBar({ onAdd }: { onAdd: (kind: ActionRowKind) => void }) {
 
 function EmptyPicker({ onAdd }: { onAdd: (kind: ActionRowKind) => void }) {
   return (
-    <div className="rounded-xl border border-dashed border-white/[0.1] bg-black/15 p-4">
+    <div className="rounded-xl border border-dashed border-white/[0.14] bg-[#162235] p-4">
       <div className="text-[11px] font-semibold uppercase tracking-[1px] text-[#8FA1B8]">
         Pick a starting step
       </div>
@@ -286,7 +277,7 @@ function EmptyPicker({ onAdd }: { onAdd: (kind: ActionRowKind) => void }) {
               key={option.kind}
               type="button"
               onClick={() => onAdd(option.kind)}
-              className="group flex items-start gap-2.5 rounded-lg border border-white/[0.06] bg-black/20 px-3 py-2.5 text-left transition-colors hover:border-white/[0.16] hover:bg-black/30"
+              className="group flex items-start gap-2.5 rounded-lg border border-white/[0.12] bg-[#111C2B] px-3 py-2.5 text-left transition-colors hover:border-white/[0.20] hover:bg-[#1B2A40]"
             >
               <span
                 className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg"
@@ -300,7 +291,7 @@ function EmptyPicker({ onAdd }: { onAdd: (kind: ActionRowKind) => void }) {
               </span>
               <span className="min-w-0 flex-1">
                 <span className="block text-[12px] font-semibold text-[#F5FAFF]">{option.label}</span>
-                <span className="mt-0.5 block text-[10.5px] leading-snug text-[#93A4B8]">
+                <span className="mt-0.5 block text-[10.5px] leading-snug text-[#AFC0D4]">
                   {option.description}
                 </span>
               </span>

--- a/apps/desktop/src/renderer/components/automations/ActionRow.tsx
+++ b/apps/desktop/src/renderer/components/automations/ActionRow.tsx
@@ -17,8 +17,6 @@ import type {
 } from "../../../shared/types";
 import { Chip } from "../ui/Chip";
 import { cn } from "../ui/cn";
-import { ModelSelector } from "../shared/ModelSelector";
-import { permissionControlsForModel, patchPermissionConfig } from "./permissionControls";
 import { inputCls, labelCls, selectCls, textareaCls } from "./designTokens";
 import { AdeActionEditor, type AdeActionValue } from "./AdeActionEditor";
 
@@ -74,61 +72,30 @@ export function ActionRow({
   value,
   lanes,
   suites,
-  fallbackModel,
-  executionLaneMode,
   onChange,
   onRemove,
   onMove,
-  onOpenAiSettings,
 }: {
   index: number;
   total: number;
   value: ActionRowValue;
   lanes: Array<{ id: string; name: string }>;
   suites: TestSuiteDefinition[];
-  fallbackModel: ModelConfig;
-  executionLaneMode?: string | null;
   onChange: (next: ActionRowValue) => void;
   onRemove: () => void;
   onMove: (direction: -1 | 1) => void;
-  onOpenAiSettings?: () => void;
 }) {
   const meta = KIND_META[value.kind];
   const Icon = meta.icon;
-  const triggerSuppliesLane = executionLaneMode === "require-on-trigger"
-    || executionLaneMode === "provided"
-    || executionLaneMode === "prompt-at-run";
-  const activeModel = value.modelConfig ?? fallbackModel;
-  const permissionMeta = permissionControlsForModel(activeModel.modelId);
-  const currentPermission = permissionMeta
-    ? value.permissionConfig?.providers?.[permissionMeta.key] ?? ""
-    : "";
-  const patchValue = (patch: Partial<ActionRowValue>) => {
-    const next = { ...value, ...patch };
-    if ("condition" in patch && !patch.condition?.trim()) delete next.condition;
-    if ("targetLaneId" in patch && !patch.targetLaneId) delete next.targetLaneId;
-    if ("timeoutMs" in patch && patch.timeoutMs == null) delete next.timeoutMs;
-    if ("retry" in patch && patch.retry == null) delete next.retry;
-    if ("continueOnFailure" in patch && !patch.continueOnFailure) delete next.continueOnFailure;
-    onChange(next);
-  };
-  const setCodexFastMode = (enabled: boolean) => {
-    if (enabled) {
-      onChange({ ...value, codexFastMode: true });
-      return;
-    }
-    const { codexFastMode: _codexFastMode, ...rest } = value;
-    onChange(rest);
-  };
 
   return (
     <div
-      className="rounded-xl border border-white/[0.08] bg-black/20"
-      style={{ boxShadow: `inset 0 0 0 1px ${meta.accent}1f` }}
+      className="rounded-xl border border-white/[0.12] bg-[#162235]"
+      style={{ boxShadow: `inset 0 0 0 1px ${meta.accent}24, 0 10px 26px rgba(0,0,0,0.14)` }}
     >
       <div
-        className="flex items-center justify-between gap-2 rounded-t-xl border-b border-white/[0.06] px-3 py-2"
-        style={{ background: `${meta.accent}0d` }}
+        className="flex items-center justify-between gap-2 rounded-t-xl border-b border-white/[0.10] px-3 py-2"
+        style={{ background: `linear-gradient(90deg, ${meta.accent}14, rgba(28,43,64,0.82))` }}
       >
         <div className="flex min-w-0 items-center gap-2">
           <span
@@ -141,7 +108,7 @@ export function ActionRow({
           >
             <Icon size={12} weight="fill" />
           </span>
-          <span className="text-[10px] font-bold tracking-wider text-[#7E8A9A]">
+          <span className="text-[10px] font-bold tracking-wider text-[#AFC0D4]">
             STEP {index + 1}
           </span>
           <span className="text-[12px] font-semibold text-[#F5FAFF]">{meta.label}</span>
@@ -216,55 +183,6 @@ export function ActionRow({
 
         {value.kind === "agent-session" ? (
           <div className="space-y-2">
-            {/* Per-action lane override removed — every action inherits the
-                rule's EXECUTION lane setting. Model + Permissions remain
-                here as overrides since users do legitimately want different
-                models per step in a multi-step pipeline. */}
-            <div className="grid gap-2 md:grid-cols-[1.2fr_1fr]">
-              <div className="min-w-0 space-y-1.5">
-                <div className="flex items-center justify-between gap-2">
-                  <div className={labelCls}>Model</div>
-                  {value.modelConfig ? (
-                    <button
-                      type="button"
-                      className="text-[10px] text-muted-fg/60 transition-colors hover:text-fg"
-                      onClick={() => onChange({ ...value, modelConfig: undefined })}
-                    >
-                      Use rule
-                    </button>
-                  ) : null}
-                </div>
-                <ModelSelector
-                  value={activeModel}
-                  onChange={(modelConfig) => onChange({ ...value, modelConfig })}
-                  compact
-                  onOpenAiSettings={onOpenAiSettings}
-                  fastModeActive={value.codexFastMode === true}
-                  onFastModeToggle={setCodexFastMode}
-                />
-              </div>
-              <label className="block space-y-1.5">
-                <div className={labelCls}>Permissions</div>
-                <select
-                  className={selectCls}
-                  value={currentPermission}
-                  onChange={(event) =>
-                    onChange({
-                      ...value,
-                      permissionConfig: patchPermissionConfig(value.permissionConfig, activeModel.modelId, event.target.value),
-                    })
-                  }
-                  disabled={!permissionMeta}
-                >
-                  <option value="">Rule permissions</option>
-                  {permissionMeta?.options.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            </div>
             <input
               className={inputCls}
               value={value.sessionTitle ?? ""}
@@ -272,7 +190,7 @@ export function ActionRow({
               placeholder="Thread title (optional)"
             />
             <textarea
-              className={cn(textareaCls, "min-h-[72px] font-mono text-[11px]")}
+              className={cn(textareaCls, "min-h-[112px] text-[12px] leading-relaxed")}
               value={value.prompt ?? ""}
               onChange={(event) => onChange({ ...value, prompt: event.target.value })}
               placeholder="Prompt for the agent session"
@@ -327,183 +245,11 @@ export function ActionRow({
         ) : null}
 
         {value.kind === "predict-conflicts" ? (
-          <div className="text-[11px] leading-relaxed text-[#93A4B8]">
+          <div className="text-[11px] leading-relaxed text-[#AFC0D4]">
             Runs the built-in conflict prediction pass against recent lanes. No configuration required.
           </div>
         ) : null}
-
-        {value.kind !== "create-lane" ? (
-          <RuntimeControls
-            value={value}
-            lanes={lanes}
-            showLaneOverride={supportsLaneOverride(value.kind)}
-            triggerSuppliesLane={triggerSuppliesLane}
-            onChange={patchValue}
-          />
-        ) : null}
       </div>
-    </div>
-  );
-}
-
-function supportsLaneOverride(kind: ActionRowKind): boolean {
-  return kind === "agent-session"
-    || kind === "run-tests"
-    || kind === "run-command"
-    || kind === "predict-conflicts";
-}
-
-function secondsFromMs(ms: number | undefined): number | "" {
-  if (!Number.isFinite(ms)) return "";
-  return Math.max(1, Math.round((ms ?? 0) / 1000));
-}
-
-function RuntimeControls({
-  value,
-  lanes,
-  showLaneOverride,
-  triggerSuppliesLane,
-  onChange,
-}: {
-  value: ActionRowValue;
-  lanes: Array<{ id: string; name: string }>;
-  showLaneOverride: boolean;
-  triggerSuppliesLane: boolean;
-  onChange: (patch: Partial<ActionRowValue>) => void;
-}) {
-  const condition = value.condition?.trim() ?? "";
-  const conditionMode =
-    condition === ""
-      ? "always"
-      : condition === "provider-enabled"
-        ? "provider-enabled"
-        : condition === "false"
-          ? "false"
-          : "custom";
-  const sortedLanes = [...lanes].sort((a, b) => a.name.localeCompare(b.name));
-
-  return (
-    <div className="mt-3 border-t border-white/[0.06] pt-3">
-      <div className="mb-2 flex items-center justify-between gap-2">
-        <div className={labelCls}>Runtime</div>
-        <div className="text-[10px] text-[#7E8A9A]">Controls how this step runs</div>
-      </div>
-      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
-        <label className="block space-y-1.5">
-          <div className={labelCls}>Condition</div>
-          <select
-            className={selectCls}
-            value={conditionMode}
-            onChange={(event) => {
-              const next = event.target.value;
-              if (next === "always") onChange({ condition: undefined });
-              else if (next === "provider-enabled") onChange({ condition: "provider-enabled" });
-              else if (next === "false") onChange({ condition: "false" });
-              else onChange({ condition: condition || "provider-enabled" });
-            }}
-          >
-            <option value="always">Always run</option>
-            <option value="provider-enabled">Only when providers are enabled</option>
-            <option value="false">Always skip</option>
-            <option value="custom">Stored expression</option>
-          </select>
-        </label>
-
-        <label className="block space-y-1.5">
-          <div className={labelCls}>On failure</div>
-          <select
-            className={selectCls}
-            value={value.continueOnFailure ? "continue" : "stop"}
-            onChange={(event) => onChange({ continueOnFailure: event.target.value === "continue" })}
-          >
-            <option value="stop">Stop workflow</option>
-            <option value="continue">Continue to next step</option>
-          </select>
-        </label>
-
-        <label className="block space-y-1.5">
-          <div className={labelCls}>Timeout (sec)</div>
-          <input
-            className={inputCls}
-            type="number"
-            min={1}
-            value={secondsFromMs(value.timeoutMs)}
-            onChange={(event) => {
-              const raw = event.target.value.trim();
-              if (!raw) {
-                onChange({ timeoutMs: undefined });
-                return;
-              }
-              const parsed = Number(raw);
-              onChange({ timeoutMs: Number.isFinite(parsed) ? Math.max(1, Math.floor(parsed)) * 1000 : undefined });
-            }}
-            placeholder="Default"
-          />
-        </label>
-
-        <label className="block space-y-1.5">
-          <div className={labelCls}>Retries</div>
-          <input
-            className={inputCls}
-            type="number"
-            min={0}
-            max={5}
-            value={Number.isFinite(value.retry) ? value.retry : ""}
-            onChange={(event) => {
-              const raw = event.target.value.trim();
-              if (!raw) {
-                onChange({ retry: undefined });
-                return;
-              }
-              const parsed = Number(raw);
-              onChange({ retry: Number.isFinite(parsed) ? Math.max(0, Math.min(5, Math.floor(parsed))) : undefined });
-            }}
-            placeholder="0"
-          />
-        </label>
-      </div>
-
-      {conditionMode === "custom" ? (
-        <label className="mt-2 block space-y-1.5">
-          <div className={labelCls}>Stored condition</div>
-          <input
-            className={inputCls}
-            value={value.condition ?? ""}
-            onChange={(event) => onChange({ condition: event.target.value })}
-            placeholder="provider-enabled"
-          />
-          <div className="text-[10px] leading-snug text-[#7E8A9A]">
-            Runtime currently treats <span className="font-mono text-[#A7B7CA]">false</span> and{" "}
-            <span className="font-mono text-[#A7B7CA]">provider-enabled</span> specially.
-          </div>
-        </label>
-      ) : null}
-
-      {triggerSuppliesLane ? (
-        <div className="mt-2 rounded-md border border-[#2DD4BF]/20 bg-[#2DD4BF]/[0.06] px-2.5 py-2 text-[10.5px] leading-snug text-[#9BE7D8]">
-          This rule uses the lane supplied at run time for every step. Saved step lane overrides are ignored and removed on save.
-        </div>
-      ) : showLaneOverride ? (
-        <label className="mt-2 block space-y-1.5">
-          <div className={labelCls}>Lane override</div>
-          <select
-            className={selectCls}
-            value={value.targetLaneId ?? ""}
-            onChange={(event) => onChange({ targetLaneId: event.target.value || null })}
-          >
-            <option value="">Use execution lane</option>
-            {sortedLanes.map((lane) => (
-              <option key={lane.id} value={lane.id}>
-                {lane.name}
-              </option>
-            ))}
-          </select>
-        </label>
-      ) : value.targetLaneId ? (
-        <div className="mt-2 rounded-md border border-warning/20 bg-warning/[0.06] px-2.5 py-2 text-[10.5px] text-warning">
-          This saved step has a lane override, but this action type does not use it at runtime.
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/automations/AdeActionEditor.tsx
+++ b/apps/desktop/src/renderer/components/automations/AdeActionEditor.tsx
@@ -9,6 +9,7 @@ import {
 } from "@phosphor-icons/react";
 import { useClickOutside } from "../../hooks/useClickOutside";
 import { cn } from "../ui/cn";
+import { textareaCls } from "./designTokens";
 import { INPUT_CLS, INPUT_STYLE } from "./shared";
 import {
   ADE_ACTION_SCHEMAS,
@@ -109,7 +110,7 @@ export function AdeActionEditor({
           onToggleJson={() => setShowJson((current) => !current)}
         />
       ) : (
-        <div className="rounded-lg border border-white/[0.06] bg-black/15 px-3 py-3 text-[11px] text-[#93A4B8]">
+        <div className="rounded-lg border border-white/[0.12] bg-[#111C2B] px-3 py-3 text-[11px] text-[#AFC0D4]">
           Pick a domain and action to fill in its parameters.
         </div>
       )}
@@ -187,12 +188,12 @@ function ActionPicker({
     <span className="flex items-center gap-2 truncate">
       <Code size={12} weight="bold" className="text-[#A78BFA]" />
       <span className="truncate text-[12px] font-semibold text-[#F5FAFF]">{currentLabel}</span>
-      <span className="truncate text-[11px] text-[#93A4B8]">
+      <span className="truncate text-[11px] text-[#AFC0D4]">
         {value.domain}.{value.action}
       </span>
     </span>
   ) : (
-    <span className="flex items-center gap-2 text-[12px] text-[#93A4B8]">
+    <span className="flex items-center gap-2 text-[12px] text-[#AFC0D4]">
       <MagnifyingGlass size={12} weight="bold" />
       Search ADE actions…
     </span>
@@ -206,8 +207,8 @@ function ActionPicker({
         className={cn(
           "flex w-full items-center justify-between gap-2 rounded-lg border px-3 py-2 transition-colors",
           open
-            ? "border-[#A78BFA]/40 bg-[#1a1830]"
-            : "border-white/[0.08] bg-black/20 hover:border-white/[0.16]",
+            ? "border-[#A78BFA]/45 bg-[#1B2A40]"
+            : "border-white/[0.12] bg-[#111C2B] hover:border-white/[0.20] hover:bg-[#152235]",
         )}
       >
         {summary}
@@ -219,15 +220,15 @@ function ActionPicker({
       </button>
 
       {open ? (
-        <div className="absolute left-0 right-0 z-30 mt-1.5 max-h-[420px] overflow-hidden rounded-xl border border-white/[0.1] bg-[#0B121A] shadow-2xl">
-          <div className="flex items-center gap-2 border-b border-white/[0.06] bg-[#101926] px-2.5 py-2">
+        <div className="absolute left-0 right-0 z-30 mt-1.5 max-h-[420px] overflow-hidden rounded-xl border border-white/[0.12] bg-[#162235] shadow-2xl">
+          <div className="flex items-center gap-2 border-b border-white/[0.10] bg-[#1B2A40] px-2.5 py-2">
             <MagnifyingGlass size={11} weight="bold" className="text-[#8FA1B8]" />
             <input
               autoFocus
               value={search}
               onChange={(event) => setSearch(event.target.value)}
               placeholder="Search by domain, action, or description"
-              className="flex-1 bg-transparent text-[12px] text-[#F5FAFF] placeholder:text-[#7E8A9A] focus:outline-none"
+              className="flex-1 bg-transparent text-[12px] text-[#F5FAFF] placeholder:text-[#94A3B8] focus:outline-none"
             />
             {search ? (
               <button
@@ -241,7 +242,7 @@ function ActionPicker({
           </div>
           <div className="max-h-[360px] overflow-y-auto p-1">
             {grouped.length === 0 ? (
-              <div className="px-3 py-4 text-center text-[11px] text-[#7E8A9A]">
+              <div className="px-3 py-4 text-center text-[11px] text-[#AFC0D4]">
                 No actions match "{search}".
               </div>
             ) : (
@@ -263,17 +264,17 @@ function ActionPicker({
                         }}
                         className={cn(
                           "flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left",
-                          active ? "bg-[#A78BFA]/15" : "hover:bg-white/[0.04]",
+                          active ? "bg-[#A78BFA]/15" : "hover:bg-[#1E2D42]",
                         )}
                       >
                         <span className="mt-0.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-[#A78BFA]" />
                         <span className="min-w-0 flex-1">
                           <span className="flex items-center gap-1.5">
                             <span className="text-[12px] font-medium text-[#F5FAFF]">{item.label}</span>
-                            <span className="text-[10px] text-[#7E8A9A]">{item.action}</span>
+                            <span className="text-[10px] text-[#AFC0D4]">{item.action}</span>
                           </span>
                           {item.description ? (
-                            <span className="mt-0.5 block text-[10.5px] leading-snug text-[#93A4B8]">
+                            <span className="mt-0.5 block text-[10.5px] leading-snug text-[#AFC0D4]">
                               {item.description}
                             </span>
                           ) : null}
@@ -352,11 +353,11 @@ function ActionParamsEditor({
           </div>
         </>
       ) : (
-        <div className="rounded-lg border border-white/[0.06] bg-black/15 px-3 py-2.5 text-[11px] text-[#93A4B8]">
+        <div className="rounded-lg border border-white/[0.12] bg-[#111C2B] px-3 py-2.5 text-[11px] text-[#AFC0D4]">
           <span className="block text-[#D8E3F2]">
             {schema?.description ?? "No structured form for this action yet."}
           </span>
-          <span className="mt-1 block text-[#7E8A9A]">Pass arguments as JSON below.</span>
+          <span className="mt-1 block text-[#AFC0D4]">Pass arguments as JSON below.</span>
         </div>
       )}
 
@@ -367,7 +368,7 @@ function ActionParamsEditor({
       ) : null}
 
       {schema ? (
-        <div className="flex items-center gap-1.5 text-[10px] text-[#7E8A9A]">
+        <div className="flex items-center gap-1.5 text-[10px] text-[#AFC0D4]">
           <ArrowSquareOut size={10} weight="bold" />
           Maps to <span className="font-mono text-[#9FB2C7]">ade {value.domain} {value.action}</span>
         </div>
@@ -392,7 +393,7 @@ function ParamField({
         {param.required ? <span className="ml-0.5 text-[#F472B6]">*</span> : null}
       </span>
       {param.description ? (
-        <span className="ml-2 truncate text-[10px] text-[#7E8A9A]" title={param.description}>
+        <span className="ml-2 truncate text-[10px] text-[#AFC0D4]" title={param.description}>
           {param.description}
         </span>
       ) : null}
@@ -402,14 +403,14 @@ function ParamField({
   if (param.type === "boolean") {
     const checked = value === true;
     return (
-      <label className="flex cursor-pointer items-center justify-between rounded-md border border-white/[0.06] bg-black/15 px-3 py-2 text-[11px] text-[#D8E3F2] hover:border-white/[0.12]">
+      <label className="flex cursor-pointer items-center justify-between rounded-md border border-white/[0.12] bg-[#111C2B] px-3 py-2 text-[11px] text-[#D8E3F2] hover:border-white/[0.20]">
         <span className="min-w-0 flex-1">
           <span className="block text-[10.5px] font-semibold text-[#D8E3F2]">
             {param.name}
             {param.required ? <span className="ml-0.5 text-[#F472B6]">*</span> : null}
           </span>
           {param.description ? (
-            <span className="mt-0.5 block text-[10px] text-[#7E8A9A]">{param.description}</span>
+            <span className="mt-0.5 block text-[10px] text-[#AFC0D4]">{param.description}</span>
           ) : null}
         </span>
         <input
@@ -502,8 +503,7 @@ function ParamField({
       <label className="block space-y-1">
         {labelEl}
         <textarea
-          className="min-h-[60px] w-full rounded-md px-3 py-2 font-mono text-[11px] text-[#F5F7FA] placeholder:text-[#7E8A9A]"
-          style={INPUT_STYLE}
+          className={cn(textareaCls, "min-h-[60px] font-mono text-[11px]")}
           value={current}
           placeholder={param.placeholder ?? '{ "key": "value" }'}
           onChange={(event) => {
@@ -548,7 +548,7 @@ function PlaceholderRow() {
     }
   };
   return (
-    <details className="rounded-md border border-white/[0.06] bg-black/15 px-2.5 py-1.5 text-[10px]">
+    <details className="rounded-md border border-white/[0.12] bg-[#111C2B] px-2.5 py-1.5 text-[10px]">
       <summary className="cursor-pointer text-[10px] uppercase tracking-[1px] text-[#8FA1B8] hover:text-[#D8E3F2]">
         Trigger variables — click to copy
       </summary>
@@ -624,8 +624,7 @@ function JsonArgsEditor({
         ) : null}
       </div>
       <textarea
-        className="min-h-[80px] w-full rounded-md px-3 py-2 font-mono text-[11px] text-[#F5F7FA] placeholder:text-[#7E8A9A]"
-        style={INPUT_STYLE}
+        className={cn(textareaCls, "min-h-[80px] font-mono text-[11px]")}
         value={text}
         onChange={(event) => commit(event.target.value)}
         placeholder='{ "labels": ["triage"] }'

--- a/apps/desktop/src/renderer/components/automations/AutomationsComingSoon.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsComingSoon.tsx
@@ -1,0 +1,73 @@
+import { useNavigate } from "react-router-dom";
+import { ArrowRight, GitBranch, Robot, Sparkle } from "@phosphor-icons/react";
+
+const PREVIEW_ITEMS = [
+  {
+    icon: GitBranch,
+    title: "Linear and GitHub triggers",
+    body: "External-event automations need a production-ready delivery path before they ship.",
+  },
+  {
+    icon: Robot,
+    title: "Short agent workflows",
+    body: "The goal is a compact flow: trigger, prompt, action, and result without heavy setup.",
+  },
+  {
+    icon: Sparkle,
+    title: "Internal testing only",
+    body: "Dev builds keep the prototype available while packaged builds stay honest.",
+  },
+] as const;
+
+export function ProductionAutomationsComingSoon() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto bg-[#0D0F12] text-[#F6F8FA]">
+      <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col justify-center gap-8 px-6 py-12">
+        <section className="flex max-w-2xl flex-col gap-4">
+          <span className="inline-flex w-fit items-center gap-2 rounded-md border border-cyan-300/30 bg-cyan-300/10 px-2.5 py-1 font-mono text-[10px] font-bold uppercase tracking-[1px] text-cyan-100">
+            <span className="h-1.5 w-1.5 rounded-full bg-cyan-300" aria-hidden />
+            Coming soon
+          </span>
+          <div>
+            <h1 className="text-[26px] font-semibold leading-tight text-[#F6F8FA]">
+              Automations are paused in production.
+            </h1>
+            <p className="mt-3 max-w-[58ch] text-[13px] leading-6 text-[#9EA7B3]">
+              The prototype is still available in dev builds, but packaged ADE
+              will not expose automation triggers, webhook ingress, or agent
+              automation commands until the delivery path is real.
+            </p>
+          </div>
+        </section>
+
+        <div className="grid gap-3 md:grid-cols-3">
+          {PREVIEW_ITEMS.map(({ icon: Icon, title, body }) => (
+            <article key={title} className="rounded-lg border border-white/[0.08] bg-white/[0.035] p-4">
+              <div className="mb-3 flex h-8 w-8 items-center justify-center rounded-md border border-cyan-300/25 bg-cyan-300/10 text-cyan-200">
+                <Icon size={15} weight="duotone" />
+              </div>
+              <div className="text-[13px] font-semibold text-[#F6F8FA]">{title}</div>
+              <p className="mt-1 text-[12px] leading-5 text-[#9EA7B3]">{body}</p>
+            </article>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={() => navigate("/lanes")}
+            className="inline-flex h-9 items-center gap-2 rounded-md bg-cyan-300 px-4 font-mono text-[10px] font-bold uppercase tracking-[1px] text-[#081116] transition active:scale-[0.98]"
+          >
+            Open lanes
+            <ArrowRight size={13} weight="bold" />
+          </button>
+          <span className="text-[11px] text-[#7D8794]">
+            Use lanes, PRs, Linear sync, and proof flows while Automations bakes.
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
@@ -1,7 +1,65 @@
-import { useEffect, useState } from "react";
+import { type ReactElement, useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import type { AutomationRuleDraft } from "../../../shared/types";
 import { RulesTab } from "./RulesTab";
+import { ProductionAutomationsComingSoon } from "./AutomationsComingSoon";
+
+type AppPackagingState = "checking" | "packaged" | "dev";
+
+function useAppPackagingState(): AppPackagingState {
+  const [state, setState] = useState<AppPackagingState>("checking");
+
+  useEffect(() => {
+    let cancelled = false;
+    let probe: Promise<{ isPackaged: boolean }> | null = null;
+    try {
+      const getInfo = window.ade?.app?.getInfo;
+      probe = typeof getInfo === "function" ? getInfo() : null;
+    } catch {
+      probe = null;
+    }
+    if (!probe) {
+      setState("dev");
+      return () => {
+        cancelled = true;
+      };
+    }
+    probe.then(
+      (info) => {
+        if (!cancelled) setState(info.isPackaged ? "packaged" : "dev");
+      },
+      () => {
+        if (!cancelled) setState("dev");
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return state;
+}
+
+export function AutomationsProductionGate({ children }: { children: ReactElement }) {
+  const state = useAppPackagingState();
+
+  if (state === "checking") {
+    return (
+      <div className="flex h-full min-w-0 flex-col bg-[#0D0F12]">
+        <div className="flex flex-1 flex-col items-center justify-center gap-3">
+          <div className="h-4 w-48 animate-pulse rounded-md bg-white/[0.06]" />
+          <div className="font-mono text-[10px] font-bold uppercase tracking-[1px] text-[#7D8794]">
+            Checking automation availability...
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (state === "packaged") return <ProductionAutomationsComingSoon />;
+
+  return children;
+}
 
 export function AutomationsPage({ active = true }: { active?: boolean } = {}) {
   const navigate = useNavigate();
@@ -24,15 +82,17 @@ export function AutomationsPage({ active = true }: { active?: boolean } = {}) {
   }, [active, location.pathname, location.state, navigate]);
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden bg-bg text-fg" data-testid="automations-page">
-      <div className="flex-1 min-h-0 overflow-hidden">
-        <RulesTab
-          active={active}
-          pendingDraft={pendingDraft}
-          onDraftConsumed={() => setPendingDraft(null)}
-          onOpenTemplates={() => navigate("/automations/templates")}
-        />
+    <AutomationsProductionGate>
+      <div className="flex h-full w-full flex-col overflow-hidden bg-bg text-fg" data-testid="automations-page">
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <RulesTab
+            active={active}
+            pendingDraft={pendingDraft}
+            onDraftConsumed={() => setPendingDraft(null)}
+            onOpenTemplates={() => navigate("/automations/templates")}
+          />
+        </div>
       </div>
-    </div>
+    </AutomationsProductionGate>
   );
 }

--- a/apps/desktop/src/renderer/components/automations/AutomationsTemplatesPage.tsx
+++ b/apps/desktop/src/renderer/components/automations/AutomationsTemplatesPage.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { ArrowLeft } from "@phosphor-icons/react";
 import type { AutomationRuleDraft } from "../../../shared/types";
 import { Button } from "../ui/Button";
+import { AutomationsProductionGate } from "./AutomationsPage";
 import { TemplatesTab } from "./TemplatesTab";
 
 export function AutomationsTemplatesPage({ active = true }: { active?: boolean } = {}) {
@@ -9,25 +10,27 @@ export function AutomationsTemplatesPage({ active = true }: { active?: boolean }
   void active;
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden bg-bg text-fg" data-testid="automations-templates-page">
-      <div
-        className="shrink-0 flex items-center gap-3 border-b border-white/[0.06] bg-white/[0.02] px-4"
-        style={{ minHeight: 40 }}
-      >
-        <Button size="sm" variant="ghost" onClick={() => navigate("/automations")}>
-          <ArrowLeft size={12} weight="regular" />
-          Back to automations
-        </Button>
-        <div className="text-sm font-semibold text-[#F5FAFF]">Templates</div>
-      </div>
+    <AutomationsProductionGate>
+      <div className="flex h-full w-full flex-col overflow-hidden bg-bg text-fg" data-testid="automations-templates-page">
+        <div
+          className="shrink-0 flex items-center gap-3 border-b border-white/[0.06] bg-white/[0.02] px-4"
+          style={{ minHeight: 40 }}
+        >
+          <Button size="sm" variant="ghost" onClick={() => navigate("/automations")}>
+            <ArrowLeft size={12} weight="regular" />
+            Back to automations
+          </Button>
+          <div className="text-sm font-semibold text-[#F5FAFF]">Templates</div>
+        </div>
 
-      <div className="flex-1 min-h-0 overflow-hidden">
-        <TemplatesTab
-          onUseTemplate={(draft) => {
-            navigate("/automations", { state: { draft: draft as AutomationRuleDraft } });
-          }}
-        />
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <TemplatesTab
+            onUseTemplate={(draft) => {
+              navigate("/automations", { state: { draft: draft as AutomationRuleDraft } });
+            }}
+          />
+        </div>
       </div>
-    </div>
+    </AutomationsProductionGate>
   );
 }

--- a/apps/desktop/src/renderer/components/automations/RulesTab.tsx
+++ b/apps/desktop/src/renderer/components/automations/RulesTab.tsx
@@ -14,11 +14,13 @@ import type {
   AutomationAction,
   AutomationDraftConfirmationRequirement,
   AutomationDraftIssue,
+  AutomationIngressStatus,
   AutomationRuleDraft,
   AutomationRuleSummary,
   LaneSummary,
   TestSuiteDefinition,
 } from "../../../shared/types";
+import { isWebhookGatewayTriggerType } from "../../../shared/types";
 import { Button } from "../ui/Button";
 import { Chip } from "../ui/Chip";
 import { cn } from "../ui/cn";
@@ -174,8 +176,14 @@ function modeSummary(rule: AutomationRuleSummary): string {
   return [rule.mode, rule.reviewProfile, rule.modelConfig?.modelId ?? null].filter(Boolean).join(" · ");
 }
 
+function ruleNeedsWebhookGateway(rule: Pick<AutomationRuleSummary, "triggers" | "trigger">): boolean {
+  const triggers = rule.triggers.length ? rule.triggers : rule.trigger ? [rule.trigger] : [];
+  return triggers.some((trigger) => isWebhookGatewayTriggerType(trigger.type));
+}
+
 function RuleListRow({
   rule,
+  webhookGatewayReady,
   selected,
   onSelect,
   onToggle,
@@ -184,6 +192,7 @@ function RuleListRow({
   onDelete,
 }: {
   rule: AutomationRuleSummary;
+  webhookGatewayReady: boolean;
   selected: boolean;
   onSelect: () => void;
   onToggle: (enabled: boolean) => void;
@@ -191,6 +200,7 @@ function RuleListRow({
   onRunNow: () => void;
   onDelete: () => void;
 }) {
+  const waitingForGateway = rule.enabled && ruleNeedsWebhookGateway(rule) && !webhookGatewayReady;
   return (
     <div
       role="button"
@@ -205,8 +215,8 @@ function RuleListRow({
       className={cn(
         "group w-full cursor-pointer rounded-xl border px-3 py-3 text-left transition-colors focus:outline-none focus:ring-1 focus:ring-[#7DD3FC]/45",
         selected
-          ? "border-[#7DD3FC]/35 bg-[#13263A]"
-          : "border-white/[0.08] bg-black/15 hover:border-white/[0.14]",
+          ? "border-[#7DD3FC]/45 bg-[#17304A]"
+          : "border-white/[0.12] bg-[#162235] hover:border-white/[0.20] hover:bg-[#1B2A40]",
       )}
     >
       <div className="flex items-start justify-between gap-3">
@@ -216,6 +226,11 @@ function RuleListRow({
             <Chip className={cn("text-[9px]", statusTone(rule.running ? "running" : rule.lastRunStatus))}>
               {rule.running ? "running" : rule.lastRunStatus ?? "idle"}
             </Chip>
+            {waitingForGateway ? (
+              <Chip className="border-amber-300/25 bg-amber-300/10 text-[9px] text-amber-100">
+                needs gateway
+              </Chip>
+            ) : null}
           </div>
           <div className="mt-2 flex flex-wrap items-center gap-2">
             <Chip className="text-[9px]">{primaryTriggerLabel(rule)}</Chip>
@@ -234,8 +249,8 @@ function RuleListRow({
               </button>
             ) : null}
           </div>
-          <div className="mt-2 text-[11px] text-muted-fg/70">{modeSummary(rule)}</div>
-          <div className="mt-1 text-[11px] text-muted-fg/50">
+          <div className="mt-2 text-[11px] text-[#AFC0D4]">{modeSummary(rule)}</div>
+          <div className="mt-1 text-[11px] text-[#94A3B8]">
             Next {formatDate(rule.nextRunAt, "on demand")} · Last {formatDate(rule.lastRunAt, "never")}
           </div>
         </div>
@@ -297,6 +312,17 @@ function RuleListRow({
 
 type DetailView = "editor" | "history";
 
+function draftWithCreateLaneMode(source: AutomationRuleDraft): AutomationRuleDraft {
+  const execution = source.execution ?? { kind: "agent-session" as const, session: {} };
+  const nextExecution = {
+    ...execution,
+    laneMode: "create" as const,
+    laneNamePreset: execution.laneNamePreset ?? ("issue-title" as const),
+  };
+  delete (nextExecution as { targetLaneId?: string | null }).targetLaneId;
+  return { ...source, execution: nextExecution };
+}
+
 export function RulesTab({
   active = true,
   pendingDraft,
@@ -312,9 +338,11 @@ export function RulesTab({
   const [rules, setRules] = useState<AutomationRuleSummary[]>([]);
   const [lanes, setLanes] = useState<LaneSummary[]>([]);
   const [suites, setSuites] = useState<TestSuiteDefinition[]>([]);
+  const [ingressStatus, setIngressStatus] = useState<AutomationIngressStatus | null>(null);
   const [selectedRuleId, setSelectedRuleId] = useState<string | null>(null);
   const [draft, setDraft] = useState<AutomationRuleDraft | null>(null);
   const [issues, setIssues] = useState<AutomationDraftIssue[]>([]);
+  const [simulationNotes, setSimulationNotes] = useState<string[]>([]);
   const [requiredConfirmations, setRequiredConfirmations] = useState<AutomationDraftConfirmationRequirement[]>([]);
   const [acceptedConfirmations, setAcceptedConfirmations] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState("");
@@ -346,6 +374,7 @@ export function RulesTab({
       try {
         setDraft(JSON.parse(savedSnapshotRef.current) as AutomationRuleDraft);
         setIssues([]);
+        setSimulationNotes([]);
       } catch {
         // Snapshot was malformed — leave the draft as-is rather than crashing.
       }
@@ -357,15 +386,17 @@ export function RulesTab({
     setLoading(true);
     setError(null);
     try {
-      const [nextRules, nextSuites, nextLanes, snapshot] = await Promise.all([
+      const [nextRules, nextSuites, nextLanes, nextIngressStatus, snapshot] = await Promise.all([
         window.ade.automations.list(),
         window.ade.tests.listSuites(),
         window.ade.lanes.list({ includeArchived: false, includeStatus: false }),
+        window.ade.automations.getIngressStatus(),
         window.ade.projectConfig.get(),
       ]);
       setRules(nextRules);
       setSuites(nextSuites);
       setLanes(nextLanes);
+      setIngressStatus(nextIngressStatus);
       setConfigTrustRequired(Boolean(snapshot.trust.requiresSharedTrust));
       setSelectedRuleId((current) => {
         if (current && nextRules.some((rule) => rule.id === current)) return current;
@@ -404,6 +435,7 @@ export function RulesTab({
     // isDirty stays false until the user edits.
     savedSnapshotRef.current = JSON.stringify(pendingDraft);
     setIssues([]);
+    setSimulationNotes([]);
     setRequiredConfirmations([]);
     setAcceptedConfirmations(new Set());
     onDraftConsumed();
@@ -417,6 +449,7 @@ export function RulesTab({
     setDraft(nextDraft);
     savedSnapshotRef.current = JSON.stringify(nextDraft);
     setIssues([]);
+    setSimulationNotes([]);
     setRequiredConfirmations([]);
     setAcceptedConfirmations(new Set());
   }, [rules, selectedRuleId]);
@@ -442,6 +475,7 @@ export function RulesTab({
       confirmations: [...acceptedConfirmations],
     });
     setIssues(result.issues);
+    setSimulationNotes([]);
     setRequiredConfirmations(result.requiredConfirmations);
     return result;
   }, [acceptedConfirmations]);
@@ -464,6 +498,7 @@ export function RulesTab({
       setDraft(nextDraft);
       savedSnapshotRef.current = JSON.stringify(nextDraft);
       setIssues([]);
+      setSimulationNotes([]);
     } catch (err) {
       setError(extractError(err));
     } finally {
@@ -478,15 +513,13 @@ export function RulesTab({
     try {
       const result = await window.ade.automations.simulate({ draft });
       setIssues(result.issues);
-      if (!result.issues.length) {
-        setIssues([
-          {
-            level: "warning",
-            path: "simulate",
-            message: result.notes.join(" · ") || "Simulation completed with no blocking issues.",
-          },
-        ]);
-      }
+      setSimulationNotes(
+        result.issues.length
+          ? []
+          : result.notes.length
+            ? result.notes
+            : ["Simulation completed with no blocking issues."],
+      );
     } catch (err) {
       setError(extractError(err));
     } finally {
@@ -501,6 +534,7 @@ export function RulesTab({
     setDraft(blank);
     savedSnapshotRef.current = JSON.stringify(blank);
     setIssues([]);
+    setSimulationNotes([]);
     setRequiredConfirmations([]);
     setAcceptedConfirmations(new Set());
     setDetailView("editor");
@@ -556,12 +590,12 @@ export function RulesTab({
       transition={{ duration: 0.18 }}
       className="flex h-full min-h-0"
     >
-      <div className="flex min-h-0 w-[360px] shrink-0 flex-col border-r border-white/[0.06] bg-black/10">
-        <div className="shrink-0 border-b border-white/[0.06] px-4 py-4">
+      <div className="flex min-h-0 w-[360px] shrink-0 flex-col border-r border-white/[0.10] bg-[#101826]">
+        <div className="shrink-0 border-b border-white/[0.10] px-4 py-4">
           <div className="flex items-start justify-between gap-3">
             <div>
               <div className="text-[15px] font-semibold text-[#F5FAFF]">Rules</div>
-              <div className="mt-1 text-sm text-[#93A4B8]">
+              <div className="mt-1 text-sm text-[#AFC0D4]">
                 Build time-based or action-based automations. This screen only covers rules, execution, and history.
               </div>
             </div>
@@ -618,6 +652,7 @@ export function RulesTab({
                 <RuleListRow
                   key={rule.id}
                   rule={rule}
+                  webhookGatewayReady={ingressStatus?.webhookGateway.ready === true}
                   selected={rule.id === selectedRuleId}
                   onSelect={() => {
                     if (rule.id !== selectedRuleId && !confirmDiscardIfDirty()) return;
@@ -644,7 +679,7 @@ export function RulesTab({
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {selectedRule ? (
           <div
-            className="shrink-0 flex items-center gap-0 border-b border-white/[0.06] bg-white/[0.02] px-3"
+            className="shrink-0 flex items-center gap-0 border-b border-white/[0.10] bg-[#111C2B] px-3"
             style={{ minHeight: 36 }}
           >
             <DetailTab
@@ -673,7 +708,9 @@ export function RulesTab({
               setDraft={setDraft}
               lanes={lanes.map((lane) => ({ id: lane.id, name: lane.name }))}
               suites={suites}
+              ingressStatus={ingressStatus}
               issues={issues}
+              simulationNotes={simulationNotes}
               requiredConfirmations={requiredConfirmations}
               acceptedConfirmations={acceptedConfirmations}
               onToggleConfirmation={(key, checked) => {
@@ -693,7 +730,7 @@ export function RulesTab({
             <div className="flex h-full items-center justify-center px-6">
               <div className={cn(cardCls, "max-w-md text-center")}>
                 <div className="text-[17px] font-semibold text-fg">Create an automation</div>
-                <div className="mt-2 text-sm leading-relaxed text-muted-fg/70">
+                <div className="mt-2 text-sm leading-relaxed text-[#AFC0D4]">
                   Start with a schedule or a product event, then tell ADE whether it should run a built-in task or send a prompt to an automation chat thread.
                 </div>
                 <div className="mt-4 flex justify-center gap-2">
@@ -719,9 +756,9 @@ export function RulesTab({
       </div>
       {manualRunRule ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4">
-          <div className="w-full max-w-md rounded-xl border border-white/[0.12] bg-[#0B121A] p-4 shadow-2xl">
+          <div className="w-full max-w-md rounded-xl border border-white/[0.12] bg-[#162235] p-4 shadow-2xl">
             <div className="text-sm font-semibold text-[#F5FAFF]">Select lane for this run</div>
-            <div className="mt-1 text-xs leading-relaxed text-[#93A4B8]">
+            <div className="mt-1 text-xs leading-relaxed text-[#AFC0D4]">
               {manualRunRule.name} requires a lane when triggered.
             </div>
             <label className="mt-4 block space-y-1.5">
@@ -739,8 +776,44 @@ export function RulesTab({
               </select>
             </label>
             {!lanes.length ? (
-              <div className="mt-3 rounded-md border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-200">
-                No active lanes are available for this automation run.
+              <div className="mt-3 rounded-md border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+                <div className="font-semibold">No active lanes are available for this run.</div>
+                <div className="mt-1 leading-relaxed text-amber-100/80">
+                  Switch the rule to create a lane for each run, or create a lane from the Work tab and run again.
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="primary"
+                    onClick={() => {
+                      const nextDraft = draftWithCreateLaneMode(toDraftFromRule(manualRunRule));
+                      setSelectedRuleId(manualRunRule.id);
+                      setDraft(nextDraft);
+                      savedSnapshotRef.current = JSON.stringify(toDraftFromRule(manualRunRule));
+                      setIssues([]);
+                      setSimulationNotes([]);
+                      setRequiredConfirmations([]);
+                      setAcceptedConfirmations(new Set());
+                      setDetailView("editor");
+                      setManualRunRule(null);
+                      setManualRunLaneId("");
+                    }}
+                  >
+                    Create lanes for runs
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      setSelectedRuleId(manualRunRule.id);
+                      setDetailView("editor");
+                      setManualRunRule(null);
+                      setManualRunLaneId("");
+                    }}
+                  >
+                    Edit lane mode
+                  </Button>
+                </div>
               </div>
             ) : null}
             <div className="mt-4 flex justify-end gap-2">

--- a/apps/desktop/src/renderer/components/automations/components/RuleEditorPanel.tsx
+++ b/apps/desktop/src/renderer/components/automations/components/RuleEditorPanel.tsx
@@ -1,10 +1,7 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useMemo, useRef } from "react";
 import {
-  Brain,
   Calendar,
-  Clock,
-  CloudArrowUp,
+  CheckCircle,
   Cpu,
   FileText,
   Flag,
@@ -12,7 +9,6 @@ import {
   Flask,
   GitBranch,
   GithubLogo,
-  Hourglass,
   Lightning,
   ListChecks,
   Sparkle,
@@ -22,37 +18,27 @@ import {
   WebhooksLogo,
 } from "@phosphor-icons/react";
 import type { ElementType } from "react";
-import { getDefaultModelDescriptor } from "../../../../shared/modelRegistry";
 import type {
   AutomationAction,
   AutomationDraftConfirmationRequirement,
   AutomationDraftIssue,
+  AutomationIngressStatus,
   AutomationLaneMode,
   AutomationLaneNamePreset,
-  AutomationMode,
-  AutomationOutputDisposition,
-  AutomationReviewProfile,
   AutomationRuleDraft,
-  AutomationToolFamily,
   AutomationTrigger,
   TestSuiteDefinition,
 } from "../../../../shared/types";
-import { ModelSelector } from "../../shared/ModelSelector";
+import { isWebhookGatewayTriggerType } from "../../../../shared/types";
 import { Button } from "../../ui/Button";
 import { Chip } from "../../ui/Chip";
 import { cn } from "../../ui/cn";
-import { permissionControlsForModel, patchPermissionConfig } from "../permissionControls";
-import { cardCls, inputCls, labelCls, selectCls } from "../designTokens";
+import { cardCls, inputCls, labelCls, selectCls, textareaCls } from "../designTokens";
 import { GitHubTriggerFilters } from "../GitHubTriggerFilters";
 import { LinearTriggerFilters } from "../LinearTriggerFilters";
 import { ActionList } from "../ActionList";
 import type { ActionRowValue } from "../ActionRow";
-import { CARD_STYLE, INPUT_CLS, INPUT_STYLE } from "../shared";
-
-const DEFAULT_MODEL_ID =
-  getDefaultModelDescriptor("opencode")?.id
-  ?? getDefaultModelDescriptor("claude")?.id
-  ?? "anthropic/claude-sonnet-4-6";
+import { INPUT_CLS, INPUT_STYLE } from "../shared";
 
 type TriggerFamily =
   | "manual"
@@ -79,7 +65,7 @@ const TRIGGER_FAMILIES: Array<{
   { value: "file-change", label: "File change", icon: FileText, accent: "#34D399", hint: "Watches paths in the repo" },
   { value: "lane", label: "Lane", icon: TreeStructure, accent: "#7DD3FC", hint: "Lane lifecycle events" },
   { value: "session", label: "Session", icon: Cpu, accent: "#94A3B8", hint: "Agent session ends" },
-  { value: "webhook", label: "Webhook", icon: WebhooksLogo, accent: "#F472B6", hint: "External relay" },
+  { value: "webhook", label: "Webhook", icon: WebhooksLogo, accent: "#F472B6", hint: "External events" },
   { value: "manual", label: "Manual", icon: Lightning, accent: "#FACC15", hint: "Run on click only" },
 ];
 
@@ -116,7 +102,7 @@ const TRIGGER_OPTIONS: Record<TriggerFamily, Array<{ value: AutomationTrigger["t
   ],
   session: [{ value: "session-end", label: "Session ended" }],
   webhook: [
-    { value: "github-webhook", label: "GitHub relay webhook" },
+    { value: "github-webhook", label: "GitHub event" },
     { value: "webhook", label: "Custom webhook" },
   ],
   manual: [{ value: "manual", label: "Run on click only" }],
@@ -127,38 +113,6 @@ const SCHEDULE_PRESETS: Array<{ label: string; cron: string }> = [
   { label: "Every day at 9 AM", cron: "0 9 * * *" },
   { label: "Every day at 2 AM", cron: "0 2 * * *" },
   { label: "Fridays at 4 PM", cron: "0 16 * * 5" },
-];
-
-const REVIEW_PROFILES: Array<{ value: AutomationReviewProfile; label: string }> = [
-  { value: "quick", label: "Quick" },
-  { value: "incremental", label: "Incremental" },
-  { value: "full", label: "Full" },
-  { value: "security", label: "Security" },
-  { value: "release-risk", label: "Release risk" },
-  { value: "cross-repo-contract", label: "Cross-repo contract" },
-];
-
-const RULE_MODES: Array<{ value: AutomationMode; label: string }> = [
-  { value: "review", label: "Review" },
-  { value: "fix", label: "Fix" },
-  { value: "monitor", label: "Monitor" },
-];
-
-const TOOL_FAMILIES: Array<{ value: AutomationToolFamily; label: string }> = [
-  { value: "repo", label: "Repo" },
-  { value: "git", label: "Git" },
-  { value: "tests", label: "Tests" },
-  { value: "github", label: "GitHub" },
-  { value: "linear", label: "Linear" },
-  { value: "browser", label: "Browser" },
-];
-
-const OUTPUT_DISPOSITIONS: Array<{ value: AutomationOutputDisposition; label: string }> = [
-  { value: "comment-only", label: "Comment only" },
-  { value: "open-task", label: "Open task" },
-  { value: "open-lane", label: "Open lane" },
-  { value: "prepare-patch", label: "Prepare patch" },
-  { value: "open-pr-draft", label: "Open PR draft" },
 ];
 
 const LANE_NAME_PRESETS: Array<{
@@ -313,12 +267,6 @@ function triggerLabel(trigger: AutomationTrigger): string {
   if (trigger.branch?.trim()) return `${trigger.type} · ${trigger.branch.trim()}`;
   if (trigger.team?.trim()) return `${trigger.type} · ${trigger.team.trim()}`;
   return trigger.type;
-}
-
-function computeIncludeProjectContext(draft: AutomationRuleDraft): boolean {
-  if (typeof draft.includeProjectContext === "boolean") return draft.includeProjectContext;
-  if ((draft.contextSources ?? []).length > 0) return true;
-  return false;
 }
 
 // --- draft <-> ActionRow[] bridge ---
@@ -568,7 +516,9 @@ export function RuleEditorPanel({
   setDraft,
   lanes,
   suites,
+  ingressStatus,
   issues,
+  simulationNotes,
   requiredConfirmations,
   acceptedConfirmations,
   onToggleConfirmation,
@@ -581,7 +531,9 @@ export function RuleEditorPanel({
   setDraft: (draft: AutomationRuleDraft) => void;
   lanes: Array<{ id: string; name: string }>;
   suites: TestSuiteDefinition[];
+  ingressStatus: AutomationIngressStatus | null;
   issues: AutomationDraftIssue[];
+  simulationNotes?: string[];
   requiredConfirmations: AutomationDraftConfirmationRequirement[];
   acceptedConfirmations: Set<string>;
   onToggleConfirmation: (key: string, checked: boolean) => void;
@@ -590,27 +542,16 @@ export function RuleEditorPanel({
   saving: boolean;
   simulating?: boolean;
 }) {
-  const navigate = useNavigate();
-  const openAiSettings = useCallback(() => navigate("/settings?tab=ai#ai-providers"), [navigate]);
-
   const primaryTrigger = ensurePrimaryTrigger(draft);
   const triggerFamily = triggerFamilyForType(primaryTrigger.type);
+  const needsWebhookGateway = isWebhookGatewayTriggerType(primaryTrigger.type);
+  const webhookGateway = ingressStatus?.webhookGateway ?? null;
+  const webhookGatewayReady = webhookGateway?.ready === true;
   const triggerOptions = TRIGGER_OPTIONS[triggerFamily];
   const triggerMeta =
     TRIGGER_FAMILIES.find((family) => family.value === triggerFamily) ?? TRIGGER_FAMILIES[0]!;
 
   const actionRows = useMemo(() => draftToActionRows(draft), [draft]);
-  const includeProjectContext = computeIncludeProjectContext(draft);
-  const modelValue = draft.modelConfig ?? { modelId: DEFAULT_MODEL_ID, thinkingLevel: "medium" as const };
-  const outputs = draft.outputs ?? { disposition: "comment-only" as const, createArtifact: true };
-  const verification = draft.verification ?? { verifyBeforePublish: false, mode: "intervention" as const };
-  const toolPalette: AutomationToolFamily[] = draft.toolPalette ?? ["repo"];
-  const permissionMeta = permissionControlsForModel(modelValue.modelId);
-  const currentPermission = permissionMeta
-    ? draft.permissionConfig?.providers?.[permissionMeta.key] ?? ""
-    : "";
-  const ruleFastModeActive = draft.execution?.kind === "agent-session"
-    && draft.execution.session?.codexFastMode === true;
 
   // laneMode resolution: missing → "reuse" (server-side migration handles
   // legacy create-lane-as-first-action collapse).
@@ -659,21 +600,6 @@ export function RuleEditorPanel({
     const nextDraft = { ...draft, execution: next };
     setDraft(isRequireLaneAtRunTimeMode(next.laneMode) ? stripActionTargetLaneIdsFromDraft(nextDraft) : nextDraft);
   };
-  const setRuleCodexFastMode = (enabled: boolean) => {
-    const current = draft.execution ?? { kind: "agent-session" as const };
-    if (current.kind !== "agent-session") return;
-    setDraft({
-      ...draft,
-      execution: {
-        ...current,
-        session: {
-          ...(current.session ?? {}),
-          codexFastMode: enabled,
-        },
-      },
-    });
-  };
-
   // Smart defaults: when the trigger event changes and the user hasn't yet
   // manually adjusted lane mode/preset, snap to a sensible default. We key on
   // the trigger type so switching from "Issue opened" to "Issue closed"
@@ -694,11 +620,12 @@ export function RuleEditorPanel({
 
   const errors = issues.filter((i) => i.level === "error");
   const warnings = issues.filter((i) => i.level === "warning");
+  const successNotes = simulationNotes ?? [];
 
   return (
     <div className="flex h-full min-h-0 flex-col">
       {/* Sticky top bar */}
-      <div className="shrink-0 border-b border-white/[0.06] bg-[#0B121A]/80 px-5 py-3 backdrop-blur">
+      <div className="shrink-0 border-b border-white/[0.10] bg-[#111C2B]/92 px-5 py-3 backdrop-blur">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <div className="flex items-center gap-2 text-[15px] font-semibold text-[#F5FAFF]">
@@ -730,13 +657,12 @@ export function RuleEditorPanel({
         </div>
       </div>
 
-      {/* Body — full width 2-column layout */}
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="grid h-full min-h-0 grid-cols-1 gap-4 p-5 xl:grid-cols-[minmax(320px,400px)_1fr]">
-          {/* Left column — settings */}
-          <div className="flex flex-col gap-4">
+      {/* Body — one readable setup flow, not competing scroll columns. */}
+      <div className="min-h-0 flex-1 overflow-y-auto bg-[#101826]">
+        <div className="mx-auto flex w-full max-w-[1120px] flex-col gap-4 px-5 py-5">
             {errors.length ? <IssueList title="Errors" issues={errors} tone="error" /> : null}
             {warnings.length ? <IssueList title="Notes" issues={warnings} tone="warning" /> : null}
+            {successNotes.length ? <SuccessNotice notes={successNotes} /> : null}
             <ConfirmationsChecklist
               required={requiredConfirmations}
               accepted={acceptedConfirmations}
@@ -754,8 +680,7 @@ export function RuleEditorPanel({
                   placeholder="e.g. Triage new GitHub issues"
                 />
                 <textarea
-                  className="min-h-[60px] w-full rounded-md px-3 py-2 text-[12px] text-[#F5F7FA] placeholder:text-[#7E8A9A]"
-                  style={INPUT_STYLE}
+                  className={cn(textareaCls, "min-h-[76px] text-[12px] leading-relaxed")}
                   value={draft.description ?? ""}
                   onChange={(event) => setDraft({ ...draft, description: event.target.value })}
                   placeholder="What this rule is for"
@@ -766,20 +691,6 @@ export function RuleEditorPanel({
                   checked={draft.enabled}
                   onChange={(next) => setDraft({ ...draft, enabled: next })}
                 />
-                <label className="block space-y-1.5">
-                  <SmallLabel>Mode</SmallLabel>
-                  <select
-                    className={selectCls}
-                    value={draft.mode}
-                    onChange={(event) => setDraft({ ...draft, mode: event.target.value as AutomationMode })}
-                  >
-                    {RULE_MODES.map((mode) => (
-                      <option key={mode.value} value={mode.value}>
-                        {mode.label}
-                      </option>
-                    ))}
-                  </select>
-                </label>
               </div>
             </Section>
 
@@ -796,10 +707,10 @@ export function RuleEditorPanel({
                         type="button"
                         onClick={() => setTriggerFamily(family.value)}
                         className={cn(
-                          "flex flex-col items-center gap-1 rounded-lg border px-2 py-2 text-[10px] font-medium transition-colors",
+                          "flex flex-col items-center gap-1 rounded-lg border px-2 py-2 text-[10px] font-semibold transition-colors",
                           active
                             ? "text-[#F5FAFF]"
-                            : "border-white/[0.06] bg-black/15 text-[#93A4B8] hover:border-white/[0.14] hover:text-[#F5FAFF]",
+                            : "border-white/[0.12] bg-[#152235] text-[#B9C7DA] hover:border-white/[0.20] hover:text-[#F8FAFC]",
                         )}
                         style={
                           active
@@ -838,7 +749,9 @@ export function RuleEditorPanel({
                   </label>
                 ) : null}
 
-                <div className="rounded-lg border border-white/[0.08] bg-black/20 p-2.5">
+                {needsWebhookGateway ? <WebhookGatewayCallout ready={webhookGatewayReady} status={webhookGateway} /> : null}
+
+                <div className="rounded-lg border border-white/[0.12] bg-[#111C2B] p-2.5">
                   {primaryTrigger.type === "schedule" ? (
                     <ScheduleFields trigger={primaryTrigger} onPatch={patchTrigger} />
                   ) : triggerFamily === "github" ? (
@@ -852,11 +765,11 @@ export function RuleEditorPanel({
                   ) : triggerFamily === "lane" ? (
                     <LaneFields trigger={primaryTrigger} onPatch={patchTrigger} />
                   ) : triggerFamily === "session" ? (
-                    <div className="text-[11px] text-[#93A4B8]">Runs after any agent session ends.</div>
+                    <div className="text-[11px] text-[#B9C7DA]">Runs after any agent session ends.</div>
                   ) : triggerFamily === "webhook" ? (
                     <WebhookFields trigger={primaryTrigger} onPatch={patchTrigger} />
                   ) : (
-                    <div className="text-[11px] text-[#93A4B8]">Runs only when you click Run now.</div>
+                    <div className="text-[11px] text-[#B9C7DA]">Runs only when you click Run now.</div>
                   )}
                 </div>
               </div>
@@ -888,283 +801,20 @@ export function RuleEditorPanel({
               </div>
             </Section>
 
-            {/* Context + Model */}
-            <Section icon={Brain} accent="#A78BFA" title="Brains" hint="Model and project context">
-              <div className="space-y-3">
-                <Toggle
-                  label="Include project context"
-                  hint="Linked docs and project paths"
-                  checked={includeProjectContext}
-                  onChange={(next) => {
-                    setDraft({
-                      ...draft,
-                      includeProjectContext: next,
-                      contextSources: next ? (draft.contextSources?.length ? draft.contextSources : []) : [],
-                    });
-                  }}
-                />
-                <div className="space-y-1.5">
-                  <SmallLabel>Review profile</SmallLabel>
-                  <select
-                    className={selectCls}
-                    value={draft.reviewProfile}
-                    onChange={(event) =>
-                      setDraft({ ...draft, reviewProfile: event.target.value as AutomationReviewProfile })
-                    }
-                  >
-                    {REVIEW_PROFILES.map((profile) => (
-                      <option key={profile.value} value={profile.value}>
-                        {profile.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div className="space-y-1.5">
-                  <SmallLabel>Tool palette</SmallLabel>
-                  <div className="grid grid-cols-2 gap-1.5">
-                    {TOOL_FAMILIES.map((tool) => {
-                      const checked = toolPalette.includes(tool.value);
-                      const wouldEmptyPalette = checked && toolPalette.length === 1;
-                      return (
-                        <label
-                          key={tool.value}
-                          className={cn(
-                            "flex items-center gap-2 rounded-md border border-white/[0.08] bg-black/15 px-2 py-1.5 text-[11px] text-[#D8E3F2]",
-                            wouldEmptyPalette && "opacity-60",
-                          )}
-                          title={wouldEmptyPalette ? "At least one tool family is required." : undefined}
-                        >
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            disabled={wouldEmptyPalette}
-                            onChange={(event) => {
-                              const next = event.target.checked
-                                ? [...new Set([...toolPalette, tool.value])]
-                                : toolPalette.filter((entry) => entry !== tool.value);
-                              setDraft({ ...draft, toolPalette: next });
-                            }}
-                            className="accent-[#7DD3FC]"
-                          />
-                          {tool.label}
-                        </label>
-                      );
-                    })}
-                  </div>
-                </div>
-                <div className="space-y-1.5">
-                  <SmallLabel>Model</SmallLabel>
-                  <ModelSelector
-                    value={modelValue}
-                    onChange={(next) =>
-                      setDraft({
-                        ...draft,
-                        modelConfig: next,
-                      })
-                    }
-                    onOpenAiSettings={openAiSettings}
-                    fastModeActive={ruleFastModeActive}
-                    onFastModeToggle={draft.execution?.kind === "agent-session" ? setRuleCodexFastMode : undefined}
-                  />
-                </div>
-                {permissionMeta ? (
-                  <label className="block space-y-1.5">
-                    <SmallLabel>Permissions</SmallLabel>
-                    <select
-                      className={selectCls}
-                      value={currentPermission}
-                      onChange={(event) =>
-                        setDraft({
-                          ...draft,
-                          permissionConfig: patchPermissionConfig(
-                            draft.permissionConfig,
-                            modelValue.modelId,
-                            event.target.value,
-                          ),
-                        })
-                      }
-                    >
-                      <option value="">Default</option>
-                      {permissionMeta.options.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                ) : null}
-              </div>
-            </Section>
-
-            {/* Limits */}
-            <Section icon={Hourglass} accent="#F59E0B" title="Limits" hint="Caps and active hours">
-              <div className="space-y-3">
-                <LabeledNumber
-                  label="Max duration (minutes)"
-                  value={draft.guardrails.maxDurationMin ?? null}
-                  onChange={(n) =>
-                    setDraft({
-                      ...draft,
-                      guardrails: { ...draft.guardrails, maxDurationMin: n ?? undefined },
-                    })
-                  }
-                  placeholder="20"
-                  icon={Clock}
-                />
-                <div className="grid gap-2 md:grid-cols-2">
-                  <label className="block space-y-1">
-                    <SmallLabel>Confidence threshold</SmallLabel>
-                    <input
-                      className={inputCls}
-                      type="number"
-                      min={0}
-                      max={1}
-                      step={0.05}
-                      value={draft.guardrails.confidenceThreshold ?? ""}
-                      onChange={(event) => {
-                        const raw = event.target.value.trim();
-                        const parsed = Number(raw);
-                        setDraft({
-                          ...draft,
-                          guardrails: {
-                            ...draft.guardrails,
-                            confidenceThreshold: raw && Number.isFinite(parsed)
-                              ? Math.max(0, Math.min(1, parsed))
-                              : undefined,
-                          },
-                        });
-                      }}
-                      placeholder="Default"
-                    />
-                  </label>
-                  <LabeledNumber
-                    label="Max findings"
-                    value={draft.guardrails.maxFindings ?? null}
-                    onChange={(n) =>
-                      setDraft({
-                        ...draft,
-                        guardrails: {
-                          ...draft.guardrails,
-                          maxFindings: n == null ? undefined : Math.max(1, Math.floor(n)),
-                        },
-                      })
-                    }
-                    placeholder="Default"
-                  />
-                </div>
-                <ActiveHoursFields
-                  hours={primaryTrigger.activeHours ?? null}
-                  onChange={(next) => patchTrigger({ activeHours: next ?? undefined })}
-                />
-                <div className="rounded-md border border-[#35506B]/40 bg-[#0F1B2A]/60 px-2.5 py-2 text-[10px] leading-relaxed text-[#9FB2C7]">
-                  <CloudArrowUp size={10} weight="regular" className="mr-1 inline-block align-text-bottom" />
-                  Budget caps live in the <span className="text-[#D8E3F2]">header Usage popup → Automation guardrails</span> and apply to every rule.
-                </div>
-              </div>
-            </Section>
-
-            {/* Output */}
-            <Section icon={Flag} accent="#34D399" title="Output" hint="Artifacts and publish gates">
-              <div className="space-y-3">
-                <label className="block space-y-1.5">
-                  <SmallLabel>Disposition</SmallLabel>
-                  <select
-                    className={selectCls}
-                    value={outputs.disposition}
-                    onChange={(event) =>
-                      setDraft({
-                        ...draft,
-                        outputs: { ...outputs, disposition: event.target.value as AutomationOutputDisposition },
-                      })
-                    }
-                  >
-                    {OUTPUT_DISPOSITIONS.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <Toggle
-                  label="Create artifact"
-                  hint={outputs.createArtifact === false ? "Run stores history only" : "Run stores an artifact"}
-                  checked={outputs.createArtifact !== false}
-                  onChange={(next) => setDraft({ ...draft, outputs: { ...outputs, createArtifact: next } })}
-                />
-                <label className="block space-y-1.5">
-                  <SmallLabel>Notification channel</SmallLabel>
-                  <input
-                    className={inputCls}
-                    value={outputs.notificationChannel ?? ""}
-                    onChange={(event) =>
-                      setDraft({
-                        ...draft,
-                        outputs: {
-                          ...outputs,
-                          notificationChannel: event.target.value.trim() || null,
-                        },
-                      })
-                    }
-                    placeholder="Optional"
-                  />
-                </label>
-                <div className="grid gap-2 md:grid-cols-2">
-                  <label className="block space-y-1.5">
-                    <SmallLabel>Verification mode</SmallLabel>
-                    <select
-                      className={selectCls}
-                      value={verification.mode ?? "intervention"}
-                      onChange={(event) =>
-                        setDraft({
-                          ...draft,
-                          verification: {
-                            ...verification,
-                            mode: event.target.value as "intervention" | "dry-run",
-                          },
-                        })
-                      }
-                    >
-                      <option value="intervention">Intervention</option>
-                      <option value="dry-run">Dry run</option>
-                    </select>
-                  </label>
-                  <Toggle
-                    label="Verify before publish"
-                    hint={verification.verifyBeforePublish ? "Publish waits for review" : "Publish can complete automatically"}
-                    checked={verification.verifyBeforePublish}
-                    onChange={(next) =>
-                      setDraft({
-                        ...draft,
-                        verification: { ...verification, verifyBeforePublish: next },
-                      })
-                    }
-                  />
-                </div>
-              </div>
-            </Section>
-          </div>
-
-          {/* Right column — workflow steps */}
-          <div className="flex min-h-0 flex-col">
-            <Section
-              icon={ListChecks}
-              accent="#22D3EE"
-              title="Workflow steps"
-              hint={`${actionRows.length} step${actionRows.length === 1 ? "" : "s"} — runs top to bottom`}
-              dense
-              fill
-            >
-              <ActionList
-                actions={actionRows}
-                lanes={lanes}
-                suites={suites}
-                fallbackModel={modelValue}
-                executionLaneMode={laneMode}
-                onChange={setActionRows}
-                onOpenAiSettings={openAiSettings}
-              />
-            </Section>
-          </div>
+          <Section
+            icon={ListChecks}
+            accent="#22D3EE"
+            title="Workflow steps"
+            hint={`${actionRows.length} step${actionRows.length === 1 ? "" : "s"} — runs top to bottom`}
+            dense
+          >
+            <ActionList
+              actions={actionRows}
+              lanes={lanes}
+              suites={suites}
+              onChange={setActionRows}
+            />
+          </Section>
         </div>
       </div>
     </div>
@@ -1270,8 +920,8 @@ function LaneCreatePanel({
     && triggerKind !== "any";
 
   return (
-    <div className="mt-3 space-y-3 rounded-lg border border-accent/15 bg-accent/[0.03] p-3">
-      <div className="flex items-center gap-2 text-[11px] text-accent">
+    <div className="mt-3 space-y-3 rounded-lg border border-[#2DD4BF]/25 bg-[#111C2B] p-3">
+      <div className="flex items-center gap-2 text-[11px] text-[#9BE7D8]">
         <Sparkle size={12} weight="fill" />
         <span className="font-medium">A fresh lane is created for every run.</span>
       </div>
@@ -1303,14 +953,14 @@ function LaneCreatePanel({
         ) : null}
       </div>
 
-      <div className="rounded-md border border-white/[0.05] bg-[rgba(12,10,22,0.6)] px-3 py-2">
-        <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.08em] text-muted-fg/50">
+      <div className="rounded-md border border-white/[0.12] bg-[#152235] px-3 py-2">
+        <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.08em] text-[#AFC0D4]">
           <GitBranch size={10} weight="regular" />
           <span>Preview</span>
         </div>
-        <div className="mt-1 break-all font-mono text-[11px] text-fg/80">
+        <div className="mt-1 break-all font-mono text-[11px] text-[#F8FAFC]">
           {preview.resolved.trim() || (
-            <span className="text-muted-fg/40">(empty — pick a preset or enter a template)</span>
+            <span className="text-[#94A3B8]">(empty — pick a preset or enter a template)</span>
           )}
         </div>
       </div>
@@ -1324,9 +974,44 @@ function LaneCreatePanel({
         </div>
       ) : null}
 
-      <p className="text-[11px] leading-relaxed text-muted-fg/60">
+      <p className="text-[11px] leading-relaxed text-[#AFC0D4]">
         Lane names auto-disambiguate by appending the issue / PR number if a duplicate exists.
       </p>
+    </div>
+  );
+}
+
+function WebhookGatewayCallout({
+  ready,
+  status,
+}: {
+  ready: boolean;
+  status: AutomationIngressStatus["webhookGateway"] | null;
+}) {
+  const label = ready ? "Webhook gateway online" : "Webhook gateway required";
+  const detail = ready
+    ? status?.publicUrl
+      ? `Events will arrive through ${status.publicUrl}.`
+      : "Events can reach this ADE runtime."
+    : status?.tailscale.available
+      ? "Internal builds can start ingress from the ADE CLI before enabling this trigger."
+      : "Internal builds need Tailscale available before ADE CLI ingress can expose this runtime.";
+  return (
+    <div
+      className={cn(
+        "flex items-start justify-between gap-3 rounded-lg border px-3 py-2.5",
+        ready
+          ? "border-emerald-300/25 bg-emerald-300/10 text-emerald-100"
+          : "border-amber-300/25 bg-amber-300/10 text-amber-100",
+      )}
+    >
+      <div className="min-w-0">
+        <div className="flex items-center gap-2 text-[12px] font-semibold">
+          {ready ? <CheckCircle size={13} weight="fill" /> : <Warning size={13} weight="regular" />}
+          {label}
+        </div>
+        <div className="mt-1 break-words text-[11px] leading-relaxed opacity-90">{detail}</div>
+      </div>
     </div>
   );
 }
@@ -1350,19 +1035,21 @@ function Section({
 }) {
   return (
     <section
-      className={cn("rounded-2xl", fill ? "flex min-h-0 flex-1 flex-col" : "")}
-      style={CARD_STYLE}
+      className={cn(
+        "overflow-hidden rounded-xl border border-white/[0.12] bg-[#162235] shadow-[0_18px_45px_rgba(0,0,0,0.18)]",
+        fill ? "flex min-h-0 flex-1 flex-col" : "",
+      )}
     >
-      <div className="flex items-center gap-2 border-b border-white/[0.06] px-4 py-3">
+      <div className="flex items-center gap-2 border-b border-white/[0.10] bg-[#1B2A40] px-4 py-3">
         <div
-          className="flex h-7 w-7 items-center justify-center rounded-lg"
+          className="flex h-7 w-7 items-center justify-center rounded-md"
           style={{ background: `${accent}1f`, color: accent, boxShadow: `inset 0 0 0 1px ${accent}33` }}
         >
           <Icon size={14} weight="fill" />
         </div>
         <div className="min-w-0 flex-1">
-          <div className="text-[12px] font-semibold text-[#F5FAFF]">{title}</div>
-          {hint ? <div className="text-[10px] text-[#93A4B8]">{hint}</div> : null}
+          <div className="text-[13px] font-semibold text-[#F8FAFC]">{title}</div>
+          {hint ? <div className="text-[11px] text-[#AFC0D4]">{hint}</div> : null}
         </div>
       </div>
       <div className={cn(dense ? "p-3" : "p-4", fill && "min-h-0 flex-1 overflow-visible")}>
@@ -1387,6 +1074,22 @@ function AccentBadge({ accent, children }: { accent: string; children: React.Rea
   );
 }
 
+function SuccessNotice({ notes }: { notes: string[] }) {
+  return (
+    <div className="rounded-xl border border-emerald-500/25 bg-emerald-500/10 px-3 py-2 text-[11px] text-emerald-100">
+      <div className="flex items-center gap-1.5 font-semibold">
+        <CheckCircle size={13} weight="fill" />
+        Simulation ready
+      </div>
+      <ul className="mt-1 space-y-0.5">
+        {notes.map((note, index) => (
+          <li key={`${note}-${index}`}>{note}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 function Toggle({
   label,
   hint,
@@ -1399,10 +1102,10 @@ function Toggle({
   onChange: (next: boolean) => void;
 }) {
   return (
-    <label className="flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-white/[0.06] bg-black/15 px-3 py-2 text-[12px] text-[#D8E3F2] hover:border-white/[0.12]">
+    <label className="flex cursor-pointer items-center justify-between gap-3 rounded-lg border border-white/[0.12] bg-[#152235] px-3 py-2 text-[12px] text-[#E6EEF8] hover:border-white/[0.20]">
       <span className="min-w-0 flex-1">
         <span className="block">{label}</span>
-        {hint ? <span className="block text-[10px] text-[#7E8A9A]">{hint}</span> : null}
+        {hint ? <span className="block text-[10px] text-[#AFC0D4]">{hint}</span> : null}
       </span>
       <input
         type="checkbox"
@@ -1612,87 +1315,6 @@ function WebhookFields({
           placeholder="github-webhook"
         />
       </label>
-    </div>
-  );
-}
-
-function LabeledNumber({
-  label,
-  value,
-  placeholder,
-  onChange,
-  icon: Icon,
-}: {
-  label: string;
-  value: number | null;
-  placeholder?: string;
-  onChange: (next: number | null) => void;
-  icon?: ElementType;
-}) {
-  return (
-    <label className="block space-y-1">
-      <SmallLabel>
-        {Icon ? <Icon size={10} weight="regular" className="mr-1 inline-block align-text-bottom" /> : null}
-        {label}
-      </SmallLabel>
-      <input
-        className={inputCls}
-        type="number"
-        min={0}
-        value={value ?? ""}
-        onChange={(event) => {
-          const raw = event.target.value.trim();
-          if (!raw) {
-            onChange(null);
-            return;
-          }
-          const parsed = Number(raw);
-          onChange(Number.isFinite(parsed) ? parsed : null);
-        }}
-        placeholder={placeholder}
-      />
-    </label>
-  );
-}
-
-function ActiveHoursFields({
-  hours,
-  onChange,
-}: {
-  hours: { start: string; end: string; timezone: string } | null;
-  onChange: (next: { start: string; end: string; timezone: string } | null) => void;
-}) {
-  const enabled = !!hours;
-  return (
-    <div className="space-y-2">
-      <Toggle
-        label="Active hours"
-        hint={enabled && hours ? `${hours.start} – ${hours.end} (${hours.timezone})` : "Always on"}
-        checked={enabled}
-        onChange={(next) =>
-          onChange(
-            next
-              ? hours ?? { start: "09:00", end: "18:00", timezone: Intl.DateTimeFormat().resolvedOptions().timeZone }
-              : null,
-          )
-        }
-      />
-      {enabled && hours ? (
-        <div className="grid grid-cols-2 gap-2">
-          <input
-            className={inputCls}
-            value={hours.start}
-            onChange={(event) => onChange({ ...hours, start: event.target.value })}
-            placeholder="09:00"
-          />
-          <input
-            className={inputCls}
-            value={hours.end}
-            onChange={(event) => onChange({ ...hours, end: event.target.value })}
-            placeholder="18:00"
-          />
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/automations/designTokens.ts
+++ b/apps/desktop/src/renderer/components/automations/designTokens.ts
@@ -1,15 +1,28 @@
 /**
- * Design tokens for the Automations UI. Re-exports the CTO panel tokens so
- * we share a single source of truth for input chrome, focus rings, card
- * surfaces, and accent palette across the two surfaces.
+ * Design tokens for the Automations UI.
+ *
+ * Automations is a long-form builder, so it uses slightly brighter surfaces
+ * than the CTO dashboard tokens. That keeps prompts and form labels legible
+ * when users are scanning multi-step rules.
  */
-export {
-  inputCls,
-  selectCls,
-  labelCls,
-  textareaCls,
-  cardCls,
-  surfaceCardCls,
-  recessedPanelCls,
-  ACCENT,
-} from "../cto/shared/designTokens";
+export { ACCENT } from "../cto/shared/designTokens";
+
+export const inputCls =
+  "h-8 w-full rounded-md border border-white/[0.14] bg-[#152235] px-3 text-xs font-sans text-[#F8FAFC] shadow-[inset_0_1px_1px_rgba(0,0,0,0.18)] placeholder:text-[#94A3B8] hover:border-[#7DD3FC]/35 focus:border-[#7DD3FC]/55 focus:shadow-[0_0_0_2px_rgba(125,211,252,0.14)] focus:outline-none transition-all duration-150";
+
+export const selectCls = `${inputCls} appearance-none`;
+
+export const labelCls =
+  "mb-1.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-[#AFC0D4]";
+
+export const textareaCls =
+  "w-full resize-y rounded-md border border-white/[0.14] bg-[#152235] p-3 text-xs font-sans text-[#F8FAFC] shadow-[inset_0_1px_1px_rgba(0,0,0,0.18)] placeholder:text-[#94A3B8] hover:border-[#7DD3FC]/35 focus:border-[#7DD3FC]/55 focus:shadow-[0_0_0_2px_rgba(125,211,252,0.14)] focus:outline-none transition-all duration-150";
+
+export const cardCls =
+  "rounded-xl border border-white/[0.12] bg-[#162235] p-5 shadow-[0_18px_45px_rgba(0,0,0,0.18)]";
+
+export const surfaceCardCls =
+  "rounded-xl border border-white/[0.12] bg-[#162235] p-4 shadow-[0_14px_34px_rgba(0,0,0,0.16)]";
+
+export const recessedPanelCls =
+  "rounded-lg border border-white/[0.12] bg-[#111C2B] shadow-[inset_0_1px_2px_rgba(0,0,0,0.18)]";

--- a/apps/desktop/src/renderer/components/automations/shared.ts
+++ b/apps/desktop/src/renderer/components/automations/shared.ts
@@ -1,7 +1,7 @@
 /** Shared utilities for the automations UI. */
 
 import type React from "react";
-import { inputCls } from "../cto/shared/designTokens";
+import { inputCls } from "./designTokens";
 
 /**
  * Legacy aliases. Existing automation call sites use these names; they now

--- a/apps/desktop/src/renderer/components/graph/WorkspaceGraphPage.tsx
+++ b/apps/desktop/src/renderer/components/graph/WorkspaceGraphPage.tsx
@@ -378,6 +378,7 @@ function GraphInner({ active = true }: { active?: boolean }) {
     message: string;
     undoAction: () => Promise<void>;
   } | null>(null);
+  const [undoToastPending, setUndoToastPending] = React.useState(false);
   const [activityScoreByLaneId, setActivityScoreByLaneId] = React.useState<Record<string, number>>({});
   const [activeSessionsByLaneId, setActiveSessionsByLaneId] = React.useState<Record<string, number>>({});
   const activeGraphSessionsRef = React.useRef(0);
@@ -1003,9 +1004,10 @@ function GraphInner({ active = true }: { active?: boolean }) {
 
   React.useEffect(() => {
     if (!undoToast) return;
+    if (undoToastPending) return;
     const timer = window.setTimeout(() => setUndoToast(null), 10_000);
     return () => window.clearTimeout(timer);
-  }, [undoToast]);
+  }, [undoToast, undoToastPending]);
 
   React.useEffect(() => {
     const timers = Object.entries(mergeDisappearingAtByLaneId).map(([laneId, startedAt]) =>
@@ -2215,7 +2217,7 @@ function GraphInner({ active = true }: { active?: boolean }) {
         const result = await window.ade.lanes.reparent({ laneId, newParentLaneId: target.id });
         completed.push({ laneId, previousParentLaneId: result.previousParentLaneId });
       } catch (error) {
-        for (const rollback of completed.reverse()) {
+        for (const rollback of [...completed].reverse()) {
           if (!rollback.previousParentLaneId) continue;
           try {
             await window.ade.lanes.reparent({ laneId: rollback.laneId, newParentLaneId: rollback.previousParentLaneId });
@@ -2230,10 +2232,11 @@ function GraphInner({ active = true }: { active?: boolean }) {
       }
     }
 
+    setUndoToastPending(false);
     setUndoToast({
       message: `Reparented ${orderedLaneIds.length === 1 ? `'${laneById.get(orderedLaneIds[0]!)?.name ?? orderedLaneIds[0]}'` : `${orderedLaneIds.length} lanes`} under '${target.name}'`,
       undoAction: async () => {
-        for (const rollback of completed.reverse()) {
+        for (const rollback of [...completed].reverse()) {
           if (!rollback.previousParentLaneId) continue;
           await window.ade.lanes.reparent({ laneId: rollback.laneId, newParentLaneId: rollback.previousParentLaneId });
         }
@@ -4417,14 +4420,20 @@ function GraphInner({ active = true }: { active?: boolean }) {
               size="sm"
               variant="primary"
               className="h-6 px-2 text-[11px]"
+              disabled={undoToastPending}
               onClick={() => {
+                if (undoToastPending) return;
+                setUndoToastPending(true);
                 void undoToast
                   .undoAction()
                   .catch((error) => setErrorBanner(error instanceof Error ? error.message : String(error)))
-                  .finally(() => setUndoToast(null));
+                  .finally(() => {
+                    setUndoToastPending(false);
+                    setUndoToast(null);
+                  });
               }}
             >
-              Undo
+              {undoToastPending ? "Undoing" : "Undo"}
             </Button>
           </div>
         </div>

--- a/apps/desktop/src/shared/adeCliGuidance.ts
+++ b/apps/desktop/src/shared/adeCliGuidance.ts
@@ -10,7 +10,6 @@ export const adeBundledAgentSkills = [
   "ade-linear",
   "ade-orchestrator",
   "ade-proof-artifacts",
-  "ade-macos-vm",
   "ade-deeplinks",
 ] as const;
 
@@ -34,6 +33,7 @@ export function buildAdeCliAgentGuidance(skillRoots: readonly string[] = getAdeA
   "- Start with `ade doctor --text` when the ADE environment is unclear. Use `ade help <command>` for exact flags and `ade actions list --text` as the escape hatch for service actions without a typed command.",
   "- If `command -v ade` fails, try `${ADE_CLI_PATH:-}` when set, then `${ADE_CLI_BIN_DIR:-}/ade`, and in an ADE source checkout fall back to `node apps/ade-cli/dist/cli.cjs ...` after confirming it exists. The only normal reason to skip ADE CLI for an ADE action is that it is truly unreachable.",
   "- Use typed commands with `--text` for readable output. Common starts: `ade lanes list --text`, `ade chat list --text`, `ade proof status --text`, and `ade actions list --text`.",
+  "- Automations, Linear webhook ingress, and macOS VM are internal/coming-soon in production builds. Do not use `ade automations`, `ade linear ingress`, or `ade macos-vm` unless the user explicitly asks and the matching internal override env var is set.",
   "- Use `--socket` when the ADE desktop drawer and the CLI must share live state such as App Control, iOS Simulator, Preview Lab, browser tabs, terminal logs, selection/context capture, proof drawer updates, or macOS VM state.",
   "- If any task needs a browser, web page, localhost preview, login-backed site, screenshot, DOM inspection, form fill, click, or navigation, use ADE's built-in browser through `ade --socket browser ...` and the `ade-browser` skill before trying an external browser/tool. Start by listing tabs, then use only a tab/session owned by this chat; otherwise open a fresh owned tab with `ade --socket browser open <url> --new-tab --text` and start a browser session.",
   "- When the user asks you to capture, send, attach, or provide proof, use the relevant capture tool first, then register it with ADE via `ade proof ...` so it appears in the ADE proof drawer for the active chat or lane.",

--- a/apps/desktop/src/shared/automationAvailability.ts
+++ b/apps/desktop/src/shared/automationAvailability.ts
@@ -1,0 +1,45 @@
+type EnvLike = Record<string, string | undefined>;
+
+export const AUTOMATIONS_ENABLE_ENV = "ADE_ENABLE_AUTOMATIONS";
+export const AUTOMATIONS_DISABLE_ENV = "ADE_DISABLE_AUTOMATIONS";
+export const MACOS_VM_ENABLE_ENV = "ADE_ENABLE_MACOS_VM";
+export const MACOS_VM_DISABLE_ENV = "ADE_DISABLE_MACOS_VM";
+
+export const AUTOMATIONS_COMING_SOON_MESSAGE =
+  "Automations are coming soon in production builds.";
+export const MACOS_VM_COMING_SOON_MESSAGE =
+  "Mac VM is coming soon in production builds.";
+
+function envFlagEnabled(value: string | undefined): boolean {
+  return ["1", "true", "yes", "on"].includes((value ?? "").trim().toLowerCase());
+}
+
+export function readAutomationsEnvOverride(env: EnvLike = process.env): boolean | null {
+  if (envFlagEnabled(env[AUTOMATIONS_ENABLE_ENV])) return true;
+  if (envFlagEnabled(env[AUTOMATIONS_DISABLE_ENV])) return false;
+  return null;
+}
+
+export function areAutomationsEnabledForPackagedState(
+  isPackaged: boolean,
+  env: EnvLike = process.env,
+): boolean {
+  const override = readAutomationsEnvOverride(env);
+  if (override !== null) return override;
+  return !isPackaged;
+}
+
+export function readMacosVmEnvOverride(env: EnvLike = process.env): boolean | null {
+  if (envFlagEnabled(env[MACOS_VM_ENABLE_ENV])) return true;
+  if (envFlagEnabled(env[MACOS_VM_DISABLE_ENV])) return false;
+  return null;
+}
+
+export function isMacosVmEnabledForPackagedState(
+  isPackaged: boolean,
+  env: EnvLike = process.env,
+): boolean {
+  const override = readMacosVmEnvOverride(env);
+  if (override !== null) return override;
+  return !isPackaged;
+}

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -443,6 +443,8 @@ export const IPC = {
   automationsListRuns: "ade.automations.listRuns",
   automationsGetRunDetail: "ade.automations.getRunDetail",
   automationsGetIngressStatus: "ade.automations.getIngressStatus",
+  automationsRefreshWebhookGatewayStatus: "ade.automations.refreshWebhookGatewayStatus",
+  automationsSetWebhookGatewayPublicUrl: "ade.automations.setWebhookGatewayPublicUrl",
   automationsListIngressEvents: "ade.automations.listIngressEvents",
   automationsParseNaturalLanguage: "ade.automations.parseNaturalLanguage",
   automationsValidateDraft: "ade.automations.validateDraft",

--- a/apps/desktop/src/shared/types/automations.ts
+++ b/apps/desktop/src/shared/types/automations.ts
@@ -120,6 +120,49 @@ export type AutomationIngressSource =
   | "linear-relay"
   | "local-webhook";
 
+export const WEBHOOK_GATEWAY_TRIGGER_TYPES = [
+  "github.pr_opened",
+  "github.pr_updated",
+  "github.pr_merged",
+  "github.pr_closed",
+  "github.pr_commented",
+  "github.pr_review_submitted",
+  "github.issue_opened",
+  "github.issue_edited",
+  "github.issue_closed",
+  "github.issue_labeled",
+  "github.issue_commented",
+  "linear.issue_created",
+  "linear.issue_updated",
+  "linear.issue_assigned",
+  "linear.issue_status_changed",
+  "linear.issue_labeled",
+  "github-webhook",
+  "webhook",
+] as const satisfies readonly AutomationTriggerType[];
+
+export type WebhookGatewayTriggerType = (typeof WEBHOOK_GATEWAY_TRIGGER_TYPES)[number];
+
+export function isWebhookGatewayTriggerType(type: AutomationTriggerType | string | null | undefined): type is WebhookGatewayTriggerType {
+  return WEBHOOK_GATEWAY_TRIGGER_TYPES.includes(type as WebhookGatewayTriggerType);
+}
+
+export type AutomationWebhookGatewayStatus = {
+  enabled: boolean;
+  ready: boolean;
+  status: "disabled" | "starting" | "online" | "needs-public-url" | "needs-tailscale" | "pending-approval" | "error";
+  publicUrl: string | null;
+  localUrl: string | null;
+  provider: "tailscale" | "custom" | "unknown" | null;
+  tailscale: {
+    available: boolean;
+    hostname: string | null;
+    message: string | null;
+  };
+  lastCheckedAt: string | null;
+  lastError: string | null;
+};
+
 export type AutomationTriggerIssueContext = {
   number: number;
   title: string;
@@ -149,6 +192,7 @@ export type AutomationTriggerLinearIssueContext = {
 };
 
 export type AutomationIngressStatus = {
+  webhookGateway: AutomationWebhookGatewayStatus;
   githubRelay: {
     configured: boolean;
     healthy: boolean;
@@ -165,6 +209,7 @@ export type AutomationIngressStatus = {
     listening: boolean;
     status: "disabled" | "ready" | "listening" | "error";
     url: string | null;
+    githubUrl: string | null;
     port: number | null;
     lastDeliveryAt: string | null;
     lastError: string | null;

--- a/apps/desktop/src/shared/types/config.ts
+++ b/apps/desktop/src/shared/types/config.ts
@@ -1403,6 +1403,11 @@ export type AiIntegrationStatus = {
 
 export type ProjectUiConfig = {
   linearBatchLaunchDefaultPrompt?: string;
+  /**
+   * Public HTTPS base URL for the ADE Webhook Gateway. Stored in local config
+   * so external event automations can be gated without exposing local sockets.
+   */
+  webhookGatewayPublicUrl?: string;
 };
 
 export type ProjectConfigFile = {


### PR DESCRIPTION
## Summary\n- hide Automations behind a production coming-soon gate in packaged desktop builds while keeping source/dev builds available\n- block production CLI/runtime wiring for Automations, Linear ingress, and macOS VM unless internal env overrides are set\n- remove production-facing webhook settings affordances and update agent CLI guidance so agents do not treat these surfaces as usable in production\n\n## Validation\n- npm --prefix apps/ade-cli run typecheck -- --pretty false\n- npm --prefix apps/ade-cli run test\n- npm --prefix apps/desktop run typecheck -- --pretty false\n- npm --prefix apps/desktop exec -- vitest run src/main/services/adeActions/registry.test.ts src/main/services/automations/automationService.test.ts src/main/services/automations/automationIngressService.test.ts\n- npm --prefix apps/desktop run build\n- git diff --check\n- packaged CLI gate smoke: copied built cli.cjs outside source checkout and confirmed automations, linear ingress, and macos-vm are hidden/blocked without internal env overrides\n\n## Notes\nThis intentionally keeps Automations and macOS VM available for source/dev builds while packaged production builds present them as coming soon or unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added webhook gateway configuration for external event automations
  * GitHub webhooks can now trigger automations directly
  * New CLI commands for managing automation ingress webhooks
  * Automations feature now gated appropriately for production vs. dev builds

* **UI Updates**
  * Improved automation rule editor with webhook gateway status indicators
  * Added "Coming soon" messaging for automations in production builds
  * Updated design tokens and styling for automations interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates Automations, Linear webhook ingress, and macOS VM behind a production-build wall: packaged desktop builds show a "coming soon" screen and have all automation services nulled out, while source/dev builds retain full access. It also adds a webhook gateway abstraction (Tailscale Funnel or custom HTTPS URL) for directing external GitHub/Linear events to the local ADE runtime, plus a `/github-webhooks` endpoint with HMAC verification.

- **Feature gates**: `automationAvailability.ts` centralises env-override logic; `main.ts`, `bootstrap.ts`, and `registry.ts` all use it to conditionally create/expose services. `AutomationsProductionGate` in the renderer mirrors this for the UI.
- **Webhook gateway**: `automationService.ts` gains `setWebhookGatewayPublicUrl`, `refreshWebhookGatewayStatus` (Tailscale probe via `execFile`), and `assertWebhookGatewayReadyForRule` gating; `automationIngressService.ts` adds a `/github-webhooks` route with HMAC verification; `linearIngressService.ts` grows a direct-webhook registration path bypassing the relay when a gateway URL is configured.
- **Bug fixes in `WorkspaceGraphPage.tsx`**: in-place `completed.reverse()` mutations replaced with `[...completed].reverse()`, and an `undoToastPending` guard prevents double-click undo races.

<h3>Confidence Score: 3/5</h3>

The core feature-flag plumbing is solid, but two issues in the new webhook gateway path could cause incorrect data at runtime for users who enable the feature.

The gating logic in automationAvailability.ts, main.ts, bootstrap.ts, and registry.ts is straightforward and well-tested. The bug fixes in WorkspaceGraphPage.tsx are correct. The concern is concentrated in the new webhook integration code: linearIngressService.ts can accumulate duplicate Linear webhook registrations when the gateway public URL is changed, leading to doubled event delivery. Separately, automationService.ts getIngressStatus() silently overwrites ingressStatusRef on every call, potentially discarding freshly-refreshed Tailscale probe data.

apps/desktop/src/main/services/cto/linearIngressService.ts (direct-webhook deduplication on URL change) and apps/desktop/src/main/services/automations/automationService.ts (getIngressStatus side-effectful mutation of ingressStatusRef).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/shared/automationAvailability.ts | New shared module centralizing env-override and packaged-state checks for Automations and macOS VM; logic is clean and well-tested. |
| apps/ade-cli/src/bootstrap.ts | Adds feature-flag gating for automationService, automationIngressService, automationPlannerService, and macosVmService in the headless runtime; dist/bootstrap.cjs is treated as a source-checkout build. |
| apps/ade-cli/src/cli.ts | Adds assertAutomationsCliEnabled / assertMacosVmCliEnabled guards, new automations ingress subcommands and linear ingress start / start-local routes, and dynamic help-text stripping for hidden features. |
| apps/desktop/src/main/main.ts | Gates automationService, automationIngressService, githubPollingService, linearIngressService, automationPlannerService, and both macosVm service instances behind areAutomationsEnabledForPackagedState / isMacosVmEnabledForPackagedState. |
| apps/desktop/src/main/services/automations/automationService.ts | Adds webhook gateway status tracking (Tailscale probe via execFile, publicUrl persistence in project config), assertWebhookGatewayReadyForRule gating, and new public methods; getIngressStatus() mutates ingressStatusRef and normalizePublicWebhookUrl is duplicated vs. linearIngressService.ts. |
| apps/desktop/src/main/services/cto/linearIngressService.ts | Adds direct-webhook fallback path, env-var relay config overrides, and startLocalWebhook as a public method; orphaned webhook accumulation when the gateway URL changes is not handled. |
| apps/desktop/src/main/services/automations/automationIngressService.ts | Adds a /github-webhooks endpoint with HMAC verification and full GitHub event → AutomationTriggerType mapping; path normalization under /ade-webhooks/ is correctly handled. |
| apps/desktop/src/main/services/adeActions/registry.ts | Adds automations/macosVm/linearIngress domain nullification based on packaged state and new startIngress / refreshWebhookGatewayStatus / setWebhookGatewayPublicUrl action entries. |
| apps/desktop/src/renderer/components/automations/AutomationsPage.tsx | Wraps Automations UI in AutomationsProductionGate; defaults to dev on IPC error, which could briefly show the full UI to packaged users. |
| apps/desktop/src/renderer/components/graph/WorkspaceGraphPage.tsx | Fixes in-place mutation of completed[] in rollback loops and adds undoToastPending guard to prevent double-click undo race; both are correct bug fixes. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[App Start / CLI Invoked] --> B{isPackaged?}
    B -- Yes / packaged --> C[automationsEnabled = false\nmacosVmEnabled = false]
    B -- No / dev --> D[automationsEnabled = true\nmacosVmEnabled = true]
    B -- ENV override set --> E[readAutomationsEnvOverride\nreadMacosVmEnvOverride]
    E --> C
    E --> D
    C --> F[automationService = null\nlinearIngressService = null\nmacosVmService = null]
    C --> G[UI: ProductionAutomationsComingSoon]
    C --> H[ADE action domains: automations/linear_ingress/macos_vm → null]
    D --> I[automationService created]
    I --> J[refreshWebhookGatewayStatus\n— Tailscale probe via execFile]
    J --> K{publicUrl configured?}
    K -- Custom HTTPS URL --> L[Gateway ready]
    K -- Tailscale .ts.net URL --> M{Funnel active?}
    M -- Yes --> L
    M -- No --> N[pending-approval]
    K -- None --> O[needs-public-url]
    I --> P[automationIngressService\n/automation-webhooks/:id\n/github-webhooks — HMAC verified]
    I --> Q[linearIngressService\ndirect webhook or relay path]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `apps/desktop/src/main/services/automations/automationService.ts`, line 2779-2807 ([link](https://github.com/arul28/ade/blob/1e4380cc4d27f271b70894e4cd9f0058a327438b/apps/desktop/src/main/services/automations/automationService.ts#L2779-L2807)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`getIngressStatus()` silently mutates `ingressStatusRef`**

   `getIngressStatus()` directly assigns to `ingressStatusRef` without going through `updateIngressStatus()`, which means it bypasses the `emit({ type: "ingress-updated" })` side-channel. Callers reading status through subscribed events will not be notified of the re-computed values, while callers using the return value will see the updated data — two different pictures of the same state until the next explicit update. More importantly, every call to this method silently overwrites the current `ingressStatusRef`, including any freshly-refreshed Tailscale data written by `refreshWebhookGatewayStatus()`, because the block unconditionally overwrites `webhookGateway.status` with a fallback derivation that may lag the async refresh result.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/automations/automationService.ts
   Line: 2779-2807

   Comment:
   **`getIngressStatus()` silently mutates `ingressStatusRef`**

   `getIngressStatus()` directly assigns to `ingressStatusRef` without going through `updateIngressStatus()`, which means it bypasses the `emit({ type: "ingress-updated" })` side-channel. Callers reading status through subscribed events will not be notified of the re-computed values, while callers using the return value will see the updated data — two different pictures of the same state until the next explicit update. More importantly, every call to this method silently overwrites the current `ingressStatusRef`, including any freshly-refreshed Tailscale data written by `refreshWebhookGatewayStatus()`, because the block unconditionally overwrites `webhookGateway.status` with a fallback derivation that may lag the async refresh result.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fautomations%2FautomationService.ts%0ALine%3A%202779-2807%0A%0AComment%3A%0A**%60getIngressStatus%28%29%60%20silently%20mutates%20%60ingressStatusRef%60**%0A%0A%60getIngressStatus%28%29%60%20directly%20assigns%20to%20%60ingressStatusRef%60%20without%20going%20through%20%60updateIngressStatus%28%29%60%2C%20which%20means%20it%20bypasses%20the%20%60emit%28%7B%20type%3A%20%22ingress-updated%22%20%7D%29%60%20side-channel.%20Callers%20reading%20status%20through%20subscribed%20events%20will%20not%20be%20notified%20of%20the%20re-computed%20values%2C%20while%20callers%20using%20the%20return%20value%20will%20see%20the%20updated%20data%20%E2%80%94%20two%20different%20pictures%20of%20the%20same%20state%20until%20the%20next%20explicit%20update.%20More%20importantly%2C%20every%20call%20to%20this%20method%20silently%20overwrites%20the%20current%20%60ingressStatusRef%60%2C%20including%20any%20freshly-refreshed%20Tailscale%20data%20written%20by%20%60refreshWebhookGatewayStatus%28%29%60%2C%20because%20the%20block%20unconditionally%20overwrites%20%60webhookGateway.status%60%20with%20a%20fallback%20derivation%20that%20may%20lag%20the%20async%20refresh%20result.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=523&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


2. `apps/desktop/src/main/services/automations/automationService.ts`, line 2520-2531 ([link](https://github.com/arul28/ade/blob/1e4380cc4d27f271b70894e4cd9f0058a327438b/apps/desktop/src/main/services/automations/automationService.ts#L2520-L2531)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Duplicate `normalizePublicWebhookUrl` with diverging behavior**

   `linearIngressService.ts` defines its own `normalizePublicWebhookUrl` with two differences: it also clears `hash` and `search` from the URL, and it strips all trailing slashes (`/\/+$/`) instead of just one (`/\/$/`). A URL like `https://host.example.com/ade-webhooks//` normalizes to `https://host.example.com/ade-webhooks/` in `automationService.ts` but to `https://host.example.com/ade-webhooks` in `linearIngressService.ts`. The webhook URL appended by `appendWebhookPath` in `linearIngressService.ts` would then not match the `publicUrl` stored by `automationService`, breaking the `isReady` checks that compare the two values.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/automations/automationService.ts
   Line: 2520-2531

   Comment:
   **Duplicate `normalizePublicWebhookUrl` with diverging behavior**

   `linearIngressService.ts` defines its own `normalizePublicWebhookUrl` with two differences: it also clears `hash` and `search` from the URL, and it strips all trailing slashes (`/\/+$/`) instead of just one (`/\/$/`). A URL like `https://host.example.com/ade-webhooks//` normalizes to `https://host.example.com/ade-webhooks/` in `automationService.ts` but to `https://host.example.com/ade-webhooks` in `linearIngressService.ts`. The webhook URL appended by `appendWebhookPath` in `linearIngressService.ts` would then not match the `publicUrl` stored by `automationService`, breaking the `isReady` checks that compare the two values.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fautomations%2FautomationService.ts%0ALine%3A%202520-2531%0A%0AComment%3A%0A**Duplicate%20%60normalizePublicWebhookUrl%60%20with%20diverging%20behavior**%0A%0A%60linearIngressService.ts%60%20defines%20its%20own%20%60normalizePublicWebhookUrl%60%20with%20two%20differences%3A%20it%20also%20clears%20%60hash%60%20and%20%60search%60%20from%20the%20URL%2C%20and%20it%20strips%20all%20trailing%20slashes%20%28%60%2F%5C%2F%2B%24%2F%60%29%20instead%20of%20just%20one%20%28%60%2F%5C%2F%24%2F%60%29.%20A%20URL%20like%20%60https%3A%2F%2Fhost.example.com%2Fade-webhooks%2F%2F%60%20normalizes%20to%20%60https%3A%2F%2Fhost.example.com%2Fade-webhooks%2F%60%20in%20%60automationService.ts%60%20but%20to%20%60https%3A%2F%2Fhost.example.com%2Fade-webhooks%60%20in%20%60linearIngressService.ts%60.%20The%20webhook%20URL%20appended%20by%20%60appendWebhookPath%60%20in%20%60linearIngressService.ts%60%20would%20then%20not%20match%20the%20%60publicUrl%60%20stored%20by%20%60automationService%60%2C%20breaking%20the%20%60isReady%60%20checks%20that%20compare%20the%20two%20values.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=523&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>


3. `apps/desktop/src/renderer/components/automations/AutomationsPage.tsx`, line 144-176 ([link](https://github.com/arul28/ade/blob/1e4380cc4d27f271b70894e4cd9f0058a327438b/apps/desktop/src/renderer/components/automations/AutomationsPage.tsx#L144-L176)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **UI gate defaults to "dev" on IPC failure**

   When `window.ade.app.getInfo()` rejects (e.g., transient IPC error on startup), the `useAppPackagingState` hook resolves to `"dev"`, rendering the full Automations UI to packaged users. The backend gate (`automationsEnabled` in `main.ts` and `getAdeActionDomainServices`) still prevents actual execution, so data won't be exposed, but users will briefly see the Automations interface. Defaulting to `"packaged"` on error would be more conservative for a production gate.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/automations/AutomationsPage.tsx
   Line: 144-176

   Comment:
   **UI gate defaults to "dev" on IPC failure**

   When `window.ade.app.getInfo()` rejects (e.g., transient IPC error on startup), the `useAppPackagingState` hook resolves to `"dev"`, rendering the full Automations UI to packaged users. The backend gate (`automationsEnabled` in `main.ts` and `getAdeActionDomainServices`) still prevents actual execution, so data won't be exposed, but users will briefly see the Automations interface. Defaulting to `"packaged"` on error would be more conservative for a production gate.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fautomations%2FAutomationsPage.tsx%0ALine%3A%20144-176%0A%0AComment%3A%0A**UI%20gate%20defaults%20to%20%22dev%22%20on%20IPC%20failure**%0A%0AWhen%20%60window.ade.app.getInfo%28%29%60%20rejects%20%28e.g.%2C%20transient%20IPC%20error%20on%20startup%29%2C%20the%20%60useAppPackagingState%60%20hook%20resolves%20to%20%60%22dev%22%60%2C%20rendering%20the%20full%20Automations%20UI%20to%20packaged%20users.%20The%20backend%20gate%20%28%60automationsEnabled%60%20in%20%60main.ts%60%20and%20%60getAdeActionDomainServices%60%29%20still%20prevents%20actual%20execution%2C%20so%20data%20won't%20be%20exposed%2C%20but%20users%20will%20briefly%20see%20the%20Automations%20interface.%20Defaulting%20to%20%60%22packaged%22%60%20on%20error%20would%20be%20more%20conservative%20for%20a%20production%20gate.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=523&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fcto%2FlinearIngressService.ts%3A350-382%0A**Orphaned%20Linear%20webhooks%20on%20gateway%20URL%20change**%0A%0A%60ensureRelayEndpoint%60%20creates%20a%20new%20Linear%20webhook%20when%20%60direct.webhookUrl%60%20doesn't%20already%20exist%20in%20the%20list%20of%20registered%20webhooks.%20But%20when%20%60webhookGatewayPublicUrl%60%20is%20changed%20%28via%20%60setWebhookGatewayPublicUrl%60%29%2C%20the%20new%20URL%20produces%20a%20different%20%60direct.webhookUrl%60.%20The%20check%20%60!existing.some%28%28entry%29%20%3D%3E%20entry.url%20%3D%3D%3D%20direct.webhookUrl%29%60%20now%20misses%20the%20old%20entry%20and%20registers%20a%20second%20webhook.%20Both%20old%20and%20new%20URLs%20remain%20active%20on%20Linear's%20side%2C%20causing%20every%20event%20to%20be%20delivered%20twice%20%28duplicate%20%60handleIngressEvent%60%20calls%29%20until%20the%20stale%20registration%20is%20manually%20removed.%0A%0AThe%20same%20issue%20applies%20in%20reverse%3A%20if%20the%20gateway%20URL%20is%20cleared%2C%20the%20previously%20registered%20webhook%20is%20abandoned%20on%20Linear%20but%20continues%20to%20receive%20deliveries%20that%20will%20now%20404%20or%20go%20unprocessed.%0A%0A%23%23%23%20Issue%202%20of%205%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fautomations%2FautomationService.ts%3A2779-2807%0A**%60getIngressStatus%28%29%60%20silently%20mutates%20%60ingressStatusRef%60**%0A%0A%60getIngressStatus%28%29%60%20directly%20assigns%20to%20%60ingressStatusRef%60%20without%20going%20through%20%60updateIngressStatus%28%29%60%2C%20which%20means%20it%20bypasses%20the%20%60emit%28%7B%20type%3A%20%22ingress-updated%22%20%7D%29%60%20side-channel.%20Callers%20reading%20status%20through%20subscribed%20events%20will%20not%20be%20notified%20of%20the%20re-computed%20values%2C%20while%20callers%20using%20the%20return%20value%20will%20see%20the%20updated%20data%20%E2%80%94%20two%20different%20pictures%20of%20the%20same%20state%20until%20the%20next%20explicit%20update.%20More%20importantly%2C%20every%20call%20to%20this%20method%20silently%20overwrites%20the%20current%20%60ingressStatusRef%60%2C%20including%20any%20freshly-refreshed%20Tailscale%20data%20written%20by%20%60refreshWebhookGatewayStatus%28%29%60%2C%20because%20the%20block%20unconditionally%20overwrites%20%60webhookGateway.status%60%20with%20a%20fallback%20derivation%20that%20may%20lag%20the%20async%20refresh%20result.%0A%0A%23%23%23%20Issue%203%20of%205%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fautomations%2FautomationService.ts%3A2520-2531%0A**Duplicate%20%60normalizePublicWebhookUrl%60%20with%20diverging%20behavior**%0A%0A%60linearIngressService.ts%60%20defines%20its%20own%20%60normalizePublicWebhookUrl%60%20with%20two%20differences%3A%20it%20also%20clears%20%60hash%60%20and%20%60search%60%20from%20the%20URL%2C%20and%20it%20strips%20all%20trailing%20slashes%20%28%60%2F%5C%2F%2B%24%2F%60%29%20instead%20of%20just%20one%20%28%60%2F%5C%2F%24%2F%60%29.%20A%20URL%20like%20%60https%3A%2F%2Fhost.example.com%2Fade-webhooks%2F%2F%60%20normalizes%20to%20%60https%3A%2F%2Fhost.example.com%2Fade-webhooks%2F%60%20in%20%60automationService.ts%60%20but%20to%20%60https%3A%2F%2Fhost.example.com%2Fade-webhooks%60%20in%20%60linearIngressService.ts%60.%20The%20webhook%20URL%20appended%20by%20%60appendWebhookPath%60%20in%20%60linearIngressService.ts%60%20would%20then%20not%20match%20the%20%60publicUrl%60%20stored%20by%20%60automationService%60%2C%20breaking%20the%20%60isReady%60%20checks%20that%20compare%20the%20two%20values.%0A%0A%23%23%23%20Issue%204%20of%205%0Aapps%2Fade-cli%2Fsrc%2Fbootstrap.ts%3A271-290%0A**%60isSourceCheckoutRuntimeModule%60%20regex%20matches%20%60dist%2Fbootstrap.cjs%60%20in%20the%20source%20tree**%0A%0AThe%20pattern%20matches%20both%20%60src%2Fbootstrap.ts%60%20%28dev%29%20and%20%60dist%2Fbootstrap.cjs%60%20%28local%20build%29.%20A%20developer%20who%20builds%20the%20CLI%20and%20runs%20it%20outside%20the%20source%20tree%20would%20still%20be%20gated%20correctly%2C%20but%20this%20asymmetry%20is%20worth%20keeping%20in%20mind%20if%20the%20%60dist%2F%60%20artifacts%20are%20ever%20distributed%20separately%20from%20the%20packaged%20build.%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=arul28%2Fade&pr=523&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
apps/desktop/src/main/services/cto/linearIngressService.ts:350-382
**Orphaned Linear webhooks on gateway URL change**

`ensureRelayEndpoint` creates a new Linear webhook when `direct.webhookUrl` doesn't already exist in the list of registered webhooks. But when `webhookGatewayPublicUrl` is changed (via `setWebhookGatewayPublicUrl`), the new URL produces a different `direct.webhookUrl`. The check `!existing.some((entry) => entry.url === direct.webhookUrl)` now misses the old entry and registers a second webhook. Both old and new URLs remain active on Linear's side, causing every event to be delivered twice (duplicate `handleIngressEvent` calls) until the stale registration is manually removed.

The same issue applies in reverse: if the gateway URL is cleared, the previously registered webhook is abandoned on Linear but continues to receive deliveries that will now 404 or go unprocessed.

### Issue 2 of 5
apps/desktop/src/main/services/automations/automationService.ts:2779-2807
**`getIngressStatus()` silently mutates `ingressStatusRef`**

`getIngressStatus()` directly assigns to `ingressStatusRef` without going through `updateIngressStatus()`, which means it bypasses the `emit({ type: "ingress-updated" })` side-channel. Callers reading status through subscribed events will not be notified of the re-computed values, while callers using the return value will see the updated data — two different pictures of the same state until the next explicit update. More importantly, every call to this method silently overwrites the current `ingressStatusRef`, including any freshly-refreshed Tailscale data written by `refreshWebhookGatewayStatus()`, because the block unconditionally overwrites `webhookGateway.status` with a fallback derivation that may lag the async refresh result.

### Issue 3 of 5
apps/desktop/src/main/services/automations/automationService.ts:2520-2531
**Duplicate `normalizePublicWebhookUrl` with diverging behavior**

`linearIngressService.ts` defines its own `normalizePublicWebhookUrl` with two differences: it also clears `hash` and `search` from the URL, and it strips all trailing slashes (`/\/+$/`) instead of just one (`/\/$/`). A URL like `https://host.example.com/ade-webhooks//` normalizes to `https://host.example.com/ade-webhooks/` in `automationService.ts` but to `https://host.example.com/ade-webhooks` in `linearIngressService.ts`. The webhook URL appended by `appendWebhookPath` in `linearIngressService.ts` would then not match the `publicUrl` stored by `automationService`, breaking the `isReady` checks that compare the two values.

### Issue 4 of 5
apps/ade-cli/src/bootstrap.ts:271-290
**`isSourceCheckoutRuntimeModule` regex matches `dist/bootstrap.cjs` in the source tree**

The pattern matches both `src/bootstrap.ts` (dev) and `dist/bootstrap.cjs` (local build). A developer who builds the CLI and runs it outside the source tree would still be gated correctly, but this asymmetry is worth keeping in mind if the `dist/` artifacts are ever distributed separately from the packaged build.

### Issue 5 of 5
apps/desktop/src/renderer/components/automations/AutomationsPage.tsx:144-176
**UI gate defaults to "dev" on IPC failure**

When `window.ade.app.getInfo()` rejects (e.g., transient IPC error on startup), the `useAppPackagingState` hook resolves to `"dev"`, rendering the full Automations UI to packaged users. The backend gate (`automationsEnabled` in `main.ts` and `getAdeActionDomainServices`) still prevents actual execution, so data won't be exposed, but users will briefly see the Automations interface. Defaulting to `"packaged"` on error would be more conservative for a production gate.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Gate automations and VM in production bu..."](https://github.com/arul28/ade/commit/1e4380cc4d27f271b70894e4cd9f0058a327438b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35283841)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->