### PR TITLE
Fix packaged ADE CLI runtime sidecars

### DIFF
--- a/apps/ade-cli/scripts/build-static.mjs
+++ b/apps/ade-cli/scripts/build-static.mjs
@@ -185,7 +185,6 @@ function __adeSeaCandidateRuntimeRoots() {
   if (explicitRoot) roots.push(explicitRoot);
   if (explicitNodeModules) roots.push(__adeSeaRuntimeRootFromNodeModules(explicitNodeModules));
   roots.push(__adeSeaPath.join(__adeSeaPath.dirname(process.execPath), "ade-" + target + ".native"));
-  roots.push(__adeSeaPath.dirname(process.execPath));
   roots.push(__adeSeaPath.join(__adeSeaPath.dirname(process.execPath), "..", "runtime", target));
   if (process.env.NODE_PATH) {
     process.env.NODE_PATH.split(__adeSeaPath.delimiter).forEach(function (entry) {
@@ -345,23 +344,24 @@ async function main() {
   let nativeArchivePath = null;
   const nativeStagingRoot = path.join(args.outDir, `ade-${args.target}.native`);
   const shouldRemoveNativeStaging = !args.skipNativeDeps && process.env.ADE_KEEP_NATIVE_RUNTIME_STAGING !== "1";
-  if (!args.skipNativeDeps) {
-    await run(process.execPath, [
-      path.join(packageRoot, "scripts", "package-native-deps.mjs"),
-      "--target",
-      args.target,
-      "--out-dir",
-      args.outDir,
-    ], {
-      env: {
-        ...process.env,
-        ADE_KEEP_NATIVE_RUNTIME_STAGING: "1",
-      },
-    });
-    nativeArchivePath = path.join(args.outDir, `ade-${args.target}.native.tar.gz`);
-  }
 
   try {
+    if (!args.skipNativeDeps) {
+      await run(process.execPath, [
+        path.join(packageRoot, "scripts", "package-native-deps.mjs"),
+        "--target",
+        args.target,
+        "--out-dir",
+        args.outDir,
+      ], {
+        env: {
+          ...process.env,
+          ADE_KEEP_NATIVE_RUNTIME_STAGING: "1",
+        },
+      });
+      nativeArchivePath = path.join(args.outDir, `ade-${args.target}.native.tar.gz`);
+    }
+
     await assertStaticRuntimeVersion(binaryPath, runtimeVersion, args.target);
   } finally {
     if (shouldRemoveNativeStaging) {

--- a/apps/ade-cli/scripts/build-static.mjs
+++ b/apps/ade-cli/scripts/build-static.mjs
@@ -236,12 +236,20 @@ function __adeSeaShouldUseFilesystemRequireFirst(id) {
     && __adeSeaIsBareModuleId(id)
     && !__adeSeaIsBuiltinModuleId(id);
 }
+function __adeSeaCanFallbackAfterResolveError(error, id) {
+  if (!error) return false;
+  if (error.code === "ERR_UNKNOWN_BUILTIN_MODULE") return true;
+  if (error.code !== "MODULE_NOT_FOUND") return false;
+  var message = typeof error.message === "string" ? error.message : "";
+  return message.indexOf("Cannot find module '" + id + "'") !== -1
+    || message.indexOf("Cannot find module \\"" + id + "\\"") !== -1;
+}
 function __adeSeaRequire(id) {
   if (__adeSeaShouldUseFilesystemRequireFirst(id)) {
     try {
       return __adeSeaFilesystemRequire(id);
     } catch (error) {
-      if (!error || (error.code !== "ERR_UNKNOWN_BUILTIN_MODULE" && error.code !== "MODULE_NOT_FOUND")) {
+      if (!__adeSeaCanFallbackAfterResolveError(error, id)) {
         throw error;
       }
     }
@@ -249,7 +257,7 @@ function __adeSeaRequire(id) {
   try {
     return __adeSeaOriginalRequire(id);
   } catch (error) {
-    if (error && (error.code === "ERR_UNKNOWN_BUILTIN_MODULE" || error.code === "MODULE_NOT_FOUND")) {
+    if (__adeSeaCanFallbackAfterResolveError(error, id)) {
       return __adeSeaFilesystemRequire(id);
     }
     throw error;
@@ -261,7 +269,7 @@ __adeSeaRequire.resolve = function __adeSeaRequireResolve(id, options) {
     try {
       return __adeSeaFilesystemRequire.resolve(id, options);
     } catch (error) {
-      if (!error || (error.code !== "ERR_UNKNOWN_BUILTIN_MODULE" && error.code !== "MODULE_NOT_FOUND")) {
+      if (!__adeSeaCanFallbackAfterResolveError(error, id)) {
         throw error;
       }
     }
@@ -269,7 +277,7 @@ __adeSeaRequire.resolve = function __adeSeaRequireResolve(id, options) {
   try {
     return __adeSeaOriginalRequire.resolve(id, options);
   } catch (error) {
-    if (error && (error.code === "ERR_UNKNOWN_BUILTIN_MODULE" || error.code === "MODULE_NOT_FOUND")) {
+    if (__adeSeaCanFallbackAfterResolveError(error, id)) {
       return __adeSeaFilesystemRequire.resolve(id, options);
     }
     throw error;

--- a/apps/ade-cli/scripts/build-static.mjs
+++ b/apps/ade-cli/scripts/build-static.mjs
@@ -184,14 +184,14 @@ function __adeSeaCandidateRuntimeRoots() {
   var explicitNodeModules = process.env.ADE_RUNTIME_NODE_MODULES;
   if (explicitRoot) roots.push(explicitRoot);
   if (explicitNodeModules) roots.push(__adeSeaRuntimeRootFromNodeModules(explicitNodeModules));
+  roots.push(__adeSeaPath.join(__adeSeaPath.dirname(process.execPath), "ade-" + target + ".native"));
+  roots.push(__adeSeaPath.dirname(process.execPath));
+  roots.push(__adeSeaPath.join(__adeSeaPath.dirname(process.execPath), "..", "runtime", target));
   if (process.env.NODE_PATH) {
     process.env.NODE_PATH.split(__adeSeaPath.delimiter).forEach(function (entry) {
       roots.push(__adeSeaRuntimeRootFromNodeModules(entry));
     });
   }
-  roots.push(__adeSeaPath.join(__adeSeaPath.dirname(process.execPath), "ade-" + target + ".native"));
-  roots.push(__adeSeaPath.dirname(process.execPath));
-  roots.push(__adeSeaPath.join(__adeSeaPath.dirname(process.execPath), "..", "runtime", target));
   roots.push(__adeSeaPath.join(__adeSeaOs.homedir(), ".ade", "runtime", target));
   return roots.filter(function (entry, index) {
     return Boolean(entry) && roots.indexOf(entry) === index;
@@ -220,7 +220,33 @@ if (__adeSeaRuntimeRoot) {
 var __adeSeaFilesystemRequire = __adeSeaModule.createRequire(
   __adeSeaRuntimeRoot ? __adeSeaPath.join(__adeSeaRuntimeRoot, ".ade-runtime.cjs") : process.execPath
 );
+var __adeSeaBuiltinModules = new Set(__adeSeaModule.builtinModules || []);
+function __adeSeaIsBuiltinModuleId(id) {
+  var bare = id.indexOf("node:") === 0 ? id.slice(5) : id;
+  return __adeSeaBuiltinModules.has(id) || __adeSeaBuiltinModules.has(bare);
+}
+function __adeSeaIsBareModuleId(id) {
+  return typeof id === "string"
+    && id.length > 0
+    && id.charAt(0) !== "."
+    && !__adeSeaPath.isAbsolute(id)
+    && !/^[A-Za-z]:[\\/]/.test(id);
+}
+function __adeSeaShouldUseFilesystemRequireFirst(id) {
+  return Boolean(__adeSeaRuntimeRoot)
+    && __adeSeaIsBareModuleId(id)
+    && !__adeSeaIsBuiltinModuleId(id);
+}
 function __adeSeaRequire(id) {
+  if (__adeSeaShouldUseFilesystemRequireFirst(id)) {
+    try {
+      return __adeSeaFilesystemRequire(id);
+    } catch (error) {
+      if (!error || (error.code !== "ERR_UNKNOWN_BUILTIN_MODULE" && error.code !== "MODULE_NOT_FOUND")) {
+        throw error;
+      }
+    }
+  }
   try {
     return __adeSeaOriginalRequire(id);
   } catch (error) {
@@ -232,6 +258,15 @@ function __adeSeaRequire(id) {
 }
 Object.assign(__adeSeaRequire, __adeSeaOriginalRequire);
 __adeSeaRequire.resolve = function __adeSeaRequireResolve(id, options) {
+  if (__adeSeaShouldUseFilesystemRequireFirst(id)) {
+    try {
+      return __adeSeaFilesystemRequire.resolve(id, options);
+    } catch (error) {
+      if (!error || (error.code !== "ERR_UNKNOWN_BUILTIN_MODULE" && error.code !== "MODULE_NOT_FOUND")) {
+        throw error;
+      }
+    }
+  }
   try {
     return __adeSeaOriginalRequire.resolve(id, options);
   } catch (error) {
@@ -306,9 +341,10 @@ async function main() {
   }
   await run(path.join(packageRoot, "node_modules", ".bin", process.platform === "win32" ? "postject.cmd" : "postject"), postjectArgs);
   await adHocSignIfNeeded(binaryPath);
-  await assertStaticRuntimeVersion(binaryPath, runtimeVersion, args.target);
 
   let nativeArchivePath = null;
+  const nativeStagingRoot = path.join(args.outDir, `ade-${args.target}.native`);
+  const shouldRemoveNativeStaging = !args.skipNativeDeps && process.env.ADE_KEEP_NATIVE_RUNTIME_STAGING !== "1";
   if (!args.skipNativeDeps) {
     await run(process.execPath, [
       path.join(packageRoot, "scripts", "package-native-deps.mjs"),
@@ -316,12 +352,24 @@ async function main() {
       args.target,
       "--out-dir",
       args.outDir,
-    ]);
+    ], {
+      env: {
+        ...process.env,
+        ADE_KEEP_NATIVE_RUNTIME_STAGING: "1",
+      },
+    });
     nativeArchivePath = path.join(args.outDir, `ade-${args.target}.native.tar.gz`);
   }
 
-  if (process.env.ADE_KEEP_STATIC_RUNTIME_STAGING !== "1") {
-    await fs.rm(workDir, { recursive: true, force: true });
+  try {
+    await assertStaticRuntimeVersion(binaryPath, runtimeVersion, args.target);
+  } finally {
+    if (shouldRemoveNativeStaging) {
+      await fs.rm(nativeStagingRoot, { recursive: true, force: true });
+    }
+    if (process.env.ADE_KEEP_STATIC_RUNTIME_STAGING !== "1") {
+      await fs.rm(workDir, { recursive: true, force: true });
+    }
   }
 
   process.stdout.write(`${JSON.stringify({

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -220,6 +220,14 @@
         "to": "ade-cli/ptyHostWorker.cjs"
       },
       {
+        "from": "../ade-cli/dist/cursorSdkWorker.cjs",
+        "to": "ade-cli/cursorSdkWorker.cjs"
+      },
+      {
+        "from": "../ade-cli/dist/droidSdkWorker.cjs",
+        "to": "ade-cli/droidSdkWorker.cjs"
+      },
+      {
         "from": "../ade-cli/dist/adeRpcServer.cjs",
         "to": "ade-cli/adeRpcServer.cjs"
       },

--- a/apps/desktop/scripts/after-pack-runtime-fixes.cjs
+++ b/apps/desktop/scripts/after-pack-runtime-fixes.cjs
@@ -316,11 +316,15 @@ module.exports = async function afterPack(context) {
   const bundledCliPath = path.join(resourcesRoot, "ade-cli", "cli.cjs");
   const bundledCliBootstrapPath = path.join(resourcesRoot, "ade-cli", "bootstrap.cjs");
   const bundledCliPtyHostWorkerPath = path.join(resourcesRoot, "ade-cli", "ptyHostWorker.cjs");
+  const bundledCliCursorSdkWorkerPath = path.join(resourcesRoot, "ade-cli", "cursorSdkWorker.cjs");
+  const bundledCliDroidSdkWorkerPath = path.join(resourcesRoot, "ade-cli", "droidSdkWorker.cjs");
   const bundledCliRpcPath = path.join(resourcesRoot, "ade-cli", "adeRpcServer.cjs");
   const bundledCliTuiPath = path.join(resourcesRoot, "ade-cli", "tuiClient", "cli.mjs");
   requireFile(bundledCliPath, "bundled ADE CLI entry");
   requireFile(bundledCliBootstrapPath, "bundled ADE CLI bootstrap entry");
   requireFile(bundledCliPtyHostWorkerPath, "bundled ADE CLI PTY host worker");
+  requireFile(bundledCliCursorSdkWorkerPath, "bundled ADE CLI Cursor SDK worker");
+  requireFile(bundledCliDroidSdkWorkerPath, "bundled ADE CLI Droid SDK worker");
   requireFile(bundledCliRpcPath, "bundled ADE CLI RPC entry");
   requireFile(bundledCliTuiPath, "bundled ADE CLI TUI entry");
 

--- a/apps/desktop/scripts/ensure-ade-cli-build.cjs
+++ b/apps/desktop/scripts/ensure-ade-cli-build.cjs
@@ -12,6 +12,9 @@ const distFiles = [
   path.join(cliRoot, "dist", "cli.cjs"),
   path.join(cliRoot, "dist", "bootstrap.cjs"),
   path.join(cliRoot, "dist", "adeRpcServer.cjs"),
+  path.join(cliRoot, "dist", "ptyHostWorker.cjs"),
+  path.join(cliRoot, "dist", "cursorSdkWorker.cjs"),
+  path.join(cliRoot, "dist", "droidSdkWorker.cjs"),
   path.join(cliRoot, "dist", "tuiClient", "cli.mjs"),
 ];
 

--- a/apps/desktop/scripts/validate-mac-artifacts.mjs
+++ b/apps/desktop/scripts/validate-mac-artifacts.mjs
@@ -30,6 +30,17 @@ const bundledAgentSkills = [
   "ade-macos-vm",
   "ade-deeplinks",
 ];
+const bundledAdeCliFiles = [
+  ["cli.cjs", "bundled ADE CLI entry"],
+  ["bootstrap.cjs", "bundled ADE CLI bootstrap entry"],
+  ["ptyHostWorker.cjs", "bundled ADE CLI PTY host worker"],
+  ["cursorSdkWorker.cjs", "bundled ADE CLI Cursor SDK worker"],
+  ["droidSdkWorker.cjs", "bundled ADE CLI Droid SDK worker"],
+  ["adeRpcServer.cjs", "bundled ADE CLI RPC entry"],
+  ["tuiClient/cli.mjs", "bundled ADE CLI TUI entry"],
+  ["bin/ade", "bundled ADE CLI wrapper"],
+  ["install-path.sh", "bundled ADE CLI PATH installer"],
+];
 
 function readFlag(name) {
   const prefix = `${name}=`;
@@ -403,10 +414,6 @@ async function validatePackagedRuntime(appPath, description) {
   const resourcesPath = path.join(appPath, "Contents", "Resources");
   const appAsarPath = path.join(resourcesPath, "app.asar");
   const unpackedPath = await resolveRuntimeUnpackedPath(resourcesPath);
-  const adeCliPath = path.join(resourcesPath, "ade-cli", "cli.cjs");
-  const adeCliBootstrapPath = path.join(resourcesPath, "ade-cli", "bootstrap.cjs");
-  const adeCliPtyHostWorkerPath = path.join(resourcesPath, "ade-cli", "ptyHostWorker.cjs");
-  const adeCliRpcPath = path.join(resourcesPath, "ade-cli", "adeRpcServer.cjs");
   const adeCliTuiPath = path.join(resourcesPath, "ade-cli", "tuiClient", "cli.mjs");
   const adeCliBinPath = path.join(resourcesPath, "ade-cli", "bin", "ade");
   const adeCliInstallerPath = path.join(resourcesPath, "ade-cli", "install-path.sh");
@@ -420,13 +427,9 @@ async function validatePackagedRuntime(appPath, description) {
   await assertPathExists(appAsarPath, "app.asar payload");
   await assertPathExists(unpackedPath, "unpacked runtime payload");
   assertPackagedStartupModules(appAsarPath, description);
-  await assertPathExists(adeCliPath, "bundled ADE CLI entry");
-  await assertPathExists(adeCliBootstrapPath, "bundled ADE CLI bootstrap entry");
-  await assertPathExists(adeCliPtyHostWorkerPath, "bundled ADE CLI PTY host worker");
-  await assertPathExists(adeCliRpcPath, "bundled ADE CLI RPC entry");
-  await assertPathExists(adeCliTuiPath, "bundled ADE CLI TUI entry");
-  await assertPathExists(adeCliBinPath, "bundled ADE CLI wrapper");
-  await assertPathExists(adeCliInstallerPath, "bundled ADE CLI PATH installer");
+  for (const [relativePath, label] of bundledAdeCliFiles) {
+    await assertPathExists(path.join(resourcesPath, "ade-cli", relativePath), label);
+  }
   await assertBundledAgentSkills(bundledAgentSkillsRoot);
   await assertExecutable(adeCliBinPath, "bundled ADE CLI wrapper");
   await assertExecutable(adeCliInstallerPath, "bundled ADE CLI PATH installer");

--- a/apps/desktop/scripts/validate-win-artifacts.mjs
+++ b/apps/desktop/scripts/validate-win-artifacts.mjs
@@ -218,6 +218,7 @@ function validatePreflight() {
   requireFile("vendor/crsqlite/win32-x64/crsqlite.dll", "Windows cr-sqlite extension");
 
   for (const relativePath of [
+    "cli.cjs",
     "bin/ade.cmd",
     "bootstrap.cjs",
     "ptyHostWorker.cjs",
@@ -516,8 +517,6 @@ async function validatePackagedRuntime(appDir) {
   const appAsarPath = path.join(resourcesPath, "app.asar");
   const unpackedPath = path.join(resourcesPath, "app.asar.unpacked");
   const adeCliTuiPath = path.join(resourcesPath, "ade-cli", "tuiClient", "cli.mjs");
-  const adeCliBinPath = path.join(resourcesPath, "ade-cli", "bin", "ade.cmd");
-  const adeCliInstallerPath = path.join(resourcesPath, "ade-cli", "install-path.cmd");
   const bundledAgentSkillsRoot = path.join(resourcesPath, "agent-skills");
   const nodeModulesPath = path.join(unpackedPath, "node_modules");
   const nodePtyModulePath = path.join(nodeModulesPath, "node-pty");

--- a/apps/desktop/scripts/validate-win-artifacts.mjs
+++ b/apps/desktop/scripts/validate-win-artifacts.mjs
@@ -33,6 +33,17 @@ const bundledAgentSkills = [
   "ade-macos-vm",
   "ade-deeplinks",
 ];
+const bundledAdeCliFiles = [
+  ["cli.cjs", "bundled ADE CLI entry"],
+  ["bootstrap.cjs", "bundled ADE CLI bootstrap entry"],
+  ["ptyHostWorker.cjs", "bundled ADE CLI PTY host worker"],
+  ["cursorSdkWorker.cjs", "bundled ADE CLI Cursor SDK worker"],
+  ["droidSdkWorker.cjs", "bundled ADE CLI Droid SDK worker"],
+  ["adeRpcServer.cjs", "bundled ADE CLI RPC entry"],
+  ["tuiClient/cli.mjs", "bundled ADE CLI TUI entry"],
+  ["bin/ade.cmd", "bundled ADE CLI wrapper"],
+  ["install-path.cmd", "bundled ADE CLI PATH installer"],
+];
 
 function readFlag(name) {
   const prefix = `${name}=`;
@@ -171,6 +182,12 @@ function hasExtraResource(to) {
     && pkg.build.extraResources.some((entry) => entry && entry.to === to);
 }
 
+function requireExtraResource(to) {
+  if (!hasExtraResource(to)) {
+    fail(`package.json build.extraResources must ship ${to}`);
+  }
+}
+
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
@@ -200,23 +217,17 @@ function validatePreflight() {
   requireFile("scripts/ade-cli-install-path.cmd", "Windows ADE CLI PATH installer");
   requireFile("vendor/crsqlite/win32-x64/crsqlite.dll", "Windows cr-sqlite extension");
 
-  if (!hasExtraResource("ade-cli/bin/ade.cmd")) {
-    fail("package.json build.extraResources must ship ade-cli/bin/ade.cmd");
-  }
-  if (!hasExtraResource("ade-cli/bootstrap.cjs")) {
-    fail("package.json build.extraResources must ship ade-cli/bootstrap.cjs");
-  }
-  if (!hasExtraResource("ade-cli/ptyHostWorker.cjs")) {
-    fail("package.json build.extraResources must ship ade-cli/ptyHostWorker.cjs");
-  }
-  if (!hasExtraResource("ade-cli/adeRpcServer.cjs")) {
-    fail("package.json build.extraResources must ship ade-cli/adeRpcServer.cjs");
-  }
-  if (!hasExtraResource("ade-cli/tuiClient")) {
-    fail("package.json build.extraResources must ship ade-cli/tuiClient");
-  }
-  if (!hasExtraResource("ade-cli/install-path.cmd")) {
-    fail("package.json build.extraResources must ship ade-cli/install-path.cmd");
+  for (const relativePath of [
+    "bin/ade.cmd",
+    "bootstrap.cjs",
+    "ptyHostWorker.cjs",
+    "cursorSdkWorker.cjs",
+    "droidSdkWorker.cjs",
+    "adeRpcServer.cjs",
+    "tuiClient",
+    "install-path.cmd",
+  ]) {
+    requireExtraResource(`ade-cli/${relativePath}`);
   }
   if (!Array.isArray(pkg.build?.asarUnpack) || !pkg.build.asarUnpack.includes("vendor/crsqlite/**")) {
     fail("package.json build.asarUnpack must unpack vendor/crsqlite/**");
@@ -504,10 +515,6 @@ async function validatePackagedRuntime(appDir) {
   const resourcesPath = path.join(appDir, "resources");
   const appAsarPath = path.join(resourcesPath, "app.asar");
   const unpackedPath = path.join(resourcesPath, "app.asar.unpacked");
-  const adeCliPath = path.join(resourcesPath, "ade-cli", "cli.cjs");
-  const adeCliBootstrapPath = path.join(resourcesPath, "ade-cli", "bootstrap.cjs");
-  const adeCliPtyHostWorkerPath = path.join(resourcesPath, "ade-cli", "ptyHostWorker.cjs");
-  const adeCliRpcPath = path.join(resourcesPath, "ade-cli", "adeRpcServer.cjs");
   const adeCliTuiPath = path.join(resourcesPath, "ade-cli", "tuiClient", "cli.mjs");
   const adeCliBinPath = path.join(resourcesPath, "ade-cli", "bin", "ade.cmd");
   const adeCliInstallerPath = path.join(resourcesPath, "ade-cli", "install-path.cmd");
@@ -521,13 +528,9 @@ async function validatePackagedRuntime(appDir) {
   await assertPathExists(appExe, "packaged Windows app executable");
   await assertPathExists(appAsarPath, "app.asar payload");
   await assertPathExists(unpackedPath, "app.asar.unpacked runtime payload");
-  await assertPathExists(adeCliPath, "bundled ADE CLI entry");
-  await assertPathExists(adeCliBootstrapPath, "bundled ADE CLI bootstrap entry");
-  await assertPathExists(adeCliPtyHostWorkerPath, "bundled ADE CLI PTY host worker");
-  await assertPathExists(adeCliRpcPath, "bundled ADE CLI RPC entry");
-  await assertPathExists(adeCliTuiPath, "bundled ADE CLI TUI entry");
-  await assertPathExists(adeCliBinPath, "bundled ADE CLI wrapper");
-  await assertPathExists(adeCliInstallerPath, "bundled ADE CLI PATH installer");
+  for (const [relativePath, label] of bundledAdeCliFiles) {
+    await assertPathExists(path.join(resourcesPath, "ade-cli", relativePath), label);
+  }
   await assertBundledAgentSkills(bundledAgentSkillsRoot);
   await assertPathExists(nodePtyModulePath, "unpacked node-pty module");
   await assertPathExists(sqlJsModulePath, "unpacked sql.js module");

--- a/apps/desktop/scripts/validate-win-artifacts.mjs
+++ b/apps/desktop/scripts/validate-win-artifacts.mjs
@@ -516,6 +516,8 @@ async function validatePackagedRuntime(appDir) {
   const resourcesPath = path.join(appDir, "resources");
   const appAsarPath = path.join(resourcesPath, "app.asar");
   const unpackedPath = path.join(resourcesPath, "app.asar.unpacked");
+  const adeCliBinPath = path.join(resourcesPath, "ade-cli", "bin", "ade.cmd");
+  const adeCliInstallerPath = path.join(resourcesPath, "ade-cli", "install-path.cmd");
   const adeCliTuiPath = path.join(resourcesPath, "ade-cli", "tuiClient", "cli.mjs");
   const bundledAgentSkillsRoot = path.join(resourcesPath, "agent-skills");
   const nodeModulesPath = path.join(unpackedPath, "node_modules");


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fsee-ade-lane-called-mobile-855b647a num=556 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fsee-ade-lane-called-mobile-855b647a&amp;pr=556">ade/see-ade-lane-called-mobile-855b647a branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=556">PR #556</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced static application build process with improved module resolution and runtime handling.
  * Strengthened validation of bundled application components during packaging across platforms.
  * Improved build artifact verification to ensure consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships two new CLI worker bundles (`cursorSdkWorker.cjs`, `droidSdkWorker.cjs`) into the packaged desktop app and tightens the SEA runtime module-resolution logic so sidecar modules are reliably found at runtime.

- **New workers**: `cursorSdkWorker.cjs` and `droidSdkWorker.cjs` are added to `extraResources` in `package.json` and to all three validation scripts (`after-pack-runtime-fixes.cjs`, `validate-mac-artifacts.mjs`, `validate-win-artifacts.mjs`), keeping packaging and validation in sync.
- **Module resolution overhaul** (`build-static.mjs`): The `.native` staging dir and `../runtime/target` are now probed before `NODE_PATH` entries; `__adeSeaRequire` tries the filesystem first for bare non-builtin IDs, and the `MODULE_NOT_FOUND` fallback is narrowed to the top-level requested module (preventing spurious fallbacks when a transitive dependency is missing).
- **Cleanup ordering fix**: `assertStaticRuntimeVersion` is now called while native staging is still present (inside a `try/finally` block) so version assertions have access to the staged artifacts before cleanup.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive (new worker bundles) plus a narrowed-fallback improvement to the SEA module resolver with no breaking changes to existing resolution paths.

All six files are build/packaging scripts with no changes to application logic. The module-resolution refactor in build-static.mjs is well-structured: it only widens coverage for bare non-builtin modules when a runtime root is present, and the narrowed MODULE_NOT_FOUND check is strictly safer than the previous catch-all. Packaging and validation scripts are kept in sync across both platforms.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/scripts/build-static.mjs | Refactors SEA runtime module resolution: prioritises .native and ../runtime/target directories before NODE_PATH, adds filesystem-first require for bare non-builtin modules, narrows MODULE_NOT_FOUND fallback to top-level module only, and fixes staging-cleanup ordering via try/finally. |
| apps/desktop/package.json | Adds cursorSdkWorker.cjs and droidSdkWorker.cjs to extraResources so they are shipped alongside the packaged desktop app. |
| apps/desktop/scripts/after-pack-runtime-fixes.cjs | Adds presence checks for the two new worker bundles during after-pack validation. |
| apps/desktop/scripts/ensure-ade-cli-build.cjs | Extends the dist-file existence check with ptyHostWorker.cjs, cursorSdkWorker.cjs, and droidSdkWorker.cjs to catch missing builds early. |
| apps/desktop/scripts/validate-mac-artifacts.mjs | Refactors per-file assertPathExists calls into a bundledAdeCliFiles loop, adds the two new workers and preserves assertExecutable calls for bin/ade and install-path.sh. |
| apps/desktop/scripts/validate-win-artifacts.mjs | Mirrors the Mac refactor for Windows: adds requireExtraResource helper, loops bundledAdeCliFiles for both preflight and packaged-runtime checks, adds cli.cjs coverage that was missing from the old list. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[__adeSeaRequire called with id] --> B{__adeSeaShouldUseFilesystemRequireFirst?}
    B -- "No\n(relative, absolute, builtin,\nor no runtimeRoot)" --> E[Try originalRequire]
    B -- "Yes\n(bare, non-builtin, runtimeRoot set)" --> C[Try filesystemRequire]
    C -- success --> DONE[Return module]
    C -- error --> D{__adeSeaCanFallbackAfterResolveError?}
    D -- "No\n(transitive dep missing\nor other error)" --> THROW[Re-throw error]
    D -- "Yes\n(ERR_UNKNOWN_BUILTIN_MODULE\nor top-level MODULE_NOT_FOUND)" --> E
    E -- success --> DONE
    E -- error --> F{__adeSeaCanFallbackAfterResolveError?}
    F -- Yes --> G[Try filesystemRequire fallback]
    F -- No --> THROW
    G --> DONE
```

<sub>Reviews (4): Last reviewed commit: ["Tighten static runtime require fallback"](https://github.com/arul28/ade/commit/c88b54cd836b61d8844139c9b39114ab3ff1bedd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36929548)</sub>

<!-- /greptile_comment -->