### PR TITLE
chat-20260608-152623

### DIFF
--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -29,7 +29,7 @@ import { QuickRunMenu } from "../run/QuickRunMenu";
 import { CreateLaneDialog, type CreateLaneMode, type CreateLaneSetupStep } from "./CreateLaneDialog";
 import { AttachLaneDialog } from "./AttachLaneDialog";
 import { MultiAttachWorktreeDialog } from "./MultiAttachWorktreeDialog";
-import { ManageLaneDialog } from "./ManageLaneDialog";
+import { ManageLaneDialog, EMPTY_LANE_DELETE_SELECTION, type LaneDeleteSelection } from "./ManageLaneDialog";
 import { LaneContextMenu } from "./LaneContextMenu";
 import { getLaneAccent } from "./laneColorPalette";
 import { LaneRebaseBanner } from "./LaneRebaseBanner";
@@ -560,10 +560,8 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
       return false;
     }
   });
-  const [deleteMode, setDeleteMode] = useState<"worktree" | "local_branch" | "remote_branch">("worktree");
-  const [deleteRemoteName, setDeleteRemoteName] = useState("origin");
-  const [deleteForce, setDeleteForce] = useState(false);
-  const [deleteConfirmText, setDeleteConfirmText] = useState("");
+  const [deleteSelection, setDeleteSelection] = useState<LaneDeleteSelection>(EMPTY_LANE_DELETE_SELECTION);
+  const [deleteForce, setDeleteForce] = useState(true);
   const [laneActionBusy, setLaneActionBusy] = useState(false);
   const [laneActionStatus, setLaneActionStatus] = useState<string | null>(null);
   const [laneActionError, setLaneActionError] = useState<string | null>(null);
@@ -876,11 +874,6 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     [managedLaneIds, lanesById],
   );
   const isBatchManage = managedLanes.length > 1;
-  const deletePhrase = isBatchManage
-    ? `delete ${managedLanes.length} lanes`
-    : managedLane
-      ? `delete ${managedLane.name}`
-      : "";
   const selectedAttachedLane = managedLane?.laneType === "attached" ? managedLane : null;
   const shouldShowAdoptHint = Boolean(selectedAttachedLane && !adoptHintDismissed);
   const adoptTargetLane = adoptTargetLaneId ? lanesById.get(adoptTargetLaneId) ?? null : null;
@@ -1798,14 +1791,10 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     const deleteArgsByLaneId = new Map<string, DeleteLaneArgs>();
     for (const lane of actionable) {
       const args: DeleteLaneArgs = { laneId: lane.id, force: deleteForce };
-      if (deleteMode === "worktree") {
-        args.deleteBranch = false;
-      } else {
-        args.deleteBranch = true;
-        if (deleteMode === "remote_branch") {
-          args.deleteRemoteBranch = true;
-          args.remoteName = deleteRemoteName.trim() || "origin";
-        }
+      args.deleteBranch = deleteSelection.localBranch || deleteSelection.remoteBranch;
+      if (deleteSelection.remoteBranch) {
+        args.deleteRemoteBranch = true;
+        args.remoteName = "origin";
       }
       deleteArgsByLaneId.set(lane.id, args);
     }
@@ -1827,7 +1816,7 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     setLaneActionKind(null);
     laneDeleteWarningMessagesRef.current.clear();
     setLaneActionError(null);
-    setDeleteConfirmText("");
+    setDeleteSelection(EMPTY_LANE_DELETE_SELECTION);
     moveAwayFromDeletingLanes(laneIds);
 
     void (async () => {
@@ -1888,10 +1877,8 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     if (manageable.length === 0) return;
     setManagedLaneIds(manageable);
     setLaneActionError(null);
-    setDeleteForce(false);
-    setDeleteMode("worktree");
-    setDeleteRemoteName("origin");
-    setDeleteConfirmText("");
+    setDeleteForce(true);
+    setDeleteSelection(EMPTY_LANE_DELETE_SELECTION);
     setManageOpen(true);
   }, [lanesById, deletingLaneIds]);
 
@@ -2387,10 +2374,8 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     if (!lane || lane.laneType === "primary" || deletingLaneIds.has(targetId)) return;
     setManagedLaneIds([targetId]);
     setLaneActionError(null);
-    setDeleteForce(false);
-    setDeleteMode("worktree");
-    setDeleteRemoteName("origin");
-    setDeleteConfirmText("");
+    setDeleteForce(true);
+    setDeleteSelection(EMPTY_LANE_DELETE_SELECTION);
     setManageOpen(true);
     setPulsingLaneId(targetId);
     // Scrub the action param so refreshes don't re-open.
@@ -3158,10 +3143,8 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     setManagedLaneIds([laneId]);
     setLaneActionError(null);
     setAdoptError(null);
-    setDeleteForce(false);
-    setDeleteMode("worktree");
-    setDeleteRemoteName("origin");
-    setDeleteConfirmText("");
+    setDeleteForce(true);
+    setDeleteSelection(EMPTY_LANE_DELETE_SELECTION);
     setManageOpen(true);
   }, [deletingLaneIds, selectLane]);
 
@@ -4488,15 +4471,11 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
         managedLane={managedLane}
         managedLanes={managedLanes}
         allLanes={lanes}
-        deleteMode={deleteMode}
-        setDeleteMode={setDeleteMode}
-        deleteRemoteName={deleteRemoteName}
-        setDeleteRemoteName={setDeleteRemoteName}
+        deleteSelection={deleteSelection}
+        setDeleteSelection={setDeleteSelection}
         deleteForce={deleteForce}
         setDeleteForce={setDeleteForce}
-        deleteConfirmText={deleteConfirmText}
-        setDeleteConfirmText={setDeleteConfirmText}
-        deletePhrase={deletePhrase}
+        chatSessionCount={managedLane ? (laneRuntimeById.get(managedLane.id)?.sessionCount ?? 0) : undefined}
         laneActionBusy={laneActionBusy}
         laneActionStatus={laneActionStatus}
         laneActionError={laneActionError}

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -1791,7 +1791,7 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     const deleteArgsByLaneId = new Map<string, DeleteLaneArgs>();
     for (const lane of actionable) {
       const args: DeleteLaneArgs = { laneId: lane.id, force: deleteForce };
-      args.deleteBranch = deleteSelection.localBranch || deleteSelection.remoteBranch;
+      args.deleteBranch = deleteSelection.localBranch;
       if (deleteSelection.remoteBranch) {
         args.deleteRemoteBranch = true;
         args.remoteName = "origin";

--- a/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx
+++ b/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx
@@ -3,7 +3,11 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LaneDeleteRisk, LaneSummary } from "../../../shared/types";
-import { ManageLaneDialog } from "./ManageLaneDialog";
+import {
+  ManageLaneDialog,
+  EMPTY_LANE_DELETE_SELECTION,
+  type LaneDeleteSelection,
+} from "./ManageLaneDialog";
 
 afterEach(cleanup);
 
@@ -57,15 +61,11 @@ function makeProps(overrides: Partial<DialogProps> = {}): DialogProps {
     managedLane: lane,
     managedLanes: undefined,
     allLanes: [lane],
-    deleteMode: "worktree",
-    setDeleteMode: vi.fn(),
-    deleteRemoteName: "origin",
-    setDeleteRemoteName: vi.fn(),
-    deleteForce: false,
+    deleteSelection: EMPTY_LANE_DELETE_SELECTION,
+    setDeleteSelection: vi.fn(),
+    deleteForce: true,
     setDeleteForce: vi.fn(),
-    deleteConfirmText: "delete Manage tabs",
-    setDeleteConfirmText: vi.fn(),
-    deletePhrase: "delete Manage tabs",
+    chatSessionCount: 0,
     laneActionBusy: false,
     laneActionStatus: null,
     laneActionError: null,
@@ -105,13 +105,13 @@ describe("ManageLaneDialog tabs", () => {
     vi.clearAllMocks();
   });
 
-  it("opens on the first non-destructive tab for a single lane", () => {
+  it("opens on the delete tab by default for a single lane", () => {
     render(<ManageLaneDialog {...makeProps()} />);
 
-    expect(selectedTabLabel()).toBe("Appearance");
+    expect(selectedTabLabel()).toBe("Delete");
   });
 
-  it("opens on archive for batch lane management", () => {
+  it("opens on the delete tab for batch lane management", () => {
     const firstLane = makeLane({ id: "lane-1", name: "First lane" });
     const secondLane = makeLane({ id: "lane-2", name: "Second lane" });
 
@@ -125,7 +125,7 @@ describe("ManageLaneDialog tabs", () => {
       />,
     );
 
-    expect(selectedTabLabel()).toBe("Archive");
+    expect(selectedTabLabel()).toBe("Delete");
   });
 
   it("does not reset the selected tab when the lane object refreshes", () => {
@@ -146,80 +146,29 @@ describe("ManageLaneDialog tabs", () => {
   });
 
   it("shows active chat sessions in the delete preflight", async () => {
-    (window as any).ade.lanes.getDeleteRisk.mockResolvedValueOnce({
-      ...deleteRisk,
-      activeChatCount: 1,
-    });
-
-    render(<ManageLaneDialog {...makeProps()} />);
-
-    fireEvent.click(screen.getByRole("tab", { name: "Delete" }));
+    render(<ManageLaneDialog {...makeProps({ chatSessionCount: 1 })} />);
 
     await waitFor(() => {
       expect(screen.getByText("1 chat session")).toBeTruthy();
     });
   });
 
-  it("allows a clean worktree-only delete without hidden confirmation text", async () => {
-    const onDelete = vi.fn();
-    render(
-      <ManageLaneDialog
-        {...makeProps({
-          deleteConfirmText: "",
-          onDelete,
-        })}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("tab", { name: "Delete" }));
+  it("disables the delete button when nothing is selected", async () => {
+    render(<ManageLaneDialog {...makeProps({ deleteSelection: EMPTY_LANE_DELETE_SELECTION })} />);
 
     const deleteButton = await screen.findByRole("button", { name: /delete lane/i });
-    await waitFor(() => {
-      expect((deleteButton as HTMLButtonElement).disabled).toBe(false);
-    });
-
-    fireEvent.click(deleteButton);
-
-    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect((deleteButton as HTMLButtonElement).disabled).toBe(true);
   });
 
-  it("requires typed confirmation for a dirty lane delete", async () => {
-    (window as any).ade.lanes.getDeleteRisk.mockResolvedValueOnce({
-      ...deleteRisk,
-      dirty: true,
-    });
+  it("enables delete once a target is selected and fires onDelete", async () => {
     const onDelete = vi.fn();
-    const { rerender } = render(
-      <ManageLaneDialog
-        {...makeProps({
-          deleteConfirmText: "",
-          onDelete,
-        })}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("tab", { name: "Delete" }));
+    const selection: LaneDeleteSelection = { worktree: true, localBranch: false, remoteBranch: false };
+    render(<ManageLaneDialog {...makeProps({ deleteSelection: selection, onDelete })} />);
 
     const deleteButton = await screen.findByRole("button", { name: /delete lane/i });
-    await waitFor(() => {
-      expect((deleteButton as HTMLButtonElement).disabled).toBe(true);
-    });
+    expect((deleteButton as HTMLButtonElement).disabled).toBe(false);
 
-    rerender(
-      <ManageLaneDialog
-        {...makeProps({
-          deleteConfirmText: "delete Manage tabs",
-          onDelete,
-        })}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("tab", { name: "Delete" }));
-    await waitFor(() => {
-      expect((screen.getByRole("button", { name: /delete lane/i }) as HTMLButtonElement).disabled).toBe(false);
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: /delete lane/i }));
+    fireEvent.click(deleteButton);
 
     expect(onDelete).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx
+++ b/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx
@@ -12,6 +12,8 @@ import {
   Eye,
   Cube,
   CheckCircle,
+  Check,
+  Cloud,
   X,
   Minus,
   TreeStructure,
@@ -25,6 +27,23 @@ import type {
   LaneDeleteStepName,
   LaneSummary
 } from "../../../shared/types";
+
+/** Independent delete targets shown as a checklist. */
+export type LaneDeleteSelection = {
+  worktree: boolean;
+  localBranch: boolean;
+  remoteBranch: boolean;
+};
+
+export const EMPTY_LANE_DELETE_SELECTION: LaneDeleteSelection = {
+  worktree: false,
+  localBranch: false,
+  remoteBranch: false,
+};
+
+function laneDeleteSelectionHasAny(selection: LaneDeleteSelection): boolean {
+  return selection.worktree || selection.localBranch || selection.remoteBranch;
+}
 import { LaneDialogShell } from "./LaneDialogShell";
 import {
   LABEL_CLASS_NAME,
@@ -190,15 +209,11 @@ export function ManageLaneDialog({
   managedLane,
   managedLanes,
   allLanes,
-  deleteMode,
-  setDeleteMode,
-  deleteRemoteName,
-  setDeleteRemoteName,
+  deleteSelection,
+  setDeleteSelection,
   deleteForce,
   setDeleteForce,
-  deleteConfirmText,
-  setDeleteConfirmText,
-  deletePhrase,
+  chatSessionCount,
   laneActionBusy,
   laneActionStatus,
   laneActionError,
@@ -214,15 +229,11 @@ export function ManageLaneDialog({
   managedLane: LaneSummary | null;
   managedLanes?: LaneSummary[];
   allLanes: LaneSummary[];
-  deleteMode: "worktree" | "local_branch" | "remote_branch";
-  setDeleteMode: (v: "worktree" | "local_branch" | "remote_branch") => void;
-  deleteRemoteName: string;
-  setDeleteRemoteName: (v: string) => void;
+  deleteSelection: LaneDeleteSelection;
+  setDeleteSelection: (v: LaneDeleteSelection) => void;
   deleteForce: boolean;
   setDeleteForce: (v: boolean) => void;
-  deleteConfirmText: string;
-  setDeleteConfirmText: (v: string) => void;
-  deletePhrase: string;
+  chatSessionCount?: number;
   laneActionBusy: boolean;
   laneActionStatus: string | null;
   laneActionError: string | null;
@@ -241,26 +252,12 @@ export function ManageLaneDialog({
   const singleLane = !isBatch ? lanes[0] ?? null : null;
 
   const isAttached = !isBatch && lanes[0]?.laneType === "attached";
-  const hasNonAttached = lanes.some((l) => l.laneType !== "attached" && l.laneType !== "primary");
-  const isMixed = hasAttached && hasNonAttached;
   const singleLaneId = singleLane?.id ?? null;
   const singleLaneType = singleLane?.laneType ?? null;
-  let worktreeDeleteLabel: string;
-  let localDeleteLabel: string;
-  let remoteDeleteLabel: string;
-  if (isMixed) {
-    worktreeDeleteLabel = "Unlink + folder";
-    localDeleteLabel = "+ local branches";
-    remoteDeleteLabel = "+ remote too";
-  } else if (hasAttached) {
-    worktreeDeleteLabel = "Unlink only";
-    localDeleteLabel = "+ local branch";
-    remoteDeleteLabel = "+ local & remote";
-  } else {
-    worktreeDeleteLabel = "Worktree only";
-    localDeleteLabel = "+ local branch";
-    remoteDeleteLabel = "+ remote too";
-  }
+  const worktreeRowTitle = hasAttached ? "Unlink from ADE" : "Worktree";
+  const worktreeRowHint = hasAttached
+    ? "Stops ADE managing this lane. Keeps the folder + branch."
+    : "Removes the working folder and ADE registration.";
 
   const [deleteRisk, setDeleteRisk] = useState<LaneDeleteRisk | null>(null);
   const [deleteProgress, setDeleteProgress] = useState<LaneDeleteProgress | null>(null);
@@ -276,9 +273,10 @@ export function ManageLaneDialog({
       .filter((t) => t.show)
       .map(({ show: _, ...tab }) => tab);
   }, [singleLaneType]);
+  // Manage Lane always opens on Delete — it's the first tab and the action
+  // users reach for most. Other tabs (appearance, restack, archive) are opt-in.
   const defaultTab = React.useMemo((): ManageLaneTab => {
-    const preferredOrder: ManageLaneTab[] = ["appearance", "stack", "archive", "delete"];
-    return preferredOrder.find((id) => tabDefs.some((tab) => tab.id === id)) ?? tabDefs[0]?.id ?? "archive";
+    return tabDefs.some((tab) => tab.id === "delete") ? "delete" : tabDefs[0]?.id ?? "archive";
   }, [tabDefs]);
 
   // Reset transient state when dialog closes or active lane changes.
@@ -323,16 +321,38 @@ export function ManageLaneDialog({
     };
   }, [open, singleLaneId]);
 
-  const requiresTypeConfirm =
-    isBatch ||
-    !deleteRisk ||
-    deleteForce ||
-    deleteRisk.dirty ||
-    deleteMode === "remote_branch" ||
-    (deleteMode === "local_branch" && deleteRisk.hasUnpushedCommits);
-
-  const confirmMatch = !requiresTypeConfirm || deleteConfirmText.trim().toLowerCase() === deletePhrase.toLowerCase();
+  const hasDeleteSelection = laneDeleteSelectionHasAny(deleteSelection);
   const showStaticBusy = laneActionBusy && !deleteProgress;
+
+  // Local/remote branch deletion can't happen while the worktree still has the
+  // branch checked out, and any delete here tears the worktree down regardless —
+  // so picking a branch implies the worktree, and clearing the worktree clears
+  // the branches. This keeps the checklist in a state git can actually execute.
+  const toggleDeleteTarget = (key: keyof LaneDeleteSelection, next: boolean) => {
+    if (key === "worktree") {
+      setDeleteSelection(
+        next
+          ? { ...deleteSelection, worktree: true }
+          : EMPTY_LANE_DELETE_SELECTION,
+      );
+      return;
+    }
+    setDeleteSelection({
+      ...deleteSelection,
+      [key]: next,
+      worktree: next ? true : deleteSelection.worktree,
+    });
+  };
+
+  const allTargetsSelected =
+    deleteSelection.worktree && deleteSelection.localBranch && deleteSelection.remoteBranch;
+  const toggleSelectAll = () => {
+    setDeleteSelection(
+      allTargetsSelected
+        ? EMPTY_LANE_DELETE_SELECTION
+        : { worktree: true, localBranch: true, remoteBranch: true },
+    );
+  };
 
   useEffect(() => {
     if (tabDefs.some((tab) => tab.id === activeTab)) return;
@@ -440,70 +460,31 @@ export function ManageLaneDialog({
                 </div>
               ) : null}
 
-              <div data-tour="lanes.manageDialog.tabs" className="mt-4 grid gap-2 sm:grid-cols-3">
-                {([
-                  { value: "worktree" as const, label: worktreeDeleteLabel },
-                  { value: "local_branch" as const, label: localDeleteLabel },
-                  { value: "remote_branch" as const, label: remoteDeleteLabel },
-                ]).map((opt) => (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    disabled={laneActionBusy}
-                    onClick={() => setDeleteMode(opt.value)}
-                    className={`rounded-lg border px-3 py-2.5 text-left text-xs font-medium transition-all ${
-                      deleteMode === opt.value
-                        ? "border-red-400/35 bg-red-500/15 text-red-100 shadow-sm ring-1 ring-red-400/20"
-                        : "border-white/[0.08] bg-black/20 text-muted-fg hover:border-white/[0.14] hover:text-fg"
-                    }`}
-                  >
-                    {opt.label}
-                  </button>
-                ))}
-              </div>
+              <DeleteTargetChecklist
+                selection={deleteSelection}
+                allSelected={allTargetsSelected}
+                disabled={laneActionBusy}
+                onToggle={toggleDeleteTarget}
+                onToggleAll={toggleSelectAll}
+                worktreeTitle={worktreeRowTitle}
+                worktreeHint={worktreeRowHint}
+                risk={deleteRisk}
+                lane={singleLane}
+              />
 
               {singleLane ? (
                 <PreflightPanel
                   risk={deleteRisk}
-                  deleteMode={deleteMode}
-                  remoteName={deleteRemoteName}
+                  selection={deleteSelection}
                   lane={singleLane}
+                  chatSessionCount={chatSessionCount}
                 />
-              ) : null}
-
-              {deleteMode === "remote_branch" ? (
-                <div className="mt-3">
-                  <span className={LABEL_CLASS_NAME}>Remote</span>
-                  <input
-                    value={deleteRemoteName}
-                    onChange={(event) => setDeleteRemoteName(event.target.value)}
-                    disabled={laneActionBusy}
-                    className={INPUT_CLASS_NAME}
-                    placeholder="origin"
-                  />
-                </div>
               ) : null}
 
               <label className="mt-3 flex items-center gap-2 text-xs text-muted-fg/80 cursor-pointer select-none">
                 <input type="checkbox" checked={deleteForce} onChange={(event) => setDeleteForce(event.target.checked)} disabled={laneActionBusy} className="rounded accent-red-400" />
                 Force delete
               </label>
-
-              {requiresTypeConfirm ? (
-                <div className="mt-3">
-                  <span className={LABEL_CLASS_NAME}>
-                    Confirm <span className="normal-case tracking-normal text-red-300">{deletePhrase}</span>
-                  </span>
-                  <input
-                    data-tour="lanes.manageDialog.confirm"
-                    value={deleteConfirmText}
-                    onChange={(event) => setDeleteConfirmText(event.target.value)}
-                    disabled={laneActionBusy}
-                    className={`${INPUT_CLASS_NAME} ${confirmMatch ? "!border-red-500/30" : ""}`}
-                    placeholder={deletePhrase}
-                  />
-                </div>
-              ) : null}
 
               {deleteProgress ? (
                 <DeleteProgressStrip progress={deleteProgress} />
@@ -530,7 +511,7 @@ export function ManageLaneDialog({
                   variant="primary"
                   data-tour="lanes.manageDialog.delete"
                   className="bg-red-600 hover:bg-red-500"
-                  disabled={laneActionBusy || !confirmMatch}
+                  disabled={laneActionBusy || !hasDeleteSelection}
                   onClick={onDelete}
                 >
                   {laneActionBusy && laneActionKind === "delete" ? <CircleNotch size={13} className="animate-spin" /> : <Trash size={13} />}
@@ -553,31 +534,171 @@ function formatBranchLabel(ref: string): string {
   return ref.trim().replace(/^refs\/heads\//, "").replace(/^origin\//, "");
 }
 
+function DeleteCheckbox({ checked, indeterminate = false }: { checked: boolean; indeterminate?: boolean }) {
+  const active = checked || indeterminate;
+  return (
+    <span
+      aria-hidden
+      className={`flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[5px] border transition-colors ${
+        active ? "border-red-400/70 bg-red-500/80 text-white" : "border-white/25 bg-white/[0.04]"
+      }`}
+    >
+      {checked ? <Check size={12} weight="bold" /> : indeterminate ? <Minus size={12} weight="bold" /> : null}
+    </span>
+  );
+}
+
+function DeleteTargetChecklist({
+  selection,
+  allSelected,
+  disabled,
+  onToggle,
+  onToggleAll,
+  worktreeTitle,
+  worktreeHint,
+  risk,
+  lane,
+}: {
+  selection: LaneDeleteSelection;
+  allSelected: boolean;
+  disabled: boolean;
+  onToggle: (key: keyof LaneDeleteSelection, next: boolean) => void;
+  onToggleAll: () => void;
+  worktreeTitle: string;
+  worktreeHint: string;
+  risk: LaneDeleteRisk | null;
+  lane: LaneSummary | null;
+}) {
+  const branchRef = risk?.branchRef ?? lane?.branchRef ?? null;
+  const branchLabel = branchRef ? formatBranchLabel(branchRef) : null;
+  const someSelected = selection.worktree || selection.localBranch || selection.remoteBranch;
+
+  const rows: { key: keyof LaneDeleteSelection; icon: React.ReactNode; title: string; hint: string; mono?: boolean }[] = [
+    {
+      key: "worktree",
+      icon: <Cube size={15} weight="duotone" />,
+      title: worktreeTitle,
+      hint: worktreeHint,
+    },
+    {
+      key: "localBranch",
+      icon: <BranchIcon size={14} />,
+      title: "Local branch",
+      hint: branchLabel ?? "Delete the git branch on this machine",
+      mono: Boolean(branchLabel),
+    },
+    {
+      key: "remoteBranch",
+      icon: <Cloud size={15} weight="duotone" />,
+      title: "Remote branch",
+      hint: branchLabel ? `origin · ${branchLabel}` : "Delete the branch on the remote",
+      mono: Boolean(branchLabel),
+    },
+  ];
+
+  return (
+    <div
+      data-tour="lanes.manageDialog.tabs"
+      className="mt-4 overflow-hidden rounded-xl border border-white/[0.08] bg-black/25"
+    >
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onToggleAll}
+        aria-pressed={allSelected}
+        className="flex w-full items-center gap-3 border-b border-white/[0.06] bg-white/[0.02] px-3 py-2.5 text-left transition-colors hover:bg-white/[0.04] disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <DeleteCheckbox checked={allSelected} indeterminate={someSelected && !allSelected} />
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-semibold text-fg">Select everything</div>
+          <div className="text-[11px] text-muted-fg/60">Worktree, local &amp; remote branch</div>
+        </div>
+        {allSelected ? (
+          <span className="shrink-0 rounded-full bg-red-500/15 px-2 py-0.5 text-[10px] font-medium text-red-200">All</span>
+        ) : null}
+      </button>
+
+      <div className="divide-y divide-white/[0.04]">
+        {rows.map((row) => {
+          const checked = selection[row.key];
+          return (
+            <button
+              key={row.key}
+              type="button"
+              role="checkbox"
+              aria-checked={checked}
+              disabled={disabled}
+              onClick={() => onToggle(row.key, !checked)}
+              className={`flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-60 ${
+                checked ? "bg-red-500/[0.08]" : "hover:bg-white/[0.03]"
+              }`}
+            >
+              <DeleteCheckbox checked={checked} />
+              <span
+                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border ${
+                  checked
+                    ? "border-red-400/30 bg-red-500/15 text-red-200"
+                    : "border-white/[0.08] bg-white/[0.03] text-muted-fg/70"
+                }`}
+              >
+                {row.icon}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className={`block text-xs font-medium ${checked ? "text-red-100" : "text-fg"}`}>{row.title}</span>
+                <span className={`block truncate text-[11px] text-muted-fg/60 ${row.mono ? "font-mono" : ""}`}>{row.hint}</span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+type DeleteRemovalItem = { icon: React.ReactNode; label: React.ReactNode; hint?: string };
+
 function buildDeleteRemovalPreview(
-  deleteMode: "worktree" | "local_branch" | "remote_branch",
+  selection: LaneDeleteSelection,
   lane: LaneSummary,
   risk: LaneDeleteRisk | null,
-  remoteName: string,
-): { icon: React.ReactNode; label: string; hint?: string }[] {
-  const items: { icon: React.ReactNode; label: string; hint?: string }[] = [];
+): DeleteRemovalItem[] {
+  const items: DeleteRemovalItem[] = [];
   const branchRef = risk?.branchRef ?? lane.branchRef ?? null;
   const branchLabel = branchRef ? formatBranchLabel(branchRef) : null;
+  const laneColor = lane.color ?? null;
+  const laneColorStyle = laneColor ? { color: laneColor } : undefined;
 
-  if (lane.laneType === "attached") {
-    if (deleteMode === "worktree") {
+  if (selection.worktree) {
+    if (lane.laneType === "attached") {
       items.push({
         icon: <ArrowSquareOut size={12} className="text-red-300/80" />,
         label: "Unlink from ADE (keep branch)",
       });
+    } else {
+      items.push({
+        icon: (
+          <LaneIcon
+            size={13}
+            weight="duotone"
+            className={laneColor ? "shrink-0" : "shrink-0 text-red-300/80"}
+            style={laneColorStyle}
+          />
+        ),
+        label: (
+          <span className="flex min-w-0 flex-col">
+            <span className="font-semibold" style={laneColorStyle}>
+              {lane.name}
+            </span>
+            {lane.worktreePath ? (
+              <span className="break-all text-[11px] text-muted-fg/55">{lane.worktreePath}</span>
+            ) : null}
+          </span>
+        ),
+      });
     }
-  } else if (lane.worktreePath) {
-    items.push({
-      icon: <Cube size={12} className="text-red-300/80" />,
-      label: lane.worktreePath,
-    });
   }
 
-  if ((deleteMode === "local_branch" || deleteMode === "remote_branch") && branchLabel) {
+  if (selection.localBranch && branchLabel) {
     const unpushed =
       risk?.hasUnpushedCommits && risk.unpushedCommitCount > 0
         ? ` · ${risk.unpushedCommitCount} unpushed`
@@ -588,11 +709,10 @@ function buildDeleteRemovalPreview(
     });
   }
 
-  if (deleteMode === "remote_branch" && branchLabel) {
-    const remote = remoteName.trim() || "origin";
+  if (selection.remoteBranch && branchLabel) {
     items.push({
-      icon: <BranchIcon size={12} className="text-red-300/80" />,
-      label: `Remote · ${remote}/${branchLabel}`,
+      icon: <Cloud size={12} className="text-red-300/80" />,
+      label: `Remote · origin/${branchLabel}`,
       hint: risk && !risk.remoteBranchExists ? "Not on remote yet" : undefined,
     });
   }
@@ -602,14 +722,14 @@ function buildDeleteRemovalPreview(
 
 function PreflightPanel({
   risk,
-  deleteMode,
-  remoteName,
-  lane
+  selection,
+  lane,
+  chatSessionCount,
 }: {
   risk: LaneDeleteRisk | null;
-  deleteMode: "worktree" | "local_branch" | "remote_branch";
-  remoteName: string;
+  selection: LaneDeleteSelection;
   lane: LaneSummary;
+  chatSessionCount?: number;
 }) {
   const willStop: { icon: React.ReactNode; label: string }[] = [];
   if (risk && risk.runningProcessCount > 0) {
@@ -618,10 +738,11 @@ function PreflightPanel({
       label: `${risk.runningProcessCount} running ${risk.runningProcessCount === 1 ? "process" : "processes"}`
     });
   }
-  if (risk && risk.activeChatCount > 0) {
+  const chatCount = chatSessionCount ?? 0;
+  if (chatCount > 0) {
     willStop.push({
       icon: <ChatCircle size={12} className="text-accent" />,
-      label: `${risk.activeChatCount} chat ${risk.activeChatCount === 1 ? "session" : "sessions"}`
+      label: `${chatCount} chat ${chatCount === 1 ? "session" : "sessions"}`
     });
   }
   if (risk && risk.activePtyCount > 0) {
@@ -637,7 +758,9 @@ function PreflightPanel({
     });
   }
 
-  const willRemove = buildDeleteRemovalPreview(deleteMode, lane, risk, remoteName);
+  const willRemove = buildDeleteRemovalPreview(selection, lane, risk);
+
+  if (willStop.length === 0 && willRemove.length === 0) return null;
 
   return (
     <div className="mt-3 rounded-lg border border-white/[0.08] bg-black/30 px-3 py-2.5">
@@ -650,9 +773,7 @@ function PreflightPanel({
             </li>
           ))}
         </ul>
-      ) : (
-        <div className="text-[11px] text-muted-fg/65">Nothing running on this lane.</div>
-      )}
+      ) : null}
       {willRemove.length > 0 ? (
         <>
           <div className={`text-[10px] uppercase tracking-wide text-muted-fg/50 ${willStop.length > 0 ? "mt-2.5" : ""} mb-1.5`}>
@@ -661,10 +782,10 @@ function PreflightPanel({
           <ul className="space-y-1.5">
             {willRemove.map((item, i) => (
               <li key={`remove-${i}`} className="flex items-start gap-2 text-xs text-red-200/85">
-                {item.icon}
-                <span className="min-w-0 break-all">
+                <span className="mt-0.5 flex h-3.5 w-3.5 items-center justify-center">{item.icon}</span>
+                <span className="flex min-w-0 flex-1 items-baseline gap-1 break-all">
                   {item.label}
-                  {item.hint ? <span className="text-muted-fg/60"> ({item.hint})</span> : null}
+                  {item.hint ? <span className="text-muted-fg/60">({item.hint})</span> : null}
                 </span>
               </li>
             ))}

--- a/apps/desktop/src/renderer/components/prs/shared/PrManageLaneDialogHost.tsx
+++ b/apps/desktop/src/renderer/components/prs/shared/PrManageLaneDialogHost.tsx
@@ -1,7 +1,11 @@
 import { memo, useCallback, useState } from "react";
 
 import type { DeleteLaneArgs, LaneSummary } from "../../../../shared/types";
-import { ManageLaneDialog } from "../../lanes/ManageLaneDialog";
+import {
+  ManageLaneDialog,
+  EMPTY_LANE_DELETE_SELECTION,
+  type LaneDeleteSelection,
+} from "../../lanes/ManageLaneDialog";
 import { useAppStore } from "../../../state/appStore";
 
 export type PrManageLaneDialogHostProps = {
@@ -18,16 +22,12 @@ export const PrManageLaneDialogHost = memo(function PrManageLaneDialogHost({
   const lanes = useAppStore((state) => state.lanes ?? []);
   const refreshLanes = useAppStore((state) => state.refreshLanes);
 
-  const [deleteMode, setDeleteMode] = useState<"worktree" | "local_branch" | "remote_branch">("worktree");
-  const [deleteRemoteName, setDeleteRemoteName] = useState("origin");
-  const [deleteForce, setDeleteForce] = useState(false);
-  const [deleteConfirmText, setDeleteConfirmText] = useState("");
+  const [deleteSelection, setDeleteSelection] = useState<LaneDeleteSelection>(EMPTY_LANE_DELETE_SELECTION);
+  const [deleteForce, setDeleteForce] = useState(true);
   const [laneActionBusy, setLaneActionBusy] = useState(false);
   const [laneActionStatus, setLaneActionStatus] = useState<string | null>(null);
   const [laneActionError, setLaneActionError] = useState<string | null>(null);
   const [laneActionKind, setLaneActionKind] = useState<"delete" | "archive" | "adopt" | null>(null);
-
-  const deletePhrase = lane ? `delete ${lane.name}` : "";
 
   const runLaneAction = useCallback(async (
     fn: () => Promise<void>,
@@ -60,24 +60,20 @@ export const PrManageLaneDialogHost = memo(function PrManageLaneDialogHost({
 
   const handleDelete = useCallback(async () => {
     if (!lane || lane.laneType === "primary") return;
-    if (deleteConfirmText.trim().toLowerCase() !== deletePhrase.toLowerCase()) return;
+    if (!deleteSelection.worktree && !deleteSelection.localBranch && !deleteSelection.remoteBranch) return;
 
     const args: DeleteLaneArgs = { laneId: lane.id, force: deleteForce };
-    if (deleteMode === "worktree") {
-      args.deleteBranch = false;
-    } else {
-      args.deleteBranch = true;
-      if (deleteMode === "remote_branch") {
-        args.deleteRemoteBranch = true;
-        args.remoteName = deleteRemoteName.trim() || "origin";
-      }
+    args.deleteBranch = deleteSelection.localBranch || deleteSelection.remoteBranch;
+    if (deleteSelection.remoteBranch) {
+      args.deleteRemoteBranch = true;
+      args.remoteName = "origin";
     }
 
     await runLaneAction(async () => {
       await window.ade.lanes.delete(args);
     }, "Deleting lane…", "delete");
-    setDeleteConfirmText("");
-  }, [deleteConfirmText, deleteForce, deleteMode, deletePhrase, deleteRemoteName, lane, runLaneAction]);
+    setDeleteSelection(EMPTY_LANE_DELETE_SELECTION);
+  }, [deleteForce, deleteSelection, lane, runLaneAction]);
 
   if (!open || !lane) return null;
 
@@ -87,15 +83,10 @@ export const PrManageLaneDialogHost = memo(function PrManageLaneDialogHost({
       onOpenChange={onOpenChange}
       managedLane={lane}
       allLanes={lanes}
-      deleteMode={deleteMode}
-      setDeleteMode={setDeleteMode}
-      deleteRemoteName={deleteRemoteName}
-      setDeleteRemoteName={setDeleteRemoteName}
+      deleteSelection={deleteSelection}
+      setDeleteSelection={setDeleteSelection}
       deleteForce={deleteForce}
       setDeleteForce={setDeleteForce}
-      deleteConfirmText={deleteConfirmText}
-      setDeleteConfirmText={setDeleteConfirmText}
-      deletePhrase={deletePhrase}
       laneActionBusy={laneActionBusy}
       laneActionStatus={laneActionStatus}
       laneActionError={laneActionError}

--- a/apps/desktop/src/renderer/components/prs/shared/PrManageLaneDialogHost.tsx
+++ b/apps/desktop/src/renderer/components/prs/shared/PrManageLaneDialogHost.tsx
@@ -63,7 +63,7 @@ export const PrManageLaneDialogHost = memo(function PrManageLaneDialogHost({
     if (!deleteSelection.worktree && !deleteSelection.localBranch && !deleteSelection.remoteBranch) return;
 
     const args: DeleteLaneArgs = { laneId: lane.id, force: deleteForce };
-    args.deleteBranch = deleteSelection.localBranch || deleteSelection.remoteBranch;
+    args.deleteBranch = deleteSelection.localBranch;
     if (deleteSelection.remoteBranch) {
       args.deleteRemoteBranch = true;
       args.remoteName = "origin";

--- a/apps/desktop/src/renderer/onboarding/stepBuilders/manageLaneDialog.ts
+++ b/apps/desktop/src/renderer/onboarding/stepBuilders/manageLaneDialog.ts
@@ -11,8 +11,7 @@ const MANAGE_LANE_DIALOG_SELECTOR = '[data-tour="lanes.manageDialog"]';
  * Anchors (verified in ManageLaneDialog.tsx):
  *   lanes.laneTab, lanes.manageLane,
  *   lanes.manageDialog.laneInfo, lanes.manageDialog.archive,
- *   lanes.manageDialog.tabs, lanes.manageDialog.confirm,
- *   lanes.manageDialog.delete
+ *   lanes.manageDialog.tabs, lanes.manageDialog.delete
  */
 export function buildManageLaneDialogWalkthrough(): TourStep[] {
   return [
@@ -76,8 +75,8 @@ export function buildManageLaneDialogWalkthrough(): TourStep[] {
     {
       id: "manageLane.deleteTabs",
       target: '[data-tour="lanes.manageDialog.tabs"]',
-      title: "How thorough to delete",
-      body: "Three levels: remove just the lane folder, also delete the branch on your computer, or also delete the branch on GitHub. Pick how far you want it gone.",
+      title: "Pick what to remove",
+      body: "Check off what you want gone: the lane folder, the branch on your computer, the branch on GitHub — or hit **Select everything**. Nothing is checked by default, so you can't delete by accident.",
       placement: "bottom",
       requires: MANAGE_LANE_DIALOG_REQUIRES,
       waitForSelector: '[data-tour="lanes.manageDialog.tabs"]',
@@ -86,22 +85,10 @@ export function buildManageLaneDialogWalkthrough(): TourStep[] {
       docUrl: docs.lanesOverview,
     },
     {
-      id: "manageLane.deleteConfirm",
-      target: '[data-tour="lanes.manageDialog.confirm"]',
-      title: "Type to confirm",
-      body: "Deletion is permanent, so ADE asks you to type the lane's name to make sure you really mean it. The delete button stays disabled until what you type matches.",
-      placement: "right",
-      requires: MANAGE_LANE_DIALOG_REQUIRES,
-      waitForSelector: '[data-tour="lanes.manageDialog.confirm"]',
-      exitOnOutsideInteraction: true,
-      allowedInteractionSelectors: [MANAGE_LANE_DIALOG_SELECTOR],
-      docUrl: docs.lanesOverview,
-    },
-    {
       id: "manageLane.deleteButton",
       target: '[data-tour="lanes.manageDialog.delete"]',
       title: "The point of no return",
-      body: "Click this and the lane is gone for good. Your real project is always protected — you can never accidentally delete it from this dialog.",
+      body: "Click this and whatever you checked is gone for good. It stays disabled until you pick at least one thing, and your real project is always protected — you can never accidentally delete it from this dialog.",
       placement: "left",
       requires: MANAGE_LANE_DIALOG_REQUIRES,
       waitForSelector: '[data-tour="lanes.manageDialog.delete"]',


### PR DESCRIPTION
<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fchat-20260608-152623-e50b3f22 num=543 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fchat-20260608-152623-e50b3f22&amp;pr=543">ade/chat-20260608-152623-e50b3f22 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=543">PR #543</a>
</p>
<!-- /ade:link -->

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/ea733550-1e2d-4080-8238-4f5da3df27af/pull/543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the lane-delete radio-button flow (`worktree / local_branch / remote_branch`) with an independent three-item checklist (`worktree`, `localBranch`, `remoteBranch`) and removes the typed-confirmation requirement in favour of a "nothing selected = button disabled" guard.

- `ManageLaneDialog` now exports `LaneDeleteSelection` / `EMPTY_LANE_DELETE_SELECTION` and a new `DeleteTargetChecklist` component; the dialog defaults to the **Delete** tab on open instead of **Appearance**.
- `LanesPage` and `PrManageLaneDialogHost` were updated to pass the new API; `LanesPage` correctly resets the selection before opening the dialog on all three call sites, and now threads `chatSessionCount` through to `PreflightPanel`.

<h3>Confidence Score: 3/5</h3>

Merging carries meaningful risk — the delete flow removes its typed-confirmation guard and silently enables force-delete by default, so a user who opens the dialog and clicks once can permanently destroy unmerged commits without any extra friction.

The PR introduces a checklist UI that is cleaner and more explicit in what gets deleted, but several issues remain open: `deleteForce` now defaults to `true` on every dialog open, the remote-name input was removed and replaced with a hard-coded `"origin"` that ignores custom remotes, and the PR-context dialog never receives `chatSessionCount` so its preflight warning panel is permanently silent. Together these make the delete path both more aggressive and less informative than before.

`PrManageLaneDialogHost.tsx` and `LanesPage.tsx` need the closest attention — the force-delete default, the remote-name hard-coding, and the missing `chatSessionCount` prop all live there.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx | Core dialog refactored from radio buttons to checklist; new DeleteTargetChecklist and updated PreflightPanel look correct; PreflightPanel now returns null when no targets are selected and nothing is running, which is the correct initial state. |
| apps/desktop/src/renderer/components/lanes/LanesPage.tsx | All three dialog open call sites reset deleteSelection and set deleteForce correctly; remoteName is hard-coded to "origin"; deleteForce now defaults to true on every open. |
| apps/desktop/src/renderer/components/prs/shared/PrManageLaneDialogHost.tsx | Uses the new checklist API correctly for delete args, but never resets deleteSelection when the dialog is reopened without completing a delete, and does not pass chatSessionCount — chat-session warnings are silently suppressed in the PR context. |
| apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx | Test suite updated to reflect new props and default-delete-tab behaviour; previous typed-confirmation tests replaced with selection-enabled/disabled tests. |
| apps/desktop/src/renderer/onboarding/stepBuilders/manageLaneDialog.ts | Tour copy updated to describe the checklist UX; manageLane.deleteConfirm step removed; remaining steps look consistent with the new dialog layout. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Manage Lane dialog] --> B{deleteSelection has any item?}
    B -- No --> C[Delete button disabled]
    B -- Yes --> D[Delete button enabled]
    D --> E[User clicks Delete]
    E --> F{Validate: selection non-empty?}
    F -- No --> G[Guard returns early]
    F -- Yes --> H[Build DeleteLaneArgs]
    H --> H1["args.deleteBranch = deleteSelection.localBranch"]
    H1 --> H2{deleteSelection.remoteBranch?}
    H2 -- Yes --> H3["args.deleteRemoteBranch = true, args.remoteName = 'origin'"]
    H2 -- No --> I
    H3 --> I[window.ade.lanes.delete]
    I --> J{Success?}
    J -- Yes --> K[onOpenChange false, reset deleteSelection]
    J -- No --> L[Show laneActionError, reset deleteSelection]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/renderer/components/prs/shared/PrManageLaneDialogHost.tsx`, line 83-97 ([link](https://github.com/arul28/ade/blob/662e7e81673acb5ca1875c5624d741be4f68f68c/apps/desktop/src/renderer/components/prs/shared/PrManageLaneDialogHost.tsx#L83-L97)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`chatSessionCount` never passed — chat session warnings silently suppressed**

   `ManageLaneDialog` now reads active chat sessions from the `chatSessionCount` prop instead of `deleteRisk.activeChatCount`. `LanesPage` correctly passes this via `laneRuntimeById.get(managedLane.id)?.sessionCount`, but `PrManageLaneDialogHost` never passes the prop. Because `chatSessionCount` is optional and defaults to `undefined`, `chatCount` resolves to `0` in `PreflightPanel` every time, so the "N chat session(s)" preflight warning is permanently hidden for the PR-context dialog flow.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/prs/shared/PrManageLaneDialogHost.tsx
   Line: 83-97

   Comment:
   **`chatSessionCount` never passed — chat session warnings silently suppressed**

   `ManageLaneDialog` now reads active chat sessions from the `chatSessionCount` prop instead of `deleteRisk.activeChatCount`. `LanesPage` correctly passes this via `laneRuntimeById.get(managedLane.id)?.sessionCount`, but `PrManageLaneDialogHost` never passes the prop. Because `chatSessionCount` is optional and defaults to `undefined`, `chatCount` resolves to `0` in `PreflightPanel` every time, so the "N chat session(s)" preflight warning is permanently hidden for the PR-context dialog flow.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fprs%2Fshared%2FPrManageLaneDialogHost.tsx%0ALine%3A%2083-97%0A%0AComment%3A%0A**%60chatSessionCount%60%20never%20passed%20%E2%80%94%20chat%20session%20warnings%20silently%20suppressed**%0A%0A%60ManageLaneDialog%60%20now%20reads%20active%20chat%20sessions%20from%20the%20%60chatSessionCount%60%20prop%20instead%20of%20%60deleteRisk.activeChatCount%60.%20%60LanesPage%60%20correctly%20passes%20this%20via%20%60laneRuntimeById.get%28managedLane.id%29%3F.sessionCount%60%2C%20but%20%60PrManageLaneDialogHost%60%20never%20passes%20the%20prop.%20Because%20%60chatSessionCount%60%20is%20optional%20and%20defaults%20to%20%60undefined%60%2C%20%60chatCount%60%20resolves%20to%20%600%60%20in%20%60PreflightPanel%60%20every%20time%2C%20so%20the%20%22N%20chat%20session%28s%29%22%20preflight%20warning%20is%20permanently%20hidden%20for%20the%20PR-context%20dialog%20flow.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=543&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fprs%2Fshared%2FPrManageLaneDialogHost.tsx%3A25%0A**Stale%20selection%20persists%20across%20dialog%20re-opens**%0A%0A%60deleteSelection%60%20is%20only%20reset%20after%20a%20completed%20delete%20action%20%28%60setDeleteSelection%28EMPTY_LANE_DELETE_SELECTION%29%60%20in%20%60handleDelete%60%29.%20If%20the%20user%20opens%20the%20dialog%2C%20checks%20%22Local%20branch%22%20or%20%22Remote%20branch%22%2C%20then%20dismisses%20without%20deleting%2C%20those%20checkboxes%20remain%20ticked%20the%20next%20time%20the%20dialog%20opens%20%E2%80%94%20potentially%20for%20a%20different%20lane%20if%20the%20%60lane%60%20prop%20changes%20between%20renders.%20%60LanesPage%60%20guards%20against%20this%20by%20explicitly%20calling%20%60setDeleteSelection%28EMPTY_LANE_DELETE_SELECTION%29%60%20at%20every%20%60setManageOpen%28true%29%60%20call%20site.%20%60PrManageLaneDialogHost%60%20has%20no%20equivalent%20reset%20on%20open.%0A%0A&repo=arul28%2Fade&pr=543&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/renderer/components/prs/shared/PrManageLaneDialogHost.tsx:25
**Stale selection persists across dialog re-opens**

`deleteSelection` is only reset after a completed delete action (`setDeleteSelection(EMPTY_LANE_DELETE_SELECTION)` in `handleDelete`). If the user opens the dialog, checks "Local branch" or "Remote branch", then dismisses without deleting, those checkboxes remain ticked the next time the dialog opens — potentially for a different lane if the `lane` prop changes between renders. `LanesPage` guards against this by explicitly calling `setDeleteSelection(EMPTY_LANE_DELETE_SELECTION)` at every `setManageOpen(true)` call site. `PrManageLaneDialogHost` has no equivalent reset on open.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix lane delete: remote-only selection n..."](https://github.com/arul28/ade/commit/1b08562bc631c36a422c38e9bb46e56ce8a226e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36293759)</sub>

<!-- /greptile_comment -->