### PR TITLE
Github Auth Checks Failed

### DIFF
--- a/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.test.ts
+++ b/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.test.ts
@@ -44,4 +44,15 @@ describe("GitHubAppInstallPanel status helpers", () => {
     expect(view.label).toBe("Check failed");
     expect(view.description("arul28/ADE")).toBe("GitHub App relay status check failed (500)");
   });
+
+  it("detects repository-not-found error variants as pending repo access", () => {
+    expect(isGitHubAppRepoAccessPending(makeStatus({ error: "Repository not found." }))).toBe(true);
+    expect(isGitHubAppRepoAccessPending(makeStatus({ error: "Could not resolve to a Repository." }))).toBe(true);
+  });
+
+  it("ignores repo access errors when status guards do not match", () => {
+    expect(isGitHubAppRepoAccessPending(makeStatus({ relayConfigured: false }))).toBe(false);
+    expect(isGitHubAppRepoAccessPending(makeStatus({ installed: true }))).toBe(false);
+    expect(isGitHubAppRepoAccessPending(makeStatus({ state: "not_installed" }))).toBe(false);
+  });
 });

--- a/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.test.ts
+++ b/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { GitHubAppInstallationStatus } from "../../../shared/types";
+import { isGitHubAppRepoAccessPending, statusView } from "./GitHubAppInstallPanel";
+
+function makeStatus(overrides: Partial<GitHubAppInstallationStatus> = {}): GitHubAppInstallationStatus {
+  return {
+    repo: { owner: "arul28", name: "ADE" },
+    appName: "ADE",
+    appSlug: "ade-for-github",
+    installUrl: "https://github.com/apps/ade-for-github/installations/new",
+    manageUrl: "https://github.com/settings/installations",
+    relayConfigured: true,
+    installed: false,
+    state: "error",
+    installationId: null,
+    repositorySelection: null,
+    lastSeenAt: null,
+    webhookEvents: [],
+    missingWebhookEvents: [],
+    webhookState: "unknown",
+    webhookLastSeenAt: null,
+    checkedAt: "2026-07-02T18:39:42.000Z",
+    error: "Not Found",
+    ...overrides,
+  };
+}
+
+describe("GitHubAppInstallPanel status helpers", () => {
+  it("treats post-authorization GitHub repo 404s as pending repo access", () => {
+    const status = makeStatus();
+    const view = statusView(status, false, true);
+
+    expect(isGitHubAppRepoAccessPending(status)).toBe(true);
+    expect(view.label).toBe("Checking access");
+    expect(view.description("arul28/ADE")).toContain("GitHub accepted authorization");
+    expect(view.description("arul28/ADE")).toContain("select this repo in GitHub");
+  });
+
+  it("keeps non-propagation relay failures as check failures after authorization", () => {
+    const status = makeStatus({ error: "GitHub App relay status check failed (500)" });
+    const view = statusView(status, false, true);
+
+    expect(isGitHubAppRepoAccessPending(status)).toBe(false);
+    expect(view.label).toBe("Check failed");
+    expect(view.description("arul28/ADE")).toBe("GitHub App relay status check failed (500)");
+  });
+});

--- a/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.tsx
+++ b/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.tsx
@@ -79,21 +79,24 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
         error: error instanceof Error ? error.message : String(error),
       });
     } finally {
-      if (!mountedRef.current || statusRequestSeqRef.current !== requestSeq) return;
+      const isCurrentRequest = () => mountedRef.current && statusRequestSeqRef.current === requestSeq;
       // Read auth state AFTER the status call (success or failure): an
       // expired stored token can be cleared during the status check, and the
       // panel must reflect that immediately.
-      const authStatus = await window.ade.github.getAppUserAuthStatus?.().catch(() => null);
-      if (!mountedRef.current || statusRequestSeqRef.current !== requestSeq) return;
-      setAppAuth(authStatus ?? null);
-      if (opts.retryAfterAuthorization) {
-        setDeviceMessage(
-          latestStatus && isGitHubAppRepoAccessPending(latestStatus)
-            ? "GitHub authorization is complete. Repository access is still warming up; use Refresh again in a moment."
-            : null,
-        );
+      if (isCurrentRequest()) {
+        const authStatus = await window.ade.github.getAppUserAuthStatus?.().catch(() => null);
+        if (isCurrentRequest()) {
+          setAppAuth(authStatus ?? null);
+          if (opts.retryAfterAuthorization) {
+            setDeviceMessage(
+              latestStatus && isGitHubAppRepoAccessPending(latestStatus)
+                ? "GitHub authorization is complete. Repository access is still warming up; use Refresh again in a moment."
+                : null,
+            );
+          }
+          setLoading(false);
+        }
       }
-      setLoading(false);
     }
   }, []);
 

--- a/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.tsx
+++ b/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.tsx
@@ -12,6 +12,7 @@ import { COLORS, MONO_FONT, SANS_FONT, cardStyle, inlineBadge, outlineButton, pr
 const ADE_GITHUB_APP_NAME = "ADE";
 const ADE_GITHUB_APP_INSTALL_URL = "https://github.com/apps/ade-for-github/installations/new";
 const GITHUB_APP_INSTALLATIONS_URL = "https://github.com/settings/installations";
+const POST_AUTH_STATUS_RETRY_DELAYS_MS = [1_500, 3_000, 6_000] as const;
 
 type GitHubAppInstallPanelProps = {
   variant?: "settings" | "onboarding";
@@ -29,14 +30,35 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
   const autoRenewCountRef = useRef(0);
   const copyFeedbackTimeoutRef = useRef<number | null>(null);
   const appAuthRef = useRef<GitHubAppUserAuthStatus | null>(null);
+  const statusRequestSeqRef = useRef(0);
+  const mountedRef = useRef(true);
   appAuthRef.current = appAuth;
 
-  const loadStatus = useCallback(async (forceRefresh = false) => {
+  const loadStatus = useCallback(async (forceRefresh = false, opts: { retryAfterAuthorization?: boolean } = {}) => {
     if (!window.ade?.github?.getAppInstallationStatus) return;
+    const requestSeq = statusRequestSeqRef.current + 1;
+    statusRequestSeqRef.current = requestSeq;
     setLoading(true);
+    let latestStatus: GitHubAppInstallationStatus | null = null;
     try {
-      setStatus(await window.ade.github.getAppInstallationStatus({ forceRefresh }));
+      const attemptCount = opts.retryAfterAuthorization
+        ? POST_AUTH_STATUS_RETRY_DELAYS_MS.length + 1
+        : 1;
+      for (let attempt = 0; attempt < attemptCount; attempt += 1) {
+        latestStatus = await window.ade.github.getAppInstallationStatus({
+          forceRefresh: forceRefresh || attempt > 0,
+        });
+        if (!mountedRef.current || statusRequestSeqRef.current !== requestSeq) return;
+        setStatus(latestStatus);
+        if (!opts.retryAfterAuthorization || !isGitHubAppRepoAccessPending(latestStatus)) break;
+        const retryDelay = POST_AUTH_STATUS_RETRY_DELAYS_MS[attempt];
+        if (retryDelay == null) break;
+        setDeviceMessage("GitHub authorization is complete. Waiting for repository access to appear...");
+        await sleepMs(retryDelay);
+        if (!mountedRef.current || statusRequestSeqRef.current !== requestSeq) return;
+      }
     } catch (error) {
+      if (!mountedRef.current || statusRequestSeqRef.current !== requestSeq) return;
       setStatus({
         repo: null,
         appName: ADE_GITHUB_APP_NAME,
@@ -57,11 +79,20 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
         error: error instanceof Error ? error.message : String(error),
       });
     } finally {
+      if (!mountedRef.current || statusRequestSeqRef.current !== requestSeq) return;
       // Read auth state AFTER the status call (success or failure): an
       // expired stored token can be cleared during the status check, and the
       // panel must reflect that immediately.
       const authStatus = await window.ade.github.getAppUserAuthStatus?.().catch(() => null);
+      if (!mountedRef.current || statusRequestSeqRef.current !== requestSeq) return;
       setAppAuth(authStatus ?? null);
+      if (opts.retryAfterAuthorization) {
+        setDeviceMessage(
+          latestStatus && isGitHubAppRepoAccessPending(latestStatus)
+            ? "GitHub authorization is complete. Repository access is still warming up; use Refresh again in a moment."
+            : null,
+        );
+      }
       setLoading(false);
     }
   }, []);
@@ -145,7 +176,8 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
       setDeviceMessage(result.message);
       if (result.status === "authorized") {
         autoRenewCountRef.current = 0;
-        await loadStatus(true);
+        setDeviceMessage("GitHub authorization is complete. Checking repository access...");
+        await loadStatus(true, { retryAfterAuthorization: true });
       }
     }, Math.max(1, deviceSession.intervalSec) * 1000);
     return () => {
@@ -159,7 +191,10 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
   }, [deviceSession?.sessionId]);
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
+      mountedRef.current = false;
+      statusRequestSeqRef.current += 1;
       if (copyFeedbackTimeoutRef.current != null) {
         window.clearTimeout(copyFeedbackTimeoutRef.current);
       }
@@ -171,6 +206,7 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
   }, [loadStatus]);
 
   const appAuthorized = appAuth?.tokenStored === true;
+  const repoAccessPending = appAuthorized && isGitHubAppRepoAccessPending(status);
   const view = statusView(status, loading, appAuthorized);
   const repoLabel = status?.repo ? `${status.repo.owner}/${status.repo.name}` : null;
 
@@ -221,7 +257,7 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
       {!appAuthorized && !deviceSession ? <p style={authMessageStyle}>One-time GitHub sign-off that lets ADE verify your repo access for instant PR updates.</p> : null}
 
       <div style={actionRowStyle}>
-        {!appAuthorized || status?.state === "error" ? (
+        {!appAuthorized || (status?.state === "error" && !repoAccessPending) ? (
           <button
             type="button"
             style={
@@ -256,7 +292,7 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
         <button
           type="button"
           style={outlineButton(compact ? compactSecondaryButtonStyle : undefined)}
-          onClick={() => void loadStatus(true)}
+          onClick={() => void loadStatus(true, { retryAfterAuthorization: appAuthorized })}
           disabled={loading}
         >
           {loading ? <WarningCircle size={12} weight="bold" /> : <ArrowClockwise size={12} weight="bold" />}
@@ -267,7 +303,21 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
   );
 }
 
-function statusView(status: GitHubAppInstallationStatus | null, loading: boolean, appAuthorized: boolean): {
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+export function isGitHubAppRepoAccessPending(status: GitHubAppInstallationStatus | null): boolean {
+  if (status?.state !== "error" || !status.relayConfigured || status.installed) return false;
+  const error = status.error?.trim().toLowerCase() ?? "";
+  return error === "not found"
+    || error.includes("repository not found")
+    || error.includes("could not resolve to a repository");
+}
+
+export function statusView(status: GitHubAppInstallationStatus | null, loading: boolean, appAuthorized: boolean): {
   label: string;
   color: string;
   description: (repoLabel: string | null) => string;
@@ -322,6 +372,16 @@ function statusView(status: GitHubAppInstallationStatus | null, loading: boolean
         label: "Authorize GitHub",
         color: COLORS.warning,
         description: () => "Authorize ADE with GitHub to enable instant PR updates for this repo.",
+      };
+    }
+    if (isGitHubAppRepoAccessPending(status)) {
+      return {
+        label: "Checking access",
+        color: COLORS.warning,
+        description: (repoLabel) =>
+          repoLabel
+            ? `GitHub accepted authorization. ADE is waiting for the GitHub App's repository access to become visible for ${repoLabel}. If this stays here, install the App or select this repo in GitHub.`
+            : "GitHub accepted authorization. ADE is waiting for the GitHub App's repository access to become visible. If this stays here, install the App or select this repo in GitHub.",
       };
     }
     return {

--- a/docs/features/onboarding-and-settings/README.md
+++ b/docs/features/onboarding-and-settings/README.md
@@ -156,9 +156,13 @@ Renderer — settings:
   `startAppUserDeviceAuth` surfaces the user code as a copyable chip plus a
   waiting state and the verification URL, `pollAppUserDeviceAuth` drives the
   poll loop and auto-renews an expired code up to 3 times, a pre-auth status
-  pill reflects `getAppUserAuthStatus` (stored token, signed-in login, expiry),
-  and `clearAppUserAuth` revokes the local token. Offers a Refresh. Rendered in
-  Settings and, in a compact `onboarding` variant, during setup. The
+  pill reflects `getAppUserAuthStatus` (stored token, signed-in login, expiry).
+  After device authorization succeeds, the panel force-refreshes the hosted
+  relay status with a short retry window and treats GitHub repo-access 404s as a
+  temporary "Checking access" state so GitHub App installation propagation does
+  not look like failed authorization. `clearAppUserAuth` revokes the local token.
+  Offers a Refresh. Rendered in Settings and, in a compact `onboarding` variant,
+  during setup. The
   device-flow, token store, and single-flight refresh are backed by
   `githubAppUserAuthService` in the main process (see the automations feature
   doc's Source file map).


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fok-start-skill-ade-desktop-c2abd496 num=687 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fok-start-skill-ade-desktop-c2abd496&amp;pr=687">ade/ok-start-skill-ade-desktop-c2abd496 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=687">PR #687</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Checking access” state while GitHub repository access is being verified after authorization.
  * Refresh and authorization actions now better handle the short delay before access becomes available.

* **Bug Fixes**
  * Improved handling of transient GitHub access errors so the panel shows clearer status updates instead of immediately failing.
  * Prevented outdated status updates from overwriting newer results, making the install panel more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the GitHub App authorization status flow. The main changes are:

- Adds a short retry window after device authorization succeeds.
- Treats GitHub repo-access 404 responses as a temporary `Checking access` state.
- Prevents stale status requests from overwriting newer results.
- Adds focused tests for the new status helper behavior.
- Updates onboarding and settings documentation for the new flow.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

Changes are localized to UI status handling and helper logic, with targeted tests for the new behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the before and after runs for the github-checking-access-state tests and confirmed the after run passes all four status-helper scenarios, including the new pending repo-access 404 state.
- Analyzed the github-auth-retry-workflow tests and observed that the post-auth call count increased from 1 to 3 in the after run, all calls used forceRefresh, the Configured status is displayed after retries, and the harness source for the test is saved at trex-artifacts/github-auth-retry-workflow-test.tsx.

<a href="https://app.greptile.com/trex/runs/13110618/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.tsx | Adds post-authorization retry handling, stale request guards, and a pending repo-access status for transient GitHub 404 responses. |
| apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.test.ts | Adds unit coverage for pending repo-access classification and status view behavior. |
| docs/features/onboarding-and-settings/README.md | Documents the new post-device-auth retry window and temporary `Checking access` state. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Panel as GitHubAppInstallPanel
participant GitHub as GitHub device auth
participant Relay as Hosted relay status

User->>Panel: Authorize ADE
Panel->>GitHub: start/poll device auth
GitHub-->>Panel: authorized
Panel->>Relay: getAppInstallationStatus(forceRefresh)
Relay-->>Panel: repo access 404
Panel->>Panel: show Checking access
loop Retry window
    Panel->>Relay: getAppInstallationStatus(forceRefresh)
    Relay-->>Panel: status result
end
Panel->>Panel: ignore stale responses via request sequence
Panel-->>User: Configured, Checking access, or Check failed
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Panel as GitHubAppInstallPanel
participant GitHub as GitHub device auth
participant Relay as Hosted relay status

User->>Panel: Authorize ADE
Panel->>GitHub: start/poll device auth
GitHub-->>Panel: authorized
Panel->>Relay: getAppInstallationStatus(forceRefresh)
Relay-->>Panel: repo access 404
Panel->>Panel: show Checking access
loop Retry window
    Panel->>Relay: getAppInstallationStatus(forceRefresh)
    Relay-->>Panel: status result
end
Panel->>Panel: ignore stale responses via request sequence
Panel-->>User: Configured, Checking access, or Check failed
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Address GitHub App status review feedbac..."](https://github.com/arul28/ade/commit/2c9943b39b2b97e3438a9ada145f02f862ef1f68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41468808)</sub>

<!-- /greptile_comment -->