### PR TITLE
Ios Sim Inspect Stays Active

### DIFF
--- a/apps/desktop/src/renderer/components/chat/ChatIosSimulatorPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatIosSimulatorPanel.test.tsx
@@ -837,6 +837,96 @@ describe("ChatIosSimulatorPanel", () => {
     expect(api.renderPreview).not.toHaveBeenCalled();
   });
 
+  it("keeps the inspect hover target live after attaching simulator context", async () => {
+    vi.stubGlobal("PointerEvent", MouseEvent);
+    vi.stubGlobal("Image", class {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      set src(_value: string) {
+        queueMicrotask(() => this.onerror?.());
+      }
+    });
+    const settingsElement: IosScreenElement = {
+      ...inspectElement,
+      id: "element-2",
+      label: "Settings",
+      identifier: "settingsButton",
+      componentId: "SettingsView/SettingsButton",
+      sourceFile: "SettingsView.swift",
+      sourceLine: 24,
+      frame: { x: 190, y: 190, width: 60, height: 40 },
+      pixelFrame: { x: 570, y: 570, width: 180, height: 120 },
+    };
+    const onAddContext = vi.fn();
+    const { api } = installIosSimulatorApi({
+      screenElements: [inspectElement, settingsElement],
+      previewTargets: [previewTarget],
+    });
+    api.selectPoint.mockImplementation(async (args: { x: number; y: number }) => {
+      const element = args.x >= settingsElement.pixelFrame.x
+        ? settingsElement
+        : inspectElement;
+      return {
+        item: {
+          kind: "ios_simulator_target",
+          id: `ios:${element.id}`,
+          deviceUdid: device.udid,
+          label: element.label,
+          source: element.source,
+          screenshotDataUrl: null,
+          metadata: {},
+        },
+        source: element.source,
+      };
+    });
+
+    render(
+      <ChatIosSimulatorPanel
+        sessionId="chat-1"
+        projectRoot="/tmp/project"
+        onAddContext={onAddContext}
+      />,
+    );
+
+    await waitFor(() => expect(document.querySelector("video")).toBeTruthy());
+    fireEvent.click(screen.getByRole("button", { name: "Inspect" }));
+    const image = await screen.findByAltText("iOS Simulator snapshot") as HTMLImageElement;
+    const imageRect = {
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 393,
+      bottom: 852,
+      width: 393,
+      height: 852,
+      toJSON: () => ({}),
+    } as DOMRect;
+    image.getBoundingClientRect = () => imageRect;
+    if (image.parentElement) {
+      image.parentElement.getBoundingClientRect = () => imageRect;
+    }
+
+    fireEvent.pointerDown(image, { clientX: 50, clientY: 40 });
+    await screen.findByText(/Added selected UI context/);
+    expect(onAddContext).toHaveBeenCalledWith(expect.objectContaining({ label: "Continue" }));
+
+    fireEvent.pointerMove(image, { clientX: 210, clientY: 210 });
+    expect(await screen.findByText("Settings")).toBeTruthy();
+
+    fireEvent.pointerDown(image, { clientX: 210, clientY: 210 });
+
+    await waitFor(() => {
+      expect(api.selectPoint).toHaveBeenLastCalledWith({
+        deviceUdid: device.udid,
+        projectRoot: "/tmp/project",
+        x: 660,
+        y: 630,
+      });
+      expect(onAddContext).toHaveBeenLastCalledWith(expect.objectContaining({ label: "Settings" }));
+    });
+  });
+
   it("treats Swift #fileID source paths as the same Preview Lab match", async () => {
     vi.stubGlobal("PointerEvent", MouseEvent);
     vi.stubGlobal("Image", class {

--- a/apps/desktop/src/renderer/components/chat/ChatIosSimulatorPanel.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatIosSimulatorPanel.tsx
@@ -2354,7 +2354,7 @@ export function ChatIosSimulatorPanel({
       ? `Snapshot ready with ${snapshotElementCount} selectable item${snapshotElementCount === 1 ? "" : "s"}.`
       : "Snapshot ready with no selectable elements. Click a point or use Screenshot to attach visual context."
     : null;
-  const activeInspectElement = selectedElement ?? hoveredElement;
+  const activeInspectElement = hoveredElement ?? selectedElement;
   const activeInspectSource = activeInspectElement?.source ?? null;
   let previewModeHint: string | null = null;
   if (mode === "preview") {


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fteh-ade-ios-sim-thing-344ce49a num=667 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fteh-ade-ios-sim-thing-344ce49a&amp;pr=667">ade/teh-ade-ios-sim-thing-344ce49a branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=667">PR #667</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inspect-hover behavior in the desktop chat simulator so the highlighted element stays aligned with what the pointer is currently over.
  * Updated selection behavior in the simulator overlay to prefer the hovered element when both hover and selection are present.
  * Added coverage for switching hover targets after simulator context is attached, helping prevent regressions in inspect interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in the iOS Simulator inspect overlay where the highlight box stayed locked to the most recently clicked element instead of following the pointer as the user hovered over different elements. The fix is a single one-line change that reverses operator precedence between `hoveredElement` and `selectedElement`.

- **Core change** (`ChatIosSimulatorPanel.tsx` line 2357): flips `selectedElement ?? hoveredElement` to `hoveredElement ?? selectedElement`, so the inspect overlay follows the live hover target and falls back to the selected element only when the pointer leaves the snapshot area.
- **New test** (`ChatIosSimulatorPanel.test.tsx`): adds a scenario that attaches a simulator context, clicks one element, then moves the pointer to a different element and verifies the overlay label updates and the subsequent click targets the new element correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is isolated to a single derived-value computation, pointer-leave events still clear hoveredElement so the fallback to selectedElement works correctly, and the new test directly exercises the fixed scenario end-to-end.

The one-line swap is mechanically correct: hoveredElement is already set to null on every onPointerLeave handler, so the fallback to selectedElement is preserved when the cursor leaves the snapshot area. The alt-click parent-selection path in handleInspectClick continues to reference selectedElement directly and is unaffected. The new test confirms both the overlay label update and the pixel coordinates sent to selectPoint after switching hover targets.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/chat/ChatIosSimulatorPanel.tsx | Single-line operator swap — `hoveredElement ?? selectedElement` replaces `selectedElement ?? hoveredElement` — so the inspect highlight follows the pointer while hovering and falls back to the last clicked element when the pointer leaves the surface. |
| apps/desktop/src/renderer/components/chat/ChatIosSimulatorPanel.test.tsx | Adds a new integration-style test that covers the hover-then-click flow after simulator context is attached; verifies both the overlay label update and the correct pixel coordinates passed to `selectPoint`. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User moves pointer over snapshot] --> B{hoveredElement set?}
    B -- Yes --> C[activeInspectElement = hoveredElement]
    B -- No: pointer left surface --> D{selectedElement set?}
    D -- Yes --> E[activeInspectElement = selectedElement]
    D -- No --> F[activeInspectElement = null\noverlay hidden]
    C --> G[Overlay highlight + label\nfollows pointer]
    E --> H[Overlay stays on\nlast clicked element]

    A2[User clicks on element] --> I[selectElementAt called\nsets selectedElement]
    I --> J[hoveredElement still set\noverlay continues following pointer]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User moves pointer over snapshot] --> B{hoveredElement set?}
    B -- Yes --> C[activeInspectElement = hoveredElement]
    B -- No: pointer left surface --> D{selectedElement set?}
    D -- Yes --> E[activeInspectElement = selectedElement]
    D -- No --> F[activeInspectElement = null\noverlay hidden]
    C --> G[Overlay highlight + label\nfollows pointer]
    E --> H[Overlay stays on\nlast clicked element]

    A2[User clicks on element] --> I[selectElementAt called\nsets selectedElement]
    I --> J[hoveredElement still set\noverlay continues following pointer]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Fix iOS simulator inspect hover after at..."](https://github.com/arul28/ade/commit/a1961e689f615eed05d7f59efeed5106063cd9de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40651133)</sub>

<!-- /greptile_comment -->