### PR TITLE
release: changelog for v1.2.6

### DIFF
--- a/changelog/v1.2.6.mdx
+++ b/changelog/v1.2.6.mdx
@@ -1,0 +1,20 @@
+---
+title: "v1.2.6"
+description: "Release notes for ADE v1.2.6 - June 16, 2026"
+---
+
+v1.2.6 unblocks on-device voice input from the chat mic, fixes image paste in remote ADE Code, and makes phone sync hold onto projects through hide, unhide, and forget.
+
+---
+
+## Desktop
+
+- **Voice input you can actually turn on.** The voice dictation model now downloads straight from the chat mic — and from Settings → General — instead of the old dead-end "ships with a future update" tooltip. The ~141 MB download runs in the background, survives leaving Settings, verifies its checksum, and retries on failure.
+- **Image paste in remote ADE Code.** Pasting an image into `ade code` connected to a remote machine no longer crashes with a permission error. The image is materialized locally and uploaded to the runtime, mirroring the desktop composer; local mode is unchanged.
+- **Steadier phone sync.** Mobile sync now resolves project identity aliases, so a paired phone keeps tracking the right project through hide, unhide, and forget instead of losing it.
+
+---
+
+## iOS
+
+- **Reliable project sync.** The companion app stays mapped to the correct project across identity changes (hide / unhide / forget), fixing cases where a project could drop off the phone after those actions.

--- a/docs.json
+++ b/docs.json
@@ -194,6 +194,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.6",
               "changelog/v1.2.5",
               "changelog/v1.2.4",
               "changelog/v1.2.3",


### PR DESCRIPTION
Changelog for v1.2.6 (desktop + iOS). Tag will be cut after this lands on main.

- Voice model downloadable from chat mic + General settings
- ADE Code remote clipboard image paste fix
- Mobile sync project identity alias fix (desktop + iOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds the v1.2.6 changelog page for desktop and iOS release notes.
- Adds the v1.2.6 page to the docs sidebar navigation.
- Documents voice model download, remote clipboard image paste, and mobile sync identity fixes.

<h3>Confidence Score: 4/5</h3>

The release documentation is not ready to merge because the new release page is not consistently reflected in the changelog entry points.

The changed docs are small and focused, and the affected release-documentation mismatches are concrete and reproducible.

docs.json, changelog/v1.2.6.mdx, changelog/index.mdx, and CHANGELOG.md need alignment for v1.2.6.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a reproducibility script to compare the latest sidebar entry with the landing page card and found a mismatch where v1.2.6 appears in the sidebar but the landing page links to v1.2.5.
- Ran a root changelog validation to verify that v1.2.6 is present in the PR but not in the root CHANGELOG.md, and observed a mismatch causing the check to fail.
- Started base and head Mintlify dev servers to compare versions and confirmed that the head includes v1.2.6 in the sidebar and that the /changelog/v1.2.6 page renders.

<a href="https://app.greptile.com/trex/runs/11248737/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Adocs.json%3A197%0A**Latest%20card%20stays%20stale.**%20This%20adds%20%60changelog%2Fv1.2.6%60%20as%20the%20newest%20sidebar%20page%2C%20but%20the%20%60%2Fchangelog%60%20landing%20page%20still%20links%20and%20labels%20the%20latest%20release%20as%20v1.2.5.%20Users%20who%20open%20the%20stable%20changelog%20page%20will%20still%20be%20sent%20to%20the%20old%20release%2C%20and%20the%20release-doc%20validation%20will%20fail%20once%20the%20v1.2.6%20tag%20exists%20because%20it%20requires%20the%20latest-release%20card%20to%20mention%20and%20link%20to%20the%20latest%20tag.%0A%0A%23%23%23%20Issue%202%20of%202%0Achangelog%2Fv1.2.6.mdx%3A1-3%0A**Root%20changelog%20missing.**%20This%20PR%20adds%20the%20v1.2.6%20docs%20page%2C%20but%20the%20root%20%60CHANGELOG.md%60%20still%20has%20%601.2.5%60%20as%20the%20top%20released%20version%20and%20has%20no%20%601.2.6%60%20heading%20or%20compare%20link.%20After%20the%20v1.2.6%20tag%20is%20cut%2C%20the%20docs%20validation%20path%20that%20checks%20the%20latest%20git%20tag%20against%20%60CHANGELOG.md%60%20will%20fail%2C%20and%20consumers%20of%20the%20root%20changelog%20will%20not%20see%20this%20release.%0A%0A&repo=arul28%2Fade&pr=585&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
docs.json:197
**Latest card stays stale.** This adds `changelog/v1.2.6` as the newest sidebar page, but the `/changelog` landing page still links and labels the latest release as v1.2.5. Users who open the stable changelog page will still be sent to the old release, and the release-doc validation will fail once the v1.2.6 tag exists because it requires the latest-release card to mention and link to the latest tag.

### Issue 2 of 2
changelog/v1.2.6.mdx:1-3
**Root changelog missing.** This PR adds the v1.2.6 docs page, but the root `CHANGELOG.md` still has `1.2.5` as the top released version and has no `1.2.6` heading or compare link. After the v1.2.6 tag is cut, the docs validation path that checks the latest git tag against `CHANGELOG.md` will fail, and consumers of the root changelog will not see this release.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["release: changelog for v1.2.6"](https://github.com/arul28/ade/commit/582a402b90b494f16236c2536d5f18b169015480) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37852146)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->