### PR TITLE
Claude Auth Login Prompt

### DIFF
--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -2819,6 +2819,55 @@ describe("AgentChatPane submit recovery", () => {
     expect(cursorCloudListAgents).not.toHaveBeenCalled();
   });
 
+  it("shows the Claude login prompt when the loaded chat history contains auth notices", async () => {
+    const session = buildSession("session-1", {
+      provider: "claude",
+      model: "claude-sonnet-4-6",
+      modelId: "anthropic/claude-sonnet-4-6",
+      status: "idle",
+    });
+    installAdeMocks({
+      sessions: [session],
+      includeClaudeModel: true,
+      eventHistory: {
+        sessionId: session.sessionId,
+        sessionFound: true,
+        truncated: false,
+        events: [
+          {
+            sessionId: session.sessionId,
+            timestamp: "2026-06-22T12:00:00.000Z",
+            sequence: 1,
+            event: { type: "user_message", text: "hello" },
+          },
+          {
+            sessionId: session.sessionId,
+            timestamp: "2026-06-22T12:00:01.000Z",
+            sequence: 2,
+            event: {
+              type: "system_notice",
+              noticeKind: "warning",
+              severity: "info",
+              status: "authentication_failed",
+              message: "Claude API retry 2/10: authentication failed",
+              detail: "HTTP 401",
+            },
+          },
+          {
+            sessionId: session.sessionId,
+            timestamp: "2026-06-22T12:00:03.000Z",
+            sequence: 3,
+            event: { type: "done", turnId: "turn-1", status: "failed" },
+          },
+        ],
+      },
+    });
+
+    renderPane(session);
+
+    expect(await screen.findByRole("button", { name: "Login to Claude" })).toBeTruthy();
+  });
+
   it("keeps the committed model visible until the backend confirms the switch", async () => {
     const session = buildSession("session-1", { status: "idle" });
     const sessions = [session];

--- a/apps/desktop/src/renderer/lib/claudeAuthPrompt.test.ts
+++ b/apps/desktop/src/renderer/lib/claudeAuthPrompt.test.ts
@@ -177,6 +177,19 @@ describe("claude auth prompt helpers", () => {
     })).toBe(false);
   });
 
+  it("does not treat successful text that quotes an API auth error as a Claude login failure", () => {
+    expect(shouldShowClaudeChatLoginPrompt({
+      provider: "claude",
+      events: [
+        envelope({
+          type: "text",
+          text: "The GitHub API Error: 401 Invalid authentication credentials means the repo token is stale.",
+        }),
+        envelope({ type: "done", turnId: "turn-1", status: "completed" }),
+      ],
+    })).toBe(false);
+  });
+
   it("suppresses the chat prompt once Claude has produced a later successful reply", () => {
     expect(shouldShowClaudeChatLoginPrompt({
       provider: "claude",

--- a/apps/desktop/src/renderer/lib/claudeAuthPrompt.test.ts
+++ b/apps/desktop/src/renderer/lib/claudeAuthPrompt.test.ts
@@ -165,6 +165,18 @@ describe("claude auth prompt helpers", () => {
     })).toBe(false);
   });
 
+  it("does not treat third-party invalid-credentials text as a Claude login failure", () => {
+    expect(shouldShowClaudeChatLoginPrompt({
+      provider: "claude",
+      events: [
+        envelope({
+          type: "text",
+          text: "GitHub request failed: Invalid authentication credentials",
+        }),
+      ],
+    })).toBe(false);
+  });
+
   it("suppresses the chat prompt once Claude has produced a later successful reply", () => {
     expect(shouldShowClaudeChatLoginPrompt({
       provider: "claude",

--- a/apps/desktop/src/renderer/lib/claudeAuthPrompt.test.ts
+++ b/apps/desktop/src/renderer/lib/claudeAuthPrompt.test.ts
@@ -110,6 +110,21 @@ describe("claude auth prompt helpers", () => {
     })).toBe(false);
   });
 
+  it("does not treat non-Claude auth system notices as Claude login failures", () => {
+    expect(shouldShowClaudeChatLoginPrompt({
+      provider: "claude",
+      events: [
+        envelope({
+          type: "system_notice",
+          noticeKind: "warning",
+          status: "authentication_failed",
+          message: "MCP tool failed to authenticate to GitHub",
+          detail: "HTTP 401",
+        }),
+      ],
+    })).toBe(false);
+  });
+
   it("detects the final plaintext Claude invalid-credentials failure", () => {
     expect(shouldShowClaudeChatLoginPrompt({
       provider: "claude",

--- a/apps/desktop/src/renderer/lib/claudeAuthPrompt.test.ts
+++ b/apps/desktop/src/renderer/lib/claudeAuthPrompt.test.ts
@@ -125,6 +125,20 @@ describe("claude auth prompt helpers", () => {
     })).toBe(false);
   });
 
+  it("does not treat generic invalid-credentials notice details as Claude login failures", () => {
+    expect(shouldShowClaudeChatLoginPrompt({
+      provider: "claude",
+      events: [
+        envelope({
+          type: "system_notice",
+          noticeKind: "hook",
+          message: "Hook response",
+          detail: "GitHub request failed: Invalid authentication credentials",
+        }),
+      ],
+    })).toBe(false);
+  });
+
   it("detects the final plaintext Claude invalid-credentials failure", () => {
     expect(shouldShowClaudeChatLoginPrompt({
       provider: "claude",

--- a/apps/desktop/src/renderer/lib/claudeAuthPrompt.test.ts
+++ b/apps/desktop/src/renderer/lib/claudeAuthPrompt.test.ts
@@ -79,6 +79,63 @@ describe("claude auth prompt helpers", () => {
     })).toBe(true);
   });
 
+  it("detects Claude auth failures emitted as system notices", () => {
+    expect(shouldShowClaudeChatLoginPrompt({
+      provider: "claude",
+      events: [
+        envelope({ type: "user_message", text: "hello" }),
+        envelope({
+          type: "system_notice",
+          noticeKind: "warning",
+          severity: "info",
+          status: "authentication_failed",
+          message: "Claude API retry 2/10: authentication failed",
+          detail: "HTTP 401",
+        }),
+        envelope({ type: "done", turnId: "turn-1", status: "failed" }),
+      ],
+    })).toBe(true);
+  });
+
+  it("does not treat Claude auth progress notices as failures", () => {
+    expect(shouldShowClaudeChatLoginPrompt({
+      provider: "claude",
+      events: [
+        envelope({
+          type: "system_notice",
+          noticeKind: "auth",
+          message: "Authenticating...",
+        }),
+      ],
+    })).toBe(false);
+  });
+
+  it("detects the final plaintext Claude invalid-credentials failure", () => {
+    expect(shouldShowClaudeChatLoginPrompt({
+      provider: "claude",
+      events: [
+        envelope({ type: "user_message", text: "hello" }),
+        envelope({
+          type: "text",
+          text: "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+        }),
+        envelope({ type: "done", turnId: "turn-1", status: "failed" }),
+      ],
+    })).toBe(true);
+  });
+
+  it("does not treat generic Claude text about auth failures as a login failure", () => {
+    expect(shouldShowClaudeChatLoginPrompt({
+      provider: "claude",
+      events: [
+        envelope({
+          type: "text",
+          text: "A GitHub request failed to authenticate because the remote server rejected it.",
+        }),
+      ],
+    })).toBe(false);
+  });
+
   it("suppresses the chat prompt once Claude has produced a later successful reply", () => {
     expect(shouldShowClaudeChatLoginPrompt({
       provider: "claude",

--- a/apps/desktop/src/renderer/lib/claudeAuthPrompt.ts
+++ b/apps/desktop/src/renderer/lib/claudeAuthPrompt.ts
@@ -52,7 +52,7 @@ export function textHasClaudeAuthError(value: string | null | undefined): boolea
   return CLAUDE_AUTH_ERROR_PATTERNS.some((pattern) => pattern.test(text));
 }
 
-function isClaudeAuthErrorEvent(event: AgentChatEvent): boolean {
+function isClaudeAuthErrorEvent(event: AgentChatEvent, options?: { allowTextAuthError?: boolean }): boolean {
   if (event.type === "error") {
     const info = typeof event.errorInfo === "object" && event.errorInfo ? event.errorInfo : null;
     if (info?.agentCli?.agent === "claude" && info.agentCli.category === "unauthenticated") return true;
@@ -64,7 +64,7 @@ function isClaudeAuthErrorEvent(event: AgentChatEvent): boolean {
     return textHasClaudeAuthError(text);
   }
   if (event.type === "text") {
-    return CLAUDE_TEXT_AUTH_ERROR_PATTERN.test(eventText(event));
+    return options?.allowTextAuthError === true && CLAUDE_TEXT_AUTH_ERROR_PATTERN.test(eventText(event));
   }
   return false;
 }
@@ -89,10 +89,19 @@ export function shouldShowClaudeChatLoginPrompt({
 }): boolean {
   if (provider !== "claude" || turnActive) return false;
 
+  let sawFailedTurnBoundary = false;
   for (let index = events.length - 1; index >= 0 && index >= events.length - 80; index -= 1) {
     const event = events[index]?.event;
     if (!event) continue;
-    if (isClaudeAuthErrorEvent(event)) return true;
+    if (event.type === "done" && event.status === "failed") {
+      sawFailedTurnBoundary = true;
+      continue;
+    }
+    if (event.type === "status" && event.turnStatus === "failed") {
+      sawFailedTurnBoundary = true;
+      continue;
+    }
+    if (isClaudeAuthErrorEvent(event, { allowTextAuthError: sawFailedTurnBoundary })) return true;
     if (isSuccessfulConversationBoundary(event)) return false;
     if (event.type === "status" && event.turnStatus === "started") return false;
   }

--- a/apps/desktop/src/renderer/lib/claudeAuthPrompt.ts
+++ b/apps/desktop/src/renderer/lib/claudeAuthPrompt.ts
@@ -10,8 +10,8 @@ const CLAUDE_INVALID_CREDENTIALS_PATTERNS: RegExp[] = [
 const CLAUDE_AUTH_ERROR_PATTERNS: RegExp[] = [
   /\bplease\s+run\s+\/login\b/i,
   ...CLAUDE_INVALID_CREDENTIALS_PATTERNS,
-  /\bauthentication[_\s-]*failed\b/i,
-  /\bfailed\s+to\s+authenticate\b/i,
+  /\bclaude\b.*\bauthentication[_\s-]*failed\b/i,
+  /\bclaude\b.*\bfailed\s+to\s+authenticate\b/i,
   /\bclaude\b.*\b(not\s+logged\s+in|not\s+authenticated|unauthorized|authentication\s+failed|login\s+required)\b/i,
   /\brun\s+[`'"]?claude\s+auth\s+login[`'"]?/i,
   /\brun\s+[`'"]?claude\s+\/login[`'"]?/i,

--- a/apps/desktop/src/renderer/lib/claudeAuthPrompt.ts
+++ b/apps/desktop/src/renderer/lib/claudeAuthPrompt.ts
@@ -58,7 +58,9 @@ function isClaudeAuthErrorEvent(event: AgentChatEvent): boolean {
     return textHasClaudeAuthError(eventText(event));
   }
   if (event.type === "system_notice") {
-    return textHasClaudeAuthError(eventText(event));
+    const text = eventText(event);
+    if (event.noticeKind !== "auth" && !/\bclaude\b/i.test(text)) return false;
+    return textHasClaudeAuthError(text);
   }
   if (event.type === "text") {
     const text = eventText(event);

--- a/apps/desktop/src/renderer/lib/claudeAuthPrompt.ts
+++ b/apps/desktop/src/renderer/lib/claudeAuthPrompt.ts
@@ -2,10 +2,16 @@ import type { AgentChatEvent, AgentChatEventEnvelope, TerminalSessionSummary } f
 
 export const CLAUDE_AUTH_LOGIN_COMMAND = "claude auth login";
 
-const CLAUDE_AUTH_ERROR_PATTERNS: RegExp[] = [
-  /\bplease\s+run\s+\/login\b/i,
+const CLAUDE_INVALID_CREDENTIALS_PATTERNS: RegExp[] = [
   /\bapi\s+error:\s*401\b.*\binvalid\s+authentication\s+credentials\b/i,
   /\binvalid\s+authentication\s+credentials\b/i,
+];
+
+const CLAUDE_AUTH_ERROR_PATTERNS: RegExp[] = [
+  /\bplease\s+run\s+\/login\b/i,
+  ...CLAUDE_INVALID_CREDENTIALS_PATTERNS,
+  /\bauthentication[_\s-]*failed\b/i,
+  /\bfailed\s+to\s+authenticate\b/i,
   /\bclaude\b.*\b(not\s+logged\s+in|not\s+authenticated|unauthorized|authentication\s+failed|login\s+required)\b/i,
   /\brun\s+[`'"]?claude\s+auth\s+login[`'"]?/i,
   /\brun\s+[`'"]?claude\s+\/login[`'"]?/i,
@@ -16,9 +22,27 @@ const CLAUDE_CLI_TOOL_TYPES = new Set<TerminalSessionSummary["toolType"]>([
   "claude-orchestrated",
 ]);
 
+function noticeDetailText(detail: Extract<AgentChatEvent, { type: "system_notice" }>["detail"]): string {
+  if (typeof detail === "string") return detail;
+  if (!detail || typeof detail !== "object") return "";
+  return [
+    typeof detail.title === "string" ? detail.title : "",
+    typeof detail.summary === "string" ? detail.summary : "",
+    ...(Array.isArray(detail.metrics) ? detail.metrics.map((metric) => `${metric.label}: ${metric.value}`) : []),
+    ...(Array.isArray(detail.sections)
+      ? detail.sections.flatMap((section) => [
+          section.title,
+          ...section.items.map((item) => typeof item === "string" ? item : `${item.label}: ${item.value}`),
+        ])
+      : []),
+  ].filter(Boolean).join("\n");
+}
+
 function eventText(event: AgentChatEvent): string {
-  if (event.type !== "error") return "";
-  return `${event.message ?? ""}\n${event.detail ?? ""}`;
+  if (event.type === "error") return `${event.message ?? ""}\n${event.detail ?? ""}`;
+  if (event.type === "system_notice") return `${event.message ?? ""}\n${event.status ?? ""}\n${noticeDetailText(event.detail)}`;
+  if (event.type === "text") return event.text ?? "";
+  return "";
 }
 
 export function textHasClaudeAuthError(value: string | null | undefined): boolean {
@@ -28,10 +52,19 @@ export function textHasClaudeAuthError(value: string | null | undefined): boolea
 }
 
 function isClaudeAuthErrorEvent(event: AgentChatEvent): boolean {
-  if (event.type !== "error") return false;
-  const info = typeof event.errorInfo === "object" && event.errorInfo ? event.errorInfo : null;
-  if (info?.agentCli?.agent === "claude" && info.agentCli.category === "unauthenticated") return true;
-  return textHasClaudeAuthError(eventText(event));
+  if (event.type === "error") {
+    const info = typeof event.errorInfo === "object" && event.errorInfo ? event.errorInfo : null;
+    if (info?.agentCli?.agent === "claude" && info.agentCli.category === "unauthenticated") return true;
+    return textHasClaudeAuthError(eventText(event));
+  }
+  if (event.type === "system_notice") {
+    return textHasClaudeAuthError(eventText(event));
+  }
+  if (event.type === "text") {
+    const text = eventText(event);
+    return CLAUDE_INVALID_CREDENTIALS_PATTERNS.some((pattern) => pattern.test(text));
+  }
+  return false;
 }
 
 function isSuccessfulConversationBoundary(event: AgentChatEvent): boolean {

--- a/apps/desktop/src/renderer/lib/claudeAuthPrompt.ts
+++ b/apps/desktop/src/renderer/lib/claudeAuthPrompt.ts
@@ -6,6 +6,7 @@ const CLAUDE_INVALID_CREDENTIALS_PATTERNS: RegExp[] = [
   /\bapi\s+error:\s*401\b.*\binvalid\s+authentication\s+credentials\b/i,
   /\binvalid\s+authentication\s+credentials\b/i,
 ];
+const CLAUDE_TEXT_AUTH_ERROR_PATTERN = /\bapi\s+error:\s*401\b.*\binvalid\s+authentication\s+credentials\b/i;
 
 const CLAUDE_AUTH_ERROR_PATTERNS: RegExp[] = [
   /\bplease\s+run\s+\/login\b/i,
@@ -63,8 +64,7 @@ function isClaudeAuthErrorEvent(event: AgentChatEvent): boolean {
     return textHasClaudeAuthError(text);
   }
   if (event.type === "text") {
-    const text = eventText(event);
-    return CLAUDE_INVALID_CREDENTIALS_PATTERNS.some((pattern) => pattern.test(text));
+    return CLAUDE_TEXT_AUTH_ERROR_PATTERN.test(eventText(event));
   }
   return false;
 }


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fcorrect-if-im-wrong-but-1a89ed5f num=652 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fcorrect-if-im-wrong-but-1a89ed5f&amp;pr=652">ade/correct-if-im-wrong-but-1a89ed5f branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=652">PR #652</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Claude login failures so the app now shows a “Login to Claude” prompt more reliably after authentication errors.
  * Better handles warning notices, failed chat turns, and invalid-credentials messages, while avoiding false prompts for unrelated or in-progress authentication messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves Claude login-prompt detection by extending the auth-error scanner to handle `system_notice` events (authentication-failure retries) and `text` events (raw API 401 messages), adding appropriate guards to avoid false positives from third-party tools.

- `claudeAuthPrompt.ts` refactors `isClaudeAuthErrorEvent` to process `system_notice` and `text` event types, using a new `sawFailedTurnBoundary` flag so `text`-based detection is only active after a confirmed failed turn.
- New `CLAUDE_INVALID_CREDENTIALS_PATTERNS` array and `CLAUDE_TEXT_AUTH_ERROR_PATTERN` constant are introduced; the `system_notice` path requires the word "claude" in the event text (or `noticeKind === "auth"`) before applying auth-error patterns.
- Twelve new unit tests and one integration test cover the happy path, progress-notice exclusion, third-party-credential exclusion, and cross-boundary suppression scenarios.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The new detection paths are well-guarded and the test suite covers the key boundary conditions introduced by this change.

The core backward-scan logic is sound: system_notice events require 'claude' in the concatenated text (or noticeKind === 'auth') before any pattern is tested, and text events require both a confirmed failed-turn boundary and the stricter API-error-401 pattern. No existing behaviour is removed, only extended.

apps/desktop/src/renderer/lib/claudeAuthPrompt.ts — the regex duplication and the noticeKind='auth' guard bypass are both in this file.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/lib/claudeAuthPrompt.ts | Core logic file. New system_notice and text event handling is well-guarded overall, but CLAUDE_TEXT_AUTH_ERROR_PATTERN is a verbatim duplicate of CLAUDE_INVALID_CREDENTIALS_PATTERNS[0], and the noticeKind==="auth" bypass silently drops the "claude" anchor and applies the broad invalid-authentication-credentials pattern. |
| apps/desktop/src/renderer/lib/claudeAuthPrompt.test.ts | Good unit test coverage: progress-notice exclusion, non-Claude third-party exclusion, text-with-API-error detection, successful-boundary suppression, and generic-text false-positive prevention are all exercised. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx | Integration test adds a realistic history scenario (user message → auth-retry notice → done:failed) and asserts the "Login to Claude" button is rendered. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[shouldShowClaudeChatLoginPrompt] --> B{provider=claude\nand not turnActive?}
    B -- No --> Z[return false]
    B -- Yes --> C[Scan last 80 events backward]
    C --> D{event type?}
    D -- done:failed\nor status:failed --> E[sawFailedTurnBoundary=true\ncontinue]
    E --> D
    D -- error --> F{structured unauthenticated\nor textHasClaudeAuthError?}
    F -- Yes --> T[return true]
    F -- No --> G{isSuccessfulBoundary?}
    D -- system_notice --> H{noticeKind=auth\nor text contains 'claude'?}
    H -- No --> G
    H -- Yes --> I{textHasClaudeAuthError\nall patterns}
    I -- Yes --> T
    I -- No --> G
    D -- text --> J{allowTextAuthError\ni.e. sawFailedTurnBoundary?}
    J -- No --> G
    J -- Yes --> K{CLAUDE_TEXT_AUTH_ERROR_PATTERN\nAPI Error 401 + invalid credentials}
    K -- Yes --> T
    K -- No --> G
    G -- Yes done:completed\nor tool event\nor non-empty text --> Z
    G -- No --> D
    C -- exhausted loop --> L{authAvailable=false\nand any auth error event\nexcluding text events}
    L -- Yes --> T
    L -- No --> Z
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[shouldShowClaudeChatLoginPrompt] --> B{provider=claude\nand not turnActive?}
    B -- No --> Z[return false]
    B -- Yes --> C[Scan last 80 events backward]
    C --> D{event type?}
    D -- done:failed\nor status:failed --> E[sawFailedTurnBoundary=true\ncontinue]
    E --> D
    D -- error --> F{structured unauthenticated\nor textHasClaudeAuthError?}
    F -- Yes --> T[return true]
    F -- No --> G{isSuccessfulBoundary?}
    D -- system_notice --> H{noticeKind=auth\nor text contains 'claude'?}
    H -- No --> G
    H -- Yes --> I{textHasClaudeAuthError\nall patterns}
    I -- Yes --> T
    I -- No --> G
    D -- text --> J{allowTextAuthError\ni.e. sawFailedTurnBoundary?}
    J -- No --> G
    J -- Yes --> K{CLAUDE_TEXT_AUTH_ERROR_PATTERN\nAPI Error 401 + invalid credentials}
    K -- Yes --> T
    K -- No --> G
    G -- Yes done:completed\nor tool event\nor non-empty text --> Z
    G -- No --> D
    C -- exhausted loop --> L{authAvailable=false\nand any auth error event\nexcluding text events}
    L -- Yes --> T
    L -- No --> Z
```

</a>

<sub>Reviews (5): Last reviewed commit: ["fix: require failed turn for text auth p..."](https://github.com/arul28/ade/commit/9a6f95161bac00b786c7d3ffeb9ad91bf6fe1563) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40120716)</sub>

<!-- /greptile_comment -->