### PR TITLE
Fix sync socket trust and runtime event availability

### DIFF
--- a/apps/ade-cli/src/adeRpcServer.test.ts
+++ b/apps/ade-cli/src/adeRpcServer.test.ts
@@ -300,6 +300,14 @@ function createRuntime() {
       readTranscriptTail: vi.fn(async () => ""),
       list: vi.fn(() => []),
       enrichSessions: vi.fn((sessions: unknown[]) => sessions),
+      listTerminals: vi.fn(() => []),
+      readTerminal: vi.fn(async () => ({ terminalId: "session-1", data: "", nextSince: 0 })),
+      previewTerminal: vi.fn(async () => ({ terminalId: "session-1", session: null, source: "empty", snapshot: null, transcript: null, capturedAt: new Date().toISOString() })),
+      writeTerminal: vi.fn(async () => ({ ok: true })),
+      resizeTerminal: vi.fn(() => ({ ok: true, cols: 100, rows: 30 })),
+      signalTerminal: vi.fn(() => ({ ok: true })),
+      activeForChat: vi.fn(() => null),
+      reattachChatCli: vi.fn(async () => ({ terminalId: "session-1", ptyId: "pty-1", pid: 123, relaunched: false })),
     },
     testService: {
       run: vi.fn(async () => ({ id: "test-run-1", status: "running" })),
@@ -653,8 +661,10 @@ function createRuntime() {
           { id: cursor + 1, timestamp: new Date().toISOString(), category: "orchestrator", payload: { type: "test" } }
         ],
         nextCursor: cursor + 1,
-        hasMore: false
+        hasMore: false,
+        eventEpoch: "test-event-epoch",
       })),
+      epoch: vi.fn(() => "test-event-epoch"),
       size: vi.fn(() => 1)
     } as any,
     dispose: vi.fn()
@@ -2682,6 +2692,57 @@ describe("adeRpcServer", () => {
       variables: { first: 1 },
     });
     expect(graphql.structuredContent.result).toMatchObject({ viewer: { id: "user-1" } });
+  });
+
+  it("scopes PTY and terminal ADE actions to the caller's lane or chat", async () => {
+    const fixture = createRuntime();
+    const ownChat = { id: "chat-1", laneId: "lane-1", chatSessionId: "chat-1" };
+    const ownTerminal = { id: "terminal-1", laneId: "lane-1", ptyId: "pty-1", chatSessionId: "chat-1" };
+    const otherTerminal = { id: "terminal-2", laneId: "lane-2", ptyId: "pty-2", chatSessionId: "chat-2" };
+    fixture.runtime.sessionService.get.mockImplementation((sessionId: string) => {
+      if (sessionId === "chat-1") return ownChat;
+      if (sessionId === "terminal-1") return ownTerminal;
+      if (sessionId === "terminal-2") return otherTerminal;
+      return null;
+    });
+    fixture.runtime.ptyService.list.mockReturnValue([ownTerminal, otherTerminal]);
+    const handler = createAdeRpcRequestHandler({ runtime: fixture.runtime, serverVersion: "test" });
+    await initialize(handler, { callerId: "agent-1", role: "agent", chatSessionId: "chat-1" });
+
+    const listed = await callTool(handler, "run_ade_action", {
+      domain: "pty",
+      action: "list",
+      args: {},
+    });
+    expect(listed?.isError).toBeUndefined();
+    expect(listed.structuredContent.result).toEqual([ownTerminal]);
+
+    const deniedPtyWrite = await callTool(handler, "run_ade_action", {
+      domain: "pty",
+      action: "write",
+      args: { ptyId: "pty-2", data: "stop\n" },
+    });
+    expect(deniedPtyWrite.isError).toBe(true);
+    expect(fixture.runtime.ptyService.write).not.toHaveBeenCalled();
+
+    const deniedTerminalWrite = await callTool(handler, "run_ade_action", {
+      domain: "terminal",
+      action: "write",
+      args: { chatSessionId: "chat-2", data: "stop\n" },
+    });
+    expect(deniedTerminalWrite.isError).toBe(true);
+    expect(fixture.runtime.ptyService.writeTerminal).not.toHaveBeenCalled();
+
+    const ownTerminalWrite = await callTool(handler, "run_ade_action", {
+      domain: "terminal",
+      action: "write",
+      args: { data: "continue\n" },
+    });
+    expect(ownTerminalWrite?.isError).toBeUndefined();
+    expect(fixture.runtime.ptyService.writeTerminal).toHaveBeenCalledWith({
+      data: "continue\n",
+      chatSessionId: "chat-1",
+    });
   });
 
   it("invokes review.startRun through ADE actions without dropping unlimited budgets", async () => {

--- a/apps/ade-cli/src/adeRpcServer.ts
+++ b/apps/ade-cli/src/adeRpcServer.ts
@@ -2391,8 +2391,6 @@ function authorizePtyAdeActionInvocation(
     case "dispose":
       ensurePtyTargetAuthorized(runtime, session, method, ptyArgs);
       return;
-    case "list":
-      return;
     default:
       ptyAccessDenied(method);
   }

--- a/apps/ade-cli/src/adeRpcServer.ts
+++ b/apps/ade-cli/src/adeRpcServer.ts
@@ -2360,6 +2360,150 @@ function listAuthorizedPtySessions(
     .filter((target) => isPtySessionAuthorized(runtime, session, target));
 }
 
+function requireObjectArgsForScopedAdeAction(
+  domain: string,
+  action: string,
+  argsList: unknown[] | null,
+  hasScalarArg: boolean,
+  rawObjectArgs: Record<string, unknown>,
+): Record<string, unknown> {
+  if (argsList || hasScalarArg) {
+    ptyAccessDenied(`run_ade_action:${domain}.${action}`);
+  }
+  return rawObjectArgs;
+}
+
+function authorizePtyAdeActionInvocation(
+  runtime: AdeRuntime,
+  session: SessionState,
+  action: string,
+  ptyArgs: Record<string, unknown>,
+): void {
+  const method = `run_ade_action:pty.${action}`;
+  switch (action) {
+    case "create":
+      ensurePtyCreateAuthorized(runtime, session, method, ptyArgs);
+      return;
+    case "sendToSession":
+    case "resumeSession":
+    case "write":
+    case "resize":
+    case "dispose":
+      ensurePtyTargetAuthorized(runtime, session, method, ptyArgs);
+      return;
+    case "list":
+      return;
+    default:
+      ptyAccessDenied(method);
+  }
+}
+
+function scopeTerminalChatArgs(
+  runtime: AdeRuntime,
+  session: SessionState,
+  method: string,
+  terminalArgs: Record<string, unknown>,
+): Record<string, unknown> {
+  const scopedArgs = { ...terminalArgs };
+  const callerChatSessionId = asOptionalTrimmedString(session.identity.chatSessionId);
+  const requestedChatSessionId = asOptionalTrimmedString(scopedArgs.chatSessionId);
+  const requestedLaneId = extractLaneId(scopedArgs);
+  if (requestedChatSessionId && requestedChatSessionId !== callerChatSessionId) {
+    ptyAccessDenied(method);
+  }
+  if (requestedLaneId && !authorizedPtyLaneIds(runtime, session).has(requestedLaneId)) {
+    ptyAccessDenied(method);
+  }
+  if (!requestedChatSessionId && callerChatSessionId) {
+    scopedArgs.chatSessionId = callerChatSessionId;
+  } else if (!requestedChatSessionId) {
+    ptyAccessDenied(method);
+  }
+  return scopedArgs;
+}
+
+function scopeTerminalListArgs(
+  runtime: AdeRuntime,
+  session: SessionState,
+  method: string,
+  terminalArgs: Record<string, unknown>,
+): Record<string, unknown> {
+  const scopedArgs = { ...terminalArgs };
+  const callerChatSessionId = asOptionalTrimmedString(session.identity.chatSessionId);
+  const requestedChatSessionId = asOptionalTrimmedString(scopedArgs.chatSessionId);
+  const requestedLaneId = extractLaneId(scopedArgs);
+  const laneIds = authorizedPtyLaneIds(runtime, session);
+  if (requestedChatSessionId && requestedChatSessionId !== callerChatSessionId) {
+    ptyAccessDenied(method);
+  }
+  if (requestedLaneId && !laneIds.has(requestedLaneId)) {
+    ptyAccessDenied(method);
+  }
+  if (!requestedChatSessionId && callerChatSessionId) {
+    scopedArgs.chatSessionId = callerChatSessionId;
+  } else if (!requestedLaneId && laneIds.size === 1) {
+    scopedArgs.laneId = [...laneIds][0];
+  } else if (!requestedChatSessionId && !requestedLaneId) {
+    ptyAccessDenied(method);
+  }
+  return scopedArgs;
+}
+
+function scopeTerminalTargetArgs(
+  runtime: AdeRuntime,
+  session: SessionState,
+  method: string,
+  terminalArgs: Record<string, unknown>,
+): Record<string, unknown> {
+  const scopedArgs = { ...terminalArgs };
+  const callerChatSessionId = asOptionalTrimmedString(session.identity.chatSessionId);
+  const requestedChatSessionId = asOptionalTrimmedString(scopedArgs.chatSessionId);
+  const terminalId = asOptionalTrimmedString(scopedArgs.terminalId);
+  const ptyId = asOptionalTrimmedString(scopedArgs.ptyId);
+
+  if (requestedChatSessionId && requestedChatSessionId !== callerChatSessionId) {
+    ptyAccessDenied(method);
+  }
+  if (!requestedChatSessionId && !terminalId && !ptyId && callerChatSessionId) {
+    scopedArgs.chatSessionId = callerChatSessionId;
+  }
+  if (terminalId || ptyId) {
+    ensurePtyTargetAuthorized(runtime, session, method, {
+      ...(terminalId ? { sessionId: terminalId } : {}),
+      ...(ptyId ? { ptyId } : {}),
+    });
+    return scopedArgs;
+  }
+  if (asOptionalTrimmedString(scopedArgs.chatSessionId) !== callerChatSessionId || !callerChatSessionId) {
+    ptyAccessDenied(method);
+  }
+  return scopedArgs;
+}
+
+function scopeTerminalAdeActionArgs(
+  runtime: AdeRuntime,
+  session: SessionState,
+  action: string,
+  terminalArgs: Record<string, unknown>,
+): Record<string, unknown> {
+  const method = `run_ade_action:terminal.${action}`;
+  switch (action) {
+    case "list":
+      return scopeTerminalListArgs(runtime, session, method, terminalArgs);
+    case "activeForChat":
+    case "reattachChatCli":
+      return scopeTerminalChatArgs(runtime, session, method, terminalArgs);
+    case "read":
+    case "preview":
+    case "write":
+    case "resize":
+    case "signal":
+      return scopeTerminalTargetArgs(runtime, session, method, terminalArgs);
+    default:
+      ptyAccessDenied(method);
+  }
+}
+
 async function runCtoOperatorBridgeTool(
   runtime: AdeRuntime,
   session: SessionState,
@@ -3233,16 +3377,37 @@ async function runTool(args: {
     const argsList = Array.isArray(toolArgs.argsList) ? toolArgs.argsList : null;
     const hasScalarArg = Object.prototype.hasOwnProperty.call(toolArgs, "arg");
     const rawObjectArgs = safeObject(toolArgs.args);
+    const callerIsCto = callerHasRoleAtLeast(callerCtx.role, "cto");
+    let scopedObjectArgs = rawObjectArgs;
+    let scopedResultHandled = false;
     let result: unknown;
-    if (argsList) {
-      result = await (callable as (...params: unknown[]) => Promise<unknown>).apply(service, argsList);
-    } else if (hasScalarArg) {
-      result = await (callable as (arg: unknown) => Promise<unknown>).call(service, toolArgs.arg);
-    } else {
-      result = await (callable as (args?: Record<string, unknown>) => Promise<unknown>).call(
-        service,
-        Object.keys(rawObjectArgs).length > 0 ? rawObjectArgs : undefined,
+    if (!callerIsCto && domain === "pty") {
+      scopedObjectArgs = requireObjectArgsForScopedAdeAction(domain, action, argsList, hasScalarArg, rawObjectArgs);
+      if (action === "list") {
+        result = listAuthorizedPtySessions(runtime, session, `run_ade_action:pty.${action}`, scopedObjectArgs);
+        scopedResultHandled = true;
+      } else {
+        authorizePtyAdeActionInvocation(runtime, session, action, scopedObjectArgs);
+      }
+    } else if (!callerIsCto && domain === "terminal") {
+      scopedObjectArgs = scopeTerminalAdeActionArgs(
+        runtime,
+        session,
+        action,
+        requireObjectArgsForScopedAdeAction(domain, action, argsList, hasScalarArg, rawObjectArgs),
       );
+    }
+    if (!scopedResultHandled) {
+      if (argsList) {
+        result = await (callable as (...params: unknown[]) => Promise<unknown>).apply(service, argsList);
+      } else if (hasScalarArg) {
+        result = await (callable as (arg: unknown) => Promise<unknown>).call(service, toolArgs.arg);
+      } else {
+        result = await (callable as (args?: Record<string, unknown>) => Promise<unknown>).call(
+          service,
+          Object.keys(scopedObjectArgs).length > 0 ? scopedObjectArgs : undefined,
+        );
+      }
     }
     const record = isRecord(result) ? result : null;
     const statusHints = {

--- a/apps/ade-cli/src/eventBuffer.ts
+++ b/apps/ade-cli/src/eventBuffer.ts
@@ -18,6 +18,7 @@ export type EventBuffer = {
   push(event: Omit<BufferedEvent, "id">): void;
   drain(cursor: number, limit?: number): EventBufferDrainResult;
   subscribe(listener: (event: BufferedEvent) => void): () => void;
+  epoch(): string;
   size(): number;
 };
 
@@ -62,6 +63,9 @@ export function createEventBuffer(capacity = 10_000): EventBuffer {
       return () => {
         listeners.delete(listener);
       };
+    },
+    epoch() {
+      return eventEpoch;
     },
     size() {
       return events.length;

--- a/apps/ade-cli/src/multiProjectRpcServer.test.ts
+++ b/apps/ade-cli/src/multiProjectRpcServer.test.ts
@@ -494,7 +494,8 @@ describe("multi-project RPC server", () => {
         projectId: added.projectId,
         category: "runtime",
       },
-    }) as { subscriptionId: string };
+    }) as { subscriptionId: string; eventEpoch: string };
+    expect(subscribed.eventEpoch).toBe(eventBuffer.epoch());
 
     eventBuffer.push({
       timestamp: "2026-05-10T00:00:00.000Z",
@@ -511,6 +512,7 @@ describe("multi-project RPC server", () => {
     expect(notify).toHaveBeenCalledWith("runtime/event", {
       subscriptionId: subscribed.subscriptionId,
       projectId: added.projectId,
+      eventEpoch: eventBuffer.epoch(),
       event: expect.objectContaining({
         category: "runtime",
         payload: { type: "file_change", event: { path: "README.md" } },

--- a/apps/ade-cli/src/multiProjectRpcServer.ts
+++ b/apps/ade-cli/src/multiProjectRpcServer.ts
@@ -264,11 +264,13 @@ export function createMultiProjectRpcRequestHandler(
     subscriptionId: string,
     projectId: ProjectId,
     event: BufferedEvent,
+    eventEpoch: string,
   ): void => {
     notifier?.("runtime/event", {
       subscriptionId,
       projectId,
       event,
+      eventEpoch,
     });
   };
 
@@ -325,11 +327,12 @@ export function createMultiProjectRpcRequestHandler(
     const replay = params.replay !== false;
     const scope = await scopeRegistry.get(projectId);
     const subscriptionId = `runtime-events-${nextSubscriptionId++}`;
+    const eventEpoch = scope.runtime.eventBuffer.epoch();
     const shouldForward = (event: BufferedEvent): boolean =>
       !category || event.category === category;
     const unsubscribe = scope.runtime.eventBuffer.subscribe((event) => {
       if (shouldForward(event))
-        emitRuntimeEvent(subscriptionId, projectId, event);
+        emitRuntimeEvent(subscriptionId, projectId, event, eventEpoch);
     });
     eventSubscriptions.set(subscriptionId, {
       id: subscriptionId,
@@ -339,15 +342,16 @@ export function createMultiProjectRpcRequestHandler(
 
     const replayResult = replay
       ? scope.runtime.eventBuffer.drain(cursor, limit)
-      : { events: [], nextCursor: cursor, hasMore: false };
+      : { events: [], nextCursor: cursor, hasMore: false, eventEpoch };
     for (const event of replayResult.events) {
       if (shouldForward(event))
-        emitRuntimeEvent(subscriptionId, projectId, event);
+        emitRuntimeEvent(subscriptionId, projectId, event, replayResult.eventEpoch);
     }
     return {
       subscriptionId,
       nextCursor: replayResult.nextCursor,
       hasMore: replayResult.hasMore,
+      eventEpoch: replayResult.eventEpoch,
     };
   };
 

--- a/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
+++ b/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
@@ -47,11 +47,13 @@ type BrainProjectActionsSyncHandlerArgs = {
   localSiteIdPath: string;
   heartbeatIntervalMs?: number;
   pollIntervalMs?: number;
+  authTimeoutMs?: number;
 };
 
 type BrainPeerState = {
   ws: WebSocket;
   authenticated: boolean;
+  authTimeout: ReturnType<typeof setTimeout> | null;
   metadata: SyncPeerMetadata | null;
 };
 
@@ -60,6 +62,7 @@ const BOOTSTRAP_TOKEN_KEY = "sync.bootstrapToken.v1";
 const PAIR_FAILURE_THRESHOLD = 5;
 const PAIR_COOLDOWN_MS = 10 * 60_000;
 const PAIR_FAILURE_WINDOW_MS = 10 * 60_000;
+const BRAIN_SYNC_AUTH_TIMEOUT_MS = 15_000;
 
 type PairFailureEntry = {
   count: number;
@@ -313,6 +316,7 @@ export function createBrainProjectActionsSyncHandler(
   const localSiteId = ensureSecretFile(args.localSiteIdPath, 16);
   const heartbeatIntervalMs = Math.max(5_000, Math.floor(args.heartbeatIntervalMs ?? 5_000));
   const pollIntervalMs = Math.max(100, Math.floor(args.pollIntervalMs ?? 1_500));
+  const authTimeoutMs = Math.max(1_000, Math.floor(args.authTimeoutMs ?? BRAIN_SYNC_AUTH_TIMEOUT_MS));
   const pairFailures = createPairFailureTracker();
 
   const brainMetadata = (): SyncPeerMetadata => ({
@@ -519,8 +523,26 @@ export function createBrainProjectActionsSyncHandler(
     const peer: BrainPeerState = {
       ws,
       authenticated: false,
+      authTimeout: null,
       metadata: null,
     };
+    const clearAuthTimeout = (): void => {
+      if (!peer.authTimeout) return;
+      clearTimeout(peer.authTimeout);
+      peer.authTimeout = null;
+    };
+    peer.authTimeout = setTimeout(() => {
+      if (peer.authenticated || peer.ws.readyState !== WS_OPEN) return;
+      args.logger.warn("sync_brain.auth_timeout", {
+        remoteAddress: remoteAddress ?? null,
+      });
+      try {
+        peer.ws.close(4003, "Authentication timed out");
+      } catch {
+        // ignore close failures
+      }
+    }, authTimeoutMs);
+    peer.authTimeout.unref?.();
     ws.on("message", (data: RawData) => {
       void (async () => {
         let envelope: ReturnType<typeof parseSyncEnvelope>;
@@ -599,6 +621,11 @@ export function createBrainProjectActionsSyncHandler(
               code: "invalid_hello",
               message: "Authenticate with hello or pairing_request before sending other messages.",
             }, envelope.requestId);
+            try {
+              ws.close(4003, "Authentication required");
+            } catch {
+              // ignore close failures
+            }
             return;
           }
           const hello = parseHelloPayload(envelope.payload);
@@ -607,6 +634,11 @@ export function createBrainProjectActionsSyncHandler(
               code: "invalid_hello",
               message: "Invalid hello payload.",
             }, envelope.requestId);
+            try {
+              ws.close(4003, "Invalid hello");
+            } catch {
+              // ignore close failures
+            }
             return;
           }
           const auth = hello.auth;
@@ -628,6 +660,7 @@ export function createBrainProjectActionsSyncHandler(
             return;
           }
           peer.authenticated = true;
+          clearAuthTimeout();
           peer.metadata = hello.peer;
           const catalog = await projectCatalog(args.projectCatalogProvider, args.logger);
           const brain = brainMetadata();
@@ -670,6 +703,9 @@ export function createBrainProjectActionsSyncHandler(
         error: error instanceof Error ? error.message : String(error),
         peerDeviceId: peer.metadata?.deviceId ?? null,
       });
+    });
+    ws.on("close", () => {
+      clearAuthTimeout();
     });
   };
 }

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -698,6 +698,47 @@ describe("createSyncHostService LAN discovery", () => {
     vi.restoreAllMocks();
   });
 
+  it("closes inbound sockets that never authenticate", async () => {
+    const { projectRoot, cleanup } = createTempProjectRoot();
+    const host = createSyncHostService({
+      ...createHostArgs(projectRoot, [createDiscoveryProject({ id: "project-1" })]),
+      authTimeoutMs: 1_000,
+    } as unknown as Parameters<typeof createSyncHostService>[0]);
+    let client: WebSocket | null = null;
+
+    try {
+      const port = await host.waitUntilListening();
+      client = new WebSocket(`ws://127.0.0.1:${port}`);
+      await new Promise<void>((resolve, reject) => {
+        client!.once("open", () => resolve());
+        client!.once("error", reject);
+      });
+
+      const closeEvent = await Promise.race([
+        new Promise<{ code: number; reason: string }>((resolve) => {
+          client!.once("close", (code, reason) => {
+            resolve({ code, reason: reason.toString("utf8") });
+          });
+        }),
+        new Promise<never>((_, reject) => {
+          setTimeout(() => reject(new Error("Timed out waiting for unauthenticated socket close.")), 3_000);
+        }),
+      ]);
+      expect(closeEvent).toEqual({
+        code: 4003,
+        reason: "Authentication timed out",
+      });
+    } finally {
+      try {
+        client?.close();
+      } catch {
+        // ignore close failures
+      }
+      await host.dispose();
+      cleanup();
+    }
+  });
+
   it("does not publish LAN Bonjour metadata when the sync host is loopback-bound", async () => {
     const { projectRoot, cleanup } = createTempProjectRoot();
     const projects = [

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -150,6 +150,7 @@ const PEER_BACKPRESSURE_BYTES = 4 * 1024 * 1024;
 const MOBILE_COMMAND_RESULT_CACHE_TTL_MS = 30 * 60 * 1000;
 const MOBILE_COMMAND_RESULT_CACHE_MAX_ENTRIES = 512;
 const CHANGESET_ACK_TIMEOUT_MS = 10_000;
+const SYNC_HOST_AUTH_TIMEOUT_MS = 15_000;
 const MAX_CHANGESET_ACK_RETRIES = 6;
 const LANE_PRESENCE_TTL_MS = 60_000;
 const SYNC_MDNS_SERVICE_TYPE = "ade-sync";
@@ -182,6 +183,7 @@ type PeerState = {
   ws: WebSocket;
   metadata: SyncPeerMetadata | null;
   authenticated: boolean;
+  authTimeout: ReturnType<typeof setTimeout> | null;
   authKind: "bootstrap" | "paired" | null;
   pairedDeviceId: string | null;
   pairingRecord: SyncPairingRecord | null;
@@ -404,6 +406,7 @@ type SyncHostServiceArgs = {
   runtimeVersion?: string;
   heartbeatIntervalMs?: number;
   pollIntervalMs?: number;
+  authTimeoutMs?: number;
   brainStatusIntervalMs?: number;
   compressionThresholdBytes?: number;
   deviceRegistryService?: DeviceRegistryService;
@@ -987,6 +990,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
   const heartbeatIntervalMs = Math.max(5_000, Math.floor(args.heartbeatIntervalMs ?? DEFAULT_SYNC_HEARTBEAT_INTERVAL_MS));
   const pollIntervalMs = Math.max(100, Math.floor(args.pollIntervalMs ?? DEFAULT_SYNC_POLL_INTERVAL_MS));
   const brainStatusIntervalMs = Math.max(1_000, Math.floor(args.brainStatusIntervalMs ?? DEFAULT_BRAIN_STATUS_INTERVAL_MS));
+  const authTimeoutMs = Math.max(1_000, Math.floor(args.authTimeoutMs ?? SYNC_HOST_AUTH_TIMEOUT_MS));
   const compressionThresholdBytes = Math.max(256, Math.floor(args.compressionThresholdBytes ?? DEFAULT_SYNC_COMPRESSION_THRESHOLD_BYTES));
   const maxChangesetBatchBytes = DEFAULT_MAX_CHANGESET_BATCH_BYTES;
   const maxChangesetBatchRows = DEFAULT_MAX_CHANGESET_BATCH_ROWS;
@@ -1541,11 +1545,18 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     }
   }
 
+  function clearPeerAuthTimeout(peer: PeerState): void {
+    if (!peer.authTimeout) return;
+    clearTimeout(peer.authTimeout);
+    peer.authTimeout = null;
+  }
+
   function registerPeer(ws: WebSocket, remoteAddress: string | null, remotePort: number | null): PeerState {
     const peer: PeerState = {
       ws,
       metadata: null,
       authenticated: false,
+      authTimeout: null,
       authKind: null,
       pairedDeviceId: null,
       pairingRecord: null,
@@ -1565,6 +1576,19 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       pendingChangesetBatch: null,
     };
     peers.add(peer);
+    peer.authTimeout = setTimeout(() => {
+      if (disposed || peer.authenticated || peer.ws.readyState !== WebSocket.OPEN) return;
+      args.logger.warn("sync_host.auth_timeout", {
+        remoteAddress: peer.remoteAddress ?? null,
+        connectedAt: peer.connectedAt,
+      });
+      try {
+        peer.ws.close(4003, "Authentication timed out");
+      } catch {
+        // ignore close failures
+      }
+    }, authTimeoutMs);
+    peer.authTimeout.unref?.();
     ws.on("message", (raw) => {
       void handleMessage(peer, raw).catch((error) => {
         args.logger.warn("sync_host.message_failed", {
@@ -1574,6 +1598,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       });
     });
     ws.on("close", (code, reason) => {
+      clearPeerAuthTimeout(peer);
       // The close frame is the only record of WHY a peer left: a deliberate
       // client teardown carries a code + reason string ("Network route
       // changed.", "The machine took too long to respond.", …) while 1006
@@ -1653,6 +1678,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         if (snapshot.authKind === "paired" && !pairingRecord) {
           // Pairing is not valid for this host (revoked or different secrets
           // store) — fail closed and force a fresh authenticated reconnect.
+          clearPeerAuthTimeout(peer);
           peers.delete(peer);
           try {
             ws.close(4003, "Authentication required");
@@ -1662,6 +1688,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
           continue;
         }
         peer.authenticated = true;
+        clearPeerAuthTimeout(peer);
         peer.metadata = snapshot.metadata;
         peer.authKind = snapshot.authKind;
         peer.pairedDeviceId = snapshot.pairedDeviceId;
@@ -3492,6 +3519,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
 
       closeExistingPeersForDevice(hello.peer.deviceId, peer);
       peer.authenticated = true;
+      clearPeerAuthTimeout(peer);
       peer.metadata = hello.peer;
       const auth = hello.auth ?? { kind: "bootstrap", token: "" };
       peer.authKind = auth.kind;
@@ -4190,6 +4218,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         detachSharedListener = null;
         const snapshots: SyncPeerHandoffSnapshot[] = [];
         for (const peer of peers) {
+          clearPeerAuthTimeout(peer);
           peer.ws.removeAllListeners("message");
           peer.ws.removeAllListeners("close");
           peer.ws.removeAllListeners("error");
@@ -4227,6 +4256,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         await new Promise<void>((resolve) => {
           const finish = () => resolve();
           for (const peer of peers) {
+            clearPeerAuthTimeout(peer);
             try {
               peer.ws.close();
             } catch {

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.ts
@@ -95,7 +95,7 @@ type RuntimeEventWindowSubscription = {
 };
 
 type RuntimeEventSubscribe = (
-  onEvent: (event: RemoteRuntimeBufferedEvent) => void,
+  onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
   onEnded: () => void,
 ) => Promise<() => void>;
 
@@ -385,6 +385,7 @@ export function registerRuntimeBridge({
     bindingKey: string,
     requestKey: string,
     event: RemoteRuntimeBufferedEvent,
+    eventEpoch?: string | null,
   ): void => {
     const existing = runtimeEventSubscriptions.get(sender.id);
     if (
@@ -398,6 +399,7 @@ export function registerRuntimeBridge({
     const payload: RemoteRuntimeEventNotificationPayload = {
       bindingKey,
       event,
+      ...(eventEpoch ? { eventEpoch } : {}),
     };
     try {
       sender.send(IPC.runtimeEvent, payload);
@@ -424,7 +426,8 @@ export function registerRuntimeBridge({
       }
     };
     void subscribe(
-      (event) => sendRuntimeEvent(sender, bindingKey, requestKey, event),
+      (event, eventEpoch) =>
+        sendRuntimeEvent(sender, bindingKey, requestKey, event, eventEpoch),
       onEnded,
     )
       .then((cleanup) => {

--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.test.ts
@@ -2031,9 +2031,10 @@ describe("local runtime connection pool", () => {
               category: "runtime",
               payload: { type: "file_change" },
             },
+            eventEpoch: "epoch-local-1",
           });
         }
-        return { subscriptionId: "runtime-events-4", nextCursor: 22, hasMore: false };
+        return { subscriptionId: "runtime-events-4", nextCursor: 22, hasMore: false, eventEpoch: "epoch-local-1" };
       }
       if (method === "runtimeEvents.unsubscribe") {
         return { removed: true };
@@ -2094,7 +2095,7 @@ describe("local runtime connection pool", () => {
       timestamp: "2026-05-10T12:00:00.000Z",
       category: "runtime",
       payload: { type: "file_change" },
-    });
+    }, "epoch-local-1");
 
     cleanup();
     expect(call).toHaveBeenCalledWith("runtimeEvents.unsubscribe", { subscriptionId: "runtime-events-4" });

--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
@@ -40,6 +40,7 @@ type RuntimeEventNotification = {
   subscriptionId: string;
   projectId: string;
   event: RemoteRuntimeBufferedEvent;
+  eventEpoch: string | null;
 };
 
 type RuntimeServiceManagerOutput = {
@@ -1148,7 +1149,7 @@ export class LocalRuntimeConnectionPool {
   async subscribeEventsForRoot(
     rootPath: string,
     request: RemoteRuntimeStreamEventsRequest = {},
-    onEvent: (event: RemoteRuntimeBufferedEvent) => void,
+    onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
     onEnded?: () => void,
   ): Promise<() => void> {
     const project = await this.ensureProject(rootPath);
@@ -1765,7 +1766,7 @@ async function subscribeToRuntimeEvents(
   client: RuntimeRpcClient,
   projectId: string,
   request: RemoteRuntimeStreamEventsRequest,
-  onEvent: (event: RemoteRuntimeBufferedEvent) => void,
+  onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
   onEnded?: () => void,
 ): Promise<() => void> {
   const pendingNotifications: RuntimeEventNotification[] = [];
@@ -1781,7 +1782,7 @@ async function subscribeToRuntimeEvents(
       return;
     }
     if (notification.subscriptionId === subscriptionId) {
-      onEvent(notification.event);
+      onEvent(notification.event, notification.eventEpoch);
     }
   });
   const removeDisconnectListener = client.onDisconnect(() => {
@@ -1803,7 +1804,7 @@ async function subscribeToRuntimeEvents(
     for (const notification of pendingNotifications) {
       if (closed) break;
       if (notification.subscriptionId === subscriptionId) {
-        onEvent(notification.event);
+        onEvent(notification.event, notification.eventEpoch);
       }
     }
   } catch (error) {
@@ -1844,6 +1845,9 @@ function normalizeRuntimeEventNotification(value: unknown): RuntimeEventNotifica
     : null;
   const projectId = typeof record.projectId === "string" ? record.projectId : "";
   const event = normalizeBufferedEvent(record.event);
+  const eventEpoch = typeof record.eventEpoch === "string" && record.eventEpoch.trim()
+    ? record.eventEpoch.trim()
+    : null;
   if (subscriptionId == null || !projectId || !event) return null;
-  return { subscriptionId, projectId, event };
+  return { subscriptionId, projectId, event, eventEpoch };
 }

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.test.ts
@@ -1206,6 +1206,7 @@ describe("RemoteConnectionPool", () => {
             category: "pty",
             payload: { type: "pty_data" },
           },
+          eventEpoch: "epoch-remote-1",
         });
         client.emitNotification("runtime/event", {
           subscriptionId: "runtime-events-8",
@@ -1216,11 +1217,13 @@ describe("RemoteConnectionPool", () => {
             category: "runtime",
             payload: { type: "other_subscription" },
           },
+          eventEpoch: "epoch-remote-1",
         });
         return {
           subscriptionId: "runtime-events-7",
           nextCursor: 13,
           hasMore: false,
+          eventEpoch: "epoch-remote-1",
         };
       }
       if (method === "runtimeEvents.unsubscribe") {
@@ -1261,7 +1264,7 @@ describe("RemoteConnectionPool", () => {
       timestamp: "2026-05-10T12:00:00.000Z",
       category: "pty",
       payload: { type: "pty_data" },
-    });
+    }, "epoch-remote-1");
 
     client.emitNotification("runtime/event", {
       subscriptionId: "runtime-events-7",
@@ -1272,6 +1275,7 @@ describe("RemoteConnectionPool", () => {
         category: "runtime",
         payload: { type: "live" },
       },
+      eventEpoch: "epoch-remote-1",
     });
     expect(onEvent).toHaveBeenCalledTimes(2);
 

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.ts
@@ -56,6 +56,7 @@ type RuntimeEventNotification = {
   subscriptionId: string;
   projectId: string;
   event: RemoteRuntimeBufferedEvent;
+  eventEpoch: string | null;
 };
 
 type ConnectFailureBackoff = {
@@ -734,7 +735,7 @@ export class RemoteConnectionPool {
     targetId: string,
     projectId: string,
     request: RemoteRuntimeStreamEventsRequest = {},
-    onEvent: (event: RemoteRuntimeBufferedEvent) => void,
+    onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
     onEnded?: () => void,
   ): Promise<() => void> {
     const entry = await this.requireEntry(targetId);
@@ -751,7 +752,7 @@ export class RemoteConnectionPool {
     target: RemoteRuntimeTarget,
     projectId: string,
     request: RemoteRuntimeStreamEventsRequest = {},
-    onEvent: (event: RemoteRuntimeBufferedEvent) => void,
+    onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
     onEnded?: () => void,
   ): Promise<() => void> {
     return await this.withEntryForTarget(
@@ -1053,7 +1054,7 @@ async function subscribeToRuntimeEvents(
   client: RuntimeRpcClient,
   projectId: string,
   request: RemoteRuntimeStreamEventsRequest,
-  onEvent: (event: RemoteRuntimeBufferedEvent) => void,
+  onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
   onEnded?: () => void,
 ): Promise<() => void> {
   const pendingNotifications: RuntimeEventNotification[] = [];
@@ -1071,7 +1072,7 @@ async function subscribeToRuntimeEvents(
         return;
       }
       if (notification.subscriptionId === subscriptionId) {
-        onEvent(notification.event);
+        onEvent(notification.event, notification.eventEpoch);
       }
     },
   );
@@ -1096,7 +1097,7 @@ async function subscribeToRuntimeEvents(
     for (const notification of pendingNotifications) {
       if (closed) break;
       if (notification.subscriptionId === subscriptionId) {
-        onEvent(notification.event);
+        onEvent(notification.event, notification.eventEpoch);
       }
     }
   } catch (error) {
@@ -1147,6 +1148,10 @@ function normalizeRuntimeEventNotification(
   const projectId =
     typeof record.projectId === "string" ? record.projectId : "";
   const event = normalizeBufferedEvent(record.event);
+  const eventEpoch =
+    typeof record.eventEpoch === "string" && record.eventEpoch.trim()
+      ? record.eventEpoch.trim()
+      : null;
   if (subscriptionId == null || !projectId || !event) return null;
-  return { subscriptionId, projectId, event };
+  return { subscriptionId, projectId, event, eventEpoch };
 }

--- a/apps/desktop/src/preload/preload.test.ts
+++ b/apps/desktop/src/preload/preload.test.ts
@@ -3714,6 +3714,89 @@ describe("preload OAuth bridge", () => {
     });
   });
 
+  it("dispatches live runtime notifications when event ids repeat after an epoch change", async () => {
+    const binding = {
+      kind: "local",
+      key: "local:/repo/project",
+      rootPath: "/repo/project",
+      displayName: "Project",
+    };
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === IPC.appGetWindowSession) {
+        return { windowId: 1, project: null, binding };
+      }
+      if (channel === IPC.localRuntimeStreamEvents) {
+        return { events: [], nextCursor: 0, hasMore: false };
+      }
+      return undefined;
+    });
+    const on = vi.fn();
+    const removeListener = vi.fn();
+    const exposeInMainWorld = vi.fn((name: string, value: unknown) => {
+      (globalThis as any).__bridgeName = name;
+      (globalThis as any).__adeBridge = value;
+    });
+
+    vi.doMock("electron", () => ({
+      contextBridge: { exposeInMainWorld },
+      ipcRenderer: { invoke, on, removeListener },
+      webFrame: {
+        getZoomLevel: vi.fn(() => 0),
+        setZoomLevel: vi.fn(),
+        getZoomFactor: vi.fn(() => 1),
+      },
+    }));
+
+    await import("./preload");
+
+    const bridge = (globalThis as any).__adeBridge;
+    await bridge.app.getWindowSession();
+
+    const callback = vi.fn();
+    bridge.pty.onData(callback);
+
+    const runtimeListener = on.mock.calls.find(([channel]) => channel === IPC.runtimeEvent)?.[1];
+    expect(typeof runtimeListener).toBe("function");
+    runtimeListener({}, {
+      bindingKey: binding.key,
+      eventEpoch: "epoch-before-restart",
+      event: {
+        id: 1,
+        timestamp: "2026-05-10T12:00:01.000Z",
+        category: "pty",
+        payload: {
+          type: "pty_data",
+          event: { ptyId: "pty-1", sessionId: "session-1", data: "before" },
+        },
+      },
+    });
+    runtimeListener({}, {
+      bindingKey: binding.key,
+      eventEpoch: "epoch-after-restart",
+      event: {
+        id: 1,
+        timestamp: "2026-05-10T12:00:02.000Z",
+        category: "pty",
+        payload: {
+          type: "pty_data",
+          event: { ptyId: "pty-1", sessionId: "session-1", data: "after" },
+        },
+      },
+    });
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenNthCalledWith(1, {
+      ptyId: "pty-1",
+      sessionId: "session-1",
+      data: "before",
+    });
+    expect(callback).toHaveBeenNthCalledWith(2, {
+      ptyId: "pty-1",
+      sessionId: "session-1",
+      data: "after",
+    });
+  });
+
   it("fans out remote runtime events for routed project utility domains", async () => {
     const binding = {
       kind: "remote",

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1888,6 +1888,21 @@ function handleRemoteRuntimeEventNotification(value: unknown): void {
   const binding = currentProjectBinding;
   if (!payload || !binding || payload.bindingKey !== binding.key) return;
   resetRemoteRuntimeEmptyPolls();
+  const notificationEpoch =
+    typeof payload.eventEpoch === "string" && payload.eventEpoch.trim()
+      ? payload.eventEpoch.trim()
+      : null;
+  if (notificationEpoch) {
+    const epochChanged = remoteRuntimeEventEpoch
+      ? notificationEpoch !== remoteRuntimeEventEpoch
+      : remoteRuntimeEventCursor > 0 || remoteRuntimeSeenEventIds.size > 0;
+    remoteRuntimeEventEpoch = notificationEpoch;
+    if (epochChanged) {
+      remoteRuntimeEventCursor = 0;
+      remoteRuntimeEventReplaySuppressed = binding.kind === "remote";
+      resetRemoteRuntimeEventDedup(binding.key);
+    }
+  }
   const eventTime = Date.parse(payload.event.timestamp);
   if (
     binding.kind === "local" &&
@@ -1909,8 +1924,12 @@ function toRemoteRuntimeEventNotificationPayload(
   const bindingKey =
     typeof value.bindingKey === "string" ? value.bindingKey : "";
   const event = toRemoteRuntimeBufferedEvent(value.event);
+  const eventEpoch =
+    typeof value.eventEpoch === "string" && value.eventEpoch.trim()
+      ? value.eventEpoch.trim()
+      : null;
   if (!bindingKey || !event) return null;
-  return { bindingKey, event };
+  return { bindingKey, event, ...(eventEpoch ? { eventEpoch } : {}) };
 }
 
 function isRemoteRuntimeEventCategory(

--- a/apps/desktop/src/shared/types/remoteRuntime.ts
+++ b/apps/desktop/src/shared/types/remoteRuntime.ts
@@ -209,6 +209,7 @@ export type RemoteRuntimeStreamEventsResult = {
 export type RemoteRuntimeEventNotificationPayload = {
   bindingKey: string;
   event: RemoteRuntimeBufferedEvent;
+  eventEpoch?: string | null;
 };
 
 export type RemoteRuntimeLocalWorkMatch = {


### PR DESCRIPTION
## Summary
- add inbound sync auth timeouts and fallback pre-auth closes so silent sockets cannot stay open forever
- scope generic run_ade_action PTY/terminal calls through the existing lane/chat authorization checks
- carry runtime event epochs through live subscriptions so renderer dedup survives daemon restarts

## Validation
- npm --prefix apps/ade-cli run typecheck
- npm --prefix apps/desktop run typecheck
- npx vitest run src/adeRpcServer.test.ts src/multiProjectRpcServer.test.ts src/services/sync/syncHostService.test.ts (apps/ade-cli)
- npx vitest run src/preload/preload.test.ts src/main/services/localRuntime/localRuntimeConnectionPool.test.ts src/main/services/remoteRuntime/remoteConnectionPool.test.ts (apps/desktop)
- npm --prefix apps/desktop run build
- npm --prefix apps/ade-cli run build

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens three independent security and correctness surfaces: inbound sync socket auth timeouts, PTY/terminal `run_ade_action` authorization scoping, and daemon-restart-safe event dedup via epoch propagation.

- **Sync auth timeouts**: Both `syncHostService` and `brainProjectActionsSyncHandler` now close unauthenticated sockets after 15 s, with `clearPeerAuthTimeout` wired into all exit paths (close, handoff, dispose, successful auth, pairing failure).
- **PTY/terminal action scoping**: `run_ade_action` calls for the `pty` and `terminal` domains are gated through the existing lane/chat authorization helpers for non-CTO callers; unknown actions default-deny.
- **Epoch propagation**: `eventBuffer.epoch()` is threaded through subscription responses and live notification payloads so the renderer can reset its dedup set when the daemon restarts, preventing stale event-ID suppression.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: the polling handler's epoch-change guard can miss stale seen-IDs after a daemon restart, causing legitimate events to be silently dropped.

The auth-timeout and PTY-scoping changes are solid. The epoch propagation wiring is correct end-to-end, but the polling path in preload.ts uses a narrower condition (remoteRuntimeEventCursor > 0) than the notification path (remoteRuntimeEventCursor > 0 || remoteRuntimeSeenEventIds.size > 0) for the 'no prior epoch' case. If notifications without an epoch field populated the seen-ID set before a restart, the first post-restart poll will not clear it, and events with recycled IDs from the new daemon will be silently dropped until the user refreshes.

apps/desktop/src/preload/preload.ts — the epoch-change condition in the polling path (around line 1812).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/preload/preload.ts | Adds epoch-aware dedup reset for live runtime event notifications; polling path has a gap in its 'no prior epoch' guard that can leave stale seen-IDs in place after a daemon restart. |
| apps/ade-cli/src/adeRpcServer.ts | Adds lane/chat-scoped authorization helpers for run_ade_action PTY and terminal calls; logic is correct and fail-closed (default denies unknown actions). |
| apps/ade-cli/src/services/sync/syncHostService.ts | Adds 15 s auth timeout for inbound sync peers; clearPeerAuthTimeout is called at all relevant code paths (close, handoff, dispose, success auth). |
| apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts | Mirrors syncHostService auth-timeout pattern for brain-side sync connections; close listener correctly covers the timeout cleanup. |
| apps/ade-cli/src/multiProjectRpcServer.ts | Captures and forwards eventEpoch through both replay and live subscription paths consistently. |
| apps/ade-cli/src/eventBuffer.ts | Adds epoch() accessor and includes eventEpoch in drain results; UUID is stable for the buffer's lifetime. |
| apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts | Threads eventEpoch from subscription notifications through to the onEvent callback correctly. |
| apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.ts | Same eventEpoch threading as localRuntimeConnectionPool; normalization guard correctly handles missing/blank epoch. |
| apps/desktop/src/main/services/ipc/runtimeBridge.ts | Propagates optional eventEpoch from the connection pool callback into the IPC payload sent to preload. |
| apps/desktop/src/shared/types/remoteRuntime.ts | Adds optional eventEpoch field to RemoteRuntimeEventNotificationPayload type. |

</details>



<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Daemon
    participant ConnPool as ConnectionPool
    participant Bridge as RuntimeBridge
    participant Preload

    Daemon->>ConnPool: "runtimeEvents.subscribe → {subscriptionId, eventEpoch}"
    ConnPool->>Bridge: onEvent(event, eventEpoch)
    Bridge->>Preload: "IPC runtimeEvent {event, eventEpoch}"
    Preload->>Preload: epoch changed? → resetDedup()

    note over Daemon,Preload: Daemon restarts (new epoch)

    Daemon->>ConnPool: "runtime/event notification {event, eventEpoch: new}"
    ConnPool->>Bridge: onEvent(event, eventEpoch: new)
    Bridge->>Preload: "IPC runtimeEvent {event, eventEpoch: new}"
    Preload->>Preload: epoch changed → clear remoteRuntimeSeenEventIds
    Preload->>Preload: dispatch event (not dedup-blocked)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Daemon
    participant ConnPool as ConnectionPool
    participant Bridge as RuntimeBridge
    participant Preload

    Daemon->>ConnPool: "runtimeEvents.subscribe → {subscriptionId, eventEpoch}"
    ConnPool->>Bridge: onEvent(event, eventEpoch)
    Bridge->>Preload: "IPC runtimeEvent {event, eventEpoch}"
    Preload->>Preload: epoch changed? → resetDedup()

    note over Daemon,Preload: Daemon restarts (new epoch)

    Daemon->>ConnPool: "runtime/event notification {event, eventEpoch: new}"
    ConnPool->>Bridge: onEvent(event, eventEpoch: new)
    Bridge->>Preload: "IPC runtimeEvent {event, eventEpoch: new}"
    Preload->>Preload: epoch changed → clear remoteRuntimeSeenEventIds
    Preload->>Preload: dispatch event (not dedup-blocked)
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/preload/preload.ts`, line 1812-1814 ([link](https://github.com/arul28/ade/blob/ad9512991e5d8b7d31256db40cc95ccc4bd05497/apps/desktop/src/preload/preload.ts#L1812-L1814)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Epoch-change condition is inconsistent between the polling and notification paths. The notification handler treats the "no prior epoch" case as changed when either `remoteRuntimeEventCursor > 0` **or** `remoteRuntimeSeenEventIds.size > 0`, but the polling handler only checks `remoteRuntimeEventCursor > 0`. If live notifications have populated `remoteRuntimeSeenEventIds` (cursor still 0) and the first poll response arrives with a new epoch, dedup state won't be cleared — stale IDs in the seen set can then cause legitimate events to be silently dropped.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/preload/preload.ts
   Line: 1812-1814

   Comment:
   Epoch-change condition is inconsistent between the polling and notification paths. The notification handler treats the "no prior epoch" case as changed when either `remoteRuntimeEventCursor > 0` **or** `remoteRuntimeSeenEventIds.size > 0`, but the polling handler only checks `remoteRuntimeEventCursor > 0`. If live notifications have populated `remoteRuntimeSeenEventIds` (cursor still 0) and the first poll response arrives with a new epoch, dedup state won't be cleared — stale IDs in the seen set can then cause legitimate events to be silently dropped.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fpreload%2Fpreload.ts%0ALine%3A%201812-1814%0A%0AComment%3A%0AEpoch-change%20condition%20is%20inconsistent%20between%20the%20polling%20and%20notification%20paths.%20The%20notification%20handler%20treats%20the%20%22no%20prior%20epoch%22%20case%20as%20changed%20when%20either%20%60remoteRuntimeEventCursor%20%3E%200%60%20**or**%20%60remoteRuntimeSeenEventIds.size%20%3E%200%60%2C%20but%20the%20polling%20handler%20only%20checks%20%60remoteRuntimeEventCursor%20%3E%200%60.%20If%20live%20notifications%20have%20populated%20%60remoteRuntimeSeenEventIds%60%20%28cursor%20still%200%29%20and%20the%20first%20poll%20response%20arrives%20with%20a%20new%20epoch%2C%20dedup%20state%20won't%20be%20cleared%20%E2%80%94%20stale%20IDs%20in%20the%20seen%20set%20can%20then%20cause%20legitimate%20events%20to%20be%20silently%20dropped.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20epochChanged%20%3D%20remoteRuntimeEventEpoch%0A%20%20%20%20%20%20%20%20%3F%20batchEpoch%20!%3D%3D%20remoteRuntimeEventEpoch%0A%20%20%20%20%20%20%20%20%3A%20remoteRuntimeEventCursor%20%3E%200%20%7C%7C%20remoteRuntimeSeenEventIds.size%20%3E%200%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=610&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Fpreload%2Fpreload.ts%3A1812-1814%0AEpoch-change%20detection%20is%20inconsistent%20between%20the%20polling%20and%20notification%20paths.%20The%20notification%20handler%20%28line%201898%29%20treats%20%22no%20prior%20epoch%22%20as%20changed%20when%20%60remoteRuntimeEventCursor%20%3E%200%20%7C%7C%20remoteRuntimeSeenEventIds.size%20%3E%200%60%2C%20but%20the%20polling%20handler%20only%20guards%20on%20%60remoteRuntimeEventCursor%20%3E%200%60.%20If%20notifications%20without%20an%20epoch%20field%20arrive%20first%20%28populating%20%60remoteRuntimeSeenEventIds%60%20while%20cursor%20stays%200%29%2C%20then%20a%20daemon%20restarts%20and%20the%20next%20poll%20returns%20a%20new%20epoch%2C%20the%20polling%20path%20will%20set%20%60epochChanged%20%3D%20false%60%2C%20leaving%20stale%20IDs%20in%20the%20seen%20set.%20Subsequent%20events%20from%20the%20new%20daemon%20that%20re-use%20those%20IDs%20will%20then%20be%20silently%20dropped.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20epochChanged%20%3D%20remoteRuntimeEventEpoch%0A%20%20%20%20%20%20%20%20%3F%20batchEpoch%20!%3D%3D%20remoteRuntimeEventEpoch%0A%20%20%20%20%20%20%20%20%3A%20remoteRuntimeEventCursor%20%3E%200%20%7C%7C%20remoteRuntimeSeenEventIds.size%20%3E%200%3B%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=610&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/preload/preload.ts:1812-1814
Epoch-change detection is inconsistent between the polling and notification paths. The notification handler (line 1898) treats "no prior epoch" as changed when `remoteRuntimeEventCursor > 0 || remoteRuntimeSeenEventIds.size > 0`, but the polling handler only guards on `remoteRuntimeEventCursor > 0`. If notifications without an epoch field arrive first (populating `remoteRuntimeSeenEventIds` while cursor stays 0), then a daemon restarts and the next poll returns a new epoch, the polling path will set `epochChanged = false`, leaving stale IDs in the seen set. Subsequent events from the new daemon that re-use those IDs will then be silently dropped.

```suggestion
      const epochChanged = remoteRuntimeEventEpoch
        ? batchEpoch !== remoteRuntimeEventEpoch
        : remoteRuntimeEventCursor > 0 || remoteRuntimeSeenEventIds.size > 0;
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Remove dead PTY action branch"](https://github.com/arul28/ade/commit/c422307f86084c2ccd8232239debb89d93961f56) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38586892)</sub>

<!-- /greptile_comment -->

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fsync-runtime-trust-availability-no-1bc681f9 num=610 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fsync-runtime-trust-availability-no-1bc681f9&amp;pr=610">ade/sync-runtime-trust-availability-no-1bc681f9 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=610">PR #610</a>
</p>
<!-- /ade:link -->
