### PR TITLE
Mobile Chat Image Attachments

### DIFF
--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -1821,7 +1821,7 @@ struct AgentChatEventHistoryPage: Decodable, Equatable {
   var sessionFound: Bool
 }
 
-struct AgentChatFileRef: Codable, Equatable {
+struct AgentChatFileRef: Codable, Equatable, Hashable {
   var path: String
   var type: String
   var url: String? = nil

--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -2395,6 +2395,7 @@ struct SyncChatSubscribeSnapshotPayload: Decodable, Equatable {
 struct AgentChatSteerRequest: Codable, Equatable {
   var sessionId: String
   var text: String
+  var attachments: [AgentChatFileRef]? = nil
 }
 
 struct AgentChatCancelSteerRequest: Codable, Equatable {

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -99,6 +99,12 @@ enum SyncChatMessageDelivery: Equatable {
   case queued(steerId: String?)
 }
 
+struct SavedChatTempAttachment: Decodable, Equatable {
+  var path: String
+  var mimeType: String
+  var previewDataUrl: String?
+}
+
 func syncChatMessageDelivery(from response: Any) -> SyncChatMessageDelivery {
   if let response = response as? [String: Any], response["queued"] as? Bool == true {
     return .queued(steerId: response["steerId"] as? String)
@@ -6804,6 +6810,7 @@ final class SyncService: ObservableObject {
   func sendChatMessage(
     sessionId: String,
     text: String,
+    attachments: [AgentChatFileRef]? = nil,
     targetProjectId: String? = nil,
     targetProjectRootPath: String? = nil
   ) async throws -> SyncChatMessageDelivery {
@@ -6811,9 +6818,22 @@ final class SyncService: ObservableObject {
     // unless the caller already named a target explicitly (e.g. the hub
     // composer creating into a chosen project).
     let scope = chatCommandScope(for: sessionId)
+    var args: [String: Any] = ["sessionId": sessionId, "text": text]
+    if let attachments, !attachments.isEmpty {
+      args["attachments"] = attachments.map { ref in
+        var entry: [String: Any] = [
+          "path": ref.path,
+          "type": ref.type,
+        ]
+        if let url = ref.url, !url.isEmpty {
+          entry["url"] = url
+        }
+        return entry
+      }
+    }
     let response = try await sendCommand(
       action: "chat.send",
-      args: ["sessionId": sessionId, "text": text],
+      args: args,
       disconnectOnTimeout: false,
       timeoutMessage: SyncRequestTimeout.chatSendMessage,
       timeoutNanoseconds: SyncRequestTimeout.chatSendTimeoutNanoseconds,
@@ -6834,15 +6854,53 @@ final class SyncService: ObservableObject {
   }
 
   @discardableResult
-  func steerChatSession(sessionId: String, text: String) async throws -> SyncChatMessageDelivery {
+  func steerChatSession(
+    sessionId: String,
+    text: String,
+    attachments: [AgentChatFileRef]? = nil
+  ) async throws -> SyncChatMessageDelivery {
     let scope = chatCommandScope(for: sessionId)
     let response = try await sendChatCommand(
       action: "chat.steer",
-      payload: AgentChatSteerRequest(sessionId: sessionId, text: text),
+      payload: AgentChatSteerRequest(sessionId: sessionId, text: text, attachments: attachments),
       targetProjectId: scope.projectId,
       targetProjectRootPath: scope.rootPath
     )
     return syncChatMessageDelivery(from: response)
+  }
+
+  func saveChatTempAttachment(
+    dataUrl: String,
+    filename: String,
+    targetProjectId: String? = nil,
+    targetProjectRootPath: String? = nil
+  ) async throws -> SavedChatTempAttachment {
+    var args: [String: Any] = ["dataUrl": dataUrl]
+    let trimmedFilename = filename.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmedFilename.isEmpty {
+      args["filename"] = trimmedFilename
+    }
+    return try await sendDecodableCommand(
+      action: "chat.saveTempAttachment",
+      args: args,
+      targetProjectId: targetProjectId,
+      targetProjectRootPath: targetProjectRootPath,
+      as: SavedChatTempAttachment.self
+    )
+  }
+
+  func saveChatTempAttachmentForChat(
+    sessionId: String,
+    dataUrl: String,
+    filename: String
+  ) async throws -> SavedChatTempAttachment {
+    let scope = chatCommandScope(for: sessionId)
+    return try await saveChatTempAttachment(
+      dataUrl: dataUrl,
+      filename: filename,
+      targetProjectId: scope.projectId,
+      targetProjectRootPath: scope.rootPath
+    )
   }
 
   func cancelChatSteer(sessionId: String, steerId: String) async throws {

--- a/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
+++ b/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
@@ -77,6 +77,8 @@ struct HubInlineComposer: View {
 
   // UI / flow.
   @State private var draft: String = ""
+  @State private var attachments: [WorkChatInputAttachment] = []
+  @State private var composerTextHeight: CGFloat = 28
   @State private var busy: Bool = false
   @State private var errorMessage: String?
   @State private var modelPickerPresented = false
@@ -207,7 +209,12 @@ struct HubInlineComposer: View {
   }
 
   private var canSend: Bool {
-    canStart && !trimmedDraft.isEmpty
+    guard canStart else { return false }
+    if sessionMode != .chat {
+      return !trimmedDraft.isEmpty
+    }
+    return !workChatInputHasLoadingAttachments(attachments)
+      && (!trimmedDraft.isEmpty || !workChatInputReadyAttachments(attachments).isEmpty)
   }
 
   private var isControlsCollapsed: Bool {
@@ -288,6 +295,9 @@ struct HubInlineComposer: View {
     }
     .onChange(of: sessionMode) { _, newMode in
       normalizeSelection(for: newMode)
+      if newMode != .chat {
+        attachments.removeAll()
+      }
     }
     .onChange(of: modelId) { _, newModel in
       if !modelSupportsReasoning(modelId: newModel, provider: provider) {
@@ -603,6 +613,8 @@ struct HubInlineComposer: View {
   /// controls row (model/mode/fast/dictation) beneath the field.
   private var composerCard: some View {
     VStack(alignment: .leading, spacing: 12) {
+      WorkChatInputAttachmentTray(attachments: $attachments)
+
       HStack(alignment: .center, spacing: 10) {
         if !isExpanded {
           Image(systemName: "sparkles")
@@ -611,15 +623,20 @@ struct HubInlineComposer: View {
             .transition(.opacity)
         }
 
-        TextField("Type to vibecode…", text: $draft, axis: .vertical)
-          .textFieldStyle(.plain)
-          .lineLimit(1...6)
-          .font(.body)
-          .foregroundStyle(ADEColor.textPrimary)
-          .tint(ADEColor.accent)
-          .adePromptInputTraits()
-          .focused($composerFocused)
-          .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
+        WorkPlainComposerTextView(
+          text: $draft,
+          isFocused: Binding(
+            get: { composerFocused },
+            set: { composerFocused = $0 }
+          ),
+          measuredHeight: $composerTextHeight,
+          placeholder: "Type to vibecode…",
+          acceptsPastedImages: sessionMode == .chat,
+          onPasteImages: { images in
+            workChatInputPasteImages(images, into: $attachments)
+          }
+        )
+        .frame(maxWidth: .infinity, minHeight: 28, idealHeight: composerTextHeight, maxHeight: composerTextHeight, alignment: .leading)
 
         if !isExpanded {
           ADEComposerSendButton(
@@ -637,6 +654,11 @@ struct HubInlineComposer: View {
       if isExpanded {
         HStack(alignment: .center, spacing: 8) {
           if !isDictating {
+            WorkChatAttachmentAddButton(
+              attachments: $attachments,
+              disabled: busy || sessionMode != .chat
+            )
+
             ScrollView(.horizontal, showsIndicators: false) {
               WorkComposerControlsRow(
                 provider: provider,
@@ -725,20 +747,26 @@ struct HubInlineComposer: View {
 
   @MainActor
   private func dispatch() {
-    let text = trimmedDraft
+    let outgoingAttachments = workChatInputReadyAttachments(attachments)
+    let text = workChatOutgoingText(draft, attachmentCount: outgoingAttachments.count)
     guard !text.isEmpty else { return }
+    let restoredDraft = draft
+    let restoredAttachments = attachments
     draft = ""
+    attachments.removeAll()
     Task {
-      let started = await submit(opener: text)
+      let started = await submit(opener: text, attachments: outgoingAttachments)
       if !started {
-        draft = text
+        draft = restoredDraft
+        attachments = restoredAttachments
       }
     }
   }
 
   @MainActor
-  private func submit(opener rawOpener: String) async -> Bool {
-    let opener = rawOpener.trimmingCharacters(in: .whitespacesAndNewlines)
+  private func submit(opener rawOpener: String, attachments inputAttachments: [WorkChatInputAttachment]) async -> Bool {
+    let readyAttachments = workChatInputReadyAttachments(inputAttachments)
+    let opener = workChatOutgoingText(rawOpener, attachmentCount: readyAttachments.count)
     guard canStart, !opener.isEmpty, !modelId.isEmpty else { return false }
     guard let project = pickedProject else {
       errorMessage = "Pick a project first."
@@ -811,6 +839,12 @@ struct HubInlineComposer: View {
         )
         sessionId = result.sessionId
       } else {
+        let attachmentRefs = try await workChatSaveInputAttachments(
+          readyAttachments,
+          syncService: syncService,
+          targetProjectId: targetProjectId,
+          targetProjectRootPath: targetProjectRootPath
+        )
         let summary = try await syncService.createChatSession(
           laneId: targetLaneId,
           provider: provider,
@@ -835,6 +869,7 @@ struct HubInlineComposer: View {
         try await syncService.sendChatMessage(
           sessionId: summary.sessionId,
           text: opener,
+          attachments: attachmentRefs.isEmpty ? nil : attachmentRefs,
           targetProjectId: targetProjectId,
           targetProjectRootPath: targetProjectRootPath
         )

--- a/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
+++ b/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
@@ -204,6 +204,10 @@ struct HubInlineComposer: View {
       && !modelId.isEmpty
   }
 
+  private var canUploadAttachments: Bool {
+    syncService.connectionState == .connected || syncService.connectionState == .syncing
+  }
+
   private var trimmedDraft: String {
     draft.trimmingCharacters(in: .whitespacesAndNewlines)
   }
@@ -213,8 +217,10 @@ struct HubInlineComposer: View {
     if sessionMode != .chat {
       return !trimmedDraft.isEmpty
     }
+    let readyAttachments = workChatInputReadyAttachments(attachments)
     return !workChatInputHasLoadingAttachments(attachments)
-      && (!trimmedDraft.isEmpty || !workChatInputReadyAttachments(attachments).isEmpty)
+      && (!trimmedDraft.isEmpty || !readyAttachments.isEmpty)
+      && (readyAttachments.isEmpty || canUploadAttachments)
   }
 
   private var isControlsCollapsed: Bool {
@@ -656,7 +662,7 @@ struct HubInlineComposer: View {
           if !isDictating {
             WorkChatAttachmentAddButton(
               attachments: $attachments,
-              disabled: busy || sessionMode != .chat
+              disabled: busy || sessionMode != .chat || !canUploadAttachments
             )
 
             ScrollView(.horizontal, showsIndicators: false) {
@@ -768,6 +774,10 @@ struct HubInlineComposer: View {
     let readyAttachments = workChatInputReadyAttachments(inputAttachments)
     let opener = workChatOutgoingText(rawOpener, attachmentCount: readyAttachments.count)
     guard canStart, !opener.isEmpty, !modelId.isEmpty else { return false }
+    guard readyAttachments.isEmpty || canUploadAttachments else {
+      errorMessage = "Reconnect to attach images."
+      return false
+    }
     guard let project = pickedProject else {
       errorMessage = "Pick a project first."
       return false

--- a/apps/ios/ADE/Views/Work/WorkChatAttachmentTray.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatAttachmentTray.swift
@@ -1,10 +1,14 @@
 import SwiftUI
 import ImageIO
+import PhotosUI
 import UIKit
 
 private let workChatRemoteImageMaxBytes = 5 * 1024 * 1024
 private let workChatRemoteImageTimeoutSeconds: TimeInterval = 12
 private let workChatAttachmentPreviewMinimumPixels: CGFloat = 96
+private let workChatInputAttachmentMaxBytes = 10 * 1024 * 1024
+private let workChatInputAttachmentInitialMaxDimension: CGFloat = 2400
+private let workChatInputAttachmentMinimumMaxDimension: CGFloat = 960
 
 private let workChatRemoteImageSession: URLSession = {
   let configuration = URLSessionConfiguration.ephemeral
@@ -41,6 +45,462 @@ func workChatAttachmentAccessibilityLabel(_ attachments: [AgentChatFileRef]) -> 
     return "Attachment: \(names[0])"
   }
   return "\(names.count) attachments: \(names.joined(separator: ", "))"
+}
+
+enum WorkChatInputAttachmentState: Equatable {
+  case loading
+  case ready
+  case failed(String)
+}
+
+struct WorkChatInputAttachment: Identifiable {
+  let id: UUID
+  var image: UIImage?
+  var uploadData: Data?
+  var filename: String
+  var mimeType: String
+  var state: WorkChatInputAttachmentState
+
+  init(
+    id: UUID = UUID(),
+    image: UIImage? = nil,
+    uploadData: Data? = nil,
+    filename: String,
+    mimeType: String = "image/jpeg",
+    state: WorkChatInputAttachmentState
+  ) {
+    self.id = id
+    self.image = image
+    self.uploadData = uploadData
+    self.filename = filename
+    self.mimeType = mimeType
+    self.state = state
+  }
+
+  var isReady: Bool {
+    if case .ready = state { return uploadData != nil }
+    return false
+  }
+
+  var isLoading: Bool {
+    if case .loading = state { return true }
+    return false
+  }
+
+  var errorMessage: String? {
+    if case .failed(let message) = state { return message }
+    return nil
+  }
+}
+
+func workChatOutgoingText(_ text: String, attachmentCount: Int) -> String {
+  let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+  if !trimmed.isEmpty { return trimmed }
+  guard attachmentCount > 0 else { return "" }
+  return attachmentCount == 1 ? "Attached image." : "Attached \(attachmentCount) images."
+}
+
+func workChatInputReadyAttachments(_ attachments: [WorkChatInputAttachment]) -> [WorkChatInputAttachment] {
+  attachments.filter(\.isReady)
+}
+
+func workChatInputHasLoadingAttachments(_ attachments: [WorkChatInputAttachment]) -> Bool {
+  attachments.contains(where: \.isLoading)
+}
+
+func workChatInputAttachmentDataURL(_ attachment: WorkChatInputAttachment) -> String? {
+  guard let uploadData = attachment.uploadData else { return nil }
+  return "data:\(attachment.mimeType);base64,\(uploadData.base64EncodedString())"
+}
+
+@MainActor
+func workChatInputAttachment(from image: UIImage, filename: String? = nil, id: UUID = UUID()) -> WorkChatInputAttachment? {
+  guard let encoded = workChatJPEGDataForUpload(image) else { return nil }
+  let cleanedFilename = filename?.trimmingCharacters(in: .whitespacesAndNewlines)
+  let resolvedFilename: String
+  if let cleanedFilename, !cleanedFilename.isEmpty {
+    resolvedFilename = cleanedFilename
+  } else {
+    resolvedFilename = "image-\(id.uuidString.prefix(8)).jpg"
+  }
+  return WorkChatInputAttachment(
+    id: id,
+    image: encoded.image,
+    uploadData: encoded.data,
+    filename: resolvedFilename,
+    state: .ready
+  )
+}
+
+@MainActor
+func workChatInputPasteImages(_ images: [UIImage], into attachments: Binding<[WorkChatInputAttachment]>) {
+  guard !images.isEmpty else { return }
+  var next = attachments.wrappedValue
+  for image in images {
+    let id = UUID()
+    if let attachment = workChatInputAttachment(from: image, filename: "pasted-\(id.uuidString.prefix(8)).jpg", id: id) {
+      next.append(attachment)
+    } else {
+      next.append(WorkChatInputAttachment(
+        id: id,
+        filename: "pasted-\(id.uuidString.prefix(8)).jpg",
+        state: .failed("This image could not be prepared for upload.")
+      ))
+    }
+  }
+  attachments.wrappedValue = next
+}
+
+@MainActor
+func workChatSaveInputAttachments(
+  _ attachments: [WorkChatInputAttachment],
+  syncService: SyncService,
+  chatSessionId: String? = nil,
+  targetProjectId: String? = nil,
+  targetProjectRootPath: String? = nil
+) async throws -> [AgentChatFileRef] {
+  var refs: [AgentChatFileRef] = []
+  for attachment in workChatInputReadyAttachments(attachments) {
+    guard let dataUrl = workChatInputAttachmentDataURL(attachment) else { continue }
+    let saved: SavedChatTempAttachment
+    if let chatSessionId, !chatSessionId.isEmpty {
+      saved = try await syncService.saveChatTempAttachmentForChat(
+        sessionId: chatSessionId,
+        dataUrl: dataUrl,
+        filename: attachment.filename
+      )
+    } else {
+      saved = try await syncService.saveChatTempAttachment(
+        dataUrl: dataUrl,
+        filename: attachment.filename,
+        targetProjectId: targetProjectId,
+        targetProjectRootPath: targetProjectRootPath
+      )
+    }
+    refs.append(AgentChatFileRef(path: saved.path, type: "image"))
+  }
+  return refs
+}
+
+private func workChatJPEGDataForUpload(_ image: UIImage) -> (image: UIImage, data: Data)? {
+  var maxDimension = min(
+    workChatInputAttachmentInitialMaxDimension,
+    max(image.size.width, image.size.height)
+  )
+  let qualities: [CGFloat] = [0.88, 0.76, 0.64, 0.52, 0.40]
+  var attempted = false
+
+  while !attempted || maxDimension >= workChatInputAttachmentMinimumMaxDimension {
+    attempted = true
+    guard let rendered = workChatRenderedJPEGImage(image, maxDimension: maxDimension) else { return nil }
+    for quality in qualities {
+      guard let data = rendered.jpegData(compressionQuality: quality) else { continue }
+      if data.count <= workChatInputAttachmentMaxBytes {
+        return (rendered, data)
+      }
+    }
+    if maxDimension <= workChatInputAttachmentMinimumMaxDimension {
+      break
+    }
+    maxDimension *= 0.75
+  }
+
+  return nil
+}
+
+private func workChatRenderedJPEGImage(_ image: UIImage, maxDimension: CGFloat) -> UIImage? {
+  guard image.size.width > 0, image.size.height > 0 else { return nil }
+  let longest = max(image.size.width, image.size.height)
+  let scale = min(1, maxDimension / longest)
+  let targetSize = CGSize(
+    width: max(1, floor(image.size.width * scale)),
+    height: max(1, floor(image.size.height * scale))
+  )
+  let format = UIGraphicsImageRendererFormat()
+  format.scale = 1
+  format.opaque = true
+  return UIGraphicsImageRenderer(size: targetSize, format: format).image { context in
+    UIColor.white.setFill()
+    context.fill(CGRect(origin: .zero, size: targetSize))
+    image.draw(in: CGRect(origin: .zero, size: targetSize))
+  }
+}
+
+struct WorkChatAttachmentAddButton: View {
+  @Binding var attachments: [WorkChatInputAttachment]
+  var disabled = false
+
+  @State private var pickerPresented = false
+  @State private var pickerItems: [PhotosPickerItem] = []
+
+  var body: some View {
+    Menu {
+      Button {
+        pickerPresented = true
+      } label: {
+        Label("Attach from camera roll", systemImage: "photo.on.rectangle")
+      }
+    } label: {
+      Image(systemName: "plus")
+        .font(.system(size: 14, weight: .bold))
+        .foregroundStyle(disabled ? ADEColor.textMuted.opacity(0.35) : ADEColor.textPrimary)
+        .frame(width: 28, height: 28)
+        .background(ADEColor.surfaceBackground.opacity(disabled ? 0.18 : 0.38), in: Circle())
+        .overlay(Circle().stroke(ADEColor.border.opacity(disabled ? 0.16 : 0.28), lineWidth: 0.6))
+        .contentShape(Circle())
+    }
+    .disabled(disabled)
+    .accessibilityLabel("Add attachment")
+    .accessibilityHint("Shows attachment options.")
+    .photosPicker(
+      isPresented: $pickerPresented,
+      selection: $pickerItems,
+      maxSelectionCount: 0,
+      matching: .images,
+      preferredItemEncoding: .automatic
+    )
+    .onChange(of: pickerItems) { _, newItems in
+      guard !newItems.isEmpty else { return }
+      pickerItems = []
+      Task { await appendPhotoPickerItems(newItems) }
+    }
+  }
+
+  @MainActor
+  private func appendPhotoPickerItems(_ items: [PhotosPickerItem]) async {
+    for item in items {
+      let id = UUID()
+      let fallbackName = "image-\(id.uuidString.prefix(8)).jpg"
+      attachments.append(WorkChatInputAttachment(
+        id: id,
+        filename: fallbackName,
+        state: .loading
+      ))
+      do {
+        guard let data = try await item.loadTransferable(type: Data.self),
+              let image = UIImage(data: data) else {
+          markAttachment(id: id, failed: "This image could not be read.")
+          continue
+        }
+        guard let attachment = workChatInputAttachment(from: image, filename: fallbackName, id: id) else {
+          markAttachment(id: id, failed: "This image is too large to upload.")
+          continue
+        }
+        replaceAttachment(id: id, with: attachment)
+      } catch is CancellationError {
+        attachments.removeAll { $0.id == id }
+      } catch {
+        markAttachment(
+          id: id,
+          failed: "Could not load this image from camera roll. If it is in iCloud, check your connection and try again."
+        )
+      }
+    }
+  }
+
+  @MainActor
+  private func replaceAttachment(id: UUID, with attachment: WorkChatInputAttachment) {
+    guard let index = attachments.firstIndex(where: { $0.id == id }) else { return }
+    attachments[index] = attachment
+  }
+
+  @MainActor
+  private func markAttachment(id: UUID, failed message: String) {
+    guard let index = attachments.firstIndex(where: { $0.id == id }) else { return }
+    attachments[index].state = .failed(message)
+  }
+}
+
+struct WorkChatInputAttachmentTray: View {
+  @Binding var attachments: [WorkChatInputAttachment]
+  @State private var expandedAttachment: WorkChatInputAttachment?
+
+  private var attachmentCountLabel: String {
+    let readyCount = attachments.filter(\.isReady).count
+    let loadingCount = attachments.filter(\.isLoading).count
+    if loadingCount > 0 {
+      return loadingCount == 1 ? "Loading image" : "Loading \(loadingCount) images"
+    }
+    if readyCount == 1 { return "1 image attached" }
+    return "\(readyCount) images attached"
+  }
+
+  var body: some View {
+    if !attachments.isEmpty {
+      VStack(alignment: .leading, spacing: 7) {
+        HStack(spacing: 6) {
+          Image(systemName: "photo.on.rectangle")
+            .font(.system(size: 11, weight: .semibold))
+          Text(attachmentCountLabel)
+            .font(.caption2.weight(.semibold))
+          Spacer(minLength: 0)
+        }
+        .foregroundStyle(ADEColor.textMuted)
+
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack(spacing: 8) {
+            ForEach(attachments) { attachment in
+              WorkChatInputAttachmentThumb(attachment: attachment) {
+                expandedAttachment = attachment
+              } onRemove: {
+                attachments.removeAll { $0.id == attachment.id }
+              }
+            }
+          }
+        }
+      }
+      .padding(.horizontal, 2)
+      .sheet(item: $expandedAttachment) { attachment in
+        WorkChatInputAttachmentPreview(
+          attachment: attachment,
+          onRemove: {
+            attachments.removeAll { $0.id == attachment.id }
+            expandedAttachment = nil
+          }
+        )
+      }
+    }
+  }
+}
+
+private struct WorkChatInputAttachmentThumb: View {
+  let attachment: WorkChatInputAttachment
+  let onOpen: () -> Void
+  let onRemove: () -> Void
+
+  var body: some View {
+    ZStack(alignment: .topTrailing) {
+      Button(action: onOpen) {
+        ZStack {
+          RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .fill(ADEColor.surfaceBackground.opacity(0.42))
+            .frame(width: 72, height: 72)
+            .overlay(
+              RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(ADEColor.border.opacity(0.34), lineWidth: 0.8)
+            )
+
+          if let image = attachment.image {
+            Image(uiImage: image)
+              .resizable()
+              .scaledToFill()
+              .frame(width: 72, height: 72)
+              .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+          } else {
+            placeholder
+          }
+        }
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel(accessibilityLabel)
+
+      Button(action: onRemove) {
+        Image(systemName: "xmark")
+          .font(.system(size: 8, weight: .bold))
+          .foregroundStyle(Color.white)
+          .frame(width: 18, height: 18)
+          .background(Color.black.opacity(0.62), in: Circle())
+      }
+      .buttonStyle(.plain)
+      .padding(4)
+      .accessibilityLabel("Remove image")
+    }
+  }
+
+  @ViewBuilder
+  private var placeholder: some View {
+    switch attachment.state {
+    case .loading:
+      ProgressView()
+        .controlSize(.small)
+        .tint(ADEColor.textSecondary)
+    case .ready:
+      Image(systemName: "photo")
+        .font(.system(size: 18, weight: .semibold))
+        .foregroundStyle(ADEColor.textSecondary)
+    case .failed:
+      VStack(spacing: 4) {
+        Image(systemName: "photo.badge.exclamationmark")
+          .font(.system(size: 17, weight: .semibold))
+        Text("Failed")
+          .font(.system(size: 9, weight: .semibold))
+      }
+      .foregroundStyle(ADEColor.warning)
+    }
+  }
+
+  private var accessibilityLabel: String {
+    switch attachment.state {
+    case .loading:
+      return "Image loading"
+    case .ready:
+      return "Open attached image"
+    case .failed(let message):
+      return "Image failed. \(message)"
+    }
+  }
+}
+
+private struct WorkChatInputAttachmentPreview: View {
+  let attachment: WorkChatInputAttachment
+  let onRemove: () -> Void
+
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    NavigationStack {
+      VStack(spacing: 16) {
+        if let image = attachment.image {
+          Image(uiImage: image)
+            .resizable()
+            .scaledToFit()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.black.opacity(0.18), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        } else if attachment.isLoading {
+          ProgressView("Loading image…")
+            .foregroundStyle(ADEColor.textSecondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+          VStack(spacing: 10) {
+            Image(systemName: "photo.badge.exclamationmark")
+              .font(.system(size: 34, weight: .semibold))
+              .foregroundStyle(ADEColor.warning)
+            Text(attachment.errorMessage ?? "This image could not be loaded.")
+              .font(.body)
+              .foregroundStyle(ADEColor.textSecondary)
+              .multilineTextAlignment(.center)
+          }
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+      }
+      .padding(16)
+      .background(ADEColor.pageBackground.ignoresSafeArea())
+      .navigationTitle("Attached image")
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .topBarLeading) {
+          Button("Done") { dismiss() }
+        }
+        ToolbarItemGroup(placement: .topBarTrailing) {
+          Button {
+            if let image = attachment.image {
+              UIPasteboard.general.image = image
+              ADEHaptics.success()
+            }
+          } label: {
+            Label("Copy", systemImage: "doc.on.doc")
+          }
+          .disabled(attachment.image == nil)
+
+          Button(role: .destructive) {
+            onRemove()
+          } label: {
+            Label("Remove", systemImage: "trash")
+          }
+        }
+      }
+    }
+  }
 }
 
 private func workChatAttachmentStableIdentity(_ ref: AgentChatFileRef) -> String {

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -1137,6 +1137,12 @@ func workLocalEchoMessagesRenderSignature(_ messages: [WorkLocalEchoMessage]) ->
     hasher.combine(message.text.hashValue)
     hasher.combine(message.timestamp)
     hasher.combine(message.deliveryState)
+    hasher.combine(message.attachments?.count ?? 0)
+    for attachment in message.attachments ?? [] {
+      hasher.combine(attachment.path)
+      hasher.combine(attachment.type)
+      hasher.combine(attachment.url)
+    }
   }
   return hasher.finalize()
 }

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -167,7 +167,7 @@ struct WorkChatSessionView: View {
   var inputLockMessage: String? = nil
   let transitionNamespace: Namespace.ID?
   let onOpenLane: (() -> Void)?
-  let onSend: @MainActor (String) async -> Bool
+  let onSend: @MainActor (String, [WorkChatInputAttachment]) async -> Bool
   let onInterrupt: @MainActor () async -> Void
   let onApproveRequest: @MainActor (String, AgentChatApprovalDecision, String?) async -> Void
   let onRespondToQuestion: @MainActor (String, String, AgentChatInputAnswerValue?, String?) async -> Void
@@ -1619,7 +1619,7 @@ private struct WorkChatComposerCard: View {
   let onOpenModelPicker: (() -> Void)?
   let onSelectRuntimeMode: ((String) -> Void)?
   let onToggleCodexFastMode: ((Bool) -> Void)?
-  let onSend: @MainActor (String) async -> Bool
+  let onSend: @MainActor (String, [WorkChatInputAttachment]) async -> Bool
   let onSent: () -> Void
 
   var body: some View {
@@ -1677,7 +1677,7 @@ private struct WorkChatComposerDraftInput: View {
   let onOpenModelPicker: (() -> Void)?
   let onSelectRuntimeMode: ((String) -> Void)?
   let onToggleCodexFastMode: ((Bool) -> Void)?
-  let onSend: @MainActor (String) async -> Bool
+  let onSend: @MainActor (String, [WorkChatInputAttachment]) async -> Bool
   let onSent: () -> Void
 
   @EnvironmentObject private var syncService: SyncService
@@ -1686,20 +1686,30 @@ private struct WorkChatComposerDraftInput: View {
   @State private var contextUsagePresented = false
   @StateObject private var dictationCoordinator = DictationInsertionCoordinator()
   @State private var isDictating = false
+  @State private var inputAttachments: [WorkChatInputAttachment] = []
+
+  private var hasSendableDraftOrAttachment: Bool {
+    draftState.hasSendableText || !workChatInputReadyAttachments(inputAttachments).isEmpty
+  }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
       WorkComposerSuggestionStrip(controller: suggestionController)
         .animation(.smooth(duration: 0.16), value: suggestionController.isVisible)
 
+      WorkChatInputAttachmentTray(attachments: $inputAttachments)
+
       WorkChatComposerTextField(
         draftState: draftState,
         controller: suggestionController,
         canCompose: canCompose,
-        placeholder: composerPlaceholder
+        placeholder: composerPlaceholder,
+        onPasteImages: { images in
+          workChatInputPasteImages(images, into: $inputAttachments)
+        }
       )
 
-      if showInterrupt && draftState.hasSendableText {
+      if showInterrupt && hasSendableDraftOrAttachment {
         Text("Message will stage behind the active turn.")
           .font(.caption2)
           .foregroundStyle(ADEColor.textMuted)
@@ -1711,6 +1721,11 @@ private struct WorkChatComposerDraftInput: View {
         // Leading controls collapse while dictating so the recording pill can
         // expand into the row without a layout jump.
         if !isDictating {
+          WorkChatAttachmentAddButton(
+            attachments: $inputAttachments,
+            disabled: !canCompose || settingsMutationInFlight
+          )
+
           WorkComposerChipStrip(
             chatSummary: chatSummary,
             settingsMutationInFlight: settingsMutationInFlight,
@@ -1757,10 +1772,11 @@ private struct WorkChatComposerDraftInput: View {
 
         if !isDictating {
           if showInterrupt {
-            if draftState.hasSendableText {
+            if hasSendableDraftOrAttachment {
               stopButton()
               WorkChatComposerSendButton(
                 draftState: draftState,
+                attachments: $inputAttachments,
                 canSend: canSend,
                 sending: sending,
                 accessibilityLabelText: "Stage message",
@@ -1773,6 +1789,7 @@ private struct WorkChatComposerDraftInput: View {
           } else {
             WorkChatComposerSendButton(
               draftState: draftState,
+              attachments: $inputAttachments,
               canSend: canSend,
               sending: sending,
               onSend: onSend,
@@ -2040,6 +2057,7 @@ private struct WorkChatComposerTextField: View {
   @ObservedObject var controller: WorkComposerSuggestionController
   let canCompose: Bool
   let placeholder: String
+  var onPasteImages: (([UIImage]) -> Void)? = nil
   @State private var measuredHeight: CGFloat = 24
 
   var body: some View {
@@ -2048,7 +2066,8 @@ private struct WorkChatComposerTextField: View {
       controller: controller,
       canCompose: canCompose,
       placeholder: placeholder,
-      measuredHeight: $measuredHeight
+      measuredHeight: $measuredHeight,
+      onPasteImages: onPasteImages
     )
     .frame(height: measuredHeight)
     .frame(maxWidth: .infinity, alignment: .leading)
@@ -2057,14 +2076,17 @@ private struct WorkChatComposerTextField: View {
 
 private struct WorkChatComposerSendButton: View {
   @ObservedObject var draftState: WorkChatComposerDraftState
+  @Binding var attachments: [WorkChatInputAttachment]
   let canSend: Bool
   let sending: Bool
   var accessibilityLabelText = "Send message"
-  let onSend: @MainActor (String) async -> Bool
+  let onSend: @MainActor (String, [WorkChatInputAttachment]) async -> Bool
   let onSent: () -> Void
 
   private var sendEnabled: Bool {
-    canSend && draftState.hasSendableText
+    canSend
+      && !workChatInputHasLoadingAttachments(attachments)
+      && (draftState.hasSendableText || !workChatInputReadyAttachments(attachments).isEmpty)
   }
 
   var body: some View {
@@ -2073,13 +2095,18 @@ private struct WorkChatComposerSendButton: View {
       sending: sending,
       accessibilityLabelText: accessibilityLabelText
     ) {
-      let text = draftState.consumeSendableText()
+      let originalText = draftState.consumeSendableText()
+      let outgoingAttachments = workChatInputReadyAttachments(attachments)
+      let text = workChatOutgoingText(originalText, attachmentCount: outgoingAttachments.count)
+      let restoredAttachments = attachments
+      attachments.removeAll()
       Task { @MainActor in
-        let sent = await onSend(text)
+        let sent = await onSend(text, outgoingAttachments)
         if sent {
           onSent()
         } else {
-          draftState.restoreUnsentText(text)
+          draftState.restoreUnsentText(originalText)
+          attachments = restoredAttachments
         }
       }
     }

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -715,6 +715,7 @@ struct WorkChatSessionView: View {
         composerPlaceholder: composerPlaceholderText,
         canCompose: canCompose,
         canSend: canSend && !composerSettingMutationInFlight,
+        canUploadAttachments: isLive,
         sending: sending && !sendWillQueue,
         settingsMutationInFlight: composerSettingMutationInFlight,
         codexFastModeOverride: pendingCodexFastMode,
@@ -1612,6 +1613,7 @@ private struct WorkChatComposerCard: View {
   let composerPlaceholder: String
   let canCompose: Bool
   let canSend: Bool
+  let canUploadAttachments: Bool
   let sending: Bool
   let settingsMutationInFlight: Bool
   let codexFastModeOverride: Bool?
@@ -1638,6 +1640,7 @@ private struct WorkChatComposerCard: View {
       composerPlaceholder: composerPlaceholder,
       canCompose: canCompose,
       canSend: canSend,
+      canUploadAttachments: canUploadAttachments,
       sending: sending,
       settingsMutationInFlight: settingsMutationInFlight,
       codexFastModeOverride: codexFastModeOverride,
@@ -1674,6 +1677,7 @@ private struct WorkChatComposerDraftInput: View {
   let composerPlaceholder: String
   let canCompose: Bool
   let canSend: Bool
+  let canUploadAttachments: Bool
   let sending: Bool
   let settingsMutationInFlight: Bool
   let codexFastModeOverride: Bool?
@@ -1784,6 +1788,7 @@ private struct WorkChatComposerDraftInput: View {
                 draftState: draftState,
                 attachments: $inputAttachments,
                 canSend: canSend,
+                canUploadAttachments: canUploadAttachments,
                 sending: sending,
                 accessibilityLabelText: "Stage message",
                 onSend: onSend,
@@ -1797,6 +1802,7 @@ private struct WorkChatComposerDraftInput: View {
               draftState: draftState,
               attachments: $inputAttachments,
               canSend: canSend,
+              canUploadAttachments: canUploadAttachments,
               sending: sending,
               onSend: onSend,
               onSent: onSent
@@ -2084,15 +2090,18 @@ private struct WorkChatComposerSendButton: View {
   @ObservedObject var draftState: WorkChatComposerDraftState
   @Binding var attachments: [WorkChatInputAttachment]
   let canSend: Bool
+  let canUploadAttachments: Bool
   let sending: Bool
   var accessibilityLabelText = "Send message"
   let onSend: @MainActor (String, [WorkChatInputAttachment]) async -> Bool
   let onSent: () -> Void
 
   private var sendEnabled: Bool {
-    canSend
+    let readyAttachments = workChatInputReadyAttachments(attachments)
+    return canSend
       && !workChatInputHasLoadingAttachments(attachments)
-      && (draftState.hasSendableText || !workChatInputReadyAttachments(attachments).isEmpty)
+      && (draftState.hasSendableText || !readyAttachments.isEmpty)
+      && (readyAttachments.isEmpty || canUploadAttachments)
   }
 
   var body: some View {

--- a/apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift
+++ b/apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift
@@ -296,6 +296,163 @@ final class WorkComposerChipLayoutManager: NSLayoutManager {
 
 // MARK: - Composer text view
 
+private final class WorkComposerPastingTextView: UITextView {
+  var onPasteImages: (([UIImage]) -> Bool)?
+
+  override func paste(_ sender: Any?) {
+    if let image = UIPasteboard.general.image,
+       onPasteImages?([image]) == true {
+      return
+    }
+    super.paste(sender)
+  }
+}
+
+/// Plain UITextView composer for start-chat surfaces that do not need typed
+/// trigger chips but still need multiline sizing and image-paste interception.
+struct WorkPlainComposerTextView: UIViewRepresentable {
+  @Binding var text: String
+  @Binding var isFocused: Bool
+  @Binding var measuredHeight: CGFloat
+  let placeholder: String
+  var acceptsPastedImages = true
+  var onPasteImages: (([UIImage]) -> Void)? = nil
+
+  private var maxHeight: CGFloat {
+    ceil(UIFont.preferredFont(forTextStyle: .body).lineHeight * 6) + 8
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(self)
+  }
+
+  func makeUIView(context: Context) -> UITextView {
+    let textView = WorkComposerPastingTextView()
+    textView.delegate = context.coordinator
+    textView.backgroundColor = .clear
+    textView.textContainerInset = .zero
+    textView.textContainer.lineFragmentPadding = 0
+    textView.isScrollEnabled = false
+    textView.font = UIFont.preferredFont(forTextStyle: .body)
+    textView.textColor = UIColor(ADEColor.textPrimary)
+    textView.tintColor = UIColor(ADEColor.accent)
+    textView.autocorrectionType = .yes
+    textView.autocapitalizationType = .sentences
+    textView.spellCheckingType = .yes
+    textView.smartQuotesType = .no
+    textView.smartDashesType = .no
+    textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    textView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    textView.accessibilityIdentifier = "Work.StartChat.Composer.TextView"
+    textView.onPasteImages = { [weak coordinator = context.coordinator] images in
+      coordinator?.handlePasteImages(images) ?? false
+    }
+
+    context.coordinator.textView = textView
+    context.coordinator.applyPlaceholder(placeholder)
+    if !text.isEmpty { textView.text = text }
+    context.coordinator.updatePlaceholderVisibility()
+    context.coordinator.updateHeight()
+    return textView
+  }
+
+  func updateUIView(_ textView: UITextView, context: Context) {
+    context.coordinator.parent = self
+    if let textView = textView as? WorkComposerPastingTextView {
+      textView.onPasteImages = { [weak coordinator = context.coordinator] images in
+        coordinator?.handlePasteImages(images) ?? false
+      }
+    }
+    if textView.text != text {
+      textView.text = text
+      context.coordinator.updatePlaceholderVisibility()
+    }
+    context.coordinator.applyPlaceholder(placeholder)
+    if isFocused, !textView.isFirstResponder {
+      textView.becomeFirstResponder()
+    } else if !isFocused, textView.isFirstResponder {
+      textView.resignFirstResponder()
+    }
+    context.coordinator.updateHeight()
+  }
+
+  @MainActor
+  final class Coordinator: NSObject, UITextViewDelegate {
+    var parent: WorkPlainComposerTextView
+    weak var textView: UITextView?
+    private var placeholderLabel: UILabel?
+
+    init(_ parent: WorkPlainComposerTextView) {
+      self.parent = parent
+    }
+
+    func textViewDidBeginEditing(_ textView: UITextView) {
+      if !parent.isFocused { parent.isFocused = true }
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+      if parent.isFocused { parent.isFocused = false }
+    }
+
+    func textViewDidChange(_ textView: UITextView) {
+      if parent.text != textView.text {
+        parent.text = textView.text
+      }
+      updatePlaceholderVisibility()
+      updateHeight()
+    }
+
+    func handlePasteImages(_ images: [UIImage]) -> Bool {
+      guard parent.acceptsPastedImages,
+            let onPasteImages = parent.onPasteImages,
+            !images.isEmpty
+      else { return false }
+      onPasteImages(images)
+      return true
+    }
+
+    func applyPlaceholder(_ text: String) {
+      guard let textView else { return }
+      if placeholderLabel == nil {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.textColor = UIColor(ADEColor.textMuted)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        textView.addSubview(label)
+        NSLayoutConstraint.activate([
+          label.leadingAnchor.constraint(equalTo: textView.leadingAnchor),
+          label.trailingAnchor.constraint(lessThanOrEqualTo: textView.trailingAnchor),
+          label.topAnchor.constraint(equalTo: textView.topAnchor),
+        ])
+        placeholderLabel = label
+      }
+      placeholderLabel?.text = text
+      updatePlaceholderVisibility()
+    }
+
+    func updatePlaceholderVisibility() {
+      placeholderLabel?.isHidden = !(textView?.text.isEmpty ?? true)
+    }
+
+    func updateHeight() {
+      guard let textView else { return }
+      let width = textView.bounds.width
+      guard width > 0 else { return }
+      let fitting = textView.sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)).height
+      let clamped = min(max(fitting, parent.minHeight), parent.maxHeight)
+      textView.isScrollEnabled = fitting > parent.maxHeight
+      if abs(parent.measuredHeight - clamped) > 0.5 {
+        DispatchQueue.main.async { [weak self] in
+          self?.parent.measuredHeight = clamped
+        }
+      }
+    }
+  }
+
+  var minHeight: CGFloat { 28 }
+}
+
 /// UITextView-backed composer input. SwiftUI's `TextField` exposes neither the
 /// cursor position (needed for cursor-relative trigger detection) nor inline
 /// styled runs (needed for chips), so the composer drops to UIKit here while
@@ -306,6 +463,7 @@ struct WorkComposerTextView: UIViewRepresentable {
   let canCompose: Bool
   let placeholder: String
   @Binding var measuredHeight: CGFloat
+  var onPasteImages: (([UIImage]) -> Void)? = nil
 
   private var maxHeight: CGFloat {
     ceil(UIFont.preferredFont(forTextStyle: .body).lineHeight * 6) + 8
@@ -326,7 +484,7 @@ struct WorkComposerTextView: UIViewRepresentable {
     container.lineFragmentPadding = 0
     layoutManager.addTextContainer(container)
 
-    let textView = UITextView(frame: .zero, textContainer: container)
+    let textView = WorkComposerPastingTextView(frame: .zero, textContainer: container)
     // UITextView retains only the text container of a manually-built TextKit 1
     // stack; keep the storage + layout manager alive on the coordinator or the
     // stack deallocates out from under the view.
@@ -347,6 +505,9 @@ struct WorkComposerTextView: UIViewRepresentable {
     textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     textView.setContentHuggingPriority(.defaultLow, for: .horizontal)
     textView.accessibilityIdentifier = "Work.Chat.Composer.TextView"
+    textView.onPasteImages = { [weak coordinator = context.coordinator] images in
+      coordinator?.handlePasteImages(images) ?? false
+    }
 
     context.coordinator.textView = textView
     // Route committed suggestions straight to the live text view.
@@ -365,6 +526,11 @@ struct WorkComposerTextView: UIViewRepresentable {
   func updateUIView(_ textView: UITextView, context: Context) {
     context.coordinator.parent = self
     textView.isEditable = canCompose
+    if let textView = textView as? WorkComposerPastingTextView {
+      textView.onPasteImages = { [weak coordinator = context.coordinator] images in
+        coordinator?.handlePasteImages(images) ?? false
+      }
+    }
     context.coordinator.applyPlaceholder(placeholder)
 
     // Reflect external mutations to the source of truth (dictation insert,
@@ -514,6 +680,13 @@ struct WorkComposerTextView: UIViewRepresentable {
       if textView.markedTextRange == nil {
         detectTrigger()
       }
+    }
+
+    func handlePasteImages(_ images: [UIImage]) -> Bool {
+      guard let onPasteImages = parent.onPasteImages, !images.isEmpty else { return false }
+      onPasteImages(images)
+      parent.controller.clear()
+      return true
     }
 
     // MARK: Detection + commit

--- a/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkErrorAndMessageHelpers.swift
@@ -1090,6 +1090,7 @@ enum WorkPendingInputItem: Identifiable, Equatable {
 struct WorkPendingSteerModel: Identifiable, Equatable {
   let id: String
   var text: String
+  var attachments: [AgentChatFileRef]? = nil
   let turnId: String?
   let timestamp: String
 }
@@ -1496,10 +1497,16 @@ func derivePendingWorkSteers(from transcript: [WorkChatEnvelope]) -> [WorkPendin
   var queuedSteerIdsByText: [String: Set<String>] = [:]
   for envelope in sortedWorkChatEnvelopes(transcript) {
     switch envelope.event {
-    case .userMessage(let text, _, let turnId, let steerId, let deliveryState, _):
+    case .userMessage(let text, let attachments, let turnId, let steerId, let deliveryState, _):
       if let steerId, deliveryState == "queued", !resolved.contains(steerId) {
         if queue[steerId] == nil { order.append(steerId) }
-        queue[steerId] = WorkPendingSteerModel(id: steerId, text: text, turnId: turnId, timestamp: envelope.timestamp)
+        queue[steerId] = WorkPendingSteerModel(
+          id: steerId,
+          text: text,
+          attachments: attachments,
+          turnId: turnId,
+          timestamp: envelope.timestamp
+        )
         let normalizedText = normalizedQueuedSteerText(text)
         if !normalizedText.isEmpty {
           queuedSteerIdsByText[normalizedText, default: []].insert(steerId)

--- a/apps/ios/ADE/Views/Work/WorkModels.swift
+++ b/apps/ios/ADE/Views/Work/WorkModels.swift
@@ -127,6 +127,7 @@ struct WorkLocalEchoMessage: Identifiable, Equatable {
   let text: String
   let timestamp: String
   var deliveryState: String? = nil
+  var attachments: [AgentChatFileRef]? = nil
 }
 
 struct WorkPendingApprovalModel: Identifiable, Equatable {

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -537,7 +537,7 @@ struct WorkNewChatScreen: View {
   /// while shown.
   let activeProjectId: String?
   let activeProjectRootPath: String?
-  let onStarted: @MainActor (AgentChatSessionSummary, String, Bool, [AgentChatFileRef]) async -> Void
+  let onStarted: @MainActor (AgentChatSessionSummary, String, Bool, String?, [AgentChatFileRef]) async -> Void
   let onCliStarted: @MainActor (TerminalSessionSummary) async -> Void
   let onChatImported: @MainActor (String) async -> Void
   let onRefreshLanes: @MainActor () async -> Void
@@ -568,7 +568,7 @@ struct WorkNewChatScreen: View {
     preferredLaneId: String?,
     activeProjectId: String?,
     activeProjectRootPath: String?,
-    onStarted: @escaping @MainActor (AgentChatSessionSummary, String, Bool, [AgentChatFileRef]) async -> Void,
+    onStarted: @escaping @MainActor (AgentChatSessionSummary, String, Bool, String?, [AgentChatFileRef]) async -> Void,
     onCliStarted: @escaping @MainActor (TerminalSessionSummary) async -> Void,
     onChatImported: @escaping @MainActor (String) async -> Void = { _ in },
     onRefreshLanes: @escaping @MainActor () async -> Void
@@ -1130,16 +1130,23 @@ struct WorkNewChatScreen: View {
         pendingDisplayName: opener
       )
       if attachmentRefs.isEmpty {
-        await onStarted(summary, opener, false, [])
+        await onStarted(summary, opener, false, nil, [])
       } else {
-        _ = try await syncService.sendChatMessage(
+        let delivery = try await syncService.sendChatMessage(
           sessionId: summary.sessionId,
           text: opener,
           attachments: attachmentRefs,
           targetProjectId: targetScope.projectId,
           targetProjectRootPath: targetScope.projectRootPath
         )
-        await onStarted(summary, opener, true, attachmentRefs)
+        let deliveryState: String?
+        switch delivery {
+        case .queued:
+          deliveryState = "queued"
+        case .sent:
+          deliveryState = nil
+        }
+        await onStarted(summary, opener, true, deliveryState, attachmentRefs)
       }
       if let createdLaneId, let autoCreatedFallbackName {
         startBackgroundLaneNaming(laneId: createdLaneId, opener: opener, fallbackName: autoCreatedFallbackName)

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -1010,6 +1010,7 @@ struct WorkNewChatScreen: View {
     // Track whether we created the lane so we can clean it up if the session
     // launch fails immediately afterwards (desktop parity).
     let targetLaneId: String
+    let targetLaneForScope: LaneSummary?
     var createdLaneId: String?
     var autoCreatedFallbackName: String?
     if isAutoCreateLane {
@@ -1023,6 +1024,7 @@ struct WorkNewChatScreen: View {
           description: opener.isEmpty ? "" : String(opener.prefix(280))
         )
         targetLaneId = lane.id
+        targetLaneForScope = lane
         createdLaneId = lane.id
         autoCreatedFallbackName = laneName
         await onRefreshLanes()
@@ -1035,8 +1037,9 @@ struct WorkNewChatScreen: View {
       }
     } else {
       targetLaneId = selectedLaneId
+      targetLaneForScope = lanes.first { $0.id == selectedLaneId }
     }
-    let targetScope = lanes.first { $0.id == targetLaneId }
+    let targetScope = targetLaneForScope
       .map { workShellProjectScope(for: $0, projects: syncService.projects) }
       ?? WorkProjectCommandScope(projectId: nil, projectRootPath: nil)
 

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -677,6 +677,7 @@ struct WorkNewChatScreen: View {
           }
 
           laneSelector
+          sessionActionChips
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 16)
@@ -705,8 +706,6 @@ struct WorkNewChatScreen: View {
           .padding(.horizontal, 20)
           .padding(.bottom, 6)
       }
-
-      sessionActionChips
 
       composerBar
     }
@@ -852,8 +851,7 @@ struct WorkNewChatScreen: View {
         .disabled(chipsDisabled)
         Spacer(minLength: 0)
       }
-      .padding(.horizontal, 20)
-      .padding(.bottom, 8)
+      .padding(.top, 2)
     }
   }
 
@@ -914,7 +912,7 @@ struct WorkNewChatScreen: View {
       fastModeSupported: fastModeSupported,
       codexFastMode: $codexFastMode,
       onOpenModelPicker: { modelPickerPresented = true },
-      onSubmit: submit(openingMessage:)
+      onSubmit: submit(openingMessage:attachments:)
     )
   }
 
@@ -994,8 +992,9 @@ struct WorkNewChatScreen: View {
   }
 
   @MainActor
-  private func submit(openingMessage: String) async -> Bool {
-    let opener = openingMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+  private func submit(openingMessage: String, attachments inputAttachments: [WorkChatInputAttachment]) async -> Bool {
+    let readyAttachments = workChatInputReadyAttachments(inputAttachments)
+    let opener = workChatOutgoingText(openingMessage, attachmentCount: readyAttachments.count)
     guard !busy && !shellLaunchBusy && (isAutoCreateLane || !selectedLaneId.isEmpty) else { return false }
     guard !opener.isEmpty && !modelId.isEmpty else { return false }
     // Anchor the "last time you sent a message" choice — covers the case where
@@ -1096,6 +1095,10 @@ struct WorkNewChatScreen: View {
         busy = false
         return true
       }
+      let attachmentRefs = try await workChatSaveInputAttachments(
+        readyAttachments,
+        syncService: syncService
+      )
       let summary = try await syncService.createChatSession(
         laneId: targetLaneId,
         provider: provider,
@@ -1116,7 +1119,16 @@ struct WorkNewChatScreen: View {
         cursorModeId: wire.cursorModeId,
         pendingDisplayName: opener
       )
-      await onStarted(summary, opener)
+      if attachmentRefs.isEmpty {
+        await onStarted(summary, opener)
+      } else {
+        _ = try await syncService.sendChatMessage(
+          sessionId: summary.sessionId,
+          text: opener,
+          attachments: attachmentRefs
+        )
+        await onStarted(summary, "")
+      }
       if let createdLaneId, let autoCreatedFallbackName {
         startBackgroundLaneNaming(laneId: createdLaneId, opener: opener, fallbackName: autoCreatedFallbackName)
       }
@@ -1281,9 +1293,11 @@ private struct WorkNewChatComposerBar: View {
   let fastModeSupported: Bool
   @Binding var codexFastMode: Bool
   let onOpenModelPicker: () -> Void
-  let onSubmit: @MainActor (String) async -> Bool
+  let onSubmit: @MainActor (String, [WorkChatInputAttachment]) async -> Bool
 
   @State private var draft: String = ""
+  @State private var attachments: [WorkChatInputAttachment] = []
+  @State private var composerTextHeight: CGFloat = 28
   @FocusState private var composerFocused: Bool
   @StateObject private var dictationCoordinator = DictationInsertionCoordinator()
   @State private var isDictating = false
@@ -1297,7 +1311,12 @@ private struct WorkNewChatComposerBar: View {
   }
 
   private var canSend: Bool {
-    canStart && !trimmedDraft.isEmpty
+    guard canStart else { return false }
+    if sessionMode != .chat {
+      return !trimmedDraft.isEmpty
+    }
+    return !workChatInputHasLoadingAttachments(attachments)
+      && (!trimmedDraft.isEmpty || !workChatInputReadyAttachments(attachments).isEmpty)
   }
 
   private var runtimeOptions: [WorkRuntimeModeOption] {
@@ -1314,30 +1333,48 @@ private struct WorkNewChatComposerBar: View {
 
   @MainActor
   private func dispatch() {
-    let text = trimmedDraft
+    let outgoingAttachments = workChatInputReadyAttachments(attachments)
+    let text = workChatOutgoingText(draft, attachmentCount: outgoingAttachments.count)
+    guard !text.isEmpty else { return }
+    let restoredDraft = draft
+    let restoredAttachments = attachments
     draft = ""
+    attachments.removeAll()
     Task {
-      let started = await onSubmit(text)
+      let started = await onSubmit(text, outgoingAttachments)
       if !started {
-        draft = text
+        draft = restoredDraft
+        attachments = restoredAttachments
       }
     }
   }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
-      TextField(placeholder, text: $draft, axis: .vertical)
-        .textFieldStyle(.plain)
-        .lineLimit(1...6)
-        .font(.body)
-        .foregroundStyle(ADEColor.textPrimary)
-        .tint(ADEColor.accent)
-        .adePromptInputTraits()
-        .focused($composerFocused)
-        .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
+      WorkChatInputAttachmentTray(attachments: $attachments)
+
+      WorkPlainComposerTextView(
+        text: $draft,
+        isFocused: Binding(
+          get: { composerFocused },
+          set: { composerFocused = $0 }
+        ),
+        measuredHeight: $composerTextHeight,
+        placeholder: placeholder,
+        acceptsPastedImages: sessionMode == .chat,
+        onPasteImages: { images in
+          workChatInputPasteImages(images, into: $attachments)
+        }
+      )
+      .frame(maxWidth: .infinity, minHeight: 28, idealHeight: composerTextHeight, maxHeight: composerTextHeight, alignment: .leading)
 
       HStack(alignment: .center, spacing: 8) {
         if !isDictating {
+          WorkChatAttachmentAddButton(
+            attachments: $attachments,
+            disabled: busy || sessionMode != .chat
+          )
+
           ScrollView(.horizontal, showsIndicators: false) {
             WorkComposerControlsRow(
               provider: provider,
@@ -1407,6 +1444,11 @@ private struct WorkNewChatComposerBar: View {
     .shadow(color: Color.black.opacity(0.32), radius: 14, y: 6)
     .padding(.horizontal, 16)
     .padding(.bottom, 0)
+    .onChange(of: sessionMode) { _, newMode in
+      if newMode != .chat {
+        attachments.removeAll()
+      }
+    }
   }
 
   /// Primary foreground launch button — the compact arrow-in-circle send glyph

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -642,6 +642,10 @@ struct WorkNewChatScreen: View {
     return lanes.first(where: { $0.id == selectedLaneId })
   }
 
+  private var canUploadAttachments: Bool {
+    syncService.connectionState == .connected || syncService.connectionState == .syncing
+  }
+
   /// Fast mode only applies to in-app chat sessions on fast-tier models — the
   /// CLI launcher has no fast-mode parameter — so the lightning toggle (and the
   /// value we send) is gated on both. The picker's option can only *add* support
@@ -907,6 +911,7 @@ struct WorkNewChatScreen: View {
       modelName: prettyNewChatModelName(modelId),
       busy: busy,
       canStart: !busy && !shellLaunchBusy && (isAutoCreateLane || !selectedLaneId.isEmpty) && !modelId.isEmpty,
+      canUploadAttachments: canUploadAttachments,
       runtimeMode: $runtimeMode,
       reasoningEffort: $reasoningEffort,
       fastModeSupported: fastModeSupported,
@@ -997,6 +1002,10 @@ struct WorkNewChatScreen: View {
     let opener = workChatOutgoingText(openingMessage, attachmentCount: readyAttachments.count)
     guard !busy && !shellLaunchBusy && (isAutoCreateLane || !selectedLaneId.isEmpty) else { return false }
     guard !opener.isEmpty && !modelId.isEmpty else { return false }
+    guard readyAttachments.isEmpty || canUploadAttachments else {
+      errorMessage = "Reconnect to attach images."
+      return false
+    }
     // Anchor the "last time you sent a message" choice — covers the case where
     // the user sent with the restored/default selection without changing it.
     WorkComposerPreferences.save(composerSelection)
@@ -1307,6 +1316,7 @@ private struct WorkNewChatComposerBar: View {
   let modelName: String
   let busy: Bool
   let canStart: Bool
+  let canUploadAttachments: Bool
   @Binding var runtimeMode: String
   @Binding var reasoningEffort: String
   let fastModeSupported: Bool
@@ -1334,8 +1344,10 @@ private struct WorkNewChatComposerBar: View {
     if sessionMode != .chat {
       return !trimmedDraft.isEmpty
     }
+    let readyAttachments = workChatInputReadyAttachments(attachments)
     return !workChatInputHasLoadingAttachments(attachments)
-      && (!trimmedDraft.isEmpty || !workChatInputReadyAttachments(attachments).isEmpty)
+      && (!trimmedDraft.isEmpty || !readyAttachments.isEmpty)
+      && (readyAttachments.isEmpty || canUploadAttachments)
   }
 
   private var runtimeOptions: [WorkRuntimeModeOption] {
@@ -1391,7 +1403,7 @@ private struct WorkNewChatComposerBar: View {
         if !isDictating {
           WorkChatAttachmentAddButton(
             attachments: $attachments,
-            disabled: busy || sessionMode != .chat
+            disabled: busy || sessionMode != .chat || !canUploadAttachments
           )
 
           ScrollView(.horizontal, showsIndicators: false) {

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -537,7 +537,7 @@ struct WorkNewChatScreen: View {
   /// while shown.
   let activeProjectId: String?
   let activeProjectRootPath: String?
-  let onStarted: @MainActor (AgentChatSessionSummary, String) async -> Void
+  let onStarted: @MainActor (AgentChatSessionSummary, String, Bool, [AgentChatFileRef]) async -> Void
   let onCliStarted: @MainActor (TerminalSessionSummary) async -> Void
   let onChatImported: @MainActor (String) async -> Void
   let onRefreshLanes: @MainActor () async -> Void
@@ -568,7 +568,7 @@ struct WorkNewChatScreen: View {
     preferredLaneId: String?,
     activeProjectId: String?,
     activeProjectRootPath: String?,
-    onStarted: @escaping @MainActor (AgentChatSessionSummary, String) async -> Void,
+    onStarted: @escaping @MainActor (AgentChatSessionSummary, String, Bool, [AgentChatFileRef]) async -> Void,
     onCliStarted: @escaping @MainActor (TerminalSessionSummary) async -> Void,
     onChatImported: @escaping @MainActor (String) async -> Void = { _ in },
     onRefreshLanes: @escaping @MainActor () async -> Void
@@ -1036,6 +1036,9 @@ struct WorkNewChatScreen: View {
     } else {
       targetLaneId = selectedLaneId
     }
+    let targetScope = lanes.first { $0.id == targetLaneId }
+      .map { workShellProjectScope(for: $0, projects: syncService.projects) }
+      ?? WorkProjectCommandScope(projectId: nil, projectRootPath: nil)
 
     // Lane is ready; the naming/creating banner is done — the composer + nav
     // spinner carry the remaining "starting session" state.
@@ -1097,7 +1100,9 @@ struct WorkNewChatScreen: View {
       }
       let attachmentRefs = try await workChatSaveInputAttachments(
         readyAttachments,
-        syncService: syncService
+        syncService: syncService,
+        targetProjectId: targetScope.projectId,
+        targetProjectRootPath: targetScope.projectRootPath
       )
       let summary = try await syncService.createChatSession(
         laneId: targetLaneId,
@@ -1117,17 +1122,21 @@ struct WorkNewChatScreen: View {
         opencodePermissionMode: wire.opencodePermissionMode,
         droidPermissionMode: wire.droidPermissionMode,
         cursorModeId: wire.cursorModeId,
+        targetProjectId: targetScope.projectId,
+        targetProjectRootPath: targetScope.projectRootPath,
         pendingDisplayName: opener
       )
       if attachmentRefs.isEmpty {
-        await onStarted(summary, opener)
+        await onStarted(summary, opener, false, [])
       } else {
         _ = try await syncService.sendChatMessage(
           sessionId: summary.sessionId,
           text: opener,
-          attachments: attachmentRefs
+          attachments: attachmentRefs,
+          targetProjectId: targetScope.projectId,
+          targetProjectRootPath: targetScope.projectRootPath
         )
-        await onStarted(summary, "")
+        await onStarted(summary, opener, true, attachmentRefs)
       }
       if let createdLaneId, let autoCreatedFallbackName {
         startBackgroundLaneNaming(laneId: createdLaneId, opener: opener, fallbackName: autoCreatedFallbackName)

--- a/apps/ios/ADE/Views/Work/WorkPreviews.swift
+++ b/apps/ios/ADE/Views/Work/WorkPreviews.swift
@@ -462,7 +462,7 @@ private enum WorkPreviewData {
       sendWillQueueIsReconnect: false,
       transitionNamespace: nil,
       onOpenLane: {},
-      onSend: { _ in true },
+      onSend: { _, _ in true },
       onInterrupt: {},
       onApproveRequest: { _, _, _ in },
       onRespondToQuestion: { _, _, _, _ in },

--- a/apps/ios/ADE/Views/Work/WorkPreviews.swift
+++ b/apps/ios/ADE/Views/Work/WorkPreviews.swift
@@ -502,7 +502,7 @@ private enum WorkPreviewData {
       preferredLaneId: WorkPreviewData.lane.id,
       activeProjectId: nil,
       activeProjectRootPath: nil,
-      onStarted: { _, _, _, _ in },
+      onStarted: { _, _, _, _, _ in },
       onCliStarted: { _ in },
       onRefreshLanes: {}
     )

--- a/apps/ios/ADE/Views/Work/WorkPreviews.swift
+++ b/apps/ios/ADE/Views/Work/WorkPreviews.swift
@@ -502,7 +502,7 @@ private enum WorkPreviewData {
       preferredLaneId: WorkPreviewData.lane.id,
       activeProjectId: nil,
       activeProjectRootPath: nil,
-      onStarted: { _, _ in },
+      onStarted: { _, _, _, _ in },
       onCliStarted: { _ in },
       onRefreshLanes: {}
     )

--- a/apps/ios/ADE/Views/Work/WorkRootScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootScreen.swift
@@ -25,7 +25,8 @@ struct WorkSessionRoute: Hashable {
   let openId: UUID = UUID()
   let sessionId: String
   var openingPrompt: String? = nil
-  var openingPromptAlreadySent = false
+  var openingPromptDispatchHandled = false
+  var openingDeliveryState: String? = nil
   var openingAttachments: [AgentChatFileRef] = []
 }
 
@@ -644,7 +645,8 @@ struct WorkRootScreen: View {
         WorkSessionDestinationView(
           sessionId: route.sessionId,
           initialOpeningPrompt: route.openingPrompt,
-          initialOpeningPromptAlreadySent: route.openingPromptAlreadySent,
+          initialOpeningPromptDispatchHandled: route.openingPromptDispatchHandled,
+          initialOpeningDeliveryState: route.openingDeliveryState,
           initialOpeningAttachments: route.openingAttachments,
           initialSession: initialSession,
           initialChatSummary: chatSummaries[route.sessionId],
@@ -668,7 +670,7 @@ struct WorkRootScreen: View {
           preferredLaneId: route.preferredLaneId,
           activeProjectId: syncService.activeProjectId,
           activeProjectRootPath: syncService.activeProjectRootPath,
-          onStarted: { summary, opener, openerAlreadySent, openerAttachments in
+          onStarted: { summary, opener, openerDispatchHandled, openerDeliveryState, openerAttachments in
             let sessionId = summary.sessionId
             let trimmed = opener.trimmingCharacters(in: .whitespacesAndNewlines)
             optimisticSessions[sessionId] = makeOptimisticSession(for: summary)
@@ -682,7 +684,8 @@ struct WorkRootScreen: View {
             fresh.append(WorkSessionRoute(
               sessionId: sessionId,
               openingPrompt: trimmed.isEmpty ? nil : trimmed,
-              openingPromptAlreadySent: openerAlreadySent,
+              openingPromptDispatchHandled: openerDispatchHandled,
+              openingDeliveryState: openerDeliveryState,
               openingAttachments: openerAttachments
             ))
             await Task.yield()

--- a/apps/ios/ADE/Views/Work/WorkRootScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootScreen.swift
@@ -675,7 +675,7 @@ struct WorkRootScreen: View {
             // Back goes to the sidebar, not to an empty "Start a new chat"
             // form.
             var fresh = NavigationPath()
-            fresh.append(WorkSessionRoute(sessionId: sessionId, openingPrompt: trimmed))
+            fresh.append(WorkSessionRoute(sessionId: sessionId, openingPrompt: trimmed.isEmpty ? nil : trimmed))
             await Task.yield()
             path = fresh
             Task { @MainActor in

--- a/apps/ios/ADE/Views/Work/WorkRootScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootScreen.swift
@@ -25,6 +25,8 @@ struct WorkSessionRoute: Hashable {
   let openId: UUID = UUID()
   let sessionId: String
   var openingPrompt: String? = nil
+  var openingPromptAlreadySent = false
+  var openingAttachments: [AgentChatFileRef] = []
 }
 
 struct WorkDraftChatSession {
@@ -642,6 +644,8 @@ struct WorkRootScreen: View {
         WorkSessionDestinationView(
           sessionId: route.sessionId,
           initialOpeningPrompt: route.openingPrompt,
+          initialOpeningPromptAlreadySent: route.openingPromptAlreadySent,
+          initialOpeningAttachments: route.openingAttachments,
           initialSession: initialSession,
           initialChatSummary: chatSummaries[route.sessionId],
           initialTranscript: nil,
@@ -664,7 +668,7 @@ struct WorkRootScreen: View {
           preferredLaneId: route.preferredLaneId,
           activeProjectId: syncService.activeProjectId,
           activeProjectRootPath: syncService.activeProjectRootPath,
-          onStarted: { summary, opener in
+          onStarted: { summary, opener, openerAlreadySent, openerAttachments in
             let sessionId = summary.sessionId
             let trimmed = opener.trimmingCharacters(in: .whitespacesAndNewlines)
             optimisticSessions[sessionId] = makeOptimisticSession(for: summary)
@@ -675,7 +679,12 @@ struct WorkRootScreen: View {
             // Back goes to the sidebar, not to an empty "Start a new chat"
             // form.
             var fresh = NavigationPath()
-            fresh.append(WorkSessionRoute(sessionId: sessionId, openingPrompt: trimmed.isEmpty ? nil : trimmed))
+            fresh.append(WorkSessionRoute(
+              sessionId: sessionId,
+              openingPrompt: trimmed.isEmpty ? nil : trimmed,
+              openingPromptAlreadySent: openerAlreadySent,
+              openingAttachments: openerAttachments
+            ))
             await Task.yield()
             path = fresh
             Task { @MainActor in

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
@@ -79,7 +79,12 @@ extension WorkSessionDestinationView {
       case .queued(let steerId):
         updateLocalEchoDeliveryState(echoId: echoId, deliveryState: "queued")
         if let steerId {
-          upsertOptimisticPendingSteer(id: steerId, text: text, timestamp: echo.timestamp)
+          upsertOptimisticPendingSteer(
+            id: steerId,
+            text: text,
+            timestamp: echo.timestamp,
+            attachments: attachmentRefs.isEmpty ? nil : attachmentRefs
+          )
         }
       case .sent:
         updateLocalEchoDeliveryState(echoId: echoId, deliveryState: nil)
@@ -151,6 +156,7 @@ extension WorkSessionDestinationView {
         optimisticPendingSteers[index] = WorkPendingSteerModel(
           id: steerId,
           text: trimmed,
+          attachments: optimisticPendingSteers[index].attachments,
           turnId: optimisticPendingSteers[index].turnId,
           timestamp: workDateFormatter.string(from: Date())
         )

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
@@ -20,12 +20,25 @@ func workFilteredQuestionAnswersForSubmit(
 
 extension WorkSessionDestinationView {
   @MainActor
-  func sendMessage(_ text: String) async -> Bool {
+  func sendMessage(_ text: String, attachments inputAttachments: [WorkChatInputAttachment] = []) async -> Bool {
     let useSteer = shouldSteerActiveTurn
     guard !sending || useSteer else { return false }
     let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !text.isEmpty else { return false }
     guard canSendChatMessages else { return false }
+
+    let attachmentRefs: [AgentChatFileRef]
+    do {
+      attachmentRefs = try await workChatSaveInputAttachments(
+        inputAttachments,
+        syncService: syncService,
+        chatSessionId: sessionId
+      )
+    } catch {
+      ADEHaptics.error()
+      errorMessage = error.localizedDescription
+      return false
+    }
 
     let initialDeliveryState = (sendWillQueueChatMessage || useSteer) ? "queued" : "sending"
     let echo = WorkLocalEchoMessage(
@@ -40,13 +53,25 @@ extension WorkSessionDestinationView {
     do {
       let delivery: SyncChatMessageDelivery
       if useSteer {
-        delivery = try await syncService.steerChatSession(sessionId: sessionId, text: text)
+        delivery = try await syncService.steerChatSession(
+          sessionId: sessionId,
+          text: text,
+          attachments: attachmentRefs.isEmpty ? nil : attachmentRefs
+        )
       } else {
         do {
-          delivery = try await syncService.sendChatMessage(sessionId: sessionId, text: text)
+          delivery = try await syncService.sendChatMessage(
+            sessionId: sessionId,
+            text: text,
+            attachments: attachmentRefs.isEmpty ? nil : attachmentRefs
+          )
         } catch where workChatErrorIndicatesActiveTurn(error) {
           updateLocalEchoDeliveryState(echoId: echoId, deliveryState: "queued")
-          delivery = try await syncService.steerChatSession(sessionId: sessionId, text: text)
+          delivery = try await syncService.steerChatSession(
+            sessionId: sessionId,
+            text: text,
+            attachments: attachmentRefs.isEmpty ? nil : attachmentRefs
+          )
         }
       }
       switch delivery {

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
@@ -44,7 +44,8 @@ extension WorkSessionDestinationView {
     let echo = WorkLocalEchoMessage(
       text: text,
       timestamp: workDateFormatter.string(from: Date()),
-      deliveryState: initialDeliveryState
+      deliveryState: initialDeliveryState,
+      attachments: attachmentRefs.isEmpty ? nil : attachmentRefs
     )
     let echoId = echo.id
     localEchoMessages.append(echo)

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -1907,19 +1907,21 @@ struct WorkSessionDestinationView: View {
   @MainActor
   func reconcileLocalEchoMessages() {
     guard !localEchoMessages.isEmpty else { return }
-    let pendingSteerTexts = Set(
-      derivePendingWorkSteers(from: transcript).map { normalizedWorkLocalEchoText($0.text) }
+    let pendingSteerKeys = Set(
+      derivePendingWorkSteers(from: transcript).compactMap { workLocalEchoDedupeKey(text: $0.text, attachments: nil) }
     )
     localEchoMessages.removeAll { echo in
-      let normalizedEcho = normalizedWorkLocalEchoText(echo.text)
-      if pendingSteerTexts.contains(normalizedEcho) {
+      guard let echoKey = workLocalEchoDedupeKey(text: echo.text, attachments: echo.attachments) else {
+        return false
+      }
+      if pendingSteerKeys.contains(echoKey) {
         return true
       }
       return transcript.contains { envelope in
-        guard case .userMessage(let text, _, _, let steerId, let deliveryState, _) = envelope.event else {
+        guard case .userMessage(let text, let attachments, _, let steerId, let deliveryState, _) = envelope.event else {
           return false
         }
-        guard normalizedWorkLocalEchoText(text) == normalizedEcho else { return false }
+        guard workLocalEchoDedupeKey(text: text, attachments: attachments) == echoKey else { return false }
         if deliveryState == "queued", steerId != nil {
           return false
         }

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -1858,9 +1858,14 @@ struct WorkSessionDestinationView: View {
   }
 
   @MainActor
-  func upsertOptimisticPendingSteer(id: String, text: String, timestamp: String) {
+  func upsertOptimisticPendingSteer(
+    id: String,
+    text: String,
+    timestamp: String,
+    attachments: [AgentChatFileRef]? = nil
+  ) {
     let turnId = latestActiveTurnId(from: transcript)
-    let model = WorkPendingSteerModel(id: id, text: text, turnId: turnId, timestamp: timestamp)
+    let model = WorkPendingSteerModel(id: id, text: text, attachments: attachments, turnId: turnId, timestamp: timestamp)
     if let index = optimisticPendingSteers.firstIndex(where: { $0.id == id }) {
       optimisticPendingSteers[index] = model
     } else {
@@ -1908,7 +1913,7 @@ struct WorkSessionDestinationView: View {
   func reconcileLocalEchoMessages() {
     guard !localEchoMessages.isEmpty else { return }
     let pendingSteerKeys = Set(
-      derivePendingWorkSteers(from: transcript).compactMap { workLocalEchoDedupeKey(text: $0.text, attachments: nil) }
+      derivePendingWorkSteers(from: transcript).compactMap { workLocalEchoDedupeKey(text: $0.text, attachments: $0.attachments) }
     )
     localEchoMessages.removeAll { echo in
       guard let echoKey = workLocalEchoDedupeKey(text: echo.text, attachments: echo.attachments) else {

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -300,7 +300,8 @@ struct WorkSessionDestinationView: View {
 
   let sessionId: String
   let initialOpeningPrompt: String?
-  var initialOpeningPromptAlreadySent = false
+  var initialOpeningPromptDispatchHandled = false
+  var initialOpeningDeliveryState: String? = nil
   var initialOpeningAttachments: [AgentChatFileRef] = []
   let initialSession: TerminalSessionSummary?
   let initialChatSummary: AgentChatSessionSummary?
@@ -1711,7 +1712,7 @@ struct WorkSessionDestinationView: View {
     guard !sending else { return }
     let promptKey = "\(sessionId)|\(prompt)"
     guard handledOpeningPromptKey != promptKey else { return }
-    if initialOpeningPromptAlreadySent {
+    if initialOpeningPromptDispatchHandled {
       handledOpeningPromptKey = promptKey
       return
     }
@@ -1782,8 +1783,8 @@ struct WorkSessionDestinationView: View {
     guard stagedOpeningPromptKey != promptKey else { return }
     stagedOpeningPromptKey = promptKey
     let useSteer = shouldSteerActiveTurn
-    let deliveryState = initialOpeningPromptAlreadySent
-      ? nil
+    let deliveryState = initialOpeningPromptDispatchHandled
+      ? initialOpeningDeliveryState
       : ((sendWillQueueChatMessage || useSteer) ? "queued" : "sending")
     localEchoMessages.append(WorkLocalEchoMessage(
       text: prompt,
@@ -2219,7 +2220,8 @@ extension WorkSessionDestinationView: Equatable {
   static func == (lhs: WorkSessionDestinationView, rhs: WorkSessionDestinationView) -> Bool {
     lhs.sessionId == rhs.sessionId
       && lhs.initialOpeningPrompt == rhs.initialOpeningPrompt
-      && lhs.initialOpeningPromptAlreadySent == rhs.initialOpeningPromptAlreadySent
+      && lhs.initialOpeningPromptDispatchHandled == rhs.initialOpeningPromptDispatchHandled
+      && lhs.initialOpeningDeliveryState == rhs.initialOpeningDeliveryState
       && lhs.initialOpeningAttachments == rhs.initialOpeningAttachments
       && lhs.initialSession == rhs.initialSession
       && lhs.initialChatSummary == rhs.initialChatSummary

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -300,6 +300,8 @@ struct WorkSessionDestinationView: View {
 
   let sessionId: String
   let initialOpeningPrompt: String?
+  var initialOpeningPromptAlreadySent = false
+  var initialOpeningAttachments: [AgentChatFileRef] = []
   let initialSession: TerminalSessionSummary?
   let initialChatSummary: AgentChatSessionSummary?
   let initialTranscript: [WorkChatEnvelope]?
@@ -1709,6 +1711,10 @@ struct WorkSessionDestinationView: View {
     guard !sending else { return }
     let promptKey = "\(sessionId)|\(prompt)"
     guard handledOpeningPromptKey != promptKey else { return }
+    if initialOpeningPromptAlreadySent {
+      handledOpeningPromptKey = promptKey
+      return
+    }
     if transcript.contains(where: { envelope in
       if case .userMessage(let text, _, _, _, _, _) = envelope.event {
         return text.trimmingCharacters(in: .whitespacesAndNewlines) == prompt
@@ -1776,10 +1782,14 @@ struct WorkSessionDestinationView: View {
     guard stagedOpeningPromptKey != promptKey else { return }
     stagedOpeningPromptKey = promptKey
     let useSteer = shouldSteerActiveTurn
+    let deliveryState = initialOpeningPromptAlreadySent
+      ? nil
+      : ((sendWillQueueChatMessage || useSteer) ? "queued" : "sending")
     localEchoMessages.append(WorkLocalEchoMessage(
       text: prompt,
       timestamp: workDateFormatter.string(from: Date()),
-      deliveryState: (sendWillQueueChatMessage || useSteer) ? "queued" : "sending"
+      deliveryState: deliveryState,
+      attachments: initialOpeningAttachments.isEmpty ? nil : initialOpeningAttachments
     ))
   }
 
@@ -2209,6 +2219,8 @@ extension WorkSessionDestinationView: Equatable {
   static func == (lhs: WorkSessionDestinationView, rhs: WorkSessionDestinationView) -> Bool {
     lhs.sessionId == rhs.sessionId
       && lhs.initialOpeningPrompt == rhs.initialOpeningPrompt
+      && lhs.initialOpeningPromptAlreadySent == rhs.initialOpeningPromptAlreadySent
+      && lhs.initialOpeningAttachments == rhs.initialOpeningAttachments
       && lhs.initialSession == rhs.initialSession
       && lhs.initialChatSummary == rhs.initialChatSummary
       && workInitialTranscriptSeedRenderSignature(lhs.initialTranscript) == workInitialTranscriptSeedRenderSignature(rhs.initialTranscript)

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -119,6 +119,12 @@ private func workChatTimelineSnapshotSignature(
     combineLongTextSignature(echo.text, into: &hasher)
     hasher.combine(echo.timestamp)
     combineOptional(echo.deliveryState, into: &hasher)
+    hasher.combine(echo.attachments?.count ?? 0)
+    for attachment in echo.attachments ?? [] {
+      hasher.combine(attachment.path)
+      hasher.combine(attachment.type)
+      combineOptional(attachment.url, into: &hasher)
+    }
   }
 
   return hasher.finalize()
@@ -1022,7 +1028,8 @@ func buildWorkTimeline(
       timestamp: echo.timestamp,
       turnId: nil,
       itemId: nil,
-      deliveryState: echo.deliveryState
+      deliveryState: echo.deliveryState,
+      attachments: echo.attachments
     )
     return WorkTimelineEntry(id: "echo-\(echo.id)", timestamp: echo.timestamp, rank: 3_000 + index, payload: .message(message))
   })

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -950,22 +950,21 @@ func buildWorkTimeline(
       }
     : buildWorkChatMessages(from: transcript)
 
-  let pendingSteerTexts = Set(
-    derivePendingWorkSteers(from: transcript).map { normalizedWorkLocalEchoText($0.text) }.filter { !$0.isEmpty }
+  let pendingSteerEchoKeys = Set(
+    derivePendingWorkSteers(from: transcript).compactMap { workLocalEchoDedupeKey(text: $0.text, attachments: nil) }
   )
 
   var entries: [WorkTimelineEntry] = messages.enumerated().map { index, message in
     WorkTimelineEntry(id: "message-\(message.id)", timestamp: message.timestamp, rank: index, payload: .message(message))
   }
-  let transcriptUserMessageTexts = Set(
+  let transcriptUserMessageEchoKeys = Set(
     messages
       .filter { $0.role.lowercased() == "user" }
-      .map { normalizedWorkLocalEchoText($0.markdown) }
-      .filter { !$0.isEmpty }
+      .compactMap { workLocalEchoDedupeKey(text: $0.markdown, attachments: $0.attachments) }
   )
   let visibleLocalEchoMessages = localEchoMessages.filter { echo in
-    let normalized = normalizedWorkLocalEchoText(echo.text)
-    return !transcriptUserMessageTexts.contains(normalized) && !pendingSteerTexts.contains(normalized)
+    guard let key = workLocalEchoDedupeKey(text: echo.text, attachments: echo.attachments) else { return true }
+    return !transcriptUserMessageEchoKeys.contains(key) && !pendingSteerEchoKeys.contains(key)
   }
 
   entries.append(contentsOf: toolCards.enumerated().map { index, card in
@@ -1576,6 +1575,15 @@ func normalizedWorkLocalEchoText(_ text: String) -> String {
   text
     .trimmingCharacters(in: .whitespacesAndNewlines)
     .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+}
+
+private func workLocalEchoDedupeKey(text: String, attachments: [AgentChatFileRef]?) -> String? {
+  let normalized = normalizedWorkLocalEchoText(text)
+  guard !normalized.isEmpty else { return nil }
+  let attachmentKey = (attachments ?? [])
+    .map { "\($0.type)|\($0.path)|\($0.url ?? "")" }
+    .joined(separator: "\u{1f}")
+  return "\(normalized)\u{1e}\(attachmentKey)"
 }
 
 func buildWorkCommandCards(from transcript: [WorkChatEnvelope]) -> [WorkCommandCardModel] {

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -951,7 +951,7 @@ func buildWorkTimeline(
     : buildWorkChatMessages(from: transcript)
 
   let pendingSteerEchoKeys = Set(
-    derivePendingWorkSteers(from: transcript).compactMap { workLocalEchoDedupeKey(text: $0.text, attachments: nil) }
+    derivePendingWorkSteers(from: transcript).compactMap { workLocalEchoDedupeKey(text: $0.text, attachments: $0.attachments) }
   )
 
   var entries: [WorkTimelineEntry] = messages.enumerated().map { index, message in

--- a/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift
@@ -1577,7 +1577,7 @@ func normalizedWorkLocalEchoText(_ text: String) -> String {
     .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
 }
 
-private func workLocalEchoDedupeKey(text: String, attachments: [AgentChatFileRef]?) -> String? {
+func workLocalEchoDedupeKey(text: String, attachments: [AgentChatFileRef]?) -> String? {
   let normalized = normalizedWorkLocalEchoText(text)
   guard !normalized.isEmpty else { return nil }
   let attachmentKey = (attachments ?? [])

--- a/apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift
+++ b/apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import UIKit
 @testable import ADE
 
 /// Pure-logic coverage for the cursor-relative trigger detector that mirrors the
@@ -108,5 +109,22 @@ final class WorkComposerTriggerDetectorTests: XCTestCase {
   func testOutOfRangeCursorIsNoTrigger() {
     XCTAssertNil(detect("/rev", cursor: 99))
     XCTAssertNil(detect("/rev", cursor: -1))
+  }
+
+  @MainActor
+  func testInputImageAttachmentNormalizesToJPEGDataURL() throws {
+    let image = UIGraphicsImageRenderer(size: CGSize(width: 24, height: 12)).image { context in
+      UIColor.systemBlue.setFill()
+      context.fill(CGRect(x: 0, y: 0, width: 24, height: 12))
+    }
+
+    let attachment = try XCTUnwrap(workChatInputAttachment(from: image, filename: " pasted.png "))
+    XCTAssertEqual(attachment.filename, "pasted.png")
+    XCTAssertEqual(attachment.mimeType, "image/jpeg")
+    XCTAssertTrue(attachment.isReady)
+    XCTAssertTrue((attachment.uploadData?.count ?? 0) > 0)
+    XCTAssertTrue(workChatInputAttachmentDataURL(attachment)?.hasPrefix("data:image/jpeg;base64,") == true)
+    XCTAssertEqual(workChatOutgoingText("", attachmentCount: 1), "Attached image.")
+    XCTAssertEqual(workChatOutgoingText("  hello  ", attachmentCount: 1), "hello")
   }
 }

--- a/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
+++ b/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
@@ -279,6 +279,42 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     XCTAssertNil(message?.deliveryState)
   }
 
+  func testImageOnlyLocalEchoDedupeIncludesAttachmentIdentity() {
+    let first = AgentChatFileRef(path: "/project/.ade/attachments/first.jpg", type: "image", url: nil)
+    let second = AgentChatFileRef(path: "/project/.ade/attachments/second.jpg", type: "image", url: nil)
+    let snapshot = buildWorkChatTimelineSnapshot(
+      transcript: [
+        WorkChatEnvelope(
+          sessionId: "chat-1",
+          timestamp: iso(now),
+          sequence: 1,
+          event: .userMessage(
+            text: "Attached image.",
+            attachments: [first],
+            turnId: nil,
+            steerId: nil,
+            deliveryState: nil,
+            processed: nil
+          )
+        )
+      ],
+      fallbackEntries: [],
+      artifacts: [],
+      localEchoMessages: [
+        WorkLocalEchoMessage(text: "Attached image.", timestamp: iso(now), deliveryState: nil, attachments: [first]),
+        WorkLocalEchoMessage(text: "Attached image.", timestamp: iso(now), deliveryState: nil, attachments: [second]),
+      ]
+    )
+    let visibleUserMessages = snapshot.timeline.compactMap { entry -> WorkChatMessage? in
+      if case .message(let message) = entry.payload, message.role == "user" { return message }
+      return nil
+    }
+
+    XCTAssertEqual(visibleUserMessages.count, 2)
+    XCTAssertTrue(visibleUserMessages.contains { $0.attachments == [first] })
+    XCTAssertTrue(visibleUserMessages.contains { $0.attachments == [second] })
+  }
+
   // MARK: - Fixtures
 
   private func makeSession(

--- a/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
+++ b/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
@@ -248,6 +248,37 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     XCTAssertNil(badge)
   }
 
+  // MARK: - Local echo rendering
+
+  func testLocalEchoTimelinePreservesImageAttachments() {
+    let attachment = AgentChatFileRef(
+      path: "/project/.ade/attachments/mobile-image.jpg",
+      type: "image",
+      url: nil
+    )
+    let echo = WorkLocalEchoMessage(
+      text: "Attached image.",
+      timestamp: iso(now),
+      deliveryState: nil,
+      attachments: [attachment]
+    )
+
+    let snapshot = buildWorkChatTimelineSnapshot(
+      transcript: [],
+      fallbackEntries: [],
+      artifacts: [],
+      localEchoMessages: [echo]
+    )
+    let message = snapshot.timeline.compactMap { entry -> WorkChatMessage? in
+      if case .message(let message) = entry.payload { return message }
+      return nil
+    }.first
+
+    XCTAssertEqual(message?.markdown, "Attached image.")
+    XCTAssertEqual(message?.attachments, [attachment])
+    XCTAssertNil(message?.deliveryState)
+  }
+
   // MARK: - Fixtures
 
   private func makeSession(

--- a/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
+++ b/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
@@ -282,6 +282,10 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
   func testImageOnlyLocalEchoDedupeIncludesAttachmentIdentity() {
     let first = AgentChatFileRef(path: "/project/.ade/attachments/first.jpg", type: "image", url: nil)
     let second = AgentChatFileRef(path: "/project/.ade/attachments/second.jpg", type: "image", url: nil)
+    XCTAssertNotEqual(
+      workLocalEchoDedupeKey(text: "Attached image.", attachments: [first]),
+      workLocalEchoDedupeKey(text: "Attached image.", attachments: [second])
+    )
     let snapshot = buildWorkChatTimelineSnapshot(
       transcript: [
         WorkChatEnvelope(

--- a/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
+++ b/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
@@ -319,6 +319,45 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     XCTAssertTrue(visibleUserMessages.contains { $0.attachments == [second] })
   }
 
+  func testQueuedImageSteerDedupeIncludesAttachmentIdentity() {
+    let first = AgentChatFileRef(path: "/project/.ade/attachments/first.jpg", type: "image", url: nil)
+    let second = AgentChatFileRef(path: "/project/.ade/attachments/second.jpg", type: "image", url: nil)
+    let transcript = [
+      WorkChatEnvelope(
+        sessionId: "chat-1",
+        timestamp: iso(now),
+        sequence: 1,
+        event: .userMessage(
+          text: "Attached image.",
+          attachments: [first],
+          turnId: nil,
+          steerId: "steer-1",
+          deliveryState: "queued",
+          processed: nil
+        )
+      )
+    ]
+    XCTAssertEqual(derivePendingWorkSteers(from: transcript).first?.attachments, [first])
+
+    let snapshot = buildWorkChatTimelineSnapshot(
+      transcript: transcript,
+      fallbackEntries: [],
+      artifacts: [],
+      localEchoMessages: [
+        WorkLocalEchoMessage(text: "Attached image.", timestamp: iso(now), deliveryState: "queued", attachments: [first]),
+        WorkLocalEchoMessage(text: "Attached image.", timestamp: iso(now), deliveryState: "queued", attachments: [second]),
+      ]
+    )
+    let visibleUserMessages = snapshot.timeline.compactMap { entry -> WorkChatMessage? in
+      if case .message(let message) = entry.payload, message.role == "user" { return message }
+      return nil
+    }
+
+    XCTAssertEqual(visibleUserMessages.count, 1)
+    XCTAssertEqual(visibleUserMessages.filter { $0.attachments == [first] }.count, 0)
+    XCTAssertEqual(visibleUserMessages.filter { $0.attachments == [second] }.count, 1)
+  }
+
   // MARK: - Fixtures
 
   private func makeSession(

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -950,6 +950,21 @@ stored choice. `WorkNewChatScreen` captures the active project id when pushed;
 changes so a hub-created session cannot accidentally launch with the previous
 project's interface mode.
 
+Mobile chat image attachments use the same host-side temp attachment contract as
+desktop. Work and Hub chat composers expose an add-attachment control beside the
+permission/model controls; its menu currently has one action, Attach from camera
+roll, backed by scoped `PhotosPicker` access rather than a full photo-library
+permission. Picked or pasted images stage in `WorkChatInputAttachmentTray` above
+the prompt with thumbnail, loading, and failed states; tapping a staged image
+opens the larger preview sheet with copy and remove actions. The in-session
+`UITextView` composer intercepts pasted `UIPasteboard` images and feeds the same
+tray. Images are normalized to JPEG before upload, saved through
+`chat.saveTempAttachment`, and then sent on `chat.send` / `chat.steer` as
+`AgentChatFileRef` image refs. If a selected asset cannot be loaded yet (for
+example an iCloud-only photo that is not currently available on the phone), the
+tile remains local and shows a recoverable load error instead of sending a
+broken attachment.
+
 ### Shipped
 
 | Tab | Icon | Desktop equivalent | Capabilities |


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fwant-way-upload-pictures-camera-3b392ebd num=733 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fwant-way-upload-pictures-camera-3b392ebd&amp;pr=733">ade/want-way-upload-pictures-camera-3b392ebd branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=733">PR #733</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds image attachments to mobile chat. The main changes are:

- Attachment pickers, previews, paste handling, and upload preparation in chat composers.
- Scoped temp attachment saving and attachment-aware chat send and steer requests.
- Local echo, pending steer, and timeline dedupe updates that preserve attachment identity.
- New-chat navigation state for opener text, delivery state, and opener attachments.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The blocker state was captured in ios-image-attachment-01-before.log, showing the iOS project directory and missing xcodebuild/swift checks.
- The exact targeted xcodebuild test command and the 'xcodebuild: not found' failure were captured in ios-image-attachment-02-after.log.
- Per request, no mock UI, hand-authored screenshots, browser lookalikes, or unrelated JS validation were created.

<a href="https://app.greptile.com/trex/runs/13705133/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Views/Work/WorkChatAttachmentTray.swift | Adds input attachment state, image preparation, preview UI, and scoped temp-save helpers. |
| apps/ios/ADE/Views/Work/WorkNewChatScreen.swift | Threads opener attachments through new-chat creation, scoped save, initial send, and navigation state. |
| apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift | Saves attachment refs before send or steer and includes them in local echoes and queued steer state. |
| apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift | Uses opener dispatch state and attachment-aware keys when staging and reconciling local echoes. |
| apps/ios/ADE/Views/Work/WorkTimelineHelpers.swift | Updates timeline filtering so local echo dedupe includes attachment identity. |

<sub>Reviews (7): Last reviewed commit: ["Preserve attachments on queued steers"](https://github.com/arul28/ade/commit/ecb1bef8076a73a6044538249e2f4fad98fcb3df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42724319)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sending images and other attachments in chat.
  * Users can paste images, pick photos, preview attachments, and remove them before sending.
  * New chats and ongoing chats now preserve attachment state more reliably.

* **Bug Fixes**
  * Improved message preview and timeline behavior so attachment-based messages render correctly.
  * Fixed duplicate message handling when two messages have the same text but different attachments.
  * Restored drafts and attachments if sending fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->