### PR TITLE
Mic Model Status Refresh

### DIFF
--- a/apps/desktop/src/renderer/components/settings/DictationSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/DictationSection.tsx
@@ -31,8 +31,8 @@ function formatMb(bytes: number): string {
  * The ~141 MB speech model is NOT bundled (it would bloat the auto-update). When
  * voice input is enabled but the model hasn't been downloaded, this offers a
  * one-time download driven by the app-global installer — so it keeps running in
- * the background even if the user leaves Settings. After it lands, ADE must be
- * restarted for voice input to take effect everywhere.
+ * the background even if the user leaves Settings. When it lands, every chat mic
+ * (which subscribes to the same installer) enables live — no restart needed.
  */
 export function DictationSection() {
   const voiceInputEnabled = useAppStore((s) => s.voiceInputEnabled);
@@ -51,9 +51,8 @@ export function DictationSection() {
       : null;
 
   const isDownloading = install.phase === "downloading";
-  const justDownloaded = install.phase === "installed" && install.restartRequired;
-  const alreadyInstalled = install.modelInstalled && !install.restartRequired && !isDownloading;
-  const needsDownload = !isDownloading && !justDownloaded && !alreadyInstalled;
+  const alreadyInstalled = install.modelInstalled && !isDownloading;
+  const needsDownload = !isDownloading && !alreadyInstalled;
 
   return (
     <section id="voice-input">
@@ -109,11 +108,6 @@ export function DictationSection() {
               You can leave this page — the download continues in the background.
             </span>
           </div>
-        ) : justDownloaded ? (
-          <div style={detailStyle}>
-            <span style={{ color: COLORS.accent, fontWeight: 600 }}>✓ Voice model downloaded.</span>{" "}
-            Restart ADE to enable voice input.
-          </div>
         ) : alreadyInstalled ? (
           <div style={detailStyle}>
             <span style={{ color: COLORS.accent, fontWeight: 600 }}>✓ Voice model installed.</span>{" "}
@@ -122,8 +116,8 @@ export function DictationSection() {
         ) : needsDownload ? (
           <div style={{ marginLeft: 24, display: "flex", flexDirection: "column", gap: 8 }}>
             <span style={{ fontSize: 10, fontFamily: MONO_FONT, color: COLORS.textMuted, lineHeight: 1.5 }}>
-              The on-device speech model (~{VOICE_MODEL_SIZE_LABEL}) downloads once, then runs fully offline. ADE
-              must be restarted after it installs.
+              The on-device speech model (~{VOICE_MODEL_SIZE_LABEL}) downloads once, then runs fully offline. The
+              mic enables as soon as it finishes — no restart.
             </span>
             <button
               type="button"

--- a/apps/desktop/src/renderer/hooks/useVoiceModelInstalled.test.tsx
+++ b/apps/desktop/src/renderer/hooks/useVoiceModelInstalled.test.tsx
@@ -1,0 +1,104 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+
+interface FakeStatus {
+  installed: boolean;
+  binaryInstalled: boolean;
+  modelInstalled: boolean;
+  downloading: boolean;
+  binaryPath: string | null;
+  modelPath: string | null;
+}
+
+function statusFor(modelInstalled: boolean): FakeStatus {
+  return {
+    installed: modelInstalled,
+    binaryInstalled: true,
+    modelInstalled,
+    downloading: false,
+    binaryPath: "/app/whisper/whisper-cli",
+    modelPath: modelInstalled ? "/userData/whisper/ggml-base.en.bin" : null,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.resetModules();
+  delete (window as unknown as { ade?: unknown }).ade;
+});
+
+describe("useVoiceModelInstalled", () => {
+  it("flips false → true when the model download completes, without remounting", async () => {
+    // Mirrors the real bug scenario: a chat composer stays mounted while the
+    // model is downloaded from Settings. The mic must enable live (no restart).
+    let modelInstalled = false;
+    const status = vi.fn(async () => statusFor(modelInstalled));
+    const downloadModel = vi.fn(async () => {
+      modelInstalled = true; // main resolves the model fresh on the next call
+      return statusFor(true);
+    });
+    (window as unknown as { ade: unknown }).ade = {
+      transcription: {
+        status,
+        downloadModel,
+        onModelDownloadProgress: () => () => {},
+      },
+    };
+
+    // Fresh singleton + hook from the same (reset) module graph so the hook
+    // subscribes to the very installer the download drives.
+    const { useVoiceModelInstalled } = await import("./useVoiceModelInstalled");
+    const { globalVoiceModelInstaller } = await import(
+      "../services/globalVoiceModelInstaller"
+    );
+
+    const { result } = renderHook(() => useVoiceModelInstalled(true));
+
+    // Unknown until the first probe resolves, then known-absent.
+    expect(result.current).toBeNull();
+    await waitFor(() => expect(result.current).toBe(false));
+
+    // Download completes on the shared singleton — no remount of the consumer.
+    await act(async () => {
+      await globalVoiceModelInstaller.start();
+    });
+
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it("resolves to false (not stuck null) when the transcription bridge is absent", async () => {
+    // Degraded / non-Electron surface: no window.ade.transcription. The hook must
+    // still resolve to known-absent (false) so the mic shows its download CTA
+    // rather than hanging on null forever. Guards the refresh() no-bridge branch
+    // that marks `probed` even without an API — the mechanic the live-flip relies
+    // on to leave the "unknown" state.
+    delete (window as unknown as { ade?: unknown }).ade;
+
+    const { useVoiceModelInstalled } = await import("./useVoiceModelInstalled");
+    const { globalVoiceModelInstaller } = await import(
+      "../services/globalVoiceModelInstaller"
+    );
+    const { result } = renderHook(() => useVoiceModelInstalled(true));
+
+    // The no-bridge probe resolves synchronously (no IPC round-trip), so the hook
+    // settles directly on known-absent rather than passing through a null window.
+    await waitFor(() => expect(result.current).toBe(false));
+
+    const state = globalVoiceModelInstaller.getState();
+    expect(state.probed).toBe(true);
+    expect(state.binaryInstalled).toBe(false);
+  });
+
+  it("returns null while voice input is disabled (no probe)", async () => {
+    const status = vi.fn(async () => statusFor(true));
+    (window as unknown as { ade: unknown }).ade = { transcription: { status } };
+
+    const { useVoiceModelInstalled } = await import("./useVoiceModelInstalled");
+    const { result } = renderHook(() => useVoiceModelInstalled(false));
+
+    expect(result.current).toBeNull();
+    expect(status).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/hooks/useVoiceModelInstalled.ts
+++ b/apps/desktop/src/renderer/hooks/useVoiceModelInstalled.ts
@@ -1,32 +1,31 @@
 import { useEffect, useState } from "react";
+import { globalVoiceModelInstaller } from "../services/globalVoiceModelInstaller";
 
 /**
- * Probe whether the on-device voice transcription model is installed.
+ * Whether the on-device voice transcription model is installed.
  * Returns `null` until known, then `true`/`false`. The transcription bridge is
  * absent in non-Electron / test surfaces, which is treated as not installed.
  *
- * Pass `enabled = false` to skip the probe (e.g. while voice input is disabled).
+ * Backed by the app-global installer singleton (the same source the Settings
+ * download drives), so when a download completes the mic flips live — no app
+ * restart. Pass `enabled = false` to skip the probe (e.g. while voice input is
+ * disabled).
  */
 export function useVoiceModelInstalled(enabled = true): boolean | null {
-  const [installed, setInstalled] = useState<boolean | null>(null);
+  const [state, setState] = useState(() => globalVoiceModelInstaller.getState());
   useEffect(() => {
+    // Disabled → this hook returns null below, so subscribing would only churn
+    // setState for a value we discard. Gate the whole effect on `enabled` (the
+    // sibling useVoiceModelInstall subscribes unconditionally because it always
+    // surfaces live phase/progress, even while disabled).
     if (!enabled) return;
-    const status = window.ade?.transcription?.status;
-    if (!status) {
-      setInstalled(false);
-      return;
-    }
-    let cancelled = false;
-    status()
-      .then((result) => {
-        if (!cancelled) setInstalled(result.installed);
-      })
-      .catch(() => {
-        if (!cancelled) setInstalled(false);
-      });
-    return () => {
-      cancelled = true;
-    };
+    const unsubscribe = globalVoiceModelInstaller.subscribe(setState);
+    // Sync immediately in case state changed between render and subscribe.
+    setState(globalVoiceModelInstaller.getState());
+    void globalVoiceModelInstaller.refresh();
+    return unsubscribe;
   }, [enabled]);
-  return installed;
+
+  if (!enabled || !state.probed) return null;
+  return state.binaryInstalled && state.modelInstalled;
 }

--- a/apps/desktop/src/renderer/services/globalVoiceModelInstaller.ts
+++ b/apps/desktop/src/renderer/services/globalVoiceModelInstaller.ts
@@ -10,10 +10,10 @@
  * so any surface (Settings, the chat mic) reads a consistent state and a
  * navigation away never loses an in-flight download.
  *
- * Restart note: after a successful download we set `restartRequired`. The model
- * is resolved dynamically by the main process, but the renderer probes
- * install-state on mount and won't live-flip every open composer — so we tell
- * the user to restart ADE for voice input to take effect everywhere.
+ * Live flip: the main process resolves the model dynamically (it stats disk on
+ * every status/transcribe call), and every voice surface — Settings and each
+ * chat mic — subscribes to this singleton. So when a download completes we just
+ * push the new state and the mic enables everywhere immediately; no app restart.
  */
 
 export type VoiceModelPhase = "idle" | "downloading" | "installed" | "error";
@@ -27,8 +27,8 @@ export interface VoiceModelInstallState {
   receivedBytes: number;
   totalBytes: number | null;
   error: string | null;
-  /** A successful download happened this session → restart ADE to enable it everywhere. */
-  restartRequired: boolean;
+  /** True once we've probed the main process at least once (else state is unknown). */
+  probed: boolean;
 }
 
 type Listener = (state: VoiceModelInstallState) => void;
@@ -49,7 +49,7 @@ class VoiceModelInstaller {
     receivedBytes: 0,
     totalBytes: null,
     error: null,
-    restartRequired: false,
+    probed: false,
   };
 
   private readonly listeners = new Set<Listener>();
@@ -81,12 +81,13 @@ class VoiceModelInstaller {
 
   /**
    * Probe whether the binary + model are present. Safe to call repeatedly; never
-   * clobbers an in-flight download or the restart-required flag.
+   * clobbers an in-flight download. Marks `probed` so consumers can distinguish
+   * "unknown" from "known absent".
    */
   async refresh(): Promise<void> {
     const api = window.ade?.transcription;
     if (!api?.status) {
-      this.set({ binaryInstalled: false, modelInstalled: false });
+      this.set({ binaryInstalled: false, modelInstalled: false, probed: true });
       return;
     }
     if (this.refreshing) return;
@@ -94,13 +95,11 @@ class VoiceModelInstaller {
     try {
       const status = await api.status();
       const modelInstalled = Boolean(status.modelInstalled);
-      // Never downgrade an in-flight download, a this-session restart-required
-      // state, or a sticky error; otherwise reflect on-disk presence.
+      // Never downgrade an in-flight download or a sticky error; otherwise
+      // reflect on-disk presence.
       let phase = this.state.phase;
       if (phase !== "downloading") {
-        if (this.state.restartRequired) {
-          phase = "installed";
-        } else if (modelInstalled) {
+        if (modelInstalled) {
           phase = "installed";
         } else if (phase !== "error") {
           phase = "idle";
@@ -110,6 +109,7 @@ class VoiceModelInstaller {
         binaryInstalled: Boolean(status.binaryInstalled),
         modelInstalled,
         phase,
+        probed: true,
       });
     } catch {
       // Best-effort probe — leave prior state intact on failure.
@@ -155,11 +155,13 @@ class VoiceModelInstaller {
     this.inFlight = (async () => {
       try {
         const next = await api.downloadModel();
+        // Main resolves the model on every call, and every mic subscribes here,
+        // so this push enables voice input live — no restart.
         this.set({
           phase: "installed",
           modelInstalled: next?.modelInstalled ?? true,
           binaryInstalled: next?.binaryInstalled ?? this.state.binaryInstalled,
-          restartRequired: true,
+          probed: true,
           error: null,
         });
       } catch (error) {


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fmic-model-status-refresh-2c9ee016 num=600 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fmic-model-status-refresh-2c9ee016&amp;pr=600">ade/mic-model-status-refresh-2c9ee016 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=600">PR #600</a>
</p>
<!-- /ade:link -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Voice model downloads now continue in the background, allowing voice input to activate immediately upon completion without requiring an application restart
  * Updated status messaging to accurately reflect installation progress

* **Tests**
  * Added tests for voice model installation behavior to verify correct state transitions across different scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Updates voice model installation state so chat microphones can become available without an app restart.
- Adds shared installer probing state and subscribes the chat mic hook to the global installer singleton.
- Updates Settings messaging to reflect background download completion.
- Adds hook tests for live model installation state changes and missing bridge behavior.

<h3>Confidence Score: 4/5</h3>

The change is close to mergeable, but the failed initial voice model probe path can leave chat microphone UI in an indeterminate loading state.

The modified hook/service behavior is narrowly scoped and covered by new tests, and the remaining issue is a concrete startup/transient-failure path in the shared installer state handling.

apps/desktop/src/renderer/services/globalVoiceModelInstaller.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Vitest/jsdom hook repro that mocks window.ade.transcription.status to reject with a simulated transient IPC failure on the initial probe, and observed useVoiceModelInstalled remained null while globalVoiceModelInstaller.getState().probed stayed false.
- Compared base and head command results, noting the before run showed observed hook sequence \[null,false\] and final hook value false with modelInstalled true, while the after run showed observed \[null,false,true\] and final hook value true under the same installation path.
- Captured artifact logs documenting the attempted real-component capture commands and blockers, and confirmed that no fabricated UI screenshots or hand-authored lookalike captures were produced.

<a href="https://app.greptile.com/trex/runs/11447663/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/renderer/services/globalVoiceModelInstaller.ts`, line 114-116 ([link](https://github.com/arul28/ade/blob/315de556c30ceb12aa6f677831b309265f91f51a/apps/desktop/src/renderer/services/globalVoiceModelInstaller.ts#L114-L116)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Mark failed probes complete**

   `useVoiceModelInstalled()` now stays `null` until `state.probed` is true, but this `catch` path leaves `probed` false. If the first `transcription.status()` IPC call rejects during app startup or a transient main-process failure, an already-mounted chat composer renders neither the setup mic nor the dictation button and no retry is scheduled. The old hook caught this same failure and returned `false`, so the setup CTA remained visible.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: focused hook test with rejected transcription status probe](https://app.greptile.com/trex/artifacts/c5e65196-d173-43a4-b64c-7728034eea6b)**

   - Contains supporting evidence from the run (text/tsx; charset=utf-8).

   **[Repro: verbose Vitest output showing hook null and probed false after rejection](https://app.greptile.com/trex/artifacts/f9a84242-8aa2-48db-adbf-8ca514f9842b)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/11447663/artifacts?artifact=c5e65196-d173-43a4-b64c-7728034eea6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=1" height="32"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/services/globalVoiceModelInstaller.ts
   Line: 114-116

   Comment:
   **Mark failed probes complete**

   `useVoiceModelInstalled()` now stays `null` until `state.probed` is true, but this `catch` path leaves `probed` false. If the first `transcription.status()` IPC call rejects during app startup or a transient main-process failure, an already-mounted chat composer renders neither the setup mic nor the dictation button and no retry is scheduled. The old hook caught this same failure and returned `false`, so the setup CTA remained visible.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fservices%2FglobalVoiceModelInstaller.ts%0ALine%3A%20114-116%0A%0AComment%3A%0A**Mark%20failed%20probes%20complete**%0A%0A%60useVoiceModelInstalled%28%29%60%20now%20stays%20%60null%60%20until%20%60state.probed%60%20is%20true%2C%20but%20this%20%60catch%60%20path%20leaves%20%60probed%60%20false.%20If%20the%20first%20%60transcription.status%28%29%60%20IPC%20call%20rejects%20during%20app%20startup%20or%20a%20transient%20main-process%20failure%2C%20an%20already-mounted%20chat%20composer%20renders%20neither%20the%20setup%20mic%20nor%20the%20dictation%20button%20and%20no%20retry%20is%20scheduled.%20The%20old%20hook%20caught%20this%20same%20failure%20and%20returned%20%60false%60%2C%20so%20the%20setup%20CTA%20remained%20visible.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=600&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fservices%2FglobalVoiceModelInstaller.ts%3A114-116%0A**Mark%20failed%20probes%20complete**%0A%0A%60useVoiceModelInstalled%28%29%60%20now%20stays%20%60null%60%20until%20%60state.probed%60%20is%20true%2C%20but%20this%20%60catch%60%20path%20leaves%20%60probed%60%20false.%20If%20the%20first%20%60transcription.status%28%29%60%20IPC%20call%20rejects%20during%20app%20startup%20or%20a%20transient%20main-process%20failure%2C%20an%20already-mounted%20chat%20composer%20renders%20neither%20the%20setup%20mic%20nor%20the%20dictation%20button%20and%20no%20retry%20is%20scheduled.%20The%20old%20hook%20caught%20this%20same%20failure%20and%20returned%20%60false%60%2C%20so%20the%20setup%20CTA%20remained%20visible.%0A%0A&repo=arul28%2Fade&pr=600&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/renderer/services/globalVoiceModelInstaller.ts:114-116
**Mark failed probes complete**

`useVoiceModelInstalled()` now stays `null` until `state.probed` is true, but this `catch` path leaves `probed` false. If the first `transcription.status()` IPC call rejects during app startup or a transient main-process failure, an already-mounted chat composer renders neither the setup mic nor the dictation button and no retry is scheduled. The old hook caught this same failure and returned `false`, so the setup CTA remained visible.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Refresh chat mic live after voice model ..."](https://github.com/arul28/ade/commit/315de556c30ceb12aa6f677831b309265f91f51a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38238854)</sub>

<!-- /greptile_comment -->