### PR TITLE
Ended Cli Sidebar Button

### DIFF
--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.test.tsx
@@ -72,10 +72,45 @@ vi.mock("./useWorkLaneContextMenu", () => ({
 vi.mock("./CliSessionWorkSurfaceHeader", () => ({
   CliSessionWorkSurfaceHeader: ({
     session,
+    onToggleSessionsPane,
+    sessionsPaneCollapsed = false,
+    sessionsPaneCount,
+    onToggleToolsPane,
+    toolsPaneOpen = false,
   }: {
     session: TerminalSessionSummary;
+    onToggleSessionsPane?: () => void;
+    sessionsPaneCollapsed?: boolean;
+    sessionsPaneCount?: number;
+    onToggleToolsPane?: () => void;
+    toolsPaneOpen?: boolean;
   }) => (
-    <div data-testid="work-cli-session-header" data-session-id={session.id} />
+    <div
+      data-testid="work-cli-session-header"
+      data-session-id={session.id}
+      data-sessions-pane-collapsed={String(sessionsPaneCollapsed)}
+      data-sessions-pane-count={String(sessionsPaneCount ?? "")}
+      data-tools-pane-open={String(toolsPaneOpen)}
+    >
+      {onToggleSessionsPane ? (
+        <button
+          type="button"
+          aria-label="Toggle sessions pane"
+          onClick={onToggleSessionsPane}
+        >
+          Sessions
+        </button>
+      ) : null}
+      {onToggleToolsPane ? (
+        <button
+          type="button"
+          aria-label="Toggle tools pane"
+          onClick={onToggleToolsPane}
+        >
+          Tools
+        </button>
+      ) : null}
+    </div>
   ),
   CliSurfaceTrailingActions: () => null,
   GridTileSessionHeaderActions: ({ session }: { session: TerminalSessionSummary }) => (
@@ -528,6 +563,56 @@ describe("WorkViewArea", () => {
     expect(terminalPreviewMock).toHaveBeenCalledWith({ terminalId: "session-1", maxBytes: 160_000 });
     expect(slashCommandsMock).toHaveBeenCalledWith({ laneId: "lane-1", provider: "claude" });
     expect(modelsMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the Work sidebar toggles available on closed agent CLI sessions", () => {
+    const onToggleSessionsPane = vi.fn();
+    const onToggleWorkSidebar = vi.fn();
+    const session = {
+      ...makeSession(),
+      toolType: "codex" as const,
+      resumeCommand: "codex resume thread-1",
+      resumeMetadata: {
+        provider: "codex" as const,
+        targetKind: "thread" as const,
+        targetId: "thread-1",
+        launch: { permissionMode: "plan" as const },
+      },
+    };
+
+    const view = render(
+      <WorkViewArea
+        lanes={[]}
+        sessions={[session]}
+        visibleSessions={[session]}
+        activeItemId={session.id}
+        draftKind="chat"
+        onSelectItem={() => {}}
+        onCloseItem={() => {}}
+        onOpenChatSession={() => {}}
+        onLaunchPtySession={resolvePtyLaunch}
+        onShowDraftKind={() => {}}
+        closingPtyIds={new Set()}
+        sessionsPaneCollapsed
+        sessionsPaneListCount={6}
+        onToggleSessionsPane={onToggleSessionsPane}
+        workSidebarOpen
+        onToggleWorkSidebar={onToggleWorkSidebar}
+      />,
+    );
+    const local = within(view.container);
+    const header = local.getByTestId("work-cli-session-header");
+
+    expect(header.getAttribute("data-session-id")).toBe("session-1");
+    expect(header.getAttribute("data-sessions-pane-collapsed")).toBe("true");
+    expect(header.getAttribute("data-sessions-pane-count")).toBe("6");
+    expect(header.getAttribute("data-tools-pane-open")).toBe("true");
+
+    fireEvent.click(local.getByRole("button", { name: "Toggle sessions pane" }));
+    fireEvent.click(local.getByRole("button", { name: "Toggle tools pane" }));
+
+    expect(onToggleSessionsPane).toHaveBeenCalledTimes(1);
+    expect(onToggleWorkSidebar).toHaveBeenCalledTimes(1);
   });
 
   it("does not hydrate hidden tab session previews or continuation commands", async () => {

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
@@ -485,6 +485,11 @@ function ClosedCliSessionSurface({
   onContextMenu,
   onContinue,
   onResume,
+  onToggleSessionsPane,
+  sessionsPaneCollapsed,
+  sessionsPaneCount,
+  onToggleToolsPane,
+  toolsPaneOpen,
 }: {
   session: TerminalSessionSummary;
   lanes: LaneSummary[];
@@ -493,6 +498,11 @@ function ClosedCliSessionSurface({
   onContextMenu?: (session: TerminalSessionSummary, event: React.MouseEvent<HTMLElement>) => void;
   onContinue?: (session: TerminalSessionSummary, text: string) => Promise<void> | void;
   onResume?: (session: TerminalSessionSummary) => Promise<void> | void;
+  onToggleSessionsPane?: () => void;
+  sessionsPaneCollapsed?: boolean;
+  sessionsPaneCount?: number;
+  onToggleToolsPane?: () => void;
+  toolsPaneOpen?: boolean;
 }) {
   const [preview, setPreview] = useState<ChatTerminalPreviewResult | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -553,6 +563,11 @@ function ClosedCliSessionSurface({
           lanes={lanes}
           onInfoClick={onInfoClick}
           onContextMenu={onContextMenu}
+          onToggleSessionsPane={onToggleSessionsPane}
+          sessionsPaneCollapsed={sessionsPaneCollapsed}
+          sessionsPaneCount={sessionsPaneCount}
+          onToggleToolsPane={onToggleToolsPane}
+          toolsPaneOpen={toolsPaneOpen}
         />
       ) : null}
       <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden px-4 py-3">
@@ -722,6 +737,11 @@ function SessionSurface({
         onContextMenu={onContextMenu}
         onContinue={onContinueCliSession}
         onResume={onResumeCliSession}
+        onToggleSessionsPane={onToggleSessionsPane}
+        sessionsPaneCollapsed={sessionsPaneCollapsed}
+        sessionsPaneCount={sessionsPaneCount}
+        onToggleToolsPane={onToggleToolsPane}
+        toolsPaneOpen={toolsPaneOpen}
       />
     );
   }

--- a/docs/features/terminals-and-sessions/ui-surfaces.md
+++ b/docs/features/terminals-and-sessions/ui-surfaces.md
@@ -238,7 +238,10 @@ when the snapshot contains TUI frame characters (`╭`, `─`, etc.) or
 enough styled cells to be obviously a TUI redraw, the snapshot wins so
 the user sees the Claude/Codex final screen instead of a flattened
 transcript with the alt-screen escape codes visible. Ended tracked CLI
-surfaces expose two relaunch paths: **Resume** calls
+surfaces keep the same `WorkSurfaceHeader` controls as live CLI and chat
+surfaces, including the far-left sessions-pane toggle and the far-right
+Tools toggle, so a collapsed session sidebar is always recoverable. They
+also expose two relaunch paths: **Resume** calls
 `ade.pty.resumeSession` and opens the provider TUI without sending a
 prompt, while the continuation composer calls `ade.pty.sendToSession`
 and sends the follow-up as part of the first resume launch when


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstart-skill-work-tab-cli-16c18a2a num=666 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstart-skill-work-tab-cli-16c18a2a&amp;pr=666">ade/start-skill-work-tab-cli-16c18a2a branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=666">PR #666</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the session and tools pane toggle controls for closed agent CLI sessions.
  * Improved sidebar behavior so the available pane controls stay responsive when viewing a closed session.
  * Added coverage to ensure the session and tools toggle actions continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores sidebar controls on ended agent CLI sessions. The main changes are:

- Forwards sessions-pane and tools-pane toggle props into `ClosedCliSessionSurface`.
- Renders the existing CLI session header controls on closed agent CLI surfaces.
- Adds a test for toggling the sessions pane and Work tools sidebar from a closed CLI session.
- Updates the terminal UI surfaces documentation for ended tracked CLI sessions.

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to restoring existing controls on closed CLI session surfaces and includes targeted coverage for the affected toggles.

The implementation forwards existing props into the closed-session component path, reuses established header controls, and adds a focused test for the restored interactions.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The adapted base test was run and failed because the closed CLI header did not include the sessions-pane collapsed/count props.
- The committed head test was run and passed, including assertions for both the sessions-pane toggle and the Tools toggle callback.

<a href="https://app.greptile.com/trex/runs/12682104/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix closed CLI session sidebar toggle"](https://github.com/arul28/ade/commit/d8b2da2e9e106f5f5153b5a0d6269a67144fb253) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40626288)</sub>

<!-- /greptile_comment -->