### PR TITLE
Mobile Connection Button

### DIFF
--- a/apps/desktop/src/renderer/components/app/TopBar.test.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.test.tsx
@@ -403,7 +403,7 @@ describe("TopBar", () => {
     expect(screen.getByTitle(rootPath)).toBeTruthy();
   });
 
-  it("renders a remote project tab without local sync polling", async () => {
+  it("renders a remote project tab with mobile sync control without immediate polling", async () => {
     (globalThis.window.ade.remoteRuntime.getConnectionSnapshot as any)
       .mockResolvedValue(makeRemoteConnectionSnapshot("studio"));
     useAppStore.setState({
@@ -427,8 +427,49 @@ describe("TopBar", () => {
     expect(screen.getByText("Remote App")).toBeTruthy();
     expect(screen.getByLabelText("Remote: Mac Studio")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Remote, connected" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Mobile, not connected" })).toBeTruthy();
     expect(globalThis.window.ade.sync.getStatus).not.toHaveBeenCalled();
-    expect(screen.queryByTitle("Connect a phone to this machine")).toBeNull();
+  });
+
+  it("opens mobile sync from a remote-bound project and reads the routed runtime status", async () => {
+    vi.useFakeTimers();
+    (globalThis.window.ade.remoteRuntime.getConnectionSnapshot as any)
+      .mockResolvedValue(makeRemoteConnectionSnapshot("studio"));
+    const getStatus = vi.fn(async () => makeSyncSnapshot());
+    globalThis.window.ade.sync.getStatus = getStatus as any;
+    useAppStore.setState({
+      project: { rootPath: "/srv/ade/remote-app", displayName: "Remote App", baseRef: "main" },
+      projectBinding: {
+        kind: "remote",
+        key: "remote:studio:project-1",
+        targetId: "studio",
+        runtimeName: "Mac Studio",
+        projectId: "project-1",
+        rootPath: "/srv/ade/remote-app",
+        displayName: "Remote App",
+      },
+      projectHydrated: true,
+      showWelcome: false,
+    } as any);
+
+    try {
+      render(<TopBar />);
+
+      expect(screen.getByRole("button", { name: "Mobile, not connected" })).toBeTruthy();
+      expect(getStatus).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByTitle("Connect a phone to this machine"));
+      await act(async () => {
+        vi.advanceTimersByTime(0);
+        await flushMicrotasks(2);
+      });
+
+      expect(screen.getByText("Connect to the ADE mobile app")).toBeTruthy();
+      expect(screen.getByTestId("sync-devices-section")).toBeTruthy();
+      expect(getStatus).toHaveBeenCalledWith({ includeTransferReadiness: false });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("marks a remote project tab disconnected when the target snapshot is errored", async () => {

--- a/apps/desktop/src/renderer/components/app/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.tsx
@@ -937,7 +937,9 @@ export function TopBar() {
   const remoteStatusCount = Math.max(connectedRemoteCount, openRemoteProjectTabs.length);
   const remoteConnected = connectedRemoteCount > 0;
   const syncConnected = isSyncConnected(syncSnapshot);
-  const showSyncControl = projectHydrated === true && !remoteBinding;
+  const showSyncControl = projectHydrated === true;
+  const syncStatusTargetKey =
+    remoteBinding?.key ?? project?.rootPath ?? "machine";
 
   useEffect(() => {
     openProjectTabRootsRef.current = openProjectTabRoots;
@@ -1220,11 +1222,12 @@ export function TopBar() {
       disposeSyncEvents?.();
     };
     // Background projects don't broadcast sync-status events (main.ts filters
-    // them to the active project), so we re-run this effect on rootPath change
-    // and let the delayed startup check pick up the current state. With no
-    // project open, sync calls fall back to the machine-level brain service.
-    // Focus and explicit drawer opens still refresh immediately.
-  }, [phoneSyncOpen, project?.rootPath, showSyncControl]);
+    // them to the active project), so we re-run this effect when the routed
+    // runtime target changes and let the delayed startup check pick up the
+    // current state. With no project open, sync calls fall back to the
+    // machine-level brain service. Focus and explicit drawer opens still
+    // refresh immediately.
+  }, [phoneSyncOpen, showSyncControl, syncStatusTargetKey]);
 
   const checkForActiveWorkloads = useCallback(
     async (projectRootPath: string): Promise<boolean> => {

--- a/docs/features/remote-runtime/README.md
+++ b/docs/features/remote-runtime/README.md
@@ -162,7 +162,7 @@ Local project bindings use the local ADE runtime for the same surfaces — agent
 
 iOS does not SSH into a machine. The phone pairs with an ADE machine and connects to that runtime's sync WebSocket advertised on the LAN or over a Tailscale tailnet. Install Tailscale on the phone and the ADE machine when they are not on the same local network.
 
-On desktop, phone pairing and sync status are managed by the local ADE runtime's sync service. The legacy in-process desktop sync host is disabled by default and can be re-enabled only for diagnostics with `ADE_ENABLE_DESKTOP_SYNC_HOST=1`.
+On desktop, the top-bar Mobile control is a runtime control, not a project control. It remains visible while a window is bound to a remote project: `window.ade.sync.*` routes to the active runtime binding, so a local/no-project window manages the local machine brain while a remote-bound window manages the remote machine's sync service. The legacy in-process desktop sync host is disabled by default and can be re-enabled only for diagnostics with `ADE_ENABLE_DESKTOP_SYNC_HOST=1`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fade-desktop-app-ahve-moible-8a03a326 num=661 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fade-desktop-app-ahve-moible-8a03a326&amp;pr=661">ade/ade-desktop-app-ahve-moible-8a03a326 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=661">PR #661</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the top-bar Mobile control available for remote-bound desktop windows. The main changes are:

- Shows the Mobile sync control whenever the project is hydrated.
- Refreshes sync status when the active runtime target changes.
- Adds tests for remote-bound Mobile control visibility and drawer-open status reads.
- Updates the remote-runtime docs to describe runtime-scoped mobile sync behavior.

<h3>Confidence Score: 5/5</h3>

The changes are narrowly scoped to the top-bar Mobile control visibility/status behavior, covered by targeted tests, and accompanied by matching documentation.

No blocking correctness or security issues were identified in the modified files, and the added tests exercise the main remote-bound visibility and drawer status scenarios.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the baseline mobile connection button tests to establish the pre-change state for the remote-bound project, capturing TREX visible Mobile button: false and TREX getStatus calls before open: \[\] in mobile-connection-button-01-before.log.
- Ran the post-change head tests to verify mobile visibility without immediate polling and drawer open/routed runtime status, with the results captured in mobile-connection-button-02-after.log.

<a href="https://app.greptile.com/trex/runs/12641610/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix mobile sync control on remote projec..."](https://github.com/arul28/ade/commit/b51cca8094f3c5802662f17037d49dd1d23ee3ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40535136)</sub>

<!-- /greptile_comment -->