### PR TITLE
Start Skill Mobile Prs View

### DIFF
--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -1138,8 +1138,8 @@ export async function createAdeRuntime(args: {
   // `pr.listQueueStates` call over the local runtime fails with "is not
   // callable". Mirror the desktop main-process wiring (see main.ts) so the PRs
   // tab loads against the local runtime.
-  // Fan-out for the push publisher: PR merge-ready / checks-failing notifications
-  // are bridged here so the publisher never has to poll GitHub itself. Populated
+  // Fan-out for the push publisher: PR lifecycle/status notifications are
+  // bridged here so the publisher never has to poll GitHub itself. Populated
   // by pushPublisherService.start() (declared below), so it stays empty and inert
   // when push publishing is not running.
   const pushPrNotificationSubscribers = new Set<(notification: PushPrNotification) => void>();

--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -1151,6 +1151,8 @@ export async function createAdeRuntime(args: {
         prNumber: event.prNumber,
         prTitle: event.prTitle ?? null,
         laneId: event.laneId ?? null,
+        repoOwner: event.repoOwner ?? null,
+        repoName: event.repoName ?? null,
       };
       for (const subscriber of pushPrNotificationSubscribers) {
         try {

--- a/apps/ade-cli/src/services/push/pushPublisherService.test.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.test.ts
@@ -384,6 +384,55 @@ describe("createPushPublisherService flush", () => {
     publisher.dispose();
   });
 
+  it("publishes repeated PR transition alerts after an intervening state change", async () => {
+    const { publisher, publish } = makeHarness();
+    let prCb: (event: PushPrNotification) => void = () => {
+      throw new Error("PR notification source was not attached");
+    };
+    publisher.attachSources("project-a", {
+      subscribePrNotifications: (cb) => {
+        prCb = cb;
+        return () => {};
+      },
+    });
+    await publisher.start();
+
+    const pr = {
+      prNumber: 42,
+      prTitle: "Repeatable PR lifecycle",
+      laneId: null,
+      repoOwner: "arul28",
+      repoName: "ADE",
+    };
+
+    prCb({ ...pr, kind: "closed" });
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(publish.mock.calls.at(-1)?.[0].notifications[0]).toMatchObject({
+      title: "PR #42 closed",
+      body: "Repeatable PR lifecycle",
+      dedupeKey: "alert:pr:project-a:repo:arul28:ade:42:closed",
+    });
+
+    publish.mockClear();
+    prCb({ ...pr, kind: "reopened" });
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(publish.mock.calls.at(-1)?.[0].notifications[0]).toMatchObject({
+      title: "PR #42 reopened",
+      body: "Repeatable PR lifecycle",
+    });
+
+    publish.mockClear();
+    prCb({ ...pr, kind: "closed" });
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(publish.mock.calls.at(-1)?.[0].notifications[0]).toMatchObject({
+      title: "PR #42 closed",
+      body: "Repeatable PR lifecycle",
+      dedupeKey: "alert:pr:project-a:repo:arul28:ade:42:closed",
+    });
+
+    publisher.dispose();
+  });
+
   it("uses the uncapped PR count in the aggregate Live Activity start alert", async () => {
     const { publisher, publish } = makeHarness();
     let prCb: (event: PushPrNotification) => void = () => {

--- a/apps/ade-cli/src/services/push/pushPublisherService.test.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.test.ts
@@ -229,19 +229,29 @@ describe("createPushPublisherService flush", () => {
 
   it("publishes PR lifecycle alerts into the aggregate Live Activity", async () => {
     const { publisher, publish } = makeHarness();
-    let prCb: (event: PushPrNotification) => void = () => {
-      throw new Error("PR notification source was not attached");
+    let firstPrCb: (event: PushPrNotification) => void = () => {
+      throw new Error("first PR notification source was not attached");
     };
-    publisher.attachSources("scope-pr", {
+    let secondPrCb: (event: PushPrNotification) => void = () => {
+      throw new Error("second PR notification source was not attached");
+    };
+    publisher.attachSources("project-a", {
       subscribePrNotifications: (cb) => {
-        prCb = cb;
+        firstPrCb = cb;
         return () => {};
       },
       resolveLaneName: (laneId: string) => laneId === "lane-42" ? "Mobile PR lane" : laneId,
     });
+    publisher.attachSources("project-b", {
+      subscribePrNotifications: (cb) => {
+        secondPrCb = cb;
+        return () => {};
+      },
+      resolveLaneName: (laneId: string) => laneId === "lane-other" ? "Other repo lane" : laneId,
+    });
     await publisher.start();
 
-    prCb?.({ kind: "merged", prNumber: 42, prTitle: "Ship mobile PR view", laneId: "lane-42" });
+    firstPrCb({ kind: "merged", prNumber: 42, prTitle: "Ship mobile PR view", laneId: "lane-42" });
     await vi.advanceTimersByTimeAsync(2_500);
 
     const payload = publish.mock.calls[0][0];
@@ -249,16 +259,37 @@ describe("createPushPublisherService flush", () => {
       title: "PR #42 merged",
       body: "Ship mobile PR view",
       deepLink: "ade://pr/42",
-      threadId: "pr-42",
+      threadId: "pr:project-a:42",
     });
     expect(payload.liveActivity[0].contentState.prs[0]).toMatchObject({
-      id: "pr-42",
+      id: "pr:project-a:42",
       prNumber: 42,
       title: "Ship mobile PR view",
       phase: "merged",
       lane: "Mobile PR lane",
     });
     expect(payload.liveActivity[0].phase).toBe("running");
+
+    secondPrCb({ kind: "checks_failing", prNumber: 42, prTitle: "Same number, other repo", laneId: "lane-other" });
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    const updatePayload = publish.mock.calls.at(-1)?.[0];
+    expect(updatePayload?.liveActivity[0].contentState.prs).toMatchObject([
+      {
+        id: "pr:project-b:42",
+        prNumber: 42,
+        title: "Same number, other repo",
+        phase: "checks_failing",
+        lane: "Other repo lane",
+      },
+      {
+        id: "pr:project-a:42",
+        prNumber: 42,
+        title: "Ship mobile PR view",
+        phase: "merged",
+        lane: "Mobile PR lane",
+      },
+    ]);
 
     await vi.advanceTimersByTimeAsync(45 * 60 * 1000 + 1_000);
     const endPayload = publish.mock.calls.at(-1)?.[0];

--- a/apps/ade-cli/src/services/push/pushPublisherService.test.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.test.ts
@@ -331,6 +331,38 @@ describe("createPushPublisherService flush", () => {
     publisher.dispose();
   });
 
+  it("uses the uncapped PR count in the aggregate Live Activity start alert", async () => {
+    const { publisher, publish } = makeHarness();
+    let prCb: (event: PushPrNotification) => void = () => {
+      throw new Error("PR notification source was not attached");
+    };
+    publisher.attachSources("project-prs", {
+      subscribePrNotifications: (cb) => {
+        prCb = cb;
+        return () => {};
+      },
+    });
+    await publisher.start();
+
+    for (const prNumber of [101, 102, 103]) {
+      prCb({
+        kind: "opened",
+        prNumber,
+        prTitle: `PR ${prNumber}`,
+        laneId: null,
+        repoOwner: "arul28",
+        repoName: "ADE",
+      });
+    }
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    const liveActivity = publish.mock.calls[0][0].liveActivity[0];
+    expect(liveActivity.contentState.prs).toHaveLength(2);
+    expect(liveActivity.alert.title).toBe("3 pull requests updated");
+
+    publisher.dispose();
+  });
+
   it("carries actionable fields: category + sessionId/itemId on the alert, itemId on the waiting LA row, badge count", async () => {
     const { publisher, publish, emit } = makeHarness();
     await publisher.start();

--- a/apps/ade-cli/src/services/push/pushPublisherService.test.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.test.ts
@@ -15,6 +15,7 @@ import {
   parseHhMm,
   shouldDeliverAlertForPrefs,
   type AgentRunState,
+  type PushPrNotification,
 } from "./pushPublisherService";
 
 function run(overrides: Partial<AgentRunState>): AgentRunState {
@@ -222,6 +223,50 @@ describe("createPushPublisherService flush", () => {
     emit(approval);
     await vi.advanceTimersByTimeAsync(2_500);
     expect(publish).toHaveBeenCalledTimes(1);
+
+    publisher.dispose();
+  });
+
+  it("publishes PR lifecycle alerts into the aggregate Live Activity", async () => {
+    const { publisher, publish } = makeHarness();
+    let prCb: (event: PushPrNotification) => void = () => {
+      throw new Error("PR notification source was not attached");
+    };
+    publisher.attachSources("scope-pr", {
+      subscribePrNotifications: (cb) => {
+        prCb = cb;
+        return () => {};
+      },
+      resolveLaneName: (laneId: string) => laneId === "lane-42" ? "Mobile PR lane" : laneId,
+    });
+    await publisher.start();
+
+    prCb?.({ kind: "merged", prNumber: 42, prTitle: "Ship mobile PR view", laneId: "lane-42" });
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    const payload = publish.mock.calls[0][0];
+    expect(payload.notifications[0]).toMatchObject({
+      title: "PR #42 merged",
+      body: "Ship mobile PR view",
+      deepLink: "ade://pr/42",
+      threadId: "pr-42",
+    });
+    expect(payload.liveActivity[0].contentState.prs[0]).toMatchObject({
+      id: "pr-42",
+      prNumber: 42,
+      title: "Ship mobile PR view",
+      phase: "merged",
+      lane: "Mobile PR lane",
+    });
+    expect(payload.liveActivity[0].phase).toBe("running");
+
+    await vi.advanceTimersByTimeAsync(45 * 60 * 1000 + 1_000);
+    const endPayload = publish.mock.calls.at(-1)?.[0];
+    expect(endPayload.liveActivity[0]).toMatchObject({
+      event: "end",
+      phase: "terminal",
+    });
+    expect(endPayload.liveActivity[0].contentState.prs).toEqual([]);
 
     publisher.dispose();
   });

--- a/apps/ade-cli/src/services/push/pushPublisherService.test.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.test.ts
@@ -453,6 +453,44 @@ describe("createPushPublisherService flush", () => {
     publisher.dispose();
   });
 
+  it("drops terminal run rows before PR-backed Live Activity updates", async () => {
+    const { publisher, publish, emit } = makeHarness();
+    let prCb: (event: PushPrNotification) => void = () => {
+      throw new Error("PR notification source was not attached");
+    };
+    publisher.attachSources("project-prs", {
+      subscribePrNotifications: (cb) => {
+        prCb = cb;
+        return () => {};
+      },
+    });
+    await publisher.start();
+
+    emit(approval);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(publish.mock.calls[0][0].liveActivity[0].contentState.runs[0].id).toBe("s-1");
+    publish.mockClear();
+
+    emit({ sessionId: "s-1", timestamp: "", event: { type: "status", turnStatus: "completed" } });
+    prCb({
+      kind: "opened",
+      prNumber: 42,
+      prTitle: "Actual PR title",
+      laneId: null,
+      repoOwner: "arul28",
+      repoName: "ADE",
+    });
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    const liveActivity = publish.mock.calls.at(-1)![0].liveActivity[0];
+    expect(liveActivity.event).toBe("update");
+    expect(liveActivity.contentState.prs[0].prNumber).toBe(42);
+    expect(liveActivity.contentState.runs.find((run: { id: string }) => run.id === "s-1")).toBeUndefined();
+    expect(publisher._debug.runs.has("s-1")).toBe(false);
+
+    publisher.dispose();
+  });
+
   it("carries actionable fields: category + sessionId/itemId on the alert, itemId on the waiting LA row, badge count", async () => {
     const { publisher, publish, emit } = makeHarness();
     await publisher.start();

--- a/apps/ade-cli/src/services/push/pushPublisherService.test.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.test.ts
@@ -416,6 +416,43 @@ describe("createPushPublisherService flush", () => {
     publisher.dispose();
   });
 
+  it("uses the PR title for a PR-only aggregate start when stale CLI rows exist", async () => {
+    const { publisher, publish, cliSessions } = makeHarness();
+    let prCb: (event: PushPrNotification) => void = () => {
+      throw new Error("PR notification source was not attached");
+    };
+    publisher.attachSources("project-prs", {
+      subscribePrNotifications: (cb) => {
+        prCb = cb;
+        return () => {};
+      },
+    });
+    cliSessions.set("cli-1", { title: "stale CLI title", toolType: "claude", chatSessionId: null });
+    await publisher.start();
+
+    publisher.handleCliRuntimeSignal("scope-1", { laneId: "auth-lane", sessionId: "cli-1", runtimeState: "idle" });
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(publish.mock.calls.every(([payload]) => !payload.liveActivity)).toBe(true);
+    publish.mockClear();
+
+    prCb({
+      kind: "opened",
+      prNumber: 42,
+      prTitle: "Actual PR title",
+      laneId: null,
+      repoOwner: "arul28",
+      repoName: "ADE",
+    });
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    const liveActivity = publish.mock.calls[0][0].liveActivity[0];
+    expect(liveActivity.event).toBe("start");
+    expect(liveActivity.alert.title).toBe("PR #42 updated");
+    expect(liveActivity.alert.body).toBe("Actual PR title");
+
+    publisher.dispose();
+  });
+
   it("carries actionable fields: category + sessionId/itemId on the alert, itemId on the waiting LA row, badge count", async () => {
     const { publisher, publish, emit } = makeHarness();
     await publisher.start();

--- a/apps/ade-cli/src/services/push/pushPublisherService.test.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.test.ts
@@ -242,7 +242,7 @@ describe("createPushPublisherService flush", () => {
       },
       resolveLaneName: (laneId: string) => laneId === "lane-42" ? "Mobile PR lane" : laneId,
     });
-    publisher.attachSources("project-b", {
+    const detachProjectB = publisher.attachSources("project-b", {
       subscribePrNotifications: (cb) => {
         secondPrCb = cb;
         return () => {};
@@ -251,14 +251,21 @@ describe("createPushPublisherService flush", () => {
     });
     await publisher.start();
 
-    firstPrCb({ kind: "merged", prNumber: 42, prTitle: "Ship mobile PR view", laneId: "lane-42" });
+    firstPrCb({
+      kind: "merged",
+      prNumber: 42,
+      prTitle: "Ship mobile PR view",
+      laneId: "lane-42",
+      repoOwner: "arul28",
+      repoName: "ADE",
+    });
     await vi.advanceTimersByTimeAsync(2_500);
 
     const payload = publish.mock.calls[0][0];
     expect(payload.notifications[0]).toMatchObject({
       title: "PR #42 merged",
       body: "Ship mobile PR view",
-      deepLink: "ade://pr/42",
+      deepLink: "ade://pr/arul28/ADE/42",
       threadId: "pr:project-a:42",
     });
     expect(payload.liveActivity[0].contentState.prs[0]).toMatchObject({
@@ -267,10 +274,19 @@ describe("createPushPublisherService flush", () => {
       title: "Ship mobile PR view",
       phase: "merged",
       lane: "Mobile PR lane",
+      repoOwner: "arul28",
+      repoName: "ADE",
     });
     expect(payload.liveActivity[0].phase).toBe("running");
 
-    secondPrCb({ kind: "checks_failing", prNumber: 42, prTitle: "Same number, other repo", laneId: "lane-other" });
+    secondPrCb({
+      kind: "checks_failing",
+      prNumber: 42,
+      prTitle: "Same number, other repo",
+      laneId: "lane-other",
+      repoOwner: "other-org",
+      repoName: "other-repo",
+    });
     await vi.advanceTimersByTimeAsync(2_500);
 
     const updatePayload = publish.mock.calls.at(-1)?.[0];
@@ -281,6 +297,8 @@ describe("createPushPublisherService flush", () => {
         title: "Same number, other repo",
         phase: "checks_failing",
         lane: "Other repo lane",
+        repoOwner: "other-org",
+        repoName: "other-repo",
       },
       {
         id: "pr:project-a:42",
@@ -288,8 +306,19 @@ describe("createPushPublisherService flush", () => {
         title: "Ship mobile PR view",
         phase: "merged",
         lane: "Mobile PR lane",
+        repoOwner: "arul28",
+        repoName: "ADE",
       },
     ]);
+
+    detachProjectB();
+    await vi.advanceTimersByTimeAsync(2_500);
+    const detachPayload = publish.mock.calls.at(-1)?.[0];
+    expect(detachPayload?.liveActivity[0].contentState.prs).toHaveLength(1);
+    expect(detachPayload?.liveActivity[0].contentState.prs[0]).toMatchObject({
+      id: "pr:project-a:42",
+      title: "Ship mobile PR view",
+    });
 
     await vi.advanceTimersByTimeAsync(45 * 60 * 1000 + 1_000);
     const endPayload = publish.mock.calls.at(-1)?.[0];

--- a/apps/ade-cli/src/services/push/pushPublisherService.test.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.test.ts
@@ -266,10 +266,10 @@ describe("createPushPublisherService flush", () => {
       title: "PR #42 merged",
       body: "Ship mobile PR view",
       deepLink: "ade://pr/arul28/ADE/42",
-      threadId: "pr:project-a:42",
+      threadId: "pr:project-a:repo:arul28:ade:42",
     });
     expect(payload.liveActivity[0].contentState.prs[0]).toMatchObject({
-      id: "pr:project-a:42",
+      id: "pr:project-a:repo:arul28:ade:42",
       prNumber: 42,
       title: "Ship mobile PR view",
       phase: "merged",
@@ -292,7 +292,7 @@ describe("createPushPublisherService flush", () => {
     const updatePayload = publish.mock.calls.at(-1)?.[0];
     expect(updatePayload?.liveActivity[0].contentState.prs).toMatchObject([
       {
-        id: "pr:project-b:42",
+        id: "pr:project-b:repo:other-org:other-repo:42",
         prNumber: 42,
         title: "Same number, other repo",
         phase: "checks_failing",
@@ -301,7 +301,7 @@ describe("createPushPublisherService flush", () => {
         repoName: "other-repo",
       },
       {
-        id: "pr:project-a:42",
+        id: "pr:project-a:repo:arul28:ade:42",
         prNumber: 42,
         title: "Ship mobile PR view",
         phase: "merged",
@@ -316,7 +316,7 @@ describe("createPushPublisherService flush", () => {
     const detachPayload = publish.mock.calls.at(-1)?.[0];
     expect(detachPayload?.liveActivity[0].contentState.prs).toHaveLength(1);
     expect(detachPayload?.liveActivity[0].contentState.prs[0]).toMatchObject({
-      id: "pr:project-a:42",
+      id: "pr:project-a:repo:arul28:ade:42",
       title: "Ship mobile PR view",
     });
 
@@ -327,6 +327,59 @@ describe("createPushPublisherService flush", () => {
       phase: "terminal",
     });
     expect(endPayload.liveActivity[0].contentState.prs).toEqual([]);
+
+    publisher.dispose();
+  });
+
+  it("separates duplicate PR numbers inside one project scope by repo", async () => {
+    const { publisher, publish } = makeHarness();
+    let prCb: (event: PushPrNotification) => void = () => {
+      throw new Error("PR notification source was not attached");
+    };
+    publisher.attachSources("project-a", {
+      subscribePrNotifications: (cb) => {
+        prCb = cb;
+        return () => {};
+      },
+    });
+    await publisher.start();
+
+    prCb({
+      kind: "opened",
+      prNumber: 42,
+      prTitle: "API PR",
+      laneId: null,
+      repoOwner: "Org-A",
+      repoName: "api",
+    });
+    prCb({
+      kind: "opened",
+      prNumber: 42,
+      prTitle: "Web PR",
+      laneId: null,
+      repoOwner: "Org-B",
+      repoName: "web",
+    });
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    const payload = publish.mock.calls[0][0];
+    expect(payload.notifications.map((item: { threadId: string; dedupeKey: string }) => ({
+      threadId: item.threadId,
+      dedupeKey: item.dedupeKey,
+    }))).toEqual([
+      {
+        threadId: "pr:project-a:repo:org-a:api:42",
+        dedupeKey: "alert:pr:project-a:repo:org-a:api:42:opened",
+      },
+      {
+        threadId: "pr:project-a:repo:org-b:web:42",
+        dedupeKey: "alert:pr:project-a:repo:org-b:web:42:opened",
+      },
+    ]);
+    expect(payload.liveActivity[0].contentState.prs).toMatchObject([
+      { id: "pr:project-a:repo:org-a:api:42", title: "API PR" },
+      { id: "pr:project-a:repo:org-b:web:42", title: "Web PR" },
+    ]);
 
     publisher.dispose();
   });

--- a/apps/ade-cli/src/services/push/pushPublisherService.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.ts
@@ -633,7 +633,7 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
         title: activeCount > 0
           ? (activeCount === 1 && mostRecent ? `${runSubject(mostRecent)} is running` : `${activeCount} agent runs active`)
           : (prActivityCount === 1 && mostRecentPr ? `PR #${mostRecentPr.prNumber} updated` : `${prActivityCount} pull requests updated`),
-        body: mostRecent ? laneTitleLine(mostRecent) : mostRecentPr?.title ?? null,
+        body: activeCount > 0 ? (mostRecent ? laneTitleLine(mostRecent) : null) : mostRecentPr?.title ?? null,
       };
     }
     if (event === "end") {

--- a/apps/ade-cli/src/services/push/pushPublisherService.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.ts
@@ -516,6 +516,12 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     }
   };
 
+  const dropTerminalRuns = (): void => {
+    for (const [sessionId, run] of runs) {
+      if (isTerminalPhase(run.phase)) runs.delete(sessionId);
+    }
+  };
+
   const schedulePrActivityExpiry = (nowMs: number): void => {
     if (prExpiryTimer) {
       clearTimeout(prExpiryTimer);
@@ -580,9 +586,10 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     nowMs: number,
   ): { item: PushRelayLiveActivityItem; commit: () => void } | null => {
     if (deviceIds.length === 0) return null;
-    const allRuns = [...runs.values()];
     prunePrActivities(nowMs);
     schedulePrActivityExpiry(nowMs);
+    if (prActivities.size > 0) dropTerminalRuns();
+    const allRuns = [...runs.values()];
     const allPrActivities = [...prActivities.values()];
     const contentState = buildAgentRunsContentState(allRuns, nowMs, allPrActivities);
     const activeCount = contentState.activeCount;
@@ -647,9 +654,7 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
         liveActivityStarted = false;
         lastLiveActivityFingerprint = null;
         // Once the aggregate ends, drop terminal rows so the next run starts fresh.
-        for (const [sessionId, run] of runs) {
-          if (isTerminalPhase(run.phase)) runs.delete(sessionId);
-        }
+        dropTerminalRuns();
       }
     };
 

--- a/apps/ade-cli/src/services/push/pushPublisherService.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.ts
@@ -33,12 +33,14 @@ export function resolvePushRelayStateFile(secretsDir: string): string {
 export const APPROVAL_NOTIFICATION_CATEGORY = "ADE_APPROVAL";
 const SHUTDOWN_PUBLISH_TIMEOUT_MS = 2_500;
 const AGENT_RUNS_MAX = 3;
+const PR_LIVE_ACTIVITY_MAX = 2;
 const DETAIL_MAX_CHARS = 160;
 /** Fixed lock-screen copy for failed runs — never leak error text to the widget. */
 const FAILED_DETAIL = "Run failed";
 
 const RUNNING_TTL_MS = 2 * 60 * 60 * 1000; // 2h for running/starting
 const WAITING_TTL_MS = 24 * 60 * 60 * 1000; // 24h for waiting_for_*
+const PR_LIVE_ACTIVITY_TTL_MS = 45 * 60 * 1000; // keep recent PR status visible, then age it out
 const DEFAULT_FLUSH_DEBOUNCE_MS = 2_000;
 const DEFAULT_PROMPT_FLUSH_MS = 150;
 const PUBLISH_RETRY_MS = 30_000;
@@ -84,6 +86,15 @@ export type PushPrNotification = {
   prNumber: number;
   prTitle: string | null;
   laneId: string | null;
+};
+
+export type PrLiveActivityState = {
+  id: string;
+  prNumber: number;
+  title: string;
+  phase: PrNotificationKind;
+  lane: string | null;
+  updatedAt: number;
 };
 
 type PendingAlert = {
@@ -243,6 +254,7 @@ function capDetail(detail: string | null | undefined): string | null {
 export function buildAgentRunsContentState(
   runs: AgentRunState[],
   nowMs: number,
+  prs: PrLiveActivityState[] = [],
 ): {
   updatedAt: number;
   activeCount: number;
@@ -255,9 +267,18 @@ export function buildAgentRunsContentState(
     detail: string | null;
     itemId?: string;
   }>;
+  prs: Array<{
+    id: string;
+    prNumber: number;
+    title: string;
+    phase: PrNotificationKind;
+    lane: string | null;
+    updatedAt: number;
+  }>;
 } {
   const activeCount = runs.filter((run) => isActivePhase(run.phase)).length;
   const ordered = [...runs].sort((left, right) => right.lastActiveAt - left.lastActiveAt).slice(0, AGENT_RUNS_MAX);
+  const orderedPrs = [...prs].sort((left, right) => right.updatedAt - left.updatedAt).slice(0, PR_LIVE_ACTIVITY_MAX);
   return {
     updatedAt: Math.floor(nowMs / 1000),
     activeCount,
@@ -271,6 +292,14 @@ export function buildAgentRunsContentState(
       // Additive optional field (older widgets ignore it): lets the lock
       // screen render Approve/Deny intents against the pending item.
       ...(run.phase === "waiting_for_approval" && run.itemId ? { itemId: run.itemId } : {}),
+    })),
+    prs: orderedPrs.map((pr) => ({
+      id: pr.id,
+      prNumber: pr.prNumber,
+      title: pr.title,
+      phase: pr.phase,
+      lane: pr.lane,
+      updatedAt: Math.floor(pr.updatedAt / 1000),
     })),
   };
 }
@@ -358,6 +387,7 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
   const promptFlushMs = deps.promptFlushMs ?? DEFAULT_PROMPT_FLUSH_MS;
 
   const runs = new Map<string, AgentRunState>();
+  const prActivities = new Map<string, PrLiveActivityState>();
   let pendingAlerts: PendingAlert[] = [];
   const lastAlertFingerprintByKey = new Map<string, string>();
   let lastLiveActivityFingerprint: string | null = null;
@@ -371,6 +401,7 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
   const lastSentBadgeByDevice = new Map<string, number>();
 
   let flushTimer: NodeJS.Timeout | null = null;
+  let prExpiryTimer: NodeJS.Timeout | null = null;
   let flushFireAt = 0;
   let flushing = false;
   let disposed = false;
@@ -469,6 +500,31 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     }
   };
 
+  const prunePrActivities = (nowMs: number): void => {
+    for (const [id, pr] of prActivities) {
+      if (nowMs - pr.updatedAt > PR_LIVE_ACTIVITY_TTL_MS) {
+        prActivities.delete(id);
+      }
+    }
+  };
+
+  const schedulePrActivityExpiry = (nowMs: number): void => {
+    if (prExpiryTimer) {
+      clearTimeout(prExpiryTimer);
+      prExpiryTimer = null;
+    }
+    let nextExpiryMs = Number.POSITIVE_INFINITY;
+    for (const pr of prActivities.values()) {
+      nextExpiryMs = Math.min(nextExpiryMs, pr.updatedAt + PR_LIVE_ACTIVITY_TTL_MS);
+    }
+    if (!Number.isFinite(nextExpiryMs)) return;
+    const delayMs = Math.max(250, nextExpiryMs - nowMs + 250);
+    prExpiryTimer = setTimeout(() => {
+      prExpiryTimer = null;
+      scheduleFlush(true);
+    }, delayMs);
+  };
+
   const resolveMissingMeta = async (): Promise<void> => {
     for (const run of runs.values()) {
       if (run.metaResolved) continue;
@@ -517,8 +573,12 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
   ): { item: PushRelayLiveActivityItem; commit: () => void } | null => {
     if (deviceIds.length === 0) return null;
     const allRuns = [...runs.values()];
-    const contentState = buildAgentRunsContentState(allRuns, nowMs);
+    prunePrActivities(nowMs);
+    schedulePrActivityExpiry(nowMs);
+    const allPrActivities = [...prActivities.values()];
+    const contentState = buildAgentRunsContentState(allRuns, nowMs, allPrActivities);
     const activeCount = contentState.activeCount;
+    const prActivityCount = contentState.prs.length;
     // Stale rows (quiet CLIs) don't count as active but must not END the
     // activity either — a 12s-quiet CLI that resumes output would otherwise
     // churn end→push-to-start cycles. Only an all-completed/failed (or empty)
@@ -526,8 +586,8 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     const dormantCount = allRuns.filter((run) => run.phase === "stale").length;
 
     let event: "start" | "update" | "end";
-    if (activeCount > 0 && !liveActivityStarted) event = "start";
-    else if (activeCount === 0 && dormantCount === 0 && liveActivityStarted) event = "end";
+    if ((activeCount > 0 || prActivityCount > 0) && !liveActivityStarted) event = "start";
+    else if (activeCount === 0 && dormantCount === 0 && prActivityCount === 0 && liveActivityStarted) event = "end";
     else if (!liveActivityStarted) return null; // nothing live to report (stale-only never starts)
     else event = "update";
 
@@ -536,10 +596,14 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
 
     const anyWaiting = allRuns.some(
       (run) => run.phase === "waiting_for_approval" || run.phase === "waiting_for_input",
-    );
+    ) || allPrActivities.some((pr) =>
+      pr.phase === "checks_failing"
+      || pr.phase === "changes_requested"
+      || pr.phase === "review_requested"
+      || pr.phase === "merge_ready");
     const phase: "running" | "waiting" | "terminal" = anyWaiting
       ? "waiting"
-      : activeCount > 0
+      : (activeCount > 0 || prActivityCount > 0)
         ? "running"
         : "terminal";
 
@@ -556,9 +620,12 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
       item.attributesType = AGENT_RUNS_ATTRIBUTES_TYPE;
       item.attributes = { machineName: deps.machineName };
       const mostRecent = allRuns.sort((left, right) => right.lastActiveAt - left.lastActiveAt)[0];
+      const mostRecentPr = allPrActivities.sort((left, right) => right.updatedAt - left.updatedAt)[0];
       item.alert = {
-        title: activeCount === 1 && mostRecent ? `${runSubject(mostRecent)} is running` : `${activeCount} agent runs active`,
-        body: mostRecent ? laneTitleLine(mostRecent) : null,
+        title: activeCount > 0
+          ? (activeCount === 1 && mostRecent ? `${runSubject(mostRecent)} is running` : `${activeCount} agent runs active`)
+          : (prActivityCount === 1 && mostRecentPr ? `PR #${mostRecentPr.prNumber} updated` : `${prActivityCount} pull requests updated`),
+        body: mostRecent ? laneTitleLine(mostRecent) : mostRecentPr?.title ?? null,
       };
     }
     if (event === "end") {
@@ -944,37 +1011,56 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     scheduleFlush(false);
   };
 
-  const onPrNotification = (notification: PushPrNotification): void => {
-    if (notification.kind === "merge_ready") {
-      enqueueAlert({
-        sessionId: null,
-        dedupeKey: `alert:pr:${notification.prNumber}:merge_ready`,
-        render: () => ({
-          title: `PR #${notification.prNumber} is ready to merge`,
-          body: notification.prTitle ?? "Required checks passed and it has approval.",
-        }),
-        deepLink: `ade://pr/${notification.prNumber}`,
-        threadId: `pr-${notification.prNumber}`,
-        phase: "terminal",
-        interruptionLevel: "active",
-      });
-      scheduleFlush(false);
-    } else if (notification.kind === "checks_failing") {
-      enqueueAlert({
-        sessionId: null,
-        dedupeKey: `alert:pr:${notification.prNumber}:checks_failing`,
-        render: () => ({
-          title: `PR #${notification.prNumber} checks are failing`,
-          body: notification.prTitle ?? "One or more required checks failed.",
-        }),
-        deepLink: `ade://pr/${notification.prNumber}`,
-        threadId: `pr-${notification.prNumber}`,
-        phase: "terminal",
-        interruptionLevel: "active",
-      });
-      scheduleFlush(false);
+  const prNotificationCopy = (notification: PushPrNotification): { title: string; body: string; interruptionLevel: PendingAlert["interruptionLevel"] } => {
+    const fallbackTitle = notification.prTitle?.trim() || `Pull request #${notification.prNumber}`;
+    switch (notification.kind) {
+      case "opened":
+        return { title: `PR #${notification.prNumber} opened`, body: fallbackTitle, interruptionLevel: "passive" };
+      case "reopened":
+        return { title: `PR #${notification.prNumber} reopened`, body: fallbackTitle, interruptionLevel: "passive" };
+      case "closed":
+        return { title: `PR #${notification.prNumber} closed`, body: fallbackTitle, interruptionLevel: "passive" };
+      case "merged":
+        return { title: `PR #${notification.prNumber} merged`, body: fallbackTitle, interruptionLevel: "active" };
+      case "merge_ready":
+        return { title: `PR #${notification.prNumber} is ready to merge`, body: notification.prTitle ?? "Required checks passed and it has approval.", interruptionLevel: "active" };
+      case "checks_failing":
+        return { title: `PR #${notification.prNumber} checks are failing`, body: notification.prTitle ?? "One or more required checks failed.", interruptionLevel: "active" };
+      case "changes_requested":
+        return { title: `Changes requested on PR #${notification.prNumber}`, body: fallbackTitle, interruptionLevel: "active" };
+      case "review_requested":
+        return { title: `Review requested on PR #${notification.prNumber}`, body: fallbackTitle, interruptionLevel: "active" };
     }
-    // review_requested / changes_requested are intentionally not pushed.
+  };
+
+  const onPrNotification = (
+    notification: PushPrNotification,
+    resolveLaneName?: (laneId: string) => string | null | undefined,
+  ): void => {
+    const lane = notification.laneId
+      ? (resolveLaneName?.(notification.laneId) ?? notification.laneId)
+      : null;
+    prActivities.set(`pr-${notification.prNumber}`, {
+      id: `pr-${notification.prNumber}`,
+      prNumber: notification.prNumber,
+      title: notification.prTitle?.trim() || `Pull request #${notification.prNumber}`,
+      phase: notification.kind,
+      lane,
+      updatedAt: now(),
+    });
+    schedulePrActivityExpiry(now());
+
+    const copy = prNotificationCopy(notification);
+    enqueueAlert({
+      sessionId: null,
+      dedupeKey: `alert:pr:${notification.prNumber}:${notification.kind}`,
+      render: () => ({ title: copy.title, body: copy.body }),
+      deepLink: `ade://pr/${notification.prNumber}`,
+      threadId: `pr-${notification.prNumber}`,
+      phase: copy.interruptionLevel === "passive" ? "terminal" : "waiting",
+      interruptionLevel: copy.interruptionLevel,
+    });
+    scheduleFlush(false);
   };
 
   const relayApnsConfigured = async (): Promise<boolean | null> => {
@@ -1033,6 +1119,9 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
       if (flushTimer) clearTimeout(flushTimer);
       flushTimer = null;
       flushFireAt = 0;
+      if (prExpiryTimer) clearTimeout(prExpiryTimer);
+      prExpiryTimer = null;
+      prActivities.clear();
       pendingAlerts = [];
     }
   };
@@ -1041,7 +1130,9 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     disposed = true;
     for (const scopeKey of [...scopes.keys()]) detachScope(scopeKey);
     if (flushTimer) clearTimeout(flushTimer);
+    if (prExpiryTimer) clearTimeout(prExpiryTimer);
     flushTimer = null;
+    prExpiryTimer = null;
   };
 
   return {
@@ -1068,7 +1159,9 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
         scopeUnsubscribes.push(sources.ptyService.onExit((event) => onPtyExit(scopeKey, event)));
       }
       if (sources.subscribePrNotifications) {
-        scopeUnsubscribes.push(sources.subscribePrNotifications(onPrNotification));
+        scopeUnsubscribes.push(sources.subscribePrNotifications((notification) => {
+          onPrNotification(notification, sources.resolveLaneName);
+        }));
       }
       scopes.set(scopeKey, {
         agentChatService: sources.agentChatService ?? null,

--- a/apps/ade-cli/src/services/push/pushPublisherService.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.ts
@@ -1041,7 +1041,14 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     }
   };
 
-  const prActivityId = (scopeKey: string, prNumber: number): string => `pr:${scopeKey}:${prNumber}`;
+  const prActivityId = (scopeKey: string, notification: PushPrNotification): string => {
+    const owner = notification.repoOwner?.trim().toLowerCase();
+    const repo = notification.repoName?.trim().toLowerCase();
+    const repoScope = owner && repo
+      ? `repo:${encodeURIComponent(owner)}:${encodeURIComponent(repo)}`
+      : "number";
+    return `pr:${scopeKey}:${repoScope}:${notification.prNumber}`;
+  };
   const prDeepLink = (notification: PushPrNotification): string => {
     const owner = notification.repoOwner?.trim();
     const repo = notification.repoName?.trim();
@@ -1070,7 +1077,7 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     const lane = notification.laneId
       ? (resolveLaneName?.(notification.laneId) ?? notification.laneId)
       : null;
-    const activityId = prActivityId(scopeKey, notification.prNumber);
+    const activityId = prActivityId(scopeKey, notification);
     prActivities.set(activityId, {
       id: activityId,
       prNumber: notification.prNumber,
@@ -1086,7 +1093,7 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     const copy = prNotificationCopy(notification);
     enqueueAlert({
       sessionId: null,
-      dedupeKey: `alert:pr:${scopeKey}:${notification.prNumber}:${notification.kind}`,
+      dedupeKey: `alert:${activityId}:${notification.kind}`,
       render: () => ({ title: copy.title, body: copy.body }),
       deepLink: prDeepLink(notification),
       threadId: activityId,

--- a/apps/ade-cli/src/services/push/pushPublisherService.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.ts
@@ -110,6 +110,8 @@ type PendingAlert = {
   threadId?: string | null;
   phase: "running" | "waiting" | "terminal";
   interruptionLevel?: "passive" | "active" | "time-sensitive" | null;
+  /** Keeps same-copy lifecycle events publishable without disabling queue coalescing. */
+  fingerprintSalt?: string | number | null;
   /** Approval item id — rides the payload so iOS can act without opening the app. */
   itemId?: string | null;
   /** UNNotificationCategory identifier binding actionable buttons on iOS. */
@@ -694,6 +696,7 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
         phase: alert.phase,
         itemId: alert.itemId ?? null,
         category: alert.category ?? null,
+        salt: alert.fingerprintSalt ?? null,
       });
       if (lastAlertFingerprintByKey.get(alert.dedupeKey) === fingerprint) continue;
       alertCommits.push([alert.dedupeKey, fingerprint]);
@@ -1079,6 +1082,7 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     notification: PushPrNotification,
     resolveLaneName?: (laneId: string) => string | null | undefined,
   ): void => {
+    const eventStamp = now();
     const lane = notification.laneId
       ? (resolveLaneName?.(notification.laneId) ?? notification.laneId)
       : null;
@@ -1091,9 +1095,9 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
       lane,
       repoOwner: notification.repoOwner?.trim() || null,
       repoName: notification.repoName?.trim() || null,
-      updatedAt: now(),
+      updatedAt: eventStamp,
     });
-    schedulePrActivityExpiry(now());
+    schedulePrActivityExpiry(eventStamp);
 
     const copy = prNotificationCopy(notification);
     enqueueAlert({
@@ -1104,6 +1108,7 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
       threadId: activityId,
       phase: copy.interruptionLevel === "passive" ? "terminal" : "waiting",
       interruptionLevel: copy.interruptionLevel,
+      fingerprintSalt: eventStamp,
     });
     scheduleFlush(false);
   };

--- a/apps/ade-cli/src/services/push/pushPublisherService.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.ts
@@ -86,6 +86,8 @@ export type PushPrNotification = {
   prNumber: number;
   prTitle: string | null;
   laneId: string | null;
+  repoOwner?: string | null;
+  repoName?: string | null;
 };
 
 export type PrLiveActivityState = {
@@ -94,6 +96,8 @@ export type PrLiveActivityState = {
   title: string;
   phase: PrNotificationKind;
   lane: string | null;
+  repoOwner: string | null;
+  repoName: string | null;
   updatedAt: number;
 };
 
@@ -273,6 +277,8 @@ export function buildAgentRunsContentState(
     title: string;
     phase: PrNotificationKind;
     lane: string | null;
+    repoOwner: string | null;
+    repoName: string | null;
     updatedAt: number;
   }>;
 } {
@@ -299,6 +305,8 @@ export function buildAgentRunsContentState(
       title: pr.title,
       phase: pr.phase,
       lane: pr.lane,
+      repoOwner: pr.repoOwner,
+      repoName: pr.repoName,
       updatedAt: Math.floor(pr.updatedAt / 1000),
     })),
   };
@@ -1034,6 +1042,25 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
   };
 
   const prActivityId = (scopeKey: string, prNumber: number): string => `pr:${scopeKey}:${prNumber}`;
+  const prDeepLink = (notification: PushPrNotification): string => {
+    const owner = notification.repoOwner?.trim();
+    const repo = notification.repoName?.trim();
+    if (owner && repo) {
+      return `ade://pr/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${notification.prNumber}`;
+    }
+    return `ade://pr/${notification.prNumber}`;
+  };
+  const removePrActivitiesForScope = (scopeKey: string): boolean => {
+    const prefix = `pr:${scopeKey}:`;
+    let removed = false;
+    for (const id of prActivities.keys()) {
+      if (id.startsWith(prefix)) {
+        prActivities.delete(id);
+        removed = true;
+      }
+    }
+    return removed;
+  };
 
   const onPrNotification = (
     scopeKey: string,
@@ -1050,6 +1077,8 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
       title: notification.prTitle?.trim() || `Pull request #${notification.prNumber}`,
       phase: notification.kind,
       lane,
+      repoOwner: notification.repoOwner?.trim() || null,
+      repoName: notification.repoName?.trim() || null,
       updatedAt: now(),
     });
     schedulePrActivityExpiry(now());
@@ -1059,7 +1088,7 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
       sessionId: null,
       dedupeKey: `alert:pr:${scopeKey}:${notification.prNumber}:${notification.kind}`,
       render: () => ({ title: copy.title, body: copy.body }),
-      deepLink: `ade://pr/${notification.prNumber}`,
+      deepLink: prDeepLink(notification),
       threadId: activityId,
       phase: copy.interruptionLevel === "passive" ? "terminal" : "waiting",
       interruptionLevel: copy.interruptionLevel,
@@ -1117,6 +1146,7 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     for (const [sessionId, run] of runs) {
       if (run.scopeKey === scopeKey) runs.delete(sessionId);
     }
+    const removedPrActivities = removePrActivitiesForScope(scopeKey);
     if (scopes.size === 0) {
       // Nothing attached — stop the flush loop so no timer lingers. The shared
       // instance stays memoized and resumes when a project re-attaches.
@@ -1127,6 +1157,8 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
       prExpiryTimer = null;
       prActivities.clear();
       pendingAlerts = [];
+    } else if (removedPrActivities) {
+      scheduleFlush(false);
     }
   };
 

--- a/apps/ade-cli/src/services/push/pushPublisherService.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.ts
@@ -1033,15 +1033,19 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     }
   };
 
+  const prActivityId = (scopeKey: string, prNumber: number): string => `pr:${scopeKey}:${prNumber}`;
+
   const onPrNotification = (
+    scopeKey: string,
     notification: PushPrNotification,
     resolveLaneName?: (laneId: string) => string | null | undefined,
   ): void => {
     const lane = notification.laneId
       ? (resolveLaneName?.(notification.laneId) ?? notification.laneId)
       : null;
-    prActivities.set(`pr-${notification.prNumber}`, {
-      id: `pr-${notification.prNumber}`,
+    const activityId = prActivityId(scopeKey, notification.prNumber);
+    prActivities.set(activityId, {
+      id: activityId,
       prNumber: notification.prNumber,
       title: notification.prTitle?.trim() || `Pull request #${notification.prNumber}`,
       phase: notification.kind,
@@ -1053,10 +1057,10 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     const copy = prNotificationCopy(notification);
     enqueueAlert({
       sessionId: null,
-      dedupeKey: `alert:pr:${notification.prNumber}:${notification.kind}`,
+      dedupeKey: `alert:pr:${scopeKey}:${notification.prNumber}:${notification.kind}`,
       render: () => ({ title: copy.title, body: copy.body }),
       deepLink: `ade://pr/${notification.prNumber}`,
-      threadId: `pr-${notification.prNumber}`,
+      threadId: activityId,
       phase: copy.interruptionLevel === "passive" ? "terminal" : "waiting",
       interruptionLevel: copy.interruptionLevel,
     });
@@ -1160,7 +1164,7 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
       }
       if (sources.subscribePrNotifications) {
         scopeUnsubscribes.push(sources.subscribePrNotifications((notification) => {
-          onPrNotification(notification, sources.resolveLaneName);
+          onPrNotification(scopeKey, notification, sources.resolveLaneName);
         }));
       }
       scopes.set(scopeKey, {

--- a/apps/ade-cli/src/services/push/pushPublisherService.ts
+++ b/apps/ade-cli/src/services/push/pushPublisherService.ts
@@ -586,7 +586,7 @@ export function createPushPublisherService(deps: PushPublisherDeps) {
     const allPrActivities = [...prActivities.values()];
     const contentState = buildAgentRunsContentState(allRuns, nowMs, allPrActivities);
     const activeCount = contentState.activeCount;
-    const prActivityCount = contentState.prs.length;
+    const prActivityCount = allPrActivities.length;
     // Stale rows (quiet CLIs) don't count as active but must not END the
     // activity either — a 12s-quiet CLI that resumes output would otherwise
     // churn end→push-to-start cycles. Only an all-completed/failed (or empty)

--- a/apps/desktop/src/main/services/prs/prAsync.test.ts
+++ b/apps/desktop/src/main/services/prs/prAsync.test.ts
@@ -201,6 +201,44 @@ describe("prPollingService", () => {
     expect(events.filter((event) => event.type === "prs-updated")).toHaveLength(1);
   });
 
+  it("does not re-emit opened notifications after a transient empty poll", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00.000Z"));
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    const summary = createSummary({ title: "Tracked PR", state: "open" });
+    let rows: PrSummary[] = [summary];
+    const events: any[] = [];
+
+    const prService = {
+      listAll: () => rows,
+      discoverLanePullRequests: vi.fn(async () => rows),
+      refresh: vi.fn(async () => rows),
+      getHotRefreshDelayMs: () => null,
+      getHotRefreshPrIds: () => [],
+    } as any;
+
+    const service = createPrPollingService({
+      logger: createLogger() as any,
+      prService,
+      projectConfigService: { get: () => ({ effective: {} }) } as any,
+      onEvent: (event) => events.push(event),
+    });
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(12_000);
+
+    rows = [];
+    service.poke();
+    await vi.advanceTimersByTimeAsync(0);
+
+    rows = [summary];
+    service.poke();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(events.filter((event) => event.type === "pr-notification" && event.kind === "opened")).toHaveLength(0);
+  });
+
   it("keeps rate-limit backoff ahead of hot wakeups", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-24T12:00:00.000Z"));

--- a/apps/desktop/src/main/services/prs/prAsync.test.ts
+++ b/apps/desktop/src/main/services/prs/prAsync.test.ts
@@ -237,6 +237,7 @@ describe("prPollingService", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(events.filter((event) => event.type === "pr-notification" && event.kind === "opened")).toHaveLength(0);
+    expect(events.filter((event) => event.type === "prs-updated").length).toBeGreaterThanOrEqual(2);
   });
 
   it("keeps rate-limit backoff ahead of hot wakeups", async () => {

--- a/apps/desktop/src/main/services/prs/prPollingService.ts
+++ b/apps/desktop/src/main/services/prs/prPollingService.ts
@@ -20,6 +20,26 @@ function jitterMs(value: number): number {
 
 function summarizeNotification(kind: PrNotificationKind): { title: string; message: string } {
   switch (kind) {
+    case "opened":
+      return {
+        title: "Pull request opened",
+        message: "A pull request opened and is now tracked by ADE.",
+      };
+    case "reopened":
+      return {
+        title: "Pull request reopened",
+        message: "This pull request moved back to an open state.",
+      };
+    case "closed":
+      return {
+        title: "Pull request closed",
+        message: "This pull request was closed without being merged.",
+      };
+    case "merged":
+      return {
+        title: "Pull request merged",
+        message: "This pull request was merged and closed.",
+      };
     case "checks_failing":
       return {
         title: "Checks failing",
@@ -41,6 +61,25 @@ function summarizeNotification(kind: PrNotificationKind): { title: string; messa
         message: "Required checks are passing and the pull request has approval. Other merge requirements (e.g. base branch currency) may still apply.",
       };
   }
+}
+
+function lifecycleNotificationKind(
+  previousState: PrSummary["state"] | null,
+  currentState: PrSummary["state"],
+): PrNotificationKind | null {
+  if (previousState == null) {
+    return currentState === "open" || currentState === "draft" ? "opened" : null;
+  }
+  if ((previousState === "closed" || previousState === "merged") && (currentState === "open" || currentState === "draft")) {
+    return "reopened";
+  }
+  if (previousState !== "merged" && currentState === "merged") {
+    return "merged";
+  }
+  if (previousState !== "closed" && currentState === "closed") {
+    return "closed";
+  }
+  return null;
 }
 
 /**
@@ -257,7 +296,7 @@ export function createPrPollingService({
           });
         }
 
-        const shouldNotify = (kind: PrNotificationKind): boolean => {
+        const shouldNotifyStatusKind = (kind: PrNotificationKind): boolean => {
           if (pr.state !== "open" && pr.state !== "draft") return false;
           if (!prev) return false;
           if (kind === "checks_failing") return prev.checksStatus !== "failing" && pr.checksStatus === "failing";
@@ -267,9 +306,16 @@ export function createPrPollingService({
           return false;
         };
 
-        const kinds: PrNotificationKind[] = ["checks_failing", "review_requested", "changes_requested", "merge_ready"];
+        const lifecycleKind = lifecycleNotificationKind(prev?.state ?? null, pr.state);
+        const kinds: PrNotificationKind[] = [
+          ...(lifecycleKind ? [lifecycleKind] : []),
+          "checks_failing",
+          "review_requested",
+          "changes_requested",
+          "merge_ready",
+        ];
         for (const kind of kinds) {
-          if (!shouldNotify(kind)) continue;
+          if (kind !== lifecycleKind && !shouldNotifyStatusKind(kind)) continue;
           const summary = summarizeNotification(kind);
           onEvent({
             type: "pr-notification",

--- a/apps/desktop/src/main/services/prs/prPollingService.ts
+++ b/apps/desktop/src/main/services/prs/prPollingService.ts
@@ -224,9 +224,11 @@ export function createPrPollingService({
       }
       if (existing.length === 0) {
         consecutiveFailures = 0;
-        initialized = true;
-        lastByPrId.clear();
-        lastFingerprintByPrId.clear();
+        if (!initialized) {
+          initialized = true;
+          lastByPrId.clear();
+          lastFingerprintByPrId.clear();
+        }
         if (lastPrFingerprint !== "[]") {
           onEvent({ type: "prs-updated", polledAt, prs: [] });
           lastPrFingerprint = "[]";

--- a/apps/desktop/src/renderer/components/app/prToastPresentation.ts
+++ b/apps/desktop/src/renderer/components/app/prToastPresentation.ts
@@ -12,7 +12,7 @@ function compactLabel(value: string | null | undefined): string | null {
 export function getPrToastTone(kind: PrNotificationEvent["kind"]): PrToastTone {
   if (kind === "checks_failing" || kind === "changes_requested") return "danger";
   if (kind === "review_requested") return "warning";
-  if (kind === "merge_ready") return "success";
+  if (kind === "merge_ready" || kind === "merged" || kind === "opened" || kind === "reopened") return "success";
   return "info";
 }
 

--- a/apps/desktop/src/shared/types/prs.ts
+++ b/apps/desktop/src/shared/types/prs.ts
@@ -17,7 +17,15 @@ export type PrState = "draft" | "open" | "merged" | "closed";
 export type PrChecksStatus = "pending" | "passing" | "failing" | "none";
 export type PrReviewStatus = "none" | "requested" | "approved" | "changes_requested";
 export type MergeMethod = "merge" | "squash" | "rebase";
-export type PrNotificationKind = "checks_failing" | "review_requested" | "changes_requested" | "merge_ready";
+export type PrNotificationKind =
+  | "opened"
+  | "reopened"
+  | "closed"
+  | "merged"
+  | "checks_failing"
+  | "review_requested"
+  | "changes_requested"
+  | "merge_ready";
 
 /**
  * GitHub's merge-box state, mirrored from the GraphQL `mergeStateStatus` enum

--- a/apps/ios/ADE/App/DeepLinkRouter.swift
+++ b/apps/ios/ADE/App/DeepLinkRouter.swift
@@ -5,7 +5,8 @@ import Foundation
 /// `.adeDeepLinkRequested` and flip their selection when fired; new
 /// cross-machine shapes (lane / repo / extended pr / linear-issue) instead
 /// post `.adeSendToMacRequested` so the parent view can show a "Send to your
-/// Mac" confirmation card.
+/// Mac" confirmation card. Repo-scoped PR URLs are also accepted locally
+/// because push notifications use them to disambiguate duplicate PR numbers.
 ///
 /// Kept intentionally tiny — the heavy lifting lives in the individual tabs.
 @MainActor
@@ -47,13 +48,15 @@ final class DeepLinkRouter {
     case "pr":
       // Two accepted shapes today:
       //   `ade://pr/<n>`                       (compact local link)
-      //   `ade://pr/<owner>/<repo>/<number>`   (desktop cross-machine form)
+      //   `ade://pr/<owner>/<repo>/<number>`   (repo-scoped local link)
       // Anything else is ignored so a malformed link can't crash navigation.
       if pathComponents.count >= 3 {
-        guard !pathComponents[0].isEmpty,
-              !pathComponents[1].isEmpty,
-              !pathComponents[2].isEmpty else { return }
-        postSendToMac(url: url)
+        let owner = pathComponents[0]
+        let repo = pathComponents[1]
+        guard ADEDeepLinkURLParsing.splitRepo("\(owner)/\(repo)") != nil,
+              let number = Int(pathComponents[2]),
+              number > 0 else { return }
+        post(kind: "pr", identifier: "\(number)", prNumber: number, repoOwner: owner, repoName: repo)
         return
       }
       guard let raw = pathComponents.first, !raw.isEmpty else { return }
@@ -206,14 +209,32 @@ final class DeepLinkRouter {
     if let pr = userInfo["prNumber"] {
       let identifier = "\(pr)"
       guard !identifier.isEmpty else { return }
-      post(kind: "pr", identifier: identifier)
+      post(
+        kind: "pr",
+        identifier: identifier,
+        prNumber: prNumberValue(from: userInfo["prNumber"]),
+        repoOwner: stringValue(from: userInfo["repoOwner"]),
+        repoName: stringValue(from: userInfo["repoName"])
+      )
     }
   }
 
-  private func post(kind: String, identifier: String, prNumber: Int? = nil, event: Int? = nil, offset: Int? = nil) {
+  private func post(
+    kind: String,
+    identifier: String,
+    prNumber: Int? = nil,
+    repoOwner: String? = nil,
+    repoName: String? = nil,
+    event: Int? = nil,
+    offset: Int? = nil
+  ) {
     var userInfo: [String: Any] = ["kind": kind, "identifier": identifier]
     if let event { userInfo["event"] = event }
     if let offset { userInfo["offset"] = offset }
+    let scopedRepoOwner = repoOwner?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let scopedRepoName = repoName?.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let scopedRepoOwner, !scopedRepoOwner.isEmpty { userInfo["repoOwner"] = scopedRepoOwner }
+    if let scopedRepoName, !scopedRepoName.isEmpty { userInfo["repoName"] = scopedRepoName }
     NotificationCenter.default.post(
       name: .adeDeepLinkRequested,
       object: nil,
@@ -228,7 +249,17 @@ final class DeepLinkRouter {
     }
     if kind == "pr" {
       let trimmed = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
-      if let prId = resolvePrId(from: trimmed) {
+      if let number = prNumber ?? Int(trimmed),
+         let scopedRepoOwner,
+         let scopedRepoName,
+         !scopedRepoOwner.isEmpty,
+         !scopedRepoName.isEmpty {
+        SyncService.shared?.requestedPrNavigation = PrNavigationRequest(
+          prNumber: number,
+          repoOwner: scopedRepoOwner,
+          repoName: scopedRepoName
+        )
+      } else if let prId = resolvePrId(from: trimmed) {
         SyncService.shared?.requestedPrNavigation = PrNavigationRequest(
           prId: prId,
           prNumber: prNumber ?? Int(trimmed)
@@ -327,6 +358,12 @@ final class DeepLinkRouter {
       if let number = Int(trimmed), number > 0 { return number }
     }
     return nil
+  }
+
+  private func stringValue(from value: Any?) -> String? {
+    guard let string = value as? String else { return nil }
+    let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
   }
 
   /// PR deep links carry either a numeric PR number (from `ade://pr/<n>`

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -1264,7 +1264,7 @@ struct PairingQrNavigationRequest: Equatable, Identifiable {
 
 enum PrNavigationRequestTarget: Equatable {
   case detail(prId: String, prNumber: Int?, laneId: String?)
-  case githubNumber(Int)
+  case githubNumber(Int, repoOwner: String?, repoName: String?)
   case create(laneId: String)
 }
 
@@ -1277,9 +1277,9 @@ struct PrNavigationRequest: Equatable, Identifiable {
     self.target = .detail(prId: prId, prNumber: prNumber, laneId: laneId)
   }
 
-  init(prNumber: Int) {
+  init(prNumber: Int, repoOwner: String? = nil, repoName: String? = nil) {
     self.id = UUID().uuidString
-    self.target = .githubNumber(prNumber)
+    self.target = .githubNumber(prNumber, repoOwner: repoOwner, repoName: repoName)
   }
 
   init(createLaneId: String) {

--- a/apps/ios/ADE/Shared/ADEAgentActivityAttributes.swift
+++ b/apps/ios/ADE/Shared/ADEAgentActivityAttributes.swift
@@ -59,6 +59,8 @@ public struct ADEAgentRunsAttributes: ActivityAttributes {
         public let title: String
         public let phase: String
         public let lane: String?
+        public let repoOwner: String?
+        public let repoName: String?
         public let updatedAt: Double
 
         public init(
@@ -67,6 +69,8 @@ public struct ADEAgentRunsAttributes: ActivityAttributes {
             title: String,
             phase: String,
             lane: String? = nil,
+            repoOwner: String? = nil,
+            repoName: String? = nil,
             updatedAt: Double = 0
         ) {
             self.id = id
@@ -74,11 +78,13 @@ public struct ADEAgentRunsAttributes: ActivityAttributes {
             self.title = title
             self.phase = phase
             self.lane = lane
+            self.repoOwner = repoOwner
+            self.repoName = repoName
             self.updatedAt = updatedAt
         }
 
         private enum CodingKeys: String, CodingKey {
-            case id, prNumber, title, phase, lane, updatedAt
+            case id, prNumber, title, phase, lane, repoOwner, repoName, updatedAt
         }
 
         public init(from decoder: Decoder) throws {
@@ -88,6 +94,8 @@ public struct ADEAgentRunsAttributes: ActivityAttributes {
             self.title = (try? c.decode(String.self, forKey: .title)) ?? "Pull request"
             self.phase = (try? c.decode(String.self, forKey: .phase)) ?? PullRequestPhase.opened.rawValue
             self.lane = try? c.decodeIfPresent(String.self, forKey: .lane)
+            self.repoOwner = try? c.decodeIfPresent(String.self, forKey: .repoOwner)
+            self.repoName = try? c.decodeIfPresent(String.self, forKey: .repoName)
             self.updatedAt = (try? c.decode(Double.self, forKey: .updatedAt)) ?? 0
         }
 
@@ -98,6 +106,25 @@ public struct ADEAgentRunsAttributes: ActivityAttributes {
         public var subtitle: String? {
             let lane = lane?.trimmingCharacters(in: .whitespacesAndNewlines)
             return lane?.isEmpty == false ? lane : nil
+        }
+
+        public var deepLinkURL: URL? {
+            guard prNumber > 0 else { return nil }
+            let owner = repoOwner?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let repo = repoName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if !owner.isEmpty,
+               !repo.isEmpty,
+               let encodedOwner = owner.addingPercentEncoding(withAllowedCharacters: Self.pathSegmentAllowed),
+               let encodedRepo = repo.addingPercentEncoding(withAllowedCharacters: Self.pathSegmentAllowed) {
+                return URL(string: "ade://pr/\(encodedOwner)/\(encodedRepo)/\(prNumber)")
+            }
+            return URL(string: "ade://pr/\(prNumber)")
+        }
+
+        private static var pathSegmentAllowed: CharacterSet {
+            var allowed = CharacterSet.alphanumerics
+            allowed.insert(charactersIn: "-._~")
+            return allowed
         }
     }
 

--- a/apps/ios/ADE/Shared/ADEAgentActivityAttributes.swift
+++ b/apps/ios/ADE/Shared/ADEAgentActivityAttributes.swift
@@ -9,7 +9,7 @@ import SwiftUI
 ///   attributesType: "ADEAgentRunsAttributes"
 ///   attributes:     { "machineName": String }
 ///   activityId:     "agent-runs"
-///   contentState:   { updatedAt, activeCount, runs: [Run] }  (runs capped at 3)
+///   contentState:   { updatedAt, activeCount, runs: [Run], prs: [PullRequest] }
 ///
 /// Decoding is deliberately lenient — a run row with an unrecognised `phase`
 /// still renders (as `.running`), and a missing optional collapses to `nil`
@@ -23,15 +23,17 @@ public struct ADEAgentRunsAttributes: ActivityAttributes {
         /// because the roster is capped at three for the glance.
         public var activeCount: Int
         public var runs: [Run]
+        public var prs: [PullRequest]
 
-        public init(updatedAt: Double, activeCount: Int, runs: [Run]) {
+        public init(updatedAt: Double, activeCount: Int, runs: [Run], prs: [PullRequest] = []) {
             self.updatedAt = updatedAt
             self.activeCount = activeCount
             self.runs = runs
+            self.prs = prs
         }
 
         private enum CodingKeys: String, CodingKey {
-            case updatedAt, activeCount, runs
+            case updatedAt, activeCount, runs, prs
         }
 
         public init(from decoder: Decoder) throws {
@@ -41,11 +43,61 @@ public struct ADEAgentRunsAttributes: ActivityAttributes {
             self.activeCount = (try? c.decode(Int.self, forKey: .activeCount)) ?? 0
             let decodedRuns = (try? c.decode([Run].self, forKey: .runs)) ?? []
             self.runs = Array(decodedRuns.prefix(3))
+            let decodedPrs = (try? c.decode([PullRequest].self, forKey: .prs)) ?? []
+            self.prs = Array(decodedPrs.prefix(2))
         }
 
         /// `Date` view over the unix-seconds marker for relative formatting.
         public var updatedAtDate: Date {
             Date(timeIntervalSince1970: updatedAt)
+        }
+    }
+
+    public struct PullRequest: Codable, Hashable, Identifiable {
+        public let id: String
+        public let prNumber: Int
+        public let title: String
+        public let phase: String
+        public let lane: String?
+        public let updatedAt: Double
+
+        public init(
+            id: String,
+            prNumber: Int,
+            title: String,
+            phase: String,
+            lane: String? = nil,
+            updatedAt: Double = 0
+        ) {
+            self.id = id
+            self.prNumber = prNumber
+            self.title = title
+            self.phase = phase
+            self.lane = lane
+            self.updatedAt = updatedAt
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case id, prNumber, title, phase, lane, updatedAt
+        }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            self.id = (try? c.decode(String.self, forKey: .id)) ?? UUID().uuidString
+            self.prNumber = (try? c.decode(Int.self, forKey: .prNumber)) ?? 0
+            self.title = (try? c.decode(String.self, forKey: .title)) ?? "Pull request"
+            self.phase = (try? c.decode(String.self, forKey: .phase)) ?? PullRequestPhase.opened.rawValue
+            self.lane = try? c.decodeIfPresent(String.self, forKey: .lane)
+            self.updatedAt = (try? c.decode(Double.self, forKey: .updatedAt)) ?? 0
+        }
+
+        public var resolvedPhase: PullRequestPhase {
+            PullRequestPhase(rawValue: phase.lowercased()) ?? .opened
+        }
+
+        public var subtitle: String? {
+            let lane = lane?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return lane?.isEmpty == false ? lane : nil
         }
     }
 
@@ -116,6 +168,68 @@ public struct ADEAgentRunsAttributes: ActivityAttributes {
 
     public init(machineName: String) {
         self.machineName = machineName
+    }
+}
+
+public enum PullRequestPhase: String, CaseIterable, Sendable {
+    case opened
+    case reopened
+    case closed
+    case merged
+    case checksFailing = "checks_failing"
+    case reviewRequested = "review_requested"
+    case changesRequested = "changes_requested"
+    case mergeReady = "merge_ready"
+
+    public var tint: Color {
+        switch self {
+        case .opened, .reopened:
+            return ADESharedTheme.statusSuccess
+        case .merged, .mergeReady:
+            return ADESharedTheme.statusSuccess
+        case .checksFailing, .changesRequested:
+            return ADESharedTheme.statusFailed
+        case .reviewRequested:
+            return ADESharedTheme.warningAmber
+        case .closed:
+            return ADESharedTheme.statusIdle
+        }
+    }
+
+    public var symbol: String {
+        switch self {
+        case .opened, .reopened:
+            return "arrow.triangle.pull"
+        case .closed:
+            return "xmark.circle.fill"
+        case .merged:
+            return "arrow.triangle.merge"
+        case .checksFailing:
+            return "xmark.octagon.fill"
+        case .reviewRequested:
+            return "person.crop.circle.badge.clock"
+        case .changesRequested:
+            return "exclamationmark.bubble.fill"
+        case .mergeReady:
+            return "checkmark.seal.fill"
+        }
+    }
+
+    public var label: String {
+        switch self {
+        case .opened: return "Opened"
+        case .reopened: return "Reopened"
+        case .closed: return "Closed"
+        case .merged: return "Merged"
+        case .checksFailing: return "Checks"
+        case .reviewRequested: return "Review"
+        case .changesRequested: return "Changes"
+        case .mergeReady: return "Ready"
+        }
+    }
+
+    public var needsAttention: Bool {
+        self == .checksFailing || self == .changesRequested || self == .reviewRequested || self == .mergeReady
     }
 }
 

--- a/apps/ios/ADE/Views/PRs/CreatePrWizardView.swift
+++ b/apps/ios/ADE/Views/PRs/CreatePrWizardView.swift
@@ -1565,37 +1565,16 @@ struct CreateIntegrationRequest: Equatable {
 struct PrMarkdownRenderer: View {
   let markdown: String
 
-  private var attributed: AttributedString? {
-    if let cached = PrMarkdownRenderingCache.shared.attributedString(for: markdown) {
-      return cached
-    }
-
-    guard let parsed = try? AttributedString(
-      markdown: markdown,
-      options: AttributedString.MarkdownParsingOptions(
-        interpretedSyntax: .full,
-        failurePolicy: .returnPartiallyParsedIfPossible
-      )
-    ) else {
-      return nil
-    }
-
-    PrMarkdownRenderingCache.shared.store(parsed, for: markdown)
-    return parsed
+  private var normalizedMarkdown: String {
+    normalizePrMarkdownText(markdown)
   }
 
   var body: some View {
-    Group {
-      if let attributed {
-        Text(attributed)
-          .foregroundStyle(ADEColor.textPrimary)
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .textSelection(.enabled)
-      } else {
-        Text(markdown)
-          .foregroundStyle(ADEColor.textPrimary)
-          .frame(maxWidth: .infinity, alignment: .leading)
-      }
-    }
+    WorkMarkdownRenderer(markdown: normalizedMarkdown)
+      .font(.system(.footnote))
+      .foregroundStyle(ADEColor.textPrimary)
+      .tint(ADEColor.accent)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .textSelection(.enabled)
   }
 }

--- a/apps/ios/ADE/Views/PRs/PrDetailActivityTab.swift
+++ b/apps/ios/ADE/Views/PRs/PrDetailActivityTab.swift
@@ -12,6 +12,7 @@ struct PrReviewThreadCard: View {
   let onResolve: (Bool) -> Void
 
   @State private var showReplyField = false
+  @State private var expanded = false
 
   private var firstComment: PrReviewThreadComment? { thread.comments.first }
 
@@ -50,118 +51,158 @@ struct PrReviewThreadCard: View {
     return PrReviewSuggestion.extract(from: body)
   }
 
+  private var isExpanded: Bool {
+    expanded || isFocused || showReplyField
+  }
+
+  private var strippedBody: String? {
+    guard let body = firstComment?.body else { return nil }
+    let stripped = PrReviewSuggestion.stripSuggestion(from: body)
+    return stripped.isEmpty ? nil : stripped
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
-      HStack(alignment: .center, spacing: 9) {
-        threadAvatar
-        VStack(alignment: .leading, spacing: 2) {
-          HStack(spacing: 5) {
-            Text(displayName)
-              .font(.subheadline.weight(.bold))
-              .foregroundStyle(ADEColor.textPrimary)
-            if botProvider != nil {
-              PrTagChip(label: "bot", color: ADEColor.tintPRs)
-            }
-            Spacer(minLength: 0)
-          }
-          HStack(spacing: 0) {
-            if let path = thread.path {
-              Text(path)
-                .font(.system(size: 10, design: .monospaced))
-                .foregroundStyle(ADEColor.textSecondary)
-                .lineLimit(1)
-            }
-            if let line = lineLabel {
-              Text(" · ")
-                .font(.system(size: 10, design: .monospaced))
-                .foregroundStyle(ADEColor.textMuted)
-              Text(line)
-                .font(.system(size: 10, design: .monospaced))
-                .foregroundStyle(ADEColor.tintPRs)
-            }
-            Text(" · \(ago)")
-              .font(.system(size: 10, design: .monospaced))
-              .foregroundStyle(ADEColor.textMuted)
-          }
+      Button {
+        withAnimation(.easeInOut(duration: 0.18)) {
+          expanded.toggle()
         }
-        if !thread.isResolved {
-          PrTagChip(label: "unresolved", color: ADEColor.warning)
-        }
+      } label: {
+        threadHeader
       }
-      .padding(.horizontal, 14)
-      .padding(.top, 12)
-      .padding(.bottom, 8)
+      .buttonStyle(.plain)
 
-      VStack(alignment: .leading, spacing: 10) {
-        if let body = firstComment?.body, !body.isEmpty {
-          let stripped = PrReviewSuggestion.stripSuggestion(from: body)
-          if !stripped.isEmpty {
-            PrInlineCodeText(text: stripped)
-          }
-        }
-
-        if let suggestion {
-          PrDiffPreview(lines: suggestion.diffLines(startLine: thread.line ?? thread.originalLine))
-        }
-
-        // Subsequent replies (collapsed behind "N more replies" affordance)
-        if thread.comments.count > 1 {
-          PrThreadRepliesSection(comments: Array(thread.comments.dropFirst()))
-        }
-
-        HStack(spacing: 6) {
-          if suggestion != nil {
-            ThreadButton(label: "Apply suggestion", isProminent: true, isEnabled: isLive) {
-              onFocus()
-              onReply("✅ applying suggestion")
-            }
-          }
-          ThreadButton(label: "Reply", isEnabled: true) {
-            onFocus()
-            withAnimation(.snappy) { showReplyField = true }
-          }
-          ThreadButton(label: thread.isResolved ? "Reopen" : "Resolve", isEnabled: isLive) {
-            onResolve(!thread.isResolved)
-          }
-          Spacer(minLength: 0)
-        }
-
-        if showReplyField {
-          VStack(alignment: .trailing, spacing: 6) {
-            TextEditor(text: $replyDraft)
-              .frame(minHeight: 70)
-              .adeInsetField(cornerRadius: 10, padding: 8)
-              .font(.footnote)
-            HStack(spacing: 8) {
-              Button("Cancel") {
-                withAnimation(.snappy) { showReplyField = false }
-                replyDraft = ""
-              }
-              .font(.caption)
-              .foregroundStyle(ADEColor.textSecondary)
-
-              Button("Send") {
-                let trimmed = replyDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmed.isEmpty else { return }
-                onReply(trimmed)
-                withAnimation(.snappy) { showReplyField = false }
-              }
-              .buttonStyle(.borderedProminent)
-              .tint(ADEColor.tintPRs)
-              .controlSize(.small)
-              .disabled(!isLive || replyDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-            }
-          }
-        }
+      if isExpanded {
+        expandedContent
+          .transition(.opacity.combined(with: .move(edge: .top)))
+      } else if let strippedBody {
+        PrInlineCodeText(text: strippedBody)
+          .lineLimit(2)
+          .padding(.horizontal, 14)
+          .padding(.bottom, 12)
       }
-      .padding(.horizontal, 14)
-      .padding(.bottom, 12)
     }
     .prGlassCard(
       cornerRadius: 18,
       tint: isFocused ? ADEColor.accent : nil,
       strokeOpacity: isFocused ? 0.45 : 0.10
     )
+  }
+
+  private var threadHeader: some View {
+    HStack(alignment: .center, spacing: 9) {
+      threadAvatar
+      VStack(alignment: .leading, spacing: 2) {
+        HStack(spacing: 5) {
+          Text(displayName)
+            .font(.subheadline.weight(.bold))
+            .foregroundStyle(ADEColor.textPrimary)
+            .lineLimit(1)
+          if botProvider != nil {
+            PrTagChip(label: "bot", color: ADEColor.tintPRs)
+          }
+          if !thread.isResolved {
+            PrTagChip(label: "unresolved", color: ADEColor.warning)
+          }
+          Spacer(minLength: 0)
+        }
+        HStack(spacing: 0) {
+          if let path = thread.path {
+            Text(path)
+              .font(.system(size: 10, design: .monospaced))
+              .foregroundStyle(ADEColor.textSecondary)
+              .lineLimit(1)
+          }
+          if let line = lineLabel {
+            Text(" · ")
+              .font(.system(size: 10, design: .monospaced))
+              .foregroundStyle(ADEColor.textMuted)
+            Text(line)
+              .font(.system(size: 10, design: .monospaced))
+              .foregroundStyle(ADEColor.tintPRs)
+          }
+          Text(" · \(ago)")
+            .font(.system(size: 10, design: .monospaced))
+            .foregroundStyle(ADEColor.textMuted)
+        }
+      }
+      Image(systemName: "chevron.right")
+        .font(.system(size: 11, weight: .semibold))
+        .foregroundStyle(ADEColor.textMuted)
+        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+    }
+    .padding(.horizontal, 14)
+    .padding(.top, 12)
+    .padding(.bottom, isExpanded ? 8 : 10)
+    .contentShape(Rectangle())
+  }
+
+  private var expandedContent: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      if let strippedBody {
+        PrMarkdownRenderer(markdown: strippedBody)
+      }
+
+      if let suggestion {
+        PrDiffPreview(lines: suggestion.diffLines(startLine: thread.line ?? thread.originalLine))
+      }
+
+      // Subsequent replies (collapsed behind "N more replies" affordance).
+      if thread.comments.count > 1 {
+        PrThreadRepliesSection(comments: Array(thread.comments.dropFirst()))
+      }
+
+      HStack(spacing: 6) {
+        if suggestion != nil {
+          ThreadButton(label: "Apply suggestion", isProminent: true, isEnabled: isLive) {
+            expanded = true
+            onFocus()
+            onReply("✅ applying suggestion")
+          }
+        }
+        ThreadButton(label: "Reply", isEnabled: true) {
+          onFocus()
+          withAnimation(.snappy) {
+            expanded = true
+            showReplyField = true
+          }
+        }
+        ThreadButton(label: thread.isResolved ? "Reopen" : "Resolve", isEnabled: isLive) {
+          onResolve(!thread.isResolved)
+        }
+        Spacer(minLength: 0)
+      }
+
+      if showReplyField {
+        VStack(alignment: .trailing, spacing: 6) {
+          TextEditor(text: $replyDraft)
+            .frame(minHeight: 70)
+            .adeInsetField(cornerRadius: 10, padding: 8)
+            .font(.footnote)
+          HStack(spacing: 8) {
+            Button("Cancel") {
+              withAnimation(.snappy) { showReplyField = false }
+              replyDraft = ""
+            }
+            .font(.caption)
+            .foregroundStyle(ADEColor.textSecondary)
+
+            Button("Send") {
+              let trimmed = replyDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+              guard !trimmed.isEmpty else { return }
+              onReply(trimmed)
+              withAnimation(.snappy) { showReplyField = false }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(ADEColor.tintPRs)
+            .controlSize(.small)
+            .disabled(!isLive || replyDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+          }
+        }
+      }
+    }
+    .padding(.horizontal, 14)
+    .padding(.bottom, 12)
   }
 
   private var threadAvatar: some View {
@@ -245,11 +286,9 @@ private struct PrThreadReplyBubble: View {
             .font(.system(size: 9, design: .monospaced))
             .foregroundStyle(ADEColor.textMuted)
         }
-        Text(comment.body ?? "")
+        PrMarkdownRenderer(markdown: comment.body ?? "")
           .font(.system(size: 11))
           .foregroundStyle(ADEColor.textSecondary)
-          .fixedSize(horizontal: false, vertical: true)
-          .lineLimit(8)
       }
     }
     .padding(.horizontal, 2)
@@ -306,11 +345,12 @@ struct PrInlineCodeText: View {
     // Namespaced key: the shared cache is also used by the full-markdown
     // renderer, and both key by content — an unprefixed key would let the two
     // renderings clobber each other for identical source strings.
-    let cacheKey = "inline:\(text)"
+    let normalized = normalizePrMarkdownText(text)
+    let cacheKey = "inline:\(normalized)"
     if let cached = PrMarkdownRenderingCache.shared.attributedString(for: cacheKey) {
       return cached
     }
-    let rendered = render(text)
+    let rendered = render(normalized)
     PrMarkdownRenderingCache.shared.store(rendered, for: cacheKey)
     return rendered
   }
@@ -771,6 +811,14 @@ private struct PrTimelineCommentCard: View {
     botProvider != nil ? ADEColor.tintPRs : ADEColor.accent
   }
 
+  private var normalizedBody: String {
+    normalizePrMarkdownText(bodyText)
+  }
+
+  private var shouldOfferExpansion: Bool {
+    normalizedBody.count > 280 || normalizedBody.filter({ $0 == "\n" }).count >= Self.collapsedLineLimit
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
       HStack(alignment: .center, spacing: 9) {
@@ -801,17 +849,23 @@ private struct PrTimelineCommentCard: View {
         Spacer(minLength: 0)
       }
 
-      PrInlineCodeText(text: bodyText)
-        .lineLimit(expanded ? nil : Self.collapsedLineLimit)
+      if expanded {
+        PrMarkdownRenderer(markdown: normalizedBody)
+      } else {
+        PrInlineCodeText(text: normalizedBody)
+          .lineLimit(Self.collapsedLineLimit)
+      }
 
       // Offer expansion whenever the clamp could plausibly truncate: at
       // footnote size a phone renders ~35+ chars/line, so <280 chars with
       // fewer than 10 hard newlines cannot exceed the 10-line clamp.
-      if !expanded, bodyText.count > 280 || bodyText.filter({ $0 == "\n" }).count >= Self.collapsedLineLimit {
+      if shouldOfferExpansion {
         Button {
-          expanded = true
+          withAnimation(.easeInOut(duration: 0.18)) {
+            expanded.toggle()
+          }
         } label: {
-          Text("Show more")
+          Text(expanded ? "Show less" : "Show more")
             .font(.system(size: 11, weight: .semibold))
             .foregroundStyle(ADEColor.accent)
         }

--- a/apps/ios/ADE/Views/PRs/PrDetailOverviewTab.swift
+++ b/apps/ios/ADE/Views/PRs/PrDetailOverviewTab.swift
@@ -60,11 +60,260 @@ struct PrThreadDescriptionCard: View {
             .foregroundStyle(ADEColor.textMuted)
         }
       }
-      PrInlineCodeText(text: text)
+      PrMarkdownRenderer(markdown: text)
     }
     .padding(14)
     .frame(maxWidth: .infinity, alignment: .leading)
     .prGlassCard(cornerRadius: 16)
+  }
+}
+
+/// Compact mobile summary that replaces the old PR hero card. It keeps the
+/// state/actions context above the thread without forcing a large title card at
+/// the top of every detail screen.
+struct PrDetailSummarySection: View {
+  let pr: PullRequestListItem
+  let snapshot: PullRequestSnapshot?
+  let mergeGate: PrMergeGateInfo
+  @Binding var commitsExpanded: Bool
+  let onStatusTap: () -> Void
+  let onChecksTap: () -> Void
+  let onFilesTap: () -> Void
+  let onCommitTap: (PrCommit) -> Void
+
+  private var state: String { snapshot?.status?.state ?? pr.state }
+  private var stateTint: Color { prStateTint(state) }
+  private var checksStatus: String { snapshot?.status?.checksStatus ?? pr.checksStatus }
+  private var files: [PrFile] { snapshot?.files ?? [] }
+  private var commits: [PrCommit] { snapshot?.commits ?? [] }
+
+  private var additions: Int {
+    files.isEmpty ? pr.additions : files.reduce(0) { $0 + $1.additions }
+  }
+
+  private var deletions: Int {
+    files.isEmpty ? pr.deletions : files.reduce(0) { $0 + $1.deletions }
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      HStack(alignment: .center, spacing: 8) {
+        PrTagChip(label: state.isEmpty ? "unknown" : state, color: stateTint)
+        Text(mergeGate.subline)
+          .font(.system(size: 11.5, design: .monospaced))
+          .foregroundStyle(ADEColor.textSecondary)
+          .lineLimit(2)
+        Spacer(minLength: 0)
+      }
+      .padding(.horizontal, 14)
+      .padding(.top, 13)
+      .padding(.bottom, 10)
+
+      Divider().overlay(PrGlassPalette.cardBorder)
+
+      LazyVGrid(
+        columns: [
+          GridItem(.flexible(), spacing: 0),
+          GridItem(.flexible(), spacing: 0),
+        ],
+        spacing: 0
+      ) {
+        PrSummaryMetricButton(
+          title: "Status",
+          value: titleCase(state),
+          icon: "arrow.triangle.pull",
+          tint: stateTint,
+          action: onStatusTap
+        )
+        PrSummaryMetricButton(
+          title: "Checks",
+          value: prChecksLabel(checksStatus),
+          icon: "checklist.checked",
+          tint: prChecksTint(checksStatus),
+          action: onChecksTap
+        )
+        PrSummaryMetricButton(
+          title: "Diff",
+          value: "\(files.count) file\(files.count == 1 ? "" : "s")",
+          detail: "+\(additions) / -\(deletions)",
+          icon: "doc.text.magnifyingglass",
+          tint: ADEColor.info,
+          action: onFilesTap
+        )
+        PrSummaryMetricButton(
+          title: "Commits",
+          value: "\(commits.count)",
+          detail: commits.count == 1 ? "commit" : "commits",
+          icon: "point.topleft.down.curvedto.point.bottomright.up",
+          tint: ADEColor.accent,
+          action: {
+            withAnimation(.easeInOut(duration: 0.18)) {
+              commitsExpanded.toggle()
+            }
+          }
+        )
+      }
+
+      if !commits.isEmpty {
+        Divider().overlay(PrGlassPalette.cardBorder)
+        Button {
+          withAnimation(.easeInOut(duration: 0.18)) {
+            commitsExpanded.toggle()
+          }
+        } label: {
+          HStack(spacing: 8) {
+            Text("Commits")
+              .font(.system(size: 12, weight: .semibold))
+              .foregroundStyle(ADEColor.textPrimary)
+            Spacer(minLength: 0)
+            Text(commitsExpanded ? "Hide" : "Show")
+              .font(.system(size: 11, weight: .semibold, design: .monospaced))
+              .foregroundStyle(ADEColor.textSecondary)
+            Image(systemName: "chevron.right")
+              .font(.system(size: 10, weight: .semibold))
+              .foregroundStyle(ADEColor.textMuted)
+              .rotationEffect(.degrees(commitsExpanded ? 90 : 0))
+          }
+          .padding(.horizontal, 14)
+          .padding(.vertical, 11)
+          .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+
+        if commitsExpanded {
+          VStack(spacing: 0) {
+            ForEach(Array(commits.prefix(25).enumerated()), id: \.element.id) { index, commit in
+              PrSummaryCommitRow(commit: commit) {
+                onCommitTap(commit)
+              }
+              if index < min(commits.count, 25) - 1 {
+                Divider()
+                  .padding(.leading, 14)
+                  .overlay(PrGlassPalette.cardBorder)
+              }
+            }
+            if commits.count > 25 {
+              Divider()
+                .padding(.leading, 14)
+                .overlay(PrGlassPalette.cardBorder)
+              Text("+ \(commits.count - 25) older commits")
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(ADEColor.textMuted)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+            }
+          }
+          .transition(.opacity.combined(with: .move(edge: .top)))
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .prGlassCard(cornerRadius: 16)
+  }
+}
+
+private struct PrSummaryMetricButton: View {
+  let title: String
+  let value: String
+  var detail: String?
+  let icon: String
+  let tint: Color
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      HStack(alignment: .top, spacing: 9) {
+        Image(systemName: icon)
+          .font(.system(size: 13, weight: .semibold))
+          .foregroundStyle(tint)
+          .frame(width: 17, height: 18)
+        VStack(alignment: .leading, spacing: 2) {
+          Text(title)
+            .font(.system(size: 10, weight: .semibold, design: .monospaced))
+            .foregroundStyle(ADEColor.textMuted)
+            .lineLimit(1)
+          Text(value)
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(ADEColor.textPrimary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
+          if let detail, !detail.isEmpty {
+            Text(detail)
+              .font(.system(size: 10, design: .monospaced))
+              .foregroundStyle(ADEColor.textSecondary)
+              .lineLimit(1)
+          }
+        }
+        Spacer(minLength: 0)
+      }
+      .padding(.horizontal, 14)
+      .padding(.vertical, 12)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+}
+
+private struct PrSummaryCommitRow: View {
+  let commit: PrCommit
+  let action: () -> Void
+
+  private var author: String? {
+    commit.authorLogin ?? commit.authorName
+  }
+
+  private var message: String {
+    commit.message
+      .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
+      .first
+      .map(String.init)?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      ?? "Commit"
+  }
+
+  private var shortSha: String {
+    commit.shortSha.isEmpty ? String(commit.sha.prefix(7)) : commit.shortSha
+  }
+
+  var body: some View {
+    Button(action: action) {
+      HStack(alignment: .top, spacing: 10) {
+        Image(systemName: "smallcircle.filled.circle")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(prChecksTint(commit.checkStatus ?? "none"))
+          .frame(width: 15, height: 18)
+        VStack(alignment: .leading, spacing: 3) {
+          Text(message)
+            .font(.system(size: 12.5, weight: .medium))
+            .foregroundStyle(ADEColor.textPrimary)
+            .lineLimit(2)
+          HStack(spacing: 7) {
+            Text(shortSha)
+              .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
+              .foregroundStyle(ADEColor.accent)
+            if let author, !author.isEmpty {
+              Text(author)
+                .font(.system(size: 10.5, design: .monospaced))
+                .foregroundStyle(ADEColor.textMuted)
+                .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+            Text(prCompactRelativeTime(commit.committedDate))
+              .font(.system(size: 10.5, design: .monospaced))
+              .foregroundStyle(ADEColor.textMuted)
+          }
+        }
+        Image(systemName: "arrow.down.to.line.compact")
+          .font(.system(size: 10, weight: .semibold))
+          .foregroundStyle(ADEColor.textMuted)
+          .padding(.top, 2)
+      }
+      .padding(.horizontal, 14)
+      .padding(.vertical, 10)
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
   }
 }
 

--- a/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
+++ b/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
@@ -35,6 +35,7 @@ struct PrDetailView: View {
   @State private var hasSeededFromWarmCache = false
   @State private var summaryCommitsExpanded = false
   @State private var pendingTimelineScrollId: String?
+  @State private var timelineSectionMounted = false
 
   // MARK: - Derived models (computed off the render path)
   //
@@ -522,7 +523,7 @@ struct PrDetailView: View {
         // is routed here too so any persisted/legacy selection still renders.
         // Emitted as SIBLING List rows (not one nested mega-row) so the List
         // actually virtualizes offscreen thread content.
-        overviewThreadRows
+        overviewThreadRows(scrollProxy: scrollProxy)
       case .files:
         PrFilesTab(
           snapshot: snapshot,
@@ -588,15 +589,7 @@ struct PrDetailView: View {
     }
     .onChange(of: pendingTimelineScrollId) { _, anchorId in
       guard let anchorId else { return }
-      Task { @MainActor in
-        await Task.yield()
-        withAnimation(.easeInOut(duration: 0.25)) {
-          scrollProxy.scrollTo(anchorId, anchor: .center)
-        }
-        if pendingTimelineScrollId == anchorId {
-          pendingTimelineScrollId = nil
-        }
-      }
+      scrollPendingTimelineAnchorIfReady(anchorId: anchorId, scrollProxy: scrollProxy)
     }
     .sheet(isPresented: $cleanupConfirmationPresented) {
       PrCleanupConfirmationSheet(
@@ -900,7 +893,7 @@ struct PrDetailView: View {
   // metadata cards (checks / commits / files / people / stack). Every card is
   // its own List row.
   @ViewBuilder
-  private var overviewThreadRows: some View {
+  private func overviewThreadRows(scrollProxy: ScrollViewProxy) -> some View {
     if !isCurrentPrMapped {
       PrUnmappedThreadBanner(
         canAutoMap: canAutoMapCurrentPr,
@@ -940,8 +933,18 @@ struct PrDetailView: View {
 
     // Chronological event feed — one row per event / folded commit group.
     ForEach(timelineDisplayItems) { item in
+      let anchorId = timelineAnchorId(for: item)
       PrTimelineDisplayRow(item: item)
-        .id(timelineAnchorId(for: item))
+        .id(anchorId)
+        .onAppear {
+          timelineSectionMounted = true
+          scrollPendingTimelineAnchorIfReady(anchorId: pendingTimelineScrollId, scrollProxy: scrollProxy)
+        }
+        .onDisappear {
+          if selectedTab != .overview && selectedTab != .activity {
+            timelineSectionMounted = false
+          }
+        }
         .prListRow()
     }
 
@@ -1068,6 +1071,10 @@ struct PrDetailView: View {
   }
 
   private func focusCommitInTimeline(_ commit: PrCommit) {
+    let timelineWasMounted = selectedTab == .overview || selectedTab == .activity
+    if !timelineWasMounted {
+      timelineSectionMounted = false
+    }
     selectedTab = .overview
     guard let anchorId = timelineAnchorId(for: commit) else {
       errorMessage = "That commit is not in the loaded conversation timeline yet."
@@ -1097,13 +1104,35 @@ struct PrDetailView: View {
     guard event.kind == .commit else { return false }
     let shortSha = commit.shortSha.isEmpty ? String(commit.sha.prefix(7)) : commit.shortSha
     let fullSha = commit.sha
+    guard !shortSha.isEmpty || !fullSha.isEmpty else { return false }
     let haystack = [
       event.id,
       event.title,
       event.metadata ?? "",
     ].joined(separator: " ")
-    return haystack.localizedCaseInsensitiveContains(shortSha)
+    return (!shortSha.isEmpty && haystack.localizedCaseInsensitiveContains(shortSha))
       || (!fullSha.isEmpty && haystack.localizedCaseInsensitiveContains(fullSha))
+  }
+
+  private func scrollPendingTimelineAnchorIfReady(anchorId: String?, scrollProxy: ScrollViewProxy) {
+    guard let anchorId, timelineSectionMounted else { return }
+    Task { @MainActor in
+      let retryDelays: [UInt64] = [0, 80_000_000, 220_000_000]
+      for (index, delay) in retryDelays.enumerated() {
+        if delay == 0 {
+          await Task.yield()
+        } else {
+          try? await Task.sleep(nanoseconds: delay)
+        }
+        guard pendingTimelineScrollId == anchorId, timelineSectionMounted else { return }
+        withAnimation(.easeInOut(duration: 0.25)) {
+          scrollProxy.scrollTo(anchorId, anchor: .center)
+        }
+        if index == retryDelays.count - 1 {
+          pendingTimelineScrollId = nil
+        }
+      }
+    }
   }
 
   // MARK: - Sticky action bar

--- a/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
+++ b/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
@@ -588,10 +588,15 @@ struct PrDetailView: View {
     }
     .onChange(of: pendingTimelineScrollId) { _, anchorId in
       guard let anchorId else { return }
-      withAnimation(.easeInOut(duration: 0.25)) {
-        scrollProxy.scrollTo(anchorId, anchor: .center)
+      Task { @MainActor in
+        await Task.yield()
+        withAnimation(.easeInOut(duration: 0.25)) {
+          scrollProxy.scrollTo(anchorId, anchor: .center)
+        }
+        if pendingTimelineScrollId == anchorId {
+          pendingTimelineScrollId = nil
+        }
       }
-      pendingTimelineScrollId = nil
     }
     .sheet(isPresented: $cleanupConfirmationPresented) {
       PrCleanupConfirmationSheet(

--- a/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
+++ b/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
@@ -33,6 +33,8 @@ struct PrDetailView: View {
   @State private var hasLoadedLiveSidecars = false
   @State private var hasAttemptedInitialLoad = false
   @State private var hasSeededFromWarmCache = false
+  @State private var summaryCommitsExpanded = false
+  @State private var pendingTimelineScrollId: String?
 
   // MARK: - Derived models (computed off the render path)
   //
@@ -171,6 +173,19 @@ struct PrDetailView: View {
       return "Pull request \(displayedPrNumber), \(currentPr.title)"
     }
     return "Pull request, \(currentPr.title)"
+  }
+
+  private var detailHeaderMetaText: String {
+    let number = displayedPrNumber.map { "#\($0)" }
+    let lane = currentPr.laneName?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let laneLabel = lane?.isEmpty == false
+      ? lane
+      : (currentPr.laneId.isEmpty ? "Unmapped" : currentPr.laneId)
+    let branchLabel = currentPr.headBranch.isEmpty ? nil : currentPr.headBranch
+    return [number, laneLabel, branchLabel]
+      .compactMap { $0 }
+      .filter { !$0.isEmpty }
+      .joined(separator: " · ")
   }
 
   private var currentPr: PullRequestListItem {
@@ -428,7 +443,8 @@ struct PrDetailView: View {
   }
 
   var body: some View {
-    List {
+    ScrollViewReader { scrollProxy in
+      List {
       // Durable in-flight banner: reads the label from the service registry so
       // a merge/close/comment started here keeps showing a spinner even if the
       // user switches tabs and returns.
@@ -485,18 +501,16 @@ struct PrDetailView: View {
         )
         .prListRow()
       } else {
-        heroCard
-          .prListRow()
-
-        PrMergeGateCard(info: mergeGateInfo) {
-          switch mergeGateInfo.target {
-          case .checks: selectedTab = .checks
-          // Reviews now live inside the unified Overview thread (Activity folded
-          // in), so the merge-gate "reviews" target lands on Overview.
-          case .reviews: selectedTab = .overview
-          case .overview: selectedTab = .overview
-          }
-        }
+        PrDetailSummarySection(
+          pr: currentPr,
+          snapshot: snapshot,
+          mergeGate: mergeGateInfo,
+          commitsExpanded: $summaryCommitsExpanded,
+          onStatusTap: { selectedTab = .overview },
+          onChecksTap: { selectedTab = .checks },
+          onFilesTap: { selectedTab = .files },
+          onCommitTap: focusCommitInTimeline
+        )
         .prListRow()
 
         subTabPicker
@@ -528,10 +542,10 @@ struct PrDetailView: View {
           onRerun: rerunChecks
         )
         .prListRow()
+        }
       }
       }
-    }
-    .listStyle(.plain)
+      .listStyle(.plain)
     .listRowSpacing(12)
     .scrollContentBackground(.hidden)
     .background(prLiquidGlassBackdrop().ignoresSafeArea())
@@ -571,6 +585,13 @@ struct PrDetailView: View {
         refreshRemote: false
       ) || !syncService.prDetailWarmEntryIsFresh(for: prId, within: Self.detailFreshnessWindow)
       await reload(includeLiveSidecars: needLiveSidecars)
+    }
+    .onChange(of: pendingTimelineScrollId) { _, anchorId in
+      guard let anchorId else { return }
+      withAnimation(.easeInOut(duration: 0.25)) {
+        scrollProxy.scrollTo(anchorId, anchor: .center)
+      }
+      pendingTimelineScrollId = nil
     }
     .sheet(isPresented: $cleanupConfirmationPresented) {
       PrCleanupConfirmationSheet(
@@ -675,48 +696,53 @@ struct PrDetailView: View {
         }
       }
     }
+    }
   }
 
   private var detailNavigationHeader: some View {
-    HStack(spacing: 10) {
+    HStack(spacing: 8) {
       Button {
         dismiss()
       } label: {
         Image(systemName: "chevron.left")
-          .font(.system(size: 17, weight: .semibold))
-          .frame(width: 38, height: 38)
+          .font(.system(size: 18, weight: .semibold))
+          .foregroundStyle(ADEColor.textPrimary)
+          .frame(width: 40, height: 40)
+          .contentShape(Rectangle())
       }
-      .buttonStyle(.glass)
+      .buttonStyle(.plain)
       .accessibilityLabel("Back to PRs")
 
-      VStack(alignment: .leading, spacing: 2) {
-        if let displayedPrNumber {
-          Text("#\(displayedPrNumber)")
-            .font(.system(size: 11, weight: .bold, design: .monospaced))
-            .foregroundStyle(prStateTint(currentPr.state))
-        }
+      VStack(alignment: .center, spacing: 2) {
         Text(currentPr.title)
-          .font(.headline.weight(.semibold))
+          .font(.system(size: 15, weight: .semibold))
           .foregroundStyle(ADEColor.textPrimary)
           .lineLimit(1)
           .truncationMode(.tail)
+        Text(detailHeaderMetaText)
+          .font(.system(size: 10.5, weight: .medium, design: .monospaced))
+          .foregroundStyle(ADEColor.textSecondary)
+          .lineLimit(1)
+          .truncationMode(.middle)
       }
+      .frame(maxWidth: .infinity)
       .accessibilityElement(children: .combine)
       .accessibilityLabel(detailHeaderAccessibilityLabel)
-
-      Spacer(minLength: 0)
 
       Button {
         actionsSheetPresented = true
       } label: {
-        Image(systemName: "ellipsis.circle")
-          .font(.system(size: 17, weight: .semibold))
-          .frame(width: 38, height: 38)
+        Image(systemName: "ellipsis")
+          .font(.system(size: 18, weight: .semibold))
+          .foregroundStyle(ADEColor.textPrimary)
+          .frame(width: 40, height: 40)
+          .contentShape(Rectangle())
       }
-      .buttonStyle(.glass)
+      .buttonStyle(.plain)
       .accessibilityLabel("Pull request actions")
     }
     .padding(.horizontal, 16)
+    .padding(.top, 2)
     .padding(.bottom, 8)
     .background {
       ADEColor.pageBackground
@@ -790,75 +816,6 @@ struct PrDetailView: View {
         Task { await reload(refreshRemote: true) }
       }
     )
-  }
-
-  // MARK: - Hero
-
-  private var heroCard: some View {
-    let state = snapshot?.status?.state ?? currentPr.state
-    let stateTint = prStateTint(state)
-    let author = snapshot?.detail?.author.login ?? githubItem?.author ?? "unknown"
-    let baseLabel = currentPr.baseBranch.isEmpty ? "base" : currentPr.baseBranch
-    let headLabel = currentPr.headBranch.isEmpty ? "head" : currentPr.headBranch
-
-    return HStack(alignment: .top, spacing: 12) {
-      // 44pt state tile on the left
-      ZStack {
-        RoundedRectangle(cornerRadius: 12, style: .continuous)
-          .fill(stateTint.opacity(0.14))
-        RoundedRectangle(cornerRadius: 12, style: .continuous)
-          .strokeBorder(stateTint.opacity(0.48), lineWidth: 0.75)
-        Image(systemName: "arrow.triangle.pull")
-          .font(.system(size: 17, weight: .semibold))
-          .foregroundStyle(stateTint)
-      }
-      .frame(width: 44, height: 44)
-      .adeMatchedGeometry(id: transitionNamespace == nil ? nil : "pr-status-\(currentPr.id)", in: transitionNamespace)
-
-      VStack(alignment: .leading, spacing: 6) {
-        HStack(spacing: 6) {
-          Text("#\(currentPr.githubPrNumber)")
-            .font(.system(size: 11, weight: .bold, design: .monospaced))
-            .foregroundStyle(stateTint)
-          PrTagChip(label: state, color: stateTint)
-          if let kindLabel = prAdeKindLabel(currentPr.adeKind) {
-            PrTagChip(label: kindLabel, color: ADEColor.tintPRs)
-          }
-          Spacer(minLength: 0)
-        }
-
-        Text(currentPr.title)
-          .font(.system(size: 15, weight: .semibold))
-          .tracking(-0.2)
-          .foregroundStyle(ADEColor.textPrimary)
-          .lineSpacing(1)
-          .lineLimit(3)
-          .fixedSize(horizontal: false, vertical: true)
-          .adeMatchedGeometry(id: transitionNamespace == nil ? nil : "pr-title-\(currentPr.id)", in: transitionNamespace)
-
-        // Single mono meta line: branch → base · opened … by @author
-        (
-          Text(headLabel)
-            .foregroundColor(ADEColor.textSecondary)
-          + Text(" → ")
-            .foregroundColor(ADEColor.textMuted)
-          + Text(baseLabel)
-            .foregroundColor(ADEColor.textSecondary)
-          + Text("  ·  opened \(prRelativeTime(currentPr.createdAt)) by @\(author)")
-            .foregroundColor(ADEColor.textMuted)
-        )
-        .font(.system(size: 11, design: .monospaced))
-        .lineLimit(1)
-        .truncationMode(.middle)
-      }
-
-      Spacer(minLength: 0)
-    }
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .padding(.horizontal, 14)
-    .padding(.vertical, 14)
-    .prGlassCard(cornerRadius: 20, tint: stateTint)
-    .padding(.horizontal, 2)
   }
 
   // MARK: - Sub-tab picker
@@ -979,6 +936,7 @@ struct PrDetailView: View {
     // Chronological event feed — one row per event / folded commit group.
     ForEach(timelineDisplayItems) { item in
       PrTimelineDisplayRow(item: item)
+        .id(timelineAnchorId(for: item))
         .prListRow()
     }
 
@@ -1098,6 +1056,49 @@ struct PrDetailView: View {
       .frame(height: 88)
       .accessibilityHidden(true)
       .prListRow()
+  }
+
+  private func timelineAnchorId(for item: PrTimelineDisplayItem) -> String {
+    "pr-timeline-\(item.id)"
+  }
+
+  private func focusCommitInTimeline(_ commit: PrCommit) {
+    selectedTab = .overview
+    guard let anchorId = timelineAnchorId(for: commit) else {
+      errorMessage = "That commit is not in the loaded conversation timeline yet."
+      return
+    }
+    ADEHaptics.light()
+    pendingTimelineScrollId = anchorId
+  }
+
+  private func timelineAnchorId(for commit: PrCommit) -> String? {
+    for item in timelineDisplayItems {
+      switch item {
+      case .event(let event):
+        if eventMatches(commit: commit, event: event) {
+          return timelineAnchorId(for: item)
+        }
+      case .commitGroup(_, _, let events):
+        if events.contains(where: { eventMatches(commit: commit, event: $0) }) {
+          return timelineAnchorId(for: item)
+        }
+      }
+    }
+    return nil
+  }
+
+  private func eventMatches(commit: PrCommit, event: PrTimelineEvent) -> Bool {
+    guard event.kind == .commit else { return false }
+    let shortSha = commit.shortSha.isEmpty ? String(commit.sha.prefix(7)) : commit.shortSha
+    let fullSha = commit.sha
+    let haystack = [
+      event.id,
+      event.title,
+      event.metadata ?? "",
+    ].joined(separator: " ")
+    return haystack.localizedCaseInsensitiveContains(shortSha)
+      || (!fullSha.isEmpty && haystack.localizedCaseInsensitiveContains(fullSha))
   }
 
   // MARK: - Sticky action bar

--- a/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
+++ b/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
@@ -6,6 +6,20 @@ struct PrDetailView: View {
   @EnvironmentObject private var syncService: SyncService
   let prId: String
   let transitionNamespace: Namespace.ID?
+  let requestedRepoOwner: String?
+  let requestedRepoName: String?
+
+  init(
+    prId: String,
+    transitionNamespace: Namespace.ID?,
+    requestedRepoOwner: String? = nil,
+    requestedRepoName: String? = nil
+  ) {
+    self.prId = prId
+    self.transitionNamespace = transitionNamespace
+    self.requestedRepoOwner = requestedRepoOwner
+    self.requestedRepoName = requestedRepoName
+  }
 
   @State private var pr: PullRequestListItem?
   @State private var githubItem: GitHubPrListItem?
@@ -135,6 +149,10 @@ struct PrDetailView: View {
     Self.prNumber(fromRouteId: prId)
   }
 
+  private var requestedRepoScope: PrDetailRouteScope? {
+    PrDetailRouteScope(repoOwner: requestedRepoOwner, repoName: requestedRepoName)
+  }
+
   private var hasPrDetailData: Bool {
     pr != nil || githubItem != nil || snapshot != nil
   }
@@ -196,6 +214,8 @@ struct PrDetailView: View {
     return Self.synthesizePlaceholderPr(
       prId: prId,
       routedPrNumber: routedPrNumber,
+      requestedRepoOwner: requestedRepoScope?.repoOwner,
+      requestedRepoName: requestedRepoScope?.repoName,
       githubItem: githubItem,
       snapshot: snapshot
     )
@@ -204,6 +224,8 @@ struct PrDetailView: View {
   private static func synthesizePlaceholderPr(
     prId: String,
     routedPrNumber: Int?,
+    requestedRepoOwner: String?,
+    requestedRepoName: String?,
     githubItem: GitHubPrListItem?,
     snapshot: PullRequestSnapshot?
   ) -> PullRequestListItem {
@@ -217,8 +239,8 @@ struct PrDetailView: View {
       laneId: "",
       laneName: nil,
       projectId: "",
-      repoOwner: githubItem?.repoOwner ?? "",
-      repoName: githubItem?.repoName ?? "",
+      repoOwner: githubItem?.repoOwner ?? requestedRepoOwner ?? "",
+      repoName: githubItem?.repoName ?? requestedRepoName ?? "",
       githubPrNumber: githubItem?.githubPrNumber ?? routedPrNumber ?? 0,
       githubUrl: githubItem?.githubUrl ?? "",
       title: githubItem?.title ?? routedPrNumber.map { "Pull request #\($0)" } ?? "Pull request",
@@ -254,6 +276,8 @@ struct PrDetailView: View {
       ? Self.synthesizePlaceholderPr(
           prId: prId,
           routedPrNumber: routedPrNumber,
+          requestedRepoOwner: requestedRepoScope?.repoOwner,
+          requestedRepoName: requestedRepoScope?.repoName,
           githubItem: githubItem,
           snapshot: snapshot
         )
@@ -1304,7 +1328,9 @@ struct PrDetailView: View {
         from: listItems,
         prId: prId,
         requestedPrNumber: requestedPrNumber,
-        githubItem: fallbackGitHubItem
+        githubItem: fallbackGitHubItem,
+        requestedRepoOwner: requestedRepoScope?.repoOwner,
+        requestedRepoName: requestedRepoScope?.repoName
       )
       let snapshotPrId = pr?.id ?? (requestedPrNumber == nil ? prId : nil)
       if let snapshotPrId {
@@ -1442,11 +1468,15 @@ struct PrDetailView: View {
   @MainActor
   private func fetchGitHubFallbackItem(requestedPrNumber: Int?) async -> GitHubPrListItem? {
     guard let github = try? await syncService.fetchGitHubPullRequestSnapshot() else { return nil }
+    let routeScope = requestedRepoScope
     return repoScopedGitHubPullRequests(from: github)
       .first {
-        $0.linkedPrId == prId ||
-          $0.id == prId ||
-          (requestedPrNumber != nil && $0.githubPrNumber == requestedPrNumber)
+        let identityMatches = $0.linkedPrId == prId || $0.id == prId
+        let numberMatches = requestedPrNumber != nil && $0.githubPrNumber == requestedPrNumber
+        guard identityMatches || numberMatches else { return false }
+        guard let routeScope else { return true }
+        return $0.repoOwner.caseInsensitiveCompare(routeScope.repoOwner) == .orderedSame
+          && $0.repoName.caseInsensitiveCompare(routeScope.repoName) == .orderedSame
       }
   }
 

--- a/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
+++ b/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
@@ -1095,14 +1095,19 @@ struct PrDetailView: View {
   }
 
   private func focusCommitInTimeline(_ commit: PrCommit) {
+    let missingCommitMessage = "That commit is not in the loaded conversation timeline yet."
     let timelineWasMounted = selectedTab == .overview || selectedTab == .activity
     if !timelineWasMounted {
       timelineSectionMounted = false
     }
     selectedTab = .overview
+    pendingTimelineScrollId = nil
     guard let anchorId = timelineAnchorId(for: commit) else {
-      errorMessage = "That commit is not in the loaded conversation timeline yet."
+      errorMessage = missingCommitMessage
       return
+    }
+    if errorMessage == missingCommitMessage {
+      errorMessage = nil
     }
     ADEHaptics.light()
     pendingTimelineScrollId = anchorId
@@ -1412,7 +1417,10 @@ struct PrDetailView: View {
   private func seedFromWarmCacheIfNeeded() {
     guard !hasSeededFromWarmCache, !hasPrDetailData else { return }
     hasSeededFromWarmCache = true
-    guard let entry = syncService.prDetailWarmEntry(for: prId) else { return }
+    guard
+      let entry = syncService.prDetailWarmEntry(for: prId),
+      prDetailWarmEntryMatchesRequestedScope(entry, requestedRepoScope: requestedRepoScope)
+    else { return }
     pr = entry.pr
     githubItem = entry.githubItem
     snapshot = entry.snapshot

--- a/apps/ios/ADE/Views/PRs/PrHelpers.swift
+++ b/apps/ios/ADE/Views/PRs/PrHelpers.swift
@@ -872,6 +872,22 @@ final class PrMarkdownRenderingCache {
   }
 }
 
+func normalizePrMarkdownText(_ text: String) -> String {
+  var normalized = text
+    .replacingOccurrences(of: "\r\n", with: "\n")
+    .replacingOccurrences(of: "\r", with: "\n")
+
+  if normalized.contains("\\n") || normalized.contains("\\r") || normalized.contains("\\t") {
+    normalized = normalized
+      .replacingOccurrences(of: "\\r\\n", with: "\n")
+      .replacingOccurrences(of: "\\n", with: "\n")
+      .replacingOccurrences(of: "\\r", with: "\n")
+      .replacingOccurrences(of: "\\t", with: "\t")
+  }
+
+  return normalized
+}
+
 private final class PrMarkdownAttributedStringBox: NSObject {
   let value: AttributedString
 

--- a/apps/ios/ADE/Views/PRs/PrHelpers.swift
+++ b/apps/ios/ADE/Views/PRs/PrHelpers.swift
@@ -495,8 +495,21 @@ func prDetailRouteListItem(
   return candidates.count == 1 ? candidates[0] : nil
 }
 
+struct PrDetailRouteScope: Equatable {
+  let repoOwner: String
+  let repoName: String
+
+  init?(repoOwner: String?, repoName: String?) {
+    let owner = repoOwner?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    let name = repoName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    guard !owner.isEmpty, !name.isEmpty else { return nil }
+    self.repoOwner = owner
+    self.repoName = name
+  }
+}
+
 enum PrNavigationTarget: Equatable {
-  case detail(prId: String, laneId: String?)
+  case detail(prId: String, laneId: String?, repoScope: PrDetailRouteScope?)
   case github(GitHubPrListItem)
   case unresolved
 }
@@ -527,11 +540,12 @@ func prNavigationTarget(
   case .create:
     return .unresolved
   }
+  let requestedRepoScope = PrDetailRouteScope(repoOwner: requestedRepoOwner, repoName: requestedRepoName)
   guard !prId.isEmpty else { return .unresolved }
 
   guard prId.hasPrefix("github-pr-number:") else {
     let match = pullRequests.first { $0.id == prId }
-    return .detail(prId: prId, laneId: requestLaneId ?? match?.laneId)
+    return .detail(prId: prId, laneId: requestLaneId ?? match?.laneId, repoScope: nil)
   }
 
   let requestedPrNumber = explicitPrNumber ?? syntheticPrNumber(from: prId)
@@ -554,12 +568,14 @@ func prNavigationTarget(
     requestedRepoOwner: requestedRepoOwner,
     requestedRepoName: requestedRepoName
   ) {
-    return .detail(prId: match.id, laneId: requestLaneId ?? match.laneId)
+    let repoScope = requestedRepoScope ?? PrDetailRouteScope(repoOwner: githubItem?.repoOwner, repoName: githubItem?.repoName)
+    return .detail(prId: match.id, laneId: requestLaneId ?? match.laneId, repoScope: repoScope)
   }
 
   if let linkedPrId = githubItem?.linkedPrId?.trimmingCharacters(in: .whitespacesAndNewlines),
      !linkedPrId.isEmpty {
-    return .detail(prId: linkedPrId, laneId: requestLaneId ?? githubItem?.linkedLaneId)
+    let repoScope = requestedRepoScope ?? PrDetailRouteScope(repoOwner: githubItem?.repoOwner, repoName: githubItem?.repoName)
+    return .detail(prId: linkedPrId, laneId: requestLaneId ?? githubItem?.linkedLaneId, repoScope: repoScope)
   }
 
   if let githubItem {

--- a/apps/ios/ADE/Views/PRs/PrHelpers.swift
+++ b/apps/ios/ADE/Views/PRs/PrHelpers.swift
@@ -909,7 +909,7 @@ func normalizePrMarkdownText(_ text: String) -> String {
     .replacingOccurrences(of: "\r\n", with: "\n")
     .replacingOccurrences(of: "\r", with: "\n")
 
-  if normalized.contains("\\n") || normalized.contains("\\r") || normalized.contains("\\t") {
+  if prMarkdownLooksDoubleEscaped(normalized) {
     normalized = normalized
       .replacingOccurrences(of: "\\r\\n", with: "\n")
       .replacingOccurrences(of: "\\n", with: "\n")
@@ -918,6 +918,23 @@ func normalizePrMarkdownText(_ text: String) -> String {
   }
 
   return normalized
+}
+
+private func prMarkdownLooksDoubleEscaped(_ text: String) -> Bool {
+  guard !text.contains("\n"), !text.contains("\r") else { return false }
+  let escapedBreakCount = text.components(separatedBy: "\\n").count - 1
+    + text.components(separatedBy: "\\r").count - 1
+  guard escapedBreakCount >= 2 else { return false }
+  return [
+    "\\n\\n",
+    "\\n#",
+    "\\n- ",
+    "\\n* ",
+    "\\n> ",
+    "\\n```",
+    "\\n1. ",
+    "\\n|",
+  ].contains { text.contains($0) }
 }
 
 private final class PrMarkdownAttributedStringBox: NSObject {

--- a/apps/ios/ADE/Views/PRs/PrHelpers.swift
+++ b/apps/ios/ADE/Views/PRs/PrHelpers.swift
@@ -508,6 +508,24 @@ struct PrDetailRouteScope: Equatable {
   }
 }
 
+func prDetailWarmEntryMatchesRequestedScope(
+  _ entry: PrDetailWarmEntry,
+  requestedRepoScope: PrDetailRouteScope?
+) -> Bool {
+  guard let requestedRepoScope else { return true }
+  let repoOwner = firstNonEmptyPrRepoValue(entry.pr?.repoOwner, entry.githubItem?.repoOwner)
+  let repoName = firstNonEmptyPrRepoValue(entry.pr?.repoName, entry.githubItem?.repoName)
+  guard let repoOwner, let repoName else { return false }
+  return repoOwner.caseInsensitiveCompare(requestedRepoScope.repoOwner) == .orderedSame
+    && repoName.caseInsensitiveCompare(requestedRepoScope.repoName) == .orderedSame
+}
+
+private func firstNonEmptyPrRepoValue(_ values: String?...) -> String? {
+  values
+    .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+    .first { !$0.isEmpty }
+}
+
 enum PrNavigationTarget: Equatable {
   case detail(prId: String, laneId: String?, repoScope: PrDetailRouteScope?)
   case github(GitHubPrListItem)

--- a/apps/ios/ADE/Views/PRs/PrHelpers.swift
+++ b/apps/ios/ADE/Views/PRs/PrHelpers.swift
@@ -447,7 +447,9 @@ func prDetailRouteListItem(
   from items: [PullRequestListItem],
   prId: String,
   requestedPrNumber: Int?,
-  githubItem: GitHubPrListItem?
+  githubItem: GitHubPrListItem?,
+  requestedRepoOwner: String? = nil,
+  requestedRepoName: String? = nil
 ) -> PullRequestListItem? {
   guard let requestedPrNumber else {
     return items.first { $0.id == prId }
@@ -476,6 +478,20 @@ func prDetailRouteListItem(
     }
   }
 
+  if let requestedRepoOwner,
+     let requestedRepoName,
+     !requestedRepoOwner.isEmpty,
+     !requestedRepoName.isEmpty {
+    let repoMatches = candidates.filter {
+      $0.repoOwner.caseInsensitiveCompare(requestedRepoOwner) == .orderedSame
+        && $0.repoName.caseInsensitiveCompare(requestedRepoName) == .orderedSame
+    }
+    if repoMatches.count == 1 {
+      return repoMatches[0]
+    }
+    return nil
+  }
+
   return candidates.count == 1 ? candidates[0] : nil
 }
 
@@ -493,15 +509,21 @@ func prNavigationTarget(
   let prId: String
   let requestLaneId: String?
   let explicitPrNumber: Int?
+  let requestedRepoOwner: String?
+  let requestedRepoName: String?
   switch request.target {
   case .detail(let rawPrId, let prNumber, let laneId):
     prId = rawPrId.trimmingCharacters(in: .whitespacesAndNewlines)
     requestLaneId = laneId
     explicitPrNumber = prNumber
-  case .githubNumber(let prNumber):
+    requestedRepoOwner = nil
+    requestedRepoName = nil
+  case .githubNumber(let prNumber, let repoOwner, let repoName):
     prId = "github-pr-number:\(prNumber)"
     requestLaneId = nil
     explicitPrNumber = prNumber
+    requestedRepoOwner = repoOwner?.trimmingCharacters(in: .whitespacesAndNewlines)
+    requestedRepoName = repoName?.trimmingCharacters(in: .whitespacesAndNewlines)
   case .create:
     return .unresolved
   }
@@ -514,13 +536,23 @@ func prNavigationTarget(
 
   let requestedPrNumber = explicitPrNumber ?? syntheticPrNumber(from: prId)
   guard let requestedPrNumber else { return .unresolved }
-  let githubItem = githubItems.first { $0.githubPrNumber == requestedPrNumber }
+  let githubItem = githubItems.first {
+    guard $0.githubPrNumber == requestedPrNumber else { return false }
+    guard let requestedRepoOwner,
+          let requestedRepoName,
+          !requestedRepoOwner.isEmpty,
+          !requestedRepoName.isEmpty else { return true }
+    return $0.repoOwner.caseInsensitiveCompare(requestedRepoOwner) == .orderedSame
+      && $0.repoName.caseInsensitiveCompare(requestedRepoName) == .orderedSame
+  }
 
   if let match = prDetailRouteListItem(
     from: pullRequests,
     prId: prId,
     requestedPrNumber: requestedPrNumber,
-    githubItem: githubItem
+    githubItem: githubItem,
+    requestedRepoOwner: requestedRepoOwner,
+    requestedRepoName: requestedRepoName
   ) {
     return .detail(prId: match.id, laneId: requestLaneId ?? match.laneId)
   }

--- a/apps/ios/ADE/Views/PRs/PrsRootScreen.swift
+++ b/apps/ios/ADE/Views/PRs/PrsRootScreen.swift
@@ -33,6 +33,7 @@ struct PRsTabView: View {
   @State private var lastPrsLiveSnapshotAttempt = Date.distantPast
   @State private var selectedPrTransitionId: String?
   @State private var laneContextLaneId: String?
+  @State private var prDetailRouteScopes: [String: PrDetailRouteScope] = [:]
   /// Memoized GitHub-list derivations (filter/sort/counts). Recomputed only
   /// when the snapshot or a filter input changes — see `recomputeGitHubDerived`
   /// — instead of on every `body` pass.
@@ -474,9 +475,12 @@ struct PRsTabView: View {
       // Root PR actions now run at the service level (`runDurablePrAction`), so
       // switching tabs must not abort in-flight queue / integration / link work.
       .navigationDestination(for: String.self) { prId in
+        let routeScope = prDetailRouteScopes[prId]
         PrDetailView(
           prId: prId,
-          transitionNamespace: ADEMotion.allowsMatchedGeometry(reduceMotion: reduceMotion) ? prTransitionNamespace : nil
+          transitionNamespace: ADEMotion.allowsMatchedGeometry(reduceMotion: reduceMotion) ? prTransitionNamespace : nil,
+          requestedRepoOwner: routeScope?.repoOwner,
+          requestedRepoName: routeScope?.repoName
         )
           .environmentObject(syncService)
       }
@@ -908,6 +912,9 @@ struct PRsTabView: View {
   private func githubRowNavigation(for item: GitHubPrListItem) -> some View {
     if let prId = item.linkedPrId {
       Button {
+        if let routeScope = PrDetailRouteScope(repoOwner: item.repoOwner, repoName: item.repoName) {
+          prDetailRouteScopes[prId] = routeScope
+        }
         path.append(prId)
       } label: {
         PrRowCard(
@@ -1376,9 +1383,14 @@ struct PRsTabView: View {
     laneContextLaneId = nil
 
     switch target {
-    case .detail(let prId, let laneId):
+    case .detail(let prId, let laneId, let repoScope):
       selectedPrTransitionId = prId
       laneContextLaneId = laneId
+      if let repoScope {
+        prDetailRouteScopes[prId] = repoScope
+      } else {
+        prDetailRouteScopes.removeValue(forKey: prId)
+      }
       path.append(prId)
     case .github(let item):
       if item.scope == "external" {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -372,7 +372,28 @@ final class ADETests: XCTestCase {
 
     DeepLinkRouter.shared.handleNotificationUserInfo(["prNumber": 9876])
 
-    XCTAssertEqual(service.requestedPrNavigation?.target, .githubNumber(9876))
+    XCTAssertEqual(
+      service.requestedPrNavigation?.target,
+      .githubNumber(9876, repoOwner: nil, repoName: nil)
+    )
+  }
+
+  @MainActor
+  func testDeepLinkRouterRoutesScopedPrLinksLocally() throws {
+    let previousShared = SyncService.shared
+    defer { SyncService.shared = previousShared }
+
+    let database = makeDatabase(baseURL: makeTemporaryDirectory())
+    defer { database.close() }
+    let service = SyncService(database: database)
+    SyncService.shared = service
+
+    DeepLinkRouter.shared.handle(try XCTUnwrap(URL(string: "ade://pr/arul28/ADE/729")))
+
+    XCTAssertEqual(
+      service.requestedPrNavigation?.target,
+      .githubNumber(729, repoOwner: "arul28", repoName: "ADE")
+    )
   }
 
   @MainActor
@@ -6686,6 +6707,20 @@ final class ADETests: XCTestCase {
     )
 
     XCTAssertNil(match)
+
+    let scopedMatch = prDetailRouteListItem(
+      from: [
+        item(id: "first", owner: "arul", repo: "ade"),
+        item(id: "second", owner: "elsewhere", repo: "other"),
+      ],
+      prId: "github-pr-number:42",
+      requestedPrNumber: 42,
+      githubItem: nil,
+      requestedRepoOwner: "ARUL",
+      requestedRepoName: "ADE"
+    )
+
+    XCTAssertEqual(scopedMatch?.id, "first")
   }
 
   func testPrNavigationTargetResolvesNumberRouteToLocalPrId() {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -6332,7 +6332,7 @@ final class ADETests: XCTestCase {
       "activeCount": 0,
       "runs": [],
       "prs": [
-        { "id": "pr-42", "prNumber": 42, "title": "Ship mobile PR view", "phase": "merge_ready", "lane": "Mobile PR lane", "updatedAt": 1720000000 }
+        { "id": "pr-42", "prNumber": 42, "title": "Ship mobile PR view", "phase": "merge_ready", "lane": "Mobile PR lane", "repoOwner": "arul28", "repoName": "ADE", "updatedAt": 1720000000 }
       ]
     }
     """.utf8)
@@ -6342,6 +6342,9 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(state.prs[0].prNumber, 42)
     XCTAssertEqual(state.prs[0].resolvedPhase, .mergeReady)
     XCTAssertEqual(state.prs[0].subtitle, "Mobile PR lane")
+    XCTAssertEqual(state.prs[0].repoOwner, "arul28")
+    XCTAssertEqual(state.prs[0].repoName, "ADE")
+    XCTAssertEqual(state.prs[0].deepLinkURL?.absoluteString, "ade://pr/arul28/ADE/42")
   }
 
   @MainActor

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -6762,7 +6762,59 @@ final class ADETests: XCTestCase {
       githubItems: []
     )
 
-    XCTAssertEqual(target, .detail(prId: "pr_42", laneId: "lane-pr_42"))
+    XCTAssertEqual(target, .detail(prId: "pr_42", laneId: "lane-pr_42", repoScope: nil))
+  }
+
+  func testPrNavigationTargetPreservesRepoScopeForDetailRoute() {
+    func item(id: String, owner: String, repo: String) -> PullRequestListItem {
+      PullRequestListItem(
+        id: id,
+        laneId: "lane-\(id)",
+        laneName: nil,
+        projectId: "project-1",
+        repoOwner: owner,
+        repoName: repo,
+        githubPrNumber: 42,
+        githubUrl: "https://github.com/\(owner)/\(repo)/pull/42",
+        title: "\(owner)/\(repo) PR 42",
+        state: "open",
+        baseBranch: "main",
+        headBranch: "feature/42",
+        checksStatus: "passing",
+        reviewStatus: "approved",
+        additions: 1,
+        deletions: 0,
+        lastSyncedAt: nil,
+        createdAt: "2026-05-14T00:00:00.000Z",
+        updatedAt: "2026-05-14T00:00:00.000Z",
+        adeKind: nil,
+        linkedGroupId: nil,
+        linkedGroupType: nil,
+        linkedGroupName: nil,
+        linkedGroupPosition: nil,
+        linkedGroupCount: 0,
+        workflowDisplayState: nil,
+        cleanupState: nil
+      )
+    }
+
+    let target = prNavigationTarget(
+      for: PrNavigationRequest(prNumber: 42, repoOwner: "ARUL", repoName: "ade"),
+      pullRequests: [
+        item(id: "api-pr", owner: "elsewhere", repo: "api"),
+        item(id: "ade-pr", owner: "arul", repo: "ADE"),
+      ],
+      githubItems: []
+    )
+
+    XCTAssertEqual(
+      target,
+      .detail(
+        prId: "ade-pr",
+        laneId: "lane-ade-pr",
+        repoScope: PrDetailRouteScope(repoOwner: "ARUL", repoName: "ade")
+      )
+    )
   }
 
   func testPrNavigationTargetUsesGitHubItemWhenNumberRouteHasNoLocalPr() {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -6325,6 +6325,25 @@ final class ADETests: XCTestCase {
     XCTAssertNil(state.runs[1].itemId, "runs without an itemId key decode to nil")
   }
 
+  func testAgentRunsContentStateDecodesPullRequestRows() throws {
+    let json = Data("""
+    {
+      "updatedAt": 1720000000,
+      "activeCount": 0,
+      "runs": [],
+      "prs": [
+        { "id": "pr-42", "prNumber": 42, "title": "Ship mobile PR view", "phase": "merge_ready", "lane": "Mobile PR lane", "updatedAt": 1720000000 }
+      ]
+    }
+    """.utf8)
+
+    let state = try JSONDecoder().decode(ADEAgentRunsAttributes.ContentState.self, from: json)
+    XCTAssertEqual(state.prs.count, 1)
+    XCTAssertEqual(state.prs[0].prNumber, 42)
+    XCTAssertEqual(state.prs[0].resolvedPhase, .mergeReady)
+    XCTAssertEqual(state.prs[0].subtitle, "Mobile PR lane")
+  }
+
   @MainActor
   func testSyncMergedRelayCandidatesFoldsAdvertisedFreshestFirst() {
     let service = SyncService(database: makeDatabase(baseURL: makeTemporaryDirectory()))
@@ -8822,6 +8841,9 @@ final class ADETests: XCTestCase {
         parentToolUseId: "call-old",
         description: "Old helper",
         background: false,
+        label: nil,
+        model: nil,
+        reasoningEffort: nil,
         status: .stopped,
         lastToolName: nil,
         latestSummary: "Finished earlier",
@@ -8836,6 +8858,9 @@ final class ADETests: XCTestCase {
         parentToolUseId: "call-new",
         description: "Throwaway ADE mobile subagent UI test",
         background: false,
+        label: nil,
+        model: nil,
+        reasoningEffort: nil,
         status: .running,
         lastToolName: nil,
         latestSummary: nil,
@@ -8852,6 +8877,9 @@ final class ADETests: XCTestCase {
         parentToolUseId: "call-new",
         description: "Local detail",
         background: false,
+        label: nil,
+        model: nil,
+        reasoningEffort: nil,
         status: .stopped,
         lastToolName: "Read",
         latestSummary: "Parent turn completed before ADE received a final subagent status",

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -6817,6 +6817,65 @@ final class ADETests: XCTestCase {
     )
   }
 
+  func testPrWarmEntryMatchesRequestedRepoScope() {
+    let pr = PullRequestListItem(
+      id: "ade-pr",
+      laneId: "lane-ade-pr",
+      laneName: nil,
+      projectId: "project-1",
+      repoOwner: "arul",
+      repoName: "ADE",
+      githubPrNumber: 42,
+      githubUrl: "https://github.com/arul/ADE/pull/42",
+      title: "arul/ADE PR 42",
+      state: "open",
+      baseBranch: "main",
+      headBranch: "feature/42",
+      checksStatus: "passing",
+      reviewStatus: "approved",
+      additions: 1,
+      deletions: 0,
+      lastSyncedAt: nil,
+      createdAt: "2026-05-14T00:00:00.000Z",
+      updatedAt: "2026-05-14T00:00:00.000Z",
+      adeKind: nil,
+      linkedGroupId: nil,
+      linkedGroupType: nil,
+      linkedGroupName: nil,
+      linkedGroupPosition: nil,
+      linkedGroupCount: 0,
+      workflowDisplayState: nil,
+      cleanupState: nil
+    )
+    let entry = PrDetailWarmEntry(
+      pr: pr,
+      githubItem: nil,
+      snapshot: nil,
+      reviewThreads: [],
+      actionRuns: [],
+      activityEvents: [],
+      deployments: [],
+      aiSummary: nil,
+      groupMembers: [],
+      capabilities: nil,
+      loadedAt: Date(timeIntervalSince1970: 0)
+    )
+
+    XCTAssertTrue(prDetailWarmEntryMatchesRequestedScope(entry, requestedRepoScope: nil))
+    XCTAssertTrue(
+      prDetailWarmEntryMatchesRequestedScope(
+        entry,
+        requestedRepoScope: PrDetailRouteScope(repoOwner: "ARUL", repoName: "ade")
+      )
+    )
+    XCTAssertFalse(
+      prDetailWarmEntryMatchesRequestedScope(
+        entry,
+        requestedRepoScope: PrDetailRouteScope(repoOwner: "elsewhere", repoName: "ADE")
+      )
+    )
+  }
+
   func testPrNavigationTargetUsesGitHubItemWhenNumberRouteHasNoLocalPr() {
     let githubItem = GitHubPrListItem(
       id: "repo-pr-42",

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -6811,6 +6811,17 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(fallback, prParsedDate("2026-05-14T00:00:00Z"))
   }
 
+  func testPrMarkdownNormalizationOnlyUnescapesDoubleEscapedBodies() {
+    XCTAssertEqual(
+      normalizePrMarkdownText("Summary\\n\\n- item one\\n- item two"),
+      "Summary\n\n- item one\n- item two"
+    )
+    XCTAssertEqual(
+      normalizePrMarkdownText("Inline code `foo\\nbar` should stay literal"),
+      "Inline code `foo\\nbar` should stay literal"
+    )
+  }
+
   func testPrDetailSidecarFetchPolicySkipsLocalRevisionAfterInitialLoad() {
     XCTAssertTrue(shouldFetchPrDetailLiveSidecars(hasLoadedLiveSidecars: false, refreshRemote: false))
     XCTAssertFalse(shouldFetchPrDetailLiveSidecars(hasLoadedLiveSidecars: true, refreshRemote: false))

--- a/apps/ios/ADEWidgets/ADEAgentActivityWidget.swift
+++ b/apps/ios/ADEWidgets/ADEAgentActivityWidget.swift
@@ -149,6 +149,9 @@ struct AgentRunsPresentation {
 
     var destinationURL: URL {
         let workspace = URL(string: "ade://workspace") ?? URL(fileURLWithPath: "/")
+        if let prUrl = prs.first(where: { $0.resolvedPhase.needsAttention })?.deepLinkURL {
+            return prUrl
+        }
         let target = runs.first(where: { $0.resolvedPhase.needsAttention }) ?? primary
         guard let id = target?.id.trimmingCharacters(in: .whitespacesAndNewlines),
               !id.isEmpty else {

--- a/apps/ios/ADEWidgets/ADEAgentActivityWidget.swift
+++ b/apps/ios/ADEWidgets/ADEAgentActivityWidget.swift
@@ -27,7 +27,7 @@ struct ADEAgentActivityWidget: Widget {
             )
             return DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
-                    Image(systemName: presentation.primary?.resolvedPhase.symbol ?? "circle.dotted")
+                    Image(systemName: presentation.primarySymbol)
                         .font(.system(size: 15, weight: .semibold))
                         .foregroundStyle(presentation.tint)
                 }
@@ -38,6 +38,11 @@ struct ADEAgentActivityWidget: Widget {
                     VStack(alignment: .leading, spacing: 4) {
                         ForEach(presentation.runs.prefix(2)) { run in
                             AgentRunRow(run: run, compact: true)
+                        }
+                        if presentation.runs.isEmpty {
+                            ForEach(presentation.prs.prefix(2)) { pr in
+                                PullRequestActivityRow(pr: pr, compact: true)
+                            }
                         }
                         if presentation.isStale {
                             AgentRunsStaleHint()
@@ -54,7 +59,7 @@ struct ADEAgentActivityWidget: Widget {
                     }
                 }
             } compactLeading: {
-                Image(systemName: presentation.primary?.resolvedPhase.symbol ?? "circle.dotted")
+                Image(systemName: presentation.primarySymbol)
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(presentation.tint)
             } compactTrailing: {
@@ -63,7 +68,7 @@ struct ADEAgentActivityWidget: Widget {
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(ADESharedTheme.warningAmber)
                 } else {
-                    Text("\(presentation.activeCount)")
+                    Text("\(presentation.glanceCount)")
                         .font(.system(size: 13, weight: .bold))
                         .foregroundStyle(presentation.tint)
                 }
@@ -82,9 +87,11 @@ struct ADEAgentActivityWidget: Widget {
 
 struct AgentRunsPresentation {
     let runs: [ADEAgentRunsAttributes.Run]
+    let prs: [ADEAgentRunsAttributes.PullRequest]
     let activeCount: Int
     let waitingCount: Int
     let primary: ADEAgentRunsAttributes.Run?
+    let primaryPr: ADEAgentRunsAttributes.PullRequest?
     let isStale: Bool
     let machineName: String
 
@@ -96,9 +103,18 @@ struct AgentRunsPresentation {
             return l < r
         }
         self.runs = Array(sorted.prefix(3))
+        let sortedPrs = Array(state.prs.sorted { lhs, rhs in
+            let l = lhs.resolvedPhase.needsAttention ? 0 : 1
+            let r = rhs.resolvedPhase.needsAttention ? 0 : 1
+            if l != r { return l < r }
+            return lhs.updatedAt > rhs.updatedAt
+        }.prefix(2))
+        self.prs = sortedPrs
         self.activeCount = max(state.activeCount, state.runs.count)
         self.waitingCount = state.runs.filter { $0.resolvedPhase.needsAttention }.count
+            + state.prs.filter { $0.resolvedPhase.needsAttention }.count
         self.primary = sorted.first
+        self.primaryPr = sortedPrs.first
         self.isStale = isStale || state.runs.contains { $0.resolvedPhase == .stale }
         self.machineName = attributes.machineName
     }
@@ -108,7 +124,16 @@ struct AgentRunsPresentation {
     var tint: Color {
         if isStale { return ADESharedTheme.statusIdle }
         if waitingCount > 0 { return ADESharedTheme.warningAmber }
+        if let primaryPr, primary == nil { return primaryPr.resolvedPhase.tint }
         return primary?.resolvedPhase.tint ?? ADESharedTheme.statusIdle
+    }
+
+    var primarySymbol: String {
+        primary?.resolvedPhase.symbol ?? primaryPr?.resolvedPhase.symbol ?? "circle.dotted"
+    }
+
+    var glanceCount: Int {
+        max(activeCount, prs.count)
     }
 
     /// Footer only earns its space when there's more than one run or a machine
@@ -126,7 +151,12 @@ struct AgentRunsPresentation {
         let workspace = URL(string: "ade://workspace") ?? URL(fileURLWithPath: "/")
         let target = runs.first(where: { $0.resolvedPhase.needsAttention }) ?? primary
         guard let id = target?.id.trimmingCharacters(in: .whitespacesAndNewlines),
-              !id.isEmpty else { return workspace }
+              !id.isEmpty else {
+            if let prNumber = primaryPr?.prNumber, prNumber > 0, let prUrl = URL(string: "ade://pr/\(prNumber)") {
+                return prUrl
+            }
+            return workspace
+        }
         var allowed = CharacterSet.alphanumerics
         allowed.insert(charactersIn: "-._~")
         guard let encoded = id.addingPercentEncoding(withAllowedCharacters: allowed),
@@ -162,7 +192,7 @@ private struct AgentRunsLockScreenView: View {
                 }
             }
 
-            if presentation.runs.isEmpty {
+            if presentation.runs.isEmpty && presentation.prs.isEmpty {
                 Text("No active runs")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
@@ -170,6 +200,9 @@ private struct AgentRunsLockScreenView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     ForEach(presentation.runs) { run in
                         AgentRunRow(run: run, compact: false)
+                    }
+                    ForEach(presentation.prs) { pr in
+                        PullRequestActivityRow(pr: pr, compact: false)
                     }
                 }
             }
@@ -185,7 +218,10 @@ private struct AgentRunsLockScreenView: View {
 
     private var headline: String {
         if presentation.waitingCount > 0 {
-            return presentation.waitingCount == 1 ? "1 run needs you" : "\(presentation.waitingCount) runs need you"
+            return presentation.waitingCount == 1 ? "1 item needs you" : "\(presentation.waitingCount) items need you"
+        }
+        if presentation.runs.isEmpty && !presentation.prs.isEmpty {
+            return presentation.prs.count == 1 ? "1 pull request updated" : "\(presentation.prs.count) pull requests updated"
         }
         let count = presentation.activeCount
         return count == 1 ? "1 agent running" : "\(count) agents running"
@@ -299,6 +335,51 @@ private struct AgentRunRow: View {
         let detail = run.detail?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let detail, !detail.isEmpty { return detail }
         return run.subtitle
+    }
+}
+
+private struct PullRequestActivityRow: View {
+    let pr: ADEAgentRunsAttributes.PullRequest
+    let compact: Bool
+
+    private var phase: PullRequestPhase { pr.resolvedPhase }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: phase.symbol)
+                .font(.system(size: compact ? 10 : 11, weight: .semibold))
+                .foregroundStyle(phase.tint)
+                .frame(width: 14, alignment: .center)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text("#\(pr.prNumber) \(pr.title)")
+                    .font(.system(size: compact ? 11 : 12.5, weight: .medium))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+                if let subtitle = pr.subtitle {
+                    Text(subtitle)
+                        .font(.system(size: compact ? 9 : 10, weight: .regular))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.85)
+                }
+            }
+
+            Spacer(minLength: 4)
+
+            Text(phase.label)
+                .font(.system(size: compact ? 9 : 9.5, weight: .semibold))
+                .foregroundStyle(phase.needsAttention ? phase.tint : .secondary)
+                .lineLimit(1)
+        }
+        .padding(.vertical, phase.needsAttention && !compact ? 3 : 0)
+        .padding(.horizontal, phase.needsAttention && !compact ? 6 : 0)
+        .background(
+            phase.needsAttention && !compact
+                ? RoundedRectangle(cornerRadius: 7, style: .continuous).fill(phase.tint.opacity(0.14))
+                : nil
+        )
     }
 }
 

--- a/apps/ios/ADEWidgets/ADEAgentActivityWidget.swift
+++ b/apps/ios/ADEWidgets/ADEAgentActivityWidget.swift
@@ -149,10 +149,16 @@ struct AgentRunsPresentation {
 
     var destinationURL: URL {
         let workspace = URL(string: "ade://workspace") ?? URL(fileURLWithPath: "/")
+        let attentionRun = runs.first(where: { $0.resolvedPhase.needsAttention })
+        if let id = attentionRun?.id.trimmingCharacters(in: .whitespacesAndNewlines),
+           !id.isEmpty,
+           let url = sessionURL(for: id) {
+            return url
+        }
         if let prUrl = prs.first(where: { $0.resolvedPhase.needsAttention })?.deepLinkURL {
             return prUrl
         }
-        let target = runs.first(where: { $0.resolvedPhase.needsAttention }) ?? primary
+        let target = primary
         guard let id = target?.id.trimmingCharacters(in: .whitespacesAndNewlines),
               !id.isEmpty else {
             if let prUrl = primaryPr?.deepLinkURL {
@@ -160,11 +166,15 @@ struct AgentRunsPresentation {
             }
             return workspace
         }
+        return sessionURL(for: id) ?? workspace
+    }
+
+    private func sessionURL(for id: String) -> URL? {
         var allowed = CharacterSet.alphanumerics
         allowed.insert(charactersIn: "-._~")
         guard let encoded = id.addingPercentEncoding(withAllowedCharacters: allowed),
               let url = URL(string: "ade://session/\(encoded)") else {
-            return workspace
+            return nil
         }
         return url
     }

--- a/apps/ios/ADEWidgets/ADEAgentActivityWidget.swift
+++ b/apps/ios/ADEWidgets/ADEAgentActivityWidget.swift
@@ -152,7 +152,7 @@ struct AgentRunsPresentation {
         let target = runs.first(where: { $0.resolvedPhase.needsAttention }) ?? primary
         guard let id = target?.id.trimmingCharacters(in: .whitespacesAndNewlines),
               !id.isEmpty else {
-            if let prNumber = primaryPr?.prNumber, prNumber > 0, let prUrl = URL(string: "ade://pr/\(prNumber)") {
+            if let prUrl = primaryPr?.deepLinkURL {
                 return prUrl
             }
             return workspace
@@ -393,7 +393,7 @@ private struct AgentRunsCountBadge: View {
                 .labelStyle(.titleAndIcon)
                 .foregroundStyle(ADESharedTheme.warningAmber)
         } else {
-            Text("\(presentation.activeCount)")
+            Text("\(presentation.glanceCount)")
                 .font(.system(size: 15, weight: .bold))
                 .foregroundStyle(presentation.tint)
         }

--- a/docs/features/pull-requests/README.md
+++ b/docs/features/pull-requests/README.md
@@ -362,8 +362,9 @@ desktop main process for local-bound windows (see
    `lastSyncedAt`, `createdAt`, `updatedAt`, `projectId`).
 3. Diffs against last seen fingerprints; only changed PRs trigger
    events/UI updates.
-4. Emits `PrEventPayload` for state transitions (checks failing,
-   review requested, changes requested, merge ready).
+4. Emits `PrEventPayload` for lifecycle and status transitions
+   (opened, reopened, closed, merged, checks failing, review requested,
+   changes requested, merge ready).
 
 When `prService` reports zero tracked PRs, the tick can force a full
 repo-snapshot discovery (`discoverLanePullRequests`). Because that is
@@ -733,6 +734,16 @@ projection revision: webhook-driven host updates rewrite the replicated
 snapshot rows, the changeset pump bumps the projection, and the detail
 screen re-fetches the sidecars at most once every 25 s. See
 [iOS companion → PR detail screen](../sync-and-multi-device/ios-companion.md#pr-detail-screen).
+
+The mobile detail header is intentionally compact: a plain back chevron,
+centered PR title with `#number · lane · branch`, and a plain ellipsis
+actions button. The old large PR hero is replaced by a small summary section
+showing state, merge/check status, diff totals, and commit count. Commit rows
+expand inline and tap into the same timeline anchors that desktop uses for
+commit-focused navigation. Markdown bodies are normalized for escaped GitHub
+newlines and rendered through the shared mobile Work markdown renderer;
+collapsed comment/thread previews stay cheap text so large PRs do not pay
+markdown layout cost for offscreen or folded content.
 
 ## Gotchas
 

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -749,13 +749,17 @@ contract) is documented in
   on every foreground transition (`PushNotificationService.clearAppBadge`,
   called from `ADEApp`'s scene-phase handler) so a lingering count never
   reads as stale.
-- **Live Activity** mirrors up to three active agent runs on the Lock
-  Screen and Dynamic Island. `LiveActivityService` starts one aggregate
-  activity per machine (`activityId: "agent-runs"`), applies brain-pushed
-  content-state updates, and ends it when all runs reach a terminal
-  phase. `NSSupportsLiveActivities` / `FrequentUpdates` are declared in
-  `Info.plist` and the `aps-environment` entitlement + `remote-notification`
-  background mode are in `ADE.entitlements`.
+- **Live Activity** mirrors up to three active agent runs plus up to two
+  recent PR lifecycle/status rows on the Lock Screen and Dynamic Island.
+  `LiveActivityService` starts one aggregate activity per machine
+  (`activityId: "agent-runs"`), applies brain-pushed content-state updates,
+  and ends it when all runs are terminal and the short-lived PR rows expire.
+  PR rows are sourced from the same `pr-notification` fan-out as desktop
+  toasts and cover opened, reopened, closed, merged, checks failing, changes
+  requested, review requested, and merge-ready states. `NSSupportsLiveActivities`
+  / `FrequentUpdates` are declared in `Info.plist` and the
+  `aps-environment` entitlement + `remote-notification` background mode are
+  in `ADE.entitlements`.
 - **Settings > Push delivery** (`SettingsPushDeliverySection`, wired from
   `ConnectionSettingsView` via `SettingsConnectionPresentationModel`)
   shows registration state, token suffix, APNs environment, last push
@@ -1085,25 +1089,32 @@ The detail screen is a single-column adaptation of the desktop
 Timeline+Rails PR view. Its Overview is emitted as sibling `List` rows
 (`overviewThreadRows`) rather than a single nested card, so the `List`
 virtualizes offscreen thread content instead of laying out the whole PR on
-every scroll frame. Reading order (desktop parity, folded to one column):
+every scroll frame. The navigation header uses a plain back chevron, centered
+PR title with `#number · lane · branch`, and a plain ellipsis actions button.
+Reading order (desktop parity, folded to one column):
 
-1. an unmapped-PR banner (`PrUnmappedThreadBanner`) when the PR has no ADE
+1. a compact summary section (`PrDetailSummarySection`) with state, merge/check
+   status, diff totals, and an expandable commit list whose rows jump to the
+   matching timeline anchor;
+2. an unmapped-PR banner (`PrUnmappedThreadBanner`) when the PR has no ADE
    lane, offering auto-map (`prs.createLaneFromPrBranch`) or Open in GitHub;
-2. the AI summary card (`PrAiSummaryCard`, +/- totals from the file list);
-3. the PR description (`PrThreadDescriptionCard`);
-4. a chronological event feed — one row per timeline event or folded
+3. the AI summary card (`PrAiSummaryCard`, +/- totals from the file list);
+4. the PR description (`PrThreadDescriptionCard`);
+5. a chronological event feed — one row per timeline event or folded
    commit group, ascending oldest → newest, built by
    `buildPullRequestTimeline` and folded via `buildPrTimelineDisplayItems`
    (`PrDetailActivityTab.swift`) so runs of same-author commits collapse
    into a single group row;
-5. review threads (unresolved first, resolved folded into a collapsible
-   section);
-6. the comment composer (locked for unmapped PRs);
-7. the inline merge rail (`PrOverviewMergeRail`) carrying the desktop
+6. review threads (unresolved first, resolved folded into a collapsible
+   section). Individual thread/comment cards are also collapsible on mobile:
+   folded rows use cheap inline preview text, while expanded rows render the
+   full normalized markdown body through `WorkMarkdownRenderer`;
+7. the comment composer (locked for unmapped PRs);
+8. the inline merge rail (`PrOverviewMergeRail`) carrying the desktop
    GitHub-style requirement checklist (`PrMergeChecklist` —
    conflicts / behind-base / checks / review), the merge-method sheet, and
    admin-bypass gating;
-8. metadata cards — checks, commits, files, people, and the stack card,
+9. metadata cards — checks, commits, files, people, and the stack card,
    plus a post-merge cleanup banner.
 
 There is no separate Activity sub-tab — the activity feed lives inside


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstart-skill-mobile-prs-view-c2520191 num=729 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstart-skill-mobile-prs-view-c2520191&amp;pr=729">ade/start-skill-mobile-prs-view-c2520191 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=729">PR #729</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PR lifecycle notifications (opened/reopened/closed/merged) end-to-end across desktop and iOS.
  * PR activity is now included in Live Activities, and PRs are also surfaced in the iOS widgets.
  * Improved PR detail UI with a compact summary section, better commit/timeline navigation, and scoped PR deep links.

* **Bug Fixes**
  * Improved PR markdown normalization for more consistent rendering.
  * Updated PR toast tone and alert copy so lifecycle events are presented with the correct style and priority.

* **Tests**
  * Expanded automated coverage for PR lifecycle, Live Activity aggregation, scoped routing, and notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds PR lifecycle activity across desktop, CLI push, and iOS. The main changes are:

- PR lifecycle notifications and Live Activity rows.
- Repo-scoped PR deep links and navigation state.
- iOS PR widget and detail screen updates.
- Expanded tests for PR notifications, routing, and sync behavior.

<h3>Confidence Score: 4/5</h3>

The scoped notification path still needs a fix before merging.

Repo owner and name now flow through most PR notification paths, but the notification branch that receives prId drops that scope.

apps/ios/ADE/App/DeepLinkRouter.swift

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the notification-scope drop by running a focused source-backed harness against the real DeepLinkRouter.swift to exercise the handleNotificationUserInfo branch for a notification containing prId, prNumber, repoOwner, and repoName.
- Observed that the adeDeepLinkRequested payload included kind, identifier, and prNumber but omitted repoOwner and repoName, while the prNumber-only branch includes those scope arguments.
- Verified end-to-end test validation by reviewing CLI and desktop proof logs, both exiting with code 0, and examined the notes artifact for command, cwd, exit-code details and iOS tool blockers.

<a href="https://app.greptile.com/trex/runs/13641997/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/services/push/pushPublisherService.ts | Adds repo-scoped PR activity IDs, scoped PR deep links, PR lifecycle alert copy, and PR Live Activity expiry. |
| apps/ios/ADE/App/DeepLinkRouter.swift | Accepts scoped PR URLs and notification payload scope, but one notification branch still drops repo owner/name. |
| apps/ios/ADE/Views/PRs/PrDetailScreen.swift | Passes requested repo scope into detail loading and adds delayed timeline scrolling for commit taps. |
| apps/ios/ADE/Views/PRs/PrHelpers.swift | Adds repo-scope helpers for PR detail route selection and warm-cache validation. |
| apps/ios/ADE/Views/PRs/PrsRootScreen.swift | Stores scoped PR route data and passes it into PR detail navigation. |


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `apps/ios/ADE/Views/PRs/PrDetailScreen.swift`, line 1303-1308 ([link](https://github.com/arul28/ade/blob/006ea879bc8c67530baeb0878ab610ffea51b5dc/apps/ios/ADE/Views/PRs/PrDetailScreen.swift#L1303-L1308)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Scoped Route Loses Repo**

   When a repo-scoped PR notification opens a synthetic `github-pr-number:<n>` route, this reload path calls `prDetailRouteListItem` without the requested owner and repo. If two tracked repositories both have PR `#42`, a later reload can resolve only by number and leave the detail screen on the wrong PR or no PR.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ios/ADE/Views/PRs/PrDetailScreen.swift
   Line: 1303-1308

   Comment:
   **Scoped Route Loses Repo**

   When a repo-scoped PR notification opens a synthetic `github-pr-number:<n>` route, this reload path calls `prDetailRouteListItem` without the requested owner and repo. If two tracked repositories both have PR `#42`, a later reload can resolve only by number and leave the detail screen on the wrong PR or no PR.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fios%2FADE%2FViews%2FPRs%2FPrDetailScreen.swift%0ALine%3A%201303-1308%0A%0AComment%3A%0A**Scoped%20Route%20Loses%20Repo**%0A%0AWhen%20a%20repo-scoped%20PR%20notification%20opens%20a%20synthetic%20%60github-pr-number%3A%3Cn%3E%60%20route%2C%20this%20reload%20path%20calls%20%60prDetailRouteListItem%60%20without%20the%20requested%20owner%20and%20repo.%20If%20two%20tracked%20repositories%20both%20have%20PR%20%60%2342%60%2C%20a%20later%20reload%20can%20resolve%20only%20by%20number%20and%20leave%20the%20detail%20screen%20on%20the%20wrong%20PR%20or%20no%20PR.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=729&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

2. `apps/ios/ADE/Views/PRs/PrDetailScreen.swift`, line 1445-1450 ([link](https://github.com/arul28/ade/blob/006ea879bc8c67530baeb0878ab610ffea51b5dc/apps/ios/ADE/Views/PRs/PrDetailScreen.swift#L1445-L1450)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Fallback Match Ignores Repo**

   The fallback GitHub item lookup scans all repo PRs and accepts the first matching `githubPrNumber` without checking the scoped owner and repo. Tapping a notification for `ownerA/repoA#42` can hydrate the detail screen with `ownerB/repoB#42` when that item appears first.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ios/ADE/Views/PRs/PrDetailScreen.swift
   Line: 1445-1450

   Comment:
   **Fallback Match Ignores Repo**

   The fallback GitHub item lookup scans all repo PRs and accepts the first matching `githubPrNumber` without checking the scoped owner and repo. Tapping a notification for `ownerA/repoA#42` can hydrate the detail screen with `ownerB/repoB#42` when that item appears first.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fios%2FADE%2FViews%2FPRs%2FPrDetailScreen.swift%0ALine%3A%201445-1450%0A%0AComment%3A%0A**Fallback%20Match%20Ignores%20Repo**%0A%0AThe%20fallback%20GitHub%20item%20lookup%20scans%20all%20repo%20PRs%20and%20accepts%20the%20first%20matching%20%60githubPrNumber%60%20without%20checking%20the%20scoped%20owner%20and%20repo.%20Tapping%20a%20notification%20for%20%60ownerA%2FrepoA%2342%60%20can%20hydrate%20the%20detail%20screen%20with%20%60ownerB%2FrepoB%2342%60%20when%20that%20item%20appears%20first.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=729&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

3. `apps/ios/ADE/App/DeepLinkRouter.swift`, line 205 ([link](https://github.com/arul28/ade/blob/bd81b876896a4326856252e5aa553ad8c7e758ad/apps/ios/ADE/App/DeepLinkRouter.swift#L205)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Notification Scope Is Dropped**

   When a PR notification includes both `prId` and repo scope, this branch posts the navigation request without `repoOwner` or `repoName`. Tapping a scoped notification for `ownerA/repoA#42` can still enter the unscoped PR route and resolve the wrong duplicate PR.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: Swift and xcodebuild availability check output](https://app.greptile.com/trex/artifacts/b79a2deb-d893-4cd3-b74e-ce14fee25403)**

   - Keeps the command output available without making the summary code-heavy.

   **[Repro: focused source-backed notification scope harness](https://app.greptile.com/trex/artifacts/a5c1f871-0241-4e1c-a9d5-522463c3d113)**

   - Contains supporting evidence from the run (text/x-python; charset=utf-8).

   **[Repro: harness execution output showing scoped notification becomes unscoped](https://app.greptile.com/trex/artifacts/80d773d5-4a4e-4f3f-9b18-30dffe8a10ad)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/13641997/artifacts?artifact=b79a2deb-d893-4cd3-b74e-ce14fee25403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ios/ADE/App/DeepLinkRouter.swift
   Line: 205

   Comment:
   **Notification Scope Is Dropped**

   When a PR notification includes both `prId` and repo scope, this branch posts the navigation request without `repoOwner` or `repoName`. Tapping a scoped notification for `ownerA/repoA#42` can still enter the unscoped PR route and resolve the wrong duplicate PR.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fios%2FADE%2FApp%2FDeepLinkRouter.swift%0ALine%3A%20205%0A%0AComment%3A%0A**Notification%20Scope%20Is%20Dropped**%0A%0AWhen%20a%20PR%20notification%20includes%20both%20%60prId%60%20and%20repo%20scope%2C%20this%20branch%20posts%20the%20navigation%20request%20without%20%60repoOwner%60%20or%20%60repoName%60.%20Tapping%20a%20scoped%20notification%20for%20%60ownerA%2FrepoA%2342%60%20can%20still%20enter%20the%20unscoped%20PR%20route%20and%20resolve%20the%20wrong%20duplicate%20PR.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=729&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fios%2FADE%2FApp%2FDeepLinkRouter.swift%3A205%0A**Notification%20Scope%20Is%20Dropped**%0A%0AWhen%20a%20PR%20notification%20includes%20both%20%60prId%60%20and%20repo%20scope%2C%20this%20branch%20posts%20the%20navigation%20request%20without%20%60repoOwner%60%20or%20%60repoName%60.%20Tapping%20a%20scoped%20notification%20for%20%60ownerA%2FrepoA%2342%60%20can%20still%20enter%20the%20unscoped%20PR%20route%20and%20resolve%20the%20wrong%20duplicate%20PR.%0A%0A&repo=arul28%2Fade&pr=729&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/ios/ADE/App/DeepLinkRouter.swift:205
**Notification Scope Is Dropped**

When a PR notification includes both `prId` and repo scope, this branch posts the navigation request without `repoOwner` or `repoName`. Tapping a scoped notification for `ownerA/repoA#42` can still enter the unscoped PR route and resolve the wrong duplicate PR.


`````

</details>

<sub>Reviews (9): Last reviewed commit: ["ship: iteration 8 address repeat PR aler..."](https://github.com/arul28/ade/commit/bd81b876896a4326856252e5aa553ad8c7e758ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42582661)</sub>

<!-- /greptile_comment -->