### PR TITLE
release: changelog for v1.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.12] - 2026-07-03
+
+### Added
+
+- Added cross-project chat quick-look: open a lane's chat transcript from the hub (desktop and iOS) without switching projects, streamed read-only from the brain without booting the foreign runtime, capability-gated and fail-closed on older brains.
+- Added Work-tab lane creation in place with a redesigned create-lane modal and lane action toasts.
+- Added repo-gated webhook-secret heal and delivery-log routes to the GitHub webhook relay to recover from webhook secret drift.
+
+### Changed
+
+- Improved GitHub PR freshness in installed builds: daemon-owned PR polling now starts at project startup so Work, Lanes, and PRs refresh without opening the PR tab first, and the GitHub relay is polled every 30s instead of 60s.
+- Improved the mobile hub and chat surfaces with an inline keyboard composer, hydration-gated chat open, and redesigned question/approval/plan cards with hardened chat-event decoding.
+- Improved Lanes tab performance via conditional CRR upserts for no-op lane-state snapshots, conditional (ifNoneMatch/notModified) lane list/detail responses with presence stamping, and per-lane detail invalidation.
+- Improved GitHub App authorization status UX and restyled the post-update restart card to point release notes at the docs changelog route.
+- Kept the current mobile marketing version for a build-number-only iOS TestFlight update.
+
+### Fixed
+
+- Fixed terminal ADE PR state (merged/closed) being overridden by a stale open GitHub snapshot in desktop and iOS lane PR chips.
+
 ## [1.2.11] - 2026-07-02
 
 ### Added
@@ -509,7 +529,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.11...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.12...HEAD
+[1.2.12]: https://github.com/arul28/ADE/compare/v1.2.11...v1.2.12
 [1.2.11]: https://github.com/arul28/ADE/compare/v1.2.10...v1.2.11
 [1.2.10]: https://github.com/arul28/ADE/compare/v1.2.9...v1.2.10
 [1.2.9]: https://github.com/arul28/ADE/compare/v1.2.8...v1.2.9

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.11">
-  v1.2.11 - unified ADE chat and CLI launching, hardened GitHub PR sync through the webhook relay, tighter Work and Files flows, and build-number-only iOS sync updates.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.12">
+  v1.2.12 - GitHub PR freshness in installed builds, cross-project chat quick-look, a mobile hub and chat overhaul, faster Lanes tab, and build-number-only iOS sync updates.
 </Card>

--- a/changelog/v1.2.12.mdx
+++ b/changelog/v1.2.12.mdx
@@ -1,0 +1,26 @@
+---
+title: "v1.2.12"
+description: "Release notes for ADE v1.2.12 - July 3, 2026"
+---
+
+v1.2.12 makes GitHub PR freshness work in installed builds, adds cross-project chat quick-look, overhauls the mobile hub and chat surfaces, and speeds up the Lanes tab. iOS stays on its current marketing version and gets a build-number-only TestFlight update for the same release train.
+
+---
+
+## Desktop
+
+- **PR freshness in installed builds.** Daemon-owned GitHub PR polling now starts at project startup, so Work, Lanes, and PRs refresh without opening the PR tab first. Terminal ADE PR state (merged/closed) is no longer overridden by a stale open GitHub snapshot, and the webhook relay gained repo-gated secret-heal and delivery-log routes to recover from webhook secret drift.
+- **Faster webhook delivery.** The GitHub relay is polled every 30s instead of 60s, halving worst-case webhook-to-app latency at negligible cost.
+- **Cross-project chat quick-look.** Open a lane's chat transcript from the hub without switching projects — the brain streams a foreign lane read-only without booting its runtime, capability-gated and fail-closed on older brains.
+- **Work-tab lane creation.** Create a lane in place from the Work tab with a redesigned create-lane modal and lane action toasts, including scoped setup retry and conflict-aware pull-success suppression.
+- **Lanes tab performance.** No-op lane-state snapshot writes are suppressed via conditional CRR upserts, lane list/detail responses are conditional (ifNoneMatch/notModified with presence stamping), and per-lane detail invalidation cuts redundant list reloads.
+- **GitHub auth status and update card.** Clearer GitHub App authorization status UX, plus a restyled post-update restart card whose release notes point at the docs changelog route.
+
+---
+
+## iOS
+
+- **Build-number-only TestFlight update.** The mobile app keeps its existing marketing version for this train; this release only bumps the iOS build number for TestFlight.
+- **Mobile hub and chat overhaul.** An inline keyboard composer replaces the sheet drawer (draft and settings survive collapse), hub chat-open waits for real project hydration so transcripts no longer open blank, and question/approval/plan cards are redesigned with hardened chat-event decoding so one unknown event can't wipe a transcript.
+- **Cross-project quick-look on phone.** Phones open hub chats across projects read-only without switching projects, falling back to activation on older brains.
+- **PR chip accuracy.** Terminal ADE PR state now wins over a stale GitHub snapshot in iOS lane chips, matching the desktop rule.

--- a/docs.json
+++ b/docs.json
@@ -179,6 +179,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.12",
               "changelog/v1.2.11",
               "changelog/v1.2.10",
               "changelog/v1.2.9",


### PR DESCRIPTION
Changelog for v1.2.12. Tag will be cut after this lands on main.

- Desktop: PR freshness in installed builds, faster webhook relay polling, cross-project chat quick-look, Work-tab lane creation, Lanes tab perf.
- iOS: build-number-only TestFlight update on the current marketing version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the ADE v1.2.12 release notes. The main changes are:

- Adds a new `CHANGELOG.md` entry for v1.2.12.
- Adds the docs page at `changelog/v1.2.12.mdx`.
- Updates the changelog landing page to point to v1.2.12.
- Adds v1.2.12 to the docs sidebar navigation.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are documentation-only and the new release page is consistently linked from the changelog index and docs navigation.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Adjusted the base changelog navigation so that v1.2.12 is listed as the latest and the latest card links to changelog/v1.2.12.
- Validated the updated head changelog navigation now starts with changelog, changelog/v1.2.12, and changelog/v1.2.11, with the latest card linking to changelog/v1.2.12.
- Rendered the /changelog/v1.2.12 page and confirmed it loads successfully while displaying v1.2.12, Desktop, iOS, PR freshness, and Build-number-only TestFlight update.
- Captured and archived visual proof of the before and after changelog navigation with four artifacts (two poster frames and two videos) to document the changes.
- Inspected the render log artifacts to verify the render activity for the changelog page.

<a href="https://app.greptile.com/trex/runs/13166604/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds the v1.2.12 release section and updates comparison links for the new release. |
| changelog/index.mdx | Updates the changelog landing card to point to v1.2.12 with matching summary text. |
| changelog/v1.2.12.mdx | Adds the v1.2.12 documentation release notes covering desktop and iOS changes. |
| docs.json | Adds the v1.2.12 changelog page to the release navigation in newest-first order. |

<sub>Reviews (1): Last reviewed commit: ["release: changelog for v1.2.12"](https://github.com/arul28/ade/commit/c1ef7d023669fbabd945de6f89b033bbb68cf472) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41583270)</sub>

<!-- /greptile_comment -->