### PR TITLE
Normalize ADE chat peer messaging

### DIFF
--- a/apps/ade-cli/README.md
+++ b/apps/ade-cli/README.md
@@ -308,6 +308,8 @@ ade chat list --lane lane-id --include-automation --no-archived --text
 ade chat create --lane lane-id --provider codex --model openai/gpt-5.5 --permissions full-auto --print-config --json
 ade chat create --lane lane-id --provider codex --no-parent   # spawned chats default their parent to $ADE_CHAT_SESSION_ID; --parent <session> overrides, --no-parent opts out
 ade chat read session-id --limit 20 --text
+ade chat message session-id --kind auto --text "status/context"
+ade chat wait session-id --for idle --timeout-ms 600000
 ade code
 ade code --embedded
 ade tests run --lane lane-id --suite unit --wait

--- a/apps/ade-cli/src/adeRpcServer.test.ts
+++ b/apps/ade-cli/src/adeRpcServer.test.ts
@@ -495,6 +495,14 @@ function createRuntime() {
         responseText: "yes",
       })),
       sendMessage: vi.fn(async () => {}),
+      messageSession: vi.fn(async (args: unknown) => ({
+        sessionId: (args as { sessionId?: string }).sessionId ?? "chat-unknown",
+        kind: (args as { kind?: string }).kind ?? "auto",
+        routedAction: "sendMessage",
+        statusBefore: "idle",
+        awaitingInputBefore: false,
+        delivery: "sent",
+      })),
       interrupt: vi.fn(async () => {}),
       resumeSession: vi.fn(async ({ sessionId }: { sessionId: string }) => ({
         id: sessionId,
@@ -2819,6 +2827,18 @@ describe("adeRpcServer", () => {
     expect(fixture.runtime.agentChatService.sendMessage).toHaveBeenCalledWith({
       sessionId: "chat-1",
       text: "own-chat write",
+    });
+
+    const peerMessage = await callTool(handler, "run_ade_action", {
+      domain: "chat",
+      action: "messageSession",
+      args: { sessionId: "chat-2", kind: "auto", text: "peer context" },
+    });
+    expect(peerMessage?.isError).toBeUndefined();
+    expect(fixture.runtime.agentChatService.messageSession).toHaveBeenCalledWith({
+      sessionId: "chat-2",
+      kind: "auto",
+      text: "peer context",
     });
   });
 

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -1956,6 +1956,127 @@ describe("ADE CLI", () => {
     });
   });
 
+  it("routes chat send through the normalized message primitive", () => {
+    const executePlan = expectExecutePlan(buildCliPlan([
+      "chat",
+      "send",
+      "chat-1",
+      "--text",
+      "keep going",
+    ]));
+
+    expect(executePlan.steps[0]?.params).toMatchObject({
+      arguments: {
+        domain: "chat",
+        action: "messageSession",
+        args: {
+          sessionId: "chat-1",
+          text: "keep going",
+          kind: "auto",
+        },
+      },
+    });
+  });
+
+  it("builds chat steer as an explicit steer action", () => {
+    const executePlan = expectExecutePlan(buildCliPlan([
+      "chat",
+      "steer",
+      "chat-1",
+      "--text",
+      "use this context",
+    ]));
+
+    expect(executePlan.label).toBe("chat steer");
+    expect(executePlan.steps[0]?.params).toMatchObject({
+      arguments: {
+        domain: "chat",
+        action: "steer",
+        args: {
+          sessionId: "chat-1",
+          text: "use this context",
+        },
+      },
+    });
+  });
+
+  it("builds chat message with an explicit routing kind", () => {
+    const executePlan = expectExecutePlan(buildCliPlan([
+      "chat",
+      "message",
+      "chat-1",
+      "--kind",
+      "interrupt-replace",
+      "--text",
+      "stop and use this direction",
+    ]));
+
+    expect(executePlan.label).toBe("chat message");
+    expect(executePlan.steps[0]?.params).toMatchObject({
+      arguments: {
+        domain: "chat",
+        action: "messageSession",
+        args: {
+          sessionId: "chat-1",
+          text: "stop and use this direction",
+          kind: "interrupt-replace",
+        },
+      },
+    });
+  });
+
+  it("builds chat wait as a bounded state wait", () => {
+    const plan = buildCliPlan([
+      "chat",
+      "wait",
+      "chat-1",
+      "--for",
+      "awaiting-input",
+      "--timeout-ms",
+      "120000",
+      "--poll-interval-ms",
+      "500",
+    ]);
+
+    expect(plan).toMatchObject({
+      kind: "chat-wait",
+      sessionId: "chat-1",
+      waitFor: "awaiting-input",
+      timeoutMs: 120000,
+      pollIntervalMs: 500,
+    });
+  });
+
+  it("parses chat session ids after value flags", () => {
+    const plan = buildCliPlan([
+      "chat",
+      "wait",
+      "--for",
+      "idle",
+      "chat-1",
+    ]);
+
+    expect(plan).toMatchObject({
+      kind: "chat-wait",
+      sessionId: "chat-1",
+      waitFor: "idle",
+    });
+  });
+
+  it("defaults chat wait to idle and accepts a positional wait target", () => {
+    expect(buildCliPlan(["chat", "wait", "chat-1"])).toMatchObject({
+      kind: "chat-wait",
+      sessionId: "chat-1",
+      waitFor: "idle",
+    });
+
+    expect(buildCliPlan(["chat", "wait", "chat-1", "terminal"])).toMatchObject({
+      kind: "chat-wait",
+      sessionId: "chat-1",
+      waitFor: "terminal",
+    });
+  });
+
   it("rejects reasoning effort on legacy agent spawn", () => {
     expect(() =>
       buildCliPlan([
@@ -3496,6 +3617,9 @@ describe("ADE CLI", () => {
     const chatHelp = buildCliPlan(["help", "chat"]);
     expect(chatHelp.kind).toBe("help");
     if (chatHelp.kind !== "help") return;
+    expect(chatHelp.text).toContain("ade chat message <session>");
+    expect(chatHelp.text).toContain("ade chat steer <session>");
+    expect(chatHelp.text).toContain("ade chat wait <session>");
     expect(chatHelp.text).toContain("ade chat read <session>");
     expect(chatHelp.text).toContain("ade new chat --mode cli");
 

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -198,6 +198,12 @@ type FormatterId =
   | "external-sessions"
   | "sync-web";
 
+type ChatWaitTarget =
+  | "idle"
+  | "active"
+  | "awaiting-input"
+  | "terminal";
+
 type CliPlan =
   | { kind: "help"; text: string }
   | { kind: "static"; value: unknown; formatter?: FormatterId }
@@ -236,6 +242,13 @@ type CliPlan =
   | { kind: "cursor-cloud"; rest: string[] }
   | { kind: "deeplink"; rest: string[] }
   | { kind: "skill"; rest: string[] }
+  | {
+      kind: "chat-wait";
+      sessionId: string;
+      waitFor: ChatWaitTarget;
+      timeoutMs: number;
+      pollIntervalMs: number;
+    }
   | { kind: "github-app-login"; maxWaitSec: number | null };
 
 type CliConnection = {
@@ -1499,7 +1512,12 @@ const HELP_BY_COMMAND: Record<string, string> = {
     $ ade chat create --lane <lane> --provider codex --model openai/gpt-5.5 --reasoning-effort xhigh --no-fast --permissions full-auto
     $ ade chat create --lane <lane> --provider claude --model anthropic/claude-opus-4-8 --prompt "fix the tests"
     $ ade chat create --from-linear-issue ENG-431   Start a chat with an attached issue + kickoff (alias: --linear-issue-json)
-    $ ade chat send <session> --text "next step"    Send a message
+    $ ade chat send <session> --text "next step"    Send a message; steers automatically if the turn is active
+    $ ade chat message <session> --kind auto --text "status"
+                                                    Deliver via auto | queue | wake | interrupt-replace
+    $ ade chat steer <session> --text "context"     Steer/queue context into an active turn
+    $ ade chat wait <session> --for idle --timeout-ms 600000
+                                                    Wait for idle, active, awaiting-input, or terminal
     $ ade chat read <session> --limit 20 --text     Read recent chat messages
     $ ade chat goal <session> --objective "Ship it" Set or inspect a Codex goal
     $ ade chat goal <session> --status paused       Update a Codex goal status
@@ -2680,6 +2698,56 @@ function readJsonPayloadOption(
 function requireValue(value: string | null, label: string): string {
   if (value && value.trim().length > 0) return value.trim();
   throw new CliUsageError(`${label} is required.`);
+}
+
+function normalizeChatMessageKind(value: string | null): "auto" | "queue" | "wake" | "interrupt-replace" {
+  const normalized = (value ?? "auto").trim().toLowerCase();
+  if (normalized === "auto") return "auto";
+  if (normalized === "queue" || normalized === "steer") return "queue";
+  if (normalized === "wake" || normalized === "send") return "wake";
+  if (
+    normalized === "interrupt-replace" ||
+    normalized === "interrupt" ||
+    normalized === "replace"
+  ) {
+    return "interrupt-replace";
+  }
+  throw new CliUsageError(
+    "chat message --kind must be auto, queue, wake, or interrupt-replace.",
+  );
+}
+
+function normalizeChatWaitTarget(value: string | null): ChatWaitTarget {
+  const normalized = (value ?? "idle").trim().toLowerCase();
+  if (normalized === "idle" || normalized === "done" || normalized === "complete") return "idle";
+  if (normalized === "active" || normalized === "running") return "active";
+  if (
+    normalized === "awaiting-input" ||
+    normalized === "awaiting_input" ||
+    normalized === "input" ||
+    normalized === "blocked"
+  ) {
+    return "awaiting-input";
+  }
+  if (
+    normalized === "terminal" ||
+    normalized === "ended" ||
+    normalized === "failed" ||
+    normalized === "interrupted"
+  ) {
+    return "terminal";
+  }
+  throw new CliUsageError(
+    "chat wait --for must be idle, active, awaiting-input, or terminal.",
+  );
+}
+
+function chatWaitTargetMatches(summary: JsonObject, waitFor: ChatWaitTarget): boolean {
+  const status = asString(summary.status);
+  if (waitFor === "idle") return status === "idle";
+  if (waitFor === "active") return status === "active" && summary.awaitingInput !== true;
+  if (waitFor === "awaiting-input") return summary.awaitingInput === true;
+  return status === "failed" || status === "interrupted" || status === "completed" || summary.endedAt != null;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -6254,7 +6322,7 @@ function buildChatPlan(args: string[]): CliPlan {
   const sessionId =
     readValue(args, ["--session", "--session-id"]) ??
     (sub !== "create" && sub !== "list" && !linearSessionSub
-      ? firstPositional(args)
+      ? firstStandalonePositional(args)
       : null);
   const withSession = (base: JsonObject = {}) =>
     collectGenericObjectArgs(args, {
@@ -6590,21 +6658,94 @@ function buildChatPlan(args: string[]): CliPlan {
       readValue(args, ["--text", "--message"]) ?? args.join(" "),
       "message text",
     );
+    const targetSession = requireValue(sessionId, "sessionId");
+    const messageArgs = withSession({
+      sessionId: targetSession,
+      text: sendText,
+      kind: "auto",
+      ...(imageUrl ? { attachments: [{ type: "image-url", url: imageUrl, path: imageUrl }] } : {}),
+    });
     return {
       kind: "execute",
       label: "chat send",
       steps: [
+        actionStep("result", "chat", "messageSession", messageArgs),
+      ],
+    };
+  }
+  if (sub === "message" || sub === "tell" || sub === "notify") {
+    const imageUrl = readValue(args, ["--image-url"]);
+    const kindFlag = readValue(args, ["--kind", "--delivery"]);
+    const queueFlag = readFlag(args, ["--queue", "--steer"]);
+    const wakeFlag = readFlag(args, ["--wake"]);
+    const interruptFlag = readFlag(args, ["--interrupt", "--replace"]);
+    const selectedKinds = [
+      kindFlag,
+      queueFlag ? "queue" : null,
+      wakeFlag ? "wake" : null,
+      interruptFlag ? "interrupt-replace" : null,
+    ].filter((value): value is string => typeof value === "string" && value.length > 0);
+    if (selectedKinds.length > 1) {
+      throw new CliUsageError("Use only one of --kind, --queue, --wake, or --interrupt.");
+    }
+    const messageText = requireValue(
+      readValue(args, ["--text", "--message"]) ?? args.join(" "),
+      "message text",
+    );
+    return {
+      kind: "execute",
+      label: "chat message",
+      steps: [
         actionStep(
           "result",
           "chat",
-          "sendMessage",
+          "messageSession",
           withSession({
             sessionId: requireValue(sessionId, "sessionId"),
-            text: sendText,
+            text: messageText,
+            kind: normalizeChatMessageKind(selectedKinds[0] ?? null),
             ...(imageUrl ? { attachments: [{ type: "image-url", url: imageUrl, path: imageUrl }] } : {}),
           }),
         ),
       ],
+    };
+  }
+  if (sub === "steer") {
+    const imageUrl = readValue(args, ["--image-url"]);
+    const steerText = requireValue(
+      readValue(args, ["--text", "--message"]) ?? args.join(" "),
+      "message text",
+    );
+    return {
+      kind: "execute",
+      label: "chat steer",
+      steps: [
+        actionStep(
+          "result",
+          "chat",
+          "steer",
+          withSession({
+            sessionId: requireValue(sessionId, "sessionId"),
+            text: steerText,
+            ...(imageUrl ? { attachments: [{ type: "image-url", url: imageUrl, path: imageUrl }] } : {}),
+          }),
+        ),
+      ],
+    };
+  }
+  if (sub === "wait" || sub === "watch") {
+    const timeoutMs = readIntOption(args, ["--timeout-ms", "--timeout"], 10 * 60 * 1000) ?? 10 * 60 * 1000;
+    const pollIntervalMs = readIntOption(args, ["--poll-interval-ms", "--interval-ms"], 2_000) ?? 2_000;
+    if (timeoutMs <= 0) throw new CliUsageError("chat wait --timeout-ms must be greater than zero.");
+    if (pollIntervalMs <= 0) throw new CliUsageError("chat wait --poll-interval-ms must be greater than zero.");
+    return {
+      kind: "chat-wait",
+      sessionId: requireValue(sessionId, "sessionId"),
+      waitFor: normalizeChatWaitTarget(
+        readValue(args, ["--for", "--state", "--until"]) ?? firstStandalonePositional(args),
+      ),
+      timeoutMs,
+      pollIntervalMs,
     };
   }
   if (sub === "interrupt")
@@ -10306,7 +10447,9 @@ const VALUE_CARRIER_FLAGS: ReadonlySet<string> = new Set([
   "--event",
   "--end-x",
   "--end-y",
+  "--delivery",
   "--file",
+  "--for",
   "--fps",
   "--from",
   "--from-file",
@@ -10316,11 +10459,13 @@ const VALUE_CARRIER_FLAGS: ReadonlySet<string> = new Set([
   "--icon",
   "--id",
   "--image",
+  "--image-url",
   "--index",
   "--initial-input",
   "--input",
   "--input-json",
   "--input-text",
+  "--interval-ms",
   "--instructions",
   "--kind",
   "--json-input",
@@ -10365,6 +10510,7 @@ const VALUE_CARRIER_FLAGS: ReadonlySet<string> = new Set([
   "--process",
   "--process-id",
   "--project-root",
+  "--poll-interval-ms",
   "--prompt",
   "--provider",
   "--pty",
@@ -10414,6 +10560,7 @@ const VALUE_CARRIER_FLAGS: ReadonlySet<string> = new Set([
   "--suite",
   "--suite-id",
   "--surface",
+  "--state",
   "--tab",
   "--tab-identifier",
   "--target",
@@ -10429,6 +10576,7 @@ const VALUE_CARRIER_FLAGS: ReadonlySet<string> = new Set([
   "--title-query",
   "--udid",
   "--url",
+  "--until",
   "--value",
   "--window-title",
   "--workspace",
@@ -16318,13 +16466,15 @@ function summarizeExecution(args: {
     };
   }
 
-  if (plan.label === "chat send") {
+  if (plan.label === "chat send" || plan.label === "chat steer" || plan.label === "chat message") {
     const raw = unwrapActionEnvelope(values.result);
     if (isRecord(raw)) return raw;
     return {
       ok: true,
       accepted: true,
-      note: "Message accepted by the ADE chat service; provider dispatch continues asynchronously.",
+      note: plan.label === "chat steer"
+        ? "Message accepted by the ADE chat steer path."
+        : "Message accepted by the ADE chat message path; provider dispatch continues asynchronously.",
     };
   }
 
@@ -16707,6 +16857,88 @@ async function executePlan(
   }
 }
 
+async function runChatWaitCommand(
+  plan: CliPlan & { kind: "chat-wait" },
+  options: GlobalOptions,
+): Promise<{ output: string; exitCode: number }> {
+  let connection: CliConnection;
+  try {
+    connection = await createConnection(options, { autoRegisterProject: true });
+  } catch (error) {
+    throw new CliExecutionError(
+      "Failed to initialize ADE CLI connection for chat wait.",
+      {
+        cause: error instanceof Error ? error.message : String(error),
+        nextAction:
+          "Verify --project-root points at an ADE project and run ade doctor --json.",
+      },
+    );
+  }
+
+  const startedAt = Date.now();
+  const readSummary = async (): Promise<JsonObject | null> => {
+    const raw = await connection.request("ade/actions/call", {
+      name: "run_ade_action",
+      arguments: {
+        domain: "chat",
+        action: "getSessionSummary",
+        argsList: [plan.sessionId],
+      },
+    });
+    const unwrapped = unwrapActionEnvelope(unwrapToolResult(raw));
+    if (unwrapped == null) return null;
+    if (!isRecord(unwrapped)) {
+      throw new CliExecutionError("chat.getSessionSummary returned an unexpected result.", {
+        sessionId: plan.sessionId,
+        result: unwrapped,
+      });
+    }
+    return unwrapped;
+  };
+
+  try {
+    while (true) {
+      const summary = await readSummary();
+      const elapsedMs = Date.now() - startedAt;
+      if (!summary) {
+        const result = {
+          ok: false,
+          error: "session_not_found",
+          sessionId: plan.sessionId,
+          waitFor: plan.waitFor,
+          elapsedMs,
+        };
+        return { output: formatOutput(result, options), exitCode: 1 };
+      }
+      if (chatWaitTargetMatches(summary, plan.waitFor)) {
+        const result = {
+          ok: true,
+          sessionId: plan.sessionId,
+          waitFor: plan.waitFor,
+          elapsedMs,
+          summary,
+        };
+        return { output: formatOutput(result, options), exitCode: 0 };
+      }
+      if (elapsedMs >= plan.timeoutMs) {
+        const result = {
+          ok: false,
+          error: "timed_out",
+          sessionId: plan.sessionId,
+          waitFor: plan.waitFor,
+          timeoutMs: plan.timeoutMs,
+          elapsedMs,
+          summary,
+        };
+        return { output: formatOutput(result, options), exitCode: 1 };
+      }
+      await sleep(Math.min(plan.pollIntervalMs, Math.max(1, plan.timeoutMs - elapsedMs)));
+    }
+  } finally {
+    await connection.close();
+  }
+}
+
 function formatOutput(
   value: unknown,
   options: GlobalOptions,
@@ -16892,6 +17124,9 @@ async function runCli(
           result == null ? "" : formatOutput(result, parsed.options, undefined),
         exitCode: isFailedServiceManagerResult(result) ? 1 : 0,
       };
+    }
+    if (plan.kind === "chat-wait") {
+      return await runChatWaitCommand(plan, parsed.options);
     }
     if (plan.kind === "init") {
       const result = await runInit(plan.targetPath);

--- a/apps/desktop/resources/ade-cli-help.txt
+++ b/apps/desktop/resources/ade-cli-help.txt
@@ -29,6 +29,7 @@ _    ____  _____
     $ ade rpc --stdio                               Speak ADE JSON-RPC over stdin/stdout
     $ ade init [path]                               Register a project with this machine brain
     $ ade projects list                             List projects registered on this machine
+    $ ade sync web [--open] [--no-clipboard]        Print (and copy) the web client pairing link + code
     $ ade sync status | pin generate                Manage machine sync and phone pairing
     $ ade doctor                                    Inspect project, brain, runtime, and tool availability
     $ ade lanes list | show | create | child        Work with lanes and lane stacks
@@ -135,6 +136,7 @@ _    ____  _____
     $ ade rpc --stdio                               Speak ADE JSON-RPC over stdin/stdout
     $ ade init [path]                               Register a project with this machine brain
     $ ade projects list                             List projects registered on this machine
+    $ ade sync web [--open] [--no-clipboard]        Print (and copy) the web client pairing link + code
     $ ade sync status | pin generate                Manage machine sync and phone pairing
     $ ade doctor                                    Inspect project, brain, runtime, and tool availability
     $ ade lanes list | show | create | child        Work with lanes and lane stacks
@@ -241,6 +243,7 @@ _    ____  _____
     $ ade rpc --stdio                               Speak ADE JSON-RPC over stdin/stdout
     $ ade init [path]                               Register a project with this machine brain
     $ ade projects list                             List projects registered on this machine
+    $ ade sync web [--open] [--no-clipboard]        Print (and copy) the web client pairing link + code
     $ ade sync status | pin generate                Manage machine sync and phone pairing
     $ ade doctor                                    Inspect project, brain, runtime, and tool availability
     $ ade lanes list | show | create | child        Work with lanes and lane stacks
@@ -658,8 +661,20 @@ _    ____  _____
     $ ade chat create --lane <lane> --provider codex --model openai/gpt-5.5 --reasoning-effort xhigh --no-fast --permissions full-auto
     $ ade chat create --lane <lane> --provider claude --model anthropic/claude-opus-4-8 --prompt "fix the tests"
     $ ade chat create --from-linear-issue ENG-431   Start a chat with an attached issue + kickoff (alias: --linear-issue-json)
-    $ ade chat send <session> --text "next step"    Send a message
+    $ ade chat send <session> --text "next step"    Send a message; steers automatically if the turn is active
+    $ ade chat message <session> --kind auto --text "status"
+                                                    Deliver via auto | queue | wake | interrupt-replace
+    $ ade chat steer <session> --text "context"     Steer/queue context into an active turn
+    $ ade chat wait <session> --for idle --timeout-ms 600000
+                                                    Wait for idle, active, awaiting-input, or terminal
     $ ade chat read <session> --limit 20 --text     Read recent chat messages
+    $ ade chat goal <session> --objective "Ship it" Set or inspect a Codex goal
+    $ ade chat goal <session> --status paused       Update a Codex goal status
+    $ ade chat fork <session> --model openai/gpt-5.5
+                                                    Fork full provider history into a new chat
+    $ ade chat rewind-files <session> --message <user-message-id> --dry-run
+                                                    Preview or apply file/context rewind
+    $ ade chat subagents <session> --text           List child agents for a chat
     $ ade new chat --mode cli --lane <lane> --provider claude --reasoning-effort ultracode --prompt "fix"
                                                     Start a tracked provider CLI session
     $ ade chat attach-linear-issue <session> --issue-id ENG-431
@@ -744,7 +759,7 @@ _    ____  _____
     $ ade new chat --mode chat|cli --prompt "fix"   Start an ADE Work chat or tracked CLI session
     $ ade desktop                                   Launch the installed desktop app
     $ ade open <url>                                Open an ade:// or ade-app.dev deeplink via the OS
-    $ ade link lane | session | branch | pr | linear-issue
+    $ ade link lane | session | file | commit | artifact | branch | pr | linear-issue
                                                      Build a shareable deeplink (copies to clipboard)
     $ ade linear install                            Register ADE as Linear's "Open in coding tool" target
     $ ade skill list | show <name>                  Browse ADE's bundled agent skills (local)
@@ -753,6 +768,7 @@ _    ____  _____
     $ ade rpc --stdio                               Speak ADE JSON-RPC over stdin/stdout
     $ ade init [path]                               Register a project with this machine brain
     $ ade projects list                             List projects registered on this machine
+    $ ade sync web [--open] [--no-clipboard]        Print (and copy) the web client pairing link + code
     $ ade sync status | pin generate                Manage machine sync and phone pairing
     $ ade doctor                                    Inspect project, brain, runtime, and tool availability
     $ ade lanes list | show | create | child        Work with lanes and lane stacks
@@ -928,7 +944,7 @@ _    ____  _____
     $ ade new chat --mode chat|cli --prompt "fix"   Start an ADE Work chat or tracked CLI session
     $ ade desktop                                   Launch the installed desktop app
     $ ade open <url>                                Open an ade:// or ade-app.dev deeplink via the OS
-    $ ade link lane | session | branch | pr | linear-issue
+    $ ade link lane | session | file | commit | artifact | branch | pr | linear-issue
                                                      Build a shareable deeplink (copies to clipboard)
     $ ade linear install                            Register ADE as Linear's "Open in coding tool" target
     $ ade skill list | show <name>                  Browse ADE's bundled agent skills (local)
@@ -937,6 +953,7 @@ _    ____  _____
     $ ade rpc --stdio                               Speak ADE JSON-RPC over stdin/stdout
     $ ade init [path]                               Register a project with this machine brain
     $ ade projects list                             List projects registered on this machine
+    $ ade sync web [--open] [--no-clipboard]        Print (and copy) the web client pairing link + code
     $ ade sync status | pin generate                Manage machine sync and phone pairing
     $ ade doctor                                    Inspect project, brain, runtime, and tool availability
     $ ade lanes list | show | create | child        Work with lanes and lane stacks
@@ -1339,6 +1356,7 @@ _    ____  _____
     $ ade rpc --stdio                               Speak ADE JSON-RPC over stdin/stdout
     $ ade init [path]                               Register a project with this machine brain
     $ ade projects list                             List projects registered on this machine
+    $ ade sync web [--open] [--no-clipboard]        Print (and copy) the web client pairing link + code
     $ ade sync status | pin generate                Manage machine sync and phone pairing
     $ ade doctor                                    Inspect project, brain, runtime, and tool availability
     $ ade lanes list | show | create | child        Work with lanes and lane stacks

--- a/apps/desktop/resources/agent-skills/ade-cli-control-plane/SKILL.md
+++ b/apps/desktop/resources/agent-skills/ade-cli-control-plane/SKILL.md
@@ -108,8 +108,32 @@ provider CLI terminal. Both accept lane, provider, model, reasoning effort,
 permission mode, fast/no-fast, and prompt flags. Use `--lane auto` or
 `--auto-create-lane` when the desktop UI would use the auto-create lane row.
 
-Use `ade chat send <session> --text ...` for later messages and
-`ade chat read <session> --text` to confirm recent transcript messages.
+Use `ade chat read <session> --text` to confirm recent transcript messages
+before and after steering another chat.
+
+Use `ade chat show <session> --text` before messaging a chat you do not own:
+
+- If you just need to hand context/directive/status to another chat, prefer
+  `ade chat message <session> --kind auto --text ...`. ADE inspects the target:
+  active turns are steered, idle chats are woken with a new turn, and the result
+  reports the route (`sendMessage`, `steer`, or `interrupt-replace`) plus whether
+  a steer was queued.
+- If `status` is `active` and it is not waiting for user input, use
+  `ade chat steer <session> --text ...`. This routes through the provider's
+  active-turn path: Codex receives `turn/steer`, Claude stages a steer message,
+  and Cursor/Droid/OpenCode queue the message for the next safe boundary.
+- If the chat is idle/dormant, use `ade chat send <session> --text ...` to start
+  the next turn. The CLI also checks the session summary and will steer instead
+  of sending when the target is already active, but prefer the explicit verb
+  when your intent is to steer.
+- If you need to wait for a peer before reading final output, use
+  `ade chat wait <session> --for idle --timeout-ms <ms>` (also supports
+  `active`, `awaiting-input`, and `terminal`).
+- If you need to stop or redirect a running chat, use
+  `ade chat message <session> --kind interrupt-replace --text ...` or, when
+  you need manual control, `ade chat interrupt <session>` first, then
+  `ade chat send ...` with the new instruction. Do not send a second normal turn
+  into an active chat and hope the provider interprets it as steering.
 
 Compatibility commands still exist, but do not teach them as the first choice:
 

--- a/apps/desktop/resources/agent-skills/ade-orchestrator/SKILL.md
+++ b/apps/desktop/resources/agent-skills/ade-orchestrator/SKILL.md
@@ -171,6 +171,36 @@ The caller picks the ping `kind` (`queue` / `interrupt-replace` / `wake`) per th
 
 Pick `queue` for non-urgent context drops (worker progress reports, validator pass/fail). Pick `interrupt-replace` for cancellations and high-priority redirects. Pick `wake` only when the target is dormant.
 
+When you need to message an ADE chat through the CLI instead of the orchestration
+tool, check the target first:
+
+```
+ade chat show <session> --text
+ade chat read <session> --limit 20 --text
+```
+
+- General handoff/status/directive: use
+  `ade chat message <session> --kind auto --text "..."`. This is the CLI
+  counterpart to `messageAgent`: ADE wakes idle chats with a normal turn, steers
+  active chats through the provider-normalized steer path, and reports whether
+  the message was sent, delivered, or queued.
+- Active target: use `ade chat steer <session> --text "..."`. This preserves the
+  provider's active-turn semantics (`turn/steer` for Codex, staged steer for
+  Claude, queued boundary delivery for Cursor/Droid/OpenCode).
+- Dormant/idle target: use `ade chat send <session> --text "..."` to start the
+  next turn.
+- Hard redirect/cancel: use `messageAgent({ kind: "interrupt-replace", ... })`
+  when you have orchestration tools; from a plain shell use
+  `ade chat message <session> --kind interrupt-replace --text "..."` or
+  `ade chat interrupt <session>` and then send the replacement instruction.
+- Waiting for a peer: use `ade chat wait <session> --for idle --timeout-ms <ms>`
+  before reading final output; `--for active`, `awaiting-input`, and `terminal`
+  are also available.
+
+Do not use a normal send as a substitute for steering a running chat. It can
+surface as "A turn is already active" inside the target transcript instead of
+being delivered through the provider's steering channel.
+
 ## §9 — Cancellation with smart revert
 
 Lead's `messageAgent({ kind: "interrupt-replace", intent: "cancellation", cancellation: { revert: true | false | "review", reason } })`. The tool also records `agents[target].cancellationRequested = true` in `manifest.json`; running worker bash tools watch that bit and abort.

--- a/apps/desktop/src/main/services/adeActions/registry.test.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.test.ts
@@ -82,9 +82,11 @@ describe("isAllowedAdeAction", () => {
     expect(isAllowedAdeAction("chat", "getSubagentTranscript")).toBe(true);
     expect(isAllowedAdeAction("chat", "readTranscript")).toBe(true);
     expect(isAllowedAdeAction("chat", "sendMessage")).toBe(true);
+    expect(isAllowedAdeAction("chat", "messageSession")).toBe(true);
     expect(isCtoOnlyAdeAction("chat", "getSubagentTranscript")).toBe(false);
     expect(isCtoOnlyAdeAction("chat", "readTranscript")).toBe(false);
     expect(isCtoOnlyAdeAction("chat", "sendMessage")).toBe(false);
+    expect(isCtoOnlyAdeAction("chat", "messageSession")).toBe(false);
   });
 
   it("exposes Codex goal actions and getCommit through the runtime action surface", () => {
@@ -362,6 +364,10 @@ describe("ADE_ACTION_ALLOWLIST shape", () => {
     expect(getAdeActionInputContract("chat", "sendMessage")).toMatchObject({
       description: expect.stringContaining("asynchronously"),
     });
+    expect(getAdeActionInputContract("chat", "messageSession")).toMatchObject({
+      description: expect.stringContaining("normalized"),
+      input: expect.stringContaining("interrupt-replace"),
+    });
   });
 
   it("normalizes chat action argument shapes for model discovery, summaries, transcript reads, and sends", async () => {
@@ -380,6 +386,7 @@ describe("ADE_ACTION_ALLOWLIST shape", () => {
       options,
     }));
     const sendMessage = vi.fn(async () => undefined);
+    const messageSession = vi.fn(async (args: unknown) => ({ ok: true, args }));
     const runtime = {
       agentChatService: {
         createSession,
@@ -389,6 +396,7 @@ describe("ADE_ACTION_ALLOWLIST shape", () => {
         getChatEventHistory,
         getChatEventHistoryPage,
         sendMessage,
+        messageSession,
       },
     } as unknown as Parameters<typeof getAdeActionDomainServices>[0];
 
@@ -400,6 +408,7 @@ describe("ADE_ACTION_ALLOWLIST shape", () => {
       getChatEventHistory?: (args?: unknown) => Promise<unknown>;
       getChatEventHistoryPage?: (args?: unknown) => Promise<unknown>;
       sendMessage?: (args?: unknown) => Promise<unknown>;
+      messageSession?: (args?: unknown) => Promise<unknown>;
     };
 
     await expect(chat.getAvailableModels?.({})).resolves.toEqual([{ id: "any" }]);
@@ -479,6 +488,26 @@ describe("ADE_ACTION_ALLOWLIST shape", () => {
     expect(sendMessage).toHaveBeenCalledWith({ sessionId: "chat-1", text: "next" });
     await expect(chat.sendMessage?.({ sessionId: "chat-1", text: "   " })).rejects.toThrow(/text/);
     expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    await expect(chat.messageSession?.({
+      sessionId: " chat-1 ",
+      text: "status",
+      kind: "queue",
+    })).resolves.toEqual({
+      ok: true,
+      args: {
+        sessionId: "chat-1",
+        text: "status",
+        kind: "queue",
+      },
+    });
+    expect(messageSession).toHaveBeenCalledWith({
+      sessionId: "chat-1",
+      text: "status",
+      kind: "queue",
+    });
+    await expect(chat.messageSession?.({ sessionId: "chat-1", text: "" })).rejects.toThrow(/text/);
+    expect(messageSession).toHaveBeenCalledTimes(1);
   });
 
   it("resolves chat fileSearch lanes from getSessionSummary and caches the result", async () => {

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -450,6 +450,7 @@ export const ADE_ACTION_ALLOWLIST: Partial<Record<AdeActionDomain, readonly stri
     "listClaudeSessions",
     "listSessions",
     "listSubagents",
+    "messageSession",
     "modelCatalog",
     "approveToolUse",
     "codexFuzzyFileSearch",
@@ -744,6 +745,11 @@ const ADE_ACTION_INPUT_CONTRACTS: Partial<Record<AdeActionDomain, Partial<Record
       description: "Send a user message to a chat session; provider dispatch continues asynchronously.",
       input: "object { sessionId: string, text: string, attachments? }",
       example: "ade actions run chat.sendMessage --input-json '{\"sessionId\":\"chat-123\",\"text\":\"next step\"}'",
+    },
+    messageSession: {
+      description: "Deliver a message to a chat using ADE-normalized routing: auto steers active turns, wakes idle chats, queues non-urgent context, or interrupts and replaces.",
+      input: "object { sessionId: string, text: string, kind?: \"auto\" | \"queue\" | \"wake\" | \"interrupt-replace\", attachments?, contextAttachments?, metadata? }",
+      example: "ade actions run chat.messageSession --input-json '{\"sessionId\":\"chat-123\",\"kind\":\"auto\",\"text\":\"use this context\"}'",
     },
     modelCatalog: {
       description: "Read the provider/model catalog, including reasoning tiers and fast service tiers.",
@@ -1210,6 +1216,15 @@ function buildChatDomainService(runtime: AdeRuntime): OpaqueService | null {
         sessionId,
         note: "Message accepted by the ADE chat service; provider dispatch continues asynchronously.",
       };
+    },
+    messageSession: async (args?: unknown) => {
+      const record = readObjectActionArg(args, "chat.messageSession");
+      const sessionId = requireNonEmptyString(record.sessionId, "sessionId");
+      const text = requireNonEmptyString(record.text, "text");
+      if (typeof agentChatService.messageSession !== "function") {
+        throw new Error("Chat messageSession is not available in this runtime.");
+      }
+      return agentChatService.messageSession({ ...record, sessionId, text } as never);
     },
     setParallelLaunchState: (args?: AgentChatSetParallelLaunchStateArgs) => {
       const parentLaneId = requireNonEmptyString(args?.parentLaneId, "parentLaneId");

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -157,6 +157,9 @@ import type {
   AgentChatNoticeDetail,
   AgentChatInteractionMode,
   AgentChatInterruptArgs,
+  AgentChatMessageSessionArgs,
+  AgentChatMessageSessionKind,
+  AgentChatMessageSessionResult,
   AgentChatCursorModelSource,
   AgentChatModelCatalog,
   AgentChatModelCatalogArgs,
@@ -26405,6 +26408,95 @@ export function createAgentChatService(args: {
     return { steerId, queued: false };
   };
 
+  const normalizeMessageSessionKind = (
+    kind: AgentChatMessageSessionArgs["kind"],
+  ): AgentChatMessageSessionKind => {
+    if (kind == null || kind === "auto") return "auto";
+    if (kind === "queue" || kind === "wake" || kind === "interrupt-replace") return kind;
+    throw new Error(`Unsupported chat message kind: ${String(kind)}`);
+  };
+
+  const messageSession = async ({
+    sessionId,
+    text,
+    kind,
+    attachments = [],
+    contextAttachments = [],
+    metadata,
+  }: AgentChatMessageSessionArgs): Promise<AgentChatMessageSessionResult> => {
+    const managed = ensureManagedSession(sessionId);
+    const normalizedKind = normalizeMessageSessionKind(kind);
+    const statusBefore = managed.session.status;
+    const awaitingInputBefore = hasLivePendingInput(managed);
+    if (awaitingInputBefore) {
+      throw new Error(`${PENDING_INPUT_SEND_BLOCKED_MESSAGE} Use chat.respondToInput for the pending input instead.`);
+    }
+
+    const steerTarget =
+      normalizedKind === "queue" ||
+      (normalizedKind === "auto" && statusBefore === "active");
+    if (steerTarget) {
+      const result = await steer({
+        sessionId,
+        text,
+        attachments,
+        contextAttachments,
+        metadata,
+      });
+      return {
+        sessionId,
+        kind: normalizedKind,
+        routedAction: "steer",
+        statusBefore,
+        awaitingInputBefore,
+        delivery: result.queued ? "queued" : statusBefore === "active" ? "delivered" : "sent",
+        steerId: result.steerId,
+        queued: result.queued,
+      };
+    }
+
+    if (normalizedKind === "interrupt-replace") {
+      await interrupt({ sessionId });
+      await sendMessage(
+        {
+          sessionId,
+          text,
+          attachments,
+          contextAttachments,
+          metadata,
+        },
+        { awaitDispatch: false },
+      );
+      return {
+        sessionId,
+        kind: normalizedKind,
+        routedAction: "interrupt-replace",
+        statusBefore,
+        awaitingInputBefore,
+        delivery: "sent",
+      };
+    }
+
+    await sendMessage(
+      {
+        sessionId,
+        text,
+        attachments,
+        contextAttachments,
+        metadata,
+      },
+      { awaitDispatch: false },
+    );
+    return {
+      sessionId,
+      kind: normalizedKind,
+      routedAction: "sendMessage",
+      statusBefore,
+      awaitingInputBefore,
+      delivery: "sent",
+    };
+  };
+
   const cancelSteer = async ({ sessionId, steerId }: AgentChatCancelSteerArgs): Promise<void> => {
     const managed = ensureManagedSession(sessionId);
     const runtime = managed.runtime;
@@ -31235,6 +31327,7 @@ export function createAgentChatService(args: {
     suggestLaneNameFromPrompt,
     handoffSession,
     sendMessage,
+    messageSession,
     readTranscript,
     setOrchestrationFields,
     getCodexGoal,

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -2496,6 +2496,66 @@ describe("AgentChatPane submit recovery", () => {
     });
   });
 
+  it("keeps active-turn controls when hydrated history starts after the turn-start marker", async () => {
+    const session = buildSession("session-1", { status: "active", awaitingInput: false });
+    installAdeMocks({
+      sessions: [session],
+      eventHistory: {
+        sessionId: session.sessionId,
+        events: [{
+          sessionId: session.sessionId,
+          timestamp: "2026-03-24T05:57:46.000Z",
+          event: {
+            type: "text",
+            text: "Still packaging the release.",
+            turnId: "turn-1",
+          },
+        }],
+        truncated: true,
+        windowTruncated: true,
+        sessionFound: true,
+      },
+    });
+
+    renderPane(session);
+
+    expect(await screen.findByText("Still packaging the release.")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Steer the active turn...")).toBeTruthy();
+    expect(screen.getByLabelText("Stop active turn")).toBeTruthy();
+  });
+
+  it("stops active-turn controls immediately when a terminal event streams", async () => {
+    const session = buildSession("session-1", { status: "active", awaitingInput: false });
+    const { emitChatEvent } = installAdeMocks({
+      sessions: [session],
+      transcript: buildStatusStartedTranscript(session.sessionId),
+    });
+
+    renderPane(session);
+
+    expect(await screen.findByPlaceholderText("Steer the active turn...")).toBeTruthy();
+
+    act(() => {
+      emitChatEvent({
+        sessionId: session.sessionId,
+        timestamp: "2026-03-24T05:58:00.000Z",
+        sequence: 2,
+        event: {
+          type: "done",
+          turnId: "turn-1",
+          status: "completed",
+          model: "gpt-5.4",
+          modelId: "openai/gpt-5.4",
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText("Steer the active turn...")).toBeNull();
+      expect(screen.getByRole("button", { name: "Send" })).toBeTruthy();
+    });
+  });
+
   it("falls back to a normal send when the active-turn marker is stale", async () => {
     const session = buildSession("session-1");
     const { send, steer } = installAdeMocks({

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -978,6 +978,14 @@ export function deriveRuntimeState(events: AgentChatEventEnvelope[]): {
   };
 }
 
+function chatSummaryIndicatesActiveTurn(summary: AgentChatSessionSummary | null | undefined): boolean {
+  return summary?.status === "active" && summary.awaitingInput !== true;
+}
+
+function chatEventEndsTurn(event: AgentChatEventEnvelope["event"]): boolean {
+  return event.type === "done" || (event.type === "status" && event.turnStatus !== "started");
+}
+
 type AgentChatSessionViewCache = {
   events: AgentChatEventEnvelope[];
   turnActive: boolean;
@@ -5166,11 +5174,16 @@ export function AgentChatPane({
     loadedHistoryRef.current.add(sessionId);
     applyOlderHistoryCursor(sessionId, typeof cached.historyCursor === "number" ? cached.historyCursor : null);
     setEventsBySession((prev) => ({ ...prev, [sessionId]: cached.events }));
-    setTurnActiveBySession((prev) => ({ ...prev, [sessionId]: cached.turnActive }));
+    const sessionSummary = sessionsRef.current.find((entry) => entry.sessionId === sessionId)
+      ?? (initialSessionSummary?.sessionId === sessionId ? initialSessionSummary : null);
+    setTurnActiveBySession((prev) => ({
+      ...prev,
+      [sessionId]: cached.turnActive || (cached.events.length > 0 && chatSummaryIndicatesActiveTurn(sessionSummary)),
+    }));
     setPendingInputsBySession((prev) => ({ ...prev, [sessionId]: cached.pendingInputs }));
     setPendingSteersBySession((prev) => ({ ...prev, [sessionId]: cached.pendingSteers }));
     return true;
-  }, [applyOlderHistoryCursor]);
+  }, [applyOlderHistoryCursor, initialSessionSummary]);
 
   const loadHistory = useCallback(async (sessionId: string, options?: { force?: boolean }) => {
     if (options?.force) {
@@ -5265,7 +5278,10 @@ export function AgentChatPane({
       eventsBySessionRef.current = { ...eventsBySessionRef.current, [sessionId]: merged };
       applyOlderHistoryCursor(sessionId, historyCursor);
       setEventsBySession((prev) => ({ ...prev, [sessionId]: merged }));
-      setTurnActiveBySession((prev) => ({ ...prev, [sessionId]: allowRunningFromSummary ? derived.turnActive : false }));
+      setTurnActiveBySession((prev) => ({
+        ...prev,
+        [sessionId]: derived.turnActive || (merged.length > 0 && allowRunningFromSummary),
+      }));
       setPendingInputsBySession((prev) => ({ ...prev, [sessionId]: derived.pendingInputs }));
       setPendingSteersBySession((prev) => ({ ...prev, [sessionId]: derived.pendingSteers }));
     } catch {
@@ -5888,9 +5904,13 @@ export function AgentChatPane({
     // after a "done" event.
     let next = eventsBySessionRef.current;
     const touchedSessionIds = new Set<string>();
+    const endingEventSessionIds = new Set<string>();
 
     for (const envelope of queued) {
       const sessionId = envelope.sessionId;
+      if (chatEventEndsTurn(envelope.event)) {
+        endingEventSessionIds.add(sessionId);
+      }
       const sessionEvents = next === eventsBySessionRef.current
         ? (eventsBySessionRef.current[sessionId] ?? [])
         : (next[sessionId] ?? []);
@@ -5922,6 +5942,12 @@ export function AgentChatPane({
     const pendingSteerPatch: Record<string, PendingSteerEntry[]> = {};
     for (const sessionId of touchedSessionIds) {
       const derived = deriveRuntimeState(next[sessionId] ?? []);
+      const sessionSummary = sessionsRef.current.find((entry) => entry.sessionId === sessionId)
+        ?? (initialSessionSummary?.sessionId === sessionId ? initialSessionSummary : null);
+      const keepActiveFromSummary =
+        chatSummaryIndicatesActiveTurn(sessionSummary)
+        && (next[sessionId]?.length ?? 0) > 0
+        && !endingEventSessionIds.has(sessionId);
       const maxEvents = sessionId === selectedSessionIdRef.current || sessionId === lockSessionId
         ? MAX_SELECTED_CHAT_SESSION_RESIDENT_EVENTS
         : MAX_BACKGROUND_CHAT_SESSION_EVENTS;
@@ -5932,7 +5958,7 @@ export function AgentChatPane({
         olderHistoryCursorRef.current[sessionId] ?? null,
         maxEvents,
       );
-      activePatch[sessionId] = derived.turnActive;
+      activePatch[sessionId] = derived.turnActive || keepActiveFromSummary;
       pendingInputPatch[sessionId] = derived.pendingInputs;
       pendingSteerPatch[sessionId] = derived.pendingSteers;
     }
@@ -5942,7 +5968,7 @@ export function AgentChatPane({
     setTurnActiveBySession((activePrev) => ({ ...activePrev, ...activePatch }));
     setPendingInputsBySession((pendingPrev) => ({ ...pendingPrev, ...pendingInputPatch }));
     setPendingSteersBySession((steerPrev) => ({ ...steerPrev, ...pendingSteerPatch }));
-  }, [lockSessionId]);
+  }, [initialSessionSummary, lockSessionId]);
 
   const scheduleQueuedEventFlush = useCallback(() => {
     if (eventFlushTimerRef.current != null) return;

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -1732,6 +1732,32 @@ export type AgentChatSteerResult = {
   queued: boolean;
 };
 
+export type AgentChatMessageSessionKind =
+  | "auto"
+  | "queue"
+  | "wake"
+  | "interrupt-replace";
+
+export type AgentChatMessageSessionArgs = {
+  sessionId: string;
+  text: string;
+  kind?: AgentChatMessageSessionKind;
+  attachments?: AgentChatFileRef[];
+  contextAttachments?: AgentChatContextAttachment[];
+  metadata?: AgentChatEventMetadata | null | undefined;
+};
+
+export type AgentChatMessageSessionResult = {
+  sessionId: string;
+  kind: AgentChatMessageSessionKind;
+  routedAction: "sendMessage" | "steer" | "interrupt-replace";
+  statusBefore: AgentChatSessionStatus;
+  awaitingInputBefore: boolean;
+  delivery: "sent" | "delivered" | "queued";
+  steerId?: string;
+  queued?: boolean;
+};
+
 export type AgentChatCancelSteerArgs = {
   sessionId: string;
   steerId: string;

--- a/docs/features/chat/README.md
+++ b/docs/features/chat/README.md
@@ -414,15 +414,24 @@ imported user/assistant text when the caller did not provide one.
    recreated on the next turn.
 3. `sendMessage({ sessionId, text, attachments? })` via
    `ade.agentChat.send` dispatches a turn. The ADE action bridge exposes
-   the same path as `chat.sendMessage`; `ade chat send` returns an accepted
-   acknowledgement after the service accepts the message, while provider
-   dispatch and event streaming continue asynchronously. `ade chat create
-   --prompt` uses this same follow-up send after the session is created, and
-   `ade chat read <session>` calls `chat.readTranscript` to inspect recent
-   transcript messages for chat sessions only; shell/terminal transcript reads
-   stay on the terminal/session surfaces. When invoked through the generic ADE
-   action bridge by a session-bound non-CTO caller, `chat.sendMessage` and
-   `chat.readTranscript` are scoped to that caller's own chat session.
+   the same low-level path as `chat.sendMessage`, plus
+   `chat.messageSession({ sessionId, text, kind })` as the normalized
+   agent-to-agent primitive. `kind: "auto"` steers active sessions and wakes
+   idle sessions, `queue` always routes through the provider-normalized steer
+   path, `wake` starts a normal turn, and `interrupt-replace` interrupts before
+   sending the replacement. The result reports the routed action and whether a
+   steer was delivered or queued. `ade chat send` uses the auto route, while
+   `ade chat message --kind ...` exposes the explicit primitive. Provider
+   dispatch and event streaming continue asynchronously after acceptance.
+   `ade chat create --prompt` uses this same follow-up send after the session is
+   created, and `ade chat read <session>` calls `chat.readTranscript` to inspect
+   recent transcript messages for chat sessions only; shell/terminal transcript
+   reads stay on the terminal/session surfaces. When invoked through the generic
+   ADE action bridge by a session-bound non-CTO caller, the low-level
+   `chat.sendMessage` and `chat.readTranscript` actions are scoped to that
+   caller's own chat session; `chat.messageSession` is the reviewed peer-control
+   primitive for deliberately messaging another ADE chat through ADE's routing
+   contract.
    Interactive chat sends are not wall-clock bounded by the service; the turn
    runs until the provider
    completes or the user/app interrupts it. The blocking `runSessionTurn`


### PR DESCRIPTION
## Summary

- Adds `chat.messageSession` as the normalized agent-to-agent delivery primitive for ADE chats.
- Adds CLI affordances for peer interaction: `ade chat message`, explicit `ade chat steer`, and bounded `ade chat wait`.
- Fixes the Work chat running indicator disappearing when hydrated history starts after the active-turn marker.
- Updates bundled ADE skills and chat docs with provider-specific steering guidance.

## Validation

- `npm --prefix apps/ade-cli run test -- cli.test.ts adeRpcServer.test.ts`
- `npm --prefix apps/ade-cli run typecheck`
- `npm --prefix apps/desktop exec -- vitest run src/main/services/adeActions/registry.test.ts`
- `npm --prefix apps/desktop exec -- vitest run src/renderer/components/chat/AgentChatPane.test.tsx`
- `node scripts/validate-docs.mjs`
- `git diff --check`

## Known caveat

- `npm --prefix apps/desktop run typecheck` is still blocked by pre-existing Cursor SDK declaration drift in `cursorSdkErrors.ts` and `cursorSdkWorker.ts` (`LocalAgentStore`, `@cursor/sdk/sqlite`, `Cursor.configure`, `mode`, `requestId`). Those files are untouched by this PR.

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstart-skill-session-lane-repo-53464909 num=741 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstart-skill-session-lane-repo-53464909&amp;pr=741">ade/start-skill-session-lane-repo-53464909 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=741">PR #741</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds normalized chat messaging and steering support across the CLI and desktop chat service. The main changes are:

- New `ade chat message`, `ade chat steer`, and `ade chat wait` command flows.
- A new `chat.messageSession` ADE action that routes messages through auto, queue, wake, or interrupt-replace behavior.
- Updated chat service types, registry contracts, tests, docs, help text, and bundled skill guidance.
- Renderer active-turn state handling that keeps steering controls visible for truncated history and clears them on terminal events.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changed paths have targeted coverage for CLI planning, action registration, RPC routing, and renderer active-turn state. No verified correctness or security issues were found in the changed code.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Baseline state captured: the merge-base checkout with the new targeted tests absent reported 155 skipped tests.
- On the PR code, the focused active-summary and terminal-event tests for the chat-running-indicator component produced 2 passed and 155 skipped.
- UI server and video capture were not pursued because the focused tests already verified the running-indicator behavior in the real repository component.

<a href="https://app.greptile.com/trex/runs/13747577/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/cli.ts | Adds normalized chat message and steer commands plus a polling `chat wait` execution path. |
| apps/desktop/src/main/services/adeActions/registry.ts | Exposes `chat.messageSession` through the ADE action registry with input contract and validation. |
| apps/desktop/src/main/services/chat/agentChatService.ts | Implements the normalized `messageSession` route across auto, queue, wake, and interrupt-replace behavior. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Keeps active-turn UI from session summaries when transcript windows omit the start marker, while clearing on terminal events. |
| apps/desktop/src/shared/types/chat.ts | Adds shared argument and result types for normalized chat session messaging. |
| docs/features/chat/README.md | Updates chat lifecycle documentation for `messageSession`, CLI auto routing, and peer-control semantics. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant CLI as ade chat CLI
participant Registry as ADE action registry
participant ChatService as AgentChatService
participant Provider as Provider runtime
participant Renderer as AgentChatPane

User->>CLI: ade chat message/steer/send/wait
CLI->>Registry: run_ade_action(chat.messageSession / steer / getSessionSummary)
alt messageSession auto/queue
    Registry->>ChatService: "messageSession({ sessionId, text, kind })"
    ChatService->>ChatService: inspect status + pending input
    alt active or queue
        ChatService->>Provider: steer / queued steer
    else idle or wake
        ChatService->>Provider: sendMessage normal turn
    else interrupt-replace
        ChatService->>Provider: interrupt active turn
        ChatService->>Provider: send replacement message
    end
    ChatService-->>Registry: routedAction + delivery
    Registry-->>CLI: action result
else chat wait
    CLI->>Registry: getSessionSummary loop
    Registry-->>CLI: status / awaitingInput / endedAt
end
Provider-->>Renderer: chat event stream
Renderer->>Renderer: derive active controls from events + summary
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant CLI as ade chat CLI
participant Registry as ADE action registry
participant ChatService as AgentChatService
participant Provider as Provider runtime
participant Renderer as AgentChatPane

User->>CLI: ade chat message/steer/send/wait
CLI->>Registry: run_ade_action(chat.messageSession / steer / getSessionSummary)
alt messageSession auto/queue
    Registry->>ChatService: "messageSession({ sessionId, text, kind })"
    ChatService->>ChatService: inspect status + pending input
    alt active or queue
        ChatService->>Provider: steer / queued steer
    else idle or wake
        ChatService->>Provider: sendMessage normal turn
    else interrupt-replace
        ChatService->>Provider: interrupt active turn
        ChatService->>Provider: send replacement message
    end
    ChatService-->>Registry: routedAction + delivery
    Registry-->>CLI: action result
else chat wait
    CLI->>Registry: getSessionSummary loop
    Registry-->>CLI: status / awaitingInput / endedAt
end
Provider-->>Renderer: chat event stream
Renderer->>Renderer: derive active controls from events + summary
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat: normalize ADE chat peer messaging"](https://github.com/arul28/ade/commit/a06cf722a00290711374e70a49bc85f96d575ff7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42836226)</sub>

<!-- /greptile_comment -->