### PR TITLE
Work-tab status truthfulness: CLI status in Live Activity, attention capsules, lane PR badges, instant webhook PR freshness

### DIFF
--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -1061,10 +1061,14 @@ export async function createAdeRuntime(args: {
   // GitHub relay poll feeds prService.ingestGithubWebhook, which is how
   // webhook-driven PR state updates reach installed (non-source) runtimes.
   // Automation rule dispatch stays gated on automationService being present.
+  // The PR poller is constructed below; late-bind so webhook ingest can poke
+  // an immediate re-read instead of waiting out the next scheduled tick.
+  let prPollingServiceForIngress: { poke: () => void } | null = null;
   const automationIngressService = createAutomationIngressService({
     logger,
     automationService,
     prService: headlessLinearServices.prService,
+    onPrStateIngested: () => prPollingServiceForIngress?.poke(),
     secretService: automationSecretService,
     githubService: headlessLinearServices.githubService,
     listRules: () => (automationService ? projectConfigService.get().effective.automations ?? [] : []),
@@ -1189,6 +1193,7 @@ export async function createAdeRuntime(args: {
     },
   });
   prPollingService.start();
+  prPollingServiceForIngress = prPollingService;
 
   // Brain → Cloudflare push relay publisher. Owns push registration (from the
   // paired phone via `push.*` sync commands) and fans agent/PR state transitions

--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -727,6 +727,10 @@ export async function createAdeRuntime(args: {
   // pattern as desktop main. Without this bridge, paired phones only ever
   // receive terminal snapshots, never live terminal_data push.
   let syncServiceForPtyEvents: ReturnType<typeof createSyncService> | null = null;
+  // Same late-binding for the push publisher: it feeds tracked CLI runtime
+  // states (running / waiting-input from OSC 133 markers) into the phone's
+  // Live Activity, and it's constructed after ptyService.
+  let pushPublisherForPtySignals: PushPublisherService | null = null;
   const ptyService = createPtyService({
     projectRoot,
     transcriptsDir: paths.transcriptsDir,
@@ -746,6 +750,13 @@ export async function createAdeRuntime(args: {
       pushEvent("pty", { type: "pty_exit", event });
       const { projectRoot: _projectRoot, ...syncEvent } = event;
       syncServiceForPtyEvents?.handlePtyExit(syncEvent);
+    },
+    onSessionRuntimeSignal: (signal) => {
+      pushPublisherForPtySignals?.handleCliRuntimeSignal(projectId, {
+        laneId: signal.laneId,
+        sessionId: signal.sessionId,
+        runtimeState: signal.runtimeState,
+      });
     },
     onSessionEnded: (event) => {
       void sessionDeltaService.computeSessionDelta(event.sessionId).catch((error) => {
@@ -1215,7 +1226,21 @@ export async function createAdeRuntime(args: {
         return null;
       }
     },
+    resolveCliSession: (sessionId) => {
+      try {
+        const session = sessionService.get(sessionId);
+        if (!session) return null;
+        return {
+          title: session.title ?? null,
+          toolType: session.toolType ?? null,
+          chatSessionId: session.chatSessionId ?? null,
+        };
+      } catch {
+        return null;
+      }
+    },
   });
+  pushPublisherForPtySignals = pushPublisherService;
   void pushPublisherService.start().catch((error) => {
     logger.warn("push.start_failed", { error: error instanceof Error ? error.message : String(error) });
   });

--- a/apps/ade-cli/src/services/push/pushPublisherService.test.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.test.ts
@@ -528,6 +528,35 @@ describe("createPushPublisherService flush", () => {
     publisher.dispose();
   });
 
+  it("prunes a stale CLI row at the running TTL despite idle heartbeats", async () => {
+    // Regression (Greptile P1): idle heartbeats used to refresh lastActiveAt,
+    // so a quiet CLI's stale row never aged past the 2h TTL and pinned the
+    // Live Activity open forever.
+    const { publisher, publish, cliSessions } = makeHarness();
+    cliSessions.set("cli-1", { title: "claude in auth", toolType: "claude", chatSessionId: null });
+    await publisher.start();
+
+    publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "cli-1", runtimeState: "running" });
+    await vi.advanceTimersByTimeAsync(2_500);
+    publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "cli-1", runtimeState: "idle" });
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    // Re-fire idle heartbeats across 2h+; the frozen stale timestamp must let
+    // the row age out, ending the (now-empty) aggregate.
+    for (let i = 0; i < 5; i += 1) {
+      publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "cli-1", runtimeState: "idle" });
+      await vi.advanceTimersByTimeAsync(25 * 60 * 1000);
+    }
+    publisher.poke();
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    const last = publish.mock.calls.at(-1)![0];
+    const lastLa = last.liveActivity?.[0];
+    expect(lastLa?.event).toBe("end");
+
+    publisher.dispose();
+  });
+
   it("publishes a quiet CLI as stale without ending the Live Activity", async () => {
     const { publisher, publish, cliSessions } = makeHarness();
     cliSessions.set("cli-1", { title: "claude in auth", toolType: "claude", chatSessionId: null });

--- a/apps/ade-cli/src/services/push/pushPublisherService.test.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.test.ts
@@ -475,8 +475,9 @@ describe("createPushPublisherService flush", () => {
     expect(publish).toHaveBeenCalledTimes(1);
     const first = publish.mock.calls[0][0];
     // Live Activity only — a CLI agent hits its prompt after every turn, so
-    // waiting-input must never generate alert pushes.
-    expect(first.notifications ?? []).toHaveLength(0);
+    // waiting-input must never generate user-facing alert pushes. (A silent
+    // badge-only item — no title — may ride along for icon-count sync.)
+    expect((first.notifications ?? []).filter((n: { title: string }) => n.title)).toHaveLength(0);
     expect(first.liveActivity).toHaveLength(1);
     const startRun = first.liveActivity[0].contentState.runs.find((r: { id: string }) => r.id === "cli-1");
     expect(startRun.phase).toBe("running");
@@ -491,7 +492,9 @@ describe("createPushPublisherService flush", () => {
     await vi.advanceTimersByTimeAsync(2_500);
     expect(publish).toHaveBeenCalledTimes(2);
     const second = publish.mock.calls[1][0];
-    expect(second.notifications ?? []).toHaveLength(0);
+    expect((second.notifications ?? []).filter((n: { title: string }) => n.title)).toHaveLength(0);
+    // A CLI at its prompt is its resting state — it must not badge the icon.
+    for (const item of second.notifications ?? []) expect(item.badge).toBe(0);
     const waitingRun = second.liveActivity[0].contentState.runs.find((r: { id: string }) => r.id === "cli-1");
     expect(waitingRun.phase).toBe("waiting_for_input");
 
@@ -507,8 +510,12 @@ describe("createPushPublisherService flush", () => {
     publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "ghost-1", runtimeState: "running" });
     await vi.advanceTimersByTimeAsync(2_500);
 
-    // Both rows resolve to nothing user-facing → nothing to publish at all.
-    expect(publish).not.toHaveBeenCalled();
+    // Both rows resolve to nothing user-facing → no alerts, no Live Activity
+    // (the initial silent badge sync is the only thing allowed through).
+    for (const call of publish.mock.calls) {
+      expect((call[0].notifications ?? []).filter((n: { title: string }) => n.title)).toHaveLength(0);
+      expect(call[0].liveActivity ?? []).toHaveLength(0);
+    }
 
     // With a real chat run present, the publish payload must still exclude them.
     publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "shell-1", runtimeState: "running" });

--- a/apps/ade-cli/src/services/push/pushPublisherService.test.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.test.ts
@@ -20,6 +20,7 @@ function run(overrides: Partial<AgentRunState>): AgentRunState {
   return {
     sessionId: "s",
     scopeKey: "scope",
+    kind: "chat",
     title: "Run",
     lane: "lane",
     model: "gpt-5",
@@ -170,8 +171,13 @@ describe("createPushPublisherService flush", () => {
       flushDebounceMs: 2_000,
       promptFlushMs: 150,
     });
-    publisher.attachSources("scope-1", { agentChatService: agentChatService as never });
-    return { publisher, publish, emit: (env: AgentChatEventEnvelope) => chatCb?.(env), store };
+    const cliSessions = new Map<string, { title: string | null; toolType?: string | null; chatSessionId?: string | null }>();
+    publisher.attachSources("scope-1", {
+      agentChatService: agentChatService as never,
+      resolveLaneName: (laneId: string) => laneId,
+      resolveCliSession: (sessionId: string) => cliSessions.get(sessionId) ?? null,
+    });
+    return { publisher, publish, emit: (env: AgentChatEventEnvelope) => chatCb?.(env), store, cliSessions };
   }
 
   const approval: AgentChatEventEnvelope = {
@@ -454,6 +460,60 @@ describe("createPushPublisherService flush", () => {
     const lastLa = laPayloads[laPayloads.length - 1].liveActivity[0];
     expect(lastLa.contentState.activeCount).toBe(2);
     expect(lastLa.contentState.runs.map((r: { id: string }) => r.id).sort()).toEqual(["s-a", "s-b"]);
+
+    publisher.dispose();
+  });
+
+  it("surfaces CLI runtime signals in the Live Activity without alert pushes", async () => {
+    const { publisher, publish, cliSessions } = makeHarness();
+    cliSessions.set("cli-1", { title: "claude in auth", toolType: "claude", chatSessionId: null });
+    await publisher.start();
+
+    publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "cli-1", runtimeState: "running" });
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    const first = publish.mock.calls[0][0];
+    // Live Activity only — a CLI agent hits its prompt after every turn, so
+    // waiting-input must never generate alert pushes.
+    expect(first.notifications ?? []).toHaveLength(0);
+    expect(first.liveActivity).toHaveLength(1);
+    const startRun = first.liveActivity[0].contentState.runs.find((r: { id: string }) => r.id === "cli-1");
+    expect(startRun.phase).toBe("running");
+    expect(startRun.title).toBe("claude in auth");
+
+    // Heartbeat re-fires of the same state must not churn LA updates.
+    publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "cli-1", runtimeState: "running" });
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(publish).toHaveBeenCalledTimes(1);
+
+    publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "cli-1", runtimeState: "waiting-input" });
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(publish).toHaveBeenCalledTimes(2);
+    const second = publish.mock.calls[1][0];
+    expect(second.notifications ?? []).toHaveLength(0);
+    const waitingRun = second.liveActivity[0].contentState.runs.find((r: { id: string }) => r.id === "cli-1");
+    expect(waitingRun.phase).toBe("waiting_for_input");
+
+    publisher.dispose();
+  });
+
+  it("drops chat-owned shells and unknown sessions from CLI run tracking", async () => {
+    const { publisher, publish, cliSessions } = makeHarness();
+    cliSessions.set("shell-1", { title: "attached shell", toolType: "shell", chatSessionId: "s-1" });
+    await publisher.start();
+
+    publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "shell-1", runtimeState: "running" });
+    publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "ghost-1", runtimeState: "running" });
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    // Both rows resolve to nothing user-facing → no LA content and no publish
+    // (a chat-attached shell is already represented by its chat run).
+    for (const call of publish.mock.calls) {
+      const runs = call[0].liveActivity?.[0]?.contentState.runs ?? [];
+      expect(runs.map((r: { id: string }) => r.id)).not.toContain("shell-1");
+      expect(runs.map((r: { id: string }) => r.id)).not.toContain("ghost-1");
+    }
 
     publisher.dispose();
   });

--- a/apps/ade-cli/src/services/push/pushPublisherService.test.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.test.ts
@@ -9,6 +9,7 @@ import { createPushRegistrationStore, type PushRegistrationStore } from "./pushR
 import { createPushRelayClient } from "./pushRelayClient";
 import {
   buildAgentRunsContentState,
+  countAwaitingAttentionRuns,
   createPushPublisherService,
   isWithinQuietHours,
   parseHhMm,
@@ -494,7 +495,14 @@ describe("createPushPublisherService flush", () => {
     const second = publish.mock.calls[1][0];
     expect((second.notifications ?? []).filter((n: { title: string }) => n.title)).toHaveLength(0);
     // A CLI at its prompt is its resting state — it must not badge the icon.
-    for (const item of second.notifications ?? []) expect(item.badge).toBe(0);
+    // Assert on the counting function directly (a badge-only item is only
+    // emitted on count *changes*, so payload inspection here would be vacuous).
+    expect(countAwaitingAttentionRuns([
+      run({ sessionId: "cli-1", kind: "cli", phase: "waiting_for_input" }),
+    ])).toBe(0);
+    expect(countAwaitingAttentionRuns([
+      run({ sessionId: "s-1", kind: "chat", phase: "waiting_for_input" }),
+    ])).toBe(1);
     const waitingRun = second.liveActivity[0].contentState.runs.find((r: { id: string }) => r.id === "cli-1");
     expect(waitingRun.phase).toBe("waiting_for_input");
 

--- a/apps/ade-cli/src/services/push/pushPublisherService.test.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.test.ts
@@ -499,7 +499,7 @@ describe("createPushPublisherService flush", () => {
   });
 
   it("drops chat-owned shells and unknown sessions from CLI run tracking", async () => {
-    const { publisher, publish, cliSessions } = makeHarness();
+    const { publisher, publish, emit, cliSessions } = makeHarness();
     cliSessions.set("shell-1", { title: "attached shell", toolType: "shell", chatSessionId: "s-1" });
     await publisher.start();
 
@@ -507,13 +507,47 @@ describe("createPushPublisherService flush", () => {
     publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "ghost-1", runtimeState: "running" });
     await vi.advanceTimersByTimeAsync(2_500);
 
-    // Both rows resolve to nothing user-facing → no LA content and no publish
-    // (a chat-attached shell is already represented by its chat run).
-    for (const call of publish.mock.calls) {
-      const runs = call[0].liveActivity?.[0]?.contentState.runs ?? [];
-      expect(runs.map((r: { id: string }) => r.id)).not.toContain("shell-1");
-      expect(runs.map((r: { id: string }) => r.id)).not.toContain("ghost-1");
-    }
+    // Both rows resolve to nothing user-facing → nothing to publish at all.
+    expect(publish).not.toHaveBeenCalled();
+
+    // With a real chat run present, the publish payload must still exclude them.
+    publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "shell-1", runtimeState: "running" });
+    emit(approval);
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(publish).toHaveBeenCalled();
+    const runs = publish.mock.calls.at(-1)![0].liveActivity[0].contentState.runs;
+    expect(runs.map((r: { id: string }) => r.id)).toEqual(["s-1"]);
+
+    publisher.dispose();
+  });
+
+  it("publishes a quiet CLI as stale without ending the Live Activity", async () => {
+    const { publisher, publish, cliSessions } = makeHarness();
+    cliSessions.set("cli-1", { title: "claude in auth", toolType: "claude", chatSessionId: null });
+    await publisher.start();
+
+    publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "cli-1", runtimeState: "running" });
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish.mock.calls[0][0].liveActivity[0].event).toBe("start");
+
+    // 12s-quiet idle → the row goes stale (not active) but the activity stays
+    // open: ending on a quiet spell would churn end→push-to-start cycles.
+    publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "cli-1", runtimeState: "idle" });
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(publish).toHaveBeenCalledTimes(2);
+    const idleItem = publish.mock.calls[1][0].liveActivity[0];
+    expect(idleItem.event).toBe("update");
+    expect(idleItem.contentState.activeCount).toBe(0);
+    expect(idleItem.contentState.runs[0].phase).toBe("stale");
+
+    // Output resumes → back to an active running row on the same activity.
+    publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "cli-1", runtimeState: "running" });
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(publish).toHaveBeenCalledTimes(3);
+    const resumed = publish.mock.calls[2][0].liveActivity[0];
+    expect(resumed.event).toBe("update");
+    expect(resumed.contentState.runs[0].phase).toBe("running");
 
     publisher.dispose();
   });

--- a/apps/ade-cli/src/services/push/pushPublisherService.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.ts
@@ -275,10 +275,17 @@ export function buildAgentRunsContentState(
   };
 }
 
-/** Waiting runs are what the app icon badge counts — agents blocked on the user. */
+/**
+ * Waiting runs are what the app icon badge counts — agents blocked on the
+ * user. CLI runs are excluded: a CLI at its prompt reports waiting_for_input
+ * as its normal resting state (mirroring the no-alert rule for CLI prompts),
+ * so counting it would pin the badge non-zero forever.
+ */
 export function countAwaitingAttentionRuns(runs: AgentRunState[]): number {
   return runs.filter(
-    (run) => run.phase === "waiting_for_approval" || run.phase === "waiting_for_input",
+    (run) =>
+      run.kind !== "cli"
+      && (run.phase === "waiting_for_approval" || run.phase === "waiting_for_input"),
   ).length;
 }
 

--- a/apps/ade-cli/src/services/push/pushPublisherService.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.ts
@@ -57,6 +57,8 @@ export type AgentRunState = {
   sessionId: string;
   /** Which attached project scope produced this run (for metadata resolution). */
   scopeKey: string;
+  /** Chat runs come from agentChatService events; cli runs from PTY signals. */
+  kind: "chat" | "cli";
   title: string | null;
   lane: string | null;
   model: string | null;
@@ -68,6 +70,13 @@ export type AgentRunState = {
   startedAt: number;
   lastActiveAt: number;
   metaResolved: boolean;
+};
+
+/** The OSC 133-derived terminal state pushed by ptyService.onSessionRuntimeSignal. */
+export type PushCliRuntimeSignal = {
+  laneId: string;
+  sessionId: string;
+  runtimeState: string;
 };
 
 export type PushPrNotification = {
@@ -124,6 +133,16 @@ export type PushPublisherSources = {
   /** Injected bridge over prPollingService's `pr-notification` events. */
   subscribePrNotifications?: (cb: (event: PushPrNotification) => void) => () => void;
   resolveLaneName?: (laneId: string) => string | null | undefined;
+  /**
+   * Resolves a tracked terminal session for CLI-run metadata. Returning a
+   * record with a `chatSessionId` (a chat-attached shell) or null (unknown /
+   * infra row) drops the run — the chat run already represents that work.
+   */
+  resolveCliSession?: (sessionId: string) => {
+    title: string | null;
+    toolType?: string | null;
+    chatSessionId?: string | null;
+  } | null;
 };
 
 const ACTIVE_PHASES: ReadonlySet<AgentRunPhase> = new Set<AgentRunPhase>([
@@ -353,6 +372,7 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
   type AttachedScope = {
     agentChatService?: PushAgentChatService | null;
     resolveLaneName?: (laneId: string) => string | null | undefined;
+    resolveCliSession?: PushPublisherSources["resolveCliSession"];
     unsubscribes: Array<() => void>;
   };
   const scopes = new Map<string, AttachedScope>();
@@ -369,13 +389,14 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     return false;
   };
 
-  const ensureRun = (sessionId: string, scopeKey: string): AgentRunState => {
+  const ensureRun = (sessionId: string, scopeKey: string, kind: "chat" | "cli" = "chat"): AgentRunState => {
     let run = runs.get(sessionId);
     if (!run) {
       const ts = now();
       run = {
         sessionId,
         scopeKey,
+        kind,
         title: null,
         lane: null,
         model: null,
@@ -444,6 +465,19 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
       // Resolve against the scope that produced the run — each project has its
       // own chat service and lane-name resolver.
       const scope = scopes.get(run.scopeKey);
+      if (run.kind === "cli") {
+        const record = scope?.resolveCliSession?.(run.sessionId) ?? null;
+        // Unknown session or a chat-attached shell: the chat run (or nothing)
+        // represents this work — a duplicate CLI row would double-count it.
+        if (!record || record.chatSessionId) {
+          runs.delete(run.sessionId);
+          continue;
+        }
+        run.title = record.title?.trim() || run.title || null;
+        run.agent = providerDisplayName(record.toolType) ?? run.agent ?? "CLI";
+        run.metaResolved = true;
+        continue;
+      }
       const chat = scope?.agentChatService;
       if (!chat) continue;
       try {
@@ -828,7 +862,45 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     });
   };
 
+  /**
+   * OSC 133-derived terminal state for tracked CLI sessions. Feeds the Live
+   * Activity only — no alert pushes: a CLI agent returns to its prompt
+   * (waiting-input) after EVERY turn, so alerting on it would ping the user
+   * once per turn. Failure alerts stay with onPtyExit's non-zero-exit path.
+   */
+  const onCliRuntimeSignal = (scopeKey: string, signal: PushCliRuntimeSignal): void => {
+    if (disposed || !signal.sessionId) return;
+    const existing = runs.get(signal.sessionId);
+    // Exit/kill phases are owned by onPtyExit (which knows the exit code).
+    if (signal.runtimeState === "exited" || signal.runtimeState === "killed") return;
+    const phase: AgentRunPhase = signal.runtimeState === "waiting-input" ? "waiting_for_input" : "running";
+    // Signals re-fire on a ~10s heartbeat; only a phase change is worth a
+    // Live Activity update (the run row shows phase, not output).
+    if (existing && existing.kind === "cli" && existing.phase === phase) {
+      existing.lastActiveAt = now();
+      return;
+    }
+    // A chat run with the same session id would mean a chat-owned shell that
+    // resolveCliSession failed to filter — never downgrade a chat run.
+    if (existing && existing.kind === "chat") return;
+    const run = ensureRun(signal.sessionId, scopeKey, "cli");
+    run.lastActiveAt = now();
+    run.phase = phase;
+    if (!run.lane) {
+      run.lane = scopes.get(scopeKey)?.resolveLaneName?.(signal.laneId) ?? signal.laneId ?? null;
+    }
+    scheduleFlush(false);
+  };
+
   const onPtyExit = (scopeKey: string, event: PtyExitEvent & { laneId: string }): void => {
+    // A tracked CLI run in the aggregate reaches its terminal phase here — the
+    // runtime signal stream never reports exit codes.
+    const run = runs.get(event.sessionId);
+    if (run && run.kind === "cli") {
+      run.phase = event.exitCode == null || event.exitCode === 0 ? "completed" : "failed";
+      run.lastActiveAt = now();
+      scheduleFlush(false);
+    }
     // Keep it simple: only surface non-clean exits of tracked CLI sessions.
     if (event.exitCode == null || event.exitCode === 0) return;
     const resolveLaneName = scopes.get(scopeKey)?.resolveLaneName;
@@ -975,9 +1047,18 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
       scopes.set(scopeKey, {
         agentChatService: sources.agentChatService ?? null,
         resolveLaneName: sources.resolveLaneName,
+        resolveCliSession: sources.resolveCliSession,
         unsubscribes: scopeUnsubscribes,
       });
       return () => detachScope(scopeKey);
+    },
+
+    /**
+     * Entry point for ptyService's onSessionRuntimeSignal callback (a
+     * create-time hook, not a subscription — bootstrap forwards it here).
+     */
+    handleCliRuntimeSignal(scopeKey: string, signal: PushCliRuntimeSignal): void {
+      onCliRuntimeSignal(scopeKey, signal);
     },
 
     /** Force a flush soon (e.g. right after a device registers). */

--- a/apps/ade-cli/src/services/push/pushPublisherService.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.ts
@@ -448,7 +448,10 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
   const pruneRuns = (nowMs: number): void => {
     for (const [sessionId, run] of runs) {
       const age = nowMs - run.lastActiveAt;
-      if ((run.phase === "running" || run.phase === "starting") && age > RUNNING_TTL_MS) {
+      if (
+        (run.phase === "running" || run.phase === "starting" || run.phase === "stale")
+        && age > RUNNING_TTL_MS
+      ) {
         runs.delete(sessionId);
       } else if (
         (run.phase === "waiting_for_approval" || run.phase === "waiting_for_input")
@@ -509,11 +512,16 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     const allRuns = [...runs.values()];
     const contentState = buildAgentRunsContentState(allRuns, nowMs);
     const activeCount = contentState.activeCount;
+    // Stale rows (quiet CLIs) don't count as active but must not END the
+    // activity either — a 12s-quiet CLI that resumes output would otherwise
+    // churn end→push-to-start cycles. Only an all-completed/failed (or empty)
+    // roster ends the aggregate.
+    const dormantCount = allRuns.filter((run) => run.phase === "stale").length;
 
     let event: "start" | "update" | "end";
     if (activeCount > 0 && !liveActivityStarted) event = "start";
-    else if (activeCount === 0 && liveActivityStarted) event = "end";
-    else if (activeCount === 0 && !liveActivityStarted) return null; // nothing live to report
+    else if (activeCount === 0 && dormantCount === 0 && liveActivityStarted) event = "end";
+    else if (!liveActivityStarted) return null; // nothing live to report (stale-only never starts)
     else event = "update";
 
     const fingerprint = JSON.stringify({ ...contentState, updatedAt: 0 });
@@ -873,7 +881,14 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     const existing = runs.get(signal.sessionId);
     // Exit/kill phases are owned by onPtyExit (which knows the exit code).
     if (signal.runtimeState === "exited" || signal.runtimeState === "killed") return;
-    const phase: AgentRunPhase = signal.runtimeState === "waiting-input" ? "waiting_for_input" : "running";
+    // `idle` = no output for 12s with no OSC prompt marker — we can't prove
+    // the CLI is working OR at a prompt, so publish it as `stale` (dimmed,
+    // not counted active) instead of overstating it as a live running row.
+    const phase: AgentRunPhase = signal.runtimeState === "waiting-input"
+      ? "waiting_for_input"
+      : signal.runtimeState === "idle"
+        ? "stale"
+        : "running";
     // Signals re-fire on a ~10s heartbeat; only a phase change is worth a
     // Live Activity update (the run row shows phase, not output).
     if (existing && existing.kind === "cli" && existing.phase === phase) {

--- a/apps/ade-cli/src/services/push/pushPublisherService.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.ts
@@ -899,7 +899,11 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     // Signals re-fire on a ~10s heartbeat; only a phase change is worth a
     // Live Activity update (the run row shows phase, not output).
     if (existing && existing.kind === "cli" && existing.phase === phase) {
-      existing.lastActiveAt = now();
+      // A `stale` row must keep its `lastActiveAt` frozen at the moment it went
+      // stale so `pruneRuns` can retire it RUNNING_TTL_MS later. Refreshing it
+      // on every idle heartbeat (idle = no output, not real activity) would
+      // reset that 2h clock and hold the stale Live Activity open forever.
+      if (phase !== "stale") existing.lastActiveAt = now();
       return;
     }
     // A chat run with the same session id would mean a chat-owned shell that

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -3117,6 +3117,9 @@ app.whenReady().then(async () => {
       logger,
       automationService: automationService ?? null,
       prService,
+      // Webhook-driven PR changes poke the poller so `prs-updated` reaches the
+      // renderer now instead of on the next scheduled tick.
+      onPrStateIngested: () => prPollingServiceRef?.poke(),
       secretService: automationSecretService,
       githubService,
       listRules: () => (automationService ? projectConfigService.get().effective.automations ?? [] : []),

--- a/apps/desktop/src/main/services/automations/automationIngressService.ts
+++ b/apps/desktop/src/main/services/automations/automationIngressService.ts
@@ -42,6 +42,11 @@ type AutomationIngressServiceArgs = {
   // require the automation service.
   automationService: ReturnType<typeof createAutomationService> | null;
   prService?: ReturnType<typeof createPrService> | null;
+  /**
+   * Fired when a polled webhook event changed PR state — wired to the PR
+   * poller's poke() so freshness rides the webhook, not the next poll tick.
+   */
+  onPrStateIngested?: () => void;
   secretService: AutomationSecretService;
   githubService?: {
     detectRepo: () => Promise<GitHubRepoRef | null> | GitHubRepoRef | null;
@@ -337,7 +342,7 @@ export function createAutomationIngressService(args: AutomationIngressServiceArg
     deliveryId: string,
     payload: Record<string, unknown>,
   ): Promise<AutomationIngressEventRecord | null> => {
-    await args.prService?.ingestGithubWebhook({
+    const ingested = await args.prService?.ingestGithubWebhook({
       eventName: githubEvent,
       deliveryId,
       payload,
@@ -347,7 +352,14 @@ export function createAutomationIngressService(args: AutomationIngressServiceArg
         deliveryId,
         error: error instanceof Error ? error.message : String(error),
       });
+      return null;
     });
+    // Webhook-driven PR changes used to sit silently in the DB until the PR
+    // poller's next scheduled tick — throwing away the webhook's speed
+    // advantage. Notify the poller so it re-reads and emits `prs-updated` now.
+    if (ingested?.processed && !ingested.duplicate && ingested.linkedPrIds.length > 0) {
+      args.onPrStateIngested?.();
+    }
 
     if (!args.automationService) return null;
     const mapped = mapGithubWebhookToTrigger(githubEvent, payload);

--- a/apps/desktop/src/main/services/automations/automationIngressService.ts
+++ b/apps/desktop/src/main/services/automations/automationIngressService.ts
@@ -605,7 +605,7 @@ export function createAutomationIngressService(args: AutomationIngressServiceArg
         const summary = typeof event.summary === "string" ? event.summary : `GitHub ${githubEvent} event`;
         const rawPayload = isRecord(event.payload) ? event.payload : event;
         lastDeliveryAt = String(event.createdAt ?? new Date().toISOString());
-        await args.prService?.ingestGithubWebhook({
+        const ingested = await args.prService?.ingestGithubWebhook({
           eventName: githubEvent,
           deliveryId: eventId,
           payload: rawPayload,
@@ -615,7 +615,13 @@ export function createAutomationIngressService(args: AutomationIngressServiceArg
             eventId,
             error: error instanceof Error ? error.message : String(error),
           });
+          return null;
         });
+        // Same as the local-webhook path: a relay-delivered PR change should
+        // refresh the poller immediately instead of waiting for its next tick.
+        if (ingested?.processed && !ingested.duplicate && ingested.linkedPrIds.length > 0) {
+          args.onPrStateIngested?.();
+        }
         await args.automationService?.dispatchIngressTrigger({
           source: "github-relay",
           eventKey: eventId,

--- a/apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx
@@ -10,6 +10,7 @@ import type {
   SyncTailnetDiscoveryStatus,
 } from "../../../shared/types";
 import { buildPairingQrPayload, encodePairingQrUrl } from "../../../shared/pairingQr";
+import { publicAssetUrl } from "../onboarding/WelcomeVideoGate";
 import { SettingsToggle } from "./settingsSectionUi";
 import {
   COLORS,
@@ -753,25 +754,34 @@ function PairQrPanel({ connectInfo }: { connectInfo: SyncPairingConnectInfo }) {
     () => encodePairingQrUrl(buildPairingQrPayload({ connectInfo })),
     [connectInfo],
   );
+  // Same ADE-branded treatment as the welcome modal's TestFlight QR: white
+  // tile, accent-tinted border, excavated ADE mark in the center (which is
+  // why the error-correction level is H).
   return (
     <div style={{ ...panelStyle, gap: 0, padding: 12, placeItems: "center" }}>
       <div
         style={{
           display: "inline-flex",
-          padding: 12,
-          borderRadius: 12,
+          padding: 14,
+          borderRadius: 14,
           background: "#FFFFFF",
-          border: `1px solid ${COLORS.accentBorder}`,
+          border: "1px solid color-mix(in srgb, var(--color-accent, #A78BFA) 30%, transparent)",
         }}
       >
         <QRCodeSVG
           value={qrUrl}
           size={148}
-          level="M"
+          level="H"
           marginSize={1}
           bgColor="#FFFFFF"
           fgColor="#111827"
-          title="Pairing QR code"
+          title="QR code to pair ADE Mobile with this machine"
+          imageSettings={{
+            src: publicAssetUrl("welcome/ade-icon.webp"),
+            height: 32,
+            width: 32,
+            excavate: true,
+          }}
         />
       </div>
     </div>

--- a/apps/desktop/src/renderer/components/terminals/SessionCard.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.test.tsx
@@ -139,3 +139,69 @@ describe("SessionCard auto-naming status", () => {
     expect(screen.getByText(/running the build/i)).toBeTruthy();
   });
 });
+
+describe("SessionCard attention capsule", () => {
+  it("shows a Failed capsule for a non-zero exit", () => {
+    render(
+      <SessionCard
+        session={makeSession({ toolType: "codex", status: "failed", exitCode: 1 })}
+        lane={lane}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onContextMenu={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Failed")).toBeTruthy();
+  });
+
+  it("shows a Stale capsule for a long-silent running session", () => {
+    render(
+      <SessionCard
+        session={makeSession({
+          toolType: "codex",
+          status: "running",
+          runtimeState: "running",
+          lastActivityAt: "2020-01-01T00:00:00.000Z",
+        })}
+        lane={lane}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onContextMenu={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Stale")).toBeTruthy();
+  });
+
+  it("renders no capsule for a calm running session", () => {
+    render(
+      <SessionCard
+        session={makeSession({ toolType: "codex", status: "running", runtimeState: "running" })}
+        lane={lane}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onContextMenu={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/^(Needs you|Failed|Stale)$/)).toBeNull();
+  });
+
+  it("does not double up the amber pill for a chat waiting on input", () => {
+    render(
+      <SessionCard
+        session={makeSession({
+          toolType: "codex-chat",
+          runtimeState: "waiting-input",
+          pendingInputItemId: "pending-1",
+        })}
+        lane={lane}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onContextMenu={vi.fn()}
+      />,
+    );
+    // The chat-specific "Awaiting you" chip covers this; the canonical capsule
+    // is suppressed so the card never shows two amber pills.
+    expect(screen.getByLabelText("Awaiting your input")).toBeTruthy();
+    expect(screen.queryByText("Needs you")).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
@@ -1,8 +1,14 @@
 import React from "react";
-import { GridFour, WarningCircle, Question } from "@phosphor-icons/react";
+import { GridFour, WarningCircle, Question, Clock } from "@phosphor-icons/react";
 import type { LaneSummary, TerminalSessionSummary } from "../../../shared/types";
 import type { OrchestrationRole } from "../../../shared/types/orchestration";
-import { sessionStatusDot, sanitizeTerminalInlineText, sessionNeedsChatTabHighlight } from "../../lib/terminalAttention";
+import {
+  sessionStatusDot,
+  sanitizeTerminalInlineText,
+  sessionNeedsChatTabHighlight,
+  sessionCapsuleBadge,
+} from "../../lib/terminalAttention";
+import type { SessionBadge } from "../../../shared/sessionCanonicalState";
 import {
   getStaleRunningCliSessionAgeHours,
   primarySessionLabel,
@@ -109,6 +115,38 @@ function orchestrationRoleA11yLabel(role: OrchestrationRole, tag?: string | null
   return role;
 }
 
+/* ──────────────────────────────────────────────────────────────────────────
+   Attention capsule — one-word status from the shared canonical state module.
+   Only ever renders for the three attention states; calm sessions get nothing
+   (so the title row never reflows). Amber "Needs you", red "Failed", and an
+   outlined "Stale" with a clock glyph.
+   ────────────────────────────────────────────────────────────────────────── */
+
+const ATTENTION_CAPSULE_STYLE: Record<SessionBadge["kind"], string> = {
+  needs_you: "border-amber-400/30 bg-amber-400/15 text-amber-300",
+  failed: "border-red-500/30 bg-red-500/15 text-red-300",
+  // Stale is the calm-but-silent state: outlined, muted, no fill.
+  stale: "border-white/15 bg-transparent text-muted-fg/60",
+};
+
+function AttentionCapsule({ badge, compact }: { badge: SessionBadge; compact: boolean }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center gap-0.5 rounded-full border font-semibold leading-none",
+        compact ? "px-1 py-0.5 text-[8px]" : "px-1.5 py-0.5 text-[10px]",
+        ATTENTION_CAPSULE_STYLE[badge.kind],
+      )}
+      title={badge.label}
+      aria-label={badge.label}
+      data-session-badge={badge.kind}
+    >
+      {badge.kind === "stale" ? <Clock size={compact ? 9 : 10} weight="bold" /> : null}
+      {badge.label}
+    </span>
+  );
+}
+
 function getPreviewLine(session: TerminalSessionSummary, primaryText: string): string | null {
   const summary = preferredSessionLabel(session.summary);
   if (summary && summary !== primaryText) return summary;
@@ -151,6 +189,20 @@ export const SessionCard = React.memo(function SessionCard({
     toolType: session.toolType,
     pendingInputItemId: session.pendingInputItemId,
   });
+  // Canonical one-word status capsule (Needs you / Failed / Stale). When the
+  // chat-specific "Awaiting you" chip is already showing the same needs-input
+  // condition, suppress the capsule so a chat card never doubles up amber pills.
+  const capsuleBadge = sessionCapsuleBadge({
+    status: session.status,
+    lastOutputPreview: session.lastOutputPreview,
+    runtimeState: session.runtimeState,
+    toolType: session.toolType,
+    pendingInputItemId: session.pendingInputItemId,
+    lastActivityAt: session.lastActivityAt,
+    exitCode: session.exitCode,
+  });
+  const attentionBadge =
+    capsuleBadge && !(awaitingUser && capsuleBadge.kind === "needs_you") ? capsuleBadge : null;
   const isRemoteProject = useAppStore((s) => s.projectBinding?.kind === "remote");
   const delta = useSessionDelta(session.id, !isRemoteProject || isSelected);
   const primaryText = primarySessionLabel(session);
@@ -260,6 +312,7 @@ export const SessionCard = React.memo(function SessionCard({
               >
                 {primaryText}
               </span>
+              {attentionBadge ? <AttentionCapsule badge={attentionBadge} compact={compact} /> : null}
               <div className="flex shrink-0 items-center gap-1.5">
                 {session.orchestrationRole ? (
                   <>

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
@@ -277,6 +277,9 @@ function useLanePrsByLaneId(): Map<string, PrSummary[]> {
   const projectRoot = useAppStore(selectActiveProjectRoot);
   const [prs, setPrs] = useState<PrSummary[]>([]);
   useEffect(() => {
+    // `window.ade.prs` is absent in some renders (e.g. tests with a partial
+    // `window.ade` mock); no-op gracefully so the badge just doesn't render.
+    if (!window.ade?.prs) return;
     let cancelled = false;
     void listPrsCoalesced({ projectRoot })
       .then((list) => {

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
@@ -1,9 +1,12 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { CaretDown, CaretRight, CircleNotch, Funnel, MagnifyingGlass, Plus, Square, Terminal, Trash, X } from "@phosphor-icons/react";
 import { AnimatePresence, motion } from "motion/react";
 import { BranchIcon, LaneIcon } from "../ui/vcsIcons";
-import type { LaneSummary, TerminalSessionSummary } from "../../../shared/types";
+import type { LaneSummary, PrSummary, TerminalSessionSummary } from "../../../shared/types";
+import { listPrsCoalesced } from "../../lib/prReadCache";
+import { selectPrimaryLanePr, lanePrStateColor, lanePrStateLabel } from "../../lib/lanePrBadge";
+import { selectActiveProjectRoot, useAppStore } from "../../state/appStore";
 import { SessionCard } from "./SessionCard";
 import { ToolLogo } from "./ToolLogos";
 import { LaneCombobox } from "./LaneCombobox";
@@ -139,6 +142,7 @@ function StickyGroupHeader({
   accentColor,
   children,
   subLabel,
+  prBadge = null,
   variant = "default",
 }: {
   sectionId: string;
@@ -152,6 +156,8 @@ function StickyGroupHeader({
   children: React.ReactNode;
   /** Branch label shown on the right for `variant="lane"` (e.g. from `branchNameFromRef`). */
   subLabel?: string | null;
+  /** Compact PR badge shown left of the count for `variant="lane"`. */
+  prBadge?: React.ReactNode;
   /** `lane` uses a larger header and pads the nested session list. */
   variant?: "default" | "lane";
 }) {
@@ -212,9 +218,12 @@ function StickyGroupHeader({
                 </span>
               </div>
             ) : null}
-            <span className="ml-auto shrink-0 rounded-full bg-white/[0.08] px-1.5 py-px text-[10px] font-semibold tabular-nums text-muted-fg/60">
-              {count}
-            </span>
+            <div className="ml-auto flex shrink-0 items-center gap-1.5">
+              {prBadge}
+              <span className="rounded-full bg-white/[0.08] px-1.5 py-px text-[10px] font-semibold tabular-nums text-muted-fg/60">
+                {count}
+              </span>
+            </div>
           </div>
         ) : (
           <>
@@ -254,6 +263,76 @@ function StickyGroupHeader({
         ) : null}
       </AnimatePresence>
     </div>
+  );
+}
+
+/**
+ * ADE-mapped PRs grouped by lane id for the Work tab's lane dividers. One lazy
+ * read plus the `prs-updated` push keeps it fresh without polling.
+ *
+ * TODO: iOS merges GitHub-by-branch (unmapped) PRs into the same badge; the
+ * desktop Work tab has no external-PR cache here, so this is ADE-mapped only.
+ */
+function useLanePrsByLaneId(): Map<string, PrSummary[]> {
+  const projectRoot = useAppStore(selectActiveProjectRoot);
+  const [prs, setPrs] = useState<PrSummary[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    void listPrsCoalesced({ projectRoot })
+      .then((list) => {
+        if (!cancelled) setPrs(list);
+      })
+      .catch(() => {});
+    const unsubscribe = window.ade.prs.onEvent((event) => {
+      if (event.type === "prs-updated") setPrs(event.prs);
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [projectRoot]);
+  return useMemo(() => {
+    const byLane = new Map<string, PrSummary[]>();
+    for (const pr of prs) {
+      const list = byLane.get(pr.laneId);
+      if (list) list.push(pr);
+      else byLane.set(pr.laneId, [pr]);
+    }
+    return byLane;
+  }, [prs]);
+}
+
+/**
+ * Compact PR status badge on a lane divider: state-colored dot + `#<number>` +
+ * one-word state. Clicking deep-links into the PRs tab. Rendered inside the
+ * header button, so it stops propagation to avoid also toggling the section.
+ */
+function LanePrHeaderBadge({ pr, onOpen }: { pr: PrSummary; onOpen: () => void }) {
+  const color = lanePrStateColor(pr.state);
+  const label = lanePrStateLabel(pr.state);
+  const open = (event: React.SyntheticEvent) => {
+    event.stopPropagation();
+    onOpen();
+  };
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      onClick={open}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          open(event);
+        }
+      }}
+      className="inline-flex shrink-0 items-center gap-1 rounded-full border border-white/10 bg-white/[0.04] px-1.5 py-px text-[10px] font-medium leading-none text-muted-fg/70 transition-colors hover:bg-white/[0.09]"
+      title={`Pull request #${pr.githubPrNumber} · ${label}`}
+      aria-label={`Pull request #${pr.githubPrNumber}, ${label}`}
+    >
+      <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ background: color }} />
+      <span className="tabular-nums">#{pr.githubPrNumber}</span>
+      <span style={{ color }}>{label}</span>
+    </span>
   );
 }
 
@@ -321,6 +400,7 @@ export const SessionListPane = React.memo(function SessionListPane({
   handoffJobs?: HandoffLaunchJob[];
 }) {
   const navigate = useNavigate();
+  const prsByLaneId = useLanePrsByLaneId();
   const [createLaneOpen, setCreateLaneOpen] = useState(false);
   const orderedLanes = useMemo(() => sortLanesForTabs(lanes), [lanes]);
   const { trigger: triggerLaneContextMenu, menu: laneContextMenuPortal } = useWorkLaneContextMenu();
@@ -647,6 +727,13 @@ export const SessionListPane = React.memo(function SessionListPane({
             {lane.icon ? iconGlyph(lane.icon) : <LaneIcon size={12} weight="regular" />}
           </span>
         );
+        const primaryPr = selectPrimaryLanePr(lane, prsByLaneId.get(lane.id) ?? []);
+        const prBadge = primaryPr ? (
+          <LanePrHeaderBadge
+            pr={primaryPr}
+            onOpen={() => navigate(`/prs?tab=normal&prId=${encodeURIComponent(primaryPr.id)}`)}
+          />
+        ) : null;
         return (
           <StickyGroupHeader
             key={lane.id}
@@ -658,6 +745,7 @@ export const SessionListPane = React.memo(function SessionListPane({
             count={total}
             collapsed={collapsed}
             accentColor={laneAccent}
+            prBadge={prBadge}
             onToggleCollapsed={() => toggleWorkLaneCollapsed(lane.id)}
             onContextMenu={(e) => triggerLaneContextMenu(lane.id, e)}
           >

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
@@ -169,29 +169,29 @@ function StickyGroupHeader({
   const laneLabelColor = isLane && laneTint.text ? laneTint.text : accentColor ?? undefined;
   return (
     <div className={cn(isLane ? "mb-1.5" : "mt-0.5 first:mt-0")}>
-      <button
-        type="button"
-        className={cn(
-          "ade-lane-group-header sticky top-0 z-10 flex w-full items-center text-left transition-colors backdrop-blur-xl cursor-pointer select-none",
-          isLane ? "gap-1.5 rounded-lg px-3 py-2" : "gap-1.5 rounded-md px-2 py-1.5",
-          laneTint.text ? "hover:brightness-[1.03]" : "hover:bg-white/[0.04]",
-        )}
-        style={{
-          background: laneTint.background,
-          border: isLane
-            ? laneTint.border ?? "1px solid rgba(255, 255, 255, 0.08)"
-            : undefined,
-          borderBottom: isLane ? undefined : "1px solid rgba(255, 255, 255, 0.04)",
-          boxShadow: isLane
-            ? "0 1px 6px -2px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.04)"
-            : undefined,
-        }}
-        onClick={onToggleCollapsed}
-        onContextMenu={onContextMenu}
-        data-section-id={sectionId}
-      >
-        {isLane ? (
-          <div className="flex w-full min-w-0 items-center gap-1.5">
+      {isLane ? (
+        // The lane header is a flex row, NOT one big <button>: the PR badge is
+        // itself interactive, and nesting interactive elements inside a native
+        // button is invalid HTML (breaks focus order / assistive tech). The
+        // collapse toggle button spans everything left of the badge cluster.
+        <div
+          className={cn(
+            "ade-lane-group-header sticky top-0 z-10 flex w-full items-center gap-1.5 rounded-lg px-3 py-2 transition-colors backdrop-blur-xl select-none",
+            laneTint.text ? "hover:brightness-[1.03]" : "hover:bg-white/[0.04]",
+          )}
+          style={{
+            background: laneTint.background,
+            border: laneTint.border ?? "1px solid rgba(255, 255, 255, 0.08)",
+            boxShadow: "0 1px 6px -2px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.04)",
+          }}
+          data-section-id={sectionId}
+        >
+          <button
+            type="button"
+            className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
+            onClick={onToggleCollapsed}
+            onContextMenu={onContextMenu}
+          >
             {collapsed ? (
               <CaretRight size={12} className="shrink-0 text-muted-fg/35" />
             ) : (
@@ -218,14 +218,30 @@ function StickyGroupHeader({
                 </span>
               </div>
             ) : null}
-            <div className="ml-auto flex shrink-0 items-center gap-1.5">
-              {prBadge}
-              <span className="rounded-full bg-white/[0.08] px-1.5 py-px text-[10px] font-semibold tabular-nums text-muted-fg/60">
-                {count}
-              </span>
-            </div>
+          </button>
+          <div className="ml-auto flex shrink-0 items-center gap-1.5">
+            {prBadge}
+            <span className="rounded-full bg-white/[0.08] px-1.5 py-px text-[10px] font-semibold tabular-nums text-muted-fg/60">
+              {count}
+            </span>
           </div>
-        ) : (
+        </div>
+      ) : (
+      <button
+        type="button"
+        className={cn(
+          "ade-lane-group-header sticky top-0 z-10 flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left transition-colors backdrop-blur-xl cursor-pointer select-none",
+          laneTint.text ? "hover:brightness-[1.03]" : "hover:bg-white/[0.04]",
+        )}
+        style={{
+          background: laneTint.background,
+          borderBottom: "1px solid rgba(255, 255, 255, 0.04)",
+        }}
+        onClick={onToggleCollapsed}
+        onContextMenu={onContextMenu}
+        data-section-id={sectionId}
+      >
+        {(
           <>
             {collapsed ? (
               <CaretRight size={10} className="shrink-0 text-muted-fg/30" />
@@ -245,6 +261,7 @@ function StickyGroupHeader({
           </>
         )}
       </button>
+      )}
       {/* Children slide out/retract smoothly; the header stays put (no reflow jump). */}
       <AnimatePresence initial={false}>
         {!collapsed && count > 0 ? (

--- a/apps/desktop/src/renderer/lib/lanePrBadge.test.ts
+++ b/apps/desktop/src/renderer/lib/lanePrBadge.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { PrState } from "../../shared/types";
+import { pickPrimaryPr, primaryPrStateRank } from "./lanePrBadge";
+
+type TestPr = { id: string; state: PrState; updatedAt: string; githubPrNumber: number };
+
+function pr(id: string, state: PrState, updatedAt: string, githubPrNumber: number): TestPr {
+  return { id, state, updatedAt, githubPrNumber };
+}
+
+describe("primaryPrStateRank", () => {
+  it("ranks open < draft < merged < closed", () => {
+    expect(primaryPrStateRank("open")).toBeLessThan(primaryPrStateRank("draft"));
+    expect(primaryPrStateRank("draft")).toBeLessThan(primaryPrStateRank("merged"));
+    expect(primaryPrStateRank("merged")).toBeLessThan(primaryPrStateRank("closed"));
+  });
+});
+
+describe("pickPrimaryPr", () => {
+  const cases: Array<{ name: string; prs: TestPr[]; expected: string | null }> = [
+    {
+      name: "empty list -> null",
+      prs: [],
+      expected: null,
+    },
+    {
+      name: "open beats draft",
+      prs: [pr("draft", "draft", "2026-07-06T00:00:00Z", 5), pr("open", "open", "2026-07-01T00:00:00Z", 1)],
+      expected: "open",
+    },
+    {
+      name: "draft beats merged and closed",
+      prs: [
+        pr("closed", "closed", "2026-07-06T00:00:00Z", 9),
+        pr("merged", "merged", "2026-07-05T00:00:00Z", 8),
+        pr("draft", "draft", "2026-07-01T00:00:00Z", 2),
+      ],
+      expected: "draft",
+    },
+    {
+      name: "newest open wins among opens",
+      prs: [
+        pr("old", "open", "2026-07-01T00:00:00Z", 3),
+        pr("new", "open", "2026-07-06T00:00:00Z", 1),
+      ],
+      expected: "new",
+    },
+    {
+      name: "highest number breaks a same-timestamp tie",
+      prs: [
+        pr("lo", "open", "2026-07-06T00:00:00Z", 4),
+        pr("hi", "open", "2026-07-06T00:00:00Z", 7),
+      ],
+      expected: "hi",
+    },
+    {
+      name: "falls back to a terminal PR when nothing is open/draft",
+      prs: [
+        pr("closed", "closed", "2026-07-01T00:00:00Z", 1),
+        pr("merged", "merged", "2026-07-02T00:00:00Z", 2),
+      ],
+      expected: "merged",
+    },
+  ];
+
+  for (const { name, prs, expected } of cases) {
+    it(name, () => {
+      expect(pickPrimaryPr(prs)?.id ?? null).toBe(expected);
+    });
+  }
+});

--- a/apps/desktop/src/renderer/lib/lanePrBadge.ts
+++ b/apps/desktop/src/renderer/lib/lanePrBadge.ts
@@ -1,0 +1,84 @@
+import type { LaneSummary, PrState, PrSummary } from "../../shared/types";
+import { lanePrMatchesCurrentBranch } from "../components/lanes/lanePageModel";
+import { COLORS } from "../components/lanes/laneDesignTokens";
+
+/**
+ * Rank used to choose the one PR that represents a lane in a dense list:
+ * an open PR is the most actionable, then a draft, then a merged/closed one.
+ * Lower rank wins.
+ */
+export function primaryPrStateRank(state: PrState): number {
+  switch (state) {
+    case "open":
+      return 0;
+    case "draft":
+      return 1;
+    case "merged":
+      return 2;
+    default:
+      return 3; // closed
+  }
+}
+
+type PrimaryPrComparable = Pick<PrSummary, "state" | "updatedAt" | "githubPrNumber">;
+
+function comparePrimaryPr(a: PrimaryPrComparable, b: PrimaryPrComparable): number {
+  const byRank = primaryPrStateRank(a.state) - primaryPrStateRank(b.state);
+  if (byRank !== 0) return byRank;
+  const aUpdated = Date.parse(a.updatedAt);
+  const bUpdated = Date.parse(b.updatedAt);
+  if (Number.isFinite(aUpdated) && Number.isFinite(bUpdated) && aUpdated !== bUpdated) {
+    return bUpdated - aUpdated;
+  }
+  return b.githubPrNumber - a.githubPrNumber;
+}
+
+/**
+ * Pick the single PR that best represents a set of PRs: prefer open over draft
+ * over merged/closed; among equals the most recently updated (then highest
+ * number) wins. Returns null for an empty list. Pure — the caller pre-filters
+ * to a lane's PRs.
+ */
+export function pickPrimaryPr<T extends PrimaryPrComparable>(prs: T[]): T | null {
+  let best: T | null = null;
+  for (const pr of prs) {
+    if (best === null || comparePrimaryPr(pr, best) < 0) best = pr;
+  }
+  return best;
+}
+
+/** The lane's primary PR from the ADE-mapped set, matched on the lane's current branch. */
+export function selectPrimaryLanePr(
+  lane: Pick<LaneSummary, "id" | "laneType" | "branchRef" | "baseRef">,
+  prs: PrSummary[],
+): PrSummary | null {
+  return pickPrimaryPr(prs.filter((pr) => lanePrMatchesCurrentBranch(lane, pr)));
+}
+
+/** One-word capsule copy for a PR state. */
+export function lanePrStateLabel(state: PrState): string {
+  switch (state) {
+    case "open":
+      return "Open";
+    case "draft":
+      return "Draft";
+    case "merged":
+      return "Merged";
+    default:
+      return "Closed";
+  }
+}
+
+/** State-colored dot color, mirroring the PR-tab badge palette. */
+export function lanePrStateColor(state: PrState): string {
+  switch (state) {
+    case "open":
+      return COLORS.info;
+    case "draft":
+      return COLORS.accent;
+    case "merged":
+      return COLORS.success;
+    default:
+      return COLORS.textSecondary; // closed
+  }
+}

--- a/apps/desktop/src/renderer/lib/terminalAttention.ts
+++ b/apps/desktop/src/renderer/lib/terminalAttention.ts
@@ -1,4 +1,5 @@
 import type { TerminalRuntimeState, TerminalSessionStatus, TerminalSessionSummary, TerminalToolType } from "../../shared/types";
+import { canonicalSessionState, type SessionBadge } from "../../shared/sessionCanonicalState";
 import { isChatToolType } from "./sessions";
 
 export type TerminalRunIndicatorState = "none" | "running-active" | "running-needs-attention";
@@ -98,16 +99,52 @@ export function sessionIndicatorState(args: {
   lastOutputPreview: string | null;
   runtimeState?: TerminalRuntimeState;
   toolType?: TerminalToolType | null;
+  pendingInputItemId?: string | null;
 }): SessionUiState {
   if (args.status === "detached") return "ended";
   if (args.status === "running") {
-    if (args.runtimeState === "waiting-input") return "running-needs-attention";
-    if (args.runtimeState === "idle" && idleRuntimeNeedsAttention(args.toolType)) return "running-needs-attention";
+    // Deterministic signals first (pendingInputItemId now counts — it used to
+    // be invisible here); the preview-text heuristic is consulted LAST and can
+    // only upgrade a plain running session, never outvote runtime state.
+    if (args.pendingInputItemId || args.runtimeState === "waiting-input") return "running-needs-attention";
+    if (args.runtimeState === "idle") {
+      return idleRuntimeNeedsAttention(args.toolType) ? "running-needs-attention" : "running-active";
+    }
     return runningSessionNeedsAttention(args.lastOutputPreview) ? "running-needs-attention" : "running-active";
   }
   // Agent chats do not "end" like PTY sessions — they idle until deleted.
   if (isChatToolType(args.toolType)) return "running-needs-attention";
   return "ended";
+}
+
+/**
+ * The one-word attention capsule for a session row (desktop SessionCard; iOS
+ * mirrors the vocabulary). Null for every calm state — rows must not shift
+ * layout when no capsule renders. Backed by the shared canonical state module
+ * so the capsule, the Live Activity phase, and notifications always agree.
+ */
+export function sessionCapsuleBadge(session: {
+  status: TerminalSessionStatus;
+  lastOutputPreview: string | null;
+  runtimeState?: TerminalRuntimeState;
+  toolType?: TerminalToolType | null;
+  pendingInputItemId?: string | null;
+  lastActivityAt?: string | null;
+  exitCode?: number | null;
+  nowMs?: number;
+}): SessionBadge | null {
+  return canonicalSessionState({
+    status: session.status,
+    runtimeState: session.runtimeState ?? null,
+    toolType: session.toolType ?? null,
+    pendingInputItemId: session.pendingInputItemId ?? null,
+    lastOutputPreview: session.lastOutputPreview,
+    lastActivityAt: session.lastActivityAt ?? null,
+    exitCode: session.exitCode ?? null,
+    nowMs: session.nowMs,
+    previewSuggestsNeedsInput: runningSessionNeedsAttention,
+    isChatTool: isChatToolType,
+  }).badge;
 }
 
 export function sessionNeedsUserInput(args: {

--- a/apps/desktop/src/shared/sessionCanonicalState.test.ts
+++ b/apps/desktop/src/shared/sessionCanonicalState.test.ts
@@ -34,6 +34,7 @@ describe("canonicalSessionState precedence", () => {
     ["waiting-input wins even when preview looks calm", { runtimeState: "waiting-input", lastOutputPreview: "compiling..." }, "needs_you", "Needs you"],
     ["pendingInputItemId wins on an ended session", { pendingInputItemId: "i-1", status: "detached", exitCode: 1 }, "needs_you", "Needs you"],
     ["non-zero exit is failed", { status: "detached", exitCode: 2 }, "failed", "Failed"],
+    ["persisted failed status with null exit is failed (spawn failure)", { status: "failed", exitCode: null, runtimeState: "exited" }, "failed", "Failed"],
     ["killed runtime is failed", { status: "detached", runtimeState: "killed", exitCode: null }, "failed", "Failed"],
     ["running + silent past threshold is stale", { lastActivityAt: silentSince }, "stale", "Stale"],
     ["stale wins over a prompt-looking preview", { lastActivityAt: silentSince, lastOutputPreview: "continue? (y/n)" }, "stale", "Stale"],

--- a/apps/desktop/src/shared/sessionCanonicalState.test.ts
+++ b/apps/desktop/src/shared/sessionCanonicalState.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalSessionState,
+  SESSION_STALE_AFTER_MS,
+  type CanonicalSessionInputs,
+} from "./sessionCanonicalState";
+
+const NOW = Date.parse("2026-07-06T12:00:00.000Z");
+const promptLikePreview = (preview: string | null | undefined) =>
+  Boolean(preview && /\(y\/n\)/i.test(preview));
+const chatTools = new Set(["claude-chat", "cursor"]);
+const isChatTool = (toolType: string | null | undefined) => Boolean(toolType && chatTools.has(toolType));
+
+function state(overrides: Partial<CanonicalSessionInputs>) {
+  return canonicalSessionState({
+    status: "running",
+    runtimeState: "running",
+    toolType: "claude",
+    nowMs: NOW,
+    previewSuggestsNeedsInput: promptLikePreview,
+    isChatTool,
+    ...overrides,
+  });
+}
+
+describe("canonicalSessionState precedence", () => {
+  const silentSince = new Date(NOW - SESSION_STALE_AFTER_MS - 1_000).toISOString();
+
+  // Table: deterministic signals must outrank everything below them, and the
+  // preview heuristic must never outvote a deterministic runtime state.
+  const cases: Array<[string, Partial<CanonicalSessionInputs>, string, string | null]> = [
+    ["pendingInputItemId wins over stale silence", { pendingInputItemId: "i-1", lastActivityAt: silentSince }, "needs_you", "Needs you"],
+    ["waiting-input wins over stale silence", { runtimeState: "waiting-input", lastActivityAt: silentSince }, "needs_you", "Needs you"],
+    ["waiting-input wins even when preview looks calm", { runtimeState: "waiting-input", lastOutputPreview: "compiling..." }, "needs_you", "Needs you"],
+    ["pendingInputItemId wins on an ended session", { pendingInputItemId: "i-1", status: "detached", exitCode: 1 }, "needs_you", "Needs you"],
+    ["non-zero exit is failed", { status: "detached", exitCode: 2 }, "failed", "Failed"],
+    ["killed runtime is failed", { status: "detached", runtimeState: "killed", exitCode: null }, "failed", "Failed"],
+    ["running + silent past threshold is stale", { lastActivityAt: silentSince }, "stale", "Stale"],
+    ["stale wins over a prompt-looking preview", { lastActivityAt: silentSince, lastOutputPreview: "continue? (y/n)" }, "stale", "Stale"],
+    ["heuristic upgrades plain running LAST", { lastOutputPreview: "continue? (y/n)" }, "needs_you", "Needs you"],
+    ["plain running stays running (no badge)", { lastOutputPreview: "compiling..." }, "running", null],
+    ["idle chat is ready (no badge)", { runtimeState: "idle", toolType: "claude-chat" }, "ready", null],
+    ["idle CLI is idle (no badge)", { runtimeState: "idle" }, "idle", null],
+    ["heuristic does NOT fire on idle sessions", { runtimeState: "idle", lastOutputPreview: "continue? (y/n)" }, "idle", null],
+    ["clean exit is ended (no badge)", { status: "detached", exitCode: 0 }, "ended", null],
+    ["ended chat is ready (no badge)", { status: "detached", toolType: "claude-chat", exitCode: null }, "ready", null],
+  ];
+
+  it.each(cases)("%s", (_name, overrides, phase, label) => {
+    const result = state(overrides);
+    expect(result.phase).toBe(phase);
+    expect(result.badge?.label ?? null).toBe(label);
+    // Attention states and ONLY attention states carry a badge.
+    expect(result.badge !== null).toBe(["needs_you", "failed", "stale"].includes(phase));
+  });
+});
+
+describe("stale boundary", () => {
+  it("flips exactly at the threshold, not before", () => {
+    const justUnder = new Date(NOW - SESSION_STALE_AFTER_MS + 1_000).toISOString();
+    const exactly = new Date(NOW - SESSION_STALE_AFTER_MS).toISOString();
+    expect(state({ lastActivityAt: justUnder }).phase).toBe("running");
+    expect(state({ lastActivityAt: exactly }).phase).toBe("stale");
+  });
+
+  it("never goes stale without an activity timestamp or with garbage", () => {
+    expect(state({ lastActivityAt: null }).phase).toBe("running");
+    expect(state({ lastActivityAt: "not-a-date" }).phase).toBe("running");
+  });
+});

--- a/apps/desktop/src/shared/sessionCanonicalState.ts
+++ b/apps/desktop/src/shared/sessionCanonicalState.ts
@@ -1,0 +1,133 @@
+import type { TerminalRuntimeState, TerminalSessionStatus, TerminalToolType } from "./types/sessions";
+
+/**
+ * The ONE vocabulary for "what state is this session in", shared by the Work
+ * tab (desktop + iOS mirror), the TUI, and — by documented mapping — the push
+ * pipeline, so a session's badge, its Live Activity phase, and any
+ * notification always tell the same story.
+ *
+ * Mapping to the Live Activity wire phases (names unchanged on the push side):
+ *   needs_you  ⇔ waiting_for_approval | waiting_for_input
+ *   failed     ⇔ failed
+ *   stale      ⇔ stale
+ *   starting/running ⇔ starting/running
+ *   ready/idle/ended have no LA row (terminal or chat-resting states).
+ */
+export type CanonicalSessionPhase =
+  | "starting"
+  | "running"
+  | "needs_you"
+  | "failed"
+  | "stale"
+  | "ready"
+  | "idle"
+  | "ended";
+
+export type SessionBadgeKind = "needs_you" | "failed" | "stale";
+
+export type SessionBadge = {
+  kind: SessionBadgeKind;
+  /** One-word capsule copy; calm states get no badge at all. */
+  label: string;
+};
+
+export type CanonicalSessionState = {
+  phase: CanonicalSessionPhase;
+  /** Non-null ONLY for attention states — capsules never render for calm ones. */
+  badge: SessionBadge | null;
+};
+
+/**
+ * A session still marked running that has produced no output for this long is
+ * "stale" — running but silent. Distinct from the push relay's APNs TTLs
+ * (2h/24h delivery expiry) and the Live Activity stale-date (10min lock-screen
+ * dimming): this is the human-facing "is anything actually happening" bar.
+ */
+export const SESSION_STALE_AFTER_MS = 20 * 60 * 1000;
+
+const BADGE_BY_KIND: Record<SessionBadgeKind, SessionBadge> = {
+  needs_you: { kind: "needs_you", label: "Needs you" },
+  failed: { kind: "failed", label: "Failed" },
+  stale: { kind: "stale", label: "Stale" },
+};
+
+export type CanonicalSessionInputs = {
+  status: TerminalSessionStatus;
+  runtimeState?: TerminalRuntimeState | null;
+  toolType?: TerminalToolType | null;
+  pendingInputItemId?: string | null;
+  lastOutputPreview?: string | null;
+  /** ISO timestamp of most recent output/activity (drives stale). */
+  lastActivityAt?: string | null;
+  exitCode?: number | null;
+  nowMs?: number;
+  /**
+   * The preview-text heuristic (regex over terminal output) supplied by the
+   * caller so this module stays dependency-free. It is consulted LAST and can
+   * only upgrade running → needs_you — deterministic signals always win.
+   */
+  previewSuggestsNeedsInput?: (preview: string | null | undefined) => boolean;
+  /** Chat sessions idle between turns are "ready", not running/ended. */
+  isChatTool?: (toolType: TerminalToolType | null | undefined) => boolean;
+};
+
+function isSilentPast(lastActivityAt: string | null | undefined, nowMs: number, thresholdMs: number): boolean {
+  if (!lastActivityAt) return false;
+  const at = Date.parse(lastActivityAt);
+  if (!Number.isFinite(at)) return false;
+  return nowMs - at >= thresholdMs;
+}
+
+/**
+ * Canonical precedence (highest first):
+ *   1. deterministic needs-input — pendingInputItemId or runtimeState
+ *      "waiting-input" (never outvoted by anything below),
+ *   2. failed — non-zero exit / killed,
+ *   3. stale — status running but silent ≥ SESSION_STALE_AFTER_MS,
+ *   4. running (incl. the preview heuristic's needs_you upgrade, LAST),
+ *   5. resting states — ready (idle chat), idle, ended.
+ */
+export function canonicalSessionState(args: CanonicalSessionInputs): CanonicalSessionState {
+  const nowMs = args.nowMs ?? Date.now();
+  const chat = args.isChatTool?.(args.toolType) ?? false;
+
+  // 1. Deterministic attention beats everything — including the failure and
+  // stale checks below (an agent explicitly asking is actionable regardless).
+  if (args.pendingInputItemId || args.runtimeState === "waiting-input") {
+    return { phase: "needs_you", badge: BADGE_BY_KIND.needs_you };
+  }
+
+  const ended = args.status !== "running";
+  if (ended) {
+    // 2. Failure: a non-clean exit is the only deterministic "failed" a
+    // terminal-backed session reports.
+    if (typeof args.exitCode === "number" && args.exitCode !== 0) {
+      return { phase: "failed", badge: BADGE_BY_KIND.failed };
+    }
+    if (args.runtimeState === "killed") {
+      return { phase: "failed", badge: BADGE_BY_KIND.failed };
+    }
+    // Chats never "end" like PTYs — they rest between turns, ready for input.
+    if (chat) return { phase: "ready", badge: null };
+    return { phase: "ended", badge: null };
+  }
+
+  // 3. Stale: running but silent past the threshold.
+  if (isSilentPast(args.lastActivityAt, nowMs, SESSION_STALE_AFTER_MS)) {
+    return { phase: "stale", badge: BADGE_BY_KIND.stale };
+  }
+
+  // Idle chats between turns are ready (calm); idle agent CLIs at an
+  // undetected prompt stay actionable via the caller's existing idle rules —
+  // canonical keeps them "idle" (calm) because there is no deterministic ask.
+  if (args.runtimeState === "idle") {
+    return chat ? { phase: "ready", badge: null } : { phase: "idle", badge: null };
+  }
+
+  // 4. Preview heuristic LAST: it may only upgrade running → needs_you.
+  if (args.previewSuggestsNeedsInput?.(args.lastOutputPreview)) {
+    return { phase: "needs_you", badge: BADGE_BY_KIND.needs_you };
+  }
+
+  return { phase: "running", badge: null };
+}

--- a/apps/desktop/src/shared/sessionCanonicalState.ts
+++ b/apps/desktop/src/shared/sessionCanonicalState.ts
@@ -99,9 +99,14 @@ export function canonicalSessionState(args: CanonicalSessionInputs): CanonicalSe
 
   const ended = args.status !== "running";
   if (ended) {
-    // 2. Failure: a non-clean exit is the only deterministic "failed" a
-    // terminal-backed session reports.
+    // 2. Failure: a non-clean exit, an explicit "failed" persisted status
+    // (spawn/setup failures that die before an exit code), or a killed
+    // runtime — all deterministic "failed" signals a terminal-backed session
+    // reports.
     if (typeof args.exitCode === "number" && args.exitCode !== 0) {
+      return { phase: "failed", badge: BADGE_BY_KIND.failed };
+    }
+    if (args.status === "failed") {
       return { phase: "failed", badge: BADGE_BY_KIND.failed };
     }
     if (args.runtimeState === "killed") {

--- a/apps/ios/ADE.xcodeproj/project.pbxproj
+++ b/apps/ios/ADE.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		E10000000000000000000036 /* WorkErrorAndMessageHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000036 /* WorkErrorAndMessageHelpers.swift */; };
 		E10000000000000000000037 /* WorkEventMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000037 /* WorkEventMapping.swift */; };
 		E10000000000000000000038 /* WorkStatusAndFormattingHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000038 /* WorkStatusAndFormattingHelpers.swift */; };
+		FB000000000000000000C1C1 /* WorkSessionCanonicalState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000000000000000000C1C1 /* WorkSessionCanonicalState.swift */; };
 		E10000000000000000000039 /* WorkChatSessionView+Timeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000039 /* WorkChatSessionView+Timeline.swift */; };
 		E1000000000000000000003A /* WorkReasoningCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000000000000000000003A /* WorkReasoningCard.swift */; };
 		E1000000000000000000003B /* WorkActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1000000000000000000003B /* WorkActivityIndicator.swift */; };
@@ -124,6 +125,7 @@
 		D30000000000000000000017 /* WorkMarkdownStreamingParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30000000000000000000007 /* WorkMarkdownStreamingParsingTests.swift */; };
 		D30000000000000000000018 /* PrMergeMergeStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30000000000000000000008 /* PrMergeMergeStateTests.swift */; };
 		D30000000000000000000019 /* WorkComposerTriggerDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30000000000000000000009 /* WorkComposerTriggerDetectorTests.swift */; };
+		FB000000000000000000C2C2 /* WorkSessionCanonicalStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000000000000000000C2C2 /* WorkSessionCanonicalStateTests.swift */; };
 		889573D8A5ED468D3BD12894 /* PRsTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EE4D463D21266B62B422D11 /* PRsTabView.swift */; };
 		B10000000000000000000002 /* LaneAttachSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000002 /* LaneAttachSheet.swift */; };
 		B10000000000000000000003 /* LaneBatchManageSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000000000000000000003 /* LaneBatchManageSheet.swift */; };
@@ -280,6 +282,7 @@
 		D10000000000000000000036 /* WorkErrorAndMessageHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkErrorAndMessageHelpers.swift; path = ADE/Views/Work/WorkErrorAndMessageHelpers.swift; sourceTree = "<group>"; };
 		D10000000000000000000037 /* WorkEventMapping.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkEventMapping.swift; path = ADE/Views/Work/WorkEventMapping.swift; sourceTree = "<group>"; };
 		D10000000000000000000038 /* WorkStatusAndFormattingHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkStatusAndFormattingHelpers.swift; path = ADE/Views/Work/WorkStatusAndFormattingHelpers.swift; sourceTree = "<group>"; };
+		FA000000000000000000C1C1 /* WorkSessionCanonicalState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkSessionCanonicalState.swift; path = ADE/Views/Work/WorkSessionCanonicalState.swift; sourceTree = "<group>"; };
 		D10000000000000000000039 /* WorkChatSessionView+Timeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "WorkChatSessionView+Timeline.swift"; path = "ADE/Views/Work/WorkChatSessionView+Timeline.swift"; sourceTree = "<group>"; };
 		D1000000000000000000003A /* WorkReasoningCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "WorkReasoningCard.swift"; path = "ADE/Views/Work/WorkReasoningCard.swift"; sourceTree = "<group>"; };
 		D1000000000000000000003B /* WorkActivityIndicator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkActivityIndicator.swift; path = ADE/Views/Work/WorkActivityIndicator.swift; sourceTree = "<group>"; };
@@ -329,6 +332,7 @@
 		D30000000000000000000007 /* WorkMarkdownStreamingParsingTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkMarkdownStreamingParsingTests.swift; path = ADETests/WorkMarkdownStreamingParsingTests.swift; sourceTree = "<group>"; };
 		D30000000000000000000008 /* PrMergeMergeStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrMergeMergeStateTests.swift; path = ADETests/PrMergeMergeStateTests.swift; sourceTree = "<group>"; };
 		D30000000000000000000009 /* WorkComposerTriggerDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkComposerTriggerDetectorTests.swift; path = ADETests/WorkComposerTriggerDetectorTests.swift; sourceTree = "<group>"; };
+		FA000000000000000000C2C2 /* WorkSessionCanonicalStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkSessionCanonicalStateTests.swift; path = ADETests/WorkSessionCanonicalStateTests.swift; sourceTree = "<group>"; };
 		27A125DE2C17BA32F9291513 /* ADE.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ADE.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2856F8D2F2D630DD985B870A /* DatabaseBootstrap.sql */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = DatabaseBootstrap.sql; path = ADE/Resources/DatabaseBootstrap.sql; sourceTree = "<group>"; };
 		781DE0B3C61717AE3057B82D /* VoiceGlossary.json */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.json; name = VoiceGlossary.json; path = ADE/Resources/VoiceGlossary.json; sourceTree = "<group>"; };
@@ -664,6 +668,7 @@
 				D10000000000000000000036 /* WorkErrorAndMessageHelpers.swift */,
 				D10000000000000000000037 /* WorkEventMapping.swift */,
 				D10000000000000000000038 /* WorkStatusAndFormattingHelpers.swift */,
+				FA000000000000000000C1C1 /* WorkSessionCanonicalState.swift */,
 			);
 			name = Work;
 			sourceTree = "<group>";
@@ -829,6 +834,7 @@
 				D30000000000000000000007 /* WorkMarkdownStreamingParsingTests.swift */,
 				D30000000000000000000008 /* PrMergeMergeStateTests.swift */,
 				D30000000000000000000009 /* WorkComposerTriggerDetectorTests.swift */,
+				FA000000000000000000C2C2 /* WorkSessionCanonicalStateTests.swift */,
 			);
 			name = ADETests;
 			sourceTree = "<group>";
@@ -1156,6 +1162,7 @@
 				E10000000000000000000036 /* WorkErrorAndMessageHelpers.swift in Sources */,
 				E10000000000000000000037 /* WorkEventMapping.swift in Sources */,
 				E10000000000000000000038 /* WorkStatusAndFormattingHelpers.swift in Sources */,
+				FB000000000000000000C1C1 /* WorkSessionCanonicalState.swift in Sources */,
 				H10000000000000000000001 /* CtoRootScreen.swift in Sources */,
 				H10000000000000000000002 /* CtoSessionDestinationView.swift in Sources */,
 				H10000000000000000000005 /* CtoIdentityEditor.swift in Sources */,
@@ -1188,6 +1195,7 @@
 				D30000000000000000000017 /* WorkMarkdownStreamingParsingTests.swift in Sources */,
 				D30000000000000000000018 /* PrMergeMergeStateTests.swift in Sources */,
 				D30000000000000000000019 /* WorkComposerTriggerDetectorTests.swift in Sources */,
+				FB000000000000000000C2C2 /* WorkSessionCanonicalStateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/apps/ios/ADE/Views/Work/WorkRootComponents.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootComponents.swift
@@ -316,37 +316,56 @@ struct WorkSidebarSectionHeader: View {
   let group: WorkSessionGroup
   let collapsed: Bool
   let onToggle: () -> Void
+  /// Primary open PR for this lane section (by-lane grouping only). Rendered
+  /// once on the header, left of the session count, replacing the former
+  /// per-row indicator. Nil for status/time sections.
+  var pullRequest: LanePrTag? = nil
+  /// Navigates to the header PR in the PRs tab. Defaults to a no-op so preview
+  /// harnesses don't have to wire it.
+  var onOpenPullRequest: (LanePrTag) -> Void = { _ in }
 
   var body: some View {
-    Button(action: onToggle) {
-      HStack(spacing: 8) {
-        Image(systemName: collapsed ? "chevron.right" : "chevron.down")
-          .font(.system(size: 9, weight: .bold))
-          .foregroundStyle(ADEColor.textMuted)
-          .frame(width: 10, alignment: .center)
+    HStack(spacing: 8) {
+      Button(action: onToggle) {
+        HStack(spacing: 8) {
+          Image(systemName: collapsed ? "chevron.right" : "chevron.down")
+            .font(.system(size: 9, weight: .bold))
+            .foregroundStyle(ADEColor.textMuted)
+            .frame(width: 10, alignment: .center)
 
-        sectionIcon
+          sectionIcon
 
-        Text(group.label)
-          .font(.caption.weight(.semibold))
-          .foregroundStyle(group.laneColor != nil ? group.tint : ADEColor.textPrimary)
-          .lineLimit(1)
+          Text(group.label)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(group.laneColor != nil ? group.tint : ADEColor.textPrimary)
+            .lineLimit(1)
 
-        Spacer(minLength: 0)
-
-        Text("\(group.sessions.count)")
-          .font(.caption2.monospacedDigit().weight(.semibold))
-          .foregroundStyle(ADEColor.textMuted)
-          .padding(.horizontal, 7)
-          .padding(.vertical, 2)
-          .background(ADEColor.surfaceBackground.opacity(0.65), in: Capsule())
+          Spacer(minLength: 0)
+        }
+        .contentShape(Rectangle())
       }
-      .padding(.horizontal, 4)
-      .padding(.vertical, 8)
-      .contentShape(Rectangle())
+      .buttonStyle(.plain)
+      .accessibilityLabel("\(group.label), \(group.sessions.count) session\(group.sessions.count == 1 ? "" : "s"). Tap to \(collapsed ? "expand" : "collapse").")
+
+      if let pullRequest {
+        Button {
+          onOpenPullRequest(pullRequest)
+        } label: {
+          WorkLanePrIndicator(tag: pullRequest)
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint("Opens in the PRs tab")
+      }
+
+      Text("\(group.sessions.count)")
+        .font(.caption2.monospacedDigit().weight(.semibold))
+        .foregroundStyle(ADEColor.textMuted)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 2)
+        .background(ADEColor.surfaceBackground.opacity(0.65), in: Capsule())
     }
-    .buttonStyle(.plain)
-    .accessibilityLabel("\(group.label), \(group.sessions.count) session\(group.sessions.count == 1 ? "" : "s"). Tap to \(collapsed ? "expand" : "collapse").")
+    .padding(.horizontal, 4)
+    .padding(.vertical, 8)
   }
 
   @ViewBuilder
@@ -808,6 +827,11 @@ private struct WorkSessionRowRenderSignature: Equatable {
   let pullRequestNumber: Int?
   let pullRequestState: String?
   let status: String
+  // Deterministic inputs to the attention capsule, so a badge transition
+  // (needs_you / failed) re-renders even when the display status is unchanged.
+  let runtimeState: String
+  let pendingInputItemId: String?
+  let exitCode: Int?
   let isArchived: Bool
   let isMuted: Bool
   let isSelectedTransitionSource: Bool
@@ -839,6 +863,9 @@ private struct WorkSessionRowRenderSignature: Equatable {
     self.pullRequestNumber = pullRequest?.githubPrNumber
     self.pullRequestState = pullRequest.map { lanePrStateLabel($0.state) }
     self.status = status
+    self.runtimeState = session.runtimeState
+    self.pendingInputItemId = session.pendingInputItemId
+    self.exitCode = session.exitCode
     self.isArchived = isArchived
     self.isMuted = isMuted
     self.isSelectedTransitionSource = isSelectedTransitionSource
@@ -921,6 +948,10 @@ struct WorkSessionRow: View, Equatable {
         .lineLimit(1)
         .truncationMode(.tail)
 
+      if let badge = capsuleBadge {
+        WorkSessionStatusCapsule(badge: badge)
+      }
+
       Spacer(minLength: 6)
 
       if isPendingSyncCreation {
@@ -979,6 +1010,9 @@ struct WorkSessionRow: View, Equatable {
               .foregroundStyle(ADEColor.textMuted)
               .accessibilityLabel("Notifications muted")
           }
+          if let badge = capsuleBadge {
+            WorkSessionStatusCapsule(badge: badge)
+          }
           Spacer(minLength: 6)
           Text(relativeTimestampCompact(workSessionActivityTimestamp(session: session, summary: chatSummary)))
             .font(.caption2.monospacedDigit())
@@ -1019,10 +1053,6 @@ struct WorkSessionRow: View, Equatable {
             .lineLimit(1)
             .truncationMode(.middle)
             .layoutPriority(-1)
-
-          if let pullRequest {
-            WorkLanePrIndicator(tag: pullRequest)
-          }
 
           if lane?.status.dirty == true {
             Circle()
@@ -1093,6 +1123,12 @@ struct WorkSessionRow: View, Equatable {
 
   var providerTintColor: Color {
     providerTint(chatSummary?.provider ?? session.toolType)
+  }
+
+  /// Canonical attention capsule (needs_you / failed / stale); nil for calm
+  /// states so the row never shifts layout when no capsule renders.
+  var capsuleBadge: SessionBadge? {
+    workSessionCapsuleBadge(session: session, summary: chatSummary)
   }
 
   var isPendingSyncCreation: Bool {

--- a/apps/ios/ADE/Views/Work/WorkRootScreen+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootScreen+Actions.swift
@@ -356,6 +356,24 @@ extension WorkRootScreen {
     }
   }
 
+  /// Header-tag variant of `openPullRequest` — navigates straight to a lane
+  /// section's primary PR in the PRs tab (no owning session row). Reuses the
+  /// same `requestedPrNavigation` cross-tab handoff.
+  func openLanePullRequest(tag: LanePrTag, laneId: String?) {
+    let trimmedLaneId = laneId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    Task { @MainActor in
+      if let prId = tag.prId, !prId.isEmpty {
+        syncService.requestedPrNavigation = PrNavigationRequest(
+          prId: prId,
+          prNumber: tag.githubPrNumber,
+          laneId: trimmedLaneId.isEmpty ? nil : trimmedLaneId
+        )
+      } else {
+        syncService.requestedPrNavigation = PrNavigationRequest(prNumber: tag.githubPrNumber)
+      }
+    }
+  }
+
   func openSession(_ session: TerminalSessionSummary) {
     // A pending-sync row has no synced session to open yet.
     guard !workIsPendingChatCreationSession(session) else { return }

--- a/apps/ios/ADE/Views/Work/WorkRootScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootScreen.swift
@@ -371,6 +371,10 @@ struct WorkRootScreen: View {
                   withAnimation(ADEMotion.quick(reduceMotion: reduceMotion)) {
                     toggleCollapsed(group.id)
                   }
+                },
+                pullRequest: group.laneId.flatMap { rowPrTagsByLaneId[$0] },
+                onOpenPullRequest: { tag in
+                  openLanePullRequest(tag: tag, laneId: group.laneId)
                 }
               )
               .id(group.id)

--- a/apps/ios/ADE/Views/Work/WorkSessionCanonicalState.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionCanonicalState.swift
@@ -1,0 +1,282 @@
+import SwiftUI
+
+/// The ONE vocabulary for "what state is this session in", mirrored from the
+/// desktop `apps/desktop/src/shared/sessionCanonicalState.ts` so a session's
+/// Work-row capsule, its Live Activity phase, and any push notification always
+/// tell the same story. This is a VIEW-layer vocabulary: the existing awaiting
+/// derivation in `SyncService`/`normalizedWorkChatSessionStatus` is untouched.
+///
+/// Mapping to the Live Activity wire phases (names unchanged on the push side):
+///   needs_you  ⇔ waiting_for_approval | waiting_for_input
+///   failed     ⇔ failed
+///   stale      ⇔ stale
+///   starting/running ⇔ starting/running
+///   ready/idle/ended have no LA row (terminal or chat-resting states).
+enum CanonicalSessionPhase: Equatable {
+  case starting
+  case running
+  case needsYou
+  case failed
+  case stale
+  case ready
+  case idle
+  case ended
+}
+
+/// The three attention states that earn a capsule. Calm phases get no badge.
+enum SessionBadgeKind: Equatable {
+  case needsYou
+  case failed
+  case stale
+}
+
+struct SessionBadge: Equatable {
+  let kind: SessionBadgeKind
+  /// Short capsule copy; calm states get no badge at all.
+  let label: String
+}
+
+struct CanonicalSessionState: Equatable {
+  let phase: CanonicalSessionPhase
+  /// Non-nil ONLY for attention states — capsules never render for calm ones.
+  let badge: SessionBadge?
+}
+
+/// A session still marked running that has produced no output for this long is
+/// "stale" — running but silent. Distinct from the push relay's APNs TTLs and
+/// the Live Activity 10-minute lock-screen dimming: this is the human-facing
+/// "is anything actually happening" bar. Exactly mirrors the desktop
+/// `SESSION_STALE_AFTER_MS` (20 minutes); do not reuse other stale semantics
+/// (e.g. the 7-day chat reclassification in `normalizedWorkChatSessionStatus`).
+let sessionStaleAfterSeconds: TimeInterval = 20 * 60
+
+private let badgeByKind: [SessionBadgeKind: SessionBadge] = [
+  .needsYou: SessionBadge(kind: .needsYou, label: "Needs you"),
+  .failed: SessionBadge(kind: .failed, label: "Failed"),
+  .stale: SessionBadge(kind: .stale, label: "Stale"),
+]
+
+private func isSilentPast(_ lastActivityAt: String?, now: Date, thresholdSeconds: TimeInterval) -> Bool {
+  guard let at = workParsedDate(lastActivityAt) else { return false }
+  return now.timeIntervalSince(at) >= thresholdSeconds
+}
+
+/// Whether a tool type is a chat provider (vs a raw terminal/CLI session).
+/// Mirrors desktop `isChatToolType` — explicit chat tools plus `*-chat`
+/// providers. `isChatSession(_:)` delegates here so both agree.
+func isWorkChatToolType(_ toolType: String?) -> Bool {
+  let raw = toolType?
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+    .lowercased() ?? ""
+  guard !raw.isEmpty else { return false }
+  if raw == "codex-chat" || raw == "claude-chat" || raw == "opencode-chat" || raw == "cursor" {
+    return true
+  }
+  return raw.hasSuffix("-chat")
+}
+
+/// Canonical precedence (highest first), identical to the desktop module:
+///   1. deterministic needs-input — a pending input item or a "waiting-input"
+///      runtime (never outvoted by anything below),
+///   2. failed — non-zero exit / killed,
+///   3. stale — status running but silent ≥ `sessionStaleAfterSeconds`,
+///   4. running (incl. the preview heuristic's needs_you upgrade, consulted LAST),
+///   5. resting states — ready (idle chat), idle, ended.
+func workCanonicalSessionState(
+  status: String,
+  runtimeState: String? = nil,
+  toolType: String? = nil,
+  pendingInputItemId: String? = nil,
+  lastOutputPreview: String? = nil,
+  lastActivityAt: String? = nil,
+  exitCode: Int? = nil,
+  now: Date = Date(),
+  previewSuggestsNeedsInput: (String?) -> Bool = workSessionPreviewSuggestsNeedsInput,
+  isChatTool: (String?) -> Bool = isWorkChatToolType
+) -> CanonicalSessionState {
+  let chat = isChatTool(toolType)
+  let runtimeLower = runtimeState?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+  let pending = pendingInputItemId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+  // 1. Deterministic attention beats everything — including the failure and
+  // stale checks below (an agent explicitly asking is actionable regardless).
+  if !pending.isEmpty || runtimeLower == "waiting-input" {
+    return CanonicalSessionState(phase: .needsYou, badge: badgeByKind[.needsYou])
+  }
+
+  let ended = status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() != "running"
+  if ended {
+    // 2. Failure: a non-clean exit is the only deterministic "failed" a
+    // terminal-backed session reports.
+    if let exitCode, exitCode != 0 {
+      return CanonicalSessionState(phase: .failed, badge: badgeByKind[.failed])
+    }
+    if runtimeLower == "killed" {
+      return CanonicalSessionState(phase: .failed, badge: badgeByKind[.failed])
+    }
+    // Chats never "end" like PTYs — they rest between turns, ready for input.
+    if chat { return CanonicalSessionState(phase: .ready, badge: nil) }
+    return CanonicalSessionState(phase: .ended, badge: nil)
+  }
+
+  // 3. Stale: running but silent past the threshold.
+  if isSilentPast(lastActivityAt, now: now, thresholdSeconds: sessionStaleAfterSeconds) {
+    return CanonicalSessionState(phase: .stale, badge: badgeByKind[.stale])
+  }
+
+  // Idle chats between turns are ready (calm); idle agent CLIs stay calm here —
+  // there is no deterministic ask.
+  if runtimeLower == "idle" {
+    return chat
+      ? CanonicalSessionState(phase: .ready, badge: nil)
+      : CanonicalSessionState(phase: .idle, badge: nil)
+  }
+
+  // 4. Preview heuristic LAST: it may only upgrade running → needs_you.
+  if previewSuggestsNeedsInput(lastOutputPreview) {
+    return CanonicalSessionState(phase: .needsYou, badge: badgeByKind[.needsYou])
+  }
+
+  return CanonicalSessionState(phase: .running, badge: nil)
+}
+
+// MARK: - Preview-text heuristic (mirrors desktop `runningSessionNeedsAttention`)
+
+private let workNeedsInputPatterns: [NSRegularExpression] = {
+  let specs: [(String, Bool)] = [
+    ("\\b(?:waiting|awaiting)\\b.{0,28}\\b(?:input|confirmation|response|prompt)\\b", true),
+    ("\\b(?:press|hit)\\b.{0,14}\\b(?:enter|return|any key)\\b", true),
+    ("\\b(?:select|choose|pick)\\b.{0,28}\\b(?:option|number|profile|item)\\b", true),
+    ("\\b(?:confirm|continue|proceed|retry)\\b.{0,24}\\?", true),
+    ("\\((?:y/n|yes/no)\\)", true),
+    ("\\[(?:y/n|yes/no)\\]", true),
+    ("\\b(?:enter|type)\\b.{0,24}:\\s*$", true),
+    // Claude Code tool-approval / plan-mode prompts: "(Y)es / (N)o".
+    ("\\([Yy]\\)\\w*\\s*.{0,12}\\([Nn]\\)\\w*", false),
+    ("\\ballow\\b.{0,40}\\?\\s", true),
+  ]
+  return specs.compactMap { pattern, caseInsensitive in
+    let options: NSRegularExpression.Options = caseInsensitive ? [.caseInsensitive] : []
+    return try? NSRegularExpression(pattern: pattern, options: options)
+  }
+}()
+
+// ESC-introduced control sequences (OSC/CSI) plus a two-char escape sweep so a
+// raw terminal-tail preview reads as plain text before pattern matching.
+private let workAnsiEscapeRegexes: [NSRegularExpression] = {
+  // ICU escape syntax (\uHHHH) — not Swift/JS \u{..}. Matches ESC-introduced OSC/CSI sequences plus a two-char escape sweep.
+  [
+    "\\u001B\\][^\\u0007]*(?:\\u0007|\\u001B\\\\)",
+    "\\u001B\\[[0-?]*[ -/]*[@-~]",
+    "\\u001B(?:[@-Z\\\\-_]|[0-9=>])",
+  ].compactMap { try? NSRegularExpression(pattern: $0) }
+}()
+
+/// The preview-text needs-input heuristic, ported from the desktop
+/// `runningSessionNeedsAttention`. Consulted LAST by `workCanonicalSessionState`
+/// and can only upgrade a plain running session to needs_you.
+func workSessionPreviewSuggestsNeedsInput(_ preview: String?) -> Bool {
+  guard var text = preview, !text.isEmpty else { return false }
+  let fullRange = { NSRange(text.startIndex..<text.endIndex, in: text) }
+  for regex in workAnsiEscapeRegexes {
+    text = regex.stringByReplacingMatches(in: text, range: fullRange(), withTemplate: "")
+  }
+  // Drop remaining control characters, collapse whitespace, and cap length to
+  // match the desktop sanitizer's 280-char window.
+  let stripped = String(text.unicodeScalars.filter { scalar in
+    scalar == " " || scalar == "\n" || scalar == "\t" || !(scalar.properties.generalCategory == .control)
+  })
+  let normalized = stripped
+    .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  guard !normalized.isEmpty else { return false }
+  let capped = normalized.count <= 280 ? normalized : String(normalized.prefix(280))
+  let range = NSRange(capped.startIndex..<capped.endIndex, in: capped)
+  return workNeedsInputPatterns.contains { $0.firstMatch(in: capped, range: range) != nil }
+}
+
+// MARK: - Row capsule wiring
+
+/// The one-word attention capsule for a Work session row, backed by the shared
+/// canonical state so the capsule, the Live Activity phase, and notifications
+/// always agree. Returns nil for every calm state — rows must not shift layout
+/// when no capsule renders.
+///
+/// This maps iOS's awaiting derivation (chat summary `awaitingInput`, plus
+/// `awaiting_input` session statuses) onto the canonical "waiting-input" runtime
+/// so a chat blocked on a question/plan/approval reads as needs_you exactly like
+/// `SyncService.isAwaiting`, without touching that derivation.
+func workSessionCapsuleBadge(
+  session: TerminalSessionSummary,
+  summary: AgentChatSessionSummary?,
+  now: Date = Date()
+) -> SessionBadge? {
+  let statusLower = session.status.lowercased()
+  let runtimeLower = session.runtimeState.lowercased()
+  let isAwaiting = summary?.awaitingInput == true
+    || runtimeLower == "waiting-input"
+    || statusLower == "awaiting-input"
+    || statusLower == "awaiting_input"
+  let effectiveRuntime = isAwaiting ? "waiting-input" : session.runtimeState
+  return workCanonicalSessionState(
+    status: session.status,
+    runtimeState: effectiveRuntime,
+    toolType: session.toolType,
+    pendingInputItemId: session.pendingInputItemId,
+    lastOutputPreview: session.lastOutputPreview,
+    lastActivityAt: workSessionActivityTimestamp(session: session, summary: summary),
+    exitCode: session.exitCode,
+    now: now
+  ).badge
+}
+
+/// Small attention capsule shown next to a Work row title. Amber for needs_you
+/// (matching the app's existing amber chip language), red for failed, and an
+/// outlined muted capsule with a clock glyph for stale. Calm states render
+/// nothing, so callers gate on a non-nil badge to avoid any layout shift.
+struct WorkSessionStatusCapsule: View {
+  let badge: SessionBadge
+
+  var body: some View {
+    HStack(spacing: 3) {
+      if badge.kind == .stale {
+        Image(systemName: "clock")
+          .font(.system(size: 8, weight: .semibold))
+      }
+      Text(badge.label)
+        .font(.caption2.weight(.semibold))
+    }
+    .foregroundStyle(tint)
+    .padding(.horizontal, 7)
+    .padding(.vertical, 2)
+    .background(fill, in: Capsule())
+    .overlay(Capsule().stroke(stroke, lineWidth: 0.5))
+    .fixedSize()
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(accessibilityLabel)
+  }
+
+  private var tint: Color {
+    switch badge.kind {
+    case .needsYou: return ADEColor.warning
+    case .failed: return ADEColor.danger
+    case .stale: return ADEColor.textMuted
+    }
+  }
+
+  private var fill: Color {
+    badge.kind == .stale ? Color.clear : tint.opacity(0.14)
+  }
+
+  private var stroke: Color {
+    badge.kind == .stale ? tint.opacity(0.4) : tint.opacity(0.3)
+  }
+
+  private var accessibilityLabel: String {
+    switch badge.kind {
+    case .needsYou: return "Needs your input"
+    case .failed: return "Failed"
+    case .stale: return "Stale, no recent activity"
+    }
+  }
+}

--- a/apps/ios/ADE/Views/Work/WorkSessionCanonicalState.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionCanonicalState.swift
@@ -106,9 +106,13 @@ func workCanonicalSessionState(
 
   let ended = status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() != "running"
   if ended {
-    // 2. Failure: a non-clean exit is the only deterministic "failed" a
-    // terminal-backed session reports.
+    // 2. Failure: a non-clean exit, an explicit "failed" persisted status
+    // (spawn/setup failures that die before an exit code), or a killed runtime
+    // — all deterministic "failed" signals a terminal-backed session reports.
     if let exitCode, exitCode != 0 {
+      return CanonicalSessionState(phase: .failed, badge: badgeByKind[.failed])
+    }
+    if status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "failed" {
       return CanonicalSessionState(phase: .failed, badge: badgeByKind[.failed])
     }
     if runtimeLower == "killed" {
@@ -224,10 +228,25 @@ func workSessionCapsuleBadge(
     toolType: session.toolType,
     pendingInputItemId: session.pendingInputItemId,
     lastOutputPreview: session.lastOutputPreview,
-    lastActivityAt: workSessionActivityTimestamp(session: session, summary: summary),
+    lastActivityAt: workSessionStaleActivityTimestamp(session: session, summary: summary),
     exitCode: session.exitCode,
     now: now
   ).badge
+}
+
+/// The genuine last-activity timestamp used ONLY to drive the stale check.
+/// Unlike `workSessionActivityTimestamp` (which feeds display/sort and falls
+/// back to `session.startedAt`), this returns nil when no real activity signal
+/// exists — the iOS `TerminalSessionSummary` carries no desktop-style
+/// `lastActivityAt`, so a plain terminal has no output timestamp. Falling back
+/// to `startedAt` would flag any terminal open >20min as Stale even with output
+/// seconds ago; nil disables the check, mirroring the desktop caller which
+/// passes the real `lastActivityAt` or null (never `startedAt`).
+private func workSessionStaleActivityTimestamp(
+  session: TerminalSessionSummary,
+  summary: AgentChatSessionSummary?
+) -> String? {
+  summary?.lastActivityAt ?? session.chatIdleSinceAt
 }
 
 /// Small attention capsule shown next to a Work row title. Amber for needs_you

--- a/apps/ios/ADE/Views/Work/WorkSessionGrouping.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionGrouping.swift
@@ -55,6 +55,12 @@ struct WorkSessionGroup: Identifiable, Equatable {
     self.laneIcon = laneIcon
   }
 
+  /// Lane id for by-lane sections (id is `lane:<laneId>`); nil for status/time
+  /// groupings whose headers span multiple lanes and carry no single PR tag.
+  var laneId: String? {
+    id.hasPrefix("lane:") ? String(id.dropFirst("lane:".count)) : nil
+  }
+
   static func == (lhs: WorkSessionGroup, rhs: WorkSessionGroup) -> Bool {
     lhs.id == rhs.id
       && lhs.label == rhs.label

--- a/apps/ios/ADE/Views/Work/WorkStatusAndFormattingHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkStatusAndFormattingHelpers.swift
@@ -51,15 +51,9 @@ func workPendingChatCreationOptimisticSession(
 }
 
 func isChatSession(_ session: TerminalSessionSummary) -> Bool {
-  let raw = session.toolType?
-    .trimmingCharacters(in: .whitespacesAndNewlines)
-    .lowercased() ?? ""
-  guard !raw.isEmpty else { return false }
-  // Must match desktop `isChatToolType` (`apps/desktop/src/renderer/lib/sessions.ts`) — explicit chat tools plus `*-chat` providers.
-  if raw == "codex-chat" || raw == "claude-chat" || raw == "opencode-chat" || raw == "cursor" {
-    return true
-  }
-  return raw.hasSuffix("-chat")
+  // Single source of truth for the chat-tool predicate (mirrors desktop
+  // `isChatToolType`); `isWorkChatToolType` lives in WorkSessionCanonicalState.
+  isWorkChatToolType(session.toolType)
 }
 
 func isRunOwnedSession(_ session: TerminalSessionSummary) -> Bool {

--- a/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
+++ b/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
@@ -1,0 +1,338 @@
+import XCTest
+@testable import ADE
+
+/// Table-driven coverage for the Work-tab canonical session vocabulary — the
+/// iOS mirror of desktop `sessionCanonicalState.ts`. Locks the precedence chain,
+/// the exact 20-minute stale boundary, and the no-badge-for-calm-states rule.
+final class WorkSessionCanonicalStateTests: XCTestCase {
+  private let now = Date(timeIntervalSince1970: 1_780_000_000)
+
+  private func iso(_ date: Date) -> String {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return f.string(from: date)
+  }
+
+  /// lastActivityAt for a session that has been silent for `seconds`.
+  private func silentFor(_ seconds: TimeInterval) -> String {
+    iso(now.addingTimeInterval(-seconds))
+  }
+
+  // MARK: - Precedence
+
+  func testDeterministicNeedsInputBeatsEverything() {
+    struct Case {
+      let name: String
+      let status: String
+      let runtimeState: String?
+      let toolType: String?
+      let pendingInputItemId: String?
+      let lastActivityAt: String?
+      let exitCode: Int?
+    }
+
+    let cases: [Case] = [
+      Case(
+        name: "pendingInput beats stale",
+        status: "running",
+        runtimeState: "running",
+        toolType: "codex",
+        pendingInputItemId: "item-1",
+        lastActivityAt: silentFor(30 * 60),
+        exitCode: nil
+      ),
+      Case(
+        name: "waiting-input beats stale",
+        status: "running",
+        runtimeState: "waiting-input",
+        toolType: "codex",
+        pendingInputItemId: nil,
+        lastActivityAt: silentFor(30 * 60),
+        exitCode: nil
+      ),
+      Case(
+        name: "waiting-input beats calm idle chat preview",
+        status: "running",
+        runtimeState: "waiting-input",
+        toolType: "codex-chat",
+        pendingInputItemId: nil,
+        lastActivityAt: iso(now),
+        exitCode: nil
+      ),
+      Case(
+        name: "pendingInput beats a non-zero exit (deterministic ask still actionable)",
+        status: "ended",
+        runtimeState: "running",
+        toolType: "codex",
+        pendingInputItemId: "item-2",
+        lastActivityAt: iso(now),
+        exitCode: 7
+      ),
+    ]
+
+    for c in cases {
+      let state = workCanonicalSessionState(
+        status: c.status,
+        runtimeState: c.runtimeState,
+        toolType: c.toolType,
+        pendingInputItemId: c.pendingInputItemId,
+        lastActivityAt: c.lastActivityAt,
+        exitCode: c.exitCode,
+        now: now
+      )
+      XCTAssertEqual(state.phase, .needsYou, c.name)
+      XCTAssertEqual(state.badge?.kind, .needsYou, c.name)
+      XCTAssertEqual(state.badge?.label, "Needs you", c.name)
+    }
+  }
+
+  func testFailedOnlyForEndedNonCleanExitOrKilled() {
+    // Non-zero exit on an ended session → failed.
+    let failedExit = workCanonicalSessionState(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 1, now: now)
+    XCTAssertEqual(failedExit.phase, .failed)
+    XCTAssertEqual(failedExit.badge?.label, "Failed")
+
+    // Killed runtime → failed even with a nil exit code.
+    let killed = workCanonicalSessionState(status: "ended", runtimeState: "killed", toolType: "codex", exitCode: nil, now: now)
+    XCTAssertEqual(killed.phase, .failed)
+
+    // Clean exit (0) → calm ended, no badge.
+    let clean = workCanonicalSessionState(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 0, now: now)
+    XCTAssertEqual(clean.phase, .ended)
+    XCTAssertNil(clean.badge)
+
+    // A non-zero exit while still running is ignored (failure is an ended-only
+    // signal); the session stays running.
+    let runningWithCode = workCanonicalSessionState(status: "running", runtimeState: "running", toolType: "codex", lastActivityAt: iso(now), exitCode: 5, now: now)
+    XCTAssertEqual(runningWithCode.phase, .running)
+    XCTAssertNil(runningWithCode.badge)
+  }
+
+  func testStaleBoundaryIsExactlyTwentyMinutes() {
+    // Just under 20 minutes of silence → still running (no capsule).
+    let justUnder = workCanonicalSessionState(
+      status: "running",
+      runtimeState: "running",
+      toolType: "codex",
+      lastActivityAt: silentFor(sessionStaleAfterSeconds - 1),
+      now: now
+    )
+    XCTAssertEqual(justUnder.phase, .running)
+    XCTAssertNil(justUnder.badge)
+
+    // Exactly at the threshold → stale.
+    let exactly = workCanonicalSessionState(
+      status: "running",
+      runtimeState: "running",
+      toolType: "codex",
+      lastActivityAt: silentFor(sessionStaleAfterSeconds),
+      now: now
+    )
+    XCTAssertEqual(exactly.phase, .stale)
+    XCTAssertEqual(exactly.badge?.kind, .stale)
+    XCTAssertEqual(exactly.badge?.label, "Stale")
+  }
+
+  func testStaleBeatsRunningPreviewHeuristic() {
+    // Silent past threshold AND a prompt-like preview → stale wins (heuristic is
+    // consulted only for otherwise-plain running sessions).
+    let state = workCanonicalSessionState(
+      status: "running",
+      runtimeState: "running",
+      toolType: "codex",
+      lastOutputPreview: "Continue? (y/n)",
+      lastActivityAt: silentFor(sessionStaleAfterSeconds + 60),
+      now: now
+    )
+    XCTAssertEqual(state.phase, .stale)
+  }
+
+  // MARK: - Preview heuristic (running → needs_you, LAST)
+
+  func testPreviewHeuristicUpgradesRunningToNeedsYou() {
+    let prompts = ["Continue? (y/n)", "Press enter to proceed", "Allow this action? (Y)es / (N)o"]
+    for prompt in prompts {
+      let state = workCanonicalSessionState(
+        status: "running",
+        runtimeState: "running",
+        toolType: "codex",
+        lastOutputPreview: prompt,
+        lastActivityAt: iso(now),
+        now: now
+      )
+      XCTAssertEqual(state.phase, .needsYou, "prompt: \(prompt)")
+    }
+  }
+
+  func testPreviewHeuristicIgnoredForEndedSessions() {
+    // A prompt-like preview never resurrects an ended session — the heuristic
+    // only upgrades a live running session.
+    let state = workCanonicalSessionState(
+      status: "ended",
+      runtimeState: "exited",
+      toolType: "codex",
+      lastOutputPreview: "Continue? (y/n)",
+      exitCode: 0,
+      now: now
+    )
+    XCTAssertEqual(state.phase, .ended)
+    XCTAssertNil(state.badge)
+  }
+
+  func testBenignPreviewLeavesRunningCalm() {
+    let state = workCanonicalSessionState(
+      status: "running",
+      runtimeState: "running",
+      toolType: "codex",
+      lastOutputPreview: "Compiling module ADE (43 files)",
+      lastActivityAt: iso(now),
+      now: now
+    )
+    XCTAssertEqual(state.phase, .running)
+    XCTAssertNil(state.badge)
+  }
+
+  // MARK: - No badge for calm states
+
+  func testCalmStatesCarryNoBadge() {
+    // Fresh running CLI.
+    let running = workCanonicalSessionState(status: "running", runtimeState: "running", toolType: "codex", lastActivityAt: iso(now), now: now)
+    XCTAssertEqual(running.phase, .running)
+    XCTAssertNil(running.badge)
+
+    // Idle chat rests between turns → ready.
+    let idleChat = workCanonicalSessionState(status: "running", runtimeState: "idle", toolType: "codex-chat", lastActivityAt: iso(now), now: now)
+    XCTAssertEqual(idleChat.phase, .ready)
+    XCTAssertNil(idleChat.badge)
+
+    // Idle CLI → idle (calm, no deterministic ask).
+    let idleCli = workCanonicalSessionState(status: "running", runtimeState: "idle", toolType: "codex", lastActivityAt: iso(now), now: now)
+    XCTAssertEqual(idleCli.phase, .idle)
+    XCTAssertNil(idleCli.badge)
+
+    // Ended chat rests, ready for input — never "ended".
+    let endedChat = workCanonicalSessionState(status: "ended", runtimeState: "exited", toolType: "codex-chat", exitCode: 0, now: now)
+    XCTAssertEqual(endedChat.phase, .ready)
+    XCTAssertNil(endedChat.badge)
+  }
+
+  // MARK: - Chat-tool predicate
+
+  func testChatToolTypePredicate() {
+    for chat in ["codex-chat", "claude-chat", "opencode-chat", "cursor", "droid-chat"] {
+      XCTAssertTrue(isWorkChatToolType(chat), chat)
+    }
+    for cli in ["codex", "claude", "droid", "run-shell", nil, ""] {
+      XCTAssertFalse(isWorkChatToolType(cli), cli ?? "nil")
+    }
+  }
+
+  // MARK: - Row wrapper (iOS field mapping)
+
+  func testCapsuleBadgeMapsChatAwaitingInputToNeedsYou() {
+    let session = makeSession(status: "running", runtimeState: "running", toolType: "codex-chat")
+    let summary = makeChatSummary(status: "active", awaitingInput: true)
+    let badge = workSessionCapsuleBadge(session: session, summary: summary, now: now)
+    XCTAssertEqual(badge?.kind, .needsYou)
+  }
+
+  func testCapsuleBadgeSurfacesFailedExit() {
+    let session = makeSession(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 130)
+    let badge = workSessionCapsuleBadge(session: session, summary: nil, now: now)
+    XCTAssertEqual(badge?.kind, .failed)
+  }
+
+  func testCapsuleBadgeNilForFreshRunning() {
+    let session = makeSession(status: "running", runtimeState: "running", toolType: "codex", startedAt: iso(now))
+    let badge = workSessionCapsuleBadge(session: session, summary: nil, now: now)
+    XCTAssertNil(badge)
+  }
+
+  // MARK: - Fixtures
+
+  private func makeSession(
+    status: String,
+    runtimeState: String,
+    toolType: String?,
+    exitCode: Int? = nil,
+    pendingInputItemId: String? = nil,
+    lastOutputPreview: String? = nil,
+    startedAt: String? = nil
+  ) -> TerminalSessionSummary {
+    TerminalSessionSummary(
+      id: "s-1",
+      laneId: "lane-1",
+      laneName: "feature/work",
+      ptyId: nil,
+      tracked: true,
+      pinned: false,
+      manuallyNamed: nil,
+      goal: nil,
+      toolType: toolType,
+      title: "Session",
+      status: status,
+      startedAt: startedAt ?? iso(now),
+      endedAt: nil,
+      archivedAt: nil,
+      exitCode: exitCode,
+      transcriptPath: "",
+      headShaStart: nil,
+      headShaEnd: nil,
+      lastOutputPreview: lastOutputPreview,
+      summary: nil,
+      runtimeState: runtimeState,
+      resumeCommand: nil,
+      resumeMetadata: nil,
+      chatIdleSinceAt: nil,
+      chatSessionId: nil,
+      pendingInputItemId: pendingInputItemId
+    )
+  }
+
+  private func makeChatSummary(status: String, awaitingInput: Bool?) -> AgentChatSessionSummary {
+    AgentChatSessionSummary(
+      sessionId: "chat-1",
+      laneId: "lane-1",
+      provider: "codex",
+      model: "gpt-5.4",
+      modelId: nil,
+      sessionProfile: nil,
+      title: nil,
+      goal: nil,
+      reasoningEffort: nil,
+      codexFastMode: nil,
+      fastMode: nil,
+      executionMode: nil,
+      permissionMode: nil,
+      interactionMode: nil,
+      claudePermissionMode: nil,
+      codexApprovalPolicy: nil,
+      codexSandbox: nil,
+      codexConfigSource: nil,
+      opencodePermissionMode: nil,
+      droidPermissionMode: nil,
+      cursorModeSnapshot: nil,
+      cursorModeId: nil,
+      cursorConfigValues: nil,
+      identityKey: nil,
+      surface: nil,
+      automationId: nil,
+      automationRunId: nil,
+      capabilityMode: nil,
+      computerUse: nil,
+      completion: nil,
+      status: status,
+      idleSinceAt: nil,
+      startedAt: iso(now),
+      endedAt: nil,
+      archivedAt: nil,
+      lastActivityAt: iso(now),
+      lastOutputPreview: nil,
+      summary: nil,
+      awaitingInput: awaitingInput,
+      pendingInputItemId: nil,
+      threadId: nil,
+      requestedCwd: nil
+    )
+  }
+}

--- a/docs/features/sync-and-multi-device/push-notifications.md
+++ b/docs/features/sync-and-multi-device/push-notifications.md
@@ -133,6 +133,16 @@ aggregate (2 h running / 24 h waiting) so dead sessions cannot pin
 `activeCount`. `start` fires on 0→N running, `end` (dismissal +5 min)
 when all runs reach a terminal phase.
 
+## One status vocabulary
+
+`apps/desktop/src/shared/sessionCanonicalState.ts` is the canonical mapping
+from session inputs to a phase + attention badge, consumed by the Work tab
+(desktop and the iOS mirror). Its `needs_you` covers the Live Activity's
+`waiting_for_approval`/`waiting_for_input` (wire names unchanged);
+`failed`/`stale`/`running` correspond directly. Its 20-minute stale threshold
+is the human-facing "running but silent" bar — distinct from the relay's APNs
+delivery TTLs and the Live Activity's 10-minute lock-screen stale-date.
+
 ## iOS
 
 - `aps-environment` entitlement + `remote-notification` background mode +

--- a/docs/features/sync-and-multi-device/push-notifications.md
+++ b/docs/features/sync-and-multi-device/push-notifications.md
@@ -58,7 +58,13 @@ re-derives state:
 - `agentChatService.subscribeToEvents` — `approval_request` /
   `structured_question` → waiting phases + alert; `pending_input_resolved`
   clears; failed turn statuses → alert.
-- `ptyService.onExit` — CLI session ended.
+- `ptyService.onSessionRuntimeSignal` — tracked CLI sessions' OSC 133-derived
+  state (`running` / `waiting-input`) feeds Live Activity run rows **only**,
+  never alert pushes: a CLI agent returns to its prompt after every turn, so
+  alerting on waiting-input would ping once per turn. Chat-attached shells and
+  untitled infra rows are filtered out (the chat run already represents them).
+- `ptyService.onExit` — CLI session ended: flips the run to
+  completed/failed in the aggregate; a non-zero exit also alerts.
 - `prPollingService`'s `pr-notification` events — `merge_ready` /
   `checks_failing` alerts (edge-transition gated by that service).
 


### PR DESCRIPTION
Follow-up to #705/#710 — makes session status truthful end to end, producer to pixels.

### Producer (push publisher)
- `ptyService.onSessionRuntimeSignal` (OSC 133-derived) feeds tracked CLI sessions into the agent-runs Live Activity: `running` / `waiting_for_input` rows; `idle` publishes as `stale` (dimmed, not counted active, holds the activity open — no end→push-to-start churn); no alert pushes for CLI prompts (a CLI at its prompt is its resting state) and CLI prompts don't badge the app icon.
- Chat-owned shells and unknown sessions are filtered so a chat's helper shell never double-counts.

### One vocabulary (`shared/sessionCanonicalState.ts`)
Canonical `{phase, badge}` mapping with locked precedence: `pendingInputItemId`/`waiting-input` (deterministic) > failed > stale (running + silent ≥ 20 min) > running, preview-text heuristic consulted LAST (fixes it outvoting deterministic signals; `sessionIndicatorState` now also honors `pendingInputItemId`). `needs_you` ⇔ the Live Activity's waiting phases; wire names unchanged. 17 table-driven tests.

### Consumers
- **Desktop SessionCard**: one-word capsule next to the title — amber "Needs you", red "Failed", outlined "Stale" (clock glyph). Calm states render nothing; zero layout shift; no double-amber on chat cards.
- **Desktop Work lane headers**: primary-open-PR badge (state dot + #num + state) left of the session count, click → PR detail in the PRs tab. ADE-mapped PRs; GitHub-by-branch parity gap noted inline.
- **iOS**: `WorkSessionCanonicalState` mirrors the module exactly (12 unit tests incl. stale boundary); capsules on Work rows; the per-row PR indicator consolidates onto the lane section header with the same `requestedPrNavigation` handoff.
- TUI renders status as dot glyphs, not labels — no change needed (verified).

### PR panel freshness (webhook → UI, previously broken link)
Webhook events polled from the relay updated the DB **silently** — the panel waited for the PR poller's next scheduled tick. `automationIngressService` now fires `onPrStateIngested` when an ingested event changed PR state, wired to `prPollingService.poke()` in both the daemon and desktop-main, so webhook-driven changes surface in the panel immediately.

### Also in this PR
Idle→stale Greptile fix, ADE-branded pairing QR (matches the welcome modal's TestFlight QR treatment), post-#710 reconciliation.

Tests: ade-cli 1526 green; desktop canonical/attention/card/badge/ingress suites green; iOS build + 12 new tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer session status badges across desktop, iOS, and CLI views, including “Needs you,” “Failed,” and “Stale.”
  * Added PR badges in lane/session lists and quicker navigation to the relevant pull request.
  * Improved device pairing QR codes with a more recognizable branded image and stronger scan reliability.

* **Bug Fixes**
  * Terminal and session alerts now update more consistently for runtime changes, inactivity, and completed/failed sessions.
  * PR updates can appear faster after webhook activity instead of waiting for the next refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires CLI session runtime signals into the Live Activity pipeline, introduces a shared canonical session-state vocabulary (`sessionCanonicalState.ts` / `WorkSessionCanonicalState.swift`) that locks the deterministic-signal precedence chain across desktop, iOS, and the push publisher, and fixes the previously broken webhook → PR-panel freshness link by poking the PR poller immediately on ingestion.

- **CLI Live Activity**: `ptyService.onSessionRuntimeSignal` feeds the push publisher; idle maps to `stale` (dimmed, not counted active, holds the activity open without churn); chat-owned shells are filtered via `resolveCliSession`; `countAwaitingAttentionRuns` excludes CLI runs to avoid a pinned-forever badge.
- **Canonical state vocabulary**: One precedence chain (`pendingInputItemId`/`waiting-input` > failed > stale > running with preview heuristic last) shared by desktop capsule badges, iOS `WorkSessionStatusCapsule`, and documented to map onto the Live Activity wire phases; 17 desktop + 12 iOS table-driven tests lock the boundary conditions.
- **Webhook → UI freshness**: `automationIngressService` now fires `onPrStateIngested` when an ingested event actually changed PR state, wired to `prPollingService.poke()` in both the daemon and desktop-main, so panel updates ride the webhook instead of the next scheduled tick.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are additive and well-tested; the two previously flagged bugs are confirmed fixed.

All new logic is covered by table-driven tests on both desktop and iOS. The onPrStateIngested poke is gated on processed and non-duplicate conditions so it will not fire spuriously. The late-binding pattern for pushPublisherForPtySignals and prPollingServiceForIngress is consistent with existing bootstrap patterns.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/services/push/pushPublisherService.ts | CLI runtime signal handling added: `kind` field, `onCliRuntimeSignal`, `countAwaitingAttentionRuns` CLI exclusion, stale-phase TTL pruning, and `onPtyExit` terminal-phase fix. Previously flagged idle→stale and TTL issues are addressed. |
| apps/desktop/src/shared/sessionCanonicalState.ts | New shared vocabulary module with locked precedence chain: pendingInputItemId/waiting-input > failed > stale > running (preview heuristic last). Well-structured with 17 table-driven tests. |
| apps/desktop/src/main/services/automations/automationIngressService.ts | Webhook path now fires `onPrStateIngested` when an ingested event actually changed PR state (processed, non-duplicate, linked PRs present). Return null added to catch handlers for correct assignment typing. |
| apps/desktop/src/renderer/lib/terminalAttention.ts | Added `pendingInputItemId` to `sessionIndicatorState`, fixing it to honor deterministic signals; idle sessions no longer fall through to the preview heuristic. New `sessionCapsuleBadge` delegates to the canonical state module. |
| apps/desktop/src/renderer/components/terminals/SessionListPane.tsx | Lane header refactored from a single `<button>` to `<div>` + inner `<button>` to allow the interactive PR badge alongside the collapse toggle. Adds `useLanePrsByLaneId` hook and `LanePrHeaderBadge` component. |
| apps/ios/ADE/Views/Work/WorkSessionCanonicalState.swift | iOS mirror of the desktop canonical state module: identical precedence chain, 20-minute stale threshold, preview heuristic, `WorkSessionStatusCapsule` view, and `workSessionCapsuleBadge` row wrapper. |
| apps/desktop/src/renderer/components/terminals/SessionCard.tsx | Adds `AttentionCapsule` for three states (needs_you, failed, stale) next to the session title. Suppresses the capsule when the chat-specific amber chip already shows the same condition, preventing double-amber. |
| apps/ade-cli/src/bootstrap.ts | Late-binds `pushPublisherForPtySignals` and `prPollingServiceForIngress` to enable the new onSessionRuntimeSignal→Live Activity bridge and webhook→immediate-poll paths. |
| apps/ios/ADETests/WorkSessionCanonicalStateTests.swift | 12 new XCTest cases covering the stale boundary, precedence chain, preview heuristic gating, and capsule badge mapping. Mirrors the desktop's Vitest table-driven coverage. |
| apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx | QR code upgraded to error-correction level H with the ADE icon excavated in the center; uses the same `publicAssetUrl` helper as the welcome modal. |
| apps/desktop/src/renderer/lib/lanePrBadge.ts | New pure utility: primary-PR selection (open > draft > merged/closed, then recency), state labels, and state colors for lane divider badges. |
| apps/ios/ADE/Views/Work/WorkRootComponents.swift | Lane section header now carries `WorkLanePrIndicator` as a dedicated button, outside the collapse-toggle button. `WorkSessionRow` renders canonical attention capsule from `workSessionCapsuleBadge`. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ptyService.onSessionRuntimeSignal] -->|running / waiting-input / idle| B[onCliRuntimeSignal]
    B -->|waiting-input| C[phase: waiting_for_input]
    B -->|idle| D[phase: stale]
    B -->|running| E[phase: running]
    F[ptyService.onPtyExit] -->|exitCode=0| G[phase: completed]
    F -->|exitCode not 0| H[phase: failed + alert push]
    C & E & G & H --> I[scheduleFlush]
    D --> I
    I --> J{activeCount > 0?}
    J -->|yes, not started| K[start Live Activity]
    J -->|no, dormantCount > 0| L[update - stale holds open]
    J -->|no, dormantCount=0, started| M[end Live Activity]
    N[GitHub webhook] --> O[automationIngressService]
    O -->|processed and linkedPrIds present| P[onPrStateIngested]
    P --> Q[prPollingService.poke]
    Q --> R[prs-updated to renderer]
    S[sessionCanonicalState] -->|pendingInputItemId or waiting-input| T[needs_you badge]
    S -->|non-zero exit or killed| U[failed badge]
    S -->|running + silent 20min| V[stale badge]
    S -->|calm states| W[no badge]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ptyService.onSessionRuntimeSignal] -->|running / waiting-input / idle| B[onCliRuntimeSignal]
    B -->|waiting-input| C[phase: waiting_for_input]
    B -->|idle| D[phase: stale]
    B -->|running| E[phase: running]
    F[ptyService.onPtyExit] -->|exitCode=0| G[phase: completed]
    F -->|exitCode not 0| H[phase: failed + alert push]
    C & E & G & H --> I[scheduleFlush]
    D --> I
    I --> J{activeCount > 0?}
    J -->|yes, not started| K[start Live Activity]
    J -->|no, dormantCount > 0| L[update - stale holds open]
    J -->|no, dormantCount=0, started| M[end Live Activity]
    N[GitHub webhook] --> O[automationIngressService]
    O -->|processed and linkedPrIds present| P[onPrStateIngested]
    P --> Q[prPollingService.poke]
    Q --> R[prs-updated to renderer]
    S[sessionCanonicalState] -->|pendingInputItemId or waiting-input| T[needs_you badge]
    S -->|non-zero exit or killed| U[failed badge]
    S -->|running + silent 20min| V[stale badge]
    S -->|calm states| W[no badge]
```

</a>

<sub>Reviews (5): Last reviewed commit: ["fix: ship round 2 — hoist PR badge out o..."](https://github.com/arul28/ade/commit/96597d047cf190b9026e78bf9dde94021413eff8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42050559)</sub>

<!-- /greptile_comment -->