### PR TITLE
Refresh Work lanes for mobile-created sessions

### DIFF
--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts
@@ -327,6 +327,29 @@ describe("useWorkSessions — refresh-before-focus ordering", () => {
     expect(refreshLanesSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("lightly refreshes lanes when Work sessions reference a lane missing from cached lane state", async () => {
+    fakeAppStoreState = {
+      ...fakeAppStoreState,
+      lanes: [{ id: "lane-primary", name: "Primary" }],
+    };
+    listSessionsCachedMock.mockResolvedValue([
+      makeSession("session-1", "lane-mobile"),
+    ]);
+
+    renderHook(() => useWorkSessions());
+
+    await waitFor(() => {
+      expect(refreshLanesSpy).toHaveBeenCalledWith({
+        includeStatus: false,
+        includeSnapshots: false,
+        includeConflictStatus: false,
+        includeRebaseSuggestions: false,
+        includeAutoRebaseStatus: false,
+      });
+    });
+    expect(refreshLanesSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("passes permission mode through to tracked CLI launch fields", async () => {
     const { result } = renderHook(() => useWorkSessions());
 

--- a/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
+++ b/apps/desktop/src/renderer/components/terminals/useWorkSessions.ts
@@ -404,7 +404,7 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
   /** Blocks mirror/prune while `sessions` still reflects the previous project after `projectRoot` changes. */
   const pendingProjectSwitchRef = useRef<string | null>(null);
   const projectRootRef = useRef<string | null>(projectRoot);
-  const laneRecoveryRefreshProjectRef = useRef<string | null>(null);
+  const laneRecoveryRefreshKeyRef = useRef<string | null>(null);
   const isWorkRoute = active && (location.pathname === "/work" || location.pathname.startsWith("/work/"));
 
   useEffect(() => {
@@ -453,10 +453,17 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
     for (const session of sessions) map.set(session.id, session);
     return map;
   }, [sessions]);
-  const hasLaneBackedSessions = useMemo(
-    () => sessions.some((session) => Boolean(session.laneId)),
-    [sessions],
-  );
+  const missingSessionLaneIdsSignature = useMemo(() => {
+    if (sessions.length === 0) return "";
+    const knownLaneIds = new Set(lanes.map((lane) => lane.id));
+    const missingLaneIds = new Set<string>();
+    for (const session of sessions) {
+      const laneId = session.laneId?.trim();
+      if (!laneId || knownLaneIds.has(laneId)) continue;
+      missingLaneIds.add(laneId);
+    }
+    return Array.from(missingLaneIds).sort().join("\0");
+  }, [lanes, sessions]);
 
   const selectLaneForActiveTab = useCallback(
     (sessionId: string | null) => {
@@ -965,7 +972,7 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
     // upcoming refresh runs silently in the background (no spinner).
     hasLoadedOnceRef.current = cachedSessions != null;
     hasRunningSessionsRef.current = (cachedSessions ?? []).some((s) => s.status === "running");
-    laneRecoveryRefreshProjectRef.current = null;
+    laneRecoveryRefreshKeyRef.current = null;
     appliedQuerySessionIdRef.current = null;
     appliedUrlFilterKeyRef.current = null;
     partiallyAppliedUrlFilterKeyRef.current = null;
@@ -997,13 +1004,14 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
 
   useEffect(() => {
     if (!projectRoot || !isWorkRoute) return;
-    if (lanes.length > 0) {
-      laneRecoveryRefreshProjectRef.current = null;
+    if (pendingProjectSwitchRef.current != null) return;
+    if (!missingSessionLaneIdsSignature) {
+      laneRecoveryRefreshKeyRef.current = null;
       return;
     }
-    if (!hasLaneBackedSessions) return;
-    if (laneRecoveryRefreshProjectRef.current === projectRoot) return;
-    laneRecoveryRefreshProjectRef.current = projectRoot;
+    const recoveryKey = `${projectRoot}:${missingSessionLaneIdsSignature}`;
+    if (laneRecoveryRefreshKeyRef.current === recoveryKey) return;
+    laneRecoveryRefreshKeyRef.current = recoveryKey;
     void refreshLanes({
       includeStatus: false,
       includeSnapshots: false,
@@ -1011,7 +1019,12 @@ export function useWorkSessions({ active = true }: UseWorkSessionsOptions = {}) 
       includeRebaseSuggestions: false,
       includeAutoRebaseStatus: false,
     }).catch(() => {});
-  }, [hasLaneBackedSessions, isWorkRoute, lanes.length, projectRoot, refreshLanes]);
+  }, [
+    isWorkRoute,
+    missingSessionLaneIdsSignature,
+    projectRoot,
+    refreshLanes,
+  ]);
 
   useEffect(() => {
     if (!projectRoot || !isWorkRoute) return;


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstart-skill-then-why-getting-aef8fed2 num=739 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstart-skill-then-why-getting-aef8fed2&amp;pr=739">ade/start-skill-then-why-getting-aef8fed2 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=739">PR #739</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lane recovery in terminal work sessions so missing or outdated lane data is refreshed more reliably.
  * Prevented repeated refreshes when the same missing lane information is encountered.
  * Ensured lane recovery works correctly after switching projects or during hydration, helping sessions appear with the right lane details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates Work session lane recovery to refresh lane data only when needed. The main changes are:

- Detects session `laneId` values that are missing from the current lane cache.
- Tracks refreshes by project and missing-lane signature to avoid duplicate recovery calls.
- Adds a regression test for sessions whose lane is absent while other cached lanes exist.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is localized to a memoized missing-lane signature and one recovery effect. Existing lightweight refresh options are preserved. A targeted test covers the new partial lane-cache case. No functional or security issues were identified in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the Vitest test command for useWorkSessions and captured verbose output.
- T-Rex saved a proof log of the Vitest run documenting the command and results.
- T-Rex confirmed the relevant tests passed, including 'lightly refreshes lanes when Work sessions reference a lane missing from cached lane state' and 'does not retry lane recovery on every session refresh after a failure'.

<a href="https://app.greptile.com/trex/runs/13744492/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/terminals/useWorkSessions.ts | Replaces project-level lane recovery tracking with a missing-lane signature so `refreshLanes` runs when sessions reference lanes absent from cached lane state. |
| apps/desktop/src/renderer/components/terminals/useWorkSessions.test.ts | Adds coverage for refreshing lanes when cached lane state exists but does not include a session's lane. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Hook as useWorkSessions
participant Sessions as listSessionsCached
participant State as Lane state
participant Store as refreshLanes

Hook->>Sessions: load cached/current Work sessions
Sessions-->>Hook: sessions with laneId values
Hook->>State: read current lanes
Hook->>Hook: compute missingSessionLaneIdsSignature
alt signature is non-empty and not already refreshed
    Hook->>Store: refreshLanes(lightweight options)
    Store-->>State: update lane cache
else no missing lanes or duplicate signature
    Hook->>Hook: skip lane recovery refresh
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Hook as useWorkSessions
participant Sessions as listSessionsCached
participant State as Lane state
participant Store as refreshLanes

Hook->>Sessions: load cached/current Work sessions
Sessions-->>Hook: sessions with laneId values
Hook->>State: read current lanes
Hook->>Hook: compute missingSessionLaneIdsSignature
alt signature is non-empty and not already refreshed
    Hook->>Store: refreshLanes(lightweight options)
    Store-->>State: update lane cache
else no missing lanes or duplicate signature
    Hook->>Hook: skip lane recovery refresh
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix: refresh work lanes for mobile-creat..."](https://github.com/arul28/ade/commit/8b48cd746ce00956260d0a30a3cc9daba4205f80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42830579)</sub>

<!-- /greptile_comment -->