### PR TITLE
Remote Cli Clipboard Fix

### DIFF
--- a/apps/desktop/src/renderer/browserMock.ts
+++ b/apps/desktop/src/renderer/browserMock.ts
@@ -3173,7 +3173,11 @@ if (typeof window !== "undefined" && shouldInstallBrowserMock(window)) {
       onNavigate: () => () => {},
       openExternal: resolvedArg(undefined),
       revealPath: resolvedArg(undefined),
-      writeClipboardText: resolvedArg(undefined),
+      writeClipboardText: async (text: string): Promise<void> => {
+        const writeText = window.navigator.clipboard?.writeText;
+        if (typeof writeText !== "function") return;
+        await writeText.call(window.navigator.clipboard, text);
+      },
       hasClipboardImage: resolved(false),
       readClipboardImage: resolved(null),
       saveClipboardImageAttachment: resolved(null),

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -1150,6 +1150,134 @@ describe("TerminalView", () => {
     }
   });
 
+  it("falls back to browser clipboard when the local clipboard bridge rejects", async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "platform");
+    const clipboardDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "clipboard");
+    const originalPlatform = window.navigator.platform;
+    try {
+      Object.defineProperty(window.navigator, "platform", {
+        configurable: true,
+        value: "MacIntel",
+      });
+      Object.defineProperty(window.navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: vi.fn().mockResolvedValue(undefined),
+        },
+      });
+      (window.ade.app.writeClipboardText as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("bridge unavailable"));
+
+      render(<TerminalView ptyId="pty-copy-fallback" sessionId="session-copy-fallback" isActive />);
+      await flushAllTimers();
+
+      const terminal = mockState.terminalInstances.at(-1) as {
+        attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
+        getSelection: ReturnType<typeof vi.fn>;
+      } | undefined;
+      const keyHandler = terminal?.attachCustomKeyEventHandler.mock.calls.at(-1)?.[0] as ((ev: KeyboardEvent) => boolean) | undefined;
+      expect(keyHandler).toBeTruthy();
+      terminal!.getSelection.mockReturnValue("fallback terminal text");
+
+      const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
+      ptyWrite.mockClear();
+
+      const handled = keyHandler!({
+        type: "keydown",
+        key: "c",
+        metaKey: true,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+        preventDefault: vi.fn(),
+      } as unknown as KeyboardEvent);
+
+      await flushPromises();
+
+      expect(handled).toBe(false);
+      expect(window.ade.app.writeClipboardText).toHaveBeenCalledWith("fallback terminal text");
+      expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith("fallback terminal text");
+      expect(ptyWrite).not.toHaveBeenCalled();
+    } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(window.navigator, "platform", platformDescriptor);
+      } else {
+        Object.defineProperty(window.navigator, "platform", {
+          configurable: true,
+          value: originalPlatform,
+        });
+      }
+      if (clipboardDescriptor) {
+        Object.defineProperty(window.navigator, "clipboard", clipboardDescriptor);
+      } else {
+        Reflect.deleteProperty(window.navigator, "clipboard");
+      }
+    }
+  });
+
+  it("falls back to browser clipboard when the local clipboard bridge returns false", async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "platform");
+    const clipboardDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "clipboard");
+    const originalPlatform = window.navigator.platform;
+    try {
+      Object.defineProperty(window.navigator, "platform", {
+        configurable: true,
+        value: "MacIntel",
+      });
+      Object.defineProperty(window.navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: vi.fn().mockResolvedValue(undefined),
+        },
+      });
+      (window.ade.app.writeClipboardText as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+
+      render(<TerminalView ptyId="pty-copy-false-fallback" sessionId="session-copy-false-fallback" isActive />);
+      await flushAllTimers();
+
+      const terminal = mockState.terminalInstances.at(-1) as {
+        attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
+        getSelection: ReturnType<typeof vi.fn>;
+      } | undefined;
+      const keyHandler = terminal?.attachCustomKeyEventHandler.mock.calls.at(-1)?.[0] as ((ev: KeyboardEvent) => boolean) | undefined;
+      expect(keyHandler).toBeTruthy();
+      terminal!.getSelection.mockReturnValue("false fallback text");
+
+      const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
+      ptyWrite.mockClear();
+
+      const handled = keyHandler!({
+        type: "keydown",
+        key: "c",
+        metaKey: true,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+        preventDefault: vi.fn(),
+      } as unknown as KeyboardEvent);
+
+      await flushPromises();
+
+      expect(handled).toBe(false);
+      expect(window.ade.app.writeClipboardText).toHaveBeenCalledWith("false fallback text");
+      expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith("false fallback text");
+      expect(ptyWrite).not.toHaveBeenCalled();
+    } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(window.navigator, "platform", platformDescriptor);
+      } else {
+        Object.defineProperty(window.navigator, "platform", {
+          configurable: true,
+          value: originalPlatform,
+        });
+      }
+      if (clipboardDescriptor) {
+        Object.defineProperty(window.navigator, "clipboard", clipboardDescriptor);
+      } else {
+        Reflect.deleteProperty(window.navigator, "clipboard");
+      }
+    }
+  });
+
   it("uploads image-only paste to runtime attachments for tracked agent CLI terminals", async () => {
     (window.ade.app.readClipboardImage as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       data: "abc123",

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -169,6 +169,7 @@ function installWindowAde() {
     app: {
       hasClipboardImage: vi.fn().mockResolvedValue(false),
       readClipboardImage: vi.fn().mockResolvedValue(null),
+      writeClipboardText: vi.fn().mockResolvedValue(undefined),
     },
     agentChat: {
       saveTempAttachment: vi.fn().mockResolvedValue({ path: "/project/a/.ade/attachments/clipboard.png" }),
@@ -1095,6 +1096,60 @@ describe("TerminalView", () => {
     }
   });
 
+  it("copies selected terminal text through the local clipboard bridge", async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "platform");
+    const originalPlatform = window.navigator.platform;
+    try {
+      Object.defineProperty(window.navigator, "platform", {
+        configurable: true,
+        value: "MacIntel",
+      });
+
+      render(<TerminalView ptyId="pty-copy-selection" sessionId="session-copy-selection" isActive />);
+      await flushAllTimers();
+
+      const terminal = mockState.terminalInstances.at(-1) as {
+        attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
+        getSelection: ReturnType<typeof vi.fn>;
+      } | undefined;
+      const keyHandler = terminal?.attachCustomKeyEventHandler.mock.calls.at(-1)?.[0] as ((ev: KeyboardEvent) => boolean) | undefined;
+      expect(keyHandler).toBeTruthy();
+      terminal!.getSelection.mockReturnValue("selected terminal text");
+
+      const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
+      const writeClipboardText = window.ade.app.writeClipboardText as unknown as ReturnType<typeof vi.fn>;
+      ptyWrite.mockClear();
+      writeClipboardText.mockClear();
+      const preventDefault = vi.fn();
+
+      const handled = keyHandler!({
+        type: "keydown",
+        key: "c",
+        metaKey: true,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+        preventDefault,
+      } as unknown as KeyboardEvent);
+
+      await flushPromises();
+
+      expect(handled).toBe(false);
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+      expect(writeClipboardText).toHaveBeenCalledWith("selected terminal text");
+      expect(ptyWrite).not.toHaveBeenCalled();
+    } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(window.navigator, "platform", platformDescriptor);
+      } else {
+        Object.defineProperty(window.navigator, "platform", {
+          configurable: true,
+          value: originalPlatform,
+        });
+      }
+    }
+  });
+
   it("uploads image-only paste to runtime attachments for tracked agent CLI terminals", async () => {
     (window.ade.app.readClipboardImage as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
       data: "abc123",
@@ -1247,7 +1302,7 @@ describe("TerminalView", () => {
     });
   });
 
-  it("forwards Shift+mouse selection gestures while terminal mouse tracking is active", async () => {
+  it("leaves Shift+mouse gestures available for local selection while terminal mouse tracking is active", async () => {
     render(<TerminalView ptyId="pty-shift-mouse" sessionId="session-shift-mouse" isActive />);
     await flushAllTimers();
 
@@ -1313,75 +1368,10 @@ describe("TerminalView", () => {
     });
     document.dispatchEvent(up);
 
-    expect(down.defaultPrevented).toBe(true);
-    expect(move.defaultPrevented).toBe(true);
-    expect(up.defaultPrevented).toBe(true);
-    expect(ptyWrite).toHaveBeenNthCalledWith(1, {
-      ptyId: "pty-shift-mouse",
-      data: "\x1b[<4;1;1M",
-    });
-    expect(ptyWrite).toHaveBeenNthCalledWith(2, {
-      ptyId: "pty-shift-mouse",
-      data: "\x1b[<36;13;9M",
-    });
-    expect(ptyWrite).toHaveBeenNthCalledWith(3, {
-      ptyId: "pty-shift-mouse",
-      data: "\x1b[<4;13;9m",
-    });
-  });
-
-  it("does not forward a Shift+mouse release after the runtime is disposed", async () => {
-    render(<TerminalView ptyId="pty-shift-disposed" sessionId="session-shift-disposed" isActive />);
-    await flushAllTimers();
-
-    const terminal = mockState.terminalInstances.at(-1) as {
-      element: HTMLElement | null;
-    } | undefined;
-    expect(terminal?.element).toBeTruthy();
-
-    for (const listener of mockState.ptyDataListeners) {
-      listener({
-        ptyId: "pty-shift-disposed",
-        sessionId: "session-shift-disposed",
-        projectRoot: "/project/a",
-        data: "\x1b[?1000h\x1b[?1002h\x1b[?1006h",
-      });
-    }
-
-    const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
-    ptyWrite.mockClear();
-    terminal!.element!.dispatchEvent(new MouseEvent("mousedown", {
-      bubbles: true,
-      cancelable: true,
-      shiftKey: true,
-      button: 0,
-      buttons: 1,
-      clientX: 0,
-      clientY: 0,
-    }));
-    expect(ptyWrite).toHaveBeenCalledTimes(1);
-
-    __resetTerminalRuntimesForTests();
-    terminal!.element!.dispatchEvent(new MouseEvent("mousedown", {
-      bubbles: true,
-      cancelable: true,
-      shiftKey: true,
-      button: 0,
-      buttons: 1,
-      clientX: 0,
-      clientY: 0,
-    }));
-    document.dispatchEvent(new MouseEvent("mouseup", {
-      bubbles: true,
-      cancelable: true,
-      shiftKey: true,
-      button: 0,
-      buttons: 0,
-      clientX: 64,
-      clientY: 72,
-    }));
-
-    expect(ptyWrite).toHaveBeenCalledTimes(1);
+    expect(down.defaultPrevented).toBe(false);
+    expect(move.defaultPrevented).toBe(false);
+    expect(up.defaultPrevented).toBe(false);
+    expect(ptyWrite).not.toHaveBeenCalled();
   });
 
   it("falls back to native image paste when macOS Cmd+V does not fire a paste event", async () => {

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -893,28 +893,23 @@ function pasteClipboardImageShortcut(runtime: CachedRuntime, mode: TerminalImage
 }
 
 async function writeTerminalSelectionToClipboard(text: string): Promise<void> {
-  const attempts: Promise<void>[] = [];
   try {
-    attempts.push(window.ade.app.writeClipboardText(text));
+    const appBridge = window.ade?.app;
+    const writeClipboardText = appBridge?.writeClipboardText;
+    if (typeof writeClipboardText === "function") {
+      const result: unknown = await writeClipboardText.call(appBridge, text);
+      if (result !== false) return;
+    }
   } catch {
     // Browser-preview/test fallback below covers missing or partial bridges.
   }
   const writeText = navigator.clipboard?.writeText;
-  if (typeof writeText === "function") {
-    try {
-      attempts.push(writeText.call(navigator.clipboard, text));
-    } catch {
-      // Ignore synchronous browser clipboard failures; async failures are
-      // handled with the rest of the attempts below.
-    }
-  }
-  for (const attempt of attempts) {
-    try {
-      await attempt;
-      return;
-    } catch {
-      // Try the next clipboard path.
-    }
+  if (typeof writeText !== "function") return;
+  try {
+    await writeText.call(navigator.clipboard, text);
+  } catch {
+    // Ignore clipboard permission failures; there is no useful terminal-side
+    // recovery once the copy key has been handled.
   }
 }
 

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -103,8 +103,6 @@ type CachedRuntime = {
   imagePasteMode: TerminalImagePasteMode;
   bracketedPasteMode: boolean;
   mouseTrackingModes: Set<number>;
-  shiftMouseBridgeCleanup: (() => void) | null;
-  shiftMouseCleanup: (() => void) | null;
   // Set when a webgl→dom fallback is in flight and the runtime turned
   // invisible before the webgl restore could run. Persists across renderer
   // changes so the restore can be retried on the next visibility-true.
@@ -841,86 +839,9 @@ function updateTerminalInputModes(runtime: CachedRuntime, data: string): void {
   }
 }
 
-function clampTerminalMouseCoordinate(value: number, max: number): number {
-  if (!Number.isFinite(value)) return 1;
-  return Math.max(1, Math.min(max, Math.floor(value)));
-}
-
-function terminalMousePoint(runtime: CachedRuntime, ev: MouseEvent): { col: number; row: number } | null {
-  const screen = runtime.term.element?.querySelector<HTMLElement>(".xterm-screen")
-    ?? runtime.host.querySelector<HTMLElement>(".xterm-screen")
-    ?? runtime.term.element
-    ?? runtime.host;
-  const rect = screen.getBoundingClientRect();
-  if (rect.width <= 0 || rect.height <= 0) return null;
-  const cols = Math.max(1, runtime.term.cols || 1);
-  const rows = Math.max(1, runtime.term.rows || 1);
-  const col = clampTerminalMouseCoordinate(((ev.clientX - rect.left) / rect.width) * cols + 1, cols);
-  const row = clampTerminalMouseCoordinate(((ev.clientY - rect.top) / rect.height) * rows + 1, rows);
-  return { col, row };
-}
-
-function writeSgrMouse(runtime: CachedRuntime, code: number, point: { col: number; row: number }, final: "M" | "m"): void {
-  writePtyInput(runtime, `\x1b[<${code};${point.col};${point.row}${final}`);
-}
-
 function isTerminalMouseTrackingActive(runtime: CachedRuntime): boolean {
   const xtermMode = runtime.term.modes?.mouseTrackingMode;
   return runtime.mouseTrackingModes.size > 0 || (xtermMode != null && xtermMode !== "none");
-}
-
-function consumeMouseEvent(ev: MouseEvent): void {
-  ev.preventDefault();
-  ev.stopPropagation();
-  ev.stopImmediatePropagation();
-}
-
-function installShiftMouseBridge(runtime: CachedRuntime): void {
-  const onMouseDown = (ev: MouseEvent) => {
-    if (runtime.disposed || !isTerminalMouseTrackingActive(runtime)) return;
-    if (!ev.shiftKey || ev.button !== 0) return;
-    const point = terminalMousePoint(runtime, ev);
-    if (!point) return;
-
-    consumeMouseEvent(ev);
-    writeSgrMouse(runtime, 4, point, "M");
-
-    let cleanup = () => {};
-    const onMouseMove = (moveEv: MouseEvent) => {
-      if (runtime.disposed) {
-        cleanup();
-        return;
-      }
-      if ((moveEv.buttons & 1) === 0) return;
-      const nextPoint = terminalMousePoint(runtime, moveEv);
-      if (!nextPoint) return;
-      consumeMouseEvent(moveEv);
-      writeSgrMouse(runtime, 36, nextPoint, "M");
-    };
-    const onMouseUp = (upEv: MouseEvent) => {
-      cleanup();
-      if (runtime.disposed) return;
-      const releasePoint = terminalMousePoint(runtime, upEv) ?? point;
-      consumeMouseEvent(upEv);
-      writeSgrMouse(runtime, 4, releasePoint, "m");
-    };
-
-    cleanup = () => {
-      document.removeEventListener("mousemove", onMouseMove, true);
-      document.removeEventListener("mouseup", onMouseUp, true);
-      if (runtime.shiftMouseCleanup === cleanup) runtime.shiftMouseCleanup = null;
-    };
-    runtime.shiftMouseCleanup?.();
-    runtime.shiftMouseCleanup = cleanup;
-    document.addEventListener("mousemove", onMouseMove, true);
-    document.addEventListener("mouseup", onMouseUp, true);
-  };
-  runtime.host.addEventListener("mousedown", onMouseDown, true);
-  const cleanupBridge = () => {
-    runtime.host.removeEventListener("mousedown", onMouseDown, true);
-    if (runtime.shiftMouseBridgeCleanup === cleanupBridge) runtime.shiftMouseBridgeCleanup = null;
-  };
-  runtime.shiftMouseBridgeCleanup = cleanupBridge;
 }
 
 async function pasteNativeClipboardImageShortcut(runtime: CachedRuntime): Promise<boolean> {
@@ -971,6 +892,32 @@ function pasteClipboardImageShortcut(runtime: CachedRuntime, mode: TerminalImage
     : pasteNativeClipboardImageShortcut(runtime);
 }
 
+async function writeTerminalSelectionToClipboard(text: string): Promise<void> {
+  const attempts: Promise<void>[] = [];
+  try {
+    attempts.push(window.ade.app.writeClipboardText(text));
+  } catch {
+    // Browser-preview/test fallback below covers missing or partial bridges.
+  }
+  const writeText = navigator.clipboard?.writeText;
+  if (typeof writeText === "function") {
+    try {
+      attempts.push(writeText.call(navigator.clipboard, text));
+    } catch {
+      // Ignore synchronous browser clipboard failures; async failures are
+      // handled with the rest of the attempts below.
+    }
+  }
+  for (const attempt of attempts) {
+    try {
+      await attempt;
+      return;
+    } catch {
+      // Try the next clipboard path.
+    }
+  }
+}
+
 function teardownRuntime(runtime: CachedRuntime) {
   flushPendingPtyInput(runtime);
   runtime.disposed = true;
@@ -985,16 +932,6 @@ function teardownRuntime(runtime: CachedRuntime) {
   if (runtime.hydrateRetryTimer) clearTimeout(runtime.hydrateRetryTimer);
   if (runtime.hydrationBackfillTimer) clearTimeout(runtime.hydrationBackfillTimer);
   if (runtime.invalidFitRetryTimer) clearTimeout(runtime.invalidFitRetryTimer);
-  try {
-    runtime.shiftMouseCleanup?.();
-  } catch {
-    // ignore
-  }
-  try {
-    runtime.shiftMouseBridgeCleanup?.();
-  } catch {
-    // ignore
-  }
 
   try {
     runtime.ptyDataUnsub?.();
@@ -1854,8 +1791,6 @@ function createRuntime(args: {
     imagePasteMode: args.imagePasteMode,
     bracketedPasteMode: false,
     mouseTrackingModes: new Set(),
-    shiftMouseBridgeCleanup: null,
-    shiftMouseCleanup: null,
     pendingWebGLRestore: false,
     invalidFitRetryTimer: null,
     fitWarningLogged: false,
@@ -1877,7 +1812,6 @@ function createRuntime(args: {
     }
     void pasteClipboardImageShortcut(runtime, runtime.imagePasteMode);
   }, true);
-  installShiftMouseBridge(runtime);
 
   term.attachCustomKeyEventHandler((ev) => {
     if (!runtime.inputEnabled) return false;
@@ -1917,7 +1851,8 @@ function createRuntime(args: {
     if (mod && key === "c") {
       const selection = term.getSelection();
       if (selection) {
-        navigator.clipboard.writeText(selection).catch(() => {});
+        ev.preventDefault();
+        void writeTerminalSelectionToClipboard(selection);
         return false;
       }
       if (isMac && ev.metaKey) {

--- a/docs/features/terminals-and-sessions/README.md
+++ b/docs/features/terminals-and-sessions/README.md
@@ -307,7 +307,10 @@ Renderer surfaces:
   back to `terminal.preview`. Work-tracked agent CLI terminals paste clipboard
   images by saving the bytes as chat temp attachments through the active runtime
   and bracketed-pasting a short path/type stub into the PTY, while standalone
-  terminals keep the native clipboard-image shortcut behavior.
+  terminals keep the native clipboard-image shortcut behavior. Selected terminal
+  text copies through the local desktop clipboard bridge (with browser clipboard
+  fallback for previews), and Shift+drag remains available for local text
+  selection when a full-screen CLI enables terminal mouse tracking.
 - `apps/desktop/src/renderer/components/terminals/workSessionTiling.ts` —
   pure helper that produces the seed `PaneSplit` for the Work grid from
   an ordered list of session IDs. Accepts a `TilingPreset` of


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fremote-cli-clipboard-fix-6d76cf48 num=625 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fremote-cli-clipboard-fix-6d76cf48&amp;pr=625">ade/remote-cli-clipboard-fix-6d76cf48 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=625">PR #625</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved terminal text selection clipboard handling with enhanced fallback support for better cross-platform compatibility.
  * Modified Shift+mouse event behavior in terminals with active mouse tracking to prevent unintended gesture interference.

* **Tests**
  * Added test coverage for terminal clipboard operations and mouse tracking interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces direct `navigator.clipboard.writeText` calls in the terminal copy handler with a new `writeTerminalSelectionToClipboard` helper that first tries the desktop IPC bridge (`window.ade.app.writeClipboardText`), then falls back to the browser Clipboard API. It also removes the `shiftMouseBridge` that previously forwarded Shift+mouse events as SGR sequences to PTY-tracked terminals, restoring standard terminal-emulator behaviour where Shift overrides mouse tracking for local text selection.

- **Clipboard write path**: The new sequential fallback (`bridge → browser clipboard`) addresses a prior race between two concurrent clipboard promises. The `result !== false` sentinel lets the bridge signal an explicit soft-failure without throwing.
- **Shift+mouse removal**: `installShiftMouseBridge` and its two cleanup fields are fully deleted; tests are updated to assert that Shift+mouse events are no longer consumed or forwarded to the PTY.
- **Browser mock & tests**: `browserMock.ts` now delegates to `navigator.clipboard.writeText` (instead of a no-op resolved value), and three new test cases cover the primary bridge path, rejection fallback, and `false`-return fallback.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge; the clipboard fallback is sequential and all error paths are caught.

All clipboard writes are now sequential and wrapped in their own try-catch blocks, so there is no unhandled-rejection risk. The shiftMouseBridge removal aligns the terminal with standard emulator conventions and is backed by updated tests.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/terminals/TerminalView.tsx | Core logic change: new writeTerminalSelectionToClipboard helper (sequential bridge to browser fallback), ev.preventDefault() added to copy path, and the entire shiftMouseBridge subsystem removed. Logic is correct and the previous concurrent-promise hazard is resolved. |
| apps/desktop/src/renderer/browserMock.ts | writeClipboardText mock now delegates to navigator.clipboard.writeText with correct this-binding; consistent with how TerminalView.tsx calls the real bridge. |
| apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx | Three new tests cover the primary bridge path, rejection fallback, and false-return fallback. The shift+mouse test is updated to reflect the new no-forward behaviour. Cleanup via Object.defineProperty restore in finally blocks is thorough. |
| docs/features/terminals-and-sessions/README.md | Documentation updated to describe the new clipboard bridge and Shift+drag local-selection behaviour; accurate and consistent with code changes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ship: iteration 1 — address clipboard re..."](https://github.com/arul28/ade/commit/4dfa5f26f8e376f1cea9d8172ddb8e4ef6fc6972) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38934743)</sub>

<!-- /greptile_comment -->