### PR TITLE
Fix mobile sync project identity aliases

### DIFF
--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -1252,6 +1252,7 @@ export async function createAdeRuntime(args: {
       db,
       logger,
       projectId: resolvedArgs.syncRuntime.registryProjectId ?? projectId,
+      runtimeProjectId: projectId,
       projectRoot,
       appVersion: resolvedArgs.syncRuntime.appVersion ?? "ade-cli",
       runtimeKind: resolvedArgs.syncRuntime.runtimeKind ?? "headless",

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -65,6 +65,8 @@ import {
 } from "../../desktop/src/shared/cliLaunch";
 import type {
   SyncMobileProjectSummary,
+  SyncProjectForgetRequestPayload,
+  SyncProjectForgetResultPayload,
   SyncProjectOpenRequestPayload,
   SyncProjectSwitchRequestPayload,
   SyncProjectSwitchResultPayload,
@@ -13128,6 +13130,56 @@ async function runServe(
       await createHeadlessProjectScaffoldService().cloneRepository(input);
     return await registerHeadlessMobileProject(result.rootPath);
   };
+  const resolveHeadlessMobileProjectRequest = (
+    input: SyncProjectForgetRequestPayload | SyncProjectSwitchRequestPayload,
+  ): {
+    requestedId: string;
+    requestedRootPath: string;
+    record: ProjectRecord | null;
+  } => {
+    const requestedId =
+      typeof input.projectId === "string" && input.projectId.trim()
+        ? input.projectId.trim()
+        : "";
+    const requestedRootPath =
+      typeof input.rootPath === "string" && input.rootPath.trim()
+        ? path.resolve(input.rootPath)
+        : "";
+    const record =
+      projectRegistry
+        .list()
+        .find(
+          (candidate) =>
+            (requestedId.length > 0 && candidate.projectId === requestedId) ||
+            (requestedRootPath.length > 0 && path.resolve(candidate.rootPath) === requestedRootPath),
+        ) ?? null;
+    return { requestedId, requestedRootPath, record };
+  };
+  const forgetHeadlessMobileProject = async (
+    input: SyncProjectForgetRequestPayload,
+  ): Promise<SyncProjectForgetResultPayload> => {
+    const { requestedId, requestedRootPath, record } = resolveHeadlessMobileProjectRequest(input);
+    if (!requestedId && !requestedRootPath) {
+      return {
+        ok: false,
+        message: "Project id or path is required.",
+      };
+    }
+    if (!record) {
+      return {
+        ok: true,
+        message: "Project is already removed from this ADE machine.",
+        projectId: requestedId || null,
+        rootPath: requestedRootPath || null,
+      };
+    }
+    projectRegistry.remove(record.projectId);
+    return {
+      ok: true,
+      projectId: record.projectId,
+      rootPath: record.rootPath,
+    };
+  };
   const machineProjectCatalogProvider: SyncProjectCatalogProvider = {
     listProjects: async () => ({
       projects: projectRegistry
@@ -13140,24 +13192,7 @@ async function runServe(
     prepareProjectConnection: async (
       request: SyncProjectSwitchRequestPayload,
     ): Promise<SyncProjectSwitchResultPayload> => {
-      const requestedId =
-        typeof request.projectId === "string"
-          ? request.projectId.trim()
-          : "";
-      const requestedRootPath =
-        typeof request.rootPath === "string"
-          ? path.resolve(request.rootPath)
-          : "";
-      const record =
-        projectRegistry
-          .list()
-          .find(
-            (candidate) =>
-              (requestedId.length > 0 &&
-                candidate.projectId === requestedId) ||
-              (requestedRootPath.length > 0 &&
-                path.resolve(candidate.rootPath) === requestedRootPath),
-          ) ?? null;
+      const { record } = resolveHeadlessMobileProjectRequest(request);
       const project = record
         ? toMobileProjectSummary(record, { isOpen: true })
         : null;
@@ -13253,6 +13288,7 @@ async function runServe(
     openProject: openHeadlessMobileProject,
     createProject: createHeadlessMobileProject,
     cloneProject: cloneHeadlessMobileProject,
+    forgetProject: forgetHeadlessMobileProject,
     listMyGitHubRepos: async (input: ListMyGitHubReposInput) =>
       createHeadlessProjectScaffoldService().listMyGitHubRepos(input),
   };

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -13136,6 +13136,7 @@ async function runServe(
     requestedId: string;
     requestedRootPath: string;
     record: ProjectRecord | null;
+    conflict: boolean;
   } => {
     const requestedId =
       typeof input.projectId === "string" && input.projectId.trim()
@@ -13145,24 +13146,32 @@ async function runServe(
       typeof input.rootPath === "string" && input.rootPath.trim()
         ? path.resolve(input.rootPath)
         : "";
-    const record =
-      projectRegistry
-        .list()
-        .find(
-          (candidate) =>
-            (requestedId.length > 0 && candidate.projectId === requestedId) ||
-            (requestedRootPath.length > 0 && path.resolve(candidate.rootPath) === requestedRootPath),
-        ) ?? null;
-    return { requestedId, requestedRootPath, record };
+    const records = projectRegistry.list();
+    const idRecord =
+      requestedId.length > 0
+        ? records.find((candidate) => candidate.projectId === requestedId) ?? null
+        : null;
+    const rootRecord =
+      requestedRootPath.length > 0
+        ? records.find((candidate) => path.resolve(candidate.rootPath) === requestedRootPath) ?? null
+        : null;
+    const conflict = Boolean(idRecord && rootRecord && idRecord.projectId !== rootRecord.projectId);
+    return { requestedId, requestedRootPath, record: conflict ? null : idRecord ?? rootRecord, conflict };
   };
   const forgetHeadlessMobileProject = async (
     input: SyncProjectForgetRequestPayload,
   ): Promise<SyncProjectForgetResultPayload> => {
-    const { requestedId, requestedRootPath, record } = resolveHeadlessMobileProjectRequest(input);
+    const { requestedId, requestedRootPath, record, conflict } = resolveHeadlessMobileProjectRequest(input);
     if (!requestedId && !requestedRootPath) {
       return {
         ok: false,
         message: "Project id or path is required.",
+      };
+    }
+    if (conflict) {
+      return {
+        ok: false,
+        message: "projectId and rootPath refer to different projects.",
       };
     }
     if (!record) {
@@ -13173,8 +13182,16 @@ async function runServe(
         rootPath: requestedRootPath || null,
       };
     }
-    await scopeRegistry.dispose(record.projectId);
     projectRegistry.remove(record.projectId);
+    const disposeTimer = setImmediate(() => {
+      void scopeRegistry.dispose(record.projectId).catch((error) => {
+        headlessProjectLogger.warn("headless_project_forget_dispose_failed", {
+          projectId: record.projectId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    });
+    disposeTimer.unref?.();
     return {
       ok: true,
       projectId: record.projectId,
@@ -13193,10 +13210,17 @@ async function runServe(
     prepareProjectConnection: async (
       request: SyncProjectSwitchRequestPayload,
     ): Promise<SyncProjectSwitchResultPayload> => {
-      const { record } = resolveHeadlessMobileProjectRequest(request);
+      const { record, conflict } = resolveHeadlessMobileProjectRequest(request);
       const project = record
         ? toMobileProjectSummary(record, { isOpen: true })
         : null;
+      if (conflict) {
+        return {
+          ok: false,
+          message: "projectId and rootPath refer to different projects.",
+          project,
+        };
+      }
       if (!record) {
         return {
           ok: false,

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -13173,6 +13173,7 @@ async function runServe(
         rootPath: requestedRootPath || null,
       };
     }
+    await scopeRegistry.dispose(record.projectId);
     projectRegistry.remove(record.projectId);
     return {
       ok: true,

--- a/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
+++ b/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
@@ -12,6 +12,8 @@ import type {
   SyncMobileProjectSummary,
   SyncPairingRequestPayload,
   SyncPeerMetadata,
+  SyncProjectForgetRequestPayload,
+  SyncProjectForgetResultPayload,
   SyncProjectCatalogPayload,
   SyncProjectOpenRequestPayload,
   SyncProjectSwitchRequestPayload,
@@ -387,6 +389,30 @@ export function createBrainProjectActionsSyncHandler(
               message: error instanceof Error ? error.message : String(error),
             }, envelope.requestId);
           }
+        }
+        break;
+      }
+      case "project_forget_request": {
+        if (!args.projectCatalogProvider.forgetProject) {
+          send(peer.ws, "project_forget_result", {
+            ok: false,
+            message: "Removing projects is not available from this machine.",
+          } satisfies SyncProjectForgetResultPayload, envelope.requestId);
+          break;
+        }
+        try {
+          const result = await args.projectCatalogProvider.forgetProject(
+            (envelope.payload ?? {}) as SyncProjectForgetRequestPayload,
+          );
+          send(peer.ws, "project_forget_result", result, envelope.requestId);
+          if (result.ok) {
+            send(peer.ws, "project_catalog", await projectCatalog(args.projectCatalogProvider, args.logger));
+          }
+        } catch (error) {
+          send(peer.ws, "project_forget_result", {
+            ok: false,
+            message: error instanceof Error ? error.message : String(error),
+          } satisfies SyncProjectForgetResultPayload, envelope.requestId);
         }
         break;
       }

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -117,6 +117,19 @@ describe("resolveSyncHostInboundProjectScope", () => {
     });
   });
 
+  it("accepts project-scoped envelopes that use the hosted DB project id alias", () => {
+    expect(resolveSyncHostInboundProjectScope(
+      "changeset_ack",
+      "24b96ceb-7ff6-4852-af99-2c36ffa6e9bf",
+      "project_80c9b7785de5e4060adf68c2",
+      ["24b96ceb-7ff6-4852-af99-2c36ffa6e9bf"],
+    )).toEqual({
+      ok: true,
+      projectId: "project_80c9b7785de5e4060adf68c2",
+      usedSingleProjectFallback: false,
+    });
+  });
+
   it("rejects project-scoped envelopes for a different active project", () => {
     expect(resolveSyncHostInboundProjectScope("changeset_ack", "project-2", "project-1")).toMatchObject({
       ok: false,

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -46,6 +46,8 @@ import type {
   SyncProjectOpenRequestPayload,
   SyncProjectCatalogChunkPayload,
   SyncProjectCatalogPayload,
+  SyncProjectForgetRequestPayload,
+  SyncProjectForgetResultPayload,
   SyncProjectSwitchRequestPayload,
   SyncProjectSwitchResultPayload,
   ListMyGitHubReposInput,
@@ -353,12 +355,14 @@ export type SyncProjectCatalogProvider = {
   createProject?: (args: CreateProjectInput) => Promise<SyncMobileProjectSummary>;
   cloneProject?: (args: CloneProjectInput) => Promise<SyncMobileProjectSummary>;
   listMyGitHubRepos?: (args: ListMyGitHubReposInput) => Promise<ListMyGitHubReposResult>;
+  forgetProject?: (args: SyncProjectForgetRequestPayload) => Promise<SyncProjectForgetResultPayload>;
 };
 
 type SyncHostServiceArgs = {
   db: AdeDb;
   logger: Logger;
   projectId?: string | null;
+  projectIdAliases?: string[];
   projectRoot: string;
   fileService: ReturnType<typeof createFileService>;
   laneService: ReturnType<typeof createLaneService>;
@@ -570,10 +574,22 @@ type SyncHostProjectScopeResolution =
       receivedProjectId: string | null;
     };
 
+function projectIdMatchesHost(
+  receivedProjectId: string | null | undefined,
+  hostProjectId: string | null | undefined,
+  hostProjectIdAliases: readonly (string | null | undefined)[] = [],
+): boolean {
+  const received = toOptionalString(receivedProjectId);
+  const host = toOptionalString(hostProjectId);
+  if (!received || !host) return false;
+  return received === host || hostProjectIdAliases.some((alias) => toOptionalString(alias) === received);
+}
+
 export function resolveSyncHostInboundProjectScope(
   type: SyncEnvelope["type"],
   receivedProjectId: string | null | undefined,
   hostProjectId: string | null | undefined,
+  hostProjectIdAliases: readonly (string | null | undefined)[] = [],
 ): SyncHostProjectScopeResolution {
   if (!SYNC_HOST_PROJECT_SCOPED_INBOUND_ENVELOPE_TYPES.has(type)) {
     return { ok: true, projectId: null, usedSingleProjectFallback: false };
@@ -593,7 +609,7 @@ export function resolveSyncHostInboundProjectScope(
   if (!received) {
     return { ok: true, projectId: host, usedSingleProjectFallback: true };
   }
-  if (received !== host) {
+  if (!projectIdMatchesHost(received, host, hostProjectIdAliases)) {
     return {
       ok: false,
       code: "project_mismatch",
@@ -989,6 +1005,11 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
   const maxChangesetBatchRows = DEFAULT_MAX_CHANGESET_BATCH_ROWS;
   const maxProjectCatalogEnvelopeBytes = MAX_PROJECT_CATALOG_ENVELOPE_BYTES;
   const maxProjectCatalogChunkBytes = 192 * 1024;
+  const hostProjectIdAliases = uniqueStrings(
+    (args.projectIdAliases ?? [])
+      .map((alias) => toOptionalString(alias))
+      .filter((alias): alias is string => Boolean(alias) && alias !== toOptionalString(args.projectId)),
+  );
   const localPresenceCommandDescriptors: SyncRemoteCommandDescriptor[] = [
     {
       action: "lanes.presence.announce",
@@ -2479,6 +2500,32 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     }
   }
 
+  async function handleProjectForgetRequest(
+    peer: PeerState,
+    requestId: string | null | undefined,
+    payload: SyncProjectForgetRequestPayload | null,
+  ): Promise<void> {
+    if (!args.projectCatalogProvider?.forgetProject) {
+      sendRequired(peer, "project_forget_result", {
+        ok: false,
+        message: "Removing projects is not available from this machine.",
+      } satisfies SyncProjectForgetResultPayload, requestId);
+      return;
+    }
+    try {
+      const result = await args.projectCatalogProvider.forgetProject(payload ?? {});
+      sendRequired(peer, "project_forget_result", result, requestId);
+      if (result.ok) {
+        broadcastProjectCatalogToConnectedPeers(await buildProjectCatalogPayload());
+      }
+    } catch (error) {
+      sendRequired(peer, "project_forget_result", {
+        ok: false,
+        message: error instanceof Error ? error.message : String(error),
+      } satisfies SyncProjectForgetResultPayload, requestId);
+    }
+  }
+
   function broadcastProjectCatalogToConnectedPeers(
     projectCatalog: SyncProjectCatalogPayload,
   ): void {
@@ -3056,7 +3103,10 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     const commandId = toOptionalString(payload.commandId) ?? requestId ?? `cmd-${Date.now()}`;
     const requestedProjectId = toOptionalString(payload.projectId);
     const hostProjectId = toOptionalString(args.projectId);
-    const commandScopeKey = requestedProjectId ?? hostProjectId ?? args.projectRoot;
+    const matchesHostProject = projectIdMatchesHost(requestedProjectId, hostProjectId, hostProjectIdAliases);
+    const commandScopeKey = matchesHostProject
+      ? hostProjectId ?? args.projectRoot
+      : requestedProjectId ?? hostProjectId ?? args.projectRoot;
     const commandCacheKey = mobileCommandCacheKey(commandScopeKey, peer, commandId);
     const commandArgsKey = stableJsonKey(payload.args ?? {});
     const commandArgsFingerprint = mobileCommandArgsFingerprint(commandArgsKey);
@@ -3154,8 +3204,8 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     const shouldRouteToProject =
       Boolean(args.remoteCommandExecutor)
       && Boolean(requestedProjectId)
-      && requestedProjectId !== hostProjectId;
-    if (requestedProjectId && hostProjectId && requestedProjectId !== hostProjectId && !shouldRouteToProject) {
+      && !matchesHostProject;
+    if (requestedProjectId && hostProjectId && !matchesHostProject && !shouldRouteToProject) {
       reject("This ADE machine is hosting a different project. Select the project again and retry.", "project_not_open");
       return;
     }
@@ -3190,7 +3240,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       return;
     }
     if (payload.action === "lanes.presence.announce" || payload.action === "lanes.presence.release") {
-      if (requestedProjectId && hostProjectId && requestedProjectId !== hostProjectId) {
+      if (requestedProjectId && hostProjectId && !matchesHostProject) {
         reject("Lane presence is not available for a project that is not open in this phone sync host.", "project_not_open");
         return;
       }
@@ -3272,7 +3322,10 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       const executor = shouldRouteToProject && args.remoteCommandExecutor
         ? args.remoteCommandExecutor
         : remoteCommandService;
-      const created = await executor.execute(payload);
+      const routedPayload = matchesHostProject && hostProjectId
+        ? { ...payload, projectId: hostProjectId }
+        : payload;
+      const created = await executor.execute(routedPayload);
       sendResult(acceptedRecord, {
         commandId,
         ok: true,
@@ -3553,7 +3606,12 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       return;
     }
 
-    const projectScope = resolveSyncHostInboundProjectScope(envelope.type, envelope.projectId, args.projectId);
+    const projectScope = resolveSyncHostInboundProjectScope(
+      envelope.type,
+      envelope.projectId,
+      args.projectId,
+      hostProjectIdAliases,
+    );
     if (!projectScope.ok) {
       rejectProjectScopedEnvelope(peer, envelope.type, envelope.requestId, envelope.payload, projectScope);
       return;
@@ -3574,6 +3632,10 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       }
       case "project_switch_request": {
         await handleProjectSwitchRequest(peer, envelope.requestId, envelope.payload as SyncProjectSwitchRequestPayload);
+        break;
+      }
+      case "project_forget_request": {
+        await handleProjectForgetRequest(peer, envelope.requestId, envelope.payload as SyncProjectForgetRequestPayload);
         break;
       }
       case "project_browse_request": {

--- a/apps/ade-cli/src/services/sync/syncService.ts
+++ b/apps/ade-cli/src/services/sync/syncService.ts
@@ -68,6 +68,7 @@ type SyncServiceArgs = {
   db: AdeDb;
   logger: Logger;
   projectId?: string | null;
+  runtimeProjectId?: string | null;
   projectRoot: string;
   appVersion?: string;
   runtimeKind?: SyncRuntimeKind;
@@ -685,6 +686,9 @@ export function createSyncService(args: SyncServiceArgs) {
       db: args.db,
       logger: args.logger,
       projectId: args.projectId ?? null,
+      projectIdAliases: args.runtimeProjectId && args.runtimeProjectId !== args.projectId
+        ? [args.runtimeProjectId]
+        : [],
       projectRoot: args.projectRoot,
       fileService: args.fileService,
       laneService: args.laneService,

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -5130,7 +5130,7 @@ app.whenReady().then(async () => {
     if (projectContexts.has(rootToForget)) {
       const rootToClose = rootToForget;
       const closeTimer = setTimeout(() => {
-        void closeProjectContext(rootToClose).catch((error) => {
+        void closeProjectByPath(rootToClose).catch((error) => {
           console.warn("sync.mobile_project_forget_close_failed", {
             rootPath: rootToClose,
             error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -3592,6 +3592,7 @@ app.whenReady().then(async () => {
       logger,
       projectRoot,
       projectId,
+      runtimeProjectId: recentProjectInspectionForRoot(projectRoot)?.projectId ?? projectId,
       appVersion: app.getVersion(),
       localDeviceIdPath: path.join(machineAdeLayout.secretsDir, "sync-device-id"),
       fileService,
@@ -5095,19 +5096,36 @@ app.whenReady().then(async () => {
 
     const state = readGlobalState(globalStatePath);
     const inspected = (state.recentProjects ?? []).map(inspectRecentProject);
-    const recent = inspected.find((entry) => {
-      const entryRoot = normalizeProjectRoot(entry.summary.rootPath);
-      return (requestedRoot != null && entryRoot === requestedRoot)
-        || (requestedProjectId != null && entry.projectId === requestedProjectId);
-    }) ?? null;
-    const contextMatch = [...projectContexts.entries()].find(([root, ctx]) =>
-      (requestedRoot != null && root === requestedRoot)
-        || (requestedProjectId != null && ctx.projectId === requestedProjectId)
-    ) ?? null;
-    const rootToForget = requestedRoot
-      ?? (recent ? normalizeProjectRoot(recent.summary.rootPath) : null)
-      ?? contextMatch?.[0]
+    const recentByRoot = requestedRoot == null
+      ? null
+      : inspected.find((entry) => normalizeProjectRoot(entry.summary.rootPath) === requestedRoot) ?? null;
+    const recentById = requestedProjectId == null
+      ? null
+      : inspected.find((entry) => entry.projectId === requestedProjectId) ?? null;
+    const contextByRoot = requestedRoot == null
+      ? null
+      : [...projectContexts.entries()].find(([root]) => root === requestedRoot) ?? null;
+    const contextById = requestedProjectId == null
+      ? null
+      : [...projectContexts.entries()].find(([, ctx]) => ctx.projectId === requestedProjectId) ?? null;
+    const rootFromPath = requestedRoot
+      ?? (recentByRoot ? normalizeProjectRoot(recentByRoot.summary.rootPath) : null)
+      ?? contextByRoot?.[0]
       ?? null;
+    const rootFromId = (recentById ? normalizeProjectRoot(recentById.summary.rootPath) : null)
+      ?? contextById?.[0]
+      ?? null;
+    if (rootFromPath && rootFromId && rootFromPath !== rootFromId) {
+      return {
+        ok: false,
+        message: "projectId and rootPath refer to different projects.",
+        projectId: requestedProjectId,
+        rootPath: requestedRoot,
+      };
+    }
+    const recent = recentByRoot ?? recentById;
+    const contextMatch = contextByRoot ?? contextById;
+    const rootToForget = rootFromPath ?? rootFromId;
     if (!rootToForget) {
       return {
         ok: true,

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -106,6 +106,8 @@ import type {
   ProjectInfo,
   PtyDataEvent,
   SyncMobileProjectSummary,
+  SyncProjectForgetRequestPayload,
+  SyncProjectForgetResultPayload,
   SyncProjectOpenRequestPayload,
   SyncPeerConnectionState,
   SyncProjectConnectionPayload,
@@ -3638,6 +3640,7 @@ app.whenReady().then(async () => {
           createMobileSyncProject(input, projectScaffoldService),
         cloneProject: (input: CloneProjectInput) =>
           cloneMobileSyncProject(input, projectScaffoldService),
+        forgetProject: forgetMobileSyncProject,
         listMyGitHubRepos: async (input: ListMyGitHubReposInput) =>
           projectScaffoldService.listMyGitHubRepos(input),
       },
@@ -5072,6 +5075,76 @@ app.whenReady().then(async () => {
   ): Promise<SyncMobileProjectSummary> {
     const result = await scaffoldService.cloneRepository(input);
     return await mobileProjectSummaryForRoot(result.rootPath);
+  }
+
+  async function forgetMobileSyncProject(
+    input: SyncProjectForgetRequestPayload,
+  ): Promise<SyncProjectForgetResultPayload> {
+    const requestedProjectId = typeof input.projectId === "string" && input.projectId.trim()
+      ? input.projectId.trim()
+      : null;
+    const requestedRoot = typeof input.rootPath === "string" && input.rootPath.trim()
+      ? normalizeProjectRoot(input.rootPath)
+      : null;
+    if (!requestedProjectId && !requestedRoot) {
+      return {
+        ok: false,
+        message: "Project id or path is required.",
+      };
+    }
+
+    const state = readGlobalState(globalStatePath);
+    const inspected = (state.recentProjects ?? []).map(inspectRecentProject);
+    const recent = inspected.find((entry) => {
+      const entryRoot = normalizeProjectRoot(entry.summary.rootPath);
+      return (requestedRoot != null && entryRoot === requestedRoot)
+        || (requestedProjectId != null && entry.projectId === requestedProjectId);
+    }) ?? null;
+    const contextMatch = [...projectContexts.entries()].find(([root, ctx]) =>
+      (requestedRoot != null && root === requestedRoot)
+        || (requestedProjectId != null && ctx.projectId === requestedProjectId)
+    ) ?? null;
+    const rootToForget = requestedRoot
+      ?? (recent ? normalizeProjectRoot(recent.summary.rootPath) : null)
+      ?? contextMatch?.[0]
+      ?? null;
+    if (!rootToForget) {
+      return {
+        ok: true,
+        message: "Project is already removed from this ADE machine.",
+        projectId: requestedProjectId,
+        rootPath: requestedRoot,
+      };
+    }
+
+    const nextRecentProjects = (state.recentProjects ?? []).filter((entry) => {
+      return normalizeProjectRoot(entry.rootPath) !== rootToForget;
+    });
+    writeGlobalState(globalStatePath, {
+      ...state,
+      recentProjects: nextRecentProjects,
+      lastProjectRoot: state.lastProjectRoot && normalizeProjectRoot(state.lastProjectRoot) === rootToForget
+        ? undefined
+        : state.lastProjectRoot,
+    });
+    if (projectContexts.has(rootToForget)) {
+      const rootToClose = rootToForget;
+      const closeTimer = setTimeout(() => {
+        void closeProjectContext(rootToClose).catch((error) => {
+          console.warn("sync.mobile_project_forget_close_failed", {
+            rootPath: rootToClose,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      }, 0);
+      closeTimer.unref?.();
+    }
+    notifyMobileSyncProjectCatalogChanged();
+    return {
+      ok: true,
+      projectId: requestedProjectId ?? contextMatch?.[1].projectId ?? recent?.projectId ?? null,
+      rootPath: rootToForget,
+    };
   }
 
   async function ensureProjectContextForMobileSync(projectRoot: string): Promise<AppContext> {

--- a/apps/desktop/src/main/services/sync/syncHostService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncHostService.test.ts
@@ -2848,6 +2848,77 @@ describe.skipIf(!isCrsqliteAvailable())("syncHostService", () => {
     expect(laneList).not.toHaveBeenCalled();
   });
 
+  it("executes project-scoped commands locally when the phone sends the hosted DB project id alias", async () => {
+    const brainDb = await openKvDb(makeDbPath("ade-sync-command-project-alias-"), createLogger() as any);
+    const projectRoot = makeProjectRoot("ade-sync-command-project-alias-project-");
+    const workspaceRoot = path.join(projectRoot, "workspace");
+    fs.mkdirSync(workspaceRoot, { recursive: true });
+    const execute = vi.fn(async () => ({ routed: true }));
+    const laneList = vi.fn().mockResolvedValue([]);
+
+    const host = createSyncHostService({
+      db: brainDb,
+      logger: createLogger() as any,
+      projectId: "project_80c9b7785de5e4060adf68c2",
+      projectIdAliases: ["24b96ceb-7ff6-4852-af99-2c36ffa6e9bf"],
+      projectRoot,
+      port: 0,
+      pinStore: createStubPinStore(),
+      fileService: createStubFileService(workspaceRoot) as any,
+      laneService: {
+        list: laneList,
+        create: vi.fn(),
+        archive: vi.fn(),
+      } as any,
+      prService: {
+        listAll: vi.fn().mockResolvedValue([]),
+        refresh: vi.fn().mockResolvedValue([]),
+      } as any,
+      ptyService: {
+        create: vi.fn(),
+        enrichSessions: (rows: any[]) => rows,
+      } as any,
+      sessionService: { list: () => [] } as any,
+      computerUseArtifactBrokerService: {
+        listArtifacts: () => [],
+      } as any,
+      remoteCommandExecutor: { execute },
+    });
+    activeDisposers.push(async () => {
+      await host.dispose();
+      brainDb.close();
+    });
+
+    const client = await connectClient({
+      port: await host.waitUntilListening(),
+      token: host.getBootstrapToken(),
+      deviceId: "peer-project-alias",
+      deviceName: "Project Alias Phone",
+      siteId: brainDb.sync.getSiteId(),
+      dbVersion: brainDb.sync.getDbVersion(),
+      deviceType: "phone",
+    });
+    activeDisposers.push(client.close);
+
+    client.ws.send(encodeSyncEnvelope({
+      type: "command",
+      projectId: "24b96ceb-7ff6-4852-af99-2c36ffa6e9bf",
+      requestId: "cmd-db-project-alias",
+      payload: {
+        commandId: "cmd-db-project-alias",
+        action: "lanes.list",
+        args: {},
+      },
+    }));
+
+    const ack = await client.queue.next("command_ack");
+    expect((ack.payload as { accepted: boolean }).accepted).toBe(true);
+    const result = await client.queue.next("command_result");
+    expect((result.payload as { ok: boolean }).ok).toBe(true);
+    expect(execute).not.toHaveBeenCalled();
+    expect(laneList).toHaveBeenCalledTimes(1);
+  });
+
   it("clears prior PIN failures after a successful pair and still allows paired hello", async () => {
     const brainDb = await openKvDb(makeDbPath("ade-sync-pairing-cooldown-"), createLogger() as any);
     const projectRoot = makeProjectRoot("ade-sync-pairing-cooldown-project-");

--- a/apps/desktop/src/shared/types/sync.ts
+++ b/apps/desktop/src/shared/types/sync.ts
@@ -296,6 +296,11 @@ export type SyncProjectSwitchRequestPayload = {
   rootPath?: string | null;
 };
 
+export type SyncProjectForgetRequestPayload = {
+  projectId?: string | null;
+  rootPath?: string | null;
+};
+
 export type SyncProjectConnectionPayload = {
   authKind: "bootstrap" | "paired";
   token?: string | null;
@@ -310,6 +315,13 @@ export type SyncProjectSwitchResultPayload = {
   message?: string | null;
   project?: SyncMobileProjectSummary | null;
   connection?: SyncProjectConnectionPayload | null;
+};
+
+export type SyncProjectForgetResultPayload = {
+  ok: boolean;
+  message?: string | null;
+  projectId?: string | null;
+  rootPath?: string | null;
 };
 
 export type SyncProjectOpenRequestPayload = {
@@ -1108,6 +1120,8 @@ export type SyncProjectCatalogEnvelope = SyncEnvelopeWithPayload<"project_catalo
 export type SyncProjectCatalogChunkEnvelope = SyncEnvelopeWithPayload<"project_catalog_chunk", SyncProjectCatalogChunkPayload>;
 export type SyncProjectSwitchRequestEnvelope = SyncEnvelopeWithPayload<"project_switch_request", SyncProjectSwitchRequestPayload>;
 export type SyncProjectSwitchResultEnvelope = SyncEnvelopeWithPayload<"project_switch_result", SyncProjectSwitchResultPayload>;
+export type SyncProjectForgetRequestEnvelope = SyncEnvelopeWithPayload<"project_forget_request", SyncProjectForgetRequestPayload>;
+export type SyncProjectForgetResultEnvelope = SyncEnvelopeWithPayload<"project_forget_result", SyncProjectForgetResultPayload>;
 export type SyncProjectBrowseRequestEnvelope = SyncEnvelopeWithPayload<"project_browse_request", ProjectBrowseInput>;
 export type SyncProjectBrowseResultEnvelope = SyncEnvelopeWithPayload<"project_browse_result", SyncProjectBrowseResultPayload>;
 export type SyncProjectDefaultParentDirRequestEnvelope = SyncEnvelopeWithPayload<"project_default_parent_dir_request", Record<string, never>>;
@@ -1170,6 +1184,8 @@ export type SyncEnvelope =
   | SyncProjectCatalogChunkEnvelope
   | SyncProjectSwitchRequestEnvelope
   | SyncProjectSwitchResultEnvelope
+  | SyncProjectForgetRequestEnvelope
+  | SyncProjectForgetResultEnvelope
   | SyncProjectBrowseRequestEnvelope
   | SyncProjectBrowseResultEnvelope
   | SyncProjectDefaultParentDirRequestEnvelope

--- a/apps/ios/ADE/App/ContentView.swift
+++ b/apps/ios/ADE/App/ContentView.swift
@@ -314,6 +314,8 @@ private struct ProjectHomeView: View {
               isDisabled: syncService.isProjectSwitching
             ) {
               syncService.selectProject(project)
+            } onForget: {
+              syncService.forgetProject(project)
             }
           }
         }
@@ -484,6 +486,7 @@ private struct ProjectHomeRow: View {
   let isSwitching: Bool
   let isDisabled: Bool
   let action: () -> Void
+  let onForget: () -> Void
 
   var body: some View {
     Button(action: action) {
@@ -535,6 +538,12 @@ private struct ProjectHomeRow: View {
     }
     .buttonStyle(.plain)
     .disabled(isDisabled)
+    .contextMenu {
+      Button(role: .destructive, action: onForget) {
+        Label("Remove from list", systemImage: "trash")
+      }
+    }
+    .accessibilityAction(named: "Remove from list", onForget)
   }
 }
 

--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -147,6 +147,13 @@ struct MobileProjectSwitchResultPayload: Codable, Equatable {
   var connection: MobileProjectConnectionPayload?
 }
 
+struct MobileProjectForgetResultPayload: Codable, Equatable {
+  var ok: Bool
+  var message: String?
+  var projectId: String?
+  var rootPath: String?
+}
+
 struct MobileProjectBrowseEntry: Codable, Equatable, Identifiable {
   var id: String { fullPath }
   var name: String

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -2256,7 +2256,7 @@ final class SyncService: ObservableObject {
 
   private func unhideProject(_ project: MobileProjectSummary) {
     let keys = hiddenKeys(for: project)
-    guard !keys.isEmpty else { return }
+    guard !keys.isEmpty, !hiddenProjectKeys.isDisjoint(with: keys) else { return }
     hiddenProjectKeys.subtract(keys)
     saveHiddenProjectKeys()
   }

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -1539,6 +1539,8 @@ final class SyncService: ObservableObject {
     refreshProjectCatalog()
     if wasActive {
       _ = beginProjectSelection()
+      resetChatEventState(clearHistory: false)
+      resetTerminalSubscriptionState(clearHistory: true)
       setActiveProjectId(nil)
       latestRemoteDbVersion = 0
       resetOutboundCursorStateForActiveProject()
@@ -2237,25 +2239,55 @@ final class SyncService: ObservableObject {
     !hiddenProjectKeys.isDisjoint(with: hiddenKeys(for: project))
   }
 
+  private func hiddenProjectsStorageKey() -> String {
+    if let hostKey = activeHostStorageKey() {
+      return "\(hiddenProjectsKey).\(hostKey)"
+    }
+    return hiddenProjectsKey
+  }
+
   private func loadHiddenProjectKeys() -> Set<String> {
-    Set(UserDefaults.standard.stringArray(forKey: hiddenProjectsKey) ?? [])
+    let key = hiddenProjectsStorageKey()
+    if key != hiddenProjectsKey,
+       UserDefaults.standard.stringArray(forKey: key) == nil,
+       let legacyKeys = UserDefaults.standard.stringArray(forKey: hiddenProjectsKey),
+       !legacyKeys.isEmpty {
+      UserDefaults.standard.set(legacyKeys, forKey: key)
+      UserDefaults.standard.removeObject(forKey: hiddenProjectsKey)
+      return Set(legacyKeys)
+    }
+    return Set(UserDefaults.standard.stringArray(forKey: key) ?? [])
   }
 
   private func saveHiddenProjectKeys() {
+    let key = hiddenProjectsStorageKey()
     if hiddenProjectKeys.isEmpty {
-      UserDefaults.standard.removeObject(forKey: hiddenProjectsKey)
+      UserDefaults.standard.removeObject(forKey: key)
     } else {
-      UserDefaults.standard.set(hiddenProjectKeys.sorted(), forKey: hiddenProjectsKey)
+      UserDefaults.standard.set(hiddenProjectKeys.sorted(), forKey: key)
+    }
+    if key != hiddenProjectsKey {
+      UserDefaults.standard.removeObject(forKey: hiddenProjectsKey)
     }
   }
 
   private func rememberHiddenProject(_ project: MobileProjectSummary) {
-    hiddenProjectKeys.formUnion(hiddenKeys(for: project))
+    let keys = hiddenKeys(for: project)
+    guard !keys.isEmpty else { return }
+    let previous = hiddenProjectKeys
+    hiddenProjectKeys.formUnion(keys)
+    guard hiddenProjectKeys != previous else { return }
     saveHiddenProjectKeys()
   }
 
   private func unhideProject(_ project: MobileProjectSummary) {
-    let keys = hiddenKeys(for: project)
+    var keys = hiddenKeys(for: project)
+    if let root = normalizedProjectRoot(project.rootPath) {
+      let aliases = projects + remoteProjectCatalog + database.listMobileProjects()
+      for alias in aliases where normalizedProjectRoot(alias.rootPath) == root {
+        keys.formUnion(hiddenKeys(for: alias))
+      }
+    }
     guard !keys.isEmpty, !hiddenProjectKeys.isDisjoint(with: keys) else { return }
     hiddenProjectKeys.subtract(keys)
     saveHiddenProjectKeys()
@@ -2316,6 +2348,8 @@ final class SyncService: ObservableObject {
     activeProjectId = UserDefaults.standard.string(forKey: activeProjectIdKey)
     activeProjectRootPath = normalizedProjectRoot(UserDefaults.standard.string(forKey: activeProjectRootPathKey))
     activeProjectHostIdentity = UserDefaults.standard.string(forKey: activeProjectHostIdentityKey)
+    activeHostProfile = loadProfile()
+    hostName = activeHostProfile?.hostName
     database.setActiveProjectId(activeProjectId)
     hiddenProjectKeys = loadHiddenProjectKeys()
     projects = deduplicateProjectListByRoot(
@@ -2328,8 +2362,6 @@ final class SyncService: ObservableObject {
     }
     pendingOperationCount = loadPendingOperations().count
     resetOutboundCursorStateForActiveProject()
-    activeHostProfile = loadProfile()
-    hostName = activeHostProfile?.hostName
     latestRemoteDbVersion = activeHostProfile?.lastRemoteDbVersion ?? 0
     remoteCommandDescriptors = loadRemoteCommandDescriptors()
     refreshReducedSyncLoad()
@@ -5724,6 +5756,7 @@ final class SyncService: ObservableObject {
       }
       activeHostProfile = profile
       hostName = profile.hostName
+      hiddenProjectKeys = loadHiddenProjectKeys()
       if activeProjectId != nil {
         let hostIdentity = syncNormalizedCommandScopeValue(profile.hostIdentity)
           ?? syncNormalizedCommandScopeValue(profile.lastHostDeviceId)
@@ -5739,6 +5772,7 @@ final class SyncService: ObservableObject {
       UserDefaults.standard.removeObject(forKey: legacyDraftKey)
       activeHostProfile = nil
       hostName = nil
+      hiddenProjectKeys = loadHiddenProjectKeys()
       activeProjectHostIdentity = nil
       UserDefaults.standard.removeObject(forKey: activeProjectHostIdentityKey)
     }
@@ -8734,7 +8768,7 @@ final class SyncService: ObservableObject {
       try await InitialHydrationGate.waitForProjectRow(
         currentProjectId: {
           guard let activeProjectId = self.activeProjectId else {
-            let cachedProjects = self.database.listMobileProjects()
+            let cachedProjects = self.database.listMobileProjects().filter { !self.isProjectHidden($0) }
             guard cachedProjects.count == 1, let onlyProject = cachedProjects.first else {
               return nil
             }
@@ -8766,7 +8800,7 @@ final class SyncService: ObservableObject {
 
     guard isCurrentConnectionGeneration(connectionGeneration) else { return }
     if activeProjectId == nil {
-      let cachedProjects = database.listMobileProjects()
+      let cachedProjects = database.listMobileProjects().filter { !isProjectHidden($0) }
       if cachedProjects.count == 1, let onlyProject = cachedProjects.first {
         if supportsProjectCatalog {
           guard remoteProjectCatalog.count == 1,

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -1256,6 +1256,7 @@ final class SyncService: ObservableObject {
   private let activeProjectIdKey = "ade.sync.activeProjectId"
   private let activeProjectRootPathKey = "ade.sync.activeProjectRootPath"
   private let activeProjectHostIdentityKey = "ade.sync.activeProjectHostIdentity"
+  private let hiddenProjectsKey = "ade.sync.hiddenProjects"
   private let pendingOperationsKey = "ade.sync.pendingOperations"
   private let remoteCommandDescriptorsKey = "ade.sync.remoteCommandDescriptors"
   private let outboundSyncCursorsKey = "ade.sync.outboundSyncCursors"
@@ -1357,6 +1358,7 @@ final class SyncService: ObservableObject {
   private(set) var deviceId: String
   private var remoteCommandDescriptors: [SyncRemoteCommandDescriptor] = []
   private var remoteProjectCatalog: [MobileProjectSummary] = []
+  private var hiddenProjectKeys: Set<String> = []
   private var pendingProjectCatalogChunks: [String: [Int: [MobileProjectSummary]]] = [:]
   private var supportsProjectCatalog = false
   private var supportsProjectActions = false
@@ -1475,6 +1477,7 @@ final class SyncService: ObservableObject {
 
   func selectProject(_ project: MobileProjectSummary) {
     let selectionGeneration = beginProjectSelection()
+    unhideProject(project)
 
     if isActiveProject(project) {
       projectHomePresented = false
@@ -1525,8 +1528,55 @@ final class SyncService: ObservableObject {
     }
   }
 
+  func forgetProject(_ project: MobileProjectSummary) {
+    let wasActive = isActiveProject(project)
+    rememberHiddenProject(project)
+    remoteProjectCatalog.removeAll { existing in
+      existing.id == project.id
+        || (normalizedProjectRoot(existing.rootPath) != nil
+          && normalizedProjectRoot(existing.rootPath) == normalizedProjectRoot(project.rootPath))
+    }
+    refreshProjectCatalog()
+    if wasActive {
+      _ = beginProjectSelection()
+      setActiveProjectId(nil)
+      latestRemoteDbVersion = 0
+      resetOutboundCursorStateForActiveProject()
+      projectHomePresented = true
+      localStateRevision += 1
+      refreshActiveSessionsAndSnapshot()
+      scheduleWorkspaceSnapshotWrite()
+    }
+
+    guard canSendLiveRequests() else { return }
+    let requestId = makeRequestId()
+    var payload: [String: Any] = ["projectId": project.id]
+    if let rootPath = project.rootPath?.trimmingCharacters(in: .whitespacesAndNewlines), !rootPath.isEmpty {
+      payload["rootPath"] = rootPath
+    }
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      do {
+        let raw = try await awaitResponse(
+          requestId: requestId,
+          disconnectOnTimeout: false,
+          timeoutMessage: "Timed out removing that project.",
+          timeoutNanoseconds: 8_000_000_000
+        ) {
+          self.sendEnvelope(type: "project_forget_request", requestId: requestId, payload: payload)
+        }
+        let result = try decode(raw, as: MobileProjectForgetResultPayload.self)
+        if !result.ok {
+          syncConnectLog.info("project forget failed message=\((result.message ?? "unknown"), privacy: .public)")
+        }
+      } catch {
+        syncConnectLog.info("project forget request failed error=\(String(describing: error), privacy: .public)")
+      }
+    }
+  }
+
   func refreshProjectCatalog(preferRemoteSelection: Bool = false) {
-    let cachedProjects = database.listMobileProjects()
+    let cachedProjects = database.listMobileProjects().filter { !isProjectHidden($0) }
     let remoteCatalog = deduplicatedRemoteProjectCatalog()
     let hasRemoteCatalog = !remoteCatalog.isEmpty
     var mergedById = Dictionary(uniqueKeysWithValues: remoteCatalog.map { ($0.id, $0) })
@@ -1612,6 +1662,9 @@ final class SyncService: ObservableObject {
     var idByRoot: [String: String] = [:]
 
     for project in remoteProjectCatalog {
+      if isProjectHidden(project) {
+        continue
+      }
       let rootKey = normalizedProjectRoot(project.rootPath)
       if let rootKey, let existingId = idByRoot[rootKey], let existing = byId[existingId] {
         if shouldPreferProject(project, over: existing) {
@@ -1692,7 +1745,7 @@ final class SyncService: ObservableObject {
     _ catalog: MobileProjectCatalogPayload,
     preferRemoteSelection: Bool = true
   ) {
-    remoteProjectCatalog = catalog.projects
+    remoteProjectCatalog = catalog.projects.filter { !isProjectHidden($0) }
     refreshProjectCatalog(preferRemoteSelection: preferRemoteSelection)
   }
 
@@ -1821,6 +1874,7 @@ final class SyncService: ObservableObject {
         NSLocalizedDescriptionKey: response.message ?? fallbackMessage
       ])
     }
+    unhideProject(project)
     remoteProjectCatalog.removeAll { existing in
       existing.id == project.id
         || (normalizedProjectRoot(existing.rootPath) != nil
@@ -2168,6 +2222,45 @@ final class SyncService: ObservableObject {
     syncNormalizedProjectRootScope(rootPath)
   }
 
+  private func hiddenKeys(for project: MobileProjectSummary) -> Set<String> {
+    var keys = Set<String>()
+    if let id = normalizedProjectId(project.id) {
+      keys.insert("id:\(id)")
+    }
+    if let root = normalizedProjectRoot(project.rootPath) {
+      keys.insert("root:\(root)")
+    }
+    return keys
+  }
+
+  private func isProjectHidden(_ project: MobileProjectSummary) -> Bool {
+    !hiddenProjectKeys.isDisjoint(with: hiddenKeys(for: project))
+  }
+
+  private func loadHiddenProjectKeys() -> Set<String> {
+    Set(UserDefaults.standard.stringArray(forKey: hiddenProjectsKey) ?? [])
+  }
+
+  private func saveHiddenProjectKeys() {
+    if hiddenProjectKeys.isEmpty {
+      UserDefaults.standard.removeObject(forKey: hiddenProjectsKey)
+    } else {
+      UserDefaults.standard.set(hiddenProjectKeys.sorted(), forKey: hiddenProjectsKey)
+    }
+  }
+
+  private func rememberHiddenProject(_ project: MobileProjectSummary) {
+    hiddenProjectKeys.formUnion(hiddenKeys(for: project))
+    saveHiddenProjectKeys()
+  }
+
+  private func unhideProject(_ project: MobileProjectSummary) {
+    let keys = hiddenKeys(for: project)
+    guard !keys.isEmpty else { return }
+    hiddenProjectKeys.subtract(keys)
+    saveHiddenProjectKeys()
+  }
+
   private let queueableFileActions: Set<String> = [
     "writeText",
     "createFile",
@@ -2224,7 +2317,10 @@ final class SyncService: ObservableObject {
     activeProjectRootPath = normalizedProjectRoot(UserDefaults.standard.string(forKey: activeProjectRootPathKey))
     activeProjectHostIdentity = UserDefaults.standard.string(forKey: activeProjectHostIdentityKey)
     database.setActiveProjectId(activeProjectId)
-    projects = deduplicateProjectListByRoot(sortedProjectList(database.listMobileProjects()))
+    hiddenProjectKeys = loadHiddenProjectKeys()
+    projects = deduplicateProjectListByRoot(
+      sortedProjectList(database.listMobileProjects().filter { !isProjectHidden($0) })
+    )
     outboundLocalDbVersion = loadOutboundCursorVersionForActiveProject(defaultVersion: database.currentDbVersion())
     normalizeActiveProjectSelection(allowSingleProjectFallback: false)
     if activeProjectId != nil {
@@ -7416,6 +7512,7 @@ final class SyncService: ObservableObject {
          "project_open_result",
          "project_create_result",
          "project_clone_result",
+         "project_forget_result",
          "project_list_my_github_repos_result":
       resolve(requestId: requestId, result: .success(payload))
     case "hello_error":

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -2689,14 +2689,26 @@ final class ADETests: XCTestCase {
   func testSyncServiceForgetProjectHidesCachedAndRemoteRowsByRoot() throws {
     let activeProjectIdKey = "ade.sync.activeProjectId"
     let activeProjectRootPathKey = "ade.sync.activeProjectRootPath"
+    let activeProjectHostIdentityKey = "ade.sync.activeProjectHostIdentity"
+    let profileKey = "ade.sync.hostProfile"
+    let profilesKey = "ade.sync.hostProfiles"
     let hiddenProjectsKey = "ade.sync.hiddenProjects"
+    let hostHiddenProjectsKey = "\(hiddenProjectsKey).host-1"
     UserDefaults.standard.removeObject(forKey: activeProjectIdKey)
     UserDefaults.standard.removeObject(forKey: activeProjectRootPathKey)
+    UserDefaults.standard.removeObject(forKey: activeProjectHostIdentityKey)
+    UserDefaults.standard.removeObject(forKey: profileKey)
+    UserDefaults.standard.removeObject(forKey: profilesKey)
     UserDefaults.standard.removeObject(forKey: hiddenProjectsKey)
+    UserDefaults.standard.removeObject(forKey: hostHiddenProjectsKey)
     defer {
       UserDefaults.standard.removeObject(forKey: activeProjectIdKey)
       UserDefaults.standard.removeObject(forKey: activeProjectRootPathKey)
+      UserDefaults.standard.removeObject(forKey: activeProjectHostIdentityKey)
+      UserDefaults.standard.removeObject(forKey: profileKey)
+      UserDefaults.standard.removeObject(forKey: profilesKey)
       UserDefaults.standard.removeObject(forKey: hiddenProjectsKey)
+      UserDefaults.standard.removeObject(forKey: hostHiddenProjectsKey)
     }
 
     let baseURL = makeTemporaryDirectory()
@@ -2710,22 +2722,31 @@ final class ADETests: XCTestCase {
     """)
 
     let service = SyncService(database: database)
+    try service.applyHelloPayloadForTesting([
+      "brain": [
+        "deviceId": "host-1",
+        "deviceName": "Mac Studio",
+      ],
+      "features": [
+        "projectCatalog": true,
+      ],
+      "projects": [],
+    ])
     let cachedProject = try XCTUnwrap(service.projects.first(where: { $0.id == "db-project" }))
-    service.selectProject(cachedProject)
+    service.setActiveProjectForTesting(projectId: cachedProject.id, rootPath: cachedProject.rootPath)
     XCTAssertEqual(service.activeProjectId, "db-project")
 
-    service.seedRemoteProjectCatalogForTesting([
-      MobileProjectSummary(
-        id: "registry-project",
-        displayName: "Project One",
-        rootPath: "/tmp/project-one/",
-        defaultBaseRef: "main",
-        lastOpenedAt: "2026-04-22T02:00:00.000Z",
-        laneCount: 2,
-        isAvailable: true,
-        isCached: false
-      ),
-    ])
+    let registryProject = MobileProjectSummary(
+      id: "registry-project",
+      displayName: "Project One",
+      rootPath: "/tmp/project-one/",
+      defaultBaseRef: "main",
+      lastOpenedAt: "2026-04-22T02:00:00.000Z",
+      laneCount: 2,
+      isAvailable: true,
+      isCached: false
+    )
+    service.seedRemoteProjectCatalogForTesting([registryProject])
     XCTAssertTrue(service.projects.contains { $0.id == "db-project" || $0.id == "registry-project" })
 
     service.forgetProject(cachedProject)
@@ -2735,8 +2756,9 @@ final class ADETests: XCTestCase {
     XCTAssertTrue(service.shouldShowProjectHome)
     XCTAssertFalse(service.projects.contains { $0.id == "db-project" })
     XCTAssertFalse(service.projects.contains { $0.id == "registry-project" })
+    XCTAssertNil(UserDefaults.standard.stringArray(forKey: hiddenProjectsKey))
     XCTAssertEqual(
-      UserDefaults.standard.stringArray(forKey: hiddenProjectsKey),
+      UserDefaults.standard.stringArray(forKey: hostHiddenProjectsKey),
       ["id:db-project", "root:/tmp/project-one"]
     )
 
@@ -2754,6 +2776,10 @@ final class ADETests: XCTestCase {
     ])
     XCTAssertFalse(service.projects.contains { $0.id == "db-project" })
     XCTAssertFalse(service.projects.contains { $0.id == "registry-project" })
+
+    service.disconnect(clearCredentials: false, suspendAutoReconnect: true)
+    service.selectProject(registryProject)
+    XCTAssertNil(UserDefaults.standard.stringArray(forKey: hostHiddenProjectsKey))
 
     database.close()
   }

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -2643,11 +2643,14 @@ final class ADETests: XCTestCase {
   func testSyncServiceProjectHomeUsesCachedProjectsAndLocalSelection() throws {
     let activeProjectIdKey = "ade.sync.activeProjectId"
     let activeProjectRootPathKey = "ade.sync.activeProjectRootPath"
+    let hiddenProjectsKey = "ade.sync.hiddenProjects"
     UserDefaults.standard.removeObject(forKey: activeProjectIdKey)
     UserDefaults.standard.removeObject(forKey: activeProjectRootPathKey)
+    UserDefaults.standard.removeObject(forKey: hiddenProjectsKey)
     defer {
       UserDefaults.standard.removeObject(forKey: activeProjectIdKey)
       UserDefaults.standard.removeObject(forKey: activeProjectRootPathKey)
+      UserDefaults.standard.removeObject(forKey: hiddenProjectsKey)
     }
 
     let baseURL = makeTemporaryDirectory()
@@ -2678,6 +2681,79 @@ final class ADETests: XCTestCase {
     XCTAssertTrue(service.shouldShowProjectHome)
     service.closeProjectHome()
     XCTAssertFalse(service.shouldShowProjectHome)
+
+    database.close()
+  }
+
+  @MainActor
+  func testSyncServiceForgetProjectHidesCachedAndRemoteRowsByRoot() throws {
+    let activeProjectIdKey = "ade.sync.activeProjectId"
+    let activeProjectRootPathKey = "ade.sync.activeProjectRootPath"
+    let hiddenProjectsKey = "ade.sync.hiddenProjects"
+    UserDefaults.standard.removeObject(forKey: activeProjectIdKey)
+    UserDefaults.standard.removeObject(forKey: activeProjectRootPathKey)
+    UserDefaults.standard.removeObject(forKey: hiddenProjectsKey)
+    defer {
+      UserDefaults.standard.removeObject(forKey: activeProjectIdKey)
+      UserDefaults.standard.removeObject(forKey: activeProjectRootPathKey)
+      UserDefaults.standard.removeObject(forKey: hiddenProjectsKey)
+    }
+
+    let baseURL = makeTemporaryDirectory()
+    let database = makeControllerHydrationDatabase(baseURL: baseURL)
+    XCTAssertNil(database.initializationError)
+    try database.executeSqlForTesting("""
+      insert into projects (
+        id, root_path, display_name, default_base_ref, created_at, last_opened_at
+      ) values
+        ('db-project', '/tmp/project-one', 'Project One', 'main', '2026-04-22T00:00:00.000Z', '2026-04-22T01:00:00.000Z');
+    """)
+
+    let service = SyncService(database: database)
+    let cachedProject = try XCTUnwrap(service.projects.first(where: { $0.id == "db-project" }))
+    service.selectProject(cachedProject)
+    XCTAssertEqual(service.activeProjectId, "db-project")
+
+    service.seedRemoteProjectCatalogForTesting([
+      MobileProjectSummary(
+        id: "registry-project",
+        displayName: "Project One",
+        rootPath: "/tmp/project-one/",
+        defaultBaseRef: "main",
+        lastOpenedAt: "2026-04-22T02:00:00.000Z",
+        laneCount: 2,
+        isAvailable: true,
+        isCached: false
+      ),
+    ])
+    XCTAssertTrue(service.projects.contains { $0.id == "db-project" || $0.id == "registry-project" })
+
+    service.forgetProject(cachedProject)
+
+    XCTAssertNil(service.activeProjectId)
+    XCTAssertNil(service.activeProjectRootPath)
+    XCTAssertTrue(service.shouldShowProjectHome)
+    XCTAssertFalse(service.projects.contains { $0.id == "db-project" })
+    XCTAssertFalse(service.projects.contains { $0.id == "registry-project" })
+    XCTAssertEqual(
+      UserDefaults.standard.stringArray(forKey: hiddenProjectsKey),
+      ["id:db-project", "root:/tmp/project-one"]
+    )
+
+    service.seedRemoteProjectCatalogForTesting([
+      MobileProjectSummary(
+        id: "registry-project",
+        displayName: "Project One",
+        rootPath: "/tmp/project-one/",
+        defaultBaseRef: "main",
+        lastOpenedAt: "2026-04-22T03:00:00.000Z",
+        laneCount: 3,
+        isAvailable: true,
+        isCached: false
+      ),
+    ])
+    XCTAssertFalse(service.projects.contains { $0.id == "db-project" })
+    XCTAssertFalse(service.projects.contains { $0.id == "registry-project" })
 
     database.close()
   }

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -393,10 +393,10 @@ When a project host is active, `syncHostService` handles them; when no
 project host owns the shared listener, `brainProjectActionsSyncHandler`
 handles the same envelopes so the phone can add a first project or
 remove stale recents on a headless or freshly-started machine. On the
-phone, removal also stores a local hidden key by project id and
-normalised root path so a cached DB row and a remote catalog row for the
-same project do not reappear until the user opens/selects that project
-again.
+phone, removal also stores host-scoped local hidden keys by project id
+and normalised root path so a cached DB row and a remote catalog row for
+the same project do not reappear until the user opens/selects that
+project again.
 
 Project catalog snapshots are also chunked
 (`MAX_PROJECT_CATALOG_ENVELOPE_BYTES = 768 KB`,

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -166,7 +166,8 @@ Canonical files (`apps/ade-cli/src/services/sync/`):
   into subscribed PTYs, desktop-size restore after the last phone
   detaches, lane presence decoration, project catalog/switch envelopes,
   runtime-scoped project action envelopes (browse/open/create/clone/
-  list GitHub repos/default parent directory), per-IP pairing rate
+  list GitHub repos/default parent directory/forget), project-id alias
+  matching between the machine catalog id and the hosted DB id, per-IP pairing rate
   limiter, and the Tailscale Serve / mDNS
   publication paths. Runtime
   kind is one of `desktop-embedded`, `headless`, `remote-stdio`,
@@ -193,7 +194,7 @@ Canonical files (`apps/ade-cli/src/services/sync/`):
   authenticates the same PIN / paired-secret / bootstrap paths as the
   per-project host, applies the same failed-PIN cooldown, and serves
   project catalog plus runtime-scoped project actions so a phone can
-  add/open/create/clone a project even from the project-home state.
+  add/open/create/clone/remove a project even from the project-home state.
 - `changesetPump.ts` — batch-chunk selection for changeset fan-out.
   Splits an export into `changeset_batch` envelopes at ~256 KB / 250
   rows while never splitting rows that share a `db_version` (the ack
@@ -310,7 +311,9 @@ iOS service files (`apps/ios/ADE/Services/`):
   reparent payload building with the optional stack base-branch
   override, project home/catalog state, active-project scoping,
   unregistered-worktree discovery, and APNs push-token registration
-  to the runtime.
+  to the runtime, plus local project-list hiding for "Remove from list"
+  so cached DB rows and runtime catalog rows for the same root disappear
+  together.
 - `KeychainService.swift` — iOS Keychain Services for paired device
   secrets (per-machine token shelf included).
 - `LiveActivityCoordinator.swift` — owns the single workspace
@@ -383,12 +386,17 @@ port across project switches. The phone flow:
 The project home can also manage machine projects without first binding
 to a project DB. `project_browse_request`,
 `project_default_parent_dir_request`, `project_open_request`,
-`project_create_request`, `project_clone_request`, and
-`project_list_my_github_repos_request` are runtime-scoped envelopes.
+`project_create_request`, `project_clone_request`,
+`project_list_my_github_repos_request`, and `project_forget_request`
+are runtime-scoped envelopes.
 When a project host is active, `syncHostService` handles them; when no
 project host owns the shared listener, `brainProjectActionsSyncHandler`
-handles the same envelopes so the phone can add a first project on a
-headless or freshly-started machine.
+handles the same envelopes so the phone can add a first project or
+remove stale recents on a headless or freshly-started machine. On the
+phone, removal also stores a local hidden key by project id and
+normalised root path so a cached DB row and a remote catalog row for the
+same project do not reappear until the user opens/selects that project
+again.
 
 Project catalog snapshots are also chunked
 (`MAX_PROJECT_CATALOG_ENVELOPE_BYTES = 768 KB`,
@@ -405,6 +413,11 @@ At dispatch time:
 - If the command is `project`-scoped and the runtime has a `hostProjectId`
   but the caller did not include `requestedProjectId`, the runtime rejects
   the command with `"requires projectId"` (`code: missing_project`).
+- If the runtime was opened from the machine project registry with one id
+  and the project DB already contains a different persisted project id,
+  the host accepts either id as an alias for the same open project. This
+  keeps older mobile caches and DB-scoped command payloads from being
+  misrouted as `project_not_open`.
 - If the command is `project`-scoped and the runtime has no project open,
   the runtime rejects it with `"requires an open project on this ADE
   machine"` (`code: project_not_open`).
@@ -614,7 +627,7 @@ payload.
 | Chat stream | Agent chat transcript events. Each `chat_event` carries a host-assigned per-session monotonic `seq` backed by a capped replay buffer (500 events / 2 MB per session, 64-session LRU). `chat_subscribe` accepts `sinceSeq`: gaps the buffer covers replay as ordinary events; uncoverable gaps fall back to a snapshot, and a non-resumed ack tells the client to drop its stale seq watermark (seq epochs restart at 1 on a new host). The ack also carries `turnActive` from the live agent chat service — snapshots are byte-capped tails, so a long turn's `status: started` event can fall outside the window and the flag is what lets a mid-turn subscriber render streaming/stop affordances without waiting on the changeset pump (a full ack without the flag tells the client to drop any latched hint) | iOS Work tab, controller chat |
 | Command routing | Send named actions (`chat.send`, `lanes.create`, `git.push`, `prs.getMobileSnapshot`, etc.) | Controller devices |
 | Project switching | `project_catalog` + `project_switch_request/result` for multi-project runtimes | iOS project home |
-| Project actions | Runtime-scoped project browser plus open/create/clone/list-GitHub-repos/default-parent-dir envelopes. Available from the active project host or the machine-wide fallback handler before a project is selected | iOS project home |
+| Project actions | Runtime-scoped project browser plus open/create/clone/list-GitHub-repos/default-parent-dir/forget envelopes. Available from the active project host or the machine-wide fallback handler before a project is selected | iOS project home |
 | Runtime status | Runtime broadcasts cluster/version status (`brain_status` is the legacy envelope name) | All devices |
 | Lane presence | Controllers call `lanes.presence.announce` / `lanes.presence.release`; the runtime decorates `LaneSummary.devicesOpen` for 60 s TTL | iOS Lanes tab; desktop runtime presence heartbeat |
 
@@ -705,7 +718,7 @@ project scope split.
 | PIN-based phone pairing + per-device secrets | Implemented |
 | Live chat-event push from runtime | Implemented |
 | Mobile project catalog + project switch handoff | Implemented |
-| Mobile project actions (browse/open/create/clone/list GitHub repos) | Implemented |
+| Mobile project actions (browse/open/create/clone/list GitHub repos/remove from list) | Implemented |
 | Brain-level shared listener (peers adopted across project switches) | Implemented |
 | Chunked envelopes (`envelope_chunk`, 720 KB frame budget) | Implemented |
 | Per-host-DB sync cursors (`serverDbSiteId` / `remoteDbVersionBySite`) | Implemented |
@@ -734,7 +747,9 @@ project scope split.
 - **Project-scoped commands need `projectId`.** A runtime hosting
   multiple projects has no implicit "current project". Forward the
   active `projectId` on every project-scoped command or the runtime
-  rejects with `code: missing_project`.
+  rejects with `code: missing_project`. The host accepts the runtime
+  catalog id and the DB-local project id as aliases for the same open
+  project when both are known.
 - **CRR retrofit strips non-PK UNIQUE constraints.** Upserts on
   synced tables must target the primary key only. Use explicit
   select-then-update for non-PK merge cases.

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -796,9 +796,10 @@ catalog rows from different OS reports of the same path don't
 duplicate. Project list dedup runs as a final pass
 (`deduplicateProjectListByRoot`) keyed on the normalised root path.
 Project removal stores the same normalised-root key in addition to the
-project id, so a DB-cached row and a runtime-catalog row representing
-the same filesystem path disappear together. Opening or selecting the
-project again clears those hidden keys.
+project id under the active host profile, so a DB-cached row and a
+runtime-catalog row representing the same filesystem path disappear
+together without hiding matching paths from other paired machines.
+Opening or selecting the project again clears those hidden keys.
 
 ### Shipped
 

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -387,6 +387,7 @@ Implemented envelope types on iOS:
 | `project_create_request` / `project_create_result` | Phone → runtime / runtime → phone | Create a new local Git project under a selected parent directory |
 | `project_clone_request` / `project_clone_result` | Phone → runtime / runtime → phone | Clone a GitHub repository on the machine and register it in the project catalog |
 | `project_list_my_github_repos_request` / `project_list_my_github_repos_result` | Phone → runtime / runtime → phone | List the runtime machine's authenticated GitHub repositories for the Clone flow |
+| `project_forget_request` / `project_forget_result` | Phone → runtime / runtime → phone | Remove a project from the machine recent-project catalog |
 | `changeset_batch` | Bidirectional | cr-sqlite changeset batch |
 | `changeset_ack` | Bidirectional | Per-batch apply confirmation (or error code); the sender retransmits on timeout |
 | `command` | Phone → runtime | Execution request |
@@ -773,7 +774,10 @@ when no active project is selected or the user taps the Projects toolbar
 button. It merges the runtime-provided catalog with projects already present
 in the local replicated DB, marks cached/unavailable rows, and requests a
 fresh bootstrap connection for the selected machine project through
-`project_switch_request`. Each tile renders `MobileProjectSummary.iconDataUrl`
+`project_switch_request`. Each tile exposes a long-press "Remove from list"
+action that hides the project locally and sends `project_forget_request`
+to the runtime so the machine catalog drops the matching recent entry.
+Each tile renders `MobileProjectSummary.iconDataUrl`
 when the runtime's `projectIconResolver` found a favicon for the project,
 falling back to the brand glyph otherwise. The runtime pre-renders icons
 to a 64×64 PNG via Electron `nativeImage` before they reach the phone,
@@ -791,6 +795,10 @@ false`) and normalises the `rootPath` (trim, drop trailing `/`) so
 catalog rows from different OS reports of the same path don't
 duplicate. Project list dedup runs as a final pass
 (`deduplicateProjectListByRoot`) keyed on the normalised root path.
+Project removal stores the same normalised-root key in addition to the
+project id, so a DB-cached row and a runtime-catalog row representing
+the same filesystem path disappear together. Opening or selecting the
+project again clears those hidden keys.
 
 ### Shipped
 
@@ -940,7 +948,7 @@ reflected in the phone's UI on the next descriptor read.
 | WebSocket client | Implemented |
 | PIN pairing flow | Implemented |
 | QR pairing payload (v2, address candidates + port) | Implemented |
-| Project home + machine project switching | Implemented, including Add project actions for browsing/opening existing Git repos, creating local projects, and cloning GitHub repos on the paired machine |
+| Project home + machine project switching | Implemented, including Add project actions for browsing/opening existing Git repos, creating local projects, cloning GitHub repos on the paired machine, and removing projects from the list |
 | Lanes tab | Implemented to live machine parity (with `devicesOpen`, multi-attach, stack canvas, stack-position/base-branch editing in Manage Lane, and template environment progress) |
 | Files tab | Implemented with `mobileReadOnly` workspace gate and capped search/quick-open result rendering |
 | Work tab | Implemented; live chat-event push from runtime, subscribed terminal input/resize control with `terminal_unsubscribe` on view disappear, in-app CLI session launcher (`work.startCliSession`), message-to-continue on ended agent CLI rows |


### PR DESCRIPTION
## Summary

Fixes mobile Work hydration failures when a paired phone sends the project DB id while the multi-project runtime is routing by the machine project registry id. The sync host now treats the runtime/catalog id and DB-local project id as aliases for the same open project.

## What Changed

- Adds project-id alias matching for sync host scope resolution, project-scoped commands, and lane presence.
- Adds `project_forget_request/result` so mobile can remove a project from the project list like desktop recents.
- Adds iOS local hiding for removed project rows by id and normalized root path, plus a long-press "Remove from list" action.
- Updates sync/multi-device docs for alias handling and mobile project removal.

## Validation

- `npm --prefix apps/desktop run typecheck`
- `cd apps/desktop && npx vitest run src/main/services/sync/syncHostService.test.ts`
- `npm --prefix apps/ade-cli run typecheck`
- `npm --prefix apps/ade-cli run test`
- `node scripts/validate-docs.mjs`
- XcodeBuildMCP targeted iOS test: `ADETests/ADETests/testSyncServiceForgetProjectHidesCachedAndRemoteRowsByRoot`
- XcodeBuildMCP iOS simulator build for scheme `ADE`

## Risks

Low. The alias behavior is scoped to the current host project id and explicit aliases; mobile project removal is local-first and still sends a runtime forget request when connected.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now remove mobile sync projects from their project list.
  * Removed projects automatically remain hidden and won't reappear.
  * Added context menu option to remove projects from the list.

* **Tests**
  * Added test coverage for project removal and hidden project management across desktop and iOS apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds project-id alias handling so mobile sync can resolve runtime/catalog ids and DB-local project ids for the same open project.
- Adds `project_forget_request/result` support for removing projects from mobile project lists.
- Updates iOS project hiding and long-press removal behavior for cached and remote rows.
- Updates sync and multi-device documentation for alias handling and mobile project removal.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge after addressing the iOS host-switch catalog filtering issue.

The changes are focused and covered by targeted desktop, CLI, docs, and iOS validation, but one host-scoped state ordering issue can leave valid mobile projects hidden until another refresh.

apps/ios/ADE/Services/SyncService.swift

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The CI environment is blocked from running Swift-based tests because there is no Swift toolchain available (swift, swiftc, or xcodebuild not found).
- I compared test outcomes for the alias envelope before and after the change: before head there were 1 failing and 2 passing tests, after head all 3 tests pass. The before state showed the envelope returning {ok:false, code:"project\_mismatch"}.
- I grepped the codebase for project\_forget references and found zero occurrences in the base worktree, while the head contains references at specific locations (brain handler, syncHostService, and type definitions), and the vitest run reports 34/34 tests passing, including the new project-id-alias test.
- I ran the docs validation workflow and confirmed that validate-docs.mjs passes for 159 files both before and after the change, and I noted envelope names and alias resolution details across the repository documentation and codebase.

<a href="https://app.greptile.com/trex/runs/11243481/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/desktop/src/main/main.ts`, line 3590-3595 ([link](https://github.com/arul28/ade/blob/7161f7dcbc4314ce65533ccce4638436356ba7fd/apps/desktop/src/main/main.ts#L3590-L3595)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Alias not wired**

   The alias fix is only wired through the CLI runtime path. Desktop still creates the shared phone sync service with just the DB-local `projectId`, so `createSyncService` never receives the registry/runtime id as `runtimeProjectId` and `hostProjectIdAliases` stays empty. In the desktop paired-phone path, a phone that sends the catalog/registry id can still get `project_mismatch` or `project_not_open`, which leaves the mobile hydration failure in place for this host path.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: script exercising scope resolution with empty vs populated aliases](https://app.greptile.com/trex/artifacts/ae19d50f-6efd-4bb2-85b1-afe528eb0f2d)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: execution output showing project\_mismatch for desktop path](https://app.greptile.com/trex/artifacts/8e06bd7b-2362-4652-a1fe-d693b40ec30a)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11240503/artifacts?artifact=ae19d50f-6efd-4bb2-85b1-afe528eb0f2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/main.ts
   Line: 3590-3595

   Comment:
   **Alias not wired**

   The alias fix is only wired through the CLI runtime path. Desktop still creates the shared phone sync service with just the DB-local `projectId`, so `createSyncService` never receives the registry/runtime id as `runtimeProjectId` and `hostProjectIdAliases` stays empty. In the desktop paired-phone path, a phone that sends the catalog/registry id can still get `project_mismatch` or `project_not_open`, which leaves the mobile hydration failure in place for this host path.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fmain.ts%0ALine%3A%203590-3595%0A%0AComment%3A%0A**Alias%20not%20wired**%0A%0AThe%20alias%20fix%20is%20only%20wired%20through%20the%20CLI%20runtime%20path.%20Desktop%20still%20creates%20the%20shared%20phone%20sync%20service%20with%20just%20the%20DB-local%20%60projectId%60%2C%20so%20%60createSyncService%60%20never%20receives%20the%20registry%2Fruntime%20id%20as%20%60runtimeProjectId%60%20and%20%60hostProjectIdAliases%60%20stays%20empty.%20In%20the%20desktop%20paired-phone%20path%2C%20a%20phone%20that%20sends%20the%20catalog%2Fregistry%20id%20can%20still%20get%20%60project_mismatch%60%20or%20%60project_not_open%60%2C%20which%20leaves%20the%20mobile%20hydration%20failure%20in%20place%20for%20this%20host%20path.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=584&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `apps/ios/ADE/Services/SyncService.swift`, line 7312-7316 ([link](https://github.com/arul28/ade/blob/f071b8981516b0ca833ef4fed6b733c4280941fa/apps/ios/ADE/Services/SyncService.swift#L7312-L7316)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Reload hidden keys earlier**

   This applies the hello project catalog before `saveProfile(profile)` switches `activeHostProfile` and reloads `hiddenProjectKeys` for the connected host. If the phone previously hid `/tmp/foo` on host A and then connects to host B whose hello payload includes `/tmp/foo`, this path filters host B's catalog using host A's hidden keys. `saveProfile(profile)` reloads the right host-scoped keys later, but the already-filtered catalog is not rebuilt, so host B's project can stay missing from Project Home until another catalog refresh. Reload the host-scoped hidden keys before applying the incoming catalog, or re-apply the catalog after switching profiles.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ios/ADE/Services/SyncService.swift
   Line: 7312-7316

   Comment:
   **Reload hidden keys earlier**

   This applies the hello project catalog before `saveProfile(profile)` switches `activeHostProfile` and reloads `hiddenProjectKeys` for the connected host. If the phone previously hid `/tmp/foo` on host A and then connects to host B whose hello payload includes `/tmp/foo`, this path filters host B's catalog using host A's hidden keys. `saveProfile(profile)` reloads the right host-scoped keys later, but the already-filtered catalog is not rebuilt, so host B's project can stay missing from Project Home until another catalog refresh. Reload the host-scoped hidden keys before applying the incoming catalog, or re-apply the catalog after switching profiles.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fios%2FADE%2FServices%2FSyncService.swift%0ALine%3A%207312-7316%0A%0AComment%3A%0A**Reload%20hidden%20keys%20earlier**%0A%0AThis%20applies%20the%20hello%20project%20catalog%20before%20%60saveProfile%28profile%29%60%20switches%20%60activeHostProfile%60%20and%20reloads%20%60hiddenProjectKeys%60%20for%20the%20connected%20host.%20If%20the%20phone%20previously%20hid%20%60%2Ftmp%2Ffoo%60%20on%20host%20A%20and%20then%20connects%20to%20host%20B%20whose%20hello%20payload%20includes%20%60%2Ftmp%2Ffoo%60%2C%20this%20path%20filters%20host%20B's%20catalog%20using%20host%20A's%20hidden%20keys.%20%60saveProfile%28profile%29%60%20reloads%20the%20right%20host-scoped%20keys%20later%2C%20but%20the%20already-filtered%20catalog%20is%20not%20rebuilt%2C%20so%20host%20B's%20project%20can%20stay%20missing%20from%20Project%20Home%20until%20another%20catalog%20refresh.%20Reload%20the%20host-scoped%20hidden%20keys%20before%20applying%20the%20incoming%20catalog%2C%20or%20re-apply%20the%20catalog%20after%20switching%20profiles.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=584&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fios%2FADE%2FServices%2FSyncService.swift%3A7312-7316%0A**Reload%20hidden%20keys%20earlier**%0A%0AThis%20applies%20the%20hello%20project%20catalog%20before%20%60saveProfile%28profile%29%60%20switches%20%60activeHostProfile%60%20and%20reloads%20%60hiddenProjectKeys%60%20for%20the%20connected%20host.%20If%20the%20phone%20previously%20hid%20%60%2Ftmp%2Ffoo%60%20on%20host%20A%20and%20then%20connects%20to%20host%20B%20whose%20hello%20payload%20includes%20%60%2Ftmp%2Ffoo%60%2C%20this%20path%20filters%20host%20B's%20catalog%20using%20host%20A's%20hidden%20keys.%20%60saveProfile%28profile%29%60%20reloads%20the%20right%20host-scoped%20keys%20later%2C%20but%20the%20already-filtered%20catalog%20is%20not%20rebuilt%2C%20so%20host%20B's%20project%20can%20stay%20missing%20from%20Project%20Home%20until%20another%20catalog%20refresh.%20Reload%20the%20host-scoped%20hidden%20keys%20before%20applying%20the%20incoming%20catalog%2C%20or%20re-apply%20the%20catalog%20after%20switching%20profiles.%0A%0A&repo=arul28%2Fade&pr=584&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/ios/ADE/Services/SyncService.swift:7312-7316
**Reload hidden keys earlier**

This applies the hello project catalog before `saveProfile(profile)` switches `activeHostProfile` and reloads `hiddenProjectKeys` for the connected host. If the phone previously hid `/tmp/foo` on host A and then connects to host B whose hello payload includes `/tmp/foo`, this path filters host B's catalog using host A's hidden keys. `saveProfile(profile)` reloads the right host-scoped keys later, but the already-filtered catalog is not rebuilt, so host B's project can stay missing from Project Home until another catalog refresh. Reload the host-scoped hidden keys before applying the incoming catalog, or re-apply the catalog after switching profiles.


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["ship: address hidden project review feed..."](https://github.com/arul28/ade/commit/f071b8981516b0ca833ef4fed6b733c4280941fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37826533)</sub>

<!-- /greptile_comment -->