### PR TITLE
Mobile Cancel Reconnect

### DIFF
--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -3288,7 +3288,7 @@ final class SyncService: ObservableObject {
     }
     allowAutoReconnect = false
     reconnectConnectInFlight = false
-    reconnectTask?.cancel()
+    cancelReconnectLoop()
     teardownSocket(closeCode: .normalClosure)
     connectionState = .disconnected
     hostName = activeHostProfile?.hostName
@@ -6710,6 +6710,8 @@ final class SyncService: ObservableObject {
     reconnectState.reset()
     reconnectTask?.cancel()
     reconnectTask = nil
+    networkPathReconnectTask?.cancel()
+    networkPathReconnectTask = nil
   }
 
   private func shouldInvalidateSavedPairing(for error: Error) -> Bool {
@@ -7174,6 +7176,14 @@ final class SyncService: ObservableObject {
       isExpensive: isExpensive,
       isConstrained: isConstrained
     )
+  }
+
+  func scheduleNetworkPathReconnectForTesting(delayNanoseconds: UInt64) {
+    scheduleNetworkPathReconnect(forceSocketReset: false, delayNanoseconds: delayNanoseconds)
+  }
+
+  func hasScheduledReconnectWorkForTesting() -> Bool {
+    reconnectTask != nil || networkPathReconnectTask != nil
   }
 
   func setActiveProjectForTesting(projectId: String?, rootPath: String?) {

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -152,7 +152,7 @@ struct WorkNewChatScreen: View {
     selectedLaneId == workAutoCreateLaneSentinelId
   }
 
-  private var autoCreateToolsLane: LaneSummary? {
+  private var defaultNewSessionLane: LaneSummary? {
     if let preferredLaneId, let lane = lanes.first(where: { $0.id == preferredLaneId }) {
       return lane
     }
@@ -245,7 +245,7 @@ struct WorkNewChatScreen: View {
     }
     .onAppear {
       if selectedLaneId.isEmpty {
-        selectedLaneId = preferredLaneId ?? lanes.first?.id ?? ""
+        selectedLaneId = defaultNewSessionLane?.id ?? ""
       }
       if runtimeMode.isEmpty {
         runtimeMode = workDefaultRuntimeMode(provider: provider)
@@ -396,7 +396,7 @@ struct WorkNewChatScreen: View {
       // deterministic name mobile already used.
       let deterministicName = autoCreatedLaneName(opener: opener)
       var resolvedName = deterministicName
-      if let contextLaneId = autoCreateToolsLane?.id, !contextLaneId.isEmpty {
+      if let contextLaneId = defaultNewSessionLane?.id, !contextLaneId.isEmpty {
         withAnimation(.snappy(duration: 0.16)) {
           autoCreateStatus = "Naming lane with \(prettyNewChatModelName(modelId))…"
         }

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -156,7 +156,9 @@ struct WorkNewChatScreen: View {
     if let preferredLaneId, let lane = lanes.first(where: { $0.id == preferredLaneId }) {
       return lane
     }
-    return lanes.first
+    return lanes.first { $0.laneType == "primary" }
+      ?? lanes.first { $0.name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "primary" }
+      ?? lanes.first
   }
 
   /// Fast mode only applies to in-app chat sessions on fast-tier models — the

--- a/apps/ios/ADE/Views/Work/WorkRootScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootScreen.swift
@@ -199,7 +199,7 @@ struct WorkRootScreen: View {
 
   func pushNewChatRoute() {
     guard !navigationMutationPending else { return }
-    let preferred = selectedLaneId == "all" ? lanes.first?.id : selectedLaneId
+    let preferred = selectedLaneId == "all" ? nil : selectedLaneId
     navigationMutationPending = true
     selectedSessionTransitionId = nil
     Task { @MainActor in

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -1632,6 +1632,27 @@ final class ADETests: XCTestCase {
     )
   }
 
+  @MainActor
+  func testSyncDisconnectCancelsScheduledReconnectWork() {
+    let pausedKey = "ade.sync.autoReconnectPausedByUser"
+    UserDefaults.standard.removeObject(forKey: pausedKey)
+    defer {
+      UserDefaults.standard.removeObject(forKey: pausedKey)
+    }
+
+    let database = makeDatabase(baseURL: makeTemporaryDirectory())
+    defer { database.close() }
+    let service = SyncService(database: database)
+    service.scheduleNetworkPathReconnectForTesting(delayNanoseconds: 60_000_000_000)
+    XCTAssertTrue(service.hasScheduledReconnectWorkForTesting())
+
+    service.disconnect()
+
+    XCTAssertFalse(service.hasScheduledReconnectWorkForTesting())
+    XCTAssertEqual(service.connectionState, .disconnected)
+    XCTAssertTrue(UserDefaults.standard.bool(forKey: pausedKey))
+  }
+
   func testSyncMessageTooLongTransportFailureForcesErrorState() {
     let fatalError = NSError(
       domain: "ADE",

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -349,10 +349,13 @@ Source: `apps/ios/ADE/Services/SyncService.swift`.
    in detached tasks (the SQLite connection is FULLMUTEX). The receive
    loop awaits frames in order, so application order is unchanged —
    the UI just never freezes under sync load.
-7. On disconnect: a fast exponential-backoff reconnect burst, then an
-   indefinite ~30 s slow-heartbeat retry loop. The phone never
+7. On transport disconnect: a fast exponential-backoff reconnect burst,
+   then an indefinite ~30 s slow-heartbeat retry loop. The phone never
    permanently gives up — a paired machine that comes back minutes
-   later reconnects without the user touching anything.
+   later reconnects without the user touching anything. User-initiated
+   disconnects from Settings (including the connecting-state Cancel
+   button) cancel scheduled reconnect work and leave the phone in the
+   disconnected state until the user reconnects or pairs again.
 8. After pairing completes, the phone announces currently-open lanes
    via `lanes.presence.announce` so the runtime decorates
    `LaneSummary.devicesOpen` for other controllers; the phone calls


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fmobile-cancel-reconnect-3681c221 num=606 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fmobile-cancel-reconnect-3681c221&amp;pr=606">ade/mobile-cancel-reconnect-3681c221 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=606">PR #606</a>
</p>
<!-- /ade:link -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced socket disconnection to properly cancel all scheduled reconnection attempts, including network path reconnects, before completing the disconnection process.

* **New Features**
  * Implemented intelligent automatic primary tools lane selection with smart fallback logic for optimal workflow initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Tightens iOS sync disconnect behavior so user-initiated disconnects cancel scheduled reconnect work, including network-path reconnects.
- Updates Work new-chat routing and lane resolution so primary-aware defaults are used for initial selection and auto-created lane naming.
- Adds test coverage and documentation for reconnect cancellation behavior.

<h3>Confidence Score: 5/5</h3>

The changes are narrowly scoped to reconnect cancellation and default lane selection behavior, with corresponding test and documentation updates.

No code issues were identified in the reviewed diff, and the modified areas appear consistent with the described behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The before/after evidence demonstrates that disconnect() now calls cancelReconnectLoop() and cancels the networkPathReconnectTask, changing the probe outcome from scheduled\_network\_reconnect\_remains\_after\_disconnect: True to False.
- Two log artifacts were produced to document the before/after disconnect behavior, including the command, cwd, commit SHA, source file, extracted function bodies, scenario result, assertion output, and exit code.
- T-Rex ran the requested verification, but its local artifact references were not uploaded.

<a href="https://app.greptile.com/trex/runs/11473540/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/ios/ADE/Views/Work/WorkNewChatScreen.swift`, line 248 ([link](https://github.com/arul28/ade/blob/e2b4d71fcdbcdf54964590736ed52733ee7d931a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift#L248)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Initial lane stays first**

   The screen still initializes `selectedLaneId` from `preferredLaneId ?? lanes.first?.id`, so the new primary-lane fallback is not used for normal chat or CLI starts. If the lane list is ordered with a worktree before the primary lane, a user who opens New Chat from the `all` filter and submits without changing the picker starts the session in the worktree lane instead of the primary lane.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
   Line: 248

   Comment:
   **Initial lane stays first**

   The screen still initializes `selectedLaneId` from `preferredLaneId ?? lanes.first?.id`, so the new primary-lane fallback is not used for normal chat or CLI starts. If the lane list is ordered with a worktree before the primary lane, a user who opens New Chat from the `all` filter and submits without changing the picker starts the session in the worktree lane instead of the primary lane.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fios%2FADE%2FViews%2FWork%2FWorkNewChatScreen.swift%0ALine%3A%20248%0A%0AComment%3A%0A**Initial%20lane%20stays%20first**%0A%0AThe%20screen%20still%20initializes%20%60selectedLaneId%60%20from%20%60preferredLaneId%20%3F%3F%20lanes.first%3F.id%60%2C%20so%20the%20new%20primary-lane%20fallback%20is%20not%20used%20for%20normal%20chat%20or%20CLI%20starts.%20If%20the%20lane%20list%20is%20ordered%20with%20a%20worktree%20before%20the%20primary%20lane%2C%20a%20user%20who%20opens%20New%20Chat%20from%20the%20%60all%60%20filter%20and%20submits%20without%20changing%20the%20picker%20starts%20the%20session%20in%20the%20worktree%20lane%20instead%20of%20the%20primary%20lane.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=606&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `apps/ios/ADE/Views/Work/WorkNewChatScreen.swift`, line 246-250 ([link](https://github.com/arul28/ade/blob/67aa5392daa387e7efca004dcbc3b50e00f83085/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift#L246-L250)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Initial selection skips primary**

   When `WorkRootScreen` opens this page from the All-lanes filter, it now passes `nil` for `preferredLaneId`, but this initializer still falls back to `lanes.first?.id`. If the lane list is ordered as worktree first and primary second, the screen opens with the worktree selected and a normal submit uses that worktree as `targetLaneId`, so the primary fallback is never used.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
   Line: 246-250

   Comment:
   **Initial selection skips primary**

   When `WorkRootScreen` opens this page from the All-lanes filter, it now passes `nil` for `preferredLaneId`, but this initializer still falls back to `lanes.first?.id`. If the lane list is ordered as worktree first and primary second, the screen opens with the worktree selected and a normal submit uses that worktree as `targetLaneId`, so the primary fallback is never used.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fios%2FADE%2FViews%2FWork%2FWorkNewChatScreen.swift%0ALine%3A%20246-250%0A%0AComment%3A%0A**Initial%20selection%20skips%20primary**%0A%0AWhen%20%60WorkRootScreen%60%20opens%20this%20page%20from%20the%20All-lanes%20filter%2C%20it%20now%20passes%20%60nil%60%20for%20%60preferredLaneId%60%2C%20but%20this%20initializer%20still%20falls%20back%20to%20%60lanes.first%3F.id%60.%20If%20the%20lane%20list%20is%20ordered%20as%20worktree%20first%20and%20primary%20second%2C%20the%20screen%20opens%20with%20the%20worktree%20selected%20and%20a%20normal%20submit%20uses%20that%20worktree%20as%20%60targetLaneId%60%2C%20so%20the%20primary%20fallback%20is%20never%20used.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=606&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["ship: iteration 2 - align default new ch..."](https://github.com/arul28/ade/commit/bf0786431acffc24bd60c242a74b4bbc2c0cbadd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38295224)</sub>

<!-- /greptile_comment -->