### PR TITLE
Fix macOS traffic-light overlap when zoomed out

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -6120,6 +6120,18 @@ app.whenReady().then(async () => {
             click: (_item, browserWindow) =>
               sendZoomCommand("in", browserWindow),
           },
+          // Electron's native zoomIn role also bound Cmd/Ctrl+= (the unshifted
+          // "+" key most keyboards use). A single CmdOrCtrl+Plus accelerator
+          // drops it, so register the "=" variant on a hidden twin to preserve
+          // the shortcut (acceleratorWorksWhenHidden defaults true on macOS).
+          {
+            label: "Zoom In",
+            accelerator: "CmdOrCtrl+=",
+            visible: false,
+            acceleratorWorksWhenHidden: true,
+            click: (_item, browserWindow) =>
+              sendZoomCommand("in", browserWindow),
+          },
           {
             label: "Zoom Out",
             accelerator: "CmdOrCtrl+-",

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -87,6 +87,7 @@ import { resolveAdeLayout } from "../shared/adeLayout";
 import type {
   OpenProjectBinding,
   AppNavigationRequest,
+  AppZoomCommand,
   CloneProjectInput,
   CreateProjectInput,
   LaneDeleteProgress,
@@ -6045,6 +6046,21 @@ app.whenReady().then(async () => {
   };
 
   const installApplicationMenu = (): void => {
+    // Route menu/keyboard zoom through the renderer so it follows the same path
+    // as the in-app zoom counter (display %, persistence, macOS traffic-light
+    // inset). Falls back to the focused window when the click handler omits one
+    // (e.g. accelerator fired with no menu-provided window reference).
+    const sendZoomCommand = (
+      command: AppZoomCommand,
+      browserWindow?: Electron.BaseWindow,
+    ): void => {
+      const target =
+        browserWindow instanceof BrowserWindow
+          ? browserWindow
+          : BrowserWindow.getFocusedWindow();
+      if (!target || target.isDestroyed()) return;
+      target.webContents.send(IPC.appZoomCommand, command);
+    };
     const template: Electron.MenuItemConstructorOptions[] = [
       ...(process.platform === "darwin"
         ? [{
@@ -6092,9 +6108,24 @@ app.whenReady().then(async () => {
           { role: "reload" },
           { role: "toggleDevTools" },
           { type: "separator" },
-          { role: "resetZoom" },
-          { role: "zoomIn" },
-          { role: "zoomOut" },
+          {
+            label: "Actual Size",
+            accelerator: "CmdOrCtrl+0",
+            click: (_item, browserWindow) =>
+              sendZoomCommand("reset", browserWindow),
+          },
+          {
+            label: "Zoom In",
+            accelerator: "CmdOrCtrl+Plus",
+            click: (_item, browserWindow) =>
+              sendZoomCommand("in", browserWindow),
+          },
+          {
+            label: "Zoom Out",
+            accelerator: "CmdOrCtrl+-",
+            click: (_item, browserWindow) =>
+              sendZoomCommand("out", browserWindow),
+          },
           { type: "separator" },
           { role: "togglefullscreen" },
         ],

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -15,6 +15,7 @@ import type {
   AppResourceUsageSnapshot,
   LatestReleaseInfo,
   AppNavigationRequest,
+  AppZoomCommand,
   AutoUpdateSnapshot,
   UpdateInstallImpact,
   ClearLocalAdeDataArgs,
@@ -2065,6 +2066,7 @@ declare global {
         getLevel: () => number;
         setLevel: (level: number) => void;
         getFactor: () => number;
+        onCommand: (cb: (command: AppZoomCommand) => void) => () => void;
       };
       cto?: {
         getState: (args?: CtoGetStateArgs) => Promise<CtoSnapshot>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -21,6 +21,7 @@ import type {
   AppResourceUsageSnapshot,
   LatestReleaseInfo,
   AppNavigationRequest,
+  AppZoomCommand,
   AutoUpdateSnapshot,
   UpdateInstallImpact,
   ClearLocalAdeDataArgs,
@@ -8054,6 +8055,14 @@ contextBridge.exposeInMainWorld("ade", {
     getLevel: (): number => webFrame.getZoomLevel(),
     setLevel: (level: number): void => webFrame.setZoomLevel(level),
     getFactor: (): number => webFrame.getZoomFactor(),
+    onCommand: (cb: (command: AppZoomCommand) => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        payload: AppZoomCommand,
+      ) => cb(payload);
+      ipcRenderer.on(IPC.appZoomCommand, listener);
+      return () => ipcRenderer.removeListener(IPC.appZoomCommand, listener);
+    },
   },
   cto: {
     getState: async (args: CtoGetStateArgs = {}): Promise<CtoSnapshot> =>

--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -5748,6 +5748,7 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
       getLevel: () => 0,
       setLevel: (_level: number) => {},
       getFactor: () => 1,
+      onCommand: () => () => {},
     },
     updateCheckForUpdates: resolved(undefined),
     updateGetState: resolved({

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -59,7 +59,11 @@ import {
   snoozeStaleCliNotice,
 } from "../../lib/staleCliNoticeSnooze";
 import { summarizeTerminalAttention } from "../../lib/terminalAttention";
-import { getStoredZoomLevel, displayZoomToLevel } from "../../lib/zoom";
+import {
+  getStoredZoomLevel,
+  displayZoomToLevel,
+  applyShellHeaderInset,
+} from "../../lib/zoom";
 import { ONBOARDING_STATUS_UPDATED_EVENT } from "../../lib/onboardingStatusEvents";
 import { logRendererDebugEvent } from "../../lib/debugLog";
 import { cn } from "../ui/cn";
@@ -1067,6 +1071,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       const clamped = getStoredZoomLevel();
       const zoomLevel = displayZoomToLevel(clamped);
       window.ade.zoom.setLevel(zoomLevel);
+      applyShellHeaderInset(clamped);
     } catch {
       // ignore
     }

--- a/apps/desktop/src/renderer/components/app/TopBar.test.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.test.tsx
@@ -42,8 +42,11 @@ vi.mock("../../lib/zoom", () => ({
   ZOOM_LEVEL_KEY: "ade.zoomLevel",
   MIN_ZOOM_LEVEL: 50,
   MAX_ZOOM_LEVEL: 200,
+  DEFAULT_ZOOM: 100,
+  ZOOM_STEP: 10,
   displayZoomToLevel: (value: number) => value,
   getStoredZoomLevel: () => 100,
+  applyShellHeaderInset: () => {},
 }));
 
 function makeSyncSnapshot(overrides: Record<string, unknown> = {}) {
@@ -304,6 +307,7 @@ describe("TopBar", () => {
       },
       zoom: {
         setLevel: vi.fn(),
+        onCommand: vi.fn(() => () => {}),
       },
       lanes: { list: vi.fn(async () => []) },
       sessions: { list: vi.fn(async () => []) },
@@ -1403,5 +1407,50 @@ describe("TopBar", () => {
       expect(useAppStore.getState().closeProject).toHaveBeenCalledTimes(1);
     });
     expect(globalThis.window.ade.project.forgetRecent).not.toHaveBeenCalled();
+  });
+
+  // The native View-menu zoom items dispatch an appZoomCommand that the renderer
+  // routes through the same applyZoom path as the in-app zoom counter, so the
+  // applied level and persistence stay consistent. displayZoomToLevel is mocked
+  // as identity, so setLevel receives the display percentage directly; the
+  // stored level starts at 100 (getStoredZoomLevel mock).
+  const getZoomCommandHandler = (): ((command: string) => void) => {
+    const onCommand = globalThis.window.ade.zoom.onCommand as unknown as {
+      mock: { calls: Array<[(command: string) => void]> };
+    };
+    const handler = onCommand.mock.calls[0]?.[0];
+    expect(handler, "TopBar must subscribe to zoom.onCommand").toBeTruthy();
+    return handler;
+  };
+
+  it("zooms in via the View-menu command, applying and persisting the new level", () => {
+    render(<TopBar />);
+    const handler = getZoomCommandHandler();
+
+    act(() => handler("in"));
+
+    expect(globalThis.window.ade.zoom.setLevel).toHaveBeenLastCalledWith(110);
+    expect(globalThis.window.localStorage.getItem("ade.zoomLevel")).toBe("110");
+  });
+
+  it("zooms out via the View-menu command, applying and persisting the new level", () => {
+    render(<TopBar />);
+    const handler = getZoomCommandHandler();
+
+    act(() => handler("out"));
+
+    expect(globalThis.window.ade.zoom.setLevel).toHaveBeenLastCalledWith(90);
+    expect(globalThis.window.localStorage.getItem("ade.zoomLevel")).toBe("90");
+  });
+
+  it("resets to the default level via the View-menu command regardless of current zoom", () => {
+    render(<TopBar />);
+    const handler = getZoomCommandHandler();
+
+    act(() => handler("in"));
+    act(() => handler("reset"));
+
+    expect(globalThis.window.ade.zoom.setLevel).toHaveBeenLastCalledWith(100);
+    expect(globalThis.window.localStorage.getItem("ade.zoomLevel")).toBe("100");
   });
 });

--- a/apps/desktop/src/renderer/components/app/TopBar.test.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, createEvent, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { TopBar } from "./TopBar";
+import { applyShellHeaderInset } from "../../lib/zoom";
 import { useAppStore } from "../../state/appStore";
 import { requestLinearIssueQuickView } from "../../lib/linearIssueQuickViewNavigation";
 import {
@@ -46,7 +47,7 @@ vi.mock("../../lib/zoom", () => ({
   ZOOM_STEP: 10,
   displayZoomToLevel: (value: number) => value,
   getStoredZoomLevel: () => 100,
-  applyShellHeaderInset: () => {},
+  applyShellHeaderInset: vi.fn(),
 }));
 
 function makeSyncSnapshot(overrides: Record<string, unknown> = {}) {
@@ -1431,6 +1432,7 @@ describe("TopBar", () => {
 
     expect(globalThis.window.ade.zoom.setLevel).toHaveBeenLastCalledWith(110);
     expect(globalThis.window.localStorage.getItem("ade.zoomLevel")).toBe("110");
+    expect(vi.mocked(applyShellHeaderInset)).toHaveBeenLastCalledWith(110);
   });
 
   it("zooms out via the View-menu command, applying and persisting the new level", () => {
@@ -1441,6 +1443,7 @@ describe("TopBar", () => {
 
     expect(globalThis.window.ade.zoom.setLevel).toHaveBeenLastCalledWith(90);
     expect(globalThis.window.localStorage.getItem("ade.zoomLevel")).toBe("90");
+    expect(vi.mocked(applyShellHeaderInset)).toHaveBeenLastCalledWith(90);
   });
 
   it("resets to the default level via the View-menu command regardless of current zoom", () => {
@@ -1452,5 +1455,21 @@ describe("TopBar", () => {
 
     expect(globalThis.window.ade.zoom.setLevel).toHaveBeenLastCalledWith(100);
     expect(globalThis.window.localStorage.getItem("ade.zoomLevel")).toBe("100");
+    expect(vi.mocked(applyShellHeaderInset)).toHaveBeenLastCalledWith(100);
+  });
+
+  it("compounds back-to-back menu zoom-in commands without a render in between", () => {
+    render(<TopBar />);
+    const handler = getZoomCommandHandler();
+
+    // Two commands dispatched before React re-renders must each build on the
+    // last applied level (110 → 120), not collapse onto a stale ref (both 110).
+    act(() => {
+      handler("in");
+      handler("in");
+    });
+
+    expect(globalThis.window.ade.zoom.setLevel).toHaveBeenLastCalledWith(120);
+    expect(globalThis.window.localStorage.getItem("ade.zoomLevel")).toBe("120");
   });
 });

--- a/apps/desktop/src/renderer/components/app/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.tsx
@@ -1034,11 +1034,17 @@ export function TopBar() {
     openRemoteProjectTabsRef.current = openRemoteProjectTabs;
   }, [openRemoteProjectTabs]);
 
+  // Mirrors the latest applied zoom so menu/keyboard commands compound off the
+  // current level. Updated synchronously inside applyZoom (not via a passive
+  // effect) so back-to-back commands before the next render don't reuse a stale
+  // value and collapse multiple steps into one.
+  const zoomRef = useRef(zoom);
   const applyZoom = useCallback((pct: number) => {
     const clamped = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, pct));
     window.ade.zoom.setLevel(displayZoomToLevel(clamped));
     localStorage.setItem(ZOOM_LEVEL_KEY, String(clamped));
     applyShellHeaderInset(clamped);
+    zoomRef.current = clamped;
     setZoom(clamped);
   }, []);
 
@@ -1047,11 +1053,6 @@ export function TopBar() {
 
   // Route native View-menu (and keyboard) zoom through the same applyZoom path
   // so display %, persistence, and the macOS traffic-light inset stay in sync.
-  // A ref holds the latest zoom so the listener stays subscribed across changes.
-  const zoomRef = useRef(zoom);
-  useEffect(() => {
-    zoomRef.current = zoom;
-  }, [zoom]);
   useEffect(() => {
     const onCommand = window.ade?.zoom?.onCommand;
     if (typeof onCommand !== "function") return;

--- a/apps/desktop/src/renderer/components/app/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.tsx
@@ -31,8 +31,11 @@ import {
   ZOOM_LEVEL_KEY,
   MIN_ZOOM_LEVEL,
   MAX_ZOOM_LEVEL,
+  DEFAULT_ZOOM,
+  ZOOM_STEP,
   displayZoomToLevel,
   getStoredZoomLevel,
+  applyShellHeaderInset,
 } from "../../lib/zoom";
 import { cn } from "../ui/cn";
 import { SmartTooltip } from "../ui/SmartTooltip";
@@ -1035,11 +1038,29 @@ export function TopBar() {
     const clamped = Math.max(MIN_ZOOM_LEVEL, Math.min(MAX_ZOOM_LEVEL, pct));
     window.ade.zoom.setLevel(displayZoomToLevel(clamped));
     localStorage.setItem(ZOOM_LEVEL_KEY, String(clamped));
+    applyShellHeaderInset(clamped);
     setZoom(clamped);
   }, []);
 
-  const zoomIn = useCallback(() => applyZoom(zoom + 10), [applyZoom, zoom]);
-  const zoomOut = useCallback(() => applyZoom(zoom - 10), [applyZoom, zoom]);
+  const zoomIn = useCallback(() => applyZoom(zoom + ZOOM_STEP), [applyZoom, zoom]);
+  const zoomOut = useCallback(() => applyZoom(zoom - ZOOM_STEP), [applyZoom, zoom]);
+
+  // Route native View-menu (and keyboard) zoom through the same applyZoom path
+  // so display %, persistence, and the macOS traffic-light inset stay in sync.
+  // A ref holds the latest zoom so the listener stays subscribed across changes.
+  const zoomRef = useRef(zoom);
+  useEffect(() => {
+    zoomRef.current = zoom;
+  }, [zoom]);
+  useEffect(() => {
+    const onCommand = window.ade?.zoom?.onCommand;
+    if (typeof onCommand !== "function") return;
+    return onCommand((command) => {
+      if (command === "in") applyZoom(zoomRef.current + ZOOM_STEP);
+      else if (command === "out") applyZoom(zoomRef.current - ZOOM_STEP);
+      else applyZoom(DEFAULT_ZOOM);
+    });
+  }, [applyZoom]);
 
   const fetchRecent = useCallback((options?: { force?: boolean }) => {
     listRecentProjectsCached(options)

--- a/apps/desktop/src/renderer/lib/platform.ts
+++ b/apps/desktop/src/renderer/lib/platform.ts
@@ -8,6 +8,6 @@ function getPlatformValue(): string {
   return "";
 }
 
-const isMac = /mac|darwin/i.test(getPlatformValue());
+export const isMac = /mac|darwin/i.test(getPlatformValue());
 export const revealLabel = isMac ? "Reveal in Finder" : "Reveal in File Explorer";
 export const modifierKeyLabel = isMac ? "Cmd" : "Ctrl";

--- a/apps/desktop/src/renderer/lib/zoom.test.ts
+++ b/apps/desktop/src/renderer/lib/zoom.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+  zoomFactorForDisplay,
+  shellHeaderInsetPx,
+  SHELL_HEADER_TRAFFIC_LIGHT_DIP,
+  DEFAULT_ZOOM,
+  MIN_ZOOM_LEVEL,
+  MAX_ZOOM_LEVEL,
+} from "./zoom";
+
+describe("zoomFactorForDisplay", () => {
+  it("maps the displayed percentage to its effective render factor (+10% offset)", () => {
+    expect(zoomFactorForDisplay(100)).toBeCloseTo(1.1, 5);
+    expect(zoomFactorForDisplay(70)).toBeCloseTo(0.8, 5);
+    expect(zoomFactorForDisplay(150)).toBeCloseTo(1.6, 5);
+  });
+});
+
+describe("shellHeaderInsetPx", () => {
+  it("preserves the legacy 80px reservation at the default zoom", () => {
+    // 88 DIP / factor 1.1 === 80 CSS px — no visual change at 100%.
+    expect(shellHeaderInsetPx(DEFAULT_ZOOM)).toBe(80);
+  });
+
+  it("grows the CSS reservation as the page zooms out", () => {
+    // The native traffic lights don't scale, so zooming out must reserve more
+    // CSS px to keep them clear of the logo.
+    expect(shellHeaderInsetPx(MIN_ZOOM_LEVEL)).toBeGreaterThan(
+      shellHeaderInsetPx(DEFAULT_ZOOM),
+    );
+    expect(shellHeaderInsetPx(70)).toBe(110); // 88 / 0.8
+  });
+
+  it("shrinks the CSS reservation as the page zooms in", () => {
+    expect(shellHeaderInsetPx(MAX_ZOOM_LEVEL)).toBeLessThan(
+      shellHeaderInsetPx(DEFAULT_ZOOM),
+    );
+    expect(shellHeaderInsetPx(150)).toBe(55); // 88 / 1.6
+  });
+
+  it("keeps the on-screen clearance physically constant across all zoom levels", () => {
+    // inset(css) * factor should equal the fixed DIP clearance (± rounding).
+    for (let pct = MIN_ZOOM_LEVEL; pct <= MAX_ZOOM_LEVEL; pct += 10) {
+      const physical = shellHeaderInsetPx(pct) * zoomFactorForDisplay(pct);
+      expect(physical).toBeGreaterThanOrEqual(SHELL_HEADER_TRAFFIC_LIGHT_DIP - 1);
+      expect(physical).toBeLessThanOrEqual(SHELL_HEADER_TRAFFIC_LIGHT_DIP + 1);
+    }
+  });
+
+  it("falls back to the base clearance for non-finite input", () => {
+    expect(shellHeaderInsetPx(Number.NaN)).toBe(SHELL_HEADER_TRAFFIC_LIGHT_DIP);
+  });
+});

--- a/apps/desktop/src/renderer/lib/zoom.ts
+++ b/apps/desktop/src/renderer/lib/zoom.ts
@@ -6,11 +6,15 @@
  * We add a +10% offset so the displayed "100%" actually renders at 110%.
  */
 
+import { isMac } from "./platform";
+
 export const ZOOM_LEVEL_KEY = "ade:zoom-level";
 export const MIN_ZOOM_LEVEL = 70;
 export const MAX_ZOOM_LEVEL = 150;
 export const ZOOM_OFFSET = 10;
 export const DEFAULT_ZOOM = 100;
+/** Display-percentage step for one zoom-in/zoom-out increment. */
+export const ZOOM_STEP = 10;
 const LEGACY_DEFAULT_ZOOM = 110;
 
 /** Clamp and normalize a raw zoom-level value. */
@@ -38,4 +42,51 @@ export function getStoredZoomLevel(): number {
   } catch {
     return DEFAULT_ZOOM;
   }
+}
+
+/**
+ * Effective render factor for a display percentage. Because of the +10% offset,
+ * a displayed 100% renders at factor 1.1, 70% at 0.8, 150% at 1.6, etc.
+ */
+export function zoomFactorForDisplay(displayZoom: number): number {
+  return (Math.trunc(displayZoom) + ZOOM_OFFSET) / 100;
+}
+
+/**
+ * Physical clearance (in DIP) reserved at the start of the title bar for the
+ * native macOS traffic lights. Matches the legacy 80px CSS value at the default
+ * zoom (80px × factor 1.1 ≈ 88 DIP).
+ */
+export const SHELL_HEADER_TRAFFIC_LIGHT_DIP = 88;
+
+/**
+ * CSS px to reserve at the start of the title bar so the macOS traffic lights
+ * clear the ADE logo at the given display zoom.
+ *
+ * Electron's `webFrame` zoom scales the whole renderer, but the native traffic
+ * lights are drawn by the OS at a fixed screen position and do NOT scale. A
+ * static CSS reservation therefore shrinks on screen as the page zooms out,
+ * letting the logo slide under the lights. Dividing the fixed DIP clearance by
+ * the live zoom factor keeps the on-screen reservation constant at every level.
+ */
+export function shellHeaderInsetPx(displayZoom: number): number {
+  const factor = zoomFactorForDisplay(displayZoom);
+  if (!Number.isFinite(factor) || factor <= 0) {
+    return SHELL_HEADER_TRAFFIC_LIGHT_DIP;
+  }
+  return Math.round(SHELL_HEADER_TRAFFIC_LIGHT_DIP / factor);
+}
+
+/**
+ * Sync the title bar's start padding to the current zoom so the macOS traffic
+ * lights never overlap the logo. No-op off macOS (no native traffic lights) and
+ * outside a DOM; there the static `--shell-header-padding-start` default stands.
+ */
+export function applyShellHeaderInset(displayZoom: number): void {
+  if (!isMac) return;
+  if (typeof document === "undefined") return;
+  document.documentElement.style.setProperty(
+    "--shell-header-padding-start",
+    `${shellHeaderInsetPx(displayZoom)}px`,
+  );
 }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -10,6 +10,7 @@ export const IPC = {
   appOpenProjectInNewWindow: "ade.app.openProjectInNewWindow",
   appCloseWindow: "ade.app.closeWindow",
   appNavigate: "ade.app.navigate",
+  appZoomCommand: "ade.app.zoomCommand",
   appProjectChanged: "ade.app.projectChanged",
   appProjectBindingChanged: "ade.app.projectBindingChanged",
   appOpenExternal: "ade.app.openExternal",

--- a/apps/desktop/src/shared/types/core.ts
+++ b/apps/desktop/src/shared/types/core.ts
@@ -202,6 +202,13 @@ export type AppNavigationRequest = {
   source?: "ade-code" | "desktop" | "cli" | string;
 };
 
+/**
+ * Window-zoom command dispatched from the native View menu to the renderer so
+ * menu/keyboard zoom flows through the same path as the in-app zoom counter
+ * (display %, persistence, and the macOS traffic-light inset stay in sync).
+ */
+export type AppZoomCommand = "in" | "out" | "reset";
+
 export type AppNavigationResult = {
   ok: boolean;
   mode: "desktop" | "unavailable";

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -404,7 +404,7 @@ Related feature docs: [Chat](./features/chat/README.md), [Agents](./features/age
 `apps/desktop/src/shared/ipc.ts` defines the single `IPC` const with ~550 named channel strings in a `ade.<domain>.<action>` namespace:
 
 ```
-ade.app.*                    # app lifecycle, clipboard text and image (writeClipboardText, writeClipboardImage, saveClipboardImageAttachment), paths, image data-URL preview (getImageDataUrl), and the deeplink navigation push channel ade.app.navigate (AppNavigationRequest payloads from the ade:// protocol handler, the ade code app/navigate JSON-RPC, and the iOS deeplinks.open sync command — see features/deeplinks/README.md)
+ade.app.*                    # app lifecycle, clipboard text and image (writeClipboardText, writeClipboardImage, saveClipboardImageAttachment), paths, image data-URL preview (getImageDataUrl), the deeplink navigation push channel ade.app.navigate (AppNavigationRequest payloads from the ade:// protocol handler, the ade code app/navigate JSON-RPC, and the iOS deeplinks.open sync command — see features/deeplinks/README.md), and the one-way zoom push channel ade.app.zoomCommand (AppZoomCommand "in"/"out"/"reset" sent from the native View menu to the renderer's window.ade.zoom.onCommand so menu/keyboard zoom shares the in-app zoom path — display %, persistence, and the macOS traffic-light inset)
 ade.project.*                # project open/close/switch/state, in-app directory browser (browseDirectories, getDetail), favicon resolver (resolveIcon)
 ade.onboarding.*
 ade.lanes.*                  # lane list/create/delete/stack/template/env/port/proxy/rebase


### PR DESCRIPTION
## Problem

Zooming the desktop app below 100% via the in-app zoom counter pushed the macOS traffic lights out of place — the ADE logo slid underneath them. Electron's `webFrame` zoom scales the whole renderer (including the title bar), but the native traffic lights are drawn by the OS at a fixed screen position and don't scale. The static `80px` left reservation shrank on screen as the page zoomed out.

## Fix

- **Zoom-invariant title-bar inset.** Divide a fixed DIP clearance (88) by the live zoom factor so the on-screen reservation for the traffic lights stays physically constant at every zoom level. Preserves the exact `80px` reservation at the default 100% zoom (`88 / 1.1 = 80`). macOS-only; Windows/Linux keep the static default.
- **Menu zoom consistency.** The native View-menu items (Zoom In / Zoom Out / Actual Size) previously used Electron's native zoom roles, which bypassed the in-app counter — so the displayed %, persistence, and the new inset never updated. They now dispatch a one-way `appZoomCommand` IPC that the renderer routes through the same `applyZoom` path. Accelerators (`Cmd+0/+/-`) match the prior native roles, so keyboard zoom behavior is unchanged.

## Tests

- New `lib/zoom.test.ts` — proves the inset stays physically constant across 70–150% and equals `80px` at the default (no visual regression).
- Extended `TopBar.test.tsx` — menu-zoom commands (`in`/`out`/`reset`) route through `applyZoom` with the correct level + persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Zoom commands from the native View menu now properly route through the application, supporting zoom in, zoom out, and reset to default functionality.

* **Bug Fixes**
  * macOS title bar layout now dynamically adjusts padding when zooming to prevent overlap with window controls.

* **Tests**
  * Added test coverage for zoom operations, including level persistence and reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Routes native desktop View-menu zoom commands through the renderer zoom path so menu actions, shortcuts, persisted zoom, and the in-app zoom display stay consistent.
- Adds macOS-specific title-bar inset calculation based on the live zoom factor to keep traffic-light spacing physically stable while zooming.
- Extends zoom and TopBar tests to cover inset invariants, menu zoom commands, persistence, and reset behavior.

<h3>Confidence Score: 5/5</h3>

The changes are narrowly scoped to desktop zoom handling and title-bar spacing, with no outstanding code issues identified.

The implementation is covered by targeted tests for inset calculations, menu zoom routing, persistence, and reset behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the zoom-inset behavior before and after the change by reviewing the baseline and updated calculation logs; attempted a Vitest test but dependencies were unavailable, so the after-state was validated with a Node-based probe exercising the changed zoom path.
- Compared the menu zoom consistency before/after by reviewing the IPC/preload/renderer/persist/inset state and the accelerator usage and setLevel/inset flow; since the Vitest seam was unavailable, the verification used an embedded probe script to exercise the closest testable seam.

<a href="https://app.greptile.com/trex/runs/11453086/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["ship: iter 2 — sync zoomRef in applyZoom..."](https://github.com/arul28/ade/commit/395eb3a3d294e0fcbbdf12fdb9374d421c78c981) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38244120)</sub>

<!-- /greptile_comment -->