### PR TITLE
Fix iOS Simulator live view for runtime-backed lanes

### DIFF
--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -24,7 +24,15 @@ import {
 } from "../projects/projectIconResolver";
 import { launchAgentChatCli } from "../chat/agentChatCliLaunch";
 import { runGit } from "../git/git";
-import type { AdeCleanupResult, AdeProjectSnapshot, IosSimulatorStatus, IosSimulatorWindowState } from "../../../shared/types";
+import type {
+  AdeCleanupResult,
+  AdeProjectSnapshot,
+  IosSimulatorDevice,
+  IosSimulatorSession,
+  IosSimulatorStatus,
+  IosSimulatorToolStatus,
+  IosSimulatorWindowState,
+} from "../../../shared/types";
 import { toShallowRecentProjectSummary } from "../projects/recentProjectSummary";
 import type {
   ApplyConflictProposalArgs,
@@ -1980,10 +1988,65 @@ export function registerIpc({
     const value = (arg as { projectRoot?: unknown }).projectRoot;
     return typeof value === "string" && value.trim() ? value.trim() : null;
   };
-  const isIosSimulatorStatus = (value: unknown): value is IosSimulatorStatus => {
-    if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-    const record = value as Partial<IosSimulatorStatus>;
-    return typeof record.platform === "string" && typeof record.supported === "boolean";
+  const isOptionalString = (value: unknown): value is string | null =>
+    value === null || typeof value === "string";
+  const isIosSimulatorToolStatus = (value: unknown): value is IosSimulatorToolStatus =>
+    isRecord(value)
+    && (value.name === "xcrun"
+      || value.name === "xcodebuild"
+      || value.name === "simulator_window"
+      || value.name === "idb"
+      || value.name === "idb_companion")
+    && typeof value.available === "boolean"
+    && typeof value.detail === "string"
+    && typeof value.installHint === "string";
+  const isIosSimulatorDevice = (value: unknown): value is IosSimulatorDevice =>
+    isRecord(value)
+    && typeof value.udid === "string"
+    && typeof value.name === "string"
+    && typeof value.runtime === "string"
+    && typeof value.state === "string"
+    && typeof value.isAvailable === "boolean";
+  const isIosSimulatorSession = (value: unknown): value is IosSimulatorSession =>
+    isRecord(value)
+    && typeof value.id === "string"
+    && typeof value.deviceUdid === "string"
+    && isOptionalString(value.deviceName)
+    && typeof value.bundleId === "string"
+    && isOptionalString(value.appName)
+    && isOptionalString(value.appBundlePath)
+    && isOptionalString(value.targetId)
+    && isOptionalString(value.projectRoot)
+    && isOptionalString(value.laneId)
+    && isOptionalString(value.chatSessionId)
+    && (value.mode === "snapshot" || value.mode === "live")
+    && (value.keepSimulatorInBackground === undefined
+      || value.keepSimulatorInBackground === null
+      || typeof value.keepSimulatorInBackground === "boolean")
+    && isOptionalString(value.bridgeUrl)
+    && typeof value.startedAt === "string"
+    && isOptionalString(value.claimedAt);
+  const normalizeIosSimulatorStatus = (value: unknown): IosSimulatorStatus | null => {
+    if (!isRecord(value)) return null;
+    const activeDevice = value.activeDevice;
+    const activeSession = value.activeSession;
+    if (
+      typeof value.platform !== "string"
+      || typeof value.supported !== "boolean"
+      || !Array.isArray(value.tools)
+      || !value.tools.every(isIosSimulatorToolStatus)
+      || (activeDevice !== null && !isIosSimulatorDevice(activeDevice))
+      || (activeSession !== null && !isIosSimulatorSession(activeSession))
+    ) {
+      return null;
+    }
+    return {
+      platform: value.platform as NodeJS.Platform,
+      supported: value.supported,
+      tools: value.tools,
+      activeDevice,
+      activeSession,
+    };
   };
   const getIosSimulatorContextForEvent = (event: IpcMainInvokeEvent, arg?: unknown): AppContext | null => {
     const windowId = BrowserWindow.fromWebContents(event.sender)?.id ?? null;
@@ -2002,7 +2065,7 @@ export function registerIpc({
     }
     const sessionRoot = boundLocalRoot ?? session?.project?.rootPath ?? null;
     if (sessionRoot) return resolveProjectContext(sessionRoot);
-    return getCtx();
+    return getWindowSession ? null : getCtx();
   };
   const throwIosSimulatorUnavailableForEvent = (ctx: AppContext | null, arg?: unknown, channel = IPC.iosSimulatorListWindowSources): never => {
     const requestedProjectRoot = readProjectRootArg(arg);
@@ -2027,17 +2090,18 @@ export function registerIpc({
   ): Promise<IosSimulatorStatus> => {
     const ctx = getIosSimulatorContextForEvent(event, arg);
     const service = ctx?.iosSimulatorService;
-    if (service) return await service.getStatus();
+    if (service) {
+      const status = normalizeIosSimulatorStatus(await service.getStatus());
+      if (status) return status;
+    }
 
-    const requestedProjectRoot = readProjectRootArg(arg);
     const runtimeStatus = await tryLocalRuntimeSync(event, async (pool, rootPath) => {
-      if (requestedProjectRoot && rootPath !== requestedProjectRoot) return null;
       const response = await pool.callActionForRoot(rootPath, {
         domain: "ios_simulator",
         action: "getStatus",
         args: {},
       });
-      return isIosSimulatorStatus(response.result) ? response.result : null;
+      return normalizeIosSimulatorStatus(response.result);
     });
     if (runtimeStatus) return runtimeStatus;
     return throwIosSimulatorUnavailableForEvent(ctx, arg, channel);

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -24,7 +24,7 @@ import {
 } from "../projects/projectIconResolver";
 import { launchAgentChatCli } from "../chat/agentChatCliLaunch";
 import { runGit } from "../git/git";
-import type { AdeCleanupResult, AdeProjectSnapshot, IosSimulatorWindowState } from "../../../shared/types";
+import type { AdeCleanupResult, AdeProjectSnapshot, IosSimulatorStatus, IosSimulatorWindowState } from "../../../shared/types";
 import { toShallowRecentProjectSummary } from "../projects/recentProjectSummary";
 import type {
   ApplyConflictProposalArgs,
@@ -1980,6 +1980,11 @@ export function registerIpc({
     const value = (arg as { projectRoot?: unknown }).projectRoot;
     return typeof value === "string" && value.trim() ? value.trim() : null;
   };
+  const isIosSimulatorStatus = (value: unknown): value is IosSimulatorStatus => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+    const record = value as Partial<IosSimulatorStatus>;
+    return typeof record.platform === "string" && typeof record.supported === "boolean";
+  };
   const getIosSimulatorContextForEvent = (event: IpcMainInvokeEvent, arg?: unknown): AppContext | null => {
     const windowId = BrowserWindow.fromWebContents(event.sender)?.id ?? null;
     const session = getWindowSession?.(windowId) ?? null;
@@ -1999,30 +2004,43 @@ export function registerIpc({
     if (sessionRoot) return resolveProjectContext(sessionRoot);
     return getCtx();
   };
-  const ensureIosSimulatorForEvent = (
+  const throwIosSimulatorUnavailableForEvent = (ctx: AppContext | null, arg?: unknown, channel = IPC.iosSimulatorListWindowSources): never => {
+    const requestedProjectRoot = readProjectRootArg(arg);
+    const projectRoot = requestedProjectRoot ?? ctx?.project?.rootPath ?? null;
+    const logger = ctx?.logger ?? getCtx().logger;
+    logger.warn("ios_simulator.service_unavailable", {
+      channel,
+      requestedProjectRoot,
+      contextProjectRoot: ctx?.project?.rootPath ?? null,
+      hasUserSelectedProject: ctx?.hasUserSelectedProject ?? false,
+    });
+    throw new Error(
+      projectRoot
+        ? `iOS Simulator service is not available for ${projectRoot}.`
+        : "iOS Simulator service is not available because no local project is bound to this window.",
+    );
+  };
+  const getIosSimulatorStatusForEvent = async (
     event: IpcMainInvokeEvent,
     arg?: unknown,
     channel = IPC.iosSimulatorListWindowSources,
-  ): NonNullable<AppContext["iosSimulatorService"]> => {
+  ): Promise<IosSimulatorStatus> => {
     const ctx = getIosSimulatorContextForEvent(event, arg);
     const service = ctx?.iosSimulatorService;
-    if (!service) {
-      const requestedProjectRoot = readProjectRootArg(arg);
-      const projectRoot = requestedProjectRoot ?? ctx?.project?.rootPath ?? null;
-      const logger = ctx?.logger ?? getCtx().logger;
-      logger.warn("ios_simulator.service_unavailable", {
-        channel,
-        requestedProjectRoot,
-        contextProjectRoot: ctx?.project?.rootPath ?? null,
-        hasUserSelectedProject: ctx?.hasUserSelectedProject ?? false,
+    if (service) return await service.getStatus();
+
+    const requestedProjectRoot = readProjectRootArg(arg);
+    const runtimeStatus = await tryLocalRuntimeSync(event, async (pool, rootPath) => {
+      if (requestedProjectRoot && rootPath !== requestedProjectRoot) return null;
+      const response = await pool.callActionForRoot(rootPath, {
+        domain: "ios_simulator",
+        action: "getStatus",
+        args: {},
       });
-      throw new Error(
-        projectRoot
-          ? `iOS Simulator service is not available for ${projectRoot}.`
-          : "iOS Simulator service is not available because no local project is bound to this window.",
-      );
-    }
-    return service;
+      return isIosSimulatorStatus(response.result) ? response.result : null;
+    });
+    if (runtimeStatus) return runtimeStatus;
+    return throwIosSimulatorUnavailableForEvent(ctx, arg, channel);
   };
 
   const ensureAppControl = (): NonNullable<AppContext["appControlService"]> => {
@@ -7074,7 +7092,7 @@ export function registerIpc({
   ipcMain.handle(IPC.iosSimulatorGetWindowState, async () => getSimulatorWindowState());
 
   ipcMain.handle(IPC.iosSimulatorListWindowSources, async (event, arg = {}) => {
-    const status = await ensureIosSimulatorForEvent(event, arg, IPC.iosSimulatorListWindowSources).getStatus();
+    const status = await getIosSimulatorStatusForEvent(event, arg, IPC.iosSimulatorListWindowSources);
     if (!status.supported) return [];
     const readSources = async () => desktopCapturer.getSources({
       types: ["window"],

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
@@ -884,6 +884,58 @@ describe("registerIpc sync bridge", () => {
     expect(otherGetStatus).not.toHaveBeenCalled();
   });
 
+  it("uses the bound local runtime for iOS Simulator window sources when no in-process project context is loaded", async () => {
+    const getProjectContext = vi.fn(() => null);
+    const localRuntimeConnectionPool = {
+      callActionForRoot: vi.fn(async () => ({
+        domain: "ios_simulator",
+        action: "getStatus",
+        result: {
+          platform: "darwin",
+          supported: false,
+          tools: [],
+          activeDevice: null,
+          activeSession: null,
+        },
+        statusHints: {},
+      })),
+    };
+    registerIpc({
+      getCtx: () => ({
+        project: { rootPath: "/fallback" },
+        logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+      }) as any,
+      getWindowSession: () => ({
+        windowId: 7,
+        project: { rootPath: "/repo", displayName: "Repo" } as any,
+        binding: localBinding("/repo"),
+      }),
+      getProjectContext,
+      localRuntimeConnectionPool: localRuntimeConnectionPool as any,
+      switchProjectFromDialog: vi.fn(),
+      closeCurrentProject: vi.fn(),
+      closeProjectByPath: vi.fn(),
+      globalStatePath: "/tmp/ade-state.json",
+    });
+
+    await expect(
+      ipcHandlers.get(IPC.iosSimulatorListWindowSources)?.(
+        eventForSender(),
+        { projectRoot: "/repo" },
+      ),
+    ).resolves.toEqual([]);
+
+    expect(getProjectContext).toHaveBeenCalledWith("/repo");
+    expect(localRuntimeConnectionPool.callActionForRoot).toHaveBeenCalledWith(
+      "/repo",
+      {
+        domain: "ios_simulator",
+        action: "getStatus",
+        args: {},
+      },
+    );
+  });
+
   it("rejects iOS Simulator window-source requests for an unbound project root", async () => {
     const getProjectContext = vi.fn(() => ({
       project: { rootPath: "/other" },

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
@@ -839,8 +839,20 @@ describe("registerIpc sync bridge", () => {
   });
 
   it("uses the sender window's bound local project for iOS Simulator window sources", async () => {
-    const repoGetStatus = vi.fn(async () => ({ supported: false }));
-    const otherGetStatus = vi.fn(async () => ({ supported: false }));
+    const repoGetStatus = vi.fn(async () => ({
+      platform: "darwin",
+      supported: false,
+      tools: [],
+      activeDevice: null,
+      activeSession: null,
+    }));
+    const otherGetStatus = vi.fn(async () => ({
+      platform: "darwin",
+      supported: false,
+      tools: [],
+      activeDevice: null,
+      activeSession: null,
+    }));
     const contexts = new Map<string, any>([
       ["/repo", {
         project: { rootPath: "/repo" },
@@ -936,6 +948,80 @@ describe("registerIpc sync bridge", () => {
     );
   });
 
+  it("rejects malformed local-runtime iOS Simulator status for window sources", async () => {
+    const getProjectContext = vi.fn(() => null);
+    const localRuntimeConnectionPool = {
+      callActionForRoot: vi.fn(async () => ({
+        domain: "ios_simulator",
+        action: "getStatus",
+        result: {
+          platform: "darwin",
+          supported: true,
+        },
+        statusHints: {},
+      })),
+    };
+    registerIpc({
+      getCtx: () => ({
+        project: { rootPath: "/fallback" },
+        logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+      }) as any,
+      getWindowSession: () => ({
+        windowId: 7,
+        project: { rootPath: "/repo", displayName: "Repo" } as any,
+        binding: localBinding("/repo"),
+      }),
+      getProjectContext,
+      localRuntimeConnectionPool: localRuntimeConnectionPool as any,
+      switchProjectFromDialog: vi.fn(),
+      closeCurrentProject: vi.fn(),
+      closeProjectByPath: vi.fn(),
+      globalStatePath: "/tmp/ade-state.json",
+    });
+
+    await expect(
+      ipcHandlers.get(IPC.iosSimulatorListWindowSources)?.(
+        eventForSender(),
+        { projectRoot: "/repo" },
+      ),
+    ).rejects.toThrow("iOS Simulator service is not available for /repo.");
+  });
+
+  it("does not fall back to the active project for unbound iOS Simulator window-source requests", async () => {
+    const getStatus = vi.fn(async () => ({
+      platform: "darwin",
+      supported: false,
+      tools: [],
+      activeDevice: null,
+      activeSession: null,
+    }));
+    registerIpc({
+      getCtx: () => ({
+        project: { rootPath: "/fallback" },
+        logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+        iosSimulatorService: { getStatus },
+      }) as any,
+      getWindowSession: () => ({
+        windowId: 7,
+        project: null,
+        binding: null,
+      }),
+      switchProjectFromDialog: vi.fn(),
+      closeCurrentProject: vi.fn(),
+      closeProjectByPath: vi.fn(),
+      globalStatePath: "/tmp/ade-state.json",
+    });
+
+    await expect(
+      ipcHandlers.get(IPC.iosSimulatorListWindowSources)?.(
+        eventForSender(),
+        {},
+      ),
+    ).rejects.toThrow("no local project is bound");
+
+    expect(getStatus).not.toHaveBeenCalled();
+  });
+
   it("rejects iOS Simulator window-source requests for an unbound project root", async () => {
     const getProjectContext = vi.fn(() => ({
       project: { rootPath: "/other" },
@@ -970,7 +1056,13 @@ describe("registerIpc sync bridge", () => {
   });
 
   it("falls back to the active context for matching iOS Simulator roots when no project context lookup is registered", async () => {
-    const getStatus = vi.fn(async () => ({ supported: false }));
+    const getStatus = vi.fn(async () => ({
+      platform: "darwin",
+      supported: false,
+      tools: [],
+      activeDevice: null,
+      activeSession: null,
+    }));
     registerIpc({
       getCtx: () => ({
         project: { rootPath: "/repo" },

--- a/apps/desktop/src/renderer/components/chat/ChatIosSimulatorPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatIosSimulatorPanel.tsx
@@ -2225,10 +2225,11 @@ export function ChatIosSimulatorPanel({
     }
   }, [armWindowCaptureRecoveryAfterInput, liveInputBlocked, liveInputBlockedMessage, projectRoot, selectedDeviceUdid]);
 
+  const snapshotElementCount = snapshot?.elements.length ?? 0;
   const providerSummary = snapshot
-    ? snapshot.elements.length > 0
-      ? `Snapshot ready with ${snapshot.elements.length} selectable item${snapshot.elements.length === 1 ? "" : "s"}.`
-      : "Snapshot ready."
+    ? snapshotElementCount > 0
+      ? `Snapshot ready with ${snapshotElementCount} selectable item${snapshotElementCount === 1 ? "" : "s"}.`
+      : "Snapshot ready with no selectable elements. Click a point or use Screenshot to attach visual context."
     : null;
   const hoverSource = hoveredElement?.source ?? null;
   let previewModeHint: string | null = null;
@@ -2262,6 +2263,8 @@ export function ChatIosSimulatorPanel({
       ? "Drag a region on the simulator snapshot to attach a screenshot crop and screen context."
       : selectedElement
       ? `Selected element: ${elementLabel(selectedElement)}. Click another outline to swap, or Alt-click to select a parent.`
+      : snapshot && snapshotElementCount === 0
+      ? "No inspectable elements found. Click a point to attach coordinate context, or use Screenshot to capture a region."
       : "Click a UI element outline to insert it as context. Alt-click to select a larger container.";
   }
   const simulatorWindowWarning = mode === "interact"


### PR DESCRIPTION
## Summary

Fixes the iOS Simulator drawer live-view failure where Electron could not enumerate Simulator window sources for a project hosted by a bound local runtime instead of an in-process desktop `AppContext`.

## What changed

- Route `ade.iosSimulator.listWindowSources` through the sender window's bound local runtime for `ios_simulator.getStatus` when no in-process project context is loaded.
- Keep the existing bound-project guard, so the Electron-only `desktopCapturer` path still only runs for the window's local project root.
- Add a regression test for runtime-backed window-source requests.
- Clarify the Simulator inspect empty-state copy when AX/idb returns no elements, so coordinate or screenshot context attachment is still discoverable.

## App Control audit

Checked the App Control pane for the same shape of bug. Its status, launch/connect, snapshot, inspect/select, target, input, and screenshot APIs already route through `callProjectRuntimeActionOr("app_control", ...)` before direct desktop IPC fallback, and `app_control` is exposed through the runtime action registry. There is no matching Electron-only window-source bridge in App Control.

## Validation

- `npm --prefix apps/desktop run test -- src/main/services/ipc/runtimeBridge.test.ts src/renderer/components/chat/ChatIosSimulatorPanel.test.tsx`
- `npm --prefix apps/desktop run typecheck`
- `npm --prefix apps/desktop run lint` (passes with existing repo warnings)
- `npm --prefix apps/desktop run build`

## Risks

Low. The changed main-process path only affects the Electron window-source enumeration used by Simulator live view; normal Simulator actions remain served by the runtime path.

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fios-sim-launch-error-f0f04e8d num=526 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fios-sim-launch-error-f0f04e8d&amp;pr=526">ade/ios-sim-launch-error-f0f04e8d branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=526">PR #526</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined iOS Simulator error handling for more consistent status resolution
  * Enhanced messaging in iOS Simulator panel to provide clearer guidance when snapshots contain no selectable elements

* **Tests**
  * Added test coverage for iOS Simulator status resolution workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes iOS Simulator live-view for windows bound to a local runtime (rather than an in-process `AppContext`) by routing the `getStatus` call through `tryLocalRuntimeSync` when no in-process `iosSimulatorService` is found, and by adding `normalizeIosSimulatorStatus` to strictly validate both in-process and RPC-backed responses.

- **`registerIpc.ts`**: Replaces the old `ensureIosSimulatorForEvent` with `getIosSimulatorStatusForEvent`, which tries the in-process service first, falls through to the local runtime pool, and throws with a clear message only if both paths yield nothing; companion type-guard helpers validate the full `IosSimulatorStatus` shape.
- **`runtimeBridge.test.ts`**: Existing tests are updated to supply the complete status shape; three new cases cover the runtime-backed path, malformed-response rejection, and the unbound-window error.
- **`ChatIosSimulatorPanel.tsx`**: Empty-snapshot hint copy is improved to guide users toward coordinate-click or screenshot when AX inspection returns zero elements.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the changed IPC path is narrow and the new runtime fallback is well-guarded.

The main-process change is isolated to `iosSimulatorListWindowSources` and the new `getIosSimulatorStatusForEvent` helper. All other Simulator IPC handlers continue to use the existing `ensureIosSimulator` path unchanged. The new tests adequately cover the runtime-backed path, malformed-response rejection, and the unbound-window error case.

apps/desktop/src/main/services/ipc/registerIpc.ts — specifically the `normalizeIosSimulatorStatus` null/undefined handling and the silent in-process service fallthrough.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/ipc/registerIpc.ts | Core logic change: replaces `ensureIosSimulatorForEvent` with `getIosSimulatorStatusForEvent` and adds strict `normalizeIosSimulatorStatus`; the fallthrough from a present-but-bad in-process service to the runtime pool is worth a second look, and `undefined` fields from a runtime that omits optional-null keys would silently fail normalization. |
| apps/desktop/src/main/services/ipc/runtimeBridge.test.ts | Test updates supply the full IosSimulatorStatus shape to existing tests and add three targeted new cases covering the runtime-backed path, malformed-response rejection, and the unbound-window error. |
| apps/desktop/src/renderer/components/chat/ChatIosSimulatorPanel.tsx | Minor copy improvement for the zero-element snapshot empty state; logic is straightforward and low-risk. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[IPC: iosSimulatorListWindowSources] --> B[getIosSimulatorStatusForEvent]
    B --> C[getIosSimulatorContextForEvent]
    C --> D{explicitRoot set?}
    D -- yes --> E{matches boundLocalRoot?}
    E -- no --> F[throw: access only for bound project]
    E -- yes --> G[resolveProjectContext explicitRoot]
    D -- no --> H{sessionRoot exists?}
    H -- yes --> G
    H -- no --> I{getWindowSession registered?}
    I -- yes --> J[ctx = null]
    I -- no --> K[ctx = getCtx]
    G --> L[ctx = project context]
    J --> M[service = ctx?.iosSimulatorService]
    K --> M
    L --> M
    M --> N{service exists?}
    N -- yes --> O[normalizeIosSimulatorStatus service.getStatus]
    O --> P{valid status?}
    P -- yes --> Q[return status]
    P -- no --> R[tryLocalRuntimeSync]
    N -- no --> R
    R --> S{pool + rootPath available?}
    S -- yes --> T[callActionForRoot ios_simulator/getStatus]
    T --> U[normalizeIosSimulatorStatus response.result]
    U --> V{valid status?}
    V -- yes --> Q
    V -- no --> W[throwIosSimulatorUnavailableForEvent]
    S -- no --> W
    Q --> X{status.supported?}
    X -- no --> Y[return empty array]
    X -- yes --> Z[desktopCapturer.getSources + prepareSimulatorWindow]
    Z --> AA[return filtered window sources]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fipc%2FregisterIpc.ts%3A2093-2096%0AWhen%20%60service%60%20is%20present%20but%20%60normalizeIosSimulatorStatus%60%20rejects%20its%20result%20%28e.g.%2C%20a%20transitional%20build%20where%20the%20in-process%20service's%20shape%20slightly%20diverges%20from%20the%20new%20type-guard%29%2C%20the%20code%20silently%20falls%20through%20to%20%60tryLocalRuntimeSync%60.%20If%20the%20runtime%20pool%20is%20also%20unavailable%20the%20error%20message%20reads%20%22iOS%20Simulator%20service%20is%20not%20available%22%20%E2%80%94%20no%20hint%20that%20an%20in-process%20service%20was%20found%20but%20returned%20unexpected%20data.%20Consider%20logging%20a%20warning%20before%20the%20fallthrough%20so%20this%20scenario%20is%20diagnosable%20in%20production%20logs.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20%28service%29%20%7B%0A%20%20%20%20%20%20const%20status%20%3D%20normalizeIosSimulatorStatus%28await%20service.getStatus%28%29%29%3B%0A%20%20%20%20%20%20if%20%28status%29%20return%20status%3B%0A%20%20%20%20%20%20const%20logger%20%3D%20ctx%3F.logger%20%3F%3F%20getCtx%28%29.logger%3B%0A%20%20%20%20%20%20logger.warn%28%22ios_simulator.status_normalization_failed%22%2C%20%7B%0A%20%20%20%20%20%20%20%20channel%2C%0A%20%20%20%20%20%20%20%20contextProjectRoot%3A%20ctx%3F.project%3F.rootPath%20%3F%3F%20null%2C%0A%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fipc%2FregisterIpc.ts%3A2038-2039%0A%60normalizeIosSimulatorStatus%60%20checks%20%60activeDevice%20!%3D%3D%20null%60%20before%20validating%2C%20but%20does%20not%20guard%20against%20%60undefined%60%20%28an%20absent%20key%29.%20If%20a%20runtime%20response%20omits%20%60activeDevice%60%20entirely%20%E2%80%94%20rather%20than%20explicitly%20sending%20%60null%60%20%E2%80%94%20%60undefined%20!%3D%3D%20null%60%20is%20%60true%60%2C%20%60isIosSimulatorDevice%28undefined%29%60%20returns%20%60false%60%2C%20and%20the%20whole%20validation%20silently%20rejects%20an%20otherwise%20valid%20%60supported%3A%20false%60%20response.%20Adding%20an%20%60activeDevice%20!%3D%3D%20undefined%60%20%28or%20%60activeDevice%20!%3D%20null%60%29%20guard%20makes%20the%20contract%20explicit%20and%20prevents%20a%20correctly-behaving%20runtime%20from%20having%20its%20status%20dropped.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%7C%7C%20%28activeDevice%20!%3D%20null%20%26%26%20!isIosSimulatorDevice%28activeDevice%29%29%0A%20%20%20%20%20%20%7C%7C%20%28activeSession%20!%3D%20null%20%26%26%20!isIosSimulatorSession%28activeSession%29%29%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=526&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src/main/services/ipc/registerIpc.ts:2093-2096
When `service` is present but `normalizeIosSimulatorStatus` rejects its result (e.g., a transitional build where the in-process service's shape slightly diverges from the new type-guard), the code silently falls through to `tryLocalRuntimeSync`. If the runtime pool is also unavailable the error message reads "iOS Simulator service is not available" — no hint that an in-process service was found but returned unexpected data. Consider logging a warning before the fallthrough so this scenario is diagnosable in production logs.

```suggestion
    if (service) {
      const status = normalizeIosSimulatorStatus(await service.getStatus());
      if (status) return status;
      const logger = ctx?.logger ?? getCtx().logger;
      logger.warn("ios_simulator.status_normalization_failed", {
        channel,
        contextProjectRoot: ctx?.project?.rootPath ?? null,
      });
    }
```

### Issue 2 of 2
apps/desktop/src/main/services/ipc/registerIpc.ts:2038-2039
`normalizeIosSimulatorStatus` checks `activeDevice !== null` before validating, but does not guard against `undefined` (an absent key). If a runtime response omits `activeDevice` entirely — rather than explicitly sending `null` — `undefined !== null` is `true`, `isIosSimulatorDevice(undefined)` returns `false`, and the whole validation silently rejects an otherwise valid `supported: false` response. Adding an `activeDevice !== undefined` (or `activeDevice != null`) guard makes the contract explicit and prevents a correctly-behaving runtime from having its status dropped.

```suggestion
      || (activeDevice != null && !isIosSimulatorDevice(activeDevice))
      || (activeSession != null && !isIosSimulatorSession(activeSession))
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Address iOS simulator window-source revi..."](https://github.com/arul28/ade/commit/4ebacf3310e6b400e18e1a9943a200b4a5cb2965) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35419854)</sub>

<!-- /greptile_comment -->