### PR TITLE
release: changelog for v1.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.11] - 2026-07-02
+
+### Added
+
+- Added `ade new chat --mode chat|cli` as the unified command for persistent Work chats and tracked provider CLI sessions, including auto-created lanes, provider/model/reasoning controls, fast-mode selection, dry-run previews, and prompt kickoff.
+- Added GitHub App device-flow auth, repository permission gates, durable repository/event storage, and relay tests for webhook-backed PR sync.
+
+### Changed
+
+- Improved Work and chat launch reliability across start-chat-in-lane, tracked CLI naming, chat PR live refresh, Claude logout recovery, compact Claude hook errors, Codex continuation recovery, and no-op prompt handling.
+- Improved Files, onboarding, browser, project secrets, and web download surfaces, including multi-lane editor tabs, removed edit-trust friction, clamped context menus, welcome-card polish, and mobile TestFlight links.
+- Improved iOS Work, Hub, PR, Files, CTO, Settings, and sync flows while keeping the current mobile marketing version for a build-number-only TestFlight update.
+
+### Removed
+
+- Removed the old edit-trust gate from the Files workflow.
+
+### Fixed
+
+- Fixed mobile sync control on remote projects, iPhone handoff recovery, chunk assembly, roster hydration, and phone-started CLI session launch parity for fast-mode and reasoning settings.
+
 ## [1.2.10] - 2026-06-28
 
 ### Added
@@ -488,7 +509,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.10...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.11...HEAD
+[1.2.11]: https://github.com/arul28/ADE/compare/v1.2.10...v1.2.11
 [1.2.10]: https://github.com/arul28/ADE/compare/v1.2.9...v1.2.10
 [1.2.9]: https://github.com/arul28/ADE/compare/v1.2.8...v1.2.9
 [1.2.8]: https://github.com/arul28/ADE/compare/v1.2.7...v1.2.8

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.10">
-  v1.2.10 - simplified onboarding with a welcome video and passive help, tighter ADE Code and chat launch behavior, more reliable Files workflows, and build-number-only iOS sync fixes.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.11">
+  v1.2.11 - unified ADE chat and CLI launching, hardened GitHub PR sync through the webhook relay, tighter Work and Files flows, and build-number-only iOS sync updates.
 </Card>

--- a/changelog/v1.2.11.mdx
+++ b/changelog/v1.2.11.mdx
@@ -1,0 +1,25 @@
+---
+title: "v1.2.11"
+description: "Release notes for ADE v1.2.11 - July 2, 2026"
+---
+
+v1.2.11 ships the new unified ADE chat/CLI launch command, hardens GitHub PR sync through the webhook relay, and tightens Work, Files, onboarding, browser, and mobile sync flows. iOS stays on its current marketing version and gets a build-number-only TestFlight update for the same release train.
+
+---
+
+## Desktop
+
+- **Unified work launch command.** `ade new chat --mode chat|cli` now mirrors the desktop New Chat toggle, with lane auto-creation, provider/model/reasoning controls, fast-mode selection, dry-run previews, and prompt kickoff for persistent Work chats or tracked provider CLI sessions.
+- **GitHub PR sync hardening.** The webhook relay now supports GitHub App device-flow auth, repository permission gates, durable repository/event records, and stronger relay tests so PR state refreshes without depending on broad user tokens.
+- **Work and chat recovery.** Start-chat-in-lane, tracked CLI session naming, chat PR live refresh, compact Claude hook errors, Claude logout recovery, Codex continuation recovery, and no-op prompt handling are all tightened.
+- **Files and project trust.** Files can keep multi-lane editor tabs open, remove the old edit-trust friction, clamp context menus to the viewport, and preserve safer remote file and markdown viewer behavior.
+- **Onboarding and web polish.** The welcome card has sharper visuals, mobile TestFlight links are available from desktop and web surfaces, the ADE browser handles popups and renderer crashes more defensively, and project secrets are available to agent-facing flows.
+
+---
+
+## iOS
+
+- **Build-number-only TestFlight update.** The mobile app keeps its existing marketing version for this train; this release only bumps the iOS build number for TestFlight.
+- **More reliable mobile sync.** Remote-project sync control, iPhone handoff, chunk assembly, roster hydration, and mobile command routing have stronger recovery paths and regression coverage.
+- **Work launch parity.** The iOS Work and Hub new-session flows pass fast-mode and reasoning settings through the runtime, so phone-started CLI sessions match desktop launch behavior.
+- **Mobile review surfaces.** PR, Files, CTO, Settings, and Work screens pick up the latest rendering, navigation, and status fixes from the desktop/runtime sync model.

--- a/docs.json
+++ b/docs.json
@@ -179,6 +179,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.11",
               "changelog/v1.2.10",
               "changelog/v1.2.9",
               "changelog/v1.2.8",


### PR DESCRIPTION
Changelog for v1.2.11. Tag will be cut after this lands on main and ci-pass is green on the release SHA.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR publishes the `v1.2.11` release notes across the project docs. The main changes are:

- Added the `v1.2.11` entry to `CHANGELOG.md`.
- Added a standalone `changelog/v1.2.11.mdx` release notes page.
- Updated the changelog landing card to link to `v1.2.11`.
- Registered the new release page in `docs.json` sidebar navigation.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

Documentation-only release updates with consistent version links and navigation entries.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Captured the before state of the changelog documentation surface, including a 404 on the /changelog/v1.2.11 page.
- Captured the after state of the changelog documentation surface, showing v1.2.11 and the rendered Release notes page with Desktop and iOS sections.
- Captured videos and poster frames that document both the before and after states of the changelog UI.

<a href="https://app.greptile.com/trex/runs/13048583/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds the `v1.2.11` release entry and updates compare links so `Unreleased` starts from the new tag. |
| changelog/index.mdx | Updates the changelog landing card to point at and summarize `v1.2.11`. |
| changelog/v1.2.11.mdx | Adds the standalone Mintlify release notes page for `v1.2.11`. |
| docs.json | Registers the `v1.2.11` changelog page in the sidebar ahead of prior releases. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Reader as Docs reader
participant Index as changelog/index.mdx
participant Page as changelog/v1.2.11.mdx
participant Nav as docs.json sidebar
participant Root as CHANGELOG.md

Reader->>Nav: Browse Changelog releases
Nav->>Page: Open v1.2.11 release page
Reader->>Index: Open changelog landing page
Index->>Page: Latest release card links to v1.2.11
Reader->>Root: Read repository changelog
Root->>Root: Compare links advance from v1.2.10 to v1.2.11
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Reader as Docs reader
participant Index as changelog/index.mdx
participant Page as changelog/v1.2.11.mdx
participant Nav as docs.json sidebar
participant Root as CHANGELOG.md

Reader->>Nav: Browse Changelog releases
Nav->>Page: Open v1.2.11 release page
Reader->>Index: Open changelog landing page
Index->>Page: Latest release card links to v1.2.11
Reader->>Root: Read repository changelog
Root->>Root: Compare links advance from v1.2.10 to v1.2.11
```

</a>

<sub>Reviews (1): Last reviewed commit: ["release: changelog for v1.2.11"](https://github.com/arul28/ade/commit/f9be99cb87a5883b27c89af72f435a93fd72c51e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41345275)</sub>

<!-- /greptile_comment -->