### PR TITLE
Mobile Linear Pane Backlog Loading

### DIFF
--- a/apps/ios/ADE/Views/Linear/LinearIssueListScreen.swift
+++ b/apps/ios/ADE/Views/Linear/LinearIssueListScreen.swift
@@ -15,9 +15,9 @@ struct LinearIssueListScreen: View {
   @ObservedObject var store: LinearPaneStore
   var onClose: () -> Void = {}
 
-  /// State-group ids the user has collapsed. Collapsed groups keep their header
-  /// (with a filled count) but hide their rows.
-  @State private var collapsedGroups: Set<String> = []
+  /// User overrides for group collapse state. Completed groups collapse by
+  /// default, while all other groups open until the user toggles them.
+  @State private var groupCollapseOverrides: [String: Bool] = [:]
 
   private enum ListContent { case skeletons, failure, empty, issues }
 
@@ -72,7 +72,7 @@ struct LinearIssueListScreen: View {
   @ViewBuilder
   private var issueSections: some View {
     ForEach(store.groupedIssues) { group in
-      let collapsed = collapsedGroups.contains(group.id)
+      let collapsed = groupCollapseOverrides[group.id] ?? linearGroupCollapsedByDefault(stateType: group.stateType)
       Section {
         if !collapsed {
           ForEach(group.issues) { issue in
@@ -85,7 +85,7 @@ struct LinearIssueListScreen: View {
       } header: {
         Button {
           withAnimation(.snappy(duration: 0.2)) {
-            if collapsed { collapsedGroups.remove(group.id) } else { collapsedGroups.insert(group.id) }
+            groupCollapseOverrides[group.id] = !collapsed
           }
         } label: {
           LinearGroupHeader(title: group.title, stateType: group.stateType, count: group.issues.count, collapsed: collapsed)

--- a/apps/ios/ADE/Views/Linear/LinearPaneStore.swift
+++ b/apps/ios/ADE/Views/Linear/LinearPaneStore.swift
@@ -17,6 +17,17 @@ func linearIssueFallbackSearch(identifier: String) -> LinearIssueFallbackSearch 
   LinearIssueFallbackSearch(query: identifier, assignedToMe: false)
 }
 
+@MainActor
+protocol LinearPaneSyncing: AnyObject {
+  var linearConnectionStatus: LinearConnectionStatus? { get }
+  func attachedLinearIssueIds() -> Set<String>
+  func fetchLinearQuickView() async throws -> LinearQuickView
+  func fetchLinearIssuePickerData() async throws -> LinearIssuePickerData
+  func searchLinearIssues(_ args: LinearIssueSearchArgs) async throws -> LinearIssueSearchResult
+}
+
+extension SyncService: LinearPaneSyncing {}
+
 /// Backing store for the global Linear pane: holds the filter selection, drives
 /// the `cto.searchLinearIssues` / picker / quick-view reads, and exposes issues
 /// grouped by workflow state. Active-project scoped (mirrors desktop).
@@ -36,17 +47,19 @@ final class LinearPaneStore: ObservableObject {
     var stateTypes: [String]? {
       switch self {
       case .all: return nil
-      case .active: return ["started", "unstarted"]
-      case .backlog: return ["backlog", "triage"]
+      case .active: return ["backlog", "unstarted", "started"]
+      case .backlog: return ["backlog"]
       }
     }
   }
+
+  static let defaultAssignedToMe = false
 
   enum Phase { case idle, loading, loaded, failed }
 
   // Filters
   @Published var query = ""
-  @Published var assignedToMe = true
+  @Published var assignedToMe = LinearPaneStore.defaultAssignedToMe
   @Published var statePreset: StatePreset = .all
   @Published var projectId: String?
   @Published var priority: Int?
@@ -61,13 +74,13 @@ final class LinearPaneStore: ObservableObject {
   @Published private(set) var hasNextPage = false
   @Published private(set) var errorMessage: String?
 
-  private let pageSize = 50
+  private let pageSize = 100
   private var endCursor: String?
   private var searchGeneration = 0
   private var reloadTask: Task<Void, Never>?
-  private unowned let sync: SyncService
+  private let sync: any LinearPaneSyncing
 
-  init(sync: SyncService) {
+  init(sync: any LinearPaneSyncing) {
     self.sync = sync
   }
 
@@ -96,8 +109,8 @@ final class LinearPaneStore: ObservableObject {
 
   // MARK: Loads
 
-  /// First load when the pane opens: catalog + quick view (for the viewer id the
-  /// assigned-to-me default needs), the attached-issue set, then the first page.
+  /// First load when the pane opens: catalog + quick view, the attached-issue
+  /// set, then every page matching the current filters.
   func start() async {
     refreshAttachedIssueIds()
     await withTaskGroup(of: Void.self) { group in
@@ -147,12 +160,14 @@ final class LinearPaneStore: ObservableObject {
     phase = .loading
     errorMessage = nil
     do {
-      let result = try await sync.searchLinearIssues(currentArgs(after: nil))
+      let result = try await loadAllPages(after: nil)
       guard generation == searchGeneration else { return }
       issues = result.issues
       endCursor = result.pageInfo.endCursor
       hasNextPage = result.pageInfo.hasNextPage
       phase = .loaded
+    } catch is CancellationError {
+      return
     } catch {
       guard generation == searchGeneration else { return }
       issues = []
@@ -166,12 +181,14 @@ final class LinearPaneStore: ObservableObject {
     loadingMore = true
     let generation = searchGeneration
     do {
-      let result = try await sync.searchLinearIssues(currentArgs(after: cursor))
+      let result = try await loadAllPages(after: cursor)
       if generation == searchGeneration {
-        issues.append(contentsOf: result.issues)
+        issues = linearMergeIssuePages(issues, result.issues)
         endCursor = result.pageInfo.endCursor
         hasNextPage = result.pageInfo.hasNextPage
       }
+    } catch is CancellationError {
+      // A newer reload superseded this paging request.
     } catch {
       // Keep what we have; the row-level "Load more" affordance can retry.
     }
@@ -198,6 +215,36 @@ final class LinearPaneStore: ObservableObject {
     return args
   }
 
+  private func loadAllPages(after initialCursor: String?) async throws -> LinearIssueSearchResult {
+    var loaded: [NormalizedLinearIssue] = []
+    var cursor = initialCursor
+    var pageInfo = LinearIssueSearchResultPageInfo(hasNextPage: true, endCursor: cursor)
+    var seenCursors = Set<String>()
+
+    while pageInfo.hasNextPage {
+      try Task.checkCancellation()
+      if let cursor {
+        guard seenCursors.insert(cursor).inserted else {
+          pageInfo = LinearIssueSearchResultPageInfo(hasNextPage: false, endCursor: cursor)
+          break
+        }
+      }
+      let result = try await sync.searchLinearIssues(currentArgs(after: cursor))
+      loaded = linearMergeIssuePages(loaded, result.issues)
+      pageInfo = result.pageInfo
+      guard pageInfo.hasNextPage else {
+        break
+      }
+      guard let nextCursor = pageInfo.endCursor else {
+        pageInfo = LinearIssueSearchResultPageInfo(hasNextPage: false, endCursor: nil)
+        break
+      }
+      cursor = nextCursor
+    }
+
+    return LinearIssueSearchResult(issues: loaded, pageInfo: pageInfo)
+  }
+
 }
 
 /// Rank for ordering workflow-state groups: active work first, closed last.
@@ -205,8 +252,8 @@ func linearStateRank(_ stateType: String) -> Int {
   switch linearNormalizedStateType(stateType) {
   case "started": return 0
   case "unstarted": return 1
-  case "triage": return 2
-  case "backlog": return 3
+  case "backlog": return 2
+  case "triage": return 3
   case "completed": return 4
   case "canceled": return 5
   default: return 6
@@ -240,4 +287,19 @@ func linearGroupIssues(_ issues: [NormalizedLinearIssue]) -> [LinearIssueGroup] 
       if l != r { return l < r }
       return (order.firstIndex(of: lhs.id) ?? 0) < (order.firstIndex(of: rhs.id) ?? 0)
     }
+}
+
+func linearMergeIssuePages(_ current: [NormalizedLinearIssue], _ next: [NormalizedLinearIssue]) -> [NormalizedLinearIssue] {
+  var seen = Set<String>()
+  var merged: [NormalizedLinearIssue] = []
+  merged.reserveCapacity(current.count + next.count)
+  for issue in current + next {
+    guard seen.insert(issue.id).inserted else { continue }
+    merged.append(issue)
+  }
+  return merged
+}
+
+func linearGroupCollapsedByDefault(stateType: String) -> Bool {
+  linearNormalizedStateType(stateType) == "completed"
 }

--- a/apps/ios/ADE/Views/Linear/LinearPaneStore.swift
+++ b/apps/ios/ADE/Views/Linear/LinearPaneStore.swift
@@ -75,6 +75,7 @@ final class LinearPaneStore: ObservableObject {
   @Published private(set) var errorMessage: String?
 
   private let pageSize = 100
+  private let maxPagesPerRequest = 10
   private var endCursor: String?
   private var searchGeneration = 0
   private var reloadTask: Task<Void, Never>?
@@ -220,8 +221,9 @@ final class LinearPaneStore: ObservableObject {
     var cursor = initialCursor
     var pageInfo = LinearIssueSearchResultPageInfo(hasNextPage: true, endCursor: cursor)
     var seenCursors = Set<String>()
+    var pagesLoaded = 0
 
-    while pageInfo.hasNextPage {
+    while pageInfo.hasNextPage && pagesLoaded < maxPagesPerRequest {
       try Task.checkCancellation()
       if let cursor {
         guard seenCursors.insert(cursor).inserted else {
@@ -230,6 +232,7 @@ final class LinearPaneStore: ObservableObject {
         }
       }
       let result = try await sync.searchLinearIssues(currentArgs(after: cursor))
+      pagesLoaded += 1
       loaded = linearMergeIssuePages(loaded, result.issues)
       pageInfo = result.pageInfo
       guard pageInfo.hasNextPage else {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -16360,15 +16360,10 @@ final class LinearPaneTests: XCTestCase {
         pageInfo: LinearIssueSearchResultPageInfo(hasNextPage: true, endCursor: "cursor-1")
       ),
       LinearIssueSearchResult(
-        issues: (2...9).map { index in
-          makeIssue(
-            id: "backlog-\(index)",
-            identifier: "ADE-\(index + 1)",
-            title: "Backlog \(index)",
-            stateId: "state-backlog",
-            stateName: "Backlog",
-            stateType: "backlog"
-          )
+        issues: [
+          makeIssue(id: "backlog-1", identifier: "ADE-2", title: "Backlog 1 updated", stateId: "state-backlog", stateName: "Backlog", stateType: "backlog"),
+        ] + (2...9).map { index in
+          makeIssue(id: "backlog-\(index)", identifier: "ADE-\(index + 1)", title: "Backlog \(index)", stateId: "state-backlog", stateName: "Backlog", stateType: "backlog")
         },
         pageInfo: LinearIssueSearchResultPageInfo(hasNextPage: false, endCursor: nil)
       ),
@@ -16386,6 +16381,35 @@ final class LinearPaneTests: XCTestCase {
     XCTAssertEqual(sync.searchArgs.last?.after, "cursor-1")
     XCTAssertEqual(store.groupedIssues.first { $0.title == "Backlog" }?.issues.count, 9)
     XCTAssertFalse(store.hasNextPage)
+  }
+
+  @MainActor
+  func testLinearPaneStoreKeepsOverflowPagingReachableAfterEagerBatchLimit() async {
+    let sync = LinearPaneSyncSpy()
+    sync.searchResults = (1...11).map { index in
+      LinearIssueSearchResult(
+        issues: [makeIssue(id: "i\(index)", identifier: "ADE-\(index)", title: "Issue \(index)")],
+        pageInfo: LinearIssueSearchResultPageInfo(
+          hasNextPage: index < 11,
+          endCursor: index < 11 ? "cursor-\(index)" : nil
+        )
+      )
+    }
+
+    let store = LinearPaneStore(sync: sync)
+    await store.reload()
+
+    XCTAssertEqual(store.issues.count, 10)
+    XCTAssertTrue(store.hasNextPage)
+    XCTAssertEqual(sync.searchArgs.count, 10)
+    XCTAssertEqual(sync.searchArgs.last?.after, "cursor-9")
+
+    await store.loadMore()
+
+    XCTAssertEqual(store.issues.count, 11)
+    XCTAssertFalse(store.hasNextPage)
+    XCTAssertEqual(sync.searchArgs.count, 11)
+    XCTAssertEqual(sync.searchArgs.last?.after, "cursor-10")
   }
 
   func testLinearCompletedGroupsCollapseByDefault() {

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -16239,6 +16239,29 @@ private actor LinearLaunchSpy {
   func recordCli() { cliLaunches += 1 }
 }
 
+@MainActor
+private final class LinearPaneSyncSpy: LinearPaneSyncing {
+  var linearConnectionStatus: LinearConnectionStatus? = LinearConnectionStatus(connected: true)
+  var searchResults: [LinearIssueSearchResult] = []
+  private(set) var searchArgs: [LinearIssueSearchArgs] = []
+
+  func attachedLinearIssueIds() -> Set<String> { [] }
+
+  func fetchLinearQuickView() async throws -> LinearQuickView {
+    throw LinearTestError.launchFailed
+  }
+
+  func fetchLinearIssuePickerData() async throws -> LinearIssuePickerData {
+    LinearIssuePickerData(projects: [], users: [], states: [])
+  }
+
+  func searchLinearIssues(_ args: LinearIssueSearchArgs) async throws -> LinearIssueSearchResult {
+    searchArgs.append(args)
+    guard !searchResults.isEmpty else { throw LinearTestError.launchFailed }
+    return searchResults.removeFirst()
+  }
+}
+
 final class LinearPaneTests: XCTestCase {
   private func makeIssue(
     id: String = "i1",
@@ -16323,6 +16346,76 @@ final class LinearPaneTests: XCTestCase {
     XCTAssertEqual(linearNormalizedStateType("weird"), "unstarted")
     // Started/completed carry distinct brand hues (not the neutral gray).
     XCTAssertNotEqual(linearStateColor("started"), linearStateColor("backlog"))
+  }
+
+  @MainActor
+  func testLinearPaneStoreLoadsAllPagesWithoutAssignedFilterByDefault() async {
+    let sync = LinearPaneSyncSpy()
+    sync.searchResults = [
+      LinearIssueSearchResult(
+        issues: [
+          makeIssue(id: "started-1", identifier: "ADE-1", title: "Started", stateId: "state-started", stateName: "In Progress", stateType: "started"),
+          makeIssue(id: "backlog-1", identifier: "ADE-2", title: "Backlog 1", stateId: "state-backlog", stateName: "Backlog", stateType: "backlog"),
+        ],
+        pageInfo: LinearIssueSearchResultPageInfo(hasNextPage: true, endCursor: "cursor-1")
+      ),
+      LinearIssueSearchResult(
+        issues: (2...9).map { index in
+          makeIssue(
+            id: "backlog-\(index)",
+            identifier: "ADE-\(index + 1)",
+            title: "Backlog \(index)",
+            stateId: "state-backlog",
+            stateName: "Backlog",
+            stateType: "backlog"
+          )
+        },
+        pageInfo: LinearIssueSearchResultPageInfo(hasNextPage: false, endCursor: nil)
+      ),
+    ]
+
+    let store = LinearPaneStore(sync: sync)
+    XCTAssertFalse(store.assignedToMe)
+
+    await store.reload()
+
+    XCTAssertEqual(store.issues.count, 10)
+    XCTAssertEqual(sync.searchArgs.count, 2)
+    XCTAssertNil(sync.searchArgs.first?.assigneeId)
+    XCTAssertEqual(sync.searchArgs.first?.first, 100)
+    XCTAssertEqual(sync.searchArgs.last?.after, "cursor-1")
+    XCTAssertEqual(store.groupedIssues.first { $0.title == "Backlog" }?.issues.count, 9)
+    XCTAssertFalse(store.hasNextPage)
+  }
+
+  func testLinearCompletedGroupsCollapseByDefault() {
+    XCTAssertTrue(linearGroupCollapsedByDefault(stateType: "completed"))
+    XCTAssertFalse(linearGroupCollapsedByDefault(stateType: "backlog"))
+    XCTAssertFalse(linearGroupCollapsedByDefault(stateType: "started"))
+  }
+
+  func testLinearStatePresetsMatchDesktopIssueBrowser() {
+    XCTAssertNil(LinearPaneStore.StatePreset.all.stateTypes)
+    XCTAssertEqual(LinearPaneStore.StatePreset.active.stateTypes, ["backlog", "unstarted", "started"])
+    XCTAssertEqual(LinearPaneStore.StatePreset.backlog.stateTypes, ["backlog"])
+  }
+
+  @MainActor
+  func testLinearPaneStoreStopsPagingWhenHostOmitsCursor() async {
+    let sync = LinearPaneSyncSpy()
+    sync.searchResults = [
+      LinearIssueSearchResult(
+        issues: [makeIssue(id: "i1", identifier: "ADE-1", title: "Loaded")],
+        pageInfo: LinearIssueSearchResultPageInfo(hasNextPage: true, endCursor: nil)
+      ),
+    ]
+
+    let store = LinearPaneStore(sync: sync)
+    await store.reload()
+
+    XCTAssertEqual(store.issues.count, 1)
+    XCTAssertFalse(store.hasNextPage)
+    XCTAssertEqual(sync.searchArgs.count, 1)
   }
 
   // Launch orchestration contract.


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fokay-start-skill-disc-write-c7a0cf29 num=743 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fokay-start-skill-disc-write-c7a0cf29&amp;pr=743">ade/okay-start-skill-disc-write-c7a0cf29 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=743">PR #743</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issue lists now keep group collapse state more consistently and remember per-group overrides.
  * Larger issue lists can load all remaining pages automatically for a more complete view.

* **Bug Fixes**
  * Prevented duplicate issues from appearing when additional pages are merged.
  * Improved default filtering and group collapse behavior for several issue states, including completed items.

* **Tests**
  * Added coverage for paging, grouping, default collapse behavior, and preset state mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the iOS Linear pane issue browser. The main changes are:

- Eagerly loads larger batches of paged Linear issues.
- Deduplicates issues when merging additional pages.
- Keeps overflow paging reachable after the eager batch limit.
- Aligns default assignment filtering and state presets with the backlog browser behavior.
- Collapses completed issue groups by default while preserving user overrides.
- Adds tests for paging, grouping defaults, and state preset behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are localized to the Linear pane list and store. The new pagination, deduplication, preset, and collapse behavior is covered by targeted tests. No blocking correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex verified tool availability by reviewing the ios-linear-tool-availability.log.
- T-Rex identified a blocker for ADETests based on the ios-linear-xcodebuild-test-blocker.log.
- T-Rex performed a fallback repository sanity check using the ios-linear-diff-check.log to confirm consistency.

<a href="https://app.greptile.com/trex/runs/13761518/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Views/Linear/LinearIssueListScreen.swift | Replaces explicit collapsed group tracking with per-group override state so completed groups default collapsed while preserving user toggles. |
| apps/ios/ADE/Views/Linear/LinearPaneStore.swift | Adds a testable syncing protocol, eager multi-page loading, deduplication, updated state presets, and new default assignment filtering. |
| apps/ios/ADETests/ADETests.swift | Adds Linear pane store tests for eager pagination, overflow paging, default filters, state presets, and group collapse defaults. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Screen as LinearIssueListScreen
participant Store as LinearPaneStore
participant Sync as LinearPaneSyncing

Screen->>Store: start() / reload()
Store->>Sync: searchLinearIssues(first: 100, after: nil)
Sync-->>Store: issues + pageInfo(endCursor, hasNextPage)
loop "while hasNextPage and pagesLoaded < 10"
    Store->>Sync: searchLinearIssues(first: 100, after: endCursor)
    Sync-->>Store: next page
    Store->>Store: linearMergeIssuePages(existing, next)
end
Store-->>Screen: published issues, hasNextPage, groupedIssues
alt more pages remain
    Screen->>Store: loadMore() from footer onAppear
    Store->>Sync: searchLinearIssues(after: endCursor)
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Screen as LinearIssueListScreen
participant Store as LinearPaneStore
participant Sync as LinearPaneSyncing

Screen->>Store: start() / reload()
Store->>Sync: searchLinearIssues(first: 100, after: nil)
Sync-->>Store: issues + pageInfo(endCursor, hasNextPage)
loop "while hasNextPage and pagesLoaded < 10"
    Store->>Sync: searchLinearIssues(first: 100, after: endCursor)
    Sync-->>Store: next page
    Store->>Store: linearMergeIssuePages(existing, next)
end
Store-->>Screen: published issues, hasNextPage, groupedIssues
alt more pages remain
    Screen->>Store: loadMore() from footer onAppear
    Store->>Sync: searchLinearIssues(after: endCursor)
end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Address Linear pane paging review"](https://github.com/arul28/ade/commit/93fb91303c5e7717244ff69a6ddfb1f77e8f026e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42857333)</sub>

<!-- /greptile_comment -->