### PR TITLE
Final Release Audit

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -491,10 +491,10 @@ Release v<VERSION> — summary
 
 Next steps:
 1. Review the draft release, then `gh release edit v<VERSION> --draft=false` to publish.
-2. After publishing, bump the Homebrew tap: `scripts/update-brew-tap.sh v<VERSION>`
-   (updates the cask version + sha256 in arul28/homebrew-ade so
-   `brew install --cask arul28/ade/ade` serves the new DMG. It refuses to run
-   against a draft, so it cannot be done before step 1.)
+2. Publishing automatically bumps the Homebrew tap (arul28/homebrew-ade) via the
+   `update-brew-tap.yml` workflow — verify with
+   `gh run list --workflow update-brew-tap.yml --limit 1` after publishing.
+   Manual fallback if that run fails: `scripts/update-brew-tap.sh v<VERSION>`.
 ```
 
 If any phase ended in `blocked`, the summary says `BLOCKED` at the top with the failing phase and the command to resume.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -465,17 +465,17 @@ Before printing the summary, verify the draft release carries every expected ass
 gh release view "v<VERSION>" --json assets --jq '.assets[].name' | sort
 ```
 
-Expected asset set when `scope.desktop=true`:
+Expected asset set when `scope.desktop=true` (releases are macOS-only right now;
+Windows publishing is commented out in `release-core.yml`):
 - `ADE-<version>-universal.dmg`
 - `ADE-<version>-universal-mac.zip`
 - `ADE-<version>-universal-mac.zip.blockmap`
 - `latest-mac.yml`
-- `ADE-<version>-win-x64.exe`
-- `ADE-<version>-win-x64.exe.blockmap`
-- `latest.yml`
 
-If any macOS asset is missing → mac build or upload broke; re-inspect the `build-mac-release` job.
-If any Windows asset is missing → `build-win-release` broke or its artifact upload failed; re-inspect that job. Do not flip the draft if Windows artifacts are missing — shipping an asymmetric desktop release will confuse electron-updater consumers on the missing platform.
+These four are the complete set — the zip + blockmap + `latest-mac.yml` are what
+electron-updater consumes for auto-update (macOS updates install from the zip,
+not the DMG), so a release missing any of them silently bricks auto-update.
+If any asset is missing → mac build or upload broke; re-inspect the `build-mac-release` job.
 
 Then print a single final block and stop:
 
@@ -484,12 +484,17 @@ Release v<VERSION> — summary
 
 - Changelog:     https://www.ade-app.dev/docs/changelog/v<VERSION>
 - Draft release: <gh release url>  (still draft — flip manually)
-- Desktop assets: mac=<present|MISSING>, windows=<present|MISSING>
+- Desktop assets: mac=<present|MISSING>
 - Workflow run:  <gh run url>      (conclusion: success)
 - iOS TestFlight build <BUILD_NUMBER>: <VALID | processing | skipped>
 - Beta group:    <group name | n/a>
 
-Next step: review the draft release, then `gh release edit v<VERSION> --draft=false` to publish.
+Next steps:
+1. Review the draft release, then `gh release edit v<VERSION> --draft=false` to publish.
+2. After publishing, bump the Homebrew tap: `scripts/update-brew-tap.sh v<VERSION>`
+   (updates the cask version + sha256 in arul28/homebrew-ade so
+   `brew install --cask arul28/ade/ade` serves the new DMG. It refuses to run
+   against a draft, so it cannot be done before step 1.)
 ```
 
 If any phase ended in `blocked`, the summary says `BLOCKED` at the top with the failing phase and the command to resume.

--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -271,9 +271,9 @@ RELEASE_SHA=$(git rev-parse origin/main)
 
    Leave `isDraft=true`. Do not publish.
 
-   Expect the draft to carry both macOS and Windows assets once `publish-release` runs:
-   - macOS: `ADE-<version>-universal.dmg`, `ADE-<version>-universal-mac.zip`, `ADE-<version>-universal-mac.zip.blockmap`, `latest-mac.yml`
-   - Windows: `ADE-<version>-win-x64.exe`, `ADE-<version>-win-x64.exe.blockmap`, `latest.yml`
+   Expect the draft to carry the macOS-only asset set once `publish-release` runs
+   (the Windows/runtime surface is currently disabled in `release-core.yml`):
+   - `ADE-<version>-universal.dmg`, `ADE-<version>-universal-mac.zip`, `ADE-<version>-universal-mac.zip.blockmap`, `latest-mac.yml`
 
 ---
 

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -175,74 +175,78 @@ jobs:
             apps/desktop/release/latest-mac.yml
           if-no-files-found: error
 
-  build-win-release:
-    needs:
-      - verify
-      - build-runtime-binaries
-    runs-on: windows-latest
-    concurrency:
-      group: release-${{ inputs.release_tag }}-win
-      cancel-in-progress: true
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.target_ref }}
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: |
-            apps/desktop/package-lock.json
-            apps/ade-cli/package-lock.json
-
-      - name: Install desktop dependencies
-        run: cd apps/desktop && npm ci
-
-      - name: Install ADE CLI dependencies
-        run: cd apps/ade-cli && npm ci
-
-      - name: Download ADE runtime binaries
-        uses: actions/download-artifact@v4
-        with:
-          pattern: ade-runtime-*
-          path: apps/desktop/resources/runtime
-          merge-multiple: true
-
-      - name: Materialize ADE runtime resources
-        env:
-          ADE_RUNTIME_ARTIFACTS_DIR: ${{ github.workspace }}\apps\desktop\resources\runtime
-        run: cd apps/desktop && npm run materialize:runtime-resources
-
-      - name: Stamp release version
-        env:
-          ADE_RELEASE_TAG: ${{ inputs.release_tag }}
-        run: cd apps/desktop && npm run version:release
-
-      - name: Reset release output
-        shell: pwsh
-        run: |
-          Remove-Item -Recurse -Force apps/desktop/release, apps/desktop/.cache -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Path apps/desktop/.cache | Out-Null
-
-      - name: Build and validate Windows release
-        env:
-          ELECTRON_CACHE: ${{ github.workspace }}\apps\desktop\.cache\electron
-          ELECTRON_BUILDER_CACHE: ${{ github.workspace }}\apps\desktop\.cache\electron-builder
-          CSC_LINK: ${{ ((secrets.WINDOWS_CSC_LINK || secrets.WIN_CSC_LINK) && (secrets.WINDOWS_CSC_KEY_PASSWORD || secrets.WIN_CSC_KEY_PASSWORD)) && (secrets.WINDOWS_CSC_LINK || secrets.WIN_CSC_LINK) || '' }}
-          CSC_KEY_PASSWORD: ${{ ((secrets.WINDOWS_CSC_LINK || secrets.WIN_CSC_LINK) && (secrets.WINDOWS_CSC_KEY_PASSWORD || secrets.WIN_CSC_KEY_PASSWORD)) && (secrets.WINDOWS_CSC_KEY_PASSWORD || secrets.WIN_CSC_KEY_PASSWORD) || '' }}
-        run: cd apps/desktop && npm run dist:win
-
-      - name: Upload validated Windows artifacts to workflow run
-        uses: actions/upload-artifact@v4
-        with:
-          name: ade-win-release-${{ inputs.release_tag }}
-          path: |
-            apps/desktop/release/*.exe
-            apps/desktop/release/*.exe.blockmap
-            apps/desktop/release/latest.yml
-          if-no-files-found: error
+  # Windows release builds are disabled for now — ADE ships macOS-only releases.
+  # To re-enable: uncomment this job, add `build-win-release` back to
+  # publish-release `needs`, and restore the win blocks in the publish job
+  # (artifact download, manifest validation, upload list).
+  # build-win-release:
+  #   needs:
+  #     - verify
+  #     - build-runtime-binaries
+  #   runs-on: windows-latest
+  #   concurrency:
+  #     group: release-${{ inputs.release_tag }}-win
+  #     cancel-in-progress: true
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ inputs.target_ref }}
+  #         fetch-depth: 0
+  #
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 22
+  #         cache: npm
+  #         cache-dependency-path: |
+  #           apps/desktop/package-lock.json
+  #           apps/ade-cli/package-lock.json
+  #
+  #     - name: Install desktop dependencies
+  #       run: cd apps/desktop && npm ci
+  #
+  #     - name: Install ADE CLI dependencies
+  #       run: cd apps/ade-cli && npm ci
+  #
+  #     - name: Download ADE runtime binaries
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         pattern: ade-runtime-*
+  #         path: apps/desktop/resources/runtime
+  #         merge-multiple: true
+  #
+  #     - name: Materialize ADE runtime resources
+  #       env:
+  #         ADE_RUNTIME_ARTIFACTS_DIR: ${{ github.workspace }}\apps\desktop\resources\runtime
+  #       run: cd apps/desktop && npm run materialize:runtime-resources
+  #
+  #     - name: Stamp release version
+  #       env:
+  #         ADE_RELEASE_TAG: ${{ inputs.release_tag }}
+  #       run: cd apps/desktop && npm run version:release
+  #
+  #     - name: Reset release output
+  #       shell: pwsh
+  #       run: |
+  #         Remove-Item -Recurse -Force apps/desktop/release, apps/desktop/.cache -ErrorAction SilentlyContinue
+  #         New-Item -ItemType Directory -Path apps/desktop/.cache | Out-Null
+  #
+  #     - name: Build and validate Windows release
+  #       env:
+  #         ELECTRON_CACHE: ${{ github.workspace }}\apps\desktop\.cache\electron
+  #         ELECTRON_BUILDER_CACHE: ${{ github.workspace }}\apps\desktop\.cache\electron-builder
+  #         CSC_LINK: ${{ ((secrets.WINDOWS_CSC_LINK || secrets.WIN_CSC_LINK) && (secrets.WINDOWS_CSC_KEY_PASSWORD || secrets.WIN_CSC_KEY_PASSWORD)) && (secrets.WINDOWS_CSC_LINK || secrets.WIN_CSC_LINK) || '' }}
+  #         CSC_KEY_PASSWORD: ${{ ((secrets.WINDOWS_CSC_LINK || secrets.WIN_CSC_LINK) && (secrets.WINDOWS_CSC_KEY_PASSWORD || secrets.WIN_CSC_KEY_PASSWORD)) && (secrets.WINDOWS_CSC_KEY_PASSWORD || secrets.WIN_CSC_KEY_PASSWORD) || '' }}
+  #       run: cd apps/desktop && npm run dist:win
+  #
+  #     - name: Upload validated Windows artifacts to workflow run
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: ade-win-release-${{ inputs.release_tag }}
+  #         path: |
+  #           apps/desktop/release/*.exe
+  #           apps/desktop/release/*.exe.blockmap
+  #           apps/desktop/release/latest.yml
+  #         if-no-files-found: error
 
   build-runtime-binaries:
     needs: verify
@@ -377,7 +381,6 @@ jobs:
     needs:
       - build-runtime-binaries
       - build-mac-release
-      - build-win-release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -391,23 +394,33 @@ jobs:
           name: ade-mac-release-${{ inputs.release_tag }}
           path: release-assets/mac
 
-      - name: Download Windows release artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: ade-win-release-${{ inputs.release_tag }}
-          path: release-assets/win
-
-      - name: Download ADE runtime binaries
-        uses: actions/download-artifact@v4
-        with:
-          pattern: ade-runtime-*
-          path: release-assets/runtime
-          merge-multiple: true
-
-      - name: Add standalone runtime installer
-        run: |
-          cp apps/ade-cli/scripts/install-runtime.sh release-assets/runtime/install.sh
-          chmod 755 release-assets/runtime/install.sh
+      # Windows artifacts and the standalone runtime assets (ade-* binaries,
+      # native tarballs, install.sh) are intentionally NOT published right now.
+      # The release surface is macOS-only and kept minimal: the DMG for humans,
+      # plus the zip + blockmap + latest-mac.yml that electron-updater requires
+      # for auto-update (macOS auto-update installs from the zip, NOT the DMG —
+      # removing those three assets silently bricks updates for every install).
+      # The runtime binaries are still BUILT above because the macOS app bundles
+      # them as sidecars (local brain + remote-runtime bootstrap payloads).
+      # To publish them again, restore the blocks below.
+      #
+      # - name: Download Windows release artifacts
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: ade-win-release-${{ inputs.release_tag }}
+      #     path: release-assets/win
+      #
+      # - name: Download ADE runtime binaries
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     pattern: ade-runtime-*
+      #     path: release-assets/runtime
+      #     merge-multiple: true
+      #
+      # - name: Add standalone runtime installer
+      #   run: |
+      #     cp apps/ade-cli/scripts/install-runtime.sh release-assets/runtime/install.sh
+      #     chmod 755 release-assets/runtime/install.sh
 
       - name: Validate publish asset manifest
         run: |
@@ -440,23 +453,26 @@ jobs:
           require_glob 'release-assets/mac/*.zip' 'macOS zip'
           require_glob 'release-assets/mac/*-mac.zip.blockmap' 'macOS blockmap'
           require_file 'release-assets/mac/latest-mac.yml' 'macOS auto-update metadata'
-          require_glob 'release-assets/win/*.exe' 'Windows installer'
-          require_glob 'release-assets/win/*.exe.blockmap' 'Windows blockmap'
-          require_file 'release-assets/win/latest.yml' 'Windows auto-update metadata'
-          require_file 'release-assets/runtime/install.sh' 'standalone runtime installer'
-          if [ ! -x 'release-assets/runtime/install.sh' ]; then
-            echo "::error::Standalone runtime installer is not executable."
-            exit 1
-          fi
 
-          for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
-            require_file "release-assets/runtime/ade-$target" "ADE runtime binary for $target"
-            require_file "release-assets/runtime/ade-$target.native.tar.gz" "ADE native dependency archive for $target"
-            tar -tzf "release-assets/runtime/ade-$target.native.tar.gz" | grep -q '^\./node_modules/' || {
-              echo "::error::ADE native dependency archive for $target is missing node_modules."
-              exit 1
-            }
-          done
+          # Windows + standalone runtime assets are not published right now.
+          # Restore these checks together with the publish blocks above.
+          # require_glob 'release-assets/win/*.exe' 'Windows installer'
+          # require_glob 'release-assets/win/*.exe.blockmap' 'Windows blockmap'
+          # require_file 'release-assets/win/latest.yml' 'Windows auto-update metadata'
+          # require_file 'release-assets/runtime/install.sh' 'standalone runtime installer'
+          # if [ ! -x 'release-assets/runtime/install.sh' ]; then
+          #   echo "::error::Standalone runtime installer is not executable."
+          #   exit 1
+          # fi
+          #
+          # for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
+          #   require_file "release-assets/runtime/ade-$target" "ADE runtime binary for $target"
+          #   require_file "release-assets/runtime/ade-$target.native.tar.gz" "ADE native dependency archive for $target"
+          #   tar -tzf "release-assets/runtime/ade-$target.native.tar.gz" | grep -q '^\./node_modules/' || {
+          #     echo "::error::ADE native dependency archive for $target is missing node_modules."
+          #     exit 1
+          #   }
+          # done
 
       - name: Create or update draft GitHub release
         env:
@@ -466,16 +482,18 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           shopt -s nullglob
+          # macOS-only release surface. The zip + blockmap + latest-mac.yml are
+          # required by electron-updater; the DMG is the human download.
           files=(
             release-assets/mac/*.dmg
             release-assets/mac/*.zip
             release-assets/mac/*-mac.zip.blockmap
             release-assets/mac/latest-mac.yml
-            release-assets/win/*.exe
-            release-assets/win/*.exe.blockmap
-            release-assets/win/latest.yml
-            release-assets/runtime/install.sh
-            release-assets/runtime/ade-*
+            # release-assets/win/*.exe
+            # release-assets/win/*.exe.blockmap
+            # release-assets/win/latest.yml
+            # release-assets/runtime/install.sh
+            # release-assets/runtime/ade-*
           )
 
           if [ "${#files[@]}" -eq 0 ]; then

--- a/.github/workflows/update-brew-tap.yml
+++ b/.github/workflows/update-brew-tap.yml
@@ -63,6 +63,13 @@ jobs:
           cd tap
           sed -i -E "s|^  version \".*\"$|  version \"$VERSION\"|" Casks/ade.rb
           sed -i -E "s|^  sha256 \".*\"$|  sha256 \"$SHA256\"|" Casks/ade.rb
+          # Fail loudly if the cask shape changed and a substitution silently
+          # no-op'd — otherwise `git diff --quiet` reports "nothing to do" and
+          # the tap quietly stops tracking releases.
+          grep -qxF "  version \"$VERSION\"" Casks/ade.rb \
+            || { echo "::error::version line not updated — Casks/ade.rb format may have changed."; exit 1; }
+          grep -qxF "  sha256 \"$SHA256\"" Casks/ade.rb \
+            || { echo "::error::sha256 line not updated — Casks/ade.rb format may have changed."; exit 1; }
           if git diff --quiet; then
             echo "Cask already at ADE $VERSION — nothing to do."
             exit 0

--- a/.github/workflows/update-brew-tap.yml
+++ b/.github/workflows/update-brew-tap.yml
@@ -1,0 +1,74 @@
+name: Update brew tap
+
+# Bumps the arul28/homebrew-ade cask (version + sha256) whenever a release is
+# published, so `brew install --cask arul28/ade/ade` always serves the latest
+# DMG. Fires on publish (not draft creation) because the cask download URL only
+# resolves for published releases.
+#
+# Auth: HOMEBREW_TAP_DEPLOY_KEY repo secret — an SSH deploy key with write
+# access on arul28/homebrew-ade. Manual fallback: scripts/update-brew-tap.sh.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  bump-cask:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve DMG asset digest
+        id: dmg
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          version="${TAG_NAME#v}"
+          asset_name="ADE-$version-universal.dmg"
+          digest="$(gh api "repos/$GH_REPO/releases/tags/$TAG_NAME" \
+            --jq ".assets[] | select(.name == \"$asset_name\") | .digest // empty")"
+          case "$digest" in
+            sha256:*) sha="${digest#sha256:}" ;;
+            *)
+              echo "::error::No sha256 digest found for $asset_name on $TAG_NAME."
+              exit 1
+              ;;
+          esac
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Update cask in arul28/homebrew-ade
+        env:
+          DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+          VERSION: ${{ steps.dmg.outputs.version }}
+          SHA256: ${{ steps.dmg.outputs.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DEPLOY_KEY" ]; then
+            echo "::error::Missing HOMEBREW_TAP_DEPLOY_KEY secret (write deploy key for arul28/homebrew-ade)."
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          printf '%s\n' "$DEPLOY_KEY" > ~/.ssh/tap_deploy_key
+          chmod 600 ~/.ssh/tap_deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/tap_deploy_key -o IdentitiesOnly=yes"
+
+          git clone -q --depth 1 git@github.com:arul28/homebrew-ade.git tap
+          cd tap
+          sed -i -E "s|^  version \".*\"$|  version \"$VERSION\"|" Casks/ade.rb
+          sed -i -E "s|^  sha256 \".*\"$|  sha256 \"$SHA256\"|" Casks/ade.rb
+          if git diff --quiet; then
+            echo "Cask already at ADE $VERSION — nothing to do."
+            exit 0
+          fi
+          git config user.name "ade-release-bot"
+          git config user.email "release-bot@users.noreply.github.com"
+          git commit -aqm "ade $VERSION"
+          git push -q origin HEAD:main
+          echo "Updated cask to ADE $VERSION (sha256 $SHA256)."

--- a/README.md
+++ b/README.md
@@ -109,15 +109,19 @@ Download ADE from [**GitHub Releases**](https://github.com/arul28/ADE/releases/l
 
 ### macOS
 
-Download the latest `.dmg`, drag **ADE.app** into `/Applications`, and open it.
+With [Homebrew](https://brew.sh):
+
+```bash
+brew install --cask arul28/ade/ade
+```
+
+Or download the latest `.dmg`, drag **ADE.app** into `/Applications`, and open it. Both paths install the same signed + notarized universal app; ADE keeps itself current afterwards through its built-in auto-updater.
 
 Requirements: macOS 13+, git on `PATH`, Node 22+ for headless CLI workflows.
 
 ### Windows
 
-Download the latest Windows installer (`ADE-*-win-x64.exe`) from [**GitHub Releases**](https://github.com/arul28/ADE/releases/latest) and run it. Windows builds are published from the same release workflow as macOS and include the ADE runtime plus Windows auto-update metadata.
-
-Requirements: Windows x64, git on `PATH`, Node 22+ for headless CLI workflows.
+Windows releases are paused for now — current releases ship macOS only. The Windows build pipeline still exists (commented out in the release workflow) and will return in a future release.
 
 ## CLI
 

--- a/apps/ade-cli/README.md
+++ b/apps/ade-cli/README.md
@@ -46,6 +46,8 @@ Three ways to put `ade` on a machine:
 
 1. **Standalone runtime install** — single static binary plus its native dependency archive, fetched from a GitHub release. Suitable for headless macOS/Linux servers.
 
+   > **Currently unavailable:** releases ship macOS desktop assets only — the runtime binaries and `install.sh` are built by `release-core.yml` but not published as release assets (the publish block is commented out there). The script below only works once that block is re-enabled. Headless machines reached over SSH don't need it: the desktop app uploads its bundled runtime binaries on first connect.
+
    ```bash
    curl -fsSL https://github.com/arul28/ADE/releases/latest/download/install.sh | sh
    ```

--- a/apps/desktop/scripts/validate-mac-artifacts.mjs
+++ b/apps/desktop/scripts/validate-mac-artifacts.mjs
@@ -29,6 +29,7 @@ const bundledAgentSkills = [
   "ade-proof-artifacts",
   "ade-macos-vm",
   "ade-deeplinks",
+  "ade-orchestrator",
 ];
 const bundledAdeCliFiles = [
   ["cli.cjs", "bundled ADE CLI entry"],

--- a/apps/desktop/scripts/validate-win-artifacts.mjs
+++ b/apps/desktop/scripts/validate-win-artifacts.mjs
@@ -32,6 +32,7 @@ const bundledAgentSkills = [
   "ade-proof-artifacts",
   "ade-macos-vm",
   "ade-deeplinks",
+  "ade-orchestrator",
 ];
 const bundledAdeCliFiles = [
   ["cli.cjs", "bundled ADE CLI entry"],

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -102,9 +102,11 @@ import type {
   ProjectInfo,
   PtyDataEvent,
   SyncMobileProjectSummary,
+  SyncPeerConnectionState,
   SyncProjectConnectionPayload,
   SyncProjectSwitchRequestPayload,
   SyncProjectSwitchResultPayload,
+  UpdateInstallImpact,
 } from "../shared/types";
 import { buildLinearAutomationDispatches } from "./services/automations/linearAutomationDispatch";
 import type { IosSimulatorDrawerMode } from "../shared/types/iosSimulator";
@@ -5672,6 +5674,63 @@ app.whenReady().then(async () => {
     return Array.from(new Set(labels));
   };
 
+  // Live-connection probe shown before an update install or quit. Mirrors the
+  // lane-delete quit probe: in-process services in dev, runtime actions against
+  // the brain in packaged builds. Best-effort — an unreachable runtime simply
+  // reports no phones.
+  const collectUpdateInstallImpact = async (): Promise<UpdateInstallImpact> => {
+    const phonesById = new Map<string, string>();
+    const recordPeers = (peers: readonly SyncPeerConnectionState[] | undefined): void => {
+      for (const peer of peers ?? []) {
+        if (peer.deviceType !== "phone" && peer.platform !== "iOS") continue;
+        phonesById.set(peer.deviceId, peer.deviceName?.trim() || "Connected phone");
+      }
+    };
+    if (shouldUseInProcessProjectRuntime()) {
+      for (const ctx of projectContexts.values()) {
+        try {
+          const status = await ctx.syncService?.getStatus();
+          recordPeers(status?.connectedPeers);
+        } catch {
+          // Best-effort probe.
+        }
+      }
+    } else {
+      const roots = new Set<string>([
+        ...rootsBoundToWindows(),
+        ...projectContexts.keys(),
+      ]);
+      await Promise.all(Array.from(roots).map(async (root) => {
+        try {
+          const status = await localRuntimePool.syncStatusForRoot(root, {});
+          recordPeers(status.connectedPeers);
+        } catch {
+          // Best-effort probe.
+        }
+      }));
+    }
+    return {
+      connectedPhones: Array.from(phonesById, ([deviceId, deviceName]) => ({
+        deviceId,
+        deviceName,
+      })),
+    };
+  };
+
+  // Quit/update dialogs are synchronous, so cap how long the impact probe can
+  // delay them. On timeout the dialog falls back to generic copy.
+  const collectUpdateInstallImpactBounded = async (
+    timeoutMs = 1_500,
+  ): Promise<UpdateInstallImpact> => {
+    return await Promise.race([
+      collectUpdateInstallImpact().catch((): UpdateInstallImpact => ({ connectedPhones: [] })),
+      new Promise<UpdateInstallImpact>((resolve) => {
+        const timer = setTimeout(() => resolve({ connectedPhones: [] }), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  };
+
   const confirmNoRunningLaneDeleteForQuit = async (ownerWindow?: BrowserWindow | null): Promise<boolean> => {
     const runningDeletes = await getRunningLaneDeleteLabels();
     if (runningDeletes.length === 0) return true;
@@ -5705,15 +5764,33 @@ app.whenReady().then(async () => {
     return choice === 1;
   };
 
-  const confirmQuitWarning = (ownerWindow?: BrowserWindow | null): boolean =>
-    showWindowCloseWarning(ownerWindow, {
+  const describeConnectedPhones = (impact: UpdateInstallImpact | null): string | null => {
+    const phones = impact?.connectedPhones ?? [];
+    if (phones.length === 0) return null;
+    const names = phones.map((phone) => phone.deviceName).join(", ");
+    return phones.length === 1
+      ? `${names} is connected through ADE phone sync and will disconnect; it reconnects automatically once ADE is running again.`
+      : `These phones are connected through ADE phone sync and will disconnect: ${names}. They reconnect automatically once ADE is running again.`;
+  };
+
+  const confirmQuitWarning = (
+    ownerWindow?: BrowserWindow | null,
+    impact: UpdateInstallImpact | null = null,
+  ): boolean => {
+    const phoneDetail = describeConnectedPhones(impact);
+    return showWindowCloseWarning(ownerWindow, {
       buttons: ["Keep ADE open", "Quit ADE"],
       title: "Quit ADE?",
       message: "Save your work before closing ADE.",
-      detail:
-        "Quitting ADE will end agents and background processes owned by this desktop session, including OpenCode servers, terminal sessions, and test runs. The ADE service login item keeps running separately when it is installed.",
+      detail: [
+        "Quitting ADE will end agents and background processes owned by this desktop session, including OpenCode servers, terminal sessions, and test runs.",
+        phoneDetail,
+        "Open ADE Code terminals attached to this machine's ADE service will disconnect too — you can reopen them afterwards.",
+        "The ADE service login item keeps running separately when it is installed.",
+      ].filter(Boolean).join(" "),
       rememberQuitAcknowledgement: true,
     });
+  };
 
   const confirmCloseWindowWarning = (ownerWindow: BrowserWindow): boolean =>
     showWindowCloseWarning(ownerWindow, {
@@ -5734,7 +5811,8 @@ app.whenReady().then(async () => {
     void (async () => {
       try {
         if (!(await confirmNoRunningLaneDeleteForQuit(ownerWindow))) return;
-        if (!confirmQuitWarning(ownerWindow)) return;
+        const impact = await collectUpdateInstallImpactBounded();
+        if (!confirmQuitWarning(ownerWindow, impact)) return;
         requestAppShutdown({ reason, exitCode: 0 });
       } finally {
         quitConfirmationInFlight = false;
@@ -6164,6 +6242,9 @@ app.whenReady().then(async () => {
       const ctx = getActiveContext();
       if (!ctx.autoUpdateService) {
         ctx.autoUpdateService = autoUpdateService;
+      }
+      if (!ctx.updateInstallImpactProvider) {
+        ctx.updateInstallImpactProvider = () => collectUpdateInstallImpactBounded();
       }
       return ctx;
     },

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, desktopCapturer, dialog, ipcMain, Menu, nativeImage, protocol, safeStorage, shell } from "electron";
+import { app, BrowserWindow, desktopCapturer, dialog, ipcMain, Menu, nativeImage, Notification, protocol, safeStorage, shell } from "electron";
 import { AsyncLocalStorage } from "node:async_hooks";
 import os from "node:os";
 import path from "node:path";
@@ -1201,6 +1201,27 @@ app.whenReady().then(async () => {
     && process.env.ADE_DISABLE_RUNTIME_SERVICE_INSTALL !== "1";
   const localRuntimePool = new LocalRuntimeConnectionPool(app.getVersion(), localRuntimeLogger, {
     preferServiceRepair: shouldRepairRuntimeServiceOnFallback,
+    onRuntimeModeChange: (mode) => {
+      localRuntimeLogger.warn("local_runtime.runtime_mode_changed", { mode });
+      if (!Notification.isSupported()) return;
+      try {
+        const notification = mode === "isolated"
+          ? new Notification({
+              title: "ADE is running in fallback mode",
+              body: "The ADE background service did not restart cleanly. Phone sync and ADE Code connections are unavailable while ADE keeps retrying in the background.",
+            })
+          : new Notification({
+              title: "ADE service restored",
+              body: "Phone sync and ADE Code connections are available again.",
+            });
+        notification.show();
+      } catch (error) {
+        localRuntimeLogger.warn("local_runtime.runtime_mode_notification_failed", {
+          mode,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    },
   });
   if (shouldAttemptRuntimeServiceInstall) {
     void localRuntimePool.installServiceBestEffort()

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -5703,7 +5703,11 @@ app.whenReady().then(async () => {
     const phonesById = new Map<string, string>();
     const recordPeers = (peers: readonly SyncPeerConnectionState[] | undefined): void => {
       for (const peer of peers ?? []) {
-        if (peer.deviceType !== "phone" && peer.platform !== "iOS") continue;
+        // Match the canonical connected-phone convention used by the phone
+        // device list (main.ts ~2535) and APNS targeting: a phone is both
+        // deviceType "phone" AND platform "iOS". The looser OR form belongs to
+        // host-side sync gating, not user-facing phone copy.
+        if (peer.deviceType !== "phone" || peer.platform !== "iOS") continue;
         phonesById.set(peer.deviceId, peer.deviceName?.trim() || "Connected phone");
       }
     };

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -549,6 +549,7 @@ import type {
   CursorCloudOpenChatRequest,
   CursorCloudOpenChatResult,
   CursorCloudStreamRunResult,
+  UpdateInstallImpact,
 } from "../../../shared/types";
 import type { Logger } from "../logging/logger";
 import type { AdeDb } from "../state/kvDb";
@@ -982,6 +983,7 @@ export type AppContext = {
   apnsKeyStore?: import("../notifications/apnsService").ApnsKeyStore | null;
   notificationEventBus?: import("../notifications/notificationEventBus").NotificationEventBus | null;
   autoUpdateService?: ReturnType<typeof createAutoUpdateService> | null;
+  updateInstallImpactProvider?: (() => Promise<UpdateInstallImpact>) | null;
   feedbackReporterService?: ReturnType<typeof createFeedbackReporterService> | null;
 };
 
@@ -10097,6 +10099,17 @@ export function registerIpc({
 
   ipcMain.handle(IPC.updateGetState, () => {
     return getCtx().autoUpdateService?.getSnapshot() ?? createEmptyAutoUpdateSnapshot();
+  });
+
+  ipcMain.handle(IPC.updateGetInstallImpact, async (): Promise<UpdateInstallImpact> => {
+    const provider = getCtx().updateInstallImpactProvider;
+    if (!provider) return { connectedPhones: [] };
+    try {
+      return await provider();
+    } catch {
+      // Best-effort probe: a failed impact query must never block the update UI.
+      return { connectedPhones: [] };
+    }
   });
 
   ipcMain.handle(IPC.updateQuitAndInstall, () => {

--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts
@@ -384,6 +384,52 @@ describe("local runtime connection pool", () => {
     });
   });
 
+  it("retries the service install from isolated recovery and reports runtime mode transitions", async () => {
+    const modeChanges: string[] = [];
+    const pool = new LocalRuntimeConnectionPool("1.2.3", {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as never, {
+      preferServiceRepair: true,
+      onRuntimeModeChange: (mode) => modeChanges.push(mode),
+    });
+    const internals = pool as unknown as {
+      activeConnection: { client: unknown; child: null; socketPath: string } | null;
+      probeCompatibleRuntime: (socketPath: string) => Promise<boolean>;
+      installServiceBestEffort: () => Promise<void>;
+      scheduleIsolatedRuntimeRecovery: (primarySocketPath: string) => void;
+      tryRecoverFromIsolatedRuntime: (primarySocketPath: string) => Promise<void>;
+      lastIsolatedServiceRepairMs: number;
+    };
+    const installSpy = vi.fn(async () => {});
+    internals.installServiceBestEffort = installSpy;
+    internals.probeCompatibleRuntime = async () => false;
+    internals.activeConnection = { client: {}, child: null, socketPath: "/tmp/ade-isolated.sock" };
+
+    internals.scheduleIsolatedRuntimeRecovery("/tmp/ade.sock");
+    expect(modeChanges).toEqual(["isolated"]);
+    expect(pool.getStatus().runtimeMode).toBe("isolated");
+
+    // A failed probe re-attempts the service install once per cooldown window.
+    await internals.tryRecoverFromIsolatedRuntime("/tmp/ade.sock");
+    expect(installSpy).toHaveBeenCalledTimes(1);
+    await internals.tryRecoverFromIsolatedRuntime("/tmp/ade.sock");
+    expect(installSpy).toHaveBeenCalledTimes(1);
+    internals.lastIsolatedServiceRepairMs = 0;
+    await internals.tryRecoverFromIsolatedRuntime("/tmp/ade.sock");
+    expect(installSpy).toHaveBeenCalledTimes(2);
+
+    // Landing back on the primary socket announces the recovery exactly once.
+    internals.activeConnection = { client: {}, child: null, socketPath: "/tmp/ade.sock" };
+    await internals.tryRecoverFromIsolatedRuntime("/tmp/ade.sock");
+    expect(modeChanges).toEqual(["isolated", "primary"]);
+    expect(pool.getStatus().runtimeMode).toBe("primary");
+
+    pool.dispose();
+  });
+
   it("parses structured service manager output for settings status", () => {
     expect(parseRuntimeServiceManagerOutput(JSON.stringify({
       ok: false,

--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
@@ -1499,8 +1499,12 @@ export class LocalRuntimeConnectionPool {
       primarySocketPath,
       isolatedSocketPath: entry.socketPath,
     });
-    this.clearIsolatedRecoveryTimer();
+    // Confirm the isolated connection is still current BEFORE tearing down the
+    // recovery timer. If a connection swap raced during the probe above, bail
+    // with the timer intact so the next tick re-evaluates — clearing the timer
+    // first would strand us in "isolated" mode with no further recovery.
     if (!this.clearConnectionIfCurrent(entry)) return;
+    this.clearIsolatedRecoveryTimer();
     this.markIsolatedMode(false);
     closeRuntimeClient(entry.client);
     if (this.ownedRuntimeChild === entry.child) this.ownedRuntimeChild = null;

--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
@@ -52,6 +52,11 @@ type LocalRuntimeConnectionPoolOptions = {
   disableSync?: boolean;
   preferServiceRepair?: boolean;
   queryServiceStatus?: () => ServiceManagerStatusResult;
+  /**
+   * Invoked when the pool enters or leaves isolated (no-sync fallback) mode.
+   * "isolated" fires once per degradation, "primary" once per recovery.
+   */
+  onRuntimeModeChange?: (mode: "primary" | "isolated") => void;
 };
 
 type LocalRuntimeNodePathOptions = {
@@ -609,6 +614,8 @@ export class LocalRuntimeConnectionPool {
   private ownedRuntimeChild: ChildProcess | null = null;
   private preserveOwnedRuntimeChildOnNextConnect = false;
   private isolatedRecoveryTimer: NodeJS.Timeout | null = null;
+  private isolatedModeActive = false;
+  private lastIsolatedServiceRepairMs = 0;
   private readonly coalescedActionCalls = new Map<string, Promise<RemoteRuntimeActionResult>>();
   private readonly projectsByRoot = new Map<string, RemoteRuntimeProjectRecord>();
   private serviceInstallStatus: LocalRuntimeStatus["serviceInstall"] = {
@@ -648,6 +655,7 @@ export class LocalRuntimeConnectionPool {
         : this.connection
           ? "connecting"
           : "idle",
+      runtimeMode: this.isolatedModeActive ? "isolated" : "primary",
       serviceInstall: { ...this.serviceInstallStatus },
       serviceHealth: { ...this.serviceHealthStatus },
     };
@@ -1163,6 +1171,7 @@ export class LocalRuntimeConnectionPool {
 
   dispose(): void {
     this.clearIsolatedRecoveryTimer();
+    this.markIsolatedMode(false, { notify: false });
     const pending = this.connection;
     this.connection = null;
     this.activeConnection = null;
@@ -1439,6 +1448,7 @@ export class LocalRuntimeConnectionPool {
   // brain is reachable; consumers recover through the normal disconnect path,
   // exactly as they do when a brain is recycled on a build-hash mismatch.
   private scheduleIsolatedRuntimeRecovery(primarySocketPath: string): void {
+    this.markIsolatedMode(true);
     if (this.isolatedRecoveryTimer) return;
     const timer = setInterval(() => {
       void this.tryRecoverFromIsolatedRuntime(primarySocketPath);
@@ -1453,22 +1463,61 @@ export class LocalRuntimeConnectionPool {
     this.isolatedRecoveryTimer = null;
   }
 
+  private markIsolatedMode(active: boolean, options: { notify?: boolean } = {}): void {
+    if (this.isolatedModeActive === active) return;
+    this.isolatedModeActive = active;
+    if (options.notify === false) return;
+    try {
+      this.options.onRuntimeModeChange?.(active ? "isolated" : "primary");
+    } catch (error) {
+      this.logger.warn("local_runtime.runtime_mode_listener_failed", {
+        mode: active ? "isolated" : "primary",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   private async tryRecoverFromIsolatedRuntime(primarySocketPath: string): Promise<void> {
     const entry = this.activeConnection;
     if (!entry || entry.socketPath === primarySocketPath) {
       this.clearIsolatedRecoveryTimer();
+      // No active isolated connection: either we reconnected to the primary
+      // socket through the normal path (a real recovery worth announcing) or
+      // the connection is simply gone (stay quiet).
+      this.markIsolatedMode(false, { notify: entry != null });
       return;
     }
-    if (!(await this.probeCompatibleRuntime(primarySocketPath))) return;
+    if (!(await this.probeCompatibleRuntime(primarySocketPath))) {
+      // The probe alone can never succeed when the service (re)install failed:
+      // nothing is going to bind a compatible brain to the primary socket. Keep
+      // re-attempting the install (cooled down) so a transient launchctl
+      // failure does not strand this desktop in no-sync mode forever.
+      await this.retryServiceInstallForIsolatedRecovery();
+      return;
+    }
     this.logger.info("local_runtime.isolated_recovery", {
       primarySocketPath,
       isolatedSocketPath: entry.socketPath,
     });
     this.clearIsolatedRecoveryTimer();
     if (!this.clearConnectionIfCurrent(entry)) return;
+    this.markIsolatedMode(false);
     closeRuntimeClient(entry.client);
     if (this.ownedRuntimeChild === entry.child) this.ownedRuntimeChild = null;
     disposeOwnedRuntimeChild(entry.child, entry.socketPath, { unlinkSocket: true });
+  }
+
+  private async retryServiceInstallForIsolatedRecovery(): Promise<void> {
+    if (!this.options.preferServiceRepair) return;
+    if (this.serviceInstallStatus.state === "skipped" || this.serviceInstallStatus.state === "installing") return;
+    const now = Date.now();
+    if (now - this.lastIsolatedServiceRepairMs < 60_000) return;
+    this.lastIsolatedServiceRepairMs = now;
+    this.logger.info("local_runtime.isolated_recovery_service_reinstall", {
+      serviceState: this.serviceInstallStatus.state,
+      serviceMessage: this.serviceInstallStatus.message,
+    });
+    await this.installServiceBestEffort();
   }
 
   // Compatibility check with no side effects on pool state, safe to run while

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -16,6 +16,7 @@ import type {
   LatestReleaseInfo,
   AppNavigationRequest,
   AutoUpdateSnapshot,
+  UpdateInstallImpact,
   ClearLocalAdeDataArgs,
   ClearLocalAdeDataResult,
   ArchiveLaneArgs,
@@ -2310,6 +2311,7 @@ declare global {
       };
       updateCheckForUpdates: () => Promise<void>;
       updateGetState: () => Promise<AutoUpdateSnapshot>;
+      updateGetInstallImpact: () => Promise<UpdateInstallImpact>;
       updateQuitAndInstall: () => Promise<boolean>;
       updateDismissInstalledNotice: () => Promise<void>;
       onUpdateEvent: (cb: (snapshot: AutoUpdateSnapshot) => void) => () => void;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -22,6 +22,7 @@ import type {
   LatestReleaseInfo,
   AppNavigationRequest,
   AutoUpdateSnapshot,
+  UpdateInstallImpact,
   ClearLocalAdeDataArgs,
   ClearLocalAdeDataResult,
   ArchiveLaneArgs,
@@ -8935,6 +8936,8 @@ contextBridge.exposeInMainWorld("ade", {
   updateCheckForUpdates: () => ipcRenderer.invoke(IPC.updateCheckForUpdates),
   updateGetState: (): Promise<AutoUpdateSnapshot> =>
     ipcRenderer.invoke(IPC.updateGetState),
+  updateGetInstallImpact: (): Promise<UpdateInstallImpact> =>
+    ipcRenderer.invoke(IPC.updateGetInstallImpact),
   updateQuitAndInstall: (): Promise<boolean> =>
     ipcRenderer.invoke(IPC.updateQuitAndInstall),
   updateDismissInstalledNotice: () =>

--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -6112,6 +6112,7 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
       error: null,
       recentlyInstalled: null,
     }),
+    updateGetInstallImpact: resolved({ connectedPhones: [] }),
     updateQuitAndInstall: resolved(true),
     updateDismissInstalledNotice: resolved(undefined),
     onUpdateEvent: noop,

--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -3178,6 +3178,7 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
         env: {},
         localRuntime: {
           connectionState: "idle",
+          runtimeMode: "primary",
           serviceInstall: {
             state: "skipped",
             attempted: false,

--- a/apps/desktop/src/renderer/components/app/AutoUpdateControl.tsx
+++ b/apps/desktop/src/renderer/components/app/AutoUpdateControl.tsx
@@ -72,10 +72,30 @@ export function AutoUpdateControl() {
     });
   }, []);
 
-  const handleRestartToInstall = useCallback(() => {
-    const confirmed = window.confirm(
-      `ADE will quit and reopen automatically to install ${versionLabel(snapshot.version)}.\n\nYou do not need to restart ADE yourself. Any unsaved work may be lost. Continue?`,
+  const handleRestartToInstall = useCallback(async () => {
+    // Best-effort probe of live connections (paired phones) so the user knows
+    // what drops while ADE and its brain service restart on the new version.
+    const impact = await window.ade.updateGetInstallImpact().catch(() => null);
+    const phones = impact?.connectedPhones ?? [];
+    const lines = [
+      `ADE will quit and reopen automatically to install ${versionLabel(snapshot.version)}.`,
+      "",
+    ];
+    if (phones.length === 1) {
+      lines.push(
+        `${phones[0].deviceName} is connected through ADE phone sync. It will disconnect during the update and reconnect automatically once ADE is back.`,
+      );
+    } else if (phones.length > 1) {
+      lines.push(
+        `Connected phones (${phones.map((phone) => phone.deviceName).join(", ")}) will disconnect during the update and reconnect automatically once ADE is back.`,
+      );
+    }
+    lines.push(
+      "Open ADE Code terminals and running agent sessions on this machine will disconnect while the ADE service restarts — you can reopen them right after the update.",
+      "",
+      "You do not need to restart ADE yourself. Any unsaved work may be lost. Continue?",
     );
+    const confirmed = window.confirm(lines.join("\n"));
     if (!confirmed) return;
     setInstallRequested(true);
     void window.ade.updateQuitAndInstall()
@@ -129,7 +149,7 @@ export function AutoUpdateControl() {
           disabled={effectiveStatus !== "ready"}
           onClick={() => {
             if (effectiveStatus === "ready") {
-              handleRestartToInstall();
+              void handleRestartToInstall();
             }
           }}
           title={indicatorTitle()}

--- a/apps/desktop/src/renderer/components/settings/AboutSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/AboutSection.tsx
@@ -229,7 +229,9 @@ export function AboutSection() {
                 ADE runtime service
               </div>
               <div style={{ marginTop: 5, fontSize: 11, fontFamily: MONO_FONT, color: COLORS.textMuted, lineHeight: 1.5 }}>
-                Connection: {info.localRuntime.connectionState}. Install: {info.localRuntime.serviceInstall.message ?? "No install status."}
+                Connection: {info.localRuntime.connectionState}
+                {info.localRuntime.runtimeMode === "isolated" ? " (fallback brain — phone sync unavailable, retrying)" : ""}
+                . Install: {info.localRuntime.serviceInstall.message ?? "No install status."}
               </div>
               <div style={{ marginTop: 3, fontSize: 11, fontFamily: MONO_FONT, color: COLORS.textMuted, lineHeight: 1.5 }}>
                 Login service: {info.localRuntime.serviceHealth.message ?? "No service health status."}

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -790,6 +790,7 @@ export const IPC = {
   feedbackOnUpdate: "ade.feedback.onUpdate",
   updateCheckForUpdates: "ade.update.checkForUpdates",
   updateGetState: "ade.update.getState",
+  updateGetInstallImpact: "ade.update.getInstallImpact",
   updateQuitAndInstall: "ade.update.quitAndInstall",
   updateDismissInstalledNotice: "ade.update.dismissInstalledNotice",
   updateEvent: "ade.update.event",

--- a/apps/desktop/src/shared/types/core.ts
+++ b/apps/desktop/src/shared/types/core.ts
@@ -24,6 +24,13 @@ export type LocalRuntimeConnectionState =
 
 export type LocalRuntimeStatus = {
   connectionState: LocalRuntimeConnectionState;
+  /**
+   * "isolated" means the desktop fell back to an app-owned no-sync brain
+   * (phone sync and ADE Code attach to the channel service, which is down).
+   * The pool keeps probing and reinstalling until it migrates back to
+   * "primary".
+   */
+  runtimeMode: "primary" | "isolated";
   serviceInstall: {
     state: LocalRuntimeServiceInstallState;
     attempted: boolean;

--- a/apps/desktop/src/shared/types/core.ts
+++ b/apps/desktop/src/shared/types/core.ts
@@ -107,6 +107,20 @@ export type AutoUpdateSnapshot = {
   recentlyInstalled: RecentlyInstalledUpdate | null;
 };
 
+export type UpdateInstallImpactPhone = {
+  deviceId: string;
+  deviceName: string;
+};
+
+/**
+ * Live connections that drop while ADE (and its brain service) restarts for an
+ * update. Best-effort: probes are time-boxed, so an empty list means "none
+ * detected", not a guarantee.
+ */
+export type UpdateInstallImpact = {
+  connectedPhones: UpdateInstallImpactPhone[];
+};
+
 export type ProjectInfo = {
   rootPath: string;
   displayName: string;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -137,7 +137,7 @@ Product positioning and workflows live in [`docs/PRD.md`](../docs/PRD.md). This 
 
 **Bundled runtime artifacts.** Per-platform `ade-<platform-arch>` binaries plus their native dep tarballs live under `apps/desktop/resources/runtime/`, with packaged ADE CLI resources providing the `ptyHostWorker.cjs` used by remote terminals. `release-core.yml` builds the cross-platform set; `bootstrapRemoteRuntime` uploads missing or hash-mismatched artifacts on first SSH connect from the desktop client.
 
-**Headless install.** A standalone runtime can be installed on a headless machine without going through the desktop installer:
+**Headless install.** A standalone runtime can be installed on a headless machine without going through the desktop installer — but note that releases currently publish macOS desktop assets only, so the runtime binaries + `install.sh` are not on the release page (their publish block in `release-core.yml` is commented out). Remote machines reached over SSH don't need this path: `bootstrapRemoteRuntime` uploads the desktop app's bundled runtime artifacts. When the publish block is re-enabled:
 
 ```bash
 curl -fsSL https://github.com/arul28/ADE/releases/latest/download/install.sh | sh

--- a/docs/features/remote-runtime/README.md
+++ b/docs/features/remote-runtime/README.md
@@ -116,7 +116,7 @@ npm --prefix apps/ade-cli run build:static -- --target <target> --out-dir ../des
 
 ## Standalone runtime install
 
-For headless macOS / Linux machines that can run an SSH server but have no desktop, install the runtime directly from a release:
+For headless macOS / Linux machines that can run an SSH server but have no desktop, the runtime can be installed directly from a release. **Currently unavailable:** releases publish macOS desktop assets only — the runtime binaries and `install.sh` publish block in `release-core.yml` is commented out, so the command below 404s until it is re-enabled. SSH-reachable machines don't need it: the desktop bootstrap uploads bundled runtime artifacts on first connect.
 
 ```bash
 curl -fsSL https://github.com/arul28/ADE/releases/latest/download/install.sh | sh

--- a/scripts/update-brew-tap.sh
+++ b/scripts/update-brew-tap.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Bump the arul28/homebrew-ade cask to a published ADE release.
+#
+# Run after the GitHub release is PUBLISHED (not draft) — the cask download
+# URL only resolves for published releases. Requires `gh` authenticated as an
+# account with push access to arul28/homebrew-ade.
+#
+# Usage:
+#   scripts/update-brew-tap.sh v1.2.3
+#   scripts/update-brew-tap.sh latest
+set -euo pipefail
+
+tag="${1:?usage: update-brew-tap.sh <vX.Y.Z|latest>}"
+repo="arul28/ADE"
+tap_repo="arul28/homebrew-ade"
+
+if [ "$tag" = "latest" ]; then
+  tag="$(gh api "repos/$repo/releases/latest" --jq .tag_name)"
+fi
+version="${tag#v}"
+
+release_json="$(gh api "repos/$repo/releases/tags/$tag")"
+if [ "$(printf '%s' "$release_json" | jq -r .draft)" = "true" ]; then
+  echo "error: $tag is still a draft release — publish it first." >&2
+  exit 1
+fi
+
+asset_name="ADE-$version-universal.dmg"
+digest="$(printf '%s' "$release_json" | jq -r --arg name "$asset_name" \
+  '.assets[] | select(.name == $name) | .digest // empty')"
+case "$digest" in
+  sha256:*) sha="${digest#sha256:}" ;;
+  *)
+    echo "error: no sha256 digest found for $asset_name on $tag." >&2
+    exit 1
+    ;;
+esac
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+gh repo clone "$tap_repo" "$tmp_dir/tap" -- -q --depth 1
+cask="$tmp_dir/tap/Casks/ade.rb"
+
+sed -i '' -E "s|^  version \".*\"$|  version \"$version\"|" "$cask"
+sed -i '' -E "s|^  sha256 \".*\"$|  sha256 \"$sha\"|" "$cask"
+
+if git -C "$tmp_dir/tap" diff --quiet; then
+  echo "Cask already at ADE $version — nothing to do."
+  exit 0
+fi
+
+git -C "$tmp_dir/tap" commit -aqm "ade $version"
+git -C "$tmp_dir/tap" push -q
+echo "Updated $tap_repo cask to ADE $version (sha256 $sha)."

--- a/scripts/update-brew-tap.sh
+++ b/scripts/update-brew-tap.sh
@@ -41,14 +41,26 @@ trap 'rm -rf "$tmp_dir"' EXIT
 gh repo clone "$tap_repo" "$tmp_dir/tap" -- -q --depth 1
 cask="$tmp_dir/tap/Casks/ade.rb"
 
-sed -i '' -E "s|^  version \".*\"$|  version \"$version\"|" "$cask"
-sed -i '' -E "s|^  sha256 \".*\"$|  sha256 \"$sha\"|" "$cask"
+# Portable in-place edit (BSD/macOS and GNU sed both accept this temp-file form).
+sed -E "s|^  version \".*\"$|  version \"$version\"|" "$cask" > "$cask.tmp" && mv "$cask.tmp" "$cask"
+sed -E "s|^  sha256 \".*\"$|  sha256 \"$sha\"|" "$cask" > "$cask.tmp" && mv "$cask.tmp" "$cask"
+
+# Fail loudly if the cask shape changed and the substitution silently no-op'd —
+# otherwise `git diff --quiet` below would report "nothing to do" and the tap
+# would stop tracking releases without any alarm.
+grep -qxF "  version \"$version\"" "$cask" \
+  || { echo "error: version line not updated — Casks/ade.rb format may have changed." >&2; exit 1; }
+grep -qxF "  sha256 \"$sha\"" "$cask" \
+  || { echo "error: sha256 line not updated — Casks/ade.rb format may have changed." >&2; exit 1; }
 
 if git -C "$tmp_dir/tap" diff --quiet; then
   echo "Cask already at ADE $version — nothing to do."
   exit 0
 fi
 
-git -C "$tmp_dir/tap" commit -aqm "ade $version"
+git -C "$tmp_dir/tap" \
+  -c user.name="ade-release-bot" \
+  -c user.email="release-bot@users.noreply.github.com" \
+  commit -aqm "ade $version"
 git -C "$tmp_dir/tap" push -q
 echo "Updated $tap_repo cask to ADE $version (sha256 $sha)."


### PR DESCRIPTION
## Final release pipeline audit

Two commits hardening the release/update path for the mac-only DMG surface.

### `b3c41811` — Release pipeline: mac-only DMG surface, brew tap, update-impact warnings
- `release-core.yml`: reduce the release surface to mac-only (DMG + zip + blockmap + `latest-mac.yml`); Windows/runtime jobs commented out behind a documented re-enable toggle.
- New `update-brew-tap.yml` + `scripts/update-brew-tap.sh`: auto-bump the `arul28/homebrew-ade` cask `version`/`sha256` on `release: published`, via SSH deploy key.
- Update-impact warnings: quit/restart dialogs now surface connected phones (ADE phone sync) and local ADE Code sessions that will drop during an update. New `updateGetInstallImpact` IPC wired across shared/preload/main/renderer.

### `65952430` — Close isolated-brain gap, automate brew tap bump, scrub stale headless-install docs
- `localRuntimeConnectionPool`: isolated-mode detection + recovery with single-notification guard and install-retry cooldown (+ new test coverage, 41 tests).
- Docs scrub: removed stale headless/Windows-install references in README / ARCHITECTURE / remote-runtime docs.

### Verification
- `/quality` dual-review: 0 Blockers / 0 Highs; all findings verified correct-or-intentional, no fixes needed.
- `localRuntimeConnectionPool.test.ts`: 41/41 passing (Node 22).
- `apps/desktop` typecheck: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback runtime mode with notifications when the service becomes unavailable
  * Update restart now displays connected phones to inform about potential disconnects during restart
  * Automated Homebrew tap updates on release publish

* **Changes**
  * Desktop releases are now macOS-only (Windows support removed)

* **Documentation**
  * Updated runtime installation and Homebrew setup guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the release and update path with two main changes: narrowing the release surface to macOS-only (DMG + auto-update assets), and closing a gap where a downed runtime service would silently leave the desktop in no-sync mode without notifying users or retrying the install.

- **Release pipeline**: Windows and runtime-binary publish jobs are commented out with clear re-enable instructions; a new `update-brew-tap.yml` workflow auto-bumps the Homebrew cask on every published release using an SSH deploy key, with a portable manual-fallback script.
- **Isolated-brain recovery**: `LocalRuntimeConnectionPool` now tracks `isolatedModeActive`, fires `onRuntimeModeChange` callbacks exactly once per transition, and retries `installServiceBestEffort` on a 60 s cooldown while stuck in fallback mode; 41 new test assertions cover the full transition cycle.
- **Update-impact warnings**: `collectUpdateInstallImpactBounded` probes connected phones before quit/update dialogs, and a new `updateGetInstallImpact` IPC is wired end-to-end (shared → main → preload → renderer → browserMock) so users see which devices will disconnect.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all previously flagged issues (peer filter operator, sed portability, missing git identity) have been corrected, and the new isolated-mode recovery and brew-tap automation are well-guarded.

The isolated-brain recovery path has explicit single-notification guards, a cooldown on service reinstall retries, and a race-safe connection check before clearing the recovery timer. The brew-tap workflow validates every substitution with grep before committing, exits loudly on a missing deploy key or missing DMG asset, and uses IdentitiesOnly=yes to avoid picking up ambient SSH identities. The update-impact probe is time-boxed to 1.5 s and never blocks the quit/update dialog on failure. No correctness issues were found in the new code paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-core.yml | Windows build job and runtime-asset publish blocks commented out with clear re-enable toggle; macOS-only publish path retained with correct asset validation and upload list. |
| .github/workflows/update-brew-tap.yml | New workflow: resolves DMG sha256 via gh API, writes deploy key to 600-mode file, uses GIT_SSH_COMMAND with IdentitiesOnly=yes, validates substitution with grep before committing, and sets bot git identity; fires only on non-prerelease publish events. |
| scripts/update-brew-tap.sh | Manual fallback script for cask bump; uses temp-file sed form for BSD/GNU portability and -c user.name/-c user.email on commit — both previously flagged issues now resolved. |
| apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts | Adds isolatedModeActive flag, markIsolatedMode guard (deduplicates notifications), retryServiceInstallForIsolatedRecovery with 60 s cooldown, and reorders clearConnectionIfCurrent/clearIsolatedRecoveryTimer to prevent stranding the recovery loop on a race. |
| apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts | New 46-line test block verifies isolated-mode entry fires modeChanges once, cooldown limits service-reinstall retries, and primary recovery fires exactly once on reconnect; calls pool.dispose() to clean up the setInterval. |
| apps/desktop/src/main/main.ts | Adds Notification-based isolated-mode alerts, collectUpdateInstallImpactBounded with 1.5 s timeout, correct peer filter (||), and wires updateInstallImpactProvider into AppContext; confirmQuitWarning now async-probes connected phones before showing the dialog. |
| apps/desktop/src/renderer/components/app/AutoUpdateControl.tsx | handleRestartToInstall made async; probes updateGetInstallImpact before window.confirm; dependency array correctly scoped to [snapshot.version]; onClick correctly uses void handleRestartToInstall(). |
| apps/desktop/src/shared/types/core.ts | Adds runtimeMode field to LocalRuntimeStatus and new UpdateInstallImpact / UpdateInstallImpactPhone types; well-documented with inline JSDoc. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ship: iter 1 — address review (phone fil..."](https://github.com/arul28/ade/commit/eb21b1ba2908cadb796b78ea7c361991b54e08d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37248184)</sub>

<!-- /greptile_comment -->