### PR TITLE
Poll the GitHub relay every 30s

### DIFF
--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -1085,6 +1085,9 @@ export async function createAdeRuntime(args: {
     githubService: headlessLinearServices.githubService,
     listRules: () => (automationService ? projectConfigService.get().effective.automations ?? [] : []),
     ingressCursorStore: createKvIngressCursorStore(db),
+    // 30s halves worst-case webhook latency. Each poll is one request to our
+    // own relay worker (no GitHub data cost); the service floors at 30s.
+    pollIntervalMs: 30_000,
   });
   void automationIngressService.start().catch((error) => {
     logger.warn("automations.ingress_start_failed", {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -3201,6 +3201,9 @@ app.whenReady().then(async () => {
       githubService,
       listRules: () => (automationService ? projectConfigService.get().effective.automations ?? [] : []),
       ingressCursorStore: createKvIngressCursorStore(db),
+      // 30s halves worst-case webhook latency. Each poll is one request to
+      // our own relay worker (no GitHub data cost); the service floors at 30s.
+      pollIntervalMs: 30_000,
     });
 
     const githubPollingService = automationService


### PR DESCRIPTION
Follow-up to #691: halve worst-case webhook-to-app latency (60s → 30s) by polling the relay at the service's 30s floor at both wiring sites (desktop main + daemon bootstrap).

Cost analysis: each poll is one request to our own Cloudflare worker — ~86k req/month per active client against a 10M-included plan; the per-poll GitHub permission check doubles to 120 calls/hour against the 5,000/hour app-user-token budget. No GitHub data fetch is involved in the poll itself.

Validation: desktop + ade-cli typechecks clean, ingress test file green (9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lowers the GitHub relay polling interval for automation ingress. The main changes are:

- Sets the daemon bootstrap relay poll interval to 30 seconds.
- Sets the desktop main-process relay poll interval to 30 seconds.
- Keeps the interval aligned with the ingress service's 30-second floor.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped to passing `pollIntervalMs: 30_000` into an existing service that already clamps polling to a 30-second minimum.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the daemon poll interval baseline to the head, confirming that pollIntervalMs is now set to 30\_000 in the daemon bootstrap create block and that effectiveDaemonRelayPollIntervalMs also updates to 30\_000.
- Compared the desktop poll interval behavior between base and head, confirming that createAutomationIngressService on base used pollIntervalMsOwnProperty=false and did not pass observedPollIntervalMs, while the head uses pollIntervalMsOwnProperty=true with observedPollIntervalMs equal to 30\_000.

<a href="https://app.greptile.com/trex/runs/13151519/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=3"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=3"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/bootstrap.ts | Sets the daemon automation ingress relay poll interval to the 30-second service floor. |
| apps/desktop/src/main/main.ts | Sets the desktop automation ingress relay poll interval to the 30-second service floor. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Runtime as Desktop/Daemon Runtime
participant Ingress as AutomationIngressService
participant Relay as GitHub Relay Worker
participant PR as prService

Runtime->>Ingress: createAutomationIngressService(pollIntervalMs: 30_000)
Runtime->>Ingress: start()
loop every 30s floor
    Ingress->>Relay: poll for GitHub webhook deliveries
    Relay-->>Ingress: deliveries + next cursor
    Ingress->>PR: ingestGithubWebhook(delivery)
    Ingress->>Ingress: persist relay cursor
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Runtime as Desktop/Daemon Runtime
participant Ingress as AutomationIngressService
participant Relay as GitHub Relay Worker
participant PR as prService

Runtime->>Ingress: createAutomationIngressService(pollIntervalMs: 30_000)
Runtime->>Ingress: start()
loop every 30s floor
    Ingress->>Relay: poll for GitHub webhook deliveries
    Relay-->>Ingress: deliveries + next cursor
    Ingress->>PR: ingestGithubWebhook(delivery)
    Ingress->>Ingress: persist relay cursor
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Poll the GitHub relay every 30s instead ..."](https://github.com/arul28/ade/commit/8d2fc7f247d275b44ecaa38135d087d481beb90e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41553554)</sub>

<!-- /greptile_comment -->