### PR TITLE
Fix iOS relay fallback without Tailscale

### DIFF
--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -35,9 +35,9 @@ struct HostConnectionProfile: Codable, Equatable {
   var tailscaleAddress: String?
   /// Full `wss://…/connect/<machineKey>` cloud-relay URLs learned from a pairing
   /// QR or advertised live by the host in `hello_ok`/`brain_status`. Optional so
-  /// profiles persisted before the relay feature decode cleanly. Always raced
-  /// LAST (after every LAN and Tailscale route) — unconditionally, no user
-  /// toggle; the relay is a zero-config fallback.
+  /// profiles persisted before the relay feature decode cleanly. The relay is a
+  /// zero-config fallback: Tailscale/direct routes are preferred when currently
+  /// usable, and the relay is promoted when this phone has no Tailscale tunnel.
   var savedRelayCandidates: [String]?
   var updatedAt: String
 

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -466,6 +466,55 @@ func syncConnectionEndpointAttempts(
   return primaryAttempts + fallbackAttempts
 }
 
+func syncDeduplicatedEndpointAttempts(
+  _ attempts: [SyncConnectionEndpointAttempt]
+) -> [SyncConnectionEndpointAttempt] {
+  var seen = Set<SyncConnectionEndpointAttempt>()
+  return attempts.filter { seen.insert($0).inserted }
+}
+
+func syncRelayAwareEndpointAttempts(
+  directAddresses: [String],
+  ports: [Int],
+  relayRoutes: [String],
+  relayPort: Int,
+  phoneHasTailnetInterface: Bool,
+  liveDirectAddresses: Set<String> = []
+) -> [SyncConnectionEndpointAttempt] {
+  var seenRelayRoutes = Set<String>()
+  let relayAttempts = relayRoutes.filter { route in
+    syncIsFullWebSocketRoute(route) && seenRelayRoutes.insert(route).inserted
+  }.map { route in
+    SyncConnectionEndpointAttempt(address: route, port: relayPort)
+  }
+  let directAttempts = syncConnectionEndpointAttempts(addresses: directAddresses, ports: ports)
+  guard !relayAttempts.isEmpty else { return directAttempts }
+  guard !phoneHasTailnetInterface else {
+    return syncDeduplicatedEndpointAttempts(directAttempts + relayAttempts)
+  }
+
+  let primaryPorts = Array(ports.prefix(1))
+  let liveDirectAttempts = syncConnectionEndpointAttempts(
+    addresses: directAddresses.filter { address in
+      liveDirectAddresses.contains(address) && !syncIsTailscaleRoute(address)
+    },
+    ports: primaryPorts
+  )
+  return syncDeduplicatedEndpointAttempts(liveDirectAttempts + relayAttempts + directAttempts)
+}
+
+func syncReconnectProbeAddresses(
+  directAddresses: [String],
+  relayRoutes: [String],
+  phoneHasTailnetInterface: Bool,
+  liveDirectAddresses: Set<String> = []
+) -> [String] {
+  guard !relayRoutes.isEmpty, !phoneHasTailnetInterface else { return directAddresses }
+  return directAddresses.filter { address in
+    liveDirectAddresses.contains(address) && !syncIsTailscaleRoute(address)
+  }
+}
+
 func syncStalePortRecoveryEndpointAttempts(
   addresses: [String],
   ports: [Int]
@@ -593,18 +642,21 @@ func syncCopyNetworkInterfaceAddresses() -> [SyncNetworkInterfaceAddress] {
 }
 
 /// The saved machine advertises a Tailscale route, it is not discoverable on
-/// the current network, and this phone holds no tailnet address — the one
-/// user action that fixes the connection is turning Tailscale on (or moving
-/// back onto the machine's Wi-Fi). Never shown while connected: a user on a
-/// working VPN-to-LAN route (LAN probes succeed) simply connects.
+/// the current network, this phone holds no tailnet address, and the profile
+/// has no saved ADE relay route. Never shown while connected: a user on a
+/// working VPN-to-LAN route (LAN probes succeed) simply connects. When relay
+/// is available, relay is the fallback path; the hard "open Tailscale" card
+/// would incorrectly imply Tailscale is required.
 func syncShouldShowTailscaleOffHint(
   transport: SyncTransportHealth,
   hasSavedMachine: Bool,
   savedMachineHasTailnetRoute: Bool,
   phoneHasTailnetInterface: Bool,
-  machineDiscoveredNearby: Bool
+  machineDiscoveredNearby: Bool,
+  hasRelayCandidate: Bool = false
 ) -> Bool {
   guard hasSavedMachine, savedMachineHasTailnetRoute else { return false }
+  guard !hasRelayCandidate else { return false }
   guard !phoneHasTailnetInterface, !machineDiscoveredNearby else { return false }
   switch transport {
   case .connecting, .unreachable, .disconnected:
@@ -2590,7 +2642,8 @@ final class SyncService: ObservableObject {
         guard host != "127.0.0.1" else { return false }
         return !syncIsTailscaleRoute(host)
       },
-      tailscaleAddress: addressCandidates.first(where: syncIsTailscaleRoute)
+      tailscaleAddress: addressCandidates.first(where: syncIsTailscaleRoute),
+      savedRelayCandidates: previousProfile?.savedRelayCandidates
     )
 
     let connectAttemptGeneration = beginConnectAttempt()
@@ -3699,6 +3752,7 @@ final class SyncService: ObservableObject {
       syncConnectLog.info("reconnect skipped: paused by user")
       return
     }
+    refreshPhoneTailnetInterfaceState()
     allowAutoReconnect = true
     guard let profile = loadProfile(), let token = tokenForProfile(profile) else { return }
     if preferTailnet || (userInitiated && shouldPreferTailnetForUserReconnect(profile)) {
@@ -3867,7 +3921,8 @@ final class SyncService: ObservableObject {
       hasSavedMachine: true,
       savedMachineHasTailnetRoute: profileHasTailnetRoute(profile),
       phoneHasTailnetInterface: phoneHasTailnetInterface,
-      machineDiscoveredNearby: machineDiscoveredNearby
+      machineDiscoveredNearby: machineDiscoveredNearby,
+      hasRelayCandidate: !relayFallbackCandidates(for: profile).isEmpty
     )
   }
 
@@ -3994,6 +4049,7 @@ final class SyncService: ObservableObject {
     lastPairingErrorCode = nil
     let connectAttemptGeneration: UInt64
     do {
+      refreshPhoneTailnetInterfaceState()
       cancelReconnectLoop()
       allowAutoReconnect = false
       setAutoReconnectPausedByUser(false)
@@ -4040,9 +4096,10 @@ final class SyncService: ObservableObject {
         normalizedCandidateAddresses
       ))
       let portCandidates = syncConnectPortCandidates(primaryPort: requestedPort, addresses: addressCandidates)
-      // Relay URLs (full wss://) are attempted LAST, always. They ride their own
-      // path/port, so they're kept out of the direct port sweep and appended as
-      // single attempts after every direct route.
+      // Relay URLs (full wss://) ride their own path/port, so they're kept out
+      // of the direct port sweep. When this phone is not on Tailscale, the relay
+      // is promoted ahead of stale saved direct routes instead of waiting behind
+      // a dead tailnet sweep.
       let normalizedRelayCandidates = deduplicatedAddresses(relayCandidates.filter(syncIsFullWebSocketRoute))
       let relayWalkCandidates = normalizedRelayCandidates
       syncConnectLog.info(
@@ -4058,9 +4115,15 @@ final class SyncService: ObservableObject {
       guard !addressCandidates.isEmpty || !relayWalkCandidates.isEmpty else {
         throw noConnectableAddressError()
       }
-      let directAttempts = syncConnectionEndpointAttempts(addresses: addressCandidates, ports: portCandidates)
-      let relayAttempts = relayWalkCandidates.map { SyncConnectionEndpointAttempt(address: $0, port: requestedPort) }
-      for attempt in directAttempts + relayAttempts {
+      let endpointAttempts = syncRelayAwareEndpointAttempts(
+        directAddresses: addressCandidates,
+        ports: portCandidates,
+        relayRoutes: relayWalkCandidates,
+        relayPort: requestedPort,
+        phoneHasTailnetInterface: phoneHasTailnetInterface,
+        liveDirectAddresses: Set(discoveryAddresses + discoveryTailscaleAddresses)
+      )
+      for attempt in endpointAttempts {
         guard isCurrentConnectAttempt(connectAttemptGeneration) else {
           throw CancellationError()
         }
@@ -4135,7 +4198,8 @@ final class SyncService: ObservableObject {
           return !syncIsTailscaleRoute(host)
         },
         tailscaleAddress: normalizedTailscaleAddress ?? addressCandidates.first(where: syncIsTailscaleRoute),
-        // Persist relay candidates so later reconnects can race them last.
+        // Persist relay candidates so later reconnects can promote them when
+        // this phone has no Tailscale interface.
         savedRelayCandidates: normalizedRelayCandidates.isEmpty ? nil : normalizedRelayCandidates
       )
       currentAddress = preferredAddress
@@ -8204,8 +8268,9 @@ final class SyncService: ObservableObject {
     return false
   }
 
-  /// Relay `wss://` candidates for a profile. Relay always races, strictly LAST
-  /// (after every LAN and Tailscale route) — zero config, no user toggle.
+  /// Relay `wss://` candidates for a profile. Relay is zero-config: when this
+  /// phone has no Tailscale interface, connection attempts promote the relay
+  /// ahead of stale saved direct routes.
   private func relayFallbackCandidates(for profile: HostConnectionProfile) -> [String] {
     return deduplicatedAddresses((profile.savedRelayCandidates ?? []).filter(syncIsFullWebSocketRoute))
   }
@@ -8253,7 +8318,8 @@ final class SyncService: ObservableObject {
         + savedProfileTailnet
         + savedTailnet
     }
-    // Relay is the last-resort route: only tried when no direct path opened.
+    // The endpoint walker promotes relay ahead of stale direct routes when this
+    // phone is not on Tailscale, while keeping direct routes first otherwise.
     return deduplicatedAddresses(prioritizedLive + fallbackSaved + relayFallbackCandidates(for: profile))
   }
 
@@ -8318,8 +8384,9 @@ final class SyncService: ObservableObject {
       : prioritizedAddresses(for: profile)
     // Relay routes (full wss:// URLs) carry their own path and port: keep them
     // out of the TCP probe race and the port sweep — crossing one with the
-    // fallback port list would retry the identical URL once per port. Each is
-    // a single attempt, strictly after every direct address × port pair.
+    // fallback port list would retry the identical URL once per port. When the
+    // phone is not on Tailscale, the route walker tries the relay before stale
+    // saved direct routes.
     let relayRoutes = rawAddresses.filter(syncIsFullWebSocketRoute)
     let addresses = connectableAddresses(from: rawAddresses.filter { !syncIsFullWebSocketRoute($0) })
     let portCandidates = syncConnectPortCandidates(
@@ -8337,26 +8404,42 @@ final class SyncService: ObservableObject {
       throw noConnectableAddressError()
     }
 
-    let racedAddresses = await syncRaceAddressCandidates(
-      addresses: addresses,
+    let liveDirectAddressSet = Set(matchingDiscovery.flatMap(\.addresses) + matchingDiscovery.compactMap(\.tailscaleAddress))
+    let probeAddresses = syncReconnectProbeAddresses(
+      directAddresses: addresses,
+      relayRoutes: relayRoutes,
+      phoneHasTailnetInterface: phoneHasTailnetInterface,
+      liveDirectAddresses: liveDirectAddressSet
+    )
+    let racedProbeAddresses = await syncRaceAddressCandidates(
+      addresses: probeAddresses,
       port: portCandidates.first ?? profile.port
     )
+    let racedAddresses = probeAddresses == addresses
+      ? racedProbeAddresses
+      : deduplicatedAddresses(racedProbeAddresses + addresses.filter { !Set(probeAddresses).contains($0) })
     if racedAddresses != addresses {
       syncConnectLog.info(
         "ADE_SYNC_TRACE reconnect probe reorder raced=[\(syncLogAddressList(racedAddresses), privacy: .public)]"
       )
     }
 
-    let directAttempts = preferLiveCandidatesOnly && livePorts.isEmpty && portCandidates.count > 1
+    let racedDirectAttempts = preferLiveCandidatesOnly && livePorts.isEmpty && portCandidates.count > 1
       ? syncStalePortRecoveryEndpointAttempts(addresses: racedAddresses, ports: portCandidates)
       : syncConnectionEndpointAttempts(addresses: racedAddresses, ports: portCandidates)
-    // Relay routes: one attempt each, after the whole direct sweep. openSocket
-    // uses the full URL verbatim; the port field is informational.
-    let endpointAttempts = directAttempts + relayRoutes.map { route in
-      SyncConnectionEndpointAttempt(address: route, port: portCandidates.first ?? profile.port)
-    }
+    let endpointAttempts = syncRelayAwareEndpointAttempts(
+      directAddresses: racedAddresses,
+      ports: portCandidates,
+      relayRoutes: relayRoutes,
+      relayPort: portCandidates.first ?? profile.port,
+      phoneHasTailnetInterface: phoneHasTailnetInterface,
+      liveDirectAddresses: liveDirectAddressSet
+    )
+    let orderedEndpointAttempts = phoneHasTailnetInterface || relayRoutes.isEmpty
+      ? racedDirectAttempts + endpointAttempts.filter { syncIsFullWebSocketRoute($0.address) }
+      : endpointAttempts
 
-    for attempt in endpointAttempts {
+    for attempt in orderedEndpointAttempts {
       guard isCurrentConnectAttempt(connectAttemptGeneration) else {
         throw CancellationError()
       }

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -515,6 +515,25 @@ func syncReconnectProbeAddresses(
   }
 }
 
+func syncProjectSwitchRelayCandidates(
+  connectionHosts: [String],
+  previousProfile: HostConnectionProfile?,
+  targetHostIdentity: String
+) -> [String] {
+  func dedupeRelayRoutes(_ routes: [String]) -> [String] {
+    var seen = Set<String>()
+    return routes.filter { route in
+      syncIsFullWebSocketRoute(route) && seen.insert(route).inserted
+    }
+  }
+  let advertisedRelayRoutes = dedupeRelayRoutes(connectionHosts)
+  let previousMatchesTarget = previousProfile.map { profile in
+    profile.hostIdentity == targetHostIdentity || profile.lastHostDeviceId == targetHostIdentity
+  } ?? false
+  guard previousMatchesTarget else { return advertisedRelayRoutes }
+  return dedupeRelayRoutes(advertisedRelayRoutes + (previousProfile?.savedRelayCandidates ?? []))
+}
+
 func syncStalePortRecoveryEndpointAttempts(
   addresses: [String],
   ports: [Int]
@@ -2601,12 +2620,22 @@ final class SyncService: ObservableObject {
       return
     }
 
-    let addressCandidates = deduplicatedAddresses(
-      connection.addressCandidates.map(\.host)
-        + (currentAddress.map { [$0] } ?? [])
-        + (activeHostProfile?.savedAddressCandidates ?? [])
+    let connectionHosts = connection.addressCandidates.map(\.host)
+    let relayCandidates = syncProjectSwitchRelayCandidates(
+      connectionHosts: connectionHosts,
+      previousProfile: previousProfile,
+      targetHostIdentity: connection.hostIdentity.deviceId
     )
-    guard !addressCandidates.isEmpty else {
+    let directConnectionHosts = connectionHosts.filter { !syncIsFullWebSocketRoute($0) }
+    let currentDirectAddress = currentAddress.flatMap { address in
+      syncIsFullWebSocketRoute(address) ? nil : address
+    }
+    let addressCandidates = deduplicatedAddresses(
+      directConnectionHosts
+        + (currentDirectAddress.map { [$0] } ?? [])
+        + (activeHostProfile?.savedAddressCandidates ?? []).filter { !syncIsFullWebSocketRoute($0) }
+    )
+    guard !addressCandidates.isEmpty || !relayCandidates.isEmpty else {
       throw NSError(domain: "ADE", code: 25, userInfo: [
         NSLocalizedDescriptionKey: "The machine did not provide an address for that project."
       ])
@@ -2635,7 +2664,7 @@ final class SyncService: ObservableObject {
       pairedDeviceId: resolvedPairedDeviceId,
       lastRemoteDbVersion: 0,
       lastHostDeviceId: connection.hostIdentity.deviceId,
-      lastSuccessfulAddress: addressCandidates.first,
+      lastSuccessfulAddress: addressCandidates.first ?? relayCandidates.first,
       savedAddressCandidates: addressCandidates,
       discoveredLanAddresses: addressCandidates.filter { host in
         guard !host.contains(":") else { return false }
@@ -2643,7 +2672,7 @@ final class SyncService: ObservableObject {
         return !syncIsTailscaleRoute(host)
       },
       tailscaleAddress: addressCandidates.first(where: syncIsTailscaleRoute),
-      savedRelayCandidates: previousProfile?.savedRelayCandidates
+      savedRelayCandidates: relayCandidates.isEmpty ? nil : relayCandidates
     )
 
     let connectAttemptGeneration = beginConnectAttempt()

--- a/apps/ios/ADE/Views/Components/ADEDesignSystem.swift
+++ b/apps/ios/ADE/Views/Components/ADEDesignSystem.swift
@@ -485,9 +485,10 @@ struct ADENoticeCard: View {
 }
 
 /// Warning card shown on connection surfaces when the saved machine expects a
-/// Tailscale route but this iPhone has no tailnet interface (see
-/// `SyncService.tailscaleOffHintVisible`). The action opens the Tailscale app
-/// when installed, falling back to its App Store page.
+/// Tailscale route, this iPhone has no tailnet interface, and no saved ADE
+/// relay route is available (see `SyncService.tailscaleOffHintVisible`). The
+/// action opens the Tailscale app when installed, falling back to its App Store
+/// page.
 struct ADETailscaleOffHintCard: View {
   @Environment(\.openURL) private var openURL
 

--- a/apps/ios/ADE/Views/Settings/SettingsConnectionHeader.swift
+++ b/apps/ios/ADE/Views/Settings/SettingsConnectionHeader.swift
@@ -48,9 +48,9 @@ struct SettingsConnectionHeader: View {
         VStack(alignment: .leading, spacing: 4) {
           SettingsConnectedHostDetails(routeLine: snapshot.routeLine)
           if snapshot.usingRelay {
-            // Quiet nudge: we're reachable over the relay, but a direct tailnet
-            // path would be faster and stays private. Nothing modal.
-            Text("Using ADE relay — Tailscale gives a faster, private connection")
+            // Quiet nudge: relay is a valid automatic path; Tailscale is only a
+            // recommendation for faster, steadier direct sync.
+            Text("Using ADE relay. For faster, more stable sync, connect both devices with Tailscale.")
               .font(.caption)
               .foregroundStyle(ADEColor.textSecondary)
               .fixedSize(horizontal: false, vertical: true)

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -1640,13 +1640,16 @@ struct WorkSessionDestinationView: View {
   @MainActor
   func refreshChatStateAfterAction(forceRemote: Bool = true) async {
     let preferLightweight = syncService.prefersReducedSyncLoad
+    let localEchoSnapshot = localEchoMessages
     await loadTranscript(forceRemote: forceRemote, preferLightweight: preferLightweight)
     if preferLightweight,
        forceRemote,
        transcript.isEmpty,
        fallbackEntries.isEmpty,
        shouldHydrateTranscriptFromHost {
+      let hydrationEchoSnapshot = localEchoMessages.isEmpty ? localEchoSnapshot : localEchoMessages
       await hydrateEmptyTranscriptFromHostIfNeeded(force: true)
+      restoreLocalEchoesIfHydrationStillEmpty(hydrationEchoSnapshot)
     }
     if !preferLightweight {
       await refreshArtifacts(force: true)
@@ -1655,6 +1658,17 @@ struct WorkSessionDestinationView: View {
     if let refreshedSession = try? await syncService.fetchSession(id: sessionId) {
       session = refreshedSession
     }
+  }
+
+  @MainActor
+  func restoreLocalEchoesIfHydrationStillEmpty(_ echoes: [WorkLocalEchoMessage]) {
+    guard !echoes.isEmpty,
+          localEchoMessages.isEmpty,
+          transcript.isEmpty,
+          fallbackEntries.isEmpty else {
+      return
+    }
+    localEchoMessages = echoes
   }
 
   @MainActor

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -1114,7 +1114,7 @@ struct WorkSessionDestinationView: View {
   }
 
   var emptyTranscriptHydrationKey: String {
-    "\(session?.id ?? sessionId)-empty:\(transcript.isEmpty)-fallback:\(fallbackEntries.isEmpty)-host:\(hostReachable)-local:\(syncService.localStateRevision)"
+    "\(session?.id ?? sessionId)-empty:\(transcript.isEmpty)-fallback:\(fallbackEntries.isEmpty)-host:\(hostReachable)-opening:\(openingLoadInFlight)-local:\(syncService.localStateRevision)"
   }
 
   var selectedSubagentPollingKey: String {
@@ -1641,6 +1641,13 @@ struct WorkSessionDestinationView: View {
   func refreshChatStateAfterAction(forceRemote: Bool = true) async {
     let preferLightweight = syncService.prefersReducedSyncLoad
     await loadTranscript(forceRemote: forceRemote, preferLightweight: preferLightweight)
+    if preferLightweight,
+       forceRemote,
+       transcript.isEmpty,
+       fallbackEntries.isEmpty,
+       shouldHydrateTranscriptFromHost {
+      await hydrateEmptyTranscriptFromHostIfNeeded(force: true)
+    }
     if !preferLightweight {
       await refreshArtifacts(force: true)
     }
@@ -1759,6 +1766,7 @@ struct WorkSessionDestinationView: View {
       case .sent:
         updateLocalEchoDeliveryState(echoId: echo.id, deliveryState: nil)
         await refreshChatStateAfterAction(forceRemote: true)
+        reconcileLocalEchoMessages()
       }
       errorMessage = nil
     } catch {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -1695,6 +1695,97 @@ final class ADETests: XCTestCase {
     )
   }
 
+  func testSyncRelayAwareAttemptsPreferTailscaleWhenPhoneIsOnTailnet() {
+    let relay = "wss://relay.ade-app.dev/connect/machinekey123"
+    let addresses = ["100.75.20.63"]
+    let ports = syncConnectPortCandidates(primaryPort: 8787, addresses: addresses)
+
+    let attempts = syncRelayAwareEndpointAttempts(
+      directAddresses: addresses,
+      ports: ports,
+      relayRoutes: [relay],
+      relayPort: 8787,
+      phoneHasTailnetInterface: true
+    )
+
+    XCTAssertEqual(attempts.first, SyncConnectionEndpointAttempt(address: "100.75.20.63", port: 8787))
+    XCTAssertEqual(attempts.last, SyncConnectionEndpointAttempt(address: relay, port: 8787))
+  }
+
+  func testSyncRelayAwareAttemptsPromoteRelayWhenPhoneIsNotOnTailnet() {
+    let relay = "wss://relay.ade-app.dev/connect/machinekey123"
+    let addresses = ["100.75.20.63"]
+    let ports = syncConnectPortCandidates(primaryPort: 8787, addresses: addresses)
+
+    let attempts = syncRelayAwareEndpointAttempts(
+      directAddresses: addresses,
+      ports: ports,
+      relayRoutes: [relay],
+      relayPort: 8787,
+      phoneHasTailnetInterface: false
+    )
+
+    XCTAssertEqual(attempts.first, SyncConnectionEndpointAttempt(address: relay, port: 8787))
+    XCTAssertEqual(attempts.dropFirst().first, SyncConnectionEndpointAttempt(address: "100.75.20.63", port: 8787))
+  }
+
+  func testSyncRelayAwareAttemptsGiveLiveLanOneShotBeforeRelayWithoutTailnet() {
+    let relay = "wss://relay.ade-app.dev/connect/machinekey123"
+    let addresses = ["192.168.1.240", "100.75.20.63"]
+    let ports = syncConnectPortCandidates(primaryPort: 8787, addresses: addresses)
+
+    let attempts = syncRelayAwareEndpointAttempts(
+      directAddresses: addresses,
+      ports: ports,
+      relayRoutes: [relay],
+      relayPort: 8787,
+      phoneHasTailnetInterface: false,
+      liveDirectAddresses: ["192.168.1.240"]
+    )
+
+    XCTAssertEqual(Array(attempts.prefix(3)), [
+      SyncConnectionEndpointAttempt(address: "192.168.1.240", port: 8787),
+      SyncConnectionEndpointAttempt(address: relay, port: 8787),
+      SyncConnectionEndpointAttempt(address: "100.75.20.63", port: 8787),
+    ])
+  }
+
+  func testSyncReconnectProbeAddressesSkipStaleDirectRoutesBeforeRelayWithoutTailnet() {
+    let relay = "wss://relay.ade-app.dev/connect/machinekey123"
+    let addresses = ["192.168.1.240", "100.75.20.63"]
+
+    XCTAssertEqual(
+      syncReconnectProbeAddresses(
+        directAddresses: addresses,
+        relayRoutes: [relay],
+        phoneHasTailnetInterface: false
+      ),
+      [],
+      "Relay should not wait behind TCP probes for stale saved LAN/Tailscale routes."
+    )
+
+    XCTAssertEqual(
+      syncReconnectProbeAddresses(
+        directAddresses: addresses,
+        relayRoutes: [relay],
+        phoneHasTailnetInterface: false,
+        liveDirectAddresses: ["192.168.1.240"]
+      ),
+      ["192.168.1.240"],
+      "Only a live same-LAN direct route gets probed before relay."
+    )
+
+    XCTAssertEqual(
+      syncReconnectProbeAddresses(
+        directAddresses: addresses,
+        relayRoutes: [relay],
+        phoneHasTailnetInterface: true
+      ),
+      addresses,
+      "When the phone is on Tailscale, direct route probing remains preferred."
+    )
+  }
+
   func testSyncRoamDecisionUsesSavedTailnetWhenWifiDrops() {
     XCTAssertTrue(
       syncShouldRoamToTailnet(
@@ -2067,14 +2158,16 @@ final class ADETests: XCTestCase {
       hasSavedMachine: Bool = true,
       tailnetRoute: Bool = true,
       phoneOnTailnet: Bool = false,
-      nearby: Bool = false
+      nearby: Bool = false,
+      hasRelayCandidate: Bool = false
     ) -> Bool {
       syncShouldShowTailscaleOffHint(
         transport: transport,
         hasSavedMachine: hasSavedMachine,
         savedMachineHasTailnetRoute: tailnetRoute,
         phoneHasTailnetInterface: phoneOnTailnet,
-        machineDiscoveredNearby: nearby
+        machineDiscoveredNearby: nearby,
+        hasRelayCandidate: hasRelayCandidate
       )
     }
 
@@ -2086,6 +2179,7 @@ final class ADETests: XCTestCase {
     XCTAssertFalse(hint(transport: .unreachable, tailnetRoute: false))
     XCTAssertFalse(hint(transport: .unreachable, phoneOnTailnet: true))
     XCTAssertFalse(hint(transport: .unreachable, nearby: true))
+    XCTAssertFalse(hint(transport: .unreachable, hasRelayCandidate: true))
   }
 
   @MainActor

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -1786,6 +1786,48 @@ final class ADETests: XCTestCase {
     )
   }
 
+  func testSyncProjectSwitchRelayCandidatesMergeOnlyForSameHost() {
+    let previousProfile = HostConnectionProfile(
+      hostIdentity: "host-1",
+      hostName: "Mac Studio",
+      port: 8787,
+      authKind: "paired",
+      pairedDeviceId: "phone-1",
+      lastRemoteDbVersion: 0,
+      lastHostDeviceId: "host-1",
+      lastSuccessfulAddress: "100.75.20.63",
+      savedAddressCandidates: ["100.75.20.63"],
+      discoveredLanAddresses: [],
+      tailscaleAddress: "100.75.20.63",
+      savedRelayCandidates: ["wss://relay.ade.dev/connect/old"]
+    )
+
+    XCTAssertEqual(
+      syncProjectSwitchRelayCandidates(
+        connectionHosts: [
+          "192.168.1.240",
+          "wss://relay.ade.dev/connect/new",
+        ],
+        previousProfile: previousProfile,
+        targetHostIdentity: "host-1"
+      ),
+      [
+        "wss://relay.ade.dev/connect/new",
+        "wss://relay.ade.dev/connect/old",
+      ]
+    )
+
+    XCTAssertEqual(
+      syncProjectSwitchRelayCandidates(
+        connectionHosts: ["192.168.1.240"],
+        previousProfile: previousProfile,
+        targetHostIdentity: "host-2"
+      ),
+      [],
+      "A project switch to a different host must not inherit the old host's relay URL."
+    )
+  }
+
   func testSyncRoamDecisionUsesSavedTailnetWhenWifiDrops() {
     XCTAssertTrue(
       syncShouldRoamToTailnet(

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -676,11 +676,12 @@ is not supported.
   `127.0.0.1`, and — unless the relay kill-switch is off — a
   `relay`-kind candidate carrying a full
   `wss://…/connect/<machineKey>` URL. `SyncAddressCandidateKind` is
-  `lan | saved | tailscale | loopback | relay`; the relay candidate is
-  the lowest-priority transport (see the transport race in
-  `ios-companion.md`). Already-paired phones also learn the relay URL
-  from `hello_ok` / `brain_status` (`cloudRelayWssUrl`) and persist it
-  with the host profile for reconnects.
+  `lan | saved | tailscale | loopback | relay`; iOS treats relay as an
+  automatic fallback and promotes it when the phone has no Tailscale
+  tunnel (see the transport race in `ios-companion.md`). Already-paired
+  phones also learn the relay URL from `hello_ok` / `brain_status`
+  (`cloudRelayWssUrl`) and persist it with the host profile for
+  reconnects.
 - **mDNS**: `publishLanDiscovery` builds a TXT record whose
   `addresses` CSV includes the Tailscale IP alongside LAN IPs. It also
   advertises `runtimeKind`, `runtimeVersion`, `projects`, and
@@ -933,10 +934,12 @@ feature is merged or because a deliberately isolated-port host is running.
   kill-switch)**: the brain keeps an outbound HMAC-authenticated tunnel
   to the `apps/tunnel-relay` Cloudflare Worker so a phone off the
   LAN/tailnet can dial the machine over TLS with zero configuration.
-  Phones always try direct routes first — the relay candidate is
-  strictly the lowest-priority transport. The relay only pipes bytes:
-  the normal ADE hello / PIN / paired-secret / DPoP handshake still runs
-  end-to-end, so the relay never sees pairing credentials in the clear.
+  Phones prefer direct routes when they are currently usable; when an
+  iPhone has no Tailscale tunnel and holds a saved relay URL, reconnect
+  dials the relay ahead of stale saved LAN/Tailscale sweeps. The relay
+  only pipes bytes: the normal ADE hello / PIN / paired-secret / DPoP
+  handshake still runs end-to-end, so the relay never sees pairing
+  credentials in the clear.
   The `machineKey` is an unguessable 32-hex identifier and the tunnel
   upgrades are HMAC-signed with a per-machine secret. Operators who
   never want traffic relayed flip the single "ADE relay" control in

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -316,8 +316,11 @@ With a saved machine the primary action is **Reconnect** (calls
 
 Connection surfaces show an "iPhone isn't on Tailscale" warning card
 (`ADETailscaleOffHintCard` in `ADEDesignSystem.swift`) when the one
-user action that can fix the connection is turning Tailscale on. Gating
-is the pure helper `syncShouldShowTailscaleOffHint(...)`, exposed as
+user action that can fix the connection is turning Tailscale on. The
+card is not shown when the phone has a saved ADE relay route, because
+relay is a valid automatic fallback and Tailscale is then only a
+performance recommendation. Gating is the pure helper
+`syncShouldShowTailscaleOffHint(...)`, exposed as
 `SyncService.tailscaleOffHintVisible`; all of the following must hold:
 
 - a pairing credential exists and the saved profile carries a Tailscale
@@ -329,6 +332,7 @@ is the pure helper `syncShouldShowTailscaleOffHint(...)`, exposed as
   unscoped scan would false-positive on LTE),
 - no live discovery hit matches the profile (Bonjour ⇒ same LAN; the
   tailnet probe only resolves when the tunnel is up),
+- no saved full-URL relay candidate exists for the profile,
 - transport is connecting / disconnected / unreachable — never while
   connected, so a working VPN-to-LAN setup is left alone.
 
@@ -458,19 +462,24 @@ Source: `apps/ios/ADE/Services/SyncService.swift`.
    plus `SyncTailnetDiscovery.probePortCandidates` (default port + 8) —
    never the full 8787–8999 stale-port range, which belongs to the
    connect path's recovery sweep. Cloud-relay candidates (full
-   `wss://…/connect/<machineKey>` URLs) are appended **last**, as the
-   lowest-priority transport — a full-URL relay route cannot be
-   host:port TCP-probed, so it is dialed only after every direct route
-   fails. There is no user toggle: relay candidates always race
-   (LAN → Tailscale → relay, zero config). They arrive from the pairing
-   QR and — for already-paired phones — from `hello_ok` /
+   `wss://…/connect/<machineKey>` URLs) are zero-config and carry their
+   own path/port, so they are never mixed into the host:port TCP probe
+   or fallback-port sweep. When the phone has a Tailscale tunnel,
+   direct routes stay preferred. When the phone has no Tailscale tunnel
+   and a saved relay route exists, reconnect probes only currently live
+   same-LAN routes, then dials the relay before stale saved LAN/Tailscale
+   routes; this prevents "Tailscale off" from waiting behind a dead
+   tailnet sweep. Pairing uses the same endpoint ordering, so a phone
+   without Tailscale can pair through relay without extra user setup.
+   Relay routes arrive from the pairing QR and — for already-paired
+   phones — from `hello_ok` /
    `brain_status`'s `cloudRelayWssUrl`, persisted into the host
    profile's `savedRelayCandidates` (an explicit `cloudRelayWssUrl:
    null` in `brain_status` means the operator flipped the machine's
    relay kill-switch, and the phone clears its saved relay routes).
    When the ACTIVE connection is a relay route, the Settings connection
-   header shows one quiet line — "Using ADE relay — Tailscale gives a
-   faster, private connection" — and nothing else changes. `reconnectIfPossible` is guarded so overlapping
+   header shows one quiet line: "Using ADE relay. For faster, more
+   stable sync, connect both devices with Tailscale." `reconnectIfPossible` is guarded so overlapping
    wake-ups never stack TCP/WebSocket attempts, and a reconnect never
    tears down an already-live connection. The socket declares the
    `chunkedEnvelopes` capability and sets a 32 MiB
@@ -1196,7 +1205,7 @@ reflected in the phone's UI on the next descriptor read.
 | PIN pairing flow | Implemented |
 | QR pairing payload (v3 smart URL) + camera scanner (`SettingsPairingScannerSheet`) | Implemented |
 | Device-bound pairing (DPoP, Secure Enclave P-256) | Implemented (`DpopKeyService`; signed proof on every paired hello) |
-| Cloud relay (lowest-priority `relay` transport, always races, no toggle) | Implemented |
+| Cloud relay (automatic `relay` transport, promoted when the phone has no Tailscale tunnel, no user setup) | Implemented |
 | Project home + machine project switching | Implemented, including Add project actions for browsing/opening existing Git repos, creating local projects, cloning GitHub repos on the paired machine, and removing projects from the list |
 | Lanes tab | Implemented to live machine parity (with `devicesOpen`, multi-attach, stack canvas, stack-position/base-branch editing in Manage Lane, and template environment progress) |
 | Files tab | Implemented with freely-editable workspaces (mobile read-only file gate removed) and a unified full-screen name + content search page (`FilesSearchScreen`) |


### PR DESCRIPTION
## Summary
- promote ADE cloud relay ahead of stale saved LAN/Tailscale routes when the iPhone has no Tailscale tunnel
- preserve learned relay candidates across mobile project switches and suppress the hard Tailscale-required warning when relay is available
- improve weak-connection chat recovery so empty transcripts rehydrate after opening loads and sent messages reconcile local echoes
- update sync docs for the automatic relay behavior

## Validation
- node scripts/validate-docs.mjs
- XcodeBuildMCP test_sim: ADETests/testSyncRelayAwareAttemptsPreferTailscaleWhenPhoneIsOnTailnet
- XcodeBuildMCP test_sim: ADETests/testSyncRelayAwareAttemptsPromoteRelayWhenPhoneIsNotOnTailnet
- XcodeBuildMCP test_sim: ADETests/testSyncRelayAwareAttemptsGiveLiveLanOneShotBeforeRelayWithoutTailnet
- XcodeBuildMCP test_sim: ADETests/testSyncReconnectProbeAddressesSkipStaleDirectRoutesBeforeRelayWithoutTailnet
- XcodeBuildMCP test_sim: ADETests/testSyncTailscaleOffHintGating
- XcodeBuildMCP test_sim: ADETests/testSyncMergedRelayCandidatesFoldsAdvertisedFreshestFirst

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves iOS sync fallback behavior for relay and reduced-load chat recovery. The main changes are:

- Relay candidates are promoted when the phone has no Tailscale tunnel.
- Project switching keeps relay candidates only for the same host identity.
- The Tailscale-off warning is hidden when relay fallback is available.
- Reduced-load chat refresh can restore local echoes after empty hydration.
- Tests and sync docs now cover the updated relay behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The docs validation ran with node scripts/validate-docs.mjs and returned exit code 0, confirming documentation validation passed for 169 files.
- The iOS tooling check executed and reported XcodeBuild, Swift, and MCP exit codes of 1 on Linux, indicating the simulator/MCP path is unavailable.
- Because the simulator path is unavailable, no simulator test result was fabricated.

<a href="https://app.greptile.com/trex/runs/13711315/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Services/SyncService.swift | Adds relay-aware endpoint ordering, same-host relay merging during project switches, tailnet state refresh before connection attempts, and relay-aware hint gating. |
| apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift | Adds local-echo snapshot and restore behavior around reduced-load transcript refresh. |
| apps/ios/ADETests/ADETests.swift | Adds tests for relay ordering, reconnect probe filtering, project-switch relay merging, and Tailscale hint gating. |
| docs/features/sync-and-multi-device/README.md | Updates sync documentation for automatic relay promotion when Tailscale is unavailable. |
| docs/features/sync-and-multi-device/ios-companion.md | Documents relay-aware reconnect ordering, hint gating, and updated relay status copy. |

<sub>Reviews (2): Last reviewed commit: ["Address relay and chat review findings"](https://github.com/arul28/ade/commit/173b62fafb59a5cac94a2e7e3fb802be58486334) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42754666)</sub>

<!-- /greptile_comment -->