### PR TITLE
fix(updates): simplify and center the post-update modal

### DIFF
--- a/apps/desktop/src/main/services/updates/autoUpdateService.test.ts
+++ b/apps/desktop/src/main/services/updates/autoUpdateService.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildReleaseNotesUrl, compareUpdateVersions, createAutoUpdateService } from "./autoUpdateService";
+import { buildGithubReleaseUrl, buildReleaseNotesUrl, compareUpdateVersions, createAutoUpdateService } from "./autoUpdateService";
 import type { Logger } from "../logging/logger";
 
 const electronAppMock = vi.hoisted(() => ({ isPackaged: false }));
@@ -61,6 +61,14 @@ describe("buildReleaseNotesUrl", () => {
     expect(buildReleaseNotesUrl("v1.2.11")).toBe("https://www.ade-app.dev/docs/changelog/v1.2.11");
     expect(buildReleaseNotesUrl("1.2.11", "https://staging.ade-app.dev/")).toBe("https://staging.ade-app.dev/docs/changelog/v1.2.11");
     expect(buildReleaseNotesUrl(" ", "https://www.ade-app.dev")).toBeNull();
+  });
+});
+
+describe("buildGithubReleaseUrl", () => {
+  it("points at the GitHub release tag and normalizes the version", () => {
+    expect(buildGithubReleaseUrl("1.2.18")).toBe("https://github.com/arul28/ADE/releases/tag/v1.2.18");
+    expect(buildGithubReleaseUrl("v1.2.18")).toBe("https://github.com/arul28/ADE/releases/tag/v1.2.18");
+    expect(buildGithubReleaseUrl(" ")).toBeNull();
   });
 });
 
@@ -188,6 +196,7 @@ describe("createAutoUpdateService", () => {
       version: "1.2.3",
       installedAt: "2026-04-06T15:21:00.000Z",
       releaseNotesUrl: "https://www.ade-app.dev/docs/changelog/v1.2.3",
+      githubReleaseUrl: "https://github.com/arul28/ADE/releases/tag/v1.2.3",
     });
 
     expect(JSON.parse(fs.readFileSync(globalStatePath, "utf8"))).toEqual({
@@ -195,6 +204,7 @@ describe("createAutoUpdateService", () => {
         version: "1.2.3",
         installedAt: "2026-04-06T15:21:00.000Z",
         releaseNotesUrl: "https://www.ade-app.dev/docs/changelog/v1.2.3",
+        githubReleaseUrl: "https://github.com/arul28/ADE/releases/tag/v1.2.3",
       },
     });
     expectCacheEmpty(updaterCacheDir);
@@ -652,6 +662,7 @@ describe("createAutoUpdateService", () => {
       version: "1.2.4",
       installedAt: "2026-04-06T15:21:00.000Z",
       releaseNotesUrl: "https://www.ade-app.dev/docs/changelog/v1.2.4",
+      githubReleaseUrl: "https://github.com/arul28/ADE/releases/tag/v1.2.4",
     });
     expectCacheEmpty(updaterCacheDir);
 

--- a/apps/desktop/src/main/services/updates/autoUpdateService.ts
+++ b/apps/desktop/src/main/services/updates/autoUpdateService.ts
@@ -135,10 +135,29 @@ export function buildReleaseNotesUrl(
   return `${normalizedBaseUrl}/docs/changelog/${encodeURIComponent(`v${normalizedVersion}`)}`;
 }
 
+// Deterministic GitHub release page for a version tag, e.g.
+// https://github.com/arul28/ADE/releases/tag/v1.2.18 — the same repo the
+// updater feed points at above.
+export function buildGithubReleaseUrl(version: string): string | null {
+  const normalizedVersion = version.trim().replace(/^v/i, "");
+  if (!normalizedVersion) return null;
+  return `https://github.com/arul28/ADE/releases/tag/${encodeURIComponent(`v${normalizedVersion}`)}`;
+}
+
 function cloneRecentlyInstalledUpdate(
   update: RecentlyInstalledUpdate | null,
 ): RecentlyInstalledUpdate | null {
   return update ? { ...update } : null;
+}
+
+// Backfills the GitHub release URL for updates persisted before that field
+// existed, so the renderer always has a "View on GitHub" target.
+function withGithubReleaseUrl(
+  update: RecentlyInstalledUpdate | null,
+): RecentlyInstalledUpdate | null {
+  if (!update) return null;
+  if (update.githubReleaseUrl) return update;
+  return { ...update, githubReleaseUrl: buildGithubReleaseUrl(update.version) };
 }
 
 function cloneSnapshot(snapshot: AutoUpdateSnapshot): AutoUpdateSnapshot {
@@ -221,6 +240,7 @@ function reconcilePersistedUpdateState(args: {
         installedAt: args.now,
         releaseNotesUrl: buildReleaseNotesUrl(args.currentVersion, args.releaseNotesBaseUrl)
           ?? pendingInstall.releaseNotesUrl,
+        githubReleaseUrl: buildGithubReleaseUrl(args.currentVersion),
       };
       cacheCleanupReason = "installed";
     } else {
@@ -233,7 +253,9 @@ function reconcilePersistedUpdateState(args: {
   return {
     state: nextState,
     changed,
-    recentlyInstalled: cloneRecentlyInstalledUpdate(nextState.recentlyInstalledUpdate ?? null),
+    recentlyInstalled: withGithubReleaseUrl(
+      cloneRecentlyInstalledUpdate(nextState.recentlyInstalledUpdate ?? null),
+    ),
     cacheCleanupReason,
   };
 }

--- a/apps/desktop/src/renderer/components/app/AutoUpdateControl.test.tsx
+++ b/apps/desktop/src/renderer/components/app/AutoUpdateControl.test.tsx
@@ -71,22 +71,35 @@ function installAdeMock(args: {
   updateCheckForUpdates?: () => Promise<void>;
 } = {}) {
   const updateCheckForUpdates = vi.fn(args.updateCheckForUpdates ?? (async () => undefined));
+  const openExternal = vi.fn(async () => undefined);
+  const updateDismissInstalledNotice = vi.fn(async () => undefined);
   Object.defineProperty(window, "ade", {
     configurable: true,
     value: {
       app: {
         getInfo: vi.fn(async () => args.appInfo ?? appInfoWithRuntimeSkew("none")),
+        openExternal,
       },
       updateGetState: vi.fn(async () => args.snapshot ?? idleSnapshot),
       updateCheckForUpdates,
       updateGetInstallImpact: vi.fn(async () => ({ connectedPhones: [] })),
       updateQuitAndInstall: vi.fn(async () => true),
-      updateDismissInstalledNotice: vi.fn(async () => undefined),
+      updateDismissInstalledNotice,
       onUpdateEvent: vi.fn(() => () => undefined),
     },
   });
-  return { updateCheckForUpdates };
+  return { updateCheckForUpdates, openExternal, updateDismissInstalledNotice };
 }
+
+const installedSnapshot: AutoUpdateSnapshot = {
+  ...idleSnapshot,
+  recentlyInstalled: {
+    version: "1.2.18",
+    installedAt: "2026-07-09T00:00:00.000Z",
+    releaseNotesUrl: "https://www.ade-app.dev/docs/changelog/v1.2.18",
+    githubReleaseUrl: "https://github.com/arul28/ADE/releases/tag/v1.2.18",
+  },
+};
 
 describe("AutoUpdateControl", () => {
   beforeEach(() => {
@@ -130,5 +143,44 @@ describe("AutoUpdateControl", () => {
 
     expect(await screen.findByText("Install update v1.3.0")).toBeTruthy();
     expect(screen.queryByText("Update required")).toBeNull();
+  });
+
+  it("shows the simplified installed modal with Changelog and View on GitHub actions", async () => {
+    installAdeMock({ snapshot: installedSnapshot });
+
+    render(<AutoUpdateControl />);
+
+    expect(await screen.findByText("Updated to v1.2.18")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /changelog/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /view on github/i })).toBeTruthy();
+    // Redundant copy and the old text buttons are gone.
+    expect(screen.queryByText(/open release notes/i)).toBeNull();
+    expect(screen.queryByText(/the update is installed and ade is ready/i)).toBeNull();
+  });
+
+  it("opens the docs changelog and dismisses when Changelog is clicked", async () => {
+    const { openExternal, updateDismissInstalledNotice } = installAdeMock({ snapshot: installedSnapshot });
+
+    render(<AutoUpdateControl />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /changelog/i }));
+
+    await waitFor(() => {
+      expect(openExternal).toHaveBeenCalledWith("https://www.ade-app.dev/docs/changelog/v1.2.18");
+    });
+    expect(updateDismissInstalledNotice).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the GitHub release page and dismisses when View on GitHub is clicked", async () => {
+    const { openExternal, updateDismissInstalledNotice } = installAdeMock({ snapshot: installedSnapshot });
+
+    render(<AutoUpdateControl />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /view on github/i }));
+
+    await waitFor(() => {
+      expect(openExternal).toHaveBeenCalledWith("https://github.com/arul28/ADE/releases/tag/v1.2.18");
+    });
+    expect(updateDismissInstalledNotice).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/renderer/components/app/AutoUpdateControl.tsx
+++ b/apps/desktop/src/renderer/components/app/AutoUpdateControl.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-import { ArrowSquareOut, ArrowsClockwise, CheckCircle, WarningCircle, X } from "@phosphor-icons/react";
+import { ArrowSquareOut, ArrowsClockwise, CheckCircle, GithubLogo, WarningCircle, X } from "@phosphor-icons/react";
 import type { AppInfo, AutoUpdateSnapshot } from "../../../shared/types";
 import { Button } from "../ui/Button";
 import { cn } from "../ui/cn";
@@ -127,6 +127,11 @@ export function AutoUpdateControl() {
     });
   }, []);
 
+  const openInstalledLink = useCallback((url: string) => {
+    void window.ade.app.openExternal(url);
+    dismissInstalledNotice();
+  }, [dismissInstalledNotice]);
+
   const handleRestartToInstall = useCallback(async () => {
     // Best-effort probe of live connections (paired phones) so the user knows
     // what drops while ADE and its brain service restart on the new version.
@@ -185,8 +190,8 @@ export function AutoUpdateControl() {
     || isReadyOrInstalling;
   const downloadProgress = progressLabel(snapshot.progressPercent);
   const releaseNotesUrl = snapshot.recentlyInstalled?.releaseNotesUrl ?? null;
+  const githubReleaseUrl = snapshot.recentlyInstalled?.githubReleaseUrl ?? null;
   const installedVersion = snapshot.recentlyInstalled?.version ?? null;
-  const releaseNotesDisplayUrl = releaseNotesUrl?.replace(/^https?:\/\//, "") ?? null;
   const runtimeRequiresDesktopUpdate = runtimeSkew?.state === "runtime_newer";
   const showRuntimeSkewIndicator = runtimeRequiresDesktopUpdate && !shouldShowIndicator;
 
@@ -275,88 +280,71 @@ export function AutoUpdateControl() {
       >
         <Dialog.Portal>
           <Dialog.Overlay className="fixed inset-0 z-[120] bg-black/55 backdrop-blur-sm" />
-          <Dialog.Content
-            className={cn(
-              "ade-update-installed-card fixed left-1/2 top-1/2 z-[121] w-[min(92vw,480px)] -translate-x-1/2 -translate-y-1/2",
-              "overflow-hidden rounded-xl border border-white/[0.12] bg-[color:var(--ade-shell-surface,#121019)] text-fg shadow-2xl shadow-black/55 outline-none",
-            )}
-          >
-            <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-emerald-300/60 to-transparent" />
-            <div className="p-5 sm:p-6">
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex min-w-0 items-start gap-3">
-                  <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-emerald-300/25 bg-emerald-400/10 text-emerald-200 shadow-[0_0_24px_rgba(16,185,129,0.18)]">
-                    <CheckCircle size={20} weight="fill" aria-hidden="true" />
-                  </div>
-                  <div className="min-w-0">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Dialog.Title className="text-sm font-semibold text-fg">
-                        ADE is up to date
-                      </Dialog.Title>
-                      {installedVersion ? (
-                        <span className="rounded-full border border-white/[0.10] bg-white/[0.04] px-2 py-0.5 font-mono text-[10px] font-semibold text-muted-fg">
-                          v{installedVersion}
-                        </span>
-                      ) : null}
+          {/* Full-viewport flex layer centers the card. Positioning the card
+              this way (instead of fixed + translate) keeps it centered even if
+              an ancestor establishes a containing block for fixed descendants.
+              The layer is click-through so a click outside the card lands on the
+              overlay and dismisses via onOpenChange. */}
+          <div className="pointer-events-none fixed inset-0 z-[121] grid place-items-center p-4">
+            <Dialog.Content
+              className={cn(
+                "ade-update-installed-card pointer-events-auto relative w-[min(92vw,420px)]",
+                "overflow-hidden rounded-xl border border-white/[0.12] bg-[color:var(--ade-shell-surface,#121019)] text-fg shadow-2xl shadow-black/55 outline-none",
+              )}
+            >
+              <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-emerald-300/60 to-transparent" />
+              <div className="p-5 sm:p-6">
+                <div className="flex items-center justify-between gap-4">
+                  <div className="flex min-w-0 items-center gap-3">
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-emerald-300/25 bg-emerald-400/10 text-emerald-200 shadow-[0_0_24px_rgba(16,185,129,0.18)]">
+                      <CheckCircle size={20} weight="fill" aria-hidden="true" />
                     </div>
-                    <Dialog.Description className="mt-1 text-sm text-muted-fg">
-                      {installedVersion
-                        ? `Restarted on v${installedVersion}.`
-                        : "ADE finished installing the latest version."}
-                    </Dialog.Description>
+                    <Dialog.Title className="min-w-0 truncate text-sm font-semibold text-fg">
+                      {installedVersion ? `Updated to v${installedVersion}` : "ADE updated"}
+                    </Dialog.Title>
                   </div>
+                  <Dialog.Close asChild>
+                    <button
+                      type="button"
+                      className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-fg transition-colors hover:bg-white/[0.06] hover:text-fg"
+                      aria-label="Close update details"
+                    >
+                      <X size={14} weight="bold" />
+                    </button>
+                  </Dialog.Close>
                 </div>
-                <Dialog.Close asChild>
-                  <button
-                    type="button"
-                    className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-fg transition-colors hover:bg-white/[0.06] hover:text-fg"
-                    aria-label="Close update details"
-                  >
-                    <X size={14} weight="bold" />
-                  </button>
-                </Dialog.Close>
-              </div>
 
-              <p className="mt-4 text-[13px] leading-6 text-muted-fg">
-                The update is installed and ADE is ready again.
-                {releaseNotesUrl ? " Review what changed in this release." : null}
-              </p>
+                <Dialog.Description className="sr-only">
+                  ADE finished installing {installedVersion ? `v${installedVersion}` : "the latest update"}.
+                </Dialog.Description>
 
-              {releaseNotesDisplayUrl ? (
-                <div className="mt-3 flex min-w-0 items-center gap-2 border-t border-white/[0.08] pt-3 text-[11px] text-muted-fg">
-                  <ArrowSquareOut size={12} weight="bold" className="shrink-0 text-emerald-200/80" aria-hidden="true" />
-                  <span className="truncate" title={releaseNotesUrl ?? undefined}>
-                    {releaseNotesDisplayUrl}
-                  </span>
+                <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:justify-end">
+                  {releaseNotesUrl ? (
+                    <Button
+                      type="button"
+                      variant="primary"
+                      className="w-full sm:w-auto"
+                      onClick={() => openInstalledLink(releaseNotesUrl)}
+                    >
+                      <ArrowSquareOut size={12} weight="bold" />
+                      Changelog
+                    </Button>
+                  ) : null}
+                  {githubReleaseUrl ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-full sm:w-auto"
+                      onClick={() => openInstalledLink(githubReleaseUrl)}
+                    >
+                      <GithubLogo size={12} weight="bold" />
+                      View on GitHub
+                    </Button>
+                  ) : null}
                 </div>
-              ) : null}
-
-              <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-end">
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="w-full sm:w-auto"
-                  onClick={dismissInstalledNotice}
-                >
-                  Close
-                </Button>
-                {releaseNotesUrl ? (
-                  <Button
-                    type="button"
-                    variant="primary"
-                    className="w-full sm:w-auto"
-                    onClick={() => {
-                      void window.ade.app.openExternal(releaseNotesUrl);
-                      dismissInstalledNotice();
-                    }}
-                  >
-                    <ArrowSquareOut size={12} weight="bold" />
-                    Open release notes
-                  </Button>
-                ) : null}
               </div>
-            </div>
-          </Dialog.Content>
+            </Dialog.Content>
+          </div>
         </Dialog.Portal>
       </Dialog.Root>
     </>

--- a/apps/desktop/src/renderer/index.css
+++ b/apps/desktop/src/renderer/index.css
@@ -3978,13 +3978,17 @@ button:active, [role="button"]:active {
   animation: ade-fade-slide-up 0.3s ease-out both;
 }
 
-.ade-update-installed-card[data-state="open"] {
+/* The card is centered by a flex layer (not fixed + translate), so its entrance
+   must stay translate-free. The [data-radix-dialog-content] prefix raises
+   specificity above the global ade-dialog-in rule (translateX(-50%)), which
+   would otherwise shift a flex-centered card left by half its width. */
+[data-radix-dialog-content].ade-update-installed-card[data-state="open"] {
   animation: ade-update-installed-card-in 180ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
 }
 
 @keyframes ade-update-installed-card-in {
-  from { opacity: 0; transform: translate(-50%, -48%) scale(0.98); }
-  to { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  from { opacity: 0; transform: scale(0.97); }
+  to { opacity: 1; transform: scale(1); }
 }
 
 /*

--- a/apps/desktop/src/shared/types/core.ts
+++ b/apps/desktop/src/shared/types/core.ts
@@ -114,6 +114,7 @@ export type RecentlyInstalledUpdate = {
   version: string;
   installedAt: string;
   releaseNotesUrl: string | null;
+  githubReleaseUrl: string | null;
 };
 
 export type AutoUpdateStatus = "idle" | "checking" | "downloading" | "ready" | "installing" | "error";

--- a/docs/features/onboarding-and-settings/README.md
+++ b/docs/features/onboarding-and-settings/README.md
@@ -310,9 +310,13 @@ Auto-update (top-bar control, not a settings tab):
   so the badge falls back to the underlying snapshot. While
   `installing` (or after the user clicks install but before the main
   process flips status), the badge animates in fuchsia and is
-  disabled. The "Update installed" dialog reads
-  `recentlyInstalled.releaseNotesUrl` and opens the public release
-  notes link for the running version.
+  disabled. The post-install dialog is a centered card titled
+  "Updated to vX.Y.Z" (the running version) with an X close button
+  and click-outside dismiss; it offers a "Changelog" button that opens
+  `recentlyInstalled.releaseNotesUrl` (the docs changelog) and a "View
+  on GitHub" button that opens `recentlyInstalled.githubReleaseUrl`
+  (the GitHub release page). Each button is shown only when its URL is
+  present; opening either link also dismisses the notice.
 
 ## Detail docs
 


### PR DESCRIPTION
## What
The post-update ("installed") modal was left-of-center and said the same thing three ways. This simplifies and re-centers it.

**Before:** "ADE is up to date" + "Restarted on vX" + "The update is installed and ADE is ready again…" + a changelog-URL row + `Close` / `Open release notes` buttons — and mis-centered.

**After:** a single centered card:
- Title: **"Updated to vX.Y.Z"**
- Two actions: **Changelog** (docs changelog) and **View on GitHub** (the GitHub release page)
- Top-right **✕** and **click-outside** to dismiss (no redundant "Close" button)

## Why not centered before
The card used `fixed left-1/2 -translate-x-1/2`, which mis-resolves when an ancestor establishes a containing block for the fixed element. It now centers via a full-viewport flex layer; the entrance keyframe is translate-free and its selector out-specifies the global `translateX(-50%)` dialog keyframe (which would otherwise re-introduce the left shift).

## Changes
- `AutoUpdateControl.tsx` — modal rewrite (flex centering, simplified copy, Changelog + View on GitHub)
- `autoUpdateService.ts` / `core.ts` — new `buildGithubReleaseUrl()` plumbed as `recentlyInstalled.githubReleaseUrl` (backfilled for older persisted state)
- `index.css` — translate-free card keyframe + specificity bump
- Tests: `buildGithubReleaseUrl` unit test + 3 behavioral modal tests (title, both buttons open the right URLs and dismiss)
- Docs: `onboarding-and-settings/README.md` updated to match

## Verification
Centering verified live in the standalone renderer: card center == viewport center on both axes; DOM confirmed the new title and buttons. Affected test files green (24 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the desktop auto-update post-install experience. The main changes are:

- Adds a GitHub release URL to recently installed update metadata.
- Backfills the GitHub release URL for persisted update state.
- Replaces the installed-update dialog with a compact centered modal.
- Adds Changelog and View on GitHub actions that dismiss the notice after opening.
- Updates tests, shared types, CSS, and documentation for the new behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changes are localized to auto-update metadata and the installed-update modal. Tests cover the new URL generation and renderer actions. No functional bugs were identified in the reviewed diff.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted a real UI capture using the repository's Vite renderer and the app's code and styles.
- Artifacts documenting the run were produced, including a UI capture script and server and Playwright logs.
- The final server log showed Vite failed to start because port 5173 was already in use, signaling an environment startup blocker.
- The Playwright run log showed navigation failed with net::ERR\_CONNECTION\_REFUSED to the internal URL.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/updates/autoUpdateService.test.ts | Adds coverage for GitHub release URL construction and persisted recently-installed update metadata. |
| apps/desktop/src/main/services/updates/autoUpdateService.ts | Adds deterministic GitHub release URL generation and backfills/persists it for recently installed updates. |
| apps/desktop/src/renderer/components/app/AutoUpdateControl.test.tsx | Adds renderer tests for the simplified installed-update modal and its external link actions. |
| apps/desktop/src/renderer/components/app/AutoUpdateControl.tsx | Simplifies the post-install modal UI and adds Changelog/GitHub release actions that dismiss the notice. |
| apps/desktop/src/renderer/index.css | Updates installed-update card animation to avoid translate offsets when centered by the wrapper layer. |
| apps/desktop/src/shared/types/core.ts | Extends the recently-installed update shared type with a GitHub release URL field. |
| docs/features/onboarding-and-settings/README.md | Documents the updated post-install auto-update dialog behavior and link destinations. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Main as AutoUpdateService
  participant State as Global State
  participant Renderer as AutoUpdateControl
  participant Shell as External Browser

  Main->>State: Persist recentlyInstalledUpdate(version, releaseNotesUrl, githubReleaseUrl)
  Renderer->>Main: updateGetState()
  Main-->>Renderer: AutoUpdateSnapshot.recentlyInstalled
  Renderer->>Renderer: Open installed-update modal
  alt User clicks Changelog
    Renderer->>Shell: openExternal(releaseNotesUrl)
    Renderer->>Main: updateDismissInstalledNotice()
  else User clicks View on GitHub
    Renderer->>Shell: openExternal(githubReleaseUrl)
    Renderer->>Main: updateDismissInstalledNotice()
  end
  Main->>State: Clear recentlyInstalledUpdate
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Main as AutoUpdateService
  participant State as Global State
  participant Renderer as AutoUpdateControl
  participant Shell as External Browser

  Main->>State: Persist recentlyInstalledUpdate(version, releaseNotesUrl, githubReleaseUrl)
  Renderer->>Main: updateGetState()
  Main-->>Renderer: AutoUpdateSnapshot.recentlyInstalled
  Renderer->>Renderer: Open installed-update modal
  alt User clicks Changelog
    Renderer->>Shell: openExternal(releaseNotesUrl)
    Renderer->>Main: updateDismissInstalledNotice()
  else User clicks View on GitHub
    Renderer->>Shell: openExternal(githubReleaseUrl)
    Renderer->>Main: updateDismissInstalledNotice()
  end
  Main->>State: Clear recentlyInstalledUpdate
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(updates): simplify and center the po..."](https://github.com/arul28/ade/commit/87429b3dd2151e4a69070a5dafd68e55702fdcf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43144010)</sub>

<!-- /greptile_comment -->