### PR TITLE
Fix chat scroll gap/lock and reword working indicator

### DIFF
--- a/apps/desktop/src/renderer/components/chat/AgentChatMessageList.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatMessageList.test.tsx
@@ -47,7 +47,9 @@ vi.mock("@lobehub/icons", () => {
 import {
   AgentChatMessageList,
   calculateVirtualWindow,
+  calculateVirtualWindowAnchoredToEnd,
   deriveTurnModelState,
+  formatElapsedSeconds,
   reconcileMeasuredScrollTop,
   shouldAbsorbProgrammaticScrollEvent,
   shouldStickToBottomAfterScroll,
@@ -1244,6 +1246,45 @@ describe("AgentChatMessageList transcript rendering", () => {
     expect(updated.offsetTop).toBeGreaterThan(baseline.offsetTop);
   });
 
+  it("anchors the follow-bottom window to the last row regardless of stale estimates", () => {
+    const win = calculateVirtualWindowAnchoredToEnd({
+      rowCount: 100,
+      containerHeight: 240,
+      rowHeight: () => 80,
+      rowGap: 0,
+    });
+    // The tail must always be mounted so the streaming indicator stays flush.
+    expect(win.endIndex).toBe(100);
+    // Window must cover the viewport (240 / 80 = 3 rows) plus overscan.
+    expect(win.startIndex).toBeLessThan(100 - 3);
+    // offsetTop + rendered estimate must reconstruct totalHeight exactly so
+    // there is no phantom gap below the rendered rows.
+    const renderedEstimate = (100 - win.startIndex) * 80;
+    expect(win.offsetTop + renderedEstimate).toBe(win.totalHeight);
+  });
+
+  it("keeps the anchored window valid when the viewport is taller than the content", () => {
+    const win = calculateVirtualWindowAnchoredToEnd({
+      rowCount: 3,
+      containerHeight: 2000,
+      rowHeight: () => 80,
+      rowGap: 0,
+    });
+    expect(win.startIndex).toBe(0);
+    expect(win.endIndex).toBe(3);
+    expect(win.offsetTop).toBe(0);
+  });
+
+  it("formats turn elapsed time as working-for seconds then minutes", () => {
+    expect(formatElapsedSeconds(0)).toBe("0s");
+    expect(formatElapsedSeconds(42)).toBe("42s");
+    expect(formatElapsedSeconds(59)).toBe("59s");
+    expect(formatElapsedSeconds(60)).toBe("1m 00s");
+    expect(formatElapsedSeconds(65)).toBe("1m 05s");
+    expect(formatElapsedSeconds(793)).toBe("13m 13s");
+    expect(formatElapsedSeconds(-5)).toBe("0s");
+  });
+
   it("does not vertically clip virtualized transcript rows while heights settle", () => {
     const originalResizeObserver = globalThis.ResizeObserver;
     class ResizeObserverStub {
@@ -1479,6 +1520,10 @@ describe("AgentChatMessageList transcript rendering", () => {
     // the raw tool detail (kept calm — t3code / Codex reference).
     expect(streaming.container.textContent).toContain("Running command");
     expect(streaming.container.textContent).not.toContain("npm test");
+    // Elapsed reads as "working for <duration>" so the timer is attributed to
+    // the whole turn, not the current sub-action. The space before the digits
+    // guards against JSX collapsing "working for " into "working for0s".
+    expect(streaming.container.textContent).toMatch(/working for \d/);
 
     cleanup();
 

--- a/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
@@ -1140,6 +1140,20 @@ function ThinkingDots({ toneClass = "bg-emerald-300/70" }: { toneClass?: string 
 const LONG_RUNNING_TURN_SECONDS = 30;
 
 /**
+ * Formats the elapsed turn time as a compact "working for" duration. Stays as
+ * bare seconds under a minute ("42s") and rolls into minutes past it
+ * ("1m 03s", "13m 13s") so a long turn doesn't read as an enormous raw second
+ * count. The whole turn — not the current sub-action — is what's been running.
+ */
+export function formatElapsedSeconds(totalSeconds: number): string {
+  const safe = Math.max(0, Math.floor(totalSeconds));
+  if (safe < 60) return `${safe}s`;
+  const minutes = Math.floor(safe / 60);
+  const seconds = safe % 60;
+  return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+}
+
+/**
  * The single, calm "model is working" indicator (replaces the prior tangle of
  * shimmer-text / emerald + violet dot variants). Three violet pulses + a
  * concise verb + a self-ticking elapsed timer that mutates textContent via a
@@ -1158,7 +1172,7 @@ function WorkingIndicator({ activity, startedAt }: { activity: string | null; st
     let handle = 0;
     const tick = () => {
       const elapsedSec = Math.max(0, Math.floor((Date.now() - startMs) / 1000));
-      if (el) el.textContent = `${elapsedSec}s`;
+      if (el) el.textContent = formatElapsedSeconds(elapsedSec);
       setLongRunning(elapsedSec >= LONG_RUNNING_TURN_SECONDS);
       handle = window.setTimeout(tick, 1000);
     };
@@ -1170,7 +1184,9 @@ function WorkingIndicator({ activity, startedAt }: { activity: string | null; st
       <ThinkingDots toneClass="bg-violet-400/70" />
       <span className="font-medium text-fg/55">{activity ?? "Working"}</span>
       <span className="text-fg/28" aria-hidden>·</span>
-      <span ref={timerRef} className="tabular-nums text-fg/38">0s</span>
+      <span className="text-fg/38">
+        working for <span ref={timerRef} className="tabular-nums">0s</span>
+      </span>
       {longRunning ? (
         <>
           <span className="text-fg/28" aria-hidden>·</span>
@@ -3676,6 +3692,63 @@ export function calculateVirtualWindow({
   };
 }
 
+/**
+ * Window anchored to the *end* of the list, used while we're following the
+ * bottom of a streaming turn. Estimate-based `scrollTop` windowing drifts on
+ * long transcripts (a single rendered row whose stored height lags its real
+ * DOM height desyncs the spacer math from `el.scrollTop`), which strands the
+ * tail above a phantom gap and "locks" — new content keeps landing at the top
+ * while the space above the composer stays empty. Anchoring directly to the
+ * last row keeps the tail permanently mounted and re-measured every frame, so
+ * `bottomSpacerHeight` is always 0 and the streaming indicator sits flush
+ * against the final message regardless of how stale the off-screen estimates
+ * upstream are.
+ */
+export function calculateVirtualWindowAnchoredToEnd({
+  rowCount,
+  containerHeight,
+  rowHeight,
+  overscan = OVERSCAN,
+  rowGap = CHAT_TIMELINE_ROW_GAP_PX,
+}: {
+  rowCount: number;
+  containerHeight: number;
+  rowHeight: (index: number) => number;
+  overscan?: number;
+  rowGap?: number;
+}): {
+  startIndex: number;
+  endIndex: number;
+  totalHeight: number;
+  offsetTop: number;
+} {
+  if (rowCount <= 0) {
+    return { startIndex: 0, endIndex: 0, totalHeight: 0, offsetTop: 0 };
+  }
+
+  let total = 0;
+  for (let i = 0; i < rowCount; i += 1) {
+    total += rowHeight(i) + rowGap;
+  }
+  const totalHeight = total - rowGap;
+
+  // Walk back from the last row until the rendered rows cover the viewport.
+  let firstVisible = rowCount - 1;
+  let filled = rowHeight(firstVisible);
+  while (firstVisible > 0 && filled < containerHeight) {
+    firstVisible -= 1;
+    filled += rowHeight(firstVisible) + rowGap;
+  }
+  const startIndex = Math.max(0, firstVisible - overscan);
+
+  let offsetTop = 0;
+  for (let i = 0; i < startIndex; i += 1) {
+    offsetTop += rowHeight(i) + rowGap;
+  }
+
+  return { startIndex, endIndex: rowCount, totalHeight, offsetTop };
+}
+
 export function reconcileMeasuredScrollTop({
   index,
   previousHeight,
@@ -4088,6 +4161,18 @@ function AgentChatMessageListMain({
       return { startIndex: 0, endIndex: groupedRows.length, totalHeight: 0, offsetTop: 0 };
     }
 
+    // While following the bottom, anchor the window to the last row instead of
+    // deriving it from the estimate-based scrollTop. This keeps the tail mounted
+    // so it can't strand behind a phantom gap on long transcripts.
+    if (stickToBottom) {
+      return calculateVirtualWindowAnchoredToEnd({
+        rowCount: groupedRows.length,
+        containerHeight,
+        rowHeight,
+        rowGap: timelineRowGapPx,
+      });
+    }
+
     return calculateVirtualWindow({
       rowCount: groupedRows.length,
       scrollTop,
@@ -4096,7 +4181,7 @@ function AgentChatMessageListMain({
       rowGap: timelineRowGapPx,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldVirtualize, groupedRows.length, scrollTop, containerHeight, rowHeight, measurementTick, timelineRowGapPx]);
+  }, [shouldVirtualize, stickToBottom, groupedRows.length, scrollTop, containerHeight, rowHeight, measurementTick, timelineRowGapPx]);
 
   useLayoutEffect(() => {
     if (stickToBottomRef.current) scrollToBottomSoon(2);


### PR DESCRIPTION
## Summary
- Anchor the virtualized chat window to the last row while following the bottom of a streaming turn. Estimate-based `scrollTop` windowing drifts on long transcripts and strands the tail above a phantom gap, locking the view so new content lands at the top while the space above the composer stays empty. Anchoring to the end keeps the tail mounted and re-measured every frame.
- Reword the working indicator to `working for <Nm Ns>` so elapsed time reads as the whole turn rather than the current sub-action, and roll seconds into minutes past 60s (e.g. `793s` → `13m 13s`).

## Test plan
- [x] `AgentChatMessageList.test.tsx` — 65/65 pass (added anchored-window + `formatElapsedSeconds` coverage)
- [x] Desktop `tsc --noEmit` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two focused improvements to the streaming chat view: a formatted elapsed-time display in the `WorkingIndicator` ("working for 42s" / "1m 05s") and a new end-anchored virtual windowing strategy that prevents the streaming tail from stranding behind a phantom spacer gap on long transcripts.

- **`formatElapsedSeconds`**: extracted helper formats raw seconds into a compact `"Xs"` / `"Xm Ys"` string; replaces the previous bare `"${n}s"` mutation. The timer span is restructured so "working for" is static accessible text while only the numeric part updates via ref mutation (no per-second React commit).
- **`calculateVirtualWindowAnchoredToEnd`**: when `stickToBottom` is true, the `useMemo` now calls this function instead of the estimate-driven `calculateVirtualWindow`, pinning `endIndex` to the last row so the bottom spacer is always 0 and the streaming indicator stays flush regardless of how stale off-screen row-height estimates are.

<h3>Confidence Score: 5/5</h3>

Safe to merge. Changes are self-contained to the virtual scroll windowing logic and the timer display; no shared state, auth, or data-persistence paths are touched.

Both new functions have correct geometry math (totalHeight, offsetTop, and walk-back are all consistent), the stickToBottom branch in the useMemo integrates cleanly with the existing scroll-state machinery, and the timer restructuring only moves static text out of the ref-mutated span. Tests cover boundary cases for all three changed behaviours.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx | Adds formatElapsedSeconds export, restructures WorkingIndicator timer span to prefix 'working for', introduces calculateVirtualWindowAnchoredToEnd for end-pinned virtual windows, and wires it into the windowing useMemo when stickToBottom is true. Logic is correct: totalHeight, offsetTop, and the walk-back math all produce consistent results. |
| apps/desktop/src/renderer/components/chat/AgentChatMessageList.test.tsx | Adds unit tests for calculateVirtualWindowAnchoredToEnd (two geometry cases) and formatElapsedSeconds (boundary/minute-rollover values), plus an assertion that the streaming indicator text matches /working for \d/. Coverage is thorough for the added paths. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useMemo: compute virtual window] --> B{shouldVirtualize?}
    B -- No --> C[render all rows: startIndex=0, endIndex=length]
    B -- Yes --> D{stickToBottom?}
    D -- Yes --> E[calculateVirtualWindowAnchoredToEnd\nendIndex = rowCount always\nbottomSpacer = 0\ntail stays mounted]
    D -- No --> F[calculateVirtualWindow\nscrollTop-based\nestimate-driven offsets]
    E --> G[WorkingIndicator visible\nflush at bottom]
    F --> H[Normal scroll position\nwindowing]
    G --> I[tick: formatElapsedSeconds\nworking for Xs / Xm Ys]
```

<sub>Reviews (1): Last reviewed commit: ["Fix chat scroll gap/lock and reword work..."](https://github.com/arul28/ade/commit/1c9e1ae9e1f55296f7defa6a6fc08c8566e26d32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36262761)</sub>

<!-- /greptile_comment -->