### PR TITLE
Mobile Model Picker

### DIFF
--- a/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
+++ b/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
@@ -182,11 +182,9 @@ struct HubInlineComposer: View {
     return LaneColorPalette.displayColor(forHex: lane.color)
   }
 
-  /// Fast mode only applies to in-app chat sessions on fast-tier models — the
-  /// CLI launcher has no fast-mode parameter — so the lightning toggle (and the
-  /// value we send) is gated on both. The live picker option can only *add*
-  /// support; the catalog/allow-list fallback still shows the toggle for a
-  /// known-fast model whose option ships empty `serviceTiers`.
+  /// Fast mode only applies to in-app chat sessions on fast-tier models. The
+  /// picker owns the control, but launch still gates the submitted value on the
+  /// resolved session interface and model support.
   private var fastModeSupported: Bool {
     guard sessionMode == .chat else { return false }
     if let option = selectedModelOption,
@@ -325,17 +323,18 @@ struct HubInlineComposer: View {
         currentModelId: modelId,
         currentProvider: provider,
         currentReasoningEffort: reasoningEffort,
+        currentCodexFastMode: codexFastMode,
         cursorAvailabilityMode: sessionMode == .cli ? .cli : .chat,
         isBusy: false,
-        onSelect: { option, pickedReasoning, runtimeProvider in
+        onSelect: { option, pickedReasoning, runtimeProvider, pickedFastMode in
           selectedModelOption = option
           modelId = option.id
           provider = sessionMode == .chat
             ? hubNormalizedChatProvider(runtimeProvider)
             : workResolveCliProvider(for: option.id, provider: runtimeProvider)
           reasoningEffort = pickedReasoning ?? ""
+          codexFastMode = option.supportsCodexFastMode ? pickedFastMode : false
           runtimeMode = workDefaultRuntimeMode(provider: provider)
-          modelPickerPresented = false
         }
       )
       .environmentObject(syncService)
@@ -674,12 +673,9 @@ struct HubInlineComposer: View {
                 modeOptions: workRuntimeModeOptions(provider: provider),
                 modeLabel: workRuntimeModeLabel(provider: provider, mode: runtimeMode),
                 isCollapsed: isControlsCollapsed,
-                fastModeSupported: fastModeSupported,
                 fastModeEnabled: codexFastMode,
-                settingsMutationInFlight: busy,
                 onOpenModelPicker: { modelPickerPresented = true },
-                onSelectMode: { runtimeMode = $0 },
-                onToggleFastMode: { codexFastMode = $0 }
+                onSelectMode: { runtimeMode = $0 }
               )
               .padding(.trailing, 4)
             }

--- a/apps/ios/ADE/Views/Linear/LinearLaunchScreen.swift
+++ b/apps/ios/ADE/Views/Linear/LinearLaunchScreen.swift
@@ -103,9 +103,10 @@ struct LinearLaunchScreen: View {
         currentModelId: modelId,
         currentProvider: provider,
         currentReasoningEffort: reasoningEffort,
+        currentCodexFastMode: codexFastMode,
         cursorAvailabilityMode: sessionType == .cli ? .cli : .chat,
         isBusy: false,
-        onSelect: { option, pickedReasoning, runtimeProvider in
+        onSelect: { option, pickedReasoning, runtimeProvider, pickedFastMode in
           selectedModelOption = option
           modelId = option.id
           modelName = option.displayName
@@ -114,10 +115,7 @@ struct LinearLaunchScreen: View {
             : runtimeProvider
           reasoningEffort = pickedReasoning ?? ""
           runtimeMode = workDefaultRuntimeMode(provider: provider)
-          if !fastModeSupported {
-            codexFastMode = false
-          }
-          modelPickerPresented = false
+          codexFastMode = option.supportsCodexFastMode ? pickedFastMode : false
         }
       )
     }
@@ -188,15 +186,6 @@ struct LinearLaunchScreen: View {
         }
       } label: {
         LinearConfigRow(label: "Permissions", value: workRuntimeModeLabel(provider: provider, mode: runtimeMode))
-      }
-
-      if fastModeSupported {
-        Divider().overlay(ADEColor.glassBorder.opacity(0.5))
-        Toggle(isOn: $codexFastMode) {
-          Text("Fast mode").font(.subheadline).foregroundStyle(ADEColor.textPrimary)
-        }
-        .tint(LinearBrand.primary)
-        .padding(.vertical, 4)
       }
     }
     .padding(.horizontal, 14)

--- a/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
@@ -107,8 +107,8 @@ func workChatComposerSupportsFastMode(_ summary: AgentChatSessionSummary) -> Boo
 }
 
 /// Whether a model (by raw id + provider family) can use the "fast" service
-/// tier. Shared by the in-session and new-chat composers so both surfaces show
-/// the fast-mode lightning toggle for the same models.
+/// tier. Shared by the in-session and new-chat composers so launch payloads
+/// agree with the model picker.
 func workComposerSupportsFastMode(modelId: String, provider: String) -> Bool {
   workComposerFastModeSupported(
     modelId: modelId,
@@ -248,13 +248,13 @@ struct WorkComposerInputBanner: View {
 /// in-session and new-chat composers collapse at the same point.
 let workComposerControlsCollapseThreshold: CGFloat = 360
 
-/// The composer's access/model/fast-mode controls, shared verbatim by the
+/// The composer's access/model controls, shared verbatim by the
 /// in-session composer (`WorkComposerChipStrip`) and the new-chat composer
 /// (`WorkNewChatComposerBar`) so the two surfaces stay visually and
 /// behaviorally identical: a permission/access control (single tone-dot Menu
-/// when space is tight, segmented chips when wide), a model pill, and a
-/// fast-mode lightning toggle. The caller owns width measurement and passes
-/// `isCollapsed` so the GeometryReader can sit on the scroll viewport.
+/// when space is tight, segmented chips when wide) and a model pill. The caller
+/// owns width measurement and passes `isCollapsed` so the GeometryReader can sit
+/// on the scroll viewport.
 struct WorkComposerControlsRow: View {
   let provider: String
   let modelDisplayName: String
@@ -263,18 +263,14 @@ struct WorkComposerControlsRow: View {
   let modeOptions: [WorkRuntimeModeOption]
   let modeLabel: String
   let isCollapsed: Bool
-  let fastModeSupported: Bool
   let fastModeEnabled: Bool
-  let settingsMutationInFlight: Bool
   let onOpenModelPicker: (() -> Void)?
   let onSelectMode: ((String) -> Void)?
-  let onToggleFastMode: ((Bool) -> Void)?
 
   var body: some View {
     HStack(spacing: 8) {
       accessControl
       modelPill
-      fastModeToggle
     }
   }
 
@@ -447,6 +443,11 @@ struct WorkComposerControlsRow: View {
             .foregroundStyle(ADEColor.textMuted)
             .lineLimit(1)
         }
+        if fastModeEnabled {
+          Image(systemName: "bolt.fill")
+            .font(.system(size: 10, weight: .bold))
+            .foregroundStyle(ADEColor.warning)
+        }
         Image(systemName: "chevron.down")
           .font(.system(size: 9, weight: .bold))
           .foregroundStyle(ADEColor.textMuted)
@@ -463,38 +464,10 @@ struct WorkComposerControlsRow: View {
     .disabled(onOpenModelPicker == nil)
     .accessibilityLabel("Model: \(modelDisplayName)\(reasoning.isEmpty ? "" : ", reasoning \(reasoning)"). Tap to switch.")
   }
-
-  @ViewBuilder
-  private var fastModeToggle: some View {
-    if fastModeSupported {
-      Button {
-        onToggleFastMode?(!fastModeEnabled)
-      } label: {
-        Image(systemName: "bolt.fill")
-          .font(.system(size: 11, weight: .bold))
-          .foregroundStyle(fastModeEnabled ? ADEColor.warning : ADEColor.textMuted)
-          .frame(width: 28, height: 28)
-          .background(
-            Capsule(style: .continuous)
-              .fill(ADEColor.surfaceBackground.opacity(fastModeEnabled ? 0.56 : 0.34))
-          )
-          .overlay(
-            Capsule(style: .continuous)
-              .stroke(fastModeEnabled ? ADEColor.warning.opacity(0.38) : ADEColor.border.opacity(0.22), lineWidth: 0.5)
-          )
-      }
-      .buttonStyle(.plain)
-      .disabled(onToggleFastMode == nil || settingsMutationInFlight)
-      .contentShape(Rectangle())
-      .accessibilityLabel("Fast mode \(fastModeEnabled ? "on" : "off"). Tap to turn \(fastModeEnabled ? "off" : "on").")
-      .accessibilityValue(settingsMutationInFlight ? "\(fastModeEnabled ? "On" : "Off"), saving" : (fastModeEnabled ? "On" : "Off"))
-      .accessibilityIdentifier("Work.Chat.Composer.FastModeToggle")
-    }
-  }
 }
 
 /// Compact horizontal strip matching the desktop composer toolbar: small
-/// single-line pills for access, model, fast mode, pending status chips,
+/// single-line pills for access, model, pending status chips,
 /// and nothing else. Reasoning is summarized in the model chip and changed
 /// through the full model picker.
 struct WorkComposerChipStrip: View {
@@ -503,7 +476,6 @@ struct WorkComposerChipStrip: View {
   let codexFastModeOverride: Bool?
   let onOpenModelPicker: (() -> Void)?
   let onSelectRuntimeMode: ((String) -> Void)?
-  let onToggleCodexFastMode: ((Bool) -> Void)?
 
   /// Width below which the access control collapses from the full segmented
   /// chip row to a single dot-only Menu button — mirroring the desktop
@@ -532,12 +504,9 @@ struct WorkComposerChipStrip: View {
             modeOptions: workRuntimeModeOptions(provider: chatSummary.provider),
             modeLabel: workRuntimeModeLabel(provider: chatSummary.provider, mode: currentMode),
             isCollapsed: isCollapsed,
-            fastModeSupported: chatSummary.fastModeSupported,
             fastModeEnabled: codexFastModeOverride ?? chatSummary.effectiveFastMode,
-            settingsMutationInFlight: settingsMutationInFlight,
             onOpenModelPicker: onOpenModelPicker,
-            onSelectMode: onSelectRuntimeMode,
-            onToggleFastMode: onToggleCodexFastMode
+            onSelectMode: onSelectRuntimeMode
           )
         }
       }
@@ -1444,9 +1413,6 @@ struct WorkModelSelectionPendingCard: View {
     VStack(alignment: .leading, spacing: 12) {
       header
       selectedModelSummary
-      if shouldShowFastModeToggle {
-        fastModeToggle
-      }
       footer
     }
     .adeGlassCard(cornerRadius: 18, padding: 14)
@@ -1455,17 +1421,15 @@ struct WorkModelSelectionPendingCard: View {
         currentModelId: selectedModelId,
         currentProvider: selectedProvider,
         currentReasoningEffort: selectedReasoningEffort,
+        currentCodexFastMode: selectedCodexFastMode,
         availableModelIds: request.availableModelIds,
         isBusy: busy,
-        onSelect: { option, pickedReasoning, provider in
+        onSelect: { option, pickedReasoning, provider, pickedFastMode in
           selectedModel = option
           selectedModelId = option.id
           selectedProvider = provider
           selectedReasoningEffort = pickedReasoning ?? ""
-          if !option.supportsCodexFastMode {
-            selectedCodexFastMode = false
-          }
-          pickerPresented = false
+          selectedCodexFastMode = option.supportsCodexFastMode ? pickedFastMode : false
         }
       )
       .environmentObject(syncService)
@@ -1540,6 +1504,14 @@ struct WorkModelSelectionPendingCard: View {
             Text("·")
             Text(selectedReasoningEffort.capitalized)
           }
+          if selectedCodexFastMode {
+            Text("·")
+            Image(systemName: "bolt.fill")
+              .font(.caption2.weight(.bold))
+              .foregroundStyle(ADEColor.warning)
+              .accessibilityLabel("Fast mode on")
+            Text("Fast")
+          }
         }
         .font(.caption.monospaced())
         .foregroundStyle(ADEColor.textSecondary)
@@ -1563,22 +1535,6 @@ struct WorkModelSelectionPendingCard: View {
       RoundedRectangle(cornerRadius: 14, style: .continuous)
         .stroke(ADEColor.glassBorder, lineWidth: 0.5)
     )
-  }
-
-  @ViewBuilder
-  private var fastModeToggle: some View {
-    Toggle(isOn: $selectedCodexFastMode) {
-      VStack(alignment: .leading, spacing: 2) {
-        Text("Fast mode")
-          .font(.subheadline.weight(.semibold))
-          .foregroundStyle(ADEColor.textPrimary)
-        Text("Use the fast service tier for this worker.")
-          .font(.caption)
-          .foregroundStyle(ADEColor.textSecondary)
-      }
-    }
-    .tint(ADEColor.accent)
-    .disabled(busy)
   }
 
   @ViewBuilder
@@ -1614,10 +1570,6 @@ struct WorkModelSelectionPendingCard: View {
       return known
     }
     return selectedModelId.isEmpty ? "No model selected" : selectedModelId
-  }
-
-  private var shouldShowFastModeToggle: Bool {
-    selectedCodexFastMode || selectedModel?.supportsCodexFastMode == true
   }
 
   @MainActor

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -742,14 +742,6 @@ struct WorkChatSessionView: View {
             await onSelectRuntimeMode(mode)
           }
         },
-        onToggleCodexFastMode: !chatSummaryContext.isAvailable ? nil : { enabled in
-          pendingCodexFastMode = enabled
-          runComposerSettingMutation(onFailure: {
-            pendingCodexFastMode = nil
-          }) {
-            await onSelectCodexFastMode(enabled)
-          }
-        },
         onSend: onSend,
         onSent: {
           scrollToLatest(proxy, animated: true)
@@ -1034,8 +1026,9 @@ struct WorkChatSessionView: View {
             currentModelId: currentModelId,
             currentProvider: chatSummaryContext.provider,
             currentReasoningEffort: chatSummaryContext.reasoningEffort,
+            currentCodexFastMode: chatSummaryContext.effectiveFastMode,
             isBusy: modelUpdateInFlight,
-            onSelect: { option, pickedReasoning, _ in
+            onSelect: { option, pickedReasoning, _, pickedFastMode in
               Task { @MainActor in
                 modelUpdateInFlight = true
                 defer { modelUpdateInFlight = false }
@@ -1050,7 +1043,9 @@ struct WorkChatSessionView: View {
                   await onSelectEffort(nextReasoning)
                 }
                 guard !Task.isCancelled else { return }
-                modelPickerPresented = false
+                if option.supportsCodexFastMode || chatSummaryContext.effectiveFastMode != pickedFastMode {
+                  _ = await onSelectCodexFastMode(option.supportsCodexFastMode ? pickedFastMode : false)
+                }
               }
             }
           )
@@ -1636,7 +1631,6 @@ private struct WorkChatComposerCard: View {
   let onInterrupt: @MainActor () async -> Void
   let onOpenModelPicker: (() -> Void)?
   let onSelectRuntimeMode: ((String) -> Void)?
-  let onToggleCodexFastMode: ((Bool) -> Void)?
   let onSend: @MainActor (String, [WorkChatInputAttachment]) async -> Bool
   let onSent: () -> Void
 
@@ -1659,7 +1653,6 @@ private struct WorkChatComposerCard: View {
       onInterrupt: onInterrupt,
       onOpenModelPicker: onOpenModelPicker,
       onSelectRuntimeMode: onSelectRuntimeMode,
-      onToggleCodexFastMode: onToggleCodexFastMode,
       onSend: onSend,
       onSent: onSent
     )
@@ -1696,7 +1689,6 @@ private struct WorkChatComposerDraftInput: View {
   let onInterrupt: @MainActor () async -> Void
   let onOpenModelPicker: (() -> Void)?
   let onSelectRuntimeMode: ((String) -> Void)?
-  let onToggleCodexFastMode: ((Bool) -> Void)?
   let onSend: @MainActor (String, [WorkChatInputAttachment]) async -> Bool
   let onSent: () -> Void
 
@@ -1751,8 +1743,7 @@ private struct WorkChatComposerDraftInput: View {
             settingsMutationInFlight: settingsMutationInFlight,
             codexFastModeOverride: codexFastModeOverride,
             onOpenModelPicker: onOpenModelPicker,
-            onSelectRuntimeMode: onSelectRuntimeMode,
-            onToggleCodexFastMode: onToggleCodexFastMode
+            onSelectRuntimeMode: onSelectRuntimeMode
           )
 
           DictationRawUndoChip(coordinator: dictationCoordinator, draft: $draftState.text)

--- a/apps/ios/ADE/Views/Work/WorkModelPickerSheet.swift
+++ b/apps/ios/ADE/Views/Work/WorkModelPickerSheet.swift
@@ -17,45 +17,54 @@ struct WorkModelPickerSheet: View {
   let currentModelId: String
   let currentProvider: String
   let currentReasoningEffort: String
+  let currentCodexFastMode: Bool
   let availableModelIds: [String]?
   let cursorAvailabilityMode: WorkCursorAvailabilityMode
   let isBusy: Bool
-  let onSelect: (WorkModelOption, String?, String) -> Void
+  let onSelect: (WorkModelOption, String?, String, Bool) -> Void
 
   init(
     currentModelId: String,
     currentProvider: String,
     currentReasoningEffort: String = "",
+    currentCodexFastMode: Bool = false,
     availableModelIds: [String]? = nil,
     cursorAvailabilityMode: WorkCursorAvailabilityMode = .chat,
     isBusy: Bool,
-    onSelect: @escaping (WorkModelOption, String?, String) -> Void
+    onSelect: @escaping (WorkModelOption, String?, String, Bool) -> Void
   ) {
     self.currentModelId = currentModelId
     self.currentProvider = currentProvider
     self.currentReasoningEffort = currentReasoningEffort
+    self.currentCodexFastMode = currentCodexFastMode
     self.availableModelIds = availableModelIds
     self.cursorAvailabilityMode = cursorAvailabilityMode
     self.isBusy = isBusy
     self.onSelect = onSelect
+    _selectedModelId = State(initialValue: currentModelId)
+    _selectedRuntimeProvider = State(initialValue: currentProvider)
+    _selectedReasoningEffort = State(initialValue: currentReasoningEffort)
+    _selectedCodexFastMode = State(initialValue: currentCodexFastMode)
   }
 
   @StateObject private var picker = ModelPickerStore()
   @State private var selection: ModelPickerRailSelection = .favorites
-	  @State private var searchText: String = ""
-	  @State private var liveCatalog: [WorkModelCatalogGroup]?
-	  @State private var isLoadingCatalog = false
-	  @State private var didPickInitialSelection = false
-	  @State private var selectedProviderTabKey: String?
-	  /// Model card awaiting a reasoning tier before the picker commits.
-	  @State private var pendingModelId: String?
+  @State private var searchText: String = ""
+  @State private var liveCatalog: [WorkModelCatalogGroup]?
+  @State private var isLoadingCatalog = false
+  @State private var didPickInitialSelection = false
+  @State private var selectedProviderTabKey: String?
+  @State private var selectedModelId: String
+  @State private var selectedRuntimeProvider: String
+  @State private var selectedReasoningEffort: String
+  @State private var selectedCodexFastMode: Bool
 
-	  private var catalog: [WorkModelCatalogGroup] {
-	    if let liveCatalog {
-	      return scopedCatalog(liveCatalog)
-	    }
-	    return []
-	  }
+  private var catalog: [WorkModelCatalogGroup] {
+    if let liveCatalog {
+      return scopedCatalog(liveCatalog)
+    }
+    return []
+  }
 
   private var flattenedModels: [WorkModelOption] {
     var seen = Set<String>()
@@ -107,10 +116,7 @@ struct WorkModelPickerSheet: View {
   var body: some View {
     NavigationStack {
       VStack(spacing: 0) {
-        if pendingModelId != nil {
-          pendingReasoningBanner
-        }
-        searchBar
+        topControlBar
         if isLoadingCatalog && catalog.isEmpty {
           loadingState
         } else if catalog.isEmpty {
@@ -118,69 +124,59 @@ struct WorkModelPickerSheet: View {
         } else {
           Divider().overlay(ADEColor.glassBorder)
           HStack(spacing: 0) {
-	            ModelPickerRail(
+            ModelPickerRail(
               entries: railEntries,
               selected: effectiveSelection,
               favoritesCount: picker.favorites.count,
               recentsCount: picker.recents.count,
-	              onSelect: { next in
-	                selection = next
-	                selectedProviderTabKey = nil
-	                pendingModelId = nil
-	                if case .providerGroup(let key, _) = next {
-	                  Task { await refreshCatalog(for: key) }
-	                }
-	              }
-	            )
+              onSelect: { next in
+                selection = next
+                selectedProviderTabKey = nil
+                if case .providerGroup(let key, _) = next {
+                  Task { await refreshCatalog(for: key) }
+                }
+              }
+            )
             Divider().overlay(ADEColor.glassBorder)
             ModelPickerContentPane(
               selection: effectiveSelection,
               isSearching: isSearching,
               searchText: searchText,
               models: visibleModels,
-	              groupedRows: groupedRows,
-	              providerTabs: providerTabs,
-	              selectedProviderTabKey: selectedProviderTabKey,
-	              currentModelId: currentModelId,
-              currentReasoningEffort: currentReasoningEffort,
-              pendingModelId: pendingModelId,
+              groupedRows: groupedRows,
+              providerTabs: providerTabs,
+              selectedProviderTabKey: selectedProviderTabKey,
+              selectedModelId: selectedModelId,
+              selectedReasoningEffort: selectedReasoningEffort,
+              selectedCodexFastMode: selectedCodexFastMode,
               favorites: picker.favorites,
               isBusy: isBusy,
-	              onHighlight: { model in pendingModelId = model.id },
-	              onSelect: { model, effort in commit(model: model, effort: effort) },
-	              onSelectProviderTab: { selectedProviderTabKey = $0 },
+              onSelect: { model in select(model: model) },
+              onSelectReasoning: { model, effort in select(reasoningEffort: effort, for: model) },
+              onToggleFastMode: { model, enabled in select(fastMode: enabled, for: model) },
+              onSelectProviderTab: { selectedProviderTabKey = $0 },
               onToggleFavorite: { picker.toggleFavorite($0, syncService: syncService) }
             )
           }
+          Divider().overlay(ADEColor.glassBorder)
+          currentModelBar
         }
       }
       .adeScreenBackground()
-      .navigationTitle("Select Model")
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .topBarTrailing) {
-          Button {
-            dismiss()
-          } label: {
-            Image(systemName: "xmark")
-              .font(.subheadline.weight(.semibold))
-          }
-          .accessibilityLabel("Close")
-        }
-      }
+      .toolbar(.hidden, for: .navigationBar)
     }
     .presentationDetents([.large])
     .presentationDragIndicator(.visible)
     .onAppear {
       picker.load(syncService: syncService)
     }
-	    .task(id: "\(currentModelId)\u{0}\(currentProvider)") {
-	      await loadLiveCatalog()
-	      pickInitialSelectionIfNeeded()
-	      if case .providerGroup(let key, _) = selection {
-	        await refreshCatalog(for: key)
-	      }
-	    }
+    .task(id: "\(currentModelId)\u{0}\(currentProvider)") {
+      await loadLiveCatalog()
+      pickInitialSelectionIfNeeded()
+      if case .providerGroup(let key, _) = selection {
+        await refreshCatalog(for: key)
+      }
+    }
   }
 
   /// Falls back to the first available provider entry only when the user's
@@ -256,10 +252,10 @@ struct WorkModelPickerSheet: View {
       case .recents:
         let lookup = modelById
         pool = picker.recents.compactMap { lookup[$0] }
-	      case .providerGroup(let key, _):
-	        let group = catalog.first(where: { $0.key == key })
-	        let providers = filteredProviders(for: group)
-	        pool = providers.flatMap { $0.models }
+      case .providerGroup(let key, _):
+        let group = catalog.first(where: { $0.key == key })
+        let providers = filteredProviders(for: group)
+        pool = providers.flatMap { $0.models }
       }
     }
 
@@ -287,23 +283,23 @@ struct WorkModelPickerSheet: View {
     }
   }
 
-	  private var providerTabs: [WorkModelProvider] {
-	    guard !isSearching else { return [] }
-	    guard case .providerGroup(let key, _) = effectiveSelection else { return [] }
-	    return catalog.first(where: { $0.key == key })?.providers.filter { !$0.models.isEmpty } ?? []
-	  }
+  private var providerTabs: [WorkModelProvider] {
+    guard !isSearching else { return [] }
+    guard case .providerGroup(let key, _) = effectiveSelection else { return [] }
+    return catalog.first(where: { $0.key == key })?.providers.filter { !$0.models.isEmpty } ?? []
+  }
 
-	  private func filteredProviders(for group: WorkModelCatalogGroup?) -> [WorkModelProvider] {
-	    guard let group else { return [] }
-	    let providers = group.providers.filter { !$0.models.isEmpty }
-	    guard providers.count > 1 else { return providers }
-	    let activeKey = selectedProviderTabKey
-	      ?? providers.first(where: { provider in provider.models.contains(where: { workModelIdsEquivalent($0.id, currentModelId) }) })?.key
-	      ?? providers.first(where: { provider in provider.models.contains(where: { $0.isAvailable }) })?.key
-	      ?? providers.first?.key
-	    guard let activeKey else { return providers }
-	    return providers.filter { $0.key == activeKey }
-	  }
+  private func filteredProviders(for group: WorkModelCatalogGroup?) -> [WorkModelProvider] {
+    guard let group else { return [] }
+    let providers = group.providers.filter { !$0.models.isEmpty }
+    guard providers.count > 1 else { return providers }
+    let activeKey = selectedProviderTabKey
+      ?? providers.first(where: { provider in provider.models.contains(where: { workModelIdsEquivalent($0.id, selectedModelId) }) })?.key
+      ?? providers.first(where: { provider in provider.models.contains(where: { $0.isAvailable }) })?.key
+      ?? providers.first?.key
+    guard let activeKey else { return providers }
+    return providers.filter { $0.key == activeKey }
+  }
 
   private func catalogGroupContaining(modelId: String) -> String? {
     for group in catalog {
@@ -338,66 +334,67 @@ struct WorkModelPickerSheet: View {
   // MARK: Subviews
 
   @ViewBuilder
-  private var pendingReasoningBanner: some View {
-    HStack(spacing: 8) {
-      Image(systemName: "brain.head.profile")
-        .font(.subheadline.weight(.semibold))
-        .foregroundStyle(ADEColor.accent)
-      Text("Pick reasoning level")
-        .font(.subheadline.weight(.semibold))
-        .foregroundStyle(ADEColor.textPrimary)
-      Spacer(minLength: 0)
-      if let pendingModelId, let model = modelById[pendingModelId] {
-        Text(model.displayName)
-          .font(.caption.weight(.semibold))
-          .foregroundStyle(ADEColor.textSecondary)
-          .lineLimit(1)
+  private var topControlBar: some View {
+    HStack(spacing: 10) {
+      HStack(spacing: 8) {
+        Image(systemName: "magnifyingglass")
+          .font(.subheadline)
+          .foregroundStyle(ADEColor.textMuted)
+        TextField("Search models…", text: $searchText)
+          .textFieldStyle(.plain)
+          .font(.subheadline)
+          .foregroundStyle(ADEColor.textPrimary)
+          .autocorrectionDisabled()
+          .textInputAutocapitalization(.never)
+        if !searchText.isEmpty {
+          Button {
+            searchText = ""
+          } label: {
+            Image(systemName: "xmark.circle.fill")
+              .font(.subheadline)
+              .foregroundStyle(ADEColor.textMuted)
+          }
+          .buttonStyle(.plain)
+          .accessibilityLabel("Clear search")
+        }
       }
+      .padding(.horizontal, 12)
+      .padding(.vertical, 8)
+      .background(ADEColor.recessedBackground.opacity(0.55), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+      .overlay(
+        RoundedRectangle(cornerRadius: 10, style: .continuous)
+          .stroke(ADEColor.glassBorder, lineWidth: 0.5)
+      )
+
+      Button {
+        dismiss()
+      } label: {
+        Image(systemName: "xmark")
+          .font(.subheadline.weight(.bold))
+          .foregroundStyle(ADEColor.textPrimary)
+          .frame(width: 38, height: 38)
+          .background(ADEColor.surfaceBackground.opacity(0.62), in: Circle())
+          .overlay(Circle().stroke(ADEColor.glassBorder, lineWidth: 0.75))
+      }
+      .buttonStyle(.plain)
+      .accessibilityLabel("Close")
     }
     .padding(.horizontal, 14)
-    .padding(.top, 10)
-    .padding(.bottom, 4)
+    .padding(.top, 12)
+    .padding(.bottom, 8)
   }
 
   @ViewBuilder
-  private var searchBar: some View {
-    HStack(spacing: 8) {
-      Image(systemName: "magnifyingglass")
-        .font(.subheadline)
-        .foregroundStyle(ADEColor.textMuted)
-      TextField("Search models…", text: $searchText)
-        .textFieldStyle(.plain)
-        .font(.subheadline)
-        .foregroundStyle(ADEColor.textPrimary)
-        .autocorrectionDisabled()
-        .textInputAutocapitalization(.never)
-        .onChange(of: searchText) { _, newValue in
-          if !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            pendingModelId = nil
-          }
-        }
-      if !searchText.isEmpty {
-        Button {
-          searchText = ""
-        } label: {
-          Image(systemName: "xmark.circle.fill")
-            .font(.subheadline)
-            .foregroundStyle(ADEColor.textMuted)
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Clear search")
-      }
-    }
-    .padding(.horizontal, 12)
-    .padding(.vertical, 8)
-    .background(ADEColor.recessedBackground.opacity(0.55), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-    .overlay(
-      RoundedRectangle(cornerRadius: 10, style: .continuous)
-        .stroke(ADEColor.glassBorder, lineWidth: 0.5)
+  private var currentModelBar: some View {
+    ModelPickerCurrentModelBar(
+      model: selectedModel,
+      provider: selectedModel.map(runtimeProvider(for:)) ?? selectedRuntimeProvider,
+      reasoningEffort: selectedReasoningEffort,
+      fastModeEnabled: selectedCodexFastMode
     )
     .padding(.horizontal, 14)
-    .padding(.top, 10)
-    .padding(.bottom, 8)
+    .padding(.vertical, 9)
+    .background(ADEColor.recessedBackground.opacity(0.32))
   }
 
   @ViewBuilder
@@ -434,94 +431,155 @@ struct WorkModelPickerSheet: View {
     .frame(maxWidth: .infinity)
   }
 
+  private var selectedModel: WorkModelOption? {
+    modelById.first(where: { workModelIdsEquivalent($0.key, selectedModelId) })?.value
+  }
+
   // MARK: Behavior
 
-	  @MainActor
-	  private func loadLiveCatalog() async {
-	    isLoadingCatalog = true
-	    defer { isLoadingCatalog = false }
+  @MainActor
+  private func loadLiveCatalog() async {
+    isLoadingCatalog = true
+    defer { isLoadingCatalog = false }
 
-	    if liveCatalog == nil, let cached = syncService.cachedChatModelCatalog() {
+    if liveCatalog == nil, let cached = syncService.cachedChatModelCatalog() {
       liveCatalog = workModelCatalogGroups(
         hostCatalog: cached,
         currentModelId: currentModelId,
         currentProvider: currentProvider
       )
-	    }
+    }
 
-	    do {
-	      let hostCatalog = try await syncService.getChatModelCatalog(
-	        mode: "cached",
-	        cursorSource: cursorCatalogSource()
-	      )
+    do {
+      let hostCatalog = try await syncService.getChatModelCatalog(
+        mode: "cached",
+        cursorSource: cursorCatalogSource()
+      )
       guard !Task.isCancelled else { return }
-	      apply(hostCatalog: hostCatalog)
-	    } catch {
-	      guard !Task.isCancelled else { return }
-	    }
-	  }
+      apply(hostCatalog: hostCatalog)
+    } catch {
+      guard !Task.isCancelled else { return }
+    }
+  }
 
-	  @MainActor
-	  private func refreshCatalog(for groupKey: String) async {
-	    let refreshProvider: String?
-	    switch groupKey {
-	    case "opencode", "cursor", "droid", "lmstudio", "ollama":
-	      refreshProvider = groupKey
-	    default:
-	      refreshProvider = nil
-	    }
-		    guard let refreshProvider else { return }
-		    do {
-		      let hostCatalog = try await syncService.getChatModelCatalog(
-		        mode: "refresh-stale",
-		        refreshProvider: refreshProvider,
-		        cursorSource: cursorCatalogSource(for: refreshProvider)
-		      )
-	      guard !Task.isCancelled else { return }
-	      apply(hostCatalog: hostCatalog)
-	      if hostCatalog.stale == true {
-	        let freshCatalog = try await syncService.getChatModelCatalog(
-	          mode: "force",
-	          refreshProvider: refreshProvider,
-	          cursorSource: cursorCatalogSource(for: refreshProvider)
-	        )
-	        guard !Task.isCancelled else { return }
-	        apply(hostCatalog: freshCatalog)
-	      }
-		    } catch {
-		      // Keep stale catalog visible.
-		    }
-		  }
+  @MainActor
+  private func refreshCatalog(for groupKey: String) async {
+    let refreshProvider: String?
+    switch groupKey {
+    case "opencode", "cursor", "droid", "lmstudio", "ollama":
+      refreshProvider = groupKey
+    default:
+      refreshProvider = nil
+    }
+    guard let refreshProvider else { return }
+    do {
+      let hostCatalog = try await syncService.getChatModelCatalog(
+        mode: "refresh-stale",
+        refreshProvider: refreshProvider,
+        cursorSource: cursorCatalogSource(for: refreshProvider)
+      )
+      guard !Task.isCancelled else { return }
+      apply(hostCatalog: hostCatalog)
+      if hostCatalog.stale == true {
+        let freshCatalog = try await syncService.getChatModelCatalog(
+          mode: "force",
+          refreshProvider: refreshProvider,
+          cursorSource: cursorCatalogSource(for: refreshProvider)
+        )
+        guard !Task.isCancelled else { return }
+        apply(hostCatalog: freshCatalog)
+      }
+    } catch {
+      // Keep stale catalog visible.
+    }
+  }
 
-	  @MainActor
-	  private func apply(hostCatalog: AgentChatModelCatalog) {
-	    liveCatalog = workModelCatalogGroups(
-	      hostCatalog: hostCatalog,
-	      currentModelId: currentModelId,
-	      currentProvider: currentProvider
-	    )
-	  }
+  @MainActor
+  private func apply(hostCatalog: AgentChatModelCatalog) {
+    liveCatalog = workModelCatalogGroups(
+      hostCatalog: hostCatalog,
+      currentModelId: currentModelId,
+      currentProvider: currentProvider
+    )
+  }
 
-	  private func commit(model: WorkModelOption, effort: String?) {
-	    guard model.isAvailable else { return }
-    let normalizedEffort = effort?
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-      .lowercased() ?? ""
-    let normalizedCurrentEffort = currentReasoningEffort
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-      .lowercased()
-    let nextEffort: String? = normalizedEffort.isEmpty ? nil : normalizedEffort
-    let effortChanged = (nextEffort ?? "") != normalizedCurrentEffort
-    let isNoOp = workModelIdsEquivalent(model.id, currentModelId) && !effortChanged
+  private func select(model: WorkModelOption) {
+    guard model.isAvailable else { return }
 
-    pendingModelId = nil
-    if isNoOp {
-      dismiss()
-      return
+    let changedModel = !workModelIdsEquivalent(model.id, selectedModelId)
+    selectedModelId = model.id
+    selectedRuntimeProvider = runtimeProvider(for: model)
+    if changedModel {
+      selectedReasoningEffort = defaultReasoningEffort(for: model) ?? ""
+      selectedCodexFastMode = false
+    } else if !modelSupportsReasoningEffort(model, selectedReasoningEffort) {
+      selectedReasoningEffort = defaultReasoningEffort(for: model) ?? ""
+    }
+    if !model.supportsCodexFastMode {
+      selectedCodexFastMode = false
     }
 
     picker.pushRecent(model.id, syncService: syncService)
-    onSelect(model, nextEffort, runtimeProvider(for: model))
+    emitSelection(model)
+  }
+
+  private func select(reasoningEffort: String, for model: WorkModelOption) {
+    guard model.isAvailable else { return }
+    if !workModelIdsEquivalent(model.id, selectedModelId) {
+      selectedModelId = model.id
+      selectedRuntimeProvider = runtimeProvider(for: model)
+      selectedCodexFastMode = false
+    }
+    selectedReasoningEffort = reasoningEffort.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    picker.pushRecent(model.id, syncService: syncService)
+    emitSelection(model)
+  }
+
+  private func select(fastMode enabled: Bool, for model: WorkModelOption) {
+    guard model.isAvailable else { return }
+    if !workModelIdsEquivalent(model.id, selectedModelId) {
+      selectedModelId = model.id
+      selectedRuntimeProvider = runtimeProvider(for: model)
+      selectedReasoningEffort = defaultReasoningEffort(for: model) ?? ""
+    }
+    selectedCodexFastMode = model.supportsCodexFastMode ? enabled : false
+    picker.pushRecent(model.id, syncService: syncService)
+    emitSelection(model)
+  }
+
+  private func emitSelection(_ model: WorkModelOption) {
+    let normalizedEffort = selectedReasoningEffort
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased()
+    let effortPayload = normalizedEffort.isEmpty ? nil : normalizedEffort
+    onSelect(
+      model,
+      effortPayload,
+      runtimeProvider(for: model),
+      model.supportsCodexFastMode ? selectedCodexFastMode : false
+    )
+  }
+
+  private func defaultReasoningEffort(for model: WorkModelOption) -> String? {
+    let tiers = supportedReasoningTiers(for: model)
+    guard !tiers.isEmpty else { return nil }
+    if tiers.contains("medium") { return "medium" }
+    return tiers[tiers.count / 2]
+  }
+
+  private func modelSupportsReasoningEffort(_ model: WorkModelOption, _ effort: String) -> Bool {
+    let normalized = effort.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    guard !normalized.isEmpty else { return false }
+    return supportedReasoningTiers(for: model).contains(normalized)
+  }
+
+  private func supportedReasoningTiers(for model: WorkModelOption) -> [String] {
+    var seen = Set<String>()
+    return model.reasoningEfforts.compactMap { effort in
+      let tier = effort.effort.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+      guard !tier.isEmpty, seen.insert(tier).inserted else { return nil }
+      return tier
+    }
   }
 }
 
@@ -587,7 +645,7 @@ struct ModelPickerRail: View {
       .padding(.vertical, 8)
       .padding(.horizontal, 5)
     }
-    .frame(width: 52)
+    .frame(width: 60)
     .background(ADEColor.recessedBackground.opacity(0.35))
   }
 
@@ -608,14 +666,6 @@ struct ModelPickerRail: View {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
               .stroke(isActive ? Color.white.opacity(0.06) : Color.clear, lineWidth: 0.8)
           )
-          .overlay(alignment: .trailing) {
-            if isActive {
-              RoundedRectangle(cornerRadius: 1, style: .continuous)
-                .fill(ADEColor.accent.opacity(0.85))
-                .frame(width: 2, height: 20)
-                .offset(x: 2)
-            }
-          }
         if let badge = badgeCount(for: entry), badge > 0 {
           Text("\(badge)")
             .font(.system(size: 8, weight: .bold))
@@ -693,13 +743,14 @@ struct ModelPickerContentPane: View {
   let groupedRows: [ModelPickerRowGroup]
   let providerTabs: [WorkModelProvider]
   let selectedProviderTabKey: String?
-  let currentModelId: String
-  let currentReasoningEffort: String
-  let pendingModelId: String?
+  let selectedModelId: String
+  let selectedReasoningEffort: String
+  let selectedCodexFastMode: Bool
   let favorites: [String]
   let isBusy: Bool
-  let onHighlight: (WorkModelOption) -> Void
-  let onSelect: (WorkModelOption, String?) -> Void
+  let onSelect: (WorkModelOption) -> Void
+  let onSelectReasoning: (WorkModelOption, String) -> Void
+  let onToggleFastMode: (WorkModelOption, Bool) -> Void
   let onSelectProviderTab: (String) -> Void
   let onToggleFavorite: (String) -> Void
 
@@ -745,14 +796,14 @@ struct ModelPickerContentPane: View {
                     model: model,
                     style: rowStyle,
                     catalogGroupKey: catalogGroupKey,
-                    isSessionActive: workModelIdsEquivalent(model.id, currentModelId),
-                    isPending: pendingModelId.map { workModelIdsEquivalent(model.id, $0) } ?? false,
-                    hasPendingSelection: pendingModelId != nil,
+                    isSelected: workModelIdsEquivalent(model.id, selectedModelId),
                     isFavorite: favoritesSet.contains(model.id),
                     isBusy: isBusy,
-                    currentReasoningEffort: currentReasoningEffort,
-                    onHighlight: { onHighlight(model) },
-                    onSelect: { effort in onSelect(model, effort) },
+                    selectedReasoningEffort: selectedReasoningEffort,
+                    selectedCodexFastMode: selectedCodexFastMode,
+                    onSelect: { onSelect(model) },
+                    onSelectReasoning: { effort in onSelectReasoning(model, effort) },
+                    onToggleFastMode: { enabled in onToggleFastMode(model, enabled) },
                     onToggleFavorite: { onToggleFavorite(model.id) }
                   )
                 }
@@ -798,7 +849,7 @@ struct ModelPickerContentPane: View {
   private var activeProviderTabKey: String? {
     selectedProviderTabKey
       ?? providerTabs.first(where: { tab in
-        tab.models.contains { workModelIdsEquivalent($0.id, currentModelId) }
+        tab.models.contains { workModelIdsEquivalent($0.id, selectedModelId) }
       })?.key
       ?? providerTabs.first(where: { tab in
         tab.models.contains(where: { $0.isAvailable })
@@ -808,26 +859,33 @@ struct ModelPickerContentPane: View {
 
   @ViewBuilder
   private var header: some View {
-    HStack(alignment: .center, spacing: 8) {
-      headerLeadingIcon
-      Text(headerTitle)
-        .font(.subheadline.weight(.semibold))
-        .foregroundStyle(ADEColor.textPrimary)
-      Spacer()
+    ZStack {
+      HStack(spacing: 7) {
+        headerLeadingIcon
+        Text(headerTitle)
+          .font(.subheadline.weight(.semibold))
+          .foregroundStyle(ADEColor.textPrimary)
+          .lineLimit(1)
+      }
+
       if !models.isEmpty {
-        Text("\(models.count)")
-          .font(.caption.weight(.bold))
-          .foregroundStyle(ADEColor.textMuted)
-          .padding(.horizontal, 6)
-          .padding(.vertical, 2)
-          .background(
-            Capsule(style: .continuous)
-              .fill(ADEColor.recessedBackground.opacity(0.5))
-          )
+        HStack {
+          Spacer()
+          Text("\(models.count)")
+            .font(.caption.weight(.bold))
+            .foregroundStyle(ADEColor.textMuted)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+              Capsule(style: .continuous)
+                .fill(ADEColor.recessedBackground.opacity(0.5))
+            )
+        }
       }
     }
     .padding(.horizontal, 12)
-    .padding(.vertical, 6)
+    .padding(.top, 10)
+    .padding(.bottom, 8)
   }
 
   @ViewBuilder
@@ -933,22 +991,18 @@ struct ModelPickerListRow: View {
   let model: WorkModelOption
   let style: ModelPickerRowStyle
   let catalogGroupKey: String?
-  let isSessionActive: Bool
-  let isPending: Bool
-  let hasPendingSelection: Bool
+  let isSelected: Bool
   let isFavorite: Bool
   let isBusy: Bool
-  let currentReasoningEffort: String
-  let onHighlight: () -> Void
-  let onSelect: (String?) -> Void
+  let selectedReasoningEffort: String
+  let selectedCodexFastMode: Bool
+  let onSelect: () -> Void
+  let onSelectReasoning: (String) -> Void
+  let onToggleFastMode: (Bool) -> Void
   let onToggleFavorite: () -> Void
 
   private var isHighlighted: Bool {
-    isPending || (isSessionActive && !hasPendingSelection)
-  }
-
-  private var showsSessionActiveBadge: Bool {
-    isSessionActive && !hasPendingSelection
+    isSelected
   }
 
   private var rowLogoProvider: String {
@@ -967,11 +1021,7 @@ struct ModelPickerListRow: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
       Button {
-        if supportedTiers.isEmpty {
-          onSelect(nil)
-        } else {
-          onHighlight()
-        }
+        onSelect()
       } label: {
         Group {
           switch style {
@@ -987,9 +1037,16 @@ struct ModelPickerListRow: View {
       .buttonStyle(.plain)
       .disabled(isBusy || !model.isAvailable)
 
-      if !supportedTiers.isEmpty {
-        reasoningPills(tiers: supportedTiers)
-          .padding(.top, style == .detailed ? 6 : 4)
+      if isHighlighted && shouldShowSelectedControls {
+        VStack(alignment: .leading, spacing: 8) {
+          if !supportedTiers.isEmpty {
+            reasoningPills(tiers: supportedTiers)
+          }
+          if model.supportsCodexFastMode {
+            fastModeToggle
+          }
+        }
+        .padding(.top, style == .detailed ? 8 : 6)
       }
     }
     .padding(.horizontal, style == .compact ? 10 : 11)
@@ -1000,9 +1057,13 @@ struct ModelPickerListRow: View {
     )
     .overlay(
       RoundedRectangle(cornerRadius: style == .compact ? 10 : 11, style: .continuous)
-        .stroke(isHighlighted ? ADEColor.accent.opacity(isPending ? 0.45 : 0.32) : ADEColor.glassBorder.opacity(0.7), lineWidth: isHighlighted ? 1 : 0.5)
+        .stroke(isHighlighted ? ADEColor.accent.opacity(0.42) : ADEColor.glassBorder.opacity(0.7), lineWidth: isHighlighted ? 1 : 0.5)
     )
     .contentShape(Rectangle())
+  }
+
+  private var shouldShowSelectedControls: Bool {
+    !supportedTiers.isEmpty || model.supportsCodexFastMode
   }
 
   @ViewBuilder
@@ -1020,19 +1081,10 @@ struct ModelPickerListRow: View {
           .font(.subheadline.weight(.semibold))
           .foregroundStyle(model.isAvailable ? ADEColor.textPrimary : ADEColor.textMuted)
           .lineLimit(1)
-        Text(providerLabel(rowLogoProvider))
-          .font(.caption2)
-          .foregroundStyle(ADEColor.textMuted.opacity(0.85))
-          .lineLimit(1)
       }
       Spacer(minLength: 4)
-      if showsSessionActiveBadge {
-        Image(systemName: "checkmark")
-          .font(.caption.weight(.bold))
-          .foregroundStyle(ADEColor.accent)
-      }
     }
-    .accessibilityLabel("\(model.displayName), \(providerLabel(rowLogoProvider))\(showsSessionActiveBadge ? ". Currently selected." : isPending ? ". Pick a reasoning level." : "")")
+    .accessibilityLabel("\(model.displayName)\(isSelected ? ". Selected." : "")")
   }
 
   @ViewBuilder
@@ -1045,31 +1097,15 @@ struct ModelPickerListRow: View {
         size: 20
       )
       VStack(alignment: .leading, spacing: 1) {
-        HStack(spacing: 6) {
-          Text(model.displayName)
-            .font(.subheadline.weight(.semibold))
-            .foregroundStyle(model.isAvailable ? ADEColor.textPrimary : ADEColor.textMuted)
-            .lineLimit(1)
-          if showsSessionActiveBadge {
-            Text("active")
-              .font(.caption2.weight(.bold))
-              .tracking(0.3)
-              .foregroundStyle(ADEColor.accent)
-              .padding(.horizontal, 5)
-              .padding(.vertical, 2)
-              .background(ADEColor.accent.opacity(0.15), in: Capsule())
-          }
-        }
+        Text(model.displayName)
+          .font(.subheadline.weight(.semibold))
+          .foregroundStyle(model.isAvailable ? ADEColor.textPrimary : ADEColor.textMuted)
+          .lineLimit(1)
       }
       Spacer(minLength: 6)
       favoriteButton
-      if showsSessionActiveBadge {
-        Image(systemName: "checkmark")
-          .font(.subheadline.weight(.bold))
-          .foregroundStyle(ADEColor.accent)
-      }
     }
-    .accessibilityLabel("\(model.displayName)\(showsSessionActiveBadge ? ". Currently selected." : isPending ? ". Pick a reasoning level." : "")")
+    .accessibilityLabel("\(model.displayName)\(isSelected ? ". Selected." : "")")
   }
 
   @ViewBuilder
@@ -1089,16 +1125,16 @@ struct ModelPickerListRow: View {
 
   @ViewBuilder
   private func reasoningPills(tiers: [String]) -> some View {
-    let normalizedCurrent = currentReasoningEffort
+    let normalizedCurrent = selectedReasoningEffort
       .trimmingCharacters(in: .whitespacesAndNewlines)
       .lowercased()
     ScrollView(.horizontal, showsIndicators: false) {
       HStack(spacing: 6) {
         ForEach(tiers, id: \.self) { tier in
           let normalized = tier.lowercased()
-          let isActiveTier = showsSessionActiveBadge && normalized == normalizedCurrent
+          let isActiveTier = normalized == normalizedCurrent
           Button {
-            onSelect(normalized)
+            onSelectReasoning(normalized)
           } label: {
             Text(reasoningLabel(for: tier))
               .font(.caption.weight(.semibold))
@@ -1108,7 +1144,7 @@ struct ModelPickerListRow: View {
               .padding(.vertical, 7)
               .background(
                 Capsule(style: .continuous)
-                  .fill(isActiveTier ? ADEColor.accent : ADEColor.surfaceBackground.opacity(isPending ? 0.75 : 0.5))
+                  .fill(isActiveTier ? ADEColor.accent : ADEColor.surfaceBackground.opacity(0.55))
               )
               .overlay(
                 Capsule(style: .continuous)
@@ -1116,12 +1152,36 @@ struct ModelPickerListRow: View {
               )
           }
           .buttonStyle(.plain)
-          .disabled(isBusy || !model.isAvailable || !isPending)
+          .disabled(isBusy || !model.isAvailable)
           .accessibilityLabel("\(model.displayName) · reasoning \(reasoningLabel(for: tier))")
           .accessibilityAddTraits(isActiveTier ? .isSelected : [])
         }
       }
     }
+  }
+
+  @ViewBuilder
+  private var fastModeToggle: some View {
+    Toggle(isOn: Binding(
+      get: { selectedCodexFastMode },
+      set: { onToggleFastMode($0) }
+    )) {
+      HStack(spacing: 7) {
+        Image(systemName: "bolt.fill")
+          .font(.caption.weight(.bold))
+          .foregroundStyle(selectedCodexFastMode ? ADEColor.warning : ADEColor.textMuted)
+        Text("Fast mode")
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(ADEColor.textPrimary)
+        Text(selectedCodexFastMode ? "On" : "Off")
+          .font(.caption2.weight(.semibold))
+          .foregroundStyle(ADEColor.textMuted)
+      }
+    }
+    .toggleStyle(.switch)
+    .tint(ADEColor.warning)
+    .disabled(isBusy || !model.isAvailable)
+    .accessibilityLabel("Fast mode \(selectedCodexFastMode ? "on" : "off")")
   }
 
   private func reasoningLabel(for tier: String) -> String {
@@ -1131,6 +1191,82 @@ struct ModelPickerListRow: View {
     case "ultracode": return "Ultracode"
     default: return tier.capitalized
     }
+  }
+}
+
+struct ModelPickerCurrentModelBar: View {
+  let model: WorkModelOption?
+  let provider: String
+  let reasoningEffort: String
+  let fastModeEnabled: Bool
+
+  private var logoProvider: String {
+    model?.provider ?? provider
+  }
+
+  private var reasoningLabel: String {
+    workReasoningChipLabel(reasoningEffort) ?? "Default"
+  }
+
+  var body: some View {
+    HStack(spacing: 9) {
+      WorkProviderBareLogo(
+        provider: logoProvider,
+        fallbackSymbol: providerIcon(logoProvider),
+        tint: providerTint(logoProvider),
+        size: 18
+      )
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text("Current model")
+          .font(.caption2.weight(.bold))
+          .tracking(0.4)
+          .foregroundStyle(ADEColor.textMuted)
+        Text(model?.displayName ?? "Pick a model")
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(ADEColor.textPrimary)
+          .lineLimit(1)
+      }
+
+      Spacer(minLength: 6)
+
+      HStack(spacing: 6) {
+        Text(reasoningLabel)
+          .font(.caption2.weight(.semibold))
+          .foregroundStyle(ADEColor.textSecondary)
+          .lineLimit(1)
+
+        HStack(spacing: 3) {
+          Image(systemName: "bolt.fill")
+            .font(.system(size: 9, weight: .bold))
+            .foregroundStyle(fastModeEnabled ? ADEColor.warning : ADEColor.textMuted)
+          Text(fastModeStatusLabel)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(fastModeEnabled ? ADEColor.warning : ADEColor.textMuted)
+        }
+      }
+      .padding(.horizontal, 8)
+      .padding(.vertical, 5)
+      .background(ADEColor.surfaceBackground.opacity(0.46), in: Capsule(style: .continuous))
+      .overlay(
+        Capsule(style: .continuous)
+          .stroke(ADEColor.border.opacity(0.22), lineWidth: 0.5)
+      )
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("Current model \(model?.displayName ?? "none"), reasoning \(reasoningLabel), \(fastModeAccessibilityLabel)")
+  }
+
+  private var fastModeStatusLabel: String {
+    if fastModeEnabled { return "Fast on" }
+    if model?.supportsCodexFastMode == true { return "Fast off" }
+    return "No fast"
+  }
+
+  private var fastModeAccessibilityLabel: String {
+    if fastModeEnabled { return "fast mode on" }
+    if model?.supportsCodexFastMode == true { return "fast mode off" }
+    return "fast mode unavailable"
   }
 }
 

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -646,12 +646,9 @@ struct WorkNewChatScreen: View {
     syncService.connectionState == .connected || syncService.connectionState == .syncing
   }
 
-  /// Fast mode only applies to in-app chat sessions on fast-tier models — the
-  /// CLI launcher has no fast-mode parameter — so the lightning toggle (and the
-  /// value we send) is gated on both. The picker's option can only *add* support
-  /// (a live host-advertised fast tier the curated catalog may miss); it never
-  /// suppresses the catalog/allow-list fallback, so a known-fast model whose
-  /// option ships empty `serviceTiers` still shows the toggle.
+  /// Fast mode only applies to in-app chat sessions on fast-tier models. The
+  /// picker owns the control, but launch still gates the submitted value on the
+  /// resolved session interface and model support.
   private var fastModeSupported: Bool {
     guard sessionMode == .chat else { return false }
     if let option = selectedModelOption,
@@ -783,9 +780,10 @@ struct WorkNewChatScreen: View {
         currentModelId: modelId,
         currentProvider: provider,
         currentReasoningEffort: reasoningEffort,
+        currentCodexFastMode: codexFastMode,
         cursorAvailabilityMode: sessionMode == .cli ? .cli : .chat,
         isBusy: false,
-        onSelect: { option, pickedReasoning, runtimeProvider in
+        onSelect: { option, pickedReasoning, runtimeProvider, pickedFastMode in
           selectedModelOption = option
           modelId = option.id
           provider = sessionMode == .chat
@@ -793,7 +791,7 @@ struct WorkNewChatScreen: View {
             : workResolveCliProvider(for: option.id, provider: runtimeProvider)
           reasoningEffort = pickedReasoning ?? ""
           runtimeMode = workDefaultRuntimeMode(provider: provider)
-          modelPickerPresented = false
+          codexFastMode = option.supportsCodexFastMode ? pickedFastMode : false
         }
       )
     }
@@ -914,7 +912,6 @@ struct WorkNewChatScreen: View {
       canUploadAttachments: canUploadAttachments,
       runtimeMode: $runtimeMode,
       reasoningEffort: $reasoningEffort,
-      fastModeSupported: fastModeSupported,
       codexFastMode: $codexFastMode,
       onOpenModelPicker: { modelPickerPresented = true },
       onSubmit: submit(openingMessage:attachments:)
@@ -1319,7 +1316,6 @@ private struct WorkNewChatComposerBar: View {
   let canUploadAttachments: Bool
   @Binding var runtimeMode: String
   @Binding var reasoningEffort: String
-  let fastModeSupported: Bool
   @Binding var codexFastMode: Bool
   let onOpenModelPicker: () -> Void
   let onSubmit: @MainActor (String, [WorkChatInputAttachment]) async -> Bool
@@ -1415,12 +1411,9 @@ private struct WorkNewChatComposerBar: View {
               modeOptions: runtimeOptions,
               modeLabel: workRuntimeModeLabel(provider: provider, mode: runtimeMode),
               isCollapsed: isControlsCollapsed,
-              fastModeSupported: fastModeSupported,
               fastModeEnabled: codexFastMode,
-              settingsMutationInFlight: busy,
               onOpenModelPicker: onOpenModelPicker,
-              onSelectMode: { runtimeMode = $0 },
-              onToggleFastMode: { codexFastMode = $0 }
+              onSelectMode: { runtimeMode = $0 }
             )
             .padding(.trailing, 4)
           }

--- a/apps/ios/ADE/Views/Work/WorkPreviews.swift
+++ b/apps/ios/ADE/Views/Work/WorkPreviews.swift
@@ -516,8 +516,9 @@ private enum WorkPreviewData {
     currentModelId: WorkPreviewData.chatSummary.model,
     currentProvider: WorkPreviewData.chatSummary.provider,
     currentReasoningEffort: WorkPreviewData.chatSummary.reasoningEffort ?? "",
+    currentCodexFastMode: WorkPreviewData.chatSummary.effectiveFastMode,
     isBusy: false,
-    onSelect: { _, _, _ in }
+    onSelect: { _, _, _, _ in }
   )
   .environmentObject(WorkPreviewData.syncService)
 }


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstart-skill-wanan-some-changes-e9a71575 num=749 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstart-skill-wanan-some-changes-e9a71575&amp;pr=749">ade/start-skill-wanan-some-changes-e9a71575 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=749">PR #749</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves mobile model, reasoning, and fast-mode selection into the shared model picker. The main changes are:

- Adds picker-owned fast-mode state and callback plumbing.
- Updates chat, new chat, hub, Linear launch, and pending-selection flows to use the expanded picker selection.
- Reworks the mobile picker UI with rail navigation, provider tabs, inline controls, favorites, recents, and a current-model footer.
- Updates the model picker preview for the new picker API.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are localized SwiftUI state and callback plumbing around the model picker, with all reviewed call sites updated to the new callback shape.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - The environment blocker logs reveal missing Xcode tools with exit codes 127 for xcodebuild, xcrun, and swift, signaling a blocked toolchain during setup.
- - A follow-up check shows xcodebuild is not found when attempting to query the project list, confirming the tool is not installed or not in PATH.
- - A simulator build attempt for the iPhone 16 failed due to the same blocker, as shown in the mobile-model-picker-build.log.
- - A project existence check confirms apps/ios/ADE.xcodeproj exists in the repository, validating the expected iOS project path.

<a href="https://app.greptile.com/trex/runs/13807208/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Views/Work/WorkModelPickerSheet.swift | Reworks the mobile model picker into a live-selection UI with rail navigation, provider tabs, inline reasoning tiers, fast-mode toggle, favorites, recents, and a current-model footer. |
| apps/ios/ADE/Views/Work/WorkChatSessionView.swift | Updates in-session model picker handling to submit model, reasoning, and fast-mode changes from the picker. |
| apps/ios/ADE/Views/Work/WorkNewChatScreen.swift | Passes current fast-mode state into the model picker and reflects picker-selected fast mode in the new chat composer. |
| apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift | Removes standalone composer fast-mode toggles and updates pending model selection cards to use picker-owned reasoning and fast-mode controls. |
| apps/ios/ADE/Views/Hub/HubComposerDrawer.swift | Routes fast-mode selection through the shared model picker and updates the composer controls to show fast-mode state in the model pill. |
| apps/ios/ADE/Views/Linear/LinearLaunchScreen.swift | Moves Linear launch fast-mode selection into the model picker and removes the separate launch form toggle. |
| apps/ios/ADE/Views/Work/WorkPreviews.swift | Updates the model picker preview to the new picker callback shape and fast-mode input. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Surface as Chat/New Chat/Hub/Linear
  participant Picker as WorkModelPickerSheet
  participant Store as ModelPickerStore
  participant Sync as SyncService

  Surface->>Picker: Present current model/provider/reasoning/fast mode
  Picker->>Store: load favorites and recents
  Picker->>Sync: getChatModelCatalog(cached/refresh)
  Sync-->>Picker: catalog groups/providers/models
  Surface->>Picker: User opens picker UI
  Picker->>Picker: Select model, reasoning tier, or fast mode
  Picker->>Store: pushRecent/toggleFavorite
  Picker-->>Surface: onSelect(model, reasoning, runtimeProvider, fastMode)
  Surface->>Surface: Update launch/session settings and render selected state
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Surface as Chat/New Chat/Hub/Linear
  participant Picker as WorkModelPickerSheet
  participant Store as ModelPickerStore
  participant Sync as SyncService

  Surface->>Picker: Present current model/provider/reasoning/fast mode
  Picker->>Store: load favorites and recents
  Picker->>Sync: getChatModelCatalog(cached/refresh)
  Sync-->>Picker: catalog groups/providers/models
  Surface->>Picker: User opens picker UI
  Picker->>Picker: Select model, reasoning tier, or fast mode
  Picker->>Store: pushRecent/toggleFavorite
  Picker-->>Surface: onSelect(model, reasoning, runtimeProvider, fastMode)
  Surface->>Surface: Update launch/session settings and render selected state
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Redesign iOS model picker"](https://github.com/arul28/ade/commit/e02df92ec38840bac2a7d10fc87e904fc4206f4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42948035)</sub>

<!-- /greptile_comment -->