### PR TITLE
release: changelog for v1.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.10] - 2026-06-28
+
+### Added
+
+- One-time "Welcome to ADE" video gate with Help menu replay, tab tooltips, expanded Did you know hints, and updated first-run docs.
+
+### Changed
+
+- Upgraded ADE Code terminal rendering and tightened TUI input, approval prompts, palettes, polling, Codex initial prompt handling, PTY reads, and shell-session startup behavior.
+- Improved auto-lane chat recovery, pinned project-config cache keys, stale launch UI guards, running-work notifications, and Claude auth recovery prompts.
+- Improved Files workbench/editor state, search-result collapse behavior, dirty-buffer handling, recent-file tracking, and remote file event cursor updates.
+
+### Removed
+
+- Removed guided tour, wizard, tutorial UI, and the old tour IPC/preload/service contract in favor of passive help surfaces.
+
+### Fixed
+
+- Fixed iOS sync freezes during mobile actions and preserved running chat badge counts in the mobile Work flow.
+
 ## [1.2.9] - 2026-06-23
 
 ### Added
@@ -467,7 +487,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.9...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.10...HEAD
+[1.2.10]: https://github.com/arul28/ADE/compare/v1.2.9...v1.2.10
 [1.2.9]: https://github.com/arul28/ADE/compare/v1.2.8...v1.2.9
 [1.2.8]: https://github.com/arul28/ADE/compare/v1.2.7...v1.2.8
 [1.2.7]: https://github.com/arul28/ADE/compare/v1.2.6...v1.2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed iOS sync freezes during mobile actions and preserved running chat badge counts in the mobile Work flow.
+- Fixed release-doc validation so the next changelog page can pass CI before its tag exists.
 
 ## [1.2.9] - 2026-06-23
 

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.9">
-  v1.2.9 - an upgraded Claude integration with a real login flow, instant lane and chat naming, safer Codex full-auto permission switching, first-class orchestration delegation lineage, and snappier mobile realtime sync.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.10">
+  v1.2.10 - simplified onboarding with a welcome video and passive help, tighter ADE Code and chat launch behavior, more reliable Files workflows, and build-number-only iOS sync fixes.
 </Card>

--- a/changelog/v1.2.10.mdx
+++ b/changelog/v1.2.10.mdx
@@ -14,6 +14,7 @@ v1.2.10 replaces the guided onboarding tour with a one-time welcome video and pa
 - **Chat launch recovery.** Auto-lane and pinned chat launches now recover more reliably, guard stale UI updates, fix project-config cache keys, and keep notifications tied to the right running work.
 - **Claude auth recovery.** Claude auth notices now show a focused login prompt only for real Claude failures, reducing false positives while giving expired sessions a clear recovery path.
 - **Files reliability.** Search-result folders collapse correctly, remote file events preserve cursor state, editor groups track dirty buffers more safely, and recent-file and warm-empty states behave more predictably.
+- **Release validation.** Changelog validation now accepts the next release page before its tag exists, so release-doc PRs can pass CI before tagging.
 
 ---
 

--- a/changelog/v1.2.10.mdx
+++ b/changelog/v1.2.10.mdx
@@ -1,0 +1,24 @@
+---
+title: "v1.2.10"
+description: "Release notes for ADE v1.2.10 - June 28, 2026"
+---
+
+v1.2.10 replaces the guided onboarding tour with a one-time welcome video and passive help, tightens ADE Code and chat launch behavior, and fixes Files reliability around search, remote events, and editor state. iOS stays on its current marketing version and gets a build-number-only TestFlight update for sync and chat stability fixes.
+
+---
+
+## Desktop
+
+- **Onboarding, simplified.** The old guided tour and wizard stack is replaced with a one-time "Welcome to ADE" video, Help menu replay, richer Did you know hints, and tab hover tooltips that point to the right docs without blocking the app.
+- **ADE Code and terminal polish.** The ADE Code terminal renderer is upgraded, with tighter TUI input, approval prompt, palette, polling, Codex initial prompt, PTY read, and shell-session startup behavior.
+- **Chat launch recovery.** Auto-lane and pinned chat launches now recover more reliably, guard stale UI updates, fix project-config cache keys, and keep notifications tied to the right running work.
+- **Claude auth recovery.** Claude auth notices now show a focused login prompt only for real Claude failures, reducing false positives while giving expired sessions a clear recovery path.
+- **Files reliability.** Search-result folders collapse correctly, remote file events preserve cursor state, editor groups track dirty buffers more safely, and recent-file and warm-empty states behave more predictably.
+
+---
+
+## iOS
+
+- **Build-number-only TestFlight update.** The mobile app keeps its existing marketing version for this train; this release only bumps the iOS build number for TestFlight.
+- **Sync crash fixes.** Mobile actions no longer freeze the sync path, with stronger database and sync-service regression coverage.
+- **Work chat continuity.** The new-chat flow handles pinned auto-lane launches more reliably, and running chat badge counts stay accurate.

--- a/docs.json
+++ b/docs.json
@@ -179,6 +179,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.10",
               "changelog/v1.2.9",
               "changelog/v1.2.8",
               "changelog/v1.2.7",

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -223,10 +223,16 @@ async function validateReleaseDocs() {
 
   const changelog = await fs.readFile(path.join(repoRoot, "CHANGELOG.md"), "utf8");
   const topVersion = changelog.match(/^## \[(\d+\.\d+\.\d+)\]/m)?.[1];
+  let docsLatestTag = latestTag;
   if (!topVersion) {
     errors.push("CHANGELOG.md: missing a released ## [x.y.z] heading after Unreleased");
   } else if (topVersion !== latestTag.version) {
-    errors.push(`CHANGELOG.md: top release ${topVersion} does not match latest git tag ${latestTag.raw}`);
+    const topTag = parseSemverTag(`v${topVersion}`);
+    if (!topTag || compareSemver(topTag, latestTag) <= 0) {
+      errors.push(`CHANGELOG.md: top release ${topVersion} does not match latest git tag ${latestTag.raw}`);
+    } else {
+      docsLatestTag = topTag;
+    }
   }
 
   const linkRefs = new Set([...changelog.matchAll(/^\[([^\]]+)\]:\s+\S+/gm)].map((match) => match[1]));
@@ -244,8 +250,8 @@ async function validateReleaseDocs() {
     }
   }
 
-  if (!(await targetExists({ absolute: `/changelog/${latestTag.raw}`, source: latestTag.raw, fromFile: "CHANGELOG.md" }))) {
-    errors.push(`changelog/${latestTag.raw}.mdx: missing docs page for latest git tag ${latestTag.raw}`);
+  if (!(await targetExists({ absolute: `/changelog/${docsLatestTag.raw}`, source: docsLatestTag.raw, fromFile: "CHANGELOG.md" }))) {
+    errors.push(`changelog/${docsLatestTag.raw}.mdx: missing docs page for latest release ${docsLatestTag.raw}`);
   }
 
   let changelogIndex;
@@ -255,11 +261,11 @@ async function validateReleaseDocs() {
     errors.push("changelog/index.mdx: file is missing; create it with a latest-release Card");
     return;
   }
-  if (!changelogIndex.includes(`/changelog/${latestTag.raw}`)) {
-    errors.push(`changelog/index.mdx: latest release card must link to /changelog/${latestTag.raw}`);
+  if (!changelogIndex.includes(`/changelog/${docsLatestTag.raw}`)) {
+    errors.push(`changelog/index.mdx: latest release card must link to /changelog/${docsLatestTag.raw}`);
   }
-  if (!changelogIndex.includes(latestTag.raw)) {
-    errors.push(`changelog/index.mdx: latest release copy must mention ${latestTag.raw}`);
+  if (!changelogIndex.includes(docsLatestTag.raw)) {
+    errors.push(`changelog/index.mdx: latest release copy must mention ${docsLatestTag.raw}`);
   }
 
   let readme;


### PR DESCRIPTION
Changelog for v1.2.10. Tag will be cut after this lands on main and ci-pass is green.\n\nRelease scope: desktop + iOS. iOS keeps its existing marketing version and will get a build-number-only TestFlight update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release documentation validation so it checks the latest changelog entry more reliably.
  * Validation now better matches the newest published release when confirming changelog links and release page references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the v1.2.10 changelog release entry and a companion script fix so that release-doc PRs can pass CI before the git tag is actually cut.

- **CHANGELOG.md / changelog/v1.2.10.mdx / changelog/index.mdx / docs.json**: Standard release-doc updates — new `## [1.2.10]` section, updated `[Unreleased]` link ref, new MDX page, updated latest-release card, and the page added to `docs.json`.
- **scripts/validate-docs.mjs**: The validator now compares the CHANGELOG's top version against the latest git tag using semver ordering. If the CHANGELOG version is strictly newer than the latest tag (pre-tag scenario), it uses that version for the docs-existence and `index.mdx` card checks rather than failing immediately — allowing release PRs to pass CI before tagging.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive documentation and a targeted, well-scoped validator fix.

The changelog content and MDX page are straightforward additions that follow the established pattern. The validator change is narrow: it only relaxes the version-match check when the CHANGELOG top version is a valid semver strictly greater than the latest git tag, and falls back to the previous latestTag behavior in every error condition. The downstream doc-existence and index.mdx checks still run against the resolved reference version, so no validation is silently skipped.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/validate-docs.mjs | Adds pre-tag leniency: when the CHANGELOG top version is a valid semver strictly greater than the latest git tag, the validator uses it as the reference for doc-existence checks instead of erroring out. Logic is correct — falls back to latestTag on any error condition, and raw/version fields on the synthesized topTag are consistent with the check targets. |
| CHANGELOG.md | Adds v1.2.10 release block with Added/Changed/Removed/Fixed sections, updates [Unreleased] link ref to v1.2.10...HEAD, and adds [1.2.10] comparison link. Format follows Keep a Changelog conventions used by earlier entries. |
| changelog/v1.2.10.mdx | New MDX release page for v1.2.10 covering Desktop and iOS sections; no broken links or leaked markup detected. |
| changelog/index.mdx | Latest-release card updated from v1.2.9 to v1.2.10 with a matching summary blurb; href and mention both updated consistently. |
| docs.json | changelog/v1.2.10 page inserted at the top of the changelog pages list in the sidebar; ordering matches newest-first convention. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validate-docs.mjs runs] --> B[Read latest git tag]
    B --> C{latestTag exists?}
    C -- No --> D[Warn / error and return]
    C -- Yes --> E[Read CHANGELOG.md top version]
    E --> F{topVersion found?}
    F -- No --> G[Error: missing heading]
    F -- Yes --> H{topVersion == latestTag.version?}
    H -- Yes --> I[docsLatestTag = latestTag]
    H -- No --> J[Parse topVersion as semver topTag]
    J --> K{topTag valid AND topTag > latestTag?}
    K -- No --> L[Error: version mismatch]
    K -- Yes --> M[docsLatestTag = topTag - pre-tag scenario allowed]
    I --> N[Check changelog/docsLatestTag.mdx exists]
    M --> N
    L --> N
    G --> N
    N --> O[Check index.mdx links to docsLatestTag]
    O --> P[Check README stable changelog URL]
    P --> Q{errors.length > 0?}
    Q -- Yes --> R[Exit 1]
    Q -- No --> S[Validation passed]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[validate-docs.mjs runs] --> B[Read latest git tag]
    B --> C{latestTag exists?}
    C -- No --> D[Warn / error and return]
    C -- Yes --> E[Read CHANGELOG.md top version]
    E --> F{topVersion found?}
    F -- No --> G[Error: missing heading]
    F -- Yes --> H{topVersion == latestTag.version?}
    H -- Yes --> I[docsLatestTag = latestTag]
    H -- No --> J[Parse topVersion as semver topTag]
    J --> K{topTag valid AND topTag > latestTag?}
    K -- No --> L[Error: version mismatch]
    K -- Yes --> M[docsLatestTag = topTag - pre-tag scenario allowed]
    I --> N[Check changelog/docsLatestTag.mdx exists]
    M --> N
    L --> N
    G --> N
    N --> O[Check index.mdx links to docsLatestTag]
    O --> P[Check README stable changelog URL]
    P --> Q{errors.length > 0?}
    Q -- Yes --> R[Exit 1]
    Q -- No --> S[Validation passed]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: allow pending release changelog val..."](https://github.com/arul28/ade/commit/7ce4f5aa84457efd76b85a7b5404732476581f53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40398690)</sub>

<!-- /greptile_comment -->