### PR TITLE
chat-20260608-042211

### DIFF
--- a/apps/desktop/src/main/services/prs/prService.test.ts
+++ b/apps/desktop/src/main/services/prs/prService.test.ts
@@ -239,6 +239,7 @@ interface BuildServiceOpts {
   db?: any;
   conflictService?: any;
   projectConfigService?: any;
+  aiIntegrationService?: any;
 }
 
 function buildService(opts: BuildServiceOpts = {}) {
@@ -281,6 +282,7 @@ function buildService(opts: BuildServiceOpts = {}) {
     githubService,
     conflictService: opts.conflictService,
     projectConfigService: opts.projectConfigService ?? makeProjectConfigService(),
+    ...(opts.aiIntegrationService ? { aiIntegrationService: opts.aiIntegrationService } : {}),
     openExternal: vi.fn(async () => {}),
   });
 
@@ -2783,6 +2785,78 @@ describe("prService.land", () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/merge conflicts/i);
     expect(githubService.apiRequest).not.toHaveBeenCalledWith(expect.objectContaining({ method: "PUT" }));
+  });
+});
+
+describe("prService.draftDescription", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const makeAi = (impl?: () => unknown) =>
+    ({ draftPrDescription: vi.fn(impl ?? (() => undefined)) }) as any;
+
+  // Regression: the in-chat "AI draft" button (requireAi) must run the real AI
+  // path using the chat's own model even though the stored providerMode is the
+  // default "guest" — providerMode is NOT derived from live CLI auth, so a chat
+  // running on a connected runtime would otherwise be wrongly refused.
+  it("runs the AI path on the chat's model when requireAi is set, even in guest providerMode", async () => {
+    // NB: this file mocks extractFirstJsonObject → null, so parsePrDraftJson
+    // always falls back to using the raw model text as the body. We assert the
+    // call shape (the regression) and that the AI output reaches the draft.
+    const aiIntegrationService = makeAi(async () => ({ text: "Drafted by the chat model." }));
+    const { service } = buildService({ aiIntegrationService });
+
+    const draft = await (service as any).draftDescription({
+      laneId: LANE_ID,
+      requireAi: true,
+      model: "openai/gpt-5.5",
+    });
+
+    expect(aiIntegrationService.draftPrDescription).toHaveBeenCalledTimes(1);
+    expect(aiIntegrationService.draftPrDescription.mock.calls[0][0]).toMatchObject({
+      laneId: LANE_ID,
+      model: "openai/gpt-5.5",
+    });
+    expect(draft.body).toContain("Drafted by the chat model.");
+  });
+
+  it("surfaces a precise error (not the misleading provider message) when no AI service exists", async () => {
+    const { service } = buildService();
+
+    await expect(
+      (service as any).draftDescription({ laneId: LANE_ID, requireAi: true }),
+    ).rejects.toThrow(/open this lane in the desktop app to draft with AI/);
+  });
+
+  it("returns the deterministic template (no AI call) when requireAi is not set in guest mode", async () => {
+    const aiIntegrationService = makeAi();
+    const { service } = buildService({ aiIntegrationService });
+
+    const draft = await (service as any).draftDescription({ laneId: LANE_ID });
+
+    expect(aiIntegrationService.draftPrDescription).not.toHaveBeenCalled();
+    expect(draft.body).toContain("## Summary");
+  });
+
+  it("treats an empty (non-throwing) model response as a failure when requireAi is set", async () => {
+    const aiIntegrationService = makeAi(async () => ({ text: "   " }));
+    const { service } = buildService({ aiIntegrationService });
+
+    await expect(
+      (service as any).draftDescription({ laneId: LANE_ID, requireAi: true }),
+    ).rejects.toThrow(/AI draft failed: the model returned an empty response\./);
+  });
+
+  it("rethrows AI failures as an explicit draft error when requireAi is set", async () => {
+    const aiIntegrationService = makeAi(async () => {
+      throw new Error("No AI provider is available.");
+    });
+    const { service } = buildService({ aiIntegrationService });
+
+    await expect(
+      (service as any).draftDescription({ laneId: LANE_ID, requireAi: true }),
+    ).rejects.toThrow(/AI draft failed: No AI provider is available\./);
   });
 });
 

--- a/apps/desktop/src/main/services/prs/prService.ts
+++ b/apps/desktop/src/main/services/prs/prService.ts
@@ -4432,15 +4432,20 @@ export function createPrService({
       };
     };
 
-    // When the caller demands AI (the in-chat "AI draft" button), surface a clear
-    // error instead of silently falling through to the deterministic template.
-    if (args.requireAi && (providerMode === "guest" || !aiIntegrationService)) {
+    // The in-chat "AI draft" button sets requireAi. The chat is already running on
+    // a live runtime, so the coarse stored providerMode — which stays "guest" until
+    // the user explicitly enables subscription mode in Settings → AI Connections,
+    // and is NOT derived from active CLI auth — must NOT gate it. We attempt the
+    // real AI path using the chat's own model and let aiIntegrationService.executeTask
+    // perform the authoritative auth/runtime detection, surfacing a precise error
+    // only when no provider is genuinely reachable.
+    if (args.requireAi && !aiIntegrationService) {
       throw new Error(
-        "AI drafting is unavailable — connect a model provider in Settings → AI Connections.",
+        "AI drafting is unavailable in this mode — open this lane in the desktop app to draft with AI.",
       );
     }
 
-    if (providerMode !== "guest" && aiIntegrationService) {
+    if (aiIntegrationService && (providerMode !== "guest" || args.requireAi)) {
       const prompt = [
         "You are ADE's PR drafting assistant. Keep content factual and concise.",
         "Return JSON only with shape: {\"title\": string, \"body\": string}.",
@@ -4467,6 +4472,13 @@ export function createPrService({
             title: defaultTitle,
             body: `${draft.text.trim()}\n`
           });
+        }
+
+        // requireAi promises a real AI draft, never a stub template — so an empty
+        // (but non-throwing) model response is itself a failure to surface. The
+        // catch below adds the "AI draft failed:" prefix.
+        if (args.requireAi) {
+          throw new Error("the model returned an empty response.");
         }
       } catch (error) {
         logger.warn("prs.draft.ai_failed", {

--- a/apps/desktop/src/renderer/components/chat/ChatPrInlineCreator.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPrInlineCreator.tsx
@@ -13,6 +13,7 @@ import { BranchIcon } from "../ui/vcsIcons";
 import { LaneCombobox } from "../terminals/LaneCombobox";
 import { LaneLogoMark, laneDisplayColor } from "../terminals/LaneChip";
 import { useAppStore } from "../../state/appStore";
+import type { PrSummary } from "../../../shared/types";
 import { branchNameFromRef, resolveLaneBaseBranch } from "../prs/shared/laneBranchTargets";
 import {
   buildLinearPrReference,
@@ -35,8 +36,9 @@ import {
  * inject Linear magic words or the "Open in ADE" deeplink footer here — prService
  * owns those trailers on create (idempotently), so the editable fields stay clean.
  *
- * On success we do NOT navigate: ChatPrPane's `prs.onEvent` subscription swaps to
- * the live PR-details panel automatically.
+ * On success we do NOT navigate: we hand the freshly-created PR up via `onCreated`
+ * so ChatPrPane swaps to the live PR-details panel immediately (the subsequent
+ * `prs.onEvent` poll just enriches the same row with checks/review state).
  */
 
 const sectionLabel = "block text-[10px] font-semibold uppercase tracking-[0.08em] text-fg/45";
@@ -50,11 +52,18 @@ export const ChatPrInlineCreator = React.memo(function ChatPrInlineCreator({
   laneId,
   branchName,
   chatModelId,
+  onCreated,
 }: {
   laneId: string;
   branchName?: string | null;
   /** The active chat session's model — the AI draft runs on this exact model. */
   chatModelId?: string | null;
+  /**
+   * Called the instant `createFromLane` resolves, with the freshly-created PR.
+   * The parent swaps to the live PR-details view immediately instead of waiting
+   * for the next GitHub polling round-trip (`prs-updated`) to arrive.
+   */
+  onCreated?: (pr: PrSummary) => void;
 }) {
   const navigate = useNavigate();
   const lanes = useAppStore((s) => s.lanes);
@@ -180,7 +189,7 @@ export const ChatPrInlineCreator = React.memo(function ChatPrInlineCreator({
         linearIssue && !title.trim()
           ? buildLinearPrTitle(linearIssue)
           : title.trim() || lane?.name || branchName || "PR";
-      await window.ade.prs.createFromLane({
+      const created = await window.ade.prs.createFromLane({
         laneId,
         title: resolvedTitle,
         body,
@@ -188,13 +197,22 @@ export const ChatPrInlineCreator = React.memo(function ChatPrInlineCreator({
         ...(linearIssue ? { closeLinearIssueOnMerge: true } : {}),
         ...(resolvedBaseBranch ? { baseBranch: resolvedBaseBranch } : {}),
       });
-      // Success: ChatPrPane's prs.onEvent subscription swaps to the details view
-      // automatically, so we leave busy=true until this unmounts.
+      // createFromLane has already persisted the PR row and returns the full
+      // summary — hand it straight to the parent so it swaps to the details view
+      // in real time. We deliberately leave busy=true: onCreated unmounts this
+      // creator, and the later `prs-updated` poll just enriches the same PR.
+      // Production always returns a PrSummary; only the web-preview mock can
+      // resolve null — recover the button in that case rather than spinning.
+      if (created) {
+        onCreated?.(created);
+      } else {
+        setBusy(false);
+      }
     } catch (err: unknown) {
       setError(cleanError(err));
       setBusy(false);
     }
-  }, [body, branchName, lane?.name, laneId, linearIssue, resolvedBaseBranch, title]);
+  }, [body, branchName, lane?.name, laneId, linearIssue, onCreated, resolvedBaseBranch, title]);
 
   // The full composer (queue / integration + multi-lane ordering) lives in the
   // PRs tab; this just hands off with the lane pre-selected.

--- a/apps/desktop/src/renderer/components/chat/ChatPrInlineCreator.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPrInlineCreator.tsx
@@ -61,9 +61,11 @@ export const ChatPrInlineCreator = React.memo(function ChatPrInlineCreator({
   /**
    * Called the instant `createFromLane` resolves, with the freshly-created PR.
    * The parent swaps to the live PR-details view immediately instead of waiting
-   * for the next GitHub polling round-trip (`prs-updated`) to arrive.
+   * for the next GitHub polling round-trip (`prs-updated`) to arrive. Required:
+   * the success path relies on the parent unmounting this creator, so omitting
+   * it would leave the button stuck "Creating…".
    */
-  onCreated?: (pr: PrSummary) => void;
+  onCreated: (pr: PrSummary) => void;
 }) {
   const navigate = useNavigate();
   const lanes = useAppStore((s) => s.lanes);
@@ -204,7 +206,7 @@ export const ChatPrInlineCreator = React.memo(function ChatPrInlineCreator({
       // Production always returns a PrSummary; only the web-preview mock can
       // resolve null — recover the button in that case rather than spinning.
       if (created) {
-        onCreated?.(created);
+        onCreated(created);
       } else {
         setBusy(false);
       }

--- a/apps/desktop/src/renderer/components/chat/ChatPrPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPrPane.tsx
@@ -128,10 +128,10 @@ export const ChatPrPane = React.memo(function ChatPrPane({
 
   // The inline creator hands us the freshly-created PR the moment createFromLane
   // resolves — swap to the details view instantly rather than waiting for the
-  // next GitHub polling round-trip (`prs-updated`) to refresh the row.
+  // next GitHub polling round-trip (`prs-updated`) to refresh the row. (The
+  // creator only renders once `loading` is false, so no setLoading needed here.)
   const handleCreated = useCallback((created: PrSummary) => {
     setPr(created);
-    setLoading(false);
   }, []);
 
   useEffect(() => { void refresh(); }, [refresh]);

--- a/apps/desktop/src/renderer/components/chat/ChatPrPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPrPane.tsx
@@ -126,6 +126,14 @@ export const ChatPrPane = React.memo(function ChatPrPane({
     }
   }, [laneId]);
 
+  // The inline creator hands us the freshly-created PR the moment createFromLane
+  // resolves — swap to the details view instantly rather than waiting for the
+  // next GitHub polling round-trip (`prs-updated`) to refresh the row.
+  const handleCreated = useCallback((created: PrSummary) => {
+    setPr(created);
+    setLoading(false);
+  }, []);
+
   useEffect(() => { void refresh(); }, [refresh]);
 
   useEffect(() => {
@@ -179,7 +187,12 @@ export const ChatPrPane = React.memo(function ChatPrPane({
             onCopy={() => void copyLink()}
           />
         ) : (
-          <ChatPrInlineCreator laneId={laneId} branchName={branchName ?? null} chatModelId={chatModelId ?? null} />
+          <ChatPrInlineCreator
+            laneId={laneId}
+            branchName={branchName ?? null}
+            chatModelId={chatModelId ?? null}
+            onCreated={handleCreated}
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fchat-20260608-042211-2c3154e3 num=540 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fchat-20260608-042211-2c3154e3&amp;pr=540">ade/chat-20260608-042211-2c3154e3 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=540">PR #540</a>
</p>
<!-- /ade:link -->

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/ea733550-1e2d-4080-8238-4f5da3df27af/pull/540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when AI services are unavailable for PR drafting
  * Enhanced handling of empty AI responses during automated description generation

* **Improvements**
  * Pull requests now display immediately after creation without waiting for background refresh

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent issues: the in-chat AI draft button now works for users whose stored `providerMode` is `"guest"` (the common case when running a live runtime via CLI auth), and PRs now appear in the chat pane immediately after creation instead of waiting for the next GitHub polling cycle.

- **`prService.ts`**: The `requireAi` guard no longer checks `providerMode === \"guest\"` — it only blocks when `aiIntegrationService` is entirely absent. The AI-path entry condition is updated to match (`providerMode !== \"guest\" || args.requireAi`), and an empty-but-non-throwing model response is now surfaced as an explicit error when `requireAi` is set.
- **`ChatPrInlineCreator` / `ChatPrPane`**: `createFromLane`'s return value is now forwarded to the parent via a new required `onCreated` callback; `ChatPrPane` calls `setPr(created)` immediately, with the subsequent `prs-updated` poll only enriching the existing row.

<h3>Confidence Score: 5/5</h3>

All changes are safe to merge — the logic is self-consistent, well-tested, and the only caller of the updated component has been updated accordingly.

The providerMode gate removal is narrow and deliberate, backed by four new unit tests covering the regression, the no-service error, the template fallback, the empty-response case, and rethrown AI errors. The onCreated callback is TypeScript-required and the only consumer passes it correctly.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/prs/prService.ts | Fixes requireAi gate to bypass stored providerMode, adds empty-response error, and adjusts the AI-path condition — logic is sound and well-commented |
| apps/desktop/src/main/services/prs/prService.test.ts | Adds four focused tests for draftDescription covering the regression, no-AI error, template fallback, empty response, and rethrown AI errors — good coverage |
| apps/desktop/src/renderer/components/chat/ChatPrInlineCreator.tsx | Adds required onCreated callback prop; PR creation now immediately notifies the parent with the returned summary instead of relying on polling |
| apps/desktop/src/renderer/components/chat/ChatPrPane.tsx | Adds handleCreated callback that calls setPr(created) directly, wiring the instant-display behavior; clean and minimal change |

</details>

<sub>Reviews (2): Last reviewed commit: ["Address PR review: make ChatPrInlineCrea..."](https://github.com/arul28/ade/commit/1e1234f0b309ba55fd3be938d8b12594dbcdf223) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36252385)</sub>

<!-- /greptile_comment -->