### PR TITLE
release: changelog for v1.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.13] - 2026-07-06
+
+### Added
+
+- Added mobile push notifications, Live Activities, APNs-backed delivery, deployed push/tunnel relay workers, per-device notification preferences, and optional cloud relay fallback.
+- Added smart universal-link pairing QR payloads, Secure Enclave DPoP proofs for paired hellos, fail-closed sync ingress controls, and an offline outbox for queued mobile chat creation.
+- Added cursor-relative slash command and `@file` composer chips across desktop, ADE Code, and iOS.
+- Added Claude Workflow progress rows, CLI-spawned child-chat lineage, "Subagent spawned" transcript notices, and strict Mosaic v1 interactive cards for Claude-family chats.
+
+### Changed
+
+- Reworked CTO into one persistent-memory agent thread across desktop and iOS, with file-backed memory, daily journals, model-switch preservation, memory tools, and a simpler setup/settings flow.
+- Improved ADE Code and CLI reliability with per-provider Chat/CLI mode, provider-neutral tracked CLI sessions, faster TUI rendering, safer JSON-RPC/event-buffer handling, closed-session browsing, `/secrets`, and remote sync hardening.
+- Improved mobile PR details with virtualized timeline rows, desktop-style merge requirements, metadata cards, freshness reloads, and Work-row "Open in PRs tab" routing.
+- Improved mobile connection, Work list, lane creation, and terminal behavior, including Tailscale-off warnings, attributed pairing revocation, bounded port probes, standalone CLI rows, remote-first lane bases, background AI lane naming, and live-tail terminal pinning.
+- Improved the landing page with lighter animations, cheaper showcase transitions, and bounded media loading.
+- Kept the current mobile marketing version for a build-number-only iOS TestFlight update.
+
+### Removed
+
+- Removed the legacy CTO worker/hiring subsystem, Linear workflow engine, pipeline builder, Team/Workflows surfaces, and dead CTO/flow CLI paths.
+
+### Fixed
+
+- Fixed stale quick-open cache races, partially-built quick-open index reads, unmatched composer-token dead keys, iOS suggestion cache drift, and iOS TextKit retention during composer chip usage.
+- Fixed sync-host startup loops after transient cross-channel conflicts, queue handling for `host_unavailable`, old failed CLI sessions pinning hub attention, and terminal live-tail drift after keyboard or font layout changes.
+
 ## [1.2.12] - 2026-07-03
 
 ### Added
@@ -529,7 +556,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.12...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.13...HEAD
+[1.2.13]: https://github.com/arul28/ADE/compare/v1.2.12...v1.2.13
 [1.2.12]: https://github.com/arul28/ADE/compare/v1.2.11...v1.2.12
 [1.2.11]: https://github.com/arul28/ADE/compare/v1.2.10...v1.2.11
 [1.2.10]: https://github.com/arul28/ADE/compare/v1.2.9...v1.2.10

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.12">
-  v1.2.12 - GitHub PR freshness in installed builds, cross-project chat quick-look, a mobile hub and chat overhaul, faster Lanes tab, and build-number-only iOS sync updates.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.13">
+  v1.2.13 - Push notifications, Live Activities, smart pairing, composer chips anywhere, the single-thread CTO, richer agent workflow visibility, and build-number-only iOS updates.
 </Card>

--- a/changelog/v1.2.13.mdx
+++ b/changelog/v1.2.13.mdx
@@ -1,0 +1,32 @@
+---
+title: "v1.2.13"
+description: "Release notes for ADE v1.2.13 - July 6, 2026"
+---
+
+v1.2.13 adds mobile push notifications, Live Activities, smart pairing, and optional cloud relay; makes composer chips work anywhere you type; turns CTO into one persistent-memory thread; and brings richer agent workflow visibility across desktop, ADE Code, and iOS. iOS stays on its current marketing version and gets a build-number-only TestFlight update for the same release train.
+
+---
+
+## Desktop
+
+- **Push and relay infrastructure.** ADE now has deployed push and tunnel relay workers, APNs delivery, Live Activity routing, per-device notification preferences, quiet hours, dead-token cleanup, and brain-side event publishing for chats, terminals, and PR updates.
+- **Smart pairing and sync security.** The desktop pairing QR now carries a universal-link payload with machine identity, address candidates, and relay metadata; paired devices can use Secure Enclave DPoP proofs, fail-closed machine ingress, and an offline outbox that renders queued chat creation while the phone reconnects.
+- **Composer chips anywhere.** Slash commands and `@file` mentions are cursor-relative in desktop composers and ADE Code, with exact trigger-span replacement, faster command-menu debounce, same-frame cache hits, lazy quick-open indexing, and stale-result guards.
+- **Agent workflow visibility.** Claude Workflow progress now fans out into live agent rows, CLI-spawned child chats keep parent lineage and a spawn notice, and Claude-family chats can render strict Mosaic v1 interactive cards without executing agent-authored code.
+- **CTO as one thread.** The CTO tab is now a single long-running agent thread with file-backed smart memory, daily journals, model switching that preserves context, memory tools, a slimmer settings surface, and the old worker/workflow pipeline removed.
+- **ADE Code and remote runtime hardening.** ADE Code gains a per-provider Chat/CLI interface choice, provider-neutral tracked CLI sessions, local provider permission parity, closed-session browsing, `/secrets`, faster TUI rendering, safer JSON-RPC/event-buffer handling, and more resilient remote sync startup.
+- **Remote-first lane and session parity.** CLI sessions appear as real Work entries, lane creation defaults to the desktop remote-first base policy when callers omit a base branch, and transient sync-host conflicts retry instead of stranding paired phones.
+- **Website performance.** The landing page drops heavy looping animations and blur filters, keeps showcase media mounted with cheaper CSS crossfades, and bounds initial image loading so the product page starts faster.
+
+---
+
+## iOS
+
+- **Push notifications and Live Activities.** The app registers for push after pairing, deep-links alert notifications back into ADE, shows up to three active agent runs on the Lock Screen and Dynamic Island, and adds push delivery settings with quiet hours.
+- **Smart pairing, relay fallback, and DPoP.** The scanner understands the new universal-link QR payload, can reconnect an already-paired machine, supports optional cloud relay fallback, and signs paired hellos with Secure Enclave DPoP proofs once upgraded.
+- **Composer chips anywhere.** The mobile composer now detects slash commands and `@file` mentions at the cursor, shows an inline suggestion strip above the keyboard, renders confirmed tokens as chips, and keeps Chat/CLI mode preferences per project.
+- **CTO mobile parity.** The CTO tab matches the new single-thread model with the brain tab icon, one-card setup, personality/work-style choices, memory access, and a non-blocking "Set up later" path.
+- **PR detail rebuild.** Mobile PR details move to a flatter adaptive palette, virtualized overview rows, desktop-style merge requirements, metadata cards, fresh sidecar reloads, comment expansion fixes, and an "Open in PRs tab" action from Work rows.
+- **Connection reliability.** iOS now warns when a saved machine expects Tailscale but the phone is off tailnet, preserves credentials through unattributed auth failures, bounds stale-port probes, and handles Tailscale IPv6 routes correctly.
+- **Work list and lane creation parity.** Standalone CLI sessions show up whether ended or live, failed old CLI sessions no longer pin hub attention, mobile lane creation defaults to remote-first bases, and AI lane naming runs in the background after creation instead of blocking launch.
+- **Terminal live tail.** The terminal view keeps the live tail pinned through keyboard, layout, and font-size changes while preserving manual scroll position when the user scrolls away.

--- a/docs.json
+++ b/docs.json
@@ -178,6 +178,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.13",
               "changelog/v1.2.12",
               "changelog/v1.2.11",
               "changelog/v1.2.10",


### PR DESCRIPTION
Changelog for v1.2.13. Tag will be cut after this lands on main.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the v1.2.13 changelog and docs release notes. The main changes are:

- Adds the v1.2.13 entry to `CHANGELOG.md`.
- Adds a dedicated `changelog/v1.2.13.mdx` release notes page.
- Updates the changelog index card to point to v1.2.13.
- Adds v1.2.13 to the docs sidebar in newest-first order.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are documentation and navigation updates for a release changelog. Version ordering, release links, and sidebar placement match the existing structure. No functional or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the preview probe for v1.2.13 - ADE returned a 200 response and included the changelog content in the Desktop/iOS release notes.
- Confirmed the Mintlify docs app renders the v1.2.13 changelog page with real styles in the preview, not a mocked page.
- Reviewed the server logs and saw that the preview reported ready, along with a non-blocking warning about a missing changelog file for v1.2.13 while the route rendered correctly.

<a href="https://app.greptile.com/trex/runs/13394611/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds the v1.2.13 changelog entry and updates compare links from v1.2.13 onward; no issues found. |
| changelog/index.mdx | Updates the latest-release card to point at v1.2.13; no issues found. |
| changelog/v1.2.13.mdx | Adds the dedicated v1.2.13 release notes page with desktop and iOS sections; no issues found. |
| docs.json | Adds v1.2.13 to the changelog sidebar in newest-first order; no issues found. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
A[CHANGELOG.md] --> B[v1.2.13 release entry]
B --> C[Updated compare links]
D[changelog/v1.2.13.mdx] --> E[Dedicated docs release page]
F[changelog/index.mdx] --> G[Latest release card points to v1.2.13]
H[docs.json] --> I[Sidebar includes v1.2.13]
G --> E
I --> E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
A[CHANGELOG.md] --> B[v1.2.13 release entry]
B --> C[Updated compare links]
D[changelog/v1.2.13.mdx] --> E[Dedicated docs release page]
F[changelog/index.mdx] --> G[Latest release card points to v1.2.13]
H[docs.json] --> I[Sidebar includes v1.2.13]
G --> E
I --> E
```

</a>

<sub>Reviews (1): Last reviewed commit: ["release: changelog for v1.2.13"](https://github.com/arul28/ade/commit/d2972e2b7ee05968e4f46d349cb1d9bdb27fc017) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42065163)</sub>

<!-- /greptile_comment -->