### PR TITLE
Claude Hook Error Styling

### DIFF
--- a/apps/desktop/src/renderer/components/chat/AgentChatMessageList.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatMessageList.test.tsx
@@ -702,6 +702,43 @@ describe("AgentChatMessageList transcript rendering", () => {
     expect(screen.getByRole("button")).toBeTruthy();
   });
 
+  it("renders Claude PreToolUse hook errors in the compact work-log disclosure", () => {
+    renderMessageList([
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:00.000Z",
+        event: {
+          type: "system_notice",
+          noticeKind: "hook",
+          message: "Hook: PreToolUse:Bash error",
+          detail: "Command rejected by hook",
+          turnId: "turn-1",
+        },
+      },
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:01.000Z",
+        event: {
+          type: "system_notice",
+          noticeKind: "hook",
+          message: "Hook: PreToolUse:Read error",
+          detail: "Read rejected by hook",
+          turnId: "turn-1",
+        },
+      },
+    ]);
+
+    const disclosure = findButtonByTextContent(/Tool calls.*\(2\).*PreToolUse:Read error/);
+    expect(screen.queryByText("Hook: PreToolUse:Bash error")).toBeNull();
+
+    fireEvent.click(disclosure);
+
+    expect(screen.getByText("PreToolUse:Bash error")).toBeTruthy();
+    expect(screen.getAllByText("PreToolUse:Read error").length).toBeGreaterThan(0);
+    expect(screen.getByText("Command rejected by hook")).toBeTruthy();
+    expect(screen.getByText("Read rejected by hook")).toBeTruthy();
+  });
+
   // Work-log grouping, file-change grouping, and overflow-expand tests
   // removed: they tested old ChatWorkLogBlock rendering (Show N earlier,
   // specific label text) which changes with every UI iteration.

--- a/apps/desktop/src/renderer/components/chat/ChatWorkLogBlock.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatWorkLogBlock.tsx
@@ -85,6 +85,9 @@ function entryArgText(entry: ChatWorkLogEntry): string {
   if (entry.entryKind === "web_search") {
     return summarizeInlineText(entry.query ?? "", 140);
   }
+  if (entry.entryKind === "hook") {
+    return summarizeInlineText(entry.detail ?? entry.label, 140);
+  }
   if (entry.entryKind === "tool" && entry.toolName) {
     const meta = getToolMeta(entry.toolName);
     const args = readRecord(entry.args) ?? {};
@@ -214,6 +217,7 @@ function terminalizePrompt(args: {
 function workLogEntryKindSlug(entry: ChatWorkLogEntry): string {
   if (entry.entryKind === "command") return "shell";
   if (entry.entryKind === "web_search") return "search";
+  if (entry.entryKind === "hook") return "hook";
   if (entry.entryKind === "tool" && entry.toolName?.trim()) {
     let raw = entry.toolName.trim();
     if (raw.includes(".")) {
@@ -448,6 +452,11 @@ function buildEntryDetail(entry: ChatWorkLogEntry): string | null {
     const out = entry.output?.trim();
     if (!out) return null;
     return out;
+  }
+  if (entry.entryKind === "hook") {
+    const out = entry.output?.trim();
+    if (out) return out;
+    return entry.detail?.trim().length ? entry.detail : null;
   }
   if (entry.entryKind === "web_search") {
     const action = entry.action?.trim();

--- a/apps/desktop/src/renderer/components/chat/chatTranscriptRows.test.ts
+++ b/apps/desktop/src/renderer/components/chat/chatTranscriptRows.test.ts
@@ -1342,6 +1342,63 @@ describe("chatTranscriptRows edge cases", () => {
     expect(rows[0]!.event.items).toHaveLength(2);
   });
 
+  it("batches Claude PreToolUse hook errors into compact work-log groups", () => {
+    const grouped = groupEvents([
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:00.000Z",
+        event: {
+          type: "tool_call",
+          tool: "functions.exec_command",
+          args: { cmd: "pwd" },
+          itemId: "tool-1",
+          turnId: "turn-1",
+        },
+      },
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:01.000Z",
+        event: {
+          type: "system_notice",
+          noticeKind: "hook",
+          message: "Hook: PreToolUse:Bash error",
+          detail: "Command rejected by hook",
+          turnId: "turn-1",
+        },
+      },
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:02.000Z",
+        event: {
+          type: "system_notice",
+          noticeKind: "hook",
+          message: "Hook: PreToolUse:Read error",
+          detail: "Read rejected by hook",
+          turnId: "turn-1",
+        },
+      },
+    ]);
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0]!.event.type).toBe("work_log_group");
+    if (grouped[0]!.event.type !== "work_log_group") {
+      throw new Error("Expected a work log group");
+    }
+    expect(grouped[0]!.event.entries.map((entry) => entry.entryKind)).toEqual(["tool", "hook", "hook"]);
+    expect(grouped[0]!.event.entries[1]).toMatchObject({
+      label: "Hook",
+      detail: "PreToolUse:Bash error",
+      output: "Command rejected by hook",
+      status: "failed",
+      tone: "error",
+    });
+    expect(grouped[0]!.event.entries[2]).toMatchObject({
+      detail: "PreToolUse:Read error",
+      output: "Read rejected by hook",
+      status: "failed",
+    });
+  });
+
   it("builds web_search work log entries", () => {
     const rows = collapseChatTranscriptEvents([
       {

--- a/apps/desktop/src/renderer/components/chat/chatTranscriptRows.ts
+++ b/apps/desktop/src/renderer/components/chat/chatTranscriptRows.ts
@@ -1,7 +1,7 @@
 import type { AgentChatEvent, AgentChatEventEnvelope } from "../../../shared/types";
 
 export type ChatWorkLogStatus = "running" | "completed" | "failed" | "interrupted";
-export type ChatWorkLogEntryKind = "tool" | "command" | "file_change" | "web_search";
+export type ChatWorkLogEntryKind = "tool" | "command" | "file_change" | "web_search" | "hook";
 export type ChatWorkLogEntryTone = "tool" | "info" | "error";
 
 export type ChatLocalhostUrl = {
@@ -122,6 +122,13 @@ function isLowValueHookNotice(event: Extract<AgentChatEvent, { type: "system_not
   const message = event.message.trim();
   return /^hook:\s+.+\s+started$/i.test(message)
     || message.toLowerCase() === "trimmed large tool output before sending it back to claude.";
+}
+
+function summarizePreToolUseHookError(event: Extract<AgentChatEvent, { type: "system_notice" }>): string | null {
+  if (event.noticeKind !== "hook") return null;
+  const message = event.message.replace(/\s+/g, " ").trim();
+  const match = message.match(/^hook:\s*(PreToolUse:[^\n]+?\s+error)$/i);
+  return match?.[1]?.trim() ?? null;
 }
 
 const LOCALHOST_URL_PATTERN =
@@ -450,6 +457,29 @@ function buildWebSearchWorkLogEvent(
   };
 }
 
+function buildHookErrorWorkLogEvent(
+  event: Extract<AgentChatEvent, { type: "system_notice" }>,
+  timestamp: string,
+  sequence: number,
+  summary: string,
+): WorkLogRenderEvent {
+  const detail = eventHasPayload(event.detail) ? formatStructuredValue(event.detail) : undefined;
+  return {
+    type: "work_log_entry",
+    entry: withLocalhostUrls({
+      id: ["hook-error", event.turnId ?? "no-turn", sequence, summary].join("::"),
+      createdAt: timestamp,
+      label: "Hook",
+      detail: summary,
+      ...(detail ? { output: detail } : {}),
+      tone: "error",
+      status: "failed",
+      entryKind: "hook",
+      ...(event.turnId ? { turnId: event.turnId } : {}),
+    }),
+  };
+}
+
 function mergeFileChanges(
   previous: ReadonlyArray<ChatWorkLogFileChange> | undefined,
   next: ReadonlyArray<ChatWorkLogFileChange> | undefined,
@@ -603,6 +633,16 @@ export function appendCollapsedChatTranscriptEvent(
       return;
     }
     if (isLowValueHookNotice(event)) {
+      return;
+    }
+    const preToolUseHookError = summarizePreToolUseHookError(event);
+    if (preToolUseHookError) {
+      appendWorkLogRow(
+        rows,
+        envelope,
+        sequence,
+        buildHookErrorWorkLogEvent(event, envelope.timestamp, sequence, preToolUseHookError),
+      );
       return;
     }
   }


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fspecific-tool-hook-error-clude-afc9f82c num=677 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fspecific-tool-hook-error-clude-afc9f82c&amp;pr=677">ade/specific-tool-hook-error-clude-afc9f82c branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=677">PR #677</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how certain chat hook errors appear in the transcript, so they now show up clearly in the compact “Tool calls” section and expand with the right error details.
  * Fixed grouping so related hook errors are bundled together instead of being treated as generic notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The review has been submitted successfully. Two minor P2 suggestions were made: (1) align the `\s*` regex quantifier in `summarizePreToolUseHookError` to `\s+` to match the sibling `isLowValueHookNotice` guard, and (2) remove the `buildEntryDetail` fallback that returns `entry.detail` for hook entries when no output is present, as it would render the same text already shown in the compact row.

<h3>Confidence Score: 4/5</h3>

The change is narrowly scoped to transcript display logic with no data-mutation side-effects; both unit and integration tests cover the new path.

The logic is correct and well-tested. Two minor style/consistency points exist: the regex uses \s* where the sibling guard uses \s+, and the expanded-detail fallback for hook entries mirrors the compact label when no rejection message is present.

chatTranscriptRows.ts — the \s* vs \s+ regex inconsistency and ChatWorkLogBlock.tsx — the buildEntryDetail fallback.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/chat/chatTranscriptRows.ts | Adds hook to ChatWorkLogEntryKind, summarizePreToolUseHookError(), and buildHookErrorWorkLogEvent(); minor whitespace-pattern inconsistency in regex vs. isLowValueHookNotice. |
| apps/desktop/src/renderer/components/chat/ChatWorkLogBlock.tsx | Adds hook-kind branches to entryArgText, workLogEntryKindSlug, and buildEntryDetail; fallback to entry.detail produces redundant expanded-view content when no output is present. |
| apps/desktop/src/renderer/components/chat/chatTranscriptRows.test.ts | Adds unit test verifying PreToolUse hook errors are batched into a single work_log_group with the correct entry shape. |
| apps/desktop/src/renderer/components/chat/AgentChatMessageList.test.tsx | Adds integration test verifying hook errors render inside the compact Tool calls disclosure and expand correctly. |

<sub>Reviews (1): Last reviewed commit: ["Compact Claude hook errors in chat"](https://github.com/arul28/ade/commit/c7d9ff1dbe6b1d7bc2ed2bc9ba83796c83359b29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40975298)</sub>

<!-- /greptile_comment -->