### PR TITLE
Context Menu Positioning Lane Chat

### DIFF
--- a/apps/desktop/src/renderer/components/app/TabNav.tsx
+++ b/apps/desktop/src/renderer/components/app/TabNav.tsx
@@ -14,6 +14,7 @@ import {
   GearSix,
 } from "@phosphor-icons/react";
 import { cn } from "../ui/cn";
+import { useClampedFixedPosition } from "../../hooks/useClampedFixedPosition";
 import { useAppStore } from "../../state/appStore";
 import { revealLabel } from "../../lib/platform";
 import { openExternalUrl } from "../../lib/openExternal";
@@ -106,6 +107,7 @@ export function TabNav({ githubStatus }: { githubStatus?: GitHubStatus | null })
     projectBinding?.kind === "remote" ? projectBinding.rootPath : (project?.rootPath ?? null);
   const hasActiveProject = Boolean(activeProjectRoot);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const { ref: sidebarMenuRef, position: sidebarMenuPosition } = useClampedFixedPosition(contextMenu);
   const [avatarBroken, setAvatarBroken] = useState(false);
   const [isPackaged, setIsPackaged] = useState(false);
   const githubLogin = githubStatus?.userLogin || null;
@@ -329,8 +331,13 @@ export function TabNav({ githubStatus }: { githubStatus?: GitHubStatus | null })
       {/* Context menu */}
       {contextMenu && activeProjectRoot ? (
         <div
+          ref={sidebarMenuRef}
           className="ade-shell-sidebar-menu fixed z-40 min-w-[170px] p-1 shadow-float"
-          style={{ left: contextMenu.x, top: contextMenu.y }}
+          style={{
+            left: sidebarMenuPosition?.left ?? contextMenu.x,
+            top: sidebarMenuPosition?.top ?? contextMenu.y,
+            visibility: sidebarMenuPosition ? "visible" : "hidden",
+          }}
           onPointerDown={(e) => e.stopPropagation()}
         >
           <button

--- a/apps/desktop/src/renderer/components/files/v2/ContextMenu.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/ContextMenu.tsx
@@ -29,7 +29,7 @@ export function ContextMenu({
   onClose: () => void;
 }) {
   const itemsKey = items.map((item) => (item.type === "separator" ? "|" : `${item.label}:${item.disabled ? "0" : "1"}`)).join("\0");
-  const { ref, position } = useClampedFixedPosition({ x, y }, [itemsKey]);
+  const { ref, position } = useClampedFixedPosition({ x, y }, itemsKey);
 
   useEffect(() => {
     const onDocMouseDown = (e: MouseEvent) => {

--- a/apps/desktop/src/renderer/components/files/v2/ContextMenu.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/ContextMenu.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 import { COLORS } from "../../lanes/laneDesignTokens";
+import { useClampedFixedPosition } from "../../../hooks/useClampedFixedPosition";
 
 export type ContextMenuItem =
   | { type: "separator" }
@@ -27,7 +28,8 @@ export function ContextMenu({
   items: ContextMenuItem[];
   onClose: () => void;
 }) {
-  const ref = useRef<HTMLDivElement | null>(null);
+  const itemsKey = items.map((item) => (item.type === "separator" ? "|" : `${item.label}:${item.disabled ? "0" : "1"}`)).join("\0");
+  const { ref, position } = useClampedFixedPosition({ x, y }, [itemsKey]);
 
   useEffect(() => {
     const onDocMouseDown = (e: MouseEvent) => {
@@ -47,18 +49,16 @@ export function ContextMenu({
   }, [onClose]);
 
   const width = 220;
-  const estHeight = items.reduce((h, it) => h + (it.type === "separator" ? 9 : ROW_H), 8);
-  const left = Math.max(6, Math.min(x, window.innerWidth - width - 6));
-  const top = Math.max(6, Math.min(y, window.innerHeight - estHeight - 6));
 
   return (
     <div
       ref={ref}
       className="fixed z-[200] py-1"
       style={{
-        left,
-        top,
+        left: position?.left ?? x,
+        top: position?.top ?? y,
         width,
+        visibility: position ? "visible" : "hidden",
         background: COLORS.cardBgSolid,
         border: `1px solid ${COLORS.outlineBorder}`,
         borderRadius: 10,

--- a/apps/desktop/src/renderer/components/graph/WorkspaceGraphPage.tsx
+++ b/apps/desktop/src/renderer/components/graph/WorkspaceGraphPage.tsx
@@ -345,7 +345,7 @@ function GraphInner({ active = true }: { active?: boolean }) {
   const [contextMenu, setContextMenu] = React.useState<{ laneId: string; x: number; y: number } | null>(null);
   const { ref: graphContextMenuRef, position: graphContextMenuPosition } = useClampedFixedPosition(
     contextMenu ? { x: contextMenu.x, y: contextMenu.y } : null,
-    [contextMenu?.laneId],
+    contextMenu?.laneId ?? null,
   );
   const [selectedLaneIds, setSelectedLaneIds] = React.useState<string[]>([]);
   const [batchStatus, setBatchStatus] = React.useState<{

--- a/apps/desktop/src/renderer/components/graph/WorkspaceGraphPage.tsx
+++ b/apps/desktop/src/renderer/components/graph/WorkspaceGraphPage.tsx
@@ -60,6 +60,7 @@ import { Button } from "../ui/Button";
 import { Chip } from "../ui/Chip";
 import { EmptyState } from "../ui/EmptyState";
 import { cn } from "../ui/cn";
+import { useClampedFixedPosition } from "../../hooks/useClampedFixedPosition";
 import { useLaneAgents, type LaneAgent } from "../lanes/laneAgents";
 import { openAgentInWorkTabPath } from "../../lib/laneNavigation";
 import {
@@ -342,6 +343,10 @@ function GraphInner({ active = true }: { active?: boolean }) {
   const [loadingRisk, setLoadingRisk] = React.useState(true);
   const [errorBanner, setErrorBanner] = React.useState<string | null>(null);
   const [contextMenu, setContextMenu] = React.useState<{ laneId: string; x: number; y: number } | null>(null);
+  const { ref: graphContextMenuRef, position: graphContextMenuPosition } = useClampedFixedPosition(
+    contextMenu ? { x: contextMenu.x, y: contextMenu.y } : null,
+    [contextMenu?.laneId],
+  );
   const [selectedLaneIds, setSelectedLaneIds] = React.useState<string[]>([]);
   const [batchStatus, setBatchStatus] = React.useState<{
     operation: string;
@@ -3531,8 +3536,13 @@ function GraphInner({ active = true }: { active?: boolean }) {
 
       {contextMenu ? (
         <div
+          ref={graphContextMenuRef}
           className="fixed z-[90] min-w-[190px] rounded-xl border border-white/[0.06] bg-white/[0.03] backdrop-blur-xl p-1 shadow-float"
-          style={{ left: contextMenu.x, top: contextMenu.y }}
+          style={{
+            left: graphContextMenuPosition?.left ?? contextMenu.x,
+            top: graphContextMenuPosition?.top ?? contextMenu.y,
+            visibility: graphContextMenuPosition ? "visible" : "hidden",
+          }}
           onMouseLeave={() => setContextMenu(null)}
         >
           {(() => {

--- a/apps/desktop/src/renderer/components/lanes/LaneContextMenu.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneContextMenu.tsx
@@ -113,7 +113,7 @@ export function LaneContextMenu({
 
   const { ref: menuRef, position: menuPosition } = useClampedFixedPosition(
     { x: laneContextMenu.x, y: laneContextMenu.y },
-    [laneContextMenu.laneId, ctxLane?.id],
+    `${laneContextMenu.laneId}:${ctxLane?.id ?? ""}`,
   );
 
   React.useEffect(() => {

--- a/apps/desktop/src/renderer/components/lanes/LaneContextMenu.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LaneContextMenu.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { LaneSummary } from "../../../shared/types";
+import { useClampedFixedPosition } from "../../hooks/useClampedFixedPosition";
 import { revealLabel } from "../../lib/platform";
 import { useAppStore } from "../../state/appStore";
 import { COLORS, MONO_FONT } from "./laneDesignTokens";
@@ -83,6 +84,7 @@ export function LaneContextMenu({
   onSelectAll,
   onBatchManage,
   onAppearanceChanged,
+  onStartChatInLane,
 }: {
   laneContextMenu: { laneId: string; x: number; y: number };
   lanesById: Map<string, LaneSummary>;
@@ -97,6 +99,7 @@ export function LaneContextMenu({
   onSelectAll: () => void;
   onBatchManage: (laneIds: string[]) => void;
   onAppearanceChanged?: () => void | Promise<void>;
+  onStartChatInLane?: (laneId: string) => void;
 }) {
   const isRemoteProject = useAppStore((s) => s.projectBinding?.kind === "remote");
   const ctxLane = lanesById.get(laneContextMenu.laneId) ?? null;
@@ -108,7 +111,10 @@ export function LaneContextMenu({
     return lane && lane.laneType !== "primary";
   });
 
-  const menuRef = React.useRef<HTMLDivElement>(null);
+  const { ref: menuRef, position: menuPosition } = useClampedFixedPosition(
+    { x: laneContextMenu.x, y: laneContextMenu.y },
+    [laneContextMenu.laneId, ctxLane?.id],
+  );
 
   React.useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -139,8 +145,9 @@ export function LaneContextMenu({
         overflowY: "auto",
         border: `1px solid ${COLORS.outlineBorder}`,
         padding: "4px 0",
-        left: laneContextMenu.x,
-        top: Math.min(laneContextMenu.y, window.innerHeight - 20),
+        left: menuPosition?.left ?? laneContextMenu.x,
+        top: menuPosition?.top ?? laneContextMenu.y,
+        visibility: menuPosition ? "visible" : "hidden",
       }}
       onPointerDown={(e) => e.stopPropagation()}
     >
@@ -231,6 +238,23 @@ export function LaneContextMenu({
               Copy Linear Issue Link
             </HoverButton>
           ) : null}
+        </>
+      ) : null}
+
+      {ctxLane && onStartChatInLane ? (
+        <>
+          <div style={{ height: 1, background: COLORS.border, margin: "4px 0" }} />
+          <HoverButton
+            style={menuItemStyle}
+            dataTour="lanes.startChatInLane"
+            onClick={() => {
+              const ctxLaneId = laneContextMenu.laneId;
+              onClose();
+              onStartChatInLane(ctxLaneId);
+            }}
+          >
+            Start chat in lane
+          </HoverButton>
         </>
       ) : null}
 

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -15,6 +15,7 @@ import { ResizeGutter } from "../ui/ResizeGutter";
 import { LaneStackPane } from "./LaneStackPane";
 import { useLaneAgents, type LaneAgent } from "./laneAgents";
 import { openAgentInWorkTabPath } from "../../lib/laneNavigation";
+import { startChatDraftPatch } from "../../lib/workDraft";
 import {
   consumeLaunchedLanesHighlight,
   subscribeLaunchedLanesHighlight,
@@ -423,6 +424,7 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
   const setLaneInspectorTab = useAppStore((s) => s.setLaneInspectorTab);
   const clearLaneInspectorTab = useAppStore((s) => s.clearLaneInspectorTab);
   const setLaneWorkViewState = useAppStore((s) => s.setLaneWorkViewState);
+  const setWorkViewState = useAppStore((s) => s.setWorkViewState);
   const keybindings = useAppStore((s) => s.keybindings);
   const activeProjectRoot = useAppStore(selectActiveProjectRoot);
   const getActiveProjectRoot = useCallback(() => {
@@ -1276,6 +1278,20 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     window.addEventListener("pointerdown", onPointerDown);
     return () => window.removeEventListener("pointerdown", onPointerDown);
   }, [laneContextMenu]);
+
+  const startChatInLane = useCallback(
+    (laneId: string) => {
+      if (activeProjectRoot) {
+        setWorkViewState(activeProjectRoot, (prev) => ({
+          ...prev,
+          ...startChatDraftPatch(laneId),
+        }));
+      }
+      selectLane(laneId);
+      void navigate("/work");
+    },
+    [activeProjectRoot, navigate, selectLane, setWorkViewState],
+  );
 
   useEffect(() => {
     if (!adoptTargetLaneId) return;
@@ -4211,6 +4227,7 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
           }}
           onBatchManage={openBatchManage}
           onAppearanceChanged={() => refreshLanes({ includeStatus: false }).catch(() => {})}
+          onStartChatInLane={startChatInLane}
         />
       ) : null}
 

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -15,7 +15,7 @@ import { ResizeGutter } from "../ui/ResizeGutter";
 import { LaneStackPane } from "./LaneStackPane";
 import { useLaneAgents, type LaneAgent } from "./laneAgents";
 import { openAgentInWorkTabPath } from "../../lib/laneNavigation";
-import { startChatDraftPatch } from "../../lib/workDraft";
+import { useStartChatInLane } from "../../hooks/useStartChatInLane";
 import {
   consumeLaunchedLanesHighlight,
   subscribeLaunchedLanesHighlight,
@@ -1279,19 +1279,12 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     return () => window.removeEventListener("pointerdown", onPointerDown);
   }, [laneContextMenu]);
 
-  const startChatInLane = useCallback(
-    (laneId: string) => {
-      if (activeProjectRoot) {
-        setWorkViewState(activeProjectRoot, (prev) => ({
-          ...prev,
-          ...startChatDraftPatch(laneId),
-        }));
-      }
-      selectLane(laneId);
-      void navigate("/work");
-    },
-    [activeProjectRoot, navigate, selectLane, setWorkViewState],
-  );
+  const startChatInLane = useStartChatInLane({
+    projectRoot: activeProjectRoot,
+    setWorkViewState,
+    selectLane,
+    navigate,
+  });
 
   useEffect(() => {
     if (!adoptTargetLaneId) return;

--- a/apps/desktop/src/renderer/components/terminals/SessionContextMenu.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionContextMenu.tsx
@@ -51,7 +51,7 @@ export function SessionContextMenu({
   const finalizedRef = useRef(false);
   const { ref: menuRef, position: clampedPosition } = useClampedFixedPosition(
     menu ? { x: menu.x, y: menu.y } : null,
-    [menu?.x, menu?.y, renaming],
+    renaming,
   );
 
   // Reset rename state when menu changes

--- a/apps/desktop/src/renderer/components/terminals/SessionContextMenu.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionContextMenu.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef, useEffect, useLayoutEffect } from "react";
+import { useState, useRef, useEffect } from "react";
 import type { TerminalSessionSummary } from "../../../shared/types";
+import { useClampedFixedPosition } from "../../hooks/useClampedFixedPosition";
 import { isChatToolType } from "../../lib/sessions";
 
 export type SessionContextMenuState = {
@@ -47,14 +48,11 @@ export function SessionContextMenu({
   const [renaming, setRenaming] = useState(false);
   const [draft, setDraft] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
   const finalizedRef = useRef(false);
-  const [clampedPosition, setClampedPosition] = useState<{
-    sourceX: number;
-    sourceY: number;
-    left: number;
-    top: number;
-  } | null>(null);
+  const { ref: menuRef, position: clampedPosition } = useClampedFixedPosition(
+    menu ? { x: menu.x, y: menu.y } : null,
+    [menu?.x, menu?.y, renaming],
+  );
 
   // Reset rename state when menu changes
   useEffect(() => {
@@ -71,36 +69,10 @@ export function SessionContextMenu({
     }
   }, [renaming]);
 
-  useLayoutEffect(() => {
-    if (!menu) return;
-    if (!menuRef.current) return;
-    const { x, y } = menu;
-    const padding = 8;
-    const rect = menuRef.current.getBoundingClientRect();
-    const maxLeft = Math.max(padding, window.innerWidth - rect.width - padding);
-    const maxTop = Math.max(padding, window.innerHeight - rect.height - padding);
-    const left = Math.min(Math.max(padding, x), maxLeft);
-    const top = Math.min(Math.max(padding, y), maxTop);
-    setClampedPosition((prev) => {
-      if (
-        prev?.sourceX === x &&
-        prev.sourceY === y &&
-        Math.abs(prev.left - left) < 0.5 &&
-        Math.abs(prev.top - top) < 0.5
-      ) {
-        return prev;
-      }
-      return { sourceX: x, sourceY: y, left, top };
-    });
-  }, [menu, renaming]);
-
   if (!menu) return null;
 
   const { session, x, y } = menu;
-  const menuPosition =
-    clampedPosition?.sourceX === x && clampedPosition.sourceY === y
-      ? { left: clampedPosition.left, top: clampedPosition.top }
-      : { left: x, top: y };
+  const menuPosition = clampedPosition ?? { left: x, top: y };
   const isRunning = session.status === "running";
   const isChat = isChatToolType(session.toolType);
 
@@ -123,7 +95,10 @@ export function SessionContextMenu({
       <div
         ref={menuRef}
         className="ade-liquid-glass-menu fixed z-50 min-w-[180px] py-1"
-        style={menuPosition}
+        style={{
+          ...menuPosition,
+          visibility: clampedPosition ? "visible" : "hidden",
+        }}
         onPointerDown={(e) => e.stopPropagation()}
       >
         {renaming && (

--- a/apps/desktop/src/renderer/components/terminals/useWorkLaneContextMenu.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/useWorkLaneContextMenu.test.tsx
@@ -1,0 +1,108 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, render, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import type { LaneSummary } from "../../../shared/types";
+import { useWorkLaneContextMenu } from "./useWorkLaneContextMenu";
+
+const navigate = vi.fn();
+const selectLane = vi.fn();
+const setWorkViewState = vi.fn();
+
+let capturedLaneContextMenuProps: Record<string, unknown> | null = null;
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+vi.mock("../../state/appStore", async () => {
+  const actual = await vi.importActual<typeof import("../../state/appStore")>("../../state/appStore");
+  return {
+    ...actual,
+    useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+      selector({
+        lanes: [
+          {
+            id: "lane-remote",
+            name: "Remote Lane",
+            laneType: "worktree",
+            baseRef: "main",
+            branchRef: "remote-lane",
+            worktreePath: "/tmp/remote-lane",
+            parentLaneId: null,
+            childCount: 0,
+            stackDepth: 0,
+            parentStatus: null,
+            isEditProtected: false,
+            status: { dirty: false, ahead: 0, behind: 0, remoteBehind: 0, rebaseInProgress: false },
+            color: null,
+            icon: null,
+            tags: [],
+            createdAt: "2026-04-22T10:00:00.000Z",
+          } satisfies LaneSummary,
+        ],
+        project: { rootPath: "/local/project" },
+        projectBinding: { kind: "remote", rootPath: "/remote/project" },
+        selectLane,
+        setWorkViewState,
+      }),
+  };
+});
+
+vi.mock("../lanes/LaneContextMenu", () => ({
+  LaneContextMenu: (props: Record<string, unknown>) => {
+    capturedLaneContextMenuProps = props;
+    return null;
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  capturedLaneContextMenuProps = null;
+  navigate.mockReset();
+  selectLane.mockReset();
+  setWorkViewState.mockReset();
+});
+
+describe("useWorkLaneContextMenu", () => {
+  it("persists start-chat draft state under the active project root for remote projects", () => {
+    const { result } = renderHook(() => useWorkLaneContextMenu(), {
+      wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+    });
+
+    act(() => {
+      result.current.trigger("lane-remote", {
+        preventDefault: vi.fn(),
+        clientX: 12,
+        clientY: 34,
+      });
+    });
+
+    render(<>{result.current.menu}</>);
+
+    expect(capturedLaneContextMenuProps).not.toBeNull();
+    const onStartChatInLane = capturedLaneContextMenuProps?.onStartChatInLane as (laneId: string) => void;
+
+    act(() => {
+      onStartChatInLane("lane-remote");
+    });
+
+    expect(setWorkViewState).toHaveBeenCalledWith("/remote/project", expect.any(Function));
+    const updater = setWorkViewState.mock.calls[0]?.[1] as (prev: Record<string, unknown>) => Record<string, unknown>;
+    expect(updater({ draftKind: "cli", orchestratorEnabled: true, activeItemId: "session-1" })).toMatchObject({
+      draftKind: "chat",
+      orchestratorEnabled: false,
+      draftLaneId: "lane-remote",
+      activeItemId: null,
+      selectedItemId: null,
+    });
+    expect(selectLane).toHaveBeenCalledWith("lane-remote");
+    expect(navigate).toHaveBeenCalledWith("/work");
+  });
+});

--- a/apps/desktop/src/renderer/components/terminals/useWorkLaneContextMenu.tsx
+++ b/apps/desktop/src/renderer/components/terminals/useWorkLaneContextMenu.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
-import { useAppStore } from "../../state/appStore";
+import { useAppStore, selectActiveProjectRoot } from "../../state/appStore";
+import { startChatDraftPatch } from "../../lib/workDraft";
 import { LaneContextMenu } from "../lanes/LaneContextMenu";
 
 type MenuState = { laneId: string; x: number; y: number };
@@ -18,6 +19,8 @@ export function useWorkLaneContextMenu(): {
   const navigate = useNavigate();
   const lanes = useAppStore((s) => s.lanes);
   const selectLane = useAppStore((s) => s.selectLane);
+  const projectRoot = useAppStore(selectActiveProjectRoot);
+  const setWorkViewState = useAppStore((s) => s.setWorkViewState);
 
   const [menuState, setMenuState] = useState<MenuState | null>(null);
 
@@ -57,6 +60,20 @@ export function useWorkLaneContextMenu(): {
     [navigate, selectLane],
   );
 
+  const startChatInLane = useCallback(
+    (laneId: string) => {
+      if (projectRoot) {
+        setWorkViewState(projectRoot, (prev) => ({
+          ...prev,
+          ...startChatDraftPatch(laneId),
+        }));
+      }
+      selectLane(laneId);
+      void navigate("/work");
+    },
+    [navigate, projectRoot, selectLane, setWorkViewState],
+  );
+
   const menu = menuState
     ? createPortal(
         <LaneContextMenu
@@ -84,6 +101,7 @@ export function useWorkLaneContextMenu(): {
             if (!laneIds.length) return;
             goToLanesAction(laneIds[0], "batch", { laneIds: laneIds.join(",") });
           }}
+          onStartChatInLane={startChatInLane}
         />,
         document.body,
       )

--- a/apps/desktop/src/renderer/components/terminals/useWorkLaneContextMenu.tsx
+++ b/apps/desktop/src/renderer/components/terminals/useWorkLaneContextMenu.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
 import { useAppStore, selectActiveProjectRoot } from "../../state/appStore";
-import { startChatDraftPatch } from "../../lib/workDraft";
+import { useStartChatInLane } from "../../hooks/useStartChatInLane";
 import { LaneContextMenu } from "../lanes/LaneContextMenu";
 
 type MenuState = { laneId: string; x: number; y: number };
@@ -60,19 +60,12 @@ export function useWorkLaneContextMenu(): {
     [navigate, selectLane],
   );
 
-  const startChatInLane = useCallback(
-    (laneId: string) => {
-      if (projectRoot) {
-        setWorkViewState(projectRoot, (prev) => ({
-          ...prev,
-          ...startChatDraftPatch(laneId),
-        }));
-      }
-      selectLane(laneId);
-      void navigate("/work");
-    },
-    [navigate, projectRoot, selectLane, setWorkViewState],
-  );
+  const startChatInLane = useStartChatInLane({
+    projectRoot,
+    setWorkViewState,
+    selectLane,
+    navigate,
+  });
 
   const menu = menuState
     ? createPortal(

--- a/apps/desktop/src/renderer/hooks/useClampedFixedPosition.test.ts
+++ b/apps/desktop/src/renderer/hooks/useClampedFixedPosition.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { clampFixedPosition } from "./useClampedFixedPosition";
+
+describe("clampFixedPosition", () => {
+  it("keeps menus inside the viewport on both axes", () => {
+    const result = clampFixedPosition(
+      { x: 900, y: 700 },
+      { width: 220, height: 320 },
+      8,
+      { width: 1024, height: 768 },
+    );
+    expect(result.left).toBe(796);
+    expect(result.top).toBe(440);
+  });
+
+  it("respects padding when the menu is larger than the viewport", () => {
+    const result = clampFixedPosition(
+      { x: 12, y: 18 },
+      { width: 1200, height: 900 },
+      8,
+      { width: 800, height: 600 },
+    );
+    expect(result.left).toBe(8);
+    expect(result.top).toBe(8);
+  });
+});

--- a/apps/desktop/src/renderer/hooks/useClampedFixedPosition.ts
+++ b/apps/desktop/src/renderer/hooks/useClampedFixedPosition.ts
@@ -1,0 +1,50 @@
+import { useLayoutEffect, useRef, useState, type MutableRefObject } from "react";
+
+export type FixedAnchor = { x: number; y: number };
+
+export type ClampedFixedPosition = {
+  left: number;
+  top: number;
+};
+
+export function clampFixedPosition(
+  anchor: FixedAnchor,
+  size: { width: number; height: number },
+  padding = 8,
+  viewport?: { width: number; height: number },
+): ClampedFixedPosition {
+  const viewportWidth = viewport?.width ?? (typeof window !== "undefined" ? window.innerWidth : size.width + padding * 2);
+  const viewportHeight = viewport?.height ?? (typeof window !== "undefined" ? window.innerHeight : size.height + padding * 2);
+  const maxLeft = Math.max(padding, viewportWidth - size.width - padding);
+  const maxTop = Math.max(padding, viewportHeight - size.height - padding);
+  return {
+    left: Math.min(Math.max(padding, anchor.x), maxLeft),
+    top: Math.min(Math.max(padding, anchor.y), maxTop),
+  };
+}
+
+/**
+ * Keeps a fixed-position popover inside the viewport after layout, using the
+ * element's measured size (handles menus that open near window edges).
+ */
+export function useClampedFixedPosition(
+  anchor: FixedAnchor | null,
+  deps: unknown[] = [],
+): {
+  ref: MutableRefObject<HTMLDivElement | null>;
+  position: ClampedFixedPosition | null;
+} {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = useState<ClampedFixedPosition | null>(null);
+
+  useLayoutEffect(() => {
+    if (!anchor || !ref.current) {
+      setPosition(null);
+      return;
+    }
+    const rect = ref.current.getBoundingClientRect();
+    setPosition(clampFixedPosition(anchor, { width: rect.width, height: rect.height }));
+  }, [anchor?.x, anchor?.y, ...deps]);
+
+  return { ref, position };
+}

--- a/apps/desktop/src/renderer/hooks/useClampedFixedPosition.ts
+++ b/apps/desktop/src/renderer/hooks/useClampedFixedPosition.ts
@@ -29,7 +29,7 @@ export function clampFixedPosition(
  */
 export function useClampedFixedPosition(
   anchor: FixedAnchor | null,
-  deps: unknown[] = [],
+  remeasureKey: unknown = null,
 ): {
   ref: MutableRefObject<HTMLDivElement | null>;
   position: ClampedFixedPosition | null;
@@ -44,7 +44,7 @@ export function useClampedFixedPosition(
     }
     const rect = ref.current.getBoundingClientRect();
     setPosition(clampFixedPosition(anchor, { width: rect.width, height: rect.height }));
-  }, [anchor?.x, anchor?.y, ...deps]);
+  }, [anchor?.x, anchor?.y, remeasureKey]);
 
   return { ref, position };
 }

--- a/apps/desktop/src/renderer/hooks/useStartChatInLane.ts
+++ b/apps/desktop/src/renderer/hooks/useStartChatInLane.ts
@@ -1,0 +1,33 @@
+import { useCallback } from "react";
+import type { WorkProjectViewState } from "../state/appStore";
+import { startChatDraftPatch } from "../lib/workDraft";
+
+type WorkViewStateUpdater = (
+  projectRoot: string,
+  next: WorkProjectViewState | ((prev: WorkProjectViewState) => WorkProjectViewState),
+) => void;
+
+export function useStartChatInLane({
+  projectRoot,
+  setWorkViewState,
+  selectLane,
+  navigate,
+}: {
+  projectRoot: string | null;
+  setWorkViewState: WorkViewStateUpdater;
+  selectLane: (laneId: string) => void;
+  navigate: (path: string) => void | Promise<void>;
+}) {
+  return useCallback(
+    (laneId: string) => {
+      if (!projectRoot) return;
+      setWorkViewState(projectRoot, (prev) => ({
+        ...prev,
+        ...startChatDraftPatch(laneId),
+      }));
+      selectLane(laneId);
+      void navigate("/work");
+    },
+    [navigate, projectRoot, selectLane, setWorkViewState],
+  );
+}

--- a/apps/desktop/src/renderer/lib/workDraft.test.ts
+++ b/apps/desktop/src/renderer/lib/workDraft.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { startChatDraftPatch } from "./workDraft";
+
+describe("startChatDraftPatch", () => {
+  it("opens a chat draft on the requested lane and clears active session selection", () => {
+    expect(startChatDraftPatch("lane-42")).toEqual({
+      draftKind: "chat",
+      orchestratorEnabled: false,
+      draftLaneId: "lane-42",
+      activeItemId: null,
+      selectedItemId: null,
+    });
+  });
+});

--- a/apps/desktop/src/renderer/lib/workDraft.ts
+++ b/apps/desktop/src/renderer/lib/workDraft.ts
@@ -1,0 +1,16 @@
+import type { WorkProjectViewState } from "../state/appStore";
+
+export type StartChatDraftPatch = Pick<
+  WorkProjectViewState,
+  "draftKind" | "orchestratorEnabled" | "draftLaneId" | "activeItemId" | "selectedItemId"
+>;
+
+export function startChatDraftPatch(laneId: string): StartChatDraftPatch {
+  return {
+    draftKind: "chat",
+    orchestratorEnabled: false,
+    draftLaneId: laneId,
+    activeItemId: null,
+    selectedItemId: null,
+  };
+}


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fcontext-menu-positioning-lane-chat-490fc737 num=682 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fcontext-menu-positioning-lane-chat-490fc737&amp;pr=682">ade/context-menu-positioning-lane-chat-490fc737 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=682">PR #682</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Start chat in lane” action from lane context menus.
  * Starting a chat now opens the Work view with the selected lane preconfigured.
  * Improved context menu positioning across the app so menus stay visible on screen.
* **Bug Fixes**
  * Fixed context menus appearing off-screen or partially hidden in terminal, graph, lane, and tab views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds "Start chat in lane" to lane context menus and fixes context menus appearing off-screen across multiple views (terminal, graph, lane, tab) by replacing ad-hoc layout math with a shared `useClampedFixedPosition` hook.

- **New `useClampedFixedPosition` hook** measures the rendered element via `getBoundingClientRect` in a `useLayoutEffect`, hides the menu with `visibility: "hidden"` on first render, then reveals it at the correct clamped position — ensuring menus never paint off-screen even once.
- **New "Start chat in lane" action** is wired through `useStartChatInLane` (shared between `LanesPage` and `useWorkLaneContextMenu`) and `startChatDraftPatch`, with unit tests covering both the patch helper and the full navigation flow for remote projects.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all context menu sites migrate cleanly to the shared hook, and the new chat-in-lane feature is well-guarded and tested.

The positioning refactor is a straightforward extraction with identical semantics (the visibility:hidden pattern is correct and useLayoutEffect fires before paint). The new start-chat feature has unit tests covering the remote-project root path, the patch shape, and the full navigation sequence. No pre-existing guards were removed and no new unguarded code paths were introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/hooks/useClampedFixedPosition.ts | New shared hook for viewport-clamped fixed positioning; uses useLayoutEffect + visibility:hidden pattern to prevent off-screen flashes. Clean implementation with exported clampFixedPosition for testability. |
| apps/desktop/src/renderer/hooks/useStartChatInLane.ts | New custom hook extracting shared 'start chat in lane' logic; correctly guards against null projectRoot with early return. |
| apps/desktop/src/renderer/lib/workDraft.ts | New helper that returns a typed patch object for opening a chat draft on a specific lane; simple, well-typed, and tested. |
| apps/desktop/src/renderer/components/lanes/LaneContextMenu.tsx | Migrated to useClampedFixedPosition and added optional onStartChatInLane menu item behind a conditional guard. Old window.innerHeight arithmetic removed. |
| apps/desktop/src/renderer/components/terminals/useWorkLaneContextMenu.tsx | Wires useStartChatInLane and passes onStartChatInLane to LaneContextMenu; correctly selects active project root via selectActiveProjectRoot selector. |
| apps/desktop/src/renderer/components/terminals/SessionContextMenu.tsx | Replaced manual useLayoutEffect clamping with useClampedFixedPosition; simplified clampedPosition usage. Logic is equivalent to the previous implementation. |
| apps/desktop/src/renderer/components/files/v2/ContextMenu.tsx | Replaced estimated height arithmetic with useClampedFixedPosition; itemsKey is used as remeasureKey so menu remeasures when items change. Minor padding change (6→8). |
| apps/desktop/src/renderer/components/graph/WorkspaceGraphPage.tsx | Graph context menu now uses useClampedFixedPosition with laneId as remeasureKey; consistent with other menu sites. |
| apps/desktop/src/renderer/components/app/TabNav.tsx | Sidebar context menu migrated to useClampedFixedPosition; anchor is set to null when contextMenu is null so position resets correctly on close. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Right-click on lane / tab / terminal / graph node"] --> B["setState: anchor = {x, y}"]
    B --> C["Render menu div\nvisibility: hidden\nposition = null"]
    C --> D["useLayoutEffect fires\nanchor != null && ref.current != null"]
    D --> E["getBoundingClientRect()\nmeasure actual width/height"]
    E --> F["clampFixedPosition(anchor, size, padding=8)"]
    F --> G["setPosition({left, top})"]
    G --> H["Re-render\nvisibility: visible\nposition = clamped coords"]
    H --> I["Menu displayed within viewport"]

    J["User clicks 'Start chat in lane'"] --> K["onClose() - close menu"]
    K --> L["useStartChatInLane callback"]
    L --> M{projectRoot null?}
    M -- yes --> N["early return (no-op)"]
    M -- no --> O["setWorkViewState with startChatDraftPatch\ndraftKind=chat, draftLaneId, orchestratorEnabled=false"]
    O --> P["selectLane(laneId)"]
    P --> Q["navigate('/work')"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Right-click on lane / tab / terminal / graph node"] --> B["setState: anchor = {x, y}"]
    B --> C["Render menu div\nvisibility: hidden\nposition = null"]
    C --> D["useLayoutEffect fires\nanchor != null && ref.current != null"]
    D --> E["getBoundingClientRect()\nmeasure actual width/height"]
    E --> F["clampFixedPosition(anchor, size, padding=8)"]
    F --> G["setPosition({left, top})"]
    G --> H["Re-render\nvisibility: visible\nposition = clamped coords"]
    H --> I["Menu displayed within viewport"]

    J["User clicks 'Start chat in lane'"] --> K["onClose() - close menu"]
    K --> L["useStartChatInLane callback"]
    L --> M{projectRoot null?}
    M -- yes --> N["early return (no-op)"]
    M -- no --> O["setWorkViewState with startChatDraftPatch\ndraftKind=chat, draftLaneId, orchestratorEnabled=false"]
    O --> P["selectLane(laneId)"]
    P --> Q["navigate('/work')"]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Address review feedback for start-chat a..."](https://github.com/arul28/ade/commit/15484f215643b551ef8e97349dc4e698635e228d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41171874)</sub>

<!-- /greptile_comment -->