### PR TITLE
Project List Reconnecting Icons

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -23,9 +23,11 @@ import { registerPerfIpcHandlers } from "./services/perf/perfIpc";
 import { openKvDb } from "./services/state/kvDb";
 import { ensureAdeDirs } from "./services/state/projectState";
 import {
+  persistableRemoteProjectIconDataUrl,
   readGlobalState,
   type RecentProject,
   upsertRecentProject,
+  withPersistableRemoteProjectIcon,
   writeGlobalState,
 } from "./services/state/globalState";
 import { createLaneService, type LaneDeleteTeardownDeps } from "./services/lanes/laneService";
@@ -1103,7 +1105,9 @@ app.whenReady().then(async () => {
       displayName: readString(record, "displayName") ?? path.basename(rootPath),
       // Restore the cached project logo so the tab shows it immediately on a
       // cold start, before the remote reconnects and refreshes the icon.
-      iconDataUrl: readString(record, "iconDataUrl") ?? null,
+      iconDataUrl: persistableRemoteProjectIconDataUrl(
+        readString(record, "iconDataUrl"),
+      ),
     };
   };
   const savedRemoteProjectBinding = parseSavedRemoteProjectBinding(
@@ -1603,6 +1607,8 @@ app.whenReady().then(async () => {
     binding: RemoteOpenProjectBinding,
   ): void => {
     const state = readGlobalState(globalStatePath);
+    const iconDataUrl = persistableRemoteProjectIconDataUrl(binding.iconDataUrl);
+    const persistedBinding = withPersistableRemoteProjectIcon(binding);
     // Record the remote project in recents so it appears in the unified recents
     // list on the welcome screen (alongside local projects) — no need to re-add
     // it from the remote panel next time.
@@ -1616,7 +1622,7 @@ app.whenReady().then(async () => {
           projectId: binding.projectId,
           runtimeName: binding.runtimeName,
           hostname: binding.hostname || binding.runtimeName,
-          iconDataUrl: binding.iconDataUrl ?? null,
+          ...(iconDataUrl ? { iconDataUrl } : {}),
         },
       },
       { recordLastProject: false, recordRecent: true },
@@ -1624,7 +1630,7 @@ app.whenReady().then(async () => {
     const next = {
       ...withRecent,
       lastRemoteProjectBinding: {
-        ...binding,
+        ...persistedBinding,
         updatedAt: new Date().toISOString(),
       },
     };

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1616,6 +1616,7 @@ app.whenReady().then(async () => {
           projectId: binding.projectId,
           runtimeName: binding.runtimeName,
           hostname: binding.hostname || binding.runtimeName,
+          iconDataUrl: binding.iconDataUrl ?? null,
         },
       },
       { recordLastProject: false, recordRecent: true },

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1105,10 +1105,25 @@ app.whenReady().then(async () => {
       displayName: readString(record, "displayName") ?? path.basename(rootPath),
       // Restore the cached project logo so the tab shows it immediately on a
       // cold start, before the remote reconnects and refreshes the icon.
-      iconDataUrl: persistableRemoteProjectIconDataUrl(
+      iconDataUrl: remoteProjectIconDataUrlForPersistence(
         readString(record, "iconDataUrl"),
       ),
     };
+  };
+  const remoteProjectIconDataUrlForPersistence = (
+    value: string | null | undefined,
+  ): string | null => {
+    const direct = persistableRemoteProjectIconDataUrl(value);
+    if (direct || !value) return direct;
+    try {
+      const image = nativeImage.createFromDataURL(value);
+      if (image.isEmpty()) return null;
+      return persistableRemoteProjectIconDataUrl(
+        image.resize({ width: 64, height: 64, quality: "best" }).toDataURL(),
+      );
+    } catch {
+      return null;
+    }
   };
   const savedRemoteProjectBinding = parseSavedRemoteProjectBinding(
     saved.lastRemoteProjectBinding,
@@ -1607,8 +1622,11 @@ app.whenReady().then(async () => {
     binding: RemoteOpenProjectBinding,
   ): void => {
     const state = readGlobalState(globalStatePath);
-    const iconDataUrl = persistableRemoteProjectIconDataUrl(binding.iconDataUrl);
-    const persistedBinding = withPersistableRemoteProjectIcon(binding);
+    const iconDataUrl = remoteProjectIconDataUrlForPersistence(binding.iconDataUrl);
+    const persistedBinding = withPersistableRemoteProjectIcon({
+      ...binding,
+      iconDataUrl,
+    });
     // Record the remote project in recents so it appears in the unified recents
     // list on the welcome screen (alongside local projects) — no need to re-add
     // it from the remote panel next time.

--- a/apps/desktop/src/main/services/projects/startupProjectResolver.test.ts
+++ b/apps/desktop/src/main/services/projects/startupProjectResolver.test.ts
@@ -107,8 +107,20 @@ describe("normalizeStartupProjectState", () => {
       runtimeName: "mac-mini",
       hostname: "mac-mini.local",
     };
+    const lastRemoteProjectBinding = {
+      kind: "remote" as const,
+      key: "remote:t1:p1",
+      targetId: "t1",
+      runtimeName: "mac-mini",
+      hostname: "mac-mini.local",
+      projectId: "p1",
+      rootPath: "/home/u/webapp",
+      displayName: "webapp",
+      iconDataUrl: "data:image/png;base64,remote-icon",
+    };
     const result = normalizeStartupProjectState({
       saved: {
+        lastRemoteProjectBinding,
         recentProjects: [
           // A remote path that does NOT exist on this machine — must survive.
           { rootPath: "/home/u/webapp", displayName: "webapp", lastOpenedAt: "2026-05-10T00:00:00.000Z", remote, pinned: true },
@@ -122,7 +134,10 @@ describe("normalizeStartupProjectState", () => {
 
     const remoteEntry = result.recentProjects.find((p) => p.remote);
     expect(remoteEntry).toBeDefined();
-    expect(remoteEntry?.remote).toEqual(remote);
+    expect(remoteEntry?.remote).toEqual({
+      ...remote,
+      iconDataUrl: "data:image/png;base64,remote-icon",
+    });
     expect(remoteEntry?.rootPath).toBe("/home/u/webapp"); // not normalized to a local path
     expect(remoteEntry?.pinned).toBe(true);
     // The local entry is still cleaned/normalized as before.

--- a/apps/desktop/src/main/services/projects/startupProjectResolver.test.ts
+++ b/apps/desktop/src/main/services/projects/startupProjectResolver.test.ts
@@ -144,6 +144,52 @@ describe("normalizeStartupProjectState", () => {
     expect(result.recentProjects.some((p) => !p.remote && p.rootPath === "/valid-project")).toBe(true);
   });
 
+  it("strips oversized remote icons from saved startup state", () => {
+    const oversizedIcon = `data:image/png;base64,${"a".repeat(129 * 1024)}`;
+    const lastRemoteProjectBinding = {
+      kind: "remote" as const,
+      key: "remote:t1:p1",
+      targetId: "t1",
+      runtimeName: "mac-mini",
+      hostname: "mac-mini.local",
+      projectId: "p1",
+      rootPath: "/home/u/webapp",
+      displayName: "webapp",
+      iconDataUrl: oversizedIcon,
+    };
+    const result = normalizeStartupProjectState({
+      saved: {
+        lastRemoteProjectBinding,
+        recentProjects: [
+          {
+            rootPath: "/home/u/webapp",
+            displayName: "webapp",
+            lastOpenedAt: "2026-05-10T00:00:00.000Z",
+            remote: {
+              targetId: "t1",
+              projectId: "p1",
+              runtimeName: "mac-mini",
+              hostname: "mac-mini.local",
+              iconDataUrl: oversizedIcon,
+            },
+          },
+        ],
+      },
+      isLikelyRepoRoot,
+      normalizeProjectPath,
+      nowIso,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.recentProjects[0]?.remote).toEqual({
+      targetId: "t1",
+      projectId: "p1",
+      runtimeName: "mac-mini",
+      hostname: "mac-mini.local",
+    });
+    expect(result.state.lastRemoteProjectBinding?.iconDataUrl).toBeUndefined();
+  });
+
   it("reports changed when cleanup only normalizes pinned metadata", () => {
     const result = normalizeStartupProjectState({
       saved: {

--- a/apps/desktop/src/main/services/projects/startupProjectResolver.ts
+++ b/apps/desktop/src/main/services/projects/startupProjectResolver.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 import type { GlobalState, RecentProject } from "../state/globalState";
-import { recentProjectKey } from "../state/globalState";
+import {
+  persistableRecentProjectRemote,
+  recentProjectKey,
+  withPersistableRemoteProjectIcon,
+} from "../state/globalState";
 
 // Keep more than the visible window so pinned-but-stale projects don't crowd
 // out fresh ones; pinned entries are retained beyond the cap entirely.
@@ -46,10 +50,13 @@ export function normalizeStartupProjectState(args: {
   nowIso?: string;
 }): StartupProjectStateNormalization {
   const savedRecentProjects = args.saved.recentProjects ?? [];
-  const lastRemoteProjectBinding =
+  const savedLastRemoteProjectBinding =
     args.saved.lastRemoteProjectBinding?.kind === "remote"
       ? args.saved.lastRemoteProjectBinding
       : null;
+  const lastRemoteProjectBinding = savedLastRemoteProjectBinding
+    ? withPersistableRemoteProjectIcon(savedLastRemoteProjectBinding)
+    : null;
   const candidateRecentProjects = [
     ...savedRecentProjects,
     ...(args.additionalRecentProjects ?? []),
@@ -66,7 +73,7 @@ export function normalizeStartupProjectState(args: {
       const key = recentProjectKey(entry);
       if (acc.some((item) => recentProjectKey(item) === key)) return acc;
       const remoteRoot = typeof entry.rootPath === "string" ? entry.rootPath : "";
-      const remote = { ...entry.remote };
+      const remote = persistableRecentProjectRemote(entry.remote);
       // Legacy remote recents can only borrow the last opened binding's icon.
       if (
         remote.iconDataUrl == null &&
@@ -132,9 +139,16 @@ export function normalizeStartupProjectState(args: {
     recentProjects.some((project, index) =>
       recentProjectEntryChanged(project, savedRecentProjects[index])
     );
+  const lastRemoteProjectBindingChanged =
+    savedLastRemoteProjectBinding !== null &&
+    (savedLastRemoteProjectBinding.iconDataUrl ?? null) !==
+      (lastRemoteProjectBinding?.iconDataUrl ?? null);
   const lastProjectRootChanged =
     args.saved.lastProjectRoot !== undefined;
-  const stateWithoutLastProject: GlobalState = { ...args.saved };
+  const stateWithoutLastProject: GlobalState = {
+    ...args.saved,
+    ...(lastRemoteProjectBinding ? { lastRemoteProjectBinding } : {}),
+  };
   delete stateWithoutLastProject.lastProjectRoot;
   return {
     state: {
@@ -142,7 +156,7 @@ export function normalizeStartupProjectState(args: {
       recentProjects,
     },
     recentProjects,
-    changed: recentProjectsChanged || lastProjectRootChanged,
+    changed: recentProjectsChanged || lastRemoteProjectBindingChanged || lastProjectRootChanged,
   };
 }
 

--- a/apps/desktop/src/main/services/projects/startupProjectResolver.ts
+++ b/apps/desktop/src/main/services/projects/startupProjectResolver.ts
@@ -34,7 +34,8 @@ function recentProjectEntryChanged(
     (savedRemote?.targetId ?? null) !== (projectRemote?.targetId ?? null) ||
     (savedRemote?.projectId ?? null) !== (projectRemote?.projectId ?? null) ||
     (savedRemote?.runtimeName ?? null) !== (projectRemote?.runtimeName ?? null) ||
-    (savedRemote?.hostname ?? null) !== (projectRemote?.hostname ?? null);
+    (savedRemote?.hostname ?? null) !== (projectRemote?.hostname ?? null) ||
+    (savedRemote?.iconDataUrl ?? null) !== (projectRemote?.iconDataUrl ?? null);
 }
 
 export function normalizeStartupProjectState(args: {
@@ -45,6 +46,10 @@ export function normalizeStartupProjectState(args: {
   nowIso?: string;
 }): StartupProjectStateNormalization {
   const savedRecentProjects = args.saved.recentProjects ?? [];
+  const lastRemoteProjectBinding =
+    args.saved.lastRemoteProjectBinding?.kind === "remote"
+      ? args.saved.lastRemoteProjectBinding
+      : null;
   const candidateRecentProjects = [
     ...savedRecentProjects,
     ...(args.additionalRecentProjects ?? []),
@@ -61,14 +66,23 @@ export function normalizeStartupProjectState(args: {
       const key = recentProjectKey(entry);
       if (acc.some((item) => recentProjectKey(item) === key)) return acc;
       const remoteRoot = typeof entry.rootPath === "string" ? entry.rootPath : "";
+      const remote = { ...entry.remote };
+      if (
+        remote.iconDataUrl == null &&
+        lastRemoteProjectBinding?.targetId === remote.targetId &&
+        lastRemoteProjectBinding.projectId === remote.projectId &&
+        lastRemoteProjectBinding.iconDataUrl
+      ) {
+        remote.iconDataUrl = lastRemoteProjectBinding.iconDataUrl;
+      }
       acc.push({
         rootPath: remoteRoot,
         displayName:
           typeof entry.displayName === "string" && entry.displayName.trim().length > 0
             ? entry.displayName
-            : path.basename(remoteRoot) || entry.remote.runtimeName,
+            : path.basename(remoteRoot) || remote.runtimeName,
         lastOpenedAt: fallbackOpenedAt,
-        remote: entry.remote,
+        remote,
         ...(entry.pinned ? { pinned: true } : {}),
       });
       return acc;

--- a/apps/desktop/src/main/services/projects/startupProjectResolver.ts
+++ b/apps/desktop/src/main/services/projects/startupProjectResolver.ts
@@ -67,6 +67,7 @@ export function normalizeStartupProjectState(args: {
       if (acc.some((item) => recentProjectKey(item) === key)) return acc;
       const remoteRoot = typeof entry.rootPath === "string" ? entry.rootPath : "";
       const remote = { ...entry.remote };
+      // Legacy remote recents can only borrow the last opened binding's icon.
       if (
         remote.iconDataUrl == null &&
         lastRemoteProjectBinding?.targetId === remote.targetId &&

--- a/apps/desktop/src/main/services/state/globalState.test.ts
+++ b/apps/desktop/src/main/services/state/globalState.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  persistableRemoteProjectIconDataUrl,
   readGlobalState,
   recentProjectKey,
   setRecentProjectPinned,
@@ -90,6 +91,31 @@ describe("upsertRecentProject", () => {
     expect(recentProjectKey(next.recentProjects![0]!)).toBe("remote:t1:p1");
   });
 
+  it("drops oversized remote project icons before storing recents", () => {
+    const oversizedIcon = `data:image/png;base64,${"a".repeat(129 * 1024)}`;
+    const next = upsertRecentProject(
+      {},
+      {
+        rootPath: "/home/u/webapp",
+        displayName: "webapp",
+        remote: {
+          targetId: "t1",
+          projectId: "p1",
+          runtimeName: "mac-mini",
+          hostname: "mac-mini.local",
+          iconDataUrl: oversizedIcon,
+        },
+      },
+    );
+
+    expect(next.recentProjects?.[0]?.remote).toEqual({
+      targetId: "t1",
+      projectId: "p1",
+      runtimeName: "mac-mini",
+      hostname: "mac-mini.local",
+    });
+  });
+
   it("dedupes remote recents by remote key, not by root path", () => {
     const remote = {
       targetId: "t1",
@@ -140,6 +166,21 @@ describe("upsertRecentProject", () => {
     const next = upsertRecentProject(state, { rootPath: "/projects/new", displayName: "New" });
 
     expect(next.recentProjects?.some((p) => p.rootPath === "/projects/p29" && p.pinned)).toBe(true);
+  });
+});
+
+describe("persistableRemoteProjectIconDataUrl", () => {
+  it("keeps small image data URLs", () => {
+    expect(persistableRemoteProjectIconDataUrl("data:image/png;base64,abc")).toBe(
+      "data:image/png;base64,abc",
+    );
+  });
+
+  it("rejects non-image or oversized data URLs", () => {
+    expect(persistableRemoteProjectIconDataUrl("data:text/plain;base64,abc")).toBeNull();
+    expect(
+      persistableRemoteProjectIconDataUrl(`data:image/png;base64,${"a".repeat(129 * 1024)}`),
+    ).toBeNull();
   });
 });
 

--- a/apps/desktop/src/main/services/state/globalState.test.ts
+++ b/apps/desktop/src/main/services/state/globalState.test.ts
@@ -78,6 +78,7 @@ describe("upsertRecentProject", () => {
       projectId: "p1",
       runtimeName: "mac-mini",
       hostname: "mac-mini.local",
+      iconDataUrl: "data:image/png;base64,remote-icon",
     };
     const next = upsertRecentProject(
       {},

--- a/apps/desktop/src/main/services/state/globalState.ts
+++ b/apps/desktop/src/main/services/state/globalState.ts
@@ -102,6 +102,44 @@ type UpsertRecentProjectOptions = {
 // pinned-but-stale projects don't crowd out fresh ones, and pinned entries are
 // retained beyond the cap entirely (they are never auto-evicted).
 const RECENT_PROJECT_CAP = 24;
+const REMOTE_PROJECT_ICON_DATA_URL_MAX_BYTES = 128 * 1024;
+const REMOTE_PROJECT_ICON_DATA_URL_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
+
+export function persistableRemoteProjectIconDataUrl(
+  value: string | null | undefined,
+): string | null {
+  const dataUrl = typeof value === "string" ? value.trim() : "";
+  if (!dataUrl || !REMOTE_PROJECT_ICON_DATA_URL_RE.test(dataUrl)) return null;
+  return Buffer.byteLength(dataUrl, "utf8") <= REMOTE_PROJECT_ICON_DATA_URL_MAX_BYTES
+    ? dataUrl
+    : null;
+}
+
+export function withPersistableRemoteProjectIcon<T extends { iconDataUrl?: string | null }>(
+  value: T,
+): T {
+  const next = { ...value };
+  const iconDataUrl = persistableRemoteProjectIconDataUrl(value.iconDataUrl);
+  if (iconDataUrl) {
+    next.iconDataUrl = iconDataUrl;
+  } else {
+    delete next.iconDataUrl;
+  }
+  return next;
+}
+
+export function persistableRecentProjectRemote(
+  remote: RecentProjectRemote,
+): RecentProjectRemote {
+  const iconDataUrl = persistableRemoteProjectIconDataUrl(remote.iconDataUrl);
+  return {
+    targetId: remote.targetId,
+    projectId: remote.projectId,
+    runtimeName: remote.runtimeName,
+    hostname: remote.hostname,
+    ...(iconDataUrl ? { iconDataUrl } : {}),
+  };
+}
 
 export function upsertRecentProject(
   state: GlobalState,
@@ -121,11 +159,12 @@ export function upsertRecentProject(
   const prev = next.recentProjects ?? [];
   const key = recentProjectKey(proj);
   const existing = prev.find((p) => recentProjectKey(p) === key);
+  const remote = proj.remote ? persistableRecentProjectRemote(proj.remote) : undefined;
   const nextEntry: RecentProject = {
     rootPath: proj.rootPath,
     displayName: proj.displayName,
     lastOpenedAt: now,
-    ...(proj.remote ? { remote: proj.remote } : {}),
+    ...(remote ? { remote } : {}),
     ...(existing?.pinned ? { pinned: true } : {}),
   };
   if (options.preserveRecentOrder === true) {

--- a/apps/desktop/src/main/services/state/globalState.ts
+++ b/apps/desktop/src/main/services/state/globalState.ts
@@ -105,6 +105,8 @@ const RECENT_PROJECT_CAP = 24;
 const REMOTE_PROJECT_ICON_DATA_URL_MAX_BYTES = 128 * 1024;
 const REMOTE_PROJECT_ICON_DATA_URL_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
 
+// Global state should only store small, already-bounded project icon payloads.
+// Callers with full-size remote icons should thumbnail before this boundary.
 export function persistableRemoteProjectIconDataUrl(
   value: string | null | undefined,
 ): string | null {

--- a/apps/desktop/src/main/services/state/globalState.ts
+++ b/apps/desktop/src/main/services/state/globalState.ts
@@ -1,14 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
-import type { AppWelcomeVideoState, OpenProjectBinding, RecentlyInstalledUpdate } from "../../../shared/types";
+import type { AppWelcomeVideoState, OpenProjectBinding, RecentProjectRemoteRef, RecentlyInstalledUpdate } from "../../../shared/types";
 
-export type RecentProjectRemote = {
-  targetId: string;
-  projectId: string;
-  runtimeName: string;
-  hostname: string;
-};
+export type RecentProjectRemote = RecentProjectRemoteRef;
 
 export type RecentProject = {
   rootPath: string;

--- a/apps/desktop/src/renderer/components/run/RunPage.test.tsx
+++ b/apps/desktop/src/renderer/components/run/RunPage.test.tsx
@@ -183,6 +183,17 @@ function installAdeStub() {
     project: {
       listRecent: vi.fn().mockResolvedValue([]),
       resolveIcon: vi.fn().mockResolvedValue({ dataUrl: null, sourcePath: null, mimeType: null }),
+      forgetRecent: vi.fn().mockResolvedValue([]),
+      setRecentPinned: vi.fn().mockResolvedValue([]),
+    },
+    remoteRuntime: {
+      getConnectionSnapshot: vi.fn().mockResolvedValue({
+        connections: [],
+        connectedCount: 0,
+        updatedAt: Date.now(),
+      }),
+      onConnectionSnapshotChanged: vi.fn(() => vi.fn()),
+      connect: vi.fn().mockResolvedValue(undefined),
     },
     app: {
       writeClipboardText: vi.fn(),
@@ -295,6 +306,110 @@ describe("RunPage Advanced lane runtime drawer", () => {
       expect(ade.project.resolveIcon).toHaveBeenCalledWith("/tmp/icon-project");
       expect(container.querySelector('img[src="data:image/png;base64,icon"]')).toBeTruthy();
     });
+  });
+
+  it("renders remote project icons in the recent projects list", async () => {
+    const ade = (window as unknown as {
+      ade: {
+        project: {
+          listRecent: ReturnType<typeof vi.fn>;
+          resolveIcon: ReturnType<typeof vi.fn>;
+        };
+        remoteRuntime: {
+          getConnectionSnapshot: ReturnType<typeof vi.fn>;
+        };
+      };
+    }).ade;
+    ade.project.listRecent.mockResolvedValueOnce([
+      {
+        rootPath: "/srv/ade/remote-app",
+        displayName: "Remote App",
+        exists: true,
+        lastOpenedAt: "2026-05-08T00:00:00.000Z",
+        kind: "remote",
+        remote: {
+          targetId: "studio",
+          projectId: "remote-app",
+          runtimeName: "Mac Studio",
+          hostname: "studio.local",
+          iconDataUrl: "data:image/png;base64,remote-icon",
+        },
+      },
+    ]);
+    ade.remoteRuntime.getConnectionSnapshot.mockResolvedValueOnce({
+      connections: [
+        {
+          target: { id: "studio", name: "Mac Studio" },
+          state: "connected",
+        },
+      ],
+      connectedCount: 1,
+      updatedAt: Date.now(),
+    });
+    useAppStore.setState({ showWelcome: true, project: null });
+
+    const { container } = render(
+      <MemoryRouter>
+        <RunPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Remote App")).toBeTruthy();
+    expect(
+      container.querySelector('img[src="data:image/png;base64,remote-icon"]'),
+    ).toBeTruthy();
+    expect(ade.project.resolveIcon).not.toHaveBeenCalled();
+  });
+
+  it("shows only reconnecting copy on the right side while a remote recent reconnects", async () => {
+    const ade = (window as unknown as {
+      ade: {
+        project: {
+          listRecent: ReturnType<typeof vi.fn>;
+        };
+        remoteRuntime: {
+          getConnectionSnapshot: ReturnType<typeof vi.fn>;
+        };
+      };
+    }).ade;
+    ade.project.listRecent.mockResolvedValueOnce([
+      {
+        rootPath: "/srv/ade/remote-app",
+        displayName: "Remote App",
+        exists: true,
+        lastOpenedAt: new Date().toISOString(),
+        kind: "remote",
+        pinned: true,
+        remote: {
+          targetId: "studio",
+          projectId: "remote-app",
+          runtimeName: "Mac Studio",
+          hostname: "studio.local",
+        },
+      },
+    ]);
+    ade.remoteRuntime.getConnectionSnapshot.mockResolvedValueOnce({
+      connections: [
+        {
+          target: { id: "studio", name: "Mac Studio" },
+          state: "connecting",
+        },
+      ],
+      connectedCount: 0,
+      updatedAt: Date.now(),
+    });
+    useAppStore.setState({ showWelcome: true, project: null });
+
+    render(
+      <MemoryRouter>
+        <RunPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Reconnecting")).toBeTruthy();
+    expect(screen.queryByLabelText("Unpin Remote App")).toBeNull();
+    expect(screen.queryByLabelText("Remove Remote App from recents")).toBeNull();
+    expect(screen.queryByText("active just now")).toBeNull();
   });
 
   it("keeps LaneRuntimeBar collapsed by default with aria-expanded on the toggle", async () => {

--- a/apps/desktop/src/renderer/components/run/RunPage.tsx
+++ b/apps/desktop/src/renderer/components/run/RunPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   ArrowsClockwise,
   CaretDown,
@@ -336,38 +336,25 @@ function runPageLaneStateEqual(
   );
 }
 
-function RecentProjectIcon({
-  rootPath,
+function ProjectIconArtwork({
+  dataUrl,
+  fallback,
   onAccentColor,
 }: {
-  rootPath: string;
+  dataUrl: string | null | undefined;
+  fallback: ReactNode;
   // Reports the icon's sampled accent color (or null) so the row can tint its
   // tile to match the logo. Fires null until an icon resolves.
   onAccentColor?: (color: string | null) => void;
 }) {
-  const [icon, setIcon] = useState<ProjectIcon | null>(null);
   const [failed, setFailed] = useState(false);
 
   useEffect(() => {
-    let cancelled = false;
-    setIcon(null);
     setFailed(false);
-    window.ade.project
-      .resolveIcon(rootPath)
-      .then((nextIcon) => {
-        if (!cancelled) setIcon(nextIcon);
-      })
-      .catch(() => {
-        if (!cancelled) setIcon(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [rootPath]);
+  }, [dataUrl]);
 
   useEffect(() => {
     let cancelled = false;
-    const dataUrl = icon?.dataUrl;
     if (!dataUrl || failed) {
       onAccentColor?.(null);
       return () => {
@@ -384,12 +371,12 @@ function RecentProjectIcon({
     return () => {
       cancelled = true;
     };
-  }, [failed, icon?.dataUrl, onAccentColor]);
+  }, [dataUrl, failed, onAccentColor]);
 
-  if (icon?.dataUrl && !failed) {
+  if (dataUrl && !failed) {
     return (
       <img
-        src={icon.dataUrl}
+        src={dataUrl}
         alt=""
         draggable={false}
         onError={() => setFailed(true)}
@@ -403,7 +390,41 @@ function RecentProjectIcon({
     );
   }
 
-  return <Folder size={16} weight="regular" />;
+  return <>{fallback}</>;
+}
+
+function RecentProjectIcon({
+  rootPath,
+  onAccentColor,
+}: {
+  rootPath: string;
+  onAccentColor?: (color: string | null) => void;
+}) {
+  const [icon, setIcon] = useState<ProjectIcon | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIcon(null);
+    window.ade.project
+      .resolveIcon(rootPath)
+      .then((nextIcon) => {
+        if (!cancelled) setIcon(nextIcon);
+      })
+      .catch(() => {
+        if (!cancelled) setIcon(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [rootPath]);
+
+  return (
+    <ProjectIconArtwork
+      dataUrl={icon?.dataUrl}
+      fallback={<Folder size={16} weight="regular" />}
+      onAccentColor={onAccentColor}
+    />
+  );
 }
 
 const REMOTE_ACCENT = "#F59E0B";
@@ -425,8 +446,9 @@ function abbreviateHome(path: string): string {
 }
 
 // A single recents row. Local rows resolve a project icon (and tint their tile
-// with the sampled accent); remote rows use the amber DesktopTower glyph and a
-// connection dot. Offline remote rows are dimmed with a Reconnect affordance.
+// with the sampled accent); remote rows use a host-resolved icon when present,
+// plus the amber machine badge and connection dot. Offline remote rows are
+// dimmed with a Reconnect affordance.
 function RecentProjectRow({
   rp,
   connectionState,
@@ -450,12 +472,18 @@ function RecentProjectRow({
   const connecting = connectionState === "connecting";
   // Remote rows are "offline" until their target reports a live connection.
   const offline = isRemote && !connected;
-  const tileAccent = isRemote ? REMOTE_ACCENT : accentColor;
+  const remoteIconDataUrl = isRemote ? rp.remote?.iconDataUrl : null;
+  const hasRemoteIcon = Boolean(remoteIconDataUrl);
+  let tileAccent = accentColor;
+  if (isRemote) {
+    tileAccent = hasRemoteIcon ? (accentColor ?? REMOTE_ACCENT) : REMOTE_ACCENT;
+  }
   const tileBg = tileAccent
     ? `color-mix(in srgb, ${tileAccent} 18%, transparent)`
     : "color-mix(in srgb, var(--color-accent) 15%, transparent)";
   const tileColor = tileAccent ?? COLORS.accent;
-  const edgeColor = tileAccent ?? COLORS.accent;
+  const edgeColor = isRemote ? REMOTE_ACCENT : (tileAccent ?? COLORS.accent);
+  const showRowActions = !connecting;
 
   const dotColor = connected
     ? "#34D399"
@@ -474,6 +502,7 @@ function RecentProjectRow({
           alignItems: "center",
           gap: 12,
           padding: "12px 16px",
+          paddingRight: showRowActions ? 64 : 16,
           width: "100%",
           background: "rgba(255,255,255,0.02)",
           border: `1px solid ${COLORS.border}`,
@@ -500,10 +529,39 @@ function RecentProjectRow({
             background: tileBg,
             color: tileColor,
             flexShrink: 0,
+            position: "relative",
           }}
         >
           {isRemote ? (
-            <DesktopTower size={18} weight="duotone" />
+            <>
+              <ProjectIconArtwork
+                dataUrl={remoteIconDataUrl}
+                fallback={<DesktopTower size={18} weight="duotone" />}
+                onAccentColor={setAccentColor}
+              />
+              {hasRemoteIcon ? (
+                <span
+                  aria-hidden
+                  style={{
+                    position: "absolute",
+                    right: -3,
+                    bottom: -3,
+                    width: 14,
+                    height: 14,
+                    borderRadius: 5,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    background: "rgba(18,13,6,0.94)",
+                    border: "1px solid color-mix(in srgb, #F59E0B 62%, transparent)",
+                    color: "#FBBF24",
+                    boxShadow: "0 2px 6px rgba(0,0,0,0.35)",
+                  }}
+                >
+                  <DesktopTower size={9} weight="duotone" />
+                </span>
+              ) : null}
+            </>
           ) : (
             <RecentProjectIcon
               rootPath={rp.rootPath}
@@ -584,6 +642,8 @@ function RecentProjectRow({
             alignItems: "flex-end",
             gap: 4,
             flexShrink: 0,
+            minWidth: connecting ? 96 : 68,
+            maxWidth: connecting ? 116 : 96,
           }}
         >
           {offline ? (
@@ -608,7 +668,7 @@ function RecentProjectRow({
                     : undefined
                 }
               />
-              {connecting ? "Connecting" : "Reconnect"}
+              {connecting ? "Reconnecting" : "Reconnect"}
             </span>
           ) : rp.laneCount !== undefined ? (
             <span
@@ -625,96 +685,98 @@ function RecentProjectRow({
               {rp.laneCount} lane{rp.laneCount !== 1 ? "s" : ""}
             </span>
           ) : null}
-          {rp.lastOpenedAt ? (
+          {rp.lastOpenedAt && !connecting ? (
             <span style={{ fontSize: 9, color: COLORS.textDim }}>
               {toRelativeTime(rp.lastOpenedAt)}
             </span>
           ) : null}
         </div>
       </button>
-      <div
-        className={
-          rp.pinned ? undefined : "opacity-0 group-hover:opacity-100"
-        }
-        style={{
-          position: "absolute",
-          top: 6,
-          right: 6,
-          display: "flex",
-          gap: 4,
-          transition: "opacity 0.15s ease",
-          zIndex: 2,
-        }}
-      >
-        <button
-          type="button"
-          aria-label={
-            rp.pinned
-              ? `Unpin ${rp.displayName}`
-              : `Pin ${rp.displayName} to top`
+      {showRowActions ? (
+        <div
+          className={
+            rp.pinned ? undefined : "opacity-0 group-hover:opacity-100"
           }
-          aria-pressed={rp.pinned ? true : false}
-          onClick={(e) => {
-            e.stopPropagation();
-            onTogglePin();
-          }}
           style={{
-            width: 22,
-            height: 22,
-            borderRadius: 6,
+            position: "absolute",
+            top: 6,
+            right: 6,
             display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            background: rp.pinned
-              ? "color-mix(in srgb, var(--color-accent) 26%, transparent)"
-              : "rgba(255,255,255,0.06)",
-            border: rp.pinned
-              ? "1px solid color-mix(in srgb, var(--color-accent) 45%, transparent)"
-              : "1px solid rgba(255,255,255,0.08)",
-            color: rp.pinned ? COLORS.accent : COLORS.textDim,
-            cursor: "pointer",
-            transition: "background 0.15s ease, color 0.15s ease",
-            padding: 0,
+            gap: 4,
+            transition: "opacity 0.15s ease",
+            zIndex: 2,
           }}
-          title={rp.pinned ? "Unpin" : "Pin to top"}
         >
-          <PushPin size={12} weight={rp.pinned ? "fill" : "regular"} />
-        </button>
-        <button
-          type="button"
-          aria-label={`Remove ${rp.displayName} from recents`}
-          onClick={(e) => {
-            e.stopPropagation();
-            onForget();
-          }}
-          disabled={isForgetting}
-          style={{
-            width: 22,
-            height: 22,
-            borderRadius: 6,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            background: "rgba(255,255,255,0.06)",
-            border: "1px solid rgba(255,255,255,0.08)",
-            color: COLORS.textDim,
-            cursor: "pointer",
-            transition: "background 0.15s ease, color 0.15s ease",
-            padding: 0,
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.background = "rgba(239,68,68,0.18)";
-            e.currentTarget.style.color = "#EF4444";
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.background = "rgba(255,255,255,0.06)";
-            e.currentTarget.style.color = COLORS.textDim;
-          }}
-          title="Remove from recents"
-        >
-          <X size={12} weight="bold" />
-        </button>
-      </div>
+          <button
+            type="button"
+            aria-label={
+              rp.pinned
+                ? `Unpin ${rp.displayName}`
+                : `Pin ${rp.displayName} to top`
+            }
+            aria-pressed={rp.pinned ? true : false}
+            onClick={(e) => {
+              e.stopPropagation();
+              onTogglePin();
+            }}
+            style={{
+              width: 22,
+              height: 22,
+              borderRadius: 6,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              background: rp.pinned
+                ? "color-mix(in srgb, var(--color-accent) 26%, transparent)"
+                : "rgba(255,255,255,0.06)",
+              border: rp.pinned
+                ? "1px solid color-mix(in srgb, var(--color-accent) 45%, transparent)"
+                : "1px solid rgba(255,255,255,0.08)",
+              color: rp.pinned ? COLORS.accent : COLORS.textDim,
+              cursor: "pointer",
+              transition: "background 0.15s ease, color 0.15s ease",
+              padding: 0,
+            }}
+            title={rp.pinned ? "Unpin" : "Pin to top"}
+          >
+            <PushPin size={12} weight={rp.pinned ? "fill" : "regular"} />
+          </button>
+          <button
+            type="button"
+            aria-label={`Remove ${rp.displayName} from recents`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onForget();
+            }}
+            disabled={isForgetting}
+            style={{
+              width: 22,
+              height: 22,
+              borderRadius: 6,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              background: "rgba(255,255,255,0.06)",
+              border: "1px solid rgba(255,255,255,0.08)",
+              color: COLORS.textDim,
+              cursor: "pointer",
+              transition: "background 0.15s ease, color 0.15s ease",
+              padding: 0,
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.background = "rgba(239,68,68,0.18)";
+              e.currentTarget.style.color = "#EF4444";
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.background = "rgba(255,255,255,0.06)";
+              e.currentTarget.style.color = COLORS.textDim;
+            }}
+            title="Remove from recents"
+          >
+            <X size={12} weight="bold" />
+          </button>
+        </div>
+      ) : null}
       {isOpen ? (
         <span
           aria-hidden

--- a/apps/desktop/src/shared/types/core.ts
+++ b/apps/desktop/src/shared/types/core.ts
@@ -308,6 +308,8 @@ export type RecentProjectRemoteRef = {
   /** Human-friendly machine name shown on the recents row chip. */
   runtimeName: string;
   hostname: string;
+  /** Host-resolved project logo for remote recents, when available. */
+  iconDataUrl?: string | null;
 };
 
 export type RecentProjectSummary = {

--- a/docs/features/project-home/README.md
+++ b/docs/features/project-home/README.md
@@ -266,8 +266,9 @@ a prior session. Shows:
 - unified recent projects list from `window.ade.project.listRecent()`,
   with local and remote rows. Local rows show display name, path, lane
   count, last-opened timestamp, and availability. Remote rows show the
-  remote machine/project metadata and use live remote connection state
-  for their connected / reconnecting affordance.
+  host-resolved project icon when available, keep the amber remote
+  machine badge, and use live remote connection state for their
+  connected / reconnecting affordance.
 - per-row pin / unpin; pinned rows float above unpinned rows while
   preserving recency order inside each group.
 - deferred remove with an Undo toast. The renderer hides the row
@@ -493,10 +494,10 @@ detection or override). The override is committed to `.ade/ade.yaml`
 the `.ade/project-icons/` directory is part of the tracked shared
 scaffold so the actual bytes travel with the override.
 
-Remote project tabs cannot run the local resolver — the project files
-live on another machine. Instead the host brain resolves the icon and
-inlines it: the ade-cli `projects.list` RPC stamps each record with an
-`icon: { dataUrl, sourcePath, mimeType }` produced by
+Remote project tabs and remote recent-project rows cannot run the local
+resolver — the project files live on another machine. Instead the host
+brain resolves the icon and inlines it: the ade-cli `projects.list` RPC
+stamps each record with an `icon: { dataUrl, sourcePath, mimeType }` produced by
 `resolveRemoteProjectIcon` (`apps/ade-cli/src/services/projects/projectIconResolver.ts`),
 a compact electron-free port of the desktop resolver that covers the
 `.ade/ade.yaml` override, the conventional icon/logo files, and an
@@ -504,14 +505,15 @@ a compact electron-free port of the desktop resolver that covers the
 capped at 2 MB so it stays inline-safe on the wire; a failure for one
 project degrades to a null icon rather than breaking the list). That
 icon rides through `RemoteRuntimeProjectRecord.icon` →
-`OpenProjectBinding.iconDataUrl` → the remote project tab. `TopBar`'s
-`ProjectTabIcon` takes an `iconDataUrlOverride`: when the caller owns
-the icon (remote tabs), it renders the data URL directly and skips the
-local `resolveIcon` path entirely (falling back to the folder glyph
-when the host returned no icon). The binding's `iconDataUrl` is
-persisted to `globalState.lastRemoteProjectBinding` and restored on a
-cold start so the real logo shows immediately, before the remote
-reconnects and refreshes it.
+`OpenProjectBinding.iconDataUrl`. The desktop persists that data URL on
+both `globalState.lastRemoteProjectBinding` and the matching remote recent
+metadata, so the TopBar tab and welcome row can render the real logo before
+the remote reconnects. `TopBar`'s `ProjectTabIcon` takes an
+`iconDataUrlOverride`: when the caller owns the icon (remote tabs), it
+renders the data URL directly and skips the local `resolveIcon` path
+entirely (falling back to the folder glyph when the host returned no
+icon). The welcome row uses the same saved data URL for its primary tile and
+overlays the amber remote-machine badge so remote identity stays visible.
 
 The mobile companion gets the icon through a dedicated path: the host's
 `mobileProjectSummaryForContext` / `mobileProjectSummaryForRecent` in


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fcouple-isseus-view-here-start-6e570ecb num=657 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fcouple-isseus-view-here-start-6e570ecb&amp;pr=657">ade/couple-isseus-view-here-start-6e570ecb branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=657">PR #657</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds host-resolved project icons to remote entries in the welcome screen's recent projects list. Icons are validated and capped at 128 KB before being written to global state; oversized icons are thumbnailed down to 64 × 64 via `nativeImage` in the main process.

- `RecentProjectRemoteRef` gains an optional `iconDataUrl` field that flows through persistence helpers (`persistableRemoteProjectIconDataUrl`, `withPersistableRemoteProjectIcon`, `persistableRecentProjectRemote`) — each enforcing the size cap before any write.
- `normalizeStartupProjectState` now strips oversized icons from existing saved state on startup and backfills the icon from `lastRemoteProjectBinding` into older legacy recent entries that pre-date this change.
- `RunPage.tsx` splits the monolithic `RecentProjectIcon` into a generic `ProjectIconArtwork` (accepts a `dataUrl` prop) and a local-only `RecentProjectIcon`; remote rows render via `ProjectIconArtwork` + an amber `DesktopTower` badge overlay, and action buttons (pin/unpin, remove) are hidden while a connection is in the "connecting" state.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the icon persistence path is fully bounded by the 128 KB cap and a thumbnail fallback, and the startup normalizer strips any pre-existing oversized blobs before writing them back.

All three layers of the change (persistence helpers, startup normalizer, renderer component) are well-tested and handle their edge cases: oversized icons are resized or dropped, the backfill only fires when the data is already valid, and the UI correctly falls back to the tower glyph when no icon is present. No write-path regressions or data-loss scenarios were identified.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/state/globalState.ts | Adds three new exported helpers — persistableRemoteProjectIconDataUrl, withPersistableRemoteProjectIcon, persistableRecentProjectRemote — that validate and size-cap icon data URLs before any write, with consistent behavior across all call sites. |
| apps/desktop/src/main/services/projects/startupProjectResolver.ts | Adds startup-time icon migration: strips oversized icons from lastRemoteProjectBinding, backfills icon into legacy remote recents from the binding, and extends recentProjectEntryChanged to track iconDataUrl changes so the state is persisted when anything is stripped or backfilled. |
| apps/desktop/src/main/main.ts | Adds remoteProjectIconDataUrlForPersistence (thumbnail via nativeImage if oversized) and uses it at both the cold-start parse path and the live binding-record path; passes the capped icon into upsertRecentProject so the recent entry gets the icon immediately on first open. |
| apps/desktop/src/renderer/components/run/RunPage.tsx | Refactors icon rendering into a generic ProjectIconArtwork component; remote rows now show the cached icon with an amber DesktopTower badge overlay, hide pin/remove actions while reconnecting, and suppress the timestamp during a reconnect. |
| apps/desktop/src/shared/types/core.ts | Adds optional iconDataUrl?: string | null to RecentProjectRemoteRef, making the icon field part of the shared contract between main process and renderer. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Host as Remote Host (ade-cli)
    participant Main as Main Process (main.ts)
    participant GS as GlobalState
    participant Resolver as startupProjectResolver
    participant Renderer as RunPage (Renderer)

    Host->>Main: RemoteOpenProjectBinding (iconDataUrl up to 2 MB)
    Main->>Main: remoteProjectIconDataUrlForPersistence() resize to 64x64 if oversized, cap at 128 KB
    Main->>GS: "upsertRecentProject (remote + iconDataUrl <=128 KB)"
    Main->>GS: "lastRemoteProjectBinding = persistedBinding"

    Note over Main,GS: Cold start / app relaunch

    GS->>Resolver: normalizeStartupProjectState(saved)
    Resolver->>Resolver: withPersistableRemoteProjectIcon() strips oversized icons from binding
    Resolver->>Resolver: persistableRecentProjectRemote() strips oversized icons from each recent
    Resolver->>Resolver: backfill: if recent has no icon and targetId+projectId match binding copy icon
    Resolver-->>GS: write back if changed

    GS->>Renderer: listRecent() RecentProjectSummary[] remote.iconDataUrl present when available
    Renderer->>Renderer: ProjectIconArtwork(dataUrl) renders img or DesktopTower fallback + amber badge overlay when icon present
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Host as Remote Host (ade-cli)
    participant Main as Main Process (main.ts)
    participant GS as GlobalState
    participant Resolver as startupProjectResolver
    participant Renderer as RunPage (Renderer)

    Host->>Main: RemoteOpenProjectBinding (iconDataUrl up to 2 MB)
    Main->>Main: remoteProjectIconDataUrlForPersistence() resize to 64x64 if oversized, cap at 128 KB
    Main->>GS: "upsertRecentProject (remote + iconDataUrl <=128 KB)"
    Main->>GS: "lastRemoteProjectBinding = persistedBinding"

    Note over Main,GS: Cold start / app relaunch

    GS->>Resolver: normalizeStartupProjectState(saved)
    Resolver->>Resolver: withPersistableRemoteProjectIcon() strips oversized icons from binding
    Resolver->>Resolver: persistableRecentProjectRemote() strips oversized icons from each recent
    Resolver->>Resolver: backfill: if recent has no icon and targetId+projectId match binding copy icon
    Resolver-->>GS: write back if changed

    GS->>Renderer: listRecent() RecentProjectSummary[] remote.iconDataUrl present when available
    Renderer->>Renderer: ProjectIconArtwork(dataUrl) renders img or DesktopTower fallback + amber badge overlay when icon present
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/desktop/src/main/services/state/globalState.ts`, line 106-143 ([link](https://github.com/arul28/ade/blob/3ccc7ab093cde1e6fdc3712a3a292985ea83dc30/apps/desktop/src/main/services/state/globalState.ts#L106-L143)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Global state file can grow very large with multiple remote icons**

   `upsertRecentProject` now stores the full `iconDataUrl` (up to 2 MB base64 per the docs cap) inside every remote `RecentProject` entry, and `persistLastRemoteProjectBinding` also keeps a copy in `lastRemoteProjectBinding`. With up to 24 remote recent projects each carrying a 2 MB base64 icon the state file can reach ~50+ MB. `writeGlobalState` serialises the whole object with `JSON.stringify` then calls `fsyncSync` on every project open, so this write path slows proportionally as the icon set grows.

   Consider storing icons in a separate side-car directory (keyed by `targetId:projectId`) and replacing the inline `iconDataUrl` field with a short cache key, or at least evicting `iconDataUrl` from the remote entry when it isn't the most-recently-opened project.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/state/globalState.ts
   Line: 106-143

   Comment:
   **Global state file can grow very large with multiple remote icons**

   `upsertRecentProject` now stores the full `iconDataUrl` (up to 2 MB base64 per the docs cap) inside every remote `RecentProject` entry, and `persistLastRemoteProjectBinding` also keeps a copy in `lastRemoteProjectBinding`. With up to 24 remote recent projects each carrying a 2 MB base64 icon the state file can reach ~50+ MB. `writeGlobalState` serialises the whole object with `JSON.stringify` then calls `fsyncSync` on every project open, so this write path slows proportionally as the icon set grows.

   Consider storing icons in a separate side-car directory (keyed by `targetId:projectId`) and replacing the inline `iconDataUrl` field with a short cache key, or at least evicting `iconDataUrl` from the remote entry when it isn't the most-recently-opened project.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fstate%2FglobalState.ts%0ALine%3A%20106-143%0A%0AComment%3A%0A**Global%20state%20file%20can%20grow%20very%20large%20with%20multiple%20remote%20icons**%0A%0A%60upsertRecentProject%60%20now%20stores%20the%20full%20%60iconDataUrl%60%20%28up%20to%202%20MB%20base64%20per%20the%20docs%20cap%29%20inside%20every%20remote%20%60RecentProject%60%20entry%2C%20and%20%60persistLastRemoteProjectBinding%60%20also%20keeps%20a%20copy%20in%20%60lastRemoteProjectBinding%60.%20With%20up%20to%2024%20remote%20recent%20projects%20each%20carrying%20a%202%20MB%20base64%20icon%20the%20state%20file%20can%20reach%20~50%2B%20MB.%20%60writeGlobalState%60%20serialises%20the%20whole%20object%20with%20%60JSON.stringify%60%20then%20calls%20%60fsyncSync%60%20on%20every%20project%20open%2C%20so%20this%20write%20path%20slows%20proportionally%20as%20the%20icon%20set%20grows.%0A%0AConsider%20storing%20icons%20in%20a%20separate%20side-car%20directory%20%28keyed%20by%20%60targetId%3AprojectId%60%29%20and%20replacing%20the%20inline%20%60iconDataUrl%60%20field%20with%20a%20short%20cache%20key%2C%20or%20at%20least%20evicting%20%60iconDataUrl%60%20from%20the%20remote%20entry%20when%20it%20isn't%20the%20most-recently-opened%20project.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=657&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["ship: iteration 3 - thumbnail persisted ..."](https://github.com/arul28/ade/commit/7dd84f5e48a2413643110304261364958a91e97d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40449321)</sub>

<!-- /greptile_comment -->