### PR TITLE
Slash Badges File Search

### DIFF
--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
@@ -315,6 +315,39 @@ describe("AgentChatComposer", () => {
     expect(await screen.findByText("README.md")).toBeTruthy();
   });
 
+  it("does not reuse cached at-command suggestions when attachment search changes", async () => {
+    const laneSearch = vi.fn().mockResolvedValue([{ path: "lane-a/AOnly.tsx", type: "file" }]);
+    const sessionSearch = vi.fn().mockResolvedValue([{ path: "lane-b/BOnly.tsx", type: "file" }]);
+    const props = buildComposerProps({
+      turnActive: false,
+      draft: "",
+      sessionId: null,
+      onSearchAttachments: laneSearch,
+    });
+    const view = render(<AgentChatComposer {...props} />);
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "@src", selectionStart: 4 },
+    });
+
+    expect(await screen.findByText("AOnly.tsx")).toBeTruthy();
+
+    view.rerender(
+      <AgentChatComposer
+        {...props}
+        draft="@src"
+        sessionId="session-1"
+        onSearchAttachments={sessionSearch}
+      />,
+    );
+
+    expect(screen.queryByText("AOnly.tsx")).toBeNull();
+    await waitFor(() => {
+      expect(sessionSearch).toHaveBeenCalledWith("src");
+    });
+    expect(await screen.findByText("BOnly.tsx")).toBeTruthy();
+  });
+
   it("keeps the caret visible when the plain composer renders a slash command badge", async () => {
     const props = buildComposerProps({
       turnActive: false,

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
@@ -275,17 +275,13 @@ describe("AgentChatComposer", () => {
   });
 
   it("shows file matches when typing an at-command", async () => {
-    const fileSearch = vi.fn().mockResolvedValue([{ path: "src/App.tsx" }]);
-    (window as any).ade = {
-      agentChat: {
-        fileSearch,
-      },
-    };
+    const onSearchAttachments = vi.fn().mockResolvedValue([{ path: "src/App.tsx", type: "file" }]);
 
     renderComposer({
       turnActive: false,
       draft: "",
       sessionId: "session-1",
+      onSearchAttachments,
     });
 
     fireEvent.change(screen.getByRole("textbox"), {
@@ -293,9 +289,53 @@ describe("AgentChatComposer", () => {
     });
 
     await waitFor(() => {
-      expect(fileSearch).toHaveBeenCalledWith({ sessionId: "session-1", query: "src" });
+      expect(onSearchAttachments).toHaveBeenCalledWith("src");
     });
     expect(await screen.findByText("App.tsx")).toBeTruthy();
+  });
+
+  it("uses lane attachment search for at-command suggestions before a session exists", async () => {
+    const onSearchAttachments = vi.fn().mockResolvedValue([{ path: "docs/README.md", type: "file" }]);
+
+    renderComposer({
+      turnActive: false,
+      draft: "",
+      sessionId: null,
+      onSearchAttachments,
+    });
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "@read", selectionStart: 5 },
+    });
+
+    await waitFor(() => {
+      expect(onSearchAttachments).toHaveBeenCalledWith("read");
+    });
+    expect(screen.queryByText("File search unavailable for this session")).toBeNull();
+    expect(await screen.findByText("README.md")).toBeTruthy();
+  });
+
+  it("keeps the caret visible when the plain composer renders a slash command badge", async () => {
+    const props = buildComposerProps({
+      turnActive: false,
+      draft: "",
+      sdkSlashCommands: [{
+        name: "status",
+        description: "Summarize current state",
+        source: "sdk",
+      }],
+    });
+    const view = render(<AgentChatComposer {...props} />);
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "/", selectionStart: 1 },
+    });
+    fireEvent.click(await screen.findByText("/status"));
+    view.rerender(<AgentChatComposer {...props} draft="/status " />);
+
+    const textbox = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textbox.style.caretColor).toBe("var(--color-fg)");
+    expect(textbox.className).toContain("text-left");
   });
 
   it("opens the slash menu mid-sentence and splices only the trigger span", async () => {
@@ -346,12 +386,12 @@ describe("AgentChatComposer", () => {
   });
 
   it("replaces a mid-sentence @query with the selected file and attaches it", async () => {
-    const fileSearch = vi.fn().mockResolvedValue([{ path: "src/App.tsx" }]);
-    (window as any).ade = { agentChat: { fileSearch } };
+    const onSearchAttachments = vi.fn().mockResolvedValue([{ path: "src/App.tsx", type: "file" }]);
     const props = buildComposerProps({
       turnActive: false,
       draft: "",
       sessionId: "session-1",
+      onSearchAttachments,
     });
     const view = render(<AgentChatComposer {...props} />);
 

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -4306,7 +4306,7 @@ export function AgentChatComposer({
               argumentHint: c.argumentHint,
               source: c.source,
             }))}
-            sessionId={sessionId ?? null}
+            onFileSearch={onSearchAttachments}
             anchor={commandMenuAnchor}
             onSelect={handleCommandMenuSelect}
             onClose={() => setCommandMenuTrigger(null)}
@@ -4398,7 +4398,7 @@ export function AgentChatComposer({
                 <div aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden">
                   <div
                     className={cn(
-                      "whitespace-pre-wrap break-words px-4 py-2.5 text-[length:calc(var(--chat-font-size)*13/14)] leading-[1.6] text-fg/88",
+                      "whitespace-pre-wrap break-words px-4 py-2.5 text-left text-[length:calc(var(--chat-font-size)*13/14)] leading-[1.6] text-fg/88",
                       dragActive ? "opacity-30" : "",
                       parallelLaunchBusy || composerInputLocked ? "opacity-50" : "",
                     )}
@@ -4446,11 +4446,12 @@ export function AgentChatComposer({
                 spellCheck={true}
                 aria-label={composerInputAccessibleLabel}
                 className={cn(
-                  "block w-full resize-none bg-transparent px-4 py-2.5 text-[length:calc(var(--chat-font-size)*13/14)] leading-[1.6] text-fg/88 outline-none transition-colors placeholder:text-muted-fg/30",
-                  plainOverlayContent ? "relative z-[1] text-transparent caret-fg" : "",
+                  "block w-full resize-none bg-transparent px-4 py-2.5 text-left text-[length:calc(var(--chat-font-size)*13/14)] leading-[1.6] text-fg/88 outline-none transition-colors placeholder:text-muted-fg/30",
+                  plainOverlayContent ? "relative z-[1] text-transparent" : "",
                   dragActive ? "opacity-30" : "",
                   parallelLaunchBusy || composerInputLocked ? "cursor-not-allowed opacity-50" : "",
                 )}
+                style={plainOverlayContent ? { caretColor: "var(--color-fg)" } : undefined}
                 data-chat-layout-variant={layoutVariant}
                 placeholder={composerInputLockMessage ?? (turnActive ? "Steer the active turn..." : (promptSuggestion || messagePlaceholder || "Type to vibecode..."))}
                 onKeyDown={handleKeyDown}

--- a/apps/desktop/src/renderer/components/chat/ChatCommandMenu.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatCommandMenu.tsx
@@ -44,6 +44,11 @@ type ChatCommandMenuProps = {
   onClose: () => void;
 };
 
+type FileSearch = ChatCommandMenuProps["onFileSearch"];
+type FileResult = { path: string };
+type CachedFileResults = { search: FileSearch; results: FileResult[] };
+type FileResultState = { search: FileSearch; results: FileResult[] };
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -112,15 +117,15 @@ function getViewportMenuStyle(anchor: NonNullable<ChatCommandMenuProps["anchor"]
 export const ChatCommandMenu = forwardRef<ChatCommandMenuHandle, ChatCommandMenuProps>(
   function ChatCommandMenu({ trigger, slashCommands, onFileSearch, anchor, onSelect, onClose }, ref) {
     const [selectedIndex, setSelectedIndex] = useState(0);
-    const [fileResults, setFileResults] = useState<Array<{ path: string }>>([]);
+    const [fileResultState, setFileResultState] = useState<FileResultState>({ search: undefined, results: [] });
     const [fileLoading, setFileLoading] = useState(false);
     const listRef = useRef<HTMLDivElement | null>(null);
     const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    // Per-query result cache for the lifetime of one menu session. Cached
-    // queries render in the same frame; a background revalidation still runs
-    // so watcher-driven index changes land on the next keystroke. Cleared
+    // Per-query, per-provider cache for the lifetime of one menu session.
+    // Cached queries render in the same frame; a background revalidation still
+    // runs so watcher-driven index changes land on the next keystroke. Cleared
     // when the menu closes so staleness cannot outlive the interaction.
-    const queryCacheRef = useRef<Map<string, Array<{ path: string }>>>(new Map());
+    const queryCacheRef = useRef<Map<string, CachedFileResults>>(new Map());
     const searchSeqRef = useRef(0);
 
     const triggerType = trigger?.type ?? null;
@@ -141,27 +146,34 @@ export const ChatCommandMenu = forwardRef<ChatCommandMenuHandle, ChatCommandMenu
         .slice(0, MAX_COMMAND_RESULTS);
     }, [trigger, slashCommands]);
 
-    // ---- File search: short debounce, per-query cache, stale-result guard ----
+    // ---- File search: short debounce, provider-scoped cache, stale-result guard ----
     useEffect(() => {
       if (triggerType !== "at") {
-        setFileResults([]);
+        searchSeqRef.current += 1;
+        setFileResultState({ search: onFileSearch, results: [] });
         setFileLoading(false);
         return;
       }
 
       const query = triggerQuery.trim();
       if (!onFileSearch) {
-        setFileResults([]);
+        searchSeqRef.current += 1;
+        setFileResultState({ search: onFileSearch, results: [] });
         setFileLoading(false);
         return;
       }
 
-      const cached = queryCacheRef.current.get(query);
+      const cachedEntry = queryCacheRef.current.get(query);
+      const cached = cachedEntry?.search === onFileSearch ? cachedEntry.results : undefined;
+      if (cachedEntry && cachedEntry.search !== onFileSearch) {
+        queryCacheRef.current.delete(query);
+      }
       if (cached) {
         // Warm path: render cached results immediately, revalidate silently.
-        setFileResults(cached.slice(0, MAX_FILE_RESULTS));
+        setFileResultState({ search: onFileSearch, results: cached.slice(0, MAX_FILE_RESULTS) });
         setFileLoading(false);
       } else {
+        setFileResultState({ search: onFileSearch, results: [] });
         setFileLoading(true);
       }
 
@@ -172,14 +184,16 @@ export const ChatCommandMenu = forwardRef<ChatCommandMenuHandle, ChatCommandMenu
           const results = await onFileSearch(query);
           if (searchSeqRef.current !== seq) return;
           queryCacheRef.current.delete(query);
-          queryCacheRef.current.set(query, results);
+          queryCacheRef.current.set(query, { search: onFileSearch, results });
           if (queryCacheRef.current.size > QUERY_CACHE_MAX) {
             const oldest = queryCacheRef.current.keys().next().value;
             if (oldest !== undefined) queryCacheRef.current.delete(oldest);
           }
-          setFileResults(results.slice(0, MAX_FILE_RESULTS));
+          setFileResultState({ search: onFileSearch, results: results.slice(0, MAX_FILE_RESULTS) });
         } catch {
-          if (searchSeqRef.current === seq && !cached) setFileResults([]);
+          if (searchSeqRef.current === seq && !cached) {
+            setFileResultState({ search: onFileSearch, results: [] });
+          }
         } finally {
           if (searchSeqRef.current === seq) setFileLoading(false);
         }
@@ -194,10 +208,11 @@ export const ChatCommandMenu = forwardRef<ChatCommandMenuHandle, ChatCommandMenu
     const items: ChatCommandMenuItem[] = useMemo(() => {
       if (!trigger) return [];
       if (trigger.type === "at") {
+        const fileResults = fileResultState.search === onFileSearch ? fileResultState.results : [];
         return fileResults.map((r) => ({ type: "file" as const, path: r.path }));
       }
       return filteredCommands.map((c) => ({ type: "command" as const, name: c.name }));
-    }, [trigger, fileResults, filteredCommands]);
+    }, [trigger, fileResultState, onFileSearch, filteredCommands]);
 
     // ---- Reset selection when items change ----
     useEffect(() => {

--- a/apps/desktop/src/renderer/components/chat/ChatCommandMenu.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatCommandMenu.tsx
@@ -34,8 +34,8 @@ type ChatCommandMenuProps = {
   trigger: ComposerTrigger | null;
   /** Available slash commands. */
   slashCommands: Array<{ name: string; description: string; argumentHint?: string; source?: "sdk" | "local" }>;
-  /** Session ID for file search. */
-  sessionId: string | null;
+  /** File search callback. When omitted, @ file suggestions are unavailable. */
+  onFileSearch?: (query: string) => Promise<Array<{ path: string }>>;
   /** Anchor position in viewport coordinates. */
   anchor: { top: number; left: number; bottom?: number } | null;
   /** Called when user selects an item. */
@@ -110,7 +110,7 @@ function getViewportMenuStyle(anchor: NonNullable<ChatCommandMenuProps["anchor"]
 }
 
 export const ChatCommandMenu = forwardRef<ChatCommandMenuHandle, ChatCommandMenuProps>(
-  function ChatCommandMenu({ trigger, slashCommands, sessionId, anchor, onSelect, onClose }, ref) {
+  function ChatCommandMenu({ trigger, slashCommands, onFileSearch, anchor, onSelect, onClose }, ref) {
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [fileResults, setFileResults] = useState<Array<{ path: string }>>([]);
     const [fileLoading, setFileLoading] = useState(false);
@@ -150,7 +150,7 @@ export const ChatCommandMenu = forwardRef<ChatCommandMenuHandle, ChatCommandMenu
       }
 
       const query = triggerQuery.trim();
-      if (!sessionId) {
+      if (!onFileSearch) {
         setFileResults([]);
         setFileLoading(false);
         return;
@@ -169,10 +169,7 @@ export const ChatCommandMenu = forwardRef<ChatCommandMenuHandle, ChatCommandMenu
       if (debounceRef.current) clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(async () => {
         try {
-          const results = await window.ade.agentChat.fileSearch({
-            sessionId,
-            query,
-          });
+          const results = await onFileSearch(query);
           if (searchSeqRef.current !== seq) return;
           queryCacheRef.current.delete(query);
           queryCacheRef.current.set(query, results);
@@ -191,7 +188,7 @@ export const ChatCommandMenu = forwardRef<ChatCommandMenuHandle, ChatCommandMenu
       return () => {
         if (debounceRef.current) clearTimeout(debounceRef.current);
       };
-    }, [triggerType, triggerQuery, sessionId]);
+    }, [triggerType, triggerQuery, onFileSearch]);
 
     // ---- Derive display items ----
     const items: ChatCommandMenuItem[] = useMemo(() => {
@@ -263,9 +260,10 @@ export const ChatCommandMenu = forwardRef<ChatCommandMenuHandle, ChatCommandMenu
 
     const query = trigger?.query.trim() ?? "";
     const isAtTrigger = trigger?.type === "at";
-    const isUnavailable = isAtTrigger && !sessionId;
+    const canSearchFiles = Boolean(onFileSearch);
+    const isUnavailable = isAtTrigger && !canSearchFiles;
     const isIdle = Boolean(trigger) && !query.length && !isUnavailable && !isAtTrigger;
-    const isNoResults = Boolean(query.length) && !fileLoading && items.length === 0 && (!isAtTrigger || Boolean(sessionId));
+    const isNoResults = Boolean(query.length) && !fileLoading && items.length === 0 && (!isAtTrigger || canSearchFiles);
     const isAtEmptyResults = isAtTrigger && !query.length && !fileLoading && !isUnavailable && items.length === 0;
     const menuStyle = anchor ? getViewportMenuStyle(anchor) : undefined;
 

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
@@ -461,7 +461,6 @@ function WorkCliContinuationComposer({
             argumentHint: command.argumentHint,
             source: command.source,
           }))}
-          sessionId={null}
           anchor={commandMenuAnchor}
           onSelect={handleCommandSelect}
           onClose={() => setCommandMenuTrigger(null)}


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fgoal-theres-uissue-where-when-e5e188ba num=717 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fgoal-theres-uissue-where-when-e5e188ba&amp;pr=717">ade/goal-theres-uissue-where-when-e5e188ba branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=717">PR #717</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds file search support for slash and at-command composer menus. The main changes are:

- Injects the file search callback into `ChatCommandMenu`.
- Scopes cached file suggestions to the active search provider.
- Uses lane attachment search before a chat session exists.
- Keeps the plain composer caret visible when badge overlays render.
- Updates tests for file search, cache changes, and caret styling.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the test proof and confirmed the test suite completed with exit code 0 and 66 passing tests.
- Saved harness and source artifacts under trex-artifacts, including trex-agent-composer-harness.tsx, trex-harness.html, trex-vite.config.mjs, and capture/probe logs.
- Encountered a UI capture blocker where Playwright loaded the harness HTML title but the Vite server stopped responding during module loading, preventing the textbox from appearing.
- Inspected probe logs that show repeated ERR\_EMPTY\_RESPONSE and ERR\_CONNECTION\_REFUSED errors during the UI load sequence.

<a href="https://app.greptile.com/trex/runs/13501123/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/chat/ChatCommandMenu.tsx | Replaces session-based file search with an injected callback and scopes cached suggestions to the active provider. |
| apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx | Passes attachment search into the command menu and adjusts plain composer overlay styling. |
| apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx | Adds coverage for attachment search, cache invalidation, and caret visibility. |
| apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx | Updates the command menu call site for the new prop shape. |

<sub>Reviews (3): Last reviewed commit: ["Fix file mention cache scope"](https://github.com/arul28/ade/commit/92bc1b6f302d28ce007ba1cd73468023513cb261) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42267794)</sub>

<!-- /greptile_comment -->