### PR TITLE
Fix Configured Hidden Pairing PIN State

### DIFF
--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -756,8 +756,13 @@ describe("ADE CLI", () => {
     });
     const output = formatOutput(result, { text: true } as any, inferFormatter(plan));
     expect(output).toContain("  Code   (PIN configured but hidden after runtime restart)");
+    expect(output).toContain("  Known  Use the existing code if you already know it.");
     expect(output).toContain("  New    ade sync pin generate");
     expect(output).toContain("  Set    ade sync pin set <6-digit-code>");
+    expect(output).toContain(
+      "Open the link and enter the existing code if you know it. " +
+        "Generate or set a new code only if you need ADE to display or copy one.",
+    );
     expect(output).not.toContain("no PIN set");
   });
 

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -717,6 +717,50 @@ describe("ADE CLI", () => {
       .toContain("  Code   123456");
   });
 
+  it("formats sync web pairing info when the configured PIN is hidden", () => {
+    const plan = expectExecutePlan(buildCliPlan(["sync", "web"]));
+    const connection = {
+      mode: "runtime-socket" as const,
+      projectRoot: "/tmp/project",
+      workspaceRoot: "/tmp/project",
+      socketPath: "/tmp/ade.sock",
+      request: async () => null,
+      close: () => {},
+    };
+    const result = summarizeExecution({
+      plan,
+      connection,
+      values: {
+        result: {
+          pairingPin: null,
+          pairingPinConfigured: true,
+          localDevice: { name: "Fallback Machine" },
+          pairingConnectInfo: {
+            hostIdentity: {
+              deviceId: "device-1",
+              siteId: "site-1",
+              name: "Arul's Mac Studio",
+              platform: "macOS",
+              deviceType: "desktop",
+            },
+            port: 8787,
+            addressCandidates: [{ host: "10.0.0.2", kind: "lan" }],
+          },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      code: null,
+      pinConfigured: true,
+    });
+    const output = formatOutput(result, { text: true } as any, inferFormatter(plan));
+    expect(output).toContain("  Code   (PIN configured but hidden after runtime restart)");
+    expect(output).toContain("  New    ade sync pin generate");
+    expect(output).toContain("  Set    ade sync pin set <6-digit-code>");
+    expect(output).not.toContain("no PIN set");
+  });
+
   it("applies sync web clipboard and open flags only when a link exists", () => {
     const options = {
       ...baseResolveOpts(),

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -14524,10 +14524,13 @@ function formatSyncWebPairing(value: unknown): string {
   } else if (info.pinConfigured) {
     codeLines = [
       "  Code   (PIN configured but hidden after runtime restart)",
+      "  Known  Use the existing code if you already know it.",
       "  New    ade sync pin generate",
       "  Set    ade sync pin set <6-digit-code>",
     ];
-    nextStep = "Generate or set a new code on this machine, then run ade sync web again.";
+    nextStep =
+      "Open the link and enter the existing code if you know it. " +
+      "Generate or set a new code only if you need ADE to display or copy one.";
   } else {
     codeLines = ["  Code   (no PIN set — run: ade sync pin generate)"];
     nextStep = "Generate or set a new code on this machine, then run ade sync web again.";

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -14515,15 +14515,30 @@ function formatSyncWebPairing(value: unknown): string {
   if (!info.pairingUrl) {
     return "No machine addresses are published yet — is the sync host running? (ade sync status)";
   }
+  const hasVisibleCode = info.pinConfigured && Boolean(info.code);
+  let codeLines: string[];
+  let nextStep: string;
+  if (hasVisibleCode) {
+    codeLines = [`  Code   ${info.code}`];
+    nextStep = "Open the link in any browser and enter the code to pair.";
+  } else if (info.pinConfigured) {
+    codeLines = [
+      "  Code   (PIN configured but hidden after runtime restart)",
+      "  New    ade sync pin generate",
+      "  Set    ade sync pin set <6-digit-code>",
+    ];
+    nextStep = "Generate or set a new code on this machine, then run ade sync web again.";
+  } else {
+    codeLines = ["  Code   (no PIN set — run: ade sync pin generate)"];
+    nextStep = "Generate or set a new code on this machine, then run ade sync web again.";
+  }
   return [
     "Web client pairing",
     "",
     `  Link   ${info.pairingUrl}`,
-    info.pinConfigured && info.code
-      ? `  Code   ${info.code}`
-      : "  Code   (no PIN set — run: ade sync pin generate)",
+    ...codeLines,
     "",
-    "Open the link in any browser and enter the code to pair.",
+    nextStep,
     "Off your LAN or tailnet? Turn on the relay so the browser can reach this machine:",
     "  ade sync relay enable",
   ].join("\n");

--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.test.ts
@@ -157,6 +157,32 @@ describe("createSyncRemoteCommandService", () => {
     });
   });
 
+  it("returns configured hidden web pairing info when only the PIN hash is available", async () => {
+    const syncPinStore = {
+      getPin: vi.fn(() => null),
+      hasPin: vi.fn(() => true),
+    };
+    const { service } = createService({
+      syncPinStore,
+      getPairingConnectInfo: () => makePairingConnectInfo(),
+      isCloudRelayEnabled: () => false,
+    });
+
+    const result = await service.execute(makePayload("sync.getWebPairingInfo")) as SyncWebPairingInfo;
+
+    expect(result.pairingUrl).toContain("https://app.ade-app.dev/pair#");
+    expect(result).toEqual({
+      pairingUrl: result.pairingUrl,
+      code: null,
+      pinConfigured: true,
+      machineName: "Arul's Mac Studio",
+      relayEnabled: false,
+      hasRelayCandidate: false,
+    });
+    expect(syncPinStore.hasPin).toHaveBeenCalled();
+    expect(syncPinStore.getPin).toHaveBeenCalled();
+  });
+
   it("routes work.resumeCliSession through the durable PTY resume path", async () => {
     const { service, ptyService } = createService();
 

--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
@@ -3912,7 +3912,7 @@ function registerSyncRemoteCommands({ args, register }: RemoteCommandRegistratio
       );
       const connectInfo = requireService(getPairingConnectInfo(), "Sync pairing connect info is not available.");
       const pinConfigured = syncPinStore.hasPin();
-      const code = syncPinStore.getPin();
+      const code = pinConfigured ? syncPinStore.getPin() : null;
       const hasRelayCandidate = connectInfo.addressCandidates.some((candidate) =>
         candidate.kind === "relay" && candidate.host.trim().length > 0);
       return {

--- a/apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx
@@ -846,6 +846,13 @@ function WebClientCard({
 }) {
   const hasAddresses = (connectInfo?.addressCandidates.length ?? 0) > 0;
   const pinMissing = !pinConfigured;
+  const pinHidden = pinConfigured && !pin;
+  let pairingHelpText = "Open the link, enter the pairing code in the browser, and the browser pairs to this machine.";
+  if (pinMissing) {
+    pairingHelpText = "No PIN set. Browsers cannot pair. Set a PIN in the phone pairing section above.";
+  } else if (pinHidden) {
+    pairingHelpText = "A PIN is configured but hidden after runtime restart. Generate or set a new PIN above to display or copy it for browser pairing.";
+  }
 
   return (
     <div style={cardStyle({ display: "grid", gap: 16 })}>
@@ -893,11 +900,7 @@ function WebClientCard({
         <div style={helperTextStyle}>No machine addresses are published yet.</div>
       )}
 
-      <div style={helperTextStyle}>
-        {pinMissing
-          ? "No PIN set. Browsers cannot pair. Set a PIN in the phone pairing section above."
-          : "Open the link, enter the pairing code in the browser, and the browser pairs to this machine."}
-      </div>
+      <div style={helperTextStyle}>{pairingHelpText}</div>
     </div>
   );
 }
@@ -926,7 +929,7 @@ function WebPairCode({ pin, pinConfigured }: { pin: string | null; pinConfigured
         style={outlineButton({ justifySelf: "start", height: 30 })}
         onClick={() => void handleCopy()}
         disabled={!pin}
-        title={pin ? undefined : "The PIN is hidden; reveal or set it in the phone pairing section above."}
+        title={pin ? undefined : "The PIN is hidden; generate or set a new PIN in the phone pairing section above."}
       >
         {copied ? "Copied" : "Copy code"}
       </button>

--- a/apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx
@@ -851,7 +851,9 @@ function WebClientCard({
   if (pinMissing) {
     pairingHelpText = "No PIN set. Browsers cannot pair. Set a PIN in the phone pairing section above.";
   } else if (pinHidden) {
-    pairingHelpText = "A PIN is configured but hidden after runtime restart. Generate or set a new PIN above to display or copy it for browser pairing.";
+    pairingHelpText =
+      "A PIN is configured but hidden after runtime restart. If you already know it, the existing PIN still pairs. " +
+      "Generate or set a new PIN above only when you need ADE to display or copy one.";
   }
 
   return (

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -1433,6 +1433,20 @@ struct WebPairingInfo: Decodable, Equatable {
   let hasRelayCandidate: Bool
 }
 
+enum WebPairingPinState: Equatable {
+  case notConfigured
+  case configuredHidden
+  case visible(String)
+}
+
+extension WebPairingInfo {
+  var pinState: WebPairingPinState {
+    guard pinConfigured else { return .notConfigured }
+    let trimmedCode = code?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return trimmedCode.isEmpty ? .configuredHidden : .visible(trimmedCode)
+  }
+}
+
 /// Delivery events for the full-screen terminal. The active screen attaches a
 /// handler per session id and receives hydration snapshots, ordered live
 /// chunks, and process exit without polling `terminalBuffers`.

--- a/apps/ios/ADE/Views/Settings/SettingsWebClientPairSheet.swift
+++ b/apps/ios/ADE/Views/Settings/SettingsWebClientPairSheet.swift
@@ -245,7 +245,8 @@ struct SettingsWebClientPairSheet: View {
       unavailableCodePanel(
         iconName: "lock",
         title: "Pairing code hidden",
-        detail: "A PIN is configured on \(machineName(info)), but ADE cannot display it after the runtime restarts. Generate or set a new PIN on the machine if you need to display or copy it."
+        detail: "A PIN is configured on \(machineName(info)), but ADE cannot display it after the runtime restarts. If you already know it, the existing PIN still pairs. " +
+          "Generate or set a new PIN on the machine only when you need to display or copy one."
       )
     case .notConfigured:
       unavailableCodePanel(

--- a/apps/ios/ADE/Views/Settings/SettingsWebClientPairSheet.swift
+++ b/apps/ios/ADE/Views/Settings/SettingsWebClientPairSheet.swift
@@ -211,7 +211,8 @@ struct SettingsWebClientPairSheet: View {
 
   @ViewBuilder
   private func codePanel(_ info: WebPairingInfo) -> some View {
-    if let code = pairingCode(info) {
+    switch info.pinState {
+    case .visible(let code):
       VStack(alignment: .leading, spacing: 12) {
         captionHeader("Pairing code")
         HStack(alignment: .center, spacing: 12) {
@@ -240,37 +241,55 @@ struct SettingsWebClientPairSheet: View {
         }
       }
       .webPairPanel()
-    } else {
-      VStack(alignment: .leading, spacing: 12) {
-        HStack(alignment: .top, spacing: 10) {
-          Image(systemName: "lock.slash")
-            .font(.system(size: 18, weight: .semibold))
-            .foregroundStyle(ADEColor.warning)
-            .frame(width: 28, height: 28)
-            .background(Circle().fill(ADEColor.warning.opacity(0.14)))
-          VStack(alignment: .leading, spacing: 4) {
-            Text("No pairing code set")
-              .font(.subheadline.weight(.semibold))
-              .foregroundStyle(ADEColor.textPrimary)
-            Text("Set a PIN in ADE on the computer, then retry.")
-              .font(.footnote)
-              .foregroundStyle(ADEColor.textSecondary)
-              .fixedSize(horizontal: false, vertical: true)
-          }
-        }
-
-        Button {
-          Task { await load() }
-        } label: {
-          Label("Retry", systemImage: "arrow.clockwise")
-            .font(.subheadline.weight(.semibold))
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 10)
-        }
-        .buttonStyle(.glass)
-      }
-      .webPairPanel()
+    case .configuredHidden:
+      unavailableCodePanel(
+        iconName: "lock",
+        title: "Pairing code hidden",
+        detail: "A PIN is configured on \(machineName(info)), but ADE cannot display it after the runtime restarts. Generate or set a new PIN on the machine if you need to display or copy it."
+      )
+    case .notConfigured:
+      unavailableCodePanel(
+        iconName: "lock.slash",
+        title: "No pairing code set",
+        detail: "Set a PIN in ADE on the computer, then retry."
+      )
     }
+  }
+
+  private func unavailableCodePanel(
+    iconName: String,
+    title: String,
+    detail: String
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack(alignment: .top, spacing: 10) {
+        Image(systemName: iconName)
+          .font(.system(size: 18, weight: .semibold))
+          .foregroundStyle(ADEColor.warning)
+          .frame(width: 28, height: 28)
+          .background(Circle().fill(ADEColor.warning.opacity(0.14)))
+        VStack(alignment: .leading, spacing: 4) {
+          Text(title)
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(ADEColor.textPrimary)
+          Text(detail)
+            .font(.footnote)
+            .foregroundStyle(ADEColor.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+
+      Button {
+        Task { await load() }
+      } label: {
+        Label("Retry", systemImage: "arrow.clockwise")
+          .font(.subheadline.weight(.semibold))
+          .frame(maxWidth: .infinity)
+          .padding(.vertical, 10)
+      }
+      .buttonStyle(.glass)
+    }
+    .webPairPanel()
   }
 
   private func securityLine(_ info: WebPairingInfo) -> some View {
@@ -321,15 +340,6 @@ struct SettingsWebClientPairSheet: View {
   private func machineName(_ info: WebPairingInfo) -> String {
     let trimmed = info.machineName.trimmingCharacters(in: .whitespacesAndNewlines)
     return trimmed.isEmpty ? "this machine" : trimmed
-  }
-
-  private func pairingCode(_ info: WebPairingInfo) -> String? {
-    guard info.pinConfigured,
-          let code = info.code?.trimmingCharacters(in: .whitespacesAndNewlines),
-          !code.isEmpty else {
-      return nil
-    }
-    return code
   }
 
   private func spacedCode(_ code: String) -> String {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -1063,6 +1063,38 @@ final class ADETests: XCTestCase {
     XCTAssertNil(syncOutboundEnvelopeProjectId(type: "file_request", activeProjectId: "  "))
   }
 
+  func testWebPairingInfoPinStateDistinguishesHiddenConfiguredPin() {
+    let visible = WebPairingInfo(
+      pairingUrl: "https://app.ade-app.dev/pair#payload",
+      code: " 123456 ",
+      pinConfigured: true,
+      machineName: "Arul's Mac Studio",
+      relayEnabled: true,
+      hasRelayCandidate: true
+    )
+    XCTAssertEqual(visible.pinState, .visible("123456"))
+
+    let hidden = WebPairingInfo(
+      pairingUrl: "https://app.ade-app.dev/pair#payload",
+      code: nil,
+      pinConfigured: true,
+      machineName: "Arul's Mac Studio",
+      relayEnabled: true,
+      hasRelayCandidate: true
+    )
+    XCTAssertEqual(hidden.pinState, .configuredHidden)
+
+    let missing = WebPairingInfo(
+      pairingUrl: "https://app.ade-app.dev/pair#payload",
+      code: nil,
+      pinConfigured: false,
+      machineName: "Arul's Mac Studio",
+      relayEnabled: true,
+      hasRelayCandidate: true
+    )
+    XCTAssertEqual(missing.pinState, .notConfigured)
+  }
+
   func testDecodeHydrationPayloadWrapsMalformedHostData() {
     XCTAssertThrowsError(
       try decodeHydrationPayload(

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -653,10 +653,14 @@ is not supported.
   `KeychainService.tokenAccount`) when the desktop did not bundle a
   fresh credential.
 - **Phone pairing**: user-set **6-digit PIN** stored on the runtime at
-  `~/.ade/secrets/sync-pin.json`. The PIN is owned by the human
-  operator — the runtime does not rotate it, does not time-expire it,
-  and does not mint a one-shot code. The phone enters the same digits
-  the user typed in the machine's Settings > Sync > Phone pairing sheet.
+  `~/.ade/secrets/sync-pin.json` as a PBKDF2 hash. The PIN is owned by
+  the human operator — the runtime does not rotate it, does not
+  time-expire it, and does not mint a one-shot code. The runtime keeps
+  plaintext only in the current process after the user sets/generates
+  it (or after legacy migration), so after a restart the host can verify
+  pairings but cannot display or copy the digits until the user
+  generates or sets a new PIN. The phone enters the same digits the user
+  typed in the machine's Settings > Sync > Phone pairing sheet.
   Failed PIN attempts increment a per-IP counter; after 5 failures
   the runtime rejects further attempts from that IP for 10 minutes
   (`PAIR_FAILURE_THRESHOLD = 5`, `PAIR_COOLDOWN_MS = 10 * 60_000` in
@@ -909,13 +913,16 @@ feature is merged or because a deliberately isolated-port host is running.
   device backups — a restored phone re-pairs with the PIN.
 - **Pairing**: two independent paths. Machine-to-machine pairing uses
   the shared bootstrap token from the machine secrets directory.
-  Phone pairing uses a **user-set 6-digit PIN** stored in
-  `~/.ade/secrets/sync-pin.json` on the runtime machine. The runtime never auto-rotates
-  or TTLs the PIN; the user sets it through Settings > Sync and clears
-  it when they want to stop accepting new pairings. The PIN unlocks
-  generation of a durable per-device secret that the phone stores in
-  its Keychain; subsequent connections use that paired secret, not the
-  PIN.
+  Phone pairing uses a **user-set 6-digit PIN** stored as a PBKDF2 hash in
+  `~/.ade/secrets/sync-pin.json` on the runtime machine. The runtime never
+  auto-rotates or TTLs the PIN; the user sets it through Settings > Sync
+  and clears it when they want to stop accepting new pairings. Plaintext is
+  process-local and intentionally unrecoverable after restart, so Settings
+  and CLI surfaces treat `hasPin() && getPin() == null` as "configured but
+  hidden" and tell the user to generate/set a new PIN if they need to display
+  or copy it. The PIN unlocks generation of a durable per-device secret that
+  the phone stores in its Keychain; subsequent connections use that paired
+  secret, not the PIN.
 - **Rate limiting**: the runtime tracks failed `pairing_request` attempts
   per remote IP. Five failures put that IP into a 10-minute cooldown
   during which new pairing requests are rejected without touching the
@@ -1031,7 +1038,9 @@ feature is merged or because a deliberately isolated-port host is running.
   perpetually pairable by anyone on the network who knows the digits
   (subject to the per-IP rate limiter). Clearing the PIN from
   Settings > Sync is how you stop accepting new pairings; already-paired
-  devices keep their per-device secret and remain connected.
+  devices keep their per-device secret and remain connected. Because
+  only the hash persists, a restarted runtime can report that a PIN is
+  configured but cannot reveal it.
 - **`brain_*` is legacy naming.** In new docs and code comments prefer
   "sync authority" or "machine runtime"; existing database column names
   are kept for compatibility.

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -658,8 +658,9 @@ is not supported.
   time-expire it, and does not mint a one-shot code. The runtime keeps
   plaintext only in the current process after the user sets/generates
   it (or after legacy migration), so after a restart the host can verify
-  pairings but cannot display or copy the digits until the user
-  generates or sets a new PIN. The phone enters the same digits the user
+  pairings with the existing digits if the user still knows them. It
+  cannot display or copy those digits until the user generates or sets a
+  new PIN. The phone enters the same digits the user
   typed in the machine's Settings > Sync > Phone pairing sheet.
   Failed PIN attempts increment a per-IP counter; after 5 failures
   the runtime rejects further attempts from that IP for 10 minutes
@@ -919,10 +920,11 @@ feature is merged or because a deliberately isolated-port host is running.
   and clears it when they want to stop accepting new pairings. Plaintext is
   process-local and intentionally unrecoverable after restart, so Settings
   and CLI surfaces treat `hasPin() && getPin() == null` as "configured but
-  hidden" and tell the user to generate/set a new PIN if they need to display
-  or copy it. The PIN unlocks generation of a durable per-device secret that
-  the phone stores in its Keychain; subsequent connections use that paired
-  secret, not the PIN.
+  hidden". They still allow pairing with the existing PIN if the user knows
+  it, and tell the user to generate/set a new PIN only if they need to
+  display or copy one. The PIN unlocks generation of a durable per-device
+  secret that the phone stores in its Keychain; subsequent connections use that
+  paired secret, not the PIN.
 - **Rate limiting**: the runtime tracks failed `pairing_request` attempts
   per remote IP. Five failures put that IP into a 10-minute cooldown
   during which new pairing requests are rejected without touching the

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -645,10 +645,11 @@ yet arrived in the catchup batch.
 
 ### PIN pairing flow
 
-1. User opens Settings > Sync on the machine and sets a 6-digit
-   PIN. The runtime writes the PIN under `~/.ade/secrets` (chmod `0600`)
-   and surfaces it on the Settings > Sync sheet for the duration the
-   user wants to accept pairings.
+1. User opens Settings > Sync on the machine and sets or generates a
+   6-digit PIN. The runtime writes a PBKDF2 hash under `~/.ade/secrets`
+   (chmod `0600`) and keeps the plaintext in process memory only while
+   that runtime is alive, so a restarted machine can still verify
+   pairings but cannot display/copy the digits.
 2. Phone opens Settings > Pairing, either scans the machine QR
    (`SettingsPairingScannerSheet` → `PairingQrPayload.parse`, a v3 smart
    URL carrying machine identity, port, and address candidates — never a
@@ -678,19 +679,25 @@ runtime-scoped `sync.getWebPairingInfo` remote command (gated on
 `supportsRemoteAction("sync.getWebPairingInfo")`, so it stays hidden against
 older hosts). The runtime returns a `WebPairingInfo`: the web-client pairing URL
 (`https://app.ade-app.dev/pair#<payload>`, built host-side with
-`buildWebClientPairUrl(buildPairingQrPayload(...))`), the current 6-digit PIN
-(`code` / `pinConfigured`), the machine name, and relay reachability
-(`relayEnabled` / `hasRelayCandidate`). The sheet renders a QR of the pairing
-URL, a copyable/shareable link, and the pairing code as three separate panels —
-the payload carries machine identity, port, address candidates, and the relay
-URL, never the PIN, so the code is shown apart from the link.
+`buildWebClientPairUrl(buildPairingQrPayload(...))`), the current visible
+6-digit PIN when this runtime still has it (`code` / `pinConfigured`), the
+machine name, and relay reachability (`relayEnabled` / `hasRelayCandidate`).
+`pinConfigured == true` with `code == nil` means the hash exists but the
+plaintext is hidden after runtime restart; the sheet renders that state
+separately from "No pairing code set" and tells the user to generate or set a
+new PIN on the machine if they need to display or copy it. The sheet renders a
+QR of the pairing URL, a copyable/shareable link, and the pairing code state as
+three separate panels — the payload carries machine identity, port, address
+candidates, and the relay URL, never the PIN, so the code is shown apart from
+the link.
 
 Because the browser is a hosted HTTPS page, it can only reach the machine over a
 `wss://` route: when the machine advertises no relay candidate the sheet warns
 that the browser may only work on the same network (or that no relay route is
-available yet), and when no PIN is set it tells the user to set one in ADE on the
-computer. This is the phone-side mirror of the desktop's Settings > Sync web
-client card.
+available yet). When no PIN is set it tells the user to set one in ADE on the
+computer; when a PIN is configured but hidden it tells the user to generate or
+set a new one to display/copy it. This is the phone-side mirror of the desktop's
+Settings > Sync web client card.
 
 ### Background App Refresh
 

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -684,8 +684,9 @@ older hosts). The runtime returns a `WebPairingInfo`: the web-client pairing URL
 machine name, and relay reachability (`relayEnabled` / `hasRelayCandidate`).
 `pinConfigured == true` with `code == nil` means the hash exists but the
 plaintext is hidden after runtime restart; the sheet renders that state
-separately from "No pairing code set" and tells the user to generate or set a
-new PIN on the machine if they need to display or copy it. The sheet renders a
+separately from "No pairing code set", says the existing PIN still pairs if the
+user knows it, and tells the user to generate or set a new PIN on the machine
+only if they need to display or copy one. The sheet renders a
 QR of the pairing URL, a copyable/shareable link, and the pairing code state as
 three separate panels — the payload carries machine identity, port, address
 candidates, and the relay URL, never the PIN, so the code is shown apart from
@@ -695,8 +696,9 @@ Because the browser is a hosted HTTPS page, it can only reach the machine over a
 `wss://` route: when the machine advertises no relay candidate the sheet warns
 that the browser may only work on the same network (or that no relay route is
 available yet). When no PIN is set it tells the user to set one in ADE on the
-computer; when a PIN is configured but hidden it tells the user to generate or
-set a new one to display/copy it. This is the phone-side mirror of the desktop's
+computer; when a PIN is configured but hidden it says the existing PIN still
+pairs if known and tells the user to generate or set a new one only to
+display/copy it. This is the phone-side mirror of the desktop's
 Settings > Sync web client card.
 
 ### Background App Refresh


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=fix-configured-hidden-pairing-pin num=736 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=fix-configured-hidden-pairing-pin&amp;pr=736">fix-configured-hidden-pairing-pin branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=736">PR #736</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes how web pairing surfaces describe configured PINs that are hidden after restart. The main changes are:

- Separate visible, hidden, and missing PIN states in the CLI output.
- Return `pinConfigured` independently from the visible pairing code.
- Update desktop and iOS pairing UI copy for hidden configured PINs.
- Add tests and docs for the hidden PIN state.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Partial artifact generation and data collection occurred in the artifacts bundle, including harness source, capture scripts, server logs, browser logs, screenshots, and DOM evidence files.
- The evidence JSON from the failed capture is not conclusive because it reflects an error and an empty DOM capture rather than the rendered UI.
- A Chromium screenshot artifact shows an attempted capture where the rendered component text could not be validated, making the capture inconclusive.
- No severity-bearing finding was reported because the real UI was not conclusively captured, which aligns with the PR intent not being verified.

<a href="https://app.greptile.com/trex/runs/13703545/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/cli.ts | The CLI now renders configured-hidden PINs separately from missing PINs. |
| apps/ade-cli/src/services/sync/syncRemoteCommandService.ts | The web pairing command now reports PIN configuration separately from the displayed code. |
| apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx | The desktop web pairing card now explains that a hidden configured PIN can still be used if known. |
| apps/ios/ADE/Services/SyncService.swift | The iOS client now derives a three-state web pairing PIN model. |
| apps/ios/ADE/Views/Settings/SettingsWebClientPairSheet.swift | The iOS pairing sheet now renders hidden configured PINs separately from unset PINs. |

<sub>Reviews (2): Last reviewed commit: ["clarify hidden sync PIN pairing copy"](https://github.com/arul28/ade/commit/0c879b95aae4c058e8053328407db81184682e21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42733018)</sub>

<!-- /greptile_comment -->