### PR TITLE
Codex Cli Start Delay

### DIFF
--- a/apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts
@@ -303,6 +303,14 @@ describe("buildTrackedCliStartupCommand", () => {
       }
     });
 
+    it("keeps empty Codex CLI launches waiting for the next user task", () => {
+      const launch = buildTrackedCliLaunchCommand({ provider: "codex", permissionMode: "default" });
+
+      expect(launch.initialInput).toContain("ADE session guidance");
+      expect(launch.initialInput).toContain("wait for the user's next instruction before taking action");
+      expect(launch.initialInput).not.toContain("User prompt:");
+    });
+
     it("passes no extra flags for config-toml", () => {
       const command = buildTrackedCliStartupCommand({ provider: "codex", permissionMode: "config-toml" });
       expect(command).toContain("codex --no-alt-screen");
@@ -356,6 +364,8 @@ describe("buildTrackedCliStartupCommand", () => {
       ]));
       expect(launch.args.join("\n")).not.toContain("ADE session guidance");
       expect(launch.initialInput).toContain("ADE session guidance");
+      expect(launch.initialInput).toContain("Start working on that user prompt immediately.");
+      expect(launch.initialInput).not.toContain("wait for the user's next instruction before taking action");
       expect(launch.initialInput).toContain("User prompt:");
       expect(launch.initialInput).toContain("Fix the failing Work tests.");
       expect(launch.startupCommand).toContain("model_reasoning_effort");

--- a/apps/desktop/src/shared/cliLaunch.ts
+++ b/apps/desktop/src/shared/cliLaunch.ts
@@ -256,9 +256,20 @@ export function defaultTrackedCliStartupCommand(provider: CliProvider): string {
   return "claude";
 }
 
-function workTabCliPreamblePrompt(skillRoots: readonly string[]): string {
+function workTabCliPreamblePrompt(skillRoots: readonly string[], hasInitialPrompt = false): string {
+  const launchInstruction = hasInitialPrompt
+    ? [
+        "ADE session guidance. Treat this as operating guidance for the CLI session",
+        "and keep it in mind while handling the user prompt below.",
+        "Start working on that user prompt immediately.",
+      ].join(" ")
+    : [
+        "ADE session guidance. Treat this as operating guidance for the CLI session,",
+        "keep it in mind for future user messages, and wait for the user's next",
+        "instruction before taking action.",
+      ].join(" ");
   return [
-    "ADE session guidance. Treat this as operating guidance for the CLI session, keep it in mind for future user messages, and wait for the user's next instruction before taking action.",
+    launchInstruction,
     "",
     buildAdeCliInlineGuidance(skillRoots),
   ].join("\n");
@@ -524,7 +535,7 @@ function claudeSessionSettingsFlags(
 }
 
 function workTabCliPrompt(initialPrompt: string | null, skillRoots: readonly string[]): string {
-  const preamble = workTabCliPreamblePrompt(skillRoots);
+  const preamble = workTabCliPreamblePrompt(skillRoots, Boolean(initialPrompt));
   if (!initialPrompt) return preamble;
   return [
     preamble,


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fsee-screenshot-after-submitting-emssage-749c4815 num=647 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fsee-screenshot-after-submitting-emssage-749c4815&amp;pr=647">ade/see-screenshot-after-submitting-emssage-749c4815 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=647">PR #647</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launch instructions so they now adapt to whether a task prompt was provided.
  * When a prompt is present, the app now tells the CLI to begin work right away.
  * When no prompt is provided, the app now waits for the next user instruction before taking action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates CLI launch guidance for sessions with and without an initial prompt. The main changes are:

- Adds separate ADE preamble text for idle launches and prompted launches.
- Tells prompted CLI sessions to start on the supplied user prompt immediately.
- Adds Codex tests for empty launches and initial-prompt launches.

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to CLI launch guidance and accompanying tests, with no accepted correctness concerns.

The modified behavior is covered by targeted tests for empty and initial-prompt launches, and no issues were identified in the changed files.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a test with a user prompt block present and observed that the base launch emitted wait guidance.
- Verified that the head launch preserves wait guidance for an empty launch and switches a prompted launch to immediate-start guidance.

<a href="https://app.greptile.com/trex/runs/12195954/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Codex CLI initial prompt handling"](https://github.com/arul28/ade/commit/9901ae71930b616113fd3cd42baa667cfbf93525) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39643775)</sub>

<!-- /greptile_comment -->