### PR TITLE
Add Manage Lane rename UI and retry auto lane naming

### DIFF
--- a/apps/desktop/src/main/services/lanes/laneService.test.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.test.ts
@@ -5087,3 +5087,158 @@ describe("laneService createWorktreeLane orphan cleanup", () => {
     }
   });
 });
+
+describe("laneService rename", () => {
+  const RENAME_NOW = "2026-06-29T12:00:00.000Z";
+
+  function seedRenameProject(db: any, args: { projectId: string; repoRoot: string }) {
+    db.run(
+      "insert into projects(id, root_path, display_name, default_base_ref, created_at, last_opened_at) values (?, ?, ?, ?, ?, ?)",
+      [args.projectId, args.repoRoot, "demo", "main", RENAME_NOW, RENAME_NOW],
+    );
+  }
+
+  function insertRenameLane(
+    db: any,
+    args: {
+      id: string;
+      projectId: string;
+      name: string;
+      laneType: "primary" | "worktree";
+      branchRef: string;
+      worktreePath: string;
+    },
+  ) {
+    db.run(
+      `insert into lanes(
+        id, project_id, name, description, lane_type, base_ref, branch_ref, worktree_path,
+        attached_root_path, is_edit_protected, parent_lane_id, color, icon, tags_json, status, created_at, archived_at
+      ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        args.id,
+        args.projectId,
+        args.name,
+        null,
+        args.laneType,
+        "main",
+        args.branchRef,
+        args.worktreePath,
+        null,
+        args.laneType === "primary" ? 1 : 0,
+        null,
+        null,
+        null,
+        null,
+        "active",
+        RENAME_NOW,
+        null,
+      ],
+    );
+  }
+
+  it("updates the lane display name", async () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-lane-rename-"));
+    const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
+    try {
+      seedRenameProject(db, { projectId: "proj-rename", repoRoot });
+      insertRenameLane(db, {
+        id: "lane-a",
+        projectId: "proj-rename",
+        name: "old-name",
+        laneType: "worktree",
+        branchRef: "ade/old-name",
+        worktreePath: path.join(repoRoot, "lane-a"),
+      });
+
+      const service = createLaneService({
+        db,
+        projectRoot: repoRoot,
+        projectId: "proj-rename",
+        defaultBaseRef: "main",
+        worktreesDir: path.join(repoRoot, "worktrees"),
+        logger: createLogger(),
+      });
+
+      service.rename({ laneId: "lane-a", name: "new-name" });
+
+      const row = db.get<{ name: string }>(
+        "select name from lanes where id = ? and project_id = ?",
+        ["lane-a", "proj-rename"],
+      );
+      expect(row?.name).toBe("new-name");
+    } finally {
+      db.close();
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects duplicate lane names case-insensitively", async () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-lane-rename-dup-"));
+    const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
+    try {
+      seedRenameProject(db, { projectId: "proj-rename-dup", repoRoot });
+      insertRenameLane(db, {
+        id: "lane-a",
+        projectId: "proj-rename-dup",
+        name: "alpha-lane",
+        laneType: "worktree",
+        branchRef: "ade/alpha-lane",
+        worktreePath: path.join(repoRoot, "lane-a"),
+      });
+      insertRenameLane(db, {
+        id: "lane-b",
+        projectId: "proj-rename-dup",
+        name: "Beta-Lane",
+        laneType: "worktree",
+        branchRef: "ade/beta-lane",
+        worktreePath: path.join(repoRoot, "lane-b"),
+      });
+
+      const service = createLaneService({
+        db,
+        projectRoot: repoRoot,
+        projectId: "proj-rename-dup",
+        defaultBaseRef: "main",
+        worktreesDir: path.join(repoRoot, "worktrees"),
+        logger: createLogger(),
+      });
+
+      expect(() => service.rename({ laneId: "lane-a", name: "beta-lane" }))
+        .toThrow(/already exists/i);
+    } finally {
+      db.close();
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects renaming the primary lane", async () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-lane-rename-primary-"));
+    const db = await openKvDb(path.join(repoRoot, "kv.sqlite"), createLogger());
+    try {
+      seedRenameProject(db, { projectId: "proj-rename-primary", repoRoot });
+      insertRenameLane(db, {
+        id: "lane-primary",
+        projectId: "proj-rename-primary",
+        name: "primary",
+        laneType: "primary",
+        branchRef: "main",
+        worktreePath: repoRoot,
+      });
+
+      const service = createLaneService({
+        db,
+        projectRoot: repoRoot,
+        projectId: "proj-rename-primary",
+        defaultBaseRef: "main",
+        worktreesDir: path.join(repoRoot, "worktrees"),
+        logger: createLogger(),
+      });
+
+      expect(() => service.rename({ laneId: "lane-primary", name: "renamed-primary" }))
+        .toThrow(/primary lane cannot be renamed/i);
+    } finally {
+      db.close();
+      fs.rmSync(repoRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop/src/main/services/lanes/laneService.ts
+++ b/apps/desktop/src/main/services/lanes/laneService.ts
@@ -4788,7 +4788,29 @@ export function createLaneService({
     },
 
     rename({ laneId, name }: { laneId: string; name: string }): void {
-      db.run("update lanes set name = ? where id = ? and project_id = ?", [name, laneId, projectId]);
+      const trimmed = name.trim();
+      if (!trimmed) throw new Error("Lane name is required");
+      const lane = getLaneRow(laneId);
+      if (!lane) throw new Error(`Lane not found: ${laneId}`);
+      if (lane.lane_type === "primary") throw new Error("Primary lane cannot be renamed");
+      if (trimmed === lane.name) return;
+
+      const duplicate = db.get<{ name: string }>(
+        `
+          select name from lanes
+          where project_id = ?
+            and id != ?
+            and archived_at is null
+            and lower(name) = lower(?)
+          limit 1
+        `,
+        [projectId, laneId, trimmed],
+      );
+      if (duplicate) {
+        throw new Error(`A lane named "${duplicate.name}" already exists`);
+      }
+
+      db.run("update lanes set name = ? where id = ? and project_id = ?", [trimmed, laneId, projectId]);
       invalidateLaneListCache();
     },
 

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -3606,9 +3606,57 @@ describe("AgentChatPane submit recovery", () => {
         });
         expect(create).toHaveBeenCalledWith(expect.objectContaining({ laneId: "lane-created" }));
       });
+      await waitFor(() => {
+        expect(suggestLaneName).toHaveBeenCalledTimes(2);
+      });
     } finally {
       consoleWarn.mockRestore();
     }
+  });
+
+  it("auto-create retries background lane naming once before keeping the deterministic name", async () => {
+    let attempts = 0;
+    const { createLane, suggestLaneName, renameLane } = installAdeMocks({ sessions: [] });
+    suggestLaneName.mockImplementation(async () => {
+      attempts += 1;
+      return attempts === 1 ? "keep-going-even-naming-fails" : "auto-create-lane-fix";
+    });
+    createLane.mockImplementation(async ({ name }: { name: string }) => ({
+      id: "lane-created",
+      name,
+      laneType: "worktree",
+      branchRef: `refs/heads/${name}`,
+      worktreePath: `/tmp/project-under-test/${name}`,
+      parentLaneId: "lane-primary",
+    }));
+
+    renderAutoCreateDraftPane();
+
+    const modelTrigger = await screen.findByRole("button", { name: /^Select model/ });
+    const codexLabel = getModelById("openai/gpt-5.4")?.displayName ?? "GPT-5.4";
+    fireEvent.pointerDown(modelTrigger, { button: 0 });
+    fireEvent.click(modelTrigger);
+    fireEvent.click(await screen.findByRole("tab", { name: /^OpenAI$/i }));
+    await clickEnabledModelOption(new RegExp(escapeRegExp(codexLabel), "i"));
+
+    fireEvent.click(await screen.findByRole("button", { name: "Select lane" }));
+    fireEvent.click(await screen.findByRole("button", { name: /Auto-create lane/i }));
+
+    const textbox = await screen.findByRole("textbox");
+    fireEvent.change(textbox, { target: { value: "Keep going even if naming fails." } });
+    fireEvent.click(await screen.findByRole("button", { name: "Send" }));
+
+    await waitFor(() => {
+      expect(createLane).toHaveBeenCalled();
+    }, { timeout: 5000 });
+
+    await waitFor(() => {
+      expect(suggestLaneName).toHaveBeenCalledTimes(2);
+      expect(renameLane).toHaveBeenCalledWith({
+        laneId: "lane-created",
+        name: "auto-create-lane-fix",
+      });
+    }, { timeout: 5000 });
   });
 
   it("can keep foreground draft launches inside an embedded Lanes work pane", async () => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -6959,16 +6959,40 @@ export function AgentChatPane({
     if (!args.flagLaneIds.length) return;
     for (const id of args.flagLaneIds) setLaneNaming(id, true);
     void (async () => {
+      const suggestArgs = {
+        laneId: args.laneId,
+        prompt: args.prompt,
+        modelId: args.modelId,
+        fallbackName: args.fallbackName,
+      };
+      const suggestLaneName = () => (args.pin
+        ? window.ade.agentChat.suggestLaneName(suggestArgs, args.pin)
+        : window.ade.agentChat.suggestLaneName(suggestArgs));
+      const sleep = (ms: number) => new Promise<void>((resolve) => {
+        window.setTimeout(resolve, ms);
+      });
+      const BACKGROUND_LANE_NAMING_ATTEMPTS = 2;
+      const BACKGROUND_LANE_NAMING_RETRY_DELAY_MS = 750;
       try {
-        const suggestArgs = {
-          laneId: args.laneId,
-          prompt: args.prompt,
-          modelId: args.modelId,
-          fallbackName: args.fallbackName,
-        };
-        const suggested = (args.pin
-          ? await window.ade.agentChat.suggestLaneName(suggestArgs, args.pin)
-          : await window.ade.agentChat.suggestLaneName(suggestArgs)).trim();
+        let suggested = "";
+        for (let attempt = 1; attempt <= BACKGROUND_LANE_NAMING_ATTEMPTS; attempt += 1) {
+          try {
+            suggested = (await suggestLaneName()).trim();
+          } catch (error) {
+            if (attempt >= BACKGROUND_LANE_NAMING_ATTEMPTS) {
+              throw error;
+            }
+            console.warn(`background lane naming attempt ${attempt} failed; retrying`, error);
+            await sleep(BACKGROUND_LANE_NAMING_RETRY_DELAY_MS);
+            continue;
+          }
+          if (suggested && suggested !== args.fallbackName) {
+            break;
+          }
+          if (attempt < BACKGROUND_LANE_NAMING_ATTEMPTS) {
+            await sleep(BACKGROUND_LANE_NAMING_RETRY_DELAY_MS);
+          }
+        }
         if (suggested && suggested !== args.fallbackName) {
           await args.apply(suggested);
           if (canRefreshPinnedProject(args.pin)) {

--- a/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx
+++ b/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx
@@ -96,6 +96,7 @@ describe("ManageLaneDialog tabs", () => {
         onDeleteEvent: vi.fn(() => vi.fn()),
         updateAppearance: vi.fn().mockResolvedValue(undefined),
         reparent: vi.fn().mockResolvedValue(undefined),
+        rename: vi.fn().mockResolvedValue(undefined),
       },
     };
   });
@@ -171,5 +172,53 @@ describe("ManageLaneDialog tabs", () => {
     fireEvent.click(deleteButton);
 
     expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("renames a lane from the header pencil control", async () => {
+    const onAppearanceChanged = vi.fn().mockResolvedValue(undefined);
+    const lane = makeLane({ name: "Old lane name" });
+    const otherLane = makeLane({ id: "lane-2", name: "Other lane" });
+    render(
+      <ManageLaneDialog
+        {...makeProps({
+          managedLane: lane,
+          allLanes: [lane, otherLane],
+          onAppearanceChanged,
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Rename lane" }));
+    const input = screen.getByRole("textbox", { name: "Lane name" });
+    fireEvent.change(input, { target: { value: "Renamed lane" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect((globalThis.window as any).ade.lanes.rename).toHaveBeenCalledWith({
+        laneId: "lane-1",
+        name: "Renamed lane",
+      });
+      expect(onAppearanceChanged).toHaveBeenCalled();
+    });
+  });
+
+  it("blocks rename when another lane already uses the name", async () => {
+    const lane = makeLane({ name: "Old lane name" });
+    const otherLane = makeLane({ id: "lane-2", name: "Taken name" });
+    render(
+      <ManageLaneDialog
+        {...makeProps({
+          managedLane: lane,
+          allLanes: [lane, otherLane],
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Rename lane" }));
+    const input = screen.getByRole("textbox", { name: "Lane name" });
+    fireEvent.change(input, { target: { value: "Taken name" } });
+
+    expect(screen.getByText('A lane named "Taken name" already exists.')).toBeTruthy();
+    expect((screen.getByRole("button", { name: "Save" }) as HTMLButtonElement).disabled).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx
+++ b/apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx
@@ -17,6 +17,7 @@ import {
   X,
   Minus,
   TreeStructure,
+  PencilSimple,
 } from "@phosphor-icons/react";
 import { Button } from "../ui/Button";
 import { BranchIcon, LaneIcon } from "../ui/vcsIcons";
@@ -68,7 +69,144 @@ const STEP_LABELS: Record<LaneDeleteStepName, string> = {
   database_cleanup: "Updating database"
 };
 
-function ManageLaneHeaderDetails({ lanes, isBatch }: { lanes: LaneSummary[]; isBatch: boolean }) {
+function ManageLaneRenameControls({
+  lane,
+  allLanes,
+  onRenamed,
+}: {
+  lane: LaneSummary;
+  allLanes: LaneSummary[];
+  onRenamed?: () => void | Promise<void>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draftName, setDraftName] = useState(lane.name);
+  const [renameBusy, setRenameBusy] = useState(false);
+  const [renameError, setRenameError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!editing) {
+      setDraftName(lane.name);
+      setRenameError(null);
+    }
+  }, [editing, lane.name]);
+
+  const trimmedDraft = draftName.trim();
+  const unchanged = trimmedDraft === lane.name.trim();
+  const duplicateLane = allLanes.find(
+    (candidate) => candidate.id !== lane.id
+      && candidate.archivedAt == null
+      && candidate.name.trim().toLowerCase() === trimmedDraft.toLowerCase(),
+  );
+  const canSave = Boolean(trimmedDraft) && !unchanged && !duplicateLane && !renameBusy;
+  const canRename = lane.laneType !== "primary";
+
+  const cancelEdit = () => {
+    setEditing(false);
+    setDraftName(lane.name);
+    setRenameError(null);
+  };
+
+  const saveRename = async () => {
+    if (!canSave) return;
+    setRenameBusy(true);
+    setRenameError(null);
+    try {
+      await window.ade.lanes.rename({ laneId: lane.id, name: trimmedDraft });
+      setEditing(false);
+      await onRenamed?.();
+    } catch (error) {
+      setRenameError(error instanceof Error ? error.message : "Failed to rename lane");
+    } finally {
+      setRenameBusy(false);
+    }
+  };
+
+  if (!canRename) {
+    return (
+      <span className="text-base font-semibold tracking-tight text-accent">{lane.name}</span>
+    );
+  }
+
+  if (!editing) {
+    return (
+      <div className="flex min-w-0 items-center gap-1.5">
+        <span className="truncate text-base font-semibold tracking-tight text-accent">{lane.name}</span>
+        <button
+          type="button"
+          aria-label="Rename lane"
+          title="Rename lane"
+          data-tour="lanes.manageDialog.rename"
+          className="inline-flex shrink-0 items-center justify-center rounded-md p-1 text-muted-fg/70 transition hover:bg-white/[0.06] hover:text-fg"
+          onClick={() => setEditing(true)}
+        >
+          <PencilSimple size={14} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-w-0 space-y-2">
+      <div className="flex min-w-0 flex-wrap items-center gap-2">
+        <input
+          type="text"
+          value={draftName}
+          autoFocus
+          aria-label="Lane name"
+          className={`${INPUT_CLASS_NAME} min-w-[12rem] flex-1 text-sm`}
+          onChange={(event) => setDraftName(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              void saveRename();
+            }
+            if (event.key === "Escape") {
+              event.preventDefault();
+              cancelEdit();
+            }
+          }}
+        />
+        <div className="flex shrink-0 items-center gap-1.5">
+          <Button
+            type="button"
+            size="sm"
+            disabled={!canSave}
+            onClick={() => { void saveRename(); }}
+          >
+            {renameBusy ? <CircleNotch size={14} className="animate-spin" /> : "Save"}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            disabled={renameBusy}
+            onClick={cancelEdit}
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+      {duplicateLane ? (
+        <div className="text-xs text-red-300">A lane named &quot;{duplicateLane.name}&quot; already exists.</div>
+      ) : null}
+      {renameError ? (
+        <div className="text-xs text-red-300">{renameError}</div>
+      ) : null}
+    </div>
+  );
+}
+
+function ManageLaneHeaderDetails({
+  lanes,
+  isBatch,
+  allLanes,
+  onRenamed,
+}: {
+  lanes: LaneSummary[];
+  isBatch: boolean;
+  allLanes: LaneSummary[];
+  onRenamed?: () => void | Promise<void>;
+}) {
   if (isBatch) {
     return (
       <div data-tour="lanes.manageDialog.laneInfo" className="space-y-2">
@@ -102,7 +240,7 @@ function ManageLaneHeaderDetails({ lanes, isBatch }: { lanes: LaneSummary[]; isB
     <div data-tour="lanes.manageDialog.laneInfo" className="min-w-0">
       <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
         <LaneIcon size={14} weight="duotone" className="shrink-0 text-accent/80" />
-        <span className="text-base font-semibold tracking-tight text-accent">{lane.name}</span>
+        <ManageLaneRenameControls lane={lane} allLanes={allLanes} onRenamed={onRenamed} />
         {lane.status.dirty ? (
           <span className="rounded-md bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase text-amber-400">
             dirty
@@ -365,7 +503,9 @@ export function ManageLaneDialog({
   }, [laneActionKind]);
 
   const headerExtra =
-    lanes.length > 0 && !allPrimary ? <ManageLaneHeaderDetails lanes={lanes} isBatch={isBatch} /> : undefined;
+    lanes.length > 0 && !allPrimary
+      ? <ManageLaneHeaderDetails lanes={lanes} isBatch={isBatch} allLanes={allLanes} onRenamed={onAppearanceChanged} />
+      : undefined;
 
   return (
     <LaneDialogShell

--- a/docs/features/chat/composer-and-ui.md
+++ b/docs/features/chat/composer-and-ui.md
@@ -246,8 +246,9 @@ and a footer that contains the composer.
   background (the backend has its own timeout and returns the
   deterministic fallback on failure, so a no-op result is skipped) and,
   if the suggestion differs, applies it via `lanes.rename` and refreshes
-  the lane store. Branch uniqueness is handled by the lane id suffix
-  added by the lane service. Each launch creates a `DraftLaunchJob` that
+  the lane store. The renderer retries the background naming pass once
+  (750 ms apart) before keeping the deterministic slug. Branch uniqueness
+  is handled by the lane id suffix added by the lane service. Each launch creates a `DraftLaunchJob` that
   tracks progress through `creating-lane` / `starting-session` /
   `sending-prompt` / `ready` / `failed` states (auto-create no longer has
   a distinct `naming-lane` phase — it goes straight to `creating-lane`).

--- a/docs/features/lanes/README.md
+++ b/docs/features/lanes/README.md
@@ -326,7 +326,11 @@ a lane parented to primary would always show zero behind.
 5. **Attach** — `attach` links an external worktree path (pre-existing
    outside ADE). `lane_type = 'attached'`.
 6. **Rename / update appearance / reparent** — `rename`, `updateAppearance`,
-   `reparent` edit the lane row. `reparent({ laneId, newParentLaneId,
+   `reparent` edit the lane row. `rename` trims the name, rejects empty
+   values, blocks primary-lane renames, and rejects duplicate display
+   names among active lanes (case-insensitive). The desktop **Manage Lane**
+   dialog exposes rename via a pencil control beside the lane name in the
+   header. `reparent({ laneId, newParentLaneId,
    stackBaseBranchRef? })` refuses to move a lane under one of its own
    descendants and refuses to reparent the primary lane. When
    `stackBaseBranchRef` is supplied the service resolves it in the project


### PR DESCRIPTION
## Summary
- Retry background AI lane naming once (750ms apart) before keeping the deterministic auto-create slug
- Add inline lane rename to Manage Lane via a pencil control beside the lane title
- Validate duplicate lane display names in `laneService.rename` (case-insensitive, active lanes only)

## Test plan
- [x] `npx vitest run src/main/services/lanes/laneService.test.ts -t "laneService rename"`
- [x] `npx vitest run src/renderer/components/lanes/ManageLaneDialog.test.tsx -t "renames a lane|blocks rename"`
- [x] `npx vitest run src/renderer/components/chat/AgentChatPane.test.tsx -t "auto-create retries|auto-create keeps launching"`
- [x] Desktop typecheck pass

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two related features: a retry mechanism for background AI lane naming (retries once after 750 ms before keeping the deterministic slug), and an inline rename control in the Manage Lane dialog (pencil button beside the lane name, with client-side case-insensitive duplicate validation and keyboard shortcuts).

- **`laneService.rename`** now trims, validates empty input, guards against primary-lane renames, and checks for case-insensitive duplicates among active lanes before updating.
- **`ManageLaneRenameControls`** (new component in `ManageLaneDialog.tsx`) handles the editing UI state, mirrors the service's duplicate check client-side, and delegates to `window.ade.lanes.rename` on save.
- **`runBackgroundLaneNaming`** in `AgentChatPane.tsx` wraps the `suggestLaneName` call in a two-attempt loop, sleeping 750 ms between attempts on both errors and fallback-name echoes.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; all three paths (service validation, retry logic, rename UI) are well-tested and the core rename operation is correct.

The rename and retry implementations are solid. The only notable issue is that `setEditing(false)` is called before `await onRenamed?.()` in `ManageLaneRenameControls`, so if the post-rename refresh callback throws, the error is caught but never shown — it's silently absorbed while the underlying rename did succeed. This is a UX gap worth addressing but does not affect data correctness.

The `saveRename` flow in `ManageLaneDialog.tsx` around the ordering of `setEditing(false)` and `await onRenamed?.()` deserves a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/lanes/laneService.ts | Adds validation to `rename`: trims the name, rejects empty values, blocks primary-lane renames, and enforces case-insensitive duplicate detection among active lanes. The check-then-update pattern is consistent with other operations in this file. |
| apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx | Adds `ManageLaneRenameControls` component for inline rename with client-side dupe validation and keyboard shortcuts. Minor issue: `setEditing(false)` is called before `await onRenamed?.()`, so if `onRenamed` throws the error is caught but never displayed. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Extracts the `suggestLaneName` call into a helper, wraps it in a retry loop (2 attempts, 750 ms apart) that retries on both errors and fallback-name echoes. Logic is correct; constants are clear. |
| apps/desktop/src/main/services/lanes/laneService.test.ts | New `laneService rename` describe block covers the happy path, case-insensitive duplicate rejection, and primary-lane guard. Tests use real SQLite via `openKvDb` and clean up temp directories in `finally`. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx | Adds a new test for the retry path and updates an existing test to assert `suggestLaneName` is called twice. The new test's description says the deterministic name is 'kept' but the assertions verify the second attempt's name is actually applied — minor mismatch. |
| apps/desktop/src/renderer/components/lanes/ManageLaneDialog.test.tsx | Two new test cases: one covering a successful rename through the pencil control, another verifying the Save button is disabled when the typed name collides with an existing lane. Both are well-structured. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as ManageLaneRenameControls
    participant IPC as window.ade.lanes.rename
    participant SVC as laneService.rename
    participant DB as SQLite

    UI->>IPC: "rename({ laneId, name })"
    IPC->>SVC: "rename({ laneId, name })"
    SVC->>SVC: trim / validate empty
    SVC->>DB: getLaneRow(laneId)
    DB-->>SVC: lane row
    SVC->>SVC: guard primary lane
    SVC->>SVC: early-return if unchanged
    SVC->>DB: SELECT duplicate (lower(name), archived_at IS NULL)
    DB-->>SVC: duplicate row or null
    alt duplicate found
        SVC-->>IPC: throw already exists
        IPC-->>UI: reject
        UI->>UI: setRenameError(msg)
    else no duplicate
        SVC->>DB: "UPDATE lanes SET name = trimmed"
        SVC->>SVC: invalidateLaneListCache()
        SVC-->>IPC: void
        IPC-->>UI: resolve
        UI->>UI: setEditing(false)
        UI->>UI: onRenamed() [refresh]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as ManageLaneRenameControls
    participant IPC as window.ade.lanes.rename
    participant SVC as laneService.rename
    participant DB as SQLite

    UI->>IPC: "rename({ laneId, name })"
    IPC->>SVC: "rename({ laneId, name })"
    SVC->>SVC: trim / validate empty
    SVC->>DB: getLaneRow(laneId)
    DB-->>SVC: lane row
    SVC->>SVC: guard primary lane
    SVC->>SVC: early-return if unchanged
    SVC->>DB: SELECT duplicate (lower(name), archived_at IS NULL)
    DB-->>SVC: duplicate row or null
    alt duplicate found
        SVC-->>IPC: throw already exists
        IPC-->>UI: reject
        UI->>UI: setRenameError(msg)
    else no duplicate
        SVC->>DB: "UPDATE lanes SET name = trimmed"
        SVC->>SVC: invalidateLaneListCache()
        SVC-->>IPC: void
        IPC-->>UI: resolve
        UI->>UI: setEditing(false)
        UI->>UI: onRenamed() [refresh]
    end
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Flanes%2FManageLaneDialog.tsx%3A113-121%0A**Error%20from%20%60onRenamed%60%20is%20silently%20swallowed%20after%20a%20successful%20rename**%0A%0A%60setEditing%28false%29%60%20is%20called%20before%20%60await%20onRenamed%3F.%28%29%60.%20When%20editing%20becomes%20%60false%60%2C%20the%20component's%20early-return%20branch%20%28pencil-button%20view%29%20is%20rendered%2C%20so%20the%20%60renameError%60%20div%20is%20no%20longer%20in%20the%20tree.%20If%20%60onRenamed%60%20subsequently%20throws%2C%20the%20catch%20block%20stores%20the%20message%20in%20%60renameError%60%2C%20but%20the%20error%20is%20never%20shown%20to%20the%20user%20because%20the%20editing%20UI%20is%20already%20hidden.%20The%20rename%20itself%20succeeds%2C%20but%20the%20post-rename%20refresh%20failure%20disappears%20silently.%0A%0AConsider%20flipping%20the%20order%20%E2%80%94%20call%20%60await%20onRenamed%3F.%28%29%60%20before%20%60setEditing%28false%29%60%2C%20or%20move%20the%20%60setEditing%28false%29%60%20into%20a%20%60finally%60-style%20block%20only%20after%20both%20the%20rename%20and%20refresh%20succeed.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FAgentChatPane.test.tsx%3A3613-3663%0A**Test%20description%20does%20not%20match%20what%20the%20test%20actually%20verifies**%0A%0AThe%20test%20is%20named%20%60%22auto-create%20retries%20background%20lane%20naming%20once%20before%20keeping%20the%20deterministic%20name%22%60%2C%20which%20implies%20the%20deterministic%20slug%20is%20ultimately%20kept.%20In%20practice%20the%20mock%20makes%20the%20second%20attempt%20return%20%60%22auto-create-lane-fix%22%60%20%28a%20different%20name%29%2C%20and%20the%20assertion%20confirms%20%60renameLane%60%20is%20called%20with%20that%20name%20%E2%80%94%20meaning%20the%20AI%20name%20**is**%20applied%2C%20not%20kept.%20A%20more%20accurate%20title%20would%20be%20something%20like%20%60%22auto-create%20retries%20background%20lane%20naming%20once%20and%20applies%20the%20second%20attempt's%20suggestion%22%60.%0A%0A&repo=arul28%2Fade&pr=664&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src/renderer/components/lanes/ManageLaneDialog.tsx:113-121
**Error from `onRenamed` is silently swallowed after a successful rename**

`setEditing(false)` is called before `await onRenamed?.()`. When editing becomes `false`, the component's early-return branch (pencil-button view) is rendered, so the `renameError` div is no longer in the tree. If `onRenamed` subsequently throws, the catch block stores the message in `renameError`, but the error is never shown to the user because the editing UI is already hidden. The rename itself succeeds, but the post-rename refresh failure disappears silently.

Consider flipping the order — call `await onRenamed?.()` before `setEditing(false)`, or move the `setEditing(false)` into a `finally`-style block only after both the rename and refresh succeed.

### Issue 2 of 2
apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx:3613-3663
**Test description does not match what the test actually verifies**

The test is named `"auto-create retries background lane naming once before keeping the deterministic name"`, which implies the deterministic slug is ultimately kept. In practice the mock makes the second attempt return `"auto-create-lane-fix"` (a different name), and the assertion confirms `renameLane` is called with that name — meaning the AI name **is** applied, not kept. A more accurate title would be something like `"auto-create retries background lane naming once and applies the second attempt's suggestion"`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Manage Lane rename UI and retry auto..."](https://github.com/arul28/ade/commit/64d80fc4b42412929066d2876f4669b6cfd8a2da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40539301)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->