### PR TITLE
Fix mobile prompt autocorrect traits

### DIFF
--- a/apps/ios/ADE/Views/Components/ADEDesignSystem.swift
+++ b/apps/ios/ADE/Views/Components/ADEDesignSystem.swift
@@ -1332,6 +1332,11 @@ extension View {
     modifier(ADEInsetFieldModifier(cornerRadius: cornerRadius, padding: padding))
   }
 
+  func adePromptInputTraits() -> some View {
+    textInputAutocapitalization(.sentences)
+      .autocorrectionDisabled(false)
+  }
+
   func adeListCard(
     cornerRadius: CGFloat = ADEListRowMetrics.cornerRadius,
     padding: CGFloat = ADEListRowMetrics.padding

--- a/apps/ios/ADE/Views/Cto/CtoIdentityEditor.swift
+++ b/apps/ios/ADE/Views/Cto/CtoIdentityEditor.swift
@@ -76,6 +76,7 @@ struct CtoIdentityEditor: View {
           Section {
             TextEditor(text: $localExtension)
               .font(.system(.body))
+              .adePromptInputTraits()
               .frame(minHeight: 140)
           } header: {
             Text("System prompt extension")

--- a/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
+++ b/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
@@ -617,7 +617,7 @@ struct HubInlineComposer: View {
           .font(.body)
           .foregroundStyle(ADEColor.textPrimary)
           .tint(ADEColor.accent)
-          .textInputAutocapitalization(.sentences)
+          .adePromptInputTraits()
           .focused($composerFocused)
           .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
 

--- a/apps/ios/ADE/Views/Linear/LinearLaunchScreen.swift
+++ b/apps/ios/ADE/Views/Linear/LinearLaunchScreen.swift
@@ -210,6 +210,7 @@ struct LinearLaunchScreen: View {
       TextEditor(text: $kickoff)
         .font(.subheadline)
         .foregroundStyle(ADEColor.textPrimary)
+        .adePromptInputTraits()
         .frame(minHeight: 120)
         .scrollContentBackground(.hidden)
         .padding(10)

--- a/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
@@ -724,8 +724,7 @@ struct WorkQueuedSteerRow: View {
       if isEditing {
         TextField("Queued message", text: $draft, axis: .vertical)
           .lineLimit(1...5)
-          .autocorrectionDisabled(false)
-          .textInputAutocapitalization(.sentences)
+          .adePromptInputTraits()
           .adeInsetField(cornerRadius: 12, padding: 10)
           .disabled(busy || !isLive)
 
@@ -1063,8 +1062,7 @@ struct WorkStructuredQuestionCard: View {
       TextField(q.options.isEmpty ? "Response" : "Optional response", text: binding, axis: .vertical)
         .focused($freeformFocused)
         .lineLimit(1...4)
-        .autocorrectionDisabled(false)
-        .textInputAutocapitalization(.sentences)
+        .adePromptInputTraits()
         .adeInsetField(cornerRadius: 14, padding: 12)
         .disabled(busy)
     }

--- a/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
@@ -2027,6 +2027,7 @@ struct WorkPlanReviewCard: View {
         .foregroundStyle(ADEColor.textMuted)
       TextField("Describe what to change…", text: $feedbackText, axis: .vertical)
         .lineLimit(2...5)
+        .adePromptInputTraits()
         .adeInsetField(cornerRadius: 12, padding: 10)
         .disabled(busy)
     }

--- a/apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift
+++ b/apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift
@@ -386,6 +386,7 @@ struct WorkComposerTextView: UIViewRepresentable {
     /// keep styled and which to de-chip when they're edited into.
     private var chips: [(range: NSRange, text: String)] = []
     private var placeholderLabel: UILabel?
+    private var triggerInputTraitsActive = false
 
     init(_ parent: WorkComposerTextView) {
       self.parent = parent
@@ -413,6 +414,19 @@ struct WorkComposerTextView: UIViewRepresentable {
         .foregroundColor: tint,
         .workComposerChipTint: tint,
       ]
+    }
+
+    private func applyPromptInputTraits(protectingTrigger: Bool) {
+      guard let textView else { return }
+      guard triggerInputTraitsActive != protectingTrigger else { return }
+      triggerInputTraitsActive = protectingTrigger
+
+      textView.autocorrectionType = protectingTrigger ? .no : .yes
+      textView.autocapitalizationType = protectingTrigger ? .none : .sentences
+      textView.spellCheckingType = protectingTrigger ? .no : .yes
+      if textView.isFirstResponder {
+        textView.reloadInputViews()
+      }
     }
 
     // MARK: Text sync
@@ -507,12 +521,14 @@ struct WorkComposerTextView: UIViewRepresentable {
     private func detectTrigger() {
       guard let textView else { return }
       guard textView.isFirstResponder else {
+        applyPromptInputTraits(protectingTrigger: false)
         parent.controller.clear()
         return
       }
       let selection = textView.selectedRange
       // Only detect against a collapsed caret; a ranged selection isn't a trigger.
       guard selection.length == 0 else {
+        applyPromptInputTraits(protectingTrigger: false)
         parent.controller.clear()
         return
       }
@@ -520,6 +536,7 @@ struct WorkComposerTextView: UIViewRepresentable {
         in: textView.text as NSString,
         cursor: selection.location
       )
+      applyPromptInputTraits(protectingTrigger: match != nil)
       parent.controller.update(match: match)
     }
 

--- a/apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift
+++ b/apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift
@@ -336,9 +336,10 @@ struct WorkComposerTextView: UIViewRepresentable {
     textView.backgroundColor = .clear
     textView.textContainerInset = .zero
     textView.isScrollEnabled = false
-    textView.autocorrectionType = .no
-    textView.autocapitalizationType = .none
-    textView.spellCheckingType = .no
+    // Keep natural-language prompt traits aligned with `adePromptInputTraits()`.
+    textView.autocorrectionType = .yes
+    textView.autocapitalizationType = .sentences
+    textView.spellCheckingType = .yes
     textView.smartQuotesType = .no
     textView.smartDashesType = .no
     textView.tintColor = UIColor(ADEColor.accent)

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -1332,8 +1332,7 @@ private struct WorkNewChatComposerBar: View {
         .font(.body)
         .foregroundStyle(ADEColor.textPrimary)
         .tint(ADEColor.accent)
-        .autocorrectionDisabled(false)
-        .textInputAutocapitalization(.sentences)
+        .adePromptInputTraits()
         .focused($composerFocused)
         .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
 

--- a/apps/ios/ADE/Views/Work/WorkNewChatSheet.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatSheet.swift
@@ -323,8 +323,7 @@ struct WorkNewChatSheet: View {
           GlassSection(title: "Opening prompt") {
             VStack(alignment: .leading, spacing: 8) {
               TextField("Tell the agent what to do", text: $initialMessage, axis: .vertical)
-                .textInputAutocapitalization(.sentences)
-                .autocorrectionDisabled(false)
+                .adePromptInputTraits()
                 .adeInsetField(cornerRadius: 14, padding: 12)
                 .disabled(busy)
 

--- a/apps/ios/ADE/Views/Work/WorkPlanComposerViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkPlanComposerViews.swift
@@ -91,6 +91,7 @@ struct WorkPlanRejectFeedbackSection: View {
 
       TextField("Describe what to change...", text: $feedbackText, axis: .vertical)
         .lineLimit(2...4)
+        .adePromptInputTraits()
         .adeInsetField(cornerRadius: 12, padding: 10)
         .disabled(busy)
     }


### PR DESCRIPTION
## Summary
- enable sentence autocorrect traits for all natural-language mobile prompt/composer fields
- add a shared SwiftUI prompt-input modifier and align the UIKit-backed Work composer traits
- keep technical fields like paths, terminal input, branches, URLs, and search autocorrect-free

## Tests
- XcodeBuildMCP build_sim ADE / iPhone 17 Pro
- XcodeBuildMCP test_sim -only-testing:ADETests/WorkComposerTriggerDetectorTests
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates mobile prompt fields to use natural-language input traits.

- Adds a shared SwiftUI prompt input modifier.
- Applies the modifier to natural-language prompt and feedback fields.
- Keeps the trigger-aware Work composer protected while slash and mention triggers are active.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The iOS explicit test plan transcript was saved and captures exact commands, working directories, command outputs, blockers for missing xcodebuild, and exit statuses.
- The git diff --check run reported no whitespace errors for the requested PR range.

<a href="https://app.greptile.com/trex/runs/13699158/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Views/Components/ADEDesignSystem.swift | Adds a shared prompt input modifier for sentence autocapitalization and enabled autocorrection. |
| apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift | Uses natural-language traits by default and disables them while slash or mention triggers are active. |
| apps/ios/ADE/Views/Cto/CtoIdentityEditor.swift | Applies prompt input traits to the system prompt extension editor. |
| apps/ios/ADE/Views/Hub/HubComposerDrawer.swift | Replaces inline input traits with the shared prompt input modifier. |
| apps/ios/ADE/Views/Linear/LinearLaunchScreen.swift | Applies prompt input traits to the Linear kickoff editor. |
| apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift | Uses the shared prompt input modifier for queued message and structured response fields. |
| apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift | Applies prompt input traits to plan review feedback. |
| apps/ios/ADE/Views/Work/WorkNewChatScreen.swift | Uses the shared prompt input modifier in the new chat composer bar. |
| apps/ios/ADE/Views/Work/WorkNewChatSheet.swift | Uses the shared prompt input modifier for the opening prompt field. |
| apps/ios/ADE/Views/Work/WorkPlanComposerViews.swift | Applies prompt input traits to plan rejection feedback. |

<sub>Reviews (2): Last reviewed commit: ["ship: iteration 1 - protect composer tri..."](https://github.com/arul28/ade/commit/9197b01611bfc09a528c26031c15aad8332d837d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42729218)</sub>

<!-- /greptile_comment -->