### PR TITLE
fix: stabilize release runtime archive validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,8 +352,11 @@ jobs:
       - name: Smoke test ADE runtime binary
         run: |
           apps/ade-cli/dist-static/ade-${{ matrix.target }} --version
-          tar -tzf apps/ade-cli/dist-static/ade-${{ matrix.target }}.native.tar.gz | grep -q '^\./node_modules/'
-          if tar -tzf apps/ade-cli/dist-static/ade-${{ matrix.target }}.native.tar.gz | grep -Eq '^\./node_modules/opencode-(darwin|linux|windows)-'; then
+          archive="apps/ade-cli/dist-static/ade-${{ matrix.target }}.native.tar.gz"
+          archive_listing="$RUNNER_TEMP/ade-${{ matrix.target }}-native-files.txt"
+          tar -tzf "$archive" > "$archive_listing"
+          grep -q '^\./node_modules/' "$archive_listing"
+          if grep -Eq '^\./node_modules/opencode-(darwin|linux|windows)-' "$archive_listing"; then
             echo "Unexpected duplicate OpenCode platform package in native runtime archive"
             exit 1
           fi

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -407,8 +407,11 @@ jobs:
       - name: Smoke test ADE runtime binary
         run: |
           apps/ade-cli/dist-static/ade-${{ matrix.target }} --version
-          tar -tzf apps/ade-cli/dist-static/ade-${{ matrix.target }}.native.tar.gz | grep -q '^\./node_modules/'
-          if tar -tzf apps/ade-cli/dist-static/ade-${{ matrix.target }}.native.tar.gz | grep -Eq '^\./node_modules/opencode-(darwin|linux|windows)-'; then
+          archive="apps/ade-cli/dist-static/ade-${{ matrix.target }}.native.tar.gz"
+          archive_listing="$RUNNER_TEMP/ade-${{ matrix.target }}-native-files.txt"
+          tar -tzf "$archive" > "$archive_listing"
+          grep -q '^\./node_modules/' "$archive_listing"
+          if grep -Eq '^\./node_modules/opencode-(darwin|linux|windows)-' "$archive_listing"; then
             echo "Unexpected duplicate OpenCode platform package in native runtime archive"
             exit 1
           fi
@@ -533,7 +536,9 @@ jobs:
           for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
             require_file "release-assets/runtime/ade-$target" "ADE runtime binary for $target"
             require_file "release-assets/runtime/ade-$target.native.tar.gz" "ADE native dependency archive for $target"
-            tar -tzf "release-assets/runtime/ade-$target.native.tar.gz" | grep -q '^\./node_modules/' || {
+            archive_listing="$RUNNER_TEMP/ade-$target-native-files.txt"
+            tar -tzf "release-assets/runtime/ade-$target.native.tar.gz" > "$archive_listing"
+            grep -q '^\./node_modules/' "$archive_listing" || {
               echo "::error::ADE native dependency archive for $target is missing node_modules."
               exit 1
             }


### PR DESCRIPTION
## Summary
- avoid `tar | grep -q` under pipefail in release publish validation
- reuse a tar listing file for runtime archive smoke checks in CI and release

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/release-core.yml .github/workflows/ci.yml`

This fixes the false-negative publish failure hit during v1.2.14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release and runtime validation checks to make archive verification more reliable.
  * Reduced repeated archive scanning during automated checks, helping the build and release process run more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes ADE runtime archive validation in GitHub Actions. The main changes are:

- Writes each `tar -tzf` listing to a target-specific temp file.
- Reuses the listing for runtime archive smoke checks.
- Applies the same listing-file pattern during release asset validation.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code. Tar listing failures still stop the workflow, and target-specific temp filenames avoid stale listing reuse across matrix targets and release validation loop iterations.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- GitHub Actions workflows were parsed successfully and exited with code 0.
- A reproducible smoke snippet shell harness for the synthetic archive check was generated.
- The smoke snippet run demonstrated tar listing reuse and that the grep checks passed under strict shell options with exit status 0.
- The captured tar listing artifact used by the smoke snippet was produced.

<a href="https://app.greptile.com/trex/runs/13688850/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Refactors the ADE runtime smoke test to validate a cached tar listing from `$RUNNER_TEMP`. |
| .github/workflows/release-core.yml | Refactors runtime smoke checks and release asset validation to reuse target-specific tar listing files. |

<sub>Reviews (1): Last reviewed commit: ["fix: stabilize release runtime archive v..."](https://github.com/arul28/ade/commit/473f463c0181a6c1feb24b23d52850f8a87f52d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42705915)</sub>

<!-- /greptile_comment -->