### PR TITLE
Usage Panel Top Right Ade

### DIFF
--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -12391,6 +12391,9 @@ async function spawnMachineRuntimeDaemon(
   const { args, buildHash: runtimeBuildHash } =
     prepareMachineRuntimeDaemonCommand(serviceCommand);
   args.push("--socket", socketPath);
+  if (isEphemeralRuntimeSocketPath(socketPath) && !args.includes("--no-sync")) {
+    args.push("--no-sync");
+  }
 
   const env: NodeJS.ProcessEnv = {
     ...process.env,

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -4561,17 +4561,22 @@ app.whenReady().then(async () => {
     });
     adeCliService.applyToProcessEnv();
     installAdeCliForTerminalInBackground(adeCliService, logger);
-    const usageTrackingService = options.enableUsageTracking === false
-      ? null
-      : createUsageTrackingService({
-          logger,
-          pollIntervalMs: 120_000,
-          onUpdate: (snapshot) => {
-            broadcast(IPC.usageEvent, snapshot);
-          },
-          projectRoot: normalizedRoot || null,
-        });
-    usageTrackingService?.start();
+    let usageTrackingService: ReturnType<typeof createUsageTrackingService> | null = null;
+    if (options.enableUsageTracking !== false) {
+      usageTrackingService = createUsageTrackingService({
+        logger,
+        pollIntervalMs: 120_000,
+        onUpdate: (snapshot) => {
+          const currentDormantUsageService =
+            (dormantContext as AppContext | undefined)?.usageTrackingService;
+          if (currentDormantUsageService !== usageTrackingService || projectContexts.size > 0) {
+            return;
+          }
+          broadcast(IPC.usageEvent, snapshot);
+        },
+        projectRoot: normalizedRoot || null,
+      });
+    }
     return {
       db: null,
       logger,
@@ -4665,15 +4670,15 @@ app.whenReady().then(async () => {
 
   const replaceDormantContext = (projectRoot = ""): void => {
     const previous = dormantContext as AppContext | undefined;
-    dormantContext = createDormantProjectContext(projectRoot);
-    syncDormantUsageTrackingState();
-    if (previous && previous !== dormantContext) {
+    if (previous) {
       try {
         previous.usageTrackingService?.dispose();
       } catch {
         // ignore
       }
     }
+    dormantContext = createDormantProjectContext(projectRoot);
+    syncDormantUsageTrackingState();
   };
 
   const disposeContextResources = async (ctx: AppContext): Promise<void> => {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -4410,7 +4410,7 @@ app.whenReady().then(async () => {
     const logger = createFileLogger(path.join(adePaths.logsDir, "main.jsonl"));
     const project = toProjectInfo(projectRoot, baseRef);
     const runtimeProject = await localRuntimePool.ensureProject(projectRoot);
-    const shellContext = createDormantProjectContext(projectRoot);
+    const shellContext = createDormantProjectContext(projectRoot, { enableUsageTracking: false });
     let macosVmLaunchProviderForProject: MacosVmLaunchProvider | null = null;
     const macosVmService = isMacosVmEnabledForPackagedState(app.isPackaged)
       ? createMacosVmService({
@@ -4523,7 +4523,10 @@ app.whenReady().then(async () => {
     };
   };
 
-  const createDormantProjectContext = (projectRoot = ""): AppContext => {
+  const createDormantProjectContext = (
+    projectRoot = "",
+    options: { enableUsageTracking?: boolean } = {},
+  ): AppContext => {
     const rootIsDefined =
       typeof projectRoot === "string" && projectRoot.trim().length > 0;
     const normalizedRoot = rootIsDefined ? path.resolve(projectRoot) : "";
@@ -4558,6 +4561,17 @@ app.whenReady().then(async () => {
     });
     adeCliService.applyToProcessEnv();
     installAdeCliForTerminalInBackground(adeCliService, logger);
+    const usageTrackingService = options.enableUsageTracking === false
+      ? null
+      : createUsageTrackingService({
+          logger,
+          pollIntervalMs: 120_000,
+          onUpdate: (snapshot) => {
+            broadcast(IPC.usageEvent, snapshot);
+          },
+          projectRoot: normalizedRoot || null,
+        });
+    usageTrackingService?.start();
     return {
       db: null,
       logger,
@@ -4610,7 +4624,7 @@ app.whenReady().then(async () => {
       automationPlannerService: null,
       automationIngressService: null,
       githubPollingService: null,
-      usageTrackingService: null,
+      usageTrackingService,
       budgetCapService: null,
       syncHostService: null,
       syncService: null,
@@ -4637,6 +4651,29 @@ app.whenReady().then(async () => {
       linearSyncService: null,
       configReloadService: null,
     };
+  };
+
+  const syncDormantUsageTrackingState = (): void => {
+    const usageTrackingService = (dormantContext as AppContext | undefined)?.usageTrackingService;
+    if (!usageTrackingService) return;
+    if (projectContexts.size > 0) {
+      usageTrackingService.stop();
+      return;
+    }
+    usageTrackingService.start();
+  };
+
+  const replaceDormantContext = (projectRoot = ""): void => {
+    const previous = dormantContext as AppContext | undefined;
+    dormantContext = createDormantProjectContext(projectRoot);
+    syncDormantUsageTrackingState();
+    if (previous && previous !== dormantContext) {
+      try {
+        previous.usageTrackingService?.dispose();
+      } catch {
+        // ignore
+      }
+    }
   };
 
   const disposeContextResources = async (ctx: AppContext): Promise<void> => {
@@ -4829,6 +4866,7 @@ app.whenReady().then(async () => {
     const closePromise = (async () => {
       await disposeContextResources(ctx);
       projectContexts.delete(normalizedRoot);
+      syncDormantUsageTrackingState();
       projectLastActivatedAt.delete(normalizedRoot);
       const leaseTimer = mobileSyncHandoffLeaseTimers.get(normalizedRoot);
       if (leaseTimer) {
@@ -4961,6 +4999,7 @@ app.whenReady().then(async () => {
           userSelectedProject: false,
         });
         projectContexts.set(normalizedRoot, ctx);
+        syncDormantUsageTrackingState();
         return ctx;
       })().finally(() => {
         projectInitPromises.delete(normalizedRoot);
@@ -5299,6 +5338,7 @@ app.whenReady().then(async () => {
             durationMs: Date.now() - initStartedAt,
           });
           projectContexts.set(repoRoot!, ctx);
+          syncDormantUsageTrackingState();
           projectOpenLogger.info("project.open.context_registered", {
             selectedPath,
             repoRoot,
@@ -5368,7 +5408,7 @@ app.whenReady().then(async () => {
     await closeProjectContext(normalizedRoot);
     if (wasActive) {
       setForegroundProject(firstOpenWindowProjectRoot());
-      dormantContext = createDormantProjectContext(normalizedRoot);
+      replaceDormantContext(normalizedRoot);
     }
   };
 
@@ -5388,7 +5428,7 @@ app.whenReady().then(async () => {
       if (nextRoot == null && (activeProjectRoot === previousRoot || activeProjectRoot == null)) {
         setForegroundProject(firstOpenWindowProjectRoot());
       }
-      dormantContext = createDormantProjectContext(previousRoot);
+      replaceDormantContext(previousRoot);
       scheduleProjectContextRebalance();
       return;
     }
@@ -5396,10 +5436,10 @@ app.whenReady().then(async () => {
       await closeProjectContext(activeProjectRoot);
     }
     setForegroundProject(firstOpenWindowProjectRoot());
-    dormantContext = createDormantProjectContext(previousRoot);
+    replaceDormantContext(previousRoot);
   };
 
-  dormantContext = createDormantProjectContext();
+  replaceDormantContext();
   configureBuiltInBrowserWebAuthn({
     getLogger: () => getActiveContext().logger,
   });
@@ -5546,7 +5586,7 @@ app.whenReady().then(async () => {
         // ignore
       }
       setForegroundProject(null);
-      dormantContext = createDormantProjectContext(previousRoot);
+      replaceDormantContext(previousRoot);
 
       try {
         await closeAllProjectContexts();
@@ -6287,7 +6327,7 @@ app.whenReady().then(async () => {
       await switchProjectFromDialog(startupProject.rootPath);
     } catch {
       setForegroundProject(null);
-      dormantContext = createDormantProjectContext();
+      replaceDormantContext();
     }
   }
 

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -1230,15 +1230,17 @@ async function buildGlobalAiStatus(args?: { force?: boolean }): Promise<AiSettin
     skipAuthProbe: args?.force !== true,
   });
   const providerConnections = await buildProviderConnections(cliStatuses);
-  const hasSubscriptionProvider =
+  const hasConfirmedSubscriptionProvider =
     providerConnections.claude.authAvailable ||
     providerConnections.codex.authAvailable ||
     providerConnections.cursor.authAvailable ||
     providerConnections.droid.authAvailable ||
-    cliStatuses.some((entry) => entry.installed && (entry.authenticated || !entry.verified));
+    cliStatuses.some((entry) => entry.installed && entry.authenticated);
 
+  // This no-project fallback reports machine-level provider/auth signals only;
+  // feature flags, usage counters, and model catalogs remain project-scoped.
   return {
-    mode: hasSubscriptionProvider ? "subscription" : "guest",
+    mode: hasConfirmedSubscriptionProvider ? "subscription" : "guest",
     availableProviders: {
       claude: buildClaudeAvailabilityFromConnection(providerConnections.claude),
       codex: providerConnections.codex.runtimeAvailable,
@@ -4256,7 +4258,10 @@ export function registerIpc({
     if (!aiIntegrationService) {
       try {
         return await buildGlobalAiStatus({ force: arg?.force === true });
-      } catch {
+      } catch (error) {
+        ctx.logger.warn("ai.get_status.global_fallback_failed", {
+          error: getErrorMessage(error),
+        });
         return getUnavailableAiStatus();
       }
     }

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -11,6 +11,9 @@ import { IPC } from "../../../shared/ipc";
 import { getModelById } from "../../../shared/modelRegistry";
 import { appendEvent as perfAppend, isRunActive as isPerfRunActive } from "../perf/perfLog";
 import { buildPrAiResolutionContextKey } from "../../../shared/types";
+import { detectCliAuthStatuses } from "../ai/authDetector";
+import { resolveClaudeCodeExecutable } from "../ai/claudeCodeExecutable";
+import { buildProviderConnections } from "../ai/providerConnectionStatus";
 import { browseProjectDirectories } from "../projects/projectBrowserService";
 import { getProjectDetail } from "../projects/projectDetailService";
 import { deleteTerminalSessionWithRuntimeCleanup } from "../sessions/deleteTerminalSession";
@@ -421,7 +424,10 @@ import type {
   UpdateIntegrationProposalArgs,
   UpdateLaneAppearanceArgs,
   WriteTextAtomicArgs,
+  AiClaudeAvailability,
+  AiDetectedAuth,
   AiFeatureKey,
+  AiProviderConnections,
   AiApiKeyVerificationResult,
   AiConfig,
   AiSettingsStatus,
@@ -1148,6 +1154,115 @@ function getUnavailableAiStatus(): AiSettingsStatus {
     availableModelIds: [],
     opencodeBinaryInstalled: false,
     opencodeBinarySource: "missing" as const,
+    opencodeInventoryError: null,
+    opencodeProviders: [],
+  };
+}
+
+function detectClaudeAuthModeFromConnection(
+  connection: AiProviderConnections["claude"],
+): AiClaudeAvailability["auth"]["mode"] {
+  const localCredentials = connection.sources.find((source) => source.kind === "local-credentials" && source.detected);
+  if (localCredentials?.source === "claude-credentials-file" || localCredentials?.source === "macos-keychain") return "oauth";
+  if (localCredentials) return "api_key";
+  const cli = connection.sources.find((source) => source.kind === "cli" && source.detected);
+  if (cli || connection.authAvailable) return "oauth";
+  return "none";
+}
+
+function resolveBundledClaudeBinary(): Pick<AiClaudeAvailability["binary"], "present" | "source" | "path"> {
+  const resolved = resolveClaudeCodeExecutable({ env: { PATH: "" } });
+  return resolved.source === "bundled"
+    ? { present: true, source: "bundled", path: resolved.path }
+    : { present: false, source: "missing", path: null };
+}
+
+function buildClaudeAvailabilityFromConnection(
+  connection: AiProviderConnections["claude"],
+): AiClaudeAvailability {
+  const bundledBinary = resolveBundledClaudeBinary();
+  const binary = bundledBinary.present
+    ? bundledBinary
+    : {
+        present: connection.runtimeDetected,
+        source: connection.runtimeDetected ? "path" as const : "missing" as const,
+        path: connection.path,
+      };
+  const normalizedBlocker = connection.blocker?.toLowerCase() ?? "";
+  const blockerIsOnlyAboutPath = binary.source === "bundled"
+    && [
+      "could not find the claude cli",
+      "cli not found",
+      "claude cli is installed",
+      "add that bin directory",
+    ].some((needle) => normalizedBlocker.includes(needle));
+  const ready = binary.present
+    && connection.authAvailable
+    && (connection.runtimeAvailable || blockerIsOnlyAboutPath || !connection.blocker);
+  const authMode = detectClaudeAuthModeFromConnection(connection);
+  return {
+    binary,
+    auth: {
+      ready,
+      mode: ready ? authMode : "none",
+      detail: ready ? null : connection.blocker,
+    },
+  };
+}
+
+function redactedCliAuthFromStatuses(
+  cliStatuses: Awaited<ReturnType<typeof detectCliAuthStatuses>>,
+): AiDetectedAuth[] {
+  return cliStatuses
+    .filter((status) => status.installed)
+    .map((status) => ({
+      type: "cli-subscription" as const,
+      cli: status.cli,
+      path: status.path ?? status.cli,
+      authenticated: status.authenticated,
+      verified: status.verified,
+    }));
+}
+
+async function buildGlobalAiStatus(args?: { force?: boolean }): Promise<AiSettingsStatus> {
+  const cliStatuses = await detectCliAuthStatuses({
+    force: args?.force === true,
+    skipAuthProbe: args?.force !== true,
+  });
+  const providerConnections = await buildProviderConnections(cliStatuses);
+  const hasSubscriptionProvider =
+    providerConnections.claude.authAvailable ||
+    providerConnections.codex.authAvailable ||
+    providerConnections.cursor.authAvailable ||
+    providerConnections.droid.authAvailable ||
+    cliStatuses.some((entry) => entry.installed && (entry.authenticated || !entry.verified));
+
+  return {
+    mode: hasSubscriptionProvider ? "subscription" : "guest",
+    availableProviders: {
+      claude: buildClaudeAvailabilityFromConnection(providerConnections.claude),
+      codex: providerConnections.codex.runtimeAvailable,
+      cursor: providerConnections.cursor.runtimeAvailable,
+      droid: providerConnections.droid.runtimeAvailable,
+    },
+    models: {
+      claude: [],
+      codex: [],
+      cursor: [],
+      droid: [],
+    },
+    detectedAuth: redactedCliAuthFromStatuses(cliStatuses),
+    providerConnections,
+    features: AI_USAGE_FEATURE_KEYS.map((feature) => ({
+      feature,
+      enabled: false,
+      dailyUsage: 0,
+      dailyLimit: null,
+    })),
+    runtimeConnections: {},
+    availableModelIds: [],
+    opencodeBinaryInstalled: false,
+    opencodeBinarySource: "missing",
     opencodeInventoryError: null,
     opencodeProviders: [],
   };
@@ -4139,7 +4254,11 @@ export function registerIpc({
     const ctx = getCtx();
     const aiIntegrationService = ctx.aiIntegrationService;
     if (!aiIntegrationService) {
-      return getUnavailableAiStatus();
+      try {
+        return await buildGlobalAiStatus({ force: arg?.force === true });
+      } catch {
+        return getUnavailableAiStatus();
+      }
     }
     try {
       const status = await aiIntegrationService.getStatus({

--- a/apps/desktop/src/renderer/components/app/App.tsx
+++ b/apps/desktop/src/renderer/components/app/App.tsx
@@ -1027,8 +1027,7 @@ export function App() {
   }, []);
 
   React.useEffect(() => {
-    if (!projectRoot) return;
-    void getAiStatusCached({ projectRoot }).catch(() => undefined);
+    void getAiStatusCached({ projectRoot: projectRoot ?? null }).catch(() => undefined);
   }, [projectRoot]);
 
   React.useEffect(() => {

--- a/apps/desktop/src/renderer/components/app/AppShell.aiStatus.test.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.aiStatus.test.tsx
@@ -231,6 +231,33 @@ describe("AppShell AI provider status", () => {
     });
   });
 
+  it("warms AI status on the main menu before a project is open", async () => {
+    getStatusMock.mockResolvedValue(makeAiStatus(true));
+    (window.ade.app.getWindowSession as any).mockResolvedValue({
+      project: null,
+      binding: null,
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/project"]}>
+        <AppShell>
+          <div>Main menu</div>
+        </AppShell>
+      </MemoryRouter>,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(getStatusMock).toHaveBeenCalledWith({
+      force: false,
+      refreshOpenCodeInventory: false,
+    });
+  });
+
   it("skips shell GitHub auth discovery on remote Work startup", async () => {
     getStatusMock.mockResolvedValue(makeAiStatus(true));
     useAppStore.setState({

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -899,12 +899,13 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     let cancelled = false;
-    if (!currentProjectRoot || !shouldLoadShellAiStatus(location.pathname, isRemoteProject)) {
+    if (!shouldLoadShellAiStatus(location.pathname, isRemoteProject)) {
       setAiStatus(null);
       setAiStatusLoaded(false);
       return;
     }
-    const cachedStatus = peekAiStatusCached(currentProjectRoot);
+    const aiStatusProjectRoot = currentProjectRoot ?? null;
+    const cachedStatus = peekAiStatusCached(aiStatusProjectRoot);
     setAiStatus(cachedStatus);
     setAiStatusLoaded(Boolean(cachedStatus));
 
@@ -915,7 +916,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     const refreshAiStatus = (options: { force?: boolean } = {}) => {
       if (document.visibilityState !== "visible") return;
       const serial = ++refreshSerial;
-      void getAiStatusCached({ projectRoot: currentProjectRoot, force: options.force === true }).then((status) => {
+      void getAiStatusCached({ projectRoot: aiStatusProjectRoot, force: options.force === true }).then((status) => {
         if (cancelled) return;
         if (serial !== refreshSerial) return;
         lastKnownHasProvider = hasConfiguredAiProvider(status);
@@ -957,7 +958,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     });
     const onAiStatusCacheInvalidated = (event: Event) => {
       const detail = (event as CustomEvent<AiStatusCacheInvalidatedEventDetail>).detail;
-      if (detail && !detail.allProjects && detail.projectRoot !== currentProjectRoot) return;
+      if (detail && !detail.allProjects && detail.projectRoot !== aiStatusProjectRoot) return;
       refreshAiStatus({ force: true });
     };
     window.addEventListener(AI_STATUS_CACHE_INVALIDATED_EVENT, onAiStatusCacheInvalidated);

--- a/apps/desktop/src/renderer/components/usage/HeaderUsageControl.tsx
+++ b/apps/desktop/src/renderer/components/usage/HeaderUsageControl.tsx
@@ -5,6 +5,7 @@ import type {
   UsageProvider,
   UsageSnapshot,
 } from "../../../shared/types";
+import { hasLocalProviderConnectionSignal } from "../../lib/aiProviderStatus";
 import { cn } from "../ui/cn";
 import { UsageQuotaPanel } from "./UsageQuotaPanel";
 import { ClaudeLogo, CodexLogo } from "../terminals/ToolLogos";
@@ -262,7 +263,7 @@ export function HeaderUsageControl({
       return providersWithUsage;
     }
     const configuredProviders = TRACKED_PROVIDERS.filter(
-      (provider) => providerConnections[provider]?.usageAvailable || providerConnections[provider]?.authAvailable,
+      (provider) => hasLocalProviderConnectionSignal(providerConnections[provider]),
     );
     return configuredProviders.length > 0 ? configuredProviders : providersWithUsage;
   }, [providerConnections, snapshot?.windows]);

--- a/apps/desktop/src/renderer/components/usage/UsageQuotaPanel.tsx
+++ b/apps/desktop/src/renderer/components/usage/UsageQuotaPanel.tsx
@@ -23,7 +23,7 @@ const PROVIDER_ORDER: UsageProvider[] = ["claude", "codex"];
 
 const PROVIDER_META: Record<UsageProvider, { label: string; color: string }> = {
   claude: { label: "Claude", color: "#D97757" },
-  codex: { label: "Codex", color: providerChatAccent("codex") ?? "#E7E5E4" },
+  codex: { label: "Codex", color: providerChatAccent("codex")! },
   cursor: { label: "Cursor", color: "#00BFA5" },
 };
 

--- a/apps/desktop/src/renderer/components/usage/UsageQuotaPanel.tsx
+++ b/apps/desktop/src/renderer/components/usage/UsageQuotaPanel.tsx
@@ -10,6 +10,9 @@ import type {
   UsageSnapshot,
   UsageWindow,
 } from "../../../shared/types";
+import { hasLocalProviderConnectionSignal } from "../../lib/aiProviderStatus";
+import { providerChatAccent } from "../chat/chatSurfaceTheme";
+import { ClaudeLogo, CodexLogo } from "../terminals/ToolLogos";
 import { cn } from "../ui/cn";
 
 // How long cached numbers may sit before opening the popup quietly refreshes
@@ -20,7 +23,7 @@ const PROVIDER_ORDER: UsageProvider[] = ["claude", "codex"];
 
 const PROVIDER_META: Record<UsageProvider, { label: string; color: string }> = {
   claude: { label: "Claude", color: "#D97757" },
-  codex: { label: "Codex", color: "#5BC98C" },
+  codex: { label: "Codex", color: providerChatAccent("codex") ?? "#E7E5E4" },
   cursor: { label: "Cursor", color: "#00BFA5" },
 };
 
@@ -268,7 +271,7 @@ export function UsageQuotaPanel({
     if (!providerConnections) return PROVIDER_ORDER;
     return PROVIDER_ORDER.filter((provider) => {
       const conn = providerConnection(providerConnections, provider);
-      return conn?.runtimeDetected !== false;
+      return hasLocalProviderConnectionSignal(conn);
     });
   }, [providerConnections]);
 
@@ -500,7 +503,7 @@ function ProviderUsageCard({
     return (
       <div className="rounded-xl px-4 py-3.5 opacity-55" style={CARD_STYLE}>
         <div className="flex items-center justify-between gap-3">
-          <ProviderHeading color={meta.color} label={meta.label} dim />
+          <ProviderHeading provider={provider} color={meta.color} label={meta.label} dim />
           <span className="text-[11px] text-fg/45">{status?.message ?? "Not signed in"}</span>
         </div>
       </div>
@@ -521,7 +524,7 @@ function ProviderUsageCard({
   return (
     <div className="rounded-xl px-4 py-3.5" style={CARD_STYLE}>
       <div className="mb-3 flex items-center justify-between gap-3">
-        <ProviderHeading color={meta.color} label={meta.label} />
+        <ProviderHeading provider={provider} color={meta.color} label={meta.label} />
         {status?.state === "stale" ? (
           <span className="text-[10px] text-amber-300/70" title={status.message ?? "Showing last reading"}>
             stale
@@ -575,13 +578,35 @@ function ProviderUsageCard({
   );
 }
 
-function ProviderHeading({ color, label, dim }: { color: string; label: string; dim?: boolean }) {
+function ProviderHeading({
+  provider,
+  color,
+  label,
+  dim,
+}: {
+  provider: UsageProvider;
+  color: string;
+  label: string;
+  dim?: boolean;
+}) {
+  const Logo = provider === "claude" ? ClaudeLogo : provider === "codex" ? CodexLogo : null;
   return (
     <div className="flex items-center gap-2">
-      <span
-        className="h-2 w-2 shrink-0 rounded-full"
-        style={{ background: color, opacity: dim ? 0.5 : 1, boxShadow: dim ? undefined : `0 0 8px ${color}66` }}
-      />
+      {Logo ? (
+        <Logo
+          size={16}
+          className={cn(
+            "shrink-0",
+            provider === "codex" && "text-zinc-100",
+            dim && "opacity-55",
+          )}
+        />
+      ) : (
+        <span
+          className="h-2 w-2 shrink-0 rounded-full"
+          style={{ background: color, opacity: dim ? 0.5 : 1, boxShadow: dim ? undefined : `0 0 8px ${color}66` }}
+        />
+      )}
       <span className="text-[12.5px] font-semibold tracking-[-0.01em] text-fg">{label}</span>
     </div>
   );
@@ -604,7 +629,7 @@ function ExtraUsageCard({ extra, reducedMotion }: { extra: ExtraUsage; reducedMo
   return (
     <div className="rounded-xl px-4 py-3.5" style={CARD_STYLE}>
       <div className="flex items-center justify-between gap-3">
-        <ProviderHeading color={meta.color} label={`${meta.label} extra usage`} />
+        <ProviderHeading provider={extra.provider} color={meta.color} label={`${meta.label} extra usage`} />
         <span className="text-[11px] tabular-nums text-fg/70">
           {formatUsd(usedUsd)}
           {limitUsd > 0 ? <span className="text-fg/40"> / {formatUsd(limitUsd)}</span> : null}

--- a/apps/desktop/src/renderer/components/usage/usage.test.tsx
+++ b/apps/desktop/src/renderer/components/usage/usage.test.tsx
@@ -252,6 +252,31 @@ describe("usage components", () => {
       expect(screen.queryByText("Claude")).toBeNull();
     });
 
+    it("keeps providers visible when local auth exists before CLI detection warms up", async () => {
+      vi.mocked(window.ade.ai.getStatus).mockResolvedValue(
+        makeAiStatus({
+          claude: makeProviderConnection("claude", {
+            runtimeDetected: false,
+            runtimeAvailable: false,
+            authAvailable: true,
+            usageAvailable: true,
+          }),
+          codex: makeProviderConnection("codex", {
+            runtimeDetected: false,
+            runtimeAvailable: false,
+            authAvailable: true,
+            usageAvailable: true,
+          }),
+        }),
+      );
+
+      render(<UsageQuotaPanel />);
+
+      expect((await screen.findAllByText("Claude")).length).toBeGreaterThan(0);
+      expect((await screen.findAllByText("Codex")).length).toBeGreaterThan(0);
+      expect(screen.queryByText("No provider CLIs detected")).toBeNull();
+    });
+
     it("dims the provider card when the CLI is installed but not signed in", async () => {
       vi.mocked(window.ade.ai.getStatus).mockResolvedValue(
         makeAiStatus({
@@ -321,6 +346,31 @@ describe("usage components", () => {
         expect(window.ade.usage.getSnapshot).toHaveBeenCalled();
         expect(window.ade.ai.getStatus).toHaveBeenCalled();
       });
+    });
+
+    it("shows configured auth-only providers in the main-menu row before usage windows load", async () => {
+      vi.mocked(window.ade.usage.getSnapshot).mockResolvedValue(makeEmptySnapshot());
+      vi.mocked(window.ade.ai.getStatus).mockResolvedValue(
+        makeAiStatus({
+          claude: makeProviderConnection("claude", {
+            runtimeDetected: false,
+            runtimeAvailable: false,
+            authAvailable: true,
+            usageAvailable: true,
+          }),
+          codex: makeProviderConnection("codex", {
+            runtimeDetected: false,
+            runtimeAvailable: false,
+            authAvailable: true,
+            usageAvailable: true,
+          }),
+        }),
+      );
+
+      render(<HeaderUsageControl variant="menu-row" />);
+
+      expect(await screen.findByRole("menuitem", { name: /Claude/ })).toBeTruthy();
+      expect(screen.getByRole("menuitem", { name: /Codex/ })).toBeTruthy();
     });
 
     it("applies pushed usage updates without forcing a refresh", async () => {

--- a/apps/desktop/src/renderer/lib/aiProviderStatus.ts
+++ b/apps/desktop/src/renderer/lib/aiProviderStatus.ts
@@ -36,6 +36,17 @@ function hasUsableProviderConnection(
   return Boolean(connection?.authAvailable || connection?.runtimeAvailable);
 }
 
+export function hasLocalProviderConnectionSignal(
+  connection: AiProviderConnectionStatus | null | undefined,
+): boolean {
+  return Boolean(
+    connection?.authAvailable ||
+    connection?.usageAvailable ||
+    connection?.runtimeDetected ||
+    connection?.runtimeAvailable,
+  );
+}
+
 function hasUsableRuntimeConnection(
   connection: AiRuntimeConnectionStatus | null | undefined,
 ): boolean {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1032,7 +1032,7 @@ Post-packaging hardening (`apps/desktop/scripts/`):
 - **IPC tracing** — every handler emits `ipc.invoke.begin` / `ipc.invoke.done` / `ipc.invoke.failed` with call ID, channel, window ID, duration, summarized args. Mandatory for new handlers.
 - **Renderer lifecycle** — `renderer.route_change`, `renderer.tab_change`, `renderer.window_error`, `renderer.unhandled_rejection`, `renderer.event_loop_stall`. Mandatory for new surfaces that introduce novel lifecycle transitions.
 - **Startup tasks** — `project.startup_task_enabled`, `project.startup_task_skipped`, `project.startup_task_begin`, `project.startup_task_done` with durations.
-- **Usage tracking** — `usageTrackingService.ts` + `usage/ledgers/*` + `budgetCapService.ts` account for tokens and cost per provider/model/call-type; surfaced in the top-bar Usage popup (`HeaderUsageControl` → `UsageQuotaPanel` + collapsible `BudgetCapEditor`).
+- **Usage tracking** — `usageTrackingService.ts` + `usage/ledgers/*` + `budgetCapService.ts` account for tokens and cost per provider/model/call-type; surfaced in the top-bar Usage popup (`HeaderUsageControl` → `UsageQuotaPanel` + collapsible `BudgetCapEditor`). `main.ts` keeps a dormant usage tracker alive while no project context is open so the main menu can show provider usage from machine-level Claude/Codex auth, then pauses it while project-scoped contexts own polling.
 - **Local perf runs** — `scripts/perf-launch.mjs` / `scripts/run-perf-scenario.mjs` launch ADE with a run id, feed renderer scenarios, and collect JSONL events plus `summary.json` under `~/.ade/perf-runs/<runId>/`. This is local-only diagnostics, not external telemetry.
 - **No external telemetry** — ADE does not ship analytics to any cloud service. All telemetry is local.
 


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fusage-panel-top-right-ade-0263e310 num=576 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fusage-panel-top-right-ade-0263e310&amp;pr=576">ade/usage-panel-top-right-ade-0263e310 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=576">PR #576</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI provider status detection now initializes earlier in the app, enabling visibility before a project is open.
  * Provider logos for Claude and Codex now appear in the usage panel for clearer visual identification.

* **Bug Fixes**
  * Improved detection reliability for AI provider availability when switching between projects.
  * Enhanced visibility logic for locally configured authentication providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables the usage panel and AI provider status to appear in the top-right area of the main menu before any project is opened, by lifting those signals to machine-level detection.

- A dormant `usageTrackingService` is kept alive in `createDormantProjectContext` while no project context is active, and `syncDormantUsageTrackingState` starts/stops it around project open/close events; a stale-broadcast guard in the `onUpdate` closure prevents replaced services from emitting.
- `buildGlobalAiStatus` in `registerIpc.ts` provides a machine-level `AiSettingsStatus` (provider connections, auth mode, detected CLIs) when no `aiIntegrationService` exists, falling back to `getUnavailableAiStatus` on error.
- `hasLocalProviderConnectionSignal` broadens the provider-visibility predicate to include `usageAvailable` and `runtimeDetected`, ensuring auth-only providers are displayed before CLI detection completes; `UsageQuotaPanel` and `HeaderUsageControl` both adopt this predicate.
- Provider headings in `UsageQuotaPanel` now render `ClaudeLogo`/`CodexLogo` instead of the colored dot for known providers, with the Codex color sourced from `providerChatAccent`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the dormant service lifecycle, stale-broadcast guard, and global AI status fallback are all correctly scoped and covered by new tests.

The main-process changes introduce a well-guarded dormant usage tracker that stops when any project context opens and restarts when the last one closes. The onUpdate closure compares service identity against the live dormant context to prevent stale broadcasts after a context swap. The IPC fallback for machine-level AI status catches all exceptions and degrades gracefully. Renderer changes (AppShell guard removal, hasLocalProviderConnectionSignal) are matched by two new test cases that confirm auth-only providers remain visible before CLI detection warms up. No incorrect data flows or uncovered error paths were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/main.ts | Adds dormant usage tracking service that runs while no project is open; uses replaceDormantContext helper and syncDormantUsageTrackingState to correctly start/stop around project lifecycle events. The stale-broadcast guard in the onUpdate callback is well-implemented. |
| apps/desktop/src/main/services/ipc/registerIpc.ts | Adds buildGlobalAiStatus as a machine-level fallback when no project context is open; builds from detectCliAuthStatuses and buildProviderConnections, with a try/catch fallback to getUnavailableAiStatus. Intentionally omits project-scoped data (features, usage, models). |
| apps/desktop/src/renderer/lib/aiProviderStatus.ts | Adds hasLocalProviderConnectionSignal, a broader visibility predicate that includes usageAvailable and runtimeDetected alongside the existing authAvailable/runtimeAvailable checks. |
| apps/desktop/src/renderer/components/usage/UsageQuotaPanel.tsx | Replaces colored dot with ClaudeLogo/CodexLogo in ProviderHeading; switches provider visibility filter from runtimeDetected !== false to hasLocalProviderConnectionSignal; updates Codex color to use providerChatAccent. |
| apps/desktop/src/renderer/components/usage/HeaderUsageControl.tsx | Updates configuredProviders filter to use hasLocalProviderConnectionSignal, improving visibility for auth-only providers before CLI detection warms up. |
| apps/desktop/src/renderer/components/app/AppShell.tsx | Removes the currentProjectRoot guard on the AI status load effect, enabling status refresh before a project opens; passes null as projectRoot when no project is selected. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Renderer (App/AppShell)
    participant IPC as IPC Handler
    participant DormantCtx as Dormant Context
    participant ProjCtx as Project Context

    Note over App,DormantCtx: No project open
    App->>IPC: getAiStatus(projectRoot: null)
    IPC->>IPC: buildGlobalAiStatus()
    IPC-->>App: AiSettingsStatus (machine-level signals)
    DormantCtx->>DormantCtx: usageTrackingService.start()
    DormantCtx-->>App: broadcast(usageEvent, snapshot)

    Note over App,ProjCtx: Project opened
    App->>IPC: openProject(root)
    IPC->>ProjCtx: createProjectContext(root)
    IPC->>DormantCtx: syncDormantUsageTrackingState()
    DormantCtx->>DormantCtx: usageTrackingService.stop()
    ProjCtx-->>App: broadcast(usageEvent, snapshot)

    Note over App,DormantCtx: Project closed
    IPC->>ProjCtx: disposeContextResources()
    IPC->>DormantCtx: syncDormantUsageTrackingState()
    DormantCtx->>DormantCtx: usageTrackingService.start()
    DormantCtx-->>App: broadcast(usageEvent, snapshot)
```

<sub>Reviews (2): Last reviewed commit: ["Address usage panel review feedback"](https://github.com/arul28/ade/commit/9dcfe284ad8da0c28858bd5d256d1397c447b292) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37547555)</sub>

<!-- /greptile_comment -->