### PR TITLE
release: sync CHANGELOG.md + changelog index for v1.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.9] - 2026-06-23
+
+### Added
+
+- Claude chat: upgraded Agent SDK integration with long-lived and background chat timeout handling and new chat surfaces, plus a dedicated Claude login prompt that recovers stale auth in one click.
+- Orchestration delegation lineage: lead↔worker and lead↔validator spawns and results are recorded as first-class manifest state — who spawned whom, with what brief and resolved model, and what came back.
+
+### Changed
+
+- Instant lane and chat/CLI naming: sessions get a deterministic name immediately and are upgraded to an AI name in the background, removing the 10-second race that left many stuck on the fallback name; deterministic names now strip URLs and markdown.
+- Codex full-auto permission switching is fixed and hardened: queued approvals are guarded by lane path, grants are validated before they apply, and project-root permission paths resolve safely.
+- Remote project tabs show the real project icon and the correct yellow machine accent instead of a blank folder glyph.
+- Faster mobile realtime sync, including changeset-ack backpressure handling so a busy stream stays responsive.
+
+### Fixed
+
+- Files tree refreshes on external directory changes, with better external opening and previews; remote ADE Code clipboard paste; the ADE deeplink footer logo; and mobile notification, widget, and PR-navigation fixes.
+
 ## [1.2.8] - 2026-06-19
 
 ### Added
@@ -448,7 +466,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.8...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.9...HEAD
+[1.2.9]: https://github.com/arul28/ADE/compare/v1.2.8...v1.2.9
 [1.2.8]: https://github.com/arul28/ADE/compare/v1.2.7...v1.2.8
 [1.2.7]: https://github.com/arul28/ADE/compare/v1.2.6...v1.2.7
 [1.2.6]: https://github.com/arul28/ADE/compare/v1.2.5...v1.2.6

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.8">
-  v1.2.8 - PR merge and timeline reach GitHub parity across desktop and iOS, orchestration planning becomes a deterministic approval-gated flow, sync gets faster and more resilient, and a security and correctness sweep hardens orchestration, persistence, git, and the iOS data layer.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.9">
+  v1.2.9 - an upgraded Claude integration with a real login flow, instant lane and chat naming, safer Codex full-auto permission switching, first-class orchestration delegation lineage, and snappier mobile realtime sync.
 </Card>


### PR DESCRIPTION
Post-tag changelog sync for **v1.2.9**. Bumps `CHANGELOG.md` (new `## [1.2.9]` entry + compare link-ref, `[Unreleased]` retargeted to `v1.2.9...HEAD`) and the `changelog/index.mdx` latest-release card to v1.2.9.

Required because `validate-docs` derives "latest" from the highest git tag — now v1.2.9 — so main goes red until these match. The `changelog/v1.2.9.mdx` page itself already landed in #640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR syncs the changelog docs for the v1.2.9 release. The main changes are:

- Adds a new `1.2.9` section to `CHANGELOG.md`.
- Retargets the `Unreleased` compare link to start from `v1.2.9`.
- Updates the changelog index card to point at `/changelog/v1.2.9`.

<h3>Confidence Score: 3/5</h3>

The docs-only changes are straightforward, but validation depends on the release tag being available in the checkout.

The changed files are limited to changelog metadata, with one workflow-sensitive validation condition remaining around tag availability.

CHANGELOG.md

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The latest-release Card was repointed to /changelog/v1.2.9.
- The CHANGELOG top release was updated to 1.2.9 with an Unreleased section and compare ranges v1.2.8...v1.2.9.
- Docs validation completed successfully for 167 files.

<a href="https://app.greptile.com/trex/runs/11971276/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACHANGELOG.md%3A10%0A**Tag-dependent%20validation%20failure**%0A%0AThis%20release%20heading%20now%20advertises%20%601.2.9%60%2C%20but%20%60validate-docs%60%20derives%20the%20latest%20release%20from%20the%20local%20git%20tags.%20In%20a%20checkout%20where%20%60v1.2.9%60%20has%20not%20been%20fetched%20yet%2C%20the%20validator%20still%20sees%20%60v1.2.8%60%20as%20latest%20and%20fails%20with%20%60CHANGELOG.md%3A%20top%20release%201.2.9%20does%20not%20match%20latest%20git%20tag%20v1.2.8%60.%20Since%20this%20PR%20is%20meant%20to%20make%20docs%20validation%20pass%2C%20the%20workflow%20needs%20to%20ensure%20the%20%60v1.2.9%60%20tag%20is%20available%20before%20this%20change%20is%20validated%20or%20merged.%0A%0A&repo=arul28%2Fade&pr=641&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
CHANGELOG.md:10
**Tag-dependent validation failure**

This release heading now advertises `1.2.9`, but `validate-docs` derives the latest release from the local git tags. In a checkout where `v1.2.9` has not been fetched yet, the validator still sees `v1.2.8` as latest and fails with `CHANGELOG.md: top release 1.2.9 does not match latest git tag v1.2.8`. Since this PR is meant to make docs validation pass, the workflow needs to ensure the `v1.2.9` tag is available before this change is validated or merged.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["release: sync CHANGELOG.md + changelog i..."](https://github.com/arul28/ade/commit/d7070ead5a4d7333af3d966beaf4cdabe3c2258e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39235894)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->