### PR TITLE
Fix chat history OOM hydration

### DIFF
--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -10777,13 +10777,15 @@ describe("createAgentChatService", () => {
       const history = service.getChatEventHistory("unknown-session");
       expect(history.events).toEqual([]);
       expect(history.truncated).toBe(false);
+      expect(history.transcriptTruncated).toBe(false);
+      expect(history.windowTruncated).toBe(false);
       expect(history.sessionFound).toBe(false);
     });
 
     it("hydrates history from the on-disk transcript on first read", async () => {
       // This is the core contract that fixes chat-history-loss on project
       // switch / tab switch: a late subscriber that missed the live broadcast
-      // still sees the full history, because getChatEventHistory hydrates
+      // still sees persisted recent history, because getChatEventHistory hydrates
       // itself from the transcript the first time the session is queried.
       const { service } = createService();
       const session = await service.createSession({
@@ -10818,6 +10820,144 @@ describe("createAgentChatService", () => {
       expect(history.events.map((envelope) =>
         envelope.event.type === "text" ? envelope.event.text : "",
       )).toEqual(["persisted-1", "persisted-2"]);
+    });
+
+    it("bounds oversized transcript hydration before parsing", async () => {
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+
+      const oldEnvelope: AgentChatEventEnvelope = {
+        sessionId: session.id,
+        timestamp: "2026-04-23T09:59:00.000Z",
+        event: { type: "text", text: "old-head" },
+        sequence: 1,
+      };
+      const recentEnvelope: AgentChatEventEnvelope = {
+        sessionId: session.id,
+        timestamp: "2026-04-23T10:01:00.000Z",
+        event: { type: "text", text: "recent-tail" },
+        sequence: 2,
+      };
+
+      const transcriptFile = path.join(tmpRoot, "transcripts", `${session.id}.chat.jsonl`);
+      const hugeMiddleEnvelope: AgentChatEventEnvelope = {
+        sessionId: session.id,
+        timestamp: "2026-04-23T10:00:00.000Z",
+        event: { type: "text", text: "x".repeat(2_100_000) },
+        sequence: 2,
+      };
+      fs.writeFileSync(
+        transcriptFile,
+        [
+          JSON.stringify(oldEnvelope),
+          JSON.stringify(hugeMiddleEnvelope),
+          JSON.stringify(recentEnvelope),
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      vi.mocked(parseAgentChatTranscript).mockImplementation((raw) => {
+        expect(raw.length).toBeLessThan(50_000);
+        expect(raw).toContain("recent-tail");
+        expect(raw).not.toContain("old-head");
+        return [recentEnvelope];
+      });
+
+      const history = service.getChatEventHistory(session.id);
+
+      expect(history.truncated).toBe(true);
+      expect(history.transcriptTruncated).toBe(true);
+      expect(history.windowTruncated).toBe(false);
+      expect(history.events.map((envelope) =>
+        envelope.event.type === "text" ? envelope.event.text : "",
+      )).toEqual(["recent-tail"]);
+    });
+
+    it("separates max-event window truncation from transcript-tail truncation", async () => {
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+
+      const envelopes: AgentChatEventEnvelope[] = Array.from({ length: 5 }, (_, index) => ({
+        sessionId: session.id,
+        timestamp: `2026-04-23T10:0${index}:00.000Z`,
+        event: { type: "text", text: `event-${index}` },
+        sequence: index + 1,
+      }));
+      const transcriptFile = path.join(tmpRoot, "transcripts", `${session.id}.chat.jsonl`);
+      fs.writeFileSync(transcriptFile, `${envelopes.map((entry) => JSON.stringify(entry)).join("\n")}\n`, "utf8");
+      vi.mocked(parseAgentChatTranscript).mockReturnValue(envelopes);
+
+      const history = service.getChatEventHistory(session.id, { maxEvents: 3 });
+
+      expect(history.truncated).toBe(true);
+      expect(history.transcriptTruncated).toBe(false);
+      expect(history.windowTruncated).toBe(true);
+      expect(history.events.map((envelope) =>
+        envelope.event.type === "text" ? envelope.event.text : "",
+      )).toEqual(["event-2", "event-3", "event-4"]);
+    });
+
+    it("marks window truncation when the service response cap removes events", async () => {
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+
+      const envelopes: AgentChatEventEnvelope[] = Array.from({ length: 20_001 }, (_, index) => ({
+        sessionId: session.id,
+        timestamp: new Date(Date.UTC(2026, 3, 23, 10, 0, index)).toISOString(),
+        event: { type: "text", text: `event-${index}` },
+        sequence: index + 1,
+      }));
+      const transcriptFile = path.join(tmpRoot, "transcripts", `${session.id}.chat.jsonl`);
+      fs.writeFileSync(transcriptFile, "ignored\n", "utf8");
+      vi.mocked(parseAgentChatTranscript).mockReturnValue(envelopes);
+
+      const history = service.getChatEventHistory(session.id);
+
+      expect(history.events).toHaveLength(20_000);
+      expect(history.truncated).toBe(true);
+      expect(history.transcriptTruncated).toBe(false);
+      expect(history.windowTruncated).toBe(true);
+      expect(history.events[0]?.event).toMatchObject({ type: "text", text: "event-1" });
+    });
+
+    it("reuses an unchanged parsed transcript tail across repeated history snapshots", async () => {
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+      });
+
+      const envelope: AgentChatEventEnvelope = {
+        sessionId: session.id,
+        timestamp: "2026-04-23T10:00:00.000Z",
+        event: { type: "text", text: "persisted-once" },
+        sequence: 1,
+      };
+
+      const transcriptFile = path.join(tmpRoot, "transcripts", `${session.id}.chat.jsonl`);
+      fs.writeFileSync(transcriptFile, `${JSON.stringify(envelope)}\n`, "utf8");
+      vi.mocked(parseAgentChatTranscript).mockClear();
+      vi.mocked(parseAgentChatTranscript).mockReturnValue([envelope]);
+
+      const firstHistory = service.getChatEventHistory(session.id);
+      const secondHistory = service.getChatEventHistory(session.id);
+
+      expect(firstHistory.events).toHaveLength(1);
+      expect(secondHistory.events).toHaveLength(1);
+      expect(parseAgentChatTranscript).toHaveBeenCalledTimes(1);
     });
 
     it("re-reads the on-disk transcript on repeated history snapshots", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -5150,7 +5150,16 @@ export function createAgentChatService(args: {
   // have reached fs.appendFile yet.
   const CHAT_EVENT_HISTORY_BUFFER_MAX_PER_SESSION = 4_000;
   const CHAT_EVENT_HISTORY_RESPONSE_MAX_PER_SESSION = 20_000;
+  const CHAT_EVENT_HISTORY_TRANSCRIPT_MAX_BYTES = 2_000_000;
+  const CHAT_EVENT_HISTORY_TRANSCRIPT_CACHE_MAX_SESSIONS = 32;
   const eventHistoryBySession = new Map<string, AgentChatEventEnvelope[]>();
+  const transcriptHistoryCacheBySession = new Map<string, {
+    transcriptPath: string;
+    size: number;
+    mtimeMs: number;
+    truncated: boolean;
+    envelopes: AgentChatEventEnvelope[];
+  }>();
 
   const recordChatEventInHistory = (envelope: AgentChatEventEnvelope): void => {
     const current = eventHistoryBySession.get(envelope.sessionId) ?? [];
@@ -5159,6 +5168,25 @@ export function createAgentChatService(args: {
       current.splice(0, current.length - CHAT_EVENT_HISTORY_BUFFER_MAX_PER_SESSION);
     }
     eventHistoryBySession.set(envelope.sessionId, current);
+  };
+
+  const rememberTranscriptHistoryCache = (
+    sessionId: string,
+    entry: {
+      transcriptPath: string;
+      size: number;
+      mtimeMs: number;
+      truncated: boolean;
+      envelopes: AgentChatEventEnvelope[];
+    },
+  ): void => {
+    transcriptHistoryCacheBySession.delete(sessionId);
+    transcriptHistoryCacheBySession.set(sessionId, entry);
+    while (transcriptHistoryCacheBySession.size > CHAT_EVENT_HISTORY_TRANSCRIPT_CACHE_MAX_SESSIONS) {
+      const oldestSessionId = transcriptHistoryCacheBySession.keys().next().value;
+      if (typeof oldestSessionId !== "string") break;
+      transcriptHistoryCacheBySession.delete(oldestSessionId);
+    }
   };
 
   let computerUseArtifactBrokerRef = computerUseArtifactBrokerService ?? null;
@@ -6355,20 +6383,77 @@ export function createAgentChatService(args: {
     return null;
   };
 
-  // Read the full on-disk transcript for a session without requiring an active
-  // ManagedChatSession. Used by getChatEventHistory to hydrate the in-memory
-  // ring buffer on first read, even for sessions that haven't been resumed yet
-  // (e.g. a chat whose runtime was torn down by idle_ttl / budget_eviction).
-  const readTranscriptEnvelopesForSessionId = (sessionId: string): AgentChatEventEnvelope[] => {
+  const readTranscriptTailForHistory = (
+    transcriptPath: string,
+    stat: fs.Stats,
+  ): { raw: string; truncated: boolean } => {
+    const size = stat.size;
+    const start = Math.max(0, size - CHAT_EVENT_HISTORY_TRANSCRIPT_MAX_BYTES);
+    const length = size - start;
+    if (length <= 0) return { raw: "", truncated: false };
+    const fd = fs.openSync(transcriptPath, "r");
+    try {
+      const out = Buffer.allocUnsafe(length);
+      const bytesRead = fs.readSync(fd, out, 0, out.length, start);
+      let slice = bytesRead === out.length ? out : out.subarray(0, bytesRead);
+      const truncated = start > 0;
+      if (truncated && slice.length > 0) {
+        const nextNewline = slice.indexOf(0x0a);
+        if (nextNewline >= 0 && nextNewline + 1 < slice.length) {
+          slice = slice.subarray(nextNewline + 1);
+        } else {
+          slice = Buffer.alloc(0);
+        }
+      }
+      return { raw: slice.toString("utf8"), truncated };
+    } finally {
+      fs.closeSync(fd);
+    }
+  };
+
+  const parseTranscriptHistoryTail = (
+    sessionId: string,
+    transcriptPath: string,
+  ): { envelopes: AgentChatEventEnvelope[]; truncated: boolean } => {
+    const stat = fs.statSync(transcriptPath);
+    const cached = transcriptHistoryCacheBySession.get(sessionId);
+    if (
+      cached
+      && cached.transcriptPath === transcriptPath
+      && cached.size === stat.size
+      && cached.mtimeMs === stat.mtimeMs
+    ) {
+      rememberTranscriptHistoryCache(sessionId, cached);
+      return { envelopes: cached.envelopes.slice(), truncated: cached.truncated };
+    }
+
+    const { raw, truncated } = readTranscriptTailForHistory(transcriptPath, stat);
+    const envelopes = parseAgentChatTranscript(raw)
+      .filter((entry) => entry.sessionId === sessionId);
+    rememberTranscriptHistoryCache(sessionId, {
+      transcriptPath,
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+      truncated,
+      envelopes,
+    });
+    return { envelopes: envelopes.slice(), truncated };
+  };
+
+  // Read a bounded on-disk transcript tail for a session without requiring an
+  // active ManagedChatSession. Used by getChatEventHistory to hydrate the
+  // in-memory ring buffer without allocating huge historical transcripts.
+  const readTranscriptEnvelopesForSessionId = (
+    sessionId: string,
+  ): { envelopes: AgentChatEventEnvelope[]; truncated: boolean } => {
     const managed = managedSessions.get(sessionId);
     if (managed?.transcriptPath) {
       try {
         const transcriptPath = resolveReadableChatPath(managed.transcriptPath, "agent_chat.transcript_read_skipped_path_outside_ade");
-        if (!transcriptPath) return [];
-        return parseAgentChatTranscript(fs.readFileSync(transcriptPath, "utf8"))
-          .filter((entry) => entry.sessionId === sessionId);
+        if (!transcriptPath) return { envelopes: [], truncated: false };
+        return parseTranscriptHistoryTail(sessionId, transcriptPath);
       } catch {
-        return [];
+        return { envelopes: [], truncated: false };
       }
     }
     // Fall back to the known transcript layout so sessions that were never
@@ -6382,8 +6467,36 @@ export function createAgentChatService(args: {
       try {
         const transcriptPath = resolveReadableChatPath(candidatePath, "agent_chat.transcript_read_skipped_path_outside_ade");
         if (!transcriptPath) continue;
-        const raw = fs.readFileSync(transcriptPath, "utf8");
-        return parseAgentChatTranscript(raw).filter((entry) => entry.sessionId === sessionId);
+        return parseTranscriptHistoryTail(sessionId, transcriptPath);
+      } catch {
+        // try next candidate
+      }
+    }
+    return { envelopes: [], truncated: false };
+  };
+
+  const readFullTranscriptEnvelopesForSessionId = (sessionId: string): AgentChatEventEnvelope[] => {
+    const managed = managedSessions.get(sessionId);
+    if (managed?.transcriptPath) {
+      try {
+        const transcriptPath = resolveReadableChatPath(managed.transcriptPath, "agent_chat.transcript_read_skipped_path_outside_ade");
+        if (!transcriptPath) return [];
+        return parseAgentChatTranscript(fs.readFileSync(transcriptPath, "utf8"))
+          .filter((entry) => entry.sessionId === sessionId);
+      } catch {
+        return [];
+      }
+    }
+    const candidates = [
+      path.join(transcriptsDir, `${sessionId}.chat.jsonl`),
+      path.join(chatTranscriptsDir, `${sessionId}.jsonl`),
+    ];
+    for (const candidatePath of candidates) {
+      try {
+        const transcriptPath = resolveReadableChatPath(candidatePath, "agent_chat.transcript_read_skipped_path_outside_ade");
+        if (!transcriptPath) continue;
+        return parseAgentChatTranscript(fs.readFileSync(transcriptPath, "utf8"))
+          .filter((entry) => entry.sessionId === sessionId);
       } catch {
         // try next candidate
       }
@@ -6397,7 +6510,7 @@ export function createAgentChatService(args: {
     // restart per run), and Claude streaming emits multiple text/reasoning
     // fragments within the same millisecond + type — timestamp+type alone
     // would wrongly collapse those into one. JSON.stringify is fine at our
-    // scale (≤2000 events, events typically <1KB).
+    // bounded snapshot scale.
     return `${entry.timestamp}#${entry.event.type}#${JSON.stringify(entry.event)}`;
   };
 
@@ -6428,16 +6541,16 @@ export function createAgentChatService(args: {
   };
 
   /**
-   * Return the complete, ordered event history for a chat session.
+   * Return the recent, ordered event history for a chat session.
    *
-   * On first call (or any call that can tolerate a larger read), we merge the
-   * on-disk transcript with the in-memory ring buffer so that:
+   * Each snapshot merges a bounded on-disk transcript tail with the in-memory
+   * ring buffer so that:
    *   - events that were emitted while the renderer was on a different project
    *     (and therefore dropped by emitProjectEvent) are still recovered;
    *   - events that are still in fs.appendFile flight but already recorded in
    *     the buffer are still delivered;
-   *   - truncating the persistent transcript for size does not lose recent
-   *     events that the buffer still has.
+   *   - oversized transcripts do not have to be fully read and inflated into
+   *     JS objects just to hydrate the Work chat pane.
    *
    * This is the canonical snapshot path for renderer resubscribe / remount.
    */
@@ -6454,7 +6567,14 @@ export function createAgentChatService(args: {
     // filesystem paths from `trimmedId` downstream.
     const row = sessionService.get(trimmedId);
     if (!row || !isChatToolType(row.toolType)) {
-      return { sessionId: trimmedId, events: [], truncated: false, sessionFound: false };
+      return {
+        sessionId: trimmedId,
+        events: [],
+        truncated: false,
+        transcriptTruncated: false,
+        windowTruncated: false,
+        sessionFound: false,
+      };
     }
     const maxEvents = Math.max(
       1,
@@ -6464,20 +6584,32 @@ export function createAgentChatService(args: {
       ),
     );
 
-    // Re-read disk on every snapshot. A long-running background chat can age
-    // older entries out of the live ring buffer; the persisted transcript is
-    // the durable source for project/tab switch recovery, while the buffer
-    // contributes events that fs.appendFile may not have flushed yet.
+    // Stat the transcript on every snapshot; actual I/O is skipped when the
+    // file size and mtime are unchanged (cached). A long-running background
+    // chat can age older entries out of the live ring buffer; the persisted
+    // transcript is the durable source for project/tab switch recovery, while
+    // the buffer contributes events that fs.appendFile may not have flushed yet.
     const bufferExisting = eventHistoryBySession.get(trimmedId) ?? [];
-    let merged = mergeEnvelopeStreams(readTranscriptEnvelopesForSessionId(trimmedId), bufferExisting);
+    const transcriptHistory = readTranscriptEnvelopesForSessionId(trimmedId);
+    let merged = mergeEnvelopeStreams(transcriptHistory.envelopes, bufferExisting);
+    const mergedLength = merged.length;
     if (merged.length > CHAT_EVENT_HISTORY_RESPONSE_MAX_PER_SESSION) {
       merged = merged.slice(-CHAT_EVENT_HISTORY_RESPONSE_MAX_PER_SESSION);
     }
     eventHistoryBySession.set(trimmedId, merged.slice(-CHAT_EVENT_HISTORY_BUFFER_MAX_PER_SESSION));
 
-    const truncated = merged.length > maxEvents;
-    const windowed = truncated ? merged.slice(-maxEvents) : merged;
-    return { sessionId: trimmedId, events: windowed, truncated, sessionFound: true };
+    const transcriptTruncated = transcriptHistory.truncated;
+    const windowTruncated = mergedLength > maxEvents;
+    const truncated = transcriptTruncated || windowTruncated;
+    const windowed = windowTruncated ? merged.slice(-maxEvents) : merged;
+    return {
+      sessionId: trimmedId,
+      events: windowed,
+      truncated,
+      transcriptTruncated,
+      windowTruncated,
+      sessionFound: true,
+    };
   };
 
   const deriveTranscriptTurnActive = (entries: AgentChatEventEnvelope[]): boolean => {
@@ -21832,6 +21964,7 @@ export function createAgentChatService(args: {
     flushQueuedTranscriptWrite(path.join(chatTranscriptsDir, `${sessionId}.jsonl`));
     managedSessions.delete(sessionId);
     eventHistoryBySession.delete(sessionId);
+    transcriptHistoryCacheBySession.delete(sessionId);
   };
 
   const countActiveForLane = (laneId: string): number => {
@@ -23020,6 +23153,7 @@ export function createAgentChatService(args: {
       clearSubagentSnapshots(trimmedSessionId);
     }
     eventHistoryBySession.delete(trimmedSessionId);
+    transcriptHistoryCacheBySession.delete(trimmedSessionId);
 
     const persistedMetadataPath = metadataPathFor(trimmedSessionId);
     const dedicatedTranscriptPath = path.join(chatTranscriptsDir, `${trimmedSessionId}.jsonl`);
@@ -25022,7 +25156,7 @@ export function createAgentChatService(args: {
     const managed = managedSessions.get(sessionId);
     const entries = managed
       ? readTranscriptEntries(managed)
-      : transcriptEntriesFromEnvelopes(sessionId, readTranscriptEnvelopesForSessionId(sessionId));
+      : transcriptEntriesFromEnvelopes(sessionId, readFullTranscriptEnvelopesForSessionId(sessionId));
     let filtered = entries;
     if (typeof since === "string" && since.trim().length) {
       filtered = filtered.filter((entry) => entry.timestamp >= since);

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -4139,8 +4139,8 @@ export function AgentChatPane({
       // ring buffer with the on-disk transcript. This recovers events that
       // were emitted while the user was on a different project (IPC dropped),
       // events that were still in fs.appendFile flight when a previous load
-      // ran, and the full history even when the transcript has been truncated
-      // for size. Fall back to the disk-only readTranscriptTail path if the
+      // ran, and recent transcript history even when the transcript has been
+      // truncated for size. Fall back to the disk-only readTranscriptTail path if the
       // snapshot call fails or the desktop app is running against an older
       // main-process build that lacks the handler.
       let parsed: AgentChatEventEnvelope[] = [];

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -764,7 +764,13 @@ export type AgentChatEventEnvelope = {
 export type AgentChatEventHistorySnapshot = {
   sessionId: string;
   events: AgentChatEventEnvelope[];
+  /**
+   * True when any history was omitted from this snapshot, either because the
+   * transcript tail was bounded or because maxEvents windowed the result.
+   */
   truncated: boolean;
+  transcriptTruncated?: boolean;
+  windowTruncated?: boolean;
   /**
    * Explicitly false means the session id did not resolve in this project
    * runtime. Optional for compatibility with older desktop/runtime pairs.


### PR DESCRIPTION
## Summary

- Bound chat-history transcript hydration to a 2 MB line-aligned tail before parsing.
- Cache parsed transcript tails per session while invalidating on file size/mtime changes.
- Preserve live-buffer merging and expose explicit `transcriptTruncated` / `windowTruncated` causes while keeping `truncated` backward-compatible.

## What Changed

- `getChatEventHistory` no longer reads and inflates entire large transcript files on each snapshot.
- Session disposal/deletion now clears the transcript history cache.
- Renderer and service comments now describe bounded recent history rather than full transcript hydration.
- Added regression coverage for oversized transcript tails, repeated unchanged snapshots, and max-event window truncation.

## Validation

- `npx vitest run src/main/services/chat/agentChatService.test.ts -t getChatEventHistory`
- `npx vitest run src/main/services/chat/agentChatService.test.ts`
- `npm --prefix apps/desktop run typecheck`
- `npm --prefix apps/ade-cli run typecheck`
- `npm --prefix apps/web run typecheck`
- `npm --prefix apps/desktop run lint` (existing warnings only)
- `npm run build` in `apps/desktop`, `apps/ade-cli`, and `apps/web`
- `node scripts/validate-docs.mjs`

## Risks

- Extremely old chat events outside the bounded transcript tail may not hydrate into the Work pane snapshot; recent events and live-buffer events are preserved.

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fchat-history-oom-a0e74a3d num=525 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fchat-history-oom-a0e74a3d&amp;pr=525">ade/chat-history-oom-a0e74a3d branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=525">PR #525</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat history retrieval performance with caching and optimized file reading to reduce redundant disk operations.

* **New Features**
  * Enhanced truncation indicators in chat history to distinguish whether history was limited by transcript size or result window capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an out-of-memory issue in chat history hydration by bounding on-disk transcript reads to a 2 MB line-aligned tail and caching parsed results per session (LRU-evicted at 32 sessions), invalidated on file size or mtime change.

- `getChatEventHistory` now reads at most the last 2 MB of a transcript file, aligns to a JSONL line boundary, and skips the read entirely when the file is unchanged since the last snapshot.
- The `AgentChatEventHistorySnapshot` type gains optional `transcriptTruncated` and `windowTruncated` fields to distinguish the two truncation causes, while the existing `truncated` field remains backward-compatible.
- Session disposal and deletion paths both clear the new transcript cache, and `readFullTranscriptEnvelopesForSessionId` preserves the full-read path for transcript export.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the bounded tail read, LRU cache, and both session-cleanup paths are correctly implemented, and the new truncation flags preserve backward compatibility.

The 2 MB bounding logic, line-boundary alignment, and stat-based cache invalidation are all correct. windowTruncated is computed from mergedLength (pre-response-cap) while windowed uses the post-cap merged, which is consistent because maxEvents is clamped to RESPONSE_MAX by construction, ensuring the response cap always sets windowTruncated when it fires. Cache eviction, cache promotion on hit, and session-cleanup wiring are all correct. The four new regression tests cover the core scenarios.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/chat/agentChatService.ts | Core change: adds 2 MB transcript tail reading with line-boundary alignment, a 32-session LRU parse cache invalidated by size+mtime, and distinct transcriptTruncated/windowTruncated flags; cache cleanup is wired into both session disposal paths. |
| apps/desktop/src/main/services/chat/agentChatService.test.ts | Adds four targeted regression tests: oversized-transcript tail bounding, window vs transcript truncation separation, response-cap window truncation, and cache reuse on unchanged files; existing tests updated to assert on the new fields. |
| apps/desktop/src/shared/types/chat.ts | Adds optional transcriptTruncated and windowTruncated to AgentChatEventHistorySnapshot with a JSDoc clarifying when truncated is set; backward-compatible change. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Comment-only change updating the description of getChatEventHistory from 'full history' to 'recent transcript history'; no logic altered. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getChatEventHistory called] --> B{trimmedId empty?}
    B -- yes --> Z1[return empty, sessionFound:false]
    B -- no --> C{Session in sessionService?}
    C -- no --> Z2[return empty, sessionFound:false
transcriptTruncated:false, windowTruncated:false]
    C -- yes --> D[readTranscriptEnvelopesForSessionId]
    D --> E{managed.transcriptPath set?}
    E -- yes --> F[resolveReadableChatPath]
    E -- no --> G[try candidate paths on disk]
    F --> H[parseTranscriptHistoryTail]
    G --> H
    H --> I{Cache hit?
size + mtime match?}
    I -- yes --> J[promote in LRU, return cached.envelopes.slice]
    I -- no --> K[readTranscriptTailForHistory
read last 2 MB]
    K --> L{size > 2 MB?}
    L -- yes, truncated=true --> M[align to next newline boundary]
    L -- no, truncated=false --> N[use full slice]
    M --> O[parseAgentChatTranscript
filter by sessionId]
    N --> O
    O --> P[store in LRU cache
evict oldest if > 32 sessions]
    J --> Q[mergeEnvelopeStreams
transcript + live buffer]
    P --> Q
    Q --> R{mergedLength > RESPONSE_MAX 20k?}
    R -- yes --> S[slice to last 20k]
    R -- no --> T[keep merged as-is]
    S --> U[update eventHistoryBySession buffer]
    T --> U
    U --> V{mergedLength > maxEvents?}
    V -- yes, windowTruncated=true --> W[windowed = merged.slice -maxEvents]
    V -- no, windowTruncated=false --> X[windowed = merged]
    W --> Y[return snapshot
truncated = transcriptTruncated OR windowTruncated]
    X --> Y
```

<sub>Reviews (4): Last reviewed commit: ["Fix chat history OOM hydration"](https://github.com/arul28/ade/commit/2b122c081728da0a38ca489d21ef6142ec449bd6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35332417)</sub>

<!-- /greptile_comment -->