### PR TITLE
Output Ade Cli Session Carlify

### DIFF
--- a/apps/ade-cli/src/eventBuffer.ts
+++ b/apps/ade-cli/src/eventBuffer.ts
@@ -19,6 +19,7 @@ export type EventBuffer = {
   drain(cursor: number, limit?: number): EventBufferDrainResult;
   subscribe(listener: (event: BufferedEvent) => void): () => void;
   epoch(): string;
+  latestCursor(): number;
   size(): number;
 };
 
@@ -66,6 +67,9 @@ export function createEventBuffer(capacity = 10_000): EventBuffer {
     },
     epoch() {
       return eventEpoch;
+    },
+    latestCursor() {
+      return nextId - 1;
     },
     size() {
       return events.length;

--- a/apps/ade-cli/src/multiProjectRpcServer.test.ts
+++ b/apps/ade-cli/src/multiProjectRpcServer.test.ts
@@ -588,6 +588,7 @@ describe("multi-project RPC server", () => {
     }) as { subscriptionId: string; hasMore: boolean; nextCursor: number };
 
     expect(subscribed.hasMore).toBe(false);
+    expect(subscribed.nextCursor).toBe(1);
     expect(notify).not.toHaveBeenCalled();
 
     eventBuffer.push({

--- a/apps/ade-cli/src/multiProjectRpcServer.ts
+++ b/apps/ade-cli/src/multiProjectRpcServer.ts
@@ -397,7 +397,12 @@ export function createMultiProjectRpcRequestHandler(
 
     const replayResult = replay
       ? scope.runtime.eventBuffer.drain(cursor, limit)
-      : { events: [], nextCursor: cursor, hasMore: false, eventEpoch };
+      : {
+          events: [],
+          nextCursor: scope.runtime.eventBuffer.latestCursor(),
+          hasMore: false,
+          eventEpoch,
+        };
     for (const event of replayResult.events) {
       if (shouldForward(event))
         emitRuntimeEvent(subscriptionId, projectId, event, replayResult.eventEpoch);

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
@@ -443,6 +443,7 @@ describe("registerRuntimeBridge", () => {
       expect.objectContaining({ cursor: 3, limit: 10 }),
       expect.any(Function),
       expect.any(Function),
+      expect.any(Function),
     );
   });
 
@@ -525,6 +526,7 @@ describe("registerRuntimeBridge", () => {
     expect(localRuntimeConnectionPool.subscribeEventsForRoot).toHaveBeenCalledWith(
       "/other-repo",
       { cursor: 2, limit: 10, category: undefined, replay: undefined },
+      expect.any(Function),
       expect.any(Function),
       expect.any(Function),
     );
@@ -664,6 +666,17 @@ describe("registerRuntimeBridge", () => {
       nextCursor: 1,
       hasMore: false,
     });
+    remoteSubscribeEventsForTargetMock.mockImplementation(
+      async (_target, _projectId, _request, _onEvent, _onEnded, onSubscribed) => {
+        onSubscribed?.({
+          events: [],
+          nextCursor: 7,
+          hasMore: false,
+          eventEpoch: "epoch-remote-1",
+        });
+        return vi.fn();
+      },
+    );
     registerRuntimeBridge({
       appVersion: "1.0.0",
       globalStatePath: "/tmp/ade-state.json",
@@ -678,13 +691,19 @@ describe("registerRuntimeBridge", () => {
           request: { cursor: 0, limit: 100, replay: false },
         },
       ),
-    ).resolves.toEqual({ events: [], nextCursor: 0, hasMore: false });
+    ).resolves.toEqual({
+      events: [],
+      nextCursor: 7,
+      hasMore: false,
+      eventEpoch: "epoch-remote-1",
+    });
 
     expect(remoteStreamEventsForTargetMock).not.toHaveBeenCalled();
     expect(remoteSubscribeEventsForTargetMock).toHaveBeenCalledWith(
       target,
       "project-1",
       { cursor: 0, limit: 100, category: undefined, replay: false },
+      expect.any(Function),
       expect.any(Function),
       expect.any(Function),
     );
@@ -727,6 +746,7 @@ describe("registerRuntimeBridge", () => {
         category: undefined,
         replay: undefined,
       },
+      expect.any(Function),
       expect.any(Function),
       expect.any(Function),
     );

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.ts
@@ -94,9 +94,15 @@ type RuntimeEventWindowSubscription = {
   cleanup: (() => void) | null;
 };
 
+type RuntimeEventSubscriptionInit = Pick<
+  RemoteRuntimeStreamEventsResult,
+  "nextCursor" | "hasMore" | "eventEpoch"
+>;
+
 type RuntimeEventSubscribe = (
   onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
   onEnded: () => void,
+  onSubscribed?: (result: RuntimeEventSubscriptionInit) => void,
 ) => Promise<() => void>;
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -408,14 +414,14 @@ export function registerRuntimeBridge({
     }
   };
 
-  const ensureRuntimeEventSubscription = (
+  const ensureRuntimeEventSubscription = async (
     sender: WebContents,
     bindingKey: string,
     requestKey: string,
     subscribe: RuntimeEventSubscribe,
-  ): void => {
+  ): Promise<RuntimeEventSubscriptionInit | null> => {
     const existing = runtimeEventSubscriptions.get(sender.id);
-    if (existing?.requestKey === requestKey) return;
+    if (existing?.requestKey === requestKey) return null;
     cleanupRuntimeEventSubscription(sender.id);
     watchRuntimeEventSender(sender);
     runtimeEventSubscriptions.set(sender.id, { bindingKey, requestKey, cleanup: null });
@@ -425,31 +431,36 @@ export function registerRuntimeBridge({
         runtimeEventSubscriptions.delete(sender.id);
       }
     };
-    void subscribe(
-      (event, eventEpoch) =>
-        sendRuntimeEvent(sender, bindingKey, requestKey, event, eventEpoch),
-      onEnded,
-    )
-      .then((cleanup) => {
-        const current = runtimeEventSubscriptions.get(sender.id);
-        if (
-          !current ||
-          current.requestKey !== requestKey ||
-          current.bindingKey !== bindingKey ||
-          sender.isDestroyed()
-        ) {
-          cleanup();
-          return;
-        }
-        current.cleanup = cleanup;
-      })
-      .catch((error) => {
-        const current = runtimeEventSubscriptions.get(sender.id);
-        if (current?.requestKey === requestKey && current.bindingKey === bindingKey && !current.cleanup) {
-          runtimeEventSubscriptions.delete(sender.id);
-        }
-        console.warn("Runtime event subscription failed", error);
-      });
+    let subscriptionInit: RuntimeEventSubscriptionInit | null = null;
+    try {
+      const cleanup = await subscribe(
+        (event, eventEpoch) =>
+          sendRuntimeEvent(sender, bindingKey, requestKey, event, eventEpoch),
+        onEnded,
+        (result) => {
+          subscriptionInit = result;
+        },
+      );
+      const current = runtimeEventSubscriptions.get(sender.id);
+      if (
+        !current ||
+        current.requestKey !== requestKey ||
+        current.bindingKey !== bindingKey ||
+        sender.isDestroyed()
+      ) {
+        cleanup();
+        return subscriptionInit;
+      }
+      current.cleanup = cleanup;
+      return subscriptionInit;
+    } catch (error) {
+      const current = runtimeEventSubscriptions.get(sender.id);
+      if (current?.requestKey === requestKey && current.bindingKey === bindingKey && !current.cleanup) {
+        runtimeEventSubscriptions.delete(sender.id);
+      }
+      console.warn("Runtime event subscription failed", error);
+      throw error;
+    }
   };
 
   ipcMain.handle(
@@ -976,27 +987,35 @@ export function registerRuntimeBridge({
           localRuntimeRootKey(binding.rootPath) === localRuntimeRootKey(rootPath)
             ? binding.key
             : `local:${rootPath}`;
-        ensureRuntimeEventSubscription(
+        const subscribe = (
+          onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
+          onEnded: () => void,
+          onSubscribed?: (result: RuntimeEventSubscriptionInit) => void,
+        ) =>
+          localRuntimeConnectionPool.subscribeEventsForRoot(
+            rootPath,
+            {
+              cursor: request.cursor,
+              limit: request.limit,
+              category: request.category,
+              replay: request.replay,
+            },
+            onEvent,
+            onEnded,
+            onSubscribed,
+          );
+        const requestKey = `${bindingKey}:${request.category ?? "*"}:${request.replay === false ? "live" : "replay"}`;
+        const subscriptionInit = await ensureRuntimeEventSubscription(
           event.sender,
           bindingKey,
-          `${bindingKey}:${request.category ?? "*"}:${request.replay === false ? "live" : "replay"}`,
-          (onEvent, onEnded) =>
-            localRuntimeConnectionPool.subscribeEventsForRoot(
-              rootPath,
-              {
-                cursor: request.cursor,
-                limit: request.limit,
-                category: request.category,
-                replay: request.replay,
-              },
-              onEvent,
-              onEnded,
-            ),
+          requestKey,
+          subscribe,
         );
         return {
           events: [],
-          nextCursor: request.cursor ?? 0,
-          hasMore: false,
+          nextCursor: subscriptionInit?.nextCursor ?? request.cursor ?? 0,
+          hasMore: subscriptionInit?.hasMore === true,
+          ...(subscriptionInit?.eventEpoch ? { eventEpoch: subscriptionInit.eventEpoch } : {}),
         };
       }
       return await localRuntimeConnectionPool.streamEventsForRoot(
@@ -1024,35 +1043,51 @@ export function registerRuntimeBridge({
       const target = remoteConnectionService.getTarget(id);
       if (!target) throw new Error("Remote target was not found.");
       const request = normalizeRuntimeStreamEventsRequest(arg?.request);
-      const result = request.replay === false
-        ? {
-            events: [],
-            nextCursor: request.cursor ?? 0,
-            hasMore: false,
-          }
-        : await remoteConnectionService.streamEvents(
-            target.id,
-            projectId,
-            request,
-          );
-      ensureRuntimeEventSubscription(
-        event.sender,
-        `remote:${target.id}:${projectId}`,
-        `remote:${target.id}:${projectId}:${request.category ?? "*"}:${request.replay === false ? "live" : "replay"}`,
-        (onEvent, onEnded) =>
-          remoteConnectionService.subscribeEvents(
-            target.id,
-            projectId,
-            {
-              cursor: request.cursor,
-              limit: request.limit,
-              category: request.category,
-              replay: request.replay,
-            },
-            onEvent,
-            onEnded,
-          ),
+      const bindingKey = `remote:${target.id}:${projectId}`;
+      const requestKey = `${bindingKey}:${request.category ?? "*"}:${request.replay === false ? "live" : "replay"}`;
+      const subscribe = (
+        onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
+        onEnded: () => void,
+        onSubscribed?: (result: RuntimeEventSubscriptionInit) => void,
+      ) =>
+        remoteConnectionService.subscribeEvents(
+          target.id,
+          projectId,
+          {
+            cursor: request.cursor,
+            limit: request.limit,
+            category: request.category,
+            replay: request.replay,
+          },
+          onEvent,
+          onEnded,
+          onSubscribed,
+        );
+      if (request.replay === false) {
+        const subscriptionInit = await ensureRuntimeEventSubscription(
+          event.sender,
+          bindingKey,
+          requestKey,
+          subscribe,
+        );
+        return {
+          events: [],
+          nextCursor: subscriptionInit?.nextCursor ?? request.cursor ?? 0,
+          hasMore: subscriptionInit?.hasMore === true,
+          ...(subscriptionInit?.eventEpoch ? { eventEpoch: subscriptionInit.eventEpoch } : {}),
+        };
+      }
+      const result = await remoteConnectionService.streamEvents(
+        target.id,
+        projectId,
+        request,
       );
+      void ensureRuntimeEventSubscription(
+        event.sender,
+        bindingKey,
+        requestKey,
+        subscribe,
+      ).catch(() => {});
       return result;
     },
   );

--- a/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
+++ b/apps/desktop/src/main/services/localRuntime/localRuntimeConnectionPool.ts
@@ -1151,10 +1151,11 @@ export class LocalRuntimeConnectionPool {
     request: RemoteRuntimeStreamEventsRequest = {},
     onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
     onEnded?: () => void,
+    onSubscribed?: (result: RemoteRuntimeStreamEventsResult) => void,
   ): Promise<() => void> {
     const project = await this.ensureProject(rootPath);
     const entry = await this.connect();
-    return await subscribeToRuntimeEvents(entry.client, project.projectId, request, onEvent, onEnded);
+    return await subscribeToRuntimeEvents(entry.client, project.projectId, request, onEvent, onEnded, onSubscribed);
   }
 
   async callSyncForRoot<T>(
@@ -1768,6 +1769,7 @@ async function subscribeToRuntimeEvents(
   request: RemoteRuntimeStreamEventsRequest,
   onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
   onEnded?: () => void,
+  onSubscribed?: (result: RemoteRuntimeStreamEventsResult) => void,
 ): Promise<() => void> {
   const pendingNotifications: RuntimeEventNotification[] = [];
   let closed = false;
@@ -1801,6 +1803,7 @@ async function subscribeToRuntimeEvents(
       ...(typeof request.replay === "boolean" ? { replay: request.replay } : {}),
     });
     subscriptionId = readSubscriptionId(value);
+    onSubscribed?.(normalizeRuntimeEventsSubscribeResult(value, request.cursor));
     for (const notification of pendingNotifications) {
       if (closed) break;
       if (notification.subscriptionId === subscriptionId) {
@@ -1823,6 +1826,31 @@ async function subscribeToRuntimeEvents(
     if (id != null) {
       void client.call("runtimeEvents.unsubscribe", { subscriptionId: id }).catch(() => {});
     }
+  };
+}
+
+function normalizeRuntimeEventsSubscribeResult(
+  value: unknown,
+  fallbackCursor: number | undefined,
+): RemoteRuntimeStreamEventsResult {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {
+      events: [],
+      nextCursor: clampCursor(fallbackCursor),
+      hasMore: false,
+    };
+  }
+  const record = value as Record<string, unknown>;
+  const eventEpoch = typeof record.eventEpoch === "string" && record.eventEpoch.trim()
+    ? record.eventEpoch.trim()
+    : null;
+  return {
+    events: [],
+    nextCursor: typeof record.nextCursor === "number" && Number.isFinite(record.nextCursor)
+      ? Math.max(0, Math.floor(record.nextCursor))
+      : clampCursor(fallbackCursor),
+    hasMore: record.hasMore === true,
+    ...(eventEpoch ? { eventEpoch } : {}),
   };
 }
 

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.ts
@@ -737,6 +737,7 @@ export class RemoteConnectionPool {
     request: RemoteRuntimeStreamEventsRequest = {},
     onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
     onEnded?: () => void,
+    onSubscribed?: (result: RemoteRuntimeStreamEventsResult) => void,
   ): Promise<() => void> {
     const entry = await this.requireEntry(targetId);
     return await subscribeToRuntimeEvents(
@@ -745,6 +746,7 @@ export class RemoteConnectionPool {
       request,
       onEvent,
       onEnded,
+      onSubscribed,
     );
   }
 
@@ -754,6 +756,7 @@ export class RemoteConnectionPool {
     request: RemoteRuntimeStreamEventsRequest = {},
     onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
     onEnded?: () => void,
+    onSubscribed?: (result: RemoteRuntimeStreamEventsResult) => void,
   ): Promise<() => void> {
     return await this.withEntryForTarget(
       target,
@@ -764,6 +767,7 @@ export class RemoteConnectionPool {
           request,
           onEvent,
           onEnded,
+          onSubscribed,
         ),
       { retryOnConnectionError: true },
     );
@@ -1068,6 +1072,7 @@ async function subscribeToRuntimeEvents(
   request: RemoteRuntimeStreamEventsRequest,
   onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
   onEnded?: () => void,
+  onSubscribed?: (result: RemoteRuntimeStreamEventsResult) => void,
 ): Promise<() => void> {
   const pendingNotifications: RuntimeEventNotification[] = [];
   let closed = false;
@@ -1106,6 +1111,7 @@ async function subscribeToRuntimeEvents(
       ...(typeof request.replay === "boolean" ? { replay: request.replay } : {}),
     });
     subscriptionId = readSubscriptionId(value);
+    onSubscribed?.(normalizeRuntimeEventsSubscribeResult(value, request.cursor));
     for (const notification of pendingNotifications) {
       if (closed) break;
       if (notification.subscriptionId === subscriptionId) {
@@ -1130,6 +1136,34 @@ async function subscribeToRuntimeEvents(
         .call("runtimeEvents.unsubscribe", { subscriptionId: id })
         .catch(() => {});
     }
+  };
+}
+
+function normalizeRuntimeEventsSubscribeResult(
+  value: unknown,
+  fallbackCursor: number | undefined,
+): RemoteRuntimeStreamEventsResult {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {
+      events: [],
+      nextCursor: clampCursor(fallbackCursor),
+      hasMore: false,
+    };
+  }
+  const record = value as Record<string, unknown>;
+  const eventEpoch =
+    typeof record.eventEpoch === "string" && record.eventEpoch.trim()
+      ? record.eventEpoch.trim()
+      : null;
+  return {
+    events: [],
+    nextCursor:
+      typeof record.nextCursor === "number" &&
+      Number.isFinite(record.nextCursor)
+        ? Math.max(0, Math.floor(record.nextCursor))
+        : clampCursor(fallbackCursor),
+    hasMore: record.hasMore === true,
+    ...(eventEpoch ? { eventEpoch } : {}),
   };
 }
 

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts
@@ -504,8 +504,9 @@ export class RemoteConnectionService {
     targetId: string,
     projectId: string,
     request: RemoteRuntimeStreamEventsRequest = {},
-    onEvent: (event: RemoteRuntimeBufferedEvent) => void,
+    onEvent: (event: RemoteRuntimeBufferedEvent, eventEpoch?: string | null) => void,
     onEnded?: () => void,
+    onSubscribed?: (result: RemoteRuntimeStreamEventsResult) => void,
   ): Promise<() => void> {
     const target = this.requireTargetForImplicitUse(targetId);
     try {
@@ -515,6 +516,7 @@ export class RemoteConnectionService {
         request,
         onEvent,
         onEnded,
+        onSubscribed,
       );
       this.mergeStatus(targetId, {
         state: "connected",

--- a/apps/desktop/src/preload/preload.test.ts
+++ b/apps/desktop/src/preload/preload.test.ts
@@ -4092,7 +4092,7 @@ describe("preload OAuth bridge", () => {
           streamRequests.push(arg);
           return {
             events: [],
-            nextCursor: 0,
+            nextCursor: 12,
             hasMore: false,
             eventEpoch: "epoch-a",
           };
@@ -4123,11 +4123,18 @@ describe("preload OAuth bridge", () => {
 
       await vi.advanceTimersByTimeAsync(0);
       expect(streamRequests).toHaveLength(1);
+      expect(streamRequests[0]).toMatchObject({
+        request: { cursor: 0, limit: 100, replay: false },
+      });
 
       await vi.advanceTimersByTimeAsync(2_499);
       expect(streamRequests).toHaveLength(1);
       await vi.advanceTimersByTimeAsync(1);
       expect(streamRequests).toHaveLength(2);
+      expect(streamRequests[1]).toMatchObject({
+        request: { cursor: 12, limit: 100 },
+      });
+      expect((streamRequests[1] as { request?: { replay?: boolean } }).request?.replay).toBeUndefined();
 
       await vi.advanceTimersByTimeAsync(4_999);
       expect(streamRequests).toHaveLength(2);

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1803,6 +1803,8 @@ async function pollRemoteRuntimeEvents(): Promise<void> {
         ? { replay: false }
         : {}),
     } satisfies RemoteRuntimeStreamEventsRequest;
+    const suppressingInitialRemoteReplay =
+      binding.kind === "remote" && request.replay === false;
     const batch =
       binding.kind === "remote"
         ? ((await ipcRenderer.invoke(IPC.remoteRuntimeStreamEvents, {
@@ -1845,6 +1847,9 @@ async function pollRemoteRuntimeEvents(): Promise<void> {
     remoteRuntimeEventCursor = Number.isFinite(batch.nextCursor)
       ? Math.max(0, Math.floor(batch.nextCursor))
       : remoteRuntimeEventCursor;
+    if (suppressingInitialRemoteReplay) {
+      remoteRuntimeEventReplaySuppressed = false;
+    }
 
     for (const event of batch.events) {
       const eventTime = Date.parse(event.timestamp);

--- a/apps/desktop/src/renderer/components/files/treeHelpers.test.ts
+++ b/apps/desktop/src/renderer/components/files/treeHelpers.test.ts
@@ -4,6 +4,7 @@ import {
   hasLoadedDirectoryChildren,
   isUnavailableGitDecorationsError,
   loadedDirectoryChildrenCount,
+  nearestLoadedAncestorDirectoryPath,
   parentPathForFileChange,
   replaceTreeNodeChildren,
 } from "./treeHelpers";
@@ -74,6 +75,33 @@ describe("file tree change refresh helpers", () => {
     expect(loadedDirectoryChildrenCount(tree, "marketing")).toBe(1);
     expect(loadedDirectoryChildrenCount(tree, "src")).toBe(0);
     expect(loadedDirectoryChildrenCount(tree, "missing")).toBe(0);
+  });
+
+  it("falls back to the nearest loaded ancestor for external create events", () => {
+    const tree = [
+      {
+        name: "marketing",
+        path: "marketing",
+        type: "directory" as const,
+        children: [
+          {
+            name: "assets",
+            path: "marketing/assets",
+            type: "directory" as const,
+          },
+        ],
+      },
+      {
+        name: "src",
+        path: "src",
+        type: "directory" as const,
+      },
+    ];
+
+    expect(nearestLoadedAncestorDirectoryPath(tree, "marketing/assets/screens")).toBe("marketing");
+    expect(nearestLoadedAncestorDirectoryPath(tree, "marketing")).toBe("marketing");
+    expect(nearestLoadedAncestorDirectoryPath(tree, "src/routes")).toBe("");
+    expect(nearestLoadedAncestorDirectoryPath(tree, "missing/path")).toBe("");
   });
 
   it("preserves loaded descendant folders during a scoped directory refresh", () => {

--- a/apps/desktop/src/renderer/components/files/treeHelpers.ts
+++ b/apps/desktop/src/renderer/components/files/treeHelpers.ts
@@ -95,6 +95,16 @@ export function hasLoadedDirectoryChildren(nodes: FileTreeNode[], directoryPath:
   return node?.type === "directory" && Array.isArray(node.children);
 }
 
+export function nearestLoadedAncestorDirectoryPath(nodes: FileTreeNode[], directoryPath: string): string {
+  let current = directoryPath.replace(/\\/g, "/").split("/").filter(Boolean).join("/");
+  for (;;) {
+    if (hasLoadedDirectoryChildren(nodes, current)) return current;
+    if (!current) return "";
+    const index = current.lastIndexOf("/");
+    current = index > 0 ? current.slice(0, index) : "";
+  }
+}
+
 export function loadedDirectoryChildrenCount(nodes: FileTreeNode[], directoryPath: string): number {
   if (!directoryPath) return nodes.length;
   const node = findFileTreeNodeByPath(nodes, directoryPath);

--- a/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
@@ -19,6 +19,7 @@ import {
   isUnavailableGitDecorationsError,
   loadedDirectoryChildrenCount,
   mergeTreePreservingLoadedChildren,
+  nearestLoadedAncestorDirectoryPath,
   parentPathForFileChange,
   replaceTreeNodeChildren,
 } from "../treeHelpers";
@@ -555,12 +556,17 @@ export function FilesWorkbench({
         rootRefreshQueued = true;
         return;
       }
-      if (hasLoadedDirectoryChildren(treeRef.current, parentPath)) {
-        queuedParentPaths.add(parentPath);
-        if (queuedParentPaths.size > MAX_QUEUED_TREE_PARENT_REFRESHES) {
-          fullRootRefreshQueued = true;
-          queuedParentPaths.clear();
-        }
+      const refreshPath = hasLoadedDirectoryChildren(treeRef.current, parentPath)
+        ? parentPath
+        : nearestLoadedAncestorDirectoryPath(treeRef.current, parentPath);
+      if (!refreshPath) {
+        rootRefreshQueued = true;
+        return;
+      }
+      queuedParentPaths.add(refreshPath);
+      if (queuedParentPaths.size > MAX_QUEUED_TREE_PARENT_REFRESHES) {
+        fullRootRefreshQueued = true;
+        queuedParentPaths.clear();
       }
     };
 

--- a/docs/features/files-and-editor/README.md
+++ b/docs/features/files-and-editor/README.md
@@ -41,6 +41,13 @@ targets for the legacy IPC path.
   — local runtime project registration, file action dispatch, and event
   polling; file actions use a bounded per-call timeout before the
   desktop IPC handler timeout can fire.
+- `apps/desktop/src/main/services/ipc/runtimeBridge.ts`,
+  `apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.ts`,
+  `apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts`,
+  and `apps/ade-cli/src/multiProjectRpcServer.ts` — bridge the runtime
+  event stream to bound desktop windows. A `replay: false` subscription
+  returns the runtime's current cursor, so a remote Files tab can begin
+  watching live changes without replaying stale runtime events.
 - `apps/desktop/src/main/services/remoteRuntime/runtimeRpcClient.ts` —
   JSON-RPC client used by both local and remote runtime transports,
   including per-call timeout overrides for file actions and event

--- a/docs/features/files-and-editor/file-watcher-and-trust.md
+++ b/docs/features/files-and-editor/file-watcher-and-trust.md
@@ -219,6 +219,14 @@ handles events like this:
    24`) forces a full tree refresh when bulk operations exceed the
    cap (e.g. `git checkout` touches hundreds of files at once).
 
+Remote-bound windows start their runtime event pump with
+`replay: false`. The runtime acknowledges that subscription with its
+current cursor, and `preload.ts` uses that cursor for the next poll
+before it resumes ordinary replay. This keeps a newly opened Files tab
+on the live edge of a remote worktree, so a file created by an ADE CLI
+session on the remote machine refreshes the loaded tree instead of
+waiting behind older runtime events.
+
 Rename detection on the renderer side: because watcher events come as
 `unlink` + `add`, renames surface as a tab close + a new tab path. The
 renderer inspects the modified timestamp and file size to correlate


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Foutput-ade-cli-session-carlify-d1a6fed4 num=653 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Foutput-ade-cli-session-carlify-d1a6fed4&amp;pr=653">ade/output-ade-cli-session-carlify-d1a6fed4 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=653">PR #653</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates remote runtime event handling for Files tabs. The main changes are:

- Adds a current-cursor acknowledgement for `replay: false` runtime event subscriptions.
- Propagates subscription initialization metadata through local and remote runtime connection layers.
- Updates preload polling to resume normal replay from the acknowledged remote cursor.
- Refreshes the nearest loaded file-tree ancestor for nested external file changes.
- Adds tests and documentation for the live-edge subscription and file watcher behavior.

<h3>Confidence Score: 5/5</h3>

The changes are focused, covered by targeted tests, and do not leave identified merge-blocking issues.

No code issues were identified in the reviewed changes, and the updated behavior is exercised across CLI, runtime bridge, preload, and file-tree helper tests.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Updated the subscription flow so SUBSCRIBE\_RESPONSE reports nextCursor based on the latest live edge and marks hasMore as false when there is no replay, aligning eventEpoch and removing replay notifications before the live event.
- Changed ancestor refresh logic to select and queue the nearest loaded ancestor source (marketing) instead of relying on the immediate parent, updating the refresh path accordingly.

<a href="https://app.greptile.com/trex/runs/12434388/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix remote file event cursor updates"](https://github.com/arul28/ade/commit/6421356b20a98fe84ca6196624afb288b863da7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40120880)</sub>

<!-- /greptile_comment -->