### PR TITLE
release: sync CHANGELOG + index for v1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.6] - 2026-06-16
+
+### Fixed
+
+- Voice input is reachable again: the on-device dictation model now downloads straight from the chat mic and from Settings → General instead of a dead-end "ships with a future update" tooltip. The download runs in the background, survives leaving Settings, and verifies its checksum with retry.
+- ADE Code: pasting an image while connected to a remote machine no longer crashes with a permission error — the image is materialized locally and uploaded to the runtime.
+- Mobile sync resolves project identity aliases, so a paired phone keeps tracking the right project through hide, unhide, and forget (desktop + iOS).
+
 ## [1.2.5] - 2026-06-16
 
 ### Added
@@ -402,6 +410,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial public release.
 
 [Unreleased]: https://github.com/arul28/ADE/compare/v1.2.5...HEAD
+[1.2.6]: https://github.com/arul28/ADE/compare/v1.2.5...v1.2.6
 [1.2.5]: https://github.com/arul28/ADE/compare/v1.2.4...v1.2.5
 [1.2.4]: https://github.com/arul28/ADE/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/arul28/ADE/compare/v1.2.2...v1.2.3

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.5">
-  v1.2.5 - reliable macOS auto-updates via smaller per-architecture builds, plus remote ADE Code and MCP in Claude chats.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.6">
+  v1.2.6 - voice input downloadable straight from the chat mic, image paste fixed in remote ADE Code, and steadier phone sync across project hide, unhide, and forget.
 </Card>


### PR DESCRIPTION
Follow-up to #585. validate-docs (ci-pass gate) requires CHANGELOG.md + changelog/index.mdx to track the latest tag v1.2.6. This unblocks the release verify job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds the ADE v1.2.6 release notes to `CHANGELOG.md`.
- Updates the changelog index card to point at the v1.2.6 release page.
- Documents the voice input, remote image paste, and phone sync fixes included in the release.

<h3>Confidence Score: 4/5</h3>

Merge is low risk after correcting the stale changelog comparison link.

The change is documentation-only and narrowly scoped, with one release-link accuracy issue affecting future changelog diffs.

CHANGELOG.md

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The changelog review confirmed that v1.2.6 was added to CHANGELOG.md and the latest release card in index.mdx now links to /changelog/v1.2.6.

<a href="https://app.greptile.com/trex/runs/11249047/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACHANGELOG.md%3A412-413%0A**Advance%20Unreleased%20link**%0A%0AAfter%20adding%20%601.2.6%60%20as%20the%20latest%20released%20section%2C%20the%20%60Unreleased%60%20compare%20link%20still%20starts%20at%20%60v1.2.5%60.%20Clicking%20it%20now%20includes%20all%20v1.2.6%20changes%20as%20unreleased%20content%2C%20so%20the%20next%20unreleased%20diff%20will%20be%20inaccurate%20until%20this%20link%20advances%20to%20the%20new%20tag.%0A%0A&repo=arul28%2Fade&pr=586&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
CHANGELOG.md:412-413
**Advance Unreleased link**

After adding `1.2.6` as the latest released section, the `Unreleased` compare link still starts at `v1.2.5`. Clicking it now includes all v1.2.6 changes as unreleased content, so the next unreleased diff will be inaccurate until this link advances to the new tag.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["release: sync CHANGELOG.md + changelog i..."](https://github.com/arul28/ade/commit/79c18475ff958a6cfbe46082592ae792a6a48502) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37852746)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->