### PR TITLE
Guard ADE brain against self-shutdown from managed sessions

### DIFF
--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -56,7 +56,10 @@ import type {
   SyncProjectSwitchResultPayload,
 } from "../../desktop/src/shared/types/sync";
 import { MACOS_VM_PHASES } from "../../desktop/src/shared/types/macosVm";
-import type { AdeServiceCommand } from "./serviceManager/common";
+import {
+  isCurrentProcessDescendantOfPid,
+  type AdeServiceCommand,
+} from "./serviceManager/common";
 import { normalizeAdeRuntimeRole, resolveAdeDefaultRole } from "./runtimeRoles";
 import type { AdeRuntime } from "./bootstrap";
 import { reseedBundledAdeSkillsForCli } from "./bootstrap";
@@ -12542,6 +12545,35 @@ function isRuntimeShutdownCloseError(error: unknown): boolean {
   return message.includes("socket closed") || message.includes("runtime endpoint closed");
 }
 
+function shouldAllowRuntimeSelfShutdown(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION === "1";
+}
+
+class RuntimeSelfShutdownBlockedError extends Error {}
+
+function runtimeSelfShutdownBlock(
+  runtimeInfo: MachineRuntimeInfo,
+  action: "repair" | "stop",
+): string | null {
+  const runtimePid = runtimeInfo.pid;
+  if (!runtimePid || shouldAllowRuntimeSelfShutdown()) return null;
+  if (!isCurrentProcessDescendantOfPid({ targetPid: runtimePid })) return null;
+  const verb = action === "repair" ? "repair/restart" : "stop";
+  return (
+    `Refusing to ${verb} ADE runtime from a command running inside that runtime ` +
+    `(pid ${runtimePid}). Run this from an external terminal, or set ` +
+    "ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION=1 if you intentionally want to tear down active ADE sessions."
+  );
+}
+
+function runtimeSelfShutdownBlockedError(
+  runtimeInfo: MachineRuntimeInfo,
+  action: "repair" | "stop",
+): RuntimeSelfShutdownBlockedError | null {
+  const message = runtimeSelfShutdownBlock(runtimeInfo, action);
+  return message ? new RuntimeSelfShutdownBlockedError(message) : null;
+}
+
 function shouldRepairMachineRuntimeServiceBeforeSpawn(
   socketPath: string,
   socketPathOverride?: string | null,
@@ -12584,6 +12616,8 @@ async function repairMachineRuntimeServiceConnection(args: {
       { enforceBuildCompatibility: args.enforceBuildCompatibility },
     );
     if (mismatch) {
+      const selfShutdownBlock = runtimeSelfShutdownBlockedError(runtimeInfo, "repair");
+      if (selfShutdownBlock) throw selfShutdownBlock;
       uninstallRuntimeService();
       client.close();
       return null;
@@ -12591,7 +12625,8 @@ async function repairMachineRuntimeServiceConnection(args: {
     const repaired = client;
     client = null;
     return repaired;
-  } catch {
+  } catch (error) {
+    if (error instanceof RuntimeSelfShutdownBlockedError) throw error;
     return null;
   } finally {
     try {
@@ -12691,6 +12726,11 @@ async function connectMachineRuntimeDaemon(
           `ADE runtime ${mismatch}.`,
         );
       }
+      const selfShutdownBlock = runtimeSelfShutdownBlockedError(runtimeInfo, "repair");
+      if (selfShutdownBlock) {
+        client.close();
+        throw selfShutdownBlock;
+      }
       await shutdownMachineRuntimeDaemon(client);
       const repaired = await repairServiceConnection();
       if (repaired) return repaired;
@@ -12716,6 +12756,11 @@ async function connectMachineRuntimeDaemon(
         { enforceBuildCompatibility },
       );
       if (restartedMismatch) {
+        const selfShutdownBlock = runtimeSelfShutdownBlockedError(restartedInfo, "repair");
+        if (selfShutdownBlock) {
+          restarted.close();
+          throw selfShutdownBlock;
+        }
         await shutdownMachineRuntimeDaemon(restarted);
         throw new Error(
           `ADE runtime ${restartedMismatch}.`,
@@ -12725,6 +12770,7 @@ async function connectMachineRuntimeDaemon(
     }
     return client;
   } catch (firstError) {
+    if (firstError instanceof RuntimeSelfShutdownBlockedError) throw firstError;
     if (!allowSpawn) throw firstError;
     const repaired = await repairServiceConnection();
     if (repaired) return repaired;
@@ -12747,6 +12793,11 @@ async function connectMachineRuntimeDaemon(
         { enforceBuildCompatibility },
       );
       if (mismatch) {
+        const selfShutdownBlock = runtimeSelfShutdownBlockedError(runtimeInfo, "repair");
+        if (selfShutdownBlock) {
+          client.close();
+          throw selfShutdownBlock;
+        }
         await shutdownMachineRuntimeDaemon(client);
         throw new Error(
           `ADE runtime ${mismatch}.`,
@@ -12754,6 +12805,7 @@ async function connectMachineRuntimeDaemon(
       }
       return client;
     } catch (secondError) {
+      if (secondError instanceof RuntimeSelfShutdownBlockedError) throw secondError;
       const firstMessage =
         firstError instanceof Error ? firstError.message : String(firstError);
       const secondMessage =
@@ -12847,7 +12899,18 @@ async function runRuntimeCommand(
         "ADE runtime endpoint",
       );
       try {
-        await initializeMachineRuntimeDaemon(client, options).catch(() => null);
+        const runtimeInfo = await initializeMachineRuntimeDaemon(client, options).catch(() => null);
+        if (runtimeInfo) {
+          const selfShutdownBlock = runtimeSelfShutdownBlock(runtimeInfo, "stop");
+          if (selfShutdownBlock) {
+            return {
+              ok: false,
+              running: true,
+              socketPath,
+              message: selfShutdownBlock,
+            };
+          }
+        }
         await shutdownMachineRuntimeDaemon(client);
       } finally {
         client.close();
@@ -12954,6 +13017,15 @@ async function runBrainCommand(
   if (sub === "restart") {
     const { installRuntimeService, uninstallRuntimeService } = await import("./serviceManager");
     const stopped = uninstallRuntimeService();
+    if (!stopped.ok) {
+      return {
+        ok: false,
+        action: "restart",
+        stopped,
+        started: null,
+        message: stopped.message,
+      };
+    }
     const started = await withAdeDefaultRole("cto", () => installRuntimeService());
     return {
       ok: stopped.ok && started.ok,

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -12551,13 +12551,14 @@ function shouldAllowRuntimeSelfShutdown(env: NodeJS.ProcessEnv = process.env): b
 
 class RuntimeSelfShutdownBlockedError extends Error {}
 
-function runtimeSelfShutdownBlock(
-  runtimeInfo: MachineRuntimeInfo,
+function isLocalRuntimeSocketPath(socketPath: string): boolean {
+  return !socketPath.startsWith("tcp://");
+}
+
+function runtimeSelfShutdownMessage(
+  runtimePid: number,
   action: "repair" | "stop",
-): string | null {
-  const runtimePid = runtimeInfo.pid;
-  if (!runtimePid || shouldAllowRuntimeSelfShutdown()) return null;
-  if (!isCurrentProcessDescendantOfPid({ targetPid: runtimePid })) return null;
+): string {
   const verb = action === "repair" ? "repair/restart" : "stop";
   return (
     `Refusing to ${verb} ADE runtime from a command running inside that runtime ` +
@@ -12566,12 +12567,47 @@ function runtimeSelfShutdownBlock(
   );
 }
 
+function runtimeSelfShutdownBlock(
+  runtimeInfo: MachineRuntimeInfo,
+  action: "repair" | "stop",
+  options: { localRuntime?: boolean } = {},
+): string | null {
+  if (options.localRuntime === false) return null;
+  const runtimePid = runtimeInfo.pid;
+  if (!runtimePid || shouldAllowRuntimeSelfShutdown()) return null;
+  if (!isCurrentProcessDescendantOfPid({ targetPid: runtimePid })) return null;
+  return runtimeSelfShutdownMessage(runtimePid, action);
+}
+
 function runtimeSelfShutdownBlockedError(
   runtimeInfo: MachineRuntimeInfo,
   action: "repair" | "stop",
+  options: { localRuntime?: boolean } = {},
 ): RuntimeSelfShutdownBlockedError | null {
-  const message = runtimeSelfShutdownBlock(runtimeInfo, action);
+  const message = runtimeSelfShutdownBlock(runtimeInfo, action, options);
   return message ? new RuntimeSelfShutdownBlockedError(message) : null;
+}
+
+async function runtimeServiceSelfShutdownBlock(
+  socketPath: string,
+  action: "repair" | "stop",
+): Promise<string | null> {
+  if (!isLocalRuntimeSocketPath(socketPath) || shouldAllowRuntimeSelfShutdown()) {
+    return null;
+  }
+  const { getRuntimeServiceMainPid } = await import("./serviceManager");
+  const runtimePid = getRuntimeServiceMainPid();
+  if (!runtimePid) return null;
+  if (!isCurrentProcessDescendantOfPid({ targetPid: runtimePid })) return null;
+  return runtimeSelfShutdownMessage(runtimePid, action);
+}
+
+function isRuntimeSelfShutdownBlockedResult(result: unknown): boolean {
+  return isRecord(result)
+    && result.ok === false
+    && typeof result.message === "string"
+    && result.message.includes("ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION=1")
+    && result.message.includes("running inside that brain");
 }
 
 function shouldRepairMachineRuntimeServiceBeforeSpawn(
@@ -12616,7 +12652,9 @@ async function repairMachineRuntimeServiceConnection(args: {
       { enforceBuildCompatibility: args.enforceBuildCompatibility },
     );
     if (mismatch) {
-      const selfShutdownBlock = runtimeSelfShutdownBlockedError(runtimeInfo, "repair");
+      const selfShutdownBlock = runtimeSelfShutdownBlockedError(runtimeInfo, "repair", {
+        localRuntime: isLocalRuntimeSocketPath(args.socketPath),
+      });
       if (selfShutdownBlock) throw selfShutdownBlock;
       uninstallRuntimeService();
       client.close();
@@ -12685,6 +12723,7 @@ async function connectMachineRuntimeDaemon(
   const label = "ADE runtime endpoint";
   const allowSpawn = connectOptions.allowSpawn ?? !options.requireSocket;
   const isTcpSocket = socketPath.startsWith("tcp://");
+  const isLocalRuntime = isLocalRuntimeSocketPath(socketPath);
   const enforceBuildCompatibility =
     shouldEnforceMachineRuntimeBuildCompatibility(socketPathOverride);
   const expectedBuildHash = isTcpSocket || !enforceBuildCompatibility
@@ -12726,7 +12765,9 @@ async function connectMachineRuntimeDaemon(
           `ADE runtime ${mismatch}.`,
         );
       }
-      const selfShutdownBlock = runtimeSelfShutdownBlockedError(runtimeInfo, "repair");
+      const selfShutdownBlock = runtimeSelfShutdownBlockedError(runtimeInfo, "repair", {
+        localRuntime: isLocalRuntime,
+      });
       if (selfShutdownBlock) {
         client.close();
         throw selfShutdownBlock;
@@ -12756,7 +12797,9 @@ async function connectMachineRuntimeDaemon(
         { enforceBuildCompatibility },
       );
       if (restartedMismatch) {
-        const selfShutdownBlock = runtimeSelfShutdownBlockedError(restartedInfo, "repair");
+        const selfShutdownBlock = runtimeSelfShutdownBlockedError(restartedInfo, "repair", {
+          localRuntime: isLocalRuntime,
+        });
         if (selfShutdownBlock) {
           restarted.close();
           throw selfShutdownBlock;
@@ -12793,7 +12836,9 @@ async function connectMachineRuntimeDaemon(
         { enforceBuildCompatibility },
       );
       if (mismatch) {
-        const selfShutdownBlock = runtimeSelfShutdownBlockedError(runtimeInfo, "repair");
+        const selfShutdownBlock = runtimeSelfShutdownBlockedError(runtimeInfo, "repair", {
+          localRuntime: isLocalRuntime,
+        });
         if (selfShutdownBlock) {
           client.close();
           throw selfShutdownBlock;
@@ -12901,7 +12946,19 @@ async function runRuntimeCommand(
       try {
         const runtimeInfo = await initializeMachineRuntimeDaemon(client, options).catch(() => null);
         if (runtimeInfo) {
-          const selfShutdownBlock = runtimeSelfShutdownBlock(runtimeInfo, "stop");
+          const selfShutdownBlock = runtimeSelfShutdownBlock(runtimeInfo, "stop", {
+            localRuntime: isLocalRuntimeSocketPath(socketPath),
+          });
+          if (selfShutdownBlock) {
+            return {
+              ok: false,
+              running: true,
+              socketPath,
+              message: selfShutdownBlock,
+            };
+          }
+        } else if (!socketOverride?.trim()) {
+          const selfShutdownBlock = await runtimeServiceSelfShutdownBlock(socketPath, "stop");
           if (selfShutdownBlock) {
             return {
               ok: false,
@@ -13017,7 +13074,7 @@ async function runBrainCommand(
   if (sub === "restart") {
     const { installRuntimeService, uninstallRuntimeService } = await import("./serviceManager");
     const stopped = uninstallRuntimeService();
-    if (!stopped.ok) {
+    if (isRuntimeSelfShutdownBlockedResult(stopped)) {
       return {
         ok: false,
         action: "restart",
@@ -13032,9 +13089,11 @@ async function runBrainCommand(
       action: "restart",
       stopped,
       started,
-      message: started.ok
-        ? "ADE brain restarted."
-        : started.message,
+      message: !stopped.ok
+        ? `ADE brain restart attempted after stop warning: ${stopped.message}`
+        : started.ok
+          ? "ADE brain restarted."
+          : started.message,
     };
   }
 

--- a/apps/ade-cli/src/serviceManager/common.test.ts
+++ b/apps/ade-cli/src/serviceManager/common.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   ADE_RUNTIME_SERVICE_NAME,
+  isCurrentProcessDescendantOfPid,
   isStaleChannelServeCommandLine,
   renderCommand,
   renderWindowsCommand,
@@ -19,6 +20,7 @@ import {
   launchAgentPath,
   parseLaunchdPrintPid,
   renderLaunchdPlist,
+  uninstallLaunchdService,
 } from "./installLaunchd";
 import { installSystemdService, renderSystemdEnvironment, renderSystemdUnit, servicePath as systemdServicePath } from "./installSystemd";
 import {
@@ -210,6 +212,34 @@ describe("resolveAdeServeCommand", () => {
         ADE_RUNTIME_BUILD_HASH: fileSha256(distPath),
       },
     });
+  });
+});
+
+describe("isCurrentProcessDescendantOfPid", () => {
+  it("detects when the current process descends from the target pid", () => {
+    const parentPid = (pid: number) => ({
+      400: 300,
+      300: 100,
+      100: 1,
+    })[pid] ?? null;
+
+    expect(isCurrentProcessDescendantOfPid({
+      targetPid: 100,
+      currentPid: 400,
+      parentPid,
+    })).toBe(true);
+  });
+
+  it("returns false for unrelated process trees and parent cycles", () => {
+    expect(isCurrentProcessDescendantOfPid({
+      targetPid: 100,
+      currentPid: 400,
+      parentPid: (pid) => ({
+        400: 300,
+        300: 200,
+        200: 300,
+      })[pid] ?? null,
+    })).toBe(false);
   });
 });
 
@@ -504,6 +534,7 @@ describe("launchd service install", () => {
       spawnSync,
       homeDir,
       env: { ...process.env, ADE_HOME: adeHome },
+      parentPid: () => null,
       terminateDeps: {
         kill: (pid, signal) => killed.push({ pid, signal }),
         pidAlive: () => false,
@@ -515,6 +546,75 @@ describe("launchd service install", () => {
       { pid: 9876, signal: "SIGTERM" },
       { pid: 4242, signal: "SIGTERM" },
     ]);
+  });
+
+  it("refuses to restart a launch agent from a descendant of the loaded service", () => {
+    const homeDir = makeTempHome("ade-launchd-self-install-");
+    const servicePath = launchAgentPath(homeDir);
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const spawnSync = spawnSequence(calls, [
+      { status: 0, stdout: "state = running\npid = 100\n", stderr: "" },
+    ]);
+    const parentPid = (pid: number) => ({
+      400: 300,
+      300: 100,
+      100: 1,
+    })[pid] ?? null;
+
+    const result = installLaunchdService({
+      command: serviceCommand,
+      spawnSync,
+      homeDir,
+      currentPid: 400,
+      parentPid,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      serviceName: ADE_RUNTIME_SERVICE_NAME,
+      action: "install",
+      path: servicePath,
+    });
+    expect(result.message).toContain("Refusing to restart ADE brain");
+    expect(calls).toEqual([
+      { command: "launchctl", args: ["print", currentLaunchdDomain()] },
+    ]);
+    expect(fs.existsSync(servicePath)).toBe(false);
+  });
+
+  it("refuses to uninstall a launch agent from a descendant of the loaded service", () => {
+    const homeDir = makeTempHome("ade-launchd-self-uninstall-");
+    const servicePath = launchAgentPath(homeDir);
+    fs.mkdirSync(path.dirname(servicePath), { recursive: true });
+    fs.writeFileSync(servicePath, renderLaunchdPlist(serviceCommand, homeDir), "utf8");
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const spawnSync = spawnSequence(calls, [
+      { status: 0, stdout: "state = running\npid = 100\n", stderr: "" },
+    ]);
+    const parentPid = (pid: number) => ({
+      400: 300,
+      300: 100,
+      100: 1,
+    })[pid] ?? null;
+
+    const result = uninstallLaunchdService({
+      spawnSync,
+      homeDir,
+      currentPid: 400,
+      parentPid,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      serviceName: ADE_RUNTIME_SERVICE_NAME,
+      action: "uninstall",
+      path: servicePath,
+    });
+    expect(result.message).toContain("Refusing to stop ADE brain");
+    expect(calls).toEqual([
+      { command: "launchctl", args: ["print", currentLaunchdDomain()] },
+    ]);
+    expect(fs.existsSync(servicePath)).toBe(true);
   });
 
   it("surfaces launchctl load failures", () => {

--- a/apps/ade-cli/src/serviceManager/common.test.ts
+++ b/apps/ade-cli/src/serviceManager/common.test.ts
@@ -39,6 +39,7 @@ import {
 const originalArgv = [...process.argv];
 const originalNodePath = process.env.NODE_PATH;
 const originalAdeDefaultRole = process.env.ADE_DEFAULT_ROLE;
+const originalAllowSelfMutation = process.env.ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION;
 const tempDirs: string[] = [];
 
 afterEach(() => {
@@ -47,6 +48,11 @@ afterEach(() => {
   else process.env.NODE_PATH = originalNodePath;
   if (originalAdeDefaultRole === undefined) delete process.env.ADE_DEFAULT_ROLE;
   else process.env.ADE_DEFAULT_ROLE = originalAdeDefaultRole;
+  if (originalAllowSelfMutation === undefined) {
+    delete process.env.ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION;
+  } else {
+    process.env.ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION = originalAllowSelfMutation;
+  }
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (dir) fs.rmSync(dir, { recursive: true, force: true });
@@ -230,7 +236,18 @@ describe("isCurrentProcessDescendantOfPid", () => {
     })).toBe(true);
   });
 
-  it("returns false for unrelated process trees and parent cycles", () => {
+  it("returns false when the current process is in an unrelated process tree", () => {
+    expect(isCurrentProcessDescendantOfPid({
+      targetPid: 100,
+      currentPid: 400,
+      parentPid: (pid) => ({
+        400: 300,
+        300: 1,
+      })[pid] ?? null,
+    })).toBe(false);
+  });
+
+  it("returns false for parent cycles", () => {
     expect(isCurrentProcessDescendantOfPid({
       targetPid: 100,
       currentPid: 400,
@@ -582,6 +599,41 @@ describe("launchd service install", () => {
     expect(fs.existsSync(servicePath)).toBe(false);
   });
 
+  it("allows launch agent restart from a descendant when self-mutation is explicitly enabled", () => {
+    const homeDir = makeTempHome("ade-launchd-self-install-override-");
+    const servicePath = launchAgentPath(homeDir);
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const spawnSync = spawnSequence(calls, [
+      { status: 0, stdout: "state = running\npid = 100\n", stderr: "" },
+      { status: 0, stdout: "", stderr: "" },
+      { status: 0, stdout: "", stderr: "" },
+      { status: 0, stdout: "", stderr: "" },
+    ]);
+    const parentPid = (pid: number) => ({
+      400: 300,
+      300: 100,
+      100: 1,
+    })[pid] ?? null;
+    process.env.ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION = "1";
+
+    const result = installLaunchdService({
+      command: serviceCommand,
+      spawnSync,
+      homeDir,
+      currentPid: 400,
+      parentPid,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      serviceName: ADE_RUNTIME_SERVICE_NAME,
+      action: "install",
+      path: servicePath,
+    });
+    expect(fs.existsSync(servicePath)).toBe(true);
+    expect(calls.map((call) => call.args[0])).toEqual(["print", "unload", "-axo", "load"]);
+  });
+
   it("refuses to uninstall a launch agent from a descendant of the loaded service", () => {
     const homeDir = makeTempHome("ade-launchd-self-uninstall-");
     const servicePath = launchAgentPath(homeDir);
@@ -615,6 +667,48 @@ describe("launchd service install", () => {
       { command: "launchctl", args: ["print", currentLaunchdDomain()] },
     ]);
     expect(fs.existsSync(servicePath)).toBe(true);
+  });
+
+  it("allows launch agent uninstall from a descendant when self-mutation is explicitly enabled", () => {
+    const homeDir = makeTempHome("ade-launchd-self-uninstall-override-");
+    const servicePath = launchAgentPath(homeDir);
+    fs.mkdirSync(path.dirname(servicePath), { recursive: true });
+    fs.writeFileSync(servicePath, renderLaunchdPlist(serviceCommand, homeDir), "utf8");
+    const calls: Array<{ command: string; args: string[] }> = [];
+    const killed: Array<{ pid: number; signal: NodeJS.Signals | number }> = [];
+    const spawnSync = spawnSequence(calls, [
+      { status: 0, stdout: "state = running\npid = 100\n", stderr: "" },
+      { status: 0, stdout: "", stderr: "" },
+      { status: 0, stdout: "", stderr: "" },
+      { status: 0, stdout: "", stderr: "" },
+    ]);
+    const parentPid = (pid: number) => ({
+      400: 300,
+      300: 100,
+      100: 1,
+    })[pid] ?? null;
+    process.env.ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION = "1";
+
+    const result = uninstallLaunchdService({
+      spawnSync,
+      homeDir,
+      currentPid: 400,
+      parentPid,
+      terminateDeps: {
+        kill: (pid, signal) => killed.push({ pid, signal }),
+        pidAlive: () => false,
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      serviceName: ADE_RUNTIME_SERVICE_NAME,
+      action: "uninstall",
+      path: servicePath,
+    });
+    expect(calls.map((call) => call.args[0])).toEqual(["print", "bootout", "bootout", "unload"]);
+    expect(killed).toEqual([{ pid: 100, signal: "SIGTERM" }]);
+    expect(fs.existsSync(servicePath)).toBe(false);
   });
 
   it("surfaces launchctl load failures", () => {

--- a/apps/ade-cli/src/serviceManager/common.ts
+++ b/apps/ade-cli/src/serviceManager/common.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import { createHash } from "node:crypto";
 import path from "node:path";
-import type { SpawnSyncOptions } from "node:child_process";
+import { spawnSync, type SpawnSyncOptions } from "node:child_process";
 
 export type ServiceManagerResult = {
   ok: boolean;
@@ -49,6 +49,44 @@ export type ServiceManagerSpawnSync = (
   args: string[],
   options?: SpawnSyncOptions,
 ) => ServiceManagerProcessResult;
+
+function processOutputText(result: ServiceManagerProcessResult): string {
+  if (typeof result.stdout === "string") return result.stdout.trim();
+  if (Buffer.isBuffer(result.stdout)) return result.stdout.toString("utf8").trim();
+  return "";
+}
+
+function readParentPid(
+  run: ServiceManagerSpawnSync,
+  pid: number,
+): number | null {
+  const result = run("ps", ["-o", "ppid=", "-p", String(pid)], { encoding: "utf8" });
+  if (result.status !== 0) return null;
+  const parentPid = Number.parseInt(processOutputText(result), 10);
+  return Number.isFinite(parentPid) && parentPid > 0 ? parentPid : null;
+}
+
+export function isCurrentProcessDescendantOfPid(args: {
+  targetPid: number;
+  run?: ServiceManagerSpawnSync;
+  currentPid?: number;
+  parentPid?: (pid: number) => number | null;
+}): boolean {
+  const targetPid = Math.floor(args.targetPid);
+  if (!Number.isFinite(targetPid) || targetPid <= 0) return false;
+  const run = args.run ?? spawnSync;
+  const readPid = args.parentPid ?? ((pid) => readParentPid(run, pid));
+  const seen = new Set<number>();
+  let cursor = Math.floor(args.currentPid ?? process.pid);
+  while (Number.isFinite(cursor) && cursor > 0 && !seen.has(cursor)) {
+    if (cursor === targetPid) return true;
+    seen.add(cursor);
+    const next = readPid(cursor);
+    if (!next || next === cursor) return false;
+    cursor = next;
+  }
+  return false;
+}
 
 const RUNTIME_ENV_PASSTHROUGH = [
   "NODE_PATH",

--- a/apps/ade-cli/src/serviceManager/installLaunchd.ts
+++ b/apps/ade-cli/src/serviceManager/installLaunchd.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
   ADE_RUNTIME_SERVICE_NAME,
   type AdeServiceCommand,
+  isCurrentProcessDescendantOfPid,
   listStaleChannelServePids,
   resolveAdeServeCliScriptPath,
   resolveAdeServeCommand,
@@ -29,6 +30,17 @@ type LaunchdServiceManagerDeps = {
   syncHostSingletonDeps?: SyncHostSingletonDeps;
   terminateDeps?: TerminatePidDeps;
   env?: NodeJS.ProcessEnv;
+  currentPid?: number;
+  parentPid?: (pid: number) => number | null;
+};
+
+type LaunchdServiceUninstallDeps = {
+  spawnSync?: ServiceManagerSpawnSync;
+  homeDir?: string;
+  terminateDeps?: TerminatePidDeps;
+  env?: NodeJS.ProcessEnv;
+  currentPid?: number;
+  parentPid?: (pid: number) => number | null;
 };
 
 function escapeXml(value: string): string {
@@ -67,6 +79,54 @@ export function parseLaunchdPrintPid(output: string): number | null {
   if (!match) return null;
   const pid = Number(match[1]);
   return Number.isFinite(pid) && pid > 0 ? Math.floor(pid) : null;
+}
+
+function shouldAllowSelfServiceMutation(env: NodeJS.ProcessEnv): boolean {
+  return env.ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION === "1";
+}
+
+function selfServiceMutationBlockedResult(args: {
+  action: "install" | "uninstall";
+  servicePath: string;
+  servicePid: number;
+}): ServiceManagerResult {
+  const verb = args.action === "install" ? "restart" : "stop";
+  return {
+    ok: false,
+    serviceName: ADE_RUNTIME_SERVICE_NAME,
+    action: args.action,
+    path: args.servicePath,
+    message:
+      `Refusing to ${verb} ADE brain from a command running inside that brain ` +
+      `(pid ${args.servicePid}). Run this from an external terminal, or set ` +
+      "ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION=1 if you intentionally want to tear down active ADE sessions.",
+  };
+}
+
+function selfServiceMutationBlock(args: {
+  action: "install" | "uninstall";
+  loadedPid: number | null | undefined;
+  servicePath: string;
+  run: ServiceManagerSpawnSync;
+  env: NodeJS.ProcessEnv;
+  currentPid?: number;
+  parentPid?: (pid: number) => number | null;
+}): ServiceManagerResult | null {
+  const servicePid = args.loadedPid ?? null;
+  if (!servicePid || shouldAllowSelfServiceMutation(args.env)) return null;
+  if (!isCurrentProcessDescendantOfPid({
+    targetPid: servicePid,
+    run: args.run,
+    currentPid: args.currentPid,
+    parentPid: args.parentPid,
+  })) {
+    return null;
+  }
+  return selfServiceMutationBlockedResult({
+    action: args.action,
+    servicePath: args.servicePath,
+    servicePid,
+  });
 }
 
 export function renderLaunchdPlist(command: AdeServiceCommand, homeDir = os.homedir()): string {
@@ -158,6 +218,16 @@ export function installLaunchdService(deps: LaunchdServiceManagerDeps = {}): Ser
       message: "ADE service launchd service is already installed and running.",
     };
   }
+  const selfBlock = selfServiceMutationBlock({
+    action: "install",
+    loadedPid: loaded?.pid,
+    servicePath,
+    run,
+    env,
+    currentPid: deps.currentPid,
+    parentPid: deps.parentPid,
+  });
+  if (selfBlock) return selfBlock;
 
   // From here on the service is being (re)started, so this install is the
   // channel's lifecycle authority. Same-channel brains holding the mobile
@@ -215,14 +285,26 @@ export function installLaunchdService(deps: LaunchdServiceManagerDeps = {}): Ser
   };
 }
 
-export function uninstallLaunchdService(): ServiceManagerResult {
-  const servicePath = launchAgentPath();
-  const loaded = getLoadedLaunchdState(spawnSync);
+export function uninstallLaunchdService(deps: LaunchdServiceUninstallDeps = {}): ServiceManagerResult {
+  const run = deps.spawnSync ?? spawnSync;
+  const env = deps.env ?? process.env;
+  const servicePath = launchAgentPath(deps.homeDir);
+  const loaded = getLoadedLaunchdState(run);
+  const selfBlock = selfServiceMutationBlock({
+    action: "uninstall",
+    loadedPid: loaded?.pid,
+    servicePath,
+    run,
+    env,
+    currentPid: deps.currentPid,
+    parentPid: deps.parentPid,
+  });
+  if (selfBlock) return selfBlock;
   const uid = typeof process.getuid === "function" ? process.getuid() : os.userInfo().uid;
-  spawnSync("launchctl", ["bootout", `gui/${uid}/${ADE_RUNTIME_SERVICE_NAME}`], { stdio: "ignore" });
-  spawnSync("launchctl", ["bootout", `user/${uid}/${ADE_RUNTIME_SERVICE_NAME}`], { stdio: "ignore" });
-  spawnSync("launchctl", ["unload", servicePath], { stdio: "ignore" });
-  terminatePidGracefully(loaded?.pid ?? null);
+  run("launchctl", ["bootout", `gui/${uid}/${ADE_RUNTIME_SERVICE_NAME}`], { stdio: "ignore" });
+  run("launchctl", ["bootout", `user/${uid}/${ADE_RUNTIME_SERVICE_NAME}`], { stdio: "ignore" });
+  run("launchctl", ["unload", servicePath], { stdio: "ignore" });
+  terminatePidGracefully(loaded?.pid ?? null, deps.terminateDeps);
   try { fs.unlinkSync(servicePath); } catch {}
   return {
     ok: true,


### PR DESCRIPTION
## Summary

Prevent ADE-managed sessions from accidentally stopping or restarting the ADE brain/runtime that owns them.

## What Changed

- Added process-tree detection for commands running as descendants of the loaded ADE launchd service/runtime.
- Refuse launchd install/uninstall, `ade brain restart`, `ade runtime stop`, and runtime repair/restart paths when they would tear down the caller's own active ADE session.
- Keep external lifecycle management working for desktop app upgrades, external terminals, and explicit emergency override via `ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION=1`.

## Validation

- `npm exec -- vitest run src/serviceManager/common.test.ts src/cli.test.ts`
- `npm --prefix apps/ade-cli run typecheck`
- `npm --prefix apps/ade-cli run test`
- `npm --prefix apps/ade-cli run build`

## Risks

This changes only ADE CLI/runtime lifecycle guardrails. The main risk is an overly conservative refusal in unusual service-management contexts; the error message includes the external-terminal path and explicit override for intentional teardown.

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fchat-20260610-104957-a079086e num=549 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fchat-20260610-104957-a079086e&amp;pr=549">ade/chat-20260610-104957-a079086e branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=549">PR #549</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime self-mutation protection that blocks accidental shutdown or repair operations when running from within the ADE runtime process (controllable via environment variable for advanced users)

* **Bug Fixes**
  * Enhanced `brain restart` error handling to exit early when the stop operation fails, returning detailed error information

* **Tests**
  * Expanded test coverage for the new safety guard mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a process-tree self-mutation guard to the ADE CLI so that commands running inside a managed ADE runtime session cannot accidentally tear down the runtime that owns them. The guard is implemented for the macOS launchd path and is escapable via `ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION=1`.

- `isCurrentProcessDescendantOfPid` walks the process tree via `ps -o ppid=`, with a `seen` set for cycle detection, and is injected as a testable dependency throughout.
- `selfServiceMutationBlock` is wired into both `installLaunchdService` and `uninstallLaunchdService`; `RuntimeSelfShutdownBlockedError` is re-thrown through the `connectMachineRuntimeDaemon` / `repairMachineRuntimeServiceConnection` call stack so callers can distinguish it from other errors.
- `runBrainCommand restart` gains an early-exit on a blocked stop result, detected via `isRuntimeSelfShutdownBlockedResult`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the guard is additive and the escape hatch keeps intentional teardown possible.

All changed paths are defensive additions — they either block an unsafe operation and return early, or re-throw a typed error that callers already handle. The core `isCurrentProcessDescendantOfPid` logic is straightforward and well-tested. The `isRuntimeSelfShutdownBlockedResult` substring mismatch ("brain" vs "runtime") is inconsistent but does not affect any live code path today.

apps/ade-cli/src/cli.ts — the `isRuntimeSelfShutdownBlockedResult` function anchors on a substring that differs from the one produced by `runtimeSelfShutdownMessage`, which is worth hardening before the pattern is extended to other platforms.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/serviceManager/common.ts | Adds `isCurrentProcessDescendantOfPid` with cycle detection via a `seen` set and clean termination on null parent; logic is correct and well-bounded. |
| apps/ade-cli/src/serviceManager/installLaunchd.ts | Adds `selfServiceMutationBlock` to both `installLaunchdService` and `uninstallLaunchdService`; also injects deps (`spawnSync`, `homeDir`, `terminateDeps`) into `uninstallLaunchdService` for testability. |
| apps/ade-cli/src/cli.ts | Adds self-shutdown guards across repair, connect, and stop paths; `isRuntimeSelfShutdownBlockedResult` uses a different substring ("brain") than `runtimeSelfShutdownMessage` generates ("runtime"), which is fragile if the detection is ever widened. |
| apps/ade-cli/src/serviceManager/common.test.ts | Comprehensive new tests for descendant detection and install/uninstall blocking; "refuses" tests don't isolate the `ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION` env var, making them sensitive to ambient environment. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["ade brain restart / ade runtime stop / repair"] --> B{Local socket?}
    B -- No TCP --> C[Allow — skip self-mutation check]
    B -- Yes local --> D{ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION=1?}
    D -- Yes --> C
    D -- No --> E{runtimePid available?}
    E -- No --> C
    E -- Yes --> F["isCurrentProcessDescendantOfPid\n(walk ps ppid chain)"]
    F -- Not a descendant --> C
    F -- Is a descendant --> G["Block with RuntimeSelfShutdownBlockedError\nor ServiceManagerResult ok=false"]
    C --> H[Proceed with stop / repair / install]
    G --> I[Return error to caller]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fade-cli%2Fsrc%2Fcli.ts%3A12605-12611%0A**%60isRuntimeSelfShutdownBlockedResult%60%20checks%20a%20substring%20that%20won't%20match%20the%20sister%20function**%0A%0A%60runtimeSelfShutdownMessage%60%20%28used%20in%20%60runtimeSelfShutdownBlock%60%20%2F%20%60runtimeServiceSelfShutdownBlock%60%29%20emits%20%60%22running%20inside%20that%20runtime%22%60%2C%20but%20this%20detector%20anchors%20on%20%60%22running%20inside%20that%20brain%22%60.%20The%20two%20strings%20never%20overlap.%0A%0AThe%20mismatch%20doesn't%20cause%20a%20bug%20today%20because%20%60isRuntimeSelfShutdownBlockedResult%60%20is%20only%20called%20against%20results%20from%20%60uninstallLaunchdService%60%2C%20which%20produces%20%60selfServiceMutationBlockedResult%60%20messages%20containing%20%60%22inside%20that%20brain%22%60.%20But%20if%20a%20second%20platform%20%28e.g.%20systemd%29%20ever%20adds%20the%20same%20guard%20and%20follows%20the%20%60%22runtime%22%60%20phrasing%2C%20the%20early-exit%20in%20%60runBrainCommand%20restart%60%20would%20silently%20fail%20to%20fire%20%E2%80%94%20%60installRuntimeService%60%20would%20be%20called%20even%20though%20the%20stop%20was%20blocked%2C%20producing%20a%20confusing%20partial-restart%20outcome.%20Giving%20%60ServiceManagerResult%60%20a%20typed%20%60blockedBySelfMutation%3F%3A%20true%60%20discriminant%20would%20eliminate%20the%20coupling%20entirely.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fade-cli%2Fsrc%2FserviceManager%2Fcommon.test.ts%3A568-599%0A**Self-mutation%20guard%20tests%20not%20isolated%20from%20ambient%20environment**%0A%0ABoth%20%22refuses%20to%20restart%22%20and%20%22refuses%20to%20uninstall%22%20tests%20call%20%60installLaunchdService%60%20%2F%20%60uninstallLaunchdService%60%20without%20passing%20an%20explicit%20%60env%60%20parameter%2C%20so%20they%20fall%20back%20to%20%60process.env%60.%20If%20%60ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION%3D1%60%20is%20present%20in%20the%20environment%20%28e.g.%2C%20a%20developer%20or%20CI%20script%20set%20it%20before%20running%20the%20suite%29%2C%20%60shouldAllowSelfServiceMutation%60%20returns%20%60true%60%2C%20the%20guard%20is%20bypassed%2C%20and%20both%20tests%20would%20unexpectedly%20fail%20or%20produce%20wrong%20assertions.%20Passing%20%60env%3A%20%7B%20...process.env%2C%20ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION%3A%20undefined%20%7D%60%20%28or%20simply%20%60env%3A%20%7B%7D%60%29%20keeps%20the%20guard%20predictably%20active%20regardless%20of%20the%20caller's%20environment.%0A%0A&repo=arul28%2Fade&pr=549&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/ade-cli/src/cli.ts:12605-12611
**`isRuntimeSelfShutdownBlockedResult` checks a substring that won't match the sister function**

`runtimeSelfShutdownMessage` (used in `runtimeSelfShutdownBlock` / `runtimeServiceSelfShutdownBlock`) emits `"running inside that runtime"`, but this detector anchors on `"running inside that brain"`. The two strings never overlap.

The mismatch doesn't cause a bug today because `isRuntimeSelfShutdownBlockedResult` is only called against results from `uninstallLaunchdService`, which produces `selfServiceMutationBlockedResult` messages containing `"inside that brain"`. But if a second platform (e.g. systemd) ever adds the same guard and follows the `"runtime"` phrasing, the early-exit in `runBrainCommand restart` would silently fail to fire — `installRuntimeService` would be called even though the stop was blocked, producing a confusing partial-restart outcome. Giving `ServiceManagerResult` a typed `blockedBySelfMutation?: true` discriminant would eliminate the coupling entirely.

### Issue 2 of 2
apps/ade-cli/src/serviceManager/common.test.ts:568-599
**Self-mutation guard tests not isolated from ambient environment**

Both "refuses to restart" and "refuses to uninstall" tests call `installLaunchdService` / `uninstallLaunchdService` without passing an explicit `env` parameter, so they fall back to `process.env`. If `ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION=1` is present in the environment (e.g., a developer or CI script set it before running the suite), `shouldAllowSelfServiceMutation` returns `true`, the guard is bypassed, and both tests would unexpectedly fail or produce wrong assertions. Passing `env: { ...process.env, ADE_ALLOW_RUNTIME_SERVICE_SELF_MUTATION: undefined }` (or simply `env: {}`) keeps the guard predictably active regardless of the caller's environment.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["ship: iteration 1 - address review feedb..."](https://github.com/arul28/ade/commit/7ea789fd412a2db1493d7fead98e20119babf071) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36760467)</sub>

<!-- /greptile_comment -->