### PR TITLE
Idle-session notice: activity-based staleness, per-project hourly throttle, lane breakdown

### DIFF
--- a/apps/desktop/src/main/services/pty/ptyService.test.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.test.ts
@@ -312,6 +312,7 @@ function createHarness(overrides: {
     get: vi.fn((id: string) => sessionStore.get(id) ?? null),
     setSummary: vi.fn(),
     setLastOutputPreview: vi.fn(),
+    touchSessionActivity: vi.fn(),
     setResumeCommand: vi.fn((sessionId: string, resumeCommand: string | null) => {
       const session = sessionStore.get(sessionId);
       if (!session) return;

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -2761,6 +2761,13 @@ export function createPtyService({
     const now = Date.now();
     if (now - entry.lastPreviewWriteAt < 900) return;
     entry.lastPreviewWriteAt = now;
+    // Refresh the activity timestamp on every throttled output tick — even when
+    // the derived preview line is blank or unchanged — so a tracked session
+    // emitting steady but non-preview-changing output (spinners, repeated
+    // status lines) is not wrongly flagged idle by the stale-session detector.
+    if (entry.tracked) {
+      sessionService.touchSessionActivity(entry.sessionId, new Date(now).toISOString());
+    }
     flushPreview(entry);
   };
 

--- a/apps/desktop/src/main/services/sessions/sessionService.test.ts
+++ b/apps/desktop/src/main/services/sessions/sessionService.test.ts
@@ -1133,4 +1133,35 @@ describe("sessionService resume metadata", () => {
 
     activeDisposers.push(async () => db.close());
   });
+
+  it("touchSessionActivity refreshes only the activity timestamp", async () => {
+    const projectRoot = makeProjectRoot("ade-session-service-");
+    const dbPath = path.join(projectRoot, ".ade", "ade.db");
+    const db = await openKvDb(dbPath, createLogger() as any);
+    insertProjectGraph(db);
+    const service = createSessionService({ db });
+
+    service.create({
+      sessionId: "session-touch",
+      laneId: "lane-1",
+      ptyId: "pty-touch",
+      tracked: true,
+      title: "Spinner shell",
+      startedAt: "2026-03-17T00:10:00.000Z",
+      transcriptPath: path.join(projectRoot, "session-touch.log"),
+      toolType: "shell",
+    });
+    // No output yet → no recorded activity.
+    expect(service.get("session-touch")?.lastActivityAt ?? null).toBeNull();
+
+    service.touchSessionActivity("session-touch", "2026-03-18T08:00:00.000Z");
+
+    const touched = service.get("session-touch");
+    // Activity timestamp advances even though the preview text never changed —
+    // this is what keeps steady-output sessions from being flagged idle.
+    expect(touched?.lastActivityAt).toBe("2026-03-18T08:00:00.000Z");
+    expect(touched?.lastOutputPreview).toBeNull();
+
+    activeDisposers.push(async () => db.close());
+  });
 });

--- a/apps/desktop/src/main/services/sessions/sessionService.ts
+++ b/apps/desktop/src/main/services/sessions/sessionService.ts
@@ -1002,6 +1002,19 @@ export function createSessionService({ db }: { db: AdeDb }) {
       );
     },
 
+    /**
+     * Refresh only the activity timestamp (not the preview text). Lets the PTY
+     * layer record that a session is still producing output even when the
+     * derived preview line is blank or unchanged (spinners, repeated status
+     * lines), so the stale-session detector does not treat live work as idle.
+     */
+    touchSessionActivity(sessionId: string, at: string = new Date().toISOString()): void {
+      db.run(
+        "update terminal_sessions set last_output_at = ? where id = ?",
+        [at, sessionId]
+      );
+    },
+
     setSummary(sessionId: string, summary: string | null): void {
       db.run("update terminal_sessions set summary = ? where id = ?", [summary, sessionId]);
     },

--- a/apps/desktop/src/main/services/sessions/sessionService.ts
+++ b/apps/desktop/src/main/services/sessions/sessionService.ts
@@ -46,6 +46,7 @@ type SessionRow = {
   headShaStart: string | null;
   headShaEnd: string | null;
   lastOutputPreview: string | null;
+  lastActivityAt: string | null;
   summary: string | null;
   resumeCommand: string | null;
   resumeMetadataJson: string | null;
@@ -87,6 +88,7 @@ const SESSION_COLUMNS = `
   s.head_sha_start as headShaStart,
   s.head_sha_end as headShaEnd,
   s.last_output_preview as lastOutputPreview,
+  s.last_output_at as lastActivityAt,
   s.summary as summary,
   s.resume_command as resumeCommand,
   s.resume_metadata_json as resumeMetadataJson,
@@ -318,6 +320,7 @@ export function createSessionService({ db }: { db: AdeDb }) {
       goal: row.goal ?? null,
       toolType,
       summary: row.summary ?? null,
+      lastActivityAt: row.lastActivityAt ?? null,
       runtimeState: runtimeStateFromStatus(row.status),
       resumeMetadata,
       resumeCommand: deriveResumeMetadataCommand(resumeMetadata, row.resumeCommand, toolType),

--- a/apps/desktop/src/main/services/sessions/sessionService.ts
+++ b/apps/desktop/src/main/services/sessions/sessionService.ts
@@ -229,6 +229,17 @@ function normalizeOwnerProcessStartedAt(startedAt: unknown): string | null {
   return normalized.length ? normalized : null;
 }
 
+/**
+ * Normalize a persisted timestamp column to a valid ISO string or null, so
+ * downstream idle-age math never keys off an empty/garbage string (which would
+ * otherwise show a misleading floored age instead of "no activity recorded").
+ */
+function normalizeIsoTimestamp(value: unknown): string | null {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) return null;
+  return Number.isFinite(Date.parse(text)) ? text : null;
+}
+
 export function createSessionService({ db }: { db: AdeDb }) {
   const changeListeners = new Set<(event: TerminalSessionChangedEvent) => void>();
 
@@ -320,7 +331,7 @@ export function createSessionService({ db }: { db: AdeDb }) {
       goal: row.goal ?? null,
       toolType,
       summary: row.summary ?? null,
-      lastActivityAt: row.lastActivityAt ?? null,
+      lastActivityAt: normalizeIsoTimestamp(row.lastActivityAt),
       runtimeState: runtimeStateFromStatus(row.status),
       resumeMetadata,
       resumeCommand: deriveResumeMetadataCommand(resumeMetadata, row.resumeCommand, toolType),

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -1197,6 +1197,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       }) ?? 24
     : 0;
   const dismissStaleCliNotice = useCallback(() => {
+    // Intentionally re-arms (resets) the snooze from the dismiss moment, not
+    // just the first-show moment: "if dismissed, don't show again for an hour"
+    // is measured from the dismissal. The show-time arming in
+    // refreshStaleCliNotice is what keeps the once-per-hour cadence alive
+    // across restarts when the user never dismisses; the two are complementary,
+    // not a bug.
     if (currentProjectRoot) snoozeStaleCliNotice(currentProjectRoot);
     staleCliNoticeActiveRef.current = false;
     setStaleCliNotice(null);

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowCounterClockwise,
   ArrowSquareOut,
@@ -54,6 +54,10 @@ import {
   shouldRefreshAiStatusForChatEvent,
 } from "../../lib/aiProviderStatus";
 import { getStaleRunningCliSessionAgeHours, isRunOwnedSession } from "../../lib/sessions";
+import {
+  isStaleCliNoticeSnoozed,
+  snoozeStaleCliNotice,
+} from "../../lib/staleCliNoticeSnooze";
 import { summarizeTerminalAttention } from "../../lib/terminalAttention";
 import { getStoredZoomLevel, displayZoomToLevel } from "../../lib/zoom";
 import { ONBOARDING_STATUS_UPDATED_EVENT } from "../../lib/onboardingStatusEvents";
@@ -162,9 +166,18 @@ type RemoteConnectionNotice = {
   body: string;
 };
 
+type StaleCliNoticeLane = {
+  laneId: string;
+  laneName: string;
+  count: number;
+};
+
 type StaleCliNotice = {
   count: number;
-  oldestStartedAt: string;
+  /** Oldest last-activity (or startedAt fallback) among the stale sessions. */
+  oldestActivityAt: string;
+  /** Per-lane breakdown so the notice can show which lanes hold stale sessions. */
+  lanes: StaleCliNoticeLane[];
 };
 
 const EMPTY_TERMINAL_ATTENTION = {
@@ -306,6 +319,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const closeProject = useAppStore((s) => s.closeProject);
   const selectLane = useAppStore((s) => s.selectLane);
   const setLaneInspectorTab = useAppStore((s) => s.setLaneInspectorTab);
+  const setWorkViewState = useAppStore((s) => s.setWorkViewState);
   const [commandOpen, setCommandOpen] = useState(false);
   const visitedTabsRef = useRef(new Set<string>());
   const isFirstVisit = !visitedTabsRef.current.has(location.pathname);
@@ -331,7 +345,10 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const linearToastTimersRef = useRef<Map<string, number>>(new Map());
   const [staleCliNotice, setStaleCliNotice] =
     useState<StaleCliNotice | null>(null);
-  const dismissedStaleCliNoticeKeyRef = useRef<string | null>(null);
+  // Whether a stale-CLI notice is currently displayed. Lets refreshes keep an
+  // already-visible notice updated without re-tripping the once-per-hour snooze,
+  // and prevents the snooze from hiding a notice the user is actively looking at.
+  const staleCliNoticeActiveRef = useRef(false);
   const [remoteSnapshot, setRemoteSnapshot] =
     useState<RemoteRuntimeConnectionSnapshot | null>(null);
   const [dismissedRemoteNoticeKey, setDismissedRemoteNoticeKey] =
@@ -699,7 +716,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       (!isRemoteProject || isWorkAdjacentRoute);
     if (!shouldCheckStaleCliNotice) {
       setStaleCliNotice(null);
-      dismissedStaleCliNoticeKeyRef.current = null;
+      staleCliNoticeActiveRef.current = false;
       return;
     }
 
@@ -710,6 +727,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     // Prevent cross-project stale notice carryover while the first refresh is
     // pending for the new project.
     setStaleCliNotice(null);
+    staleCliNoticeActiveRef.current = false;
+
+    const sessionActivityMs = (session: TerminalSessionSummary): number => {
+      const activityMs = session.lastActivityAt ? Date.parse(session.lastActivityAt) : Number.NaN;
+      return Number.isFinite(activityMs) ? activityMs : Date.parse(session.startedAt);
+    };
 
     const refreshStaleCliNotice = async () => {
       if (document.visibilityState !== "visible") return;
@@ -722,20 +745,47 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             if (isRunOwnedSession(session)) return false;
             return getStaleRunningCliSessionAgeHours(session, nowMs) != null;
           })
-          .sort((left, right) => Date.parse(left.startedAt) - Date.parse(right.startedAt));
+          .sort((left, right) => sessionActivityMs(left) - sessionActivityMs(right));
 
         if (!stale.length) {
           setStaleCliNotice(null);
+          staleCliNoticeActiveRef.current = false;
           return;
         }
 
-        const oldestStartedAt = stale[0]?.startedAt ?? new Date(nowMs).toISOString();
-        const noticeKey = `${projectRoot}:${stale.length}:${oldestStartedAt}`;
-        if (dismissedStaleCliNoticeKeyRef.current === noticeKey) {
+        const oldest = stale[0];
+        const oldestActivityAt =
+          oldest?.lastActivityAt ?? oldest?.startedAt ?? new Date(nowMs).toISOString();
+
+        const laneMap = new Map<string, StaleCliNoticeLane>();
+        for (const session of stale) {
+          const existing = laneMap.get(session.laneId);
+          if (existing) existing.count += 1;
+          else
+            laneMap.set(session.laneId, {
+              laneId: session.laneId,
+              laneName: session.laneName || session.laneId,
+              count: 1,
+            });
+        }
+        const lanesBreakdown = [...laneMap.values()].sort((a, b) => b.count - a.count);
+        const notice: StaleCliNotice = { count: stale.length, oldestActivityAt, lanes: lanesBreakdown };
+
+        // Already showing a notice for this project? Keep it fresh without
+        // re-tripping the snooze. Otherwise gate on the per-project hourly
+        // snooze, and arm the snooze the moment we first show it so the
+        // once-per-hour cadence survives restarts / project re-opens.
+        if (staleCliNoticeActiveRef.current) {
+          setStaleCliNotice(notice);
+          return;
+        }
+        if (isStaleCliNoticeSnoozed(projectRoot, nowMs)) {
           setStaleCliNotice(null);
           return;
         }
-        setStaleCliNotice({ count: stale.length, oldestStartedAt });
+        snoozeStaleCliNotice(projectRoot, nowMs);
+        staleCliNoticeActiveRef.current = true;
+        setStaleCliNotice(notice);
       } catch {
         // best effort
       }
@@ -1141,14 +1191,16 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const staleCliNoticeAgeHours = staleCliNotice
     ? getStaleRunningCliSessionAgeHours({
         status: "running",
-        startedAt: staleCliNotice.oldestStartedAt,
+        startedAt: staleCliNotice.oldestActivityAt,
         toolType: "shell",
-      }) ?? 12
+        lastActivityAt: staleCliNotice.oldestActivityAt,
+      }) ?? 24
     : 0;
-  const staleCliNoticeDismissKey =
-    staleCliNotice && currentProjectRoot
-      ? `${currentProjectRoot}:${staleCliNotice.count}:${staleCliNotice.oldestStartedAt}`
-      : null;
+  const dismissStaleCliNotice = useCallback(() => {
+    if (currentProjectRoot) snoozeStaleCliNotice(currentProjectRoot);
+    staleCliNoticeActiveRef.current = false;
+    setStaleCliNotice(null);
+  }, [currentProjectRoot]);
   const activeRemoteConnection =
     activeRemoteBinding && remoteSnapshot
       ? remoteSnapshot.connections.find(
@@ -1485,40 +1537,69 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                       <div className="flex items-start justify-between gap-2">
                         <div className="min-w-0">
                           <span className="inline-flex items-center rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[10px] font-medium text-amber-300">
-                            Running sessions
+                            Idle sessions
                           </span>
                           <div className="mt-2 text-[13px] font-semibold leading-tight text-fg">
-                            {staleCliNotice.count} old CLI or shell process{staleCliNotice.count === 1 ? "" : "es"} still running
+                            {staleCliNotice.count} CLI or shell session{staleCliNotice.count === 1 ? "" : "s"} sitting idle
                           </div>
                         </div>
                         <button
                           type="button"
                           className="shrink-0 rounded p-1 text-muted-fg transition-colors hover:bg-fg/[0.05] hover:text-fg"
-                          onClick={() => {
-                            if (staleCliNoticeDismissKey) {
-                              dismissedStaleCliNoticeKeyRef.current = staleCliNoticeDismissKey;
-                            }
-                            setStaleCliNotice(null);
-                          }}
-                          aria-label="Dismiss old running sessions notice"
-                          title="Dismiss"
+                          onClick={dismissStaleCliNotice}
+                          aria-label="Dismiss idle sessions notice"
+                          title="Dismiss for an hour"
                         >
                           ×
                         </button>
                       </div>
                       <div className="mt-2 text-[12px] leading-relaxed text-muted-fg">
-                        The oldest has been open for about {staleCliNoticeAgeHours} hours. Review running sessions and close anything no longer in use.
+                        No activity for about {staleCliNoticeAgeHours} hours. Close anything you're done with to free up memory.
                       </div>
+                      {staleCliNotice.lanes.length > 0 ? (
+                        <div className="mt-2 flex flex-wrap items-center gap-1">
+                          {staleCliNotice.lanes.slice(0, 4).map((noticeLane) => {
+                            const laneColor =
+                              lanes.find((lane) => lane.id === noticeLane.laneId)?.color ?? null;
+                            return (
+                              <span
+                                key={noticeLane.laneId}
+                                className="inline-flex max-w-full items-center gap-1 rounded-full border border-fg/10 bg-fg/[0.04] px-1.5 py-0.5 text-[10px] text-muted-fg"
+                                title={`${noticeLane.count} idle session${noticeLane.count === 1 ? "" : "s"} in ${noticeLane.laneName}`}
+                              >
+                                <span
+                                  className="h-1.5 w-1.5 shrink-0 rounded-full"
+                                  style={{ backgroundColor: laneColor ?? "currentColor" }}
+                                />
+                                <span className="max-w-[120px] truncate">{noticeLane.laneName}</span>
+                                {noticeLane.count > 1 ? (
+                                  <span className="shrink-0 tabular-nums text-muted-fg/70">×{noticeLane.count}</span>
+                                ) : null}
+                              </span>
+                            );
+                          })}
+                          {staleCliNotice.lanes.length > 4 ? (
+                            <span className="text-[10px] text-muted-fg/70">
+                              +{staleCliNotice.lanes.length - 4} more
+                            </span>
+                          ) : null}
+                        </div>
+                      ) : null}
                       <div className="mt-3 flex justify-end">
                         <button
                           type="button"
                           className="inline-flex h-8 items-center gap-1.5 rounded-md bg-amber-300 px-3 text-[11px] font-medium text-[#0F0D14] transition-colors hover:brightness-110"
                           onClick={() => {
-                            navigate("/work?status=running");
-                            if (staleCliNoticeDismissKey) {
-                              dismissedStaleCliNoticeKeyRef.current = staleCliNoticeDismissKey;
+                            if (currentProjectRoot) {
+                              // Reset the lane filter too so stale sessions across
+                              // *all* lanes are visible, not just the active one.
+                              setWorkViewState(currentProjectRoot, {
+                                statusFilter: "running",
+                                laneFilter: "all",
+                              });
                             }
-                            setStaleCliNotice(null);
+                            navigate("/work");
+                            dismissStaleCliNotice();
                           }}
                         >
                           View processes

--- a/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
@@ -676,6 +676,7 @@ export function useLaneWorkSessions(laneId: string | null) {
         headShaStart: null,
         headShaEnd: null,
         lastOutputPreview: null,
+        lastActivityAt: null,
         summary: null,
         runtimeState: "running",
         resumeCommand: null,

--- a/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
@@ -227,9 +227,9 @@ export const SessionCard = React.memo(function SessionCard({
                 ) : null}
                 {staleAgeHours != null ? (
                   <span
-                    className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-amber-500/30 bg-amber-500/10 text-amber-300"
-                    aria-label="Old running session"
-                    title={`Old running session. This CLI or shell session has been running for about ${staleAgeHours} hours. Stop the runtime if it is no longer being used.`}
+                    className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-amber-500/40 bg-amber-500/15 text-amber-300"
+                    aria-label="Idle session"
+                    title={`This CLI or shell session has had no activity for about ${staleAgeHours} hours. Consider closing it to clean up memory if it is no longer in use.`}
                   >
                     <WarningCircle size={11} weight="fill" />
                   </span>

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.test.tsx
@@ -57,6 +57,7 @@ function makeSession(overrides: Partial<TerminalSessionSummary> = {}): TerminalS
     headShaStart: null,
     headShaEnd: null,
     lastOutputPreview: null,
+    lastActivityAt: null,
     summary: null,
     runtimeState: "running",
     resumeCommand: null,
@@ -179,14 +180,17 @@ describe("SessionListPane", () => {
     expect(within(row!).getByText("Ran the latest command").className).not.toContain("font-semibold");
   });
 
-  it("marks old running CLI and shell sessions", () => {
+  it("marks idle CLI and shell sessions", () => {
     const staleSession = makeSession({
       id: "session-stale-shell",
       laneId: "lane-known",
       laneName: "Known Lane",
       toolType: "shell",
       title: "Old shell",
+      // No activity recorded → idle age falls back to startedAt, which is far
+      // enough in the past to clear the 24h idle threshold.
       startedAt: "2026-04-20T10:00:00.000Z",
+      lastActivityAt: null,
       status: "running",
       runtimeState: "waiting-input",
     });
@@ -195,7 +199,7 @@ describe("SessionListPane", () => {
       sessionsGroupedByLane: new Map([[staleSession.laneId, [staleSession]]]),
     });
 
-    expect(screen.getByLabelText("Old running session")).toBeTruthy();
+    expect(screen.getByLabelText("Idle session")).toBeTruthy();
   });
 
   it("collapses and expands child shell sections under a chat parent", () => {

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -1365,6 +1365,7 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
         headShaStart: null,
         headShaEnd: null,
         lastOutputPreview: null,
+        lastActivityAt: null,
         summary: null,
         runtimeState: "running",
         resumeCommand: null,

--- a/apps/desktop/src/renderer/lib/sessions.test.ts
+++ b/apps/desktop/src/renderer/lib/sessions.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import type { TerminalSessionSummary } from "../../shared/types";
 import {
   canBulkDeleteSession,
   canBulkStopSession,
+  getStaleRunningCliSessionAgeHours,
   isChatToolType,
   normalizeSessionLabel,
   preferredSessionLabel,
@@ -112,5 +114,66 @@ describe("session labels", () => {
   it("removes Claude fullscreen chrome from persisted terminal summaries", () => {
     const label = "Ran Say exactly: patched exit works (FAIL, exit code 143, \u001b7\u001b8╭───Claude Codev2.1.141────)";
     expect(normalizeSessionLabel(label)).toBe("Ran Say exactly: patched exit works (STOPPED, exit code 143)");
+  });
+});
+
+describe("getStaleRunningCliSessionAgeHours", () => {
+  const HOUR = 60 * 60 * 1_000;
+  const NOW = Date.parse("2026-06-06T00:00:00.000Z");
+
+  const session = (overrides: Partial<TerminalSessionSummary>): TerminalSessionSummary =>
+    ({
+      status: "running",
+      toolType: "shell",
+      startedAt: new Date(NOW - 100 * HOUR).toISOString(),
+      lastActivityAt: null,
+      ...overrides,
+    }) as TerminalSessionSummary;
+
+  it("flags a non-chat session whose last activity is 24h+ ago", () => {
+    const result = getStaleRunningCliSessionAgeHours(
+      session({ lastActivityAt: new Date(NOW - 30 * HOUR).toISOString() }),
+      NOW,
+    );
+    expect(result).toBe(30);
+  });
+
+  it("does NOT flag an old session that is still actively producing output", () => {
+    // Started 100h ago, but produced output 2h ago — not stale.
+    const result = getStaleRunningCliSessionAgeHours(
+      session({ lastActivityAt: new Date(NOW - 2 * HOUR).toISOString() }),
+      NOW,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("uses a 24h threshold (23h idle is not yet stale)", () => {
+    expect(
+      getStaleRunningCliSessionAgeHours(
+        session({ lastActivityAt: new Date(NOW - 23 * HOUR).toISOString() }),
+        NOW,
+      ),
+    ).toBeNull();
+    expect(
+      getStaleRunningCliSessionAgeHours(
+        session({ lastActivityAt: new Date(NOW - 25 * HOUR).toISOString() }),
+        NOW,
+      ),
+    ).toBe(25);
+  });
+
+  it("falls back to startedAt when there is no activity timestamp yet", () => {
+    const result = getStaleRunningCliSessionAgeHours(
+      session({ startedAt: new Date(NOW - 40 * HOUR).toISOString(), lastActivityAt: null }),
+      NOW,
+    );
+    expect(result).toBe(40);
+  });
+
+  it("never flags chat, run-owned, or non-running sessions", () => {
+    const idle = new Date(NOW - 50 * HOUR).toISOString();
+    expect(getStaleRunningCliSessionAgeHours(session({ toolType: "claude-chat", lastActivityAt: idle }), NOW)).toBeNull();
+    expect(getStaleRunningCliSessionAgeHours(session({ toolType: "run-shell", lastActivityAt: idle }), NOW)).toBeNull();
+    expect(getStaleRunningCliSessionAgeHours(session({ status: "detached", lastActivityAt: idle }), NOW)).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/lib/sessions.ts
+++ b/apps/desktop/src/renderer/lib/sessions.ts
@@ -42,20 +42,30 @@ export function isRunOwnedSession(session: Pick<TerminalSessionSummary, "toolTyp
   return isRunOwnedToolType(session.toolType);
 }
 
-export const STALE_RUNNING_CLI_SESSION_MS = 12 * 60 * 60 * 1_000;
+export const STALE_RUNNING_CLI_SESSION_MS = 24 * 60 * 60 * 1_000;
+const STALE_RUNNING_CLI_SESSION_HOURS = STALE_RUNNING_CLI_SESSION_MS / (60 * 60 * 1_000);
 
+/**
+ * Returns how many hours a running CLI/shell session has been *idle* (no output),
+ * or null if it is not stale. Staleness keys off the last activity timestamp —
+ * not when the session started — so an old session that is still actively
+ * producing output is never flagged; only genuinely untouched ones are. Falls
+ * back to startedAt when no activity timestamp has been recorded yet.
+ */
 export function getStaleRunningCliSessionAgeHours(
-  session: Pick<TerminalSessionSummary, "status" | "startedAt" | "toolType">,
+  session: Pick<TerminalSessionSummary, "status" | "startedAt" | "toolType" | "lastActivityAt">,
   nowMs: number = Date.now(),
 ): number | null {
   if (session.status !== "running") return null;
   if (isRunOwnedSession(session)) return null;
   if (isChatToolType(session.toolType)) return null;
+  const lastActivityMs = session.lastActivityAt ? Date.parse(session.lastActivityAt) : Number.NaN;
   const startedMs = Date.parse(session.startedAt);
-  if (!Number.isFinite(startedMs)) return null;
-  const ageMs = nowMs - startedMs;
-  if (ageMs < STALE_RUNNING_CLI_SESSION_MS) return null;
-  return Math.max(12, Math.floor(ageMs / (60 * 60 * 1_000)));
+  const referenceMs = Number.isFinite(lastActivityMs) ? lastActivityMs : startedMs;
+  if (!Number.isFinite(referenceMs)) return null;
+  const idleMs = nowMs - referenceMs;
+  if (idleMs < STALE_RUNNING_CLI_SESSION_MS) return null;
+  return Math.max(STALE_RUNNING_CLI_SESSION_HOURS, Math.floor(idleMs / (60 * 60 * 1_000)));
 }
 
 export function defaultSessionLabel(toolType: string | null | undefined): string {
@@ -114,6 +124,7 @@ export function buildOptimisticChatSessionSummary(args: {
     headShaStart: null,
     headShaEnd: null,
     lastOutputPreview: null,
+    lastActivityAt: args.session.lastActivityAt ?? null,
     summary: null,
     runtimeState: isEnded ? "exited" : args.session.status === "active" ? "running" : "idle",
     resumeCommand: null,

--- a/apps/desktop/src/renderer/lib/staleCliNoticeSnooze.test.ts
+++ b/apps/desktop/src/renderer/lib/staleCliNoticeSnooze.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  STALE_CLI_NOTICE_SNOOZE_MS,
+  getStaleCliNoticeSnoozeUntil,
+  isStaleCliNoticeSnoozed,
+  snoozeStaleCliNotice,
+} from "./staleCliNoticeSnooze";
+
+function installLocalStorage(): void {
+  const store = new Map<string, string>();
+  const localStorage = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => store.clear(),
+  };
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { localStorage },
+  });
+}
+
+describe("staleCliNoticeSnooze", () => {
+  const NOW = Date.parse("2026-06-06T00:00:00.000Z");
+  const ROOT = "/project/a";
+
+  beforeEach(() => {
+    installLocalStorage();
+  });
+
+  it("reports no snooze for an unknown project", () => {
+    expect(getStaleCliNoticeSnoozeUntil(ROOT)).toBe(0);
+    expect(isStaleCliNoticeSnoozed(ROOT, NOW)).toBe(false);
+  });
+
+  it("snoozes a project for exactly one hour from now", () => {
+    snoozeStaleCliNotice(ROOT, NOW);
+    expect(getStaleCliNoticeSnoozeUntil(ROOT)).toBe(NOW + STALE_CLI_NOTICE_SNOOZE_MS);
+    expect(isStaleCliNoticeSnoozed(ROOT, NOW)).toBe(true);
+    // Still snoozed 59 minutes later, expired just after the hour.
+    expect(isStaleCliNoticeSnoozed(ROOT, NOW + 59 * 60_000)).toBe(true);
+    expect(isStaleCliNoticeSnoozed(ROOT, NOW + STALE_CLI_NOTICE_SNOOZE_MS + 1)).toBe(false);
+  });
+
+  it("keeps snooze windows independent per project", () => {
+    snoozeStaleCliNotice(ROOT, NOW);
+    expect(isStaleCliNoticeSnoozed("/project/b", NOW)).toBe(false);
+    expect(isStaleCliNoticeSnoozed(ROOT, NOW)).toBe(true);
+  });
+
+  it("ignores blank/null project roots", () => {
+    snoozeStaleCliNotice(null, NOW);
+    snoozeStaleCliNotice("   ", NOW);
+    expect(getStaleCliNoticeSnoozeUntil(null)).toBe(0);
+    expect(getStaleCliNoticeSnoozeUntil("")).toBe(0);
+  });
+
+  it("prunes expired entries for other projects when snoozing", () => {
+    // Snooze B in the distant past so it is expired by the time A is snoozed.
+    snoozeStaleCliNotice("/project/b", NOW - 2 * STALE_CLI_NOTICE_SNOOZE_MS);
+    snoozeStaleCliNotice(ROOT, NOW);
+    expect(getStaleCliNoticeSnoozeUntil("/project/b")).toBe(0);
+    expect(getStaleCliNoticeSnoozeUntil(ROOT)).toBe(NOW + STALE_CLI_NOTICE_SNOOZE_MS);
+  });
+});

--- a/apps/desktop/src/renderer/lib/staleCliNoticeSnooze.ts
+++ b/apps/desktop/src/renderer/lib/staleCliNoticeSnooze.ts
@@ -1,0 +1,73 @@
+/**
+ * Persistent, per-project snooze for the "stale CLI/shell sessions" notice.
+ *
+ * The notice should appear at most once per hour per project, and that cadence
+ * must survive app restarts, project close/reopen, and leaving/returning to a
+ * project — so it is backed by localStorage (durable in the Electron renderer)
+ * rather than in-memory React state. Keyed by project root: each project gets
+ * its own hourly window.
+ */
+
+const STORAGE_KEY = "ade.staleCliNoticeSnoozeByRoot";
+
+/** How long the notice stays suppressed after it is shown or dismissed. */
+export const STALE_CLI_NOTICE_SNOOZE_MS = 60 * 60 * 1_000;
+
+type SnoozeMap = Record<string, number>;
+
+function readMap(): SnoozeMap {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const out: SnoozeMap = {};
+    for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof value === "number" && Number.isFinite(value)) out[key] = value;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function writeMap(map: SnoozeMap): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // best effort — storage may be unavailable
+  }
+}
+
+/** Epoch ms until which the notice is snoozed for this project (0 if not snoozed). */
+export function getStaleCliNoticeSnoozeUntil(projectRoot: string | null | undefined): number {
+  const root = projectRoot?.trim();
+  if (!root) return 0;
+  return readMap()[root] ?? 0;
+}
+
+/** True if the notice is currently snoozed for this project. */
+export function isStaleCliNoticeSnoozed(
+  projectRoot: string | null | undefined,
+  nowMs: number = Date.now(),
+): boolean {
+  return getStaleCliNoticeSnoozeUntil(projectRoot) > nowMs;
+}
+
+/**
+ * Snooze the notice for this project for one hour from `nowMs`. Also prunes
+ * already-expired entries for other projects so the map can't grow unbounded.
+ */
+export function snoozeStaleCliNotice(
+  projectRoot: string | null | undefined,
+  nowMs: number = Date.now(),
+): void {
+  const root = projectRoot?.trim();
+  if (!root) return;
+  const map = readMap();
+  map[root] = nowMs + STALE_CLI_NOTICE_SNOOZE_MS;
+  for (const key of Object.keys(map)) {
+    if (key !== root && map[key] <= nowMs) delete map[key];
+  }
+  writeMap(map);
+}

--- a/apps/desktop/src/shared/types/sessions.ts
+++ b/apps/desktop/src/shared/types/sessions.ts
@@ -87,7 +87,10 @@ export type TerminalSessionSummary = {
   lastOutputPreview: string | null;
   /**
    * ISO timestamp of the session's most recent output/activity
-   * (terminal_sessions.last_output_at). Null when it has never produced output.
+   * (terminal_sessions.last_output_at). Null when it has never produced output;
+   * optional so optimistic/partial UI constructions need not supply it. The DB
+   * boundary normalizes it to a valid ISO string or null, and consumers treat
+   * undefined/null/empty identically, so the extra state is harmless.
    * Used to detect sessions that are old *and untouched*, vs. old-but-active.
    */
   lastActivityAt?: string | null;

--- a/apps/desktop/src/shared/types/sessions.ts
+++ b/apps/desktop/src/shared/types/sessions.ts
@@ -85,6 +85,12 @@ export type TerminalSessionSummary = {
   headShaStart: string | null;
   headShaEnd: string | null;
   lastOutputPreview: string | null;
+  /**
+   * ISO timestamp of the session's most recent output/activity
+   * (terminal_sessions.last_output_at). Null when it has never produced output.
+   * Used to detect sessions that are old *and untouched*, vs. old-but-active.
+   */
+  lastActivityAt?: string | null;
   summary: string | null;
   runtimeState: TerminalRuntimeState;
   pendingInputItemId?: string | null;

--- a/docs/features/terminals-and-sessions/ui-surfaces.md
+++ b/docs/features/terminals-and-sessions/ui-surfaces.md
@@ -145,9 +145,13 @@ clearly even when the primary single-selection points elsewhere.
 A small amber warning pip with a tooltip appears next to the title
 when `getStaleRunningCliSessionAgeHours(session)` returns a value —
 i.e. the session is still `running`, is not chat-typed, is not a
-run-owned shell, and has been running for at least 12 hours. The
-tooltip reports the rounded age so the user can decide whether to
-close it.
+run-owned shell, and has been *idle* (no new output) for at least 24
+hours. Idleness is measured from the session's last activity
+(`lastActivityAt`, sourced from `terminal_sessions.last_output_at`),
+falling back to `startedAt` when no output has been recorded — so an
+old session that is still actively producing output is never flagged,
+only genuinely untouched ones are. The tooltip reports the rounded
+idle age so the user can decide whether to close it.
 
 ## Work view: `WorkViewArea.tsx`
 


### PR DESCRIPTION
## What & why

The recurring "old CLI or shell processes still running" notice had three problems: it re-nagged on every restart/project-switch (dismissal was in-memory only), it flagged sessions by **total runtime** so old-but-actively-used sessions got marked stale, and its "View processes" button silently no-opped. This reworks it.

## Changes

- **Activity-based staleness.** Staleness is now measured from a session's last activity (`last_output_at`, surfaced as `TerminalSessionSummary.lastActivityAt`) rather than total runtime, with a **24h** window (was 12h since start). An old session still producing output is no longer flagged — only genuinely untouched ones are. Falls back to `startedAt` when no output has been recorded yet.
- **Once-per-hour, per project, persisted.** A new localStorage-backed snooze (`staleCliNoticeSnooze.ts`) throttles the notice to at most once per hour per project, surviving app restart, project close/reopen, and leaving/returning.
- **Lane breakdown.** The notice now shows which lanes hold the idle sessions as lane chips, plus refreshed idle-focused copy ("Idle sessions" / "N CLI or shell sessions sitting idle").
- **"View processes" works.** It now drives the Work running-filter directly via `setWorkViewState` (and resets the lane filter so stale sessions across all lanes are visible) instead of a fragile `?status=` URL round-trip that the once-per-URL-signature guard silently dropped.
- **Sidebar pip.** Updated the `SessionCard` stale-pip tooltip copy to reflect inactivity; it remains non-clickable and uses the native `title` so it shows regardless of the smart-tooltips setting.

## Testing

- `tsc -p tsconfig.json --noEmit` clean; eslint clean on touched files (3 pre-existing ref-cleanup warnings only).
- New unit tests: `sessions.test.ts` (5 activity-based staleness cases), `staleCliNoticeSnooze.test.ts` (5 cases). Re-ran `sessionService` (22), `sessionListCache` (9), `SessionCard` (3) — all pass.
- Docs: updated `docs/features/terminals-and-sessions/ui-surfaces.md` to describe the new activity-based rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added snooze capability for idle session notices, with independent snooze periods per project
  * "View processes" action in idle session notices now filters and navigates to the relevant sessions view

* **Improvements**
  * Enhanced idle session detection with improved activity tracking
  * Increased idle session detection threshold from 12 to 24 hours of inactivity
  * Refined idle session messaging and visual indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reworks the \"stale CLI/shell sessions\" notice with three improvements: activity-based staleness detection (using `last_output_at` / `lastActivityAt` instead of session start time), a persisted per-project hourly snooze via `localStorage`, and a lane breakdown in the notice UI. It also fixes the broken \"View processes\" button by driving `setWorkViewState` directly instead of a URL round-trip.

- **Activity-based staleness** — `getStaleRunningCliSessionAgeHours` now keys off `lastActivityAt` (falling back to `startedAt`), raising the threshold from 12 h to 24 h; `touchSessionActivity` is added to the session service so the PTY layer can record output even when the preview text is unchanged (spinners/repeated lines).
- **Persisted snooze** — `staleCliNoticeSnooze.ts` writes a per-project epoch timestamp to `localStorage`, surviving restarts and project switches, with bounded growth via expiry pruning on each write.
- **\"View processes\" fix & UX** — button now calls `setWorkViewState` with `statusFilter: \"running\"` and `laneFilter: \"all\"`, and the notice surface gains lane chips with per-lane idle counts.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed paths are well-guarded with tested fallbacks and the fix to the View processes button is straightforward.

The staleness rework is correct end-to-end: DB writes from touchSessionActivity are picked up by the 1.5 s TTL session-list cache before the next polling tick, the localStorage snooze is idempotent and bounded, and the lane breakdown is purely additive UI. New unit tests cover all five staleness cases, all five snooze cases, and the touchSessionActivity DB contract. No cross-cutting behaviour was broken.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/lib/staleCliNoticeSnooze.ts | New localStorage-backed snooze module; per-project entries, bounded growth via expiry pruning, safe fallbacks for unavailable storage. |
| apps/desktop/src/renderer/components/app/AppShell.tsx | Replaces key-based dismiss with staleCliNoticeActiveRef + hourly snooze; View processes now drives setWorkViewState; lane breakdown chips added to notice UI. |
| apps/desktop/src/main/services/sessions/sessionService.ts | Adds touchSessionActivity DB method and lastActivityAt column projection; normalizeIsoTimestamp guards against garbage timestamps from DB. |
| apps/desktop/src/renderer/lib/sessions.ts | getStaleRunningCliSessionAgeHours updated to use lastActivityAt with startedAt fallback; threshold bumped to 24 h. |
| apps/desktop/src/main/services/pty/ptyService.ts | Calls touchSessionActivity on every throttled output tick for tracked sessions, catching steady-output spinner cases missed by preview deduplication. |
| apps/desktop/src/shared/types/sessions.ts | Adds optional lastActivityAt to TerminalSessionSummary; doc comment explains intentional optionality for optimistic UI constructors. |

</details>

<sub>Reviews (3): Last reviewed commit: ["ship: iteration 2 — refresh session acti..."](https://github.com/arul28/ade/commit/702864be54dd25a6cefe38cb33981c0934998570) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36038493)</sub>

<!-- /greptile_comment -->