### PR TITLE
Fix tracked CLI session naming

### DIFF
--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -736,6 +736,8 @@ export async function createAdeRuntime(args: {
     laneService,
     sessionService,
     processRegistry,
+    aiIntegrationService,
+    projectConfigService,
     logger,
     broadcastData: (event) => {
       pushEvent("pty", { type: "pty_data", event });

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -12069,6 +12069,38 @@ describe("createAgentChatService", () => {
     });
   });
 
+  describe("readTranscript", () => {
+    it("refuses non-chat sessions even when a transcript file exists", async () => {
+      const { service, sessionService } = createService();
+      const transcriptPath = path.join(tmpRoot, "transcripts", "terminal-session.chat.jsonl");
+      fs.writeFileSync(
+        transcriptPath,
+        `${JSON.stringify({
+          sessionId: "terminal-session",
+          timestamp: "2026-06-30T12:00:00.000Z",
+          event: { type: "user_message", text: "terminal secret" },
+          sequence: 1,
+        })}\n`,
+        "utf8",
+      );
+      sessionService.create({
+        sessionId: "terminal-session",
+        laneId: "lane-1",
+        toolType: "terminal",
+        transcriptPath,
+      });
+      vi.mocked(parseAgentChatTranscript).mockReturnValue([{
+        sessionId: "terminal-session",
+        timestamp: "2026-06-30T12:00:00.000Z",
+        event: { type: "user_message", text: "terminal secret" },
+        sequence: 1,
+      }]);
+
+      await expect(service.readTranscript("terminal-session")).resolves.toEqual([]);
+      expect(parseAgentChatTranscript).not.toHaveBeenCalled();
+    });
+  });
+
   describe("getChatEventHistory", () => {
     it("returns an empty history for an unknown session", async () => {
       const { service } = createService();

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -28003,10 +28003,14 @@ export function createAgentChatService(args: {
     limit?: number,
     since?: string,
   ): Promise<AgentChatTranscriptEntry[]> => {
-    const managed = managedSessions.get(sessionId);
+    const trimmedId = sessionId.trim();
+    if (!trimmedId.length) return [];
+    const row = sessionService.get(trimmedId);
+    if (!row || !isChatToolType(row.toolType)) return [];
+    const managed = managedSessions.get(trimmedId);
     const entries = managed
       ? readTranscriptEntries(managed)
-      : transcriptEntriesFromEnvelopes(sessionId, readFullTranscriptEnvelopesForSessionId(sessionId));
+      : transcriptEntriesFromEnvelopes(trimmedId, readFullTranscriptEnvelopesForSessionId(trimmedId));
     let filtered = entries;
     if (typeof since === "string" && since.trim().length) {
       filtered = filtered.filter((entry) => entry.timestamp >= since);

--- a/apps/desktop/src/main/services/pty/ptyService.test.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.test.ts
@@ -3311,7 +3311,7 @@ describe("ptyService", () => {
       });
 
       const createdSessionId = (sessionService.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]?.sessionId;
-      expect(createdSessionId).toBeTruthy();
+      expect(typeof createdSessionId).toBe("string");
 
       service.write({ ptyId, data: "Fix the flaky login tests\r" });
 
@@ -3322,6 +3322,43 @@ describe("ptyService", () => {
         }),
       );
       expect(sessionService.get(createdSessionId)?.goal).toBe("Fix the flaky login tests");
+    });
+
+    it("uses the wrapped ADE user task instead of launch guidance for CLI fallback titles", async () => {
+      const { service, sessionService } = createHarness();
+      const { ptyId } = await service.create({
+        laneId: "lane-1",
+        title: "Codex",
+        cols: 80,
+        rows: 24,
+        toolType: "codex",
+      });
+
+      const createdSessionId = (sessionService.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]?.sessionId;
+      expect(typeof createdSessionId).toBe("string");
+
+      service.write({
+        ptyId,
+        data: [
+          "ADE session guidance. Treat this as operating guidance for the CLI session.",
+          "Start working on that user prompt immediately.",
+          "",
+          "User prompt:",
+          "You are working in ADE lane:",
+          "/repo/.ade/worktrees/context-iphone-17-simulator",
+          "",
+          "Edits and mutating commands must stay inside that worktree.",
+          "",
+          "The user is debugging the ADE iOS Work chat scroll/layout bugs.",
+        ].join("\n") + "\r",
+      });
+
+      expect(sessionService.get(createdSessionId)?.title).toBe(
+        "The user is debugging the ADE iOS Work chat scroll/layout bugs",
+      );
+      expect(sessionService.get(createdSessionId)?.goal).toBe(
+        "The user is debugging the ADE iOS Work chat scroll/layout bugs.",
+      );
     });
 
     it("ignores provider slash commands when choosing the first CLI title seed", async () => {
@@ -3335,7 +3372,7 @@ describe("ptyService", () => {
       });
 
       const createdSessionId = (sessionService.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]?.sessionId;
-      expect(createdSessionId).toBeTruthy();
+      expect(typeof createdSessionId).toBe("string");
 
       service.write({ ptyId, data: "/model\r" });
 
@@ -3359,7 +3396,7 @@ describe("ptyService", () => {
       });
 
       const createdSessionId = (sessionService.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]?.sessionId;
-      expect(createdSessionId).toBeTruthy();
+      expect(typeof createdSessionId).toBe("string");
 
       service.write({ ptyId, data: "/this is a test\r" });
 
@@ -3416,6 +3453,69 @@ describe("ptyService", () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it("adopts Claude runtime window titles emitted by the live PTY", async () => {
+      const { service, mockPty, sessionService } = createHarness();
+      await service.create({
+        laneId: "lane-1",
+        title: "Start with context skill then i wanna redesign the ade",
+        cols: 80,
+        rows: 24,
+        toolType: "claude",
+      });
+
+      const createdSessionId = (sessionService.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]?.sessionId;
+      expect(typeof createdSessionId).toBe("string");
+
+      mockPty._emitter.emit(
+        "data",
+        "\x1b]0;\u2802 Redesign ADE mobile app with unified project hub\x07",
+      );
+
+      expect(sessionService.get(createdSessionId)?.title).toBe(
+        "Redesign ADE mobile app with unified project hub",
+      );
+      expect(sessionService.updateMeta).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: createdSessionId,
+          title: "Redesign ADE mobile app with unified project hub",
+          manuallyNamed: false,
+        }),
+      );
+    });
+
+    it("does not let provider window titles replace ADE AI title generation", async () => {
+      const aiIntegrationService = {
+        getMode: vi.fn(() => "subscription"),
+        summarizeTerminal: vi.fn(async () => ({ text: "ADE generated title" })),
+      };
+      const { service, mockPty, sessionService } = createHarness({ aiIntegrationService });
+      await service.create({
+        laneId: "lane-1",
+        title: "Start with context skill then i wanna redesign the ade",
+        cols: 80,
+        rows: 24,
+        toolType: "claude",
+      });
+
+      const createdSessionId = (sessionService.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]?.sessionId;
+      expect(typeof createdSessionId).toBe("string");
+
+      mockPty._emitter.emit(
+        "data",
+        "\x1b]0;\u2802 Redesign ADE mobile app with unified project hub\x07",
+      );
+
+      expect(sessionService.get(createdSessionId)?.title).toBe(
+        "Start with context skill then i wanna redesign the ade",
+      );
+      expect(sessionService.updateMeta).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: createdSessionId,
+          title: "Redesign ADE mobile app with unified project hub",
+        }),
+      );
     });
 
     it("sets a deterministic title immediately, then upgrades it via a deferred AI pass for Claude CLI sessions", async () => {

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -53,7 +53,11 @@ import type {
   PtyProcessResourceUsageSnapshot,
 } from "../../../shared/types";
 import { isProviderSlashCommandInput } from "../../../shared/chatSlashCommands";
-import { withCodexNoAltScreen } from "../../../shared/cliLaunch";
+import {
+  sanitizeTrackedCliPromptSeed,
+  trackedCliTitleFromPromptSeed,
+  withCodexNoAltScreen,
+} from "../../../shared/cliLaunch";
 import { stripAnsi } from "../../utils/ansiStrip";
 import { summarizeTerminalSession } from "../../utils/sessionSummary";
 import { derivePreviewFromChunk } from "../../utils/terminalPreview";
@@ -109,8 +113,6 @@ function shouldScheduleOutputSnippetTitle(tool: TerminalToolType | null): boolea
 }
 
 const CLI_USER_TITLE_SEED_MIN_LEN = 3;
-const CLI_USER_TITLE_SEED_MAX_LEN = 180;
-const CLI_USER_TITLE_FALLBACK_MAX_LEN = 72;
 const CODEX_ADE_GUIDANCE_SCAN_BYTES = 160 * 1024;
 const CODEX_THREAD_NAME_SCAN_BYTES = 512 * 1024;
 const CLAUDE_TITLE_SCAN_BYTES = 512 * 1024;
@@ -492,52 +494,6 @@ function withAdeTerminalContextEnv(env: NodeJS.ProcessEnv, args: {
   return next;
 }
 
-function sanitizeCliUserTitleSeed(raw: string): string {
-  const stripped = stripAnsi(raw)
-    .replace(/\r\n/g, "\n")
-    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
-    .replace(/\n/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (!stripped.length) return "";
-  return stripped.slice(0, CLI_USER_TITLE_SEED_MAX_LEN);
-}
-
-function trimPromptLeadIn(raw: string): string {
-  let text = raw.trim();
-  for (let i = 0; i < 4; i += 1) {
-    const next = text
-      .replace(/^(?:ok(?:ay)?|so|hey|hi|hello|please|pls|vv)\b[\s,.:;-]*/iu, "")
-      .trim();
-    if (next === text) break;
-    text = next;
-  }
-  return text;
-}
-
-function sentenceCase(raw: string): string {
-  return raw ? raw.charAt(0).toUpperCase() + raw.slice(1) : raw;
-}
-
-function deterministicCliTitleFromSeed(seed: string): string {
-  const naturalLanguageSlashTitle = seed.startsWith("/") && !isProviderSlashCommandInput(seed)
-    ? seed.slice(1).trim()
-    : seed;
-  const cleaned = trimPromptLeadIn(naturalLanguageSlashTitle)
-    .replace(/^["'`]+|["'`]+$/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (!cleaned) return "";
-
-  const clauseMatch = cleaned.match(/^(.{18,}?[,.!?;:])\s/u);
-  const clause = clauseMatch?.[1]?.replace(/[,.!?;:]+$/u, "").trim();
-  const base = clause && clause.length >= 12 ? clause : cleaned;
-  const clipped = base.length > CLI_USER_TITLE_FALLBACK_MAX_LEN
-    ? base.slice(0, CLI_USER_TITLE_FALLBACK_MAX_LEN).replace(/\s+\S*$/u, "").trim()
-    : base;
-  return sentenceCase(clipped || base.slice(0, CLI_USER_TITLE_FALLBACK_MAX_LEN).trim()).replace(/[.?!,:;]+$/u, "");
-}
-
 function isCliPlaceholderTitle(title: string | null | undefined, toolType: TerminalToolType | null | undefined): boolean {
   const normalized = String(title ?? "").trim().toLowerCase();
   if (!normalized.length) return true;
@@ -576,6 +532,30 @@ function sanitizeGeneratedCliTitle(raw: string): string {
   ]);
   if (/^(new session|new chat|untitled chat|untitled)\b/u.test(collapsed)) return "";
   return rejected.has(collapsed) ? "" : title;
+}
+
+function extractLatestOscWindowTitle(entry: PtyEntry, data: string): string {
+  const combined = `${entry.runtimeWindowTitleScanBuffer}${data}`.slice(-2048);
+  const titlePattern = /\x1b\](?:0|2);([^\x07\x1b]*)(?:\x07|\x1b\\)/g;
+  let match: RegExpExecArray | null;
+  let latestRawTitle = "";
+  let latestEnd = 0;
+  while ((match = titlePattern.exec(combined))) {
+    latestRawTitle = match[1] ?? "";
+    latestEnd = titlePattern.lastIndex;
+  }
+
+  const partialStart = combined.lastIndexOf("\x1b]");
+  entry.runtimeWindowTitleScanBuffer = partialStart >= latestEnd
+    ? combined.slice(partialStart)
+    : "";
+
+  if (!latestRawTitle.trim()) return "";
+  return sanitizeGeneratedCliTitle(
+    latestRawTitle
+      .replace(/^[\s\u2800-\u28ff\u2022\u00b7.:-]+/u, "")
+      .trim(),
+  );
 }
 
 function isSessionManuallyNamed(
@@ -626,6 +606,7 @@ type PtyEntry = {
   lastUserInputAt: number;
   terminalSnapshot: TerminalSnapshotMirror | null;
   recentOutputTail: string;
+  runtimeWindowTitleScanBuffer: string;
   /** Output-snippet title timer (skipped for interactive Claude/Codex; see CLI user-title path). */
   aiTitleTimer: ReturnType<typeof setTimeout> | null;
   startupTimer: ReturnType<typeof setTimeout> | null;
@@ -1495,7 +1476,7 @@ export function createPtyService({
       if (idx === -1) break;
       const segment = entry.cliUserTitleLineBuffer.slice(0, idx);
       entry.cliUserTitleLineBuffer = entry.cliUserTitleLineBuffer.slice(idx + 1);
-      const seed = sanitizeCliUserTitleSeed(segment);
+      const seed = sanitizeTrackedCliPromptSeed(segment);
       if (seed.length < CLI_USER_TITLE_SEED_MIN_LEN) continue;
       if (isProviderSlashCommandInput(seed)) continue;
 
@@ -1515,7 +1496,7 @@ export function createPtyService({
         return;
       }
       if (isCliPlaceholderTitle(session.title, session.toolType)) {
-        const fallbackTitle = deterministicCliTitleFromSeed(seed);
+        const fallbackTitle = trackedCliTitleFromPromptSeed(seed);
         if (fallbackTitle) {
           sessionService.updateMeta({ sessionId: entry.sessionId, title: fallbackTitle, manuallyNamed: false });
         }
@@ -1538,6 +1519,25 @@ export function createPtyService({
     if (entry.cliUserTitleLineBuffer.length > 8000) {
       entry.cliUserTitleLineBuffer = entry.cliUserTitleLineBuffer.slice(-4000);
     }
+  };
+
+  const adoptCliRuntimeWindowTitle = (entry: PtyEntry, data: string): void => {
+    if (!CLI_USER_TITLE_TOOL_TYPES.has(entry.toolTypeHint ?? "shell")) return;
+    if (aiIntegrationService && aiIntegrationService.getMode() !== "guest" && isTitleGenerationEnabled()) return;
+    const title = extractLatestOscWindowTitle(entry, data);
+    if (!title) return;
+    if (isSessionManuallyNamed(sessionService, entry.sessionId)) {
+      logger.info("pty.cli_runtime_window_title_skipped_user_renamed", { sessionId: entry.sessionId });
+      return;
+    }
+    const session = sessionService.get(entry.sessionId);
+    if (!session || session.title?.trim() === title) return;
+    sessionService.updateMeta({ sessionId: entry.sessionId, title, manuallyNamed: false });
+    logger.info("pty.cli_runtime_window_title_adopted", {
+      sessionId: entry.sessionId,
+      toolType: entry.toolTypeHint,
+      titleLength: title.length,
+    });
   };
 
   const clearIdleTimer = (sessionId: string) => {
@@ -3917,6 +3917,7 @@ export function createPtyService({
         lastUserInputAt: 0,
         terminalSnapshot: tracked ? createTerminalSnapshotMirror(cols, rows) : null,
         recentOutputTail: "",
+        runtimeWindowTitleScanBuffer: "",
         aiTitleTimer: null,
         startupTimer: null,
         initialInputTimer: null,
@@ -3945,6 +3946,7 @@ export function createPtyService({
         if (entry.disposed) return;
         resyncLiveSessionRowIfNeeded(entry, ptyId);
         appendRecentOutput(entry, data);
+        adoptCliRuntimeWindowTitle(entry, data);
         writeTranscript(entry, data);
         feedTerminalSnapshot(entry, data);
         updatePreviewThrottled(entry, data);

--- a/apps/desktop/src/renderer/components/files/v2/EditorGroups.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/EditorGroups.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react";
 import { Funnel, Stack } from "@phosphor-icons/react";
 import { Group, Panel } from "react-resizable-panels";
-import type { FilesWorkspace, LaneSummary } from "../../../../shared/types";
+import type { LaneSummary } from "../../../../shared/types";
 import { ResizeGutter } from "../../ui/ResizeGutter";
 import type { MonacoModelRegistry } from "../monacoModelRegistry";
 import type { EditorTab, GroupsState } from "./editorGroupsStore";
@@ -22,7 +22,6 @@ export type TabWorkspaceContext = {
 export type EditorGroupsProps = {
   sessionKey: string;
   state: GroupsState;
-  workspaces: FilesWorkspace[];
   explorerWorkspaceId: string;
   explorerLaneId: string | null;
   lanes: LaneSummary[];
@@ -51,9 +50,14 @@ export type EditorGroupsProps = {
 };
 
 export function EditorGroups(props: EditorGroupsProps) {
-  const ids = props.state.groupOrder.filter((id) => props.state.groups[id]);
-  const evenSize = (100 / Math.max(1, ids.length)).toFixed(4);
-  const layoutKey = ids.join("|");
+  const groupEntries = props.state.groupOrder
+    .map((id) => {
+      const group = props.state.groups[id];
+      return group ? { id, group } : null;
+    })
+    .filter((entry): entry is { id: string; group: GroupsState["groups"][string] } => entry != null);
+  const evenSize = (100 / Math.max(1, groupEntries.length)).toFixed(4);
+  const layoutKey = groupEntries.map((entry) => entry.id).join("|");
   const sizeKey = `${props.sessionKey}::${layoutKey}`;
   const persisted = splitSizesByKey.get(sizeKey);
 
@@ -94,11 +98,11 @@ export function EditorGroups(props: EditorGroupsProps) {
           if (next && Object.keys(next).length > 1) splitSizesByKey.set(sizeKey, next);
         }}
       >
-        {ids.map((id, i) => (
+        {groupEntries.map(({ id, group }, i) => (
           <Fragment key={id}>
             <Panel id={`files-group-${id}`} defaultSize={panelSize(id)} minSize="15%" className="min-h-0 min-w-0 overflow-hidden">
               <EditorGroup
-                group={props.state.groups[id]!}
+                group={group}
                 isActiveGroup={id === props.state.activeGroupId}
                 explorerWorkspaceId={props.explorerWorkspaceId}
                 explorerLaneId={props.explorerLaneId}
@@ -126,7 +130,7 @@ export function EditorGroups(props: EditorGroupsProps) {
                 onBodyDrop={props.onBodyDrop}
               />
             </Panel>
-            {i < ids.length - 1 ? <ResizeGutter orientation="vertical" thin /> : null}
+            {i < groupEntries.length - 1 ? <ResizeGutter orientation="vertical" thin /> : null}
           </Fragment>
         ))}
       </Group>

--- a/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.test.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.test.tsx
@@ -4,8 +4,10 @@ import React from "react";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FilesWorkspace } from "../../../../shared/types";
+import { filesSessionKey } from "../treeHelpers";
 import { useEditorGroupsStore } from "./editorGroupsStore";
 import { FilesWorkbench } from "./FilesWorkbench";
+import { recordRecentFile } from "./recentFiles";
 
 const testState = vi.hoisted(() => ({
   appState: {
@@ -24,10 +26,13 @@ vi.mock("../../../state/appStore", () => ({
 }));
 
 vi.mock("../FilesExplorer", () => ({
-  FilesExplorer: ({ onOpenFile }: { onOpenFile: (path: string) => void }) => (
-    <button type="button" data-testid="open-file" onClick={() => onOpenFile("src/a.ts")}>
-      Open file
-    </button>
+  FilesExplorer: ({ canMutate, onOpenFile }: { canMutate?: boolean; onOpenFile: (path: string) => void }) => (
+    <div>
+      <div data-testid="explorer-can-mutate">{String(canMutate)}</div>
+      <button type="button" data-testid="open-file" onClick={() => onOpenFile("src/a.ts")}>
+        Open file
+      </button>
+    </div>
   ),
 }));
 
@@ -82,7 +87,7 @@ const workspaces: FilesWorkspace[] = [
     name: "Lane B",
     rootPath: "/repo/.ade/worktrees/b",
     laneId: "lane-b",
-    isReadOnlyByDefault: false,
+    isReadOnlyByDefault: true,
     mobileReadOnly: true,
   },
 ];
@@ -142,5 +147,35 @@ describe("FilesWorkbench", () => {
 
     expect(window.confirm).not.toHaveBeenCalled();
     await waitFor(() => expect(screen.getByTestId("dirty-count").textContent).toBe("1"));
+  });
+
+  it("lets read-only-by-default workspaces opt into editing for the session", async () => {
+    render(<FilesWorkbench active />);
+
+    fireEvent.click(await screen.findByTestId("switch-workspace"));
+
+    await waitFor(() => expect(screen.getByTestId("explorer-can-mutate").textContent).toBe("false"));
+    fireEvent.click(screen.getByTestId("open-file"));
+    await waitFor(() => expect(screen.getByTestId("can-edit").textContent).toBe("false"));
+
+    fireEvent.click(screen.getByRole("button", { name: /enable editing/i }));
+
+    await waitFor(() => expect(screen.getByTestId("explorer-can-mutate").textContent).toBe("true"));
+    expect(screen.getByTestId("can-edit").textContent).toBe("true");
+  });
+
+  it("keeps recent files scoped to the selected lane workspace", async () => {
+    recordRecentFile(filesSessionKey("/repo", "lane-a"), "src/lane-a.ts");
+    recordRecentFile(filesSessionKey("/repo", "lane-b"), "src/lane-b.ts");
+
+    render(<FilesWorkbench active />);
+
+    await screen.findByRole("button", { name: /lane-a\.ts/i });
+    expect(screen.queryByRole("button", { name: /lane-b\.ts/i })).toBeNull();
+
+    fireEvent.click(screen.getByTestId("switch-workspace"));
+
+    await screen.findByRole("button", { name: /lane-b\.ts/i });
+    expect(screen.queryByRole("button", { name: /lane-a\.ts/i })).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.test.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.test.tsx
@@ -38,9 +38,14 @@ vi.mock("../FilesExplorer", () => ({
 
 vi.mock("./WorkspacePicker", () => ({
   WorkspacePicker: ({ onChange }: { onChange: (workspaceId: string) => void }) => (
-    <button type="button" data-testid="switch-workspace" onClick={() => onChange("workspace-b")}>
-      Switch workspace
-    </button>
+    <div>
+      <button type="button" data-testid="switch-workspace" onClick={() => onChange("workspace-b")}>
+        Switch workspace
+      </button>
+      <button type="button" data-testid="switch-attached-workspace" onClick={() => onChange("workspace-c")}>
+        Switch attached
+      </button>
+    </div>
   ),
 }));
 
@@ -90,10 +95,21 @@ const workspaces: FilesWorkspace[] = [
     isReadOnlyByDefault: true,
     mobileReadOnly: true,
   },
+  {
+    id: "workspace-c",
+    kind: "attached",
+    name: "Attached",
+    rootPath: "/repo-attached",
+    laneId: null,
+    isReadOnlyByDefault: false,
+    mobileReadOnly: true,
+  },
 ];
 
 describe("FilesWorkbench", () => {
   beforeEach(() => {
+    testState.appState.project = { rootPath: "/repo" };
+    testState.appState.selectedLaneId = "lane-a";
     useEditorGroupsStore.setState({ sessions: {} });
     vi.spyOn(window, "confirm").mockReturnValue(true);
     Object.defineProperty(window, "ade", {
@@ -150,7 +166,7 @@ describe("FilesWorkbench", () => {
   });
 
   it("lets read-only-by-default workspaces opt into editing for the session", async () => {
-    render(<FilesWorkbench active />);
+    const { rerender } = render(<FilesWorkbench active />);
 
     fireEvent.click(await screen.findByTestId("switch-workspace"));
 
@@ -162,6 +178,11 @@ describe("FilesWorkbench", () => {
 
     await waitFor(() => expect(screen.getByTestId("explorer-can-mutate").textContent).toBe("true"));
     expect(screen.getByTestId("can-edit").textContent).toBe("true");
+
+    testState.appState.project = { rootPath: "/other-repo" };
+    rerender(<FilesWorkbench active />);
+
+    await waitFor(() => expect(screen.getByTestId("explorer-can-mutate").textContent).toBe("false"));
   });
 
   it("keeps recent files scoped to the selected lane workspace", async () => {
@@ -176,6 +197,21 @@ describe("FilesWorkbench", () => {
     fireEvent.click(screen.getByTestId("switch-workspace"));
 
     await screen.findByRole("button", { name: /lane-b\.ts/i });
+    expect(screen.queryByRole("button", { name: /lane-a\.ts/i })).toBeNull();
+  });
+
+  it("keeps recent files scoped to attached workspace ids", async () => {
+    recordRecentFile(filesSessionKey("/repo", "lane-a"), "src/lane-a.ts");
+    recordRecentFile(filesSessionKey("/repo", "workspace-c"), "src/attached.ts");
+
+    render(<FilesWorkbench active />);
+
+    await screen.findByRole("button", { name: /lane-a\.ts/i });
+    expect(screen.queryByRole("button", { name: /attached\.ts/i })).toBeNull();
+
+    fireEvent.click(screen.getByTestId("switch-attached-workspace"));
+
+    await screen.findByRole("button", { name: /attached\.ts/i });
     expect(screen.queryByRole("button", { name: /lane-a\.ts/i })).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
@@ -68,12 +68,21 @@ const workspacesCacheByProject = new Map<string, FilesWorkspace[]>();
 const rootTreeCacheByKey = new Map<string, FileTreeNode[]>();
 const readCachedWorkspaces = (projectRoot: string): FilesWorkspace[] => workspacesCacheByProject.get(projectRoot) ?? [];
 const rootTreeCacheKey = (projectRoot: string, workspaceId: string): string => `${projectRoot}::${workspaceId}`;
+const editOverrideKey = (projectRoot: string, workspaceId: string): string => `${projectRoot}::${workspaceId}`;
+
+function recentScopeIdForWorkspace(workspace: FilesWorkspace | null | undefined, fallbackLaneId: string | null): string | null {
+  if (!workspace) return fallbackLaneId;
+  if (workspace.kind === "worktree") return workspace.laneId ?? workspace.id;
+  if (workspace.kind === "primary") return workspace.laneId ?? fallbackLaneId;
+  return workspace.id;
+}
 
 function canEditWorkspace(
   workspace: FilesWorkspace | null | undefined,
   editOverrides: ReadonlySet<string> = new Set(),
+  projectRoot = "",
 ): boolean {
-  return workspace != null && (!workspace.isReadOnlyByDefault || editOverrides.has(workspace.id));
+  return workspace != null && (!workspace.isReadOnlyByDefault || editOverrides.has(editOverrideKey(projectRoot, workspace.id)));
 }
 
 function mergeExternalWorkspaces(next: FilesWorkspace[], previous: FilesWorkspace[]): FilesWorkspace[] {
@@ -130,23 +139,24 @@ export function FilesWorkbench({
   const workspace = useMemo(() => workspaces.find((w) => w.id === workspaceId) ?? null, [workspaces, workspaceId]);
   const rootPath = workspace?.rootPath ?? projectRootPath;
   const [editOverrides, setEditOverrides] = useState<Set<string>>(() => new Set());
-  const canEdit = canEditWorkspace(workspace, editOverrides);
+  const workspaceEditOverrideKey = workspace ? editOverrideKey(projectRootPath, workspace.id) : "";
+  const canEdit = canEditWorkspace(workspace, editOverrides, projectRootPath);
   const canRevealInFinder = workspace != null && (workspace.kind === "external" || !isRemoteProject);
-  const showEnableEditing = Boolean(workspace?.isReadOnlyByDefault) && !editOverrides.has(workspaceId);
+  const showEnableEditing = Boolean(workspace?.isReadOnlyByDefault) && !editOverrides.has(workspaceEditOverrideKey);
   const enableEditingForWorkspace = useCallback(() => {
-    if (!workspaceId) return;
+    if (!workspace) return;
     setEditOverrides((prev) => {
       const next = new Set(prev);
-      next.add(workspaceId);
+      next.add(editOverrideKey(projectRootPath, workspace.id));
       return next;
     });
-  }, [workspaceId]);
+  }, [projectRootPath, workspace]);
   const branch = workspace?.branchRef?.replace("refs/heads/", "") ?? null;
   const theme: EditorThemeMode = "dark";
   const sessionKey = filesProjectSessionKey(projectRootPath);
   const recentSessionKey = filesSessionKey(
     projectRootPath,
-    workspace?.kind === "external" ? workspace.id : workspace?.laneId ?? globalLaneId,
+    recentScopeIdForWorkspace(workspace, globalLaneId),
   );
   const [tabScope, setTabScope] = useState<FilesTabScope>(() => getFilesTabScope(projectRootPath));
 
@@ -227,7 +237,7 @@ export function FilesWorkbench({
         workspaceId: tab.workspaceId,
         rootPath: wsRoot,
         laneId: tab.laneId,
-        canEdit: canEditWorkspace(ws, editOverrides),
+        canEdit: canEditWorkspace(ws, editOverrides, projectRootPath),
         canRevealInFinder: ws != null && (ws.kind === "external" || !isRemoteProject),
       };
     },

--- a/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowSquareOut, Copy, FilePlus, FolderPlus, PencilSimple, Trash } from "@phosphor-icons/react";
+import { ArrowSquareOut, Copy, FilePlus, FolderPlus, LockOpen, PencilSimple, Trash } from "@phosphor-icons/react";
 import type { FileTreeNode, FilesWorkspace } from "../../../../shared/types";
 import { useAppStore } from "../../../state/appStore";
 import { createMonacoModelRegistry } from "../monacoModelRegistry";
@@ -69,8 +69,11 @@ const rootTreeCacheByKey = new Map<string, FileTreeNode[]>();
 const readCachedWorkspaces = (projectRoot: string): FilesWorkspace[] => workspacesCacheByProject.get(projectRoot) ?? [];
 const rootTreeCacheKey = (projectRoot: string, workspaceId: string): string => `${projectRoot}::${workspaceId}`;
 
-function canEditWorkspace(workspace: FilesWorkspace | null | undefined): boolean {
-  return workspace != null && !workspace.isReadOnlyByDefault;
+function canEditWorkspace(
+  workspace: FilesWorkspace | null | undefined,
+  editOverrides: ReadonlySet<string> = new Set(),
+): boolean {
+  return workspace != null && (!workspace.isReadOnlyByDefault || editOverrides.has(workspace.id));
 }
 
 function mergeExternalWorkspaces(next: FilesWorkspace[], previous: FilesWorkspace[]): FilesWorkspace[] {
@@ -126,11 +129,25 @@ export function FilesWorkbench({
   const [workspaceId, setWorkspaceId] = useState<string>(initialWorkspaceId);
   const workspace = useMemo(() => workspaces.find((w) => w.id === workspaceId) ?? null, [workspaces, workspaceId]);
   const rootPath = workspace?.rootPath ?? projectRootPath;
-  const canEdit = canEditWorkspace(workspace);
+  const [editOverrides, setEditOverrides] = useState<Set<string>>(() => new Set());
+  const canEdit = canEditWorkspace(workspace, editOverrides);
   const canRevealInFinder = workspace != null && (workspace.kind === "external" || !isRemoteProject);
+  const showEnableEditing = Boolean(workspace?.isReadOnlyByDefault) && !editOverrides.has(workspaceId);
+  const enableEditingForWorkspace = useCallback(() => {
+    if (!workspaceId) return;
+    setEditOverrides((prev) => {
+      const next = new Set(prev);
+      next.add(workspaceId);
+      return next;
+    });
+  }, [workspaceId]);
   const branch = workspace?.branchRef?.replace("refs/heads/", "") ?? null;
   const theme: EditorThemeMode = "dark";
   const sessionKey = filesProjectSessionKey(projectRootPath);
+  const recentSessionKey = filesSessionKey(
+    projectRootPath,
+    workspace?.kind === "external" ? workspace.id : workspace?.laneId ?? globalLaneId,
+  );
   const [tabScope, setTabScope] = useState<FilesTabScope>(() => getFilesTabScope(projectRootPath));
 
   const [tree, setTree] = useState<FileTreeNode[]>(
@@ -210,11 +227,11 @@ export function FilesWorkbench({
         workspaceId: tab.workspaceId,
         rootPath: wsRoot,
         laneId: tab.laneId,
-        canEdit: canEditWorkspace(ws),
+        canEdit: canEditWorkspace(ws, editOverrides),
         canRevealInFinder: ws != null && (ws.kind === "external" || !isRemoteProject),
       };
     },
-    [isRemoteProject, projectRootPath, workspaces],
+    [editOverrides, isRemoteProject, projectRootPath, workspaces],
   );
 
   const migratedSessionsRef = useRef<string | null>(null);
@@ -266,7 +283,7 @@ export function FilesWorkbench({
   }, [projectRootPath]);
 
   const knownRootPaths = useMemo(() => new Set(tree.map((node) => node.path)), [tree]);
-  const recentFiles = getRecentFiles(sessionKey);
+  const recentFiles = getRecentFiles(recentSessionKey);
   const visibleRecentFiles = useMemo(
     () => (
       tree.length > 0
@@ -278,8 +295,8 @@ export function FilesWorkbench({
 
   useEffect(() => {
     if (tree.length === 0) return;
-    pruneMissingRootRecentFiles(sessionKey, knownRootPaths);
-  }, [knownRootPaths, sessionKey, tree.length]);
+    pruneMissingRootRecentFiles(recentSessionKey, knownRootPaths);
+  }, [knownRootPaths, recentSessionKey, tree.length]);
 
   const dirtyTabsUnder = useCallback(
     (wsId: string, target: string): string[] =>
@@ -732,12 +749,12 @@ export function FilesWorkbench({
           pinned: false,
         };
         applyGroups((s) => openInGroup(s, s.activeGroupId, tab, { preview: opts.preview ?? true }));
-        recordRecentFile(sessionKey, path);
+        recordRecentFile(recentSessionKey, path);
       } catch (err) {
         setError(err instanceof Error ? err.message : String(err));
       }
     },
-    [workspace, workspaceId, applyGroups, sessionKey],
+    [workspace, workspaceId, applyGroups, recentSessionKey],
   );
 
   const handleActivateTab = useCallback(
@@ -941,11 +958,11 @@ export function FilesWorkbench({
         setError(err instanceof Error ? err.message : String(err));
         return;
       }
-      forgetRecentFilesUnder(sessionKey, sourcePath);
+      forgetRecentFilesUnder(recentSessionKey, sourcePath);
       closeOpenTabsUnder(workspaceId, sourcePath);
       await refreshRoot();
     },
-    [canEdit, closeOpenTabsUnder, confirmDiscardDirtyTabIds, dirtyTabsUnder, refreshRoot, sessionKey, workspaceId],
+    [canEdit, closeOpenTabsUnder, confirmDiscardDirtyTabIds, dirtyTabsUnder, recentSessionKey, refreshRoot, workspaceId],
   );
 
   const deletePath = useCallback(
@@ -960,14 +977,14 @@ export function FilesWorkbench({
       if (!confirmDiscardDirtyTabIds(dirtyTabsUnder(workspaceId, path), "Delete it")) return;
       try {
         await window.ade.files.delete({ workspaceId, path });
-        forgetRecentFilesUnder(sessionKey, path);
+        forgetRecentFilesUnder(recentSessionKey, path);
         closeOpenTabsUnder(workspaceId, path);
         await refreshRoot();
       } catch (err) {
         setError(err instanceof Error ? err.message : String(err));
       }
     },
-    [canEdit, closeOpenTabsUnder, confirmDiscardDirtyTabIds, dirtyTabsUnder, refreshRoot, sessionKey, workspaceId],
+    [canEdit, closeOpenTabsUnder, confirmDiscardDirtyTabIds, dirtyTabsUnder, recentSessionKey, refreshRoot, workspaceId],
   );
 
   const dirForNode = (menu: FilesExplorerContextMenuEvent): string =>
@@ -1096,6 +1113,18 @@ export function FilesWorkbench({
           {!embedded ? (
             <WorkspacePicker workspaces={workspaces} workspaceId={workspaceId} onChange={selectWorkspace} />
           ) : null}
+          {showEnableEditing ? (
+            <button
+              type="button"
+              onClick={enableEditingForWorkspace}
+              className="mx-2 mb-2 mt-1 flex shrink-0 items-center justify-center gap-1.5 rounded-md border px-2 py-1.5 font-sans text-[11px] font-medium text-fg/75 transition-colors hover:bg-white/[0.06]"
+              style={{ borderColor: COLORS.border }}
+              title="This workspace is read-only by default (edit-protected). Enable editing for this session."
+            >
+              <LockOpen size={13} weight="bold" />
+              Enable editing
+            </button>
+          ) : null}
           <div className="min-h-0 flex-1">
             <FilesExplorer
               tree={tree}
@@ -1142,7 +1171,6 @@ export function FilesWorkbench({
           <EditorGroups
             sessionKey={sessionKey}
             state={groupsState}
-            workspaces={workspaces}
             explorerWorkspaceId={workspaceId}
             explorerLaneId={workspace?.laneId ?? null}
             lanes={lanes}

--- a/apps/desktop/src/renderer/components/files/v2/editorGroupsStore.ts
+++ b/apps/desktop/src/renderer/components/files/v2/editorGroupsStore.ts
@@ -44,6 +44,10 @@ export type EditorTab = {
   pinned: boolean;
 };
 
+type LegacyEditorTab = Partial<EditorTab> & {
+  path: string;
+};
+
 export function editorTabId(workspaceId: string, path: string): string {
   return `${workspaceId}::${path}`;
 }
@@ -318,18 +322,18 @@ export function upgradeLegacySession(
     const group = session.groups[groupId];
     if (!group) continue;
     const upgradedTabs = group.tabs.map((raw) => {
-      const partial = raw as Partial<EditorTab> & { path: string };
-      const id = partial.id ?? editorTabId(workspaceId, partial.path);
+      const legacy = raw as LegacyEditorTab;
+      const id = legacy.id ?? editorTabId(workspaceId, legacy.path);
       return {
         id,
-        workspaceId: partial.workspaceId ?? workspaceId,
-        laneId: partial.laneId !== undefined ? partial.laneId : laneId,
-        path: partial.path,
-        title: partial.title ?? partial.path.split("/").pop() ?? partial.path,
-        viewerKind: partial.viewerKind ?? "code",
-        languageId: partial.languageId ?? "plaintext",
-        preview: partial.preview ?? false,
-        pinned: partial.pinned ?? false,
+        workspaceId: legacy.workspaceId ?? workspaceId,
+        laneId: legacy.laneId !== undefined ? legacy.laneId : laneId,
+        path: legacy.path,
+        title: legacy.title ?? legacy.path.split("/").pop() ?? legacy.path,
+        viewerKind: legacy.viewerKind ?? "code",
+        languageId: legacy.languageId ?? "plaintext",
+        preview: legacy.preview ?? false,
+        pinned: legacy.pinned ?? false,
       } satisfies EditorTab;
     });
     const pathToId = new Map(upgradedTabs.map((t) => [t.path, t.id]));

--- a/apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts
@@ -5,6 +5,7 @@ import {
   buildTrackedCliStartupCommand,
   buildOpenCodeReplayResumeCommand,
   defaultTrackedCliStartupCommand,
+  deriveTrackedCliInitialInputSessionMeta,
   resolveCleanShellLaunchFields,
   resolveTrackedCliResumeCommand,
   withCodexNoAltScreen,
@@ -370,6 +371,29 @@ describe("buildTrackedCliStartupCommand", () => {
       expect(launch.initialInput).toContain("Fix the failing Work tests.");
       expect(launch.startupCommand).toContain("model_reasoning_effort");
       expect(launch.startupCommand).not.toContain("Fix the failing Work tests.");
+    });
+
+    it("derives initial metadata from the user task inside ADE guidance", () => {
+      const meta = deriveTrackedCliInitialInputSessionMeta({
+        provider: "codex",
+        title: "Codex",
+        initialInput: [
+          "ADE session guidance. Treat this as operating guidance for the CLI session.",
+          "Start working on that user prompt immediately.",
+          "",
+          "User prompt:",
+          "You are working in ADE lane:",
+          "/repo/.ade/worktrees/context-iphone-17-simulator",
+          "",
+          "Edits and mutating commands must stay inside that worktree.",
+          "",
+          "The user is debugging the ADE iOS Work chat scroll/layout bugs.",
+        ].join("\n"),
+      });
+
+      expect(meta.goal).toBe("The user is debugging the ADE iOS Work chat scroll/layout bugs.");
+      expect(meta.title).toBe("The user is debugging the ADE iOS Work chat scroll/layout bugs");
+      expect(meta.promptTitle).toBe("The user is debugging the ADE iOS Work chat scroll/layout bugs");
     });
 
     it("passes explicit Codex service tier overrides for fast mode", () => {

--- a/apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/cliLaunch.test.ts
@@ -396,6 +396,34 @@ describe("buildTrackedCliStartupCommand", () => {
       expect(meta.promptTitle).toBe("The user is debugging the ADE iOS Work chat scroll/layout bugs");
     });
 
+    it("derives metadata from ADE lane guidance without a blank separator", () => {
+      const meta = deriveTrackedCliInitialInputSessionMeta({
+        provider: "codex",
+        title: "Codex",
+        initialInput: [
+          "You are working in ADE lane:",
+          "/repo/.ade/worktrees/context-iphone-17-simulator",
+          "Redesign the ADE mobile project hub.",
+        ].join("\n"),
+      });
+
+      expect(meta.goal).toBe("Redesign the ADE mobile project hub.");
+      expect(meta.title).toBe("Redesign the ADE mobile project hub");
+      expect(meta.promptTitle).toBe("Redesign the ADE mobile project hub");
+    });
+
+    it("does not unwrap ordinary prompts that mention ADE guidance text", () => {
+      const meta = deriveTrackedCliInitialInputSessionMeta({
+        provider: "codex",
+        title: "Codex",
+        initialInput: "Explain why docs say Start working on that user prompt immediately.",
+      });
+
+      expect(meta.goal).toBe("Explain why docs say Start working on that user prompt immediately.");
+      expect(meta.title).toBe("Explain why docs say Start working on that user prompt immediately");
+      expect(meta.promptTitle).toBe("Explain why docs say Start working on that user prompt immediately");
+    });
+
     it("passes explicit Codex service tier overrides for fast mode", () => {
       const fastLaunch = buildTrackedCliLaunchCommand({
         provider: "codex",

--- a/apps/desktop/src/shared/cliLaunch.ts
+++ b/apps/desktop/src/shared/cliLaunch.ts
@@ -96,12 +96,12 @@ export function sanitizeTrackedCliPromptSeed(raw: string): string {
 function unwrapAdeGuidancePromptForTitle(raw: string): string {
   const text = raw.trim();
   if (!text.length) return "";
+  const marker = /\bUser prompt:\s*/iu.exec(text);
   const looksLikeAdeGuidance =
     /^ADE session guidance\b/iu.test(text)
-    || text.includes("Start working on that user prompt immediately.");
+    || (/^Start working on that user prompt immediately\./iu.test(text) && marker != null);
   if (!looksLikeAdeGuidance) return stripAdeLaneDirectiveForTitle(text);
 
-  const marker = /\bUser prompt:\s*/iu.exec(text);
   const userPrompt = marker ? text.slice(marker.index + marker[0].length).trim() : text;
   return stripAdeLaneDirectiveForTitle(userPrompt);
 }
@@ -119,11 +119,10 @@ function stripAdeLaneDirectiveForTitle(raw: string): string {
       pathLine.includes(".ade/worktrees/")
       || pathLine.startsWith("/")
       || /^[A-Za-z]:[\\/]/u.test(pathLine)
-    );
+  );
   if (!looksLikeLaneDirective) return raw.trim();
 
   let i = start + 2;
-  while (i < lines.length && lines[i]!.trim().length > 0) i += 1;
   while (i < lines.length && lines[i]!.trim().length === 0) i += 1;
 
   const maybeMutationRule = lines[i]?.trim() ?? "";
@@ -137,7 +136,7 @@ function stripAdeLaneDirectiveForTitle(raw: string): string {
   }
 
   const remainder = lines.slice(i).join("\n").trim();
-  return remainder || raw.trim();
+  return remainder;
 }
 
 function trimPromptLeadIn(raw: string): string {

--- a/apps/desktop/src/shared/cliLaunch.ts
+++ b/apps/desktop/src/shared/cliLaunch.ts
@@ -79,14 +79,65 @@ function stripAnsiForCliTitle(raw: string): string {
 }
 
 export function sanitizeTrackedCliPromptSeed(raw: string): string {
-  const stripped = stripAnsiForCliTitle(raw)
+  const normalized = stripAnsiForCliTitle(raw)
     .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
     .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
+    .trim();
+  const unwrapped = unwrapAdeGuidancePromptForTitle(normalized);
+  const stripped = unwrapped
     .replace(/\n/g, " ")
     .replace(/\s+/g, " ")
     .trim();
   if (!stripped.length) return "";
   return stripped.slice(0, TRACKED_CLI_PROMPT_SEED_MAX_LEN);
+}
+
+function unwrapAdeGuidancePromptForTitle(raw: string): string {
+  const text = raw.trim();
+  if (!text.length) return "";
+  const looksLikeAdeGuidance =
+    /^ADE session guidance\b/iu.test(text)
+    || text.includes("Start working on that user prompt immediately.");
+  if (!looksLikeAdeGuidance) return stripAdeLaneDirectiveForTitle(text);
+
+  const marker = /\bUser prompt:\s*/iu.exec(text);
+  const userPrompt = marker ? text.slice(marker.index + marker[0].length).trim() : text;
+  return stripAdeLaneDirectiveForTitle(userPrompt);
+}
+
+function stripAdeLaneDirectiveForTitle(raw: string): string {
+  const lines = raw.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+  let start = lines.findIndex((line) => line.trim().length > 0);
+  if (start < 0) return "";
+
+  const firstLine = lines[start]?.trim() ?? "";
+  const pathLine = lines[start + 1]?.trim() ?? "";
+  const looksLikeLaneDirective =
+    /^You are working in ADE lane:?$/iu.test(firstLine)
+    && (
+      pathLine.includes(".ade/worktrees/")
+      || pathLine.startsWith("/")
+      || /^[A-Za-z]:[\\/]/u.test(pathLine)
+    );
+  if (!looksLikeLaneDirective) return raw.trim();
+
+  let i = start + 2;
+  while (i < lines.length && lines[i]!.trim().length > 0) i += 1;
+  while (i < lines.length && lines[i]!.trim().length === 0) i += 1;
+
+  const maybeMutationRule = lines[i]?.trim() ?? "";
+  if (
+    maybeMutationRule.length > 0
+    && /(?:edit|edits|mutating|commands)/iu.test(maybeMutationRule)
+    && /(?:worktree|lane|inside)/iu.test(maybeMutationRule)
+  ) {
+    i += 1;
+    while (i < lines.length && lines[i]!.trim().length === 0) i += 1;
+  }
+
+  const remainder = lines.slice(i).join("\n").trim();
+  return remainder || raw.trim();
 }
 
 function trimPromptLeadIn(raw: string): string {

--- a/docs/features/chat/README.md
+++ b/docs/features/chat/README.md
@@ -352,11 +352,12 @@ See the detail docs for the specifics:
    dispatch and event streaming continue asynchronously. `ade chat create
    --prompt` uses this same follow-up send after the session is created, and
    `ade chat read <session>` calls `chat.readTranscript` to inspect recent
-   transcript messages. Interactive chat sends are not wall-clock bounded by
-   the service; the turn runs until the provider completes or the user/app
-   interrupts it. The blocking `runSessionTurn` helper used by automation has
-   a 5 min default RPC timeout unless the caller passes `timeoutMs: null`;
-   background/headless chat launches opt out.
+   transcript messages for chat sessions only; shell/terminal transcript reads
+   stay on the terminal/session surfaces. Interactive chat sends are not
+   wall-clock bounded by the service; the turn runs until the provider
+   completes or the user/app interrupts it. The blocking `runSessionTurn`
+   helper used by automation has a 5 min default RPC timeout unless the caller
+   passes `timeoutMs: null`; background/headless chat launches opt out.
 4. The runtime streams events through the main-process event emitter and
    into the renderer via `ade.agentChat.event` (a push channel owned by
    `registerIpc.ts`).

--- a/docs/features/terminals-and-sessions/README.md
+++ b/docs/features/terminals-and-sessions/README.md
@@ -422,9 +422,12 @@ Renderer surfaces:
   without a startup command. `deriveTrackedCliInitialInputSessionMeta`
   seeds the session title and `goal` field from the first prompt
   (sanitised + clipped to ~72 chars) when the caller did not supply a
-  manual title, so tracked CLI rows render with a meaningful name
-  instead of "Codex" / "Claude" while still letting providers like
-  Shell fall back to the generic profile title.
+  manual title; ADE launch guidance is unwrapped first so lane/worktree
+  directives do not become the title. Tracked CLI rows render with a
+  meaningful name instead of "Codex" / "Claude" while still letting
+  providers like Shell fall back to the generic profile title. If ADE
+  AI title generation is unavailable, `ptyService` can also adopt a
+  provider-emitted terminal window title after sanitizing it.
 - `apps/desktop/src/renderer/components/terminals/cliLaunch.ts` — thin
   re-export of `apps/desktop/src/shared/cliLaunch.ts` plus the renderer-
   local Work launch envelope types: `WorkPtyLaunchDisposition`
@@ -582,7 +585,11 @@ See `apps/desktop/src/shared/types/sessions.ts` for the full shape.
    service may summarize the early output into a short title via the AI
    integration service. For Claude/Codex it prefers the first submitted
    user line (`tryCliUserTitleFromWrite`) because the TUI hides useful
-   text in the alternate screen.
+   text in the alternate screen; ADE guidance wrappers are stripped
+   before deriving the visible title/goal. Provider-emitted OSC window
+   titles are accepted only when ADE title generation is not available,
+   so the ADE summarizer remains authoritative for normal desktop and
+   CLI runtime launches.
 
 5. **Runtime exit** — on PTY exit, `sessionService.end()` finalizes `endedAt`,
    `exitCode`, and `status`. The transcript stream is flushed, then:


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Ftwo-chats-working-ade-lane-3248ca8a num=675 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Ftwo-chats-working-ade-lane-3248ca8a&amp;pr=675">ade/two-chats-working-ade-lane-3248ca8a branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=675">PR #675</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now enable editing for workspaces that are read-only by default during a session.
  * Session titles can now update from terminal window title changes in supported runtimes.

* **Bug Fixes**
  * Recent files are now tracked per selected workspace, reducing cross-workspace mix-ups.
  * Transcript reading now ignores non-chat sessions and handles blank or trimmed session IDs safely.
  * CLI session titles and goals now derive more accurately from the user’s actual task text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes CLI session naming accuracy in ADE by stripping ADE-specific guidance wrappers from prompts before deriving the session title/goal, and adds OSC window title adoption as a fallback when AI title generation is unavailable.

- **`cliLaunch.ts`**: New `unwrapAdeGuidancePromptForTitle` and `stripAdeLaneDirectiveForTitle` helpers extract the actual user task from ADE runtime guidance, so lane/worktree directives don't appear as session names.
- **`ptyService.ts`**: New `adoptCliRuntimeWindowTitle` handler reads OSC `\\x1b]0;` / `\\x1b]2;` sequences from PTY output and applies the sanitized title to the session when AI generation is not active. `runtimeWindowTitleScanBuffer` tracks partial escape sequences across data chunks.
- **`agentChatService.ts`**: `readTranscript` now early-exits for blank or non-chat session IDs, preventing accidental transcript reads for terminal sessions.
- **`FilesWorkbench.tsx`**: Recent-file records are now scoped per-workspace rather than per-project, and read-only-by-default workspaces expose an \"Enable editing\" session-local override.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changed paths are additive or guarded, tests cover both the happy path and the AI-suppression path for the new OSC title adoption.

The ADE guidance unwrapping, OSC title adoption, and recent-file scoping changes are all well-tested. The only observable behavioral quirk — OSC titles replacing user-prompt-derived names in guest/offline mode — is exercised by the test suite and appears intentional. No data-loss, crash, or auth-boundary concerns were found.

apps/desktop/src/shared/cliLaunch.ts — the `looksLikeAdeGuidance` second arm and the empty-remainder path in `stripAdeLaneDirectiveForTitle` (already noted in prior threads). apps/desktop/src/main/services/pty/ptyService.ts — `adoptCliRuntimeWindowTitle` has no placeholder guard before overwriting.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/shared/cliLaunch.ts | New ADE guidance unwrapping logic with edge-case risks in `looksLikeAdeGuidance` detection (covered by prior threads); core extraction logic is sound. |
| apps/desktop/src/main/services/pty/ptyService.ts | Adds OSC window title adoption (`adoptCliRuntimeWindowTitle`) with a rolling 2 KB buffer; guard logic correctly skips adoption when AI title generation is active. |
| apps/desktop/src/main/services/chat/agentChatService.ts | Added defensive early-exits in `readTranscript` for blank session IDs and non-chat tool types; logic is correct. |
| apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx | Recent file scoping correctly delegates to `recentScopeIdForWorkspace`; session-local edit override accumulates without cleanup but is bounded to component lifetime. |
| apps/desktop/src/renderer/components/files/v2/EditorGroups.tsx | Removed unused `workspaces` prop; refactored group iteration avoids `!` non-null assertion on `props.state.groups[id]`. |
| apps/ade-cli/src/bootstrap.ts | Passes `aiIntegrationService` and `projectConfigService` (already created earlier in the bootstrap) to `createPtyService`, enabling AI title generation in the CLI runtime. |
| apps/desktop/src/renderer/components/files/v2/editorGroupsStore.ts | Extracted `LegacyEditorTab` type to replace the inline cast in `upgradeLegacySession`; no behavioral change. |
| apps/desktop/src/main/services/pty/ptyService.test.ts | Good test coverage for OSC title adoption, ADE guidance unwrapping, and AI-guard bypass; tests for both success and suppression paths. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PTY data received] --> B[appendRecentOutput]
    A --> C[adoptCliRuntimeWindowTitle]
    A --> D[writeTranscript / feedTerminalSnapshot / updatePreview]

    C --> E{CLI_USER_TITLE_TOOL_TYPES?}
    E -- no --> Z[skip]
    E -- yes --> F{aiIntegrationService\nnon-guest &\nisTitleGenerationEnabled?}
    F -- yes --> Z
    F -- no --> G[extractLatestOscWindowTitle]
    G --> H{title found?}
    H -- no --> Z
    H -- yes --> I{manuallyNamed?}
    I -- yes --> Z
    I -- no --> J[sessionService.updateMeta\ntitle = OSC title]

    K[User input write] --> L[tryCliUserTitleFromWrite]
    L --> M{seed length OK &\nnot slash cmd?}
    M -- no --> Z
    M -- yes --> N[sanitizeTrackedCliPromptSeed]
    N --> O[unwrapAdeGuidancePromptForTitle]
    O --> P{ADE guidance?}
    P -- yes --> Q[extract after 'User prompt:'\nstripAdeLaneDirective]
    P -- no --> R[stripAdeLaneDirective]
    Q --> S[trackedCliTitleFromPromptSeed]
    R --> S
    S --> T{placeholder title?}
    T -- yes --> U[sessionService.updateMeta\ntitle = derived title]
    T -- no --> V{AI available?}
    V -- yes --> W[scheduleAiTitle]
    V -- no --> Z
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PTY data received] --> B[appendRecentOutput]
    A --> C[adoptCliRuntimeWindowTitle]
    A --> D[writeTranscript / feedTerminalSnapshot / updatePreview]

    C --> E{CLI_USER_TITLE_TOOL_TYPES?}
    E -- no --> Z[skip]
    E -- yes --> F{aiIntegrationService\nnon-guest &\nisTitleGenerationEnabled?}
    F -- yes --> Z
    F -- no --> G[extractLatestOscWindowTitle]
    G --> H{title found?}
    H -- no --> Z
    H -- yes --> I{manuallyNamed?}
    I -- yes --> Z
    I -- no --> J[sessionService.updateMeta\ntitle = OSC title]

    K[User input write] --> L[tryCliUserTitleFromWrite]
    L --> M{seed length OK &\nnot slash cmd?}
    M -- no --> Z
    M -- yes --> N[sanitizeTrackedCliPromptSeed]
    N --> O[unwrapAdeGuidancePromptForTitle]
    O --> P{ADE guidance?}
    P -- yes --> Q[extract after 'User prompt:'\nstripAdeLaneDirective]
    P -- no --> R[stripAdeLaneDirective]
    Q --> S[trackedCliTitleFromPromptSeed]
    R --> S
    S --> T{placeholder title?}
    T -- yes --> U[sessionService.updateMeta\ntitle = derived title]
    T -- no --> V{AI available?}
    V -- yes --> W[scheduleAiTitle]
    V -- no --> Z
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Address CLI naming review feedback"](https://github.com/arul28/ade/commit/fb3345b0eb2908bfd2399470c491ef75338ddc53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40871241)</sub>

<!-- /greptile_comment -->