### PR TITLE
Stop And Delete Sessions

### DIFF
--- a/apps/desktop/src/renderer/components/terminals/CliSessionWorkSurfaceHeader.tsx
+++ b/apps/desktop/src/renderer/components/terminals/CliSessionWorkSurfaceHeader.tsx
@@ -279,6 +279,14 @@ export function CliSessionWorkSurfaceHeader({
       showCacheBadge={showCache}
       cacheIdleSinceAt={session.chatIdleSinceAt}
       showGitToolbar
+      onContextMenu={
+        onContextMenu
+          ? (event) => {
+              event.preventDefault();
+              onContextMenu(session, event);
+            }
+          : undefined
+      }
       onToggleSessionsPane={onToggleSessionsPane}
       sessionsPaneCollapsed={sessionsPaneCollapsed}
       sessionsPaneCount={sessionsPaneCount}

--- a/apps/desktop/src/renderer/components/terminals/SessionContextMenu.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionContextMenu.tsx
@@ -12,6 +12,7 @@ type SessionContextMenuProps = {
   menu: SessionContextMenuState;
   onClose: () => void;
   onStopRuntime: (args: { ptyId: string; sessionId: string }) => void;
+  onStopAndDelete: (session: TerminalSessionSummary) => void;
   onDeleteChat: (session: TerminalSessionSummary) => void;
   onDeleteSession: (session: TerminalSessionSummary) => void;
   deletingSessionId: string | null;
@@ -30,6 +31,7 @@ export function SessionContextMenu({
   menu,
   onClose,
   onStopRuntime,
+  onStopAndDelete,
   onDeleteChat,
   onDeleteSession,
   deletingSessionId,
@@ -158,6 +160,16 @@ export function SessionContextMenu({
             onClick={() => { onStopRuntime({ ptyId: session.ptyId!, sessionId: session.id }); onClose(); }}
           >
             Stop runtime
+          </button>
+        ) : null}
+
+        {isRunning && session.ptyId && !isChat ? (
+          <button
+            className="flex w-full items-center gap-2 rounded px-3 py-1.5 text-left text-xs text-red-300 hover:bg-red-500/10 transition-colors"
+            disabled={deletingSessionId === session.id}
+            onClick={() => { onStopAndDelete(session); onClose(); }}
+          >
+            {deletingSessionId === session.id ? "Deleting..." : "Stop and delete"}
           </button>
         ) : null}
 

--- a/apps/desktop/src/renderer/components/terminals/SessionContextMenu.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionContextMenu.tsx
@@ -169,7 +169,7 @@ export function SessionContextMenu({
             disabled={deletingSessionId === session.id}
             onClick={() => { onStopAndDelete(session); onClose(); }}
           >
-            {deletingSessionId === session.id ? "Deleting..." : "Stop and delete"}
+            {deletingSessionId === session.id ? "Deleting…" : "Stop & delete"}
           </button>
         ) : null}
 
@@ -179,7 +179,7 @@ export function SessionContextMenu({
             disabled={deletingSessionId === session.id}
             onClick={() => { onDeleteChat(session); onClose(); }}
           >
-            {deletingSessionId === session.id ? "Deleting..." : "Delete chat"}
+            {deletingSessionId === session.id ? "Deleting…" : "Delete chat"}
           </button>
         ) : null}
 
@@ -189,7 +189,7 @@ export function SessionContextMenu({
             disabled={deletingSessionId === session.id}
             onClick={() => { onDeleteSession(session); onClose(); }}
           >
-            {deletingSessionId === session.id ? "Deleting..." : "Delete session"}
+            {deletingSessionId === session.id ? "Deleting…" : "Delete session"}
           </button>
         ) : null}
 

--- a/apps/desktop/src/renderer/components/terminals/SessionInfoPopover.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionInfoPopover.tsx
@@ -293,7 +293,7 @@ export function SessionInfoPopover({
             </SmartTooltip>
           ) : null}
           {session.status === "running" && session.ptyId && !isChat ? (
-            <SmartTooltip content={{ label: "Stop and delete", description: "Stop the runtime and permanently delete this session." }}>
+            <SmartTooltip content={{ label: "Stop & delete", description: "Stop the runtime and permanently delete this session." }}>
               <Button
                 variant="danger"
                 size="sm"

--- a/apps/desktop/src/renderer/components/terminals/SessionInfoPopover.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionInfoPopover.tsx
@@ -79,6 +79,7 @@ export function SessionInfoPopover({
   popover,
   onClose,
   onStopRuntime,
+  onStopAndDelete,
   onDeleteChat,
   onDeleteSession,
   onGoToLane,
@@ -88,6 +89,7 @@ export function SessionInfoPopover({
   popover: InfoPopoverState;
   onClose: () => void;
   onStopRuntime: (args: { ptyId: string; sessionId: string }) => void;
+  onStopAndDelete: (session: TerminalSessionSummary) => void;
   onDeleteChat: (session: TerminalSessionSummary) => void;
   onDeleteSession: (session: TerminalSessionSummary) => void;
   onGoToLane: (session: TerminalSessionSummary) => void;
@@ -287,6 +289,19 @@ export function SessionInfoPopover({
               >
                 <Square size={14} weight="regular" />
                 {closingPtyIds.has(session.ptyId) ? "Stopping..." : "Stop runtime"}
+              </Button>
+            </SmartTooltip>
+          ) : null}
+          {session.status === "running" && session.ptyId && !isChat ? (
+            <SmartTooltip content={{ label: "Stop and delete", description: "Stop the runtime and permanently delete this session." }}>
+              <Button
+                variant="danger"
+                size="sm"
+                disabled={deletingSessionId === session.id}
+                onClick={() => onStopAndDelete(session)}
+              >
+                <Trash size={14} weight="regular" />
+                {deletingSessionId === session.id ? "Deleting…" : "Stop & delete"}
               </Button>
             </SmartTooltip>
           ) : null}

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.test.tsx
@@ -1,9 +1,9 @@
 /* @vitest-environment jsdom */
 
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import type { ComponentProps } from "react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { LaneSummary, TerminalSessionSummary } from "../../../shared/types";
 import { SessionListPane } from "./SessionListPane";
 
@@ -99,6 +99,10 @@ function renderPane(props: Partial<ComponentProps<typeof SessionListPane>> = {})
 }
 
 describe("SessionListPane", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   it("renders by-lane sessions whose lane is missing from the cached lane list", () => {
     renderPane();
 
@@ -337,5 +341,69 @@ describe("SessionListPane", () => {
     expect(onBulkClose).toHaveBeenCalledTimes(1);
     expect(onBulkDelete).toHaveBeenCalledTimes(1);
     expect(onClearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers stop & delete only when the selection includes a running runtime", () => {
+    const onBulkStopAndDelete = vi.fn();
+    const running = makeSession({
+      id: "session-running",
+      laneId: "lane-known",
+      laneName: "Known Lane",
+      title: "Running shell",
+      toolType: "shell",
+      status: "running",
+    });
+    const chat = makeSession({
+      id: "session-chat",
+      laneId: "lane-known",
+      laneName: "Known Lane",
+      title: "Active chat",
+      toolType: "codex-chat",
+      status: "running",
+      ptyId: null,
+    });
+
+    renderPane({
+      runningFiltered: [running, chat],
+      selectedSessionIds: new Set([running.id, chat.id]),
+      sessionsGroupedByLane: new Map([[running.laneId, [running, chat]]]),
+      onBulkStopAndDelete,
+    });
+
+    // Mixed selection: the whole selection (both sessions) is targeted.
+    const stopAndDelete = screen.getByRole("button", { name: /stop & delete 2/i });
+    fireEvent.click(stopAndDelete);
+    expect(onBulkStopAndDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides stop & delete when nothing in the selection needs stopping", () => {
+    const endedShell = makeSession({
+      id: "session-ended",
+      laneId: "lane-known",
+      laneName: "Known Lane",
+      title: "Ended shell",
+      toolType: "shell",
+      status: "disposed",
+      runtimeState: "exited",
+    });
+    const chat = makeSession({
+      id: "session-chat",
+      laneId: "lane-known",
+      laneName: "Known Lane",
+      title: "Active chat",
+      toolType: "codex-chat",
+      status: "running",
+      ptyId: null,
+    });
+
+    renderPane({
+      runningFiltered: [chat],
+      endedFiltered: [endedShell],
+      selectedSessionIds: new Set([endedShell.id, chat.id]),
+      sessionsGroupedByLane: new Map([[chat.laneId, [chat, endedShell]]]),
+      onBulkStopAndDelete: vi.fn(),
+    });
+
+    expect(screen.queryByRole("button", { name: /stop & delete/i })).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
@@ -187,6 +187,7 @@ export const SessionListPane = React.memo(function SessionListPane({
   onClearSelection,
   onBulkClose,
   onBulkDelete,
+  onBulkStopAndDelete,
   onContextMenu,
   sessionListOrganization,
   setSessionListOrganization,
@@ -218,6 +219,7 @@ export const SessionListPane = React.memo(function SessionListPane({
   onClearSelection?: () => void;
   onBulkClose?: () => void;
   onBulkDelete?: () => void;
+  onBulkStopAndDelete?: () => void;
   onContextMenu: (session: TerminalSessionSummary, e: React.MouseEvent) => void;
   sessionListOrganization: WorkSessionListOrganization;
   setSessionListOrganization: (v: WorkSessionListOrganization) => void;
@@ -732,6 +734,18 @@ export const SessionListPane = React.memo(function SessionListPane({
                 >
                   <Trash size={10} />
                   Delete {selectedDeletableCount}
+                </button>
+              </SmartTooltip>
+            ) : null}
+            {selectedRunningCount > 0 ? (
+              <SmartTooltip content={{ label: "Stop & delete selected", description: "Stop running runtimes, then permanently delete every selected session." }}>
+                <button
+                  type="button"
+                  className="inline-flex h-6 items-center gap-1 rounded-md border border-red-500/30 bg-red-500/15 px-2 text-[10px] font-medium text-red-200"
+                  onClick={onBulkStopAndDelete}
+                >
+                  <Trash size={10} />
+                  Stop &amp; delete {selectedCount}
                 </button>
               </SmartTooltip>
             ) : null}

--- a/apps/desktop/src/renderer/components/terminals/TerminalsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalsPage.test.tsx
@@ -170,6 +170,7 @@ type MockSessionListPaneProps = {
   endedFiltered: TerminalSessionSummary[];
   onSelectSession: (id: string, event: React.MouseEvent, visibleSessionIds: string[]) => void;
   onBulkDelete?: () => void;
+  onBulkStopAndDelete?: () => void;
 };
 
 const sessionListPaneProps = vi.hoisted(() => ({
@@ -234,6 +235,9 @@ vi.mock("./SessionListPane", () => ({
         ))}
         <button type="button" onClick={() => props.onBulkDelete?.()}>
           bulk delete
+        </button>
+        <button type="button" onClick={() => props.onBulkStopAndDelete?.()}>
+          bulk stop and delete
         </button>
       </div>
     );
@@ -515,5 +519,51 @@ describe("TerminalsPage chat session activation", () => {
     expect(workMocks.currentWork.removeSessionFromList).not.toHaveBeenCalledWith("shell-running");
     expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining("Delete 2 selected sessions?"));
     confirmSpy.mockRestore();
+  });
+
+  it("stops and deletes a mixed selection of running CLI and chat sessions", async () => {
+    const runningCli = workMocks.makeTerminalSession("cli-running", "lane-primary", "codex");
+    const runningChat = workMocks.makeTerminalSession("chat-running", "lane-primary", "codex-chat", {
+      ptyId: null,
+    });
+    const agentChatDelete = vi.fn().mockResolvedValue(undefined);
+    const sessionDelete = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(window, "ade", {
+      configurable: true,
+      value: {
+        agentChat: { delete: agentChatDelete },
+        builtInBrowser: { onEvent: vi.fn(() => vi.fn()) },
+        sessions: { delete: sessionDelete },
+      },
+    });
+    workMocks.currentWork = {
+      ...workMocks.baseWork,
+      sessions: [runningCli, runningChat],
+      visibleSessions: [runningCli, runningChat],
+      runningFiltered: [runningCli, runningChat],
+      runningSessions: [runningCli, runningChat],
+      filtered: [runningCli, runningChat],
+      sessionsGroupedByLane: new Map([["lane-primary", [runningCli, runningChat]]]),
+      closingPtyIds: new Set<string>(),
+    };
+
+    render(<TerminalsPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "select cli-running" }), { metaKey: true });
+    fireEvent.click(await screen.findByRole("button", { name: "select chat-running" }), { metaKey: true });
+    fireEvent.click(await screen.findByRole("button", { name: "bulk stop and delete" }));
+
+    // The styled confirmation dialog gates the destructive action.
+    fireEvent.click(await screen.findByRole("button", { name: "Stop & delete" }));
+
+    await waitFor(() => {
+      // The running CLI session is stopped+deleted via the session-delete service,
+      // and the chat is removed via the chat delete flow — both in one action.
+      expect(sessionDelete).toHaveBeenCalledWith({ sessionId: "cli-running" });
+      expect(agentChatDelete).toHaveBeenCalledWith({ sessionId: "chat-running" });
+      expect(workMocks.currentWork.removeSessionFromList).toHaveBeenCalledWith("cli-running");
+      expect(workMocks.currentWork.removeSessionFromList).toHaveBeenCalledWith("chat-running");
+    });
   });
 });

--- a/apps/desktop/src/renderer/components/terminals/TerminalsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalsPage.test.tsx
@@ -171,6 +171,7 @@ type MockSessionListPaneProps = {
   onSelectSession: (id: string, event: React.MouseEvent, visibleSessionIds: string[]) => void;
   onBulkDelete?: () => void;
   onBulkStopAndDelete?: () => void;
+  onContextMenu: (session: TerminalSessionSummary, event: React.MouseEvent) => void;
 };
 
 const sessionListPaneProps = vi.hoisted(() => ({
@@ -225,13 +226,20 @@ vi.mock("./SessionListPane", () => ({
     return (
       <div data-testid="session-list-pane">
         {visibleSessions.map((session) => (
-          <button
-            key={session.id}
-            type="button"
-            onClick={(event) => props.onSelectSession(session.id, event, visibleSessionIds)}
-          >
-            select {session.id}
-          </button>
+          <React.Fragment key={session.id}>
+            <button
+              type="button"
+              onClick={(event) => props.onSelectSession(session.id, event, visibleSessionIds)}
+            >
+              select {session.id}
+            </button>
+            <button
+              type="button"
+              onClick={(event) => props.onContextMenu(session, event)}
+            >
+              context menu {session.id}
+            </button>
+          </React.Fragment>
         ))}
         <button type="button" onClick={() => props.onBulkDelete?.()}>
           bulk delete
@@ -256,7 +264,18 @@ vi.mock("./WorkSidebar", () => ({
 }));
 
 vi.mock("./SessionContextMenu", () => ({
-  SessionContextMenu: () => null,
+  SessionContextMenu: (props: {
+    menu: { session: TerminalSessionSummary } | null;
+    onStopAndDelete: (session: TerminalSessionSummary) => void;
+  }) => {
+    if (!props.menu) return null;
+    const session = props.menu.session;
+    return (
+      <button type="button" onClick={() => props.onStopAndDelete(session)}>
+        context stop and delete {session.id}
+      </button>
+    );
+  },
 }));
 
 vi.mock("./SessionInfoPopover", () => ({
@@ -519,6 +538,85 @@ describe("TerminalsPage chat session activation", () => {
     expect(workMocks.currentWork.removeSessionFromList).not.toHaveBeenCalledWith("shell-running");
     expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining("Delete 2 selected sessions?"));
     confirmSpy.mockRestore();
+  });
+
+  it("stops and deletes a single running CLI session via the context menu", async () => {
+    const runningCli = workMocks.makeTerminalSession("cli-single", "lane-primary", "codex");
+    const sessionDelete = vi.fn().mockResolvedValue(undefined);
+    const agentChatDelete = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(window, "ade", {
+      configurable: true,
+      value: {
+        agentChat: { delete: agentChatDelete },
+        builtInBrowser: { onEvent: vi.fn(() => vi.fn()) },
+        sessions: { delete: sessionDelete },
+      },
+    });
+    workMocks.currentWork = {
+      ...workMocks.baseWork,
+      sessions: [runningCli],
+      visibleSessions: [runningCli],
+      runningFiltered: [runningCli],
+      runningSessions: [runningCli],
+      filtered: [runningCli],
+      sessionsGroupedByLane: new Map([["lane-primary", [runningCli]]]),
+      closingPtyIds: new Set<string>(),
+    };
+
+    render(<TerminalsPage />);
+
+    // Open the context menu for the session, then trigger stop-and-delete.
+    fireEvent.click(await screen.findByRole("button", { name: "context menu cli-single" }));
+    fireEvent.click(await screen.findByRole("button", { name: "context stop and delete cli-single" }));
+
+    // The styled confirmation dialog must gate the destructive single-session action.
+    fireEvent.click(await screen.findByRole("button", { name: "Stop & delete" }));
+
+    await waitFor(() => {
+      // The session-delete service stops the runtime and removes the record in one call;
+      // the chat-delete path must not be touched for a non-chat session.
+      expect(sessionDelete).toHaveBeenCalledWith({ sessionId: "cli-single" });
+      expect(workMocks.currentWork.removeSessionFromList).toHaveBeenCalledWith("cli-single");
+      expect(workMocks.currentWork.closeTab).toHaveBeenCalledWith("cli-single");
+    });
+    expect(agentChatDelete).not.toHaveBeenCalled();
+  });
+
+  it("does not delete when the stop-and-delete confirmation is dismissed", async () => {
+    const runningCli = workMocks.makeTerminalSession("cli-cancel", "lane-primary", "codex");
+    const sessionDelete = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(window, "ade", {
+      configurable: true,
+      value: {
+        agentChat: { delete: vi.fn() },
+        builtInBrowser: { onEvent: vi.fn(() => vi.fn()) },
+        sessions: { delete: sessionDelete },
+      },
+    });
+    workMocks.currentWork = {
+      ...workMocks.baseWork,
+      sessions: [runningCli],
+      visibleSessions: [runningCli],
+      runningFiltered: [runningCli],
+      runningSessions: [runningCli],
+      filtered: [runningCli],
+      sessionsGroupedByLane: new Map([["lane-primary", [runningCli]]]),
+      closingPtyIds: new Set<string>(),
+    };
+
+    render(<TerminalsPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "context menu cli-cancel" }));
+    fireEvent.click(await screen.findByRole("button", { name: "context stop and delete cli-cancel" }));
+    fireEvent.click(await screen.findByRole("button", { name: "CANCEL" }));
+
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "Stop & delete" })).toBeNull(),
+    );
+    expect(sessionDelete).not.toHaveBeenCalled();
+    expect(workMocks.currentWork.removeSessionFromList).not.toHaveBeenCalled();
   });
 
   it("stops and deletes a mixed selection of running CLI and chat sessions", async () => {

--- a/apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx
@@ -7,6 +7,7 @@ import { WorkViewArea } from "./WorkViewArea";
 import { WorkSidebar, type WorkSidebarContextTarget } from "./WorkSidebar";
 import { SessionContextMenu, type SessionContextMenuState } from "./SessionContextMenu";
 import { SessionInfoPopover, type InfoPopoverState } from "./SessionInfoPopover";
+import { ConfirmDialog, useConfirmDialog } from "../shared/InlineDialogs";
 import type { AgentChatSession, TerminalSessionSummary } from "../../../shared/types";
 import { buildDeeplink } from "../../../shared/deeplinks";
 import type { AgentChatSessionCreatedOptions } from "../chat/AgentChatPane";
@@ -117,6 +118,7 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
   const [deletingSessionId, setDeletingSessionId] = useState<string | null>(null);
   const [selectedSessionIds, setSelectedSessionIds] = useState<Set<string>>(new Set());
   const [selectionAnchorId, setSelectionAnchorId] = useState<string | null>(null);
+  const stopAndDeleteConfirm = useConfirmDialog();
   const workContentPaneRef = useRef<HTMLDivElement | null>(null);
   const workSidebarPaneRef = useRef<HTMLDivElement | null>(null);
   const unifiedChromeRef = useRef<HTMLDivElement | null>(null);
@@ -324,6 +326,45 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
     [work],
   );
 
+  const handleStopAndDeleteSession = useCallback(
+    (session: TerminalSessionSummary) => {
+      void (async () => {
+        const label = (session.goal ?? session.title).trim() || "this session";
+        const confirmed = await stopAndDeleteConfirm.confirmAsync({
+          title: "Stop and delete session",
+          message: `Stop the runtime for "${label}" and permanently delete it?\n\nThis terminates the running process and removes the saved session from ADE.`,
+          confirmLabel: "Stop & delete",
+          danger: true,
+        });
+        if (!confirmed) return;
+
+        setSessionActionError(null);
+        setDeletingSessionId(session.id);
+        // The session-delete service stops a running runtime before removing the
+        // record, so a single call covers both steps for CLI and shell sessions.
+        try {
+          await window.ade.sessions.delete({ sessionId: session.id });
+          invalidateSessionListCache();
+          work.removeSessionFromList(session.id);
+          work.closeTab(session.id);
+          setContextMenu((current) => (current?.session.id === session.id ? null : current));
+          setInfoPopover((current) => (current?.session.id === session.id ? null : current));
+          await work.refresh({ showLoading: false, force: true }).catch((refreshErr: unknown) => {
+            console.error("[TerminalsPage] refresh after stop-and-delete failed", { sessionId: session.id, refreshErr });
+          });
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error("[TerminalsPage] stop-and-delete session failed", { sessionId: session.id, err });
+          setSessionActionError(`Stop and delete failed: ${message}`);
+          window.setTimeout(() => setSessionActionError(null), 6000);
+        } finally {
+          setDeletingSessionId((current) => (current === session.id ? null : current));
+        }
+      })();
+    },
+    [stopAndDeleteConfirm, work],
+  );
+
   const selectedSessions = useMemo(
     () => selectableSessions.filter((session) => selectedSessionIds.has(session.id)),
     [selectableSessions, selectedSessionIds],
@@ -416,6 +457,66 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
         setDeletingSessionId((current) => (current === "bulk" ? null : current));
       });
   }, [selectedSessions, work]);
+
+  const handleBulkStopAndDeleteSelected = useCallback(() => {
+    void (async () => {
+      // Operates on the entire selection: chats delete directly, while running
+      // CLI/shell sessions are stopped and then deleted by the session-delete
+      // service. This is what makes a mixed selection deletable in one action.
+      const targets = selectedSessions;
+      if (!targets.length) return;
+      const runningCount = targets.filter(canBulkStopSession).length;
+      const confirmed = await stopAndDeleteConfirm.confirmAsync({
+        title: "Stop and delete sessions",
+        message: `Stop ${runningCount} running runtime${runningCount === 1 ? "" : "s"} and permanently delete ${targets.length} selected session${targets.length === 1 ? "" : "s"}?\n\nThis terminates running CLI and shell processes, then removes every selected session from ADE.`,
+        confirmLabel: "Stop & delete",
+        danger: true,
+      });
+      if (!confirmed) return;
+
+      setSessionActionError(null);
+      setDeletingSessionId("bulk");
+      try {
+        const results = await allSettledWithConcurrency(
+          targets,
+          BULK_SESSION_DELETE_CONCURRENCY,
+          async (session) => {
+            if (isChatToolType(session.toolType)) {
+              await window.ade.agentChat.delete({ sessionId: session.id });
+              return;
+            }
+            await window.ade.sessions.delete({ sessionId: session.id });
+          },
+        );
+        const failed = results.filter((result) => result.status === "rejected").length;
+        const succeededIds = targets
+          .filter((_, index) => results[index]?.status === "fulfilled")
+          .map((session) => session.id);
+        for (const sessionId of succeededIds) {
+          work.removeSessionFromList(sessionId);
+          work.closeTab(sessionId);
+        }
+        setSelectedSessionIds(new Set());
+        setSelectionAnchorId(null);
+        setContextMenu(null);
+        setInfoPopover(null);
+        invalidateSessionListCache();
+        await work.refresh({ showLoading: false, force: true }).catch((refreshErr: unknown) => {
+          console.error("[TerminalsPage] refresh after bulk stop-and-delete failed", { refreshErr });
+        });
+        if (failed > 0) {
+          setSessionActionError(`Stop and delete failed for ${failed} selected session${failed === 1 ? "" : "s"}.`);
+          window.setTimeout(() => setSessionActionError(null), 6000);
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        setSessionActionError(`Stop and delete failed: ${message}`);
+        window.setTimeout(() => setSessionActionError(null), 6000);
+      } finally {
+        setDeletingSessionId((current) => (current === "bulk" ? null : current));
+      }
+    })();
+  }, [selectedSessions, stopAndDeleteConfirm, work]);
 
   const handleContinueCliSession = useCallback(
     async (session: TerminalSessionSummary, text: string) => {
@@ -895,6 +996,7 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
             }}
             onBulkClose={handleBulkCloseSelected}
             onBulkDelete={handleBulkDeleteSelected}
+            onBulkStopAndDelete={handleBulkStopAndDeleteSelected}
             onContextMenu={handleContextMenu}
             sessionListOrganization={work.sessionListOrganization}
             setSessionListOrganization={work.setSessionListOrganization}
@@ -926,6 +1028,7 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
       selectedSessionIds,
       handleBulkCloseSelected,
       handleBulkDeleteSelected,
+      handleBulkStopAndDeleteSelected,
       handleInfoClick,
       handleContextMenu,
       workViewWithSidebar,
@@ -964,6 +1067,7 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
         menu={contextMenu}
         onClose={() => setContextMenu(null)}
         onStopRuntime={({ ptyId, sessionId }) => work.stopRuntime(ptyId, sessionId).catch(() => {})}
+        onStopAndDelete={handleStopAndDeleteSession}
         onDeleteChat={handleDeleteChat}
         onDeleteSession={handleDeleteSession}
         deletingSessionId={deletingSessionId}
@@ -1005,12 +1109,15 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
         popover={infoPopover}
         onClose={() => setInfoPopover(null)}
         onStopRuntime={({ ptyId, sessionId }) => work.stopRuntime(ptyId, sessionId).catch(() => {})}
+        onStopAndDelete={handleStopAndDeleteSession}
         onDeleteChat={handleDeleteChat}
         onDeleteSession={handleDeleteSession}
         onGoToLane={handleGoToLane}
         closingPtyIds={work.closingPtyIds}
         deletingSessionId={deletingSessionId}
       />
+
+      <ConfirmDialog state={stopAndDeleteConfirm.state} onClose={stopAndDeleteConfirm.close} />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/work/WorkSurfaceHeader.tsx
+++ b/apps/desktop/src/renderer/components/work/WorkSurfaceHeader.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { SidebarSimple } from "@phosphor-icons/react";
 import { ChatGitToolbar } from "../chat/ChatGitToolbar";
 import { LaneChip } from "../terminals/LaneChip";
@@ -141,6 +141,12 @@ export type WorkSurfaceHeaderProps = {
   onToggleToolsPane?: () => void;
   toolsPaneOpen?: boolean;
   className?: string;
+  /**
+   * Right-click handler for the whole header row. CLI session surfaces wire this
+   * to open the session context menu (parity with right-clicking a sidebar card);
+   * chat surfaces omit it.
+   */
+  onContextMenu?: (event: ReactMouseEvent<HTMLElement>) => void;
   /** data-testid for integration tests. */
   testId?: string;
 };
@@ -170,6 +176,7 @@ export function WorkSurfaceHeader({
   onToggleToolsPane,
   toolsPaneOpen = false,
   className,
+  onContextMenu,
   testId,
 }: WorkSurfaceHeaderProps) {
   // When this header is the title row of a grid tile (FloatingPane with hidden
@@ -178,7 +185,7 @@ export function WorkSurfaceHeader({
   const embeddedChrome = useFloatingPaneEmbeddedChrome();
   const tileDragProps = embeddedChrome?.dragHandleProps ?? null;
   return (
-    <div className={cn(WORK_SURFACE_HEADER_CLASS, className)} data-testid={testId}>
+    <div className={cn(WORK_SURFACE_HEADER_CLASS, className)} data-testid={testId} onContextMenu={onContextMenu}>
       <div className="flex items-center gap-2">
         {onToggleSessionsPane ? (
           <WorkHeaderSidebarToggle


### PR DESCRIPTION
## What

Adds **Stop and delete** for runtime-backed sessions in the Work tab.

### Single session
- Right-clicking a running CLI or shell session — on the **sidebar card**, the **work-area header** (right-click is newly wired), or via the **session info popover** — now offers **Stop and delete**: it stops the runtime and deletes the session in one confirmed step, alongside the existing two-step *Stop runtime → Delete session* flow.
- Chats keep their direct *Delete chat* (they have no runtime to stop).

### Multi-select
- A **Stop & delete** bulk action appears whenever the selection includes a running runtime. It stops everything that needs stopping, then deletes the **whole** selection.
- Fixes the bug where a mixed selection (e.g. a running CLI + a chat) only deleted the chat, because the running CLI couldn't be deleted without first being stopped.

Both flows are gated by a styled confirmation dialog (reusing `useConfirmDialog`/`ConfirmDialog`).

## How it works
The session-delete service (`deleteTerminalSessionWithRuntimeCleanup`) already stops a running runtime before removing the record, so a single `sessions.delete` call covers both steps for CLI/shell. The bulk handler routes chats → `agentChat.delete` and everything else → `sessions.delete`.

## Tests
- TerminalsPage: single stop-and-delete (happy path + cancel), mixed-selection bulk stop-and-delete.
- SessionListPane: bulk button visibility rule (shown iff selection has a running non-chat session); added `afterEach(cleanup)` for isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added "Stop and delete" functionality for individual sessions via context menu and session info
- Added bulk "Stop and delete" action for multiple selected sessions
- Added confirmation dialog for destructive session operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a "Stop & delete" action for runtime-backed sessions, available from the sidebar context menu, the work-area header (right-click now wired), the session info popover, and as a bulk multi-select action. It also fixes a pre-existing bug where a mixed selection containing a running CLI session couldn't be bulk-deleted in one step.

- **Single session flow**: `handleStopAndDeleteSession` shows a styled `ConfirmDialog`, then delegates to `window.ade.sessions.delete`, which already stops the runtime server-side before removing the record — so one call covers both steps.
- **Bulk flow**: `handleBulkStopAndDeleteSelected` routes chats to `agentChat.delete` and everything else to `sessions.delete`, resolves them concurrently via `allSettledWithConcurrency`, and clears the selection on success. Both flows guard the destructive action with the shared `stopAndDeleteConfirm` dialog instance.
- **Tests** cover the happy path and cancel path for single context-menu deletion, plus the mixed-selection bulk case and the button visibility rule in `SessionListPane`.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The new stop-and-delete paths follow the same error handling and local-state cleanup patterns as the existing bulk-delete and single-delete handlers, and both flows are gated behind a styled confirmation dialog.

The new handlers are structurally consistent with existing delete handlers: they use allSettledWithConcurrency for bulk operations, clear selections and close menus on success, log errors without swallowing them, and rely on the server-side sessions.delete to handle runtime teardown atomically. No state mutation bypasses, unchecked branches, or missing cleanup steps were found in the changed code.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx | Adds handleStopAndDeleteSession and handleBulkStopAndDeleteSelected with useConfirmDialog gating, wires both handlers to SessionContextMenu and SessionInfoPopover, renders shared ConfirmDialog at page root — logic is consistent with existing bulk-delete patterns. |
| apps/desktop/src/renderer/components/terminals/SessionContextMenu.tsx | Adds onStopAndDelete prop and a new Stop & delete button (visible for running non-chat sessions with a ptyId); upgrades two sibling buttons from ASCII ... to Unicode ellipsis for consistency. |
| apps/desktop/src/renderer/components/terminals/SessionInfoPopover.tsx | Adds onStopAndDelete prop and a danger Button with tooltip, gated by session.status === running && ptyId && !isChat — mirrors the context-menu condition. |
| apps/desktop/src/renderer/components/terminals/SessionListPane.tsx | Adds onBulkStopAndDelete prop and a Stop & delete N bulk button shown when selectedRunningCount > 0; selectedCount correctly matches the confirmed scope. |
| apps/desktop/src/renderer/components/terminals/TerminalsPage.test.tsx | Adds three new tests covering context-menu stop-and-delete (confirm + cancel) and bulk mixed-selection, and updates mocks to expose the new actions. |
| apps/desktop/src/renderer/components/terminals/SessionListPane.test.tsx | Adds afterEach(cleanup) for isolation and two tests verifying Stop & delete button visibility. |
| apps/desktop/src/renderer/components/terminals/CliSessionWorkSurfaceHeader.tsx | Wires the new onContextMenu prop through to WorkSurfaceHeader with event.preventDefault() — adds right-click parity with the sidebar card. |
| apps/desktop/src/renderer/components/work/WorkSurfaceHeader.tsx | Adds optional onContextMenu prop and attaches it to the outer header div — minimal, safe change. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ship: iteration 1 — unify &#39;Stop &amp; delete..."](https://github.com/arul28/ade/commit/17a500e02540b98fbd36d7b3f4055a3fb9258439) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36044015)</sub>

<!-- /greptile_comment -->