### PR TITLE
Fix GitHub webhook delivery + restore PR freshness in installed runtimes

### DIFF
--- a/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.test.ts
+++ b/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.test.ts
@@ -44,4 +44,15 @@ describe("GitHubAppInstallPanel status helpers", () => {
     expect(view.label).toBe("Check failed");
     expect(view.description("arul28/ADE")).toBe("GitHub App relay status check failed (500)");
   });
+
+  it("detects repository-not-found error variants as pending repo access", () => {
+    expect(isGitHubAppRepoAccessPending(makeStatus({ error: "Repository not found." }))).toBe(true);
+    expect(isGitHubAppRepoAccessPending(makeStatus({ error: "Could not resolve to a Repository." }))).toBe(true);
+  });
+
+  it("ignores repo access errors when status guards do not match", () => {
+    expect(isGitHubAppRepoAccessPending(makeStatus({ relayConfigured: false }))).toBe(false);
+    expect(isGitHubAppRepoAccessPending(makeStatus({ installed: true }))).toBe(false);
+    expect(isGitHubAppRepoAccessPending(makeStatus({ state: "not_installed" }))).toBe(false);
+  });
 });

--- a/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.test.ts
+++ b/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { GitHubAppInstallationStatus } from "../../../shared/types";
+import { isGitHubAppRepoAccessPending, statusView } from "./GitHubAppInstallPanel";
+
+function makeStatus(overrides: Partial<GitHubAppInstallationStatus> = {}): GitHubAppInstallationStatus {
+  return {
+    repo: { owner: "arul28", name: "ADE" },
+    appName: "ADE",
+    appSlug: "ade-for-github",
+    installUrl: "https://github.com/apps/ade-for-github/installations/new",
+    manageUrl: "https://github.com/settings/installations",
+    relayConfigured: true,
+    installed: false,
+    state: "error",
+    installationId: null,
+    repositorySelection: null,
+    lastSeenAt: null,
+    webhookEvents: [],
+    missingWebhookEvents: [],
+    webhookState: "unknown",
+    webhookLastSeenAt: null,
+    checkedAt: "2026-07-02T18:39:42.000Z",
+    error: "Not Found",
+    ...overrides,
+  };
+}
+
+describe("GitHubAppInstallPanel status helpers", () => {
+  it("treats post-authorization GitHub repo 404s as pending repo access", () => {
+    const status = makeStatus();
+    const view = statusView(status, false, true);
+
+    expect(isGitHubAppRepoAccessPending(status)).toBe(true);
+    expect(view.label).toBe("Checking access");
+    expect(view.description("arul28/ADE")).toContain("GitHub accepted authorization");
+    expect(view.description("arul28/ADE")).toContain("select this repo in GitHub");
+  });
+
+  it("keeps non-propagation relay failures as check failures after authorization", () => {
+    const status = makeStatus({ error: "GitHub App relay status check failed (500)" });
+    const view = statusView(status, false, true);
+
+    expect(isGitHubAppRepoAccessPending(status)).toBe(false);
+    expect(view.label).toBe("Check failed");
+    expect(view.description("arul28/ADE")).toBe("GitHub App relay status check failed (500)");
+  });
+});

--- a/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.tsx
+++ b/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.tsx
@@ -79,21 +79,24 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
         error: error instanceof Error ? error.message : String(error),
       });
     } finally {
-      if (!mountedRef.current || statusRequestSeqRef.current !== requestSeq) return;
+      const isCurrentRequest = () => mountedRef.current && statusRequestSeqRef.current === requestSeq;
       // Read auth state AFTER the status call (success or failure): an
       // expired stored token can be cleared during the status check, and the
       // panel must reflect that immediately.
-      const authStatus = await window.ade.github.getAppUserAuthStatus?.().catch(() => null);
-      if (!mountedRef.current || statusRequestSeqRef.current !== requestSeq) return;
-      setAppAuth(authStatus ?? null);
-      if (opts.retryAfterAuthorization) {
-        setDeviceMessage(
-          latestStatus && isGitHubAppRepoAccessPending(latestStatus)
-            ? "GitHub authorization is complete. Repository access is still warming up; use Refresh again in a moment."
-            : null,
-        );
+      if (isCurrentRequest()) {
+        const authStatus = await window.ade.github.getAppUserAuthStatus?.().catch(() => null);
+        if (isCurrentRequest()) {
+          setAppAuth(authStatus ?? null);
+          if (opts.retryAfterAuthorization) {
+            setDeviceMessage(
+              latestStatus && isGitHubAppRepoAccessPending(latestStatus)
+                ? "GitHub authorization is complete. Repository access is still warming up; use Refresh again in a moment."
+                : null,
+            );
+          }
+          setLoading(false);
+        }
       }
-      setLoading(false);
     }
   }, []);
 

--- a/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.tsx
+++ b/apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.tsx
@@ -12,6 +12,7 @@ import { COLORS, MONO_FONT, SANS_FONT, cardStyle, inlineBadge, outlineButton, pr
 const ADE_GITHUB_APP_NAME = "ADE";
 const ADE_GITHUB_APP_INSTALL_URL = "https://github.com/apps/ade-for-github/installations/new";
 const GITHUB_APP_INSTALLATIONS_URL = "https://github.com/settings/installations";
+const POST_AUTH_STATUS_RETRY_DELAYS_MS = [1_500, 3_000, 6_000] as const;
 
 type GitHubAppInstallPanelProps = {
   variant?: "settings" | "onboarding";
@@ -29,14 +30,35 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
   const autoRenewCountRef = useRef(0);
   const copyFeedbackTimeoutRef = useRef<number | null>(null);
   const appAuthRef = useRef<GitHubAppUserAuthStatus | null>(null);
+  const statusRequestSeqRef = useRef(0);
+  const mountedRef = useRef(true);
   appAuthRef.current = appAuth;
 
-  const loadStatus = useCallback(async (forceRefresh = false) => {
+  const loadStatus = useCallback(async (forceRefresh = false, opts: { retryAfterAuthorization?: boolean } = {}) => {
     if (!window.ade?.github?.getAppInstallationStatus) return;
+    const requestSeq = statusRequestSeqRef.current + 1;
+    statusRequestSeqRef.current = requestSeq;
     setLoading(true);
+    let latestStatus: GitHubAppInstallationStatus | null = null;
     try {
-      setStatus(await window.ade.github.getAppInstallationStatus({ forceRefresh }));
+      const attemptCount = opts.retryAfterAuthorization
+        ? POST_AUTH_STATUS_RETRY_DELAYS_MS.length + 1
+        : 1;
+      for (let attempt = 0; attempt < attemptCount; attempt += 1) {
+        latestStatus = await window.ade.github.getAppInstallationStatus({
+          forceRefresh: forceRefresh || attempt > 0,
+        });
+        if (!mountedRef.current || statusRequestSeqRef.current !== requestSeq) return;
+        setStatus(latestStatus);
+        if (!opts.retryAfterAuthorization || !isGitHubAppRepoAccessPending(latestStatus)) break;
+        const retryDelay = POST_AUTH_STATUS_RETRY_DELAYS_MS[attempt];
+        if (retryDelay == null) break;
+        setDeviceMessage("GitHub authorization is complete. Waiting for repository access to appear...");
+        await sleepMs(retryDelay);
+        if (!mountedRef.current || statusRequestSeqRef.current !== requestSeq) return;
+      }
     } catch (error) {
+      if (!mountedRef.current || statusRequestSeqRef.current !== requestSeq) return;
       setStatus({
         repo: null,
         appName: ADE_GITHUB_APP_NAME,
@@ -57,11 +79,20 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
         error: error instanceof Error ? error.message : String(error),
       });
     } finally {
+      if (!mountedRef.current || statusRequestSeqRef.current !== requestSeq) return;
       // Read auth state AFTER the status call (success or failure): an
       // expired stored token can be cleared during the status check, and the
       // panel must reflect that immediately.
       const authStatus = await window.ade.github.getAppUserAuthStatus?.().catch(() => null);
+      if (!mountedRef.current || statusRequestSeqRef.current !== requestSeq) return;
       setAppAuth(authStatus ?? null);
+      if (opts.retryAfterAuthorization) {
+        setDeviceMessage(
+          latestStatus && isGitHubAppRepoAccessPending(latestStatus)
+            ? "GitHub authorization is complete. Repository access is still warming up; use Refresh again in a moment."
+            : null,
+        );
+      }
       setLoading(false);
     }
   }, []);
@@ -145,7 +176,8 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
       setDeviceMessage(result.message);
       if (result.status === "authorized") {
         autoRenewCountRef.current = 0;
-        await loadStatus(true);
+        setDeviceMessage("GitHub authorization is complete. Checking repository access...");
+        await loadStatus(true, { retryAfterAuthorization: true });
       }
     }, Math.max(1, deviceSession.intervalSec) * 1000);
     return () => {
@@ -159,7 +191,10 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
   }, [deviceSession?.sessionId]);
 
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
+      mountedRef.current = false;
+      statusRequestSeqRef.current += 1;
       if (copyFeedbackTimeoutRef.current != null) {
         window.clearTimeout(copyFeedbackTimeoutRef.current);
       }
@@ -171,6 +206,7 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
   }, [loadStatus]);
 
   const appAuthorized = appAuth?.tokenStored === true;
+  const repoAccessPending = appAuthorized && isGitHubAppRepoAccessPending(status);
   const view = statusView(status, loading, appAuthorized);
   const repoLabel = status?.repo ? `${status.repo.owner}/${status.repo.name}` : null;
 
@@ -221,7 +257,7 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
       {!appAuthorized && !deviceSession ? <p style={authMessageStyle}>One-time GitHub sign-off that lets ADE verify your repo access for instant PR updates.</p> : null}
 
       <div style={actionRowStyle}>
-        {!appAuthorized || status?.state === "error" ? (
+        {!appAuthorized || (status?.state === "error" && !repoAccessPending) ? (
           <button
             type="button"
             style={
@@ -256,7 +292,7 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
         <button
           type="button"
           style={outlineButton(compact ? compactSecondaryButtonStyle : undefined)}
-          onClick={() => void loadStatus(true)}
+          onClick={() => void loadStatus(true, { retryAfterAuthorization: appAuthorized })}
           disabled={loading}
         >
           {loading ? <WarningCircle size={12} weight="bold" /> : <ArrowClockwise size={12} weight="bold" />}
@@ -267,7 +303,21 @@ export function GitHubAppInstallPanel({ variant = "settings" }: GitHubAppInstall
   );
 }
 
-function statusView(status: GitHubAppInstallationStatus | null, loading: boolean, appAuthorized: boolean): {
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+export function isGitHubAppRepoAccessPending(status: GitHubAppInstallationStatus | null): boolean {
+  if (status?.state !== "error" || !status.relayConfigured || status.installed) return false;
+  const error = status.error?.trim().toLowerCase() ?? "";
+  return error === "not found"
+    || error.includes("repository not found")
+    || error.includes("could not resolve to a repository");
+}
+
+export function statusView(status: GitHubAppInstallationStatus | null, loading: boolean, appAuthorized: boolean): {
   label: string;
   color: string;
   description: (repoLabel: string | null) => string;
@@ -322,6 +372,16 @@ function statusView(status: GitHubAppInstallationStatus | null, loading: boolean
         label: "Authorize GitHub",
         color: COLORS.warning,
         description: () => "Authorize ADE with GitHub to enable instant PR updates for this repo.",
+      };
+    }
+    if (isGitHubAppRepoAccessPending(status)) {
+      return {
+        label: "Checking access",
+        color: COLORS.warning,
+        description: (repoLabel) =>
+          repoLabel
+            ? `GitHub accepted authorization. ADE is waiting for the GitHub App's repository access to become visible for ${repoLabel}. If this stays here, install the App or select this repo in GitHub.`
+            : "GitHub accepted authorization. ADE is waiting for the GitHub App's repository access to become visible. If this stays here, install the App or select this repo in GitHub.",
       };
     }
     return {

--- a/docs/features/onboarding-and-settings/README.md
+++ b/docs/features/onboarding-and-settings/README.md
@@ -156,9 +156,13 @@ Renderer — settings:
   `startAppUserDeviceAuth` surfaces the user code as a copyable chip plus a
   waiting state and the verification URL, `pollAppUserDeviceAuth` drives the
   poll loop and auto-renews an expired code up to 3 times, a pre-auth status
-  pill reflects `getAppUserAuthStatus` (stored token, signed-in login, expiry),
-  and `clearAppUserAuth` revokes the local token. Offers a Refresh. Rendered in
-  Settings and, in a compact `onboarding` variant, during setup. The
+  pill reflects `getAppUserAuthStatus` (stored token, signed-in login, expiry).
+  After device authorization succeeds, the panel force-refreshes the hosted
+  relay status with a short retry window and treats GitHub repo-access 404s as a
+  temporary "Checking access" state so GitHub App installation propagation does
+  not look like failed authorization. `clearAppUserAuth` revokes the local token.
+  Offers a Refresh. Rendered in Settings and, in a compact `onboarding` variant,
+  during setup. The
   device-flow, token store, and single-flight refresh are backed by
   `githubAppUserAuthService` in the main process (see the automations feature
   doc's Source file map).


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fok-start-skill-ade-desktop-c2abd496 num=690 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fok-start-skill-ade-desktop-c2abd496&amp;pr=690">ade/ok-start-skill-ade-desktop-c2abd496 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=690">PR #690</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Checking access” state after GitHub authorization while repository access is still propagating.
  * The app now retries status checks for a short period before showing a failure, giving access time to become available.
* **Bug Fixes**
  * Improved handling of repository-not-found errors so they’re treated as pending access when appropriate.
  * Prevented outdated status updates from overriding newer results during refreshes.
  * Updated action visibility so authorization prompts are hidden when access is already being checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a stale-update prevention layer and a post-authorization retry window to the GitHub App installation panel, so GitHub's App-access propagation delay is shown as a friendly "Checking access" state rather than a misleading "Check failed" error.

- Introduces `isGitHubAppRepoAccessPending` to detect GitHub 404/not-found error variants as transient access states, and `statusView` now returns a "Checking access" label for that condition when the user is already authorized.
- `loadStatus` gains a `statusRequestSeqRef` + `mountedRef` guard that discards stale responses when a newer call supersedes them, and an optional `retryAfterAuthorization` path that re-polls up to four times (1.5 s → 3 s → 6 s delays) while access is still propagating.
- The authorize button is hidden during the pending state and the Refresh button triggers the same retry path when the user is authorized.

<h3>Confidence Score: 4/5</h3>

The change is self-contained to a single UI component and introduces no new network surfaces or data mutations; the worst outcome of a bug here is a stale loading spinner or an incorrect status label, both recoverable by navigating away.

The sequence-number guard and mountedRef correctly discard stale async results in all observed scenarios, including React StrictMode double-invocation. The retry loop exits early as soon as access resolves, so the 10+ second wait only materialises when the repo truly isn't accessible yet. A minor timing window exists where the 'Waiting for repository access…' device message set inside the retry loop can briefly persist after a newer request takes over, but the succeeding request's finally block always corrects it. No state corruption or data loss paths were found.

The retry loop in GitHubAppInstallPanel.tsx (lines 47–59) is the densest part of the change and is worth a second read to confirm the stale-guard ordering matches expectations.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.tsx | Core change: adds sequence-number stale-guard, post-auth retry loop, isGitHubAppRepoAccessPending helper, and 'Checking access' UI state. Logic is generally sound with correct stale-check ordering throughout. |
| apps/desktop/src/renderer/components/github/GitHubAppInstallPanel.test.ts | New unit tests covering the two exported helpers (isGitHubAppRepoAccessPending and statusView); all four scenarios are meaningful and assertions are correct. |
| docs/features/onboarding-and-settings/README.md | Doc update accurately describes the new retry window and 'Checking access' state; no issues. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User completes device auth
 result.status === 'authorized'] --> B[setDeviceMessage
'Checking repository access...']
    B --> C[loadStatus forceRefresh=true
retryAfterAuthorization=true
seq++, setLoading=true]
    C --> D[attempt 0: getAppInstallationStatus]
    D --> E{Stale?
mountedRef or seq mismatch}
    E -- Yes --> Z[return early
finally: skip setLoading]
    E -- No --> F[setStatus latestStatus]
    F --> G{isGitHubAppRepoAccessPending?}
    G -- No --> H[break loop]
    G -- Yes --> I[setDeviceMessage
'Waiting for repo access...']
    I --> J[await sleepMs
1500 / 3000 / 6000 ms]
    J --> K{Stale?}
    K -- Yes --> Z
    K -- No --> L{More attempts?}
    L -- Yes --> D
    L -- No --> H
    H --> M[finally: isCurrentRequest?]
    M -- No --> Z
    M -- Yes --> N[await getAppUserAuthStatus]
    N --> O{Still current?}
    O -- No --> Z
    O -- Yes --> P[setAppAuth
setDeviceMessage based on pending state
setLoading=false]
    P --> Q{Access was pending
after all retries?}
    Q -- Yes --> R[Show 'still warming up' message
'Checking access' status label]
    Q -- No --> S[Clear message
Show resolved status]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User completes device auth
 result.status === 'authorized'] --> B[setDeviceMessage
'Checking repository access...']
    B --> C[loadStatus forceRefresh=true
retryAfterAuthorization=true
seq++, setLoading=true]
    C --> D[attempt 0: getAppInstallationStatus]
    D --> E{Stale?
mountedRef or seq mismatch}
    E -- Yes --> Z[return early
finally: skip setLoading]
    E -- No --> F[setStatus latestStatus]
    F --> G{isGitHubAppRepoAccessPending?}
    G -- No --> H[break loop]
    G -- Yes --> I[setDeviceMessage
'Waiting for repo access...']
    I --> J[await sleepMs
1500 / 3000 / 6000 ms]
    J --> K{Stale?}
    K -- Yes --> Z
    K -- No --> L{More attempts?}
    L -- Yes --> D
    L -- No --> H
    H --> M[finally: isCurrentRequest?]
    M -- No --> Z
    M -- Yes --> N[await getAppUserAuthStatus]
    N --> O{Still current?}
    O -- No --> Z
    O -- Yes --> P[setAppAuth
setDeviceMessage based on pending state
setLoading=false]
    P --> Q{Access was pending
after all retries?}
    Q -- Yes --> R[Show 'still warming up' message
'Checking access' status label]
    Q -- No --> S[Clear message
Show resolved status]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Address GitHub App status review feedbac..."](https://github.com/arul28/ade/commit/2c9943b39b2b97e3438a9ada145f02f862ef1f68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41520614)</sub>

<!-- /greptile_comment -->