### PR TITLE
Fix PTY terminal read and shell session ergonomics

### DIFF
--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -4775,6 +4775,24 @@ describe("ADE CLI", () => {
       },
     });
 
+    const readByPty = buildCliPlan([
+      "terminal",
+      "read",
+      "--pty",
+      "pty-1",
+      "--since",
+      "12",
+    ]);
+    expect(readByPty.kind).toBe("execute");
+    if (readByPty.kind !== "execute") return;
+    expect(readByPty.steps[0]?.params).toMatchObject({
+      arguments: {
+        domain: "terminal",
+        action: "read",
+        args: { ptyId: "pty-1", since: 12 },
+      },
+    });
+
     const write = buildCliPlan([
       "terminal",
       "write",
@@ -4792,6 +4810,19 @@ describe("ADE CLI", () => {
         args: { terminalId: "term-1", data: "y\n" },
       },
     });
+  });
+
+  it("formats shell start text with the terminal read command", () => {
+    const text = formatOutput(
+      { sessionId: "session-1", ptyId: "pty-1", pid: 1234 },
+      { ...baseResolveOpts(), projectRoot: null, workspaceRoot: null, text: true },
+      "pty-create",
+    );
+
+    expect(text).toContain("ADE shell session");
+    expect(text).toContain("session-1");
+    expect(text).toContain("pty-1");
+    expect(text).toContain("ade terminal read --terminal session-1 --text");
   });
 
   it("app-control logs and terminal write use the active App Control terminal", () => {

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -164,6 +164,7 @@ type FormatterId =
   | "browser-sessions"
   | "browser-observation"
   | "browser-trace"
+  | "pty-create"
   | "terminal-list"
   | "terminal-read"
   | "history-list"
@@ -519,6 +520,7 @@ const TOP_LEVEL_HELP = `${ADE_BANNER}
     $ ade app-control launch --command "pnpm dev" --text
     $ ade --socket browser open http://localhost:5173 --new-tab --text
     $ ade terminal read --chat-session <id> --text
+    $ ade terminal read --pty <pty-id> --text
 
   Generic ADE action JSON contract:
     Object-shaped call:
@@ -1293,6 +1295,9 @@ const HELP_BY_COMMAND: Record<string, string> = {
     $ ade shell write <pty-id> --data "q"           Write data to a PTY
     $ ade shell resize <pty-id> --cols 120 --rows 36
     $ ade shell close <pty-id>                      Dispose a PTY
+
+  After start, use the returned session id with:
+    $ ade terminal read --terminal <session-id> --text
 `,
   terminal: `${ADE_BANNER}
   Chat terminal
@@ -1302,10 +1307,11 @@ const HELP_BY_COMMAND: Record<string, string> = {
 
     $ ade terminal list --chat-session <id> --text  List terminals for a chat
     $ ade terminal active --chat-session <id> --text Show the active chat terminal
-    $ ade terminal read --terminal <id> --text      Read terminal scrollback
+    $ ade terminal read --terminal <session-id> --text Read terminal scrollback
+    $ ade terminal read --pty <pty-id> --text       Read by PTY id
     $ ade app-control logs --text                   Read the active App Control launch terminal
-    $ ade terminal write --terminal <id> --data "y\\n"
-    $ ade terminal signal --terminal <id> --signal SIGINT
+    $ ade terminal write --terminal <session-id> --data "y\\n"
+    $ ade terminal signal --terminal <session-id> --signal SIGINT
 `,
   files: `${ADE_BANNER}
   Files
@@ -1558,7 +1564,8 @@ const HELP_BY_COMMAND: Record<string, string> = {
     $ ade app-control minimize --text              Minimize the controlled app window
     $ ade app-control stop --text                  Signal the App Control terminal session
     $ ade app-control actions --text               List every callable app_control action
-    $ ade terminal read --terminal <id> --text     Read a specific chat terminal
+    $ ade terminal read --terminal <session-id> --text Read a specific chat terminal
+    $ ade terminal read --pty <pty-id> --text      Read by PTY id
     $ ade terminal write --chat-session <id> --data "y\\n" Answer a prompt
 
   Capture and context:
@@ -5241,6 +5248,7 @@ function buildShellPlan(args: string[]): CliPlan {
     return {
       kind: "execute",
       label: "shell start",
+      formatter: "pty-create",
       steps: [actionStep("result", "pty", "create", input)],
     };
   }
@@ -5524,6 +5532,7 @@ function buildTerminalPlan(args: string[]): CliPlan {
   }
   if (sub === "read" || sub === "tail" || sub === "scrollback") {
     const terminal = readValue(args, ["--terminal", "--terminal-id"]);
+    const ptyId = readValue(args, ["--pty", "--pty-id"]);
     const chat = chatSessionId();
     const maxBytes = readIntOption(args, ["--max-bytes"], undefined);
     const since = readIntOption(args, ["--since"], undefined);
@@ -5537,6 +5546,7 @@ function buildTerminalPlan(args: string[]): CliPlan {
           "read",
           collectGenericObjectArgs(args, {
             terminalId: terminal ?? firstPositional(args),
+            ptyId,
             chatSessionId: chat,
             maxBytes,
             since,
@@ -14589,6 +14599,19 @@ function formatTerminalList(value: unknown): string {
   );
 }
 
+function formatPtyCreate(value: unknown): string {
+  const result = isRecord(value) ? value : {};
+  const sessionId = typeof result.sessionId === "string" ? result.sessionId : null;
+  const ptyId = typeof result.ptyId === "string" ? result.ptyId : null;
+  const readCommand = sessionId ? `ade terminal read --terminal ${sessionId} --text` : null;
+  return renderKeyValues("ADE shell session", [
+    ["session", sessionId],
+    ["pty", ptyId],
+    ["pid", result.pid],
+    ["read with", readCommand],
+  ]);
+}
+
 function formatTerminalRead(value: unknown): string {
   const result = isRecord(value) ? value : {};
   const data = typeof result.data === "string" ? result.data : "";
@@ -14868,6 +14891,8 @@ function formatTextOutput(
       return formatBrowserObservation(value);
     case "browser-trace":
       return formatBrowserTrace(value);
+    case "pty-create":
+      return formatPtyCreate(value);
     case "terminal-list":
       return formatTerminalList(value);
     case "terminal-read":
@@ -14994,6 +15019,7 @@ function inferFormatter(
   )
     return "browser-observation";
   if (label === "browser trace") return "browser-trace";
+  if (label === "shell start") return "pty-create";
   if (label === "terminal list" || label === "terminal active")
     return "terminal-list";
   if (label === "terminal read") return "terminal-read";

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -2775,6 +2775,7 @@ export function registerIpc({
     const record = terminalRecord(value);
     return {
       terminalId: optionalTerminalString(record, "terminalId", 128),
+      ptyId: optionalTerminalString(record, "ptyId", 128),
       chatSessionId: optionalTerminalString(record, "chatSessionId", 128),
       maxBytes: optionalTerminalNumber(record, "maxBytes", 1, 8 * 1024 * 1024),
       since: optionalTerminalNumber(record, "since", 0, 8 * 1024 * 1024),

--- a/apps/desktop/src/main/services/pty/ptyService.test.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.test.ts
@@ -649,7 +649,9 @@ describe("ptyService", () => {
 
     it("starts command-backed shell sessions without reading user startup files", async () => {
       const previousShell = process.env.SHELL;
+      const previousPath = process.env.PATH;
       process.env.SHELL = "/bin/zsh";
+      process.env.PATH = "/usr/bin";
       try {
         const { service, loadPty, mockPty } = createHarness();
         await service.create({
@@ -671,10 +673,20 @@ describe("ptyService", () => {
             }),
           }),
         );
+        const opts = ptyLib.spawn.mock.calls.at(-1)?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+        const pathEntries = opts?.env?.PATH?.split(path.delimiter) ?? [];
+        expect(pathEntries).toEqual(expect.arrayContaining([
+          "/usr/bin",
+          "/opt/homebrew/bin",
+          path.join(os.homedir(), ".asdf", "shims"),
+          path.join(os.homedir(), ".mise", "shims"),
+        ]));
         expect(mockPty.write).toHaveBeenCalledWith("npm test\r");
       } finally {
         if (previousShell == null) delete process.env.SHELL;
         else process.env.SHELL = previousShell;
+        if (previousPath == null) delete process.env.PATH;
+        else process.env.PATH = previousPath;
       }
     });
 
@@ -1141,12 +1153,16 @@ describe("ptyService", () => {
         const ptyLib = loadPty.mock.results.at(-1)?.value as { spawn: ReturnType<typeof vi.fn> };
         const spawnArgs = ptyLib.spawn.mock.calls.at(-1);
         const opts = spawnArgs?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
-        expect(opts?.env?.PATH?.split(path.delimiter)).toEqual([
-          "/opt/homebrew/bin",
-          "/usr/bin",
+        const pathEntries = opts?.env?.PATH?.split(path.delimiter) ?? [];
+        const yarnGlobalBin = path.join(os.homedir(), ".config", "yarn", "global", "node_modules", ".bin");
+        expect(pathEntries.slice(0, 2)).toEqual(["/opt/homebrew/bin", "/usr/bin"]);
+        expect(pathEntries.slice(-2)).toEqual([
           "/repo/apps/desktop/node_modules/.bin",
           "/tmp/project/node_modules/.bin",
         ]);
+        expect(pathEntries).toContain(path.join(os.homedir(), ".asdf", "shims"));
+        expect(pathEntries.indexOf(yarnGlobalBin)).toBeGreaterThanOrEqual(0);
+        expect(pathEntries.indexOf(yarnGlobalBin)).toBeLessThan(pathEntries.indexOf("/repo/apps/desktop/node_modules/.bin"));
       } finally {
         if (previousPath == null) delete process.env.PATH;
         else process.env.PATH = previousPath;

--- a/apps/desktop/src/main/services/pty/ptyService.test.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.test.ts
@@ -129,7 +129,7 @@ const mocks = vi.hoisted(() => {
     parseTrackedCliLaunchConfig: vi.fn(() => null),
     runtimeStateFromOsc133Chunk: vi.fn(() => "running"),
     resolveOpenCodeBinaryPath: vi.fn<[], string | null>(() => null),
-    execFileSync: vi.fn(() => ""),
+    execFileSync: vi.fn((_file?: unknown, _args?: unknown) => ""),
     spawnSync: vi.fn(() => ({ status: 1, stdout: "", stderr: "" })),
   };
 });
@@ -652,6 +652,12 @@ describe("ptyService", () => {
       const previousPath = process.env.PATH;
       process.env.SHELL = "/bin/zsh";
       process.env.PATH = "/usr/bin";
+      mocks.execFileSync.mockImplementation((_file, args) => {
+        const shellFlag = Array.isArray(args) ? args[0] : null;
+        if (shellFlag === "-lc") return "__ADE_PATH_START__/login/bin:/usr/bin__ADE_PATH_END__";
+        if (shellFlag === "-ic") return "__ADE_PATH_START__/custom/nvm/bin:/usr/bin__ADE_PATH_END__";
+        return "";
+      });
       try {
         const { service, loadPty, mockPty } = createHarness();
         await service.create({
@@ -677,16 +683,24 @@ describe("ptyService", () => {
         const pathEntries = opts?.env?.PATH?.split(path.delimiter) ?? [];
         expect(pathEntries).toEqual(expect.arrayContaining([
           "/usr/bin",
+          "/login/bin",
+          "/custom/nvm/bin",
           "/opt/homebrew/bin",
           path.join(os.homedir(), ".asdf", "shims"),
           path.join(os.homedir(), ".mise", "shims"),
         ]));
+        expect(mocks.execFileSync).toHaveBeenCalledWith(
+          "/bin/zsh",
+          ["-ic", expect.stringContaining("__ADE_PATH_START__")],
+          expect.objectContaining({ env: expect.objectContaining({ SHELL: "/bin/zsh" }) }),
+        );
         expect(mockPty.write).toHaveBeenCalledWith("npm test\r");
       } finally {
         if (previousShell == null) delete process.env.SHELL;
         else process.env.SHELL = previousShell;
         if (previousPath == null) delete process.env.PATH;
         else process.env.PATH = previousPath;
+        mocks.execFileSync.mockImplementation(() => "");
       }
     });
 

--- a/apps/desktop/src/main/services/pty/ptyService.test.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.test.ts
@@ -647,6 +647,37 @@ describe("ptyService", () => {
       }
     });
 
+    it("starts command-backed shell sessions without reading user startup files", async () => {
+      const previousShell = process.env.SHELL;
+      process.env.SHELL = "/bin/zsh";
+      try {
+        const { service, loadPty, mockPty } = createHarness();
+        await service.create({
+          laneId: "lane-1",
+          title: "Shell command",
+          cols: 80,
+          rows: 24,
+          toolType: "shell",
+          startupCommand: "npm test",
+        });
+
+        const ptyLib = loadPty.mock.results.at(-1)?.value as { spawn: ReturnType<typeof vi.fn> };
+        expect(ptyLib.spawn).toHaveBeenCalledWith(
+          "/bin/zsh",
+          ["-f"],
+          expect.objectContaining({
+            env: expect.objectContaining({
+              ZDOTDIR: "/var/empty",
+            }),
+          }),
+        );
+        expect(mockPty.write).toHaveBeenCalledWith("npm test\r");
+      } finally {
+        if (previousShell == null) delete process.env.SHELL;
+        else process.env.SHELL = previousShell;
+      }
+    });
+
     it("uses a caller-provided sessionId when creating a new tracked session", async () => {
       const { service, sessionService } = createHarness();
       const result = await service.create({
@@ -5240,6 +5271,30 @@ describe("ptyService", () => {
       expect(read.terminalId).toBe(created.sessionId);
       expect(read.data).toBe("456789");
       expect(read.nextSince).toBe(4 + "456789".length);
+    });
+
+    it("readTerminal accepts a live PTY handle as an alias for the terminal session id", async () => {
+      const { service, sessionService } = createChatHarness();
+      const created = await service.create({
+        laneId: "lane-1",
+        title: "Reader",
+        cols: 80,
+        rows: 24,
+        chatSessionId: "chat-7",
+      });
+      sessionService.readTranscriptTail.mockResolvedValueOnce("pty transcript");
+
+      const read = await service.readTerminal({ ptyId: created.ptyId, maxBytes: 1024 });
+
+      expect(read.terminalId).toBe(created.sessionId);
+      expect(read.data).toBe("pty transcript");
+      expect(sessionService.get).toHaveBeenCalledWith(created.sessionId);
+
+      sessionService.readTranscriptTail.mockResolvedValueOnce("terminal flag pty transcript");
+      const terminalFlagRead = await service.readTerminal({ terminalId: created.ptyId, maxBytes: 1024 });
+
+      expect(terminalFlagRead.terminalId).toBe(created.sessionId);
+      expect(terminalFlagRead.data).toBe("terminal flag pty transcript");
     });
 
     it("readTerminal merges recent live output before the transcript stream flushes", async () => {

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -18,7 +18,7 @@ import type { createProjectConfigService } from "../config/projectConfigService"
 import { runGit } from "../git/git";
 import { resolveOpenCodeBinaryPath } from "../opencode/openCodeBinaryManager";
 import { resolveCliSpawnInvocation } from "../shared/processExecution";
-import { getPathEnvValue, setPathEnvValue, splitPathEntries } from "../ai/cliExecutableResolver";
+import { augmentPathWithKnownCliDirs, getPathEnvValue, setPathEnvValue, splitPathEntries } from "../ai/cliExecutableResolver";
 import type {
   PtyDataEvent,
   PtyExitEvent,
@@ -966,7 +966,11 @@ function inferSessionCwdFromTranscriptPath(transcriptPath: string | null | undef
 
 function isNodeModulesBinPath(value: string): boolean {
   const normalized = value.replace(/\\/g, "/").toLowerCase();
-  return normalized.endsWith("/node_modules/.bin");
+  const userYarnGlobalBin = path
+    .join(os.homedir(), ".config", "yarn", "global", "node_modules", ".bin")
+    .replace(/\\/g, "/")
+    .toLowerCase();
+  return normalized.endsWith("/node_modules/.bin") && normalized !== userYarnGlobalBin;
 }
 
 function looksLikeCodexCommand(command: string | null | undefined): boolean {
@@ -999,6 +1003,12 @@ function withUserCodexCliPathPriority(
   // Codex CLI and send every Work launch into Codex's update-and-restart flow.
   // Keep node_modules bins as a last-resort fallback, but never let them win.
   setPathEnvValue(next, [...nonNodeModulesEntries, ...nodeModulesEntries].join(path.delimiter));
+  return next;
+}
+
+function withKnownCliLaunchPath(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const next = { ...env };
+  setPathEnvValue(next, augmentPathWithKnownCliDirs(getPathEnvValue(next), next));
   return next;
 }
 
@@ -3702,6 +3712,7 @@ export function createPtyService({
         getAdeCliAgentEnv?.(contextLaunchEnv) ?? contextLaunchEnv,
         { preserveNoColor: explicitNoColor },
       );
+      launchEnv = withKnownCliLaunchPath(launchEnv);
       const shouldBackfillResumeTarget =
         existingSession
         && isTrackedCliToolType(toolTypeHint)

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -3292,10 +3292,19 @@ export function createPtyService({
 
   const resolveTerminalId = (args: {
     terminalId?: string | null;
+    ptyId?: string | null;
     chatSessionId?: string | null;
   }): string | null => {
     const terminalId = cleanOptionalId(args.terminalId);
-    if (terminalId) return terminalId;
+    if (terminalId) {
+      if (!sessionService.get(terminalId)) {
+        const liveByPtyId = ptys.get(terminalId);
+        if (liveByPtyId && !liveByPtyId.disposed) return liveByPtyId.sessionId;
+      }
+      return terminalId;
+    }
+    const ptyId = cleanOptionalId(args.ptyId);
+    if (ptyId) return ptys.get(ptyId)?.sessionId ?? null;
     const chatSessionId = cleanOptionalId(args.chatSessionId);
     if (!chatSessionId) return null;
     // Auxiliary terminals (shell, App Control, etc.) — never route chat-CLI rows.
@@ -3715,7 +3724,10 @@ export function createPtyService({
       let pty: IPty;
       let selectedShell: ShellSpec | null = null;
       const useLoginInteractiveShell = toolTypeHint === "shell" && !directCommand && !startupCommand;
-      const shellCandidates = resolveShellCandidates({ login: useLoginInteractiveShell });
+      const shellCandidates = resolveShellCandidates({
+        clean: Boolean(directCommand || startupCommand),
+        login: useLoginInteractiveShell,
+      });
       let launchedDirectCommand = false;
       try {
         const spawnHelperRepair = ensureNodePtySpawnHelperExecutable();
@@ -4484,7 +4496,7 @@ export function createPtyService({
 
     async readTerminal(args: ChatTerminalReadArgs = {}): Promise<ChatTerminalReadResult> {
       const terminalId = resolveTerminalId(args);
-      if (!terminalId) throw new Error("terminal.read requires terminalId or an active chat terminal.");
+      if (!terminalId) throw new Error("terminal.read requires terminalId, ptyId, or an active chat terminal.");
       const session = sessionService.get(terminalId);
       if (!session) throw new Error(`Terminal session '${terminalId}' was not found.`);
       if (isPersistedChatToolType(session.toolType)) {

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -18,7 +18,7 @@ import type { createProjectConfigService } from "../config/projectConfigService"
 import { runGit } from "../git/git";
 import { resolveOpenCodeBinaryPath } from "../opencode/openCodeBinaryManager";
 import { resolveCliSpawnInvocation } from "../shared/processExecution";
-import { augmentPathWithKnownCliDirs, getPathEnvValue, setPathEnvValue, splitPathEntries } from "../ai/cliExecutableResolver";
+import { augmentProcessPathWithShellAndKnownCliDirs, getPathEnvValue, setPathEnvValue, splitPathEntries } from "../ai/cliExecutableResolver";
 import type {
   PtyDataEvent,
   PtyExitEvent,
@@ -1006,9 +1006,15 @@ function withUserCodexCliPathPriority(
   return next;
 }
 
-function withKnownCliLaunchPath(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+function withResolvedCliLaunchPath(
+  env: NodeJS.ProcessEnv,
+  options: { includeInteractiveShell?: boolean } = {},
+): NodeJS.ProcessEnv {
   const next = { ...env };
-  setPathEnvValue(next, augmentPathWithKnownCliDirs(getPathEnvValue(next), next));
+  setPathEnvValue(next, augmentProcessPathWithShellAndKnownCliDirs({
+    env: next,
+    includeInteractiveShell: options.includeInteractiveShell,
+  }));
   return next;
 }
 
@@ -3712,7 +3718,9 @@ export function createPtyService({
         getAdeCliAgentEnv?.(contextLaunchEnv) ?? contextLaunchEnv,
         { preserveNoColor: explicitNoColor },
       );
-      launchEnv = withKnownCliLaunchPath(launchEnv);
+      launchEnv = withResolvedCliLaunchPath(launchEnv, {
+        includeInteractiveShell: Boolean(directCommand || startupCommand),
+      });
       const shouldBackfillResumeTarget =
         existingSession
         && isTrackedCliToolType(toolTypeHint)

--- a/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.test.tsx
@@ -86,6 +86,37 @@ describe("ChatTerminalDrawer", () => {
     expect(screen.getByTestId("terminal-view").textContent).toBe("terminal-race-1:pty-race-1");
   });
 
+  it("keeps rapid new-terminal clicks to one in-flight PTY create", async () => {
+    type CreateResolver = (value: { sessionId: string; ptyId: string; pid: number }) => void;
+    const resolveCreate: { current?: CreateResolver } = {};
+    vi.mocked(window.ade.pty.create).mockReturnValueOnce(new Promise((resolve) => {
+      resolveCreate.current = resolve;
+    }) as any);
+
+    render(
+      <ChatTerminalDrawer
+        open
+        onToggle={vi.fn()}
+        laneId="lane-1"
+        chatSessionId="chat-1"
+        autoCreateOnOpen={false}
+      />,
+    );
+
+    const createButton = screen.getByTitle("New terminal");
+    fireEvent.click(createButton);
+    fireEvent.click(createButton);
+
+    expect(window.ade.pty.create).toHaveBeenCalledTimes(1);
+    expect(resolveCreate.current).toBeTruthy();
+    resolveCreate.current!({ sessionId: "terminal-once", ptyId: "pty-once", pid: 1234 });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("terminal-view").textContent).toBe("terminal-once:pty-once");
+    });
+    expect(screen.getAllByText(/^Terminal \d+$/)).toHaveLength(1);
+  });
+
   it("toggles the terminal drawer open and closed", () => {
     const onToggle = vi.fn();
     const view = render(<ChatTerminalToggle open={false} onToggle={onToggle} />);

--- a/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx
@@ -149,6 +149,7 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
   const previousOpenRef = useRef(open);
   const pendingAutoCreateRef = useRef(false);
   const tabsRef = useRef<TabEntry[]>([]);
+  const createTabFlightRef = useRef<Promise<void> | null>(null);
   const restoringUiStateRef = useRef(false);
   const lastHandledCreateRequestRef = useRef(0);
   const createRequestHandledThisOpenRef = useRef(false);
@@ -212,12 +213,14 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
   }, [drawerHeight]);
 
   const createTab = useCallback(async () => {
-    if (creatingTab) return;
+    if (createTabFlightRef.current) {
+      await createTabFlightRef.current.catch(() => {});
+      return;
+    }
     setCreatingTab(true);
-    try {
+    const flight = (async () => {
       const tabIndex = nextTabIndex++;
       const label = `Terminal ${tabIndex}`;
-      const tabId = `chat-term-${Date.now()}-${tabIndex}`;
       const created = await window.ade.pty.create({
         laneId,
         chatSessionId,
@@ -228,6 +231,7 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
         toolType: "shell",
       });
 
+      const tabId = `chat-term-${created.sessionId}`;
       const nextEntry: TabEntry = {
         id: tabId,
         ptyId: created.ptyId,
@@ -236,17 +240,32 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
         exited: false,
       };
 
-      const existing = tabs.find(
+      const existing = tabsRef.current.find(
         (tab) => tab.sessionId === created.sessionId || tab.ptyId === created.ptyId,
       );
-      setActiveTabId(existing?.id ?? tabId);
-      if (!existing) setTabs((prev) => [...prev, nextEntry]);
+      if (existing) {
+        setActiveTabId(existing.id);
+      } else {
+        setTabs((prev) => {
+          const prevExisting = prev.find(
+            (tab) => tab.sessionId === created.sessionId || tab.ptyId === created.ptyId,
+          );
+          if (prevExisting) return prev;
+          return [...prev, nextEntry];
+        });
+        setActiveTabId(tabId);
+      }
+    })();
+    createTabFlightRef.current = flight;
+    try {
+      await flight;
     } catch (error) {
       reportCreateError(error);
     } finally {
+      if (createTabFlightRef.current === flight) createTabFlightRef.current = null;
       setCreatingTab(false);
     }
-  }, [chatSessionId, creatingTab, laneId, reportCreateError, tabs]);
+  }, [chatSessionId, laneId, reportCreateError]);
 
   useEffect(() => {
     if (!chatSessionId) return;
@@ -263,10 +282,16 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
         if (!restored.length) return;
         setTabs((prev) => {
           const restoredBySessionId = new Map(restored.map((tab) => [tab.sessionId, tab]));
-          const next = prev.map((tab) => restoredBySessionId.get(tab.sessionId) ?? tab);
+          const restoredByPtyId = new Map(restored.map((tab) => [tab.ptyId, tab]));
+          const next = prev.map((tab) => restoredBySessionId.get(tab.sessionId) ?? restoredByPtyId.get(tab.ptyId) ?? tab);
           const existingSessionIds = new Set(next.map((tab) => tab.sessionId));
+          const existingPtyIds = new Set(next.map((tab) => tab.ptyId));
           for (const tab of restored) {
-            if (!existingSessionIds.has(tab.sessionId)) next.push(tab);
+            if (!existingSessionIds.has(tab.sessionId) && !existingPtyIds.has(tab.ptyId)) {
+              next.push(tab);
+              existingSessionIds.add(tab.sessionId);
+              existingPtyIds.add(tab.ptyId);
+            }
           }
           return next;
         });
@@ -313,7 +338,13 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
       label: revealRequest.label || "App Control",
       exited: false,
     };
-    setTabs((prev) => [...prev, nextEntry]);
+    setTabs((prev) => {
+      const existingInUpdate = prev.find(
+        (tab) => tab.sessionId === revealRequest.terminalId || tab.ptyId === revealRequest.ptyId,
+      );
+      if (existingInUpdate) return prev;
+      return [...prev, nextEntry];
+    });
     setActiveTabId(tabId);
     revealHandledThisOpenRef.current = true;
   }, [revealRequest, uiStateKey]);

--- a/apps/desktop/src/shared/types/sessions.ts
+++ b/apps/desktop/src/shared/types/sessions.ts
@@ -245,6 +245,7 @@ export type ChatTerminalListArgs = {
 
 export type ChatTerminalReadArgs = {
   terminalId?: string | null;
+  ptyId?: string | null;
   chatSessionId?: string | null;
   maxBytes?: number | null;
   since?: number | null;

--- a/docs/features/computer-use/app-control.md
+++ b/docs/features/computer-use/app-control.md
@@ -54,7 +54,7 @@ Channels live under `ade.appControl.*`:
 The companion **chat terminal** surface lives at `ade.terminal.*` and shares the same backend as PTY:
 
 - `ade.terminal.list` — list chat-attached terminals (filterable by `chatSessionId` / `laneId`).
-- `ade.terminal.read` — read scrollback by `terminalId` *or* by `chatSessionId` (resolves to the chat's active terminal).
+- `ade.terminal.read` — read scrollback by `terminalId`, live `ptyId`, or `chatSessionId` (resolves to the chat's active terminal).
 - `ade.terminal.write` / `ade.terminal.signal` — send input or `SIGINT` / `SIGTERM` / `SIGKILL`.
 - `ade.terminal.activeForChat` — fetch the currently active terminal for a chat.
 


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fread-transcript-chat-review-sync-2f34f932 num=649 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fread-transcript-chat-review-sync-2f34f932&amp;pr=649">ade/read-transcript-chat-review-sync-2f34f932 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=649">PR #649</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now read terminal scrollback using a PTY identifier with `ade terminal read --pty <pty-id>`.
  * Shell session creation output now includes clearer session and PTY details, plus a suggested command for reading the session when available.

* **Bug Fixes**
  * Fixed duplicate terminal tabs from being created when clicking “New terminal” multiple times or when the same terminal is restored/revealed again.
  * Improved terminal read handling so PTY-based sessions are recognized consistently across desktop and CLI flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds PTY-id-based terminal read lookup (`--pty <pty-id>` in the CLI and `ptyId` in the IPC contract), fixes duplicate terminal tabs from rapid "New terminal" clicks and from restore/reveal re-entry, and improves shell session ergonomics by emitting a suggested `ade terminal read` command after `shell start`.

- **PTY read alias**: `resolveTerminalId` now accepts `ptyId` directly and also falls back to a PTY lookup when `terminalId` doesn't match a known session, making `--pty` and `--terminal <ptyId>` both work from the CLI.
- **Duplicate-tab fix**: `createTabFlightRef` serialises concurrent `createTab` calls and tab IDs are now derived from `created.sessionId`, so backend-returned duplicates are caught both at flight-guard time and inside the `setTabs` updater.
- **Shell env ergonomics**: `resolveShellCandidates` gains a `clean` flag (skips startup files for command-backed shells), `withResolvedCliLaunchPath` augments PATH with interactive-shell and known-CLI directories, and `isNodeModulesBinPath` now excludes the user's yarn global bin so it isn't demoted to last resort.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the stale-flight race in ChatTerminalDrawer; all other changes are additive and well-tested.

The `createTabFlightRef` is not reset when `chatSessionId` changes, which means a terminal create that's in-flight for the old chat session can resolve after the user has switched to a new session, append the old session's tab into the new session's drawer, and prevent the new session from auto-creating its own terminal. Every other change — the ptyId IPC path, the CLI formatter, the shell-env helpers, and the deduplication logic itself — is solid and covered by tests.

apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx — the chatSessionId-change cleanup effect should reset createTabFlightRef.current to null.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx | Duplicate-tab prevention via createTabFlightRef is solid for rapid clicks, but the ref is not cleared on chatSessionId change, which can leak an old session's terminal into a new session's drawer on fast chat switches. |
| apps/desktop/src/main/services/pty/ptyService.ts | Adds resolveTerminalId ptyId path and withResolvedCliLaunchPath helper; logic is correct with the noted asymmetry on disposed PTYs already called out in previous threads. |
| apps/ade-cli/src/cli.ts | Adds --pty flag to terminal read, pty-create formatter, and shell-help read-command hint; all changes are additive and well-tested. |
| apps/desktop/src/main/services/pty/ptyService.test.ts | New tests cover ptyId terminal read aliasing, command-backed shell clean startup, and updated PATH ordering assertions; coverage is thorough. |
| apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.test.tsx | New test verifies rapid double-click deduplication but does not cover the chatSessionId-change race that leaks a stale tab. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Drawer as ChatTerminalDrawer
    participant IPC as registerIpc
    participant PtyService
    participant SessionService

    User->>Drawer: click "New terminal"
    Drawer->>Drawer: createTabFlightRef set → guard active
    Drawer->>IPC: "window.ade.pty.create({ chatSessionId, toolType: "shell" })"
    IPC->>PtyService: create(args)
    PtyService-->>IPC: "{ sessionId, ptyId, pid }"
    IPC-->>Drawer: created
    Drawer->>Drawer: "tabId = chat-term-{sessionId}"
    Drawer->>Drawer: setTabs (dedup by sessionId/ptyId)
    Drawer->>Drawer: "createTabFlightRef = null"

    User->>Drawer: "ade terminal read --pty <pty-id>"
    Drawer->>IPC: "terminal.read({ ptyId })"
    IPC->>PtyService: "readTerminal({ ptyId })"
    PtyService->>PtyService: resolveTerminalId → ptys.get(ptyId)?.sessionId
    PtyService->>SessionService: get(sessionId)
    SessionService-->>PtyService: session
    PtyService-->>IPC: "{ terminalId, data }"
    IPC-->>Drawer: result
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Drawer as ChatTerminalDrawer
    participant IPC as registerIpc
    participant PtyService
    participant SessionService

    User->>Drawer: click "New terminal"
    Drawer->>Drawer: createTabFlightRef set → guard active
    Drawer->>IPC: "window.ade.pty.create({ chatSessionId, toolType: "shell" })"
    IPC->>PtyService: create(args)
    PtyService-->>IPC: "{ sessionId, ptyId, pid }"
    IPC-->>Drawer: created
    Drawer->>Drawer: "tabId = chat-term-{sessionId}"
    Drawer->>Drawer: setTabs (dedup by sessionId/ptyId)
    Drawer->>Drawer: "createTabFlightRef = null"

    User->>Drawer: "ade terminal read --pty <pty-id>"
    Drawer->>IPC: "terminal.read({ ptyId })"
    IPC->>PtyService: "readTerminal({ ptyId })"
    PtyService->>PtyService: resolveTerminalId → ptys.get(ptyId)?.sessionId
    PtyService->>SessionService: get(sessionId)
    SessionService-->>PtyService: session
    PtyService-->>IPC: "{ terminalId, data }"
    IPC-->>Drawer: result
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx`, line 170-179 ([link](https://github.com/arul28/ade/blob/9e996d0447bd217de831122a066bb43b0d8db704/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx#L170-L179)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Stale flight leaks into new chat session on fast session switch**

   When `chatSessionId` changes, this cleanup effect resets most refs and clears `tabs`, but does **not** reset `createTabFlightRef.current`. If a `window.ade.pty.create(...)` call is in-flight for Session A when the user switches to Session B, the flight resolves after the switch, appending the Session-A terminal entry into Session B's now-empty `tabs` via `setTabs`. Because `tabs.length > 0`, the auto-create guard for Session B (`if (!autoCreateOnOpen || revealActive || tabs.length > 0)`) short-circuits and Session B never gets its own terminal — it just shows Session A's PTY. Adding `createTabFlightRef.current = null` here would cancel the in-progress guard and let the old flight's `setTabs` call be ignored (or at least let Session B detect stale state).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx
   Line: 170-179

   Comment:
   **Stale flight leaks into new chat session on fast session switch**

   When `chatSessionId` changes, this cleanup effect resets most refs and clears `tabs`, but does **not** reset `createTabFlightRef.current`. If a `window.ade.pty.create(...)` call is in-flight for Session A when the user switches to Session B, the flight resolves after the switch, appending the Session-A terminal entry into Session B's now-empty `tabs` via `setTabs`. Because `tabs.length > 0`, the auto-create guard for Session B (`if (!autoCreateOnOpen || revealActive || tabs.length > 0)`) short-circuits and Session B never gets its own terminal — it just shows Session A's PTY. Adding `createTabFlightRef.current = null` here would cancel the in-progress guard and let the old flight's `setTabs` call be ignored (or at least let Session B detect stale state).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FChatTerminalDrawer.tsx%0ALine%3A%20170-179%0A%0AComment%3A%0A**Stale%20flight%20leaks%20into%20new%20chat%20session%20on%20fast%20session%20switch**%0A%0AWhen%20%60chatSessionId%60%20changes%2C%20this%20cleanup%20effect%20resets%20most%20refs%20and%20clears%20%60tabs%60%2C%20but%20does%20**not**%20reset%20%60createTabFlightRef.current%60.%20If%20a%20%60window.ade.pty.create%28...%29%60%20call%20is%20in-flight%20for%20Session%20A%20when%20the%20user%20switches%20to%20Session%20B%2C%20the%20flight%20resolves%20after%20the%20switch%2C%20appending%20the%20Session-A%20terminal%20entry%20into%20Session%20B's%20now-empty%20%60tabs%60%20via%20%60setTabs%60.%20Because%20%60tabs.length%20%3E%200%60%2C%20the%20auto-create%20guard%20for%20Session%20B%20%28%60if%20%28!autoCreateOnOpen%20%7C%7C%20revealActive%20%7C%7C%20tabs.length%20%3E%200%29%60%29%20short-circuits%20and%20Session%20B%20never%20gets%20its%20own%20terminal%20%E2%80%94%20it%20just%20shows%20Session%20A's%20PTY.%20Adding%20%60createTabFlightRef.current%20%3D%20null%60%20here%20would%20cancel%20the%20in-progress%20guard%20and%20let%20the%20old%20flight's%20%60setTabs%60%20call%20be%20ignored%20%28or%20at%20least%20let%20Session%20B%20detect%20stale%20state%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=649&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FChatTerminalDrawer.tsx%3A170-179%0A**Stale%20flight%20leaks%20into%20new%20chat%20session%20on%20fast%20session%20switch**%0A%0AWhen%20%60chatSessionId%60%20changes%2C%20this%20cleanup%20effect%20resets%20most%20refs%20and%20clears%20%60tabs%60%2C%20but%20does%20**not**%20reset%20%60createTabFlightRef.current%60.%20If%20a%20%60window.ade.pty.create%28...%29%60%20call%20is%20in-flight%20for%20Session%20A%20when%20the%20user%20switches%20to%20Session%20B%2C%20the%20flight%20resolves%20after%20the%20switch%2C%20appending%20the%20Session-A%20terminal%20entry%20into%20Session%20B's%20now-empty%20%60tabs%60%20via%20%60setTabs%60.%20Because%20%60tabs.length%20%3E%200%60%2C%20the%20auto-create%20guard%20for%20Session%20B%20%28%60if%20%28!autoCreateOnOpen%20%7C%7C%20revealActive%20%7C%7C%20tabs.length%20%3E%200%29%60%29%20short-circuits%20and%20Session%20B%20never%20gets%20its%20own%20terminal%20%E2%80%94%20it%20just%20shows%20Session%20A's%20PTY.%20Adding%20%60createTabFlightRef.current%20%3D%20null%60%20here%20would%20cancel%20the%20in-progress%20guard%20and%20let%20the%20old%20flight's%20%60setTabs%60%20call%20be%20ignored%20%28or%20at%20least%20let%20Session%20B%20detect%20stale%20state%29.%0A%0A&repo=arul28%2Fade&pr=649&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx:170-179
**Stale flight leaks into new chat session on fast session switch**

When `chatSessionId` changes, this cleanup effect resets most refs and clears `tabs`, but does **not** reset `createTabFlightRef.current`. If a `window.ade.pty.create(...)` call is in-flight for Session A when the user switches to Session B, the flight resolves after the switch, appending the Session-A terminal entry into Session B's now-empty `tabs` via `setTabs`. Because `tabs.length > 0`, the auto-create guard for Session B (`if (!autoCreateOnOpen || revealActive || tabs.length > 0)`) short-circuits and Session B never gets its own terminal — it just shows Session A's PTY. Adding `createTabFlightRef.current = null` here would cancel the in-progress guard and let the old flight's `setTabs` call be ignored (or at least let Session B detect stale state).


`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Preserve interactive PATH for clean PTY ..."](https://github.com/arul28/ade/commit/9e996d0447bd217de831122a066bb43b0d8db704) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39727600)</sub>

<!-- /greptile_comment -->