### PR TITLE
Codex Permission Switching

### DIFF
--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -14835,6 +14835,76 @@ describe("createAgentChatService", () => {
       expect(turnStartParams?.effort).toBe("medium");
     });
 
+    it("auto-approves pending Codex approvals when switched to full-auto during an active turn", async () => {
+      vi.mocked(mapPermissionToCodex).mockImplementation((mode) => {
+        if (mode === "full-auto") {
+          return { approvalPolicy: "never", sandbox: "danger-full-access" };
+        }
+        if (mode === "edit") {
+          return { approvalPolicy: "untrusted", sandbox: "workspace-write" };
+        }
+        return { approvalPolicy: "on-request", sandbox: "read-only" };
+      });
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+        permissionMode: "edit",
+      });
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Make the change.",
+      }, { awaitDispatch: true });
+
+      await vi.waitFor(() => {
+        expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(true);
+      });
+
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        id: "cmd-switch-1",
+        method: "item/commandExecution/requestApproval",
+        params: {
+          itemId: "cmd-switch-1",
+          turnId: "turn-1",
+          command: "/bin/zsh -lc 'npm test'",
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(events.some((event) =>
+          event.event.type === "approval_request"
+          && event.event.itemId === "cmd-switch-1"
+        )).toBe(true);
+      });
+
+      await service.updateSession({
+        sessionId: session.id,
+        permissionMode: "full-auto",
+      });
+
+      await vi.waitFor(() => {
+        expect(mockState.codexRequestPayloads.find((payload) => payload.id === "cmd-switch-1")).toMatchObject({
+          result: { decision: "accept" },
+        });
+        expect(events.some((event) =>
+          event.event.type === "pending_input_resolved"
+          && event.event.itemId === "cmd-switch-1"
+          && event.event.resolution === "accepted"
+        )).toBe(true);
+      });
+
+      const summary = await service.getSessionSummary(session.id);
+      expect(summary?.permissionMode).toBe("full-auto");
+      expect(summary?.codexApprovalPolicy).toBe("never");
+      expect(summary?.codexSandbox).toBe("danger-full-access");
+    });
+
     it("keeps Codex planner approval guard scoped to the turn that started in plan mode", async () => {
       vi.mocked(mapPermissionToCodex).mockImplementation((mode) => {
         if (mode === "full-auto") {
@@ -14932,11 +15002,14 @@ describe("createAgentChatService", () => {
       });
 
       await vi.waitFor(() => {
-        expect(events.some((event) =>
-          event.event.type === "approval_request"
-          && event.event.itemId === "cmd-full-auto-1"
-        )).toBe(true);
+        expect(mockState.codexRequestPayloads.find((payload) => payload.id === "cmd-full-auto-1")).toMatchObject({
+          result: { decision: "accept" },
+        });
       });
+      expect(events.some((event) =>
+        event.event.type === "approval_request"
+        && event.event.itemId === "cmd-full-auto-1"
+      )).toBe(false);
       expect(events.some((event) =>
         event.event.type === "error"
         && event.event.turnId === "turn-2"

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -14875,11 +14875,30 @@ describe("createAgentChatService", () => {
           command: "/bin/zsh -lc 'npm test'",
         },
       });
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        id: "perm-switch-1",
+        method: "item/permissions/requestApproval",
+        params: {
+          itemId: "perm-switch-1",
+          turnId: "turn-1",
+          cwd: tmpRoot,
+          permissions: {
+            fileSystem: {
+              write: [path.join(tmpRoot, "generated.txt")],
+            },
+          },
+        },
+      });
 
       await vi.waitFor(() => {
         expect(events.some((event) =>
           event.event.type === "approval_request"
           && event.event.itemId === "cmd-switch-1"
+        )).toBe(true);
+        expect(events.some((event) =>
+          event.event.type === "approval_request"
+          && event.event.itemId === "perm-switch-1"
         )).toBe(true);
       });
 
@@ -14892,9 +14911,25 @@ describe("createAgentChatService", () => {
         expect(mockState.codexRequestPayloads.find((payload) => payload.id === "cmd-switch-1")).toMatchObject({
           result: { decision: "accept" },
         });
+        expect(mockState.codexRequestPayloads.find((payload) => payload.id === "perm-switch-1")).toMatchObject({
+          result: {
+            permissions: {
+              fileSystem: {
+                write: [path.join(tmpRoot, "generated.txt")],
+              },
+            },
+            scope: "session",
+          },
+        });
         expect(events.some((event) =>
           event.event.type === "pending_input_resolved"
           && event.event.itemId === "cmd-switch-1"
+          && event.event.resolution === "accepted"
+          && event.event.turnId === "turn-1"
+        )).toBe(true);
+        expect(events.some((event) =>
+          event.event.type === "pending_input_resolved"
+          && event.event.itemId === "perm-switch-1"
           && event.event.resolution === "accepted"
           && event.event.turnId === "turn-1"
         )).toBe(true);
@@ -14974,6 +15009,30 @@ describe("createAgentChatService", () => {
         )).toBe(true);
       });
       expect(mockState.codexRequestPayloads.find((payload) => payload.id === "file-escape-1")).toBeUndefined();
+
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        id: "perm-escape-1",
+        method: "item/permissions/requestApproval",
+        params: {
+          itemId: "perm-escape-1",
+          turnId: "turn-1",
+          cwd: tmpRoot,
+          permissions: {
+            fileSystem: {
+              write: [path.join(outsideLane, "escape.txt")],
+            },
+          },
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(events.some((event) =>
+          event.event.type === "approval_request"
+          && event.event.itemId === "perm-escape-1"
+        )).toBe(true);
+      });
+      expect(mockState.codexRequestPayloads.find((payload) => payload.id === "perm-escape-1")).toBeUndefined();
     });
 
     it("keeps escaped pending Codex approvals manual when switched to full-auto", async () => {
@@ -15030,6 +15089,21 @@ describe("createAgentChatService", () => {
           reason: "Edit outside the lane",
         },
       });
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        id: "perm-pending-escape-1",
+        method: "item/permissions/requestApproval",
+        params: {
+          itemId: "perm-pending-escape-1",
+          turnId: "turn-1",
+          cwd: outsideLane,
+          permissions: {
+            fileSystem: {
+              write: [path.join(outsideLane, "escape.txt")],
+            },
+          },
+        },
+      });
 
       await vi.waitFor(() => {
         expect(events.some((event) =>
@@ -15040,6 +15114,10 @@ describe("createAgentChatService", () => {
           event.event.type === "approval_request"
           && event.event.itemId === "file-pending-escape-1"
         )).toBe(true);
+        expect(events.some((event) =>
+          event.event.type === "approval_request"
+          && event.event.itemId === "perm-pending-escape-1"
+        )).toBe(true);
       });
 
       await service.updateSession({
@@ -15049,9 +15127,14 @@ describe("createAgentChatService", () => {
 
       expect(mockState.codexRequestPayloads.find((payload) => payload.id === "cmd-pending-escape-1")).toBeUndefined();
       expect(mockState.codexRequestPayloads.find((payload) => payload.id === "file-pending-escape-1")).toBeUndefined();
+      expect(mockState.codexRequestPayloads.find((payload) => payload.id === "perm-pending-escape-1")).toBeUndefined();
       expect(events.some((event) =>
         event.event.type === "pending_input_resolved"
-        && (event.event.itemId === "cmd-pending-escape-1" || event.event.itemId === "file-pending-escape-1")
+        && (
+          event.event.itemId === "cmd-pending-escape-1"
+          || event.event.itemId === "file-pending-escape-1"
+          || event.event.itemId === "perm-pending-escape-1"
+        )
       )).toBe(false);
 
       await service.respondToInput({
@@ -15062,6 +15145,11 @@ describe("createAgentChatService", () => {
       await service.respondToInput({
         sessionId: session.id,
         itemId: "file-pending-escape-1",
+        decision: "decline",
+      });
+      await service.respondToInput({
+        sessionId: session.id,
+        itemId: "perm-pending-escape-1",
         decision: "decline",
       });
     });

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -15091,6 +15091,38 @@ describe("createAgentChatService", () => {
         )).toBe(true);
       });
       expect(mockState.codexRequestPayloads.find((payload) => payload.id === "perm-project-roots-escape-1")).toBeUndefined();
+
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        id: "perm-project-roots-whole-1",
+        method: "item/permissions/requestApproval",
+        params: {
+          itemId: "perm-project-roots-whole-1",
+          turnId: "turn-1",
+          cwd: tmpRoot,
+          permissions: {
+            fileSystem: {
+              entries: [{
+                access: "write",
+                path: {
+                  type: "special",
+                  value: {
+                    kind: "project_roots",
+                  },
+                },
+              }],
+            },
+          },
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(events.some((event) =>
+          event.event.type === "approval_request"
+          && event.event.itemId === "perm-project-roots-whole-1"
+        )).toBe(true);
+      });
+      expect(mockState.codexRequestPayloads.find((payload) => payload.id === "perm-project-roots-whole-1")).toBeUndefined();
     });
 
     it("keeps escaped pending Codex approvals manual when switched to full-auto", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -14918,7 +14918,7 @@ describe("createAgentChatService", () => {
                 write: [path.join(tmpRoot, "generated.txt")],
               },
             },
-            scope: "session",
+            scope: "turn",
           },
         });
         expect(events.some((event) =>
@@ -14989,6 +14989,31 @@ describe("createAgentChatService", () => {
         )).toBe(true);
       });
       expect(mockState.codexRequestPayloads.find((payload) => payload.id === "cmd-escape-1")).toBeUndefined();
+
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        id: "cmd-additional-perms-escape-1",
+        method: "item/commandExecution/requestApproval",
+        params: {
+          itemId: "cmd-additional-perms-escape-1",
+          turnId: "turn-1",
+          cwd: tmpRoot,
+          command: "/bin/zsh -lc 'cat /tmp/escape.txt'",
+          additionalPermissions: {
+            fileSystem: {
+              read: [path.join(outsideLane, "escape.txt")],
+            },
+          },
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(events.some((event) =>
+          event.event.type === "approval_request"
+          && event.event.itemId === "cmd-additional-perms-escape-1"
+        )).toBe(true);
+      });
+      expect(mockState.codexRequestPayloads.find((payload) => payload.id === "cmd-additional-perms-escape-1")).toBeUndefined();
 
       mockState.emitCodexPayload({
         jsonrpc: "2.0",
@@ -15124,6 +15149,22 @@ describe("createAgentChatService", () => {
       });
       mockState.emitCodexPayload({
         jsonrpc: "2.0",
+        id: "cmd-pending-additional-perms-escape-1",
+        method: "item/commandExecution/requestApproval",
+        params: {
+          itemId: "cmd-pending-additional-perms-escape-1",
+          turnId: "turn-1",
+          cwd: tmpRoot,
+          command: "/bin/zsh -lc 'cat /tmp/escape.txt'",
+          additionalPermissions: {
+            fileSystem: {
+              read: [path.join(outsideLane, "escape.txt")],
+            },
+          },
+        },
+      });
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
         id: "perm-pending-escape-1",
         method: "item/permissions/requestApproval",
         params: {
@@ -15149,6 +15190,10 @@ describe("createAgentChatService", () => {
         )).toBe(true);
         expect(events.some((event) =>
           event.event.type === "approval_request"
+          && event.event.itemId === "cmd-pending-additional-perms-escape-1"
+        )).toBe(true);
+        expect(events.some((event) =>
+          event.event.type === "approval_request"
           && event.event.itemId === "perm-pending-escape-1"
         )).toBe(true);
       });
@@ -15160,12 +15205,14 @@ describe("createAgentChatService", () => {
 
       expect(mockState.codexRequestPayloads.find((payload) => payload.id === "cmd-pending-escape-1")).toBeUndefined();
       expect(mockState.codexRequestPayloads.find((payload) => payload.id === "file-pending-escape-1")).toBeUndefined();
+      expect(mockState.codexRequestPayloads.find((payload) => payload.id === "cmd-pending-additional-perms-escape-1")).toBeUndefined();
       expect(mockState.codexRequestPayloads.find((payload) => payload.id === "perm-pending-escape-1")).toBeUndefined();
       expect(events.some((event) =>
         event.event.type === "pending_input_resolved"
         && (
           event.event.itemId === "cmd-pending-escape-1"
           || event.event.itemId === "file-pending-escape-1"
+          || event.event.itemId === "cmd-pending-additional-perms-escape-1"
           || event.event.itemId === "perm-pending-escape-1"
         )
       )).toBe(false);
@@ -15178,6 +15225,11 @@ describe("createAgentChatService", () => {
       await service.respondToInput({
         sessionId: session.id,
         itemId: "file-pending-escape-1",
+        decision: "decline",
+      });
+      await service.respondToInput({
+        sessionId: session.id,
+        itemId: "cmd-pending-additional-perms-escape-1",
         decision: "decline",
       });
       await service.respondToInput({

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -15305,6 +15305,36 @@ describe("createAgentChatService", () => {
 
       mockState.emitCodexPayload({
         jsonrpc: "2.0",
+        id: "perm-plan-1",
+        method: "item/permissions/requestApproval",
+        params: {
+          itemId: "perm-plan-1",
+          turnId: "turn-1",
+          cwd: tmpRoot,
+          reason: "Allow write access",
+          permissions: {
+            fileSystem: {
+              write: [path.join(tmpRoot, "planned-edit.txt")],
+            },
+          },
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(mockState.codexRequestPayloads.find((payload) => payload.id === "perm-plan-1")).toMatchObject({
+          result: {
+            permissions: {},
+            scope: "turn",
+          },
+        });
+      });
+      expect(events.some((event) =>
+        event.event.type === "approval_request"
+        && event.event.itemId === "perm-plan-1"
+      )).toBe(false);
+
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
         method: "turn/completed",
         params: {
           turn: {

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -14976,6 +14976,96 @@ describe("createAgentChatService", () => {
       expect(mockState.codexRequestPayloads.find((payload) => payload.id === "file-escape-1")).toBeUndefined();
     });
 
+    it("keeps escaped pending Codex approvals manual when switched to full-auto", async () => {
+      vi.mocked(mapPermissionToCodex).mockImplementation((mode) => {
+        if (mode === "full-auto") {
+          return { approvalPolicy: "never", sandbox: "danger-full-access" };
+        }
+        if (mode === "edit") {
+          return { approvalPolicy: "untrusted", sandbox: "workspace-write" };
+        }
+        return { approvalPolicy: "on-request", sandbox: "read-only" };
+      });
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+        permissionMode: "edit",
+      });
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Make the change.",
+      }, { awaitDispatch: true });
+
+      await vi.waitFor(() => {
+        expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(true);
+      });
+      mockState.codexRequestPayloads = [];
+
+      const outsideLane = path.dirname(tmpRoot);
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        id: "cmd-pending-escape-1",
+        method: "item/commandExecution/requestApproval",
+        params: {
+          itemId: "cmd-pending-escape-1",
+          turnId: "turn-1",
+          cwd: outsideLane,
+          command: "/bin/zsh -lc 'pwd'",
+        },
+      });
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        id: "file-pending-escape-1",
+        method: "item/fileChange/requestApproval",
+        params: {
+          itemId: "file-pending-escape-1",
+          turnId: "turn-1",
+          grantRoot: outsideLane,
+          reason: "Edit outside the lane",
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(events.some((event) =>
+          event.event.type === "approval_request"
+          && event.event.itemId === "cmd-pending-escape-1"
+        )).toBe(true);
+        expect(events.some((event) =>
+          event.event.type === "approval_request"
+          && event.event.itemId === "file-pending-escape-1"
+        )).toBe(true);
+      });
+
+      await service.updateSession({
+        sessionId: session.id,
+        permissionMode: "full-auto",
+      });
+
+      expect(mockState.codexRequestPayloads.find((payload) => payload.id === "cmd-pending-escape-1")).toBeUndefined();
+      expect(mockState.codexRequestPayloads.find((payload) => payload.id === "file-pending-escape-1")).toBeUndefined();
+      expect(events.some((event) =>
+        event.event.type === "pending_input_resolved"
+        && (event.event.itemId === "cmd-pending-escape-1" || event.event.itemId === "file-pending-escape-1")
+      )).toBe(false);
+
+      await service.respondToInput({
+        sessionId: session.id,
+        itemId: "cmd-pending-escape-1",
+        decision: "decline",
+      });
+      await service.respondToInput({
+        sessionId: session.id,
+        itemId: "file-pending-escape-1",
+        decision: "decline",
+      });
+    });
+
     it("keeps Codex planner approval guard scoped to the turn that started in plan mode", async () => {
       vi.mocked(mapPermissionToCodex).mockImplementation((mode) => {
         if (mode === "full-auto") {

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -15033,6 +15033,39 @@ describe("createAgentChatService", () => {
         )).toBe(true);
       });
       expect(mockState.codexRequestPayloads.find((payload) => payload.id === "perm-escape-1")).toBeUndefined();
+
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        id: "perm-project-roots-escape-1",
+        method: "item/permissions/requestApproval",
+        params: {
+          itemId: "perm-project-roots-escape-1",
+          turnId: "turn-1",
+          cwd: path.join(tmpRoot, "src"),
+          permissions: {
+            fileSystem: {
+              entries: [{
+                access: "write",
+                path: {
+                  type: "special",
+                  value: {
+                    kind: "project_roots",
+                    subpath: "..",
+                  },
+                },
+              }],
+            },
+          },
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(events.some((event) =>
+          event.event.type === "approval_request"
+          && event.event.itemId === "perm-project-roots-escape-1"
+        )).toBe(true);
+      });
+      expect(mockState.codexRequestPayloads.find((payload) => payload.id === "perm-project-roots-escape-1")).toBeUndefined();
     });
 
     it("keeps escaped pending Codex approvals manual when switched to full-auto", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -14871,7 +14871,7 @@ describe("createAgentChatService", () => {
         method: "item/commandExecution/requestApproval",
         params: {
           itemId: "cmd-switch-1",
-          turnId: "turn-1",
+          turnId: "  turn-1  ",
           command: "/bin/zsh -lc 'npm test'",
         },
       });
@@ -14896,6 +14896,7 @@ describe("createAgentChatService", () => {
           event.event.type === "pending_input_resolved"
           && event.event.itemId === "cmd-switch-1"
           && event.event.resolution === "accepted"
+          && event.event.turnId === "turn-1"
         )).toBe(true);
       });
 
@@ -14903,6 +14904,76 @@ describe("createAgentChatService", () => {
       expect(summary?.permissionMode).toBe("full-auto");
       expect(summary?.codexApprovalPolicy).toBe("never");
       expect(summary?.codexSandbox).toBe("danger-full-access");
+    });
+
+    it("keeps escaped Codex command and file-change approvals manual in full-auto", async () => {
+      vi.mocked(mapPermissionToCodex).mockImplementation((mode) => {
+        if (mode === "full-auto") {
+          return { approvalPolicy: "never", sandbox: "danger-full-access" };
+        }
+        return { approvalPolicy: "on-request", sandbox: "read-only" };
+      });
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.4",
+        permissionMode: "full-auto",
+      });
+
+      await service.sendMessage({
+        sessionId: session.id,
+        text: "Make the change.",
+      }, { awaitDispatch: true });
+
+      await vi.waitFor(() => {
+        expect(mockState.codexRequestPayloads.some((payload) => payload.method === "turn/start")).toBe(true);
+      });
+      mockState.codexRequestPayloads = [];
+
+      const outsideLane = path.dirname(tmpRoot);
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        id: "cmd-escape-1",
+        method: "item/commandExecution/requestApproval",
+        params: {
+          itemId: "cmd-escape-1",
+          turnId: "turn-1",
+          cwd: outsideLane,
+          command: "/bin/zsh -lc 'pwd'",
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(events.some((event) =>
+          event.event.type === "approval_request"
+          && event.event.itemId === "cmd-escape-1"
+        )).toBe(true);
+      });
+      expect(mockState.codexRequestPayloads.find((payload) => payload.id === "cmd-escape-1")).toBeUndefined();
+
+      mockState.emitCodexPayload({
+        jsonrpc: "2.0",
+        id: "file-escape-1",
+        method: "item/fileChange/requestApproval",
+        params: {
+          itemId: "file-escape-1",
+          turnId: "turn-1",
+          grantRoot: outsideLane,
+          reason: "Edit outside the lane",
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(events.some((event) =>
+          event.event.type === "approval_request"
+          && event.event.itemId === "file-escape-1"
+        )).toBe(true);
+      });
+      expect(mockState.codexRequestPayloads.find((payload) => payload.id === "file-escape-1")).toBeUndefined();
     });
 
     it("keeps Codex planner approval guard scoped to the turn that started in plan mode", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -2937,6 +2937,13 @@ function rememberCodexPlanningApprovalGuard(
   }
 }
 
+function normalizeCodexTurnId(turnId: unknown, fallback?: string | null): string | null {
+  const normalized = typeof turnId === "string" ? turnId.trim() : "";
+  if (normalized.length > 0) return normalized;
+  const normalizedFallback = typeof fallback === "string" ? fallback.trim() : "";
+  return normalizedFallback.length > 0 ? normalizedFallback : null;
+}
+
 function isPlanningApprovalGuarded(
   managed: ManagedChatSession,
   runtime: CodexRuntime,
@@ -9642,7 +9649,11 @@ export function createAgentChatService(args: {
     itemId: string,
     pending: PendingCodexApproval,
   ): void => {
-    if (isPlanningApprovalGuarded(managed, runtime, pending.request?.turnId ?? null)) return;
+    const pendingTurnId = normalizeCodexTurnId(
+      pending.request?.turnId,
+      runtime.activeTurnId ?? runtime.startedTurnId ?? null,
+    );
+    if (isPlanningApprovalGuarded(managed, runtime, pendingTurnId)) return;
     if (pending.kind === "permissions") {
       runtime.sendResponse(pending.requestId, {
         permissions: pending.permissions ?? {},
@@ -9659,7 +9670,7 @@ export function createAgentChatService(args: {
     emitPendingInputResolved(managed, {
       itemId,
       decision: "accept",
-      turnId: pending.request?.turnId ?? null,
+      turnId: pendingTurnId,
     });
   };
 
@@ -14083,6 +14094,20 @@ export function createAgentChatService(args: {
     }
   };
 
+  const codexApprovalPathStaysWithinLane = (
+    managed: ManagedChatSession,
+    candidate: string | null | undefined,
+  ): boolean => {
+    const trimmed = typeof candidate === "string" ? candidate.trim() : "";
+    if (!trimmed.length) return false;
+    try {
+      resolvePathWithinRoot(managed.laneWorktreePath, trimmed, { allowMissing: true });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
   const handleCodexServerRequest = (managed: ManagedChatSession, runtime: CodexRuntime, payload: JsonRpcEnvelope): void => {
     const method = typeof payload.method === "string" ? payload.method : "";
     const id = payload.id;
@@ -14090,7 +14115,7 @@ export function createAgentChatService(args: {
 
     if (method === "item/commandExecution/requestApproval") {
       const params = (payload.params as { itemId?: string; command?: string; cwd?: string; reason?: string; turnId?: string } | null) ?? {};
-      const requestTurnId = typeof params.turnId === "string" ? params.turnId : runtime.activeTurnId ?? runtime.startedTurnId ?? null;
+      const requestTurnId = normalizeCodexTurnId(params.turnId, runtime.activeTurnId ?? runtime.startedTurnId ?? null);
       if (isPlanningApprovalGuarded(managed, runtime, requestTurnId)) {
         emitChatEvent(managed, {
           type: "error",
@@ -14100,7 +14125,10 @@ export function createAgentChatService(args: {
         runtime.sendResponse(id, { decision: "decline" });
         return;
       }
-      if (isSessionCodexFullAuto(managed.session)) {
+      const commandCwd = typeof params.cwd === "string" && params.cwd.trim().length
+        ? params.cwd
+        : managed.laneWorktreePath;
+      if (isSessionCodexFullAuto(managed.session) && codexApprovalPathStaysWithinLane(managed, commandCwd)) {
         runtime.sendResponse(id, { decision: mapApprovalDecisionForCodex("accept") });
         return;
       }
@@ -14138,7 +14166,7 @@ export function createAgentChatService(args: {
 
     if (method === "item/fileChange/requestApproval") {
       const params = (payload.params as { itemId?: string; reason?: string; grantRoot?: string; turnId?: string } | null) ?? {};
-      const requestTurnId = typeof params.turnId === "string" ? params.turnId : runtime.activeTurnId ?? runtime.startedTurnId ?? null;
+      const requestTurnId = normalizeCodexTurnId(params.turnId, runtime.activeTurnId ?? runtime.startedTurnId ?? null);
       if (isPlanningApprovalGuarded(managed, runtime, requestTurnId)) {
         emitChatEvent(managed, {
           type: "error",
@@ -14148,7 +14176,7 @@ export function createAgentChatService(args: {
         runtime.sendResponse(id, { decision: "decline" });
         return;
       }
-      if (isSessionCodexFullAuto(managed.session)) {
+      if (isSessionCodexFullAuto(managed.session) && codexApprovalPathStaysWithinLane(managed, params.grantRoot)) {
         runtime.sendResponse(id, { decision: mapApprovalDecisionForCodex("accept") });
         return;
       }
@@ -14191,7 +14219,7 @@ export function createAgentChatService(args: {
         turnId?: string;
       } | null) ?? {};
       const itemId = String(params.itemId ?? randomUUID());
-      const requestTurnId = typeof params.turnId === "string" ? params.turnId : runtime.activeTurnId ?? null;
+      const requestTurnId = normalizeCodexTurnId(params.turnId, runtime.activeTurnId ?? runtime.startedTurnId ?? null);
       const description = typeof params.reason === "string" && params.reason.trim().length
         ? params.reason.trim()
         : "Codex requested additional permissions";
@@ -14233,7 +14261,7 @@ export function createAgentChatService(args: {
         providerMetadata: {
           permissions: params.permissions ?? null,
           threadId: params.threadId ?? null,
-          turnId: params.turnId ?? null,
+          turnId: requestTurnId,
         },
         turnId: requestTurnId,
       };

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -4448,6 +4448,20 @@ function isSessionCodexFullAuto(
     && resolveSessionCodexSandbox(session, "read-only") === "danger-full-access";
 }
 
+function codexApprovalPathStaysWithinLane(
+  managed: Pick<ManagedChatSession, "laneWorktreePath">,
+  candidate: string | null | undefined,
+): boolean {
+  const trimmed = typeof candidate === "string" ? candidate.trim() : "";
+  if (!trimmed.length) return false;
+  try {
+    resolvePathWithinRoot(managed.laneWorktreePath, trimmed, { allowMissing: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 type CodexCollaborationModePayload = {
   mode: "default" | "plan";
   settings: {
@@ -9654,12 +9668,26 @@ export function createAgentChatService(args: {
       runtime.activeTurnId ?? runtime.startedTurnId ?? null,
     );
     if (isPlanningApprovalGuarded(managed, runtime, pendingTurnId)) return;
+    const providerMetadata = pending.request?.providerMetadata;
+    const metadata = providerMetadata && typeof providerMetadata === "object" && !Array.isArray(providerMetadata)
+      ? providerMetadata as Record<string, unknown>
+      : {};
     if (pending.kind === "permissions") {
       runtime.sendResponse(pending.requestId, {
         permissions: pending.permissions ?? {},
         scope: "session",
       });
-    } else if (pending.kind === "command" || pending.kind === "file_change") {
+    } else if (pending.kind === "command") {
+      const cwd = typeof metadata.cwd === "string" && metadata.cwd.trim().length
+        ? metadata.cwd
+        : managed.laneWorktreePath;
+      if (!codexApprovalPathStaysWithinLane(managed, cwd)) return;
+      runtime.sendResponse(pending.requestId, {
+        decision: mapApprovalDecisionForCodex("accept"),
+      });
+    } else if (pending.kind === "file_change") {
+      const grantRoot = typeof metadata.grantRoot === "string" ? metadata.grantRoot : null;
+      if (!codexApprovalPathStaysWithinLane(managed, grantRoot)) return;
       runtime.sendResponse(pending.requestId, {
         decision: mapApprovalDecisionForCodex("accept"),
       });
@@ -14091,20 +14119,6 @@ export function createAgentChatService(args: {
           text: error instanceof Error ? error.message : String(error),
         }],
       });
-    }
-  };
-
-  const codexApprovalPathStaysWithinLane = (
-    managed: ManagedChatSession,
-    candidate: string | null | undefined,
-  ): boolean => {
-    const trimmed = typeof candidate === "string" ? candidate.trim() : "";
-    if (!trimmed.length) return false;
-    try {
-      resolvePathWithinRoot(managed.laneWorktreePath, trimmed, { allowMissing: true });
-      return true;
-    } catch {
-      return false;
     }
   };
 

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -4462,6 +4462,82 @@ function codexApprovalPathStaysWithinLane(
   }
 }
 
+function codexPermissionPathStaysWithinLane(
+  managed: Pick<ManagedChatSession, "laneWorktreePath">,
+  cwd: string,
+  candidate: string | null | undefined,
+): boolean {
+  const trimmed = typeof candidate === "string" ? candidate.trim() : "";
+  if (!trimmed.length) return false;
+  const resolvedCandidate = path.isAbsolute(trimmed)
+    ? trimmed
+    : path.join(cwd, trimmed);
+  return codexApprovalPathStaysWithinLane(managed, resolvedCandidate);
+}
+
+function codexFileSystemPermissionsStayWithinLane(
+  managed: Pick<ManagedChatSession, "laneWorktreePath">,
+  cwd: string,
+  fileSystemPermissions: Record<string, unknown>,
+): boolean {
+  const legacyPaths = [
+    ...(Array.isArray(fileSystemPermissions.read) ? fileSystemPermissions.read : []),
+    ...(Array.isArray(fileSystemPermissions.write) ? fileSystemPermissions.write : []),
+  ];
+  for (const candidate of legacyPaths) {
+    if (typeof candidate !== "string" || !codexPermissionPathStaysWithinLane(managed, cwd, candidate)) {
+      return false;
+    }
+  }
+
+  const entries = fileSystemPermissions.entries;
+  if (entries == null) return true;
+  if (!Array.isArray(entries)) return false;
+  for (const entryValue of entries) {
+    const entry = asRecord(entryValue);
+    if (!entry) return false;
+    if (entry.access === "deny") continue;
+    const entryPath = asRecord(entry.path);
+    if (!entryPath) return false;
+    if (entryPath.type === "path") {
+      if (!codexPermissionPathStaysWithinLane(managed, cwd, typeof entryPath.path === "string" ? entryPath.path : null)) {
+        return false;
+      }
+      continue;
+    }
+    if (entryPath.type === "special") {
+      const value = asRecord(entryPath.value);
+      if (value?.kind !== "project_roots") return false;
+      const subpath = value.subpath;
+      if (subpath == null) continue;
+      if (typeof subpath !== "string" || !codexPermissionPathStaysWithinLane(managed, cwd, subpath)) {
+        return false;
+      }
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+function codexPermissionsStayWithinLane(
+  managed: Pick<ManagedChatSession, "laneWorktreePath">,
+  cwd: string | null | undefined,
+  permissions: Record<string, unknown> | null | undefined,
+): boolean {
+  const permissionCwd = typeof cwd === "string" && cwd.trim().length
+    ? cwd.trim()
+    : managed.laneWorktreePath;
+  if (!codexApprovalPathStaysWithinLane(managed, permissionCwd)) return false;
+  const permissionRecord = asRecord(permissions);
+  if (!permissionRecord) return permissions == null;
+  if (permissionRecord.fileSystem == null) return true;
+  const fileSystemPermissions = asRecord(permissionRecord.fileSystem);
+  return fileSystemPermissions
+    ? codexFileSystemPermissionsStayWithinLane(managed, permissionCwd, fileSystemPermissions)
+    : false;
+}
+
 type CodexCollaborationModePayload = {
   mode: "default" | "plan";
   settings: {
@@ -9673,6 +9749,10 @@ export function createAgentChatService(args: {
       ? providerMetadata as Record<string, unknown>
       : {};
     if (pending.kind === "permissions") {
+      const cwd = typeof metadata.cwd === "string" && metadata.cwd.trim().length
+        ? metadata.cwd
+        : managed.laneWorktreePath;
+      if (!codexPermissionsStayWithinLane(managed, cwd, pending.permissions)) return;
       runtime.sendResponse(pending.requestId, {
         permissions: pending.permissions ?? {},
         scope: "session",
@@ -14227,6 +14307,7 @@ export function createAgentChatService(args: {
     if (method === "item/permissions/requestApproval") {
       const params = (payload.params as {
         itemId?: string;
+        cwd?: string;
         permissions?: Record<string, unknown> | null;
         reason?: string | null;
         threadId?: string;
@@ -14254,7 +14335,11 @@ export function createAgentChatService(args: {
           return;
         }
       }
-      if (isSessionCodexFullAuto(managed.session) && !isPlanningApprovalGuarded(managed, runtime, requestTurnId)) {
+      if (
+        isSessionCodexFullAuto(managed.session)
+        && !isPlanningApprovalGuarded(managed, runtime, requestTurnId)
+        && codexPermissionsStayWithinLane(managed, params.cwd, params.permissions)
+      ) {
         runtime.sendResponse(id, {
           permissions: params.permissions ?? {},
           scope: "session",
@@ -14273,6 +14358,7 @@ export function createAgentChatService(args: {
         blocking: true,
         canProceedWithoutAnswer: false,
         providerMetadata: {
+          cwd: params.cwd ?? null,
           permissions: params.permissions ?? null,
           threadId: params.threadId ?? null,
           turnId: requestTurnId,
@@ -14289,6 +14375,7 @@ export function createAgentChatService(args: {
         kind: "tool_call",
         description,
         detail: {
+          cwd: params.cwd ?? null,
           permissions: params.permissions ?? null,
           reason: params.reason ?? null,
         },

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -4430,6 +4430,17 @@ function resolveSessionCodexConfigSource(
     ?? "flags";
 }
 
+function isSessionCodexFullAuto(
+  session: Pick<
+    AgentChatSession,
+    "codexApprovalPolicy" | "codexSandbox" | "codexConfigSource" | "permissionMode"
+  >,
+): boolean {
+  if (resolveSessionCodexConfigSource(session) === "config-toml") return false;
+  return resolveSessionCodexApprovalPolicy(session, "on-request") === "never"
+    && resolveSessionCodexSandbox(session, "read-only") === "danger-full-access";
+}
+
 type CodexCollaborationModePayload = {
   mode: "default" | "plan";
   settings: {
@@ -9625,6 +9636,43 @@ export function createAgentChatService(args: {
     persistChatState(managed);
   };
 
+  const autoApproveCodexRuntimeApproval = (
+    managed: ManagedChatSession,
+    runtime: CodexRuntime,
+    itemId: string,
+    pending: PendingCodexApproval,
+  ): void => {
+    if (isPlanningApprovalGuarded(managed, runtime, pending.request?.turnId ?? null)) return;
+    if (pending.kind === "permissions") {
+      runtime.sendResponse(pending.requestId, {
+        permissions: pending.permissions ?? {},
+        scope: "session",
+      });
+    } else if (pending.kind === "command" || pending.kind === "file_change") {
+      runtime.sendResponse(pending.requestId, {
+        decision: mapApprovalDecisionForCodex("accept"),
+      });
+    } else {
+      return;
+    }
+    runtime.approvals.delete(itemId);
+    emitPendingInputResolved(managed, {
+      itemId,
+      decision: "accept",
+      turnId: pending.request?.turnId ?? null,
+    });
+  };
+
+  const autoApprovePendingCodexRuntimeApprovals = (
+    managed: ManagedChatSession,
+    runtime: CodexRuntime,
+  ): void => {
+    if (!isSessionCodexFullAuto(managed.session)) return;
+    for (const [itemId, pending] of [...runtime.approvals.entries()]) {
+      autoApproveCodexRuntimeApproval(managed, runtime, itemId, pending);
+    }
+  };
+
   const normalizePendingInputAnswers = (
     request: PendingInputRequest | undefined,
     answers: Record<string, string | string[]> | undefined,
@@ -14052,6 +14100,10 @@ export function createAgentChatService(args: {
         runtime.sendResponse(id, { decision: "decline" });
         return;
       }
+      if (isSessionCodexFullAuto(managed.session)) {
+        runtime.sendResponse(id, { decision: mapApprovalDecisionForCodex("accept") });
+        return;
+      }
       const itemId = String(params.itemId ?? randomUUID());
       const description = params.reason?.trim() || `Run command: ${params.command ?? "command"}`;
       const request: PendingInputRequest = {
@@ -14096,6 +14148,10 @@ export function createAgentChatService(args: {
         runtime.sendResponse(id, { decision: "decline" });
         return;
       }
+      if (isSessionCodexFullAuto(managed.session)) {
+        runtime.sendResponse(id, { decision: mapApprovalDecisionForCodex("accept") });
+        return;
+      }
       const itemId = String(params.itemId ?? randomUUID());
       const description = params.reason?.trim() || "Approve file changes";
       const request: PendingInputRequest = {
@@ -14135,6 +14191,7 @@ export function createAgentChatService(args: {
         turnId?: string;
       } | null) ?? {};
       const itemId = String(params.itemId ?? randomUUID());
+      const requestTurnId = typeof params.turnId === "string" ? params.turnId : runtime.activeTurnId ?? null;
       const description = typeof params.reason === "string" && params.reason.trim().length
         ? params.reason.trim()
         : "Codex requested additional permissions";
@@ -14155,6 +14212,13 @@ export function createAgentChatService(args: {
           return;
         }
       }
+      if (isSessionCodexFullAuto(managed.session) && !isPlanningApprovalGuarded(managed, runtime, requestTurnId)) {
+        runtime.sendResponse(id, {
+          permissions: params.permissions ?? {},
+          scope: "session",
+        });
+        return;
+      }
       const request: PendingInputRequest = {
         requestId: String(id),
         itemId,
@@ -14171,7 +14235,7 @@ export function createAgentChatService(args: {
           threadId: params.threadId ?? null,
           turnId: params.turnId ?? null,
         },
-        turnId: typeof params.turnId === "string" ? params.turnId : runtime.activeTurnId ?? null,
+        turnId: requestTurnId,
       };
       runtime.approvals.set(itemId, {
         requestId: id,
@@ -25022,6 +25086,9 @@ export function createAgentChatService(args: {
       ) {
         managed.runtime.threadResumed = false;
         managed.runtime.canAttachResumedTurnStart = false;
+      }
+      if (managed.runtime?.kind === "codex") {
+        autoApprovePendingCodexRuntimeApprovals(managed, managed.runtime);
       }
       if (
         managed.runtime?.kind === "claude"

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -4509,7 +4509,7 @@ function codexFileSystemPermissionsStayWithinLane(
       const value = asRecord(entryPath.value);
       if (value?.kind !== "project_roots") return false;
       const subpath = value.subpath;
-      if (subpath == null) continue;
+      if (subpath == null) return false;
       if (typeof subpath !== "string" || !codexPermissionPathStaysWithinLane(managed, managed.laneWorktreePath, subpath)) {
         return false;
       }

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -4510,7 +4510,7 @@ function codexFileSystemPermissionsStayWithinLane(
       if (value?.kind !== "project_roots") return false;
       const subpath = value.subpath;
       if (subpath == null) continue;
-      if (typeof subpath !== "string" || !codexPermissionPathStaysWithinLane(managed, cwd, subpath)) {
+      if (typeof subpath !== "string" || !codexPermissionPathStaysWithinLane(managed, managed.laneWorktreePath, subpath)) {
         return false;
       }
       continue;

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -4523,7 +4523,7 @@ function codexFileSystemPermissionsStayWithinLane(
 function codexPermissionsStayWithinLane(
   managed: Pick<ManagedChatSession, "laneWorktreePath">,
   cwd: string | null | undefined,
-  permissions: Record<string, unknown> | null | undefined,
+  permissions: unknown,
 ): boolean {
   const permissionCwd = typeof cwd === "string" && cwd.trim().length
     ? cwd.trim()
@@ -4536,6 +4536,16 @@ function codexPermissionsStayWithinLane(
   return fileSystemPermissions
     ? codexFileSystemPermissionsStayWithinLane(managed, permissionCwd, fileSystemPermissions)
     : false;
+}
+
+function codexCommandApprovalStaysWithinLane(
+  managed: Pick<ManagedChatSession, "laneWorktreePath">,
+  cwd: string | null | undefined,
+  additionalPermissions: unknown,
+): boolean {
+  if (!codexApprovalPathStaysWithinLane(managed, cwd)) return false;
+  return additionalPermissions == null
+    || codexPermissionsStayWithinLane(managed, cwd, additionalPermissions);
 }
 
 type CodexCollaborationModePayload = {
@@ -9755,13 +9765,13 @@ export function createAgentChatService(args: {
       if (!codexPermissionsStayWithinLane(managed, cwd, pending.permissions)) return;
       runtime.sendResponse(pending.requestId, {
         permissions: pending.permissions ?? {},
-        scope: "session",
+        scope: "turn",
       });
     } else if (pending.kind === "command") {
       const cwd = typeof metadata.cwd === "string" && metadata.cwd.trim().length
         ? metadata.cwd
         : managed.laneWorktreePath;
-      if (!codexApprovalPathStaysWithinLane(managed, cwd)) return;
+      if (!codexCommandApprovalStaysWithinLane(managed, cwd, metadata.additionalPermissions)) return;
       runtime.sendResponse(pending.requestId, {
         decision: mapApprovalDecisionForCodex("accept"),
       });
@@ -14208,7 +14218,14 @@ export function createAgentChatService(args: {
     if (id == null) return;
 
     if (method === "item/commandExecution/requestApproval") {
-      const params = (payload.params as { itemId?: string; command?: string; cwd?: string; reason?: string; turnId?: string } | null) ?? {};
+      const params = (payload.params as {
+        itemId?: string;
+        command?: string;
+        cwd?: string;
+        reason?: string;
+        turnId?: string;
+        additionalPermissions?: Record<string, unknown> | null;
+      } | null) ?? {};
       const requestTurnId = normalizeCodexTurnId(params.turnId, runtime.activeTurnId ?? runtime.startedTurnId ?? null);
       if (isPlanningApprovalGuarded(managed, runtime, requestTurnId)) {
         emitChatEvent(managed, {
@@ -14222,7 +14239,10 @@ export function createAgentChatService(args: {
       const commandCwd = typeof params.cwd === "string" && params.cwd.trim().length
         ? params.cwd
         : managed.laneWorktreePath;
-      if (isSessionCodexFullAuto(managed.session) && codexApprovalPathStaysWithinLane(managed, commandCwd)) {
+      if (
+        isSessionCodexFullAuto(managed.session)
+        && codexCommandApprovalStaysWithinLane(managed, commandCwd, params.additionalPermissions)
+      ) {
         runtime.sendResponse(id, { decision: mapApprovalDecisionForCodex("accept") });
         return;
       }
@@ -14239,6 +14259,7 @@ export function createAgentChatService(args: {
         blocking: true,
         canProceedWithoutAnswer: false,
         providerMetadata: {
+          additionalPermissions: params.additionalPermissions ?? null,
           command: params.command ?? null,
           cwd: params.cwd ?? null,
           reason: params.reason ?? null,
@@ -14250,6 +14271,7 @@ export function createAgentChatService(args: {
         kind: "command",
         description,
         detail: {
+          additionalPermissions: params.additionalPermissions ?? null,
           command: params.command ?? null,
           cwd: params.cwd ?? null,
           reason: params.reason ?? null,
@@ -14342,7 +14364,7 @@ export function createAgentChatService(args: {
       ) {
         runtime.sendResponse(id, {
           permissions: params.permissions ?? {},
-          scope: "session",
+          scope: "turn",
         });
         return;
       }

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -14357,9 +14357,20 @@ export function createAgentChatService(args: {
           return;
         }
       }
+      if (isPlanningApprovalGuarded(managed, runtime, requestTurnId)) {
+        emitChatEvent(managed, {
+          type: "error",
+          message: buildPlanningApprovalViolation(description),
+          turnId: requestTurnId ?? undefined,
+        });
+        runtime.sendResponse(id, {
+          permissions: {},
+          scope: "turn",
+        });
+        return;
+      }
       if (
         isSessionCodexFullAuto(managed.session)
-        && !isPlanningApprovalGuarded(managed, runtime, requestTurnId)
         && codexPermissionsStayWithinLane(managed, params.cwd, params.permissions)
       ) {
         runtime.sendResponse(id, {

--- a/docs/features/chat/README.md
+++ b/docs/features/chat/README.md
@@ -140,8 +140,9 @@ render them, but neither one *runs* them.
   older policy, the service auto-responds to stale lane-confined
   command/file/permissions gates and clears existing approval cards. Permission
   auto-grants are turn-scoped and validate the request `cwd` and concrete
-  filesystem grant paths; escaped paths remain manual and the planner guard
-  still declines mutation requests from turns that started in plan mode.
+  filesystem grant paths; escaped or ambiguous whole-root grants remain manual
+  and the planner guard still declines mutation requests from turns that
+  started in plan mode.
 - **Steer queue.** Follow-up user messages during an active turn are
   queued (cap 10) with per-entry edit/cancel/dispatch. Default delivery
   happens on turn boundaries; for Claude SDK sessions the user can also

--- a/docs/features/chat/README.md
+++ b/docs/features/chat/README.md
@@ -138,7 +138,8 @@ render them, but neither one *runs* them.
   changes on thread/turn start. When a live Codex session is switched to
   Full Auto while an active turn still emits approval requests from its
   older policy, the service auto-responds to stale lane-confined
-  command/file/permissions gates and clears existing approval cards, while
+  command/file/permissions gates and clears existing approval cards. Permission
+  auto-grants validate the request `cwd` and concrete filesystem grant paths;
   escaped paths remain manual and the planner guard still declines mutation
   requests from turns that started in plan mode.
 - **Steer queue.** Follow-up user messages during an active turn are

--- a/docs/features/chat/README.md
+++ b/docs/features/chat/README.md
@@ -134,6 +134,12 @@ render them, but neither one *runs* them.
   and plan approvals from every provider collapse into
   `PendingInputRequest`. Renderer derives them via
   `derivePendingInputRequests()`.
+- **Codex permission switches.** Codex app-server receives approval/sandbox
+  changes on thread/turn start. When a live Codex session is switched to
+  Full Auto while an active turn still emits approval requests from its
+  older policy, the service auto-responds to stale command/file/permissions
+  gates and clears existing approval cards, while the planner guard still
+  declines mutation requests from turns that started in plan mode.
 - **Steer queue.** Follow-up user messages during an active turn are
   queued (cap 10) with per-entry edit/cancel/dispatch. Default delivery
   happens on turn boundaries; for Claude SDK sessions the user can also

--- a/docs/features/chat/README.md
+++ b/docs/features/chat/README.md
@@ -137,9 +137,10 @@ render them, but neither one *runs* them.
 - **Codex permission switches.** Codex app-server receives approval/sandbox
   changes on thread/turn start. When a live Codex session is switched to
   Full Auto while an active turn still emits approval requests from its
-  older policy, the service auto-responds to stale command/file/permissions
-  gates and clears existing approval cards, while the planner guard still
-  declines mutation requests from turns that started in plan mode.
+  older policy, the service auto-responds to stale lane-confined
+  command/file/permissions gates and clears existing approval cards, while
+  escaped paths remain manual and the planner guard still declines mutation
+  requests from turns that started in plan mode.
 - **Steer queue.** Follow-up user messages during an active turn are
   queued (cap 10) with per-entry edit/cancel/dispatch. Default delivery
   happens on turn boundaries; for Claude SDK sessions the user can also

--- a/docs/features/chat/README.md
+++ b/docs/features/chat/README.md
@@ -139,9 +139,9 @@ render them, but neither one *runs* them.
   Full Auto while an active turn still emits approval requests from its
   older policy, the service auto-responds to stale lane-confined
   command/file/permissions gates and clears existing approval cards. Permission
-  auto-grants validate the request `cwd` and concrete filesystem grant paths;
-  escaped paths remain manual and the planner guard still declines mutation
-  requests from turns that started in plan mode.
+  auto-grants are turn-scoped and validate the request `cwd` and concrete
+  filesystem grant paths; escaped paths remain manual and the planner guard
+  still declines mutation requests from turns that started in plan mode.
 - **Steer queue.** Follow-up user messages during an active turn are
   queued (cap 10) with per-entry edit/cancel/dispatch. Default delivery
   happens on turn boundaries; for Claude SDK sessions the user can also


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fcodex-permission-switching-1aa65108 num=634 -->
<p>
  <img src="https://ade-app.dev/images/ade-mark.svg" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fcodex-permission-switching-1aa65108&amp;pr=634">ade/codex-permission-switching-1aa65108 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=634">PR #634</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex sessions in **“full-auto”** mode now automatically resolve eligible pending runtime approvals (command execution, file-change, and permission approvals) and emit the corresponding resolution events.
  * Auto-approval is constrained to the session’s allowed lane scope; escaped/out-of-scope approvals are not auto-accepted.

* **Tests**
  * Added coverage for full-auto permission-mode switching during active turns, including correct acceptance decisions and emitted/omitted `approval_request` and resolution events.
  * Extended planner/guard scenarios to verify full-auto behavior without unintended approval requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables Codex sessions in **full-auto** mode to automatically resolve pending runtime approval requests (command execution, file-change, and permission grants) that are already queued, and to inline-approve new ones as they arrive — subject to lane-boundary validation.

- **New approval helpers:** `isSessionCodexFullAuto`, `codexApprovalPathStaysWithinLane`, `codexPermissionsStayWithinLane`, and `codexCommandApprovalStaysWithinLane` gate auto-approval on whether the request CWD and every concrete filesystem path resolves within the session lane root; escaped or out-of-scope requests remain queued for manual review.
- **Retroactive sweep:** `autoApprovePendingCodexRuntimeApprovals` (called from `updateSession`) iterates the in-memory approvals map and resolves eligible entries; it also gates on the existing `isPlanningApprovalGuarded` check so plan-mode sessions are unaffected.
- **Planning guard extended to permissions:** The `item/permissions/requestApproval` handler gains the same `isPlanningApprovalGuarded` early-exit that command and file-change handlers already had.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all three approval kinds carry correct lane-boundary checks in both the inline and retroactive paths, and the planning guard is properly applied throughout.

The lane-escape validation is thorough: `cwd`, `grantRoot`, and every concrete filesystem path are checked before any auto-accept is sent. The planning guard is now consistently applied to command, file-change, and permissions handlers. Test coverage is wide, including both in-lane acceptance and escape-blocking for all approval kinds in both live and retroactive modes.

The `autoApproveCodexRuntimeApproval` and surrounding helper functions in `agentChatService.ts` are the security-critical paths worth a careful second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/chat/agentChatService.ts | Adds full-auto inline approval, retroactive approval on permission switch, and planning guard for permissions requests. Lane-boundary checks are present for all three approval kinds. |
| apps/desktop/src/main/services/chat/agentChatService.test.ts | Adds three new test scenarios covering happy-path auto-approval on switch, escape blocking for all approval kinds in full-auto, and retroactive escape blocking on switch. In-lane retroactive approval of commands with `additionalPermissions` is not covered. |
| docs/features/chat/README.md | Documentation update describing the new Codex permission-switch auto-approval behaviour, turn scoping, and planner guard interaction. Accurate and consistent with implementation. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Service as agentChatService
    participant Runtime as CodexRuntime
    participant Approvals as runtime.approvals

    Note over Service,Runtime: Session starts in non-full-auto mode
    Runtime->>Service: item/commandExecution/requestApproval (in-lane)
    Service->>Approvals: "approvals.set(itemId, {kind:command})"
    Service->>User: emit approval_request event

    Runtime->>Service: item/fileChange/requestApproval (escaped)
    Service->>Approvals: "approvals.set(itemId, {kind:file_change})"
    Service->>User: emit approval_request event

    User->>Service: "updateSession(permissionMode=full-auto)"
    Service->>Service: isSessionCodexFullAuto() → true
    Service->>Service: autoApprovePendingCodexRuntimeApprovals()

    loop for each pending approval
        Service->>Service: isPlanningApprovalGuarded? → no
        alt in-lane command
            Service->>Service: codexCommandApprovalStaysWithinLane() → true
            Service->>Runtime: sendResponse(accept)
            Service->>Approvals: approvals.delete(itemId)
            Service->>User: emit pending_input_resolved(accepted)
        else escaped file_change
            Service->>Service: codexApprovalPathStaysWithinLane() → false
            Note over Service: skip — remains in approvals map
        end
    end

    Note over Service,Runtime: Session now in full-auto mode
    Runtime->>Service: item/permissions/requestApproval (in-lane)
    Service->>Service: codexPermissionsStayWithinLane() → true
    Service->>Runtime: "sendResponse(permissions, scope=turn)"
    Note over Service: bypasses approvals queue entirely
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Service as agentChatService
    participant Runtime as CodexRuntime
    participant Approvals as runtime.approvals

    Note over Service,Runtime: Session starts in non-full-auto mode
    Runtime->>Service: item/commandExecution/requestApproval (in-lane)
    Service->>Approvals: "approvals.set(itemId, {kind:command})"
    Service->>User: emit approval_request event

    Runtime->>Service: item/fileChange/requestApproval (escaped)
    Service->>Approvals: "approvals.set(itemId, {kind:file_change})"
    Service->>User: emit approval_request event

    User->>Service: "updateSession(permissionMode=full-auto)"
    Service->>Service: isSessionCodexFullAuto() → true
    Service->>Service: autoApprovePendingCodexRuntimeApprovals()

    loop for each pending approval
        Service->>Service: isPlanningApprovalGuarded? → no
        alt in-lane command
            Service->>Service: codexCommandApprovalStaysWithinLane() → true
            Service->>Runtime: sendResponse(accept)
            Service->>Approvals: approvals.delete(itemId)
            Service->>User: emit pending_input_resolved(accepted)
        else escaped file_change
            Service->>Service: codexApprovalPathStaysWithinLane() → false
            Note over Service: skip — remains in approvals map
        end
    end

    Note over Service,Runtime: Session now in full-auto mode
    Runtime->>Service: item/permissions/requestApproval (in-lane)
    Service->>Service: codexPermissionsStayWithinLane() → true
    Service->>Runtime: "sendResponse(permissions, scope=turn)"
    Note over Service: bypasses approvals queue entirely
```

</a>

<sub>Reviews (8): Last reviewed commit: ["Keep ambiguous Codex root grants manual"](https://github.com/arul28/ade/commit/438347160cc18dbc423f00225fe4647b71ca0714) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39164511)</sub>

<!-- /greptile_comment -->