### PR TITLE
Chat 20260609 123514

### DIFF
--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
@@ -2058,7 +2058,6 @@ function registerLaneRemoteCommands({ args, register }: RemoteCommandRegistratio
   register("lanes.listRebaseSuggestions", { viewerAllowed: true }, async () => args.rebaseSuggestionService?.listSuggestions() ?? []);
   register("lanes.dismissRebaseSuggestion", { viewerAllowed: true, queueable: true }, async (payload) => {
     const laneId = requireString(payload.laneId, "lanes.dismissRebaseSuggestion requires laneId.");
-    args.conflictService?.dismissRebase(laneId);
     if (args.rebaseSuggestionService) {
       await args.rebaseSuggestionService.dismiss({ laneId });
     }
@@ -2067,8 +2066,6 @@ function registerLaneRemoteCommands({ args, register }: RemoteCommandRegistratio
   register("lanes.deferRebaseSuggestion", { viewerAllowed: true, queueable: true }, async (payload) => {
     const laneId = requireString(payload.laneId, "lanes.deferRebaseSuggestion requires laneId.");
     const minutes = Math.max(5, Math.min(7 * 24 * 60, Math.floor(asOptionalNumber(payload.minutes) ?? 60)));
-    const until = new Date(Date.now() + minutes * 60_000).toISOString();
-    args.conflictService?.deferRebase(laneId, until);
     if (args.rebaseSuggestionService) {
       await args.rebaseSuggestionService.defer({
         laneId,

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -1450,14 +1450,11 @@ function buildLaneDomainService(runtime: AdeRuntime): OpaqueService {
     },
     dismissRebaseSuggestion: async (args?: { laneId?: string }) => {
       const laneId = requireNonEmptyString(args?.laneId, "laneId");
-      runtime.conflictService?.dismissRebase(laneId);
       await runtime.rebaseSuggestionService?.dismiss({ laneId });
     },
     deferRebaseSuggestion: async (args?: { laneId?: string; minutes?: number }) => {
       const laneId = requireNonEmptyString(args?.laneId, "laneId");
       const minutes = Math.max(5, Math.min(7 * 24 * 60, Math.floor(args?.minutes ?? 60)));
-      const until = new Date(Date.now() + minutes * 60_000).toISOString();
-      runtime.conflictService?.deferRebase(laneId, until);
       await runtime.rebaseSuggestionService?.defer({ laneId, minutes });
     },
     listAutoRebaseStatuses: () =>

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -4066,8 +4066,13 @@ export function createLaneService({
         let parentHead = "";
         let parentTargetLabel = "";
         let operationMetadata: Record<string, unknown> = {
+          runId,
+          rootLaneId: target.id,
           reason,
           recursive: scope === "lane_and_descendants",
+          scope,
+          pushMode,
+          actor,
         };
         try {
           const parent = lane.parent_lane_id ? getLaneRow(lane.parent_lane_id) : null;

--- a/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
@@ -487,6 +487,14 @@ function createMockConflictService() {
   } as any;
 }
 
+function createMockRebaseSuggestionService() {
+  return {
+    listSuggestions: vi.fn().mockResolvedValue([]),
+    dismiss: vi.fn().mockResolvedValue(undefined),
+    defer: vi.fn().mockResolvedValue(undefined),
+  } as any;
+}
+
 function createMockWorkerAgentService() {
   return {
     listAgents: vi.fn().mockReturnValue([]),
@@ -610,6 +618,7 @@ describe("createSyncRemoteCommandService", () => {
   let linearSyncService: ReturnType<typeof createMockLinearSyncService>;
   let linearCredentialService: ReturnType<typeof createMockLinearCredentialService>;
   let conflictService: ReturnType<typeof createMockConflictService>;
+  let rebaseSuggestionService: ReturnType<typeof createMockRebaseSuggestionService>;
   let processService: ReturnType<typeof createMockProcessService>;
   let issueInventoryService: ReturnType<typeof createMockIssueInventoryService>;
   let queueLandingService: ReturnType<typeof createMockQueueLandingService>;
@@ -631,6 +640,7 @@ describe("createSyncRemoteCommandService", () => {
     linearSyncService = createMockLinearSyncService();
     linearCredentialService = createMockLinearCredentialService();
     conflictService = createMockConflictService();
+    rebaseSuggestionService = createMockRebaseSuggestionService();
     processService = createMockProcessService();
     issueInventoryService = createMockIssueInventoryService();
     queueLandingService = createMockQueueLandingService();
@@ -652,6 +662,7 @@ describe("createSyncRemoteCommandService", () => {
       getLinearIssueTracker: () => linearIssueTracker,
       getLinearSyncService: () => linearSyncService,
       conflictService,
+      rebaseSuggestionService,
       processService,
       logger: createLogger() as any,
     });
@@ -3172,36 +3183,29 @@ describe("createSyncRemoteCommandService", () => {
       }))).rejects.toThrow("lanes.rebasePush requires laneIds.");
     });
 
-    it("lanes.dismissRebaseSuggestion routes to conflictService even without a rebaseSuggestionService", async () => {
+    it("lanes.dismissRebaseSuggestion hides the banner without dismissing the rebase need", async () => {
       const result = await service.execute(makePayload("lanes.dismissRebaseSuggestion", {
         laneId: "lane-1",
       }));
-      expect(conflictService.dismissRebase).toHaveBeenCalledWith("lane-1");
+      expect(rebaseSuggestionService.dismiss).toHaveBeenCalledWith({ laneId: "lane-1" });
+      expect(conflictService.dismissRebase).not.toHaveBeenCalled();
       expect(result).toEqual({ ok: true });
     });
 
-    it("lanes.deferRebaseSuggestion clamps minutes and forwards an ISO timestamp to conflictService", async () => {
-      vi.useFakeTimers();
-      try {
-        vi.setSystemTime(new Date("2026-04-15T22:00:00.000Z"));
-        await service.execute(makePayload("lanes.deferRebaseSuggestion", {
-          laneId: "lane-1",
-          minutes: 1,
-        }));
-        expect(conflictService.deferRebase).toHaveBeenCalledWith(
-          "lane-1",
-          "2026-04-15T22:05:00.000Z",
-        );
-        conflictService.deferRebase.mockClear();
-        await service.execute(makePayload("lanes.deferRebaseSuggestion", {
-          laneId: "lane-1",
-          minutes: 60 * 24 * 30,
-        }));
-        const [, until] = conflictService.deferRebase.mock.calls.at(-1) ?? [];
-        expect(until).toBe(new Date(Date.parse("2026-04-15T22:00:00.000Z") + 7 * 24 * 60 * 60_000).toISOString());
-      } finally {
-        vi.useRealTimers();
-      }
+    it("lanes.deferRebaseSuggestion clamps minutes and snoozes the banner without deferring the rebase need", async () => {
+      await service.execute(makePayload("lanes.deferRebaseSuggestion", {
+        laneId: "lane-1",
+        minutes: 1,
+      }));
+      expect(rebaseSuggestionService.defer).toHaveBeenCalledWith({ laneId: "lane-1", minutes: 5 });
+      expect(conflictService.deferRebase).not.toHaveBeenCalled();
+
+      await service.execute(makePayload("lanes.deferRebaseSuggestion", {
+        laneId: "lane-1",
+        minutes: 60 * 24 * 30,
+      }));
+      expect(rebaseSuggestionService.defer).toHaveBeenLastCalledWith({ laneId: "lane-1", minutes: 7 * 24 * 60 });
+      expect(conflictService.deferRebase).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/renderer/components/app/App.workKeepAlive.test.tsx
+++ b/apps/desktop/src/renderer/components/app/App.workKeepAlive.test.tsx
@@ -7,6 +7,8 @@ import type * as ReactNamespace from "react";
 import type * as RouterNamespace from "react-router-dom";
 import { ADE_OPEN_BUILT_IN_BROWSER_EVENT } from "../../lib/openExternal";
 
+const ROUTE_INTEGRATION_TIMEOUT_MS = 45_000;
+
 const workLifecycle = vi.hoisted(() => ({
   mounts: 0,
   unmounts: 0,
@@ -186,6 +188,7 @@ vi.mock("../lanes/LanesPage", async () => {
 
 describe("App Work route keep-alive", () => {
   beforeEach(() => {
+    cleanup();
     vi.clearAllMocks();
     workLifecycle.mounts = 0;
     workLifecycle.unmounts = 0;
@@ -257,7 +260,7 @@ describe("App Work route keep-alive", () => {
     });
     expect(workLifecycle.mounts).toBe(1);
     expect(workLifecycle.unmounts).toBe(0);
-  });
+  }, ROUTE_INTEGRATION_TIMEOUT_MS);
 
   it("parks the native Work browser view when the Work route is backgrounded", async () => {
     const { App } = await import("./App");
@@ -285,7 +288,7 @@ describe("App Work route keep-alive", () => {
         visible: false,
       });
     });
-  });
+  }, ROUTE_INTEGRATION_TIMEOUT_MS);
 
   it("reveals the Work browser pane when an ADE browser URL opens from another tab", async () => {
     window.history.replaceState({}, "", "/files");
@@ -310,7 +313,7 @@ describe("App Work route keep-alive", () => {
         workSidebarTab: "browser",
       }),
     );
-  });
+  }, ROUTE_INTEGRATION_TIMEOUT_MS);
 
   it("hydrates project stores with launch clipboard reminder preferences", async () => {
     appStoreState.launchPromptClipboardNoticeEnabled = false;

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -5797,7 +5797,7 @@ describe("AgentChatPane submit recovery", () => {
     await waitFor(() => {
       expect(create).toHaveBeenCalledTimes(2);
       expect(send).toHaveBeenCalledTimes(2);
-    });
+    }, { timeout: 5000 });
     expect(writeClipboardText).toHaveBeenCalledTimes(1);
     expect(writeClipboardText).toHaveBeenCalledWith("Fix the login bug");
     expect(create).toHaveBeenNthCalledWith(1, expect.objectContaining({

--- a/apps/desktop/src/renderer/components/prs/PrRebaseBanner.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/PrRebaseBanner.test.tsx
@@ -35,7 +35,9 @@ describe("PrRebaseBanner", () => {
         execute: vi.fn(async () => {
           throw new Error("rebase failed");
         }),
-        dismiss: vi.fn(),
+      },
+      lanes: {
+        dismissRebaseSuggestion: vi.fn(),
       },
     };
 
@@ -58,7 +60,9 @@ describe("PrRebaseBanner", () => {
     (window as any).ade = {
       rebase: {
         execute: vi.fn(async () => undefined),
-        dismiss: vi.fn(),
+      },
+      lanes: {
+        dismissRebaseSuggestion: vi.fn(),
       },
     };
 
@@ -76,5 +80,35 @@ describe("PrRebaseBanner", () => {
 
     await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
     expect(onRebaseDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the banner without dismissing the active rebase need", async () => {
+    const dismissRebaseSuggestion = vi.fn(async () => undefined);
+    const onRefresh = vi.fn(async () => undefined);
+    (window as any).ade = {
+      rebase: {
+        execute: vi.fn(async () => undefined),
+        dismiss: vi.fn(),
+      },
+      lanes: {
+        dismissRebaseSuggestion,
+      },
+    };
+
+    render(
+      <PrRebaseBanner
+        laneId="lane-1"
+        rebaseNeeds={[makeNeed()]}
+        onTabChange={() => {}}
+        onRefresh={onRefresh}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /HIDE BANNER/i }));
+
+    await waitFor(() => expect(dismissRebaseSuggestion).toHaveBeenCalledWith({ laneId: "lane-1" }));
+    expect((window as any).ade.rebase.dismiss).not.toHaveBeenCalled();
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/2 commits behind main/i)).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/components/prs/PrRebaseBanner.tsx
+++ b/apps/desktop/src/renderer/components/prs/PrRebaseBanner.tsx
@@ -19,8 +19,7 @@ export function PrRebaseBanner({ laneId, rebaseNeeds, autoRebaseStatuses, onTabC
 
   const need = React.useMemo(() => {
     const laneNeed = findLaneBaseNeed(rebaseNeeds, laneId);
-    if (!laneNeed || laneNeed.behindBy <= 0 || laneNeed.dismissedAt) return null;
-    if (laneNeed.deferredUntil && new Date(laneNeed.deferredUntil) > new Date()) return null;
+    if (!laneNeed || laneNeed.behindBy <= 0) return null;
     return laneNeed;
   }, [laneId, rebaseNeeds]);
   const autoStatus = autoRebaseStatuses?.find((s) => s.laneId === laneId);
@@ -93,7 +92,7 @@ export function PrRebaseBanner({ laneId, rebaseNeeds, autoRebaseStatuses, onTabC
   const handleDismiss = async () => {
     setActionError(null);
     try {
-      await window.ade.rebase.dismiss(laneId);
+      await window.ade.lanes.dismissRebaseSuggestion({ laneId });
       await onRefresh?.();
       setDismissed(true);
     } catch (error) {
@@ -168,7 +167,7 @@ export function PrRebaseBanner({ laneId, rebaseNeeds, autoRebaseStatuses, onTabC
             }}
             onClick={() => void handleDismiss()}
           >
-            DISMISS
+            HIDE BANNER
           </button>
         </div>
       </div>

--- a/apps/desktop/src/renderer/components/prs/tabs/IntegrationTab.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/IntegrationTab.tsx
@@ -24,6 +24,7 @@ import { isDirtyWorktreeErrorMessage, stripDirtyWorktreePrefix } from "../shared
 import { deriveIntegrationPrLiveModel } from "../shared/integrationPrModel";
 import { PrAiResolverPanel } from "../shared/PrAiResolverPanel";
 import { findLaneBaseNeed, findMatchingRebaseNeed, rebaseNeedItemKey } from "../shared/rebaseNeedUtils";
+import { getActiveRebaseNeeds } from "./rebaseWorkflowModel";
 
 /* ---- Outcome dot with design-system colors ---- */
 
@@ -603,8 +604,8 @@ export function IntegrationTab({ prs, lanes, mergeContextByPrId, mergeMethod, se
   );
   const rebaseNeedByLaneId = React.useMemo(
     () => new Map(
-      rebaseNeeds
-        .filter((need) => need.kind === "lane_base" && need.behindBy > 0 && !need.dismissedAt)
+      getActiveRebaseNeeds(rebaseNeeds)
+        .filter((need) => need.kind === "lane_base")
         .map((need) => [need.laneId, need] as const),
     ),
     [rebaseNeeds],

--- a/apps/desktop/src/renderer/components/prs/tabs/RebaseTab.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/RebaseTab.tsx
@@ -500,7 +500,7 @@ export function RebaseTab({
     if (!selectedNeed) return;
     setRebaseError(null);
     try {
-      await window.ade.rebase.dismiss(selectedNeed.laneId);
+      await window.ade.lanes.dismissRebaseSuggestion({ laneId: selectedNeed.laneId });
       await onRefresh();
     } catch (err: unknown) {
       setRebaseError(err instanceof Error ? err.message : String(err));
@@ -509,10 +509,9 @@ export function RebaseTab({
 
   const handleDefer = async () => {
     if (!selectedNeed) return;
-    const until = new Date(Date.now() + 4 * 60 * 60 * 1000).toISOString();
     setRebaseError(null);
     try {
-      await window.ade.rebase.defer(selectedNeed.laneId, until);
+      await window.ade.lanes.deferRebaseSuggestion({ laneId: selectedNeed.laneId, minutes: 4 * 60 });
       await onRefresh();
     } catch (err: unknown) {
       setRebaseError(err instanceof Error ? err.message : String(err));
@@ -1329,7 +1328,7 @@ export function RebaseTab({
                 >
                   <Clock size={12} className="mr-1" />
                   <span className="font-mono font-bold uppercase" style={{ fontSize: 10, letterSpacing: "1px" }}>
-                    DEFER 4H
+                    SNOOZE BANNER 4H
                   </span>
                 </Button>
                 <Button
@@ -1341,7 +1340,7 @@ export function RebaseTab({
                 >
                   <XCircle size={12} className="mr-1" />
                   <span className="font-mono font-bold uppercase" style={{ fontSize: 10, letterSpacing: "1px" }}>
-                    DISMISS
+                    HIDE BANNER
                   </span>
                 </Button>
               </div>

--- a/apps/desktop/src/renderer/components/prs/tabs/WorkflowsTab.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/WorkflowsTab.tsx
@@ -14,6 +14,7 @@ import { EmptyState } from "../../ui/EmptyState";
 import type {
   IntegrationProposal,
   LaneSummary,
+  OperationRecord,
   PrMergeContext,
   PrWithConflicts,
 } from "../../../../shared/types";
@@ -27,6 +28,13 @@ import { rebaseNeedItemKey } from "../shared/rebaseNeedUtils";
 import { filterRebaseAttentionStatuses } from "../shared/rebaseAttentionUtils";
 import { usePrs } from "../state/PrsContext";
 import { getQueueWorkflowBucket } from "./queueWorkflowModel";
+import {
+  getActiveRebaseNeeds,
+  getRebaseHistoryOperations,
+  getRebaseOperationLabel,
+  parseRebaseOperationMetadata,
+  sortRebaseHistoryOperations,
+} from "./rebaseWorkflowModel";
 import { selectActiveProjectRoot, useAppStore } from "../../../state/appStore";
 
 const CATEGORY_THEMES = {
@@ -40,6 +48,8 @@ type WorkflowView = "active" | "history";
 const WORKFLOWS_VIEW_STORAGE_KEY = "ade:prs:workflows:view";
 const WORKFLOWS_CACHE_TTL_MS = 120_000;
 const WORKFLOWS_CACHE_DISABLED = import.meta.env.MODE === "test";
+const REBASE_HISTORY_OPERATION_LIMIT = 100;
+const REBASE_HISTORY_PULL_OPERATION_LIMIT = 1000;
 
 type WorkflowsWarmCache = {
   view: WorkflowView;
@@ -252,44 +262,63 @@ function QueueHistoryPanel({
 }
 
 function RebaseHistoryPanel({
-  needs,
+  operations,
+  loading,
 }: {
-  needs: import("../../../../shared/types").RebaseNeed[];
+  operations: OperationRecord[];
+  loading?: boolean;
 }) {
-  if (!needs.length) {
-    return <EmptyState title="No rebase history" description="Deferred, dismissed, and recently resolved rebase items will appear here." />;
+  if (loading && !operations.length) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", padding: 32, gap: 8 }}>
+        <ArrowsClockwise size={16} className="animate-spin" style={{ color: COLORS.textMuted }} />
+        <span style={{ fontSize: 13, color: COLORS.textMuted, fontFamily: SANS_FONT }}>Loading rebase history...</span>
+      </div>
+    );
+  }
+
+  if (!operations.length) {
+    return <EmptyState title="No ADE rebase history yet" description="Completed, failed, and canceled ADE rebase operations will appear here." />;
   }
 
   const theme = CATEGORY_THEMES.rebase;
   const statusColors: Record<string, string> = {
-    "dismissed": "#EF4444",
-    "deferred": "#F59E0B",
-    "resolved recently": COLORS.success,
+    succeeded: COLORS.success,
+    failed: COLORS.danger,
+    canceled: COLORS.warning,
+    running: theme.color,
   };
+  const shortSha = (sha: string | null) => sha ? sha.slice(0, 8) : "unknown";
 
   return (
     <div style={{ display: "grid", gap: 14, padding: 16 }}>
-      {needs.map((need) => {
-        const statusLabel = need.dismissedAt
-          ? "dismissed"
-          : need.deferredUntil && new Date(need.deferredUntil) > new Date()
-            ? "deferred"
-            : "resolved recently";
-        const timestamp = need.dismissedAt ?? need.deferredUntil ?? null;
-        const badgeColor = statusColors[statusLabel] ?? theme.color;
+      {operations.map((operation) => {
+        const metadata = parseRebaseOperationMetadata(operation);
+        const badgeColor = statusColors[operation.status] ?? theme.color;
+        const target =
+          typeof metadata.baseTargetRef === "string" ? metadata.baseTargetRef
+            : typeof metadata.baseBranchRef === "string" ? metadata.baseBranchRef
+              : typeof metadata.parentBranchRef === "string" ? metadata.parentBranchRef
+                : null;
+        const actor = typeof metadata.actor === "string" ? metadata.actor : null;
         return (
-          <div key={need.laneId} style={cardStyle({ background: theme.bgSubtle, borderColor: theme.border, borderLeft: `3px solid ${theme.color}` })}>
+          <div key={operation.id} style={cardStyle({ background: theme.bgSubtle, borderColor: theme.border, borderLeft: `3px solid ${theme.color}` })}>
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
               <div>
-                <div style={{ fontSize: 15, fontWeight: 700, color: COLORS.textPrimary, fontFamily: SANS_FONT }}>{need.laneName}</div>
+                <div style={{ fontSize: 15, fontWeight: 700, color: COLORS.textPrimary, fontFamily: SANS_FONT }}>{operation.laneName ?? operation.laneId ?? "Unknown lane"}</div>
                 <div style={{ marginTop: 5, fontSize: 12, color: COLORS.textMuted, fontFamily: SANS_FONT }}>
-                  base <span style={{ fontFamily: MONO_FONT, fontSize: 11 }}>{need.baseBranch}</span> · behind <span style={{ fontFamily: MONO_FONT, fontSize: 11, color: badgeColor, fontWeight: 600 }}>{need.behindBy}</span>
+                  {getRebaseOperationLabel(operation)}
+                  {target ? <> · target <span style={{ fontFamily: MONO_FONT, fontSize: 11 }}>{target}</span></> : null}
+                  {actor ? <> · actor <span style={{ fontFamily: MONO_FONT, fontSize: 11 }}>{actor}</span></> : null}
                 </div>
               </div>
-              <span style={inlineBadge(badgeColor, { background: `${badgeColor}18`, fontWeight: 600, borderRadius: 8 })}>{statusLabel}</span>
+              <span style={inlineBadge(badgeColor, { background: `${badgeColor}18`, fontWeight: 600, borderRadius: 8 })}>{operation.status}</span>
             </div>
             <div style={{ marginTop: 10, fontSize: 12, fontFamily: SANS_FONT, color: COLORS.textSecondary }}>
-              {timestamp ? <>Updated <span style={{ fontFamily: MONO_FONT, fontSize: 11 }}>{formatTimestampShort(timestamp)}</span></> : "Captured in workflow history."}
+              Started <span style={{ fontFamily: MONO_FONT, fontSize: 11 }}>{formatTimestampShort(operation.startedAt)}</span>
+              {operation.endedAt ? <> · ended <span style={{ fontFamily: MONO_FONT, fontSize: 11 }}>{formatTimestampShort(operation.endedAt)}</span></> : null}
+              {" · "}
+              <span style={{ fontFamily: MONO_FONT, fontSize: 11 }}>{shortSha(operation.preHeadSha)} {"->"} {shortSha(operation.postHeadSha)}</span>
             </div>
           </div>
         );
@@ -681,7 +710,10 @@ export function WorkflowsTab({
     () => warmCache?.integrationWorkflows ?? [],
   );
   const [loading, setLoading] = React.useState(() => !warmCache);
-  const [error, setError] = React.useState<string | null>(null);
+  const [rebaseHistoryOperations, setRebaseHistoryOperations] = React.useState<OperationRecord[]>([]);
+  const [rebaseHistoryLoading, setRebaseHistoryLoading] = React.useState(true);
+  const [workflowError, setWorkflowError] = React.useState<string | null>(null);
+  const [rebaseHistoryError, setRebaseHistoryError] = React.useState<string | null>(null);
   const workflowsLoadedRef = React.useRef(Boolean(warmCache));
 
   const setView = React.useCallback((next: WorkflowView) => {
@@ -705,21 +737,47 @@ export function WorkflowsTab({
       return;
     }
     if (!options?.silent) setLoading(true);
-    setError(null);
+    setWorkflowError(null);
     try {
       const next = await window.ade.prs.listIntegrationWorkflows({ view: "all" });
       workflowsLoadedRef.current = true;
       setIntegrationWorkflows(next);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setWorkflowError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
     }
   }, [cacheKey]);
 
+  const loadRebaseHistory = React.useCallback(async () => {
+    setRebaseHistoryLoading(true);
+    try {
+      const operationGroups = await Promise.all([
+        window.ade.history.listOperations({ kind: "lane_rebase", limit: REBASE_HISTORY_OPERATION_LIMIT }),
+        window.ade.history.listOperations({ kind: "git_sync_rebase", limit: REBASE_HISTORY_OPERATION_LIMIT }),
+        window.ade.history.listOperations({ kind: "git_pull", limit: REBASE_HISTORY_PULL_OPERATION_LIMIT }),
+      ]);
+      const operationsById = new Map<string, OperationRecord>();
+      for (const operation of getRebaseHistoryOperations(operationGroups.flat())) {
+        operationsById.set(operation.id, operation);
+      }
+      setRebaseHistoryOperations(sortRebaseHistoryOperations(Array.from(operationsById.values())));
+      setRebaseHistoryError(null);
+    } catch (err) {
+      setRebaseHistoryError(err instanceof Error ? `Rebase history unavailable: ${err.message}` : `Rebase history unavailable: ${String(err)}`);
+      setRebaseHistoryOperations([]);
+    } finally {
+      setRebaseHistoryLoading(false);
+    }
+  }, []);
+
   React.useEffect(() => {
     void loadWorkflows({ silent: Boolean(warmCache), skipFreshCache: true });
   }, [loadWorkflows, warmCache]);
+
+  React.useEffect(() => {
+    void loadRebaseHistory();
+  }, [loadRebaseHistory]);
 
   React.useEffect(() => {
     if (WORKFLOWS_CACHE_DISABLED) return;
@@ -735,8 +793,9 @@ export function WorkflowsTab({
     await Promise.all([
       onRefreshAll().catch(() => {}),
       loadWorkflows(),
+      loadRebaseHistory(),
     ]);
-  }, [loadWorkflows, onRefreshAll]);
+  }, [loadRebaseHistory, loadWorkflows, onRefreshAll]);
 
   const queueWorkflowGroups = React.useMemo(
     () => buildQueueWorkflowGroups({ prs, mergeContextByPrId, lanes, queueStates }),
@@ -751,9 +810,9 @@ export function WorkflowsTab({
     history: queueWorkflowGroups.filter((group) => group.bucket === "history"),
   }), [queueWorkflowGroups]);
   const rebaseByView = React.useMemo(() => ({
-    active: rebaseNeeds.filter((need) => !need.dismissedAt && !(need.deferredUntil && new Date(need.deferredUntil) > new Date()) && need.behindBy > 0),
-    history: rebaseNeeds.filter((need) => need.dismissedAt || (need.deferredUntil && new Date(need.deferredUntil) > new Date()) || need.behindBy === 0),
-  }), [rebaseNeeds]);
+    active: getActiveRebaseNeeds(rebaseNeeds),
+    history: rebaseHistoryOperations,
+  }), [rebaseHistoryOperations, rebaseNeeds]);
   const rebaseAttentionByView = React.useMemo(() => ({
     active: filterRebaseAttentionStatuses({
       autoRebaseStatuses,
@@ -775,11 +834,6 @@ export function WorkflowsTab({
       if (view !== "active") setView("active");
       return;
     }
-    const historyKeys = new Set(rebaseByView.history.map(rebaseNeedItemKey));
-    if (historyKeys.has(selectedRebaseItemId) && view !== "history") {
-      setView("history");
-      return;
-    }
     const historyAttentionLaneIds = new Set(rebaseAttentionByView.history.map((status) => status.laneId));
     if (historyAttentionLaneIds.has(selectedRebaseItemId) && view !== "history") {
       setView("history");
@@ -789,10 +843,13 @@ export function WorkflowsTab({
   const counts = {
     integration: integrationByView[view].length,
     queue: queueByView[view].length,
-    rebase: rebaseByView[view].length + rebaseAttentionByView[view].length,
+    rebase: view === "history"
+      ? rebaseHistoryOperations.length
+      : rebaseByView.active.length + rebaseAttentionByView.active.length,
   };
 
   const activeTheme = CATEGORY_THEMES[activeCategory];
+  const error = workflowError ?? rebaseHistoryError;
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: 0 }}>
@@ -970,7 +1027,7 @@ export function WorkflowsTab({
               onNavigate={(path) => navigate(path)}
             />
           ) : (
-            <RebaseHistoryPanel needs={rebaseByView.history} />
+            <RebaseHistoryPanel operations={rebaseHistoryOperations} loading={rebaseHistoryLoading} />
           )
         ) : null}
       </div>

--- a/apps/desktop/src/renderer/components/prs/tabs/rebaseWorkflowModel.test.ts
+++ b/apps/desktop/src/renderer/components/prs/tabs/rebaseWorkflowModel.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { OperationRecord, RebaseNeed } from "../../../../shared/types";
+import {
+  getActiveRebaseNeeds,
+  getRebaseHistoryOperations,
+  getRebaseOperationLabel,
+  parseRebaseOperationMetadata,
+  sortRebaseHistoryOperations,
+} from "./rebaseWorkflowModel";
+
+function makeNeed(overrides: Partial<RebaseNeed> = {}): RebaseNeed {
+  return {
+    laneId: overrides.laneId ?? "lane-1",
+    laneName: overrides.laneName ?? "Feature Lane",
+    kind: overrides.kind ?? "lane_base",
+    baseBranch: overrides.baseBranch ?? "main",
+    behindBy: overrides.behindBy ?? 3,
+    conflictPredicted: overrides.conflictPredicted ?? false,
+    conflictingFiles: overrides.conflictingFiles ?? [],
+    prId: overrides.prId ?? null,
+    groupContext: overrides.groupContext ?? null,
+    dismissedAt: overrides.dismissedAt ?? null,
+    deferredUntil: overrides.deferredUntil ?? null,
+  };
+}
+
+function makeOperation(overrides: Partial<OperationRecord> = {}): OperationRecord {
+  return {
+    id: overrides.id ?? "op-1",
+    laneId: overrides.laneId ?? "lane-1",
+    laneName: overrides.laneName ?? "Feature Lane",
+    kind: overrides.kind ?? "lane_rebase",
+    startedAt: overrides.startedAt ?? "2026-06-09T12:00:00.000Z",
+    endedAt: overrides.endedAt ?? "2026-06-09T12:01:00.000Z",
+    status: overrides.status ?? "succeeded",
+    preHeadSha: overrides.preHeadSha ?? "1111111111111111111111111111111111111111",
+    postHeadSha: overrides.postHeadSha ?? "2222222222222222222222222222222222222222",
+    metadataJson: overrides.metadataJson ?? null,
+  };
+}
+
+describe("getActiveRebaseNeeds", () => {
+  it("keeps dismissed and deferred still-behind needs actionable", () => {
+    const needs = [
+      makeNeed({ laneId: "dismissed", behindBy: 42, dismissedAt: "2026-06-07T21:50:22.774Z" }),
+      makeNeed({ laneId: "deferred", behindBy: 2, deferredUntil: "2999-01-01T00:00:00.000Z" }),
+      makeNeed({ laneId: "resolved", behindBy: 0 }),
+    ];
+
+    expect(getActiveRebaseNeeds(needs).map((need) => need.laneId)).toEqual(["dismissed", "deferred"]);
+  });
+});
+
+describe("getRebaseHistoryOperations", () => {
+  it("includes ADE rebase operations and pull --rebase operations only", () => {
+    const operations = [
+      makeOperation({ id: "lane", kind: "lane_rebase" }),
+      makeOperation({ id: "sync", kind: "git_sync_rebase" }),
+      makeOperation({ id: "pull-rebase", kind: "git_pull", metadataJson: JSON.stringify({ mode: "rebase" }) }),
+      makeOperation({ id: "pull-merge", kind: "git_pull", metadataJson: JSON.stringify({ mode: "merge" }) }),
+      makeOperation({ id: "fetch", kind: "git_fetch" }),
+    ];
+
+    expect(getRebaseHistoryOperations(operations).map((operation) => operation.id)).toEqual([
+      "lane",
+      "sync",
+      "pull-rebase",
+    ]);
+  });
+
+  it("parses metadata defensively and labels known operation kinds", () => {
+    const operation = makeOperation({
+      kind: "git_pull",
+      metadataJson: JSON.stringify({ mode: "rebase", actor: "user" }),
+    });
+
+    expect(parseRebaseOperationMetadata(operation)).toEqual({ mode: "rebase", actor: "user" });
+    expect(parseRebaseOperationMetadata(makeOperation({ metadataJson: "{" }))).toEqual({});
+    expect(getRebaseOperationLabel(operation)).toBe("Pull --rebase");
+  });
+
+  it("sorts history operations newest first", () => {
+    const older = makeOperation({ id: "older", startedAt: "2026-06-09T12:00:00.000Z" });
+    const newer = makeOperation({ id: "newer", startedAt: "2026-06-09T12:05:00.000Z" });
+
+    expect(sortRebaseHistoryOperations([older, newer]).map((operation) => operation.id)).toEqual(["newer", "older"]);
+  });
+});

--- a/apps/desktop/src/renderer/components/prs/tabs/rebaseWorkflowModel.ts
+++ b/apps/desktop/src/renderer/components/prs/tabs/rebaseWorkflowModel.ts
@@ -1,0 +1,42 @@
+import type { OperationRecord, RebaseNeed } from "../../../../shared/types";
+
+export type RebaseOperationMetadata = Record<string, unknown>;
+
+function safeParseMetadata(raw: string | null | undefined): RebaseOperationMetadata {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as RebaseOperationMetadata : {};
+  } catch {
+    return {};
+  }
+}
+
+export function getActiveRebaseNeeds(needs: RebaseNeed[]): RebaseNeed[] {
+  return needs.filter((need) => need.behindBy > 0);
+}
+
+export function parseRebaseOperationMetadata(operation: OperationRecord): RebaseOperationMetadata {
+  return safeParseMetadata(operation.metadataJson);
+}
+
+export function isRebaseHistoryOperation(operation: OperationRecord): boolean {
+  if (operation.kind === "lane_rebase" || operation.kind === "git_sync_rebase") return true;
+  if (operation.kind !== "git_pull") return false;
+  return parseRebaseOperationMetadata(operation).mode === "rebase";
+}
+
+export function getRebaseHistoryOperations(operations: OperationRecord[]): OperationRecord[] {
+  return operations.filter(isRebaseHistoryOperation);
+}
+
+export function sortRebaseHistoryOperations(operations: OperationRecord[]): OperationRecord[] {
+  return [...operations].sort((a, b) => Date.parse(b.startedAt) - Date.parse(a.startedAt));
+}
+
+export function getRebaseOperationLabel(operation: OperationRecord): string {
+  if (operation.kind === "lane_rebase") return "Lane rebase";
+  if (operation.kind === "git_sync_rebase") return "Sync rebase";
+  if (operation.kind === "git_pull") return "Pull --rebase";
+  return operation.kind.replace(/[_-]+/g, " ");
+}

--- a/docs/features/lanes/stacking.md
+++ b/docs/features/lanes/stacking.md
@@ -178,7 +178,10 @@ suggestion can re-appear.
 
 The renderer subscribes via `ade.lanes.rebaseSuggestions.event` and
 surfaces a banner on lane rows plus a `LaneRebaseBanner` inline with
-Rebase Now / Defer / Dismiss actions.
+Rebase Now / Snooze banner / Hide banner actions. Those controls only
+change suggestion visibility; PR workflow rebase needs come from
+`conflictService.scanRebaseNeeds()` and remain actionable while the lane
+is still behind.
 
 ## Auto-rebase
 
@@ -225,7 +228,10 @@ and `laneService.rebaseStart` both respect.
   `buildIntegrationSourcesByLaneId` from `renderer/lib/integrationLanes.ts`.
 - `LaneRebaseBanner` is conditionally rendered above the lane detail
   when `listRebaseSuggestions` returns a suggestion that is neither
-  dismissed nor deferred.
+  dismissed nor deferred. PR workflow banners use rebase-need drift and
+  route hide/snooze actions back to `rebaseSuggestionService`, so hiding
+  a notification does not move a still-behind lane out of the active
+  Rebase/Merge action list.
 - `rebaseNeedUtils.ts` on the renderer side provides
   `buildUpstreamRebaseChain` for surfacing the full upstream rebase
   chain in the PRs Rebase tab (see `pull-requests/stacking.md`).

--- a/docs/features/pull-requests/README.md
+++ b/docs/features/pull-requests/README.md
@@ -91,9 +91,10 @@ Renderer components (`apps/desktop/src/renderer/components/prs/`):
 | `tabs/QueueTab.tsx` | Merge queue UI. Hosts the "Automate Merging" entry point that opens `QueueAutomateMergingModal` with the queue's eligible members (everything that has not landed yet). |
 | `tabs/QueueAutomateMergingModal.tsx` | Stack-wide automation modal: edits one `PipelineSettings` config that applies to every queue member, then sequentially saves settings, calls `ade.prs.retargetBase` for non-leading members so each PR's base points at the queue's tracking branch, starts Path-to-Merge via `ade.prs.pathToMerge.start`, and polls `convergenceStateGet` every 4 s until the runtime status is terminal. Halts the sequence on the first `failed | cancelled | stopped`. Closing mid-sequence stops dispatching new starts but leaves already-launched orchestrators running. |
 | `tabs/IntegrationTab.tsx` | Integration (merge-plan) proposals and execution, including merge-into-lane selection, apply-and-resimulate, and adopted-lane cleanup messaging |
-| `tabs/RebaseTab.tsx` | Lane rebase needs (base + queue + PR target) and attention items |
-| `tabs/WorkflowsTab.tsx` | Container for queue/integration/rebase sub-tabs |
+| `tabs/RebaseTab.tsx` | Lane rebase needs (base + queue + PR target) and attention items. Hide/snooze controls only affect the lane rebase suggestion banner; still-behind needs remain actionable in the Rebase view. |
+| `tabs/WorkflowsTab.tsx` | Container for queue/integration/rebase sub-tabs. The Rebase/Merge history view is backed by actual ADE rebase operation records, while active rebase needs include any lane still behind its target regardless of banner hide/snooze state. |
 | `tabs/queueWorkflowModel.ts` | Pure model for queue tab rendering (active/history bucketing, guidance computation) |
+| `tabs/rebaseWorkflowModel.ts` | Pure model for active rebase bucketing and operation-history filtering |
 | `detail/PrDetailPane.tsx` | Selected PR detail pane: status, checks, reviews, comments, files, commits, merge readiness, bypass, Path-to-Merge convergence sub-tab (labelled "Path to Merge" in the tab list), resolver modals. Rich detail/files/commits/action-run reads render progressively; late cached snapshot hydration can update snapshot-owned fields but cannot overwrite richer live detail/files/commits already loaded for the selected PR. Switches the Overview tab between the legacy grid and the Timeline+Rails layout based on `prsTimelineRailsEnabled`. Persists the selected sub-tab (`overview | convergence | files | checks | activity`) per PR in `localStorage` under `ade:prs:detailTabs:v1`, mirrored through the `detailTab` URL param so deep links restore the last-used tab |
 | `detail/PrDetailTimelineRails.tsx` | Timeline+Rails overview: hosts the central `PrTimeline`, the left commit/checks rail, the right merge/metadata rail, the inline comment composer, and the command palette. Seeds the timeline with a synthetic `pr_opened` event followed by description, review threads, activity-stream entries (commits, comments, reviews, label changes, merges, deployments) and falls back to `args.checks` for any check that did not appear in the activity stream. Owns the deep-link scroll behaviour and the merge-bypass plumbing through to the right rail. |
 | `shared/PrTimeline.tsx` | Timeline column: renders the pre-computed `PrTimelineEvent[]` from `PrDetailTimelineRails`, handles per-PR filters (`PrTimelineFilters`), and groups events |
@@ -706,19 +707,20 @@ Builder responsibilities:
 - **Workflow cards** (`buildWorkflowCards`) — pulls non-terminal
   queue entries from `queue_landing_state` joined with `pr_groups`,
   active integration proposals via `listIntegrationWorkflows({ view:
-  "active" })`, and rebase needs from `conflictService.scanRebaseNeeds()`
-  (filtered to `kind === "lane_base"` with `behindBy > 0` and a live
-  defer window). Using the same source the desktop Rebase tab consumes
+  "active" })`, and active rebase needs from
+  `conflictService.scanRebaseNeeds()` (filtered to `kind ===
+  "lane_base"` with `behindBy > 0`). Using the same source the desktop
+  Rebase tab consumes
   via `window.ade.rebase.scanNeeds` keeps the phone's rebase cards
   in sync with the desktop — including drift against a local `main`
   that hasn't been pushed yet, which `rebaseSuggestionService` misses
-  because it only reads `origin/<base>`. Dismiss / defer rebase from
-  the phone (`lanes.dismissRebaseSuggestion`,
-  `lanes.deferRebaseSuggestion`) updates `conflictService` first so
-  the next snapshot reflects the action immediately, then forwards to
-  `rebaseSuggestionService` for legacy parity. Failures in any source
-  log a warning and skip that card category rather than failing the
-  whole snapshot.
+  because it only reads `origin/<base>`. Hide / snooze rebase-banner
+  actions (`lanes.dismissRebaseSuggestion`,
+  `lanes.deferRebaseSuggestion`) update only `rebaseSuggestionService`;
+  they do not dismiss or defer the underlying `conflictService` rebase
+  need, so unresolved drift stays actionable in PR workflow surfaces.
+  Failures in any source log a warning and skip that card category
+  rather than failing the whole snapshot.
 
 The snapshot is read-only; create/merge/close/comment actions go
 through the existing command surface (`prs.createFromLane`,


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fchat-20260609-123514-68a5fb30 num=547 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fchat-20260609-123514-68a5fb30&amp;pr=547">ade/chat-20260609-123514-68a5fb30 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=547">PR #547</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced rebase history view with detailed operation records, including execution status and metadata.

* **Improvements**
  * Updated rebase action button labels for improved clarity ("HIDE BANNER," "SNOOZE BANNER 4H").
  * Better handling of dismissed and deferred rebase suggestions in the UI.
  * Improved tracking of rebase operation metadata for more accurate history records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates dismiss and snooze banner actions away from `conflictService` and onto `rebaseSuggestionService`, making "HIDE BANNER" / "SNOOZE BANNER 4H" purely cosmetic controls that do not move still-behind lanes out of the active rebase list. The rebase history panel is rewritten to display real `OperationRecord` data instead of dismissed/deferred `RebaseNeed` entries.

- **Dismiss/defer routing change**: `conflictService.dismissRebase`/`deferRebase` calls are removed from both `syncRemoteCommandService` (CLI) and `registry.ts` (desktop); only `rebaseSuggestionService` is now updated.
- **Active needs semantics**: `getActiveRebaseNeeds` keeps dismissed and deferred but still-behind needs in the active list; `IntegrationTab`, `RebaseTab`, and `PrRebaseBanner` all adopt this helper.
- **Operation-record history**: `WorkflowsTab` now fetches `lane_rebase`, `git_sync_rebase`, and `git_pull` operations to back the Rebase history panel, with de-duplication and newest-first sorting handled in the new `rebaseWorkflowModel.ts`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changed paths are additive or well-scoped refactors with good test coverage.

The core dismiss/snooze routing change is clean and consistently applied across both the CLI and desktop surfaces. The new operation-record history panel is well-tested and introduces no regressions. Two non-blocking observations exist: loadRebaseHistory may serve stale data if the component stays mounted across a project switch, and concurrent workflow + history failures would only surface the workflow error in the shared banner.

WorkflowsTab.tsx — loadRebaseHistory dependency array and the combined error display are worth a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/prs/tabs/rebaseWorkflowModel.ts | New pure-model file; well-tested, defensive JSON parsing, stable sort. No issues found. |
| apps/desktop/src/renderer/components/prs/PrRebaseBanner.tsx | Routes dismiss to lanes.dismissRebaseSuggestion; local `dismissed` state correctly hides the banner after success; laneId-change effect resets state properly. |
| apps/desktop/src/renderer/components/prs/tabs/WorkflowsTab.tsx | Adds loadRebaseHistory with split error state; loadRebaseHistory has an empty dep array so it won't re-run when the project context changes (unlike loadWorkflows which tracks cacheKey). Also, the combined error = workflowError ?? rebaseHistoryError silently drops rebaseHistoryError when both fail together. |
| apps/desktop/src/renderer/components/prs/tabs/RebaseTab.tsx | Dismiss and defer now route to lanes.dismissRebaseSuggestion / deferRebaseSuggestion; button labels updated; logic is correct. |
| apps/desktop/src/renderer/components/prs/tabs/IntegrationTab.tsx | Adopts getActiveRebaseNeeds helper, consistently keeping dismissed/deferred but still-behind needs in the integration rebase map. |
| apps/ade-cli/src/services/sync/syncRemoteCommandService.ts | Removes conflictService dismiss/defer calls; delegates exclusively to rebaseSuggestionService. Tests updated to match. |
| apps/desktop/src/main/services/adeActions/registry.ts | Mirrors CLI change: removes conflictService dismiss/defer calls from dismissRebaseSuggestion and deferRebaseSuggestion actions. |
| apps/desktop/src/main/services/lanes/laneService.ts | Adds runId, rootLaneId, scope, pushMode, and actor to operationMetadata for richer history records. Simple additive change. |
| apps/desktop/src/renderer/components/prs/tabs/rebaseWorkflowModel.test.ts | New test file with good coverage of active-need filtering, history operation filtering, metadata parsing, and sort order. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks HIDE BANNER / SNOOZE BANNER 4H] --> B[lanes.dismissRebaseSuggestion\nor deferRebaseSuggestion]
    B --> C[rebaseSuggestionService\nsets dismissedAt / deferredUntil]
    B --> D["conflictService NOT updated\n(old behavior removed)"]
    C --> E[onRefresh called]
    E --> F[rebaseNeeds re-fetched\nfrom conflictService.scanRebaseNeeds]
    F --> G{behindBy > 0?}
    G -->|Yes| H[Need stays in\ngetActiveRebaseNeeds]
    G -->|No| I[Need filtered out\nof active list]
    H --> J[Banner hidden via\nlocal dismissed state\nor stays in RebaseTab list]
    H --> K[Still shows in\nIntegrationTab rebaseNeedByLaneId]

    subgraph History Panel
      L[loadRebaseHistory fetches\nlane_rebase + git_sync_rebase\n+ git_pull operations]
      L --> M[getRebaseHistoryOperations\nfilters to rebase-mode only]
      M --> N[Deduplicated by id\nSorted newest-first]
      N --> O[RebaseHistoryPanel renders\nOperationRecord cards]
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fprs%2Ftabs%2FWorkflowsTab.tsx%3A752-753%0A%60loadRebaseHistory%60%20captures%20no%20context-changing%20dependencies%2C%20so%20it%20only%20fires%20once%20on%20mount.%20%60loadWorkflows%60%20depends%20on%20%60cacheKey%60%20%28which%20changes%20when%20the%20active%20project%20changes%29%2C%20triggering%20a%20fresh%20fetch%20via%20its%20own%20%60useEffect%60.%20If%20%60WorkflowsTab%60%20stays%20mounted%20across%20a%20project%20switch%2C%20%60loadWorkflows%60%20re-runs%20but%20%60loadRebaseHistory%60%20silently%20keeps%20serving%20the%20previous%20project's%20history%20until%20the%20user%20manually%20clicks%20refresh.%0A%0A%60%60%60suggestion%0A%20%20const%20loadRebaseHistory%20%3D%20React.useCallback%28async%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20setRebaseHistoryLoading%28true%29%3B%0A%20%20%20%20setRebaseHistoryError%28null%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fprs%2Ftabs%2FWorkflowsTab.tsx%3A851-852%0AWhen%20%60loadWorkflows%60%20and%20%60loadRebaseHistory%60%20both%20fail%20%28e.g.%20during%20the%20parallel%20%60refreshWorkflows%60%20call%29%2C%20%60workflowError%20%3F%3F%20rebaseHistoryError%60%20will%20show%20only%20%60workflowError%60%20and%20silently%20discard%20the%20rebase%20history%20failure.%20A%20user%20trying%20to%20diagnose%20why%20the%20history%20panel%20is%20empty%20would%20see%20no%20indication%20that%20a%20separate%20error%20occurred.%0A%0A%60%60%60suggestion%0A%20%20const%20activeTheme%20%3D%20CATEGORY_THEMES%5BactiveCategory%5D%3B%0A%20%20const%20error%20%3D%20%5BworkflowError%2C%20rebaseHistoryError%5D.filter%28Boolean%29.join%28%22%20%C2%B7%20%22%29%20%7C%7C%20null%3B%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=547&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src/renderer/components/prs/tabs/WorkflowsTab.tsx:752-753
`loadRebaseHistory` captures no context-changing dependencies, so it only fires once on mount. `loadWorkflows` depends on `cacheKey` (which changes when the active project changes), triggering a fresh fetch via its own `useEffect`. If `WorkflowsTab` stays mounted across a project switch, `loadWorkflows` re-runs but `loadRebaseHistory` silently keeps serving the previous project's history until the user manually clicks refresh.

```suggestion
  const loadRebaseHistory = React.useCallback(async () => {
    setRebaseHistoryLoading(true);
    setRebaseHistoryError(null);
```

### Issue 2 of 2
apps/desktop/src/renderer/components/prs/tabs/WorkflowsTab.tsx:851-852
When `loadWorkflows` and `loadRebaseHistory` both fail (e.g. during the parallel `refreshWorkflows` call), `workflowError ?? rebaseHistoryError` will show only `workflowError` and silently discard the rebase history failure. A user trying to diagnose why the history panel is empty would see no indication that a separate error occurred.

```suggestion
  const activeTheme = CATEGORY_THEMES[activeCategory];
  const error = [workflowError, rebaseHistoryError].filter(Boolean).join(" · ") || null;
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Fix rebase workflow dismissal handling"](https://github.com/arul28/ade/commit/f13ab62952139910b2e3f579326cc02979eb43a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36541882)</sub>

<!-- /greptile_comment -->