### PR TITLE
Usage Bar Fix

### DIFF
--- a/apps/ade-cli/src/adeRpcServer.test.ts
+++ b/apps/ade-cli/src/adeRpcServer.test.ts
@@ -289,7 +289,7 @@ function createRuntime() {
         resumed: true,
         reusedExistingRuntime: false,
       })),
-      dispose: vi.fn(),
+      dispose: vi.fn(() => ({ disposed: true, reason: "disposed" })),
       writeBySessionId: vi.fn((sessionId: string, data: string): boolean => {
         void sessionId;
         void data;
@@ -990,7 +990,7 @@ describe("adeRpcServer", () => {
       id: 7,
       method: "pty.dispose",
       params: { args: { ptyId: "pty-1", sessionId: "session-1" } },
-    })).resolves.toBeNull();
+    })).resolves.toEqual({ disposed: true, reason: "disposed" });
     expect(runtime.ptyService.dispose).toHaveBeenCalledWith({ ptyId: "pty-1", sessionId: "session-1" });
 
     const listed = await handler({

--- a/apps/ade-cli/src/adeRpcServer.ts
+++ b/apps/ade-cli/src/adeRpcServer.ts
@@ -5448,8 +5448,7 @@ export function createAdeRpcRequestHandler(args: {
       }
       if (method === "pty.dispose") {
         ensurePtyTargetAuthorized(runtime, session, method, ptyArgs);
-        runtime.ptyService.dispose(ptyArgs as Parameters<typeof runtime.ptyService.dispose>[0]);
-        return null;
+        return runtime.ptyService.dispose(ptyArgs as Parameters<typeof runtime.ptyService.dispose>[0]);
       }
       if (method === "pty.list") {
         return { sessions: listAuthorizedPtySessions(runtime, session, method, ptyArgs) };

--- a/apps/ade-cli/src/headlessLinearServices.ts
+++ b/apps/ade-cli/src/headlessLinearServices.ts
@@ -1899,7 +1899,7 @@ export function createHeadlessLinearServices(
         "PTY-backed run commands are unavailable in headless Linear services.",
       );
     },
-    dispose: () => {},
+    dispose: () => ({ disposed: false as const, reason: "missing" as const }),
     onData: () => () => {},
     onExit: () => () => {},
   };

--- a/apps/desktop/src/main/services/config/projectConfigService.ts
+++ b/apps/desktop/src/main/services/config/projectConfigService.ts
@@ -152,6 +152,10 @@ function asComputeBackend(value: unknown): "local" | "vps" | "daytona" | undefin
   return COMPUTE_BACKEND_SCHEMA.parse(value);
 }
 
+function asNewLaneBaseSource(value: unknown): "local" | "remote" | undefined {
+  return value === "local" || value === "remote" ? value : undefined;
+}
+
 function coerceOrchestratorHookConfig(value: unknown): { command: string; timeoutMs?: number } | null {
   if (typeof value === "string") {
     const command = value.trim();
@@ -2009,10 +2013,15 @@ function coerceConfigFile(value: unknown): ProjectConfigFile {
 
   const github = coerceGithubConfig(value.github);
 
-  const git =
-    isRecord(value.git) && asBool(value.git.autoRebaseOnHeadChange) != null
-      ? { autoRebaseOnHeadChange: asBool(value.git.autoRebaseOnHeadChange) }
-      : undefined;
+  const git = (() => {
+    if (!isRecord(value.git)) return undefined;
+    const autoRebaseOnHeadChange = asBool(value.git.autoRebaseOnHeadChange);
+    const newLaneBaseSource = asNewLaneBaseSource(value.git.newLaneBaseSource);
+    const out: NonNullable<ProjectConfigFile["git"]> = {};
+    if (autoRebaseOnHeadChange != null) out.autoRebaseOnHeadChange = autoRebaseOnHeadChange;
+    if (newLaneBaseSource) out.newLaneBaseSource = newLaneBaseSource;
+    return Object.keys(out).length ? out : undefined;
+  })();
 
   const providersRaw = isRecord(value.providers)
     ? { ...(value.providers as Record<string, unknown>) }
@@ -2515,7 +2524,8 @@ function resolveEffectiveConfig(shared: ProjectConfigFile, local: ProjectConfigF
     providerMode,
     ...(mergedGithub ? { github: mergedGithub } : {}),
     git: {
-      autoRebaseOnHeadChange: mergedGit?.autoRebaseOnHeadChange ?? false
+      autoRebaseOnHeadChange: mergedGit?.autoRebaseOnHeadChange ?? false,
+      newLaneBaseSource: mergedGit?.newLaneBaseSource ?? "remote",
     },
     ...(effectiveAi ? { ai: effectiveAi } : {}),
     ...(mergedProviders ? { providers: mergedProviders } : {}),

--- a/apps/desktop/src/main/services/git/gitOperationsService.test.ts
+++ b/apps/desktop/src/main/services/git/gitOperationsService.test.ts
@@ -1569,10 +1569,10 @@ describe("gitOperationsService.listBranches annotations", () => {
     }
   });
 
-  it("dedupes a remote ref when its local counterpart already exists", async () => {
+  it("dedupes a remote ref when its local counterpart tracks it", async () => {
     mockGit.runGitOrThrow.mockResolvedValue(
       [
-        "refs/heads/feature/dup\tfeature/dup\t*\t",
+        "refs/heads/feature/dup\tfeature/dup\t*\torigin/feature/dup",
         "refs/remotes/origin/feature/dup\torigin/feature/dup\t \t",
       ].join("\n"),
     );
@@ -1581,6 +1581,20 @@ describe("gitOperationsService.listBranches annotations", () => {
     const branches = await service.listBranches({ laneId: "lane-1" });
     expect(branches.filter((b) => b.name === "feature/dup")).toHaveLength(1);
     expect(branches.find((b) => b.name === "origin/feature/dup")).toBeUndefined();
+  });
+
+  it("keeps a remote counterpart when the local branch has no upstream", async () => {
+    mockGit.runGitOrThrow.mockResolvedValue(
+      [
+        "refs/heads/feature/untracked\tfeature/untracked\t*\t",
+        "refs/remotes/origin/feature/untracked\torigin/feature/untracked\t \t",
+      ].join("\n"),
+    );
+    const { service } = makeServiceWithLanes({});
+
+    const branches = await service.listBranches({ laneId: "lane-1" });
+    expect(branches.find((b) => b.name === "feature/untracked")).toBeDefined();
+    expect(branches.find((b) => b.name === "origin/feature/untracked")).toBeDefined();
   });
 
   it("filters refs/remotes/.../HEAD entries out of the result", async () => {

--- a/apps/desktop/src/main/services/git/gitOperationsService.ts
+++ b/apps/desktop/src/main/services/git/gitOperationsService.ts
@@ -1679,7 +1679,9 @@ export function createGitOperationsService({
       const localNames = new Set(localBranches.keys());
       const dedupedRemotes = remoteBranches.filter((branch) => {
         const localCandidate = localBranchNameFromRemoteRef(branch.name);
-        return !localNames.has(localCandidate);
+        if (!localNames.has(localCandidate)) return true;
+        const local = localBranches.get(localCandidate);
+        return local?.upstream !== branch.name;
       });
 
       const sortedLocals = Array.from(localBranches.values()).sort((a, b) => {

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -389,6 +389,7 @@ import type {
   RecentProjectSummary,
   PtyCreateArgs,
   PtyCreateResult,
+  PtyDisposeResult,
   PtyResumeSessionArgs,
   PtyResumeSessionResult,
   PtySendToSessionArgs,
@@ -6062,10 +6063,20 @@ export function registerIpc({
         });
       }
     }
-    return ptyService.enrichSessions([session])[0] ?? {
+    let enriched = ptyService.enrichSessions([session])[0] ?? {
       ...session,
       runtimeState: ptyService.getRuntimeState(session.id, session.status)
     };
+    if (enriched.status === "running" && isChatToolType(enriched.toolType)) {
+      try {
+        const chat = await ctx.agentChatService?.getSessionSummary(enriched.id);
+        if (chat) enriched = projectChatOntoSession(enriched, chat);
+      } catch {
+        // Detail reads should still return the persisted session if chat state
+        // hydration fails during runtime restart/recovery.
+      }
+    }
+    return enriched;
   });
 
   ipcMain.handle(IPC.sessionsDelete, async (_event, arg: DeleteSessionArgs): Promise<void> => {
@@ -7566,8 +7577,8 @@ export function registerIpc({
     requirePtyService().resize(arg);
   });
 
-  ipcMain.handle(IPC.ptyDispose, async (_event, arg: { ptyId: string; sessionId?: string }): Promise<void> => {
-    requirePtyService().dispose(arg);
+  ipcMain.handle(IPC.ptyDispose, async (_event, arg: { ptyId: string; sessionId?: string }): Promise<PtyDisposeResult> => {
+    return requirePtyService().dispose(arg);
   });
 
   ipcMain.handle(IPC.terminalList, async (_event, arg) =>

--- a/apps/desktop/src/main/services/lanes/laneTemplateService.test.ts
+++ b/apps/desktop/src/main/services/lanes/laneTemplateService.test.ts
@@ -34,7 +34,7 @@ function makeEffective(overrides: Partial<EffectiveProjectConfig> = {}): Effecti
     testSuites: [],
     laneOverlayPolicies: [],
     automations: [],
-    git: { autoRebaseOnHeadChange: false },
+    git: { autoRebaseOnHeadChange: false, newLaneBaseSource: "remote" },
     ...overrides,
   };
 }

--- a/apps/desktop/src/main/services/pty/ptyService.test.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.test.ts
@@ -3669,7 +3669,7 @@ describe("ptyService", () => {
       });
     });
 
-    it("does not end persisted agent chat rows just because there is no PTY", () => {
+    it("keeps persisted agent chat rows resumable but idle when there is no PTY", () => {
       const { service } = createHarness();
       const enriched = service.enrichSessions([{
         id: "chat-session",
@@ -3682,7 +3682,7 @@ describe("ptyService", () => {
       expect(enriched[0]).toMatchObject({
         id: "chat-session",
         status: "running",
-        runtimeState: "running",
+        runtimeState: "idle",
       });
     });
 

--- a/apps/desktop/src/main/services/pty/ptyService.test.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.test.ts
@@ -3730,6 +3730,19 @@ describe("ptyService", () => {
       );
     });
 
+    it("does not kill a live PTY when the supplied session id belongs to another session", async () => {
+      const { service, mockPty, sessionService, broadcastExit } = createHarness();
+      const first = await service.create({ laneId: "lane-1", title: "first", cols: 80, rows: 24 });
+      const second = await service.create({ laneId: "lane-1", title: "second", cols: 80, rows: 24 });
+
+      const result = service.dispose({ ptyId: second.ptyId, sessionId: first.sessionId });
+
+      expect(result).toEqual({ disposed: false, reason: "session-mismatch" });
+      expect(mockPty.kill).not.toHaveBeenCalled();
+      expect(sessionService.end).not.toHaveBeenCalled();
+      expect(broadcastExit).not.toHaveBeenCalled();
+    });
+
     it("handles disposing an already-disposed PTY gracefully", async () => {
       const { service } = createHarness();
       const { ptyId } = await service.create({ laneId: "lane-1", title: "d", cols: 80, rows: 24 });

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -24,6 +24,7 @@ import type {
   PtyExitEvent,
   PtyCreateArgs,
   PtyCreateResult,
+  PtyDisposeResult,
   PtyResumeSessionArgs,
   PtyResumeSessionResult,
   PtySendToSessionArgs,
@@ -4690,6 +4691,10 @@ export function createPtyService({
         const runningWithoutReachablePty = !live
           && row.status === "running"
           && !isPersistedChatToolType(row.toolType ?? null);
+        const idlePersistedChatRuntime = !live
+          && row.status === "running"
+          && isPersistedChatToolType(row.toolType ?? null)
+          && computeRuntimeState(row.id, row.status) === "running";
         const isDetachedFromThisRuntime = ownedByLivePeer || runningWithoutReachablePty;
         const fallbackStatus = live ? "running" : row.status;
         return {
@@ -4707,7 +4712,11 @@ export function createPtyService({
                   status: "detached" as const,
                 }
               : {}),
-          runtimeState: isDetachedFromThisRuntime ? "exited" : computeRuntimeState(row.id, fallbackStatus),
+          runtimeState: isDetachedFromThisRuntime
+            ? "exited"
+            : idlePersistedChatRuntime
+              ? "idle"
+              : computeRuntimeState(row.id, fallbackStatus),
           chatSessionId: live
             ? terminalChatSessions.get(row.id) ?? live[1].chatSessionId ?? row.chatSessionId ?? null
             : terminalChatSessions.get(row.id) ?? row.chatSessionId ?? null,
@@ -4715,14 +4724,14 @@ export function createPtyService({
       });
     },
 
-    dispose({ ptyId, sessionId }: { ptyId: string; sessionId?: string }): void {
+    dispose({ ptyId, sessionId }: { ptyId: string; sessionId?: string }): PtyDisposeResult {
       const entry = ptys.get(ptyId);
       if (!entry) {
-        if (!sessionId) return;
+        if (!sessionId) return { disposed: false, reason: "missing" };
         const session = sessionService.get(sessionId);
-        if (!session) return;
-        if (session.status && session.status !== "running") return;
-        if (session.ptyId && session.ptyId !== ptyId) return;
+        if (!session) return { disposed: false, reason: "missing" };
+        if (session.status && session.status !== "running") return { disposed: false, reason: "not-running" };
+        if (session.ptyId && session.ptyId !== ptyId) return { disposed: false, reason: "session-mismatch" };
         if (
           ownerPid != null
           && session.ownerPid != null
@@ -4735,7 +4744,7 @@ export function createPtyService({
             ownerPid: session.ownerPid,
             currentPid: ownerPid,
           });
-          return;
+          return { disposed: false, reason: "owned-by-peer" };
         }
         // The renderer can outlive the pty map (for example after app restart). Allow closing by session id
         // so stale sessions do not get stuck in a "running" state forever.
@@ -4766,9 +4775,9 @@ export function createPtyService({
           }
         }
         logger.warn("pty.dispose_orphaned", { ptyId, sessionId });
-        return;
+        return { disposed: true, reason: "orphaned" };
       }
-      if (entry.disposed) return;
+      if (entry.disposed) return { disposed: false, reason: "already-disposed" };
       entry.disposed = true;
       if (entry.aiTitleTimer) {
         clearTimeout(entry.aiTitleTimer);
@@ -4808,7 +4817,7 @@ export function createPtyService({
       ptys.delete(ptyId);
 
       if (!entry.tracked) {
-        return;
+        return { disposed: true, reason: "disposed" };
       }
 
       try {
@@ -4816,6 +4825,7 @@ export function createPtyService({
       } catch {
         // ignore
       }
+      return { disposed: true, reason: "disposed" };
     },
 
     disposeAll(): void {

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -4777,6 +4777,9 @@ export function createPtyService({
         logger.warn("pty.dispose_orphaned", { ptyId, sessionId });
         return { disposed: true, reason: "orphaned" };
       }
+      if (sessionId && entry.sessionId !== sessionId) {
+        return { disposed: false, reason: "session-mismatch" };
+      }
       if (entry.disposed) return { disposed: false, reason: "already-disposed" };
       entry.disposed = true;
       if (entry.aiTitleTimer) {

--- a/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
@@ -901,6 +901,37 @@ describe("pollCodexViaCliRpc", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("does not spawn the CLI fallback for non-auth Codex 4xx responses", async () => {
+    const tmpDir = makeTmpDir();
+    const originalCodexHome = process.env.CODEX_HOME;
+    fs.writeFileSync(path.join(tmpDir, "auth.json"), JSON.stringify({
+      tokens: { access_token: "rate-limited-token" },
+    }));
+    process.env.CODEX_HOME = tmpDir;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => ({}),
+    }));
+
+    try {
+      const logger = createLogger();
+      const result = await pollCodexUsage(logger as any);
+
+      expect(result.windows).toEqual([]);
+      expect(result.errors).toEqual(["codex: API returned 429"]);
+      expect(mockState.spawn).not.toHaveBeenCalled();
+    } finally {
+      if (originalCodexHome === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = originalCodexHome;
+      }
+      vi.unstubAllGlobals();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ── Service Integration ──────────────────────────────────────────

--- a/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
@@ -39,7 +39,10 @@ const {
   parseClaudeWindows,
   parseCodexRateLimitWindows,
   calculatePacingByProvider,
+  buildProviderWindows,
+  fetchJsonWithRetry,
   collectAdeUsageStats,
+  pollCodexUsage,
   pollCodexViaCliRpc,
   resolveTokenPrice,
   resetDynamicTokenPricingForTest,
@@ -857,6 +860,46 @@ describe("pollCodexViaCliRpc", () => {
       "usage.poll.codex_cli_rpc_non_zero_exit",
       expect.objectContaining({ exitCode: 1, stderr: "codex said no\n" }),
     );
+  });
+
+  it("preserves Codex HTTP auth failures when CLI fallback cannot return windows", async () => {
+    const tmpDir = makeTmpDir();
+    const originalCodexHome = process.env.CODEX_HOME;
+    fs.writeFileSync(path.join(tmpDir, "auth.json"), JSON.stringify({
+      tokens: { access_token: "expired-token" },
+    }));
+    process.env.CODEX_HOME = tmpDir;
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    }));
+    const fake = createFakeCodexChild({
+      closeCode: 1,
+      stderr: "rpc unavailable\n",
+    });
+    mockState.resolveCodexExecutable.mockReturnValue({
+      path: "codex.exe",
+      source: "path",
+    });
+    mockState.spawn.mockReturnValue(fake.child);
+
+    try {
+      const logger = createLogger();
+      const result = await pollCodexUsage(logger as any);
+
+      expect(result.windows).toEqual([]);
+      expect(result.errors).toContain("codex: API returned 401");
+      expect(result.errors).toContain("codex: CLI RPC exited with non-zero code");
+    } finally {
+      if (originalCodexHome === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = originalCodexHome;
+      }
+      vi.unstubAllGlobals();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -1882,5 +1925,247 @@ describe("findJsonlFiles", () => {
 
     expect(files).toEqual([smallPath]);
     fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});
+
+describe("buildProviderWindows", () => {
+  const win = (percentUsed: number) => ({
+    provider: "claude" as const,
+    windowType: "weekly" as const,
+    percentUsed,
+    resetsAt: "2026-01-01T00:00:00Z",
+    resetsInMs: 1,
+  });
+
+  it("marks ok and stamps lastSuccessAt when fresh windows arrive", () => {
+    const fresh = [win(10)];
+    const result = buildProviderWindows("claude", fresh, [], [], null, "2026-06-07T00:00:00Z");
+    expect(result.status.state).toBe("ok");
+    expect(result.status.lastSuccessAt).toBe("2026-06-07T00:00:00Z");
+    expect(result.lastSuccessAt).toBe("2026-06-07T00:00:00Z");
+    expect(result.windows).toBe(fresh);
+  });
+
+  it("carries forward previous windows as stale on an empty/failed poll", () => {
+    const prev = [{ ...win(42), resetsAt: "2026-06-08T00:00:00Z" }];
+    const result = buildProviderWindows(
+      "claude",
+      [],
+      ["claude: API returned 409"],
+      prev,
+      "2026-06-06T00:00:00Z",
+      "2026-06-07T00:00:00Z",
+    );
+    expect(result.status.state).toBe("stale");
+    expect(result.windows).toHaveLength(1);
+    expect(result.windows[0]?.percentUsed).toBe(42);
+    // lastSuccessAt is preserved from the previous success, not the failed poll.
+    expect(result.status.lastSuccessAt).toBe("2026-06-06T00:00:00Z");
+    expect(result.status.message).toContain("Claude");
+  });
+
+  it("drops carried windows that have passed their reset boundary", () => {
+    const result = buildProviderWindows(
+      "claude",
+      [],
+      ["claude: API returned 409"],
+      [
+        { ...win(99), resetsAt: "2026-06-06T23:59:00Z", resetsInMs: 0 },
+        { ...win(12), resetsAt: "2026-06-07T00:30:00Z", resetsInMs: 30 * 60 * 1000 },
+      ],
+      "2026-06-06T00:00:00Z",
+      "2026-06-07T00:00:00Z",
+    );
+
+    expect(result.status.state).toBe("stale");
+    expect(result.windows).toHaveLength(1);
+    expect(result.windows[0]?.percentUsed).toBe(12);
+    expect(result.windows[0]?.resetsInMs).toBe(30 * 60 * 1000);
+  });
+
+  it("reports an error instead of carrying only expired windows", () => {
+    const result = buildProviderWindows(
+      "codex",
+      [],
+      ["codex: API returned 500"],
+      [{ ...win(88), provider: "codex" as const, resetsAt: "2026-06-06T23:59:00Z", resetsInMs: 0 }],
+      "2026-06-06T00:00:00Z",
+      "2026-06-07T00:00:00Z",
+    );
+
+    expect(result.status.state).toBe("error");
+    expect(result.status.message).toMatch(/expired/i);
+    expect(result.windows).toEqual([]);
+  });
+
+  it("reports unauthed when there is no fallback and credentials are missing", () => {
+    const result = buildProviderWindows("codex", [], ["codex: no credentials found"], [], null, "t");
+    expect(result.status.state).toBe("unauthed");
+    expect(result.windows).toEqual([]);
+  });
+
+  it("clears previous windows when credentials disappear", () => {
+    const prev = [win(42)];
+    const result = buildProviderWindows(
+      "codex",
+      [],
+      ["codex: no credentials found"],
+      prev,
+      "2026-06-06T00:00:00Z",
+      "2026-06-07T00:00:00Z",
+    );
+    expect(result.status.state).toBe("unauthed");
+    expect(result.status.lastSuccessAt).toBe("2026-06-06T00:00:00Z");
+    expect(result.windows).toEqual([]);
+  });
+
+  it("reports error (not unauthed) when there is no fallback and the call failed", () => {
+    const result = buildProviderWindows("codex", [], ["codex: API returned 500"], [], null, "t");
+    expect(result.status.state).toBe("error");
+    expect(result.status.message).toMatch(/couldn't reach/i);
+  });
+
+  it("frames a 401/expired-token failure as reconnect, not unreachable", () => {
+    const result = buildProviderWindows("claude", [], ["claude: API returned 401"], [], null, "t");
+    expect(result.status.state).toBe("error");
+    expect(result.status.message).toMatch(/sign-in expired|reconnect/i);
+  });
+});
+
+describe("usage reliability: non-destructive merge", () => {
+  const futureIso = (ms: number) => new Date(Date.now() + ms).toISOString();
+
+  it("keeps the last-good windows when a provider poll fails (no flicker)", async () => {
+    const logger = createLogger();
+    const weeklyMs = 3 * 24 * 60 * 60 * 1000;
+    const claudeWindow = {
+      provider: "claude" as const,
+      windowType: "weekly" as const,
+      percentUsed: 40,
+      resetsAt: futureIso(weeklyMs),
+      resetsInMs: weeklyMs,
+    };
+    const claudeExtraUsage = {
+      provider: "claude" as const,
+      isEnabled: true,
+      usedCreditsUsd: 12,
+      monthlyLimitUsd: 100,
+      utilization: 12,
+      currency: "usd",
+    };
+    const pollClaudeUsage = vi
+      .fn()
+      .mockResolvedValueOnce({ windows: [claudeWindow], extraUsage: claudeExtraUsage, errors: [] })
+      .mockResolvedValueOnce({ windows: [], extraUsage: null, errors: ["claude: API returned 409"] });
+    const service = createUsageTrackingService({
+      logger,
+      dependencies: {
+        pollClaudeUsage,
+        pollCodexUsage: vi.fn(async () => ({ windows: [], errors: [] })),
+      },
+    });
+
+    const first = await service.poll({ includeCosts: false });
+    expect(first.windows.filter((w) => w.provider === "claude")).toHaveLength(1);
+    expect(first.extraUsage).toEqual([claudeExtraUsage]);
+    expect(first.providerStatus?.claude?.state).toBe("ok");
+
+    const second = await service.poll({ includeCosts: false });
+    const claudeWindows = second.windows.filter((w) => w.provider === "claude");
+    expect(claudeWindows).toHaveLength(1);
+    expect(claudeWindows[0]?.percentUsed).toBe(40);
+    expect(second.extraUsage).toEqual([claudeExtraUsage]);
+    expect(second.providerStatus?.claude?.state).toBe("stale");
+    expect(second.providerStatus?.claude?.lastSuccessAt).toBe(first.lastPolledAt);
+
+    service.dispose();
+  });
+
+  it("attaches per-window pacing for both the 5-hour and weekly windows", async () => {
+    const logger = createLogger();
+    const fiveHourMs = 2 * 60 * 60 * 1000; // 60% of the 5h window elapsed
+    const weeklyMs = 3 * 24 * 60 * 60 * 1000;
+    const service = createUsageTrackingService({
+      logger,
+      dependencies: {
+        pollClaudeUsage: vi.fn(async () => ({
+          windows: [
+            { provider: "claude" as const, windowType: "five_hour" as const, percentUsed: 80, resetsAt: futureIso(fiveHourMs), resetsInMs: fiveHourMs },
+            { provider: "claude" as const, windowType: "weekly" as const, percentUsed: 8, resetsAt: futureIso(weeklyMs), resetsInMs: weeklyMs },
+          ],
+          extraUsage: null,
+          errors: [],
+        })),
+        pollCodexUsage: vi.fn(async () => ({ windows: [], errors: [] })),
+      },
+    });
+
+    const snap = await service.poll({ includeCosts: false });
+    const five = snap.windows.find((w) => w.windowType === "five_hour");
+    const weekly = snap.windows.find((w) => w.windowType === "weekly");
+    expect(five?.pacing).toBeDefined();
+    expect(weekly?.pacing).toBeDefined();
+    // 80% used with only ~60% of the 5h window elapsed → burning ahead of pace.
+    expect(five?.pacing?.deltaPercent ?? 0).toBeGreaterThan(0);
+
+    service.dispose();
+  });
+});
+
+describe("fetchJsonWithRetry", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("retries a transient 5xx and then succeeds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 503, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ five_hour: { percent_used: 5 } }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchJsonWithRetry("https://example.test/usage", {}, { attempts: 2, backoffMs: 0 });
+    expect(res.ok).toBe(true);
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a network/timeout abort and then succeeds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("The operation was aborted"))
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchJsonWithRetry("https://example.test/usage", {}, { attempts: 2, backoffMs: 0 });
+    expect(res.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry a 429 — backs off instead of amplifying the throttle", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 429, json: async () => ({}) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchJsonWithRetry("https://example.test/usage", {}, { attempts: 2, backoffMs: 0 });
+    expect(res.status).toBe(429);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a 409 conflict", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 409, json: async () => ({}) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchJsonWithRetry("https://example.test/usage", {}, { attempts: 2, backoffMs: 0 });
+    expect(res.status).toBe(409);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a non-transient 401 (defers to the refresh path)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({}) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchJsonWithRetry("https://example.test/usage", {}, { attempts: 2, backoffMs: 0 });
+    expect(res.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
@@ -2182,6 +2182,21 @@ describe("fetchJsonWithRetry", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("does not retry a 429 with an empty or non-JSON body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => {
+        throw new SyntaxError("Unexpected end of JSON input");
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchJsonWithRetry("https://example.test/usage", {}, { attempts: 2, backoffMs: 0 });
+    expect(res).toEqual({ ok: false, status: 429, data: null });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("does not retry a 409 conflict", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 409, json: async () => ({}) });
     vi.stubGlobal("fetch", fetchMock);

--- a/apps/desktop/src/main/services/usage/usageTrackingService.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.ts
@@ -163,7 +163,12 @@ async function fetchJson(
       ...(init?.body != null ? { body: init.body } : {}),
       signal: controller.signal,
     });
-    const data = await resp.json();
+    let data: unknown = null;
+    try {
+      data = await resp.json();
+    } catch {
+      data = null;
+    }
     return { ok: resp.ok, status: resp.status, data };
   } finally {
     clearTimeout(timer);

--- a/apps/desktop/src/main/services/usage/usageTrackingService.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.ts
@@ -21,6 +21,8 @@ import type {
   UsageProvider,
   UsageWindow,
   UsagePacing,
+  UsageProviderStatus,
+  UsageProviderStatusMap,
   CostSnapshot,
   CostTokenBreakdown,
   ExtraUsage,
@@ -166,6 +168,53 @@ async function fetchJson(
   } finally {
     clearTimeout(timer);
   }
+}
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+// Only genuine *server*/transport faults are retried. We deliberately do NOT
+// retry any 4xx — a 429 means "back off, you're rate-limited", so retrying it
+// amplifies load and sustains the throttle (CodexBar and the pre-retry code
+// issue one request per poll and stay under the limit). 401 keeps its dedicated
+// token-refresh path; 409/429/etc. return immediately and rely on carry-forward.
+const RETRYABLE_STATUS = new Set([500, 502, 503, 504]);
+
+type RetryOptions = {
+  attempts?: number;
+  perAttemptTimeoutMs?: number;
+  /** Base backoff; attempt N waits backoffMs * 3^(N-1). Set 0 to disable (tests). */
+  backoffMs?: number;
+  init?: { method?: string; body?: string };
+};
+
+/**
+ * fetchJson with a single bounded retry for transient server / network faults
+ * (5xx, plus network/timeout aborts). Any 4xx — including 429 (rate-limit) and
+ * 409 — returns on the first try so we never hammer a throttled endpoint; a
+ * thrown error on the final attempt propagates to the caller.
+ */
+async function fetchJsonWithRetry(
+  url: string,
+  headers: Record<string, string>,
+  opts: RetryOptions = {},
+): Promise<{ ok: boolean; status: number; data: unknown }> {
+  const attempts = Math.max(1, opts.attempts ?? 2);
+  const timeoutMs = opts.perAttemptTimeoutMs ?? 8_000;
+  const backoffMs = opts.backoffMs ?? 400;
+  let last: { ok: boolean; status: number; data: unknown } | null = null;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (attempt > 0 && backoffMs > 0) {
+      await delay(backoffMs * 3 ** (attempt - 1));
+    }
+    try {
+      const result = await fetchJson(url, headers, timeoutMs, opts.init);
+      last = result;
+      if (result.ok || !RETRYABLE_STATUS.has(result.status)) return result;
+    } catch (err) {
+      if (attempt === attempts - 1) throw err;
+    }
+  }
+  return last ?? { ok: false, status: 0, data: null };
 }
 
 // ── Window Helpers ───────────────────────────────────────────────
@@ -353,7 +402,7 @@ async function pollClaudeUsage(logger: Logger): Promise<{ windows: UsageWindow[]
   }
 
   try {
-    const result = await fetchJson(CLAUDE_USAGE_URL, {
+    const result = await fetchJsonWithRetry(CLAUDE_USAGE_URL, {
       Authorization: `Bearer ${creds.accessToken}`,
       "anthropic-beta": "oauth-2025-04-20",
     });
@@ -365,7 +414,7 @@ async function pollClaudeUsage(logger: Logger): Promise<{ windows: UsageWindow[]
         clearClaudeCredentialCache();
         const refreshed = await refreshClaudeCredentials(creds.refreshToken);
         if (refreshed) {
-          const retry = await fetchJson(CLAUDE_USAGE_URL, {
+          const retry = await fetchJsonWithRetry(CLAUDE_USAGE_URL, {
             Authorization: `Bearer ${refreshed.accessToken}`,
             "anthropic-beta": "oauth-2025-04-20",
           });
@@ -411,11 +460,13 @@ async function pollCodexUsage(logger: Logger): Promise<{ windows: UsageWindow[];
   // the token is truly dead, and tokens often remain valid well past the
   // local last_refresh timestamp.
   try {
-    const result = await fetchJson(CODEX_USAGE_URL, {
+    const result = await fetchJsonWithRetry(CODEX_USAGE_URL, {
       Authorization: `Bearer ${creds.accessToken}`,
     });
 
-    if (result.ok && result.data && typeof result.data === "object") {
+    if (!result.ok) {
+      errors.push(`codex: API returned ${result.status}`);
+    } else if (result.data && typeof result.data === "object") {
       windows.push(...parseCodexRateLimitWindows(result.data as Record<string, unknown>));
       if (windows.length > 0) return { windows, errors };
     }
@@ -1636,6 +1687,95 @@ function calculatePacingByProvider(windows: UsageWindow[]): UsageSnapshot["pacin
   return out;
 }
 
+const PROVIDER_DISPLAY_NAME: Record<UsageProvider, string> = {
+  claude: "Claude",
+  codex: "Codex",
+  cursor: "Cursor",
+};
+
+function filterUnexpiredCarriedWindows(prevWindows: UsageWindow[], polledAt: string): UsageWindow[] {
+  const nowMs = Date.parse(polledAt);
+  if (!Number.isFinite(nowMs)) return prevWindows;
+  return prevWindows
+    .filter((window) => {
+      const resetMs = Date.parse(window.resetsAt);
+      return !Number.isFinite(resetMs) || resetMs > nowMs;
+    })
+    .map((window) => {
+      const resetMs = Date.parse(window.resetsAt);
+      if (!Number.isFinite(resetMs)) return window;
+      const resetsInMs = Math.max(0, resetMs - nowMs);
+      return resetsInMs === window.resetsInMs ? window : { ...window, resetsInMs };
+    });
+}
+
+/**
+ * Reconcile a provider's freshly-polled windows against the last snapshot so a
+ * transient failure never blanks good data. When the poll yields nothing, we
+ * carry forward the previous windows and mark the provider `stale` (or
+ * `unauthed`/`error` when there is no fallback). Returns the windows to render
+ * plus the per-provider status and the timestamp of the last real success.
+ */
+function buildProviderWindows(
+  provider: UsageProvider,
+  freshWindows: UsageWindow[],
+  errors: string[],
+  prevWindows: UsageWindow[],
+  prevLastSuccessAt: string | null,
+  polledAt: string,
+): { windows: UsageWindow[]; status: UsageProviderStatus; lastSuccessAt: string | null } {
+  if (freshWindows.length > 0) {
+    return {
+      windows: freshWindows,
+      status: { state: "ok", lastSuccessAt: polledAt },
+      lastSuccessAt: polledAt,
+    };
+  }
+
+  const name = PROVIDER_DISPLAY_NAME[provider] ?? provider;
+  const unauthed = errors.some((entry) => /no credentials/i.test(entry));
+  // A 401/403 means we reached the API but auth was rejected (expired token,
+  // failed refresh) — that's "reconnect", not "couldn't reach".
+  const authExpired = errors.some((entry) => /\b(401|403)\b|authentication|invalid.*credential/i.test(entry));
+
+  if (unauthed || authExpired) {
+    return {
+      windows: [],
+      status: {
+        state: unauthed ? "unauthed" : "error",
+        lastSuccessAt: prevLastSuccessAt,
+        message: unauthed ? undefined : `${name} sign-in expired — reconnect`,
+      },
+      lastSuccessAt: prevLastSuccessAt,
+    };
+  }
+
+  const carriedWindows = filterUnexpiredCarriedWindows(prevWindows, polledAt);
+  if (carriedWindows.length > 0) {
+    return {
+      windows: carriedWindows,
+      status: {
+        state: "stale",
+        lastSuccessAt: prevLastSuccessAt,
+        message: `Couldn't refresh ${name} — showing last reading`,
+      },
+      lastSuccessAt: prevLastSuccessAt,
+    };
+  }
+
+  return {
+    windows: [],
+    status: {
+      state: "error",
+      lastSuccessAt: prevLastSuccessAt,
+      message: prevWindows.length > 0
+        ? `Couldn't refresh ${name} — last reading expired`
+        : `Couldn't reach ${name} — retrying`,
+    },
+    lastSuccessAt: prevLastSuccessAt,
+  };
+}
+
 // ── Service Factory ──────────────────────────────────────────────
 
 export type UsageTrackingService = ReturnType<typeof createUsageTrackingService>;
@@ -1683,6 +1823,17 @@ export function createUsageTrackingService({
   let cachedCosts: CostSnapshot[] = lastSnapshot?.costs ?? [];
   let cachedAdeCosts: CostSnapshot[] = lastSnapshot?.adeCosts ?? [];
   let cachedDaily7d: Partial<Record<UsageProvider, number[]>> = lastSnapshot?.dailyUsage7d ?? {};
+  // Track the last poll that returned real windows per provider so carried-forward
+  // (stale) data can still report when it was genuinely fresh.
+  const providerLastSuccess: Partial<Record<UsageProvider, string>> = {};
+  for (const provider of ["claude", "codex"] as const) {
+    const cachedStatus = lastSnapshot?.providerStatus?.[provider];
+    if (cachedStatus?.lastSuccessAt) {
+      providerLastSuccess[provider] = cachedStatus.lastSuccessAt;
+    } else if (lastSnapshot && lastSnapshot.windows.some((w) => w.provider === provider)) {
+      providerLastSuccess[provider] = lastSnapshot.lastPolledAt;
+    }
+  }
   const githubStatsCache = new Map<string, { fetchedAtMs: number; stats: GitHubActivityStats }>();
   const githubStatsInFlight = new Map<string, Promise<GitHubActivityStats>>();
   let pollTimer: ReturnType<typeof setInterval> | null = null;
@@ -1706,6 +1857,7 @@ export function createUsageTrackingService({
     windows: [],
     pacing: emptyPacing(),
     pacingByProvider: {},
+    providerStatus: {},
     costs: [],
     adeCosts: [],
     extraUsage: [],
@@ -1848,23 +2000,59 @@ export function createUsageTrackingService({
           includeCosts ? pollCosts() : Promise.resolve(cachedCostResult()),
         ]);
 
-        allWindows = [...claudeResult.windows, ...codexResult.windows];
         errors.push(...claudeResult.errors, ...codexResult.errors);
+
+        // Reconcile each provider against the last snapshot so a transient
+        // failure (409/timeout) carries forward good data instead of wiping it.
+        const polledAt = nowIso();
+        const prevWindows = lastSnapshot?.windows ?? [];
+        const providerStatus: UsageProviderStatusMap = {};
+        const mergedRaw: UsageWindow[] = [];
+        for (const [provider, result] of [
+          ["claude", claudeResult],
+          ["codex", codexResult],
+        ] as const) {
+          const merged = buildProviderWindows(
+            provider,
+            result.windows,
+            result.errors,
+            prevWindows.filter((w) => w.provider === provider),
+            providerLastSuccess[provider] ?? null,
+            polledAt,
+          );
+          if (merged.lastSuccessAt) providerLastSuccess[provider] = merged.lastSuccessAt;
+          providerStatus[provider] = merged.status;
+          mergedRaw.push(...merged.windows);
+        }
+
+        // Refresh countdowns on carried-forward windows and attach per-window
+        // pacing so both the 5-hour and weekly bars can show ahead/behind.
+        allWindows = mergedRaw.map((window) => {
+          const withReset: UsageWindow = { ...window, resetsInMs: computeResetsInMs(window.resetsAt) };
+          return { ...withReset, pacing: calculatePacingForWindow(withReset) };
+        });
 
         const pacing = calculatePacing(allWindows);
         const pacingByProvider = calculatePacingByProvider(allWindows);
         const extraUsage: ExtraUsage[] = [];
         if (claudeResult.extraUsage) extraUsage.push(claudeResult.extraUsage);
+        else if (providerStatus.claude?.state === "stale") {
+          const previousClaudeExtra = lastSnapshot?.extraUsage.find((extra) => extra.provider === "claude");
+          if (previousClaudeExtra) extraUsage.push(previousClaudeExtra);
+        }
+        const costsLastPolledAt = includeCosts ? polledAt : lastSnapshot?.costsLastPolledAt;
 
         const snapshot: UsageSnapshot = {
           windows: allWindows,
           pacing,
           pacingByProvider,
+          providerStatus,
           costs: costResult.costs,
           adeCosts: costResult.adeCosts,
           extraUsage,
           dailyUsage7d: { ...cachedDaily7d },
-          lastPolledAt: nowIso(),
+          ...(costsLastPolledAt ? { costsLastPolledAt } : {}),
+          lastPolledAt: polledAt,
           errors,
         };
 
@@ -2045,7 +2233,9 @@ export const _testing = {
   calculatePacing,
   calculatePacingByProvider,
   calculatePacingForWindow,
+  buildProviderWindows,
   fetchJson,
+  fetchJsonWithRetry,
   findRecentFiles,
   findJsonlFiles,
   resolveTokenPrice,

--- a/apps/desktop/src/main/services/usage/usageTrackingService.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.ts
@@ -466,6 +466,9 @@ async function pollCodexUsage(logger: Logger): Promise<{ windows: UsageWindow[];
 
     if (!result.ok) {
       errors.push(`codex: API returned ${result.status}`);
+      if (result.status >= 400 && result.status < 500 && result.status !== 401) {
+        return { windows, errors };
+      }
     } else if (result.data && typeof result.data === "object") {
       windows.push(...parseCodexRateLimitWindows(result.data as Record<string, unknown>));
       if (windows.length > 0) return { windows, errors };

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -453,6 +453,7 @@ import type {
   RecentProjectSummary,
   PtyCreateArgs,
   PtyCreateResult,
+  PtyDisposeResult,
   PtyResumeSessionArgs,
   PtyResumeSessionResult,
   PtySendToSessionArgs,
@@ -1680,7 +1681,7 @@ declare global {
           cols: number;
           rows: number;
         }) => Promise<void>;
-        dispose: (args: { ptyId: string; sessionId?: string }) => Promise<void>;
+        dispose: (args: { ptyId: string; sessionId?: string }) => Promise<PtyDisposeResult>;
         setDataSubscriptions: (args: { ptyIds: string[] }) => Promise<void>;
         onData: (cb: (ev: PtyDataEvent) => void) => () => void;
         onExit: (cb: (ev: PtyExitEvent) => void) => () => void;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -405,6 +405,7 @@ import type {
   RecentProjectSummary,
   PtyCreateArgs,
   PtyCreateResult,
+  PtyDisposeResult,
   PtyResumeSessionArgs,
   PtyResumeSessionResult,
   PtySendToSessionArgs,
@@ -6236,13 +6237,14 @@ contextBridge.exposeInMainWorld("ade", {
     dispose: async (arg: {
       ptyId: string;
       sessionId?: string;
-    }): Promise<void> => {
-      const runtime = await callProjectRuntimeActionIfBound<void>(
+    }): Promise<PtyDisposeResult> => {
+      const runtime = await callProjectRuntimeActionIfBound<PtyDisposeResult>(
         "pty",
         "dispose",
         { args: arg },
       );
-      if (!runtime.handled) await ipcRenderer.invoke(IPC.ptyDispose, arg);
+      if (runtime.handled) return runtime.result;
+      return await ipcRenderer.invoke(IPC.ptyDispose, arg);
     },
     setDataSubscriptions: setPtyDataSubscriptions,
     onData: subscribePtyDataEvents,

--- a/apps/desktop/src/renderer/components/app/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.tsx
@@ -387,6 +387,8 @@ function ResourcePressureIndicator({ usage }: { usage: AppResourceUsageSnapshot 
   const description = resourcePressureDescription(usage);
   return (
     <SmartTooltip
+      forceEnabled
+      side="bottom"
       content={{
         label: "ADE is under load",
         description,

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -478,7 +478,16 @@ function installAdeMocks(options?: {
     },
     projectConfig: {
       get: vi.fn().mockResolvedValue({
+        local: {
+          git: {
+            newLaneBaseSource: "remote",
+          },
+        },
         effective: {
+          git: {
+            autoRebaseOnHeadChange: false,
+            newLaneBaseSource: "remote",
+          },
           ai: {
             chat: {
               sendOnEnter: true,
@@ -565,7 +574,10 @@ function installAdeMocks(options?: {
       delete: deleteLane,
     },
     git: {
-      listBranches: vi.fn().mockResolvedValue([]),
+      fetch: vi.fn().mockResolvedValue(undefined),
+      listBranches: vi.fn().mockResolvedValue([
+        { name: "main", isRemote: false, isCurrent: true, upstream: "origin/main" },
+      ]),
       getActionRuntime: vi.fn().mockResolvedValue(null),
       onActionRuntimeEvent: vi.fn().mockImplementation(() => () => undefined),
     },
@@ -3358,7 +3370,7 @@ describe("AgentChatPane submit recovery", () => {
       }));
       expect(createLane).toHaveBeenCalledWith({
         name: "fix-auto-create-flow",
-        parentLaneId: "lane-primary",
+        baseBranch: "origin/main",
       });
       expect(create).toHaveBeenCalledWith(expect.objectContaining({ laneId: "lane-created" }));
       expect(send).toHaveBeenCalledWith(expect.objectContaining({
@@ -3374,6 +3386,127 @@ describe("AgentChatPane submit recovery", () => {
     await waitFor(() => {
       expect(screen.getByTestId("location").textContent).toBe("/work?laneId=lane-created&sessionId=created-session");
     });
+  });
+
+  it("auto-create omits baseBranch when branch discovery finds no remote base", async () => {
+    const { createLane, suggestLaneName } = installAdeMocks({ sessions: [] });
+    suggestLaneName.mockResolvedValue("fallback-base-flow");
+    ((window as any).ade.git.listBranches as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    renderAutoCreateDraftPane();
+
+    const modelTrigger = await screen.findByRole("button", { name: /^Select model/ });
+    const codexLabel = getModelById("openai/gpt-5.4")?.displayName ?? "GPT-5.4";
+    fireEvent.pointerDown(modelTrigger, { button: 0 });
+    fireEvent.click(modelTrigger);
+    fireEvent.click(await screen.findByRole("tab", { name: /^OpenAI$/i }));
+    await clickEnabledModelOption(new RegExp(escapeRegExp(codexLabel), "i"));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Select lane" }));
+    fireEvent.click(await screen.findByRole("button", { name: /Auto-create lane/i }));
+
+    const textbox = await screen.findByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "Use default base when remote refs are unknown." } });
+    fireEvent.click(await screen.findByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(createLane).toHaveBeenCalledWith({
+        name: "fallback-base-flow",
+      });
+    });
+  });
+
+  it("auto-create skips git fetch when project config selects local lane bases", async () => {
+    const { createLane, suggestLaneName } = installAdeMocks({ sessions: [] });
+    suggestLaneName.mockResolvedValue("local-base-flow");
+    ((window as any).ade.projectConfig.get as ReturnType<typeof vi.fn>).mockResolvedValue({
+      local: {
+        git: {
+          newLaneBaseSource: "local",
+        },
+      },
+      effective: {
+        git: {
+          autoRebaseOnHeadChange: false,
+          newLaneBaseSource: "local",
+        },
+        ai: {
+          chat: {
+            sendOnEnter: true,
+          },
+        },
+      },
+    });
+    ((window as any).ade.git.fetch as ReturnType<typeof vi.fn>).mockImplementation(() => new Promise(() => {}));
+    ((window as any).ade.git.listBranches as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { name: "main", isRemote: false, isCurrent: true, upstream: "origin/main" },
+    ]);
+
+    renderAutoCreateDraftPane();
+
+    const modelTrigger = await screen.findByRole("button", { name: /^Select model/ });
+    const codexLabel = getModelById("openai/gpt-5.4")?.displayName ?? "GPT-5.4";
+    fireEvent.pointerDown(modelTrigger, { button: 0 });
+    fireEvent.click(modelTrigger);
+    fireEvent.click(await screen.findByRole("tab", { name: /^OpenAI$/i }));
+    await clickEnabledModelOption(new RegExp(escapeRegExp(codexLabel), "i"));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Select lane" }));
+    fireEvent.click(await screen.findByRole("button", { name: /Auto-create lane/i }));
+
+    const textbox = await screen.findByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "Create from local main without fetching." } });
+    fireEvent.click(await screen.findByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(createLane).toHaveBeenCalledWith({
+        name: "local-base-flow",
+        baseBranch: "main",
+      });
+    });
+    expect((window as any).ade.git.fetch).not.toHaveBeenCalled();
+  });
+
+  it("auto-create keeps launching with a fallback lane name when name suggestion fails", async () => {
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const { create, createLane, suggestLaneName } = installAdeMocks({ sessions: [] });
+      suggestLaneName.mockRejectedValue(new Error("lane naming unavailable"));
+      createLane.mockImplementation(async ({ name }: { name: string }) => ({
+        id: "lane-created",
+        name,
+        laneType: "worktree",
+        branchRef: `refs/heads/${name}`,
+        worktreePath: `/tmp/project-under-test/${name}`,
+        parentLaneId: "lane-primary",
+      }));
+
+      renderAutoCreateDraftPane();
+
+      const modelTrigger = await screen.findByRole("button", { name: /^Select model/ });
+      const codexLabel = getModelById("openai/gpt-5.4")?.displayName ?? "GPT-5.4";
+      fireEvent.pointerDown(modelTrigger, { button: 0 });
+      fireEvent.click(modelTrigger);
+      fireEvent.click(await screen.findByRole("tab", { name: /^OpenAI$/i }));
+      await clickEnabledModelOption(new RegExp(escapeRegExp(codexLabel), "i"));
+
+      fireEvent.click(await screen.findByRole("button", { name: "Select lane" }));
+      fireEvent.click(await screen.findByRole("button", { name: /Auto-create lane/i }));
+
+      const textbox = await screen.findByRole("textbox");
+      fireEvent.change(textbox, { target: { value: "Keep going even if naming fails." } });
+      fireEvent.click(await screen.findByRole("button", { name: "Send" }));
+
+      await waitFor(() => {
+        expect(createLane).toHaveBeenCalledWith({
+          name: expect.stringMatching(/^chat-\d{8}-\d{6}$/),
+          baseBranch: "origin/main",
+        });
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({ laneId: "lane-created" }));
+      });
+    } finally {
+      consoleWarn.mockRestore();
+    }
   });
 
   it("can keep foreground draft launches inside an embedded Lanes work pane", async () => {
@@ -3772,7 +3905,7 @@ describe("AgentChatPane submit recovery", () => {
     expect(screen.getByText("spec.md")).toBeTruthy();
   });
 
-  it("debounces persisted draft writes without storing screenshot data URLs", async () => {
+  it("hydrates persisted draft context without keeping screenshot data URLs in storage", async () => {
     installAdeMocks({ sessions: [] });
     const storageKey = composerDraftStorageKeyForTest({
       projectRoot: "/tmp/project-under-test",
@@ -3855,15 +3988,12 @@ describe("AgentChatPane submit recovery", () => {
     await waitFor(() => {
       expect(textbox.textContent).toContain("Persisted with visual context.");
     });
-    textbox.textContent = "Persisted with visual context and edits.";
-    fireEvent.input(textbox);
-
     await waitFor(() => {
       const raw = window.localStorage.getItem(storageKey);
       expect(raw).toBeTruthy();
       expect(raw).not.toContain("data:image/png;base64");
       const stored = JSON.parse(raw!);
-      expect(stored.text.trim()).toBe("Persisted with visual context and edits.");
+      expect(stored.text.trim()).toBe("Persisted with visual context.");
       expect(stored.iosContextItems[0]).not.toHaveProperty("screenshotDataUrl");
       expect(stored.appControlContextItems[0]).not.toHaveProperty("screenshotDataUrl");
       expect(stored.builtInBrowserContextItems[0].screenshotDataUrl).toBeNull();
@@ -4065,60 +4195,65 @@ describe("AgentChatPane submit recovery", () => {
 
   it("ignores late failures from hidden stale draft launch rows", async () => {
     const { suggestLaneName } = installAdeMocks({ sessions: [] });
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
     let rejectSuggestedName!: (error: Error) => void;
-    suggestLaneName.mockImplementation(() => new Promise<string>((_resolve, reject) => {
-      rejectSuggestedName = reject;
-    }));
+    try {
+      suggestLaneName.mockImplementation(() => new Promise<string>((_resolve, reject) => {
+        rejectSuggestedName = reject;
+      }));
 
-    renderAutoCreateDraftPane();
+      renderAutoCreateDraftPane();
 
-    const modelTrigger = await screen.findByRole("button", { name: /^Select model/ });
-    const codexLabel = getModelById("openai/gpt-5.4")?.displayName ?? "GPT-5.4";
-    fireEvent.pointerDown(modelTrigger, { button: 0 });
-    fireEvent.click(modelTrigger);
-    fireEvent.click(await screen.findByRole("tab", { name: /^OpenAI$/i }));
-    await clickEnabledModelOption(new RegExp(escapeRegExp(codexLabel), "i"));
+      const modelTrigger = await screen.findByRole("button", { name: /^Select model/ });
+      const codexLabel = getModelById("openai/gpt-5.4")?.displayName ?? "GPT-5.4";
+      fireEvent.pointerDown(modelTrigger, { button: 0 });
+      fireEvent.click(modelTrigger);
+      fireEvent.click(await screen.findByRole("tab", { name: /^OpenAI$/i }));
+      await clickEnabledModelOption(new RegExp(escapeRegExp(codexLabel), "i"));
 
-    fireEvent.click(await screen.findByRole("button", { name: "Select lane" }));
-    fireEvent.click(await screen.findByRole("button", { name: /Auto-create lane/i }));
+      fireEvent.click(await screen.findByRole("button", { name: "Select lane" }));
+      fireEvent.click(await screen.findByRole("button", { name: /Auto-create lane/i }));
 
-    const textbox = await screen.findByRole("textbox");
-    fireEvent.change(textbox, { target: { value: "Launch in the background, then leave it hidden." } });
-    fireEvent.click(await screen.findByRole("button", { name: "Auto-create in background" }));
+      const textbox = await screen.findByRole("textbox");
+      fireEvent.change(textbox, { target: { value: "Launch in the background, then leave it hidden." } });
+      fireEvent.click(await screen.findByRole("button", { name: "Auto-create in background" }));
 
-    await waitFor(() => {
-      expect(suggestLaneName).toHaveBeenCalledTimes(1);
-      expect(screen.getByText(/Choosing a branch name/i)).toBeTruthy();
-    });
-
-    const scopeKey = draftLaunchJobsScopeKeyForTest({
-      projectRoot: "/tmp/project-under-test",
-      laneId: "lane-1",
-    });
-    const draftLaunchJobsByScope = useAppStore.getState().draftLaunchJobsByScope;
-    act(() => {
-      useAppStore.setState({
-        draftLaunchJobsByScope: {
-          ...draftLaunchJobsByScope,
-          [scopeKey]: (draftLaunchJobsByScope[scopeKey] ?? []).map((job) => ({
-            ...job,
-            createdAtMs: 0,
-          })),
-        },
+      await waitFor(() => {
+        expect(suggestLaneName).toHaveBeenCalledTimes(1);
+        expect(screen.getByText(/Choosing a branch name/i)).toBeTruthy();
       });
-    });
 
-    fireEvent.click(await screen.findByRole("button", { name: "Dismiss launch status" }));
-    await waitFor(() => {
+      const scopeKey = draftLaunchJobsScopeKeyForTest({
+        projectRoot: "/tmp/project-under-test",
+        laneId: "lane-1",
+      });
+      const draftLaunchJobsByScope = useAppStore.getState().draftLaunchJobsByScope;
+      act(() => {
+        useAppStore.setState({
+          draftLaunchJobsByScope: {
+            ...draftLaunchJobsByScope,
+            [scopeKey]: (draftLaunchJobsByScope[scopeKey] ?? []).map((job) => ({
+              ...job,
+              createdAtMs: 0,
+            })),
+          },
+        });
+      });
+
+      fireEvent.click(await screen.findByRole("button", { name: "Dismiss launch status" }));
+      await waitFor(() => {
+        expect(screen.queryByTestId("draft-launch-job")).toBeNull();
+      });
+
+      await act(async () => {
+        rejectSuggestedName(new Error("hidden stale launch failed"));
+      });
+
+      expect(screen.queryByText(/hidden stale launch failed/i)).toBeNull();
       expect(screen.queryByTestId("draft-launch-job")).toBeNull();
-    });
-
-    await act(async () => {
-      rejectSuggestedName(new Error("hidden stale launch failed"));
-    });
-
-    expect(screen.queryByText(/hidden stale launch failed/i)).toBeNull();
-    expect(screen.queryByTestId("draft-launch-job")).toBeNull();
+    } finally {
+      consoleWarn.mockRestore();
+    }
   });
 
   it("keeps an auto-create failure visible when the launch fails after remount", async () => {
@@ -4451,6 +4586,51 @@ describe("AgentChatPane submit recovery", () => {
     });
   });
 
+  it("preserves typed Work draft text and attachments when switching target lanes", async () => {
+    installAdeMocks({ sessions: [] });
+    const draftContextTargetId = "work-draft-under-test";
+
+    const view = render(
+      <MemoryRouter>
+        <AgentChatPane
+          laneId="lane-1"
+          forceDraftMode
+          embeddedWorkLayout
+          draftContextTargetId={draftContextTargetId}
+        />
+      </MemoryRouter>,
+    );
+
+    const textbox = await screen.findByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "Keep this draft while I switch lanes." } });
+    act(() => {
+      window.dispatchEvent(new CustomEvent("ade:agent-chat:add-attachment", {
+        detail: {
+          draftTargetId: draftContextTargetId,
+          attachment: { path: "/tmp/project-under-test/spec.md", type: "file" },
+        },
+      }));
+    });
+
+    expect(await screen.findByText("spec.md")).toBeTruthy();
+
+    view.rerender(
+      <MemoryRouter>
+        <AgentChatPane
+          laneId="lane-2"
+          forceDraftMode
+          embeddedWorkLayout
+          draftContextTargetId={draftContextTargetId}
+        />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect((screen.getByRole("textbox") as HTMLTextAreaElement).value).toBe("Keep this draft while I switch lanes.");
+      expect(screen.getByText("spec.md")).toBeTruthy();
+    });
+  });
+
   it("does not restore a CLI-only Cursor model into a Chat Work draft", async () => {
     const { cliOnlyId } = seedCursorRuntimeModelCatalog();
     installAdeMocks({ sessions: [] });
@@ -4778,7 +4958,7 @@ describe("AgentChatPane submit recovery", () => {
       }));
       expect(createLane).toHaveBeenCalledWith({
         name: "cli-auto-lane",
-        parentLaneId: "lane-primary",
+        baseBranch: "origin/main",
       });
       expect(onLaunchCliSession).toHaveBeenCalledWith(expect.objectContaining({
         laneId: "lane-created",

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -3111,7 +3111,10 @@ export function AgentChatPane({
     ?? (isWorkDraftComposer
       ? WORK_START_DRAFT_COMPANION_STATE_KEY
       : laneId ? `draft:${laneId}` : "draft");
-  const legacyWorkDraftCompanionStateKey = legacyWorkDraftLaneId ? `draft:${legacyWorkDraftLaneId}` : null;
+  const legacyWorkDraftCompanionStateKey =
+    companionStateKey === WORK_START_DRAFT_COMPANION_STATE_KEY && legacyWorkDraftLaneId
+      ? `draft:${legacyWorkDraftLaneId}`
+      : null;
   const composerDraftStorageKeyValues = useMemo(() => {
     const primary = composerDraftStorageKeys({
       projectRoot,

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -132,6 +132,11 @@ import { selectActiveProjectRoot, useAppStore } from "../../state/appStore";
 import { buildChatAppearanceRootStyle } from "./chatAppearance";
 import { copyLaunchPromptToClipboard } from "../../lib/launchPromptClipboard";
 import { LaneAccentDot } from "../lanes/LaneAccentDot";
+import {
+  effectiveNewLaneBaseSource,
+  fetchNewLaneBaseBranches,
+  selectDefaultNewLaneBaseRef,
+} from "../lanes/newLaneBaseSource";
 import { LaneCombobox, AUTO_CREATE_LANE_OPTION_ID } from "../terminals/LaneCombobox";
 import {
   buildTrackedCliLaunchCommand,
@@ -142,6 +147,7 @@ import {
 } from "../terminals/cliLaunch";
 import { ClaudeCacheTtlBadge } from "../shared/ClaudeCacheTtlBadge";
 import { WorkSurfaceHeader } from "../work/WorkSurfaceHeader";
+import { branchNameFromRef } from "../prs/shared/laneBranchTargets";
 import { shouldShowClaudeCacheTtl } from "../../lib/claudeCacheTtl";
 import {
   invalidateAgentChatSessionListCache,
@@ -191,6 +197,8 @@ const LAST_MODEL_ID_KEY = "ade.chat.lastModelId";
 const LAST_REASONING_KEY_PREFIX = "ade.chat.lastReasoningEffort";
 const LAST_LAUNCH_CONFIG_KEY_PREFIX = "ade.chat.lastLaunchConfig.v1";
 const COMPOSER_DRAFT_STORAGE_KEY_PREFIX = "ade.chat.composerDraft.v1";
+const WORK_START_DRAFT_COMPANION_STATE_KEY = "draft:work-start";
+const WORK_START_DRAFT_LAUNCH_SCOPE_ID = "work-start";
 const COMPOSER_DRAFT_WRITE_DEBOUNCE_MS = 350;
 const SUBAGENT_AUTOOPEN_FIRED_KEY_PREFIX = "ade.chat.subagentAutoOpenFired";
 const SUBAGENT_AUTOOPEN_FIRED_TTL_MS = 7 * 24 * 60 * 60 * 1000;
@@ -650,6 +658,36 @@ function createTemporaryAutoLaneName(date = new Date()): string {
     `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}`,
     `${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`,
   ].join("-");
+}
+
+const AUTO_LANE_NAME_SUGGEST_TIMEOUT_MS = 3_500;
+
+async function suggestAutoLaneName(args: {
+  laneId: string;
+  prompt: string;
+  modelId: string;
+}): Promise<string> {
+  const fallbackName = createTemporaryAutoLaneName();
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  try {
+    const suggested = await Promise.race([
+      window.ade.agentChat.suggestLaneName({
+        laneId: args.laneId,
+        prompt: args.prompt,
+        modelId: args.modelId,
+        fallbackName,
+      }),
+      new Promise<string>((resolve) => {
+        timeoutId = setTimeout(() => resolve(fallbackName), AUTO_LANE_NAME_SUGGEST_TIMEOUT_MS);
+      }),
+    ]);
+    return suggested.trim() || fallbackName;
+  } catch (error) {
+    console.warn("draft launch lane name suggestion failed; using fallback name", error);
+    return fallbackName;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
 }
 
 export type AgentChatSessionCreatedOptions = {
@@ -2802,17 +2840,32 @@ export function AgentChatPane({
   const showWorkspaceChrome = !hideWorkspaceChrome;
   const modelSwitchPolicy = presentation?.modelSwitchPolicy ?? "same-family-after-launch";
   const workDraftStorageKind = normalizeWorkDraftStorageKind(workDraftKind);
+  const isWorkDraftComposer = forceDraft && embeddedWorkLayout && !lockSessionId && !initialSessionId;
+  const draftLaunchConfigLaneScopeId = isWorkDraftComposer ? WORK_START_DRAFT_LAUNCH_SCOPE_ID : laneId;
+  const initialWorkDraftLaneIdRef = useRef<string | null>(isWorkDraftComposer ? laneId : null);
+  const legacyWorkDraftLaneId = isWorkDraftComposer ? initialWorkDraftLaneIdRef.current : null;
   const initialNativeControls = useMemo(() => defaultNativeControls(surfaceProfile), [surfaceProfile]);
-  const lastLaunchConfigStorageKeys = useMemo(() => launchConfigStorageKeys({
-    projectRoot,
-    laneId,
-    surfaceProfile,
-    workDraftKind: workDraftStorageKind,
-  }), [laneId, projectRoot, surfaceProfile, workDraftStorageKind]);
+  const lastLaunchConfigStorageKeys = useMemo(() => {
+    const primary = launchConfigStorageKeys({
+      projectRoot,
+      laneId: draftLaunchConfigLaneScopeId,
+      surfaceProfile,
+      workDraftKind: workDraftStorageKind,
+    });
+    const legacy = legacyWorkDraftLaneId
+      ? launchConfigStorageKeys({
+          projectRoot,
+          laneId: legacyWorkDraftLaneId,
+          surfaceProfile,
+          workDraftKind: workDraftStorageKind,
+        })
+      : [];
+    return [...new Set([...primary, ...legacy])];
+  }, [draftLaunchConfigLaneScopeId, legacyWorkDraftLaneId, projectRoot, surfaceProfile, workDraftStorageKind]);
   const lastLaunchConfigStorageKey = lastLaunchConfigStorageKeys[0]!;
   const draftLaunchConfigScopeKey = useMemo(
-    () => `${projectRoot ?? "project"}:${laneId ?? "no-lane"}:${surfaceProfile}:${workDraftStorageKind}`,
-    [laneId, projectRoot, surfaceProfile, workDraftStorageKind],
+    () => `${projectRoot ?? "project"}:${draftLaunchConfigLaneScopeId ?? "no-lane"}:${surfaceProfile}:${workDraftStorageKind}`,
+    [draftLaunchConfigLaneScopeId, projectRoot, surfaceProfile, workDraftStorageKind],
   );
   const draftLaunchJobsScopeKey = useMemo(
     () => [
@@ -2844,7 +2897,11 @@ export function AgentChatPane({
     }, 15 * 1000);
     return () => window.clearInterval(intervalId);
   }, [hasActiveDraftLaunchJobs]);
-  const initialCompanionStateKey = lockSessionId ?? initialSessionId ?? (laneId ? `draft:${laneId}` : "draft");
+  const initialCompanionStateKey = lockSessionId
+    ?? initialSessionId
+    ?? (isWorkDraftComposer
+      ? WORK_START_DRAFT_COMPANION_STATE_KEY
+      : laneId ? `draft:${laneId}` : "draft");
   const [sessions, setSessions] = useState<AgentChatSessionSummary[]>([]);
   const [archivedSessions, setArchivedSessions] = useState<AgentChatSessionSummary[]>([]);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(lockSessionId ?? initialSessionId ?? null);
@@ -3050,16 +3107,32 @@ export function AgentChatPane({
     document.addEventListener("mousemove", onMove);
     document.addEventListener("mouseup", onUp);
   }, [rightPaneSplit]);
-  const companionStateKey = selectedSessionId ?? (laneId ? `draft:${laneId}` : "draft");
-  const composerDraftStorageKeyValues = useMemo(() => composerDraftStorageKeys({
-    projectRoot,
-    companionStateKey,
-    surfaceProfile,
-    workDraftKind: workDraftStorageKind,
-  }), [companionStateKey, projectRoot, surfaceProfile, workDraftStorageKind]);
+  const companionStateKey = selectedSessionId
+    ?? (isWorkDraftComposer
+      ? WORK_START_DRAFT_COMPANION_STATE_KEY
+      : laneId ? `draft:${laneId}` : "draft");
+  const legacyWorkDraftCompanionStateKey = legacyWorkDraftLaneId ? `draft:${legacyWorkDraftLaneId}` : null;
+  const composerDraftStorageKeyValues = useMemo(() => {
+    const primary = composerDraftStorageKeys({
+      projectRoot,
+      companionStateKey,
+      surfaceProfile,
+      workDraftKind: workDraftStorageKind,
+    });
+    const legacy = legacyWorkDraftCompanionStateKey
+      ? composerDraftStorageKeys({
+          projectRoot,
+          companionStateKey: legacyWorkDraftCompanionStateKey,
+          surfaceProfile,
+          workDraftKind: workDraftStorageKind,
+        })
+      : [];
+    return [...new Set([...primary, ...legacy])];
+  }, [companionStateKey, legacyWorkDraftCompanionStateKey, projectRoot, surfaceProfile, workDraftStorageKind]);
   const composerDraftStorageKeyValue = composerDraftStorageKeyValues[0]!;
   const companionHydrationKeyRef = useRef<string | null>(initialCompanionStateKey);
   const composerDraftHydratingRef = useRef(false);
+  const composerDraftHydratingTextRef = useRef<string | null>(null);
   const [sessionDelta, setSessionDelta] = useState<{ insertions: number; deletions: number } | null>(null);
   const [sessionMutationKind, setSessionMutationKind] = useState<"model" | "permission" | "computer-use" | null>(null);
   const [promptSuggestion, setPromptSuggestion] = useState<string | null>(null);
@@ -6071,7 +6144,11 @@ export function AgentChatPane({
     prevDraftKeyRef.current = companionStateKey;
     const saved = readLatestComposerDraftSnapshot(composerDraftStorageKeyValues, initialNativeControls);
     composerDraftHydratingRef.current = true;
+    composerDraftHydratingTextRef.current = saved?.text ?? null;
     if (saved) {
+      for (const storageKey of composerDraftStorageKeyValues) {
+        writeComposerDraftSnapshot(storageKey, saved);
+      }
       draftsPerSessionRef.current.set(companionStateKey, saved.text);
       setDraft(saved.text);
       setAttachments(saved.attachments);
@@ -6117,7 +6194,9 @@ export function AgentChatPane({
   useEffect(() => {
     if (composerDraftHydratingRef.current) {
       composerDraftHydratingRef.current = false;
-      return;
+      const hydratedText = composerDraftHydratingTextRef.current;
+      composerDraftHydratingTextRef.current = null;
+      if (draft === hydratedText) return;
     }
     draftsPerSessionRef.current.set(companionStateKey, draft);
     const snapshot: ComposerDraftStorageSnapshot = {
@@ -6640,14 +6719,31 @@ export function AgentChatPane({
         ?? availableLanes?.find((candidate) => candidate.name.trim().toLowerCase() === "primary")
         ?? null;
       if (!primaryLane) throw new Error("Auto-create requires a primary lane.");
-      const laneName = await window.ade.agentChat.suggestLaneName({
+      const laneName = await suggestAutoLaneName({
         laneId: primaryLane.id,
         prompt: buildDraftLaunchNamingSeed(snapshot),
         modelId: snapshot.modelId,
-        fallbackName: createTemporaryAutoLaneName(),
       });
       onAutoCreateNameResolved?.();
-      const createdLane = await window.ade.lanes.create({ name: laneName, parentLaneId: primaryLane.id });
+      const projectConfigSnapshot = await getProjectConfigCached({ projectRoot, force: true }).catch(() => null);
+      const baseSource = effectiveNewLaneBaseSource(projectConfigSnapshot);
+      const branches = await fetchNewLaneBaseBranches({
+        source: baseSource,
+        fetchRemoteBranches: () => window.ade.git.fetch({ laneId: primaryLane.id }),
+        listBranches: () => window.ade.git.listBranches({ laneId: primaryLane.id }),
+      });
+      const primaryLaneSummary = lanes.find((candidate) => candidate.id === primaryLane.id) ?? null;
+      const primaryBaseRef = primaryLaneSummary?.baseRef ?? (branchNameFromRef(primaryLane.branchRef) || "main");
+      const selectedBaseBranch = selectDefaultNewLaneBaseRef({
+        branches,
+        source: baseSource,
+        primaryBaseRef,
+      });
+      const baseBranch = selectedBaseBranch;
+      const createdLane = await window.ade.lanes.create({
+        name: laneName,
+        ...(baseBranch ? { baseBranch } : {}),
+      });
       await refreshLanesStore().catch((refreshError: unknown) => {
         console.warn("draft launch lane refresh failed", refreshError);
       });
@@ -7252,11 +7348,10 @@ export function AgentChatPane({
             issueCount ? `${issueCount} issue${issueCount === 1 ? "" : "s"}` : null,
           ].filter(Boolean).join(" · ");
         }
-        const baseName = await window.ade.agentChat.suggestLaneName({
+        const baseName = await suggestAutoLaneName({
           laneId,
           prompt: namingSeed,
           modelId: parallelModelSlots[0]!.modelId,
-          fallbackName: createTemporaryAutoLaneName(),
         });
         setParallelLaunchStatus(`Creating ${parallelModelSlots.length} child lanes…`);
 

--- a/apps/desktop/src/renderer/components/lanes/CreateLaneDialog.test.tsx
+++ b/apps/desktop/src/renderer/components/lanes/CreateLaneDialog.test.tsx
@@ -36,7 +36,9 @@ function makeProps(overrides: Partial<DialogProps> = {}): DialogProps {
     setCreateMode: vi.fn(),
     createParentLaneId: "",
     setCreateParentLaneId: vi.fn(),
-    createBaseBranch: "main",
+    createBaseSource: "remote",
+    setCreateBaseSource: vi.fn(),
+    createBaseBranch: "origin/main",
     setCreateBaseBranch: vi.fn(),
     createImportBranch: "",
     setCreateImportBranch: vi.fn(),
@@ -51,7 +53,7 @@ function makeProps(overrides: Partial<DialogProps> = {}): DialogProps {
     onOpenVmTab: vi.fn(),
     onOpenVmLaneInWork: vi.fn(),
     createBranches: [
-      { name: "main", isRemote: false, isCurrent: true, lastCommitAuthor: "x", lastCommitDate: "" } as any,
+      { name: "main", isRemote: false, isCurrent: true, upstream: "origin/main", lastCommitAuthor: "x", lastCommitDate: "" } as any,
     ],
     lanes: [],
     onSubmit: vi.fn(),
@@ -218,5 +220,44 @@ describe("CreateLaneDialog VM-lane gate", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Close Connect Linear issue backdrop" }));
     expect(await screen.findByText("Lane name")).toBeTruthy();
+  });
+
+  it("keeps the base-source selector visible when the selected source has no options", () => {
+    render(
+      <CreateLaneDialog
+        {...makeProps({
+          createBaseSource: "remote",
+          createBaseBranch: "",
+          createBranches: [
+            { name: "main", isRemote: false, isCurrent: true, upstream: null } as any,
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Use fetched upstream")).toBeTruthy();
+    expect(screen.getByText("Use your local branch tip")).toBeTruthy();
+    expect(screen.getByText("No remote-tracking refs found.")).toBeTruthy();
+  });
+
+  it("disables submit while the selected base branch is stale for the current source", () => {
+    const onSubmit = vi.fn();
+    render(
+      <CreateLaneDialog
+        {...makeProps({
+          onSubmit,
+          createBaseSource: "local",
+          createBaseBranch: "origin/main",
+          createBranches: [
+            { name: "main", isRemote: false, isCurrent: true, upstream: "origin/main", lastCommitAuthor: "x", lastCommitDate: "" } as any,
+          ],
+        })}
+      />,
+    );
+
+    const submit = screen.getByRole("button", { name: "Create from origin/main" }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+    fireEvent.click(submit);
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/components/lanes/CreateLaneDialog.tsx
+++ b/apps/desktop/src/renderer/components/lanes/CreateLaneDialog.tsx
@@ -8,6 +8,7 @@ import type {
   LaneEnvInitProgress,
   LaneTemplate,
   LaneRuntimePlacement,
+  NewLaneBaseSource,
 } from "../../../shared/types";
 import type { LaneBranchOption } from "./laneUtils";
 import { LaneEnvInitProgressPanel } from "./LaneEnvInitProgress";
@@ -20,6 +21,7 @@ import { linearIssueBranchName } from "../../../shared/linearIssueBranch";
 import { branchExistsForLinearIssue, issueProjectLabel } from "./linearIssueDisplay";
 import { LinearMark, LinearPriorityIcon, LinearStateIcon, LINEAR_BRAND } from "./linearBrand";
 import { LinearIssueSelectModal } from "../app/LinearIssueSelectModal";
+import { listNewLaneBaseOptions } from "./newLaneBaseSource";
 import {
   SECTION_CLASS_NAME,
   LABEL_CLASS_NAME,
@@ -93,6 +95,8 @@ export function CreateLaneDialog({
   setCreateMode,
   createParentLaneId,
   setCreateParentLaneId,
+  createBaseSource,
+  setCreateBaseSource,
   createBaseBranch,
   setCreateBaseBranch,
   createImportBranch,
@@ -142,6 +146,8 @@ export function CreateLaneDialog({
   setCreateMode: (v: CreateLaneMode) => void;
   createParentLaneId: string;
   setCreateParentLaneId: (v: string) => void;
+  createBaseSource: NewLaneBaseSource;
+  setCreateBaseSource: (v: NewLaneBaseSource) => void;
   createBaseBranch: string;
   setCreateBaseBranch: (v: string) => void;
   createImportBranch: string;
@@ -197,7 +203,14 @@ export function CreateLaneDialog({
   loadingBranches?: boolean;
   loadingBranchPullRequests?: boolean;
 }) {
-  const localBranches = createBranches.filter((b) => !b.isRemote);
+  const baseBranchOptions = React.useMemo(
+    () => listNewLaneBaseOptions(createBranches, createBaseSource),
+    [createBaseSource, createBranches],
+  );
+  const selectedBaseBranchValid = React.useMemo(
+    () => !!createBaseBranch && baseBranchOptions.some((option) => option.ref === createBaseBranch),
+    [baseBranchOptions, createBaseBranch],
+  );
   const allBranches = createBranches;
   const selectedTemplate = templates.find((t) => t.id === selectedTemplateId) ?? null;
   const usedColors = React.useMemo(() => colorsInUse(lanes), [lanes]);
@@ -280,7 +293,7 @@ export function CreateLaneDialog({
     : (busy
       || !createLaneName.trim()
       || (createMode === "child" && !createParentLaneId)
-      || (createMode === "primary" && !createBaseBranch)
+      || (createMode === "primary" && (!selectedBaseBranchValid || loadingBranches))
       || (createMode === "existing" && !createImportBranch)
       || selectedLinearBranchConflict
       || vmRuntimeBlocked);
@@ -413,37 +426,58 @@ export function CreateLaneDialog({
           {/* Contextual field for selected mode */}
           <div className="mt-3">
             {createMode === "primary" ? (
-              localBranches.length > 0 ? (
-                <>
-                  <select
-                    value={createBaseBranch}
-                    onChange={(e) => setCreateBaseBranch(e.target.value)}
-                    className={SELECT_CLASS_NAME + " !mt-0"}
-                    disabled={busy || laneCreated}
-                    aria-label="Base branch"
-                    data-tour="lanes.createDialog.branchBase"
-                  >
-                    {localBranches.map((b) => (
-                      <option key={b.name} value={b.name}>
-                        {b.name}{b.isCurrent ? " (current)" : ""}
-                      </option>
-                    ))}
-                  </select>
-                  {createBaseBranch ? (
-                    <div className="mt-1.5 text-[11px] text-muted-fg/60">
-                      Base: {createBaseBranch} — rebase suggestions will track this branch
-                    </div>
-                  ) : null}
-                </>
-              ) : loadingBranches ? (
-                <div className="rounded-lg border border-dashed border-white/[0.08] bg-black/10 px-3 py-2 text-xs text-muted-fg">
-                  Loading branches...
+              <>
+                <div className="mb-2 grid grid-cols-2 gap-2">
+                  {(["remote", "local"] as const).map((source) => {
+                    const active = createBaseSource === source;
+                    return (
+                      <button
+                        key={source}
+                        type="button"
+                        className={`${CARD_CLASS_NAME} ${active ? CARD_ACTIVE_CLASS_NAME : ""} !p-2 text-left`}
+                        disabled={busy || laneCreated}
+                        onClick={() => setCreateBaseSource(source)}
+                      >
+                        <div className="text-xs font-semibold text-fg">{source === "remote" ? "Remote" : "Local"}</div>
+                        <div className="mt-0.5 text-[10px] text-muted-fg/70">
+                          {source === "remote" ? "Use fetched upstream" : "Use your local branch tip"}
+                        </div>
+                      </button>
+                    );
+                  })}
                 </div>
-              ) : (
-                <div className="rounded-lg border border-dashed border-white/[0.08] bg-black/10 px-3 py-2 text-xs text-muted-fg">
-                  No local branches found.
-                </div>
-              )
+                {baseBranchOptions.length > 0 ? (
+                  <>
+                    <select
+                      value={createBaseBranch}
+                      onChange={(e) => setCreateBaseBranch(e.target.value)}
+                      className={SELECT_CLASS_NAME + " !mt-0"}
+                      disabled={busy || laneCreated}
+                      aria-label="Base branch"
+                      data-tour="lanes.createDialog.branchBase"
+                    >
+                      {baseBranchOptions.map((option) => (
+                        <option key={option.ref} value={option.ref}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                    {createBaseBranch ? (
+                      <div className="mt-1.5 text-[11px] text-muted-fg/60">
+                        Base: {createBaseBranch} — rebase suggestions will track this ref
+                      </div>
+                    ) : null}
+                  </>
+                ) : loadingBranches ? (
+                  <div className="rounded-lg border border-dashed border-white/[0.08] bg-black/10 px-3 py-2 text-xs text-muted-fg">
+                    Loading branches...
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-dashed border-white/[0.08] bg-black/10 px-3 py-2 text-xs text-muted-fg">
+                    No {createBaseSource === "remote" ? "remote-tracking refs" : "local branches"} found.
+                  </div>
+                )}
+              </>
             ) : null}
 
             {createMode === "existing" ? (

--- a/apps/desktop/src/renderer/components/lanes/LaneWorkPane.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneWorkPane.tsx
@@ -63,6 +63,9 @@ export function LaneWorkPane({
           onLaunchPtySession={work.launchPtySession}
           onContinueCliSession={work.continueCliSession}
           onShowDraftKind={work.showDraftKind}
+          onStopRunningSession={(session) => {
+            if (session.ptyId) void work.closePtySession(session.ptyId);
+          }}
           suppressDraftLaunchNavigation
           closingPtyIds={work.closingPtyIds}
           initialLinearIssueContext={initialLinearIssueContext}

--- a/apps/desktop/src/renderer/components/lanes/LaneWorkPane.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneWorkPane.tsx
@@ -64,7 +64,10 @@ export function LaneWorkPane({
           onContinueCliSession={work.continueCliSession}
           onShowDraftKind={work.showDraftKind}
           onStopRunningSession={(session) => {
-            if (session.ptyId) void work.closePtySession(session.ptyId);
+            if (!session.ptyId) return;
+            void work.closePtySession(session.ptyId).catch((error) => {
+              console.warn("[LaneWorkPane] Failed to stop running session", error);
+            });
           }}
           suppressDraftLaunchNavigation
           closingPtyIds={work.closingPtyIds}

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -518,6 +518,7 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
   const createBaseSourceRef = useRef<NewLaneBaseSource>(DEFAULT_NEW_LANE_BASE_SOURCE);
   const createBaseSourceUserPickedRef = useRef(false);
   const createBaseBranchesLoadSeqRef = useRef(0);
+  const createBaseSourceSaveInFlightRef = useRef(false);
   const [createBaseBranch, setCreateBaseBranch] = useState("");
   const [createImportBranch, setCreateImportBranch] = useState("");
   const [createChildBaseBranch, setCreateChildBaseBranch] = useState("");
@@ -2806,6 +2807,40 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     setCreateBaseBranch(v);
   }, []);
 
+  const persistCreateBaseSourceConfig = useCallback(() => {
+    if (createBaseSourceSaveInFlightRef.current) return;
+    createBaseSourceSaveInFlightRef.current = true;
+    let lastSavedSource: NewLaneBaseSource | null = null;
+
+    void (async () => {
+      try {
+        while (lastSavedSource !== createBaseSourceRef.current) {
+          const source: NewLaneBaseSource = createBaseSourceRef.current;
+          const snapshot = await window.ade.projectConfig.get();
+          const currentGit = snapshot.local.git ?? {};
+          await window.ade.projectConfig.save({
+            shared: snapshot.shared,
+            local: {
+              ...snapshot.local,
+              git: {
+                ...currentGit,
+                newLaneBaseSource: source,
+              },
+            },
+          });
+          lastSavedSource = source;
+        }
+      } catch (saveError) {
+        setCreateError(saveError instanceof Error ? saveError.message : String(saveError));
+      } finally {
+        createBaseSourceSaveInFlightRef.current = false;
+        if (lastSavedSource !== createBaseSourceRef.current) {
+          persistCreateBaseSourceConfig();
+        }
+      }
+    })();
+  }, []);
+
   const handleSetCreateBaseSource = useCallback((source: NewLaneBaseSource) => {
     createBaseSourceRef.current = source;
     createBaseSourceUserPickedRef.current = true;
@@ -2842,24 +2877,8 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     } else {
       setCreateBranchesLoading(false);
     }
-    window.ade.projectConfig.get()
-      .then((snapshot) => {
-        const currentGit = snapshot.local.git ?? {};
-        return window.ade.projectConfig.save({
-          shared: snapshot.shared,
-          local: {
-            ...snapshot.local,
-            git: {
-              ...currentGit,
-              newLaneBaseSource: source,
-            },
-          },
-        });
-      })
-      .catch((saveError) => {
-        setCreateError(saveError instanceof Error ? saveError.message : String(saveError));
-      });
-  }, [lanes]);
+    persistCreateBaseSourceConfig();
+  }, [lanes, persistCreateBaseSourceConfig]);
 
   const handleSetCreateLinearIssue = useCallback((issue: LaneLinearIssue | null) => {
     setCreateSelectedLinearIssue(issue);

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -519,6 +519,7 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
   const createBaseSourceUserPickedRef = useRef(false);
   const createBaseBranchesLoadSeqRef = useRef(0);
   const createBaseSourceSaveInFlightRef = useRef(false);
+  const createBaseSourceSavePendingRef = useRef<NewLaneBaseSource | null>(null);
   const [createBaseBranch, setCreateBaseBranch] = useState("");
   const [createImportBranch, setCreateImportBranch] = useState("");
   const [createChildBaseBranch, setCreateChildBaseBranch] = useState("");
@@ -2809,13 +2810,14 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
 
   const persistCreateBaseSourceConfig = useCallback(() => {
     if (createBaseSourceSaveInFlightRef.current) return;
+    if (!createBaseSourceSavePendingRef.current) return;
     createBaseSourceSaveInFlightRef.current = true;
-    let lastSavedSource: NewLaneBaseSource | null = null;
+    let failed = false;
 
     void (async () => {
       try {
-        while (lastSavedSource !== createBaseSourceRef.current) {
-          const source: NewLaneBaseSource = createBaseSourceRef.current;
+        while (createBaseSourceSavePendingRef.current) {
+          const source: NewLaneBaseSource = createBaseSourceSavePendingRef.current;
           const snapshot = await window.ade.projectConfig.get();
           const currentGit = snapshot.local.git ?? {};
           await window.ade.projectConfig.save({
@@ -2828,13 +2830,16 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
               },
             },
           });
-          lastSavedSource = source;
+          if (createBaseSourceSavePendingRef.current === source) {
+            createBaseSourceSavePendingRef.current = null;
+          }
         }
       } catch (saveError) {
+        failed = true;
         setCreateError(saveError instanceof Error ? saveError.message : String(saveError));
       } finally {
         createBaseSourceSaveInFlightRef.current = false;
-        if (lastSavedSource !== createBaseSourceRef.current) {
+        if (!failed && createBaseSourceSavePendingRef.current) {
           persistCreateBaseSourceConfig();
         }
       }
@@ -2877,6 +2882,7 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     } else {
       setCreateBranchesLoading(false);
     }
+    createBaseSourceSavePendingRef.current = source;
     persistCreateBaseSourceConfig();
   }, [lanes, persistCreateBaseSourceConfig]);
 

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -35,6 +35,13 @@ import { getLaneAccent } from "./laneColorPalette";
 import { LaneRebaseBanner } from "./LaneRebaseBanner";
 import { LinearIssueBadge } from "./LinearIssueBadge";
 import { LanePrBadgePopover } from "./LanePrBadgePopover";
+import {
+  DEFAULT_NEW_LANE_BASE_SOURCE,
+  effectiveNewLaneBaseSource,
+  fetchNewLaneBaseBranches,
+  listNewLaneBaseOptions,
+  selectDefaultNewLaneBaseRef,
+} from "./newLaneBaseSource";
 import { HelpChip } from "../onboarding/HelpChip";
 import { useOnboardingStore } from "../../state/onboardingStore";
 import { useDialogBus } from "../../lib/useDialogBus";
@@ -98,7 +105,8 @@ import type {
   RebaseScope,
   IntegrationProposal,
   LaneDeleteProgress,
-  LaneTemplate
+  LaneTemplate,
+  NewLaneBaseSource,
 } from "../../../shared/types";
 import { eventMatchesBinding, getEffectiveBinding } from "../../lib/keybindings";
 import { SmartTooltip } from "../ui/SmartTooltip";
@@ -506,6 +514,10 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
   const [createVmStatusLoading, setCreateVmStatusLoading] = useState(false);
   const [createVmStatusError, setCreateVmStatusError] = useState<string | null>(null);
   const [createVmRuntimeAuthConfirmed, setCreateVmRuntimeAuthConfirmed] = useState(readMacosVmRuntimeAuthConfirmed);
+  const [createBaseSource, setCreateBaseSource] = useState<NewLaneBaseSource>(DEFAULT_NEW_LANE_BASE_SOURCE);
+  const createBaseSourceRef = useRef<NewLaneBaseSource>(DEFAULT_NEW_LANE_BASE_SOURCE);
+  const createBaseSourceUserPickedRef = useRef(false);
+  const createBaseBranchesLoadSeqRef = useRef(0);
   const [createBaseBranch, setCreateBaseBranch] = useState("");
   const [createImportBranch, setCreateImportBranch] = useState("");
   const [createChildBaseBranch, setCreateChildBaseBranch] = useState("");
@@ -2225,6 +2237,7 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
   const resetCreateDialogState = useCallback(() => {
     createEnvInitLaneIdRef.current = null;
     createBaseBranchUserPickedRef.current = false;
+    createBaseBranchesLoadSeqRef.current += 1;
     setLaneCreated(false);
     setCreateLaneName("");
     setCreateParentLaneId("");
@@ -2259,6 +2272,9 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     setCreateVmStatusLoading(false);
     setCreateVmRuntimeAuthConfirmed(readMacosVmRuntimeAuthConfirmed());
     setCreateVmSetupDetail(null);
+    setCreateBaseSource(DEFAULT_NEW_LANE_BASE_SOURCE);
+    createBaseSourceRef.current = DEFAULT_NEW_LANE_BASE_SOURCE;
+    createBaseSourceUserPickedRef.current = false;
     setCreateBaseBranch("");
     setCreateImportBranch("");
     setCreateChildBaseBranch("");
@@ -2273,25 +2289,41 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     createBaseBranchUserPickedRef.current = false;
     const primary = lanes.find((l) => l.laneType === "primary");
     if (primary) {
-      // Fetch remotes first so remote-only branches (pushed from other machines) appear.
+      const loadSeq = ++createBaseBranchesLoadSeqRef.current;
       setCreateBranchesLoading(true);
-      window.ade.git.fetch({ laneId: primary.id })
-        .catch(() => {})
-        .then(() => window.ade.git.listBranches({ laneId: primary.id }))
-        .then((branches) => {
-          if (!branches) return;
+      window.ade.projectConfig.get()
+        .catch(() => null)
+        .then(async (snapshot) => {
+          const baseSource = effectiveNewLaneBaseSource(snapshot);
+          const selectedBaseSource = createBaseSourceUserPickedRef.current
+            ? createBaseSourceRef.current
+            : baseSource;
+          if (!createBaseSourceUserPickedRef.current) {
+            createBaseSourceRef.current = baseSource;
+            setCreateBaseSource(baseSource);
+          }
+          const branches = await fetchNewLaneBaseBranches({
+            source: selectedBaseSource,
+            fetchRemoteBranches: () => window.ade.git.fetch({ laneId: primary.id }),
+            listBranches: () => window.ade.git.listBranches({ laneId: primary.id }),
+          });
+          if (createBaseBranchesLoadSeqRef.current !== loadSeq) return;
           setCreateBranches(branches);
-          // Default new root lanes to the project's base branch. Users can still
-          // pick the current primary checkout explicitly when they want that.
           if (!createBaseBranchUserPickedRef.current) {
-            const defaultBranch = branches.find((b) => !b.isRemote && b.name === primary.baseRef)
-              ?? branches.find((b) => b.isCurrent && !b.isRemote)
-              ?? branches.find((b) => !b.isRemote);
-            if (defaultBranch) setCreateBaseBranch(defaultBranch.name);
+            const defaultBaseRef = selectDefaultNewLaneBaseRef({
+              branches,
+              source: createBaseSourceUserPickedRef.current
+                ? createBaseSourceRef.current
+                : selectedBaseSource,
+              primaryBaseRef: primary.baseRef,
+            });
+            if (defaultBaseRef) setCreateBaseBranch(defaultBaseRef);
           }
         })
         .catch(() => {})
-        .finally(() => setCreateBranchesLoading(false));
+        .finally(() => {
+          if (createBaseBranchesLoadSeqRef.current === loadSeq) setCreateBranchesLoading(false);
+        });
 
       // Capture git user.name so the picker can resolve `mine` / `author:me`.
       window.ade.git.getUserIdentity({ laneId: primary.id })
@@ -2774,6 +2806,61 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     setCreateBaseBranch(v);
   }, []);
 
+  const handleSetCreateBaseSource = useCallback((source: NewLaneBaseSource) => {
+    createBaseSourceRef.current = source;
+    createBaseSourceUserPickedRef.current = true;
+    createBaseBranchUserPickedRef.current = false;
+    const loadSeq = ++createBaseBranchesLoadSeqRef.current;
+    setCreateBaseSource(source);
+    setCreateBaseBranch("");
+    setCreateBranches([]);
+    const primary = lanes.find((l) => l.laneType === "primary");
+    if (primary) {
+      setCreateBranchesLoading(true);
+      fetchNewLaneBaseBranches({
+        source,
+        fetchRemoteBranches: () => window.ade.git.fetch({ laneId: primary.id }),
+        listBranches: () => window.ade.git.listBranches({ laneId: primary.id }),
+        })
+        .then((branches) => {
+          if (createBaseSourceRef.current !== source || createBaseBranchesLoadSeqRef.current !== loadSeq) return;
+          setCreateBranches(branches);
+          if (!createBaseBranchUserPickedRef.current) {
+            setCreateBaseBranch(selectDefaultNewLaneBaseRef({
+              branches,
+              source,
+              primaryBaseRef: primary.baseRef,
+            }));
+          }
+        })
+        .catch(() => {})
+        .finally(() => {
+          if (createBaseSourceRef.current === source && createBaseBranchesLoadSeqRef.current === loadSeq) {
+            setCreateBranchesLoading(false);
+          }
+        });
+    } else {
+      setCreateBranchesLoading(false);
+    }
+    window.ade.projectConfig.get()
+      .then((snapshot) => {
+        const currentGit = snapshot.local.git ?? {};
+        return window.ade.projectConfig.save({
+          shared: snapshot.shared,
+          local: {
+            ...snapshot.local,
+            git: {
+              ...currentGit,
+              newLaneBaseSource: source,
+            },
+          },
+        });
+      })
+      .catch((saveError) => {
+        setCreateError(saveError instanceof Error ? saveError.message : String(saveError));
+      });
+  }, [lanes]);
+
   const handleSetCreateLinearIssue = useCallback((issue: LaneLinearIssue | null) => {
     setCreateSelectedLinearIssue(issue);
     if (!issue) return;
@@ -2844,7 +2931,16 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     const name = createLaneName.trim();
     if (!name || createBusy) return;
     if (createMode === "child" && !createParentLaneId) return;
-    if (createMode === "primary" && !createBaseBranch) return;
+    if (createMode === "primary") {
+      const validBaseBranch = listNewLaneBaseOptions(createBranches, createBaseSource)
+        .some((option) => option.ref === createBaseBranch);
+      if (createBranchesLoading || !validBaseBranch) {
+        setCreateError(createBranchesLoading
+          ? "Still loading base branches. Try again in a moment."
+          : "Choose a valid base branch for the selected source.");
+        return;
+      }
+    }
     if (createMode === "existing" && !createImportBranch) return;
     if (createSelectedLinearIssue && createMode === "existing") {
       setCreateError("Detach the Linear issue before importing an existing branch.");
@@ -2986,12 +3082,16 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     createLaneName,
     createMode,
     createParentLaneId,
+    createBaseSource,
     createBaseBranch,
+    createBranches,
+    createBranchesLoading,
     createImportBranch,
     createChildBaseBranch,
     lanes,
     createBusy,
     createRuntimePlacement,
+    createVmRuntimeAuthConfirmed,
     createVmRuntimeAvailable,
     createVmRuntimeUnavailableReason,
     navigate,
@@ -4399,6 +4499,8 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
         setCreateMode={setCreateMode}
         createParentLaneId={createParentLaneId}
         setCreateParentLaneId={setCreateParentLaneId}
+        createBaseSource={createBaseSource}
+        setCreateBaseSource={handleSetCreateBaseSource}
         createBaseBranch={createBaseBranch}
         setCreateBaseBranch={handleSetCreateBaseBranch}
         createImportBranch={createImportBranch}

--- a/apps/desktop/src/renderer/components/lanes/newLaneBaseSource.test.ts
+++ b/apps/desktop/src/renderer/components/lanes/newLaneBaseSource.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  effectiveNewLaneBaseSource,
+  fetchNewLaneBaseBranches,
+  listNewLaneBaseOptions,
+  remoteNewLaneBaseFallback,
+  selectDefaultNewLaneBaseRef,
+} from "./newLaneBaseSource";
+import type { LaneBranchOption } from "./laneUtils";
+
+const branches: LaneBranchOption[] = [
+  { name: "main", isCurrent: true, isRemote: false, upstream: "origin/main" },
+  { name: "feature/local", isCurrent: false, isRemote: false, upstream: null },
+  { name: "origin/release", isCurrent: false, isRemote: true, upstream: null },
+];
+
+describe("newLaneBaseSource", () => {
+  it("defaults the effective setting to remote", () => {
+    expect(effectiveNewLaneBaseSource(null)).toBe("remote");
+    expect(effectiveNewLaneBaseSource({ local: {}, effective: { git: { autoRebaseOnHeadChange: false, newLaneBaseSource: "local" } } } as any)).toBe("local");
+  });
+
+  it("selects the upstream ref when remote bases are enabled", () => {
+    expect(selectDefaultNewLaneBaseRef({
+      branches,
+      source: "remote",
+      primaryBaseRef: "main",
+    })).toBe("origin/main");
+  });
+
+  it("prefers a remote-only primary base before the current branch upstream", () => {
+    expect(selectDefaultNewLaneBaseRef({
+      branches,
+      source: "remote",
+      primaryBaseRef: "release",
+    })).toBe("origin/release");
+  });
+
+  it("uses a matching remote ref when the local primary has no upstream", () => {
+    expect(selectDefaultNewLaneBaseRef({
+      branches: [
+        { name: "main", isCurrent: true, isRemote: false, upstream: null },
+        { name: "origin/main", isCurrent: false, isRemote: true, upstream: null },
+      ],
+      source: "remote",
+      primaryBaseRef: "main",
+    })).toBe("origin/main");
+  });
+
+  it("does not synthesize a remote ref for local-only repositories", () => {
+    expect(selectDefaultNewLaneBaseRef({
+      branches: [
+        { name: "main", isCurrent: true, isRemote: false, upstream: null },
+      ],
+      source: "remote",
+      primaryBaseRef: "main",
+    })).toBe("");
+  });
+
+  it("preserves a discovered non-origin remote primary base", () => {
+    expect(selectDefaultNewLaneBaseRef({
+      branches: [
+        ...branches,
+        { name: "upstream/release", isCurrent: false, isRemote: true, upstream: null },
+      ],
+      source: "remote",
+      primaryBaseRef: "upstream/release",
+    })).toBe("upstream/release");
+  });
+
+  it("selects the local branch when local bases are enabled", () => {
+    expect(selectDefaultNewLaneBaseRef({
+      branches,
+      source: "local",
+      primaryBaseRef: "main",
+    })).toBe("main");
+  });
+
+  it("lists local branch upstreams plus remote-only branches for remote bases", () => {
+    expect(listNewLaneBaseOptions(branches, "remote").map((option) => option.ref)).toEqual([
+      "origin/main",
+      "origin/release",
+    ]);
+  });
+
+  it("builds a remote fallback from the primary base ref without rewriting existing remote refs", () => {
+    expect(remoteNewLaneBaseFallback("main")).toBe("origin/main");
+    expect(remoteNewLaneBaseFallback("refs/heads/feature/x")).toBe("origin/feature/x");
+    expect(remoteNewLaneBaseFallback("refs/remotes/origin/main")).toBe("origin/main");
+    expect(remoteNewLaneBaseFallback("origin/main")).toBe("origin/main");
+    expect(remoteNewLaneBaseFallback("0123456789abcdef0123456789abcdef01234567")).toBe("");
+  });
+
+  it("lists branches without fetching when local bases are enabled", async () => {
+    const fetchRemoteBranches = vi.fn(() => new Promise<void>(() => {}));
+    const listBranches = vi.fn().mockResolvedValue(branches);
+
+    await expect(fetchNewLaneBaseBranches({
+      source: "local",
+      fetchRemoteBranches,
+      listBranches,
+      fetchTimeoutMs: 1,
+    })).resolves.toBe(branches);
+
+    expect(fetchRemoteBranches).not.toHaveBeenCalled();
+    expect(listBranches).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds remote fetch before listing branches", async () => {
+    const fetchRemoteBranches = vi.fn(() => new Promise<void>(() => {}));
+    const listBranches = vi.fn().mockResolvedValue(branches);
+
+    await expect(fetchNewLaneBaseBranches({
+      source: "remote",
+      fetchRemoteBranches,
+      listBranches,
+      fetchTimeoutMs: 1,
+    })).resolves.toBe(branches);
+
+    expect(fetchRemoteBranches).toHaveBeenCalledTimes(1);
+    expect(listBranches).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/renderer/components/lanes/newLaneBaseSource.ts
+++ b/apps/desktop/src/renderer/components/lanes/newLaneBaseSource.ts
@@ -1,0 +1,140 @@
+import type { NewLaneBaseSource, ProjectConfigSnapshot } from "../../../shared/types";
+import type { LaneBranchOption } from "./laneUtils";
+
+export const DEFAULT_NEW_LANE_BASE_SOURCE: NewLaneBaseSource = "remote";
+export const DEFAULT_NEW_LANE_REMOTE_FETCH_TIMEOUT_MS = 4_000;
+
+export type NewLaneBaseOption = {
+  ref: string;
+  label: string;
+  source: NewLaneBaseSource;
+  isCurrent?: boolean;
+};
+
+export function effectiveNewLaneBaseSource(snapshot: ProjectConfigSnapshot | null | undefined): NewLaneBaseSource {
+  const value = snapshot?.local.git?.newLaneBaseSource
+    ?? snapshot?.effective.git?.newLaneBaseSource
+    ?? DEFAULT_NEW_LANE_BASE_SOURCE;
+  return value === "local" ? "local" : "remote";
+}
+
+function remoteRefForLocalBranch(
+  branch: LaneBranchOption,
+  branches: LaneBranchOption[],
+): string | null {
+  if (branch.isRemote) return branch.name;
+  if (branch.upstream?.trim()) return branch.upstream.trim();
+  const originRef = `origin/${branch.name}`;
+  if (branches.some((candidate) => candidate.isRemote && candidate.name === originRef)) {
+    return originRef;
+  }
+  return null;
+}
+
+export function listNewLaneBaseOptions(
+  branches: LaneBranchOption[],
+  source: NewLaneBaseSource,
+): NewLaneBaseOption[] {
+  if (source === "local") {
+    return branches
+      .filter((branch) => !branch.isRemote)
+      .map((branch) => ({
+        ref: branch.name,
+        label: `${branch.name}${branch.isCurrent ? " (current)" : ""}`,
+        source,
+        isCurrent: branch.isCurrent,
+      }));
+  }
+
+  const out: NewLaneBaseOption[] = [];
+  const seen = new Set<string>();
+  const add = (ref: string, label = ref, isCurrent = false): void => {
+    const trimmed = ref.trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    out.push({ ref: trimmed, label, source, isCurrent });
+  };
+
+  for (const branch of branches.filter((entry) => !entry.isRemote)) {
+    const ref = remoteRefForLocalBranch(branch, branches);
+    if (ref) add(ref, `${ref}${branch.isCurrent ? " (tracks current)" : ""}`, branch.isCurrent);
+  }
+  for (const branch of branches.filter((entry) => entry.isRemote)) {
+    add(branch.name);
+  }
+  return out;
+}
+
+export function selectDefaultNewLaneBaseRef(args: {
+  branches: LaneBranchOption[];
+  source: NewLaneBaseSource;
+  primaryBaseRef?: string | null;
+}): string {
+  const baseRef = args.primaryBaseRef?.trim() ?? "";
+  const localBranches = args.branches.filter((branch) => !branch.isRemote);
+  const preferredBaseLocal = baseRef
+    ? localBranches.find((branch) => branch.name === baseRef)
+    : null;
+  const currentLocal = localBranches.find((branch) => branch.isCurrent) ?? null;
+  const fallbackLocal = currentLocal ?? localBranches[0] ?? null;
+
+  if (args.source === "remote") {
+    if (preferredBaseLocal) {
+      const remoteRef = remoteRefForLocalBranch(preferredBaseLocal, args.branches);
+      if (remoteRef) return remoteRef;
+    }
+    const remoteQualifiedBase = baseRef.startsWith("refs/remotes/")
+      ? baseRef.slice("refs/remotes/".length)
+      : baseRef;
+    if (
+      remoteQualifiedBase
+      && args.branches.some((branch) => branch.isRemote && branch.name === remoteQualifiedBase)
+    ) {
+      return remoteQualifiedBase;
+    }
+    const originBase = remoteNewLaneBaseFallback(baseRef);
+    if (originBase && args.branches.some((branch) => branch.isRemote && branch.name === originBase)) {
+      return originBase;
+    }
+    if (fallbackLocal) {
+      const remoteRef = remoteRefForLocalBranch(fallbackLocal, args.branches);
+      if (remoteRef) return remoteRef;
+    }
+    return listNewLaneBaseOptions(args.branches, "remote")[0]?.ref ?? "";
+  }
+
+  const preferredLocal = preferredBaseLocal ?? fallbackLocal;
+  return preferredLocal?.name ?? "";
+}
+
+export function remoteNewLaneBaseFallback(primaryBaseRef: string | null | undefined): string {
+  const trimmed = primaryBaseRef?.trim() ?? "";
+  if (!trimmed) return "";
+  if (trimmed.startsWith("refs/remotes/")) return trimmed.slice("refs/remotes/".length);
+  if (trimmed.startsWith("origin/")) return trimmed;
+  if (trimmed.startsWith("refs/heads/")) return `origin/${trimmed.slice("refs/heads/".length)}`;
+  if (/^[0-9a-f]{40}$/i.test(trimmed)) return "";
+  return `origin/${trimmed}`;
+}
+
+export async function fetchNewLaneBaseBranches(args: {
+  source: NewLaneBaseSource;
+  fetchRemoteBranches: () => Promise<unknown>;
+  listBranches: () => Promise<LaneBranchOption[]>;
+  fetchTimeoutMs?: number;
+}): Promise<LaneBranchOption[]> {
+  if (args.source === "remote") {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    try {
+      await Promise.race([
+        args.fetchRemoteBranches().catch(() => {}),
+        new Promise<void>((resolve) => {
+          timeoutId = setTimeout(resolve, args.fetchTimeoutMs ?? DEFAULT_NEW_LANE_REMOTE_FETCH_TIMEOUT_MS);
+        }),
+      ]);
+    } finally {
+      if (timeoutId) clearTimeout(timeoutId);
+    }
+  }
+  return args.listBranches().catch(() => []);
+}

--- a/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.test.ts
@@ -469,6 +469,79 @@ describe("useLaneWorkSessions — refresh-before-focus ordering", () => {
     expect(result.current.sessions.map((session) => session.id)).toContain("new-pty-session");
   });
 
+  it("keeps a stopped lane runtime closed when a stale refresh returns the old running row", async () => {
+    const runningSession = {
+      ...makeSession("session-stop", "lane-1", "Running Codex"),
+      ptyId: "pty-stop",
+      toolType: "codex",
+      runtimeState: "running",
+    } as any;
+    listSessionsCachedMock
+      .mockResolvedValueOnce([runningSession])
+      .mockResolvedValueOnce([runningSession]);
+
+    const { result } = renderHook(() => useLaneWorkSessions("lane-1"));
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    expect(result.current.sessions[0]?.ptyId).toBe("pty-stop");
+
+    await act(async () => {
+      await result.current.closePtySession("pty-stop");
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect((window as any).ade.pty.dispose).toHaveBeenCalledWith({
+      ptyId: "pty-stop",
+      sessionId: "session-stop",
+    });
+    expect(result.current.sessions[0]).toMatchObject({
+      id: "session-stop",
+      ptyId: null,
+      status: "disposed",
+      runtimeState: "killed",
+      exitCode: null,
+    });
+  });
+
+  it("restores a lane runtime row when dispose reports that a peer still owns it", async () => {
+    const runningSession = {
+      ...makeSession("session-peer", "lane-1", "Running Codex"),
+      ptyId: "pty-peer",
+      toolType: "codex",
+      runtimeState: "running",
+    } as any;
+    listSessionsCachedMock
+      .mockResolvedValueOnce([runningSession])
+      .mockResolvedValueOnce([runningSession]);
+    (window as any).ade.pty.dispose.mockResolvedValueOnce({
+      disposed: false,
+      reason: "owned-by-peer",
+    });
+
+    const { result } = renderHook(() => useLaneWorkSessions("lane-1"));
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    expect(result.current.sessions[0]?.ptyId).toBe("pty-peer");
+
+    await act(async () => {
+      await result.current.closePtySession("pty-peer");
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(result.current.sessions[0]).toMatchObject({
+      id: "session-peer",
+      ptyId: "pty-peer",
+      status: "running",
+      runtimeState: "running",
+    });
+  });
+
   it("launchPtySession: opens immediately when another refresh is already running", async () => {
     const callOrder: string[] = [];
     let refreshCallCount = 0;

--- a/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.test.ts
@@ -542,6 +542,43 @@ describe("useLaneWorkSessions — refresh-before-focus ordering", () => {
     });
   });
 
+  it("keeps a lane runtime row stopped when dispose reports the pty is already gone", async () => {
+    const runningSession = {
+      ...makeSession("session-missing", "lane-1", "Running Codex"),
+      ptyId: "pty-missing",
+      toolType: "codex",
+      runtimeState: "running",
+    } as any;
+    listSessionsCachedMock
+      .mockResolvedValueOnce([runningSession])
+      .mockRejectedValueOnce(new Error("refresh failed"));
+    (window as any).ade.pty.dispose.mockResolvedValueOnce({
+      disposed: false,
+      reason: "missing",
+    });
+
+    const { result } = renderHook(() => useLaneWorkSessions("lane-1"));
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    expect(result.current.sessions[0]?.ptyId).toBe("pty-missing");
+
+    await act(async () => {
+      await result.current.closePtySession("pty-missing");
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(result.current.sessions[0]).toMatchObject({
+      id: "session-missing",
+      ptyId: null,
+      status: "disposed",
+      runtimeState: "killed",
+      exitCode: null,
+    });
+  });
+
   it("launchPtySession: opens immediately when another refresh is already running", async () => {
     const callOrder: string[] = [];
     let refreshCallCount = 0;

--- a/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.test.ts
@@ -579,6 +579,40 @@ describe("useLaneWorkSessions — refresh-before-focus ordering", () => {
     });
   });
 
+  it("restores a lane runtime row when dispose reports a session mismatch", async () => {
+    const runningSession = {
+      ...makeSession("session-mismatch", "lane-1", "Running Codex"),
+      ptyId: "pty-stale",
+      toolType: "codex",
+      runtimeState: "running",
+    } as any;
+    listSessionsCachedMock
+      .mockResolvedValueOnce([runningSession])
+      .mockRejectedValueOnce(new Error("refresh failed"));
+    (window as any).ade.pty.dispose.mockResolvedValueOnce({
+      disposed: false,
+      reason: "session-mismatch",
+    });
+
+    const { result } = renderHook(() => useLaneWorkSessions("lane-1"));
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    await act(async () => {
+      await result.current.closePtySession("pty-stale");
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(result.current.sessions[0]).toMatchObject({
+      id: "session-mismatch",
+      ptyId: "pty-stale",
+      status: "running",
+      runtimeState: "running",
+    });
+  });
+
   it("launchPtySession: opens immediately when another refresh is already running", async () => {
     const callOrder: string[] = [];
     let refreshCallCount = 0;

--- a/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.test.ts
@@ -515,7 +515,7 @@ describe("useLaneWorkSessions — refresh-before-focus ordering", () => {
     } as any;
     listSessionsCachedMock
       .mockResolvedValueOnce([runningSession])
-      .mockResolvedValueOnce([runningSession]);
+      .mockRejectedValueOnce(new Error("refresh failed"));
     (window as any).ade.pty.dispose.mockResolvedValueOnce({
       disposed: false,
       reason: "owned-by-peer",

--- a/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
@@ -803,18 +803,26 @@ export function useLaneWorkSessions(laneId: string | null) {
           : session,
       ),
     );
+    const rememberStoppedRuntime = () => {
+      if (!sessionId) return;
+      stoppedRuntimeSessionsRef.current.set(sessionId, {
+        ptyId,
+        endedAt,
+        expiresAtMs: Date.now() + STOPPED_RUNTIME_GUARD_TTL_MS,
+      });
+    };
     let disposeError: unknown = null;
     try {
       const result = await window.ade.pty.dispose({ ptyId, ...(sessionId ? { sessionId } : {}) });
       if (result?.disposed === false) {
-        if (sessionId) stoppedRuntimeSessionsRef.current.delete(sessionId);
-        restorePreviousSessions();
-      } else if (sessionId) {
-        stoppedRuntimeSessionsRef.current.set(sessionId, {
-          ptyId,
-          endedAt,
-          expiresAtMs: Date.now() + STOPPED_RUNTIME_GUARD_TTL_MS,
-        });
+        if (result.reason === "owned-by-peer") {
+          if (sessionId) stoppedRuntimeSessionsRef.current.delete(sessionId);
+          restorePreviousSessions();
+        } else {
+          rememberStoppedRuntime();
+        }
+      } else {
+        rememberStoppedRuntime();
       }
     } catch (error) {
       disposeError = error;

--- a/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
@@ -38,6 +38,7 @@ const EMPTY_WORK_STATE: WorkProjectViewState = {
 
 const laneSessionsCacheByScope = new Map<string, TerminalSessionSummary[]>();
 const OPTIMISTIC_PTY_SESSION_TTL_MS = 2 * 60 * 1000;
+const STOPPED_RUNTIME_GUARD_TTL_MS = 12_000;
 
 export function __clearLaneWorkSessionCacheForTests(): void {
   laneSessionsCacheByScope.clear();
@@ -56,6 +57,12 @@ type QueuedRefresh = {
 type PendingOptimisticSession = {
   session: TerminalSessionSummary;
   createdAtMs: number;
+};
+
+type StoppedRuntimeSession = {
+  ptyId: string;
+  endedAt: string;
+  expiresAtMs: number;
 };
 
 function compareSessionsByStartedAtDesc(left: TerminalSessionSummary, right: TerminalSessionSummary): number {
@@ -139,6 +146,8 @@ export function useLaneWorkSessions(laneId: string | null) {
   const scopeKeyRef = useRef("");
   const sessionIdsRef = useRef<Set<string>>(new Set());
   const pendingOptimisticSessionsRef = useRef<Map<string, PendingOptimisticSession>>(new Map());
+  const sessionsRef = useRef<TerminalSessionSummary[]>([]);
+  const stoppedRuntimeSessionsRef = useRef<Map<string, StoppedRuntimeSession>>(new Map());
 
   const currentLane = useMemo(
     () => (laneId ? lanes.find((lane) => lane.id === laneId) ?? null : null),
@@ -247,6 +256,37 @@ export function useLaneWorkSessions(laneId: string | null) {
           }
           rows.sort(compareSessionsByStartedAtDesc);
         }
+        const stoppedRuntimeSessions = stoppedRuntimeSessionsRef.current;
+        if (stoppedRuntimeSessions.size > 0) {
+          const now = Date.now();
+          for (const [sessionId, stopped] of [...stoppedRuntimeSessions.entries()]) {
+            if (stopped.expiresAtMs <= now) stoppedRuntimeSessions.delete(sessionId);
+          }
+          if (stoppedRuntimeSessions.size > 0) {
+            for (let index = 0; index < rows.length; index += 1) {
+              const row = rows[index];
+              if (!row) continue;
+              const stopped = stoppedRuntimeSessions.get(row.id);
+              if (!stopped) continue;
+              if (row.status !== "running") {
+                stoppedRuntimeSessions.delete(row.id);
+                continue;
+              }
+              if (row.ptyId && row.ptyId !== stopped.ptyId) {
+                stoppedRuntimeSessions.delete(row.id);
+                continue;
+              }
+              rows[index] = {
+                ...row,
+                ptyId: null,
+                status: "disposed",
+                runtimeState: "killed",
+                endedAt: row.endedAt ?? stopped.endedAt,
+                exitCode: null,
+              };
+            }
+          }
+        }
         const nextSessions = rows;
         setSessions(nextSessions);
         if (requestedScopeKey) {
@@ -318,6 +358,7 @@ export function useLaneWorkSessions(laneId: string | null) {
 
   useEffect(() => {
     sessionIdsRef.current = new Set(sessions.map((session) => session.id));
+    sessionsRef.current = sessions;
   }, [sessions]);
 
   const upsertSessionSnapshot = useCallback((session: TerminalSessionSummary) => {
@@ -731,19 +772,46 @@ export function useLaneWorkSessions(laneId: string | null) {
   }, [focusSession, openSessionTab, refresh, selectLane, upsertSessionSnapshot]);
 
   const closePtySession = useCallback(async (ptyId: string) => {
+    const sessionId = sessionsRef.current.find((session) => session.ptyId === ptyId)?.id ?? null;
+    const endedAt = new Date().toISOString();
     setClosingPtyIds((prev) => {
       const next = new Set(prev);
       next.add(ptyId);
       return next;
     });
+    invalidateSessionListCache();
+    setSessions((prev) =>
+      prev.map((session) =>
+        session.ptyId === ptyId || (sessionId != null && session.id === sessionId)
+          ? {
+              ...session,
+              ptyId: null,
+              status: "disposed" as const,
+              runtimeState: "killed" as const,
+              endedAt,
+              exitCode: null,
+            }
+          : session,
+      ),
+    );
     try {
-      await window.ade.pty.dispose({ ptyId });
+      const result = await window.ade.pty.dispose({ ptyId, ...(sessionId ? { sessionId } : {}) });
+      if (result?.disposed === false) {
+        if (sessionId) stoppedRuntimeSessionsRef.current.delete(sessionId);
+      } else if (sessionId) {
+        stoppedRuntimeSessionsRef.current.set(sessionId, {
+          ptyId,
+          endedAt,
+          expiresAtMs: Date.now() + STOPPED_RUNTIME_GUARD_TTL_MS,
+        });
+      }
     } finally {
       setClosingPtyIds((prev) => {
         const next = new Set(prev);
         next.delete(ptyId);
         return next;
       });
+      invalidateSessionListCache();
       await refresh({ showLoading: false, force: true });
     }
   }, [refresh]);

--- a/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
@@ -772,7 +772,16 @@ export function useLaneWorkSessions(laneId: string | null) {
   }, [focusSession, openSessionTab, refresh, selectLane, upsertSessionSnapshot]);
 
   const closePtySession = useCallback(async (ptyId: string) => {
-    const sessionId = sessionsRef.current.find((session) => session.ptyId === ptyId)?.id ?? null;
+    const matchedSession = sessionsRef.current.find((session) => session.ptyId === ptyId) ?? null;
+    const sessionId = matchedSession?.id ?? null;
+    const previousSessions = sessionsRef.current.filter((session) =>
+      session.ptyId === ptyId || (sessionId != null && session.id === sessionId),
+    );
+    const restorePreviousSessions = () => {
+      if (previousSessions.length === 0) return;
+      const previousById = new Map(previousSessions.map((session) => [session.id, session] as const));
+      setSessions((prev) => prev.map((session) => previousById.get(session.id) ?? session));
+    };
     const endedAt = new Date().toISOString();
     setClosingPtyIds((prev) => {
       const next = new Set(prev);
@@ -794,10 +803,12 @@ export function useLaneWorkSessions(laneId: string | null) {
           : session,
       ),
     );
+    let disposeError: unknown = null;
     try {
       const result = await window.ade.pty.dispose({ ptyId, ...(sessionId ? { sessionId } : {}) });
       if (result?.disposed === false) {
         if (sessionId) stoppedRuntimeSessionsRef.current.delete(sessionId);
+        restorePreviousSessions();
       } else if (sessionId) {
         stoppedRuntimeSessionsRef.current.set(sessionId, {
           ptyId,
@@ -805,6 +816,10 @@ export function useLaneWorkSessions(laneId: string | null) {
           expiresAtMs: Date.now() + STOPPED_RUNTIME_GUARD_TTL_MS,
         });
       }
+    } catch (error) {
+      disposeError = error;
+      if (sessionId) stoppedRuntimeSessionsRef.current.delete(sessionId);
+      restorePreviousSessions();
     } finally {
       setClosingPtyIds((prev) => {
         const next = new Set(prev);
@@ -814,6 +829,7 @@ export function useLaneWorkSessions(laneId: string | null) {
       invalidateSessionListCache();
       await refresh({ showLoading: false, force: true });
     }
+    if (disposeError) throw disposeError;
   }, [refresh]);
 
   return {

--- a/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
@@ -815,7 +815,7 @@ export function useLaneWorkSessions(laneId: string | null) {
     try {
       const result = await window.ade.pty.dispose({ ptyId, ...(sessionId ? { sessionId } : {}) });
       if (result?.disposed === false) {
-        if (result.reason === "owned-by-peer") {
+        if (result.reason === "owned-by-peer" || result.reason === "session-mismatch") {
           if (sessionId) stoppedRuntimeSessionsRef.current.delete(sessionId);
           restorePreviousSessions();
         } else {

--- a/apps/desktop/src/renderer/components/settings/LaneBehaviorSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/LaneBehaviorSection.test.tsx
@@ -145,4 +145,34 @@ describe("LaneBehaviorSection", () => {
       newLaneBaseSource: "remote",
     });
   });
+
+  it("does not create a local base-source override when toggled back before saving", async () => {
+    const projectConfig = renderLaneBehaviorSection(makeSnapshot({
+      shared: { git: { newLaneBaseSource: "local" } },
+      local: { git: { autoRebaseOnHeadChange: false } },
+      effective: {
+        version: 1,
+        processes: [],
+        stackButtons: [],
+        processGroups: [],
+        testSuites: [],
+        laneOverlayPolicies: [],
+        automations: [],
+        git: {
+          autoRebaseOnHeadChange: false,
+          newLaneBaseSource: "local",
+        },
+      },
+    }));
+
+    await waitFor(() => expect(projectConfig.get).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole("button", { name: /Remote/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Local/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(projectConfig.save).toHaveBeenCalledTimes(1));
+    expect(projectConfig.save.mock.calls[0]?.[0].local.git).toEqual({
+      autoRebaseOnHeadChange: false,
+    });
+  });
 });

--- a/apps/desktop/src/renderer/components/settings/LaneBehaviorSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/LaneBehaviorSection.test.tsx
@@ -1,0 +1,148 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ProjectConfigSnapshot } from "../../../shared/types";
+import { LaneBehaviorSection } from "./LaneBehaviorSection";
+
+function makeSnapshot(overrides: Partial<ProjectConfigSnapshot> = {}): ProjectConfigSnapshot {
+  return {
+    shared: {},
+    local: {},
+    effective: {
+      version: 1,
+      processes: [],
+      stackButtons: [],
+      processGroups: [],
+      testSuites: [],
+      laneOverlayPolicies: [],
+      automations: [],
+      git: {
+        autoRebaseOnHeadChange: false,
+        newLaneBaseSource: "remote",
+      },
+    },
+    validation: { ok: true, issues: [] },
+    trust: {
+      sharedHash: "shared",
+      localHash: "local",
+      approvedSharedHash: "shared",
+      requiresSharedTrust: false,
+    },
+    paths: {
+      sharedPath: "/tmp/project/.ade/project.json",
+      localPath: "/tmp/project/.ade/project.local.json",
+    },
+    ...overrides,
+  };
+}
+
+function renderLaneBehaviorSection(snapshot: ProjectConfigSnapshot) {
+  const projectConfig = {
+    get: vi.fn().mockResolvedValue(snapshot),
+    save: vi.fn().mockResolvedValue(snapshot),
+  };
+  (window as any).ade = { projectConfig };
+
+  render(
+    <MemoryRouter>
+      <LaneBehaviorSection />
+    </MemoryRouter>,
+  );
+
+  return projectConfig;
+}
+
+afterEach(() => {
+  cleanup();
+  delete (window as any).ade;
+});
+
+describe("LaneBehaviorSection", () => {
+  it("does not create a local base-source override when saving unrelated settings", async () => {
+    const projectConfig = renderLaneBehaviorSection(makeSnapshot({
+      shared: { git: { newLaneBaseSource: "local" } },
+      local: { git: { autoRebaseOnHeadChange: false } },
+      effective: {
+        version: 1,
+        processes: [],
+        stackButtons: [],
+        processGroups: [],
+        testSuites: [],
+        laneOverlayPolicies: [],
+        automations: [],
+        git: {
+          autoRebaseOnHeadChange: false,
+          newLaneBaseSource: "local",
+        },
+      },
+    }));
+
+    await waitFor(() => expect(projectConfig.get).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(projectConfig.save).toHaveBeenCalledTimes(1));
+    expect(projectConfig.save.mock.calls[0]?.[0].local.git).toEqual({
+      autoRebaseOnHeadChange: false,
+    });
+  });
+
+  it("preserves an existing local base-source override when saving", async () => {
+    const projectConfig = renderLaneBehaviorSection(makeSnapshot({
+      local: { git: { autoRebaseOnHeadChange: false, newLaneBaseSource: "local" } },
+      effective: {
+        version: 1,
+        processes: [],
+        stackButtons: [],
+        processGroups: [],
+        testSuites: [],
+        laneOverlayPolicies: [],
+        automations: [],
+        git: {
+          autoRebaseOnHeadChange: false,
+          newLaneBaseSource: "local",
+        },
+      },
+    }));
+
+    await waitFor(() => expect(projectConfig.get).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(projectConfig.save).toHaveBeenCalledTimes(1));
+    expect(projectConfig.save.mock.calls[0]?.[0].local.git).toEqual({
+      autoRebaseOnHeadChange: false,
+      newLaneBaseSource: "local",
+    });
+  });
+
+  it("writes a local base-source override when the control changes", async () => {
+    const projectConfig = renderLaneBehaviorSection(makeSnapshot({
+      shared: { git: { newLaneBaseSource: "local" } },
+      local: { git: { autoRebaseOnHeadChange: false } },
+      effective: {
+        version: 1,
+        processes: [],
+        stackButtons: [],
+        processGroups: [],
+        testSuites: [],
+        laneOverlayPolicies: [],
+        automations: [],
+        git: {
+          autoRebaseOnHeadChange: false,
+          newLaneBaseSource: "local",
+        },
+      },
+    }));
+
+    await waitFor(() => expect(projectConfig.get).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole("button", { name: /Remote/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(projectConfig.save).toHaveBeenCalledTimes(1));
+    expect(projectConfig.save.mock.calls[0]?.[0].local.git).toEqual({
+      autoRebaseOnHeadChange: false,
+      newLaneBaseSource: "remote",
+    });
+  });
+});

--- a/apps/desktop/src/renderer/components/settings/LaneBehaviorSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/LaneBehaviorSection.tsx
@@ -36,6 +36,7 @@ export function LaneBehaviorSection() {
   const navigate = useNavigate();
   const [autoRebaseDraft, setAutoRebaseDraft] = useState(false);
   const [newLaneBaseSource, setNewLaneBaseSource] = useState<NewLaneBaseSource>(DEFAULT_NEW_LANE_BASE_SOURCE);
+  const [newLaneBaseSourceChanged, setNewLaneBaseSourceChanged] = useState(false);
   const [cleanup, setCleanup] = useState<LaneCleanupConfig>({});
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
@@ -51,6 +52,7 @@ export function LaneBehaviorSection() {
         : null;
     setAutoRebaseDraft(localAutoRebase ?? effectiveAutoRebase ?? false);
     setNewLaneBaseSource(effectiveNewLaneBaseSource(snapshot));
+    setNewLaneBaseSourceChanged(false);
 
     const effectiveCleanup = snapshot.effective.laneCleanup ?? {};
     const localCleanup = snapshot.local.laneCleanup ?? {};
@@ -68,15 +70,22 @@ export function LaneBehaviorSection() {
     try {
       const snapshot = await window.ade.projectConfig.get();
       const currentGit = isRecord(snapshot.local.git) ? snapshot.local.git : {};
+      const hasLocalNewLaneBaseSource =
+        currentGit.newLaneBaseSource === "local" || currentGit.newLaneBaseSource === "remote";
+      const nextGit = {
+        ...currentGit,
+        autoRebaseOnHeadChange: autoRebaseDraft,
+      };
+      if (newLaneBaseSourceChanged || hasLocalNewLaneBaseSource) {
+        nextGit.newLaneBaseSource = newLaneBaseSource;
+      } else {
+        delete nextGit.newLaneBaseSource;
+      }
       await window.ade.projectConfig.save({
         shared: snapshot.shared,
         local: {
           ...snapshot.local,
-          git: {
-            ...currentGit,
-            autoRebaseOnHeadChange: autoRebaseDraft,
-            newLaneBaseSource,
-          },
+          git: nextGit,
           laneCleanup: cleanup,
         },
       });
@@ -127,7 +136,11 @@ export function LaneBehaviorSection() {
                 <button
                   key={source}
                   type="button"
-                  onClick={() => setNewLaneBaseSource(source)}
+                  onClick={() => {
+                    if (source === newLaneBaseSource) return;
+                    setNewLaneBaseSource(source);
+                    setNewLaneBaseSourceChanged(true);
+                  }}
                   style={{
                     ...outlineButton({ height: 56, padding: "8px 10px", borderRadius: 8 }),
                     justifyContent: "flex-start",

--- a/apps/desktop/src/renderer/components/settings/LaneBehaviorSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/LaneBehaviorSection.tsx
@@ -36,7 +36,8 @@ export function LaneBehaviorSection() {
   const navigate = useNavigate();
   const [autoRebaseDraft, setAutoRebaseDraft] = useState(false);
   const [newLaneBaseSource, setNewLaneBaseSource] = useState<NewLaneBaseSource>(DEFAULT_NEW_LANE_BASE_SOURCE);
-  const [newLaneBaseSourceChanged, setNewLaneBaseSourceChanged] = useState(false);
+  const [initialNewLaneBaseSource, setInitialNewLaneBaseSource] =
+    useState<NewLaneBaseSource>(DEFAULT_NEW_LANE_BASE_SOURCE);
   const [cleanup, setCleanup] = useState<LaneCleanupConfig>({});
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
@@ -51,8 +52,9 @@ export function LaneBehaviorSection() {
         ? snapshot.effective.git.autoRebaseOnHeadChange
         : null;
     setAutoRebaseDraft(localAutoRebase ?? effectiveAutoRebase ?? false);
-    setNewLaneBaseSource(effectiveNewLaneBaseSource(snapshot));
-    setNewLaneBaseSourceChanged(false);
+    const initialSource = effectiveNewLaneBaseSource(snapshot);
+    setNewLaneBaseSource(initialSource);
+    setInitialNewLaneBaseSource(initialSource);
 
     const effectiveCleanup = snapshot.effective.laneCleanup ?? {};
     const localCleanup = snapshot.local.laneCleanup ?? {};
@@ -72,11 +74,12 @@ export function LaneBehaviorSection() {
       const currentGit = isRecord(snapshot.local.git) ? snapshot.local.git : {};
       const hasLocalNewLaneBaseSource =
         currentGit.newLaneBaseSource === "local" || currentGit.newLaneBaseSource === "remote";
+      const sourceDiffersFromInitial = newLaneBaseSource !== initialNewLaneBaseSource;
       const nextGit = {
         ...currentGit,
         autoRebaseOnHeadChange: autoRebaseDraft,
       };
-      if (newLaneBaseSourceChanged || hasLocalNewLaneBaseSource) {
+      if (sourceDiffersFromInitial || hasLocalNewLaneBaseSource) {
         nextGit.newLaneBaseSource = newLaneBaseSource;
       } else {
         delete nextGit.newLaneBaseSource;
@@ -139,7 +142,6 @@ export function LaneBehaviorSection() {
                   onClick={() => {
                     if (source === newLaneBaseSource) return;
                     setNewLaneBaseSource(source);
-                    setNewLaneBaseSourceChanged(true);
                   }}
                   style={{
                     ...outlineButton({ height: 56, padding: "8px 10px", borderRadius: 8 }),

--- a/apps/desktop/src/renderer/components/settings/LaneBehaviorSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/LaneBehaviorSection.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState, type CSSProperties } from "react";
 import { useNavigate } from "react-router-dom";
 import { COLORS, MONO_FONT, SANS_FONT, LABEL_STYLE, cardStyle, outlineButton, primaryButton, recessedStyle } from "../lanes/laneDesignTokens";
-import type { LaneCleanupConfig } from "../../../shared/types";
+import type { LaneCleanupConfig, NewLaneBaseSource } from "../../../shared/types";
+import { DEFAULT_NEW_LANE_BASE_SOURCE, effectiveNewLaneBaseSource } from "../lanes/newLaneBaseSource";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -34,6 +35,7 @@ const miniLabel: CSSProperties = {
 export function LaneBehaviorSection() {
   const navigate = useNavigate();
   const [autoRebaseDraft, setAutoRebaseDraft] = useState(false);
+  const [newLaneBaseSource, setNewLaneBaseSource] = useState<NewLaneBaseSource>(DEFAULT_NEW_LANE_BASE_SOURCE);
   const [cleanup, setCleanup] = useState<LaneCleanupConfig>({});
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
@@ -48,6 +50,7 @@ export function LaneBehaviorSection() {
         ? snapshot.effective.git.autoRebaseOnHeadChange
         : null;
     setAutoRebaseDraft(localAutoRebase ?? effectiveAutoRebase ?? false);
+    setNewLaneBaseSource(effectiveNewLaneBaseSource(snapshot));
 
     const effectiveCleanup = snapshot.effective.laneCleanup ?? {};
     const localCleanup = snapshot.local.laneCleanup ?? {};
@@ -72,6 +75,7 @@ export function LaneBehaviorSection() {
           git: {
             ...currentGit,
             autoRebaseOnHeadChange: autoRebaseDraft,
+            newLaneBaseSource,
           },
           laneCleanup: cleanup,
         },
@@ -108,6 +112,43 @@ export function LaneBehaviorSection() {
       {error ? <div style={{ ...messageStyle(COLORS.danger), marginBottom: 12 }}>{error}</div> : null}
 
       <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        {/* New lane base */}
+        <div style={cardStyle({ borderRadius: 12 })}>
+          <div style={{ marginBottom: 10 }}>
+            <div style={{ fontSize: 13, fontWeight: 600, color: COLORS.textPrimary }}>New lane base</div>
+            <div style={{ marginTop: 4, fontSize: 11, color: COLORS.textMuted, lineHeight: 1.5 }}>
+              Choose whether new root lanes and chat auto-created lanes start from the fetched remote branch or your local branch tip.
+            </div>
+          </div>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+            {(["remote", "local"] as const).map((source) => {
+              const active = newLaneBaseSource === source;
+              return (
+                <button
+                  key={source}
+                  type="button"
+                  onClick={() => setNewLaneBaseSource(source)}
+                  style={{
+                    ...outlineButton({ height: 56, padding: "8px 10px", borderRadius: 8 }),
+                    justifyContent: "flex-start",
+                    textAlign: "left",
+                    borderColor: active ? COLORS.accent : COLORS.outlineBorder,
+                    background: active ? `${COLORS.accent}12` : COLORS.recessedBg,
+                    color: active ? COLORS.textPrimary : COLORS.textMuted,
+                  }}
+                >
+                  <div>
+                    <div style={{ fontSize: 12, fontWeight: 700 }}>{source === "remote" ? "Remote" : "Local"}</div>
+                    <div style={{ marginTop: 2, fontSize: 10, color: COLORS.textDim }}>
+                      {source === "remote" ? "Start from fetched upstream" : "Start from local branch"}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
         {/* Auto-rebase */}
         <div style={cardStyle({ borderRadius: 12 })}>
           <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -442,7 +442,19 @@ describe("TerminalView", () => {
 
   it("uses the WebGL renderer by default on supported platforms", async () => {
     vi.useRealTimers();
+    const platformDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "platform");
+    const userAgentDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "userAgent");
+    const originalPlatform = window.navigator.platform;
+    const originalUserAgent = window.navigator.userAgent;
     try {
+      Object.defineProperty(window.navigator, "platform", {
+        configurable: true,
+        value: "MacIntel",
+      });
+      Object.defineProperty(window.navigator, "userAgent", {
+        configurable: true,
+        value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/537.36",
+      });
       render(<TerminalView ptyId="pty-webgl-default" sessionId="session-webgl-default" isActive />);
 
       await waitFor(
@@ -454,6 +466,22 @@ describe("TerminalView", () => {
         { timeout: 10_000 },
       );
     } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(window.navigator, "platform", platformDescriptor);
+      } else {
+        Object.defineProperty(window.navigator, "platform", {
+          configurable: true,
+          value: originalPlatform,
+        });
+      }
+      if (userAgentDescriptor) {
+        Object.defineProperty(window.navigator, "userAgent", userAgentDescriptor);
+      } else {
+        Object.defineProperty(window.navigator, "userAgent", {
+          configurable: true,
+          value: originalUserAgent,
+        });
+      }
       vi.useFakeTimers();
     }
   });

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -261,7 +261,39 @@ function terminalHeightFor(element: HTMLElement): number {
   return 180;
 }
 
+function installLocalStorageShim() {
+  let nativeLocalStorage: Storage | undefined;
+  try {
+    nativeLocalStorage = window.localStorage;
+  } catch {
+    nativeLocalStorage = undefined;
+  }
+  if (nativeLocalStorage) return;
+
+  const values = new Map<string, string>();
+  const shim = {
+    get length() {
+      return values.size;
+    },
+    clear: vi.fn(() => values.clear()),
+    getItem: vi.fn((key: string) => values.get(String(key)) ?? null),
+    key: vi.fn((index: number) => Array.from(values.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      values.delete(String(key));
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(String(key), String(value));
+    }),
+  } as unknown as Storage;
+
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: shim,
+  });
+}
+
 beforeAll(() => {
+  installLocalStorageShim();
   vi.stubGlobal("ResizeObserver", MockResizeObserver);
   vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
   // xterm WebGL path needs a getContext("webgl") that succeeds in jsdom / headless CI.
@@ -408,6 +440,24 @@ describe("TerminalView", () => {
     }
   });
 
+  it("uses the WebGL renderer by default on supported platforms", async () => {
+    vi.useRealTimers();
+    try {
+      render(<TerminalView ptyId="pty-webgl-default" sessionId="session-webgl-default" isActive />);
+
+      await waitFor(
+        () => {
+          const runtime = getTerminalRuntimeSnapshot("session-webgl-default");
+          expect(runtime?.renderer).toBe("webgl");
+          expect(mockState.lastContextLossHandler).toBeTruthy();
+        },
+        { timeout: 10_000 },
+      );
+    } finally {
+      vi.useFakeTimers();
+    }
+  });
+
   it("uses the DOM renderer when explicitly opted out", async () => {
     vi.useRealTimers();
     try {
@@ -505,7 +555,7 @@ describe("TerminalView", () => {
     vi.useRealTimers();
     const platformDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "platform");
     const originalPlatform = window.navigator.platform;
-    const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+    const getItemSpy = vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
       throw new Error("storage unavailable");
     });
     try {
@@ -582,6 +632,7 @@ describe("TerminalView", () => {
 
     const resizeSpy = (window as any).ade.pty.resize as ReturnType<typeof vi.fn>;
     const terminal = mockState.terminalInstances.at(-1) as {
+      clearTextureAtlas: ReturnType<typeof vi.fn>;
       focus: ReturnType<typeof vi.fn>;
     } | undefined;
 
@@ -592,10 +643,12 @@ describe("TerminalView", () => {
     });
     expect(terminal?.focus).not.toHaveBeenCalled();
 
+    terminal?.clearTextureAtlas.mockClear();
     mockState.nextFitDims = { cols: 140, rows: 44 };
     triggerResizeObserver();
     await flushAnimationFrame();
 
+    expect(terminal?.clearTextureAtlas).toHaveBeenCalled();
     expect(resizeSpy).toHaveBeenLastCalledWith({
       ptyId: "pty-visible",
       cols: 140,
@@ -1008,6 +1061,113 @@ describe("TerminalView", () => {
         });
       }
     }
+  });
+
+  it("sends Shift+Enter as a bracketed-paste newline only while the terminal requests bracketed paste mode", async () => {
+    render(<TerminalView ptyId="pty-shift-enter" sessionId="session-shift-enter" isActive />);
+    await flushAllTimers();
+
+    const terminal = mockState.terminalInstances.at(-1) as {
+      attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
+    } | undefined;
+    const keyHandler = terminal?.attachCustomKeyEventHandler.mock.calls.at(-1)?.[0] as ((ev: KeyboardEvent) => boolean) | undefined;
+    expect(keyHandler).toBeTruthy();
+
+    const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
+    ptyWrite.mockClear();
+
+    const pressShiftEnter = () => {
+      const preventDefault = vi.fn();
+      const handled = keyHandler!({
+        type: "keydown",
+        key: "Enter",
+        metaKey: false,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: true,
+        preventDefault,
+      } as unknown as KeyboardEvent);
+      expect(handled).toBe(false);
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+    };
+
+    pressShiftEnter();
+    expect(ptyWrite).toHaveBeenLastCalledWith({
+      ptyId: "pty-shift-enter",
+      data: "\n",
+    });
+
+    for (const listener of mockState.ptyDataListeners) {
+      listener({
+        ptyId: "pty-shift-enter",
+        sessionId: "session-shift-enter",
+        projectRoot: "/project/a",
+        data: "\x1b[?2004h",
+      });
+    }
+
+    pressShiftEnter();
+    expect(ptyWrite).toHaveBeenLastCalledWith({
+      ptyId: "pty-shift-enter",
+      data: "\x1b[200~\n\x1b[201~",
+    });
+
+    for (const listener of mockState.ptyDataListeners) {
+      listener({
+        ptyId: "pty-shift-enter",
+        sessionId: "session-shift-enter",
+        projectRoot: "/project/a",
+        data: "\x1b[?2004l",
+      });
+    }
+
+    pressShiftEnter();
+    expect(ptyWrite).toHaveBeenLastCalledWith({
+      ptyId: "pty-shift-enter",
+      data: "\n",
+    });
+    expect(ptyWrite).toHaveBeenCalledTimes(3);
+  });
+
+  it("restores bracketed paste mode from transcript hydration before handling Shift+Enter", async () => {
+    const previewMock = window.ade.terminal.preview as unknown as ReturnType<typeof vi.fn>;
+    previewMock.mockResolvedValue({
+      terminalId: "session-shift-enter-hydrated",
+      session: null,
+      source: "transcript",
+      snapshot: null,
+      transcript: "\x1b[?2004hCodex ready\n",
+      capturedAt: new Date().toISOString(),
+    });
+
+    render(<TerminalView ptyId="pty-shift-enter-hydrated" sessionId="session-shift-enter-hydrated" isActive />);
+    await flushAllTimers();
+
+    const terminal = mockState.terminalInstances.at(-1) as {
+      attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
+    } | undefined;
+    const keyHandler = terminal?.attachCustomKeyEventHandler.mock.calls.at(-1)?.[0] as ((ev: KeyboardEvent) => boolean) | undefined;
+    expect(keyHandler).toBeTruthy();
+
+    const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
+    ptyWrite.mockClear();
+    const preventDefault = vi.fn();
+    const handled = keyHandler!({
+      type: "keydown",
+      key: "Enter",
+      metaKey: false,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: true,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+
+    expect(handled).toBe(false);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(ptyWrite).toHaveBeenCalledWith({
+      ptyId: "pty-shift-enter-hydrated",
+      data: "\x1b[200~\n\x1b[201~",
+    });
   });
 
   it("forwards Shift+mouse selection gestures while terminal mouse tracking is active", async () => {

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -100,6 +100,7 @@ type CachedRuntime = {
   inputEnabled: boolean;
   active: boolean;
   visible: boolean;
+  bracketedPasteMode: boolean;
   mouseTrackingModes: Set<number>;
   shiftMouseBridgeCleanup: (() => void) | null;
   shiftMouseCleanup: (() => void) | null;
@@ -136,6 +137,9 @@ const INVALID_FIT_RETRY_MS = 90;
 const RENDERER_RESET_COOLDOWN_MS = 250;
 const TERMINAL_RENDERER_STORAGE_KEY = "ade.terminalRenderer";
 const TERMINAL_CTRL_V = "\x16";
+const TERMINAL_BRACKETED_PASTE_START = "\x1b[200~";
+const TERMINAL_BRACKETED_PASTE_END = "\x1b[201~";
+const TERMINAL_BRACKETED_PASTE_MODE = 2004;
 const TERMINAL_LINK_PATTERN = /(?:https?:\/\/[^\s<>"'`]+|(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?(?:\/[^\s<>"'`]*)?)/gi;
 const TERMINAL_MOUSE_TRACKING_EVENT_MODES = new Set([1000, 1002, 1003]);
 const runtimeCache = new Map<string, CachedRuntime>();
@@ -183,7 +187,8 @@ function terminalWebglRendererEnabled(): boolean {
     // Storage can be unavailable in hardened/browser-like environments; still
     // honor the Linux renderer fallback below.
   }
-  if (stored != null) return stored !== "dom";
+  if (stored === "dom") return false;
+  if (stored === "webgl") return true;
   const platform = window.navigator?.platform?.toLowerCase() ?? "";
   const userAgent = window.navigator?.userAgent?.toLowerCase() ?? "";
   if (platform.includes("linux") || userAgent.includes("linux")) return false;
@@ -815,11 +820,15 @@ function enqueuePtyInput(runtime: CachedRuntime, data: string) {
   schedulePtyInputFlush(runtime);
 }
 
-function updateTerminalMouseTrackingModes(runtime: CachedRuntime, data: string): void {
+function updateTerminalInputModes(runtime: CachedRuntime, data: string): void {
   for (const match of data.matchAll(/\x1b\[\?([0-9;]+)([hl])/g)) {
     const action = match[2];
     for (const rawParam of match[1].split(";")) {
       const mode = Number(rawParam);
+      if (mode === TERMINAL_BRACKETED_PASTE_MODE) {
+        runtime.bracketedPasteMode = action === "h";
+        continue;
+      }
       if (!TERMINAL_MOUSE_TRACKING_EVENT_MODES.has(mode)) continue;
       if (action === "h") {
         runtime.mouseTrackingModes.add(mode);
@@ -1025,6 +1034,7 @@ function doFit(runtime: CachedRuntime, forcePtyResize = false) {
   // Hide cursor before fit to prevent ghost cursor artifact at stale position
   const cursorLayer = runtime.host.querySelector<HTMLElement>(".xterm-cursor-layer");
   if (cursorLayer) cursorLayer.style.visibility = "hidden";
+  clearTextureAtlas(runtime);
 
   try {
     runtime.fit.fit();
@@ -1217,7 +1227,7 @@ function handleRuntimePtyData(runtime: CachedRuntime, ev: PtyDataEvent) {
     pauseRuntimePtyStream(runtime);
     return;
   }
-  updateTerminalMouseTrackingModes(runtime, ev.data);
+  updateTerminalInputModes(runtime, ev.data);
 
   if (!runtime.hydrationCompleted) {
     runtime.pendingHydrationChunks.push(ev.data);
@@ -1337,6 +1347,7 @@ function flushHydrationData(
 
   const merged = appendPending ? `${stabilizedTail}${pending.slice(overlap)}` : stabilizedTail;
   if (merged.length) {
+    updateTerminalInputModes(runtime, merged);
     try {
       runtime.term.write(merged);
       if (hasRenderableTerminalText(merged)) {
@@ -1801,6 +1812,7 @@ function createRuntime(args: {
     inputEnabled: true,
     active: true,
     visible: true,
+    bracketedPasteMode: false,
     mouseTrackingModes: new Set(),
     shiftMouseBridgeCleanup: null,
     shiftMouseCleanup: null,
@@ -1879,7 +1891,9 @@ function createRuntime(args: {
     // Shift+Enter should insert a newline in tools like Claude/Codex prompts.
     if (ev.shiftKey && ev.key === "Enter") {
       ev.preventDefault();
-      writePtyInput(runtime, "\n");
+      writePtyInput(runtime, runtime.bracketedPasteMode
+        ? `${TERMINAL_BRACKETED_PASTE_START}\n${TERMINAL_BRACKETED_PASTE_END}`
+        : "\n");
       return false;
     }
 
@@ -2086,6 +2100,7 @@ export function TerminalView({
     startHydration(runtime);
 
     const obs = new ResizeObserver(() => {
+      clearTextureAtlas(runtime);
       schedule();
     });
     obs.observe(el);

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
@@ -508,6 +508,43 @@ describe("useWorkSessions — refresh-before-focus ordering", () => {
     expect(listSessionsCachedMock).toHaveBeenCalledWith({ limit: 500 }, { force: true });
   });
 
+  it("keeps a runtime row stopped when dispose reports the pty is already gone", async () => {
+    const missingPtySession = makeSession("session-missing", "lane-1", {
+      ptyId: "pty-missing",
+      toolType: "codex",
+      runtimeState: "running",
+    });
+    listSessionsCachedMock.mockResolvedValue([missingPtySession]);
+    (window as any).ade.pty.dispose.mockResolvedValueOnce({
+      disposed: false,
+      reason: "missing",
+    });
+
+    const { result } = renderHook(() => useWorkSessions());
+
+    await waitFor(() => {
+      expect(result.current.sessions[0]?.id).toBe("session-missing");
+    });
+
+    listSessionsCachedMock.mockClear();
+    listSessionsCachedMock.mockRejectedValueOnce(new Error("refresh failed"));
+
+    await act(async () => {
+      await result.current.stopRuntime("pty-missing", "session-missing");
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessions[0]).toMatchObject({
+        id: "session-missing",
+        ptyId: null,
+        status: "disposed",
+        runtimeState: "killed",
+        exitCode: null,
+      });
+    });
+    expect(listSessionsCachedMock).toHaveBeenCalledWith({ limit: 500 }, { force: true });
+  });
+
   it("launchPtySession can start a terminal in the background without changing the active tab", async () => {
     const workState = {
       openItemIds: ["existing-session"] as string[],

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
@@ -435,6 +435,79 @@ describe("useWorkSessions — refresh-before-focus ordering", () => {
     expect(workState.selectedItemId).toBe("new-pty-session");
   });
 
+  it("keeps a stopped runtime closed when a stale refresh returns the old running row", async () => {
+    const staleRunningSession = makeSession("session-stop", "lane-1", {
+      ptyId: "pty-stop",
+      toolType: "codex",
+      runtimeState: "running",
+    });
+    listSessionsCachedMock.mockResolvedValue([staleRunningSession]);
+
+    const { result } = renderHook(() => useWorkSessions());
+
+    await waitFor(() => {
+      expect(result.current.sessions[0]?.id).toBe("session-stop");
+    });
+
+    listSessionsCachedMock.mockClear();
+    listSessionsCachedMock.mockResolvedValue([staleRunningSession]);
+
+    await act(async () => {
+      await result.current.stopRuntime("pty-stop", "session-stop");
+    });
+
+    await waitFor(() => {
+      expect(listSessionsCachedMock).toHaveBeenCalledWith({ limit: 500 }, { force: true });
+    });
+    expect((window as any).ade.pty.dispose).toHaveBeenCalledWith({
+      ptyId: "pty-stop",
+      sessionId: "session-stop",
+    });
+    expect(result.current.sessions[0]).toMatchObject({
+      id: "session-stop",
+      ptyId: null,
+      status: "disposed",
+      runtimeState: "killed",
+      exitCode: null,
+    });
+  });
+
+  it("restores a runtime row when dispose reports that a peer still owns it", async () => {
+    const peerOwnedSession = makeSession("session-peer", "lane-1", {
+      ptyId: "pty-peer",
+      toolType: "codex",
+      runtimeState: "running",
+    });
+    listSessionsCachedMock.mockResolvedValue([peerOwnedSession]);
+    (window as any).ade.pty.dispose.mockResolvedValueOnce({
+      disposed: false,
+      reason: "owned-by-peer",
+    });
+
+    const { result } = renderHook(() => useWorkSessions());
+
+    await waitFor(() => {
+      expect(result.current.sessions[0]?.id).toBe("session-peer");
+    });
+
+    listSessionsCachedMock.mockClear();
+    listSessionsCachedMock.mockResolvedValue([peerOwnedSession]);
+
+    await act(async () => {
+      await result.current.stopRuntime("pty-peer", "session-peer");
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessions[0]).toMatchObject({
+        id: "session-peer",
+        ptyId: "pty-peer",
+        status: "running",
+        runtimeState: "running",
+      });
+    });
+    expect(listSessionsCachedMock).toHaveBeenCalledWith({ limit: 500 }, { force: true });
+  });
+
   it("launchPtySession can start a terminal in the background without changing the active tab", async () => {
     const workState = {
       openItemIds: ["existing-session"] as string[],

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
@@ -545,6 +545,42 @@ describe("useWorkSessions — refresh-before-focus ordering", () => {
     expect(listSessionsCachedMock).toHaveBeenCalledWith({ limit: 500 }, { force: true });
   });
 
+  it("restores a runtime row when dispose reports a session mismatch", async () => {
+    const stalePtySession = makeSession("session-mismatch", "lane-1", {
+      ptyId: "pty-stale",
+      toolType: "codex",
+      runtimeState: "running",
+    });
+    listSessionsCachedMock.mockResolvedValue([stalePtySession]);
+    (window as any).ade.pty.dispose.mockResolvedValueOnce({
+      disposed: false,
+      reason: "session-mismatch",
+    });
+
+    const { result } = renderHook(() => useWorkSessions());
+
+    await waitFor(() => {
+      expect(result.current.sessions[0]?.id).toBe("session-mismatch");
+    });
+
+    listSessionsCachedMock.mockClear();
+    listSessionsCachedMock.mockRejectedValueOnce(new Error("refresh failed"));
+
+    await act(async () => {
+      await result.current.stopRuntime("pty-stale", "session-mismatch");
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessions[0]).toMatchObject({
+        id: "session-mismatch",
+        ptyId: "pty-stale",
+        status: "running",
+        runtimeState: "running",
+      });
+    });
+    expect(listSessionsCachedMock).toHaveBeenCalledWith({ limit: 500 }, { force: true });
+  });
+
   it("launchPtySession can start a terminal in the background without changing the active tab", async () => {
     const workState = {
       openItemIds: ["existing-session"] as string[],

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
@@ -491,7 +491,7 @@ describe("useWorkSessions — refresh-before-focus ordering", () => {
     });
 
     listSessionsCachedMock.mockClear();
-    listSessionsCachedMock.mockResolvedValue([peerOwnedSession]);
+    listSessionsCachedMock.mockRejectedValueOnce(new Error("refresh failed"));
 
     await act(async () => {
       await result.current.stopRuntime("pty-peer", "session-peer");

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -1359,8 +1359,12 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
       try {
         const result = await window.ade.pty.dispose({ ptyId, ...(sessionId ? { sessionId } : {}) });
         if (result?.disposed === false) {
-          forgetStoppedRuntime(sessionId);
-          restorePtyClosed(previousSessions);
+          if (result.reason === "owned-by-peer") {
+            forgetStoppedRuntime(sessionId);
+            restorePtyClosed(previousSessions);
+          } else {
+            rememberStoppedRuntime(ptyId, sessionId, endedAt);
+          }
         } else {
           rememberStoppedRuntime(ptyId, sessionId, endedAt);
         }

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -49,6 +49,7 @@ const DEFAULT_PROJECT_WORK_STATE: WorkProjectViewState = {
 };
 
 const OPTIMISTIC_PTY_SESSION_TTL_MS = 2 * 60 * 1000;
+const STOPPED_RUNTIME_GUARD_TTL_MS = 12_000;
 const EMPTY_STRING_ARRAY: string[] = [];
 const EMPTY_LANE_SESSION_ORDER: Record<string, string[]> = {};
 const EMPTY_GRID_SETS: WorkGridSet[] = [];
@@ -343,6 +344,12 @@ type PendingOptimisticSession = {
   createdAtMs: number;
 };
 
+type StoppedRuntimeSession = {
+  ptyId: string;
+  endedAt: string;
+  expiresAtMs: number;
+};
+
 type UseWorkSessionsOptions = {
   active?: boolean;
 };
@@ -370,6 +377,7 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
   const refreshInFlightRef = useRef(false);
   const refreshQueuedRef = useRef<QueuedRefresh | null>(null);
   const pendingOptimisticSessionsRef = useRef<Map<string, PendingOptimisticSession>>(new Map());
+  const stoppedRuntimeSessionsRef = useRef<Map<string, StoppedRuntimeSession>>(new Map());
   const hasRunningSessionsRef = useRef(false);
   const backgroundRefreshTimerRef = useRef<number | null>(null);
   const pendingHiddenSessionRefreshRef = useRef(false);
@@ -814,6 +822,37 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
           rowIndexById.set(sessionId, rows.length - 1);
         }
         rows.sort(compareSessionsByStartedAtDesc);
+      }
+      const stoppedRuntimeSessions = stoppedRuntimeSessionsRef.current;
+      if (stoppedRuntimeSessions.size > 0) {
+        const now = Date.now();
+        for (const [sessionId, stopped] of [...stoppedRuntimeSessions.entries()]) {
+          if (stopped.expiresAtMs <= now) stoppedRuntimeSessions.delete(sessionId);
+        }
+        if (stoppedRuntimeSessions.size > 0) {
+          for (let index = 0; index < rows.length; index += 1) {
+            const row = rows[index];
+            if (!row) continue;
+            const stopped = stoppedRuntimeSessions.get(row.id);
+            if (!stopped) continue;
+            if (row.status !== "running") {
+              stoppedRuntimeSessions.delete(row.id);
+              continue;
+            }
+            if (row.ptyId && row.ptyId !== stopped.ptyId) {
+              stoppedRuntimeSessions.delete(row.id);
+              continue;
+            }
+            rows[index] = {
+              ...row,
+              ptyId: null,
+              status: "disposed",
+              runtimeState: "killed",
+              endedAt: row.endedAt ?? stopped.endedAt,
+              exitCode: null,
+            };
+          }
+        }
       }
       setSessions(rows);
       hasLoadedOnceRef.current = true;
@@ -1262,21 +1301,37 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
     });
   }, [projectRoot, sessions, setProjectViewState]);
 
-  const markPtyClosed = (ptyId: string) => {
+  const rememberStoppedRuntime = (ptyId: string, sessionId: string | undefined, endedAt: string) => {
+    if (!sessionId) return;
+    stoppedRuntimeSessionsRef.current.set(sessionId, {
+      ptyId,
+      endedAt,
+      expiresAtMs: Date.now() + STOPPED_RUNTIME_GUARD_TTL_MS,
+    });
+  };
+
+  const forgetStoppedRuntime = (sessionId: string | undefined) => {
+    if (!sessionId) return;
+    stoppedRuntimeSessionsRef.current.delete(sessionId);
+  };
+
+  const markPtyClosed = (ptyId: string, sessionId?: string): string => {
+    const endedAt = new Date().toISOString();
     setSessions((prev) =>
       prev.map((session) =>
-        session.ptyId === ptyId
+        session.ptyId === ptyId || (sessionId != null && session.id === sessionId)
           ? {
               ...session,
               ptyId: null,
               status: "disposed" as const,
               runtimeState: "killed" as const,
-              endedAt: new Date().toISOString(),
+              endedAt,
               exitCode: null,
             }
           : session,
       ),
     );
+    return endedAt;
   };
 
   const stopRuntime = useCallback(
@@ -1286,35 +1341,33 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
         next.add(ptyId);
         return next;
       });
-      markPtyClosed(ptyId);
-
-      // Optimistically mark the session as disposed so the UI updates
-      // immediately instead of waiting for a full session list refresh.
-      if (sessionId) {
-        setSessions((prev) =>
-          prev.map((s) => (s.id === sessionId ? { ...s, status: "disposed" as const } : s)),
-        );
-      }
+      invalidateSessionListCache();
+      const endedAt = markPtyClosed(ptyId, sessionId);
 
       try {
-        await window.ade.pty.dispose({ ptyId, ...(sessionId ? { sessionId } : {}) });
+        const result = await window.ade.pty.dispose({ ptyId, ...(sessionId ? { sessionId } : {}) });
+        if (result?.disposed === false) forgetStoppedRuntime(sessionId);
+        else rememberStoppedRuntime(ptyId, sessionId, endedAt);
       } finally {
         setClosingPtyIds((prev) => {
           const next = new Set(prev);
           next.delete(ptyId);
           return next;
         });
-        // Reconcile with the real backend state in the background.
-        scheduleBackgroundRefresh();
+        invalidateSessionListCache();
+        // Reconcile with the real backend state using a forced read; otherwise
+        // an older in-flight session list can briefly resurrect the stopped PTY.
+        void refresh({ showLoading: false, force: true }).catch(() => {});
       }
     },
-    [scheduleBackgroundRefresh],
+    [refresh],
   );
 
   const stopAllRuntimes = useCallback(async () => {
-    const ptyIds = runningSessions.map((session) => session.ptyId).filter((id): id is string => Boolean(id));
     await Promise.allSettled([
-      ...ptyIds.map((id) => stopRuntime(id)),
+      ...runningSessions
+        .filter((session) => Boolean(session.ptyId))
+        .map((session) => stopRuntime(session.ptyId as string, session.id)),
     ]);
   }, [runningSessions, stopRuntime]);
 

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -374,6 +374,7 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
   const [sessions, setSessions] = useState<TerminalSessionSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [closingPtyIds, setClosingPtyIds] = useState<Set<string>>(new Set());
+  const sessionsRef = useRef<TerminalSessionSummary[]>([]);
   const refreshInFlightRef = useRef(false);
   const refreshQueuedRef = useRef<QueuedRefresh | null>(null);
   const pendingOptimisticSessionsRef = useRef<Map<string, PendingOptimisticSession>>(new Map());
@@ -995,6 +996,7 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
   }, [isWorkRoute]);
 
   useEffect(() => {
+    sessionsRef.current = sessions;
     hasRunningSessionsRef.current = sessions.some((s) => s.status === "running");
   }, [sessions]);
 
@@ -1315,6 +1317,12 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
     stoppedRuntimeSessionsRef.current.delete(sessionId);
   };
 
+  const restorePtyClosed = (previousSessions: readonly TerminalSessionSummary[]) => {
+    if (previousSessions.length === 0) return;
+    const previousById = new Map(previousSessions.map((session) => [session.id, session] as const));
+    setSessions((prev) => prev.map((session) => previousById.get(session.id) ?? session));
+  };
+
   const markPtyClosed = (ptyId: string, sessionId?: string): string => {
     const endedAt = new Date().toISOString();
     setSessions((prev) =>
@@ -1336,6 +1344,9 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
 
   const stopRuntime = useCallback(
     async (ptyId: string, sessionId?: string) => {
+      const previousSessions = sessionsRef.current.filter((session) =>
+        session.ptyId === ptyId || (sessionId != null && session.id === sessionId),
+      );
       setClosingPtyIds((prev) => {
         const next = new Set(prev);
         next.add(ptyId);
@@ -1344,10 +1355,19 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
       invalidateSessionListCache();
       const endedAt = markPtyClosed(ptyId, sessionId);
 
+      let disposeError: unknown = null;
       try {
         const result = await window.ade.pty.dispose({ ptyId, ...(sessionId ? { sessionId } : {}) });
-        if (result?.disposed === false) forgetStoppedRuntime(sessionId);
-        else rememberStoppedRuntime(ptyId, sessionId, endedAt);
+        if (result?.disposed === false) {
+          forgetStoppedRuntime(sessionId);
+          restorePtyClosed(previousSessions);
+        } else {
+          rememberStoppedRuntime(ptyId, sessionId, endedAt);
+        }
+      } catch (error) {
+        disposeError = error;
+        forgetStoppedRuntime(sessionId);
+        restorePtyClosed(previousSessions);
       } finally {
         setClosingPtyIds((prev) => {
           const next = new Set(prev);
@@ -1359,6 +1379,7 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
         // an older in-flight session list can briefly resurrect the stopped PTY.
         void refresh({ showLoading: false, force: true }).catch(() => {});
       }
+      if (disposeError) throw disposeError;
     },
     [refresh],
   );

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -1359,7 +1359,7 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
       try {
         const result = await window.ade.pty.dispose({ ptyId, ...(sessionId ? { sessionId } : {}) });
         if (result?.disposed === false) {
-          if (result.reason === "owned-by-peer") {
+          if (result.reason === "owned-by-peer" || result.reason === "session-mismatch") {
             forgetStoppedRuntime(sessionId);
             restorePtyClosed(previousSessions);
           } else {

--- a/apps/desktop/src/renderer/components/usage/HeaderUsageControl.tsx
+++ b/apps/desktop/src/renderer/components/usage/HeaderUsageControl.tsx
@@ -98,6 +98,33 @@ function shouldApplyCachedSnapshot(
   return nextTimestamp == null || currentTimestamp == null || nextTimestamp >= currentTimestamp;
 }
 
+function formatUpdatedAgo(snapshot: UsageSnapshot | null, nowMs: number): string {
+  const t = snapshot ? Date.parse(snapshot.lastPolledAt) : Number.NaN;
+  if (!Number.isFinite(t)) return "";
+  const sec = Math.max(0, Math.round((nowMs - t) / 1000));
+  if (sec < 5) return "updated just now";
+  if (sec < 60) return `updated ${sec}s ago`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `updated ${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `updated ${hr}h ago`;
+  return `updated ${Math.round(hr / 24)}d ago`;
+}
+
+// A quiet, non-destructive warning: data is being shown, but the last refresh
+// for one or more providers failed (stale) or has nothing yet (error).
+function usageWarning(snapshot: UsageSnapshot | null): { warn: boolean; detail: string | null } {
+  const statuses = snapshot?.providerStatus;
+  if (!statuses) return { warn: false, detail: null };
+  const issues: string[] = [];
+  for (const [provider, status] of Object.entries(statuses)) {
+    if (status && (status.state === "stale" || status.state === "error")) {
+      issues.push(status.message ?? `${PROVIDER_LABEL[provider as UsageProvider] ?? provider} unavailable`);
+    }
+  }
+  return { warn: issues.length > 0, detail: issues.length > 0 ? issues.join(" · ") : null };
+}
+
 function HeaderProviderUsageChip({
   provider,
   usage,
@@ -136,6 +163,15 @@ export function HeaderUsageControl({
   const snapshotRef = useRef<UsageSnapshot | null>(null);
 
   const [refreshing, setRefreshing] = useState(false);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  // Tick the "updated Xs ago" label only while the popup is open.
+  useEffect(() => {
+    if (!open) return;
+    setNowMs(Date.now());
+    const timer = window.setInterval(() => setNowMs(Date.now()), 5_000);
+    return () => window.clearInterval(timer);
+  }, [open]);
 
   const applySnapshot = useCallback((nextSnapshot: UsageSnapshot | null) => {
     snapshotRef.current = nextSnapshot;
@@ -254,7 +290,9 @@ export function HeaderUsageControl({
     })),
     [detectedProviders, snapshot],
   );
-  const hasErrors = (snapshot?.errors.length ?? 0) > 0;
+  const warning = useMemo(() => usageWarning(snapshot), [snapshot]);
+  const hasErrors = warning.warn;
+  const updatedAgo = formatUpdatedAgo(snapshot, nowMs);
 
   const titleParts = providersWithUsage.map(
     ({ provider, usage }) => `${PROVIDER_LABEL[provider]} ${formatUsageTitle(usage)}`,
@@ -367,7 +405,25 @@ export function HeaderUsageControl({
                   Usage
                 </div>
               </div>
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-2">
+                {updatedAgo ? (
+                  <span className="flex items-center gap-1.5 text-[10.5px] tabular-nums text-fg/40">
+                    <span>{updatedAgo}</span>
+                    {warning.warn ? (
+                      <span
+                        className="h-1.5 w-1.5 rounded-full bg-amber-400/80"
+                        title={warning.detail ?? "Some usage couldn't be refreshed"}
+                        aria-label={warning.detail ?? "Some usage couldn't be refreshed"}
+                      />
+                    ) : (
+                      <span
+                        className="h-1.5 w-1.5 rounded-full bg-emerald-400/70"
+                        title="Usage is up to date"
+                        aria-hidden
+                      />
+                    )}
+                  </span>
+                ) : null}
                 <button
                   type="button"
                   className="ade-shell-control inline-flex h-7 w-7 items-center justify-center rounded-md"

--- a/apps/desktop/src/renderer/components/usage/UsageQuotaPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/usage/UsageQuotaPanel.test.tsx
@@ -73,23 +73,29 @@ describe("UsageQuotaPanel refresh freshness", () => {
     window.ade = originalAde;
   });
 
-  it("refreshes a fresh provider-only snapshot so local cost history loads", async () => {
+  it("refreshes a fresh provider-only snapshot once so local cost history loads without a retry loop", async () => {
     const providerOnlySnapshot = makeSnapshot({
       costs: [],
       lastPolledAt: new Date().toISOString(),
     });
-    const fullSnapshot = makeSnapshot({
-      ...providerOnlySnapshot,
-      costsLastPolledAt: new Date().toISOString(),
-    });
     vi.mocked(window.ade.usage.getSnapshot).mockResolvedValue(providerOnlySnapshot);
-    vi.mocked(window.ade.usage.refresh).mockResolvedValue(fullSnapshot);
+    vi.mocked(window.ade.usage.refresh).mockResolvedValue(providerOnlySnapshot);
 
-    render(<UsageQuotaPanel />);
+    const { unmount } = render(<UsageQuotaPanel />);
 
     await waitFor(() => {
       expect(window.ade.usage.refresh).toHaveBeenCalledTimes(1);
     });
+
+    unmount();
+    render(<UsageQuotaPanel />);
+    expect(await screen.findByText("Codex")).toBeTruthy();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(window.ade.usage.refresh).toHaveBeenCalledTimes(1);
   });
 
   it("shows signed-out state when usage polling reports missing credentials", async () => {

--- a/apps/desktop/src/renderer/components/usage/UsageQuotaPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/usage/UsageQuotaPanel.test.tsx
@@ -1,0 +1,134 @@
+/* @vitest-environment jsdom */
+
+import React from "react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UsageSnapshot } from "../../../shared/types";
+import { UsageQuotaPanel } from "./UsageQuotaPanel";
+
+function makeSnapshot(overrides: Partial<UsageSnapshot> = {}): UsageSnapshot {
+  const nowIso = new Date().toISOString();
+  return {
+    windows: [
+      {
+        provider: "codex",
+        windowType: "weekly",
+        percentUsed: 63,
+        resetsAt: "2099-05-15T07:00:00.000Z",
+        resetsInMs: 86_400_000,
+      },
+    ],
+    pacing: {
+      status: "on-track",
+      projectedWeeklyPercent: 63,
+      weekElapsedPercent: 50,
+      expectedPercent: 50,
+      deltaPercent: 13,
+      etaHours: null,
+      willLastToReset: true,
+      resetsInHours: 24,
+    },
+    pacingByProvider: {},
+    costs: [],
+    extraUsage: [],
+    lastPolledAt: nowIso,
+    errors: [],
+    ...overrides,
+  };
+}
+
+describe("UsageQuotaPanel refresh freshness", () => {
+  const originalAde = window.ade;
+
+  beforeEach(() => {
+    const snapshot = makeSnapshot();
+    (window as any).ade = {
+      usage: {
+        getSnapshot: vi.fn(async () => snapshot),
+        refresh: vi.fn(async () => snapshot),
+        onUpdate: vi.fn(() => () => {}),
+      },
+      ai: {
+        getStatus: vi.fn(async () => ({
+          providerConnections: {
+            codex: {
+              provider: "codex",
+              authAvailable: true,
+              runtimeDetected: true,
+              runtimeAvailable: true,
+              usageAvailable: true,
+              path: null,
+              blocker: null,
+              lastCheckedAt: snapshot.lastPolledAt,
+              sources: [],
+            },
+          },
+        })),
+      },
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.ade = originalAde;
+  });
+
+  it("refreshes a fresh provider-only snapshot so local cost history loads", async () => {
+    const providerOnlySnapshot = makeSnapshot({
+      costs: [],
+      lastPolledAt: new Date().toISOString(),
+    });
+    const fullSnapshot = makeSnapshot({
+      ...providerOnlySnapshot,
+      costsLastPolledAt: new Date().toISOString(),
+    });
+    vi.mocked(window.ade.usage.getSnapshot).mockResolvedValue(providerOnlySnapshot);
+    vi.mocked(window.ade.usage.refresh).mockResolvedValue(fullSnapshot);
+
+    render(<UsageQuotaPanel />);
+
+    await waitFor(() => {
+      expect(window.ade.usage.refresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("shows signed-out state when usage polling reports missing credentials", async () => {
+    const unauthedSnapshot = makeSnapshot({
+      windows: [],
+      providerStatus: {
+        codex: {
+          state: "unauthed",
+          lastSuccessAt: null,
+        },
+      },
+      lastPolledAt: new Date().toISOString(),
+      costsLastPolledAt: new Date().toISOString(),
+    });
+    vi.mocked(window.ade.usage.getSnapshot).mockResolvedValue(unauthedSnapshot);
+    vi.mocked(window.ade.usage.refresh).mockResolvedValue(unauthedSnapshot);
+
+    render(<UsageQuotaPanel />);
+
+    expect(await screen.findByText("Not signed in")).toBeTruthy();
+    expect(window.ade.usage.refresh).not.toHaveBeenCalled();
+  });
+
+  it("skips the mount refresh when provider and cost scans are both fresh", async () => {
+    const freshSnapshot = makeSnapshot({
+      lastPolledAt: new Date().toISOString(),
+      costsLastPolledAt: new Date().toISOString(),
+    });
+    vi.mocked(window.ade.usage.getSnapshot).mockResolvedValue(freshSnapshot);
+    vi.mocked(window.ade.usage.refresh).mockResolvedValue(freshSnapshot);
+
+    render(<UsageQuotaPanel />);
+
+    expect(await screen.findByText("Codex")).toBeTruthy();
+    expect(await screen.findByText("63.0% used")).toBeTruthy();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(window.ade.usage.refresh).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/components/usage/UsageQuotaPanel.tsx
+++ b/apps/desktop/src/renderer/components/usage/UsageQuotaPanel.tsx
@@ -4,39 +4,42 @@ import type {
   AiProviderConnectionStatus,
   AiProviderConnections,
   ExtraUsage,
+  UsagePacing,
   UsageProvider,
+  UsageProviderStatus,
   UsageSnapshot,
   UsageWindow,
 } from "../../../shared/types";
 import { cn } from "../ui/cn";
-import { UsageMeter } from "../settings/UsageMeter";
 
-const CARD_SHADOW_STYLE: React.CSSProperties = {
-  background: "linear-gradient(180deg, rgba(20, 31, 45, 0.96) 0%, rgba(10, 18, 28, 0.94) 100%)",
-  border: "1px solid rgba(87, 108, 128, 0.22)",
-  boxShadow: "0 18px 40px -24px rgba(0, 0, 0, 0.78), inset 0 1px 0 rgba(255,255,255,0.04)",
-};
+// How long cached numbers may sit before opening the popup quietly refreshes
+// them in the background. A failed refresh never clears what's already shown.
+const STALE_REFRESH_THRESHOLD_MS = 60_000;
 
 const PROVIDER_ORDER: UsageProvider[] = ["claude", "codex"];
 
 const PROVIDER_META: Record<UsageProvider, { label: string; color: string }> = {
   claude: { label: "Claude", color: "#D97757" },
-  codex: { label: "Codex", color: "#4ADE80" },
+  codex: { label: "Codex", color: "#5BC98C" },
   cursor: { label: "Cursor", color: "#00BFA5" },
 };
 
-function extractError(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
+const CARD_STYLE: React.CSSProperties = {
+  background: "linear-gradient(180deg, rgba(28,27,38,0.72) 0%, rgba(18,17,26,0.72) 100%)",
+  border: "1px solid rgba(255,255,255,0.06)",
+  boxShadow: "0 12px 30px -22px rgba(0,0,0,0.7), inset 0 1px 0 rgba(255,255,255,0.03)",
+};
+
+// ── small formatters ─────────────────────────────────────────────
 
 function computeResetsInMs(resetsAt: string, nowMs: number): number {
   if (!resetsAt) return 0;
   return Math.max(0, new Date(resetsAt).getTime() - nowMs);
 }
 
-function formatResetSublabel(resetsAt: string, nowMs: number): string {
+function formatResetIn(resetsAt: string, nowMs: number): string {
   const ms = computeResetsInMs(resetsAt, nowMs);
-  if (ms <= 0) return "resets now";
+  if (ms <= 0) return "resetting now";
   const days = Math.floor(ms / 86_400_000);
   const hours = Math.floor((ms % 86_400_000) / 3_600_000);
   const mins = Math.floor((ms % 3_600_000) / 60_000);
@@ -45,9 +48,41 @@ function formatResetSublabel(resetsAt: string, nowMs: number): string {
   return `resets in ${mins}m`;
 }
 
-function displayPercent(window: UsageWindow, nowMs: number): number {
-  const resetsInMs = computeResetsInMs(window.resetsAt, nowMs);
-  return resetsInMs <= 0 ? 0 : window.percentUsed;
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}k`;
+  return `${Math.round(n)}`;
+}
+
+function formatUsagePercent(percent: number): string {
+  return `${percent.toFixed(1)}%`;
+}
+
+function formatHoursShort(hours: number): string {
+  if (hours < 1) return `${Math.round(hours * 60)}m`;
+  if (hours < 24) return `${hours.toFixed(hours < 10 ? 1 : 0)}h`;
+  const days = Math.floor(hours / 24);
+  const rem = Math.round(hours % 24);
+  return rem > 0 ? `${days}d ${rem}h` : `${days}d`;
+}
+
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function startOfDay(ms: number): number {
+  const d = new Date(ms);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+// "today 3pm" / "tomorrow 9am" / "Tue 3pm" — when the quota would run dry.
+function formatClock(targetMs: number, nowMs: number): string {
+  const d = new Date(targetMs);
+  const hours = d.getHours();
+  const ampm = hours >= 12 ? "pm" : "am";
+  const h12 = hours % 12 === 0 ? 12 : hours % 12;
+  const dayDiff = Math.round((startOfDay(targetMs) - startOfDay(nowMs)) / 86_400_000);
+  const prefix = dayDiff <= 0 ? "today" : dayDiff === 1 ? "tomorrow" : WEEKDAYS[d.getDay()];
+  return `${prefix} ${h12}${ampm}`;
 }
 
 function windowLabel(window: UsageWindow): string {
@@ -67,12 +102,80 @@ function windowLabel(window: UsageWindow): string {
   }
 }
 
+function displayPercent(window: UsageWindow, nowMs: number): number {
+  const resetsInMs = computeResetsInMs(window.resetsAt, nowMs);
+  const value = resetsInMs <= 0 ? 0 : window.percentUsed;
+  return Math.max(0, Math.min(100, value));
+}
+
+function fillColorFor(percent: number, tone: string): string {
+  if (percent > 90) return "#F87171";
+  if (percent > 70) return "#F5A623";
+  return tone;
+}
+
+type PaceVisual = { label: string; arrow: string; color: string; tint: string };
+
+// Map the computed pacing to a calm/warm/hot read. "ahead" = burning faster
+// than a steady pace (warm); "behind" = headroom (cool); "on track" (green).
+function paceVisual(pacing?: UsagePacing | null): PaceVisual | null {
+  if (!pacing || pacing.weekElapsedPercent <= 0) return null;
+  const { status, deltaPercent } = pacing;
+  const mag = Math.round(Math.abs(deltaPercent));
+  if (status === "on-track" || mag < 1) {
+    return { label: "on track", arrow: "", color: "#34D399", tint: "#34D39920" };
+  }
+  let color: string;
+  if (status === "far-ahead") color = "#F87171";
+  else if (status === "ahead" || status === "slightly-ahead") color = "#F5A623";
+  else color = "#8B93A7"; // behind family = headroom, kept calm
+  const ahead = deltaPercent >= 0;
+  return { label: `${mag}% ${ahead ? "ahead" : "behind"}`, arrow: ahead ? "▴" : "▾", color, tint: `${color}20` };
+}
+
+function headroomTitle(window: UsageWindow, nowMs: number): string {
+  const reset = formatResetIn(window.resetsAt, nowMs);
+  const pacing = window.pacing;
+  const pct = Math.round(window.percentUsed);
+  if (!pacing || pacing.etaHours == null) return `${pct}% used · ${reset}`;
+  if (pacing.etaHours <= 0) return `Quota exhausted · ${reset}`;
+  const left = formatHoursShort(pacing.etaHours);
+  return pacing.willLastToReset
+    ? `~${left} of headroom at this pace · ${reset}`
+    : `~${left} left at this pace — would run dry before reset · ${reset}`;
+}
+
 function providerConnection(
   connections: AiProviderConnections | null,
   provider: UsageProvider,
 ): AiProviderConnectionStatus | null {
   return connections?.[provider] ?? null;
 }
+
+function ageMsFromIso(iso: string | undefined, nowMs: number): number {
+  if (!iso) return Number.POSITIVE_INFINITY;
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return Number.POSITIVE_INFINITY;
+  return nowMs - parsed;
+}
+
+function shouldRefreshPanelSnapshot(snapshot: UsageSnapshot | null, nowMs: number): boolean {
+  if (!snapshot) return true;
+  if (ageMsFromIso(snapshot.lastPolledAt, nowMs) > STALE_REFRESH_THRESHOLD_MS) return true;
+  return ageMsFromIso(snapshot.costsLastPolledAt, nowMs) > STALE_REFRESH_THRESHOLD_MS;
+}
+
+function usePrefersReducedMotion(): boolean {
+  return useMemo(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+    [],
+  );
+}
+
+// ── panel ────────────────────────────────────────────────────────
 
 export function UsageQuotaPanel({
   className,
@@ -83,14 +186,10 @@ export function UsageQuotaPanel({
 }) {
   const [snapshot, setSnapshot] = useState<UsageSnapshot | null>(null);
   const [providerConnections, setProviderConnections] = useState<AiProviderConnections | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [bridgeMissing, setBridgeMissing] = useState(false);
   const [nowMs, setNowMs] = useState(() => Date.now());
+  const reducedMotion = usePrefersReducedMotion();
 
-  // Keep the latest onSnapshotChange in a ref so applySnapshot/manualRefresh
-  // identities stay stable. Without this, a caller that passes an inline
-  // arrow as onSnapshotChange would re-derive manualRefresh every render and
-  // the auto-refresh-on-mount effect would re-fire in a loop.
   const onSnapshotChangeRef = useRef(onSnapshotChange);
   useEffect(() => {
     onSnapshotChangeRef.current = onSnapshotChange;
@@ -101,52 +200,50 @@ export function UsageQuotaPanel({
     onSnapshotChangeRef.current?.(nextSnapshot);
   }, []);
 
-  const load = useCallback(async () => {
+  // Render cached numbers instantly, subscribe to live updates, and only kick a
+  // background refresh if the data is stale. A failed refresh changes nothing.
+  useEffect(() => {
     if (!window.ade?.usage) {
-      setError("Usage bridge unavailable.");
+      setBridgeMissing(true);
       return;
     }
-    setLoading(true);
-    setError(null);
-    try {
-      applySnapshot(await window.ade.usage.getSnapshot());
-    } catch (err) {
-      setError(extractError(err));
-    } finally {
-      setLoading(false);
-    }
+    const bridge = window.ade.usage;
+    let cancelled = false;
+    const unsubscribe = bridge.onUpdate?.((next) => {
+      if (!cancelled) applySnapshot(next);
+    });
+
+    void (async () => {
+      let current: UsageSnapshot | null = null;
+      try {
+        current = await bridge.getSnapshot();
+      } catch {
+        current = null;
+      }
+      if (cancelled) return;
+      if (current) applySnapshot(current);
+
+      if (shouldRefreshPanelSnapshot(current, Date.now())) {
+        try {
+          const fresh = await bridge.refresh();
+          if (!cancelled && fresh) applySnapshot(fresh);
+        } catch {
+          // Quiet — the service preserves last-good data and marks it stale.
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
   }, [applySnapshot]);
-
-  const manualRefresh = useCallback(async () => {
-    if (!window.ade?.usage) return;
-    setLoading(true);
-    setError(null);
-    try {
-      applySnapshot(await window.ade.usage.refresh());
-    } catch (err) {
-      setError(extractError(err));
-    } finally {
-      setLoading(false);
-    }
-  }, [applySnapshot]);
-
-  useEffect(() => {
-    void load();
-    if (!window.ade?.usage) return;
-    const unsubscribe = window.ade.usage.onUpdate(applySnapshot);
-    return unsubscribe;
-  }, [applySnapshot, load]);
-
-  // Auto-refresh on open so the drawer always shows fresh data instead of
-  // whatever the last background poll happened to leave behind.
-  useEffect(() => {
-    void manualRefresh();
-  }, [manualRefresh]);
 
   useEffect(() => {
     let cancelled = false;
     if (!window.ade?.ai?.getStatus) return;
-    window.ade.ai.getStatus()
+    window.ade.ai
+      .getStatus()
       .then((status) => {
         if (!cancelled) setProviderConnections(status.providerConnections ?? null);
       })
@@ -167,9 +264,6 @@ export function UsageQuotaPanel({
     if (!providerConnections) return PROVIDER_ORDER;
     return PROVIDER_ORDER.filter((provider) => {
       const conn = providerConnection(providerConnections, provider);
-      // Show only providers whose CLI is detected on this machine. Auth is
-      // optional — a CLI without auth still renders so the user knows it's
-      // installed but hasn't been signed in.
       return conn?.runtimeDetected !== false;
     });
   }, [providerConnections]);
@@ -182,23 +276,24 @@ export function UsageQuotaPanel({
     return grouped;
   }, [snapshot?.windows, visibleProviders]);
 
+  if (bridgeMissing) {
+    return (
+      <div className={cn("rounded-lg px-3 py-6 text-center text-[12px] text-fg/45", className)}>
+        Usage isn't available in this view.
+      </div>
+    );
+  }
+
   return (
     <div className={cn("space-y-3", className)}>
-      {error ? (
-        <div className="rounded-lg bg-red-500/10 p-2 text-xs text-red-300">{error}</div>
-      ) : null}
-
-      {snapshot?.errors.map((entry, index) => (
-        <div key={`${entry}-${index}`} className="rounded-lg bg-amber-500/10 p-2 text-xs text-amber-300">
-          {entry}
-        </div>
-      ))}
-
       {visibleProviders.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-lg border border-border/10 bg-card/70 py-8 text-center">
-          <Gauge size={32} weight="regular" className="mb-3 text-[#2D2840]" />
-          <div className="text-sm font-semibold text-fg">No provider CLIs detected</div>
-          <div className="mt-2 max-w-[44ch] text-[11px] text-muted-fg">
+        <div
+          className="flex flex-col items-center justify-center rounded-xl py-9 text-center"
+          style={CARD_STYLE}
+        >
+          <Gauge size={30} weight="regular" className="mb-3 text-fg/25" />
+          <div className="text-[13px] font-semibold text-fg">No provider CLIs detected</div>
+          <div className="mt-1.5 max-w-[44ch] text-[11.5px] text-fg/45">
             Install Claude Code or the Codex CLI to start tracking usage here.
           </div>
         </div>
@@ -210,8 +305,10 @@ export function UsageQuotaPanel({
               provider={provider}
               windows={windowsByProvider[provider] ?? []}
               connection={providerConnection(providerConnections, provider)}
+              status={snapshot?.providerStatus?.[provider] ?? null}
               dailyUsage7d={snapshot?.dailyUsage7d?.[provider] ?? null}
               nowMs={nowMs}
+              reducedMotion={reducedMotion}
             />
           ))}
         </div>
@@ -220,49 +317,157 @@ export function UsageQuotaPanel({
       {(snapshot?.extraUsage ?? [])
         .filter((extra) => extra.provider !== "cursor")
         .map((extra) => (
-          <ExtraUsageCard key={extra.provider} extra={extra} />
+          <ExtraUsageCard key={extra.provider} extra={extra} reducedMotion={reducedMotion} />
         ))}
     </div>
   );
 }
 
-function Sparkline7d({
-  data,
-  color,
+// ── pace bar ─────────────────────────────────────────────────────
+
+function PaceBar({
+  window,
+  toneColor,
+  nowMs,
+  reducedMotion,
 }: {
-  data: number[];
-  color: string;
+  window: UsageWindow;
+  toneColor: string;
+  nowMs: number;
+  reducedMotion: boolean;
 }) {
-  const max = Math.max(1, ...data);
-  const width = 100;
-  const height = 16;
-  const step = width / Math.max(1, data.length);
+  const percent = displayPercent(window, nowMs);
+  const fill = fillColorFor(percent, toneColor);
+  const pace = paceVisual(window.pacing);
+  const expected = window.pacing?.expectedPercent;
+  const showTick = typeof expected === "number" && expected > 1 && expected < 99;
+
+  const [grown, setGrown] = useState(reducedMotion);
+  useEffect(() => {
+    if (reducedMotion) {
+      setGrown(true);
+      return;
+    }
+    const frame = requestAnimationFrame(() => setGrown(true));
+    return () => cancelAnimationFrame(frame);
+  }, [reducedMotion]);
+
   return (
-    <svg
-      width={width}
-      height={height}
-      viewBox={`0 0 ${width} ${height}`}
-      className="block w-full"
-      preserveAspectRatio="none"
-      aria-hidden
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11.5px] font-medium text-fg/85">{windowLabel(window)}</span>
+        {pace ? <PacePill pace={pace} /> : null}
+      </div>
+
+      <div
+        className="relative h-2.5 w-full overflow-hidden rounded-full"
+        style={{ background: "rgba(255,255,255,0.07)" }}
+        role="progressbar"
+        aria-label={`${windowLabel(window)}: ${formatUsagePercent(percent)} used`}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(percent)}
+        title={headroomTitle(window, nowMs)}
+      >
+        <div
+          className="absolute inset-y-0 left-0 rounded-full"
+          style={{
+            width: `${grown ? percent : 0}%`,
+            background: fill,
+            transition: reducedMotion ? undefined : "width 700ms cubic-bezier(0.22,1,0.36,1)",
+          }}
+        />
+        {showTick ? (
+          <span
+            className="absolute top-[-1px] bottom-[-1px] w-px"
+            style={{ left: `${expected}%`, background: "rgba(255,255,255,0.6)" }}
+            aria-hidden
+            title={`Expected ~${Math.round(expected ?? 0)}% by now`}
+          />
+        ) : null}
+      </div>
+
+      <div className="text-[10.5px] tabular-nums text-fg/45">
+        <span>{formatUsagePercent(percent)} used</span>
+        <span>{` · ${formatResetIn(window.resetsAt, nowMs)}`}</span>
+      </div>
+    </div>
+  );
+}
+
+function PacePill({ pace }: { pace: PaceVisual }) {
+  return (
+    <span
+      className="inline-flex shrink-0 items-center gap-0.5 rounded-full px-1.5 py-[1px] text-[10px] font-medium leading-none"
+      style={{ color: pace.color, background: pace.tint }}
     >
+      {pace.label}
+      {pace.arrow ? <span aria-hidden>{pace.arrow}</span> : null}
+    </span>
+  );
+}
+
+// ── trend + sparkline ────────────────────────────────────────────
+
+function TrendLine({ pacing, nowMs }: { pacing?: UsagePacing | null; nowMs: number }) {
+  if (!pacing || pacing.weekElapsedPercent <= 0) return null;
+  const projected = Math.round(pacing.projectedWeeklyPercent);
+  const parts = [`trending to ${projected}% by reset`];
+  if (pacing.etaHours != null && pacing.etaHours > 0 && !pacing.willLastToReset) {
+    parts.push(`runs dry ~${formatClock(nowMs + pacing.etaHours * 3_600_000, nowMs)}`);
+  } else if (pacing.willLastToReset) {
+    parts.push("lasts to reset");
+  }
+  return <div className="text-[10.5px] text-fg/45">{parts.join(" · ")}</div>;
+}
+
+function Sparkline7d({ data, color, nowMs }: { data: number[]; color: string; nowMs: number }) {
+  const max = Math.max(1, ...data);
+  return (
+    <div className="flex h-4 items-end gap-[3px]">
       {data.map((value, index) => {
-        const h = Math.max(1, (value / max) * (height - 1));
-        const x = index * step + step * 0.1;
-        const w = step * 0.8;
+        const heightPx = Math.max(2, Math.round((value / max) * 16));
+        const isToday = index === data.length - 1;
+        const dayMs = nowMs - (data.length - 1 - index) * 86_400_000;
+        const date = new Date(dayMs);
+        const title = `${WEEKDAYS[date.getDay()]} ${date.getMonth() + 1}/${date.getDate()} · ${formatTokens(value)} tokens`;
         return (
-          <rect
+          <div
             key={index}
-            x={x}
-            y={height - h}
-            width={w}
-            height={h}
-            fill={color}
-            opacity={0.65}
+            title={title}
+            className="w-full rounded-[2px]"
+            style={{ minWidth: 4, height: heightPx, background: color, opacity: isToday ? 0.95 : 0.4 }}
           />
         );
       })}
-    </svg>
+    </div>
+  );
+}
+
+function ModelSplitLine({ breakdown }: { breakdown: Record<string, number> }) {
+  const entries = Object.entries(breakdown).filter(([, pct]) => pct > 0);
+  if (entries.length === 0) return null;
+  return (
+    <span className="truncate text-[10.5px] text-fg/45">
+      {entries.map(([model, pct]) => `${model} ${Math.round(pct)}%`).join(" · ")}
+    </span>
+  );
+}
+
+// ── provider card ────────────────────────────────────────────────
+
+function SkeletonRows() {
+  return (
+    <div className="space-y-3" aria-hidden>
+      {[0, 1].map((i) => (
+        <div key={i} className="space-y-1.5">
+          <div className="h-3 w-16 rounded bg-white/[0.05]" />
+          <div className="h-2.5 w-full overflow-hidden rounded-full bg-white/[0.05]">
+            <div className="h-full w-1/3 animate-pulse rounded-full bg-white/[0.09]" />
+          </div>
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -270,118 +475,117 @@ function ProviderUsageCard({
   provider,
   windows,
   connection,
+  status,
   dailyUsage7d,
   nowMs,
+  reducedMotion,
 }: {
   provider: UsageProvider;
   windows: UsageWindow[];
   connection: AiProviderConnectionStatus | null;
+  status: UsageProviderStatus | null;
   dailyUsage7d: number[] | null;
   nowMs: number;
+  reducedMotion: boolean;
 }) {
   const meta = PROVIDER_META[provider];
   const isAuthed = connection?.authAvailable !== false;
+  const isUsageUnauthed = status?.state === "unauthed";
 
-  // Unauthed: render the card dimmed with a single "Not signed in" line and
-  // no bars (matches the locked R2 wireframe).
-  if (!isAuthed) {
+  if (!isAuthed || isUsageUnauthed) {
     return (
-      <div className="space-y-2 rounded-lg p-4 opacity-50" style={CARD_SHADOW_STYLE}>
+      <div className="rounded-xl px-4 py-3.5 opacity-55" style={CARD_STYLE}>
         <div className="flex items-center justify-between gap-3">
-          <div className="flex items-center gap-2">
-            <span
-              className="h-2 w-2 shrink-0 rounded-full"
-              style={{ background: meta.color, opacity: 0.5 }}
-            />
-            <span className="text-[12px] font-bold tracking-[-0.2px] text-[#FAFAFA]">
-              {meta.label}
-            </span>
-          </div>
-          <span className="text-[11px] text-muted-fg">Not signed in</span>
+          <ProviderHeading color={meta.color} label={meta.label} dim />
+          <span className="text-[11px] text-fg/45">{status?.message ?? "Not signed in"}</span>
         </div>
       </div>
     );
   }
 
+  const fiveHourWindow = windows.find((w) => w.windowType === "five_hour");
   const weeklyWindow = windows.find((w) => w.windowType === "weekly");
   const monthlyWindow = windows.find((w) => w.windowType === "monthly");
   const trendWindow = weeklyWindow ?? monthlyWindow;
-  const fiveHourWindow = windows.find((w) => w.windowType === "five_hour");
-  const otherWindows = windows.filter(
-    (w) => w !== weeklyWindow && w !== monthlyWindow && w !== fiveHourWindow,
-  );
+  const secondaryWindows = [
+    ...(monthlyWindow && monthlyWindow !== trendWindow ? [monthlyWindow] : []),
+    ...windows.filter((w) => w !== fiveHourWindow && w !== weeklyWindow && w !== monthlyWindow),
+  ];
+  const has7d = !!dailyUsage7d && dailyUsage7d.some((value) => value > 0);
+  const modelBreakdown = trendWindow?.modelBreakdown;
 
   return (
-    <div className="space-y-3 rounded-lg p-4" style={CARD_SHADOW_STYLE}>
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2">
-          <span className="h-2 w-2 shrink-0 rounded-full" style={{ background: meta.color }} />
-          <span className="text-[12px] font-bold tracking-[-0.2px] text-[#FAFAFA]">
-            {meta.label}
+    <div className="rounded-xl px-4 py-3.5" style={CARD_STYLE}>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <ProviderHeading color={meta.color} label={meta.label} />
+        {status?.state === "stale" ? (
+          <span className="text-[10px] text-amber-300/70" title={status.message ?? "Showing last reading"}>
+            stale
           </span>
-        </div>
+        ) : null}
       </div>
 
       {windows.length > 0 ? (
         <div className="space-y-3">
           {fiveHourWindow ? (
-            <UsageMeter
-              key={`${provider}-five_hour`}
-              label={windowLabel(fiveHourWindow)}
-              percent={displayPercent(fiveHourWindow, nowMs)}
-              sublabel={formatResetSublabel(fiveHourWindow.resetsAt, nowMs)}
-              modelBreakdown={fiveHourWindow.modelBreakdown}
-              mode="used"
-              toneColor={meta.color}
-            />
+            <PaceBar window={fiveHourWindow} toneColor={meta.color} nowMs={nowMs} reducedMotion={reducedMotion} />
           ) : null}
-          {[weeklyWindow, monthlyWindow].map((window) => window ? (
-            <div className="space-y-1" key={`${provider}-${window.windowType}`}>
-              <UsageMeter
-                label={windowLabel(window)}
-                percent={displayPercent(window, nowMs)}
-                sublabel={formatResetSublabel(window.resetsAt, nowMs)}
-                modelBreakdown={window.modelBreakdown}
-                mode="used"
-                toneColor={meta.color}
-              />
-              {window === trendWindow && dailyUsage7d && dailyUsage7d.some((value) => value > 0) ? (
-                <div
-                  className="flex items-center gap-2"
-                  title="Daily token usage over the last 7 days (oldest → today)"
-                >
-                  <span className="font-mono text-[8px] uppercase tracking-[1px] text-[#71717A]">
-                    7d
-                  </span>
-                  <div className="flex-1">
-                    <Sparkline7d data={dailyUsage7d} color={meta.color} />
-                  </div>
+
+          {trendWindow ? (
+            <div className="space-y-1.5">
+              <PaceBar window={trendWindow} toneColor={meta.color} nowMs={nowMs} reducedMotion={reducedMotion} />
+              <TrendLine pacing={trendWindow.pacing} nowMs={nowMs} />
+            </div>
+          ) : null}
+
+          {modelBreakdown || has7d ? (
+            <div className="flex items-end justify-between gap-3 pt-0.5">
+              {modelBreakdown ? <ModelSplitLine breakdown={modelBreakdown} /> : <span />}
+              {has7d && dailyUsage7d ? (
+                <div className="flex items-center gap-2">
+                  <Sparkline7d data={dailyUsage7d} color={meta.color} nowMs={nowMs} />
+                  <span className="text-[9.5px] text-fg/35">7d</span>
                 </div>
               ) : null}
             </div>
-          ) : null)}
-          {otherWindows.map((window) => (
-            <UsageMeter
+          ) : null}
+
+          {secondaryWindows.map((window) => (
+            <PaceBar
               key={`${provider}-${window.windowType}`}
-              label={windowLabel(window)}
-              percent={displayPercent(window, nowMs)}
-              sublabel={formatResetSublabel(window.resetsAt, nowMs)}
-              modelBreakdown={window.modelBreakdown}
-              mode="used"
+              window={window}
               toneColor={meta.color}
+              nowMs={nowMs}
+              reducedMotion={reducedMotion}
             />
           ))}
         </div>
-      ) : (
-        <div className="text-[11px] text-muted-fg">
-          Waiting for the first usage poll…
+      ) : status?.state === "error" ? (
+        <div className="text-[11.5px] text-fg/45">
+          {status.message ?? "Couldn't reach this provider — retrying"}
         </div>
+      ) : (
+        <SkeletonRows />
       )}
     </div>
   );
 }
 
-function ExtraUsageCard({ extra }: { extra: ExtraUsage }) {
+function ProviderHeading({ color, label, dim }: { color: string; label: string; dim?: boolean }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        className="h-2 w-2 shrink-0 rounded-full"
+        style={{ background: color, opacity: dim ? 0.5 : 1, boxShadow: dim ? undefined : `0 0 8px ${color}66` }}
+      />
+      <span className="text-[12.5px] font-semibold tracking-[-0.01em] text-fg">{label}</span>
+    </div>
+  );
+}
+
+// ── extra usage (monthly spend) ──────────────────────────────────
+
+function ExtraUsageCard({ extra, reducedMotion }: { extra: ExtraUsage; reducedMotion: boolean }) {
   if (!extra.isEnabled) return null;
   if (extra.provider === "cursor") return null;
 
@@ -389,44 +593,37 @@ function ExtraUsageCard({ extra }: { extra: ExtraUsage }) {
   const usedUsd = extra.usedCreditsUsd;
   const limitUsd = extra.monthlyLimitUsd;
   const percent = limitUsd > 0 ? Math.min(100, (usedUsd / limitUsd) * 100) : 0;
-  let fillColor = meta.color;
-  if (percent > 90) fillColor = "#EF4444";
-  else if (percent > 70) fillColor = "#F59E0B";
-
-  const formatUsd = (v: number) => v.toLocaleString("en-US", { style: "currency", currency: extra.currency.toUpperCase() });
+  const fillColor = fillColorFor(percent, meta.color);
+  const formatUsd = (v: number) =>
+    v.toLocaleString("en-US", { style: "currency", currency: extra.currency.toUpperCase() });
 
   return (
-    <div className="mt-3 rounded-lg p-4" style={CARD_SHADOW_STYLE}>
-      <div className="flex items-center gap-2">
-        <span className="h-2 w-2 rounded-full" style={{ background: meta.color }} />
-        <span className="text-[12px] font-bold tracking-[-0.2px] text-[#FAFAFA]">
-          {meta.label} extra usage
+    <div className="rounded-xl px-4 py-3.5" style={CARD_STYLE}>
+      <div className="flex items-center justify-between gap-3">
+        <ProviderHeading color={meta.color} label={`${meta.label} extra usage`} />
+        <span className="text-[11px] tabular-nums text-fg/70">
+          {formatUsd(usedUsd)}
+          {limitUsd > 0 ? <span className="text-fg/40"> / {formatUsd(limitUsd)}</span> : null}
         </span>
       </div>
 
-      <div className="mt-3 space-y-1.5">
-        <div className="flex items-baseline justify-between gap-2">
-          <span className="font-mono text-[10px] font-bold uppercase tracking-[1px] text-[#A1A1AA]">
-            Monthly spend
-          </span>
-          <span className="font-mono text-[10px] font-bold text-[#FAFAFA]">
-            {formatUsd(usedUsd)}{limitUsd > 0 ? ` / ${formatUsd(limitUsd)}` : ""}
-          </span>
+      {limitUsd > 0 ? (
+        <div
+          className="mt-2.5 h-2.5 w-full overflow-hidden rounded-full"
+          style={{ background: "rgba(255,255,255,0.07)" }}
+        >
+          <div
+            className="h-full rounded-full"
+            style={{
+              width: `${percent}%`,
+              background: fillColor,
+              transition: reducedMotion ? undefined : "width 700ms cubic-bezier(0.22,1,0.36,1)",
+            }}
+          />
         </div>
-
-        {limitUsd > 0 ? (
-          <div className="relative h-2 w-full overflow-hidden" style={{ background: "#1A1720", border: "1px solid #1E1B26" }}>
-            <div
-              className="absolute inset-y-0 left-0 transition-all duration-500 ease-out"
-              style={{ width: `${percent}%`, background: fillColor }}
-            />
-          </div>
-        ) : (
-          <div className="font-mono text-[9px] text-[#71717A]">
-            No monthly limit configured
-          </div>
-        )}
-      </div>
+      ) : (
+        <div className="mt-2 text-[10.5px] text-fg/40">No monthly limit configured</div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/usage/UsageQuotaPanel.tsx
+++ b/apps/desktop/src/renderer/components/usage/UsageQuotaPanel.tsx
@@ -159,10 +159,13 @@ function ageMsFromIso(iso: string | undefined, nowMs: number): number {
   return nowMs - parsed;
 }
 
+let lastPanelCostRefreshAttemptAtMs = Number.NEGATIVE_INFINITY;
+
 function shouldRefreshPanelSnapshot(snapshot: UsageSnapshot | null, nowMs: number): boolean {
   if (!snapshot) return true;
   if (ageMsFromIso(snapshot.lastPolledAt, nowMs) > STALE_REFRESH_THRESHOLD_MS) return true;
-  return ageMsFromIso(snapshot.costsLastPolledAt, nowMs) > STALE_REFRESH_THRESHOLD_MS;
+  if (ageMsFromIso(snapshot.costsLastPolledAt, nowMs) <= STALE_REFRESH_THRESHOLD_MS) return false;
+  return nowMs - lastPanelCostRefreshAttemptAtMs > STALE_REFRESH_THRESHOLD_MS;
 }
 
 function usePrefersReducedMotion(): boolean {
@@ -225,6 +228,7 @@ export function UsageQuotaPanel({
 
       if (shouldRefreshPanelSnapshot(current, Date.now())) {
         try {
+          lastPanelCostRefreshAttemptAtMs = Date.now();
           const fresh = await bridge.refresh();
           if (!cancelled && fresh) applySnapshot(fresh);
         } catch {

--- a/apps/desktop/src/renderer/lib/resourcePressure.test.ts
+++ b/apps/desktop/src/renderer/lib/resourcePressure.test.ts
@@ -44,4 +44,19 @@ describe("resourcePressure", () => {
     expect(pressureLevelForThresholds(70, [30, 50, 70, 90])).toBe(3);
     expect(pressureLevelForThresholds(null, [30, 50, 70, 90])).toBe(0);
   });
+
+  it("describes runtime pressure by agent processes as well as ADE runtime count", () => {
+    const usage = makeUsage({
+      activePtyCount: 4,
+      ptyProcessCount: 9,
+      ptyCpuPercent: 71,
+      ptyMemoryMB: 1536,
+    });
+
+    const description = resourcePressureDescription(usage);
+    expect(description).toContain("4 live ADE runtimes");
+    expect(description).toContain("9 agent processes");
+    expect(description).toContain("71% CPU");
+    expect(description).toContain("1.5 GB");
+  });
 });

--- a/apps/desktop/src/renderer/lib/resourcePressure.ts
+++ b/apps/desktop/src/renderer/lib/resourcePressure.ts
@@ -85,7 +85,8 @@ function preferPositiveMetric(primary: number | null | undefined, fallback: numb
 
 export function resourcePressureDescription(usage: AppResourceUsageSnapshot | null): string {
   const details = [
-    usage?.activePtyCount ? `${usage.activePtyCount} live terminal${usage.activePtyCount === 1 ? "" : "s"}` : null,
+    usage?.activePtyCount ? `${usage.activePtyCount} live ADE runtime${usage.activePtyCount === 1 ? "" : "s"}` : null,
+    usage?.ptyProcessCount ? `${usage.ptyProcessCount} agent process${usage.ptyProcessCount === 1 ? "" : "es"}` : null,
     formatPercent(preferPositiveMetric(usage?.ptyCpuPercent, usage?.cpuPercent)),
     formatMemory(preferPositiveMetric(usage?.ptyMemoryMB, usage?.memoryMB)),
   ].filter((part): part is string => Boolean(part));

--- a/apps/desktop/src/shared/types/config.ts
+++ b/apps/desktop/src/shared/types/config.ts
@@ -304,6 +304,8 @@ export type ConfigLaneTemplate = {
  */
 export const NO_DEFAULT_LANE_TEMPLATE = "__ade_none__";
 
+export type NewLaneBaseSource = "local" | "remote";
+
 /** IPC args for listing templates */
 export type ListLaneTemplatesArgs = Record<string, never>;
 
@@ -1434,6 +1436,7 @@ export type ProjectConfigFile = {
   };
   git?: {
     autoRebaseOnHeadChange?: boolean;
+    newLaneBaseSource?: NewLaneBaseSource;
   };
   ai?: AiConfig;
   /** Default lane environment initialization config */
@@ -1476,6 +1479,7 @@ export type EffectiveProjectConfig = {
   };
   git: {
     autoRebaseOnHeadChange: boolean;
+    newLaneBaseSource: NewLaneBaseSource;
   };
   ai?: AiConfig;
   /** Default lane environment initialization config */

--- a/apps/desktop/src/shared/types/sessions.ts
+++ b/apps/desktop/src/shared/types/sessions.ts
@@ -167,6 +167,11 @@ export type PtyCreateResult = {
   pid: number | null;
 };
 
+export type PtyDisposeResult = {
+  disposed: boolean;
+  reason: "disposed" | "orphaned" | "missing" | "not-running" | "session-mismatch" | "owned-by-peer" | "already-disposed";
+};
+
 export type PtySendToSessionArgs = {
   sessionId: string;
   text: string;

--- a/apps/desktop/src/shared/types/usage.ts
+++ b/apps/desktop/src/shared/types/usage.ts
@@ -223,6 +223,8 @@ export type UsageWindow = {
   resetsAt: string;
   resetsInMs: number;
   windowDurationMs?: number;
+  /** Pace of this specific window (ahead/behind a steady burn). Computed per-window. */
+  pacing?: UsagePacing;
 };
 
 export type UsagePacingStatus =
@@ -253,6 +255,28 @@ export type UsagePacing = {
 };
 
 export type UsagePacingByProvider = Partial<Record<UsageProvider, UsagePacing>>;
+
+/**
+ * Per-provider freshness/health for the most recent poll. Lets the UI keep
+ * showing last-good numbers while signalling a quiet retry, instead of wiping
+ * data and surfacing a raw error string.
+ *
+ * - `ok`       — this poll returned fresh windows.
+ * - `stale`    — this poll failed, but we are still showing carried-forward data.
+ * - `unauthed` — no credentials for this provider (sign-in required).
+ * - `error`    — this poll failed and there is no prior data to fall back to.
+ */
+export type UsageProviderState = "ok" | "stale" | "unauthed" | "error";
+
+export type UsageProviderStatus = {
+  state: UsageProviderState;
+  /** ISO timestamp of the last poll that returned real windows, if any. */
+  lastSuccessAt: string | null;
+  /** Friendly, log-free reason for a non-ok state (e.g. "Couldn't reach Claude"). */
+  message?: string;
+};
+
+export type UsageProviderStatusMap = Partial<Record<UsageProvider, UsageProviderStatus>>;
 
 export type CostTokenBreakdown = {
   input: number;
@@ -286,12 +310,16 @@ export type UsageSnapshot = {
   windows: UsageWindow[];
   pacing: UsagePacing;
   pacingByProvider?: UsagePacingByProvider;
+  /** Per-provider freshness/health for the latest poll (drives quiet-retry UI). */
+  providerStatus?: UsageProviderStatusMap;
   costs: CostSnapshot[];
   /** Local runtime usage that can be attributed specifically to ADE-originated sessions. */
   adeCosts?: CostSnapshot[];
   extraUsage: ExtraUsage[];
   /** Per-provider daily token usage for the last 7 calendar days, oldest first. */
   dailyUsage7d?: Partial<Record<UsageProvider, number[]>>;
+  /** ISO timestamp of the last poll that included local cost/history scans. */
+  costsLastPolledAt?: string;
   lastPolledAt: string;
   errors: string[];
 };


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fusage-bar-fix-bbe8e7a3 num=536 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fusage-bar-fix-bbe8e7a3&amp;pr=536">ade/usage-bar-fix-bbe8e7a3 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=536">PR #536</a>
</p>
<!-- /ade:link -->

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/ea733550-1e2d-4080-8238-4f5da3df27af/pull/536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose Remote vs Local as the default base when creating new lanes; setting available in Lane Behavior.
  * PTY disposal now returns structured status info to surface precise outcomes.

* **Improvements**
  * Usage tracking shows per-provider health status and fresher relative-time labels.
  * Terminal paste handling and renderer robustness improved.
  * Better prevention of UI flicker when stopping sessions.

* **Bug Fixes**
  * Preserve remote branches when local branches lack upstreams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a broad multi-area update: it redesigns the usage quota panel with stale carry-forward, per-provider health status, and pacing bars; adds a remote-vs-local base-source picker for new lane creation; returns structured status from `pty.dispose`; and fixes several terminal input-handling issues.

- **Usage panel** (`UsageQuotaPanel.tsx`, `usageTrackingService.ts`, `HeaderUsageControl.tsx`): Replaces the polling-on-open pattern with an `onUpdate` subscription and a conditional background refresh; adds `fetchJsonWithRetry` (retries only 5xx, never 4xx), per-provider `providerStatus` carry-forward, and a live \"updated Xs ago\" indicator with a green/amber health dot.
- **Lane base source** (`newLaneBaseSource.ts`, `LanesPage.tsx`, `CreateLaneDialog.tsx`, `LaneBehaviorSection.tsx`): Introduces a configurable remote/local base-source preference, load-sequenced branch fetching, and a serialised config-save loop; also fixes remote-branch deduplication in `gitOperationsService.ts` to preserve untracked remote branches.
- **PTY & terminal** (`ptyService.ts`, `TerminalView.tsx`, `useLaneWorkSessions.ts`): Changes `dispose` to return `PtyDisposeResult`, adds an optimistic session-stop UI with a 12 s guard against concurrent-refresh undo, tracks `bracketedPasteMode` for correct Shift+Enter handling, and clears the texture atlas on fit to prevent ghost artefacts.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one terminal paste regression to resolve first.

The clipboard paste handler calls ev.preventDefault() / ev.stopPropagation() and forwards raw text to the PTY, bypassing xterm's own bracketed-paste logic. Now that the PR tracks bracketedPasteMode and applies it to Shift+Enter, the same wrapping is expected for Cmd+V paste — but is absent from both the synchronous paste listener and the async navigator.clipboard.readText fallback. Multi-line Cmd+V paste into vim insert mode will still execute lines as commands. The usage-panel and lane-base-source changes are well-structured with appropriate guards, and no other runtime-breaking issues were found.

apps/desktop/src/renderer/components/terminals/TerminalView.tsx — the clipboard paste paths need the same bracketedPasteMode wrap that Shift+Enter received.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/usage/UsageQuotaPanel.tsx | Major redesign: drops manual load/refresh in favour of an onUpdate subscription + single background refresh on open. Adds pacing bars, sparklines, per-provider status, and stale carry-forward display. |
| apps/desktop/src/main/services/usage/usageTrackingService.ts | Adds fetchJsonWithRetry (retries only 5xx/network errors, never 4xx), per-provider status tracking with stale-carry-forward, and buildProviderWindows reconciliation. Logic is well-guarded and the retry policy is clearly documented. |
| apps/desktop/src/renderer/components/terminals/TerminalView.tsx | Adds bracketedPasteMode tracking and wraps Shift+Enter correctly, but the synchronous paste event listener and async clipboard fallback both still send raw text without bracketed-paste escapes, leaving Cmd+V broken in vim/nvim when bracketed paste mode is active. |
| apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts | Replaces fire-and-forget dispose with a structured optimistic update: marks session disposed before the IPC call and restores on failure, backed by a 12 s guard in stoppedRuntimeSessionsRef to survive concurrent refreshes. |
| apps/desktop/src/renderer/components/lanes/newLaneBaseSource.ts | New helper module for remote-vs-local lane base selection. Pure functions, well-tested, timeout handled in finally block. |
| apps/desktop/src/renderer/components/lanes/LanesPage.tsx | Adds remote/local base-source picker to lane creation, with load-sequencing via createBaseBranchesLoadSeqRef and a serialised save loop via persistCreateBaseSourceConfig. |
| apps/desktop/src/main/services/pty/ptyService.ts | Changes dispose return type from void to PtyDisposeResult, adds idlePersistedChatRuntime computation for idle state. All return paths now provide structured status. |
| apps/desktop/src/renderer/components/usage/HeaderUsageControl.tsx | Adds a live 'updated Xs ago' label that ticks only while the popup is open, plus a green/amber dot for provider health status. Timer lifecycle is correct. |
| apps/desktop/src/main/services/git/gitOperationsService.ts | Fixes remote-branch deduplication: now only suppresses a remote when the local branch explicitly tracks it, preserving untracked remote branches in the picker. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[UsageQuotaPanel mounts] --> B[bridge.getSnapshot]
    B --> C{snapshot fresh?}
    C -- yes --> D[render cached data]
    C -- no / null --> E[bridge.refresh in background]
    E --> F{refresh ok?}
    F -- yes --> G[applySnapshot with fresh data]
    F -- no --> H[keep last-good data\nmark provider stale/error]
    G --> D
    H --> D
    D --> I[bridge.onUpdate subscription\nlive poll updates]
    I --> D
    subgraph usageTrackingService poll
        J[pollClaudeUsage + pollCodexUsage] --> K[fetchJsonWithRetry\nretry 5xx only]
        K --> L{fresh windows?}
        L -- yes --> M[providerStatus: ok]
        L -- no --> N[filterUnexpiredCarriedWindows]
        N --> O{carried windows?}
        O -- yes --> P[providerStatus: stale]
        O -- no --> Q[providerStatus: error]
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts`, line 772-827 ([link](https://github.com/arul28/ade/blob/73bddd33222a83e705a8ec38228cb99eafb5fdd8/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts#L772-L827)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Optimistic update creates a narrow race with concurrent refreshes**

   The session is immediately marked "disposed" via `setSessions` before `stoppedRuntimeSessionsRef` is populated. If a concurrent refresh fires between that optimistic call and when the `dispose` result is received (e.g., triggered by an IPC event during the async call), `processRows` will see the session is NOT in `stoppedRuntimeSessionsRef` and will restore it to "running" from the server response — briefly undoing the optimistic state. The guard only becomes effective after the `try` block resolves.

   The window is short (one IPC round-trip), but the visual flicker is real if another refresh lands mid-flight, particularly for slow `dispose` calls under load.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
   Line: 772-827

   Comment:
   **Optimistic update creates a narrow race with concurrent refreshes**

   The session is immediately marked "disposed" via `setSessions` before `stoppedRuntimeSessionsRef` is populated. If a concurrent refresh fires between that optimistic call and when the `dispose` result is received (e.g., triggered by an IPC event during the async call), `processRows` will see the session is NOT in `stoppedRuntimeSessionsRef` and will restore it to "running" from the server response — briefly undoing the optimistic state. The guard only becomes effective after the `try` block resolves.

   The window is short (one IPC round-trip), but the visual flicker is real if another refresh lands mid-flight, particularly for slow `dispose` calls under load.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Flanes%2FuseLaneWorkSessions.ts%0ALine%3A%20772-827%0A%0AComment%3A%0A**Optimistic%20update%20creates%20a%20narrow%20race%20with%20concurrent%20refreshes**%0A%0AThe%20session%20is%20immediately%20marked%20%22disposed%22%20via%20%60setSessions%60%20before%20%60stoppedRuntimeSessionsRef%60%20is%20populated.%20If%20a%20concurrent%20refresh%20fires%20between%20that%20optimistic%20call%20and%20when%20the%20%60dispose%60%20result%20is%20received%20%28e.g.%2C%20triggered%20by%20an%20IPC%20event%20during%20the%20async%20call%29%2C%20%60processRows%60%20will%20see%20the%20session%20is%20NOT%20in%20%60stoppedRuntimeSessionsRef%60%20and%20will%20restore%20it%20to%20%22running%22%20from%20the%20server%20response%20%E2%80%94%20briefly%20undoing%20the%20optimistic%20state.%20The%20guard%20only%20becomes%20effective%20after%20the%20%60try%60%20block%20resolves.%0A%0AThe%20window%20is%20short%20%28one%20IPC%20round-trip%29%2C%20but%20the%20visual%20flicker%20is%20real%20if%20another%20refresh%20lands%20mid-flight%2C%20particularly%20for%20slow%20%60dispose%60%20calls%20under%20load.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=536&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fterminals%2FTerminalView.tsx%3A1829-1874%0A**Clipboard%20paste%20ignores%20%60bracketedPasteMode%60**%0A%0AThis%20PR%20introduces%20%60runtime.bracketedPasteMode%60%20tracking%20and%20wraps%20Shift%2BEnter%20in%20the%20%60ESC%5B200~%60%2F%60ESC%5B201~%60%20sequences%20when%20the%20mode%20is%20active.%20However%2C%20both%20clipboard%20paste%20paths%20%28the%20synchronous%20%60paste%60%20event%20listener%20at%20line%201835%20and%20the%20async%20%60navigator.clipboard.readText%60%20fallback%20at%20line%201866%29%20call%20%60writePtyInput%28runtime%2C%20text%29%60%20without%20those%20sequences.%20Because%20the%20listener%20calls%20%60ev.preventDefault%28%29%60%20and%20%60ev.stopPropagation%28%29%60%2C%20xterm.js%20never%20sees%20the%20event%20and%20cannot%20apply%20its%20own%20bracketed-paste%20handling.%20As%20a%20result%2C%20pasting%20multi-line%20clipboard%20content%20into%20vim%2Fnvim%20insert%20mode%20via%20Cmd%2BV%20sends%20raw%20newlines%20that%20are%20interpreted%20as%20commands%20rather%20than%20as%20literal%20text%20%E2%80%94%20the%20exact%20problem%20bracketed%20paste%20mode%20is%20designed%20to%20prevent%2C%20now%20inconsistently%20fixed%20only%20for%20Shift%2BEnter.%0A%0A&repo=arul28%2Fade&pr=536&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/renderer/components/terminals/TerminalView.tsx:1829-1874
**Clipboard paste ignores `bracketedPasteMode`**

This PR introduces `runtime.bracketedPasteMode` tracking and wraps Shift+Enter in the `ESC[200~`/`ESC[201~` sequences when the mode is active. However, both clipboard paste paths (the synchronous `paste` event listener at line 1835 and the async `navigator.clipboard.readText` fallback at line 1866) call `writePtyInput(runtime, text)` without those sequences. Because the listener calls `ev.preventDefault()` and `ev.stopPropagation()`, xterm.js never sees the event and cannot apply its own bracketed-paste handling. As a result, pasting multi-line clipboard content into vim/nvim insert mode via Cmd+V sends raw newlines that are interpreted as commands rather than as literal text — the exact problem bracketed paste mode is designed to prevent, now inconsistently fixed only for Shift+Enter.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Fix lane behavior source toggle save"](https://github.com/arul28/ade/commit/3d6ddb61554be5e9d002354a11ed790853a0dc20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36071483)</sub>

<!-- /greptile_comment -->