### PR TITLE
Fix Files search folder collapse

### DIFF
--- a/apps/desktop/src/renderer/components/files/FilesExplorer.test.tsx
+++ b/apps/desktop/src/renderer/components/files/FilesExplorer.test.tsx
@@ -2,7 +2,24 @@
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FileTreeNode } from "../../../shared/types";
 import { FilesExplorer, type FilesExplorerProps } from "./FilesExplorer";
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count, estimateSize }: { count: number; estimateSize: () => number }) => {
+    const size = estimateSize();
+    return {
+      getTotalSize: () => count * size,
+      getVirtualItems: () =>
+        Array.from({ length: count }, (_, index) => ({
+          index,
+          key: index,
+          size,
+          start: index * size,
+        })),
+    };
+  },
+}));
 
 afterEach(cleanup);
 
@@ -60,5 +77,36 @@ describe("FilesExplorer mutating controls", () => {
     fireEvent.click(newFolder);
     expect(props.onCreateFile).toHaveBeenCalledWith("");
     expect(props.onCreateDirectory).toHaveBeenCalledWith("");
+  });
+});
+
+describe("FilesExplorer search filtering", () => {
+  it("lets users collapse and re-expand folders in filtered results", () => {
+    const tree: FileTreeNode[] = [
+      {
+        name: "src",
+        path: "src",
+        type: "directory",
+        children: [
+          {
+            name: "Button.tsx",
+            path: "src/Button.tsx",
+            type: "file",
+          },
+        ],
+      },
+    ];
+    renderExplorer({
+      tree,
+      searchQuery: "button",
+    });
+
+    expect(screen.getByText("Button.tsx")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("src"));
+    expect(screen.queryByText("Button.tsx")).toBeNull();
+
+    fireEvent.click(screen.getByText("src"));
+    expect(screen.getByText("Button.tsx")).toBeTruthy();
   });
 });

--- a/apps/desktop/src/renderer/components/files/FilesExplorer.test.tsx
+++ b/apps/desktop/src/renderer/components/files/FilesExplorer.test.tsx
@@ -96,7 +96,7 @@ describe("FilesExplorer search filtering", () => {
         ],
       },
     ];
-    renderExplorer({
+    const props = renderExplorer({
       tree,
       searchQuery: "button",
     });
@@ -104,9 +104,31 @@ describe("FilesExplorer search filtering", () => {
     expect(screen.getByText("Button.tsx")).toBeTruthy();
 
     fireEvent.click(screen.getByText("src"));
+    expect(props.onToggleDirectory).not.toHaveBeenCalled();
     expect(screen.queryByText("Button.tsx")).toBeNull();
 
     fireEvent.click(screen.getByText("src"));
+    expect(props.onToggleDirectory).not.toHaveBeenCalled();
     expect(screen.getByText("Button.tsx")).toBeTruthy();
+  });
+
+  it("keeps loaded folder matches under search-local expansion", () => {
+    const tree: FileTreeNode[] = [
+      {
+        name: "docs",
+        path: "docs",
+        type: "directory",
+        children: [],
+      },
+    ];
+    const props = renderExplorer({
+      tree,
+      searchQuery: "docs",
+    });
+
+    fireEvent.click(screen.getByText("docs"));
+
+    expect(props.onToggleDirectory).not.toHaveBeenCalled();
+    expect(screen.getByText("docs")).toBeTruthy();
   });
 });

--- a/apps/desktop/src/renderer/components/files/FilesExplorer.tsx
+++ b/apps/desktop/src/renderer/components/files/FilesExplorer.tsx
@@ -149,9 +149,13 @@ function flattenVisibleRows(args: {
         level: level + 1,
       })
       : [];
-    if (matchesQuery(node, query) || childRows.length > 0) {
+    const nodeMatchesQuery = matchesQuery(node, query);
+    if (nodeMatchesQuery || childRows.length > 0) {
+      const hasLoadedChildren = Array.isArray(node.children);
+      const useSearchExpansion = node.type === "directory"
+        && (childRows.length > 0 || (nodeMatchesQuery && hasLoadedChildren));
       const expansion = node.type === "directory"
-        ? childRows.length > 0
+        ? useSearchExpansion
           ? { mode: "search" as const, expanded: !args.searchCollapsed.has(node.path) }
           : { mode: "tree" as const, expanded: args.expanded.has(node.path) }
         : undefined;

--- a/apps/desktop/src/renderer/components/files/FilesExplorer.tsx
+++ b/apps/desktop/src/renderer/components/files/FilesExplorer.tsx
@@ -29,6 +29,10 @@ type ExplorerNodeRow = {
   kind: "node";
   node: FileTreeNode;
   level: number;
+  expansion?: {
+    mode: "tree" | "search";
+    expanded: boolean;
+  };
 };
 
 type ExplorerLoadMoreRow = {
@@ -103,6 +107,7 @@ function matchesQuery(node: FileTreeNode, query: string): boolean {
 function flattenVisibleRows(args: {
   nodes: FileTreeNode[];
   expanded: Set<string>;
+  searchCollapsed: Set<string>;
   query: string;
   includeLoadMore?: boolean;
   level?: number;
@@ -114,11 +119,15 @@ function flattenVisibleRows(args: {
   for (const node of args.nodes) {
     const children = node.children ?? [];
     if (!query) {
-      rows.push({ kind: "node", node, level });
-      if (node.type === "directory" && args.expanded.has(node.path) && children.length) {
+      const expansion = node.type === "directory"
+        ? { mode: "tree" as const, expanded: args.expanded.has(node.path) }
+        : undefined;
+      rows.push({ kind: "node", node, level, expansion });
+      if (expansion?.expanded && children.length) {
         rows.push(...flattenVisibleRows({
           nodes: children,
           expanded: args.expanded,
+          searchCollapsed: args.searchCollapsed,
           query,
           includeLoadMore: args.includeLoadMore,
           level: level + 1,
@@ -134,14 +143,20 @@ function flattenVisibleRows(args: {
       ? flattenVisibleRows({
         nodes: children,
         expanded: args.expanded,
+        searchCollapsed: args.searchCollapsed,
         query,
         includeLoadMore: false,
         level: level + 1,
       })
       : [];
     if (matchesQuery(node, query) || childRows.length > 0) {
-      rows.push({ kind: "node", node, level });
-      rows.push(...childRows);
+      const expansion = node.type === "directory"
+        ? childRows.length > 0
+          ? { mode: "search" as const, expanded: !args.searchCollapsed.has(node.path) }
+          : { mode: "tree" as const, expanded: args.expanded.has(node.path) }
+        : undefined;
+      rows.push({ kind: "node", node, level, expansion });
+      if (expansion?.mode !== "search" || expansion.expanded) rows.push(...childRows);
     }
   }
 
@@ -182,14 +197,17 @@ export function FilesExplorer({
   const [renamingPath, setRenamingPath] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
   const [renameError, setRenameError] = useState<string | null>(null);
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase();
+  const [searchCollapsed, setSearchCollapsed] = useState<Set<string>>(new Set());
   const rows = useMemo(
     () => flattenVisibleRows({
       nodes: tree,
       expanded,
+      searchCollapsed,
       query: searchQuery,
       includeLoadMore: Boolean(onLoadMoreChildren),
     }),
-    [tree, expanded, searchQuery, onLoadMoreChildren],
+    [tree, expanded, searchCollapsed, searchQuery, onLoadMoreChildren],
   );
 
   const virtualizer = useVirtualizer({
@@ -198,6 +216,10 @@ export function FilesExplorer({
     estimateSize: () => ROW_HEIGHT,
     overscan: 14,
   });
+
+  useEffect(() => {
+    setSearchCollapsed(new Set());
+  }, [normalizedSearchQuery]);
 
   useEffect(() => {
     if (!inlineRenameRequest?.path) return;
@@ -551,7 +573,7 @@ export function FilesExplorer({
                 );
               }
               const { node, level } = row;
-              const isExpanded = expanded.has(node.path);
+              const isExpanded = row.expansion?.expanded ?? false;
               const isLoading = node.type === "directory" && loadingDirectories.has(node.path);
               const isActive = (activeTabPath != null && arePathsEqual(activeTabPath, node.path, workspaceComparisonRoot))
                 || (selectedNodePath != null && arePathsEqual(selectedNodePath, node.path, workspaceComparisonRoot));
@@ -576,6 +598,15 @@ export function FilesExplorer({
               const handleRowActivate = () => {
                 onSelectNode(node.path);
                 if (node.type === "directory") {
+                  if (row.expansion?.mode === "search") {
+                    setSearchCollapsed((prev) => {
+                      const next = new Set(prev);
+                      if (isExpanded) next.add(node.path);
+                      else next.delete(node.path);
+                      return next;
+                    });
+                    return;
+                  }
                   onToggleDirectory(node.path, isExpanded, Array.isArray(node.children));
                   return;
                 }


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fwhere-og-image-thing-ade-23d53939 num=651 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fwhere-og-image-thing-ade-23d53939&amp;pr=651">ade/where-og-image-thing-ade-23d53939 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=651">PR #651</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved file explorer search behavior so matching folders can be collapsed and re-expanded without losing visibility of matching child files.

* **Bug Fixes**
  * Search results now preserve a more predictable folder expansion state while filtering, making navigation through filtered files easier.
  * Fixed explorer row state handling so search and normal tree browsing behave consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates file explorer search behavior for folder collapse state. The main changes are:

- Adds search-local expansion metadata to flattened explorer rows.
- Tracks collapsed folders separately while a search filter is active.
- Resets search collapse state when the normalized query changes.
- Adds tests for collapsing and re-expanding filtered folder matches.

<h3>Confidence Score: 5/5</h3>

The file explorer search changes are narrow and covered by targeted tests for the collapse and re-expand behavior.

The changes are limited to explorer row state handling and associated tests, with no unresolved functional concerns identified.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The FilesExplorer collapse tests were run and showed that, before the change, clicking src or docs invoked onToggleDirectory and caused the test failures on base.
- The changes were validated by re-running the tests, and all four FilesExplorer tests passed on head, with Button.tsx visibility cycling from visible to hidden to visible without onToggleDirectory, and docs remaining visible without onToggleDirectory.

<a href="https://app.greptile.com/trex/runs/12437390/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["ship: iteration 1 - address CodeRabbit r..."](https://github.com/arul28/ade/commit/05f30ffb92d1e8631c1ca3370fe5f934ba04b938) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40120282)</sub>

<!-- /greptile_comment -->