### PR TITLE
Mobile: restore auto-lane AI naming as background rename (desktop pattern)

### DIFF
--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -5275,17 +5275,20 @@ final class SyncService: ObservableObject {
   /// `titleGenerationEnabled` setting and clamps the name; it returns a
   /// deterministic fallback when naming is disabled/unavailable. This command is
   /// NOT queueable, so an offline phone throws here rather than queueing — the
-  /// caller is expected to catch and fall back to its own deterministic name.
+  /// caller is expected to catch and keep its own deterministic name.
   ///
-  /// The request is short (10s) and non-disconnecting: it's a best-effort lookup
-  /// that the caller races against its own 10s UI deadline, so a slow/stuck host
-  /// must not strain the connection or trigger a probe/reconnect that could
-  /// disrupt the chat/CLI session started right after the lane is created.
+  /// Callers run this fire-and-forget AFTER the lane is created with the
+  /// deterministic name (desktop's `startBackgroundLaneNaming` pattern), so the
+  /// request is short (10s) and non-disconnecting: a slow/stuck host must not
+  /// strain the connection or trigger a probe/reconnect that could disrupt the
+  /// chat/CLI session just started in the new lane.
   func suggestLaneName(
     laneId: String,
     prompt: String,
     modelId: String,
-    fallbackName: String
+    fallbackName: String,
+    targetProjectId: String? = nil,
+    targetProjectRootPath: String? = nil
   ) async throws -> String {
     let args: [String: Any] = [
       "laneId": laneId,
@@ -5298,6 +5301,8 @@ final class SyncService: ObservableObject {
       args: args,
       disconnectOnTimeout: false,
       timeoutNanoseconds: 10_000_000_000,
+      targetProjectId: targetProjectId,
+      targetProjectRootPath: targetProjectRootPath,
       as: SuggestLaneNameResult.self
     )
     let trimmed = result.name.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -5386,8 +5391,18 @@ final class SyncService: ObservableObject {
     try await sendDecodableCommand(action: "lanes.listUnregisteredWorktrees", as: [UnregisteredLaneCandidate].self)
   }
 
-  func renameLane(_ laneId: String, name: String) async throws {
-    _ = try await sendCommand(action: "lanes.rename", args: ["laneId": laneId, "name": name])
+  func renameLane(
+    _ laneId: String,
+    name: String,
+    targetProjectId: String? = nil,
+    targetProjectRootPath: String? = nil
+  ) async throws {
+    _ = try await sendCommand(
+      action: "lanes.rename",
+      args: ["laneId": laneId, "name": name],
+      targetProjectId: targetProjectId,
+      targetProjectRootPath: targetProjectRootPath
+    )
   }
 
   func reparentLane(

--- a/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
+++ b/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
@@ -762,6 +762,7 @@ struct HubInlineComposer: View {
     let targetLaneId: String
     let targetLaneName: String
     var createdLaneId: String?
+    var autoCreatedFallbackName: String?
     if isAutoCreateLane {
       let name = workDeterministicAutoLaneName(from: opener, genericSuffix: workAutoLaneGenericSuffix())
       do {
@@ -774,6 +775,7 @@ struct HubInlineComposer: View {
         targetLaneId = lane.id
         targetLaneName = lane.name
         createdLaneId = lane.id
+        autoCreatedFallbackName = name
       } catch {
         ADEHaptics.error()
         errorMessage = error.localizedDescription
@@ -859,6 +861,15 @@ struct HubInlineComposer: View {
       // Collapse back to the minimized box; the hub's toast takes over from here.
       collapse()
       onCreated(created)
+      if let createdLaneId, let autoCreatedFallbackName {
+        startBackgroundLaneNaming(
+          laneId: createdLaneId,
+          opener: opener,
+          fallbackName: autoCreatedFallbackName,
+          targetProjectId: targetProjectId,
+          targetProjectRootPath: targetProjectRootPath
+        )
+      }
       return true
     } catch {
       ADEHaptics.error()
@@ -874,6 +885,44 @@ struct HubInlineComposer: View {
       }
       busy = false
       return false
+    }
+  }
+
+  /// Desktop-parity background lane naming (`startBackgroundLaneNaming` in
+  /// AgentChatPane): the lane was already created with the deterministic
+  /// fallback name, so this runs fire-and-forget after the session launch and
+  /// any failure/timeout/offline is a no-op. `lanes.suggestName` honors the
+  /// host's own titleGenerationEnabled setting and clamps the name; the rename
+  /// applies only when the suggestion differs from the fallback. Both calls
+  /// carry the picked project's scope since the hub can launch into a project
+  /// other than the active one (same envelope routing as createLane above).
+  private func startBackgroundLaneNaming(
+    laneId: String,
+    opener: String,
+    fallbackName: String,
+    targetProjectId: String?,
+    targetProjectRootPath: String?
+  ) {
+    let syncService = syncService
+    let modelId = modelId
+    Task {
+      guard
+        let suggested = try? await syncService.suggestLaneName(
+          laneId: laneId,
+          prompt: opener,
+          modelId: modelId,
+          fallbackName: fallbackName,
+          targetProjectId: targetProjectId,
+          targetProjectRootPath: targetProjectRootPath
+        ),
+        suggested != fallbackName
+      else { return }
+      try? await syncService.renameLane(
+        laneId,
+        name: suggested,
+        targetProjectId: targetProjectId,
+        targetProjectRootPath: targetProjectRootPath
+      )
     }
   }
 

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -697,17 +697,20 @@ struct WorkNewChatScreen: View {
     // launch fails immediately afterwards (desktop parity).
     let targetLaneId: String
     var createdLaneId: String?
+    var autoCreatedFallbackName: String?
     if isAutoCreateLane {
       withAnimation(.snappy(duration: 0.16)) {
         autoCreateStatus = "Creating lane…"
       }
       do {
+        let laneName = autoCreatedLaneName(opener: opener)
         let lane = try await syncService.createLane(
-          name: autoCreatedLaneName(opener: opener),
+          name: laneName,
           description: opener.isEmpty ? "" : String(opener.prefix(280))
         )
         targetLaneId = lane.id
         createdLaneId = lane.id
+        autoCreatedFallbackName = laneName
         await onRefreshLanes()
       } catch {
         ADEHaptics.error()
@@ -772,6 +775,9 @@ struct WorkNewChatScreen: View {
             chatIdleSinceAt: nil
           ))
         }
+        if let createdLaneId, let autoCreatedFallbackName {
+          startBackgroundLaneNaming(laneId: createdLaneId, opener: opener, fallbackName: autoCreatedFallbackName)
+        }
         busy = false
         return true
       }
@@ -795,6 +801,9 @@ struct WorkNewChatScreen: View {
         cursorModeId: wire.cursorModeId
       )
       await onStarted(summary, opener)
+      if let createdLaneId, let autoCreatedFallbackName {
+        startBackgroundLaneNaming(laneId: createdLaneId, opener: opener, fallbackName: autoCreatedFallbackName)
+      }
       busy = false
       return true
     } catch {
@@ -815,6 +824,35 @@ struct WorkNewChatScreen: View {
   /// lane. The host can still replace this through the best-effort naming call.
   private func autoCreatedLaneName(opener: String) -> String {
     workDeterministicAutoLaneName(from: opener, genericSuffix: workAutoLaneGenericSuffix())
+  }
+
+  /// Desktop-parity background lane naming (`startBackgroundLaneNaming` in
+  /// AgentChatPane): the lane was already created with the deterministic
+  /// fallback name, so this runs fire-and-forget after the session launch and
+  /// any failure/timeout/offline is a no-op. `lanes.suggestName` honors the
+  /// host's own titleGenerationEnabled setting and clamps the name; the rename
+  /// applies only when the suggestion differs from the fallback.
+  private func startBackgroundLaneNaming(laneId: String, opener: String, fallbackName: String) {
+    let syncService = syncService
+    let modelId = modelId
+    let onRefreshLanes = onRefreshLanes
+    Task {
+      guard
+        let suggested = try? await syncService.suggestLaneName(
+          laneId: laneId,
+          prompt: opener,
+          modelId: modelId,
+          fallbackName: fallbackName
+        ),
+        suggested != fallbackName
+      else { return }
+      do {
+        try await syncService.renameLane(laneId, name: suggested)
+      } catch {
+        return
+      }
+      await onRefreshLanes()
+    }
   }
 
   private func normalizeSelection(for mode: WorkNewSessionMode) {

--- a/docs/features/lanes/README.md
+++ b/docs/features/lanes/README.md
@@ -171,19 +171,24 @@ iOS companion (`apps/ios/ADE/Views/Lanes/`):
   `ade://repo/<owner>/<repo>/branch/<branch>` links the lane options
   menu copies to the pasteboard.
 - `apps/ios/ADE/Views/Work/WorkNewChatScreen.swift` — mobile
-  auto-create (the "Auto-create lane" sentinel) now names the new lane
-  with the host's small AI model, mirroring desktop's draft-launch
-  flow. `submit()` resolves the name **before** creating the lane:
-  it calls `SyncService.suggestLaneName` (the non-queueable
-  `lanes.suggestName` sync command → `agentChatService.suggestLaneNameFromPrompt`
-  on the host), raced against a 10s deadline, and shows a banner above
-  the composer (`Naming lane with <model>… → Creating lane…`). Any
-  failure / timeout / offline / host-disabled state falls back to the
-  existing deterministic `autoCreatedLaneName(opener:)`, so lane
-  creation is never blocked or failed by naming. The host command is
+  auto-create (the "Auto-create lane" sentinel) names the new lane with
+  the host's small AI model using desktop's background-rename pattern
+  (`startBackgroundLaneNaming` in `AgentChatPane`): `submit()` creates
+  the lane instantly with the deterministic
+  `autoCreatedLaneName(opener:)`, launches the chat/CLI session, then
+  fires a fire-and-forget task that calls `SyncService.suggestLaneName`
+  (the non-queueable `lanes.suggestName` sync command →
+  `agentChatService.suggestLaneNameFromPrompt` on the host) and applies
+  the result via `lanes.rename` only when it differs from the
+  deterministic fallback. Naming never blocks or fails lane creation or
+  session launch — any failure / timeout / offline / host-disabled
+  state simply keeps the deterministic name. The host command is
   deliberately not queueable so an offline phone fails fast to the
   deterministic name instead of queueing a stale suggestion. Covers
-  both the Chat and CLI auto-create paths.
+  both the Chat and CLI auto-create paths; the all-projects hub
+  composer (`HubComposerDrawer.swift`) runs the same background naming
+  with `targetProjectId`/`targetProjectRootPath` scope so it works for
+  foreign-project launches.
 
 Detail docs in this folder:
 

--- a/docs/features/sync-and-multi-device/remote-commands.md
+++ b/docs/features/sync-and-multi-device/remote-commands.md
@@ -384,10 +384,12 @@ A handful have more logic:
   result; a missing `agentChatService`, a thrown error, or an empty name
   all fall back to the supplied `fallbackName` (or, when none was passed,
   a prompt-derived `deriveDeterministicLaneNameFromPrompt`), so naming
-  can never block or fail lane creation. The iOS caller
-  (`SyncService.suggestLaneName`, raced against a 10s deadline in
-  `WorkNewChatScreen`) catches any throw and uses the same deterministic
-  name.
+  can never block or fail lane creation. The iOS callers
+  (`WorkNewChatScreen` and the hub composer) create the lane instantly
+  with the deterministic name, then call `SyncService.suggestLaneName`
+  fire-and-forget after the session launch and apply a differing
+  suggestion via `lanes.rename` — desktop's background-rename pattern;
+  any throw keeps the deterministic name.
 - **`lanes.initEnv` / `lanes.applyTemplate`** — resolves the lane's
   overlay context (`resolveLaneOverlayContext`), merges overrides with
   the template's env init config, and invokes


### PR DESCRIPTION
## Summary

Restores mobile auto-lane AI naming, which died as collateral in #683's stability refactor (the commit never mentioned naming; #591 had added it as a blocking pre-create race). This brings it back using **exactly the desktop pattern** (`startBackgroundLaneNaming` in `AgentChatPane`): create the lane instantly with the deterministic name, launch the chat/CLI session undelayed, then a fire-and-forget task asks the host's naming model (`lanes.suggestName`) and applies the result via `lanes.rename` only when it differs from the deterministic fallback. No banner, no 10s pre-create race — the name just improves in place a few seconds later.

- `WorkNewChatScreen.swift` — background naming after session launch for both Chat and CLI auto-create paths; refreshes the lane list after a successful rename.
- `HubComposerDrawer.swift` — same background naming after the hub's auto-create, passing `targetProjectId`/`targetProjectRootPath` through so foreign-project launches route via the command envelope like `chat.create`.
- `SyncService.swift` — thin plumbing only: optional scope params on the existing `suggestLaneName` (previously dead code) and `renameLane` wrappers; doc comments updated to the background pattern. Keeps the 10s non-disconnecting timeout budget.
- Docs (`lanes/README.md`, `remote-commands.md`) updated to describe the background pattern instead of the removed pre-create race.

Naming can never block or fail creation/launch: all naming errors are swallowed, and `lanes.suggestName` stays non-queueable so an offline phone fails fast to the deterministic name. No new UX, settings, or host logic — the host command already honors `titleGenerationEnabled` and clamps names.

## Validation

- iOS: direct `xcodebuild` Debug/simulator build green (per repo norm, not XcodeBuildMCP).
- No desktop/ade-cli TS touched; existing `lanes.suggestName` host tests and iOS deterministic-naming tests still cover the contracts.
- /quality dual-review: 0 Blocker/High/Medium; 4 accepted Lows (benign edges documented in the review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-created lanes may now be renamed automatically after a session starts, giving them more relevant names without interrupting the flow.
  * Lane name suggestions can be applied even when working in a different project scope, not just the currently active one.

* **Bug Fixes**
  * Improved lane naming consistency for newly created chats and work sessions.
  * Kept the existing fallback name in place if a suggested name can’t be used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes mobile auto-created lane naming to run after session startup. The main changes are:

- Create iOS auto lanes immediately with a deterministic fallback name.
- Start chat or CLI sessions before asking the host for a suggested lane name.
- Rename the lane in the background only when the host returns a different name.
- Preserve selected-project routing for hub-created lanes.
- Update lane and remote-command docs for the new background naming flow.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are localized and keep lane naming failures non-blocking. Hub background naming preserves target-project routing. No correctness or security issues were identified in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed that the pre-change environment lacked iOS tooling support, as shown in auto-lane-naming-01-before.log.
- Verified that the after-change log contains matching excerpts from the updated Swift/docs for the auto-lane naming flow.
- Executed the Python repository check for the auto-lane naming flow and confirmed all targeted flow assertions passed with exit code 0.

<a href="https://app.greptile.com/trex/runs/13269226/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Services/SyncService.swift | Adds optional target-project routing to lane name suggestion and rename commands. |
| apps/ios/ADE/Views/Hub/HubComposerDrawer.swift | Adds fire-and-forget background naming for hub-created auto lanes with foreign-project routing preserved. |
| apps/ios/ADE/Views/Work/WorkNewChatScreen.swift | Changes mobile auto-create to create deterministic lanes first, then asynchronously suggest and apply a better name. |
| docs/features/lanes/README.md | Updates lane feature documentation to describe background mobile lane naming and hub project scoping. |
| docs/features/sync-and-multi-device/remote-commands.md | Updates remote command documentation to describe fire-and-forget iOS lane naming behavior. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant IOS as iOS composer
participant Sync as SyncService
participant Host as Desktop host

User->>IOS: Submit opener with auto-create lane
IOS->>Sync: lanes.create(deterministic fallback name)
Sync->>Host: Create lane
Host-->>Sync: LaneSummary
Sync-->>IOS: Lane id/name
IOS->>Sync: start chat or CLI session
Sync->>Host: Session command
Host-->>Sync: Session summary/id
Sync-->>IOS: Session started
IOS-->>User: Navigate/collapse and show created session
IOS-)Sync: lanes.suggestName(laneId, opener, fallback)
Sync-)Host: Best-effort naming request
Host--)Sync: Suggested or fallback name
alt suggestion differs from fallback
    IOS-)Sync: lanes.rename(suggested name)
    Sync-)Host: Rename lane
else suggestion equals fallback or request fails
    IOS-->>IOS: Keep deterministic lane name
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant IOS as iOS composer
participant Sync as SyncService
participant Host as Desktop host

User->>IOS: Submit opener with auto-create lane
IOS->>Sync: lanes.create(deterministic fallback name)
Sync->>Host: Create lane
Host-->>Sync: LaneSummary
Sync-->>IOS: Lane id/name
IOS->>Sync: start chat or CLI session
Sync->>Host: Session command
Host-->>Sync: Session summary/id
Sync-->>IOS: Session started
IOS-->>User: Navigate/collapse and show created session
IOS-)Sync: lanes.suggestName(laneId, opener, fallback)
Sync-)Host: Best-effort naming request
Host--)Sync: Suggested or fallback name
alt suggestion differs from fallback
    IOS-)Sync: lanes.rename(suggested name)
    Sync-)Host: Rename lane
else suggestion equals fallback or request fails
    IOS-->>IOS: Keep deterministic lane name
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Mobile: restore auto-lane AI naming as b..."](https://github.com/arul28/ade/commit/f139475951b764f93e75fd2d66f78af337ac6dfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41807338)</sub>

<!-- /greptile_comment -->