### PR TITLE
Ios Keyboard Prompt Box

### DIFF
--- a/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
+++ b/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
@@ -88,7 +88,7 @@ struct HubInlineComposer: View {
   // Global top edge of the destination control, so the picker popover can size
   // itself to the room above it (and never overflow the top of the screen).
   @State private var destinationControlTopY: CGFloat = 0
-  @FocusState private var composerFocused: Bool
+  @State private var composerFocused: Bool = false
   @StateObject private var dictationCoordinator = DictationInsertionCoordinator()
 
   private let dictationTargetId = "hub-new-chat-drawer"

--- a/apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift
+++ b/apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift
@@ -368,11 +368,7 @@ struct WorkPlainComposerTextView: UIViewRepresentable {
       context.coordinator.updatePlaceholderVisibility()
     }
     context.coordinator.applyPlaceholder(placeholder)
-    if isFocused, !textView.isFirstResponder {
-      textView.becomeFirstResponder()
-    } else if !isFocused, textView.isFirstResponder {
-      textView.resignFirstResponder()
-    }
+    context.coordinator.applyFocusRequest(isFocused, to: textView)
     context.coordinator.updateHeight()
   }
 
@@ -381,6 +377,7 @@ struct WorkPlainComposerTextView: UIViewRepresentable {
     var parent: WorkPlainComposerTextView
     weak var textView: UITextView?
     private var placeholderLabel: UILabel?
+    private var lastFocusRequest: Bool?
 
     init(_ parent: WorkPlainComposerTextView) {
       self.parent = parent
@@ -400,6 +397,15 @@ struct WorkPlainComposerTextView: UIViewRepresentable {
       }
       updatePlaceholderVisibility()
       updateHeight()
+    }
+
+    func applyFocusRequest(_ isFocused: Bool, to textView: UITextView) {
+      if isFocused, !textView.isFirstResponder {
+        textView.becomeFirstResponder()
+      } else if !isFocused, lastFocusRequest == true, textView.isFirstResponder {
+        textView.resignFirstResponder()
+      }
+      lastFocusRequest = isFocused
     }
 
     func handlePasteImages(_ images: [UIImage]) -> Bool {

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -1327,7 +1327,7 @@ private struct WorkNewChatComposerBar: View {
   @State private var draft: String = ""
   @State private var attachments: [WorkChatInputAttachment] = []
   @State private var composerTextHeight: CGFloat = 28
-  @FocusState private var composerFocused: Bool
+  @State private var composerFocused: Bool = false
   @StateObject private var dictationCoordinator = DictationInsertionCoordinator()
   @State private var isDictating = false
   /// Live viewport width of the controls scroll area, so the access control

--- a/apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift
+++ b/apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import UIKit
+import SwiftUI
 @testable import ADE
 
 /// Pure-logic coverage for the cursor-relative trigger detector that mirrors the
@@ -126,5 +127,61 @@ final class WorkComposerTriggerDetectorTests: XCTestCase {
     XCTAssertTrue(workChatInputAttachmentDataURL(attachment)?.hasPrefix("data:image/jpeg;base64,") == true)
     XCTAssertEqual(workChatOutgoingText("", attachmentCount: 1), "Attached image.")
     XCTAssertEqual(workChatOutgoingText("  hello  ", attachmentCount: 1), "hello")
+  }
+
+  @MainActor
+  func testPlainComposerIgnoresInitialFalseFocusUpdate() {
+    var text = ""
+    var isFocused = false
+    var measuredHeight: CGFloat = 28
+    let parent = WorkPlainComposerTextView(
+      text: Binding(get: { text }, set: { text = $0 }),
+      isFocused: Binding(get: { isFocused }, set: { isFocused = $0 }),
+      measuredHeight: Binding(get: { measuredHeight }, set: { measuredHeight = $0 }),
+      placeholder: "Type to vibecode..."
+    )
+    let coordinator = WorkPlainComposerTextView.Coordinator(parent)
+    let textView = FocusRecordingTextView()
+    textView.resetRecording()
+
+    textView.fakeIsFirstResponder = true
+    coordinator.applyFocusRequest(false, to: textView)
+    XCTAssertEqual(textView.resignCount, 0)
+    XCTAssertTrue(textView.fakeIsFirstResponder)
+
+    textView.fakeIsFirstResponder = false
+    coordinator.applyFocusRequest(true, to: textView)
+    coordinator.applyFocusRequest(false, to: textView)
+    XCTAssertEqual(textView.becomeCount, 1)
+    XCTAssertEqual(textView.resignCount, 1)
+    XCTAssertFalse(textView.fakeIsFirstResponder)
+  }
+}
+
+private final class FocusRecordingTextView: UITextView {
+  var fakeIsFirstResponder = false
+  var becomeCount = 0
+  var resignCount = 0
+
+  override var isFirstResponder: Bool {
+    fakeIsFirstResponder
+  }
+
+  override func becomeFirstResponder() -> Bool {
+    becomeCount += 1
+    fakeIsFirstResponder = true
+    return true
+  }
+
+  override func resignFirstResponder() -> Bool {
+    resignCount += 1
+    fakeIsFirstResponder = false
+    return true
+  }
+
+  func resetRecording() {
+    becomeCount = 0
+    resignCount = 0
+    fakeIsFirstResponder = false
   }
 }


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fokay-start-skill-some-recent-a0a5eda1 num=740 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fokay-start-skill-some-recent-a0a5eda1&amp;pr=740">ade/okay-start-skill-some-recent-a0a5eda1 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=740">PR #740</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates iOS composer focus handling for the start-chat prompt box. The main changes are:

- Replaces SwiftUI focus-state storage with explicit state in the hub and new-chat composers.
- Moves UIKit first-responder reconciliation into `WorkPlainComposerTextView.Coordinator`.
- Adds a test for preserving an already-present keyboard during the initial false focus update.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge with minimal risk.

The changes are narrowly scoped to iOS composer focus synchronization and keep the delegate-driven focus binding path intact. The new test covers the main keyboard-preservation behavior introduced by this change. No functional or security issues were identified in the changed code.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the recommended macOS validation command for iOS ADETests/WorkComposerTriggerDetectorTests: cd apps/ios && xcodebuild test -project ADE.xcodeproj -scheme ADE -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:ADETests/WorkComposerTriggerDetectorTests.
- Noted that UI capture was not attempted with Playwright/HTML because the app uses native iOS SwiftUI and fabricated UI mockups were disallowed.

<a href="https://app.greptile.com/trex/runs/13744970/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Views/Hub/HubComposerDrawer.swift | Replaces SwiftUI focus-state storage with explicit state for the hub composer while preserving existing expand/collapse and picker refocus behavior. |
| apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift | Centralizes UITextView focus reconciliation so initial false focus updates do not resign an already-active iOS keyboard. |
| apps/ios/ADE/Views/Work/WorkNewChatScreen.swift | Updates the new-chat composer bar to use explicit state for focus tracking with the shared UIKit composer binding. |
| apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift | Adds test coverage for the plain composer focus-request behavior using a recording UITextView test double. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Composer as Hub/New Chat Composer
participant Plain as WorkPlainComposerTextView
participant Coord as Coordinator
participant UIKit as UITextView

User->>UIKit: Tap or dismiss keyboard
UIKit->>Coord: textViewDidBegin/EndEditing
Coord->>Composer: Update isFocused binding
Composer->>Plain: Re-render with composerFocused state
Plain->>Coord: applyFocusRequest(isFocused, textView)
alt isFocused true and not first responder
    Coord->>UIKit: becomeFirstResponder()
else isFocused false after prior true request
    Coord->>UIKit: resignFirstResponder()
else initial false update
    Coord-->>UIKit: Leave first-responder state unchanged
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Composer as Hub/New Chat Composer
participant Plain as WorkPlainComposerTextView
participant Coord as Coordinator
participant UIKit as UITextView

User->>UIKit: Tap or dismiss keyboard
UIKit->>Coord: textViewDidBegin/EndEditing
Coord->>Composer: Update isFocused binding
Composer->>Plain: Re-render with composerFocused state
Plain->>Coord: applyFocusRequest(isFocused, textView)
alt isFocused true and not first responder
    Coord->>UIKit: becomeFirstResponder()
else isFocused false after prior true request
    Coord->>UIKit: resignFirstResponder()
else initial false update
    Coord-->>UIKit: Leave first-responder state unchanged
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Fix mobile start-chat keyboard focus"](https://github.com/arul28/ade/commit/0cdf7d05cc15421bbde0a0b13f9dfe4f89f9c649) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42831423)</sub>

<!-- /greptile_comment -->