### PR TITLE
fix(chat): load user MCP servers in Claude chats (parity with CLI)

### DIFF
--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -2454,6 +2454,10 @@ describe("createAgentChatService", () => {
 
       const opts = vi.mocked(claudeSdkCreateSessionCompat).mock.calls[0]?.[0] as any;
       expect(opts?.mcpServers?.["ade-orchestration"]).toBeUndefined();
+      // Regression guard (removed base MCP lock): a draft lead has no managed MCP block
+      // yet, so strictMcpConfig must isolate it — user/project MCP servers must not restore
+      // tool capability the read-only lead is denied.
+      expect(opts?.strictMcpConfig).toBe(true);
       expect(opts?.disallowedTools).toEqual(expect.arrayContaining([
         "Agent",
         "Bash",
@@ -2491,6 +2495,9 @@ describe("createAgentChatService", () => {
       });
 
       const opts = vi.mocked(claudeSdkCreateSessionCompat).mock.calls[0]?.[0] as any;
+      // Role-marked lead (no interactionMode, no bundle) is still a read-only lead, so it
+      // must be MCP-isolated too (regression guard for the removed base MCP lock).
+      expect(opts?.strictMcpConfig).toBe(true);
       expect(opts?.disallowedTools).toEqual(expect.arrayContaining([
         "Agent",
         "Bash",

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -2323,6 +2323,7 @@ describe("createAgentChatService", () => {
       const opts = vi.mocked(claudeSdkCreateSessionCompat).mock.calls[0]?.[0] as {
         managedSettings?: Record<string, unknown>;
         settingSources?: string[];
+        strictMcpConfig?: boolean;
       } | undefined;
       expect(opts).toBeTruthy();
       // Project/user setting sources stay enabled so the SDK reads the user's
@@ -2332,6 +2333,9 @@ describe("createAgentChatService", () => {
       // and it no longer locks MCP to managed-only — so the user's servers can load.
       expect(opts).not.toHaveProperty("mcpServers");
       expect(opts?.managedSettings).toBeUndefined();
+      // Inverse of the lightweight test: strictMcpConfig must NOT leak into normal
+      // chats, or it would silently re-block the user's MCP servers we just enabled.
+      expect(opts?.strictMcpConfig).toBeUndefined();
     });
 
     it("keeps lightweight sessions lean by ignoring on-disk MCP config (strictMcpConfig)", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -2291,7 +2291,7 @@ describe("createAgentChatService", () => {
       ]);
     });
 
-    it("disables Claude MCP while keeping project setting source enabled", async () => {
+    it("loads user/project MCP servers in normal chats (no managed-only lock)", async () => {
       fs.writeFileSync(path.join(tmpRoot, ".mcp.json"), JSON.stringify({
         mcpServers: {
           projectTools: {
@@ -2325,13 +2325,57 @@ describe("createAgentChatService", () => {
         settingSources?: string[];
       } | undefined;
       expect(opts).toBeTruthy();
+      // Project/user setting sources stay enabled so the SDK reads the user's
+      // configured MCP servers (.mcp.json / ~/.claude.json) — same as a terminal session.
       expect(opts?.settingSources).toEqual(expect.arrayContaining(["project"]));
+      // ADE does not inject mcpServers into a normal chat (only orchestration does),
+      // and it no longer locks MCP to managed-only — so the user's servers can load.
       expect(opts).not.toHaveProperty("mcpServers");
-      expect(opts?.managedSettings).toMatchObject({
-        allowedMcpServers: [],
-        allowManagedMcpServersOnly: true,
-        strictPluginOnlyCustomization: ["mcp"],
+      expect(opts?.managedSettings).toBeUndefined();
+    });
+
+    it("keeps lightweight sessions lean by ignoring on-disk MCP config (strictMcpConfig)", async () => {
+      fs.writeFileSync(path.join(tmpRoot, ".mcp.json"), JSON.stringify({
+        mcpServers: {
+          projectTools: {
+            command: "node",
+            args: ["mcp-server.js"],
+          },
+        },
+      }));
+      vi.mocked(claudeSdkCreateSessionCompat).mockReturnValue({
+        send: vi.fn(),
+        stream: vi.fn(async function* () {
+          return;
+        }),
+        close: vi.fn(),
+        sessionId: "sdk-session-light-mcp",
+      } as any);
+
+      const { service } = createService();
+      await service.createSession({
+        laneId: "lane-1",
+        provider: "claude",
+        model: "sonnet",
+        sessionProfile: "light",
       });
+
+      await vi.waitFor(() => {
+        expect(claudeSdkCreateSessionCompat).toHaveBeenCalled();
+      });
+
+      const opts = vi.mocked(claudeSdkCreateSessionCompat).mock.calls[0]?.[0] as {
+        strictMcpConfig?: boolean;
+        managedSettings?: Record<string, unknown>;
+        settingSources?: string[];
+      } | undefined;
+      expect(opts).toBeTruthy();
+      // Lightweight side-jobs (auto-title / lane-naming) don't get settingSources,
+      // and the SDK loads all MCP sources when unconstrained — so strictMcpConfig must
+      // be set to keep them from spawning the user's whole MCP fleet for a trivial job.
+      expect(opts?.settingSources).toBeUndefined();
+      expect(opts?.strictMcpConfig).toBe(true);
+      expect(opts?.managedSettings).toBeUndefined();
     });
 
     it("attaches ADE orchestration tools to Claude lead sessions through an SDK MCP server", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -16948,7 +16948,12 @@ export function createAgentChatService(args: {
       // Lightweight side-jobs (auto-title / lane-naming) get no settingSources, and the
       // SDK loads all MCP sources when unconstrained — so keep them lean with
       // strictMcpConfig (ignores on-disk .mcp.json / user MCP), preserving prior behavior.
-      ...(lightweight ? { strictMcpConfig: true } : {}),
+      // Orchestration LEAD sessions are read-only planners (their direct Claude tools are
+      // denied below); isolate their MCP the same way so user/project MCP servers can't
+      // hand a draft lead (no bundle yet → orchestration block skipped) tool capability
+      // back. Workers/validators do real work and keep user MCP. strictMcpConfig still
+      // permits the programmatic orchestration MCP server added below for bundled leads.
+      ...((lightweight || isOrchestrationLeadSession(managed.session)) ? { strictMcpConfig: true } : {}),
       settings: {
         outputStyle,
         enabledPlugins: CLAUDE_SESSION_DISABLED_PLUGINS,

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -16937,11 +16937,18 @@ export function createAgentChatService(args: {
       cwd: managed.laneWorktreePath,
       env: claudeEnv,
       pathToClaudeCodeExecutable: claudeExecutable.path,
-      managedSettings: {
-        allowedMcpServers: [],
-        allowManagedMcpServersOnly: true,
-        strictPluginOnlyCustomization: ["mcp"],
-      },
+      // User-configured MCP servers (~/.claude.json, project .mcp.json) load via
+      // settingSources below, matching a terminal `claude` session. We previously
+      // locked this to managed-only (allowManagedMcpServersOnly + empty allowlist) as
+      // a context/perf trim in #294, but that silently stripped the user's MCP tools
+      // from chats — e.g. iOS-automation servers — making the SDK chat strictly less
+      // capable than an `ade` CLI session for the same task. ENABLE_TOOL_SEARCH now
+      // keeps large tool catalogs cheap, so the trim is no longer worth the capability
+      // loss. Orchestration sessions re-apply managed-only isolation in their own block.
+      // Lightweight side-jobs (auto-title / lane-naming) get no settingSources, and the
+      // SDK loads all MCP sources when unconstrained — so keep them lean with
+      // strictMcpConfig (ignores on-disk .mcp.json / user MCP), preserving prior behavior.
+      ...(lightweight ? { strictMcpConfig: true } : {}),
       settings: {
         outputStyle,
         enabledPlugins: CLAUDE_SESSION_DISABLED_PLUGINS,


### PR DESCRIPTION
## What

ADE's Work-tab Claude **chat** (Agent SDK) locked MCP to managed-only
(`allowManagedMcpServersOnly: true` + empty `allowedMcpServers`) — a context/perf
trim from #294. That silently stripped the user's configured MCP servers
(`~/.claude.json`, project `.mcp.json`) from chats, making the SDK chat strictly
**less capable than an `ade` CLI session** for the same task (e.g. iOS
automation / WebDriverAgent, where an Xcode/Appium MCP would be present in the
CLI but absent in the chat).

## Why now

`ENABLE_TOOL_SEARCH` now defers large tool catalogs on demand, so the original
context/perf rationale for the lock no longer outweighs the capability loss.

## Change

- Remove the unconditional managed-only MCP lock in `buildClaudeQueryOptions` so
  normal chats load the user's MCP servers via `settingSources` — parity with a
  terminal/CLI `claude` session.
- Keep lightweight side-jobs (auto-title / lane-naming) lean via `strictMcpConfig`
  (they have no `settingSources`, and the SDK loads all MCP sources when
  unconstrained — this preserves their pre-change behavior).
- **Orchestration sessions are unchanged** — they re-apply managed-only isolation
  in their own block.

## Tests

- Updated the test that pinned the old lock → now asserts `managedSettings`
  undefined + project setting source enabled (user MCP loadable).
- Added a regression test: lightweight session → `strictMcpConfig: true`.
- Full `agentChatService.test.ts` green (425 tests); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected MCP server configuration handling for chat sessions; lightweight sessions now properly ignore on-disk configurations while standard sessions maintain expected setting sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the blanket managed-only MCP lock (`allowManagedMcpServersOnly: true` + empty `allowedMcpServers`) that was previously applied to every Claude chat session, restoring parity between SDK chats and terminal `claude` sessions for user-configured MCP servers. The rationale (context/perf savings) is superseded by `ENABLE_TOOL_SEARCH`.

- **Normal chats** now load `~/.claude.json` and project `.mcp.json` servers via `settingSources`; `managedSettings` is no longer injected at the base level.
- **Lightweight sessions** (auto-title / lane-naming) and **orchestration lead sessions** (read-only planners) receive `strictMcpConfig: true` to keep them from spawning the user's full MCP fleet; bundled leads additionally retain the orchestration block's `allowManagedMcpServersOnly` constraint.
- Test suite is updated with symmetric assertions: normal chats assert `strictMcpConfig` is absent; lightweight and lead sessions assert it is present.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is well-scoped and all three session categories (normal, lightweight, orchestration lead) are correctly handled with matching test coverage.

The removed managed-only lock is cleanly replaced by a targeted strictMcpConfig spread that only fires for lightweight and orchestration-lead sessions. Normal chats regain user MCP access through settingSources, which is the intended parity. Bundled orchestration leads still receive the existing allowManagedMcpServersOnly guard from the orchestration block. The symmetry is verified by new regression tests in both directions.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/chat/agentChatService.ts | Removes the unconditional managed-only MCP lock from buildClaudeQueryOptions; replaces it with a conditional strictMcpConfig: true spread for lightweight sessions and orchestration-lead sessions, while normal chats now load user/project MCP servers via settingSources. |
| apps/desktop/src/main/services/chat/agentChatService.test.ts | Updates the existing MCP-lock test to verify the lock is gone and strictMcpConfig is absent in normal chats; adds regression tests for lightweight sessions (strictMcpConfig: true) and read-only orchestration leads (strictMcpConfig: true). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildClaudeQueryOptions] --> B{isLightweightSession?}
    B -- Yes --> C[strictMcpConfig: true\nno settingSources]
    B -- No --> D{isOrchestrationLeadSession?}
    D -- Yes --> E[strictMcpConfig: true\nsettingSources: user/project/local\ndisallowedTools applied]
    D -- No --> F[Normal chat\nsettingSources: user/project/local\nuser MCP servers load]
    E --> G{orchestrationMcpServer exists?}
    F --> G
    G -- Yes --> H[managedSettings:\nallowManagedMcpServersOnly: true\nallowedMcpServers: orch-server only]
    G -- No --> I[no managedSettings\nstrictMcpConfig alone guards leads]
```

<sub>Reviews (3): Last reviewed commit: ["ship: iter 2 — isolate MCP for orchestra..."](https://github.com/arul28/ade/commit/cde738afa9030ccdf8b2bc222da95e69a716ad4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37652606)</sub>

<!-- /greptile_comment -->