### PR TITLE
Mobile connection reliability: Tailscale-off hint, attributed pairing revocation, probe hardening

### DIFF
--- a/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
+++ b/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
@@ -691,9 +691,17 @@ export function createBrainProjectActionsSyncHandler(
               || !safeStringEquals(bootstrapToken, auth.token)
               || (!SYNC_HOST_BIND_LOOPBACK_ONLY && !pairingStore.hasPairingRecord(hello.peer.deviceId));
           if (authFailed) {
+            // Same attribution as the project host's auth_failed: name the
+            // rejecting machine so clients never drop a saved pairing over a
+            // rejection they cannot attribute to the paired machine.
+            const rejectingHost = brainMetadata();
             send(ws, "hello_error", {
               code: "auth_failed",
               message: "Sync authentication failed.",
+              host: {
+                deviceId: rejectingHost.deviceId,
+                name: rejectingHost.deviceName,
+              },
             }, envelope.requestId);
             try {
               ws.close(4003, "Authentication failed");

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -4192,9 +4192,18 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         return true;
       })();
       if (authFailed) {
+        // Attribute the rejection: a phone dialing a stale/reused address can
+        // reach a stranger machine whose auth check fails. Only when the
+        // rejecting machine's identity matches the client's saved pairing may
+        // the client safely drop its credentials.
+        const rejectingHost = readBrainMetadata();
         send(peer.ws, "hello_error", {
           code: "auth_failed",
           message: "Sync authentication failed.",
+          host: {
+            deviceId: rejectingHost.deviceId,
+            name: rejectingHost.deviceName,
+          },
         }, envelope.requestId);
         try {
           peer.ws.close(4003, "Authentication failed");

--- a/apps/desktop/src/main/services/sync/syncHostService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncHostService.test.ts
@@ -2996,8 +2996,16 @@ describe.skipIf(!isCrsqliteAvailable())("syncHostService", () => {
       },
     }));
     const revokedHello = await revokedQueue.next("hello_error");
-    const revokedPayload = revokedHello.payload as { code: string; message: string };
+    const revokedPayload = revokedHello.payload as {
+      code: string;
+      message: string;
+      host?: { deviceId?: string; name?: string };
+    };
     expect(revokedPayload.code).toBe("auth_failed");
+    // The rejection must be attributed: clients only drop a saved pairing
+    // when the rejecting machine's identity matches the one they paired with.
+    expect(typeof revokedPayload.host?.deviceId).toBe("string");
+    expect(revokedPayload.host?.deviceId?.length).toBeGreaterThan(0);
     revokedWs.close();
     await new Promise((resolve) => revokedWs.once("close", resolve));
   });

--- a/apps/desktop/src/shared/types/sync.ts
+++ b/apps/desktop/src/shared/types/sync.ts
@@ -474,6 +474,18 @@ export type SyncHelloOkPayload = {
 export type SyncHelloErrorPayload = {
   code: "auth_failed" | "invalid_hello";
   message: string;
+  /**
+   * Identity of the machine that rejected this hello. Lets a client tell
+   * "the machine I'm paired with revoked this device" (safe to drop the
+   * saved pairing) apart from "a different machine answered on a reused
+   * address" (keep the pairing and try other routes). Older hosts omit it,
+   * in which case clients must treat the rejection as unattributed and
+   * never destroy saved credentials over it.
+   */
+  host?: {
+    deviceId: string;
+    name?: string;
+  };
 };
 
 export type SyncAddressCandidateKind = "lan" | "saved" | "tailscale" | "loopback";

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -873,7 +873,7 @@ private func syncLogPathSummary(_ snapshot: SyncNetworkPathSnapshot?) -> String 
 private let syncAmbiguousRouteAuthFailureKey = "ADEAmbiguousRouteAuthFailure"
 /// userInfo key carrying `hello_error.host.deviceId` — the identity of the
 /// machine that rejected the hello, when the host was new enough to send it.
-let syncRespondingHostIdentityKey = "ADERespondingHostIdentity"
+private let syncRespondingHostIdentityKey = "ADERespondingHostIdentity"
 
 private func syncLogProfileSummary(_ profile: HostConnectionProfile) -> String {
   [

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -324,7 +324,16 @@ enum SyncTailnetDiscovery {
   static let hostCandidates = [
     "ade-sync",
   ]
-  static let portCandidates = SyncDirectHostPorts.portCandidates
+  /// Bounded discovery sweep. The full stale-port recovery range
+  /// (`SyncDirectHostPorts.portCandidates`, 8787–8999) belongs to the actual
+  /// connect path; probing all 213 ports here — sequentially, 2 s timeout
+  /// each, on a 45 s cadence — overruns the refresh interval by minutes and
+  /// keeps the radio hot whenever the tailnet host is resolvable but dropping
+  /// packets (asleep Mac). Saved-profile ports are injected separately via
+  /// `SyncTailnetProbe.preferredPortsProvider` so a drifted port is still found.
+  static let probePortCandidates = Array(
+    SyncDirectHostPorts.defaultPort...(SyncDirectHostPorts.defaultPort + 8)
+  )
 }
 
 enum SyncDirectHostPorts {
@@ -497,6 +506,91 @@ func syncIsTailscaleIPv4Address(_ host: String) -> Bool {
   return first == 100 && (64...127).contains(second)
 }
 
+/// Tailscale assigns every node an IPv6 address inside fd7a:115c:a1e0::/48
+/// alongside the CGNAT IPv4. Classifying it keeps tailnet-preference ordering
+/// and cellular roaming correct when a host advertises its v6 address.
+func syncIsTailscaleIPv6Address(_ host: String) -> Bool {
+  let normalized = host
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+    .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+  guard let v6 = IPv6Address(normalized) else { return false }
+  let bytes = v6.rawValue
+  guard bytes.count == 16 else { return false }
+  return bytes[0] == 0xfd && bytes[1] == 0x7a && bytes[2] == 0x11 && bytes[3] == 0x5c
+    && bytes[4] == 0xa1 && bytes[5] == 0xe0
+}
+
+struct SyncNetworkInterfaceAddress: Equatable {
+  let interfaceName: String
+  let address: String
+}
+
+/// True when this device itself holds a Tailscale-assigned address — CGNAT
+/// IPv4 (100.64.0.0/10) or the Tailscale IPv6 slice (fd7a:115c:a1e0::/48) —
+/// on a tunnel interface. The utun scoping is load-bearing: cellular carriers
+/// hand phones CGNAT 100.64/10 addresses on pdp_ip*, so an unscoped address
+/// scan would read as "on Tailscale" whenever the phone is on LTE.
+func syncHasTailnetSelfAddress(_ interfaces: [SyncNetworkInterfaceAddress]) -> Bool {
+  interfaces.contains { entry in
+    entry.interfaceName.hasPrefix("utun")
+      && (syncIsTailscaleIPv4Address(entry.address) || syncIsTailscaleIPv6Address(entry.address))
+  }
+}
+
+/// Snapshot of the device's current interface addresses via getifaddrs.
+func syncCopyNetworkInterfaceAddresses() -> [SyncNetworkInterfaceAddress] {
+  var result: [SyncNetworkInterfaceAddress] = []
+  var head: UnsafeMutablePointer<ifaddrs>?
+  guard getifaddrs(&head) == 0, let first = head else { return result }
+  defer { freeifaddrs(first) }
+  var cursor: UnsafeMutablePointer<ifaddrs>? = first
+  while let entry = cursor {
+    cursor = entry.pointee.ifa_next
+    guard let addrPtr = entry.pointee.ifa_addr else { continue }
+    let family = Int32(addrPtr.pointee.sa_family)
+    guard family == AF_INET || family == AF_INET6 else { continue }
+    let addressLength = family == AF_INET
+      ? socklen_t(MemoryLayout<sockaddr_in>.size)
+      : socklen_t(MemoryLayout<sockaddr_in6>.size)
+    var hostBuffer = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+    guard getnameinfo(addrPtr, addressLength, &hostBuffer, socklen_t(hostBuffer.count), nil, 0, NI_NUMERICHOST) == 0 else {
+      continue
+    }
+    var address = String(cString: hostBuffer)
+    // Drop the IPv6 zone suffix (fe80::1%utun3 → fe80::1).
+    if let percent = address.firstIndex(of: "%") {
+      address = String(address[..<percent])
+    }
+    result.append(SyncNetworkInterfaceAddress(
+      interfaceName: String(cString: entry.pointee.ifa_name),
+      address: address
+    ))
+  }
+  return result
+}
+
+/// The saved machine advertises a Tailscale route, it is not discoverable on
+/// the current network, and this phone holds no tailnet address — the one
+/// user action that fixes the connection is turning Tailscale on (or moving
+/// back onto the machine's Wi-Fi). Never shown while connected: a user on a
+/// working VPN-to-LAN route (LAN probes succeed) simply connects.
+func syncShouldShowTailscaleOffHint(
+  transport: SyncTransportHealth,
+  hasSavedMachine: Bool,
+  savedMachineHasTailnetRoute: Bool,
+  phoneHasTailnetInterface: Bool,
+  machineDiscoveredNearby: Bool
+) -> Bool {
+  guard hasSavedMachine, savedMachineHasTailnetRoute else { return false }
+  guard !phoneHasTailnetInterface, !machineDiscoveredNearby else { return false }
+  switch transport {
+  case .connecting, .unreachable, .disconnected:
+    return true
+  case .connected:
+    return false
+  }
+}
+
 func syncNormalizedRouteHost(_ address: String) -> String {
   syncEndpointHost(address)?
     .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -507,6 +601,7 @@ func syncIsTailscaleRoute(_ address: String) -> Bool {
   let host = syncNormalizedRouteHost(address)
   if host.isEmpty { return false }
   return syncIsTailscaleIPv4Address(host)
+    || syncIsTailscaleIPv6Address(host)
     || syncIsTailnetDiscoveryHost(host)
     || host.hasSuffix(".ts.net")
 }
@@ -587,13 +682,21 @@ func syncTcpProbe(host: String, port: Int, timeoutNanoseconds: UInt64) async -> 
 func syncRaceAddressCandidates(
   addresses: [String],
   port: Int,
-  timeoutNanoseconds: UInt64 = 1_500_000_000
+  timeoutNanoseconds: UInt64 = 1_500_000_000,
+  tailscaleTimeoutNanoseconds: UInt64 = 3_000_000_000
 ) async -> [String] {
   guard addresses.count > 1 else { return addresses }
   return await withTaskGroup(of: (Int, Bool).self) { group in
     for (index, address) in addresses.enumerated() {
+      // First contact over a Tailscale route can ride a cold DERP relay and
+      // exceed the LAN-sized budget — exactly on the networks where the
+      // tailnet is the only working route. Give those candidates more room
+      // so they don't get demoted to the fallback tail.
+      let probeTimeout = syncIsTailscaleRoute(address)
+        ? max(timeoutNanoseconds, tailscaleTimeoutNanoseconds)
+        : timeoutNanoseconds
       group.addTask {
-        (index, await syncTcpProbe(host: address, port: port, timeoutNanoseconds: timeoutNanoseconds))
+        (index, await syncTcpProbe(host: address, port: port, timeoutNanoseconds: probeTimeout))
       }
     }
     var reachable: [Int] = []
@@ -768,6 +871,9 @@ private func syncLogPathSummary(_ snapshot: SyncNetworkPathSnapshot?) -> String 
 }
 
 private let syncAmbiguousRouteAuthFailureKey = "ADEAmbiguousRouteAuthFailure"
+/// userInfo key carrying `hello_error.host.deviceId` — the identity of the
+/// machine that rejected the hello, when the host was new enough to send it.
+let syncRespondingHostIdentityKey = "ADERespondingHostIdentity"
 
 private func syncLogProfileSummary(_ profile: HostConnectionProfile) -> String {
   [
@@ -931,7 +1037,7 @@ enum SyncUserFacingError {
   static func message(for error: Error) -> String {
     let nsError = error as NSError
     if nsError.userInfo[syncAmbiguousRouteAuthFailureKey] as? Bool == true {
-      return "Reached a different ADE machine on this route. ADE kept the saved pairing and will keep trying other routes."
+      return "A machine on this route rejected the saved pairing — possibly a different ADE machine. ADE kept the pairing and will keep trying other routes. If you unpaired this phone on purpose, pair again from Settings."
     }
     if let code = nsError.userInfo["ADEErrorCode"] as? String, code == "auth_failed" {
       return "This phone is no longer paired with this machine. Pair again from Settings."
@@ -1273,6 +1379,9 @@ enum TerminalStreamEvent {
 final class SyncService: ObservableObject {
   @Published private(set) var connectionState: RemoteConnectionState = .disconnected
   @Published private(set) var hostName: String?
+  /// Whether this phone currently holds a Tailscale-assigned address on a
+  /// tunnel interface. Drives the "iPhone isn't on Tailscale" connection hint.
+  @Published private(set) var phoneHasTailnetInterface = false
   @Published private(set) var activeHostProfile: HostConnectionProfile?
   @Published private(set) var projects: [MobileProjectSummary] = []
   @Published private(set) var activeProjectId: String?
@@ -2703,6 +2812,12 @@ final class SyncService: ObservableObject {
         self?.publishMergedDiscoveredHosts()
       }
     }
+    tailnetDiscovery.preferredPortsProvider = { [weak self] in
+      await MainActor.run {
+        guard let self else { return [] }
+        return self.loadSavedProfiles().values.map(\.port)
+      }
+    }
     tailnetDiscovery.start()
     pathMonitor.pathUpdateHandler = { [weak self] path in
       let snapshot = SyncNetworkPathSnapshot(
@@ -3481,9 +3596,43 @@ final class SyncService: ObservableObject {
     refreshReducedSyncLoad()
   }
 
+  /// Rescan interfaces for a tailnet self-address. Called on network-path
+  /// changes (NWPathMonitor fires when a VPN tunnel comes up or down), on
+  /// foreground transitions, and before surfacing an unreachable state.
+  private func refreshPhoneTailnetInterfaceState() {
+    let hasTailnet = syncHasTailnetSelfAddress(syncCopyNetworkInterfaceAddresses())
+    if phoneHasTailnetInterface != hasTailnet {
+      phoneHasTailnetInterface = hasTailnet
+    }
+  }
+
+  /// True when the "iPhone isn't on Tailscale" hint should show on connection
+  /// surfaces (Hub blank states, Settings header). See
+  /// `syncShouldShowTailscaleOffHint` for the gating rationale.
+  var tailscaleOffHintVisible: Bool {
+    guard let profile = activeHostProfile ?? loadProfile(),
+          tokenForProfile(profile) != nil else {
+      return false
+    }
+    // Any live discovery hit means the current network already reaches the
+    // machine (Bonjour ⇒ same LAN; the tailnet probe only resolves when the
+    // tunnel is up), so the hint would be noise.
+    let machineDiscoveredNearby = discoveredHosts.contains { host in
+      matchesDiscoveredHost(host, profile: profile)
+    }
+    return syncShouldShowTailscaleOffHint(
+      transport: connectionHealth.transport,
+      hasSavedMachine: true,
+      savedMachineHasTailnetRoute: profileHasTailnetRoute(profile),
+      phoneHasTailnetInterface: phoneHasTailnetInterface,
+      machineDiscoveredNearby: machineDiscoveredNearby
+    )
+  }
+
   private func handleNetworkPathChange(_ snapshot: SyncNetworkPathSnapshot) {
     let previous = lastNetworkPathSnapshot
     lastNetworkPathSnapshot = snapshot
+    refreshPhoneTailnetInterfaceState()
     refreshReducedSyncLoad()
     guard previous != nil else { return }
     guard canReconnectToSavedHost,
@@ -3548,6 +3697,7 @@ final class SyncService: ObservableObject {
   }
 
   func handleForegroundTransition() async {
+    refreshPhoneTailnetInterfaceState()
     guard !reconnectConnectInFlight else { return }
     if canSendLiveRequests() {
       lastError = nil
@@ -7741,7 +7891,11 @@ final class SyncService: ObservableObject {
         syncConnectLog.info("ADE_SYNC_TRACE reconnect success host=\(attempt.address, privacy: .public) port=\(attempt.port)")
         return (host: attempt.address, port: attempt.port)
       } catch {
-        let reconnectError = errorByMarkingAmbiguousRouteAuthFailure(error, attemptedAddress: attempt.address)
+        let reconnectError = errorByMarkingAmbiguousRouteAuthFailure(
+          error,
+          attemptedAddress: attempt.address,
+          expectedHostIdentity: profile.hostIdentity
+        )
         syncConnectLog.info("ADE_SYNC_TRACE reconnect failure host=\(attempt.address, privacy: .public) port=\(attempt.port) error=\(syncLogErrorSummary(reconnectError), privacy: .public)")
         lastFailure = reconnectError
         if shouldInvalidateSavedPairing(for: reconnectError) {
@@ -7841,10 +7995,13 @@ final class SyncService: ObservableObject {
     networkPathReconnectTask = nil
     clearReconnectConnectInFlight()
     autoReconnectAwaitingLiveDiscovery = false
+    refreshPhoneTailnetInterfaceState()
     let machineName = syncTrimmedNonEmptyName(profile?.hostName)
       ?? syncTrimmedNonEmptyName(hostName)
       ?? "this machine"
-    lastError = "Can't reach \(machineName)."
+    lastError = tailscaleOffHintVisible
+      ? "Can't reach \(machineName). This iPhone isn't connected to Tailscale, which ADE needs when you're away from the machine's Wi-Fi."
+      : "Can't reach \(machineName)."
     connectionState = .error
     setDomainStatus(SyncDomain.allCases, phase: .failed, error: lastError)
   }
@@ -7872,37 +8029,33 @@ final class SyncService: ObservableObject {
     return nsError.userInfo["ADEErrorCode"] as? String == "auth_failed"
   }
 
-  private func isAmbiguousSavedRoute(_ attemptedAddress: String) -> Bool {
-    let host = syncNormalizedRouteHost(attemptedAddress)
-    if host.isEmpty { return false }
-    if syncIsTailnetDiscoveryHost(host) { return true }
-    if host == "localhost" || host.hasSuffix(".localhost") || host.hasSuffix(".local") { return true }
-    if let v4 = IPv4Address(host) {
-      let bytes = v4.rawValue
-      guard bytes.count == 4 else { return false }
-      let a = bytes[0], b = bytes[1]
-      return a == 127
-        || a == 10
-        || (a == 172 && (16...31).contains(b))
-        || (a == 192 && b == 168)
-        || (a == 169 && b == 254)
-    }
-    if let v6 = IPv6Address(host) {
-      let bytes = v6.rawValue
-      guard bytes.count == 16 else { return false }
-      if bytes == Data([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]) { return true }
-      if (bytes[0] & 0xfe) == 0xfc { return true }
-      if bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0x80 { return true }
-    }
-    return false
-  }
-
-  private func errorByMarkingAmbiguousRouteAuthFailure(_ error: Error, attemptedAddress: String) -> Error {
+  /// A destructive `forgetHost()` needs positive attribution: the rejection
+  /// must come from the exact machine this profile is paired with. A reused
+  /// DHCP lease, an mDNS alias, or a stale Tailscale candidate can all dial a
+  /// stranger whose auth check fails — and older hosts omit their identity
+  /// from `hello_error` entirely. Anything unattributed is marked ambiguous so
+  /// `shouldInvalidateSavedPairing` keeps the saved pairing and the reconnect
+  /// loop moves on to other routes.
+  private func errorByMarkingAmbiguousRouteAuthFailure(
+    _ error: Error,
+    attemptedAddress: String,
+    expectedHostIdentity: String?
+  ) -> Error {
     let nsError = error as NSError
-    guard nsError.userInfo["ADEErrorCode"] as? String == "auth_failed",
-          isAmbiguousSavedRoute(attemptedAddress) else {
+    guard nsError.userInfo["ADEErrorCode"] as? String == "auth_failed" else {
       return error
     }
+    let responding = syncNonEmpty(nsError.userInfo[syncRespondingHostIdentityKey] as? String)
+    if let responding,
+       let expected = syncNonEmpty(expectedHostIdentity),
+       responding == expected {
+      // The paired machine itself rejected this device — the pairing is
+      // genuinely revoked and the saved credentials may be dropped.
+      return error
+    }
+    syncConnectLog.info(
+      "ADE_SYNC_TRACE auth failure kept pairing (unattributed) address=\(attemptedAddress, privacy: .public) expected=\(expectedHostIdentity ?? "none", privacy: .public) responding=\(responding ?? "none", privacy: .public)"
+    )
     var userInfo = nsError.userInfo
     userInfo[syncAmbiguousRouteAuthFailureKey] = true
     return NSError(domain: nsError.domain, code: nsError.code, userInfo: userInfo)
@@ -8364,17 +8517,25 @@ final class SyncService: ObservableObject {
     currentPeerMetadata()["dbVersion"] as? Int ?? -1
   }
 
-  func shouldInvalidateSavedPairingAfterAuthFailureForTesting(address: String) -> Bool {
-    let error = NSError(
-      domain: "ADE",
-      code: 3,
-      userInfo: [
-        NSLocalizedDescriptionKey: "Authentication failed.",
-        "ADEErrorCode": "auth_failed",
-      ]
-    )
+  func shouldInvalidateSavedPairingAfterAuthFailureForTesting(
+    address: String,
+    respondingHostIdentity: String? = nil,
+    expectedHostIdentity: String? = nil
+  ) -> Bool {
+    var userInfo: [String: Any] = [
+      NSLocalizedDescriptionKey: "Authentication failed.",
+      "ADEErrorCode": "auth_failed",
+    ]
+    if let respondingHostIdentity {
+      userInfo[syncRespondingHostIdentityKey] = respondingHostIdentity
+    }
+    let error = NSError(domain: "ADE", code: 3, userInfo: userInfo)
     return shouldInvalidateSavedPairing(
-      for: errorByMarkingAmbiguousRouteAuthFailure(error, attemptedAddress: address)
+      for: errorByMarkingAmbiguousRouteAuthFailure(
+        error,
+        attemptedAddress: address,
+        expectedHostIdentity: expectedHostIdentity
+      )
     )
   }
 
@@ -8738,16 +8899,26 @@ final class SyncService: ObservableObject {
          "project_list_my_github_repos_result":
       resolve(requestId: requestId, result: .success(payload))
     case "hello_error":
-      let code = ((payload as? [String: Any])?["code"] as? String) ?? "auth_failed"
-      let message = ((payload as? [String: Any])?["message"] as? String) ?? "Authentication failed."
+      let errorPayload = payload as? [String: Any]
+      let code = (errorPayload?["code"] as? String) ?? "auth_failed"
+      let message = (errorPayload?["message"] as? String) ?? "Authentication failed."
+      // Newer hosts attribute the rejection: the identity of the machine that
+      // refused the hello. Without it (older host, or a stranger machine on a
+      // reused address) the client must never destroy its saved pairing.
+      let respondingHostIdentity = ((errorPayload?["host"] as? [String: Any])?["deviceId"] as? String)?
+        .trimmingCharacters(in: .whitespacesAndNewlines)
       connectionState = .error
+      var userInfo: [String: Any] = [
+        NSLocalizedDescriptionKey: message,
+        "ADEErrorCode": code,
+      ]
+      if let respondingHostIdentity, !respondingHostIdentity.isEmpty {
+        userInfo[syncRespondingHostIdentityKey] = respondingHostIdentity
+      }
       resolve(requestId: requestId, result: .failure(NSError(
         domain: "ADE",
         code: 5,
-        userInfo: [
-          NSLocalizedDescriptionKey: message,
-          "ADEErrorCode": code,
-        ]
+        userInfo: userInfo
       )))
     case "pairing_result":
       resolve(requestId: requestId, result: .success(payload))
@@ -10713,6 +10884,9 @@ extension SyncService {
 
 private final class SyncTailnetProbe {
   var onHostsChanged: (([DiscoveredSyncHost]) -> Void)?
+  /// Live saved-profile ports injected by SyncService so a host serving on a
+  /// drifted port is still discovered without sweeping the whole port range.
+  var preferredPortsProvider: (() async -> [Int])?
 
   private let connectionQueue = DispatchQueue(label: "com.ade.sync.tailnet-probe")
   private var probeTask: Task<Void, Never>?
@@ -10734,9 +10908,13 @@ private final class SyncTailnetProbe {
   }
 
   private func refresh() async {
+    let preferredPorts = await preferredPortsProvider?() ?? []
+    var seenPorts = Set<Int>()
+    let ports = (preferredPorts + SyncTailnetDiscovery.probePortCandidates)
+      .filter { (1...65_535).contains($0) && seenPorts.insert($0).inserted }
     var nextHosts: [String: DiscoveredSyncHost] = [:]
     for host in SyncTailnetDiscovery.hostCandidates {
-      for port in SyncTailnetDiscovery.portCandidates {
+      for port in ports {
         guard !Task.isCancelled else { return }
         let result = await probe(host: host, port: port)
         guard result != .unresolvedHost else { break }

--- a/apps/ios/ADE/Views/Components/ADEDesignSystem.swift
+++ b/apps/ios/ADE/Views/Components/ADEDesignSystem.swift
@@ -483,6 +483,36 @@ struct ADENoticeCard: View {
   }
 }
 
+/// Warning card shown on connection surfaces when the saved machine expects a
+/// Tailscale route but this iPhone has no tailnet interface (see
+/// `SyncService.tailscaleOffHintVisible`). The action opens the Tailscale app
+/// when installed, falling back to its App Store page.
+struct ADETailscaleOffHintCard: View {
+  @Environment(\.openURL) private var openURL
+
+  var body: some View {
+    ADENoticeCard(
+      title: "iPhone isn't on Tailscale",
+      message: "Away from your machine's Wi-Fi, ADE connects through Tailscale. Open it and connect this iPhone.",
+      icon: "network.badge.shield.half.filled",
+      tint: ADEColor.warning,
+      actionTitle: "Open Tailscale",
+      action: openTailscale
+    )
+  }
+
+  private func openTailscale() {
+    guard let appUrl = URL(string: "tailscale://") else { return }
+    openURL(appUrl) { accepted in
+      guard !accepted,
+            let storeUrl = URL(string: "https://apps.apple.com/app/tailscale/id1470499037") else {
+        return
+      }
+      openURL(storeUrl)
+    }
+  }
+}
+
 struct ADEStatusPill: View {
   let text: String
   let tint: Color

--- a/apps/ios/ADE/Views/Hub/HubComponents.swift
+++ b/apps/ios/ADE/Views/Hub/HubComponents.swift
@@ -695,12 +695,19 @@ struct HubStatusDot: View {
 // MARK: - State cards
 
 struct HubConnectingCard: View {
+  @EnvironmentObject private var syncService: SyncService
+
   var body: some View {
-    HStack(spacing: 10) {
-      ProgressView().controlSize(.small)
-      Text("Connecting to your machine…")
-        .font(.system(.subheadline, design: .rounded))
-        .foregroundStyle(ADEColor.textSecondary)
+    VStack(spacing: 16) {
+      HStack(spacing: 10) {
+        ProgressView().controlSize(.small)
+        Text("Connecting to your machine…")
+          .font(.system(.subheadline, design: .rounded))
+          .foregroundStyle(ADEColor.textSecondary)
+      }
+      if syncService.tailscaleOffHintVisible {
+        ADETailscaleOffHintCard()
+      }
     }
     .frame(maxWidth: .infinity)
     .padding(.vertical, 28)
@@ -748,11 +755,11 @@ struct HubNoMachineState: View {
         .accessibilityLabel("ADE")
 
       HStack(spacing: 8) {
-        Circle().fill(ADEColor.textMuted).frame(width: 8, height: 8)
+        Circle().fill(statusDotColor).frame(width: 8, height: 8)
         Image(systemName: "desktopcomputer")
           .font(.system(size: 13, weight: .semibold))
           .foregroundStyle(ADEColor.textSecondary)
-        Text(syncService.connectionState == .error ? "Cannot reach machine" : "No machine attached")
+        Text(statusText)
           .font(.system(.footnote, design: .rounded).weight(.semibold))
           .foregroundStyle(ADEColor.textPrimary)
       }
@@ -762,30 +769,85 @@ struct HubNoMachineState: View {
       .overlay(Capsule().stroke(ADEColor.border.opacity(0.8), lineWidth: 1))
       .padding(.top, 30)
 
+      if syncService.tailscaleOffHintVisible {
+        ADETailscaleOffHintCard()
+          .padding(.top, 22)
+      }
+
       Spacer(minLength: 40)
 
-      Button {
-        syncService.settingsPresented = true
-      } label: {
-        HStack(spacing: 10) {
-          Image(systemName: "link")
-            .font(.system(size: 15, weight: .semibold))
-            .foregroundStyle(ADEColor.accent)
-          Text("Connect Machine")
-            .font(.system(.subheadline, design: .rounded).weight(.semibold))
-            .foregroundStyle(ADEColor.textPrimary)
+      VStack(spacing: 12) {
+        if hasSavedMachine {
+          Button {
+            Task { await syncService.reconnectIfPossible(userInitiated: true) }
+          } label: {
+            primaryButtonLabel(symbol: "arrow.clockwise", title: "Reconnect")
+          }
+          .buttonStyle(.plain)
+
+          Button {
+            syncService.settingsPresented = true
+          } label: {
+            Text("Connection settings")
+              .font(.system(.footnote, design: .rounded).weight(.semibold))
+              .foregroundStyle(ADEColor.textSecondary)
+          }
+          .buttonStyle(.plain)
+        } else {
+          Button {
+            syncService.settingsPresented = true
+          } label: {
+            primaryButtonLabel(symbol: "link", title: "Connect Machine")
+          }
+          .buttonStyle(.plain)
         }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 16)
-        .background(ADEColor.accent.opacity(0.14), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).stroke(ADEColor.accent.opacity(0.4), lineWidth: 1))
       }
-      .buttonStyle(.plain)
       .padding(.bottom, 56)
     }
     .frame(maxWidth: 520)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     .padding(.horizontal, 22)
+  }
+
+  /// A machine is "saved" when a pairing credential still exists for it —
+  /// plain `.disconnected` with a saved machine must not read as unpaired.
+  private var hasSavedMachine: Bool {
+    syncService.canReconnectToSavedHost
+  }
+
+  private var machineDisplayName: String? {
+    let name = syncService.hostName ?? syncService.activeHostProfile?.hostName
+    let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed?.isEmpty == false ? trimmed : nil
+  }
+
+  private var statusText: String {
+    if syncService.connectionState == .error {
+      return "Cannot reach \(machineDisplayName ?? "machine")"
+    }
+    if hasSavedMachine {
+      return "Disconnected from \(machineDisplayName ?? "saved machine")"
+    }
+    return "No machine attached"
+  }
+
+  private var statusDotColor: Color {
+    syncService.connectionState == .error ? ADEColor.danger : ADEColor.textMuted
+  }
+
+  private func primaryButtonLabel(symbol: String, title: String) -> some View {
+    HStack(spacing: 10) {
+      Image(systemName: symbol)
+        .font(.system(size: 15, weight: .semibold))
+        .foregroundStyle(ADEColor.accent)
+      Text(title)
+        .font(.system(.subheadline, design: .rounded).weight(.semibold))
+        .foregroundStyle(ADEColor.textPrimary)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, 16)
+    .background(ADEColor.accent.opacity(0.14), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).stroke(ADEColor.accent.opacity(0.4), lineWidth: 1))
   }
 }
 

--- a/apps/ios/ADE/Views/Hub/HubComponents.swift
+++ b/apps/ios/ADE/Views/Hub/HubComponents.swift
@@ -791,6 +791,8 @@ struct HubNoMachineState: View {
             Text("Connection settings")
               .font(.system(.footnote, design: .rounded).weight(.semibold))
               .foregroundStyle(ADEColor.textSecondary)
+              .frame(minHeight: 44)
+              .contentShape(Rectangle())
           }
           .buttonStyle(.plain)
         } else {

--- a/apps/ios/ADE/Views/Settings/ConnectionSettingsView.swift
+++ b/apps/ios/ADE/Views/Settings/ConnectionSettingsView.swift
@@ -139,6 +139,7 @@ struct SettingsConnectionSnapshot: Equatable {
   var canReconnectToSavedHost: Bool
   var savedReconnectPrefersTailnet: Bool
   var errorMessage: String?
+  var showTailscaleOffHint = false
 }
 
 struct SettingsPairingSnapshot: Equatable {
@@ -213,7 +214,8 @@ private final class SettingsConnectionPresentationModel: ObservableObject {
         routeLine: Self.routeLine(address: address, port: activeProfile?.port),
         canReconnectToSavedHost: syncService.canReconnectToSavedHost,
         savedReconnectPrefersTailnet: savedReconnectHost?.tailscaleAddress != nil,
-        errorMessage: health.transport == .unreachable ? health.lastFailureMessage : nil
+        errorMessage: health.transport == .unreachable ? health.lastFailureMessage : nil,
+        showTailscaleOffHint: syncService.tailscaleOffHintVisible
       )
     )
 
@@ -242,7 +244,7 @@ private final class SettingsConnectionPresentationModel: ObservableObject {
 
   private static func routeLine(address: String?, port: Int?) -> String? {
     guard let address else { return nil }
-    let prefix = syncIsTailscaleIPv4Address(address) ? "Tailscale " : ""
+    let prefix = syncIsTailscaleRoute(address) ? "Tailscale " : ""
     if let port {
       return "\(prefix)\(address) · :\(port)"
     }

--- a/apps/ios/ADE/Views/Settings/SettingsConnectionHeader.swift
+++ b/apps/ios/ADE/Views/Settings/SettingsConnectionHeader.swift
@@ -65,6 +65,10 @@ struct SettingsConnectionHeader: View {
          !health.transport.isConnected {
         SettingsInlineErrorBanner(message: errorMessage)
       }
+
+      if snapshot.showTailscaleOffHint {
+        ADETailscaleOffHintCard()
+      }
     }
     .padding(18)
     .frame(maxWidth: .infinity, alignment: .leading)

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -1329,7 +1329,11 @@ final class ADETests: XCTestCase {
     XCTAssertTrue(
       syncConnectPortCandidates(primaryPort: 8790, addresses: ["100.75.20.63"]).contains(SyncDirectHostPorts.fallbackMaxPort)
     )
-    XCTAssertEqual(SyncTailnetDiscovery.portCandidates, SyncDirectHostPorts.portCandidates)
+    // The tailnet discovery probe must stay a bounded sweep: probing the full
+    // stale-port recovery range (213 ports, sequentially, 2 s timeout each)
+    // overruns the 45 s refresh interval whenever the host drops packets.
+    XCTAssertEqual(SyncTailnetDiscovery.probePortCandidates.first, SyncDirectHostPorts.defaultPort)
+    XCTAssertLessThanOrEqual(SyncTailnetDiscovery.probePortCandidates.count, 16)
   }
 
   func testSyncConnectionEndpointAttemptsTryPrimaryPortForEveryAddressFirst() {
@@ -1658,13 +1662,90 @@ final class ADETests: XCTestCase {
   }
 
   @MainActor
-  func testSyncAuthFailureOnAmbiguousSavedLanRouteKeepsPairing() {
+  func testSyncAuthFailureOnlyInvalidatesPairingWhenRejectionIsAttributedToPairedMachine() {
     let service = SyncService(database: makeDatabase(baseURL: makeTemporaryDirectory()))
 
+    // Unattributed rejections (older host, or a stranger machine on a reused
+    // address) must never destroy the saved pairing — on any route shape.
     XCTAssertFalse(service.shouldInvalidateSavedPairingAfterAuthFailureForTesting(address: "192.168.1.8"))
     XCTAssertFalse(service.shouldInvalidateSavedPairingAfterAuthFailureForTesting(address: "mac.local"))
     XCTAssertFalse(service.shouldInvalidateSavedPairingAfterAuthFailureForTesting(address: "ade-sync"))
-    XCTAssertTrue(service.shouldInvalidateSavedPairingAfterAuthFailureForTesting(address: "macbook.tailnet.ts.net"))
+    XCTAssertFalse(service.shouldInvalidateSavedPairingAfterAuthFailureForTesting(address: "macbook.tailnet.ts.net"))
+    XCTAssertFalse(service.shouldInvalidateSavedPairingAfterAuthFailureForTesting(address: "100.75.20.63"))
+
+    // A rejection from a machine whose identity differs from the pairing is a
+    // wrong-machine dial, not a revocation.
+    XCTAssertFalse(service.shouldInvalidateSavedPairingAfterAuthFailureForTesting(
+      address: "100.75.20.63",
+      respondingHostIdentity: "some-other-machine",
+      expectedHostIdentity: "host-1"
+    ))
+
+    // Only the paired machine itself rejecting this device may drop the
+    // saved credentials — and then on every route shape, including LAN.
+    XCTAssertTrue(service.shouldInvalidateSavedPairingAfterAuthFailureForTesting(
+      address: "macbook.tailnet.ts.net",
+      respondingHostIdentity: "host-1",
+      expectedHostIdentity: "host-1"
+    ))
+    XCTAssertTrue(service.shouldInvalidateSavedPairingAfterAuthFailureForTesting(
+      address: "192.168.1.8",
+      respondingHostIdentity: "host-1",
+      expectedHostIdentity: "host-1"
+    ))
+  }
+
+  func testSyncTailscaleIPv6RouteClassification() {
+    XCTAssertTrue(syncIsTailscaleIPv6Address("fd7a:115c:a1e0::1234"))
+    XCTAssertTrue(syncIsTailscaleRoute("ws://[fd7a:115c:a1e0:ab12::42]:8787"))
+    XCTAssertFalse(syncIsTailscaleIPv6Address("fd00::1"))
+    XCTAssertFalse(syncIsTailscaleIPv6Address("fe80::1"))
+    XCTAssertFalse(syncIsTailscaleRoute("fd00::1"))
+  }
+
+  func testSyncTailnetSelfAddressRequiresTunnelInterface() {
+    // Carrier CGNAT on the cellular interface must not read as "on Tailscale".
+    XCTAssertFalse(syncHasTailnetSelfAddress([
+      SyncNetworkInterfaceAddress(interfaceName: "pdp_ip0", address: "100.85.12.9"),
+      SyncNetworkInterfaceAddress(interfaceName: "en0", address: "192.168.1.20"),
+    ]))
+    XCTAssertTrue(syncHasTailnetSelfAddress([
+      SyncNetworkInterfaceAddress(interfaceName: "utun4", address: "100.85.12.9"),
+    ]))
+    XCTAssertTrue(syncHasTailnetSelfAddress([
+      SyncNetworkInterfaceAddress(interfaceName: "utun2", address: "fd7a:115c:a1e0::4"),
+    ]))
+    // A non-Tailscale VPN tunnel is not a tailnet.
+    XCTAssertFalse(syncHasTailnetSelfAddress([
+      SyncNetworkInterfaceAddress(interfaceName: "utun1", address: "10.8.0.2"),
+    ]))
+  }
+
+  func testSyncTailscaleOffHintGating() {
+    func hint(
+      transport: SyncTransportHealth,
+      hasSavedMachine: Bool = true,
+      tailnetRoute: Bool = true,
+      phoneOnTailnet: Bool = false,
+      nearby: Bool = false
+    ) -> Bool {
+      syncShouldShowTailscaleOffHint(
+        transport: transport,
+        hasSavedMachine: hasSavedMachine,
+        savedMachineHasTailnetRoute: tailnetRoute,
+        phoneHasTailnetInterface: phoneOnTailnet,
+        machineDiscoveredNearby: nearby
+      )
+    }
+
+    XCTAssertTrue(hint(transport: .connecting))
+    XCTAssertTrue(hint(transport: .unreachable))
+    XCTAssertTrue(hint(transport: .disconnected))
+    XCTAssertFalse(hint(transport: .connected))
+    XCTAssertFalse(hint(transport: .unreachable, hasSavedMachine: false))
+    XCTAssertFalse(hint(transport: .unreachable, tailnetRoute: false))
+    XCTAssertFalse(hint(transport: .unreachable, phoneOnTailnet: true))
+    XCTAssertFalse(hint(transport: .unreachable, nearby: true))
   }
 
   @MainActor

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -168,7 +168,11 @@ Canonical files (`apps/ade-cli/src/services/sync/`):
   false so a second runtime becomes a viewer instead of stealing the
   sync authority role.
 - `syncHostService.ts` — the per-project WebSocket host. Owns
-  connection acceptance, hello/pairing handshakes, per-peer state,
+  connection acceptance, hello/pairing handshakes (an `auth_failed`
+  rejection is attributed with the rejecting machine's
+  `host: { deviceId, name }` — read from `readBrainMetadata()` — so a
+  client can only ever drop a saved pairing when the rejection came from
+  the machine it is actually paired with), per-peer state,
   changeset fan-out + ack tracking (bounded, windowed exports — see
   `crdt-model.md`), chat-first scheduling (chat events are pumped before
   background changesets, and peers with active chat subscriptions get
@@ -259,7 +263,11 @@ Canonical files (`apps/ade-cli/src/services/sync/`):
 - `brainProjectActionsSyncHandler.ts` — machine-wide fallback sync
   handler used by `ade serve` before any project host is active. It
   authenticates the same PIN / paired-secret / bootstrap paths as the
-  per-project host, applies the same failed-PIN cooldown, and serves
+  per-project host, applies the same failed-PIN cooldown, attributes its
+  `auth_failed` rejections with the same `host: { deviceId, name }`
+  identity the per-project host sends (so a phone that reaches this
+  fallback over a stale address still won't destroy a pairing it can't
+  attribute), and serves
   project catalog plus runtime-scoped project actions so a phone can
   add/open/create/clone/remove a project even from the project-home state.
   It also answers `command` envelopes: when no project host owns the peer

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -661,7 +661,15 @@ snapshots, `file_response`, and large `command_result` payloads can
 no longer kill the connection with "Message too long".
 
 `SyncHelloErrorPayload.code` is trimmed to `auth_failed |
-invalid_hello`. `SyncPairingResultPayload.error.code` is one of
+invalid_hello`. An `auth_failed` payload also carries an optional
+`host: { deviceId, name }` naming the machine that rejected the hello —
+both the project host and the brain-level fallback handler send it. This
+is the client's only safe basis for destroying a saved pairing: a phone
+drops its credentials **only** when the rejecting `host.deviceId` matches
+the paired machine's identity. An unattributed rejection (older host, or
+a stranger machine reached over a reused DHCP lease / mDNS alias / stale
+Tailscale candidate) keeps the pairing and the client moves on to other
+routes. `SyncPairingResultPayload.error.code` is one of
 `invalid_pin | pin_not_set | pairing_failed`.
 
 Heartbeat interval is 30 seconds. Desktop peers close after **two**

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -230,13 +230,47 @@ cards — controllers no longer ship duplicate offline / reconnect /
 hydrating cards inside each screen body.
 
 The Hub is the exception: with the navigation bar hidden, its
-no-machine / connection-error state renders `HubNoMachineState`
-("No machine attached" / "Cannot reach machine") instead of project
-cards, using the same `SyncConnectionHealth` mapping as `ADEConnectionDot`
-(success when connected and not strained, warning when connecting or
-strained, danger when unreachable, muted when disconnected) and routing
-taps through `syncService.settingsPresented` to the same Settings sheet
-the dot opens.
+no-machine / connection-error state renders `HubNoMachineState` instead
+of project cards, using the same `SyncConnectionHealth` mapping as
+`ADEConnectionDot` and routing taps through
+`syncService.settingsPresented` to the same Settings sheet the dot
+opens. Its status capsule distinguishes three states: "Cannot reach
+\<machine\>" (`.error`, danger dot), "Disconnected from \<machine\>"
+(`.disconnected` while a pairing credential is still saved —
+`canReconnectToSavedHost`), and "No machine attached" (truly unpaired).
+With a saved machine the primary action is **Reconnect** (calls
+`reconnectIfPossible(userInitiated: true)`) with a secondary
+"Connection settings" link; unpaired phones keep the single
+"Connect Machine" button into Settings.
+
+### Tailscale-off route hint
+
+Connection surfaces show an "iPhone isn't on Tailscale" warning card
+(`ADETailscaleOffHintCard` in `ADEDesignSystem.swift`) when the one
+user action that can fix the connection is turning Tailscale on. Gating
+is the pure helper `syncShouldShowTailscaleOffHint(...)`, exposed as
+`SyncService.tailscaleOffHintVisible`; all of the following must hold:
+
+- a pairing credential exists and the saved profile carries a Tailscale
+  route (`profileHasTailnetRoute`),
+- the phone holds **no** tailnet self-address — `syncHasTailnetSelfAddress`
+  scans `getifaddrs` output for a Tailscale CGNAT IPv4 (100.64/10) or
+  Tailscale IPv6 (fd7a:115c:a1e0::/48) address **on a `utun*` interface
+  only** (cellular carriers assign CGNAT 100.64/10 to `pdp_ip*`, so an
+  unscoped scan would false-positive on LTE),
+- no live discovery hit matches the profile (Bonjour ⇒ same LAN; the
+  tailnet probe only resolves when the tunnel is up),
+- transport is connecting / disconnected / unreachable — never while
+  connected, so a working VPN-to-LAN setup is left alone.
+
+The interface scan refreshes on `NWPathMonitor` path changes (VPN
+tunnels flip the path), on foreground transitions, and before
+`enterUnreachableTerminalState` surfaces its terminal error (whose
+message appends the Tailscale explanation when the hint holds). The
+card renders in `HubNoMachineState`, `HubConnectingCard`, and
+`SettingsConnectionHeader` (via
+`SettingsConnectionSnapshot.showTailscaleOffHint`); its action opens
+the Tailscale app (`tailscale://`), falling back to the App Store page.
 
 `SettingsConnectionHeader` distinguishes the four states explicitly:
 
@@ -344,11 +378,26 @@ Source: `apps/ios/ADE/Services/SyncService.swift`.
    candidates are raced with concurrent raw-TCP reachability probes
    (happy eyeballs) and tried in first-reachable order, so a dead LAN
    IP does not cost a full open timeout before the live Tailscale
-   route is attempted. `reconnectIfPossible` is guarded so overlapping
-   wake-ups never stack TCP/WebSocket attempts, and a reconnect never
-   tears down an already-live connection. The socket declares the
-   `chunkedEnvelopes` capability and sets a 32 MiB
+   route is attempted. Tailscale-classified candidates get a longer
+   probe budget (3 s vs 1.5 s) because first contact through a cold
+   DERP relay can exceed the LAN-sized timeout on exactly the networks
+   where the tailnet is the only working route. Route classification
+   (`syncIsTailscaleRoute`) covers CGNAT IPv4 (100.64/10), Tailscale
+   IPv6 (fd7a:115c:a1e0::/48), `.ts.net` names, and the `ade-sync`
+   alias. The background tailnet discovery probe (`SyncTailnetProbe`,
+   45 s cadence) sweeps only a bounded port set — saved-profile ports
+   plus `SyncTailnetDiscovery.probePortCandidates` (default port + 8) —
+   never the full 8787–8999 stale-port range, which belongs to the
+   connect path's recovery sweep. `reconnectIfPossible` is guarded so
+   overlapping wake-ups never stack TCP/WebSocket attempts, and a
+   reconnect never tears down an already-live connection. The socket
+   declares the `chunkedEnvelopes` capability and sets a 32 MiB
    `maximumMessageSize` receive budget.
+   An `auth_failed` hello rejection drops the saved pairing **only**
+   when the rejecting machine attributed itself (`hello_error.host`)
+   and its identity matches the paired machine; unattributed or
+   mismatched rejections are marked ambiguous, keep the pairing, and
+   let the reconnect loop try other routes.
 3. Send local `db_version` plus the per-host-DB cursor map
    (`remoteDbVersionBySite`); `hello_ok` returns the host DB's
    `serverDbSiteId` and the runtime's current project catalog when the


### PR DESCRIPTION
## Summary

Makes ADE mobile connections more legible and more resilient, per the sync docs (`docs/features/sync-and-multi-device/`):

- **Tailscale-off hint** — when the saved machine expects a Tailscale route, the phone holds no tailnet address on a `utun*` interface (carrier CGNAT on `pdp_ip*` is excluded), and no live discovery reaches the machine, the Hub blank/connecting states and Settings header show an "iPhone isn't on Tailscale" card with an Open Tailscale action (App Store fallback). The unreachable error message explains the same cause.
- **Hub state fix** — "No machine attached" no longer shows for a paired-but-disconnected machine; the blank state now distinguishes Cannot reach / Disconnected from `<machine>` / truly unpaired, and offers a real Reconnect button.
- **Attributed pairing revocation** — `hello_error(auth_failed)` now carries the rejecting machine's identity (project host + brain fallback handler). The phone drops its saved pairing only when that identity matches the paired machine; unattributed rejections (older hosts, stranger machines on reused DHCP leases / stale Tailscale candidates) keep credentials and try other routes.
- **Probe hardening** — the background tailnet discovery probe sweeps a bounded port set (default+8 plus saved-profile ports) instead of all 213 stale-port-recovery ports; Tailscale IPv6 (fd7a:115c:a1e0::/48) is classified as a tailnet route; Tailscale candidates get a 3 s TCP probe budget so cold DERP relays aren't demoted.

## Testing

- iOS: full ADETests suite green on simulator; app builds via direct xcodebuild. New tests cover attribution-gated invalidation, TS IPv6 classification, utun-scoped self-address detection, hint gating, and probe port bounds.
- Desktop/CLI: `syncHostService.test.ts` extended to assert `hello_error.host` attribution (24/24); ade-cli + desktop typechecks green; ade-cli sync tests 116/116; TUI tests 813/813.
- Docs updated: `sync-and-multi-device/README.md`, `ios-companion.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves mobile sync reliability around Tailscale routes and pairing revocation. The main changes are:

- Adds rejecting-host attribution to `auth_failed` hello responses.
- Keeps iOS saved pairings unless an auth failure is attributed to the paired machine.
- Adds iOS Tailscale IPv6 and tunnel-interface detection for route classification.
- Shows a Tailscale-off hint in Hub and Settings when a saved tailnet route is unreachable.
- Bounds background tailnet discovery probes while preserving saved-port recovery.
- Updates tests and docs for the new sync behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

Changes are localized to sync connection handling and UI state. Missing host attribution remains backward-compatible because iOS treats it as non-destructive. Focused tests cover route classification, hint gating, probe bounds, and auth-failure invalidation.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The CLI proof run for sync-reliability completed, showing Vitest results with 2 passed (2) and 55 passed (55), and EXIT\_CODE: 0.
- The desktop proof run for sync-reliability completed, showing Vitest results with 1 passed (1), 7 passed | 17 skipped (24), and EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/13270311/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Services/SyncService.swift | Adds Tailscale route/interface detection, bounded tailnet probing, longer Tailscale reachability probes, and attributed auth-failure handling. |
| apps/ade-cli/src/services/sync/syncHostService.ts | Adds rejecting host metadata to project-host `hello_error` responses without changing successful authentication flow. |
| apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts | Adds host identity attribution to fallback `auth_failed` hello responses so clients can distinguish revocation from stale-route rejection. |
| apps/ios/ADE/Views/Hub/HubComponents.swift | Updates Hub connection states to show the Tailscale hint and distinguish saved-but-disconnected machines from unpaired state. |
| apps/ios/ADE/Views/Components/ADEDesignSystem.swift | Introduces a reusable Tailscale-off warning card with app-open/App Store fallback action. |
| apps/ios/ADETests/ADETests.swift | Adds tests for bounded tailnet probing, attributed pairing invalidation, Tailscale IPv6 classification, tunnel-interface gating, and hint visibility. |
| apps/desktop/src/shared/types/sync.ts | Documents and types the optional `SyncHelloErrorPayload.host` attribution field for backward-compatible clients. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Phone as iOS SyncService
  participant Routes as Candidate routes/probes
  participant Host as ADE host
  participant UI as Hub/Settings UI

  Phone->>Phone: Load saved HostConnectionProfile + token
  Phone->>Phone: Scan utun interfaces for Tailscale self-address
  Phone->>Routes: Race saved/LAN/Tailscale candidates
  Routes-->>Phone: Reachable order, with longer Tailscale probe budget
  Phone->>Host: hello(auth, expected host identity)
  alt Host accepts
    Host-->>Phone: hello_ok
    Phone->>UI: Connected state, hide Tailscale hint
  else Host rejects
    Host-->>Phone: hello_error(auth_failed, host.deviceId?)
    Phone->>Phone: Compare rejecting host with saved host identity
    alt deviceId matches saved pairing
      Phone->>Phone: Invalidate saved pairing
    else missing or mismatched attribution
      Phone->>Phone: Keep pairing and try other routes
      Phone->>UI: Show unreachable/Tailscale-off hint when gated
    end
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Phone as iOS SyncService
  participant Routes as Candidate routes/probes
  participant Host as ADE host
  participant UI as Hub/Settings UI

  Phone->>Phone: Load saved HostConnectionProfile + token
  Phone->>Phone: Scan utun interfaces for Tailscale self-address
  Phone->>Routes: Race saved/LAN/Tailscale candidates
  Routes-->>Phone: Reachable order, with longer Tailscale probe budget
  Phone->>Host: hello(auth, expected host identity)
  alt Host accepts
    Host-->>Phone: hello_ok
    Phone->>UI: Connected state, hide Tailscale hint
  else Host rejects
    Host-->>Phone: hello_error(auth_failed, host.deviceId?)
    Phone->>Phone: Compare rejecting host with saved host identity
    alt deviceId matches saved pairing
      Phone->>Phone: Invalidate saved pairing
    else missing or mismatched attribution
      Phone->>Phone: Keep pairing and try other routes
      Phone->>UI: Show unreachable/Tailscale-off hint when gated
    end
  end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test parity: 44pt tap target for Hub con..."](https://github.com/arul28/ade/commit/9c1917a186c3c0310943a83c936fd613b993292d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41809281)</sub>

<!-- /greptile_comment -->