### PR TITLE
Fix brain CRDT sync packaging + surface remote runtime integrations

### DIFF
--- a/apps/ade-cli/scripts/package-native-deps.mjs
+++ b/apps/ade-cli/scripts/package-native-deps.mjs
@@ -207,6 +207,36 @@ async function writeManifest(bundleRoot, target, packages) {
   await fs.writeFile(path.join(bundleRoot, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 }
 
+function crsqliteExtensionFileName(target) {
+  const { platform } = targetParts(target);
+  if (platform === "darwin") return "crsqlite.dylib";
+  if (platform === "linux") return "crsqlite.so";
+  return "crsqlite.so";
+}
+
+async function copyCrsqliteExtension(bundleRoot, target) {
+  // The brain (this runtime) is the default sync host and needs cr-sqlite to
+  // run CRDT replication to paired peers. The desktop app bundle ships it, but
+  // the static/headless install only gets this native tarball — so without
+  // copying it here the installed brain has no CRR engine and every write to a
+  // CRR table crashes on crsql_internal_sync_bit. Mirror the desktop vendor
+  // layout (vendor/crsqlite/<target>/) so crsqliteExtension.ts resolves it from
+  // <ADE_HOME>/runtime/<target>/.
+  const fileName = crsqliteExtensionFileName(target);
+  const source = path.join(packageRoot, "..", "desktop", "vendor", "crsqlite", target, fileName);
+  if (!(await exists(source))) {
+    process.stderr.write(
+      `[package-native-deps] WARNING: no cr-sqlite extension vendored for ${target} ` +
+        `(${source}); the installed brain on this target will lack CRDT sync.\n`,
+    );
+    return false;
+  }
+  const destination = path.join(bundleRoot, "vendor", "crsqlite", target, fileName);
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+  await fs.copyFile(source, destination);
+  return true;
+}
+
 async function copyBuiltTuiClient(bundleRoot) {
   const source = path.join(packageRoot, "dist", "tuiClient", "cli.mjs");
   if (!(await exists(source))) {
@@ -271,6 +301,7 @@ async function main() {
     }
   }
   await copyBuiltTuiClient(bundleRoot);
+  await copyCrsqliteExtension(bundleRoot, args.target);
   await chmodRuntimeExecutables(bundleRoot, args.target);
   await writeManifest(bundleRoot, args.target, copied);
 

--- a/apps/ade-cli/scripts/package-native-deps.mjs
+++ b/apps/ade-cli/scripts/package-native-deps.mjs
@@ -207,11 +207,18 @@ async function writeManifest(bundleRoot, target, packages) {
   await fs.writeFile(path.join(bundleRoot, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 }
 
+// Targets shipped as the production brain, where cr-sqlite is mandatory. A
+// missing extension for one of these would silently re-ship the exact
+// crsql_internal_sync_bit crash this packaging step exists to prevent, so it's
+// a hard build failure rather than a warning. Other targets (not yet vendored)
+// warn-and-skip until their extension is added.
+const CRSQLITE_REQUIRED_TARGETS = new Set(["darwin-arm64"]);
+
 function crsqliteExtensionFileName(target) {
   const { platform } = targetParts(target);
   if (platform === "darwin") return "crsqlite.dylib";
   if (platform === "linux") return "crsqlite.so";
-  return "crsqlite.so";
+  throw new Error(`No cr-sqlite extension filename mapping for platform '${platform}' (target ${target}).`);
 }
 
 async function copyCrsqliteExtension(bundleRoot, target) {
@@ -225,6 +232,13 @@ async function copyCrsqliteExtension(bundleRoot, target) {
   const fileName = crsqliteExtensionFileName(target);
   const source = path.join(packageRoot, "..", "desktop", "vendor", "crsqlite", target, fileName);
   if (!(await exists(source))) {
+    if (CRSQLITE_REQUIRED_TARGETS.has(target)) {
+      throw new Error(
+        `[package-native-deps] no cr-sqlite extension vendored for required target ${target} (${source}); ` +
+          `the installed brain would crash on every CRR write. Add crsqlite for this target under ` +
+          `apps/desktop/vendor/crsqlite/${target}/.`,
+      );
+    }
     process.stderr.write(
       `[package-native-deps] WARNING: no cr-sqlite extension vendored for ${target} ` +
         `(${source}); the installed brain on this target will lack CRDT sync.\n`,

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1535,7 +1535,12 @@ app.whenReady().then(async () => {
     if (!activeProjectRoot || !rootsBoundToWindows().has(activeProjectRoot)) {
       setForegroundProject(firstOpenWindowProjectRoot());
     }
-    emitProjectChangedToWindow(windowId, null);
+    // Do NOT emit a standalone projectChanged(null) before the remote binding.
+    // It would reach the renderer as a separate IPC message and momentarily put
+    // the window into project==null && !remoteBinding && showWelcome==true,
+    // which used to wipe the open-tab lists (see TopBar). The binding-changed
+    // event below fully drives the remote view (AppShell.applyProjectState) and
+    // sets the remote window title itself, so the null precursor is redundant.
     emitProjectBindingChangedToWindow(windowId, binding);
   };
 
@@ -5933,7 +5938,9 @@ app.whenReady().then(async () => {
         await switchProjectFromDialog(args.projectRoot!);
       });
     } else if (restoredRemoteBinding) {
-      emitProjectChangedToWindow(win.id, null);
+      // Binding-changed alone drives the remote view and title; skip the
+      // standalone projectChanged(null) precursor so the renderer never sees a
+      // transient "no project" state that would clear restored tabs.
       emitProjectBindingChangedToWindow(win.id, restoredRemoteBinding);
     } else {
       emitProjectChangedToWindow(win.id, null);

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.test.ts
@@ -475,7 +475,56 @@ describe("RemoteConnectionService", () => {
     expect(pool.connect).toHaveBeenCalledTimes(10);
   });
 
-  it("does not spend the reconnect budget on ordinary remote action errors", async () => {
+  it("keeps the connection healthy and spends no budget on ordinary remote action errors", async () => {
+    const previouslyConnected = target("previously-connected", 1_700_000_000);
+    const registry = {
+      list: vi.fn(() => [previouslyConnected]),
+      get: vi.fn((id: string) =>
+        id === previouslyConnected.id ? previouslyConnected : null,
+      ),
+    } as unknown as RemoteTargetRegistry;
+    let succeed = true;
+    const pool = {
+      connect: vi.fn(async (target: RemoteRuntimeTarget) =>
+        connectResult(target),
+      ),
+      disconnect: vi.fn(),
+      callActionForTarget: vi.fn(async () => {
+        if (succeed) {
+          return { domain: "file", action: "read", result: { ok: true }, statusHints: {} };
+        }
+        throw new Error("Action 'pr.listQueueStates' is not callable.");
+      }),
+      onEntryEvicted: vi.fn(() => () => {}),
+    } as unknown as RemoteConnectionPool;
+
+    const service = new RemoteConnectionService(registry, pool);
+    // Establish a healthy connection via a successful call.
+    await service.callAction(previouslyConnected.id, "project-1", {
+      domain: "file",
+      action: "read",
+    });
+    expect(service.snapshot().connections[0]?.state).toBe("connected");
+
+    succeed = false;
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      await expect(
+        service.callAction(previouslyConnected.id, "project-1", {
+          domain: "pr",
+          action: "listQueueStates",
+        }),
+      ).rejects.toThrow(/not callable/i);
+    }
+
+    // An application-level error came back over a live channel — the host is
+    // reachable, so the connection must stay connected (no "unreachable" toast,
+    // no reconnect loop) and the auto-reconnect budget is untouched.
+    expect(pool.callActionForTarget).toHaveBeenCalledTimes(11);
+    expect(service.snapshot().connections[0]?.state).toBe("connected");
+    expect(service.snapshot().connections[0]?.lastError).toBeNull();
+  });
+
+  it("does not flag the remote unreachable when adding a project fails with a host-side error", async () => {
     const previouslyConnected = target("previously-connected", 1_700_000_000);
     const registry = {
       list: vi.fn(() => [previouslyConnected]),
@@ -488,31 +537,65 @@ describe("RemoteConnectionService", () => {
         connectResult(target),
       ),
       disconnect: vi.fn(),
-      callActionForTarget: vi.fn(async () => {
-        throw new Error("Action 'pr.listQueueStates' is not callable.");
+      addProjectForTarget: vi.fn(async () => {
+        throw new Error(
+          "no such function: crsql_internal_sync_bit [sql=delete from process_definitions where project_id = ?]",
+        );
       }),
       onEntryEvicted: vi.fn(() => () => {}),
     } as unknown as RemoteConnectionPool;
 
     const service = new RemoteConnectionService(registry, pool);
-    for (let attempt = 0; attempt < 10; attempt += 1) {
-      await expect(
-        service.callAction(previouslyConnected.id, "project-1", {
-          domain: "pr",
-          action: "listQueueStates",
-        }),
-      ).rejects.toThrow(/not callable/i);
-    }
+    await service.connect(previouslyConnected.id, { explicit: true });
+    expect(service.snapshot().connections[0]?.state).toBe("connected");
 
     await expect(
-      service.callAction(previouslyConnected.id, "project-1", {
-        domain: "pr",
-        action: "listQueueStates",
+      service.addProject(previouslyConnected.id, "/repo/versic"),
+    ).rejects.toThrow(/crsql_internal_sync_bit/i);
+
+    expect(service.snapshot().connections[0]?.state).toBe("connected");
+    expect(service.snapshot().connections[0]?.lastError).toBeNull();
+  });
+
+  it("flips to error when a remote call fails with a transport-level error", async () => {
+    const previouslyConnected = target("previously-connected", 1_700_000_000);
+    const registry = {
+      list: vi.fn(() => [previouslyConnected]),
+      get: vi.fn((id: string) =>
+        id === previouslyConnected.id ? previouslyConnected : null,
+      ),
+    } as unknown as RemoteTargetRegistry;
+    let succeed = true;
+    const pool = {
+      connect: vi.fn(async (target: RemoteRuntimeTarget) =>
+        connectResult(target),
+      ),
+      disconnect: vi.fn(),
+      callActionForTarget: vi.fn(async () => {
+        if (succeed) {
+          return { domain: "file", action: "read", result: { ok: true }, statusHints: {} };
+        }
+        throw new Error("remote ADE service connection closed");
       }),
-    ).rejects.toThrow(/not callable/i);
-    expect(pool.callActionForTarget).toHaveBeenCalledTimes(11);
+      onEntryEvicted: vi.fn(() => () => {}),
+    } as unknown as RemoteConnectionPool;
+
+    const service = new RemoteConnectionService(registry, pool);
+    await service.callAction(previouslyConnected.id, "project-1", {
+      domain: "file",
+      action: "read",
+    });
+
+    succeed = false;
+    await expect(
+      service.callAction(previouslyConnected.id, "project-1", {
+        domain: "file",
+        action: "read",
+      }),
+    ).rejects.toThrow(/connection closed/i);
+    expect(service.snapshot().connections[0]?.state).toBe("error");
     expect(service.snapshot().connections[0]?.lastError).toMatch(
-      /not callable/i,
+      /connection closed/i,
     );
   });
 });

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts
@@ -329,11 +329,7 @@ export class RemoteConnectionService {
       this.clearAutomaticReconnectBudget(targetId);
       return projects;
     } catch (error) {
-      this.mergeStatus(targetId, {
-        state: "error",
-        lastError: this.recordImplicitFailure(targetId, error),
-        lastAttemptedAt: Date.now(),
-      });
+      this.markCallFailure(targetId, error);
       throw error;
     }
   }
@@ -350,11 +346,7 @@ export class RemoteConnectionService {
       this.clearAutomaticReconnectBudget(targetId);
       return project;
     } catch (error) {
-      this.mergeStatus(targetId, {
-        state: "error",
-        lastError: this.recordImplicitFailure(targetId, error),
-        lastAttemptedAt: Date.now(),
-      });
+      this.markCallFailure(targetId, error);
       throw error;
     }
   }
@@ -368,11 +360,7 @@ export class RemoteConnectionService {
     try {
       return await this.pool.ensureLocalPortForward(target.id, request);
     } catch (error) {
-      this.mergeStatus(targetId, {
-        state: "error",
-        lastError: this.recordImplicitFailure(targetId, error),
-        lastAttemptedAt: Date.now(),
-      });
+      this.markCallFailure(targetId, error);
       throw error;
     }
   }
@@ -482,11 +470,7 @@ export class RemoteConnectionService {
       this.clearAutomaticReconnectBudget(targetId);
       return result;
     } catch (error) {
-      this.mergeStatus(targetId, {
-        state: "error",
-        lastError: this.recordImplicitFailure(targetId, error),
-        lastAttemptedAt: Date.now(),
-      });
+      this.markCallFailure(targetId, error);
       throw error;
     }
   }
@@ -511,11 +495,7 @@ export class RemoteConnectionService {
       this.clearAutomaticReconnectBudget(targetId);
       return result;
     } catch (error) {
-      this.mergeStatus(targetId, {
-        state: "error",
-        lastError: this.recordImplicitFailure(targetId, error),
-        lastAttemptedAt: Date.now(),
-      });
+      this.markCallFailure(targetId, error);
       throw error;
     }
   }
@@ -544,11 +524,7 @@ export class RemoteConnectionService {
       this.clearAutomaticReconnectBudget(targetId);
       return cleanup;
     } catch (error) {
-      this.mergeStatus(targetId, {
-        state: "error",
-        lastError: this.recordImplicitFailure(targetId, error),
-        lastAttemptedAt: Date.now(),
-      });
+      this.markCallFailure(targetId, error);
       throw error;
     }
   }
@@ -571,11 +547,7 @@ export class RemoteConnectionService {
       this.clearAutomaticReconnectBudget(targetId);
       return registry;
     } catch (error) {
-      this.mergeStatus(targetId, {
-        state: "error",
-        lastError: this.recordImplicitFailure(targetId, error),
-        lastAttemptedAt: Date.now(),
-      });
+      this.markCallFailure(targetId, error);
       throw error;
     }
   }
@@ -602,11 +574,7 @@ export class RemoteConnectionService {
       this.clearAutomaticReconnectBudget(targetId);
       return result;
     } catch (error) {
-      this.mergeStatus(targetId, {
-        state: "error",
-        lastError: this.recordImplicitFailure(targetId, error),
-        lastAttemptedAt: Date.now(),
-      });
+      this.markCallFailure(targetId, error);
       throw error;
     }
   }
@@ -670,11 +638,7 @@ export class RemoteConnectionService {
       this.clearAutomaticReconnectBudget(target.id);
       return result;
     } catch (error) {
-      this.mergeStatus(target.id, {
-        state: "error",
-        lastError: this.recordImplicitFailure(target.id, error),
-        lastAttemptedAt: Date.now(),
-      });
+      this.markCallFailure(target.id, error);
       throw error;
     }
   }
@@ -709,6 +673,25 @@ export class RemoteConnectionService {
   private clearAutomaticReconnectBudget(targetId: string): void {
     this.automaticReconnectFailuresByTargetId.delete(targetId);
     this.automaticReconnectPausedTargetIds.delete(targetId);
+  }
+
+  /**
+   * Classify a failure from an RPC call made over an already-established
+   * connection. If the response came back over a live channel, the host is
+   * reachable and the error is application-level (e.g. a host-side SQL or
+   * validation failure). Such errors must NOT flip the connection to
+   * "error"/reconnecting — doing so surfaces a false "host is unreachable"
+   * toast and a reconnect loop for what is really a per-action failure. Only
+   * genuine transport failures update the connection status and reconnect
+   * budget; everything else is left to rethrow to the caller untouched.
+   */
+  private markCallFailure(targetId: string, error: unknown): void {
+    if (!isImplicitConnectionFailure(error)) return;
+    this.mergeStatus(targetId, {
+      state: "error",
+      lastError: this.recordImplicitFailure(targetId, error),
+      lastAttemptedAt: Date.now(),
+    });
   }
 
   private recordImplicitFailure(targetId: string, error: unknown): string {

--- a/apps/desktop/src/main/services/state/crsqliteExtension.ts
+++ b/apps/desktop/src/main/services/state/crsqliteExtension.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 function extensionFileName(): string {
@@ -52,10 +53,14 @@ export function resolveCrsqliteExtensionPath(): string | null {
     const moduleRepoRoot = findRepoRoot(moduleDir);
     if (moduleRepoRoot) repoRootSet.add(moduleRepoRoot);
   }
+  const adeHome = process.env.ADE_HOME ?? path.join(os.homedir(), ".ade");
   const candidates = [
     process.resourcesPath ? path.join(process.resourcesPath, `${packagedAsarName()}.unpacked`, relativePath) : null,
     process.resourcesPath ? path.join(process.resourcesPath, "app.asar.unpacked", relativePath) : null,
     process.resourcesPath ? path.join(process.resourcesPath, relativePath) : null,
+    // Installed static/headless brain: native tarball is extracted to
+    // <ADE_HOME>/runtime/<target>/, carrying crsqlite at vendor/crsqlite/<arch>/.
+    path.join(adeHome, "runtime", platformArchDir(), relativePath),
     path.resolve(process.cwd(), relativePath),
     path.resolve(process.cwd(), "apps", "desktop", relativePath),
     ...Array.from(repoRootSet, (repoRoot) => path.join(repoRoot, "apps", "desktop", relativePath)),

--- a/apps/desktop/src/main/services/state/kvDb.test.ts
+++ b/apps/desktop/src/main/services/state/kvDb.test.ts
@@ -400,6 +400,97 @@ describe.skipIf(!isCrsqliteAvailable())("openKvDb CRR repair", () => {
     ).toBe(0);
   });
 
+  it("keeps config-snapshot tables (process_definitions/stack_buttons/test_suites) local-only", async () => {
+    const projectRoot = makeProjectRoot("ade-kvdb-config-snapshot-local-");
+    const dbPath = path.join(projectRoot, ".ade", "ade.db");
+    const db = await openKvDb(dbPath, createLogger() as any);
+    activeDisposers.push(async () => db.close());
+
+    for (const table of ["process_definitions", "stack_buttons", "test_suites"]) {
+      expect(
+        db.get<{ present: number }>(
+          `select 1 as present from sqlite_master where type = 'table' and name = '${table}__crsql_clock' limit 1`,
+        ),
+      ).toBeNull();
+      expect(
+        db.get<{ present: number }>(
+          `select 1 as present from sqlite_master where type = 'trigger' and tbl_name = '${table}' and name like '${table}__crsql_%trig' limit 1`,
+        ),
+      ).toBeNull();
+    }
+  });
+
+  it("un-CRRs a previously-converted process_definitions so the snapshot rebuild delete never fires crsql triggers", async () => {
+    const projectRoot = makeProjectRoot("ade-kvdb-process-defs-crr-cleanup-");
+    const dbPath = path.join(projectRoot, ".ade", "ade.db");
+    const first = await openKvDb(dbPath, createLogger() as any);
+    insertProjectGraph(first);
+
+    // Simulate a DB written by an older build that incorrectly converted the
+    // config-snapshot table to a CRR (installs triggers calling
+    // crsql_internal_sync_bit + clock/pks shadow tables).
+    first.get("select crsql_as_crr(?)", ["process_definitions"]);
+    first.run(
+      `insert into process_definitions(
+        id, project_id, key, name, command_json, cwd, env_json, autostart,
+        restart_policy, graceful_shutdown_ms, depends_on_json, readiness_json, updated_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        "proc-1",
+        "project-1",
+        "web",
+        "Web",
+        JSON.stringify(["npm", "run", "dev"]),
+        "/repo/ade",
+        "{}",
+        1,
+        "on-failure",
+        5000,
+        "[]",
+        "[]",
+        "2026-03-17T00:00:00.000Z",
+      ],
+    );
+    expect(
+      first.get<{ count: number }>(
+        "select count(1) as count from crsql_changes where [table] = ?",
+        ["process_definitions"],
+      )?.count,
+    ).toBeGreaterThan(0);
+    first.close();
+
+    const reopened = await openKvDb(dbPath, createLogger() as any);
+    activeDisposers.push(async () => reopened.close());
+
+    // CRR metadata is stripped on reopen: no shadow tables, no triggers, no
+    // replicated changes — so a crsqlite-less runtime can run the rebuild
+    // delete without hitting the missing crsql_internal_sync_bit function.
+    expect(
+      reopened.get<{ present: number }>(
+        "select 1 as present from sqlite_master where type = 'table' and name = 'process_definitions__crsql_clock' limit 1",
+      ),
+    ).toBeNull();
+    expect(
+      reopened.get<{ present: number }>(
+        "select 1 as present from sqlite_master where type = 'table' and name = 'process_definitions__crsql_pks' limit 1",
+      ),
+    ).toBeNull();
+    expect(
+      reopened.get<{ present: number }>(
+        "select 1 as present from sqlite_master where type = 'trigger' and tbl_name = 'process_definitions' and name like 'process_definitions__crsql_%trig' limit 1",
+      ),
+    ).toBeNull();
+    expect(
+      reopened.get<{ count: number }>(
+        "select count(1) as count from crsql_changes where [table] = ?",
+        ["process_definitions"],
+      )?.count,
+    ).toBe(0);
+    expect(() =>
+      reopened.run("delete from process_definitions where project_id = ?", ["project-1"]),
+    ).not.toThrow();
+  });
+
   it("backfills phone-critical tables whose rows predate CRR enablement", async () => {
     const projectRoot = makeProjectRoot("ade-kvdb-pre-crr-");
     const dbPath = path.join(projectRoot, ".ade", "ade.db");

--- a/apps/desktop/src/main/services/state/kvDb.ts
+++ b/apps/desktop/src/main/services/state/kvDb.ts
@@ -487,8 +487,19 @@ const LOCAL_ONLY_CRR_EXCLUDED_TABLES = new Set([
   "lane_list_snapshots",
   LOCAL_CRR_CHANGE_SUPPRESSIONS_TABLE,
   "pr_auto_link_ignores",
+  // Config snapshots rebuilt (delete+reinsert) from ade.yaml on every project
+  // config load (projectConfigService.syncSnapshots). Pure local-derived state —
+  // remote clients read these via RPC (e.g. processes.listDefinitions, which
+  // returns projectConfigService.get().effective, not the table), never from a
+  // synced replica — so they must not be CRRs. Leaving them CRR makes the
+  // rebuild DELETE fire crsql triggers that call crsql_internal_sync_bit, which
+  // crashes any runtime without the extension loaded (e.g. the static machine
+  // runtime), surfacing to remote clients as a fake "host unreachable" disconnect.
+  "process_definitions",
   "pull_request_ai_summaries",
   "runtime_processes",
+  "stack_buttons",
+  "test_suites",
 ]);
 
 function listEligibleCrrTables(db: DatabaseSyncType): string[] {

--- a/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
+++ b/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
@@ -134,7 +134,12 @@ export function LinearQuickViewButton({
   const batchConfigByIssueRef = useRef<Map<string, BatchLaunchIssueConfig>>(new Map());
   const activeProjectRoot =
     projectBinding?.kind === "remote" ? projectBinding.rootPath : project?.rootPath;
-  const shouldAutoCheckVisibility = projectBinding?.kind !== "remote";
+  // Auto-check Linear visibility for both local and remote projects. The check
+  // is driven by getLinearConnectionStatus, which routes to the remote daemon
+  // when bound to a remote runtime, so a remote machine's Linear connection is
+  // surfaced just like a local one. Remote uses a longer retry interval
+  // (visibilityRetryIntervalMs) to avoid hammering the remote daemon.
+  const shouldAutoCheckVisibility = Boolean(activeProjectRoot);
   const visibilityRetryIntervalMs =
     projectBinding?.kind === "remote"
       ? REMOTE_VISIBILITY_RETRY_INTERVAL_MS

--- a/apps/desktop/src/renderer/components/app/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/components/app/SettingsPage.tsx
@@ -10,6 +10,7 @@ import { AiFeaturesSection } from "../settings/AiFeaturesSection";
 import { IntegrationsSettingsSection } from "../settings/IntegrationsSettingsSection";
 import { MobilePushPanel } from "../settings/MobilePushPanel";
 import { AdeUsageSection } from "../settings/AdeUsageSection";
+import { RemoteSettingsBanner } from "../settings/RemoteContextBadge";
 import { COLORS, SANS_FONT, LABEL_STYLE } from "../lanes/laneDesignTokens";
 
 const SECTIONS = [
@@ -186,6 +187,7 @@ export function SettingsPage({ active = true }: { active?: boolean } = {}) {
           padding: 24,
         }}
       >
+        <RemoteSettingsBanner />
         {section === "general" && <GeneralSection />}
         {section === "appearance" && <AppearanceSection />}
         {section === "ai" && <ProvidersSection />}

--- a/apps/desktop/src/renderer/components/app/TopBar.test.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.test.tsx
@@ -600,6 +600,108 @@ describe("TopBar", () => {
     ]);
   });
 
+  it("keeps a different-path local tab when the project briefly goes null during a remote bind", async () => {
+    // Repro of the disappearing-local-tab bug: binding a window to a remote
+    // project emits projectChanged(null) and projectBindingChanged(remote) as
+    // two separate IPC messages, so the renderer momentarily sees
+    // project==null && !remoteBinding && showWelcome==true with no transition
+    // in flight. That transient must NOT wipe the (different-path) local tab.
+    (globalThis.window.ade.remoteRuntime.getConnectionSnapshot as any)
+      .mockResolvedValue(makeRemoteConnectionSnapshot("target-1"));
+
+    render(<TopBar />);
+
+    // The active local project becomes a tab on mount.
+    expect(await screen.findByTitle("/Users/arul/ADE")).toBeTruthy();
+    expect(useAppStore.getState().openProjectTabRoots).toEqual(["/Users/arul/ADE"]);
+
+    // Step 1: the transient projectChanged(null) lands (no transition).
+    await act(async () => {
+      useAppStore.setState({
+        project: null,
+        projectBinding: null,
+        showWelcome: true,
+        projectTransition: null,
+      } as any);
+    });
+    expect(useAppStore.getState().openProjectTabRoots).toEqual(["/Users/arul/ADE"]);
+
+    // Step 2: the remote binding (a DIFFERENT path) lands.
+    const remoteBinding = {
+      kind: "remote" as const,
+      key: "remote:target-1:project-a",
+      targetId: "target-1",
+      runtimeName: "Mac Studio",
+      projectId: "project-a",
+      rootPath: "/srv/ade/remote-app",
+      displayName: "Remote App",
+    };
+    await act(async () => {
+      useAppStore.setState({
+        project: {
+          rootPath: remoteBinding.rootPath,
+          displayName: remoteBinding.displayName,
+          baseRef: "main",
+        },
+        projectBinding: remoteBinding,
+        showWelcome: false,
+      } as any);
+    });
+
+    // The different-path local tab survives, and the remote tab renders.
+    expect(useAppStore.getState().openProjectTabRoots).toEqual(["/Users/arul/ADE"]);
+    expect(screen.getByTitle("/Users/arul/ADE")).toBeTruthy();
+    expect(
+      await screen.findByTitle("Mac Studio: /srv/ade/remote-app (Connected)"),
+    ).toBeTruthy();
+  });
+
+  it("keeps existing local tabs when a remote-bound window restores with an empty tab snapshot", async () => {
+    // Reload variant: a remote-bound window's main-process tab snapshot can be
+    // momentarily empty (projectsForWindowTabs drops idle/evicted roots). The
+    // restore must merge, not wipe, so a different-path local tab is preserved.
+    const remoteBinding = {
+      kind: "remote" as const,
+      key: "remote:target-1:project-a",
+      targetId: "target-1",
+      runtimeName: "Mac Studio",
+      projectId: "project-a",
+      rootPath: "/srv/ade/remote-app",
+      displayName: "Remote App",
+    };
+    (globalThis.window.ade.remoteRuntime.getConnectionSnapshot as any)
+      .mockResolvedValue(makeRemoteConnectionSnapshot("target-1"));
+    useAppStore.setState({
+      project: {
+        rootPath: remoteBinding.rootPath,
+        displayName: remoteBinding.displayName,
+        baseRef: "main",
+      } as any,
+      projectBinding: remoteBinding,
+      projectInfoByRoot: {
+        "/Users/arul/ADE": {
+          rootPath: "/Users/arul/ADE",
+          displayName: "ADE",
+          baseRef: "main",
+        },
+      },
+      openProjectTabRoots: ["/Users/arul/ADE"],
+    } as any);
+    (globalThis.window.ade.app.getWindowSession as any).mockResolvedValueOnce({
+      windowId: 1,
+      project: null,
+      binding: remoteBinding,
+      openProjectTabs: [],
+    });
+
+    render(<TopBar />);
+
+    await waitFor(() => {
+      expect(useAppStore.getState().openProjectTabRoots).toEqual(["/Users/arul/ADE"]);
+    });
+    expect(screen.getByTitle("/Users/arul/ADE")).toBeTruthy();
+  });
+
   it("does not detach again after a project tab is dropped onto an ADE target", async () => {
     render(<TopBar />);
 
@@ -1214,7 +1316,11 @@ describe("TopBar", () => {
     }
   });
 
-  it("does not run automatic hidden Linear checks on remote projects", async () => {
+  it("runs automatic Linear checks on remote projects but hides the button when the remote isn't connected", async () => {
+    // A remote-bound project surfaces the REMOTE machine's Linear connection:
+    // getLinearConnectionStatus routes to the remote daemon, so the auto-check
+    // runs just like a local project. When that remote check reports the
+    // workspace is not connected, the quick-view button stays hidden.
     vi.useFakeTimers();
     useAppStore.setState({
       project: null,
@@ -1252,7 +1358,7 @@ describe("TopBar", () => {
         vi.advanceTimersByTime(30_000);
         await flushMicrotasks(2);
       });
-      expect(getLinearConnectionStatus).not.toHaveBeenCalled();
+      expect(getLinearConnectionStatus).toHaveBeenCalled();
       expect(screen.queryByRole("button", { name: /linear quick view/i })).toBeNull();
     } finally {
       vi.useRealTimers();

--- a/apps/desktop/src/renderer/components/app/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.tsx
@@ -1053,17 +1053,15 @@ export function TopBar() {
   useEffect(() => {
     const rootPath = project?.rootPath ?? null;
     if (!rootPath) {
-      // Only wipe local tabs when the user has explicitly closed the project
-      // (welcome screen visible, no remote binding, no transition in flight).
-      // Otherwise we'd nuke other tabs whenever `project` is briefly null mid
-      // open/switch/close.
-      if (
-        !remoteBinding &&
-        projectTransition == null &&
-        showWelcome === true
-      ) {
-        setOpenProjectTabRoots([]);
-      }
+      // Do NOT wipe the tab list here. `project` goes briefly null on every
+      // remote bind/unbind: `bindWindowToRemoteProject` emits
+      // projectChanged(null) and projectBindingChanged(remote) as two separate
+      // IPC messages, so the renderer momentarily sees
+      // project==null && !remoteBinding && showWelcome==true even though the
+      // window is just switching to a remote project — and wiping here would
+      // delete every local tab (any path). A genuine close already clears the
+      // list authoritatively in closeProject() (appStore), so this effect only
+      // needs to ADD the current local root, never remove.
       return;
     }
     if (remoteBinding) {
@@ -1079,7 +1077,7 @@ export function TopBar() {
     setOpenProjectTabRoots((prev) =>
       prev.includes(rootPath) ? prev : [...prev, rootPath],
     );
-  }, [project?.rootPath, remoteBinding, projectTransition, showWelcome]);
+  }, [project?.rootPath, remoteBinding, projectTransition]);
 
   useEffect(() => {
     if (!remoteBinding) return;
@@ -1138,8 +1136,23 @@ export function TopBar() {
           for (const tabProject of session.openProjectTabs) {
             useAppStore.getState().rememberProjectInfo(tabProject);
           }
-          setOpenProjectTabRoots(session.openProjectTabs.map((entry) => entry.rootPath));
-        } else if (session.binding?.kind === "remote" || !session.project) {
+          // Merge, don't replace. The main-process snapshot
+          // (projectsForWindowTabs) drops any tab root whose context was
+          // evicted while idle, so a remount could otherwise lose a local tab
+          // that the renderer still has. Restored roots come first; keep any
+          // extra local roots the renderer already knows about.
+          const restored = session.openProjectTabs.map((entry) => entry.rootPath);
+          setOpenProjectTabRoots((prev) => {
+            const merged = [...restored];
+            for (const root of prev) {
+              if (!merged.includes(root)) merged.push(root);
+            }
+            return merged;
+          });
+        } else if (!session.binding && !session.project) {
+          // Only wipe on a genuinely empty session. A remote-bound window with
+          // an empty snapshot must NOT clear local tabs — that's the reload
+          // variant of the disappearing-tab bug.
           setOpenProjectTabRoots([]);
         }
       })

--- a/apps/desktop/src/renderer/components/settings/LinearSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/LinearSection.tsx
@@ -42,6 +42,12 @@ export function LinearSection() {
   // active project changes so the autolink commands target the right repo and
   // Linear workspace instead of a stale previously-loaded project.
   const projectRoot = useAppStore(selectActiveProjectRoot);
+  // Linear OAuth uses a 127.0.0.1 loopback callback server. When the project is
+  // bound to a remote runtime that server runs on the remote host, but the
+  // browser opens locally and redirects to localhost on THIS machine — so the
+  // callback never arrives. Steer remote sessions to the API-key path, which
+  // routes cleanly to the remote machine's credential store.
+  const isRemoteRuntime = useAppStore((s) => s.projectBinding?.kind === "remote");
   const [connection, setConnection] = useState<LinearConnectionStatus | null>(null);
   const [projects, setProjects] = useState<CtoLinearProject[]>([]);
   const [githubRepo, setGithubRepo] = useState<{ owner: string; name: string } | null>(null);
@@ -331,6 +337,10 @@ export function LinearSection() {
     const cto = window.ade?.cto;
     const openExternal = window.ade?.app?.openExternal;
     if (!cto || validatingRef.current || oauthStartingRef.current) return;
+    if (isRemoteRuntime) {
+      setError("Browser sign-in isn't available over a remote connection. Use an API key instead.");
+      return;
+    }
     if (!openExternal) {
       setOauthSessionIdState(null);
       setOauthStartingState(false);
@@ -351,7 +361,7 @@ export function LinearSection() {
       setOauthStartingState(false);
       setError(err instanceof Error ? err.message : "Unable to start OAuth.");
     }
-  }, [invalidateLoadRequests, setOauthSessionIdState, setOauthStartingState]);
+  }, [invalidateLoadRequests, setOauthSessionIdState, setOauthStartingState, isRemoteRuntime]);
 
   const handleDisconnect = useCallback(async () => {
     if (!window.ade?.cto) return;
@@ -425,16 +435,18 @@ export function LinearSection() {
               </div>
             </div>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", flexWrap: "wrap", gap: 8 }}>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => void handleStartOAuth()}
-                disabled={oauthStarting || validating || connection?.oauthAvailable === false}
-              >
-                {oauthStarting ? <CircleNotch size={12} className="animate-spin" /> : null}
-                {oauthStarting ? "Waiting for Linear..." : "Reconnect current workspace"}
-              </Button>
+              {!isRemoteRuntime ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void handleStartOAuth()}
+                  disabled={oauthStarting || validating || connection?.oauthAvailable === false}
+                >
+                  {oauthStarting ? <CircleNotch size={12} className="animate-spin" /> : null}
+                  {oauthStarting ? "Waiting for Linear..." : "Reconnect current workspace"}
+                </Button>
+              ) : null}
               <button
                 type="button"
                 onClick={() => void handleDisconnect()}
@@ -555,7 +567,8 @@ export function LinearSection() {
                 size="md"
                 variant="primary"
                 onClick={() => void handleStartOAuth()}
-                disabled={oauthStarting || validating || connection?.oauthAvailable === false}
+                disabled={oauthStarting || validating || connection?.oauthAvailable === false || isRemoteRuntime}
+                title={isRemoteRuntime ? "Browser sign-in isn't available over a remote connection — use an API key below." : undefined}
                 style={{
                   background: LINEAR_BRAND,
                   width: "100%",
@@ -571,7 +584,11 @@ export function LinearSection() {
                 )}
                 {oauthStarting ? "Waiting for Linear..." : "Sign in with Linear"}
               </Button>
-              {connection?.oauthAvailable === false ? (
+              {isRemoteRuntime ? (
+                <div style={{ fontSize: 10, fontFamily: SANS_FONT, color: COLORS.textDim }}>
+                  Browser sign-in isn&rsquo;t available over a remote connection. Use an API key below — it&rsquo;s saved on the remote machine.
+                </div>
+              ) : connection?.oauthAvailable === false ? (
                 <div style={{ fontSize: 10, fontFamily: SANS_FONT, color: COLORS.textDim }}>
                   Browser sign-in is not available in this ADE build.
                 </div>

--- a/apps/desktop/src/renderer/components/settings/MobilePushPanel.tsx
+++ b/apps/desktop/src/renderer/components/settings/MobilePushPanel.tsx
@@ -35,6 +35,7 @@ import {
   inlineBadge,
   outlineButton,
 } from "../lanes/laneDesignTokens";
+import { MachineScopeBadge } from "./RemoteContextBadge";
 
 /**
  * Settings panel for the Mobile Push (APNs) integration.
@@ -509,7 +510,10 @@ export function MobilePushPanel() {
               </div>
             </div>
           </div>
-          <span style={inlineBadge(statusColor)}>{statusLabel}</span>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <MachineScopeBadge />
+            <span style={inlineBadge(statusColor)}>{statusLabel}</span>
+          </div>
         </div>
 
         {/* Minimal required fields: Team ID (after .p8 drop) */}

--- a/apps/desktop/src/renderer/components/settings/RemoteContextBadge.tsx
+++ b/apps/desktop/src/renderer/components/settings/RemoteContextBadge.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { Desktop, HardDrives } from "@phosphor-icons/react";
+import { useAppStore } from "../../state/appStore";
+import { COLORS, SANS_FONT } from "../lanes/laneDesignTokens";
+
+/**
+ * Settings reflect whichever machine the active project is bound to. When the
+ * project is opened on a remote runtime, the integration sections (Linear,
+ * GitHub, AI) already route their reads/writes to that machine's daemon — so
+ * they show the remote machine's connection state, not the local one. These
+ * helpers make that scope explicit in the UI:
+ *   - `RemoteSettingsBanner` clarifies the whole page reflects the remote host.
+ *   - `MachineScopeBadge` marks the few sections that stay local (push certs,
+ *     device pairing) so their values aren't mistaken for the remote machine's.
+ */
+export function useRemoteRuntimeContext(): {
+  isRemote: boolean;
+  runtimeName: string | null;
+} {
+  const projectBinding = useAppStore((s) => s.projectBinding);
+  if (projectBinding?.kind === "remote") {
+    return { isRemote: true, runtimeName: projectBinding.runtimeName || null };
+  }
+  return { isRemote: false, runtimeName: null };
+}
+
+/** Banner shown atop the Settings content when viewing a remote project. */
+export function RemoteSettingsBanner() {
+  const { isRemote, runtimeName } = useRemoteRuntimeContext();
+  if (!isRemote) return null;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "10px 14px",
+        marginBottom: 20,
+        borderRadius: 8,
+        background: COLORS.accentSubtle,
+        border: `1px solid ${COLORS.accentBorder}`,
+        fontFamily: SANS_FONT,
+        fontSize: 12,
+        color: COLORS.textSecondary,
+      }}
+    >
+      <HardDrives size={16} weight="regular" style={{ flexShrink: 0, color: COLORS.accent }} />
+      <span>
+        Showing settings for{" "}
+        <strong style={{ color: COLORS.textPrimary, fontWeight: 600 }}>
+          {runtimeName ?? "the remote machine"}
+        </strong>
+        . Connections and credentials reflect that machine, not this one.
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Small pill marking a section whose values are tied to THIS desktop and do not
+ * reflect the remote machine (e.g. local push certificate, device pairing).
+ * Renders nothing unless the active project is remote.
+ */
+export function MachineScopeBadge() {
+  const { isRemote } = useRemoteRuntimeContext();
+  if (!isRemote) return null;
+
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 5,
+        padding: "2px 8px",
+        borderRadius: 999,
+        background: COLORS.hoverBg,
+        border: `1px solid ${COLORS.borderMuted}`,
+        fontFamily: SANS_FONT,
+        fontSize: 10,
+        fontWeight: 600,
+        color: COLORS.textMuted,
+        whiteSpace: "nowrap",
+      }}
+      title="These values live on this computer and are not read from the remote machine."
+    >
+      <Desktop size={12} weight="regular" style={{ flexShrink: 0 }} />
+      This machine
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

Bundles several related fixes landed on this lane:

- **Ship cr-sqlite into the static/headless brain.** The native tarball (`package-native-deps.mjs`) now copies `crsqlite.<ext>` from the desktop vendor dir, and `crsqliteExtension.ts` resolves it from `<ADE_HOME>/runtime/<target>/`. Without this the installed brain — the default sync host — had no CRR engine and crashed on `crsql_internal_sync_bit` for every CRR-table write.
- **Exclude config-snapshot tables** (`process_definitions`, `stack_buttons`, `test_suites`) from CRR. Their delete+reinsert rebuild fired CRR triggers; they must never replicate.
- **Classify `crsql` / "not callable" RPC errors as app-level**, not transport-level, so a single `markCallFailure` helper keeps the remote connection green instead of tearing it down. Collapses 9 duplicated catch blocks.
- **Surface a remote machine's Linear/GitHub/AI** when bound to a remote runtime: `LinearQuickViewButton` no longer suppresses on remote (routes to the remote daemon), `LinearSection` steers remote to API-key entry (OAuth loopback can't cross remote), plus a new `RemoteContextBadge`.
- **Don't wipe open project tabs** on a transient null project state during remote rebind.

## Test plan

- [x] `crsqliteExtension` / `kvDb` CRR-exclusion unit tests (kvDb.test.ts) — 15/15
- [x] `remoteConnectionService` error-classification tests — 14/14
- [x] `TopBar` Linear remote-visibility tests — 34/34
- [x] apps/desktop typecheck + eslint clean
- [ ] CI green across shards + build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicators in Settings to identify when projects are bound to remote runtimes, with guidance on using API keys instead of browser-based authentication.

* **Bug Fixes**
  * Fixed transient "no project" state appearing during remote project binding.
  * Fixed unintended tab clearing when switching between local and remote projects.
  * Improved error handling to distinguish between connection failures and application-level errors.
  * Enhanced Linear integration to work properly with remote projects.

* **Tests**
  * Added regression tests for project tab preservation during remote transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles five related fixes: ships the cr-sqlite native extension into the static brain package so CRDT replication works on headless installs, excludes config-snapshot tables (`process_definitions`, `stack_buttons`, `test_suites`) from CRR to stop delete+reinsert rebuilds from firing missing-extension crashes, collapses nine duplicated catch blocks into a single `markCallFailure` helper that distinguishes app-level RPC errors from genuine transport failures, and surfaces the remote machine's Linear/GitHub/AI integrations in the UI while blocking OAuth loopback flows that can't cross a remote boundary.

- **Packaging & extension resolution**: `package-native-deps.mjs` copies `crsqlite.<ext>` from the desktop vendor dir; `crsqliteExtension.ts` adds `<ADE_HOME>/runtime/<target>/` as a candidate path, with matching directory structure between packager output and resolver input.
- **Remote connection hygiene**: `markCallFailure` skips `mergeStatus(error)` for app-level errors (crsql, "not callable"), preventing false "host unreachable" toasts and reconnect loops; nine prior duplicated catch blocks now delegate to this helper.
- **Tab preservation**: `main.ts` drops the redundant `emitProjectChangedToWindow(null)` precursor during remote bind; `TopBar.tsx` removes the tab-wiping branch from the `!rootPath` effect (delegating to `closeProject()` in appStore) and changes session restore to merge rather than replace tabs.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all five fix areas are well-scoped, explicitly commented, and covered by targeted regression tests.

The changes are surgical and each is backed by a concrete test that reproduces the original failure. The markCallFailure refactor correctly preserves the existing isImplicitConnectionFailure gate before touching connection state. The tab-management changes remove a side-effect that was firing too broadly and rely on closeProject() in appStore for authoritative tab clearing — an assumption the new TopBar tests validate directly. The CRR exclusion list additions and the crsqlite packaging path are structurally straightforward. No regressions were found across the changed paths.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/ade-cli/scripts/package-native-deps.mjs | Adds copyCrsqliteExtension that copies crsqlite.<ext> from the desktop vendor dir; hard-fails for CRSQLITE_REQUIRED_TARGETS (darwin-arm64 only), warns-and-skips for unvendored targets. |
| apps/desktop/src/main/main.ts | Removes two emitProjectChangedToWindow(null) precursor calls during remote bind/restore so the renderer never sees a transient project==null state that would clear open tabs. |
| apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts | Introduces markCallFailure helper that skips connection-state mutation for app-level errors; collapses nine duplicated catch blocks. |
| apps/desktop/src/main/services/state/kvDb.ts | Adds process_definitions, stack_buttons, and test_suites to LOCAL_ONLY_CRR_EXCLUDED_TABLES with detailed inline comment. |
| apps/desktop/src/renderer/components/app/TopBar.tsx | Tab management overhauled: removes tab-wiping from the !rootPath effect, changes session restore from replace to merge, tightens the clear-on-empty-session guard. |
| apps/desktop/src/renderer/components/settings/RemoteContextBadge.tsx | New file exporting useRemoteRuntimeContext hook, RemoteSettingsBanner, and MachineScopeBadge. Clean and minimal. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[RPC call over established connection throws] --> B{isImplicitConnectionFailure?}
    B -->|No - app-level error| C[markCallFailure returns early]
    C --> D[Connection stays connected]
    B -->|Yes - transport failure| E[mergeStatus: state=error]
    E --> F[Connection flips to error]
    D --> G[Error rethrown to caller]
    F --> G
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/renderer/components/settings/LinearSection.tsx`, line 765 ([link](https://github.com/arul28/ade/blob/13d98e79658423291e5a24f2b0099176cbd3c5ab/apps/desktop/src/renderer/components/settings/LinearSection.tsx#L765)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `useRemoteRuntimeContext` for settings scope — minor consistency nit

   `LinearSection` reads `s.projectBinding?.kind === "remote"` directly from the store while this PR adds the shared `useRemoteRuntimeContext` hook in `RemoteContextBadge.tsx` for exactly this purpose. The two are functionally equivalent, but using the hook here would keep the remote-context read consistent across all settings sections and make the hook easier to evolve (e.g. if the condition gains more nuance).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/settings/LinearSection.tsx
   Line: 765

   Comment:
   `useRemoteRuntimeContext` for settings scope — minor consistency nit

   `LinearSection` reads `s.projectBinding?.kind === "remote"` directly from the store while this PR adds the shared `useRemoteRuntimeContext` hook in `RemoteContextBadge.tsx` for exactly this purpose. The two are functionally equivalent, but using the hook here would keep the remote-context read consistent across all settings sections and make the hook easier to evolve (e.g. if the condition gains more nuance).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fsettings%2FLinearSection.tsx%0ALine%3A%20765%0A%0AComment%3A%0A%60useRemoteRuntimeContext%60%20for%20settings%20scope%20%E2%80%94%20minor%20consistency%20nit%0A%0A%60LinearSection%60%20reads%20%60s.projectBinding%3F.kind%20%3D%3D%3D%20%22remote%22%60%20directly%20from%20the%20store%20while%20this%20PR%20adds%20the%20shared%20%60useRemoteRuntimeContext%60%20hook%20in%20%60RemoteContextBadge.tsx%60%20for%20exactly%20this%20purpose.%20The%20two%20are%20functionally%20equivalent%2C%20but%20using%20the%20hook%20here%20would%20keep%20the%20remote-context%20read%20consistent%20across%20all%20settings%20sections%20and%20make%20the%20hook%20easier%20to%20evolve%20%28e.g.%20if%20the%20condition%20gains%20more%20nuance%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=542&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["ship: harden crsqlite packaging per revi..."](https://github.com/arul28/ade/commit/e184e819c9b5f5c8876f6315c96a1cae69231a70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36281323)</sub>

<!-- /greptile_comment -->