### PR TITLE
docs: App Clip signing/provisioning for the release flow

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -439,6 +439,7 @@ Fail fast if keychain auth is broken.
 ### 7c. iOS signing gotchas (mirrored from AGENTS.md — keep in sync)
 
 - Project uses **automatic** signing (`CODE_SIGN_STYLE = Automatic`, `DEVELOPMENT_TEAM = VQ372F39G6`). `apps/ios/ExportOptions.plist` ships with `signingStyle = manual` + named profiles for CI determinism. Local ad-hoc exports need `signingStyle = automatic` instead (drop the per-bundle profile map). `apps/ios/ExportOptions.auto.plist` is the ready-to-use auto-signing variant.
+- **Three embedded bundles must all be provisioned for a manual-signing export**: the app (`com.ade.ios`), widgets (`com.ade.ios.widgets`), and the **App Clip** (`com.ade.ios.Clip`, added PR #706). `ExportOptions.plist` maps all three to named App Store profiles; the clip's — **`ADE App Clip App Store`** — is already minted in ASC. If a manual export fails signing the clip, the profile is missing/expired: `asc profiles create --name "ADE App Clip App Store" --profile-type IOS_APP_STORE --bundle 97ZL5TPJB8 --certificate <dist-cert-ids>`. Using `ExportOptions.auto.plist` avoids the issue entirely (Xcode provisions the clip via `-allowProvisioningUpdates`).
 - `asc signing fetch` only downloads provisioning profiles and the `.cer` — it does **not** include the private key. Don't expect it to make local signing work on its own.
 - Local exports need the ASC API key passed to `xcodebuild`. In addition to `-allowProvisioningUpdates`:
   ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ Release flows live behind `asc` (installed at `/opt/homebrew/bin/asc`). There's 
 iOS signing gotchas (don't repeat these):
 
 - The iOS project uses **automatic** signing (`CODE_SIGN_STYLE = Automatic`, `DEVELOPMENT_TEAM = VQ372F39G6`). `apps/ios/ExportOptions.plist` ships with `signingStyle = manual` + named profiles for CI/archive determinism, but local ad-hoc exports need `signingStyle = automatic` instead (drop the per-bundle profile map).
+- The ADE app **embeds an App Clip** (`com.ade.ios.Clip`, target `ADEClip`, added in PR #706) alongside the app (`com.ade.ios`) and widgets (`com.ade.ios.widgets`). A manual-signing export needs a distribution profile for **every** embedded bundle. The clip's — **`ADE App Clip App Store`** (already minted in ASC, bound to the same distribution certs as the app) — is mapped in `ExportOptions.plist`. If a manual export ever fails signing the clip, the profile is missing/expired: re-mint with `asc profiles create --name "ADE App Clip App Store" --profile-type IOS_APP_STORE --bundle 97ZL5TPJB8 --certificate <dist-cert-ids>`. `ExportOptions.auto.plist` avoids the whole issue — Xcode provisions the clip via `-allowProvisioningUpdates`.
 - `asc signing fetch` only downloads provisioning profiles and the `.cer` — it does **not** include the private key. Don't expect it to make local signing work on its own.
 - Local exports need the App Store Connect API key passed to `xcodebuild` so it can create/fetch missing Distribution assets on demand. Add these flags (in addition to `-allowProvisioningUpdates`):
   ```


### PR DESCRIPTION
Documents the App Clip's release-signing requirement so a future context-free `/release` agent doesn't hit a surprise signing failure.

## Why
The ADE app now embeds an App Clip (`com.ade.ios.Clip`, PR #706). A manual-signing export (`ExportOptions.plist`) must provision **three** bundles — app, widgets, **and** clip. Neither AGENTS.md nor the release skill mentioned the clip, so an agent using the manual plist would fail at archive-export with a confusing signing error (the auto plist would silently succeed — a coin-flip depending on which path it picks).

## What
- **Minted the missing profile** in ASC: `ADE App Clip App Store` (bound to the same distribution certs as the app). No code — this is why it's not in the diff; recorded here for traceability.
- **AGENTS.md** + **release skill 7c**: document the clip bundle, the minted profile, the re-mint command, and the `ExportOptions.auto.plist` escape hatch.

Doc-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fdocs-appclip-signing-1f6b72df num=714 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fdocs-appclip-signing-1f6b72df&amp;pr=714">ade/docs-appclip-signing-1f6b72df branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=714">PR #714</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR documents the App Clip signing requirement for iOS release flows. The main changes are:

- Adds the App Clip bundle to manual signing guidance in `AGENTS.md`.
- Mirrors the same guidance in the release skill documentation.
- Records the App Clip profile name, re-mint command, and automatic export fallback.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed documentation. The added bundle ids and profile mapping match the visible iOS export configuration.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the release signing documents validation script to verify the signing documentation and content.
- Opened and inspected the validation log to review the test outcomes and blockers.
- The validation reported PASS\_WITH\_BLOCKERS due to missing macOS/iOS tools and a missing SKILL.md in checkout, while all executable content and plist assertions passed.

<a href="https://app.greptile.com/trex/runs/13494375/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds App Clip signing guidance for manual iOS exports and the automatic export fallback. |
| .agents/skills/release/SKILL.md | Mirrors the App Clip signing guidance in the release skill documentation. |

<sub>Reviews (1): Last reviewed commit: ["docs: record App Clip signing/provisioni..."](https://github.com/arul28/ade/commit/7b99ec25a4090747d3a38b0710aa4b4d5b88e92f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42262861)</sub>

<!-- /greptile_comment -->