### PR TITLE
Fix provider runtime readiness and browser attachment

### DIFF
--- a/apps/ade-cli/src/cursorCloud.ts
+++ b/apps/ade-cli/src/cursorCloud.ts
@@ -14,14 +14,49 @@
 
 import { Buffer } from "node:buffer";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 
 type CursorSdk = typeof import("@cursor/sdk");
 
+const requireFromRuntime = createRequire(
+  typeof __filename === "string" ? __filename : path.join(process.cwd(), "package.json"),
+);
 let sdkModulePromise: Promise<CursorSdk> | null = null;
+
+function cursorSdkLoadErrorText(error: unknown): string {
+  if (error instanceof Error) return `${error.name}: ${error.message}`;
+  return String(error);
+}
+
+function isCursorSdkResolutionError(error: unknown): boolean {
+  const code = error && typeof error === "object"
+    ? String((error as { code?: unknown }).code ?? "")
+    : "";
+  const message = cursorSdkLoadErrorText(error);
+  return code === "ERR_MODULE_NOT_FOUND"
+    || code === "MODULE_NOT_FOUND"
+    || /Cannot find package ['"]@cursor\/sdk['"]/i.test(message)
+    || /Cannot find module ['"]@cursor\/sdk['"]/i.test(message);
+}
+
 async function getSdk(): Promise<CursorSdk> {
   if (!sdkModulePromise) {
-    sdkModulePromise = import("@cursor/sdk");
+    sdkModulePromise = import("@cursor/sdk")
+      .catch((error) => {
+        if (!isCursorSdkResolutionError(error)) throw error;
+        try {
+          return requireFromRuntime("@cursor/sdk") as CursorSdk;
+        } catch (fallbackError) {
+          throw new Error(
+            `Failed to load @cursor/sdk via dynamic import or packaged runtime resolution. import=${cursorSdkLoadErrorText(error)} require=${cursorSdkLoadErrorText(fallbackError)}`,
+          );
+        }
+      })
+      .catch((error) => {
+        sdkModulePromise = null;
+        throw error;
+      });
   }
   return sdkModulePromise;
 }

--- a/apps/ade-cli/src/cursorCloud.ts
+++ b/apps/ade-cli/src/cursorCloud.ts
@@ -16,11 +16,12 @@ import { Buffer } from "node:buffer";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 type CursorSdk = typeof import("@cursor/sdk");
 
 const requireFromRuntime = createRequire(
-  typeof __filename === "string" ? __filename : path.join(process.cwd(), "package.json"),
+  typeof __filename === "string" ? __filename : fileURLToPath(import.meta.url),
 );
 let sdkModulePromise: Promise<CursorSdk> | null = null;
 

--- a/apps/ade-cli/src/tuiClient/components/ModelPicker/modelPickerLayout.ts
+++ b/apps/ade-cli/src/tuiClient/components/ModelPicker/modelPickerLayout.ts
@@ -106,7 +106,14 @@ export function modelPickerProviderAuthStatus(
     }
     return "unavailable";
   }
-  if (provider === "codex" || provider === "cursor" || provider === "droid") {
+  if (provider === "cursor") {
+    const connection = status.providerConnections?.cursor;
+    if (connection?.runtimeAvailable || status.availableProviders?.cursor === true) {
+      return "ready";
+    }
+    return "unavailable";
+  }
+  if (provider === "codex" || provider === "droid") {
     const connection = status.providerConnections?.[provider];
     if (connection?.authAvailable || connection?.runtimeAvailable || status.availableProviders?.[provider] === true || providerModelsCount(status, provider) > 0) {
       return "ready";

--- a/apps/ade-cli/tsup.config.ts
+++ b/apps/ade-cli/tsup.config.ts
@@ -38,7 +38,8 @@ export default defineConfig([
       bootstrap: "src/bootstrap.ts",
       adeRpcServer: "src/adeRpcServer.ts",
       ptyHostWorker: "../desktop/src/main/services/pty/ptyHostWorker.ts",
-      cursorSdkWorker: "../desktop/src/main/services/chat/cursorSdkWorker.ts"
+      cursorSdkWorker: "../desktop/src/main/services/chat/cursorSdkWorker.ts",
+      droidSdkWorker: "../desktop/src/main/services/chat/droidSdkWorker.ts"
     },
     format: ["cjs"],
     platform: "node",

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1458,6 +1458,10 @@ app.whenReady().then(async () => {
         tabRoots.add(normalizedRoot);
         windowProjectTabRoots.set(windowId, tabRoots);
       }
+      const win = BrowserWindow.fromId(windowId);
+      if (win && !win.isDestroyed()) {
+        builtInBrowserService.attachToWindow(win);
+      }
     }
     if (options.foreground ?? true) {
       setForegroundProject(normalizedRoot);

--- a/apps/desktop/src/main/services/ai/aiIntegrationService.ts
+++ b/apps/desktop/src/main/services/ai/aiIntegrationService.ts
@@ -76,6 +76,7 @@ import { getProviderRuntimeHealthVersion, resetProviderRuntimeHealth } from "./p
 import { resetClaudeRuntimeProbeCache } from "./claudeRuntimeProbe";
 import { runProviderTask } from "./providerTaskRunner";
 import { resolveClaudeCodeExecutable } from "./claudeCodeExecutable";
+import { loadCursorSdk } from "./cursorSdkLoader";
 
 export type AiTaskType =
   | "planning"
@@ -1074,7 +1075,7 @@ export function createAiIntegrationService(args: {
               ...verification,
               ok: false,
               message:
-                "Cursor account verification succeeded, but Cursor rejected this API key for agent/model access. Re-enter a key from the Cursor dashboard integrations page.",
+                "Cursor account verification succeeded, but Cursor rejected this API key for agent/model access. Re-enter a key from the Cursor dashboard API page.",
               source: apiEntry.source,
             };
           }
@@ -1105,7 +1106,7 @@ export function createAiIntegrationService(args: {
 
   const listCursorCloudRepositories = async (): Promise<CursorCloudRepository[]> => {
     const apiKey = await requireCursorCloudApiKey();
-    const { Cursor } = await import("@cursor/sdk");
+    const { Cursor } = await loadCursorSdk();
     const repos = await Cursor.repositories.list({ apiKey });
     return repos
       .map((repo) => ({ url: String(repo.url ?? "").trim() }))
@@ -1118,7 +1119,7 @@ export function createAiIntegrationService(args: {
     cursor?: string | null;
   }): Promise<CursorCloudListAgentsResult> => {
     const apiKey = await requireCursorCloudApiKey();
-    const { Agent } = await import("@cursor/sdk");
+    const { Agent } = await loadCursorSdk();
     const result = await Agent.list({
       runtime: "cloud",
       apiKey,
@@ -1140,7 +1141,7 @@ export function createAiIntegrationService(args: {
     const agentId = args.agentId.trim();
     if (!agentId) throw new Error("Cursor cloud agent id is required.");
     const apiKey = await requireCursorCloudApiKey();
-    const { Agent } = await import("@cursor/sdk");
+    const { Agent } = await loadCursorSdk();
     const result = await Agent.listRuns(agentId, {
       runtime: "cloud",
       apiKey,
@@ -1162,7 +1163,7 @@ export function createAiIntegrationService(args: {
     if (!repoUrl) throw new Error("Cursor cloud repo is required.");
     const idempotencyKey = args.idempotencyKey?.trim() || undefined;
     const apiKey = await requireCursorCloudApiKey();
-    const { Agent } = await import("@cursor/sdk");
+    const { Agent } = await loadCursorSdk();
     const agent = await Agent.create({
       apiKey,
       ...(idempotencyKey ? { idempotencyKey } : {}),
@@ -1198,7 +1199,7 @@ export function createAiIntegrationService(args: {
     const id = agentId.trim();
     if (!id) throw new Error("Cursor cloud agent id is required.");
     const apiKey = await requireCursorCloudApiKey();
-    const { Agent } = await import("@cursor/sdk");
+    const { Agent } = await loadCursorSdk();
     await Agent.archive(id, { apiKey });
   };
 
@@ -1206,7 +1207,7 @@ export function createAiIntegrationService(args: {
     const id = agentId.trim();
     if (!id) throw new Error("Cursor cloud agent id is required.");
     const apiKey = await requireCursorCloudApiKey();
-    const { Agent } = await import("@cursor/sdk");
+    const { Agent } = await loadCursorSdk();
     await Agent.unarchive(id, { apiKey });
   };
 
@@ -1214,7 +1215,7 @@ export function createAiIntegrationService(args: {
     const id = agentId.trim();
     if (!id) throw new Error("Cursor cloud agent id is required.");
     const apiKey = await requireCursorCloudApiKey();
-    const { Agent } = await import("@cursor/sdk");
+    const { Agent } = await loadCursorSdk();
     await Agent.delete(id, { apiKey });
   };
 
@@ -1222,7 +1223,7 @@ export function createAiIntegrationService(args: {
     const id = agentId.trim();
     if (!id) throw new Error("Cursor cloud agent id is required.");
     const apiKey = await requireCursorCloudApiKey();
-    const { Agent } = await import("@cursor/sdk");
+    const { Agent } = await loadCursorSdk();
     try {
       const raw = await Agent.get(id, { apiKey });
       return normalizeCursorCloudAgent(raw);
@@ -1237,7 +1238,7 @@ export function createAiIntegrationService(args: {
     const id = agentId.trim();
     if (!id) throw new Error("Cursor cloud agent id is required.");
     const apiKey = await requireCursorCloudApiKey();
-    const { Agent } = await import("@cursor/sdk");
+    const { Agent } = await loadCursorSdk();
     const cloudAgent = await Agent.resume(id, { apiKey });
     try {
       const artifacts = await cloudAgent.listArtifacts();
@@ -1264,7 +1265,7 @@ export function createAiIntegrationService(args: {
     if (!id) throw new Error("Cursor cloud agent id is required.");
     if (!artifactPath.length) throw new Error("Cursor cloud artifact path is required.");
     const apiKey = await requireCursorCloudApiKey();
-    const { Agent } = await import("@cursor/sdk");
+    const { Agent } = await loadCursorSdk();
     const cloudAgent = await Agent.resume(id, { apiKey });
     try {
       const buffer = await cloudAgent.downloadArtifact(artifactPath);

--- a/apps/desktop/src/main/services/ai/authDetector.test.ts
+++ b/apps/desktop/src/main/services/ai/authDetector.test.ts
@@ -7,6 +7,11 @@ import path from "node:path";
 const spawnMock = vi.fn();
 const execFileSyncMock = vi.fn();
 const getAllApiKeysMock = vi.fn();
+const cursorMeMock = vi.fn();
+const cursorModelsListMock = vi.fn();
+const reportProviderRuntimeAuthFailureMock = vi.fn();
+const reportProviderRuntimeFailureMock = vi.fn();
+const reportProviderRuntimeReadyMock = vi.fn();
 
 /** Helper: create a fake ChildProcess that immediately emits close with the given result. */
 function fakeChild(result: { status: number | null; stdout?: string; stderr?: string }) {
@@ -48,6 +53,23 @@ vi.mock("./apiKeyStore", () => ({
   getAllApiKeys: () => getAllApiKeysMock(),
 }));
 
+vi.mock("./cursorSdkLoader", () => ({
+  loadCursorSdk: async () => ({
+    Cursor: {
+      me: (...args: unknown[]) => cursorMeMock(...args),
+      models: {
+        list: (...args: unknown[]) => cursorModelsListMock(...args),
+      },
+    },
+  }),
+}));
+
+vi.mock("./providerRuntimeHealth", () => ({
+  reportProviderRuntimeAuthFailure: (...args: unknown[]) => reportProviderRuntimeAuthFailureMock(...args),
+  reportProviderRuntimeFailure: (...args: unknown[]) => reportProviderRuntimeFailureMock(...args),
+  reportProviderRuntimeReady: (...args: unknown[]) => reportProviderRuntimeReadyMock(...args),
+}));
+
 // Import AFTER mocks are set up — must re-import to reset the module-level cache.
 let detectAllAuth: typeof import("./authDetector").detectAllAuth;
 let detectCliAuthStatuses: typeof import("./authDetector").detectCliAuthStatuses;
@@ -64,6 +86,11 @@ function setPlatform(value: NodeJS.Platform): void {
 beforeEach(async () => {
   vi.resetModules();
   setPlatform("darwin");
+  cursorMeMock.mockReset();
+  cursorModelsListMock.mockReset();
+  reportProviderRuntimeAuthFailureMock.mockReset();
+  reportProviderRuntimeFailureMock.mockReset();
+  reportProviderRuntimeReadyMock.mockReset();
   const mod = await import("./authDetector");
   detectAllAuth = mod.detectAllAuth;
   detectCliAuthStatuses = mod.detectCliAuthStatuses;
@@ -576,6 +603,53 @@ describe("authDetector", () => {
     expect(result.ok).toBe(false);
     expect(result.message).toContain("API key is valid");
     expect(result.endpoint).toBe("https://api.openai.com/v1/models");
+  });
+
+  it("marks Cursor runtime ready only after API key and model access verification succeeds", async () => {
+    cursorMeMock.mockResolvedValue({ userEmail: "user@example.test" });
+    cursorModelsListMock.mockResolvedValue([{ id: "composer-1" }]);
+
+    const result = await verifyProviderApiKey("cursor", "crsr_test");
+
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain("user@example.test");
+    expect(result.endpoint).toBe("Cursor.me + Cursor.models.list");
+    expect(cursorMeMock).toHaveBeenCalledWith({ apiKey: "crsr_test" });
+    expect(cursorModelsListMock).toHaveBeenCalledWith({ apiKey: "crsr_test" });
+    expect(reportProviderRuntimeReadyMock).toHaveBeenCalledWith("cursor");
+    expect(reportProviderRuntimeAuthFailureMock).not.toHaveBeenCalled();
+    expect(reportProviderRuntimeFailureMock).not.toHaveBeenCalled();
+  });
+
+  it("does not mark Cursor runtime ready when model access verification fails", async () => {
+    cursorMeMock.mockResolvedValue({ userEmail: "user@example.test" });
+    cursorModelsListMock.mockRejectedValue(new Error("Forbidden: model access denied"));
+
+    const result = await verifyProviderApiKey("cursor", "crsr_test");
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("Authentication failed");
+    expect(result.endpoint).toBe("Cursor.me + Cursor.models.list");
+    expect(reportProviderRuntimeReadyMock).not.toHaveBeenCalled();
+    expect(reportProviderRuntimeAuthFailureMock).toHaveBeenCalledWith(
+      "cursor",
+      "Cursor rejected the configured API key. Check the key from the Cursor dashboard API page.",
+    );
+  });
+
+  it("does not mark Cursor runtime ready when model access returns no models", async () => {
+    cursorMeMock.mockResolvedValue({ userEmail: "user@example.test" });
+    cursorModelsListMock.mockResolvedValue([]);
+
+    const result = await verifyProviderApiKey("cursor", "crsr_test");
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("no available models");
+    expect(reportProviderRuntimeReadyMock).not.toHaveBeenCalled();
+    expect(reportProviderRuntimeFailureMock).toHaveBeenCalledWith(
+      "cursor",
+      "Cursor model verification returned no available models.",
+    );
   });
 
   it("returns auth failure for invalid API keys", async () => {

--- a/apps/desktop/src/main/services/ai/authDetector.ts
+++ b/apps/desktop/src/main/services/ai/authDetector.ts
@@ -17,8 +17,10 @@ import { inspectLocalProvider, clearLocalProviderInspectionCache } from "./local
 import { resolveDroidExecutable } from "./droidExecutable";
 import {
   reportProviderRuntimeAuthFailure,
+  reportProviderRuntimeFailure,
   reportProviderRuntimeReady,
 } from "./providerRuntimeHealth";
+import { loadCursorSdk } from "./cursorSdkLoader";
 
 type CliName = "claude" | "codex" | "cursor" | "droid";
 
@@ -797,7 +799,7 @@ async function verifyCursorApiKey(
 ): Promise<ApiKeyVerificationResult> {
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
   try {
-    const { Cursor } = await import("@cursor/sdk");
+    const { Cursor } = await loadCursorSdk();
     const user = await Promise.race([
       Cursor.me({ apiKey: key }),
       new Promise<never>((_, reject) => {
@@ -822,7 +824,9 @@ async function verifyCursorApiKey(
     const message = error instanceof Error ? error.message : String(error);
     const authFailed = /auth|unauthorized|forbidden|invalid|api key/i.test(message);
     if (authFailed) {
-      reportProviderRuntimeAuthFailure("cursor", "Cursor rejected the configured API key. Check the key from the Cursor dashboard integrations page.");
+      reportProviderRuntimeAuthFailure("cursor", "Cursor rejected the configured API key. Check the key from the Cursor dashboard API page.");
+    } else {
+      reportProviderRuntimeFailure("cursor", message);
     }
     return {
       provider: "cursor",

--- a/apps/desktop/src/main/services/ai/authDetector.ts
+++ b/apps/desktop/src/main/services/ai/authDetector.ts
@@ -801,7 +801,14 @@ async function verifyCursorApiKey(
   try {
     const { Cursor } = await loadCursorSdk();
     const user = await Promise.race([
-      Cursor.me({ apiKey: key }),
+      (async () => {
+        const account = await Cursor.me({ apiKey: key });
+        const models = await Cursor.models.list({ apiKey: key });
+        if (!Array.isArray(models) || models.length === 0) {
+          throw new Error("Cursor model verification returned no available models.");
+        }
+        return account;
+      })(),
       new Promise<never>((_, reject) => {
         timeoutHandle = setTimeout(
           () => reject(new Error("Verification timed out.")),
@@ -816,7 +823,7 @@ async function verifyCursorApiKey(
       message: user.userEmail
         ? `Connection verified for ${user.userEmail}.`
         : "Connection verified successfully.",
-      endpoint: "Cursor.me",
+      endpoint: "Cursor.me + Cursor.models.list",
       statusCode: null,
       verifiedAt,
     };
@@ -832,7 +839,7 @@ async function verifyCursorApiKey(
       provider: "cursor",
       ok: false,
       message: authFailed ? "Authentication failed. Check API key." : `Verification request failed: ${message}`,
-      endpoint: "Cursor.me",
+      endpoint: "Cursor.me + Cursor.models.list",
       statusCode: null,
       verifiedAt,
     };

--- a/apps/desktop/src/main/services/ai/cursorSdkLoader.ts
+++ b/apps/desktop/src/main/services/ai/cursorSdkLoader.ts
@@ -1,0 +1,68 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import type * as CursorSdkModuleTypes from "@cursor/sdk";
+
+export type CursorSdkModule = typeof CursorSdkModuleTypes;
+
+const requireFromRuntime = createRequire(
+  typeof __filename === "string" ? __filename : path.join(process.cwd(), "package.json"),
+);
+
+let sdkModule: CursorSdkModule | null = null;
+let sdkModulePromise: Promise<CursorSdkModule> | null = null;
+
+function errorText(error: unknown): string {
+  if (error instanceof Error) return `${error.name}: ${error.message}`;
+  return String(error);
+}
+
+export function isCursorSdkResolutionError(error: unknown): boolean {
+  const message = errorText(error);
+  const code = error && typeof error === "object"
+    ? String((error as { code?: unknown }).code ?? "")
+    : "";
+  return code === "ERR_MODULE_NOT_FOUND"
+    || code === "MODULE_NOT_FOUND"
+    || /Cannot find package ['"]@cursor\/sdk['"]/i.test(message)
+    || /Cannot find module ['"]@cursor\/sdk['"]/i.test(message);
+}
+
+function loadCursorSdkWithRequire(originalError: unknown): CursorSdkModule {
+  try {
+    return requireFromRuntime("@cursor/sdk") as CursorSdkModule;
+  } catch (fallbackError) {
+    if (isCursorSdkResolutionError(originalError)) {
+      const error = new Error(
+        `Failed to load @cursor/sdk via dynamic import or packaged runtime resolution. import=${errorText(originalError)} require=${errorText(fallbackError)}`,
+      );
+      (error as { cause?: unknown }).cause = originalError;
+      throw error;
+    }
+    throw originalError instanceof Error ? originalError : fallbackError;
+  }
+}
+
+export async function loadCursorSdk(): Promise<CursorSdkModule> {
+  if (sdkModule) return sdkModule;
+  if (!sdkModulePromise) {
+    sdkModulePromise = import("@cursor/sdk")
+      .catch((error) => {
+        if (!isCursorSdkResolutionError(error)) throw error;
+        return loadCursorSdkWithRequire(error);
+      })
+      .then((loaded) => {
+        sdkModule = loaded;
+        return loaded;
+      })
+      .catch((error) => {
+        sdkModulePromise = null;
+        throw error;
+      });
+  }
+  return sdkModulePromise;
+}
+
+export function resetCursorSdkLoaderForTests(): void {
+  sdkModule = null;
+  sdkModulePromise = null;
+}

--- a/apps/desktop/src/main/services/ai/cursorSdkLoader.ts
+++ b/apps/desktop/src/main/services/ai/cursorSdkLoader.ts
@@ -1,11 +1,11 @@
 import { createRequire } from "node:module";
-import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type * as CursorSdkModuleTypes from "@cursor/sdk";
 
 export type CursorSdkModule = typeof CursorSdkModuleTypes;
 
 const requireFromRuntime = createRequire(
-  typeof __filename === "string" ? __filename : path.join(process.cwd(), "package.json"),
+  typeof __filename === "string" ? __filename : fileURLToPath(import.meta.url),
 );
 
 let sdkModule: CursorSdkModule | null = null;
@@ -31,14 +31,11 @@ function loadCursorSdkWithRequire(originalError: unknown): CursorSdkModule {
   try {
     return requireFromRuntime("@cursor/sdk") as CursorSdkModule;
   } catch (fallbackError) {
-    if (isCursorSdkResolutionError(originalError)) {
-      const error = new Error(
-        `Failed to load @cursor/sdk via dynamic import or packaged runtime resolution. import=${errorText(originalError)} require=${errorText(fallbackError)}`,
-      );
-      (error as { cause?: unknown }).cause = originalError;
-      throw error;
-    }
-    throw originalError instanceof Error ? originalError : fallbackError;
+    const error = new Error(
+      `Failed to load @cursor/sdk via dynamic import or packaged runtime resolution. import=${errorText(originalError)} require=${errorText(fallbackError)}`,
+    );
+    (error as { cause?: unknown }).cause = originalError;
+    throw error;
   }
 }
 

--- a/apps/desktop/src/main/services/ai/droidSdkLoader.ts
+++ b/apps/desktop/src/main/services/ai/droidSdkLoader.ts
@@ -1,11 +1,11 @@
 import { createRequire } from "node:module";
-import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type * as DroidSdkModuleTypes from "@factory/droid-sdk";
 
 export type DroidSdkModule = typeof DroidSdkModuleTypes;
 
 const requireFromRuntime = createRequire(
-  typeof __filename === "string" ? __filename : path.join(process.cwd(), "package.json"),
+  typeof __filename === "string" ? __filename : fileURLToPath(import.meta.url),
 );
 
 let sdkModule: DroidSdkModule | null = null;
@@ -31,14 +31,11 @@ function loadDroidSdkWithRequire(originalError: unknown): DroidSdkModule {
   try {
     return requireFromRuntime("@factory/droid-sdk") as DroidSdkModule;
   } catch (fallbackError) {
-    if (isDroidSdkResolutionError(originalError)) {
-      const error = new Error(
-        `Failed to load @factory/droid-sdk via dynamic import or packaged runtime resolution. import=${errorText(originalError)} require=${errorText(fallbackError)}`,
-      );
-      (error as { cause?: unknown }).cause = originalError;
-      throw error;
-    }
-    throw originalError instanceof Error ? originalError : fallbackError;
+    const error = new Error(
+      `Failed to load @factory/droid-sdk via dynamic import or packaged runtime resolution. import=${errorText(originalError)} require=${errorText(fallbackError)}`,
+    );
+    (error as { cause?: unknown }).cause = originalError;
+    throw error;
   }
 }
 

--- a/apps/desktop/src/main/services/ai/droidSdkLoader.ts
+++ b/apps/desktop/src/main/services/ai/droidSdkLoader.ts
@@ -1,0 +1,68 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import type * as DroidSdkModuleTypes from "@factory/droid-sdk";
+
+export type DroidSdkModule = typeof DroidSdkModuleTypes;
+
+const requireFromRuntime = createRequire(
+  typeof __filename === "string" ? __filename : path.join(process.cwd(), "package.json"),
+);
+
+let sdkModule: DroidSdkModule | null = null;
+let sdkModulePromise: Promise<DroidSdkModule> | null = null;
+
+function errorText(error: unknown): string {
+  if (error instanceof Error) return `${error.name}: ${error.message}`;
+  return String(error);
+}
+
+export function isDroidSdkResolutionError(error: unknown): boolean {
+  const message = errorText(error);
+  const code = error && typeof error === "object"
+    ? String((error as { code?: unknown }).code ?? "")
+    : "";
+  return code === "ERR_MODULE_NOT_FOUND"
+    || code === "MODULE_NOT_FOUND"
+    || /Cannot find package ['"]@factory\/droid-sdk['"]/i.test(message)
+    || /Cannot find module ['"]@factory\/droid-sdk['"]/i.test(message);
+}
+
+function loadDroidSdkWithRequire(originalError: unknown): DroidSdkModule {
+  try {
+    return requireFromRuntime("@factory/droid-sdk") as DroidSdkModule;
+  } catch (fallbackError) {
+    if (isDroidSdkResolutionError(originalError)) {
+      const error = new Error(
+        `Failed to load @factory/droid-sdk via dynamic import or packaged runtime resolution. import=${errorText(originalError)} require=${errorText(fallbackError)}`,
+      );
+      (error as { cause?: unknown }).cause = originalError;
+      throw error;
+    }
+    throw originalError instanceof Error ? originalError : fallbackError;
+  }
+}
+
+export async function loadDroidSdk(): Promise<DroidSdkModule> {
+  if (sdkModule) return sdkModule;
+  if (!sdkModulePromise) {
+    sdkModulePromise = import("@factory/droid-sdk")
+      .catch((error) => {
+        if (!isDroidSdkResolutionError(error)) throw error;
+        return loadDroidSdkWithRequire(error);
+      })
+      .then((loaded) => {
+        sdkModule = loaded;
+        return loaded;
+      })
+      .catch((error) => {
+        sdkModulePromise = null;
+        throw error;
+      });
+  }
+  return sdkModulePromise;
+}
+
+export function resetDroidSdkLoaderForTests(): void {
+  sdkModule = null;
+  sdkModulePromise = null;
+}

--- a/apps/desktop/src/main/services/ai/providerConnectionStatus.test.ts
+++ b/apps/desktop/src/main/services/ai/providerConnectionStatus.test.ts
@@ -229,7 +229,7 @@ describe("buildProviderConnections", () => {
     expect(result.claude.blocker).toBe("ADE could not launch the Claude runtime from this packaged app session.");
   });
 
-  it("marks Cursor runtime available through the SDK when an env API key is set", async () => {
+  it("requires Cursor SDK readiness before marking runtime available for an env API key", async () => {
     const prevKey = process.env.CURSOR_API_KEY;
     const prevAdminKey = process.env.CURSOR_ADMIN_API_KEY;
     process.env.CURSOR_API_KEY = "test-key";
@@ -248,9 +248,39 @@ describe("buildProviderConnections", () => {
       );
       expect(result.cursor.authAvailable).toBe(true);
       expect(result.cursor.runtimeDetected).toBe(true);
-      expect(result.cursor.runtimeAvailable).toBe(true);
+      expect(result.cursor.runtimeAvailable).toBe(false);
       expect(result.cursor.usageAvailable).toBe(false);
       expect(result.cursor.path).toBe("@cursor/sdk");
+      expect(result.cursor.blocker).toBe("Verify the Cursor API key to enable Cursor chat.");
+    } finally {
+      if (prevKey === undefined) delete process.env.CURSOR_API_KEY;
+      else process.env.CURSOR_API_KEY = prevKey;
+      if (prevAdminKey === undefined) delete process.env.CURSOR_ADMIN_API_KEY;
+      else process.env.CURSOR_ADMIN_API_KEY = prevAdminKey;
+    }
+  });
+
+  it("marks Cursor runtime available after the SDK probe reports ready", async () => {
+    const prevKey = process.env.CURSOR_API_KEY;
+    const prevAdminKey = process.env.CURSOR_ADMIN_API_KEY;
+    process.env.CURSOR_API_KEY = "test-key";
+    delete process.env.CURSOR_ADMIN_API_KEY;
+    mockState.getProviderRuntimeHealth.mockImplementation((provider: string) => {
+      if (provider === "cursor") {
+        return {
+          provider: "cursor",
+          state: "ready",
+          message: null,
+          checkedAt: "2026-05-01T12:00:00.000Z",
+        };
+      }
+      return null;
+    });
+    try {
+      const result = await buildProviderConnections(mergeCliStatuses([]));
+      expect(result.cursor.authAvailable).toBe(true);
+      expect(result.cursor.runtimeDetected).toBe(true);
+      expect(result.cursor.runtimeAvailable).toBe(true);
       expect(result.cursor.blocker).toBeNull();
     } finally {
       if (prevKey === undefined) delete process.env.CURSOR_API_KEY;
@@ -268,7 +298,7 @@ describe("buildProviderConnections", () => {
     try {
       const result = await buildProviderConnections(mergeCliStatuses([]));
       expect(result.cursor.authAvailable).toBe(true);
-      expect(result.cursor.runtimeAvailable).toBe(true);
+      expect(result.cursor.runtimeAvailable).toBe(false);
       expect(result.cursor.usageAvailable).toBe(true);
     } finally {
       if (prevKey === undefined) delete process.env.CURSOR_API_KEY;

--- a/apps/desktop/src/main/services/ai/providerConnectionStatus.ts
+++ b/apps/desktop/src/main/services/ai/providerConnectionStatus.ts
@@ -200,20 +200,23 @@ export async function buildProviderConnections(
   if (cursorEnvAuth) cursorCredsSource = "cursor-env";
   else if (cursorStoredAuth) cursorCredsSource = "cursor-api-key-store";
   else if (cursorAdminEnvAuth) cursorCredsSource = "cursor-admin-env";
-  // Runtime is bundled with the app — it always exists. Only auth-related
-  // fields should depend on whether a Cursor API key is present.
+  // The SDK package is bundled with the app, but Cursor chat is only runtime
+  // ready after verification/model discovery proves the SDK can load and the
+  // key can access agent models.
   const cursorFlags = {
     runtimeDetected: true,
     cliAuthenticated: false,
     cliExplicitlyUnauthenticated: false,
     localCredsDetected: cursorAuthAvailable,
     authAvailable: cursorAuthAvailable,
-    runtimeAvailable: cursorSdkAuth,
+    runtimeAvailable: cursorRuntimeHealth?.state === "ready",
   };
 
   let cursorBlocker: string | null;
-  if (cursorSdkAuth) {
+  if (cursorFlags.runtimeAvailable) {
     cursorBlocker = null;
+  } else if (cursorSdkAuth) {
+    cursorBlocker = "Verify the Cursor API key to enable Cursor chat.";
   } else if (cursorAdminUsageAuth) {
     cursorBlocker = "Cursor Admin API key is configured for usage; add a Cursor agent API key for Cursor runtime access.";
   } else if (cursorAdminEnvAuth) {
@@ -221,7 +224,7 @@ export async function buildProviderConnections(
   } else if (cursorStoreUnavailable) {
     cursorBlocker = "ADE could not read the Cursor API key store yet. Retry after the key store is ready.";
   } else {
-    cursorBlocker = "Enter a Cursor API key from https://cursor.com/dashboard/integrations.";
+    cursorBlocker = "Enter a Cursor API key from https://cursor.com/dashboard/api.";
   }
 
   const cursor: AiProviderConnectionStatus = {

--- a/apps/desktop/src/main/services/ai/providerTaskRunner.ts
+++ b/apps/desktop/src/main/services/ai/providerTaskRunner.ts
@@ -14,6 +14,7 @@ import { getApiKey } from "./apiKeyStore";
 import { parseStructuredOutput } from "./utils";
 import { runOpenCodeTextPrompt } from "../opencode/openCodeRuntime";
 import { resolveCliSpawnInvocation, terminateProcessTree } from "../shared/processExecution";
+import { loadCursorSdk } from "./cursorSdkLoader";
 
 export type ProviderTaskRunnerArgs = {
   cwd: string;
@@ -336,7 +337,7 @@ async function runCursorTask(args: ProviderTaskRunnerArgs): Promise<ProviderTask
   if (!apiKey) {
     throw new Error("Cursor tasks require a Cursor API key. Add one in Settings > AI Providers.");
   }
-  const { Agent } = await import("@cursor/sdk");
+  const { Agent } = await loadCursorSdk();
   const agent = args.sessionId?.trim()
     ? await Agent.resume(args.sessionId.trim(), {
         apiKey,

--- a/apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.test.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.test.ts
@@ -359,16 +359,22 @@ let fakeWindowId = 1;
 
 function fakeBrowserWindow() {
   const children: unknown[] = [];
+  const addChildViewCalls: unknown[] = [];
+  const removeChildViewCalls: unknown[] = [];
   return {
     id: fakeWindowId++,
     isDestroyed: () => false,
     getContentBounds: () => ({ x: 0, y: 0, width: 1280, height: 720 }),
+    addChildViewCalls,
+    removeChildViewCalls,
     contentView: {
       children,
       addChildView: (view: unknown) => {
+        addChildViewCalls.push(view);
         if (!children.includes(view)) children.push(view);
       },
       removeChildView: (view: unknown) => {
+        removeChildViewCalls.push(view);
         const index = children.indexOf(view);
         if (index >= 0) children.splice(index, 1);
       },
@@ -705,6 +711,164 @@ describe("createBuiltInBrowserService — bounds and status dedupe", () => {
     expect(service.getStatus(browserWin).url).toBe("https://beta.example.test/");
     expect(service.getStatus({ projectRoot: "/Users/ade/project-alpha" }).profileProjectRoot).toBe("/Users/ade/project-alpha");
     expect(service.getStatus({ projectRoot: "/Users/ade/project-alpha" }).url).toBe("https://alpha.example.test/");
+  });
+
+  it("attaches project-scoped browser views without waiting for a window focus event", async () => {
+    const projectRootByWindow = new Map<number, string>();
+    const windowsByProjectRoot = new Map<string, ReturnType<typeof fakeBrowserWindow>>();
+    const service = createBuiltInBrowserService({
+      onEvent: collector.onEvent,
+      getProjectRootForWindow: (win) => projectRootByWindow.get(win.id) ?? null,
+      getWindowForProjectRoot: (projectRoot) =>
+        (
+          windowsByProjectRoot.get(projectRoot) as unknown as
+            Parameters<ReturnType<typeof createBuiltInBrowserService>["attachToWindow"]>[0] | undefined
+        ) ?? null,
+    });
+    const win = fakeBrowserWindow();
+    const browserWin = win as unknown as Parameters<typeof service.attachToWindow>[0];
+    windowsByProjectRoot.set("/Users/ade/project-alpha", win);
+    windowsByProjectRoot.set("/Users/ade/project-beta", win);
+
+    service.attachToWindow(browserWin);
+    projectRootByWindow.set(win.id, "/Users/ade/project-alpha");
+    await service.setBounds({
+      projectRoot: "/Users/ade/project-alpha",
+      x: 12,
+      y: 24,
+      width: 640,
+      height: 360,
+      visible: true,
+    });
+
+    expect(service.getStatus({ projectRoot: "/Users/ade/project-alpha" })).toMatchObject({
+      attached: true,
+      profileProjectRoot: "/Users/ade/project-alpha",
+      visible: true,
+    });
+    expect(win.contentView.children).toHaveLength(1);
+
+    projectRootByWindow.set(win.id, "/Users/ade/project-beta");
+    await service.setBounds({
+      projectRoot: "/Users/ade/project-beta",
+      x: 12,
+      y: 24,
+      width: 640,
+      height: 360,
+      visible: true,
+    });
+
+    expect(service.getStatus({ projectRoot: "/Users/ade/project-beta" })).toMatchObject({
+      attached: true,
+      profileProjectRoot: "/Users/ade/project-beta",
+      visible: true,
+    });
+    expect(win.contentView.children).toHaveLength(1);
+    expect(service.getStatus({ projectRoot: "/Users/ade/project-alpha" })).toMatchObject({
+      attached: false,
+      visible: false,
+    });
+  });
+
+  it("keeps same-project view attachment stable across repeated project-scoped calls", async () => {
+    const projectRootByWindow = new Map<number, string>();
+    const windowsByProjectRoot = new Map<string, ReturnType<typeof fakeBrowserWindow>>();
+    const service = createBuiltInBrowserService({
+      onEvent: collector.onEvent,
+      getProjectRootForWindow: (win) => projectRootByWindow.get(win.id) ?? null,
+      getWindowForProjectRoot: (projectRoot) =>
+        (
+          windowsByProjectRoot.get(projectRoot) as unknown as
+            Parameters<ReturnType<typeof createBuiltInBrowserService>["attachToWindow"]>[0] | undefined
+        ) ?? null,
+    });
+    const win = fakeBrowserWindow();
+    const browserWin = win as unknown as Parameters<typeof service.attachToWindow>[0];
+    projectRootByWindow.set(win.id, "/Users/ade/project-alpha");
+    windowsByProjectRoot.set("/Users/ade/project-alpha", win);
+
+    service.attachToWindow(browserWin);
+    await service.setBounds({
+      projectRoot: "/Users/ade/project-alpha",
+      x: 12,
+      y: 24,
+      width: 640,
+      height: 360,
+      visible: true,
+    });
+
+    expect(win.contentView.children).toHaveLength(1);
+    const attachedView = win.contentView.children[0];
+    const addCalls = win.addChildViewCalls.length;
+    const removeCalls = win.removeChildViewCalls.length;
+
+    expect(service.getStatus({ projectRoot: "/Users/ade/project-alpha" })).toMatchObject({
+      attached: true,
+      visible: true,
+    });
+    await service.setBounds({
+      projectRoot: "/Users/ade/project-alpha",
+      x: 12,
+      y: 24,
+      width: 640,
+      height: 360,
+      visible: true,
+    });
+
+    expect(win.contentView.children).toEqual([attachedView]);
+    expect(win.addChildViewCalls).toHaveLength(addCalls);
+    expect(win.removeChildViewCalls).toHaveLength(removeCalls);
+  });
+
+  it("keeps project browser views attached independently in separate ADE windows", async () => {
+    const projectRootByWindow = new Map<number, string>();
+    const windowsByProjectRoot = new Map<string, ReturnType<typeof fakeBrowserWindow>>();
+    const service = createBuiltInBrowserService({
+      onEvent: collector.onEvent,
+      getProjectRootForWindow: (win) => projectRootByWindow.get(win.id) ?? null,
+      getWindowForProjectRoot: (projectRoot) =>
+        (
+          windowsByProjectRoot.get(projectRoot) as unknown as
+            Parameters<ReturnType<typeof createBuiltInBrowserService>["attachToWindow"]>[0] | undefined
+        ) ?? null,
+    });
+    const winA = fakeBrowserWindow();
+    const winB = fakeBrowserWindow();
+    projectRootByWindow.set(winA.id, "/Users/ade/project-alpha");
+    projectRootByWindow.set(winB.id, "/Users/ade/project-beta");
+    windowsByProjectRoot.set("/Users/ade/project-alpha", winA);
+    windowsByProjectRoot.set("/Users/ade/project-beta", winB);
+
+    await service.setBounds({
+      projectRoot: "/Users/ade/project-alpha",
+      x: 12,
+      y: 24,
+      width: 640,
+      height: 360,
+      visible: true,
+    });
+    await service.setBounds({
+      projectRoot: "/Users/ade/project-beta",
+      x: 20,
+      y: 32,
+      width: 800,
+      height: 420,
+      visible: true,
+    });
+
+    expect(service.getStatus({ projectRoot: "/Users/ade/project-alpha" })).toMatchObject({
+      attached: true,
+      profileProjectRoot: "/Users/ade/project-alpha",
+      visible: true,
+    });
+    expect(service.getStatus({ projectRoot: "/Users/ade/project-beta" })).toMatchObject({
+      attached: true,
+      profileProjectRoot: "/Users/ade/project-beta",
+      visible: true,
+    });
+    expect(winA.contentView.children).toHaveLength(1);
+    expect(winB.contentView.children).toHaveLength(1);
+    expect(winA.contentView.children[0]).not.toBe(winB.contentView.children[0]);
   });
 
   it("re-resolves the active window profile for bridge-style calls after project switches", async () => {

--- a/apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.ts
@@ -372,9 +372,11 @@ export function createBuiltInBrowserService(args: {
     if (!win) {
       throw new Error(`No ADE browser window is open for project: ${normalized}`);
     }
-    return serviceForWindowProfile(win, profileForProjectRoot(normalized), {
+    const service = serviceForWindowProfile(win, profileForProjectRoot(normalized), {
       markActive: projectRootsMatch(projectRootForWindow(win), normalized),
     });
+    service.attachToWindow(win);
+    return service;
   };
 
   const serviceForInput = (
@@ -1290,6 +1292,11 @@ function createBuiltInBrowserWindowService(args: {
   };
 
   const attachToWindow = (nextWin: BrowserWindow): void => {
+    if (win === nextWin) {
+      attachViewsToCurrentWindow();
+      emitStatus();
+      return;
+    }
     if (win && winClosedListener) {
       win.removeListener("closed", winClosedListener);
       winClosedListener = null;

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -3123,7 +3123,7 @@ const DEFAULT_SESSION_TITLES_NORMALIZED = new Set(
     .map((title) => title.toLowerCase()),
 );
 const CURSOR_RUNTIME_AUTH_ERROR =
-  "Cursor rejected the configured API key for agent/model access. Re-enter a Cursor API key from the Cursor dashboard integrations page.";
+  "Cursor rejected the configured API key for agent/model access. Re-enter a Cursor API key from the Cursor dashboard API page.";
 
 function isCursorRuntimeAuthError(error: unknown): boolean {
   const statusCode = readErrorStatusCode(error);

--- a/apps/desktop/src/main/services/chat/cursorModelsDiscovery.test.ts
+++ b/apps/desktop/src/main/services/chat/cursorModelsDiscovery.test.ts
@@ -643,8 +643,13 @@ describe("parseCursorCliModelsStdout", () => {
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    const afterFailure = await discoverCursorSdkModelDescriptors("crsr_test");
+    cursorModelsListMock.mockClear();
+    fetchMock.mockClear();
+
+    const afterFailure = await discoverCursorSdkModelDescriptors("crsr_test", { mode: "cached-or-fallback" });
     expect(afterFailure).toEqual([]);
+    expect(cursorModelsListMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("bounds direct Cursor SDK model list discovery with a timeout", async () => {

--- a/apps/desktop/src/main/services/chat/cursorModelsDiscovery.test.ts
+++ b/apps/desktop/src/main/services/chat/cursorModelsDiscovery.test.ts
@@ -3,6 +3,7 @@ import type { ModelDescriptor } from "../../../shared/modelRegistry";
 
 const cursorModelsListMock = vi.hoisted(() => vi.fn());
 const reportProviderRuntimeAuthFailureMock = vi.hoisted(() => vi.fn());
+const reportProviderRuntimeFailureMock = vi.hoisted(() => vi.fn());
 const reportProviderRuntimeReadyMock = vi.hoisted(() => vi.fn());
 const spawnAsyncMock = vi.hoisted(() => vi.fn());
 
@@ -16,6 +17,7 @@ vi.mock("@cursor/sdk", () => ({
 
 vi.mock("../ai/providerRuntimeHealth", () => ({
   reportProviderRuntimeAuthFailure: (...args: unknown[]) => reportProviderRuntimeAuthFailureMock(...args),
+  reportProviderRuntimeFailure: (...args: unknown[]) => reportProviderRuntimeFailureMock(...args),
   reportProviderRuntimeReady: (...args: unknown[]) => reportProviderRuntimeReadyMock(...args),
 }));
 
@@ -43,6 +45,7 @@ import {
 beforeEach(() => {
   cursorModelsListMock.mockReset();
   reportProviderRuntimeAuthFailureMock.mockReset();
+  reportProviderRuntimeFailureMock.mockReset();
   reportProviderRuntimeReadyMock.mockReset();
   spawnAsyncMock.mockReset();
   clearCursorCliModelsCache();
@@ -604,6 +607,28 @@ describe("parseCursorCliModelsStdout", () => {
       failureKind: "auth",
     });
     expect(freshProbe.fromCache).toBeUndefined();
+  });
+
+  it("suppresses warmed Cursor SDK cache after an SDK runtime failure", async () => {
+    cursorModelsListMock.mockResolvedValueOnce([{ id: "cached-model", displayName: "Cached Model" }]);
+    await expect(probeCursorSdkModelDiscovery("crsr_test", { timeoutMs: 1_000 })).resolves.toMatchObject({
+      rows: [{ id: "cached-model", displayName: "Cached Model" }],
+      failureKind: null,
+    });
+
+    cursorModelsListMock.mockRejectedValue(new Error("Cannot find package '@cursor/sdk' imported from /Applications/ADE Beta.app/Contents/Resources/ade-cli/cli.js"));
+
+    await expect(probeCursorSdkModelDiscovery("crsr_test", { timeoutMs: 1_000 })).resolves.toMatchObject({
+      rows: [],
+      failureKind: "unavailable",
+    });
+
+    await expect(discoverCursorSdkModelDescriptors("crsr_test", { mode: "cached-only" })).resolves.toEqual([]);
+    expect(resolveCachedCursorModelAvailability("cursor/cached-model", "crsr_test")).toBeNull();
+    expect(reportProviderRuntimeFailureMock).toHaveBeenCalledWith(
+      "cursor",
+      expect.stringContaining("Cannot find package '@cursor/sdk'"),
+    );
   });
 
   it("suppresses fallback rows after a warm auth failure", async () => {

--- a/apps/desktop/src/main/services/chat/cursorModelsDiscovery.ts
+++ b/apps/desktop/src/main/services/chat/cursorModelsDiscovery.ts
@@ -10,8 +10,10 @@ import type { SDKModel } from "@cursor/sdk";
 import { createHash } from "node:crypto";
 import {
   reportProviderRuntimeAuthFailure,
+  reportProviderRuntimeFailure,
   reportProviderRuntimeReady,
 } from "../ai/providerRuntimeHealth";
+import { isCursorSdkResolutionError, loadCursorSdk } from "../ai/cursorSdkLoader";
 
 export type CursorModelParameterValue = { id: string; value: string };
 export type CursorModelParameterDefinition = {
@@ -54,7 +56,7 @@ const TTL_MS = 120_000;
 const SDK_MODEL_LIST_TIMEOUT_MS = 5_000;
 const CURSOR_MODELS_API_URL = "https://api.cursor.com/v0/models";
 const CURSOR_AGENT_AUTH_BLOCKER =
-  "Cursor rejected the configured API key for agent/model access. Re-enter a Cursor API key from the Cursor dashboard integrations page.";
+  "Cursor rejected the configured API key for agent/model access. Re-enter a Cursor API key from the Cursor dashboard API page.";
 
 class CursorModelDiscoveryError extends Error {
   readonly kind: CursorModelDiscoveryFailureKind;
@@ -528,6 +530,8 @@ function recordCursorModelDiscoveryFailure(error: unknown): CursorModelDiscovery
   const discoveryError = toCursorModelDiscoveryError(error);
   if (discoveryError.kind === "auth") {
     reportProviderRuntimeAuthFailure("cursor", CURSOR_AGENT_AUTH_BLOCKER);
+  } else if (discoveryError.kind === "unavailable") {
+    reportProviderRuntimeFailure("cursor", discoveryError.message);
   }
   return discoveryError;
 }
@@ -623,6 +627,14 @@ function getCachedCursorSdkModels(apiKey?: string | null): CursorCliModelRow[] |
   const now = Date.now();
   const normalizedApiKey = apiKey?.trim() || undefined;
   const keyHash = hashKeyForCache(normalizedApiKey);
+  if (
+    sdkLastFailure
+    && sdkLastFailure.keyHash === keyHash
+    && now - sdkLastFailure.at < TTL_MS
+    && (sdkLastFailure.kind === "auth" || sdkLastFailure.kind === "unavailable")
+  ) {
+    return null;
+  }
   if (sdkCached && sdkCached.keyHash === keyHash && now - sdkCached.at < TTL_MS && sdkCached.models.length) {
     return sdkCached.models;
   }
@@ -654,7 +666,7 @@ async function fetchCursorModelsFromSdk(
   const rows = await withTimeout((async () => {
     let sdkError: unknown = null;
     try {
-      const { Cursor } = await import("@cursor/sdk");
+      const { Cursor } = await loadCursorSdk();
       const sdkRows = normalizeSdkModelRows(await Cursor.models.list({ apiKey }));
       if (sdkRows.length) {
         sdkSucceeded = true;
@@ -662,6 +674,10 @@ async function fetchCursorModelsFromSdk(
       }
     } catch (error) {
       sdkError = error;
+    }
+
+    if (sdkError && isCursorSdkResolutionError(sdkError)) {
+      throw toCursorModelDiscoveryError(sdkError);
     }
 
     try {
@@ -763,8 +779,8 @@ export async function probeCursorSdkModelDiscovery(
     };
   } catch (error) {
     const discoveryError = rememberCursorModelDiscoveryFailure(keyHash, error);
-    // Best-effort: a transient SDK error or invalid key should not crash
-    // model resolution — fallback IDs cover the common case.
+    // Best-effort: model resolution reports failures to provider health and
+    // returns no rows instead of letting discovery errors crash status refresh.
     return {
       rows: [],
       failureKind: discoveryError.kind,

--- a/apps/desktop/src/main/services/chat/cursorModelsDiscovery.ts
+++ b/apps/desktop/src/main/services/chat/cursorModelsDiscovery.ts
@@ -627,12 +627,7 @@ function getCachedCursorSdkModels(apiKey?: string | null): CursorCliModelRow[] |
   const now = Date.now();
   const normalizedApiKey = apiKey?.trim() || undefined;
   const keyHash = hashKeyForCache(normalizedApiKey);
-  if (
-    sdkLastFailure
-    && sdkLastFailure.keyHash === keyHash
-    && now - sdkLastFailure.at < TTL_MS
-    && (sdkLastFailure.kind === "auth" || sdkLastFailure.kind === "unavailable")
-  ) {
+  if (hasRecentCursorSdkFailure(keyHash, now)) {
     return null;
   }
   if (sdkCached && sdkCached.keyHash === keyHash && now - sdkCached.at < TTL_MS && sdkCached.models.length) {
@@ -641,6 +636,14 @@ function getCachedCursorSdkModels(apiKey?: string | null): CursorCliModelRow[] |
   return null;
 }
 
+function hasRecentCursorSdkFailure(keyHash: string, now = Date.now()): boolean {
+  return Boolean(
+    sdkLastFailure
+    && sdkLastFailure.keyHash === keyHash
+    && now - sdkLastFailure.at < TTL_MS
+    && (sdkLastFailure.kind === "auth" || sdkLastFailure.kind === "unavailable"),
+  );
+}
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
@@ -730,7 +733,7 @@ async function fetchCursorModelsFromOfficialApi(apiKey: string | undefined): Pro
 function warmCursorModelsFromSdk(apiKey?: string | null): void {
   const normalizedApiKey = apiKey?.trim() || undefined;
   const keyHash = hashKeyForCache(normalizedApiKey);
-  if (sdkWarmInFlight?.keyHash === keyHash) return;
+  if (sdkWarmInFlight?.keyHash === keyHash || hasRecentCursorSdkFailure(keyHash)) return;
 
   const generation = sdkCacheGeneration;
   const promise = fetchCursorModelsFromSdk(

--- a/apps/desktop/src/main/services/chat/cursorSdkPool.test.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkPool.test.ts
@@ -47,6 +47,35 @@ class FakeSdkChild extends EventEmitter {
   }
 }
 
+class ExitingBeforeInitChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  exitCode: number | null = null;
+  killed = false;
+  connected = true;
+
+  send(message: { type?: string; requestId?: string }): boolean {
+    if (message.type === "init") {
+      queueMicrotask(() => {
+        this.exitCode = 1;
+        this.connected = false;
+        this.emit("exit", 1, null);
+      });
+      return true;
+    }
+    if (message.type === "dispose") {
+      throw Object.assign(new Error("Channel closed"), { code: "ERR_IPC_CHANNEL_CLOSED" });
+    }
+    return true;
+  }
+
+  kill(signal?: NodeJS.Signals): boolean {
+    this.killed = true;
+    this.emit("exit", null, signal ?? "SIGTERM");
+    return true;
+  }
+}
+
 afterEach(() => {
   forkMock.mockReset();
 });
@@ -139,5 +168,25 @@ describe("Cursor SDK pool paths", () => {
 
     releaseCursorSdkConnection(poolKey, second.generation);
     expect(child.disposeCount).toBe(1);
+  });
+
+  it("rejects initialization instead of throwing when the worker IPC channel closes", async () => {
+    forkMock.mockReturnValue(new ExitingBeforeInitChild());
+    const poolKey = `test-exit:${Date.now()}:${Math.random()}`;
+
+    await expect(acquireCursorSdkConnection({
+      poolKey,
+      projectRoot: path.join(os.tmpdir(), "ade-project"),
+      workspacePath: path.join(os.tmpdir(), "ade-workspace"),
+      modelSdkId: "cursor-model",
+      sessionId: "session-1",
+      policy: {
+        chatMode: "agent" as const,
+        approvalPolicy: "on-request" as const,
+        sandbox: "ade" as const,
+        force: false,
+        hardGuards: true,
+      },
+    })).rejects.toThrow("Cursor SDK worker exited (1).");
   });
 });

--- a/apps/desktop/src/main/services/chat/cursorSdkPool.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkPool.ts
@@ -276,6 +276,40 @@ async function createCursorSdkConnection(args: Parameters<typeof acquireCursorSd
     onCloudArtifact: null,
     onHookRequest: null,
   };
+  const workerIpcClosedError = () => new Error("Cursor SDK worker IPC channel is closed.");
+  const normalizeIpcSendError = (error: unknown): Error => (
+    error instanceof Error ? error : new Error(String(error))
+  );
+  const sendWorkerMessage = (
+    message: CursorSdkWorkerRequest,
+    onError?: (error: Error) => void,
+  ): boolean => {
+    if (child.exitCode != null || child.killed || child.connected === false) {
+      onError?.(workerIpcClosedError());
+      return false;
+    }
+    try {
+      child.send(message, (error) => {
+        if (error) onError?.(normalizeIpcSendError(error));
+      });
+      return true;
+    } catch (error) {
+      onError?.(normalizeIpcSendError(error));
+      return false;
+    }
+  };
+  const rejectPending = (error: Error) => {
+    for (const [, waiter] of pending) waiter.reject(error);
+    pending.clear();
+  };
+  const cleanupPoolEntry = (pooledRef: CursorSdkPooled) => {
+    for (const [poolKey, entry] of pools) {
+      if (entry.pooled === pooledRef) {
+        pools.delete(poolKey);
+        cleanupCursorSdkRuntimePaths(entry);
+      }
+    }
+  };
 
   child.stdout?.on("data", (chunk) => {
     const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
@@ -299,7 +333,17 @@ async function createCursorSdkConnection(args: Parameters<typeof acquireCursorSd
           reject,
           type,
         });
-        child.send?.({ type, requestId, payload } as CursorSdkWorkerRequest);
+        const sent = sendWorkerMessage({ type, requestId, payload } as CursorSdkWorkerRequest, (error) => {
+          const waiter = pending.get(requestId);
+          if (!waiter) return;
+          pending.delete(requestId);
+          waiter.reject(error);
+        });
+        if (!sent) {
+          if (pending.delete(requestId)) {
+            reject(workerIpcClosedError());
+          }
+        }
       });
     },
     sendPrompt: (payload) => pooled.request("send", payload),
@@ -308,11 +352,7 @@ async function createCursorSdkConnection(args: Parameters<typeof acquireCursorSd
     dispose: () => {
       for (const [, waiter] of pending) waiter.reject(new Error("Cursor SDK worker disposed."));
       pending.clear();
-      try {
-        child.send?.({ type: "dispose", requestId: randomUUID() } as CursorSdkWorkerRequest);
-      } catch {
-        // ignore
-      }
+      sendWorkerMessage({ type: "dispose", requestId: randomUUID() } as CursorSdkWorkerRequest);
       setTimeout(() => {
         if (child.exitCode == null && !child.killed) child.kill("SIGTERM");
       }, 800).unref();
@@ -413,11 +453,15 @@ async function createCursorSdkConnection(args: Parameters<typeof acquireCursorSd
             agent_message: "Hook evaluation failed due to an internal error.",
           };
         }
-        child.send?.({
+        sendWorkerMessage({
           type: "hook_response",
           requestId: message.requestId,
           payload: decision,
-        } as CursorSdkWorkerRequest);
+        } as CursorSdkWorkerRequest, (error) => {
+          args.logger?.warn?.("agent_chat.cursor_sdk_hook_response_failed", {
+            error: error.message,
+          });
+        });
       })();
       return;
     }
@@ -430,17 +474,14 @@ async function createCursorSdkConnection(args: Parameters<typeof acquireCursorSd
     }
   });
 
+  child.on("error", (error) => {
+    rejectPending(normalizeIpcSendError(error));
+    cleanupPoolEntry(pooled);
+  });
+
   child.on("exit", (code, signal) => {
-    for (const [, waiter] of pending) {
-      waiter.reject(new Error(`Cursor SDK worker exited (${code ?? signal ?? "unknown"}).`));
-    }
-    pending.clear();
-    for (const [poolKey, entry] of pools) {
-      if (entry.pooled === pooled) {
-        pools.delete(poolKey);
-        cleanupCursorSdkRuntimePaths(entry);
-      }
-    }
+    rejectPending(new Error(`Cursor SDK worker exited (${code ?? signal ?? "unknown"}).`));
+    cleanupPoolEntry(pooled);
   });
 
   const initPayload: CursorSdkWorkerInit = {

--- a/apps/desktop/src/main/services/chat/cursorSdkWorker.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkWorker.ts
@@ -26,6 +26,7 @@ import {
   summarizeCursorHook,
 } from "./cursorSdkPolicy";
 import { ensureCursorSdkUserHook } from "./cursorSdkHooks";
+import { loadCursorSdk } from "../ai/cursorSdkLoader";
 
 type CursorSdkModule = typeof CursorSdkModuleTypes;
 type SdkAgent = Awaited<ReturnType<CursorSdkModule["Agent"]["create"]>>;
@@ -141,7 +142,7 @@ function classifyWorkerError(error: unknown): { error: string; errorCode?: strin
 
 async function getSdk(): Promise<CursorSdkModule> {
   if (!sdkModule) {
-    sdkModule = await import("@cursor/sdk");
+    sdkModule = await loadCursorSdk();
   }
   return sdkModule;
 }

--- a/apps/desktop/src/main/services/chat/droidSdkPool.test.ts
+++ b/apps/desktop/src/main/services/chat/droidSdkPool.test.ts
@@ -48,6 +48,35 @@ class FakeSdkChild extends EventEmitter {
   }
 }
 
+class ExitingBeforeInitChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  exitCode: number | null = null;
+  killed = false;
+  connected = true;
+
+  send(message: { type?: string; requestId?: string }): boolean {
+    if (message.type === "init") {
+      queueMicrotask(() => {
+        this.exitCode = 1;
+        this.connected = false;
+        this.emit("exit", 1, null);
+      });
+      return true;
+    }
+    if (message.type === "dispose") {
+      throw Object.assign(new Error("Channel closed"), { code: "ERR_IPC_CHANNEL_CLOSED" });
+    }
+    return true;
+  }
+
+  kill(signal?: NodeJS.Signals): boolean {
+    this.killed = true;
+    this.emit("exit", null, signal ?? "SIGTERM");
+    return true;
+  }
+}
+
 afterEach(() => {
   forkMock.mockReset();
 });
@@ -83,5 +112,22 @@ describe("Droid SDK pool", () => {
 
     releaseDroidSdkConnection(poolKey, second.generation);
     expect(child.disposeCount).toBe(1);
+  });
+
+  it("rejects initialization instead of throwing when the worker IPC channel closes", async () => {
+    forkMock.mockReturnValue(new ExitingBeforeInitChild());
+    const poolKey = `test-exit:${Date.now()}:${Math.random()}`;
+
+    await expect(acquireDroidSdkConnection({
+      poolKey,
+      droidPath: "/usr/local/bin/droid",
+      workspacePath: path.join(os.tmpdir(), "ade-workspace"),
+      sessionId: "session-1",
+      settings: {
+        modelId: "droid-model",
+        autonomyLevel: "medium" as const,
+        interactionMode: "auto" as const,
+      },
+    })).rejects.toThrow("Droid SDK worker exited (1).");
   });
 });

--- a/apps/desktop/src/main/services/chat/droidSdkPool.ts
+++ b/apps/desktop/src/main/services/chat/droidSdkPool.ts
@@ -127,6 +127,37 @@ async function createDroidSdkConnection(args: Parameters<typeof acquireDroidSdkC
     onAskUserRequest: null,
     onReady: null,
   };
+  const workerIpcClosedError = () => new Error("Droid SDK worker IPC channel is closed.");
+  const normalizeIpcSendError = (error: unknown): Error => (
+    error instanceof Error ? error : new Error(String(error))
+  );
+  const sendWorkerMessage = (
+    message: DroidSdkWorkerRequest,
+    onError?: (error: Error) => void,
+  ): boolean => {
+    if (child.exitCode != null || child.killed || child.connected === false) {
+      onError?.(workerIpcClosedError());
+      return false;
+    }
+    try {
+      child.send(message, (error) => {
+        if (error) onError?.(normalizeIpcSendError(error));
+      });
+      return true;
+    } catch (error) {
+      onError?.(normalizeIpcSendError(error));
+      return false;
+    }
+  };
+  const rejectPending = (error: Error) => {
+    for (const [, waiter] of pending) waiter.reject(error);
+    pending.clear();
+  };
+  const cleanupPoolEntry = (pooledRef: DroidSdkPooled) => {
+    for (const [poolKey, entry] of pools) {
+      if (entry.pooled === pooledRef) pools.delete(poolKey);
+    }
+  };
 
   child.stdout?.on("data", (chunk) => {
     const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
@@ -151,7 +182,17 @@ async function createDroidSdkConnection(args: Parameters<typeof acquireDroidSdkC
           reject,
           type,
         });
-        child.send?.({ type, requestId, payload } as DroidSdkWorkerRequest);
+        const sent = sendWorkerMessage({ type, requestId, payload } as DroidSdkWorkerRequest, (error) => {
+          const waiter = pending.get(requestId);
+          if (!waiter) return;
+          pending.delete(requestId);
+          waiter.reject(error);
+        });
+        if (!sent) {
+          if (pending.delete(requestId)) {
+            reject(workerIpcClosedError());
+          }
+        }
       });
     },
     sendPrompt: (payload) => pooled.request("send", payload),
@@ -161,11 +202,7 @@ async function createDroidSdkConnection(args: Parameters<typeof acquireDroidSdkC
     dispose: () => {
       for (const [, waiter] of pending) waiter.reject(new Error("Droid SDK worker disposed."));
       pending.clear();
-      try {
-        child.send?.({ type: "dispose", requestId: randomUUID() } as DroidSdkWorkerRequest);
-      } catch {
-        // ignore
-      }
+      sendWorkerMessage({ type: "dispose", requestId: randomUUID() } as DroidSdkWorkerRequest);
       setTimeout(() => {
         if (child.exitCode == null && !child.killed) child.kill("SIGTERM");
       }, 800).unref();
@@ -207,11 +244,15 @@ async function createDroidSdkConnection(args: Parameters<typeof acquireDroidSdkC
           });
           decision = { selectedOption: "cancel", comment: "Droid permission evaluation failed." };
         }
-        child.send?.({
+        sendWorkerMessage({
           type: "permission_response",
           requestId: message.requestId,
           payload: decision,
-        } as DroidSdkWorkerRequest);
+        } as DroidSdkWorkerRequest, (error) => {
+          args.logger?.warn?.("agent_chat.droid_sdk_permission_response_failed", {
+            error: error.message,
+          });
+        });
       })();
       return;
     }
@@ -228,11 +269,15 @@ async function createDroidSdkConnection(args: Parameters<typeof acquireDroidSdkC
           });
           response = { cancelled: true, answers: [] };
         }
-        child.send?.({
+        sendWorkerMessage({
           type: "ask_user_response",
           requestId: message.requestId,
           payload: response,
-        } as DroidSdkWorkerRequest);
+        } as DroidSdkWorkerRequest, (error) => {
+          args.logger?.warn?.("agent_chat.droid_sdk_ask_user_response_failed", {
+            error: error.message,
+          });
+        });
       })();
       return;
     }
@@ -245,14 +290,14 @@ async function createDroidSdkConnection(args: Parameters<typeof acquireDroidSdkC
     }
   });
 
+  child.on("error", (error) => {
+    rejectPending(normalizeIpcSendError(error));
+    cleanupPoolEntry(pooled);
+  });
+
   child.on("exit", (code, signal) => {
-    for (const [, waiter] of pending) {
-      waiter.reject(new Error(`Droid SDK worker exited (${code ?? signal ?? "unknown"}).`));
-    }
-    pending.clear();
-    for (const [poolKey, entry] of pools) {
-      if (entry.pooled === pooled) pools.delete(poolKey);
-    }
+    rejectPending(new Error(`Droid SDK worker exited (${code ?? signal ?? "unknown"}).`));
+    cleanupPoolEntry(pooled);
   });
 
   const initPayload: DroidSdkWorkerInit = {

--- a/apps/desktop/src/main/services/chat/droidSdkWorker.ts
+++ b/apps/desktop/src/main/services/chat/droidSdkWorker.ts
@@ -11,6 +11,7 @@ import type {
   DroidSdkWorkerRequest,
   DroidSdkWorkerResponse,
 } from "./droidSdkProtocol";
+import { loadDroidSdk } from "../ai/droidSdkLoader";
 
 type DroidSdkModule = typeof DroidSdkTypes;
 type DroidSession = Awaited<ReturnType<DroidSdkModule["createSession"]>>;
@@ -39,7 +40,7 @@ function errorMessage(error: unknown): string {
 }
 
 async function getSdk(): Promise<DroidSdkModule> {
-  if (!sdkModule) sdkModule = await import("@factory/droid-sdk");
+  if (!sdkModule) sdkModule = await loadDroidSdk();
   return sdkModule;
 }
 

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -5180,7 +5180,7 @@ describe("AgentChatPane submit recovery", () => {
   });
 
   it("launches a CLI session draft in the background without stealing focus", async () => {
-    const { send, create, createLane, suggestLaneName } = installAdeMocks({ sessions: [] });
+    const { send, createLane, suggestLaneName } = installAdeMocks({ sessions: [] });
     const onLaunchCliSession = vi.fn().mockResolvedValue({ sessionId: "terminal-created", ptyId: "pty-created" });
     suggestLaneName.mockResolvedValue("background-cli-lane");
     createLane.mockResolvedValue({
@@ -5222,7 +5222,6 @@ describe("AgentChatPane submit recovery", () => {
     const launchArgs = onLaunchCliSession.mock.calls[0]?.[0];
     expect(launchArgs.startupCommand).not.toContain("Launch this CLI session in the background.");
     expect(launchArgs.initialInput).toContain("Launch this CLI session in the background.");
-    expect(create).not.toHaveBeenCalled();
     expect(send).not.toHaveBeenCalled();
     expect(screen.getByTestId("location").textContent).toBe("/work");
 

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -4429,7 +4429,7 @@ export function AgentChatPane({
     }
     return null;
   }, [effectiveAvailableModelIds, modelId, modelSelectionConstrained]);
-  const cursorCloudApiAvailable = providerConnections?.cursor?.authAvailable === true
+  const cursorCloudApiAvailable = providerConnections?.cursor?.runtimeAvailable === true
     || aiStatus?.availableProviders?.cursor === true;
   const cursorCloudAvailable = Boolean(laneId)
     && cursorCloudApiAvailable

--- a/apps/desktop/src/renderer/components/onboarding/AiRuntimesBand.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/AiRuntimesBand.tsx
@@ -363,7 +363,7 @@ function CursorKeyPopover({ onSave }: { onSave: (key: string) => Promise<{ ok: b
     <InputPopover
       triggerLabel="Add key"
       title="Cursor API key"
-      helpText={<>Get a key at <code style={codeStyle}>cursor.com/dashboard/integrations</code></>}
+      helpText={<>Get a key at <code style={codeStyle}>cursor.com/dashboard/api</code></>}
       placeholder="cur_..."
       onSave={onSave}
       align="left"

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.test.tsx
@@ -155,7 +155,7 @@ function buildStatus(
         runtimeAvailable: false,
         usageAvailable: false,
         path: null,
-        blocker: "Enter a Cursor API key from https://cursor.com/dashboard/integrations.",
+        blocker: "Enter a Cursor API key from https://cursor.com/dashboard/api.",
         lastCheckedAt: "2026-03-17T19:00:00.000Z",
         sources: [],
       },
@@ -372,6 +372,53 @@ describe("ProvidersSection", () => {
     });
     expect(await screen.findByText("Cursor connection verified.")).toBeTruthy();
     expect(screen.getAllByText("Connected").length).toBeGreaterThan(0);
+  });
+
+  it("shows failed Cursor verification as a dismissible error", async () => {
+    const getStatusMock = window.ade.ai.getStatus as ReturnType<typeof vi.fn>;
+    getStatusMock.mockReset();
+    getStatusMock.mockResolvedValue(buildStatus(true, []));
+    const listApiKeysMock = window.ade.ai.listApiKeys as ReturnType<typeof vi.fn>;
+    listApiKeysMock.mockReset();
+    listApiKeysMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValue(["cursor"]);
+    const verifyApiKeyMock = window.ade.ai.verifyApiKey as ReturnType<typeof vi.fn>;
+    verifyApiKeyMock.mockResolvedValueOnce({
+      provider: "cursor",
+      ok: false,
+      message: "Verification request failed: Cannot find package '@cursor/sdk'",
+      source: "store",
+      verifiedAt: "2026-03-17T19:00:00.000Z",
+    });
+
+    render(<ProvidersSection />);
+
+    await waitFor(() => {
+      expect(window.ade.ai.getStatus).toHaveBeenCalledTimes(1);
+      expect(window.ade.ai.listApiKeys).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      screen.getByLabelText("Add Cursor API key").click();
+    });
+
+    fireEvent.change(screen.getByLabelText("Cursor API key"), { target: { value: "crsr_test" } });
+
+    await act(async () => {
+      screen.getByLabelText("Save Cursor API key").click();
+    });
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Cannot find package '@cursor/sdk'");
+    expect(screen.queryByText("Cursor verification failed.")).toBeNull();
+    expect(screen.queryByText("Invalid key")).toBeNull();
+    expect(screen.getByText("Verification failed")).toBeTruthy();
+
+    await act(async () => {
+      screen.getByLabelText("Dismiss error message").click();
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("forces a provider status refresh after verifying a stored Cursor API key", async () => {

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -22,6 +22,7 @@ import {
   Cpu,
   Info,
   WarningCircle,
+  X,
   XCircle,
 } from "@phosphor-icons/react";
 import { ClaudeLogo, CodexLogo, CursorAgentLogo, OpenCodeLogo } from "../terminals/ToolLogos";
@@ -68,7 +69,7 @@ const CLI_TOOLS: Array<{
     label: "Cursor",
     description: "Cursor SDK runtime",
     loginCmd: "Add a Cursor API key",
-    installHint: "Get a Cursor API key from https://cursor.com/dashboard/integrations",
+    installHint: "Get a Cursor API key from https://cursor.com/dashboard/api",
   },
   {
     cli: "droid",
@@ -119,6 +120,57 @@ const groupLabelStyle: React.CSSProperties = {
   marginBottom: 0,
   color: COLORS.textSecondary,
 };
+
+function AlertBanner({
+  tone,
+  message,
+  onDismiss,
+}: {
+  tone: "success" | "error" | "warning";
+  message: string;
+  onDismiss: () => void;
+}) {
+  const color = tone === "success" ? COLORS.success : tone === "warning" ? COLORS.warning : COLORS.danger;
+  const token = tone === "success" ? "success" : tone === "warning" ? "warning" : "error";
+  return (
+    <div
+      role={tone === "error" ? "alert" : "status"}
+      style={{
+        padding: "8px 10px 8px 12px",
+        fontSize: 11,
+        fontFamily: MONO_FONT,
+        color,
+        background: `color-mix(in srgb, var(--color-${token}) 12%, transparent)`,
+        border: `1px solid color-mix(in srgb, var(--color-${token}) 30%, transparent)`,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+      }}
+    >
+      <span style={{ minWidth: 0, overflowWrap: "anywhere" }}>{message}</span>
+      <button
+        type="button"
+        aria-label={`Dismiss ${tone} message`}
+        onClick={onDismiss}
+        style={{
+          border: `1px solid color-mix(in srgb, ${color} 32%, transparent)`,
+          background: "transparent",
+          color,
+          width: 22,
+          height: 22,
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: 0,
+          cursor: "pointer",
+        }}
+      >
+        <X size={12} weight="bold" />
+      </button>
+    </div>
+  );
+}
 
 const SOURCE_BADGE_MAP: Record<ApiKeySource, { color: string; label: string }> = {
   store: { color: COLORS.success, label: "Local Store" },
@@ -248,6 +300,7 @@ export function ProvidersSection({ forceRefreshOnMount = false }: { forceRefresh
   const [editValue, setEditValue] = useState("");
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [dismissedApiKeyStoreWarning, setDismissedApiKeyStoreWarning] = useState<string | null>(null);
   const [verifyingProvider, setVerifyingProvider] = useState<string | null>(null);
   const [verificationByProvider, setVerificationByProvider] = useState<Record<string, AiApiKeyVerificationResult>>({});
   const pendingRefreshTimerRef = useRef<number | null>(null);
@@ -365,6 +418,10 @@ export function ProvidersSection({ forceRefreshOnMount = false }: { forceRefresh
     }
     return null;
   }, [status?.apiKeyStore]);
+  const visibleApiKeyStoreWarning =
+    apiKeyStoreWarning && dismissedApiKeyStoreWarning !== apiKeyStoreWarning
+      ? apiKeyStoreWarning
+      : null;
 
   const beginEditing = (provider: string) => {
     setEditingProvider(provider);
@@ -432,9 +489,13 @@ export function ProvidersSection({ forceRefreshOnMount = false }: { forceRefresh
       invalidateAiDiscoveryCache();
       const result = await window.ade.ai.verifyApiKey(provider);
       invalidateAiDiscoveryCache();
-      setVerificationByProvider((prev) => ({ ...prev, [provider]: result }));
-      setNotice(result.ok ? `${provider} connection verified.` : `${provider} verification failed.`);
       await refreshStatus({ force: true, refreshOpenCodeInventory: true });
+      setVerificationByProvider((prev) => ({ ...prev, [provider]: result }));
+      if (result.ok) {
+        setNotice(`${provider} connection verified.`);
+      } else {
+        setError(result.message || `${provider} verification failed.`);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -458,12 +519,16 @@ export function ProvidersSection({ forceRefreshOnMount = false }: { forceRefresh
       await window.ade.ai.storeApiKey("cursor", trimmed);
       invalidateAiDiscoveryCache();
       setStoredProviders((prev) => Array.from(new Set([...prev, "cursor"])));
-      cancelEditing();
       const result = await window.ade.ai.verifyApiKey("cursor");
       invalidateAiDiscoveryCache();
-      setVerificationByProvider((prev) => ({ ...prev, cursor: result }));
-      setNotice(result.ok ? "Cursor connection verified." : "Cursor verification failed.");
       await refreshStatus({ force: true, refreshOpenCodeInventory: true });
+      setVerificationByProvider((prev) => ({ ...prev, cursor: result }));
+      if (result.ok) {
+        setNotice("Cursor connection verified.");
+        cancelEditing();
+      } else {
+        setError(result.message || "Cursor verification failed.");
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -526,48 +591,19 @@ export function ProvidersSection({ forceRefreshOnMount = false }: { forceRefresh
   return (
     <div id="ai-providers" style={{ display: "flex", flexDirection: "column", gap: 24 }}>
       {notice && (
-        <div
-          style={{
-            padding: "8px 12px",
-            fontSize: 11,
-            fontFamily: MONO_FONT,
-            color: COLORS.success,
-            background: "color-mix(in srgb, var(--color-success) 12%, transparent)",
-            border: "1px solid color-mix(in srgb, var(--color-success) 30%, transparent)",
-          }}
-        >
-          {notice}
-        </div>
+        <AlertBanner tone="success" message={notice} onDismiss={() => setNotice(null)} />
       )}
 
       {error && (
-        <div
-          style={{
-            padding: "8px 12px",
-            fontSize: 11,
-            fontFamily: MONO_FONT,
-            color: COLORS.danger,
-            background: "color-mix(in srgb, var(--color-error) 12%, transparent)",
-            border: "1px solid color-mix(in srgb, var(--color-error) 30%, transparent)",
-          }}
-        >
-          {error}
-        </div>
+        <AlertBanner tone="error" message={error} onDismiss={() => setError(null)} />
       )}
 
-      {apiKeyStoreWarning && (
-        <div
-          style={{
-            padding: "8px 12px",
-            fontSize: 11,
-            fontFamily: MONO_FONT,
-            color: COLORS.warning,
-            background: "color-mix(in srgb, var(--color-warning) 12%, transparent)",
-            border: "1px solid color-mix(in srgb, var(--color-warning) 30%, transparent)",
-          }}
-        >
-          {apiKeyStoreWarning}
-        </div>
+      {visibleApiKeyStoreWarning && (
+        <AlertBanner
+          tone="warning"
+          message={visibleApiKeyStoreWarning}
+          onDismiss={() => setDismissedApiKeyStoreWarning(visibleApiKeyStoreWarning)}
+        />
       )}
 
       {/* ── Model Availability Summary ── */}
@@ -729,7 +765,7 @@ export function ProvidersSection({ forceRefreshOnMount = false }: { forceRefresh
           : isVerified
             ? { color: COLORS.success, label: "Connected" }
             : isInvalid
-              ? { color: COLORS.danger, label: "Invalid key" }
+              ? { color: COLORS.danger, label: "Verification failed" }
               : isInitialCheckInFlight ? { color: COLORS.info, label: "Checking" } : getStatusTone(connection);
         const message = isVerifying
           ? "Verifying Cursor API key with the Cursor SDK."
@@ -759,9 +795,9 @@ export function ProvidersSection({ forceRefreshOnMount = false }: { forceRefresh
             {credentialSourceDesc && !connection?.runtimeAvailable && !isInitialCheckInFlight ? <div style={{ fontSize: 10, fontFamily: MONO_FONT, color: COLORS.info, marginTop: 4 }}>{credentialSourceDesc}</div> : null}
             {connection?.path && !isInitialCheckInFlight ? <code style={{ display: "block", marginTop: 6, fontSize: 10, fontFamily: MONO_FONT, color: COLORS.textSecondary, background: "color-mix(in srgb, var(--color-muted-fg) 12%, transparent)", border: `1px solid ${COLORS.border}`, padding: "6px 8px", overflowWrap: "anywhere", wordBreak: "break-all" }}>{connection.path}</code> : null}
             <div style={{ fontSize: 10, fontFamily: MONO_FONT, color: COLORS.textMuted, lineHeight: 1.5, marginTop: 8 }}>
-              Get key from Cursor integrations dashboard:{" "}
-              <a href="https://cursor.com/dashboard/integrations" target="_blank" rel="noreferrer" style={{ color: COLORS.info }}>
-                https://cursor.com/dashboard/integrations
+              Get key from Cursor API dashboard:{" "}
+              <a href="https://cursor.com/dashboard/api" target="_blank" rel="noreferrer" style={{ color: COLORS.info }}>
+                https://cursor.com/dashboard/api
               </a>
             </div>
             <div style={{ marginTop: 12, paddingTop: 12, borderTop: `1px solid ${COLORS.border}`, display: "grid", gridTemplateColumns: "140px minmax(0, 1fr) auto", gap: 10, alignItems: "center" }}>

--- a/apps/desktop/src/renderer/components/shared/ModelPicker/providerEmptyState.test.tsx
+++ b/apps/desktop/src/renderer/components/shared/ModelPicker/providerEmptyState.test.tsx
@@ -39,7 +39,7 @@ describe("ProviderEmptyState", () => {
     await userEvent.click(screen.getByRole("button", { name: /Open Settings/i }));
     expect(onOpenSignIn).toHaveBeenCalledOnce();
     await userEvent.click(screen.getByRole("button", { name: /Get Cursor API key/i }));
-    expect(openExternalCalls).toContain("https://cursor.com/dashboard/integrations");
+    expect(openExternalCalls).toContain("https://cursor.com/dashboard/api");
   });
 
   it("renders connected-but-empty Cursor discovery copy", () => {

--- a/apps/desktop/src/renderer/components/shared/ModelPicker/providerEmptyState.tsx
+++ b/apps/desktop/src/renderer/components/shared/ModelPicker/providerEmptyState.tsx
@@ -42,7 +42,7 @@ const PROVIDER_COPY: Partial<Record<ProviderFamily, ProviderCopy>> = {
     primary: { label: "Open Settings", action: { kind: "open-settings" } },
     secondary: {
       label: "Get Cursor API key",
-      action: { kind: "open-external", url: "https://cursor.com/dashboard/integrations" },
+      action: { kind: "open-external", url: "https://cursor.com/dashboard/api" },
     },
   },
   factory: {
@@ -141,7 +141,7 @@ function discoveryEmptyCopy(family: ProviderFamily): ProviderCopy {
       primary: { label: "Open Settings", action: { kind: "open-settings" } },
       secondary: {
         label: "Get Cursor API key",
-        action: { kind: "open-external", url: "https://cursor.com/dashboard/integrations" },
+        action: { kind: "open-external", url: "https://cursor.com/dashboard/api" },
       },
     };
   }

--- a/apps/desktop/src/renderer/lib/modelOptions.test.ts
+++ b/apps/desktop/src/renderer/lib/modelOptions.test.ts
@@ -152,9 +152,18 @@ describe("deriveConfiguredModelIds", () => {
     }
   });
 
-  it("includes Cursor SDK models from availableModelIds when Cursor API key auth is present", () => {
+  it("includes Cursor SDK models from availableModelIds when Cursor runtime is verified", () => {
     const status = makeStatus({
       detectedAuth: [{ type: "api-key", provider: "cursor", source: "store" }],
+      availableProviders: {
+        claude: {
+          binary: { present: false, source: "missing", path: null },
+          auth: { ready: false, mode: "none", detail: null },
+        },
+        codex: false,
+        cursor: true,
+        droid: false,
+      },
       availableModelIds: ["cursor/auto", "cursor/composer-2", "openai/gpt-5.4-pro"],
     });
     const ids = deriveConfiguredModelIds(status);
@@ -170,14 +179,13 @@ describe("deriveConfiguredModelIds", () => {
     }
   });
 
-  it("includes Cursor SDK models by default", () => {
+  it("does not include Cursor SDK models from a stored key before runtime verification", () => {
     const status = makeStatus({
       detectedAuth: [{ type: "api-key", provider: "cursor", source: "store" }],
       availableModelIds: ["cursor/auto", "cursor/composer-2"],
     });
     const ids = deriveConfiguredModelIds(status, {});
-    expect(ids).toContain("cursor/auto");
-    expect(ids).toContain("cursor/composer-2");
+    expect(ids).toEqual([]);
   });
 
   it("includes Cursor SDK models when Cursor runtime is available even without api-key auth entry", () => {

--- a/apps/desktop/src/renderer/lib/modelOptions.ts
+++ b/apps/desktop/src/renderer/lib/modelOptions.ts
@@ -130,9 +130,9 @@ export function deriveConfiguredModelIds(
   const { includeCursor = true, includeDroid = true } = options ?? {};
   const runtimeConnections = (status as { runtimeConnections?: Record<string, AiRuntimeConnectionStatus> } | null | undefined)?.runtimeConnections;
 
-  // Derive available models from detectedAuth. For Cursor SDK, merge in
-  // `status.availableModelIds` entries under `cursor/*`; local runtimes also
-  // merge in discovered loaded models.
+  // Derive available models from detectedAuth. Cursor SDK models are only
+  // merged after the runtime connection is ready; a stored key alone is not
+  // enough because SDK/package/model access can still fail.
   const ids = new Set<ModelId>();
 
   // Build a set of local model IDs that are already represented by an OpenCode
@@ -197,11 +197,8 @@ export function deriveConfiguredModelIds(
   }
 
   if (includeCursor) {
-    const cursorAvailable =
-      status.availableProviders?.cursor === true
-      || status.detectedAuth?.some(
-        (a) => a.type === "api-key" && a.provider === "cursor",
-      );
+    const cursorAvailable = status.availableProviders?.cursor === true
+      || status.providerConnections?.cursor?.runtimeAvailable === true;
     if (cursorAvailable && status.availableModelIds?.length) {
       for (const raw of status.availableModelIds) {
         const id = String(raw ?? "").trim();


### PR DESCRIPTION
## Summary
- Fix Cursor SDK loading in packaged ADE/CLI runtimes and require verified SDK/model readiness before showing Cursor chat models as usable.
- Harden Cursor and Droid SDK worker IPC so failed workers reject the chat instead of taking down the brain process.
- Emit the Droid SDK worker in ADE CLI packaging and add loader fallback for packaged runtime resolution.
- Keep built-in browser views attached when project-scoped calls resolve a window, including multi-window project switches.
- Update Cursor settings/onboarding copy to the API dashboard link and make verification banners dismissible with proper error styling.

## Validation
- npm --prefix apps/desktop run test -- src/main/services/ai/providerConnectionStatus.test.ts src/main/services/builtInBrowser/builtInBrowserService.test.ts src/main/services/chat/cursorSdkPool.test.ts src/main/services/chat/cursorModelsDiscovery.test.ts src/main/services/chat/droidSdkPool.test.ts src/renderer/components/settings/ProvidersSection.test.tsx src/renderer/lib/modelOptions.test.ts src/renderer/components/shared/ModelPicker/providerEmptyState.test.tsx
- npm --prefix apps/desktop run typecheck
- npm --prefix apps/ade-cli run typecheck
- npm --prefix apps/ade-cli run test
- npm --prefix apps/desktop run lint (passes with existing warnings)
- npm --prefix apps/desktop run build
- npm run test:desktop:sharded failed only because local ADE Beta brain owned the sync singleton lock on port 8807; reran shards 3-8 with ADE_SYNC_HOST_LOCK_PATH isolated after shards 1-2 had already passed.
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Cursor and Droid SDK loading resilience with fallback mechanisms for resolution failures
  * Enhanced error handling and reporting for SDK initialization and API key verification flows
  * Fixed browser service attachment to ensure proper initialization in project-scoped sessions
  * Updated Cursor API key verification to report runtime health more accurately
  * Corrected dashboard links from integrations page to API page across onboarding and settings

* **Tests**
  * Added tests for SDK worker initialization failures and IPC error handling
  * Expanded provider connection status and model discovery test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens Cursor and Droid SDK loading in packaged/CLI runtimes with a `require`-based fallback, gates `runtimeAvailable` behind explicit verification (SDK load + model-list check), and fixes built-in browser views being detached on project-scoped window resolution.

- **SDK loader + IPC resilience**: New `cursorSdkLoader`/`droidSdkLoader` modules add a `createRequire`-based fallback for packaged runtimes; `cursorSdkPool`/`droidSdkPool` get a `sendWorkerMessage` helper with closed-channel guards, an `"error"` event handler, and shared `rejectPending`/`cleanupPoolEntry` helpers used by both `"error"` and `"exit"` handlers.
- **Runtime readiness gating**: `providerConnectionStatus` now sets `runtimeAvailable` only when `providerRuntimeHealth.state === "ready"`; `authDetector.verifyCursorApiKey` validates model access (`models.list`) in addition to identity (`Cursor.me`) and reports both auth and non-auth failures; `modelOptions` and the model picker only surface Cursor models after runtime is verified.
- **Browser attachment fix**: `builtInBrowserService.serviceForProjectRoot` now calls `attachToWindow` immediately on every project-scoped resolution, and `main.ts` calls `attachToWindow` in `bindWindowToProject` so views are attached on project switches without waiting for a window-focus event.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changed paths are well-guarded and covered by the new tests.

The runtime-readiness gating, IPC hardening, and browser-attachment fix are each narrow, self-contained changes with direct test coverage. No pre-existing guarantees are removed, and the fallback loader degrades gracefully when packaged-runtime resolution fails.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/ai/cursorSdkLoader.ts | New file: implements a cached, fallback-aware Cursor SDK loader with require-based resolution for packaged runtimes; exposes resetCursorSdkLoaderForTests for clean test isolation. |
| apps/desktop/src/main/services/ai/droidSdkLoader.ts | New file: symmetric counterpart to cursorSdkLoader for the Droid SDK; identical loading and error-classification logic targeting @factory/droid-sdk. |
| apps/desktop/src/main/services/ai/providerConnectionStatus.ts | Cursor runtimeAvailable now requires providerRuntimeHealth.state === 'ready' instead of just auth presence; blocker text updated to guide users through verification. |
| apps/desktop/src/main/services/ai/authDetector.ts | verifyCursorApiKey now validates model access via Cursor.models.list in addition to Cursor.me; reports runtime-failure (not just auth-failure) for non-auth errors like SDK unavailability or empty model list. |
| apps/desktop/src/main/services/chat/cursorSdkPool.ts | Adds sendWorkerMessage helper that guards against closed IPC channels; adds child.on('error') handler; refactors rejectPending/cleanupPoolEntry to be shared between error and exit handlers. |
| apps/desktop/src/main/services/chat/droidSdkPool.ts | Symmetric IPC hardening mirroring cursorSdkPool; cleanupPoolEntry for droid intentionally omits path cleanup since the droid pool entry carries no cacheRoot/stateRoot/socketPath. |
| apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.ts | serviceForProjectRoot now calls service.attachToWindow(win) after resolving the per-project service; attachToWindow short-circuits when the window object is already the same to avoid redundant re-attachment teardown. |
| apps/desktop/src/main/main.ts | Calls builtInBrowserService.attachToWindow(win) inside bindWindowToProject so browser views are attached immediately on project switch, not only on the next window-focus event. |
| apps/desktop/src/renderer/components/settings/ProvidersSection.tsx | Introduces a reusable AlertBanner with dismiss support; verification failures now populate the error banner with the actual error message; 'Invalid key' label renamed to 'Verification failed'. |
| apps/desktop/src/main/services/chat/cursorModelsDiscovery.ts | SDK resolution failures now short-circuit the HTTP fallback path, record a TTL-bounded failure cache entry, and report to provider health; warmCursorModelsFromSdk skips warming during recent SDK failures. |
| apps/desktop/src/renderer/lib/modelOptions.ts | Cursor SDK models are only included in derived model IDs when availableProviders.cursor === true or providerConnections.cursor.runtimeAvailable === true; stored key alone no longer unlocks them. |
| apps/ade-cli/tsup.config.ts | Adds droidSdkWorker as an explicit tsup entry point so the Droid worker is emitted into the ADE CLI bundle alongside the Cursor worker. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/renderer/components/settings/ProvidersSection.tsx`, line 514-538 ([link](https://github.com/arul28/ade/blob/7cc1872ccda564285a0ecb127213ad9b052acc92/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx#L514-L538)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`notice` and `error` banners can stack simultaneously**

   Neither `setNotice` nor `setError` clears its counterpart before setting a value. A user who successfully verifies a key (notice appears, they don't dismiss it) and then immediately tries re-verification that fails will see both the green "Cursor connection verified." banner and the new red error banner at the same time. The same applies in the `verifyApiKey` path. Adding `setError(null)` before `setNotice(...)` and `setNotice(null)` before `setError(...)` in each branch would prevent the overlap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
   Line: 514-538

   Comment:
   **`notice` and `error` banners can stack simultaneously**

   Neither `setNotice` nor `setError` clears its counterpart before setting a value. A user who successfully verifies a key (notice appears, they don't dismiss it) and then immediately tries re-verification that fails will see both the green "Cursor connection verified." banner and the new red error banner at the same time. The same applies in the `verifyApiKey` path. Adding `setError(null)` before `setNotice(...)` and `setNotice(null)` before `setError(...)` in each branch would prevent the overlap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fsettings%2FProvidersSection.tsx%0ALine%3A%20514-538%0A%0AComment%3A%0A**%60notice%60%20and%20%60error%60%20banners%20can%20stack%20simultaneously**%0A%0ANeither%20%60setNotice%60%20nor%20%60setError%60%20clears%20its%20counterpart%20before%20setting%20a%20value.%20A%20user%20who%20successfully%20verifies%20a%20key%20%28notice%20appears%2C%20they%20don't%20dismiss%20it%29%20and%20then%20immediately%20tries%20re-verification%20that%20fails%20will%20see%20both%20the%20green%20%22Cursor%20connection%20verified.%22%20banner%20and%20the%20new%20red%20error%20banner%20at%20the%20same%20time.%20The%20same%20applies%20in%20the%20%60verifyApiKey%60%20path.%20Adding%20%60setError%28null%29%60%20before%20%60setNotice%28...%29%60%20and%20%60setNotice%28null%29%60%20before%20%60setError%28...%29%60%20in%20each%20branch%20would%20prevent%20the%20overlap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=546&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Stabilize background CLI draft test"](https://github.com/arul28/ade/commit/ca8676c23ec674549c83319d128a09482a61f1ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36524238)</sub>

<!-- /greptile_comment -->