### PR TITLE
Refine session stale and stopped states

### DIFF
--- a/apps/desktop/src/renderer/components/terminals/SessionCard.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.test.tsx
@@ -154,6 +154,27 @@ describe("SessionCard attention capsule", () => {
     expect(screen.getByText("Failed")).toBeTruthy();
   });
 
+  it("shows stopped inline text, not a Failed capsule, for a disposed CLI session", () => {
+    render(
+      <SessionCard
+        session={makeSession({
+          toolType: "claude",
+          status: "disposed",
+          runtimeState: "killed",
+          exitCode: null,
+          resumeCommand: "claude --resume session-1",
+        })}
+        lane={lane}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onContextMenu={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Stopped")).toBeTruthy();
+    expect(screen.getAllByTitle("Stopped")).toHaveLength(2);
+    expect(screen.queryByText("Failed")).toBeNull();
+  });
+
   it("shows a Stale capsule for a long-silent running session", () => {
     render(
       <SessionCard

--- a/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
@@ -7,6 +7,7 @@ import {
   sanitizeTerminalInlineText,
   sessionNeedsChatTabHighlight,
   sessionCapsuleBadge,
+  sessionInlineStatusLabel,
 } from "../../lib/terminalAttention";
 import type { SessionBadge } from "../../../shared/sessionCanonicalState";
 import {
@@ -193,7 +194,7 @@ export const SessionCard = React.memo(function SessionCard({
   // Canonical one-word status capsule (Needs you / Failed / Stale). When the
   // chat-specific "Awaiting you" chip is already showing the same needs-input
   // condition, suppress the capsule so a chat card never doubles up amber pills.
-  const capsuleBadge = sessionCapsuleBadge({
+  const sessionAttentionInput = {
     status: session.status,
     lastOutputPreview: session.lastOutputPreview,
     runtimeState: session.runtimeState,
@@ -201,9 +202,11 @@ export const SessionCard = React.memo(function SessionCard({
     pendingInputItemId: session.pendingInputItemId,
     lastActivityAt: session.lastActivityAt,
     exitCode: session.exitCode,
-  });
+  };
+  const capsuleBadge = sessionCapsuleBadge(sessionAttentionInput);
   const attentionBadge =
     capsuleBadge && !(awaitingUser && capsuleBadge.kind === "needs_you") ? capsuleBadge : null;
+  const inlineStatusLabel = sessionInlineStatusLabel(sessionAttentionInput);
   const isRemoteProject = useAppStore((s) => s.projectBinding?.kind === "remote");
   const delta = useSessionDelta(session.id, !isRemoteProject || isSelected);
   const primaryText = primarySessionLabel(session);
@@ -374,6 +377,17 @@ export const SessionCard = React.memo(function SessionCard({
                   >
                     <Question size={compact ? 9 : 10} weight="bold" />
                     {compact ? null : "Awaiting you"}
+                  </span>
+                ) : null}
+                {inlineStatusLabel ? (
+                  <span
+                    className={cn(
+                      "shrink-0 font-medium leading-none text-red-300/65",
+                      compact ? "text-[9px]" : "text-[10px]",
+                    )}
+                    title={inlineStatusLabel}
+                  >
+                    {inlineStatusLabel}
                   </span>
                 ) : null}
                 <span

--- a/apps/desktop/src/renderer/lib/terminalAttention.test.ts
+++ b/apps/desktop/src/renderer/lib/terminalAttention.test.ts
@@ -206,6 +206,30 @@ describe("terminalAttention", () => {
       expect(dot.label).toBe("Ended");
     });
 
+    it("returns a stopped red dot for a disposed session", () => {
+      const dot = sessionStatusDot({
+        status: "disposed",
+        lastOutputPreview: "Stopped by user",
+        runtimeState: "killed",
+        toolType: "codex",
+      });
+      expect(dot.spinning).toBe(false);
+      expect(dot.cls).toContain("red");
+      expect(dot.label).toBe("Stopped");
+    });
+
+    it("returns a failed red dot for an explicit failed status", () => {
+      const dot = sessionStatusDot({
+        status: "failed",
+        lastOutputPreview: "Launch failed",
+        runtimeState: "exited",
+        toolType: "codex",
+      });
+      expect(dot.spinning).toBe(false);
+      expect(dot.cls).toContain("red");
+      expect(dot.label).toBe("Failed");
+    });
+
     it("returns a ready amber dot for a non-running agent chat session", () => {
       const dot = sessionStatusDot({
         status: "completed",

--- a/apps/desktop/src/renderer/lib/terminalAttention.ts
+++ b/apps/desktop/src/renderer/lib/terminalAttention.ts
@@ -1,5 +1,5 @@
 import type { TerminalRuntimeState, TerminalSessionStatus, TerminalSessionSummary, TerminalToolType } from "../../shared/types";
-import { canonicalSessionState, type SessionBadge } from "../../shared/sessionCanonicalState";
+import { canonicalSessionState, type CanonicalSessionState, type SessionBadge } from "../../shared/sessionCanonicalState";
 import { isChatToolType } from "./sessions";
 
 export type TerminalRunIndicatorState = "none" | "running-active" | "running-needs-attention";
@@ -117,13 +117,7 @@ export function sessionIndicatorState(args: {
   return "ended";
 }
 
-/**
- * The one-word attention capsule for a session row (desktop SessionCard; iOS
- * mirrors the vocabulary). Null for every calm state — rows must not shift
- * layout when no capsule renders. Backed by the shared canonical state module
- * so the capsule, the Live Activity phase, and notifications always agree.
- */
-export function sessionCapsuleBadge(session: {
+type SessionCanonicalUiInput = {
   status: TerminalSessionStatus;
   lastOutputPreview: string | null;
   runtimeState?: TerminalRuntimeState;
@@ -132,7 +126,9 @@ export function sessionCapsuleBadge(session: {
   lastActivityAt?: string | null;
   exitCode?: number | null;
   nowMs?: number;
-}): SessionBadge | null {
+};
+
+export function sessionCanonicalUiState(session: SessionCanonicalUiInput): CanonicalSessionState {
   return canonicalSessionState({
     status: session.status,
     runtimeState: session.runtimeState ?? null,
@@ -144,7 +140,23 @@ export function sessionCapsuleBadge(session: {
     nowMs: session.nowMs,
     previewSuggestsNeedsInput: runningSessionNeedsAttention,
     isChatTool: isChatToolType,
-  }).badge;
+  });
+}
+
+/**
+ * The one-word attention capsule for a session row (desktop SessionCard; iOS
+ * mirrors the vocabulary). Null for every calm state — rows must not shift
+ * layout when no capsule renders. Backed by the shared canonical state module
+ * so the capsule, the Live Activity phase, and notifications always agree.
+ */
+export function sessionCapsuleBadge(session: SessionCanonicalUiInput): SessionBadge | null {
+  return sessionCanonicalUiState(session).badge;
+}
+
+export function sessionInlineStatusLabel(session: SessionCanonicalUiInput): string | null {
+  const state = sessionCanonicalUiState(session);
+  if (state.phase === "stopped") return "Stopped";
+  return null;
 }
 
 export function sessionNeedsUserInput(args: {
@@ -229,6 +241,12 @@ export function sessionStatusDot(session: {
       label = "Awaiting input";
     }
     return { cls: "rounded-full bg-amber-300", spinning: false, label };
+  }
+  if (session.status === "disposed") {
+    return { cls: "rounded-full bg-red-400", spinning: false, label: "Stopped" };
+  }
+  if (session.status === "failed") {
+    return { cls: "rounded-full bg-red-400", spinning: false, label: "Failed" };
   }
   return { cls: "rounded-full bg-red-400", spinning: false, label: "Ended" };
 }

--- a/apps/desktop/src/shared/sessionCanonicalState.test.ts
+++ b/apps/desktop/src/shared/sessionCanonicalState.test.ts
@@ -33,6 +33,8 @@ describe("canonicalSessionState precedence", () => {
     ["waiting-input wins over stale silence", { runtimeState: "waiting-input", lastActivityAt: silentSince }, "needs_you", "Needs you"],
     ["waiting-input wins even when preview looks calm", { runtimeState: "waiting-input", lastOutputPreview: "compiling..." }, "needs_you", "Needs you"],
     ["pendingInputItemId wins on an ended session", { pendingInputItemId: "i-1", status: "detached", exitCode: 1 }, "needs_you", "Needs you"],
+    ["disposed session is stopped, not failed", { status: "disposed", runtimeState: "killed", exitCode: null }, "stopped", null],
+    ["user-stop signal is stopped, not failed", { status: "disposed", runtimeState: "killed", exitCode: 130 }, "stopped", null],
     ["non-zero exit is failed", { status: "detached", exitCode: 2 }, "failed", "Failed"],
     ["persisted failed status with null exit is failed (spawn failure)", { status: "failed", exitCode: null, runtimeState: "exited" }, "failed", "Failed"],
     ["killed runtime is failed", { status: "detached", runtimeState: "killed", exitCode: null }, "failed", "Failed"],
@@ -57,6 +59,10 @@ describe("canonicalSessionState precedence", () => {
 });
 
 describe("stale boundary", () => {
+  it("uses a three-hour silence threshold", () => {
+    expect(SESSION_STALE_AFTER_MS).toBe(3 * 60 * 60 * 1000);
+  });
+
   it("flips exactly at the threshold, not before", () => {
     const justUnder = new Date(NOW - SESSION_STALE_AFTER_MS + 1_000).toISOString();
     const exactly = new Date(NOW - SESSION_STALE_AFTER_MS).toISOString();

--- a/apps/desktop/src/shared/sessionCanonicalState.ts
+++ b/apps/desktop/src/shared/sessionCanonicalState.ts
@@ -11,7 +11,7 @@ import type { TerminalRuntimeState, TerminalSessionStatus, TerminalToolType } fr
  *   failed     ⇔ failed
  *   stale      ⇔ stale
  *   starting/running ⇔ starting/running
- *   ready/idle/ended have no LA row (terminal or chat-resting states).
+ *   ready/idle/stopped/ended have no LA row (terminal or chat-resting states).
  */
 export type CanonicalSessionPhase =
   | "starting"
@@ -19,6 +19,7 @@ export type CanonicalSessionPhase =
   | "needs_you"
   | "failed"
   | "stale"
+  | "stopped"
   | "ready"
   | "idle"
   | "ended";
@@ -43,7 +44,7 @@ export type CanonicalSessionState = {
  * (2h/24h delivery expiry) and the Live Activity stale-date (10min lock-screen
  * dimming): this is the human-facing "is anything actually happening" bar.
  */
-export const SESSION_STALE_AFTER_MS = 20 * 60 * 1000;
+export const SESSION_STALE_AFTER_MS = 3 * 60 * 60 * 1000;
 
 const BADGE_BY_KIND: Record<SessionBadgeKind, SessionBadge> = {
   needs_you: { kind: "needs_you", label: "Needs you" },
@@ -82,10 +83,11 @@ function isSilentPast(lastActivityAt: string | null | undefined, nowMs: number, 
  * Canonical precedence (highest first):
  *   1. deterministic needs-input — pendingInputItemId or runtimeState
  *      "waiting-input" (never outvoted by anything below),
- *   2. failed — non-zero exit / killed,
- *   3. stale — status running but silent ≥ SESSION_STALE_AFTER_MS,
- *   4. running (incl. the preview heuristic's needs_you upgrade, LAST),
- *   5. resting states — ready (idle chat), idle, ended.
+ *   2. stopped — user/system-disposed PTY,
+ *   3. failed — non-zero exit / killed,
+ *   4. stale — status running but silent ≥ SESSION_STALE_AFTER_MS,
+ *   5. running (incl. the preview heuristic's needs_you upgrade, LAST),
+ *   6. resting states — ready (idle chat), idle, ended.
  */
 export function canonicalSessionState(args: CanonicalSessionInputs): CanonicalSessionState {
   const nowMs = args.nowMs ?? Date.now();
@@ -99,7 +101,13 @@ export function canonicalSessionState(args: CanonicalSessionInputs): CanonicalSe
 
   const ended = args.status !== "running";
   if (ended) {
-    // 2. Failure: a non-clean exit, an explicit "failed" persisted status
+    // 2. Stopped: an explicitly disposed PTY is resumable/closed, not a task
+    // failure. Keep it badge-free and let the session row's red dot carry the
+    // ended state.
+    if (args.status === "disposed") {
+      return { phase: "stopped", badge: null };
+    }
+    // 3. Failure: a non-clean exit, an explicit "failed" persisted status
     // (spawn/setup failures that die before an exit code), or a killed
     // runtime — all deterministic "failed" signals a terminal-backed session
     // reports.
@@ -117,7 +125,7 @@ export function canonicalSessionState(args: CanonicalSessionInputs): CanonicalSe
     return { phase: "ended", badge: null };
   }
 
-  // 3. Stale: running but silent past the threshold.
+  // 4. Stale: running but silent past the threshold.
   if (isSilentPast(args.lastActivityAt, nowMs, SESSION_STALE_AFTER_MS)) {
     return { phase: "stale", badge: BADGE_BY_KIND.stale };
   }
@@ -129,7 +137,7 @@ export function canonicalSessionState(args: CanonicalSessionInputs): CanonicalSe
     return chat ? { phase: "ready", badge: null } : { phase: "idle", badge: null };
   }
 
-  // 4. Preview heuristic LAST: it may only upgrade running → needs_you.
+  // 5. Preview heuristic LAST: it may only upgrade running → needs_you.
   if (args.previewSuggestsNeedsInput?.(args.lastOutputPreview)) {
     return { phase: "needs_you", badge: BADGE_BY_KIND.needs_you };
   }

--- a/apps/ios/ADE/Views/Work/WorkSessionCanonicalState.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionCanonicalState.swift
@@ -11,7 +11,7 @@ import SwiftUI
 ///   failed     ⇔ failed
 ///   stale      ⇔ stale
 ///   starting/running ⇔ starting/running
-///   ready/idle/ended have no LA row (terminal or chat-resting states).
+///   ready/idle/stopped/ended have no LA row (terminal or chat-resting states).
 enum CanonicalSessionPhase: Equatable {
   case starting
   case running
@@ -20,6 +20,7 @@ enum CanonicalSessionPhase: Equatable {
   case stale
   case ready
   case idle
+  case stopped
   case ended
 }
 
@@ -46,9 +47,9 @@ struct CanonicalSessionState: Equatable {
 /// "stale" — running but silent. Distinct from the push relay's APNs TTLs and
 /// the Live Activity 10-minute lock-screen dimming: this is the human-facing
 /// "is anything actually happening" bar. Exactly mirrors the desktop
-/// `SESSION_STALE_AFTER_MS` (20 minutes); do not reuse other stale semantics
+/// `SESSION_STALE_AFTER_MS` (3 hours); do not reuse other stale semantics
 /// (e.g. the 7-day chat reclassification in `normalizedWorkChatSessionStatus`).
-let sessionStaleAfterSeconds: TimeInterval = 20 * 60
+let sessionStaleAfterSeconds: TimeInterval = 3 * 60 * 60
 
 private let badgeByKind: [SessionBadgeKind: SessionBadge] = [
   .needsYou: SessionBadge(kind: .needsYou, label: "Needs you"),
@@ -78,10 +79,11 @@ func isWorkChatToolType(_ toolType: String?) -> Bool {
 /// Canonical precedence (highest first), identical to the desktop module:
 ///   1. deterministic needs-input — a pending input item or a "waiting-input"
 ///      runtime (never outvoted by anything below),
-///   2. failed — non-zero exit / killed,
-///   3. stale — status running but silent ≥ `sessionStaleAfterSeconds`,
-///   4. running (incl. the preview heuristic's needs_you upgrade, consulted LAST),
-///   5. resting states — ready (idle chat), idle, ended.
+///   2. stopped — user/system-disposed PTY,
+///   3. failed — non-zero exit / killed,
+///   4. stale — status running but silent ≥ `sessionStaleAfterSeconds`,
+///   5. running (incl. the preview heuristic's needs_you upgrade, consulted LAST),
+///   6. resting states — ready (idle chat), idle, ended.
 func workCanonicalSessionState(
   status: String,
   runtimeState: String? = nil,
@@ -106,7 +108,14 @@ func workCanonicalSessionState(
 
   let ended = status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() != "running"
   if ended {
-    // 2. Failure: a non-clean exit, an explicit "failed" persisted status
+    // 2. Stopped: an explicitly disposed PTY is resumable/closed, not a task
+    // failure. Check before exit/runtime failures because disposed sessions are
+    // currently persisted with runtimeState "killed" and often exitCode 130.
+    if status.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "disposed" {
+      return CanonicalSessionState(phase: .stopped, badge: nil)
+    }
+
+    // 3. Failure: a non-clean exit, an explicit "failed" persisted status
     // (spawn/setup failures that die before an exit code), or a killed runtime
     // — all deterministic "failed" signals a terminal-backed session reports.
     if let exitCode, exitCode != 0 {
@@ -123,7 +132,7 @@ func workCanonicalSessionState(
     return CanonicalSessionState(phase: .ended, badge: nil)
   }
 
-  // 3. Stale: running but silent past the threshold.
+  // 4. Stale: running but silent past the threshold.
   if isSilentPast(lastActivityAt, now: now, thresholdSeconds: sessionStaleAfterSeconds) {
     return CanonicalSessionState(phase: .stale, badge: badgeByKind[.stale])
   }
@@ -136,7 +145,7 @@ func workCanonicalSessionState(
       : CanonicalSessionState(phase: .idle, badge: nil)
   }
 
-  // 4. Preview heuristic LAST: it may only upgrade running → needs_you.
+  // 5. Preview heuristic LAST: it may only upgrade running → needs_you.
   if previewSuggestsNeedsInput(lastOutputPreview) {
     return CanonicalSessionState(phase: .needsYou, badge: badgeByKind[.needsYou])
   }
@@ -239,7 +248,7 @@ func workSessionCapsuleBadge(
 /// back to `session.startedAt`), this returns nil when no real activity signal
 /// exists — the iOS `TerminalSessionSummary` carries no desktop-style
 /// `lastActivityAt`, so a plain terminal has no output timestamp. Falling back
-/// to `startedAt` would flag any terminal open >20min as Stale even with output
+/// to `startedAt` would flag any terminal open >3h as Stale even with output
 /// seconds ago; nil disables the check, mirroring the desktop caller which
 /// passes the real `lastActivityAt` or null (never `startedAt`).
 private func workSessionStaleActivityTimestamp(

--- a/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
+++ b/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 /// Table-driven coverage for the Work-tab canonical session vocabulary — the
 /// iOS mirror of desktop `sessionCanonicalState.ts`. Locks the precedence chain,
-/// the exact 20-minute stale boundary, and the no-badge-for-calm-states rule.
+/// the exact 3-hour stale boundary, and the no-badge-for-calm-states rule.
 final class WorkSessionCanonicalStateTests: XCTestCase {
   private let now = Date(timeIntervalSince1970: 1_780_000_000)
 
@@ -38,7 +38,7 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
         runtimeState: "running",
         toolType: "codex",
         pendingInputItemId: "item-1",
-        lastActivityAt: silentFor(30 * 60),
+        lastActivityAt: silentFor(sessionStaleAfterSeconds + 60),
         exitCode: nil
       ),
       Case(
@@ -47,7 +47,7 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
         runtimeState: "waiting-input",
         toolType: "codex",
         pendingInputItemId: nil,
-        lastActivityAt: silentFor(30 * 60),
+        lastActivityAt: silentFor(sessionStaleAfterSeconds + 60),
         exitCode: nil
       ),
       Case(
@@ -86,6 +86,16 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     }
   }
 
+  func testStoppedDisposedSessionsAreNotFailed() {
+    let disposed = workCanonicalSessionState(status: "disposed", runtimeState: "killed", toolType: "codex", exitCode: nil, now: now)
+    XCTAssertEqual(disposed.phase, .stopped)
+    XCTAssertNil(disposed.badge)
+
+    let userStop = workCanonicalSessionState(status: "disposed", runtimeState: "killed", toolType: "codex", exitCode: 130, now: now)
+    XCTAssertEqual(userStop.phase, .stopped)
+    XCTAssertNil(userStop.badge)
+  }
+
   func testFailedOnlyForEndedNonCleanExitOrKilled() {
     // Non-zero exit on an ended session → failed.
     let failedExit = workCanonicalSessionState(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 1, now: now)
@@ -108,8 +118,8 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     XCTAssertNil(runningWithCode.badge)
   }
 
-  func testStaleBoundaryIsExactlyTwentyMinutes() {
-    // Just under 20 minutes of silence → still running (no capsule).
+  func testStaleBoundaryIsExactlyThreeHours() {
+    // Just under 3 hours of silence → still running (no capsule).
     let justUnder = workCanonicalSessionState(
       status: "running",
       runtimeState: "running",
@@ -240,6 +250,12 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     let session = makeSession(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 130)
     let badge = workSessionCapsuleBadge(session: session, summary: nil, now: now)
     XCTAssertEqual(badge?.kind, .failed)
+  }
+
+  func testCapsuleBadgeNilForStoppedDisposedSession() {
+    let session = makeSession(status: "disposed", runtimeState: "killed", toolType: "codex", exitCode: 130)
+    let badge = workSessionCapsuleBadge(session: session, summary: nil, now: now)
+    XCTAssertNil(badge)
   }
 
   func testCapsuleBadgeNilForFreshRunning() {

--- a/docs/features/sync-and-multi-device/push-notifications.md
+++ b/docs/features/sync-and-multi-device/push-notifications.md
@@ -150,7 +150,7 @@ when all runs reach a terminal phase.
 from session inputs to a phase + attention badge, consumed by the Work tab
 (desktop and the iOS mirror). Its `needs_you` covers the Live Activity's
 `waiting_for_approval`/`waiting_for_input` (wire names unchanged);
-`failed`/`stale`/`running` correspond directly. Its 20-minute stale threshold
+`failed`/`stale`/`running` correspond directly. Its 3-hour stale threshold
 is the human-facing "running but silent" bar — distinct from the relay's APNs
 delivery TTLs and the Live Activity's 10-minute lock-screen stale-date.
 

--- a/docs/features/terminals-and-sessions/ui-surfaces.md
+++ b/docs/features/terminals-and-sessions/ui-surfaces.md
@@ -149,7 +149,9 @@ Three rows:
 
 1. **Status dot + title + relative time** — `sessionStatusDot()` and
    `primarySessionLabel()` drive these. The relative time comes from
-   `relativeTimeCompact`.
+   `relativeTimeCompact`. Disposed CLI rows render a small inline
+   "Stopped" label immediately before the red status dot rather than an
+   attention capsule.
 2. **Preview line** (conditional) — when the card's lane is mid
    background AI auto-naming (`useLaneNaming(lane.id)` from
    `renderer/state/laneNamingStore.ts` is true), this row instead shows an
@@ -741,7 +743,8 @@ nothing when no delta is available.
   `preferredSessionLabel`, `shortToolTypeLabel`, `isChatToolType`,
   `isRunOwnedSession`, `buildOptimisticChatSessionSummary`.
 - `apps/desktop/src/renderer/lib/terminalAttention.ts` —
-  `sessionStatusDot`, `sessionIndicatorState`, `sanitizeTerminalInlineText`.
+  `sessionStatusDot`, `sessionIndicatorState`, `sessionCapsuleBadge`,
+  `sessionInlineStatusLabel`, `sanitizeTerminalInlineText`.
 - `apps/desktop/src/renderer/lib/sessionListCache.ts` —
   `listSessionsCached`, `invalidateSessionListCache`.
 - `apps/desktop/src/renderer/lib/chatSessionEvents.ts` —


### PR DESCRIPTION
## Summary
- change the Work session stale badge threshold from 20 minutes to 3 hours
- add a canonical stopped phase for disposed CLI sessions so they no longer show as Failed
- show inline Stopped text next to the red status dot and keep iOS/docs parity in sync

## Verification
- npm --prefix apps/desktop run test -- sessionCanonicalState.test.ts terminalAttention.test.ts SessionCard.test.tsx
- npm --prefix apps/desktop run typecheck
- cd apps/desktop && npx vitest related --run src/shared/sessionCanonicalState.ts src/renderer/lib/terminalAttention.ts src/renderer/components/terminals/SessionCard.tsx
- cd apps/desktop && npx vitest run --changed --passWithNoTests
- xcodebuild test -project apps/ios/ADE.xcodeproj -scheme ADE -destination id=2107A402-C2A7-4323-AF26-74A0AC406C44 -only-testing:ADETests/WorkSessionCanonicalStateTests

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fdiscuss-when-why-stale-chip-1a579aac num=747 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fdiscuss-when-why-stale-chip-1a579aac&amp;pr=747">ade/discuss-when-why-stale-chip-1a579aac branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=747">PR #747</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refines how Work sessions report stale and stopped states. The main changes are:

- Raises the Work session stale badge threshold to 3 hours.
- Adds a canonical `stopped` phase for disposed sessions.
- Shows inline `Stopped` text on desktop session cards.
- Mirrors the canonical-state changes in iOS tests and docs.

<h3>Confidence Score: 4/5</h3>

The stopped-state paths need fixes before merging.

Non-running chat sessions can show an amber ready dot beside stopped or failed text, and disposed sessions can be canonical stopped locally while the Live Activity exit path still reports failed.

apps/desktop/src/renderer/lib/terminalAttention.ts; apps/desktop/src/shared/sessionCanonicalState.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the reproduction path for chat status branches and noted that sessionIndicatorState() returns running-needs-attention for chat tool types before sessionStatusDot() reaches disposed or failed status branches.
- Created a focused Vitest repro harness for stopped PTY push mapping that imports the canonical state function and the push publisher service.
- Attempted to run the repro harness, but the command timed out in the sandbox before running executable tests.
- Executed the desktop session state targeted tests; the log shows all 53 targeted tests passed.
- Noted a resource blocker during typechecking with increased memory limits, as the typecheck process was killed (exit code 137) rather than indicating a changed session-state behavior.

<a href="https://app.greptile.com/trex/runs/13786282/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/shared/sessionCanonicalState.ts | Adds the `stopped` phase, moves disposed sessions ahead of failure classification, and increases stale detection to 3 hours. |
| apps/desktop/src/renderer/lib/terminalAttention.ts | Adds shared canonical UI state helpers and new stopped/failed dot labels. |
| apps/desktop/src/renderer/components/terminals/SessionCard.tsx | Reuses one session-attention input object and renders inline stopped text next to the status dot. |
| apps/ios/ADE/Views/Work/WorkSessionCanonicalState.swift | Mirrors the desktop stopped phase and 3-hour stale threshold. |
| docs/features/sync-and-multi-device/push-notifications.md | Updates the documented canonical stale threshold to 3 hours. |
| docs/features/terminals-and-sessions/ui-surfaces.md | Documents the new inline stopped label and helper exports. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fdesktop%2Fsrc%2Frenderer%2Flib%2FterminalAttention.ts%3A245-250%0A**Chat%20Status%20Branches%20Are%20Bypassed**%0A%0AFor%20a%20non-running%20chat%20session%20with%20%60status%3A%20%22disposed%22%60%20or%20%60status%3A%20%22failed%22%60%2C%20%60sessionIndicatorState%28%29%60%20returns%20%60%22running-needs-attention%22%60%20before%20these%20new%20branches%20run.%20The%20card%20can%20then%20show%20an%20amber%20%60Ready%60%20dot%20next%20to%20%60Stopped%60%20inline%20text%20or%20a%20%60Failed%60%20capsule%2C%20so%20the%20same%20row%20reports%20two%20different%20states.%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fdesktop%2Fsrc%2Fshared%2FsessionCanonicalState.ts%3A107-109%0A**Stopped%20Phase%20Skips%20Push%20Mapping**%0A%0AThis%20branch%20makes%20disposed%20sessions%20with%20%60exitCode%3A%20130%60%20or%20%60runtimeState%3A%20%22killed%22%60%20canonical%20%60stopped%60%2C%20but%20the%20Live%20Activity%20publisher%20still%20derives%20terminal%20exits%20from%20the%20exit%20code%20and%20has%20no%20%60stopped%60%20phase.%20A%20user-stopped%20PTY%20can%20show%20no%20failed%20badge%20in%20the%20Work%20tab%20while%20the%20Live%20Activity%20path%20continues%20to%20publish%20it%20as%20failed.%0A%0A&repo=arul28%2Fade&pr=747&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
apps/desktop/src/renderer/lib/terminalAttention.ts:245-250
**Chat Status Branches Are Bypassed**

For a non-running chat session with `status: "disposed"` or `status: "failed"`, `sessionIndicatorState()` returns `"running-needs-attention"` before these new branches run. The card can then show an amber `Ready` dot next to `Stopped` inline text or a `Failed` capsule, so the same row reports two different states.

### Issue 2 of 2
apps/desktop/src/shared/sessionCanonicalState.ts:107-109
**Stopped Phase Skips Push Mapping**

This branch makes disposed sessions with `exitCode: 130` or `runtimeState: "killed"` canonical `stopped`, but the Live Activity publisher still derives terminal exits from the exit code and has no `stopped` phase. A user-stopped PTY can show no failed badge in the Work tab while the Live Activity path continues to publish it as failed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Refine session stale and stopped states"](https://github.com/arul28/ade/commit/05795a4f6b981d8543d2a24829b0aa5235a32d62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42907083)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->