### PR TITLE
Recover stale local sync viewer drafts

### DIFF
--- a/apps/ade-cli/src/services/sync/syncService.ts
+++ b/apps/ade-cli/src/services/sync/syncService.ts
@@ -248,16 +248,21 @@ const SYNC_HOST_MAX_PORT = DEFAULT_SYNC_HOST_PORT + SYNC_HOST_PORT_RETRY_WINDOW;
 const LOCAL_LANE_PRESENCE_HEARTBEAT_MS = 30_000;
 const TRANSFER_READINESS_CACHE_MS = 15_000;
 const STALE_BRAIN_LAST_SEEN_MS = 5 * 60_000;
-const VIEWER_DRAFT_TRANSPORT_ERROR_CODES = new Set([
+const VIEWER_DRAFT_TRANSPORT_ERROR_CODES = [
   "ECONNREFUSED",
   "ETIMEDOUT",
   "EHOSTUNREACH",
   "ENETUNREACH",
   "ENOTFOUND",
   "EAI_AGAIN",
-]);
-const VIEWER_DRAFT_TRANSPORT_ERROR_PATTERN =
-  /\b(?:ECONNREFUSED|ETIMEDOUT|EHOSTUNREACH|ENETUNREACH|ENOTFOUND|EAI_AGAIN)\b/i;
+] as const;
+const VIEWER_DRAFT_TRANSPORT_ERROR_CODE_SET = new Set<string>(
+  VIEWER_DRAFT_TRANSPORT_ERROR_CODES,
+);
+const VIEWER_DRAFT_TRANSPORT_ERROR_PATTERN = new RegExp(
+  `\\b(?:${VIEWER_DRAFT_TRANSPORT_ERROR_CODES.join("|")})\\b`,
+  "i",
+);
 
 function generatePairingPin(): string {
   return randomInt(0, 1_000_000).toString().padStart(6, "0");
@@ -375,7 +380,7 @@ function isDraftTargetLocalDevice(
 
 function isViewerDraftTransportError(error: unknown): boolean {
   const code = (error as { code?: unknown } | null | undefined)?.code;
-  if (typeof code === "string" && VIEWER_DRAFT_TRANSPORT_ERROR_CODES.has(code)) {
+  if (typeof code === "string" && VIEWER_DRAFT_TRANSPORT_ERROR_CODE_SET.has(code)) {
     return true;
   }
   const message = error instanceof Error ? error.message : String(error);

--- a/apps/ade-cli/src/services/sync/syncService.ts
+++ b/apps/ade-cli/src/services/sync/syncService.ts
@@ -248,6 +248,16 @@ const SYNC_HOST_MAX_PORT = DEFAULT_SYNC_HOST_PORT + SYNC_HOST_PORT_RETRY_WINDOW;
 const LOCAL_LANE_PRESENCE_HEARTBEAT_MS = 30_000;
 const TRANSFER_READINESS_CACHE_MS = 15_000;
 const STALE_BRAIN_LAST_SEEN_MS = 5 * 60_000;
+const VIEWER_DRAFT_TRANSPORT_ERROR_CODES = new Set([
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EAI_AGAIN",
+]);
+const VIEWER_DRAFT_TRANSPORT_ERROR_PATTERN =
+  /\b(?:ECONNREFUSED|ETIMEDOUT|EHOSTUNREACH|ENETUNREACH|ENOTFOUND|EAI_AGAIN)\b/i;
 
 function generatePairingPin(): string {
   return randomInt(0, 1_000_000).toString().padStart(6, "0");
@@ -289,6 +299,12 @@ function normalizeHost(host: string | null | undefined): string | null {
   if (!host) return null;
   const normalized = host.trim().toLowerCase();
   return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeHostKey(host: string | null | undefined): string | null {
+  const normalized = normalizeHost(host);
+  if (!normalized) return null;
+  return normalized.replace(/^\[/, "").replace(/\]$/, "").replace(/\.$/, "");
 }
 
 function tailscaleDnsNameFromDevice(
@@ -333,6 +349,37 @@ function buildAddressCandidates(
   append(localDevice.tailscaleIp, "tailscale");
   append("127.0.0.1", "loopback");
   return candidates;
+}
+
+function isDraftTargetLocalDevice(
+  draft: SyncDesktopConnectionDraft,
+  localDevice: SyncRoleSnapshot["localDevice"],
+): boolean {
+  const draftHost = normalizeHostKey(draft.host);
+  if (!draftHost) return false;
+  const localHosts = new Set<string>(["localhost", "127.0.0.1", "::1"]);
+  for (const host of localDevice.ipAddresses) {
+    const key = normalizeHostKey(host);
+    if (key) localHosts.add(key);
+  }
+  for (const host of [
+    localDevice.tailscaleIp,
+    tailscaleDnsNameFromDevice(localDevice),
+    typeof localDevice.metadata?.hostname === "string" ? localDevice.metadata.hostname : null,
+  ]) {
+    const key = normalizeHostKey(host);
+    if (key) localHosts.add(key);
+  }
+  return localHosts.has(draftHost);
+}
+
+function isViewerDraftTransportError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  if (typeof code === "string" && VIEWER_DRAFT_TRANSPORT_ERROR_CODES.has(code)) {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return VIEWER_DRAFT_TRANSPORT_ERROR_PATTERN.test(message);
 }
 
 function buildPairingConnectInfo(argsIn: {
@@ -827,6 +874,18 @@ export function createSyncService(args: SyncServiceArgs) {
     return Date.now() - lastSeenMs > STALE_BRAIN_LAST_SEEN_MS;
   };
 
+  const shouldReclaimStaleViewerDraft = (argsIn: {
+    cluster: ReturnType<typeof deviceRegistryService.getClusterState>;
+    localDevice: SyncRoleSnapshot["localDevice"];
+    draft: SyncDesktopConnectionDraft;
+    error: unknown;
+  }): boolean => {
+    if (!hostStartupEnabled || !isCrdtSyncAvailable()) return false;
+    if (!isViewerDraftTransportError(argsIn.error)) return false;
+    if (!isDraftTargetLocalDevice(argsIn.draft, argsIn.localDevice)) return false;
+    return !argsIn.cluster || isStaleNonLocalBrainCluster(argsIn.cluster, argsIn.localDevice.deviceId);
+  };
+
   const refreshRoleState = async (): Promise<void> => {
     if (disposed) return;
     if (refreshRunning) {
@@ -892,6 +951,27 @@ export function createSyncService(args: SyncServiceArgs) {
               args.logger.warn("sync.role.viewer_connect_failed", {
                 error: error instanceof Error ? error.message : String(error),
               });
+              if (shouldReclaimStaleViewerDraft({ cluster, localDevice, draft, error })) {
+                args.logger.warn("sync.role.viewer_stale_draft_reclaimed", {
+                  host: draft.host,
+                  port: draft.port,
+                  previousBrainDeviceId: cluster?.brainDeviceId ?? null,
+                  error: error instanceof Error ? error.message : String(error),
+                });
+                writeSavedDraft(null);
+                syncPeerService.setSavedDraft(null);
+                deviceRegistryService.touchLocalDevice({
+                  lastSeenAt: nowIso(),
+                  lastHost: localDevice.lastHost,
+                  lastPort: localDevice.lastPort ?? DEFAULT_SYNC_HOST_PORT,
+                });
+                cluster = deviceRegistryService.setClusterState({
+                  brainDeviceId: localDevice.deviceId,
+                  brainEpoch: (cluster?.brainEpoch ?? 0) + 1,
+                  updatedByDeviceId: localDevice.deviceId,
+                });
+                await startHostIfNeeded();
+              }
             }
           }
         }

--- a/apps/desktop/src/main/services/sync/syncService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncService.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -95,6 +96,19 @@ function makeProjectRoot(prefix: string): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   fs.mkdirSync(path.join(root, ".ade", "artifacts"), { recursive: true });
   return root;
+}
+
+async function getUnusedPort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return port;
 }
 
 function insertProjectAndLane(
@@ -413,6 +427,175 @@ describe.skipIf(!isCrsqliteAvailable())("syncService", () => {
     expect(transferred.clusterState?.brainEpoch).toBe(4);
     expect(transferred.currentBrain?.deviceId).toBe(localDevice.deviceId);
     expect(transferred.transferReadiness.ready).toBe(true);
+  }, 30_000);
+
+  it("reclaims host role from a stale local viewer draft after transport failure", async () => {
+    const projectRoot = makeProjectRoot("ade-sync-service-stale-local-draft-");
+    const appPairingDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "ade-sync-service-stale-local-draft-app-"),
+    );
+    fs.mkdirSync(appPairingDir, { recursive: true });
+    fs.writeFileSync(path.join(appPairingDir, "sync-bootstrap-token"), "local-bootstrap-token\n", "utf8");
+    fs.writeFileSync(
+      path.join(appPairingDir, "sync-peer-draft.json"),
+      `${JSON.stringify({
+        host: "127.0.0.1",
+        port: await getUnusedPort(),
+        authKind: "bootstrap",
+        lastRemoteDbVersion: 0,
+      }, null, 2)}\n`,
+      "utf8",
+    );
+    const db = await openKvDb(
+      path.join(projectRoot, ".ade", "ade.db"),
+      createLogger() as any,
+    );
+
+    const service = createSyncService({
+      db,
+      logger: createLogger() as any,
+      projectRoot,
+      phonePairingStateDir: appPairingDir,
+      fileService: { dispose: () => {} } as any,
+      laneService: {
+        list: async () => [],
+        create: async () => ({}),
+        archive: async () => {},
+      } as any,
+      prService: {} as any,
+      sessionService: { list: () => [] } as any,
+      ptyService: {} as any,
+      computerUseArtifactBrokerService: {} as any,
+      agentChatService: { listSessions: async () => [] } as any,
+      processService: { listRuntime: () => [] } as any,
+      hostStartupEnabled: true,
+    } as any);
+
+    activeDisposers.push(async () => {
+      await service.dispose();
+      db.close();
+    });
+
+    const localDevice = (await service.getStatus()).localDevice;
+    const staleAt = "2026-03-15T00:00:00.000Z";
+    db.run(
+      `insert into devices(
+        device_id, site_id, name, platform, device_type, created_at, updated_at, last_seen_at, last_host, last_port, tailscale_ip, ip_addresses_json, metadata_json
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        "stale-local-brain",
+        "stale-site",
+        "Old local host",
+        "macOS",
+        "desktop",
+        staleAt,
+        staleAt,
+        staleAt,
+        "127.0.0.1",
+        8789,
+        null,
+        JSON.stringify(["127.0.0.1"]),
+        JSON.stringify({}),
+      ],
+    );
+    db.run(
+      `insert into sync_cluster_state(cluster_id, brain_device_id, brain_epoch, updated_at, updated_by_device_id)
+       values (?, ?, ?, ?, ?)`,
+      ["default", "stale-local-brain", 41, staleAt, "stale-local-brain"],
+    );
+
+    await service.initialize();
+
+    const status = await service.getStatus();
+    expect(status.role).toBe("brain");
+    expect(status.clusterState?.brainDeviceId).toBe(localDevice.deviceId);
+    expect(status.clusterState?.brainEpoch).toBe(42);
+    expect(status.pairingConnectInfo).toBeTruthy();
+    expect(fs.existsSync(path.join(appPairingDir, "sync-peer-draft.json"))).toBe(false);
+  }, 30_000);
+
+  it("keeps a stale unreachable viewer draft when the draft target is not local", async () => {
+    const projectRoot = makeProjectRoot("ade-sync-service-stale-remote-draft-");
+    const appPairingDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "ade-sync-service-stale-remote-draft-app-"),
+    );
+    const draftPath = path.join(appPairingDir, "sync-peer-draft.json");
+    fs.mkdirSync(appPairingDir, { recursive: true });
+    fs.writeFileSync(path.join(appPairingDir, "sync-bootstrap-token"), "remote-bootstrap-token\n", "utf8");
+    fs.writeFileSync(
+      draftPath,
+      `${JSON.stringify({
+        host: "not-local.invalid",
+        port: 8789,
+        authKind: "bootstrap",
+        lastRemoteDbVersion: 0,
+      }, null, 2)}\n`,
+      "utf8",
+    );
+    const db = await openKvDb(
+      path.join(projectRoot, ".ade", "ade.db"),
+      createLogger() as any,
+    );
+
+    const service = createSyncService({
+      db,
+      logger: createLogger() as any,
+      projectRoot,
+      phonePairingStateDir: appPairingDir,
+      fileService: { dispose: () => {} } as any,
+      laneService: {
+        list: async () => [],
+        create: async () => ({}),
+        archive: async () => {},
+      } as any,
+      prService: {} as any,
+      sessionService: { list: () => [] } as any,
+      ptyService: {} as any,
+      computerUseArtifactBrokerService: {} as any,
+      agentChatService: { listSessions: async () => [] } as any,
+      processService: { listRuntime: () => [] } as any,
+      hostStartupEnabled: true,
+    } as any);
+
+    activeDisposers.push(async () => {
+      await service.dispose();
+      db.close();
+    });
+
+    const staleAt = "2026-03-15T00:00:00.000Z";
+    db.run(
+      `insert into devices(
+        device_id, site_id, name, platform, device_type, created_at, updated_at, last_seen_at, last_host, last_port, tailscale_ip, ip_addresses_json, metadata_json
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        "stale-remote-brain",
+        "stale-site",
+        "Remote host",
+        "macOS",
+        "desktop",
+        staleAt,
+        staleAt,
+        staleAt,
+        "not-local.invalid",
+        8789,
+        null,
+        JSON.stringify(["10.0.0.9"]),
+        JSON.stringify({}),
+      ],
+    );
+    db.run(
+      `insert into sync_cluster_state(cluster_id, brain_device_id, brain_epoch, updated_at, updated_by_device_id)
+       values (?, ?, ?, ?, ?)`,
+      ["default", "stale-remote-brain", 41, staleAt, "stale-remote-brain"],
+    );
+
+    await service.initialize();
+
+    const status = await service.getStatus();
+    expect(status.role).toBe("viewer");
+    expect(status.clusterState?.brainDeviceId).toBe("stale-remote-brain");
+    expect(status.pairingConnectInfo).toBeNull();
+    expect(fs.existsSync(draftPath)).toBe(true);
   }, 30_000);
 
   it("builds pairing runtime addresses with LAN-first address candidates and tailscale fallback", async () => {

--- a/apps/desktop/src/main/services/sync/syncService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncService.test.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -96,19 +95,6 @@ function makeProjectRoot(prefix: string): string {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   fs.mkdirSync(path.join(root, ".ade", "artifacts"), { recursive: true });
   return root;
-}
-
-async function getUnusedPort(): Promise<number> {
-  const server = net.createServer();
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  const port = typeof address === "object" && address ? address.port : 0;
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
-  return port;
 }
 
 function insertProjectAndLane(
@@ -440,7 +426,7 @@ describe.skipIf(!isCrsqliteAvailable())("syncService", () => {
       path.join(appPairingDir, "sync-peer-draft.json"),
       `${JSON.stringify({
         host: "127.0.0.1",
-        port: await getUnusedPort(),
+        port: 1,
         authKind: "bootstrap",
         lastRemoteDbVersion: 0,
       }, null, 2)}\n`,


### PR DESCRIPTION
## Summary
- reclaim the sync brain role when startup is stuck on a stale local saved viewer draft and transport connect fails
- keep non-local unreachable drafts intact so ADE does not steal from an offline remote authority
- add sync service regressions for both recovery and non-local preservation

## Validation
- PATH=/Users/arul/.asdf/installs/nodejs/22.13.1/bin:$PATH npm --prefix apps/desktop exec -- vitest run src/main/services/sync/syncService.test.ts
- PATH=/Users/arul/.asdf/installs/nodejs/22.13.1/bin:$PATH npm --prefix apps/ade-cli run typecheck
- PATH=/Users/arul/.asdf/installs/nodejs/22.13.1/bin:$PATH npm --prefix apps/desktop run typecheck
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a stale-local-draft recovery path to the sync service: when startup is stuck as a viewer with a saved draft pointing to a local address that fails with a transport error, ADE reclaims the brain role rather than staying blocked. Non-local (remote) unreachable drafts are explicitly preserved so a temporarily-offline remote authority is not stolen from.

- **`syncService.ts`**: Extracts `VIEWER_DRAFT_TRANSPORT_ERROR_CODES` as a single source-of-truth array used to build both the `Set` (code matching) and the derived `RegExp` (message fallback); adds `normalizeHostKey`, `isDraftTargetLocalDevice`, `isViewerDraftTransportError`, and `shouldReclaimStaleViewerDraft` helpers; invokes reclaim inside the existing viewer-connect failure handler when all guards pass.
- **`syncService.test.ts`**: Adds two regression tests — one that verifies the brain role is reclaimed from a stale local draft (port 1 on 127.0.0.1, reliably ECONNREFUSED without a TOCTOU race), and one that verifies a stale draft targeting a non-local host is left intact.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the reclaim path is gated by multiple independent guards and only fires for local-targeted drafts after a transport-level failure.

The change is narrowly scoped: it only fires when all of hostStartupEnabled, isCrdtSyncAvailable, a transport error, a local-targeted draft, and a stale-or-absent cluster all hold simultaneously. State mutations (draft cleared, cluster updated, host started) are ordered so the service remains consistent even if startHostIfNeeded throws mid-reclaim. The dual-test coverage exercises both the reclaim and the explicit non-reclaim (remote draft preservation) cases. No pre-existing paths are altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/services/sync/syncService.ts | Adds recovery helpers and the reclaim block inside the viewer connect-error handler; all guards are layered correctly, the single-source error code array resolves the previous duplication concern, and state mutations (draft clear, cluster update, host start) are ordered safely. |
| apps/desktop/src/main/services/sync/syncService.test.ts | Two new regression tests cover the reclaim and non-reclaim paths; port 1 is a cleaner choice than getUnusedPort for the local failure scenario (no TOCTOU), and 'not-local.invalid' reliably produces ENOTFOUND for the remote preservation test. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[refreshRoleState loop] --> B{isLocalBrain?}
    B -- yes --> C[startHostIfNeeded]
    B -- no --> D[try syncPeerService.connect]
    D -- success --> E[touchLocalDevice & flushLocalChanges]
    D -- failure --> F[log viewer_connect_failed]
    F --> G{shouldReclaimStaleViewerDraft?}
    G -- no --> H[stay as viewer, draft preserved]
    G -- yes --> I{all guards pass?}
    I -- hostStartupEnabled=false or CRDT unavailable --> H
    I -- not a transport error --> H
    I -- draft not local --> H
    I -- cluster fresh and non-local --> H
    I -- all pass --> J[log viewer_stale_draft_reclaimed]
    J --> K[writeSavedDraft null]
    K --> L[setClusterState brainEpoch+1]
    L --> M[startHostIfNeeded - brain role]
```

<sub>Reviews (2): Last reviewed commit: ["Address sync draft review feedback"](https://github.com/arul28/ade/commit/6857716914e36aaba76bf19496c80477eff41f5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36930267)</sub>

<!-- /greptile_comment -->