### PR TITLE
Fix web client pairing surfaces and marketing entities

### DIFF
--- a/apps/desktop/src/renderer/components/app/HeaderSheet.tsx
+++ b/apps/desktop/src/renderer/components/app/HeaderSheet.tsx
@@ -1,0 +1,170 @@
+import React, { useCallback, useEffect } from "react";
+import { X } from "@phosphor-icons/react";
+
+import { cn } from "../ui/cn";
+
+const DIALOG_FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "summary",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+export function getFocusableElements(root: HTMLElement): HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(DIALOG_FOCUSABLE_SELECTOR),
+  ).filter((element) => {
+    const closedDetails = element.closest<HTMLDetailsElement>(
+      "details:not([open])",
+    );
+    const isClosedDetailsSummary =
+      closedDetails?.querySelector(":scope > summary") === element;
+    return (
+      !element.closest('[hidden], [aria-hidden="true"]') &&
+      (!closedDetails || isClosedDetailsSummary) &&
+      !element.hasAttribute("disabled") &&
+      element.tabIndex >= 0
+    );
+  });
+}
+
+export function useDialogFocusTrap(
+  panelRef: React.RefObject<HTMLDivElement>,
+  onClose: () => void,
+  open: boolean,
+): React.KeyboardEventHandler<HTMLDivElement> {
+  useEffect(() => {
+    if (!open) return;
+    const frame = window.requestAnimationFrame(() => {
+      panelRef.current?.focus();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [open, panelRef]);
+
+  return useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusable = getFocusableElements(panel);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        panel.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (document.activeElement === panel) {
+        event.preventDefault();
+        (event.shiftKey ? last : first).focus();
+      } else if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    },
+    [onClose, panelRef],
+  );
+}
+
+type HeaderSheetProps = {
+  open: boolean;
+  panelRef: React.RefObject<HTMLDivElement>;
+  icon: React.ReactNode;
+  title: string;
+  subtitle: React.ReactNode;
+  headerActions?: React.ReactNode;
+  onClose: () => void;
+  ariaLabelledBy?: string;
+  width?: string;
+  closeTitle?: string;
+  children: React.ReactNode;
+};
+
+export function HeaderSheet({
+  open,
+  panelRef,
+  icon,
+  title,
+  subtitle,
+  headerActions,
+  onClose,
+  ariaLabelledBy,
+  width,
+  closeTitle = `Close ${title}`,
+  children,
+}: HeaderSheetProps) {
+  const handleKeyDown = useDialogFocusTrap(panelRef, onClose, open);
+  const panelPositionClassName = width
+    ? cn(
+        "absolute right-3 top-10 max-h-[calc(100vh-72px)] overflow-y-auto",
+        width,
+      )
+    : "absolute right-3 top-10 max-h-[calc(100vh-72px)] w-[min(620px,calc(100vw-24px))] overflow-y-auto";
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[120]"
+      style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+      onClick={onClose}
+    >
+      <div
+        ref={panelRef}
+        className={cn(
+          panelPositionClassName,
+          "rounded-xl border border-white/10 bg-[color:var(--ade-shell-surface,#121019)] shadow-2xl shadow-black/45",
+        )}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={ariaLabelledBy}
+        tabIndex={-1}
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/10 bg-[color:var(--ade-shell-surface,#121019)] px-4 py-3">
+          <div className="flex min-w-0 items-center gap-2">
+            {icon}
+            <div className="min-w-0">
+              <div
+                id={ariaLabelledBy}
+                className="truncate text-[13px] font-semibold"
+              >
+                {title}
+              </div>
+              <div className="truncate text-[11px] text-white/55">
+                {subtitle}
+              </div>
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            {headerActions}
+            <button
+              type="button"
+              className="ade-shell-control inline-flex h-7 w-7 items-center justify-center rounded-md"
+              data-variant="ghost"
+              onClick={onClose}
+              title={closeTitle}
+            >
+              <X size={13} weight="regular" />
+            </button>
+          </div>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/app/TopBar.test.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.test.tsx
@@ -16,7 +16,17 @@ const PROJECT_TAB_ROOT_MIME = "application/x-ade-project-root";
 const PROJECT_TAB_WINDOW_MIME = "application/x-ade-window-id";
 
 vi.mock("../settings/SyncDevicesSection", () => ({
-  SyncDevicesSection: () => <section data-testid="sync-devices-section">Sync devices panel</section>,
+  SyncDevicesSection: ({ variant = "all" }: { variant?: string }) => (
+    <section data-testid="sync-devices-section" data-variant={variant}>
+      Sync devices panel
+      {variant === "web" ? (
+        <details>
+          <summary>Web clients summary</summary>
+          <button type="button">Hidden revoke</button>
+        </details>
+      ) : null}
+    </section>
+  ),
 }));
 
 vi.mock("./AutoUpdateControl", () => ({
@@ -216,8 +226,10 @@ const resourceUsageMock = vi.fn();
 
 describe("TopBar", () => {
   const originalAde = globalThis.window.ade;
+  const originalWebClientMode = globalThis.window.__adeWebClient;
 
   beforeEach(() => {
+    delete globalThis.window.__adeWebClient;
     resetStore();
     resourceUsageMock.mockReset();
     resourceUsageMock.mockResolvedValue({
@@ -325,6 +337,11 @@ describe("TopBar", () => {
       delete (globalThis.window as any).ade;
     } else {
       globalThis.window.ade = originalAde;
+    }
+    if (originalWebClientMode === undefined) {
+      delete globalThis.window.__adeWebClient;
+    } else {
+      globalThis.window.__adeWebClient = originalWebClientMode;
     }
   });
 
@@ -875,6 +892,7 @@ describe("TopBar", () => {
 
       expect(screen.getByText("Connect to the ADE mobile app")).toBeTruthy();
       expect(screen.getByTestId("sync-devices-section")).toBeTruthy();
+      expect(screen.getByTestId("sync-devices-section").getAttribute("data-variant")).toBe("phone");
       expect(screen.getByTitle("Connect a phone to this machine").getAttribute("aria-expanded")).toBe("true");
 
       fireEvent.click(screen.getByTitle("Close phone sync"));
@@ -883,6 +901,114 @@ describe("TopBar", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("opens the web client drawer from the web status control", async () => {
+    vi.useFakeTimers();
+    try {
+      render(<TopBar />);
+
+      // Web chip is present alongside the mobile chip, disconnected until a
+      // browser peer shows up (mock snapshot only has a phone peer).
+      const webChip = screen.getByRole("button", { name: "Web, not connected" });
+      expect(webChip).toBeTruthy();
+      expect(webChip.getAttribute("title")).toBe("Pair a browser with this machine");
+
+      await advancePhoneSyncStartupDelay();
+
+      fireEvent.click(webChip);
+
+      expect(screen.getByText("Web client")).toBeTruthy();
+      const section = screen.getByTestId("sync-devices-section");
+      expect(section.getAttribute("data-variant")).toBe("web");
+      expect(section.closest("header")).toBeNull();
+      expect(screen.getByTitle("Open the ADE web client in your browser")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Web, not connected" }).getAttribute("aria-expanded")).toBe("true");
+
+      fireEvent.click(screen.getByTitle("Close web client"));
+
+      expect(screen.queryByTestId("sync-devices-section")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("marks the web chip connected when a browser peer is present", async () => {
+    vi.useFakeTimers();
+    const getStatus = vi.fn().mockResolvedValue(
+      makeSyncSnapshot({
+        connectedPeers: [
+          { deviceId: "browser-1", deviceName: "Chrome on MacBook Pro", platform: "macOS", deviceType: "browser" },
+        ],
+      }),
+    );
+    globalThis.window.ade.sync.getStatus = getStatus as any;
+    try {
+      render(<TopBar />);
+
+      await advancePhoneSyncStartupDelay();
+
+      const webChip = screen.getByRole("button", { name: "Web, connected" });
+      expect(webChip).toBeTruthy();
+      expect(webChip.getAttribute("title")).toBe("1 connected · Chrome on MacBook Pro");
+      expect(screen.getByRole("button", { name: "Mobile, not connected" })).toBeTruthy();
+      fireEvent.click(webChip);
+      const dialog = screen.getByTitle("Close web client").closest('[role="dialog"]');
+      expect(dialog?.textContent).toContain("1 web client connected to ADE Desktop");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("hides the host web-pairing control in hosted web-client mode", () => {
+    globalThis.window.__adeWebClient = true;
+
+    render(<TopBar />);
+
+    expect(screen.queryByRole("button", { name: "Web, not connected" })).toBeNull();
+  });
+
+  it("keeps the phone and web sync sheets mutually exclusive", () => {
+    render(<TopBar />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Mobile, not connected" }));
+    expect(screen.getByTitle("Close phone sync")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Web, not connected" }));
+
+    expect(screen.queryByTitle("Close phone sync")).toBeNull();
+    expect(screen.getByTitle("Close web client")).toBeTruthy();
+    expect(screen.getAllByTestId("sync-devices-section")).toHaveLength(1);
+  });
+
+  it("traps focus on the visible web clients summary", () => {
+    render(<TopBar />);
+    fireEvent.click(screen.getByRole("button", { name: "Web, not connected" }));
+
+    const first = screen.getByTitle("Open the ADE web client in your browser");
+    const summary = screen.getByText("Web clients summary");
+    summary.focus();
+    fireEvent.keyDown(summary, { key: "Tab" });
+    expect(document.activeElement).toBe(first);
+
+    first.focus();
+    fireEvent.keyDown(first, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(summary);
+  });
+
+  it("closes the web sheet on Escape without disturbing chip state", () => {
+    render(<TopBar />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Web, not connected" }));
+    const dialog = screen.getByTitle("Close web client").closest('[role="dialog"]');
+    expect(dialog).toBeTruthy();
+
+    fireEvent.keyDown(dialog as HTMLElement, { key: "Escape" });
+
+    expect(screen.queryByTestId("sync-devices-section")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Web, not connected" }).getAttribute("aria-expanded"),
+    ).toBe("false");
   });
 
   it("occludes the native browser while the remote machines panel is open", async () => {

--- a/apps/desktop/src/renderer/components/app/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.tsx
@@ -14,6 +14,7 @@ import {
   DeviceMobile,
   Folder,
   FolderOpen,
+  Globe,
   Plus,
   Minus,
   Plugs,
@@ -43,6 +44,7 @@ import { cn } from "../ui/cn";
 import { deriveIconAccentColor } from "../../lib/iconAccent";
 import { SmartTooltip } from "../ui/SmartTooltip";
 import { ADE_MOBILE_TESTFLIGHT_URL } from "../../../shared/productLinks";
+import { WEB_CLIENT_BASE_URL } from "../../../shared/webClientUrl";
 import type {
   ProcessRuntime,
   ProjectIcon,
@@ -55,6 +57,7 @@ import type {
 } from "../../../shared/types";
 import { AutoUpdateControl } from "./AutoUpdateControl";
 import { FeedbackReporterModal } from "./FeedbackReporterModal";
+import { HeaderSheet, useDialogFocusTrap } from "./HeaderSheet";
 import { HelpMenu } from "../onboarding/HelpMenu";
 import { LinearQuickViewButton } from "./LinearQuickViewButton";
 import { PublishToGitHubDialog } from "../projects/PublishToGitHubDialog";
@@ -190,31 +193,53 @@ function setProjectIconCache(rootPath: string, icon: ProjectIcon): void {
   }
   projectIconCache.set(rootPath, icon);
 }
-const PHONE_SYNC_FOCUSABLE_SELECTOR = [
-  "a[href]",
-  "button:not([disabled])",
-  "textarea:not([disabled])",
-  "input:not([disabled])",
-  "select:not([disabled])",
-  '[tabindex]:not([tabindex="-1"])',
-].join(",");
-
-function getFocusableElements(root: HTMLElement): HTMLElement[] {
-  return Array.from(
-    root.querySelectorAll<HTMLElement>(PHONE_SYNC_FOCUSABLE_SELECTOR),
-  ).filter(
-    (element) =>
-      element.getAttribute("aria-hidden") !== "true" &&
-      !element.hasAttribute("disabled") &&
-      element.tabIndex >= 0,
-  );
-}
-
 function isSyncConnected(snapshot: SyncRoleSnapshot | null): boolean {
   if (!snapshot) return false;
   if (snapshot.client.state === "error") return false;
-  if (snapshot.role === "brain") return snapshot.connectedPeers.length > 0;
+  if (snapshot.role === "brain") {
+    return snapshot.connectedPeers.some((peer) => peer.deviceType === "phone");
+  }
   return snapshot.client.state === "connected";
+}
+
+function connectedWebClients(snapshot: SyncRoleSnapshot | null) {
+  if (!snapshot) return [];
+  if (snapshot.client.state === "error") return [];
+  return snapshot.connectedPeers.filter((peer) => peer.deviceType === "browser");
+}
+
+function isWebSyncConnected(snapshot: SyncRoleSnapshot | null): boolean {
+  return connectedWebClients(snapshot).length > 0;
+}
+
+function deriveWebClientTooltip(snapshot: SyncRoleSnapshot | null): string {
+  const clients = connectedWebClients(snapshot);
+  if (clients.length === 0) return "Pair a browser with this machine";
+  const first = clients[0];
+  const name = first.deviceName?.trim();
+  return name ? `${clients.length} connected · ${name}` : `${clients.length} connected`;
+}
+
+function deriveWebSyncLabel(snapshot: SyncRoleSnapshot | null): string | null {
+  if (!snapshot) return null;
+  if (snapshot.client.state === "error") return "Web client sync error";
+  if (snapshot.role === "brain") {
+    const count = connectedWebClients(snapshot).length;
+    if (count > 0) {
+      const machineName = snapshot.localDevice.name.trim() || "this machine";
+      return `${count} web client${count === 1 ? "" : "s"} connected to ${machineName}`;
+    }
+    return "Web client pairing ready";
+  }
+  if (snapshot.mode === "standalone") return "Web client pairing ready";
+  switch (snapshot.client.state) {
+    case "connected":
+      return `Linked to ${snapshot.currentBrain?.name ?? "host"}`;
+    case "connecting":
+      return "Connecting…";
+    default:
+      return "Web client sync offline";
+  }
 }
 
 const HEADER_STATUS_COMPACT_MAX_WIDTH_PX = 767;
@@ -509,7 +534,7 @@ function deriveSyncLabel(snapshot: SyncRoleSnapshot | null): string | null {
   if (!snapshot) return null;
   if (snapshot.client.state === "error") return "Phone sync error";
   if (snapshot.role === "brain") {
-    const count = snapshot.connectedPeers.length;
+    const count = snapshot.connectedPeers.filter((peer) => peer.deviceType === "phone").length;
     if (count > 0) {
       const machineName = snapshot.localDevice.name.trim() || "this machine";
       return `${count} phone${count === 1 ? "" : "s"} connected to ${machineName}`;
@@ -881,7 +906,7 @@ export function TopBar() {
   const [syncSnapshot, setSyncSnapshot] = useState<SyncRoleSnapshot | null>(
     null,
   );
-  const [phoneSyncOpen, setPhoneSyncOpen] = useState(false);
+  const [syncPanelOpen, setSyncPanelOpen] = useState<"phone" | "web" | null>(null);
   const [remotePanelOpen, setRemotePanelOpen] = useState(false);
   const {
     state: remoteDisconnectConfirmState,
@@ -903,12 +928,22 @@ export function TopBar() {
   const [dropIdx, setDropIdx] = useState<number | null>(null);
   const [windowId, setWindowId] = useState<number | null>(null);
   const phoneSyncPanelRef = useRef<HTMLDivElement | null>(null);
+  const webSyncPanelRef = useRef<HTMLDivElement | null>(null);
   const remotePanelRef = useRef<HTMLDivElement | null>(null);
+  const closeSyncPanel = useCallback(() => setSyncPanelOpen(null), []);
+  const closeRemotePanel = useCallback(() => setRemotePanelOpen(false), []);
+  const handleRemotePanelKeyDown = useDialogFocusTrap(
+    remotePanelRef,
+    closeRemotePanel,
+    remotePanelOpen,
+  );
   const dragCounterRef = useRef(0);
   const isProjectBusy = projectTransition != null || relocatingPath != null;
   const remoteBinding =
     projectBinding?.kind === "remote" ? projectBinding : null;
-  const chromePanelOccludesNativeBrowser = remotePanelOpen || phoneSyncOpen;
+  const phoneSyncOpen = syncPanelOpen === "phone";
+  const webSyncOpen = syncPanelOpen === "web";
+  const chromePanelOccludesNativeBrowser = remotePanelOpen || syncPanelOpen !== null;
   const workspaceProjectOpen =
     projectHydrated === true &&
     showWelcome !== true &&
@@ -943,9 +978,12 @@ export function TopBar() {
   const remoteStatusCount = Math.max(connectedRemoteCount, openRemoteProjectTabs.length);
   const remoteConnected = connectedRemoteCount > 0;
   const syncConnected = isSyncConnected(syncSnapshot);
+  const webConnected = isWebSyncConnected(syncSnapshot);
+  const webClientTooltip = deriveWebClientTooltip(syncSnapshot);
   const showSyncControl = projectHydrated === true;
   const syncStatusTargetKey =
     remoteBinding?.key ?? project?.rootPath ?? "machine";
+  const syncStatusTargetRef = useRef(syncStatusTargetKey);
 
   useEffect(() => {
     openProjectTabRootsRef.current = openProjectTabRoots;
@@ -1113,14 +1151,6 @@ export function TopBar() {
   }, [setOpenProjectTabRoots]);
 
   useEffect(() => {
-    if (!phoneSyncOpen) return;
-    const frame = window.requestAnimationFrame(() => {
-      phoneSyncPanelRef.current?.focus();
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [phoneSyncOpen]);
-
-  useEffect(() => {
     const remoteRuntime = window.ade.remoteRuntime;
     if (!remoteRuntime?.getConnectionSnapshot) return;
     let cancelled = false;
@@ -1141,14 +1171,6 @@ export function TopBar() {
       unsubscribe();
     };
   }, []);
-
-  useEffect(() => {
-    if (!remotePanelOpen) return;
-    const frame = window.requestAnimationFrame(() => {
-      remotePanelRef.current?.focus();
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [remotePanelOpen]);
 
   useEffect(() => {
     if (!chromePanelOccludesNativeBrowser || typeof window === "undefined") return undefined;
@@ -1179,7 +1201,7 @@ export function TopBar() {
     let disposeSyncEvents: (() => void) | null = null;
     if (!showSyncControl) {
       setSyncSnapshot(null);
-      setPhoneSyncOpen(false);
+      setSyncPanelOpen(null);
       return () => {
         cancelled = true;
       };
@@ -1197,7 +1219,10 @@ export function TopBar() {
             setSyncSnapshot(null);
         });
     };
-    setSyncSnapshot(null);
+    if (syncStatusTargetRef.current !== syncStatusTargetKey) {
+      syncStatusTargetRef.current = syncStatusTargetKey;
+      setSyncSnapshot(null);
+    }
     const startSyncStatus = () => {
       if (cancelled || started) return;
       started = true;
@@ -1218,7 +1243,7 @@ export function TopBar() {
     };
     startupTimer = window.setTimeout(
       startSyncStatus,
-      phoneSyncOpen ? 0 : PHONE_SYNC_STARTUP_DELAY_MS,
+      phoneSyncOpen || webSyncOpen ? 0 : PHONE_SYNC_STARTUP_DELAY_MS,
     );
     window.addEventListener("focus", onFocus);
     return () => {
@@ -1233,7 +1258,7 @@ export function TopBar() {
     // current state. With no project open, sync calls fall back to the
     // machine-level brain service. Focus and explicit drawer opens still
     // refresh immediately.
-  }, [phoneSyncOpen, showSyncControl, syncStatusTargetKey]);
+  }, [phoneSyncOpen, webSyncOpen, showSyncControl, syncStatusTargetKey]);
 
   const checkForActiveWorkloads = useCallback(
     async (projectRootPath: string): Promise<boolean> => {
@@ -1726,77 +1751,14 @@ export function TopBar() {
     [],
   );
 
-  const handlePhoneSyncDialogKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setPhoneSyncOpen(false);
-        return;
-      }
-      if (event.key !== "Tab") return;
-
-      const panel = phoneSyncPanelRef.current;
-      if (!panel) return;
-      const focusable = getFocusableElements(panel);
-      if (focusable.length === 0) {
-        event.preventDefault();
-        panel.focus();
-        return;
-      }
-
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (document.activeElement === panel) {
-        event.preventDefault();
-        (event.shiftKey ? last : first).focus();
-      } else if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    },
-    [],
-  );
-
-  const handleRemotePanelKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setRemotePanelOpen(false);
-        return;
-      }
-      if (event.key !== "Tab") return;
-
-      const panel = remotePanelRef.current;
-      if (!panel) return;
-      const focusable = getFocusableElements(panel);
-      if (focusable.length === 0) {
-        event.preventDefault();
-        panel.focus();
-        return;
-      }
-
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      if (document.activeElement === panel) {
-        event.preventDefault();
-        (event.shiftKey ? last : first).focus();
-      } else if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first.focus();
-      }
-    },
-    [],
-  );
-
   const syncLabel = deriveSyncLabel(syncSnapshot) ?? "Phone sync";
+  const webSyncLabel = deriveWebSyncLabel(syncSnapshot) ?? "Web client sync";
   const openMobileTestFlight = useCallback(
     () => openExternalUrl(ADE_MOBILE_TESTFLIGHT_URL),
+    [],
+  );
+  const openWebClient = useCallback(
+    () => openExternalUrl(WEB_CLIENT_BASE_URL),
     [],
   );
 
@@ -1817,8 +1779,14 @@ export function TopBar() {
           ariaExpanded={remotePanelOpen}
           onClick={
             menuLayout
-              ? wrapActivate(() => setRemotePanelOpen(true))
-              : () => setRemotePanelOpen((open) => !open)
+              ? wrapActivate(() => {
+                setSyncPanelOpen(null);
+                setRemotePanelOpen(true);
+              })
+              : () => {
+                setSyncPanelOpen(null);
+                setRemotePanelOpen((open) => !open);
+              }
           }
           icon={(
             <DesktopTower
@@ -1839,11 +1807,45 @@ export function TopBar() {
           ariaExpanded={phoneSyncOpen}
           onClick={
             menuLayout
-              ? wrapActivate(() => setPhoneSyncOpen(true))
-              : () => setPhoneSyncOpen((open) => !open)
+              ? wrapActivate(() => {
+                setRemotePanelOpen(false);
+                setSyncPanelOpen("phone");
+              })
+              : () => {
+                setRemotePanelOpen(false);
+                setSyncPanelOpen((open) => open === "phone" ? null : "phone");
+              }
           }
           icon={(
             <DeviceMobile
+              size={12}
+              weight="regular"
+              className="shrink-0 opacity-85"
+            />
+          )}
+        />
+      ) : null;
+
+      const webChip = showSyncControl && !webMode ? (
+        <ShellConnectionChip
+          layout={menuLayout ? "menu-row" : "chip"}
+          label="Web"
+          connected={webConnected}
+          title={webClientTooltip}
+          ariaExpanded={webSyncOpen}
+          onClick={
+            menuLayout
+              ? wrapActivate(() => {
+                setRemotePanelOpen(false);
+                setSyncPanelOpen("web");
+              })
+              : () => {
+                setRemotePanelOpen(false);
+                setSyncPanelOpen((open) => open === "web" ? null : "web");
+              }
+          }
+          icon={(
+            <Globe
               size={12}
               weight="regular"
               className="shrink-0 opacity-85"
@@ -1863,6 +1865,7 @@ export function TopBar() {
             />
             {remoteChip}
             {mobileChip}
+            {webChip}
           </div>
         );
       }
@@ -1872,17 +1875,22 @@ export function TopBar() {
           <LinearQuickViewButton />
           {remoteChip}
           {mobileChip}
+          {webChip}
           <HeaderUsageControl deferInitialRead={Boolean(remoteBinding)} />
         </>
       );
     },
     [
       phoneSyncOpen,
+      webSyncOpen,
       remoteBinding,
       remoteConnected,
       remotePanelOpen,
       showSyncControl,
       syncConnected,
+      webMode,
+      webConnected,
+      webClientTooltip,
     ],
   );
 
@@ -2393,7 +2401,7 @@ export function TopBar() {
 
         <HeaderStatusMenu
           remoteConnected={remoteConnected}
-          syncConnected={syncConnected}
+          syncConnected={syncConnected || (!webMode && webConnected)}
           showSyncControl={showSyncControl}
         >
           {(closeMenu) => renderHeaderStatusControls({ menuLayout: true, onActivate: closeMenu })}
@@ -2471,109 +2479,114 @@ export function TopBar() {
             document.body,
           )
         : null}
-      {remotePanelOpen ? (
-        <div
-          className="fixed inset-0 z-[80]"
-          style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
-          onClick={() => setRemotePanelOpen(false)}
-        >
-          <div
-            ref={remotePanelRef}
-            className={cn(
-              "absolute right-3 top-10 max-h-[calc(100vh-72px)] w-[min(820px,calc(100vw-24px))] overflow-y-auto",
-              "rounded-xl border border-white/10 bg-[color:var(--ade-shell-surface,#121019)] shadow-2xl shadow-black/45",
-            )}
-            role="dialog"
-            aria-modal="true"
-            aria-label="Remote machines"
-            tabIndex={-1}
-            onClick={(event) => event.stopPropagation()}
-            onKeyDown={handleRemotePanelKeyDown}
-          >
-            <button
-              type="button"
-              className="ade-shell-control absolute right-3 top-3 z-10 inline-flex h-7 w-7 items-center justify-center rounded-md"
-              data-variant="ghost"
-              onClick={() => setRemotePanelOpen(false)}
-              title="Close remote machines"
-            >
-              <X size={13} weight="regular" />
-            </button>
-            <div className="p-4 pr-12">
-              <RemoteTargetList
-                onDisconnectRequested={handleRemoteTargetDisconnectRequested}
-                onRemoveRequested={handleRemoteTargetRemoveRequested}
-              />
-            </div>
-          </div>
-        </div>
-      ) : null}
-
-      {phoneSyncOpen ? (
-        <div
-          className="fixed inset-0 z-[80]"
-          style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
-          onClick={() => setPhoneSyncOpen(false)}
-        >
-          <div
-            ref={phoneSyncPanelRef}
-            className={cn(
-              "absolute right-3 top-10 max-h-[calc(100vh-72px)] w-[min(620px,calc(100vw-24px))] overflow-y-auto",
-              "rounded-xl border border-white/10 bg-[color:var(--ade-shell-surface,#121019)] shadow-2xl shadow-black/45",
-            )}
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="phone-sync-title"
-            tabIndex={-1}
-            onClick={(event) => event.stopPropagation()}
-            onKeyDown={handlePhoneSyncDialogKeyDown}
-          >
-            <div className="sticky top-0 z-10 flex items-center justify-between border-b border-white/10 bg-[color:var(--ade-shell-surface,#121019)] px-4 py-3">
-              <div className="flex min-w-0 items-center gap-2">
-                <DeviceMobile
-                  size={16}
-                  weight="regular"
-                  className="shrink-0 opacity-85"
-                />
-                <div className="min-w-0">
+      {typeof document !== "undefined"
+        ? createPortal(
+            <>
+              {remotePanelOpen ? (
+                <div
+                  className="fixed inset-0 z-[120]"
+                  style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+                  onClick={closeRemotePanel}
+                >
                   <div
-                    id="phone-sync-title"
-                    className="truncate text-[13px] font-semibold"
+                    ref={remotePanelRef}
+                    className={cn(
+                      "absolute right-3 top-10 max-h-[calc(100vh-72px)] w-[min(820px,calc(100vw-24px))] overflow-y-auto",
+                      "rounded-xl border border-white/10 bg-[color:var(--ade-shell-surface,#121019)] shadow-2xl shadow-black/45",
+                    )}
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label="Remote machines"
+                    tabIndex={-1}
+                    onClick={(event) => event.stopPropagation()}
+                    onKeyDown={handleRemotePanelKeyDown}
                   >
-                    Connect to the ADE mobile app
-                  </div>
-                  <div className="truncate text-[11px] text-white/55">
-                    {syncLabel}
+                    <button
+                      type="button"
+                      className="ade-shell-control absolute right-3 top-3 z-10 inline-flex h-7 w-7 items-center justify-center rounded-md"
+                      data-variant="ghost"
+                      onClick={closeRemotePanel}
+                      title="Close remote machines"
+                    >
+                      <X size={13} weight="regular" />
+                    </button>
+                    <div className="p-4 pr-12">
+                      <RemoteTargetList
+                        onDisconnectRequested={handleRemoteTargetDisconnectRequested}
+                        onRemoveRequested={handleRemoteTargetRemoveRequested}
+                      />
+                    </div>
                   </div>
                 </div>
-              </div>
-              <div className="flex shrink-0 items-center gap-2">
-                <button
-                  type="button"
-                  className="ade-shell-control inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-[11px] font-semibold"
-                  onClick={openMobileTestFlight}
-                  title="Download ADE Mobile from TestFlight"
-                >
-                  <ArrowSquareOut size={12} weight="regular" />
-                  Download
-                </button>
-                <button
-                  type="button"
-                  className="ade-shell-control inline-flex h-7 w-7 items-center justify-center rounded-md"
-                  data-variant="ghost"
-                  onClick={() => setPhoneSyncOpen(false)}
-                  title="Close phone sync"
-                >
-                  <X size={13} weight="regular" />
-                </button>
-              </div>
-            </div>
-            <div className="p-4">
-              <SyncDevicesSection />
-            </div>
-          </div>
-        </div>
-      ) : null}
+              ) : null}
+
+              <HeaderSheet
+                open={phoneSyncOpen}
+                panelRef={phoneSyncPanelRef}
+                icon={
+                  <DeviceMobile
+                    size={16}
+                    weight="regular"
+                    className="shrink-0 opacity-85"
+                  />
+                }
+                title="Connect to the ADE mobile app"
+                subtitle={syncLabel}
+                headerActions={
+                  <button
+                    type="button"
+                    className="ade-shell-control inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-[11px] font-semibold"
+                    onClick={openMobileTestFlight}
+                    title="Download ADE Mobile from TestFlight"
+                  >
+                    <ArrowSquareOut size={12} weight="regular" />
+                    Download
+                  </button>
+                }
+                onClose={closeSyncPanel}
+                ariaLabelledBy="phone-sync-title"
+                closeTitle="Close phone sync"
+              >
+                <div className="p-4">
+                  <SyncDevicesSection variant="phone" />
+                </div>
+              </HeaderSheet>
+
+              <HeaderSheet
+                open={webSyncOpen}
+                panelRef={webSyncPanelRef}
+                icon={
+                  <Globe
+                    size={16}
+                    weight="regular"
+                    className="shrink-0 opacity-85"
+                  />
+                }
+                title="Web client"
+                subtitle={webSyncLabel}
+                headerActions={
+                  <button
+                    type="button"
+                    className="ade-shell-control inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-[11px] font-semibold"
+                    onClick={openWebClient}
+                    title="Open the ADE web client in your browser"
+                  >
+                    <ArrowSquareOut size={12} weight="regular" />
+                    Open in browser
+                  </button>
+                }
+                onClose={closeSyncPanel}
+                ariaLabelledBy="web-sync-title"
+                closeTitle="Close web client"
+              >
+                <div className="p-4">
+                  <SyncDevicesSection variant="web" />
+                </div>
+              </HeaderSheet>
+            </>,
+            document.body,
+          )
+        : null}
 
       <FeedbackReporterModal
         open={feedbackOpen}

--- a/apps/desktop/src/renderer/components/settings/SyncDevicesSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/SyncDevicesSection.test.tsx
@@ -1,0 +1,229 @@
+/* @vitest-environment jsdom */
+
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SyncDevicesSection } from "./SyncDevicesSection";
+
+const originalAde = (globalThis.window as any)?.ade;
+
+function makeHostSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    mode: "brain",
+    role: "brain",
+    runtimeRole: "host",
+    localDevice: {
+      deviceId: "desktop-1",
+      siteId: "site-1",
+      name: "ADE Desktop",
+      platform: "macOS",
+      deviceType: "desktop",
+      createdAt: "2026-04-22T00:00:00.000Z",
+      updatedAt: "2026-04-22T00:00:00.000Z",
+      lastSeenAt: "2026-04-22T00:00:00.000Z",
+      lastHost: "192.168.1.20",
+      lastPort: 8787,
+      tailscaleIp: null,
+      ipAddresses: ["192.168.1.20"],
+      metadata: {},
+    },
+    currentBrain: null,
+    clusterState: null,
+    bootstrapToken: "bootstrap-token",
+    pairingPin: null,
+    pairingPinConfigured: true,
+    runtimeName: "Studio",
+    pairingConnectInfo: {
+      hostIdentity: {
+        deviceId: "desktop-1",
+        siteId: "site-1",
+        name: "ADE Desktop",
+        platform: "macOS",
+        deviceType: "desktop",
+      },
+      port: 8787,
+      addressCandidates: [{ host: "192.168.1.20", kind: "lan" }],
+    },
+    connectedPeers: [],
+    tailnetDiscovery: {
+      state: "disabled",
+      serviceName: "svc:ade-sync",
+      servicePort: 8787,
+      target: null,
+      updatedAt: null,
+      error: null,
+      stderr: null,
+    },
+    client: { state: "disconnected" },
+    transferReadiness: { ready: true, blockers: [], survivableState: [] },
+    survivableStateText: "",
+    blockingStateText: "",
+    ...overrides,
+  };
+}
+
+function installAdeMock(snapshot: Record<string, unknown>) {
+  const setPin = vi.fn(async (pin: string) => ({
+    ...snapshot,
+    pairingPin: pin,
+    pairingPinConfigured: true,
+  }));
+  const writeClipboardText = vi.fn(async (_text: string) => undefined);
+  (globalThis.window as any).ade = {
+    app: { writeClipboardText },
+    sync: {
+      getStatus: vi.fn(async () => snapshot),
+      listDevices: vi.fn(async () => []),
+      getCloudRelayStatus: vi.fn(async () => null),
+      onEvent: vi.fn(() => () => {}),
+      setPin,
+      generatePin: vi.fn(async () => snapshot),
+      clearPin: vi.fn(async () => undefined),
+      setCloudRelayEnabled: vi.fn(async () => null),
+      setRuntimeName: vi.fn(async () => undefined),
+      clearRuntimeName: vi.fn(async () => undefined),
+      updateLocalDevice: vi.fn(async () => undefined),
+      forgetDevice: vi.fn(async () => undefined),
+      refreshDiscovery: vi.fn(async () => snapshot),
+    },
+  };
+  return { setPin, writeClipboardText };
+}
+
+describe("SyncDevicesSection", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    if (originalAde === undefined) {
+      delete (globalThis.window as any).ade;
+    } else {
+      (globalThis.window as any).ade = originalAde;
+    }
+  });
+
+  it("web variant shows the hidden-PIN generate control and calls setPin with a 6-digit PIN", async () => {
+    const { setPin } = installAdeMock(makeHostSnapshot());
+    vi.spyOn(globalThis.crypto, "getRandomValues").mockImplementation((array) => {
+      (array as Uint32Array)[0] = 0;
+      return array;
+    });
+    render(<SyncDevicesSection variant="web" />);
+
+    const generate = await screen.findByRole("button", { name: "Generate new PIN" });
+    expect(generate).toBeTruthy();
+    expect(screen.getByText("Existing PIN still pairs if you know it.")).toBeTruthy();
+    // Hidden PIN renders masked digits, never a real value.
+    expect(screen.getByText("••••••")).toBeTruthy();
+
+    fireEvent.click(generate);
+
+    await waitFor(() => expect(setPin).toHaveBeenCalledTimes(1));
+    const pinArg = setPin.mock.calls[0][0];
+    expect(pinArg).toMatch(/^\d{6}$/);
+    expect(pinArg).toBe("000000");
+  });
+
+  it("web variant renders the web clients list but not phone pairing", async () => {
+    installAdeMock(makeHostSnapshot());
+    render(<SyncDevicesSection variant="web" />);
+
+    expect(await screen.findByText("Web client")).toBeTruthy();
+    expect(screen.getByText("Web clients")).toBeTruthy();
+    expect(screen.queryByText("Pair a phone")).toBeNull();
+    expect(screen.queryByText("Phones")).toBeNull();
+  });
+
+  it("phone variant renders phone pairing but not the web client card", async () => {
+    installAdeMock(makeHostSnapshot());
+    render(<SyncDevicesSection variant="phone" />);
+
+    expect(await screen.findByText("Pair a phone")).toBeTruthy();
+    expect(screen.getByText("Phones")).toBeTruthy();
+    expect(screen.queryByText("Web client")).toBeNull();
+    expect(screen.queryByText("Web clients")).toBeNull();
+  });
+
+  it("shows Copied feedback after copying a visible pairing code", async () => {
+    const { writeClipboardText } = installAdeMock(makeHostSnapshot({ pairingPin: "123456" }));
+    render(
+      <React.StrictMode>
+        <SyncDevicesSection variant="web" />
+      </React.StrictMode>,
+    );
+
+    const copy = await screen.findByRole("button", { name: "Copy code" });
+    fireEvent.click(copy);
+
+    await waitFor(() => expect(writeClipboardText).toHaveBeenCalledWith("123456"));
+    expect(await screen.findByText("Copied")).toBeTruthy();
+  });
+
+  it("keeps web status scoped to browser peers", async () => {
+    installAdeMock(makeHostSnapshot({
+      connectedPeers: [
+        { deviceId: "phone-1", deviceName: "Phone", platform: "iOS", deviceType: "phone" },
+      ],
+    }));
+    render(<SyncDevicesSection variant="web" />);
+
+    expect(await screen.findByText("Ready - no web clients connected")).toBeTruthy();
+    expect(screen.queryByText("Connected")).toBeNull();
+  });
+
+  it("keeps the default all variant unchanged", async () => {
+    installAdeMock(makeHostSnapshot());
+    render(<SyncDevicesSection />);
+
+    expect(await screen.findByText("Pair a phone")).toBeTruthy();
+    expect(screen.getByText("Web client")).toBeTruthy();
+    expect(screen.getByText("Phones")).toBeTruthy();
+    expect(screen.getByText("Web clients")).toBeTruthy();
+  });
+
+  it("closes only the enlarged QR on Escape", async () => {
+    const parentEscape = vi.fn();
+    installAdeMock(makeHostSnapshot());
+    render(
+      <div onKeyDown={(event) => {
+        if (event.key === "Escape") parentEscape();
+      }}>
+        <SyncDevicesSection variant="web" />
+      </div>,
+    );
+
+    fireEvent.click(await screen.findByTitle("Click to enlarge"));
+    const dialog = await screen.findByRole("dialog", { name: "Web client pairing QR code" });
+    expect(dialog.closest("body")).toBe(document.body);
+
+    fireEvent.keyDown(dialog, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Web client pairing QR code" })).toBeNull();
+    });
+    expect(parentEscape).not.toHaveBeenCalled();
+    expect(screen.getByText("Web client")).toBeTruthy();
+  });
+
+  it("restarts copy feedback timers on repeated copies", async () => {
+    installAdeMock(makeHostSnapshot({ pairingPin: "123456" }));
+    render(<SyncDevicesSection variant="web" />);
+    const copy = await screen.findByRole("button", { name: "Copy code" });
+
+    vi.useFakeTimers();
+    await act(async () => {
+      fireEvent.click(copy);
+      await Promise.resolve();
+    });
+    expect(screen.getByText("Copied")).toBeTruthy();
+
+    act(() => vi.advanceTimersByTime(1_000));
+    await act(async () => {
+      fireEvent.click(copy);
+      await Promise.resolve();
+    });
+    act(() => vi.advanceTimersByTime(600));
+
+    expect(screen.getByText("Copied")).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check } from "@phosphor-icons/react";
 import { QRCodeSVG } from "qrcode.react";
+import { createPortal } from "react-dom";
 import type {
   SyncAddressCandidate,
   SyncCloudRelayStatus,
@@ -32,6 +34,18 @@ const helperTextStyle: React.CSSProperties = {
   fontSize: 11,
   lineHeight: 1.6,
 };
+
+export type SyncDevicesVariant = "all" | "phone" | "web";
+
+function generateSixDigitPin(): string {
+  const range = 1_000_000;
+  const maxUnbiasedValue = Math.floor(0x1_0000_0000 / range) * range;
+  const sample = new Uint32Array(1);
+  do {
+    globalThis.crypto.getRandomValues(sample);
+  } while (sample[0] >= maxUnbiasedValue);
+  return String(sample[0] % range).padStart(6, "0");
+}
 
 const inputStyle: React.CSSProperties = {
   height: 32,
@@ -189,7 +203,7 @@ function deviceConnectionLabel(device: SyncDeviceRuntimeState): string {
   }
 }
 
-export function SyncDevicesSection() {
+export function SyncDevicesSection({ variant = "all" }: { variant?: SyncDevicesVariant } = {}) {
   const [status, setStatus] = useState<SyncRoleSnapshot | null>(null);
   const [devices, setDevices] = useState<SyncDeviceRuntimeState[]>([]);
   const [cloudRelay, setCloudRelay] = useState<SyncCloudRelayStatus | null>(null);
@@ -264,6 +278,15 @@ export function SyncDevicesSection() {
     setNotice("PIN updated.");
   }), [runAction]);
 
+  // Throwing variant used by the web pairing code's inline "Generate new PIN"
+  // control so it can surface errors next to the button instead of at the
+  // section level. The setter returns the authoritative snapshot, avoiding a
+  // second refresh that could fail after the credential was already changed.
+  const handleSetPinValue = useCallback(async (pin: string) => {
+    const nextStatus = await window.ade.sync.setPin(pin);
+    setStatus(nextStatus);
+  }, []);
+
   const handleClearPin = useCallback(() => runAction(async () => {
     await window.ade.sync.clearPin();
     setNotice("PIN removed. Phones can no longer pair.");
@@ -317,7 +340,12 @@ export function SyncDevicesSection() {
     return <div style={helperTextStyle}>Phone sync is unavailable until ADE has a project to serve.</div>;
   }
 
-  const peerCount = status.connectedPeers.length;
+  const peerType: "phone" | "browser" | null =
+    variant === "phone" ? "phone" : variant === "web" ? "browser" : null;
+  const connectedPeers = peerType
+    ? status.connectedPeers.filter((peer) => peer.deviceType === peerType)
+    : status.connectedPeers;
+  const peerCount = connectedPeers.length;
   const phones = devices.filter((device) => !device.isLocal && device.deviceType === "phone");
   const phonesConnected = phones.filter((d) => d.connectionState === "connected").length;
   const phonesOffline = phones.length - phonesConnected;
@@ -328,45 +356,68 @@ export function SyncDevicesSection() {
   const hasTailscaleAddress = Boolean(status.localDevice.tailscaleIp);
   const showTailnetDiscovery = shouldShowTailnetDiscoveryPanel(status.tailnetDiscovery);
 
+  // A "phone" surface keeps phone pairing, discovery, this-computer and the
+  // phones list. A "web" surface keeps only the web client card, its relay row
+  // and the web clients list. "all" (Settings > Sync) shows everything.
+  const showPhone = variant === "all" || variant === "phone";
+  const showWeb = variant === "all" || variant === "web";
+  const onToggleCloudRelay = (enabled: boolean) => runAction(async () => {
+    const next = await window.ade.sync.setCloudRelayEnabled(enabled);
+    setCloudRelay(next);
+  });
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
       <StatusBar
         connected={peerCount > 0}
         peerCount={peerCount}
         ready={isPhoneSyncReady(status)}
+        readyLabel={variant === "web" ? "Ready - no web clients connected" : undefined}
       />
 
-      {isLocalHost ? (
-        <PairPhoneCard
-          connectInfo={status.pairingConnectInfo}
-          pin={status.pairingPin}
-          pinConfigured={status.pairingPinConfigured}
-          runtimeName={status.runtimeName}
-          busy={busy}
-          cloudRelay={cloudRelay}
-          onToggleCloudRelay={(enabled) => runAction(async () => {
-            const next = await window.ade.sync.setCloudRelayEnabled(enabled);
-            setCloudRelay(next);
-          })}
-          onSavePin={handleSetPin}
-          onGeneratePin={handleGeneratePin}
-          onClearPin={handleClearPin}
-          onSaveRuntimeName={handleSetRuntimeName}
-          onClearRuntimeName={handleClearRuntimeName}
-        />
-      ) : (
-        <ViewerPairingNotice />
-      )}
+      {showPhone ? (
+        isLocalHost ? (
+          <PairPhoneCard
+            connectInfo={status.pairingConnectInfo}
+            pin={status.pairingPin}
+            pinConfigured={status.pairingPinConfigured}
+            runtimeName={status.runtimeName}
+            busy={busy}
+            cloudRelay={cloudRelay}
+            onToggleCloudRelay={onToggleCloudRelay}
+            onSavePin={handleSetPin}
+            onGeneratePin={handleGeneratePin}
+            onClearPin={handleClearPin}
+            onSaveRuntimeName={handleSetRuntimeName}
+            onClearRuntimeName={handleClearRuntimeName}
+          />
+        ) : (
+          <ViewerPairingNotice />
+        )
+      ) : null}
 
-      {isLocalHost ? (
+      {showWeb && isLocalHost ? (
         <WebClientCard
           connectInfo={status.pairingConnectInfo}
           pinConfigured={status.pairingPinConfigured}
           pin={status.pairingPin}
+          busy={busy}
+          onSetPin={handleSetPinValue}
         />
       ) : null}
 
-      {showTailnetDiscovery ? (
+      {/* In "web" mode the relay lives standalone; in "all"/"phone" it renders
+          inside the phone card so we do not duplicate the control. */}
+      {showWeb && !showPhone && isLocalHost && cloudRelay ? (
+        <CloudRelayRow
+          cloudRelay={cloudRelay}
+          busy={busy}
+          onToggle={onToggleCloudRelay}
+          description="Keeps web clients connected when no LAN or Tailscale route works. On by default; turn off to never route through the relay."
+        />
+      ) : null}
+
+      {showPhone && showTailnetDiscovery ? (
         <TailnetDiscoveryPanel
           status={status.tailnetDiscovery}
           hasTailscaleAddress={hasTailscaleAddress}
@@ -379,51 +430,88 @@ export function SyncDevicesSection() {
       {notice ? <div style={{ ...helperTextStyle, color: COLORS.success }}>{notice}</div> : null}
       {error ? <div style={{ ...helperTextStyle, color: COLORS.danger }}>{error}</div> : null}
 
-      <details style={detailBlockStyle}>
-        <summary style={detailSummaryStyle}>
-          <span>This computer</span>
-          <span style={helperTextStyle}>
-            {status.localDevice.name}
-            {" "}&middot;{" "}
-            {formatEndpoint(status.localDevice.lastHost, status.localDevice.lastPort ?? 8787)}
-          </span>
-        </summary>
-        <div style={{ marginTop: 12 }}>
-          <ThisComputerDetails
-            localDevice={status.localDevice}
-            busy={busy}
-            onRename={handleRenameLocal}
-          />
-        </div>
-      </details>
+      {showPhone ? (
+        <details style={detailBlockStyle}>
+          <summary style={detailSummaryStyle}>
+            <span>This computer</span>
+            <span style={helperTextStyle}>
+              {status.localDevice.name}
+              {" "}&middot;{" "}
+              {formatEndpoint(status.localDevice.lastHost, status.localDevice.lastPort ?? 8787)}
+            </span>
+          </summary>
+          <div style={{ marginTop: 12 }}>
+            <ThisComputerDetails
+              localDevice={status.localDevice}
+              busy={busy}
+              onRename={handleRenameLocal}
+            />
+          </div>
+        </details>
+      ) : null}
 
-      <details style={detailBlockStyle}>
-        <summary style={detailSummaryStyle}>
-          <span>Phones</span>
-          <span style={helperTextStyle}>
-            {phones.length === 0
-              ? "None paired"
-              : `${phonesConnected} connected, ${phonesOffline} offline`}
-          </span>
-        </summary>
-        <div style={{ marginTop: 12 }}>
-          <PhonesList devices={phones} busy={busy} onForget={handleForgetDevice} />
-        </div>
-      </details>
+      {showPhone ? (
+        <details style={detailBlockStyle}>
+          <summary style={detailSummaryStyle}>
+            <span>Phones</span>
+            <span style={helperTextStyle}>
+              {phones.length === 0
+                ? "None paired"
+                : `${phonesConnected} connected, ${phonesOffline} offline`}
+            </span>
+          </summary>
+          <div style={{ marginTop: 12 }}>
+            <PhonesList devices={phones} busy={busy} onForget={handleForgetDevice} />
+          </div>
+        </details>
+      ) : null}
 
-      <details style={detailBlockStyle}>
-        <summary style={detailSummaryStyle}>
-          <span>Web clients</span>
-          <span style={helperTextStyle}>
-            {browsers.length === 0
-              ? "None paired"
-              : `${browsersConnected} connected, ${browsersOffline} offline`}
-          </span>
-        </summary>
-        <div style={{ marginTop: 12 }}>
-          <BrowsersList devices={browsers} busy={busy} onForget={handleForgetDevice} />
+      {showWeb ? (
+        <details style={detailBlockStyle}>
+          <summary style={detailSummaryStyle}>
+            <span>Web clients</span>
+            <span style={helperTextStyle}>
+              {browsers.length === 0
+                ? "None paired"
+                : `${browsersConnected} connected, ${browsersOffline} offline`}
+            </span>
+          </summary>
+          <div style={{ marginTop: 12 }}>
+            <BrowsersList devices={browsers} busy={busy} onForget={handleForgetDevice} />
+          </div>
+        </details>
+      ) : null}
+    </div>
+  );
+}
+
+function CloudRelayRow({
+  cloudRelay,
+  busy,
+  onToggle,
+  description = "Keeps your phone connected when no LAN or Tailscale route works. On by default; turn off to never route through the relay.",
+}: {
+  cloudRelay: SyncCloudRelayStatus;
+  busy: boolean;
+  onToggle: (enabled: boolean) => void;
+  description?: string;
+}) {
+  return (
+    <div style={{ ...panelStyle, gap: 10 }}>
+      <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) auto", gap: 12, alignItems: "center" }}>
+        <div style={{ display: "grid", gap: 4 }}>
+          <div style={LABEL_STYLE}>ADE relay</div>
+          <div style={helperTextStyle}>
+            {description}
+          </div>
         </div>
-      </details>
+        <SettingsToggle
+          id="sync-cloud-relay-toggle"
+          checked={cloudRelay.enabled}
+          disabled={busy}
+          onChange={onToggle}
+        />
+      </div>
     </div>
   );
 }
@@ -432,7 +520,17 @@ function isPhoneSyncReady(status: SyncRoleSnapshot): boolean {
   return (status.runtimeRole === "host" || status.role === "brain") && Boolean(status.pairingConnectInfo);
 }
 
-function StatusBar({ connected, peerCount, ready }: { connected: boolean; peerCount: number; ready: boolean }) {
+function StatusBar({
+  connected,
+  peerCount,
+  ready,
+  readyLabel = "Ready - no phones connected",
+}: {
+  connected: boolean;
+  peerCount: number;
+  ready: boolean;
+  readyLabel?: string;
+}) {
   let dotColor: string;
   if (connected) {
     dotColor = COLORS.accent;
@@ -443,7 +541,7 @@ function StatusBar({ connected, peerCount, ready }: { connected: boolean; peerCo
   }
   let label: string;
   if (!connected) {
-    label = ready ? "Ready - no phones connected" : "Unavailable";
+    label = ready ? readyLabel : "Unavailable";
   } else if (peerCount === 1) {
     label = "Connected";
   } else {
@@ -741,22 +839,7 @@ function PairPhoneCard({
       />
 
       {cloudRelay ? (
-        <div style={{ ...panelStyle, gap: 10 }}>
-          <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) auto", gap: 12, alignItems: "center" }}>
-            <div style={{ display: "grid", gap: 4 }}>
-              <div style={LABEL_STYLE}>ADE relay</div>
-              <div style={helperTextStyle}>
-                Keeps your phone connected when no LAN or Tailscale route works. On by default; turn off to never route through the relay.
-              </div>
-            </div>
-            <SettingsToggle
-              id="sync-cloud-relay-toggle"
-              checked={cloudRelay.enabled}
-              disabled={busy}
-              onChange={onToggleCloudRelay}
-            />
-          </div>
-        </div>
+        <CloudRelayRow cloudRelay={cloudRelay} busy={busy} onToggle={onToggleCloudRelay} />
       ) : null}
 
       <div style={{ display: "grid", gap: 10 }}>
@@ -795,35 +878,119 @@ function PairPhoneCard({
 // Same ADE-branded treatment as the welcome modal's TestFlight QR: white tile,
 // accent-tinted border, excavated ADE mark in the center (which is why the
 // error-correction level is H). Shared by phone and web-client pairing panels.
-function QrCodeBox({ value, title }: { value: string; title: string }) {
+function QrCodeSvgTile({ value, title, size }: { value: string; title: string; size: number }) {
+  const iconSize = Math.round(size * (32 / 148));
   return (
-    <div style={{ ...panelStyle, gap: 0, padding: 12, placeItems: "center" }}>
+    <QRCodeSVG
+      value={value}
+      size={size}
+      level="H"
+      marginSize={1}
+      bgColor="#FFFFFF"
+      fgColor="#111827"
+      title={title}
+      imageSettings={{
+        src: publicAssetUrl("welcome/ade-icon.webp"),
+        height: iconSize,
+        width: iconSize,
+        excavate: true,
+      }}
+    />
+  );
+}
+
+function QrCodeBox({ value, title }: { value: string; title: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const triggerRef = useRef<HTMLDivElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!expanded) return;
+    const frame = window.requestAnimationFrame(() => dialogRef.current?.focus());
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        setExpanded(false);
+      } else if (event.key === "Tab") {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        dialogRef.current?.focus();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.removeEventListener("keydown", onKey, true);
+      triggerRef.current?.focus();
+    };
+  }, [expanded]);
+
+  return (
+    <>
       <div
-        style={{
-          display: "inline-flex",
-          padding: 14,
-          borderRadius: 14,
-          background: "#FFFFFF",
-          border: "1px solid color-mix(in srgb, var(--color-accent, #A78BFA) 30%, transparent)",
+        ref={triggerRef}
+        role="button"
+        tabIndex={0}
+        title="Click to enlarge"
+        onClick={() => setExpanded(true)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            setExpanded(true);
+          }
         }}
+        style={{ ...panelStyle, gap: 0, padding: 12, placeItems: "center", cursor: "pointer" }}
       >
-        <QRCodeSVG
-          value={value}
-          size={148}
-          level="H"
-          marginSize={1}
-          bgColor="#FFFFFF"
-          fgColor="#111827"
-          title={title}
-          imageSettings={{
-            src: publicAssetUrl("welcome/ade-icon.webp"),
-            height: 32,
-            width: 32,
-            excavate: true,
+        <div
+          style={{
+            display: "inline-flex",
+            padding: 14,
+            borderRadius: 14,
+            background: "#FFFFFF",
+            border: "1px solid color-mix(in srgb, var(--color-accent, #A78BFA) 30%, transparent)",
           }}
-        />
+        >
+          <QrCodeSvgTile value={value} title={title} size={148} />
+        </div>
       </div>
-    </div>
+      {expanded && typeof document !== "undefined"
+        ? createPortal(
+          <div
+            onClick={() => setExpanded(false)}
+            style={{
+              position: "fixed",
+              inset: 0,
+              zIndex: 200,
+              display: "grid",
+              placeItems: "center",
+              background: "rgba(0,0,0,0.62)",
+            }}
+          >
+            <div
+              ref={dialogRef}
+              role="dialog"
+              aria-modal="true"
+              aria-label={title}
+              tabIndex={-1}
+              onClick={(event) => event.stopPropagation()}
+              style={{
+                display: "inline-flex",
+                padding: 22,
+                borderRadius: 20,
+                background: "#FFFFFF",
+                border: "1px solid color-mix(in srgb, var(--color-accent, #A78BFA) 30%, transparent)",
+                boxShadow: "0 24px 60px rgba(0,0,0,0.45)",
+                outline: "none",
+              }}
+            >
+              <QrCodeSvgTile value={value} title={title} size={360} />
+            </div>
+          </div>,
+          document.body,
+        )
+        : null}
+    </>
   );
 }
 
@@ -839,21 +1006,25 @@ function WebClientCard({
   connectInfo,
   pinConfigured,
   pin,
+  busy,
+  onSetPin,
 }: {
   connectInfo: SyncPairingConnectInfo | null;
   pinConfigured: boolean;
   pin: string | null;
+  busy: boolean;
+  onSetPin: (pin: string) => Promise<void>;
 }) {
   const hasAddresses = (connectInfo?.addressCandidates.length ?? 0) > 0;
   const pinMissing = !pinConfigured;
   const pinHidden = pinConfigured && !pin;
+  // The hidden-PIN case is handled inline by the pairing code block below, so
+  // the card-level helper stays terse and only covers the other states.
   let pairingHelpText = "Open the link, enter the pairing code in the browser, and the browser pairs to this machine.";
   if (pinMissing) {
-    pairingHelpText = "No PIN set. Browsers cannot pair. Set a PIN in the phone pairing section above.";
+    pairingHelpText = "No PIN set. Browsers cannot pair. Set a PIN in the phone pairing section.";
   } else if (pinHidden) {
-    pairingHelpText =
-      "A PIN is configured but hidden after runtime restart. If you already know it, the existing PIN still pairs. " +
-      "Generate or set a new PIN above only when you need ADE to display or copy one.";
+    pairingHelpText = "";
   }
 
   return (
@@ -895,46 +1066,156 @@ function WebClientCard({
               Scan the QR, or open the pairing link in a browser to pair.
             </div>
             <WebPairLink connectInfo={connectInfo as SyncPairingConnectInfo} />
-            <WebPairCode pin={pin} pinConfigured={pinConfigured} />
+            <WebPairCode pin={pin} pinConfigured={pinConfigured} busy={busy} onSetPin={onSetPin} />
           </div>
         </div>
       ) : (
         <div style={helperTextStyle}>No machine addresses are published yet.</div>
       )}
 
-      <div style={helperTextStyle}>{pairingHelpText}</div>
+      {pairingHelpText ? <div style={helperTextStyle}>{pairingHelpText}</div> : null}
     </div>
   );
 }
 
-function WebPairCode({ pin, pinConfigured }: { pin: string | null; pinConfigured: boolean }) {
+function flashHighlightStyle(active: boolean): React.CSSProperties {
+  return {
+    transition: "background 600ms ease, color 600ms ease",
+    borderRadius: 6,
+    background: active
+      ? "color-mix(in srgb, var(--color-accent, #A78BFA) 22%, transparent)"
+      : "transparent",
+    color: active ? COLORS.textPrimary : undefined,
+  };
+}
+
+function CopiedGlyphLabel({ copied, idle }: { copied: boolean; idle: string }) {
+  if (!copied) return <>{idle}</>;
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
+      <Check size={12} weight="bold" />
+      Copied
+    </span>
+  );
+}
+
+function useCopyFeedback() {
   const [copied, setCopied] = useState(false);
+  const [flash, setFlash] = useState(false);
+  const copiedTimerRef = useRef<number | null>(null);
+  const flashTimerRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (copiedTimerRef.current != null) window.clearTimeout(copiedTimerRef.current);
+      if (flashTimerRef.current != null) window.clearTimeout(flashTimerRef.current);
+    };
+  }, []);
+
+  const showFeedback = useCallback(() => {
+    if (!mountedRef.current) return;
+    if (copiedTimerRef.current != null) window.clearTimeout(copiedTimerRef.current);
+    if (flashTimerRef.current != null) window.clearTimeout(flashTimerRef.current);
+    setCopied(true);
+    setFlash(true);
+    copiedTimerRef.current = window.setTimeout(() => {
+      copiedTimerRef.current = null;
+      setCopied(false);
+    }, 1500);
+    flashTimerRef.current = window.setTimeout(() => {
+      flashTimerRef.current = null;
+      setFlash(false);
+    }, 600);
+  }, []);
+
+  return { copied, flash, showFeedback };
+}
+
+function WebPairCode({
+  pin,
+  pinConfigured,
+  busy,
+  onSetPin,
+}: {
+  pin: string | null;
+  pinConfigured: boolean;
+  busy: boolean;
+  onSetPin: (pin: string) => Promise<void>;
+}) {
+  const { copied, flash, showFeedback } = useCopyFeedback();
+  const [generating, setGenerating] = useState(false);
+  const [genError, setGenError] = useState<string | null>(null);
+
   const handleCopy = useCallback(async () => {
     if (!pin) return;
     try {
-      await window.ade?.app?.writeClipboardText?.(pin);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
+      const writeClipboardText = window.ade?.app?.writeClipboardText;
+      if (!writeClipboardText) return;
+      await writeClipboardText(pin);
+      showFeedback();
     } catch {
       // Clipboard may be unavailable; the code stays visible to copy manually.
     }
-  }, [pin]);
+  }, [pin, showFeedback]);
+
+  const handleGenerate = useCallback(async () => {
+    if (busy || generating) return;
+    setGenError(null);
+    setGenerating(true);
+    try {
+      await onSetPin(generateSixDigitPin());
+    } catch (err) {
+      setGenError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setGenerating(false);
+    }
+  }, [busy, generating, onSetPin]);
+
+  const hiddenPin = pinConfigured && !pin;
 
   return (
     <div style={{ ...panelStyle, gap: 8 }}>
       <div style={LABEL_STYLE}>Pairing code</div>
-      <div style={{ ...codeValueStyle, fontSize: 18, letterSpacing: "0.32em", fontVariantNumeric: "tabular-nums" }}>
+      <div
+        style={{
+          ...codeValueStyle,
+          fontSize: 18,
+          letterSpacing: "0.32em",
+          fontVariantNumeric: "tabular-nums",
+          alignSelf: "start",
+          padding: "0 4px",
+          ...flashHighlightStyle(flash),
+        }}
+      >
         {pin ? pin : pinConfigured ? "••••••" : "Not set"}
       </div>
-      <button
-        type="button"
-        style={outlineButton({ justifySelf: "start", height: 30 })}
-        onClick={() => void handleCopy()}
-        disabled={!pin}
-        title={pin ? undefined : "The PIN is hidden; generate or set a new PIN in the phone pairing section above."}
-      >
-        {copied ? "Copied" : "Copy code"}
-      </button>
+      {hiddenPin ? (
+        <>
+          <button
+            type="button"
+            style={outlineButton({ justifySelf: "start", height: 30, opacity: busy || generating ? 0.6 : 1 })}
+            onClick={() => void handleGenerate()}
+            disabled={busy || generating}
+          >
+            {generating ? "Generating…" : "Generate new PIN"}
+          </button>
+          <div style={helperTextStyle}>Existing PIN still pairs if you know it.</div>
+        </>
+      ) : (
+        <button
+          type="button"
+          style={outlineButton({ justifySelf: "start", height: 30 })}
+          onClick={() => void handleCopy()}
+          disabled={!pin}
+          title={pin ? undefined : "Set a PIN in the phone pairing section to enable copy."}
+        >
+          <CopiedGlyphLabel copied={copied} idle="Copy code" />
+        </button>
+      )}
+      {genError ? <div style={{ ...helperTextStyle, color: COLORS.danger }}>{genError}</div> : null}
     </div>
   );
 }
@@ -952,17 +1233,18 @@ function WebPairLink({ connectInfo }: { connectInfo: SyncPairingConnectInfo }) {
     () => buildWebClientPairUrl(buildPairingQrPayload({ connectInfo })),
     [connectInfo],
   );
-  const [copied, setCopied] = useState(false);
+  const { copied, flash, showFeedback } = useCopyFeedback();
 
   const handleCopy = useCallback(async () => {
     try {
-      await window.ade?.app?.writeClipboardText?.(url);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
+      const writeClipboardText = window.ade?.app?.writeClipboardText;
+      if (!writeClipboardText) return;
+      await writeClipboardText(url);
+      showFeedback();
     } catch {
       // Clipboard may be unavailable; leave the link visible to copy manually.
     }
-  }, [url]);
+  }, [showFeedback, url]);
 
   return (
     <div style={{ ...panelStyle, gap: 8 }}>
@@ -973,6 +1255,8 @@ function WebPairLink({ connectInfo }: { connectInfo: SyncPairingConnectInfo }) {
           whiteSpace: "nowrap",
           overflow: "hidden",
           textOverflow: "ellipsis",
+          padding: "0 4px",
+          ...flashHighlightStyle(flash),
         }}
         title={url}
       >
@@ -983,7 +1267,7 @@ function WebPairLink({ connectInfo }: { connectInfo: SyncPairingConnectInfo }) {
         style={outlineButton({ justifySelf: "start", height: 30 })}
         onClick={() => void handleCopy()}
       >
-        {copied ? "Copied" : "Copy link"}
+        <CopiedGlyphLabel copied={copied} idle="Copy link" />
       </button>
     </div>
   );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "dev:detach": "nohup vite >> .vite-dev.log 2>&1 & echo \"Vite detached on http://localhost:4180/ (log: .vite-dev.log)\"",
-    "build": "tsc -p tsconfig.json --noEmit && vite build",
+    "build": "node scripts/check-entities.mjs && tsc -p tsconfig.json --noEmit && vite build",
     "preview": "vite preview",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/apps/web/scripts/check-entities.mjs
+++ b/apps/web/scripts/check-entities.mjs
@@ -1,0 +1,163 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { extname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const appRoot = fileURLToPath(new URL("..", import.meta.url));
+const sourceRoot = join(appRoot, "src");
+const allowedNames = new Set(["amp", "lt", "gt", "quot"]);
+const noAllowedNames = new Set();
+const entityPattern = /&([a-zA-Z][a-zA-Z0-9]+);/g;
+const skippedDirectories = new Set(["dist", "node_modules"]);
+
+function sourceFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      return skippedDirectories.has(entry.name) ? [] : sourceFiles(path);
+    }
+
+    return [".tsx", ".jsx"].includes(extname(entry.name)) ? [path] : [];
+  });
+}
+
+function isInsideUrl(source, position) {
+  const tokenStart = Math.max(
+    source.lastIndexOf(" ", position),
+    source.lastIndexOf("\n", position),
+    source.lastIndexOf("\t", position),
+    source.lastIndexOf('"', position),
+    source.lastIndexOf("'", position),
+    source.lastIndexOf("`", position),
+    source.lastIndexOf("<", position),
+    source.lastIndexOf(">", position),
+  ) + 1;
+  const tokenEndMatch = source.slice(position).search(/[\s"'<>]/);
+  const tokenEnd = tokenEndMatch === -1 ? source.length : position + tokenEndMatch;
+  const token = source.slice(tokenStart, tokenEnd);
+  return /^(?:[a-z][a-z\d+.-]*:\/\/|www\.)/i.test(token);
+}
+
+const violations = [];
+
+for (const file of sourceFiles(sourceRoot)) {
+  const source = readFileSync(file, "utf8");
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    extname(file) === ".tsx" ? ts.ScriptKind.TSX : ts.ScriptKind.JSX,
+  );
+
+  function checkRange(start, end, allowed = allowedNames, urlContext = false) {
+    const text = source.slice(start, end);
+    for (const match of text.matchAll(entityPattern)) {
+      const name = match[1];
+      const position = start + match.index;
+      if (allowed.has(name) || urlContext || isInsideUrl(source, position)) continue;
+      const line = sourceFile.getLineAndCharacterOfPosition(position).line + 1;
+      violations.push(`${relative(appRoot, file)}:${line}: &${name};`);
+    }
+  }
+
+  function checkRenderedStrings(node) {
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      checkRange(node.getStart(sourceFile), node.getEnd(), noAllowedNames);
+      return;
+    }
+    if (ts.isTemplateExpression(node)) {
+      const urlContext = /^(?:[a-z][a-z\d+.-]*:\/\/|www\.)/i.test(node.head.text);
+      checkRange(node.head.getStart(sourceFile), node.head.getEnd(), noAllowedNames, urlContext);
+      for (const span of node.templateSpans) {
+        checkRenderedStrings(span.expression);
+        checkRange(
+          span.literal.getStart(sourceFile),
+          span.literal.getEnd(),
+          noAllowedNames,
+          urlContext,
+        );
+      }
+      return;
+    }
+
+    if (
+      ts.isParenthesizedExpression(node)
+      || ts.isAsExpression(node)
+      || ts.isTypeAssertionExpression(node)
+      || ts.isNonNullExpression(node)
+      || ts.isSatisfiesExpression(node)
+    ) {
+      checkRenderedStrings(node.expression);
+      return;
+    }
+
+    if (ts.isConditionalExpression(node)) {
+      checkRenderedStrings(node.whenTrue);
+      checkRenderedStrings(node.whenFalse);
+      return;
+    }
+
+    if (ts.isBinaryExpression(node)) {
+      const operator = node.operatorToken.kind;
+      if (
+        operator === ts.SyntaxKind.PlusToken
+        || operator === ts.SyntaxKind.BarBarToken
+        || operator === ts.SyntaxKind.QuestionQuestionToken
+      ) {
+        checkRenderedStrings(node.left);
+      }
+      if (
+        operator === ts.SyntaxKind.PlusToken
+        || operator === ts.SyntaxKind.AmpersandAmpersandToken
+        || operator === ts.SyntaxKind.BarBarToken
+        || operator === ts.SyntaxKind.QuestionQuestionToken
+      ) {
+        checkRenderedStrings(node.right);
+      }
+      return;
+    }
+
+    if (ts.isArrayLiteralExpression(node)) {
+      for (const element of node.elements) {
+        if (!ts.isSpreadElement(element)) checkRenderedStrings(element);
+      }
+    }
+  }
+
+  function visit(node) {
+    if (ts.isJsxAttribute(node) && node.initializer) {
+      if (ts.isStringLiteral(node.initializer)) {
+        checkRange(
+          node.initializer.getStart(sourceFile),
+          node.initializer.getEnd(),
+        );
+      } else if (
+        ts.isJsxExpression(node.initializer)
+        && node.initializer.expression
+      ) {
+        checkRenderedStrings(node.initializer.expression);
+      }
+    } else if (ts.isJsxText(node)) {
+      checkRange(node.getStart(sourceFile), node.getEnd());
+    } else if (
+      ts.isJsxExpression(node)
+      && node.expression
+      && (ts.isJsxElement(node.parent) || ts.isJsxFragment(node.parent))
+    ) {
+      checkRenderedStrings(node.expression);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+}
+
+if (violations.length > 0) {
+  console.error("Named HTML entities in JSX text must use literal Unicode characters:");
+  for (const violation of violations) console.error(`  ${violation}`);
+  process.exitCode = 1;
+} else {
+  console.log("Entity check passed.");
+}

--- a/apps/web/src/components/SiteFooter.tsx
+++ b/apps/web/src/components/SiteFooter.tsx
@@ -80,7 +80,7 @@ export function SiteFooter() {
 
         <div className="mt-10 flex flex-col items-start justify-between gap-3 border-t border-border/70 pt-6 text-xs text-muted-fg sm:flex-row sm:items-center">
           <div>
-            &copy; {year} ADE.{" "}
+            © {year} ADE.{" "}
             <a className="focus-ring rounded-md hover:text-fg" href={`${LINKS.github}/blob/main/LICENSE`} target="_blank" rel="noreferrer">
               AGPL-3.0 License.
             </a>

--- a/apps/web/src/components/editorial/BackCover.tsx
+++ b/apps/web/src/components/editorial/BackCover.tsx
@@ -51,7 +51,7 @@ export function BackCover() {
           >
             The last AI coding app{" "}
             <em className="italic text-[color:var(--color-violet-bright)]">
-              you&rsquo;ll download.
+              you’ll download.
             </em>
           </motion.h2>
 
@@ -109,9 +109,9 @@ export function BackCover() {
               className="font-serif italic text-[color:var(--color-cream-faint)]"
               style={{ fontSize: "13.5px", lineHeight: 1.55 }}
             >
-              Colophon &middot; Set in Instrument Serif &amp; Inter Tight.
+              Colophon · Set in Instrument Serif & Inter Tight.
               Printed to the web from a single <code className="not-italic">git push</code>.
-              &copy; ADE, 2026. Free forever. Source on GitHub.
+              © ADE, 2026. Free forever. Source on GitHub.
             </p>
             <div className="mt-4 flex gap-4 text-[12px] text-[color:var(--color-cream-faint)]">
               <Link className="underline-offset-4 hover:text-[color:var(--color-cream)] hover:underline" to="/privacy">

--- a/apps/web/src/components/editorial/Chapter.tsx
+++ b/apps/web/src/components/editorial/Chapter.tsx
@@ -39,9 +39,9 @@ export function Chapter({
       <div className="mx-auto max-w-[1520px] px-[clamp(20px,3vw,48px)] py-[clamp(24px,3vw,52px)]">
         {/* running head */}
         <div className="mb-6 flex items-baseline justify-between border-b border-[color:var(--color-ink-hairline)] pb-3 text-[11px] uppercase tracking-[0.24em] text-[color:var(--color-ink-muted)]">
-          <span>ADE &middot; {EDITORIAL_ISSUE.shortMonthYear}</span>
+          <span>ADE · {EDITORIAL_ISSUE.shortMonthYear}</span>
           <span className="hidden sm:block">The Agentic Development Environment</span>
-          <span>{EDITORIAL_ISSUE.volume} &middot; {EDITORIAL_ISSUE.version} &middot; {pageNumber}</span>
+          <span>{EDITORIAL_ISSUE.volume} · {EDITORIAL_ISSUE.version} · {pageNumber}</span>
         </div>
 
         {/* folio */}
@@ -132,7 +132,7 @@ export function Byline({
             : "bg-[color:var(--color-hairline-strong)]"
         )}
       />
-      {author} &middot; {date}
+      {author} · {date}
     </div>
   );
 }

--- a/apps/web/src/components/editorial/FeatureGrid.tsx
+++ b/apps/web/src/components/editorial/FeatureGrid.tsx
@@ -310,9 +310,9 @@ export function FeatureGrid() {
       <div className="mx-auto max-w-[1520px] px-[clamp(20px,3vw,48px)] py-[clamp(44px,5.5vw,84px)]">
         {/* running head */}
         <div className="mb-10 flex items-baseline justify-between border-b border-[color:var(--color-ink-hairline)] pb-4 text-[11px] uppercase tracking-[0.24em] text-[color:var(--color-ink-muted)]">
-          <span>ADE &middot; {EDITORIAL_ISSUE.shortMonthYear}</span>
+          <span>ADE · {EDITORIAL_ISSUE.shortMonthYear}</span>
           <span className="hidden sm:block">Catalog</span>
-          <span>{EDITORIAL_ISSUE.volume} &middot; {EDITORIAL_ISSUE.version} &middot; 32</span>
+          <span>{EDITORIAL_ISSUE.volume} · {EDITORIAL_ISSUE.version} · 32</span>
         </div>
 
         {/* folio */}
@@ -348,7 +348,7 @@ export function FeatureGrid() {
           className="mx-auto mb-12 max-w-[52ch] text-center font-serif italic text-[color:var(--color-ink-muted)]"
           style={{ fontSize: "19px", lineHeight: 1.4 }}
         >
-          Every tab you&rsquo;d expect &mdash; and a few you wouldn&rsquo;t.
+          Every tab you’d expect — and a few you wouldn’t.
           They play as you scroll; click any to watch.
         </motion.p>
 

--- a/apps/web/src/components/editorial/IndexPage.tsx
+++ b/apps/web/src/components/editorial/IndexPage.tsx
@@ -51,9 +51,9 @@ export function IndexPage() {
     >
       <div className="mx-auto max-w-[1520px] px-[clamp(20px,3vw,48px)] py-[clamp(44px,5.5vw,84px)]">
         <div className="mb-10 flex items-baseline justify-between border-b border-[color:var(--color-ink-hairline)] pb-4 text-[11px] uppercase tracking-[0.24em] text-[color:var(--color-ink-muted)]">
-          <span>ADE &middot; {EDITORIAL_ISSUE.shortMonthYear}</span>
+          <span>ADE · {EDITORIAL_ISSUE.shortMonthYear}</span>
           <span className="hidden sm:block">Back matter</span>
-          <span>{EDITORIAL_ISSUE.volume} &middot; {EDITORIAL_ISSUE.version} &middot; 34</span>
+          <span>{EDITORIAL_ISSUE.volume} · {EDITORIAL_ISSUE.version} · 34</span>
         </div>
 
         <motion.h2

--- a/apps/web/src/components/editorial/Masthead.tsx
+++ b/apps/web/src/components/editorial/Masthead.tsx
@@ -40,7 +40,7 @@ export function Masthead() {
             rel="noreferrer"
             className="text-[color:var(--color-violet-bright)] transition-colors hover:text-[color:var(--color-cream)]"
           >
-            Web client <span aria-hidden>&nearr;</span>
+            Web client <span aria-hidden>↗</span>
           </a>
           <a
             href={LINKS.releasesLatest}
@@ -48,7 +48,7 @@ export function Masthead() {
             rel="noreferrer"
             className="text-[color:var(--color-violet-bright)] transition-colors hover:text-[color:var(--color-cream)]"
           >
-            Mac <span aria-hidden>&darr;</span>
+            Mac <span aria-hidden>↓</span>
           </a>
           <a
             href={LINKS.testflight}
@@ -56,7 +56,7 @@ export function Masthead() {
             rel="noreferrer"
             className="text-[color:var(--color-violet-bright)] transition-colors hover:text-[color:var(--color-cream)]"
           >
-            iOS <span aria-hidden>&darr;</span>
+            iOS <span aria-hidden>↓</span>
           </a>
         </nav>
       </div>

--- a/apps/web/src/components/ui/AppScreenshot.tsx
+++ b/apps/web/src/components/ui/AppScreenshot.tsx
@@ -75,13 +75,13 @@ export function AppScreenshot() {
                                 <div className="text-purple-400">import</div> <span className="text-white">{"{"} Page {"}"}</span> <div className="text-purple-400">from</div> <span className="text-green-400">"../../components/Page"</span>;<br />
                                 <br />
                                 <div className="text-purple-400">export function</div> <span className="text-yellow-300">HomePage</span>() {"{"}<br />
-                                &nbsp;&nbsp;<span className="text-blue-400">useDocumentTitle</span>(<span className="text-green-400">"ADE"</span>);<br />
+                                {"  "}<span className="text-blue-400">useDocumentTitle</span>(<span className="text-green-400">"ADE"</span>);<br />
                                 <br />
-                                &nbsp;&nbsp;<div className="text-purple-400">return</div> (<br />
-                                &nbsp;&nbsp;&nbsp;&nbsp;&lt;<span className="text-yellow-300">Page</span> <span className="text-blue-300">className</span>=<span className="text-green-400">"overflow-hidden"</span>&gt;<br />
-                                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;<span className="text-yellow-300">HeroSection</span> /&gt;<br />
-                                &nbsp;&nbsp;&nbsp;&nbsp;&lt;/<span className="text-yellow-300">Page</span>&gt;<br />
-                                &nbsp;&nbsp;);<br />
+                                {"  "}<div className="text-purple-400">return</div> (<br />
+                                {"    "}&lt;<span className="text-yellow-300">Page</span> <span className="text-blue-300">className</span>=<span className="text-green-400">"overflow-hidden"</span>&gt;<br />
+                                {"      "}&lt;<span className="text-yellow-300">HeroSection</span> /&gt;<br />
+                                {"    "}&lt;/<span className="text-yellow-300">Page</span>&gt;<br />
+                                {"  "});<br />
                                 {"}"}
                                 <motion.div
                                     animate={{ opacity: [1, 0, 1] }}
@@ -111,13 +111,13 @@ export function AppScreenshot() {
                                     <span className="text-white">npm run dev</span>
                                 </div>
                                 <div className="mt-1 text-white/50">
-                                    &nbsp;&nbsp;VITE v4.5.3	<span className="text-green-500">ready in 240 ms</span>
+                                    {"  "}VITE v4.5.3	<span className="text-green-500">ready in 240 ms</span>
                                 </div>
                                 <div className="mt-1">
-                                    &nbsp;&nbsp;<span className="text-white">➜</span>  <span className="text-white">Local:</span>   <span className="text-blue-400 underline">http://localhost:5173/</span>
+                                    {"  "}<span className="text-white">➜</span>  <span className="text-white">Local:</span>   <span className="text-blue-400 underline">http://localhost:5173/</span>
                                 </div>
                                 <div className="mt-1">
-                                    &nbsp;&nbsp;<span className="text-white">➜</span>  <span className="text-white">Network:</span> use --host to expose
+                                    {"  "}<span className="text-white">➜</span>  <span className="text-white">Network:</span> use --host to expose
                                 </div>
                             </div>
                         </div>

--- a/docs/features/onboarding-and-settings/README.md
+++ b/docs/features/onboarding-and-settings/README.md
@@ -218,13 +218,18 @@ Renderer — settings:
   and `LaneBehaviorSection.tsx` — lane initialization recipes and
   lifecycle policies.
 - `apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx`
-  — multi-device sync management. Surfaces the phone-pairing PIN (set
-  / clear / reveal), the QR payload (v2) with its LAN / Tailscale /
-  loopback address candidates, the bootstrap token for desktop peers,
-  the Tailscale MagicDNS discovery status (`svc:ade-sync` publication
-  via `tailscale serve`), and the per-device connection panel used to
-  forget paired phones. The top-bar Mobile popover wraps this section
-  with a TestFlight download action for installing ADE Mobile.
+  — multi-device sync management. The default `variant="all"` shows phone,
+  web-client, and desktop-peer controls in Settings; `"phone"` and `"web"`
+  variants provide focused content for the matching top-bar sheets. It
+  surfaces the phone-pairing PIN (set / clear / reveal, or generate a new
+  six-digit PIN when only the at-rest hash remains), the v3 smart pairing URL
+  with LAN / Tailscale / loopback / relay candidates, the web-client link and
+  QR, the bootstrap token for desktop peers, relay/discovery status, and the
+  per-device panels used to forget paired phones or revoke web clients.
+- `apps/desktop/src/renderer/components/app/TopBar.tsx` and `HeaderSheet.tsx`
+  — Mobile and Web connection chips plus their mutually exclusive portaled
+  sheets. The Mobile sheet includes the TestFlight install action; the Web
+  sheet reports connected browser peers and exposes focused browser pairing.
 - `apps/desktop/src/renderer/components/usage/HeaderUsageControl.tsx`
   and `UsageQuotaPanel.tsx` — header usage popup. Live provider quotas
   for Claude and Codex (tracked providers) and the automation budget

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -190,6 +190,23 @@ Runtime support files outside `services/sync/`:
   budget (64 icons / 12 MB per call) so large project registries cannot stall
   remote desktop or mobile catalog setup just to inline artwork.
 
+Desktop pairing UI:
+
+- `apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx` —
+  Settings uses the default `variant="all"`; the top-bar sheets use the
+  focused `"phone"` and `"web"` variants. When a configured PIN is available
+  only as its at-rest PBKDF2 hash after a runtime restart, the web pairing card
+  can generate and set a new six-digit PIN instead of leaving copy disabled.
+- `apps/desktop/src/renderer/components/app/TopBar.tsx` — Mobile and Web
+  connection chips, connected-peer summaries, and mutually exclusive pairing
+  sheets. Browser peers are identified by `deviceType === "browser"`.
+- `apps/desktop/src/renderer/components/app/HeaderSheet.tsx` — shared portaled
+  sheet and dialog focus-trap scaffold for the Mobile and Web panels.
+- `apps/desktop/src/renderer/components/settings/SyncDevicesSection.test.tsx`
+  and `apps/desktop/src/renderer/components/app/TopBar.test.tsx` — focused
+  pairing variants, hidden-PIN generation, QR/copy interactions, web-peer chip,
+  and sheet dismissal coverage.
+
 Canonical files (`apps/ade-cli/src/services/sync/`):
 
 - `syncService.ts` (~1,160 lines) — orchestrator that wires the runtime,
@@ -660,8 +677,9 @@ is not supported.
   it (or after legacy migration), so after a restart the host can verify
   pairings with the existing digits if the user still knows them. It
   cannot display or copy those digits until the user generates or sets a
-  new PIN. The phone enters the same digits the user
-  typed in the machine's Settings > Sync > Phone pairing sheet.
+  new PIN. The desktop Settings view and top-bar Web sheet expose the
+  generate-new-PIN recovery path; the phone enters the same digits shown in
+  the machine's Settings view or top-bar Mobile/Web pairing sheets.
   Failed PIN attempts increment a per-IP counter; after 5 failures
   the runtime rejects further attempts from that IP for 10 minutes
   (`PAIR_FAILURE_THRESHOLD = 5`, `PAIR_COOLDOWN_MS = 10 * 60_000` in

--- a/docs/features/web-client/README.md
+++ b/docs/features/web-client/README.md
@@ -7,9 +7,10 @@ protocol, using the same sync host that iOS uses.
 
 Production hosting is Cloudflare Pages. The Pages URL is
 `https://ade-web-client.pages.dev`; the canonical product URL in source is
-`https://app.ade-app.dev` (`WEB_CLIENT_BASE_URL`). DNS for the canonical domain
-is pending, so use the Pages URL for live deployment checks until it resolves.
-The app is built from `apps/desktop` with `npm run build:webclient`.
+`https://app.ade-app.dev` (`WEB_CLIENT_BASE_URL`). The canonical domain is live
+and attached to the `ade-web-client` Pages project; the Pages URL remains a
+direct deployment-check fallback. The app is built from `apps/desktop` with
+`npm run build:webclient`.
 
 ## Source file map
 
@@ -101,6 +102,13 @@ Reused desktop renderer (web-mode adaptation):
   `WelcomeVideoGate.tsx`) reads this flag to hide native window controls, the
   updater, the onboarding tour, and tabs with no sync-protocol backing instead
   of rendering broken affordances.
+- `apps/desktop/src/renderer/components/app/TopBar.tsx` - desktop Mobile and
+  Web connection chips. The Web chip reports connected browser peers, opens
+  the web-only pairing sheet, and is omitted from the hosted web-client shell.
+  Remote, Mobile, and Web sheets are mutually exclusive.
+- `apps/desktop/src/renderer/components/app/HeaderSheet.tsx` - shared portaled
+  sheet scaffold and dialog focus-trap helpers used by the Mobile and Web
+  top-bar sheets.
 
 Machine runtime and sync host:
 
@@ -133,8 +141,12 @@ Machine runtime and sync host:
 Pairing, links, and entry points:
 
 - `apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx` -
-  desktop Settings > Sync web-client card, web pairing QR/link, cloud relay
-  toggle, and Web clients revoke/remove list.
+  desktop Settings > Sync device management plus the focused top-bar sheet
+  bodies. Its `variant?: "all" | "phone" | "web"` prop keeps Settings complete
+  while the Mobile and Web sheets show only their relevant controls. The web
+  variant can generate a new six-digit PIN when the configured PIN is hashed
+  at rest and no longer displayable, and provides copy feedback plus an
+  enlarged pairing-QR dialog.
 - `apps/desktop/src/shared/pairingQr.ts` - smart pairing URL
   `https://ade-app.dev/pair#<base64url(JSON)>`; the fragment carries host
   identity, port, address candidates, and optional relay URL, never the PIN.
@@ -150,6 +162,10 @@ Pairing, links, and entry points:
   `SessionContextMenu.tsx` - desktop "Open in web" entry points.
 - `apps/web/src/app/pages/PairPage.tsx` - marketing-site `/pair` hash-forward
   to the hosted web client.
+- `apps/web/scripts/check-entities.mjs` - dependency-free TypeScript-AST guard
+  run by the marketing-site build. It rejects unsupported named HTML entities
+  in JSX text, expressions, and attributes before they can ship as literal UI
+  text.
 - `apps/ios/ADE/Views/Settings/SettingsWebClientPairSheet.swift` - iOS
   Settings > Pairing > "Pair a browser" sheet. It fetches the machine's
   pairing URL, PIN, machine name, and relay availability over the
@@ -158,6 +174,8 @@ Pairing, links, and entry points:
 
 Tests:
 
+- `apps/desktop/src/renderer/components/app/TopBar.test.tsx`.
+- `apps/desktop/src/renderer/components/settings/SyncDevicesSection.test.tsx`.
 - `apps/desktop/src/renderer/webclient/sync/__tests__/sync.test.ts`.
 - `apps/desktop/src/renderer/webclient/adapter/__tests__/adapter.test.ts`.
 - `apps/desktop/src/renderer/webclient/shell/__tests__/webRoutes.test.ts`.


### PR DESCRIPTION
## Summary

- add a first-class Web connection chip and dedicated pairing sheet to the desktop top bar
- split sync device UI into Settings, Mobile, and Web variants; recover hidden at-rest PINs by generating a new six-digit PIN
- replace unsupported named JSX entities on the marketing site and add a build-time AST guard
- update internal web-client, sync, and settings documentation

## Verification

- `node apps/web/scripts/check-entities.mjs`
- `npm --prefix apps/desktop run typecheck`
- `PATH="/opt/homebrew/opt/node@22/bin:$PATH" npx vitest run src/renderer/components/app/TopBar.test.tsx src/renderer/components/settings/SyncDevicesSection.test.tsx` (54/54)
- `npm --prefix apps/web run build`

## Infrastructure

The `app.ade-app.dev` Cloudflare Pages custom domain and DNS work is already live and was completed out-of-band. This PR does not redeploy or modify that infrastructure.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes web-client pairing a primary desktop header workflow and updates related web/docs surfaces. The main changes are:

- Adds a reusable `HeaderSheet` with shared dialog focus trapping.
- Adds a `Web` sync chip in `TopBar` with connected-state labeling and a web-client drawer.
- Splits `SyncDevicesSection` into `phone`, `web`, and `all` variants.
- Adds web pairing QR/link/PIN UI, browser peer filtering, and focused tests.
- Updates web marketing copy, docs, and a build-time JSX named-entity check.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

No blocking correctness or security issues were identified in the reviewed changes. The main desktop UI behavior has focused tests for chip state, drawer behavior, focus handling, and sync variants.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused TopBar and SyncDevicesSection tests and confirmed they passed.
- Verified the Vite devserver became ready on port 5173 during capture.
- Observed a blocker in the Playwright outputs where the after-render produced no visible UI.
- Noted that the before/after comparison artifacts exist but cannot demonstrate the visual change due to sandbox/setup blockers.

<a href="https://app.greptile.com/trex/runs/13943071/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/app/HeaderSheet.tsx | Adds a reusable header sheet and focus-trap helper for top-bar overlay dialogs. |
| apps/desktop/src/renderer/components/app/TopBar.tsx | Adds a web client sync control and refactors phone/web/remote panels to share focus management. |
| apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx | Splits sync settings into phone/web/all variants and adds web pairing link, QR, PIN, relay, and browser-list surfaces. |
| apps/web/package.json | Adds the entity checker to the web build pipeline before typecheck and Vite build. |
| apps/web/scripts/check-entities.mjs | Adds a JSX entity lint script that permits core entities in JSX text but rejects named entities in rendered strings. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant TopBar
participant HeaderSheet
participant SyncDevicesSection
participant SyncAPI as window.ade.sync
participant Browser as Web client

User->>TopBar: Click Web status chip
TopBar->>HeaderSheet: Open web sync sheet
HeaderSheet->>SyncDevicesSection: "Render variant="web""
SyncDevicesSection->>SyncAPI: getStatus(), listDevices(), getCloudRelayStatus()
SyncAPI-->>SyncDevicesSection: Host pairing info + browser peers
SyncDevicesSection-->>User: Show pairing QR/link/PIN and browser list
User->>SyncDevicesSection: Open pairing link or QR
SyncDevicesSection-->>Browser: Web client pairing URL
Browser->>SyncAPI: Pair using host info and PIN
SyncAPI-->>TopBar: sync-status event with browser peer
TopBar-->>User: Web chip shows connected
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant TopBar
participant HeaderSheet
participant SyncDevicesSection
participant SyncAPI as window.ade.sync
participant Browser as Web client

User->>TopBar: Click Web status chip
TopBar->>HeaderSheet: Open web sync sheet
HeaderSheet->>SyncDevicesSection: "Render variant="web""
SyncDevicesSection->>SyncAPI: getStatus(), listDevices(), getCloudRelayStatus()
SyncAPI-->>SyncDevicesSection: Host pairing info + browser peers
SyncDevicesSection-->>User: Show pairing QR/link/PIN and browser list
User->>SyncDevicesSection: Open pairing link or QR
SyncDevicesSection-->>Browser: Web client pairing URL
Browser->>SyncAPI: Pair using host info and PIN
SyncAPI-->>TopBar: sync-status event with browser peer
TopBar-->>User: Web chip shows connected
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(web-client): rescue pairing and mark..."](https://github.com/arul28/ade/commit/c6d4be20c748d7e7b28ecf6517981f7abb8e0e54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43219223)</sub>

<!-- /greptile_comment -->