### PR TITLE
Ios Testflight Download Buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 <p align="center">
   <a href="https://github.com/arul28/ADE/releases/latest"><img src="https://img.shields.io/badge/Download_for_macOS-7C3AED?style=for-the-badge&logo=apple&logoColor=white" alt="Download for macOS" /></a>
   &nbsp;
+  <a href="https://testflight.apple.com/join/ZSdJGKPy"><img src="https://img.shields.io/badge/Download_for_iOS-12101a?style=for-the-badge&logo=apple&logoColor=a78bfa" alt="Download for iOS" /></a>
+  &nbsp;
   <a href="https://ade-app.dev"><img src="https://img.shields.io/badge/Website-12101a?style=for-the-badge&logo=googlechrome&logoColor=a78bfa" alt="Website" /></a>
   &nbsp;
   <a href="https://ade-app.dev/docs"><img src="https://img.shields.io/badge/Docs-12101a?style=for-the-badge&logo=readthedocs&logoColor=a78bfa" alt="Docs" /></a>
@@ -122,7 +124,7 @@ Plus files, terminals, git history, the workspace graph, multi-tasking, Linear s
 
 ## Install
 
-Download ADE from [**GitHub Releases**](https://github.com/arul28/ADE/releases/latest), open it on any git repo, and add a provider key (or subscription) in Settings. Runs in Guest Mode without an account.
+Download ADE for macOS from [**GitHub Releases**](https://github.com/arul28/ADE/releases/latest), open it on any git repo, and add a provider key (or subscription) in Settings. Install the iOS companion from [**TestFlight**](https://testflight.apple.com/join/ZSdJGKPy). Runs in Guest Mode without an account.
 
 ### macOS
 
@@ -135,6 +137,10 @@ brew install --cask arul28/ade/ade
 Or download the latest `.dmg`, drag **ADE.app** into `/Applications`, and open it. Both paths install the same signed + notarized universal app; ADE keeps itself current afterwards through its built-in auto-updater.
 
 Requirements: macOS 13+, git on `PATH`, Node 22+ for headless CLI workflows.
+
+### iOS
+
+Install ADE Mobile from [TestFlight](https://testflight.apple.com/join/ZSdJGKPy), then pair it with the Mac from the desktop **Mobile** control or with `ade brain pin generate`.
 
 ### Windows
 

--- a/apps/desktop/src/renderer/components/app/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.tsx
@@ -27,6 +27,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { useAppStore } from "../../state/appStore";
 import { isRunOwnedSession } from "../../lib/sessions";
 import { useGithubProjectRemote } from "../../lib/useGithubProjectRemote";
+import { openExternalUrl } from "../../lib/openExternal";
 import {
   ZOOM_LEVEL_KEY,
   MIN_ZOOM_LEVEL,
@@ -40,6 +41,7 @@ import {
 import { cn } from "../ui/cn";
 import { deriveIconAccentColor } from "../../lib/iconAccent";
 import { SmartTooltip } from "../ui/SmartTooltip";
+import { ADE_MOBILE_TESTFLIGHT_URL } from "../../../shared/productLinks";
 import type {
   ProcessRuntime,
   ProjectIcon,
@@ -1786,6 +1788,10 @@ export function TopBar() {
   );
 
   const syncLabel = deriveSyncLabel(syncSnapshot) ?? "Phone sync";
+  const openMobileTestFlight = useCallback(
+    () => openExternalUrl(ADE_MOBILE_TESTFLIGHT_URL),
+    [],
+  );
 
   const renderHeaderStatusControls = useCallback(
     (options?: { menuLayout?: boolean; onActivate?: () => void }) => {
@@ -2530,15 +2536,26 @@ export function TopBar() {
                   </div>
                 </div>
               </div>
-              <button
-                type="button"
-                className="ade-shell-control inline-flex h-7 w-7 items-center justify-center rounded-md"
-                data-variant="ghost"
-                onClick={() => setPhoneSyncOpen(false)}
-                title="Close phone sync"
-              >
-                <X size={13} weight="regular" />
-              </button>
+              <div className="flex shrink-0 items-center gap-2">
+                <button
+                  type="button"
+                  className="ade-shell-control inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-[11px] font-semibold"
+                  onClick={openMobileTestFlight}
+                  title="Download ADE Mobile from TestFlight"
+                >
+                  <ArrowSquareOut size={12} weight="regular" />
+                  Download
+                </button>
+                <button
+                  type="button"
+                  className="ade-shell-control inline-flex h-7 w-7 items-center justify-center rounded-md"
+                  data-variant="ghost"
+                  onClick={() => setPhoneSyncOpen(false)}
+                  title="Close phone sync"
+                >
+                  <X size={13} weight="regular" />
+                </button>
+              </div>
             </div>
             <div className="p-4">
               <SyncDevicesSection />

--- a/apps/desktop/src/renderer/components/onboarding/WelcomeVideoGate.test.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/WelcomeVideoGate.test.tsx
@@ -9,15 +9,19 @@ import {
   ADE_WELCOME_VIDEO_REPLAY_EVENT,
   ADE_WELCOME_VIDEO_VERSION,
 } from "../../../shared/welcomeVideo";
+import { ADE_MOBILE_TESTFLIGHT_URL } from "../../../shared/productLinks";
 
 describe("WelcomeVideoGate", () => {
   const originalAde = window.ade;
   const getWelcomeVideoState = vi.fn();
   const markWelcomeVideoSeen = vi.fn();
+  const openExternal = vi.fn();
 
   beforeEach(() => {
     getWelcomeVideoState.mockReset();
     markWelcomeVideoSeen.mockReset();
+    openExternal.mockReset();
+    openExternal.mockResolvedValue(undefined);
     markWelcomeVideoSeen.mockResolvedValue({
       videoId: ADE_WELCOME_VIDEO_ID,
       version: ADE_WELCOME_VIDEO_VERSION,
@@ -29,6 +33,7 @@ describe("WelcomeVideoGate", () => {
         ...((originalAde as typeof window.ade | undefined)?.app ?? {}),
         getWelcomeVideoState,
         markWelcomeVideoSeen,
+        openExternal,
       },
     } as unknown) as typeof window.ade;
   });
@@ -90,5 +95,20 @@ describe("WelcomeVideoGate", () => {
       expect(markWelcomeVideoSeen).toHaveBeenCalledWith("dismissed");
     });
     expect(screen.queryByRole("dialog", { name: /welcome to ade/i })).toBeNull();
+  });
+
+  it("opens the mobile install link from the welcome actions", async () => {
+    getWelcomeVideoState.mockResolvedValue({
+      videoId: ADE_WELCOME_VIDEO_ID,
+      version: ADE_WELCOME_VIDEO_VERSION,
+      completedAt: null,
+      dismissedAt: null,
+    });
+
+    render(<WelcomeVideoGate />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /install mobile app/i }));
+
+    expect(openExternal).toHaveBeenCalledWith(ADE_MOBILE_TESTFLIGHT_URL);
   });
 });

--- a/apps/desktop/src/renderer/components/onboarding/WelcomeVideoGate.tsx
+++ b/apps/desktop/src/renderer/components/onboarding/WelcomeVideoGate.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import {
   ArrowSquareOut,
+  DeviceMobile,
   GithubLogo,
   PlayCircle,
   X,
@@ -9,11 +10,14 @@ import {
 import { docs } from "../../onboarding/docsLinks";
 import { openExternalUrl } from "../../lib/openExternal";
 import {
-  ADE_GITHUB_URL,
   ADE_WELCOME_VIDEO_EMBED_URL,
   ADE_WELCOME_VIDEO_REPLAY_EVENT,
   ADE_WELCOME_VIDEO_WATCH_URL,
 } from "../../../shared/welcomeVideo";
+import {
+  ADE_GITHUB_URL,
+  ADE_MOBILE_TESTFLIGHT_URL,
+} from "../../../shared/productLinks";
 
 type WelcomeVideoGateProps = {
   onVisibilityChange?: (visible: boolean, checking: boolean) => void;
@@ -60,6 +64,7 @@ export function WelcomeVideoGate({ onVisibilityChange }: WelcomeVideoGateProps) 
 
   const openGitHub = useCallback(() => openExternalUrl(ADE_GITHUB_URL), []);
   const openDocs = useCallback(() => openExternalUrl(docs.home), []);
+  const openMobileApp = useCallback(() => openExternalUrl(ADE_MOBILE_TESTFLIGHT_URL), []);
   const openVideo = useCallback(() => openExternalUrl(ADE_WELCOME_VIDEO_WATCH_URL), []);
 
   const handleOpenChange = useCallback(
@@ -171,6 +176,12 @@ export function WelcomeVideoGate({ onVisibilityChange }: WelcomeVideoGateProps) 
               </WelcomeActionButton>
               <WelcomeActionButton onClick={openDocs} icon={<ArrowSquareOut size={13} />}>
                 Docs
+              </WelcomeActionButton>
+              <WelcomeActionButton
+                onClick={openMobileApp}
+                icon={<DeviceMobile size={14} weight="regular" />}
+              >
+                Install mobile app
               </WelcomeActionButton>
               <WelcomeActionButton
                 onClick={openVideo}

--- a/apps/desktop/src/shared/productLinks.ts
+++ b/apps/desktop/src/shared/productLinks.ts
@@ -1,0 +1,2 @@
+export const ADE_GITHUB_URL = "https://github.com/arul28/ADE";
+export const ADE_MOBILE_TESTFLIGHT_URL = "https://testflight.apple.com/join/ZSdJGKPy";

--- a/apps/desktop/src/shared/welcomeVideo.ts
+++ b/apps/desktop/src/shared/welcomeVideo.ts
@@ -2,7 +2,6 @@ export const ADE_WELCOME_VIDEO_ID = "64E0pViEiB8";
 export const ADE_WELCOME_VIDEO_VERSION = 1;
 export const ADE_WELCOME_VIDEO_REPLAY_EVENT = "ade:welcome-video:replay";
 
-export const ADE_GITHUB_URL = "https://github.com/arul28/ADE";
 export const ADE_WELCOME_VIDEO_WATCH_URL = `https://www.youtube.com/watch?v=${ADE_WELCOME_VIDEO_ID}`;
 export const ADE_WELCOME_VIDEO_EMBED_URL =
   `https://www.youtube-nocookie.com/embed/${ADE_WELCOME_VIDEO_ID}?rel=0&modestbranding=1&playsinline=1`;

--- a/apps/web/src/app/pages/DownloadPage.tsx
+++ b/apps/web/src/app/pages/DownloadPage.tsx
@@ -53,8 +53,8 @@ export function DownloadPage() {
         icon: <Apple className="h-5 w-5" />,
         note: "Current beta release target: DMG and ZIP from GitHub Releases.",
         hint: "ADE for computers bundles the app, ade CLI, ade code, and the background ADE brain.",
-        actionHref: LINKS.releases,
-        actionLabel: "Download from releases"
+        actionHref: LINKS.releasesLatest,
+        actionLabel: "Download for Mac"
       },
       {
         key: "windows" as const,
@@ -78,10 +78,10 @@ export function DownloadPage() {
         key: "ios" as const,
         title: "iOS",
         icon: <Smartphone className="h-5 w-5" />,
-        note: "ADE Mobile is available to current TestFlight testers while the App Store listing is prepared.",
+        note: "ADE Mobile is available through TestFlight while the App Store listing is prepared.",
         hint: "Pair once with an ADE machine, then review, approve, and follow push state from the phone.",
-        actionHref: LINKS.changelog,
-        actionLabel: "Read mobile release notes"
+        actionHref: LINKS.testflight,
+        actionLabel: "Download for iOS"
       }
     ],
     []
@@ -103,16 +103,18 @@ export function DownloadPage() {
         </Reveal>
         <Reveal delay={0.1}>
           <p className="mt-5 max-w-2xl text-pretty text-base leading-relaxed text-muted-fg sm:text-lg">
-            Get ADE for your computer from GitHub Releases, or build from source. The computer install includes the app,
-            ade CLI, ade code, and the background ADE brain. ADE runs in Guest Mode without accounts, and can optionally
-            enable hosted or BYOK LLM providers.
+            Get ADE for Mac from GitHub Releases, install the iOS companion from TestFlight, or build from source. The
+            computer install includes the app, ade CLI, ade code, and the background ADE brain.
           </p>
         </Reveal>
 
         <Reveal delay={0.12}>
           <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-            <LinkButton to={LINKS.releases} size="lg" variant="primary" target="_blank" rel="noreferrer">
-              Latest release <ArrowUpRight className="h-4 w-4" />
+            <LinkButton to={LINKS.releasesLatest} size="lg" variant="primary" target="_blank" rel="noreferrer">
+              Download for Mac <ArrowUpRight className="h-4 w-4" />
+            </LinkButton>
+            <LinkButton to={LINKS.testflight} size="lg" variant="secondary" target="_blank" rel="noreferrer">
+              Download for iOS <Smartphone className="h-4 w-4" />
             </LinkButton>
             <LinkButton to={LINKS.github} size="lg" variant="secondary" target="_blank" rel="noreferrer">
               GitHub repo <Github className="h-4 w-4" />

--- a/apps/web/src/components/SiteFooter.tsx
+++ b/apps/web/src/components/SiteFooter.tsx
@@ -32,8 +32,11 @@ export function SiteFooter() {
             <div>
               <div className="text-sm font-semibold text-fg">Product</div>
               <div className="mt-3 flex flex-col gap-2 text-sm">
-                <a className="focus-ring w-fit rounded-md text-muted-fg hover:text-fg" href={LINKS.releases} target="_blank" rel="noreferrer">
-                  Download
+                <a className="focus-ring w-fit rounded-md text-muted-fg hover:text-fg" href={LINKS.releasesLatest} target="_blank" rel="noreferrer">
+                  Download for Mac
+                </a>
+                <a className="focus-ring w-fit rounded-md text-muted-fg hover:text-fg" href={LINKS.testflight} target="_blank" rel="noreferrer">
+                  Download for iOS
                 </a>
                 <Link className="focus-ring w-fit rounded-md text-muted-fg hover:text-fg" to="/#features">
                   Features

--- a/apps/web/src/components/SiteHeader.tsx
+++ b/apps/web/src/components/SiteHeader.tsx
@@ -109,14 +109,14 @@ export function SiteHeader() {
               GitHub
             </a>
 
-            <LinkButton to={LINKS.releases} variant="primary" size="sm" target="_blank" rel="noreferrer" className="ml-2">
-              Download
+            <LinkButton to={LINKS.releasesLatest} variant="primary" size="sm" target="_blank" rel="noreferrer" className="ml-2">
+              Download for Mac
             </LinkButton>
           </nav>
 
           <div className="flex items-center gap-2 md:hidden">
-            <LinkButton to={LINKS.releases} variant="primary" size="sm" target="_blank" rel="noreferrer">
-              Download
+            <LinkButton to={LINKS.releasesLatest} variant="primary" size="sm" target="_blank" rel="noreferrer">
+              Mac
             </LinkButton>
             <button
               type="button"

--- a/apps/web/src/components/editorial/BackCover.tsx
+++ b/apps/web/src/components/editorial/BackCover.tsx
@@ -1,5 +1,5 @@
 import { motion, useReducedMotion } from "framer-motion";
-import { Download, Github } from "lucide-react";
+import { Download, Github, Smartphone } from "lucide-react";
 import { Link } from "react-router-dom";
 import { LINKS } from "../../lib/links";
 import { IPhoneFrame } from "./IPhoneFrame";
@@ -74,14 +74,23 @@ export function BackCover() {
             className="mt-9 flex flex-wrap gap-3"
           >
             <a
-              href={LINKS.releases}
+              href={LINKS.releasesLatest}
               target="_blank"
               rel="noreferrer"
               className="inline-flex items-center gap-2 rounded-[2px] bg-[color:var(--color-cream)] px-[22px] py-[14px] text-[15px] font-medium text-[color:var(--color-bg)] transition-colors duration-200 hover:bg-white"
             >
-              <Download aria-hidden="true" className="h-4 w-4" /> Download DMG{" "}
+              <Download aria-hidden="true" className="h-4 w-4" /> Download for Mac{" "}
               <span aria-hidden="true" className="font-serif italic">→</span>
               <span className="sr-only">opens GitHub releases in a new tab</span>
+            </a>
+            <a
+              href={LINKS.testflight}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 rounded-[2px] border border-[color:var(--color-hairline-strong)] px-[22px] py-[14px] text-[15px] font-medium text-[color:var(--color-cream)] transition-colors hover:border-[color:var(--color-cream)] hover:bg-white/[0.04]"
+            >
+              <Smartphone aria-hidden="true" className="h-4 w-4" /> Download for iOS
+              <span className="sr-only">opens TestFlight in a new tab</span>
             </a>
             <a
               href={LINKS.github}

--- a/apps/web/src/components/editorial/Lede.tsx
+++ b/apps/web/src/components/editorial/Lede.tsx
@@ -1,5 +1,5 @@
 import { motion, useReducedMotion } from "framer-motion";
-import { ArrowUpRight, BookOpen, Download, Github } from "lucide-react";
+import { ArrowUpRight, BookOpen, Download, Github, Smartphone } from "lucide-react";
 import { CopyButton } from "../CopyButton";
 import { LINKS } from "../../lib/links";
 
@@ -80,12 +80,20 @@ export function Lede() {
         className="mt-4 flex flex-wrap items-center justify-center gap-3"
       >
         <a
-          href={LINKS.releases}
+          href={LINKS.releasesLatest}
           target="_blank"
           rel="noreferrer"
           className="inline-flex items-center gap-2 rounded-[2px] bg-[color:var(--color-cream)] px-[20px] py-3.5 text-[15px] font-medium text-[color:var(--color-bg)] transition-all duration-200 hover:-translate-y-[1px] hover:bg-white"
         >
-          <Download className="h-4 w-4" /> Download
+          <Download className="h-4 w-4" /> Download for Mac
+        </a>
+        <a
+          href={LINKS.testflight}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-2 rounded-[2px] border border-[color:var(--color-hairline-strong)] px-[20px] py-3.5 text-[15px] font-medium text-[color:var(--color-cream)] transition-colors hover:border-[color:var(--color-cream)] hover:bg-white/[0.04]"
+        >
+          <Smartphone className="h-4 w-4" /> Download for iOS
         </a>
         <a
           href={LINKS.github}

--- a/apps/web/src/components/editorial/Masthead.tsx
+++ b/apps/web/src/components/editorial/Masthead.tsx
@@ -35,12 +35,20 @@ export function Masthead() {
             GitHub
           </a>
           <a
-            href={LINKS.releases}
+            href={LINKS.releasesLatest}
             target="_blank"
             rel="noreferrer"
             className="text-[color:var(--color-violet-bright)] transition-colors hover:text-[color:var(--color-cream)]"
           >
-            Download <span aria-hidden>&darr;</span>
+            Mac <span aria-hidden>&darr;</span>
+          </a>
+          <a
+            href={LINKS.testflight}
+            target="_blank"
+            rel="noreferrer"
+            className="text-[color:var(--color-violet-bright)] transition-colors hover:text-[color:var(--color-cream)]"
+          >
+            iOS <span aria-hidden>&darr;</span>
           </a>
         </nav>
       </div>

--- a/apps/web/src/lib/links.ts
+++ b/apps/web/src/lib/links.ts
@@ -7,6 +7,8 @@ export const LINKS = {
   repo,
   github: `https://github.com/${repo}`,
   releases: `https://github.com/${repo}/releases`,
+  releasesLatest: `https://github.com/${repo}/releases/latest`,
+  testflight: "https://testflight.apple.com/join/ZSdJGKPy",
   docs: "https://ade-app.dev/docs",
   changelog: "https://ade-app.dev/docs/changelog",
   prd: `https://github.com/${repo}/blob/main/docs/PRD.md`,

--- a/docs.json
+++ b/docs.json
@@ -228,9 +228,14 @@
     "global": {
       "anchors": [
         {
-          "anchor": "Download",
+          "anchor": "Download for Mac",
           "href": "https://github.com/arul28/ADE/releases/latest",
           "icon": "apple"
+        },
+        {
+          "anchor": "Download for iOS",
+          "href": "https://testflight.apple.com/join/ZSdJGKPy",
+          "icon": "mobile-screen"
         },
         {
           "anchor": "GitHub",
@@ -244,7 +249,7 @@
     "links": [],
     "primary": {
       "type": "button",
-      "label": "Download ADE",
+      "label": "Download for Mac",
       "href": "https://github.com/arul28/ADE/releases/latest"
     }
   },
@@ -268,7 +273,8 @@
       {
         "header": "Product",
         "items": [
-          { "label": "Download", "href": "https://github.com/arul28/ADE/releases/latest" },
+          { "label": "Download for Mac", "href": "https://github.com/arul28/ADE/releases/latest" },
+          { "label": "Download for iOS", "href": "https://testflight.apple.com/join/ZSdJGKPy" },
           { "label": "Lanes", "href": "/lanes/overview" },
           { "label": "Changelog", "href": "/changelog" }
         ]

--- a/docs/features/onboarding-and-settings/README.md
+++ b/docs/features/onboarding-and-settings/README.md
@@ -105,8 +105,9 @@ Renderer — onboarding:
   welcome wizard are no longer mounted.
 - `apps/desktop/src/renderer/components/onboarding/WelcomeVideoGate.tsx`
   — one-time app-level welcome screen backed by global app state. It
-  links to GitHub and the docs site and embeds the current welcome
-  YouTube video. The Help menu can replay it without resetting setup.
+  links to GitHub, the docs site, the ADE Mobile TestFlight install,
+  and the current welcome YouTube video. The Help menu can replay it
+  without resetting setup.
 - `apps/desktop/src/renderer/components/onboarding/HelpMenu.tsx`
   — persistent help menu in the top bar: glossary, docs links, welcome
   video replay, and help preferences. Tour replay entries were removed
@@ -194,7 +195,8 @@ Renderer — settings:
   loopback address candidates, the bootstrap token for desktop peers,
   the Tailscale MagicDNS discovery status (`svc:ade-sync` publication
   via `tailscale serve`), and the per-device connection panel used to
-  forget paired phones.
+  forget paired phones. The top-bar Mobile popover wraps this section
+  with a TestFlight download action for installing ADE Mobile.
 - `apps/desktop/src/renderer/components/usage/HeaderUsageControl.tsx`
   and `UsageQuotaPanel.tsx` — header usage popup. Live provider quotas
   for Claude and Codex (tracked providers) and the automation budget

--- a/getting-started/install.mdx
+++ b/getting-started/install.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Install ADE"
-description: "Download ADE for macOS — DMG or Homebrew — launch it, and run in guest mode with no account."
+description: "Download ADE for macOS, install the iOS companion from TestFlight, and run in guest mode with no account."
 icon: "download"
 ---
 
-ADE is a native macOS app. Download it, drag it to Applications, and launch — no account required. You can be in a project in under a minute.
+ADE is a native macOS app with an iOS companion. Download the Mac app, launch it with no account, then add the phone app from TestFlight when you want mobile review and chat.
 
 <Frame caption="Add your first repository from the welcome screen">
   <img src="/media/features/project/add-project-button.webp" alt="Add your first repository from the ADE welcome screen" />
@@ -45,6 +45,9 @@ The fastest path is Homebrew. Prefer a download? Grab the DMG from GitHub Releas
     2. Open the DMG and drag **ADE.app** into `/Applications`.
     3. Launch ADE from `/Applications` or Spotlight. If macOS asks for confirmation, choose **Open**.
   </Accordion>
+  <Accordion title="Install the iOS companion" icon="mobile-screen">
+    Open [TestFlight](https://testflight.apple.com/join/ZSdJGKPy) on your iPhone and install ADE Mobile. Pair it after the Mac app is running from the desktop **Mobile** control.
+  </Accordion>
 </AccordionGroup>
 
 ## Launch and explore
@@ -56,7 +59,7 @@ ADE keeps itself current with a built-in auto-updater: it downloads new releases
 </Note>
 
 <Info>
-ADE is macOS-only today. A Windows build is paused — releases ship for macOS.
+ADE's desktop app is macOS-only today. The iOS companion is available through TestFlight. A Windows build is paused — releases ship for macOS.
 </Info>
 
 ## Next

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -12,7 +12,7 @@ This page is the shortest useful path. You can tune providers, permissions, Line
 
 <Steps>
   <Step title="Install ADE">
-    Download the latest macOS DMG from [GitHub Releases](https://github.com/arul28/ADE/releases), open it, and drag **ADE.app** into `/Applications`.
+    Download the latest macOS DMG from [GitHub Releases](https://github.com/arul28/ADE/releases/latest), open it, and drag **ADE.app** into `/Applications`. Install the optional iOS companion from [TestFlight](https://testflight.apple.com/join/ZSdJGKPy).
   </Step>
   <Step title="Connect one AI provider">
     Open **Settings -> AI Providers** and verify at least one provider. Claude Code, Codex, Cursor, Factory Droid, and OpenCode are the agent paths.

--- a/tools/ios-companion.mdx
+++ b/tools/ios-companion.mdx
@@ -6,6 +6,10 @@ icon: "mobile-screen"
 
 The ADE iOS app is a client for your Mac. It pairs over a live WebSocket and mirrors your lanes, chats, and PRs in real time. Start or continue a chat, review and merge a PR, or browse a lane's diff — from your phone. Your source code never leaves the Mac. The phone is a thin client; the agents run on the desktop runtime.
 
+<Card title="Download for iOS" icon="mobile-screen" href="https://testflight.apple.com/join/ZSdJGKPy" horizontal>
+  Install ADE Mobile from TestFlight, then pair it with your Mac.
+</Card>
+
 <CardGroup cols={2}>
   <Frame caption="Chat with agents from your phone">
     <img src="/media/features/mobile/agent-chat.webp" alt="Agent chat on the ADE iOS app" width="300" />
@@ -37,8 +41,11 @@ The ADE iOS app is a client for your Mac. It pairs over a live WebSocket and mir
 Pairing links the app to your Mac's runtime with a one-time PIN. Generate the PIN on the desktop (or from the CLI), enter it on the phone, and the app connects.
 
 <Steps>
+  <Step title="Install ADE Mobile">
+    Open [TestFlight](https://testflight.apple.com/join/ZSdJGKPy) on your iPhone and install ADE Mobile.
+  </Step>
   <Step title="Generate a PIN on the Mac">
-    Open desktop **Settings -> Mobile** and generate a pairing PIN, or run `ade brain pin generate` from any shell.
+    Open the desktop **Mobile** control and generate a pairing PIN, or run `ade brain pin generate` from any shell.
   </Step>
   <Step title="Enter the PIN on iOS">
     Open the ADE app on your iPhone and type the PIN to pair with your machine.
@@ -80,7 +87,7 @@ A PR your agents opened shows up on the phone with its diff, CI status, and comm
 - Source and project data stay tied to the paired Mac. The phone holds no checkout.
 
 <Note>
-If the app looks connected but updates do not arrive, check desktop **Settings -> Mobile** first, then confirm both devices can reach each other on the network.
+If the app looks connected but updates do not arrive, check the desktop **Mobile** control first, then confirm both devices can reach each other on the network.
 </Note>
 
 <CardGroup cols={2}>

--- a/welcome.mdx
+++ b/welcome.mdx
@@ -18,8 +18,11 @@ ADE runs **Claude Code, Codex, Cursor, Factory Droid, and OpenCode** — every m
   <Card title="Key concepts" icon="lightbulb" href="/key-concepts" horizontal>
     The vocabulary, in two minutes.
   </Card>
-  <Card title="Download" icon="apple" href="https://github.com/arul28/ADE/releases/latest" horizontal>
+  <Card title="Download for Mac" icon="apple" href="https://github.com/arul28/ADE/releases/latest" horizontal>
     Free, open source. macOS 13+.
+  </Card>
+  <Card title="Download for iOS" icon="mobile-screen" href="https://testflight.apple.com/join/ZSdJGKPy" horizontal>
+    Install the ADE companion app from TestFlight.
   </Card>
 </Columns>
 


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Ftestflight-apple-join-zsdjgkpy-testflight-cfcd925f num=662 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Ftestflight-apple-join-zsdjgkpy-testflight-cfcd925f&amp;pr=662">ade/testflight-apple-join-zsdjgkpy-testflight-cfcd925f branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=662">PR #662</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds iOS TestFlight download buttons and links across the web app, desktop app, and documentation, surfacing the ADE Mobile companion install path from multiple touchpoints. The `ADE_GITHUB_URL` constant is also moved from `welcomeVideo.ts` into a new `productLinks.ts` shared module alongside the new `ADE_MOBILE_TESTFLIGHT_URL`.

- **Desktop**: Adds a \"Download\" button in the TopBar phone-sync popover and an \"Install mobile app\" action in the welcome screen dialog, both opening `https://testflight.apple.com/join/ZSdJGKPy`.
- **Web**: Updates `LINKS` in `links.ts` with `releasesLatest` and `testflight`; swaps most `releases` references to `releasesLatest`; adds iOS download CTAs to `Lede`, `BackCover`, `Masthead`, `DownloadPage`, `SiteFooter`, and `SiteHeader`.
- **Docs / MDX**: Adds TestFlight download steps and cards across `welcome.mdx`, `quickstart.mdx`, `getting-started/install.mdx`, `tools/ios-companion.mdx`, and `docs.json`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — changes are additive UI links and documentation with no logic, auth, or data path modifications.

All TestFlight URLs are consistent across the 10+ touchpoints they appear in, the new productLinks.ts module correctly centralises the desktop constants, and the new welcome-screen test properly exercises the added button. The only gap is that the mobile-breakpoint site header exposes only a Mac CTA with no iOS download path visible to iPhone visitors before they open the hamburger menu.

apps/web/src/components/SiteHeader.tsx — the mobile header CTA coverage for iOS users.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/shared/productLinks.ts | New shared constants file centralizing ADE_GITHUB_URL (moved from welcomeVideo.ts) and ADE_MOBILE_TESTFLIGHT_URL; clean extraction with no issues. |
| apps/web/src/lib/links.ts | Adds releasesLatest and testflight to LINKS; testflight is hardcoded (not derived from the repo env var) which is intentional since TestFlight join codes are app-specific, not repo-specific. |
| apps/desktop/src/renderer/components/app/TopBar.tsx | Adds a "Download" button to the phone-sync popover that opens TestFlight; useCallback is used correctly with an empty dep array since openExternalUrl is stable. |
| apps/desktop/src/renderer/components/onboarding/WelcomeVideoGate.tsx | Adds "Install mobile app" action button opening TestFlight; follows the same pattern as openGitHub/openDocs callbacks; no issues. |
| apps/desktop/src/renderer/components/onboarding/WelcomeVideoGate.test.tsx | Adds a well-structured test for the mobile install button; correctly mocks openExternal and asserts it's called with ADE_MOBILE_TESTFLIGHT_URL. |
| apps/web/src/app/pages/DownloadPage.tsx | iOS card now correctly links to LINKS.testflight instead of the changelog; also adds a primary "Download for iOS" CTA button alongside the Mac download button. |
| apps/web/src/components/SiteHeader.tsx | Desktop nav CTA updated to "Download for Mac"; mobile breakpoint CTA truncated to "Mac" with no iOS option added for mobile visitors, which may create friction for iOS users reaching the site on their phone. |
| apps/web/src/components/editorial/Lede.tsx | Adds a secondary iOS download button next to the Mac CTA; styling is consistent with the existing secondary button pattern used in BackCover. |
| apps/web/src/components/editorial/BackCover.tsx | Adds iOS download link with proper sr-only text and aria-hidden on the icon; consistent with the existing Mac download link treatment in the same component. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User Entry Points] --> B[Website]
    A --> C[Desktop App]
    A --> D[Docs / README]

    B --> B1[SiteHeader — Download for Mac]
    B --> B2[Lede / BackCover / Masthead\nDownload for iOS button]
    B --> B3[DownloadPage\niOS card → TestFlight]
    B --> B4[SiteFooter\nDownload for iOS link]

    C --> C1[WelcomeVideoGate\nInstall mobile app button]
    C --> C2[TopBar phone-sync popover\nDownload button]

    D --> D1[welcome.mdx card]
    D --> D2[quickstart.mdx step]
    D --> D3[install.mdx accordion]
    D --> D4[ios-companion.mdx card + step]

    B2 --> TF[TestFlight — join/ZSdJGKPy]
    B3 --> TF
    B4 --> TF
    C1 --> TF
    C2 --> TF
    D1 --> TF
    D2 --> TF
    D3 --> TF
    D4 --> TF
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User Entry Points] --> B[Website]
    A --> C[Desktop App]
    A --> D[Docs / README]

    B --> B1[SiteHeader — Download for Mac]
    B --> B2[Lede / BackCover / Masthead\nDownload for iOS button]
    B --> B3[DownloadPage\niOS card → TestFlight]
    B --> B4[SiteFooter\nDownload for iOS link]

    C --> C1[WelcomeVideoGate\nInstall mobile app button]
    C --> C2[TopBar phone-sync popover\nDownload button]

    D --> D1[welcome.mdx card]
    D --> D2[quickstart.mdx step]
    D --> D3[install.mdx accordion]
    D --> D4[ios-companion.mdx card + step]

    B2 --> TF[TestFlight — join/ZSdJGKPy]
    B3 --> TF
    B4 --> TF
    C1 --> TF
    C2 --> TF
    D1 --> TF
    D2 --> TF
    D3 --> TF
    D4 --> TF
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fcomponents%2FSiteHeader.tsx%3A117-120%0A**Mobile%20header%20has%20no%20iOS%20download%20path**%0A%0AThe%20mobile%20breakpoint%20CTA%20was%20narrowed%20from%20%22Download%22%20to%20%22Mac%22%2C%20but%20no%20iOS%20option%20was%20added.%20An%20iOS%20user%20visiting%20the%20marketing%20site%20on%20their%20iPhone%20will%20see%20only%20a%20%22Mac%22%20download%20button%2C%20which%20doesn't%20apply%20to%20them.%20The%20footer%20and%20inner%20pages%20expose%20the%20TestFlight%20link%2C%20but%20a%20visitor%20who%20bounces%20from%20just%20the%20header%20has%20no%20visible%20path%20to%20the%20companion%20app.%20Consider%20adding%20a%20secondary%20%22iOS%22%20link%20or%20a%20%22Download%20%E2%86%93%22%20dropdown%20that%20surfaces%20both%20targets%20in%20the%20mobile%20header.%0A%0A&repo=arul28%2Fade&pr=662&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/web/src/components/SiteHeader.tsx:117-120
**Mobile header has no iOS download path**

The mobile breakpoint CTA was narrowed from "Download" to "Mac", but no iOS option was added. An iOS user visiting the marketing site on their iPhone will see only a "Mac" download button, which doesn't apply to them. The footer and inner pages expose the TestFlight link, but a visitor who bounces from just the header has no visible path to the companion app. Consider adding a secondary "iOS" link or a "Download ↓" dropdown that surfaces both targets in the mobile header.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add ADE Mobile TestFlight download links"](https://github.com/arul28/ade/commit/0dc4fc113f8f5714dfa956fd0f94c9ead086fbd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40536883)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->