### PR TITLE
Block packaged ADE launch on cross-channel sync conflict

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -202,6 +202,7 @@ import {
 } from "./services/notifications/notificationEventBus";
 import type { SyncService } from "./services/sync/syncService";
 import type { DeviceRegistryService } from "./services/sync/deviceRegistryService";
+import { blockPackagedLaunchForCrossChannelSyncConflict } from "./services/sync/packagedSyncHostLaunchGate";
 import { createAutoUpdateService } from "./services/updates/autoUpdateService";
 import { cleanupStaleTempArtifacts } from "./services/runtime/tempCleanupService";
 import type { Logger } from "./services/logging/logger";
@@ -826,6 +827,13 @@ app.whenReady().then(async () => {
   const perfRun = initPerfRunFromEnv();
   if (perfRun) {
     startMetricsSampler();
+  }
+
+  if (blockPackagedLaunchForCrossChannelSyncConflict({
+    isPackaged: app.isPackaged,
+    channel: normalizeAdePackageChannel(process.env.ADE_PACKAGE_CHANNEL),
+  })) {
+    return;
   }
 
   /** Canonical artifacts dir for the active project; ade-artifact:// only serves under this path. */

--- a/apps/desktop/src/main/services/sync/packagedSyncHostLaunchGate.test.ts
+++ b/apps/desktop/src/main/services/sync/packagedSyncHostLaunchGate.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  blockPackagedLaunchForCrossChannelSyncConflict,
+  buildPackagedSyncHostConflictDialogContent,
+  resolveCrossChannelSyncHostConflict,
+  resolveLaunchingDesktopAppName,
+} from "./packagedSyncHostLaunchGate";
+import type { SyncHostSingletonConflict } from "../../../../../ade-cli/src/services/sync/syncHostSingleton";
+
+const stableConflict: SyncHostSingletonConflict = {
+  reason: "listener",
+  owner: {
+    id: "stable-3735-8828",
+    pid: 3735,
+    port: 8828,
+    appName: "ADE",
+    packageChannel: null,
+    adeHome: "/Users/admin/.ade",
+    serviceName: "com.ade.runtime",
+    socketPath: "/Users/admin/.ade/sock/ade.sock",
+    projectRoot: null,
+    commandLine: null,
+    quitCommand:
+      "ADE_HOME='/Users/admin/.ade' '/Applications/ADE.app/Contents/Resources/ade-cli/bin/ade' brain stop --text; /bin/kill 3735 2>/dev/null || true",
+    createdAt: "2026-06-12T00:00:00.000Z",
+    updatedAt: "2026-06-12T00:00:00.000Z",
+  },
+};
+
+describe("packagedSyncHostLaunchGate", () => {
+  it("resolves launching app names for official channels", () => {
+    expect(resolveLaunchingDesktopAppName(null)).toBe("ADE");
+    expect(resolveLaunchingDesktopAppName("beta")).toBe("ADE Beta");
+    expect(resolveLaunchingDesktopAppName("alpha")).toBe("ADE Alpha");
+    expect(resolveLaunchingDesktopAppName("beta", { ADE_DESKTOP_APP_NAME: "Custom ADE" })).toBe("Custom ADE");
+  });
+
+  it("builds a clear dialog with the stop command", () => {
+    const content = buildPackagedSyncHostConflictDialogContent({
+      launchingAppName: "ADE Beta",
+      conflict: stableConflict,
+    });
+
+    expect(content.title).toBe("Cannot launch ADE Beta");
+    expect(content.message).toContain("ADE is already running with phone sync");
+    expect(content.detail).toContain("Only one official ADE build can host phone sync");
+    expect(content.detail).toContain("Running now: ADE (pid 3735) on sync port 8828");
+    expect(content.quitCommand).toContain("brain stop --text");
+    expect(content.detail).toContain(content.quitCommand);
+  });
+
+  it("does not block dev builds", () => {
+    const quit = vi.fn();
+    const blocked = blockPackagedLaunchForCrossChannelSyncConflict({
+      isPackaged: false,
+      channel: "beta",
+      detectConflict: () => stableConflict,
+      quit,
+    });
+
+    expect(blocked).toBe(false);
+    expect(quit).not.toHaveBeenCalled();
+  });
+
+  it("does not block when the conflict owner is the same channel", () => {
+    const quit = vi.fn();
+    const blocked = blockPackagedLaunchForCrossChannelSyncConflict({
+      isPackaged: true,
+      channel: "beta",
+      env: {
+        ADE_PACKAGE_CHANNEL: "beta",
+        ADE_HOME: "/Users/admin/.ade-beta",
+      },
+      detectConflict: () => ({
+        ...stableConflict,
+        owner: {
+          ...stableConflict.owner,
+          appName: "ADE Beta",
+          packageChannel: "beta",
+          adeHome: "/Users/admin/.ade-beta",
+        },
+      }),
+      quit,
+    });
+
+    expect(blocked).toBe(false);
+    expect(quit).not.toHaveBeenCalled();
+  });
+
+  it("blocks packaged launches, copies the stop command, and quits", () => {
+    const showDialog = vi.fn();
+    const copyToClipboard = vi.fn();
+    const quit = vi.fn();
+
+    const blocked = blockPackagedLaunchForCrossChannelSyncConflict({
+      isPackaged: true,
+      channel: "beta",
+      env: {
+        ADE_PACKAGE_CHANNEL: "beta",
+        ADE_HOME: "/Users/admin/.ade-beta",
+      },
+      detectConflict: () => stableConflict,
+      showDialog,
+      copyToClipboard,
+      quit,
+    });
+
+    expect(blocked).toBe(true);
+    expect(copyToClipboard).toHaveBeenCalledWith(stableConflict.owner.quitCommand);
+    expect(showDialog).toHaveBeenCalledWith(expect.objectContaining({
+      title: "Cannot launch ADE Beta",
+      quitCommand: stableConflict.owner.quitCommand,
+    }));
+    expect(quit).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolveCrossChannelSyncHostConflict ignores same-channel owners", () => {
+    const conflict = resolveCrossChannelSyncHostConflict(stableConflict, {
+      ADE_PACKAGE_CHANNEL: "beta",
+      ADE_HOME: "/Users/admin/.ade-beta",
+    });
+    expect(conflict).toEqual(stableConflict);
+
+    const sameChannel = resolveCrossChannelSyncHostConflict({
+      ...stableConflict,
+      owner: {
+        ...stableConflict.owner,
+        appName: "ADE Beta",
+        packageChannel: "beta",
+        adeHome: "/Users/admin/.ade-beta",
+      },
+    }, {
+      ADE_PACKAGE_CHANNEL: "beta",
+      ADE_HOME: "/Users/admin/.ade-beta",
+    });
+    expect(sameChannel).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/services/sync/packagedSyncHostLaunchGate.ts
+++ b/apps/desktop/src/main/services/sync/packagedSyncHostLaunchGate.ts
@@ -1,0 +1,116 @@
+import { app, clipboard, dialog } from "electron";
+import {
+  detectSyncHostSingletonConflict,
+  isSameChannelSyncHostOwner,
+  type SyncHostSingletonConflict,
+} from "../../../../../ade-cli/src/services/sync/syncHostSingleton";
+
+export type PackagedSyncHostConflictDialogContent = {
+  title: string;
+  message: string;
+  detail: string;
+  quitCommand: string;
+};
+
+export function resolveLaunchingDesktopAppName(
+  channel: "alpha" | "beta" | null,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const fromEnv = env.ADE_DESKTOP_APP_NAME?.trim();
+  if (fromEnv) return fromEnv;
+  if (channel === "alpha") return "ADE Alpha";
+  if (channel === "beta") return "ADE Beta";
+  return "ADE";
+}
+
+export function resolveCrossChannelSyncHostConflict(
+  conflict: SyncHostSingletonConflict | null,
+  env: NodeJS.ProcessEnv = process.env,
+): SyncHostSingletonConflict | null {
+  if (!conflict) return null;
+  if (isSameChannelSyncHostOwner(conflict.owner, env)) return null;
+  return conflict;
+}
+
+export function detectCrossChannelSyncHostConflict(
+  env: NodeJS.ProcessEnv = process.env,
+): SyncHostSingletonConflict | null {
+  return resolveCrossChannelSyncHostConflict(detectSyncHostSingletonConflict(), env);
+}
+
+export function buildPackagedSyncHostConflictDialogContent(args: {
+  launchingAppName: string;
+  conflict: SyncHostSingletonConflict;
+}): PackagedSyncHostConflictDialogContent {
+  const owner = args.conflict.owner;
+  const ownerName = owner.appName ?? "ADE";
+  const portText = owner.port != null ? ` on sync port ${owner.port}` : "";
+  const pidText = Number.isFinite(owner.pid) && owner.pid > 0 ? `pid ${owner.pid}` : "unknown pid";
+  const quitCommand = owner.quitCommand.trim();
+
+  return {
+    title: `Cannot launch ${args.launchingAppName}`,
+    message: `${ownerName} is already running with phone sync.`,
+    detail: [
+      "Only one official ADE build can host phone sync at a time.",
+      "",
+      `Running now: ${ownerName} (${pidText})${portText}.`,
+      `Quit that brain before launching ${args.launchingAppName}.`,
+      "",
+      "Run this in Terminal:",
+      quitCommand,
+      "",
+      `The command has been copied to your clipboard. Relaunch ${args.launchingAppName} after it finishes.`,
+    ].join("\n"),
+    quitCommand,
+  };
+}
+
+export type PackagedSyncHostLaunchGateDeps = {
+  isPackaged: boolean;
+  channel: "alpha" | "beta" | null;
+  env?: NodeJS.ProcessEnv;
+  detectConflict?: (env: NodeJS.ProcessEnv) => SyncHostSingletonConflict | null | undefined;
+  showDialog?: (content: PackagedSyncHostConflictDialogContent) => void;
+  copyToClipboard?: (text: string) => void;
+  quit?: () => void;
+};
+
+export function blockPackagedLaunchForCrossChannelSyncConflict(
+  deps: PackagedSyncHostLaunchGateDeps,
+): boolean {
+  const env = deps.env ?? process.env;
+  if (!deps.isPackaged) return false;
+  if (env.NODE_ENV === "test") return false;
+  if (env.ADE_DISABLE_SYNC_HOST_LAUNCH_GATE === "1") return false;
+
+  const rawConflict = deps.detectConflict
+    ? deps.detectConflict(env) ?? null
+    : detectSyncHostSingletonConflict();
+  const conflict = resolveCrossChannelSyncHostConflict(rawConflict, env);
+  if (!conflict) return false;
+
+  const content = buildPackagedSyncHostConflictDialogContent({
+    launchingAppName: resolveLaunchingDesktopAppName(deps.channel, env),
+    conflict,
+  });
+
+  (deps.copyToClipboard ?? ((text) => clipboard.writeText(text)))(content.quitCommand);
+  (deps.showDialog ?? showPackagedSyncHostConflictDialog)(content);
+  (deps.quit ?? (() => app.quit()))();
+  return true;
+}
+
+export function showPackagedSyncHostConflictDialog(
+  content: PackagedSyncHostConflictDialogContent,
+): void {
+  dialog.showMessageBoxSync({
+    type: "error",
+    buttons: ["OK"],
+    defaultId: 0,
+    noLink: true,
+    title: content.title,
+    message: content.message,
+    detail: content.detail,
+  });
+}


### PR DESCRIPTION
## Summary
- Show a native macOS error dialog at startup for packaged stable/beta/alpha when another official ADE build already hosts phone sync.
- Copy the dynamic `brain stop` command to the clipboard (derived from the live sync-host owner, not hardcoded).
- Quit before opening the desktop shell so users get a clear fix path instead of a broken Mobile drawer.

## Test plan
- [x] `npx vitest run src/main/services/sync/packagedSyncHostLaunchGate.test.ts`
- [x] `npm --prefix apps/desktop run typecheck`
- [ ] Manual: launch ADE Beta while stable brain holds sync → dialog appears with stable stop command
- [ ] Manual: run copied command, relaunch beta → beta brain starts cleanly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop app now prevents launching when phone sync is already running on a different app version
  * Displays an error dialog with instructions when launch is blocked
  * Automatically copies the recommended action to clipboard for convenience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->