### PR TITLE
Chat Flicker Scroll Snap

### DIFF
--- a/apps/desktop/src/renderer/components/chat/AgentChatMessageList.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatMessageList.test.tsx
@@ -50,6 +50,7 @@ import {
   deriveTurnModelState,
   reconcileMeasuredScrollTop,
   shouldAbsorbProgrammaticScrollEvent,
+  shouldStickToBottomAfterScroll,
 } from "./AgentChatMessageList";
 
 function findButtonByTextContent(matcher: RegExp): HTMLButtonElement {
@@ -694,6 +695,83 @@ describe("AgentChatMessageList transcript rendering", () => {
     await waitFor(() => {
       expect(screen.queryByRole("button", { name: "Jump to latest message" })).toBeNull();
     });
+  });
+
+  it("does not resume bottom stickiness until the user returns to latest", () => {
+    expect(shouldStickToBottomAfterScroll({
+      distanceFromBottom: 80,
+      wasStuckToBottom: true,
+    })).toBe(true);
+    expect(shouldStickToBottomAfterScroll({
+      distanceFromBottom: 80,
+      wasStuckToBottom: false,
+    })).toBe(false);
+    expect(shouldStickToBottomAfterScroll({
+      distanceFromBottom: 12,
+      wasStuckToBottom: false,
+    })).toBe(true);
+  });
+
+  it("lets upward wheel intent break bottom-follow before streaming output grows", async () => {
+    const events: AgentChatEventEnvelope[] = [
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:00.000Z",
+        event: {
+          type: "user_message",
+          text: "Start streaming",
+          deliveryState: "delivered",
+        },
+      },
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:01.000Z",
+        event: {
+          type: "text",
+          text: "Streaming chunk",
+          itemId: "text-1",
+          turnId: "turn-1",
+        },
+      },
+    ];
+    const view = renderMessageList(events, { showStreamingIndicator: true });
+
+    const transcript = document.querySelector(".ade-chat-timeline-pane") as HTMLDivElement;
+    Object.defineProperty(transcript, "scrollHeight", { configurable: true, value: 1_000 });
+    Object.defineProperty(transcript, "clientHeight", { configurable: true, value: 200 });
+    transcript.scrollTop = 800;
+
+    fireEvent.wheel(transcript, { deltaY: -80 });
+    transcript.scrollTop = 760;
+    fireEvent.scroll(transcript);
+
+    expect(await screen.findByRole("button", { name: "Jump to latest message" })).toBeTruthy();
+
+    Object.defineProperty(transcript, "scrollHeight", { configurable: true, value: 1_100 });
+    view.rerender(
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <AgentChatMessageList
+          events={[
+            ...events,
+            {
+              sessionId: "session-1",
+              timestamp: "2026-03-17T10:00:02.000Z",
+              event: {
+                type: "text",
+                text: "More streaming output",
+                itemId: "text-2",
+                turnId: "turn-1",
+              },
+            },
+          ]}
+          showStreamingIndicator
+        />
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()));
+    expect(transcript.scrollTop).toBe(760);
   });
 
   it("jumps through the user message minimap", () => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
@@ -3554,6 +3554,7 @@ const VIRTUALIZATION_THRESHOLD = 60;
  */
 const STICK_THRESHOLD_PX = 160;
 const STICK_RESUME_THRESHOLD_PX = 24;
+const TOUCH_SCROLL_DEADBAND_PX = 2;
 
 export function shouldAbsorbProgrammaticScrollEvent({
   scrollTop,
@@ -4487,7 +4488,7 @@ function AgentChatMessageListMain({
   const handleTouchMove = useCallback((event: React.TouchEvent<HTMLDivElement>) => {
     const nextY = event.touches[0]?.clientY ?? null;
     const previousY = lastTouchYRef.current;
-    if (nextY != null && previousY != null && nextY - previousY > 2) {
+    if (nextY != null && previousY != null && nextY - previousY > TOUCH_SCROLL_DEADBAND_PX) {
       releaseBottomStickinessForUserScroll();
     }
     lastTouchYRef.current = nextY;

--- a/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
@@ -3553,6 +3553,7 @@ const VIRTUALIZATION_THRESHOLD = 60;
  * auto-follow rather than being snapped back.
  */
 const STICK_THRESHOLD_PX = 160;
+const STICK_RESUME_THRESHOLD_PX = 24;
 
 export function shouldAbsorbProgrammaticScrollEvent({
   scrollTop,
@@ -3562,6 +3563,18 @@ export function shouldAbsorbProgrammaticScrollEvent({
   programmaticTarget: number | null;
 }): boolean {
   return programmaticTarget != null && Math.abs(scrollTop - programmaticTarget) < 1;
+}
+
+export function shouldStickToBottomAfterScroll({
+  distanceFromBottom,
+  wasStuckToBottom,
+}: {
+  distanceFromBottom: number;
+  wasStuckToBottom: boolean;
+}): boolean {
+  return wasStuckToBottom
+    ? distanceFromBottom < STICK_THRESHOLD_PX
+    : distanceFromBottom <= STICK_RESUME_THRESHOLD_PX;
 }
 
 export function calculateVirtualWindow({
@@ -4091,6 +4104,7 @@ function AgentChatMessageListMain({
   // into at most one scrollTop assignment per frame.
   const scrollRafRef = useRef<number | null>(null);
   const scrollFollowFramesRef = useRef(0);
+  const lastTouchYRef = useRef<number | null>(null);
   // Programmatic scroll writes can be coalesced by the browser. Track the
   // latest ADE-authored scrollTop target instead of using a counter, so a real
   // user scroll never gets swallowed by stale "programmatic" credits.
@@ -4279,6 +4293,19 @@ function AgentChatMessageListMain({
     scrollRafRef.current = requestAnimationFrame(run);
   }, []);
 
+  const releaseBottomStickinessForUserScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el || el.scrollHeight <= el.clientHeight + 1 || !stickToBottomRef.current) return;
+    stickToBottomRef.current = false;
+    setStickToBottom(false);
+    scrollFollowFramesRef.current = 0;
+    programmaticScrollTargetRef.current = null;
+    if (scrollRafRef.current !== null) {
+      cancelAnimationFrame(scrollRafRef.current);
+      scrollRafRef.current = null;
+    }
+  }, []);
+
   useEffect(() => () => {
     if (scrollRafRef.current !== null) {
       cancelAnimationFrame(scrollRafRef.current);
@@ -4436,12 +4463,38 @@ function AgentChatMessageListMain({
     // Wider threshold (~1 row of assistant text) so a small wheel nudge
     // while the turn is streaming actually breaks free instead of snapping
     // straight back to the bottom.
-    const nextStick = distanceFromBottom < STICK_THRESHOLD_PX;
+    const nextStick = shouldStickToBottomAfterScroll({
+      distanceFromBottom,
+      wasStuckToBottom: stickToBottomRef.current,
+    });
     if (nextStick !== stickToBottomRef.current) {
       stickToBottomRef.current = nextStick;
       setStickToBottom(nextStick);
     }
     setScrollTop(target.scrollTop);
+  }, []);
+
+  const handleWheel = useCallback((event: React.WheelEvent<HTMLDivElement>) => {
+    if (event.deltaY < 0) {
+      releaseBottomStickinessForUserScroll();
+    }
+  }, [releaseBottomStickinessForUserScroll]);
+
+  const handleTouchStart = useCallback((event: React.TouchEvent<HTMLDivElement>) => {
+    lastTouchYRef.current = event.touches[0]?.clientY ?? null;
+  }, []);
+
+  const handleTouchMove = useCallback((event: React.TouchEvent<HTMLDivElement>) => {
+    const nextY = event.touches[0]?.clientY ?? null;
+    const previousY = lastTouchYRef.current;
+    if (nextY != null && previousY != null && nextY - previousY > 2) {
+      releaseBottomStickinessForUserScroll();
+    }
+    lastTouchYRef.current = nextY;
+  }, [releaseBottomStickinessForUserScroll]);
+
+  const handleTouchEnd = useCallback(() => {
+    lastTouchYRef.current = null;
   }, []);
 
   const jumpToLatest = useCallback(() => {
@@ -4642,6 +4695,11 @@ function AgentChatMessageListMain({
         ref={scrollRef}
         className="ade-chat-timeline-pane h-full min-h-0 min-w-0 overflow-x-hidden overflow-y-auto pl-[length:var(--chat-timeline-pad-x)] pr-[length:var(--chat-timeline-pad-x)] pt-[length:var(--chat-timeline-pad-top)] pb-[length:var(--chat-timeline-pad-bottom)]"
         onScroll={handleScroll}
+        onWheel={handleWheel}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchEnd}
       >
         <div ref={contentWrapperRef} className="min-w-0 max-w-full overflow-visible">
           {rows.length === 0 && !streamingIndicator ? (

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -5526,6 +5526,31 @@ describe("mergeChatHistorySnapshot", () => {
       "same millisecond tail",
     ]);
   });
+
+  it("preserves existing event object identity when a recovery snapshot is unchanged", () => {
+    const first = envelope("2026-04-30T23:14:47.751Z", 1003, "first");
+    const second = envelope("2026-04-30T23:19:57.083Z", 1004, "second");
+    const parsedFirst = envelope("2026-04-30T23:14:47.751Z", 1003, "first");
+    const parsedSecond = envelope("2026-04-30T23:19:57.083Z", 1004, "second");
+
+    const existing = [first, second];
+    const merged = mergeChatHistorySnapshot([parsedFirst, parsedSecond], existing);
+
+    expect(merged).toBe(existing);
+    expect(merged[0]).toBe(first);
+    expect(merged[1]).toBe(second);
+  });
+
+  it("reuses existing snapshot entries while appending newly recovered events", () => {
+    const first = envelope("2026-04-30T23:14:47.751Z", 1003, "first");
+    const parsedFirst = envelope("2026-04-30T23:14:47.751Z", 1003, "first");
+    const parsedSecond = envelope("2026-04-30T23:19:57.083Z", 1004, "second");
+
+    const merged = mergeChatHistorySnapshot([parsedFirst, parsedSecond], [first]);
+
+    expect(merged[0]).toBe(first);
+    expect(merged[1]).toBe(parsedSecond);
+  });
 });
 
 describe("subagent auto-open storage", () => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -1269,7 +1269,17 @@ export function mergeChatHistorySnapshot(
   if (!existing.length) return parsed;
   if (!parsed.length) return existing;
 
-  const parsedKeys = new Set(parsed.map(chatEventDedupKey));
+  const existingByKey = new Map<string, AgentChatEventEnvelope>();
+  for (const entry of existing) {
+    const key = chatEventDedupKey(entry);
+    if (!existingByKey.has(key)) existingByKey.set(key, entry);
+  }
+  const parsedKeys = new Set<string>();
+  const normalizedParsed = parsed.map((entry) => {
+    const key = chatEventDedupKey(entry);
+    parsedKeys.add(key);
+    return existingByKey.get(key) ?? entry;
+  });
   const lastParsedKey = chatEventDedupKey(parsed[parsed.length - 1]!);
   let overlapIndex = -1;
   for (let index = existing.length - 1; index >= 0; index -= 1) {
@@ -1290,7 +1300,11 @@ export function mergeChatHistorySnapshot(
         return entry.timestamp > parsed[parsed.length - 1]!.timestamp;
       });
   const tail = tailCandidates.filter((entry) => !parsedKeys.has(chatEventDedupKey(entry)));
-  return tail.length ? [...parsed, ...tail] : parsed;
+  const merged = tail.length ? [...normalizedParsed, ...tail] : normalizedParsed;
+  if (merged.length === existing.length && merged.every((entry, index) => entry === existing[index])) {
+    return existing;
+  }
+  return merged;
 }
 
 function pruneSessionRecord<T>(record: Record<string, T>, keepIds: ReadonlySet<string>): Record<string, T> {


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fchat-flicker-scroll-snap-7ffceeec num=524 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fchat-flicker-scroll-snap-7ffceeec&amp;pr=524">ade/chat-flicker-scroll-snap-7ffceeec branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=524">PR #524</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced chat message auto-scroll behavior during streaming. The app now respects user scrolling intent—if you scroll upward while new messages are streaming, auto-scroll pauses instead of forcing the view back to the bottom.
  * Improved chat history recovery and merge logic for more reliable message synchronization and data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the auto-scroll experience in the chat view by detecting user scroll intent (wheel and touch events) before new streaming content arrives and triggers an auto-snap. It also refines `mergeChatHistorySnapshot` to preserve object identity for unchanged events, enabling React to skip unnecessary re-renders.

- **Scroll intent detection**: `handleWheel` and `handleTouchMove` call `releaseBottomStickinessForUserScroll` before the RAF-based auto-scroll fires, so upward gestures during streaming reliably break free. `shouldStickToBottomAfterScroll` introduces hysteresis: re-sticking only happens when the user returns to within 24 px of the bottom.
- **History merge optimisation**: `mergeChatHistorySnapshot` now builds a key→entry map over `existing` and substitutes matching parsed entries with their original object references, short-circuiting to return the same array when nothing changed.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the pinch-to-zoom guard applied; without it, zooming in during streaming silently disables auto-scroll for the rest of the session.

The wheel handler releases auto-scroll stickiness on any negative deltaY without checking ctrlKey. Trackpad pinch-to-zoom delivers exactly those events (negative deltaY, ctrlKey true) but does not move scrollTop, so handleScroll never fires to re-engage stickiness — leaving auto-scroll permanently disabled for the conversation. Everything else in the PR (touch handling, hysteresis logic, history merge) looks correct and is well-covered by tests.

apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx — specifically the handleWheel callback

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx | Adds wheel/touch intent detection to break auto-scroll stickiness before streaming content snaps back; handleWheel misses the ctrlKey guard needed to ignore pinch-to-zoom gestures, which can permanently disable auto-scroll. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | mergeChatHistorySnapshot now preserves object identity for unchanged events (dedup-key lookup via Map) and short-circuits by returning the original array when no entries changed; logic is correct and well-tested. |
| apps/desktop/src/renderer/components/chat/AgentChatMessageList.test.tsx | Adds unit tests for shouldStickToBottomAfterScroll and an integration test verifying that an upward wheel event breaks streaming auto-scroll; coverage is appropriate for the new behavior. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx | Adds two tests for the mergeChatHistorySnapshot identity-preservation optimization; both cases (fully identical and partially matching) are covered. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User wheel / touch event] --> B{Event type}
    B -->|onWheel deltaY < 0| C{ctrlKey?}
    C -->|No - scroll up| D[releaseBottomStickinessForUserScroll]
    C -->|Yes - pinch-to-zoom| E[⚠ Bug: also releases stickiness]
    B -->|onTouchMove nextY - prevY > 2px| D
    D --> F[stickToBottomRef = false\ncancel RAF]
    F --> G[Streaming content grows\nResizeObserver fires]
    G --> H{stickToBottomRef?}
    H -->|true| I[scrollToBottomSoon RAF]
    H -->|false| J[No auto-scroll ✓]
    K[onScroll] --> L[shouldStickToBottomAfterScroll]
    L --> M{wasStuckToBottom?}
    M -->|true| N[stick if dist < 160 px]
    M -->|false| O[stick if dist ≤ 24 px]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FAgentChatMessageList.tsx%3A4478-4482%0A**Pinch-to-zoom%20kills%20auto-scroll%20permanently**%0A%0AOn%20trackpads%2C%20browsers%20fire%20%60wheel%60%20events%20with%20%60ctrlKey%3A%20true%60%20when%20the%20user%20pinch-zooms.%20Zooming%20in%20%28spreading%20fingers%29%20produces%20%60deltaY%20%3C%200%60%2C%20so%20this%20handler%20calls%20%60releaseBottomStickinessForUserScroll%28%29%60%20%E2%80%94%20which%20sets%20%60stickToBottomRef.current%20%3D%20false%60%20and%20cancels%20the%20RAF.%20Crucially%2C%20pinch-to-zoom%20does%20**not**%20move%20%60scrollTop%60%2C%20so%20%60handleScroll%60%20never%20fires%20to%20re-engage%20stickiness.%20The%20result%3A%20a%20user%20who%20zooms%20in%20while%20a%20message%20is%20streaming%20silently%20loses%20auto-scroll%20for%20the%20rest%20of%20the%20conversation%20and%20must%20manually%20click%20%22Jump%20to%20latest%22.%0A%0A%60%60%60suggestion%0A%20%20const%20handleWheel%20%3D%20useCallback%28%28event%3A%20React.WheelEvent%3CHTMLDivElement%3E%29%20%3D%3E%20%7B%0A%20%20%20%20if%20%28event.deltaY%20%3C%200%20%26%26%20!event.ctrlKey%29%20%7B%0A%20%20%20%20%20%20releaseBottomStickinessForUserScroll%28%29%3B%0A%20%20%20%20%7D%0A%20%20%7D%2C%20%5BreleaseBottomStickinessForUserScroll%5D%29%3B%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=524&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx:4478-4482
**Pinch-to-zoom kills auto-scroll permanently**

On trackpads, browsers fire `wheel` events with `ctrlKey: true` when the user pinch-zooms. Zooming in (spreading fingers) produces `deltaY < 0`, so this handler calls `releaseBottomStickinessForUserScroll()` — which sets `stickToBottomRef.current = false` and cancels the RAF. Crucially, pinch-to-zoom does **not** move `scrollTop`, so `handleScroll` never fires to re-engage stickiness. The result: a user who zooms in while a message is streaming silently loses auto-scroll for the rest of the conversation and must manually click "Jump to latest".

```suggestion
  const handleWheel = useCallback((event: React.WheelEvent<HTMLDivElement>) => {
    if (event.deltaY < 0 && !event.ctrlKey) {
      releaseBottomStickinessForUserScroll();
    }
  }, [releaseBottomStickinessForUserScroll]);
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Address chat scroll review note"](https://github.com/arul28/ade/commit/b43c39cf595e45b8fef5a613fb5a058558cf552d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35327001)</sub>

<!-- /greptile_comment -->