### PR TITLE
release: changelog for v1.2.9

### DIFF
--- a/changelog/v1.2.9.mdx
+++ b/changelog/v1.2.9.mdx
@@ -1,0 +1,27 @@
+---
+title: "v1.2.9"
+description: "Release notes for ADE v1.2.9 - June 23, 2026"
+---
+
+v1.2.9 sharpens the chat and agent experience: an upgraded Claude integration with a real login flow, instant lane and chat naming that no longer stalls on a cold model, safer Codex full-auto permission switching, and a first-class record of who delegated what to whom in orchestration. Mobile gets snappier realtime sync.
+
+---
+
+## Desktop
+
+- **Claude chat upgrade and login.** ADE's Claude Agent SDK chat integration is upgraded with long-lived and background chat timeout handling and new chat surfaces, backed by regression coverage for prompt suggestions, task updates, and post-result stream tails. A dedicated Claude login prompt now handles stale auth signals so a lapsed session is fixed in one click instead of a silent failure.
+- **Instant lane and chat naming.** Auto-created lanes and chat/CLI sessions are named instantly with a deterministic name and quietly upgraded to an AI name in the background, removing the 10-second renderer race against a cold model that previously left half of them stuck on the fallback name. The session card shows an "auto-naming underway" status and warm-swaps the title when the AI name lands, and the deterministic name is smarter — it strips URLs and markdown (so "take a look at https://github…" becomes "github-org-repo").
+- **Codex full-auto permission switching.** Live switching of Codex full-auto approval is fixed: queued approvals are guarded by lane path, permission grants are validated before they apply, command-permission amendments are guarded, and project-root permission paths resolve safely.
+- **Orchestration delegation lineage.** Lead↔worker and lead↔validator spawns and results are now recorded as first-class manifest state — who spawned whom, with what brief and resolved model, and what came back — written only through the service's guarded patch path and denied to every role directly.
+- **Remote project tab branding.** Connecting to another machine's runtime and opening a remote project now shows the real project icon and the correct yellow machine accent instead of a blank folder glyph and a washed-out logo.
+- **Chat handoff and CLI help.** A cleaner chat-handoff launch UI and improved ADE chat CLI creation help make starting and moving work between sessions clearer.
+- **Files.** The Files tree refreshes on external directory changes, with better external opening and previews.
+- **More fixes.** Remote ADE Code clipboard paste and the ADE deeplink footer logo.
+
+---
+
+## iOS
+
+- **Faster realtime sync.** Mobile sync responsiveness is optimized end to end, including changeset-ack backpressure handling so a busy stream stays responsive instead of falling behind.
+- **Files.** Improved external file opening and previews carry over to the companion app.
+- **Notifications and widgets.** Mobile notification cleanup plus widget documentation and PR-navigation fixes.

--- a/docs.json
+++ b/docs.json
@@ -179,6 +179,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.9",
               "changelog/v1.2.8",
               "changelog/v1.2.7",
               "changelog/v1.2.6",


### PR DESCRIPTION
Changelog page for **v1.2.9** (desktop). Adds `changelog/v1.2.9.mdx` and registers it in `docs.json`.

`CHANGELOG.md` and `changelog/index.mdx` intentionally stay at v1.2.8 here — `validate-docs` derives "latest" from the highest git tag, so they're bumped in a post-tag follow-up. The `v1.2.9` tag is cut on this commit once it lands on `main` and `ci-pass` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `changelog/v1.2.9.mdx` with release notes for the v1.2.9 desktop and iOS builds, and registers the new page as the top entry in the changelog navigation group in `docs.json`. The file follows the same frontmatter schema and two-section (`## Desktop` / `## iOS`) structure used by every prior changelog, and the navigation ordering is correct.

- **`changelog/v1.2.9.mdx`**: New release notes page covering Claude chat/auth improvements, instant lane naming, Codex full-auto permission fixes, orchestration delegation lineage, and mobile sync optimizations.
- **`docs.json`**: Single-line addition inserting `"changelog/v1.2.9"` immediately above `"changelog/v1.2.8"` in the changelog pages list.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely additive documentation change with no logic or config impact.

Two files changed: a new MDX changelog page and a single navigation entry in docs.json. The new file matches the established frontmatter schema and section structure exactly, and the docs.json ordering places v1.2.9 correctly above v1.2.8. No code, no migrations, no logic paths affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| changelog/v1.2.9.mdx | New v1.2.9 release notes page; follows the same frontmatter schema and section structure as earlier changelogs with no issues. |
| docs.json | Registers changelog/v1.2.9 as the first entry in the changelog navigation group, correctly ordered above v1.2.8. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["docs.json\n(changelog navigation)"] --> B["changelog/v1.2.9.mdx\n(new)"]
    A --> C["changelog/v1.2.8.mdx"]
    A --> D["changelog/v1.2.7.mdx"]
    A --> E["... older entries"]
    B --> F["## Desktop\nClaude chat, lane naming,\nCodex permissions,\norchestration lineage, ..."]
    B --> G["## iOS\nFaster realtime sync,\nFiles, Notifications"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["docs.json\n(changelog navigation)"] --> B["changelog/v1.2.9.mdx\n(new)"]
    A --> C["changelog/v1.2.8.mdx"]
    A --> D["changelog/v1.2.7.mdx"]
    A --> E["... older entries"]
    B --> F["## Desktop\nClaude chat, lane naming,\nCodex permissions,\norchestration lineage, ..."]
    B --> G["## iOS\nFaster realtime sync,\nFiles, Notifications"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["release: changelog for v1.2.9"](https://github.com/arul28/ade/commit/fd8aa537510dc9e99b1f8407dde72a89523d373f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39234264)</sub>

<!-- /greptile_comment -->