### PR TITLE
Claude Sdk Idle Handoff

### DIFF
--- a/apps/ade-cli/src/tuiClient/__tests__/ChatView.test.tsx
+++ b/apps/ade-cli/src/tuiClient/__tests__/ChatView.test.tsx
@@ -798,7 +798,7 @@ describe("ChatView", () => {
     expect(frame).toContain("+2 −1");
   });
 
-  it("keeps subagent lifecycle and child tool chatter out of the center transcript", () => {
+  it("shows compact subagent lifecycle while keeping child tool chatter out of the center transcript", () => {
     const turnId = "turn-subagents";
     const frame = renderEvents([
       {
@@ -883,12 +883,12 @@ describe("ChatView", () => {
     expect(frame).toContain("Tool calls");
     expect(frame).toContain("spawn_agent");
     expect(frame).toContain("Explore renderer");
-    expect(frame).not.toContain("child launch spam");
+    expect(frame).toContain("Activity");
+    expect(frame).toContain("child result spam");
+    expect(frame).toContain("agent");
     expect(frame).not.toContain("read_file");
     expect(frame).not.toContain("noisy-child");
     expect(frame).not.toContain("child tool result spam");
-    expect(frame).not.toContain("child progress spam");
-    expect(frame).not.toContain("child result spam");
   });
 
   it("renders a selected subagent transcript with the same ChatView format", () => {

--- a/apps/ade-cli/src/tuiClient/__tests__/aggregate.test.ts
+++ b/apps/ade-cli/src/tuiClient/__tests__/aggregate.test.ts
@@ -142,9 +142,7 @@ describe("aggregateChatBlocks typed groups", () => {
     expect(toolGroup!.entries.map((e) => e.itemId)).toEqual(["kept-1"]);
   });
 
-  it("drops tool-derived activity, spawning_agent, and subagent lifecycle from the transcript", () => {
-    // Desktop parity: the subagent roster (chat-info pane) is the surface for
-    // lifecycle + spawn chatter; the transcript shows none of it.
+  it("bundles subagent lifecycle while still dropping tool-derived activity", () => {
     const events: AgentChatEventEnvelope[] = [
       env("2026-01-01T12:00:00.000Z", { type: "activity", activity: "thinking", detail: "Thinking through the answer", turnId: "turn-1" }),
       env("2026-01-01T12:00:01.000Z", { type: "activity", activity: "reading", detail: "apps/ade-cli/src/tuiClient/app.tsx", turnId: "turn-1" }),
@@ -158,6 +156,35 @@ describe("aggregateChatBlocks typed groups", () => {
 
     const blocks = aggregate(events);
     expect(blocks.some((b) => b.kind === "runtime-activity")).toBe(false);
+    const activity = blocks.find((b) => b.kind === "activity-bundle") as Extract<AggregatedBlock, { kind: "activity-bundle" }> | undefined;
+    expect(activity).toBeDefined();
+    expect(activity!.entries.map((entry) => entry.status)).toEqual(["running", "running", "ok"]);
+    expect(activity!.entries.map((entry) => entry.label)).toEqual(["child launch spam", "child progress", "child done"]);
+  });
+
+  it("bundles adjacent task and scheduled work updates in the TUI transcript", () => {
+    const events: AgentChatEventEnvelope[] = [
+      env("2026-01-01T12:00:00.000Z", {
+        type: "todo_update",
+        turnId: "turn-1",
+        items: [{ id: "task-1", description: "Review UI parity", status: "in_progress" }],
+      }),
+      env("2026-01-01T12:00:01.000Z", {
+        type: "scheduled_work_update",
+        id: "cron-1",
+        kind: "cron",
+        status: "scheduled",
+        title: "CI follow-up",
+        turnId: "turn-1",
+      } as unknown as AgentChatEvent),
+    ];
+
+    const blocks = aggregate(events);
+    expect(blocks).toHaveLength(1);
+    const activity = blocks[0] as Extract<AggregatedBlock, { kind: "activity-bundle" }>;
+    expect(activity.kind).toBe("activity-bundle");
+    expect(activity.entries.map((entry) => entry.kind)).toEqual(["task", "schedule"]);
+    expect(activity.entries.map((entry) => entry.label)).toEqual(["Review UI parity", "CI follow-up"]);
   });
 
   it("still surfaces unrecognized activity events as runtime activity", () => {

--- a/apps/ade-cli/src/tuiClient/aggregate.ts
+++ b/apps/ade-cli/src/tuiClient/aggregate.ts
@@ -47,6 +47,16 @@ export type RuntimeActivityEntry = {
   status: WorkToolStatus | "info";
 };
 
+export type ActivityBundleKind = "task" | "agent" | "workflow" | "schedule";
+
+export type ActivityBundleEntry = {
+  id: string;
+  kind: ActivityBundleKind;
+  label: string;
+  detail?: string;
+  status: WorkToolStatus | "info";
+};
+
 export type PlanStep = {
   text: string;
   status: "pending" | "in_progress" | "completed" | "failed";
@@ -64,6 +74,7 @@ export type AggregatedBlock =
   | { kind: "tool-calls-group"; id: string; turnId: string | null; entries: ToolCallEntry[]; live: boolean; durationMs?: number }
   | { kind: "files-changed-group"; id: string; turnId: string | null; entries: FileChangeEntry[]; live: boolean; durationMs?: number }
   | { kind: "runtime-activity"; id: string; turnId: string | null; entries: RuntimeActivityEntry[]; live: boolean }
+  | { kind: "activity-bundle"; id: string; turnId: string | null; entries: ActivityBundleEntry[]; live: boolean }
   | { kind: "compaction"; id: string; turnId: string | null; trigger: "manual" | "auto"; live: boolean; preTokens?: number; postTokens?: number; durationMs?: number; sessionCompactionCount?: number }
   | { kind: "queued-steer"; id: string; turnId: string | null; steerId: string; text: string }
   | { kind: "plan"; id: string; turnId: string | null; steps: PlanStep[]; current: number; total: number; live: boolean }
@@ -359,10 +370,11 @@ function findCompactionBlockForCompletion(
 
 function isLiveTurnBlock(
   block: AggregatedBlock,
-): block is Extract<AggregatedBlock, { kind: "tool-calls-group" | "files-changed-group" | "runtime-activity" | "plan" | "compaction" | "reasoning" }> {
+): block is Extract<AggregatedBlock, { kind: "tool-calls-group" | "files-changed-group" | "runtime-activity" | "activity-bundle" | "plan" | "compaction" | "reasoning" }> {
   return block.kind === "tool-calls-group"
     || block.kind === "files-changed-group"
     || block.kind === "runtime-activity"
+    || block.kind === "activity-bundle"
     || block.kind === "plan"
     || block.kind === "compaction"
     || block.kind === "reasoning";
@@ -459,6 +471,110 @@ function runtimeActivityFromEvent(id: string, event: AgentChatEvent): RuntimeAct
   return null;
 }
 
+function activityStatusFromRawStatus(status: string | null | undefined): WorkToolStatus | "info" {
+  const normalized = (status ?? "").trim().toLowerCase();
+  if (normalized === "failed" || normalized === "error") return "failed";
+  if (normalized === "completed" || normalized === "complete" || normalized === "done") return "ok";
+  if (
+    normalized === "running"
+    || normalized === "started"
+    || normalized === "fired"
+    || normalized === "in_progress"
+  ) return "running";
+  return "info";
+}
+
+function activityBundleEntryFromEvent(id: string, event: AgentChatEvent): ActivityBundleEntry | null {
+  const eventType = String((event as { type?: unknown }).type ?? "");
+  if (event.type === "todo_update") {
+    const completed = event.items.filter((task) => task.status === "completed").length;
+    const active = event.items.find((task) => task.status === "in_progress")
+      ?? event.items.find((task) => task.status !== "completed")
+      ?? event.items.at(-1);
+    const detail = event.items.length > 0 ? `${completed}/${event.items.length} complete` : "updated";
+    return {
+      id,
+      kind: "task",
+      label: active?.description?.trim() || "Task list updated",
+      detail,
+      status: event.items.length > 0 && completed === event.items.length ? "ok" : "running",
+    };
+  }
+  if (event.type === "scheduled_work_update") {
+    return {
+      id,
+      kind: "schedule",
+      label: event.title?.trim() || event.reason?.trim() || event.prompt?.trim() || (event.kind === "cron" ? "Cron schedule" : "Scheduled work"),
+      detail: compactActivityDetail(event.summary) ?? compactActivityDetail(event.error) ?? compactActivityDetail(event.cron) ?? compactActivityDetail(event.nextRunAt),
+      status: activityStatusFromRawStatus(event.status),
+    };
+  }
+  if (event.type === "subagent_started" || event.type === "subagent_progress" || event.type === "subagent_result") {
+    const isWorkflow = Boolean(event.workflowName) || event.taskType === "local_workflow";
+    const description = "description" in event ? stringField(event.description) : null;
+    const summary = "summary" in event ? stringField(event.summary) : null;
+    const status = event.type === "subagent_started" || event.type === "subagent_progress"
+      ? "running"
+      : activityStatusFromRawStatus(event.status);
+    return {
+      id,
+      kind: isWorkflow ? "workflow" : "agent",
+      label: stringField(event.label)
+        ?? stringField(event.workflowName)
+        ?? stringField(event.agentType)
+        ?? description
+        ?? summary
+        ?? event.agentId
+        ?? event.taskId,
+      detail: event.type === "subagent_progress"
+        ? compactActivityDetail(event.summary) ?? compactActivityDetail(event.lastToolName)
+        : event.type === "subagent_result"
+          ? compactActivityDetail(event.finalSummary) ?? compactActivityDetail(event.summary)
+          : description ?? undefined,
+      status,
+    };
+  }
+  if (eventType === "subagent.started" || eventType === "subagent.progress" || eventType === "subagent.completed") {
+    const record = event as Record<string, unknown>;
+    const status = eventType === "subagent.completed"
+      ? activityStatusFromRawStatus(stringField(record.status) ?? "completed")
+      : "running";
+    return {
+      id,
+      kind: "agent",
+      label: stringField(record.label)
+        ?? stringField(record.agentType)
+        ?? stringField(record.description)
+        ?? stringField(record.summary)
+        ?? stringField(record.agentId)
+        ?? "Subagent",
+      detail: compactActivityDetail(record.summary) ?? compactActivityDetail(record.description),
+      status,
+    };
+  }
+  if (eventType === "task.completed") {
+    const record = event as Record<string, unknown>;
+    return {
+      id,
+      kind: "task",
+      label: stringField(record.name) ?? stringField(record.title) ?? stringField(record.summary) ?? "Task completed",
+      detail: compactActivityDetail(record.summary),
+      status: "ok",
+    };
+  }
+  if (eventType === "teammate.idle") {
+    const record = event as Record<string, unknown>;
+    return {
+      id,
+      kind: "agent",
+      label: stringField(record.name) ?? stringField(record.agentId) ?? "Agent idle",
+      detail: compactActivityDetail(record.reason),
+      status: "info",
+    };
+  }
+  return null;
+}
+
 function summarizePreToolUseHookError(event: AgentChatEvent): string | null {
   if (event.type !== "system_notice") return null;
   if ((event as { noticeKind?: string }).noticeKind !== "hook") return null;
@@ -487,6 +603,34 @@ function appendRuntimeActivityBlock(
   }
   block.entries.push(entry);
   if (block.entries.length > 8) block.entries.splice(0, block.entries.length - 8);
+}
+
+function appendActivityBundleBlock(
+  blocks: AggregatedBlock[],
+  id: string,
+  turnId: string | null,
+  entry: ActivityBundleEntry,
+): void {
+  const last = blocks[blocks.length - 1];
+  let block: Extract<AggregatedBlock, { kind: "activity-bundle" }>;
+  if (last && last.kind === "activity-bundle" && last.turnId === turnId) {
+    block = last;
+  } else {
+    block = { kind: "activity-bundle", id, turnId, entries: [], live: true };
+    blocks.push(block);
+  }
+  const previous = block.entries[block.entries.length - 1];
+  if (
+    previous
+    && previous.kind === entry.kind
+    && previous.label === entry.label
+    && previous.detail === entry.detail
+    && previous.status === entry.status
+  ) {
+    return;
+  }
+  block.entries.push(entry);
+  if (block.entries.length > 12) block.entries.splice(0, block.entries.length - 12);
 }
 
 function subagentParentItemId(event: AgentChatEvent): string | null {
@@ -632,9 +776,12 @@ export function aggregateChatBlocks(args: {
     const id = chatEventLineId(envelope, index);
     const turnId = turnIdOf(event);
 
-    // Subagent lifecycle (started/progress/result, teammate idle, task done)
-    // never reaches the transcript — the subagent roster in the chat-info pane
-    // is its surface, matching the desktop transcript which hides these too.
+    const activityEntry = activityBundleEntryFromEvent(id, event);
+    if (activityEntry) {
+      appendActivityBundleBlock(blocks, id, turnId, activityEntry);
+      continue;
+    }
+
     if (isSubagentTimelineEvent(event)) {
       continue;
     }

--- a/apps/ade-cli/src/tuiClient/components/ChatView.tsx
+++ b/apps/ade-cli/src/tuiClient/components/ChatView.tsx
@@ -13,6 +13,7 @@ import {
 } from "../format";
 import {
   aggregateChatBlocks,
+  type ActivityBundleEntry,
   type AggregatedBlock,
   type FileChangeEntry,
   type PlanStep,
@@ -919,6 +920,66 @@ function runtimeActivityRows(
   return out;
 }
 
+function activityKindLabel(kind: ActivityBundleEntry["kind"]): string {
+  if (kind === "task") return "task";
+  if (kind === "schedule") return "schedule";
+  if (kind === "workflow") return "workflow";
+  return "agent";
+}
+
+function activityBundleRows(
+  block: Extract<AggregatedBlock, { kind: "activity-bundle" }>,
+  spinFrame: string,
+  expandedGroupIds: Set<string>,
+): RenderedChatRow[] {
+  if (!block.entries.length) return [];
+  const expandKey = workGroupExpandKey(block.id);
+  const expanded = expandedGroupIds.has(expandKey);
+  const latest = block.entries[block.entries.length - 1]!;
+  const glyph = activityStatusGlyph(latest.status, spinFrame);
+  const headerRuns: InlineRun[] = [
+    { text: expanded ? "▾ " : "▸ ", color: theme.color.t3 },
+    { text: "Activity", color: theme.color.t2, bold: true },
+    { text: ` (${block.entries.length})`, color: theme.color.t4 },
+  ];
+  if (!expanded) {
+    headerRuns.push({ text: "  " });
+    headerRuns.push({ text: glyph, color: ACTIVITY_STATUS_COLOR[latest.status] });
+    headerRuns.push({ text: ` ${activityKindLabel(latest.kind)}`, color: theme.color.t1 });
+    headerRuns.push({ text: `  ${truncateLongLine(latest.label)}`, color: theme.color.t3 });
+    if (latest.detail) headerRuns.push({ text: `  ${truncateLongLine(latest.detail)}`, color: theme.color.t4 });
+  }
+  const out: RenderedChatRow[] = [{
+    id: block.id,
+    tone: "work",
+    text: runsPlainText(headerRuns),
+    runs: headerRuns,
+    rail: null,
+    expandableGroupId: expandKey,
+  }];
+  if (!expanded) return out;
+  const { shown, remaining } = visibleEntries(block.entries);
+  for (const entry of shown) {
+    const entryGlyph = activityStatusGlyph(entry.status, spinFrame);
+    const runs: InlineRun[] = [
+      { text: "    " },
+      { text: entryGlyph, color: ACTIVITY_STATUS_COLOR[entry.status] },
+      { text: ` ${activityKindLabel(entry.kind)}`, color: theme.color.t1 },
+      { text: `  ${truncateLongLine(entry.label)}`, color: theme.color.t3 },
+    ];
+    if (entry.detail) runs.push({ text: `  ${truncateLongLine(entry.detail)}`, color: theme.color.t4 });
+    out.push({
+      id: `${block.id}:${entry.id}`,
+      tone: "work",
+      text: runsPlainText(runs),
+      runs,
+      rail: null,
+    });
+  }
+  if (remaining > 0) out.push(moreLineRow(block.id, remaining));
+  return out;
+}
+
 /**
  * Collapsed reasoning row — mirrors the desktop MinimalThought line:
  * `▸ Thinking… <preview>` while live, `▸ Thought · <preview>` once done.
@@ -1158,6 +1219,8 @@ function rowsForBlock(
       return filesChangedGroupRows(block, width, spinFrame, expandedGroupIds);
     case "runtime-activity":
       return runtimeActivityRows(block, spinFrame);
+    case "activity-bundle":
+      return activityBundleRows(block, spinFrame, expandedGroupIds);
     case "reasoning":
       return reasoningRows(block, spinFrame);
     case "compaction":

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -13219,7 +13219,10 @@ export function createAgentChatService(args: {
             || runtime.query !== sessionQuery
             || runtime.idleReaderGeneration !== generation
           ) {
-            if (handoffToForegroundIfActive(nextMessage, next)) {
+            const staleGenerationOnly = managed.runtime === runtime
+              && runtime.query === sessionQuery
+              && runtime.idleReaderGeneration !== generation;
+            if (staleGenerationOnly && handoffToForegroundIfActive(nextMessage, next)) {
               return;
             }
             return;

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -13219,6 +13219,9 @@ export function createAgentChatService(args: {
             || runtime.query !== sessionQuery
             || runtime.idleReaderGeneration !== generation
           ) {
+            if (handoffToForegroundIfActive(nextMessage, next)) {
+              return;
+            }
             return;
           }
           if (handoffToForegroundIfActive(nextMessage, next)) {

--- a/apps/desktop/src/renderer/components/chat/AgentChatMessageList.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatMessageList.test.tsx
@@ -1931,10 +1931,10 @@ describe("AgentChatMessageList transcript rendering", () => {
       },
     );
 
-    // The turn surfaces the task-list rollup with completed/in-progress items.
-    expect(rendered.container.textContent).toMatch(/Task list/);
+    // The turn surfaces task progress as a compact activity row.
+    expect(rendered.container.textContent).toMatch(/task: Refine summary card/);
     expect(rendered.container.textContent).toMatch(/1\/2 complete/);
-    expect(screen.getByText("Inspect chat renderer")).toBeTruthy();
+    expect(rendered.container.textContent).toMatch(/Inspect chat renderer/);
     expect(screen.getAllByText("Refine summary card").length).toBeGreaterThanOrEqual(1);
 
     // Files now live in the inline FilesChangedPanel — diff stats appear next to the path.
@@ -2231,9 +2231,9 @@ describe("AgentChatMessageList transcript rendering", () => {
       },
     );
 
-    expect(rendered.container.textContent).toMatch(/Task list/);
+    expect(rendered.container.textContent).toMatch(/task: Implement calmer transcript rows/);
     expect(rendered.container.textContent).toMatch(/1\/2 complete/);
-    expect(screen.getByText("Inspect shared renderer")).toBeTruthy();
+    expect(rendered.container.textContent).toMatch(/Inspect shared renderer/);
     expect(rendered.container.textContent).toMatch(/1 file changed/);
 
     fireEvent.click(screen.getByRole("button", { name: /Undo/i }));
@@ -2267,7 +2267,7 @@ describe("AgentChatMessageList transcript rendering", () => {
       },
     ]);
 
-    expect(rendered.container.textContent).toMatch(/Task list/);
+    expect(rendered.container.textContent).toMatch(/task: Investigate Claude turn status/);
     expect(rendered.container.textContent).toMatch(/1\/1 complete/);
     // Model attribution surfaces on the end-of-turn divider for non-completed turns.
     expect(screen.getAllByText(/Claude Sonnet 5/).length).toBeGreaterThanOrEqual(1);

--- a/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
@@ -76,6 +76,8 @@ import {
   readRecord,
   summarizeDiffStats,
   summarizeInlineText,
+  type ChatActivityBundleEvent,
+  type ChatActivityBundleItem,
   type ChatTranscriptGroupedEnvelope as TranscriptGroupedEnvelope,
   type ChatTranscriptRenderEnvelope as TranscriptRenderEnvelope,
 } from "./chatTranscriptRows";
@@ -850,6 +852,203 @@ function InlineDisclosureRow({
       {expandable && open ? (
         <div className="ml-5 mt-1 space-y-2 border-l border-violet-400/10 pl-3">
           {children}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function activityBundleTaskId(item: ChatActivityBundleItem): string | null {
+  const event = item.event;
+  if (event.type === "subagent_started" || event.type === "subagent_progress" || event.type === "subagent_result") {
+    return event.agentId ?? event.taskId;
+  }
+  if (event.type === "scheduled_work_update") return event.sourceTaskId ?? event.id;
+  return null;
+}
+
+function activityBundleKind(item: ChatActivityBundleItem): "task" | "agent" | "workflow" | "schedule" {
+  const event = item.event;
+  if (event.type === "todo_update") return "task";
+  if (event.type === "scheduled_work_update") return "schedule";
+  if (event.type === "subagent_started" || event.type === "subagent_progress" || event.type === "subagent_result") {
+    return event.workflowName || event.taskType === "local_workflow" ? "workflow" : "agent";
+  }
+  return "agent";
+}
+
+function activityBundleStatus(item: ChatActivityBundleItem): string {
+  const event = item.event;
+  if (event.type === "todo_update") {
+    const completed = event.items.filter((task) => task.status === "completed").length;
+    return event.items.length ? `${completed}/${event.items.length} complete` : "updated";
+  }
+  if (event.type === "scheduled_work_update") return event.status.replace(/_/g, " ");
+  if (event.type === "subagent_started") return event.background ? "background started" : "started";
+  if (event.type === "subagent_progress") return "running";
+  return event.status === "stopped" ? "stopped" : event.status;
+}
+
+function activityBundleTitle(item: ChatActivityBundleItem): string {
+  const event = item.event;
+  if (event.type === "todo_update") {
+    const active = event.items.find((task) => task.status === "in_progress") ?? event.items.find((task) => task.status !== "completed") ?? event.items.at(-1);
+    return active?.description?.trim() || "Task list updated";
+  }
+  if (event.type === "scheduled_work_update") {
+    return event.title?.trim()
+      || event.reason?.trim()
+      || event.prompt?.trim()
+      || (event.kind === "cron" ? "Cron schedule" : "Scheduled work");
+  }
+  const description = "description" in event ? event.description?.trim() : "";
+  const name = event.label?.trim()
+    || event.workflowName?.trim()
+    || event.agentType?.trim()
+    || description
+    || event.agentId
+    || event.taskId;
+  return event.type === "subagent_result" && event.status === "stopped"
+    ? `${name} stopped`
+    : name;
+}
+
+function activityBundleDetail(item: ChatActivityBundleItem): string | null {
+  const event = item.event;
+  if (event.type === "todo_update") {
+    const changed = event.items.filter((task) => task.status !== "pending");
+    return changed.slice(0, 3).map((task) => `${task.status.replace("_", " ")}: ${task.description}`).join(" · ") || null;
+  }
+  if (event.type === "scheduled_work_update") {
+    return event.summary?.trim()
+      || event.error?.trim()
+      || event.cron?.trim()
+      || event.nextRunAt?.trim()
+      || null;
+  }
+  if (event.type === "subagent_progress") return event.summary?.trim() || event.lastToolName?.trim() || null;
+  if (event.type === "subagent_result") return event.summary?.trim() || event.finalSummary?.trim() || null;
+  return event.description?.trim() || null;
+}
+
+function activityKindLabel(kind: ReturnType<typeof activityBundleKind>): string {
+  if (kind === "task") return "tasks";
+  if (kind === "schedule") return "schedule";
+  if (kind === "workflow") return "workflows";
+  return "agents";
+}
+
+function activityKindTone(kind: ReturnType<typeof activityBundleKind>): string {
+  if (kind === "task") return "border-cyan-300/14 bg-cyan-300/[0.055] text-cyan-100/72";
+  if (kind === "schedule") return "border-amber-300/14 bg-amber-300/[0.055] text-amber-100/72";
+  if (kind === "workflow") return "border-violet-300/14 bg-violet-300/[0.055] text-violet-100/72";
+  return "border-violet-300/12 bg-violet-300/[0.05] text-violet-100/72";
+}
+
+function activityStatusIcon(item: ChatActivityBundleItem): React.ReactNode {
+  const status = activityBundleStatus(item);
+  if (status.includes("failed")) return <XCircle size={12} weight="bold" className="text-red-300/80" />;
+  if (status.includes("stopped") || status.includes("cancelled")) return <Warning size={12} weight="fill" className="text-amber-300/80" />;
+  if (status.includes("complete")) return <CheckCircle size={12} weight="bold" className="text-emerald-300/80" />;
+  return <Circle size={10} weight="fill" className="text-sky-300/75" />;
+}
+
+function openChatInfoFromActivity(sessionId: string | null | undefined, taskId: string | null): void {
+  try {
+    window.dispatchEvent(
+      new CustomEvent("ade:chat:open-info", {
+        detail: {
+          ...(sessionId ? { sessionId } : {}),
+          ...(taskId ? { taskId } : {}),
+        },
+      }),
+    );
+  } catch {
+    /* no-op */
+  }
+}
+
+function ChatActivityBundle({
+  event,
+  sessionId,
+}: {
+  event: ChatActivityBundleEvent;
+  sessionId?: string | null;
+}) {
+  const [open, setOpen] = useState(event.items.length <= 3);
+  const kinds = Array.from(new Set(event.items.map(activityBundleKind)));
+  const primaryKind = kinds[0] ?? "agent";
+  const uniqueAgents = new Set(event.items.map(activityBundleTaskId).filter((id): id is string => Boolean(id)));
+  const summary = event.items.length === 1
+    ? `${activityKindLabel(primaryKind).replace(/s$/, "")}: ${activityBundleTitle(event.items[0]!)}`
+    : `${event.items.length} activity updates`;
+  const taskId = event.items.length === 1 ? activityBundleTaskId(event.items[0]!) : null;
+
+  return (
+    <div className="w-fit min-w-0 max-w-[min(100%,70ch)] rounded-lg border border-white/[0.055] bg-white/[0.028] px-2.5 py-2 shadow-[0_10px_30px_rgba(0,0,0,0.10)]">
+      <div className="flex min-w-0 items-center gap-2">
+        <button
+          type="button"
+          aria-expanded={open}
+          onClick={() => setOpen((value) => !value)}
+          className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-fg/34 transition-colors hover:bg-white/[0.045] hover:text-fg/60"
+          title={open ? "Collapse activity" : "Expand activity"}
+        >
+          {open ? <CaretDown size={11} weight="bold" /> : <CaretRight size={11} weight="bold" />}
+        </button>
+        <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-violet-300/[0.075] text-violet-100/70">
+          {primaryKind === "task" ? <ListChecks size={13} weight="regular" /> : primaryKind === "schedule" ? <Target size={13} weight="duotone" /> : <Robot size={13} weight="duotone" />}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+            <span className="truncate font-sans text-[length:calc(var(--chat-font-size)*11/14)] text-fg/76">{summary}</span>
+            {uniqueAgents.size > 1 ? (
+              <span className="rounded-md border border-violet-300/12 bg-violet-300/[0.05] px-1.5 py-0.5 font-mono text-[length:calc(var(--chat-font-size)*8/14)] font-bold uppercase tracking-[0.14em] text-violet-100/55">
+                {uniqueAgents.size} agents
+              </span>
+            ) : null}
+            {kinds.map((kind) => (
+              <span key={kind} className={cn("rounded-md border px-1.5 py-0.5 font-mono text-[length:calc(var(--chat-font-size)*8/14)] font-bold uppercase tracking-[0.14em]", activityKindTone(kind))}>
+                {activityKindLabel(kind)}
+              </span>
+            ))}
+          </div>
+        </div>
+        <button
+          type="button"
+          className="shrink-0 rounded-md border border-white/[0.07] bg-white/[0.025] px-2 py-1 font-mono text-[length:calc(var(--chat-font-size)*8/14)] font-bold uppercase tracking-[0.14em] text-fg/45 transition-colors hover:border-white/[0.14] hover:text-fg/72"
+          onClick={() => openChatInfoFromActivity(sessionId, taskId)}
+        >
+          Open
+        </button>
+      </div>
+      {open ? (
+        <div className="ml-8 mt-2 space-y-1.5 border-l border-white/[0.06] pl-3">
+          {event.items.map((item) => {
+            const kind = activityBundleKind(item);
+            const detail = activityBundleDetail(item);
+            return (
+              <button
+                key={item.key}
+                type="button"
+                className="group flex w-full min-w-0 items-start gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-white/[0.035]"
+                onClick={() => openChatInfoFromActivity(sessionId, activityBundleTaskId(item))}
+              >
+                <span className="mt-0.5 shrink-0">{activityStatusIcon(item)}</span>
+                <span className="min-w-0 flex-1">
+                  <span className="flex min-w-0 flex-wrap items-center gap-1.5">
+                    <span className="truncate font-sans text-[length:calc(var(--chat-font-size)*10.5/14)] text-fg/72">{activityBundleTitle(item)}</span>
+                    <span className={cn("rounded-md border px-1.5 py-0.5 font-mono text-[length:calc(var(--chat-font-size)*7.5/14)] font-bold uppercase tracking-[0.14em]", activityKindTone(kind))}>
+                      {activityBundleStatus(item)}
+                    </span>
+                  </span>
+                  {detail ? (
+                    <span className="mt-0.5 block truncate text-[length:calc(var(--chat-font-size)*9.5/14)] text-fg/38">{summarizeInlineText(detail, 140)}</span>
+                  ) : null}
+                </span>
+              </button>
+            );
+          })}
         </div>
       ) : null}
     </div>
@@ -3856,6 +4055,9 @@ function getGroupedTurnId(envelope: TranscriptGroupedEnvelope | undefined): stri
   if (envelope.event.type === "work_log_group") {
     return envelope.event.turnId ?? envelope.event.entries[0]?.turnId ?? null;
   }
+  if (envelope.event.type === "activity_bundle") {
+    return envelope.event.turnId ?? envelope.event.items.find((item) => item.event.turnId)?.event.turnId ?? null;
+  }
   return "turnId" in envelope.event ? envelope.event.turnId ?? null : null;
 }
 
@@ -3956,6 +4158,8 @@ const EventRow = React.memo(function EventRow({
             />
           </div>
         )
+        : envelope.event.type === "activity_bundle"
+          ? <ChatActivityBundle event={envelope.event} sessionId={sessionId} />
         : renderEvent(envelope as RenderEnvelope, {
             onApproval,
             turnModel,

--- a/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
@@ -946,6 +946,13 @@ function activityKindTone(kind: ReturnType<typeof activityBundleKind>): string {
 }
 
 function activityStatusIcon(item: ChatActivityBundleItem): React.ReactNode {
+  if (item.event.type === "todo_update") {
+    const total = item.event.items.length;
+    const completed = item.event.items.filter((task) => task.status === "completed").length;
+    return total > 0 && completed === total
+      ? <CheckCircle size={12} weight="bold" className="text-emerald-300/80" />
+      : <Circle size={10} weight="fill" className="text-sky-300/75" />;
+  }
   const status = activityBundleStatus(item);
   if (status.includes("failed")) return <XCircle size={12} weight="bold" className="text-red-300/80" />;
   if (status.includes("stopped") || status.includes("cancelled")) return <Warning size={12} weight="fill" className="text-amber-300/80" />;

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -3782,6 +3782,38 @@ export function AgentChatPane({
     }
   }, [chatActionsOpen, subagentView]);
 
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{
+        sessionId?: string | null;
+        taskId?: string | null;
+      }>).detail ?? {};
+      if (detail.sessionId && selectedSessionId && detail.sessionId !== selectedSessionId) return;
+      setChatActionsTab("agents");
+      setIosSimulatorOpen(false);
+      setAppControlOpen(false);
+      setCursorCloudPaneOpen(false);
+      setChatActionsOpen(true);
+
+      const taskId = typeof detail.taskId === "string" ? detail.taskId : null;
+      if (!taskId) return;
+      const snapshot = selectedSubagentSnapshots.find((candidate) =>
+        candidate.taskId === taskId
+        || candidate.agentId === taskId
+      );
+      if (!snapshot) return;
+      setSubagentView({
+        taskId: snapshot.taskId,
+        agentId: snapshot.agentId ?? null,
+        agentType: snapshot.agentType ?? null,
+        status: snapshot.status,
+        background: snapshot.background ?? false,
+      });
+    };
+    window.addEventListener("ade:chat:open-info", handler);
+    return () => window.removeEventListener("ade:chat:open-info", handler);
+  }, [selectedSessionId, selectedSubagentSnapshots]);
+
   // Cheap probe for the subagents panel: does this agent actually have a
   // pullable transcript? It runs the EXACT same fetch the takeover view uses
   // (just limit:1), so it can never disagree with what the takeover would

--- a/apps/desktop/src/renderer/components/chat/chatTranscriptRows.test.ts
+++ b/apps/desktop/src/renderer/components/chat/chatTranscriptRows.test.ts
@@ -292,8 +292,8 @@ describe("chatTranscriptRows", () => {
     expect(rows[0]!.event.messageId).toBe("assistant-message-1");
   });
 
-  it("hides subagent lifecycle rows and keeps adjacent assistant text merged", () => {
-    const rows = collapseChatTranscriptEvents([
+  it("renders subagent lifecycle as a compact activity bundle between assistant text", () => {
+    const rows = groupEvents([
       {
         sessionId: "session-1",
         timestamp: "2026-03-17T10:00:00.000Z",
@@ -326,12 +326,17 @@ describe("chatTranscriptRows", () => {
       },
     ]);
 
-    expect(rows).toHaveLength(1);
+    expect(rows).toHaveLength(3);
     expect(rows[0]!.event.type).toBe("text");
-    if (rows[0]!.event.type !== "text") {
+    expect(rows[1]!.event.type).toBe("activity_bundle");
+    expect(rows[2]!.event.type).toBe("text");
+    if (rows[0]!.event.type !== "text" || rows[1]!.event.type !== "activity_bundle" || rows[2]!.event.type !== "text") {
       throw new Error("Expected a text event");
     }
-    expect(rows[0]!.event.text).toBe("Hello world");
+    expect(rows[0]!.event.text).toBe("Hello");
+    expect(rows[1]!.event.items).toHaveLength(1);
+    expect(rows[1]!.event.items[0]!.event.type).toBe("subagent_started");
+    expect(rows[2]!.event.text).toBe(" world");
   });
 
   it("updates streaming command and file-change entries in place instead of stacking", () => {
@@ -1357,8 +1362,8 @@ describe("chatTranscriptRows edge cases", () => {
     expect(rows[0]!.event.text).toBe("Part 1. Part 2.");
   });
 
-  it("hides raw subagent_progress rows from the transcript", () => {
-    const rows = collapseChatTranscriptEvents([
+  it("bundles raw subagent progress rows in the grouped transcript", () => {
+    const rows = groupEvents([
       {
         sessionId: "session-1",
         timestamp: "2026-03-17T10:00:00.000Z",
@@ -1380,7 +1385,12 @@ describe("chatTranscriptRows edge cases", () => {
         },
       },
     ]);
-    expect(rows).toHaveLength(0);
+    expect(rows).toHaveLength(1);
+    if (rows[0]!.event.type !== "activity_bundle") throw new Error("Expected activity_bundle");
+    expect(rows[0]!.event.items.map((item) => item.event.type)).toEqual([
+      "subagent_progress",
+      "subagent_progress",
+    ]);
   });
 
   it("collapses todo_update events within the same turn", () => {
@@ -1410,6 +1420,94 @@ describe("chatTranscriptRows edge cases", () => {
     expect(rows).toHaveLength(1);
     if (rows[0]!.event.type !== "todo_update") throw new Error("Expected todo_update");
     expect(rows[0]!.event.items).toHaveLength(2);
+  });
+
+  it("bundles adjacent task, subagent, scheduled work, and workflow status updates by turn", () => {
+    const rows = groupEvents([
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:00.000Z",
+        event: {
+          type: "todo_update",
+          turnId: "turn-1",
+          items: [{ id: "task-1", description: "Inspect chat activity", status: "in_progress" }],
+        },
+      },
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:01.000Z",
+        event: {
+          type: "subagent_started",
+          taskId: "agent-1",
+          description: "Review transcript grouping",
+          turnId: "turn-1",
+        },
+      },
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:02.000Z",
+        event: {
+          type: "scheduled_work_update",
+          id: "cron-1",
+          kind: "cron",
+          status: "scheduled",
+          title: "Follow-up cron",
+          turnId: "turn-1",
+        },
+      },
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:03.000Z",
+        event: {
+          type: "subagent_result",
+          taskId: "workflow-1",
+          taskType: "local_workflow",
+          workflowName: "Quality pass",
+          status: "completed",
+          summary: "Quality pass completed",
+          turnId: "turn-1",
+        },
+      },
+    ]);
+
+    expect(rows).toHaveLength(1);
+    if (rows[0]!.event.type !== "activity_bundle") throw new Error("Expected activity_bundle");
+    expect(rows[0]!.event.turnId).toBe("turn-1");
+    expect(rows[0]!.event.items.map((item) => item.event.type)).toEqual([
+      "todo_update",
+      "subagent_started",
+      "scheduled_work_update",
+      "subagent_result",
+    ]);
+  });
+
+  it("keeps activity bundles separated when turn ids change", () => {
+    const rows = groupEvents([
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:00.000Z",
+        event: {
+          type: "subagent_started",
+          taskId: "agent-1",
+          description: "First turn",
+          turnId: "turn-1",
+        },
+      },
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:01.000Z",
+        event: {
+          type: "subagent_started",
+          taskId: "agent-2",
+          description: "Second turn",
+          turnId: "turn-2",
+        },
+      },
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.event.type).toBe("activity_bundle");
+    expect(rows[1]!.event.type).toBe("activity_bundle");
   });
 
   it("batches Claude PreToolUse hook errors into compact work-log groups", () => {

--- a/apps/desktop/src/renderer/components/chat/chatTranscriptRows.test.ts
+++ b/apps/desktop/src/renderer/components/chat/chatTranscriptRows.test.ts
@@ -1510,6 +1510,39 @@ describe("chatTranscriptRows edge cases", () => {
     expect(rows[1]!.event.type).toBe("activity_bundle");
   });
 
+  it("keeps activity bundles separated when turn ids are missing", () => {
+    const rows = groupEvents([
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:00.000Z",
+        event: {
+          type: "todo_update",
+          items: [{ id: "task-1", description: "First unknown turn task", status: "in_progress" }],
+        },
+      },
+      {
+        sessionId: "session-1",
+        timestamp: "2026-03-17T10:00:01.000Z",
+        event: {
+          type: "scheduled_work_update",
+          id: "cron-1",
+          kind: "cron",
+          status: "scheduled",
+          title: "Unknown turn cron",
+        },
+      },
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.event.type).toBe("activity_bundle");
+    expect(rows[1]!.event.type).toBe("activity_bundle");
+    if (rows[0]!.event.type !== "activity_bundle" || rows[1]!.event.type !== "activity_bundle") {
+      throw new Error("Expected activity bundles");
+    }
+    expect(rows[0]!.event.items).toHaveLength(1);
+    expect(rows[1]!.event.items).toHaveLength(1);
+  });
+
   it("batches Claude PreToolUse hook errors into compact work-log groups", () => {
     const grouped = groupEvents([
       {

--- a/apps/desktop/src/renderer/components/chat/chatTranscriptRows.ts
+++ b/apps/desktop/src/renderer/components/chat/chatTranscriptRows.ts
@@ -996,7 +996,7 @@ export function groupConsecutiveWorkLogRows(
         if (!isActivityBundleSourceEvent(candidate.event)) break;
         const candidateEvent = candidate.event;
         const candidateTurnId = activityBundleTurnId(candidateEvent);
-        if (items.length > 0 && baseTurnId !== candidateTurnId) break;
+        if (items.length > 0 && (!baseTurnId || !candidateTurnId || baseTurnId !== candidateTurnId)) break;
         items.push({
           key: candidate.key,
           timestamp: candidate.timestamp,

--- a/apps/desktop/src/renderer/components/chat/chatTranscriptRows.ts
+++ b/apps/desktop/src/renderer/components/chat/chatTranscriptRows.ts
@@ -89,6 +89,25 @@ export type ChatWorkLogGroupEvent = {
   turnId?: string | null;
 };
 
+export type ChatActivityBundleItem = {
+  key: string;
+  timestamp: string;
+  event: Extract<AgentChatEvent, {
+    type:
+      | "todo_update"
+      | "subagent_started"
+      | "subagent_progress"
+      | "subagent_result"
+      | "scheduled_work_update";
+  }>;
+};
+
+export type ChatActivityBundleEvent = {
+  type: "activity_bundle";
+  items: ChatActivityBundleItem[];
+  turnId?: string | null;
+};
+
 export type ChatTranscriptRenderEvent =
   | ChatTranscriptVisibleEvent
   | RenderReasoningEvent
@@ -103,7 +122,7 @@ export type ChatTranscriptRenderEnvelope = {
 export type ChatTranscriptGroupedEnvelope = {
   key: string;
   timestamp: string;
-  event: ChatTranscriptRenderEvent | ChatWorkLogGroupEvent;
+  event: ChatTranscriptRenderEvent | ChatWorkLogGroupEvent | ChatActivityBundleEvent;
 };
 
 type PlanTranscriptEvent = Extract<AgentChatEvent, { type: "plan" }>;
@@ -707,10 +726,6 @@ export function appendCollapsedChatTranscriptEvent(
     }
   }
 
-  if (event.type === "subagent_started" || event.type === "subagent_progress" || event.type === "subagent_result") {
-    return;
-  }
-
   if (event.type === "transcript_retraction") {
     const retractedIds = new Set(event.messageIds.map((messageId) => messageId.trim()).filter(Boolean));
     if (!retractedIds.size) return;
@@ -972,6 +987,36 @@ export function groupConsecutiveWorkLogRows(
       continue;
     }
 
+    if (isActivityBundleSourceEvent(row.event)) {
+      const items: ChatActivityBundleItem[] = [];
+      const baseTurnId = activityBundleTurnId(row.event);
+      let cursor = index;
+      while (cursor < rows.length) {
+        const candidate = rows[cursor]!;
+        if (!isActivityBundleSourceEvent(candidate.event)) break;
+        const candidateEvent = candidate.event;
+        const candidateTurnId = activityBundleTurnId(candidateEvent);
+        if (items.length > 0 && baseTurnId !== candidateTurnId) break;
+        items.push({
+          key: candidate.key,
+          timestamp: candidate.timestamp,
+          event: candidateEvent,
+        });
+        cursor += 1;
+      }
+      grouped.push({
+        key: `activity:${row.key}`,
+        timestamp: rows[cursor - 1]!.timestamp,
+        event: {
+          type: "activity_bundle",
+          items,
+          turnId: baseTurnId,
+        },
+      });
+      index = cursor;
+      continue;
+    }
+
     // Group consecutive reasoning events into a single merged reasoning event
     if (row.event.type === "reasoning") {
       let mergedText = (row.event as any).text ?? "";
@@ -1026,6 +1071,18 @@ export function groupConsecutiveWorkLogRows(
   }
 
   return consolidateInterruptedTerminus(grouped);
+}
+
+function isActivityBundleSourceEvent(event: ChatTranscriptRenderEvent): event is ChatActivityBundleItem["event"] {
+  return event.type === "todo_update"
+    || event.type === "subagent_started"
+    || event.type === "subagent_progress"
+    || event.type === "subagent_result"
+    || event.type === "scheduled_work_update";
+}
+
+function activityBundleTurnId(event: ChatActivityBundleItem["event"]): string | null {
+  return "turnId" in event ? event.turnId ?? null : null;
 }
 
 function classifyActivityPhaseRow(

--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -1963,7 +1963,6 @@ extension AgentChatEvent {
     case trigger
     case preTokens
     case postTokens
-    case durationMs
     case provider
     case sessionCompactionCount
     case compactionId

--- a/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
@@ -1068,7 +1068,7 @@ struct WorkEventCardView: View {
   /// reads like prose.
   private func isRibbonKind(_ kind: String) -> Bool {
     switch kind {
-    case "status", "activity", "notice", "todo", "autoApproval",
+    case "status", "activity", "activityBundle", "notice", "todo", "autoApproval",
          "pendingInputResolved", "webSearch", "promptSuggestion",
          "toolUseSummary":
       return true

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -1050,7 +1050,9 @@ func buildWorkTimeline(
       deduped.append(entry)
     }
   }
-  return collapseActivityPhaseTimelineEntries(collapseConsecutiveWorkToolEntries(deduped))
+  return collapseActivityPhaseTimelineEntries(
+    collapseConsecutiveWorkActivityEntries(collapseConsecutiveWorkToolEntries(deduped))
+  )
 }
 
 /// Fold tool-like timeline entries (tool cards, commands, file changes) into
@@ -1270,7 +1272,7 @@ private func extractCodeChangeFilePath(fromArgsText argsText: String?) -> String
 private func workToolGroupSoftBreak(_ entry: WorkTimelineEntry) -> Bool {
   guard case .eventCard(let card) = entry.payload else { return false }
   switch card.kind {
-  case "reasoning", "status", "activity", "todo", "notice",
+  case "reasoning", "status", "activity", "activityBundle", "todo", "notice",
        "autoApproval", "pendingInputResolved",
        "promptSuggestion", "toolUseSummary":
     return true
@@ -1319,8 +1321,8 @@ private func mergeReasoningTimelineEntries(_ entries: [WorkTimelineEntry]) -> Wo
     guard case .eventCard(let card) = entry.payload, card.kind == "reasoning" else { return nil }
     return card
   }
-  let first = entries[0]!
-  let last = entries[entries.count - 1]!
+  let first = entries[0]
+  let last = entries[entries.count - 1]
   let mergedBody = cards
     .compactMap { $0.body?.trimmingCharacters(in: .whitespacesAndNewlines) }
     .filter { !$0.isEmpty }
@@ -1365,7 +1367,7 @@ private func mergeToolGroupTimelineEntries(_ entries: [WorkTimelineEntry]) -> Wo
     guard case .toolGroup(let group) = entry.payload else { return nil }
     return group
   }
-  let first = entries[0]!
+  let first = entries[0]
   let merged = WorkToolGroupModel(
     id: "activity-phase-tools:\(first.id)",
     members: groups.flatMap(\.members)
@@ -1383,7 +1385,7 @@ private func mergeChangedFilesTimelineEntries(_ entries: [WorkTimelineEntry]) ->
     guard case .changedFiles(let group) = entry.payload else { return nil }
     return group
   }
-  let first = entries[0]!
+  let first = entries[0]
   let merged = WorkChangedFilesGroupModel(
     id: "activity-phase-files:\(first.id)",
     files: groups.flatMap(\.files)
@@ -1473,6 +1475,70 @@ func collapseActivityPhaseTimelineEntries(_ entries: [WorkTimelineEntry]) -> [Wo
   }
 
   return result
+}
+
+private func collapseConsecutiveWorkActivityEntries(_ entries: [WorkTimelineEntry]) -> [WorkTimelineEntry] {
+  var result: [WorkTimelineEntry] = []
+  result.reserveCapacity(entries.count)
+  var cluster: [WorkTimelineEntry] = []
+
+  func flushCluster() {
+    defer { cluster.removeAll(keepingCapacity: true) }
+    guard cluster.count > 1 else {
+      result.append(contentsOf: cluster)
+      return
+    }
+    let cards = cluster.compactMap(workActivityCard(from:))
+    guard cards.count == cluster.count, let anchor = cluster.first, let latest = cards.last else {
+      result.append(contentsOf: cluster)
+      return
+    }
+    let summaries = cards.map(workActivityCardSummary).filter { !$0.isEmpty }
+    let latestSummary = nonEmptyWorkTimelineText(latest.body) ?? summaries.last ?? latest.title
+    let body = "\(cards.count) activity updates · \(truncatedWorkTimelineText(latestSummary, limit: 90))"
+    let bundle = WorkEventCardModel(
+      id: "activity-bundle:\(anchor.id)",
+      kind: "activityBundle",
+      title: "Activity",
+      icon: "sparkles",
+      tint: .accent,
+      timestamp: latest.timestamp,
+      body: body,
+      bullets: Array(summaries.prefix(6)),
+      metadata: []
+    )
+    result.append(WorkTimelineEntry(
+      id: "activity-bundle:\(anchor.id)",
+      timestamp: anchor.timestamp,
+      rank: anchor.rank,
+      payload: .eventCard(bundle)
+    ))
+  }
+
+  for entry in entries {
+    if workActivityCard(from: entry) != nil {
+      cluster.append(entry)
+    } else {
+      flushCluster()
+      result.append(entry)
+    }
+  }
+  flushCluster()
+  return result
+}
+
+private func workActivityCard(from entry: WorkTimelineEntry) -> WorkEventCardModel? {
+  guard case .eventCard(let card) = entry.payload else { return nil }
+  switch card.kind {
+  case "activity", "todo": return card
+  default: return nil
+  }
+}
+
+private func workActivityCardSummary(_ card: WorkEventCardModel) -> String {
+  let pieces = [card.metadata.first, card.body, card.title]
+    .compactMap { nonEmptyWorkTimelineText($0) }
+  return pieces.first ?? card.title
 }
 
 func normalizedWorkLocalEchoText(_ text: String) -> String {
@@ -1818,6 +1884,14 @@ private func nonEmptyWorkTimelineText(_ value: String?) -> String? {
   return trimmed.isEmpty ? nil : trimmed
 }
 
+private func strippedWorkActivityStatusPrefix(_ value: String) -> String {
+  let prefixes = ["In Progress: ", "Completed: ", "Pending: "]
+  for prefix in prefixes where value.hasPrefix(prefix) {
+    return String(value.dropFirst(prefix.count))
+  }
+  return value
+}
+
 private func truncatedWorkTimelineText(_ value: String, limit: Int) -> String {
   guard value.count > limit, limit > 3 else { return value }
   return "\(value.prefix(limit - 3))..."
@@ -1958,16 +2032,86 @@ private func eventCard(
         resolution: resolutionByItemId[itemId]
       )
     case .todoUpdate(let items, _):
+      let completed = items.filter { $0.lowercased().hasPrefix("completed:") }.count
+      let active = items.first { $0.lowercased().hasPrefix("in progress:") }
+        ?? items.first { !$0.lowercased().hasPrefix("completed:") }
+        ?? items.last
+      let progressLabel = items.isEmpty ? "updated" : "\(completed)/\(items.count) complete"
       return WorkEventCardModel(
         id: envelope.id,
         kind: "todo",
-        title: "Todo update",
+        title: "Task update",
         icon: "checklist",
         tint: .accent,
         timestamp: envelope.timestamp,
-        body: nil,
+        body: active.map { strippedWorkActivityStatusPrefix($0) },
         bullets: items,
-        metadata: []
+        metadata: ["Tasks · \(progressLabel)"]
+      )
+    case .subagentStarted(_, _, let agentType, _, let description, let background, let label, _, _, _):
+      let title = background ? "Background agent started" : "Subagent started"
+      return WorkEventCardModel(
+        id: envelope.id,
+        kind: "activity",
+        title: title,
+        icon: "person.2",
+        tint: .accent,
+        timestamp: envelope.timestamp,
+        body: nonEmptyWorkTimelineText(label)
+          ?? nonEmptyWorkTimelineText(agentType)
+          ?? nonEmptyWorkTimelineText(description),
+        bullets: [],
+        metadata: ["Agent started"]
+      )
+    case .subagentProgress(_, _, let agentType, _, let description, let summary, let toolName, let label, _, _, _):
+      return WorkEventCardModel(
+        id: envelope.id,
+        kind: "activity",
+        title: "Subagent running",
+        icon: "person.2.wave.2",
+        tint: .accent,
+        timestamp: envelope.timestamp,
+        body: nonEmptyWorkTimelineText(label)
+          ?? nonEmptyWorkTimelineText(agentType)
+          ?? nonEmptyWorkTimelineText(summary)
+          ?? nonEmptyWorkTimelineText(description)
+          ?? nonEmptyWorkTimelineText(toolName),
+        bullets: [],
+        metadata: ["Agent running"]
+      )
+    case .subagentResult(_, _, let agentType, _, let status, let summary, let label, _, _, _):
+      let normalized = status.replacingOccurrences(of: "_", with: " ").capitalized
+      return WorkEventCardModel(
+        id: envelope.id,
+        kind: "activity",
+        title: "Subagent \(normalized.lowercased())",
+        icon: status == "failed" ? "xmark.circle" : status == "stopped" ? "pause.circle" : "checkmark.circle",
+        tint: status == "failed" ? .danger : status == "stopped" ? .warning : .success,
+        timestamp: envelope.timestamp,
+        body: nonEmptyWorkTimelineText(label)
+          ?? nonEmptyWorkTimelineText(agentType)
+          ?? nonEmptyWorkTimelineText(summary),
+        bullets: [],
+        metadata: ["Agent \(normalized.lowercased())"]
+      )
+    case .scheduledWorkUpdate(_, let kind, let status, _, let title, let summary, let prompt, let reason, let cron, let nextRunAt, _, _, _, _, _, _, let error):
+      let normalized = status.replacingOccurrences(of: "_", with: " ").capitalized
+      return WorkEventCardModel(
+        id: envelope.id,
+        kind: "activity",
+        title: kind == "cron" ? "Cron \(normalized.lowercased())" : "Scheduled work \(normalized.lowercased())",
+        icon: kind == "cron" ? "calendar.badge.clock" : "clock.arrow.circlepath",
+        tint: status == "failed" || status == "cancelled" ? .danger : status == "running" || status == "fired" ? .accent : .warning,
+        timestamp: envelope.timestamp,
+        body: nonEmptyWorkTimelineText(summary)
+          ?? nonEmptyWorkTimelineText(error)
+          ?? nonEmptyWorkTimelineText(title)
+          ?? nonEmptyWorkTimelineText(reason)
+          ?? nonEmptyWorkTimelineText(prompt)
+          ?? nonEmptyWorkTimelineText(cron)
+          ?? nonEmptyWorkTimelineText(nextRunAt),
+        bullets: [],
+        metadata: [kind == "cron" ? "Cron \(normalized.lowercased())" : "Schedule \(normalized.lowercased())"]
       )
     case .systemNotice(let kind, let message, let detail, _, _):
       guard !isLowSignalWorkSystemNotice(kind: kind, message: message, detail: detail) else { return nil }

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -1481,9 +1481,13 @@ private func collapseConsecutiveWorkActivityEntries(_ entries: [WorkTimelineEntr
   var result: [WorkTimelineEntry] = []
   result.reserveCapacity(entries.count)
   var cluster: [WorkTimelineEntry] = []
+  var clusterTurnId: String?
 
   func flushCluster() {
-    defer { cluster.removeAll(keepingCapacity: true) }
+    defer {
+      cluster.removeAll(keepingCapacity: true)
+      clusterTurnId = nil
+    }
     guard cluster.count > 1 else {
       result.append(contentsOf: cluster)
       return
@@ -1516,7 +1520,14 @@ private func collapseConsecutiveWorkActivityEntries(_ entries: [WorkTimelineEntr
   }
 
   for entry in entries {
-    if workActivityCard(from: entry) != nil {
+    if let card = workActivityCard(from: entry) {
+      let turnId = workActivityCardTurnId(from: card)
+      if !cluster.isEmpty && (clusterTurnId == nil || turnId == nil || clusterTurnId != turnId) {
+        flushCluster()
+      }
+      if cluster.isEmpty {
+        clusterTurnId = turnId
+      }
       cluster.append(entry)
     } else {
       flushCluster()
@@ -1533,6 +1544,19 @@ private func workActivityCard(from entry: WorkTimelineEntry) -> WorkEventCardMod
   case "activity", "todo": return card
   default: return nil
   }
+}
+
+private func workActivityCardId(sessionId: String, turnId: String?, fallback: String) -> String {
+  guard let turnId = normalizedWorkTurnId(turnId) else { return fallback }
+  return "\(fallback):activityTurn:\(sessionId):\(turnId)"
+}
+
+private func workActivityCardTurnId(from card: WorkEventCardModel) -> String? {
+  let parts = card.id.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+  guard let markerIndex = parts.firstIndex(of: "activityTurn"), markerIndex + 2 < parts.count else {
+    return nil
+  }
+  return normalizedWorkTurnId(parts[markerIndex + 2])
 }
 
 private func workActivityCardSummary(_ card: WorkEventCardModel) -> String {
@@ -2031,14 +2055,14 @@ private func eventCard(
         questionModel: questionModel,
         resolution: resolutionByItemId[itemId]
       )
-    case .todoUpdate(let items, _):
+    case .todoUpdate(let items, let turnId):
       let completed = items.filter { $0.lowercased().hasPrefix("completed:") }.count
       let active = items.first { $0.lowercased().hasPrefix("in progress:") }
         ?? items.first { !$0.lowercased().hasPrefix("completed:") }
         ?? items.last
       let progressLabel = items.isEmpty ? "updated" : "\(completed)/\(items.count) complete"
       return WorkEventCardModel(
-        id: envelope.id,
+        id: workActivityCardId(sessionId: envelope.sessionId, turnId: turnId, fallback: envelope.id),
         kind: "todo",
         title: "Task update",
         icon: "checklist",
@@ -2048,10 +2072,10 @@ private func eventCard(
         bullets: items,
         metadata: ["Tasks · \(progressLabel)"]
       )
-    case .subagentStarted(_, _, let agentType, _, let description, let background, let label, _, _, _):
+    case .subagentStarted(_, _, let agentType, _, let description, let background, let label, _, _, let turnId):
       let title = background ? "Background agent started" : "Subagent started"
       return WorkEventCardModel(
-        id: envelope.id,
+        id: workActivityCardId(sessionId: envelope.sessionId, turnId: turnId, fallback: envelope.id),
         kind: "activity",
         title: title,
         icon: "person.2",
@@ -2063,9 +2087,9 @@ private func eventCard(
         bullets: [],
         metadata: ["Agent started"]
       )
-    case .subagentProgress(_, _, let agentType, _, let description, let summary, let toolName, let label, _, _, _):
+    case .subagentProgress(_, _, let agentType, _, let description, let summary, let toolName, let label, _, _, let turnId):
       return WorkEventCardModel(
-        id: envelope.id,
+        id: workActivityCardId(sessionId: envelope.sessionId, turnId: turnId, fallback: envelope.id),
         kind: "activity",
         title: "Subagent running",
         icon: "person.2.wave.2",
@@ -2079,10 +2103,10 @@ private func eventCard(
         bullets: [],
         metadata: ["Agent running"]
       )
-    case .subagentResult(_, _, let agentType, _, let status, let summary, let label, _, _, _):
+    case .subagentResult(_, _, let agentType, _, let status, let summary, let label, _, _, let turnId):
       let normalized = status.replacingOccurrences(of: "_", with: " ").capitalized
       return WorkEventCardModel(
-        id: envelope.id,
+        id: workActivityCardId(sessionId: envelope.sessionId, turnId: turnId, fallback: envelope.id),
         kind: "activity",
         title: "Subagent \(normalized.lowercased())",
         icon: status == "failed" ? "xmark.circle" : status == "stopped" ? "pause.circle" : "checkmark.circle",
@@ -2094,10 +2118,10 @@ private func eventCard(
         bullets: [],
         metadata: ["Agent \(normalized.lowercased())"]
       )
-    case .scheduledWorkUpdate(_, let kind, let status, _, let title, let summary, let prompt, let reason, let cron, let nextRunAt, _, _, _, _, _, _, let error):
+    case .scheduledWorkUpdate(_, let kind, let status, _, let title, let summary, let prompt, let reason, let cron, let nextRunAt, _, _, _, _, _, let turnId, let error):
       let normalized = status.replacingOccurrences(of: "_", with: " ").capitalized
       return WorkEventCardModel(
-        id: envelope.id,
+        id: workActivityCardId(sessionId: envelope.sessionId, turnId: turnId, fallback: envelope.id),
         kind: "activity",
         title: kind == "cron" ? "Cron \(normalized.lowercased())" : "Scheduled work \(normalized.lowercased())",
         icon: kind == "cron" ? "calendar.badge.clock" : "clock.arrow.circlepath",

--- a/apps/ios/ADE/Views/Work/WorkTranscriptParser.swift
+++ b/apps/ios/ADE/Views/Work/WorkTranscriptParser.swift
@@ -43,9 +43,9 @@ func workContextCompactSummary(
   }
   let triggerLabel = trigger.replacingOccurrences(of: "_", with: " ").capitalized
   lines.append(triggerLabel)
-  if let pre, let post {
+  if let pre = preTokens, let post = postTokens {
     lines.append("\(formatWorkCompactTokenCount(pre)) → \(formatWorkCompactTokenCount(post))")
-  } else if let pre {
+  } else if let pre = preTokens {
     lines.append("Pre-compact tokens: \(pre)")
   }
   if let durationMs {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -8898,6 +8898,35 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(snapshot.scheduledWorkSnapshots.first?.durable, true)
   }
 
+  func testWorkTimelineBundlesTaskSubagentAndScheduledActivity() {
+    let raw = """
+    {"sessionId":"chat-1","timestamp":"2026-07-07T00:00:00.000Z","sequence":1,"event":{"type":"todo_update","turnId":"turn-1","items":[{"id":"task-1","description":"Review mobile activity rows","status":"in_progress"}]}}
+    {"sessionId":"chat-1","timestamp":"2026-07-07T00:00:01.000Z","sequence":2,"event":{"type":"subagent_started","taskId":"agent-1","description":"Inspect iOS transcript","turnId":"turn-1"}}
+    {"sessionId":"chat-1","timestamp":"2026-07-07T00:00:02.000Z","sequence":3,"event":{"type":"scheduled_work_update","id":"cron-1","kind":"cron","status":"scheduled","origin":"schedule_cron","title":"CI follow-up","turnId":"turn-1"}}
+    """
+
+    let snapshot = buildWorkChatTimelineSnapshot(
+      transcript: parseWorkChatTranscript(raw),
+      fallbackEntries: [],
+      artifacts: [],
+      localEchoMessages: []
+    )
+    let activityBundles = snapshot.timeline.compactMap { entry -> WorkEventCardModel? in
+      guard case .eventCard(let card) = entry.payload, card.kind == "activityBundle" else { return nil }
+      return card
+    }
+
+    XCTAssertEqual(activityBundles.count, 1)
+    XCTAssertEqual(activityBundles.first?.title, "Activity")
+    XCTAssertTrue(activityBundles.first?.body?.contains("3 activity updates") == true)
+    XCTAssertTrue(activityBundles.first?.body?.contains("CI follow-up") == true)
+    XCTAssertEqual(Array(activityBundles.first?.bullets.prefix(3) ?? []), [
+      "Tasks · 0/1 complete",
+      "Agent started",
+      "Cron scheduled",
+    ])
+  }
+
   func testParseWorkChatTranscriptAppliesTranscriptRetractionsByMessageId() {
     let raw = """
     {"sessionId":"chat-1","timestamp":"2026-07-07T00:00:01.000Z","sequence":1,"event":{"type":"text","text":"Superseded answer","messageId":"provider-message-1","turnId":"turn-1"}}
@@ -14044,19 +14073,19 @@ final class ADETests: XCTestCase {
   func testWorkContextCompactSummaryParsesAutoAndTokens() {
     let parsed = WorkContextCompactSummary.parse("auto compact freed ~12,400 tokens")
     XCTAssertEqual(parsed.triggerLabel, "AUTO")
-    XCTAssertEqual(parsed.tokensFreedLabel, "~12k tokens freed")
+    XCTAssertEqual(parsed.tokensLabel, "~12k tokens freed")
   }
 
   func testWorkContextCompactSummaryParsesManualTriggerWithoutTokens() {
     let parsed = WorkContextCompactSummary.parse("Manual compaction ran")
     XCTAssertEqual(parsed.triggerLabel, "MANUAL")
-    XCTAssertNil(parsed.tokensFreedLabel)
+    XCTAssertNil(parsed.tokensLabel)
   }
 
   func testWorkContextCompactSummaryEmptyInputReturnsDefaults() {
     let parsed = WorkContextCompactSummary.parse(nil)
     XCTAssertNil(parsed.triggerLabel)
-    XCTAssertNil(parsed.tokensFreedLabel)
+    XCTAssertNil(parsed.tokensLabel)
   }
 
   func testWorkContextCompactLifecycleMergesStartedAndCompletedCard() {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -8927,6 +8927,30 @@ final class ADETests: XCTestCase {
     ])
   }
 
+  func testWorkTimelineKeepsActivityBundlesSeparatedByTurn() {
+    let raw = """
+    {"sessionId":"chat-1","timestamp":"2026-07-07T00:00:00.000Z","sequence":1,"event":{"type":"todo_update","turnId":"turn-1","items":[{"id":"task-1","description":"First turn task","status":"in_progress"}]}}
+    {"sessionId":"chat-1","timestamp":"2026-07-07T00:00:01.000Z","sequence":2,"event":{"type":"subagent_started","taskId":"agent-1","description":"First turn agent","turnId":"turn-1"}}
+    {"sessionId":"chat-1","timestamp":"2026-07-07T00:00:02.000Z","sequence":3,"event":{"type":"todo_update","turnId":"turn-2","items":[{"id":"task-2","description":"Second turn task","status":"in_progress"}]}}
+    {"sessionId":"chat-1","timestamp":"2026-07-07T00:00:03.000Z","sequence":4,"event":{"type":"scheduled_work_update","id":"cron-2","kind":"cron","status":"scheduled","origin":"schedule_cron","title":"Second turn cron","turnId":"turn-2"}}
+    """
+
+    let snapshot = buildWorkChatTimelineSnapshot(
+      transcript: parseWorkChatTranscript(raw),
+      fallbackEntries: [],
+      artifacts: [],
+      localEchoMessages: []
+    )
+    let activityBundles = snapshot.timeline.compactMap { entry -> WorkEventCardModel? in
+      guard case .eventCard(let card) = entry.payload, card.kind == "activityBundle" else { return nil }
+      return card
+    }
+
+    XCTAssertEqual(activityBundles.count, 2)
+    XCTAssertTrue(activityBundles[0].body?.contains("First turn agent") == true)
+    XCTAssertTrue(activityBundles[1].body?.contains("Second turn cron") == true)
+  }
+
   func testParseWorkChatTranscriptAppliesTranscriptRetractionsByMessageId() {
     let raw = """
     {"sessionId":"chat-1","timestamp":"2026-07-07T00:00:01.000Z","sequence":1,"event":{"type":"text","text":"Superseded answer","messageId":"provider-message-1","turnId":"turn-1"}}


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Finvolves-claude-agent-sdk-so-e30689cf num=728 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Finvolves-claude-agent-sdk-so-e30689cf&amp;pr=728">ade/involves-claude-agent-sdk-so-e30689cf branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=728">PR #728</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds compact activity handoff and transcript rendering for Claude SDK chat flows.

- Activity bundles for task, subagent, workflow, and scheduled-work updates.
- Desktop and iOS transcript grouping updates around turn boundaries.
- CLI activity rendering for compact TUI transcript rows.
- A narrower idle-reader handoff path in the desktop chat service.

<h3>Confidence Score: 4/5</h3>

The CLI activity bundle path can still merge unrelated turn-less updates.

Desktop and iOS turn-boundary fixes cover the changed grouped transcript paths, but the TUI aggregator still treats two missing turn ids as the same bundle key.

apps/ade-cli/src/tuiClient/aggregate.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced the null-turn bundle scenario by running a targeted Vitest repro that imports the real CLI aggregateChatBlocks path and feeds a todo\_update followed by a scheduled\_work\_update with both turnId fields omitted.
- The serialized aggregation output showed exactly one activity-bundle block with turnId null containing both unrelated task and schedule entries.
- The repro assertions passed, confirming that the current PR code collapses the adjacent turn-less activity source events into a single Activity row.
- I attempted to render the UI using the claude activity bundle harness, but the environment hit a blocker: Vite reported readiness while Playwright timed out before usable captures could be produced.

<a href="https://app.greptile.com/trex/runs/13634371/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/tuiClient/aggregate.ts | Adds TUI activity bundle aggregation, but adjacent missing-turn activity events can still merge. |
| apps/desktop/src/renderer/components/chat/chatTranscriptRows.ts | Adds desktop activity bundle grouping with explicit missing-turn separation. |
| apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift | Adds iOS activity bundle collapsing with turn-aware card IDs and grouping. |
| apps/desktop/src/main/services/chat/agentChatService.ts | Narrows idle-reader handoff to the generation-only mismatch case. |


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/ade-cli/src/tuiClient/aggregate.ts`, line 246 ([link](https://github.com/arul28/ade/blob/3283cc25e930de8d30ab280819891e73e79ff3aa/apps/ade-cli/src/tuiClient/aggregate.ts#L246)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Null Turn Bundles Merge**

   When adjacent activity source events omit `turnId`, both calls pass `null` into this check, so the TUI merges unrelated task, schedule, or subagent updates into one Activity row. The desktop path now breaks on missing turn ids, but the CLI transcript can still hide separate turn-less updates behind a single bundle.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: targeted Vitest aggregation harness for adjacent turn-less activity events](https://app.greptile.com/trex/artifacts/6f32c8c8-d62d-4b21-8e3e-40dc1db7f877)**

   - Contains supporting evidence from the run (text/typescript; charset=utf-8).

   **[Repro: verbose Vitest output showing one null-turn activity-bundle with two unrelated entries](https://app.greptile.com/trex/artifacts/31ab93d0-170e-42d0-a059-139519547a2a)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/13634371/artifacts?artifact=6f32c8c8-d62d-4b21-8e3e-40dc1db7f877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ade-cli/src/tuiClient/aggregate.ts
   Line: 246

   Comment:
   **Null Turn Bundles Merge**

   When adjacent activity source events omit `turnId`, both calls pass `null` into this check, so the TUI merges unrelated task, schedule, or subagent updates into one Activity row. The desktop path now breaks on missing turn ids, but the CLI transcript can still hide separate turn-less updates behind a single bundle.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fade-cli%2Fsrc%2FtuiClient%2Faggregate.ts%0ALine%3A%20246%0A%0AComment%3A%0A**Null%20Turn%20Bundles%20Merge**%0A%0AWhen%20adjacent%20activity%20source%20events%20omit%20%60turnId%60%2C%20both%20calls%20pass%20%60null%60%20into%20this%20check%2C%20so%20the%20TUI%20merges%20unrelated%20task%2C%20schedule%2C%20or%20subagent%20updates%20into%20one%20Activity%20row.%20The%20desktop%20path%20now%20breaks%20on%20missing%20turn%20ids%2C%20but%20the%20CLI%20transcript%20can%20still%20hide%20separate%20turn-less%20updates%20behind%20a%20single%20bundle.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=728&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fade-cli%2Fsrc%2FtuiClient%2Faggregate.ts%3A246%0A**Null%20Turn%20Bundles%20Merge**%0A%0AWhen%20adjacent%20activity%20source%20events%20omit%20%60turnId%60%2C%20both%20calls%20pass%20%60null%60%20into%20this%20check%2C%20so%20the%20TUI%20merges%20unrelated%20task%2C%20schedule%2C%20or%20subagent%20updates%20into%20one%20Activity%20row.%20The%20desktop%20path%20now%20breaks%20on%20missing%20turn%20ids%2C%20but%20the%20CLI%20transcript%20can%20still%20hide%20separate%20turn-less%20updates%20behind%20a%20single%20bundle.%0A%0A&repo=arul28%2Fade&pr=728&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/ade-cli/src/tuiClient/aggregate.ts:246
**Null Turn Bundles Merge**

When adjacent activity source events omit `turnId`, both calls pass `null` into this check, so the TUI merges unrelated task, schedule, or subagent updates into one Activity row. The desktop path now breaks on missing turn ids, but the CLI transcript can still hide separate turn-less updates behind a single bundle.


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["ship: iteration 1 - address activity rev..."](https://github.com/arul28/ade/commit/3283cc25e930de8d30ab280819891e73e79ff3aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42578653)</sub>

<!-- /greptile_comment -->