### PR TITLE
Iphone 17 Handoff Failure

### DIFF
--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -3198,6 +3198,7 @@ describe("createAgentChatService", () => {
         sourceRow.summary = "Fix the iPhone 17 simulator chat layout handoff.";
       }
 
+      const handoffStart = mockState.codexRequestPayloads.length;
       const result = await service.handoffSession({
         sourceSessionId: source.id,
         targetModelId: "openai/gpt-5.5",
@@ -3206,18 +3207,24 @@ describe("createAgentChatService", () => {
       expect(result.session.provider).toBe("codex");
       expect(mockState.sessions.get(result.session.id)?.goal).toBe("No Machine State Polish");
 
-      const requestMethods = mockState.codexRequestPayloads.map((payload) => String(payload.method ?? ""));
+      const handoffPayloads = mockState.codexRequestPayloads.slice(handoffStart);
+      const requestMethods = handoffPayloads.map((payload) => String(payload.method ?? ""));
       const turnStartIndex = requestMethods.indexOf("turn/start");
       const goalSetIndex = requestMethods.indexOf("thread/goal/set");
       expect(turnStartIndex).toBeGreaterThanOrEqual(0);
-      expect(goalSetIndex === -1 || goalSetIndex > turnStartIndex).toBe(true);
+      expect(goalSetIndex).toBeGreaterThan(turnStartIndex);
 
-      const turnStartRequest = mockState.codexRequestPayloads[turnStartIndex] as {
+      const turnStartRequest = handoffPayloads[turnStartIndex] as {
         params?: { input?: Array<{ text?: unknown }> };
       };
       const inputText = turnStartRequest.params?.input?.map((entry) => String(entry.text ?? "")).join("\n") ?? "";
       expect(inputText).toContain("This message was injected automatically by ADE during a chat handoff.");
       expect(inputText).toContain("No Machine State Polish");
+
+      const goalSetRequest = handoffPayloads[goalSetIndex] as {
+        params?: { objective?: unknown };
+      };
+      expect(goalSetRequest.params?.objective).toBe("No Machine State Polish");
     });
 
     it("uses the selected Claude handoff permission instead of the source interaction mode", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -3227,6 +3227,37 @@ describe("createAgentChatService", () => {
       expect(goalSetRequest.params?.objective).toBe("No Machine State Polish");
     });
 
+    it("keeps Codex brief handoff successful when deferred goal seeding throws", async () => {
+      const { service, sessionService } = createService();
+      const source = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.5",
+        modelId: "openai/gpt-5.5",
+      });
+      sessionService.updateMeta({
+        sessionId: source.id,
+        goal: "No Machine State Polish",
+      });
+      mockState.codexResponseOverrides.set("thread/goal/set", () => {
+        throw new Error("goal seed unavailable");
+      });
+
+      const handoffStart = mockState.codexRequestPayloads.length;
+      const result = await service.handoffSession({
+        sourceSessionId: source.id,
+        targetModelId: "openai/gpt-5.5",
+      });
+
+      expect(result.session.provider).toBe("codex");
+      expect(mockState.sessions.get(result.session.id)?.goal).toBe("No Machine State Polish");
+      const handoffMethods = mockState.codexRequestPayloads
+        .slice(handoffStart)
+        .map((payload) => String(payload.method ?? ""));
+      expect(handoffMethods).toContain("turn/start");
+      expect(handoffMethods).toContain("thread/goal/set");
+    });
+
     it("uses the selected Claude handoff permission instead of the source interaction mode", async () => {
       const send = vi.fn().mockResolvedValue(undefined);
       const setPermissionMode = vi.fn().mockResolvedValue(undefined);

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -3181,6 +3181,45 @@ describe("createAgentChatService", () => {
       }, { timeout: 2000, interval: 50 });
     });
 
+    it("sends Codex brief handoff text before syncing the inherited goal", async () => {
+      const { service, sessionService } = createService();
+      const source = await service.createSession({
+        laneId: "lane-1",
+        provider: "codex",
+        model: "gpt-5.5",
+        modelId: "openai/gpt-5.5",
+      });
+      sessionService.updateMeta({
+        sessionId: source.id,
+        goal: "No Machine State Polish",
+      });
+      const sourceRow = mockState.sessions.get(source.id);
+      if (sourceRow) {
+        sourceRow.summary = "Fix the iPhone 17 simulator chat layout handoff.";
+      }
+
+      const result = await service.handoffSession({
+        sourceSessionId: source.id,
+        targetModelId: "openai/gpt-5.5",
+      });
+
+      expect(result.session.provider).toBe("codex");
+      expect(mockState.sessions.get(result.session.id)?.goal).toBe("No Machine State Polish");
+
+      const requestMethods = mockState.codexRequestPayloads.map((payload) => String(payload.method ?? ""));
+      const turnStartIndex = requestMethods.indexOf("turn/start");
+      const goalSetIndex = requestMethods.indexOf("thread/goal/set");
+      expect(turnStartIndex).toBeGreaterThanOrEqual(0);
+      expect(goalSetIndex === -1 || goalSetIndex > turnStartIndex).toBe(true);
+
+      const turnStartRequest = mockState.codexRequestPayloads[turnStartIndex] as {
+        params?: { input?: Array<{ text?: unknown }> };
+      };
+      const inputText = turnStartRequest.params?.input?.map((entry) => String(entry.text ?? "")).join("\n") ?? "";
+      expect(inputText).toContain("This message was injected automatically by ADE during a chat handoff.");
+      expect(inputText).toContain("No Machine State Polish");
+    });
+
     it("uses the selected Claude handoff permission instead of the source interaction mode", async () => {
       const send = vi.fn().mockResolvedValue(undefined);
       const setPermissionMode = vi.fn().mockResolvedValue(undefined);

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -20001,6 +20001,9 @@ export function createAgentChatService(args: {
       } finally {
         if (deferInheritedGoalUntilHandoffDispatch) {
           applyInheritedGoal();
+          if (createdManaged.runtime?.kind === "codex") {
+            await seedCodexThreadGoalFromSessionGoal(createdManaged, createdManaged.runtime);
+          }
           persistChatState(createdManaged);
         }
       }

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -19970,27 +19970,40 @@ export function createAgentChatService(args: {
     const inheritedGoal = trimLine(sourceSession.goal)
       ?? trimLine(sourceSession.summary)
       ?? trimLine(sourceSession.title);
-    if (inheritedGoal) {
+    const applyInheritedGoal = (): void => {
+      if (!inheritedGoal) return;
       createdManaged.session.goal = inheritedGoal;
       sessionService.updateMeta({
         sessionId: created.id,
         goal: inheritedGoal,
       });
+    };
+    const deferInheritedGoalUntilHandoffDispatch =
+      handoffMode === "brief" && createdManaged.session.provider === "codex";
+    if (!deferInheritedGoalUntilHandoffDispatch) {
+      applyInheritedGoal();
     }
     persistChatState(createdManaged);
 
     if (handoffMode === "brief") {
-      await sendMessage({
-        sessionId: created.id,
-        text: buildHandoffPrompt(brief),
-        displayText: "Chat handoff from previous session",
-        metadata: { kind: "handoff", hideFullPrompt: true },
-        reasoningEffort: targetReasoningEffort,
-        executionMode: createdManaged.session.executionMode ?? null,
-        interactionMode: createdManaged.session.interactionMode ?? null,
-      }, {
-        awaitDispatch: true,
-      });
+      try {
+        await sendMessage({
+          sessionId: created.id,
+          text: buildHandoffPrompt(brief),
+          displayText: "Chat handoff from previous session",
+          metadata: { kind: "handoff", hideFullPrompt: true },
+          reasoningEffort: targetReasoningEffort,
+          executionMode: createdManaged.session.executionMode ?? null,
+          interactionMode: createdManaged.session.interactionMode ?? null,
+        }, {
+          awaitDispatch: true,
+        });
+      } finally {
+        if (deferInheritedGoalUntilHandoffDispatch) {
+          applyInheritedGoal();
+          persistChatState(createdManaged);
+        }
+      }
     }
 
     return {

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -20001,10 +20001,18 @@ export function createAgentChatService(args: {
       } finally {
         if (deferInheritedGoalUntilHandoffDispatch) {
           applyInheritedGoal();
-          if (createdManaged.runtime?.kind === "codex") {
-            await seedCodexThreadGoalFromSessionGoal(createdManaged, createdManaged.runtime);
-          }
           persistChatState(createdManaged);
+          if (createdManaged.runtime?.kind === "codex") {
+            try {
+              await seedCodexThreadGoalFromSessionGoal(createdManaged, createdManaged.runtime);
+            } catch (error) {
+              logger.warn("agent_chat.codex_goal_seed_after_handoff_failed", {
+                sessionId: createdManaged.session.id,
+                error: error instanceof Error ? error.message : String(error),
+              });
+              persistChatState(createdManaged);
+            }
+          }
         }
       }
     }

--- a/apps/desktop/src/renderer/components/files/v2/EditorGroup.test.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/EditorGroup.test.tsx
@@ -27,6 +27,7 @@ const registry = {
 } as unknown as MonacoModelRegistry;
 
 const tabId = editorTabId("workspace-1", "src/file.ts");
+const otherLaneTabId = editorTabId("workspace-2", "src/other.ts");
 
 const baseProps: EditorGroupProps = {
   group: {
@@ -106,6 +107,36 @@ describe("EditorGroup", () => {
     render(<EditorGroup {...baseProps} />);
     expect(screen.getByRole("tab", { name: /file\.ts/i })).toBeTruthy();
     expect(screen.getByTestId("viewer-button")).toBeTruthy();
+  });
+
+  it("marks the visible fallback tab active when lane scope hides the stored active tab", () => {
+    render(
+      <EditorGroup
+        {...baseProps}
+        tabScope="lane"
+        group={{
+          ...baseProps.group,
+          activeTabId: otherLaneTabId,
+          tabs: [
+            ...baseProps.group.tabs,
+            {
+              id: otherLaneTabId,
+              workspaceId: "workspace-2",
+              laneId: "lane-2",
+              path: "src/other.ts",
+              title: "other.ts",
+              viewerKind: "code",
+              languageId: "typescript",
+              preview: false,
+              pinned: false,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: /file\.ts/i }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.queryByRole("tab", { name: /other\.ts/i })).toBeNull();
   });
 
   it("does not steal Cmd+S from focused text inputs", () => {

--- a/apps/desktop/src/renderer/components/files/v2/EditorGroup.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/EditorGroup.tsx
@@ -178,7 +178,7 @@ export function EditorGroup(props: EditorGroupProps) {
             <TabButton
               key={tab.id}
               tab={tab}
-              active={tab.id === group.activeTabId}
+              active={tab.id === activeTab?.id}
               dirty={dirtyTabIds.has(tab.id)}
               laneAccent={props.tabScope === "all" ? laneAccentForTab(tab, props.lanes) : undefined}
               showLaneDivider={props.tabScope === "all" && isLaneGroupBoundary(displayTabs, index)}


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fade-contesxt-find-ade-iphone-857bb2df num=673 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fade-contesxt-find-ade-iphone-857bb2df&amp;pr=673">ade/ade-contesxt-find-ade-iphone-857bb2df branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=673">PR #673</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved brief chat handoff behavior so inherited context is applied at the right time for certain providers, helping avoid missing or out-of-order handoff details.
  * Fixed tab highlighting in the file editor so the visible tab is shown as active even when the original active tab is hidden by lane scoping.

* **Tests**
  * Added coverage for chat handoff ordering and editor tab selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two bugs: a Codex handoff ordering issue where the inherited session goal was being applied before the handoff message was dispatched (causing out-of-order context for the provider), and an editor tab highlighting regression where the visible fallback tab wasn't marked active when lane scoping hid the stored active tab.

- **`agentChatService.ts`**: Introduces `deferInheritedGoalUntilHandoffDispatch` for Codex brief handoffs, moving `applyInheritedGoal()`, `persistChatState()`, and `seedCodexThreadGoalFromSessionGoal()` into a `finally` block so they execute only after `sendMessage` dispatches; a nested `try/catch` swallows goal-seed failures with a warning rather than surfacing them to the caller.
- **`EditorGroup.tsx`**: Single-line fix replacing `group.activeTabId` with `activeTab?.id` in the tab-button loop, so the already-computed fallback `activeTab` drives the `aria-selected` highlight instead of the raw stored id.

<h3>Confidence Score: 5/5</h3>

Safe to merge; both fixes are narrowly scoped with corresponding tests, and the deferred goal path is guarded entirely within the Codex brief handoff branch.

The agentChatService change correctly defers goal application and wraps goal-seed failures so they can't abort an otherwise successful handoff. The EditorGroup one-liner is straightforward and well-tested. No unhandled error paths or state divergence risks were found beyond what is already caught and logged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/chat/agentChatService.ts | Defers inherited goal application for Codex brief handoffs until after sendMessage dispatches, using a try/finally block; includes nested try/catch for goal seeding errors with a defensive extra persistChatState call in the catch branch. |
| apps/desktop/src/main/services/chat/agentChatService.test.ts | Adds two targeted tests: one verifying handoff message precedes goal seeding for Codex, and one ensuring a goal-seed failure doesn't abort the handoff. Coverage is well-scoped. |
| apps/desktop/src/renderer/components/files/v2/EditorGroup.tsx | Single-line fix: compares tab id against the computed activeTab (which already has the lane-scoped fallback logic) instead of the raw group.activeTabId, correctly highlighting the fallback tab when the stored active tab is hidden by lane scoping. |
| apps/desktop/src/renderer/components/files/v2/EditorGroup.test.tsx | Adds a test that renders with a cross-lane activeTabId and asserts the visible tab gets aria-selected=true while the hidden tab is absent from the DOM. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant handoffSession
    participant sendMessage
    participant applyInheritedGoal
    participant persistChatState
    participant seedCodexGoal

    Caller->>handoffSession: "handoffSession({ sourceSessionId, targetModelId })"
    handoffSession->>handoffSession: compute deferInheritedGoalUntilHandoffDispatch

    alt NOT deferred (non-Codex or non-brief)
        handoffSession->>applyInheritedGoal: applyInheritedGoal()
    end
    handoffSession->>persistChatState: persistChatState()

    alt "handoffMode === brief"
        handoffSession->>sendMessage: "sendMessage(handoffPrompt, { awaitDispatch: true })"
        Note over sendMessage: dispatch to Codex turn/start
        sendMessage-->>handoffSession: resolved (or throws)

        Note over handoffSession: finally block always runs
        alt deferInheritedGoalUntilHandoffDispatch (Codex brief)
            handoffSession->>applyInheritedGoal: applyInheritedGoal()
            handoffSession->>persistChatState: persistChatState()
            handoffSession->>seedCodexGoal: seedCodexThreadGoalFromSessionGoal()
            alt seeding fails
                seedCodexGoal-->>handoffSession: throws
                handoffSession->>handoffSession: logger.warn(...)
                handoffSession->>persistChatState: persistChatState() [defensive]
            else seeding succeeds
                seedCodexGoal-->>handoffSession: ok
            end
        end
    end
    handoffSession-->>Caller: "{ session, usedFallbackSummary }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant handoffSession
    participant sendMessage
    participant applyInheritedGoal
    participant persistChatState
    participant seedCodexGoal

    Caller->>handoffSession: "handoffSession({ sourceSessionId, targetModelId })"
    handoffSession->>handoffSession: compute deferInheritedGoalUntilHandoffDispatch

    alt NOT deferred (non-Codex or non-brief)
        handoffSession->>applyInheritedGoal: applyInheritedGoal()
    end
    handoffSession->>persistChatState: persistChatState()

    alt "handoffMode === brief"
        handoffSession->>sendMessage: "sendMessage(handoffPrompt, { awaitDispatch: true })"
        Note over sendMessage: dispatch to Codex turn/start
        sendMessage-->>handoffSession: resolved (or throws)

        Note over handoffSession: finally block always runs
        alt deferInheritedGoalUntilHandoffDispatch (Codex brief)
            handoffSession->>applyInheritedGoal: applyInheritedGoal()
            handoffSession->>persistChatState: persistChatState()
            handoffSession->>seedCodexGoal: seedCodexThreadGoalFromSessionGoal()
            alt seeding fails
                seedCodexGoal-->>handoffSession: throws
                handoffSession->>handoffSession: logger.warn(...)
                handoffSession->>persistChatState: persistChatState() [defensive]
            else seeding succeeds
                seedCodexGoal-->>handoffSession: ok
            end
        end
    end
    handoffSession-->>Caller: "{ session, usedFallbackSummary }"
```

</a>

<sub>Reviews (3): Last reviewed commit: ["Keep deferred Codex goal seeding best ef..."](https://github.com/arul28/ade/commit/c735d71f2239a2ac2865e5dd955c38ab2f33ef43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40734360)</sub>

<!-- /greptile_comment -->