### PR TITLE
release: fold #643 + lane worktree cleanup into v1.2.9 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Instant lane and chat/CLI naming: sessions get a deterministic name immediately and are upgraded to an AI name in the background, removing the 10-second race that left many stuck on the fallback name; deterministic names now strip URLs and markdown.
 - Codex full-auto permission switching is fixed and hardened: queued approvals are guarded by lane path, grants are validated before they apply, and project-root permission paths resolve safely.
 - Remote project tabs show the real project icon and the correct yellow machine accent instead of a blank folder glyph.
+- Settings General tab reorganized: GitHub, Linear, voice input, launch prompts, completion sound, PR transcripts, project files, and environment are consolidated under branded section headers and the separate Integrations tab is removed; background-job reasoning effort is now independent, with refreshed web-renderer UX.
 - Faster mobile realtime sync, including changeset-ack backpressure handling so a busy stream stays responsive.
 
 ### Fixed
 
-- Files tree refreshes on external directory changes, with better external opening and previews; remote ADE Code clipboard paste; the ADE deeplink footer logo; and mobile notification, widget, and PR-navigation fixes.
+- Stale lane worktree cleanup is recorded and safely retried after a delete; Files tree refreshes on external directory changes, with better external opening and previews; remote ADE Code clipboard paste; the ADE deeplink footer logo; and mobile notification, widget, and PR-navigation fixes.
 
 ## [1.2.8] - 2026-06-19
 

--- a/changelog/v1.2.9.mdx
+++ b/changelog/v1.2.9.mdx
@@ -14,9 +14,10 @@ v1.2.9 sharpens the chat and agent experience: an upgraded Claude integration wi
 - **Codex full-auto permission switching.** Live switching of Codex full-auto approval is fixed: queued approvals are guarded by lane path, permission grants are validated before they apply, command-permission amendments are guarded, and project-root permission paths resolve safely.
 - **Orchestration delegation lineage.** Lead↔worker and lead↔validator spawns and results are now recorded as first-class manifest state — who spawned whom, with what brief and resolved model, and what came back — written only through the service's guarded patch path and denied to every role directly.
 - **Remote project tab branding.** Connecting to another machine's runtime and opening a remote project now shows the real project icon and the correct yellow machine accent instead of a blank folder glyph and a washed-out logo.
+- **Settings, reorganized.** The General tab now gathers GitHub, Linear, voice input, launch prompts, the completion sound, PR transcripts, project files, and environment under branded section headers, retiring the separate Integrations tab. Background-job reasoning effort is now set independently, alongside refreshed web-renderer UX.
 - **Chat handoff and CLI help.** A cleaner chat-handoff launch UI and improved ADE chat CLI creation help make starting and moving work between sessions clearer.
 - **Files.** The Files tree refreshes on external directory changes, with better external opening and previews.
-- **More fixes.** Remote ADE Code clipboard paste and the ADE deeplink footer logo.
+- **More fixes.** Stale lane worktree cleanup is now recorded and safely retried after a delete, plus remote ADE Code clipboard paste and the ADE deeplink footer logo.
 
 ---
 


### PR DESCRIPTION
Two desktop changes landed on `main` after the initial v1.2.9 changelog and should ship in v1.2.9:

- **#643** — Settings General-tab reorganization + web-renderer UX.
- **Stale lane worktree cleanup** — recorded and safely retried after delete.

This folds both into `changelog/v1.2.9.mdx` and `CHANGELOG.md`. After this lands and `ci-pass` is green, the `v1.2.9` tag is re-pointed to this commit (no release object exists yet) and the release runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the v1.2.9 release notes with two additional desktop changes. The main changes are:

- Adds the Settings General-tab reorganization and web-renderer UX updates.
- Notes that the separate Integrations tab was retired into General.
- Adds stale lane worktree cleanup recording and safe retry behavior.
- Mirrors the release-note updates in both `CHANGELOG.md` and `changelog/v1.2.9.mdx`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the changes are limited to release-note text.

The diff only updates changelog documentation and does not alter runtime behavior, build logic, or persisted data.

<sub>Reviews (1): Last reviewed commit: ["release: fold #643 + lane worktree clean..."](https://github.com/arul28/ade/commit/418e490649e6fe5a915cc98866ab9536becade75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39349515)</sub>

<!-- /greptile_comment -->