### PR TITLE
Waht See When Auto Create

### DIFF
--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -9970,7 +9970,10 @@ export function AgentChatPane({
             data-testid="draft-launch-job"
             aria-live={isActiveJob ? "polite" : undefined}
             className={cn(
-              "mx-auto flex w-full max-w-[var(--chat-column,52rem)] items-center justify-between gap-3 rounded-lg border px-3 py-1.5 font-sans text-[length:calc(var(--chat-font-size)*11/14)]",
+              "flex items-center justify-between gap-3 rounded-lg border px-3 py-1.5 font-sans text-[length:calc(var(--chat-font-size)*11/14)]",
+              layoutVariant === "grid-tile"
+                ? "mx-auto w-full max-w-[var(--chat-column,52rem)]"
+                : "mx-3 max-w-[var(--chat-column,52rem)]",
               isFailed && "border-rose-300/20 bg-rose-500/[0.07] text-rose-100/90",
               isReady && "border-emerald-300/18 bg-emerald-500/[0.06] text-emerald-100/85",
               isActiveJob && "border-white/10 bg-white/[0.04] text-fg/70",
@@ -9987,7 +9990,7 @@ export function AgentChatPane({
                     ? (isStaleActiveJob ? staleDraftLaunchJobMessage(job) : draftLaunchJobMessage(job))
                     : (
                       <>
-                        Message sent: <span className="text-fg/85">&ldquo;{draftLaunchPromptSnippet(job)}&rdquo;</span>
+                        New Chat Started: <span className="text-fg/85">&ldquo;{draftLaunchPromptSnippet(job)}&rdquo;</span>
                       </>
                     )}
               </span>


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fwaht-see-when-auto-create-0f17b7a4 num=660 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fwaht-see-when-auto-create-0f17b7a4&amp;pr=660">ade/waht-see-when-auto-create-0f17b7a4 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=660">PR #660</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the draft launch job status card spacing to better adapt between grid-tile and other layouts.
  * Changed the inactive job message label from “Message sent” to “New Chat Started” for clearer status wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two small UI adjustments to the draft launch job status card in `AgentChatPane`. The layout now conditionally applies different spacing depending on whether `layoutVariant` is `"grid-tile"` or another variant, and the inactive job label is updated from "Message sent:" to "New Chat Started:".

- **Layout change**: grid-tile variant retains full-width centered layout (`mx-auto w-full`), while other variants switch to a margin-inset approach (`mx-3`) without `w-full`, meaning the card won't stretch to fill the container in non-grid-tile layouts.
- **Copy change**: The status label for a completed (non-active, non-failed) draft launch job is renamed from "Message sent:" to "New Chat Started:" for clearer UX messaging.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are scoped to CSS class names on a single card and a UI string label, with no logic or data-flow impact.

The diff only modifies Tailwind class selection (conditional on an already-used layoutVariant prop) and renames a status label. No state, data fetching, or event handling is touched. The non-grid-tile path drops w-full, which appears intentional to produce a margin-inset card rather than a stretched one, consistent with the PR description.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Two-line UI tweak: conditional CSS classes for grid-tile vs other layout variants, and a label copy change on the inactive draft launch job card. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Draft Launch Job Card Render] --> B{layoutVariant?}
    B -- "grid-tile" --> C["mx-auto w-full max-w-[--chat-column,52rem]\nCentered, full-width"]
    B -- "other" --> D["mx-3 max-w-[--chat-column,52rem]\nMargin-inset, content-width"]
    C --> E{job.status?}
    D --> E
    E -- "failed" --> F[Show launch error]
    E -- "active (non-stale)" --> G[draftLaunchJobMessage]
    E -- "active (stale)" --> H[staleDraftLaunchJobMessage]
    E -- "inactive / ready" --> I["New Chat Started: snippet"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Draft Launch Job Card Render] --> B{layoutVariant?}
    B -- "grid-tile" --> C["mx-auto w-full max-w-[--chat-column,52rem]\nCentered, full-width"]
    B -- "other" --> D["mx-3 max-w-[--chat-column,52rem]\nMargin-inset, content-width"]
    C --> E{job.status?}
    D --> E
    E -- "failed" --> F[Show launch error]
    E -- "active (non-stale)" --> G[draftLaunchJobMessage]
    E -- "active (stale)" --> H[staleDraftLaunchJobMessage]
    E -- "inactive / ready" --> I["New Chat Started: snippet"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Align draft launch banner width with com..."](https://github.com/arul28/ade/commit/4a419fe701ad08a0f6760042859fb9dd67ebf18d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40534035)</sub>

<!-- /greptile_comment -->