### PR TITLE
Cursor Pty Brain Flaps

### DIFF
--- a/apps/ade-cli/src/adeRpcServer.test.ts
+++ b/apps/ade-cli/src/adeRpcServer.test.ts
@@ -2155,7 +2155,7 @@ describe("adeRpcServer", () => {
     expect(fixture.runtime.ptyService.writeBySessionId).not.toHaveBeenCalled();
   });
 
-  it("passes Cursor initial input as the documented prompt argument", async () => {
+  it("submits Cursor initial input after the interactive CLI is ready", async () => {
     const fixture = createRuntime();
     const handler = createAdeRpcRequestHandler({ runtime: fixture.runtime, serverVersion: "test" });
 
@@ -2169,13 +2169,15 @@ describe("adeRpcServer", () => {
     expect(response?.isError).toBeUndefined();
     const createCall = fixture.runtime.ptyService.create.mock.calls.at(-1)?.[0];
     expect(createCall?.command).toBe("cursor-agent");
-    expect(createCall?.args?.at(-1)).toContain("fix failing tests");
+    expect(createCall?.args).toEqual(expect.arrayContaining(["--model", "auto"]));
+    expect(createCall?.args).not.toContain(expect.stringContaining("fix failing tests"));
     expect(createCall?.startupCommand).toContain("cursor-agent");
-    expect(createCall?.startupCommand).toContain("fix failing tests");
+    expect(createCall?.startupCommand).not.toContain("fix failing tests");
     expect(createCall?.startupCommand).not.toContain("create-chat");
     expect(createCall?.startupCommand).not.toContain("--resume");
-    expect(createCall?.initialInput).toBeUndefined();
-    expect(createCall?.initialInputDelayMs).toBeUndefined();
+    expect(createCall?.initialInput).toContain("ADE session guidance");
+    expect(createCall?.initialInput).toContain("fix failing tests");
+    expect(createCall?.initialInputDelayMs).toBe(750);
     expect(fixture.runtime.ptyService.writeBySessionId).not.toHaveBeenCalled();
     expect(fixture.runtime.ptyService.dispose).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
@@ -2453,7 +2453,7 @@ describe("createSyncRemoteCommandService", () => {
       }))).rejects.toThrow("work.sendToSession requires text.");
     });
 
-    it("work.startCliSession passes Cursor initial input as the documented prompt argument", async () => {
+    it("work.startCliSession submits Cursor initial input after the interactive CLI is ready", async () => {
       await service.execute(makePayload("work.startCliSession", {
         laneId: "lane-1",
         provider: "cursor",
@@ -2462,14 +2462,16 @@ describe("createSyncRemoteCommandService", () => {
 
       const call = ptyService.create.mock.calls.at(-1)?.[0];
       expect(call?.startupCommand).toContain("cursor-agent");
-      expect(call?.startupCommand).toContain("fix the tests");
+      expect(call?.startupCommand).not.toContain("fix the tests");
       expect(call?.startupCommand).not.toContain("cursor-agent create-chat");
       expect(call?.startupCommand).not.toContain("--resume");
-      expect(call?.initialInput).toBeUndefined();
-      expect(call?.initialInputDelayMs).toBeUndefined();
+      expect(call?.initialInput).toContain("ADE session guidance");
+      expect(call?.initialInput).toContain("fix the tests");
+      expect(call?.initialInputDelayMs).toBe(750);
       expect(call).not.toHaveProperty("awaitInitialInput");
       expect(call?.command).toBe("cursor-agent");
-      expect(call?.args?.at(-1)).toContain("fix the tests");
+      expect(call?.args).toEqual(expect.arrayContaining(["--model", "auto"]));
+      expect(call?.args).not.toContain(expect.stringContaining("fix the tests"));
       expect(ptyService.writeBySessionId).not.toHaveBeenCalled();
       expect(ptyService.dispose).not.toHaveBeenCalled();
     });

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -4933,7 +4933,10 @@ describe("AgentChatPane submit recovery", () => {
     });
     const launchArgs = onLaunchCliSession.mock.calls[0]?.[0];
     expect(launchArgs.startupCommand).toContain(`--model ${fastAlias}`);
-    expect(launchArgs.args).toEqual(expect.arrayContaining([expect.stringContaining("Run Cursor in fast mode.")]));
+    expect(launchArgs.startupCommand).not.toContain("Run Cursor in fast mode.");
+    expect(launchArgs.args).not.toContain(expect.stringContaining("Run Cursor in fast mode."));
+    expect(launchArgs.initialInput).toContain("Run Cursor in fast mode.");
+    expect(launchArgs.initialInputDelayMs).toBe(750);
   });
 
   it("uses the OpenCode fast variant when launching a fast Work draft CLI session", async () => {
@@ -5125,7 +5128,10 @@ describe("AgentChatPane submit recovery", () => {
     });
     const launchArgs = onLaunchCliSession.mock.calls[0]?.[0];
     expect(launchArgs.startupCommand).toContain(`--model ${concreteModel}`);
-    expect(launchArgs.args).toEqual(expect.arrayContaining([expect.stringContaining("Run Cursor with medium fast thinking.")]));
+    expect(launchArgs.startupCommand).not.toContain("Run Cursor with medium fast thinking.");
+    expect(launchArgs.args).not.toContain(expect.stringContaining("Run Cursor with medium fast thinking."));
+    expect(launchArgs.initialInput).toContain("Run Cursor with medium fast thinking.");
+    expect(launchArgs.initialInputDelayMs).toBe(750);
   });
 
   it("auto-creates a lane for a foreground CLI session draft", async () => {

--- a/apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts
@@ -408,20 +408,28 @@ describe("buildTrackedCliStartupCommand", () => {
   });
 
   describe("additional CLI providers", () => {
-    it("launches Cursor with the documented initial prompt argument", () => {
+    it("launches Cursor with initial prompts submitted through PTY input", () => {
       const launch = buildTrackedCliLaunchCommand({ provider: "cursor", permissionMode: "plan", model: "cursor-fast", initialPrompt: "Review this lane." });
       expect(launch.command).toBe("cursor-agent");
-      expect(launch.args).toEqual(expect.arrayContaining(["--mode", "plan", "--model", "cursor-fast"]));
-      expect(launch.args.at(-1)).toContain("ADE session guidance");
-      expect(launch.args.at(-1)).toContain("Review this lane.");
+      expect(launch.args).toEqual(["--mode", "plan", "--model", "cursor-fast"]);
       expect(launch.startupCommand).toContain("cursor-agent --mode plan --model cursor-fast");
-      expect(launch.startupCommand).toContain("Review this lane.");
-      expect(launch.startupCommand).toContain("ADE session guidance");
+      expect(launch.startupCommand).not.toContain("Review this lane.");
+      expect(launch.startupCommand).not.toContain("ADE session guidance");
       expect(launch.startupCommand).not.toContain("cursor-agent create-chat");
       expect(launch.startupCommand).not.toContain("--resume");
+      expect(launch.initialInput).toContain("ADE session guidance");
+      expect(launch.initialInput).toContain("Review this lane.");
+      expect(launch.initialInputDelayMs).toBe(750);
+      expect(launch.env?.[ADE_AGENT_SKILLS_DIRS_ENV]).toContain("agent-skills");
+    });
+
+    it("keeps empty Cursor launches idle instead of submitting ADE guidance as work", () => {
+      const launch = buildTrackedCliLaunchCommand({ provider: "cursor", permissionMode: "default", model: "cursor-fast" });
+      expect(launch.command).toBe("cursor-agent");
+      expect(launch.args).toEqual(["--model", "cursor-fast"]);
+      expect(launch.startupCommand).toBe("cursor-agent --model cursor-fast");
       expect(launch.initialInput).toBeUndefined();
       expect(launch.initialInputDelayMs).toBeUndefined();
-      expect(launch.env?.[ADE_AGENT_SKILLS_DIRS_ENV]).toContain("agent-skills");
     });
 
     it("normalizes Cursor registry model ids and forces full-auto interactive workspaces", () => {
@@ -437,17 +445,17 @@ describe("buildTrackedCliStartupCommand", () => {
       expect(launch.startupCommand).not.toContain("--model cursor/composer-2.5");
       expect(launch.args).toEqual(expect.arrayContaining(["--force", "--model", "composer-2.5"]));
       expect(launch.args).not.toContain("--trust");
-      expect(launch.args.at(-1)).toContain("Review this lane.");
+      expect(launch.args).not.toContain(expect.stringContaining("Review this lane."));
+      expect(launch.initialInput).toContain("Review this lane.");
     });
 
     it("keeps Cursor launch direct on Windows", () => {
       withProcessPlatform("win32", () => {
         const launch = buildTrackedCliLaunchCommand({ provider: "cursor", permissionMode: "plan", model: "cursor-fast", initialPrompt: "Review this lane." });
         expect(launch.command).toBe("cursor-agent");
-        expect(launch.args).toEqual(expect.arrayContaining(["--mode", "plan", "--model", "cursor-fast"]));
-        expect(launch.args.at(-1)).toContain("Review this lane.");
-        expect(launch.initialInput).toBeUndefined();
-        expect(launch.initialInputDelayMs).toBeUndefined();
+        expect(launch.args).toEqual(["--mode", "plan", "--model", "cursor-fast"]);
+        expect(launch.initialInput).toContain("Review this lane.");
+        expect(launch.initialInputDelayMs).toBe(750);
       });
     });
 

--- a/apps/desktop/src/shared/cliLaunch.ts
+++ b/apps/desktop/src/shared/cliLaunch.ts
@@ -377,17 +377,17 @@ export function buildTrackedCliLaunchCommand(args: {
   }
 
   if (args.provider === "cursor") {
-    const prompt = workTabCliPrompt(initialPrompt, skillRoots);
     const cursorModel = resolveCursorCliModelForLaunch(args.model);
     const commandArgs = [
       ...permissionModeToCursorFlags(permissionMode),
       ...modelToCliFlag(cursorModel),
-      prompt,
     ];
+    const initialInput = initialPrompt ? workTabCliPrompt(initialPrompt, skillRoots) : null;
     return {
       command: "cursor-agent",
       args: commandArgs,
       startupCommand: commandArrayToLine(["cursor-agent", ...commandArgs]),
+      ...(initialInput ? { initialInput, initialInputDelayMs: 750 } : {}),
       ...(agentSkillEnv ? { env: agentSkillEnv } : {}),
     };
   }

--- a/docs/features/terminals-and-sessions/README.md
+++ b/docs/features/terminals-and-sessions/README.md
@@ -360,19 +360,20 @@ Renderer surfaces:
   profile to the recorded `TerminalToolType` (`cursor-cli`, `droid`,
   `opencode`, etc.) and the human tab title. `buildTrackedCliLaunchCommand`
   returns a typed `TrackedCliLaunchCommand` (`{ command?, args,
-  startupCommand, env? }`) so `ptyService.create` can spawn tracked
+  startupCommand, initialInput?, initialInputDelayMs?, env? }`) so `ptyService.create` can spawn tracked
   CLIs with explicit argv instead of typing the launch command into an
-  already-open shell. Cursor uses a direct `/bin/bash -lc` launch on
-  non-Windows because its startup path needs a multi-line preamble:
-  Cursor pre-allocates a chat with
-  `cursor-agent create-chat` so the resume target is known up front,
-  Droid materializes a temp `--settings` JSON keyed off the active
+  already-open shell. Cursor launches `cursor-agent` directly and keeps
+  empty Work launches idle; when ADE has an actual first user prompt,
+  it waits for Cursor's interactive prompt and submits the ADE guidance
+  plus user text through PTY input instead of argv. Droid materializes a
+  temp `--settings` JSON keyed off the active
   permission mode, and OpenCode passes its inline permission policy
   through the `OPENCODE_CONFIG_CONTENT` env var. ADE session guidance is
   injected on every launch with skill roots resolved from the active
   lane worktree when known: Claude gets `buildAdeCliAgentGuidance(...)`
-  through `--append-system-prompt`, while every other provider receives
-  a leading prompt from `buildAdeCliInlineGuidance(...)`. Launch env also
+  through `--append-system-prompt`; Codex, Droid, and OpenCode receive
+  a leading prompt from `buildAdeCliInlineGuidance(...)`; Cursor receives
+  that prompt only when there is an initial user message. Launch env also
   carries `ADE_AGENT_SKILLS_DIRS` when skill roots are known, including
   lane/user `.claude`, `.agents`, `.ade`, `.codex` skill dirs plus
   bundled ADE resources.
@@ -391,15 +392,12 @@ Renderer surfaces:
   `permissionMode: "auto"`); `validateLaunchProfilePermissionMode`
   rejects `auto` for any non-Claude provider and rejects `config-toml`
   for providers other than Codex and OpenCode. A launch that passes an
-  `initialPrompt` embeds it into the provider launch itself (Claude/
-  Codex/Droid argv, OpenCode `--prompt`, Cursor's pre-created resume
-  command), not as a post-create PTY write, so the first user message
-  opens the PTY and is submitted as the provider's real first turn
-  instead of becoming a half-typed shell line. Codex argv also
-  appends `codexNoisyLocalMcpDisableFlags` (`-c
-  mcp_servers.unityMCP.enabled=false`, `-c
-  mcp_servers.xcode.enabled=false`) for every non-`config-toml`
-  launch so unbundled local MCP servers do not auto-spawn under ADE.
+  `initialPrompt` embeds it into the provider launch itself for
+  argv-oriented runtimes (Claude/Codex legacy prompt models/Droid,
+  OpenCode `--prompt`), while Codex interactive launches and Cursor use
+  `initialInput` after PTY readiness so the first user message is
+  submitted as the provider's real first turn instead of becoming a
+  half-typed shell line.
   Plain "shell" launches and `resolveCleanShellLaunchFields({
   platform, shell, comSpec })` together produce a deterministic
   argv/env per OS that skips the user's profile / rc / config files

--- a/docs/features/terminals-and-sessions/pty-and-processes.md
+++ b/docs/features/terminals-and-sessions/pty-and-processes.md
@@ -432,7 +432,8 @@ write paths into one call:
    the command line so the continuation honours the user's current
    model picker. For the first ended-session continuation with
    structured `resumeMetadata`, `text` is also passed as the provider
-   prompt argument.
+   prompt argument, except for Cursor where ADE waits for the interactive
+   prompt and writes the text through PTY input.
 4. De-duplicate concurrent sends through `resumeRuntimeFlights` (one
    in-flight continuation per session id) so rapid sends do not spawn
    parallel PTYs against the same row.
@@ -440,6 +441,8 @@ write paths into one call:
    in the same row. When the row has structured `resumeMetadata` and
    no other resume flight is already running, the prompt is included in
    the provider resume command and no follow-up PTY write is attempted.
+   Cursor is the exception: its continuation command stays prompt-free,
+   then the text is submitted after the resumed CLI is input-ready.
    OpenCode uses its replay-resume command when the installed CLI
    supports it. If the code has to reuse an already-started resume
    flight, it writes `text` after the PTY is attached. The return shape

--- a/docs/features/terminals-and-sessions/ui-surfaces.md
+++ b/docs/features/terminals-and-sessions/ui-surfaces.md
@@ -542,8 +542,10 @@ Launch commands are built by `apps/desktop/src/shared/cliLaunch.ts`:
     host-owned so ADE does not synthesize partial MCP tables that the
     CLI rejects during config validation.
   - **Cursor** → `--mode plan|ask` for read-only modes and `--force`
-    for full-auto. Sessions pre-allocate a chat id with
-    `cursor-agent create-chat` so `--resume <id>` is always known.
+    for full-auto. Fresh launches start interactive `cursor-agent`
+    directly; initial user prompts are submitted through PTY input after
+    Cursor readiness, and empty launches do not submit ADE guidance as a
+    first turn.
   - **Droid** → an autonomy-tiered settings JSON written to a temp file
     that `droid --settings $ADE_DROID_SETTINGS` consumes; `spec`
     autonomy is the plan/read-only fallback.
@@ -551,10 +553,10 @@ Launch commands are built by `apps/desktop/src/shared/cliLaunch.ts`:
     `OPENCODE_CONFIG_CONTENT` env var (`config-toml` mode skips the env
     so OpenCode reads `opencode.json` instead). Plan mode adds `--agent
     plan`.
-  Every provider also receives the ADE CLI guidance prompt — Claude
-  through `--append-system-prompt`, every other provider as a leading
-  prompt argument — so the agent starts with the ADE wrappers in
-  context.
+  Every provider also receives ADE CLI guidance — Claude through
+  `--append-system-prompt`, Codex/Droid/OpenCode as a leading prompt
+  argument, and Cursor through PTY `initialInput` only when there is an
+  initial user prompt.
 - `buildTrackedCliStartupCommand({ provider, permissionMode, ... })`
   thin wrapper that returns just the shell-typed `startupCommand`.
 - `resolveTrackedCliResumeCommand(session)` — internal runtime helper


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fcursor-pty-brain-flaps-cdd125fe num=565 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fcursor-pty-brain-flaps-cdd125fe&amp;pr=565">ade/cursor-pty-brain-flaps-cdd125fe branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=565">PR #565</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes how Cursor CLI sessions receive their initial prompt: instead of embedding the prompt (and ADE guidance) as a trailing command-line argument to `cursor-agent`, the text is now submitted through PTY input after the interactive CLI is ready, with a 750 ms readiness delay. Empty Cursor launches no longer auto-submit ADE guidance as the first turn.

- **`cliLaunch.ts`**: The Cursor branch of `buildTrackedCliLaunchCommand` drops the prompt from `args` and conditionally sets `initialInput`/`initialInputDelayMs: 750` only when an `initialPrompt` is present; empty launches produce a clean idle session.
- **Tests** (`cliLaunch.test.ts`, `adeRpcServer.test.ts`, `syncRemoteCommandService.test.ts`, `AgentChatPane.test.tsx`): All relevant assertions flipped from checking prompt membership in `args` to checking `initialInput`/`initialInputDelayMs`, and a new test case covers the empty-launch idle path.
- **Docs**: `README.md`, `pty-and-processes.md`, and `ui-surfaces.md` updated to describe the new launch strategy and the selective ADE guidance injection for Cursor.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the fresh-launch path for Cursor is cleanly implemented and thoroughly tested across all relevant test suites.

All changed test assertions are consistent with the implementation. The one area worth a follow-up is whether buildTrackedCliResumeCommand for Cursor (unchanged in this PR) also needs to stop appending the prompt to args, given the docs now describe that path as prompt-free — but that is a documentation/code alignment question for the resume path, not a defect in the fresh-launch change being shipped here.

The resume branch for Cursor in buildTrackedCliResumeCommand (cliLaunch.ts lines 803–819) may be worth a follow-up to confirm it aligns with the updated docs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/shared/cliLaunch.ts | Core behavior change: Cursor fresh launches no longer embed the initial prompt (or ADE guidance) in argv; instead, when an initialPrompt is present it is submitted via PTY input with a 750 ms delay. Empty launches remain idle. Resume path (buildTrackedCliResumeCommand for cursor) still appends prompt to args, which may be inconsistent with the updated docs. |
| apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts | Tests updated to match new PTY-input behavior: assertions flip from checking prompt in args to checking initialInput/initialInputDelayMs; new test case added for empty Cursor launches staying idle. |
| apps/ade-cli/src/adeRpcServer.test.ts | Test description and assertions updated to reflect that Cursor initial input is now submitted via PTY (initialInput/initialInputDelayMs) rather than as the last command-line argument. |
| apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts | Test updated analogously to adeRpcServer.test.ts — assertions now verify PTY-input delivery of the initial prompt for Cursor sessions launched via the sync remote command service. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx | AgentChatPane tests updated: fast-mode and medium-thinking Cursor launches now assert prompt is in initialInput (not args), consistent with the new PTY-input delivery. |
| docs/features/terminals-and-sessions/README.md | Documentation accurately updated to describe the new Cursor launch strategy: direct cursor-agent invocation, idle on empty launch, PTY submission of ADE guidance + user prompt only when an initial prompt exists. |
| docs/features/terminals-and-sessions/pty-and-processes.md | Docs now state Cursor's continuation command is prompt-free (text submitted via PTY), but the code in buildTrackedCliResumeCommand for cursor still conditionally appends the prompt to argv — the resume path may not fully match this description. |
| docs/features/terminals-and-sessions/ui-surfaces.md | UI surfaces doc updated to reflect Cursor's new launch strategy and the selective ADE guidance injection. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant ADE as ADE Runtime
    participant Builder as buildTrackedCliLaunchCommand
    participant PTY as PTY Service
    participant Cursor as cursor-agent process

    ADE->>Builder: "provider="cursor", initialPrompt?"

    alt initialPrompt present
        Builder-->>ADE: "{ args:[--mode,--model,...], initialInput:"ADE guidance\nUser prompt", initialInputDelayMs:750 }"
        ADE->>PTY: "create(command="cursor-agent", args, initialInput, initialInputDelayMs=750)"
        PTY->>Cursor: spawn cursor-agent [--mode] [--model]
        Cursor-->>PTY: interactive prompt ready
        PTY->>Cursor: write initialInput after 750ms delay
    else no initialPrompt (empty launch)
        Builder-->>ADE: "{ args:[--model,...] } — no initialInput"
        ADE->>PTY: "create(command="cursor-agent", args)"
        PTY->>Cursor: spawn cursor-agent [--model] — idle, awaits user
    end
```

<sub>Reviews (2): Last reviewed commit: ["Fix Cursor Work draft launch tests"](https://github.com/arul28/ade/commit/3addb56b5c198e865650af72ec7e0029fca9f190) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37302080)</sub>

<!-- /greptile_comment -->