### PR TITLE
Fix onboarding lane import and iOS chat send recovery

### DIFF
--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -635,6 +635,136 @@ function sendHello(client: WebSocket, token: string): void {
   }));
 }
 
+function waitForEnvelope(envelopes: ParsedSyncEnvelope[], type: string, requestId: string) {
+  return waitForValue(
+    () => envelopes.find((envelope) => envelope.type === type && envelope.requestId === requestId),
+    `${type} response ${requestId}`,
+  );
+}
+
+async function connectPeer(port: number, token: string, deviceId: string) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  const tracked = trackClientEnvelopes(ws);
+  await new Promise<void>((resolve, reject) => {
+    ws.once("open", () => resolve());
+    ws.once("error", reject);
+  });
+  ws.send(encodeSyncEnvelope({
+    type: "hello",
+    payload: {
+      peer: {
+        deviceId,
+        deviceName: deviceId,
+        platform: "iOS",
+        deviceType: "phone",
+        siteId: `${deviceId}-site`,
+        dbVersion: 0,
+      },
+      auth: { kind: "bootstrap", token },
+    },
+  }));
+  await waitForValue(
+    () => tracked.envelopes.find((envelope) => envelope.type === "hello_ok"),
+    `hello_ok for ${deviceId}`,
+  );
+  return { ws, ...tracked };
+}
+
+describe("mobile command result ledger", () => {
+  beforeEach(() => {
+    publishMock.mockReset();
+    spawnMock.mockReset();
+    bonjourDestroyMock.mockReset();
+    bonjourConstructorMock.mockReset();
+    spawnMock.mockImplementation(() => ({ kill: vi.fn(), once: vi.fn(), unref: vi.fn() }));
+  });
+
+  it("persists chat.send results so restart replays do not duplicate messages", async () => {
+    const { projectRoot, cleanup } = createTempProjectRoot();
+    const sendMessage = vi.fn(async () => {});
+    let firstHost: ReturnType<typeof createSyncHostService> | null = null;
+    let secondHost: ReturnType<typeof createSyncHostService> | null = null;
+    let firstClient: Awaited<ReturnType<typeof connectPeer>> | null = null;
+    let secondClient: Awaited<ReturnType<typeof connectPeer>> | null = null;
+    const commandId = "cmd-chat-send-1";
+
+    const makeHost = () => {
+      const base = createHostArgs(projectRoot, []);
+      return createSyncHostService({
+        ...base,
+        projectId: "project-1",
+        deviceRegistryService: {
+          ...base.deviceRegistryService,
+          upsertPeerMetadata: vi.fn(),
+        },
+        agentChatService: {
+          sendMessage,
+          subscribeToEvents: vi.fn(() => vi.fn()),
+        },
+      } as unknown as Parameters<typeof createSyncHostService>[0]);
+    };
+    const sendChatCommand = (client: Awaited<ReturnType<typeof connectPeer>>, requestId: string): void => {
+      client.ws.send(encodeSyncEnvelope({
+        type: "command",
+        requestId,
+        projectId: "project-1",
+        payload: {
+          commandId,
+          action: "chat.send",
+          projectId: "project-1",
+          args: {
+            sessionId: "session-1",
+            text: "hello from iOS",
+          },
+        },
+      }));
+    };
+
+    try {
+      firstHost = makeHost();
+      const firstPort = await firstHost.waitUntilListening();
+      const token = firstHost.getBootstrapToken();
+      firstClient = await connectPeer(firstPort, token, "ios-chat-1");
+      sendChatCommand(firstClient, "send-1");
+      await waitForEnvelope(firstClient.envelopes, "command_ack", "send-1");
+      const firstResult = await waitForEnvelope(firstClient.envelopes, "command_result", "send-1");
+      expect(firstResult.payload).toMatchObject({
+        commandId,
+        ok: true,
+        result: { ok: true },
+      });
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+
+      firstClient.ws.close();
+      await firstHost.dispose();
+      firstHost = null;
+
+      secondHost = makeHost();
+      const secondPort = await secondHost.waitUntilListening();
+      secondClient = await connectPeer(secondPort, token, "ios-chat-1");
+      sendChatCommand(secondClient, "send-2");
+      await waitForEnvelope(secondClient.envelopes, "command_ack", "send-2");
+      const replayResult = await waitForEnvelope(secondClient.envelopes, "command_result", "send-2");
+      expect(replayResult.payload).toMatchObject({
+        commandId,
+        ok: true,
+        result: { ok: true },
+      });
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    } finally {
+      try {
+        firstClient?.ws.close();
+        secondClient?.ws.close();
+      } catch {
+        // ignore
+      }
+      await firstHost?.dispose();
+      await secondHost?.dispose();
+      cleanup();
+    }
+  });
+});
+
 describe("sync host handoff over a shared listener", () => {
   beforeEach(() => {
     publishMock.mockReset();

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -254,6 +254,7 @@ const PERSISTED_MOBILE_COMMAND_ACTIONS = new Set<string>([
   "processes.start",
   "processes.stop",
   "processes.kill",
+  "chat.send",
   "chat.interrupt",
   "chat.approve",
   "chat.respondToInput",

--- a/apps/desktop/src/renderer/components/onboarding/WorktreesCard.test.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/WorktreesCard.test.tsx
@@ -1,0 +1,51 @@
+/* @vitest-environment jsdom */
+
+import React from "react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppStore } from "../../state/appStore";
+import { WorktreesCard } from "./WorktreesCard";
+
+describe("WorktreesCard", () => {
+  const originalAde = window.ade;
+  const originalRefreshLanes = useAppStore.getState().refreshLanes;
+  let refreshLanes: typeof originalRefreshLanes;
+
+  beforeEach(() => {
+    refreshLanes = vi.fn(async () => undefined) as unknown as typeof originalRefreshLanes;
+    useAppStore.setState({ refreshLanes });
+    window.ade = ({
+      ...(originalAde ?? {}),
+      lanes: {
+        ...((originalAde as typeof window.ade | undefined)?.lanes ?? {}),
+        listUnregisteredWorktrees: vi.fn()
+          .mockResolvedValueOnce([{ path: "/repo/worktree-a", branch: "feature/a" }])
+          .mockResolvedValueOnce([]),
+        attach: vi.fn(async () => ({})),
+      },
+    } as unknown) as typeof window.ade;
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.ade = originalAde;
+    useAppStore.setState({ refreshLanes: originalRefreshLanes });
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes the shared lane store after importing existing worktrees", async () => {
+    render(<WorktreesCard />);
+
+    await screen.findByText("feature/a");
+    fireEvent.click(screen.getByRole("button", { name: "Add 1 as lane" }));
+
+    await waitFor(() => {
+      expect(window.ade.lanes.attach).toHaveBeenCalledWith({
+        name: "feature/a",
+        attachedPath: "/repo/worktree-a",
+      });
+      expect(refreshLanes).toHaveBeenCalledWith({ includeStatus: false });
+      expect(window.ade.lanes.listUnregisteredWorktrees).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/desktop/src/renderer/components/onboarding/WorktreesCard.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/WorktreesCard.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { CircleNotch, GitFork, WarningCircle, Check } from "@phosphor-icons/react";
 import type { UnregisteredLaneCandidate } from "../../../shared/types/lanes";
+import { useAppStore } from "../../state/appStore";
 import { COLORS, SANS_FONT, MONO_FONT } from "../lanes/laneDesignTokens";
 import { Button } from "../ui/Button";
 import { RescanButton } from "./RescanButton";
@@ -9,6 +10,7 @@ import { CARD_BASE, SECTION_LABEL } from "./onboardingTheme";
 type LoadOptions = { preselectAll?: boolean; keepSelected?: Set<string> };
 
 export function WorktreesCard() {
+  const refreshLanes = useAppStore((s) => s.refreshLanes);
   const [worktrees, setWorktrees] = useState<UnregisteredLaneCandidate[]>([]);
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
@@ -82,6 +84,15 @@ export function WorktreesCard() {
         failedPaths.add(wt.path);
         collectedErrors.push(
           `${wt.branch || wt.path}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+    if (ok > 0) {
+      try {
+        await refreshLanes({ includeStatus: false });
+      } catch (err) {
+        collectedErrors.push(
+          `Added ${ok} worktree${ok !== 1 ? "s" : ""}, but the lane list did not refresh: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     }

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -1317,6 +1317,7 @@ final class SyncService: ObservableObject {
   private var reconnectTask: Task<Void, Never>?
   private var networkPathReconnectTask: Task<Void, Never>?
   private var pendingOperationFlushTask: Task<Void, Never>?
+  private var pendingOperationFlushInFlight = false
   private var lanePresenceHeartbeatTask: Task<Void, Never>?
   private var openLaneReferenceCounts: [String: Int] = [:]
   private var terminalBufferRevisionTask: Task<Void, Never>?
@@ -2761,7 +2762,7 @@ final class SyncService: ObservableObject {
       try? await refreshLaneSnapshots()
       try? await refreshWorkSessions()
       try? await refreshPullRequestSnapshots()
-      await flushPendingOperationsAndScheduleRetry()
+      flushPendingOperationsAndScheduleRetry()
       return
     }
 
@@ -7470,7 +7471,7 @@ final class SyncService: ObservableObject {
       guard let self else { return }
       await self.performInitialHydration(for: connectionGeneration)
       guard self.isCurrentConnectionGeneration(connectionGeneration) else { return }
-      await self.flushPendingOperationsAndScheduleRetry()
+      self.flushPendingOperationsAndScheduleRetry()
     }
   }
 
@@ -7786,6 +7787,7 @@ final class SyncService: ObservableObject {
     hydrationTask = nil
     pendingOperationFlushTask?.cancel()
     pendingOperationFlushTask = nil
+    pendingOperationFlushInFlight = false
     lanePresenceHeartbeatTask?.cancel()
     lanePresenceHeartbeatTask = nil
     if let socket {
@@ -7979,9 +7981,13 @@ final class SyncService: ObservableObject {
     pendingOperationFlushTask = Task { @MainActor [weak self] in
       var nextDelay = delayNanoseconds
       while !Task.isCancelled {
-        try? await Task.sleep(nanoseconds: nextDelay)
+        if nextDelay > 0 {
+          try? await Task.sleep(nanoseconds: nextDelay)
+        }
         guard let self, !Task.isCancelled else { return }
+        self.pendingOperationFlushInFlight = true
         let shouldRetry = await self.flushPendingOperations()
+        self.pendingOperationFlushInFlight = false
         if !shouldRetry || !self.canSendLiveRequests() {
           self.pendingOperationFlushTask = nil
           return
@@ -8061,11 +8067,13 @@ final class SyncService: ObservableObject {
     }
   }
 
-  private func flushPendingOperationsAndScheduleRetry() async {
-    let shouldRetry = await flushPendingOperations()
-    if shouldRetry, canSendLiveRequests() {
-      schedulePendingOperationFlush(delayNanoseconds: 15_000_000_000)
+  private func flushPendingOperationsAndScheduleRetry() {
+    if pendingOperationFlushTask != nil {
+      guard !pendingOperationFlushInFlight else { return }
+      pendingOperationFlushTask?.cancel()
+      pendingOperationFlushTask = nil
     }
+    schedulePendingOperationFlush(delayNanoseconds: 0)
   }
 
   @discardableResult

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -7977,10 +7977,17 @@ final class SyncService: ObservableObject {
   private func schedulePendingOperationFlush(delayNanoseconds: UInt64 = 2_000_000_000) {
     guard pendingOperationFlushTask == nil else { return }
     pendingOperationFlushTask = Task { @MainActor [weak self] in
-      try? await Task.sleep(nanoseconds: delayNanoseconds)
-      guard let self, !Task.isCancelled else { return }
-      self.pendingOperationFlushTask = nil
-      await self.flushPendingOperations()
+      var nextDelay = delayNanoseconds
+      while !Task.isCancelled {
+        try? await Task.sleep(nanoseconds: nextDelay)
+        guard let self, !Task.isCancelled else { return }
+        let shouldRetry = await self.flushPendingOperations()
+        if !shouldRetry || !self.canSendLiveRequests() {
+          self.pendingOperationFlushTask = nil
+          return
+        }
+        nextDelay = 15_000_000_000
+      }
     }
   }
 
@@ -8037,21 +8044,33 @@ final class SyncService: ObservableObject {
     return dict
   }
 
-  private func flushPendingOperations() async {
-    guard canSendLiveRequests() else { return }
+  private func pendingOperationMatches(_ lhs: PendingOperation, _ rhs: PendingOperation) -> Bool {
+    lhs.id == rhs.id
+      && lhs.kind == rhs.kind
+      && lhs.action == rhs.action
+      && lhs.payload == rhs.payload
+  }
+
+  private func removePendingOperation(_ operation: PendingOperation) {
+    var queued = loadPendingOperations()
+    if let index = queued.firstIndex(where: { pendingOperationMatches($0, operation) }) {
+      queued.remove(at: index)
+      savePendingOperations(queued)
+    } else {
+      pendingOperationCount = queued.count
+    }
+  }
+
+  @discardableResult
+  private func flushPendingOperations() async -> Bool {
+    guard canSendLiveRequests() else { return false }
     var queued = loadPendingOperations()
     guard !queued.isEmpty else {
       pendingOperationCount = 0
-      return
+      return false
     }
 
-    var index = queued.startIndex
-    while index < queued.endIndex {
-      let operation = queued[index]
-      guard pendingOperationMatchesActiveProject(operation) else {
-        index = queued.index(after: index)
-        continue
-      }
+    while let operation = queued.first(where: pendingOperationMatchesActiveProject) {
       do {
         let args = try decodeQueuedArgs(operation)
         switch operation.kind {
@@ -8068,23 +8087,28 @@ final class SyncService: ObservableObject {
         default:
           throw NSError(domain: "ADE", code: 13, userInfo: [NSLocalizedDescriptionKey: "Unknown queued operation type."])
         }
-        queued.remove(at: index)
-        savePendingOperations(queued)
+        removePendingOperation(operation)
       } catch {
         lastError = SyncUserFacingError.message(for: error)
         let stillLive = canSendLiveRequests()
         if isRemoteCommandApplicationError(error) || (stillLive && !isSyncRequestTimeoutError(error)) {
-          queued.remove(at: index)
-          savePendingOperations(queued)
+          removePendingOperation(operation)
+          queued = loadPendingOperations()
           continue
         }
-        savePendingOperations(queued)
         if !stillLive {
           connectionState = .error
         }
-        break
+        if isSyncRequestTimeoutError(error) {
+          verifyTransportAliveAfterRequestTimeout(error as NSError)
+          return stillLive
+        }
+        return false
       }
+      queued = loadPendingOperations()
     }
+    pendingOperationCount = loadPendingOperations().count
+    return false
   }
 
   private func performCommandRequest(

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -2761,7 +2761,7 @@ final class SyncService: ObservableObject {
       try? await refreshLaneSnapshots()
       try? await refreshWorkSessions()
       try? await refreshPullRequestSnapshots()
-      await flushPendingOperations()
+      await flushPendingOperationsAndScheduleRetry()
       return
     }
 
@@ -7470,7 +7470,7 @@ final class SyncService: ObservableObject {
       guard let self else { return }
       await self.performInitialHydration(for: connectionGeneration)
       guard self.isCurrentConnectionGeneration(connectionGeneration) else { return }
-      await self.flushPendingOperations()
+      await self.flushPendingOperationsAndScheduleRetry()
     }
   }
 
@@ -8058,6 +8058,13 @@ final class SyncService: ObservableObject {
       savePendingOperations(queued)
     } else {
       pendingOperationCount = queued.count
+    }
+  }
+
+  private func flushPendingOperationsAndScheduleRetry() async {
+    let shouldRetry = await flushPendingOperations()
+    if shouldRetry, canSendLiveRequests() {
+      schedulePendingOperationFlush(delayNanoseconds: 15_000_000_000)
     }
   }
 

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -129,6 +129,17 @@ func isRemoteCommandApplicationError(_ error: Error) -> Bool {
     && nsError.userInfo["ADEErrorCode"] != nil
 }
 
+func isSyncRequestTimeoutError(_ error: Error) -> Bool {
+  let nsError = error as NSError
+  return nsError.domain == "ADE" && nsError.code == 23
+}
+
+func syncShouldQueueCommandAfterSendFailure(error: Error, canSendLiveRequests: Bool, queueable: Bool) -> Bool {
+  guard queueable else { return false }
+  guard !isRemoteCommandApplicationError(error) else { return false }
+  return !canSendLiveRequests || isSyncRequestTimeoutError(error)
+}
+
 func decodeHydrationPayload<T: Decodable>(_ raw: Any, as type: T.Type, domainLabel: String, decoder: JSONDecoder) throws -> T {
   do {
     let data = try adeJSONData(withJSONObject: raw)
@@ -1305,6 +1316,7 @@ final class SyncService: ObservableObject {
   private var hydrationTask: Task<Void, Never>?
   private var reconnectTask: Task<Void, Never>?
   private var networkPathReconnectTask: Task<Void, Never>?
+  private var pendingOperationFlushTask: Task<Void, Never>?
   private var lanePresenceHeartbeatTask: Task<Void, Never>?
   private var openLaneReferenceCounts: [String: Int] = [:]
   private var terminalBufferRevisionTask: Task<Void, Never>?
@@ -2128,6 +2140,7 @@ final class SyncService: ObservableObject {
     projectSelectionTask?.cancel()
     reconnectTask?.cancel()
     networkPathReconnectTask?.cancel()
+    pendingOperationFlushTask?.cancel()
     lanePresenceHeartbeatTask?.cancel()
     terminalBufferRevisionTask?.cancel()
     chatEventRevisionTask?.cancel()
@@ -7771,6 +7784,8 @@ final class SyncService: ObservableObject {
     clientHeartbeatTask = nil
     hydrationTask?.cancel()
     hydrationTask = nil
+    pendingOperationFlushTask?.cancel()
+    pendingOperationFlushTask = nil
     lanePresenceHeartbeatTask?.cancel()
     lanePresenceHeartbeatTask = nil
     if let socket {
@@ -7959,6 +7974,16 @@ final class SyncService: ObservableObject {
     pendingOperationCount = operations.count
   }
 
+  private func schedulePendingOperationFlush(delayNanoseconds: UInt64 = 2_000_000_000) {
+    guard pendingOperationFlushTask == nil else { return }
+    pendingOperationFlushTask = Task { @MainActor [weak self] in
+      try? await Task.sleep(nanoseconds: delayNanoseconds)
+      guard let self, !Task.isCancelled else { return }
+      self.pendingOperationFlushTask = nil
+      await self.flushPendingOperations()
+    }
+  }
+
   private func enqueueOperation(kind: String, action: String, args: [String: Any], id: String? = nil) throws {
     guard JSONSerialization.isValidJSONObject(args) else {
       throw NSError(domain: "ADE", code: 11, userInfo: [NSLocalizedDescriptionKey: "Invalid queued operation payload."])
@@ -7976,6 +8001,9 @@ final class SyncService: ObservableObject {
       projectRootPath: activeProjectRootPath
     ))
     savePendingOperations(queued)
+    if canSendLiveRequests() {
+      schedulePendingOperationFlush()
+    }
   }
 
   private func pendingOperationMatchesActiveProject(_ operation: PendingOperation) -> Bool {
@@ -8044,13 +8072,16 @@ final class SyncService: ObservableObject {
         savePendingOperations(queued)
       } catch {
         lastError = SyncUserFacingError.message(for: error)
-        if canSendLiveRequests() {
+        let stillLive = canSendLiveRequests()
+        if isRemoteCommandApplicationError(error) || (stillLive && !isSyncRequestTimeoutError(error)) {
           queued.remove(at: index)
           savePendingOperations(queued)
           continue
         }
         savePendingOperations(queued)
-        connectionState = .error
+        if !stillLive {
+          connectionState = .error
+        }
         break
       }
     }
@@ -8109,10 +8140,16 @@ final class SyncService: ObservableObject {
           timeoutNanoseconds: timeoutNanoseconds
         )
       } catch {
-        if !isRemoteCommandApplicationError(error),
-           !canSendLiveRequests(),
-           commandPolicy(for: action)?.queueable == true {
+        let stillLive = canSendLiveRequests()
+        if syncShouldQueueCommandAfterSendFailure(
+          error: error,
+          canSendLiveRequests: stillLive,
+          queueable: commandPolicy(for: action)?.queueable == true
+        ) {
           try enqueueOperation(kind: "command", action: action, args: args, id: commandId)
+          if stillLive, isSyncRequestTimeoutError(error) {
+            verifyTransportAliveAfterRequestTimeout(error as NSError)
+          }
           return ["queued": true]
         }
         throw error
@@ -8744,10 +8781,16 @@ extension SyncService {
       do {
         return try await performCommandRequest(action: action, args: args, commandId: commandId)
       } catch {
-        if !isRemoteCommandApplicationError(error),
-           !canSendLiveRequests(),
-           commandPolicy(for: action)?.queueable == true {
+        let stillLive = canSendLiveRequests()
+        if syncShouldQueueCommandAfterSendFailure(
+          error: error,
+          canSendLiveRequests: stillLive,
+          queueable: commandPolicy(for: action)?.queueable == true
+        ) {
           try enqueueOperation(kind: "command", action: action, args: args, id: commandId)
+          if stillLive, isSyncRequestTimeoutError(error) {
+            verifyTransportAliveAfterRequestTimeout(error as NSError)
+          }
           return ["queued": true]
         }
         throw error

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
@@ -9,8 +9,8 @@ extension WorkSessionDestinationView {
     guard !sending || useSteer else { return false }
     let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !text.isEmpty else { return false }
-    copySubmittedWorkPromptToPasteboard(text)
     guard canSendChatMessages else { return false }
+    copySubmittedWorkPromptToPasteboard(text)
 
     let initialDeliveryState = (sendWillQueueChatMessage || useSteer) ? "queued" : "sending"
     let echo = WorkLocalEchoMessage(

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
@@ -10,7 +10,6 @@ extension WorkSessionDestinationView {
     let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !text.isEmpty else { return false }
     guard canSendChatMessages else { return false }
-    copySubmittedWorkPromptToPasteboard(text)
 
     let initialDeliveryState = (sendWillQueueChatMessage || useSteer) ? "queued" : "sending"
     let echo = WorkLocalEchoMessage(

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
@@ -9,6 +9,7 @@ extension WorkSessionDestinationView {
     guard !sending || useSteer else { return false }
     let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !text.isEmpty else { return false }
+    copySubmittedWorkPromptToPasteboard(text)
     guard canSendChatMessages else { return false }
 
     let initialDeliveryState = (sendWillQueueChatMessage || useSteer) ? "queued" : "sending"
@@ -478,6 +479,13 @@ extension WorkSessionDestinationView {
       guard !Task.isCancelled else { return }
       prLinkCopied = false
     }
+  }
+
+  @MainActor
+  func copySubmittedWorkPromptToPasteboard(_ text: String) {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
+    UIPasteboard.general.string = trimmed
   }
 
   func presentCreateLanePr() {

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -824,6 +824,7 @@ struct WorkSessionDestinationView: View {
       handledOpeningPromptKey = promptKey
       return
     }
+    copySubmittedWorkPromptToPasteboard(prompt)
     handledOpeningPromptKey = promptKey
 
     let echo: WorkLocalEchoMessage

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -693,6 +693,47 @@ final class ADETests: XCTestCase {
     )
   }
 
+  func testCommandSendFailureQueuePolicyPreservesQueueableTimeoutsOnly() {
+    XCTAssertTrue(
+      syncShouldQueueCommandAfterSendFailure(
+        error: SyncRequestTimeout.error(),
+        canSendLiveRequests: true,
+        queueable: true
+      )
+    )
+    XCTAssertTrue(
+      syncShouldQueueCommandAfterSendFailure(
+        error: NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut),
+        canSendLiveRequests: false,
+        queueable: true
+      )
+    )
+
+    let error = NSError(
+      domain: "ADE",
+      code: 17,
+      userInfo: [
+        NSLocalizedDescriptionKey: "Remote command failed.",
+        "ADEErrorCode": "command_failed",
+      ]
+    )
+
+    XCTAssertFalse(
+      syncShouldQueueCommandAfterSendFailure(
+        error: error,
+        canSendLiveRequests: false,
+        queueable: true
+      )
+    )
+    XCTAssertFalse(
+      syncShouldQueueCommandAfterSendFailure(
+        error: SyncRequestTimeout.error(),
+        canSendLiveRequests: true,
+        queueable: false
+      )
+    )
+  }
+
   func testSyncConnectionHealthTreatsSyncingAsConnectedTransport() {
     let health = syncConnectionHealth(
       connectionState: .syncing,

--- a/docs/features/onboarding-and-settings/README.md
+++ b/docs/features/onboarding-and-settings/README.md
@@ -98,6 +98,9 @@ Renderer — onboarding:
 - `apps/desktop/src/renderer/components/onboarding/GitHubCard.tsx`,
   `LinearCard.tsx`, `WorktreesCard.tsx` — setup cards for repository auth,
   Linear OAuth / API-key auth, and importing existing worktrees as lanes.
+  `WorktreesCard` refreshes the shared lane store after successful imports so
+  the first post-onboarding Work/Lanes views render the attached lanes without
+  waiting for a later project refresh.
 - `apps/desktop/src/renderer/components/onboarding/InputPopover.tsx`,
   `RescanButton.tsx`, `onboardingTheme.ts` — shared setup-card controls and
   brand/status styling tokens.

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -752,8 +752,9 @@ project scope split.
   rows, plus rows for tables that no longer exist locally, before
   opening the apply transaction. A batch that contains only ignored
   tables is a no-op and preserves the local database version.
-- **Controller command queues replay on reconnect.** If the runtime
-  advertises `chat.send` as queueable and the user sends while the
-  desktop is reconnecting, the iOS app stores the command locally with
-  a queued delivery state and replays on reconnect. Do not assume
-  synchronous semantics from the phone side.
+- **Controller command queues replay on reconnect and on live-send
+  timeouts.** If the runtime advertises `chat.send` as queueable and the user
+  sends while the desktop is reconnecting, or the send request times out while
+  the socket still appears connected, the iOS app stores the command locally
+  with a queued delivery state and replays it with the same `commandId`. Do not
+  assume synchronous semantics from the phone side.

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -386,10 +386,13 @@ turns a raw response dict into either the `result` value or throws an
 ### Offline behavior
 
 - All synced state is available offline from the local DB.
-- Execution commands queue locally and replay on reconnect. The runtime
-  deduplicates retried commands by `commandId` through a TTL'd cache
-  + persisted journal, so a replay returns the cached
-  `command_ack` / `command_result` instead of running twice.
+- Execution commands queue locally and replay on reconnect. Queueable commands
+  also enter the local queue when a send times out while the WebSocket still
+  appears connected; the phone keeps the same `commandId`, schedules a short
+  retry, and probes the transport instead of dropping the user's action. The
+  runtime deduplicates retried commands by `commandId` through a TTL'd cache +
+  persisted journal, so a replay returns the cached `command_ack` /
+  `command_result` instead of running twice.
 - UI shows "pending sync" indicators for queued actions.
 
 ### Timeouts


### PR DESCRIPTION
## Summary
- refresh the shared desktop lane store after onboarding imports existing worktrees
- queue iOS chat commands when a live send times out, preserving command IDs for host-side dedupe
- copy submitted iOS Work prompts to pasteboard before send as a recovery fallback
- document the onboarding import refresh and iOS queue-on-timeout behavior

## Validation
- npm --prefix apps/desktop run typecheck
- cd apps/desktop && npx vitest run src/renderer/components/onboarding/WorktreesCard.test.tsx
- cd apps/desktop && npx vitest run --shard=1/8
- XcodeBuildMCP simulator: ADETests/testCommandSendFailureQueuePolicyPreservesQueueableTimeoutsOnly
- node scripts/validate-docs.mjs
- npm --prefix apps/ade-cli run typecheck
- cd apps/ade-cli && npx vitest run src/tuiClient
- npm --prefix apps/ade-cli test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Work prompts and chat messages are now copied to the system pasteboard when submitted.

* **Bug Fixes**
  * Improved sync timeout handling so timed-out send attempts are retried or queued more reliably.
  * Enhanced lane/worktree import flow with clearer error reporting when lane list refresh fails.

* **Tests**
  * Added unit tests covering queueing policy for send failures and worktree import behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses two reliability gaps: the desktop onboarding lane-import flow now refreshes the shared lane store after attaching worktrees, and the iOS sync layer queues `chat.send` commands on live-send timeouts (not just on full disconnects), preserving `commandId` for host-side deduplication. Work prompts are also copied to the pasteboard as a recovery fallback before the send is attempted.

- **iOS SyncService**: Introduces `schedulePendingOperationFlush` / `flushPendingOperationsAndScheduleRetry` to replace the fire-and-forget `await flushPendingOperations()` calls; rewrites the flush loop to distinguish timeout errors (queue + retry) from application errors (discard) from transport failures (stop). Adds `chat.send` to `PERSISTED_MOBILE_COMMAND_ACTIONS` on the host side so replayed sends return from the dedup cache instead of re-executing.
- **Desktop WorktreesCard**: Calls `refreshLanes({ includeStatus: false })` after successful imports and surfaces refresh failures as a non-fatal error, with a new Vitest test verifying the behaviour.
- **Docs**: Updates the sync and onboarding docs to describe the new timeout-queue behaviour and the lane-store refresh.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The flush-loop rewrite is well-tested, the dedup path is validated end-to-end, and the desktop lane-refresh change is a non-breaking additive call.

All changed paths have direct unit or integration test coverage. The iOS flush-loop logic correctly distinguishes timeout/transport/application errors and the clearConnectionState teardown path explicitly nils the new task handle. The one gap (cancelled task not self-nilling on the cancellation exit path) is covered by clearConnectionState on every normal disconnect and is a narrow defensive concern, not a live defect.

apps/ios/ADE/Services/SyncService.swift — specifically schedulePendingOperationFlush; the task's cancellation exit branch does not nil pendingOperationFlushTask, though clearConnectionState compensates for all known callers.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Services/SyncService.swift | Adds timeout-aware queuing logic, a scheduled retry task for pending operations, and chat.send dedupe support. The flush loop rewrite and schedulePendingOperationFlush are generally correct; minor concern around task self-nil on cancelled exit. |
| apps/ios/ADETests/ADETests.swift | New unit test covers all four cases for syncShouldQueueCommandAfterSendFailure (timeout+live, generic error+offline, app error+offline, timeout+non-queueable). |
| apps/desktop/src/renderer/components/onboarding/WorktreesCard.tsx | Calls refreshLanes({ includeStatus: false }) after successful lane imports; refresh failure is surfaced as a non-fatal error message. Clean. |
| apps/ade-cli/src/services/sync/syncHostService.ts | Adds chat.send to PERSISTED_MOBILE_COMMAND_ACTIONS so the host persists and deduplicates send results across restarts. |
| apps/ade-cli/src/services/sync/syncHostService.test.ts | Adds integration test that starts two sequential hosts and confirms a replayed chat.send (same commandId) returns the cached result without calling sendMessage a second time. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant iOS as iOS App
    participant SS as SyncService
    participant Q as PendingOperations (UserDefaults)
    participant Host as Desktop Host

    iOS->>SS: sendChatMessage(sessionId, text)
    SS->>Host: performCommandRequest(chat.send)
    Host-->>SS: timeout (ADE code 23)
    SS->>SS: syncShouldQueueCommandAfterSendFailure() → queue
    SS->>Q: enqueueOperation(commandId)
    SS->>SS: verifyTransportAliveAfterRequestTimeout()
    SS->>SS: "schedulePendingOperationFlush(delay=2s)"
    SS-->>iOS: return [queued: true]

    Note over SS,Q: 2s later (or on reconnect)
    SS->>Q: loadPendingOperations()
    Q-->>SS: [operation]
    SS->>Host: performCommandRequest(operation.id)
    Host-->>SS: command_result (deduped by commandId)
    SS->>Q: removePendingOperation(operation)
    SS-->>iOS: "delivery = .queued / .sent"
```

<sub>Reviews (6): Last reviewed commit: ["ship: iteration 5 - persist chat send de..."](https://github.com/arul28/ade/commit/9ee8bfa456d06e55563d92f035995bfdedf3216f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37376807)</sub>

<!-- /greptile_comment -->