### PR TITLE
Chat 20260608 160556

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,8 +357,30 @@ Dock icons keep the exact bundle path they were pinned from, so an old icon can
 launch a stale `apps/desktop/release-*` build even after `/Applications` was
 updated.
 
+Replacing the app bundle does not replace a brain process that is already
+running for that channel. Before restarting the channel brain, close or finish
+any active ADE Desktop, ADE Code, agent, or mobile sessions that depend on it.
+Then restart and verify the channel brain through the CLI:
+
+```bash
+ADE_PACKAGE_CHANNEL=beta ADE_HOME="$HOME/.ade-beta" ade brain status --text
+ADE_PACKAGE_CHANNEL=beta ADE_HOME="$HOME/.ade-beta" ade brain restart --text
+ADE_PACKAGE_CHANNEL=beta ADE_HOME="$HOME/.ade-beta" ade doctor --text
+ADE_PACKAGE_CHANNEL=beta ADE_HOME="$HOME/.ade-beta" ade sync status --text
+```
+
+For Alpha, use `ADE_PACKAGE_CHANNEL=alpha` and `ADE_HOME="$HOME/.ade-alpha"`.
+Do not kill ADE brain processes directly during normal testing; the channel
+brain owns the mobile sync websocket and may have desktop, terminal, or phone
+clients attached. If you intentionally leave an old incompatible brain running,
+the packaged desktop may preserve it and launch a private no-sync fallback
+runtime for the desktop window, which means the Mobile drawer will not be using
+that fallback's sync service.
+
 Launching a packaged channel build should install or repair that channel's
-always-on brain service:
+always-on brain service. Official auto-updates also refresh this service on the
+first launch after an update, and the installed service is expected to report the
+same runtime build hash as the packaged desktop CLI:
 
 ```bash
 launchctl print gui/$(id -u)/com.ade.runtime.beta

--- a/apps/ade-cli/src/serviceManager/common.test.ts
+++ b/apps/ade-cli/src/serviceManager/common.test.ts
@@ -112,6 +112,40 @@ describe("resolveAdeServeCommand", () => {
       },
     });
   });
+
+  it("does not hash node when the node serve fallback has no dist CLI", () => {
+    const tempDir = makeTempHome("ade-service-command-no-dist-");
+    process.argv[1] = path.join(tempDir, "missing-cli.cjs");
+
+    const command = resolveAdeServeCommand();
+
+    expect(command).toMatchObject({
+      command: process.execPath,
+      args: ["serve"],
+    });
+    expect(command.env?.ADE_RUNTIME_BUILD_HASH).toBeUndefined();
+  });
+
+  it("sets the runtime build hash from dist cli for the node serve fallback", () => {
+    const tempDir = makeTempHome("ade-service-command-dist-");
+    const srcDir = path.join(tempDir, "src");
+    const distDir = path.join(tempDir, "dist");
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.mkdirSync(distDir, { recursive: true });
+    fs.writeFileSync(path.join(tempDir, "package.json"), "{\"name\":\"ade-cli\"}\n", "utf8");
+    fs.writeFileSync(path.join(srcDir, "cli.ts"), "export {}\n", "utf8");
+    const distPath = path.join(distDir, "cli.cjs");
+    fs.writeFileSync(distPath, "console.log('dist runtime')\n", "utf8");
+    process.argv[1] = path.join(tempDir, "missing-cli.cjs");
+
+    expect(resolveAdeServeCommand()).toMatchObject({
+      command: process.execPath,
+      args: ["serve"],
+      env: {
+        ADE_RUNTIME_BUILD_HASH: fileSha256(distPath),
+      },
+    });
+  });
 });
 
 describe("service manager status parsers", () => {

--- a/apps/ade-cli/src/serviceManager/common.test.ts
+++ b/apps/ade-cli/src/serviceManager/common.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -46,6 +47,10 @@ function makeTempHome(prefix: string): string {
   return dir;
 }
 
+function fileSha256(filePath: string): string {
+  return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
 describe("resolveAdeServeCommand", () => {
   it("uses node plus the CLI script when argv points at a real script", () => {
     process.argv[1] = path.resolve("src/cli.ts");
@@ -74,6 +79,36 @@ describe("resolveAdeServeCommand", () => {
       args: ["serve"],
       env: {
         NODE_PATH: "/opt/ade/runtime/node_modules",
+      },
+    });
+  });
+
+  it("sets the runtime build hash from the CLI script", () => {
+    const tempDir = makeTempHome("ade-service-command-");
+    const scriptPath = path.join(tempDir, "cli.cjs");
+    fs.writeFileSync(scriptPath, "console.log('ade runtime')\n", "utf8");
+    process.argv[1] = scriptPath;
+
+    expect(resolveAdeServeCommand()).toMatchObject({
+      command: process.execPath,
+      args: [scriptPath, "serve"],
+      env: {
+        ADE_RUNTIME_BUILD_HASH: fileSha256(scriptPath),
+      },
+    });
+  });
+
+  it("sets the runtime build hash from a standalone executable entrypoint", () => {
+    const tempDir = makeTempHome("ade-service-command-bin-");
+    const binaryPath = path.join(tempDir, "ade");
+    fs.writeFileSync(binaryPath, "ade runtime binary\n", "utf8");
+    process.argv[1] = binaryPath;
+
+    expect(resolveAdeServeCommand()).toMatchObject({
+      command: binaryPath,
+      args: ["serve"],
+      env: {
+        ADE_RUNTIME_BUILD_HASH: fileSha256(binaryPath),
       },
     });
   });

--- a/apps/ade-cli/src/serviceManager/common.ts
+++ b/apps/ade-cli/src/serviceManager/common.ts
@@ -73,16 +73,29 @@ function runtimeEnvironment(): Record<string, string> | undefined {
 }
 
 function fileSha256(filePath: string): string | null {
+  let fd: number | null = null;
   try {
-    return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+    fd = fs.openSync(filePath, "r");
+    const hash = createHash("sha256");
+    const buffer = Buffer.allocUnsafe(1024 * 1024);
+    for (;;) {
+      const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      hash.update(bytesRead === buffer.length ? buffer : buffer.subarray(0, bytesRead));
+    }
+    return hash.digest("hex");
   } catch {
     return null;
+  } finally {
+    if (fd != null) {
+      try { fs.closeSync(fd); } catch {}
+    }
   }
 }
 
 function resolveCliPackageRoot(entryPath: string): string | null {
   const seen = new Set<string>();
-  const starts = [entryPath ? path.dirname(entryPath) : null, process.cwd()];
+  const starts = entryPath ? [path.dirname(entryPath)] : [process.cwd()];
   for (const start of starts) {
     if (!start) continue;
     let cursor = path.resolve(start);
@@ -110,21 +123,21 @@ function resolveCliDistPath(entryPath: string): string | null {
 
 export function resolveAdeServiceCommandBuildHash(command: AdeServiceCommand): string | null {
   const firstArg = command.args[0] ? path.resolve(command.args[0]) : "";
-  if (
+  const isNodeServeFallback =
     command.command === process.execPath
     && command.args.length === 1
-    && command.args[0] === "serve"
-  ) {
+    && command.args[0] === "serve";
+  if (isNodeServeFallback) {
     const entry = typeof process.argv[1] === "string" && process.argv[1].trim()
       ? path.resolve(process.argv[1])
       : "";
     const distPath = resolveCliDistPath(entry);
-    if (distPath) return fileSha256(distPath);
+    return distPath ? fileSha256(distPath) : null;
   }
   if (command.command === process.execPath && firstArg && fs.existsSync(firstArg)) {
     return fileSha256(firstArg);
   }
-  if (fs.existsSync(command.command)) {
+  if (command.command !== process.execPath && fs.existsSync(command.command)) {
     return fileSha256(path.resolve(command.command));
   }
   return null;

--- a/apps/ade-cli/src/serviceManager/common.ts
+++ b/apps/ade-cli/src/serviceManager/common.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { createHash } from "node:crypto";
 import path from "node:path";
 import type { SpawnSyncOptions } from "node:child_process";
 
@@ -71,6 +72,76 @@ function runtimeEnvironment(): Record<string, string> | undefined {
   return Object.keys(env).length > 0 ? env : undefined;
 }
 
+function fileSha256(filePath: string): string | null {
+  try {
+    return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+function resolveCliPackageRoot(entryPath: string): string | null {
+  const seen = new Set<string>();
+  const starts = [entryPath ? path.dirname(entryPath) : null, process.cwd()];
+  for (const start of starts) {
+    if (!start) continue;
+    let cursor = path.resolve(start);
+    while (!seen.has(cursor)) {
+      seen.add(cursor);
+      const packageJson = path.join(cursor, "package.json");
+      const srcCli = path.join(cursor, "src", "cli.ts");
+      if (fs.existsSync(packageJson) && fs.existsSync(srcCli)) {
+        return cursor;
+      }
+      const parent = path.dirname(cursor);
+      if (parent === cursor) break;
+      cursor = parent;
+    }
+  }
+  return null;
+}
+
+function resolveCliDistPath(entryPath: string): string | null {
+  const packageRoot = resolveCliPackageRoot(entryPath);
+  if (!packageRoot) return null;
+  const distPath = path.join(packageRoot, "dist", "cli.cjs");
+  return fs.existsSync(distPath) ? distPath : null;
+}
+
+export function resolveAdeServiceCommandBuildHash(command: AdeServiceCommand): string | null {
+  const firstArg = command.args[0] ? path.resolve(command.args[0]) : "";
+  if (
+    command.command === process.execPath
+    && command.args.length === 1
+    && command.args[0] === "serve"
+  ) {
+    const entry = typeof process.argv[1] === "string" && process.argv[1].trim()
+      ? path.resolve(process.argv[1])
+      : "";
+    const distPath = resolveCliDistPath(entry);
+    if (distPath) return fileSha256(distPath);
+  }
+  if (command.command === process.execPath && firstArg && fs.existsSync(firstArg)) {
+    return fileSha256(firstArg);
+  }
+  if (fs.existsSync(command.command)) {
+    return fileSha256(path.resolve(command.command));
+  }
+  return null;
+}
+
+function withRuntimeBuildHash(command: AdeServiceCommand): AdeServiceCommand {
+  const buildHash = resolveAdeServiceCommandBuildHash(command);
+  if (!buildHash) return command;
+  return {
+    ...command,
+    env: {
+      ...(command.env ?? {}),
+      ADE_RUNTIME_BUILD_HASH: buildHash,
+    },
+  };
+}
+
 export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
@@ -101,24 +172,24 @@ export function resolveAdeServeCommand(): AdeServiceCommand {
     : "";
   const isNodeScript = /\.(?:cjs|mjs|js|ts)$/i.test(entry) && fs.existsSync(entry);
   if (isNodeScript) {
-    return {
+    return withRuntimeBuildHash({
       command: process.execPath,
       args: [entry, "serve"],
       env: runtimeEnvironment(),
-    };
+    });
   }
   if (entry && fs.existsSync(entry)) {
-    return {
+    return withRuntimeBuildHash({
       command: entry,
       args: ["serve"],
       env: runtimeEnvironment(),
-    };
+    });
   }
-  return {
+  return withRuntimeBuildHash({
     command: process.execPath,
     args: ["serve"],
     env: runtimeEnvironment(),
-  };
+  });
 }
 
 export function renderCommand(command: AdeServiceCommand): string {


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fchat-20260608-160556-dbfe40e7 num=545 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fchat-20260608-160556-dbfe40e7&amp;pr=545">ade/chat-20260608-160556-dbfe40e7 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=545">PR #545</a>
</p>
<!-- /ade:link -->

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/ea733550-1e2d-4080-8238-4f5da3df27af/pull/545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a>
<!-- capy-pr-badge:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build hash tracking now automatically included with ADE runtime commands. The service receives a build identifier through environment configuration, enabling better tracking of which CLI version is executing.

* **Tests**
  * Added test coverage for build hash computation across different CLI execution contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic build hash tracking to ADE runtime service commands by computing a SHA-256 of the CLI binary or script and injecting it as `ADE_RUNTIME_BUILD_HASH` into the service environment. It also expands README documentation around channel brain restart procedures.

- Introduces a streaming `fileSha256` implementation that reads in 1 MB chunks with proper fd lifecycle management, a `resolveCliPackageRoot` walk to locate the dist artifact for the node serve fallback, and a `withRuntimeBuildHash` wrapper applied to all three branches of `resolveAdeServeCommand`.
- Adds four new test cases covering the script path, standalone binary, no-dist fallback, and dist-present fallback scenarios.
- README additions clarify that active sessions must be closed before restarting a channel brain and that the installed service should report the same runtime build hash as the packaged desktop CLI.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive, well-tested, and confined to the service command construction path.

The build hash injection is additive: it only adds a new env var and does not alter the command, args, or any existing env values. The streaming fileSha256 implementation handles fd lifecycle correctly and the branch logic in resolveAdeServiceCommandBuildHash correctly guards each case. The four new tests cover the realistic code paths end-to-end.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/serviceManager/common.ts | Adds streaming fileSha256, resolveCliPackageRoot/resolveCliDistPath helpers, and withRuntimeBuildHash wrapper; logic correctly branches across all three command forms with proper guards. |
| apps/ade-cli/src/serviceManager/common.test.ts | Four new tests exercise script-path, binary, no-dist, and dist-present code paths; test-local fileSha256 duplicates production logic but correctly validates hash equivalence. |
| README.md | Documentation-only additions clarifying channel brain restart procedure and build hash consistency expectations; no code impact. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ship: iteration 1 - address service hash..."](https://github.com/arul28/ade/commit/b2678bc77f05bb122e72c762a656cdda0fa236ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36321534)</sub>

<!-- /greptile_comment -->