### PR TITLE
release: changelog for v1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.8] - 2026-06-19
+
+### Added
+
+- PR merge and timeline at GitHub parity across desktop and iOS: authoritative merge-state status, a merge dialog with selectable method and editable commit message, admin bypass, update-branch, and a unified commits/reviews/checks timeline.
+- Deterministic orchestration planning: an explicit planning → approval → developing state machine with structured plan specs, a real readiness gate, a structured validation-findings table, and crash-resume.
+- Mobile: unified Files search, project-picker icons, a Work-tab PR status indicator, and a composer that remembers your last-used model and mode.
+
+### Changed
+
+- Sync host hardening: inbound peer changesets are bounded so one oversized batch can't lock the database, cluster/brain ownership is host-authoritative so a paired peer can't seize it, and socket trust plus runtime-event availability are tightened.
+- iOS data layer is serialized through a single queue, eliminating apply-versus-main-actor data races and transaction interleaving.
+- Unified the project recents explorer and refined pending-input cards across chat surfaces.
+
+### Fixed
+
+- Security/correctness sweep: forgeable validator gate, bypassable plan-approval gate, credential-store wipe on OS-key rotation, non-atomic config writes, git commit-SHA option injection, and `/open` deeplink SSRF (now origin-pinned with a fetch timeout).
+- Sync gzip cap and Intel (x64) cr-sqlite packaging; iOS terminal/transcript renderer clamps hostile escape sequences so agent output can't exhaust memory.
+- Lost auto-create lane / background launch on project switch, macOS traffic-light overlap when zoomed out, remote image-paste attachment routing, chat mic refreshing live after a voice-model download, ADE browser downloads and overlay layering, external-link opening in remote PR surfaces, and mobile reconnect-cancel handling.
+
 ## [1.2.7] - 2026-06-16
 
 ### Added
@@ -428,7 +448,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.7...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.8...HEAD
+[1.2.8]: https://github.com/arul28/ADE/compare/v1.2.7...v1.2.8
 [1.2.7]: https://github.com/arul28/ADE/compare/v1.2.6...v1.2.7
 [1.2.6]: https://github.com/arul28/ADE/compare/v1.2.5...v1.2.6
 [1.2.5]: https://github.com/arul28/ADE/compare/v1.2.4...v1.2.5

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.7">
-  v1.2.7 - ADE Code drops the drawer flicker and gains multi-question approvals, mobile auto-names lanes with AI, iOS chat scrolling is faster, and the macOS VM and mobile push surfaces are retired.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.8">
+  v1.2.8 - PR merge and timeline reach GitHub parity across desktop and iOS, orchestration planning becomes a deterministic approval-gated flow, sync gets faster and more resilient, and a security and correctness sweep hardens orchestration, persistence, git, and the iOS data layer.
 </Card>

--- a/changelog/v1.2.8.mdx
+++ b/changelog/v1.2.8.mdx
@@ -1,0 +1,26 @@
+---
+title: "v1.2.8"
+description: "Release notes for ADE v1.2.8 - June 19, 2026"
+---
+
+v1.2.8 is a stability and hardening release: GitHub-parity PR merge and timeline across every surface, a deterministic orchestration planning flow, faster and more resilient sync, and a security and correctness sweep spanning orchestration, persistence, git, the deeplink web surface, and the iOS data layer.
+
+---
+
+## Desktop
+
+- **PR merge and timeline at GitHub parity.** The PRs tab now mirrors GitHub's merge flow end to end — authoritative merge-state status, a portaled merge dialog with selectable method and an editable commit message, admin bypass, update-branch, and a re-poll that clears a stuck "Checking mergeability…". The timeline renders commits, reviews, and checks as one unified thread.
+- **Deterministic orchestration planning.** Orchestrator runs move through an explicit planning → approval → developing state machine with structured plan specs and a real readiness gate, replacing the old gameable regex gate. Plan approval is the only way out of planning, validation findings render in a structured table, and a run resumes cleanly after a crash.
+- **Security and correctness hardening.** A sweep across orchestration, sync, persistence, git, and the deeplink endpoint: the validator gate can no longer be forged from a self-reported step id, the plan-approval gate can't be bypassed during normalization, the credential store fails safe on OS-key rotation instead of silently wiping all credentials, project config writes atomically so a crash or full disk can't truncate it, git commit-SHA arguments are validated against option injection, and the `/open` deeplink endpoint is pinned against SSRF with a fetch timeout.
+- **Sync reliability.** Inbound peer changesets are bounded so a single oversized batch can't lock the database, cluster and brain ownership is host-authoritative so a paired peer can't seize it, and the gzip cap plus Intel (x64) cr-sqlite packaging are fixed. Socket trust and runtime-event availability are tightened, and headless RPC sockets are created with restrictive permissions.
+- **Lanes and projects.** Fixed the lost auto-create lane and background launch when switching projects, unified the project recents explorer, and refined the pending-input cards across chat surfaces.
+- **More fixes.** macOS traffic-light overlap when zoomed out, remote image-paste attachment routing, the chat mic refreshing live after a voice-model download (no restart), ADE browser downloads and overlay layering, and external-link opening in remote PR surfaces.
+
+---
+
+## iOS
+
+- **PR merge and timeline parity.** The mobile PRs experience matches desktop and GitHub — authoritative merge-state, the merge method and commit-message flow, and the unified commits, reviews, and checks timeline.
+- **Files, projects, and Work.** Unified Files search, project-picker icons, a Work-tab PR status indicator, and a composer that remembers your last-used model and mode.
+- **Data-layer hardening.** The on-device database is serialized through a single queue, eliminating the apply-versus-main-actor data races and transaction interleaving that could corrupt sync or crash the app, and the terminal and transcript renderer clamps hostile escape sequences so ordinary agent output can't exhaust memory and take down the chat view.
+- **Sync fixes.** Reconnect-cancel handling is fixed, and the shared sync hardening above carries over to the companion app.

--- a/docs.json
+++ b/docs.json
@@ -179,6 +179,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.8",
               "changelog/v1.2.7",
               "changelog/v1.2.6",
               "changelog/v1.2.5",


### PR DESCRIPTION
Changelog + docs for v1.2.8. Tag is cut right after this lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds changelog and docs for v1.2.8, a stability and hardening release. All four files are updated consistently: `CHANGELOG.md` and the new `changelog/v1.2.8.mdx` document the same set of changes, `changelog/index.mdx` points the "Latest release" card at v1.2.8, and `docs.json` inserts the new page in the correct newest-first sidebar position.

- `CHANGELOG.md` gains a properly structured Added/Changed/Fixed entry for v1.2.8 dated 2026-06-19, and the `[Unreleased]` comparison link is bumped from `v1.2.7...HEAD` to `v1.2.8...HEAD` with a new `[1.2.8]` comparison link added.
- `changelog/v1.2.8.mdx` (new file) covers the Desktop and iOS changes in detail, consistent in structure and content with earlier release pages.
- `docs.json` places `changelog/v1.2.8` immediately before `changelog/v1.2.7`, preserving the newest-first ordering.

<h3>Confidence Score: 5/5</h3>

Pure documentation update with no code changes; all four files are internally consistent and correctly ordered.

Every changed file is documentation or configuration only. The version strings, comparison links, sidebar ordering, and cross-file content all agree with each other and with the stated release date.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds v1.2.8 entry with Added/Changed/Fixed sections, and updates the [Unreleased] comparison link from v1.2.7 to v1.2.8 with a new v1.2.8 comparison link added. |
| changelog/v1.2.8.mdx | New MDX file containing full v1.2.8 release notes split into Desktop and iOS sections, consistent with the existing changelog entry format. |
| changelog/index.mdx | Updates the "Latest release" card link and description from v1.2.7 to v1.2.8. |
| docs.json | Inserts `changelog/v1.2.8` into the sidebar pages array in the correct newest-first position before `changelog/v1.2.7`. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([PR lands on main]) --> B[Tag v1.2.8 is cut]
    B --> C{Docs site rebuild}
    C --> D[CHANGELOG.md\nv1.2.8 entry added\nUnreleased link bumped]
    C --> E[changelog/v1.2.8.mdx\nNew release notes page]
    C --> F[changelog/index.mdx\nLatest release card → v1.2.8]
    C --> G[docs.json\nv1.2.8 inserted newest-first\nin sidebar pages array]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([PR lands on main]) --> B[Tag v1.2.8 is cut]
    B --> C{Docs site rebuild}
    C --> D[CHANGELOG.md\nv1.2.8 entry added\nUnreleased link bumped]
    C --> E[changelog/v1.2.8.mdx\nNew release notes page]
    C --> F[changelog/index.mdx\nLatest release card → v1.2.8]
    C --> G[docs.json\nv1.2.8 inserted newest-first\nin sidebar pages array]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["release: changelog for v1.2.8"](https://github.com/arul28/ade/commit/a18e527141dacfe48bc313e34d2b55f368fd54a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38669399)</sub>

<!-- /greptile_comment -->