### PR TITLE
Fix Mobile App Crashes

### DIFF
--- a/apps/ios/ADE/Services/Database.swift
+++ b/apps/ios/ADE/Services/Database.swift
@@ -3335,7 +3335,9 @@ final class DatabaseService {
     let userInfo: [AnyHashable: Any]? = normalizedTables.isEmpty
       ? nil
       : [ADEDatabaseChangeNotification.touchedTablesUserInfoKey: normalizedTables]
-    NotificationCenter.default.post(name: .adeDatabaseDidChange, object: nil, userInfo: userInfo)
+    DispatchQueue.main.async {
+      NotificationCenter.default.post(name: .adeDatabaseDidChange, object: nil, userInfo: userInfo)
+    }
   }
 
   private func decodeJson<T: Decodable>(_ raw: String?, as type: T.Type) -> T? {

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -9423,9 +9423,7 @@ extension SyncService {
 
     activeSessions = allAgents
     awaitingInputSessionsCount = awaitingInputCount
-    runningChatSessionCount = sessions.filter { session in
-      session.status == "running" && (session.toolType?.contains("chat") == true)
-    }.count
+    runningChatSessionCount = runningAgents.count
     idleSessionsCount = idleCount
 
     scheduleWorkspaceSnapshotWrite()
@@ -9568,6 +9566,7 @@ private final class SyncTailnetProbe {
       let complete: (ProbeResult) -> Void = { result in
         guard !completed else { return }
         completed = true
+        connection.stateUpdateHandler = nil
         connection.cancel()
         continuation.resume(returning: result)
       }
@@ -9575,7 +9574,9 @@ private final class SyncTailnetProbe {
         switch state {
         case .ready:
           complete(.reachable)
-        case .waiting(let error), .failed(let error):
+        case .waiting:
+          break
+        case .failed(let error):
           complete(Self.probeResult(for: error))
         case .cancelled:
           complete(.unreachable)

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -410,6 +410,27 @@ func syncConnectPortCandidates(primaryPort: Int, addresses: [String]) -> [Int] {
     .filter { seen.insert($0).inserted }
 }
 
+struct SyncConnectionEndpointAttempt: Equatable {
+  var address: String
+  var port: Int
+}
+
+func syncConnectionEndpointAttempts(
+  addresses: [String],
+  ports: [Int]
+) -> [SyncConnectionEndpointAttempt] {
+  guard let primaryPort = ports.first else { return [] }
+  let primaryAttempts = addresses.map { address in
+    SyncConnectionEndpointAttempt(address: address, port: primaryPort)
+  }
+  let fallbackAttempts = ports.dropFirst().flatMap { port in
+    addresses.map { address in
+      SyncConnectionEndpointAttempt(address: address, port: port)
+    }
+  }
+  return primaryAttempts + fallbackAttempts
+}
+
 func syncWebSocketURLString(host rawHost: String, port defaultPort: Int) -> String? {
   guard let endpoint = syncParseRouteEndpoint(rawHost) else { return nil }
   let port = endpoint.port ?? defaultPort
@@ -1404,6 +1425,10 @@ final class SyncService: ObservableObject {
   /// Chat sessions currently waiting on user input. Surfaced as a count chip
   /// instead of a roster row so old "awaiting" zombies don't pile up visually.
   @Published private(set) var awaitingInputSessionsCount: Int = 0
+
+  /// Chat sessions currently reported as running. Kept as published state so
+  /// SwiftUI tab rendering never synchronously enters SQLite from `body`.
+  @Published private(set) var runningChatSessionCount: Int = 0
 
   /// Chat sessions paused / idle (connected but not producing output). Counted
   /// for context but never listed.
@@ -3289,32 +3314,27 @@ final class SyncService: ObservableObject {
       guard !addressCandidates.isEmpty else {
         throw noConnectableAddressError()
       }
-      for candidate in addressCandidates {
+      for attempt in syncConnectionEndpointAttempts(addresses: addressCandidates, ports: portCandidates) {
         guard isCurrentConnectAttempt(connectAttemptGeneration) else {
           throw CancellationError()
         }
-        let kind = addressCandidateKind(candidate, profile: nil, explicitTailscaleAddress: normalizedTailscaleAddress)
-        for candidatePort in portCandidates {
-          syncConnectLog.info("ADE_SYNC_TRACE pair attempt host=\(candidate, privacy: .public) port=\(candidatePort) kind=\(kind, privacy: .public)")
-          do {
-            try await openSocket(
-              host: candidate,
-              port: candidatePort,
-              connectAttemptGeneration: connectAttemptGeneration
-            )
-            syncConnectLog.info("ADE_SYNC_TRACE pair success host=\(candidate, privacy: .public) port=\(candidatePort)")
-            openedAddress = candidate
-            openedPort = candidatePort
-            break
-          } catch {
-            syncConnectLog.info("ADE_SYNC_TRACE pair failure host=\(candidate, privacy: .public) port=\(candidatePort) error=\(syncLogErrorSummary(error), privacy: .public)")
-            lastOpenError = error
-            teardownSocket()
-            continue
-          }
-        }
-        if openedAddress != nil {
+        let kind = addressCandidateKind(attempt.address, profile: nil, explicitTailscaleAddress: normalizedTailscaleAddress)
+        syncConnectLog.info("ADE_SYNC_TRACE pair attempt host=\(attempt.address, privacy: .public) port=\(attempt.port) kind=\(kind, privacy: .public)")
+        do {
+          try await openSocket(
+            host: attempt.address,
+            port: attempt.port,
+            connectAttemptGeneration: connectAttemptGeneration
+          )
+          syncConnectLog.info("ADE_SYNC_TRACE pair success host=\(attempt.address, privacy: .public) port=\(attempt.port)")
+          openedAddress = attempt.address
+          openedPort = attempt.port
           break
+        } catch {
+          syncConnectLog.info("ADE_SYNC_TRACE pair failure host=\(attempt.address, privacy: .public) port=\(attempt.port) error=\(syncLogErrorSummary(error), privacy: .public)")
+          lastOpenError = error
+          teardownSocket()
+          continue
         }
       }
       guard let preferredAddress = openedAddress, let preferredPort = openedPort else {
@@ -3873,12 +3893,6 @@ final class SyncService: ObservableObject {
 
   func stopProcess(laneId: String, processId: String) async throws {
     _ = try await sendCommand(action: "processes.stop", args: ["laneId": laneId, "processId": processId])
-  }
-
-  var runningChatSessionCount: Int {
-    database.fetchSessions().filter { session in
-      session.status == "running" && (session.toolType?.contains("chat") == true)
-    }.count
   }
 
   func fetchComputerUseArtifacts(ownerKind: String, ownerId: String) async throws -> [ComputerUseArtifactSummary] {
@@ -6809,48 +6823,46 @@ final class SyncService: ObservableObject {
       )
     }
 
-    for address in racedAddresses {
+    for attempt in syncConnectionEndpointAttempts(addresses: racedAddresses, ports: portCandidates) {
       guard isCurrentConnectAttempt(connectAttemptGeneration) else {
         throw CancellationError()
       }
-      let kind = addressCandidateKind(address, profile: profile, explicitTailscaleAddress: nil)
-      for candidatePort in portCandidates {
-        syncConnectLog.info("ADE_SYNC_TRACE reconnect attempt host=\(address, privacy: .public) port=\(candidatePort) kind=\(kind, privacy: .public)")
-        do {
-          try await openSocket(
-            host: address,
-            port: candidatePort,
-            connectAttemptGeneration: connectAttemptGeneration,
-            publishConnecting: publishConnecting
-          )
-          try await hello(
-            host: address,
-            port: candidatePort,
-            token: token,
-            authKind: profile.authKind,
-            pairedDeviceId: profile.pairedDeviceId,
-            expectedHostIdentity: profile.hostIdentity,
-            connectAttemptGeneration: connectAttemptGeneration
-          )
-          guard isCurrentConnectAttempt(connectAttemptGeneration) else {
-            throw CancellationError()
-          }
-          syncConnectLog.info("ADE_SYNC_TRACE reconnect success host=\(address, privacy: .public) port=\(candidatePort)")
-          return (host: address, port: candidatePort)
-        } catch {
-          let reconnectError = errorByMarkingAmbiguousRouteAuthFailure(error, attemptedAddress: address)
-          syncConnectLog.info("ADE_SYNC_TRACE reconnect failure host=\(address, privacy: .public) port=\(candidatePort) error=\(syncLogErrorSummary(reconnectError), privacy: .public)")
-          lastFailure = reconnectError
-          if shouldInvalidateSavedPairing(for: reconnectError) {
-            forgetHost()
-            throw reconnectError
-          }
-          // Tear down this attempt's socket and keep iterating through the
-          // remaining ports and addresses. Only surface an error if every
-          // candidate fails.
-          teardownSocket()
-          continue
+      let kind = addressCandidateKind(attempt.address, profile: profile, explicitTailscaleAddress: nil)
+      syncConnectLog.info("ADE_SYNC_TRACE reconnect attempt host=\(attempt.address, privacy: .public) port=\(attempt.port) kind=\(kind, privacy: .public)")
+      do {
+        try await openSocket(
+          host: attempt.address,
+          port: attempt.port,
+          connectAttemptGeneration: connectAttemptGeneration,
+          publishConnecting: publishConnecting
+        )
+        try await hello(
+          host: attempt.address,
+          port: attempt.port,
+          token: token,
+          authKind: profile.authKind,
+          pairedDeviceId: profile.pairedDeviceId,
+          expectedHostIdentity: profile.hostIdentity,
+          connectAttemptGeneration: connectAttemptGeneration
+        )
+        guard isCurrentConnectAttempt(connectAttemptGeneration) else {
+          throw CancellationError()
         }
+        syncConnectLog.info("ADE_SYNC_TRACE reconnect success host=\(attempt.address, privacy: .public) port=\(attempt.port)")
+        return (host: attempt.address, port: attempt.port)
+      } catch {
+        let reconnectError = errorByMarkingAmbiguousRouteAuthFailure(error, attemptedAddress: attempt.address)
+        syncConnectLog.info("ADE_SYNC_TRACE reconnect failure host=\(attempt.address, privacy: .public) port=\(attempt.port) error=\(syncLogErrorSummary(reconnectError), privacy: .public)")
+        lastFailure = reconnectError
+        if shouldInvalidateSavedPairing(for: reconnectError) {
+          forgetHost()
+          throw reconnectError
+        }
+        // Tear down this attempt's socket and keep iterating through the
+        // remaining ports and addresses. Only surface an error if every
+        // candidate fails.
+        teardownSocket()
+        continue
       }
     }
 
@@ -9411,6 +9423,9 @@ extension SyncService {
 
     activeSessions = allAgents
     awaitingInputSessionsCount = awaitingInputCount
+    runningChatSessionCount = sessions.filter { session in
+      session.status == "running" && (session.toolType?.contains("chat") == true)
+    }.count
     idleSessionsCount = idleCount
 
     scheduleWorkspaceSnapshotWrite()
@@ -9508,8 +9523,9 @@ private final class SyncTailnetProbe {
     for host in SyncTailnetDiscovery.hostCandidates {
       for port in SyncTailnetDiscovery.portCandidates {
         guard !Task.isCancelled else { return }
-        let canConnect = await probe(host: host, port: port)
-        guard canConnect else { continue }
+        let result = await probe(host: host, port: port)
+        guard result != .unresolvedHost else { break }
+        guard result == .reachable else { continue }
         let key = "\(host):\(port)"
         let routeHost = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let isTailnetRoute = syncIsTailnetDiscoveryHost(routeHost)
@@ -9534,8 +9550,14 @@ private final class SyncTailnetProbe {
     onHostsChanged?(Array(nextHosts.values))
   }
 
-  private func probe(host: String, port: Int) async -> Bool {
-    guard let endpointPort = NWEndpoint.Port(rawValue: UInt16(port)) else { return false }
+  private enum ProbeResult: Equatable {
+    case reachable
+    case unreachable
+    case unresolvedHost
+  }
+
+  private func probe(host: String, port: Int) async -> ProbeResult {
+    guard let endpointPort = NWEndpoint.Port(rawValue: UInt16(port)) else { return .unreachable }
     return await withCheckedContinuation { continuation in
       let connection = NWConnection(
         host: NWEndpoint.Host(host),
@@ -9543,7 +9565,7 @@ private final class SyncTailnetProbe {
         using: .tcp
       )
       var completed = false
-      let complete: (Bool) -> Void = { result in
+      let complete: (ProbeResult) -> Void = { result in
         guard !completed else { return }
         completed = true
         connection.cancel()
@@ -9552,9 +9574,11 @@ private final class SyncTailnetProbe {
       connection.stateUpdateHandler = { state in
         switch state {
         case .ready:
-          complete(true)
-        case .failed, .cancelled:
-          complete(false)
+          complete(.reachable)
+        case .waiting(let error), .failed(let error):
+          complete(Self.probeResult(for: error))
+        case .cancelled:
+          complete(.unreachable)
         default:
           break
         }
@@ -9563,8 +9587,17 @@ private final class SyncTailnetProbe {
       connectionQueue.asyncAfter(
         deadline: .now() + .nanoseconds(Int(SyncTailnetDiscoveryTiming.probeTimeoutNanoseconds))
       ) {
-        complete(false)
+        complete(.unreachable)
       }
+    }
+  }
+
+  private static func probeResult(for error: NWError) -> ProbeResult {
+    switch error {
+    case .dns:
+      return .unresolvedHost
+    default:
+      return .unreachable
     }
   }
 }

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -9336,6 +9336,7 @@ extension SyncService {
     // Completed / ended sessions are dropped since they're terminal.
     var allAgents: [AgentSnapshot] = []
     var runningAgents: [AgentSnapshot] = []
+    var runningChatCount = 0
     var awaitingInputCount = 0
     var idleCount = 0
 
@@ -9363,6 +9364,7 @@ extension SyncService {
       let isEndedRuntime = runtime == "exited" || runtime == "killed" || runtime == "stopped"
 
       if isEndedRuntime && !isFailedStatus && !isAwaiting { continue }
+      if isRunningRuntime && !isFailedStatus { runningChatCount += 1 }
 
       let started = Self.parseIso8601(session.startedAt) ?? now
       // For active sessions there is no `endedAt`. Use the chat summary's
@@ -9423,7 +9425,7 @@ extension SyncService {
 
     activeSessions = allAgents
     awaitingInputSessionsCount = awaitingInputCount
-    runningChatSessionCount = runningAgents.count
+    runningChatSessionCount = runningChatCount
     idleSessionsCount = idleCount
 
     scheduleWorkspaceSnapshotWrite()

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -8255,6 +8255,12 @@ final class ADETests: XCTestCase {
     ])
 
     let service = SyncService(database: database)
+    service.cacheChatSummary(makeAgentChatSessionSummary(
+      sessionId: "running-chat",
+      laneId: "lane-1",
+      status: "active",
+      lastActivityAt: "2026-04-20T00:00:00.000Z"
+    ))
     service.refreshActiveSessionsAndSnapshot()
 
     let running = try XCTUnwrap(service.activeSessions.first(where: { $0.sessionId == "running-chat" }))

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -1325,6 +1325,25 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(SyncTailnetDiscovery.portCandidates, SyncDirectHostPorts.portCandidates)
   }
 
+  func testSyncConnectionEndpointAttemptsTryPrimaryPortForEveryAddressFirst() {
+    let addresses = [
+      "aruls-mac-studio.tail7497a6.ts.net",
+      "100.75.20.63",
+      "192.168.1.240",
+    ]
+    let ports = syncConnectPortCandidates(primaryPort: 8876, addresses: addresses)
+
+    XCTAssertEqual(
+      Array(syncConnectionEndpointAttempts(addresses: addresses, ports: ports).prefix(4)),
+      [
+        SyncConnectionEndpointAttempt(address: "aruls-mac-studio.tail7497a6.ts.net", port: 8876),
+        SyncConnectionEndpointAttempt(address: "100.75.20.63", port: 8876),
+        SyncConnectionEndpointAttempt(address: "192.168.1.240", port: 8876),
+        SyncConnectionEndpointAttempt(address: "aruls-mac-studio.tail7497a6.ts.net", port: 8787),
+      ]
+    )
+  }
+
   func testSyncRoamDecisionUsesSavedTailnetWhenWifiDrops() {
     XCTAssertTrue(
       syncShouldRoamToTailnet(
@@ -3655,6 +3674,64 @@ final class ADETests: XCTestCase {
     database.close()
   }
 
+  func testDatabaseChangeNotificationDoesNotDeadlockMainObserverReadingDatabase() throws {
+    let database = DatabaseService(baseURL: makeTemporaryDirectory(), bootstrapSQL: """
+      create table if not exists notify_deadlock_rows (
+        id text primary key,
+        value text
+      );
+    """)
+    XCTAssertNil(database.initializationError)
+
+    let tableName = "notify_deadlock_rows"
+    let applyReturned = expectation(description: "applyChanges returned")
+    let notificationDelivered = expectation(description: "database change notification delivered")
+    let applyFailure = ManagedAtomicErrorBox()
+    let initialVersion = database.currentDbVersion()
+
+    let observer = NotificationCenter.default.addObserver(
+      forName: .adeDatabaseDidChange,
+      object: nil,
+      queue: .main
+    ) { notification in
+      let touchedTables = Set(
+        (notification.userInfo?[ADEDatabaseChangeNotification.touchedTablesUserInfoKey] as? [String] ?? [])
+          .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+      )
+      guard touchedTables.contains(tableName) else { return }
+      _ = database.currentDbVersion()
+      notificationDelivered.fulfill()
+    }
+    defer {
+      NotificationCenter.default.removeObserver(observer)
+      database.close()
+    }
+
+    DispatchQueue.global(qos: .userInitiated).async {
+      do {
+        _ = try database.applyChanges([
+          CrsqlChangeRow(
+            table: tableName,
+            pk: .string("row-1"),
+            cid: "value",
+            val: .string("synced"),
+            colVersion: 1,
+            dbVersion: initialVersion + 1,
+            siteId: "b00e9b92c864a27958669c1595fcb2c3",
+            cl: 1,
+            seq: 0
+          )
+        ])
+      } catch {
+        applyFailure.store(error)
+      }
+      applyReturned.fulfill()
+    }
+
+    wait(for: [applyReturned, notificationDelivered], timeout: 5)
+    XCTAssertNil(applyFailure.value)
+  }
+
   func testDatabaseAppliesPackedTextPrimaryKeysFromDesktopChanges() throws {
     let database = makeDatabase(baseURL: makeTemporaryDirectory())
     XCTAssertNil(database.initializationError)
@@ -4576,15 +4653,20 @@ final class ADETests: XCTestCase {
     defer { database.close() }
 
     try insertHydrationProjectGraph(into: database)
-    var notificationCount = 0
-    let token = NotificationCenter.default.addObserver(
+    let setupNotificationsDrained = expectation(description: "setup lane snapshot notifications drained")
+    DispatchQueue.main.async { setupNotificationsDrained.fulfill() }
+    wait(for: [setupNotificationsDrained], timeout: 1)
+
+    let firstNotification = expectation(description: "first lane snapshot notification")
+    let firstToken = NotificationCenter.default.addObserver(
       forName: .adeDatabaseDidChange,
       object: nil,
       queue: nil
-    ) { _ in
-      notificationCount += 1
+    ) { notification in
+      guard notificationTouches(notification, anyOf: ["lanes", "lane_state_snapshots", "lane_list_snapshots", "lane_detail_snapshots"]) else { return }
+      firstNotification.fulfill()
     }
-    defer { NotificationCenter.default.removeObserver(token) }
+    defer { NotificationCenter.default.removeObserver(firstToken) }
 
     let snapshot = makeLaneListSnapshot(
       id: "lane-primary",
@@ -4601,9 +4683,28 @@ final class ADETests: XCTestCase {
     )
 
     try database.replaceLaneSnapshots([snapshot.lane], snapshots: [snapshot])
-    XCTAssertEqual(notificationCount, 1)
+    wait(for: [firstNotification], timeout: 2)
+    let firstWriteNotificationsDrained = expectation(description: "first lane snapshot write notifications drained")
+    DispatchQueue.main.async { firstWriteNotificationsDrained.fulfill() }
+    wait(for: [firstWriteNotificationsDrained], timeout: 1)
+
+    let noExtraNotification = expectation(description: "no extra lane snapshot notification")
+    noExtraNotification.isInverted = true
+    let noExtraFulfilled = ManagedAtomicFlag()
+    let noExtraToken = NotificationCenter.default.addObserver(
+      forName: .adeDatabaseDidChange,
+      object: nil,
+      queue: nil
+    ) { notification in
+      guard notificationTouches(notification, anyOf: ["lanes", "lane_state_snapshots", "lane_list_snapshots", "lane_detail_snapshots"]) else { return }
+      if noExtraFulfilled.setIfUnset() {
+        noExtraNotification.fulfill()
+      }
+    }
+    defer { NotificationCenter.default.removeObserver(noExtraToken) }
+
     try database.replaceLaneSnapshots([snapshot.lane], snapshots: [snapshot])
-    XCTAssertEqual(notificationCount, 1)
+    wait(for: [noExtraNotification], timeout: 0.2)
   }
 
   func testDatabaseReplaceLaneDetailCachesRichLanePayload() throws {
@@ -4731,15 +4832,20 @@ final class ADETests: XCTestCase {
     defer { database.close() }
 
     try insertHydrationProjectGraph(into: database)
-    var notificationCount = 0
-    let token = NotificationCenter.default.addObserver(
+    let setupNotificationsDrained = expectation(description: "setup lane detail notifications drained")
+    DispatchQueue.main.async { setupNotificationsDrained.fulfill() }
+    wait(for: [setupNotificationsDrained], timeout: 1)
+
+    let firstNotification = expectation(description: "first lane detail notification")
+    let firstToken = NotificationCenter.default.addObserver(
       forName: .adeDatabaseDidChange,
       object: nil,
       queue: nil
-    ) { _ in
-      notificationCount += 1
+    ) { notification in
+      guard notificationTouches(notification, anyOf: ["lane_detail_snapshots"]) else { return }
+      firstNotification.fulfill()
     }
-    defer { NotificationCenter.default.removeObserver(token) }
+    defer { NotificationCenter.default.removeObserver(firstToken) }
 
     let snapshot = makeLaneListSnapshot(
       id: "lane-primary",
@@ -4775,9 +4881,28 @@ final class ADETests: XCTestCase {
     )
 
     try database.replaceLaneDetail(detail)
-    XCTAssertEqual(notificationCount, 1)
+    wait(for: [firstNotification], timeout: 2)
+    let firstWriteNotificationsDrained = expectation(description: "first lane detail write notifications drained")
+    DispatchQueue.main.async { firstWriteNotificationsDrained.fulfill() }
+    wait(for: [firstWriteNotificationsDrained], timeout: 1)
+
+    let noExtraNotification = expectation(description: "no extra lane detail notification")
+    noExtraNotification.isInverted = true
+    let noExtraFulfilled = ManagedAtomicFlag()
+    let noExtraToken = NotificationCenter.default.addObserver(
+      forName: .adeDatabaseDidChange,
+      object: nil,
+      queue: nil
+    ) { notification in
+      guard notificationTouches(notification, anyOf: ["lane_detail_snapshots"]) else { return }
+      if noExtraFulfilled.setIfUnset() {
+        noExtraNotification.fulfill()
+      }
+    }
+    defer { NotificationCenter.default.removeObserver(noExtraToken) }
+
     try database.replaceLaneDetail(detail)
-    XCTAssertEqual(notificationCount, 1)
+    wait(for: [noExtraNotification], timeout: 0.2)
   }
 
   func testDatabaseReplaceTerminalSessionsHydratesHostSessionProjection() throws {
@@ -12891,6 +13016,28 @@ private final class ManagedAtomicErrorBox {
     defer { lock.unlock() }
     return stored
   }
+}
+
+private final class ManagedAtomicFlag {
+  private let lock = NSLock()
+  private var stored = false
+
+  func setIfUnset() -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    guard !stored else { return false }
+    stored = true
+    return true
+  }
+}
+
+private func notificationTouches(_ notification: Notification, anyOf tables: Set<String>) -> Bool {
+  let touchedTables = Set(
+    (notification.userInfo?[ADEDatabaseChangeNotification.touchedTablesUserInfoKey] as? [String] ?? [])
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+      .filter { !$0.isEmpty }
+  )
+  return !touchedTables.isDisjoint(with: tables)
 }
 
 private func XCTAssertThrowsErrorAsync<T>(

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -4653,9 +4653,7 @@ final class ADETests: XCTestCase {
     defer { database.close() }
 
     try insertHydrationProjectGraph(into: database)
-    let setupNotificationsDrained = expectation(description: "setup lane snapshot notifications drained")
-    DispatchQueue.main.async { setupNotificationsDrained.fulfill() }
-    wait(for: [setupNotificationsDrained], timeout: 1)
+    drainMainQueueForTesting()
 
     let firstNotification = expectation(description: "first lane snapshot notification")
     let firstToken = NotificationCenter.default.addObserver(
@@ -4684,27 +4682,22 @@ final class ADETests: XCTestCase {
 
     try database.replaceLaneSnapshots([snapshot.lane], snapshots: [snapshot])
     wait(for: [firstNotification], timeout: 2)
-    let firstWriteNotificationsDrained = expectation(description: "first lane snapshot write notifications drained")
-    DispatchQueue.main.async { firstWriteNotificationsDrained.fulfill() }
-    wait(for: [firstWriteNotificationsDrained], timeout: 1)
+    drainMainQueueForTesting()
 
-    let noExtraNotification = expectation(description: "no extra lane snapshot notification")
-    noExtraNotification.isInverted = true
-    let noExtraFulfilled = ManagedAtomicFlag()
+    let noExtraNotificationObserved = ManagedAtomicFlag()
     let noExtraToken = NotificationCenter.default.addObserver(
       forName: .adeDatabaseDidChange,
       object: nil,
       queue: nil
     ) { notification in
       guard notificationTouches(notification, anyOf: ["lanes", "lane_state_snapshots", "lane_list_snapshots", "lane_detail_snapshots"]) else { return }
-      if noExtraFulfilled.setIfUnset() {
-        noExtraNotification.fulfill()
-      }
+      _ = noExtraNotificationObserved.setIfUnset()
     }
     defer { NotificationCenter.default.removeObserver(noExtraToken) }
 
     try database.replaceLaneSnapshots([snapshot.lane], snapshots: [snapshot])
-    wait(for: [noExtraNotification], timeout: 0.2)
+    drainMainQueueForTesting()
+    XCTAssertFalse(noExtraNotificationObserved.isSet)
   }
 
   func testDatabaseReplaceLaneDetailCachesRichLanePayload() throws {
@@ -4832,9 +4825,7 @@ final class ADETests: XCTestCase {
     defer { database.close() }
 
     try insertHydrationProjectGraph(into: database)
-    let setupNotificationsDrained = expectation(description: "setup lane detail notifications drained")
-    DispatchQueue.main.async { setupNotificationsDrained.fulfill() }
-    wait(for: [setupNotificationsDrained], timeout: 1)
+    drainMainQueueForTesting()
 
     let firstNotification = expectation(description: "first lane detail notification")
     let firstToken = NotificationCenter.default.addObserver(
@@ -4882,27 +4873,22 @@ final class ADETests: XCTestCase {
 
     try database.replaceLaneDetail(detail)
     wait(for: [firstNotification], timeout: 2)
-    let firstWriteNotificationsDrained = expectation(description: "first lane detail write notifications drained")
-    DispatchQueue.main.async { firstWriteNotificationsDrained.fulfill() }
-    wait(for: [firstWriteNotificationsDrained], timeout: 1)
+    drainMainQueueForTesting()
 
-    let noExtraNotification = expectation(description: "no extra lane detail notification")
-    noExtraNotification.isInverted = true
-    let noExtraFulfilled = ManagedAtomicFlag()
+    let noExtraNotificationObserved = ManagedAtomicFlag()
     let noExtraToken = NotificationCenter.default.addObserver(
       forName: .adeDatabaseDidChange,
       object: nil,
       queue: nil
     ) { notification in
       guard notificationTouches(notification, anyOf: ["lane_detail_snapshots"]) else { return }
-      if noExtraFulfilled.setIfUnset() {
-        noExtraNotification.fulfill()
-      }
+      _ = noExtraNotificationObserved.setIfUnset()
     }
     defer { NotificationCenter.default.removeObserver(noExtraToken) }
 
     try database.replaceLaneDetail(detail)
-    wait(for: [noExtraNotification], timeout: 0.2)
+    drainMainQueueForTesting()
+    XCTAssertFalse(noExtraNotificationObserved.isSet)
   }
 
   func testDatabaseReplaceTerminalSessionsHydratesHostSessionProjection() throws {
@@ -8204,6 +8190,17 @@ final class ADETests: XCTestCase {
 
     try database.replaceTerminalSessions([
       makeTerminalSessionSummary(
+        id: "running-chat",
+        laneId: "lane-1",
+        laneName: "Primary",
+        toolType: "codex-chat",
+        runtimeState: "running",
+        status: "running",
+        title: "Mobile running chat",
+        lastOutputPreview: "Still streaming",
+        startedAt: recentIso8601Fixture()
+      ),
+      makeTerminalSessionSummary(
         id: "failed-chat",
         laneId: "lane-1",
         laneName: "Primary",
@@ -8223,6 +8220,16 @@ final class ADETests: XCTestCase {
         status: "completed",
         title: "Completed chat",
         startedAt: "2026-04-20T00:02:00.000Z"
+      ),
+      makeTerminalSessionSummary(
+        id: "stale-running-chat",
+        laneId: "lane-1",
+        laneName: "Primary",
+        toolType: "codex-chat",
+        runtimeState: "stopped",
+        status: "running",
+        title: "Stale running chat",
+        startedAt: "2026-04-20T00:02:15.000Z"
       ),
       makeTerminalSessionSummary(
         id: "awaiting-chat",
@@ -8250,6 +8257,8 @@ final class ADETests: XCTestCase {
     let service = SyncService(database: database)
     service.refreshActiveSessionsAndSnapshot()
 
+    let running = try XCTUnwrap(service.activeSessions.first(where: { $0.sessionId == "running-chat" }))
+    XCTAssertEqual(running.status, "running")
     let failed = try XCTUnwrap(service.activeSessions.first(where: { $0.sessionId == "failed-chat" }))
     XCTAssertEqual(failed.status, "failed")
     XCTAssertEqual(failed.title, "Mobile failed chat")
@@ -8260,6 +8269,8 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(awaiting.title, "Mobile awaiting chat")
     XCTAssertTrue(awaiting.awaitingInput)
     XCTAssertEqual(service.awaitingInputSessionsCount, 1)
+    XCTAssertEqual(service.runningChatSessionCount, 1)
+    XCTAssertFalse(service.activeSessions.contains(where: { $0.sessionId == "stale-running-chat" }))
     XCTAssertFalse(service.activeSessions.contains(where: { $0.sessionId == "completed-chat" }))
     XCTAssertFalse(service.activeSessions.contains(where: { $0.sessionId == "failed-shell" }))
     database.close()
@@ -13029,6 +13040,23 @@ private final class ManagedAtomicFlag {
     stored = true
     return true
   }
+
+  var isSet: Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return stored
+  }
+}
+
+private func drainMainQueueForTesting(
+  timeout: TimeInterval = 1,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  let expectation = XCTestExpectation(description: "main queue drained")
+  DispatchQueue.main.async { expectation.fulfill() }
+  let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
+  XCTAssertEqual(result, .completed, file: file, line: line)
 }
 
 private func notificationTouches(_ notification: Notification, anyOf tables: Set<String>) -> Bool {


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fim-haivng-trouble-themobile-app-c59e8b76 num=648 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fim-haivng-trouble-themobile-app-c59e8b76&amp;pr=648">ade/im-haivng-trouble-themobile-app-c59e8b76 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=648">PR #648</a>
</p>
<!-- /ade:link -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database change notifications so they’re delivered on the main thread more consistently, reducing timing-related issues.
  * Made connection retries and tailnet probing more reliable, with clearer handling for unreachable hosts vs. lookup failures.
  * Updated chat session counts to refresh more efficiently and avoid extra work during reads.

* **Tests**
  * Added regression coverage for connection attempt ordering, notification behavior, and concurrent database access.
  * Tightened existing notification checks to reduce flaky results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves mobile stability around database notifications, connection retries, and Work tab session counts. The main changes are:

- Database change notifications now post through the main queue.
- Sync connection attempts now try the primary port across all addresses before fallback ports.
- Work tab badge counts now use a separate running chat count instead of the recency-gated Live Activity roster.
- Tailnet probing distinguishes reachable, unreachable, and unresolved hosts.
- Tests cover notification delivery, connection ordering, and active chat count behavior.

<h3>Confidence Score: 5/5</h3>

The changes are narrowly scoped to mobile database notifications, connection retry ordering, tailnet probing, and session count refresh behavior.

No blocking correctness or security concerns were identified, and the touched areas include targeted regression coverage for the main behavioral changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to run build and tests from /home/user/repo and encountered toolchain blockers xcodebuild: not found and swift: not found (exit code 127).
- T-Rex compared before and after runs, observing a change in the head helper order and port distribution, with both runs exiting with status 0.
- T-Rex analyzed how DNS and unreachable hosts were handled, noting that before the run unresolved.example.invalid:8787 and unresolved.example.invalid:8788 were attempted after DNS, and after the run unresolvedHost mapping stopped extra ports and led to a viable tailnet path.
- T-Rex reviewed the chat session state, noting the before state had runningChatSessionCount=2 and propertyReadPerformsFetchSessions=True, while the after state had runningChatSessionCount=1, propertyReadPerformsFetchSessions=False, isPublishedState=True, and refreshAssignsRunningCount=True.

<a href="https://app.greptile.com/trex/runs/12210231/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/ios/ADE/Services/SyncService.swift`, line 6816-6826 ([link](https://github.com/arul28/ade/blob/8ea054cbb667ebbd414aecc5489012a6f391f256/apps/ios/ADE/Services/SyncService.swift#L6816-L6826)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Fallbacks inherit primary ordering**
   The reconnect path races addresses using only the first port, then reuses that reordered address list for every fallback port. If address A is unreachable on the primary port but reachable on a fallback port, while address B wins the primary-port probe but fails the actual reconnect, the code tries B's fallback before A's known-good fallback. This can delay reconnects or select the wrong route compared with trying each address's fallback ports before moving to the next address.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ios/ADE/Services/SyncService.swift
   Line: 6816-6826

   Comment:
   **Fallbacks inherit primary ordering**
   The reconnect path races addresses using only the first port, then reuses that reordered address list for every fallback port. If address A is unreachable on the primary port but reachable on a fallback port, while address B wins the primary-port probe but fails the actual reconnect, the code tries B's fallback before A's known-good fallback. This can delay reconnects or select the wrong route compared with trying each address's fallback ports before moving to the next address.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fios%2FADE%2FServices%2FSyncService.swift%0ALine%3A%206816-6826%0A%0AComment%3A%0A**Fallbacks%20inherit%20primary%20ordering**%0AThe%20reconnect%20path%20races%20addresses%20using%20only%20the%20first%20port%2C%20then%20reuses%20that%20reordered%20address%20list%20for%20every%20fallback%20port.%20If%20address%20A%20is%20unreachable%20on%20the%20primary%20port%20but%20reachable%20on%20a%20fallback%20port%2C%20while%20address%20B%20wins%20the%20primary-port%20probe%20but%20fails%20the%20actual%20reconnect%2C%20the%20code%20tries%20B's%20fallback%20before%20A's%20known-good%20fallback.%20This%20can%20delay%20reconnects%20or%20select%20the%20wrong%20route%20compared%20with%20trying%20each%20address's%20fallback%20ports%20before%20moving%20to%20the%20next%20address.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=648&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["ship: preserve running chat badge count"](https://github.com/arul28/ade/commit/bffb21234f8cb5c8d684d8474c9afd0bc8f4dec7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39660265)</sub>

<!-- /greptile_comment -->