### PR TITLE
Cursor chat: surface SDK errors, sync permission mode across clients, consolidate mobile approvals

### DIFF
--- a/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
+++ b/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
@@ -142,6 +142,9 @@ function normalizePeerMetadata(value: unknown): SyncPeerMetadata | null {
       .map((capability) => capability.trim())
       .filter(Boolean)
     : [];
+  const appVersion = optionalString(record.appVersion);
+  const appBuild = optionalString(record.appBuild);
+  const bundleIdentifier = optionalString(record.bundleIdentifier);
   const dbVersionBySite: Record<string, number> = {};
   if (record.dbVersionBySite && typeof record.dbVersionBySite === "object" && !Array.isArray(record.dbVersionBySite)) {
     for (const [site, version] of Object.entries(record.dbVersionBySite as Record<string, unknown>)) {
@@ -165,6 +168,9 @@ function normalizePeerMetadata(value: unknown): SyncPeerMetadata | null {
     dbVersion: Math.max(0, Math.floor(Number(record.dbVersion ?? 0) || 0)),
     ...(Object.keys(dbVersionBySite).length > 0 ? { dbVersionBySite } : {}),
     capabilities,
+    ...(appVersion ? { appVersion } : {}),
+    ...(appBuild ? { appBuild } : {}),
+    ...(bundleIdentifier ? { bundleIdentifier } : {}),
   };
 }
 

--- a/apps/ade-cli/src/services/sync/deviceRegistryService.ts
+++ b/apps/ade-cli/src/services/sync/deviceRegistryService.ts
@@ -470,6 +470,9 @@ export function createDeviceRegistryService(args: DeviceRegistryServiceArgs) {
       lastPort: extras.lastPort ?? ("remotePort" in peer ? peer.remotePort : null),
       metadata: {
         dbVersion: peer.dbVersion,
+        ...(peer.appVersion ? { appVersion: peer.appVersion } : {}),
+        ...(peer.appBuild ? { appBuild: peer.appBuild } : {}),
+        ...(peer.bundleIdentifier ? { bundleIdentifier: peer.bundleIdentifier } : {}),
         ...(extras.metadata ?? {}),
       },
     });

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -974,6 +974,9 @@ function parseHelloPayload(payload: unknown): SyncHelloPayload | null {
           .map((capability) => capability.trim())
           .filter(Boolean)
         : [],
+      ...(toOptionalString(peer.appVersion) ? { appVersion: toOptionalString(peer.appVersion)! } : {}),
+      ...(toOptionalString(peer.appBuild) ? { appBuild: toOptionalString(peer.appBuild)! } : {}),
+      ...(toOptionalString(peer.bundleIdentifier) ? { bundleIdentifier: toOptionalString(peer.bundleIdentifier)! } : {}),
     },
     auth: normalizedAuth,
   };

--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.test.ts
@@ -305,12 +305,13 @@ describe("lanes.suggestName", () => {
 
   it("returns the model-suggested name on success", async () => {
     const suggestLaneNameFromPrompt = vi.fn().mockResolvedValue("refactor-auth-flow");
-    const { service } = createService({ agentChatService: { suggestLaneNameFromPrompt } });
+    const { service, logger } = createService({ agentChatService: { suggestLaneNameFromPrompt } });
 
     const result = await service.execute(makePayload("lanes.suggestName", {
       laneId: "lane-1",
       prompt: "please refactor the auth flow",
       modelId: "anthropic/claude-haiku-4-5",
+      fallbackName: "fallback-auth-flow",
     }));
 
     expect(result).toEqual({ name: "refactor-auth-flow" });
@@ -318,6 +319,12 @@ describe("lanes.suggestName", () => {
       laneId: "lane-1",
       prompt: "please refactor the auth flow",
       modelId: "anthropic/claude-haiku-4-5",
+      fallbackName: "fallback-auth-flow",
+    });
+    expect(logger.info).toHaveBeenCalledWith("sync.lanes_suggest_name_succeeded", {
+      laneId: "lane-1",
+      modelId: "anthropic/claude-haiku-4-5",
+      name: "refactor-auth-flow",
     });
   });
 

--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
@@ -2153,18 +2153,50 @@ function registerLaneRemoteCommands({ args, register }: RemoteCommandRegistratio
       const provided = parsed.fallbackName?.trim();
       return provided && provided.length ? provided : deriveDeterministicLaneNameFromPrompt(parsed.prompt);
     };
-    if (!args.agentChatService) return { name: fallback() };
+    if (!args.agentChatService) {
+      const name = fallback();
+      args.logger.warn("sync.lanes_suggest_name_service_unavailable", {
+        laneId: parsed.laneId,
+        modelId: parsed.modelId,
+        fallbackName: name,
+      });
+      return { name };
+    }
     try {
       const name = await args.agentChatService.suggestLaneNameFromPrompt(parsed);
       const trimmed = typeof name === "string" ? name.trim() : "";
-      return { name: trimmed.length ? trimmed : fallback() };
+      if (!trimmed.length) {
+        const fallbackName = fallback();
+        args.logger.warn("sync.lanes_suggest_name_empty_result", {
+          laneId: parsed.laneId,
+          modelId: parsed.modelId,
+          fallbackName,
+        });
+        return { name: fallbackName };
+      }
+      if (trimmed === fallback()) {
+        args.logger.info("sync.lanes_suggest_name_kept_fallback", {
+          laneId: parsed.laneId,
+          modelId: parsed.modelId,
+          fallbackName: trimmed,
+        });
+        return { name: trimmed };
+      }
+      args.logger.info("sync.lanes_suggest_name_succeeded", {
+        laneId: parsed.laneId,
+        modelId: parsed.modelId,
+        name: trimmed,
+      });
+      return { name: trimmed };
     } catch (error) {
+      const fallbackName = fallback();
       args.logger.warn("sync.lanes_suggest_name_failed", {
         laneId: parsed.laneId,
         modelId: parsed.modelId,
+        fallbackName,
         error: error instanceof Error ? error.message : String(error),
       });
-      return { name: fallback() };
+      return { name: fallbackName };
     }
   });
   register("lanes.createChild", { viewerAllowed: true, queueable: true }, async (payload) => args.laneService.createChild(parseCreateChildLaneArgs(payload)));

--- a/apps/ade-cli/src/services/sync/syncService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncService.test.ts
@@ -136,4 +136,35 @@ describe("createSyncService", () => {
       db.close();
     }
   });
+
+  it("persists peer app provenance in device metadata", async () => {
+    const projectRoot = makeTempRoot("ade-sync-service-device-provenance-");
+    cleanupRoots.push(projectRoot);
+    const db = await openKvDb(path.join(projectRoot, ".ade", "kv.sqlite"), createLogger() as any);
+    (db.sync as { isAvailable?: () => boolean }).isAvailable = () => true;
+    const service = createService(db, projectRoot);
+    const registry = service.getDeviceRegistryService();
+
+    registry.upsertPeerMetadata({
+      deviceId: "phone-1",
+      deviceName: "Arul iPhone",
+      platform: "iOS",
+      deviceType: "phone",
+      siteId: "phone-site",
+      dbVersion: 14,
+      appVersion: "1.1.10",
+      appBuild: "4",
+      bundleIdentifier: "com.ade.ios",
+    });
+
+    expect(registry.getDevice("phone-1")?.metadata).toMatchObject({
+      dbVersion: 14,
+      appVersion: "1.1.10",
+      appBuild: "4",
+      bundleIdentifier: "com.ade.ios",
+    });
+
+    await service.dispose();
+    db.close();
+  });
 });

--- a/apps/ade-cli/src/tuiClient/app.tsx
+++ b/apps/ade-cli/src/tuiClient/app.tsx
@@ -7284,6 +7284,42 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
           };
         });
       }
+      // A cross-client mode change (iOS/desktop re-moding the session the TUI is
+      // viewing) arrives as a transient session_meta_updated carrying the new
+      // permission/interaction fields. The composer footer reads modelState, not
+      // the summary, so re-seed it directly for the active chat — mirroring the
+      // desktop AgentChatPane handler. Apply via raw setModelState (NOT
+      // applyModelState) so we don't schedule a commit and echo back to the
+      // server. Skip while a local commit is pending: the user's own pick wins
+      // and the server will echo it back momentarily.
+      if (
+        envelope.event.type === "session_meta_updated"
+        && isActiveSessionEvent
+        && !pendingModelCommitStateRef.current
+      ) {
+        const meta = envelope.event;
+        setModelState((prev) => {
+          const next: AdeCodeModelState = {
+            ...prev,
+            ...(meta.permissionMode !== undefined ? { permissionMode: meta.permissionMode } : {}),
+            ...(meta.interactionMode !== undefined ? { interactionMode: meta.interactionMode ?? prev.interactionMode } : {}),
+            ...(meta.claudePermissionMode !== undefined ? { claudePermissionMode: meta.claudePermissionMode } : {}),
+            ...(meta.codexApprovalPolicy !== undefined ? { codexApprovalPolicy: meta.codexApprovalPolicy } : {}),
+            ...(meta.codexSandbox !== undefined ? { codexSandbox: meta.codexSandbox } : {}),
+            ...(meta.codexConfigSource !== undefined ? { codexConfigSource: meta.codexConfigSource } : {}),
+            ...(meta.opencodePermissionMode !== undefined ? { opencodePermissionMode: meta.opencodePermissionMode } : {}),
+            ...(meta.droidPermissionMode !== undefined ? { droidPermissionMode: meta.droidPermissionMode } : {}),
+            ...(meta.cursorModeId !== undefined || meta.cursorModeSnapshot !== undefined
+              ? {
+                  cursorModeId: meta.cursorModeId ?? meta.cursorModeSnapshot?.currentModeId ?? prev.cursorModeId,
+                  cursorAvailableModeIds: meta.cursorModeSnapshot?.availableModeIds ?? prev.cursorAvailableModeIds,
+                }
+              : {}),
+          };
+          modelStateRef.current = next;
+          return next;
+        });
+      }
     });
     return () => {
       unsubscribe();

--- a/apps/ade-cli/src/tuiClient/app.tsx
+++ b/apps/ade-cli/src/tuiClient/app.tsx
@@ -7309,11 +7309,25 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
             ...(meta.codexConfigSource !== undefined ? { codexConfigSource: meta.codexConfigSource } : {}),
             ...(meta.opencodePermissionMode !== undefined ? { opencodePermissionMode: meta.opencodePermissionMode } : {}),
             ...(meta.droidPermissionMode !== undefined ? { droidPermissionMode: meta.droidPermissionMode } : {}),
-            ...(meta.cursorModeId !== undefined || meta.cursorModeSnapshot !== undefined
+            ...("cursorModeId" in meta || meta.cursorModeSnapshot !== undefined
               ? {
-                  cursorModeId: meta.cursorModeId ?? meta.cursorModeSnapshot?.currentModeId ?? prev.cursorModeId,
+                  // An explicit cursorModeId (present in the event) is
+                  // authoritative — including a `null` clear, which must reach
+                  // the composer rather than `??`-falling-back to a stale
+                  // mode/snapshot. Only when the key is absent do we derive the
+                  // current mode from a snapshot; a partial event carrying
+                  // neither leaves the mode unchanged.
+                  cursorModeId: "cursorModeId" in meta
+                    ? (meta.cursorModeId ?? null)
+                    : (meta.cursorModeSnapshot?.currentModeId ?? prev.cursorModeId),
                   cursorAvailableModeIds: meta.cursorModeSnapshot?.availableModeIds ?? prev.cursorAvailableModeIds,
                 }
+              : {}),
+            // An explicit cursorConfigValues in the event is authoritative (the
+            // host recomputes the snapshot only on mode changes, so config-only
+            // edits arrive here). Absent = no change; an explicit null clears.
+            ...(meta.cursorConfigValues !== undefined
+              ? { cursorConfigValues: meta.cursorConfigValues ?? {} }
               : {}),
           };
           modelStateRef.current = next;

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -7602,6 +7602,60 @@ describe("createAgentChatService", () => {
   // --------------------------------------------------------------------------
 
   describe("updateSession", () => {
+    it("broadcasts a session_meta_updated event with mode fields on a mode change", async () => {
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "opencode",
+        model: "",
+        modelId: "opencode/anthropic/claude-sonnet-4-6",
+      });
+      events.length = 0;
+
+      await service.updateSession({
+        sessionId: session.id,
+        opencodePermissionMode: "plan",
+      });
+
+      const metaEvent = events
+        .map((envelope) => envelope.event)
+        .find((event): event is Extract<typeof event, { type: "session_meta_updated" }> =>
+          event.type === "session_meta_updated");
+      expect(metaEvent).toBeDefined();
+      expect(metaEvent?.opencodePermissionMode).toBe("plan");
+    });
+
+    it("does not broadcast mode fields when no mode field is updated", async () => {
+      const events: AgentChatEventEnvelope[] = [];
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "opencode",
+        model: "",
+        modelId: "opencode/anthropic/claude-sonnet-4-6",
+      });
+      events.length = 0;
+
+      await service.updateSession({
+        sessionId: session.id,
+        reasoningEffort: "high",
+      });
+
+      const metaEventsWithMode = events
+        .map((envelope) => envelope.event)
+        .filter((event) => event.type === "session_meta_updated")
+        .filter((event) => "opencodePermissionMode" in event
+          || "permissionMode" in event
+          || "codexApprovalPolicy" in event
+          || "cursorModeId" in event);
+      expect(metaEventsWithMode).toHaveLength(0);
+    });
+
     it("updates the session title", async () => {
       const { service, sessionService } = createService();
       const session = await service.createSession({
@@ -22192,18 +22246,16 @@ describe("suggestLaneNameFromPrompt", () => {
     expect(result).toBe("login-bug-fix");
   });
 
-  it("retries the configured title model when the requested Codex model cannot name the lane", async () => {
+  it("prefers the configured title model over the requested composer model", async () => {
     vi.mocked(detectAllAuth).mockResolvedValue([
       { type: "cli-subscription" as any, cli: "codex", authenticated: true, path: "/usr/bin/codex", verified: true },
     ]);
     const { service, aiIntegrationService } = createSuggestService({ titleModelId: "openai/gpt-5.4-mini" });
-    vi.mocked(aiIntegrationService.summarizeTerminal)
-      .mockRejectedValueOnce(new Error("GPT-5.5 unavailable for title task"))
-      .mockResolvedValueOnce({
-        text: "Auto Create Lane Fix",
-        inputTokens: 10,
-        outputTokens: 5,
-      } as any);
+    vi.mocked(aiIntegrationService.summarizeTerminal).mockResolvedValueOnce({
+      text: "Auto Create Lane Fix",
+      inputTokens: 10,
+      outputTokens: 5,
+    } as any);
 
     const result = await service.suggestLaneNameFromPrompt({
       prompt: "Fix auto create lane routing and naming",
@@ -22214,13 +22266,10 @@ describe("suggestLaneNameFromPrompt", () => {
 
     expect(result).toBe("auto-create-lane-fix");
     expect(aiIntegrationService.summarizeTerminal).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      model: "openai/gpt-5.5",
-      taskType: "session_title",
-    }));
-    expect(aiIntegrationService.summarizeTerminal).toHaveBeenNthCalledWith(2, expect.objectContaining({
       model: "openai/gpt-5.4-mini",
       taskType: "session_title",
     }));
+    expect(aiIntegrationService.summarizeTerminal).toHaveBeenCalledTimes(1);
   });
 
   it("does not fall back to a legacy title model when session intelligence model is explicitly cleared", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -26937,6 +26937,9 @@ export function createAgentChatService(args: {
           ? { cursorModeId: managed.session.cursorModeId ?? null }
           : {}),
         ...(managed.session.cursorModeSnapshot ? { cursorModeSnapshot: managed.session.cursorModeSnapshot } : {}),
+        ...(cursorConfigValues !== undefined || managed.session.cursorConfigValues != null
+          ? { cursorConfigValues: managed.session.cursorConfigValues ?? null }
+          : {}),
       });
     }
     if (

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -8450,8 +8450,8 @@ export function createAgentChatService(args: {
       if (!availableModels.length) return fallback();
       const availableIds = new Set(availableModels.map((descriptor) => descriptor.id));
       const candidateModelIds = [
-        requestedModelId,
         config.titleModelId,
+        requestedModelId,
         DEFAULT_AUTO_TITLE_MODEL_ID,
         "anthropic/claude-haiku-4-5",
         "openai/gpt-5.4-mini",
@@ -21723,6 +21723,14 @@ export function createAgentChatService(args: {
       persistChatState(managed);
     };
     runtime.sdk.bridge.onRunResult = (_result, meta) => {
+      if (meta?.errorCode) {
+        logger.warn("agent_chat.cursor_sdk_run_error", {
+          sessionId: managed.session.id,
+          runId: meta.runId ?? null,
+          agentId: meta.agentId ?? null,
+          errorCode: meta.errorCode,
+        });
+      }
       if (meta?.runtime === "cloud" && meta.runId) {
         runtime.cloudRuns.delete(meta.runId);
         if (runtime.activeCloudRunId === meta.runId) runtime.activeCloudRunId = null;
@@ -26830,7 +26838,7 @@ export function createAgentChatService(args: {
       }
     }
 
-    if (
+    const modeFieldsTouched =
       permissionMode !== undefined
       || interactionMode !== undefined
       || claudePermissionMode !== undefined
@@ -26840,8 +26848,8 @@ export function createAgentChatService(args: {
       || opencodePermissionMode !== undefined
       || droidPermissionMode !== undefined
       || cursorModeId !== undefined
-      || cursorConfigValues !== undefined
-    ) {
+      || cursorConfigValues !== undefined;
+    if (modeFieldsTouched) {
       enforceManagedLocalHarnessPermissionMode(managed);
       normalizeSessionNativePermissionControls(managed.session, chatConfig);
       enforceOrchestrationLockedPermissionMode(managed.session);
@@ -26908,6 +26916,28 @@ export function createAgentChatService(args: {
       ) {
         await syncLiveCursorSdkPolicy(managed, managed.runtime, "session_update");
       }
+    }
+    // Broadcast a transient meta patch so other clients (desktop refreshing a
+    // session an iOS device just re-moded, or vice versa) update their composer
+    // controls immediately. Emitted after the cursor policy sync above so
+    // cursorModeSnapshot reflects the recomputed mode. Kept out of the
+    // session-list refresh path — this is a direct state patch, not a refetch.
+    if (modeFieldsTouched) {
+      emitTransientChatEnvelope(sessionId, {
+        type: "session_meta_updated",
+        ...(managed.session.permissionMode !== undefined ? { permissionMode: managed.session.permissionMode } : {}),
+        ...(managed.session.interactionMode !== undefined ? { interactionMode: managed.session.interactionMode } : {}),
+        ...(managed.session.claudePermissionMode !== undefined ? { claudePermissionMode: managed.session.claudePermissionMode } : {}),
+        ...(managed.session.codexApprovalPolicy !== undefined ? { codexApprovalPolicy: managed.session.codexApprovalPolicy } : {}),
+        ...(managed.session.codexSandbox !== undefined ? { codexSandbox: managed.session.codexSandbox } : {}),
+        ...(managed.session.codexConfigSource !== undefined ? { codexConfigSource: managed.session.codexConfigSource } : {}),
+        ...(managed.session.opencodePermissionMode !== undefined ? { opencodePermissionMode: managed.session.opencodePermissionMode } : {}),
+        ...(managed.session.droidPermissionMode !== undefined ? { droidPermissionMode: managed.session.droidPermissionMode } : {}),
+        ...(cursorModeId !== undefined || managed.session.cursorModeId != null
+          ? { cursorModeId: managed.session.cursorModeId ?? null }
+          : {}),
+        ...(managed.session.cursorModeSnapshot ? { cursorModeSnapshot: managed.session.cursorModeSnapshot } : {}),
+      });
     }
     if (
       fastMode !== undefined

--- a/apps/desktop/src/main/services/chat/cursorSdkEventMapper.test.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkEventMapper.test.ts
@@ -207,6 +207,31 @@ describe("Cursor SDK event mapper", () => {
     }]);
   });
 
+  it("surfaces the run store errorCode in the ERROR message", () => {
+    expect(mapCursorSdkMessageToChatEvents({
+      type: "status",
+      status: "ERROR",
+      adeErrorCode: "insufficient_quota",
+    }, mapperMeta())).toEqual([{
+      type: "error",
+      message: "Cursor run failed: insufficient_quota",
+      turnId: "turn-1",
+    }]);
+  });
+
+  it("classifies transport errorCodes as network so the renderer can offer retry", () => {
+    expect(mapCursorSdkMessageToChatEvents({
+      type: "status",
+      status: "ERROR",
+      adeErrorCode: "[internal] Stream closed with error code NGHTTP2_INTERNAL_ERROR",
+    }, mapperMeta())).toEqual([{
+      type: "error",
+      message: "Cursor run failed: [internal] Stream closed with error code NGHTTP2_INTERNAL_ERROR",
+      turnId: "turn-1",
+      errorInfo: { category: "network" },
+    }]);
+  });
+
   it("does not stringify unknown Cursor SDK error objects into chat", () => {
     expect(mapCursorSdkMessageToChatEvents({
       type: "status",

--- a/apps/desktop/src/main/services/chat/cursorSdkEventMapper.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkEventMapper.ts
@@ -1,4 +1,5 @@
 import type { AgentChatCloudRunStatus, AgentChatEvent, AgentChatRuntime } from "../../../shared/types";
+import { isCursorSdkTransportErrorText } from "./cursorSdkProtocol";
 
 const CURSOR_WORKING_ACTIVITY_DETAIL = "Preparing response";
 
@@ -320,7 +321,19 @@ export function mapCursorSdkMessageToChatEvents(
         }, runtime)];
       }
       if (statusText === "ERROR") {
-        return [{ type: "error", message: detail ?? "Cursor SDK run failed.", turnId }];
+        // The streamed ERROR status carries no reason; the worker injects the
+        // run store's real errorCode as `adeErrorCode` after the run settles.
+        const errorCode = readString(record.adeErrorCode);
+        const message = errorCode
+          ? `Cursor run failed: ${errorCode}`
+          : detail ?? "Cursor SDK run failed.";
+        const transport = isCursorSdkTransportErrorText(errorCode ?? detail);
+        return [{
+          type: "error" as const,
+          message,
+          turnId,
+          ...(transport ? { errorInfo: { category: "network" as const } } : {}),
+        }];
       }
       return [];
     }

--- a/apps/desktop/src/main/services/chat/cursorSdkPool.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkPool.ts
@@ -29,6 +29,8 @@ export type CursorSdkRuntimeMeta = {
   runId?: string;
   agentId?: string;
   requestId?: string;
+  /** Terminal run store errorCode, present on run_result when a run errored. */
+  errorCode?: string;
 };
 
 export type CursorSdkBridge = {
@@ -602,6 +604,7 @@ async function createCursorSdkConnection(args: Parameters<typeof acquireCursorSd
         runId: message.runId,
         agentId: message.agentId,
         requestId: message.requestId,
+        ...(message.errorCode ? { errorCode: message.errorCode } : {}),
       });
       return;
     }

--- a/apps/desktop/src/main/services/chat/cursorSdkProtocol.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkProtocol.ts
@@ -234,6 +234,12 @@ export type CursorSdkWorkerResponse =
       runId?: string;
       agentId?: string;
       requestId?: string;
+      /**
+       * Terminal run error detail read from the SDK run store when a local run
+       * ends in ERROR. The public RunResult drops the store's `errorCode`, so
+       * the worker surfaces it here for logging + classification.
+       */
+      errorCode?: string;
     }
   | {
       type: "run_status";
@@ -245,3 +251,22 @@ export type CursorSdkWorkerResponse =
     }
   | { type: "hook_request"; requestId: string; request: CursorSdkHookRequest }
   | { type: "log"; level: "debug" | "info" | "warn" | "error"; message: string; detail?: unknown };
+
+/**
+ * True when an error string looks like a transport/network failure (HTTP/2
+ * stream resets, dropped sockets, connection refused/timeouts) rather than a
+ * model- or policy-level error. Callers use this to mark an error as
+ * potentially retryable. Matches on substrings so it works against both thrown
+ * Error messages and the SDK run store's `errorCode` text (e.g.
+ * "[internal] Stream closed with error code NGHTTP2_INTERNAL_ERROR").
+ */
+export function isCursorSdkTransportErrorText(text: string | null | undefined): boolean {
+  if (!text) return false;
+  const lower = text.toLowerCase();
+  return lower.includes("nghttp2")
+    || lower.includes("econnreset")
+    || lower.includes("econnrefused")
+    || lower.includes("etimedout")
+    || lower.includes("socket hang up")
+    || lower.includes("stream closed with error");
+}

--- a/apps/desktop/src/main/services/chat/cursorSdkWorker.ts
+++ b/apps/desktop/src/main/services/chat/cursorSdkWorker.ts
@@ -19,6 +19,7 @@ import type {
   CursorSdkWorkerRequest,
   CursorSdkWorkerResponse,
 } from "./cursorSdkProtocol";
+import { isCursorSdkTransportErrorText } from "./cursorSdkProtocol";
 import {
   allowCursorHook,
   denyCursorHook,
@@ -157,11 +158,48 @@ function classifyWorkerError(error: unknown): { error: string; errorCode?: strin
       errorCode: "rate_limited",
     };
   }
+  const detail = errorMessage(error);
+  if (isCursorSdkTransportErrorText(detail) || isCursorSdkTransportErrorText(errorCode(error))) {
+    return { error: detail, errorCode: "network" };
+  }
   const code = errorCode(error);
   return {
-    error: errorMessage(error),
+    error: detail,
     ...(code ? { errorCode: code } : {}),
   };
+}
+
+function isTerminalErrorStatusEvent(event: unknown): boolean {
+  const record = event && typeof event === "object" && !Array.isArray(event)
+    ? event as Record<string, unknown>
+    : null;
+  return record?.type === "status" && record?.status === "ERROR";
+}
+
+/**
+ * Read the terminal `errorCode` for a finished local run from the SDK run
+ * store. The public `Run`/`RunResult` surface drops the store's
+ * `error_code` column (`RunRecord.errorCode`), so the only way to recover the
+ * real failure reason (e.g. an NGHTTP2 stream reset) is the run store the live
+ * `StoreBackedRun` was constructed with. This reaches an internal field, so it
+ * is fully guarded — any shape change just yields `undefined` and the caller
+ * falls back to the generic message.
+ */
+async function readRunErrorCode(run: SdkRun | null): Promise<string | undefined> {
+  if (!run) return undefined;
+  try {
+    const store = (run as unknown as {
+      store?: { getRun?: (agentId: string, runId: string) => Promise<unknown> };
+    }).store;
+    if (!store || typeof store.getRun !== "function") return undefined;
+    const record = await store.getRun(run.agentId, run.id);
+    const code = record && typeof record === "object"
+      ? (record as Record<string, unknown>).errorCode
+      : undefined;
+    return typeof code === "string" && code.trim() ? code.trim() : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 async function getSdk(): Promise<CursorSdkModule> {
@@ -417,11 +455,33 @@ async function sendPrompt(payload: {
     ...(runModelParams ? { modelParams: runModelParams } : {}),
     runtime: "local",
   });
-  for await (const event of currentRun.stream()) {
-    post({ type: "sdk_event", event, runtime: "local", runId: currentRun.id, agentId: currentRun.agentId });
+  const run = currentRun;
+  // Hold a terminal ERROR status until after `wait()` so we can enrich it with
+  // the run store's real errorCode (the streamed status carries no detail).
+  let heldErrorEvent: Record<string, unknown> | null = null;
+  for await (const event of run.stream()) {
+    if (!heldErrorEvent && isTerminalErrorStatusEvent(event)) {
+      heldErrorEvent = { ...(event as unknown as Record<string, unknown>) };
+      continue;
+    }
+    post({ type: "sdk_event", event, runtime: "local", runId: run.id, agentId: run.agentId });
   }
-  const result = await currentRun.wait();
-  post({ type: "run_result", result, runtime: "local", runId: currentRun.id, agentId: currentRun.agentId });
+  const result = await run.wait();
+  const errored = heldErrorEvent != null
+    || (result && typeof result === "object" && (result as { status?: unknown }).status === "error");
+  const runErrorCode = errored ? await readRunErrorCode(run) : undefined;
+  if (heldErrorEvent) {
+    if (runErrorCode) heldErrorEvent.adeErrorCode = runErrorCode;
+    post({ type: "sdk_event", event: heldErrorEvent, runtime: "local", runId: run.id, agentId: run.agentId });
+  }
+  post({
+    type: "run_result",
+    result,
+    runtime: "local",
+    runId: run.id,
+    agentId: run.agentId,
+    ...(runErrorCode ? { errorCode: runErrorCode } : {}),
+  });
   currentRun = null;
   return result;
 }

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -5883,6 +5883,7 @@ export function AgentChatPane({
         if (meta.droidPermissionMode !== undefined) summaryPatch.droidPermissionMode = meta.droidPermissionMode;
         if (meta.cursorModeId !== undefined) summaryPatch.cursorModeId = meta.cursorModeId;
         if (meta.cursorModeSnapshot !== undefined) summaryPatch.cursorModeSnapshot = meta.cursorModeSnapshot;
+        if (meta.cursorConfigValues !== undefined) summaryPatch.cursorConfigValues = meta.cursorConfigValues;
         if (Object.keys(summaryPatch).length > 0) {
           patchSessionSummary(envelope.sessionId, summaryPatch);
         }
@@ -5903,10 +5904,22 @@ export function AgentChatPane({
           if (meta.codexConfigSource !== undefined) setCodexConfigSource(meta.codexConfigSource);
           if (meta.opencodePermissionMode !== undefined) setOpenCodePermissionMode(meta.opencodePermissionMode);
           if (meta.droidPermissionMode !== undefined) setDroidPermissionMode(meta.droidPermissionMode);
-          if (meta.cursorModeId !== undefined || meta.cursorModeSnapshot !== undefined) {
+          if (
+            meta.cursorModeId !== undefined
+            || meta.cursorModeSnapshot !== undefined
+            || meta.cursorConfigValues !== undefined
+          ) {
             const snapshot = meta.cursorModeSnapshot;
-            setCursorModeId(meta.cursorModeId ?? snapshot?.currentModeId ?? initialNativeControls.cursorModeId);
-            if (snapshot) {
+            if (meta.cursorModeId !== undefined || snapshot !== undefined) {
+              setCursorModeId(meta.cursorModeId ?? snapshot?.currentModeId ?? initialNativeControls.cursorModeId);
+            }
+            // An explicit cursorConfigValues in the event is authoritative (it
+            // carries config-only changes the snapshot may not reflect, since
+            // the host only recomputes cursorModeSnapshot on mode changes);
+            // otherwise fall back to deriving values from the snapshot.
+            if (meta.cursorConfigValues !== undefined) {
+              setCursorConfigValues(meta.cursorConfigValues ?? {});
+            } else if (snapshot) {
               setCursorConfigValues(
                 Object.fromEntries(
                   (snapshot.configOptions ?? [])

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -5871,8 +5871,51 @@ export function AgentChatPane({
       // chat event since it doesn't represent transcript content.
       if (envelope.event.type === "session_meta_updated") {
         const meta = envelope.event;
-        if (typeof meta.title === "string" && meta.title.length > 0) {
-          patchSessionSummary(envelope.sessionId, { title: meta.title });
+        const summaryPatch: Partial<AgentChatSessionSummary> = {};
+        if (typeof meta.title === "string" && meta.title.length > 0) summaryPatch.title = meta.title;
+        if (meta.permissionMode !== undefined) summaryPatch.permissionMode = meta.permissionMode;
+        if (meta.interactionMode !== undefined) summaryPatch.interactionMode = meta.interactionMode;
+        if (meta.claudePermissionMode !== undefined) summaryPatch.claudePermissionMode = meta.claudePermissionMode;
+        if (meta.codexApprovalPolicy !== undefined) summaryPatch.codexApprovalPolicy = meta.codexApprovalPolicy;
+        if (meta.codexSandbox !== undefined) summaryPatch.codexSandbox = meta.codexSandbox;
+        if (meta.codexConfigSource !== undefined) summaryPatch.codexConfigSource = meta.codexConfigSource;
+        if (meta.opencodePermissionMode !== undefined) summaryPatch.opencodePermissionMode = meta.opencodePermissionMode;
+        if (meta.droidPermissionMode !== undefined) summaryPatch.droidPermissionMode = meta.droidPermissionMode;
+        if (meta.cursorModeId !== undefined) summaryPatch.cursorModeId = meta.cursorModeId;
+        if (meta.cursorModeSnapshot !== undefined) summaryPatch.cursorModeSnapshot = meta.cursorModeSnapshot;
+        if (Object.keys(summaryPatch).length > 0) {
+          patchSessionSummary(envelope.sessionId, summaryPatch);
+        }
+        // The composer seeds its local mode state from the session scope, not
+        // summary content, so a summary patch alone won't re-seed the selected
+        // chat. Apply the authoritative mode fields directly to composer state
+        // (mirrors the plan-mode transition special-case below). summaryPatch's
+        // keys are exactly `title` plus the mode fields (each gated on the same
+        // `meta.X !== undefined` check), so any non-title key means a mode changed.
+        const modeChanged = Object.keys(summaryPatch).some((key) => key !== "title");
+        if (modeChanged && envelope.sessionId === selectedSessionIdRef.current) {
+          if (meta.interactionMode !== undefined) {
+            setInteractionMode(meta.interactionMode ?? initialNativeControls.interactionMode);
+          }
+          if (meta.claudePermissionMode !== undefined) setClaudePermissionMode(meta.claudePermissionMode);
+          if (meta.codexApprovalPolicy !== undefined) setCodexApprovalPolicy(meta.codexApprovalPolicy);
+          if (meta.codexSandbox !== undefined) setCodexSandbox(meta.codexSandbox);
+          if (meta.codexConfigSource !== undefined) setCodexConfigSource(meta.codexConfigSource);
+          if (meta.opencodePermissionMode !== undefined) setOpenCodePermissionMode(meta.opencodePermissionMode);
+          if (meta.droidPermissionMode !== undefined) setDroidPermissionMode(meta.droidPermissionMode);
+          if (meta.cursorModeId !== undefined || meta.cursorModeSnapshot !== undefined) {
+            const snapshot = meta.cursorModeSnapshot;
+            setCursorModeId(meta.cursorModeId ?? snapshot?.currentModeId ?? initialNativeControls.cursorModeId);
+            if (snapshot) {
+              setCursorConfigValues(
+                Object.fromEntries(
+                  (snapshot.configOptions ?? [])
+                    .filter((option) => option.id !== snapshot.modeConfigId)
+                    .flatMap((option) => option.currentValue == null ? [] : [[option.id, option.currentValue]]),
+                ),
+              );
+            }
+          }
         }
         return;
       }

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -5910,8 +5910,16 @@ export function AgentChatPane({
             || meta.cursorConfigValues !== undefined
           ) {
             const snapshot = meta.cursorModeSnapshot;
-            if (meta.cursorModeId !== undefined || snapshot !== undefined) {
-              setCursorModeId(meta.cursorModeId ?? snapshot?.currentModeId ?? initialNativeControls.cursorModeId);
+            if ("cursorModeId" in meta) {
+              // The event carries an explicit cursorModeId — including a `null`
+              // clear, which must reach the composer rather than `??`-falling
+              // back to a stale mode/snapshot. summaryPatch above already stored
+              // the same cleared value, so the two stay in agreement.
+              setCursorModeId(meta.cursorModeId ?? null);
+            } else if (snapshot !== undefined) {
+              // Key absent but a snapshot arrived: derive the current mode from
+              // it. A partial event with neither field leaves the mode unchanged.
+              setCursorModeId(snapshot.currentModeId ?? initialNativeControls.cursorModeId);
             }
             // An explicit cursorConfigValues in the event is authoritative (it
             // carries config-only changes the snapshot may not reflect, since

--- a/apps/desktop/src/shared/laneNameFallback.test.ts
+++ b/apps/desktop/src/shared/laneNameFallback.test.ts
@@ -26,6 +26,14 @@ describe("lane name fallback", () => {
     );
   });
 
+  it("does not treat login history as a provider auth task", () => {
+    expect(
+      deriveDeterministicLaneNameFromPrompt(
+        "Debug cursor SDK chat mobile sync issues. Look at the full login history, then follow the Claude MD guidance.",
+      ),
+    ).toBe("debug-cursor-sdk-mobile-sync");
+  });
+
   it("turns a URL-heavy 'take a look at' prompt into clean tokens, not url noise", () => {
     // Regression for "take-look-at-https-github".
     expect(

--- a/apps/desktop/src/shared/laneNameFallback.ts
+++ b/apps/desktop/src/shared/laneNameFallback.ts
@@ -157,7 +157,7 @@ function priorityNamingWords(cleanedPrompt: string): string[] {
     ?? (/\bopen code\b/u.test(normalized) ? "opencode" : null);
   if (!provider) return [];
   const mentionsAuth = /\b(auth|authenticate|authentication|credential|credentials|creds|oauth)\b/u.test(normalized);
-  const mentionsLogin = /\b(log\s*in|login|signin|sign\s*in)\b/u.test(normalized);
+  const mentionsLogin = /\b(log\s+in|login(?!\s+history)|signin|sign\s*in)\b/u.test(normalized);
   const mentionsUiControl = /\b(button|cta|call to action|chip|banner)\b/u.test(normalized);
   if (!mentionsAuth && !mentionsLogin) return [];
   if (!mentionsLogin && !mentionsUiControl) return [];

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -804,6 +804,20 @@ export type AgentChatEvent =
       type: "session_meta_updated";
       title?: string;
       manuallyNamed?: boolean;
+      // Permission/interaction mode fields — emitted when a client (e.g. iOS)
+      // changes the mode via updateSession so other renderers patch their
+      // composer state without waiting for a turn-lifecycle event. All optional
+      // and backward-compatible; a title-only emit carries none of them.
+      permissionMode?: AgentChatPermissionMode;
+      interactionMode?: AgentChatInteractionMode | null;
+      claudePermissionMode?: AgentChatClaudePermissionMode;
+      codexApprovalPolicy?: AgentChatCodexApprovalPolicy;
+      codexSandbox?: AgentChatCodexSandbox;
+      codexConfigSource?: AgentChatCodexConfigSource;
+      opencodePermissionMode?: AgentChatOpenCodePermissionMode;
+      droidPermissionMode?: AgentChatDroidPermissionMode;
+      cursorModeId?: string | null;
+      cursorModeSnapshot?: AgentChatCursorModeSnapshot;
       // Accept turnId for uniformity with other variants — ignored by handlers.
       turnId?: string;
     };

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -818,6 +818,7 @@ export type AgentChatEvent =
       droidPermissionMode?: AgentChatDroidPermissionMode;
       cursorModeId?: string | null;
       cursorModeSnapshot?: AgentChatCursorModeSnapshot;
+      cursorConfigValues?: Record<string, AgentChatCursorConfigValue> | null;
       // Accept turnId for uniformity with other variants — ignored by handlers.
       turnId?: string;
     };

--- a/apps/desktop/src/shared/types/sync.ts
+++ b/apps/desktop/src/shared/types/sync.ts
@@ -61,6 +61,9 @@ export type SyncPeerMetadata = {
    */
   dbVersionBySite?: Record<string, number>;
   capabilities?: string[];
+  appVersion?: string;
+  appBuild?: string;
+  bundleIdentifier?: string;
 };
 
 export type SyncPeerConnectionState = SyncPeerMetadata & {

--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -825,6 +825,11 @@ struct AgentChatSessionMetaModeUpdate: Decodable, Equatable {
   var cursorModeIdWasCleared: Bool = false
   var cursorModeSnapshot: RemoteJSONValue?
   var cursorConfigValues: [String: RemoteJSONValue]?
+  /// True when the event carried `cursorConfigValues: null` (an intentional
+  /// clear the host emits to drop the cursor config) rather than omitting the
+  /// key. Symmetric with `cursorModeIdWasCleared`: absent-key still means "no
+  /// change"; only an explicit null sets this so `applyModeUpdate` assigns nil.
+  var cursorConfigValuesWasCleared: Bool = false
 
   private enum CodingKeys: String, CodingKey {
     case permissionMode
@@ -869,7 +874,16 @@ struct AgentChatSessionMetaModeUpdate: Decodable, Equatable {
       cursorModeIdWasCleared = false
     }
     cursorModeSnapshot = try c.decodeIfPresent(RemoteJSONValue.self, forKey: .cursorModeSnapshot)
-    cursorConfigValues = try c.decodeIfPresent([String: RemoteJSONValue].self, forKey: .cursorConfigValues)
+    // Same null-vs-absent distinction as cursorModeId: decodeIfPresent collapses
+    // `cursorConfigValues: null` (an explicit clear) into absent, so gate on
+    // `contains` to record the clear.
+    if c.contains(.cursorConfigValues) {
+      cursorConfigValues = try c.decodeIfPresent([String: RemoteJSONValue].self, forKey: .cursorConfigValues)
+      cursorConfigValuesWasCleared = cursorConfigValues == nil
+    } else {
+      cursorConfigValues = nil
+      cursorConfigValuesWasCleared = false
+    }
   }
 
   /// True when the event carries at least one mode field. A bare
@@ -887,6 +901,7 @@ struct AgentChatSessionMetaModeUpdate: Decodable, Equatable {
       || cursorModeIdWasCleared
       || cursorModeSnapshot != nil
       || cursorConfigValues != nil
+      || cursorConfigValuesWasCleared
   }
 }
 
@@ -911,23 +926,32 @@ extension AgentChatSessionSummary {
       cursorModeId = nil
     }
     if let v = update.cursorModeSnapshot { cursorModeSnapshot = v }
-    if let v = update.cursorConfigValues { cursorConfigValues = v }
+    if let v = update.cursorConfigValues {
+      cursorConfigValues = v
+    } else if update.cursorConfigValuesWasCleared {
+      // Explicit `cursorConfigValues: null` from the host — drop the config
+      // rather than leaving the stale values in place.
+      cursorConfigValues = nil
+    }
   }
 
-  /// Overlay the non-nil mode fields from another summary (used to fold a
-  /// cache-side mode patch into an open view's live summary). Only non-nil
-  /// source values win, so it never blanks a field the source didn't populate.
+  /// Overlay the mode fields from another summary (used to fold a cache-side
+  /// mode patch into an open view's live summary on a chat-event revision bump).
   ///
-  /// `cursorModeIdCleared` is the one deliberate exception: when the cache
-  /// recorded an explicit `cursorModeId: null` clear (a folded
-  /// `session_meta_updated`), pass `true` so the nil propagates to the live
-  /// summary — the non-nil-only copy below would otherwise leave the stale
-  /// mode in place. It defaults to `false`, so a plain summary→summary merge
-  /// still never nulls cursorModeId (or any field) off a source nil.
-  mutating func mergeModeFields(
-    from other: AgentChatSessionSummary,
-    cursorModeIdCleared: Bool = false
-  ) {
+  /// The permission/interaction string fields copy only when non-nil: the host
+  /// never null-clears them, and a partial refresh summary that omits one must
+  /// not blank the live value.
+  ///
+  /// Cursor fields (`cursorModeId` / `cursorConfigValues`) copy WHOLESALE,
+  /// including a nil. The cache is authoritative for cursor state — every writer
+  /// (the `session_meta_updated` fold via `applyModeUpdate`, a full host summary
+  /// via `cacheChatSummary`, or a lane-list refresh) stores the host's true
+  /// value, and the host includes the field whenever a mode/config exists (a
+  /// clear arrives as an explicit `null`, an unset session simply has no mode).
+  /// So mirroring the cache's cursor fields — nil included — is exactly how an
+  /// explicit clear reaches the live composer, with no separate clear flag or
+  /// stateful marker to go stale.
+  mutating func mergeModeFields(from other: AgentChatSessionSummary) {
     if let v = other.permissionMode { permissionMode = v }
     if let v = other.interactionMode { interactionMode = v }
     if let v = other.claudePermissionMode { claudePermissionMode = v }
@@ -936,13 +960,9 @@ extension AgentChatSessionSummary {
     if let v = other.codexConfigSource { codexConfigSource = v }
     if let v = other.opencodePermissionMode { opencodePermissionMode = v }
     if let v = other.droidPermissionMode { droidPermissionMode = v }
-    if let v = other.cursorModeId {
-      cursorModeId = v
-    } else if cursorModeIdCleared {
-      cursorModeId = nil
-    }
+    cursorModeId = other.cursorModeId
     if let v = other.cursorModeSnapshot { cursorModeSnapshot = v }
-    if let v = other.cursorConfigValues { cursorConfigValues = v }
+    cursorConfigValues = other.cursorConfigValues
   }
 }
 

--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -917,7 +917,17 @@ extension AgentChatSessionSummary {
   /// Overlay the non-nil mode fields from another summary (used to fold a
   /// cache-side mode patch into an open view's live summary). Only non-nil
   /// source values win, so it never blanks a field the source didn't populate.
-  mutating func mergeModeFields(from other: AgentChatSessionSummary) {
+  ///
+  /// `cursorModeIdCleared` is the one deliberate exception: when the cache
+  /// recorded an explicit `cursorModeId: null` clear (a folded
+  /// `session_meta_updated`), pass `true` so the nil propagates to the live
+  /// summary — the non-nil-only copy below would otherwise leave the stale
+  /// mode in place. It defaults to `false`, so a plain summary→summary merge
+  /// still never nulls cursorModeId (or any field) off a source nil.
+  mutating func mergeModeFields(
+    from other: AgentChatSessionSummary,
+    cursorModeIdCleared: Bool = false
+  ) {
     if let v = other.permissionMode { permissionMode = v }
     if let v = other.interactionMode { interactionMode = v }
     if let v = other.claudePermissionMode { claudePermissionMode = v }
@@ -926,7 +936,11 @@ extension AgentChatSessionSummary {
     if let v = other.codexConfigSource { codexConfigSource = v }
     if let v = other.opencodePermissionMode { opencodePermissionMode = v }
     if let v = other.droidPermissionMode { droidPermissionMode = v }
-    if let v = other.cursorModeId { cursorModeId = v }
+    if let v = other.cursorModeId {
+      cursorModeId = v
+    } else if cursorModeIdCleared {
+      cursorModeId = nil
+    }
     if let v = other.cursorModeSnapshot { cursorModeSnapshot = v }
     if let v = other.cursorConfigValues { cursorConfigValues = v }
   }

--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -818,7 +818,13 @@ struct AgentChatSessionMetaModeUpdate: Decodable, Equatable {
   var opencodePermissionMode: String?
   var droidPermissionMode: String?
   var cursorModeId: String?
+  /// True when the event carried `cursorModeId: null` (an intentional clear the
+  /// host emits to drop a cursor mode) rather than omitting the key. Absent-key
+  /// still means "no change"; only an explicit null sets this so
+  /// `applyModeUpdate` assigns nil instead of skipping.
+  var cursorModeIdWasCleared: Bool = false
   var cursorModeSnapshot: RemoteJSONValue?
+  var cursorConfigValues: [String: RemoteJSONValue]?
 
   private enum CodingKeys: String, CodingKey {
     case permissionMode
@@ -832,6 +838,7 @@ struct AgentChatSessionMetaModeUpdate: Decodable, Equatable {
     case droidPermissionMode
     case cursorModeId
     case cursorModeSnapshot
+    case cursorConfigValues
   }
 
   init(from decoder: Decoder) throws {
@@ -851,8 +858,18 @@ struct AgentChatSessionMetaModeUpdate: Decodable, Equatable {
     codexConfigSource = try c.decodeIfPresent(String.self, forKey: .codexConfigSource)
     opencodePermissionMode = try c.decodeIfPresent(String.self, forKey: .opencodePermissionMode)
     droidPermissionMode = try c.decodeIfPresent(String.self, forKey: .droidPermissionMode)
-    cursorModeId = try c.decodeIfPresent(String.self, forKey: .cursorModeId)
+    // Distinguish `cursorModeId: null` (an intentional clear) from an absent
+    // key. decodeIfPresent collapses both to nil, so gate on `contains`: a
+    // present-but-null key means the host cleared the cursor mode.
+    if c.contains(.cursorModeId) {
+      cursorModeId = try c.decodeIfPresent(String.self, forKey: .cursorModeId)
+      cursorModeIdWasCleared = cursorModeId == nil
+    } else {
+      cursorModeId = nil
+      cursorModeIdWasCleared = false
+    }
     cursorModeSnapshot = try c.decodeIfPresent(RemoteJSONValue.self, forKey: .cursorModeSnapshot)
+    cursorConfigValues = try c.decodeIfPresent([String: RemoteJSONValue].self, forKey: .cursorConfigValues)
   }
 
   /// True when the event carries at least one mode field. A bare
@@ -867,7 +884,9 @@ struct AgentChatSessionMetaModeUpdate: Decodable, Equatable {
       || opencodePermissionMode != nil
       || droidPermissionMode != nil
       || cursorModeId != nil
+      || cursorModeIdWasCleared
       || cursorModeSnapshot != nil
+      || cursorConfigValues != nil
   }
 }
 
@@ -884,8 +903,15 @@ extension AgentChatSessionSummary {
     if let v = update.codexConfigSource { codexConfigSource = v }
     if let v = update.opencodePermissionMode { opencodePermissionMode = v }
     if let v = update.droidPermissionMode { droidPermissionMode = v }
-    if let v = update.cursorModeId { cursorModeId = v }
+    if let v = update.cursorModeId {
+      cursorModeId = v
+    } else if update.cursorModeIdWasCleared {
+      // Explicit `cursorModeId: null` from the host — drop the mode rather than
+      // leaving the stale one in place.
+      cursorModeId = nil
+    }
     if let v = update.cursorModeSnapshot { cursorModeSnapshot = v }
+    if let v = update.cursorConfigValues { cursorConfigValues = v }
   }
 
   /// Overlay the non-nil mode fields from another summary (used to fold a
@@ -902,6 +928,7 @@ extension AgentChatSessionSummary {
     if let v = other.droidPermissionMode { droidPermissionMode = v }
     if let v = other.cursorModeId { cursorModeId = v }
     if let v = other.cursorModeSnapshot { cursorModeSnapshot = v }
+    if let v = other.cursorConfigValues { cursorConfigValues = v }
   }
 }
 

--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -801,6 +801,110 @@ struct AgentChatSessionSummary: Codable, Identifiable, Equatable {
   }
 }
 
+/// Composer mode fields carried by a `session_meta_updated` chat event when a
+/// client (e.g. desktop) changes the session's permission / interaction mode.
+/// Every field is optional so the decode never fails and older hosts — which
+/// send only `title` / `manuallyNamed` — degrade to a no-op. Values are plain
+/// strings (the summary stores these as `String?`, not failable enums), so an
+/// unrecognized wire value patches through harmlessly instead of dropping the
+/// whole event.
+struct AgentChatSessionMetaModeUpdate: Decodable, Equatable {
+  var permissionMode: String?
+  var interactionMode: String?
+  var claudePermissionMode: String?
+  var codexApprovalPolicy: String?
+  var codexSandbox: String?
+  var codexConfigSource: String?
+  var opencodePermissionMode: String?
+  var droidPermissionMode: String?
+  var cursorModeId: String?
+  var cursorModeSnapshot: RemoteJSONValue?
+
+  private enum CodingKeys: String, CodingKey {
+    case permissionMode
+    case interactionMode
+    case claudePermissionMode
+    case codexApprovalPolicy
+    case codexSandbox
+    case codexSandboxMode
+    case codexConfigSource
+    case opencodePermissionMode
+    case droidPermissionMode
+    case cursorModeId
+    case cursorModeSnapshot
+  }
+
+  init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    permissionMode = try c.decodeIfPresent(String.self, forKey: .permissionMode)
+    interactionMode = try c.decodeIfPresent(String.self, forKey: .interactionMode)
+    claudePermissionMode = try c.decodeIfPresent(String.self, forKey: .claudePermissionMode)
+    codexApprovalPolicy = try c.decodeIfPresent(String.self, forKey: .codexApprovalPolicy)
+    // Canonical key is `codexSandbox` (matches the summary + updateSession args).
+    // Accept `codexSandboxMode` as a defensive fallback in case the host emits
+    // that alternate spelling.
+    if let sandbox = try c.decodeIfPresent(String.self, forKey: .codexSandbox) {
+      codexSandbox = sandbox
+    } else {
+      codexSandbox = try c.decodeIfPresent(String.self, forKey: .codexSandboxMode)
+    }
+    codexConfigSource = try c.decodeIfPresent(String.self, forKey: .codexConfigSource)
+    opencodePermissionMode = try c.decodeIfPresent(String.self, forKey: .opencodePermissionMode)
+    droidPermissionMode = try c.decodeIfPresent(String.self, forKey: .droidPermissionMode)
+    cursorModeId = try c.decodeIfPresent(String.self, forKey: .cursorModeId)
+    cursorModeSnapshot = try c.decodeIfPresent(RemoteJSONValue.self, forKey: .cursorModeSnapshot)
+  }
+
+  /// True when the event carries at least one mode field. A bare
+  /// title/manuallyNamed update decodes to all-nil here and is skipped.
+  var hasAnyField: Bool {
+    permissionMode != nil
+      || interactionMode != nil
+      || claudePermissionMode != nil
+      || codexApprovalPolicy != nil
+      || codexSandbox != nil
+      || codexConfigSource != nil
+      || opencodePermissionMode != nil
+      || droidPermissionMode != nil
+      || cursorModeId != nil
+      || cursorModeSnapshot != nil
+  }
+}
+
+extension AgentChatSessionSummary {
+  /// Overlay the non-nil mode fields from an incoming `session_meta_updated`
+  /// event. Absent fields leave the current value intact so a partial update
+  /// (a change touched only one mode) never clears the others.
+  mutating func applyModeUpdate(_ update: AgentChatSessionMetaModeUpdate) {
+    if let v = update.permissionMode { permissionMode = v }
+    if let v = update.interactionMode { interactionMode = v }
+    if let v = update.claudePermissionMode { claudePermissionMode = v }
+    if let v = update.codexApprovalPolicy { codexApprovalPolicy = v }
+    if let v = update.codexSandbox { codexSandbox = v }
+    if let v = update.codexConfigSource { codexConfigSource = v }
+    if let v = update.opencodePermissionMode { opencodePermissionMode = v }
+    if let v = update.droidPermissionMode { droidPermissionMode = v }
+    if let v = update.cursorModeId { cursorModeId = v }
+    if let v = update.cursorModeSnapshot { cursorModeSnapshot = v }
+  }
+
+  /// Overlay the non-nil mode fields from another summary (used to fold a
+  /// cache-side mode patch into an open view's live summary). Only non-nil
+  /// source values win, so it never blanks a field the source didn't populate.
+  mutating func mergeModeFields(from other: AgentChatSessionSummary) {
+    if let v = other.permissionMode { permissionMode = v }
+    if let v = other.interactionMode { interactionMode = v }
+    if let v = other.claudePermissionMode { claudePermissionMode = v }
+    if let v = other.codexApprovalPolicy { codexApprovalPolicy = v }
+    if let v = other.codexSandbox { codexSandbox = v }
+    if let v = other.codexConfigSource { codexConfigSource = v }
+    if let v = other.opencodePermissionMode { opencodePermissionMode = v }
+    if let v = other.droidPermissionMode { droidPermissionMode = v }
+    if let v = other.cursorModeId { cursorModeId = v }
+    if let v = other.cursorModeSnapshot { cursorModeSnapshot = v }
+  }
+}
+
 // MARK: - CTO Models (sync wire types)
 //
 // Field names mirror the desktop canonical types defined in

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -1564,12 +1564,6 @@ final class SyncService: ObservableObject {
   /// list and chat detail screens so the LA reconcile can read `modelId`
   /// + a real `lastActivityAt` without round-tripping for each running chat.
   private(set) var chatSummaryCache: [String: AgentChatSessionSummary] = [:]
-  /// Session ids whose cached summary carries an explicit cursor-mode clear (a
-  /// folded `session_meta_updated` with `cursorModeId: null`). The generic
-  /// summary→summary merge copies only non-nil cursor modes, so an open view's
-  /// `reconcileChatSummaryModeFromCacheIfNeeded` consults this set to null the
-  /// live `cursorModeId` too. Cleared once a real (non-nil) mode supersedes it.
-  private(set) var cursorModeClearedSessionIds: Set<String> = []
   private struct ChatModelsCacheEntry {
     var models: [AgentChatModelInfo]
     var fetchedAt: Date
@@ -10566,7 +10560,6 @@ final class SyncService: ObservableObject {
       // session), which means a full reset must clear it explicitly — otherwise
       // another project's / a stale connection's summaries would linger.
       chatSummaryCache.removeAll()
-      cursorModeClearedSessionIds.removeAll()
     } else {
       pruneChatEventHistoryCacheIfNeeded()
     }
@@ -10896,12 +10889,6 @@ extension SyncService {
 
   func cacheChatSummary(_ summary: AgentChatSessionSummary) {
     chatSummaryCache[summary.sessionId] = summary
-    // A full summary with a real cursor mode supersedes any pending clear
-    // marker (host confirmed a mode); a summary that itself carries nil leaves
-    // the marker untouched so an in-flight clear still reaches the open view.
-    if summary.cursorModeId != nil {
-      cursorModeClearedSessionIds.remove(summary.sessionId)
-    }
     refreshActiveSessionsAndSnapshot()
   }
 
@@ -10921,17 +10908,13 @@ extension SyncService {
           update.hasAnyField,
           var summary = chatSummaryCache[envelope.sessionId]
     else { return }
+    // `applyModeUpdate` applies an explicit `cursorModeId: null` /
+    // `cursorConfigValues: null` clear directly to the cached summary (nulling
+    // the field), so the cache is authoritative right here at receipt. The open
+    // view's reconcile mirrors the cache's cursor fields — nil included — on the
+    // revision bump, so the clear reaches the live composer without any stateful
+    // marker to go stale if the host later restores the mode.
     summary.applyModeUpdate(update)
-    // Track an explicit cursor-mode clear so the open view's reconcile can null
-    // the live cursorModeId (the non-nil-only summary merge can't). A later
-    // non-nil mode from this same event supersedes it. Done before the
-    // no-change guard below: the view reconciles off the chat-event revision
-    // bump regardless of whether the cached summary itself changed.
-    if update.cursorModeIdWasCleared {
-      cursorModeClearedSessionIds.insert(envelope.sessionId)
-    } else if update.cursorModeId != nil {
-      cursorModeClearedSessionIds.remove(envelope.sessionId)
-    }
     guard summary != chatSummaryCache[envelope.sessionId] else { return }
     chatSummaryCache[envelope.sessionId] = summary
     refreshActiveSessionsAndSnapshot()

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -8410,6 +8410,7 @@ final class SyncService: ObservableObject {
   }
 
   private func currentPeerMetadata() -> [String: Any] {
+    let info = Bundle.main.infoDictionary ?? [:]
     var metadata: [String: Any] = [
       "deviceId": deviceId,
       "deviceName": UIDevice.current.name,
@@ -8419,6 +8420,21 @@ final class SyncService: ObservableObject {
       "dbVersion": latestRemoteDbVersion,
       "capabilities": ["changesetAck", "chunkedEnvelopes"],
     ]
+    if let appVersion = (info["CFBundleShortVersionString"] as? String)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !appVersion.isEmpty {
+      metadata["appVersion"] = appVersion
+    }
+    if let appBuild = (info["CFBundleVersion"] as? String)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !appBuild.isEmpty {
+      metadata["appBuild"] = appBuild
+    }
+    if let bundleIdentifier = Bundle.main.bundleIdentifier?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !bundleIdentifier.isEmpty {
+      metadata["bundleIdentifier"] = bundleIdentifier
+    }
     // Per-project-DB cursors: the host picks the entry for the DB it serves,
     // so a brain that switched hosted projects pumps the right backlog
     // instead of trusting the single legacy cursor from a different DB.
@@ -9155,6 +9171,12 @@ final class SyncService: ObservableObject {
           chatEventLastSeqBySession[envelope.sessionId] = seq
         }
         recordChatEventEnvelope(envelope)
+        // A `session_meta_updated` event carries a client-side mode change
+        // (permission / interaction / codex-sandbox / cursor mode, …). Patch the
+        // cached summary so the open composer's mode pill updates live without a
+        // refetch. Decodes to `.unknown` for transcript purposes (older switches
+        // stay valid); the mode payload is read from the raw event dict here.
+        applyChatSessionMetaModeUpdateIfNeeded(envelope: envelope, rawPayload: dict)
         syncChatLog.debug(
           "chat_event_applied session=\(envelope.sessionId, privacy: .public) seq=\(envelope.sequence ?? -1, privacy: .public) type=\(envelope.event.typeName, privacy: .public) history=\(self.chatEventEnvelopesBySession[envelope.sessionId]?.count ?? 0, privacy: .public) revision=\(self.chatEventRevisionsBySession[envelope.sessionId] ?? 0, privacy: .public)"
         )
@@ -10533,6 +10555,11 @@ final class SyncService: ObservableObject {
       // Watermarks are only meaningful while the applied history is retained;
       // resuming from a seq after dropping history would skip those events.
       chatEventLastSeqBySession.removeAll()
+      // The summary cache is project-scoped. `cacheChatSummaries` merges rather
+      // than replaces (so partial Work-list refreshes never evict the open
+      // session), which means a full reset must clear it explicitly — otherwise
+      // another project's / a stale connection's summaries would linger.
+      chatSummaryCache.removeAll()
     } else {
       pruneChatEventHistoryCacheIfNeeded()
     }
@@ -10842,7 +10869,17 @@ extension SyncService {
   /// already have so the LA can read `modelId` and a real `lastActivityAt`
   /// without re-fetching per running session.
   func cacheChatSummaries(_ summaries: [String: AgentChatSessionSummary]) {
-    chatSummaryCache = summaries
+    // Merge, don't replace. A partial Work-list refresh (reduced-sync-load
+    // prefix(6), or a lane whose `listChatSessions` throws and returns []) hands
+    // off a summary set that omits the currently-open session. Replacing the
+    // whole cache would evict that session's summary, blanking the chat
+    // composer's model/permission controls (they gate on `summary.isAvailable`,
+    // which is false for a nil summary). Merging keeps prior summaries alive
+    // until they are explicitly overwritten. Project-switch / disconnect resets
+    // still evict the whole cache via `resetChatEventState(clearHistory: true)`.
+    for (sessionId, summary) in summaries {
+      chatSummaryCache[sessionId] = summary
+    }
     // Chat summaries feed `lastActivityAt` / `modelId` into the LA roster, so
     // a refreshed cache must trigger a snapshot recompute. Otherwise widgets
     // and live activities keep showing the stale model id / elapsed timer
@@ -10852,6 +10889,28 @@ extension SyncService {
 
   func cacheChatSummary(_ summary: AgentChatSessionSummary) {
     chatSummaryCache[summary.sessionId] = summary
+    refreshActiveSessionsAndSnapshot()
+  }
+
+  /// Fold a `session_meta_updated` event's mode fields into the cached summary
+  /// for its session. The open `WorkSessionDestinationView` reconciles its live
+  /// `chatSummary` from this cache on the revision bump the event already
+  /// triggers, so the composer's mode pill updates live without a refetch.
+  /// No-op for the bare title/manuallyNamed events older hosts send, or when
+  /// the session isn't cached (a later refresh will hydrate it).
+  private func applyChatSessionMetaModeUpdateIfNeeded(
+    envelope: AgentChatEventEnvelope,
+    rawPayload: [String: Any]
+  ) {
+    guard envelope.event.typeName == "session_meta_updated",
+          let eventObject = rawPayload["event"],
+          let update = try? decode(eventObject, as: AgentChatSessionMetaModeUpdate.self),
+          update.hasAnyField,
+          var summary = chatSummaryCache[envelope.sessionId]
+    else { return }
+    summary.applyModeUpdate(update)
+    guard summary != chatSummaryCache[envelope.sessionId] else { return }
+    chatSummaryCache[envelope.sessionId] = summary
     refreshActiveSessionsAndSnapshot()
   }
 

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -1564,6 +1564,12 @@ final class SyncService: ObservableObject {
   /// list and chat detail screens so the LA reconcile can read `modelId`
   /// + a real `lastActivityAt` without round-tripping for each running chat.
   private(set) var chatSummaryCache: [String: AgentChatSessionSummary] = [:]
+  /// Session ids whose cached summary carries an explicit cursor-mode clear (a
+  /// folded `session_meta_updated` with `cursorModeId: null`). The generic
+  /// summary→summary merge copies only non-nil cursor modes, so an open view's
+  /// `reconcileChatSummaryModeFromCacheIfNeeded` consults this set to null the
+  /// live `cursorModeId` too. Cleared once a real (non-nil) mode supersedes it.
+  private(set) var cursorModeClearedSessionIds: Set<String> = []
   private struct ChatModelsCacheEntry {
     var models: [AgentChatModelInfo]
     var fetchedAt: Date
@@ -10560,6 +10566,7 @@ final class SyncService: ObservableObject {
       // session), which means a full reset must clear it explicitly — otherwise
       // another project's / a stale connection's summaries would linger.
       chatSummaryCache.removeAll()
+      cursorModeClearedSessionIds.removeAll()
     } else {
       pruneChatEventHistoryCacheIfNeeded()
     }
@@ -10889,6 +10896,12 @@ extension SyncService {
 
   func cacheChatSummary(_ summary: AgentChatSessionSummary) {
     chatSummaryCache[summary.sessionId] = summary
+    // A full summary with a real cursor mode supersedes any pending clear
+    // marker (host confirmed a mode); a summary that itself carries nil leaves
+    // the marker untouched so an in-flight clear still reaches the open view.
+    if summary.cursorModeId != nil {
+      cursorModeClearedSessionIds.remove(summary.sessionId)
+    }
     refreshActiveSessionsAndSnapshot()
   }
 
@@ -10909,6 +10922,16 @@ extension SyncService {
           var summary = chatSummaryCache[envelope.sessionId]
     else { return }
     summary.applyModeUpdate(update)
+    // Track an explicit cursor-mode clear so the open view's reconcile can null
+    // the live cursorModeId (the non-nil-only summary merge can't). A later
+    // non-nil mode from this same event supersedes it. Done before the
+    // no-change guard below: the view reconciles off the chat-event revision
+    // bump regardless of whether the cached summary itself changed.
+    if update.cursorModeIdWasCleared {
+      cursorModeClearedSessionIds.insert(envelope.sessionId)
+    } else if update.cursorModeId != nil {
+      cursorModeClearedSessionIds.remove(envelope.sessionId)
+    }
     guard summary != chatSummaryCache[envelope.sessionId] else { return }
     chatSummaryCache[envelope.sessionId] = summary
     refreshActiveSessionsAndSnapshot()

--- a/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
+++ b/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
@@ -888,14 +888,11 @@ struct HubInlineComposer: View {
     }
   }
 
-  /// Desktop-parity background lane naming (`startBackgroundLaneNaming` in
-  /// AgentChatPane): the lane was already created with the deterministic
-  /// fallback name, so this runs fire-and-forget after the session launch and
-  /// any failure/timeout/offline is a no-op. `lanes.suggestName` honors the
-  /// host's own titleGenerationEnabled setting and clamps the name; the rename
-  /// applies only when the suggestion differs from the fallback. Both calls
-  /// carry the picked project's scope since the hub can launch into a project
-  /// other than the active one (same envelope routing as createLane above).
+  /// Desktop-parity background lane naming. The lane is created immediately
+  /// with the deterministic fallback; then the host AI gets two chances to
+  /// replace it, and every failure is logged with the lane id. Both calls carry
+  /// the picked project's scope since the hub can launch into a project other
+  /// than the active one (same envelope routing as createLane above).
   private func startBackgroundLaneNaming(
     laneId: String,
     opener: String,
@@ -906,22 +903,18 @@ struct HubInlineComposer: View {
     let syncService = syncService
     let modelId = modelId
     Task {
-      guard
-        let suggested = try? await syncService.suggestLaneName(
-          laneId: laneId,
-          prompt: opener,
-          modelId: modelId,
-          fallbackName: fallbackName,
-          targetProjectId: targetProjectId,
-          targetProjectRootPath: targetProjectRootPath
-        ),
-        suggested != fallbackName
-      else { return }
-      try? await syncService.renameLane(
-        laneId,
-        name: suggested,
+      await workRunAutoLaneAiRename(
+        laneId: laneId,
+        opener: opener,
+        fallbackName: fallbackName,
+        modelId: modelId,
+        syncService: syncService,
+        surface: .hubComposer,
         targetProjectId: targetProjectId,
-        targetProjectRootPath: targetProjectRootPath
+        targetProjectRootPath: targetProjectRootPath,
+        refreshLanes: {
+          syncService.requestRosterSnapshot()
+        }
       )
     }
   }

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
@@ -936,10 +936,11 @@ extension WorkChatSessionView {
   }
 
   @MainActor
-  func runSessionAction(_ action: @escaping @MainActor () async -> Void) async {
+  @discardableResult
+  func runSessionAction<T>(_ action: @escaping @MainActor () async -> T) async -> T {
     actionInFlight = true
     defer { actionInFlight = false }
-    await action()
+    return await action()
   }
 
   // MARK: - Consolidated pending-input answering
@@ -950,20 +951,33 @@ extension WorkChatSessionView {
   /// hide back so the card re-shows. Successful resolutions are cleared later by
   /// `reconcileOptimisticallyAnsweredInputs` once the item leaves the derived
   /// queue.
+  ///
+  /// Returns whether THIS answer succeeded so callers (the accept-all sweep) can
+  /// gate follow-up work on the real per-action result instead of the shared
+  /// `errorMessage` binding.
   @MainActor
+  @discardableResult
   func dispatchPendingInputAnswer(
     itemId: String,
     _ op: @escaping @MainActor () async -> Void
-  ) async {
+  ) async -> Bool {
     optimisticallyAnsweredInputIds.insert(itemId)
-    await runSessionAction(op)
-    // Every answer handler (`approveRequest`, `respondToPermission`,
-    // `submitQuestionAnswers`, `respondToQuestion`, `declineQuestion`) resets
-    // `errorMessage` to nil on success and sets a message on failure, so a
-    // non-nil value here means THIS command failed — roll the hide back.
-    if errorMessage != nil {
+    // Capture this action's outcome the instant its handler returns. Every
+    // answer handler (`approveRequest`, `respondToPermission`,
+    // `submitQuestionAnswers`, `respondToQuestion`, `declineQuestion`) writes
+    // `errorMessage` as its final synchronous step — nil on success, a message
+    // on failure — and there is no suspension point between that write and this
+    // read, so the value reflects THIS command rather than an unrelated
+    // concurrent action. Both the rollback below and the sweep gate key off the
+    // captured local result, never a later read of the shared binding.
+    let succeeded = await runSessionAction { () async -> Bool in
+      await op()
+      return errorMessage == nil
+    }
+    if !succeeded {
       optimisticallyAnsweredInputIds.remove(itemId)
     }
+    return succeeded
   }
 
   /// Drop optimistically-answered ids that are no longer in the canonical queue
@@ -989,8 +1003,11 @@ extension WorkChatSessionView {
     let sweepable = acceptAllSweepableInputs
     guard sweepable.contains(where: { $0.itemId == primary.itemId }) else { return }
 
-    // 1. Current item first with acceptForSession.
-    await sendPendingInputDecision(primary, decision: .acceptForSession)
+    // 1. Current item first with acceptForSession. If the session-scoped grant
+    //    fails, stop: do NOT fire `.accept` for the rest. The remaining items
+    //    stay pending and the primary's optimistic mark was already rolled back
+    //    by `dispatchPendingInputAnswer`.
+    guard await sendPendingInputDecision(primary, decision: .acceptForSession) else { return }
 
     // 2. Remaining approval/permission items, one await at a time.
     for item in sweepable where item.itemId != primary.itemId {
@@ -999,24 +1016,26 @@ extension WorkChatSessionView {
     }
   }
 
-  /// Route a single approval/permission decision through the optimistic path.
-  /// No-ops for kinds that must not be auto-answered.
+  /// Route a single approval/permission decision through the optimistic path,
+  /// returning whether the decision was dispatched successfully. No-ops (and
+  /// reports failure) for kinds that must not be auto-answered.
   @MainActor
+  @discardableResult
   private func sendPendingInputDecision(
     _ item: WorkPendingInputItem,
     decision: AgentChatApprovalDecision
-  ) async {
+  ) async -> Bool {
     switch item {
     case .approval(let model):
-      await dispatchPendingInputAnswer(itemId: model.id) {
+      return await dispatchPendingInputAnswer(itemId: model.id) {
         await onApproveRequest(model.id, decision, nil)
       }
     case .permission(let model):
-      await dispatchPendingInputAnswer(itemId: model.id) {
+      return await dispatchPendingInputAnswer(itemId: model.id) {
         await onRespondToPermission(model.id, decision)
       }
     case .question, .planApproval, .modelSelection:
-      break
+      return false
     }
   }
 }

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Actions.swift
@@ -941,4 +941,82 @@ extension WorkChatSessionView {
     defer { actionInFlight = false }
     await action()
   }
+
+  // MARK: - Consolidated pending-input answering
+
+  /// Optimistically hide a pending input the moment its decision is dispatched
+  /// (so the consolidated strip advances to the next request without waiting for
+  /// the host), run the action, then reconcile: if the command errored, roll the
+  /// hide back so the card re-shows. Successful resolutions are cleared later by
+  /// `reconcileOptimisticallyAnsweredInputs` once the item leaves the derived
+  /// queue.
+  @MainActor
+  func dispatchPendingInputAnswer(
+    itemId: String,
+    _ op: @escaping @MainActor () async -> Void
+  ) async {
+    optimisticallyAnsweredInputIds.insert(itemId)
+    await runSessionAction(op)
+    // Every answer handler (`approveRequest`, `respondToPermission`,
+    // `submitQuestionAnswers`, `respondToQuestion`, `declineQuestion`) resets
+    // `errorMessage` to nil on success and sets a message on failure, so a
+    // non-nil value here means THIS command failed — roll the hide back.
+    if errorMessage != nil {
+      optimisticallyAnsweredInputIds.remove(itemId)
+    }
+  }
+
+  /// Drop optimistically-answered ids that are no longer in the canonical queue
+  /// (confirmed resolved by the host). Keeps the set from masking a future
+  /// request that reuses an id and bounds its growth. Invoked whenever the
+  /// canonical pending queue changes.
+  @MainActor
+  func reconcileOptimisticallyAnsweredInputs() {
+    guard !optimisticallyAnsweredInputIds.isEmpty else { return }
+    let canonical = Set(timelineSnapshot.pendingInputs.map(\.itemId))
+    optimisticallyAnsweredInputIds.formIntersection(canonical)
+  }
+
+  /// "Accept all": flip session auto-approve for the current approval/permission
+  /// gate (`acceptForSession`), then accept every remaining approval/permission
+  /// request SEQUENTIALLY (never parallel). Question / plan-approval /
+  /// model-selection kinds are never swept. Stale itemIds no-op on the host, so
+  /// re-sends after `acceptForSession` auto-resolves the rest are safe.
+  @MainActor
+  func acceptAllPendingInputs() async {
+    guard let primary = primaryPendingInput else { return }
+    // Snapshot the sweep set before mutating optimistic-hide state.
+    let sweepable = acceptAllSweepableInputs
+    guard sweepable.contains(where: { $0.itemId == primary.itemId }) else { return }
+
+    // 1. Current item first with acceptForSession.
+    await sendPendingInputDecision(primary, decision: .acceptForSession)
+
+    // 2. Remaining approval/permission items, one await at a time.
+    for item in sweepable where item.itemId != primary.itemId {
+      guard !optimisticallyAnsweredInputIds.contains(item.itemId) else { continue }
+      await sendPendingInputDecision(item, decision: .accept)
+    }
+  }
+
+  /// Route a single approval/permission decision through the optimistic path.
+  /// No-ops for kinds that must not be auto-answered.
+  @MainActor
+  private func sendPendingInputDecision(
+    _ item: WorkPendingInputItem,
+    decision: AgentChatApprovalDecision
+  ) async {
+    switch item {
+    case .approval(let model):
+      await dispatchPendingInputAnswer(itemId: model.id) {
+        await onApproveRequest(model.id, decision, nil)
+      }
+    case .permission(let model):
+      await dispatchPendingInputAnswer(itemId: model.id) {
+        await onRespondToPermission(model.id, decision)
+      }
+    case .question, .planApproval, .modelSelection:
+      break
+    }
+  }
 }

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
@@ -368,3 +368,153 @@ struct WorkAssistantMessageControlsView: View, Equatable {
     .accessibilityLabel("Assistant response preview. \(controls.visibleLineCount) of \(controls.totalLineCount) lines shown.")
   }
 }
+
+// MARK: - Consolidated pending-input strip
+
+extension WorkChatSessionView {
+  /// Single consolidated pending-input strip pinned above the composer, matching
+  /// the desktop approval card. Replaces the previous split of plan/approval
+  /// composer strips plus inline question/permission/model-selection transcript
+  /// cards: it renders the current (primary) request, shows a "Request 1 of N"
+  /// header and an "Accept all" affordance once more than one request is queued,
+  /// and advances to the next request as each is answered (via the optimistic
+  /// removal path). Plan-approval keeps its existing compact strip body inside
+  /// the switch; only its placement changes.
+  /// Composer-anchored section wrapper. Type-erasing the optional pending strip
+  /// at a property boundary keeps `composerInset` / `body` under the Swift
+  /// type-inference budget (the inline `if let` version tipped `body` over).
+  /// The optimistic-answer reconcile also lives here rather than on the giant
+  /// `body` VStack — this section is always mounted (it renders empty content
+  /// when no request is pending), so the `onChange` stays active while keeping
+  /// `body`'s modifier chain small enough to type-check.
+  var consolidatedPendingStripSection: some View {
+    Group {
+      if let primaryPendingInput {
+        consolidatedPendingInputStrip(primaryPendingInput)
+          .id("pending-strip-\(primaryPendingInput.id)")
+      }
+    }
+    .onChange(of: canonicalPendingInputSignature) { _, _ in
+      reconcileOptimisticallyAnsweredInputs()
+    }
+  }
+
+  @ViewBuilder
+  func consolidatedPendingInputStrip(_ item: WorkPendingInputItem) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      if pendingInputCount > 1 {
+        pendingInputQueueHeader
+      }
+      consolidatedPendingInputBody(item)
+    }
+  }
+
+  /// "Request 1 of N" + optional "Accept all". The primary request is always the
+  /// first in the queue, so the leading index is fixed at 1.
+  @ViewBuilder
+  private var pendingInputQueueHeader: some View {
+    HStack(spacing: 8) {
+      Text("Request 1 of \(pendingInputCount)")
+        .font(.caption2.weight(.semibold))
+        .foregroundStyle(ADEColor.textMuted)
+        .accessibilityLabel("Request 1 of \(pendingInputCount) pending.")
+      Spacer(minLength: 0)
+      if canAcceptAllPendingInputs {
+        Button {
+          Task { await acceptAllPendingInputs() }
+        } label: {
+          Text("Accept all")
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(ADEColor.accent)
+        }
+        .buttonStyle(.plain)
+        .disabled(actionInFlight || !isLive)
+        .accessibilityLabel("Accept all \(acceptAllSweepableInputs.count) pending approvals")
+      }
+    }
+    .padding(.horizontal, 4)
+  }
+
+  @ViewBuilder
+  private func consolidatedPendingInputBody(_ item: WorkPendingInputItem) -> some View {
+    switch item {
+    case .planApproval(let model):
+      WorkPlanComposerStrip(
+        plan: model,
+        busy: actionInFlight || !isLive,
+        fallbackProvider: chatSummaryContext.provider,
+        onDecision: { decision, feedback in
+          await dispatchPendingInputAnswer(itemId: model.id) {
+            await onApproveRequest(model.id, decision, feedback)
+          }
+        }
+      )
+    case .approval(let model):
+      WorkApprovalComposerStrip(
+        approval: model,
+        busy: actionInFlight || !isLive,
+        fallbackProvider: chatSummaryContext.provider,
+        onDecision: { decision in
+          await dispatchPendingInputAnswer(itemId: model.id) {
+            await onApproveRequest(model.id, decision, nil)
+          }
+        }
+      )
+    case .permission(let model):
+      WorkPermissionCard(
+        permission: model,
+        busy: actionInFlight || !isLive,
+        onDecision: { decision in
+          await dispatchPendingInputAnswer(itemId: model.id) {
+            await onRespondToPermission(model.id, decision)
+          }
+        }
+      )
+    case .question(let model):
+      WorkStructuredQuestionCard(
+        question: model,
+        busy: actionInFlight || !isLive,
+        onSelectOption: { option, freeform in
+          await dispatchPendingInputAnswer(itemId: model.id) {
+            await onRespondToQuestion(
+              model.id,
+              model.questionId,
+              .string(option.value),
+              freeform
+            )
+          }
+        },
+        onSubmitAll: { answers, freeform in
+          await dispatchPendingInputAnswer(itemId: model.id) {
+            await onSubmitQuestionAnswers(model.id, answers, freeform)
+          }
+        },
+        onDecline: {
+          await dispatchPendingInputAnswer(itemId: model.id) {
+            await onDeclineQuestion(model.id)
+          }
+        },
+        fallbackProvider: chatSummaryContext.provider
+      )
+    case .modelSelection(let model):
+      WorkModelSelectionPendingCard(
+        request: model,
+        busy: actionInFlight || !isLive,
+        onConfirm: { selectionJSON in
+          await dispatchPendingInputAnswer(itemId: model.id) {
+            await onSubmitQuestionAnswers(
+              model.id,
+              ["selection": .string(selectionJSON)],
+              nil
+            )
+          }
+        },
+        onCancel: {
+          await dispatchPendingInputAnswer(itemId: model.id) {
+            await onDeclineQuestion(model.id)
+          }
+        }
+      )
+    }
+  }
+}

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -216,6 +216,12 @@ struct WorkChatSessionView: View {
   /// Last blocking pending-input id we reacted to, so re-renders that keep the
   /// same gate open don't re-fire the haptic or re-scroll.
   @State var lastBlockingPendingInputId: String?
+  /// Item ids of pending inputs the user just answered. They are hidden from the
+  /// consolidated strip immediately (optimistic removal) so it advances to the
+  /// next request without waiting for the host, and reconciled back out once the
+  /// item leaves the derived queue (or rolled back if the command errored). See
+  /// `dispatchPendingInputAnswer` / `reconcileOptimisticallyAnsweredInputs`.
+  @State var optimisticallyAnsweredInputIds: Set<String> = []
 
   var sessionStatus: String {
     resolvedSessionStatus ?? session.normalizedStatus
@@ -277,8 +283,33 @@ struct WorkChatSessionView: View {
     isStreamingTurn && timelineSnapshot.transcriptHasInterruptibleActivity
   }
 
+  /// Canonical open pending inputs minus the ones the user just answered.
+  /// `optimisticallyAnsweredInputIds` hides an item the instant a decision is
+  /// dispatched so the consolidated strip advances to the next request without
+  /// waiting for the host round-trip (iOS had no optimistic removal before, so
+  /// the card visibly flickered). Entries are reconciled back out once the item
+  /// leaves the derived queue, or rolled back if the command errored.
   var pendingInputs: [WorkPendingInputItem] {
-    timelineSnapshot.pendingInputs
+    guard !optimisticallyAnsweredInputIds.isEmpty else {
+      return timelineSnapshot.pendingInputs
+    }
+    return timelineSnapshot.pendingInputs.filter {
+      !optimisticallyAnsweredInputIds.contains($0.itemId)
+    }
+  }
+
+  /// Number of still-open requests in the consolidated strip; drives the
+  /// "Request 1 of N" header and whether "Accept all" is offered.
+  var pendingInputCount: Int {
+    pendingInputs.count
+  }
+
+  /// Order-sensitive fingerprint of the CANONICAL (host-derived) pending queue,
+  /// ignoring optimistic hides. Changes only when the host adds/removes/reorders
+  /// a request, which is exactly when `reconcileOptimisticallyAnsweredInputs`
+  /// should prune resolved optimistic entries.
+  var canonicalPendingInputSignature: String {
+    timelineSnapshot.pendingInputs.map(\.itemId).joined(separator: "\u{1F}")
   }
 
   var pendingSteers: [WorkPendingSteerModel] {
@@ -292,24 +323,29 @@ struct WorkChatSessionView: View {
     pendingInputs.first
   }
 
-  var pendingPlanApproval: WorkPendingPlanApprovalModel? {
-    pendingInputs.compactMap { item -> WorkPendingPlanApprovalModel? in
-      if case .planApproval(let model) = item {
-        return model
+  /// Open approval / permission gates that "Accept all" can sweep. Question,
+  /// plan-approval, and model-selection kinds are never auto-answered.
+  var acceptAllSweepableInputs: [WorkPendingInputItem] {
+    pendingInputs.filter { item in
+      switch item {
+      case .approval, .permission: return true
+      case .question, .planApproval, .modelSelection: return false
       }
-      return nil
-    }.first
+    }
   }
 
-  /// First open generic / file-change approval gate (Codex `approval` kind).
-  /// Rendered as a pinned badge above the composer, like the plan-ready badge.
-  var pendingApproval: WorkPendingApprovalModel? {
-    pendingInputs.compactMap { item -> WorkPendingApprovalModel? in
-      if case .approval(let model) = item {
-        return model
-      }
-      return nil
-    }.first
+  /// "Accept all" is only offered when more than one request is queued and the
+  /// current (primary) request is itself an approval/permission gate — matching
+  /// desktop, where accepting-all flips session auto-approve for the current
+  /// item then accepts the remaining approval/permission requests.
+  var canAcceptAllPendingInputs: Bool {
+    guard pendingInputCount > 1, let primary = primaryPendingInput else { return false }
+    switch primary {
+    case .approval, .permission:
+      return acceptAllSweepableInputs.count > 1
+    case .question, .planApproval, .modelSelection:
+      return false
+    }
   }
 
   var hasPendingInputGate: Bool {
@@ -329,31 +365,16 @@ struct WorkChatSessionView: View {
     return primaryPendingInput?.id
   }
 
-  /// Scroll anchor for the first blocking inline pending card. Plan approvals
-  /// live in the composer strip, so they stay visible without transcript scroll.
-  private var blockingPendingScrollAnchor: String? {
-    switch primaryPendingInput {
-    case .question(let model): return "pending-question-\(model.id)"
-    case .permission, .modelSelection, .approval, .planApproval, .none: return nil
-    }
-  }
-
-  /// React to a newly-arrived blocking pending input: fire one light haptic and
-  /// elevate the card into view. No-ops when the same gate is already open.
+  /// React to a newly-arrived blocking pending input: fire one light haptic.
+  /// All pending inputs now render in the consolidated strip pinned above the
+  /// composer, so none require a transcript scroll. No-ops when the same gate is
+  /// already open.
   @MainActor
-  func handleBlockingPendingInputChange(_ id: String?, proxy: ScrollViewProxy) {
+  func handleBlockingPendingInputChange(_ id: String?) {
     guard id != lastBlockingPendingInputId else { return }
     lastBlockingPendingInputId = id
     guard id != nil else { return }
     blockingPendingHapticToken &+= 1
-    guard let anchor = blockingPendingScrollAnchor else { return }
-    Task { @MainActor in
-      // Let the card land in the timeline before elevating it into view.
-      try? await Task.sleep(nanoseconds: 250_000_000)
-      withAnimation(.easeInOut(duration: 0.28)) {
-        proxy.scrollTo(anchor, anchor: .center)
-      }
-    }
   }
 
   @MainActor
@@ -477,12 +498,14 @@ struct WorkChatSessionView: View {
     if !canSendMessages {
       return "Reconnect to send messages."
     }
-    if pendingInputs.count == 1, pendingPlanApproval != nil || pendingApproval != nil {
-      // The plan-ready / approval badge (Approve · Decline) sits directly above
-      // the composer and is self-explanatory, so it carries no guidance banner.
+    if pendingInputs.count == 1 {
+      // The single request renders in the consolidated strip directly above the
+      // composer with its own actions, so it carries no guidance banner.
       return nil
     }
     if !pendingInputs.isEmpty {
+      // Multiple queued requests: the strip shows "Request 1 of N" and advances
+      // as each is answered, so point the user at it.
       return "Answer the waiting prompt above, or decline it before sending another message."
     }
     return nil
@@ -669,33 +692,7 @@ struct WorkChatSessionView: View {
           )
       }
 
-      if let planApproval = pendingPlanApproval {
-        WorkPlanComposerStrip(
-          plan: planApproval,
-          busy: actionInFlight || !isLive,
-          fallbackProvider: chatSummaryContext.provider,
-          onDecision: { decision, feedback in
-            await runSessionAction {
-              await onApproveRequest(planApproval.id, decision, feedback)
-            }
-          }
-        )
-        .id(planApproval.id)
-      }
-
-      if let approval = pendingApproval {
-        WorkApprovalComposerStrip(
-          approval: approval,
-          busy: actionInFlight || !isLive,
-          fallbackProvider: chatSummaryContext.provider,
-          onDecision: { decision in
-            await runSessionAction {
-              await onApproveRequest(approval.id, decision, nil)
-            }
-          }
-        )
-        .id(approval.id)
-      }
+      consolidatedPendingStripSection
 
       WorkChatComposerCard(
         chatSummary: chatSummaryContext,
@@ -961,6 +958,7 @@ struct WorkChatSessionView: View {
           pendingCodexFastMode = nil
           lastBlockingPendingInputId = nil
           blockingPendingHapticToken = 0
+          optimisticallyAnsweredInputIds.removeAll()
           assistantLineBudgets.removeAll()
           composerSettingMutationInFlight = false
           composerSettingMutationGeneration &+= 1
@@ -996,7 +994,7 @@ struct WorkChatSessionView: View {
           scheduleTimelineSnapshotRebuild()
         }
         .onChange(of: blockingPendingInputId) { _, newId in
-          handleBlockingPendingInputChange(newId, proxy: proxy)
+          handleBlockingPendingInputChange(newId)
         }
         .sensoryFeedback(.impact(weight: .light), trigger: blockingPendingHapticToken)
         .sheet(isPresented: $artifactDrawerPresented) {

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -1,4 +1,135 @@
 import SwiftUI
+import os
+
+private let workAutoLaneNamingLog = Logger(subsystem: "com.ade.ios", category: "AutoLaneNaming")
+
+@MainActor
+protocol WorkAutoLaneNamingClient: AnyObject {
+  func supportsRemoteAction(_ action: String) -> Bool
+
+  func suggestLaneName(
+    laneId: String,
+    prompt: String,
+    modelId: String,
+    fallbackName: String,
+    targetProjectId: String?,
+    targetProjectRootPath: String?
+  ) async throws -> String
+
+  func renameLane(
+    _ laneId: String,
+    name: String,
+    targetProjectId: String?,
+    targetProjectRootPath: String?
+  ) async throws
+}
+
+extension SyncService: WorkAutoLaneNamingClient {}
+
+enum WorkAutoLaneNamingSurface: String {
+  case workNewChat = "work_new_chat"
+  case hubComposer = "hub_composer"
+}
+
+enum WorkAutoLaneNamingOutcome: Equatable {
+  case missingModel
+  case keptFallback
+  case renamed(String)
+  case suggestFailed(String)
+  case renameFailed(String)
+}
+
+@discardableResult
+@MainActor
+func workRunAutoLaneAiRename(
+  laneId: String,
+  opener: String,
+  fallbackName: String,
+  modelId: String,
+  syncService: WorkAutoLaneNamingClient,
+  surface: WorkAutoLaneNamingSurface,
+  targetProjectId: String? = nil,
+  targetProjectRootPath: String? = nil,
+  maxAttempts: Int = 2,
+  retryDelayNanoseconds: UInt64 = 750_000_000,
+  refreshLanes: (@MainActor () async -> Void)? = nil
+) async -> WorkAutoLaneNamingOutcome {
+  let trimmedModelId = modelId.trimmingCharacters(in: .whitespacesAndNewlines)
+  guard !trimmedModelId.isEmpty else {
+    workAutoLaneNamingLog.error(
+      "auto_lane_naming_skipped_missing_model surface=\(surface.rawValue, privacy: .public) lane=\(laneId, privacy: .public)"
+    )
+    return .missingModel
+  }
+
+  let actionAdvertised = syncService.supportsRemoteAction("lanes.suggestName")
+  workAutoLaneNamingLog.notice(
+    "auto_lane_naming_start surface=\(surface.rawValue, privacy: .public) lane=\(laneId, privacy: .public) model=\(trimmedModelId, privacy: .public) targetProject=\(targetProjectId ?? "active", privacy: .public) advertised=\(actionAdvertised, privacy: .public)"
+  )
+
+  let attempts = max(1, maxAttempts)
+  for attempt in 1...attempts {
+    do {
+      workAutoLaneNamingLog.notice(
+        "auto_lane_naming_suggest_attempt surface=\(surface.rawValue, privacy: .public) lane=\(laneId, privacy: .public) attempt=\(attempt, privacy: .public)"
+      )
+      let suggested = try await syncService.suggestLaneName(
+        laneId: laneId,
+        prompt: opener,
+        modelId: trimmedModelId,
+        fallbackName: fallbackName,
+        targetProjectId: targetProjectId,
+        targetProjectRootPath: targetProjectRootPath
+      ).trimmingCharacters(in: .whitespacesAndNewlines)
+
+      guard !suggested.isEmpty, suggested != fallbackName else {
+        workAutoLaneNamingLog.notice(
+          "auto_lane_naming_kept_fallback surface=\(surface.rawValue, privacy: .public) lane=\(laneId, privacy: .public) attempt=\(attempt, privacy: .public)"
+        )
+        return .keptFallback
+      }
+
+      do {
+        try await syncService.renameLane(
+          laneId,
+          name: suggested,
+          targetProjectId: targetProjectId,
+          targetProjectRootPath: targetProjectRootPath
+        )
+        workAutoLaneNamingLog.notice(
+          "auto_lane_naming_renamed surface=\(surface.rawValue, privacy: .public) lane=\(laneId, privacy: .public) name=\(suggested, privacy: .public)"
+        )
+        if let refreshLanes {
+          await refreshLanes()
+        }
+        return .renamed(suggested)
+      } catch {
+        let message = error.localizedDescription
+        workAutoLaneNamingLog.error(
+          "auto_lane_naming_rename_failed surface=\(surface.rawValue, privacy: .public) lane=\(laneId, privacy: .public) error=\(message, privacy: .public)"
+        )
+        return .renameFailed(message)
+      }
+    } catch {
+      let message = error.localizedDescription
+      if attempt < attempts {
+        workAutoLaneNamingLog.warning(
+          "auto_lane_naming_suggest_retrying surface=\(surface.rawValue, privacy: .public) lane=\(laneId, privacy: .public) attempt=\(attempt, privacy: .public) error=\(message, privacy: .public)"
+        )
+        if retryDelayNanoseconds > 0 {
+          try? await Task.sleep(nanoseconds: retryDelayNanoseconds)
+        }
+        continue
+      }
+      workAutoLaneNamingLog.error(
+        "auto_lane_naming_suggest_failed surface=\(surface.rawValue, privacy: .public) lane=\(laneId, privacy: .public) attempts=\(attempts, privacy: .public) error=\(message, privacy: .public)"
+      )
+      return .suggestFailed(message)
+    }
+  }
+
+  return .suggestFailed("Auto lane naming did not complete.")
+}
 
 enum WorkNewSessionMode: String, CaseIterable, Identifiable {
   case chat
@@ -260,7 +391,7 @@ private func workPriorityLaneNamingWords(cleanedPrompt: String) -> [String] {
     normalized,
     pattern: #"\b(auth|authenticate|authentication|credential|credentials|creds|oauth)\b"#
   )
-  let mentionsLogin = workRegexContains(normalized, pattern: #"\b(log\s*in|login|signin|sign\s*in)\b"#)
+  let mentionsLogin = workRegexContains(normalized, pattern: #"\b(log\s+in|login(?!\s+history)|signin|sign\s*in)\b"#)
   let mentionsUiControl = workRegexContains(normalized, pattern: #"\b(button|cta|call to action|chip|banner)\b"#)
   guard mentionsAuth || mentionsLogin else { return [] }
   guard mentionsLogin || mentionsUiControl else { return [] }
@@ -834,32 +965,24 @@ struct WorkNewChatScreen: View {
     workDeterministicAutoLaneName(from: opener, genericSuffix: workAutoLaneGenericSuffix())
   }
 
-  /// Desktop-parity background lane naming (`startBackgroundLaneNaming` in
-  /// AgentChatPane): the lane was already created with the deterministic
-  /// fallback name, so this runs fire-and-forget after the session launch and
-  /// any failure/timeout/offline is a no-op. `lanes.suggestName` honors the
-  /// host's own titleGenerationEnabled setting and clamps the name; the rename
-  /// applies only when the suggestion differs from the fallback.
+  /// Desktop-parity background lane naming. The lane is created immediately
+  /// with the deterministic fallback; then the host AI gets two chances to
+  /// replace it, and every failure is logged with the lane id so mobile
+  /// auto-naming cannot silently disappear again.
   private func startBackgroundLaneNaming(laneId: String, opener: String, fallbackName: String) {
     let syncService = syncService
     let modelId = modelId
     let onRefreshLanes = onRefreshLanes
     Task {
-      guard
-        let suggested = try? await syncService.suggestLaneName(
-          laneId: laneId,
-          prompt: opener,
-          modelId: modelId,
-          fallbackName: fallbackName
-        ),
-        suggested != fallbackName
-      else { return }
-      do {
-        try await syncService.renameLane(laneId, name: suggested)
-      } catch {
-        return
-      }
-      await onRefreshLanes()
+      await workRunAutoLaneAiRename(
+        laneId: laneId,
+        opener: opener,
+        fallbackName: fallbackName,
+        modelId: modelId,
+        syncService: syncService,
+        surface: .workNewChat,
+        refreshLanes: onRefreshLanes
+      )
     }
   }
 

--- a/apps/ios/ADE/Views/Work/WorkRootScreen+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootScreen+Actions.swift
@@ -223,7 +223,15 @@ extension WorkRootScreen {
       }
     }
 
-    let relevantSessionIds = Set((sessions + Array(optimisticSessions.values)).map(\.id)).union(updated.keys)
+    // Keep the currently-open session(s) in the relevant set even when this
+    // partial refresh (prefix(6) lanes, or a lane whose listChatSessions threw)
+    // didn't return them. `subscribedChatSessionIds` reflects the open
+    // WorkSessionDestinationView(s); without this the open chat's summary is
+    // filtered out of `nextSummaries`, which reseeds a nil `initialChatSummary`
+    // on the next navigation rebuild and blanks the composer controls.
+    let relevantSessionIds = Set((sessions + Array(optimisticSessions.values)).map(\.id))
+      .union(updated.keys)
+      .union(syncService.subscribedChatSessionIds)
     var nextSummaries = chatSummaries.filter { relevantSessionIds.contains($0.key) }
     for (sessionId, summary) in updated {
       nextSummaries[sessionId] = summary

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -1179,22 +1179,19 @@ struct WorkSessionDestinationView: View {
   /// `session_meta_updated` event arrives from another client) into the live
   /// `chatSummary` so the composer's model/permission pill reflects the change
   /// without a refetch. Runs on the chat-event revision bump the meta event
-  /// already triggers. Only non-nil cache mode fields are merged and the
-  /// assignment is gated on a real change to avoid needless re-renders. When
-  /// `chatSummary` is nil the composer already reads the patched cache via
-  /// `composerChatSummary`, so nothing to do here.
+  /// already triggers. `mergeModeFields` mirrors the cache's cursor fields
+  /// wholesale (the cache is authoritative), so an explicit `cursorModeId` /
+  /// `cursorConfigValues` clear folded into the cache reaches the live composer
+  /// here; the assignment is gated on a real change to avoid needless
+  /// re-renders. When `chatSummary` is nil the composer already reads the
+  /// patched cache via `composerChatSummary`, so nothing to do here.
   @MainActor
   func reconcileChatSummaryModeFromCacheIfNeeded() {
     guard var current = chatSummary,
           let cached = syncService.chatSummaryCache[sessionId],
           cached.sessionId == current.sessionId
     else { return }
-    current.mergeModeFields(
-      from: cached,
-      // A cache-side explicit `cursorModeId: null` clear must reach the live
-      // composer; the non-nil-only merge would otherwise leave the stale mode.
-      cursorModeIdCleared: syncService.cursorModeClearedSessionIds.contains(sessionId)
-    )
+    current.mergeModeFields(from: cached)
     if current != chatSummary {
       chatSummary = current
     }

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -1189,7 +1189,12 @@ struct WorkSessionDestinationView: View {
           let cached = syncService.chatSummaryCache[sessionId],
           cached.sessionId == current.sessionId
     else { return }
-    current.mergeModeFields(from: cached)
+    current.mergeModeFields(
+      from: cached,
+      // A cache-side explicit `cursorModeId: null` clear must reach the live
+      // composer; the non-nil-only merge would otherwise leave the stale mode.
+      cursorModeIdCleared: syncService.cursorModeClearedSessionIds.contains(sessionId)
+    )
     if current != chatSummary {
       chatSummary = current
     }

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -322,6 +322,13 @@ struct WorkSessionDestinationView: View {
 
   @State var session: TerminalSessionSummary?
   @State var chatSummary: AgentChatSessionSummary?
+  // Last non-nil summary this mounted instance ever observed. The composer's
+  // model-picker + permission-mode row is gated on `summary.isAvailable`, so a
+  // momentary nil summary would blank those controls mid-session. This latch
+  // (plus the sync cache) backstops the coalesce in `composerChatSummary` so
+  // once the controls have rendered they never disappear while the view stays
+  // mounted.
+  @State var lastKnownChatSummary: AgentChatSessionSummary?
   @State var transcript: [WorkChatEnvelope] = []
   @State var transcriptRenderSignature = 0
   @State var mainChatRenderEpoch = 0
@@ -504,6 +511,21 @@ struct WorkSessionDestinationView: View {
       return navigationTitleOverride
     }
     return chatSummary?.title ?? session?.title ?? "Session"
+  }
+
+  /// Summary the composer's model/permission controls render from. Every other
+  /// status read coalesces `chatSummary ?? initialChatSummary`, but the composer
+  /// context was the lone consumer reading bare `chatSummary` — so a
+  /// push/deeplink rebuild (new `.id`, @State reset) that re-seeds from a nil
+  /// `initialChatSummary` (the open session can be evicted from the summary
+  /// cache by a partial Work-list refresh) blanked the controls. Coalesce
+  /// through the seed, the in-view latch, and finally the durable sync cache so
+  /// the controls survive both the rebuild and any transient nil.
+  var composerChatSummary: AgentChatSessionSummary? {
+    chatSummary
+      ?? initialChatSummary
+      ?? lastKnownChatSummary
+      ?? syncService.chatSummaryCache[sessionId]
   }
 
   var subagentProvider: String? {
@@ -826,6 +848,7 @@ struct WorkSessionDestinationView: View {
         }
       }
       .task(id: liveChatObservationKey) {
+        reconcileChatSummaryModeFromCacheIfNeeded()
         syncTranscriptFromLiveEvents()
         await reconcileIdleCanonicalTranscriptIfNeeded()
       }
@@ -878,6 +901,13 @@ struct WorkSessionDestinationView: View {
       }
       .task(id: selectedSubagentPollingKey) {
         await pollSelectedSubagentTranscriptIfNeeded()
+      }
+      .onChange(of: chatSummary) { _, newValue in
+        // Latch the last non-nil summary so the composer's model/permission
+        // controls survive a transient nil while this view stays mounted.
+        if let newValue {
+          lastKnownChatSummary = newValue
+        }
       }
       .onChange(of: transcript) { _, _ in
         refreshSubagentSnapshots()
@@ -981,7 +1011,7 @@ struct WorkSessionDestinationView: View {
     }
     return WorkChatSessionView(
       session: WorkChatSessionRenderContext(session),
-      chatSummaryContext: WorkChatSummaryRenderContext(chatSummary),
+      chatSummaryContext: WorkChatSummaryRenderContext(composerChatSummary),
       transcript: transcriptForView,
       transcriptRenderSignature: viewingSubagent ? subagentTranscriptRenderSignature : transcriptRenderSignature,
       fallbackEntries: fallbackEntriesForView,
@@ -1143,6 +1173,26 @@ struct WorkSessionDestinationView: View {
           isChatSession(currentSession)
     else { return false }
     return true
+  }
+
+  /// Fold a cache-side mode patch (applied by SyncService when a
+  /// `session_meta_updated` event arrives from another client) into the live
+  /// `chatSummary` so the composer's model/permission pill reflects the change
+  /// without a refetch. Runs on the chat-event revision bump the meta event
+  /// already triggers. Only non-nil cache mode fields are merged and the
+  /// assignment is gated on a real change to avoid needless re-renders. When
+  /// `chatSummary` is nil the composer already reads the patched cache via
+  /// `composerChatSummary`, so nothing to do here.
+  @MainActor
+  func reconcileChatSummaryModeFromCacheIfNeeded() {
+    guard var current = chatSummary,
+          let cached = syncService.chatSummaryCache[sessionId],
+          cached.sessionId == current.sessionId
+    else { return }
+    current.mergeModeFields(from: cached)
+    if current != chatSummary {
+      chatSummary = current
+    }
   }
 
   @MainActor

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -815,44 +815,13 @@ func buildWorkTimeline(
     WorkTimelineEntry(id: "event-\(card.id)", timestamp: card.timestamp, rank: 1_500 + index, payload: .eventCard(card))
   })
 
-  // Resolve a chronological timestamp for each pending-input itemId by looking
-  // up its originating approval_request / structured_question / question-tool
-  // tool_call envelope. Falling back to the latest transcript timestamp keeps
-  // the pending card in place when the source envelope was dropped upstream.
-  let pendingTimestamps = workPendingInputTimestamps(from: transcript)
-  let fallbackPendingTimestamp = transcript.last?.timestamp ?? ""
-  entries.append(contentsOf: pendingInputs.enumerated().compactMap { index, input -> WorkTimelineEntry? in
-    switch input {
-    case .question(let model):
-      let ts = pendingTimestamps[model.id] ?? fallbackPendingTimestamp
-      return WorkTimelineEntry(
-        id: "pending-question-\(model.id)",
-        timestamp: ts,
-        rank: 1_600 + index,
-        payload: .pendingQuestion(model)
-      )
-    case .permission(let model):
-      let ts = pendingTimestamps[model.id] ?? fallbackPendingTimestamp
-      return WorkTimelineEntry(
-        id: "pending-permission-\(model.id)",
-        timestamp: ts,
-        rank: 1_600 + index,
-        payload: .pendingPermission(model)
-      )
-    case .planApproval:
-      return nil
-    case .modelSelection(let model):
-      let ts = pendingTimestamps[model.id] ?? fallbackPendingTimestamp
-      return WorkTimelineEntry(
-        id: "pending-model-selection-\(model.id)",
-        timestamp: ts,
-        rank: 1_600 + index,
-        payload: .pendingModelSelection(model)
-      )
-    case .approval:
-      return nil
-    }
-  })
+  // Pending inputs (approval / question / permission / plan-approval /
+  // model-selection) are no longer emitted as inline transcript entries. They
+  // render in the single consolidated pending-input strip pinned above the
+  // composer (`WorkChatSessionView.consolidatedPendingInputStrip`), matching the
+  // desktop approval card. `pendingInputs` still drives `suppressedItemIds`
+  // above so the originating tool/approval envelopes stay hidden from the
+  // transcript.
 
   let turnUsageSummaries = transcript.compactMap { envelope -> (id: String, timestamp: String, usage: WorkUsageSummary)? in
     guard case .done(_, _, let usage, _, _, _) = envelope.event, let usage else { return nil }
@@ -1540,27 +1509,6 @@ private func mergedWorkEventCard(_ existing: WorkEventCardModel, with incoming: 
     )
   }
   return incoming
-}
-
-/// Map pending-input itemIds to the timestamp of their originating envelope so
-/// inline timeline entries sort into the chronological slot where the host
-/// first requested input, not the current "now".
-func workPendingInputTimestamps(from transcript: [WorkChatEnvelope]) -> [String: String] {
-  var result: [String: String] = [:]
-  for envelope in transcript {
-    switch envelope.event {
-    case .approvalRequest(_, _, let itemId, _),
-         .structuredQuestion(_, _, let itemId, _):
-      if result[itemId] == nil { result[itemId] = envelope.timestamp }
-    case .toolCall(let tool, _, let itemId, _, _):
-      if isQuestionInputToolName(tool), result[itemId] == nil {
-        result[itemId] = envelope.timestamp
-      }
-    default:
-      continue
-    }
-  }
-  return result
 }
 
 private func eventCard(

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -9647,6 +9647,31 @@ final class ADETests: XCTestCase {
     XCTAssertFalse(unrelatedUpdate.cursorModeIdWasCleared)
     summary.applyModeUpdate(unrelatedUpdate)
     XCTAssertEqual(summary.cursorModeId, "agent")
+
+    // The cache fold above is only half the story: the open chat view rebuilds
+    // its LIVE summary from the cache via `mergeModeFields(from:)`, which copies
+    // only non-nil cursor modes. An explicit clear must still reach that live
+    // summary, so the reconcile threads a `cursorModeIdCleared` flag.
+    var cachedAfterClear = summary
+    cachedAfterClear.cursorModeId = nil
+    var liveSummary = summary
+    liveSummary.cursorModeId = "agent"
+    // Without the cleared flag, a plain merge preserves the live mode (the
+    // invariant: a partial summary merge never nulls an unrelated field).
+    var mergedNoClear = liveSummary
+    mergedNoClear.mergeModeFields(from: cachedAfterClear)
+    XCTAssertEqual(mergedNoClear.cursorModeId, "agent")
+    // With the cleared flag, the nil propagates to the live summary/composer.
+    var mergedCleared = liveSummary
+    mergedCleared.mergeModeFields(from: cachedAfterClear, cursorModeIdCleared: true)
+    XCTAssertNil(mergedCleared.cursorModeId)
+    // A non-nil cache mode still wins even under the cleared flag (belt-and-
+    // suspenders: a re-set mode is never clobbered to nil).
+    var cachedWithMode = summary
+    cachedWithMode.cursorModeId = "plan"
+    var mergedReset = liveSummary
+    mergedReset.mergeModeFields(from: cachedWithMode, cursorModeIdCleared: true)
+    XCTAssertEqual(mergedReset.cursorModeId, "plan")
   }
 
   func testAgentChatSessionDecodesCodexFastModeFlag() throws {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -9586,6 +9586,69 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(summary.requestedCwd, "apps/ios/ADE")
   }
 
+  func testAgentChatMetaModeUpdateAppliesCursorConfigAndExplicitClear() throws {
+    let summaryPayload: [String: Any] = [
+      "sessionId": "chat-1",
+      "laneId": "lane-1",
+      "provider": "cursor",
+      "model": "cursor-agent",
+      "modelId": "cursor-agent-1",
+      "cursorModeId": "ask",
+      "cursorConfigValues": ["voice": true],
+      "status": "running",
+      "startedAt": "2026-03-25T00:00:00.000Z",
+      "lastActivityAt": "2026-03-25T00:00:00.000Z",
+    ]
+    var summary = try JSONDecoder().decode(
+      AgentChatSessionSummary.self,
+      from: try JSONSerialization.data(withJSONObject: summaryPayload)
+    )
+    XCTAssertEqual(summary.cursorModeId, "ask")
+
+    // A config-only update carries new cursorConfigValues and, per the host
+    // emit, the current (non-null) cursorModeId. Both should be applied.
+    let configUpdate = try JSONDecoder().decode(
+      AgentChatSessionMetaModeUpdate.self,
+      from: try JSONSerialization.data(withJSONObject: [
+        "type": "session_meta_updated",
+        "cursorModeId": "ask",
+        "cursorConfigValues": ["voice": false, "temperature": 0.7],
+      ])
+    )
+    XCTAssertTrue(configUpdate.hasAnyField)
+    summary.applyModeUpdate(configUpdate)
+    XCTAssertEqual(summary.cursorModeId, "ask")
+    XCTAssertEqual(summary.cursorConfigValues?["voice"], .bool(false))
+    XCTAssertEqual(summary.cursorConfigValues?["temperature"], .number(0.7))
+
+    // An explicit `cursorModeId: null` is an intentional clear and must drop
+    // the mode rather than being ignored as if the key were absent.
+    let clearUpdate = try JSONDecoder().decode(
+      AgentChatSessionMetaModeUpdate.self,
+      from: try JSONSerialization.data(withJSONObject: [
+        "type": "session_meta_updated",
+        "cursorModeId": NSNull(),
+      ])
+    )
+    XCTAssertTrue(clearUpdate.cursorModeIdWasCleared)
+    XCTAssertTrue(clearUpdate.hasAnyField)
+    summary.applyModeUpdate(clearUpdate)
+    XCTAssertNil(summary.cursorModeId)
+
+    // A partial update that omits cursorModeId entirely must NOT clear it.
+    summary.cursorModeId = "agent"
+    let unrelatedUpdate = try JSONDecoder().decode(
+      AgentChatSessionMetaModeUpdate.self,
+      from: try JSONSerialization.data(withJSONObject: [
+        "type": "session_meta_updated",
+        "permissionMode": "edit",
+      ])
+    )
+    XCTAssertFalse(unrelatedUpdate.cursorModeIdWasCleared)
+    summary.applyModeUpdate(unrelatedUpdate)
+    XCTAssertEqual(summary.cursorModeId, "agent")
+  }
+
   func testAgentChatSessionDecodesCodexFastModeFlag() throws {
     let payload: [String: Any] = [
       "sessionId": "chat-fast",

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -9648,30 +9648,60 @@ final class ADETests: XCTestCase {
     summary.applyModeUpdate(unrelatedUpdate)
     XCTAssertEqual(summary.cursorModeId, "agent")
 
+    // An explicit `cursorConfigValues: null` is likewise an intentional clear —
+    // decodeIfPresent alone collapses it into "absent", so the decoder records
+    // `cursorConfigValuesWasCleared` and applyModeUpdate drops the stale config.
+    summary.cursorConfigValues = ["voice": .bool(true)]
+    let configClearUpdate = try JSONDecoder().decode(
+      AgentChatSessionMetaModeUpdate.self,
+      from: try JSONSerialization.data(withJSONObject: [
+        "type": "session_meta_updated",
+        "cursorConfigValues": NSNull(),
+      ])
+    )
+    XCTAssertTrue(configClearUpdate.cursorConfigValuesWasCleared)
+    XCTAssertTrue(configClearUpdate.hasAnyField)
+    summary.applyModeUpdate(configClearUpdate)
+    XCTAssertNil(summary.cursorConfigValues)
+
+    // A partial update that omits cursorConfigValues must NOT clear it.
+    summary.cursorConfigValues = ["voice": .bool(true)]
+    XCTAssertFalse(unrelatedUpdate.cursorConfigValuesWasCleared)
+    summary.applyModeUpdate(unrelatedUpdate)
+    XCTAssertEqual(summary.cursorConfigValues?["voice"], .bool(true))
+
     // The cache fold above is only half the story: the open chat view rebuilds
-    // its LIVE summary from the cache via `mergeModeFields(from:)`, which copies
-    // only non-nil cursor modes. An explicit clear must still reach that live
-    // summary, so the reconcile threads a `cursorModeIdCleared` flag.
+    // its LIVE summary from the cache via `mergeModeFields(from:)`. The cache is
+    // authoritative for cursor fields, so the merge mirrors them wholesale —
+    // nil included — which is exactly how an explicit clear reaches the live
+    // composer, with no stateful clear marker.
     var cachedAfterClear = summary
     cachedAfterClear.cursorModeId = nil
+    cachedAfterClear.cursorConfigValues = nil
     var liveSummary = summary
     liveSummary.cursorModeId = "agent"
-    // Without the cleared flag, a plain merge preserves the live mode (the
-    // invariant: a partial summary merge never nulls an unrelated field).
-    var mergedNoClear = liveSummary
-    mergedNoClear.mergeModeFields(from: cachedAfterClear)
-    XCTAssertEqual(mergedNoClear.cursorModeId, "agent")
-    // With the cleared flag, the nil propagates to the live summary/composer.
+    liveSummary.cursorConfigValues = ["voice": .bool(true)]
     var mergedCleared = liveSummary
-    mergedCleared.mergeModeFields(from: cachedAfterClear, cursorModeIdCleared: true)
-    XCTAssertNil(mergedCleared.cursorModeId)
-    // A non-nil cache mode still wins even under the cleared flag (belt-and-
-    // suspenders: a re-set mode is never clobbered to nil).
-    var cachedWithMode = summary
-    cachedWithMode.cursorModeId = "plan"
-    var mergedReset = liveSummary
-    mergedReset.mergeModeFields(from: cachedWithMode, cursorModeIdCleared: true)
-    XCTAssertEqual(mergedReset.cursorModeId, "plan")
+    mergedCleared.mergeModeFields(from: cachedAfterClear)
+    XCTAssertNil(mergedCleared.cursorModeId, "explicit cache clear must null the live cursor mode")
+    XCTAssertNil(mergedCleared.cursorConfigValues, "explicit cache clear must null the live cursor config")
+
+    // Regression guard (the "stale clear marker wins" bug): after a clear, a
+    // host that RESTORES a non-null mode/config must NOT be re-cleared. With no
+    // persistent clear state, each reconcile mirrors the current authoritative
+    // cache, so a restored value survives.
+    var cachedRestored = summary
+    cachedRestored.cursorModeId = "plan"
+    cachedRestored.cursorConfigValues = ["voice": .bool(false)]
+    var liveAfterClear = liveSummary
+    liveAfterClear.cursorModeId = nil
+    liveAfterClear.cursorConfigValues = nil
+    liveAfterClear.mergeModeFields(from: cachedRestored)
+    XCTAssertEqual(liveAfterClear.cursorModeId, "plan", "a host-restored mode must not be re-cleared")
+    XCTAssertEqual(
+      liveAfterClear.cursorConfigValues?["voice"], .bool(false),
+      "a host-restored config must not be re-cleared"
+    )
   }
 
   func testAgentChatSessionDecodesCodexFastModeFlag() throws {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -4,6 +4,82 @@ import SQLite3
 import UIKit
 @testable import ADE
 
+@MainActor
+private final class WorkAutoLaneNamingClientSpy: WorkAutoLaneNamingClient {
+  enum SuggestResult {
+    case success(String)
+    case failure(Error)
+  }
+
+  struct SuggestCall: Equatable {
+    let laneId: String
+    let prompt: String
+    let modelId: String
+    let fallbackName: String
+    let targetProjectId: String?
+    let targetProjectRootPath: String?
+  }
+
+  struct RenameCall: Equatable {
+    let laneId: String
+    let name: String
+    let targetProjectId: String?
+    let targetProjectRootPath: String?
+  }
+
+  var supportedActions: Set<String> = ["lanes.suggestName"]
+  var suggestResults: [SuggestResult] = []
+  var renameError: Error?
+  private(set) var suggestCalls: [SuggestCall] = []
+  private(set) var renameCalls: [RenameCall] = []
+
+  func supportsRemoteAction(_ action: String) -> Bool {
+    supportedActions.contains(action)
+  }
+
+  func suggestLaneName(
+    laneId: String,
+    prompt: String,
+    modelId: String,
+    fallbackName: String,
+    targetProjectId: String?,
+    targetProjectRootPath: String?
+  ) async throws -> String {
+    suggestCalls.append(SuggestCall(
+      laneId: laneId,
+      prompt: prompt,
+      modelId: modelId,
+      fallbackName: fallbackName,
+      targetProjectId: targetProjectId,
+      targetProjectRootPath: targetProjectRootPath
+    ))
+    guard !suggestResults.isEmpty else { return fallbackName }
+    switch suggestResults.removeFirst() {
+    case .success(let value):
+      return value
+    case .failure(let error):
+      throw error
+    }
+  }
+
+  func renameLane(
+    _ laneId: String,
+    name: String,
+    targetProjectId: String?,
+    targetProjectRootPath: String?
+  ) async throws {
+    renameCalls.append(RenameCall(
+      laneId: laneId,
+      name: name,
+      targetProjectId: targetProjectId,
+      targetProjectRootPath: targetProjectRootPath
+    ))
+    if let renameError {
+      throw renameError
+    }
+  }
+}
+
 /// Default `lastActivityAt`/`startedAt` for fixture sessions. Returns "now"
 /// in ISO 8601 so the >7-day staleness guard in
 /// `normalizedWorkChatSessionStatus` doesn't reclassify default fixtures as
@@ -7169,6 +7245,78 @@ final class ADETests: XCTestCase {
     )
   }
 
+  func testWorkAutoLaneFallbackDoesNotTreatLoginHistoryAsProviderAuthTask() {
+    XCTAssertEqual(
+      workDeterministicAutoLaneName(
+        from: "Debug cursor SDK chat mobile sync issues. Look at the full login history, then follow the Claude MD guidance."
+      ),
+      "debug-cursor-sdk-mobile-sync"
+    )
+  }
+
+  @MainActor
+  func testWorkAutoLaneAiRenameRetriesAndRenamesWithTargetProjectScope() async {
+    let client = WorkAutoLaneNamingClientSpy()
+    client.suggestResults = [
+      .failure(NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "temporary"])),
+      .success("debug-mobile-sync"),
+    ]
+    var refreshCount = 0
+
+    let outcome = await workRunAutoLaneAiRename(
+      laneId: "lane-1",
+      opener: "Debug mobile sync issues",
+      fallbackName: "debug-mobile-sync-issue",
+      modelId: " anthropic/claude-fable-5 ",
+      syncService: client,
+      surface: .hubComposer,
+      targetProjectId: "project-1",
+      targetProjectRootPath: "/tmp/project",
+      retryDelayNanoseconds: 0,
+      refreshLanes: { refreshCount += 1 }
+    )
+
+    XCTAssertEqual(outcome, .renamed("debug-mobile-sync"))
+    XCTAssertEqual(client.suggestCalls.count, 2)
+    XCTAssertEqual(client.suggestCalls[0], WorkAutoLaneNamingClientSpy.SuggestCall(
+      laneId: "lane-1",
+      prompt: "Debug mobile sync issues",
+      modelId: "anthropic/claude-fable-5",
+      fallbackName: "debug-mobile-sync-issue",
+      targetProjectId: "project-1",
+      targetProjectRootPath: "/tmp/project"
+    ))
+    XCTAssertEqual(client.renameCalls, [
+      WorkAutoLaneNamingClientSpy.RenameCall(
+        laneId: "lane-1",
+        name: "debug-mobile-sync",
+        targetProjectId: "project-1",
+        targetProjectRootPath: "/tmp/project"
+      ),
+    ])
+    XCTAssertEqual(refreshCount, 1)
+  }
+
+  @MainActor
+  func testWorkAutoLaneAiRenameKeepsFallbackWithoutRename() async {
+    let client = WorkAutoLaneNamingClientSpy()
+    client.suggestResults = [.success("fallback-name")]
+
+    let outcome = await workRunAutoLaneAiRename(
+      laneId: "lane-1",
+      opener: "Debug mobile sync issues",
+      fallbackName: "fallback-name",
+      modelId: "m",
+      syncService: client,
+      surface: .workNewChat,
+      retryDelayNanoseconds: 0
+    )
+
+    XCTAssertEqual(outcome, .keptFallback)
+    XCTAssertEqual(client.suggestCalls.count, 1)
+    XCTAssertTrue(client.renameCalls.isEmpty)
+  }
+
   func testLaneDetailRebaseBannerAccessibilityLabelIncludesVisibleBadges() {
     XCTAssertEqual(
       laneDetailRebaseBannerAccessibilityLabel(behindCount: 1, parentLabel: "main", hasPr: true),
@@ -7379,6 +7527,53 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(
       workChatLiveObservationKey(sessionId: "chat-1", chatEventRevision: 7),
       "chat-1-7"
+    )
+  }
+
+  /// Regression: a partial Work-list refresh must MERGE into the summary cache,
+  /// never replace it. The composer's model/permission controls gate on the open
+  /// session's cached summary (`isAvailable`), so if a reduced refresh that omits
+  /// the open session evicted it, those controls would blank mid-session. This
+  /// pins that `cacheChatSummaries` keeps the omitted session's summary — with
+  /// its mode fields intact — while still overwriting the entries that ARE
+  /// present. The explicit whole-cache reset path stays covered by disconnect.
+  @MainActor
+  func testCacheChatSummariesMergesAndKeepsOpenSessionOnPartialRefresh() {
+    let database = makeDatabase(baseURL: makeTemporaryDirectory())
+    defer { database.close() }
+    let service = SyncService(database: database)
+
+    let openSession = makeAgentChatSessionSummary(
+      sessionId: "open-session",
+      status: "active",
+      permissionMode: "acceptEdits"
+    )
+    let otherSession = makeAgentChatSessionSummary(sessionId: "other-session", status: "idle")
+    service.cacheChatSummaries([
+      openSession.sessionId: openSession,
+      otherSession.sessionId: otherSession,
+    ])
+
+    // Partial refresh: only "other-session" (now active), omitting the currently
+    // open session entirely — the shape a reduced-sync-load prefix or an empty
+    // `listChatSessions` result hands off.
+    let otherRefreshed = makeAgentChatSessionSummary(sessionId: "other-session", status: "active")
+    service.cacheChatSummaries([otherRefreshed.sessionId: otherRefreshed])
+
+    XCTAssertEqual(
+      service.chatSummaryCache["open-session"],
+      openSession,
+      "Partial refresh must not evict the open session's summary; its composer controls gate on it."
+    )
+    XCTAssertEqual(
+      service.chatSummaryCache["open-session"]?.permissionMode,
+      "acceptEdits",
+      "The open session's mode fields must survive a partial refresh."
+    )
+    XCTAssertEqual(
+      service.chatSummaryCache["other-session"]?.status,
+      "active",
+      "Entries present in the refresh must be overwritten with the newer summary."
     )
   }
 
@@ -13938,7 +14133,7 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(model.questions[1].questionId, "b")
   }
 
-  func testBuildWorkTimelineEmitsInlinePendingQuestionAndSuppressesGenericApprovalCard() {
+  func testBuildWorkTimelineOmitsInlinePendingQuestionAndSuppressesGenericApprovalCard() {
     let detail = """
     {"request":{"itemId":"ap-1","kind":"structured_question","title":"T","questions":[{"id":"q","question":"Q","options":[{"label":"A","value":"a"}]}]}}
     """
@@ -13971,24 +14166,25 @@ final class ADETests: XCTestCase {
 
     XCTAssertTrue(snapshot.eventCards.allSatisfy { $0.kind != "approval" }, "Generic approval event card must be suppressed when a pending rich question exists for the same itemId.")
 
-    let pendingEntry = snapshot.timeline.first { entry in
-      if case .pendingQuestion(let model) = entry.payload, model.id == "ap-1" { return true }
+    // Pending questions now render only in the consolidated composer strip, so
+    // no inline transcript entry is emitted for them.
+    XCTAssertFalse(snapshot.timeline.contains { entry in
+      if case .pendingQuestion = entry.payload { return true }
       return false
-    }
-    guard let pendingEntry else {
-      return XCTFail("Expected a .pendingQuestion timeline entry for itemId ap-1.")
-    }
-    XCTAssertEqual(pendingEntry.timestamp, "2026-04-20T00:00:02.000Z")
+    }, "Pending questions must not render as inline transcript entries.")
 
-    // Chronological: Before (t=01) → pendingQuestion (t=02) → After (t=03).
-    let indices = snapshot.timeline.compactMap { entry -> (String, String)? in
-      switch entry.payload {
-      case .message(let msg): return (msg.id, entry.timestamp)
-      case .pendingQuestion(let m): return ("pending-\(m.id)", entry.timestamp)
-      default: return nil
-      }
+    // The question still surfaces via the derived pending-input queue that feeds
+    // the strip.
+    guard case .question(let model)? = snapshot.pendingInputs.first(where: { $0.itemId == "ap-1" }) else {
+      return XCTFail("Expected ap-1 to remain in the derived pending-input queue.")
     }
-    let timestamps = indices.map(\.1)
+    XCTAssertEqual(model.id, "ap-1")
+
+    // Remaining transcript entries (the two assistant messages) stay chronological.
+    let timestamps = snapshot.timeline.compactMap { entry -> String? in
+      if case .message = entry.payload { return entry.timestamp }
+      return nil
+    }
     XCTAssertEqual(timestamps, timestamps.sorted(), "Timeline must sort chronologically.")
   }
 
@@ -14060,7 +14256,7 @@ final class ADETests: XCTestCase {
     XCTAssertFalse(snapshot.eventCards.flatMap { [$0.body ?? ""] + $0.bullets }.contains { $0.contains("{") || $0.contains("\"request\"") })
   }
 
-  func testBuildWorkTimelineEmitsInlinePermissionAndSuppressesGenericEventCard() {
+  func testBuildWorkTimelineOmitsInlinePermissionAndSuppressesGenericEventCard() {
     let detail = """
     {"request":{"itemId":"perm-1","kind":"permissions","tool":"functions.GitHub","description":"Allow GitHub MCP"}}
     """
@@ -14079,11 +14275,20 @@ final class ADETests: XCTestCase {
       localEchoMessages: []
     )
     XCTAssertTrue(snapshot.eventCards.allSatisfy { $0.kind != "approval" })
-    let hasPendingPermission = snapshot.timeline.contains { entry in
-      if case .pendingPermission(let m) = entry.payload, m.id == "perm-1" { return true }
+
+    // Pending permissions now render only in the consolidated composer strip, so
+    // no inline transcript entry is emitted for them.
+    XCTAssertFalse(snapshot.timeline.contains { entry in
+      if case .pendingPermission = entry.payload { return true }
       return false
+    }, "Pending permissions must not render as inline transcript entries.")
+
+    // The permission still surfaces via the derived pending-input queue that
+    // feeds the strip.
+    guard case .permission(let model)? = snapshot.pendingInputs.first(where: { $0.itemId == "perm-1" }) else {
+      return XCTFail("Expected perm-1 to remain in the derived pending-input queue.")
     }
-    XCTAssertTrue(hasPendingPermission, "Expected an inline .pendingPermission timeline entry.")
+    XCTAssertEqual(model.id, "perm-1")
   }
 
   func testBuildWorkTimelineKeepsResolvedPermissionReadable() {
@@ -14200,11 +14405,19 @@ final class ADETests: XCTestCase {
     )
 
     XCTAssertTrue(snapshot.toolCards.isEmpty, "Pending permission should suppress duplicate raw tool cards.")
-    let hasPendingPermission = snapshot.timeline.contains { entry in
-      if case .pendingPermission(let model) = entry.payload, model.id == "perm-1" { return true }
+
+    // The pending permission is consumed by the consolidated composer strip, not
+    // emitted as an inline transcript entry.
+    XCTAssertFalse(snapshot.timeline.contains { entry in
+      if case .pendingPermission = entry.payload { return true }
       return false
+    }, "Pending permissions must not render as inline transcript entries.")
+
+    // It still surfaces via the derived pending-input queue that feeds the strip.
+    guard case .permission(let model)? = snapshot.pendingInputs.first(where: { $0.itemId == "perm-1" }) else {
+      return XCTFail("Expected perm-1 to remain in the derived pending-input queue.")
     }
-    XCTAssertTrue(hasPendingPermission)
+    XCTAssertEqual(model.id, "perm-1")
   }
 
   func testBuildWorkTimelineSuppressesGenericApprovalEventWhilePending() {


### PR DESCRIPTION
## Summary

Bundles the full lane per request — two workstreams:

**1. Cursor chat reliability + cross-client permission-mode sync (desktop + CLI + iOS)**
- **Real Cursor errors surfaced.** A mid-run Cursor SDK failure (e.g. an `NGHTTP2_INTERNAL_ERROR` transport reset) previously showed only the generic "Cursor SDK run failed." — the real reason lives only in the SDK's run store. The worker now reads that `errorCode` on a terminal ERROR and renders `Cursor run failed: <code>`, classifies transport-class failures as `errorInfo.category="network"` (so the renderer can offer retry), and logs `agent_chat.cursor_sdk_run_error`. No auto-retry (a resend could duplicate side effects like a push/PR).
- **Mode changes broadcast live.** Changing a chat's permission/mode from one client (e.g. iOS) applied on the runtime but left other clients' composers stale until the turn ended. `updateSession` now emits a `session_meta_updated` carrying the permission/interaction/cursor-mode fields (incl. recomputed `cursorModeSnapshot`); **desktop, TUI, and iOS** all patch their composer on receipt.

**2. iOS Work polish**
- Composer no longer blanks its model/permission controls mid-session (coalesce + latch the summary; cache merges instead of replacing, so a push/deeplink nav reset can't drop the open session's summary).
- Consolidated pending-input strip pinned above the composer (**"Request 1 of N"** + **Accept-all** sweep) replaces the scattered per-request inline approval cards.

**3. Sync / lane-naming (concurrent-session work, bundled per request)**
- Persist peer app provenance (`appVersion`/`appBuild`/`bundleIdentifier`) in device metadata.
- Lane-name heuristic excludes "login history"; auto-title prefers the configured title model before the requested composer model.

## Testing
- `/quality` (dual-track) clean: 0 Blocker/High/Medium; 2 behavior-preserving cleanups applied.
- `/test`: desktop changed-file tests 496 pass; ade-cli 1,506 pass; TUI 814 pass; iOS build + key tests green (incl. a new `cacheChatSummaries` merge regression test).
- Docs updated across chat + sync-and-multi-device feature docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved live session updates so permission, interaction, and cursor settings refresh immediately across chat and composer views.
  * Added richer lane naming behavior with better fallback handling and clearer retry results.
  * Added support for showing more app/device identity details during sync.

* **Bug Fixes**
  * Fixed lane naming so “login history” no longer gets misclassified.
  * Improved error reporting for failed runs, including clearer network-related failures.
  * Pending approvals and questions now display in a consolidated, easier-to-use strip without duplicating timeline entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves Cursor chat reliability, cross-client mode sync, and mobile chat controls. The main changes are:

- Surfaces Cursor SDK run error details and network classification.
- Broadcasts session mode and Cursor config updates to desktop, TUI, and iOS clients.
- Keeps iOS chat summaries available during partial refreshes.
- Consolidates iOS pending approvals into one composer strip.
- Adds peer app provenance and lane naming refinements.

<h3>Confidence Score: 4/5</h3>

The iOS Cursor summary merge can clear live composer state from an omitted field.

Explicit clear handling is improved across the changed sync path, but the new wholesale merge treats absent cached Cursor fields as clears.

apps/ios/ADE/Models/RemoteModels.swift

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verification in the Linux sandbox showed that Swift and Xcode tooling were unavailable, blocking the Swift decoding and merge path for absent cursor fields.
- Saved a minimal Swift harness that mirrors the repository cursor fields and merge statements to enable reruns in an environment where Swift is available.
- Ran the desktop Vitest suite; the run completed with Exit status 0 and a complete test summary across 3 files and 496 tests in 17.07s.

<a href="https://app.greptile.com/trex/runs/13504762/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Models/RemoteModels.swift | Adds explicit null handling for Cursor mode and config updates, but the live-summary merge can over-apply nil cursor fields from cached summaries. |
| apps/desktop/src/main/services/chat/agentChatService.ts | Emits transient session metadata updates for cross-client mode and Cursor config changes. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Applies session metadata updates to the desktop composer, including Cursor mode and config clears. |
| apps/ade-cli/src/tuiClient/app.tsx | Applies session metadata updates to the TUI composer without echoing local commits. |


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/desktop/src/main/services/chat/cursorSdkWorker.ts`, line 615-620 ([link](https://github.com/arul28/ade/blob/462ce7f7d941108b64ecd466d28bb3cc97a0b43d/apps/desktop/src/main/services/chat/cursorSdkWorker.ts#L615-L620)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Error Event Reorders Stream**

   This loop withholds the first terminal `ERROR` status but keeps forwarding any later stream events before posting the held error after `wait()`. If the SDK emits cleanup/final status events after the error status, the chat bridge observes those events before the failure and can update the transcript or run state in the wrong order.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/desktop/src/main/services/chat/cursorSdkWorker.ts
   Line: 615-620

   Comment:
   **Error Event Reorders Stream**

   This loop withholds the first terminal `ERROR` status but keeps forwarding any later stream events before posting the held error after `wait()`. If the SDK emits cleanup/final status events after the error status, the chat bridge observes those events before the failure and can update the transcript or run state in the wrong order.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fchat%2FcursorSdkWorker.ts%0ALine%3A%20615-620%0A%0AComment%3A%0A**Error%20Event%20Reorders%20Stream**%0A%0AThis%20loop%20withholds%20the%20first%20terminal%20%60ERROR%60%20status%20but%20keeps%20forwarding%20any%20later%20stream%20events%20before%20posting%20the%20held%20error%20after%20%60wait%28%29%60.%20If%20the%20SDK%20emits%20cleanup%2Ffinal%20status%20events%20after%20the%20error%20status%2C%20the%20chat%20bridge%20observes%20those%20events%20before%20the%20failure%20and%20can%20update%20the%20transcript%20or%20run%20state%20in%20the%20wrong%20order.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=716&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

2. `apps/ios/ADE/Models/RemoteModels.swift`, line 978-980 ([link](https://github.com/arul28/ade/blob/8b1d5a64b756980be71b942eba31a29d2c19f0e6/apps/ios/ADE/Models/RemoteModels.swift#L978-L980)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Absent Cursor Fields Clear State**

   When a cached summary comes from a payload that omits `cursorModeId` or `cursorConfigValues`, those optionals decode as `nil`. This merge then copies those nils into the live summary, so a partial refresh can clear the open iOS composer's Cursor mode or config even though no clear event was received.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ios/ADE/Models/RemoteModels.swift
   Line: 978-980

   Comment:
   **Absent Cursor Fields Clear State**

   When a cached summary comes from a payload that omits `cursorModeId` or `cursorConfigValues`, those optionals decode as `nil`. This merge then copies those nils into the live summary, so a partial refresh can clear the open iOS composer's Cursor mode or config even though no clear event was received.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fios%2FADE%2FModels%2FRemoteModels.swift%0ALine%3A%20978-980%0A%0AComment%3A%0A**Absent%20Cursor%20Fields%20Clear%20State**%0A%0AWhen%20a%20cached%20summary%20comes%20from%20a%20payload%20that%20omits%20%60cursorModeId%60%20or%20%60cursorConfigValues%60%2C%20those%20optionals%20decode%20as%20%60nil%60.%20This%20merge%20then%20copies%20those%20nils%20into%20the%20live%20summary%2C%20so%20a%20partial%20refresh%20can%20clear%20the%20open%20iOS%20composer's%20Cursor%20mode%20or%20config%20even%20though%20no%20clear%20event%20was%20received.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=716&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fios%2FADE%2FModels%2FRemoteModels.swift%3A978-980%0A**Absent%20Cursor%20Fields%20Clear%20State**%0A%0AWhen%20a%20cached%20summary%20comes%20from%20a%20payload%20that%20omits%20%60cursorModeId%60%20or%20%60cursorConfigValues%60%2C%20those%20optionals%20decode%20as%20%60nil%60.%20This%20merge%20then%20copies%20those%20nils%20into%20the%20live%20summary%2C%20so%20a%20partial%20refresh%20can%20clear%20the%20open%20iOS%20composer's%20Cursor%20mode%20or%20config%20even%20though%20no%20clear%20event%20was%20received.%0A%0A&repo=arul28%2Fade&pr=716&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/ios/ADE/Models/RemoteModels.swift:978-980
**Absent Cursor Fields Clear State**

When a cached summary comes from a payload that omits `cursorModeId` or `cursorConfigValues`, those optionals decode as `nil`. This merge then copies those nils into the live summary, so a partial refresh can clear the open iOS composer's Cursor mode or config even though no clear event was received.


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["iOS: stateless cursor mode/config clear ..."](https://github.com/arul28/ade/commit/8b1d5a64b756980be71b942eba31a29d2c19f0e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42267615)</sub>

<!-- /greptile_comment -->