### PR TITLE
Show dictation startup state on mobile

### DIFF
--- a/apps/ios/ADE/Services/Dictation/DictationController.swift
+++ b/apps/ios/ADE/Services/Dictation/DictationController.swift
@@ -64,6 +64,14 @@ final class DictationController: ObservableObject {
     @Published private(set) var isStarting = false
     @Published private(set) var isPreparing = false
 
+    var recordingPillIsStarting: Bool {
+        isStarting || isPreparing
+    }
+
+    var recordingPillStartupLabel: String {
+        isPreparing ? "Preparing..." : "Starting..."
+    }
+
     private let glossary: VoiceGlossary
 
     // MARK: - Insertion target

--- a/apps/ios/ADE/Views/Components/DictationMicButton.swift
+++ b/apps/ios/ADE/Views/Components/DictationMicButton.swift
@@ -135,9 +135,9 @@ struct DictationMicButton: View {
       RecordingPill(
         elapsedTime: controller.elapsedTime,
         audioLevel: controller.audioLevel,
-        isStarting: controller.isStarting || controller.isPreparing,
+        isStarting: controller.recordingPillIsStarting,
         isFinishing: controller.isFinishing,
-        startupLabel: controller.isPreparing ? "Preparing..." : "Starting...",
+        startupLabel: controller.recordingPillStartupLabel,
         onCancel: cancelRecording,
         onDone: finishRecording
       )

--- a/apps/ios/ADE/Views/Components/DictationMicButton.swift
+++ b/apps/ios/ADE/Views/Components/DictationMicButton.swift
@@ -83,8 +83,8 @@ struct DictationMicButton: View {
     // Observed at the top level so the transition back to idle is seen even
     // though the idle mic sub-view is removed while the pill is shown. The
     // host collapses its other controls whenever the dictation UI is active —
-    // either actively recording OR finalizing after Done — so the pill never
-    // briefly coexists with the normal cluster.
+    // starting, preparing, recording, or finalizing after Done — so the pill
+    // never briefly coexists with the normal cluster.
     .onChange(of: controller.isRecording) { _, _ in
       publishRecordingState()
     }
@@ -135,7 +135,9 @@ struct DictationMicButton: View {
       RecordingPill(
         elapsedTime: controller.elapsedTime,
         audioLevel: controller.audioLevel,
-        isFinishing: controller.isFinishing || controller.isStarting || controller.isPreparing,
+        isStarting: controller.isStarting || controller.isPreparing,
+        isFinishing: controller.isFinishing,
+        startupLabel: controller.isPreparing ? "Preparing..." : "Starting...",
         onCancel: cancelRecording,
         onDone: finishRecording
       )

--- a/apps/ios/ADE/Views/Components/GlobalDictationPill.swift
+++ b/apps/ios/ADE/Views/Components/GlobalDictationPill.swift
@@ -23,9 +23,9 @@ struct GlobalDictationPill: View {
         RecordingPill(
           elapsedTime: controller.elapsedTime,
           audioLevel: controller.audioLevel,
-          isStarting: controller.isStarting || controller.isPreparing,
+          isStarting: controller.recordingPillIsStarting,
           isFinishing: controller.isFinishing,
-          startupLabel: controller.isPreparing ? "Preparing..." : "Starting...",
+          startupLabel: controller.recordingPillStartupLabel,
           onCancel: { controller.cancelRecording() },
           onDone: { controller.finishRecording(origin: .globalPill) },
           opaque: true

--- a/apps/ios/ADE/Views/Components/GlobalDictationPill.swift
+++ b/apps/ios/ADE/Views/Components/GlobalDictationPill.swift
@@ -7,9 +7,8 @@ import SwiftUI
 /// and waveform and tap Done / Cancel without returning to the composer.
 ///
 /// It observes the injected app-level `DictationController` and shows itself
-/// whenever a recording is in flight (`isRecording`) or finalizing
-/// (`isFinishing`). It deliberately does not hide based on whether a composer's
-/// own pill is also visible.
+/// whenever startup, recording, or finalizing is in flight. It deliberately
+/// does not hide based on whether a composer's own pill is also visible.
 struct GlobalDictationPill: View {
   @EnvironmentObject private var controller: DictationController
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -24,7 +23,9 @@ struct GlobalDictationPill: View {
         RecordingPill(
           elapsedTime: controller.elapsedTime,
           audioLevel: controller.audioLevel,
-          isFinishing: controller.isFinishing || controller.isStarting || controller.isPreparing,
+          isStarting: controller.isStarting || controller.isPreparing,
+          isFinishing: controller.isFinishing,
+          startupLabel: controller.isPreparing ? "Preparing..." : "Starting...",
           onCancel: { controller.cancelRecording() },
           onDone: { controller.finishRecording(origin: .globalPill) },
           opaque: true

--- a/apps/ios/ADE/Views/Components/RecordingPill.swift
+++ b/apps/ios/ADE/Views/Components/RecordingPill.swift
@@ -1,17 +1,21 @@
 import SwiftUI
 
 /// Inline recording pill shown in place of the composer's trailing controls
-/// while dictation is active. Renders a live timer, a real-amplitude waveform
-/// driven by the dictation service's `audioLevel`, and cancel (✕) / done (✓)
-/// controls. Sized to occupy the trailing cluster so swapping it in for the
-/// idle mic + send buttons does not jump the composer layout.
+/// while dictation is active. Renders startup/finalizing feedback, a live timer,
+/// a real-amplitude waveform driven by the dictation service's `audioLevel`,
+/// and cancel (✕) / done (✓) controls. Sized to occupy the trailing cluster so
+/// swapping it in for the idle mic + send buttons does not jump the composer
+/// layout.
 struct RecordingPill: View {
   /// Elapsed recording time in seconds.
   let elapsedTime: TimeInterval
   /// Current normalized input amplitude (0...1).
   let audioLevel: Float
+  /// True while microphone / speech assets are warming up before capture starts.
+  let isStarting: Bool
   /// True while the analyzer is finalizing after the user taps done.
   let isFinishing: Bool
+  let startupLabel: String
   let onCancel: () -> Void
   let onDone: () -> Void
   var opaque = false
@@ -25,9 +29,23 @@ struct RecordingPill: View {
         .foregroundStyle(ADEColor.textPrimary)
         .accessibilityHidden(true)
 
-      DictationWaveform(level: audioLevel, reduceMotion: reduceMotion)
-        .frame(maxWidth: .infinity)
-        .accessibilityHidden(true)
+      if isStarting {
+        HStack(spacing: 6) {
+          ProgressView()
+            .controlSize(.mini)
+            .tint(ADEColor.danger)
+          Text(startupLabel)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(ADEColor.textSecondary)
+            .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, minHeight: 22, alignment: .leading)
+        .accessibilityLabel(startupLabel)
+      } else {
+        DictationWaveform(level: audioLevel, reduceMotion: reduceMotion)
+          .frame(maxWidth: .infinity)
+          .accessibilityHidden(true)
+      }
 
       Button(action: onCancel) {
         Image(systemName: "xmark")
@@ -42,7 +60,7 @@ struct RecordingPill: View {
 
       Button(action: onDone) {
         ZStack {
-          if isFinishing {
+          if isFinishing || isStarting {
             ProgressView()
               .controlSize(.mini)
               .tint(Color(red: 0.12, green: 0.12, blue: 0.14))
@@ -56,8 +74,8 @@ struct RecordingPill: View {
         .background(Circle().fill(Color.white.opacity(0.9)))
       }
       .buttonStyle(.plain)
-      .disabled(isFinishing)
-      .accessibilityLabel(isFinishing ? "Finishing dictation" : "Insert dictated text")
+      .disabled(isFinishing || isStarting)
+      .accessibilityLabel(isStarting ? startupLabel : (isFinishing ? "Finishing dictation" : "Insert dictated text"))
     }
     .padding(.horizontal, 12)
     .padding(.vertical, 8)
@@ -76,7 +94,7 @@ struct RecordingPill: View {
         .stroke(ADEColor.danger.opacity(0.25), lineWidth: 1)
     )
     .accessibilityElement(children: .contain)
-    .accessibilityLabel("Recording, \(accessibilityTime)")
+    .accessibilityLabel(isStarting ? startupLabel : "Recording, \(accessibilityTime)")
   }
 
   private var timeString: String {


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstart-skill-confirm-couple-things-977c7fd1 num=734 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstart-skill-confirm-couple-things-977c7fd1&amp;pr=734">ade/start-skill-confirm-couple-things-977c7fd1 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=734">PR #734</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearer startup state for dictation, showing “Starting…” or “Preparing…” before recording begins.
  * The dictation pill now keeps a visible progress indicator during startup, recording, and finalizing.

* **Bug Fixes**
  * Improved state handling so the pill no longer briefly overlaps with the normal mic controls during the dictation flow.
  * Updated accessibility text and button behavior to better reflect the current dictation stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the mobile dictation startup pill. The main changes are:

- Adds shared startup state and label helpers on the dictation controller.
- Shows a startup progress label before live recording begins.
- Keeps the Done button disabled during startup and finalizing.
- Updates inline and global dictation pill call sites to use the shared state.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the general contract for the dictation startup proofs by inspecting the environment probe, confirming the iOS project path exists but Apple build/runtime tools are not available.
- Reviewed the runtime attempt logs and noted specific failures due to xcodebuild and xcrun not being found, indicating the build could not proceed in this environment.
- Examined the static evidence from the code changes showing startup UI elements like recordingPillStartupLabel, Starting.../Preparing..., ProgressView, and a disabled Done control, confirming the intended startup flow is represented in the UI state.
- Prepared and organized artifacts for reviewer inspection to support verification of environment probes, runtime attempts, and post-change UI state.

<a href="https://app.greptile.com/trex/runs/13698347/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Services/Dictation/DictationController.swift | Adds shared helpers for the recording pill startup state and startup label. |
| apps/ios/ADE/Views/Components/DictationMicButton.swift | Passes the controller startup helpers into the inline recording pill. |
| apps/ios/ADE/Views/Components/GlobalDictationPill.swift | Passes the controller startup helpers into the global recording pill. |
| apps/ios/ADE/Views/Components/RecordingPill.swift | Renders startup progress separately from the live waveform and finalizing state. |

<sub>Reviews (2): Last reviewed commit: ["Address mobile dictation review feedback"](https://github.com/arul28/ade/commit/bce536fd98f0a6b6831c9b999091fb2d34734d90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42728928)</sub>

<!-- /greptile_comment -->