### PR TITLE
Refresh Files tree on external directory changes

### DIFF
--- a/apps/desktop/src/renderer/components/files/treeHelpers.test.ts
+++ b/apps/desktop/src/renderer/components/files/treeHelpers.test.ts
@@ -4,6 +4,7 @@ import {
   isUnavailableGitDecorationsError,
   loadedDirectoryChildrenCount,
   parentPathForFileChange,
+  replaceTreeNodeChildren,
 } from "./treeHelpers";
 
 describe("isUnavailableGitDecorationsError", () => {
@@ -65,5 +66,55 @@ describe("file tree change refresh helpers", () => {
     expect(loadedDirectoryChildrenCount(tree, "marketing")).toBe(1);
     expect(loadedDirectoryChildrenCount(tree, "src")).toBe(0);
     expect(loadedDirectoryChildrenCount(tree, "missing")).toBe(0);
+  });
+
+  it("preserves loaded descendant folders during a scoped directory refresh", () => {
+    const tree = [
+      {
+        name: "marketing",
+        path: "marketing",
+        type: "directory" as const,
+        children: [
+          {
+            name: "assets",
+            path: "marketing/assets",
+            type: "directory" as const,
+            children: [
+              {
+                name: "logo.png",
+                path: "marketing/assets/logo.png",
+                type: "file" as const,
+              },
+            ],
+            childrenTruncated: true,
+            loadMoreOffset: 2000,
+          },
+          {
+            name: "old.md",
+            path: "marketing/old.md",
+            type: "file" as const,
+          },
+        ],
+      },
+    ];
+
+    const refreshed = replaceTreeNodeChildren(tree, "marketing", [
+      {
+        name: "assets",
+        path: "marketing/assets",
+        type: "directory" as const,
+      },
+      {
+        name: "new.md",
+        path: "marketing/new.md",
+        type: "file" as const,
+      },
+    ]);
+
+    expect(refreshed[0].children?.map((node) => node.path)).toEqual(["marketing/assets", "marketing/new.md"]);
+    const assets = refreshed[0].children?.find((node) => node.path === "marketing/assets");
+    expect(assets?.children?.map((node) => node.path)).toEqual(["marketing/assets/logo.png"]);
+    expect(assets?.childrenTruncated).toBe(true);
+    expect(assets?.loadMoreOffset).toBe(2000);
   });
 });

--- a/apps/desktop/src/renderer/components/files/treeHelpers.test.ts
+++ b/apps/desktop/src/renderer/components/files/treeHelpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isUnavailableGitDecorationsError } from "./treeHelpers";
+import {
+  hasLoadedDirectoryChildren,
+  isUnavailableGitDecorationsError,
+  parentPathForFileChange,
+} from "./treeHelpers";
 
 describe("isUnavailableGitDecorationsError", () => {
   it("matches optional remote git decoration action availability failures", () => {
@@ -20,5 +24,41 @@ describe("isUnavailableGitDecorationsError", () => {
   it("does not hide unrelated Files errors", () => {
     expect(isUnavailableGitDecorationsError(new Error("ENOENT: no such file or directory"))).toBe(false);
     expect(isUnavailableGitDecorationsError(new Error("Action 'file.readFile' is not callable."))).toBe(false);
+  });
+});
+
+describe("file tree change refresh helpers", () => {
+  it("resolves changed paths to the directory that needs a scoped reload", () => {
+    expect(parentPathForFileChange("README.md")).toBe("");
+    expect(parentPathForFileChange("marketing/fastlane-brand-profile.md")).toBe("marketing");
+    expect(parentPathForFileChange("src/routes/app/page.tsx")).toBe("src/routes/app");
+    expect(parentPathForFileChange("src\\routes\\app\\page.tsx")).toBe("src/routes/app");
+  });
+
+  it("only treats directories with loaded children as refreshable", () => {
+    const tree = [
+      {
+        name: "marketing",
+        path: "marketing",
+        type: "directory" as const,
+        children: [
+          {
+            name: "existing.md",
+            path: "marketing/existing.md",
+            type: "file" as const,
+          },
+        ],
+      },
+      {
+        name: "src",
+        path: "src",
+        type: "directory" as const,
+      },
+    ];
+
+    expect(hasLoadedDirectoryChildren(tree, "")).toBe(true);
+    expect(hasLoadedDirectoryChildren(tree, "marketing")).toBe(true);
+    expect(hasLoadedDirectoryChildren(tree, "src")).toBe(false);
+    expect(hasLoadedDirectoryChildren(tree, "missing")).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/components/files/treeHelpers.test.ts
+++ b/apps/desktop/src/renderer/components/files/treeHelpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  compactDirectoryRefreshPaths,
+  hasAncestorDirectoryPath,
   hasLoadedDirectoryChildren,
   isUnavailableGitDecorationsError,
   loadedDirectoryChildrenCount,
@@ -38,14 +38,11 @@ describe("file tree change refresh helpers", () => {
     expect(parentPathForFileChange("src\\routes\\app\\page.tsx")).toBe("src/routes/app");
   });
 
-  it("drops descendant directory refreshes when an ancestor is already queued", () => {
-    expect(compactDirectoryRefreshPaths(["src/foo", "marketing/assets", "src", "marketing"])).toEqual([
-      "src",
-      "marketing",
-    ]);
-    expect(compactDirectoryRefreshPaths(["marketing", "marketing/assets", "marketing/assets/icons"])).toEqual([
-      "marketing",
-    ]);
+  it("detects descendant directory refreshes when an ancestor is already queued", () => {
+    expect(hasAncestorDirectoryPath("marketing/assets", ["src", "marketing"])).toBe(true);
+    expect(hasAncestorDirectoryPath("marketing/assets/icons", ["marketing/assets"])).toBe(true);
+    expect(hasAncestorDirectoryPath("marketing", ["marketing/assets"])).toBe(false);
+    expect(hasAncestorDirectoryPath("marketing", ["marketing"])).toBe(false);
   });
 
   it("only treats directories with loaded children as refreshable", () => {

--- a/apps/desktop/src/renderer/components/files/treeHelpers.test.ts
+++ b/apps/desktop/src/renderer/components/files/treeHelpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   hasLoadedDirectoryChildren,
   isUnavailableGitDecorationsError,
+  loadedDirectoryChildrenCount,
   parentPathForFileChange,
 } from "./treeHelpers";
 
@@ -60,5 +61,9 @@ describe("file tree change refresh helpers", () => {
     expect(hasLoadedDirectoryChildren(tree, "marketing")).toBe(true);
     expect(hasLoadedDirectoryChildren(tree, "src")).toBe(false);
     expect(hasLoadedDirectoryChildren(tree, "missing")).toBe(false);
+    expect(loadedDirectoryChildrenCount(tree, "")).toBe(2);
+    expect(loadedDirectoryChildrenCount(tree, "marketing")).toBe(1);
+    expect(loadedDirectoryChildrenCount(tree, "src")).toBe(0);
+    expect(loadedDirectoryChildrenCount(tree, "missing")).toBe(0);
   });
 });

--- a/apps/desktop/src/renderer/components/files/treeHelpers.test.ts
+++ b/apps/desktop/src/renderer/components/files/treeHelpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  compactDirectoryRefreshPaths,
   hasLoadedDirectoryChildren,
   isUnavailableGitDecorationsError,
   loadedDirectoryChildrenCount,
@@ -35,6 +36,16 @@ describe("file tree change refresh helpers", () => {
     expect(parentPathForFileChange("marketing/fastlane-brand-profile.md")).toBe("marketing");
     expect(parentPathForFileChange("src/routes/app/page.tsx")).toBe("src/routes/app");
     expect(parentPathForFileChange("src\\routes\\app\\page.tsx")).toBe("src/routes/app");
+  });
+
+  it("drops descendant directory refreshes when an ancestor is already queued", () => {
+    expect(compactDirectoryRefreshPaths(["src/foo", "marketing/assets", "src", "marketing"])).toEqual([
+      "src",
+      "marketing",
+    ]);
+    expect(compactDirectoryRefreshPaths(["marketing", "marketing/assets", "marketing/assets/icons"])).toEqual([
+      "marketing",
+    ]);
   });
 
   it("only treats directories with loaded children as refreshable", () => {

--- a/apps/desktop/src/renderer/components/files/treeHelpers.ts
+++ b/apps/desktop/src/renderer/components/files/treeHelpers.ts
@@ -79,6 +79,17 @@ export function parentPathForFileChange(filePath: string): string {
   return index > 0 ? normalized.slice(0, index) : "";
 }
 
+function isAncestorDirectoryPath(ancestorPath: string, childPath: string): boolean {
+  if (ancestorPath === childPath) return false;
+  if (!ancestorPath) return Boolean(childPath);
+  return childPath.startsWith(`${ancestorPath}/`);
+}
+
+export function compactDirectoryRefreshPaths(paths: string[]): string[] {
+  const uniquePaths = [...new Set(paths.filter(Boolean))];
+  return uniquePaths.filter((path) => !uniquePaths.some((otherPath) => isAncestorDirectoryPath(otherPath, path)));
+}
+
 export function hasLoadedDirectoryChildren(nodes: FileTreeNode[], directoryPath: string): boolean {
   if (!directoryPath) return true;
   const node = findFileTreeNodeByPath(nodes, directoryPath);

--- a/apps/desktop/src/renderer/components/files/treeHelpers.ts
+++ b/apps/desktop/src/renderer/components/files/treeHelpers.ts
@@ -85,9 +85,8 @@ function isAncestorDirectoryPath(ancestorPath: string, childPath: string): boole
   return childPath.startsWith(`${ancestorPath}/`);
 }
 
-export function compactDirectoryRefreshPaths(paths: string[]): string[] {
-  const uniquePaths = [...new Set(paths.filter(Boolean))];
-  return uniquePaths.filter((path) => !uniquePaths.some((otherPath) => isAncestorDirectoryPath(otherPath, path)));
+export function hasAncestorDirectoryPath(directoryPath: string, paths: readonly string[]): boolean {
+  return paths.some((path) => isAncestorDirectoryPath(path, directoryPath));
 }
 
 export function hasLoadedDirectoryChildren(nodes: FileTreeNode[], directoryPath: string): boolean {

--- a/apps/desktop/src/renderer/components/files/treeHelpers.ts
+++ b/apps/desktop/src/renderer/components/files/treeHelpers.ts
@@ -61,6 +61,19 @@ export function fileTreeNodeByPath(nodes: FileTreeNode[]): Map<string, FileTreeN
   return out;
 }
 
+export function parentPathForFileChange(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, "/").split("/").filter(Boolean).join("/");
+  if (!normalized) return "";
+  const index = normalized.lastIndexOf("/");
+  return index > 0 ? normalized.slice(0, index) : "";
+}
+
+export function hasLoadedDirectoryChildren(nodes: FileTreeNode[], directoryPath: string): boolean {
+  if (!directoryPath) return true;
+  const node = fileTreeNodeByPath(nodes).get(directoryPath);
+  return node?.type === "directory" && Array.isArray(node.children);
+}
+
 /** Merge a freshly-fetched root listing while keeping already-loaded subtrees. */
 export function mergeTreePreservingLoadedChildren(
   nextNodes: FileTreeNode[],

--- a/apps/desktop/src/renderer/components/files/treeHelpers.ts
+++ b/apps/desktop/src/renderer/components/files/treeHelpers.ts
@@ -61,6 +61,17 @@ export function fileTreeNodeByPath(nodes: FileTreeNode[]): Map<string, FileTreeN
   return out;
 }
 
+function findFileTreeNodeByPath(nodes: FileTreeNode[], nodePath: string): FileTreeNode | undefined {
+  for (const node of nodes) {
+    if (node.path === nodePath) return node;
+    if (node.children?.length) {
+      const child = findFileTreeNodeByPath(node.children, nodePath);
+      if (child) return child;
+    }
+  }
+  return undefined;
+}
+
 export function parentPathForFileChange(filePath: string): string {
   const normalized = filePath.replace(/\\/g, "/").split("/").filter(Boolean).join("/");
   if (!normalized) return "";
@@ -70,13 +81,13 @@ export function parentPathForFileChange(filePath: string): string {
 
 export function hasLoadedDirectoryChildren(nodes: FileTreeNode[], directoryPath: string): boolean {
   if (!directoryPath) return true;
-  const node = fileTreeNodeByPath(nodes).get(directoryPath);
+  const node = findFileTreeNodeByPath(nodes, directoryPath);
   return node?.type === "directory" && Array.isArray(node.children);
 }
 
 export function loadedDirectoryChildrenCount(nodes: FileTreeNode[], directoryPath: string): number {
   if (!directoryPath) return nodes.length;
-  const node = fileTreeNodeByPath(nodes).get(directoryPath);
+  const node = findFileTreeNodeByPath(nodes, directoryPath);
   return node?.type === "directory" && Array.isArray(node.children) ? node.children.length : 0;
 }
 
@@ -99,6 +110,24 @@ export function mergeTreePreservingLoadedChildren(
   });
 }
 
+function mergeChildrenPreservingLoadedDescendants(
+  nextChildren: FileTreeNode[],
+  previousChildren: FileTreeNode[] = [],
+): FileTreeNode[] {
+  const previousByPath = fileTreeNodeByPath(previousChildren);
+  return nextChildren.map((child) => {
+    if (child.type !== "directory" || child.children) return child;
+    const previous = previousByPath.get(child.path);
+    if (!previous?.children) return child;
+    return {
+      ...child,
+      children: previous.children,
+      childrenTruncated: previous.childrenTruncated,
+      loadMoreOffset: previous.loadMoreOffset,
+    };
+  });
+}
+
 /** Replace a directory node's children (used by paginated lazy expansion). */
 export function replaceTreeNodeChildren(
   nodes: FileTreeNode[],
@@ -108,7 +137,12 @@ export function replaceTreeNodeChildren(
 ): FileTreeNode[] {
   return nodes.map((node) => {
     if (node.path === parentPath) {
-      return { ...node, children, loadMoreOffset, childrenTruncated: loadMoreOffset != null };
+      return {
+        ...node,
+        children: mergeChildrenPreservingLoadedDescendants(children, node.children),
+        loadMoreOffset,
+        childrenTruncated: loadMoreOffset != null,
+      };
     }
     if (node.children?.length) {
       return { ...node, children: replaceTreeNodeChildren(node.children, parentPath, children, loadMoreOffset) };

--- a/apps/desktop/src/renderer/components/files/treeHelpers.ts
+++ b/apps/desktop/src/renderer/components/files/treeHelpers.ts
@@ -74,6 +74,12 @@ export function hasLoadedDirectoryChildren(nodes: FileTreeNode[], directoryPath:
   return node?.type === "directory" && Array.isArray(node.children);
 }
 
+export function loadedDirectoryChildrenCount(nodes: FileTreeNode[], directoryPath: string): number {
+  if (!directoryPath) return nodes.length;
+  const node = fileTreeNodeByPath(nodes).get(directoryPath);
+  return node?.type === "directory" && Array.isArray(node.children) ? node.children.length : 0;
+}
+
 /** Merge a freshly-fetched root listing while keeping already-loaded subtrees. */
 export function mergeTreePreservingLoadedChildren(
   nextNodes: FileTreeNode[],

--- a/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
@@ -193,19 +193,9 @@ export function FilesWorkbench({
   }, [workspaces, globalLaneId]);
 
   /* ---- Tree loading ---- */
-  const refreshRoot = useCallback(async (options: { preserveLoadedChildren?: boolean } = {}) => {
-    if (!workspaceId) return;
-    const reqId = workspaceId;
-    const preserveLoadedChildren = options.preserveLoadedChildren !== false;
-    try {
-      const nodes = await window.ade.files.listTree({ workspaceId: reqId, depth: 1, includeIgnored: true });
-      if (workspaceIdRef.current !== reqId) return;
-      setTree((prev) => {
-        const merged = preserveLoadedChildren ? mergeTreePreservingLoadedChildren(nodes, prev) : nodes;
-        rootTreeCacheByKey.set(rootTreeCacheKey(projectRootPath, reqId), merged);
-        return merged;
-      });
-      setError(null);
+  const refreshTreeGitDecorations = useCallback(
+    async (reqId = workspaceId) => {
+      if (!reqId) return;
       let decorations = null;
       try {
         decorations = await window.ade.files.refreshGitDecorations({ workspaceId: reqId, forceFresh: true });
@@ -219,10 +209,28 @@ export function FilesWorkbench({
         rootTreeCacheByKey.set(rootTreeCacheKey(projectRootPath, reqId), decorated);
         return decorated;
       });
+    },
+    [projectRootPath, workspaceId],
+  );
+
+  const refreshRoot = useCallback(async (options: { preserveLoadedChildren?: boolean } = {}) => {
+    if (!workspaceId) return;
+    const reqId = workspaceId;
+    const preserveLoadedChildren = options.preserveLoadedChildren !== false;
+    try {
+      const nodes = await window.ade.files.listTree({ workspaceId: reqId, depth: 1, includeIgnored: true });
+      if (workspaceIdRef.current !== reqId) return;
+      setTree((prev) => {
+        const merged = preserveLoadedChildren ? mergeTreePreservingLoadedChildren(nodes, prev) : nodes;
+        rootTreeCacheByKey.set(rootTreeCacheKey(projectRootPath, reqId), merged);
+        return merged;
+      });
+      setError(null);
+      await refreshTreeGitDecorations(reqId);
     } catch (err) {
       if (workspaceIdRef.current === reqId) setError(err instanceof Error ? err.message : String(err));
     }
-  }, [workspaceId, projectRootPath]);
+  }, [workspaceId, projectRootPath, refreshTreeGitDecorations]);
 
   // Reset + load when the workspace changes; dispose models from the old lane.
   useEffect(() => {
@@ -398,8 +406,13 @@ export function FilesWorkbench({
       if (shouldRefreshRoot) {
         void refreshRoot();
       }
-      for (const parentPath of parentPaths) {
-        void refreshLoadedDirectory(parentPath, reqId);
+      if (parentPaths.length > 0) {
+        const directoryRefreshes = parentPaths.map((parentPath) => refreshLoadedDirectory(parentPath, reqId));
+        void Promise.allSettled(directoryRefreshes)
+          .then(() => refreshTreeGitDecorations(reqId))
+          .catch((err) => {
+            if (workspaceIdRef.current === reqId) setError(formatFilesError(err));
+          });
       }
     };
 
@@ -421,7 +434,7 @@ export function FilesWorkbench({
       unsub();
       void window.ade.files.stopWatching({ workspaceId, includeIgnored: true }).catch(() => {});
     };
-  }, [active, workspaceId, refreshLoadedDirectory, refreshRoot]);
+  }, [active, workspaceId, refreshLoadedDirectory, refreshRoot, refreshTreeGitDecorations]);
 
   /* ---- Open file ---- */
   const openFile = useCallback(

--- a/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
@@ -9,11 +9,12 @@ import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import {
   applyGitStatusToTree,
   appendTreeNodeChildren,
-  compactDirectoryRefreshPaths,
   defaultFilesWorkspaceId,
   filesSessionKey,
   formatFilesError,
+  hasAncestorDirectoryPath,
   hasLoadedDirectoryChildren,
+  isMissingWorkspaceRootError,
   isUnavailableGitDecorationsError,
   loadedDirectoryChildrenCount,
   mergeTreePreservingLoadedChildren,
@@ -275,7 +276,7 @@ export function FilesWorkbench({
   }, []);
 
   const refreshLoadedDirectory = useCallback(
-    async (parentPath: string, reqId = workspaceId) => {
+    async (parentPath: string, reqId = workspaceId, options: { suppressMissingError?: boolean } = {}) => {
       if (!reqId) return;
       setLoadingDirs((prev) => new Set(prev).add(parentPath));
       try {
@@ -288,7 +289,9 @@ export function FilesWorkbench({
           return nextTree;
         });
       } catch (err) {
-        if (workspaceIdRef.current === reqId) setError(formatFilesError(err));
+        const message = formatFilesError(err);
+        if (options.suppressMissingError && isMissingWorkspaceRootError(message)) return;
+        if (workspaceIdRef.current === reqId) setError(message);
       } finally {
         setLoadingDirs((prev) => {
           const next = new Set(prev);
@@ -371,9 +374,11 @@ export function FilesWorkbench({
     const queuedParentPaths = new Set<string>();
     let rootRefreshQueued = false;
     let fullRootRefreshQueued = false;
+    let decorationsRefreshQueued = false;
 
     const enqueuePathRefresh = (path: string | undefined) => {
       if (!path) return;
+      decorationsRefreshQueued = true;
       if (fullRootRefreshQueued) return;
       const parentPath = parentPathForFileChange(path);
       if (!parentPath) {
@@ -391,12 +396,14 @@ export function FilesWorkbench({
 
     const flushQueuedRefreshes = () => {
       const reqId = workspaceIdRef.current;
-      const parentPaths = compactDirectoryRefreshPaths([...queuedParentPaths]);
+      const parentPaths = [...queuedParentPaths];
       queuedParentPaths.clear();
       const shouldRefreshRoot = rootRefreshQueued;
       const shouldRefreshFullRoot = fullRootRefreshQueued;
+      const shouldRefreshDecorations = decorationsRefreshQueued;
       rootRefreshQueued = false;
       fullRootRefreshQueued = false;
+      decorationsRefreshQueued = false;
 
       if (!reqId) return;
       if (shouldRefreshFullRoot) {
@@ -408,12 +415,20 @@ export function FilesWorkbench({
         void refreshRoot();
       }
       if (parentPaths.length > 0) {
-        const directoryRefreshes = parentPaths.map((parentPath) => refreshLoadedDirectory(parentPath, reqId));
+        const directoryRefreshes = parentPaths.map((parentPath) => (
+          refreshLoadedDirectory(parentPath, reqId, {
+            suppressMissingError: hasAncestorDirectoryPath(parentPath, parentPaths),
+          })
+        ));
         void Promise.allSettled(directoryRefreshes)
           .then(() => refreshTreeGitDecorations(reqId))
           .catch((err) => {
             if (workspaceIdRef.current === reqId) setError(formatFilesError(err));
           });
+      } else if (shouldRefreshDecorations && !shouldRefreshRoot) {
+        void refreshTreeGitDecorations(reqId).catch((err) => {
+          if (workspaceIdRef.current === reqId) setError(formatFilesError(err));
+        });
       }
     };
 

--- a/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
@@ -14,6 +14,7 @@ import {
   formatFilesError,
   hasLoadedDirectoryChildren,
   isUnavailableGitDecorationsError,
+  loadedDirectoryChildrenCount,
   mergeTreePreservingLoadedChildren,
   parentPathForFileChange,
   replaceTreeNodeChildren,
@@ -239,10 +240,11 @@ export function FilesWorkbench({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active, workspaceId, refreshRoot, projectRootPath]);
 
-  const fetchDirectoryChildren = useCallback(async (reqId: string, parentPath: string) => {
+  const fetchDirectoryChildren = useCallback(async (reqId: string, parentPath: string, minChildren = MAX_AUTO_LOADED_CHILDREN) => {
     const children: FileTreeNode[] = [];
     let offset = 0;
     let loadMoreOffset: number | null = null;
+    const targetChildren = Math.max(MAX_AUTO_LOADED_CHILDREN, minChildren);
     for (;;) {
       const page = await window.ade.files.listTreeChildren({
         workspaceId: reqId,
@@ -254,7 +256,7 @@ export function FilesWorkbench({
       if (workspaceIdRef.current !== reqId) return null;
       children.push(...page.children);
       if (page.nextOffset == null) break;
-      if (children.length >= MAX_AUTO_LOADED_CHILDREN) {
+      if (children.length >= targetChildren) {
         loadMoreOffset = page.nextOffset;
         break;
       }
@@ -268,7 +270,8 @@ export function FilesWorkbench({
       if (!reqId) return;
       setLoadingDirs((prev) => new Set(prev).add(parentPath));
       try {
-        const result = await fetchDirectoryChildren(reqId, parentPath);
+        const loadedCount = loadedDirectoryChildrenCount(treeRef.current, parentPath);
+        const result = await fetchDirectoryChildren(reqId, parentPath, loadedCount);
         if (!result || workspaceIdRef.current !== reqId) return;
         setTree((prev) => {
           const nextTree = replaceTreeNodeChildren(prev, parentPath, result.children, result.loadMoreOffset);
@@ -362,6 +365,7 @@ export function FilesWorkbench({
 
     const enqueuePathRefresh = (path: string | undefined) => {
       if (!path) return;
+      if (fullRootRefreshQueued) return;
       const parentPath = parentPathForFileChange(path);
       if (!parentPath) {
         rootRefreshQueued = true;
@@ -371,6 +375,7 @@ export function FilesWorkbench({
         queuedParentPaths.add(parentPath);
         if (queuedParentPaths.size > MAX_QUEUED_TREE_PARENT_REFRESHES) {
           fullRootRefreshQueued = true;
+          queuedParentPaths.clear();
         }
       }
     };

--- a/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
@@ -9,6 +9,7 @@ import { ContextMenu, type ContextMenuItem } from "./ContextMenu";
 import {
   applyGitStatusToTree,
   appendTreeNodeChildren,
+  compactDirectoryRefreshPaths,
   defaultFilesWorkspaceId,
   filesSessionKey,
   formatFilesError,
@@ -390,7 +391,7 @@ export function FilesWorkbench({
 
     const flushQueuedRefreshes = () => {
       const reqId = workspaceIdRef.current;
-      const parentPaths = [...queuedParentPaths];
+      const parentPaths = compactDirectoryRefreshPaths([...queuedParentPaths]);
       queuedParentPaths.clear();
       const shouldRefreshRoot = rootRefreshQueued;
       const shouldRefreshFullRoot = fullRootRefreshQueued;

--- a/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
@@ -12,8 +12,10 @@ import {
   defaultFilesWorkspaceId,
   filesSessionKey,
   formatFilesError,
+  hasLoadedDirectoryChildren,
   isUnavailableGitDecorationsError,
   mergeTreePreservingLoadedChildren,
+  parentPathForFileChange,
   replaceTreeNodeChildren,
 } from "../treeHelpers";
 import {
@@ -45,6 +47,7 @@ import type { EditorThemeMode } from "./viewers/types";
 
 const TREE_PAGE_SIZE = 2_000;
 const MAX_AUTO_LOADED_CHILDREN = 10_000;
+const MAX_QUEUED_TREE_PARENT_REFRESHES = 24;
 
 // Module-level caches survive remounts (the route unmounts FilesWorkbench when you
 // switch tabs), so re-opening Files shows the workspace + tree instantly instead of
@@ -126,6 +129,8 @@ export function FilesWorkbench({
   const dragRef = useRef<{ groupId: string; path: string } | null>(null);
   const workspaceIdRef = useRef(workspaceId);
   workspaceIdRef.current = workspaceId;
+  const treeRef = useRef(tree);
+  treeRef.current = tree;
 
   const store = useEditorGroupsStore();
   const groupsState = store.sessions[sessionKey] ?? createInitialGroupsState();
@@ -187,14 +192,15 @@ export function FilesWorkbench({
   }, [workspaces, globalLaneId]);
 
   /* ---- Tree loading ---- */
-  const refreshRoot = useCallback(async () => {
+  const refreshRoot = useCallback(async (options: { preserveLoadedChildren?: boolean } = {}) => {
     if (!workspaceId) return;
     const reqId = workspaceId;
+    const preserveLoadedChildren = options.preserveLoadedChildren !== false;
     try {
       const nodes = await window.ade.files.listTree({ workspaceId: reqId, depth: 1, includeIgnored: true });
       if (workspaceIdRef.current !== reqId) return;
       setTree((prev) => {
-        const merged = mergeTreePreservingLoadedChildren(nodes, prev);
+        const merged = preserveLoadedChildren ? mergeTreePreservingLoadedChildren(nodes, prev) : nodes;
         rootTreeCacheByKey.set(rootTreeCacheKey(projectRootPath, reqId), merged);
         return merged;
       });
@@ -233,33 +239,42 @@ export function FilesWorkbench({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [active, workspaceId, refreshRoot, projectRootPath]);
 
-  const loadDirectory = useCallback(
-    async (parentPath: string) => {
-      if (!workspaceId) return;
-      const reqId = workspaceId;
+  const fetchDirectoryChildren = useCallback(async (reqId: string, parentPath: string) => {
+    const children: FileTreeNode[] = [];
+    let offset = 0;
+    let loadMoreOffset: number | null = null;
+    for (;;) {
+      const page = await window.ade.files.listTreeChildren({
+        workspaceId: reqId,
+        parentPath,
+        offset,
+        limit: TREE_PAGE_SIZE,
+        includeIgnored: true,
+      });
+      if (workspaceIdRef.current !== reqId) return null;
+      children.push(...page.children);
+      if (page.nextOffset == null) break;
+      if (children.length >= MAX_AUTO_LOADED_CHILDREN) {
+        loadMoreOffset = page.nextOffset;
+        break;
+      }
+      offset = page.nextOffset;
+    }
+    return { children, loadMoreOffset };
+  }, []);
+
+  const refreshLoadedDirectory = useCallback(
+    async (parentPath: string, reqId = workspaceId) => {
+      if (!reqId) return;
       setLoadingDirs((prev) => new Set(prev).add(parentPath));
       try {
-        const children: FileTreeNode[] = [];
-        let offset = 0;
-        let loadMoreOffset: number | null = null;
-        for (;;) {
-          const page = await window.ade.files.listTreeChildren({
-            workspaceId: reqId,
-            parentPath,
-            offset,
-            limit: TREE_PAGE_SIZE,
-            includeIgnored: true,
-          });
-          if (workspaceIdRef.current !== reqId) return;
-          children.push(...page.children);
-          if (page.nextOffset == null) break;
-          if (children.length >= MAX_AUTO_LOADED_CHILDREN) {
-            loadMoreOffset = page.nextOffset;
-            break;
-          }
-          offset = page.nextOffset;
-        }
-        setTree((prev) => replaceTreeNodeChildren(prev, parentPath, children, loadMoreOffset));
+        const result = await fetchDirectoryChildren(reqId, parentPath);
+        if (!result || workspaceIdRef.current !== reqId) return;
+        setTree((prev) => {
+          const nextTree = replaceTreeNodeChildren(prev, parentPath, result.children, result.loadMoreOffset);
+          rootTreeCacheByKey.set(rootTreeCacheKey(projectRootPath, reqId), nextTree);
+          return nextTree;
+        });
       } catch (err) {
         if (workspaceIdRef.current === reqId) setError(formatFilesError(err));
       } finally {
@@ -270,7 +285,14 @@ export function FilesWorkbench({
         });
       }
     },
-    [workspaceId],
+    [fetchDirectoryChildren, projectRootPath, workspaceId],
+  );
+
+  const loadDirectory = useCallback(
+    async (parentPath: string) => {
+      await refreshLoadedDirectory(parentPath);
+    },
+    [refreshLoadedDirectory],
   );
 
   const loadMoreChildren = useCallback(
@@ -334,14 +356,58 @@ export function FilesWorkbench({
   useEffect(() => {
     if (!active || !workspaceId) return;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    const queuedParentPaths = new Set<string>();
+    let rootRefreshQueued = false;
+    let fullRootRefreshQueued = false;
+
+    const enqueuePathRefresh = (path: string | undefined) => {
+      if (!path) return;
+      const parentPath = parentPathForFileChange(path);
+      if (!parentPath) {
+        rootRefreshQueued = true;
+        return;
+      }
+      if (hasLoadedDirectoryChildren(treeRef.current, parentPath)) {
+        queuedParentPaths.add(parentPath);
+        if (queuedParentPaths.size > MAX_QUEUED_TREE_PARENT_REFRESHES) {
+          fullRootRefreshQueued = true;
+        }
+      }
+    };
+
+    const flushQueuedRefreshes = () => {
+      const reqId = workspaceIdRef.current;
+      const parentPaths = [...queuedParentPaths];
+      queuedParentPaths.clear();
+      const shouldRefreshRoot = rootRefreshQueued;
+      const shouldRefreshFullRoot = fullRootRefreshQueued;
+      rootRefreshQueued = false;
+      fullRootRefreshQueued = false;
+
+      if (!reqId) return;
+      if (shouldRefreshFullRoot) {
+        setExpanded(new Set());
+        void refreshRoot({ preserveLoadedChildren: false });
+        return;
+      }
+      if (shouldRefreshRoot) {
+        void refreshRoot();
+      }
+      for (const parentPath of parentPaths) {
+        void refreshLoadedDirectory(parentPath, reqId);
+      }
+    };
+
     const unsub = window.ade.files.onChange((ev) => {
       if (ev.workspaceId !== workspaceIdRef.current) return;
       // Drop the cached content for the changed path so a reopen re-reads disk.
       invalidateFileContent(ev.workspaceId, ev.path);
       if (ev.oldPath) invalidateFileContent(ev.workspaceId, ev.oldPath);
+      enqueuePathRefresh(ev.path);
+      enqueuePathRefresh(ev.oldPath);
       if (timer) clearTimeout(timer);
       timer = setTimeout(() => {
-        void refreshRoot();
+        flushQueuedRefreshes();
       }, 200);
     });
     void window.ade.files.watchChanges({ workspaceId, includeIgnored: true }).catch(() => {});
@@ -350,7 +416,7 @@ export function FilesWorkbench({
       unsub();
       void window.ade.files.stopWatching({ workspaceId, includeIgnored: true }).catch(() => {});
     };
-  }, [active, workspaceId, refreshRoot]);
+  }, [active, workspaceId, refreshLoadedDirectory, refreshRoot]);
 
   /* ---- Open file ---- */
   const openFile = useCallback(

--- a/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
@@ -417,7 +417,7 @@ export function FilesWorkbench({
       if (parentPaths.length > 0) {
         const directoryRefreshes = parentPaths.map((parentPath) => (
           refreshLoadedDirectory(parentPath, reqId, {
-            suppressMissingError: hasAncestorDirectoryPath(parentPath, parentPaths),
+            suppressMissingError: shouldRefreshRoot || hasAncestorDirectoryPath(parentPath, parentPaths),
           })
         ));
         void Promise.allSettled(directoryRefreshes)


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Ffiles-tab-realtime-bug-707f1e99 num=626 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Ffiles-tab-realtime-bug-707f1e99&amp;pr=626">ade/files-tab-realtime-bug-707f1e99 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=626">PR #626</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for file tree utilities

* **Improvements**
  * Optimized file tree refresh system with more targeted updates to specific directories when responding to filesystem changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the previous blanket full-root refresh on every filesystem change event with a smart debounced queue that dispatches targeted per-directory refreshes, falling back to a full refresh only when more than 24 directories are affected or a root-level path changes.

- **Targeted refresh queue (`FilesWorkbench.tsx`)**: `enqueuePathRefresh` classifies each event into root refresh, directory refresh, or drop (unloaded dir); `flushQueuedRefreshes` after the 200 ms debounce dispatches only what's needed using `Promise.allSettled` + a follow-up git-decorations call. An O(depth) `findFileTreeNodeByPath` is used instead of the previous full-tree `Map` build per event.
- **New tree helpers (`treeHelpers.ts`)**: Adds `parentPathForFileChange`, `hasAncestorDirectoryPath`, `hasLoadedDirectoryChildren`, `loadedDirectoryChildrenCount`, and `mergeChildrenPreservingLoadedDescendants`. The last one is wired into `replaceTreeNodeChildren` to preserve already-expanded subdirectory state when a parent directory is refreshed, preventing visible collapse of nested folders.
- **Test coverage (`treeHelpers.test.ts`)**: New `describe` block covers all five new helpers including the child-preservation merge behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the targeted refresh logic is well-guarded, all new state paths use React updater functions to avoid stale-state races, and the new helpers are fully unit-tested.

The core debounce-and-queue flow correctly deduplicates paths via a Set, guards against over-queuing with the 24-path ceiling before falling back to a full refresh, and uses treeRef to read the latest tree snapshot without creating stale closures. The concurrent root + directory refresh scenario is safe because both use the React updater form of setTree, so they serialize correctly regardless of completion order. The suppressMissingError option cleanly handles races where a directory is deleted mid-refresh. No data-loss or incorrect-state paths were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/files/treeHelpers.ts | Adds targeted O(depth) path lookup helpers, ancestor-path detection, and a merge function that preserves loaded descendant state during scoped directory refreshes; modifies replaceTreeNodeChildren to call the new merge instead of a blind replacement. |
| apps/desktop/src/renderer/components/files/treeHelpers.test.ts | Comprehensive test coverage added for all new helpers: parent-path extraction, ancestor detection, loaded-children checks, and child-preservation during directory refresh. |
| apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx | Replaces the blanket full-root refresh with a debounced queue that dispatches targeted per-directory refreshes; extracts git-decorations refresh into its own callback and adds a MAX_QUEUED_TREE_PARENT_REFRESHES=24 guard before falling back to a full refresh. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[fs onChange event] --> B[invalidateFileContent]
    B --> C[enqueuePathRefresh path + oldPath]
    C --> D{fullRootRefreshQueued?}
    D -- yes --> E[return early]
    D -- no --> F[parentPathForFileChange]
    F --> G{parentPath empty?}
    G -- yes --> H[rootRefreshQueued = true]
    G -- no --> I{hasLoadedDirectoryChildren?}
    I -- no --> J[drop — dir not expanded]
    I -- yes --> K[queuedParentPaths.add]
    K --> L{size > 24?}
    L -- yes --> M[fullRootRefreshQueued = true / queuedParentPaths.clear]
    L -- no --> N[debounce 200 ms]
    H --> N
    M --> N
    N --> O[flushQueuedRefreshes]
    O --> P{fullRootRefreshQueued?}
    P -- yes --> Q[setExpanded empty / refreshRoot preserveLoadedChildren=false]
    P -- no --> R{rootRefreshQueued?}
    R -- yes --> S[refreshRoot]
    R -- no --> T{parentPaths.length > 0?}
    S --> T
    T -- yes --> U[Promise.allSettled refreshLoadedDirectory x N / then refreshTreeGitDecorations]
    T -- no --> V{decorationsRefreshQueued?}
    V -- yes --> W[refreshTreeGitDecorations]
    V -- no --> X[done]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[fs onChange event] --> B[invalidateFileContent]
    B --> C[enqueuePathRefresh path + oldPath]
    C --> D{fullRootRefreshQueued?}
    D -- yes --> E[return early]
    D -- no --> F[parentPathForFileChange]
    F --> G{parentPath empty?}
    G -- yes --> H[rootRefreshQueued = true]
    G -- no --> I{hasLoadedDirectoryChildren?}
    I -- no --> J[drop — dir not expanded]
    I -- yes --> K[queuedParentPaths.add]
    K --> L{size > 24?}
    L -- yes --> M[fullRootRefreshQueued = true / queuedParentPaths.clear]
    L -- no --> N[debounce 200 ms]
    H --> N
    M --> N
    N --> O[flushQueuedRefreshes]
    O --> P{fullRootRefreshQueued?}
    P -- yes --> Q[setExpanded empty / refreshRoot preserveLoadedChildren=false]
    P -- no --> R{rootRefreshQueued?}
    R -- yes --> S[refreshRoot]
    R -- no --> T{parentPaths.length > 0?}
    S --> T
    T -- yes --> U[Promise.allSettled refreshLoadedDirectory x N / then refreshTreeGitDecorations]
    T -- no --> V{decorationsRefreshQueued?}
    V -- yes --> W[refreshTreeGitDecorations]
    V -- no --> X[done]
```

</a>

<sub>Reviews (3): Last reviewed commit: ["Suppress covered Files refresh misses"](https://github.com/arul28/ade/commit/11e57635d6b5295ae1a9584e31d8d1e8112c7b76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38961235)</sub>

<!-- /greptile_comment -->