### PR TITLE
Remote Cli Copy Paste

### DIFF
--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -233,7 +233,7 @@ async function flushPromises() {
 
 async function flushPasteWrite() {
   await act(async () => {
-    for (let i = 0; i < 6; i += 1) {
+    for (let i = 0; i < 10; i += 1) {
       await Promise.resolve();
     }
   });
@@ -1058,6 +1058,49 @@ describe("TerminalView", () => {
     expect(ptyWrite).toHaveBeenCalledWith({
       ptyId: "pty-parked-paste",
       data: "\x1b[200~line one\rline two\x1b[201~",
+    });
+  });
+
+  it("keeps input typed during paste refresh behind the pasted text", async () => {
+    const previewMock = window.ade.terminal.preview as unknown as ReturnType<typeof vi.fn>;
+    let resolvePreview: ((value: unknown) => void) | null = null;
+    const previewPromise = new Promise<unknown>((resolve) => {
+      resolvePreview = resolve;
+    });
+    previewMock.mockImplementation(() => previewPromise);
+
+    render(<TerminalView ptyId="pty-paste-order" sessionId="session-paste-order" isActive />);
+    await flushAnimationFrame();
+
+    const terminal = mockState.terminalInstances.at(-1) as {
+      element: HTMLElement | null;
+      onData: ReturnType<typeof vi.fn>;
+    } | undefined;
+    expect(terminal?.element).toBeTruthy();
+    const onData = terminal?.onData.mock.calls.at(-1)?.[0] as ((data: string) => void) | undefined;
+    expect(onData).toBeTruthy();
+
+    const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
+    ptyWrite.mockClear();
+
+    terminal!.element!.dispatchEvent(createPasteEvent("run build"));
+    onData!("\r");
+    await flushPasteWrite();
+    expect(ptyWrite).not.toHaveBeenCalled();
+
+    resolvePreview!({
+      terminalId: "session-paste-order",
+      session: null,
+      source: "transcript",
+      snapshot: null,
+      transcript: "\x1b[?2004hCodex ready\n",
+      capturedAt: new Date().toISOString(),
+    });
+    await flushPasteWrite();
+
+    expect(ptyWrite).toHaveBeenCalledWith({
+      ptyId: "pty-paste-order",
+      data: "\x1b[200~run build\x1b[201~\r",
     });
   });
 

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -231,6 +231,14 @@ async function flushPromises() {
   });
 }
 
+async function flushPasteWrite() {
+  await act(async () => {
+    for (let i = 0; i < 6; i += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
 function createPasteEvent(text: string): Event {
   const event = new Event("paste", { bubbles: true, cancelable: true });
   Object.defineProperty(event, "clipboardData", {
@@ -975,6 +983,7 @@ describe("TerminalView", () => {
 
     const event = createPasteEvent("hello from clipboard");
     terminal!.element!.dispatchEvent(event);
+    await flushPasteWrite();
 
     expect(event.defaultPrevented).toBe(true);
     expect(ptyWrite).toHaveBeenCalledWith({
@@ -1007,11 +1016,48 @@ describe("TerminalView", () => {
 
     const event = createPasteEvent("line one\n\x1b[31mline two");
     terminal!.element!.dispatchEvent(event);
+    await flushPasteWrite();
 
     expect(event.defaultPrevented).toBe(true);
     expect(ptyWrite).toHaveBeenCalledWith({
       ptyId: "pty-bracketed-text-paste",
       data: "\x1b[200~line one\r\u241b[31mline two\x1b[201~",
+    });
+  });
+
+  it("refreshes bracketed paste mode from parked preview before text paste", async () => {
+    const firstView = render(<TerminalView ptyId="pty-parked-paste" sessionId="session-parked-paste" isActive />);
+    await flushAllTimers();
+    firstView.unmount();
+
+    const previewMock = window.ade.terminal.preview as unknown as ReturnType<typeof vi.fn>;
+    previewMock.mockResolvedValue({
+      terminalId: "session-parked-paste",
+      session: null,
+      source: "transcript",
+      snapshot: null,
+      transcript: "\x1b[?2004hCodex ready\n",
+      capturedAt: new Date().toISOString(),
+    });
+
+    render(<TerminalView ptyId="pty-parked-paste" sessionId="session-parked-paste" isActive />);
+
+    const terminal = mockState.terminalInstances.at(-1) as {
+      element: HTMLElement | null;
+    } | undefined;
+    expect(terminal?.element).toBeTruthy();
+
+    const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
+    ptyWrite.mockClear();
+
+    const event = createPasteEvent("line one\nline two");
+    terminal!.element!.dispatchEvent(event);
+    await flushPasteWrite();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(ptyWrite).toHaveBeenCalledWith({
+      ptyId: "pty-parked-paste",
+      data: "\x1b[200~line one\rline two\x1b[201~",
     });
   });
 

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -1136,6 +1136,49 @@ describe("TerminalView", () => {
     });
   });
 
+  it("falls back to cached paste mode when paste mode refresh is slow", async () => {
+    const previewMock = window.ade.terminal.preview as unknown as ReturnType<typeof vi.fn>;
+    previewMock.mockImplementation(() => new Promise<unknown>(() => {}));
+
+    render(<TerminalView ptyId="pty-paste-timeout" sessionId="session-paste-timeout" isActive />);
+    await flushAnimationFrame();
+
+    const terminal = mockState.terminalInstances.at(-1) as {
+      element: HTMLElement | null;
+      onData: ReturnType<typeof vi.fn>;
+    } | undefined;
+    expect(terminal?.element).toBeTruthy();
+    const onData = terminal?.onData.mock.calls.at(-1)?.[0] as ((data: string) => void) | undefined;
+    expect(onData).toBeTruthy();
+
+    for (const listener of mockState.ptyDataListeners) {
+      listener({
+        ptyId: "pty-paste-timeout",
+        sessionId: "session-paste-timeout",
+        projectRoot: "/project/a",
+        data: "\x1b[?2004h",
+      });
+    }
+
+    const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
+    ptyWrite.mockClear();
+
+    terminal!.element!.dispatchEvent(createPasteEvent("run build"));
+    onData!("\r");
+    await flushPasteWrite();
+    expect(ptyWrite).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    await flushPasteWrite();
+
+    expect(ptyWrite).toHaveBeenCalledWith({
+      ptyId: "pty-paste-timeout",
+      data: "\x1b[200~run build\x1b[201~\r",
+    });
+  });
+
   it("maps macOS Cmd+V with an image-only clipboard to Ctrl+V terminal input", async () => {
     const platformDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "platform");
     const originalPlatform = window.navigator.platform;

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -984,6 +984,37 @@ describe("TerminalView", () => {
     expect(hasClipboardImage).not.toHaveBeenCalled();
   });
 
+  it("wraps pasted text when the terminal requests bracketed paste mode", async () => {
+    render(<TerminalView ptyId="pty-bracketed-text-paste" sessionId="session-bracketed-text-paste" isActive />);
+    await flushAllTimers();
+
+    const terminal = mockState.terminalInstances.at(-1) as {
+      element: HTMLElement | null;
+    } | undefined;
+    expect(terminal?.element).toBeTruthy();
+
+    for (const listener of mockState.ptyDataListeners) {
+      listener({
+        ptyId: "pty-bracketed-text-paste",
+        sessionId: "session-bracketed-text-paste",
+        projectRoot: "/project/a",
+        data: "\x1b[?2004h",
+      });
+    }
+
+    const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
+    ptyWrite.mockClear();
+
+    const event = createPasteEvent("line one\n\x1b[31mline two");
+    terminal!.element!.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(ptyWrite).toHaveBeenCalledWith({
+      ptyId: "pty-bracketed-text-paste",
+      data: "\x1b[200~line one\r\u241b[31mline two\x1b[201~",
+    });
+  });
+
   it("maps macOS Cmd+V with an image-only clipboard to Ctrl+V terminal input", async () => {
     const platformDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "platform");
     const originalPlatform = window.navigator.platform;

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -1092,6 +1092,64 @@ describe("TerminalView", () => {
     });
   });
 
+  it("refreshes paste modes from snapshot state when the transcript tail lacks mode escapes", async () => {
+    const readTranscriptTailMock = window.ade.sessions.readTranscriptTail as unknown as ReturnType<typeof vi.fn>;
+    const previewMock = window.ade.terminal.preview as unknown as ReturnType<typeof vi.fn>;
+    readTranscriptTailMock.mockResolvedValue("recent output without mode escapes\n");
+    previewMock.mockResolvedValue({
+      terminalId: "session-snapshot-mode-paste",
+      session: null,
+      source: "snapshot",
+      snapshot: {
+        version: 1,
+        terminalId: "session-snapshot-mode-paste",
+        cols: 120,
+        rows: 32,
+        capturedAt: new Date().toISOString(),
+        status: "running",
+        runtimeState: "running",
+        bufferType: "alternate",
+        cursorX: 0,
+        cursorY: 0,
+        baseY: 0,
+        viewportY: 0,
+        serialized: "\x1b[?2004hCodex ready\n",
+        visibleRows: [
+          {
+            text: "Codex ready",
+            wrapped: false,
+            cells: [],
+          },
+        ],
+      },
+      transcript: "recent output without mode escapes\n",
+      capturedAt: new Date().toISOString(),
+    });
+
+    render(<TerminalView ptyId="pty-snapshot-mode-paste" sessionId="session-snapshot-mode-paste" isActive />);
+    await flushAnimationFrame();
+
+    const terminal = mockState.terminalInstances.at(-1) as {
+      element: HTMLElement | null;
+    } | undefined;
+    expect(terminal?.element).toBeTruthy();
+
+    const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
+    ptyWrite.mockClear();
+
+    terminal!.element!.dispatchEvent(createPasteEvent("line one\nline two"));
+    await flushPasteWrite();
+
+    expect(previewMock).toHaveBeenCalledWith({
+      terminalId: "session-snapshot-mode-paste",
+      maxBytes: 2_000_000,
+    });
+    expect(ptyWrite).toHaveBeenCalledWith({
+      ptyId: "pty-snapshot-mode-paste",
+      data: "\x1b[200~line one\rline two\x1b[201~",
+    });
+  });
+
   it("keeps input typed during paste refresh behind the pasted text", async () => {
     const previewMock = window.ade.terminal.preview as unknown as ReturnType<typeof vi.fn>;
     let resolvePreview: ((value: unknown) => void) | null = null;

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -1061,6 +1061,33 @@ describe("TerminalView", () => {
     });
   });
 
+  it("refreshes paste modes from the raw transcript tail instead of snapshot rows", async () => {
+    const firstView = render(<TerminalView ptyId="pty-transcript-mode-paste" sessionId="session-transcript-mode-paste" isActive />);
+    await flushAllTimers();
+    firstView.unmount();
+
+    const readTranscriptTailMock = window.ade.sessions.readTranscriptTail as unknown as ReturnType<typeof vi.fn>;
+    readTranscriptTailMock.mockResolvedValue("\x1b[?2004hCodex ready\n");
+
+    render(<TerminalView ptyId="pty-transcript-mode-paste" sessionId="session-transcript-mode-paste" isActive />);
+
+    const terminal = mockState.terminalInstances.at(-1) as {
+      element: HTMLElement | null;
+    } | undefined;
+    expect(terminal?.element).toBeTruthy();
+
+    const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
+    ptyWrite.mockClear();
+
+    terminal!.element!.dispatchEvent(createPasteEvent("line one\nline two"));
+    await flushPasteWrite();
+
+    expect(ptyWrite).toHaveBeenCalledWith({
+      ptyId: "pty-transcript-mode-paste",
+      data: "\x1b[200~line one\rline two\x1b[201~",
+    });
+  });
+
   it("keeps input typed during paste refresh behind the pasted text", async () => {
     const previewMock = window.ade.terminal.preview as unknown as ReturnType<typeof vi.fn>;
     let resolvePreview: ((value: unknown) => void) | null = null;
@@ -1084,6 +1111,7 @@ describe("TerminalView", () => {
     ptyWrite.mockClear();
 
     terminal!.element!.dispatchEvent(createPasteEvent("run build"));
+    terminal!.element!.dispatchEvent(createPasteEvent("deploy\nnow"));
     onData!("\r");
     await flushPasteWrite();
     expect(ptyWrite).not.toHaveBeenCalled();
@@ -1100,7 +1128,7 @@ describe("TerminalView", () => {
 
     expect(ptyWrite).toHaveBeenCalledWith({
       ptyId: "pty-paste-order",
-      data: "\x1b[200~run build\x1b[201~\r",
+      data: "\x1b[200~run build\x1b[201~\x1b[200~deploy\rnow\x1b[201~\r",
     });
   });
 

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -101,6 +101,10 @@ vi.mock("@xterm/xterm", () => ({
         viewportY: 0,
       },
     };
+    modes = {
+      bracketedPasteMode: false,
+      mouseTrackingMode: "none",
+    };
     dispose = vi.fn();
     clearTextureAtlas = vi.fn();
     getSelection = vi.fn(() => "");

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -43,6 +43,10 @@ type TerminalRenderPreferences = Pick<TerminalPreferences, "fontFamily" | "fontS
 
 type RuntimeListener = (snapshot: RuntimeSnapshot) => void;
 
+type DeferredInputDuringPasteWrite =
+  | { kind: "input"; data: string }
+  | { kind: "paste"; text: string };
+
 type CachedRuntime = {
   key: string;
   ptyId: string;
@@ -88,7 +92,7 @@ type CachedRuntime = {
   inputWriteBytes: number;
   inputFlushTimer: ReturnType<typeof setTimeout> | null;
   pasteWriteInFlight: boolean;
-  deferredInputDuringPasteWrite: string[];
+  deferredInputDuringPasteWrite: DeferredInputDuringPasteWrite[];
   liveStreamPaused: boolean;
   flushRafId: number | null;
   flushTimer: ReturnType<typeof setTimeout> | null;
@@ -798,7 +802,7 @@ function flushPendingPtyInput(runtime: CachedRuntime): void {
 function writePtyInput(runtime: CachedRuntime, data: string) {
   if (!data || runtime.disposed) return;
   if (runtime.pasteWriteInFlight) {
-    runtime.deferredInputDuringPasteWrite.push(data);
+    runtime.deferredInputDuringPasteWrite.push({ kind: "input", data });
     return;
   }
   writePtyInputNow(runtime, `${consumePendingPtyInput(runtime)}${data}`);
@@ -822,19 +826,30 @@ async function refreshTerminalInputModesForPaste(runtime: CachedRuntime): Promis
   syncTerminalInputModesFromXterm(runtime);
   if (runtime.hydrationCompleted && !runtime.liveStreamPaused) return;
   try {
-    const data = await readInitialHydrationData(runtime);
-    if (!runtime.disposed && data.text) {
-      updateTerminalInputModes(runtime, data.text);
+    const data = await readTerminalInputModeRefreshData(runtime);
+    if (!runtime.disposed && data) {
+      updateTerminalInputModes(runtime, data);
     }
   } catch {
     // Best effort only; a stale cache should not block paste entirely.
   }
 }
 
+function consumeDeferredInputDuringPasteWrite(runtime: CachedRuntime): string {
+  if (!runtime.deferredInputDuringPasteWrite.length) return "";
+  const data = runtime.deferredInputDuringPasteWrite
+    .map((entry) => (
+      entry.kind === "paste" ? formatTextPasteForTerminal(runtime, entry.text) : entry.data
+    ))
+    .join("");
+  runtime.deferredInputDuringPasteWrite.length = 0;
+  return data;
+}
+
 async function writeTextPasteForTerminal(runtime: CachedRuntime, text: string): Promise<void> {
   if (!text || runtime.disposed) return;
   if (runtime.pasteWriteInFlight) {
-    runtime.deferredInputDuringPasteWrite.push(formatTextPasteForTerminal(runtime, text));
+    runtime.deferredInputDuringPasteWrite.push({ kind: "paste", text });
     return;
   }
 
@@ -843,15 +858,13 @@ async function writeTextPasteForTerminal(runtime: CachedRuntime, text: string): 
   try {
     await refreshTerminalInputModesForPaste(runtime);
     if (runtime.disposed) return;
-    const deferredInput = runtime.deferredInputDuringPasteWrite.join("");
-    runtime.deferredInputDuringPasteWrite.length = 0;
+    const deferredInput = consumeDeferredInputDuringPasteWrite(runtime);
     runtime.pasteWriteInFlight = false;
     committed = true;
     writePtyInput(runtime, `${formatTextPasteForTerminal(runtime, text)}${deferredInput}`);
   } finally {
     if (!committed) {
-      const deferredInput = runtime.deferredInputDuringPasteWrite.join("");
-      runtime.deferredInputDuringPasteWrite.length = 0;
+      const deferredInput = consumeDeferredInputDuringPasteWrite(runtime);
       runtime.pasteWriteInFlight = false;
       if (!runtime.disposed && deferredInput) {
         writePtyInput(runtime, deferredInput);
@@ -875,7 +888,7 @@ function schedulePtyInputFlush(runtime: CachedRuntime): void {
 function enqueuePtyInput(runtime: CachedRuntime, data: string) {
   if (!data || runtime.disposed) return;
   if (runtime.pasteWriteInFlight) {
-    runtime.deferredInputDuringPasteWrite.push(data);
+    runtime.deferredInputDuringPasteWrite.push({ kind: "input", data });
     return;
   }
   runtime.inputWriteChunks.push(data);
@@ -1420,6 +1433,29 @@ async function readPreviewHydrationData(
   if (options.snapshotOnly) return { source: "empty", text: "" };
   if (preview?.transcript) return { source: "transcript", text: preview.transcript };
   return { source: "empty", text: "" };
+}
+
+async function readTerminalInputModeRefreshData(runtime: CachedRuntime): Promise<string> {
+  try {
+    const transcript = await window.ade.sessions.readTranscriptTail({
+      sessionId: runtime.sessionId,
+      maxBytes: HYDRATE_TAIL_BYTES,
+      raw: true,
+    });
+    if (transcript) return transcript;
+  } catch {
+    // Fall back to preview below.
+  }
+
+  try {
+    const preview = await window.ade.terminal.preview({
+      terminalId: runtime.sessionId,
+      maxBytes: HYDRATE_TAIL_BYTES,
+    });
+    return preview?.transcript ?? "";
+  } catch {
+    return "";
+  }
 }
 
 async function readReplayHydrationData(runtime: CachedRuntime): Promise<InitialHydrationData> {

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -816,9 +816,8 @@ function formatTextPasteForTerminal(runtime: CachedRuntime, text: string): strin
 }
 
 function syncTerminalInputModesFromXterm(runtime: CachedRuntime): void {
-  const bracketedPasteMode = runtime.term.modes?.bracketedPasteMode;
-  if (typeof bracketedPasteMode === "boolean" && runtime.hydrationCompleted) {
-    runtime.bracketedPasteMode = bracketedPasteMode;
+  if (runtime.term.modes?.bracketedPasteMode === true) {
+    runtime.bracketedPasteMode = true;
   }
 }
 

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -87,6 +87,8 @@ type CachedRuntime = {
   inputWriteChunks: string[];
   inputWriteBytes: number;
   inputFlushTimer: ReturnType<typeof setTimeout> | null;
+  pasteWriteInFlight: boolean;
+  deferredInputDuringPasteWrite: string[];
   liveStreamPaused: boolean;
   flushRafId: number | null;
   flushTimer: ReturnType<typeof setTimeout> | null;
@@ -787,6 +789,7 @@ function consumePendingPtyInput(runtime: CachedRuntime): string {
 }
 
 function flushPendingPtyInput(runtime: CachedRuntime): void {
+  if (runtime.pasteWriteInFlight) return;
   const data = consumePendingPtyInput(runtime);
   if (!data) return;
   writePtyInputNow(runtime, data);
@@ -794,6 +797,10 @@ function flushPendingPtyInput(runtime: CachedRuntime): void {
 
 function writePtyInput(runtime: CachedRuntime, data: string) {
   if (!data || runtime.disposed) return;
+  if (runtime.pasteWriteInFlight) {
+    runtime.deferredInputDuringPasteWrite.push(data);
+    return;
+  }
   writePtyInputNow(runtime, `${consumePendingPtyInput(runtime)}${data}`);
 }
 
@@ -826,9 +833,31 @@ async function refreshTerminalInputModesForPaste(runtime: CachedRuntime): Promis
 
 async function writeTextPasteForTerminal(runtime: CachedRuntime, text: string): Promise<void> {
   if (!text || runtime.disposed) return;
-  await refreshTerminalInputModesForPaste(runtime);
-  if (runtime.disposed) return;
-  writePtyInput(runtime, formatTextPasteForTerminal(runtime, text));
+  if (runtime.pasteWriteInFlight) {
+    runtime.deferredInputDuringPasteWrite.push(formatTextPasteForTerminal(runtime, text));
+    return;
+  }
+
+  runtime.pasteWriteInFlight = true;
+  let committed = false;
+  try {
+    await refreshTerminalInputModesForPaste(runtime);
+    if (runtime.disposed) return;
+    const deferredInput = runtime.deferredInputDuringPasteWrite.join("");
+    runtime.deferredInputDuringPasteWrite.length = 0;
+    runtime.pasteWriteInFlight = false;
+    committed = true;
+    writePtyInput(runtime, `${formatTextPasteForTerminal(runtime, text)}${deferredInput}`);
+  } finally {
+    if (!committed) {
+      const deferredInput = runtime.deferredInputDuringPasteWrite.join("");
+      runtime.deferredInputDuringPasteWrite.length = 0;
+      runtime.pasteWriteInFlight = false;
+      if (!runtime.disposed && deferredInput) {
+        writePtyInput(runtime, deferredInput);
+      }
+    }
+  }
 }
 
 function shouldFlushPtyInputImmediately(data: string): boolean {
@@ -845,6 +874,10 @@ function schedulePtyInputFlush(runtime: CachedRuntime): void {
 
 function enqueuePtyInput(runtime: CachedRuntime, data: string) {
   if (!data || runtime.disposed) return;
+  if (runtime.pasteWriteInFlight) {
+    runtime.deferredInputDuringPasteWrite.push(data);
+    return;
+  }
   runtime.inputWriteChunks.push(data);
   runtime.inputWriteBytes += data.length;
   if (shouldFlushPtyInputImmediately(data) || runtime.inputWriteBytes >= MAX_PTY_INPUT_BATCH_BYTES) {
@@ -1804,6 +1837,8 @@ function createRuntime(args: {
     inputWriteChunks: [],
     inputWriteBytes: 0,
     inputFlushTimer: null,
+    pasteWriteInFlight: false,
+    deferredInputDuringPasteWrite: [],
     liveStreamPaused: false,
     flushRafId: null,
     flushTimer: null,

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -928,6 +928,15 @@ function updateTerminalInputModes(runtime: CachedRuntime, data: string): void {
   }
 }
 
+function hasTerminalPrivateModeSequence(data: string, targetMode: number): boolean {
+  for (const match of data.matchAll(/\x1b\[\?([0-9;]+)([hl])/g)) {
+    for (const rawParam of match[1].split(";")) {
+      if (Number(rawParam) === targetMode) return true;
+    }
+  }
+  return false;
+}
+
 function isTerminalMouseTrackingActive(runtime: CachedRuntime): boolean {
   const xtermMode = runtime.term.modes?.mouseTrackingMode;
   return runtime.mouseTrackingModes.size > 0 || (xtermMode != null && xtermMode !== "none");
@@ -1445,15 +1454,18 @@ async function readPreviewHydrationData(
 }
 
 async function readTerminalInputModeRefreshData(runtime: CachedRuntime): Promise<string> {
+  let transcript = "";
   try {
-    const transcript = await window.ade.sessions.readTranscriptTail({
+    transcript = await window.ade.sessions.readTranscriptTail({
       sessionId: runtime.sessionId,
       maxBytes: HYDRATE_TAIL_BYTES,
       raw: true,
-    });
-    if (transcript) return transcript;
+    }) || "";
+    if (hasTerminalPrivateModeSequence(transcript, TERMINAL_BRACKETED_PASTE_MODE)) {
+      return transcript;
+    }
   } catch {
-    // Fall back to preview below.
+    transcript = "";
   }
 
   try {
@@ -1461,9 +1473,11 @@ async function readTerminalInputModeRefreshData(runtime: CachedRuntime): Promise
       terminalId: runtime.sessionId,
       maxBytes: HYDRATE_TAIL_BYTES,
     });
-    return preview?.transcript ?? "";
+    const snapshot = preview?.snapshot?.serialized ?? "";
+    const previewTranscript = preview?.transcript ?? "";
+    return `${snapshot}${previewTranscript}${transcript}`;
   } catch {
-    return "";
+    return transcript;
   }
 }
 

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -804,6 +804,33 @@ function formatTextPasteForTerminal(runtime: CachedRuntime, text: string): strin
   return `${TERMINAL_BRACKETED_PASTE_START}${sanitized}${TERMINAL_BRACKETED_PASTE_END}`;
 }
 
+function syncTerminalInputModesFromXterm(runtime: CachedRuntime): void {
+  const bracketedPasteMode = runtime.term.modes?.bracketedPasteMode;
+  if (typeof bracketedPasteMode === "boolean" && runtime.hydrationCompleted) {
+    runtime.bracketedPasteMode = bracketedPasteMode;
+  }
+}
+
+async function refreshTerminalInputModesForPaste(runtime: CachedRuntime): Promise<void> {
+  syncTerminalInputModesFromXterm(runtime);
+  if (runtime.hydrationCompleted && !runtime.liveStreamPaused) return;
+  try {
+    const data = await readInitialHydrationData(runtime);
+    if (!runtime.disposed && data.text) {
+      updateTerminalInputModes(runtime, data.text);
+    }
+  } catch {
+    // Best effort only; a stale cache should not block paste entirely.
+  }
+}
+
+async function writeTextPasteForTerminal(runtime: CachedRuntime, text: string): Promise<void> {
+  if (!text || runtime.disposed) return;
+  await refreshTerminalInputModesForPaste(runtime);
+  if (runtime.disposed) return;
+  writePtyInput(runtime, formatTextPasteForTerminal(runtime, text));
+}
+
 function shouldFlushPtyInputImmediately(data: string): boolean {
   return /[\x00-\x1f\x7f]|\x1b/.test(data);
 }
@@ -1200,11 +1227,11 @@ function shouldDeliverPtyEvent(runtime: CachedRuntime, projectRoot: string | und
 
 function handleRuntimePtyData(runtime: CachedRuntime, ev: PtyDataEvent) {
   if (!shouldDeliverPtyEvent(runtime, ev.projectRoot)) return;
+  updateTerminalInputModes(runtime, ev.data);
   if (!shouldRuntimeReceivePtyData(runtime)) {
     pauseRuntimePtyStream(runtime);
     return;
   }
-  updateTerminalInputModes(runtime, ev.data);
 
   if (!runtime.hydrationCompleted) {
     runtime.pendingHydrationChunks.push(ev.data);
@@ -1809,7 +1836,7 @@ function createRuntime(args: {
     lastPasteEventAt = Date.now();
     const text = ev.clipboardData?.getData("text/plain") ?? ev.clipboardData?.getData("text");
     if (text && !runtime.disposed) {
-      writePtyInput(runtime, formatTextPasteForTerminal(runtime, text));
+      void writeTextPasteForTerminal(runtime, text);
       return;
     }
     void pasteClipboardImageShortcut(runtime, runtime.imagePasteMode);
@@ -1839,7 +1866,7 @@ function createRuntime(args: {
         }
         readText.call(navigator.clipboard).then((text) => {
           if (text && !runtime.disposed) {
-            writePtyInput(runtime, formatTextPasteForTerminal(runtime, text));
+            void writeTextPasteForTerminal(runtime, text);
             return;
           }
           void pasteClipboardImageShortcut(runtime, runtime.imagePasteMode);

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -797,6 +797,13 @@ function writePtyInput(runtime: CachedRuntime, data: string) {
   writePtyInputNow(runtime, `${consumePendingPtyInput(runtime)}${data}`);
 }
 
+function formatTextPasteForTerminal(runtime: CachedRuntime, text: string): string {
+  const prepared = text.replace(/\r?\n/g, "\r");
+  if (!runtime.bracketedPasteMode) return prepared;
+  const sanitized = prepared.replace(/\x1b/g, "\u241b");
+  return `${TERMINAL_BRACKETED_PASTE_START}${sanitized}${TERMINAL_BRACKETED_PASTE_END}`;
+}
+
 function shouldFlushPtyInputImmediately(data: string): boolean {
   return /[\x00-\x1f\x7f]|\x1b/.test(data);
 }
@@ -1802,7 +1809,7 @@ function createRuntime(args: {
     lastPasteEventAt = Date.now();
     const text = ev.clipboardData?.getData("text/plain") ?? ev.clipboardData?.getData("text");
     if (text && !runtime.disposed) {
-      writePtyInput(runtime, text);
+      writePtyInput(runtime, formatTextPasteForTerminal(runtime, text));
       return;
     }
     void pasteClipboardImageShortcut(runtime, runtime.imagePasteMode);
@@ -1832,7 +1839,7 @@ function createRuntime(args: {
         }
         readText.call(navigator.clipboard).then((text) => {
           if (text && !runtime.disposed) {
-            writePtyInput(runtime, text);
+            writePtyInput(runtime, formatTextPasteForTerminal(runtime, text));
             return;
           }
           void pasteClipboardImageShortcut(runtime, runtime.imagePasteMode);

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -133,6 +133,7 @@ const MAX_PENDING_HYDRATION_BYTES = 2_000_000;
 const MAX_FRAME_WRITE_BYTES = 1_000_000;
 const MAX_PTY_INPUT_BATCH_BYTES = 16_384;
 const PTY_INPUT_BATCH_MS = 16;
+const PASTE_MODE_REFRESH_TIMEOUT_MS = 500;
 const EXITED_RUNTIME_KEEPALIVE_MS = 8_000;
 const MIN_VALID_COLS = 20;
 const MIN_VALID_ROWS = 6;
@@ -824,13 +825,22 @@ function syncTerminalInputModesFromXterm(runtime: CachedRuntime): void {
 async function refreshTerminalInputModesForPaste(runtime: CachedRuntime): Promise<void> {
   syncTerminalInputModesFromXterm(runtime);
   if (runtime.hydrationCompleted && !runtime.liveStreamPaused) return;
+  let timeout: ReturnType<typeof setTimeout> | null = null;
   try {
-    const data = await readTerminalInputModeRefreshData(runtime);
+    const timeoutPromise = new Promise<string>((resolve) => {
+      timeout = setTimeout(() => resolve(""), PASTE_MODE_REFRESH_TIMEOUT_MS);
+    });
+    const data = await Promise.race([
+      readTerminalInputModeRefreshData(runtime),
+      timeoutPromise,
+    ]);
     if (!runtime.disposed && data) {
       updateTerminalInputModes(runtime, data);
     }
   } catch {
     // Best effort only; a stale cache should not block paste entirely.
+  } finally {
+    if (timeout) clearTimeout(timeout);
   }
 }
 


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fok-start-skill-then-dig-64f5cce5 num=663 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fok-start-skill-then-dig-64f5cce5&amp;pr=663">ade/ok-start-skill-then-dig-64f5cce5 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=663">PR #663</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved paste handling in the terminal so pasted text is wrapped correctly and processed more reliably.
  * Terminal input now preserves the order of typed keys and pasted content during paste operations.

* **Bug Fixes**
  * Reduced cases where keystrokes could be lost or reordered while a paste is in progress.
  * Paste mode is now refreshed more consistently, with better fallback behavior when mode data is slow or incomplete.
  * Updated terminal tests to cover paste and bracketed-paste scenarios more thoroughly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates terminal text paste handling for remote CLI sessions. The main changes are:

- Bracketed paste wrapping for terminals that request bracketed paste mode.
- Paste mode refresh from live xterm state, transcript tails, and parked preview snapshots.
- Deferred terminal input while paste mode refresh is in flight, preserving write order.
- Tests for live paste, parked paste, transcript and snapshot refresh, ordering, and timeout fallback.

<h3>Confidence Score: 5/5</h3>

The terminal paste handling changes are well-scoped and covered by focused tests for the new live, parked, ordering, and fallback behaviors.

The modified files are limited to the terminal view implementation and its tests, with no review comments requiring changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the terminal paste tests and compared the before-state output with the after-state output to verify paste-mode handling and payload framing.

<a href="https://app.greptile.com/trex/runs/12657419/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (7): Last reviewed commit: ["ship: iteration 5 - refresh paste modes ..."](https://github.com/arul28/ade/commit/5cac3df155f61b5af6163675e03a28347288fbd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40538280)</sub>

<!-- /greptile_comment -->