### PR TITLE
Prompt Box Ui Edits

### DIFF
--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.test.tsx
@@ -506,16 +506,16 @@ describe("AgentChatComposer", () => {
 
     expect(screen.queryByRole("button", { name: "Chat" })).toBeNull();
     const trigger = screen.getByRole("button", { name: "Claude permission mode" });
-    expect(trigger.textContent).toContain("Ask");
+    expect(trigger.textContent).toContain("Manual");
 
     fireEvent.click(trigger);
 
     expect(screen.getByRole("listbox", { name: "Claude permission mode" })).toBeTruthy();
-    expect(screen.getByRole("option", { name: /Ask permissions/ })).toBeTruthy();
+    expect(screen.getByRole("option", { name: /Manual/ })).toBeTruthy();
     expect(screen.getByRole("option", { name: /Auto/ })).toBeTruthy();
     expect(screen.getByRole("option", { name: /Accept edits/ })).toBeTruthy();
     expect(screen.getByRole("option", { name: /Plan mode/ })).toBeTruthy();
-    expect(screen.getByRole("option", { name: /Bypass permissions/ })).toBeTruthy();
+    expect(screen.getByRole("option", { name: /Bypass/ })).toBeTruthy();
   });
 
   it("routes Claude auto through the native permission callback", () => {
@@ -583,7 +583,7 @@ describe("AgentChatComposer", () => {
       codexConfigSource: "flags",
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Codex approval preset" }));
+    fireEvent.click(screen.getByRole("button", { name: "Codex permission mode" }));
 
     expect(screen.getByRole("option", { name: "Default permissions" })).toBeTruthy();
     expect(screen.getByRole("option", { name: "Edit mode" })).toBeTruthy();
@@ -605,7 +605,7 @@ describe("AgentChatComposer", () => {
 
     expect(container.querySelector(".ade-chat-composer-footer")).toBeTruthy();
 
-    const trigger = screen.getByRole("button", { name: "Codex approval preset" });
+    const trigger = screen.getByRole("button", { name: "Codex permission mode" });
     expect(trigger.className).toContain("ade-chat-composer-permission-trigger");
     expect(trigger.querySelector(".ade-chat-composer-permission-label")).toBeTruthy();
     expect(trigger.querySelector(".ade-chat-composer-permission-chevron")).toBeTruthy();
@@ -615,7 +615,7 @@ describe("AgentChatComposer", () => {
     const onCodexPresetChange = vi.fn();
     renderComposer({ onCodexPresetChange });
 
-    fireEvent.click(screen.getByRole("button", { name: "Codex approval preset" }));
+    fireEvent.click(screen.getByRole("button", { name: "Codex permission mode" }));
     fireEvent.click(screen.getByRole("option", { name: "Plan mode" }));
 
     expect(onCodexPresetChange).toHaveBeenCalledWith({
@@ -624,7 +624,7 @@ describe("AgentChatComposer", () => {
       codexConfigSource: "flags",
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Codex approval preset" }));
+    fireEvent.click(screen.getByRole("button", { name: "Codex permission mode" }));
     fireEvent.click(screen.getByRole("option", { name: "Edit mode" }));
 
     expect(onCodexPresetChange).toHaveBeenCalledWith({
@@ -633,7 +633,7 @@ describe("AgentChatComposer", () => {
       codexConfigSource: "flags",
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Codex approval preset" }));
+    fireEvent.click(screen.getByRole("button", { name: "Codex permission mode" }));
     fireEvent.click(screen.getByRole("option", { name: "Full access" }));
 
     expect(onCodexPresetChange).toHaveBeenCalledWith({
@@ -690,17 +690,16 @@ describe("AgentChatComposer", () => {
       onDroidPermissionModeChange,
     });
 
-    const autonomySelect = screen.getByRole("combobox", { name: "Autonomy" }) as HTMLSelectElement;
-    expect(Array.from(autonomySelect.options).map((option) => option.value)).toEqual([
-      "read-only",
-      "auto-low",
-      "auto-medium",
-      "auto-high",
-      "agi",
-    ]);
+    const autonomyTrigger = screen.getByRole("button", { name: "Droid autonomy mode" });
+    fireEvent.click(autonomyTrigger);
+    expect(screen.getByRole("option", { name: "Read-only" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "Auto low" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "Auto medium" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "Auto high" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "AGI (orchestrator)" })).toBeTruthy();
     expect(screen.queryByRole("combobox", { name: "Permissions" })).toBeNull();
 
-    fireEvent.change(autonomySelect, { target: { value: "auto-high" } });
+    fireEvent.click(screen.getByRole("option", { name: "Auto high" }));
 
     expect(onDroidPermissionModeChange).toHaveBeenCalledWith("auto-high");
   });
@@ -715,15 +714,14 @@ describe("AgentChatComposer", () => {
       onOpenCodePermissionModeChange,
     });
 
-    const permissionsSelect = screen.getByRole("combobox", { name: "Permissions" }) as HTMLSelectElement;
-    expect(Array.from(permissionsSelect.options).map((option) => option.value)).toEqual([
-      "plan",
-      "edit",
-      "full-auto",
-      "config-toml",
-    ]);
+    const permissionsTrigger = screen.getByRole("button", { name: "OpenCode permission mode" });
+    fireEvent.click(permissionsTrigger);
+    expect(screen.getByRole("option", { name: "Plan" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "Edit" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "Full auto" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "Config" })).toBeTruthy();
 
-    fireEvent.change(permissionsSelect, { target: { value: "config-toml" } });
+    fireEvent.click(screen.getByRole("option", { name: "Config" }));
 
     expect(onOpenCodePermissionModeChange).toHaveBeenCalledWith("config-toml");
   });
@@ -734,7 +732,7 @@ describe("AgentChatComposer", () => {
       hideNativeControls: true,
     });
 
-    expect(screen.queryByRole("button", { name: "Codex approval preset" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Codex permission mode" })).toBeNull();
   });
 
   it("avoids promising option chips when a pending question is freeform only", () => {
@@ -1428,10 +1426,10 @@ describe("AgentChatComposer", () => {
       sessionProvider: "opencode",
     });
     const view = render(<AgentChatComposer {...props} />);
-    expect(screen.queryByRole("combobox", { name: "Permissions" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "OpenCode permission mode" })).toBeNull();
 
     view.rerender(<AgentChatComposer {...props} modelId="opencode/openai/gpt-5.4" />);
-    expect(screen.getByRole("combobox", { name: "Permissions" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "OpenCode permission mode" })).toBeTruthy();
   });
 
   it("marks the textarea layout variant in grid-tile mode", () => {

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { ArrowBendDownRight, ArrowUp, At, Bug, CaretDown, Check, CloudArrowUp, Desktop, DeviceMobile, GithubLogo, Globe, Image, Lightning, MicrophoneSlash, Paperclip, PencilSimple, Plus, RocketLaunch, Square, SquareSplitHorizontal, Strategy, Trash, X } from "@phosphor-icons/react";
+import { ArrowBendDownRight, ArrowUp, At, Bug, CaretDown, Check, CloudArrowUp, Desktop, DeviceMobile, GearSix, GithubLogo, Globe, Image, Lightning, MicrophoneSlash, Paperclip, PencilSimple, Plus, RocketLaunch, ShieldCheck, ShieldWarning, Square, SquareSplitHorizontal, Strategy, Trash, X } from "@phosphor-icons/react";
 import { BorderBeam } from "border-beam";
 import {
   inferAttachmentType,
@@ -50,7 +50,7 @@ import { ModelPicker } from "../shared/ModelPicker/ModelPicker";
 import type { AuthStatus } from "../shared/ModelPicker/ModelPickerRail";
 import { resolveModelDescriptorWithRuntimeCatalog } from "../shared/ModelPicker/modelCatalog";
 import { ReasoningEffortPicker } from "../shared/ModelPicker/ReasoningEffortPicker";
-import { getPermissionOptions, safetyColors } from "../shared/permissionOptions";
+import { getPermissionOptions, type PermissionOption } from "../shared/permissionOptions";
 import { ContextUsageDial } from "./usage/ContextUsageDial";
 import type { ContextUsageViewModel } from "./usage/contextUsageModel";
 import {
@@ -468,25 +468,6 @@ function buildSlashCommands(
   return result;
 }
 
-type ClaudeModeTone = "green" | "amber" | "blue" | "purple" | "red";
-
-type ClaudeModeOption = {
-  value: AgentChatClaudePermissionMode;
-  label: string;
-  detail: string;
-  tone: ClaudeModeTone;
-};
-
-function composerPermissionLabel(label: string): string {
-  const SHORT: Record<string, string> = {
-    "Ask permissions": "Ask",
-    "Accept edits": "Edits",
-    "Bypass permissions": "Bypass",
-    "Plan mode": "Plan",
-  };
-  return SHORT[label] ?? label;
-}
-
 const COMPOSER_TOOLBAR_PICKER_TRIGGER = "max-w-[min(9.5rem,34vw)] shrink min-w-0";
 // The model name is the priority control: it keeps a readable floor and only
 // shrinks after the permission/fast labels collapse and the reasoning picker
@@ -537,60 +518,265 @@ const COMPOSER_PERMISSION_TRIGGER_CLASS = cn(
   "hover:border-violet-400/20 hover:bg-violet-500/[0.06] hover:text-fg",
 );
 
-const CLAUDE_MODE_OPTIONS: ClaudeModeOption[] = [
-  { value: "default", label: "Ask permissions", detail: "Claude asks before edits, Bash, and other sensitive tools.", tone: "green" },
-  { value: "auto", label: "Auto", detail: "Claude judges each tool call. Uses a model classifier instead of asking you.", tone: "amber" },
-  { value: "acceptEdits", label: "Accept edits", detail: "File edits are auto-approved; higher-risk actions still prompt.", tone: "blue" },
-  { value: "plan", label: "Plan mode", detail: "Read-only Claude turns for analysis and implementation planning.", tone: "purple" },
-  { value: "bypassPermissions", label: "Bypass permissions", detail: "Skip every Claude permission prompt for this chat.", tone: "red" },
-];
+type PermissionModeTone = "green" | "amber" | "blue" | "purple" | "red" | "slate";
+type PermissionModeIconKind = "manual" | "auto" | "edit" | "plan" | "full" | "config" | "agent" | "agi";
 
-const CLAUDE_MODE_TONE_STYLES: Record<
-  ClaudeModeTone,
+type PermissionModePickerOption<Value extends string = string> = {
+  value: Value;
+  label: string;
+  triggerLabel?: string;
+  detail: string;
+  tone: PermissionModeTone;
+  icon: PermissionModeIconKind;
+};
+
+const PERMISSION_MODE_TONE_STYLES: Record<
+  PermissionModeTone,
   {
-    activeBg: string;
-    activeText: string;
-    activeBorder: string;
     dot: string;
-    hoverBg: string;
+    trigger: string;
+    iconSurface: string;
+    rowActive: string;
+    rowHover: string;
   }
 > = {
   green: {
-    activeBg: "bg-emerald-500/12",
-    activeText: "text-emerald-200",
-    activeBorder: "border-emerald-500/35",
     dot: "bg-emerald-400",
-    hoverBg: "hover:bg-emerald-500/10 hover:text-emerald-100",
+    trigger: "border-emerald-400/24 bg-emerald-500/[0.08] text-emerald-100",
+    iconSurface: "border-emerald-300/20 bg-emerald-500/[0.12] text-emerald-200",
+    rowActive: "bg-emerald-500/[0.12] text-emerald-50",
+    rowHover: "hover:bg-emerald-500/[0.08] hover:text-emerald-50",
   },
   amber: {
-    activeBg: "bg-amber-500/12",
-    activeText: "text-amber-200",
-    activeBorder: "border-amber-500/35",
     dot: "bg-amber-400",
-    hoverBg: "hover:bg-amber-500/10 hover:text-amber-100",
+    trigger: "border-amber-300/22 bg-amber-500/[0.08] text-amber-100",
+    iconSurface: "border-amber-300/20 bg-amber-500/[0.12] text-amber-200",
+    rowActive: "bg-amber-500/[0.12] text-amber-50",
+    rowHover: "hover:bg-amber-500/[0.08] hover:text-amber-50",
   },
   blue: {
-    activeBg: "bg-sky-500/14",
-    activeText: "text-sky-200",
-    activeBorder: "border-sky-500/35",
     dot: "bg-sky-400",
-    hoverBg: "hover:bg-sky-500/10 hover:text-sky-100",
+    trigger: "border-sky-300/22 bg-sky-500/[0.08] text-sky-100",
+    iconSurface: "border-sky-300/20 bg-sky-500/[0.12] text-sky-200",
+    rowActive: "bg-sky-500/[0.12] text-sky-50",
+    rowHover: "hover:bg-sky-500/[0.08] hover:text-sky-50",
   },
   purple: {
-    activeBg: "bg-violet-500/14",
-    activeText: "text-violet-200",
-    activeBorder: "border-violet-500/35",
     dot: "bg-violet-400",
-    hoverBg: "hover:bg-violet-500/10 hover:text-violet-100",
+    trigger: "border-violet-300/24 bg-violet-500/[0.09] text-violet-100",
+    iconSurface: "border-violet-300/20 bg-violet-500/[0.14] text-violet-200",
+    rowActive: "bg-violet-500/[0.14] text-violet-50",
+    rowHover: "hover:bg-violet-500/[0.08] hover:text-violet-50",
   },
   red: {
-    activeBg: "bg-red-500/14",
-    activeText: "text-red-200",
-    activeBorder: "border-red-500/35",
     dot: "bg-red-400",
-    hoverBg: "hover:bg-red-500/10 hover:text-red-100",
+    trigger: "border-red-300/24 bg-red-500/[0.09] text-red-100",
+    iconSurface: "border-red-300/20 bg-red-500/[0.14] text-red-200",
+    rowActive: "bg-red-500/[0.14] text-red-50",
+    rowHover: "hover:bg-red-500/[0.08] hover:text-red-50",
+  },
+  slate: {
+    dot: "bg-slate-300",
+    trigger: "border-white/[0.08] bg-white/[0.045] text-fg/80",
+    iconSurface: "border-white/[0.08] bg-white/[0.06] text-fg/72",
+    rowActive: "bg-white/[0.08] text-fg/90",
+    rowHover: "hover:bg-white/[0.055] hover:text-fg/90",
   },
 };
+
+const CLAUDE_MODE_OPTIONS: Array<PermissionModePickerOption<AgentChatClaudePermissionMode>> = [
+  { value: "default", label: "Manual", detail: "Claude asks before edits, Bash, and other sensitive tools.", tone: "green", icon: "manual" },
+  { value: "auto", label: "Auto", detail: "Claude judges each tool call. Uses a model classifier instead of asking you.", tone: "amber", icon: "auto" },
+  { value: "acceptEdits", label: "Accept edits", triggerLabel: "Edits", detail: "File edits are auto-approved; higher-risk actions still prompt.", tone: "amber", icon: "edit" },
+  { value: "plan", label: "Plan mode", triggerLabel: "Plan", detail: "Read-only Claude turns for analysis and implementation planning.", tone: "purple", icon: "plan" },
+  { value: "bypassPermissions", label: "Bypass", detail: "Skip every Claude permission prompt for this chat.", tone: "red", icon: "full" },
+];
+
+function PermissionModeGlyph({
+  icon,
+  size = 11,
+  className,
+}: {
+  icon: PermissionModeIconKind;
+  size?: number;
+  className?: string;
+}) {
+  switch (icon) {
+    case "manual":
+      return <ShieldCheck size={size} weight="fill" className={className} />;
+    case "auto":
+      return <Lightning size={size} weight="fill" className={className} />;
+    case "edit":
+      return <PencilSimple size={size} weight="fill" className={className} />;
+    case "plan":
+      return <Strategy size={size} weight="fill" className={className} />;
+    case "full":
+      return <ShieldWarning size={size} weight="fill" className={className} />;
+    case "config":
+      return <GearSix size={size} weight="fill" className={className} />;
+    case "agent":
+      return <Desktop size={size} weight="fill" className={className} />;
+    case "agi":
+      return <RocketLaunch size={size} weight="fill" className={className} />;
+  }
+}
+
+function PermissionModePicker<Value extends string>({
+  ariaLabel,
+  selectedValue,
+  options,
+  disabled,
+  onSelect,
+  title,
+}: {
+  ariaLabel: string;
+  selectedValue: Value;
+  options: Array<PermissionModePickerOption<Value>>;
+  disabled?: boolean;
+  onSelect?: (value: Value) => void;
+  title?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+  const selectedOption = options.find((option) => option.value === selectedValue) ?? options[0];
+  const selectedTone = PERMISSION_MODE_TONE_STYLES[selectedOption?.tone ?? "slate"];
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (event: MouseEvent) => {
+      if (ref.current?.contains(event.target as Node)) return;
+      const target = event.target as Element | null;
+      if (target?.closest?.("[data-permission-mode-picker-dropdown]")) return;
+      setOpen(false);
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("mousedown", handleClick);
+    window.addEventListener("keydown", handleKey);
+    return () => {
+      window.removeEventListener("mousedown", handleClick);
+      window.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  if (!selectedOption) return null;
+
+  const triggerTitle = title ?? selectedOption.detail;
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        data-state={open ? "open" : "closed"}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        disabled={disabled || !onSelect}
+        onClick={() => {
+          if (disabled || !onSelect) return;
+          setOpen((current) => !current);
+        }}
+        className={cn(
+          COMPOSER_PERMISSION_TRIGGER_CLASS,
+          selectedTone.trigger,
+          open && "ring-1 ring-white/[0.06]",
+          (disabled || !onSelect) && "cursor-not-allowed opacity-60 hover:border-white/[0.06] hover:bg-white/[0.03]",
+        )}
+        title={triggerTitle}
+      >
+        <span className={cn("inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border", selectedTone.iconSurface)} aria-hidden>
+          <PermissionModeGlyph icon={selectedOption.icon} size={9} />
+        </span>
+        <span className="ade-chat-composer-permission-label truncate font-medium leading-none">
+          {selectedOption.triggerLabel ?? selectedOption.label}
+        </span>
+        <CaretDown
+          size={10}
+          weight="bold"
+          className={cn(
+            "ade-chat-composer-permission-chevron shrink-0 text-current/65 transition-transform duration-150",
+            open && "rotate-180 text-current/90",
+          )}
+        />
+      </button>
+      {open && ref.current ? createPortal(
+        (() => {
+          const rect = ref.current.getBoundingClientRect();
+          const width = 284;
+          const left = Math.min(Math.max(8, rect.left), Math.max(8, window.innerWidth - width - 8));
+          return (
+            <div
+              role="listbox"
+              aria-label={ariaLabel}
+              data-permission-mode-picker-dropdown
+              className="fixed z-[100] overflow-hidden rounded-xl border border-white/[0.08] bg-[#13111A]/95 shadow-[0_18px_48px_rgba(0,0,0,0.55)] backdrop-blur-md"
+              style={{
+                left,
+                bottom: Math.max(8, window.innerHeight - rect.top + 8),
+                width,
+              }}
+            >
+              <div className="flex items-center gap-2 border-b border-white/[0.05] px-3 py-2">
+                <span className={cn("inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border", selectedTone.iconSurface)} aria-hidden>
+                  <PermissionModeGlyph icon={selectedOption.icon} size={12} />
+                </span>
+                <div className="min-w-0">
+                  <div className="font-mono text-[length:calc(var(--chat-font-size)*9/14)] font-bold uppercase tracking-[0.18em] text-muted-fg/50">
+                    Mode
+                  </div>
+                  <div className="truncate font-sans text-[length:calc(var(--chat-font-size)*11/14)] text-fg/78">
+                    {selectedOption.label}
+                  </div>
+                </div>
+              </div>
+              <ul className="py-1">
+                {options.map((option) => {
+                  const active = option.value === selectedValue;
+                  const tone = PERMISSION_MODE_TONE_STYLES[option.tone];
+                  return (
+                    <li key={option.value}>
+                      <button
+                        type="button"
+                        role="option"
+                        aria-label={option.label}
+                        aria-selected={active}
+                        onClick={() => {
+                          onSelect?.(option.value);
+                          setOpen(false);
+                        }}
+                        className={cn(
+                          "flex w-full items-start gap-2.5 px-3 py-2 text-left font-sans transition-colors",
+                          active ? tone.rowActive : "text-fg/72",
+                          tone.rowHover,
+                        )}
+                        title={option.detail}
+                      >
+                        <span className={cn("mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-lg border", tone.iconSurface)} aria-hidden>
+                          <PermissionModeGlyph icon={option.icon} size={12} />
+                        </span>
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-[length:calc(var(--chat-font-size)*11/14)] font-semibold leading-4">
+                            {option.label}
+                          </span>
+                          <span className="mt-0.5 block text-[length:calc(var(--chat-font-size)*10/14)] leading-4 text-muted-fg/52">
+                            {option.detail}
+                          </span>
+                        </span>
+                        {active ? <Check size={12} weight="bold" className="mt-1 shrink-0 opacity-80" /> : null}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          );
+        })(),
+        document.body,
+      ) : null}
+    </div>
+  );
+}
 
 type CodexPermissionPreset = "default" | "edit" | "plan" | "full-auto" | "config-toml" | "custom";
 
@@ -607,33 +793,50 @@ function resolveCodexPermissionPreset(args: {
   return "custom";
 }
 
-function safetyDotClass(safety: "safe" | "semi-auto" | "full-auto" | "danger" | "custom"): string {
-  switch (safety) {
-    case "safe":
-      return "bg-emerald-400/80";
-    case "semi-auto":
-      return "bg-amber-400/80";
+function codexPermissionPickerOption(option: PermissionOption): PermissionModePickerOption<Exclude<CodexPermissionPreset, "custom">> {
+  switch (option.value) {
+    case "default":
+      return { value: "default", label: option.label, triggerLabel: "Default", detail: option.detail, tone: "green", icon: "manual" };
+    case "edit":
+      return { value: "edit", label: option.label, triggerLabel: "Edit", detail: option.detail, tone: "amber", icon: "edit" };
+    case "plan":
+      return { value: "plan", label: option.label, triggerLabel: "Plan", detail: option.detail, tone: "purple", icon: "plan" };
     case "full-auto":
-    case "danger":
-      return "bg-red-400/80";
-    case "custom":
-      return "bg-violet-400/80";
+      return { value: "full-auto", label: option.label, triggerLabel: "Full", detail: option.detail, tone: "red", icon: "full" };
+    case "config-toml":
+      return { value: "config-toml", label: option.label, triggerLabel: "Config", detail: option.detail, tone: "slate", icon: "config" };
+    default:
+      return { value: "default", label: option.label, triggerLabel: "Default", detail: option.detail, tone: "green", icon: "manual" };
   }
 }
 
-const OPENCODE_PERMISSION_OPTIONS: Array<{ value: AgentChatOpenCodePermissionMode; label: string }> = [
-  { value: "plan", label: "Plan" },
-  { value: "edit", label: "Edit" },
-  { value: "full-auto", label: "Full auto" },
-  { value: "config-toml", label: "Config" },
+function cursorPermissionPickerOption(value: string, label: string): PermissionModePickerOption<string> {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "plan") {
+    return { value, label, triggerLabel: label, detail: "Read-only planning mode.", tone: "purple", icon: "plan" };
+  }
+  if (normalized === "ask" || normalized === "edit") {
+    return { value, label, triggerLabel: label, detail: "Read-only Q&A mode.", tone: "green", icon: "manual" };
+  }
+  if (normalized === "full-auto" || normalized === "force" || normalized === "yolo") {
+    return { value, label, triggerLabel: label, detail: "Highest access mode for Cursor Agent.", tone: "red", icon: "full" };
+  }
+  return { value, label, triggerLabel: label, detail: "Cursor Agent's normal approval flow.", tone: "green", icon: "agent" };
+}
+
+const OPENCODE_PERMISSION_OPTIONS: Array<PermissionModePickerOption<AgentChatOpenCodePermissionMode>> = [
+  { value: "plan", label: "Plan", detail: "Read-only plan agent.", tone: "purple", icon: "plan" },
+  { value: "edit", label: "Edit", detail: "Allow edits; ask for the rest.", tone: "amber", icon: "edit" },
+  { value: "full-auto", label: "Full auto", detail: "Allow configured OpenCode tools.", tone: "red", icon: "full" },
+  { value: "config-toml", label: "Config", detail: "Use OpenCode config files.", tone: "slate", icon: "config" },
 ];
 
-const DROID_PERMISSION_OPTIONS: Array<{ value: AgentChatDroidPermissionMode; label: string; detail: string }> = [
-  { value: "read-only", label: "Read-only", detail: "No auto flag. Droid stays in read-only mode for analysis and planning." },
-  { value: "auto-low", label: "Auto low", detail: "Passes --auto low for safe file edits and low-risk operations." },
-  { value: "auto-medium", label: "Auto medium", detail: "Passes --auto medium for local development operations such as builds, tests, and package installs." },
-  { value: "auto-high", label: "Auto high", detail: "Passes --auto high for broad automation. Use only in trusted workspaces." },
-  { value: "agi", label: "AGI (orchestrator)", detail: "Droid decomposes the task into a mission and spawns worker subagents (read-only at the top level). Workers appear in the subagents panel." },
+const DROID_PERMISSION_OPTIONS: Array<PermissionModePickerOption<AgentChatDroidPermissionMode>> = [
+  { value: "read-only", label: "Read-only", detail: "No auto flag. Droid stays in read-only mode for analysis and planning.", tone: "green", icon: "manual" },
+  { value: "auto-low", label: "Auto low", detail: "Passes --auto low for safe file edits and low-risk operations.", tone: "green", icon: "edit" },
+  { value: "auto-medium", label: "Auto medium", detail: "Passes --auto medium for local development operations such as builds, tests, and package installs.", tone: "amber", icon: "auto" },
+  { value: "auto-high", label: "Auto high", detail: "Passes --auto high for broad automation. Use only in trusted workspaces.", tone: "red", icon: "full" },
+  { value: "agi", label: "AGI (orchestrator)", triggerLabel: "AGI", detail: "Droid decomposes the task into a mission and spawns worker subagents (read-only at the top level). Workers appear in the subagents panel.", tone: "purple", icon: "agi" },
 ];
 
 function cursorModeLabel(modeId: string): string {
@@ -1115,10 +1318,6 @@ export function AgentChatComposer({
   const [selectedAppControlContextId, setSelectedAppControlContextId] = useState<string | null>(null);
   const [selectedBuiltInBrowserContextId, setSelectedBuiltInBrowserContextId] = useState<string | null>(null);
 
-  const [claudeModePickerOpen, setClaudeModePickerOpen] = useState(false);
-  const claudeModePickerRef = useRef<HTMLDivElement | null>(null);
-  const [codexPresetPickerOpen, setCodexPresetPickerOpen] = useState(false);
-  const codexPresetPickerRef = useRef<HTMLDivElement | null>(null);
   const issueContextButtonRef = useRef<HTMLButtonElement | null>(null);
   const [dragActive, setDragActive] = useState(false);
   const [commandMenuTrigger, setCommandMenuTrigger] = useState<ComposerTrigger | null>(null);
@@ -2245,50 +2444,6 @@ export function AgentChatComposer({
     parallelControlSlot,
   ]);
   useEffect(() => {
-    if (!codexPresetPickerOpen) return;
-    const handleClick = (event: MouseEvent) => {
-      if (!codexPresetPickerRef.current) return;
-      if (codexPresetPickerRef.current.contains(event.target as Node)) return;
-      const target = event.target as Element | null;
-      if (target?.closest?.("[data-codex-preset-picker-dropdown]")) return;
-      setCodexPresetPickerOpen(false);
-    };
-    const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setCodexPresetPickerOpen(false);
-      }
-    };
-    window.addEventListener("mousedown", handleClick);
-    window.addEventListener("keydown", handleKey);
-    return () => {
-      window.removeEventListener("mousedown", handleClick);
-      window.removeEventListener("keydown", handleKey);
-    };
-  }, [codexPresetPickerOpen]);
-
-  useEffect(() => {
-    if (!claudeModePickerOpen) return;
-    const handleClick = (event: MouseEvent) => {
-      if (!claudeModePickerRef.current) return;
-      if (claudeModePickerRef.current.contains(event.target as Node)) return;
-      const target = event.target as Element | null;
-      if (target?.closest?.("[data-claude-mode-picker-dropdown]")) return;
-      setClaudeModePickerOpen(false);
-    };
-    const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setClaudeModePickerOpen(false);
-      }
-    };
-    window.addEventListener("mousedown", handleClick);
-    window.addEventListener("keydown", handleKey);
-    return () => {
-      window.removeEventListener("mousedown", handleClick);
-      window.removeEventListener("keydown", handleKey);
-    };
-  }, [claudeModePickerOpen]);
-
-  useEffect(() => {
     if (!issueContextMenuOpen) return;
     const handleClick = (event: MouseEvent) => {
       if (issueContextButtonRef.current?.contains(event.target as Node)) return;
@@ -2349,7 +2504,6 @@ export function AgentChatComposer({
     if (sp === "claude") {
       const selectedOption =
         CLAUDE_MODE_OPTIONS.find((option) => option.value === claudeSelectionMode) ?? CLAUDE_MODE_OPTIONS[0];
-      const selectedTone = CLAUDE_MODE_TONE_STYLES[selectedOption.tone];
       const applyClaudeMode = (mode: AgentChatClaudePermissionMode) => {
         if (parallelControlSlot) {
           if (mode === "plan") {
@@ -2375,227 +2529,56 @@ export function AgentChatComposer({
       };
       return (
         <div className={cn("flex flex-wrap gap-2", plainComposerToolbarChrome ? "items-center" : "items-start")}>
-          <div ref={claudeModePickerRef} className="relative">
-            <button
-              type="button"
-              data-state={claudeModePickerOpen ? "open" : "closed"}
-              aria-haspopup="listbox"
-              aria-expanded={claudeModePickerOpen}
-              aria-label="Claude permission mode"
-              disabled={nativeControlsDisabled}
-              onClick={() => {
-                if (nativeControlsDisabled) return;
-                setClaudeModePickerOpen((open) => !open);
-              }}
-              className={cn(
-                COMPOSER_PERMISSION_TRIGGER_CLASS,
-                claudeModePickerOpen && "border-violet-400/30 bg-violet-500/[0.08] text-fg",
-                nativeControlsDisabled && "cursor-not-allowed opacity-60 hover:border-white/[0.06] hover:bg-white/[0.03]",
-              )}
-              title={selectedOption.detail}
-            >
-              <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", selectedTone.dot)} aria-hidden />
-              <span className="ade-chat-composer-permission-label truncate font-medium leading-none">{composerPermissionLabel(selectedOption.label)}</span>
-              <CaretDown
-                size={10}
-                weight="bold"
-                className={cn(
-                  "ade-chat-composer-permission-chevron shrink-0 text-muted-fg/60 transition-transform duration-150",
-                  claudeModePickerOpen && "rotate-180 text-fg/80",
-                )}
-              />
-            </button>
-            {claudeModePickerOpen && claudeModePickerRef.current ? createPortal(
-              (() => {
-                const rect = claudeModePickerRef.current.getBoundingClientRect();
-                return (
-                  <div
-                    role="listbox"
-                    aria-label="Claude permission mode"
-                    data-claude-mode-picker-dropdown
-                    className="fixed z-[100] w-56 overflow-hidden rounded-xl border border-white/[0.08] bg-[#13111A]/95 shadow-[0_18px_48px_rgba(0,0,0,0.55)] backdrop-blur-md"
-                    style={{
-                      left: rect.left,
-                      bottom: window.innerHeight - rect.top + 8,
-                    }}
-                  >
-                    <div className="border-b border-white/[0.05] px-3 py-1.5 font-mono text-[length:calc(var(--chat-font-size)*9/14)] font-bold uppercase tracking-[0.18em] text-muted-fg/50">
-                      Mode
-                    </div>
-                    <ul className="py-1">
-                      {CLAUDE_MODE_OPTIONS.map((option) => {
-                        const tone = CLAUDE_MODE_TONE_STYLES[option.tone];
-                        const active = option.value === claudeSelectionMode;
-                        return (
-                          <li key={option.value}>
-                            <button
-                              type="button"
-                              role="option"
-                              aria-selected={active}
-                              onClick={() => {
-                                applyClaudeMode(option.value);
-                                setClaudeModePickerOpen(false);
-                              }}
-                              className={cn(
-                                "flex w-full items-center gap-2 px-3 py-1.5 text-left font-sans text-[length:calc(var(--chat-font-size)*11/14)] transition-colors",
-                                active ? cn(tone.activeBg, tone.activeText) : "text-fg/72",
-                                tone.hoverBg,
-                              )}
-                              title={option.detail}
-                            >
-                              <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", tone.dot)} aria-hidden />
-                              <span className="flex-1 truncate leading-none">{option.label}</span>
-                              {active ? <Check size={10} weight="bold" className="opacity-80" /> : null}
-                            </button>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  </div>
-                );
-              })(),
-              document.body,
-            ) : null}
-          </div>
+          <PermissionModePicker
+            ariaLabel="Claude permission mode"
+            selectedValue={selectedOption.value}
+            options={CLAUDE_MODE_OPTIONS}
+            disabled={nativeControlsDisabled}
+            onSelect={applyClaudeMode}
+          />
         </div>
       );
     }
 
     if (sp === "codex") {
-      const activePreset = codexPresetOptions.find((option) => option.value === codexPreset);
-      const presetLabel = codexPreset === "custom"
-        ? "Custom"
-        : activePreset?.label ?? "Plan";
+      const codexModeOptions = codexPresetOptions.map(codexPermissionPickerOption);
+      const codexCustomOption: PermissionModePickerOption<CodexPermissionPreset> = {
+        value: "custom",
+        label: "Custom",
+        detail: codexCustomSummary ?? "Custom Codex approval/sandbox combination.",
+        tone: "slate",
+        icon: "config",
+      };
+      const pickerOptions: Array<PermissionModePickerOption<CodexPermissionPreset>> = codexPreset === "custom"
+        ? [...codexModeOptions, codexCustomOption]
+        : codexModeOptions;
       return (
-        <div ref={codexPresetPickerRef} className="relative">
-          <button
-            type="button"
-            data-state={codexPresetPickerOpen ? "open" : "closed"}
-            aria-haspopup="listbox"
-            aria-expanded={codexPresetPickerOpen}
-            aria-label="Codex approval preset"
-            disabled={nativeControlsDisabled}
-            onClick={() => {
-              if (nativeControlsDisabled) return;
-              setCodexPresetPickerOpen((open) => !open);
-            }}
-            className={cn(
-              COMPOSER_PERMISSION_TRIGGER_CLASS,
-              codexPresetPickerOpen && "border-violet-400/30 bg-violet-500/[0.08] text-fg",
-              nativeControlsDisabled && "cursor-not-allowed opacity-60 hover:border-white/[0.06] hover:bg-white/[0.03]",
-            )}
-            title={activePreset?.detail ?? codexCustomSummary ?? "Codex approval preset"}
-          >
-            {activePreset ? (
-              <span
-                className={cn("h-1.5 w-1.5 shrink-0 rounded-full", safetyDotClass(activePreset.safety))}
-                aria-hidden
-              />
-            ) : (
-              <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-fg/40" aria-hidden />
-            )}
-            <span className="ade-chat-composer-permission-label truncate font-medium leading-none">{presetLabel}</span>
-            <CaretDown
-              size={10}
-              weight="bold"
-              className={cn(
-                "ade-chat-composer-permission-chevron shrink-0 text-muted-fg/60 transition-transform duration-150",
-                codexPresetPickerOpen && "rotate-180 text-fg/80",
-              )}
-            />
-          </button>
-          {codexPresetPickerOpen && codexPresetPickerRef.current ? createPortal(
-            (() => {
-              const rect = codexPresetPickerRef.current.getBoundingClientRect();
-              return (
-                <div
-                  role="listbox"
-                  aria-label="Codex approval preset"
-                  data-codex-preset-picker-dropdown
-                  className="fixed z-[100] w-56 overflow-hidden rounded-xl border border-white/[0.08] bg-[#13111A]/95 shadow-[0_18px_48px_rgba(0,0,0,0.55)] backdrop-blur-md"
-                  style={{
-                    left: rect.left,
-                    bottom: window.innerHeight - rect.top + 8,
-                  }}
-                >
-                  <div className="border-b border-white/[0.05] px-3 py-1.5 font-mono text-[length:calc(var(--chat-font-size)*9/14)] font-bold uppercase tracking-[0.18em] text-muted-fg/50">
-                    Preset
-                  </div>
-                  <ul className="py-1">
-                    {codexPresetOptions.map((option) => {
-                      const active = codexPreset === option.value;
-                      const colors = safetyColors(option.safety);
-                      return (
-                        <li key={option.value}>
-                          <button
-                            type="button"
-                            role="option"
-                            aria-selected={active}
-                            onClick={() => {
-                              applyCodexPreset(option.value as Exclude<CodexPermissionPreset, "custom">);
-                              setCodexPresetPickerOpen(false);
-                            }}
-                            className={cn(
-                              "flex w-full items-center gap-2 px-3 py-1.5 text-left font-sans text-[length:calc(var(--chat-font-size)*11/14)] transition-colors",
-                              active ? `${colors.activeBg} text-fg/88` : "text-fg/72 hover:bg-white/[0.04]",
-                            )}
-                            title={option.detail}
-                          >
-                            <span className="flex-1 truncate leading-none">{option.label}</span>
-                            {active ? <Check size={10} weight="bold" className="opacity-80" /> : null}
-                          </button>
-                        </li>
-                      );
-                    })}
-                    {codexPreset === "custom" ? (
-                      <li>
-                        <div
-                          className="flex w-full items-center gap-2 px-3 py-1.5 font-sans text-[length:calc(var(--chat-font-size)*11/14)] bg-white/[0.06] text-fg/88"
-                          title={codexCustomSummary ?? "Custom Codex approval/sandbox combination"}
-                        >
-                          <span className="flex-1 truncate leading-none">Custom</span>
-                          <Check size={10} weight="bold" className="opacity-80" />
-                        </div>
-                      </li>
-                    ) : null}
-                  </ul>
-                </div>
-              );
-            })(),
-            document.body,
-          ) : null}
-        </div>
+        <PermissionModePicker
+          ariaLabel="Codex permission mode"
+          selectedValue={codexPreset}
+          options={pickerOptions}
+          disabled={nativeControlsDisabled}
+          onSelect={(preset) => {
+            if (preset === "custom") return;
+            applyCodexPreset(preset);
+          }}
+          title={pickerOptions.find((option) => option.value === codexPreset)?.detail ?? codexCustomSummary ?? "Codex permission mode"}
+        />
       );
     }
 
     if (sp === "droid") {
       return (
-        <label
-          className={cn(
-            "flex h-8 min-h-8 items-center gap-2 rounded-md px-2",
-            plainComposerToolbarChrome
-              ? "border border-transparent bg-transparent"
-              : "border border-white/[0.06] bg-[#1a1a22] px-2.5 py-1.5",
-          )}
-        >
-          <span className="font-mono text-[9px] uppercase tracking-[0.16em] text-muted-fg/45">Autonomy</span>
-          <select
-            value={dpmUse}
-            disabled={nativeControlsDisabled || (!onDroidPermissionModeChange && !parallelControlSlot)}
-            onChange={(event) => {
-              const v = event.target.value as AgentChatDroidPermissionMode;
-              if (parallelControlSlot) parallelControlSlot.onDroidPermissionModeChange(v);
-              else onDroidPermissionModeChange?.(v);
-            }}
-            className="min-w-0 bg-transparent font-sans text-[11px] text-fg/82 outline-none disabled:cursor-not-allowed disabled:text-muted-fg/35"
-          >
-            {DROID_PERMISSION_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value} title={option.detail}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </label>
+        <PermissionModePicker
+          ariaLabel="Droid autonomy mode"
+          selectedValue={dpmUse}
+          options={DROID_PERMISSION_OPTIONS}
+          disabled={nativeControlsDisabled || (!onDroidPermissionModeChange && !parallelControlSlot)}
+          onSelect={(value) => {
+            if (parallelControlSlot) parallelControlSlot.onDroidPermissionModeChange(value);
+            else onDroidPermissionModeChange?.(value);
+          }}
+        />
       );
     }
 
@@ -2616,34 +2599,20 @@ export function AgentChatComposer({
             value: modeId,
             label: cursorModeLabel(modeId),
           }));
+      const cursorModeOptions = modeChoices.map((option) => cursorPermissionPickerOption(option.value, option.label));
       return (
         <div className="flex flex-wrap items-center gap-2">
           {modeChoices.length ? (
-            <label
-              className={cn(
-                "flex h-8 min-h-8 items-center gap-2 rounded-md px-2",
-                plainComposerToolbarChrome
-                  ? "border border-transparent bg-transparent"
-                  : "border border-white/[0.06] bg-[#1a1a22] px-2.5 py-1.5",
-              )}
-            >
-              <span className="font-mono text-[length:calc(var(--chat-font-size)*9/14)] uppercase tracking-[0.16em] text-muted-fg/45">Mode</span>
-              <select
-                value={modeValue}
-                disabled={nativeControlsDisabled || (!onCursorModeChange && !parallelControlSlot)}
-                onChange={(event) => {
-                  if (parallelControlSlot) parallelControlSlot.onCursorModeChange(event.target.value);
-                  else onCursorModeChange?.(event.target.value);
-                }}
-                className="min-w-0 bg-transparent font-sans text-[length:calc(var(--chat-font-size)*11/14)] text-fg/82 outline-none disabled:cursor-not-allowed disabled:text-muted-fg/35"
-              >
-                {modeChoices.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
+            <PermissionModePicker
+              ariaLabel="Cursor mode"
+              selectedValue={modeValue || cursorModeOptions[0]?.value || ""}
+              options={cursorModeOptions}
+              disabled={nativeControlsDisabled || (!onCursorModeChange && !parallelControlSlot)}
+              onSelect={(value) => {
+                if (parallelControlSlot) parallelControlSlot.onCursorModeChange(value);
+                else onCursorModeChange?.(value);
+              }}
+            />
           ) : null}
           {cursorExtraOptions.map((option) => {
             if (option.type === "boolean") {
@@ -2722,39 +2691,20 @@ export function AgentChatComposer({
       );
     }
 
-    const runtimeLabel = sp === "cursor" ? "Mode" : "Permissions";
     return (
-      <label
-        className={cn(
-          "flex h-8 min-h-8 items-center gap-2 rounded-md px-2",
-          plainComposerToolbarChrome
-            ? "border border-transparent bg-transparent"
-            : "border border-white/[0.06] bg-[#1a1a22] px-2.5 py-1.5",
-        )}
-      >
-        <span className="font-mono text-[length:calc(var(--chat-font-size)*9/14)] uppercase tracking-[0.16em] text-muted-fg/45">{runtimeLabel}</span>
-        <select
-          value={opmUse}
-          disabled={nativeControlsDisabled || (!onOpenCodePermissionModeChange && !parallelControlSlot)}
-          onChange={(event) => {
-            const v = event.target.value as AgentChatOpenCodePermissionMode;
-            if (parallelControlSlot) parallelControlSlot.onOpenCodePermissionModeChange(v);
-            else onOpenCodePermissionModeChange?.(v);
-          }}
-          className="min-w-0 bg-transparent font-sans text-[length:calc(var(--chat-font-size)*11/14)] text-fg/82 outline-none disabled:cursor-not-allowed disabled:text-muted-fg/35"
-        >
-          {OPENCODE_PERMISSION_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-      </label>
+      <PermissionModePicker
+        ariaLabel="OpenCode permission mode"
+        selectedValue={opmUse ?? "edit"}
+        options={OPENCODE_PERMISSION_OPTIONS}
+        disabled={nativeControlsDisabled || (!onOpenCodePermissionModeChange && !parallelControlSlot)}
+        onSelect={(value) => {
+          if (parallelControlSlot) parallelControlSlot.onOpenCodePermissionModeChange(value);
+          else onOpenCodePermissionModeChange?.(value);
+        }}
+      />
     );
   }, [
     claudeSelectionMode,
-    claudeModePickerOpen,
-    codexPresetPickerOpen,
     applyCodexPreset,
     codexPreset,
     codexPresetOptions,

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.test.tsx
@@ -1756,7 +1756,7 @@ describe("AgentChatPane submit recovery", () => {
     expect(await screen.findByRole("button", { name: new RegExp(`current: ${escapeRegExp(modelLabel)}`, "i") })).toBeTruthy();
     expect((screen.getByRole("button", { name: "Fast mode" })).getAttribute("aria-pressed")).toBe("true");
     expect(screen.getByLabelText("Reasoning effort").textContent).toContain("XH");
-    expect(screen.getByRole("button", { name: "Codex approval preset" }).textContent).toContain("Full access");
+    expect(screen.getByRole("button", { name: "Codex permission mode" }).textContent).toContain("Full");
 
     const textbox = await screen.findByRole("textbox");
     fireEvent.change(textbox, { target: { value: "Launch with the restored config." } });
@@ -1817,9 +1817,9 @@ describe("AgentChatPane submit recovery", () => {
       availableModelIdsOverride: ["openai/gpt-5.4"],
     });
 
-    const approvalButton = await screen.findByRole("button", { name: "Codex approval preset" });
+    const approvalButton = await screen.findByRole("button", { name: "Codex permission mode" });
     await waitFor(() => {
-      expect(approvalButton.textContent).toContain("Full access");
+      expect(approvalButton.textContent).toContain("Full");
       expect((screen.getByRole("button", { name: "Fast mode" })).getAttribute("aria-pressed")).toBe("true");
       expect(screen.getByLabelText("Reasoning effort").textContent).toContain("HI");
     });
@@ -2704,7 +2704,7 @@ describe("AgentChatPane submit recovery", () => {
 
     renderPane(session);
 
-    fireEvent.click(await screen.findByRole("button", { name: "Codex approval preset" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Codex permission mode" }));
     fireEvent.click(await screen.findByRole("option", { name: "Full access" }));
 
     await waitFor(() => {
@@ -4052,7 +4052,7 @@ describe("AgentChatPane submit recovery", () => {
     });
   });
 
-  it("keeps Auto-create selected while reporting Primary as the Work tools lane", async () => {
+  it("keeps Auto-create selected while routing Work tools through Primary", async () => {
     installAdeMocks({ sessions: [] });
     const onLaneChange = vi.fn();
     renderAutoCreateDraftPane({ onLaneChange });
@@ -4062,7 +4062,6 @@ describe("AgentChatPane submit recovery", () => {
 
     expect(onLaneChange).toHaveBeenCalledWith("lane-primary");
     expect(await screen.findByText("Auto-create lane")).toBeTruthy();
-    expect(await screen.findByText("Tools use Primary until the lane is created.")).toBeTruthy();
   });
 
   it("falls back to the first available Work tools lane when Auto-create has no Primary lane", async () => {
@@ -4085,7 +4084,6 @@ describe("AgentChatPane submit recovery", () => {
     fireEvent.click(await screen.findByRole("button", { name: /Auto-create lane/i }));
 
     expect(onLaneChange).toHaveBeenCalledWith("lane-worktree");
-    expect(await screen.findByText("Tools use current-lane until the lane is created.")).toBeTruthy();
   });
 
   it("keeps orchestrator lead mode on the first Claude draft send", async () => {
@@ -5312,7 +5310,7 @@ describe("AgentChatPane submit recovery", () => {
     const codexLabel = getModelById("openai/gpt-5.4")?.displayName ?? "GPT-5.4";
     expect(await screen.findByRole("button", { name: new RegExp(`current: ${escapeRegExp(codexLabel)}`, "i") })).toBeTruthy();
 
-    fireEvent.click(await screen.findByRole("button", { name: "Codex approval preset" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Codex permission mode" }));
     fireEvent.click(await screen.findByRole("option", { name: "Plan mode" }));
 
     const textbox = await screen.findByRole("textbox");
@@ -5382,7 +5380,7 @@ describe("AgentChatPane submit recovery", () => {
     const codexLabel = getModelById("openai/gpt-5.4")?.displayName ?? "GPT-5.4";
     expect(await screen.findByRole("button", { name: new RegExp(`current: ${escapeRegExp(codexLabel)}`, "i") })).toBeTruthy();
 
-    fireEvent.click(await screen.findByRole("button", { name: "Codex approval preset" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Codex permission mode" }));
     fireEvent.click(await screen.findByRole("option", { name: "Edit mode" }));
 
     const textbox = await screen.findByRole("textbox");

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -1442,7 +1442,7 @@ function clampHandoffReasoningToModel(current: string | null, descriptor: ModelD
 }
 
 const HANDOFF_CLAUDE_MODES: Array<{ value: AgentChatClaudePermissionMode; label: string }> = [
-  { value: "default", label: "Ask permissions" },
+  { value: "default", label: "Manual" },
   { value: "acceptEdits", label: "Accept edits" },
   { value: "auto", label: "Auto" },
   { value: "plan", label: "Plan" },
@@ -9339,7 +9339,7 @@ export function AgentChatPane({
             <div className="space-y-0.5">
               <select
                 value={handoffCodexSelectValue}
-                title={handoffCodexPermissionPreset === "custom" ? "Non-standard policy; choosing a preset replaces it." : undefined}
+                title={handoffCodexPermissionPreset === "custom" ? "Non-standard policy; choosing a mode replaces it." : undefined}
                 onChange={(e) => {
                   const next = e.target.value as "default" | "plan" | "full-auto" | "config-toml";
                   const updated = handoffApplyCodexPreset(next, {
@@ -9351,7 +9351,7 @@ export function AgentChatPane({
                   setHandoffCodexConfigSource(updated.codexConfigSource);
                 }}
                 className={handoffSelectCls}
-                aria-label="Codex permission preset for handoff"
+                aria-label="Codex permission mode for handoff"
               >
                 <option value="default">Default — write + prompts on risk</option>
                 <option value="plan">Plan — read only + prompts</option>
@@ -9376,7 +9376,7 @@ export function AgentChatPane({
                 </button>
               ) : null}
               {handoffCodexPermissionPreset === "custom" ? (
-                <div className="text-[10px] text-amber-200/55">Session uses a custom policy; select a standard preset to apply to the new chat.</div>
+                <div className="text-[10px] text-amber-200/55">Session uses a custom policy; select a standard mode to apply to the new chat.</div>
               ) : null}
             </div>
           ) : null}
@@ -10969,11 +10969,6 @@ export function AgentChatPane({
                                       </button>
                                     </SmartTooltip>
                                   ) : null}
-                                </div>
-                              ) : null}
-                              {draftLaunchTargetIsAutoCreate && autoCreateToolsLane ? (
-                                <div className="font-sans text-[10px] leading-4 text-muted-fg/55">
-                                  Tools use {autoCreateToolsLane.name} until the lane is created.
                                 </div>
                               ) : null}
                             </div>

--- a/apps/desktop/src/renderer/components/prs/shared/PrResolverLaunchControls.test.tsx
+++ b/apps/desktop/src/renderer/components/prs/shared/PrResolverLaunchControls.test.tsx
@@ -68,19 +68,19 @@ describe("PrResolverLaunchControls", () => {
     delete (window as unknown as { ade?: unknown }).ade;
   });
 
-  it("uses Work-tab Claude permission presets, including ask permissions", async () => {
+  it("uses Work-tab Claude permission modes, including manual", async () => {
     const user = userEvent.setup();
     const props = renderControls({
       modelId: "anthropic/claude-opus-4-8",
       permissionMode: "default",
     });
 
-    expect(screen.getByRole("button", { name: "Ask permissions" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Manual" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Accept edits" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Plan" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Bypass" })).toBeTruthy();
 
-    await user.click(screen.getByRole("button", { name: "Ask permissions" }));
+    await user.click(screen.getByRole("button", { name: "Manual" }));
     expect(props.onPermissionModeChange).toHaveBeenCalledWith("default");
   });
 

--- a/apps/desktop/src/renderer/components/prs/shared/PrResolverLaunchControls.tsx
+++ b/apps/desktop/src/renderer/components/prs/shared/PrResolverLaunchControls.tsx
@@ -117,7 +117,7 @@ function toLegacyPermissionMode(mode: AgentChatPermissionMode, providerGroup: Mo
 
 function labelForPermissionOption(value: AgentChatPermissionMode, label: string, providerGroup: ModelProviderGroup): string {
   if (providerGroup === "claude") {
-    if (value === "default") return "Ask permissions";
+    if (value === "default") return "Manual";
     if (value === "edit") return "Accept edits";
     if (value === "plan") return "Plan";
     if (value === "full-auto") return "Bypass";

--- a/apps/desktop/src/renderer/components/shared/ModelPicker/ReasoningEffortPicker.tsx
+++ b/apps/desktop/src/renderer/components/shared/ModelPicker/ReasoningEffortPicker.tsx
@@ -1,6 +1,6 @@
-import { forwardRef, memo, useCallback, useMemo, useState } from "react";
+import { forwardRef, memo, useCallback, useEffect, useMemo, useState } from "react";
 import * as Popover from "@radix-ui/react-popover";
-import { CaretDown } from "@phosphor-icons/react";
+import { CaretDown, Question } from "@phosphor-icons/react";
 import type { ModelDescriptor } from "../../../../shared/modelRegistry";
 import { cn } from "../../ui/cn";
 import { resolveModelDescriptorWithRuntimeCatalog } from "./modelCatalog";
@@ -39,6 +39,144 @@ function tierLabel(tier: string): string {
   return tier.charAt(0).toUpperCase() + tier.slice(1);
 }
 
+const reasoningSliderStyleId = "ade-reasoning-slider-effects";
+
+function ensureReasoningSliderStyles(): void {
+  if (typeof document === "undefined") return;
+  if (document.getElementById(reasoningSliderStyleId)) return;
+  const sheet = document.createElement("style");
+  sheet.id = reasoningSliderStyleId;
+  sheet.textContent = `
+    @keyframes ade-reasoning-effort-word-pop {
+      0% { opacity: 0; transform: translateY(3px); filter: blur(3px); }
+      100% { opacity: 1; transform: translateY(0); filter: blur(0); }
+    }
+    @keyframes ade-reasoning-fill-sheen {
+      0% { transform: translateX(-80%); opacity: 0; }
+      35% { opacity: 0.55; }
+      100% { transform: translateX(80%); opacity: 0; }
+    }
+    @keyframes ade-reasoning-grid-drift {
+      0% { background-position: 0 0, 0 0; }
+      100% { background-position: -18px 0, 0 0; }
+    }
+    .ade-reasoning-effort-word {
+      animation: ade-reasoning-effort-word-pop 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
+    }
+    .ade-reasoning-slider-fill {
+      background: linear-gradient(90deg, rgba(var(--reasoning-fill-rgb), 0.38), rgba(var(--reasoning-fill-rgb), 0.82));
+      box-shadow: 0 0 18px rgba(var(--reasoning-fill-rgb), 0.24);
+      transition: width 220ms cubic-bezier(0.2, 0.8, 0.2, 1), background 220ms ease, box-shadow 220ms ease;
+    }
+    .ade-reasoning-slider-fill::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      background: linear-gradient(100deg, transparent 20%, rgba(255,255,255,0.22) 50%, transparent 78%);
+      animation: ade-reasoning-fill-sheen 1.8s ease-in-out infinite;
+    }
+    .ade-reasoning-slider-fill-max {
+      background:
+        radial-gradient(circle at center, rgba(255,255,255,0.20) 0 0.8px, transparent 1px),
+        linear-gradient(90deg, rgba(124,58,237,0.34), rgba(216,180,254,0.86));
+      background-size: 4px 4px, 100% 100%;
+      animation: ade-reasoning-grid-drift 1.15s linear infinite;
+      box-shadow: 0 0 24px rgba(167,139,250,0.34);
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .ade-reasoning-effort-word,
+      .ade-reasoning-slider-fill::after,
+      .ade-reasoning-slider-fill-max {
+        animation: none;
+      }
+      .ade-reasoning-slider-fill {
+        transition: none;
+      }
+    }
+  `;
+  document.head.appendChild(sheet);
+}
+
+type ReasoningToneKey = "auto" | "low" | "steady" | "smart" | "deep" | "max";
+
+const REASONING_TONE_STYLES: Record<
+  ReasoningToneKey,
+  {
+    color: string;
+    rgb: string;
+    trigger: string;
+    chip: string;
+    thumb: string;
+    ridge: string;
+  }
+> = {
+  auto: {
+    color: "#A1A1AA",
+    rgb: "161 161 170",
+    trigger: "border-white/[0.06] bg-white/[0.03] text-fg/80 hover:border-white/[0.10] hover:bg-white/[0.055]",
+    chip: "border-white/[0.08] bg-white/[0.055] text-muted-fg/78",
+    thumb: "border-zinc-200/70 bg-zinc-200 text-zinc-950",
+    ridge: "bg-white/20",
+  },
+  low: {
+    color: "#6EE7B7",
+    rgb: "52 211 153",
+    trigger: "border-emerald-300/22 bg-emerald-500/[0.075] text-emerald-100 hover:border-emerald-300/32 hover:bg-emerald-500/[0.11]",
+    chip: "border-emerald-300/26 bg-emerald-500/[0.14] text-emerald-100",
+    thumb: "border-emerald-50 bg-emerald-200 text-emerald-950",
+    ridge: "bg-emerald-200",
+  },
+  steady: {
+    color: "#67E8F9",
+    rgb: "34 211 238",
+    trigger: "border-cyan-300/22 bg-cyan-500/[0.075] text-cyan-100 hover:border-cyan-300/32 hover:bg-cyan-500/[0.11]",
+    chip: "border-cyan-300/26 bg-cyan-500/[0.14] text-cyan-100",
+    thumb: "border-cyan-50 bg-cyan-200 text-cyan-950",
+    ridge: "bg-cyan-200",
+  },
+  smart: {
+    color: "#93C5FD",
+    rgb: "96 165 250",
+    trigger: "border-sky-300/22 bg-sky-500/[0.075] text-sky-100 hover:border-sky-300/32 hover:bg-sky-500/[0.11]",
+    chip: "border-sky-300/26 bg-sky-500/[0.14] text-sky-100",
+    thumb: "border-sky-50 bg-sky-200 text-sky-950",
+    ridge: "bg-sky-200",
+  },
+  deep: {
+    color: "#C4B5FD",
+    rgb: "167 139 250",
+    trigger: "border-violet-300/24 bg-violet-500/[0.08] text-violet-100 hover:border-violet-300/34 hover:bg-violet-500/[0.12]",
+    chip: "border-violet-300/28 bg-violet-500/[0.15] text-violet-100",
+    thumb: "border-violet-50 bg-violet-200 text-violet-950",
+    ridge: "bg-violet-200",
+  },
+  max: {
+    color: "#D8B4FE",
+    rgb: "192 132 252",
+    trigger: "border-fuchsia-300/28 bg-fuchsia-500/[0.09] text-fuchsia-100 hover:border-fuchsia-300/38 hover:bg-fuchsia-500/[0.13]",
+    chip: "border-fuchsia-300/30 bg-fuchsia-500/[0.17] text-fuchsia-100",
+    thumb: "border-fuchsia-50 bg-fuchsia-100 text-fuchsia-950",
+    ridge: "bg-fuchsia-100",
+  },
+};
+
+function reasoningToneKeyForIndex(index: number, total: number): ReasoningToneKey {
+  if (index < 0) return "auto";
+  if (total <= 1) return "max";
+  const ratio = index / (total - 1);
+  if (ratio <= 0.12) return "low";
+  if (ratio <= 0.38) return "steady";
+  if (ratio <= 0.62) return "smart";
+  if (ratio < 1) return "deep";
+  return "max";
+}
+
+function tierPercent(index: number, total: number): number {
+  if (total <= 1) return 50;
+  return (index / (total - 1)) * 100;
+}
+
 export const ReasoningEffortPicker = memo(function ReasoningEffortPicker({
   modelId,
   reasoningEffort,
@@ -51,6 +189,9 @@ export const ReasoningEffortPicker = memo(function ReasoningEffortPicker({
 }: ReasoningEffortPickerProps) {
   const [open, setOpen] = useState(false);
   const { rememberReasoning, getReasoningForFamily } = useReasoningByFamily();
+  useEffect(() => {
+    ensureReasoningSliderStyles();
+  }, []);
 
   const descriptor = useMemo<ModelDescriptor | undefined>(
     () => resolveModelDescriptorWithRuntimeCatalog(modelId),
@@ -66,14 +207,64 @@ export const ReasoningEffortPicker = memo(function ReasoningEffortPicker({
     return null;
   }, [reasoningEffort, family, getReasoningForFamily, useFamilyDefaults]);
 
-  const handleSelect = useCallback(
-    (tier: string) => {
-      const next = displayedEffort === tier ? null : tier;
+  const activeIndex = displayedEffort ? tiers.findIndex((tier) => tier === displayedEffort) : -1;
+  const activeTone = REASONING_TONE_STYLES[reasoningToneKeyForIndex(activeIndex, tiers.length)];
+  const activeLabel = activeIndex >= 0 ? tierLabel(tiers[activeIndex]!) : "Auto";
+  const fillPercent = activeIndex < 0 ? 0 : tiers.length <= 1 ? 100 : tierPercent(activeIndex, tiers.length);
+  const thumbPercent = activeIndex < 0 ? 0 : tierPercent(activeIndex, tiers.length);
+  const thumbLeft = activeIndex < 0 || tiers.length <= 1
+    ? activeIndex < 0 ? "8px" : "50%"
+    : `calc(${thumbPercent}% + ${8 - (thumbPercent / 100) * 16}px)`;
+
+  const commitEffort = useCallback(
+    (tier: string | null) => {
+      const next = tier;
       if (useFamilyDefaults && family) rememberReasoning(family, next);
       onChange(next);
+    },
+    [family, onChange, rememberReasoning, useFamilyDefaults],
+  );
+
+  const handleSelect = useCallback(
+    (tier: string) => {
+      commitEffort(displayedEffort === tier ? null : tier);
       setOpen(false);
     },
-    [displayedEffort, family, onChange, rememberReasoning, useFamilyDefaults],
+    [commitEffort, displayedEffort],
+  );
+
+  const handleTrackPointer = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (disabled || tiers.length === 0) return;
+      const target = event.target as Element | null;
+      if (target?.closest?.("[data-reasoning-slider-ridge-button]")) return;
+      const rect = event.currentTarget.getBoundingClientRect();
+      const ratio = rect.width > 0 ? (event.clientX - rect.left) / rect.width : 0;
+      const clamped = Math.max(0, Math.min(1, ratio));
+      const nextIndex = tiers.length <= 1 ? 0 : Math.round(clamped * (tiers.length - 1));
+      commitEffort(tiers[nextIndex] ?? null);
+    },
+    [commitEffort, disabled, tiers],
+  );
+
+  const handleSliderKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (disabled || tiers.length === 0) return;
+      let nextIndex: number | null = null;
+      if (event.key === "ArrowRight" || event.key === "ArrowUp") {
+        nextIndex = Math.min(tiers.length - 1, activeIndex < 0 ? 0 : activeIndex + 1);
+      } else if (event.key === "ArrowLeft" || event.key === "ArrowDown") {
+        nextIndex = Math.max(0, activeIndex < 0 ? 0 : activeIndex - 1);
+      } else if (event.key === "Home") {
+        nextIndex = 0;
+      } else if (event.key === "End") {
+        nextIndex = tiers.length - 1;
+      }
+      if (nextIndex == null) return;
+      event.preventDefault();
+      commitEffort(tiers[nextIndex] ?? null);
+    },
+    [activeIndex, commitEffort, disabled, tiers],
   );
 
   if (tiers.length === 0) return null;
@@ -94,6 +285,7 @@ export const ReasoningEffortPicker = memo(function ReasoningEffortPicker({
       <Popover.Trigger asChild>
         <ReasoningEffortTrigger
           label={label}
+          tone={activeTone}
           compact={compact}
           disabled={disabled}
           open={open}
@@ -115,46 +307,88 @@ export const ReasoningEffortPicker = memo(function ReasoningEffortPicker({
           <div
             data-reasoning-effort-picker-content="true"
             className={cn(
-              "flex min-w-[140px] flex-col overflow-hidden rounded-lg border border-white/[0.08]",
-              "bg-[#13111A]/95 p-1 shadow-[0_18px_48px_rgba(0,0,0,0.55)] backdrop-blur-md",
+              "flex w-[232px] flex-col overflow-hidden rounded-xl border border-white/[0.08]",
+              "bg-[#17151A]/96 p-3 shadow-[0_18px_48px_rgba(0,0,0,0.58)] backdrop-blur-md",
             )}
             role="radiogroup"
             aria-label="Reasoning effort"
+            style={{
+              "--reasoning-fill-rgb": activeTone.rgb,
+            } as React.CSSProperties}
           >
-            <div className="px-2 py-1 text-[9px] font-semibold uppercase tracking-wide text-muted-fg/55">
-              Thinking
-            </div>
-            {tiers.map((tier) => {
-              const isActive = displayedEffort === tier;
-              return (
-                <button
-                  key={tier}
-                  type="button"
-                  role="radio"
-                  aria-checked={isActive}
-                  onClick={() => handleSelect(tier)}
-                  className={cn(
-                    "flex items-center justify-between gap-3 rounded-md px-2 py-1.5 text-left font-sans text-[11px] font-medium leading-none",
-                    "transition-colors duration-150",
-                    isActive
-                      ? "bg-violet-500/15 text-fg shadow-[inset_0_0_0_1px_rgba(167,139,250,0.30)]"
-                      : "text-muted-fg/75 hover:bg-white/[0.04] hover:text-fg/90",
-                  )}
+            <div className="flex items-center justify-between gap-3">
+              <div className="min-w-0 font-sans text-[12px] leading-none text-muted-fg/72">
+                <span>Effort </span>
+                <span
+                  key={displayedEffort ?? "auto"}
+                  className="ade-reasoning-effort-word font-semibold"
+                  style={{ color: activeTone.color }}
                 >
-                  <span>{tierLabel(tier)}</span>
-                  <span
-                    className={cn(
-                      "rounded border px-1 py-[1px] text-[8px] font-semibold uppercase tracking-wide leading-none",
-                      isActive
-                        ? "border-violet-400/40 bg-violet-500/[0.18] text-violet-100"
-                        : "border-white/[0.08] bg-white/[0.03] text-muted-fg/60",
-                    )}
-                  >
-                    {reasoningChipLabel(tier)}
-                  </span>
-                </button>
-              );
-            })}
+                  {activeLabel}
+                </span>
+              </div>
+              <Question size={13} weight="bold" className="shrink-0 text-muted-fg/45" aria-hidden />
+            </div>
+            <div className="mt-4 flex items-center justify-between font-sans text-[11px] leading-none text-muted-fg/62">
+              <span>Faster</span>
+              <span>Smarter</span>
+            </div>
+            <div
+              className="relative mt-3 h-[18px] cursor-pointer rounded-md bg-[#242327] p-[3px] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.045),inset_0_1px_3px_rgba(0,0,0,0.45)]"
+              onPointerDown={handleTrackPointer}
+              role="presentation"
+            >
+              <div className="relative h-full overflow-hidden rounded-[5px] bg-black/18">
+                <div
+                  className={cn(
+                    "ade-reasoning-slider-fill absolute inset-y-0 left-0 overflow-hidden rounded-[5px]",
+                    activeIndex === tiers.length - 1 && activeIndex >= 0 && "ade-reasoning-slider-fill-max",
+                  )}
+                  style={{ width: `${fillPercent}%` }}
+                  aria-hidden
+                />
+                {tiers.map((tier, index) => {
+                  const percent = tierPercent(index, tiers.length);
+                  const isActive = displayedEffort === tier;
+                  const tone = REASONING_TONE_STYLES[reasoningToneKeyForIndex(index, tiers.length)];
+                  return (
+                    <button
+                      key={tier}
+                      type="button"
+                      role="radio"
+                      aria-checked={isActive}
+                      aria-label={tierLabel(tier)}
+                      data-reasoning-slider-ridge-button
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        handleSelect(tier);
+                      }}
+                      onKeyDown={handleSliderKeyDown}
+                      className="absolute top-1/2 flex h-7 w-7 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full outline-none focus-visible:ring-2 focus-visible:ring-white/40"
+                      style={{ left: `${percent}%` }}
+                    >
+                      <span className="sr-only">{tierLabel(tier)}</span>
+                      <span
+                        className={cn(
+                          "h-1 w-1 rounded-full transition-all duration-200",
+                          isActive ? cn("h-1.5 w-1.5", tone.ridge, "shadow-[0_0_10px_currentColor]") : "bg-white/20",
+                        )}
+                        aria-hidden
+                      />
+                    </button>
+                  );
+                })}
+                <div
+                  className={cn(
+                    "pointer-events-none absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-md border shadow-[0_3px_10px_rgba(0,0,0,0.32)] transition-[left,background-color,border-color,box-shadow] duration-200",
+                    activeTone.thumb,
+                    activeIndex < 0 && "opacity-60",
+                  )}
+                  style={{ left: thumbLeft }}
+                  aria-hidden
+                />
+              </div>
+            </div>
           </div>
         </Popover.Content>
       </Popover.Portal>
@@ -164,6 +398,7 @@ export const ReasoningEffortPicker = memo(function ReasoningEffortPicker({
 
 type TriggerProps = {
   label: string;
+  tone: (typeof REASONING_TONE_STYLES)[ReasoningToneKey];
   compact: boolean;
   disabled: boolean;
   open: boolean;
@@ -173,7 +408,7 @@ type TriggerProps = {
 const ReasoningEffortTrigger = memo(
   forwardRef<HTMLButtonElement, TriggerProps & React.ButtonHTMLAttributes<HTMLButtonElement>>(
     function ReasoningEffortTrigger(
-      { label, compact, disabled, open, className, ...rest },
+      { label, tone, compact, disabled, open, className, ...rest },
       ref,
     ) {
       return (
@@ -193,9 +428,8 @@ const ReasoningEffortTrigger = memo(
             compact
               ? "h-6 px-1 text-[9px]"
               : "h-8 px-2 text-[11px] sm:text-[12px]",
-            "border-white/[0.06] bg-white/[0.03] text-fg/80",
-            "hover:border-violet-400/20 hover:bg-violet-500/[0.06] hover:text-fg",
-            open && "border-violet-400/30 bg-violet-500/[0.08] text-fg",
+            tone.trigger,
+            open && "ring-1 ring-white/[0.06]",
             disabled && "cursor-not-allowed opacity-60 hover:border-white/[0.06] hover:bg-white/[0.03]",
             className,
           )}
@@ -203,7 +437,8 @@ const ReasoningEffortTrigger = memo(
           <span
             data-reasoning-chip="true"
             className={cn(
-              "shrink-0 rounded border border-violet-400/25 bg-violet-500/[0.12] px-1 font-semibold uppercase leading-none tracking-wide text-violet-100/90",
+              "shrink-0 rounded border px-1 font-semibold uppercase leading-none tracking-wide",
+              tone.chip,
               compact ? "py-[1px] text-[8px]" : "py-[2px] text-[9px]",
             )}
           >

--- a/apps/desktop/src/renderer/components/shared/permissionOptions.ts
+++ b/apps/desktop/src/renderer/components/shared/permissionOptions.ts
@@ -88,7 +88,7 @@ export function getPermissionOptions(opts: {
     return [
       {
         value: "default",
-        label: "Default",
+        label: "Manual",
         shortDesc: "Prompts before each tool type on first use",
         detail: "Standard behavior. Read operations are free; writes, edits, and Bash commands require your approval on first use per session.",
         allows: ["File reads", "Grep / Glob / LS", "Plan generation"],

--- a/apps/desktop/src/renderer/lib/nativeLaunchControls.ts
+++ b/apps/desktop/src/renderer/lib/nativeLaunchControls.ts
@@ -326,11 +326,11 @@ export type ClaudePermissionOption = {
 };
 
 export const CLAUDE_PERMISSION_OPTIONS: ClaudePermissionOption[] = [
-  { value: "default", label: "Ask permissions", detail: "Claude asks before edits, Bash, and other sensitive tools." },
+  { value: "default", label: "Manual", detail: "Claude asks before edits, Bash, and other sensitive tools." },
   { value: "auto", label: "Auto", detail: "Claude judges each tool call." },
   { value: "acceptEdits", label: "Accept edits", detail: "File edits are auto-approved; higher-risk actions still prompt." },
   { value: "plan", label: "Plan mode", detail: "Read-only Claude turns for analysis and implementation planning." },
-  { value: "bypassPermissions", label: "Bypass permissions", detail: "Skip every Claude permission prompt for this chat." },
+  { value: "bypassPermissions", label: "Bypass", detail: "Skip every Claude permission prompt for this chat." },
 ];
 
 export const CODEX_PERMISSION_PRESETS = [

--- a/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
@@ -292,7 +292,7 @@ struct WorkComposerControlsRow: View {
 
   @ViewBuilder
   private var collapsedAccessControl: some View {
-    let tint = workRuntimeModeTint(currentMode)
+    let tint = workRuntimeModeTint(provider: provider, mode: currentMode)
 
     if modeOptions.isEmpty || onSelectMode == nil {
       collapsedDotButton(tint: tint, glyph: nil)
@@ -340,13 +340,13 @@ struct WorkComposerControlsRow: View {
   @ViewBuilder
   private var accessPill: some View {
     if modeOptions.isEmpty || onSelectMode == nil {
-      pillContent(dotColor: workRuntimeModeTint(currentMode), label: modeLabel, showChevron: false)
+      pillContent(dotColor: workRuntimeModeTint(provider: provider, mode: currentMode), label: modeLabel, showChevron: false)
     } else {
       HStack(spacing: 6) {
         ForEach(modeOptions) { option in
           composerOptionChip(
             title: option.title,
-            tint: workRuntimeModeTint(option.id),
+            tint: workRuntimeModeTint(provider: provider, mode: option.id),
             isSelected: option.id == currentMode,
             accessibilityPrefix: "Access mode"
           ) {

--- a/apps/ios/ADE/Views/Work/WorkSessionSettingsSheet+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionSettingsSheet+Actions.swift
@@ -160,6 +160,7 @@ extension WorkSessionSettingsSheet {
   }
 
   func runtimeCard(option: WorkRuntimeOption, isSelected: Bool) -> some View {
+    let tint = workRuntimeModeTint(provider: summary.provider, mode: option.id)
     VStack(alignment: .leading, spacing: 8) {
       HStack(spacing: 10) {
         VStack(alignment: .leading, spacing: 4) {
@@ -176,7 +177,7 @@ extension WorkSessionSettingsSheet {
 
         if isSelected {
           Image(systemName: "checkmark.circle.fill")
-            .foregroundStyle(ADEColor.accent)
+            .foregroundStyle(tint)
         }
       }
     }
@@ -184,11 +185,11 @@ extension WorkSessionSettingsSheet {
     .padding(12)
     .background(
       RoundedRectangle(cornerRadius: 16, style: .continuous)
-        .fill(isSelected ? providerTint(summary.provider).opacity(0.14) : ADEColor.surfaceBackground.opacity(0.55))
+        .fill(isSelected ? tint.opacity(0.14) : ADEColor.surfaceBackground.opacity(0.55))
     )
     .overlay(
       RoundedRectangle(cornerRadius: 16, style: .continuous)
-        .stroke(isSelected ? providerTint(summary.provider).opacity(0.42) : ADEColor.border.opacity(0.18), lineWidth: isSelected ? 1.3 : 0.8)
+        .stroke(isSelected ? tint.opacity(0.42) : ADEColor.border.opacity(0.18), lineWidth: isSelected ? 1.3 : 0.8)
     )
     .glassEffect(in: .rect(cornerRadius: 16))
   }

--- a/apps/ios/ADE/Views/Work/WorkStatusAndFormattingHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkStatusAndFormattingHelpers.swift
@@ -708,12 +708,55 @@ func workRuntimeModeLabel(provider: String, mode: String) -> String {
   }
 }
 
+func workRuntimeModeTint(provider: String, mode: String) -> Color {
+  switch provider.lowercased() {
+  case "claude":
+    switch mode {
+    case "plan": return ADEColor.purpleAccent
+    case "full-auto": return ADEColor.danger
+    case "auto", "edit": return ADEColor.warning
+    default: return ADEColor.success
+    }
+  case "codex":
+    switch mode {
+    case "plan": return ADEColor.purpleAccent
+    case "full-auto": return ADEColor.danger
+    case "edit": return ADEColor.warning
+    case "config-toml": return ADEColor.textSecondary
+    default: return ADEColor.success
+    }
+  case "opencode":
+    switch mode {
+    case "plan": return ADEColor.purpleAccent
+    case "full-auto": return ADEColor.danger
+    case "config-toml": return ADEColor.textSecondary
+    default: return ADEColor.warning
+    }
+  case "cursor":
+    switch mode {
+    case "plan": return ADEColor.purpleAccent
+    case "full-auto": return ADEColor.danger
+    default: return ADEColor.success
+    }
+  case "droid", "factory":
+    switch mode {
+    case "auto-high", "full-auto": return ADEColor.danger
+    case "auto-medium", "default": return ADEColor.warning
+    case "agi": return ADEColor.purpleAccent
+    default: return ADEColor.success
+    }
+  default:
+    return workRuntimeModeTint(mode)
+  }
+}
+
 func workRuntimeModeTint(_ mode: String) -> Color {
   switch mode {
   case "full-auto", "auto-high": return ADEColor.danger
-  case "edit", "auto", "ask", "auto-low", "auto-medium", "default": return ADEColor.warning
+  case "edit", "auto", "ask", "auto-low", "auto-medium", "default": return ADEColor.success
   case "agi": return ADEColor.purpleAccent
-  case "plan", "read-only": return ADEColor.accent
+  case "plan": return ADEColor.purpleAccent
+  case "read-only": return ADEColor.success
   default: return ADEColor.textSecondary
   }
 }


### PR DESCRIPTION
## Summary

_Describe the change._

## What Changed

_Key files and behaviors._

## Validation

_How you tested._

## Risks

_Anything to watch._

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstart-skill-gonn-ame-ui-85ceacf7 num=750 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstart-skill-gonn-ame-ui-85ceacf7&amp;pr=750">ade/start-skill-gonn-ame-ui-85ceacf7 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=750">PR #750</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes the prompt-box controls on desktop and iOS. The main changes are:

- Shared permission-mode picker UI for Claude, Codex, Droid, Cursor, and OpenCode controls.
- Updated permission labels, icons, and safety tinting across chat and PR resolver launch controls.
- Redesigned reasoning-effort picker as a colored slider popover.
- Matching iOS composer and settings tint updates for runtime modes.
- Test updates for the renamed controls and revised picker interactions.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are UI-focused label and control refactors, and the existing launch payload mappings remain preserved. Updated tests cover the renamed controls and picker interactions. No functional or security issues were identified in the reviewed changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification but its local artifact references were not uploaded.
- A focused verification log was saved containing the exact Vitest command, cwd, timestamps, Vitest stdout, per-file pass counts, aggregate test counts, and EXIT\_CODE: 0, with a note that a shell substitution issue occurred after the run but did not indicate a test failure.

<a href="https://app.greptile.com/trex/runs/13808012/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx | Replaces provider-specific permission selects/dropdowns with a shared icon/tone permission picker. |
| apps/desktop/src/renderer/components/shared/ModelPicker/ReasoningEffortPicker.tsx | Redesigns reasoning effort selection as a colored popover slider while preserving selection behavior. |
| apps/desktop/src/renderer/components/prs/shared/PrResolverLaunchControls.tsx | Aligns Claude PR resolver permission labels with Work-tab terminology. |
| apps/desktop/src/renderer/lib/nativeLaunchControls.ts | Updates exported native control labels for Claude permissions. |
| apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift | Uses provider/mode-specific tints for mobile composer access controls. |
| apps/ios/ADE/Views/Work/WorkStatusAndFormattingHelpers.swift | Adds provider-aware runtime mode tint helpers and updates generic mode coloring. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant User
  participant Composer as Prompt box controls
  participant Picker as Permission/Reasoning picker
  participant State as Native control state
  participant Runtime as Launch/session update payload

  User->>Composer: Open prompt box controls
  Composer->>Picker: Render provider-specific options and current value
  User->>Picker: Select permission mode or reasoning tier
  Picker->>State: Invoke provider-specific change callback
  State->>Runtime: Map selected UI mode to launch/session fields
  Runtime-->>Composer: Reflect updated labels, tint, and summary chips
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant User
  participant Composer as Prompt box controls
  participant Picker as Permission/Reasoning picker
  participant State as Native control state
  participant Runtime as Launch/session update payload

  User->>Composer: Open prompt box controls
  Composer->>Picker: Render provider-specific options and current value
  User->>Picker: Select permission mode or reasoning tier
  Picker->>State: Invoke provider-specific change callback
  State->>Runtime: Map selected UI mode to launch/session fields
  Runtime-->>Composer: Reflect updated labels, tint, and summary chips
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Polish chat permission and effort picker..."](https://github.com/arul28/ade/commit/cb41f65e055b47831bfae6d420b7ba37e3c91bf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42949562)</sub>

<!-- /greptile_comment -->