### PR TITLE
Cli Session Terminal Panel

### DIFF
--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -473,7 +473,7 @@ const TOP_LEVEL_HELP = `${ADE_BANNER}
     $ ade prs list | create | show | checks          Manage PRs, queues, and GitHub integration
     $ ade run defs | ps | start | logs              Manage Run tab process definitions and runtime
     $ ade shell start | write | resize | close      Launch and control tracked shell sessions
-    $ ade terminal list | read | write | signal     Control the active in-chat terminal
+    $ ade terminal list | read | write | signal     Control an attached session terminal
     $ ade history list | show | commits | export     Inspect ADE operation timeline and lane commits
     $ ade chat list | create | send | interrupt     Work with ADE agent chats
     $ ade agent spawn --lane <id> --prompt <text>   Launch an agent session in ADE
@@ -519,7 +519,7 @@ const TOP_LEVEL_HELP = `${ADE_BANNER}
     $ ade ios-sim launch --target <id> --text
     $ ade app-control launch --command "pnpm dev" --text
     $ ade --socket browser open http://localhost:5173 --new-tab --text
-    $ ade terminal read --chat-session <id> --text
+    $ ade terminal read --chat-session <owner-session-id> --text
     $ ade terminal read --pty <pty-id> --text
 
   Generic ADE action JSON contract:
@@ -1285,13 +1285,14 @@ const HELP_BY_COMMAND: Record<string, string> = {
   Shell sessions
 
   Shell commands create tracked PTY sessions that ADE can display and audit.
-  Inside an ADE chat, shell starts attach to the active chat automatically.
+  Inside an ADE chat or tracked agent CLI session, shell starts attach to the
+  active owner session automatically.
 
     $ ade shell start --lane <lane> -- npm test     Start a tracked shell session
     $ ade shell start --lane <lane> -c "npm test"   Start with a command string
     $ ade shell start-cli codex --lane <lane> --permission-mode edit
     $ ade shell start --provider claude --lane <lane> --message "fix tests"
-    $ ade shell start --lane <lane> --chat-session <id> -c "npm test"
+    $ ade shell start --lane <lane> --chat-session <owner-session-id> -c "npm test"
     $ ade shell write <pty-id> --data "q"           Write data to a PTY
     $ ade shell resize <pty-id> --cols 120 --rows 36
     $ ade shell close <pty-id>                      Dispose a PTY
@@ -1300,13 +1301,14 @@ const HELP_BY_COMMAND: Record<string, string> = {
     $ ade terminal read --terminal <session-id> --text
 `,
   terminal: `${ADE_BANNER}
-  Chat terminal
+  Attached terminal
 
-  Terminal commands control the active in-chat terminal for an ADE chat. Use
-  attached runtime mode when you want the same terminal the app is viewing.
+  Terminal commands control the active terminal attached to an ADE chat or
+  tracked agent CLI session. Use attached runtime mode when you want the same
+  terminal the app is viewing.
 
-    $ ade terminal list --chat-session <id> --text  List terminals for a chat
-    $ ade terminal active --chat-session <id> --text Show the active chat terminal
+    $ ade terminal list --chat-session <owner-session-id> --text  List terminals for a session
+    $ ade terminal active --chat-session <owner-session-id> --text Show the active terminal
     $ ade terminal read --terminal <session-id> --text Read terminal scrollback
     $ ade terminal read --pty <pty-id> --text       Read by PTY id
     $ ade app-control logs --text                   Read the active App Control launch terminal
@@ -1537,7 +1539,7 @@ const HELP_BY_COMMAND: Record<string, string> = {
   agent-browser, Computer Use, and other tools may also attach to the same app;
   ADE keeps the launch/session state and turns snapshots into chat context.
 
-  Launching runs the command in the chat terminal instead of a hidden child
+  Launching runs the command in the attached terminal instead of a hidden child
   process. ADE sets ADE_APP_CONTROL_CDP_PORT and ADE_APP_CONTROL_DEBUG_FLAGS in
   the environment and auto-forwards debug flags for common npm/pnpm/yarn/bun
   script launches and direct electron commands. Custom launchers should forward
@@ -1552,7 +1554,7 @@ const HELP_BY_COMMAND: Record<string, string> = {
     $ ade app-control status --text                Show active session and provider readiness
     $ ade app-control claim --lane <lane-id>       Attribute the active renderer to a lane
     $ ade app-control launch --command "npm run dev" --text
-    $ ade app-control launch pnpm dev --text       Launch via the visible chat terminal
+    $ ade app-control launch pnpm dev --text       Launch via the visible attached terminal
     $ ade app-control launch --command "pnpm dev" --cwd apps/desktop --text
     $ ade app-control launch --command "/path/script.sh {ADE_APP_CONTROL_DEBUG_FLAGS}"
     $ ade app-control connect --cdp-port 9222      Attach to an already-running app
@@ -1564,15 +1566,15 @@ const HELP_BY_COMMAND: Record<string, string> = {
     $ ade app-control minimize --text              Minimize the controlled app window
     $ ade app-control stop --text                  Signal the App Control terminal session
     $ ade app-control actions --text               List every callable app_control action
-    $ ade terminal read --terminal <session-id> --text Read a specific chat terminal
+    $ ade terminal read --terminal <session-id> --text Read a specific attached terminal
     $ ade terminal read --pty <pty-id> --text      Read by PTY id
-    $ ade terminal write --chat-session <id> --data "y\\n" Answer a prompt
+    $ ade terminal write --chat-session <owner-session-id> --data "y\\n" Answer a prompt
 
   Capture and context:
     $ ade app-control screenshot --text            Capture the active renderer screenshot
     $ ade app-control snapshot --text              Screenshot + DOM element refs
     $ ade app-control inspect --x 120 --y 420      Hit-test a point without committing context
-    $ ade app-control select --x 120 --y 420       Return/select app context (chat-owned sessions auto-attach)
+    $ ade app-control select --x 120 --y 420       Return/select app context (owned sessions auto-attach)
 
   Input:
     $ ade app-control click 120 420                Click screenshot coordinates
@@ -14595,7 +14597,7 @@ function formatTerminalList(value: unknown): string {
       terminal.runtimeState,
       terminal.title,
     ]),
-    "ADE chat terminals\n(no terminals found)",
+    "ADE attached terminals\n(no terminals found)",
   );
 }
 

--- a/apps/desktop/resources/agent-skills/ade-app-control/SKILL.md
+++ b/apps/desktop/resources/agent-skills/ade-app-control/SKILL.md
@@ -28,7 +28,7 @@ ade --socket app-control elements --text
 ade --socket app-control select --x <x> --y <y> --text
 ```
 
-Use Inspect mode or `select` to return screenshot-backed DOM, selector, and source context. When the session is chat-owned, ADE can attach the selection to the drawer chat.
+Use Inspect mode or `select` to return screenshot-backed DOM, selector, and source context. When the session is owned by a chat or tracked CLI session, ADE can attach the selection to that active Work surface.
 
 ## Act
 

--- a/apps/desktop/src/main/services/pty/ptyService.test.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.test.ts
@@ -834,6 +834,28 @@ describe("ptyService", () => {
       }));
     });
 
+    it("exports tracked CLI session identity as the attached terminal owner", async () => {
+      const { service, loadPty } = createHarness();
+
+      const result = await service.create({
+        laneId: "lane-1",
+        title: "Codex CLI",
+        cols: 80,
+        rows: 24,
+        toolType: "codex",
+        command: "codex",
+      });
+
+      const ptyLib = loadPty.mock.results.at(-1)?.value as { spawn: ReturnType<typeof vi.fn> };
+      const spawnArgs = ptyLib.spawn.mock.calls.at(-1);
+      const opts = spawnArgs?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
+      expect(opts?.env).toEqual(expect.objectContaining({
+        ADE_CHAT_SESSION_ID: result.sessionId,
+        ADE_LANE_ID: "lane-1",
+        ADE_PROJECT_ROOT: "/tmp/test-project",
+      }));
+    });
+
     it("does not leak an inherited ADE chat session into unlinked terminals", async () => {
       const previous = process.env.ADE_CHAT_SESSION_ID;
       process.env.ADE_CHAT_SESSION_ID = "outer-chat";

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -476,14 +476,16 @@ function withAdeTerminalContextEnv(env: NodeJS.ProcessEnv, args: {
   projectRoot: string;
   laneId: string;
   chatSessionId: string | null;
+  ownerSessionId?: string | null;
 }): NodeJS.ProcessEnv {
   const next: NodeJS.ProcessEnv = {
     ...env,
     ADE_PROJECT_ROOT: args.projectRoot,
     ADE_LANE_ID: args.laneId,
   };
-  if (args.chatSessionId) {
-    next.ADE_CHAT_SESSION_ID = args.chatSessionId;
+  const terminalOwnerSessionId = args.chatSessionId ?? args.ownerSessionId ?? null;
+  if (terminalOwnerSessionId) {
+    next.ADE_CHAT_SESSION_ID = terminalOwnerSessionId;
   } else {
     delete next.ADE_CHAT_SESSION_ID;
   }
@@ -3713,6 +3715,7 @@ export function createPtyService({
         projectRoot,
         laneId,
         chatSessionId,
+        ownerSessionId: isTrackedCliToolType(toolTypeHint) ? sessionId : null,
       });
       let launchEnv = withInteractiveTerminalColorEnv(
         getAdeCliAgentEnv?.(contextLaunchEnv) ?? contextLaunchEnv,

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -2765,6 +2765,9 @@ export function AgentChatPane({
   sessionsPaneCount,
   onToggleToolsPane,
   toolsPaneOpen,
+  onToggleTerminalPane,
+  onOpenTerminalPane,
+  terminalPaneOpen,
 }: {
   laneId: string | null;
   laneLabel?: string | null;
@@ -2819,6 +2822,11 @@ export function AgentChatPane({
   /** Work tab: far-right Tools-pane toggle rendered in this chat's header. */
   onToggleToolsPane?: () => void;
   toolsPaneOpen?: boolean;
+  /** Work tab: terminal pane toggle rendered in this chat's header. */
+  onToggleTerminalPane?: () => void;
+  /** Work tab: open-only terminal pane action used when a tool reveals a terminal. */
+  onOpenTerminalPane?: () => void;
+  terminalPaneOpen?: boolean;
 }) {
   const projectRoot = useAppStore(selectActiveProjectRoot);
   const projectTransition = useAppStore((s) => s.projectTransition);
@@ -3133,10 +3141,32 @@ export function AgentChatPane({
     nonce: number;
   } | null>(null);
   const terminalRevealNonceRef = useRef(0);
-  const revealChatTerminal = useCallback((terminal: { terminalId: string; ptyId: string; label: string }) => {
+  const hasExternalTerminalPane = Boolean(onToggleTerminalPane || onOpenTerminalPane);
+  const effectiveTerminalPaneOpen = hasExternalTerminalPane ? terminalPaneOpen === true : terminalDrawerOpen;
+  const toggleTerminalPanel = useCallback(() => {
+    if (onToggleTerminalPane) {
+      onToggleTerminalPane();
+      return;
+    }
+    setTerminalDrawerOpen((current) => !current);
+  }, [onToggleTerminalPane]);
+  const openTerminalPanel = useCallback(() => {
+    if (onOpenTerminalPane) {
+      onOpenTerminalPane();
+      return;
+    }
+    if (onToggleTerminalPane) {
+      if (!terminalPaneOpen) onToggleTerminalPane();
+      return;
+    }
     setTerminalDrawerOpen(true);
-    setTerminalRevealRequest({ ...terminal, nonce: ++terminalRevealNonceRef.current });
-  }, []);
+  }, [onOpenTerminalPane, onToggleTerminalPane, terminalPaneOpen]);
+  const revealChatTerminal = useCallback((terminal: { terminalId: string; ptyId: string; label: string }) => {
+    openTerminalPanel();
+    if (!hasExternalTerminalPane) {
+      setTerminalRevealRequest({ ...terminal, nonce: ++terminalRevealNonceRef.current });
+    }
+  }, [hasExternalTerminalPane, openTerminalPanel]);
   const [rightPaneSplit, setRightPaneSplit] = useState<number>(() => {
     try {
       const raw = window.sessionStorage.getItem("ade.chat.rightPaneSplit");
@@ -5446,13 +5476,15 @@ export function AgentChatPane({
       const ptyId = typeof session.ptyId === "string" ? session.ptyId.trim() : "";
       if (!ptyId) return;
 
-      setTerminalDrawerOpen(true);
-      setTerminalRevealRequest({
-        terminalId: session.id,
-        ptyId,
-        label: session.title?.trim() || "Terminal",
-        nonce: ++terminalRevealNonceRef.current,
-      });
+      openTerminalPanel();
+      if (!hasExternalTerminalPane) {
+        setTerminalRevealRequest({
+          terminalId: session.id,
+          ptyId,
+          label: session.title?.trim() || "Terminal",
+          nonce: ++terminalRevealNonceRef.current,
+        });
+      }
     };
 
     const unsubscribe = sessionsApi.onChanged((event) => {
@@ -5463,7 +5495,7 @@ export function AgentChatPane({
       disposed = true;
       unsubscribe();
     };
-  }, [chatTerminalVisible, laneId]);
+  }, [chatTerminalVisible, hasExternalTerminalPane, laneId, openTerminalPanel]);
 
   useEffect(() => {
     const api = window.ade?.iosSimulator;
@@ -9158,6 +9190,16 @@ export function AgentChatPane({
       onMissingFields={(message) => setError(message)}
     />
   );
+  const terminalPanelContent = chatTerminalVisible ? (
+    <ChatTerminalDrawer
+      variant="panel"
+      open={terminalDrawerOpen}
+      onToggle={() => setTerminalDrawerOpen((current) => !current)}
+      laneId={laneId}
+      chatSessionId={selectedSessionId}
+      revealRequest={terminalRevealRequest}
+    />
+  ) : null;
   const iosSimulatorPanelContent = (
     <>
       <div className="flex shrink-0 items-center justify-between gap-3 border-b border-white/[0.06] px-4 py-2.5">
@@ -9376,7 +9418,7 @@ export function AgentChatPane({
               </button>
             </SmartTooltip>
           ) : null}
-          {chatTerminalVisible ? <ChatTerminalToggle open={terminalDrawerOpen} onToggle={() => setTerminalDrawerOpen((v) => !v)} /> : null}
+          {chatTerminalVisible ? <ChatTerminalToggle open={effectiveTerminalPaneOpen} onToggle={toggleTerminalPanel} /> : null}
           {headerChips.map((chip) => (
             <span
               key={`${chip.label}:${chip.tone ?? "accent"}`}
@@ -10076,13 +10118,14 @@ export function AgentChatPane({
   // shrinks the hero and moves the composer below.
   const appPanelOpen = effectiveIosSimulatorOpen || effectiveAppControlOpen;
   const effectiveCursorCloudPaneOpen = cursorCloudPaneOpen && cursorCloudAvailable;
+  const terminalRightPaneOpen = chatTerminalVisible && !hasExternalTerminalPane && terminalDrawerOpen && Boolean(selectedSessionId);
   // Orchestration: derive runId / role from the active session. When set, mount
   // the right plan panel and (for "orchestrator-lead") wrap the chat surface in
   // the conic-gradient frame.
   const orchestrationRunId = selectedSession?.orchestrationRunId ?? null;
   const orchestrationRole = activeOrchestrationRole;
   const orchestrationPanelOpen = Boolean(orchestrationRunId);
-  const heavyRightPaneOpen = appPanelOpen || effectiveCursorCloudPaneOpen || orchestrationPanelOpen;
+  const heavyRightPaneOpen = appPanelOpen || effectiveCursorCloudPaneOpen || orchestrationPanelOpen || terminalRightPaneOpen;
   const supportsSplit = layoutVariant !== "grid-tile";
   const chatActionsFloating = chatActionsOpen && supportsSplit && !heavyRightPaneOpen;
   const chatActionsRightPaneOpen = chatActionsOpen && !chatActionsFloating;
@@ -10411,15 +10454,6 @@ export function AgentChatPane({
                         sessionId={selectedSessionId}
                       />
                     ) : null}
-                    {chatTerminalVisible ? (
-                      <ChatTerminalDrawer
-                        open={terminalDrawerOpen}
-                        onToggle={() => setTerminalDrawerOpen((v) => !v)}
-                        laneId={laneId}
-                        chatSessionId={selectedSessionId}
-                        revealRequest={terminalRevealRequest}
-                      />
-                    ) : null}
                     {appPanelOpen ? (
                       <div className="shrink-0 border-t border-white/[0.06]">
                         {composerElement}
@@ -10451,6 +10485,7 @@ export function AgentChatPane({
                   {effectiveIosSimulatorOpen ? renderRightPane(iosSimulatorPanelContent) : null}
                   {effectiveAppControlOpen ? renderRightPane(appControlPanelContent) : null}
                   {effectiveCursorCloudPaneOpen ? renderRightPane(cursorCloudPanelContent) : null}
+                  {terminalRightPaneOpen && terminalPanelContent ? renderRightPane(terminalPanelContent) : null}
                   {orchestrationPanelOpen && orchestrationPanelContent ? renderRightPane(orchestrationPanelContent) : null}
                 </motion.div>
               ) : (

--- a/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.test.tsx
@@ -145,6 +145,32 @@ describe("ChatTerminalDrawer", () => {
     expect(window.ade.appControl.getStatus).not.toHaveBeenCalled();
   });
 
+  it("uses the panel variant for CLI-owned attached terminals without a horizontal resize handle", async () => {
+    const view = render(
+      <ChatTerminalDrawer
+        variant="panel"
+        open
+        onToggle={vi.fn()}
+        laneId="lane-1"
+        chatSessionId="cli-session-1"
+        autoCreateOnOpen={false}
+      />,
+    );
+
+    await waitFor(() => expect(window.ade.terminal.list).toHaveBeenCalled());
+    expect(view.container.querySelector(".cursor-row-resize")).toBeNull();
+    expect((view.container.firstElementChild as HTMLElement).style.height).toBe("");
+
+    fireEvent.click(screen.getByTitle("New terminal"));
+
+    await waitFor(() => expect(window.ade.pty.create).toHaveBeenCalledTimes(1));
+    expect(window.ade.pty.create).toHaveBeenCalledWith(expect.objectContaining({
+      laneId: "lane-1",
+      chatSessionId: "cli-session-1",
+      toolType: "shell",
+    }));
+  });
+
   it("switches restored terminal tabs", async () => {
     vi.mocked(window.ade.terminal.list).mockResolvedValueOnce([
       {

--- a/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx
@@ -49,7 +49,12 @@ type ChatTerminalDrawerProps = {
   open: boolean;
   onToggle: () => void;
   laneId: string;
+  /**
+   * Owner session for attached terminals. Historically this was always an ADE
+   * chat id; Work CLI sessions now use their terminal session id here too.
+   */
   chatSessionId?: string | null;
+  variant?: "drawer" | "panel";
   autoCreateOnOpen?: boolean;
   createRequestNonce?: number;
   disposeTabsOnUnmount?: boolean;
@@ -130,6 +135,7 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
   onToggle,
   laneId,
   chatSessionId,
+  variant = "drawer",
   autoCreateOnOpen = true,
   createRequestNonce = 0,
   disposeTabsOnUnmount = false,
@@ -145,6 +151,7 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
   const [restoringTabs, setRestoringTabs] = useState(false);
   const [appControlTabState, setAppControlTabState] = useState<AppControlTabState | null>(null);
   const dragRef = useRef<{ startY: number; startHeight: number } | null>(null);
+  const isPanel = variant === "panel";
   const hadTabsRef = useRef(false);
   const previousOpenRef = useRef(open);
   const pendingAutoCreateRef = useRef(false);
@@ -188,6 +195,7 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
   }, [activeTabId, drawerHeight, tabs, uiStateKey]);
 
   const handleDragStart = useCallback((e: React.MouseEvent) => {
+    if (isPanel) return;
     e.preventDefault();
     dragRef.current = { startY: e.clientY, startHeight: drawerHeight };
 
@@ -210,7 +218,7 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
 
     document.addEventListener("mousemove", handleDragMove);
     document.addEventListener("mouseup", handleDragEnd);
-  }, [drawerHeight]);
+  }, [drawerHeight, isPanel]);
 
   const createTab = useCallback(async () => {
     if (createTabFlightRef.current) {
@@ -494,17 +502,29 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
 
   return (
     <div
-      className="flex flex-col border-t border-white/[0.06] bg-[var(--color-surface-recessed)] shadow-[inset_0_2px_8px_rgba(0,0,0,0.3)]"
-      style={{ height: drawerHeight }}
+      className={cn(
+        "flex flex-col bg-[var(--color-surface-recessed)]",
+        isPanel
+          ? "h-full min-h-0"
+          : "border-t border-white/[0.06] shadow-[inset_0_2px_8px_rgba(0,0,0,0.3)]",
+      )}
+      style={isPanel ? undefined : { height: drawerHeight }}
     >
-      <div
-        className="flex h-2 cursor-row-resize items-center justify-center transition-colors hover:bg-white/[0.04]"
-        onMouseDown={handleDragStart}
-      >
-        <div className="h-0.5 w-8 rounded-full bg-white/[0.12]" />
-      </div>
+      {!isPanel ? (
+        <div
+          className="flex h-2 cursor-row-resize items-center justify-center transition-colors hover:bg-white/[0.04]"
+          onMouseDown={handleDragStart}
+        >
+          <div className="h-0.5 w-8 rounded-full bg-white/[0.12]" />
+        </div>
+      ) : null}
 
-      <div className="flex h-6 shrink-0 items-center overflow-x-auto border-b border-white/[0.06] bg-black/10">
+      <div
+        className={cn(
+          "flex shrink-0 items-center overflow-x-auto border-b border-white/[0.06] bg-black/10",
+          isPanel ? "h-8" : "h-6",
+        )}
+      >
         <div className="flex min-w-0 items-center gap-0 overflow-x-auto scrollbar-none">
           {tabs.map((tab) => {
             const appControlTone = appControlTabState && appControlTabState.terminalSessionId === tab.sessionId
@@ -512,68 +532,69 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
               : null;
             const isActive = activeTab?.id === tab.id;
             return (
-            <div
-              key={tab.id}
-              className={cn(
-                "group relative flex h-6 shrink-0 items-center gap-1 border-r border-white/[0.04] px-2 font-mono text-[10px] transition-colors",
-                isActive
-                  ? "bg-white/[0.06] text-fg/85"
-                  : "bg-transparent text-fg/35 hover:bg-white/[0.03] hover:text-fg/60",
-                appControlTone ? "pl-4" : null,
-              )}
-              title={appControlTone ? appControlTabState?.title : undefined}
-            >
-              {appControlTone ? (
-                <span
-                  aria-hidden
-                  className={cn(
-                    "pointer-events-none absolute left-1.5 top-1.5 h-1.5 w-1.5 rounded-full",
-                    appControlTone === "active" && "bg-emerald-300/85 shadow-[0_0_4px_rgba(16,185,129,0.6)]",
-                    appControlTone === "warn" && "bg-amber-300/80",
-                    appControlTone === "error" && "bg-rose-400/85",
-                  )}
-                />
-              ) : null}
-              {isActive ? (
-                <span
-                  aria-hidden
-                  className="pointer-events-none absolute inset-x-0 bottom-0 h-[2px] bg-[var(--color-accent)]"
-                />
-              ) : null}
-              <button
-                type="button"
-                onClick={() => setActiveTabId(tab.id)}
-                className="flex h-full min-w-0 items-center gap-1 bg-transparent p-0 text-inherit"
+              <div
+                key={tab.id}
+                className={cn(
+                  "group relative flex shrink-0 items-center gap-1 border-r border-white/[0.04] px-2 font-mono text-[10px] transition-colors",
+                  isPanel ? "h-8" : "h-6",
+                  isActive
+                    ? "bg-white/[0.06] text-fg/85"
+                    : "bg-transparent text-fg/35 hover:bg-white/[0.03] hover:text-fg/60",
+                  appControlTone ? "pl-4" : null,
+                )}
+                title={appControlTone ? appControlTabState?.title : undefined}
               >
-                <TerminalIcon
-                  size={10}
-                  weight="bold"
-                  className={cn("shrink-0", tabIconColorClass(tab.exited, appControlTone))}
-                />
-                <span className="max-w-[80px] truncate">{tab.label}</span>
-              </button>
-              <button
-                type="button"
-                aria-label={`Close ${tab.label}`}
-                onMouseDown={(event) => {
-                  event.stopPropagation();
-                }}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  closeTab(tab.id);
-                }}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault();
+                {appControlTone ? (
+                  <span
+                    aria-hidden
+                    className={cn(
+                      "pointer-events-none absolute left-1.5 top-1.5 h-1.5 w-1.5 rounded-full",
+                      appControlTone === "active" && "bg-emerald-300/85 shadow-[0_0_4px_rgba(16,185,129,0.6)]",
+                      appControlTone === "warn" && "bg-amber-300/80",
+                      appControlTone === "error" && "bg-rose-400/85",
+                    )}
+                  />
+                ) : null}
+                {isActive ? (
+                  <span
+                    aria-hidden
+                    className="pointer-events-none absolute inset-x-0 bottom-0 h-[2px] bg-[var(--color-accent)]"
+                  />
+                ) : null}
+                <button
+                  type="button"
+                  onClick={() => setActiveTabId(tab.id)}
+                  className="flex h-full min-w-0 items-center gap-1 bg-transparent p-0 text-inherit"
+                >
+                  <TerminalIcon
+                    size={10}
+                    weight="bold"
+                    className={cn("shrink-0", tabIconColorClass(tab.exited, appControlTone))}
+                  />
+                  <span className="max-w-[80px] truncate">{tab.label}</span>
+                </button>
+                <button
+                  type="button"
+                  aria-label={`Close ${tab.label}`}
+                  onMouseDown={(event) => {
+                    event.stopPropagation();
+                  }}
+                  onClick={(event) => {
                     event.stopPropagation();
                     closeTab(tab.id);
-                  }
-                }}
-                className="ml-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded text-white/35 opacity-60 transition-colors hover:bg-white/[0.06] hover:text-white/70 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20"
-              >
-                <X size={10} weight="bold" />
-              </button>
-            </div>
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      closeTab(tab.id);
+                    }
+                  }}
+                  className="ml-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded text-white/35 opacity-60 transition-colors hover:bg-white/[0.06] hover:text-white/70 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20"
+                >
+                  <X size={10} weight="bold" />
+                </button>
+              </div>
             );
           })}
         </div>
@@ -581,7 +602,10 @@ export const ChatTerminalDrawer = memo(function ChatTerminalDrawer({
         <button
           type="button"
           onClick={() => { void createTab(); }}
-          className="mx-1 flex h-6 w-6 shrink-0 items-center justify-center rounded-md border border-white/[0.06] text-white/30 transition-colors hover:bg-white/[0.04] hover:text-white/60"
+          className={cn(
+            "mx-1 flex shrink-0 items-center justify-center rounded-md border border-white/[0.06] text-white/30 transition-colors hover:bg-white/[0.04] hover:text-white/60",
+            isPanel ? "h-7 w-7" : "h-6 w-6",
+          )}
           title="New terminal"
           disabled={creatingTab}
         >

--- a/apps/desktop/src/renderer/components/terminals/CliSessionWorkSurfaceHeader.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/CliSessionWorkSurfaceHeader.test.tsx
@@ -64,6 +64,8 @@ const lanes: LaneSummary[] = [
 function renderHeader(overrides: Partial<TerminalSessionSummary> = {}, callbacks: {
   onInfoClick?: () => void;
   onContextMenu?: () => void;
+  onToggleTerminalPane?: () => void;
+  terminalPaneOpen?: boolean;
 } = {}) {
   const session = makeSession(overrides);
   return render(
@@ -73,6 +75,8 @@ function renderHeader(overrides: Partial<TerminalSessionSummary> = {}, callbacks
         lanes={lanes}
         onInfoClick={callbacks.onInfoClick}
         onContextMenu={callbacks.onContextMenu}
+        onToggleTerminalPane={callbacks.onToggleTerminalPane}
+        terminalPaneOpen={callbacks.terminalPaneOpen}
       />
     </MemoryRouter>,
   );
@@ -128,6 +132,18 @@ describe("CliSessionWorkSurfaceHeader", () => {
     renderHeader({}, { onInfoClick });
     fireEvent.click(screen.getByLabelText("Session info"));
     expect(onInfoClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the attached terminal panel from running CLI sessions", () => {
+    const onToggleTerminalPane = vi.fn();
+    renderHeader({}, { onToggleTerminalPane });
+    fireEvent.click(screen.getByLabelText("Open terminal panel"));
+    expect(onToggleTerminalPane).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the terminal button active while the panel is open", () => {
+    renderHeader({}, { onToggleTerminalPane: vi.fn(), terminalPaneOpen: true });
+    expect(screen.getByLabelText("Close terminal panel").getAttribute("aria-pressed")).toBe("true");
   });
 
   it("fires onContextMenu when the kebab is pressed", () => {

--- a/apps/desktop/src/renderer/components/terminals/CliSessionWorkSurfaceHeader.tsx
+++ b/apps/desktop/src/renderer/components/terminals/CliSessionWorkSurfaceHeader.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent as ReactMouseEvent } from "react";
-import { DotsThreeVertical, Info, StopCircle } from "@phosphor-icons/react";
+import { DotsThreeVertical, Info, StopCircle, Terminal } from "@phosphor-icons/react";
 import { useNavigate } from "react-router-dom";
 import type { LaneSummary, TerminalSessionSummary } from "../../../shared/types";
 import { openLaneInLanesTabPath } from "../../lib/laneNavigation";
@@ -127,6 +127,39 @@ function SessionInfoButton({
   );
 }
 
+function SessionTerminalButton({
+  open = false,
+  onToggleTerminalPane,
+}: {
+  open?: boolean;
+  onToggleTerminalPane?: () => void;
+}) {
+  return (
+    <SmartTooltip
+      content={{
+        label: open ? "Close terminal panel" : "Open terminal panel",
+        description: "Open attached shell terminals for this CLI session.",
+      }}
+    >
+      <button
+        type="button"
+        className={cn(
+          WORK_SURFACE_HEADER_ACTION_BASE,
+          open
+            ? "border-violet-400/22 bg-violet-500/10 px-1.5 text-violet-100/80"
+            : cn(WORK_SURFACE_HEADER_ACTION_IDLE, "px-1.5"),
+        )}
+        onClick={onToggleTerminalPane}
+        aria-label={open ? "Close terminal panel" : "Open terminal panel"}
+        aria-pressed={open}
+        disabled={!onToggleTerminalPane}
+      >
+        <Terminal size={13} weight={open ? "fill" : "regular"} />
+      </button>
+    </SmartTooltip>
+  );
+}
+
 function SessionActionsButton({
   session,
   onContextMenu,
@@ -177,17 +210,22 @@ export function CliSurfaceTrailingActions({
   onInfoClick,
   onContextMenu,
   onStopRunningSession,
+  onToggleTerminalPane,
+  terminalPaneOpen = false,
 }: {
   session: TerminalSessionSummary;
   stopping?: boolean;
   onInfoClick?: SessionMouseHandler;
   onContextMenu?: SessionMouseHandler;
   onStopRunningSession?: (session: TerminalSessionSummary) => void;
+  onToggleTerminalPane?: () => void;
+  terminalPaneOpen?: boolean;
 }) {
   return (
     <>
       <StopSessionButton session={session} stopping={stopping} onStopRunningSession={onStopRunningSession} />
       <SessionRunMenu session={session} />
+      <SessionTerminalButton open={terminalPaneOpen} onToggleTerminalPane={onToggleTerminalPane} />
       <SessionInfoButton session={session} onInfoClick={onInfoClick} />
       <SessionActionsButton session={session} onContextMenu={onContextMenu} />
     </>
@@ -246,6 +284,8 @@ export function CliSessionWorkSurfaceHeader({
   sessionsPaneCount,
   onToggleToolsPane,
   toolsPaneOpen,
+  onToggleTerminalPane,
+  terminalPaneOpen,
 }: {
   session: TerminalSessionSummary;
   lanes: LaneSummary[];
@@ -259,6 +299,8 @@ export function CliSessionWorkSurfaceHeader({
   sessionsPaneCount?: number;
   onToggleToolsPane?: () => void;
   toolsPaneOpen?: boolean;
+  onToggleTerminalPane?: () => void;
+  terminalPaneOpen?: boolean;
 }) {
   const navigate = useNavigate();
   const lane = lanes.find((entry) => entry.id === session.laneId) ?? null;
@@ -314,6 +356,8 @@ export function CliSessionWorkSurfaceHeader({
             onInfoClick={onInfoClick}
             onContextMenu={onContextMenu}
             onStopRunningSession={onStopRunningSession}
+            onToggleTerminalPane={onToggleTerminalPane}
+            terminalPaneOpen={terminalPaneOpen}
           />
         </>
       }

--- a/apps/desktop/src/renderer/components/terminals/TerminalsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalsPage.test.tsx
@@ -295,6 +295,9 @@ vi.mock("./WorkViewArea", () => ({
       session: AgentChatSession,
       options?: AgentChatSessionCreatedOptions,
     ) => void | Promise<void>;
+    onToggleTerminalPane?: () => void;
+    onOpenTerminalPane?: () => void;
+    terminalPaneOpen?: boolean;
   }) => (
     <div data-testid="work-view-area">
       <button
@@ -308,6 +311,19 @@ vi.mock("./WorkViewArea", () => ({
         onClick={() => props.onOpenChatSession(workMocks.foregroundSession, { activate: true, source: "draft-launch" })}
       >
         create foreground chat
+      </button>
+      <button
+        type="button"
+        data-terminal-open={props.terminalPaneOpen ? "true" : "false"}
+        onClick={() => props.onToggleTerminalPane?.()}
+      >
+        toggle terminal pane
+      </button>
+      <button
+        type="button"
+        onClick={() => props.onOpenTerminalPane?.()}
+      >
+        open terminal pane
       </button>
     </div>
   ),
@@ -447,6 +463,35 @@ describe("TerminalsPage chat session activation", () => {
     });
     // (work-tab viewMode/grid was removed by this lane's overhaul; the remote
     // guard now just suppresses the browser-sidebar open.)
+    expect(workMocks.currentWork.setWorkSidebarTab).not.toHaveBeenCalled();
+  });
+
+  it("opens and closes the Work Terminal sidebar from session headers", async () => {
+    Object.defineProperty(window, "ade", {
+      configurable: true,
+      value: { builtInBrowser: { onEvent: vi.fn(() => vi.fn()) } },
+    });
+
+    const { rerender } = render(<TerminalsPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "toggle terminal pane" }));
+    expect(workMocks.currentWork.setWorkSidebarTab).toHaveBeenCalledWith("terminal");
+
+    vi.clearAllMocks();
+    workMocks.currentWork = {
+      ...workMocks.baseWork,
+      workSidebarOpen: true,
+      workSidebarTab: "terminal",
+      closingPtyIds: new Set<string>(),
+    };
+    rerender(<TerminalsPage />);
+
+    expect(screen.getByRole("button", { name: "toggle terminal pane" }).getAttribute("data-terminal-open")).toBe("true");
+    fireEvent.click(screen.getByRole("button", { name: "toggle terminal pane" }));
+    expect(workMocks.currentWork.setWorkSidebarOpen).toHaveBeenCalledWith(false);
+
+    vi.clearAllMocks();
+    fireEvent.click(screen.getByRole("button", { name: "open terminal pane" }));
     expect(workMocks.currentWork.setWorkSidebarTab).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx
@@ -725,6 +725,19 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
   const toggleWorkSidebar = useCallback(() => {
     work.setWorkSidebarOpen(!work.workSidebarOpen);
   }, [work]);
+  const terminalPaneOpen = work.workSidebarOpen && work.workSidebarTab === "terminal";
+  const toggleTerminalPane = useCallback(() => {
+    if (work.workSidebarOpen && work.workSidebarTab === "terminal") {
+      work.setWorkSidebarOpen(false);
+    } else {
+      work.setWorkSidebarTab("terminal");
+    }
+  }, [work]);
+  const openTerminalPane = useCallback(() => {
+    if (!work.workSidebarOpen || work.workSidebarTab !== "terminal") {
+      work.setWorkSidebarTab("terminal");
+    }
+  }, [work]);
   const closeWorkSidebar = useCallback(() => {
     work.setWorkSidebarOpen(false);
   }, [work]);
@@ -886,6 +899,9 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
         sessionsPaneListCount={work.filtered.length}
         workSidebarOpen={work.workSidebarOpen}
         onToggleWorkSidebar={toggleWorkSidebar}
+        terminalPaneOpen={terminalPaneOpen}
+        onToggleTerminalPane={toggleTerminalPane}
+        onOpenTerminalPane={openTerminalPane}
         onInfoClick={handleInfoClick}
         onStopRunningSession={handleStopRunningSession}
         onGoToLane={handleGoToLaneById}
@@ -918,8 +934,12 @@ export function TerminalsPage({ active = true }: { active?: boolean }) {
       work.filtered.length,
       work.workFocusSessionsHidden,
       work.workSidebarOpen,
+      work.workSidebarTab,
+      terminalPaneOpen,
       toggleSessionsPane,
       toggleWorkSidebar,
+      toggleTerminalPane,
+      openTerminalPane,
       handleOpenChatSession,
       handleContinueCliSession,
       handleResumeCliSession,

--- a/apps/desktop/src/renderer/components/terminals/WorkSidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkSidebar.test.tsx
@@ -115,6 +115,24 @@ vi.mock("../chat/ChatBuiltInBrowserPanel", async () => {
   };
 });
 
+vi.mock("../chat/ChatTerminalDrawer", async () => {
+  const React = await import("react");
+  return {
+    ChatTerminalDrawer: (props: {
+      variant?: string;
+      laneId: string;
+      chatSessionId?: string | null;
+      open: boolean;
+    }) => React.createElement("div", {
+      "data-testid": "chat-terminal-drawer",
+      "data-variant": props.variant ?? "",
+      "data-lane-id": props.laneId,
+      "data-chat-session-id": props.chatSessionId ?? "",
+      "data-open": props.open ? "true" : "false",
+    }),
+  };
+});
+
 vi.mock("../files/FilesTab", async () => {
   const React = await import("react");
   return { FilesTab: () => React.createElement("div", null, "Files") };
@@ -369,6 +387,38 @@ describe("WorkSidebar context targets", () => {
     expect(screen.getByTestId("app-control-panel").getAttribute("data-session-id")).toBe("chat-1");
   });
 
+  it("renders the attached terminal panel for running CLI session owners", () => {
+    renderSidebar({
+      tab: "terminal",
+      contextTarget: { kind: "pty", sessionId: "term-1", ptyId: "pty-1", toolType: "codex" },
+    });
+
+    const drawer = screen.getByTestId("chat-terminal-drawer");
+    expect(drawer.getAttribute("data-variant")).toBe("panel");
+    expect(drawer.getAttribute("data-lane-id")).toBe("lane-1");
+    expect(drawer.getAttribute("data-chat-session-id")).toBe("term-1");
+    expect(drawer.getAttribute("data-open")).toBe("true");
+  });
+
+  it("renders the attached terminal panel for chat owners", () => {
+    renderSidebar({
+      tab: "terminal",
+      contextTarget: { kind: "chat", sessionId: "chat-1" },
+    });
+
+    expect(screen.getByTestId("chat-terminal-drawer").getAttribute("data-chat-session-id")).toBe("chat-1");
+  });
+
+  it("explains why ended CLI sessions cannot open attached terminals", () => {
+    renderSidebar({
+      tab: "terminal",
+      activeSession: { ...activeSession, status: "completed" },
+      contextTarget: null,
+    });
+
+    expect(screen.getByText(/Continue this .* session before opening an attached terminal\./)).toBeTruthy();
+  });
+
   it("writes formatted context to active PTY targets instead of dispatching chat events", async () => {
     const { terminalWrite } = installAdeMock();
     const dispatchSpy = vi.spyOn(window, "dispatchEvent");
@@ -591,6 +641,7 @@ describe("WorkSidebar context targets", () => {
 
     expect(screen.getByRole("button", { name: "Git" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Files" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Terminal" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "iOS Sim" })).toBeNull();
     expect(screen.queryByRole("button", { name: "App Control" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Browser" })).toBeNull();

--- a/apps/desktop/src/renderer/components/terminals/WorkSidebar.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkSidebar.tsx
@@ -5,6 +5,7 @@ import {
   FolderOpen,
   GitBranch,
   Globe,
+  Terminal,
   WarningCircle,
   X,
 } from "@phosphor-icons/react";
@@ -32,9 +33,11 @@ import {
   dispatchWorkPtyContextInserted,
   type WorkPtyContextInsertKind,
 } from "../../lib/workPtyContextEvents";
+import { formatToolTypeLabel } from "../../lib/sessions";
 import { ChatAppControlPanel } from "../chat/ChatAppControlPanel";
 import { ChatBuiltInBrowserPanel } from "../chat/ChatBuiltInBrowserPanel";
 import { ChatIosSimulatorPanel } from "../chat/ChatIosSimulatorPanel";
+import { ChatTerminalDrawer } from "../chat/ChatTerminalDrawer";
 import { FilesTab } from "../files/FilesTab";
 import { LaneDiffPane } from "../lanes/LaneDiffPane";
 import { LaneGitActionsPane } from "../lanes/LaneGitActionsPane";
@@ -42,6 +45,13 @@ import { GlowMenu, type GlowMenuItem } from "../ui/GlowMenu";
 import { cn } from "../ui/cn";
 
 const WORK_SIDEBAR_TABS: Array<GlowMenuItem<WorkSidebarTab>> = [
+  {
+    id: "terminal",
+    label: "Terminal",
+    icon: Terminal,
+    gradient: "radial-gradient(circle, rgba(196,181,253,0.38) 0%, transparent 70%)",
+    color: "#c4b5fd",
+  },
   {
     id: "git",
     label: "Git",
@@ -79,7 +89,7 @@ const WORK_SIDEBAR_TABS: Array<GlowMenuItem<WorkSidebarTab>> = [
   },
 ];
 
-const REMOTE_WORK_SIDEBAR_TAB_IDS = new Set<WorkSidebarTab>(["git", "files"]);
+const REMOTE_WORK_SIDEBAR_TAB_IDS = new Set<WorkSidebarTab>(["terminal", "git", "files"]);
 
 function isRemoteWorkSidebarTab(tab: WorkSidebarTab): boolean {
   return REMOTE_WORK_SIDEBAR_TAB_IDS.has(tab);
@@ -192,10 +202,19 @@ function WarningBanner({ message }: { message: string }) {
   );
 }
 
+function TerminalPanelEmpty({ message }: { message: string }) {
+  return (
+    <div className="flex h-full items-center justify-center px-4 text-center text-[12px] leading-5 text-muted-fg">
+      {message}
+    </div>
+  );
+}
+
 export function WorkSidebar({
   active = true,
   laneId,
   lanes,
+  activeSession,
   tab,
   onTabChange,
   onClose,
@@ -367,6 +386,10 @@ export function WorkSidebar({
   const warningReason = toolAttributionReason ?? contextDisabledReason;
   const canInsertContext = Boolean(contextTarget && !contextDisabledReason);
   const panelSessionId = contextTarget?.kind === "chat" ? contextTarget.sessionId : null;
+  const terminalOwnerSessionId =
+    contextTarget?.kind === "chat" || contextTarget?.kind === "pty"
+      ? contextTarget.sessionId
+      : null;
 
   const dispatchTargetRef = useRef({ contextTarget, contextDisabledReason });
   dispatchTargetRef.current = { contextTarget, contextDisabledReason };
@@ -479,6 +502,28 @@ export function WorkSidebar({
 
   const content = useMemo(() => {
     if (!active) return null;
+    if (effectiveTab === "terminal") {
+      if (!laneId) {
+        return <TerminalPanelEmpty message="Select a lane or open a Work session to attach terminals." />;
+      }
+      if (!terminalOwnerSessionId) {
+        const message = activeSession?.status && activeSession.status !== "running"
+          ? `Continue this ${formatToolTypeLabel(activeSession.toolType)} session before opening an attached terminal.`
+          : "Open a chat or running agent CLI session to attach terminals.";
+        return <TerminalPanelEmpty message={message} />;
+      }
+      return (
+        <ChatTerminalDrawer
+          variant="panel"
+          open
+          onToggle={onClose}
+          laneId={laneId}
+          chatSessionId={terminalOwnerSessionId}
+          emptyMessage="Create a terminal to work alongside this session."
+        />
+      );
+    }
+
     if (effectiveTab === "browser") {
       return (
         <div className="flex h-full min-h-0 flex-col">
@@ -599,6 +644,9 @@ export function WorkSidebar({
     selectedPath,
     active,
     effectiveTab,
+    activeSession,
+    onClose,
+    terminalOwnerSessionId,
   ]);
 
   return (

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
@@ -611,6 +611,9 @@ function SessionSurface({
   sessionsPaneCount,
   onToggleToolsPane,
   toolsPaneOpen,
+  onToggleTerminalPane,
+  onOpenTerminalPane,
+  terminalPaneOpen,
 }: {
   session: TerminalSessionSummary;
   lanes: LaneSummary[];
@@ -633,6 +636,9 @@ function SessionSurface({
   /** Far-right Tools-pane toggle (per-surface header now owns it). */
   onToggleToolsPane?: () => void;
   toolsPaneOpen?: boolean;
+  onToggleTerminalPane?: () => void;
+  onOpenTerminalPane?: () => void;
+  terminalPaneOpen?: boolean;
 }) {
   const isChat = isChatToolType(session.toolType);
   const surfaceActive = pageActive && isActive;
@@ -655,6 +661,9 @@ function SessionSurface({
         sessionsPaneCount={sessionsPaneCount}
         onToggleToolsPane={onToggleToolsPane}
         toolsPaneOpen={toolsPaneOpen}
+        onToggleTerminalPane={onToggleTerminalPane}
+        onOpenTerminalPane={onOpenTerminalPane}
+        terminalPaneOpen={terminalPaneOpen}
       />
     );
   }
@@ -675,6 +684,8 @@ function SessionSurface({
               sessionsPaneCount={sessionsPaneCount}
               onToggleToolsPane={onToggleToolsPane}
               toolsPaneOpen={toolsPaneOpen}
+              onToggleTerminalPane={onToggleTerminalPane}
+              terminalPaneOpen={terminalPaneOpen}
             />
           ) : null}
           <TerminalView
@@ -852,6 +863,9 @@ export function WorkViewArea({
   sessionsPaneListCount = 0,
   workSidebarOpen = false,
   onToggleWorkSidebar,
+  terminalPaneOpen = false,
+  onToggleTerminalPane,
+  onOpenTerminalPane,
   initialLinearIssueContext = null,
   initialLinearIssueContextSource = "lane_link",
   initialModelId = null,
@@ -892,6 +906,9 @@ export function WorkViewArea({
   sessionsPaneListCount?: number;
   workSidebarOpen?: boolean;
   onToggleWorkSidebar?: () => void;
+  terminalPaneOpen?: boolean;
+  onToggleTerminalPane?: () => void;
+  onOpenTerminalPane?: () => void;
   initialLinearIssueContext?: LaneLinearIssue | null;
   initialLinearIssueContextSource?: "manual" | "lane_link";
   initialModelId?: string | null;
@@ -944,6 +961,9 @@ export function WorkViewArea({
       sessionsPaneCount={sessionsPaneListCount}
       onToggleToolsPane={onToggleWorkSidebar}
       toolsPaneOpen={workSidebarOpen}
+      onToggleTerminalPane={onToggleTerminalPane}
+      onOpenTerminalPane={onOpenTerminalPane}
+      terminalPaneOpen={terminalPaneOpen}
     />
   );
 
@@ -991,6 +1011,9 @@ export function WorkViewArea({
           sessionsPaneCount={sessionsPaneListCount}
           onToggleToolsPane={onToggleWorkSidebar}
           toolsPaneOpen={workSidebarOpen}
+          onToggleTerminalPane={onToggleTerminalPane}
+          onOpenTerminalPane={onOpenTerminalPane}
+          terminalPaneOpen={terminalPaneOpen}
         />
       </SingleSessionGridDropZone>
     ) : (

--- a/apps/desktop/src/renderer/state/appStore.ts
+++ b/apps/desktop/src/renderer/state/appStore.ts
@@ -121,7 +121,7 @@ function normalizeChatShellGeometry(value: unknown): ChatShellGeometry {
   return "default";
 }
 export type TerminalAttentionIndicator = "none" | "running-active" | "running-needs-attention";
-export type WorkSidebarTab = "git" | "files" | "ios" | "app-control" | "browser";
+export type WorkSidebarTab = "terminal" | "git" | "files" | "ios" | "app-control" | "browser";
 export type WorkStatusFilter = "all" | "running" | "awaiting-input" | "ended";
 export type WorkDraftKind = "chat" | "cli";
 /** How sessions are grouped in the Work sidebar list. */
@@ -246,7 +246,13 @@ function normalizeOptionalString(value: unknown): string | null {
 }
 
 function normalizeWorkSidebarTab(value: unknown): WorkSidebarTab {
-  if (value === "files" || value === "ios" || value === "app-control" || value === "browser") return value;
+  if (
+    value === "terminal"
+    || value === "files"
+    || value === "ios"
+    || value === "app-control"
+    || value === "browser"
+  ) return value;
   return "git";
 }
 

--- a/apps/desktop/src/shared/types/sessions.ts
+++ b/apps/desktop/src/shared/types/sessions.ts
@@ -103,7 +103,7 @@ export type TerminalSessionSummary = {
   resumeCommand: string | null;
   resumeMetadata?: TerminalResumeMetadata | null;
   chatIdleSinceAt?: string | null;
-  /** Parent chat session id when this terminal was launched from a chat (e.g. App Control, in-chat terminal drawer). */
+  /** Owner session id for attached terminals, historically a parent chat id and now also a tracked CLI session id. */
   chatSessionId?: string | null;
   /**
    * Orchestration-mode fields. Populated only when the underlying chat session
@@ -136,7 +136,7 @@ export type PtyCreateArgs = {
   allowNewSessionId?: boolean;
   /** Allow an explicit absolute cwd outside the selected lane worktree. */
   allowExternalCwd?: boolean;
-  /** Chat session that owns this in-chat terminal, when launched from chat UI or App Control. */
+  /** Session that owns this attached terminal, when launched from chat/CLI UI or App Control. */
   chatSessionId?: string | null;
   laneId: string;
   cwd?: string;

--- a/docs/features/terminals-and-sessions/README.md
+++ b/docs/features/terminals-and-sessions/README.md
@@ -150,7 +150,7 @@ Shared types and IPC:
   provider continuation internally — and `ade.pty.resumeSession`, which
   relaunches an ended tracked CLI session without sending a prompt),
   `ade.processes.*`, plus the
-  chat-scoped `ade.terminal.*` family (`list`, `read`, `preview` —
+  session-owned `ade.terminal.*` family (`list`, `read`, `preview` —
   serialized xterm snapshot for the TUI / mobile renderers, `write`,
   `signal`, `activeForChat`), and the localhost-probe helper
   `ade.localhost.probePort`.
@@ -167,10 +167,10 @@ IPC registration:
   `sessionsReadTranscriptTail`, `sessionsGetDelta`, `ptyCreate`,
   `ptyResumeSession`, `ptySendToSession`, `ptyWrite`, `ptyResize`,
   `ptyDispose`, the `processes.*` handlers,
-  and the chat-scoped `terminalList` / `terminalRead` /
+  and the session-owned `terminalList` / `terminalRead` /
   `terminalWrite` / `terminalSignal` / `terminalActiveForChat`
   handlers. `terminalRead` delegates transcript-tail reads to
-  `ptyService` so chat-owned terminal drawers and `ade code` get the
+  `ptyService` so attached terminal panels and `ade code` get the
   same live-tail merge as the Work tab.
 
 Renderer surfaces:
@@ -542,9 +542,9 @@ process-local PTY is no longer reachable from the current ADE runtime.
 Fields that feed UI and downstream systems:
 
 - identity: `id`, `laneId`, `laneName`, `ptyId`, `tracked`, `pinned`,
-  `manuallyNamed`, `chatSessionId` (parent chat that owns this terminal,
-  set when launched from the chat terminal drawer or App Control —
-  stored as `chat_session_id` and indexed)
+  `manuallyNamed`, `chatSessionId` (owner session for attached terminals;
+  historically a parent chat id, and now also a tracked CLI session id
+  for CLI-owned attached terminals; stored as `chat_session_id` and indexed)
 - title and intent: `title`, `goal`, `toolType`
 - lifecycle: `status`, `startedAt`, `endedAt`, `exitCode`, `runtimeState`
   (derived), `chatIdleSinceAt`
@@ -679,7 +679,7 @@ PTY:
 
 | Channel | Purpose |
 |---|---|
-| `ade.pty.create` | create or reattach; returns `{ ptyId, sessionId, pid }`. Accepts an optional `chatSessionId` to mark the terminal as chat-owned. |
+| `ade.pty.create` | create or reattach; returns `{ ptyId, sessionId, pid }`. Accepts an optional `chatSessionId` to mark the terminal as attached to that owner session. |
 | `ade.pty.resumeSession` | prompt-free tracked CLI relaunch. Args: `{ sessionId, cols?, rows?, model?, reasoningEffort?, permissionMode? }`. Reuses a live PTY when attached; otherwise validates the row, backfills a missing resume target when possible, rebuilds the provider resume command, and spawns a continuation PTY in the same `terminal_sessions` row without writing a prompt. Returns `PtyResumeSessionResult` (`{ ptyId, sessionId, pid, session, resumed, reusedExistingRuntime }`). |
 | `ade.pty.sendToSession` | send-or-continue. Args: `{ sessionId, text, cols?, rows?, model?, reasoningEffort?, permissionMode? }`. Submits text into the live PTY when one is attached; otherwise validates that the row is a tracked agent CLI session, backfills a missing resume target when possible, rebuilds the resume command via `buildTrackedCliResumeCommand` (honouring runtime overrides), spawns the continuation PTY in the same `terminal_sessions` row, and includes the user's text in the launch command when resume metadata is available. Later sends that land after a resume flight has started are serialized through the agent CLI input protocol: line clear, bracketed paste envelope, chunked 64-byte writes with 5 ms inter-chunk delay, then carriage return with a provider-specific submit delay. Returns `PtySendToSessionResult` (`{ ptyId, sessionId, pid, session, resumed, reusedExistingRuntime }`). |
 | `ade.pty.write` | write bytes to PTY |
@@ -688,29 +688,29 @@ PTY:
 | `ade.pty.data` (event) | stream stdout/stderr to the renderer |
 | `ade.pty.exit` (event) | final exit code |
 
-Chat-owned terminals (`ade.terminal.*` — used by the chat terminal drawer, the App Control panel, the TUI `TerminalPane`, and the headless `ade terminal` / `ade app-control` CLI commands):
+Attached terminals (`ade.terminal.*` — used by the chat/CLI terminal panel, the App Control panel, the TUI `TerminalPane`, and the headless `ade terminal` / `ade app-control` CLI commands):
 
 | Channel | Purpose |
 |---|---|
-| `ade.terminal.list` | list `ChatTerminalSession[]` (filterable by `chatSessionId` and/or `laneId`). Rich rows: `toolType`, `goal`, `resumeCommand`, `resumeMetadata`, `lastOutputPreview`, `summary`, status / runtime state. Chat-toolType sessions are filtered out so the surface only lists shells and tracked agent CLI terminals. |
-| `ade.terminal.read` | tail scrollback by explicit `terminalId` *or* by `chatSessionId`. Returns `{ terminalId, data, nextSince }` for incremental polling. |
+| `ade.terminal.list` | list `ChatTerminalSession[]` (filterable by owner `chatSessionId` and/or `laneId`). Rich rows: `toolType`, `goal`, `resumeCommand`, `resumeMetadata`, `lastOutputPreview`, `summary`, status / runtime state. Chat-toolType sessions are filtered out so the surface only lists shells and tracked agent CLI terminals. |
+| `ade.terminal.read` | tail scrollback by explicit `terminalId` *or* by owner `chatSessionId`. Returns `{ terminalId, data, nextSince }` for incremental polling. |
 | `ade.terminal.preview` | serialized buffer snapshot for the TUI/mobile renderers. Each live PTY mirrors output into an `@xterm/headless` Terminal + `SerializeAddon` and debounce-writes a JSON file under `.ade/cache/terminal-snapshots/`. The preview call flushes the in-flight write, reads the snapshot (`TerminalSerializedSnapshot` with serialized scrollback, visible-row cells, cursor / viewport / buffer-type metadata), and falls back to a transcript tail when no snapshot exists yet. |
-| `ade.terminal.write` | write bytes to a terminal (by `terminalId`, `ptyId`, or `chatSessionId`). |
-| `ade.terminal.resize` | resize the live PTY (cols, rows) by `terminalId`, `ptyId`, or `chatSessionId`. Clamps dims and rebroadcasts the new size to the snapshot mirror. |
+| `ade.terminal.write` | write bytes to a terminal (by `terminalId`, `ptyId`, or owner `chatSessionId`). |
+| `ade.terminal.resize` | resize the live PTY (cols, rows) by `terminalId`, `ptyId`, or owner `chatSessionId`. Clamps dims and rebroadcasts the new size to the snapshot mirror. |
 | `ade.terminal.signal` | deliver `SIGINT` / `SIGTERM` / `SIGKILL` to the resolved terminal. |
 | `ade.terminal.activeForChat` | resolve the active `ChatTerminalSession` for a given `chatSessionId`. |
 
 `ptyService` keeps two in-memory maps to back this surface:
-`terminalChatSessions` (terminalId → chatSessionId) and
-`activeTerminalByChatSession` (chatSessionId → terminalId). Disposing
+`terminalChatSessions` (terminalId → owner session id) and
+`activeTerminalByChatSession` (owner session id → terminalId). Disposing
 the active terminal automatically promotes the most recently created
 sibling, so `ade terminal read --chat-session <id>` always resolves a
-sensible target for in-chat agents. Every PTY launched through
+sensible target for attached-session agents. Every PTY launched through
 `ptyService.create` runs through `withAdeTerminalContextEnv` which
 exports `ADE_PROJECT_ROOT`, `ADE_LANE_ID`, and (when the PTY is
-chat-owned) `ADE_CHAT_SESSION_ID` into the spawn env — that's how a
+session-owned) `ADE_CHAT_SESSION_ID` into the spawn env — that's how a
 plain shell that the user types `ade --socket terminal read --chat-session
-"$ADE_CHAT_SESSION_ID" --text` into will resolve to the parent chat's
+"$ADE_CHAT_SESSION_ID" --text` into will resolve to the owning session's
 terminal even though no agent runtime spawned it. The headless ADE
 runtime and agent chat runtime both layer the same identity envs
 (plus `ADE_WORKSPACE_ROOT`) on top through `buildAgentRuntimeEnv`.

--- a/docs/features/terminals-and-sessions/ui-surfaces.md
+++ b/docs/features/terminals-and-sessions/ui-surfaces.md
@@ -10,10 +10,13 @@ Top-level page for the Work tab. Wraps two panes with `PaneTilingLayout`:
 
 - `sessions` pane (default 24%, min 15%) → `SessionListPane`
 - `view` pane (default 76%, min 40%) → `WorkViewArea` plus the right-edge
-  `WorkSidebar` when `workSidebarOpen` is true and `viewMode !== "grid"`.
+  `WorkSidebar` when `workSidebarOpen` is true.
   The view + sidebar share the row via a flex container with a draggable
   column separator; the sidebar width is persisted as
   `workSidebarWidthPct` (clamped 26–55%).
+  The sidebar includes the Terminal tab, which renders the same
+  attached-terminal surface for chat sessions and running tracked agent CLI
+  sessions.
 
 Pulls all session state through `useWorkSessions()` and renders two
 globally-positioned overlays:
@@ -35,6 +38,9 @@ disabled message no longer appears when a draft is active. The page
 also determines PTY context insertability through
 `isPtyContextInsertableToolType`, which covers all tracked agent CLI
 tool types: `claude`, `codex`, `cursor-cli`, `droid`, and `opencode`.
+The Terminal tab uses the same active `contextTarget` owner id, so `chat`
+targets attach to the chat session and `pty` targets attach to the running
+CLI session id.
 
 The same page is the subscriber for `ade:work:select-session`, the
 renderer event dispatched by orchestration "Open chat" buttons. The
@@ -203,6 +209,9 @@ Branches on `session.toolType`:
 
 - chat tool types → `AgentChatPane` for the matching chat session
 - PTY sessions → `TerminalView` wired to the session's `ptyId`
+- running tracked agent CLI sessions add the Terminal button in their work
+  header, opening the Work sidebar's Terminal tab with that CLI session as
+  the owner
 
 When a tile is suspended (grid layout where the tile is not visible),
 it renders a static preview card instead of mounting the terminal.


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstart-skill-ade-cli-sesisons-6a35eefa num=665 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstart-skill-ade-cli-sesisons-6a35eefa&amp;pr=665">ade/start-skill-ade-cli-sesisons-6a35eefa branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=665">PR #665</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the Work tab's terminal infrastructure so that tracked agent CLI sessions (codex, claude, etc.) can attach shell terminals through a new "Terminal" sidebar panel, mirroring the terminal drawer already available inside chat sessions.

- **PTY env propagation**: `withAdeTerminalContextEnv` now accepts an `ownerSessionId` for tracked CLI tool types, setting `ADE_CHAT_SESSION_ID` to the CLI session's own ID so that child shells spawned inside that session automatically inherit the correct owner identity for terminal listing.
- **Work sidebar Terminal tab**: A new `"terminal"` tab is added to `WorkSidebarTab`; `WorkSidebar` renders `ChatTerminalDrawer` in `"panel"` variant for both chat and running CLI context targets, with appropriate empty-state messages for ended sessions or no active owner.
- **`AgentChatPane` dual-mode toggle**: The component now accepts `onToggleTerminalPane` / `onOpenTerminalPane` / `terminalPaneOpen` props so that, when hosted inside the Work tab, the terminal toggle routes to the Work sidebar instead of the inline drawer; without those props the original drawer behaviour is preserved.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is well-scoped and additive, with new tests covering the key paths.

The implementation correctly threads terminal ownership through PTY env vars, the Work sidebar tab, and the AgentChatPane dual-mode toggle. The one gap is that terminal reveal requests (auto-focus of a specific tab) are not forwarded to the Work sidebar's ChatTerminalDrawer, so in Work mode the panel opens but doesn't pinpoint the newly relevant terminal. All other logic paths—session ownership, empty-state messaging, PTY env propagation, panel vs. drawer variant branching—look correct and are backed by tests.

apps/desktop/src/renderer/components/chat/AgentChatPane.tsx — the reveal-request gap lives in the revealChatTerminal callback and the terminalRightPaneOpen gate.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/pty/ptyService.ts | Adds `ownerSessionId` to `withAdeTerminalContextEnv` so tracked CLI sessions export their own ID as `ADE_CHAT_SESSION_ID`, letting child shells inherit owner identity. Logic is correct: `chatSessionId ?? ownerSessionId ?? null` preserves existing behaviour when an explicit chatSessionId is provided. |
| apps/desktop/src/main/services/pty/ptyService.test.ts | New test verifies tracked CLI sessions (codex) set ADE_CHAT_SESSION_ID to their own sessionId in the spawn env, correctly covering the new ownerSessionId propagation path. |
| apps/desktop/src/renderer/components/terminals/WorkSidebar.tsx | Adds "terminal" tab with ChatTerminalDrawer (panel variant). terminalOwnerSessionId is correctly derived from contextTarget for both chat and pty kinds. Empty-state messaging correctly distinguishes ended sessions from "no active session" cases. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Refactors terminal toggle/reveal logic to support an external Work sidebar panel. The hasExternalTerminalPane guard correctly prevents the local drawer from interfering with the sidebar pane, but reveal requests are not forwarded to the sidebar's ChatTerminalDrawer. |
| apps/desktop/src/renderer/components/chat/ChatTerminalDrawer.tsx | Adds "panel" variant that disables the horizontal resize handle and fills its container height. Styling branches (h-8 vs h-6 tab row, h-7 vs h-6 new-terminal button) are clean and correctly gated on isPanel. |
| apps/desktop/src/renderer/components/terminals/TerminalsPage.tsx | Introduces toggleTerminalPane/openTerminalPane callbacks that wire the Work sidebar terminal tab to session header buttons. terminalPaneOpen is slightly redundant in the workViewArea deps (work.workSidebarOpen and work.workSidebarTab are already listed), but harmless. |
| apps/desktop/src/renderer/components/terminals/CliSessionWorkSurfaceHeader.tsx | Adds SessionTerminalButton for the CLI session work surface header with correct aria-label and aria-pressed semantics. Button is disabled when onToggleTerminalPane is absent. |
| apps/desktop/src/renderer/state/appStore.ts | Adds "terminal" to WorkSidebarTab union and normalizeWorkSidebarTab, correctly handled as a new valid persisted value with "git" retained as the default fallback. |
| apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx | Threads terminal pane props (terminalPaneOpen, onToggleTerminalPane, onOpenTerminalPane) down to SessionSurface and through to AgentChatPane/CliSessionWorkSurfaceHeader correctly. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Terminal toggle] --> B{hasExternalTerminalPane?}
    B -- Yes, Work mode --> C[onToggleTerminalPane / onOpenTerminalPane]
    C --> D[TerminalsPage: toggleTerminalPane]
    D --> E{sidebar open on terminal tab?}
    E -- Yes --> F[setWorkSidebarOpen false]
    E -- No --> G[setWorkSidebarTab terminal]
    G --> H[WorkSidebar renders Terminal tab]
    H --> I{contextTarget kind?}
    I -- chat --> J[ChatTerminalDrawer panel\nchatSessionId = chat session id]
    I -- pty running CLI --> K[ChatTerminalDrawer panel\nchatSessionId = CLI session id]
    I -- null / ended --> L[TerminalPanelEmpty\nwith contextual message]
    B -- No, standalone chat --> M[setTerminalDrawerOpen true]
    M --> N[terminalRightPaneOpen = true]
    N --> O[ChatTerminalDrawer panel\nin AgentChatPane right pane]

    subgraph PTY env propagation
      P[ptyService.create - tracked CLI toolType]
      P --> Q[ownerSessionId = sessionId]
      Q --> R[ADE_CHAT_SESSION_ID = cliSessionId in spawn env]
      R --> S[Child shells inherit owner id\nAppear in terminal.list for CLI session]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User clicks Terminal toggle] --> B{hasExternalTerminalPane?}
    B -- Yes, Work mode --> C[onToggleTerminalPane / onOpenTerminalPane]
    C --> D[TerminalsPage: toggleTerminalPane]
    D --> E{sidebar open on terminal tab?}
    E -- Yes --> F[setWorkSidebarOpen false]
    E -- No --> G[setWorkSidebarTab terminal]
    G --> H[WorkSidebar renders Terminal tab]
    H --> I{contextTarget kind?}
    I -- chat --> J[ChatTerminalDrawer panel\nchatSessionId = chat session id]
    I -- pty running CLI --> K[ChatTerminalDrawer panel\nchatSessionId = CLI session id]
    I -- null / ended --> L[TerminalPanelEmpty\nwith contextual message]
    B -- No, standalone chat --> M[setTerminalDrawerOpen true]
    M --> N[terminalRightPaneOpen = true]
    N --> O[ChatTerminalDrawer panel\nin AgentChatPane right pane]

    subgraph PTY env propagation
      P[ptyService.create - tracked CLI toolType]
      P --> Q[ownerSessionId = sessionId]
      Q --> R[ADE_CHAT_SESSION_ID = cliSessionId in spawn env]
      R --> S[Child shells inherit owner id\nAppear in terminal.list for CLI session]
    end
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Fcomponents%2Fchat%2FAgentChatPane.tsx%3A3164-3169%0A**Specific%20terminal%20tab%20not%20auto-focused%20when%20using%20Work%20sidebar%20panel**%0A%0A%60revealChatTerminal%60%20skips%20%60setTerminalRevealRequest%60%20when%20%60hasExternalTerminalPane%60%20is%20true%2C%20so%20when%20an%20event%20triggers%20a%20reveal%20%28e.g.%20App%20Control%20attaching%20a%20terminal%2C%20or%20a%20session%20change%20surfacing%20a%20new%20PTY%29%2C%20the%20Work%20sidebar%20terminal%20panel%20opens%20but%20doesn't%20focus%20the%20specified%20tab.%20The%20%60ChatTerminalDrawer%60%20inside%20%60WorkSidebar%60%20never%20receives%20a%20%60revealRequest%60%2C%20so%20if%20multiple%20terminals%20exist%20the%20user%20sees%20the%20last-active%20one%20rather%20than%20the%20newly%20relevant%20one.%0A%0A&repo=arul28%2Fade&pr=665&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/renderer/components/chat/AgentChatPane.tsx:3164-3169
**Specific terminal tab not auto-focused when using Work sidebar panel**

`revealChatTerminal` skips `setTerminalRevealRequest` when `hasExternalTerminalPane` is true, so when an event triggers a reveal (e.g. App Control attaching a terminal, or a session change surfacing a new PTY), the Work sidebar terminal panel opens but doesn't focus the specified tab. The `ChatTerminalDrawer` inside `WorkSidebar` never receives a `revealRequest`, so if multiple terminals exist the user sees the last-active one rather than the newly relevant one.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add CLI session terminal panel"](https://github.com/arul28/ade/commit/ec644b8e67b3c60e615d114eea57875fe5a22dae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40555489)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->