### PR TITLE
Fix external link opening in remote PR surfaces

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -69,6 +69,7 @@ import { createPrService } from "./services/prs/prService";
 import { createPrPollingService } from "./services/prs/prPollingService";
 import { createQueueLandingService } from "./services/prs/queueLandingService";
 import { createPrSummaryService } from "./services/prs/prSummaryService";
+import { openExternalUrl } from "./services/shared/externalLinks";
 import {
   detectDefaultBaseRef,
   resolveRepoRoot,
@@ -2482,9 +2483,7 @@ app.whenReady().then(async () => {
       onHotRefreshChanged: () => {
         prPollingServiceRef?.poke();
       },
-      openExternal: async (url) => {
-        await shell.openExternal(url);
-      },
+      openExternal: openExternalUrl,
     });
     prServiceRef = prService;
 

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -615,6 +615,7 @@ import { quoteWindowsCmdArg } from "../shared/processExecution";
 import { sanitizeResumeTargetId } from "../../utils/terminalSessionSignals";
 import { probeLocalhostPort } from "../probeLocalhostPort";
 import type { ProcessRegistryService } from "../runtime/processRegistryService";
+import { openExternalUrl } from "../shared/externalLinks";
 
 type ElectronProcessMetric = ReturnType<typeof app.getAppMetrics>[number];
 const APP_RESOURCE_USAGE_CACHE_MS = 900;
@@ -3011,19 +3012,7 @@ export function registerIpc({
   });
 
   ipcMain.handle(IPC.appOpenExternal, async (_event, arg: { url: string }): Promise<void> => {
-    const urlRaw = typeof arg?.url === "string" ? arg.url.trim() : "";
-    if (!urlRaw) return;
-    let parsed: URL;
-    try {
-      parsed = new URL(urlRaw);
-    } catch {
-      throw new Error("Invalid URL");
-    }
-    const ALLOWED_URL_SCHEMES = new Set(["http:", "https:", "mailto:"]);
-    if (!ALLOWED_URL_SCHEMES.has(parsed.protocol)) {
-      throw new Error("Only http(s) and mailto: URLs are allowed.");
-    }
-    await shell.openExternal(parsed.toString());
+    await openExternalUrl(arg?.url);
   });
 
   const resolveRendererSuppliedPath = (rawPath: string, projectRoot: string): string => {

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -1762,6 +1762,7 @@ export function registerIpc({
     [IPC.terminalWrite]: new Set(["data"]),
     [IPC.ptySendToSession]: new Set(["text"]),
     [IPC.ptyWrite]: new Set(["data"]),
+    [IPC.appOpenExternal]: new Set(["url"]),
     [IPC.builtInBrowserNavigate]: new Set(["url"]),
     [IPC.builtInBrowserCreateTab]: new Set(["url"]),
     [IPC.builtInBrowserShowPanel]: new Set(["url"]),

--- a/apps/desktop/src/main/services/shared/externalLinks.test.ts
+++ b/apps/desktop/src/main/services/shared/externalLinks.test.ts
@@ -46,34 +46,40 @@ describe("externalLinks", () => {
 
   it("uses /usr/bin/open on macOS", async () => {
     const restorePlatform = mockPlatform("darwin");
-    mockedExecFile.mockImplementation((_file, _args, _options, cb) => {
-      cb?.(null as never, "" as never, "" as never);
-      return {} as never;
-    });
+    try {
+      mockedExecFile.mockImplementation((_file, _args, _options, cb) => {
+        cb?.(null as never, "" as never, "" as never);
+        return {} as never;
+      });
 
-    await openExternalUrl("https://github.com/acme/ade/pull/1");
+      await openExternalUrl("https://github.com/acme/ade/pull/1");
 
-    expect(mockedExecFile).toHaveBeenCalledWith(
-      "/usr/bin/open",
-      ["https://github.com/acme/ade/pull/1"],
-      { timeout: 5_000, windowsHide: true },
-      expect.any(Function),
-    );
-    expect(shellOpenExternal).not.toHaveBeenCalled();
-    restorePlatform();
+      expect(mockedExecFile).toHaveBeenCalledWith(
+        "/usr/bin/open",
+        ["https://github.com/acme/ade/pull/1"],
+        { timeout: 5_000, windowsHide: true },
+        expect.any(Function),
+      );
+      expect(shellOpenExternal).not.toHaveBeenCalled();
+    } finally {
+      restorePlatform();
+    }
   });
 
   it("falls back to Electron shell when macOS open fails", async () => {
     const restorePlatform = mockPlatform("darwin");
-    mockedExecFile.mockImplementation((_file, _args, _options, cb) => {
-      cb?.(new Error("open failed") as never, "" as never, "" as never);
-      return {} as never;
-    });
-    shellOpenExternal.mockResolvedValue(undefined);
+    try {
+      mockedExecFile.mockImplementation((_file, _args, _options, cb) => {
+        cb?.(new Error("open failed") as never, "" as never, "" as never);
+        return {} as never;
+      });
+      shellOpenExternal.mockResolvedValue(undefined);
 
-    await openExternalUrl("https://github.com/acme/ade/pull/1");
+      await openExternalUrl("https://github.com/acme/ade/pull/1");
 
-    expect(shellOpenExternal).toHaveBeenCalledWith("https://github.com/acme/ade/pull/1");
-    restorePlatform();
+      expect(shellOpenExternal).toHaveBeenCalledWith("https://github.com/acme/ade/pull/1");
+    } finally {
+      restorePlatform();
+    }
   });
 });

--- a/apps/desktop/src/main/services/shared/externalLinks.test.ts
+++ b/apps/desktop/src/main/services/shared/externalLinks.test.ts
@@ -1,0 +1,79 @@
+import { execFile } from "node:child_process";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const shellOpenExternal = vi.hoisted(() => vi.fn());
+
+vi.mock("electron", () => ({
+  shell: {
+    openExternal: shellOpenExternal,
+  },
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+import { normalizeExternalUrl, openExternalUrl } from "./externalLinks";
+
+const mockedExecFile = vi.mocked(execFile);
+
+function mockPlatform(platform: NodeJS.Platform): () => void {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: platform });
+  return () => {
+    if (descriptor) Object.defineProperty(process, "platform", descriptor);
+  };
+}
+
+describe("externalLinks", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    shellOpenExternal.mockReset();
+    mockedExecFile.mockReset();
+  });
+
+  it("normalizes and allows http, https, and mailto URLs", () => {
+    expect(normalizeExternalUrl(" https://github.com/ade-dev/ade/pull/42 ")).toBe(
+      "https://github.com/ade-dev/ade/pull/42",
+    );
+    expect(normalizeExternalUrl("mailto:test@example.com")).toBe("mailto:test@example.com");
+  });
+
+  it("rejects unsupported schemes", () => {
+    expect(() => normalizeExternalUrl("file:///tmp/a.txt")).toThrow(/Only http/);
+    expect(() => normalizeExternalUrl("not a url")).toThrow(/Invalid URL/);
+  });
+
+  it("uses /usr/bin/open on macOS", async () => {
+    const restorePlatform = mockPlatform("darwin");
+    mockedExecFile.mockImplementation((_file, _args, _options, cb) => {
+      cb?.(null as never, "" as never, "" as never);
+      return {} as never;
+    });
+
+    await openExternalUrl("https://github.com/acme/ade/pull/1");
+
+    expect(mockedExecFile).toHaveBeenCalledWith(
+      "/usr/bin/open",
+      ["https://github.com/acme/ade/pull/1"],
+      { timeout: 5_000, windowsHide: true },
+      expect.any(Function),
+    );
+    expect(shellOpenExternal).not.toHaveBeenCalled();
+    restorePlatform();
+  });
+
+  it("falls back to Electron shell when macOS open fails", async () => {
+    const restorePlatform = mockPlatform("darwin");
+    mockedExecFile.mockImplementation((_file, _args, _options, cb) => {
+      cb?.(new Error("open failed") as never, "" as never, "" as never);
+      return {} as never;
+    });
+    shellOpenExternal.mockResolvedValue(undefined);
+
+    await openExternalUrl("https://github.com/acme/ade/pull/1");
+
+    expect(shellOpenExternal).toHaveBeenCalledWith("https://github.com/acme/ade/pull/1");
+    restorePlatform();
+  });
+});

--- a/apps/desktop/src/main/services/shared/externalLinks.ts
+++ b/apps/desktop/src/main/services/shared/externalLinks.ts
@@ -1,0 +1,50 @@
+import { execFile } from "node:child_process";
+import { shell } from "electron";
+
+const ALLOWED_EXTERNAL_URL_SCHEMES = new Set(["http:", "https:", "mailto:"]);
+
+export function normalizeExternalUrl(url: string | undefined | null): string | null {
+  const raw = typeof url === "string" ? url.trim() : "";
+  if (!raw) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error("Invalid URL");
+  }
+
+  if (!ALLOWED_EXTERNAL_URL_SCHEMES.has(parsed.protocol)) {
+    throw new Error("Only http(s) and mailto: URLs are allowed.");
+  }
+
+  return parsed.toString();
+}
+
+function openWithMacOpen(url: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile("/usr/bin/open", [url], { timeout: 5_000, windowsHide: true }, (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function openExternalUrl(url: string | undefined | null): Promise<void> {
+  const normalized = normalizeExternalUrl(url);
+  if (!normalized) return;
+
+  if (process.platform === "darwin") {
+    try {
+      await openWithMacOpen(normalized);
+      return;
+    } catch {
+      // Fall back to Electron's opener if Launch Services' `open` command is unavailable.
+    }
+  }
+
+  await shell.openExternal(normalized);
+}

--- a/apps/desktop/src/renderer/components/chat/ChatGitToolbar.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatGitToolbar.test.tsx
@@ -31,6 +31,9 @@ function installAdeMocks() {
       getChecks: vi.fn().mockResolvedValue([]),
       openInGitHub: vi.fn().mockResolvedValue(undefined),
     },
+    app: {
+      openExternal: vi.fn().mockResolvedValue(undefined),
+    },
     projectConfig: {
       get: vi.fn().mockResolvedValue({
         effective: {
@@ -130,15 +133,14 @@ describe("ChatGitToolbar", () => {
     );
   });
 
-  it("does not load diff or PR state when mounted for a remote project", async () => {
+  it("loads remote PR state on mount without fetching remote diff status", async () => {
     resetStore({ remote: true });
 
     renderToolbar();
 
-    await Promise.resolve();
+    await waitFor(() => expect(window.ade.prs.getForLane).toHaveBeenCalledWith("lane-1"));
 
     expect(window.ade.diff.getChanges).not.toHaveBeenCalled();
-    expect(window.ade.prs.getForLane).not.toHaveBeenCalled();
   });
 
   it("resolves the linked PR on first remote PR click before routing", async () => {
@@ -157,12 +159,38 @@ describe("ChatGitToolbar", () => {
 
     renderToolbar();
 
-    fireEvent.click(await screen.findByRole("button", { name: "PR" }));
+    const badge = await screen.findByRole("button", { name: /PR #/ });
+    fireEvent.click(badge);
+    fireEvent.click(screen.getByRole("button", { name: /ADE/ }));
 
     await waitFor(() => {
       expect(screen.getByTestId("location").textContent).toBe("/prs?tab=normal&prId=pr-1");
     });
-    expect(window.ade.prs.getForLane).toHaveBeenCalledTimes(1);
+    expect(window.ade.prs.getForLane).toHaveBeenCalledWith("lane-1");
     expect(window.ade.diff.getChanges).not.toHaveBeenCalled();
+  });
+
+  it("opens a linked PR URL through the local app bridge", async () => {
+    vi.mocked(window.ade.prs.getForLane).mockResolvedValue({
+      id: "pr-1",
+      laneId: "lane-1",
+      title: "Linked PR",
+      state: "open",
+      checksStatus: "unknown",
+      githubUrl: "https://github.com/acme/ade/pull/1",
+      additions: 0,
+      deletions: 0,
+      updatedAt: null,
+    } as any);
+
+    renderToolbar();
+
+    fireEvent.click(await screen.findByRole("button", { name: /PR #/ }));
+    fireEvent.click(screen.getByRole("button", { name: /GitHub/ }));
+
+    await waitFor(() => {
+      expect(window.ade.app.openExternal).toHaveBeenCalledWith("https://github.com/acme/ade/pull/1");
+    });
+    expect(window.ade.prs.openInGitHub).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/components/chat/ChatGitToolbar.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatGitToolbar.tsx
@@ -156,8 +156,7 @@ export const ChatGitToolbar = React.memo(function ChatGitToolbar({
     setPrLoaded(false);
     setPrMenuOpen(false);
     setPrChecks(null);
-    if (isRemoteProject) return;
-    void refreshStatus();
+    if (!isRemoteProject) void refreshStatus();
     void refreshPr();
   }, [isRemoteProject, refreshStatus, refreshPr]);
 
@@ -165,32 +164,32 @@ export const ChatGitToolbar = React.memo(function ChatGitToolbar({
   const prevBusy = React.useRef(runtime.busyAction);
   useEffect(() => {
     if (prevBusy.current && !runtime.busyAction) {
-      if (isRemoteProject && !prLoaded) {
-        prevBusy.current = runtime.busyAction;
-        return;
-      }
-      void refreshStatus();
+      if (!isRemoteProject) void refreshStatus();
       void refreshPr();
     }
     prevBusy.current = runtime.busyAction;
-  }, [isRemoteProject, prLoaded, runtime.busyAction, refreshStatus, refreshPr]);
+  }, [isRemoteProject, runtime.busyAction, refreshStatus, refreshPr]);
 
   // Subscribe to backend PR events so the linked-PR pill reflects external
   // changes (PR closed, merged, checks finished, etc.) without a manual refresh.
   useEffect(() => {
     const unsubscribe = window.ade.prs.onEvent((event) => {
+      if (event.type === "pr-notification") {
+        if (event.laneId === laneId || event.prId === linkedPr?.id) void refreshPr();
+        return;
+      }
       if (event.type !== "prs-updated") return;
-      // Only re-fetch when an update could plausibly touch this lane's PR.
-      if (event.prs.some((pr) => pr.laneId === laneId)) {
-        if (isRemoteProject && !prLoaded && !linkedPr) return;
+      const eventIncludesLanePr = event.prs.some((pr) => pr.laneId === laneId);
+      const eventIncludesLinkedPr = linkedPr ? event.prs.some((pr) => pr.id === linkedPr.id) : false;
+      if (eventIncludesLanePr || eventIncludesLinkedPr) {
         void refreshPr();
-      } else if (linkedPr && !event.prs.some((pr) => pr.id === linkedPr.id)) {
+      } else if (linkedPr) {
         // The linked PR vanished from the latest snapshot — clear the pill.
         setLinkedPr(null);
       }
     });
     return unsubscribe;
-  }, [isRemoteProject, laneId, linkedPr, prLoaded, refreshPr]);
+  }, [laneId, linkedPr, refreshPr]);
 
   const handlePr = useCallback(async () => {
     if (linkedPr) {
@@ -266,7 +265,7 @@ export const ChatGitToolbar = React.memo(function ChatGitToolbar({
   const handleOpenInGitHub = useCallback(async () => {
     if (!linkedPr) return;
     try {
-      await window.ade.prs.openInGitHub(linkedPr.id);
+      await window.ade.app.openExternal(linkedPr.githubUrl);
     } catch {
       // Best-effort fallback: let the OS handle the URL directly.
       try { window.open(linkedPr.githubUrl, "_blank", "noopener,noreferrer"); } catch { /* noop */ }

--- a/apps/desktop/src/renderer/components/chat/ChatPrPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatPrPane.tsx
@@ -157,7 +157,7 @@ export const ChatPrPane = React.memo(function ChatPrPane({
   const openInGitHub = useCallback(async () => {
     if (!pr) return;
     try {
-      await window.ade.prs.openInGitHub(pr.id);
+      await window.ade.app.openExternal(pr.githubUrl);
     } catch {
       try { window.open(pr.githubUrl, "_blank", "noopener,noreferrer"); } catch { /* noop */ }
     }


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstart-context-skill-issue-that-281b5042 num=598 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstart-context-skill-issue-that-281b5042&amp;pr=598">ade/start-context-skill-issue-that-281b5042 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=598">PR #598</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Centralized external link handling with improved URL validation to reject unsupported schemes and invalid inputs.
  * Enhanced macOS support for opening links using native system mechanisms with fallback support.
  * Streamlined PR link opening behavior across the application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Centralizes external URL normalization and opening in the desktop main process.
- Routes `app.openExternal` IPC through the shared helper with URL redaction in traces.
- Updates remote PR chat surfaces to open GitHub links through the local app bridge and load linked PR state.

<h3>Confidence Score: 5/5</h3>

The changes are narrowly scoped to external link handling and remote PR link behavior, with no review comments requiring code changes.

The updated helper centralizes URL validation and dispatch while renderer changes consistently route GitHub links through the app bridge.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The baseline IPC URL handling tests were executed, showing that the inline handler normalized and validated URLs and always called shell.openExternal.
- The updated IPC URL handling tests were executed, showing that the head shared helper normalizes and validates URLs and uses execFile('/usr/bin/open', \[url\], { timeout: 5000, windowsHide: true }) on simulated darwin with a fallback to shell.openExternal, and it calls shell.openExternal on Linux.
- The base UI behavior tests were executed, showing that ChatPrPane called prs.openInGitHub('pr-remote-1') and did not call app.openExternal, and the toolbar did not resolve the linked PR badge on mount.
- The updated UI behavior tests were executed, showing that TOOLBAR\_REMOTE\_CLICK opened https://github.com/acme/perf-pass/pull/1 with openExternal=1 and that PANE\_REMOTE\_CLICK also opened the same PR URL, both tests passing with exit code 0.

<a href="https://app.greptile.com/trex/runs/11365482/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Address external link review safeguards"](https://github.com/arul28/ade/commit/31d90346a8ca157781da991e8ef6966ace295188) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38076733)</sub>

<!-- /greptile_comment -->