### PR TITLE
Wire orchestrator mode through the daemon + unify new-chat draft state

### DIFF
--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -1401,6 +1401,7 @@ export async function createAdeRuntime(args: {
       swallow(() => runtimeDiagnosticsService.dispose());
       swallow(() => oauthRedirectService.dispose());
       void laneProxyService.dispose().catch(() => {});
+      void orchestrationService?.dispose().catch(() => {});
       swallow(() => portAllocationService.dispose());
       swallow(() => iosSimulatorService?.dispose());
       swallow(() => appControlService?.dispose());

--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -48,6 +48,7 @@ import {
 import { createProcessService } from "../../desktop/src/main/services/processes/processService";
 import { augmentProcessPathWithShellAndKnownCliDirs, setPathEnvValue } from "../../desktop/src/main/services/ai/cliExecutableResolver";
 import { createAgentChatService } from "../../desktop/src/main/services/chat/agentChatService";
+import { createOrchestrationService } from "../../desktop/src/main/services/orchestration/orchestrationService";
 import type { createPrService } from "../../desktop/src/main/services/prs/prService";
 import { createPrSummaryService } from "../../desktop/src/main/services/prs/prSummaryService";
 import { createQueueLandingService } from "../../desktop/src/main/services/prs/queueLandingService";
@@ -206,6 +207,7 @@ export type AdeRuntime = {
   testService: ReturnType<typeof createTestService>;
   aiIntegrationService?: ReturnType<typeof createAiIntegrationService> | null;
   agentChatService?: ReturnType<typeof createAgentChatService> | null;
+  orchestrationService?: ReturnType<typeof createOrchestrationService> | null;
   prService?: ReturnType<typeof createPrService>;
   prSummaryService?: ReturnType<typeof createPrSummaryService> | null;
   queueLandingService?: ReturnType<typeof createQueueLandingService> | null;
@@ -993,9 +995,24 @@ export async function createAdeRuntime(args: {
   });
 
   let automationServiceRef: ReturnType<typeof createAutomationService> | null = null;
+
+  const orchestrationService = createOrchestrationService({
+    resolveLaneWorktree: (laneId: string): string | undefined => {
+      try {
+        return laneService.getLaneWorktreePath(laneId);
+      } catch {
+        return undefined;
+      }
+    },
+  });
+  orchestrationService.on("event", (payload) => {
+    pushEvent("orchestrator", payload as unknown as Record<string, unknown>);
+  });
+
   let agentChatService = headlessLinearServices.agentChatService as unknown as ReturnType<typeof createAgentChatService> | null;
   if (resolvedArgs.chatRuntime === "agent") {
     agentChatService = createAgentChatService({
+      getOrchestrationService: () => orchestrationService,
       projectRoot,
       adeDir: paths.adeDir,
       transcriptsDir: paths.transcriptsDir,
@@ -1331,6 +1348,7 @@ export async function createAdeRuntime(args: {
     reviewService,
     aiIntegrationService,
     agentChatService,
+    orchestrationService,
     issueInventoryService,
     pathToMergeOrchestrator,
     ctoStateService,

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -84,6 +84,7 @@ import { parseLinearGraphQLInput } from "../cto/linearGraphQLInput";
 import { launchAgentChatCli } from "../chat/agentChatCliLaunch";
 import { createApnsBridgeService } from "../notifications/apnsBridgeService";
 import { deleteTerminalSessionWithRuntimeCleanup } from "../sessions/deleteTerminalSession";
+import { createOrchestrationDomainService } from "../orchestration/orchestrationDomain";
 
 export const ADE_ACTION_DOMAIN_NAMES = [
   "lane",
@@ -134,6 +135,7 @@ export const ADE_ACTION_DOMAIN_NAMES = [
   "review",
   "issue",
   "notifications_apns",
+  "orchestration",
 ] as const;
 
 export type AdeActionDomain = (typeof ADE_ACTION_DOMAIN_NAMES)[number];
@@ -743,6 +745,22 @@ export const ADE_ACTION_ALLOWLIST: Partial<Record<AdeActionDomain, readonly stri
     "clearKey",
     "sendTestPush",
   ],
+  orchestration: [
+    "runCreate",
+    "bundleRead",
+    "manifestReadSection",
+    "manifestPatch",
+    "planAppend",
+    "planWrite",
+    "assetRegister",
+    "claimTask",
+    "releaseTask",
+    "runList",
+    "spawnAgent",
+    "agentInject",
+    "subscribe",
+    "unsubscribe",
+  ],
 };
 
 type AutomationsDomainService = {
@@ -845,6 +863,18 @@ type OpaqueService = Record<string, unknown>;
 
 function toService(value: unknown): OpaqueService | null {
   return (value ?? null) as OpaqueService | null;
+}
+
+function buildOrchestrationDomainService(runtime: AdeRuntime): OpaqueService | null {
+  const orchestrationService = runtime.orchestrationService;
+  const laneService = runtime.laneService;
+  const agentChatService = runtime.agentChatService;
+  if (!orchestrationService || !laneService || !agentChatService) return null;
+  return createOrchestrationDomainService({
+    orchestrationService,
+    laneService: { getLaneWorktreePath: (laneId: string) => laneService.getLaneWorktreePath(laneId) },
+    agentChatService,
+  }) as unknown as OpaqueService;
 }
 
 type CachedApnsBridgeDomainService = {
@@ -2861,6 +2891,7 @@ export function getAdeActionDomainServices(
     automations: automationsEnabled ? toService(buildAutomationsDomainService(runtime)) : null,
     review: toService(runtime.reviewService),
     issue: toService(buildIssueDomainService(runtime)),
+    orchestration: toService(buildOrchestrationDomainService(runtime)),
     get notifications_apns() {
       return toService(getApnsBridgeDomainService(runtime));
     },

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -609,19 +609,13 @@ import { ADE_ACTION_ALLOWLIST, getAdeActionDomainServices, listAllowedAdeActionN
 import type { AdeRuntime } from "../../../../../ade-cli/src/bootstrap";
 
 import type { createOrchestrationService } from "../orchestration/orchestrationService";
-import { validateSpawnBrief } from "../orchestration/orchestrationService";
-import {
-  applyOrchestrationPermissionProfile,
-  isOrchestrationPlanApproved,
-  resolveOrchestrationModel,
-} from "../orchestration/runtimeProfile";
+import { createOrchestrationDomainService } from "../orchestration/orchestrationDomain";
 import type {
   ManifestSection,
   OrchestrationAgentInjectRequest,
   OrchestrationAssetRegisterRequest,
   OrchestrationClaimTaskRequest,
   OrchestrationManifestPatchRequest,
-  OrchestrationOrigin,
   OrchestrationPlanAppendRequest,
   OrchestrationPlanWriteRequest,
   OrchestrationReleaseTaskRequest,
@@ -1032,10 +1026,6 @@ function clampLayout(layout: DockLayout): DockLayout {
     out[k] = Math.max(0, Math.min(100, v));
   }
   return out;
-}
-
-function pathJoinOrchestration(worktree: string, runId: string): string {
-  return path.join(worktree, ".ade", "orchestration", runId);
 }
 
 /**
@@ -6523,292 +6513,90 @@ export function registerIpc({
     });
   };
 
-  ipcMain.handle(IPC.orchestrationRunCreate, async (_event, arg: OrchestrationRunCreateRequest & { laneId: string }) => {
+  // In-process / test-mode IPC handlers. In every runtime-backed build the
+  // renderer routes these through the daemon's "orchestration" action domain
+  // (see preload `orchestrationBridge`), so these handlers only fire when the
+  // desktop owns the orchestration service directly. Both paths share the same
+  // `createOrchestrationDomainService` factory, so behaviour stays identical.
+  const getOrchestrationDomain = () => {
     const { ctx, service } = ensureOrchestration();
+    return createOrchestrationDomainService({
+      orchestrationService: service,
+      laneService: {
+        getLaneWorktreePath: (laneId: string) => ctx.laneService.getLaneWorktreePath(laneId),
+      },
+      agentChatService: ctx.agentChatService,
+    });
+  };
+
+  ipcMain.handle(IPC.orchestrationRunCreate, async (_event, arg: OrchestrationRunCreateRequest & { laneId: string }) => {
     subscribeOrchestrationBroadcast();
-    const worktree = ctx.laneService.getLaneWorktreePath(arg.laneId);
-    const result = await service.runCreate({ ...arg, bundleRoot: worktree });
-    // Stitch the run id + bundle path back into the lead chat's persisted
-    // record so the OrchestrationPanel mounts after a restart and downstream
-    // tooling can discover the bundle from the chat session alone.
-    const setter = (
-      ctx.agentChatService as unknown as {
-        setOrchestrationFields?: (
-          sessionId: string,
-          fields: {
-            orchestrationRunId?: string | null;
-            orchestrationRole?: "lead" | "worker" | "validator" | null;
-            orchestrationBundlePath?: string | null;
-          },
-        ) => void;
-      }
-    ).setOrchestrationFields;
-    if (typeof setter === "function") {
-      try {
-        setter(arg.leadSessionId, {
-          orchestrationRunId: result.runId,
-          orchestrationRole: "lead",
-          orchestrationBundlePath: result.manifest.bundlePath,
-        });
-      } catch {
-        // best-effort; the renderer also patches its local cache so the
-        // panel mounts immediately. Persisted state will fall through to
-        // a subsequent updateSession call if needed.
-      }
-    }
-    return result;
+    return getOrchestrationDomain().runCreate(arg);
   });
 
   ipcMain.handle(IPC.orchestrationBundleRead, async (_event, arg: { runId: string; laneId: string }) => {
-    const { ctx, service } = ensureOrchestration();
     subscribeOrchestrationBroadcast();
-    const worktree = ctx.laneService.getLaneWorktreePath(arg.laneId);
-    const bundlePath = pathJoinOrchestration(worktree, arg.runId);
-    return service.bundleRead(arg.runId, bundlePath);
+    return getOrchestrationDomain().bundleRead(arg);
   });
 
   ipcMain.handle(IPC.orchestrationManifestReadSection, async (
     _event,
     arg: { runId: string; laneId: string; section: ManifestSection },
-  ) => {
-    const { ctx, service } = ensureOrchestration();
-    const worktree = ctx.laneService.getLaneWorktreePath(arg.laneId);
-    const bundlePath = pathJoinOrchestration(worktree, arg.runId);
-    return service.manifestReadSection(arg.runId, bundlePath, arg.section);
-  });
+  ) => getOrchestrationDomain().manifestReadSection(arg));
 
   ipcMain.handle(IPC.orchestrationManifestPatch, async (
     _event,
     arg: OrchestrationManifestPatchRequest & { laneId: string },
-  ) => {
-    const { ctx, service } = ensureOrchestration();
-    const worktree = ctx.laneService.getLaneWorktreePath(arg.laneId);
-    const bundlePath = pathJoinOrchestration(worktree, arg.runId);
-    return service.manifestPatch(arg, bundlePath);
-  });
+  ) => getOrchestrationDomain().manifestPatch(arg));
 
   ipcMain.handle(IPC.orchestrationPlanAppend, async (
     _event,
     arg: OrchestrationPlanAppendRequest & { laneId: string },
-  ) => {
-    const { ctx, service } = ensureOrchestration();
-    const worktree = ctx.laneService.getLaneWorktreePath(arg.laneId);
-    const bundlePath = pathJoinOrchestration(worktree, arg.runId);
-    return service.planAppend(arg, bundlePath);
-  });
+  ) => getOrchestrationDomain().planAppend(arg));
 
   ipcMain.handle(IPC.orchestrationPlanWrite, async (
     _event,
     arg: OrchestrationPlanWriteRequest & { laneId: string },
-  ) => {
-    const { ctx, service } = ensureOrchestration();
-    const worktree = ctx.laneService.getLaneWorktreePath(arg.laneId);
-    const bundlePath = pathJoinOrchestration(worktree, arg.runId);
-    return service.planWrite(arg, bundlePath);
-  });
+  ) => getOrchestrationDomain().planWrite(arg));
 
   ipcMain.handle(IPC.orchestrationAssetRegister, async (
     _event,
     arg: OrchestrationAssetRegisterRequest & { laneId: string },
-  ) => {
-    const { ctx, service } = ensureOrchestration();
-    const worktree = ctx.laneService.getLaneWorktreePath(arg.laneId);
-    const bundlePath = pathJoinOrchestration(worktree, arg.runId);
-    return service.assetRegister(arg, bundlePath);
-  });
+  ) => getOrchestrationDomain().assetRegister(arg));
 
   ipcMain.handle(IPC.orchestrationClaimTask, async (
     _event,
     arg: OrchestrationClaimTaskRequest & { laneId: string },
-  ) => {
-    const { ctx, service } = ensureOrchestration();
-    const worktree = ctx.laneService.getLaneWorktreePath(arg.laneId);
-    const bundlePath = pathJoinOrchestration(worktree, arg.runId);
-    return service.claimTask(arg, bundlePath);
-  });
+  ) => getOrchestrationDomain().claimTask(arg));
 
   ipcMain.handle(IPC.orchestrationReleaseTask, async (
     _event,
     arg: OrchestrationReleaseTaskRequest & { laneId: string },
-  ) => {
-    const { ctx, service } = ensureOrchestration();
-    const worktree = ctx.laneService.getLaneWorktreePath(arg.laneId);
-    const bundlePath = pathJoinOrchestration(worktree, arg.runId);
-    return service.releaseTask(arg, bundlePath);
-  });
+  ) => getOrchestrationDomain().releaseTask(arg));
 
-  ipcMain.handle(IPC.orchestrationRunList, async (_event, arg: { laneId?: string } = {}) => {
-    const { service } = ensureOrchestration();
-    return service.runList(arg?.laneId);
-  });
+  ipcMain.handle(IPC.orchestrationRunList, async (_event, arg: { laneId?: string } = {}) =>
+    getOrchestrationDomain().runList(arg),
+  );
 
   ipcMain.handle(IPC.orchestrationSpawnAgent, async (
     _event,
     arg: OrchestrationSpawnAgentRequest & { laneId: string; leadSessionId: string },
-  ): Promise<{ sessionId: string; etag: string }> => {
-    const { ctx, service } = ensureOrchestration();
-    const worktree = ctx.laneService.getLaneWorktreePath(arg.laneId);
-    const bundlePath = pathJoinOrchestration(worktree, arg.runId);
-    const manifest = service.getManifestForRun(arg.runId);
-    if (!manifest) {
-      throw new Error(`run ${arg.runId} not loaded — call orchestrationBundleRead first`);
-    }
-    if (!isOrchestrationPlanApproved(manifest)) {
-      throw new Error("spawnAgent is blocked until the user approves the orchestration plan.");
-    }
-    const brief = validateSpawnBrief(arg.initialMessage);
-    if (!brief.ok) {
-      throw new Error(
-        `spawn brief missing required sections: ${brief.missing.join(", ")}`,
-      );
-    }
-    const routedSelection = resolveOrchestrationModel(manifest, arg.role, arg.tag, arg.modelOverride);
-    const interactionMode =
-      arg.role === "validator" ? "orchestrator-validator" : "orchestrator-worker";
-    const created = await ctx.agentChatService.createSession({
-      laneId: arg.laneId,
-      provider: routedSelection.provider,
-      model: routedSelection.modelId,
-      reasoningEffort: routedSelection.reasoningEffort ?? null,
-      fastMode: routedSelection.fastMode,
-      interactionMode,
-      surface: "work",
-      ...applyOrchestrationPermissionProfile(routedSelection.provider),
-      orchestrationRunId: arg.runId,
-      orchestrationRole: arg.role,
-      orchestrationParentSessionId: arg.leadSessionId,
-      orchestrationTag: arg.tag,
-      orchestrationStepId: arg.stepId,
-      orchestrationBundlePath: bundlePath,
-      goal: arg.goalSummary,
-    });
-    const spawnedAt = new Date().toISOString();
-    const fp = {
-      provider: routedSelection.provider,
-      modelId: routedSelection.modelId,
-      reasoningEffort: routedSelection.reasoningEffort ?? null,
-      fastMode: routedSelection.fastMode,
-      resolvedAt: spawnedAt,
-      routingKey: routedSelection.routingKey,
-    };
-    const buildSpawnPatch = (etag: string, summary: string) =>
-      ({
-        runId: arg.runId,
-        ifMatchEtag: etag,
-        actorRole: "lead" as const,
-        actorSessionId: arg.leadSessionId,
-        summary,
-        patches: [
-          {
-            op: "add" as const,
-            path: "/agents/-",
-            value: {
-              sessionId: created.id,
-              role: arg.role,
-              tag: arg.tag,
-              goalSummary: arg.goalSummary,
-              status: "pending",
-              spawnedAt,
-              currentStepId: arg.stepId,
-              spawnFingerprint: fp,
-            },
-          },
-        ],
-      });
-    let patchRes = await service.manifestPatch(buildSpawnPatch(manifest.etag, "spawn worker"), bundlePath);
-    if (!patchRes.ok && "manifest" in patchRes && patchRes.manifest) {
-      patchRes = await service.manifestPatch(
-        buildSpawnPatch(patchRes.manifest.etag, "spawn worker (retry)"),
-        bundlePath,
-      );
-    }
-    if (!patchRes.ok) {
-      await ctx.agentChatService.deleteSession({ sessionId: created.id });
-      throw new Error(
-        `spawn manifest patch failed: ${("error" in patchRes ? patchRes.error : "unknown")}`,
-      );
-    }
-    const origin: OrchestrationOrigin = {
-      runId: arg.runId,
-      fromSessionId: arg.leadSessionId,
-      kind: "wake",
-      intent: "directive",
-      taskId: arg.stepId,
-    };
-    await ctx.agentChatService.sendMessage(
-      {
-        sessionId: created.id,
-        text: arg.initialMessage,
-        metadata: { orchestrationOrigin: origin },
-      },
-      { awaitDispatch: false },
-    );
-    return { sessionId: created.id, etag: patchRes.etag };
-  });
+  ): Promise<{ sessionId: string; etag: string }> => getOrchestrationDomain().spawnAgent(arg));
 
   ipcMain.handle(IPC.orchestrationAgentInject, async (
     _event,
     arg: OrchestrationAgentInjectRequest,
-  ): Promise<void> => {
-    const { ctx, service } = ensureOrchestration();
-    const manifest = service.getManifestForRun(arg.runId);
-    if (!manifest) throw new Error(`run ${arg.runId} not loaded`);
-    const fromAgent = manifest.agents.find((a) => a.sessionId === arg.fromSessionId);
-    const targetAgent = manifest.agents.find((a) => a.sessionId === arg.targetSessionId);
-    if (!fromAgent || !targetAgent) {
-      throw new Error("orchestrationAgentInject: source/target not in same run");
-    }
-    const origin: OrchestrationOrigin = {
-      runId: arg.runId,
-      fromSessionId: arg.fromSessionId,
-      kind: arg.payload.kind,
-      intent: arg.payload.intent,
-      taskId: arg.payload.taskId,
-    };
-    if (arg.payload.kind === "queue") {
-      await ctx.agentChatService.steer({
-        sessionId: arg.targetSessionId,
-        text: arg.payload.text,
-        metadata: { orchestrationOrigin: origin },
-      });
-    } else if (arg.payload.kind === "interrupt-replace") {
-      await ctx.agentChatService.interrupt({ sessionId: arg.targetSessionId });
-      await ctx.agentChatService.sendMessage(
-        {
-          sessionId: arg.targetSessionId,
-          text: arg.payload.text,
-          metadata: { orchestrationOrigin: origin },
-        },
-        { awaitDispatch: false },
-      );
-    } else {
-      await ctx.agentChatService.sendMessage(
-        {
-          sessionId: arg.targetSessionId,
-          text: arg.payload.text,
-          metadata: { orchestrationOrigin: origin },
-        },
-        { awaitDispatch: false },
-      );
-    }
-  });
+  ): Promise<void> => getOrchestrationDomain().agentInject(arg));
 
   ipcMain.handle(IPC.orchestrationSubscribe, async (_event, arg: { runId: string; laneId?: string }) => {
-    const { ctx, service } = ensureOrchestration();
-    if (typeof arg.laneId === "string" && arg.laneId.trim()) {
-      const worktree = ctx.laneService.getLaneWorktreePath(arg.laneId);
-      const bundlePath = pathJoinOrchestration(worktree, arg.runId);
-      await service.subscribe(arg.runId, bundlePath);
-    }
+    const result = await getOrchestrationDomain().subscribe(arg);
     subscribeOrchestrationBroadcast();
-    return { ok: true, runId: arg.runId };
+    return result;
   });
 
-  ipcMain.handle(IPC.orchestrationUnsubscribe, async (_event, arg: { runId: string }) => {
-    const { service } = ensureOrchestration();
-    await service.release(arg.runId);
-    return { ok: true };
-  });
+  ipcMain.handle(IPC.orchestrationUnsubscribe, async (_event, arg: { runId: string }) =>
+    getOrchestrationDomain().unsubscribe(arg),
+  );
 
   ipcMain.handle(IPC.computerUseListArtifacts, async (_event, arg: ComputerUseArtifactListArgs = {}): Promise<ComputerUseArtifactView[]> => {
     const ctx = ensureComputerUseBroker();

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -6518,15 +6518,26 @@ export function registerIpc({
   // (see preload `orchestrationBridge`), so these handlers only fire when the
   // desktop owns the orchestration service directly. Both paths share the same
   // `createOrchestrationDomainService` factory, so behaviour stays identical.
+  let cachedOrchestrationDomain:
+    | { ctx: ReturnType<typeof getCtx>; domain: ReturnType<typeof createOrchestrationDomainService> }
+    | null = null;
   const getOrchestrationDomain = () => {
     const { ctx, service } = ensureOrchestration();
-    return createOrchestrationDomainService({
+    // ctx identity fully determines the deps (service + laneService + agentChatService
+    // all hang off it); reuse the closure object across calls, rebuilding only when the
+    // owning context changes (e.g. in-process project switch).
+    if (cachedOrchestrationDomain && cachedOrchestrationDomain.ctx === ctx) {
+      return cachedOrchestrationDomain.domain;
+    }
+    const domain = createOrchestrationDomainService({
       orchestrationService: service,
       laneService: {
         getLaneWorktreePath: (laneId: string) => ctx.laneService.getLaneWorktreePath(laneId),
       },
       agentChatService: ctx.agentChatService,
     });
+    cachedOrchestrationDomain = { ctx, domain };
+    return domain;
   };
 
   ipcMain.handle(IPC.orchestrationRunCreate, async (_event, arg: OrchestrationRunCreateRequest & { laneId: string }) => {

--- a/apps/desktop/src/main/services/orchestration/orchestrationDomain.test.ts
+++ b/apps/desktop/src/main/services/orchestration/orchestrationDomain.test.ts
@@ -1,0 +1,337 @@
+/* @vitest-environment node */
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import path from "node:path";
+
+import { createOrchestrationDomainService } from "./orchestrationDomain";
+import type { OrchestrationService } from "./orchestrationService";
+import type {
+  OrchestrationAgentInjectRequest,
+  OrchestrationManifest,
+  OrchestrationManifestPatchResponse,
+} from "../../../shared/types/orchestration";
+
+// A spawn brief that satisfies validateSpawnBrief (all required sections present).
+const VALID_BRIEF = `## TASK
+Build login
+## FILES
+src/x.ts
+## DEPENDENCIES
+none
+## GATES
+reverify_changes
+## PEERS
+none
+## SUCCESS
+tests pass`;
+
+const LANE_PATH = "/tmp/ade-lane-fixed";
+
+/**
+ * Build a manifest whose plan is approved (currentPhase !== "planning" makes
+ * isOrchestrationPlanApproved return true) and whose modelRouting is empty so
+ * resolveOrchestrationModel falls through to the claude fallback.
+ */
+function makeApprovedManifest(
+  overrides: Partial<OrchestrationManifest> = {},
+): OrchestrationManifest {
+  return {
+    version: 1,
+    schemaCompatibility: { minReader: 1, maxKnown: 1 },
+    runId: "R-1",
+    laneId: "L-1",
+    bundlePath: path.join(LANE_PATH, ".ade", "orchestration", "R-1"),
+    etag: "etag-0",
+    serverGeneration: 0,
+    createdAt: "now",
+    updatedAt: "now",
+    title: "Run",
+    goalSummary: "do the thing",
+    currentPhase: "developing",
+    phases: [],
+    agents: [],
+    tasks: [],
+    validationStrategy: { steps: [], checklist: [] },
+    modelRouting: {},
+    assets: [],
+    decisions: [],
+    userOverrides: [],
+    leadState: {},
+    history: [],
+    ...overrides,
+  };
+}
+
+function patchOk(etag: string): OrchestrationManifestPatchResponse {
+  return { ok: true, manifest: makeApprovedManifest({ etag }), etag };
+}
+
+function patchEtagConflict(nextEtag: string): OrchestrationManifestPatchResponse {
+  return {
+    ok: false,
+    error: "etag_conflict",
+    manifest: makeApprovedManifest({ etag: nextEtag }),
+    etag: nextEtag,
+  };
+}
+
+function makeDeps() {
+  const orchestrationService = {
+    getManifestForRun: vi.fn(),
+    runCreate: vi.fn(),
+    manifestPatch: vi.fn(),
+  };
+  const agentChatService = {
+    createSession: vi.fn(async (..._args: any[]) => ({ id: "sess-1" })),
+    deleteSession: vi.fn(async (..._args: any[]) => undefined),
+    sendMessage: vi.fn(async (..._args: any[]) => undefined),
+    steer: vi.fn(async (..._args: any[]) => undefined),
+    interrupt: vi.fn(async (..._args: any[]) => undefined),
+    setOrchestrationFields: vi.fn((..._args: any[]) => undefined),
+  };
+  const laneService = {
+    getLaneWorktreePath: vi.fn(() => LANE_PATH),
+  };
+  // The domain service only calls the three orchestrationService methods above;
+  // cast through unknown to satisfy the full OrchestrationService surface.
+  const service = createOrchestrationDomainService({
+    orchestrationService: orchestrationService as unknown as OrchestrationService,
+    laneService,
+    agentChatService: agentChatService as never,
+  });
+  return { service, orchestrationService, agentChatService, laneService };
+}
+
+const SPAWN_ARG = {
+  laneId: "L-1",
+  leadSessionId: "S-lead",
+  runId: "R-1",
+  role: "worker" as const,
+  tag: "impl",
+  goalSummary: "implement login",
+  stepId: "step-1",
+  initialMessage: VALID_BRIEF,
+};
+
+describe("orchestrationDomain", () => {
+  let h: ReturnType<typeof makeDeps>;
+  beforeEach(() => {
+    h = makeDeps();
+  });
+
+  // --- spawnAgent gates -----------------------------------------------------
+
+  it("spawnAgent throws when the run manifest is not loaded", async () => {
+    h.orchestrationService.getManifestForRun.mockReturnValue(null);
+    await expect(h.service.spawnAgent(SPAWN_ARG)).rejects.toThrow(
+      /not loaded — call orchestrationBundleRead first/,
+    );
+    expect(h.agentChatService.createSession).not.toHaveBeenCalled();
+  });
+
+  it("spawnAgent throws when the plan is not approved", async () => {
+    // currentPhase "planning" with no planApprovedAt => not approved.
+    h.orchestrationService.getManifestForRun.mockReturnValue(
+      makeApprovedManifest({ currentPhase: "planning", leadState: {} }),
+    );
+    await expect(h.service.spawnAgent(SPAWN_ARG)).rejects.toThrow(
+      /blocked until the user approves the orchestration plan/,
+    );
+    expect(h.agentChatService.createSession).not.toHaveBeenCalled();
+  });
+
+  it("spawnAgent throws and lists missing sections for an invalid brief", async () => {
+    h.orchestrationService.getManifestForRun.mockReturnValue(makeApprovedManifest());
+    await expect(
+      h.service.spawnAgent({ ...SPAWN_ARG, initialMessage: "no sections here" }),
+    ).rejects.toThrow(/spawn brief missing required sections: .*## TASK/);
+    expect(h.agentChatService.createSession).not.toHaveBeenCalled();
+  });
+
+  // --- spawnAgent happy path / retry / cleanup ------------------------------
+
+  it("spawnAgent creates a session, patches the manifest, sends the brief, and returns {sessionId, etag}", async () => {
+    h.orchestrationService.getManifestForRun.mockReturnValue(
+      makeApprovedManifest({ etag: "etag-A" }),
+    );
+    h.orchestrationService.manifestPatch.mockResolvedValue(patchOk("etag-B"));
+
+    const result = await h.service.spawnAgent(SPAWN_ARG);
+
+    expect(result).toEqual({ sessionId: "sess-1", etag: "etag-B" });
+    expect(h.agentChatService.createSession).toHaveBeenCalledTimes(1);
+    expect(h.orchestrationService.manifestPatch).toHaveBeenCalledTimes(1);
+    // first patch uses the loaded manifest etag and adds the agent at /agents/-
+    const [patchReq] = h.orchestrationService.manifestPatch.mock.calls[0]!;
+    expect(patchReq.ifMatchEtag).toBe("etag-A");
+    expect(patchReq.patches[0]).toMatchObject({ op: "add", path: "/agents/-" });
+    expect(patchReq.patches[0].value.sessionId).toBe("sess-1");
+    // initial message is dispatched to the new session
+    const [sendArg] = h.agentChatService.sendMessage.mock.calls[0]!;
+    expect(sendArg).toMatchObject({ sessionId: "sess-1", text: VALID_BRIEF });
+    expect(h.agentChatService.deleteSession).not.toHaveBeenCalled();
+  });
+
+  it("spawnAgent retries the manifest patch with the conflict etag and succeeds", async () => {
+    h.orchestrationService.getManifestForRun.mockReturnValue(
+      makeApprovedManifest({ etag: "etag-A" }),
+    );
+    h.orchestrationService.manifestPatch
+      .mockResolvedValueOnce(patchEtagConflict("etag-RETRY"))
+      .mockResolvedValueOnce(patchOk("etag-FINAL"));
+
+    const result = await h.service.spawnAgent(SPAWN_ARG);
+
+    expect(result.etag).toBe("etag-FINAL");
+    expect(h.orchestrationService.manifestPatch).toHaveBeenCalledTimes(2);
+    const [firstReq] = h.orchestrationService.manifestPatch.mock.calls[0]!;
+    const [secondReq] = h.orchestrationService.manifestPatch.mock.calls[1]!;
+    expect(firstReq.ifMatchEtag).toBe("etag-A");
+    expect(secondReq.ifMatchEtag).toBe("etag-RETRY");
+    expect(h.agentChatService.deleteSession).not.toHaveBeenCalled();
+  });
+
+  it("spawnAgent deletes the orphaned session and throws when the patch ultimately fails", async () => {
+    h.orchestrationService.getManifestForRun.mockReturnValue(
+      makeApprovedManifest({ etag: "etag-A" }),
+    );
+    // First returns a conflict (with manifest), retry returns a hard validation failure.
+    h.orchestrationService.manifestPatch
+      .mockResolvedValueOnce(patchEtagConflict("etag-RETRY"))
+      .mockResolvedValueOnce({
+        ok: false,
+        error: "validation_failed",
+        message: "boom",
+      });
+
+    await expect(h.service.spawnAgent(SPAWN_ARG)).rejects.toThrow(
+      /spawn manifest patch failed/,
+    );
+    expect(h.agentChatService.deleteSession).toHaveBeenCalledWith({ sessionId: "sess-1" });
+    expect(h.agentChatService.sendMessage).not.toHaveBeenCalled();
+  });
+
+  // --- agentInject three modes + gate ---------------------------------------
+
+  function injectManifest(): OrchestrationManifest {
+    return makeApprovedManifest({
+      agents: [
+        {
+          sessionId: "S-from",
+          role: "lead",
+          goalSummary: "lead",
+          status: "running",
+          spawnedAt: "now",
+        },
+        {
+          sessionId: "S-target",
+          role: "worker",
+          goalSummary: "worker",
+          status: "running",
+          spawnedAt: "now",
+        },
+      ],
+    });
+  }
+
+  function injectReq(
+    kind: OrchestrationAgentInjectRequest["payload"]["kind"],
+  ): OrchestrationAgentInjectRequest {
+    return {
+      runId: "R-1",
+      fromSessionId: "S-from",
+      targetSessionId: "S-target",
+      payload: { kind, intent: "directive", text: "do this", taskId: "T-1" },
+    };
+  }
+
+  it("agentInject queue mode steers the target session", async () => {
+    h.orchestrationService.getManifestForRun.mockReturnValue(injectManifest());
+    await h.service.agentInject(injectReq("queue"));
+    expect(h.agentChatService.steer).toHaveBeenCalledTimes(1);
+    expect(h.agentChatService.steer.mock.calls[0]![0]).toMatchObject({
+      sessionId: "S-target",
+      text: "do this",
+    });
+    expect(h.agentChatService.sendMessage).not.toHaveBeenCalled();
+    expect(h.agentChatService.interrupt).not.toHaveBeenCalled();
+  });
+
+  it("agentInject interrupt-replace mode interrupts then sends a fresh message", async () => {
+    h.orchestrationService.getManifestForRun.mockReturnValue(injectManifest());
+    await h.service.agentInject(injectReq("interrupt-replace"));
+    expect(h.agentChatService.interrupt).toHaveBeenCalledWith({ sessionId: "S-target" });
+    expect(h.agentChatService.sendMessage).toHaveBeenCalledTimes(1);
+    expect(h.agentChatService.sendMessage.mock.calls[0]![0]).toMatchObject({
+      sessionId: "S-target",
+      text: "do this",
+    });
+    expect(h.agentChatService.steer).not.toHaveBeenCalled();
+    // interrupt must precede sendMessage
+    expect(h.agentChatService.interrupt.mock.invocationCallOrder[0]!).toBeLessThan(
+      h.agentChatService.sendMessage.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("agentInject default (wake) mode only sends a message", async () => {
+    h.orchestrationService.getManifestForRun.mockReturnValue(injectManifest());
+    await h.service.agentInject(injectReq("wake"));
+    expect(h.agentChatService.sendMessage).toHaveBeenCalledTimes(1);
+    expect(h.agentChatService.steer).not.toHaveBeenCalled();
+    expect(h.agentChatService.interrupt).not.toHaveBeenCalled();
+  });
+
+  it("agentInject throws when source/target are not both in the manifest agents", async () => {
+    h.orchestrationService.getManifestForRun.mockReturnValue(
+      makeApprovedManifest({
+        agents: [
+          {
+            sessionId: "S-from",
+            role: "lead",
+            goalSummary: "lead",
+            status: "running",
+            spawnedAt: "now",
+          },
+        ],
+      }),
+    );
+    await expect(h.service.agentInject(injectReq("queue"))).rejects.toThrow(
+      /source\/target not in same run/,
+    );
+    expect(h.agentChatService.steer).not.toHaveBeenCalled();
+  });
+
+  // --- runCreate best-effort field stitch -----------------------------------
+
+  it("runCreate resolves with the service result even when setOrchestrationFields throws", async () => {
+    const createdManifest = makeApprovedManifest({
+      bundlePath: "/bundle/R-1",
+    });
+    h.orchestrationService.runCreate.mockResolvedValue({
+      runId: "R-1",
+      manifest: createdManifest,
+      etag: "etag-create",
+    });
+    h.agentChatService.setOrchestrationFields.mockImplementation(() => {
+      throw new Error("persist failed");
+    });
+
+    const result = await h.service.runCreate({
+      laneId: "L-1",
+      leadSessionId: "S-lead",
+      title: "Run",
+      goalSummary: "goal",
+    });
+
+    expect(result).toMatchObject({ runId: "R-1", etag: "etag-create" });
+    // best-effort stitch was attempted (and swallowed)
+    expect(h.agentChatService.setOrchestrationFields).toHaveBeenCalledWith("S-lead", {
+      orchestrationRunId: "R-1",
+      orchestrationRole: "lead",
+      orchestrationBundlePath: "/bundle/R-1",
+    });
+    // the bundleRoot passed to the service is the resolved lane worktree
+    expect(h.orchestrationService.runCreate.mock.calls[0]![0]).toMatchObject({
+      bundleRoot: LANE_PATH,
+    });
+  });
+});

--- a/apps/desktop/src/main/services/orchestration/orchestrationDomain.test.ts
+++ b/apps/desktop/src/main/services/orchestration/orchestrationDomain.test.ts
@@ -128,6 +128,13 @@ describe("orchestrationDomain", () => {
     expect(h.agentChatService.createSession).not.toHaveBeenCalled();
   });
 
+  it("rejects a runId that would escape the bundle root before any work", async () => {
+    await expect(
+      h.service.spawnAgent({ ...SPAWN_ARG, runId: "../../etc/passwd" }),
+    ).rejects.toThrow(/invalid orchestration runId/);
+    expect(h.orchestrationService.getManifestForRun).not.toHaveBeenCalled();
+  });
+
   it("spawnAgent throws when the plan is not approved", async () => {
     // currentPhase "planning" with no planApprovedAt => not approved.
     h.orchestrationService.getManifestForRun.mockReturnValue(

--- a/apps/desktop/src/main/services/orchestration/orchestrationDomain.ts
+++ b/apps/desktop/src/main/services/orchestration/orchestrationDomain.ts
@@ -44,6 +44,12 @@ export type OrchestrationDomainDeps = {
 
 type RunCreateArgs = Omit<OrchestrationRunCreateRequest, "bundleRoot"> & { laneId: string };
 
+// Run ids are minted by the orchestration service as `R-<ts>-<rand>` /
+// `run-<escaped>` — single path segments of `[A-Za-z0-9_-]`. Reject anything
+// else so a crafted `runId` (e.g. `../../etc`) can't escape the bundle root
+// when composed into a filesystem path at the IPC/daemon boundary.
+const SAFE_RUN_ID = /^[A-Za-z0-9_-]+$/;
+
 /**
  * The orchestration action domain — the single source of truth shared by the
  * daemon's `run_ade_action` registry and the desktop in-process IPC handlers.
@@ -53,8 +59,12 @@ type RunCreateArgs = Omit<OrchestrationRunCreateRequest, "bundleRoot"> & { laneI
 export function createOrchestrationDomainService(deps: OrchestrationDomainDeps) {
   const { orchestrationService: service, laneService, agentChatService } = deps;
 
-  const bundlePathFor = (laneId: string, runId: string): string =>
-    path.join(laneService.getLaneWorktreePath(laneId), ".ade", "orchestration", runId);
+  const bundlePathFor = (laneId: string, runId: string): string => {
+    if (!SAFE_RUN_ID.test(runId)) {
+      throw new Error(`invalid orchestration runId: ${JSON.stringify(runId)}`);
+    }
+    return path.join(laneService.getLaneWorktreePath(laneId), ".ade", "orchestration", runId);
+  };
 
   return {
     runCreate: async (arg: RunCreateArgs) => {

--- a/apps/desktop/src/main/services/orchestration/orchestrationDomain.ts
+++ b/apps/desktop/src/main/services/orchestration/orchestrationDomain.ts
@@ -1,0 +1,261 @@
+import path from "node:path";
+import type {
+  ManifestSection,
+  OrchestrationAgentInjectRequest,
+  OrchestrationAssetRegisterRequest,
+  OrchestrationClaimTaskRequest,
+  OrchestrationManifestPatchRequest,
+  OrchestrationOrigin,
+  OrchestrationPlanAppendRequest,
+  OrchestrationPlanWriteRequest,
+  OrchestrationReleaseTaskRequest,
+  OrchestrationRunCreateRequest,
+  OrchestrationSpawnAgentRequest,
+} from "../../../shared/types/orchestration";
+import type { createAgentChatService } from "../chat/agentChatService";
+import type { OrchestrationService } from "./orchestrationService";
+import { validateSpawnBrief } from "./orchestrationService";
+import {
+  applyOrchestrationPermissionProfile,
+  isOrchestrationPlanApproved,
+  resolveOrchestrationModel,
+} from "./runtimeProfile";
+
+type LaneWorktreeResolver = {
+  getLaneWorktreePath: (laneId: string) => string;
+};
+
+/**
+ * Subset of the agent-chat service the orchestration domain drives. Both the
+ * desktop in-process context and the daemon runtime construct the same
+ * `createAgentChatService`, so the `Pick` keeps this module decoupled from the
+ * full service surface while still validating the call sites.
+ */
+export type OrchestrationDomainAgentChat = Pick<
+  ReturnType<typeof createAgentChatService>,
+  "createSession" | "deleteSession" | "sendMessage" | "steer" | "interrupt" | "setOrchestrationFields"
+>;
+
+export type OrchestrationDomainDeps = {
+  orchestrationService: OrchestrationService;
+  laneService: LaneWorktreeResolver;
+  agentChatService: OrchestrationDomainAgentChat;
+};
+
+type RunCreateArgs = Omit<OrchestrationRunCreateRequest, "bundleRoot"> & { laneId: string };
+
+/**
+ * The orchestration action domain — the single source of truth shared by the
+ * daemon's `run_ade_action` registry and the desktop in-process IPC handlers.
+ * Every method resolves the run's on-disk bundle from `(laneId, runId)` and
+ * delegates to the long-lived {@link OrchestrationService}.
+ */
+export function createOrchestrationDomainService(deps: OrchestrationDomainDeps) {
+  const { orchestrationService: service, laneService, agentChatService } = deps;
+
+  const bundlePathFor = (laneId: string, runId: string): string =>
+    path.join(laneService.getLaneWorktreePath(laneId), ".ade", "orchestration", runId);
+
+  return {
+    runCreate: async (arg: RunCreateArgs) => {
+      const worktree = laneService.getLaneWorktreePath(arg.laneId);
+      const result = await service.runCreate({ ...arg, bundleRoot: worktree });
+      // Stitch the run id + bundle path back into the lead chat's persisted
+      // record so the OrchestrationPanel mounts after a restart and downstream
+      // tooling can discover the bundle from the chat session alone.
+      try {
+        agentChatService.setOrchestrationFields(arg.leadSessionId, {
+          orchestrationRunId: result.runId,
+          orchestrationRole: "lead",
+          orchestrationBundlePath: result.manifest.bundlePath,
+        });
+      } catch {
+        // Best-effort; the renderer also patches its local cache so the panel
+        // mounts immediately, and persisted state falls through to a later
+        // updateSession call if needed.
+      }
+      return result;
+    },
+
+    bundleRead: (arg: { runId: string; laneId: string }) =>
+      service.bundleRead(arg.runId, bundlePathFor(arg.laneId, arg.runId)),
+
+    manifestReadSection: (arg: { runId: string; laneId: string; section: ManifestSection }) =>
+      service.manifestReadSection(arg.runId, bundlePathFor(arg.laneId, arg.runId), arg.section),
+
+    manifestPatch: (arg: OrchestrationManifestPatchRequest & { laneId: string }) =>
+      service.manifestPatch(arg, bundlePathFor(arg.laneId, arg.runId)),
+
+    planAppend: (arg: OrchestrationPlanAppendRequest & { laneId: string }) =>
+      service.planAppend(arg, bundlePathFor(arg.laneId, arg.runId)),
+
+    planWrite: (arg: OrchestrationPlanWriteRequest & { laneId: string }) =>
+      service.planWrite(arg, bundlePathFor(arg.laneId, arg.runId)),
+
+    assetRegister: (arg: OrchestrationAssetRegisterRequest & { laneId: string }) =>
+      service.assetRegister(arg, bundlePathFor(arg.laneId, arg.runId)),
+
+    claimTask: (arg: OrchestrationClaimTaskRequest & { laneId: string }) =>
+      service.claimTask(arg, bundlePathFor(arg.laneId, arg.runId)),
+
+    releaseTask: (arg: OrchestrationReleaseTaskRequest & { laneId: string }) =>
+      service.releaseTask(arg, bundlePathFor(arg.laneId, arg.runId)),
+
+    runList: (arg: { laneId?: string } = {}) => service.runList(arg?.laneId),
+
+    spawnAgent: async (
+      arg: OrchestrationSpawnAgentRequest & { laneId: string; leadSessionId: string },
+    ): Promise<{ sessionId: string; etag: string }> => {
+      const bundlePath = bundlePathFor(arg.laneId, arg.runId);
+      const manifest = service.getManifestForRun(arg.runId);
+      if (!manifest) {
+        throw new Error(`run ${arg.runId} not loaded — call orchestrationBundleRead first`);
+      }
+      if (!isOrchestrationPlanApproved(manifest)) {
+        throw new Error("spawnAgent is blocked until the user approves the orchestration plan.");
+      }
+      const brief = validateSpawnBrief(arg.initialMessage);
+      if (!brief.ok) {
+        throw new Error(`spawn brief missing required sections: ${brief.missing.join(", ")}`);
+      }
+      const routedSelection = resolveOrchestrationModel(manifest, arg.role, arg.tag, arg.modelOverride);
+      const interactionMode =
+        arg.role === "validator" ? "orchestrator-validator" : "orchestrator-worker";
+      const created = await agentChatService.createSession({
+        laneId: arg.laneId,
+        provider: routedSelection.provider,
+        model: routedSelection.modelId,
+        reasoningEffort: routedSelection.reasoningEffort ?? null,
+        fastMode: routedSelection.fastMode,
+        interactionMode,
+        surface: "work",
+        ...applyOrchestrationPermissionProfile(routedSelection.provider),
+        orchestrationRunId: arg.runId,
+        orchestrationRole: arg.role,
+        orchestrationParentSessionId: arg.leadSessionId,
+        orchestrationTag: arg.tag,
+        orchestrationStepId: arg.stepId,
+        orchestrationBundlePath: bundlePath,
+        goal: arg.goalSummary,
+      });
+      const spawnedAt = new Date().toISOString();
+      const fp = {
+        provider: routedSelection.provider,
+        modelId: routedSelection.modelId,
+        reasoningEffort: routedSelection.reasoningEffort ?? null,
+        fastMode: routedSelection.fastMode,
+        resolvedAt: spawnedAt,
+        routingKey: routedSelection.routingKey,
+      };
+      const buildSpawnPatch = (etag: string, summary: string) => ({
+        runId: arg.runId,
+        ifMatchEtag: etag,
+        actorRole: "lead" as const,
+        actorSessionId: arg.leadSessionId,
+        summary,
+        patches: [
+          {
+            op: "add" as const,
+            path: "/agents/-",
+            value: {
+              sessionId: created.id,
+              role: arg.role,
+              tag: arg.tag,
+              goalSummary: arg.goalSummary,
+              status: "pending",
+              spawnedAt,
+              currentStepId: arg.stepId,
+              spawnFingerprint: fp,
+            },
+          },
+        ],
+      });
+      let patchRes = await service.manifestPatch(buildSpawnPatch(manifest.etag, "spawn worker"), bundlePath);
+      if (!patchRes.ok && "manifest" in patchRes && patchRes.manifest) {
+        patchRes = await service.manifestPatch(
+          buildSpawnPatch(patchRes.manifest.etag, "spawn worker (retry)"),
+          bundlePath,
+        );
+      }
+      if (!patchRes.ok) {
+        await agentChatService.deleteSession({ sessionId: created.id });
+        throw new Error(
+          `spawn manifest patch failed: ${"error" in patchRes ? patchRes.error : "unknown"}`,
+        );
+      }
+      const origin: OrchestrationOrigin = {
+        runId: arg.runId,
+        fromSessionId: arg.leadSessionId,
+        kind: "wake",
+        intent: "directive",
+        taskId: arg.stepId,
+      };
+      await agentChatService.sendMessage(
+        {
+          sessionId: created.id,
+          text: arg.initialMessage,
+          metadata: { orchestrationOrigin: origin },
+        },
+        { awaitDispatch: false },
+      );
+      return { sessionId: created.id, etag: patchRes.etag };
+    },
+
+    agentInject: async (arg: OrchestrationAgentInjectRequest): Promise<void> => {
+      const manifest = service.getManifestForRun(arg.runId);
+      if (!manifest) throw new Error(`run ${arg.runId} not loaded`);
+      const fromAgent = manifest.agents.find((a) => a.sessionId === arg.fromSessionId);
+      const targetAgent = manifest.agents.find((a) => a.sessionId === arg.targetSessionId);
+      if (!fromAgent || !targetAgent) {
+        throw new Error("orchestrationAgentInject: source/target not in same run");
+      }
+      const origin: OrchestrationOrigin = {
+        runId: arg.runId,
+        fromSessionId: arg.fromSessionId,
+        kind: arg.payload.kind,
+        intent: arg.payload.intent,
+        taskId: arg.payload.taskId,
+      };
+      if (arg.payload.kind === "queue") {
+        await agentChatService.steer({
+          sessionId: arg.targetSessionId,
+          text: arg.payload.text,
+          metadata: { orchestrationOrigin: origin },
+        });
+      } else if (arg.payload.kind === "interrupt-replace") {
+        await agentChatService.interrupt({ sessionId: arg.targetSessionId });
+        await agentChatService.sendMessage(
+          {
+            sessionId: arg.targetSessionId,
+            text: arg.payload.text,
+            metadata: { orchestrationOrigin: origin },
+          },
+          { awaitDispatch: false },
+        );
+      } else {
+        await agentChatService.sendMessage(
+          {
+            sessionId: arg.targetSessionId,
+            text: arg.payload.text,
+            metadata: { orchestrationOrigin: origin },
+          },
+          { awaitDispatch: false },
+        );
+      }
+    },
+
+    subscribe: async (arg: { runId: string; laneId?: string }) => {
+      if (typeof arg.laneId === "string" && arg.laneId.trim()) {
+        await service.subscribe(arg.runId, bundlePathFor(arg.laneId, arg.runId));
+      }
+      return { ok: true, runId: arg.runId };
+    },
+
+    unsubscribe: async (arg: { runId: string }) => {
+      await service.release(arg.runId);
+      return { ok: true };
+    },
+  };
+}
+
+export type OrchestrationDomainService = ReturnType<typeof createOrchestrationDomainService>;

--- a/apps/desktop/src/preload/orchestrationBridge.ts
+++ b/apps/desktop/src/preload/orchestrationBridge.ts
@@ -1,4 +1,5 @@
 import { IPC } from "../shared/ipc";
+import type { OrchestrationEventPayload } from "../shared/types/orchestration";
 
 type IpcRendererLike = {
   invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
@@ -9,46 +10,75 @@ type IpcRendererLike = {
   ) => unknown;
 };
 
-export function createOrchestrationBridge(ipcRenderer: IpcRendererLike) {
+export type OrchestrationBridgeDeps = {
+  /**
+   * Route an orchestration action through the daemon (remote → local), falling
+   * back to the desktop-main IPC handler when no runtime is bound (in-process /
+   * test mode). `ipcChannel` is the legacy fallback handler.
+   */
+  callAction: (action: string, args: unknown, ipcChannel: string) => Promise<unknown>;
+  /**
+   * Register a callback fed by the daemon runtime event stream (category
+   * "orchestrator"). Returns an unregister function.
+   */
+  subscribeRuntimeOrchestrationEvents: (
+    cb: (payload: OrchestrationEventPayload) => void,
+  ) => () => void;
+  ipcRenderer: IpcRendererLike;
+};
+
+export function createOrchestrationBridge(deps: OrchestrationBridgeDeps) {
+  const { callAction, subscribeRuntimeOrchestrationEvents, ipcRenderer } = deps;
   return {
     runCreate: (args: unknown) =>
-      ipcRenderer.invoke(IPC.orchestrationRunCreate, args),
+      callAction("runCreate", args, IPC.orchestrationRunCreate),
     bundleRead: (args: unknown) =>
-      ipcRenderer.invoke(IPC.orchestrationBundleRead, args),
+      callAction("bundleRead", args, IPC.orchestrationBundleRead),
     manifestReadSection: (args: unknown) =>
-      ipcRenderer.invoke(IPC.orchestrationManifestReadSection, args),
+      callAction("manifestReadSection", args, IPC.orchestrationManifestReadSection),
     manifestPatch: (args: unknown) =>
-      ipcRenderer.invoke(IPC.orchestrationManifestPatch, args),
+      callAction("manifestPatch", args, IPC.orchestrationManifestPatch),
     planAppend: (args: unknown) =>
-      ipcRenderer.invoke(IPC.orchestrationPlanAppend, args),
+      callAction("planAppend", args, IPC.orchestrationPlanAppend),
     planWrite: (args: unknown) =>
-      ipcRenderer.invoke(IPC.orchestrationPlanWrite, args),
+      callAction("planWrite", args, IPC.orchestrationPlanWrite),
     spawnAgent: (args: unknown) =>
-      ipcRenderer.invoke(IPC.orchestrationSpawnAgent, args),
+      callAction("spawnAgent", args, IPC.orchestrationSpawnAgent),
     agentInject: (args: unknown) =>
-      ipcRenderer.invoke(IPC.orchestrationAgentInject, args),
+      callAction("agentInject", args, IPC.orchestrationAgentInject),
     assetRegister: (args: unknown) =>
-      ipcRenderer.invoke(IPC.orchestrationAssetRegister, args),
+      callAction("assetRegister", args, IPC.orchestrationAssetRegister),
     claimTask: (args: unknown) =>
-      ipcRenderer.invoke(IPC.orchestrationClaimTask, args),
+      callAction("claimTask", args, IPC.orchestrationClaimTask),
     releaseTask: (args: unknown) =>
-      ipcRenderer.invoke(IPC.orchestrationReleaseTask, args),
+      callAction("releaseTask", args, IPC.orchestrationReleaseTask),
     runList: (args: unknown = {}) =>
-      ipcRenderer.invoke(IPC.orchestrationRunList, args),
+      callAction("runList", args, IPC.orchestrationRunList),
     subscribe: (
       args: { runId: string; laneId?: string },
       callback: (payload: unknown) => void,
     ): (() => void) => {
+      // Daemon-routed runtime event stream (runtime-backed / production mode).
+      const unsubscribeRuntime = subscribeRuntimeOrchestrationEvents((payload) => {
+        if (payload.runId === args.runId) callback(payload);
+      });
+      // Legacy desktop-main broadcast (in-process / test mode).
       const listener = (_evt: unknown, payload: unknown) => {
         if (!payload || typeof payload !== "object") return;
         const runId = (payload as { runId?: string }).runId;
         if (runId === args.runId) callback(payload);
       };
       ipcRenderer.on(IPC.orchestrationEvent, listener);
-      void ipcRenderer.invoke(IPC.orchestrationSubscribe, args).catch(() => undefined);
+      // Ensure the run bundle is loaded/subscribed on whichever backend handles it.
+      void callAction("subscribe", args, IPC.orchestrationSubscribe).catch(() => undefined);
       return () => {
+        unsubscribeRuntime();
         ipcRenderer.removeListener(IPC.orchestrationEvent, listener);
-        void ipcRenderer.invoke(IPC.orchestrationUnsubscribe, args).catch(() => undefined);
+        void callAction(
+          "unsubscribe",
+          { runId: args.runId },
+          IPC.orchestrationUnsubscribe,
+        ).catch(() => undefined);
       };
     },
   };

--- a/apps/desktop/src/preload/orchestrationBridge.ts
+++ b/apps/desktop/src/preload/orchestrationBridge.ts
@@ -24,11 +24,17 @@ export type OrchestrationBridgeDeps = {
   subscribeRuntimeOrchestrationEvents: (
     cb: (payload: OrchestrationEventPayload) => void,
   ) => () => void;
+  /**
+   * Validate a raw legacy-broadcast payload against the shared union before it
+   * reaches subscribers, mirroring the guard the runtime stream already applies
+   * so both delivery paths honour the same contract.
+   */
+  parseLegacyEvent: (payload: unknown) => OrchestrationEventPayload | null;
   ipcRenderer: IpcRendererLike;
 };
 
 export function createOrchestrationBridge(deps: OrchestrationBridgeDeps) {
-  const { callAction, subscribeRuntimeOrchestrationEvents, ipcRenderer } = deps;
+  const { callAction, subscribeRuntimeOrchestrationEvents, parseLegacyEvent, ipcRenderer } = deps;
   return {
     runCreate: (args: unknown) =>
       callAction("runCreate", args, IPC.orchestrationRunCreate),
@@ -56,17 +62,27 @@ export function createOrchestrationBridge(deps: OrchestrationBridgeDeps) {
       callAction("runList", args, IPC.orchestrationRunList),
     subscribe: (
       args: { runId: string; laneId?: string },
-      callback: (payload: unknown) => void,
+      callback: (payload: OrchestrationEventPayload) => void,
     ): (() => void) => {
+      // The daemon stream (runtime-backed / production) and the legacy
+      // desktop-main broadcast (in-process / test) are mutually exclusive per
+      // mode, yet both listeners are attached here. Latch onto whichever source
+      // delivers first and ignore the other, so an event is never applied twice.
+      let activeSource: "runtime" | "legacy" | null = null;
+      const deliver = (source: "runtime" | "legacy", payload: OrchestrationEventPayload) => {
+        if (activeSource === null) activeSource = source;
+        if (activeSource !== source) return;
+        if (payload.runId === args.runId) callback(payload);
+      };
       // Daemon-routed runtime event stream (runtime-backed / production mode).
       const unsubscribeRuntime = subscribeRuntimeOrchestrationEvents((payload) => {
-        if (payload.runId === args.runId) callback(payload);
+        deliver("runtime", payload);
       });
-      // Legacy desktop-main broadcast (in-process / test mode).
+      // Legacy desktop-main broadcast (in-process / test mode); validate against
+      // the shared union so the fallback honours the same contract.
       const listener = (_evt: unknown, payload: unknown) => {
-        if (!payload || typeof payload !== "object") return;
-        const runId = (payload as { runId?: string }).runId;
-        if (runId === args.runId) callback(payload);
+        const parsed = parseLegacyEvent(payload);
+        if (parsed) deliver("legacy", parsed);
       };
       ipcRenderer.on(IPC.orchestrationEvent, listener);
       // Ensure the run bundle is loaded/subscribed on whichever backend handles it.

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -5512,6 +5512,7 @@ contextBridge.exposeInMainWorld("ade", {
         () => ipcRenderer.invoke(ipcChannel, args),
       ),
     subscribeRuntimeOrchestrationEvents: registerRemoteOrchestrationEventCallback,
+    parseLegacyEvent: toOrchestrationRuntimeEvent,
     ipcRenderer,
   }),
   computerUse: {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -2936,6 +2936,19 @@ function toOrchestrationRuntimeEvent(
   if (typeof payload.kind !== "string" || !ORCHESTRATION_EVENT_KINDS.has(payload.kind)) {
     return null;
   }
+  if (payload.kind === "heartbeat") {
+    if (typeof payload.sessionId !== "string" || !payload.sessionId) return null;
+    if (typeof payload.lastHeartbeatAt !== "string" || !payload.lastHeartbeatAt)
+      return null;
+  }
+  if (
+    payload.kind === "lifecycle" &&
+    payload.status !== "suspended" &&
+    payload.status !== "resumed" &&
+    payload.status !== "deleted"
+  ) {
+    return null;
+  }
   return payload as unknown as OrchestrationEventPayload;
 }
 

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer, webFrame, webUtils } from "electron";
 import { IPC } from "../shared/ipc";
 import { createOrchestrationBridge } from "./orchestrationBridge";
+import type { OrchestrationEventPayload } from "../shared/types/orchestration";
 import type {
   AdeCleanupResult,
   AdeProjectEvent,
@@ -1571,6 +1572,9 @@ const remoteIosSimulatorEventCallbacks = new Set<
 const remoteAppControlEventCallbacks = new Set<
   (payload: AppControlEventPayload) => void
 >();
+const remoteOrchestrationEventCallbacks = new Set<
+  (payload: OrchestrationEventPayload) => void
+>();
 
 function createLocalIpcEventSubscription<T>(
   channel: string,
@@ -1718,8 +1722,19 @@ function hasRemoteRuntimeEventSubscribers(): boolean {
     remoteComputerUseEventCallbacks.size > 0 ||
     remoteIosSimulatorEventCallbacks.size > 0 ||
     remoteAppControlEventCallbacks.size > 0 ||
+    remoteOrchestrationEventCallbacks.size > 0 ||
     remotePrAiResolutionEventCallbacks.size > 0
   );
+}
+
+function registerRemoteOrchestrationEventCallback(
+  cb: (payload: OrchestrationEventPayload) => void,
+): () => void {
+  remoteOrchestrationEventCallbacks.add(cb);
+  ensureRemoteRuntimeEventPump();
+  return () => {
+    remoteOrchestrationEventCallbacks.delete(cb);
+  };
 }
 
 function normalizePtyDataSubscriptionIds(value: unknown): Set<string> {
@@ -2002,6 +2017,17 @@ function dispatchRemoteRuntimeEventPayload(
         cb(automationsEvent);
       } catch (error) {
         console.error("preload remote automation listener failed", error);
+      }
+    }
+  }
+
+  const orchestrationEvent = toOrchestrationRuntimeEvent(payload);
+  if (orchestrationEvent) {
+    for (const cb of [...remoteOrchestrationEventCallbacks]) {
+      try {
+        cb(orchestrationEvent);
+      } catch (error) {
+        console.error("preload remote orchestration listener failed", error);
       }
     }
   }
@@ -2891,6 +2917,26 @@ function toAutomationsRuntimeEvent(
   const event: Record<string, unknown> = { ...payload };
   delete event.source;
   return event as unknown as AutomationsEventPayload;
+}
+
+const ORCHESTRATION_EVENT_KINDS = new Set([
+  "manifest",
+  "plan",
+  "asset",
+  "heartbeat",
+  "lifecycle",
+]);
+
+function toOrchestrationRuntimeEvent(
+  payload: unknown,
+): OrchestrationEventPayload | null {
+  if (!isRecord(payload)) return null;
+  if (typeof payload.runId !== "string" || !payload.runId) return null;
+  if (typeof payload.etag !== "string") return null;
+  if (typeof payload.kind !== "string" || !ORCHESTRATION_EVENT_KINDS.has(payload.kind)) {
+    return null;
+  }
+  return payload as unknown as OrchestrationEventPayload;
 }
 
 function toMacosVmRuntimeEvent(payload: unknown): MacosVmEventPayload | null {
@@ -5444,7 +5490,17 @@ contextBridge.exposeInMainWorld("ade", {
       since?: string;
     }) => ipcRenderer.invoke(IPC.agentChatReadTranscript, args),
   },
-  orchestration: createOrchestrationBridge(ipcRenderer),
+  orchestration: createOrchestrationBridge({
+    callAction: (action, args, ipcChannel) =>
+      callProjectRuntimeActionOr(
+        "orchestration",
+        action,
+        { args: args as Record<string, unknown> | undefined },
+        () => ipcRenderer.invoke(ipcChannel, args),
+      ),
+    subscribeRuntimeOrchestrationEvents: registerRemoteOrchestrationEventCallback,
+    ipcRenderer,
+  }),
   computerUse: {
     listArtifacts: async (
       args: ComputerUseArtifactListArgs = {},

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -978,7 +978,8 @@ function renderAutoCreateDraftPane(args?: {
     session: AgentChatSession,
     options?: AgentChatSessionCreatedOptions,
   ) => void | Promise<void>;
-  workDraftKind?: "chat" | "cli" | "chat-orchestrator";
+  workDraftKind?: "chat" | "cli";
+  orchestratorEnabled?: boolean;
   onLaunchCliSession?: React.ComponentProps<typeof AgentChatPane>["onLaunchCliSession"];
   onLaneChange?: React.ComponentProps<typeof AgentChatPane>["onLaneChange"];
   lanes?: any[];
@@ -1018,6 +1019,7 @@ function renderAutoCreateDraftPane(args?: {
                 forceDraftMode
                 embeddedWorkLayout
                 workDraftKind={args?.workDraftKind}
+                orchestratorEnabled={args?.orchestratorEnabled}
                 availableLanes={lanes}
                 onLaneChange={args?.onLaneChange ?? vi.fn()}
                 onSessionCreated={args?.onSessionCreated}
@@ -1035,7 +1037,7 @@ function renderAutoCreateDraftPane(args?: {
 function composerDraftStorageKeyForTest(args: {
   projectRoot: string;
   companionStateKey: string;
-  workDraftKind?: "work-start" | "chat" | "cli" | "chat-orchestrator";
+  workDraftKind?: "work-start" | "chat" | "cli";
 }) {
   return [
     "ade.chat.composerDraft.v1",
@@ -1049,7 +1051,7 @@ function composerDraftStorageKeyForTest(args: {
 function draftLaunchJobsScopeKeyForTest(args: {
   projectRoot: string;
   laneId: string;
-  workDraftKind?: "work-start" | "chat-orchestrator";
+  workDraftKind?: "work-start";
 }) {
   return [
     "draft-launch-jobs",
@@ -3699,7 +3701,7 @@ describe("AgentChatPane submit recovery", () => {
   it("keeps orchestrator lead mode on the first Claude draft send", async () => {
     const { send, create } = installAdeMocks({ sessions: [], includeClaudeModel: true });
 
-    renderAutoCreateDraftPane({ workDraftKind: "chat-orchestrator" });
+    renderAutoCreateDraftPane({ orchestratorEnabled: true });
 
     const modelTrigger = await screen.findByRole("button", { name: /^Select model/ });
     const claudeLabel = getModelById("anthropic/claude-sonnet-4-6")?.displayName ?? "Claude Sonnet 4.6";
@@ -3733,7 +3735,7 @@ describe("AgentChatPane submit recovery", () => {
     vi.mocked(window.ade.orchestration.runCreate).mockRejectedValueOnce(new Error("disk full"));
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     try {
-      renderAutoCreateDraftPane({ workDraftKind: "chat-orchestrator" });
+      renderAutoCreateDraftPane({ orchestratorEnabled: true });
 
       const modelTrigger = await screen.findByRole("button", { name: /^Select model/ });
       const claudeLabel = getModelById("anthropic/claude-sonnet-4-6")?.displayName ?? "Claude Sonnet 4.6";

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -1069,15 +1069,17 @@ type ParallelModelRowState = NativeControlState & {
   executionMode: AgentChatExecutionMode;
 };
 
-type WorkDraftLaunchKind = "chat" | "cli" | "chat-orchestrator";
+type WorkDraftLaunchKind = "chat" | "cli";
 type WorkDraftStorageKind = WorkDraftLaunchKind | "work-start";
 
-function normalizeWorkDraftStorageKind(workDraftKind: WorkDraftLaunchKind): WorkDraftStorageKind {
-  return workDraftKind === "chat" || workDraftKind === "cli" ? "work-start" : workDraftKind;
+// Orchestrator is an orthogonal boolean now, so every launch kind shares the
+// single "work-start" bucket — prompt/model/lane persist across chat↔cli↔orchestrator.
+function normalizeWorkDraftStorageKind(): WorkDraftStorageKind {
+  return "work-start";
 }
 
 function resolveWorkDraftStorageKind(workDraftKind: WorkDraftLaunchKind | WorkDraftStorageKind): WorkDraftStorageKind {
-  return workDraftKind === "work-start" ? "work-start" : normalizeWorkDraftStorageKind(workDraftKind);
+  return workDraftKind === "work-start" ? "work-start" : normalizeWorkDraftStorageKind();
 }
 
 function launchConfigStorageKey(scope: {
@@ -2359,7 +2361,7 @@ function resolveCliRegistryModelId(provider: "codex" | "claude" | "cursor" | "dr
 
 function cursorModelAllowedForDraftKind(
   descriptor: ModelDescriptor | null | undefined,
-  workDraftKind: "chat" | "cli" | "chat-orchestrator",
+  workDraftKind: "chat" | "cli",
 ): boolean {
   if (descriptor?.family !== "cursor") return true;
   const availability = descriptor.cursorAvailability;
@@ -2370,7 +2372,7 @@ function cursorModelAllowedForDraftKind(
 
 function filterCursorModelIdsForDraftKind(
   modelIds: string[],
-  workDraftKind: "chat" | "cli" | "chat-orchestrator",
+  workDraftKind: "chat" | "cli",
 ): string[] {
   return modelIds.filter((modelId) => {
     const descriptor = resolveModelDescriptorWithRuntimeCatalog(modelId) ?? getModelById(modelId);
@@ -2737,6 +2739,7 @@ export function AgentChatPane({
   onInitialLinearIssueContextConsumed,
   onSessionCreated,
   workDraftKind = "chat",
+  orchestratorEnabled = false,
   onLaunchCliSession,
   onOpenShellSession,
   availableLanes,
@@ -2779,7 +2782,14 @@ export function AgentChatPane({
   initialModelId?: string | null;
   onInitialLinearIssueContextConsumed?: () => void;
   onSessionCreated?: (session: AgentChatSession, options?: AgentChatSessionCreatedOptions) => void | Promise<void>;
-  workDraftKind?: "chat" | "cli" | "chat-orchestrator";
+  workDraftKind?: "chat" | "cli";
+  /**
+   * Orthogonal orchestrator flag: when true the chat draft launches an
+   * orchestrator-lead run. Independent of `workDraftKind` so toggling
+   * chat↔cli↔orchestrator never splits prompt/model/lane draft state. CLI
+   * surfaces force this off (orchestrator has no CLI form).
+   */
+  orchestratorEnabled?: boolean;
   onLaunchCliSession?: (args: WorkPtyLaunchArgs) => Promise<WorkPtyLaunchResult>;
   onOpenShellSession?: (laneId: string) => void | Promise<void>;
   /** Available lanes for the lane selector in empty state (full `LaneSummary` includes `branchRef` for branch sublines in the menu). */
@@ -2843,7 +2853,7 @@ export function AgentChatPane({
   const isPersistentIdentitySurface = surfaceProfile === "persistent_identity";
   const showWorkspaceChrome = !hideWorkspaceChrome;
   const modelSwitchPolicy = presentation?.modelSwitchPolicy ?? "same-family-after-launch";
-  const workDraftStorageKind = normalizeWorkDraftStorageKind(workDraftKind);
+  const workDraftStorageKind = normalizeWorkDraftStorageKind();
   const isWorkDraftComposer = forceDraft && embeddedWorkLayout && !lockSessionId && !initialSessionId;
   const draftLaunchConfigLaneScopeId = isWorkDraftComposer ? WORK_START_DRAFT_LAUNCH_SCOPE_ID : laneId;
   const initialWorkDraftLaneIdRef = useRef<string | null>(isWorkDraftComposer ? laneId : null);
@@ -4356,7 +4366,7 @@ export function AgentChatPane({
   const assistantLabel = presentation?.assistantLabel?.trim()
     || resolveAssistantLabel(selectedModelDesc, selectedSession?.provider);
   const defaultMessagePlaceholder =
-    workDraftKind === "chat-orchestrator" && !selectedSessionId
+    orchestratorEnabled && !selectedSessionId
       ? "Describe the orchestration goal..."
       : "Type to vibecode...";
   const messagePlaceholder = presentation?.messagePlaceholder?.trim() || defaultMessagePlaceholder;
@@ -6410,7 +6420,7 @@ export function AgentChatPane({
       // Orchestrator-lead draft: force the interactionMode so the lead chat
       // boots with the orchestrator skill + tool gates (`goal.md` §10.1).
       const orchestratorOverrides: Partial<Parameters<typeof window.ade.agentChat.create>[0]> =
-        workDraftKind === "chat-orchestrator"
+        orchestratorEnabled
           ? { interactionMode: "orchestrator-lead" as AgentChatInteractionMode }
           : {};
       const created = await window.ade.agentChat.create({
@@ -6429,7 +6439,7 @@ export function AgentChatPane({
       // so the bundle path is persisted alongside the new chat (workers will
       // pick it up from the manifest). If it fails, stop before sending the
       // first prompt so a half-created lead chat cannot start working.
-      if (workDraftKind === "chat-orchestrator") {
+      if (orchestratorEnabled) {
         try {
           const runCreate = await window.ade.orchestration.runCreate({
             laneId: targetLaneId,
@@ -6495,7 +6505,7 @@ export function AgentChatPane({
       if (options.notify) notifySessionCreated(created, options.notifyOptions);
       if (targetLaneId === laneId) void refreshSessions({ force: true }).catch(() => {});
       return created;
-  }, [fastMode, constrainedModelSelectionError, currentNativeControls, executionMode, initialNativeControls, laneId, lastLaunchConfigStorageKey, modelId, notifySessionCreated, patchSessionSummary, reasoningEffort, refreshSessions, touchSession, workDraftKind]);
+  }, [fastMode, constrainedModelSelectionError, currentNativeControls, executionMode, initialNativeControls, laneId, lastLaunchConfigStorageKey, modelId, notifySessionCreated, orchestratorEnabled, patchSessionSummary, reasoningEffort, refreshSessions, touchSession, workDraftKind]);
 
   const createSession = useCallback(async (): Promise<string | null> => {
     if (createSessionPromiseRef.current) {
@@ -6940,7 +6950,7 @@ export function AgentChatPane({
     if (parallelLaunchBusy || projectTransitionBlocksChat) {
       return;
     }
-    if (kind === "chat" && (selectedSessionId || (workDraftKind !== "chat" && workDraftKind !== "chat-orchestrator"))) return;
+    if (kind === "chat" && (selectedSessionId || workDraftKind !== "chat")) return;
     if (kind === "cli" && (!isWorkCliLaunchDraft || !onLaunchCliSession)) return;
     if (!modelId) {
       setError("Select a model first");
@@ -7810,7 +7820,7 @@ export function AgentChatPane({
           const sendInteractionMode: AgentChatInteractionMode | null =
             sessionProvider === "claude"
               ? (
-                workDraftKind === "chat-orchestrator" || selectedSession?.interactionMode === "orchestrator-lead"
+                orchestratorEnabled || selectedSession?.interactionMode === "orchestrator-lead"
                   ? "orchestrator-lead"
                   : interactionMode
               )
@@ -7946,6 +7956,7 @@ export function AgentChatPane({
     builtInBrowserContextItems,
     macosVmContextItems,
     workDraftKind,
+    orchestratorEnabled,
   ]);
 
   const openRewindConfirmDialog = useCallback((state: RewindFilesConfirmDialogState): Promise<boolean> => {
@@ -9013,7 +9024,7 @@ export function AgentChatPane({
 
   const activeOrchestrationRole = selectedSession?.orchestrationRole ?? null;
   const isOrchestratorLead = selectedSession?.interactionMode === "orchestrator-lead";
-  const isOrchestratorDraft = forceDraft && workDraftKind === "chat-orchestrator" && selectedSessionId == null;
+  const isOrchestratorDraft = forceDraft && orchestratorEnabled && selectedSessionId == null;
 
   const composerElement = (
       <AgentChatComposer

--- a/apps/desktop/src/renderer/components/lanes/LaneWorkPane.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneWorkPane.tsx
@@ -56,6 +56,7 @@ export function LaneWorkPane({
           visibleSessions={work.visibleSessions}
           activeItemId={work.activeItemId}
           draftKind={work.draftKind}
+          orchestratorEnabled={work.orchestratorEnabled}
           draftLaneId={laneId}
           onSelectItem={work.setActiveItemId}
           onCloseItem={work.closeTab}

--- a/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/lanes/useLaneWorkSessions.ts
@@ -20,6 +20,7 @@ const EMPTY_WORK_STATE: WorkProjectViewState = {
   gridSets: [],
   activeGridSetId: null,
   draftKind: "chat",
+  orchestratorEnabled: false,
   draftLaneId: null,
   laneFilter: "all",
   statusFilter: "all",
@@ -608,6 +609,8 @@ export function useLaneWorkSessions(laneId: string | null) {
     setViewState((prev) => ({
       ...prev,
       draftKind: nextKind,
+      // CLI has no orchestrator form — switching to it forces the flag off.
+      orchestratorEnabled: nextKind === "cli" ? false : prev.orchestratorEnabled,
       activeItemId: null,
       selectedItemId: null,
     }));
@@ -848,6 +851,7 @@ export function useLaneWorkSessions(laneId: string | null) {
     gridLayoutId,
     activeItemId: laneViewState.activeItemId,
     draftKind: laneViewState.draftKind,
+    orchestratorEnabled: laneViewState.orchestratorEnabled,
     showDraftKind,
     setActiveItemId,
     closeTab,

--- a/apps/desktop/src/renderer/components/orchestration/OrchestrationPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/orchestration/OrchestrationPanel.test.tsx
@@ -369,6 +369,14 @@ describe("OrchestrationPanel preload integration", () => {
       orchestration: createOrchestrationBridge({
         callAction: (_action, args, ipcChannel) => invoke(ipcChannel, args),
         subscribeRuntimeOrchestrationEvents: () => () => {},
+        parseLegacyEvent: (payload) => {
+          if (!payload || typeof payload !== "object") return null;
+          const p = payload as Record<string, unknown>;
+          if (typeof p.runId !== "string" || !p.runId) return null;
+          if (typeof p.etag !== "string") return null;
+          if (typeof p.kind !== "string") return null;
+          return p as unknown as OrchestrationEventPayload;
+        },
         ipcRenderer: { invoke, on, removeListener },
       }),
     };

--- a/apps/desktop/src/renderer/components/orchestration/OrchestrationPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/orchestration/OrchestrationPanel.test.tsx
@@ -366,7 +366,11 @@ describe("OrchestrationPanel preload integration", () => {
     });
 
     (window as any).ade = {
-      orchestration: createOrchestrationBridge({ invoke, on, removeListener }),
+      orchestration: createOrchestrationBridge({
+        callAction: (_action, args, ipcChannel) => invoke(ipcChannel, args),
+        subscribeRuntimeOrchestrationEvents: () => () => {},
+        ipcRenderer: { invoke, on, removeListener },
+      }),
     };
 
     expect((window as any).ade?.orchestration?.bundleRead).toEqual(expect.any(Function));

--- a/apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx
@@ -655,7 +655,7 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
 
   const workSidebarVisible = active && work.workSidebarOpen;
   const isRemoteProject = useAppStore((s) => s.projectBinding?.kind === "remote");
-  const { setWorkSidebarTab, showDraftKind } = work;
+  const { setWorkSidebarTab, setOrchestratorEnabled } = work;
   useEffect(() => {
     if (!active) return;
     const openBrowserSidebar = () => {
@@ -669,14 +669,14 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
     const unsubscribeBrowserEvents = window.ade?.builtInBrowser?.onEvent?.((event) => {
       if (event.type === "open-request" && browserEventMatchesProject(event, projectRoot)) openBrowserSidebar();
     }) ?? null;
-    // The composer's "+" menu fires `ade:work:start-orchestrator-chat` to
-    // ask TerminalsPage to switch to the orchestrator-lead draft (parallel
-    // entry point to the SessionListPane "Orchestrator" pill).
+    // The composer's "+" menu fires `ade:work:start-orchestrator-chat` to flip
+    // the orthogonal orchestrator flag on the shared chat draft (keeps prompt /
+    // model / lane intact); the stop event clears it back to a normal chat.
     const startOrchestratorChat = () => {
-      showDraftKind("chat-orchestrator");
+      setOrchestratorEnabled(true);
     };
     const stopOrchestratorChat = () => {
-      showDraftKind("chat");
+      setOrchestratorEnabled(false);
     };
     window.addEventListener("ade:work:start-orchestrator-chat", startOrchestratorChat);
     window.addEventListener("ade:work:stop-orchestrator-chat", stopOrchestratorChat);
@@ -686,7 +686,7 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
       window.removeEventListener("ade:work:stop-orchestrator-chat", stopOrchestratorChat);
       unsubscribeBrowserEvents?.();
     };
-  }, [active, isRemoteProject, projectRoot, setWorkSidebarTab, showDraftKind]);
+  }, [active, isRemoteProject, projectRoot, setWorkSidebarTab, setOrchestratorEnabled]);
 
   const toggleSessionsPane = useCallback(() => {
     work.setWorkFocusSessionsHidden(!work.workFocusSessionsHidden);
@@ -837,6 +837,7 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
         visibleSessions={work.visibleSessions}
         activeItemId={work.activeItemId}
         draftKind={work.draftKind}
+        orchestratorEnabled={work.orchestratorEnabled}
         draftLaneId={work.draftLaneId}
         draftContextTargetId={draftContextTargetId}
         onSelectItem={work.setActiveItemId}
@@ -874,6 +875,7 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
       work.visibleSessions,
       work.activeItemId,
       work.draftKind,
+      work.orchestratorEnabled,
       work.draftLaneId,
       draftContextTargetId,
       work.setDraftLaneId,

--- a/apps/desktop/src/renderer/components/terminals/WorkStartSurface.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkStartSurface.test.tsx
@@ -9,7 +9,8 @@ const selectLane = vi.fn();
 const agentChatPaneProps = vi.hoisted(() => ({
   latest: null as null | {
     laneId: string | null;
-    workDraftKind?: "chat" | "cli" | "chat-orchestrator";
+    workDraftKind?: "chat" | "cli";
+    orchestratorEnabled?: boolean;
     draftContextTargetId?: string | null;
     onOpenShellSession?: (laneId: string) => void | Promise<void>;
     onLaunchCliSession?: unknown;
@@ -25,7 +26,8 @@ vi.mock("../../state/appStore", () => ({
 vi.mock("../chat/AgentChatPane", () => ({
   AgentChatPane: (props: {
     laneId: string | null;
-    workDraftKind?: "chat" | "cli" | "chat-orchestrator";
+    workDraftKind?: "chat" | "cli";
+    orchestratorEnabled?: boolean;
     draftContextTargetId?: string | null;
     onOpenShellSession?: (laneId: string) => void | Promise<void>;
     onLaunchCliSession?: unknown;

--- a/apps/desktop/src/renderer/components/terminals/WorkStartSurface.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkStartSurface.tsx
@@ -12,6 +12,7 @@ import type { WorkPtyLaunchArgs, WorkPtyLaunchResult } from "./cliLaunch";
 
 type WorkStartSurfaceProps = {
   draftKind: WorkDraftKind;
+  orchestratorEnabled?: boolean;
   draftLaneId?: string | null;
   draftContextTargetId?: string | null;
   lanes: LaneSummary[];
@@ -27,6 +28,7 @@ type WorkStartSurfaceProps = {
 
 export function WorkStartSurface({
   draftKind,
+  orchestratorEnabled = false,
   draftLaneId = null,
   draftContextTargetId = null,
   lanes,
@@ -133,6 +135,7 @@ export function WorkStartSurface({
           embeddedWorkLayout
           suppressDraftLaunchNavigation={suppressDraftLaunchNavigation}
           workDraftKind={draftKind}
+          orchestratorEnabled={orchestratorEnabled}
           initialLinearIssueContext={initialLinearIssueContext}
           initialLinearIssueContextSource={initialLinearIssueContextSource}
           initialModelId={initialModelId}

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.test.tsx
@@ -340,7 +340,8 @@ describe("WorkViewArea", () => {
         sessions={[]}
         visibleSessions={[]}
         activeItemId={null}
-        draftKind="chat-orchestrator"
+        draftKind="chat"
+        orchestratorEnabled
         onSelectItem={() => {}}
         onCloseItem={() => {}}
         onOpenChatSession={() => {}}

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
@@ -791,9 +791,7 @@ function ModeSwitcherPills({
   return (
     <div className="ade-liquid-glass-pill inline-flex items-center gap-1 rounded-full p-1">
       {MODE_OPTIONS.map((opt) => {
-        const active = opt.kind === "chat"
-          ? draftKind === "chat" || draftKind === "chat-orchestrator"
-          : draftKind === opt.kind;
+        const active = draftKind === opt.kind;
         const Icon = opt.Icon;
         return (
           <SmartTooltip
@@ -835,6 +833,7 @@ export function WorkViewArea({
   visibleSessions,
   activeItemId,
   draftKind,
+  orchestratorEnabled = false,
   draftLaneId = null,
   draftContextTargetId = null,
   onContinueCliSession,
@@ -871,6 +870,8 @@ export function WorkViewArea({
   visibleSessions: TerminalSessionSummary[];
   activeItemId: string | null;
   draftKind: WorkDraftKind;
+  /** Orthogonal orchestrator flag for the chat draft (forwarded to the composer). */
+  orchestratorEnabled?: boolean;
   draftLaneId?: string | null;
   draftContextTargetId?: string | null;
   onSelectItem: (sessionId: string) => void;
@@ -999,6 +1000,7 @@ export function WorkViewArea({
         <div className="min-h-0 flex-1">
           <WorkStartSurface
             draftKind={draftKind}
+            orchestratorEnabled={orchestratorEnabled}
             draftLaneId={draftLaneId}
             draftContextTargetId={draftContextTargetId}
             lanes={lanes}

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -32,6 +32,7 @@ const DEFAULT_PROJECT_WORK_STATE: WorkProjectViewState = {
   gridSets: [],
   activeGridSetId: null,
   draftKind: "chat",
+  orchestratorEnabled: false,
   draftLaneId: null,
   laneFilter: "all",
   statusFilter: "all",
@@ -419,6 +420,7 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
   const activeItemId = projectViewState.activeItemId;
   const selectedSessionId = projectViewState.selectedItemId;
   const draftKind = projectViewState.draftKind;
+  const orchestratorEnabled = projectViewState.orchestratorEnabled;
   const draftLaneId = projectViewState.draftLaneId;
   const filterLaneId = projectViewState.laneFilter;
   const filterStatus = projectViewState.statusFilter;
@@ -497,6 +499,23 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
       setProjectViewState((prev) => ({
         ...prev,
         draftKind: nextKind,
+        // CLI has no orchestrator form — switching to it forces the flag off
+        // (lane/model/prompt persist via the shared draft bucket).
+        orchestratorEnabled: nextKind === "cli" ? false : prev.orchestratorEnabled,
+        activeItemId: null,
+        selectedItemId: null,
+      }));
+    },
+    [setProjectViewState],
+  );
+
+  const setOrchestratorEnabled = useCallback(
+    (enabled: boolean) => {
+      setProjectViewState((prev) => ({
+        ...prev,
+        orchestratorEnabled: enabled,
+        // Orchestrator only exists for chat drafts; enabling it implies chat mode.
+        draftKind: enabled ? "chat" : prev.draftKind,
         activeItemId: null,
         selectedItemId: null,
       }));
@@ -1535,6 +1554,8 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
     activeItemId,
     setActiveItemId,
     draftKind,
+    orchestratorEnabled,
+    setOrchestratorEnabled,
     draftLaneId,
     setDraftLaneId,
     showDraftKind,

--- a/apps/desktop/src/renderer/state/appStore.ts
+++ b/apps/desktop/src/renderer/state/appStore.ts
@@ -123,7 +123,7 @@ export type TerminalAttentionIndicator = "none" | "running-active" | "running-ne
 export type MacosVmTabIndicator = "blocker" | "failed" | null;
 export type WorkSidebarTab = "git" | "files" | "ios" | "app-control" | "browser";
 export type WorkStatusFilter = "all" | "running" | "awaiting-input" | "ended";
-export type WorkDraftKind = "chat" | "cli" | "chat-orchestrator";
+export type WorkDraftKind = "chat" | "cli";
 /** How sessions are grouped in the Work sidebar list. */
 export type WorkSessionListOrganization =
   | "all-lanes-by-status"
@@ -149,6 +149,13 @@ export type WorkProjectViewState = {
   /** The grid set currently shown in the work area (derived-from/synced-with the focused session). */
   activeGridSetId: string | null;
   draftKind: WorkDraftKind;
+  /**
+   * Whether the new-chat composer launches an orchestrator (lead) run. This is
+   * an orthogonal flag on the single unified draft — not a third `draftKind` —
+   * so toggling chat↔cli↔orchestrator never splits the prompt/model/lane state.
+   * CLI mode forces this off (orchestrator has no CLI form).
+   */
+  orchestratorEnabled: boolean;
   draftLaneId: string | null;
   laneFilter: string;
   statusFilter: WorkStatusFilter;
@@ -207,6 +214,7 @@ function createDefaultWorkProjectViewState(): WorkProjectViewState {
     gridSets: [],
     activeGridSetId: null,
     draftKind: "chat",
+    orchestratorEnabled: false,
     draftLaneId: null,
     laneFilter: "all",
     statusFilter: "all",
@@ -258,9 +266,12 @@ function normalizeWorkProjectViewState(value: unknown): WorkProjectViewState {
     selectedItemId: normalizeOptionalString(candidate.selectedItemId),
     gridSets: normalizeWorkGridSets(candidate.gridSets),
     activeGridSetId: normalizeOptionalString(candidate.activeGridSetId),
-    draftKind: candidate.draftKind === "cli" || candidate.draftKind === "chat-orchestrator"
-      ? candidate.draftKind
-      : "chat",
+    draftKind: candidate.draftKind === "cli" ? "cli" : "chat",
+    // Legacy persisted state stored orchestrator as a third draftKind
+    // ("chat-orchestrator"); migrate it onto the orthogonal boolean.
+    orchestratorEnabled:
+      candidate.orchestratorEnabled === true
+      || (candidate as { draftKind?: unknown }).draftKind === "chat-orchestrator",
     draftLaneId: normalizeOptionalString(candidate.draftLaneId),
     laneFilter: normalizeOptionalString(candidate.laneFilter) ?? "all",
     statusFilter:

--- a/apps/desktop/src/renderer/state/appStore.ts
+++ b/apps/desktop/src/renderer/state/appStore.ts
@@ -268,10 +268,12 @@ function normalizeWorkProjectViewState(value: unknown): WorkProjectViewState {
     activeGridSetId: normalizeOptionalString(candidate.activeGridSetId),
     draftKind: candidate.draftKind === "cli" ? "cli" : "chat",
     // Legacy persisted state stored orchestrator as a third draftKind
-    // ("chat-orchestrator"); migrate it onto the orthogonal boolean.
+    // ("chat-orchestrator"); migrate it onto the orthogonal boolean. CLI mode
+    // forces orchestrator off, so never resolve both at once.
     orchestratorEnabled:
-      candidate.orchestratorEnabled === true
-      || (candidate as { draftKind?: unknown }).draftKind === "chat-orchestrator",
+      candidate.draftKind !== "cli"
+      && (candidate.orchestratorEnabled === true
+        || (candidate as { draftKind?: unknown }).draftKind === "chat-orchestrator"),
     draftLaneId: normalizeOptionalString(candidate.draftLaneId),
     laneFilter: normalizeOptionalString(candidate.laneFilter) ?? "all",
     statusFilter:


### PR DESCRIPTION
## Summary
- Orchestrator runs (lead/worker/validator) crashed in **every real build** — the orchestration IPC handlers dereferenced in-process services (`orchestrationService`/`laneService`/`agentChatService`) that are `null` in runtime-backed mode (`shouldUseInProcessProjectRuntime()` is `NODE_ENV==="test"` only). Same bug class as the recurring runtime-backed null-service issue.
- Port the handler logic into a shared `createOrchestrationDomainService` (`apps/desktop/src/main/services/orchestration/orchestrationDomain.ts`), used by both the in-process IPC path and a new `"orchestration"` daemon action domain (registry allowlist). Construct the service in `apps/ade-cli/src/bootstrap.ts` and stream its events via `pushEvent("orchestrator", …)`.
- Rewrite the preload bridge to route every call through `callProjectRuntimeActionOr("orchestration", …)`; subscribe to the runtime event stream (structural `toOrchestrationRuntimeEvent` detection) while keeping the legacy in-process broadcast for test mode.
- Collapse the 3rd `chat-orchestrator` `WorkDraftKind` into an orthogonal `orchestratorEnabled` boolean on a single unified draft bucket, so prompt/model/lane/orchestrator-flag stay stable across every toggle. CLI forces orchestrator off; auto-create-lane is now allowed while orchestrator is enabled. Legacy `chat-orchestrator` draftKind is migrated in `normalizeWorkProjectViewState`.

## Test plan
- [x] Desktop `tsc --noEmit` clean (Node 22)
- [x] ade-cli `tsc --noEmit` clean (Node 22)
- [x] Desktop eslint: 0 errors
- [x] New `orchestrationDomain.test.ts` — 11 cases (spawn/inject gates, retry-on-etag, cleanup, runCreate stitch) green
- [x] Scoped renderer/main suites green (AgentChatPane, registry+orchestrationService, terminals/lanes)
- [ ] CI green
- [ ] Manual: launch orchestrator run in a packaged/runtime-backed build (the path that previously threw "orchestration service is not initialised")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Orchestrator mode is now available as a standalone feature toggle, separate from chat and CLI draft kinds for improved clarity and control.

* **Improvements**
  * Streamlined orchestration service integration across the application with enhanced event handling and agent lifecycle management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes orchestrator runs crashing in runtime-backed builds by extracting the IPC handler logic into a shared `createOrchestrationDomainService`, wiring it through both the in-process IPC path and a new `"orchestration"` daemon action domain, and collapsing the legacy `"chat-orchestrator"` draft kind into an orthogonal `orchestratorEnabled` boolean on the unified `"chat"` draft bucket.

- **Orchestration domain unification**: `orchestrationDomain.ts` introduces a single service factory with `SAFE_RUN_ID` path-traversal guards, one-retry etag conflict handling, and session cleanup on failure; used identically by the IPC handlers (`registerIpc.ts`) and the daemon registry (`registry.ts`).
- **Preload bridge rewrite**: `orchestrationBridge.ts` routes every call through `callProjectRuntimeActionOr(\"orchestration\", …)` and subscribes to the daemon runtime event stream with a per-subscription source latch, while keeping the legacy in-process broadcast as a fallback validated by the same `toOrchestrationRuntimeEvent` guard.
- **Draft state migration**: `WorkDraftKind` loses `\"chat-orchestrator\"`; `normalizeWorkProjectViewState` migrates persisted state to the new `orchestratorEnabled` boolean; `setOrchestratorEnabled` in `useWorkSessions` correctly forces `draftKind` to `\"chat\"` on enable and clears the flag on CLI switch.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the null-service crash is correctly fixed across both delivery paths and the draft state migration is backward-compatible.

The core fix (shared OrchestrationDomainService used by both IPC and daemon paths) is well-tested with 11 unit cases. The draft-kind migration in normalizeWorkProjectViewState correctly handles legacy 'chat-orchestrator' persistence. The only findings are a per-call domain service allocation in the daemon registry path and a slightly lighter event guard in one test file — neither affects runtime correctness.

apps/desktop/src/main/services/adeActions/registry.ts — buildOrchestrationDomainService allocates a new object per daemon action call; consider applying the same caching strategy used in registerIpc.ts.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/orchestration/orchestrationDomain.ts | New shared domain service centralising all orchestration logic; safe runId validation via SAFE_RUN_ID regex, one-retry etag conflict pattern, and session cleanup on failure. |
| apps/desktop/src/main/services/orchestration/orchestrationDomain.test.ts | 11 focused unit tests covering spawn gates, etag-conflict retry, orphan session cleanup, inject modes, and runCreate best-effort stitch; solid coverage of the new domain service. |
| apps/desktop/src/main/services/adeActions/registry.ts | Adds 'orchestration' to the daemon action allowlist and wires buildOrchestrationDomainService; new service object is created on every getAdeActionDomainServices call (unlike the cached IPC path). |
| apps/desktop/src/main/services/ipc/registerIpc.ts | IPC handlers collapsed to thin delegation through getOrchestrationDomain() with correct per-context caching; code reduction is significant and correct. |
| apps/desktop/src/preload/orchestrationBridge.ts | Bridge correctly routes through callProjectRuntimeActionOr with legacy IPC fallback; source-latch in subscribe is safe given the documented runtime/legacy mutual exclusivity. |
| apps/desktop/src/preload/preload.ts | Adds toOrchestrationRuntimeEvent guard with kind-specific field checks (heartbeat/lifecycle) and wires registerRemoteOrchestrationEventCallback into the existing event pump pattern. |
| apps/desktop/src/renderer/state/appStore.ts | WorkDraftKind drops 'chat-orchestrator'; normalizeWorkProjectViewState correctly migrates legacy draftKind to orchestratorEnabled boolean, CLI forces orchestrator off. |
| apps/ade-cli/src/bootstrap.ts | Instantiates orchestrationService in CLI daemon, forwards events via pushEvent('orchestrator', …), and wires it into agentChatService and disposal chain. |
| apps/desktop/src/renderer/components/terminals/useWorkSessions.ts | Adds orchestratorEnabled state and setOrchestratorEnabled callback; correctly forces draftKind to 'chat' when enabling and forces orchestratorEnabled off when switching to CLI. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Removes chat-orchestrator draftKind, adds orchestratorEnabled prop; createSession, sendMessage, isOrchestratorDraft references all correctly updated. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Renderer
    participant OrchestrationBridge
    participant Preload
    participant Daemon as Daemon (runtime-backed)
    participant IPC as Desktop IPC (in-process/test)
    participant OrchestratorDomain as OrchestrationDomainService
    participant OrchestratorSvc as OrchestrationService

    Renderer->>OrchestrationBridge: spawnAgent(args)
    OrchestrationBridge->>Preload: callProjectRuntimeActionOr("orchestration", "spawnAgent", args, fallback)

    alt Runtime-backed (production)
        Preload->>Daemon: "run_ade_action {domain:"orchestration", action:"spawnAgent"}"
        Daemon->>OrchestratorDomain: spawnAgent(arg)
        OrchestratorDomain->>OrchestratorSvc: getManifestForRun / manifestPatch
        OrchestratorDomain-->>Daemon: "{sessionId, etag}"
        Daemon-->>Preload: result
        Daemon--)Preload: pushEvent("orchestrator", payload)
        Preload--)Renderer: remoteOrchestrationEventCallbacks (runtime source)
    else In-process / test
        Preload->>IPC: ipcRenderer.invoke(IPC.orchestrationSpawnAgent, args)
        IPC->>OrchestratorDomain: getOrchestrationDomain().spawnAgent(arg)
        OrchestratorDomain->>OrchestratorSvc: getManifestForRun / manifestPatch
        OrchestratorDomain-->>IPC: "{sessionId, etag}"
        IPC-->>Preload: result
        IPC--)Renderer: ipcRenderer.on(IPC.orchestrationEvent) (legacy source)
    end

    Preload-->>OrchestrationBridge: result
    OrchestrationBridge-->>Renderer: "{sessionId, etag}"
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/renderer/components/chat/AgentChatPane.tsx`, line 1379-1382 ([link](https://github.com/arul28/ade/blob/036e0c6dd1cc9e8eb12e9f354fc576dcfd138157/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx#L1379-L1382)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Orchestrator composer draft silently abandoned on upgrade**

   `normalizeWorkDraftStorageKind` now unconditionally returns `"work-start"`, which is correct for the new unified bucket. However, users who typed a prompt in the old `"chat-orchestrator"` composer (which was stored under a key built from `"chat-orchestrator"`) will silently lose that draft after upgrading because the new code reads from `"work-start"`. The `appStore.ts` migration correctly converts the persisted `draftKind` state, but there is no corresponding migration for the localStorage composer draft key. If the UI rebuilds the storage key from the already-migrated state, the old draft becomes unreachable. Consider reading from the old key once on first boot and copying it into the `"work-start"` bucket.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
   Line: 1379-1382

   Comment:
   **Orchestrator composer draft silently abandoned on upgrade**

   `normalizeWorkDraftStorageKind` now unconditionally returns `"work-start"`, which is correct for the new unified bucket. However, users who typed a prompt in the old `"chat-orchestrator"` composer (which was stored under a key built from `"chat-orchestrator"`) will silently lose that draft after upgrading because the new code reads from `"work-start"`. The `appStore.ts` migration correctly converts the persisted `draftKind` state, but there is no corresponding migration for the localStorage composer draft key. If the UI rebuilds the storage key from the already-migrated state, the old draft becomes unreachable. Consider reading from the old key once on first boot and copying it into the `"work-start"` bucket.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FAgentChatPane.tsx%0ALine%3A%201379-1382%0A%0AComment%3A%0A**Orchestrator%20composer%20draft%20silently%20abandoned%20on%20upgrade**%0A%0A%60normalizeWorkDraftStorageKind%60%20now%20unconditionally%20returns%20%60%22work-start%22%60%2C%20which%20is%20correct%20for%20the%20new%20unified%20bucket.%20However%2C%20users%20who%20typed%20a%20prompt%20in%20the%20old%20%60%22chat-orchestrator%22%60%20composer%20%28which%20was%20stored%20under%20a%20key%20built%20from%20%60%22chat-orchestrator%22%60%29%20will%20silently%20lose%20that%20draft%20after%20upgrading%20because%20the%20new%20code%20reads%20from%20%60%22work-start%22%60.%20The%20%60appStore.ts%60%20migration%20correctly%20converts%20the%20persisted%20%60draftKind%60%20state%2C%20but%20there%20is%20no%20corresponding%20migration%20for%20the%20localStorage%20composer%20draft%20key.%20If%20the%20UI%20rebuilds%20the%20storage%20key%20from%20the%20already-migrated%20state%2C%20the%20old%20draft%20becomes%20unreachable.%20Consider%20reading%20from%20the%20old%20key%20once%20on%20first%20boot%20and%20copying%20it%20into%20the%20%60%22work-start%22%60%20bucket.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=544&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2FadeActions%2Fregistry.ts%3A868-878%0A**Per-call%20domain%20service%20allocation%20on%20the%20daemon%20path**%0A%0A%60buildOrchestrationDomainService%60%20constructs%20a%20fresh%20closure%20object%20on%20every%20%60getAdeActionDomainServices%60%20invocation.%20The%20IPC%20path%20fixed%20this%20with%20%60cachedOrchestrationDomain%60%20keyed%20by%20context%20%E2%80%94%20the%20same%20caching%20strategy%20would%20work%20here.%20Since%20the%20domain%20service%20is%20stateless%20%28all%20state%20lives%20in%20the%20three%20underlying%20services%29%2C%20a%20simple%20module-level%20cache%20keyed%20by%20%60runtime%60%20identity%20is%20enough.%0A%0A%60%60%60suggestion%0Alet%20cachedRegistryOrchestrationDomain%3A%20%7B%0A%20%20runtime%3A%20AdeRuntime%3B%0A%20%20domain%3A%20OpaqueService%3B%0A%7D%20%7C%20null%20%3D%20null%3B%0A%0Afunction%20buildOrchestrationDomainService%28runtime%3A%20AdeRuntime%29%3A%20OpaqueService%20%7C%20null%20%7B%0A%20%20const%20orchestrationService%20%3D%20runtime.orchestrationService%3B%0A%20%20const%20laneService%20%3D%20runtime.laneService%3B%0A%20%20const%20agentChatService%20%3D%20runtime.agentChatService%3B%0A%20%20if%20%28!orchestrationService%20%7C%7C%20!laneService%20%7C%7C%20!agentChatService%29%20return%20null%3B%0A%20%20if%20%28cachedRegistryOrchestrationDomain%3F.runtime%20%3D%3D%3D%20runtime%29%20%7B%0A%20%20%20%20return%20cachedRegistryOrchestrationDomain.domain%3B%0A%20%20%7D%0A%20%20const%20domain%20%3D%20createOrchestrationDomainService%28%7B%0A%20%20%20%20orchestrationService%2C%0A%20%20%20%20laneService%3A%20%7B%20getLaneWorktreePath%3A%20%28laneId%3A%20string%29%20%3D%3E%20laneService.getLaneWorktreePath%28laneId%29%20%7D%2C%0A%20%20%20%20agentChatService%2C%0A%20%20%7D%29%20as%20unknown%20as%20OpaqueService%3B%0A%20%20cachedRegistryOrchestrationDomain%20%3D%20%7B%20runtime%2C%20domain%20%7D%3B%0A%20%20return%20domain%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Forchestration%2FOrchestrationPanel.test.tsx%3A366-385%0A**Test%20%60parseLegacyEvent%60%20diverges%20from%20production%20guard**%0A%0AThe%20inline%20%60parseLegacyEvent%60%20in%20this%20test%20doesn't%20enforce%20the%20%60ORCHESTRATION_EVENT_KINDS%60%20allowlist%20or%20the%20per-kind%20required%20fields%20%28%60sessionId%60%2F%60lastHeartbeatAt%60%20for%20%60%22heartbeat%22%60%2C%20%60status%60%20for%20%60%22lifecycle%22%60%29.%20A%20test%20event%20with%20%60kind%3A%20%22bogus%22%60%20or%20a%20malformed%20heartbeat%20would%20be%20accepted%20here%20but%20rejected%20by%20%60toOrchestrationRuntimeEvent%60%20in%20production.%20Importing%20and%20reusing%20%60toOrchestrationRuntimeEvent%60%20directly%20would%20close%20the%20gap.%0A%0A&repo=arul28%2Fade&pr=544&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src/main/services/adeActions/registry.ts:868-878
**Per-call domain service allocation on the daemon path**

`buildOrchestrationDomainService` constructs a fresh closure object on every `getAdeActionDomainServices` invocation. The IPC path fixed this with `cachedOrchestrationDomain` keyed by context — the same caching strategy would work here. Since the domain service is stateless (all state lives in the three underlying services), a simple module-level cache keyed by `runtime` identity is enough.

```suggestion
let cachedRegistryOrchestrationDomain: {
  runtime: AdeRuntime;
  domain: OpaqueService;
} | null = null;

function buildOrchestrationDomainService(runtime: AdeRuntime): OpaqueService | null {
  const orchestrationService = runtime.orchestrationService;
  const laneService = runtime.laneService;
  const agentChatService = runtime.agentChatService;
  if (!orchestrationService || !laneService || !agentChatService) return null;
  if (cachedRegistryOrchestrationDomain?.runtime === runtime) {
    return cachedRegistryOrchestrationDomain.domain;
  }
  const domain = createOrchestrationDomainService({
    orchestrationService,
    laneService: { getLaneWorktreePath: (laneId: string) => laneService.getLaneWorktreePath(laneId) },
    agentChatService,
  }) as unknown as OpaqueService;
  cachedRegistryOrchestrationDomain = { runtime, domain };
  return domain;
}
```

### Issue 2 of 2
apps/desktop/src/renderer/components/orchestration/OrchestrationPanel.test.tsx:366-385
**Test `parseLegacyEvent` diverges from production guard**

The inline `parseLegacyEvent` in this test doesn't enforce the `ORCHESTRATION_EVENT_KINDS` allowlist or the per-kind required fields (`sessionId`/`lastHeartbeatAt` for `"heartbeat"`, `status` for `"lifecycle"`). A test event with `kind: "bogus"` or a malformed heartbeat would be accepted here but rejected by `toOrchestrationRuntimeEvent` in production. Importing and reusing `toOrchestrationRuntimeEvent` directly would close the gap.


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Address review: guard orchestration runI..."](https://github.com/arul28/ade/commit/5b8aac419e42bcde064c2884edf811e63a24c7ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36303160)</sub>

<!-- /greptile_comment -->