### PR TITLE
feat(remote): connect paired desktops over sync

### DIFF
--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -13978,6 +13978,7 @@ async function runServe(
     { createBrainProjectActionsSyncHandler },
     { buildRosterSnapshot, createForeignChatTranscriptResolver },
     { createSyncCloudRelayStore },
+    { setSyncRuntimeRpcHandlerFactory },
   ] = await Promise.all([
     import("./services/projects/machineLayout"),
     import("./services/projects/projectRegistry"),
@@ -13989,6 +13990,7 @@ async function runServe(
     import("./services/sync/brainProjectActionsSyncHandler"),
     import("./services/sync/rosterBuilder"),
     import("./services/sync/syncCloudRelayStore"),
+    import("./services/sync/syncPairedChannelService"),
   ]);
 
   const layout = resolveMachineAdeLayout();
@@ -14377,6 +14379,7 @@ async function runServe(
     },
   });
   const previousRole = process.env.ADE_DEFAULT_ROLE;
+  let clearSyncRuntimeRpcHandlerFactory: (() => void) | null = null;
   process.env.ADE_DEFAULT_ROLE = options.role;
   try {
 
@@ -14399,6 +14402,7 @@ async function runServe(
       disposeScopesOnDispose: false,
       onShutdown: finish,
     });
+  clearSyncRuntimeRpcHandlerFactory = setSyncRuntimeRpcHandlerFactory(createHandler);
   const startSyncHost = async () => {
     if (preferredSyncProjectId) {
       return await scopeRegistry.switchSyncHost(preferredSyncProjectId);
@@ -14435,6 +14439,8 @@ async function runServe(
     if (sharedSyncListener) {
       await sharedSyncListener.close().catch(() => {});
     }
+    clearSyncRuntimeRpcHandlerFactory?.();
+    clearSyncRuntimeRpcHandlerFactory = null;
   };
 
   const listen = async (
@@ -14570,6 +14576,7 @@ async function runServe(
   }
   return null;
   } finally {
+    clearSyncRuntimeRpcHandlerFactory?.();
     removeRuntimeProcessErrorBoundary();
     if (previousRole == null) delete process.env.ADE_DEFAULT_ROLE;
     else process.env.ADE_DEFAULT_ROLE = previousRole;

--- a/apps/ade-cli/src/multiProjectRpcServer.test.ts
+++ b/apps/ade-cli/src/multiProjectRpcServer.test.ts
@@ -365,6 +365,60 @@ describe("multi-project RPC server", () => {
     handler.dispose();
   });
 
+  it("dispatches desktop pairing info through the daemon's trusted local sync surface", async () => {
+    const { projectRoot, registry } = createRegistry();
+    const added = registry.add(projectRoot);
+    const pairingInfo = {
+      pairingUrl: "https://app.ade-app.dev/pair#desktop-grant",
+      code: "123456",
+      pinConfigured: true,
+      machineName: "Mac Studio",
+      relayEnabled: true,
+      hasRelayCandidate: true,
+    };
+    const executeRemoteCommand = vi.fn(async () => pairingInfo);
+    const scopeRegistry = {
+      get: vi.fn(),
+      ensureSyncHost: vi.fn(),
+      switchSyncHost: vi.fn(),
+      resolveActiveSyncHost: vi.fn(async () => ({
+        registryProjectId: added.projectId,
+        record: added,
+        runtime: { syncService: { executeRemoteCommand } },
+        dispose: vi.fn(),
+      })),
+      dispose: vi.fn(),
+      disposeAll: vi.fn(),
+    } as unknown as ProjectScopeRegistry;
+    const handler = createMultiProjectRpcRequestHandler({
+      serverVersion: "test",
+      projectRegistry: registry,
+      scopeRegistry,
+    });
+
+    await handler({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "ade/initialize",
+      params: {},
+    });
+
+    await expect(handler({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "sync.getDesktopPairingInfo",
+      params: {},
+    })).resolves.toEqual(pairingInfo);
+    expect(executeRemoteCommand).toHaveBeenCalledWith({
+      commandId: expect.stringMatching(/^local-runtime-/),
+      action: "sync.getDesktopPairingInfo",
+      args: {},
+    });
+    expect(scopeRegistry.resolveActiveSyncHost).toHaveBeenCalledTimes(1);
+
+    handler.dispose();
+  });
+
   it("does not switch the active sync host for read-only sync polls with a projectId", async () => {
     const { root, projectRoot, registry } = createRegistry();
     const active = registry.add(projectRoot);

--- a/apps/ade-cli/src/multiProjectRpcServer.ts
+++ b/apps/ade-cli/src/multiProjectRpcServer.ts
@@ -1,5 +1,5 @@
 import { createAdeRpcRequestHandler } from "./adeRpcServer";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -96,6 +96,7 @@ const RUNTIME_METHODS = new Set([
   "sync.getRuntimeName",
   "sync.setRuntimeName",
   "sync.clearRuntimeName",
+  "sync.getDesktopPairingInfo",
   "sync.setActiveLanePresence",
   "sync.getCloudRelayStatus",
   "sync.setCloudRelayEnabled",
@@ -772,6 +773,18 @@ export function createMultiProjectRpcRequestHandler(
 
     if (method === "sync.clearRuntimeName") {
       return await (await getSyncService()).clearRuntimeName();
+    }
+
+    if (method === "sync.getDesktopPairingInfo") {
+      const syncService = await getSyncService();
+      // This daemon socket is the trusted desktop-local surface. The paired
+      // command path still consults the descriptor's viewerAllowed=false
+      // policy before it can reach the same handler.
+      return await syncService.executeRemoteCommand({
+        commandId: `local-runtime-${randomUUID()}`,
+        action: "sync.getDesktopPairingInfo",
+        args: {},
+      });
     }
 
     if (method === "sync.getCloudRelayStatus") {

--- a/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
+++ b/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
@@ -229,7 +229,13 @@ function parsePairingRequestPayload(payload: unknown): SyncPairingRequestPayload
   const code = optionalString(record.code);
   const peer = normalizePeerMetadata(record.peer);
   const dpopPublicKey = optionalString(record.dpopPublicKey);
-  return code && peer ? { code, peer, ...(dpopPublicKey ? { dpopPublicKey } : {}) } : null;
+  const runtimeHostGrant = optionalString(record.runtimeHostGrant);
+  return code && peer ? {
+    code,
+    peer,
+    ...(dpopPublicKey ? { dpopPublicKey } : {}),
+    ...(runtimeHostGrant ? { runtimeHostGrant } : {}),
+  } : null;
 }
 
 function send(
@@ -839,6 +845,7 @@ export function createBrainProjectActionsSyncHandler(
             try {
               const paired = pairingStore.pairPeer(payload.peer, payload.code, {
                 dpopPublicKey: payload.dpopPublicKey ?? null,
+                runtimeHostGrant: payload.runtimeHostGrant ?? null,
               });
               pairFailures.clearAfterSuccess(remoteAddress ?? null);
               send(ws, "pairing_result", { ok: true, deviceId: paired.deviceId, secret: paired.secret }, envelope.requestId);

--- a/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
+++ b/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
@@ -32,7 +32,7 @@ import { nowIso } from "../../../../desktop/src/main/services/shared/utils";
 import type { SharedSyncListenerConnectionHandler } from "./sharedSyncListener";
 import { SYNC_HOST_BIND_LOOPBACK_ONLY } from "./sharedSyncListener";
 import type { SyncCredentialStore } from "../credentials/credentialStore";
-import { createSyncPairingStore } from "./syncPairingStore";
+import { createSyncPairingStore, type SyncPairingRecord } from "./syncPairingStore";
 import { createSyncDpopNonceCache, evaluatePairedHelloDpop } from "./syncDpop";
 import {
   createSyncPairedChannelService,
@@ -50,7 +50,7 @@ import {
 import {
   buildSyncHostHelloOkPayload,
   buildSyncProjectCatalogMessages,
-  isRuntimeHostDeviceType,
+  isRuntimeHostPairingRecord,
   type SyncProjectCatalogProvider,
 } from "./syncHostService";
 import { resolveDeviceDisplayName } from "./deviceRegistryService";
@@ -80,6 +80,7 @@ type BrainPeerState = {
   authTimeout: ReturnType<typeof setTimeout> | null;
   metadata: SyncPeerMetadata | null;
   personalChatSubscriptions: Map<string, { transcriptPath: string; offset: number }>;
+  pairingRecord: SyncPairingRecord | null;
 };
 
 const WS_OPEN = 1;
@@ -474,7 +475,7 @@ export function createBrainProjectActionsSyncHandler(
         envelope.payload,
         peer.authKind === "paired",
         // Runtime RPC channel + port-forward are desktop-runtime-host only.
-        peer.authKind === "paired" && isRuntimeHostDeviceType(peer.metadata),
+        peer.authKind === "paired" && isRuntimeHostPairingRecord(peer.pairingRecord),
       );
       return;
     }
@@ -755,6 +756,7 @@ export function createBrainProjectActionsSyncHandler(
       authTimeout: null,
       metadata: null,
       personalChatSubscriptions: new Map(),
+      pairingRecord: null,
     };
     let personalChatPumpRunning = false;
     const personalChatPump = setInterval(() => {
@@ -890,14 +892,15 @@ export function createBrainProjectActionsSyncHandler(
             return;
           }
           const auth = hello.auth;
+          let authenticatedPairingRecord: SyncPairingRecord | null = null;
           const authFailed = (() => {
             if (auth?.kind === "paired") {
               if (auth.deviceId !== hello.peer.deviceId) return true;
               if (!pairingStore.authenticate(auth.deviceId, auth.secret)) return true;
-              const record = pairingStore.getPairingRecord(auth.deviceId);
-              if (!record) return true;
+              authenticatedPairingRecord = pairingStore.getPairingRecord(auth.deviceId);
+              if (!authenticatedPairingRecord) return true;
               const dpopFailure = evaluatePairedHelloDpop({
-                storedPublicKey: record.dpopPublicKey,
+                storedPublicKey: authenticatedPairingRecord.dpopPublicKey,
                 deviceId: auth.deviceId,
                 secret: auth.secret,
                 proof: auth.dpop ?? null,
@@ -951,6 +954,7 @@ export function createBrainProjectActionsSyncHandler(
           peer.authKind = auth?.kind ?? null;
           clearAuthTimeout();
           peer.metadata = hello.peer;
+          peer.pairingRecord = auth?.kind === "paired" ? authenticatedPairingRecord : null;
           const catalog = await projectCatalog(args.projectCatalogProvider, args.logger);
           const brain = brainMetadata();
           const personalDescriptors = personalChatCommandDescriptors(args.personalChatScope);
@@ -972,7 +976,7 @@ export function createBrainProjectActionsSyncHandler(
             // Advertise the runtime RPC channel + port-forward only to paired
             // desktop runtime-hosts (phones/browsers stay on the allowlist).
             runtimeChannelEnabled:
-              auth?.kind === "paired" && isRuntimeHostDeviceType(hello.peer),
+              auth?.kind === "paired" && isRuntimeHostPairingRecord(authenticatedPairingRecord),
           }), envelope.requestId);
           return;
         }

--- a/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
+++ b/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
@@ -34,6 +34,10 @@ import { SYNC_HOST_BIND_LOOPBACK_ONLY } from "./sharedSyncListener";
 import type { SyncCredentialStore } from "../credentials/credentialStore";
 import { createSyncPairingStore } from "./syncPairingStore";
 import { createSyncDpopNonceCache, evaluatePairedHelloDpop } from "./syncDpop";
+import {
+  createSyncPairedChannelService,
+  isPairedRuntimeEnvelopeType,
+} from "./syncPairedChannelService";
 import { createSyncPinStore } from "./syncPinStore";
 import { createSyncSecurityStore } from "./syncSecurityStore";
 import {
@@ -71,6 +75,7 @@ type BrainProjectActionsSyncHandlerArgs = {
 type BrainPeerState = {
   ws: WebSocket;
   authenticated: boolean;
+  authKind: "bootstrap" | "paired" | null;
   authTimeout: ReturnType<typeof setTimeout> | null;
   metadata: SyncPeerMetadata | null;
   personalChatSubscriptions: Map<string, { transcriptPath: string; offset: number }>;
@@ -230,14 +235,19 @@ function send(
   type: SyncEnvelope["type"],
   payload: unknown,
   requestId?: string | null,
-): void {
-  if (ws.readyState !== WS_OPEN) return;
-  ws.send(encodeSyncEnvelope({
-    type,
-    requestId,
-    payload,
-    compressionThresholdBytes: DEFAULT_SYNC_COMPRESSION_THRESHOLD_BYTES,
-  }));
+): boolean {
+  if (ws.readyState !== WS_OPEN) return false;
+  try {
+    ws.send(encodeSyncEnvelope({
+      type,
+      requestId,
+      payload,
+      compressionThresholdBytes: DEFAULT_SYNC_COMPRESSION_THRESHOLD_BYTES,
+    }));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function sendProjectCatalog(
@@ -416,6 +426,11 @@ export function createBrainProjectActionsSyncHandler(
   const pollIntervalMs = Math.max(100, Math.floor(args.pollIntervalMs ?? 1_500));
   const authTimeoutMs = Math.max(1_000, Math.floor(args.authTimeoutMs ?? BRAIN_SYNC_AUTH_TIMEOUT_MS));
   const pairFailures = createPairFailureTracker();
+  const pairedChannelService = createSyncPairedChannelService<WebSocket>({
+    logger: args.logger,
+    getBufferedAmount: (ws) => ws.bufferedAmount,
+    send: (ws, type, payload) => send(ws, type, payload),
+  });
 
   const brainMetadata = (): SyncPeerMetadata => ({
     deviceId: localDeviceId,
@@ -451,6 +466,15 @@ export function createBrainProjectActionsSyncHandler(
   };
 
   const handleAuthenticatedEnvelope = async (peer: BrainPeerState, envelope: ReturnType<typeof parseSyncEnvelope>): Promise<void> => {
+    if (isPairedRuntimeEnvelopeType(envelope.type)) {
+      await pairedChannelService.handleEnvelope(
+        peer.ws,
+        envelope.type,
+        envelope.payload,
+        peer.authKind === "paired",
+      );
+      return;
+    }
     switch (envelope.type) {
       case "project_catalog_request": {
         sendProjectCatalog(peer.ws, await projectCatalog(args.projectCatalogProvider, args.logger), envelope.requestId);
@@ -724,6 +748,7 @@ export function createBrainProjectActionsSyncHandler(
     const peer: BrainPeerState = {
       ws,
       authenticated: false,
+      authKind: null,
       authTimeout: null,
       metadata: null,
       personalChatSubscriptions: new Map(),
@@ -920,6 +945,7 @@ export function createBrainProjectActionsSyncHandler(
             return;
           }
           peer.authenticated = true;
+          peer.authKind = auth?.kind ?? null;
           clearAuthTimeout();
           peer.metadata = hello.peer;
           const catalog = await projectCatalog(args.projectCatalogProvider, args.logger);
@@ -962,6 +988,7 @@ export function createBrainProjectActionsSyncHandler(
       clearAuthTimeout();
       clearInterval(personalChatPump);
       peer.personalChatSubscriptions.clear();
+      pairedChannelService.closePeer(ws, "Sync socket closed.", false);
     });
   };
 }

--- a/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
+++ b/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
@@ -50,6 +50,7 @@ import {
 import {
   buildSyncHostHelloOkPayload,
   buildSyncProjectCatalogMessages,
+  isRuntimeHostDeviceType,
   type SyncProjectCatalogProvider,
 } from "./syncHostService";
 import { resolveDeviceDisplayName } from "./deviceRegistryService";
@@ -472,6 +473,8 @@ export function createBrainProjectActionsSyncHandler(
         envelope.type,
         envelope.payload,
         peer.authKind === "paired",
+        // Runtime RPC channel + port-forward are desktop-runtime-host only.
+        peer.authKind === "paired" && isRuntimeHostDeviceType(peer.metadata),
       );
       return;
     }
@@ -966,6 +969,10 @@ export function createBrainProjectActionsSyncHandler(
             localCommandDescriptors: [],
             compressionThresholdBytes: DEFAULT_SYNC_COMPRESSION_THRESHOLD_BYTES,
             cloudRelayWssUrl: args.getCloudRelayWssUrl?.() ?? null,
+            // Advertise the runtime RPC channel + port-forward only to paired
+            // desktop runtime-hosts (phones/browsers stay on the allowlist).
+            runtimeChannelEnabled:
+              auth?.kind === "paired" && isRuntimeHostDeviceType(hello.peer),
           }), envelope.requestId);
           return;
         }

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -225,6 +225,8 @@ describe("buildSyncHostHelloOkPayload", () => {
     expect(payload.features.fileAccess).toBe(true);
     expect(payload.features.terminalStreaming).toBe(true);
     expect(payload.features.chatStreaming).toEqual({ enabled: true });
+    expect(payload.features.rpcChannel).toBe(true);
+    expect(payload.features.portForward).toBe(true);
     expect(payload.features.commandRouting).toEqual({
       mode: "allowlisted",
       supportedActions: [remoteCommand.action, localPresenceCommand.action],

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -26,6 +26,7 @@ import {
   compactChatEventEnvelopeForSync,
   createChatEventReplayBuffer,
   createSyncHostService,
+  isRuntimeOnlySyncPeer,
   isRuntimeHostPairingRecord,
   planChatEventResume,
   recordChatEventInReplayBuffer,
@@ -37,7 +38,7 @@ import { buildChangesetBatchPayload } from "./changesetPump";
 import { createSharedSyncListener } from "./sharedSyncListener";
 import { createSyncPairingStore, type SyncPairingRecord } from "./syncPairingStore";
 import { createSyncPinStore } from "./syncPinStore";
-import { encodeSyncEnvelope, parseSyncEnvelope, wsDataToText, type ParsedSyncEnvelope } from "./syncProtocol";
+import { encodeSyncEnvelope, parseSyncEnvelope, SYNC_RUNTIME_ONLY_CAPABILITY, wsDataToText, type ParsedSyncEnvelope } from "./syncProtocol";
 import { EncryptedFileCredentialStore } from "../credentials/credentialStore";
 
 // The sync host now binds to all interfaces (0.0.0.0) by default so phones on
@@ -391,6 +392,51 @@ describe("buildSyncHostHelloOkPayload", () => {
     // routes"; null means "kill-switch off, clear them".
     expect("cloudRelayWssUrl" in payload).toBe(true);
     expect(payload.cloudRelayWssUrl).toBeNull();
+  });
+});
+
+describe("runtime-only paired host changesets", () => {
+  const metadata = {
+    deviceId: "desktop-runtime-1",
+    deviceName: "Desktop runtime",
+    platform: "macOS",
+    deviceType: "desktop",
+    siteId: "desktop-runtime-site-1",
+    dbVersion: 0,
+    capabilities: [SYNC_RUNTIME_ONLY_CAPABILITY],
+  } satisfies SyncPeerMetadata;
+  const pairingRecord = (runtimeHostGranted: boolean): SyncPairingRecord => ({
+    secretHash: "hash",
+    createdAt: "2026-07-10T00:00:00.000Z",
+    lastUsedAt: null,
+    peerName: "Paired peer",
+    peerPlatform: "macOS",
+    peerDeviceType: "desktop",
+    runtimeHostGranted,
+  });
+
+  it("suppresses CRDT only for an authenticated runtime-host grant", () => {
+    expect(isRuntimeOnlySyncPeer({
+      authKind: "paired",
+      pairingRecord: pairingRecord(true),
+      metadata,
+    })).toBe(true);
+
+    expect(isRuntimeOnlySyncPeer({
+      authKind: "paired",
+      pairingRecord: pairingRecord(false),
+      metadata,
+    })).toBe(false);
+    expect(isRuntimeOnlySyncPeer({
+      authKind: "bootstrap",
+      pairingRecord: pairingRecord(true),
+      metadata,
+    })).toBe(false);
+    expect(isRuntimeOnlySyncPeer({
+      authKind: "paired",
+      pairingRecord: pairingRecord(true),
+      metadata: { ...metadata, capabilities: [] },
+    })).toBe(false);
   });
 });
 
@@ -1162,6 +1208,85 @@ describe("paired runtime host authorization", () => {
       });
       sendSpoofedPairedHello(client, pairing.helloPeer, pairing.secret);
       await expectSpoofedRuntimeChannelRefused(client, envelopes);
+    } finally {
+      client?.close();
+      await host.dispose();
+      cleanup();
+    }
+  });
+
+  it.each([
+    ["project", "project-1"],
+    ["brain", null],
+  ] as const)("does not send CRDT changesets to a genuine runtime-only %s host peer", async (_mode, projectId) => {
+    const { projectRoot, cleanup } = createTempProjectRoot();
+    const secretsDir = path.join(projectRoot, ".ade", "secrets");
+    const pinStore = createSyncPinStore({ filePath: path.join(secretsDir, "sync-pin.json") });
+    const pairingSecretsPath = path.join(secretsDir, "sync-paired-devices.json");
+    pinStore.setPin("428193");
+    const pairingStore = createSyncPairingStore({ filePath: pairingSecretsPath, pinStore });
+    const runtimePeer = {
+      deviceId: `runtime-only-${_mode}`,
+      deviceName: `Runtime-only ${_mode}`,
+      platform: "macOS",
+      deviceType: "desktop",
+      siteId: `runtime-only-${_mode}-site`,
+      dbVersion: 0,
+      capabilities: [SYNC_RUNTIME_ONLY_CAPABILITY],
+    } satisfies SyncPeerMetadata;
+    const runtimeHostGrant = pairingStore.issueRuntimeHostGrant();
+    const { secret } = pairingStore.pairPeer(runtimePeer, "428193", { runtimeHostGrant });
+    const baseArgs = createHostArgs(projectRoot, []);
+    const exportChangesSince = vi.fn(() => [makeChange(1, 0)]);
+    const host = createSyncHostService({
+      ...baseArgs,
+      projectId,
+      discoveryEnabled: false,
+      pollIntervalMs: 100,
+      pinStore,
+      pairingSecretsPath,
+      db: {
+        sync: {
+          getSiteId: () => "runtime-host-site",
+          getDbVersion: () => 1,
+          exportChangesSince,
+          applyChanges: () => ({ appliedCount: 0 }),
+          discardUnpublishedChangesForTables: () => {},
+        },
+      },
+      deviceRegistryService: {
+        ...baseArgs.deviceRegistryService,
+        upsertPeerMetadata: vi.fn(),
+      },
+    } as unknown as Parameters<typeof createSyncHostService>[0]);
+    let client: WebSocket | null = null;
+    try {
+      const port = await host.waitUntilListening();
+      client = new WebSocket(`ws://127.0.0.1:${port}`);
+      const { envelopes } = trackClientEnvelopes(client);
+      await new Promise<void>((resolve, reject) => {
+        client!.once("open", resolve);
+        client!.once("error", reject);
+      });
+      client.send(encodeSyncEnvelope({
+        type: "hello",
+        payload: {
+          peer: runtimePeer,
+          auth: { kind: "paired", deviceId: runtimePeer.deviceId, secret },
+        },
+      }));
+
+      const hello = await waitForValue(
+        () => envelopes.find((envelope) => envelope.type === "hello_ok"),
+        `${_mode} runtime-only hello_ok`,
+      );
+      expect(hello.payload).toMatchObject({
+        features: { rpcChannel: true, portForward: true },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 250));
+
+      expect(envelopes.some((envelope) => envelope.type === "changeset_batch")).toBe(false);
+      expect(exportChangesSince).not.toHaveBeenCalled();
     } finally {
       client?.close();
       await host.dispose();

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -26,6 +26,7 @@ import {
   compactChatEventEnvelopeForSync,
   createChatEventReplayBuffer,
   createSyncHostService,
+  isRuntimeHostPairingRecord,
   planChatEventResume,
   recordChatEventInReplayBuffer,
   resolveSyncHostInboundProjectScope,
@@ -34,6 +35,7 @@ import {
 import { createBrainProjectActionsSyncHandler } from "./brainProjectActionsSyncHandler";
 import { buildChangesetBatchPayload } from "./changesetPump";
 import { createSharedSyncListener } from "./sharedSyncListener";
+import { createSyncPairingStore, type SyncPairingRecord } from "./syncPairingStore";
 import { createSyncPinStore } from "./syncPinStore";
 import { encodeSyncEnvelope, parseSyncEnvelope, wsDataToText, type ParsedSyncEnvelope } from "./syncProtocol";
 import { EncryptedFileCredentialStore } from "../credentials/credentialStore";
@@ -284,6 +286,55 @@ describe("buildSyncHostHelloOkPayload", () => {
     });
     expect(disabled.features.rpcChannel).toBe(false);
     expect(disabled.features.portForward).toBe(false);
+  });
+
+  it("derives runtime-channel authorization from the pairing record, not spoofed hello metadata", () => {
+    const spoofedDesktopHello = {
+      deviceId: "paired-mobile-1",
+      deviceName: "Spoofed desktop",
+      platform: "macOS",
+      deviceType: "desktop",
+      siteId: "paired-mobile-site-1",
+      dbVersion: 0,
+    } satisfies SyncPeerMetadata;
+    const record = (peerDeviceType: string): SyncPairingRecord => ({
+      secretHash: "hash",
+      createdAt: "2026-07-10T00:00:00.000Z",
+      lastUsedAt: null,
+      peerName: "Paired peer",
+      peerPlatform: "macOS",
+      peerDeviceType,
+    });
+    const base = {
+      peer: spoofedDesktopHello,
+      brain: spoofedDesktopHello,
+      serverDbVersion: 0,
+      heartbeatIntervalMs: 30_000,
+      pollIntervalMs: 400,
+      projectCatalog: { projects: [] },
+      projectCatalogEnabled: false,
+      projectActionsEnabled: false,
+      crossProjectChatEnabled: false,
+      remoteCommandSupportedActions: [],
+      remoteCommandDescriptors: [],
+      localCommandDescriptors: [],
+    };
+
+    for (const peerDeviceType of ["phone", "browser"]) {
+      const payload = buildSyncHostHelloOkPayload({
+        ...base,
+        runtimeChannelEnabled: isRuntimeHostPairingRecord(record(peerDeviceType)),
+      });
+      expect(payload.features.rpcChannel).toBe(false);
+      expect(payload.features.portForward).toBe(false);
+    }
+
+    const genuineDesktop = buildSyncHostHelloOkPayload({
+      ...base,
+      runtimeChannelEnabled: isRuntimeHostPairingRecord(record("desktop")),
+    });
+    expect(genuineDesktop.features.rpcChannel).toBe(true);
+    expect(genuineDesktop.features.portForward).toBe(true);
   });
 
   it("advertises the cloud relay connect URL so already-paired phones learn the off-LAN route", () => {
@@ -724,6 +775,58 @@ describe("brain project actions fallback handler", () => {
     }
   });
 
+  it("refuses rpc/fwd when a phone pairing record spoofs desktop through the brain ingress", async () => {
+    const { projectRoot, cleanup } = createTempProjectRoot();
+    const secretsDir = path.join(projectRoot, "secrets");
+    const pairing = createSpoofedDesktopPairing(secretsDir);
+    const handler = createBrainProjectActionsSyncHandler({
+      logger: createDiscoveryLogger(),
+      projectCatalogProvider: {
+        listProjects: vi.fn(async () => ({ projects: [] })),
+        prepareProjectConnection: vi.fn(),
+      },
+      bootstrapCredentialStore: new EncryptedFileCredentialStore({
+        secretsDir,
+        keyMaterialProvider: () => null,
+      }),
+      pairingSecretsPath: pairing.pairingSecretsPath,
+      pinPath: pairing.pinPath,
+      localDeviceIdPath: path.join(secretsDir, "sync-device-id"),
+      localSiteIdPath: path.join(secretsDir, "sync-site-id"),
+    });
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    server.on("connection", (ws, request) => {
+      handler({
+        ws,
+        remoteAddress: request.socket.remoteAddress ?? null,
+        remotePort: request.socket.remotePort ?? null,
+      });
+    });
+    let client: WebSocket | null = null;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("listening", resolve);
+        server.once("error", reject);
+      });
+      const address = server.address();
+      expect(typeof address).toBe("object");
+      const port = typeof address === "object" && address ? address.port : 0;
+      expect(port).toBeGreaterThan(0);
+      client = new WebSocket(`ws://127.0.0.1:${port}`);
+      const { envelopes } = trackClientEnvelopes(client);
+      await new Promise<void>((resolve, reject) => {
+        client!.once("open", resolve);
+        client!.once("error", reject);
+      });
+      sendSpoofedPairedHello(client, pairing.helloPeer, pairing.secret);
+      await expectSpoofedRuntimeChannelRefused(client, envelopes);
+    } finally {
+      client?.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      cleanup();
+    }
+  });
+
   it("rate-limits failed PIN pairing attempts before a project host owns the listener", async () => {
     const { projectRoot, cleanup } = createTempProjectRoot();
     const secretsDir = path.join(projectRoot, "secrets");
@@ -851,6 +954,89 @@ function createTempProjectRoot(): { projectRoot: string; cleanup: () => void } {
   };
 }
 
+function createSpoofedDesktopPairing(secretsDir: string) {
+  fs.mkdirSync(secretsDir, { recursive: true });
+  const pinPath = path.join(secretsDir, "sync-pin.json");
+  const pairingSecretsPath = path.join(secretsDir, "sync-paired-devices.json");
+  const pinStore = createSyncPinStore({ filePath: pinPath });
+  pinStore.setPin("428193");
+  const recordedPeer = {
+    deviceId: "spoofed-mobile-1",
+    deviceName: "Paired phone",
+    platform: "iOS",
+    deviceType: "phone",
+    siteId: "spoofed-mobile-site-1",
+    dbVersion: 0,
+  } satisfies SyncPeerMetadata;
+  const { secret } = createSyncPairingStore({
+    filePath: pairingSecretsPath,
+    pinStore,
+  }).pairPeer(recordedPeer, "428193");
+  return {
+    pairingSecretsPath,
+    pinPath,
+    pinStore,
+    secret,
+    helloPeer: {
+      ...recordedPeer,
+      deviceName: "Spoofed desktop",
+      platform: "macOS",
+      deviceType: "desktop",
+    } satisfies SyncPeerMetadata,
+  };
+}
+
+function sendSpoofedPairedHello(
+  client: WebSocket,
+  peer: SyncPeerMetadata,
+  secret: string,
+): void {
+  client.send(encodeSyncEnvelope({
+    type: "hello",
+    requestId: "spoofed-hello",
+    payload: {
+      peer,
+      auth: { kind: "paired", deviceId: peer.deviceId, secret },
+    },
+  }));
+}
+
+async function expectSpoofedRuntimeChannelRefused(
+  client: WebSocket,
+  envelopes: ParsedSyncEnvelope[],
+): Promise<void> {
+  const hello = await waitForEnvelope(envelopes, "hello_ok", "spoofed-hello");
+  expect(hello.payload).toMatchObject({
+    features: { rpcChannel: false, portForward: false },
+  });
+  client.send(encodeSyncEnvelope({
+    type: "rpc_open",
+    payload: { channelId: "spoofed-rpc" },
+  }));
+  client.send(encodeSyncEnvelope({
+    type: "fwd_open",
+    payload: { forwardId: "spoofed-forward", host: "127.0.0.1", port: 4173 },
+  }));
+  const rpcClose = await waitForValue(
+    () => envelopes.find((envelope) =>
+      envelope.type === "rpc_close"
+      && (envelope.payload as { channelId?: unknown }).channelId === "spoofed-rpc"),
+    "spoofed rpc_close",
+  );
+  const forwardClose = await waitForValue(
+    () => envelopes.find((envelope) =>
+      envelope.type === "fwd_close"
+      && (envelope.payload as { forwardId?: unknown }).forwardId === "spoofed-forward"),
+    "spoofed fwd_close",
+  );
+  expect(rpcClose.payload).toMatchObject({
+    reason: "Runtime channel is only available to desktop clients.",
+  });
+  expect(forwardClose.payload).toMatchObject({
+    reason: "Runtime channel is only available to desktop clients.",
+  });
+}
+
 function createDiscoveryProject(overrides: Partial<SyncMobileProjectSummary>): SyncMobileProjectSummary {
   return {
     id: "project-1",
@@ -951,6 +1137,41 @@ function createHostArgs(projectRoot: string, projects: SyncMobileProjectSummary[
     },
   };
 }
+
+describe("paired runtime host authorization", () => {
+  it("refuses rpc/fwd when a phone pairing record spoofs desktop through the project-host ingress", async () => {
+    const { projectRoot, cleanup } = createTempProjectRoot();
+    const pairing = createSpoofedDesktopPairing(path.join(projectRoot, ".ade", "secrets"));
+    const baseArgs = createHostArgs(projectRoot, []);
+    const host = createSyncHostService({
+      ...baseArgs,
+      discoveryEnabled: false,
+      pinStore: pairing.pinStore,
+      pairingSecretsPath: pairing.pairingSecretsPath,
+      deviceRegistryService: {
+        ...baseArgs.deviceRegistryService,
+        upsertPeerMetadata: vi.fn(),
+      },
+    } as unknown as Parameters<typeof createSyncHostService>[0]);
+    let client: WebSocket | null = null;
+    try {
+      const port = await host.waitUntilListening();
+      expect(port).toBeGreaterThan(0);
+      client = new WebSocket(`ws://127.0.0.1:${port}`);
+      const { envelopes } = trackClientEnvelopes(client);
+      await new Promise<void>((resolve, reject) => {
+        client!.once("open", resolve);
+        client!.once("error", reject);
+      });
+      sendSpoofedPairedHello(client, pairing.helloPeer, pairing.secret);
+      await expectSpoofedRuntimeChannelRefused(client, envelopes);
+    } finally {
+      client?.close();
+      await host.dispose();
+      cleanup();
+    }
+  });
+});
 
 describe("createSyncHostService LAN discovery", () => {
   let originalPlatform: PropertyDescriptor | undefined;

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -297,13 +297,14 @@ describe("buildSyncHostHelloOkPayload", () => {
       siteId: "paired-mobile-site-1",
       dbVersion: 0,
     } satisfies SyncPeerMetadata;
-    const record = (peerDeviceType: string): SyncPairingRecord => ({
+    const record = (runtimeHostGranted: boolean): SyncPairingRecord => ({
       secretHash: "hash",
       createdAt: "2026-07-10T00:00:00.000Z",
       lastUsedAt: null,
       peerName: "Paired peer",
       peerPlatform: "macOS",
-      peerDeviceType,
+      peerDeviceType: "desktop",
+      runtimeHostGranted,
     });
     const base = {
       peer: spoofedDesktopHello,
@@ -320,18 +321,16 @@ describe("buildSyncHostHelloOkPayload", () => {
       localCommandDescriptors: [],
     };
 
-    for (const peerDeviceType of ["phone", "browser"]) {
-      const payload = buildSyncHostHelloOkPayload({
-        ...base,
-        runtimeChannelEnabled: isRuntimeHostPairingRecord(record(peerDeviceType)),
-      });
-      expect(payload.features.rpcChannel).toBe(false);
-      expect(payload.features.portForward).toBe(false);
-    }
+    const ungranted = buildSyncHostHelloOkPayload({
+      ...base,
+      runtimeChannelEnabled: isRuntimeHostPairingRecord(record(false)),
+    });
+    expect(ungranted.features.rpcChannel).toBe(false);
+    expect(ungranted.features.portForward).toBe(false);
 
     const genuineDesktop = buildSyncHostHelloOkPayload({
       ...base,
-      runtimeChannelEnabled: isRuntimeHostPairingRecord(record("desktop")),
+      runtimeChannelEnabled: isRuntimeHostPairingRecord(record(true)),
     });
     expect(genuineDesktop.features.rpcChannel).toBe(true);
     expect(genuineDesktop.features.portForward).toBe(true);
@@ -775,7 +774,7 @@ describe("brain project actions fallback handler", () => {
     }
   });
 
-  it("refuses rpc/fwd when a phone pairing record spoofs desktop through the brain ingress", async () => {
+  it("refuses rpc/fwd when a PIN-authorized brain pairing request merely claims desktop", async () => {
     const { projectRoot, cleanup } = createTempProjectRoot();
     const secretsDir = path.join(projectRoot, "secrets");
     const pairing = createSpoofedDesktopPairing(secretsDir);
@@ -962,9 +961,9 @@ function createSpoofedDesktopPairing(secretsDir: string) {
   pinStore.setPin("428193");
   const recordedPeer = {
     deviceId: "spoofed-mobile-1",
-    deviceName: "Paired phone",
-    platform: "iOS",
-    deviceType: "phone",
+    deviceName: "Self-claimed desktop",
+    platform: "macOS",
+    deviceType: "desktop",
     siteId: "spoofed-mobile-site-1",
     dbVersion: 0,
   } satisfies SyncPeerMetadata;
@@ -979,9 +978,7 @@ function createSpoofedDesktopPairing(secretsDir: string) {
     secret,
     helloPeer: {
       ...recordedPeer,
-      deviceName: "Spoofed desktop",
-      platform: "macOS",
-      deviceType: "desktop",
+      deviceName: "Self-claimed desktop",
     } satisfies SyncPeerMetadata,
   };
 }
@@ -1139,7 +1136,7 @@ function createHostArgs(projectRoot: string, projects: SyncMobileProjectSummary[
 }
 
 describe("paired runtime host authorization", () => {
-  it("refuses rpc/fwd when a phone pairing record spoofs desktop through the project-host ingress", async () => {
+  it("refuses rpc/fwd when a PIN-authorized project-host pairing request merely claims desktop", async () => {
     const { projectRoot, cleanup } = createTempProjectRoot();
     const pairing = createSpoofedDesktopPairing(path.join(projectRoot, ".ade", "secrets"));
     const baseArgs = createHostArgs(projectRoot, []);

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -225,8 +225,10 @@ describe("buildSyncHostHelloOkPayload", () => {
     expect(payload.features.fileAccess).toBe(true);
     expect(payload.features.terminalStreaming).toBe(true);
     expect(payload.features.chatStreaming).toEqual({ enabled: true });
-    expect(payload.features.rpcChannel).toBe(true);
-    expect(payload.features.portForward).toBe(true);
+    // Phone peer without runtimeChannelEnabled: runtime channel + port-forward
+    // must NOT be advertised as available.
+    expect(payload.features.rpcChannel).toBe(false);
+    expect(payload.features.portForward).toBe(false);
     expect(payload.features.commandRouting).toEqual({
       mode: "allowlisted",
       supportedActions: [remoteCommand.action, localPresenceCommand.action],
@@ -242,6 +244,46 @@ describe("buildSyncHostHelloOkPayload", () => {
     });
     // No relay URL supplied → field omitted for backward-compatible payloads.
     expect("cloudRelayWssUrl" in payload).toBe(false);
+  });
+
+  it("advertises the runtime RPC channel + port-forward only when the peer is an authorized desktop host", () => {
+    const desktop = {
+      deviceId: "mac-studio-1",
+      deviceName: "Mac Studio",
+      platform: "macOS",
+      deviceType: "desktop",
+      siteId: "desktop-site-1",
+      dbVersion: 0,
+    } satisfies SyncPeerMetadata;
+    const base = {
+      brain: desktop,
+      serverDbVersion: 0,
+      heartbeatIntervalMs: 30_000,
+      pollIntervalMs: 400,
+      projectCatalog: { projects: [] },
+      projectCatalogEnabled: false,
+      projectActionsEnabled: false,
+      crossProjectChatEnabled: false,
+      remoteCommandSupportedActions: [],
+      remoteCommandDescriptors: [],
+      localCommandDescriptors: [],
+    };
+
+    const enabled = buildSyncHostHelloOkPayload({
+      ...base,
+      peer: desktop,
+      runtimeChannelEnabled: true,
+    });
+    expect(enabled.features.rpcChannel).toBe(true);
+    expect(enabled.features.portForward).toBe(true);
+
+    const disabled = buildSyncHostHelloOkPayload({
+      ...base,
+      peer: desktop,
+      runtimeChannelEnabled: false,
+    });
+    expect(disabled.features.rpcChannel).toBe(false);
+    expect(disabled.features.portForward).toBe(false);
   });
 
   it("advertises the cloud relay connect URL so already-paired phones learn the off-LAN route", () => {

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -186,16 +186,10 @@ function isMobileChangesetPeer(peer: { metadata: SyncPeerMetadata | null }): boo
   return peer.metadata?.deviceType === "phone" || peer.metadata?.platform === "iOS";
 }
 
-/**
- * Whether the peer's advertised device type is a desktop ADE runtime-host.
- * The paired runtime RPC channel and loopback port-forwarding expose the full
- * (~44 domain) runtime action registry, well beyond the mobile allowlist, so
- * they are additionally gated to desktop clients on top of successful pairing.
- */
-export function isRuntimeHostDeviceType(
-  metadata: SyncPeerMetadata | null | undefined,
+export function isRuntimeHostPairingRecord(
+  record: SyncPairingRecord | null | undefined,
 ): boolean {
-  return metadata?.deviceType === "desktop";
+  return record?.peerDeviceType === "desktop";
 }
 
 const DEFAULT_SYNC_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -4613,7 +4607,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         // even after successful pairing (phones/browsers stay on the mobile
         // command allowlist).
         runtimeChannelEnabled:
-          auth.kind === "paired" && isRuntimeHostDeviceType(hello.peer),
+          auth.kind === "paired" && isRuntimeHostPairingRecord(authenticatedPairingRecord),
       }), envelope.requestId);
       args.onStateChanged?.();
       await pumpChanges();
@@ -4630,7 +4624,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         // Gate the runtime RPC channel + port-forward to desktop runtime-host
         // peers; paired phones/browsers get the channel closed with a clear
         // reason instead of reaching the full runtime action registry.
-        peer.authKind === "paired" && isRuntimeHostDeviceType(peer.metadata),
+        peer.authKind === "paired" && isRuntimeHostPairingRecord(peer.pairingRecord),
       );
       return;
     }

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -54,10 +54,10 @@ import type {
   SyncFileBlob,
   SyncFileRequest,
   SyncFileResponsePayload,
-  SyncHelloOkPayload,
   SyncHelloPayload,
   SyncMobileProjectSummary,
   SyncPairingRequestPayload,
+  PairedRuntimeHelloOkPayload,
   SyncPeerConnectionState,
   SyncPeerMetadata,
   SyncProjectOpenRequestPayload,
@@ -115,6 +115,10 @@ import { hasNullByte, normalizeRelative, nowIso, resolvePathWithinRoot, safeJson
 import type { DeviceRegistryService } from "./deviceRegistryService";
 import { createSyncPairingStore, type SyncPairingRecord } from "./syncPairingStore";
 import { createSyncDpopNonceCache, evaluatePairedHelloDpop } from "./syncDpop";
+import {
+  createSyncPairedChannelService,
+  isPairedRuntimeEnvelopeType,
+} from "./syncPairedChannelService";
 import type { SyncPinStore } from "./syncPinStore";
 import type { SyncRuntimeNameStore } from "./syncRuntimeNameStore";
 import { DEFAULT_SYNC_COMPRESSION_THRESHOLD_BYTES, DEFAULT_SYNC_HOST_PORT, DEFAULT_SYNC_MAX_FRAME_BYTES, encodeSyncEnvelope, encodeSyncEnvelopeFrames, mapPlatform, parseSyncEnvelope, SYNC_CHUNKED_ENVELOPES_CAPABILITY, wsDataToText, type ParsedSyncEnvelope } from "./syncProtocol";
@@ -906,7 +910,7 @@ export function buildSyncHostHelloOkPayload(args: {
   compressionThresholdBytes?: number;
   maxProjectCatalogEnvelopeBytes?: number;
   cloudRelayWssUrl?: string | null;
-}): SyncHelloOkPayload {
+}): PairedRuntimeHelloOkPayload {
   const actions = [
     ...args.remoteCommandDescriptors,
     ...args.localCommandDescriptors,
@@ -916,7 +920,7 @@ export function buildSyncHostHelloOkPayload(args: {
     ...args.localCommandDescriptors.map((entry) => entry.action),
   ];
   const mobileCompatibility = evaluateMobileSyncCompatibility(supportedActions);
-  const payload: SyncHelloOkPayload = {
+  const payload: PairedRuntimeHelloOkPayload = {
     peer: args.peer,
     brain: args.brain,
     serverDbVersion: args.serverDbVersion,
@@ -964,6 +968,8 @@ export function buildSyncHostHelloOkPayload(args: {
         requiredActions: [...MOBILE_SYNC_REQUIRED_REMOTE_COMMAND_ACTIONS],
         missingActions: mobileCompatibility.missingActions,
       },
+      rpcChannel: true,
+      portForward: true,
     },
   };
   const envelopeBytes = Buffer.byteLength(encodeSyncEnvelope({
@@ -2174,6 +2180,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       for (const sessionId of peer.subscribedSessionIds) {
         restoreDesktopTerminalSizeIfUnwatched(sessionId);
       }
+      pairedChannelService.closePeer(peer.ws, "Sync socket closed.", false);
       args.onStateChanged?.();
       broadcastBrainStatus();
     });
@@ -2887,6 +2894,15 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     return peer.backpressuredSinceMs != null
       && Date.now() - peer.backpressuredSinceMs >= backpressureTimeoutMs;
   }
+
+  const pairedChannelService = createSyncPairedChannelService<WebSocket>({
+    logger: args.logger,
+    getBufferedAmount: (ws) => ws.bufferedAmount,
+    send: (ws, type, payload) => {
+      const peer = peerForSocket(ws);
+      return peer ? sendRequired(peer, type, payload) : false;
+    },
+  });
 
   function shouldDeferBackgroundChangesForChat(peer: PeerState): boolean {
     return shouldDeferSyncHostBackgroundChangesForChat({
@@ -4580,6 +4596,16 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       return;
     }
 
+    if (isPairedRuntimeEnvelopeType(envelope.type)) {
+      await pairedChannelService.handleEnvelope(
+        peer.ws,
+        envelope.type,
+        envelope.payload,
+        peer.authKind === "paired",
+      );
+      return;
+    }
+
     const envelopePayload = safeObjectValue(envelope.payload);
     const personalChatEnvelope =
       (envelope.type === "chat_subscribe" || envelope.type === "chat_unsubscribe")
@@ -5219,6 +5245,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         revokedConnectedPeer = true;
         const presenceDeviceId = peer.metadata?.deviceId ?? peer.pairedDeviceId ?? deviceId;
         const presenceRemoved = removeAllPresenceForDevice(presenceDeviceId, "remote");
+        pairedChannelService.closePeer(peer.ws, "Pairing revoked.", true);
         peer.authenticated = false;
         peer.metadata = null;
         peer.authKind = null;
@@ -5359,6 +5386,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         detachSharedListener = null;
         const snapshots: SyncPeerHandoffSnapshot[] = [];
         for (const peer of peers) {
+          pairedChannelService.closePeer(peer.ws, "Sync host changed.", true);
           clearPeerAuthTimeout(peer);
           peer.ws.removeAllListeners("message");
           peer.ws.removeAllListeners("close");
@@ -5413,6 +5441,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         await new Promise<void>((resolve) => {
           const finish = () => resolve();
           for (const peer of peers) {
+            pairedChannelService.closePeer(peer.ws, "Sync host stopped.", false);
             clearPeerAuthTimeout(peer);
             try {
               peer.ws.close();
@@ -5431,6 +5460,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
           }
         });
       }
+      pairedChannelService.dispose();
       if (bonjourAnnouncement) {
         try {
           bonjourAnnouncement.stop?.();

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -189,7 +189,7 @@ function isMobileChangesetPeer(peer: { metadata: SyncPeerMetadata | null }): boo
 export function isRuntimeHostPairingRecord(
   record: SyncPairingRecord | null | undefined,
 ): boolean {
-  return record?.peerDeviceType === "desktop";
+  return record?.runtimeHostGranted === true;
 }
 
 const DEFAULT_SYNC_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -1076,6 +1076,7 @@ function parsePairingRequestPayload(payload: unknown): SyncPairingRequestPayload
     return null;
   }
   const dpopPublicKey = toOptionalString(value?.dpopPublicKey);
+  const runtimeHostGrant = toOptionalString(value?.runtimeHostGrant);
   return {
     code,
     peer: {
@@ -1087,6 +1088,7 @@ function parsePairingRequestPayload(payload: unknown): SyncPairingRequestPayload
       dbVersion: Number(peer.dbVersion ?? 0),
     },
     ...(dpopPublicKey ? { dpopPublicKey } : {}),
+    ...(runtimeHostGrant ? { runtimeHostGrant } : {}),
   };
 }
 
@@ -1487,6 +1489,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         });
       }
       : undefined,
+    issueRuntimeHostPairingGrant: () => pairingStore.issueRuntimeHostGrant(),
     isCloudRelayEnabled: () => Boolean(args.getCloudRelayWssUrl?.()),
     logger: args.logger,
   });
@@ -4410,6 +4413,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         try {
           const result = pairingStore.pairPeer(pairing.peer, pairing.code, {
             dpopPublicKey: pairing.dpopPublicKey ?? null,
+            runtimeHostGrant: pairing.runtimeHostGrant ?? null,
           });
           clearPairFailuresAfterSuccessfulPair(peer.remoteAddress);
           args.deviceRegistryService?.upsertPeerMetadata(pairing.peer, {

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -121,7 +121,7 @@ import {
 } from "./syncPairedChannelService";
 import type { SyncPinStore } from "./syncPinStore";
 import type { SyncRuntimeNameStore } from "./syncRuntimeNameStore";
-import { DEFAULT_SYNC_COMPRESSION_THRESHOLD_BYTES, DEFAULT_SYNC_HOST_PORT, DEFAULT_SYNC_MAX_FRAME_BYTES, encodeSyncEnvelope, encodeSyncEnvelopeFrames, mapPlatform, parseSyncEnvelope, SYNC_CHUNKED_ENVELOPES_CAPABILITY, wsDataToText, type ParsedSyncEnvelope } from "./syncProtocol";
+import { DEFAULT_SYNC_COMPRESSION_THRESHOLD_BYTES, DEFAULT_SYNC_HOST_PORT, DEFAULT_SYNC_MAX_FRAME_BYTES, encodeSyncEnvelope, encodeSyncEnvelopeFrames, mapPlatform, parseSyncEnvelope, SYNC_CHUNKED_ENVELOPES_CAPABILITY, SYNC_RUNTIME_ONLY_CAPABILITY, wsDataToText, type ParsedSyncEnvelope } from "./syncProtocol";
 import { resolveTailscaleCliPath } from "./resolveTailscaleCliPath";
 import { createSyncRemoteCommandService, type SyncRemoteCommandService } from "./syncRemoteCommandService";
 import { buildPairingConnectInfo } from "./syncPairingConnectInfo";
@@ -190,6 +190,17 @@ export function isRuntimeHostPairingRecord(
   record: SyncPairingRecord | null | undefined,
 ): boolean {
   return record?.runtimeHostGranted === true;
+}
+
+export function isRuntimeOnlySyncPeer(args: {
+  authKind: "bootstrap" | "paired" | null;
+  pairingRecord: SyncPairingRecord | null;
+  metadata: SyncPeerMetadata | null;
+}): boolean {
+  return args.authKind === "paired"
+    && isRuntimeHostPairingRecord(args.pairingRecord)
+    && Array.isArray(args.metadata?.capabilities)
+    && args.metadata.capabilities.includes(SYNC_RUNTIME_ONLY_CAPABILITY);
 }
 
 const DEFAULT_SYNC_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -2997,6 +3008,10 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     return Array.isArray(peer.metadata?.capabilities) && peer.metadata.capabilities.includes("changesetAck");
   }
 
+  function isRuntimeOnlyPairedHost(peer: PeerState): boolean {
+    return isRuntimeOnlySyncPeer(peer);
+  }
+
   function sendNextChangesetBatch(
     peer: PeerState,
     reason: SyncChangesetBatchPayload["reason"],
@@ -3712,6 +3727,11 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     const nowMs = Date.now();
     for (const peer of peers) {
       if (!peer.authenticated || !peer.metadata || peer.ws.readyState !== WebSocket.OPEN) continue;
+      // A paired desktop runtime connection shares this authenticated socket
+      // only for rpc/fwd envelopes. The authoritative pairing record remains
+      // the gate so a phone/browser cannot suppress its normal CRDT stream by
+      // spoofing the hello capability.
+      if (isRuntimeOnlyPairedHost(peer)) continue;
       if (isPeerBackpressured(peer)) continue;
       if (peer.pendingChangesetBatch) {
         if (nowMs - peer.pendingChangesetBatch.sentAtMs >= CHANGESET_ACK_TIMEOUT_MS) {

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -186,6 +186,18 @@ function isMobileChangesetPeer(peer: { metadata: SyncPeerMetadata | null }): boo
   return peer.metadata?.deviceType === "phone" || peer.metadata?.platform === "iOS";
 }
 
+/**
+ * Whether the peer's advertised device type is a desktop ADE runtime-host.
+ * The paired runtime RPC channel and loopback port-forwarding expose the full
+ * (~44 domain) runtime action registry, well beyond the mobile allowlist, so
+ * they are additionally gated to desktop clients on top of successful pairing.
+ */
+export function isRuntimeHostDeviceType(
+  metadata: SyncPeerMetadata | null | undefined,
+): boolean {
+  return metadata?.deviceType === "desktop";
+}
+
 const DEFAULT_SYNC_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_SYNC_HEARTBEAT_MISS_LIMIT = 2;
 const MOBILE_SYNC_HEARTBEAT_MISS_LIMIT = 6;
@@ -910,7 +922,15 @@ export function buildSyncHostHelloOkPayload(args: {
   compressionThresholdBytes?: number;
   maxProjectCatalogEnvelopeBytes?: number;
   cloudRelayWssUrl?: string | null;
+  /**
+   * Whether this peer is authorized to use the paired runtime RPC channel and
+   * loopback port-forwarding (paired AND a desktop runtime-host). Defaults to
+   * false so non-desktop paired devices (phones/browsers) never see the
+   * feature advertised as available.
+   */
+  runtimeChannelEnabled?: boolean;
 }): PairedRuntimeHelloOkPayload {
+  const runtimeChannelEnabled = args.runtimeChannelEnabled === true;
   const actions = [
     ...args.remoteCommandDescriptors,
     ...args.localCommandDescriptors,
@@ -968,8 +988,8 @@ export function buildSyncHostHelloOkPayload(args: {
         requiredActions: [...MOBILE_SYNC_REQUIRED_REMOTE_COMMAND_ACTIONS],
         missingActions: mobileCompatibility.missingActions,
       },
-      rpcChannel: true,
-      portForward: true,
+      rpcChannel: runtimeChannelEnabled,
+      portForward: runtimeChannelEnabled,
     },
   };
   const envelopeBytes = Buffer.byteLength(encodeSyncEnvelope({
@@ -4589,6 +4609,11 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         compressionThresholdBytes,
         maxProjectCatalogEnvelopeBytes,
         cloudRelayWssUrl: args.getCloudRelayWssUrl?.() ?? null,
+        // Runtime RPC channel + port-forward are desktop-runtime-host only,
+        // even after successful pairing (phones/browsers stay on the mobile
+        // command allowlist).
+        runtimeChannelEnabled:
+          auth.kind === "paired" && isRuntimeHostDeviceType(hello.peer),
       }), envelope.requestId);
       args.onStateChanged?.();
       await pumpChanges();
@@ -4602,6 +4627,10 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         envelope.type,
         envelope.payload,
         peer.authKind === "paired",
+        // Gate the runtime RPC channel + port-forward to desktop runtime-host
+        // peers; paired phones/browsers get the channel closed with a clear
+        // reason instead of reaching the full runtime action registry.
+        peer.authKind === "paired" && isRuntimeHostDeviceType(peer.metadata),
       );
       return;
     }

--- a/apps/ade-cli/src/services/sync/syncPairedChannelService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncPairedChannelService.test.ts
@@ -36,6 +36,7 @@ class FakeForwardSocket extends EventEmitter {
   paused = false;
   destroyed = false;
   readonly writes: Buffer[] = [];
+  readonly timeoutValues: number[] = [];
 
   constructor(private readonly echoWrites = false) {
     super();
@@ -56,6 +57,11 @@ class FakeForwardSocket extends EventEmitter {
 
   resume(): this {
     this.paused = false;
+    return this;
+  }
+
+  setTimeout(timeoutMs: number): this {
+    this.timeoutValues.push(timeoutMs);
     return this;
   }
 
@@ -92,6 +98,7 @@ function createHarness(options: {
   bufferedAmount?: () => number;
   forwardPendingBytes?: number;
   backpressurePollMs?: number;
+  forwardConnectTimeoutMs?: number;
   connectForward?: () => FakeForwardSocket;
 } = {}) {
   const sent: SentEnvelope[] = [];
@@ -101,6 +108,7 @@ function createHarness(options: {
     getBufferedAmount: options.bufferedAmount ?? (() => 0),
     forwardPendingBytes: options.forwardPendingBytes,
     backpressurePollMs: options.backpressurePollMs,
+    forwardConnectTimeoutMs: options.forwardConnectTimeoutMs,
     connectForward: options.connectForward
       ? () => options.connectForward!() as unknown as net.Socket
       : undefined,
@@ -268,6 +276,7 @@ describe("createSyncPairedChannelService", () => {
       port: 4173,
     }, true, true);
     socket.connect();
+    expect(socket.timeoutValues).toEqual([10_000, 0]);
     await service.handleEnvelope(peer, "fwd_data", {
       forwardId: "fwd-echo",
       data: Buffer.from("hello over sync", "utf8").toString("base64"),
@@ -291,6 +300,32 @@ describe("createSyncPairedChannelService", () => {
     );
     expect(sent.find((envelope) => envelope.type === "fwd_close")?.payload).toMatchObject({
       forwardId: "fwd-echo",
+    });
+    service.dispose();
+  });
+
+  it("closes a loopback forward when its TCP connection times out", async () => {
+    const socket = new FakeForwardSocket();
+    const { service, sent, peer } = createHarness({
+      connectForward: () => socket,
+      forwardConnectTimeoutMs: 25,
+    });
+
+    await service.handleEnvelope(peer, "fwd_open", {
+      forwardId: "fwd-timeout",
+      host: "127.0.0.1",
+      port: 4173,
+    }, true, true);
+    socket.emit("timeout");
+
+    expect(socket.timeoutValues).toEqual([25]);
+    expect(socket.destroyed).toBe(true);
+    expect(sent).toContainEqual({
+      type: "fwd_close",
+      payload: {
+        forwardId: "fwd-timeout",
+        reason: "Remote TCP connection timed out.",
+      },
     });
     service.dispose();
   });

--- a/apps/ade-cli/src/services/sync/syncPairedChannelService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncPairedChannelService.test.ts
@@ -6,12 +6,25 @@ import {
   createSyncPairedChannelService,
   type SyncRuntimeRpcHandler,
 } from "./syncPairedChannelService";
+import { isRuntimeHostPairingRecord } from "./syncHostService";
+import type { SyncPairingRecord } from "./syncPairingStore";
 
 type Peer = { id: string };
 type SentEnvelope = {
   type: PairedRuntimeSyncEnvelope["type"];
   payload: Record<string, unknown>;
 };
+
+function pairingRecord(peerDeviceType: string): SyncPairingRecord {
+  return {
+    secretHash: "hash",
+    createdAt: "2026-07-10T00:00:00.000Z",
+    lastUsedAt: null,
+    peerName: "Paired peer",
+    peerPlatform: "macOS",
+    peerDeviceType,
+  };
+}
 
 afterEach(() => {
   vi.useRealTimers();
@@ -312,37 +325,58 @@ describe("createSyncPairedChannelService", () => {
     service.dispose();
   });
 
-  it("rejects runtime and forward opens from a paired but non-desktop peer", async () => {
-    const createRpcHandler = vi.fn();
-    const connectForward = vi.fn(() => new FakeForwardSocket());
-    const { service, sent, peer } = createHarness({ createRpcHandler, connectForward });
+  it("rejects runtime and forward opens when phone/browser pairing records claim desktop in hello metadata", async () => {
+    const spoofedHelloMetadata = { deviceType: "desktop" };
+    expect(spoofedHelloMetadata.deviceType).toBe("desktop");
+    for (const peerDeviceType of ["phone", "browser"]) {
+      const createRpcHandler = vi.fn();
+      const connectForward = vi.fn(() => new FakeForwardSocket());
+      const { service, sent, peer } = createHarness({ createRpcHandler, connectForward });
+      const authorizedForRuntimeHost = isRuntimeHostPairingRecord(pairingRecord(peerDeviceType));
+      await service.handleEnvelope(peer, "rpc_open", { channelId: `rpc-${peerDeviceType}` }, true, authorizedForRuntimeHost);
+      await service.handleEnvelope(peer, "fwd_open", {
+        forwardId: `fwd-${peerDeviceType}`,
+        host: "127.0.0.1",
+        port: 4173,
+      }, true, authorizedForRuntimeHost);
 
-    // authenticatedWithPairing = true, authorizedForRuntimeHost = false
-    await service.handleEnvelope(peer, "rpc_open", { channelId: "rpc-phone" }, true, false);
+      expect(createRpcHandler).not.toHaveBeenCalled();
+      expect(connectForward).not.toHaveBeenCalled();
+      expect(sent).toEqual([
+        {
+          type: "rpc_close",
+          payload: {
+            channelId: `rpc-${peerDeviceType}`,
+            reason: "Runtime channel is only available to desktop clients.",
+          },
+        },
+        {
+          type: "fwd_close",
+          payload: {
+            forwardId: `fwd-${peerDeviceType}`,
+            reason: "Runtime channel is only available to desktop clients.",
+          },
+        },
+      ]);
+      service.dispose();
+    }
+  });
+
+  it("allows runtime and forward opens for a genuine desktop pairing record", async () => {
+    const createRpcHandler = vi.fn(() => (async () => null) as SyncRuntimeRpcHandler);
+    const connectForward = vi.fn(() => new FakeForwardSocket());
+    const { service, peer } = createHarness({ createRpcHandler, connectForward });
+    const authorizedForRuntimeHost = isRuntimeHostPairingRecord(pairingRecord("desktop"));
+
+    await service.handleEnvelope(peer, "rpc_open", { channelId: "rpc-desktop" }, true, authorizedForRuntimeHost);
     await service.handleEnvelope(peer, "fwd_open", {
-      forwardId: "fwd-phone",
+      forwardId: "fwd-desktop",
       host: "127.0.0.1",
       port: 4173,
-    }, true, false);
+    }, true, authorizedForRuntimeHost);
 
-    expect(createRpcHandler).not.toHaveBeenCalled();
-    expect(connectForward).not.toHaveBeenCalled();
-    expect(sent).toEqual([
-      {
-        type: "rpc_close",
-        payload: {
-          channelId: "rpc-phone",
-          reason: "Runtime channel is only available to desktop clients.",
-        },
-      },
-      {
-        type: "fwd_close",
-        payload: {
-          forwardId: "fwd-phone",
-          reason: "Runtime channel is only available to desktop clients.",
-        },
-      },
-    ]);
+    expect(createRpcHandler).toHaveBeenCalledTimes(1);
+    expect(connectForward).toHaveBeenCalledTimes(1);
     service.dispose();
   });
 

--- a/apps/ade-cli/src/services/sync/syncPairedChannelService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncPairedChannelService.test.ts
@@ -127,7 +127,7 @@ describe("createSyncPairedChannelService", () => {
     });
     const { service, sent, peer } = createHarness({ createRpcHandler });
 
-    await service.handleEnvelope(peer, "rpc_open", { channelId: "rpc-1" }, true);
+    await service.handleEnvelope(peer, "rpc_open", { channelId: "rpc-1" }, true, true);
     const initialize = `${JSON.stringify({
       jsonrpc: "2.0",
       id: 1,
@@ -139,11 +139,11 @@ describe("createSyncPairedChannelService", () => {
     await service.handleEnvelope(peer, "rpc_data", {
       channelId: "rpc-1",
       data: bytes.subarray(0, 17).toString("base64"),
-    }, true);
+    }, true, true);
     await service.handleEnvelope(peer, "rpc_data", {
       channelId: "rpc-1",
       data: bytes.subarray(17).toString("base64"),
-    }, true);
+    }, true, true);
 
     await waitFor(() => rpcText(sent, "rpc-1").split("\n").filter(Boolean).length === 2, "RPC responses");
     const responses = rpcText(sent, "rpc-1")
@@ -156,7 +156,7 @@ describe("createSyncPairedChannelService", () => {
     ]);
     expect(createRpcHandler).toHaveBeenCalledTimes(1);
 
-    await service.handleEnvelope(peer, "rpc_close", { channelId: "rpc-1", reason: "done" }, true);
+    await service.handleEnvelope(peer, "rpc_close", { channelId: "rpc-1", reason: "done" }, true, true);
     expect(disposed).toHaveBeenCalledTimes(1);
     expect(sent.some((envelope) => envelope.type === "rpc_close")).toBe(false);
     service.dispose();
@@ -199,18 +199,18 @@ describe("createSyncPairedChannelService", () => {
       createRpcHandler: () => async () => null,
       connectForward: () => socket,
     });
-    await service.handleEnvelope(peer, "rpc_open", { channelId: "rpc-owner" }, true);
+    await service.handleEnvelope(peer, "rpc_open", { channelId: "rpc-owner" }, true, true);
     await service.handleEnvelope(peer, "fwd_open", {
       forwardId: "fwd-owned",
       host: "127.0.0.1",
       port: 4173,
-    }, true);
+    }, true, true);
     socket.connect();
 
     await service.handleEnvelope(peer, "rpc_close", {
       channelId: "rpc-owner",
       reason: "runtime closed",
-    }, true);
+    }, true, true);
 
     expect(socket.destroyed).toBe(true);
     expect(sent).toContainEqual({
@@ -231,7 +231,7 @@ describe("createSyncPairedChannelService", () => {
       forwardId: "fwd-public",
       host: "192.0.2.10",
       port: 443,
-    }, true);
+    }, true, true);
 
     expect(connectForward).not.toHaveBeenCalled();
     expect(sent).toContainEqual({
@@ -252,12 +252,12 @@ describe("createSyncPairedChannelService", () => {
       forwardId: "fwd-echo",
       host: "localhost",
       port: 4173,
-    }, true);
+    }, true, true);
     socket.connect();
     await service.handleEnvelope(peer, "fwd_data", {
       forwardId: "fwd-echo",
       data: Buffer.from("hello over sync", "utf8").toString("base64"),
-    }, true);
+    }, true, true);
 
     await waitFor(
       () => sent.some((envelope) => envelope.type === "fwd_data"),
@@ -294,7 +294,7 @@ describe("createSyncPairedChannelService", () => {
       forwardId: "fwd-pressure",
       host: "127.0.0.1",
       port: 4173,
-    }, true);
+    }, true, true);
     socket.connect();
     socket.push("queued");
     await new Promise((resolve) => setTimeout(resolve, 30));
@@ -309,6 +309,90 @@ describe("createSyncPairedChannelService", () => {
       String(sent.find((envelope) => envelope.type === "fwd_data")?.payload.data),
       "base64",
     ).toString("utf8")).toBe("queued");
+    service.dispose();
+  });
+
+  it("rejects runtime and forward opens from a paired but non-desktop peer", async () => {
+    const createRpcHandler = vi.fn();
+    const connectForward = vi.fn(() => new FakeForwardSocket());
+    const { service, sent, peer } = createHarness({ createRpcHandler, connectForward });
+
+    // authenticatedWithPairing = true, authorizedForRuntimeHost = false
+    await service.handleEnvelope(peer, "rpc_open", { channelId: "rpc-phone" }, true, false);
+    await service.handleEnvelope(peer, "fwd_open", {
+      forwardId: "fwd-phone",
+      host: "127.0.0.1",
+      port: 4173,
+    }, true, false);
+
+    expect(createRpcHandler).not.toHaveBeenCalled();
+    expect(connectForward).not.toHaveBeenCalled();
+    expect(sent).toEqual([
+      {
+        type: "rpc_close",
+        payload: {
+          channelId: "rpc-phone",
+          reason: "Runtime channel is only available to desktop clients.",
+        },
+      },
+      {
+        type: "fwd_close",
+        payload: {
+          forwardId: "fwd-phone",
+          reason: "Runtime channel is only available to desktop clients.",
+        },
+      },
+    ]);
+    service.dispose();
+  });
+
+  it("caps concurrent RPC channels per peer", async () => {
+    const createRpcHandler = vi.fn(() => (async () => null) as SyncRuntimeRpcHandler);
+    const { service, sent, peer } = createHarness({ createRpcHandler });
+
+    // MAX_RPC_CHANNELS_PER_PEER = 32
+    for (let i = 0; i < 32; i += 1) {
+      await service.handleEnvelope(peer, "rpc_open", { channelId: `rpc-${i}` }, true, true);
+    }
+    expect(createRpcHandler).toHaveBeenCalledTimes(32);
+
+    await service.handleEnvelope(peer, "rpc_open", { channelId: "rpc-over" }, true, true);
+    expect(createRpcHandler).toHaveBeenCalledTimes(32);
+    expect(sent).toContainEqual({
+      type: "rpc_close",
+      payload: { channelId: "rpc-over", reason: "Too many open runtime channels." },
+    });
+
+    // Re-opening an already-open channel id replaces it, not exceeding the cap.
+    await service.handleEnvelope(peer, "rpc_open", { channelId: "rpc-0" }, true, true);
+    expect(createRpcHandler).toHaveBeenCalledTimes(33);
+    service.dispose();
+  });
+
+  it("caps concurrent forwards per peer", async () => {
+    const connectForward = vi.fn(() => new FakeForwardSocket());
+    const { service, sent, peer } = createHarness({ connectForward });
+
+    // MAX_FORWARDS_PER_PEER = 64
+    for (let i = 0; i < 64; i += 1) {
+      await service.handleEnvelope(peer, "fwd_open", {
+        forwardId: `fwd-${i}`,
+        host: "127.0.0.1",
+        port: 4173,
+      }, true, true);
+    }
+    expect(connectForward).toHaveBeenCalledTimes(64);
+
+    await service.handleEnvelope(peer, "fwd_open", {
+      forwardId: "fwd-over",
+      host: "127.0.0.1",
+      port: 4173,
+    }, true, true);
+    expect(connectForward).toHaveBeenCalledTimes(64);
+    expect(sent).toContainEqual({
+      type: "fwd_close",
+      payload: { forwardId: "fwd-over", reason: "Too many open port forwards." },
+    });
     service.dispose();
   });
 });

--- a/apps/ade-cli/src/services/sync/syncPairedChannelService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncPairedChannelService.test.ts
@@ -1,0 +1,314 @@
+import { EventEmitter } from "node:events";
+import type net from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PairedRuntimeSyncEnvelope } from "../../../../desktop/src/shared/types/pairedRuntime";
+import {
+  createSyncPairedChannelService,
+  type SyncRuntimeRpcHandler,
+} from "./syncPairedChannelService";
+
+type Peer = { id: string };
+type SentEnvelope = {
+  type: PairedRuntimeSyncEnvelope["type"];
+  payload: Record<string, unknown>;
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+class FakeForwardSocket extends EventEmitter {
+  writableLength = 0;
+  paused = false;
+  destroyed = false;
+  readonly writes: Buffer[] = [];
+
+  constructor(private readonly echoWrites = false) {
+    super();
+  }
+
+  write(data: Uint8Array): boolean {
+    if (this.destroyed) return false;
+    const bytes = Buffer.from(data);
+    this.writes.push(bytes);
+    if (this.echoWrites) queueMicrotask(() => this.emit("data", bytes));
+    return true;
+  }
+
+  pause(): this {
+    this.paused = true;
+    return this;
+  }
+
+  resume(): this {
+    this.paused = false;
+    return this;
+  }
+
+  destroy(): this {
+    if (this.destroyed) return this;
+    this.destroyed = true;
+    queueMicrotask(() => this.emit("close"));
+    return this;
+  }
+
+  connect(): void {
+    this.emit("connect");
+  }
+
+  push(data: string | Buffer): void {
+    this.emit("data", Buffer.from(data));
+  }
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${message}.`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function createHarness(options: {
+  createRpcHandler?: () => SyncRuntimeRpcHandler;
+  bufferedAmount?: () => number;
+  forwardPendingBytes?: number;
+  backpressurePollMs?: number;
+  connectForward?: () => FakeForwardSocket;
+} = {}) {
+  const sent: SentEnvelope[] = [];
+  const service = createSyncPairedChannelService<Peer>({
+    logger: { warn: vi.fn() },
+    createRpcHandler: options.createRpcHandler,
+    getBufferedAmount: options.bufferedAmount ?? (() => 0),
+    forwardPendingBytes: options.forwardPendingBytes,
+    backpressurePollMs: options.backpressurePollMs,
+    connectForward: options.connectForward
+      ? () => options.connectForward!() as unknown as net.Socket
+      : undefined,
+    send: (_peer, type, payload) => {
+      sent.push({ type, payload: payload as unknown as Record<string, unknown> });
+      return true;
+    },
+  });
+  return { service, sent, peer: { id: "desktop" } };
+}
+
+function rpcText(sent: SentEnvelope[], channelId: string): string {
+  return Buffer.concat(sent.flatMap((envelope) => {
+    if (envelope.type !== "rpc_data" || envelope.payload.channelId !== channelId) return [];
+    return [Buffer.from(String(envelope.payload.data), "base64")];
+  })).toString("utf8");
+}
+
+describe("createSyncPairedChannelService", () => {
+  it("bridges chunked newline JSON-RPC bytes through a fresh handler and closes it", async () => {
+    const disposed = vi.fn();
+    let initialized = false;
+    const createRpcHandler = vi.fn(() => {
+      initialized = false;
+      const handler = (async (request) => {
+        if (request.method === "ade/initialize") {
+          initialized = true;
+          return { runtimeInfo: { multiProject: true } };
+        }
+        if (request.method === "ping") {
+          if (!initialized) throw new Error("not initialized");
+          return { pong: true };
+        }
+        return null;
+      }) as SyncRuntimeRpcHandler;
+      handler.dispose = disposed;
+      return handler;
+    });
+    const { service, sent, peer } = createHarness({ createRpcHandler });
+
+    await service.handleEnvelope(peer, "rpc_open", { channelId: "rpc-1" }, true);
+    const initialize = `${JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "ade/initialize",
+      params: { protocolVersion: "2025-06-18" },
+    })}\n`;
+    const ping = `${JSON.stringify({ jsonrpc: "2.0", id: 2, method: "ping" })}\n`;
+    const bytes = Buffer.from(initialize + ping, "utf8");
+    await service.handleEnvelope(peer, "rpc_data", {
+      channelId: "rpc-1",
+      data: bytes.subarray(0, 17).toString("base64"),
+    }, true);
+    await service.handleEnvelope(peer, "rpc_data", {
+      channelId: "rpc-1",
+      data: bytes.subarray(17).toString("base64"),
+    }, true);
+
+    await waitFor(() => rpcText(sent, "rpc-1").split("\n").filter(Boolean).length === 2, "RPC responses");
+    const responses = rpcText(sent, "rpc-1")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as { id: number; result: unknown });
+    expect(responses).toEqual([
+      { jsonrpc: "2.0", id: 1, result: { runtimeInfo: { multiProject: true } } },
+      { jsonrpc: "2.0", id: 2, result: { pong: true } },
+    ]);
+    expect(createRpcHandler).toHaveBeenCalledTimes(1);
+
+    await service.handleEnvelope(peer, "rpc_close", { channelId: "rpc-1", reason: "done" }, true);
+    expect(disposed).toHaveBeenCalledTimes(1);
+    expect(sent.some((envelope) => envelope.type === "rpc_close")).toBe(false);
+    service.dispose();
+  });
+
+  it("rejects runtime and forward opens that did not use paired authentication", async () => {
+    const createRpcHandler = vi.fn();
+    const { service, sent, peer } = createHarness({ createRpcHandler });
+
+    await service.handleEnvelope(peer, "rpc_open", { channelId: "rpc-denied" }, false);
+    await service.handleEnvelope(peer, "fwd_open", {
+      forwardId: "fwd-denied",
+      host: "127.0.0.1",
+      port: 80,
+    }, false);
+
+    expect(createRpcHandler).not.toHaveBeenCalled();
+    expect(sent).toEqual([
+      {
+        type: "rpc_close",
+        payload: {
+          channelId: "rpc-denied",
+          reason: "Paired device authentication is required.",
+        },
+      },
+      {
+        type: "fwd_close",
+        payload: {
+          forwardId: "fwd-denied",
+          reason: "Paired device authentication is required.",
+        },
+      },
+    ]);
+    service.dispose();
+  });
+
+  it("tears down the peer's forwards when its RPC channel closes", async () => {
+    const socket = new FakeForwardSocket();
+    const { service, sent, peer } = createHarness({
+      createRpcHandler: () => async () => null,
+      connectForward: () => socket,
+    });
+    await service.handleEnvelope(peer, "rpc_open", { channelId: "rpc-owner" }, true);
+    await service.handleEnvelope(peer, "fwd_open", {
+      forwardId: "fwd-owned",
+      host: "127.0.0.1",
+      port: 4173,
+    }, true);
+    socket.connect();
+
+    await service.handleEnvelope(peer, "rpc_close", {
+      channelId: "rpc-owner",
+      reason: "runtime closed",
+    }, true);
+
+    expect(socket.destroyed).toBe(true);
+    expect(sent).toContainEqual({
+      type: "fwd_close",
+      payload: {
+        forwardId: "fwd-owned",
+        reason: "RPC channel closed by peer.",
+      },
+    });
+    service.dispose();
+  });
+
+  it("rejects authenticated forwards outside the host loopback interface", async () => {
+    const connectForward = vi.fn(() => new FakeForwardSocket());
+    const { service, sent, peer } = createHarness({ connectForward });
+
+    await service.handleEnvelope(peer, "fwd_open", {
+      forwardId: "fwd-public",
+      host: "192.0.2.10",
+      port: 443,
+    }, true);
+
+    expect(connectForward).not.toHaveBeenCalled();
+    expect(sent).toContainEqual({
+      type: "fwd_close",
+      payload: {
+        forwardId: "fwd-public",
+        reason: "Port forwards may connect only to 127.0.0.1 or localhost.",
+      },
+    });
+    service.dispose();
+  });
+
+  it("echoes forwarded TCP bytes and propagates remote close", async () => {
+    const socket = new FakeForwardSocket(true);
+    const { service, sent, peer } = createHarness({ connectForward: () => socket });
+
+    await service.handleEnvelope(peer, "fwd_open", {
+      forwardId: "fwd-echo",
+      host: "localhost",
+      port: 4173,
+    }, true);
+    socket.connect();
+    await service.handleEnvelope(peer, "fwd_data", {
+      forwardId: "fwd-echo",
+      data: Buffer.from("hello over sync", "utf8").toString("base64"),
+    }, true);
+
+    await waitFor(
+      () => sent.some((envelope) => envelope.type === "fwd_data"),
+      "forward echo",
+    );
+    const echoed = Buffer.concat(sent.flatMap((envelope) =>
+      envelope.type === "fwd_data"
+        ? [Buffer.from(String(envelope.payload.data), "base64")]
+        : []
+    )).toString("utf8");
+    expect(echoed).toBe("hello over sync");
+
+    socket.destroy();
+    await waitFor(
+      () => sent.some((envelope) => envelope.type === "fwd_close"),
+      "forward close",
+    );
+    expect(sent.find((envelope) => envelope.type === "fwd_close")?.payload).toMatchObject({
+      forwardId: "fwd-echo",
+    });
+    service.dispose();
+  });
+
+  it("pauses forwarded output while the peer is backpressured and resumes below 4 MiB", async () => {
+    const socket = new FakeForwardSocket();
+    let bufferedAmount = 4 * 1024 * 1024;
+    const { service, sent, peer } = createHarness({
+      bufferedAmount: () => bufferedAmount,
+      backpressurePollMs: 5,
+      connectForward: () => socket,
+    });
+
+    await service.handleEnvelope(peer, "fwd_open", {
+      forwardId: "fwd-pressure",
+      host: "127.0.0.1",
+      port: 4173,
+    }, true);
+    socket.connect();
+    socket.push("queued");
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(sent.some((envelope) => envelope.type === "fwd_data")).toBe(false);
+
+    bufferedAmount = 0;
+    await waitFor(
+      () => sent.some((envelope) => envelope.type === "fwd_data"),
+      "backpressure recovery",
+    );
+    expect(Buffer.from(
+      String(sent.find((envelope) => envelope.type === "fwd_data")?.payload.data),
+      "base64",
+    ).toString("utf8")).toBe("queued");
+    service.dispose();
+  });
+});

--- a/apps/ade-cli/src/services/sync/syncPairedChannelService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncPairedChannelService.test.ts
@@ -23,6 +23,7 @@ function pairingRecord(peerDeviceType: string): SyncPairingRecord {
     peerName: "Paired peer",
     peerPlatform: "macOS",
     peerDeviceType,
+    runtimeHostGranted: peerDeviceType === "desktop",
   };
 }
 

--- a/apps/ade-cli/src/services/sync/syncPairedChannelService.ts
+++ b/apps/ade-cli/src/services/sync/syncPairedChannelService.ts
@@ -23,6 +23,7 @@ import {
 } from "./syncProtocol";
 
 const DEFAULT_FORWARD_PENDING_BYTES = 4 * 1024 * 1024;
+const DEFAULT_FORWARD_CONNECT_TIMEOUT_MS = 10_000;
 const MAX_CLOSE_REASON_CHARS = 300;
 // Per-peer resource caps. Each RPC channel spins a full JSON-RPC handler with
 // its own (up to 64 MiB) line buffer, and each forward holds a live loopback
@@ -119,6 +120,7 @@ export type SyncPairedChannelServiceArgs<TPeer extends object> = {
   peerBackpressureBytes?: number;
   forwardPendingBytes?: number;
   backpressurePollMs?: number;
+  forwardConnectTimeoutMs?: number;
   /** Test seam for an in-process TCP socket pair; production uses net.connect. */
   connectForward?: (options: net.NetConnectOpts) => net.Socket;
 };
@@ -155,6 +157,10 @@ export function createSyncPairedChannelService<TPeer extends object>(
   const backpressurePollMs = Math.max(
     1,
     Math.floor(args.backpressurePollMs ?? BACKPRESSURE_POLL_MS),
+  );
+  const forwardConnectTimeoutMs = Math.max(
+    1,
+    Math.floor(args.forwardConnectTimeoutMs ?? DEFAULT_FORWARD_CONNECT_TIMEOUT_MS),
   );
   const peers = new Map<TPeer, PeerChannels>();
 
@@ -458,10 +464,18 @@ export function createSyncPairedChannelService<TPeer extends object>(
     };
     channelsFor(peer).forwards.set(forwardId, forward);
 
+    socket.setTimeout(forwardConnectTimeoutMs);
+    socket.once("timeout", () => {
+      const current = peers.get(peer)?.forwards.get(forwardId);
+      if (current !== forward || forward.connected) return;
+      closeForward(peer, forwardId, "Remote TCP connection timed out.", true);
+    });
+
     socket.once("connect", () => {
       const current = peers.get(peer)?.forwards.get(forwardId);
       if (current !== forward) return;
       forward.connected = true;
+      socket.setTimeout(0);
       for (const chunk of forward.inboundBeforeConnect) {
         socket.write(chunk);
       }

--- a/apps/ade-cli/src/services/sync/syncPairedChannelService.ts
+++ b/apps/ade-cli/src/services/sync/syncPairedChannelService.ts
@@ -1,0 +1,592 @@
+import net from "node:net";
+import type {
+  PairedRuntimeForwardClosePayload,
+  PairedRuntimeForwardDataPayload,
+  PairedRuntimeForwardOpenPayload,
+  PairedRuntimeRpcClosePayload,
+  PairedRuntimeRpcDataPayload,
+  PairedRuntimeRpcOpenPayload,
+  PairedRuntimeSyncEnvelope,
+} from "../../../../desktop/src/shared/types/pairedRuntime";
+import {
+  startJsonRpcServer,
+  type JsonRpcHandler,
+  type JsonRpcTransport,
+} from "../../jsonrpc";
+
+const DEFAULT_PEER_BACKPRESSURE_BYTES = 4 * 1024 * 1024;
+const DEFAULT_FORWARD_PENDING_BYTES = 4 * 1024 * 1024;
+const DEFAULT_BACKPRESSURE_POLL_MS = 25;
+const RPC_DATA_CHUNK_BYTES = 256 * 1024;
+const FORWARD_DATA_CHUNK_BYTES = 64 * 1024;
+const MAX_CHANNEL_ID_CHARS = 128;
+const MAX_CLOSE_REASON_CHARS = 300;
+
+export type SyncRuntimeRpcHandler = JsonRpcHandler & {
+  dispose?: () => void;
+  setNotifier?: (
+    notify: ((method: string, params?: unknown) => void) | null,
+  ) => void;
+};
+
+export type SyncRuntimeRpcHandlerFactory = () => SyncRuntimeRpcHandler;
+
+let configuredRuntimeRpcHandlerFactory: SyncRuntimeRpcHandlerFactory | null = null;
+
+/**
+ * Installs the process-local `ade serve` multi-project handler factory. The
+ * sync host consumes it lazily for each rpc_open, so every channel has the
+ * same isolated request state as a unix/TCP/stdio runtime connection while
+ * sharing the daemon's project/scope registries.
+ */
+export function setSyncRuntimeRpcHandlerFactory(
+  factory: SyncRuntimeRpcHandlerFactory | null,
+): () => void {
+  const previous = configuredRuntimeRpcHandlerFactory;
+  configuredRuntimeRpcHandlerFactory = factory;
+  return () => {
+    if (configuredRuntimeRpcHandlerFactory === factory) {
+      configuredRuntimeRpcHandlerFactory = previous;
+    }
+  };
+}
+
+export function getSyncRuntimeRpcHandlerFactory(): SyncRuntimeRpcHandlerFactory | null {
+  return configuredRuntimeRpcHandlerFactory;
+}
+
+export function isPairedRuntimeEnvelopeType(
+  type: string,
+): type is PairedRuntimeSyncEnvelope["type"] {
+  return type === "rpc_open"
+    || type === "rpc_data"
+    || type === "rpc_close"
+    || type === "fwd_open"
+    || type === "fwd_data"
+    || type === "fwd_close";
+}
+
+type LoggerLike = {
+  debug?: (message: string, fields?: Record<string, unknown>) => void;
+  warn: (message: string, fields?: Record<string, unknown>) => void;
+};
+
+type RpcChannel = {
+  handler: SyncRuntimeRpcHandler;
+  stop: ReturnType<typeof startJsonRpcServer>;
+  receive: (chunk: Buffer) => void;
+};
+
+type ForwardChannel = {
+  socket: net.Socket;
+  connected: boolean;
+  inboundBeforeConnect: Buffer[];
+  inboundBeforeConnectBytes: number;
+  outboundPending: Buffer[];
+  outboundPendingBytes: number;
+  resumeTimer: ReturnType<typeof setInterval> | null;
+};
+
+type PeerChannels = {
+  rpc: Map<string, RpcChannel>;
+  forwards: Map<string, ForwardChannel>;
+};
+
+export type SyncPairedChannelServiceArgs<TPeer extends object> = {
+  logger: LoggerLike;
+  send: (
+    peer: TPeer,
+    type: PairedRuntimeSyncEnvelope["type"],
+    payload:
+      | PairedRuntimeRpcDataPayload
+      | PairedRuntimeRpcClosePayload
+      | PairedRuntimeForwardDataPayload
+      | PairedRuntimeForwardClosePayload,
+  ) => boolean;
+  getBufferedAmount: (peer: TPeer) => number;
+  createRpcHandler?: SyncRuntimeRpcHandlerFactory;
+  peerBackpressureBytes?: number;
+  forwardPendingBytes?: number;
+  backpressurePollMs?: number;
+  /** Test seam for an in-process TCP socket pair; production uses net.connect. */
+  connectForward?: (options: net.NetConnectOpts) => net.Socket;
+};
+
+function normalizedId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const id = value.trim();
+  if (!id || id.length > MAX_CHANNEL_ID_CHARS) return null;
+  return /^[a-zA-Z0-9._:-]+$/.test(id) ? id : null;
+}
+
+function closeReason(value: unknown, fallback: string): string {
+  const reason = typeof value === "string" && value.trim()
+    ? value.trim()
+    : fallback;
+  return reason.slice(0, MAX_CLOSE_REASON_CHARS);
+}
+
+function decodeBase64(value: unknown): Buffer | null {
+  if (typeof value !== "string") return null;
+  if (value.length === 0) return Buffer.alloc(0);
+  if (value.length % 4 !== 0 || !/^[a-zA-Z0-9+/]*={0,2}$/.test(value)) {
+    return null;
+  }
+  try {
+    return Buffer.from(value, "base64");
+  } catch {
+    return null;
+  }
+}
+
+function allowedForwardHost(value: unknown): "127.0.0.1" | null {
+  if (typeof value !== "string") return null;
+  const host = value.trim().toLowerCase();
+  return host === "127.0.0.1" || host === "localhost" ? "127.0.0.1" : null;
+}
+
+function allowedForwardPort(value: unknown): number | null {
+  const port = Number(value);
+  return Number.isInteger(port) && port >= 1 && port <= 65_535 ? port : null;
+}
+
+export function createSyncPairedChannelService<TPeer extends object>(
+  args: SyncPairedChannelServiceArgs<TPeer>,
+) {
+  const peerBackpressureBytes = Math.max(
+    1,
+    Math.floor(args.peerBackpressureBytes ?? DEFAULT_PEER_BACKPRESSURE_BYTES),
+  );
+  const forwardPendingBytes = Math.max(
+    1,
+    Math.floor(args.forwardPendingBytes ?? DEFAULT_FORWARD_PENDING_BYTES),
+  );
+  const backpressurePollMs = Math.max(
+    1,
+    Math.floor(args.backpressurePollMs ?? DEFAULT_BACKPRESSURE_POLL_MS),
+  );
+  const peers = new Map<TPeer, PeerChannels>();
+
+  const channelsFor = (peer: TPeer): PeerChannels => {
+    const existing = peers.get(peer);
+    if (existing) return existing;
+    const created: PeerChannels = { rpc: new Map(), forwards: new Map() };
+    peers.set(peer, created);
+    return created;
+  };
+
+  const dropEmptyPeer = (peer: TPeer): void => {
+    const channels = peers.get(peer);
+    if (channels && channels.rpc.size === 0 && channels.forwards.size === 0) {
+      peers.delete(peer);
+    }
+  };
+
+  const sendRpcClose = (peer: TPeer, channelId: string, reason: string): void => {
+    args.send(peer, "rpc_close", { channelId, reason });
+  };
+
+  const sendForwardClose = (peer: TPeer, forwardId: string, reason: string): void => {
+    args.send(peer, "fwd_close", { forwardId, reason });
+  };
+
+  const closeRpc = (
+    peer: TPeer,
+    channelId: string,
+    reason: string,
+    notify: boolean,
+  ): void => {
+    const channels = peers.get(peer);
+    const channel = channels?.rpc.get(channelId);
+    if (!channels || !channel) return;
+    channels.rpc.delete(channelId);
+    try {
+      channel.stop();
+    } catch {
+      // Best-effort teardown; the handler is disposed independently below.
+    }
+    try {
+      channel.handler.dispose?.();
+    } catch (error) {
+      args.logger.warn("sync_paired.rpc_handler_dispose_failed", {
+        channelId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    if (notify) sendRpcClose(peer, channelId, closeReason(reason, "RPC channel closed."));
+    dropEmptyPeer(peer);
+  };
+
+  const closeForward = (
+    peer: TPeer,
+    forwardId: string,
+    reason: string,
+    notify: boolean,
+  ): void => {
+    const channels = peers.get(peer);
+    const forward = channels?.forwards.get(forwardId);
+    if (!channels || !forward) return;
+    channels.forwards.delete(forwardId);
+    if (forward.resumeTimer) clearInterval(forward.resumeTimer);
+    forward.resumeTimer = null;
+    try {
+      forward.socket.destroy();
+    } catch {
+      // ignore socket teardown failures
+    }
+    if (notify) {
+      sendForwardClose(
+        peer,
+        forwardId,
+        closeReason(reason, "Remote TCP connection closed."),
+      );
+    }
+    dropEmptyPeer(peer);
+  };
+
+  const closePeerForwards = (
+    peer: TPeer,
+    reason: string,
+    notify: boolean,
+  ): void => {
+    const channels = peers.get(peer);
+    if (!channels) return;
+    for (const forwardId of [...channels.forwards.keys()]) {
+      closeForward(peer, forwardId, reason, notify);
+    }
+  };
+
+  const sendForwardChunk = (
+    peer: TPeer,
+    forwardId: string,
+    chunk: Buffer,
+  ): boolean => args.send(peer, "fwd_data", {
+    forwardId,
+    data: chunk.toString("base64"),
+  });
+
+  const flushForwardOutbound = (peer: TPeer, forwardId: string): void => {
+    const forward = peers.get(peer)?.forwards.get(forwardId);
+    if (!forward) return;
+    while (
+      forward.outboundPending.length > 0
+      && args.getBufferedAmount(peer) < peerBackpressureBytes
+    ) {
+      const chunk = forward.outboundPending.shift()!;
+      forward.outboundPendingBytes -= chunk.byteLength;
+      if (!sendForwardChunk(peer, forwardId, chunk)) {
+        closeForward(peer, forwardId, "Sync connection could not accept forwarded data.", true);
+        return;
+      }
+    }
+    if (forward.outboundPending.length > 0) return;
+    if (forward.resumeTimer) clearInterval(forward.resumeTimer);
+    forward.resumeTimer = null;
+    forward.socket.resume();
+  };
+
+  const scheduleForwardResume = (peer: TPeer, forwardId: string): void => {
+    const forward = peers.get(peer)?.forwards.get(forwardId);
+    if (!forward || forward.resumeTimer) return;
+    forward.resumeTimer = setInterval(
+      () => flushForwardOutbound(peer, forwardId),
+      backpressurePollMs,
+    );
+    forward.resumeTimer.unref?.();
+  };
+
+  const queueForwardOutbound = (
+    peer: TPeer,
+    forwardId: string,
+    chunk: Buffer,
+  ): boolean => {
+    const forward = peers.get(peer)?.forwards.get(forwardId);
+    if (!forward) return false;
+    if (forward.outboundPendingBytes + chunk.byteLength > forwardPendingBytes) {
+      closeForward(peer, forwardId, "Forwarded data exceeded the pending buffer limit.", true);
+      return false;
+    }
+    forward.outboundPending.push(Buffer.from(chunk));
+    forward.outboundPendingBytes += chunk.byteLength;
+    forward.socket.pause();
+    scheduleForwardResume(peer, forwardId);
+    return true;
+  };
+
+  const handleForwardSocketData = (
+    peer: TPeer,
+    forwardId: string,
+    data: Buffer,
+  ): void => {
+    for (let offset = 0; offset < data.byteLength; offset += FORWARD_DATA_CHUNK_BYTES) {
+      const chunk = data.subarray(
+        offset,
+        Math.min(data.byteLength, offset + FORWARD_DATA_CHUNK_BYTES),
+      );
+      const forward = peers.get(peer)?.forwards.get(forwardId);
+      if (!forward) return;
+      if (
+        forward.outboundPending.length > 0
+        || args.getBufferedAmount(peer) >= peerBackpressureBytes
+      ) {
+        if (!queueForwardOutbound(peer, forwardId, chunk)) return;
+        continue;
+      }
+      if (!sendForwardChunk(peer, forwardId, chunk)) {
+        closeForward(peer, forwardId, "Sync connection could not accept forwarded data.", true);
+        return;
+      }
+    }
+  };
+
+  const openRpc = (peer: TPeer, payload: PairedRuntimeRpcOpenPayload): void => {
+    const channelId = normalizedId(payload.channelId);
+    if (!channelId) return;
+    const factory = args.createRpcHandler ?? getSyncRuntimeRpcHandlerFactory();
+    if (!factory) {
+      sendRpcClose(peer, channelId, "Runtime RPC channel is unavailable.");
+      return;
+    }
+    closeRpc(peer, channelId, "RPC channel replaced.", true);
+
+    let receive: ((chunk: Buffer) => void) | null = null;
+    const transport: JsonRpcTransport = {
+      onData(callback) {
+        receive = callback;
+      },
+      write(data) {
+        const bytes = Buffer.from(data, "utf8");
+        for (let offset = 0; offset < bytes.byteLength; offset += RPC_DATA_CHUNK_BYTES) {
+          const chunk = bytes.subarray(
+            offset,
+            Math.min(bytes.byteLength, offset + RPC_DATA_CHUNK_BYTES),
+          );
+          if (!args.send(peer, "rpc_data", {
+            channelId,
+            data: chunk.toString("base64"),
+          })) {
+            closeRpc(peer, channelId, "Sync connection could not accept RPC data.", true);
+            closePeerForwards(peer, "Runtime RPC delivery failed.", true);
+            return;
+          }
+        }
+      },
+      close() {
+        const wasOpen = peers.get(peer)?.rpc.has(channelId) === true;
+        closeRpc(peer, channelId, "RPC transport closed.", true);
+        if (wasOpen) {
+          closePeerForwards(peer, "RPC transport closed.", true);
+        }
+      },
+    };
+
+    let handler: SyncRuntimeRpcHandler;
+    try {
+      handler = factory();
+    } catch (error) {
+      sendRpcClose(
+        peer,
+        channelId,
+        closeReason(
+          error instanceof Error ? error.message : String(error),
+          "Runtime RPC channel is unavailable.",
+        ),
+      );
+      return;
+    }
+    const stop = startJsonRpcServer(handler, transport, {
+      nonFatal: true,
+      onError: (error, context) => {
+        args.logger.warn("sync_paired.rpc_dispatch_failed", {
+          channelId,
+          context,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      },
+    });
+    handler.setNotifier?.((method, params) => stop.notify(method, params));
+    if (!receive) {
+      try {
+        stop();
+      } catch {}
+      try {
+        handler.dispose?.();
+      } catch {}
+      sendRpcClose(peer, channelId, "Runtime RPC transport did not initialize.");
+      return;
+    }
+    channelsFor(peer).rpc.set(channelId, { handler, stop, receive });
+  };
+
+  const openForward = (
+    peer: TPeer,
+    payload: PairedRuntimeForwardOpenPayload,
+  ): void => {
+    const forwardId = normalizedId(payload.forwardId);
+    if (!forwardId) return;
+    const host = allowedForwardHost(payload.host);
+    const port = allowedForwardPort(payload.port);
+    if (!host || port == null) {
+      sendForwardClose(
+        peer,
+        forwardId,
+        !host
+          ? "Port forwards may connect only to 127.0.0.1 or localhost."
+          : "Forward port must be an integer from 1 to 65535.",
+      );
+      return;
+    }
+    closeForward(peer, forwardId, "Forward replaced.", true);
+    const socket = args.connectForward?.({ host, port }) ?? net.connect({ host, port });
+    const forward: ForwardChannel = {
+      socket,
+      connected: false,
+      inboundBeforeConnect: [],
+      inboundBeforeConnectBytes: 0,
+      outboundPending: [],
+      outboundPendingBytes: 0,
+      resumeTimer: null,
+    };
+    channelsFor(peer).forwards.set(forwardId, forward);
+
+    socket.once("connect", () => {
+      const current = peers.get(peer)?.forwards.get(forwardId);
+      if (current !== forward) return;
+      forward.connected = true;
+      for (const chunk of forward.inboundBeforeConnect) {
+        socket.write(chunk);
+      }
+      forward.inboundBeforeConnect = [];
+      forward.inboundBeforeConnectBytes = 0;
+      if (socket.writableLength > forwardPendingBytes) {
+        closeForward(peer, forwardId, "Forwarded data exceeded the pending buffer limit.", true);
+      }
+    });
+    socket.on("data", (chunk) => handleForwardSocketData(peer, forwardId, Buffer.from(chunk)));
+    socket.once("error", (error) => {
+      closeForward(peer, forwardId, error.message || "Remote TCP connection failed.", true);
+    });
+    socket.once("close", () => {
+      closeForward(peer, forwardId, "Remote TCP connection closed.", true);
+    });
+  };
+
+  const writeForward = (
+    peer: TPeer,
+    forwardId: string,
+    bytes: Buffer,
+  ): void => {
+    const forward = peers.get(peer)?.forwards.get(forwardId);
+    if (!forward) {
+      sendForwardClose(peer, forwardId, "Forward is not open.");
+      return;
+    }
+    if (!forward.connected) {
+      if (forward.inboundBeforeConnectBytes + bytes.byteLength > forwardPendingBytes) {
+        closeForward(peer, forwardId, "Forwarded data exceeded the pending buffer limit.", true);
+        return;
+      }
+      forward.inboundBeforeConnect.push(Buffer.from(bytes));
+      forward.inboundBeforeConnectBytes += bytes.byteLength;
+      return;
+    }
+    forward.socket.write(bytes);
+    if (forward.socket.writableLength > forwardPendingBytes) {
+      closeForward(peer, forwardId, "Forwarded data exceeded the pending buffer limit.", true);
+    }
+  };
+
+  const closePeer = (
+    peer: TPeer,
+    reason = "Sync connection closed.",
+    notify = false,
+  ): void => {
+    const channels = peers.get(peer);
+    if (!channels) return;
+    for (const channelId of [...channels.rpc.keys()]) {
+      closeRpc(peer, channelId, reason, notify);
+    }
+    closePeerForwards(peer, reason, notify);
+    peers.delete(peer);
+  };
+
+  return {
+    async handleEnvelope(
+      peer: TPeer,
+      type: PairedRuntimeSyncEnvelope["type"],
+      payload: unknown,
+      authenticatedWithPairing: boolean,
+    ): Promise<boolean> {
+      const value = payload && typeof payload === "object" && !Array.isArray(payload)
+        ? payload as Record<string, unknown>
+        : {};
+      const idKey = type.startsWith("rpc_") ? "channelId" : "forwardId";
+      const id = normalizedId(value[idKey]);
+      if (!id) return true;
+      if (!authenticatedWithPairing) {
+        if (type.startsWith("rpc_")) {
+          sendRpcClose(peer, id, "Paired device authentication is required.");
+        } else {
+          sendForwardClose(peer, id, "Paired device authentication is required.");
+        }
+        return true;
+      }
+
+      switch (type) {
+        case "rpc_open":
+          openRpc(peer, { channelId: id });
+          break;
+        case "rpc_data": {
+          const bytes = decodeBase64(value.data);
+          const channel = peers.get(peer)?.rpc.get(id);
+          if (!bytes || !channel) {
+            if (!channel) sendRpcClose(peer, id, "RPC channel is not open.");
+            else {
+              closeRpc(peer, id, "RPC data was not valid base64.", true);
+              closePeerForwards(peer, "RPC data was not valid base64.", true);
+            }
+            break;
+          }
+          channel.receive(bytes);
+          break;
+        }
+        case "rpc_close":
+          closeRpc(peer, id, closeReason(value.reason, "RPC channel closed by peer."), false);
+          closePeerForwards(peer, "RPC channel closed by peer.", true);
+          break;
+        case "fwd_open":
+          openForward(peer, {
+            forwardId: id,
+            host: typeof value.host === "string" ? value.host : "",
+            port: Number(value.port),
+          });
+          break;
+        case "fwd_data": {
+          const bytes = decodeBase64(value.data);
+          if (!bytes) {
+            closeForward(peer, id, "Forward data was not valid base64.", true);
+            break;
+          }
+          writeForward(peer, id, bytes);
+          break;
+        }
+        case "fwd_close":
+          closeForward(peer, id, closeReason(value.reason, "Forward closed by peer."), false);
+          break;
+      }
+      return true;
+    },
+
+    closePeer,
+
+    dispose(reason = "Sync host stopped."): void {
+      for (const peer of [...peers.keys()]) {
+        closePeer(peer, reason, false);
+      }
+    },
+  };
+}
+
+export type SyncPairedChannelService<TPeer extends object> = ReturnType<
+  typeof createSyncPairedChannelService<TPeer>
+>;

--- a/apps/ade-cli/src/services/sync/syncPairedChannelService.ts
+++ b/apps/ade-cli/src/services/sync/syncPairedChannelService.ts
@@ -21,6 +21,14 @@ const RPC_DATA_CHUNK_BYTES = 256 * 1024;
 const FORWARD_DATA_CHUNK_BYTES = 64 * 1024;
 const MAX_CHANNEL_ID_CHARS = 128;
 const MAX_CLOSE_REASON_CHARS = 300;
+// Per-peer resource caps. Each RPC channel spins a full JSON-RPC handler with
+// its own (up to 64 MiB) line buffer, and each forward holds a live loopback
+// socket fd, so an authenticated peer that opened unbounded channels could
+// exhaust file descriptors / memory on the host. These ceilings are far above
+// any legitimate desktop client's needs (one RPC channel + a handful of port
+// forwards) while capping abuse.
+const MAX_RPC_CHANNELS_PER_PEER = 32;
+const MAX_FORWARDS_PER_PEER = 64;
 
 export type SyncRuntimeRpcHandler = JsonRpcHandler & {
   dispose?: () => void;
@@ -342,6 +350,15 @@ export function createSyncPairedChannelService<TPeer extends object>(
   const openRpc = (peer: TPeer, payload: PairedRuntimeRpcOpenPayload): void => {
     const channelId = normalizedId(payload.channelId);
     if (!channelId) return;
+    const existingRpc = peers.get(peer)?.rpc;
+    if (
+      existingRpc
+      && !existingRpc.has(channelId)
+      && existingRpc.size >= MAX_RPC_CHANNELS_PER_PEER
+    ) {
+      sendRpcClose(peer, channelId, "Too many open runtime channels.");
+      return;
+    }
     const factory = args.createRpcHandler ?? getSyncRuntimeRpcHandlerFactory();
     if (!factory) {
       sendRpcClose(peer, channelId, "Runtime RPC channel is unavailable.");
@@ -424,6 +441,15 @@ export function createSyncPairedChannelService<TPeer extends object>(
   ): void => {
     const forwardId = normalizedId(payload.forwardId);
     if (!forwardId) return;
+    const existingForwards = peers.get(peer)?.forwards;
+    if (
+      existingForwards
+      && !existingForwards.has(forwardId)
+      && existingForwards.size >= MAX_FORWARDS_PER_PEER
+    ) {
+      sendForwardClose(peer, forwardId, "Too many open port forwards.");
+      return;
+    }
     const host = allowedForwardHost(payload.host);
     const port = allowedForwardPort(payload.port);
     if (!host || port == null) {
@@ -516,6 +542,12 @@ export function createSyncPairedChannelService<TPeer extends object>(
       type: PairedRuntimeSyncEnvelope["type"],
       payload: unknown,
       authenticatedWithPairing: boolean,
+      // Whether the paired peer is a desktop runtime-host. The full runtime
+      // JSON-RPC registry (~44 domains) and loopback port-forwarding are far
+      // beyond the mobile command allowlist, so they are gated to desktop
+      // clients even after successful pairing. Defaults to false so callers
+      // must opt in explicitly.
+      authorizedForRuntimeHost = false,
     ): Promise<boolean> {
       const value = payload && typeof payload === "object" && !Array.isArray(payload)
         ? payload as Record<string, unknown>
@@ -528,6 +560,14 @@ export function createSyncPairedChannelService<TPeer extends object>(
           sendRpcClose(peer, id, "Paired device authentication is required.");
         } else {
           sendForwardClose(peer, id, "Paired device authentication is required.");
+        }
+        return true;
+      }
+      if (!authorizedForRuntimeHost) {
+        if (type.startsWith("rpc_")) {
+          sendRpcClose(peer, id, "Runtime channel is only available to desktop clients.");
+        } else {
+          sendForwardClose(peer, id, "Runtime channel is only available to desktop clients.");
         }
         return true;
       }

--- a/apps/ade-cli/src/services/sync/syncPairedChannelService.ts
+++ b/apps/ade-cli/src/services/sync/syncPairedChannelService.ts
@@ -13,13 +13,16 @@ import {
   type JsonRpcHandler,
   type JsonRpcTransport,
 } from "../../jsonrpc";
+import {
+  BACKPRESSURE_POLL_MS,
+  decodeStrictBase64,
+  FORWARD_DATA_CHUNK_BYTES,
+  normalizeChannelId,
+  PEER_BACKPRESSURE_BYTES,
+  RPC_DATA_CHUNK_BYTES,
+} from "./syncProtocol";
 
-const DEFAULT_PEER_BACKPRESSURE_BYTES = 4 * 1024 * 1024;
 const DEFAULT_FORWARD_PENDING_BYTES = 4 * 1024 * 1024;
-const DEFAULT_BACKPRESSURE_POLL_MS = 25;
-const RPC_DATA_CHUNK_BYTES = 256 * 1024;
-const FORWARD_DATA_CHUNK_BYTES = 64 * 1024;
-const MAX_CHANNEL_ID_CHARS = 128;
 const MAX_CLOSE_REASON_CHARS = 300;
 // Per-peer resource caps. Each RPC channel spins a full JSON-RPC handler with
 // its own (up to 64 MiB) line buffer, and each forward holds a live loopback
@@ -120,31 +123,11 @@ export type SyncPairedChannelServiceArgs<TPeer extends object> = {
   connectForward?: (options: net.NetConnectOpts) => net.Socket;
 };
 
-function normalizedId(value: unknown): string | null {
-  if (typeof value !== "string") return null;
-  const id = value.trim();
-  if (!id || id.length > MAX_CHANNEL_ID_CHARS) return null;
-  return /^[a-zA-Z0-9._:-]+$/.test(id) ? id : null;
-}
-
 function closeReason(value: unknown, fallback: string): string {
   const reason = typeof value === "string" && value.trim()
     ? value.trim()
     : fallback;
   return reason.slice(0, MAX_CLOSE_REASON_CHARS);
-}
-
-function decodeBase64(value: unknown): Buffer | null {
-  if (typeof value !== "string") return null;
-  if (value.length === 0) return Buffer.alloc(0);
-  if (value.length % 4 !== 0 || !/^[a-zA-Z0-9+/]*={0,2}$/.test(value)) {
-    return null;
-  }
-  try {
-    return Buffer.from(value, "base64");
-  } catch {
-    return null;
-  }
 }
 
 function allowedForwardHost(value: unknown): "127.0.0.1" | null {
@@ -163,7 +146,7 @@ export function createSyncPairedChannelService<TPeer extends object>(
 ) {
   const peerBackpressureBytes = Math.max(
     1,
-    Math.floor(args.peerBackpressureBytes ?? DEFAULT_PEER_BACKPRESSURE_BYTES),
+    Math.floor(args.peerBackpressureBytes ?? PEER_BACKPRESSURE_BYTES),
   );
   const forwardPendingBytes = Math.max(
     1,
@@ -171,7 +154,7 @@ export function createSyncPairedChannelService<TPeer extends object>(
   );
   const backpressurePollMs = Math.max(
     1,
-    Math.floor(args.backpressurePollMs ?? DEFAULT_BACKPRESSURE_POLL_MS),
+    Math.floor(args.backpressurePollMs ?? BACKPRESSURE_POLL_MS),
   );
   const peers = new Map<TPeer, PeerChannels>();
 
@@ -348,7 +331,7 @@ export function createSyncPairedChannelService<TPeer extends object>(
   };
 
   const openRpc = (peer: TPeer, payload: PairedRuntimeRpcOpenPayload): void => {
-    const channelId = normalizedId(payload.channelId);
+    const channelId = normalizeChannelId(payload.channelId);
     if (!channelId) return;
     const existingRpc = peers.get(peer)?.rpc;
     if (
@@ -439,7 +422,7 @@ export function createSyncPairedChannelService<TPeer extends object>(
     peer: TPeer,
     payload: PairedRuntimeForwardOpenPayload,
   ): void => {
-    const forwardId = normalizedId(payload.forwardId);
+    const forwardId = normalizeChannelId(payload.forwardId);
     if (!forwardId) return;
     const existingForwards = peers.get(peer)?.forwards;
     if (
@@ -553,7 +536,7 @@ export function createSyncPairedChannelService<TPeer extends object>(
         ? payload as Record<string, unknown>
         : {};
       const idKey = type.startsWith("rpc_") ? "channelId" : "forwardId";
-      const id = normalizedId(value[idKey]);
+      const id = normalizeChannelId(value[idKey]);
       if (!id) return true;
       if (!authenticatedWithPairing) {
         if (type.startsWith("rpc_")) {
@@ -577,7 +560,7 @@ export function createSyncPairedChannelService<TPeer extends object>(
           openRpc(peer, { channelId: id });
           break;
         case "rpc_data": {
-          const bytes = decodeBase64(value.data);
+          const bytes = decodeStrictBase64(value.data);
           const channel = peers.get(peer)?.rpc.get(id);
           if (!bytes || !channel) {
             if (!channel) sendRpcClose(peer, id, "RPC channel is not open.");
@@ -602,7 +585,7 @@ export function createSyncPairedChannelService<TPeer extends object>(
           });
           break;
         case "fwd_data": {
-          const bytes = decodeBase64(value.data);
+          const bytes = decodeStrictBase64(value.data);
           if (!bytes) {
             closeForward(peer, id, "Forward data was not valid base64.", true);
             break;

--- a/apps/ade-cli/src/services/sync/syncPairingStore.ts
+++ b/apps/ade-cli/src/services/sync/syncPairingStore.ts
@@ -12,6 +12,8 @@ export type SyncPairingRecord = {
   peerName: string;
   peerPlatform: string;
   peerDeviceType: string;
+  /** Server-issued authorization for full runtime RPC and forwarding. */
+  runtimeHostGranted?: boolean;
   /**
    * Base64 X9.63 P-256 public key of the device's Secure Enclave DPoP key.
    * Once present, paired hellos from this device must carry a valid proof.
@@ -20,6 +22,7 @@ export type SyncPairingRecord = {
 };
 
 type PairingSecretsFile = Record<string, SyncPairingRecord>;
+type RuntimeHostGrantFile = Record<string, { expiresAt: number }>;
 
 type SyncPairingStoreArgs = {
   filePath: string;
@@ -62,6 +65,7 @@ function pairingError(code: "pin_not_set" | "invalid_pin", message: string): Err
 
 export function createSyncPairingStore(args: SyncPairingStoreArgs) {
   fs.mkdirSync(path.dirname(args.filePath), { recursive: true });
+  const runtimeHostGrantPath = `${args.filePath}.runtime-host-grants`;
 
   const readRecords = (): PairingSecretsFile => {
     if (!fs.existsSync(args.filePath)) return {};
@@ -79,14 +83,64 @@ export function createSyncPairingStore(args: SyncPairingStoreArgs) {
     }
   };
 
+  const readRuntimeHostGrants = (): RuntimeHostGrantFile => {
+    if (!fs.existsSync(runtimeHostGrantPath)) return {};
+    return safeJsonParse<RuntimeHostGrantFile>(
+      fs.readFileSync(runtimeHostGrantPath, "utf8"),
+      {},
+    );
+  };
+
+  const writeRuntimeHostGrants = (grants: RuntimeHostGrantFile): void => {
+    writeTextAtomic(runtimeHostGrantPath, `${JSON.stringify(grants, null, 2)}\n`, { mode: 0o600 });
+    try {
+      fs.chmodSync(runtimeHostGrantPath, 0o600);
+    } catch {
+      // ignore chmod failures on platforms that don't support it
+    }
+  };
+
+  const consumeRuntimeHostGrant = (token: string | null | undefined): boolean => {
+    const normalized = token?.trim();
+    if (!normalized) return false;
+    const tokenHash = hashSecret(normalized);
+    const now = Date.now();
+    const grants = readRuntimeHostGrants();
+    const granted = (grants[tokenHash]?.expiresAt ?? 0) > now;
+    delete grants[tokenHash];
+    for (const [hash, entry] of Object.entries(grants)) {
+      if (!entry || entry.expiresAt <= now) delete grants[hash];
+    }
+    writeRuntimeHostGrants(grants);
+    return granted;
+  };
+
   return {
-    pairPeer(peer: SyncPeerMetadata, pin: string, options?: { dpopPublicKey?: string | null }): { deviceId: string; secret: string } {
+    issueRuntimeHostGrant(ttlMs = 10 * 60_000): string {
+      const token = randomBytes(32).toString("base64url");
+      const grants = readRuntimeHostGrants();
+      const now = Date.now();
+      for (const [hash, entry] of Object.entries(grants)) {
+        if (!entry || entry.expiresAt <= now) delete grants[hash];
+      }
+      grants[hashSecret(token)] = {
+        expiresAt: now + Math.max(1_000, Math.floor(ttlMs)),
+      };
+      writeRuntimeHostGrants(grants);
+      return token;
+    },
+
+    pairPeer(peer: SyncPeerMetadata, pin: string, options?: {
+      dpopPublicKey?: string | null;
+      runtimeHostGrant?: string | null;
+    }): { deviceId: string; secret: string } {
       if (!args.pinStore.hasPin()) {
         throw pairingError("pin_not_set", "No pairing PIN is set on this computer.");
       }
       if (!args.pinStore.verifyPin(pin)) {
         throw pairingError("invalid_pin", "Incorrect pairing PIN.");
       }
+      const runtimeHostGranted = consumeRuntimeHostGrant(options?.runtimeHostGrant);
       const secret = randomBytes(24).toString("hex");
       const records = readRecords();
       const existing = records[peer.deviceId] ?? null;
@@ -99,6 +153,7 @@ export function createSyncPairingStore(args: SyncPairingStoreArgs) {
         peerName: peer.deviceName,
         peerPlatform: peer.platform,
         peerDeviceType: peer.deviceType,
+        runtimeHostGranted,
         // Re-pairing (PIN gated) may rotate or introduce the device key; a
         // re-pair without a key keeps the existing one rather than downgrading.
         dpopPublicKey: dpopPublicKey ?? existing?.dpopPublicKey ?? null,

--- a/apps/ade-cli/src/services/sync/syncPairingStore.ts
+++ b/apps/ade-cli/src/services/sync/syncPairingStore.ts
@@ -140,7 +140,12 @@ export function createSyncPairingStore(args: SyncPairingStoreArgs) {
       if (!args.pinStore.verifyPin(pin)) {
         throw pairingError("invalid_pin", "Incorrect pairing PIN.");
       }
-      const runtimeHostGranted = consumeRuntimeHostGrant(options?.runtimeHostGrant);
+      // The server grant is necessary but not sufficient: pairing links can be
+      // copied into phone/browser/custom clients, which must never become full
+      // runtime hosts. Consume every presented grant to preserve its one-time
+      // semantics, then authorize only a peer that paired as a desktop.
+      const consumedRuntimeHostGrant = consumeRuntimeHostGrant(options?.runtimeHostGrant);
+      const runtimeHostGranted = consumedRuntimeHostGrant && peer.deviceType === "desktop";
       const secret = randomBytes(24).toString("hex");
       const records = readRecords();
       const existing = records[peer.deviceId] ?? null;

--- a/apps/ade-cli/src/services/sync/syncProtocol.test.ts
+++ b/apps/ade-cli/src/services/sync/syncProtocol.test.ts
@@ -1,13 +1,20 @@
 import { gzipSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import {
+  BACKPRESSURE_POLL_MS,
   createSyncEnvelopeChunkAssembler,
+  decodeStrictBase64,
   DEFAULT_SYNC_MAX_FRAME_BYTES,
   encodeSyncEnvelope,
   encodeSyncEnvelopeFrames,
+  FORWARD_DATA_CHUNK_BYTES,
+  MAX_CHANNEL_ID_CHARS,
   MAX_UNCOMPRESSED_SYNC_ENVELOPE_BYTES,
+  normalizeChannelId,
   parseSyncEnvelope,
   parseSyncEnvelopeChunkPayload,
+  PEER_BACKPRESSURE_BYTES,
+  RPC_DATA_CHUNK_BYTES,
 } from "./syncProtocol";
 
 // Deterministic xorshift PRNG — gzip cannot compress its output, so payloads
@@ -40,6 +47,29 @@ function reassemble(frames: string[], options: { shuffle?: boolean } = {}): unkn
   expect(reassembled).not.toBeNull();
   return parseSyncEnvelope(reassembled!);
 }
+
+describe("paired runtime wire framing", () => {
+  it("exports the canonical framing and backpressure constants", () => {
+    expect(RPC_DATA_CHUNK_BYTES).toBe(256 * 1024);
+    expect(FORWARD_DATA_CHUNK_BYTES).toBe(64 * 1024);
+    expect(PEER_BACKPRESSURE_BYTES).toBe(4 * 1024 * 1024);
+    expect(BACKPRESSURE_POLL_MS).toBe(25);
+    expect(MAX_CHANNEL_ID_CHARS).toBe(128);
+  });
+
+  it("strictly decodes base64 and normalizes channel ids", () => {
+    expect(decodeStrictBase64(Buffer.from("hello").toString("base64"))?.toString("utf8")).toBe("hello");
+    expect(decodeStrictBase64("")).toEqual(Buffer.alloc(0));
+    expect(decodeStrictBase64("abc")).toBeNull();
+    expect(decodeStrictBase64("ab=c")).toBeNull();
+    expect(decodeStrictBase64(null)).toBeNull();
+
+    expect(normalizeChannelId(" rpc:desktop-1 ")).toBe("rpc:desktop-1");
+    expect(normalizeChannelId("bad channel")).toBeNull();
+    expect(normalizeChannelId("x".repeat(MAX_CHANNEL_ID_CHARS + 1))).toBeNull();
+    expect(normalizeChannelId(null)).toBeNull();
+  });
+});
 
 describe("encodeSyncEnvelopeFrames", () => {
   it("returns a single frame when the envelope fits the budget", () => {

--- a/apps/ade-cli/src/services/sync/syncProtocol.test.ts
+++ b/apps/ade-cli/src/services/sync/syncProtocol.test.ts
@@ -151,6 +151,29 @@ describe("parseSyncEnvelopeChunkPayload", () => {
 });
 
 describe("parseSyncEnvelope", () => {
+  it("round-trips every paired runtime channel envelope", () => {
+    const cases = [
+      ["rpc_open", { channelId: "rpc-1" }],
+      ["rpc_data", { channelId: "rpc-1", data: Buffer.from("{}\n").toString("base64") }],
+      ["rpc_close", { channelId: "rpc-1", reason: "done" }],
+      ["fwd_open", { forwardId: "fwd-1", host: "127.0.0.1", port: 4173 }],
+      ["fwd_data", { forwardId: "fwd-1", data: Buffer.from("hello").toString("base64") }],
+      ["fwd_close", { forwardId: "fwd-1", reason: "remote closed" }],
+    ] as const;
+
+    for (const [type, payload] of cases) {
+      const decoded = parseSyncEnvelope(encodeSyncEnvelope({
+        type,
+        requestId: `${type}-request`,
+        payload,
+        compressionThresholdBytes: Number.POSITIVE_INFINITY,
+      }));
+      expect(decoded.type).toBe(type);
+      expect(decoded.requestId).toBe(`${type}-request`);
+      expect(decoded.payload).toEqual(payload);
+    }
+  });
+
   it("rejects declared oversized compressed payloads before inflating", () => {
     const encoded = JSON.stringify({
       version: 1,

--- a/apps/ade-cli/src/services/sync/syncProtocol.ts
+++ b/apps/ade-cli/src/services/sync/syncProtocol.ts
@@ -16,6 +16,9 @@ export const MAX_CHANNEL_ID_CHARS = 128;
 /** Hello capability a client declares when it can reassemble envelope_chunk frames. */
 export const SYNC_CHUNKED_ENVELOPES_CAPABILITY = "chunkedEnvelopes";
 
+/** Hello capability for paired desktop clients that consume only rpc/fwd envelopes. */
+export const SYNC_RUNTIME_ONLY_CAPABILITY = "runtimeOnly";
+
 // URLSessionWebSocketTask buffers at most ~1 MiB per message by default and
 // kills the whole connection ("Message too long") past that. Keep every frame
 // comfortably under that even after the base64 + wrapper overhead of a chunk.

--- a/apps/ade-cli/src/services/sync/syncProtocol.ts
+++ b/apps/ade-cli/src/services/sync/syncProtocol.ts
@@ -7,6 +7,11 @@ export const SYNC_PROTOCOL_VERSION: SyncProtocolVersion = 1;
 export const DEFAULT_SYNC_HOST_PORT = 8787;
 export const DEFAULT_SYNC_COMPRESSION_THRESHOLD_BYTES = 4 * 1024;
 export const MAX_UNCOMPRESSED_SYNC_ENVELOPE_BYTES = 25 * 1024 * 1024;
+export const RPC_DATA_CHUNK_BYTES = 256 * 1024;
+export const FORWARD_DATA_CHUNK_BYTES = 64 * 1024;
+export const PEER_BACKPRESSURE_BYTES = 4 * 1024 * 1024;
+export const BACKPRESSURE_POLL_MS = 25;
+export const MAX_CHANNEL_ID_CHARS = 128;
 
 /** Hello capability a client declares when it can reassemble envelope_chunk frames. */
 export const SYNC_CHUNKED_ENVELOPES_CAPABILITY = "chunkedEnvelopes";
@@ -15,6 +20,21 @@ export const SYNC_CHUNKED_ENVELOPES_CAPABILITY = "chunkedEnvelopes";
 // kills the whole connection ("Message too long") past that. Keep every frame
 // comfortably under that even after the base64 + wrapper overhead of a chunk.
 export const DEFAULT_SYNC_MAX_FRAME_BYTES = 720 * 1024;
+
+export function decodeStrictBase64(value: unknown): Buffer | null {
+  if (typeof value !== "string") return null;
+  if (value.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(value)) {
+    return null;
+  }
+  return Buffer.from(value, "base64");
+}
+
+export function normalizeChannelId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const id = value.trim();
+  if (!id || id.length > MAX_CHANNEL_ID_CHARS) return null;
+  return /^[A-Za-z0-9._:-]+$/.test(id) ? id : null;
+}
 
 export function mapPlatform(platform: NodeJS.Platform): SyncPeerPlatform {
   switch (platform) {

--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { SyncCommandPayload, SyncPairingConnectInfo, SyncWebPairingInfo } from "../../../../desktop/src/shared/types";
+import { parsePairingQrText } from "../../../../desktop/src/shared/pairingQr";
 import { deriveDeterministicLaneNameFromPrompt } from "../../../../desktop/src/shared/laneNameFallback";
 import { createSyncRemoteCommandService } from "./syncRemoteCommandService";
 
@@ -32,6 +33,7 @@ function createService(options?: {
   db?: Record<string, unknown>;
   syncPinStore?: Record<string, unknown>;
   getPairingConnectInfo?: () => SyncPairingConnectInfo | null;
+  issueRuntimeHostPairingGrant?: () => string;
   isCloudRelayEnabled?: () => boolean;
   usageTrackingService?: Record<string, unknown>;
   personalChatScope?: {
@@ -80,6 +82,9 @@ function createService(options?: {
     ...(options?.externalSessionsService ? { externalSessionsService: options.externalSessionsService } : {}),
     ...(options?.syncPinStore ? { syncPinStore: options.syncPinStore } : {}),
     ...(options?.getPairingConnectInfo ? { getPairingConnectInfo: options.getPairingConnectInfo } : {}),
+    ...(options?.issueRuntimeHostPairingGrant
+      ? { issueRuntimeHostPairingGrant: options.issueRuntimeHostPairingGrant }
+      : {}),
     ...(options?.isCloudRelayEnabled ? { isCloudRelayEnabled: options.isCloudRelayEnabled } : {}),
     ...(options?.usageTrackingService ? { usageTrackingService: options.usageTrackingService } : {}),
     ...(options?.personalChatScope ? { personalChatScope: options.personalChatScope } : {}),
@@ -224,6 +229,31 @@ describe("createSyncRemoteCommandService", () => {
       relayEnabled: false,
       hasRelayCandidate: false,
     });
+  });
+
+  it("issues a desktop-only server grant in sync.getDesktopPairingInfo", async () => {
+    const issueRuntimeHostPairingGrant = vi.fn(() => "runtime-grant-1");
+    const { service } = createService({
+      syncPinStore: {
+        getPin: vi.fn(() => "428193"),
+        hasPin: vi.fn(() => true),
+      },
+      getPairingConnectInfo: () => makePairingConnectInfo(),
+      issueRuntimeHostPairingGrant,
+    });
+
+    expect(service.getDescriptor("sync.getDesktopPairingInfo")).toEqual({
+      action: "sync.getDesktopPairingInfo",
+      scope: "runtime",
+      policy: { viewerAllowed: false },
+    });
+    const result = await service.execute(
+      makePayload("sync.getDesktopPairingInfo"),
+    ) as SyncWebPairingInfo;
+
+    expect(result.pairingUrl).toContain("https://app.ade-app.dev/pair#");
+    expect(issueRuntimeHostPairingGrant).toHaveBeenCalledTimes(1);
+    expect(parsePairingQrText(result.pairingUrl)?.runtimeHostGrant).toBe("runtime-grant-1");
   });
 
   it("returns configured hidden web pairing info when only the PIN hash is available", async () => {

--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
@@ -355,6 +355,8 @@ type SyncRemoteCommandServiceArgs = {
    * including direct address candidates and the optional relay candidate.
    */
   getPairingConnectInfo?: () => SyncPairingConnectInfo | null;
+  /** Issues a short-lived one-time grant for the desktop runtime channels. */
+  issueRuntimeHostPairingGrant?: () => string;
   /** Effective relay kill-switch state for the machine-level cloud tunnel. */
   isCloudRelayEnabled?: () => boolean;
   logger: Logger;
@@ -3834,6 +3836,41 @@ function registerSyncRemoteCommands({ args, register }: RemoteCommandRegistratio
         candidate.kind === "relay" && candidate.host.trim().length > 0);
       return {
         pairingUrl: buildWebClientPairUrl(buildPairingQrPayload({ connectInfo })),
+        code: code ?? null,
+        pinConfigured,
+        machineName: connectInfo.hostIdentity.name,
+        relayEnabled: args.isCloudRelayEnabled?.() ?? hasRelayCandidate,
+        hasRelayCandidate,
+      };
+    },
+    "runtime",
+  );
+  register(
+    "sync.getDesktopPairingInfo",
+    // The desktop calls this through its local runtime connection. Paired
+    // viewers must not mint grants for the privileged runtime channels.
+    { viewerAllowed: false },
+    async (payload): Promise<SyncWebPairingInfo> => {
+      parseGetWebPairingInfoArgs(payload);
+      const syncPinStore = requireService(args.syncPinStore, "Sync PIN store is not available.");
+      const getPairingConnectInfo = requireService(
+        args.getPairingConnectInfo,
+        "Sync pairing connect info is not available.",
+      );
+      const issueGrant = requireService(
+        args.issueRuntimeHostPairingGrant,
+        "Desktop runtime pairing grants are not available.",
+      );
+      const connectInfo = requireService(getPairingConnectInfo(), "Sync pairing connect info is not available.");
+      const pinConfigured = syncPinStore.hasPin();
+      const code = pinConfigured ? syncPinStore.getPin() : null;
+      const hasRelayCandidate = connectInfo.addressCandidates.some((candidate) =>
+        candidate.kind === "relay" && candidate.host.trim().length > 0);
+      return {
+        pairingUrl: buildWebClientPairUrl(buildPairingQrPayload({
+          connectInfo,
+          runtimeHostGrant: issueGrant(),
+        })),
         code: code ?? null,
         pinConfigured,
         machineName: connectInfo.hostIdentity.name,

--- a/apps/ade-cli/src/services/sync/syncService.ts
+++ b/apps/ade-cli/src/services/sync/syncService.ts
@@ -625,6 +625,7 @@ export function createSyncService(args: SyncServiceArgs) {
     dispatchDeeplinkUrl: args.dispatchDeeplinkUrl,
     syncPinStore: pinStore,
     getPairingConnectInfo: buildCurrentPairingConnectInfo,
+    issueRuntimeHostPairingGrant: () => pairingStore.issueRuntimeHostGrant(),
     isCloudRelayEnabled: () => cloudRelayStore.isEnabled(),
     logger: args.logger,
   });

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
@@ -230,7 +230,7 @@ describe("registerRuntimeBridge", () => {
       machineName: "Studio",
       relayAvailable: true,
     });
-    expect(callSync).toHaveBeenCalledWith("sync.getWebPairingInfo");
+    expect(callSync).toHaveBeenCalledWith("sync.getDesktopPairingInfo");
   });
 
   it("does not start saved remote autoconnect when disabled for dev/test runs", async () => {

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
@@ -233,6 +233,28 @@ describe("registerRuntimeBridge", () => {
     expect(callSync).toHaveBeenCalledWith("sync.getDesktopPairingInfo");
   });
 
+  it.each([
+    ["machine name", { pairingUrl: "https://app.ade-app.dev/pair#payload" }],
+    ["pairing URL", { machineName: "Studio" }],
+  ])("rejects local pairing info missing its %s", async (_field, pairingInfo) => {
+    const callSync = vi.fn(async () => pairingInfo);
+    registerRuntimeBridge({
+      appVersion: "1.0.0",
+      globalStatePath: "/tmp/ade-state.json",
+      localRuntimeConnectionPool: { callSync } as any,
+      getWindowSession: () => ({
+        windowId: 7,
+        project: null,
+        binding: null,
+      }),
+    });
+
+    await expect(
+      ipcHandlers.get(IPC.remoteRuntimeGetLocalPairingInfo)?.(eventForSender()),
+    ).rejects.toThrow("Local ADE runtime did not return pairing information.");
+    expect(callSync).toHaveBeenCalledWith("sync.getDesktopPairingInfo");
+  });
+
   it("does not start saved remote autoconnect when disabled for dev/test runs", async () => {
     const previous = process.env.ADE_DISABLE_REMOTE_AUTOCONNECT;
     process.env.ADE_DISABLE_REMOTE_AUTOCONNECT = "1";

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.test.ts
@@ -202,6 +202,37 @@ describe("registerRuntimeBridge", () => {
     browserWindowFromWebContents.mockReturnValue({ id: 7 });
   });
 
+  it("reads local pairing info from the local runtime connection", async () => {
+    const callSync = vi.fn(async () => ({
+      pairingUrl: "https://app.ade-app.dev/pair#payload",
+      code: "123456",
+      pinConfigured: true,
+      machineName: "Studio",
+      relayEnabled: true,
+      hasRelayCandidate: true,
+    }));
+    registerRuntimeBridge({
+      appVersion: "1.0.0",
+      globalStatePath: "/tmp/ade-state.json",
+      localRuntimeConnectionPool: { callSync } as any,
+      getWindowSession: () => ({
+        windowId: 7,
+        project: null,
+        binding: null,
+      }),
+    });
+
+    await expect(
+      ipcHandlers.get(IPC.remoteRuntimeGetLocalPairingInfo)?.(eventForSender()),
+    ).resolves.toEqual({
+      url: "https://app.ade-app.dev/pair#payload",
+      pin: "123456",
+      machineName: "Studio",
+      relayAvailable: true,
+    });
+    expect(callSync).toHaveBeenCalledWith("sync.getWebPairingInfo");
+  });
+
   it("does not start saved remote autoconnect when disabled for dev/test runs", async () => {
     const previous = process.env.ADE_DISABLE_REMOTE_AUTOCONNECT;
     process.env.ADE_DISABLE_REMOTE_AUTOCONNECT = "1";

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.ts
@@ -23,9 +23,14 @@ import type {
   RemoteRuntimeBufferedEvent,
   RemoteRuntimeConnectResult,
   RemoteRuntimeDiscoveryResult,
+  RemoteRuntimeDoctorResult,
   RemoteRuntimeEventCategory,
   RemoteRuntimeEventNotificationPayload,
   RemoteRuntimeLocalWorkCheckResult,
+  RemoteRuntimeLocalPairingInfo,
+  RemoteRuntimePairWithMachineArgs,
+  RemoteRuntimePairWithMachineResult,
+  RemoteRuntimeParsedPairingInput,
   RemoteRuntimePortForward,
   RemoteRuntimePortForwardRequest,
   RemoteRuntimeProjectRecord,
@@ -36,12 +41,15 @@ import type {
   RemoteRuntimeTarget,
   RemoteRuntimeTargetInput,
   RemoteRuntimeTrustSshHostKeyResult,
+  SyncWebPairingInfo,
 } from "../../../shared/types";
 import type { LocalRuntimeConnectionPool } from "../localRuntime/localRuntimeConnectionPool";
 import { RemoteConnectionPool } from "../remoteRuntime/remoteConnectionPool";
 import { RemoteConnectionService } from "../remoteRuntime/remoteConnectionService";
 import { discoverLanRuntimes } from "../remoteRuntime/runtimeDiscovery";
 import { RemoteTargetRegistry } from "../remoteRuntime/remoteTargetRegistry";
+import { DesktopPairedMachineStore } from "../remoteRuntime/syncPairedMachineStore";
+import { parseRemoteRuntimePairingInput } from "../remoteRuntime/pairingInput";
 import { hasKnownSshHostKeyForTarget } from "../remoteRuntime/sshTransport";
 import { runGit } from "../git/git";
 import { getProjectWorkSummary } from "../projects/projectDetailService";
@@ -319,13 +327,17 @@ export function registerRuntimeBridge({
   localRuntimeConnectionPool,
 }: RuntimeBridgeArgs): void {
   const remoteTargetRegistry = new RemoteTargetRegistry();
+  const pairedMachineStore = new DesktopPairedMachineStore();
   const remoteConnectionPool = new RemoteConnectionPool(
     remoteTargetRegistry,
     appVersion,
+    pairedMachineStore,
   );
   const remoteConnectionService = new RemoteConnectionService(
     remoteTargetRegistry,
     remoteConnectionPool,
+    { appVersion },
+    pairedMachineStore,
   );
   const runtimeEventSubscriptions = new Map<
     number,
@@ -334,6 +346,7 @@ export function registerRuntimeBridge({
   const runtimeEventWatchedSenders = new Set<number>();
   const remoteOpenProjectGenerations = new Map<string, number>();
   let remoteOpenProjectGeneration = 0;
+  let lastDiscoveredMachines: RemoteRuntimeDiscoveryResult["machines"] = [];
 
   remoteConnectionService.onSnapshotChanged((snapshot) => {
     for (const window of BrowserWindow.getAllWindows()) {
@@ -545,7 +558,73 @@ export function registerRuntimeBridge({
   ipcMain.handle(
     IPC.remoteRuntimeListDiscoveredMachines,
     async (): Promise<RemoteRuntimeDiscoveryResult> => {
-      return discoverLanRuntimes();
+      const result = await discoverLanRuntimes();
+      lastDiscoveredMachines = result.machines;
+      remoteConnectionService.rememberDiscoveredMachines(result.machines);
+      return result;
+    },
+  );
+
+  ipcMain.handle(
+    IPC.remoteRuntimeParsePairingInput,
+    async (_event, arg: { text?: string }): Promise<RemoteRuntimeParsedPairingInput> => {
+      return parseRemoteRuntimePairingInput(
+        typeof arg?.text === "string" ? arg.text : "",
+      );
+    },
+  );
+
+  ipcMain.handle(
+    IPC.remoteRuntimePairWithMachine,
+    async (
+      _event,
+      arg: RemoteRuntimePairWithMachineArgs,
+    ): Promise<RemoteRuntimePairWithMachineResult> => {
+      return await remoteConnectionService.pairWithMachine({
+        input: typeof arg?.input === "string" ? arg.input : "",
+        pin: typeof arg?.pin === "string" ? arg.pin : "",
+        deviceName: typeof arg?.deviceName === "string" ? arg.deviceName : "",
+      });
+    },
+  );
+
+  ipcMain.handle(
+    IPC.remoteRuntimeGetLocalPairingInfo,
+    async (): Promise<RemoteRuntimeLocalPairingInfo> => {
+      if (!localRuntimeConnectionPool) {
+        throw new Error("Local ADE runtime connection is not available.");
+      }
+      const info = await localRuntimeConnectionPool.callSync<SyncWebPairingInfo>(
+        "sync.getWebPairingInfo",
+      );
+      const url = typeof info?.pairingUrl === "string" ? info.pairingUrl.trim() : "";
+      const machineName = typeof info?.machineName === "string"
+        ? info.machineName.trim()
+        : "";
+      if (!url || !machineName) {
+        throw new Error("Local ADE runtime did not return pairing information.");
+      }
+      return {
+        url,
+        pin: typeof info.code === "string" && info.code.trim()
+          ? info.code.trim()
+          : null,
+        machineName,
+        relayAvailable: info.relayEnabled === true || info.hasRelayCandidate === true,
+      };
+    },
+  );
+
+  ipcMain.handle(
+    IPC.remoteRuntimeRunDoctor,
+    async (_event, arg: { id?: string }): Promise<RemoteRuntimeDoctorResult> => {
+      const id = typeof arg?.id === "string" ? arg.id.trim() : "";
+      const discovered = lastDiscoveredMachines.find((machine) =>
+        machine.id === id || machine.hostIdentity === id) ?? null;
+      return await remoteConnectionService.runDoctor(
+        id,
+        discovered,
+      );
     },
   );
 
@@ -555,7 +634,11 @@ export function registerRuntimeBridge({
       _event,
       arg: RemoteRuntimeTargetInput,
     ): Promise<RemoteRuntimeTarget> => {
-      return remoteConnectionService.saveTarget(arg);
+      const discovered = remoteConnectionService.findDiscoveredTargetInputMatch(
+        lastDiscoveredMachines,
+        arg,
+      );
+      return remoteConnectionService.saveTarget(arg, discovered);
     },
   );
 

--- a/apps/desktop/src/main/services/ipc/runtimeBridge.ts
+++ b/apps/desktop/src/main/services/ipc/runtimeBridge.ts
@@ -595,7 +595,7 @@ export function registerRuntimeBridge({
         throw new Error("Local ADE runtime connection is not available.");
       }
       const info = await localRuntimeConnectionPool.callSync<SyncWebPairingInfo>(
-        "sync.getWebPairingInfo",
+        "sync.getDesktopPairingInfo",
       );
       const url = typeof info?.pairingUrl === "string" ? info.pairingUrl.trim() : "";
       const machineName = typeof info?.machineName === "string"

--- a/apps/desktop/src/main/services/remoteRuntime/connectionDoctor.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/connectionDoctor.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopPairedMachineCredentials } from "../../../shared/types/pairedRuntime";
+import type { RemoteRuntimeTarget } from "../../../shared/types/remoteRuntime";
+import type { RemoteRuntimeTargetRoute } from "../../../shared/types/remoteRuntime";
+import { runRemoteRuntimeDoctor } from "./connectionDoctor";
+
+const credentials: DesktopPairedMachineCredentials = {
+  version: 1,
+  hostIdentity: {
+    deviceId: "host-1",
+    siteId: "site-1",
+    name: "Studio",
+    platform: "macOS",
+    deviceType: "desktop",
+  },
+  deviceId: "desktop-1",
+  siteId: "desktop-site-1",
+  deviceName: "Laptop",
+  secret: "secret",
+  dpopPrivateKey: "private",
+  dpopPublicKey: "public",
+  endpoints: [
+    "ws://192.168.1.20:8787",
+    "ws://100.70.0.2:8787",
+  ],
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+const target: RemoteRuntimeTarget = {
+  id: "target-1",
+  name: "Studio",
+  hostname: "studio.local",
+  sshUser: null,
+  port: 22,
+  sshKeyPath: null,
+  routes: [{
+    hostname: "100.70.0.2",
+    port: 22,
+    source: "tailscale",
+    lastSucceededAt: null,
+  }],
+  lastSeenArch: null,
+  runtimeBinaryVersion: null,
+  lastConnectedAt: null,
+};
+
+describe("runRemoteRuntimeDoctor", () => {
+  it("returns mixed paired and SSH probe results without mutating connection state", async () => {
+    const probePaired = vi.fn(async (endpoint: string) => {
+      if (endpoint.includes("100.70")) throw new Error("tailnet offline");
+    });
+    const probeSsh = vi.fn(async (
+      _target: RemoteRuntimeTarget,
+      route: RemoteRuntimeTargetRoute,
+    ) => {
+      if (route.hostname === "studio.local") throw new Error("ssh refused");
+    });
+
+    const result = await runRemoteRuntimeDoctor({
+      target,
+      credentials,
+      dependencies: { probePaired, probeSsh },
+    });
+
+    expect(result.checks).toEqual([
+      expect.objectContaining({
+        route: "lan",
+        endpoint: "ws://192.168.1.20:8787/",
+        ok: true,
+        latencyMs: expect.any(Number),
+      }),
+      expect.objectContaining({
+        route: "tailnet",
+        endpoint: "ws://100.70.0.2:8787/",
+        ok: false,
+        error: "tailnet offline",
+      }),
+      expect.objectContaining({
+        route: "ssh",
+        endpoint: "studio.local:22",
+        ok: false,
+        error: "ssh refused",
+      }),
+      expect.objectContaining({
+        route: "ssh",
+        endpoint: "100.70.0.2:22",
+        ok: true,
+        latencyMs: expect.any(Number),
+      }),
+    ]);
+    expect(probePaired).toHaveBeenCalledTimes(2);
+    expect(probeSsh).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/main/services/remoteRuntime/connectionDoctor.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/connectionDoctor.ts
@@ -1,0 +1,171 @@
+import type {
+  DesktopPairedMachineCredentials,
+} from "../../../shared/types/pairedRuntime";
+import type {
+  RemoteRuntimeDoctorCheck,
+  RemoteRuntimeDoctorResult,
+  RemoteRuntimeTarget,
+  RemoteRuntimeTargetRoute,
+} from "../../../shared/types/remoteRuntime";
+import { buildPairedEndpointCandidates } from "./pairedRuntimeRoutes";
+import {
+  openPairedSyncConnection,
+  type AuthenticatedSyncConnection,
+} from "./syncRuntimeTransport";
+import {
+  buildSshRouteCandidates,
+  scanSshHostKeyForTarget,
+} from "./sshTransport";
+
+const DEFAULT_DOCTOR_TIMEOUT_MS = 5_000;
+
+export type RemoteRuntimeDoctorDependencies = {
+  probePaired?: (
+    endpoint: string,
+    credentials: DesktopPairedMachineCredentials,
+    timeoutMs: number,
+  ) => Promise<void>;
+  probeSsh?: (
+    target: RemoteRuntimeTarget,
+    route: RemoteRuntimeTargetRoute,
+    timeoutMs: number,
+  ) => Promise<void>;
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sshEndpoint(route: RemoteRuntimeTargetRoute, fallbackPort: number | null): string {
+  const host = route.hostname.includes(":") && !route.hostname.startsWith("[")
+    ? `[${route.hostname}]`
+    : route.hostname;
+  return `${host}:${route.port ?? fallbackPort ?? 22}`;
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms.`)), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function defaultPairedProbe(
+  endpoint: string,
+  credentials: DesktopPairedMachineCredentials,
+  timeoutMs: number,
+): Promise<void> {
+  let connection: AuthenticatedSyncConnection | null = null;
+  try {
+    connection = await openPairedSyncConnection({
+      endpoint,
+      credentials,
+      connectTimeoutMs: timeoutMs,
+      authTimeoutMs: timeoutMs,
+    });
+    if (connection.hello.features?.rpcChannel !== true) {
+      throw new Error("The host does not advertise runtime RPC support.");
+    }
+    if (connection.hello.features?.portForward !== true) {
+      throw new Error("The host does not advertise port-forward support.");
+    }
+  } finally {
+    connection?.close(1000, "Connection doctor probe finished.");
+  }
+}
+
+async function defaultSshProbe(
+  target: RemoteRuntimeTarget,
+  route: RemoteRuntimeTargetRoute,
+  timeoutMs: number,
+): Promise<void> {
+  await scanSshHostKeyForTarget({
+    ...target,
+    hostname: route.hostname,
+    port: route.port ?? target.port,
+    routes: [],
+  }, {
+    env: {
+      ...process.env,
+      ADE_REMOTE_SSH_CONNECT_TIMEOUT_MS: String(timeoutMs),
+    },
+  });
+}
+
+async function checkedProbe(args: {
+  route: RemoteRuntimeDoctorCheck["route"];
+  endpoint: string;
+  timeoutMs: number;
+  probe: () => Promise<void>;
+}): Promise<RemoteRuntimeDoctorCheck> {
+  const startedAt = Date.now();
+  try {
+    await withTimeout(args.probe(), args.timeoutMs, `${args.route} probe`);
+    return {
+      route: args.route,
+      endpoint: args.endpoint,
+      ok: true,
+      latencyMs: Math.max(0, Date.now() - startedAt),
+    };
+  } catch (error) {
+    return {
+      route: args.route,
+      endpoint: args.endpoint,
+      ok: false,
+      error: errorMessage(error),
+    };
+  }
+}
+
+export async function runRemoteRuntimeDoctor(args: {
+  target?: RemoteRuntimeTarget | null;
+  credentials?: DesktopPairedMachineCredentials | null;
+  timeoutMs?: number;
+  dependencies?: RemoteRuntimeDoctorDependencies;
+}): Promise<RemoteRuntimeDoctorResult> {
+  const timeoutMs = Math.max(250, Math.floor(args.timeoutMs ?? DEFAULT_DOCTOR_TIMEOUT_MS));
+  const checks: Array<Promise<RemoteRuntimeDoctorCheck>> = [];
+  const pairedProbe = args.dependencies?.probePaired ?? defaultPairedProbe;
+  const sshProbe = args.dependencies?.probeSsh ?? defaultSshProbe;
+
+  if (args.credentials) {
+    for (const candidate of buildPairedEndpointCandidates({
+      endpoints: args.credentials.endpoints,
+      relayUrl: args.credentials.relayUrl,
+      endpointStates: args.credentials.endpointStates,
+    })) {
+      checks.push(checkedProbe({
+        route: candidate.kind,
+        endpoint: candidate.endpoint,
+        timeoutMs,
+        probe: () => pairedProbe(candidate.endpoint, args.credentials!, timeoutMs),
+      }));
+    }
+  }
+
+  if (args.target) {
+    for (const route of buildSshRouteCandidates(args.target)) {
+      checks.push(checkedProbe({
+        route: "ssh",
+        endpoint: sshEndpoint(route, args.target.port),
+        timeoutMs,
+        probe: () => sshProbe(args.target!, route, timeoutMs),
+      }));
+    }
+  }
+
+  return { checks: await Promise.all(checks) };
+}
+

--- a/apps/desktop/src/main/services/remoteRuntime/discoveredPairedRuntime.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/discoveredPairedRuntime.ts
@@ -5,9 +5,9 @@ import type {
 } from "../../../shared/types/remoteRuntime";
 import {
   classifyPairedRuntimeEndpoint,
-  isTailnetHostname,
   syncEndpointForHost,
 } from "./pairedRuntimeRoutes";
+import { isTailnetHostname } from "../../../shared/tailnet";
 
 function normalizedHost(value: string | null | undefined): string | null {
   const host = value?.trim().toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");

--- a/apps/desktop/src/main/services/remoteRuntime/discoveredPairedRuntime.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/discoveredPairedRuntime.ts
@@ -1,0 +1,121 @@
+import type {
+  RemoteRuntimeDiscoveredMachine,
+  RemoteRuntimeTargetInput,
+  RemoteRuntimeTargetRoute,
+} from "../../../shared/types/remoteRuntime";
+import {
+  classifyPairedRuntimeEndpoint,
+  isTailnetHostname,
+  syncEndpointForHost,
+} from "./pairedRuntimeRoutes";
+
+function normalizedHost(value: string | null | undefined): string | null {
+  const host = value?.trim().toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
+  return host || null;
+}
+
+function uniqueHosts(values: Array<string | null | undefined>): string[] {
+  const hosts: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const host = normalizedHost(value);
+    if (!host || seen.has(host)) continue;
+    seen.add(host);
+    hosts.push(host);
+  }
+  return hosts;
+}
+
+export function isDiscoveredSyncRuntime(
+  machine: RemoteRuntimeDiscoveredMachine,
+): boolean {
+  return machine.connectable !== false
+    && Number.isInteger(machine.port)
+    && machine.port >= 1
+    && machine.port <= 65_535
+    && !(machine.runtimeKind ?? "").startsWith("tailscale-peer");
+}
+
+export function syncEndpointsForDiscoveredRuntime(
+  machine: RemoteRuntimeDiscoveredMachine,
+): string[] {
+  if (!isDiscoveredSyncRuntime(machine)) return [];
+  return uniqueHosts([
+    machine.primaryRoute,
+    machine.tailscaleAddress,
+    machine.hostName,
+    ...machine.addresses,
+  ]).flatMap((host) => {
+    try {
+      return [syncEndpointForHost(host, machine.port)];
+    } catch {
+      return [];
+    }
+  });
+}
+
+export function sshRoutesForPairedEndpoints(
+  endpoints: string[],
+): RemoteRuntimeTargetRoute[] {
+  const routes: RemoteRuntimeTargetRoute[] = [];
+  const seen = new Set<string>();
+  for (const endpoint of endpoints) {
+    let url: URL;
+    try {
+      url = new URL(endpoint);
+    } catch {
+      continue;
+    }
+    if (classifyPairedRuntimeEndpoint(endpoint) === "relay") continue;
+    const hostname = normalizedHost(url.hostname);
+    if (!hostname || seen.has(hostname)) continue;
+    seen.add(hostname);
+    routes.push({
+      hostname,
+      port: null,
+      source: classifyPairedRuntimeEndpoint(endpoint) === "tailnet"
+        ? "tailscale"
+        : "bonjour",
+      lastSucceededAt: null,
+    });
+  }
+  return routes;
+}
+
+export function sshRoutesForDiscoveredRuntime(
+  machine: RemoteRuntimeDiscoveredMachine,
+): RemoteRuntimeTargetRoute[] {
+  const isTailscalePeer = (machine.runtimeKind ?? "").startsWith("tailscale-peer");
+  return uniqueHosts([
+    machine.primaryRoute,
+    machine.tailscaleAddress,
+    machine.hostName,
+    ...machine.addresses,
+  ]).map((hostname) => ({
+    hostname,
+    port: isTailscalePeer ? machine.port : null,
+    source: isTailnetHostname(hostname) ? "tailscale" : "bonjour",
+    lastSucceededAt: null,
+  }));
+}
+
+export function findDiscoveredRuntimeForTargetInput(
+  machines: RemoteRuntimeDiscoveredMachine[],
+  input: RemoteRuntimeTargetInput,
+): RemoteRuntimeDiscoveredMachine | null {
+  const inputHosts = new Set(uniqueHosts([
+    input.hostname,
+    ...(input.routes ?? []).map((route) => route.hostname),
+  ]));
+  if (inputHosts.size === 0) return null;
+  return machines.find((machine) => {
+    if (!isDiscoveredSyncRuntime(machine)) return false;
+    const machineHosts = uniqueHosts([
+      machine.primaryRoute,
+      machine.tailscaleAddress,
+      machine.hostName,
+      ...machine.addresses,
+    ]);
+    return machineHosts.some((host) => inputHosts.has(host));
+  }) ?? null;
+}

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.test.ts
@@ -121,6 +121,7 @@ describe("bootstrapPairedRuntime", () => {
     };
     const pairedStore = {
       getForReference: vi.fn(() => credentials),
+      save: vi.fn(() => credentials),
       markEndpointSucceeded: vi.fn(() => credentials),
     };
 
@@ -152,6 +153,45 @@ describe("bootstrapPairedRuntime", () => {
     expect(createForwardClientMock).toHaveBeenCalledWith(result.transport.connection);
   });
 
+  it.each([
+    ["persists a learned relay route", "wss://relay.example/connect/new", [
+      "wss://relay.example/connect/new",
+      "ws://studio.local:8787",
+    ]],
+    ["clears a relay route on explicit null", null, ["ws://studio.local:8787"]],
+  ])("%s after a successful paired hello", async (_label, cloudRelayWssUrl, endpoints) => {
+    initializeMock.mockResolvedValue({
+      runtimeInfo: { version: "1.0.0", multiProject: true },
+      capabilities: { projects: true },
+    });
+    callMock.mockResolvedValue([]);
+    const credentialsWithRelay = {
+      ...credentials,
+      endpoints: ["ws://studio.local:8787", "wss://relay.example/connect/old"],
+      relayUrl: "wss://relay.example/connect/old",
+    };
+    const pairedStore = {
+      getForReference: vi.fn(() => credentialsWithRelay),
+      save: vi.fn((value) => value),
+      markEndpointSucceeded: vi.fn(() => credentialsWithRelay),
+    };
+    const connectedTransport = transport();
+    connectedTransport.connection.hello.cloudRelayWssUrl = cloudRelayWssUrl;
+
+    await bootstrapPairedRuntime({
+      target,
+      registry: { update: vi.fn(() => target) } as any,
+      pairedStore: pairedStore as any,
+      appVersion: "1.0.0",
+      options: { openTransport: vi.fn(async () => connectedTransport) },
+    });
+
+    expect(pairedStore.save).toHaveBeenCalledWith(expect.objectContaining({
+      relayUrl: cloudRelayWssUrl,
+      endpoints,
+    }));
+  });
+
   it("surfaces initialize incompatibility with an SSH update suggestion", async () => {
     initializeMock.mockResolvedValue({
       runtimeInfo: { version: "0.1.0", multiProject: false },
@@ -163,6 +203,7 @@ describe("bootstrapPairedRuntime", () => {
       registry: { update: vi.fn() } as any,
       pairedStore: {
         getForReference: vi.fn(() => credentials),
+        save: vi.fn(),
         markEndpointSucceeded: vi.fn(),
       } as any,
       appVersion: "1.0.0",

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DesktopPairedMachineCredentials } from "../../../shared/types/pairedRuntime";
+import type { RemoteRuntimeTarget } from "../../../shared/types/remoteRuntime";
+import type { SyncRuntimeTransport } from "./syncRuntimeTransport";
+
+const initializeMock = vi.hoisted(() => vi.fn());
+const callMock = vi.hoisted(() => vi.fn());
+const closeMock = vi.hoisted(() => vi.fn());
+const createForwardClientMock = vi.hoisted(() => vi.fn(() => ({
+  ensureForward: vi.fn(),
+  dispose: vi.fn(),
+})));
+
+vi.mock("./runtimeRpcClient", () => ({
+  RuntimeRpcClient: vi.fn().mockImplementation(() => ({
+    initialize: initializeMock,
+    call: callMock,
+    close: closeMock,
+  })),
+}));
+
+vi.mock("./syncPortForwardClient", () => ({
+  createSyncPortForwardClient: createForwardClientMock,
+}));
+
+import { bootstrapPairedRuntime } from "./pairedRuntimeBootstrap";
+import { PairedRuntimeCompatibilityError } from "./pairedRuntimeErrors";
+
+const credentials: DesktopPairedMachineCredentials = {
+  version: 1,
+  hostIdentity: {
+    deviceId: "host-1",
+    siteId: "host-site-1",
+    name: "Studio",
+    platform: "macOS",
+    deviceType: "desktop",
+  },
+  deviceId: "desktop-1",
+  siteId: "desktop-site-1",
+  deviceName: "Laptop",
+  secret: "secret",
+  dpopPrivateKey: "private",
+  dpopPublicKey: "public",
+  endpoints: ["ws://studio.local:8787"],
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+const target: RemoteRuntimeTarget = {
+  id: "target-1",
+  name: "Studio",
+  hostname: "studio.local",
+  transport: "paired",
+  pairedMachine: { hostIdentity: "host-1", machineKey: null },
+  sshUser: null,
+  port: null,
+  sshKeyPath: null,
+  lastSeenArch: null,
+  runtimeBinaryVersion: null,
+  lastConnectedAt: null,
+};
+
+function transport(features = { rpcChannel: true, portForward: true }): SyncRuntimeTransport {
+  return {
+    channelId: "rpc-1",
+    connection: {
+      endpoint: "ws://studio.local:8787/",
+      credentials,
+      hello: {
+        peer: {},
+        brain: {
+          deviceId: "host-1",
+          deviceName: "Studio",
+          platform: "macOS",
+          deviceType: "desktop",
+          siteId: "host-site-1",
+          dbVersion: 0,
+        },
+        serverDbVersion: 0,
+        heartbeatIntervalMs: 5_000,
+        pollIntervalMs: 1_500,
+        features,
+      } as any,
+      send: vi.fn(),
+      onEnvelope: vi.fn(() => () => {}),
+      onError: vi.fn(() => () => {}),
+      onClose: vi.fn(() => () => {}),
+      bufferedAmount: vi.fn(() => 0),
+      close: vi.fn(),
+    },
+    onData: vi.fn(),
+    onError: vi.fn(),
+    onClose: vi.fn(),
+    write: vi.fn(),
+    close: vi.fn(),
+  };
+}
+
+describe("bootstrapPairedRuntime", () => {
+  beforeEach(() => {
+    initializeMock.mockReset();
+    callMock.mockReset();
+    closeMock.mockReset();
+    createForwardClientMock.mockClear();
+  });
+
+  it("uses the same initialize validation and returns the winning paired route", async () => {
+    initializeMock.mockResolvedValue({
+      runtimeInfo: { version: "1.0.0", multiProject: true },
+      capabilities: { projects: true },
+    });
+    callMock.mockResolvedValue([]);
+    const updated = {
+      ...target,
+      lastSeenArch: "darwin",
+      runtimeBinaryVersion: "1.0.0",
+      lastConnectedAt: 100,
+    };
+    const registry = {
+      update: vi.fn(() => updated),
+    };
+    const pairedStore = {
+      get: vi.fn(() => credentials),
+      markEndpointSucceeded: vi.fn(() => credentials),
+    };
+
+    const result = await bootstrapPairedRuntime({
+      target,
+      registry: registry as any,
+      pairedStore: pairedStore as any,
+      appVersion: "1.0.0",
+      options: { openTransport: vi.fn(async () => transport()) },
+    });
+
+    expect(initializeMock).toHaveBeenCalledWith("ade-desktop-remote", "1.0.0");
+    expect(result.result).toMatchObject({
+      target: updated,
+      arch: "darwin",
+      version: "1.0.0",
+      route: {
+        kind: "lan",
+        endpoint: "ws://studio.local:8787/",
+        latencyMs: expect.any(Number),
+      },
+    });
+    expect(pairedStore.markEndpointSucceeded).toHaveBeenCalledWith(
+      "host-1",
+      "ws://studio.local:8787/",
+      expect.any(Number),
+    );
+    expect(createForwardClientMock).toHaveBeenCalledWith(result.transport.connection);
+  });
+
+  it("surfaces initialize incompatibility with an SSH update suggestion", async () => {
+    initializeMock.mockResolvedValue({
+      runtimeInfo: { version: "0.1.0", multiProject: false },
+      capabilities: { projects: false },
+    });
+
+    await expect(bootstrapPairedRuntime({
+      target,
+      registry: { update: vi.fn() } as any,
+      pairedStore: {
+        get: vi.fn(() => credentials),
+        markEndpointSucceeded: vi.fn(),
+      } as any,
+      appVersion: "1.0.0",
+      options: { openTransport: vi.fn(async () => transport()) },
+    })).rejects.toEqual(expect.objectContaining({
+      name: PairedRuntimeCompatibilityError.name,
+      message: expect.stringMatching(/connect .* with SSH to update/i),
+    }));
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.test.ts
@@ -120,7 +120,7 @@ describe("bootstrapPairedRuntime", () => {
       update: vi.fn(() => updated),
     };
     const pairedStore = {
-      get: vi.fn(() => credentials),
+      getForReference: vi.fn(() => credentials),
       markEndpointSucceeded: vi.fn(() => credentials),
     };
 
@@ -133,6 +133,7 @@ describe("bootstrapPairedRuntime", () => {
     });
 
     expect(initializeMock).toHaveBeenCalledWith("ade-desktop-remote", "1.0.0");
+    expect(pairedStore.getForReference).toHaveBeenCalledWith(target.pairedMachine);
     expect(result.result).toMatchObject({
       target: updated,
       arch: "darwin",
@@ -161,7 +162,7 @@ describe("bootstrapPairedRuntime", () => {
       target,
       registry: { update: vi.fn() } as any,
       pairedStore: {
-        get: vi.fn(() => credentials),
+        getForReference: vi.fn(() => credentials),
         markEndpointSucceeded: vi.fn(),
       } as any,
       appVersion: "1.0.0",
@@ -173,4 +174,3 @@ describe("bootstrapPairedRuntime", () => {
     expect(closeMock).toHaveBeenCalledTimes(1);
   });
 });
-

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.test.ts
@@ -186,10 +186,13 @@ describe("bootstrapPairedRuntime", () => {
       options: { openTransport: vi.fn(async () => connectedTransport) },
     });
 
-    expect(pairedStore.save).toHaveBeenCalledWith(expect.objectContaining({
-      relayUrl: cloudRelayWssUrl,
-      endpoints,
-    }));
+    expect(pairedStore.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        relayUrl: cloudRelayWssUrl,
+        endpoints,
+      }),
+      { replaceConnectionMetadata: true },
+    );
   });
 
   it("surfaces initialize incompatibility with an SSH update suggestion", async () => {

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.ts
@@ -41,16 +41,6 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function credentialsForTarget(
-  target: RemoteRuntimeTarget,
-  store: DesktopPairedMachineStore,
-): DesktopPairedMachineCredentials | null {
-  const reference = target.pairedMachine;
-  if (!reference) return null;
-  return store.get(reference.hostIdentity)
-    ?? (reference.machineKey ? store.get(reference.machineKey) : null);
-}
-
 function pairedArch(
   target: RemoteRuntimeTarget,
   credentials: DesktopPairedMachineCredentials,
@@ -90,7 +80,9 @@ export async function bootstrapPairedRuntime(args: {
   appVersion: string;
   options?: PairedRuntimeBootstrapOptions;
 }): Promise<PairedRuntimeBootstrapResult> {
-  const credentials = credentialsForTarget(args.target, args.pairedStore);
+  const credentials = args.target.pairedMachine
+    ? args.pairedStore.getForReference(args.target.pairedMachine)
+    : null;
   if (!credentials) {
     throw new PairedRuntimeTransportUnavailableError(
       "The paired-machine credentials for this remote target were not found.",

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.ts
@@ -183,13 +183,16 @@ export async function bootstrapPairedRuntime(args: {
         const endpointsWithoutPreviousRelay = routeUpdatedCredentials.endpoints.filter(
           (endpoint) => endpoint !== credentials.relayUrl,
         );
-        args.pairedStore.save({
-          ...routeUpdatedCredentials,
-          relayUrl: learnedRelay,
-          endpoints: learnedRelay
-            ? [learnedRelay, ...endpointsWithoutPreviousRelay]
-            : endpointsWithoutPreviousRelay,
-        });
+        args.pairedStore.save(
+          {
+            ...routeUpdatedCredentials,
+            relayUrl: learnedRelay,
+            endpoints: learnedRelay
+              ? [learnedRelay, ...endpointsWithoutPreviousRelay]
+              : endpointsWithoutPreviousRelay,
+          },
+          { replaceConnectionMetadata: true },
+        );
       }
       const portForwardClient = createSyncPortForwardClient(transport.connection);
       return {

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.ts
@@ -170,11 +170,27 @@ export async function bootstrapPairedRuntime(args: {
         runtimeBinaryVersion: initializeInfo.version,
         lastConnectedAt: connectedAt,
       });
-      args.pairedStore.markEndpointSucceeded(
+      const routeUpdatedCredentials = args.pairedStore.markEndpointSucceeded(
         credentials.hostIdentity.deviceId,
         candidate.endpoint,
         connectedAt,
       );
+      if (Object.prototype.hasOwnProperty.call(
+        transport.connection.hello,
+        "cloudRelayWssUrl",
+      )) {
+        const learnedRelay = transport.connection.hello.cloudRelayWssUrl ?? null;
+        const endpointsWithoutPreviousRelay = routeUpdatedCredentials.endpoints.filter(
+          (endpoint) => endpoint !== credentials.relayUrl,
+        );
+        args.pairedStore.save({
+          ...routeUpdatedCredentials,
+          relayUrl: learnedRelay,
+          endpoints: learnedRelay
+            ? [learnedRelay, ...endpointsWithoutPreviousRelay]
+            : endpointsWithoutPreviousRelay,
+        });
+      }
       const portForwardClient = createSyncPortForwardClient(transport.connection);
       return {
         client,

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.ts
@@ -1,0 +1,215 @@
+import type {
+  DesktopPairedMachineCredentials,
+} from "../../../shared/types/pairedRuntime";
+import type {
+  RemoteRuntimeConnectResult,
+  RemoteRuntimeTarget,
+} from "../../../shared/types/remoteRuntime";
+import {
+  coerceProjects,
+  validateRemoteRuntimeInitializeResult,
+} from "./remoteBootstrap";
+import type { RemoteTargetRegistry } from "./remoteTargetRegistry";
+import { RuntimeRpcClient } from "./runtimeRpcClient";
+import type { DesktopPairedMachineStore } from "./syncPairedMachineStore";
+import {
+  createSyncPortForwardClient,
+  type SyncPortForwardClient,
+} from "./syncPortForwardClient";
+import {
+  openSyncRuntimeTransport,
+  type SyncRuntimeTransport,
+} from "./syncRuntimeTransport";
+import { buildPairedEndpointCandidates } from "./pairedRuntimeRoutes";
+import {
+  PairedRuntimeCompatibilityError,
+  PairedRuntimeTransportUnavailableError,
+} from "./pairedRuntimeErrors";
+
+export type PairedRuntimeBootstrapResult = {
+  client: RuntimeRpcClient;
+  transport: SyncRuntimeTransport;
+  portForwardClient: SyncPortForwardClient;
+  result: RemoteRuntimeConnectResult;
+};
+
+type PairedRuntimeBootstrapOptions = {
+  openTransport?: typeof openSyncRuntimeTransport;
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function credentialsForTarget(
+  target: RemoteRuntimeTarget,
+  store: DesktopPairedMachineStore,
+): DesktopPairedMachineCredentials | null {
+  const reference = target.pairedMachine;
+  if (!reference) return null;
+  return store.get(reference.hostIdentity)
+    ?? (reference.machineKey ? store.get(reference.machineKey) : null);
+}
+
+function pairedArch(
+  target: RemoteRuntimeTarget,
+  credentials: DesktopPairedMachineCredentials,
+): string {
+  if (target.lastSeenArch?.trim()) return target.lastSeenArch.trim();
+  switch (credentials.hostIdentity.platform) {
+    case "macOS":
+      return "darwin";
+    case "windows":
+      return "windows";
+    case "linux":
+      return "linux";
+    default:
+      return "unknown";
+  }
+}
+
+function isPairedTransportFailure(error: unknown): boolean {
+  const message = errorMessage(error);
+  return /sync (?:websocket|connection|endpoint)|runtime rpc channel|rpc channel (?:is )?(?:closed|unavailable)|failed to connect|timed out (?:connecting|waiting for (?:sync|method))|connection closed|ECONNRESET|ECONNREFUSED|EHOSTUNREACH|ENETUNREACH|socket hang up/i.test(
+    message,
+  );
+}
+
+function compatibilityError(error: unknown): PairedRuntimeCompatibilityError {
+  return new PairedRuntimeCompatibilityError(
+    `The paired ADE runtime could not initialize compatibly: ${errorMessage(error)} `
+      + "Connect to this machine with SSH to update its ADE runtime, then try the paired connection again.",
+    error,
+  );
+}
+
+export async function bootstrapPairedRuntime(args: {
+  target: RemoteRuntimeTarget;
+  registry: RemoteTargetRegistry;
+  pairedStore: DesktopPairedMachineStore;
+  appVersion: string;
+  options?: PairedRuntimeBootstrapOptions;
+}): Promise<PairedRuntimeBootstrapResult> {
+  const credentials = credentialsForTarget(args.target, args.pairedStore);
+  if (!credentials) {
+    throw new PairedRuntimeTransportUnavailableError(
+      "The paired-machine credentials for this remote target were not found.",
+    );
+  }
+  const candidates = buildPairedEndpointCandidates({
+    endpoints: credentials.endpoints,
+    relayUrl: credentials.relayUrl,
+    endpointStates: credentials.endpointStates,
+  });
+  if (candidates.length === 0) {
+    throw new PairedRuntimeTransportUnavailableError(
+      "The paired machine has no usable sync endpoints.",
+    );
+  }
+
+  const openTransport = args.options?.openTransport ?? openSyncRuntimeTransport;
+  const routeErrors: string[] = [];
+  for (const candidate of candidates) {
+    let transport: SyncRuntimeTransport;
+    try {
+      transport = await openTransport({
+        credentials,
+        endpoint: candidate.endpoint,
+        appVersion: args.appVersion,
+      });
+    } catch (error) {
+      routeErrors.push(`${candidate.endpoint}: ${errorMessage(error)}`);
+      continue;
+    }
+
+    if (transport.connection.hello.features?.portForward !== true) {
+      transport.close();
+      routeErrors.push(
+        `${candidate.endpoint}: the paired machine does not advertise port-forward support`,
+      );
+      continue;
+    }
+
+    const client = new RuntimeRpcClient(transport);
+    let initializeResult: unknown;
+    const latencyStartedAt = Date.now();
+    try {
+      initializeResult = await client.initialize(
+        "ade-desktop-remote",
+        args.appVersion,
+      );
+    } catch (error) {
+      client.close();
+      if (isPairedTransportFailure(error)) {
+        routeErrors.push(`${candidate.endpoint}: ${errorMessage(error)}`);
+        continue;
+      }
+      throw compatibilityError(error);
+    }
+    const latencyMs = Math.max(0, Date.now() - latencyStartedAt);
+
+    let initializeInfo: ReturnType<typeof validateRemoteRuntimeInitializeResult>;
+    try {
+      initializeInfo = validateRemoteRuntimeInitializeResult({
+        result: initializeResult,
+        expectedVersion: args.appVersion,
+      });
+    } catch (error) {
+      client.close();
+      throw compatibilityError(error);
+    }
+
+    let projects;
+    try {
+      projects = coerceProjects(await client.call("projects.list", {}));
+    } catch (error) {
+      client.close();
+      if (isPairedTransportFailure(error)) {
+        routeErrors.push(`${candidate.endpoint}: ${errorMessage(error)}`);
+        continue;
+      }
+      throw compatibilityError(error);
+    }
+
+    try {
+      const connectedAt = Date.now();
+      const updated = args.registry.update(args.target.id, {
+        lastSeenArch: pairedArch(args.target, credentials),
+        runtimeBinaryVersion: initializeInfo.version,
+        lastConnectedAt: connectedAt,
+      });
+      args.pairedStore.markEndpointSucceeded(
+        credentials.hostIdentity.deviceId,
+        candidate.endpoint,
+        connectedAt,
+      );
+      const portForwardClient = createSyncPortForwardClient(transport.connection);
+      return {
+        client,
+        transport,
+        portForwardClient,
+        result: {
+          target: updated,
+          arch: updated.lastSeenArch ?? "unknown",
+          version: initializeInfo.version,
+          route: {
+            kind: candidate.kind,
+            endpoint: candidate.endpoint,
+            latencyMs,
+          },
+          capabilities: initializeInfo.capabilities,
+          compatibilityWarnings: initializeInfo.compatibilityWarnings,
+          projects,
+        },
+      };
+    } catch (error) {
+      client.close();
+      throw error;
+    }
+  }
+
+  throw new PairedRuntimeTransportUnavailableError(
+    "Could not reach the paired ADE runtime over LAN, tailnet, or relay. "
+      + routeErrors.join("; "),
+  );
+}

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeErrors.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeErrors.ts
@@ -1,3 +1,5 @@
+import type { RemoteRuntimeSshHostKeyTrustStatus } from "../../../shared/types/remoteRuntime";
+
 export class PairedRuntimeTransportUnavailableError extends Error {
   readonly code = "PAIRED_RUNTIME_TRANSPORT_UNAVAILABLE" as const;
 
@@ -30,3 +32,20 @@ export class PairedRuntimeCompatibilityError extends Error {
   }
 }
 
+export class PairedRuntimeSshTrustRequiredError extends Error {
+  readonly code = "PAIRED_RUNTIME_SSH_TRUST_REQUIRED" as const;
+
+  constructor(
+    readonly trustStatus: Extract<
+      RemoteRuntimeSshHostKeyTrustStatus,
+      { state: "needs_trust" | "changed" }
+    >,
+  ) {
+    super(
+      trustStatus.state === "changed"
+        ? "The SSH host key changed after the paired connection failed."
+        : "The SSH host key must be trusted before ADE can fall back from the paired connection.",
+    );
+    this.name = "PairedRuntimeSshTrustRequiredError";
+  }
+}

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeErrors.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeErrors.ts
@@ -1,18 +1,21 @@
 import type { RemoteRuntimeSshHostKeyTrustStatus } from "../../../shared/types/remoteRuntime";
 
+function assignCause(target: Error, cause: unknown): void {
+  if (cause === undefined) return;
+  Object.defineProperty(target, "cause", {
+    configurable: true,
+    enumerable: false,
+    value: cause,
+  });
+}
+
 export class PairedRuntimeTransportUnavailableError extends Error {
   readonly code = "PAIRED_RUNTIME_TRANSPORT_UNAVAILABLE" as const;
 
   constructor(message: string, cause?: unknown) {
     super(message);
     this.name = "PairedRuntimeTransportUnavailableError";
-    if (cause !== undefined) {
-      Object.defineProperty(this, "cause", {
-        configurable: true,
-        enumerable: false,
-        value: cause,
-      });
-    }
+    assignCause(this, cause);
   }
 }
 
@@ -22,13 +25,7 @@ export class PairedRuntimeCompatibilityError extends Error {
   constructor(message: string, cause?: unknown) {
     super(message);
     this.name = "PairedRuntimeCompatibilityError";
-    if (cause !== undefined) {
-      Object.defineProperty(this, "cause", {
-        configurable: true,
-        enumerable: false,
-        value: cause,
-      });
-    }
+    assignCause(this, cause);
   }
 }
 

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeErrors.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeErrors.ts
@@ -1,0 +1,32 @@
+export class PairedRuntimeTransportUnavailableError extends Error {
+  readonly code = "PAIRED_RUNTIME_TRANSPORT_UNAVAILABLE" as const;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "PairedRuntimeTransportUnavailableError";
+    if (cause !== undefined) {
+      Object.defineProperty(this, "cause", {
+        configurable: true,
+        enumerable: false,
+        value: cause,
+      });
+    }
+  }
+}
+
+export class PairedRuntimeCompatibilityError extends Error {
+  readonly code = "PAIRED_RUNTIME_COMPATIBILITY" as const;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = "PairedRuntimeCompatibilityError";
+    if (cause !== undefined) {
+      Object.defineProperty(this, "cause", {
+        configurable: true,
+        enumerable: false,
+        value: cause,
+      });
+    }
+  }
+}
+

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeRoutes.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeRoutes.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPairedEndpointCandidates,
+  classifyPairedRuntimeEndpoint,
+} from "./pairedRuntimeRoutes";
+
+describe("paired runtime endpoint routes", () => {
+  it("orders LAN before tailnet before relay and prefers recent success within a route kind", () => {
+    const candidates = buildPairedEndpointCandidates({
+      endpoints: [
+        "wss://relay.example/connect/machine",
+        "ws://100.64.20.3:8787",
+        "ws://studio.local:8787",
+        "ws://192.168.1.8:8787",
+        "ws://studio.example.ts.net:8787",
+      ],
+      relayUrl: "wss://relay.example/connect/machine",
+      endpointStates: [
+        { endpoint: "ws://192.168.1.8:8787", lastSucceededAt: 200 },
+        { endpoint: "ws://studio.local:8787", lastSucceededAt: 100 },
+        { endpoint: "ws://studio.example.ts.net:8787", lastSucceededAt: 300 },
+      ],
+    });
+
+    expect(candidates.map(({ endpoint, kind }) => ({ endpoint, kind }))).toEqual([
+      { endpoint: "ws://192.168.1.8:8787/", kind: "lan" },
+      { endpoint: "ws://studio.local:8787/", kind: "lan" },
+      { endpoint: "ws://studio.example.ts.net:8787/", kind: "tailnet" },
+      { endpoint: "ws://100.64.20.3:8787/", kind: "tailnet" },
+      { endpoint: "wss://relay.example/connect/machine", kind: "relay" },
+    ]);
+  });
+
+  it("classifies CGNAT and ts.net endpoints as tailnet", () => {
+    expect(classifyPairedRuntimeEndpoint("ws://100.127.255.254:8787")).toBe("tailnet");
+    expect(classifyPairedRuntimeEndpoint("ws://100.128.0.1:8787")).toBe("lan");
+    expect(classifyPairedRuntimeEndpoint("ws://studio.example.ts.net:8787")).toBe("tailnet");
+    expect(classifyPairedRuntimeEndpoint("ws://192.168.1.2:8787")).toBe("lan");
+    expect(classifyPairedRuntimeEndpoint("wss://relay.example/connect/id")).toBe("relay");
+  });
+});
+

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeRoutes.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeRoutes.test.ts
@@ -3,6 +3,7 @@ import {
   buildPairedEndpointCandidates,
   classifyPairedRuntimeEndpoint,
 } from "./pairedRuntimeRoutes";
+import { isTailnetHostname } from "../../../shared/tailnet";
 
 describe("paired runtime endpoint routes", () => {
   it("orders LAN before tailnet before relay and prefers recent success within a route kind", () => {
@@ -22,7 +23,9 @@ describe("paired runtime endpoint routes", () => {
       ],
     });
 
-    expect(candidates.map(({ endpoint, kind }) => ({ endpoint, kind }))).toEqual([
+    expect(
+      candidates.map(({ endpoint, kind }) => ({ endpoint, kind })),
+    ).toEqual([
       { endpoint: "ws://192.168.1.8:8787/", kind: "lan" },
       { endpoint: "ws://studio.local:8787/", kind: "lan" },
       { endpoint: "ws://studio.example.ts.net:8787/", kind: "tailnet" },
@@ -31,12 +34,20 @@ describe("paired runtime endpoint routes", () => {
     ]);
   });
 
-  it("classifies CGNAT and ts.net endpoints as tailnet", () => {
-    expect(classifyPairedRuntimeEndpoint("ws://100.127.255.254:8787")).toBe("tailnet");
+  it("classifies normalized CGNAT and ts.net hostnames as tailnet", () => {
+    expect(classifyPairedRuntimeEndpoint("ws://100.127.255.254:8787")).toBe(
+      "tailnet",
+    );
     expect(classifyPairedRuntimeEndpoint("ws://100.128.0.1:8787")).toBe("lan");
-    expect(classifyPairedRuntimeEndpoint("ws://studio.example.ts.net:8787")).toBe("tailnet");
+    expect(
+      classifyPairedRuntimeEndpoint("ws://studio.example.ts.net:8787"),
+    ).toBe("tailnet");
     expect(classifyPairedRuntimeEndpoint("ws://192.168.1.2:8787")).toBe("lan");
-    expect(classifyPairedRuntimeEndpoint("wss://relay.example/connect/id")).toBe("relay");
+    expect(
+      classifyPairedRuntimeEndpoint("wss://relay.example/connect/id"),
+    ).toBe("relay");
+    expect(isTailnetHostname("  STUDIO.EXAMPLE.TS.NET. ")).toBe(true);
+    expect(isTailnetHostname(" [100.64.0.1]. ")).toBe(true);
+    expect(isTailnetHostname("100.128.0.1")).toBe(false);
   });
 });
-

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeRoutes.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeRoutes.ts
@@ -1,9 +1,6 @@
-import type {
-  DesktopPairedMachineEndpointState,
-} from "../../../shared/types/pairedRuntime";
-import type {
-  RemoteRuntimeRouteKind,
-} from "../../../shared/types/remoteRuntime";
+import type { DesktopPairedMachineEndpointState } from "../../../shared/types/pairedRuntime";
+import type { RemoteRuntimeRouteKind } from "../../../shared/types/remoteRuntime";
+import { isTailnetHostname } from "../../../shared/tailnet";
 import { normalizeSyncEndpoint } from "./syncRuntimeTransport";
 
 export type PairedRuntimeEndpointCandidate = {
@@ -12,26 +9,15 @@ export type PairedRuntimeEndpointCandidate = {
   lastSucceededAt: number | null;
 };
 
-function normalizedEndpointOrNull(value: string | null | undefined): string | null {
+function normalizedEndpointOrNull(
+  value: string | null | undefined,
+): string | null {
   if (!value?.trim()) return null;
   try {
     return normalizeSyncEndpoint(value);
   } catch {
     return null;
   }
-}
-
-function normalizedHostname(value: string): string {
-  return value.trim().toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
-}
-
-export function isTailnetHostname(value: string): boolean {
-  const host = normalizedHostname(value);
-  if (host.endsWith(".ts.net")) return true;
-  const match = /^100\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
-  if (!match) return false;
-  const second = Number.parseInt(match[1] ?? "", 10);
-  return second >= 64 && second <= 127;
 }
 
 export function classifyPairedRuntimeEndpoint(
@@ -58,7 +44,8 @@ export function syncEndpointForHost(hostValue: string, port: number): string {
   if (/^wss?:\/\//i.test(host) || /^https?:\/\//i.test(host)) {
     return normalizeSyncEndpoint(host);
   }
-  const urlHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+  const urlHost =
+    host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
   return normalizeSyncEndpoint(`ws://${urlHost}:${port}`);
 }
 
@@ -72,7 +59,11 @@ export function buildPairedEndpointCandidates(args: {
   const successByEndpoint = new Map<string, number>();
   for (const state of args.endpointStates ?? []) {
     const endpoint = normalizedEndpointOrNull(state.endpoint);
-    if (!endpoint || state.lastSucceededAt == null || !Number.isFinite(state.lastSucceededAt)) {
+    if (
+      !endpoint ||
+      state.lastSucceededAt == null ||
+      !Number.isFinite(state.lastSucceededAt)
+    ) {
       continue;
     }
     successByEndpoint.set(
@@ -86,7 +77,8 @@ export function buildPairedEndpointCandidates(args: {
     ...(args.additionalEndpoints ?? []),
     ...(relayUrl ? [relayUrl] : []),
   ];
-  const candidates: Array<PairedRuntimeEndpointCandidate & { order: number }> = [];
+  const candidates: Array<PairedRuntimeEndpointCandidate & { order: number }> =
+    [];
   const seen = new Set<string>();
   for (const value of values) {
     const endpoint = normalizedEndpointOrNull(value);
@@ -106,10 +98,11 @@ export function buildPairedEndpointCandidates(args: {
     relay: 2,
   };
   return candidates
-    .sort((left, right) =>
-      rank[left.kind] - rank[right.kind]
-      || (right.lastSucceededAt ?? 0) - (left.lastSucceededAt ?? 0)
-      || left.order - right.order)
+    .sort(
+      (left, right) =>
+        rank[left.kind] - rank[right.kind] ||
+        (right.lastSucceededAt ?? 0) - (left.lastSucceededAt ?? 0) ||
+        left.order - right.order,
+    )
     .map(({ order: _order, ...candidate }) => candidate);
 }
-

--- a/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeRoutes.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairedRuntimeRoutes.ts
@@ -1,0 +1,115 @@
+import type {
+  DesktopPairedMachineEndpointState,
+} from "../../../shared/types/pairedRuntime";
+import type {
+  RemoteRuntimeRouteKind,
+} from "../../../shared/types/remoteRuntime";
+import { normalizeSyncEndpoint } from "./syncRuntimeTransport";
+
+export type PairedRuntimeEndpointCandidate = {
+  endpoint: string;
+  kind: Exclude<RemoteRuntimeRouteKind, "ssh">;
+  lastSucceededAt: number | null;
+};
+
+function normalizedEndpointOrNull(value: string | null | undefined): string | null {
+  if (!value?.trim()) return null;
+  try {
+    return normalizeSyncEndpoint(value);
+  } catch {
+    return null;
+  }
+}
+
+function normalizedHostname(value: string): string {
+  return value.trim().toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
+}
+
+export function isTailnetHostname(value: string): boolean {
+  const host = normalizedHostname(value);
+  if (host.endsWith(".ts.net")) return true;
+  const match = /^100\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!match) return false;
+  const second = Number.parseInt(match[1] ?? "", 10);
+  return second >= 64 && second <= 127;
+}
+
+export function classifyPairedRuntimeEndpoint(
+  endpointValue: string,
+  relayUrl?: string | null,
+): Exclude<RemoteRuntimeRouteKind, "ssh"> {
+  const endpoint = normalizeSyncEndpoint(endpointValue);
+  const normalizedRelay = normalizedEndpointOrNull(relayUrl);
+  if (normalizedRelay && endpoint === normalizedRelay) return "relay";
+  const url = new URL(endpoint);
+  if (isTailnetHostname(url.hostname)) return "tailnet";
+  // Direct sync is currently plain ws; relay transport is system-trusted wss.
+  // The explicit relayUrl check above keeps a future tailnet wss route visible
+  // as tailnet instead of collapsing it into the relay bucket.
+  return url.protocol === "wss:" ? "relay" : "lan";
+}
+
+export function syncEndpointForHost(hostValue: string, port: number): string {
+  const host = hostValue.trim().replace(/\.$/, "");
+  if (!host) throw new Error("A sync endpoint host is required.");
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("A sync endpoint port from 1 to 65535 is required.");
+  }
+  if (/^wss?:\/\//i.test(host) || /^https?:\/\//i.test(host)) {
+    return normalizeSyncEndpoint(host);
+  }
+  const urlHost = host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+  return normalizeSyncEndpoint(`ws://${urlHost}:${port}`);
+}
+
+export function buildPairedEndpointCandidates(args: {
+  endpoints: string[];
+  relayUrl?: string | null;
+  endpointStates?: DesktopPairedMachineEndpointState[] | null;
+  additionalEndpoints?: string[];
+}): PairedRuntimeEndpointCandidate[] {
+  const relayUrl = normalizedEndpointOrNull(args.relayUrl);
+  const successByEndpoint = new Map<string, number>();
+  for (const state of args.endpointStates ?? []) {
+    const endpoint = normalizedEndpointOrNull(state.endpoint);
+    if (!endpoint || state.lastSucceededAt == null || !Number.isFinite(state.lastSucceededAt)) {
+      continue;
+    }
+    successByEndpoint.set(
+      endpoint,
+      Math.max(successByEndpoint.get(endpoint) ?? 0, state.lastSucceededAt),
+    );
+  }
+
+  const values = [
+    ...args.endpoints,
+    ...(args.additionalEndpoints ?? []),
+    ...(relayUrl ? [relayUrl] : []),
+  ];
+  const candidates: Array<PairedRuntimeEndpointCandidate & { order: number }> = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const endpoint = normalizedEndpointOrNull(value);
+    if (!endpoint || seen.has(endpoint)) continue;
+    seen.add(endpoint);
+    candidates.push({
+      endpoint,
+      kind: classifyPairedRuntimeEndpoint(endpoint, relayUrl),
+      lastSucceededAt: successByEndpoint.get(endpoint) ?? null,
+      order: candidates.length,
+    });
+  }
+
+  const rank: Record<PairedRuntimeEndpointCandidate["kind"], number> = {
+    lan: 0,
+    tailnet: 1,
+    relay: 2,
+  };
+  return candidates
+    .sort((left, right) =>
+      rank[left.kind] - rank[right.kind]
+      || (right.lastSucceededAt ?? 0) - (left.lastSucceededAt ?? 0)
+      || left.order - right.order)
+    .map(({ order: _order, ...candidate }) => candidate);
+}
+

--- a/apps/desktop/src/main/services/remoteRuntime/pairingInput.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairingInput.test.ts
@@ -53,9 +53,16 @@ describe("parseRemoteRuntimePairingInput", () => {
     ]);
   });
 
+  it("preserves the server-issued runtime host grant", () => {
+    const url = encodePairingQrUrl(buildPairingQrPayload({
+      connectInfo,
+      runtimeHostGrant: "runtime-grant-1",
+    }));
+    expect(parseRemoteRuntimePairingInput(url).runtimeHostGrant).toBe("runtime-grant-1");
+  });
+
   it("rejects garbage", () => {
     expect(() => parseRemoteRuntimePairingInput("not-a-pairing-code"))
       .toThrow(/invalid ADE pairing link or code/i);
   });
 });
-

--- a/apps/desktop/src/main/services/remoteRuntime/pairingInput.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairingInput.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPairingQrPayload,
+  encodePairingQrUrl,
+} from "../../../shared/pairingQr";
+import type { SyncPairingConnectInfo } from "../../../shared/types/sync";
+import { parseRemoteRuntimePairingInput } from "./pairingInput";
+
+const connectInfo: SyncPairingConnectInfo = {
+  hostIdentity: {
+    deviceId: "host-1",
+    siteId: "site-1",
+    name: "Studio",
+    platform: "macOS",
+    deviceType: "desktop",
+  },
+  port: 8787,
+  addressCandidates: [
+    { host: "100.70.0.2", kind: "tailscale" },
+    { host: "192.168.1.20", kind: "lan" },
+  ],
+};
+
+describe("parseRemoteRuntimePairingInput", () => {
+  it("normalizes a full pairing URL", () => {
+    const parsed = parseRemoteRuntimePairingInput(encodePairingQrUrl(
+      buildPairingQrPayload({
+        connectInfo,
+        relayUrl: "wss://relay.example/connect/machine-1",
+      }),
+    ));
+
+    expect(parsed).toEqual({
+      hostIdentity: connectInfo.hostIdentity,
+      machineName: "Studio",
+      endpoints: [
+        "ws://192.168.1.20:8787/",
+        "ws://100.70.0.2:8787/",
+        "wss://relay.example/connect/machine-1",
+      ],
+      relayUrl: "wss://relay.example/connect/machine-1",
+      requiresPin: true,
+    });
+  });
+
+  it("accepts the bare encoded payload", () => {
+    const url = encodePairingQrUrl(buildPairingQrPayload({ connectInfo }));
+    const parsed = parseRemoteRuntimePairingInput(url.split("#")[1]!);
+    expect(parsed.hostIdentity.deviceId).toBe("host-1");
+    expect(parsed.endpoints).toEqual([
+      "ws://192.168.1.20:8787/",
+      "ws://100.70.0.2:8787/",
+    ]);
+  });
+
+  it("rejects garbage", () => {
+    expect(() => parseRemoteRuntimePairingInput("not-a-pairing-code"))
+      .toThrow(/invalid ADE pairing link or code/i);
+  });
+});
+

--- a/apps/desktop/src/main/services/remoteRuntime/pairingInput.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairingInput.ts
@@ -1,0 +1,41 @@
+import { parsePairingQrText } from "../../../shared/pairingQr";
+import type {
+  RemoteRuntimeParsedPairingInput,
+} from "../../../shared/types/remoteRuntime";
+import {
+  buildPairedEndpointCandidates,
+  syncEndpointForHost,
+} from "./pairedRuntimeRoutes";
+
+export function parseRemoteRuntimePairingInput(
+  text: string,
+): RemoteRuntimeParsedPairingInput {
+  const payload = parsePairingQrText(text);
+  if (!payload) {
+    throw new Error("Invalid ADE pairing link or code.");
+  }
+
+  const directEndpoints = payload.addressCandidates.flatMap((candidate) => {
+    try {
+      return [syncEndpointForHost(candidate.host, payload.port)];
+    } catch {
+      return [];
+    }
+  });
+  const ordered = buildPairedEndpointCandidates({
+    endpoints: directEndpoints,
+    relayUrl: payload.relayUrl,
+  });
+  if (ordered.length === 0) {
+    throw new Error("The ADE pairing link does not contain a reachable endpoint.");
+  }
+  const relayUrl = ordered.find((candidate) => candidate.kind === "relay")?.endpoint;
+
+  return {
+    hostIdentity: payload.hostIdentity,
+    ...(payload.hostIdentity.name ? { machineName: payload.hostIdentity.name } : {}),
+    endpoints: ordered.map((candidate) => candidate.endpoint),
+    ...(relayUrl ? { relayUrl } : {}),
+    requiresPin: true,
+  };
+}

--- a/apps/desktop/src/main/services/remoteRuntime/pairingInput.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/pairingInput.ts
@@ -36,6 +36,7 @@ export function parseRemoteRuntimePairingInput(
     ...(payload.hostIdentity.name ? { machineName: payload.hostIdentity.name } : {}),
     endpoints: ordered.map((candidate) => candidate.endpoint),
     ...(relayUrl ? { relayUrl } : {}),
+    ...(payload.runtimeHostGrant ? { runtimeHostGrant: payload.runtimeHostGrant } : {}),
     requiresPin: true,
   };
 }

--- a/apps/desktop/src/main/services/remoteRuntime/remoteBootstrap.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteBootstrap.test.ts
@@ -68,7 +68,14 @@ describe("normalizeRemoteArch", () => {
   });
 
   it("rejects unsupported remote ADE service targets instead of guessing", () => {
-    expect(() => normalizeRemoteArch("FreeBSD riscv64")).toThrow(/unsupported remote ade service platform/i);
+    expect(() => normalizeRemoteArch("FreeBSD riscv64")).toThrowError(
+      expect.objectContaining({
+        info: expect.objectContaining({
+          kind: "unsupported_os",
+          detail: "FreeBSD riscv64",
+        }),
+      }),
+    );
     expect(() => normalizeRemoteArch("Linux riscv64")).toThrow(/unsupported remote ade service platform/i);
   });
 });
@@ -398,6 +405,13 @@ function resolvedRemotePath(command: string): ReturnType<typeof ok> | null {
 
 function defaultRemoteBootstrapCommand(command: string): ReturnType<typeof ok> {
   if (isRemoteRuntimeSupportCommand(command)) return remoteRuntimeSupportOk();
+  if (/^mkdir -p \$HOME\/\.ade(?:-alpha|-beta)? && df -kP \$HOME\/\.ade(?:-alpha|-beta)?$/u.test(command)) {
+    return ok([
+      "Filesystem 1024-blocks Used Available Capacity Mounted on",
+      "/dev/test 10485760 1 10485759 1% /home/ade",
+      "",
+    ].join("\n"));
+  }
   throw new Error(`Unexpected SSH command: ${command}`);
 }
 
@@ -709,6 +723,179 @@ describe("bootstrapRemoteRuntime upload flow", () => {
       projects: [{ projectId: "project-1", rootPath: "/srv/ade" }],
     });
     expect(fakeSsh.end).not.toHaveBeenCalled();
+  });
+
+  it("fails before uploading when the remote install disk preflight is insufficient", async () => {
+    const resources = createTempResources("linux-x64", { nativeDeps: true });
+    cleanupResources = resources.cleanup;
+    const fakeSsh = createFakeSsh();
+    const registry = createRegistry();
+    connectSshWithRouteMock.mockResolvedValue({
+      client: fakeSsh.ssh,
+      route: uploadRoute,
+    });
+    execSshMock.mockImplementation(async (_client: Client, command: string) => {
+      if (command === "uname -sm") return ok("Linux x86_64\n");
+      if (isRemoteRuntimeIdentityCommand(command)) return remoteRuntimeIdentityOk({});
+      if (isRemoteRuntimeSupportCommand(command)) return remoteRuntimeSupportOk();
+      if (command === "mkdir -p $HOME/.ade && df -kP $HOME/.ade") {
+        return ok([
+          "Filesystem 1024-blocks Used Available Capacity Mounted on",
+          "/dev/test 1000 999 1 100% /home/ade",
+          "",
+        ].join("\n"));
+      }
+      return defaultRemoteBootstrapCommand(command);
+    });
+
+    await expect(bootstrapRemoteRuntime({
+      target: uploadTarget,
+      registry,
+      resourcesPath: resources.resourcesPath,
+      appVersion: APP_VERSION,
+    })).rejects.toMatchObject({
+      info: {
+        kind: "disk_full",
+        freeBytes: 1024,
+        requiredBytes: expect.any(Number),
+      },
+    });
+
+    expect(fakeSsh.sftp).not.toHaveBeenCalled();
+    expect(fakeSsh.exec).not.toHaveBeenCalled();
+    expect(openSshRuntimeTransportMock).not.toHaveBeenCalled();
+    expect(fakeSsh.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues uploading when the remote disk preflight command fails", async () => {
+    const resources = createTempResources();
+    cleanupResources = resources.cleanup;
+    const fakeSsh = createFakeSsh();
+    const registry = createRegistry();
+    connectSshWithRouteMock.mockResolvedValue({
+      client: fakeSsh.ssh,
+      route: uploadRoute,
+    });
+    execSshMock.mockImplementation(async (_client: Client, command: string) => {
+      const remotePath = resolvedRemotePath(command);
+      if (remotePath) return remotePath;
+      if (command === "uname -sm") return ok("Linux x86_64\n");
+      if (isRemoteRuntimeIdentityCommand(command)) return remoteRuntimeIdentityOk({});
+      if (isRemoteRuntimeSupportCommand(command)) return remoteRuntimeSupportOk();
+      if (command === "mkdir -p $HOME/.ade && df -kP $HOME/.ade") {
+        return { stdout: "", stderr: "df unavailable", code: 1 };
+      }
+      if (command === "mkdir -p $HOME/.ade/bin && chmod 700 $HOME/.ade/bin") return ok("");
+      if (command.match(/^rm -f \$HOME\/\.ade\/bin\/ade\.upload-.* && umask 077 && : > \$HOME\/\.ade\/bin\/ade\.upload-.* && chmod 600 \$HOME\/\.ade\/bin\/ade\.upload-/)) return ok("");
+      if (
+        command.includes("wc -c < $HOME/.ade/bin/ade.upload-") &&
+        !command.includes("shasum") &&
+        !command.includes("mv -f")
+      ) return ok(`${fs.statSync(resources.binaryPath).size}\n`);
+      if (
+        command.includes("wc -c < $HOME/.ade/bin/ade.upload-") &&
+        command.includes("mv -f $HOME/.ade/bin/ade.upload-")
+      ) return ok("");
+      if (command.includes("$HOME/.ade/bin/ade --version")) return ok(`ade ${APP_VERSION}\n`);
+      return defaultRemoteBootstrapCommand(command);
+    });
+
+    await expect(bootstrapRemoteRuntime({
+      target: uploadTarget,
+      registry,
+      resourcesPath: resources.resourcesPath,
+      appVersion: APP_VERSION,
+    })).resolves.toMatchObject({ result: { version: APP_VERSION } });
+
+    expect(fakeSsh.sftpWrapper.fastPut).toHaveBeenCalledWith(
+      resources.binaryPath,
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("maps extract ENOSPC to a bounded disk-full error and removes committed native artifacts", async () => {
+    const resources = createTempResources("linux-x64", { nativeDeps: true });
+    cleanupResources = resources.cleanup;
+    const fakeSsh = createFakeSsh();
+    const registry = createRegistry();
+    const nativePath = path.join(
+      resources.resourcesPath,
+      "runtime",
+      "ade-linux-x64.native.tar.gz",
+    );
+    const extractDetail = `tar: No space left on device\n${"x".repeat(6_000)}TAIL`;
+    connectSshWithRouteMock.mockResolvedValue({
+      client: fakeSsh.ssh,
+      route: uploadRoute,
+    });
+    const commands: string[] = [];
+    execSshMock.mockImplementation(async (_client: Client, command: string) => {
+      commands.push(command);
+      const remotePath = resolvedRemotePath(command);
+      if (remotePath) return remotePath;
+      if (command === "uname -sm") return ok("Linux x86_64\n");
+      if (isRemoteRuntimeIdentityCommand(command)) {
+        return remoteRuntimeIdentityOk({
+          markerVersion: APP_VERSION,
+          sha256: resources.binarySha256,
+          executableVersion: `ade ${APP_VERSION}`,
+        });
+      }
+      if (
+        command.includes("wc -c < $HOME/.ade/bin/ade") &&
+        command.includes("shasum -a 256 $HOME/.ade/bin/ade") &&
+        command.includes("echo ok")
+      ) return ok("ok\n");
+      if (isRemoteRuntimeSupportCommand(command)) {
+        return remoteRuntimeSupportOk({ nativeDepsReady: false });
+      }
+      if (command === "mkdir -p $HOME/.ade/runtime") return ok("");
+      if (command.match(/^rm -f \$HOME\/\.ade\/runtime\/ade-linux-x64\.native\.tar\.gz\.upload-.* && umask 077/)) return ok("");
+      if (
+        command.includes("wc -c < $HOME/.ade/runtime/ade-linux-x64.native.tar.gz.upload-") &&
+        !command.includes("shasum") &&
+        !command.includes("mv -f")
+      ) return ok(`${fs.statSync(nativePath).size}\n`);
+      if (
+        command.includes("mv -f $HOME/.ade/runtime/ade-linux-x64.native.tar.gz.upload-") &&
+        command.includes("tar -xzf $HOME/.ade/runtime/ade-linux-x64.native.tar.gz")
+      ) return { stdout: "", stderr: extractDetail, code: 1 };
+      if (
+        command.startsWith("rm -f $HOME/.ade/runtime/ade-linux-x64.native.tar.gz.upload-") &&
+        command.includes("$HOME/.ade/runtime/ade-linux-x64.native.tar.gz; rm -rf $HOME/.ade/runtime/linux-x64")
+      ) return ok("");
+      return defaultRemoteBootstrapCommand(command);
+    });
+
+    let caught: unknown;
+    try {
+      await bootstrapRemoteRuntime({
+        target: uploadTarget,
+        registry,
+        resourcesPath: resources.resourcesPath,
+        appVersion: APP_VERSION,
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toMatchObject({
+      info: {
+        kind: "disk_full",
+        freeBytes: expect.any(Number),
+        requiredBytes: expect.any(Number),
+      },
+    });
+    const detail = (caught as { info: { detail: string } }).info.detail;
+    expect(detail.length).toBeLessThanOrEqual(4_000);
+    expect(detail).toContain("truncated");
+    expect(detail).toContain("TAIL");
+    expect(commands.some((command) =>
+      command.startsWith("rm -f $HOME/.ade/runtime/ade-linux-x64.native.tar.gz.upload-") &&
+      command.includes("$HOME/.ade/runtime/ade-linux-x64.native.tar.gz; rm -rf $HOME/.ade/runtime/linux-x64")
+    )).toBe(true);
   });
 
   it("uploads the PTY host worker and points the remote runtime at it", async () => {

--- a/apps/desktop/src/main/services/remoteRuntime/remoteBootstrap.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteBootstrap.ts
@@ -1769,6 +1769,16 @@ export async function bootstrapRemoteRuntime(args: {
         target: updated,
         arch: arch.label,
         version: initializeInfo.version ?? runtimeVersion,
+        route: {
+          kind: "ssh",
+          endpoint: (() => {
+            const host = connectedRoute.hostname.includes(":")
+              && !connectedRoute.hostname.startsWith("[")
+              ? `[${connectedRoute.hostname}]`
+              : connectedRoute.hostname;
+            return `${host}:${connectedRoute.port ?? args.target.port ?? 22}`;
+          })(),
+        },
         capabilities: initializeInfo.capabilities,
         compatibilityWarnings,
         projects,

--- a/apps/desktop/src/main/services/remoteRuntime/remoteBootstrap.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteBootstrap.ts
@@ -13,6 +13,7 @@ import type {
   RemoteRuntimeTarget,
   RemoteRuntimeTargetRoute,
 } from "../../../shared/types/remoteRuntime";
+import { RemoteRuntimeConnectError } from "../../../shared/types/remoteRuntime";
 import { RuntimeRpcClient } from "./runtimeRpcClient";
 import { connectSshWithRoute, execSsh, openSshRuntimeTransport, type ConnectedSshRoute, type OpenSshResolvedConfig } from "./sshTransport";
 import { routeKey } from "./routeUtils";
@@ -34,7 +35,12 @@ export function normalizeRemoteArch(raw: string): { platform: string; arch: stri
       ? "x64"
       : null;
   if (!platform || !arch) {
-    throw new Error(`Unsupported remote ADE service platform: ${raw.trim() || "unknown"}. Supported targets are macOS/Linux on arm64 or x64.`);
+    const detectedPlatform = raw.trim() || "unknown";
+    throw new RemoteRuntimeConnectError({
+      kind: "unsupported_os",
+      message: `Unsupported remote ADE service platform: ${detectedPlatform}. Supported targets are macOS/Linux on arm64 or x64.`,
+      detail: detectedPlatform,
+    });
   }
   return { platform, arch, label: `${platform}-${arch}` };
 }
@@ -657,6 +663,138 @@ async function readRemoteRuntimeSupportStatus(args: {
   };
 }
 
+type RemoteInstallDiskSpace = {
+  freeBytes: number;
+  requiredBytes: number;
+};
+
+const REMOTE_INSTALL_MARGIN_BYTES = 64 * 1024 * 1024;
+
+function formatInstallMegabytes(bytes: number): string {
+  return `${Math.max(0, Math.round(bytes / (1024 * 1024)))} MB`;
+}
+
+function diskFullConnectError(args: {
+  detail: string;
+  diskSpace?: RemoteInstallDiskSpace | null;
+  cause?: unknown;
+}): RemoteRuntimeConnectError {
+  const space = args.diskSpace;
+  const message = space
+    ? `The remote machine is out of disk space (${formatInstallMegabytes(space.freeBytes)} free; ADE needs about ${formatInstallMegabytes(space.requiredBytes)} to install its runtime). Free up space and try again.`
+    : "The remote machine is out of disk space. Free up space and try again.";
+  return new RemoteRuntimeConnectError({
+    kind: "disk_full",
+    message,
+    detail: args.detail,
+    ...(space
+      ? { freeBytes: space.freeBytes, requiredBytes: space.requiredBytes }
+      : {}),
+  }, args.cause);
+}
+
+function isDiskFullError(error: unknown): boolean {
+  let current = error;
+  for (let depth = 0; current != null && depth < 5; depth += 1) {
+    if (typeof current === "object") {
+      const record = current as {
+        code?: unknown;
+        message?: unknown;
+        cause?: unknown;
+      };
+      if (record.code === "ENOSPC") return true;
+      if (
+        typeof record.message === "string" &&
+        /\bENOSPC\b|No space left on device/i.test(record.message)
+      ) {
+        return true;
+      }
+      current = record.cause;
+      continue;
+    }
+    if (/\bENOSPC\b|No space left on device/i.test(String(current))) {
+      return true;
+    }
+    break;
+  }
+  return false;
+}
+
+function normalizeBootstrapConnectError(
+  error: unknown,
+  diskSpace: RemoteInstallDiskSpace | null,
+): unknown {
+  if (error instanceof RemoteRuntimeConnectError) return error;
+  if (!isDiskFullError(error)) return error;
+  return diskFullConnectError({
+    detail: error instanceof Error ? error.message : String(error),
+    diskSpace,
+    cause: error,
+  });
+}
+
+function parseAvailableDiskKilobytes(stdout: string): number | null {
+  const lines = stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const fields = lines[index]!.split(/\s+/u);
+    if (fields.length < 6) continue;
+    const availableKb = Number.parseInt(fields[3]!, 10);
+    if (Number.isSafeInteger(availableKb) && availableKb >= 0) {
+      return availableKb;
+    }
+  }
+  return null;
+}
+
+async function preflightRemoteInstallDiskSpace(args: {
+  client: Client;
+  layout: RemoteRuntimeLayout;
+  binaryBytes: number;
+  nativeArchiveBytes: number;
+}): Promise<RemoteInstallDiskSpace | null> {
+  const requiredBytes =
+    args.binaryBytes + args.nativeArchiveBytes * 3 + REMOTE_INSTALL_MARGIN_BYTES;
+  try {
+    const result = await execSsh(
+      args.client,
+      `mkdir -p ${args.layout.homeDirExpr} && df -kP ${args.layout.homeDirExpr}`,
+    );
+    if (result.code !== 0) {
+      console.warn("remote_runtime.disk_preflight_failed", {
+        detail: result.stderr.trim() || result.stdout.trim(),
+      });
+      return null;
+    }
+    const availableKb = parseAvailableDiskKilobytes(result.stdout);
+    if (availableKb == null) {
+      console.warn("remote_runtime.disk_preflight_unparsable", {
+        output: result.stdout.slice(0, 500),
+      });
+      return null;
+    }
+    const diskSpace = {
+      freeBytes: availableKb * 1024,
+      requiredBytes,
+    };
+    if (diskSpace.freeBytes < diskSpace.requiredBytes) {
+      throw diskFullConnectError({
+        detail: `Remote disk preflight reported ${diskSpace.freeBytes} bytes free and ${diskSpace.requiredBytes} bytes required.`,
+        diskSpace,
+      });
+    }
+    return diskSpace;
+  } catch (error) {
+    if (error instanceof RemoteRuntimeConnectError) throw error;
+    console.warn("remote_runtime.disk_preflight_failed", {
+      detail: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
 const REMOTE_ARTIFACT_UPLOAD_TIMEOUT_MS = 10 * 60_000;
 const REMOTE_ARTIFACT_UPLOAD_IDLE_TIMEOUT_MS = 45_000;
 const REMOTE_ARTIFACT_UPLOAD_WATCHDOG_SECONDS = Math.ceil(
@@ -1089,6 +1227,11 @@ async function uploadNativeDepsBundle(
   );
   try {
     await uploadSshFile(client, target, route, connectedConfig, localPath, tempExpr);
+  } catch (error) {
+    await execSsh(client, `rm -f ${tempExpr}`).catch(() => undefined);
+    throw error;
+  }
+  try {
     const extract = await execSsh(
       client,
       [
@@ -1105,7 +1248,11 @@ async function uploadNativeDepsBundle(
       throw new Error(extract.stderr.trim() || "Unable to unpack ADE service native dependencies on the remote machine.");
     }
   } catch (error) {
-    await execSsh(client, `rm -f ${tempExpr}`).catch(() => undefined);
+    await execSsh(
+      client,
+      `rm -f ${tempExpr} ${remoteArchiveExpr}; rm -rf ${layout.runtimeDirExpr}/${archLabel}`,
+      { timeoutMs: 30_000 },
+    ).catch(() => undefined);
     throw error;
   }
 }
@@ -1330,6 +1477,7 @@ export async function bootstrapRemoteRuntime(args: {
     openSshConfig,
   } = await connectSshWithRoute(args.target);
   const uploadConnectionConfig = openSshConfig ?? connectedConfig;
+  let installDiskSpace: RemoteInstallDiskSpace | null = null;
   try {
     const uname = await execSsh(ssh, "uname -sm");
     if (uname.code !== 0) {
@@ -1404,6 +1552,32 @@ export async function bootstrapRemoteRuntime(args: {
       remoteBinaryMatchesLocal,
     }));
 
+    const supportStatus = await readRemoteRuntimeSupportStatus({
+      client: ssh,
+      layout,
+      archLabel: arch.label,
+      appVersion: args.appVersion,
+      checkNativeDeps: Boolean(nativeDepsBundle),
+      checkPtyHostWorker: Boolean(localPtyHostWorkerSha256),
+      localPtyHostWorkerSha256,
+    });
+    const shouldUploadNativeDeps = Boolean(
+      nativeDepsBundle &&
+      (shouldUploadRuntime || !supportStatus.nativeDepsReady),
+    );
+    if (shouldUploadRuntime || shouldUploadNativeDeps) {
+      installDiskSpace = await preflightRemoteInstallDiskSpace({
+        client: ssh,
+        layout,
+        binaryBytes:
+          shouldUploadRuntime && localBinary ? fileSizeBytes(localBinary) : 0,
+        nativeArchiveBytes:
+          shouldUploadNativeDeps && nativeDepsBundle
+            ? fileSizeBytes(nativeDepsBundle)
+            : 0,
+      });
+    }
+
     const uploadBundledRuntime = async (): Promise<void> => {
       if (!localBinary || !localBinarySha256) return;
       await uploadRuntimeBinary(ssh, args.target, connectedRoute, uploadConnectionConfig, layout, localBinary, args.appVersion, localBinarySha256);
@@ -1415,16 +1589,6 @@ export async function bootstrapRemoteRuntime(args: {
     if (shouldUploadRuntime) {
       await uploadBundledRuntime();
     }
-
-    const supportStatus = await readRemoteRuntimeSupportStatus({
-      client: ssh,
-      layout,
-      archLabel: arch.label,
-      appVersion: args.appVersion,
-      checkNativeDeps: Boolean(nativeDepsBundle) && !runtimeUploaded,
-      checkPtyHostWorker: Boolean(localPtyHostWorkerSha256) && !runtimeUploaded,
-      localPtyHostWorkerSha256,
-    });
 
     const ensureNativeDepsReady = async (forceUpload: boolean): Promise<boolean> => {
       if (!nativeDepsBundle) return false;
@@ -1612,7 +1776,7 @@ export async function bootstrapRemoteRuntime(args: {
     };
   } catch (error) {
     ssh.end();
-    throw error;
+    throw normalizeBootstrapConnectError(error, installDiskSpace);
   }
 }
 

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.test.ts
@@ -9,6 +9,7 @@ import type { RuntimeRpcClient } from "./runtimeRpcClient";
 import type { RemoteTargetRegistry } from "./remoteTargetRegistry";
 
 const bootstrapRemoteRuntimeMock = vi.hoisted(() => vi.fn());
+const bootstrapPairedRuntimeMock = vi.hoisted(() => vi.fn());
 const ensureRemoteProjectMock = vi.hoisted(() => vi.fn());
 
 vi.mock("electron", () => ({
@@ -22,7 +23,12 @@ vi.mock("./remoteBootstrap", () => ({
   ensureRemoteProject: ensureRemoteProjectMock,
 }));
 
+vi.mock("./pairedRuntimeBootstrap", () => ({
+  bootstrapPairedRuntime: bootstrapPairedRuntimeMock,
+}));
+
 import { RemoteConnectionPool } from "./remoteConnectionPool";
+import { PairedRuntimeTransportUnavailableError } from "./pairedRuntimeErrors";
 
 type DisconnectListener = (error: Error) => void;
 
@@ -55,6 +61,17 @@ const target: RemoteRuntimeTarget = {
   lastSeenArch: null,
   runtimeBinaryVersion: null,
   lastConnectedAt: null,
+};
+
+const pairedTarget: RemoteRuntimeTarget = {
+  ...target,
+  id: "paired-target-1",
+  transport: "paired",
+  pairedMachine: {
+    hostIdentity: "host-1",
+    machineKey: "machine-1",
+  },
+  sshUser: null,
 };
 
 function connectResult(version: string): RemoteRuntimeConnectResult {
@@ -192,7 +209,100 @@ function closeServer(server: net.Server): Promise<void> {
 describe("RemoteConnectionPool", () => {
   beforeEach(() => {
     bootstrapRemoteRuntimeMock.mockReset();
+    bootstrapPairedRuntimeMock.mockReset();
     ensureRemoteProjectMock.mockReset();
+  });
+
+  it("uses and disposes a port-forward client on the paired transport connection", async () => {
+    const client = createClient();
+    const ensureForward = vi.fn(async () => ({
+      remoteHost: "127.0.0.1",
+      remotePort: 4173,
+      localHost: "127.0.0.1" as const,
+      localPort: 43111,
+      localUrl: "http://127.0.0.1:43111",
+      createdAt: 10,
+      lastUsedAt: 11,
+    }));
+    const dispose = vi.fn();
+    bootstrapPairedRuntimeMock.mockResolvedValueOnce({
+      client,
+      transport: { connection: { endpoint: "ws://studio.local:8787/" } },
+      portForwardClient: { ensureForward, dispose },
+      result: {
+        ...connectResult("1.0.0"),
+        target: pairedTarget,
+        route: {
+          kind: "lan",
+          endpoint: "ws://studio.local:8787/",
+          latencyMs: 2,
+        },
+      },
+    });
+
+    const pool = new RemoteConnectionPool({} as RemoteTargetRegistry, "1.0.0");
+    await pool.connect(pairedTarget);
+    await expect(pool.ensureLocalPortForward(pairedTarget.id, {
+      remotePort: 4173,
+      label: "Preview",
+    })).resolves.toEqual({
+      targetId: pairedTarget.id,
+      remoteHost: "127.0.0.1",
+      remotePort: 4173,
+      localHost: "127.0.0.1",
+      localPort: 43111,
+      localUrl: "http://127.0.0.1:43111",
+      label: "Preview",
+      createdAt: 10,
+      lastUsedAt: 11,
+    });
+
+    await pool.disconnect(pairedTarget.id);
+    expect(ensureForward).toHaveBeenCalledWith("127.0.0.1", 4173);
+    expect(dispose).toHaveBeenCalledWith(false);
+  });
+
+  it("falls back to SSH when the paired host lacks rpcChannel support", async () => {
+    bootstrapPairedRuntimeMock.mockRejectedValueOnce(
+      new PairedRuntimeTransportUnavailableError(
+        "The paired machine does not advertise runtime RPC support.",
+      ),
+    );
+    const client = createClient();
+    bootstrapRemoteRuntimeMock.mockResolvedValueOnce({
+      client,
+      ssh: createSsh(),
+      result: { ...connectResult("1.0.0"), target: pairedTarget },
+    });
+
+    const pool = new RemoteConnectionPool({} as RemoteTargetRegistry, "1.0.0");
+    await expect(pool.connect(pairedTarget)).resolves.toMatchObject({
+      target: { id: pairedTarget.id },
+      version: "1.0.0",
+    });
+    expect(bootstrapPairedRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(bootstrapRemoteRuntimeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to SSH when every paired WebSocket dial fails", async () => {
+    bootstrapPairedRuntimeMock.mockRejectedValueOnce(
+      new PairedRuntimeTransportUnavailableError(
+        "Failed to connect to sync endpoint: ECONNREFUSED.",
+      ),
+    );
+    bootstrapRemoteRuntimeMock.mockResolvedValueOnce({
+      client: createClient(),
+      ssh: createSsh(),
+      result: { ...connectResult("1.0.0"), target: pairedTarget },
+    });
+
+    const pool = new RemoteConnectionPool({} as RemoteTargetRegistry, "1.0.0");
+    await expect(pool.connect(pairedTarget)).resolves.toMatchObject({
+      target: { id: pairedTarget.id },
+    });
+    expect(bootstrapRemoteRuntimeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ target: pairedTarget }),
+    );
   });
 
   it("evicts cached entries after the RPC client disconnects", async () => {

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.test.ts
@@ -278,6 +278,42 @@ describe("RemoteConnectionPool", () => {
     expect(dispose).toHaveBeenCalledWith(false);
   });
 
+  it("closes a paired RPC transport exactly once when client failure evicts it", async () => {
+    const client = createClient();
+    const dispose = vi.fn();
+    bootstrapPairedRuntimeMock.mockResolvedValueOnce({
+      client,
+      transport: { connection: { endpoint: "ws://studio.local:8787/" } },
+      portForwardClient: { ensureForward: vi.fn(), dispose },
+      result: {
+        ...connectResult("1.0.0"),
+        target: pairedTarget,
+        route: {
+          kind: "lan",
+          endpoint: "ws://studio.local:8787/",
+          latencyMs: 2,
+        },
+      },
+    });
+
+    const pool = new RemoteConnectionPool({} as RemoteTargetRegistry, "1.0.0");
+    const onEvicted = vi.fn();
+    pool.onEntryEvicted(onEvicted);
+    await pool.connect(pairedTarget);
+
+    client.emitDisconnect(new Error("Remote ADE service timed out waiting for method projects.list (5000ms)."));
+    await Promise.resolve();
+
+    expect(client.close).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledWith(false);
+    expect(onEvicted).toHaveBeenCalledTimes(1);
+
+    await pool.disconnect(pairedTarget.id);
+    expect(client.close).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to SSH when the paired host lacks rpcChannel support", async () => {
     bootstrapPairedRuntimeMock.mockRejectedValueOnce(
       new PairedRuntimeTransportUnavailableError(

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.test.ts
@@ -11,6 +11,7 @@ import type { RemoteTargetRegistry } from "./remoteTargetRegistry";
 const bootstrapRemoteRuntimeMock = vi.hoisted(() => vi.fn());
 const bootstrapPairedRuntimeMock = vi.hoisted(() => vi.fn());
 const ensureRemoteProjectMock = vi.hoisted(() => vi.fn());
+const getSshHostKeyTrustForTargetMock = vi.hoisted(() => vi.fn());
 
 vi.mock("electron", () => ({
   app: {
@@ -25,6 +26,10 @@ vi.mock("./remoteBootstrap", () => ({
 
 vi.mock("./pairedRuntimeBootstrap", () => ({
   bootstrapPairedRuntime: bootstrapPairedRuntimeMock,
+}));
+
+vi.mock("./sshTransport", () => ({
+  getSshHostKeyTrustForTarget: getSshHostKeyTrustForTargetMock,
 }));
 
 import { RemoteConnectionPool } from "./remoteConnectionPool";
@@ -75,6 +80,12 @@ const pairedTarget: RemoteRuntimeTarget = {
     machineKey: "machine-1",
   },
   sshUser: null,
+  routes: [{
+    hostname: "studio.local",
+    port: 22,
+    source: "bonjour",
+    lastSucceededAt: null,
+  }],
 };
 
 function connectResult(version: string): RemoteRuntimeConnectResult {
@@ -214,6 +225,8 @@ describe("RemoteConnectionPool", () => {
     bootstrapRemoteRuntimeMock.mockReset();
     bootstrapPairedRuntimeMock.mockReset();
     ensureRemoteProjectMock.mockReset();
+    getSshHostKeyTrustForTargetMock.mockReset();
+    getSshHostKeyTrustForTargetMock.mockResolvedValue({ state: "trusted" });
   });
 
   it("uses and disposes a port-forward client on the paired transport connection", async () => {
@@ -288,6 +301,7 @@ describe("RemoteConnectionPool", () => {
   });
 
   it("re-throws a paired compatibility error when the target has no SSH routes", async () => {
+    const pairedWithoutSshRoutes = { ...pairedTarget, routes: [] };
     bootstrapPairedRuntimeMock.mockRejectedValueOnce(
       new PairedRuntimeCompatibilityError(
         "The paired machine runs an older ADE runtime.",
@@ -295,21 +309,24 @@ describe("RemoteConnectionPool", () => {
     );
 
     const pool = new RemoteConnectionPool({} as RemoteTargetRegistry, "1.0.0");
-    await expect(pool.connect(pairedTarget)).rejects.toBeInstanceOf(
+    await expect(pool.connect(pairedWithoutSshRoutes)).rejects.toBeInstanceOf(
       PairedRuntimeCompatibilityError,
     );
     expect(bootstrapPairedRuntimeMock).toHaveBeenCalledTimes(1);
     expect(bootstrapRemoteRuntimeMock).not.toHaveBeenCalled();
   });
 
-  it("falls back to SSH on a paired compatibility error when the target has usable SSH routes", async () => {
+  it("uses preserved paired-target SSH credentials during compatibility fallback", async () => {
     const pairedWithSshRoutes: RemoteRuntimeTarget = {
       ...pairedTarget,
       id: "paired-ssh-target-1",
+      sshUser: "fallback-user",
+      port: 2201,
+      sshKeyPath: "/keys/fallback_ed25519",
       routes: [
         {
           hostname: "studio.local",
-          port: 22,
+          port: 2201,
           source: "manual",
           lastSucceededAt: null,
         },
@@ -332,7 +349,15 @@ describe("RemoteConnectionPool", () => {
     });
     expect(bootstrapPairedRuntimeMock).toHaveBeenCalledTimes(1);
     expect(bootstrapRemoteRuntimeMock).toHaveBeenCalledWith(
-      expect.objectContaining({ target: pairedWithSshRoutes }),
+      expect.objectContaining({
+        target: expect.objectContaining({
+          id: pairedWithSshRoutes.id,
+          hostname: "studio.local",
+          sshUser: "fallback-user",
+          port: 2201,
+          sshKeyPath: "/keys/fallback_ed25519",
+        }),
+      }),
     );
   });
 
@@ -353,8 +378,73 @@ describe("RemoteConnectionPool", () => {
       target: { id: pairedTarget.id },
     });
     expect(bootstrapRemoteRuntimeMock).toHaveBeenCalledWith(
-      expect.objectContaining({ target: pairedTarget }),
+      expect.objectContaining({
+        target: expect.objectContaining({
+          id: pairedTarget.id,
+          hostname: "studio.local",
+        }),
+      }),
     );
+  });
+
+  it("surfaces SSH trust required only after the paired route fails", async () => {
+    const trustStatus = {
+      state: "needs_trust" as const,
+      targetId: pairedTarget.id,
+      host: "studio.local",
+      port: 22,
+      route: pairedTarget.routes![0]!,
+      keyType: "ssh-ed25519",
+      fingerprintSha256: "SHA256:paired-fallback",
+      knownHostsPath: "/home/test/.ssh/known_hosts",
+    };
+    bootstrapPairedRuntimeMock.mockRejectedValueOnce(
+      new PairedRuntimeTransportUnavailableError("Paired route is offline."),
+    );
+    getSshHostKeyTrustForTargetMock.mockResolvedValueOnce(trustStatus);
+
+    const pool = new RemoteConnectionPool({} as RemoteTargetRegistry, "1.0.0");
+    await expect(pool.connect(pairedTarget)).rejects.toMatchObject({
+      name: "PairedRuntimeSshTrustRequiredError",
+      trustStatus,
+    });
+
+    expect(getSshHostKeyTrustForTargetMock).toHaveBeenCalledTimes(1);
+    expect(bootstrapRemoteRuntimeMock).not.toHaveBeenCalled();
+  });
+
+  it("does not treat a relay-only paired target as SSH-capable", async () => {
+    const relayOnlyTarget: RemoteRuntimeTarget = {
+      ...pairedTarget,
+      id: "relay-only-target",
+      hostname: "relay.example.test",
+      routes: [{
+        hostname: "relay.example.test",
+        port: null,
+        source: "manual",
+        lastSucceededAt: null,
+      }],
+    };
+    const pairedError = new PairedRuntimeTransportUnavailableError(
+      "Relay route is offline.",
+    );
+    bootstrapPairedRuntimeMock.mockRejectedValueOnce(pairedError);
+    const pairedStore = {
+      getForReference: vi.fn(() => ({
+        endpoints: ["wss://relay.example.test/connect/machine-1"],
+        relayUrl: "wss://relay.example.test/connect/machine-1",
+      })),
+    };
+
+    const pool = new RemoteConnectionPool(
+      {} as RemoteTargetRegistry,
+      "1.0.0",
+      pairedStore as any,
+    );
+    await expect(pool.connect(relayOnlyTarget)).rejects.toBe(pairedError);
+
+    expect(getSshHostKeyTrustForTargetMock).not.toHaveBeenCalled();
+    expect(bootstrapRemoteRuntimeMock).not.toHaveBeenCalled();
   });
 
   it("evicts cached entries after the RPC client disconnects", async () => {
@@ -570,12 +660,14 @@ describe("RemoteConnectionPool", () => {
         pool as unknown as {
           entries: Map<string, Promise<{
             client: FakeRuntimeRpcClient;
+            transport: "ssh";
             ssh: FakeSshClient;
             result: RemoteRuntimeConnectResult;
           }>>;
         }
       ).entries.set(target.id, Promise.resolve({
         client: secondClient,
+        transport: "ssh",
         ssh: secondSsh,
         result: connectResult("1.0.1"),
       }));

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.test.ts
@@ -28,7 +28,10 @@ vi.mock("./pairedRuntimeBootstrap", () => ({
 }));
 
 import { RemoteConnectionPool } from "./remoteConnectionPool";
-import { PairedRuntimeTransportUnavailableError } from "./pairedRuntimeErrors";
+import {
+  PairedRuntimeCompatibilityError,
+  PairedRuntimeTransportUnavailableError,
+} from "./pairedRuntimeErrors";
 
 type DisconnectListener = (error: Error) => void;
 
@@ -282,6 +285,55 @@ describe("RemoteConnectionPool", () => {
     });
     expect(bootstrapPairedRuntimeMock).toHaveBeenCalledTimes(1);
     expect(bootstrapRemoteRuntimeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-throws a paired compatibility error when the target has no SSH routes", async () => {
+    bootstrapPairedRuntimeMock.mockRejectedValueOnce(
+      new PairedRuntimeCompatibilityError(
+        "The paired machine runs an older ADE runtime.",
+      ),
+    );
+
+    const pool = new RemoteConnectionPool({} as RemoteTargetRegistry, "1.0.0");
+    await expect(pool.connect(pairedTarget)).rejects.toBeInstanceOf(
+      PairedRuntimeCompatibilityError,
+    );
+    expect(bootstrapPairedRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(bootstrapRemoteRuntimeMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to SSH on a paired compatibility error when the target has usable SSH routes", async () => {
+    const pairedWithSshRoutes: RemoteRuntimeTarget = {
+      ...pairedTarget,
+      id: "paired-ssh-target-1",
+      routes: [
+        {
+          hostname: "studio.local",
+          port: 22,
+          source: "manual",
+          lastSucceededAt: null,
+        },
+      ],
+    };
+    bootstrapPairedRuntimeMock.mockRejectedValueOnce(
+      new PairedRuntimeCompatibilityError(
+        "The paired machine runs an older ADE runtime.",
+      ),
+    );
+    bootstrapRemoteRuntimeMock.mockResolvedValueOnce({
+      client: createClient(),
+      ssh: createSsh(),
+      result: { ...connectResult("1.0.0"), target: pairedWithSshRoutes },
+    });
+
+    const pool = new RemoteConnectionPool({} as RemoteTargetRegistry, "1.0.0");
+    await expect(pool.connect(pairedWithSshRoutes)).resolves.toMatchObject({
+      target: { id: pairedWithSshRoutes.id },
+    });
+    expect(bootstrapPairedRuntimeMock).toHaveBeenCalledTimes(1);
+    expect(bootstrapRemoteRuntimeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ target: pairedWithSshRoutes }),
+    );
   });
 
   it("falls back to SSH when every paired WebSocket dial fails", async () => {

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.ts
@@ -21,7 +21,10 @@ import { bootstrapRemoteRuntime, ensureRemoteProject } from "./remoteBootstrap";
 import type { RemoteTargetRegistry } from "./remoteTargetRegistry";
 import { isRetryableRemoteAction } from "./retryableRemoteActions";
 import { bootstrapPairedRuntime } from "./pairedRuntimeBootstrap";
-import { PairedRuntimeTransportUnavailableError } from "./pairedRuntimeErrors";
+import {
+  PairedRuntimeCompatibilityError,
+  PairedRuntimeTransportUnavailableError,
+} from "./pairedRuntimeErrors";
 import {
   DesktopPairedMachineStore,
 } from "./syncPairedMachineStore";
@@ -158,6 +161,16 @@ function normalizeForwardPort(value: unknown): number {
 
 function portForwardKey(targetId: string, remoteHost: string, remotePort: number): string {
   return `${targetId}\0${remoteHost}\0${remotePort}`;
+}
+
+/**
+ * Whether the target carries SSH connection details we can fall back to when a
+ * paired bootstrap fails. Paired targets created through the registry force
+ * `sshUser` to null, so their only SSH signal is discovered `routes`; older or
+ * dual records may still carry an explicit `sshUser`.
+ */
+function targetHasUsableSshRoutes(target: RemoteRuntimeTarget): boolean {
+  return Boolean(target.sshUser?.trim()) || (target.routes?.length ?? 0) > 0;
 }
 
 function destroyAcceptedSocket(socket: net.Socket, error: Error): void {
@@ -362,7 +375,18 @@ export class RemoteConnectionPool {
           result: paired.result,
         };
       } catch (error) {
-        if (!(error instanceof PairedRuntimeTransportUnavailableError)) {
+        // Transport-unavailable (host doesn't advertise the runtime channel, or
+        // every WebSocket dial failed) always falls through to SSH. A
+        // compatibility failure (the remote runtime is too old for the paired
+        // protocol) only falls back when the target also carries usable SSH
+        // routes — otherwise there is nothing to fall back to and the clear
+        // compatibility error must reach the caller instead of a confusing SSH
+        // failure.
+        const canFallBackToSsh =
+          error instanceof PairedRuntimeTransportUnavailableError
+          || (error instanceof PairedRuntimeCompatibilityError
+            && targetHasUsableSshRoutes(target));
+        if (!canFallBackToSsh) {
           throw error;
         }
       }

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.ts
@@ -23,23 +23,31 @@ import { isRetryableRemoteAction } from "./retryableRemoteActions";
 import { bootstrapPairedRuntime } from "./pairedRuntimeBootstrap";
 import {
   PairedRuntimeCompatibilityError,
+  PairedRuntimeSshTrustRequiredError,
   PairedRuntimeTransportUnavailableError,
 } from "./pairedRuntimeErrors";
 import {
   DesktopPairedMachineStore,
 } from "./syncPairedMachineStore";
 import type { SyncPortForwardClient } from "./syncPortForwardClient";
-import type { SyncRuntimeTransport } from "./syncRuntimeTransport";
+import { classifyPairedRuntimeEndpoint } from "./pairedRuntimeRoutes";
+import { getSshHostKeyTrustForTarget } from "./sshTransport";
 
-type PoolEntry = {
+type PoolEntryBase = {
   client: RuntimeRpcClient;
-  transport: "ssh" | "paired";
-  ssh?: Client;
-  pairedTransport?: SyncRuntimeTransport;
-  pairedPortForwardClient?: SyncPortForwardClient;
   result: RemoteRuntimeConnectResult;
   dispose?: (closeClient: boolean, notify?: boolean) => void | Promise<void>;
 };
+
+type PoolEntry =
+  | (PoolEntryBase & {
+      transport: "ssh";
+      ssh: Client;
+    })
+  | (PoolEntryBase & {
+      transport: "paired";
+      pairedPortForwardClient: SyncPortForwardClient;
+    });
 
 type LocalPortForwardEntry = RemoteRuntimePortForward & {
   server: net.Server;
@@ -51,14 +59,16 @@ function closePoolEntryResources(
   forceSshDestroy = false,
 ): void {
   try {
-    entry.pairedPortForwardClient?.dispose(false);
+    if (entry.transport === "paired") {
+      entry.pairedPortForwardClient.dispose(false);
+    }
   } catch {}
   if (closeClient) {
     try {
       entry.client.close();
     } catch {}
   }
-  if (entry.ssh) {
+  if (entry.transport === "ssh") {
     try {
       entry.ssh.end();
     } catch {}
@@ -163,14 +173,35 @@ function portForwardKey(targetId: string, remoteHost: string, remotePort: number
   return `${targetId}\0${remoteHost}\0${remotePort}`;
 }
 
-/**
- * Whether the target carries SSH connection details we can fall back to when a
- * paired bootstrap fails. Paired targets created through the registry force
- * `sshUser` to null, so their only SSH signal is discovered `routes`; older or
- * dual records may still carry an explicit `sshUser`.
- */
-function targetHasUsableSshRoutes(target: RemoteRuntimeTarget): boolean {
-  return Boolean(target.sshUser?.trim()) || (target.routes?.length ?? 0) > 0;
+/** Builds an SSH-only view of a paired target from explicit, non-relay routes. */
+function pairedSshFallbackTarget(
+  target: RemoteRuntimeTarget,
+  pairedStore: DesktopPairedMachineStore,
+): RemoteRuntimeTarget | null {
+  const credentials = target.pairedMachine
+    ? pairedStore.getForReference(target.pairedMachine)
+    : null;
+  const relayHosts = new Set<string>();
+  for (const endpoint of credentials?.endpoints ?? []) {
+    try {
+      if (classifyPairedRuntimeEndpoint(endpoint, credentials?.relayUrl) === "relay") {
+        relayHosts.add(new URL(endpoint).hostname.toLowerCase());
+      }
+    } catch {
+      // Invalid endpoints are already ignored by the paired-machine store.
+    }
+  }
+  const routes = (target.routes ?? []).filter(
+    (route) => !relayHosts.has(route.hostname.trim().toLowerCase()),
+  );
+  const primary = routes[0];
+  if (!primary) return null;
+  return {
+    ...target,
+    hostname: primary.hostname,
+    port: primary.port ?? target.port,
+    routes,
+  };
 }
 
 function destroyAcceptedSocket(socket: net.Socket, error: Error): void {
@@ -359,6 +390,7 @@ export class RemoteConnectionPool {
   }
 
   private async bootstrapTarget(target: RemoteRuntimeTarget): Promise<PoolEntry> {
+    let sshTarget = target;
     if (target.transport === "paired") {
       try {
         const paired = await bootstrapPairedRuntime({
@@ -370,30 +402,30 @@ export class RemoteConnectionPool {
         return {
           client: paired.client,
           transport: "paired",
-          pairedTransport: paired.transport,
           pairedPortForwardClient: paired.portForwardClient,
           result: paired.result,
         };
       } catch (error) {
-        // Transport-unavailable (host doesn't advertise the runtime channel, or
-        // every WebSocket dial failed) always falls through to SSH. A
-        // compatibility failure (the remote runtime is too old for the paired
-        // protocol) only falls back when the target also carries usable SSH
-        // routes — otherwise there is nothing to fall back to and the clear
-        // compatibility error must reach the caller instead of a confusing SSH
-        // failure.
-        const canFallBackToSsh =
+        // Paired transport and compatibility failures fall through only when
+        // discovery or the user supplied an explicit non-relay SSH route.
+        const fallbackTarget = pairedSshFallbackTarget(target, this.pairedStore);
+        const canFallBackToSsh = fallbackTarget != null && (
           error instanceof PairedRuntimeTransportUnavailableError
-          || (error instanceof PairedRuntimeCompatibilityError
-            && targetHasUsableSshRoutes(target));
+          || error instanceof PairedRuntimeCompatibilityError
+        );
         if (!canFallBackToSsh) {
           throw error;
+        }
+        sshTarget = fallbackTarget;
+        const trustStatus = await getSshHostKeyTrustForTarget(sshTarget);
+        if (trustStatus.state !== "trusted") {
+          throw new PairedRuntimeSshTrustRequiredError(trustStatus);
         }
       }
     }
 
     const ssh = await bootstrapRemoteRuntime({
-      target,
+      target: sshTarget,
       registry: this.registry,
       resourcesPath: process.resourcesPath ?? app.getAppPath(),
       appVersion: this.appVersion,
@@ -541,7 +573,7 @@ export class RemoteConnectionPool {
           );
           return;
         }
-        if (!activeEntry.ssh) {
+        if (activeEntry.transport !== "ssh") {
           destroyAcceptedSocket(socket, new Error("The active SSH transport is unavailable."));
           return;
         }
@@ -1040,8 +1072,10 @@ export class RemoteConnectionPool {
     };
 
     entry.client.onDisconnect((error) => evict(false, true, error));
-    entry.ssh?.once("close", () => evict(true));
-    entry.ssh?.once("error", (error) => evict(true, true, error instanceof Error ? error : new Error(String(error))));
+    if (entry.transport === "ssh") {
+      entry.ssh.once("close", () => evict(true));
+      entry.ssh.once("error", (error) => evict(true, true, error instanceof Error ? error : new Error(String(error))));
+    }
     entry.dispose = evict;
   }
 

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.ts
@@ -20,10 +20,20 @@ import type { RuntimeRpcClient } from "./runtimeRpcClient";
 import { bootstrapRemoteRuntime, ensureRemoteProject } from "./remoteBootstrap";
 import type { RemoteTargetRegistry } from "./remoteTargetRegistry";
 import { isRetryableRemoteAction } from "./retryableRemoteActions";
+import { bootstrapPairedRuntime } from "./pairedRuntimeBootstrap";
+import { PairedRuntimeTransportUnavailableError } from "./pairedRuntimeErrors";
+import {
+  DesktopPairedMachineStore,
+} from "./syncPairedMachineStore";
+import type { SyncPortForwardClient } from "./syncPortForwardClient";
+import type { SyncRuntimeTransport } from "./syncRuntimeTransport";
 
 type PoolEntry = {
   client: RuntimeRpcClient;
-  ssh: Client;
+  transport: "ssh" | "paired";
+  ssh?: Client;
+  pairedTransport?: SyncRuntimeTransport;
+  pairedPortForwardClient?: SyncPortForwardClient;
   result: RemoteRuntimeConnectResult;
   dispose?: (closeClient: boolean, notify?: boolean) => void | Promise<void>;
 };
@@ -37,18 +47,23 @@ function closePoolEntryResources(
   closeClient: boolean,
   forceSshDestroy = false,
 ): void {
+  try {
+    entry.pairedPortForwardClient?.dispose(false);
+  } catch {}
   if (closeClient) {
     try {
       entry.client.close();
     } catch {}
   }
-  try {
-    entry.ssh.end();
-  } catch {}
-  if (forceSshDestroy) {
+  if (entry.ssh) {
     try {
-      (entry.ssh as unknown as { destroy?: () => void }).destroy?.();
+      entry.ssh.end();
     } catch {}
+    if (forceSshDestroy) {
+      try {
+        (entry.ssh as unknown as { destroy?: () => void }).destroy?.();
+      } catch {}
+    }
   }
 }
 
@@ -262,6 +277,7 @@ export class RemoteConnectionPool {
   constructor(
     private readonly registry: RemoteTargetRegistry,
     private readonly appVersion: string,
+    private readonly pairedStore: DesktopPairedMachineStore = new DesktopPairedMachineStore(),
   ) {}
 
   async connect(
@@ -292,15 +308,25 @@ export class RemoteConnectionPool {
     } else {
       this.assertConnectNotBackingOff(target.id);
     }
-    const pending = bootstrapRemoteRuntime({
-      target,
-      registry: this.registry,
-      resourcesPath: process.resourcesPath ?? app.getAppPath(),
-      appVersion: this.appVersion,
-    });
+    const pending = this.bootstrapTarget(target);
     let entryPromise: Promise<PoolEntry>;
-    entryPromise = pending.then(({ client, ssh, result }) => {
-      const entry = { client, ssh, result };
+    entryPromise = pending.then(async (entry) => {
+      if (entry.result.route && entry.result.route.latencyMs == null) {
+        const startedAt = Date.now();
+        try {
+          await entry.client.call("ping", {}, { timeoutMs: 5_000 });
+          entry.result = {
+            ...entry.result,
+            route: {
+              ...entry.result.route,
+              latencyMs: Math.max(0, Date.now() - startedAt),
+            },
+          };
+        } catch {
+          // Latency is optional. Connection lifecycle listeners below still
+          // evict the entry if the probe exposed a dead transport.
+        }
+      }
       this.clearUnsupportedOptionalActionsForTarget(target.id);
       this.connectFailureBackoffByTargetId.delete(target.id);
       this.resolvedEntryPromises.add(entryPromise);
@@ -317,6 +343,43 @@ export class RemoteConnectionPool {
       this.noteConnectFailure(target.id, error);
       throw error;
     }
+  }
+
+  private async bootstrapTarget(target: RemoteRuntimeTarget): Promise<PoolEntry> {
+    if (target.transport === "paired") {
+      try {
+        const paired = await bootstrapPairedRuntime({
+          target,
+          registry: this.registry,
+          pairedStore: this.pairedStore,
+          appVersion: this.appVersion,
+        });
+        return {
+          client: paired.client,
+          transport: "paired",
+          pairedTransport: paired.transport,
+          pairedPortForwardClient: paired.portForwardClient,
+          result: paired.result,
+        };
+      } catch (error) {
+        if (!(error instanceof PairedRuntimeTransportUnavailableError)) {
+          throw error;
+        }
+      }
+    }
+
+    const ssh = await bootstrapRemoteRuntime({
+      target,
+      registry: this.registry,
+      resourcesPath: process.resourcesPath ?? app.getAppPath(),
+      appVersion: this.appVersion,
+    });
+    return {
+      client: ssh.client,
+      transport: "ssh",
+      ssh: ssh.ssh,
+      result: ssh.result,
+    };
   }
 
   async projects(targetId: string): Promise<unknown> {
@@ -393,6 +456,27 @@ export class RemoteConnectionPool {
   ): Promise<RemoteRuntimePortForward> {
     const remoteHost = normalizeForwardRemoteHost(request.remoteHost);
     const remotePort = normalizeForwardPort(request.remotePort);
+    const activeEntry = await this.requireEntry(targetId);
+    if (activeEntry.transport === "paired") {
+      const forwardClient = activeEntry.pairedPortForwardClient;
+      if (!forwardClient) {
+        throw new Error("The paired runtime port-forward client is unavailable.");
+      }
+      const forward = await forwardClient.ensureForward(remoteHost, remotePort);
+      return {
+        targetId,
+        remoteHost: forward.remoteHost,
+        remotePort: forward.remotePort,
+        localHost: forward.localHost,
+        localPort: forward.localPort,
+        localUrl: forward.localUrl,
+        label: typeof request.label === "string" && request.label.trim()
+          ? request.label.trim()
+          : null,
+        createdAt: forward.createdAt,
+        lastUsedAt: forward.lastUsedAt,
+      };
+    }
     const key = portForwardKey(targetId, remoteHost, remotePort);
     const existing = this.localPortForwards.get(key);
     if (existing) {
@@ -431,6 +515,10 @@ export class RemoteConnectionPool {
             socket,
             error instanceof Error ? error : new Error(String(error)),
           );
+          return;
+        }
+        if (!activeEntry.ssh) {
+          destroyAcceptedSocket(socket, new Error("The active SSH transport is unavailable."));
           return;
         }
         activeEntry.ssh.forwardOut(
@@ -928,8 +1016,8 @@ export class RemoteConnectionPool {
     };
 
     entry.client.onDisconnect((error) => evict(false, true, error));
-    entry.ssh.once("close", () => evict(true));
-    entry.ssh.once("error", (error) => evict(true, true, error instanceof Error ? error : new Error(String(error))));
+    entry.ssh?.once("close", () => evict(true));
+    entry.ssh?.once("error", (error) => evict(true, true, error instanceof Error ? error : new Error(String(error))));
     entry.dispose = evict;
   }
 

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionPool.ts
@@ -1071,7 +1071,7 @@ export class RemoteConnectionPool {
       if (notify) notifyEvicted(error);
     };
 
-    entry.client.onDisconnect((error) => evict(false, true, error));
+    entry.client.onDisconnect((error) => evict(entry.transport === "paired", true, error));
     if (entry.transport === "ssh") {
       entry.ssh.once("close", () => evict(true));
       entry.ssh.once("error", (error) => evict(true, true, error instanceof Error ? error : new Error(String(error))));

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.test.ts
@@ -49,6 +49,97 @@ function connectResult(
 }
 
 describe("RemoteConnectionService", () => {
+  it("upgrades a discovered ADE sync machine to a paired-first target", () => {
+    const savedCredentials = {
+      version: 1 as const,
+      hostIdentity: {
+        deviceId: "host-1",
+        siteId: "site-1",
+        name: "Studio",
+        platform: "macOS" as const,
+        deviceType: "desktop" as const,
+      },
+      deviceId: "desktop-1",
+      siteId: "desktop-site-1",
+      deviceName: "Laptop",
+      secret: "secret",
+      dpopPrivateKey: "private",
+      dpopPublicKey: "public",
+      endpoints: ["wss://relay.example/connect/machine-1"],
+      machineKey: "machine-1",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const registry = {
+      list: vi.fn(() => []),
+      get: vi.fn(() => null),
+      save: vi.fn((input) => ({
+        id: "paired-target-1",
+        ...input,
+        sshUser: input.sshUser ?? null,
+        port: input.port ?? null,
+        sshKeyPath: input.sshKeyPath ?? null,
+        lastSeenArch: null,
+        runtimeBinaryVersion: null,
+        lastConnectedAt: null,
+      })),
+    } as unknown as RemoteTargetRegistry;
+    const pool = {
+      onEntryEvicted: vi.fn(() => () => {}),
+    } as unknown as RemoteConnectionPool;
+    const pairedStore = {
+      get: vi.fn(() => savedCredentials),
+      save: vi.fn((value) => value),
+    };
+    const service = new RemoteConnectionService(
+      registry,
+      pool,
+      {},
+      pairedStore as any,
+    );
+
+    const target = service.saveTarget({
+      name: "Studio",
+      hostname: "studio.example.ts.net",
+      sshUser: null,
+      port: null,
+      sshKeyPath: null,
+      routes: [],
+    }, {
+      id: "host-1::service",
+      serviceName: "ADE Sync Studio",
+      machineName: "Studio",
+      hostIdentity: "host-1",
+      hostName: "studio.local",
+      port: 8787,
+      addresses: ["192.168.1.20", "100.70.0.2"],
+      primaryRoute: "192.168.1.20",
+      tailscaleAddress: "100.70.0.2",
+      runtimeKind: "brain",
+      runtimeVersion: "1.0.0",
+      connectable: true,
+      projectIds: [],
+      projectCount: 0,
+      lastSeenAt: 1,
+    });
+
+    expect(target).toMatchObject({
+      transport: "paired",
+      pairedMachine: {
+        hostIdentity: "host-1",
+        machineKey: "machine-1",
+      },
+    });
+    expect(pairedStore.save).toHaveBeenCalledWith(expect.objectContaining({
+      endpoints: [
+        "ws://192.168.1.20:8787/",
+        "ws://100.70.0.2:8787/",
+        "ws://studio.local:8787/",
+        "wss://relay.example/connect/machine-1",
+      ],
+    }));
+  });
+
   it("stores structured connect errors with bounded detail and legacy text", async () => {
     const remote = target("disk-full", null);
     const registry = {
@@ -84,6 +175,35 @@ describe("RemoteConnectionService", () => {
     expect(status.lastErrorInfo?.detail?.length).toBeLessThanOrEqual(4_000);
     expect(status.lastErrorInfo?.detail).toContain("truncated");
     expect(status.lastErrorInfo?.detail).toContain("TAIL");
+  });
+
+  it("publishes the transport route and connect latency in connection status", async () => {
+    const remote = target("route-status", null);
+    const registry = {
+      list: vi.fn(() => [remote]),
+      get: vi.fn((id: string) => id === remote.id ? remote : null),
+    } as unknown as RemoteTargetRegistry;
+    const pool = {
+      connect: vi.fn(async () => ({
+        ...connectResult(remote),
+        route: {
+          kind: "tailnet" as const,
+          endpoint: "ws://100.70.0.2:8787/",
+          latencyMs: 12,
+        },
+      })),
+      disconnect: vi.fn(),
+      onEntryEvicted: vi.fn(() => () => {}),
+    } as unknown as RemoteConnectionPool;
+
+    const service = new RemoteConnectionService(registry, pool);
+    await service.connect(remote.id, { explicit: true });
+
+    expect(service.snapshot().connections[0]?.route).toEqual({
+      kind: "tailnet",
+      endpoint: "ws://100.70.0.2:8787/",
+      latencyMs: 12,
+    });
   });
 
   it("caps legacy connection error text at 500 characters", async () => {

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.test.ts
@@ -3,6 +3,7 @@ import type {
   RemoteRuntimeConnectResult,
   RemoteRuntimeTarget,
 } from "../../../shared/types/remoteRuntime";
+import { RemoteRuntimeConnectError } from "../../../shared/types/remoteRuntime";
 import type { RemoteConnectionPool } from "./remoteConnectionPool";
 import { RemoteConnectionService } from "./remoteConnectionService";
 import type { RemoteTargetRegistry } from "./remoteTargetRegistry";
@@ -48,6 +49,62 @@ function connectResult(
 }
 
 describe("RemoteConnectionService", () => {
+  it("stores structured connect errors with bounded detail and legacy text", async () => {
+    const remote = target("disk-full", null);
+    const registry = {
+      list: vi.fn(() => [remote]),
+      get: vi.fn((id: string) => id === remote.id ? remote : null),
+    } as unknown as RemoteTargetRegistry;
+    const error = new RemoteRuntimeConnectError({
+      kind: "disk_full",
+      message: "The remote machine is out of disk space. Free up space and try again.",
+      detail: `tar: No space left on device\n${"x".repeat(6_000)}TAIL`,
+      freeBytes: 1024,
+      requiredBytes: 2048,
+    });
+    const pool = {
+      connect: vi.fn(async () => {
+        throw error;
+      }),
+      disconnect: vi.fn(),
+      onEntryEvicted: vi.fn(() => () => {}),
+    } as unknown as RemoteConnectionPool;
+
+    const service = new RemoteConnectionService(registry, pool);
+    await expect(service.connect(remote.id, { explicit: true })).rejects.toBe(error);
+
+    const status = service.snapshot().connections[0]!;
+    expect(status.lastError).toBe(error.message);
+    expect(status.lastErrorInfo).toMatchObject({
+      kind: "disk_full",
+      message: error.message,
+      freeBytes: 1024,
+      requiredBytes: 2048,
+    });
+    expect(status.lastErrorInfo?.detail?.length).toBeLessThanOrEqual(4_000);
+    expect(status.lastErrorInfo?.detail).toContain("truncated");
+    expect(status.lastErrorInfo?.detail).toContain("TAIL");
+  });
+
+  it("caps legacy connection error text at 500 characters", async () => {
+    const remote = target("verbose-error", null);
+    const registry = {
+      list: vi.fn(() => [remote]),
+      get: vi.fn((id: string) => id === remote.id ? remote : null),
+    } as unknown as RemoteTargetRegistry;
+    const pool = {
+      connect: vi.fn(async () => {
+        throw new Error("x".repeat(1_000));
+      }),
+      disconnect: vi.fn(),
+      onEntryEvicted: vi.fn(() => () => {}),
+    } as unknown as RemoteConnectionPool;
+
+    const service = new RemoteConnectionService(registry, pool);
+    await expect(service.connect(remote.id, { explicit: true })).rejects.toThrow();
+    expect(service.snapshot().connections[0]?.lastError?.length).toBe(500);
+  });
+
   it("only autoconnects targets that have connected successfully before", async () => {
     const neverConnected = target("never-connected", null);
     const previouslyConnected = target("previously-connected", 1_700_000_000);

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   RemoteRuntimeConnectResult,
   RemoteRuntimeTarget,
@@ -7,6 +7,15 @@ import { RemoteRuntimeConnectError } from "../../../shared/types/remoteRuntime";
 import type { RemoteConnectionPool } from "./remoteConnectionPool";
 import { RemoteConnectionService } from "./remoteConnectionService";
 import type { RemoteTargetRegistry } from "./remoteTargetRegistry";
+import { PairedRuntimeSshTrustRequiredError } from "./pairedRuntimeErrors";
+
+const getSshHostKeyTrustForTargetMock = vi.hoisted(() => vi.fn());
+const trustSshHostKeyForTargetMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./sshTransport", () => ({
+  getSshHostKeyTrustForTarget: getSshHostKeyTrustForTargetMock,
+  trustSshHostKeyForTarget: trustSshHostKeyForTargetMock,
+}));
 
 function target(
   id: string,
@@ -49,6 +58,11 @@ function connectResult(
 }
 
 describe("RemoteConnectionService", () => {
+  beforeEach(() => {
+    getSshHostKeyTrustForTargetMock.mockReset();
+    trustSshHostKeyForTargetMock.mockReset();
+  });
+
   it("upgrades a discovered ADE sync machine to a paired-first target", () => {
     const savedCredentials = {
       version: 1 as const,
@@ -223,6 +237,96 @@ describe("RemoteConnectionService", () => {
     const service = new RemoteConnectionService(registry, pool);
     await expect(service.connect(remote.id, { explicit: true })).rejects.toThrow();
     expect(service.snapshot().connections[0]?.lastError?.length).toBe(500);
+  });
+
+  it("exposes paired fallback SSH trust only after connect fails and clears it after trust", async () => {
+    const remote: RemoteRuntimeTarget = {
+      ...target("paired-trust", null),
+      transport: "paired",
+      pairedMachine: { hostIdentity: "host-1", machineKey: "machine-1" },
+      routes: [{
+        hostname: "studio.local",
+        port: 22,
+        source: "bonjour",
+        lastSucceededAt: null,
+      }],
+    };
+    const trustStatus = {
+      state: "needs_trust" as const,
+      targetId: remote.id,
+      host: "studio.local",
+      port: 22,
+      route: remote.routes![0]!,
+      keyType: "ssh-ed25519",
+      fingerprintSha256: "SHA256:paired-fallback",
+      knownHostsPath: "/home/test/.ssh/known_hosts",
+    };
+    const registry = {
+      list: vi.fn(() => [remote]),
+      get: vi.fn((id: string) => id === remote.id ? remote : null),
+    } as unknown as RemoteTargetRegistry;
+    const pool = {
+      connect: vi.fn(async () => {
+        throw new PairedRuntimeSshTrustRequiredError(trustStatus);
+      }),
+      disconnect: vi.fn(),
+      onEntryEvicted: vi.fn(() => () => {}),
+    } as unknown as RemoteConnectionPool;
+    const credentials = { hostIdentity: { deviceId: "host-1" } };
+    const pairedStore = {
+      get: vi.fn(() => credentials),
+      getForReference: vi.fn(() => credentials),
+    };
+    trustSshHostKeyForTargetMock.mockResolvedValue({
+      trusted: true,
+      identity: trustStatus,
+    });
+    const service = new RemoteConnectionService(registry, pool, {}, pairedStore as any);
+
+    await expect(service.getSshHostKeyTrust(remote.id)).resolves.toEqual({ state: "trusted" });
+    expect(getSshHostKeyTrustForTargetMock).not.toHaveBeenCalled();
+
+    await expect(service.connect(remote.id, { explicit: true })).rejects.toBeInstanceOf(
+      PairedRuntimeSshTrustRequiredError,
+    );
+    await expect(service.getSshHostKeyTrust(remote.id)).resolves.toEqual(trustStatus);
+
+    await service.trustSshHostKey(remote.id, trustStatus.fingerprintSha256);
+    expect(trustSshHostKeyForTargetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostname: "studio.local",
+        routes: [trustStatus.route],
+      }),
+      trustStatus.fingerprintSha256,
+    );
+    await expect(service.getSshHostKeyTrust(remote.id)).resolves.toEqual({ state: "trusted" });
+  });
+
+  it("forgets paired credentials when removing a paired target", () => {
+    const remote: RemoteRuntimeTarget = {
+      ...target("paired-remove", null),
+      transport: "paired",
+      pairedMachine: { hostIdentity: "host-1", machineKey: "machine-1" },
+    };
+    const credentials = { hostIdentity: { deviceId: "host-1" } };
+    const registry = {
+      list: vi.fn(() => []),
+      get: vi.fn((id: string) => id === remote.id ? remote : null),
+      remove: vi.fn(() => true),
+    } as unknown as RemoteTargetRegistry;
+    const pool = {
+      disconnect: vi.fn(),
+      onEntryEvicted: vi.fn(() => () => {}),
+    } as unknown as RemoteConnectionPool;
+    const pairedStore = {
+      getForReference: vi.fn(() => credentials),
+      remove: vi.fn(() => true),
+    };
+    const service = new RemoteConnectionService(registry, pool, {}, pairedStore as any);
+
+    expect(service.removeTarget(remote.id)).toBe(true);
+    expect(pairedStore.getForReference).toHaveBeenCalledWith(remote.pairedMachine);
+    expect(pairedStore.remove).toHaveBeenCalledWith("host-1");
   });
 
   it("only autoconnects targets that have connected successfully before", async () => {

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts
@@ -47,6 +47,7 @@ import {
   syncEndpointsForDiscoveredRuntime,
 } from "./discoveredPairedRuntime";
 import { runRemoteRuntimeDoctor } from "./connectionDoctor";
+import { PairedRuntimeSshTrustRequiredError } from "./pairedRuntimeErrors";
 import {
   getSshHostKeyTrustForTarget,
   trustSshHostKeyForTarget,
@@ -160,6 +161,10 @@ export class RemoteConnectionService {
   private readonly automaticReconnectPausedTargetIds = new Set<string>();
   private readonly disconnectGenerationByTargetId = new Map<string, number>();
   private readonly latencyProbeTargetIds = new Set<string>();
+  private readonly pairedFallbackSshTrustByTargetId = new Map<
+    string,
+    Extract<RemoteRuntimeSshHostKeyTrustStatus, { state: "needs_trust" | "changed" }>
+  >();
   private readonly listeners = new Set<
     (snapshot: RemoteRuntimeConnectionSnapshot) => void
   >();
@@ -329,10 +334,7 @@ export class RemoteConnectionService {
         }
       : null);
     const credentials = target?.pairedMachine
-      ? this.pairedStore.get(target.pairedMachine.hostIdentity)
-        ?? (target.pairedMachine.machineKey
-          ? this.pairedStore.get(target.pairedMachine.machineKey)
-          : null)
+      ? this.pairedStore.getForReference(target.pairedMachine)
       : this.pairedStore.get(discoveredMachine?.hostIdentity ?? id);
     if (!target && !credentials) {
       throw new Error("Remote target or paired machine was not found.");
@@ -341,11 +343,19 @@ export class RemoteConnectionService {
   }
 
   removeTarget(targetId: string): boolean {
+    const target = this.registry.get(targetId);
+    const pairedCredentials = target?.transport === "paired" && target.pairedMachine
+      ? this.pairedStore.getForReference(target.pairedMachine)
+      : null;
     this.disconnect(targetId);
     this.manuallyDisconnectedTargetIds.delete(targetId);
     this.clearAutomaticReconnectBudget(targetId);
+    this.pairedFallbackSshTrustByTargetId.delete(targetId);
     this.statusById.delete(targetId);
     const removed = this.registry.remove(targetId);
+    if (removed && pairedCredentials) {
+      this.pairedStore.remove(pairedCredentials.hostIdentity.deviceId);
+    }
     this.emit();
     return removed;
   }
@@ -354,6 +364,8 @@ export class RemoteConnectionService {
     targetId: string,
   ): Promise<RemoteRuntimeSshHostKeyTrustStatus> {
     const target = this.requireTarget(targetId);
+    const pairedFallbackTrust = this.pairedFallbackSshTrustByTargetId.get(targetId);
+    if (pairedFallbackTrust) return pairedFallbackTrust;
     // Paired targets attempt authenticated WebSocket RPC first. Avoid asking
     // for SSH trust before that path is known to be unavailable.
     const pairedReference = target.pairedMachine;
@@ -375,10 +387,22 @@ export class RemoteConnectionService {
   ): Promise<RemoteRuntimeTrustSshHostKeyResult> {
     const fingerprint = fingerprintSha256.trim();
     if (!fingerprint) throw new Error("SSH host key fingerprint is required.");
-    return await trustSshHostKeyForTarget(
-      this.requireTarget(targetId),
+    const target = this.requireTarget(targetId);
+    const cached = this.pairedFallbackSshTrustByTargetId.get(targetId);
+    const trustTarget = cached
+      ? {
+          ...target,
+          hostname: cached.route.hostname,
+          port: cached.route.port ?? target.port,
+          routes: [cached.route],
+        }
+      : target;
+    const result = await trustSshHostKeyForTarget(
+      trustTarget,
       fingerprint,
     );
+    this.pairedFallbackSshTrustByTargetId.delete(targetId);
+    return result;
   }
 
   snapshot(): RemoteRuntimeConnectionSnapshot {
@@ -445,6 +469,7 @@ export class RemoteConnectionService {
     options: RemoteConnectionConnectOptions = {},
   ): Promise<RemoteRuntimeConnectResult> {
     const target = this.requireTarget(targetId);
+    this.pairedFallbackSshTrustByTargetId.delete(target.id);
     const explicit = options.explicit === true;
     if (explicit) {
       this.manuallyDisconnectedTargetIds.delete(target.id);
@@ -492,10 +517,14 @@ export class RemoteConnectionService {
         lastError: null,
       });
       this.clearAutomaticReconnectBudget(connectedResult.target.id);
+      this.pairedFallbackSshTrustByTargetId.delete(connectedResult.target.id);
       return connectedResult;
     } catch (error) {
       if (!this.isDisconnectGenerationCurrent(target.id, disconnectGeneration)) {
         throw error;
+      }
+      if (error instanceof PairedRuntimeSshTrustRequiredError) {
+        this.pairedFallbackSshTrustByTargetId.set(target.id, error.trustStatus);
       }
       const lastError = explicit
         ? errorMessage(error)
@@ -817,6 +846,7 @@ export class RemoteConnectionService {
     this.stopAutoconnect();
     this.pool.dispose();
     this.latencyProbeTargetIds.clear();
+    this.pairedFallbackSshTrustByTargetId.clear();
     this.listeners.clear();
   }
 

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts
@@ -13,6 +13,10 @@ import type {
   RemoteRuntimeConnectionStatus,
   RemoteRuntimeConnectErrorInfo,
   RemoteRuntimeConnectResult,
+  RemoteRuntimeDiscoveredMachine,
+  RemoteRuntimeDoctorResult,
+  RemoteRuntimePairWithMachineArgs,
+  RemoteRuntimePairWithMachineResult,
   RemoteRuntimeBufferedEvent,
   RemoteRuntimePortForward,
   RemoteRuntimePortForwardRequest,
@@ -26,6 +30,7 @@ import type {
   RemoteRuntimeTargetInput,
   RemoteRuntimeTrustSshHostKeyResult,
 } from "../../../shared/types";
+import type { DesktopPairedMachineCredentials } from "../../../shared/types/pairedRuntime";
 import {
   capRemoteRuntimeErrorDetail,
   RemoteRuntimeConnectError,
@@ -33,6 +38,15 @@ import {
 import { coerceProjects } from "./remoteBootstrap";
 import type { RemoteConnectionPool } from "./remoteConnectionPool";
 import type { RemoteTargetRegistry } from "./remoteTargetRegistry";
+import { DesktopPairedMachineStore } from "./syncPairedMachineStore";
+import { parseRemoteRuntimePairingInput } from "./pairingInput";
+import {
+  findDiscoveredRuntimeForTargetInput,
+  sshRoutesForDiscoveredRuntime,
+  sshRoutesForPairedEndpoints,
+  syncEndpointsForDiscoveredRuntime,
+} from "./discoveredPairedRuntime";
+import { runRemoteRuntimeDoctor } from "./connectionDoctor";
 import {
   getSshHostKeyTrustForTarget,
   trustSshHostKeyForTarget,
@@ -43,6 +57,7 @@ type StatusPatch = Partial<Omit<RemoteRuntimeConnectionStatus, "target">>;
 type RemoteConnectionServiceOptions = {
   autoconnectIntervalMs?: number;
   pingTimeoutMs?: number;
+  appVersion?: string;
 };
 
 type RemoteConnectionDisconnectOptions = {
@@ -107,7 +122,7 @@ function automaticReconnectStoppedMessage(): string {
 
 function isImplicitConnectionFailure(error: unknown): boolean {
   const message = errorMessage(error);
-  return /remote (?:runtime|ADE service) connection (?:closed|failed|was interrupted)|remote ADE service connection failed recently|timed out waiting for method|stream closed|channel closed|connection lost|socket closed|ECONNRESET|ECONNABORTED|EPIPE|ENOTCONN|remote target is not connected|SSH server at .* closed the connection before ADE could finish the SSH handshake|Timed out while waiting for the SSH handshake/i.test(
+  return /remote (?:runtime|ADE service) connection (?:closed|failed|was interrupted)|remote ADE service connection failed recently|sync (?:connection|websocket|endpoint).*(?:closed|failed)|timed out waiting for method|stream closed|channel closed|connection lost|socket closed|ECONNRESET|ECONNABORTED|EPIPE|ENOTCONN|remote target is not connected|SSH server at .* closed the connection before ADE could finish the SSH handshake|Timed out while waiting for the SSH handshake/i.test(
     message,
   );
 }
@@ -144,6 +159,7 @@ export class RemoteConnectionService {
   >();
   private readonly automaticReconnectPausedTargetIds = new Set<string>();
   private readonly disconnectGenerationByTargetId = new Map<string, number>();
+  private readonly latencyProbeTargetIds = new Set<string>();
   private readonly listeners = new Set<
     (snapshot: RemoteRuntimeConnectionSnapshot) => void
   >();
@@ -153,6 +169,7 @@ export class RemoteConnectionService {
     private readonly registry: RemoteTargetRegistry,
     private readonly pool: RemoteConnectionPool,
     private readonly options: RemoteConnectionServiceOptions = {},
+    private readonly pairedStore: DesktopPairedMachineStore = new DesktopPairedMachineStore(),
   ) {
     this.pool.onEntryEvicted((targetId, error) => {
       const current = this.statusById.get(targetId);
@@ -175,10 +192,152 @@ export class RemoteConnectionService {
     return this.registry.get(targetId);
   }
 
-  saveTarget(input: RemoteRuntimeTargetInput): RemoteRuntimeTarget {
-    const target = this.registry.save(input);
+  saveTarget(
+    input: RemoteRuntimeTargetInput,
+    discoveredMachine?: RemoteRuntimeDiscoveredMachine | null,
+  ): RemoteRuntimeTarget {
+    let normalizedInput = input;
+    if (discoveredMachine?.hostIdentity) {
+      const paired = this.pairedStore.get(discoveredMachine.hostIdentity);
+      const discoveredEndpoints = syncEndpointsForDiscoveredRuntime(discoveredMachine);
+      if (paired && discoveredEndpoints.length > 0) {
+        const saved = discoveredEndpoints.some((endpoint) => !paired.endpoints.includes(endpoint))
+          ? this.pairedStore.save({
+              ...paired,
+              endpoints: [...discoveredEndpoints, ...paired.endpoints],
+            })
+          : paired;
+        normalizedInput = {
+          ...input,
+          transport: "paired",
+          pairedMachine: {
+            hostIdentity: saved.hostIdentity.deviceId,
+            machineKey: saved.machineKey ?? null,
+          },
+        };
+      }
+    }
+    const target = this.registry.save(normalizedInput);
     this.mergeStatus(target.id, { state: "idle", lastError: null });
     return target;
+  }
+
+  rememberDiscoveredMachines(machines: RemoteRuntimeDiscoveredMachine[]): void {
+    for (const machine of machines) {
+      if (!machine.hostIdentity) continue;
+      const paired = this.pairedStore.get(machine.hostIdentity);
+      if (!paired) continue;
+      const endpoints = syncEndpointsForDiscoveredRuntime(machine);
+      if (endpoints.length === 0) continue;
+      if (endpoints.every((endpoint) => paired.endpoints.includes(endpoint))) {
+        continue;
+      }
+      this.pairedStore.save({
+        ...paired,
+        endpoints: [...endpoints, ...paired.endpoints],
+      });
+    }
+  }
+
+  findDiscoveredTargetInputMatch(
+    machines: RemoteRuntimeDiscoveredMachine[],
+    input: RemoteRuntimeTargetInput,
+  ): RemoteRuntimeDiscoveredMachine | null {
+    return findDiscoveredRuntimeForTargetInput(machines, input);
+  }
+
+  async pairWithMachine(
+    args: RemoteRuntimePairWithMachineArgs,
+  ): Promise<RemoteRuntimePairWithMachineResult> {
+    const parsed = parseRemoteRuntimePairingInput(args.input);
+    let paired: DesktopPairedMachineCredentials | null = null;
+    const failures: string[] = [];
+    for (const endpoint of parsed.endpoints) {
+      try {
+        paired = await this.pairedStore.pairWithMachine(
+          endpoint,
+          args.pin,
+          args.deviceName,
+          { appVersion: this.options.appVersion },
+        );
+        if (paired.hostIdentity.deviceId !== parsed.hostIdentity.deviceId) {
+          this.pairedStore.remove(paired.hostIdentity.deviceId);
+          throw new Error(
+            `Pairing endpoint identity mismatch (expected ${parsed.hostIdentity.deviceId}, received ${paired.hostIdentity.deviceId}).`,
+          );
+        }
+        break;
+      } catch (error) {
+        paired = null;
+        failures.push(`${endpoint}: ${errorMessage(error)}`);
+      }
+    }
+    if (!paired) {
+      throw new Error(`Could not pair with the ADE machine. ${failures.join("; ")}`);
+    }
+    paired = this.pairedStore.save({
+      ...paired,
+      endpoints: [...parsed.endpoints, ...paired.endpoints],
+      relayUrl: parsed.relayUrl ?? paired.relayUrl ?? null,
+    });
+    const sshRoutes = sshRoutesForPairedEndpoints(parsed.endpoints);
+    const fallbackHostname = (() => {
+      try {
+        return new URL(parsed.endpoints[0]!).hostname;
+      } catch {
+        return parsed.hostIdentity.name;
+      }
+    })();
+    const target = this.saveTarget({
+      name: parsed.machineName ?? paired.hostIdentity.name,
+      hostname: sshRoutes[0]?.hostname ?? fallbackHostname,
+      transport: "paired",
+      pairedMachine: {
+        hostIdentity: paired.hostIdentity.deviceId,
+        machineKey: paired.machineKey ?? null,
+      },
+      sshUser: null,
+      port: null,
+      sshKeyPath: null,
+      routes: sshRoutes,
+    });
+    return { targetId: target.id };
+  }
+
+  async runDoctor(
+    targetIdOrMachineId: string,
+    discoveredMachine?: RemoteRuntimeDiscoveredMachine | null,
+  ): Promise<RemoteRuntimeDoctorResult> {
+    const id = targetIdOrMachineId.trim();
+    if (!id) throw new Error("A remote target or paired machine id is required.");
+    const savedTarget = this.registry.get(id);
+    const discoveredRoutes = discoveredMachine
+      ? sshRoutesForDiscoveredRuntime(discoveredMachine)
+      : [];
+    const target: RemoteRuntimeTarget | null = savedTarget ?? (discoveredMachine && discoveredRoutes[0]
+      ? {
+          id: discoveredMachine.id,
+          name: discoveredMachine.machineName,
+          hostname: discoveredRoutes[0].hostname,
+          sshUser: null,
+          port: discoveredRoutes[0].port,
+          sshKeyPath: null,
+          routes: discoveredRoutes,
+          lastSeenArch: null,
+          runtimeBinaryVersion: discoveredMachine.runtimeVersion,
+          lastConnectedAt: null,
+        }
+      : null);
+    const credentials = target?.pairedMachine
+      ? this.pairedStore.get(target.pairedMachine.hostIdentity)
+        ?? (target.pairedMachine.machineKey
+          ? this.pairedStore.get(target.pairedMachine.machineKey)
+          : null)
+      : this.pairedStore.get(discoveredMachine?.hostIdentity ?? id);
+    if (!target && !credentials) {
+      throw new Error("Remote target or paired machine was not found.");
+    }
+    return await runRemoteRuntimeDoctor({ target, credentials });
   }
 
   removeTarget(targetId: string): boolean {
@@ -194,7 +353,20 @@ export class RemoteConnectionService {
   async getSshHostKeyTrust(
     targetId: string,
   ): Promise<RemoteRuntimeSshHostKeyTrustStatus> {
-    return await getSshHostKeyTrustForTarget(this.requireTarget(targetId));
+    const target = this.requireTarget(targetId);
+    // Paired targets attempt authenticated WebSocket RPC first. Avoid asking
+    // for SSH trust before that path is known to be unavailable.
+    const pairedReference = target.pairedMachine;
+    const hasPairedCredentials = pairedReference
+      ? this.pairedStore.get(pairedReference.hostIdentity)
+        ?? (pairedReference.machineKey
+          ? this.pairedStore.get(pairedReference.machineKey)
+          : null)
+      : null;
+    if (target.transport === "paired" && hasPairedCredentials) {
+      return { state: "trusted" };
+    }
+    return await getSshHostKeyTrustForTarget(target);
   }
 
   async trustSshHostKey(
@@ -219,6 +391,7 @@ export class RemoteConnectionService {
           state: status.state ?? (target.lastConnectedAt ? "idle" : "idle"),
           arch: status.arch ?? target.lastSeenArch,
           version: status.version ?? target.runtimeBinaryVersion,
+          ...(status.route ? { route: status.route } : {}),
           ...(status.capabilities ? { capabilities: status.capabilities } : {}),
           ...(status.compatibilityWarnings
             ? { compatibilityWarnings: status.compatibilityWarnings }
@@ -310,6 +483,7 @@ export class RemoteConnectionService {
         state: "connected",
         arch: connectedResult.arch,
         version: connectedResult.version,
+        route: connectedResult.route,
         capabilities: connectedResult.capabilities,
         compatibilityWarnings: connectedResult.compatibilityWarnings,
         projects: connectedResult.projects,
@@ -642,6 +816,7 @@ export class RemoteConnectionService {
   dispose(): void {
     this.stopAutoconnect();
     this.pool.dispose();
+    this.latencyProbeTargetIds.clear();
     this.listeners.clear();
   }
 
@@ -655,6 +830,9 @@ export class RemoteConnectionService {
       const status = this.statusById.get(target.id);
       if (status?.state === "connecting") continue;
       if (status?.state === "connected") {
+        if (this.latencyProbeTargetIds.has(target.id)) continue;
+        this.latencyProbeTargetIds.add(target.id);
+        const startedAt = Date.now();
         try {
           await this.pool.callMachineForTarget(
             target,
@@ -664,6 +842,15 @@ export class RemoteConnectionService {
               timeoutMs: options.pingTimeoutMs,
             },
           );
+          const currentRoute = this.statusById.get(target.id)?.route;
+          if (currentRoute) {
+            this.mergeStatus(target.id, {
+              route: {
+                ...currentRoute,
+                latencyMs: Math.max(0, Date.now() - startedAt),
+              },
+            });
+          }
           continue;
         } catch {
           this.pool.disconnect(target.id);
@@ -671,6 +858,8 @@ export class RemoteConnectionService {
             state: "error",
             lastError: "Remote ADE service connection was interrupted.",
           });
+        } finally {
+          this.latencyProbeTargetIds.delete(target.id);
         }
       }
       void this.connect(target.id).catch(() => {});

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts
@@ -11,6 +11,7 @@ import type {
   RemoteRuntimeConnectionSnapshot,
   RemoteRuntimeConnectionState,
   RemoteRuntimeConnectionStatus,
+  RemoteRuntimeConnectErrorInfo,
   RemoteRuntimeConnectResult,
   RemoteRuntimeBufferedEvent,
   RemoteRuntimePortForward,
@@ -24,6 +25,10 @@ import type {
   RemoteRuntimeTarget,
   RemoteRuntimeTargetInput,
   RemoteRuntimeTrustSshHostKeyResult,
+} from "../../../shared/types";
+import {
+  capRemoteRuntimeErrorDetail,
+  RemoteRuntimeConnectError,
 } from "../../../shared/types";
 import { coerceProjects } from "./remoteBootstrap";
 import type { RemoteConnectionPool } from "./remoteConnectionPool";
@@ -49,9 +54,51 @@ type RemoteConnectionConnectOptions = {
 };
 
 const AUTOMATIC_RECONNECT_FAILURE_LIMIT = 10;
+const MAX_LAST_ERROR_CHARS = 500;
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function capLastError(message: string): string {
+  if (message.length <= MAX_LAST_ERROR_CHARS) return message;
+  return `${message.slice(0, MAX_LAST_ERROR_CHARS - 1)}…`;
+}
+
+function errorInfo(
+  error: unknown,
+  messageOverride?: string,
+): RemoteRuntimeConnectErrorInfo {
+  const structured = error instanceof RemoteRuntimeConnectError
+    ? error.info
+    : null;
+  const rawMessage = messageOverride ?? structured?.message ?? errorMessage(error);
+  const message = capLastError(rawMessage);
+  if (structured) {
+    return {
+      ...structured,
+      message,
+      ...(structured.detail
+        ? { detail: capRemoteRuntimeErrorDetail(structured.detail) }
+        : {}),
+    };
+  }
+  return {
+    kind: "generic",
+    message,
+    detail: capRemoteRuntimeErrorDetail(errorMessage(error)),
+  };
+}
+
+function errorStatusPatch(
+  error: unknown,
+  messageOverride?: string,
+): Pick<RemoteRuntimeConnectionStatus, "lastError" | "lastErrorInfo"> {
+  const info = errorInfo(error, messageOverride);
+  return {
+    lastError: info.message,
+    lastErrorInfo: info,
+  };
 }
 
 function automaticReconnectStoppedMessage(): string {
@@ -114,7 +161,7 @@ export class RemoteConnectionService {
       }
       this.mergeStatus(targetId, {
         state: "error",
-        lastError: errorMessage(error),
+        ...errorStatusPatch(error),
         lastAttemptedAt: Date.now(),
       });
     });
@@ -178,6 +225,7 @@ export class RemoteConnectionService {
             : {}),
           projects: status.projects ?? [],
           lastError: status.lastError ?? null,
+          lastErrorInfo: status.lastErrorInfo ?? null,
           lastAttemptedAt: status.lastAttemptedAt ?? null,
           connectedAt: status.connectedAt ?? target.lastConnectedAt,
         };
@@ -280,7 +328,7 @@ export class RemoteConnectionService {
         : this.recordImplicitFailure(target.id, error);
       this.mergeStatus(target.id, {
         state: "error",
-        lastError,
+        ...errorStatusPatch(error, lastError),
         lastAttemptedAt: Date.now(),
       });
       throw error;
@@ -701,7 +749,10 @@ export class RemoteConnectionService {
     if (!isImplicitConnectionFailure(error)) return;
     this.mergeStatus(targetId, {
       state: "error",
-      lastError: this.recordImplicitFailure(targetId, error),
+      ...errorStatusPatch(
+        error,
+        this.recordImplicitFailure(targetId, error),
+      ),
       lastAttemptedAt: Date.now(),
     });
   }
@@ -749,10 +800,34 @@ export class RemoteConnectionService {
 
   private mergeStatus(targetId: string, patch: StatusPatch): void {
     const current = this.statusById.get(targetId) ?? {};
+    let normalizedPatch = patch;
+    if (Object.prototype.hasOwnProperty.call(patch, "lastError")) {
+      if (patch.lastError == null) {
+        normalizedPatch = { ...patch, lastError: null, lastErrorInfo: null };
+      } else {
+        const lastError = capLastError(patch.lastError);
+        const info = patch.lastErrorInfo ?? {
+          kind: "generic",
+          message: lastError,
+          detail: patch.lastError,
+        };
+        normalizedPatch = {
+          ...patch,
+          lastError,
+          lastErrorInfo: {
+            ...info,
+            message: capLastError(info.message),
+            ...(info.detail
+              ? { detail: capRemoteRuntimeErrorDetail(info.detail) }
+              : {}),
+          },
+        };
+      }
+    }
     this.statusById.set(targetId, {
       ...current,
-      ...patch,
-      state: (patch.state ??
+      ...normalizedPatch,
+      state: (normalizedPatch.state ??
         current.state ??
         "idle") as RemoteRuntimeConnectionState,
     });

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts
@@ -373,10 +373,7 @@ export class RemoteConnectionService {
     // for SSH trust before that path is known to be unavailable.
     const pairedReference = target.pairedMachine;
     const hasPairedCredentials = pairedReference
-      ? this.pairedStore.get(pairedReference.hostIdentity)
-        ?? (pairedReference.machineKey
-          ? this.pairedStore.get(pairedReference.machineKey)
-          : null)
+      ? this.pairedStore.getForReference(pairedReference)
       : null;
     if (target.transport === "paired" && hasPairedCredentials) {
       return { state: "trusted" };

--- a/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts
@@ -263,7 +263,10 @@ export class RemoteConnectionService {
           endpoint,
           args.pin,
           args.deviceName,
-          { appVersion: this.options.appVersion },
+          {
+            appVersion: this.options.appVersion,
+            runtimeHostGrant: parsed.runtimeHostGrant ?? null,
+          },
         );
         if (paired.hostIdentity.deviceId !== parsed.hostIdentity.deviceId) {
           this.pairedStore.remove(paired.hostIdentity.deviceId);

--- a/apps/desktop/src/main/services/remoteRuntime/remoteTargetRegistry.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteTargetRegistry.test.ts
@@ -101,7 +101,7 @@ describe("RemoteTargetRegistry", () => {
     });
   });
 
-  it("round-trips paired targets without SSH credentials", () => {
+  it("round-trips paired targets with SSH fallback credentials preserved", () => {
     const adeHome = fs.mkdtempSync(path.join(os.tmpdir(), "ade-remote-targets-"));
     process.env.ADE_HOME = adeHome;
 
@@ -114,8 +114,9 @@ describe("RemoteTargetRegistry", () => {
         hostIdentity: "host-device-1",
         machineKey: "relay-machine-1",
       },
-      sshUser: "ignored",
-      sshKeyPath: "/ignored/key",
+      sshUser: "admin",
+      port: 22,
+      sshKeyPath: "/Users/admin/.ssh/id_ed25519",
       routes: [{
         hostname: "studio.local",
         port: null,
@@ -130,9 +131,30 @@ describe("RemoteTargetRegistry", () => {
         hostIdentity: "host-device-1",
         machineKey: "relay-machine-1",
       },
-      sshUser: null,
-      sshKeyPath: null,
+      sshUser: "admin",
+      port: 22,
+      sshKeyPath: "/Users/admin/.ssh/id_ed25519",
     });
     expect(new RemoteTargetRegistry().get(target.id)).toEqual(target);
+  });
+
+  it("does not synthesize an SSH route for a relay-only paired target", () => {
+    const adeHome = fs.mkdtempSync(path.join(os.tmpdir(), "ade-remote-targets-"));
+    process.env.ADE_HOME = adeHome;
+
+    const registry = new RemoteTargetRegistry();
+    const target = registry.save({
+      name: "Relay-only Studio",
+      hostname: "relay.example.test",
+      transport: "paired",
+      pairedMachine: {
+        hostIdentity: "host-device-relay",
+        machineKey: "relay-machine-only",
+      },
+      routes: [],
+    });
+
+    expect(target.routes).toEqual([]);
+    expect(new RemoteTargetRegistry().get(target.id)?.routes).toEqual([]);
   });
 });

--- a/apps/desktop/src/main/services/remoteRuntime/remoteTargetRegistry.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteTargetRegistry.test.ts
@@ -100,4 +100,39 @@ describe("RemoteTargetRegistry", () => {
       manuallyDisconnectedAt: 1_700_000_100,
     });
   });
+
+  it("round-trips paired targets without SSH credentials", () => {
+    const adeHome = fs.mkdtempSync(path.join(os.tmpdir(), "ade-remote-targets-"));
+    process.env.ADE_HOME = adeHome;
+
+    const registry = new RemoteTargetRegistry();
+    const target = registry.save({
+      name: "Studio",
+      hostname: "studio.local",
+      transport: "paired",
+      pairedMachine: {
+        hostIdentity: "host-device-1",
+        machineKey: "relay-machine-1",
+      },
+      sshUser: "ignored",
+      sshKeyPath: "/ignored/key",
+      routes: [{
+        hostname: "studio.local",
+        port: null,
+        source: "bonjour",
+        lastSucceededAt: null,
+      }],
+    });
+
+    expect(target).toMatchObject({
+      transport: "paired",
+      pairedMachine: {
+        hostIdentity: "host-device-1",
+        machineKey: "relay-machine-1",
+      },
+      sshUser: null,
+      sshKeyPath: null,
+    });
+    expect(new RemoteTargetRegistry().get(target.id)).toEqual(target);
+  });
 });

--- a/apps/desktop/src/main/services/remoteRuntime/remoteTargetRegistry.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteTargetRegistry.ts
@@ -36,6 +36,7 @@ export function normalizeRemoteTargetRoutes(args: {
   hostname: string;
   port: number | null | undefined;
   routes?: unknown;
+  includePrimary?: boolean;
 }): RemoteRuntimeTargetRoute[] {
   const primaryHostname = args.hostname.trim();
   if (!primaryHostname) return [];
@@ -91,15 +92,17 @@ export function normalizeRemoteTargetRoutes(args: {
     });
   };
 
-  addRoute(
-    {
-      hostname: primaryHostname,
-      port: primaryPort,
-      source: "manual",
-      lastSucceededAt: null,
-    },
-    "manual",
-  );
+  if (args.includePrimary !== false) {
+    addRoute(
+      {
+        hostname: primaryHostname,
+        port: primaryPort,
+        source: "manual",
+        lastSucceededAt: null,
+      },
+      "manual",
+    );
+  }
   if (Array.isArray(args.routes)) {
     for (const route of args.routes) addRoute(route, "manual");
   }
@@ -169,6 +172,9 @@ function coerceTarget(value: unknown): RemoteRuntimeTarget | null {
       hostname,
       port: typeof record.port === "number" ? record.port : null,
       routes: record.routes,
+      includePrimary:
+        transport !== "paired"
+        || (Array.isArray(record.routes) && record.routes.length > 0),
     }),
     lastSeenArch: typeof record.lastSeenArch === "string" && record.lastSeenArch.trim() ? record.lastSeenArch.trim() : null,
     runtimeBinaryVersion: typeof record.runtimeBinaryVersion === "string" && record.runtimeBinaryVersion.trim() ? record.runtimeBinaryVersion.trim() : null,
@@ -192,7 +198,7 @@ export class RemoteTargetRegistry {
     const hostname = input.hostname.trim();
     const transport = input.transport === "paired" ? "paired" : "ssh";
     const pairedMachine = normalizePairedMachineReference(input.pairedMachine);
-    const sshUser = transport === "paired" ? null : input.sshUser?.trim() || null;
+    const sshUser = input.sshUser?.trim() || null;
     if (!hostname) throw new Error("Remote hostname is required.");
     if (transport === "paired" && !pairedMachine) {
       throw new Error("Paired remote targets require a paired-machine reference.");
@@ -208,11 +214,14 @@ export class RemoteTargetRegistry {
       pairedMachine: transport === "paired" ? pairedMachine : null,
       sshUser,
       port: normalizePort(input.port),
-      sshKeyPath: transport === "paired" ? null : input.sshKeyPath?.trim() || null,
+      sshKeyPath: input.sshKeyPath?.trim() || null,
       routes: normalizeRemoteTargetRoutes({
         hostname,
         port: input.port,
         routes: input.routes,
+        includePrimary:
+          transport !== "paired"
+          || (Array.isArray(input.routes) && input.routes.length > 0),
       }),
       lastSeenArch: existing?.lastSeenArch ?? null,
       runtimeBinaryVersion: existing?.runtimeBinaryVersion ?? null,

--- a/apps/desktop/src/main/services/remoteRuntime/remoteTargetRegistry.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/remoteTargetRegistry.ts
@@ -5,6 +5,7 @@ import { resolveMachineAdeLayout } from "../../../../../ade-cli/src/services/pro
 import type {
   RemoteRuntimeTarget,
   RemoteRuntimeTargetInput,
+  RemoteRuntimePairedMachineReference,
   RemoteRuntimeTargetRoute,
   RemoteRuntimeTargetRouteSource,
 } from "../../../shared/types/remoteRuntime";
@@ -109,7 +110,29 @@ function defaultName(input: RemoteRuntimeTargetInput): string {
   return input.name?.trim() || input.hostname.trim();
 }
 
+function normalizePairedMachineReference(
+  value: unknown,
+): RemoteRuntimePairedMachineReference | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const hostIdentity = typeof record.hostIdentity === "string"
+    ? record.hostIdentity.trim()
+    : "";
+  if (!hostIdentity) return null;
+  const machineKey = typeof record.machineKey === "string" && record.machineKey.trim()
+    ? record.machineKey.trim()
+    : null;
+  return { hostIdentity, machineKey };
+}
+
 function stableTargetId(input: RemoteRuntimeTargetInput): string {
+  const pairedMachine = normalizePairedMachineReference(input.pairedMachine);
+  if (input.transport === "paired" && pairedMachine) {
+    return createHash("sha256")
+      .update(`paired:${pairedMachine.hostIdentity}`)
+      .digest("hex")
+      .slice(0, 24);
+  }
   const sshUser = input.sshUser?.trim() ?? "";
   const port = normalizePort(input.port) ?? "";
   return createHash("sha256")
@@ -124,11 +147,21 @@ function coerceTarget(value: unknown): RemoteRuntimeTarget | null {
   const hostname = typeof record.hostname === "string" ? record.hostname.trim() : "";
   const sshUser = typeof record.sshUser === "string" && record.sshUser.trim() ? record.sshUser.trim() : null;
   if (!hostname) return null;
-  const fallbackInput: RemoteRuntimeTargetInput = { hostname, sshUser, port: normalizePort(typeof record.port === "number" ? record.port : null) };
+  const transport = record.transport === "paired" ? "paired" : "ssh";
+  const pairedMachine = normalizePairedMachineReference(record.pairedMachine);
+  const fallbackInput: RemoteRuntimeTargetInput = {
+    hostname,
+    transport,
+    pairedMachine,
+    sshUser,
+    port: normalizePort(typeof record.port === "number" ? record.port : null),
+  };
   return {
     id: typeof record.id === "string" && record.id.trim() ? record.id.trim() : stableTargetId(fallbackInput),
     name: typeof record.name === "string" && record.name.trim() ? record.name.trim() : hostname,
     hostname,
+    transport,
+    pairedMachine: transport === "paired" ? pairedMachine : null,
     sshUser,
     port: normalizePort(typeof record.port === "number" ? record.port : null),
     sshKeyPath: typeof record.sshKeyPath === "string" && record.sshKeyPath.trim() ? record.sshKeyPath.trim() : null,
@@ -157,8 +190,13 @@ export class RemoteTargetRegistry {
 
   save(input: RemoteRuntimeTargetInput): RemoteRuntimeTarget {
     const hostname = input.hostname.trim();
-    const sshUser = input.sshUser?.trim() || null;
+    const transport = input.transport === "paired" ? "paired" : "ssh";
+    const pairedMachine = normalizePairedMachineReference(input.pairedMachine);
+    const sshUser = transport === "paired" ? null : input.sshUser?.trim() || null;
     if (!hostname) throw new Error("Remote hostname is required.");
+    if (transport === "paired" && !pairedMachine) {
+      throw new Error("Paired remote targets require a paired-machine reference.");
+    }
     const file = this.read();
     const id = stableTargetId(input);
     const existing = file.targets.find((target) => target.id === id) ?? null;
@@ -166,9 +204,11 @@ export class RemoteTargetRegistry {
       id,
       name: defaultName(input),
       hostname,
+      transport,
+      pairedMachine: transport === "paired" ? pairedMachine : null,
       sshUser,
       port: normalizePort(input.port),
-      sshKeyPath: input.sshKeyPath?.trim() || null,
+      sshKeyPath: transport === "paired" ? null : input.sshKeyPath?.trim() || null,
       routes: normalizeRemoteTargetRoutes({
         hostname,
         port: input.port,

--- a/apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.test.ts
@@ -18,6 +18,7 @@ describe("runtimeDiscovery", () => {
           deviceName: "Studio",
           runtimeKind: "daemon",
           runtimeVersion: "0.0.0",
+          platform: "macOS",
           projects: "project-a, project-b",
           projectCount: "2",
           host: "192.168.1.42",
@@ -41,6 +42,8 @@ describe("runtimeDiscovery", () => {
       tailscaleAddress: "100.64.0.10",
       runtimeKind: "daemon",
       runtimeVersion: "0.0.0",
+      os: "macOS",
+      connectable: true,
       projectIds: ["project-a", "project-b"],
       projectCount: 2,
       lastSeenAt: 1234,
@@ -108,6 +111,8 @@ describe("runtimeDiscovery", () => {
       tailscaleAddress: "100.64.0.10",
       runtimeKind: "tailscale-peer",
       runtimeVersion: null,
+      os: "macOS",
+      connectable: true,
       projectIds: [],
       projectCount: null,
       lastSeenAt: 9012,
@@ -141,5 +146,49 @@ describe("runtimeDiscovery", () => {
 
     expect(discovered).toHaveLength(1);
     expect(discovered[0]?.machineName).toBe("studio");
+  });
+
+  it("keeps Windows peers visible but marks them unsupported", () => {
+    const discovered = discoveredRuntimesFromTailscaleStatus({
+      Peer: {
+        "nodekey:windows": {
+          ID: "peer-windows",
+          HostName: "build-pc",
+          DNSName: "build-pc.tail000000.ts.net.",
+          OS: "windows",
+          TailscaleIPs: ["100.64.0.12"],
+          Online: true,
+        },
+      },
+    }, 456);
+
+    expect(discovered).toHaveLength(1);
+    expect(discovered[0]).toMatchObject({
+      machineName: "build-pc",
+      os: "windows",
+      connectable: false,
+      unsupportedReason: "Windows machines can't run the ADE remote runtime yet.",
+    });
+  });
+
+  it("marks offline Tailscale peers as unavailable", () => {
+    const discovered = discoveredRuntimesFromTailscaleStatus({
+      Peer: {
+        "nodekey:offline": {
+          ID: "peer-offline",
+          HostName: "sleeping-mac",
+          DNSName: "sleeping-mac.tail000000.ts.net.",
+          OS: "macOS",
+          TailscaleIPs: ["100.64.0.13"],
+          Online: false,
+        },
+      },
+    });
+
+    expect(discovered[0]).toMatchObject({
+      runtimeKind: "tailscale-peer-offline",
+      connectable: false,
+      unsupportedReason: "Offline",
+    });
   });
 });

--- a/apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.test.ts
@@ -2,7 +2,57 @@ import { describe, expect, it } from "vitest";
 import {
   discoveredRuntimeFromBonjourService,
   discoveredRuntimesFromTailscaleStatus,
+  dropSelfDiscoveredMachines,
+  mergeCrossSourceDiscoveredMachines,
 } from "./runtimeDiscovery";
+import type { RemoteRuntimeDiscoveredMachine } from "../../../shared/types/remoteRuntime";
+
+function bonjourMachine(
+  overrides: Partial<RemoteRuntimeDiscoveredMachine> = {},
+): RemoteRuntimeDiscoveredMachine {
+  return {
+    id: "device-123::ADE Sync Studio._ade-sync._tcp.local",
+    serviceName: "ADE Sync Studio",
+    machineName: "Studio",
+    hostIdentity: "device-123",
+    hostName: "studio.local",
+    port: 8787,
+    addresses: ["192.168.1.42", "100.64.0.10"],
+    primaryRoute: "192.168.1.42",
+    tailscaleAddress: "100.64.0.10",
+    runtimeKind: "daemon",
+    runtimeVersion: "1.0.0",
+    connectable: true,
+    projectIds: ["p1"],
+    projectCount: 1,
+    lastSeenAt: 1,
+    ...overrides,
+  };
+}
+
+function tailscalePeerMachine(
+  overrides: Partial<RemoteRuntimeDiscoveredMachine> = {},
+): RemoteRuntimeDiscoveredMachine {
+  return {
+    id: "tailscale:peer-1",
+    serviceName: "Tailscale peer",
+    machineName: "studio",
+    hostIdentity: "peer-1",
+    hostName: "studio",
+    port: 22,
+    addresses: ["100.64.0.10", "studio.tail000000.ts.net"],
+    primaryRoute: "100.64.0.10",
+    tailscaleAddress: "100.64.0.10",
+    runtimeKind: "tailscale-peer",
+    runtimeVersion: null,
+    os: "macOS",
+    connectable: true,
+    projectIds: [],
+    projectCount: null,
+    lastSeenAt: 1,
+    ...overrides,
+  };
+}
 
 describe("runtimeDiscovery", () => {
   it("parses ADE sync Bonjour metadata into a discovered machine", () => {
@@ -169,6 +219,66 @@ describe("runtimeDiscovery", () => {
       connectable: false,
       unsupportedReason: "Windows machines can't run the ADE remote runtime yet.",
     });
+  });
+
+  it("drops this machine's own Bonjour advertisement by local sync device id", () => {
+    const machines = [
+      bonjourMachine({ id: "self::svc", hostIdentity: "self-device" }),
+      bonjourMachine({ id: "other::svc", hostIdentity: "other-device", machineName: "Other" }),
+      tailscalePeerMachine({ hostIdentity: "peer-1" }),
+    ];
+
+    const filtered = dropSelfDiscoveredMachines(machines, "self-device");
+
+    // The self Bonjour row is gone; the Tailscale peer (id space never carries
+    // our own device id) and the other machine survive.
+    expect(filtered.map((machine) => machine.id)).toEqual([
+      "other::svc",
+      "tailscale:peer-1",
+    ]);
+  });
+
+  it("leaves discovery untouched when the local device id is unknown", () => {
+    const machines = [bonjourMachine()];
+    expect(dropSelfDiscoveredMachines(machines, null)).toBe(machines);
+    expect(dropSelfDiscoveredMachines(machines, "  ")).toBe(machines);
+  });
+
+  it("merges a Tailscale peer into the Bonjour machine that shares its address", () => {
+    const merged = mergeCrossSourceDiscoveredMachines([
+      bonjourMachine({ os: undefined, addresses: ["192.168.1.42", "100.64.0.10"] }),
+      tailscalePeerMachine({
+        addresses: ["100.64.0.10", "studio.tail000000.ts.net"],
+      }),
+    ]);
+
+    expect(merged).toHaveLength(1);
+    const machine = merged[0]!;
+    // Keeps the richer Bonjour identity...
+    expect(machine.id).toBe("device-123::ADE Sync Studio._ade-sync._tcp.local");
+    expect(machine.runtimeKind).toBe("daemon");
+    // ...and gains the Tailscale route + reported OS.
+    expect(machine.addresses).toContain("studio.tail000000.ts.net");
+    expect(machine.tailscaleAddress).toBe("100.64.0.10");
+    expect(machine.os).toBe("macOS");
+  });
+
+  it("keeps a Tailscale-only peer that matches no Bonjour machine", () => {
+    const merged = mergeCrossSourceDiscoveredMachines([
+      bonjourMachine({
+        addresses: ["192.168.1.42"],
+        tailscaleAddress: null,
+      }),
+      tailscalePeerMachine({
+        id: "tailscale:peer-solo",
+        machineName: "Laptop",
+        addresses: ["100.99.0.5", "laptop.tail000000.ts.net"],
+        tailscaleAddress: "100.99.0.5",
+      }),
+    ]);
+
+    expect(merged).toHaveLength(2);
+    expect(merged.map((machine) => machine.id)).toContain("tailscale:peer-solo");
   });
 
   it("marks offline Tailscale peers as unavailable", () => {

--- a/apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.test.ts
@@ -131,6 +131,27 @@ describe("runtimeDiscovery", () => {
     });
   });
 
+  it("keeps Windows Bonjour hosts visible but marks them unsupported", () => {
+    const discovered = discoveredRuntimeFromBonjourService({
+      name: "ADE Sync Build PC",
+      host: "build-pc.local",
+      port: 8787,
+      addresses: ["192.168.1.50"],
+      txt: {
+        deviceId: "windows-host",
+        deviceName: "Build PC",
+        platform: "windows",
+      },
+    });
+
+    expect(discovered).toMatchObject({
+      machineName: "Build PC",
+      os: "windows",
+      connectable: false,
+      unsupportedReason: "Windows machines can't run the ADE remote runtime yet.",
+    });
+  });
+
   it("turns Tailscale peers into SSH discovery targets", () => {
     const discovered = discoveredRuntimesFromTailscaleStatus(
       {

--- a/apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.ts
@@ -11,6 +11,7 @@ import { promisify } from "node:util";
 import { Bonjour } from "bonjour-service";
 import { resolveTailscaleCliPath } from "../../../../../ade-cli/src/services/sync/resolveTailscaleCliPath";
 import { resolveMachineAdeLayout } from "../../../../../ade-cli/src/services/projects/machineLayout";
+import { isTailnetHostname } from "../../../shared/tailnet";
 import type {
   RemoteRuntimeDiscoveredMachine,
   RemoteRuntimeDiscoveryDiagnostic,
@@ -23,7 +24,9 @@ const execFileAsync = promisify(execFile);
 
 type BonjourClient = InstanceType<typeof Bonjour>;
 type Browser = ReturnType<BonjourClient["find"]>;
-type BonjourService = Parameters<NonNullable<Parameters<BonjourClient["find"]>[1]>>[0];
+type BonjourService = Parameters<
+  NonNullable<Parameters<BonjourClient["find"]>[1]>
+>[0];
 type BonjourServiceLike = Partial<BonjourService> & {
   rawTxt?: unknown;
 };
@@ -98,15 +101,6 @@ function isLoopbackRoute(host: string): boolean {
   );
 }
 
-function isTailscaleRoute(host: string): boolean {
-  const lower = host.toLowerCase().replace(/\.$/, "");
-  if (lower.endsWith(".ts.net")) return true;
-  const match = /^100\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(lower);
-  if (!match) return false;
-  const second = Number.parseInt(match[1] ?? "", 10);
-  return second >= 64 && second <= 127;
-}
-
 function normalizeTailscaleDnsName(value: unknown): string | null {
   const text = trimmed(value);
   if (!text) return null;
@@ -156,7 +150,7 @@ export function discoveredRuntimeFromBonjourService(
   const announcedAddresses = splitCsv(txt.addresses);
   const tailscaleAddress = firstNonEmpty(
     [txt.tailscaleIp, txt.tailscaleDnsName].filter((value): value is string =>
-      Boolean(value && isTailscaleRoute(value)),
+      Boolean(value && isTailnetHostname(value)),
     ),
   );
   const addresses = orderAddresses(
@@ -169,7 +163,7 @@ export function discoveredRuntimeFromBonjourService(
   );
   const primaryRoute = firstNonEmpty([
     addresses.find(
-      (address) => !isLoopbackRoute(address) && !isTailscaleRoute(address),
+      (address) => !isLoopbackRoute(address) && !isTailnetHostname(address),
     ),
     tailscaleAddress,
     addresses.find((address) => !isLoopbackRoute(address)),
@@ -221,7 +215,8 @@ export function discoveredRuntimesFromTailscaleStatus(
     if (!isSshCapableTailscalePeer(peer.OS)) continue;
     const tailscaleIps = Array.isArray(peer.TailscaleIPs)
       ? peer.TailscaleIPs.map((entry) => trimmed(entry)).filter(
-          (entry): entry is string => Boolean(entry && isTailscaleRoute(entry)),
+          (entry): entry is string =>
+            Boolean(entry && isTailnetHostname(entry)),
         )
       : [];
     const dnsName = normalizeTailscaleDnsName(peer.DNSName);
@@ -308,7 +303,8 @@ export function dropSelfDiscoveredMachines(
   const self = localDeviceId?.trim();
   if (!self) return machines;
   return machines.filter(
-    (machine) => !(machine.hostIdentity && machine.hostIdentity.trim() === self),
+    (machine) =>
+      !(machine.hostIdentity && machine.hostIdentity.trim() === self),
   );
 }
 
@@ -337,7 +333,10 @@ export function mergeCrossSourceDiscoveredMachines(
       addresses: [...machine.addresses],
     };
     merged.push(clone);
-    bonjourHostSets.push({ machine: clone, hosts: discoveredMachineHostSet(clone) });
+    bonjourHostSets.push({
+      machine: clone,
+      hosts: discoveredMachineHostSet(clone),
+    });
   }
 
   for (const machine of machines) {
@@ -382,9 +381,7 @@ function readLocalSyncDeviceId(): string | null {
   }
 }
 
-async function discoverTailscalePeers(
-  timeoutMs = 1_200,
-): Promise<{
+async function discoverTailscalePeers(timeoutMs = 1_200): Promise<{
   machines: RemoteRuntimeDiscoveredMachine[];
   diagnostics: RemoteRuntimeDiscoveryDiagnostic[];
 }> {
@@ -411,8 +408,7 @@ async function discoverTailscalePeers(
     };
     const message = error instanceof Error ? error.message : String(error);
     const timedOut =
-      nodeError.killed === true ||
-      /timed out|timeout|ETIMEDOUT/i.test(message);
+      nodeError.killed === true || /timed out|timeout|ETIMEDOUT/i.test(message);
     const notFound =
       nodeError.code === "ENOENT" ||
       /ENOENT|not found|no such file/i.test(message);

--- a/apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.ts
@@ -1,4 +1,6 @@
 import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import { promisify } from "node:util";
 // Named import: bonjour-service exports the constructor as a named `Bonjour`.
 // A default import (`import Bonjour from …`) survives typecheck (the package
@@ -8,6 +10,7 @@ import { promisify } from "node:util";
 // daemon's syncHostService.ts uses this same named form.
 import { Bonjour } from "bonjour-service";
 import { resolveTailscaleCliPath } from "../../../../../ade-cli/src/services/sync/resolveTailscaleCliPath";
+import { resolveMachineAdeLayout } from "../../../../../ade-cli/src/services/projects/machineLayout";
 import type {
   RemoteRuntimeDiscoveredMachine,
   RemoteRuntimeDiscoveryDiagnostic,
@@ -263,6 +266,122 @@ export function discoveredRuntimesFromTailscaleStatus(
   return discovered;
 }
 
+function normalizeDiscoveryHost(host: string | null | undefined): string {
+  return host?.trim().toLowerCase().replace(/\.$/, "") ?? "";
+}
+
+/**
+ * The set of hostnames a machine can be reached at — its Tailscale address plus
+ * every advertised address. Used to detect when a Bonjour machine and a
+ * Tailscale peer are the same physical machine seen through two discovery
+ * sources.
+ */
+function discoveredMachineHostSet(
+  machine: RemoteRuntimeDiscoveredMachine,
+): Set<string> {
+  const set = new Set<string>();
+  const add = (host: string | null | undefined): void => {
+    const normalized = normalizeDiscoveryHost(host);
+    if (normalized) set.add(normalized);
+  };
+  add(machine.tailscaleAddress);
+  for (const address of machine.addresses) add(address);
+  return set;
+}
+
+function isTailscalePeerMachine(
+  machine: RemoteRuntimeDiscoveredMachine,
+): boolean {
+  return machine.id.startsWith("tailscale:");
+}
+
+/**
+ * Drops this machine's own Bonjour advertisement from the discovery list. The
+ * ADE sync service advertises itself over mDNS with its `deviceId` in the TXT
+ * payload (surfaced as `hostIdentity`); comparing that against the local sync
+ * device id keeps the panel from listing "this Mac" as a connectable target.
+ */
+export function dropSelfDiscoveredMachines(
+  machines: RemoteRuntimeDiscoveredMachine[],
+  localDeviceId: string | null | undefined,
+): RemoteRuntimeDiscoveredMachine[] {
+  const self = localDeviceId?.trim();
+  if (!self) return machines;
+  return machines.filter(
+    (machine) => !(machine.hostIdentity && machine.hostIdentity.trim() === self),
+  );
+}
+
+/**
+ * A machine discovered over BOTH Bonjour and Tailscale currently appears twice
+ * because the two id spaces (`hostIdentity::serviceKey` vs `tailscale:…`) never
+ * collide. When a Tailscale peer's address matches a Bonjour machine's
+ * Tailscale address or any advertised address, they are the same machine: fold
+ * the peer into the Bonjour row (which carries richer ADE metadata), letting the
+ * row gain the Tailscale route and the peer's reported OS.
+ */
+export function mergeCrossSourceDiscoveredMachines(
+  machines: RemoteRuntimeDiscoveredMachine[],
+): RemoteRuntimeDiscoveredMachine[] {
+  const merged: RemoteRuntimeDiscoveredMachine[] = [];
+  const bonjourHostSets: Array<{
+    machine: RemoteRuntimeDiscoveredMachine;
+    hosts: Set<string>;
+  }> = [];
+  const unmatchedPeers: RemoteRuntimeDiscoveredMachine[] = [];
+
+  for (const machine of machines) {
+    if (isTailscalePeerMachine(machine)) continue;
+    const clone: RemoteRuntimeDiscoveredMachine = {
+      ...machine,
+      addresses: [...machine.addresses],
+    };
+    merged.push(clone);
+    bonjourHostSets.push({ machine: clone, hosts: discoveredMachineHostSet(clone) });
+  }
+
+  for (const machine of machines) {
+    if (!isTailscalePeerMachine(machine)) continue;
+    const peerHosts = discoveredMachineHostSet(machine);
+    const target = bonjourHostSets.find(({ hosts }) => {
+      for (const host of peerHosts) {
+        if (hosts.has(host)) return true;
+      }
+      return false;
+    });
+    if (!target) {
+      unmatchedPeers.push(machine);
+      continue;
+    }
+    target.machine.addresses = orderAddresses(
+      uniqueStrings([...target.machine.addresses, ...machine.addresses]),
+    );
+    if (!target.machine.tailscaleAddress && machine.tailscaleAddress) {
+      target.machine.tailscaleAddress = machine.tailscaleAddress;
+    }
+    if (!target.machine.os && machine.os) {
+      target.machine.os = machine.os;
+    }
+    // Refresh the host set so a later peer sharing only the newly-added
+    // Tailscale address still folds into the same Bonjour machine.
+    target.hosts = discoveredMachineHostSet(target.machine);
+  }
+
+  return [...merged, ...unmatchedPeers];
+}
+
+function readLocalSyncDeviceId(): string | null {
+  try {
+    const layout = resolveMachineAdeLayout();
+    const deviceIdPath = path.join(layout.secretsDir, "sync-device-id");
+    if (!fs.existsSync(deviceIdPath)) return null;
+    const value = fs.readFileSync(deviceIdPath, "utf8").trim();
+    return value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
 async function discoverTailscalePeers(
   timeoutMs = 1_200,
 ): Promise<{
@@ -373,8 +492,13 @@ export async function discoverLanRuntimes(
     })(),
   ]);
 
+  const localDeviceId = readLocalSyncDeviceId();
+  const deduped = mergeCrossSourceDiscoveredMachines(
+    dropSelfDiscoveredMachines([...discovered.values()], localDeviceId),
+  );
+
   return {
-    machines: [...discovered.values()].sort((a, b) => {
+    machines: deduped.sort((a, b) => {
       const name = a.machineName.localeCompare(b.machineName);
       if (name !== 0) return name;
       return a.serviceName.localeCompare(b.serviceName);

--- a/apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.ts
@@ -190,6 +190,10 @@ export function discoveredRuntimeFromBonjourService(
     tailscaleAddress,
     runtimeKind: firstNonEmpty([txt.runtimeKind]),
     runtimeVersion: firstNonEmpty([txt.runtimeVersion]),
+    ...(firstNonEmpty([txt.platform])
+      ? { os: firstNonEmpty([txt.platform])! }
+      : {}),
+    connectable: true,
     projectIds,
     projectCount,
     lastSeenAt: nowMs,
@@ -225,6 +229,9 @@ export function discoveredRuntimesFromTailscaleStatus(
     const machineName = trimmed(peer.HostName) ?? dnsName ?? tailscaleAddress;
     const hostIdentity = trimmed(peer.ID) ?? trimmed(peerKey);
     const online = peer.Online === true;
+    const os = trimmed(peer.OS);
+    const isWindows = os?.toLowerCase() === "windows";
+    const connectable = online && !isWindows;
     const addresses = uniqueStrings([...tailscaleIps, dnsName]);
     discovered.push({
       id: `tailscale:${hostIdentity ?? tailscaleAddress}`,
@@ -238,6 +245,15 @@ export function discoveredRuntimesFromTailscaleStatus(
       tailscaleAddress,
       runtimeKind: online ? "tailscale-peer" : "tailscale-peer-offline",
       runtimeVersion: null,
+      ...(os ? { os } : {}),
+      connectable,
+      ...(!connectable
+        ? {
+            unsupportedReason: !online
+              ? "Offline"
+              : "Windows machines can't run the ADE remote runtime yet.",
+          }
+        : {}),
       projectIds: [],
       projectCount: null,
       lastSeenAt: nowMs,

--- a/apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.ts
@@ -174,6 +174,8 @@ export function discoveredRuntimeFromBonjourService(
   const projectCount =
     parsePositiveInteger(txt.projectCount) ??
     (projectIds.length > 0 ? projectIds.length : null);
+  const os = firstNonEmpty([txt.platform]);
+  const isWindows = os?.toLowerCase() === "windows";
 
   return {
     id: hostIdentity ? `${hostIdentity}::${serviceKey}` : serviceKey,
@@ -187,10 +189,11 @@ export function discoveredRuntimeFromBonjourService(
     tailscaleAddress,
     runtimeKind: firstNonEmpty([txt.runtimeKind]),
     runtimeVersion: firstNonEmpty([txt.runtimeVersion]),
-    ...(firstNonEmpty([txt.platform])
-      ? { os: firstNonEmpty([txt.platform])! }
+    ...(os ? { os } : {}),
+    connectable: !isWindows,
+    ...(isWindows
+      ? { unsupportedReason: "Windows machines can't run the ADE remote runtime yet." }
       : {}),
-    connectable: true,
     projectIds,
     projectCount,
     lastSeenAt: nowMs,

--- a/apps/desktop/src/main/services/remoteRuntime/sshTransport.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/sshTransport.test.ts
@@ -484,6 +484,47 @@ describe("buildSshConfig", () => {
     }))(key)).toBe(true);
   });
 
+  it("omits discovery display labels when recording trusted route hostnames", async () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "ade-ssh-home-"));
+    const key = Buffer.from("remote host key");
+    const discoveredTarget: RemoteRuntimeTarget = {
+      ...target,
+      hostname: "MacBook Pro (97)",
+      routes: [
+        {
+          hostname: "100.117.237.95",
+          port: 22,
+          source: "tailscale",
+          lastSucceededAt: null,
+        },
+        {
+          hostname: "macbook-pro-97.tail.example.test",
+          port: 22,
+          source: "tailscale",
+          lastSucceededAt: null,
+        },
+      ],
+    };
+
+    await trustSshHostKeyForTarget(discoveredTarget, "SHA256:test-key", {
+      env: {},
+      homeDir,
+      sshConfigPath: null,
+      scanHostKey: async () => ({
+        ...scannedHostKey({ homeDir, key }),
+        targetId: discoveredTarget.id,
+        host: "100.117.237.95",
+        route: discoveredTarget.routes![0]!,
+      }),
+    });
+
+    const knownHosts = fs.readFileSync(path.join(homeDir, ".ssh", "known_hosts"), "utf8");
+    expect(knownHosts).toContain(
+      `100.117.237.95,macbook-pro-97.tail.example.test ssh-ed25519 ${key.toString("base64")}`,
+    );
+    expect(knownHosts).not.toContain("MacBook Pro (97)");
+  });
+
   it("refuses to overwrite a different known SSH host key", async () => {
     const knownKey = Buffer.from("known host key");
     const scannedKey = Buffer.from("new host key");

--- a/apps/desktop/src/main/services/remoteRuntime/sshTransport.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/sshTransport.test.ts
@@ -12,6 +12,7 @@ import {
   buildSshConfigCandidates,
   buildSshRouteCandidates,
   buildSshUsernameCandidates,
+  connectSshWithRoute,
   execSsh,
   getSshHostKeyTrustForTarget,
   hasKnownSshHostKeyForTarget,
@@ -184,6 +185,58 @@ describe("buildSshConfig", () => {
 
     expect(configs.map((config) => config.username)).toEqual(Array.from(new Set([os.userInfo().username, "admin"])));
     expect(configs.every((config) => config.host === "203.0.113.10" && config.port === 22)).toBe(true);
+  });
+
+  it("reports the users and resolved identity tried on final authentication failure", async () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), "ade-ssh-home-"));
+    const keyPath = path.join(homeDir, "id_remote");
+    fs.writeFileSync(keyPath, "PRIVATE KEY", "utf8");
+    const authError = Object.assign(
+      new Error("All configured authentication methods failed"),
+      { level: "client-authentication" },
+    );
+
+    await expect(connectSshWithRoute({
+      ...target,
+      sshUser: null,
+      sshKeyPath: keyPath,
+    }, {
+      env: {},
+      homeDir,
+      sshConfigPath: null,
+      knownHostsPath: null,
+      connect: async () => {
+        throw authError;
+      },
+    })).rejects.toMatchObject({
+      info: {
+        kind: "ssh_auth",
+        detail: "All configured authentication methods failed",
+      },
+    });
+
+    let message = "";
+    try {
+      await connectSshWithRoute({
+        ...target,
+        sshUser: null,
+        sshKeyPath: keyPath,
+      }, {
+        env: {},
+        homeDir,
+        sshConfigPath: null,
+        knownHostsPath: null,
+        connect: async () => {
+          throw authError;
+        },
+      });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    for (const username of new Set([os.userInfo().username, "admin"])) {
+      expect(message).toContain(`"${username}"`);
+    }
+    expect(message).toContain(`key ${keyPath}`);
   });
 
   it("tries saved route fallbacks and prioritizes the last successful route", () => {

--- a/apps/desktop/src/main/services/remoteRuntime/sshTransport.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/sshTransport.test.ts
@@ -239,6 +239,51 @@ describe("buildSshConfig", () => {
     expect(message).toContain(`key ${keyPath}`);
   });
 
+  it("reports only configs that actually failed SSH authentication", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ade-ssh-config-"));
+    const configPath = path.join(dir, "config");
+    fs.writeFileSync(configPath, [
+      "Host unavailable-route",
+      "  User transport-user",
+      "Host auth-route",
+      "  User auth-user",
+    ].join("\n"), "utf8");
+    const authError = Object.assign(
+      new Error("All configured authentication methods failed"),
+      { level: "client-authentication" },
+    );
+
+    let message = "";
+    try {
+      await connectSshWithRoute({
+        ...target,
+        hostname: "unavailable-route",
+        sshUser: null,
+        routes: [{
+          hostname: "auth-route",
+          port: 22,
+          source: "manual",
+          lastSucceededAt: null,
+        }],
+      }, {
+        env: {},
+        sshConfigPath: configPath,
+        knownHostsPath: null,
+        connect: async (config) => {
+          if (config.host === "unavailable-route") {
+            throw Object.assign(new Error("Connection refused"), { code: "ECONNREFUSED" });
+          }
+          throw authError;
+        },
+      });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain('"auth-user"');
+    expect(message).not.toContain("transport-user");
+  });
+
   it("tries saved route fallbacks and prioritizes the last successful route", () => {
     const configs = buildSshConfigCandidates({
       ...target,

--- a/apps/desktop/src/main/services/remoteRuntime/sshTransport.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/sshTransport.ts
@@ -10,6 +10,7 @@ import type {
   RemoteRuntimeTargetRoute,
   RemoteRuntimeTrustSshHostKeyResult,
 } from "../../../shared/types/remoteRuntime";
+import { RemoteRuntimeConnectError } from "../../../shared/types/remoteRuntime";
 import type { RuntimeRpcTransport } from "./runtimeRpcClient";
 import { routeKey } from "./routeUtils";
 
@@ -42,6 +43,10 @@ export type BuildSshConfigOptions = {
   knownHostsPath?: string | null;
   homeDir?: string;
   usernameOverride?: string;
+};
+
+export type ConnectSshWithRouteOptions = BuildSshConfigOptions & {
+  connect?: (config: ConnectConfig) => Promise<Client>;
 };
 
 export type ConnectedSshRoute = RemoteRuntimeTargetRoute;
@@ -946,13 +951,17 @@ function buildSshConnectionCandidates(
 
 export async function connectSshWithRoute(
   target: RemoteRuntimeTarget,
+  options: ConnectSshWithRouteOptions = {},
 ): Promise<ConnectedSshSession> {
-  const configs = buildSshConnectionCandidates(target);
+  const { connect = connectSshWithConfig, ...buildOptions } = options;
+  const configs = buildSshConnectionCandidates(target, buildOptions);
   let lastError: unknown = null;
+  const attemptedConfigs: typeof configs = [];
   for (let index = 0; index < configs.length; index += 1) {
     const candidate = configs[index]!;
+    attemptedConfigs.push(candidate);
     try {
-      const client = await connectSshWithConfig(candidate.config);
+      const client = await connect(candidate.config);
       return {
         client,
         route: candidate.route,
@@ -971,6 +980,32 @@ export async function connectSshWithRoute(
         }
       }
     }
+  }
+  if (isSshAuthenticationFailure(lastError)) {
+    const users = uniqueStrings(
+      attemptedConfigs.map((candidate) => candidate.openSshConfig.username),
+    );
+    const identities = uniqueStrings(
+      attemptedConfigs.flatMap((candidate) => {
+        const methods: string[] = [];
+        if (candidate.openSshConfig.identityFile) {
+          methods.push(`key ${candidate.openSshConfig.identityFile}`);
+        }
+        if (candidate.config.agent) methods.push("ssh-agent");
+        if (methods.length === 0) methods.push("default keys");
+        return methods;
+      }),
+    );
+    const detail = lastError instanceof Error
+      ? lastError.message
+      : String(lastError ?? "SSH authentication failed.");
+    throw new RemoteRuntimeConnectError({
+      kind: "ssh_auth",
+      message:
+        `SSH authentication failed for user(s) ${users.map((user) => `"${user}"`).join(", ")} ` +
+        `using ${identities.join(" and ")}. Check the SSH user and that the key is authorized on the remote machine.`,
+      detail,
+    }, lastError);
   }
   throw lastError instanceof Error ? lastError : new Error(String(lastError ?? "SSH connection failed."));
 }

--- a/apps/desktop/src/main/services/remoteRuntime/sshTransport.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/sshTransport.ts
@@ -204,7 +204,11 @@ function knownHostCandidates(hostAliases: string[], port: number): string[] {
 
 function knownHostWritePattern(host: string, port: number): string | null {
   const normalized = normalizeKnownHostName(host);
-  if (!normalized) return null;
+  // Discovery names are presentation labels and can contain spaces (for
+  // example, "MacBook Pro (97)"). A known_hosts host field is a
+  // comma-delimited token, so including one of those labels makes the whole
+  // line unparsable and prevents the explicitly trusted route from matching.
+  if (!normalized || /[\s,#]/.test(normalized)) return null;
   if (port === 22) return normalized;
   return normalized.startsWith("[") ? normalized : `[${normalized}]:${port}`;
 }

--- a/apps/desktop/src/main/services/remoteRuntime/sshTransport.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/sshTransport.ts
@@ -960,10 +960,9 @@ export async function connectSshWithRoute(
   const { connect = connectSshWithConfig, ...buildOptions } = options;
   const configs = buildSshConnectionCandidates(target, buildOptions);
   let lastError: unknown = null;
-  const attemptedConfigs: typeof configs = [];
+  const authFailedConfigs: typeof configs = [];
   for (let index = 0; index < configs.length; index += 1) {
     const candidate = configs[index]!;
-    attemptedConfigs.push(candidate);
     try {
       const client = await connect(candidate.config);
       return {
@@ -974,6 +973,9 @@ export async function connectSshWithRoute(
       };
     } catch (error) {
       lastError = error;
+      if (isSshAuthenticationFailure(error)) {
+        authFailedConfigs.push(candidate);
+      }
       if (index >= configs.length - 1) break;
       if (!isSshAuthenticationFailure(error)) {
         while (
@@ -987,10 +989,10 @@ export async function connectSshWithRoute(
   }
   if (isSshAuthenticationFailure(lastError)) {
     const users = uniqueStrings(
-      attemptedConfigs.map((candidate) => candidate.openSshConfig.username),
+      authFailedConfigs.map((candidate) => candidate.openSshConfig.username),
     );
     const identities = uniqueStrings(
-      attemptedConfigs.flatMap((candidate) => {
+      authFailedConfigs.flatMap((candidate) => {
         const methods: string[] = [];
         if (candidate.openSshConfig.identityFile) {
           methods.push(`key ${candidate.openSshConfig.identityFile}`);

--- a/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.test.ts
@@ -144,5 +144,17 @@ describe("DesktopPairedMachineStore", () => {
     expect(fs.statSync(store.path).mode & 0o777).toBe(0o600);
     expect(new DesktopPairedMachineStore().get("mac-studio-host")).toEqual(paired);
     expect(new DesktopPairedMachineStore().get("machine-123")).toEqual(paired);
+
+    const marked = store.markEndpointSucceeded(
+      "mac-studio-host",
+      "wss://relay.example/connect/machine-123",
+      1_700_000_000_000,
+    );
+    expect(marked.endpointStates).toContainEqual({
+      endpoint: "wss://relay.example/connect/machine-123",
+      lastSucceededAt: 1_700_000_000_000,
+    });
+    expect(new DesktopPairedMachineStore().get("mac-studio-host"))
+      .toEqual(marked);
   });
 });

--- a/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.test.ts
@@ -50,6 +50,7 @@ describe("DesktopPairedMachineStore", () => {
     process.env.ADE_HOME = adeHome;
     let pairedPublicKey: string | null = null;
     let pairedDeviceType: unknown = null;
+    let pairedRuntimeHostGrant: unknown = null;
     let dpopVerdict: SyncDpopVerification | null = null;
 
     const createWebSocket = () => new FakeWebSocket((text, ws) => {
@@ -58,10 +59,12 @@ describe("DesktopPairedMachineStore", () => {
           const payload = envelope.payload as {
             code: string;
             dpopPublicKey?: string;
+            runtimeHostGrant?: string;
             peer: { deviceId: string; deviceType: unknown };
           };
           pairedPublicKey = payload.dpopPublicKey ?? null;
           pairedDeviceType = payload.peer.deviceType;
+          pairedRuntimeHostGrant = payload.runtimeHostGrant;
           ws.receive(encodeSyncEnvelope({
             type: "pairing_result",
             requestId: envelope.requestId,
@@ -117,10 +120,15 @@ describe("DesktopPairedMachineStore", () => {
       "ws://studio.local:8787",
       "123456",
       "Desktop client",
-      { pairingTimeoutMs: 2_000, createWebSocket },
+      {
+        pairingTimeoutMs: 2_000,
+        createWebSocket,
+        runtimeHostGrant: "server-issued-runtime-grant",
+      },
     );
 
     expect(pairedDeviceType).toBe("desktop");
+    expect(pairedRuntimeHostGrant).toBe("server-issued-runtime-grant");
     expect(dpopVerdict).toEqual({ ok: true });
     expect(paired).toMatchObject({
       version: 1,

--- a/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.test.ts
@@ -144,6 +144,10 @@ describe("DesktopPairedMachineStore", () => {
     expect(fs.statSync(store.path).mode & 0o777).toBe(0o600);
     expect(new DesktopPairedMachineStore().get("mac-studio-host")).toEqual(paired);
     expect(new DesktopPairedMachineStore().get("machine-123")).toEqual(paired);
+    expect(new DesktopPairedMachineStore().getForReference({
+      hostIdentity: "missing-host-identity",
+      machineKey: "machine-123",
+    })).toEqual(paired);
 
     const marked = store.markEndpointSucceeded(
       "mac-studio-host",

--- a/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.test.ts
@@ -7,6 +7,7 @@ import type { WebSocket } from "ws";
 import type { SyncDpopVerification } from "../../../../../ade-cli/src/services/sync/syncDpop";
 import { verifySyncDpopProof } from "../../../../../ade-cli/src/services/sync/syncDpop";
 import type { SyncDpopProof } from "../../../shared/types/sync";
+import type { DesktopPairedMachineCredentials } from "../../../shared/types/pairedRuntime";
 import { encodeSyncEnvelope, parseSyncEnvelope, wsDataToText } from "../sync/syncProtocol";
 import { DesktopPairedMachineStore } from "./syncPairedMachineStore";
 
@@ -168,5 +169,65 @@ describe("DesktopPairedMachineStore", () => {
     });
     expect(new DesktopPairedMachineStore().get("mac-studio-host"))
       .toEqual(marked);
+  });
+
+  it("replaces stale relay connection metadata only when explicitly requested", () => {
+    const filePath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), "ade-desktop-pairing-store-")),
+      "paired.json",
+    );
+    const store = new DesktopPairedMachineStore({ filePath });
+    const credentials: DesktopPairedMachineCredentials = {
+      version: 1,
+      hostIdentity: {
+        deviceId: "host-1",
+        siteId: "host-site-1",
+        name: "Studio",
+        platform: "macOS",
+        deviceType: "desktop",
+      },
+      machineKey: "machine-1",
+      deviceId: "desktop-1",
+      siteId: "desktop-site-1",
+      deviceName: "Laptop",
+      secret: "secret",
+      dpopPrivateKey: "private",
+      dpopPublicKey: "public",
+      endpoints: [
+        "ws://studio.local:8787",
+        "wss://relay.example/connect/old",
+      ],
+      relayUrl: "wss://relay.example/connect/old",
+      endpointStates: [{
+        endpoint: "wss://relay.example/connect/old",
+        lastSucceededAt: 123,
+      }],
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    store.save(credentials);
+
+    const merged = store.save({
+      ...credentials,
+      endpoints: ["ws://studio.local:8787"],
+      relayUrl: null,
+    });
+    expect(merged.endpoints).toContain("wss://relay.example/connect/old");
+    expect(merged.relayUrl).toBe("wss://relay.example/connect/old");
+
+    const replaced = store.save(
+      {
+        ...credentials,
+        endpoints: ["ws://studio.local:8787"],
+        relayUrl: null,
+      },
+      { replaceConnectionMetadata: true },
+    );
+    expect(replaced.endpoints).toEqual(["ws://studio.local:8787/"]);
+    expect(replaced.relayUrl).toBeNull();
+    expect(replaced.endpointStates).toEqual([{
+      endpoint: "ws://studio.local:8787/",
+      lastSucceededAt: null,
+    }]);
   });
 });

--- a/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.test.ts
@@ -1,0 +1,148 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { WebSocket } from "ws";
+import type { SyncDpopVerification } from "../../../../../ade-cli/src/services/sync/syncDpop";
+import { verifySyncDpopProof } from "../../../../../ade-cli/src/services/sync/syncDpop";
+import type { SyncDpopProof } from "../../../shared/types/sync";
+import { encodeSyncEnvelope, parseSyncEnvelope, wsDataToText } from "../sync/syncProtocol";
+import { DesktopPairedMachineStore } from "./syncPairedMachineStore";
+
+const originalAdeHome = process.env.ADE_HOME;
+
+afterEach(() => {
+  if (originalAdeHome === undefined) delete process.env.ADE_HOME;
+  else process.env.ADE_HOME = originalAdeHome;
+});
+
+class FakeWebSocket extends EventEmitter {
+  readyState = 0;
+  bufferedAmount = 0;
+
+  constructor(private readonly onSend: (text: string, ws: FakeWebSocket) => void) {
+    super();
+    queueMicrotask(() => {
+      this.readyState = 1;
+      this.emit("open");
+    });
+  }
+
+  send(data: string | Buffer): void {
+    this.onSend(data.toString(), this);
+  }
+
+  receive(text: string): void {
+    queueMicrotask(() => this.emit("message", Buffer.from(text, "utf8")));
+  }
+
+  close(): void {
+    if (this.readyState === 3) return;
+    this.readyState = 3;
+    queueMicrotask(() => this.emit("close"));
+  }
+}
+
+describe("DesktopPairedMachineStore", () => {
+  it("pairs as a desktop with DPoP and round-trips a 0600 machine secret file", async () => {
+    const adeHome = fs.mkdtempSync(path.join(os.tmpdir(), "ade-desktop-pairing-"));
+    process.env.ADE_HOME = adeHome;
+    let pairedPublicKey: string | null = null;
+    let pairedDeviceType: unknown = null;
+    let dpopVerdict: SyncDpopVerification | null = null;
+
+    const createWebSocket = () => new FakeWebSocket((text, ws) => {
+        const envelope = parseSyncEnvelope(wsDataToText(text));
+        if (envelope.type === "pairing_request") {
+          const payload = envelope.payload as {
+            code: string;
+            dpopPublicKey?: string;
+            peer: { deviceId: string; deviceType: unknown };
+          };
+          pairedPublicKey = payload.dpopPublicKey ?? null;
+          pairedDeviceType = payload.peer.deviceType;
+          ws.receive(encodeSyncEnvelope({
+            type: "pairing_result",
+            requestId: envelope.requestId,
+            payload: {
+              ok: true,
+              deviceId: payload.peer.deviceId,
+              secret: "host-issued-secret",
+            },
+          }));
+          return;
+        }
+        if (envelope.type !== "hello") return;
+        const payload = envelope.payload as {
+          peer: unknown;
+          auth: {
+            deviceId: string;
+            secret: string;
+            dpop: SyncDpopProof;
+          };
+        };
+        if (pairedPublicKey) {
+          dpopVerdict = verifySyncDpopProof({
+            publicKeyX963Base64: pairedPublicKey,
+            deviceId: payload.auth.deviceId,
+            secret: payload.auth.secret,
+            proof: payload.auth.dpop,
+          });
+        }
+        ws.receive(encodeSyncEnvelope({
+          type: "hello_ok",
+          requestId: envelope.requestId,
+          payload: {
+            peer: payload.peer,
+            brain: {
+              deviceId: "mac-studio-host",
+              deviceName: "Studio",
+              platform: "macOS",
+              deviceType: "desktop",
+              siteId: "mac-studio-site",
+              dbVersion: 0,
+            },
+            serverDbVersion: 0,
+            heartbeatIntervalMs: 5_000,
+            pollIntervalMs: 1_500,
+            cloudRelayWssUrl: "wss://relay.example/connect/machine-123",
+            features: { rpcChannel: true, portForward: true },
+          },
+        }));
+    }) as unknown as WebSocket;
+
+    const store = new DesktopPairedMachineStore();
+    const paired = await store.pairWithMachine(
+      "ws://studio.local:8787",
+      "123456",
+      "Desktop client",
+      { pairingTimeoutMs: 2_000, createWebSocket },
+    );
+
+    expect(pairedDeviceType).toBe("desktop");
+    expect(dpopVerdict).toEqual({ ok: true });
+    expect(paired).toMatchObject({
+      version: 1,
+      hostIdentity: {
+        deviceId: "mac-studio-host",
+        siteId: "mac-studio-site",
+        name: "Studio",
+        deviceType: "desktop",
+      },
+      machineKey: "machine-123",
+      deviceName: "Desktop client",
+      secret: "host-issued-secret",
+      dpopPrivateKey: expect.any(String),
+      dpopPublicKey: pairedPublicKey,
+      endpoints: [
+        "ws://studio.local:8787/",
+        "wss://relay.example/connect/machine-123",
+      ],
+    });
+    expect(store.path).toBe(path.join(adeHome, "secrets", "desktop-paired-machines.json"));
+    expect(fs.statSync(store.path).mode & 0o777).toBe(0o600);
+    expect(new DesktopPairedMachineStore().get("mac-studio-host")).toEqual(paired);
+    expect(new DesktopPairedMachineStore().get("machine-123")).toEqual(paired);
+  });
+});

--- a/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.ts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { resolveMachineAdeLayout } from "../../../../../ade-cli/src/services/projects/machineLayout";
 import type {
+  DesktopPairedMachineEndpointState,
   DesktopPairedMachineCredentials,
   DesktopPairedMachinesFile,
   PairedRuntimeHelloOkPayload,
@@ -92,6 +93,8 @@ function coerceMachine(value: unknown): DesktopPairedMachineCredentials | null {
         }
       }))]
     : [];
+  const relayUrl = requiredString(value.relayUrl);
+  const endpointStates = coerceEndpointStates(value.endpointStates, endpoints);
   if (
     !hostIdentity
     || !deviceId
@@ -115,9 +118,55 @@ function coerceMachine(value: unknown): DesktopPairedMachineCredentials | null {
     dpopPrivateKey,
     dpopPublicKey,
     endpoints,
+    relayUrl,
+    endpointStates,
     createdAt,
     updatedAt,
   };
+}
+
+function coerceEndpointStates(
+  value: unknown,
+  endpoints: string[],
+): DesktopPairedMachineEndpointState[] {
+  const successByEndpoint = new Map<string, number | null>();
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      if (!isRecord(entry)) continue;
+      const rawEndpoint = requiredString(entry.endpoint);
+      if (!rawEndpoint) continue;
+      let endpoint: string;
+      try {
+        endpoint = normalizeSyncEndpoint(rawEndpoint);
+      } catch {
+        continue;
+      }
+      const lastSucceededAt = typeof entry.lastSucceededAt === "number"
+        && Number.isFinite(entry.lastSucceededAt)
+        ? entry.lastSucceededAt
+        : null;
+      const current = successByEndpoint.get(endpoint) ?? null;
+      if (lastSucceededAt != null && (current == null || lastSucceededAt > current)) {
+        successByEndpoint.set(endpoint, lastSucceededAt);
+      } else if (!successByEndpoint.has(endpoint)) {
+        successByEndpoint.set(endpoint, null);
+      }
+    }
+  }
+  for (const endpoint of endpoints) {
+    if (!successByEndpoint.has(endpoint)) successByEndpoint.set(endpoint, null);
+  }
+  return [...successByEndpoint].map(([endpoint, lastSucceededAt]) => ({
+    endpoint,
+    lastSucceededAt,
+  }));
+}
+
+function mergeEndpointStates(
+  endpoints: string[],
+  ...stateLists: Array<DesktopPairedMachineEndpointState[] | null | undefined>
+): DesktopPairedMachineEndpointState[] {
+  return coerceEndpointStates(stateLists.flat(), endpoints);
 }
 
 function hostIdentityFromPeer(
@@ -219,7 +268,13 @@ export class DesktopPairedMachineStore {
       createdAt: existing?.createdAt ?? machine.createdAt,
       updatedAt: nowIso(),
       endpoints: uniqueEndpoints(...machine.endpoints, ...(existing?.endpoints ?? [])),
+      relayUrl: machine.relayUrl ?? existing?.relayUrl ?? null,
     };
+    saved.endpointStates = mergeEndpointStates(
+      saved.endpoints,
+      machine.endpointStates,
+      existing?.endpointStates,
+    );
     this.write({
       version: 1,
       machines: [
@@ -243,6 +298,26 @@ export class DesktopPairedMachineStore {
     if (machines.length === file.machines.length) return false;
     this.write({ version: 1, machines });
     return true;
+  }
+
+  markEndpointSucceeded(
+    hostDeviceIdOrMachineKey: string,
+    endpointValue: string,
+    nowMs = Date.now(),
+  ): DesktopPairedMachineCredentials {
+    const machine = this.get(hostDeviceIdOrMachineKey);
+    if (!machine) throw new Error("Paired machine was not found.");
+    const endpoint = normalizeSyncEndpoint(endpointValue);
+    const endpoints = uniqueEndpoints(endpoint, ...machine.endpoints);
+    return this.save({
+      ...machine,
+      endpoints,
+      endpointStates: mergeEndpointStates(
+        endpoints,
+        machine.endpointStates,
+        [{ endpoint, lastSucceededAt: nowMs }],
+      ),
+    });
   }
 
   async pairWithMachine(
@@ -366,6 +441,11 @@ export class DesktopPairedMachineStore {
         machineKey: provisional.machineKey
           ?? (hello.cloudRelayWssUrl ? machineKeyFromEndpoint(hello.cloudRelayWssUrl) : null),
         endpoints,
+        relayUrl: hello.cloudRelayWssUrl ?? null,
+        endpointStates: endpoints.map((candidate) => ({
+          endpoint: candidate,
+          lastSucceededAt: candidate === endpoint ? Date.now() : null,
+        })),
       });
     } finally {
       connection.close(1000, "Desktop pairing finished.");

--- a/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.ts
@@ -33,6 +33,7 @@ export type PairWithMachineOptions = Omit<
 > & {
   appVersion?: string;
   pairingTimeoutMs?: number;
+  runtimeHostGrant?: string | null;
 };
 
 function nowIso(): string {
@@ -375,6 +376,9 @@ export class DesktopPairedMachineStore {
             dbVersion: 0,
           },
           dpopPublicKey: keys.publicKey,
+          ...(options.runtimeHostGrant
+            ? { runtimeHostGrant: options.runtimeHostGrant }
+            : {}),
         }, pairingRequestId);
       } catch (error) {
         void pairingResponse.catch(() => {});

--- a/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.ts
@@ -1,0 +1,423 @@
+import {
+  generateKeyPairSync,
+  randomUUID,
+} from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { resolveMachineAdeLayout } from "../../../../../ade-cli/src/services/projects/machineLayout";
+import type {
+  DesktopPairedMachineCredentials,
+  DesktopPairedMachinesFile,
+  PairedRuntimeHelloOkPayload,
+} from "../../../shared/types/pairedRuntime";
+import type {
+  SyncPairingHostIdentity,
+  SyncPairingResultPayload,
+  SyncPeerMetadata,
+} from "../../../shared/types/sync";
+import {
+  buildDesktopPairedHello,
+  normalizeSyncEndpoint,
+  openSyncEnvelopeConnection,
+  waitForSyncEnvelope,
+  type OpenSyncEnvelopeConnectionOptions,
+} from "./syncRuntimeTransport";
+
+const STORE_FILE_NAME = "desktop-paired-machines.json";
+const DEFAULT_PAIRING_TIMEOUT_MS = 15_000;
+
+export type PairWithMachineOptions = Omit<
+  OpenSyncEnvelopeConnectionOptions,
+  "endpoint"
+> & {
+  appVersion?: string;
+  pairingTimeoutMs?: number;
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function requiredString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function coerceHostIdentity(value: unknown): SyncPairingHostIdentity | null {
+  if (!isRecord(value)) return null;
+  const deviceId = requiredString(value.deviceId);
+  const siteId = requiredString(value.siteId);
+  const name = requiredString(value.name);
+  const platform = value.platform;
+  const deviceType = value.deviceType;
+  if (!deviceId || !siteId || !name) return null;
+  if (
+    platform !== "macOS"
+    && platform !== "linux"
+    && platform !== "windows"
+    && platform !== "iOS"
+    && platform !== "unknown"
+  ) return null;
+  if (
+    deviceType !== "desktop"
+    && deviceType !== "phone"
+    && deviceType !== "vps"
+    && deviceType !== "browser"
+    && deviceType !== "unknown"
+  ) return null;
+  return { deviceId, siteId, name, platform, deviceType };
+}
+
+function coerceMachine(value: unknown): DesktopPairedMachineCredentials | null {
+  if (!isRecord(value) || value.version !== 1) return null;
+  const hostIdentity = coerceHostIdentity(value.hostIdentity);
+  const deviceId = requiredString(value.deviceId);
+  const siteId = requiredString(value.siteId);
+  const deviceName = requiredString(value.deviceName);
+  const secret = requiredString(value.secret);
+  const dpopPrivateKey = requiredString(value.dpopPrivateKey);
+  const dpopPublicKey = requiredString(value.dpopPublicKey);
+  const createdAt = requiredString(value.createdAt);
+  const updatedAt = requiredString(value.updatedAt);
+  const endpoints = Array.isArray(value.endpoints)
+    ? [...new Set(value.endpoints.flatMap((entry) => {
+        if (typeof entry !== "string" || !entry.trim()) return [];
+        try {
+          return [normalizeSyncEndpoint(entry)];
+        } catch {
+          return [];
+        }
+      }))]
+    : [];
+  if (
+    !hostIdentity
+    || !deviceId
+    || !siteId
+    || !deviceName
+    || !secret
+    || !dpopPrivateKey
+    || !dpopPublicKey
+    || !createdAt
+    || !updatedAt
+    || endpoints.length === 0
+  ) return null;
+  return {
+    version: 1,
+    hostIdentity,
+    machineKey: requiredString(value.machineKey),
+    deviceId,
+    siteId,
+    deviceName,
+    secret,
+    dpopPrivateKey,
+    dpopPublicKey,
+    endpoints,
+    createdAt,
+    updatedAt,
+  };
+}
+
+function hostIdentityFromPeer(
+  peer: SyncPeerMetadata | null | undefined,
+): SyncPairingHostIdentity {
+  if (!peer) throw new Error("Paired sync host did not provide an identity.");
+  const deviceId = requiredString(peer?.deviceId);
+  const siteId = requiredString(peer?.siteId);
+  const name = requiredString(peer?.deviceName);
+  if (!deviceId || !siteId || !name) {
+    throw new Error("Paired sync host did not provide a valid identity.");
+  }
+  return {
+    deviceId,
+    siteId,
+    name,
+    platform: peer.platform,
+    deviceType: peer.deviceType,
+  };
+}
+
+function generateDpopKeyPair(): { privateKey: string; publicKey: string } {
+  const pair = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+  const jwk = pair.publicKey.export({ format: "jwk" }) as { x?: string; y?: string };
+  if (!jwk.x || !jwk.y) throw new Error("Could not export the desktop pairing public key.");
+  return {
+    privateKey: pair.privateKey.export({
+      format: "der",
+      type: "pkcs8",
+    }).toString("base64"),
+    publicKey: Buffer.concat([
+      Buffer.from([0x04]),
+      Buffer.from(jwk.x, "base64url"),
+      Buffer.from(jwk.y, "base64url"),
+    ]).toString("base64"),
+  };
+}
+
+function machineKeyFromEndpoint(endpoint: string): string | null {
+  try {
+    const segments = new URL(endpoint).pathname.split("/").filter(Boolean);
+    const connectIndex = segments.lastIndexOf("connect");
+    return connectIndex >= 0 && segments[connectIndex + 1]
+      ? decodeURIComponent(segments[connectIndex + 1]!)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function uniqueEndpoints(...values: Array<string | null | undefined>): string[] {
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (!value?.trim()) continue;
+    let endpoint: string;
+    try {
+      endpoint = normalizeSyncEndpoint(value);
+    } catch {
+      continue;
+    }
+    if (seen.has(endpoint)) continue;
+    seen.add(endpoint);
+    normalized.push(endpoint);
+  }
+  return normalized;
+}
+
+export class DesktopPairedMachineStore {
+  readonly path: string;
+
+  constructor(options: { filePath?: string } = {}) {
+    this.path = options.filePath
+      ?? path.join(resolveMachineAdeLayout().secretsDir, STORE_FILE_NAME);
+  }
+
+  list(): DesktopPairedMachineCredentials[] {
+    return this.read().machines;
+  }
+
+  get(hostDeviceIdOrMachineKey: string): DesktopPairedMachineCredentials | null {
+    const id = hostDeviceIdOrMachineKey.trim();
+    if (!id) return null;
+    return this.list().find((machine) =>
+      machine.hostIdentity.deviceId === id || machine.machineKey === id
+    ) ?? null;
+  }
+
+  save(credentials: DesktopPairedMachineCredentials): DesktopPairedMachineCredentials {
+    const machine = coerceMachine(credentials);
+    if (!machine) throw new Error("Desktop paired machine credentials are invalid.");
+    const file = this.read();
+    const existing = file.machines.find((entry) =>
+      entry.hostIdentity.deviceId === machine.hostIdentity.deviceId
+      || (machine.machineKey && entry.machineKey === machine.machineKey)
+    );
+    const saved: DesktopPairedMachineCredentials = {
+      ...machine,
+      createdAt: existing?.createdAt ?? machine.createdAt,
+      updatedAt: nowIso(),
+      endpoints: uniqueEndpoints(...machine.endpoints, ...(existing?.endpoints ?? [])),
+    };
+    this.write({
+      version: 1,
+      machines: [
+        saved,
+        ...file.machines.filter((entry) =>
+          entry.hostIdentity.deviceId !== saved.hostIdentity.deviceId
+          && (!saved.machineKey || entry.machineKey !== saved.machineKey)
+        ),
+      ],
+    });
+    return saved;
+  }
+
+  remove(hostDeviceIdOrMachineKey: string): boolean {
+    const id = hostDeviceIdOrMachineKey.trim();
+    if (!id) return false;
+    const file = this.read();
+    const machines = file.machines.filter((machine) =>
+      machine.hostIdentity.deviceId !== id && machine.machineKey !== id
+    );
+    if (machines.length === file.machines.length) return false;
+    this.write({ version: 1, machines });
+    return true;
+  }
+
+  async pairWithMachine(
+    endpointValue: string,
+    pinValue: string,
+    deviceNameValue: string,
+    options: PairWithMachineOptions = {},
+  ): Promise<DesktopPairedMachineCredentials> {
+    const endpoint = normalizeSyncEndpoint(endpointValue);
+    const pin = pinValue.trim();
+    const deviceName = deviceNameValue.trim();
+    if (!/^\d{6}$/.test(pin)) throw new Error("Pairing PIN must contain exactly 6 digits.");
+    if (!deviceName) throw new Error("Desktop device name is required.");
+
+    const keys = generateDpopKeyPair();
+    const localDeviceId = randomUUID();
+    const siteId = randomUUID();
+    const createdAt = nowIso();
+    const connection = await openSyncEnvelopeConnection({
+      endpoint,
+      connectTimeoutMs: options.connectTimeoutMs,
+      createWebSocket: options.createWebSocket,
+    });
+    try {
+      const pairingRequestId = `pair-${randomUUID()}`;
+      const pairingResponse = waitForSyncEnvelope(
+        connection,
+        (envelope) => envelope.type === "pairing_result"
+          && envelope.requestId === pairingRequestId,
+        options.pairingTimeoutMs ?? DEFAULT_PAIRING_TIMEOUT_MS,
+      );
+      try {
+        connection.send("pairing_request", {
+          code: pin,
+          peer: {
+            deviceId: localDeviceId,
+            deviceName,
+            platform: process.platform === "darwin"
+              ? "macOS"
+              : process.platform === "win32"
+                ? "windows"
+                : process.platform === "linux"
+                  ? "linux"
+                  : "unknown",
+            deviceType: "desktop",
+            siteId,
+            dbVersion: 0,
+          },
+          dpopPublicKey: keys.publicKey,
+        }, pairingRequestId);
+      } catch (error) {
+        void pairingResponse.catch(() => {});
+        throw error;
+      }
+      const pairingEnvelope = await pairingResponse;
+      const pairing = pairingEnvelope.payload as SyncPairingResultPayload;
+      if (!pairing?.ok) {
+        throw new Error(pairing?.error?.message?.trim() || "Pairing request failed.");
+      }
+      const returnedDeviceId = requiredString(pairing.deviceId);
+      if (returnedDeviceId && returnedDeviceId !== localDeviceId) {
+        throw new Error("Pairing host returned credentials for a different device id.");
+      }
+      const deviceId = returnedDeviceId ?? localDeviceId;
+      const secret = requiredString(pairing.secret);
+      if (!secret) throw new Error("Pairing host did not return a device secret.");
+
+      const provisional: DesktopPairedMachineCredentials = {
+        version: 1,
+        hostIdentity: {
+          deviceId: "pending",
+          siteId: "pending",
+          name: "pending",
+          platform: "unknown",
+          deviceType: "unknown",
+        },
+        machineKey: machineKeyFromEndpoint(endpoint),
+        deviceId,
+        siteId,
+        deviceName,
+        secret,
+        dpopPrivateKey: keys.privateKey,
+        dpopPublicKey: keys.publicKey,
+        endpoints: [endpoint],
+        createdAt,
+        updatedAt: createdAt,
+      };
+
+      const helloRequestId = `hello-${randomUUID()}`;
+      const helloResponse = waitForSyncEnvelope(
+        connection,
+        (envelope) => envelope.requestId === helloRequestId
+          && (envelope.type === "hello_ok" || envelope.type === "hello_error"),
+        options.pairingTimeoutMs ?? DEFAULT_PAIRING_TIMEOUT_MS,
+      );
+      try {
+        connection.send(
+          "hello",
+          buildDesktopPairedHello(provisional, options.appVersion),
+          helloRequestId,
+        );
+      } catch (error) {
+        void helloResponse.catch(() => {});
+        throw error;
+      }
+      const helloEnvelope = await helloResponse;
+      if (helloEnvelope.type === "hello_error") {
+        const payload = helloEnvelope.payload as { message?: unknown };
+        throw new Error(
+          typeof payload?.message === "string" && payload.message.trim()
+            ? payload.message.trim()
+            : "The host rejected the new desktop pairing.",
+        );
+      }
+      const hello = helloEnvelope.payload as PairedRuntimeHelloOkPayload;
+      const hostIdentity = hostIdentityFromPeer(hello.brain);
+      const endpoints = uniqueEndpoints(endpoint, hello.cloudRelayWssUrl);
+      return this.save({
+        ...provisional,
+        hostIdentity,
+        machineKey: provisional.machineKey
+          ?? (hello.cloudRelayWssUrl ? machineKeyFromEndpoint(hello.cloudRelayWssUrl) : null),
+        endpoints,
+      });
+    } finally {
+      connection.close(1000, "Desktop pairing finished.");
+    }
+  }
+
+  private read(): DesktopPairedMachinesFile {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.path, "utf8")) as unknown;
+      if (!isRecord(parsed) || !Array.isArray(parsed.machines)) {
+        return { version: 1, machines: [] };
+      }
+      return {
+        version: 1,
+        machines: parsed.machines
+          .map(coerceMachine)
+          .filter((machine): machine is DesktopPairedMachineCredentials => machine != null),
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { version: 1, machines: [] };
+      }
+      throw error;
+    }
+  }
+
+  private write(file: DesktopPairedMachinesFile): void {
+    fs.mkdirSync(path.dirname(this.path), { recursive: true, mode: 0o700 });
+    const tmp = `${this.path}.${process.pid}.${Date.now()}.tmp`;
+    try {
+      fs.writeFileSync(tmp, `${JSON.stringify(file, null, 2)}\n`, {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+      fs.renameSync(tmp, this.path);
+      fs.chmodSync(this.path, 0o600);
+    } finally {
+      try {
+        fs.unlinkSync(tmp);
+      } catch {
+        // Rename removes the temp path; cleanup only matters after a failure.
+      }
+    }
+  }
+}
+
+export async function pairWithMachine(
+  endpoint: string,
+  pin: string,
+  deviceName: string,
+  options: PairWithMachineOptions & { store?: DesktopPairedMachineStore } = {},
+): Promise<DesktopPairedMachineCredentials> {
+  const { store = new DesktopPairedMachineStore(), ...connectionOptions } = options;
+  return await store.pairWithMachine(endpoint, pin, deviceName, connectionOptions);
+}

--- a/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.ts
@@ -255,6 +255,14 @@ export class DesktopPairedMachineStore {
     ) ?? null;
   }
 
+  getForReference(ref: {
+    hostIdentity: string;
+    machineKey?: string | null;
+  }): DesktopPairedMachineCredentials | null {
+    return this.get(ref.hostIdentity)
+      ?? (ref.machineKey ? this.get(ref.machineKey) : null);
+  }
+
   save(credentials: DesktopPairedMachineCredentials): DesktopPairedMachineCredentials {
     const machine = coerceMachine(credentials);
     if (!machine) throw new Error("Desktop paired machine credentials are invalid.");

--- a/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.ts
@@ -264,7 +264,10 @@ export class DesktopPairedMachineStore {
       ?? (ref.machineKey ? this.get(ref.machineKey) : null);
   }
 
-  save(credentials: DesktopPairedMachineCredentials): DesktopPairedMachineCredentials {
+  save(
+    credentials: DesktopPairedMachineCredentials,
+    options: { replaceConnectionMetadata?: boolean } = {},
+  ): DesktopPairedMachineCredentials {
     const machine = coerceMachine(credentials);
     if (!machine) throw new Error("Desktop paired machine credentials are invalid.");
     const file = this.read();
@@ -276,13 +279,21 @@ export class DesktopPairedMachineStore {
       ...machine,
       createdAt: existing?.createdAt ?? machine.createdAt,
       updatedAt: nowIso(),
-      endpoints: uniqueEndpoints(...machine.endpoints, ...(existing?.endpoints ?? [])),
-      relayUrl: machine.relayUrl ?? existing?.relayUrl ?? null,
+      endpoints: options.replaceConnectionMetadata
+        ? uniqueEndpoints(...machine.endpoints)
+        : uniqueEndpoints(...machine.endpoints, ...(existing?.endpoints ?? [])),
+      relayUrl: options.replaceConnectionMetadata
+        ? machine.relayUrl ?? null
+        : machine.relayUrl ?? existing?.relayUrl ?? null,
     };
     saved.endpointStates = mergeEndpointStates(
       saved.endpoints,
-      machine.endpointStates,
-      existing?.endpointStates,
+      options.replaceConnectionMetadata
+        ? machine.endpointStates?.filter((state) =>
+            saved.endpoints.includes(state.endpoint)
+          )
+        : machine.endpointStates,
+      options.replaceConnectionMetadata ? undefined : existing?.endpointStates,
     );
     this.write({
       version: 1,

--- a/apps/desktop/src/main/services/remoteRuntime/syncPortForwardClient.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncPortForwardClient.test.ts
@@ -1,0 +1,156 @@
+import { EventEmitter } from "node:events";
+import type net from "node:net";
+import { describe, expect, it } from "vitest";
+import type { ParsedSyncEnvelope } from "../sync/syncProtocol";
+import { SyncPortForwardClient } from "./syncPortForwardClient";
+import type { AuthenticatedSyncConnection } from "./syncRuntimeTransport";
+
+class FakeLocalSocket extends EventEmitter {
+  writableLength = 0;
+  destroyed = false;
+  paused = false;
+  readonly writes: Buffer[] = [];
+
+  write(data: Uint8Array): boolean {
+    this.writes.push(Buffer.from(data));
+    return true;
+  }
+
+  pause(): this {
+    this.paused = true;
+    return this;
+  }
+
+  resume(): this {
+    this.paused = false;
+    return this;
+  }
+
+  destroy(): this {
+    if (this.destroyed) return this;
+    this.destroyed = true;
+    queueMicrotask(() => this.emit("close"));
+    return this;
+  }
+
+  send(data: Uint8Array): void {
+    this.emit("data", Buffer.from(data));
+  }
+}
+
+class FakeServer extends EventEmitter {
+  private listening = false;
+
+  constructor(private readonly acceptCallback: (socket: net.Socket) => void) {
+    super();
+  }
+
+  listen(_port: number, _host: string, callback: () => void): this {
+    this.listening = true;
+    queueMicrotask(callback);
+    return this;
+  }
+
+  address(): net.AddressInfo | null {
+    return this.listening
+      ? { address: "127.0.0.1", family: "IPv4", port: 43123 }
+      : null;
+  }
+
+  close(callback?: () => void): this {
+    if (!this.listening) return this;
+    this.listening = false;
+    queueMicrotask(() => {
+      this.emit("close");
+      callback?.();
+    });
+    return this;
+  }
+
+  accept(): FakeLocalSocket {
+    const socket = new FakeLocalSocket();
+    this.acceptCallback(socket as unknown as net.Socket);
+    return socket;
+  }
+}
+
+function createLoopbackConnection(): AuthenticatedSyncConnection {
+  const envelopeCallbacks = new Set<(envelope: ParsedSyncEnvelope) => void>();
+  const errorCallbacks = new Set<(error: Error) => void>();
+  const closeCallbacks = new Set<() => void>();
+  return {
+    endpoint: "ws://loopback.test/",
+    hello: { features: { rpcChannel: true, portForward: true } },
+    credentials: {},
+    send(
+      type: Parameters<AuthenticatedSyncConnection["send"]>[0],
+      payload: unknown,
+    ) {
+      if (type !== "fwd_data") return;
+      const envelope = {
+        version: 1,
+        type: "fwd_data",
+        projectId: null,
+        requestId: null,
+        compression: "none",
+        payload,
+        raw: {} as never,
+      } as ParsedSyncEnvelope;
+      queueMicrotask(() => {
+        for (const callback of [...envelopeCallbacks]) callback(envelope);
+      });
+    },
+    onEnvelope(callback: (envelope: ParsedSyncEnvelope) => void) {
+      envelopeCallbacks.add(callback);
+      return () => envelopeCallbacks.delete(callback);
+    },
+    onError(callback: (error: Error) => void) {
+      errorCallbacks.add(callback);
+      return () => errorCallbacks.delete(callback);
+    },
+    onClose(callback: () => void) {
+      closeCallbacks.add(callback);
+      return () => closeCallbacks.delete(callback);
+    },
+    bufferedAmount: () => 0,
+    close() {
+      for (const callback of [...closeCallbacks]) callback();
+    },
+  } as unknown as AuthenticatedSyncConnection;
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("SyncPortForwardClient", () => {
+  it("binds an ephemeral loopback listener and echoes local bytes through fwd envelopes", async () => {
+    let server: FakeServer | null = null;
+    const createServer = ((callback: (socket: net.Socket) => void) => {
+      server = new FakeServer(callback);
+      return server as unknown as net.Server;
+    }) as typeof net.createServer;
+    const client = new SyncPortForwardClient(createLoopbackConnection(), { createServer });
+
+    const forward = await client.ensureForward("localhost", 4173);
+    expect(forward).toMatchObject({
+      remoteHost: "localhost",
+      remotePort: 4173,
+      localHost: "127.0.0.1",
+      localPort: 43123,
+      localUrl: "http://127.0.0.1:43123",
+    });
+    const socket = server!.accept();
+    const payload = Buffer.from("forwarded over the paired sync channel", "utf8");
+    socket.send(payload);
+    await flushMicrotasks();
+    expect(Buffer.concat(socket.writes)).toEqual(payload);
+
+    const reused = await client.ensureForward("localhost", 4173);
+    expect(reused.localPort).toBe(forward.localPort);
+    expect(reused.lastUsedAt).toBeGreaterThanOrEqual(forward.lastUsedAt);
+    client.dispose();
+    expect(socket.destroyed).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/services/remoteRuntime/syncPortForwardClient.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncPortForwardClient.ts
@@ -1,13 +1,16 @@
 import net from "node:net";
 import { randomUUID } from "node:crypto";
 import type { PairedRuntimePortForward } from "../../../shared/types/pairedRuntime";
+import {
+  BACKPRESSURE_POLL_MS,
+  decodeStrictBase64,
+  FORWARD_DATA_CHUNK_BYTES,
+  PEER_BACKPRESSURE_BYTES,
+} from "../sync/syncProtocol";
 import type { AuthenticatedSyncConnection } from "./syncRuntimeTransport";
 
 const LOCAL_FORWARD_HOST = "127.0.0.1" as const;
-const FORWARD_DATA_CHUNK_BYTES = 64 * 1024;
 const MAX_PENDING_BYTES = 4 * 1024 * 1024;
-const PEER_BACKPRESSURE_BYTES = 4 * 1024 * 1024;
-const BACKPRESSURE_POLL_MS = 25;
 
 type ActiveSocket = {
   socket: net.Socket;
@@ -54,15 +57,6 @@ function snapshot(entry: ForwardEntry): PairedRuntimePortForward {
   };
 }
 
-function strictBase64Bytes(value: unknown): Buffer | null {
-  if (typeof value !== "string") return null;
-  if (value === "") return Buffer.alloc(0);
-  if (value.length % 4 !== 0 || !/^[a-zA-Z0-9+/]*={0,2}$/.test(value)) {
-    return null;
-  }
-  return Buffer.from(value, "base64");
-}
-
 export class SyncPortForwardClient {
   private readonly forwards = new Map<string, Promise<ForwardEntry>>();
   private readonly sockets = new Map<string, ActiveSocket>();
@@ -93,7 +87,7 @@ export class SyncPortForwardClient {
         this.closeActiveSocket(active, false);
         return;
       }
-      const bytes = strictBase64Bytes(payload.data);
+      const bytes = decodeStrictBase64(payload.data);
       if (!bytes) {
         this.closeActiveSocket(active, true, "Forward received invalid base64 data.");
         return;

--- a/apps/desktop/src/main/services/remoteRuntime/syncPortForwardClient.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncPortForwardClient.ts
@@ -1,0 +1,339 @@
+import net from "node:net";
+import { randomUUID } from "node:crypto";
+import type { PairedRuntimePortForward } from "../../../shared/types/pairedRuntime";
+import type { AuthenticatedSyncConnection } from "./syncRuntimeTransport";
+
+const LOCAL_FORWARD_HOST = "127.0.0.1" as const;
+const FORWARD_DATA_CHUNK_BYTES = 64 * 1024;
+const MAX_PENDING_BYTES = 4 * 1024 * 1024;
+const PEER_BACKPRESSURE_BYTES = 4 * 1024 * 1024;
+const BACKPRESSURE_POLL_MS = 25;
+
+type ActiveSocket = {
+  socket: net.Socket;
+  forwardId: string;
+  ownerSockets: Map<string, ActiveSocket>;
+  outboundPending: Buffer[];
+  outboundPendingBytes: number;
+  outboundTimer: ReturnType<typeof setInterval> | null;
+  remoteClosed: boolean;
+};
+
+type ForwardEntry = PairedRuntimePortForward & {
+  server: net.Server;
+  sockets: Map<string, ActiveSocket>;
+};
+
+function normalizeRemoteHost(value: string): "127.0.0.1" | "localhost" {
+  const host = value.trim().toLowerCase();
+  if (host === "127.0.0.1" || host === "localhost") return host;
+  throw new Error("Paired runtime forwards may target only 127.0.0.1 or localhost.");
+}
+
+function normalizeRemotePort(value: number): number {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`Remote port must be an integer from 1 to 65535 (received ${String(value)}).`);
+  }
+  return port;
+}
+
+function forwardKey(host: string, port: number): string {
+  return `${host}:${port}`;
+}
+
+function snapshot(entry: ForwardEntry): PairedRuntimePortForward {
+  return {
+    remoteHost: entry.remoteHost,
+    remotePort: entry.remotePort,
+    localHost: entry.localHost,
+    localPort: entry.localPort,
+    localUrl: entry.localUrl,
+    createdAt: entry.createdAt,
+    lastUsedAt: entry.lastUsedAt,
+  };
+}
+
+function strictBase64Bytes(value: unknown): Buffer | null {
+  if (typeof value !== "string") return null;
+  if (value === "") return Buffer.alloc(0);
+  if (value.length % 4 !== 0 || !/^[a-zA-Z0-9+/]*={0,2}$/.test(value)) {
+    return null;
+  }
+  return Buffer.from(value, "base64");
+}
+
+export class SyncPortForwardClient {
+  private readonly forwards = new Map<string, Promise<ForwardEntry>>();
+  private readonly sockets = new Map<string, ActiveSocket>();
+  private readonly removeEnvelopeListener: () => void;
+  private readonly removeCloseListener: () => void;
+  private readonly removeErrorListener: () => void;
+  private disposed = false;
+
+  constructor(
+    private readonly connection: AuthenticatedSyncConnection,
+    private readonly options: { createServer?: typeof net.createServer } = {},
+  ) {
+    if (connection.hello.features?.portForward !== true) {
+      throw new Error("The paired machine does not advertise port-forward support.");
+    }
+    this.removeEnvelopeListener = connection.onEnvelope((envelope) => {
+      if (envelope.type !== "fwd_data" && envelope.type !== "fwd_close") return;
+      const payload = envelope.payload as {
+        forwardId?: unknown;
+        data?: unknown;
+        reason?: unknown;
+      };
+      if (typeof payload.forwardId !== "string") return;
+      const active = this.sockets.get(payload.forwardId);
+      if (!active) return;
+      if (envelope.type === "fwd_close") {
+        active.remoteClosed = true;
+        this.closeActiveSocket(active, false);
+        return;
+      }
+      const bytes = strictBase64Bytes(payload.data);
+      if (!bytes) {
+        this.closeActiveSocket(active, true, "Forward received invalid base64 data.");
+        return;
+      }
+      if (!active.socket.write(bytes) || active.socket.writableLength > MAX_PENDING_BYTES) {
+        if (active.socket.writableLength > MAX_PENDING_BYTES) {
+          this.closeActiveSocket(active, true, "Forwarded data exceeded the local pending buffer limit.");
+        }
+      }
+    });
+    this.removeCloseListener = connection.onClose(() => this.dispose(false));
+    this.removeErrorListener = connection.onError(() => this.dispose(false));
+  }
+
+  async ensureForward(
+    remoteHostValue: string,
+    remotePortValue: number,
+  ): Promise<PairedRuntimePortForward> {
+    if (this.disposed) throw new Error("Sync port-forward client is closed.");
+    const remoteHost = normalizeRemoteHost(remoteHostValue);
+    const remotePort = normalizeRemotePort(remotePortValue);
+    const key = forwardKey(remoteHost, remotePort);
+    const existing = this.forwards.get(key);
+    if (existing) {
+      const entry = await existing;
+      entry.lastUsedAt = Date.now();
+      return snapshot(entry);
+    }
+
+    const pending = this.createForward(remoteHost, remotePort);
+    this.forwards.set(key, pending);
+    try {
+      const entry = await pending;
+      entry.server.once("close", () => {
+        if (this.forwards.get(key) === pending) this.forwards.delete(key);
+      });
+      return snapshot(entry);
+    } catch (error) {
+      if (this.forwards.get(key) === pending) this.forwards.delete(key);
+      throw error;
+    }
+  }
+
+  dispose(notifyRemote = true): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.removeEnvelopeListener();
+    this.removeCloseListener();
+    this.removeErrorListener();
+    for (const active of [...this.sockets.values()]) {
+      this.closeActiveSocket(active, notifyRemote, "Port-forward client closed.");
+    }
+    for (const pending of this.forwards.values()) {
+      void pending.then((entry) => {
+        try {
+          entry.server.close();
+        } catch {
+          // Best-effort listener cleanup.
+        }
+      }).catch(() => {});
+    }
+    this.forwards.clear();
+  }
+
+  private async createForward(
+    remoteHost: "127.0.0.1" | "localhost",
+    remotePort: number,
+  ): Promise<ForwardEntry> {
+    const sockets = new Map<string, ActiveSocket>();
+    const server = (this.options.createServer ?? net.createServer)((socket) => {
+      if (this.disposed) {
+        socket.destroy();
+        return;
+      }
+      const forwardId = randomUUID();
+      const active: ActiveSocket = {
+        socket,
+        forwardId,
+        ownerSockets: sockets,
+        outboundPending: [],
+        outboundPendingBytes: 0,
+        outboundTimer: null,
+        remoteClosed: false,
+      };
+      sockets.set(forwardId, active);
+      this.sockets.set(forwardId, active);
+      socket.on("data", (data) => this.sendLocalData(active, Buffer.from(data)));
+      socket.once("error", () => this.closeActiveSocket(active, true, "Local forward socket failed."));
+      socket.once("close", () => this.closeActiveSocket(active, !active.remoteClosed));
+      try {
+        this.connection.send("fwd_open", { forwardId, host: remoteHost, port: remotePort });
+      } catch {
+        this.closeActiveSocket(active, false);
+      }
+    });
+
+    return await new Promise<ForwardEntry>((resolve, reject) => {
+      let settled = false;
+      const fail = (error: Error) => {
+        if (settled) return;
+        settled = true;
+        try {
+          server.close();
+        } catch {
+          // The listener may not have bound yet.
+        }
+        reject(error);
+      };
+      server.once("error", fail);
+      server.listen(0, LOCAL_FORWARD_HOST, () => {
+        if (settled) return;
+        if (this.disposed) {
+          fail(new Error("Sync port-forward client closed before the listener was ready."));
+          return;
+        }
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          fail(new Error("Local paired-runtime forward did not bind to a TCP port."));
+          return;
+        }
+        settled = true;
+        server.off("error", fail);
+        server.on("error", () => {
+          for (const active of [...sockets.values()]) {
+            this.closeActiveSocket(active, true, "Local forward listener failed.");
+          }
+          try {
+            server.close();
+          } catch {
+            // The listener may already be closed.
+          }
+        });
+        const createdAt = Date.now();
+        resolve({
+          remoteHost,
+          remotePort,
+          localHost: LOCAL_FORWARD_HOST,
+          localPort: address.port,
+          localUrl: `http://${LOCAL_FORWARD_HOST}:${address.port}`,
+          createdAt,
+          lastUsedAt: createdAt,
+          server,
+          sockets,
+        });
+      });
+    });
+  }
+
+  private sendLocalData(active: ActiveSocket, data: Buffer): void {
+    for (let offset = 0; offset < data.byteLength; offset += FORWARD_DATA_CHUNK_BYTES) {
+      const chunk = Buffer.from(data.subarray(
+        offset,
+        Math.min(data.byteLength, offset + FORWARD_DATA_CHUNK_BYTES),
+      ));
+      if (
+        active.outboundPending.length > 0
+        || this.connection.bufferedAmount() >= PEER_BACKPRESSURE_BYTES
+      ) {
+        if (active.outboundPendingBytes + chunk.byteLength > MAX_PENDING_BYTES) {
+          this.closeActiveSocket(active, true, "Forwarded data exceeded the sync pending buffer limit.");
+          return;
+        }
+        active.outboundPending.push(chunk);
+        active.outboundPendingBytes += chunk.byteLength;
+        active.socket.pause();
+        this.scheduleOutboundFlush(active);
+        continue;
+      }
+      try {
+        this.connection.send("fwd_data", {
+          forwardId: active.forwardId,
+          data: chunk.toString("base64"),
+        });
+      } catch {
+        this.closeActiveSocket(active, false);
+        return;
+      }
+    }
+  }
+
+  private scheduleOutboundFlush(active: ActiveSocket): void {
+    if (active.outboundTimer) return;
+    active.outboundTimer = setInterval(() => {
+      if (!this.sockets.has(active.forwardId)) {
+        if (active.outboundTimer) clearInterval(active.outboundTimer);
+        active.outboundTimer = null;
+        return;
+      }
+      while (
+        active.outboundPending.length > 0
+        && this.connection.bufferedAmount() < PEER_BACKPRESSURE_BYTES
+      ) {
+        const chunk = active.outboundPending.shift()!;
+        active.outboundPendingBytes -= chunk.byteLength;
+        try {
+          this.connection.send("fwd_data", {
+            forwardId: active.forwardId,
+            data: chunk.toString("base64"),
+          });
+        } catch {
+          this.closeActiveSocket(active, false);
+          return;
+        }
+      }
+      if (active.outboundPending.length > 0) return;
+      if (active.outboundTimer) clearInterval(active.outboundTimer);
+      active.outboundTimer = null;
+      active.socket.resume();
+    }, BACKPRESSURE_POLL_MS);
+    active.outboundTimer.unref?.();
+  }
+
+  private closeActiveSocket(
+    active: ActiveSocket,
+    notifyRemote: boolean,
+    reason = "Local forward socket closed.",
+  ): void {
+    if (!this.sockets.delete(active.forwardId)) return;
+    active.ownerSockets.delete(active.forwardId);
+    if (active.outboundTimer) clearInterval(active.outboundTimer);
+    active.outboundTimer = null;
+    active.outboundPending = [];
+    active.outboundPendingBytes = 0;
+    if (notifyRemote) {
+      try {
+        this.connection.send("fwd_close", { forwardId: active.forwardId, reason });
+      } catch {
+        // The connection is already gone.
+      }
+    }
+    try {
+      active.socket.destroy();
+    } catch {
+      // Best-effort local socket teardown.
+    }
+  }
+}
+
+export function createSyncPortForwardClient(
+  connection: AuthenticatedSyncConnection,
+): SyncPortForwardClient {
+  return new SyncPortForwardClient(connection);
+}

--- a/apps/desktop/src/main/services/remoteRuntime/syncRuntimeTransport.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncRuntimeTransport.test.ts
@@ -1,0 +1,157 @@
+import { EventEmitter } from "node:events";
+import { generateKeyPairSync } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type { WebSocket } from "ws";
+import type { DesktopPairedMachineCredentials } from "../../../shared/types/pairedRuntime";
+import { encodeSyncEnvelope, parseSyncEnvelope, wsDataToText } from "../sync/syncProtocol";
+import { RuntimeRpcClient } from "./runtimeRpcClient";
+import { openSyncRuntimeTransport } from "./syncRuntimeTransport";
+
+class FakeWebSocket extends EventEmitter {
+  readyState = 0;
+  bufferedAmount = 0;
+
+  constructor(private readonly onSend: (text: string, ws: FakeWebSocket) => void) {
+    super();
+    queueMicrotask(() => {
+      this.readyState = 1;
+      this.emit("open");
+    });
+  }
+
+  send(data: string | Buffer): void {
+    this.onSend(data.toString(), this);
+  }
+
+  receive(text: string): void {
+    queueMicrotask(() => this.emit("message", Buffer.from(text, "utf8")));
+  }
+
+  close(): void {
+    if (this.readyState === 3) return;
+    this.readyState = 3;
+    queueMicrotask(() => this.emit("close"));
+  }
+}
+
+function credentials(): DesktopPairedMachineCredentials {
+  const pair = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+  const jwk = pair.publicKey.export({ format: "jwk" }) as { x?: string; y?: string };
+  const publicKey = Buffer.concat([
+    Buffer.from([0x04]),
+    Buffer.from(jwk.x!, "base64url"),
+    Buffer.from(jwk.y!, "base64url"),
+  ]).toString("base64");
+  return {
+    version: 1,
+    hostIdentity: {
+      deviceId: "host-1",
+      siteId: "host-site-1",
+      name: "Mac Studio",
+      platform: "macOS",
+      deviceType: "desktop",
+    },
+    machineKey: null,
+    deviceId: "desktop-1",
+    siteId: "desktop-site-1",
+    deviceName: "My Mac",
+    secret: "paired-secret",
+    dpopPrivateKey: pair.privateKey.export({ format: "der", type: "pkcs8" }).toString("base64"),
+    dpopPublicKey: publicKey,
+    endpoints: [],
+    createdAt: new Date(0).toISOString(),
+    updatedAt: new Date(0).toISOString(),
+  };
+}
+
+describe("openSyncRuntimeTransport", () => {
+  it("authenticates, opens RPC, and lets RuntimeRpcClient parse a response split across rpc_data frames", async () => {
+    let observedHello: Record<string, unknown> | null = null;
+    let observedChannelId: string | null = null;
+    const createWebSocket = () => new FakeWebSocket((text, ws) => {
+        const envelope = parseSyncEnvelope(wsDataToText(text));
+        if (envelope.type === "hello") {
+          observedHello = envelope.payload as Record<string, unknown>;
+          ws.receive(encodeSyncEnvelope({
+            type: "hello_ok",
+            requestId: envelope.requestId,
+            payload: {
+              peer: (envelope.payload as { peer: unknown }).peer,
+              brain: {
+                deviceId: "host-1",
+                deviceName: "Mac Studio",
+                platform: "macOS",
+                deviceType: "desktop",
+                siteId: "host-site-1",
+                dbVersion: 0,
+              },
+              serverDbVersion: 0,
+              heartbeatIntervalMs: 5_000,
+              pollIntervalMs: 1_500,
+              features: { rpcChannel: true, portForward: true },
+            },
+          }));
+          return;
+        }
+        if (envelope.type === "rpc_open") {
+          observedChannelId = (envelope.payload as { channelId: string }).channelId;
+          return;
+        }
+        if (envelope.type !== "rpc_data") return;
+        const payload = envelope.payload as { channelId: string; data: string };
+        const request = JSON.parse(Buffer.from(payload.data, "base64").toString("utf8").trim()) as {
+          id: number;
+          method: string;
+        };
+        expect(request.method).toBe("ade/initialize");
+        const response = Buffer.from(`${JSON.stringify({
+          jsonrpc: "2.0",
+          id: request.id,
+          result: { runtimeInfo: { name: "ade-rpc", multiProject: true } },
+        })}\n`, "utf8");
+        const split = 23;
+        for (const part of [response.subarray(0, split), response.subarray(split)]) {
+          ws.receive(encodeSyncEnvelope({
+            type: "rpc_data",
+            payload: {
+              channelId: payload.channelId,
+              data: part.toString("base64"),
+            },
+          }));
+        }
+    }) as unknown as WebSocket;
+
+    const paired = credentials();
+    paired.endpoints = ["ws://sync.test"];
+    const transport = await openSyncRuntimeTransport({
+      credentials: paired,
+      channelId: "runtime-test",
+      connectTimeoutMs: 2_000,
+      authTimeoutMs: 2_000,
+      createWebSocket,
+    });
+    const client = new RuntimeRpcClient(transport, 2_000);
+
+    await expect(client.initialize("desktop-test", "1.2.3")).resolves.toEqual({
+      runtimeInfo: { name: "ade-rpc", multiProject: true },
+    });
+    expect(observedChannelId).toBe("runtime-test");
+    expect(observedHello).toMatchObject({
+      peer: { deviceType: "desktop", deviceId: "desktop-1" },
+      auth: {
+        kind: "paired",
+        deviceId: "desktop-1",
+        secret: "paired-secret",
+        dpop: {
+          publicKey: paired.dpopPublicKey,
+          timestamp: expect.any(Number),
+          nonce: expect.any(String),
+          signature: expect.any(String),
+        },
+      },
+    });
+    client.close();
+    expect(transport.connection.endpoint).toBe("ws://sync.test/");
+    expect(transport.connection).toBeDefined();
+  });
+});

--- a/apps/desktop/src/main/services/remoteRuntime/syncRuntimeTransport.test.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncRuntimeTransport.test.ts
@@ -3,7 +3,12 @@ import { generateKeyPairSync } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import type { WebSocket } from "ws";
 import type { DesktopPairedMachineCredentials } from "../../../shared/types/pairedRuntime";
-import { encodeSyncEnvelope, parseSyncEnvelope, wsDataToText } from "../sync/syncProtocol";
+import {
+  encodeSyncEnvelope,
+  parseSyncEnvelope,
+  SYNC_RUNTIME_ONLY_CAPABILITY,
+  wsDataToText,
+} from "../sync/syncProtocol";
 import { RuntimeRpcClient } from "./runtimeRpcClient";
 import { openSyncRuntimeTransport } from "./syncRuntimeTransport";
 
@@ -137,7 +142,11 @@ describe("openSyncRuntimeTransport", () => {
     });
     expect(observedChannelId).toBe("runtime-test");
     expect(observedHello).toMatchObject({
-      peer: { deviceType: "desktop", deviceId: "desktop-1" },
+      peer: {
+        deviceType: "desktop",
+        deviceId: "desktop-1",
+        capabilities: expect.arrayContaining([SYNC_RUNTIME_ONLY_CAPABILITY]),
+      },
       auth: {
         kind: "paired",
         deviceId: "desktop-1",

--- a/apps/desktop/src/main/services/remoteRuntime/syncRuntimeTransport.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncRuntimeTransport.ts
@@ -1,0 +1,562 @@
+import {
+  createPrivateKey,
+  randomBytes,
+  randomUUID,
+  sign,
+} from "node:crypto";
+import { WebSocket, type RawData } from "ws";
+import type {
+  DesktopPairedMachineCredentials,
+  PairedRuntimeHelloOkPayload,
+} from "../../../shared/types/pairedRuntime";
+import type {
+  SyncEnvelope,
+  SyncHelloErrorPayload,
+  SyncHelloPayload,
+} from "../../../shared/types/sync";
+import {
+  buildSyncDpopChallenge,
+  sha256Hex,
+} from "../../../../../ade-cli/src/services/sync/syncDpop";
+import {
+  createSyncEnvelopeChunkAssembler,
+  encodeSyncEnvelope,
+  parseSyncEnvelope,
+  parseSyncEnvelopeChunkPayload,
+  SYNC_CHUNKED_ENVELOPES_CAPABILITY,
+  wsDataToText,
+  type ParsedSyncEnvelope,
+} from "../sync/syncProtocol";
+import type { RuntimeRpcTransport } from "./runtimeRpcClient";
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+const DEFAULT_AUTH_TIMEOUT_MS = 10_000;
+const RPC_DATA_CHUNK_BYTES = 256 * 1024;
+const MAX_CHANNEL_ID_CHARS = 128;
+
+export type SyncEnvelopeConnection = {
+  readonly endpoint: string;
+  send(type: SyncEnvelope["type"], payload: unknown, requestId?: string | null): void;
+  onEnvelope(callback: (envelope: ParsedSyncEnvelope) => void): () => void;
+  onError(callback: (error: Error) => void): () => void;
+  onClose(callback: () => void): () => void;
+  bufferedAmount(): number;
+  close(code?: number, reason?: string): void;
+};
+
+export type AuthenticatedSyncConnection = SyncEnvelopeConnection & {
+  readonly hello: PairedRuntimeHelloOkPayload;
+  readonly credentials: DesktopPairedMachineCredentials;
+};
+
+export type OpenSyncEnvelopeConnectionOptions = {
+  endpoint: string;
+  connectTimeoutMs?: number;
+  createWebSocket?: (endpoint: string) => WebSocket;
+};
+
+export type OpenPairedSyncConnectionOptions = OpenSyncEnvelopeConnectionOptions & {
+  credentials: DesktopPairedMachineCredentials;
+  authTimeoutMs?: number;
+  appVersion?: string;
+};
+
+export type OpenSyncRuntimeTransportOptions = Omit<
+  OpenPairedSyncConnectionOptions,
+  "endpoint"
+> & {
+  endpoint?: string;
+  channelId?: string;
+};
+
+export type SyncRuntimeTransport = RuntimeRpcTransport & {
+  readonly channelId: string;
+  readonly connection: AuthenticatedSyncConnection;
+};
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function normalizeTimeout(value: number | undefined, fallback: number): number {
+  const timeout = Number(value ?? fallback);
+  if (!Number.isFinite(timeout) || timeout <= 0) {
+    throw new Error("Sync connection timeout must be a finite positive number.");
+  }
+  return Math.min(2_147_483_647, Math.ceil(timeout));
+}
+
+export function normalizeSyncEndpoint(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error("A sync WebSocket endpoint is required.");
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new Error(`Invalid sync endpoint: ${trimmed}`);
+  }
+  if (url.protocol === "http:") url.protocol = "ws:";
+  if (url.protocol === "https:") url.protocol = "wss:";
+  if (url.protocol !== "ws:" && url.protocol !== "wss:") {
+    throw new Error("Sync endpoints must use ws:// or wss://.");
+  }
+  if (url.username || url.password) {
+    throw new Error("Sync endpoints must not contain embedded credentials.");
+  }
+  url.hash = "";
+  return url.toString();
+}
+
+function websocketCloseReason(value: string): string {
+  let reason = value;
+  while (Buffer.byteLength(reason, "utf8") > 123) {
+    reason = reason.slice(0, -1);
+  }
+  return reason;
+}
+
+function strictBase64Bytes(value: unknown): Buffer | null {
+  if (typeof value !== "string") return null;
+  if (value === "") return Buffer.alloc(0);
+  if (value.length % 4 !== 0 || !/^[a-zA-Z0-9+/]*={0,2}$/.test(value)) {
+    return null;
+  }
+  return Buffer.from(value, "base64");
+}
+
+function channelId(value: string | undefined): string {
+  const normalized = value?.trim() || randomUUID();
+  if (
+    normalized.length > MAX_CHANNEL_ID_CHARS
+    || !/^[a-zA-Z0-9._:-]+$/.test(normalized)
+  ) {
+    throw new Error("Sync runtime channelId is invalid.");
+  }
+  return normalized;
+}
+
+function emitCallbacks<T>(callbacks: Set<(value: T) => void>, value: T): void {
+  for (const callback of [...callbacks]) {
+    try {
+      callback(value);
+    } catch {
+      // A consumer callback must not break delivery to the other consumers.
+    }
+  }
+}
+
+function createConnection(
+  endpoint: string,
+  ws: WebSocket,
+): SyncEnvelopeConnection {
+  const envelopeCallbacks = new Set<(envelope: ParsedSyncEnvelope) => void>();
+  const errorCallbacks = new Set<(error: Error) => void>();
+  const closeCallbacks = new Set<() => void>();
+  const chunkAssembler = createSyncEnvelopeChunkAssembler();
+  let closeEmitted = false;
+
+  const emitError = (error: unknown): void => {
+    emitCallbacks(errorCallbacks, asError(error));
+  };
+  const emitClose = (): void => {
+    if (closeEmitted) return;
+    closeEmitted = true;
+    chunkAssembler.reset();
+    for (const callback of [...closeCallbacks]) {
+      try {
+        callback();
+      } catch {
+        // Continue notifying the remaining consumers.
+      }
+    }
+  };
+  const acceptText = (text: string): void => {
+    let envelope: ParsedSyncEnvelope;
+    try {
+      envelope = parseSyncEnvelope(text);
+      if (envelope.type === "envelope_chunk") {
+        const chunk = parseSyncEnvelopeChunkPayload(envelope.payload);
+        if (!chunk) throw new Error("Invalid sync envelope chunk payload.");
+        const assembled = chunkAssembler.add(chunk);
+        if (assembled == null) return;
+        envelope = parseSyncEnvelope(assembled);
+        if (envelope.type === "envelope_chunk") {
+          throw new Error("Nested sync envelope chunks are not supported.");
+        }
+      }
+    } catch (error) {
+      emitError(error);
+      try {
+        ws.close(1003, "Invalid sync envelope");
+      } catch {
+        // The socket may already be closing.
+      }
+      return;
+    }
+    emitCallbacks(envelopeCallbacks, envelope);
+  };
+
+  ws.on("message", (data: RawData) => acceptText(wsDataToText(data)));
+  ws.on("error", emitError);
+  ws.on("close", emitClose);
+
+  return {
+    endpoint,
+    send(type, payload, requestId) {
+      if (ws.readyState !== WebSocket.OPEN) {
+        throw new Error("Sync WebSocket is not open.");
+      }
+      ws.send(encodeSyncEnvelope({ type, payload, requestId }));
+    },
+    onEnvelope(callback) {
+      envelopeCallbacks.add(callback);
+      return () => envelopeCallbacks.delete(callback);
+    },
+    onError(callback) {
+      errorCallbacks.add(callback);
+      return () => errorCallbacks.delete(callback);
+    },
+    onClose(callback) {
+      if (closeEmitted) {
+        queueMicrotask(callback);
+        return () => {};
+      }
+      closeCallbacks.add(callback);
+      return () => closeCallbacks.delete(callback);
+    },
+    bufferedAmount: () => ws.bufferedAmount,
+    close(code = 1000, reason = "Sync connection closed.") {
+      if (ws.readyState === WebSocket.CLOSED) {
+        emitClose();
+        return;
+      }
+      try {
+        ws.close(code, websocketCloseReason(reason));
+      } catch (error) {
+        emitError(error);
+        emitClose();
+      }
+    },
+  };
+}
+
+export async function openSyncEnvelopeConnection(
+  options: OpenSyncEnvelopeConnectionOptions,
+): Promise<SyncEnvelopeConnection> {
+  const endpoint = normalizeSyncEndpoint(options.endpoint);
+  const timeoutMs = normalizeTimeout(options.connectTimeoutMs, DEFAULT_CONNECT_TIMEOUT_MS);
+  const ws = options.createWebSocket?.(endpoint) ?? new WebSocket(endpoint);
+  const connection = createConnection(endpoint, ws);
+
+  if (ws.readyState === WebSocket.OPEN) return connection;
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      connection.close(1000, "Sync connection timed out.");
+      reject(new Error(`Timed out connecting to sync endpoint after ${timeoutMs}ms.`));
+    }, timeoutMs);
+    timer.unref?.();
+    const onOpen = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      connection.close(1000, "Sync connection failed.");
+      reject(new Error(`Failed to connect to sync endpoint: ${error.message}`));
+    };
+    const onClose = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error("Sync endpoint closed before the connection opened."));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      ws.off("open", onOpen);
+      ws.off("error", onError);
+      ws.off("close", onClose);
+    };
+    ws.once("open", onOpen);
+    ws.once("error", onError);
+    ws.once("close", onClose);
+  });
+  return connection;
+}
+
+export function createDesktopSyncDpopProof(
+  credentials: Pick<
+    DesktopPairedMachineCredentials,
+    "deviceId" | "secret" | "dpopPrivateKey" | "dpopPublicKey"
+  >,
+) {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const nonce = randomBytes(18).toString("base64url");
+  const challenge = buildSyncDpopChallenge({
+    deviceId: credentials.deviceId,
+    secretSha256Hex: sha256Hex(credentials.secret),
+    timestamp,
+    nonce,
+  });
+  let privateKey;
+  try {
+    privateKey = createPrivateKey({
+      key: Buffer.from(credentials.dpopPrivateKey, "base64"),
+      format: "der",
+      type: "pkcs8",
+    });
+  } catch (error) {
+    throw new Error(`Stored desktop pairing key is invalid: ${asError(error).message}`);
+  }
+  return {
+    publicKey: credentials.dpopPublicKey,
+    timestamp,
+    nonce,
+    signature: sign("sha256", Buffer.from(challenge, "utf8"), privateKey).toString("base64"),
+  };
+}
+
+export function buildDesktopPairedHello(
+  credentials: DesktopPairedMachineCredentials,
+  appVersion?: string,
+): SyncHelloPayload {
+  return {
+    peer: {
+      deviceId: credentials.deviceId,
+      deviceName: credentials.deviceName,
+      platform: process.platform === "darwin"
+        ? "macOS"
+        : process.platform === "win32"
+          ? "windows"
+          : process.platform === "linux"
+            ? "linux"
+            : "unknown",
+      deviceType: "desktop",
+      siteId: credentials.siteId,
+      dbVersion: 0,
+      capabilities: [SYNC_CHUNKED_ENVELOPES_CAPABILITY],
+      ...(appVersion?.trim() ? { appVersion: appVersion.trim() } : {}),
+    },
+    auth: {
+      kind: "paired",
+      deviceId: credentials.deviceId,
+      secret: credentials.secret,
+      dpop: createDesktopSyncDpopProof(credentials),
+    },
+  };
+}
+
+export async function waitForSyncEnvelope(
+  connection: SyncEnvelopeConnection,
+  predicate: (envelope: ParsedSyncEnvelope) => boolean,
+  timeoutMs = DEFAULT_AUTH_TIMEOUT_MS,
+): Promise<ParsedSyncEnvelope> {
+  const normalizedTimeout = normalizeTimeout(timeoutMs, DEFAULT_AUTH_TIMEOUT_MS);
+  return await new Promise<ParsedSyncEnvelope>((resolve, reject) => {
+    let settled = false;
+    const finish = (action: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      removeEnvelope();
+      removeError();
+      removeClose();
+      action();
+    };
+    const timer = setTimeout(() => {
+      finish(() => reject(new Error(`Timed out waiting for sync response after ${normalizedTimeout}ms.`)));
+    }, normalizedTimeout);
+    timer.unref?.();
+    const removeEnvelope = connection.onEnvelope((envelope) => {
+      if (predicate(envelope)) finish(() => resolve(envelope));
+    });
+    const removeError = connection.onError((error) => finish(() => reject(error)));
+    const removeClose = connection.onClose(() => {
+      finish(() => reject(new Error("Sync connection closed before the expected response arrived.")));
+    });
+  });
+}
+
+function helloError(payload: unknown): Error {
+  const value = payload as Partial<SyncHelloErrorPayload> | null;
+  const message = typeof value?.message === "string" && value.message.trim()
+    ? value.message.trim()
+    : "Sync authentication failed.";
+  return new Error(message);
+}
+
+export async function openPairedSyncConnection(
+  options: OpenPairedSyncConnectionOptions,
+): Promise<AuthenticatedSyncConnection> {
+  const connection = await openSyncEnvelopeConnection(options);
+  const requestId = `hello-${randomUUID()}`;
+  let response: Promise<ParsedSyncEnvelope> | null = null;
+  try {
+    const helloPayload = buildDesktopPairedHello(options.credentials, options.appVersion);
+    response = waitForSyncEnvelope(
+      connection,
+      (envelope) => envelope.requestId === requestId
+        && (envelope.type === "hello_ok" || envelope.type === "hello_error"),
+      options.authTimeoutMs,
+    );
+    connection.send(
+      "hello",
+      helloPayload,
+      requestId,
+    );
+    const envelope = await response;
+    if (envelope.type === "hello_error") throw helloError(envelope.payload);
+    const hello = envelope.payload as PairedRuntimeHelloOkPayload;
+    const actualHostId = hello?.brain?.deviceId?.trim();
+    const expectedHostId = options.credentials.hostIdentity.deviceId.trim();
+    if (!actualHostId || actualHostId !== expectedHostId) {
+      throw new Error(
+        `Sync endpoint identity mismatch (expected ${expectedHostId || "unknown"}, received ${actualHostId || "unknown"}).`,
+      );
+    }
+    return Object.assign(connection, {
+      hello,
+      credentials: options.credentials,
+    });
+  } catch (error) {
+    void response?.catch(() => {});
+    connection.close(1000, "Sync authentication failed.");
+    throw error;
+  }
+}
+
+export async function openSyncRuntimeTransport(
+  options: OpenSyncRuntimeTransportOptions,
+): Promise<SyncRuntimeTransport> {
+  const endpoint = options.endpoint?.trim() || options.credentials.endpoints[0]?.trim();
+  if (!endpoint) throw new Error("The paired machine has no sync endpoint.");
+  const connection = await openPairedSyncConnection({ ...options, endpoint });
+  if (connection.hello.features?.rpcChannel !== true) {
+    connection.close(1000, "Runtime RPC is unavailable.");
+    throw new Error("The paired machine does not advertise runtime RPC support.");
+  }
+
+  const id = channelId(options.channelId);
+  const dataCallbacks = new Set<(chunk: Buffer) => void>();
+  const errorCallbacks = new Set<(error: Error) => void>();
+  const closeCallbacks = new Set<() => void>();
+  let closed = false;
+  let closeNotified = false;
+  let removeEnvelope = () => {};
+  let removeError = () => {};
+  let removeClose = () => {};
+
+  const notifyClose = (): void => {
+    if (closeNotified) return;
+    closeNotified = true;
+    for (const callback of [...closeCallbacks]) {
+      try {
+        callback();
+      } catch {
+        // Continue notifying the remaining transport consumers.
+      }
+    }
+  };
+  const cleanup = (): void => {
+    removeEnvelope();
+    removeError();
+    removeClose();
+    removeEnvelope = () => {};
+    removeError = () => {};
+    removeClose = () => {};
+  };
+  const fail = (error: Error, closeConnection: boolean): void => {
+    if (closed) return;
+    closed = true;
+    cleanup();
+    emitCallbacks(errorCallbacks, error);
+    notifyClose();
+    if (closeConnection) connection.close(1000, "Runtime RPC channel closed.");
+  };
+
+  removeEnvelope = connection.onEnvelope((envelope) => {
+    if (envelope.type !== "rpc_data" && envelope.type !== "rpc_close") return;
+    const payload = envelope.payload as {
+      channelId?: unknown;
+      data?: unknown;
+      reason?: unknown;
+    };
+    if (payload.channelId !== id) return;
+    if (envelope.type === "rpc_close") {
+      const reason = typeof payload.reason === "string" && payload.reason.trim()
+        ? payload.reason.trim()
+        : "Runtime RPC channel closed.";
+      fail(new Error(reason), true);
+      return;
+    }
+    const bytes = strictBase64Bytes(payload.data);
+    if (!bytes) {
+      fail(new Error("Runtime RPC channel received invalid base64 data."), false);
+      connection.close(1003, "Invalid runtime RPC data.");
+      return;
+    }
+    emitCallbacks(dataCallbacks, bytes);
+  });
+  removeError = connection.onError((error) => fail(error, true));
+  removeClose = connection.onClose(() => {
+    if (closed) return;
+    closed = true;
+    cleanup();
+    notifyClose();
+  });
+
+  const transport: SyncRuntimeTransport = {
+    channelId: id,
+    connection,
+    onData(callback) {
+      dataCallbacks.add(callback);
+    },
+    onError(callback) {
+      errorCallbacks.add(callback);
+    },
+    onClose(callback) {
+      if (closeNotified) queueMicrotask(callback);
+      else closeCallbacks.add(callback);
+    },
+    write(data) {
+      if (closed) throw new Error("Runtime RPC channel is closed.");
+      const bytes = Buffer.from(data, "utf8");
+      for (let offset = 0; offset < bytes.byteLength; offset += RPC_DATA_CHUNK_BYTES) {
+        connection.send("rpc_data", {
+          channelId: id,
+          data: bytes.subarray(
+            offset,
+            Math.min(bytes.byteLength, offset + RPC_DATA_CHUNK_BYTES),
+          ).toString("base64"),
+        });
+      }
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      try {
+        connection.send("rpc_close", { channelId: id, reason: "Desktop RPC client closed." });
+      } catch {
+        // Closing the WebSocket below is sufficient when the frame cannot send.
+      }
+      cleanup();
+      connection.close(1000, "Desktop RPC client closed.");
+      notifyClose();
+    },
+  };
+
+  try {
+    connection.send("rpc_open", { channelId: id });
+    return transport;
+  } catch (error) {
+    transport.close();
+    throw error;
+  }
+}

--- a/apps/desktop/src/main/services/remoteRuntime/syncRuntimeTransport.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncRuntimeTransport.ts
@@ -20,9 +20,12 @@ import {
 } from "../../../../../ade-cli/src/services/sync/syncDpop";
 import {
   createSyncEnvelopeChunkAssembler,
+  decodeStrictBase64,
   encodeSyncEnvelope,
+  normalizeChannelId,
   parseSyncEnvelope,
   parseSyncEnvelopeChunkPayload,
+  RPC_DATA_CHUNK_BYTES,
   SYNC_CHUNKED_ENVELOPES_CAPABILITY,
   wsDataToText,
   type ParsedSyncEnvelope,
@@ -31,8 +34,6 @@ import type { RuntimeRpcTransport } from "./runtimeRpcClient";
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
 const DEFAULT_AUTH_TIMEOUT_MS = 10_000;
-const RPC_DATA_CHUNK_BYTES = 256 * 1024;
-const MAX_CHANNEL_ID_CHARS = 128;
 
 export type SyncEnvelopeConnection = {
   readonly endpoint: string;
@@ -115,21 +116,9 @@ function websocketCloseReason(value: string): string {
   return reason;
 }
 
-function strictBase64Bytes(value: unknown): Buffer | null {
-  if (typeof value !== "string") return null;
-  if (value === "") return Buffer.alloc(0);
-  if (value.length % 4 !== 0 || !/^[a-zA-Z0-9+/]*={0,2}$/.test(value)) {
-    return null;
-  }
-  return Buffer.from(value, "base64");
-}
-
 function channelId(value: string | undefined): string {
   const normalized = value?.trim() || randomUUID();
-  if (
-    normalized.length > MAX_CHANNEL_ID_CHARS
-    || !/^[a-zA-Z0-9._:-]+$/.test(normalized)
-  ) {
+  if (!normalizeChannelId(normalized)) {
     throw new Error("Sync runtime channelId is invalid.");
   }
   return normalized;
@@ -496,7 +485,7 @@ export async function openSyncRuntimeTransport(
       fail(new Error(reason), true);
       return;
     }
-    const bytes = strictBase64Bytes(payload.data);
+    const bytes = decodeStrictBase64(payload.data);
     if (!bytes) {
       fail(new Error("Runtime RPC channel received invalid base64 data."), false);
       connection.close(1003, "Invalid runtime RPC data.");

--- a/apps/desktop/src/main/services/remoteRuntime/syncRuntimeTransport.ts
+++ b/apps/desktop/src/main/services/remoteRuntime/syncRuntimeTransport.ts
@@ -27,6 +27,7 @@ import {
   parseSyncEnvelopeChunkPayload,
   RPC_DATA_CHUNK_BYTES,
   SYNC_CHUNKED_ENVELOPES_CAPABILITY,
+  SYNC_RUNTIME_ONLY_CAPABILITY,
   wsDataToText,
   type ParsedSyncEnvelope,
 } from "../sync/syncProtocol";
@@ -330,7 +331,10 @@ export function buildDesktopPairedHello(
       deviceType: "desktop",
       siteId: credentials.siteId,
       dbVersion: 0,
-      capabilities: [SYNC_CHUNKED_ENVELOPES_CAPABILITY],
+      capabilities: [
+        SYNC_CHUNKED_ENVELOPES_CAPABILITY,
+        SYNC_RUNTIME_ONLY_CAPABILITY,
+      ],
       ...(appVersion?.trim() ? { appVersion: appVersion.trim() } : {}),
     },
     auth: {

--- a/apps/desktop/src/main/services/sync/syncPairingStore.test.ts
+++ b/apps/desktop/src/main/services/sync/syncPairingStore.test.ts
@@ -83,6 +83,26 @@ describe("syncPairingStore", () => {
       expect(record.secretHash).toMatch(/^[0-9a-f]{64}$/);
     });
 
+    it("does not grant a desktop-claiming pairing request runtime channels without a server grant", () => {
+      const { store, pinStore } = makeHarness("ade-pairing-runtime-grant-");
+      pinStore.setPin("424242");
+      const desktopPeer = {
+        ...samplePeer,
+        platform: "macOS" as const,
+        deviceType: "desktop" as const,
+      };
+
+      const ungranted = store.pairPeer(desktopPeer, "424242");
+      expect(store.getPairingRecord(ungranted.deviceId)?.runtimeHostGranted).toBe(false);
+
+      const runtimeHostGrant = store.issueRuntimeHostGrant();
+      const granted = store.pairPeer(desktopPeer, "424242", { runtimeHostGrant });
+      expect(store.getPairingRecord(granted.deviceId)?.runtimeHostGranted).toBe(true);
+
+      store.pairPeer({ ...desktopPeer, deviceId: "replay" }, "424242", { runtimeHostGrant });
+      expect(store.getPairingRecord("replay")?.runtimeHostGranted).toBe(false);
+    });
+
     it("produces a distinct secret each time even for the same device id", () => {
       const { store, pinStore } = makeHarness("ade-pairing-unique-");
       pinStore.setPin("424242");

--- a/apps/desktop/src/main/services/sync/syncPairingStore.test.ts
+++ b/apps/desktop/src/main/services/sync/syncPairingStore.test.ts
@@ -83,7 +83,7 @@ describe("syncPairingStore", () => {
       expect(record.secretHash).toMatch(/^[0-9a-f]{64}$/);
     });
 
-    it("does not grant a desktop-claiming pairing request runtime channels without a server grant", () => {
+    it("grants runtime hosting only to a desktop with a fresh one-time server grant", () => {
       const { store, pinStore } = makeHarness("ade-pairing-runtime-grant-");
       pinStore.setPin("424242");
       const desktopPeer = {
@@ -95,8 +95,18 @@ describe("syncPairingStore", () => {
       const ungranted = store.pairPeer(desktopPeer, "424242");
       expect(store.getPairingRecord(ungranted.deviceId)?.runtimeHostGranted).toBe(false);
 
+      const copiedRuntimeHostGrant = store.issueRuntimeHostGrant();
+      const nonDesktop = store.pairPeer(samplePeer, "424242", {
+        runtimeHostGrant: copiedRuntimeHostGrant,
+      });
+      expect(store.getPairingRecord(nonDesktop.deviceId)?.runtimeHostGranted).toBe(false);
+
       const runtimeHostGrant = store.issueRuntimeHostGrant();
-      const granted = store.pairPeer(desktopPeer, "424242", { runtimeHostGrant });
+      const granted = store.pairPeer(
+        { ...desktopPeer, deviceId: "genuine-desktop" },
+        "424242",
+        { runtimeHostGrant },
+      );
       expect(store.getPairingRecord(granted.deviceId)?.runtimeHostGranted).toBe(true);
 
       store.pairPeer({ ...desktopPeer, deviceId: "replay" }, "424242", { runtimeHostGrant });

--- a/apps/desktop/src/preload/global.d.ts
+++ b/apps/desktop/src/preload/global.d.ts
@@ -592,7 +592,12 @@ import type {
   RemoteRuntimeConnectionSnapshot,
   RemoteRuntimeConnectResult,
   RemoteRuntimeDiscoveryResult,
+  RemoteRuntimeDoctorResult,
   RemoteRuntimeLocalWorkCheckResult,
+  RemoteRuntimeLocalPairingInfo,
+  RemoteRuntimePairWithMachineArgs,
+  RemoteRuntimePairWithMachineResult,
+  RemoteRuntimeParsedPairingInput,
   RemoteRuntimeProjectRecord,
   RemoteRuntimeSshHostKeyTrustStatus,
   RemoteRuntimeStreamEventsRequest,
@@ -737,6 +742,14 @@ declare global {
           cb: (snapshot: RemoteRuntimeConnectionSnapshot) => void,
         ) => () => void;
         listDiscoveredMachines: () => Promise<RemoteRuntimeDiscoveryResult>;
+        parsePairingInput: (
+          text: string,
+        ) => Promise<RemoteRuntimeParsedPairingInput>;
+        pairWithMachine: (
+          args: RemoteRuntimePairWithMachineArgs,
+        ) => Promise<RemoteRuntimePairWithMachineResult>;
+        getLocalPairingInfo: () => Promise<RemoteRuntimeLocalPairingInfo>;
+        runDoctor: (id: string) => Promise<RemoteRuntimeDoctorResult>;
         saveTarget: (
           input: RemoteRuntimeTargetInput,
         ) => Promise<RemoteRuntimeTarget>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -606,9 +606,14 @@ import type {
   RemoteRuntimeConnectionSnapshot,
   RemoteRuntimeConnectResult,
   RemoteRuntimeDiscoveryResult,
+  RemoteRuntimeDoctorResult,
   RemoteRuntimeEventCategory,
   RemoteRuntimeEventNotificationPayload,
   RemoteRuntimeLocalWorkCheckResult,
+  RemoteRuntimeLocalPairingInfo,
+  RemoteRuntimePairWithMachineArgs,
+  RemoteRuntimePairWithMachineResult,
+  RemoteRuntimeParsedPairingInput,
   RemoteRuntimePortForward,
   RemoteRuntimeProjectRecord,
   RemoteRuntimeSshHostKeyTrustStatus,
@@ -3467,6 +3472,18 @@ contextBridge.exposeInMainWorld("ade", {
     listDiscoveredMachines: async (): Promise<
       RemoteRuntimeDiscoveryResult
     > => ipcRenderer.invoke(IPC.remoteRuntimeListDiscoveredMachines),
+    parsePairingInput: async (
+      text: string,
+    ): Promise<RemoteRuntimeParsedPairingInput> =>
+      ipcRenderer.invoke(IPC.remoteRuntimeParsePairingInput, { text }),
+    pairWithMachine: async (
+      args: RemoteRuntimePairWithMachineArgs,
+    ): Promise<RemoteRuntimePairWithMachineResult> =>
+      ipcRenderer.invoke(IPC.remoteRuntimePairWithMachine, args),
+    getLocalPairingInfo: async (): Promise<RemoteRuntimeLocalPairingInfo> =>
+      ipcRenderer.invoke(IPC.remoteRuntimeGetLocalPairingInfo),
+    runDoctor: async (id: string): Promise<RemoteRuntimeDoctorResult> =>
+      ipcRenderer.invoke(IPC.remoteRuntimeRunDoctor, { id }),
     saveTarget: async (
       input: RemoteRuntimeTargetInput,
     ): Promise<RemoteRuntimeTarget> =>

--- a/apps/desktop/src/renderer/components/remoteTargets/ConnectionDoctorPanel.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/ConnectionDoctorPanel.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState, type CSSProperties } from "react";
+import { CheckCircle, CircleNotch, XCircle } from "@phosphor-icons/react";
+import { COLORS, SANS_FONT } from "../lanes/laneDesignTokens";
+import { extractError } from "../../lib/format";
+import type { RemoteRuntimeDoctorCheck } from "../../../shared/types";
+
+const wrapStyle: CSSProperties = {
+  display: "grid",
+  gap: 8,
+  padding: "10px 12px",
+  borderRadius: 8,
+  border: `1px solid ${COLORS.border}`,
+  background: "rgba(0,0,0,0.16)",
+};
+
+const rowStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "16px minmax(0,1fr) auto",
+  alignItems: "center",
+  gap: 8,
+  fontFamily: SANS_FONT,
+  fontSize: 12,
+};
+
+function routeLabel(kind: RemoteRuntimeDoctorCheck["route"]): string {
+  switch (kind) {
+    case "lan":
+      return "LAN";
+    case "tailnet":
+      return "Tailnet";
+    case "relay":
+      return "Relay";
+    case "ssh":
+      return "SSH";
+    default:
+      return kind;
+  }
+}
+
+type ConnectionDoctorPanelProps = {
+  /** Saved target id or discovered machine id, passed to runDoctor. */
+  machineId: string;
+};
+
+/**
+ * Inline reachability probe. Runs the connection doctor for a machine and lists
+ * each candidate route with a pass/fail, latency, and error text — so "Test"
+ * answers "why can't I connect" without leaving the panel.
+ */
+export function ConnectionDoctorPanel({ machineId }: ConnectionDoctorPanelProps) {
+  const [checks, setChecks] = useState<RemoteRuntimeDoctorCheck[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setChecks(null);
+    void (async () => {
+      try {
+        const result = await window.ade.remoteRuntime.runDoctor(machineId);
+        if (cancelled) return;
+        setChecks(result.checks);
+      } catch (err) {
+        if (cancelled) return;
+        setError(extractError(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [machineId]);
+
+  return (
+    <div style={wrapStyle}>
+      <div
+        style={{
+          color: COLORS.textPrimary,
+          fontFamily: SANS_FONT,
+          fontSize: 12,
+          fontWeight: 600,
+        }}
+      >
+        Connection test
+      </div>
+
+      {loading ? (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            color: COLORS.textMuted,
+            fontFamily: SANS_FONT,
+            fontSize: 12,
+          }}
+        >
+          <CircleNotch size={14} weight="bold" className="animate-spin" />
+          Probing routes…
+        </div>
+      ) : null}
+
+      {error ? (
+        <div style={{ color: COLORS.danger, fontFamily: SANS_FONT, fontSize: 12 }}>
+          {error}
+        </div>
+      ) : null}
+
+      {!loading && !error && checks && checks.length === 0 ? (
+        <div style={{ color: COLORS.textMuted, fontFamily: SANS_FONT, fontSize: 12 }}>
+          No routes to test for this machine.
+        </div>
+      ) : null}
+
+      {checks && checks.length > 0
+        ? checks.map((check, index) => (
+            <div key={`${check.route}:${check.endpoint}:${index}`} style={rowStyle}>
+              {check.ok ? (
+                <CheckCircle size={15} weight="fill" color={COLORS.success} />
+              ) : (
+                <XCircle size={15} weight="fill" color={COLORS.danger} />
+              )}
+              <div style={{ minWidth: 0 }}>
+                <span style={{ color: COLORS.textPrimary }}>{routeLabel(check.route)}</span>
+                <span
+                  style={{
+                    color: COLORS.textMuted,
+                    marginLeft: 8,
+                    overflowWrap: "anywhere",
+                  }}
+                >
+                  {check.endpoint}
+                </span>
+                {check.error ? (
+                  <div style={{ color: COLORS.danger, fontSize: 11.5, marginTop: 2 }}>
+                    {check.error}
+                  </div>
+                ) : null}
+              </div>
+              <div
+                style={{
+                  color: check.ok ? COLORS.textSecondary : COLORS.textMuted,
+                  fontVariantNumeric: "tabular-nums",
+                  fontSize: 11.5,
+                }}
+              >
+                {typeof check.latencyMs === "number"
+                  ? `${Math.round(check.latencyMs)} ms`
+                  : check.ok
+                    ? "ok"
+                    : "—"}
+              </div>
+            </div>
+          ))
+        : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/remoteTargets/DiscoveredMachineRow.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/DiscoveredMachineRow.tsx
@@ -1,0 +1,113 @@
+import { PlugsConnected } from "@phosphor-icons/react";
+import type { RemoteRuntimeDiscoveredMachine } from "../../../shared/types";
+import { primaryButton, outlineButton } from "../lanes/laneDesignTokens";
+import { ConnectionDoctorPanel } from "./ConnectionDoctorPanel";
+import {
+  discoveredMachineSummary,
+  discoveredRoute,
+  type MachineSection,
+} from "./remoteMachineModel";
+import {
+  helperTextStyle,
+  machineRowStyle,
+  nameStyle,
+  subTextStyle,
+} from "./remoteTargetListStyles";
+
+type DiscoveredMachineRowProps = {
+  machine: RemoteRuntimeDiscoveredMachine;
+  section: MachineSection;
+  busyId: string | null;
+  saving: boolean;
+  testOpen: boolean;
+  onConnect: (machine: RemoteRuntimeDiscoveredMachine) => void;
+  onToggleTest: (machineId: string) => void;
+};
+
+export function DiscoveredMachineRow({
+  machine,
+  section,
+  busyId,
+  saving,
+  testOpen,
+  onConnect,
+  onToggleTest,
+}: DiscoveredMachineRowProps) {
+  const route = discoveredRoute(machine);
+  const unavailable = section === "unavailable";
+
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      <div style={{ ...machineRowStyle, opacity: unavailable ? 0.62 : 1 }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "minmax(0,1fr) auto",
+            gap: 12,
+            alignItems: "center",
+          }}
+        >
+          <div style={{ minWidth: 0, display: "grid", gap: 5 }}>
+            <div style={nameStyle}>{machine.machineName}</div>
+            <div style={subTextStyle}>
+              {route ? `${route}:${machine.port}` : "No route advertised"}
+            </div>
+            <div style={helperTextStyle}>
+              {unavailable && machine.unsupportedReason
+                ? machine.unsupportedReason
+                : discoveredMachineSummary(machine)}
+            </div>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              flexWrap: "wrap",
+              justifyContent: "flex-end",
+            }}
+          >
+            {!unavailable ? (
+              <>
+                <button
+                  type="button"
+                  disabled={!route || busyId != null || saving}
+                  onClick={() => onConnect(machine)}
+                  style={{
+                    ...primaryButton({
+                      height: 30,
+                      padding: "0 10px",
+                      fontSize: 11,
+                    }),
+                    opacity: route && busyId == null && !saving ? 1 : 0.55,
+                  }}
+                >
+                  <PlugsConnected size={14} weight="bold" />
+                  {busyId === machine.id ? "Connecting…" : "Connect"}
+                </button>
+                <button
+                  type="button"
+                  aria-controls={`remote-discovered-test-${machine.id}`}
+                  aria-expanded={testOpen}
+                  disabled={busyId != null}
+                  onClick={() => onToggleTest(machine.id)}
+                  style={outlineButton({
+                    height: 30,
+                    padding: "0 10px",
+                    fontSize: 11,
+                  })}
+                >
+                  Test
+                </button>
+              </>
+            ) : null}
+          </div>
+        </div>
+      </div>
+      {testOpen ? (
+        <div id={`remote-discovered-test-${machine.id}`}>
+          <ConnectionDoctorPanel machineId={machine.id} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/remoteTargets/HostKeyTrustCard.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/HostKeyTrustCard.tsx
@@ -1,0 +1,100 @@
+import { CheckCircle, Warning } from "@phosphor-icons/react";
+import type { RemoteRuntimeSshHostKeyTrustStatus } from "../../../shared/types";
+import {
+  COLORS,
+  MONO_FONT,
+  SANS_FONT,
+  outlineButton,
+  primaryButton,
+} from "../lanes/laneDesignTokens";
+import { helperTextStyle } from "./remoteTargetListStyles";
+
+type HostKeyTrustCardProps = {
+  trust: RemoteRuntimeSshHostKeyTrustStatus;
+  trusting: boolean;
+  busy: boolean;
+  onTrustAndConnect: () => void;
+  onCancel: () => void;
+};
+
+export function HostKeyTrustCard({
+  trust,
+  trusting,
+  busy,
+  onTrustAndConnect,
+  onCancel,
+}: HostKeyTrustCardProps) {
+  const changed = trust.state === "changed";
+  const accent = changed ? COLORS.danger : COLORS.warning;
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 10,
+        borderRadius: 8,
+        border: `1px solid ${accent}`,
+        background: `color-mix(in srgb, ${accent} 10%, transparent)`,
+        padding: "10px 12px",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          color: accent,
+          fontFamily: SANS_FONT,
+          fontSize: 12,
+          fontWeight: 700,
+        }}
+      >
+        <Warning size={15} weight="fill" />
+        {changed ? "Machine identity changed" : "Trust this machine"}
+      </div>
+      <div style={helperTextStyle}>
+        {changed
+          ? `ADE found a different SSH identity for ${trust.host}:${trust.port}. Review ${trust.knownHostsPath ?? "known_hosts"} before connecting.`
+          : `ADE found a new SSH identity for ${trust.host}:${trust.port}. Trust it once to connect.`}
+      </div>
+      <div
+        style={{
+          color: COLORS.textPrimary,
+          fontFamily: MONO_FONT,
+          fontSize: 11,
+          overflowWrap: "anywhere",
+        }}
+      >
+        {trust.fingerprintSha256}
+      </div>
+      {trust.state === "needs_trust" ? (
+        <div style={{ display: "flex", gap: 8 }}>
+          <button
+            type="button"
+            disabled={trusting || busy}
+            onClick={onTrustAndConnect}
+            style={{
+              ...primaryButton({ height: 30, padding: "0 10px", fontSize: 11 }),
+              opacity: trusting || busy ? 0.65 : 1,
+            }}
+          >
+            <CheckCircle size={15} weight="bold" />
+            {trusting ? "Trusting…" : "Trust & connect"}
+          </button>
+          <button
+            type="button"
+            disabled={trusting}
+            onClick={onCancel}
+            style={outlineButton({
+              height: 30,
+              padding: "0 10px",
+              fontSize: 11,
+            })}
+          >
+            Cancel
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/remoteTargets/PairMachineForm.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/PairMachineForm.tsx
@@ -1,0 +1,214 @@
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type FormEvent,
+} from "react";
+import { CheckCircle } from "@phosphor-icons/react";
+import { COLORS, LABEL_STYLE, MONO_FONT, SANS_FONT, primaryButton } from "../lanes/laneDesignTokens";
+import { extractError } from "../../lib/format";
+import type { RemoteRuntimeParsedPairingInput } from "../../../shared/types";
+
+const fieldStyle: CSSProperties = {
+  width: "100%",
+  height: 38,
+  borderRadius: 8,
+  border: `1px solid ${COLORS.border}`,
+  background: "rgba(255,255,255,0.03)",
+  color: COLORS.textPrimary,
+  fontFamily: MONO_FONT,
+  fontSize: 12,
+  padding: "0 10px",
+  outline: "none",
+};
+
+function friendlyPairError(error: unknown): string {
+  const message = extractError(error)
+    .replace(/^Error invoking remote method '[^']+':\s*/i, "")
+    .replace(/^Error:\s*/i, "")
+    .trim();
+  if (/pin|unauthor|forbidden|401|403|invalid code/i.test(message)) {
+    return "That PIN didn't work. Check the 6-digit code shown on the other machine and try again.";
+  }
+  if (/unreachable|timed out|timeout|ECONN|ENOTFOUND|network|connect|offline/i.test(message)) {
+    return "Couldn't reach that machine. Make sure it's awake and on the same network, Tailscale, or relay.";
+  }
+  return message || "Pairing failed.";
+}
+
+type PairMachineFormProps = {
+  defaultDeviceName: string;
+  busy?: boolean;
+  /** Runs after pairing succeeds; parent connects on the returned target id. */
+  onPaired: (targetId: string) => void | Promise<void>;
+};
+
+/**
+ * Pair tab: paste a pairing code/link, enter the 6-digit PIN, confirm this
+ * Mac's name, and connect. The link is validated live via parsePairingInput so
+ * the machine name shows before the user commits.
+ */
+export function PairMachineForm({
+  defaultDeviceName,
+  busy = false,
+  onPaired,
+}: PairMachineFormProps) {
+  const [rawInput, setRawInput] = useState("");
+  const [parsed, setParsed] = useState<RemoteRuntimeParsedPairingInput | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [parsing, setParsing] = useState(false);
+  const [pin, setPin] = useState("");
+  const [deviceName, setDeviceName] = useState(defaultDeviceName);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDeviceName((current) => (current.trim() ? current : defaultDeviceName));
+  }, [defaultDeviceName]);
+
+  const trimmedInput = rawInput.trim();
+
+  useEffect(() => {
+    if (!trimmedInput) {
+      setParsed(null);
+      setParseError(null);
+      setParsing(false);
+      return;
+    }
+    let cancelled = false;
+    setParsing(true);
+    const handle = window.setTimeout(() => {
+      void (async () => {
+        try {
+          const result = await window.ade.remoteRuntime.parsePairingInput(trimmedInput);
+          if (cancelled) return;
+          setParsed(result);
+          setParseError(null);
+        } catch (err) {
+          if (cancelled) return;
+          setParsed(null);
+          setParseError(
+            extractError(err).replace(/^Error:\s*/i, "").trim() ||
+              "That doesn't look like a valid pairing code or link.",
+          );
+        } finally {
+          if (!cancelled) setParsing(false);
+        }
+      })();
+    }, 250);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [trimmedInput]);
+
+  const pinValid = /^\d{6}$/.test(pin.trim());
+  const canSubmit = useMemo(
+    () => Boolean(parsed) && pinValid && deviceName.trim().length > 0 && !busy && !submitting,
+    [parsed, pinValid, deviceName, busy, submitting],
+  );
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const { targetId } = await window.ade.remoteRuntime.pairWithMachine({
+        input: trimmedInput,
+        pin: pin.trim(),
+        deviceName: deviceName.trim(),
+      });
+      await onPaired(targetId);
+    } catch (err) {
+      setError(friendlyPairError(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={(event) => void handleSubmit(event)} style={{ display: "grid", gap: 12 }}>
+      <label style={{ display: "grid", gap: 6 }}>
+        <span style={LABEL_STYLE}>Pairing code or link</span>
+        <input
+          value={rawInput}
+          onChange={(event) => setRawInput(event.target.value)}
+          placeholder="Paste the code or link from the other machine"
+          style={fieldStyle}
+          disabled={busy || submitting}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        {parsing ? (
+          <span style={{ color: COLORS.textMuted, fontFamily: SANS_FONT, fontSize: 11.5 }}>
+            Checking…
+          </span>
+        ) : parsed ? (
+          <span
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              color: COLORS.success,
+              fontFamily: SANS_FONT,
+              fontSize: 11.5,
+            }}
+          >
+            <CheckCircle size={14} weight="fill" />
+            {parsed.machineName?.trim() || parsed.hostIdentity.name || "Machine"} ready to pair
+          </span>
+        ) : parseError ? (
+          <span style={{ color: COLORS.danger, fontFamily: SANS_FONT, fontSize: 11.5 }}>
+            {parseError}
+          </span>
+        ) : null}
+      </label>
+
+      <div style={{ display: "grid", gridTemplateColumns: "140px minmax(0,1fr)", gap: 12 }}>
+        <label style={{ display: "grid", gap: 6 }}>
+          <span style={LABEL_STYLE}>PIN</span>
+          <input
+            value={pin}
+            onChange={(event) => setPin(event.target.value.replace(/\D/g, "").slice(0, 6))}
+            inputMode="numeric"
+            placeholder="6-digit"
+            style={{ ...fieldStyle, letterSpacing: "0.24em" }}
+            disabled={busy || submitting}
+            autoComplete="off"
+          />
+        </label>
+        <label style={{ display: "grid", gap: 6 }}>
+          <span style={LABEL_STYLE}>This device's name</span>
+          <input
+            value={deviceName}
+            onChange={(event) => setDeviceName(event.target.value)}
+            placeholder="Mac name"
+            style={fieldStyle}
+            disabled={busy || submitting}
+          />
+        </label>
+      </div>
+
+      {error ? (
+        <div style={{ color: COLORS.danger, fontFamily: SANS_FONT, fontSize: 12, lineHeight: 1.45 }}>
+          {error}
+        </div>
+      ) : null}
+
+      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          style={{
+            ...primaryButton({ height: 36, padding: "0 16px", fontSize: 12 }),
+            opacity: canSubmit ? 1 : 0.55,
+          }}
+        >
+          {submitting ? "Connecting…" : "Connect"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/desktop/src/renderer/components/remoteTargets/RemoteErrorCard.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/RemoteErrorCard.tsx
@@ -1,0 +1,133 @@
+import { useState, type CSSProperties } from "react";
+import { ArrowClockwise, CaretDown, CaretRight, Warning } from "@phosphor-icons/react";
+import { COLORS, MONO_FONT, SANS_FONT, outlineButton } from "../lanes/laneDesignTokens";
+import type { MachineErrorCard } from "./remoteMachineModel";
+
+const detailBoxStyle: CSSProperties = {
+  maxHeight: 168,
+  overflow: "auto",
+  padding: "8px 10px",
+  borderRadius: 6,
+  border: `1px solid ${COLORS.border}`,
+  background: "rgba(0,0,0,0.28)",
+  color: COLORS.textSecondary,
+  fontFamily: MONO_FONT,
+  fontSize: 11,
+  lineHeight: 1.5,
+  whiteSpace: "pre-wrap",
+  overflowWrap: "anywhere",
+  userSelect: "text",
+};
+
+type RemoteErrorCardProps = {
+  card: MachineErrorCard;
+  onRetry?: () => void;
+  retrying?: boolean;
+};
+
+/**
+ * Human-first failure surface. The plain-language message leads; the raw,
+ * capped technical detail hides behind a "Show technical details" expander
+ * (the only place monospace is warranted). A Try again button re-runs connect.
+ */
+export function RemoteErrorCard({ card, onRetry, retrying }: RemoteErrorCardProps) {
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const copyDetail = async () => {
+    if (!card.detail) return;
+    try {
+      await window.ade?.app?.writeClipboardText?.(card.detail);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard may be unavailable; the detail stays visible to copy manually.
+    }
+  };
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 10,
+        borderRadius: 8,
+        border: `1px solid color-mix(in srgb, ${COLORS.danger} 32%, transparent)`,
+        background: `color-mix(in srgb, ${COLORS.danger} 8%, transparent)`,
+        padding: "10px 12px",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: 8,
+          color: COLORS.danger,
+          fontFamily: SANS_FONT,
+          fontSize: 12.5,
+          lineHeight: 1.45,
+          fontWeight: 600,
+        }}
+      >
+        <Warning size={15} weight="fill" style={{ flexShrink: 0, marginTop: 1 }} />
+        <span>{card.message}</span>
+      </div>
+
+      {card.detail ? (
+        <div style={{ display: "grid", gap: 8 }}>
+          <button
+            type="button"
+            aria-expanded={detailOpen}
+            onClick={() => setDetailOpen((open) => !open)}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              justifySelf: "start",
+              padding: 0,
+              border: "none",
+              background: "transparent",
+              color: COLORS.textMuted,
+              fontFamily: SANS_FONT,
+              fontSize: 11.5,
+              cursor: "pointer",
+            }}
+          >
+            {detailOpen ? (
+              <CaretDown size={12} weight="bold" />
+            ) : (
+              <CaretRight size={12} weight="bold" />
+            )}
+            Show technical details
+          </button>
+          {detailOpen ? (
+            <div style={{ display: "grid", gap: 6 }}>
+              <div style={detailBoxStyle}>{card.detail}</div>
+              <button
+                type="button"
+                onClick={() => void copyDetail()}
+                style={outlineButton({ height: 28, padding: "0 10px", fontSize: 11, justifySelf: "start" })}
+              >
+                {copied ? "Copied" : "Copy details"}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {onRetry ? (
+        <button
+          type="button"
+          disabled={retrying}
+          onClick={onRetry}
+          style={{
+            ...outlineButton({ height: 30, padding: "0 12px", fontSize: 11, justifySelf: "start" }),
+            opacity: retrying ? 0.6 : 1,
+          }}
+        >
+          <ArrowClockwise size={13} weight="bold" />
+          {retrying ? "Retrying…" : "Try again"}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetForm.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetForm.tsx
@@ -1,5 +1,17 @@
-import { useEffect, useMemo, useState, type CSSProperties, type FormEvent } from "react";
-import { COLORS, LABEL_STYLE, MONO_FONT, outlineButton, primaryButton } from "../lanes/laneDesignTokens";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type FormEvent,
+} from "react";
+import {
+  COLORS,
+  LABEL_STYLE,
+  MONO_FONT,
+  outlineButton,
+  primaryButton,
+} from "../lanes/laneDesignTokens";
 import type { RemoteRuntimeTargetInput } from "../../../shared/types";
 
 export type RemoteTargetFormPrefill = Partial<RemoteRuntimeTargetInput> & {
@@ -47,42 +59,78 @@ export function RemoteTargetForm({
   const prefillPort = prefill?.port;
   const prefillSshKeyPath = prefill?.sshKeyPath;
   const prefillRoutes = prefill?.routes;
+  const prefillTransport = prefill?.transport;
+  const prefillPairedMachine = prefill?.pairedMachine;
 
   useEffect(() => {
     if (!prefill) return;
     if (prefillName !== undefined) setName(prefillName ?? "");
     if (prefillHostname !== undefined) setHostname(prefillHostname);
     if (prefillSshUser !== undefined) setSshUser(prefillSshUser ?? "");
-    if (prefillPort !== undefined) setPort(prefillPort == null ? "" : String(prefillPort));
+    if (prefillPort !== undefined)
+      setPort(prefillPort == null ? "" : String(prefillPort));
     if (prefillSshKeyPath !== undefined) setSshKeyPath(prefillSshKeyPath ?? "");
-  }, [prefill, prefillHostname, prefillKey, prefillName, prefillPort, prefillSshKeyPath, prefillSshUser]);
+  }, [
+    prefill,
+    prefillHostname,
+    prefillKey,
+    prefillName,
+    prefillPort,
+    prefillSshKeyPath,
+    prefillSshUser,
+  ]);
 
   const canSubmit = useMemo(() => {
     if (!hostname.trim()) return false;
     if (!port.trim()) return true;
     if (!/^\d+$/.test(port.trim())) return false;
     const parsedPort = Number.parseInt(port, 10);
-    return Number.isInteger(parsedPort) && parsedPort >= 1 && parsedPort <= 65_535;
+    return (
+      Number.isInteger(parsedPort) && parsedPort >= 1 && parsedPort <= 65_535
+    );
   }, [hostname, port]);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!canSubmit || busy) return;
+    const submittedHostname = hostname.trim();
+    const submittedPort = port.trim() ? Number.parseInt(port, 10) : null;
+    const hostnameChanged =
+      prefillHostname !== undefined &&
+      submittedHostname !== prefillHostname.trim();
+    const routes = hostnameChanged
+      ? prefillTransport === "paired"
+        ? [
+            {
+              hostname: submittedHostname,
+              port: submittedPort,
+              source: "manual" as const,
+              lastSucceededAt: null,
+            },
+          ]
+        : null
+      : (prefillRoutes ?? null);
     await onSubmit({
       name: name.trim() || null,
-      hostname: hostname.trim(),
+      hostname: submittedHostname,
       sshUser: sshUser.trim() || null,
-      port: port.trim() ? Number.parseInt(port, 10) : null,
+      port: submittedPort,
       sshKeyPath: sshKeyPath.trim() || null,
-      routes:
-        prefillRoutes && hostname.trim() === prefillHostname?.trim()
-          ? prefillRoutes
-          : null,
+      ...(prefillTransport !== undefined
+        ? { transport: prefillTransport }
+        : {}),
+      ...(prefillPairedMachine !== undefined
+        ? { pairedMachine: prefillPairedMachine }
+        : {}),
+      routes,
     });
   }
 
   return (
-    <form onSubmit={(event) => void handleSubmit(event)} style={{ display: "grid", gap: 12 }}>
+    <form
+      onSubmit={(event) => void handleSubmit(event)}
+      style={{ display: "grid", gap: 12 }}
+    >
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
         <label style={{ display: "grid", gap: 6 }}>
           <span style={LABEL_STYLE}>Name</span>
@@ -106,7 +154,9 @@ export function RemoteTargetForm({
           />
         </label>
       </div>
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 104px", gap: 12 }}>
+      <div
+        style={{ display: "grid", gridTemplateColumns: "1fr 104px", gap: 12 }}
+      >
         <label style={{ display: "grid", gap: 6 }}>
           <span style={LABEL_STYLE}>SSH user</span>
           <input
@@ -139,7 +189,14 @@ export function RemoteTargetForm({
           disabled={busy}
         />
       </label>
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 12 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "flex-end",
+          gap: 12,
+        }}
+      >
         <button
           type="submit"
           disabled={!canSubmit || busy}
@@ -157,7 +214,11 @@ export function RemoteTargetForm({
 
 export function RemoteTargetEmptyAction({ onClick }: { onClick: () => void }) {
   return (
-    <button type="button" onClick={onClick} style={outlineButton({ height: 32, padding: "0 12px", fontSize: 12 })}>
+    <button
+      type="button"
+      onClick={onClick}
+      style={outlineButton({ height: 32, padding: "0 12px", fontSize: 12 })}
+    >
       Add machine
     </button>
   );

--- a/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetList.test.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetList.test.tsx
@@ -25,6 +25,10 @@ const remoteRuntimeMock = {
   streamEvents: vi.fn(),
   checkLocalWork: vi.fn(),
   disconnect: vi.fn(),
+  getLocalPairingInfo: vi.fn(),
+  parsePairingInput: vi.fn(),
+  pairWithMachine: vi.fn(),
+  runDoctor: vi.fn(),
 };
 
 const lanesMock = {
@@ -32,13 +36,25 @@ const lanesMock = {
   listSnapshots: vi.fn(),
 };
 
+const appMock = {
+  writeClipboardText: vi.fn(),
+};
+
 function installAdeMock(): void {
   remoteRuntimeMock.getSshHostKeyTrust.mockResolvedValue({ state: "trusted" });
+  remoteRuntimeMock.getLocalPairingInfo.mockResolvedValue({
+    url: "https://ade-app.dev/pair#payload",
+    pin: "123456",
+    machineName: "This Mac",
+    relayAvailable: false,
+  });
+  remoteRuntimeMock.runDoctor.mockResolvedValue({ checks: [] });
   Object.defineProperty(window, "ade", {
     configurable: true,
     value: {
       remoteRuntime: remoteRuntimeMock,
       lanes: lanesMock,
+      app: appMock,
     },
   });
 }
@@ -52,7 +68,7 @@ describe("RemoteTargetList", () => {
     Reflect.deleteProperty(window, "ade");
   });
 
-  it("shows LAN-discovered machines and uses their route to prefill the SSH form", async () => {
+  it("lists a discovered ADE machine under Available and connects via its route", async () => {
     remoteRuntimeMock.listTargets.mockResolvedValue([]);
     remoteRuntimeMock.listDiscoveredMachines.mockResolvedValue({
       machines: [
@@ -81,31 +97,10 @@ describe("RemoteTargetList", () => {
     render(<RemoteTargetList />);
 
     await waitFor(() => expect(screen.getByText("Studio")).toBeTruthy());
+    expect(screen.getByText("AVAILABLE")).toBeTruthy();
     expect(screen.getByText("studio.tailnet.ts.net:8787")).toBeTruthy();
-    expect(
-      screen.getByText(/Background ADE 0\.0\.0/),
-    ).toBeTruthy();
-    expect(screen.getByText(/2 projects advertised/)).toBeTruthy();
-
-    const editButton = screen.getByRole("button", { name: "Edit" });
-    expect(editButton.getAttribute("aria-expanded")).toBe("false");
-
-    fireEvent.click(editButton);
-
-    expect(editButton.getAttribute("aria-expanded")).toBe("true");
-    expect(screen.getByText("Edit Studio")).toBeTruthy();
-    expect((screen.getByLabelText("Name") as HTMLInputElement).value).toBe(
-      "Studio",
-    );
-    expect((screen.getByLabelText("Host") as HTMLInputElement).value).toBe(
-      "studio.tailnet.ts.net",
-    );
-    expect((screen.getByLabelText("Port") as HTMLInputElement).value).toBe("");
-
-    fireEvent.click(editButton);
-
-    expect(editButton.getAttribute("aria-expanded")).toBe("false");
-    expect(screen.queryByText("Edit Studio")).toBeNull();
+    // ADE machines advertise their project count concisely.
+    expect(screen.getByText("ADE · 2 projects")).toBeTruthy();
 
     const savedTarget = {
       id: "target-1",
@@ -159,6 +154,41 @@ describe("RemoteTargetList", () => {
     await waitFor(() =>
       expect(remoteRuntimeMock.connect).toHaveBeenCalledWith("target-1"),
     );
+  });
+
+  it("shows an SSH-only Tailscale peer with its OS in the Available section", async () => {
+    remoteRuntimeMock.listTargets.mockResolvedValue([]);
+    remoteRuntimeMock.listDiscoveredMachines.mockResolvedValue({
+      machines: [
+        {
+          id: "tailscale:peer-linux",
+          serviceName: "Tailscale peer",
+          machineName: "Linux box",
+          hostIdentity: "peer-linux",
+          hostName: "linux-box",
+          port: 22,
+          addresses: ["100.64.0.20"],
+          primaryRoute: "100.64.0.20",
+          tailscaleAddress: "100.64.0.20",
+          runtimeKind: "tailscale-peer",
+          runtimeVersion: null,
+          os: "linux",
+          connectable: true,
+          projectIds: [],
+          projectCount: null,
+          lastSeenAt: 1234,
+        },
+      ],
+      diagnostics: [],
+    });
+    installAdeMock();
+
+    render(<RemoteTargetList />);
+
+    await waitFor(() => expect(screen.getByText("Linux box")).toBeTruthy());
+    expect(screen.getByText("SSH only · linux")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Connect" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Test" })).toBeTruthy();
   });
 
   it("shows why an unsupported discovered machine cannot connect", async () => {
@@ -648,6 +678,221 @@ describe("RemoteTargetList", () => {
     expect(screen.queryByText("studio.local:8787")).toBeNull();
     expect(screen.queryByRole("button", { name: "Use host" })).toBeNull();
     expect(screen.getByText("Nearby machines are already saved.")).toBeTruthy();
+  });
+
+  it("splits saved and discovered machines into status sections with a route chip", async () => {
+    const connectedTarget = {
+      id: "target-c",
+      name: "Connected Mac",
+      hostname: "100.64.0.5",
+      sshUser: "ade",
+      port: 22,
+      sshKeyPath: null,
+      lastSeenArch: "darwin-arm64",
+      runtimeBinaryVersion: "1.0.0",
+      lastConnectedAt: 1,
+    };
+    Object.defineProperty(remoteRuntimeMock, "getConnectionSnapshot", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        connections: [
+          {
+            target: connectedTarget,
+            state: "connected",
+            arch: "darwin-arm64",
+            version: "1.0.0",
+            route: { kind: "tailnet", endpoint: "100.64.0.5", latencyMs: 4 },
+            projects: [],
+            lastError: null,
+            lastAttemptedAt: 1,
+            connectedAt: 1,
+          },
+        ],
+        connectedCount: 1,
+        updatedAt: 1,
+      }),
+    });
+    remoteRuntimeMock.listDiscoveredMachines.mockResolvedValue({
+      machines: [
+        {
+          id: "tailscale:windows-pc",
+          serviceName: "Tailscale peer",
+          machineName: "Windows PC",
+          hostIdentity: "windows-pc",
+          hostName: "windows-pc",
+          port: 22,
+          addresses: ["100.64.0.12"],
+          primaryRoute: "100.64.0.12",
+          tailscaleAddress: "100.64.0.12",
+          runtimeKind: "tailscale-peer",
+          runtimeVersion: null,
+          os: "windows",
+          connectable: false,
+          unsupportedReason: "Windows — not supported yet",
+          projectIds: [],
+          projectCount: null,
+          lastSeenAt: 1234,
+        },
+      ],
+      diagnostics: [],
+    });
+    installAdeMock();
+
+    render(<RemoteTargetList />);
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Connected Mac").length).toBeGreaterThan(0),
+    );
+    expect(screen.getByText("CONNECTED")).toBeTruthy();
+    expect(screen.getByText("UNAVAILABLE")).toBeTruthy();
+    // Live route chip on the connected row, sourced from status.route.
+    expect(screen.getByText("tailnet · 4 ms")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Disconnect" })).toBeTruthy();
+    // The unsupported peer greys out with a concrete reason and no Connect.
+    expect(screen.getByText("Windows — not supported yet")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Connect" })).toBeNull();
+  });
+
+  it("reveals capped technical detail behind the error card expander", async () => {
+    const target = {
+      id: "target-1",
+      name: "Mac Studio",
+      hostname: "studio.local",
+      sshUser: null,
+      port: 22,
+      sshKeyPath: null,
+      lastSeenArch: null,
+      runtimeBinaryVersion: null,
+      lastConnectedAt: null,
+    };
+    Object.defineProperty(remoteRuntimeMock, "getConnectionSnapshot", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        connections: [
+          {
+            target,
+            state: "error",
+            arch: null,
+            version: null,
+            projects: [],
+            lastError: "ENOSPC",
+            lastErrorInfo: {
+              kind: "disk_full",
+              message: "The remote machine is out of disk space.",
+              detail: "df: /: 100% used (0 bytes free)\nextract aborted",
+            },
+            lastAttemptedAt: 1,
+            connectedAt: null,
+          },
+        ],
+        connectedCount: 0,
+        updatedAt: 1,
+      }),
+    });
+    remoteRuntimeMock.listDiscoveredMachines.mockResolvedValue({
+      machines: [],
+      diagnostics: [],
+    });
+    installAdeMock();
+
+    render(<RemoteTargetList />);
+
+    expect(
+      await screen.findByText("The remote machine is out of disk space."),
+    ).toBeTruthy();
+    // Technical detail is hidden until the expander is opened.
+    expect(screen.queryByText(/100% used/)).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show technical details/ }),
+    );
+
+    expect(screen.getByText(/df: \/: 100% used \(0 bytes free\)/)).toBeTruthy();
+  });
+
+  it("validates a pairing link and pairs on the Pair tab", async () => {
+    remoteRuntimeMock.listTargets.mockResolvedValue([]);
+    remoteRuntimeMock.listDiscoveredMachines.mockResolvedValue({
+      machines: [],
+      diagnostics: [],
+    });
+    remoteRuntimeMock.parsePairingInput
+      .mockRejectedValueOnce(new Error("That doesn't look like a pairing code."))
+      .mockResolvedValue({
+        hostIdentity: {
+          deviceId: "d1",
+          siteId: "s1",
+          name: "Studio",
+          platform: "macOS",
+          deviceType: "desktop",
+        },
+        machineName: "Studio",
+        endpoints: ["wss://studio.example"],
+        requiresPin: true,
+      });
+    const savedTarget = {
+      id: "target-9",
+      name: "Studio",
+      hostname: "studio.example",
+      transport: "paired",
+      sshUser: null,
+      port: null,
+      sshKeyPath: null,
+      lastSeenArch: null,
+      runtimeBinaryVersion: null,
+      lastConnectedAt: null,
+    };
+    remoteRuntimeMock.pairWithMachine.mockResolvedValue({ targetId: "target-9" });
+    remoteRuntimeMock.connect.mockResolvedValue({
+      target: savedTarget,
+      arch: "darwin-arm64",
+      version: "1.0.0",
+      projects: [],
+    });
+    installAdeMock();
+
+    render(<RemoteTargetList />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Add machine" })).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Add machine" }));
+
+    const input = screen.getByLabelText("Pairing code or link");
+    fireEvent.change(input, { target: { value: "nope" } });
+    await waitFor(() =>
+      expect(
+        screen.getByText("That doesn't look like a pairing code."),
+      ).toBeTruthy(),
+    );
+
+    fireEvent.change(input, {
+      target: { value: "https://ade-app.dev/pair#ok" },
+    });
+    await waitFor(() =>
+      expect(screen.getByText(/Studio ready to pair/)).toBeTruthy(),
+    );
+
+    // Device name is prefilled from this Mac's pairing info.
+    expect(
+      (screen.getByLabelText("This device's name") as HTMLInputElement).value,
+    ).toBe("This Mac");
+
+    fireEvent.change(screen.getByLabelText("PIN"), {
+      target: { value: "654321" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    await waitFor(() =>
+      expect(remoteRuntimeMock.pairWithMachine).toHaveBeenCalledWith({
+        input: "https://ade-app.dev/pair#ok",
+        pin: "654321",
+        deviceName: "This Mac",
+      }),
+    );
+    await waitFor(() =>
+      expect(remoteRuntimeMock.connect).toHaveBeenCalledWith("target-9"),
+    );
   });
 
   it("surfaces Tailscale discovery diagnostics separately from empty results", async () => {

--- a/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetList.test.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetList.test.tsx
@@ -48,6 +48,7 @@ describe("RemoteTargetList", () => {
     cleanup();
     vi.restoreAllMocks();
     vi.clearAllMocks();
+    Reflect.deleteProperty(remoteRuntimeMock, "getConnectionSnapshot");
     Reflect.deleteProperty(window, "ade");
   });
 
@@ -67,6 +68,7 @@ describe("RemoteTargetList", () => {
           tailscaleAddress: "studio.tailnet.ts.net",
           runtimeKind: "daemon",
           runtimeVersion: "0.0.0",
+          connectable: true,
           projectIds: ["project-1", "project-2"],
           projectCount: 2,
           lastSeenAt: 1234,
@@ -157,6 +159,97 @@ describe("RemoteTargetList", () => {
     await waitFor(() =>
       expect(remoteRuntimeMock.connect).toHaveBeenCalledWith("target-1"),
     );
+  });
+
+  it("shows why an unsupported discovered machine cannot connect", async () => {
+    remoteRuntimeMock.listTargets.mockResolvedValue([]);
+    remoteRuntimeMock.listDiscoveredMachines.mockResolvedValue({
+      machines: [
+        {
+          id: "tailscale:windows-pc",
+          serviceName: "Tailscale peer",
+          machineName: "Windows PC",
+          hostIdentity: "windows-pc",
+          hostName: "windows-pc",
+          port: 22,
+          addresses: ["100.64.0.12"],
+          primaryRoute: "100.64.0.12",
+          tailscaleAddress: "100.64.0.12",
+          runtimeKind: "tailscale-peer",
+          runtimeVersion: null,
+          os: "windows",
+          connectable: false,
+          unsupportedReason: "Windows machines can't run the ADE remote runtime yet.",
+          projectIds: [],
+          projectCount: null,
+          lastSeenAt: 1234,
+        },
+      ],
+      diagnostics: [],
+    });
+    installAdeMock();
+
+    render(<RemoteTargetList />);
+
+    await waitFor(() => expect(screen.getByText("Windows PC")).toBeTruthy());
+    expect(screen.getByText(/Windows machines can't run the ADE remote runtime yet/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Connect" })).toBeNull();
+  });
+
+  it("prefers the structured connection error message without rewriting it", async () => {
+    const target = {
+      id: "target-1",
+      name: "Mac Studio",
+      hostname: "studio.local",
+      sshUser: null,
+      port: 22,
+      sshKeyPath: null,
+      lastSeenArch: null,
+      runtimeBinaryVersion: null,
+      lastConnectedAt: null,
+    };
+    Object.defineProperty(remoteRuntimeMock, "getConnectionSnapshot", {
+      configurable: true,
+      value: vi.fn().mockResolvedValue({
+        connections: [
+          {
+            target,
+            state: "error",
+            arch: null,
+            version: null,
+            projects: [],
+            lastError: "All configured authentication methods failed",
+            lastErrorInfo: {
+              kind: "ssh_auth",
+              message:
+                'SSH authentication failed for user(s) "ade" using key /Users/ade/.ssh/id_ed25519.',
+            },
+            lastAttemptedAt: 1234,
+            connectedAt: null,
+          },
+        ],
+        connectedCount: 0,
+        updatedAt: 1234,
+      }),
+    });
+    remoteRuntimeMock.listDiscoveredMachines.mockResolvedValue({
+      machines: [],
+      diagnostics: [],
+    });
+    installAdeMock();
+
+    render(<RemoteTargetList />);
+
+    expect(
+      await screen.findByText(
+        'SSH authentication failed for user(s) "ade" using key /Users/ade/.ssh/id_ed25519.',
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText(
+        "SSH authentication failed. Check the SSH user, key path, and that this key is allowed on the remote machine.",
+      ),
+    ).toBeNull();
   });
 
   it("connects a saved machine without listing remote projects in the connection manager", async () => {

--- a/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetList.test.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetList.test.tsx
@@ -209,7 +209,8 @@ describe("RemoteTargetList", () => {
           runtimeVersion: null,
           os: "windows",
           connectable: false,
-          unsupportedReason: "Windows machines can't run the ADE remote runtime yet.",
+          unsupportedReason:
+            "Windows machines can't run the ADE remote runtime yet.",
           projectIds: [],
           projectCount: null,
           lastSeenAt: 1234,
@@ -222,7 +223,9 @@ describe("RemoteTargetList", () => {
     render(<RemoteTargetList />);
 
     await waitFor(() => expect(screen.getByText("Windows PC")).toBeTruthy());
-    expect(screen.getByText(/Windows machines can't run the ADE remote runtime yet/)).toBeTruthy();
+    expect(
+      screen.getByText(/Windows machines can't run the ADE remote runtime yet/),
+    ).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Connect" })).toBeNull();
   });
 
@@ -374,9 +377,7 @@ describe("RemoteTargetList", () => {
     const onDisconnectRequested = vi.fn(async () => false);
     installAdeMock();
 
-    render(
-      <RemoteTargetList onDisconnectRequested={onDisconnectRequested} />,
-    );
+    render(<RemoteTargetList onDisconnectRequested={onDisconnectRequested} />);
 
     await waitFor(() =>
       expect(screen.getAllByText("Mac Studio").length).toBeGreaterThan(0),
@@ -440,6 +441,83 @@ describe("RemoteTargetList", () => {
     expect(screen.queryByText("Edit Mac Studio")).toBeNull();
   });
 
+  it("keeps a paired target and creates one manual SSH route when its host changes", async () => {
+    const target = {
+      id: "target-paired",
+      name: "Paired Studio",
+      hostname: "studio.local",
+      transport: "paired" as const,
+      pairedMachine: {
+        hostIdentity: "host-device-1",
+        machineKey: "machine-key-1",
+      },
+      sshUser: "admin",
+      port: 22,
+      sshKeyPath: "/Users/admin/.ssh/id_ed25519",
+      routes: [
+        {
+          hostname: "studio.local",
+          port: null,
+          source: "bonjour" as const,
+          lastSucceededAt: null,
+        },
+      ],
+      lastSeenArch: "darwin-arm64",
+      runtimeBinaryVersion: "1.0.0",
+      lastConnectedAt: null,
+    };
+    const updatedTarget = {
+      ...target,
+      name: "Renamed Studio",
+      hostname: "100.75.20.64",
+    };
+    remoteRuntimeMock.listTargets.mockResolvedValue([target]);
+    remoteRuntimeMock.listDiscoveredMachines.mockResolvedValue({
+      machines: [],
+      diagnostics: [],
+    });
+    remoteRuntimeMock.saveTarget.mockResolvedValue(updatedTarget);
+    remoteRuntimeMock.connect.mockResolvedValue({
+      target: updatedTarget,
+      arch: "darwin-arm64",
+      version: "1.0.0",
+      projects: [],
+    });
+    installAdeMock();
+
+    render(<RemoteTargetList />);
+
+    await screen.findByText("Paired Studio");
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Renamed Studio" },
+    });
+    fireEvent.change(screen.getByLabelText("Host"), {
+      target: { value: "100.75.20.64" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save and connect" }));
+
+    await waitFor(() =>
+      expect(remoteRuntimeMock.saveTarget).toHaveBeenCalled(),
+    );
+    const savedInput = remoteRuntimeMock.saveTarget.mock.calls[0]?.[0];
+    expect(savedInput.transport).toBe("paired");
+    expect(savedInput.pairedMachine).toEqual(target.pairedMachine);
+    expect(savedInput.hostname).toBe("100.75.20.64");
+    expect(savedInput.routes).toEqual([
+      {
+        hostname: "100.75.20.64",
+        port: 22,
+        source: "manual",
+        lastSucceededAt: null,
+      },
+    ]);
+    expect(remoteRuntimeMock.removeTarget).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(remoteRuntimeMock.connect).toHaveBeenCalledWith("target-paired"),
+    );
+  });
+
   it("shows an actionable message when the SSH host-key probe is reset", async () => {
     const target = {
       id: "target-1",
@@ -477,7 +555,9 @@ describe("RemoteTargetList", () => {
 
     await waitFor(() =>
       expect(
-        screen.getByText(/SSH server closed the connection before ADE could finish the SSH handshake/),
+        screen.getByText(
+          /SSH server closed the connection before ADE could finish the SSH handshake/,
+        ),
       ).toBeTruthy(),
     );
     expect(screen.queryByText(/Error invoking remote method/)).toBeNull();
@@ -570,6 +650,60 @@ describe("RemoteTargetList", () => {
       expect(remoteRuntimeMock.connect).toHaveBeenCalledWith("target-1"),
     );
     expect(screen.getByText("Connected")).toBeTruthy();
+  });
+
+  it("surfaces SSH trust when a paired connection falls back after connect starts", async () => {
+    const target = {
+      id: "target-paired",
+      name: "Paired Studio",
+      hostname: "studio.local",
+      transport: "paired" as const,
+      pairedMachine: { hostIdentity: "host-device-1", machineKey: null },
+      sshUser: "ade",
+      port: 22,
+      sshKeyPath: null,
+      lastSeenArch: null,
+      runtimeBinaryVersion: null,
+      lastConnectedAt: null,
+    };
+    const trustRequired = {
+      state: "needs_trust" as const,
+      targetId: target.id,
+      host: target.hostname,
+      port: 22,
+      route: {
+        hostname: target.hostname,
+        port: 22,
+        source: "manual" as const,
+        lastSucceededAt: null,
+      },
+      keyType: "ssh-ed25519",
+      fingerprintSha256: "SHA256:fallback",
+      knownHostsPath: "/Users/test/.ssh/known_hosts",
+    };
+    remoteRuntimeMock.listTargets.mockResolvedValue([target]);
+    remoteRuntimeMock.listDiscoveredMachines.mockResolvedValue({
+      machines: [],
+      diagnostics: [],
+    });
+    remoteRuntimeMock.connect.mockRejectedValue(
+      new Error("SSH host key verification failed during paired fallback."),
+    );
+    installAdeMock();
+    remoteRuntimeMock.getSshHostKeyTrust
+      .mockResolvedValueOnce({ state: "trusted" })
+      .mockResolvedValueOnce(trustRequired);
+
+    render(<RemoteTargetList />);
+
+    await screen.findByText("Paired Studio");
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    await screen.findByText("Trust this machine");
+    expect(screen.getByText("SHA256:fallback")).toBeTruthy();
+    expect(remoteRuntimeMock.connect).toHaveBeenCalledTimes(1);
+    expect(remoteRuntimeMock.getSshHostKeyTrust).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText(/SSH host-key verification failed/)).toBeNull();
   });
 
   it("hides discovered machines that are already saved as SSH targets", async () => {
@@ -817,7 +951,9 @@ describe("RemoteTargetList", () => {
       diagnostics: [],
     });
     remoteRuntimeMock.parsePairingInput
-      .mockRejectedValueOnce(new Error("That doesn't look like a pairing code."))
+      .mockRejectedValueOnce(
+        new Error("That doesn't look like a pairing code."),
+      )
       .mockResolvedValue({
         hostIdentity: {
           deviceId: "d1",
@@ -842,7 +978,9 @@ describe("RemoteTargetList", () => {
       runtimeBinaryVersion: null,
       lastConnectedAt: null,
     };
-    remoteRuntimeMock.pairWithMachine.mockResolvedValue({ targetId: "target-9" });
+    remoteRuntimeMock.pairWithMachine.mockResolvedValue({
+      targetId: "target-9",
+    });
     remoteRuntimeMock.connect.mockResolvedValue({
       target: savedTarget,
       arch: "darwin-arm64",
@@ -915,7 +1053,9 @@ describe("RemoteTargetList", () => {
 
     await waitFor(() =>
       expect(
-        screen.getByText("Tailscale CLI was not found; only LAN discovery ran."),
+        screen.getByText(
+          "Tailscale CLI was not found; only LAN discovery ran.",
+        ),
       ).toBeTruthy(),
     );
     expect(screen.getByText("No saved or detected machines yet.")).toBeTruthy();

--- a/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetList.test.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetList.test.tsx
@@ -68,6 +68,28 @@ describe("RemoteTargetList", () => {
     Reflect.deleteProperty(window, "ade");
   });
 
+  it("does not report copied pairing data when the clipboard bridge is unavailable", async () => {
+    remoteRuntimeMock.listTargets.mockResolvedValue([]);
+    remoteRuntimeMock.listDiscoveredMachines.mockResolvedValue({
+      machines: [],
+      diagnostics: [],
+    });
+    installAdeMock();
+    Object.defineProperty(window.ade, "app", {
+      configurable: true,
+      value: {},
+    });
+
+    render(<RemoteTargetList />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Share" }));
+    const copyButton = await screen.findByRole("button", { name: "Copy code" });
+    fireEvent.click(copyButton);
+
+    expect(screen.getByRole("button", { name: "Copy code" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Copied" })).toBeNull();
+  });
+
   it("lists a discovered ADE machine under Available and connects via its route", async () => {
     remoteRuntimeMock.listTargets.mockResolvedValue([]);
     remoteRuntimeMock.listDiscoveredMachines.mockResolvedValue({

--- a/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetList.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetList.tsx
@@ -1,21 +1,5 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type CSSProperties,
-  type ReactNode,
-} from "react";
-import {
-  CaretDown,
-  CaretUp,
-  CheckCircle,
-  DesktopTower,
-  PlugsConnected,
-  ShareNetwork,
-  Trash,
-  Warning,
-} from "@phosphor-icons/react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { DesktopTower, ShareNetwork, Warning } from "@phosphor-icons/react";
 import { extractError } from "../../lib/format";
 import {
   COLORS,
@@ -37,24 +21,22 @@ import {
   RemoteTargetForm,
   type RemoteTargetFormPrefill,
 } from "./RemoteTargetForm";
-import { RemoteErrorCard } from "./RemoteErrorCard";
-import { ConnectionDoctorPanel } from "./ConnectionDoctorPanel";
 import { ShareMachineCard } from "./ShareMachineCard";
 import { PairMachineForm } from "./PairMachineForm";
 import {
   assignMachineSections,
-  connectionStateLabel,
-  discoveredMachineSummary,
-  discoveredRoute,
   discoveredTargetInput,
-  formatLastSeen,
   formatRemoteTargetError,
-  formatRouteChip,
-  selectMachineErrorCard,
-  targetConnectionLabel,
   type MachineSection,
-  type SavedMachineRow,
 } from "./remoteMachineModel";
+import { SavedMachineRow } from "./SavedMachineRow";
+import { DiscoveredMachineRow } from "./DiscoveredMachineRow";
+import {
+  helperTextStyle,
+  inlineDetailStyle,
+  panelStyle,
+  sectionHeaderStyle,
+} from "./remoteTargetListStyles";
 
 type RemoteTargetListProps = {
   onConnected?: (result: RemoteRuntimeConnectResult) => void;
@@ -72,69 +54,11 @@ type ConnectTargetOptions = {
 
 type AddMode = { tab: "pair" | "ssh" };
 
-const panelStyle: CSSProperties = {
-  display: "grid",
-  gap: 12,
-};
-
-const machineRowStyle: CSSProperties = {
-  display: "grid",
-  gap: 8,
-  padding: "12px 14px",
-  borderRadius: 8,
-  border: `1px solid ${COLORS.border}`,
-  background: "rgba(255,255,255,0.02)",
-};
-
-const inlineDetailStyle: CSSProperties = {
-  display: "grid",
-  gap: 12,
-  marginTop: -4,
-  padding: 12,
-  borderRadius: 8,
-  border: `1px solid ${COLORS.border}`,
-  background: "rgba(0,0,0,0.16)",
-};
-
-const helperTextStyle: CSSProperties = {
-  color: COLORS.textMuted,
-  fontFamily: SANS_FONT,
-  fontSize: 12,
-  lineHeight: 1.45,
-};
-
-const sectionHeaderStyle: CSSProperties = {
-  color: COLORS.textMuted,
-  fontFamily: SANS_FONT,
-  fontSize: 10.5,
-  fontWeight: 600,
-  letterSpacing: "0.08em",
-};
-
-const nameStyle: CSSProperties = {
-  color: COLORS.textPrimary,
-  fontFamily: MONO_FONT,
-  fontSize: 13,
-  fontWeight: 700,
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap",
-};
-
-const subTextStyle: CSSProperties = {
-  color: COLORS.textMuted,
-  fontFamily: MONO_FONT,
-  fontSize: 12,
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap",
-};
-
 function targetFormPrefill(
   target: RemoteRuntimeTarget,
 ): RemoteTargetFormPrefill {
   return {
-    key: `target:${target.id}:${target.lastConnectedAt ?? "never"}:${target.sshUser ?? ""}:${target.port ?? ""}:${target.sshKeyPath ?? ""}`,
+    key: `target:${target.id}:${target.lastConnectedAt ?? "never"}:${target.transport ?? "ssh"}:${target.pairedMachine?.hostIdentity ?? ""}:${target.pairedMachine?.machineKey ?? ""}:${target.sshUser ?? ""}:${target.port ?? ""}:${target.sshKeyPath ?? ""}`,
     targetId: target.id,
     name: target.name,
     hostname: target.hostname,
@@ -142,6 +66,8 @@ function targetFormPrefill(
     port: target.port,
     sshKeyPath: target.sshKeyPath,
     routes: target.routes ?? null,
+    transport: target.transport,
+    pairedMachine: target.pairedMachine,
   };
 }
 
@@ -249,7 +175,7 @@ export function RemoteTargetList({
   }, []);
 
   useEffect(() => {
-    const status = selectedId ? statusById.get(selectedId) ?? null : null;
+    const status = selectedId ? (statusById.get(selectedId) ?? null) : null;
     if (!status) return;
     if (status.state !== "connected") {
       setConnected((current) =>
@@ -294,7 +220,8 @@ export function RemoteTargetList({
     void (async () => {
       try {
         const info = await window.ade.remoteRuntime.getLocalPairingInfo();
-        if (!cancelled && info.machineName) setLocalMachineName(info.machineName);
+        if (!cancelled && info.machineName)
+          setLocalMachineName(info.machineName);
       } catch {
         // Pairing info is optional; the pair form still works with a typed name.
       }
@@ -372,42 +299,26 @@ export function RemoteTargetList({
             connectedAt: target.lastConnectedAt,
           }));
           const existing = current?.connections ?? fallbackConnections;
+          const connectedEntry: RemoteRuntimeConnectionStatus = {
+            target: result.target,
+            state: "connected",
+            arch: result.arch,
+            version: result.version,
+            route: result.route,
+            capabilities: result.capabilities,
+            compatibilityWarnings: result.compatibilityWarnings,
+            projects: result.projects,
+            lastError: null,
+            lastAttemptedAt: Date.now(),
+            connectedAt: result.target.lastConnectedAt ?? Date.now(),
+          };
           const connections = existing.some(
             (entry) => entry.target.id === result.target.id,
           )
             ? existing.map((entry) =>
-                entry.target.id === result.target.id
-                  ? {
-                      target: result.target,
-                      state: "connected" as const,
-                      arch: result.arch,
-                      version: result.version,
-                      route: result.route,
-                      capabilities: result.capabilities,
-                      compatibilityWarnings: result.compatibilityWarnings,
-                      projects: result.projects,
-                      lastError: null,
-                      lastAttemptedAt: Date.now(),
-                      connectedAt: result.target.lastConnectedAt ?? Date.now(),
-                    }
-                  : entry,
+                entry.target.id === result.target.id ? connectedEntry : entry,
               )
-            : [
-                ...existing,
-                {
-                  target: result.target,
-                  state: "connected" as const,
-                  arch: result.arch,
-                  version: result.version,
-                  route: result.route,
-                  capabilities: result.capabilities,
-                  compatibilityWarnings: result.compatibilityWarnings,
-                  projects: result.projects,
-                  lastError: null,
-                  lastAttemptedAt: Date.now(),
-                  connectedAt: result.target.lastConnectedAt ?? Date.now(),
-                },
-              ];
+            : [...existing, connectedEntry];
           return {
             connections,
             connectedCount: connections.filter(
@@ -423,7 +334,13 @@ export function RemoteTargetList({
         onConnected?.(result);
         return true;
       } catch (err) {
-        setError(formatRemoteTargetError(err));
+        let trustRequired = false;
+        try {
+          trustRequired = !(await ensureHostKeyTrust(targetId));
+        } catch {
+          // Preserve the connect failure when a follow-up trust probe also fails.
+        }
+        if (!trustRequired) setError(formatRemoteTargetError(err));
         return false;
       } finally {
         setBusyId(null);
@@ -519,47 +436,50 @@ export function RemoteTargetList({
     [connectTarget, loadTargets],
   );
 
-  const disconnectTarget = useCallback(async (targetId: string) => {
-    const target = targets.find((entry) => entry.id === targetId) ?? null;
-    if (target && onDisconnectRequested) {
-      const shouldDisconnect = await onDisconnectRequested(target);
-      if (!shouldDisconnect) return;
-    }
-    setBusyId(targetId);
-    setSelectedId(targetId);
-    try {
-      await window.ade.remoteRuntime.disconnect(targetId, { manual: true });
-      setConnected((current) =>
-        current?.target.id === targetId ? null : current,
-      );
-      setConnectionSnapshot((current) => {
-        if (!current) return current;
-        const connections = current.connections.map((entry) =>
-          entry.target.id === targetId
-            ? {
-                ...entry,
-                state: "idle" as const,
-                lastError: null,
-                connectedAt: null,
-              }
-            : entry,
+  const disconnectTarget = useCallback(
+    async (targetId: string) => {
+      const target = targets.find((entry) => entry.id === targetId) ?? null;
+      if (target && onDisconnectRequested) {
+        const shouldDisconnect = await onDisconnectRequested(target);
+        if (!shouldDisconnect) return;
+      }
+      setBusyId(targetId);
+      setSelectedId(targetId);
+      try {
+        await window.ade.remoteRuntime.disconnect(targetId, { manual: true });
+        setConnected((current) =>
+          current?.target.id === targetId ? null : current,
         );
-        return {
-          connections,
-          connectedCount: connections.filter(
-            (entry) => entry.state === "connected",
-          ).length,
-          updatedAt: Date.now(),
-        };
-      });
-      setError(null);
-      setHostKeyTrust(null);
-    } catch (err) {
-      setError(formatRemoteTargetError(err));
-    } finally {
-      setBusyId(null);
-    }
-  }, [onDisconnectRequested, targets]);
+        setConnectionSnapshot((current) => {
+          if (!current) return current;
+          const connections = current.connections.map((entry) =>
+            entry.target.id === targetId
+              ? {
+                  ...entry,
+                  state: "idle" as const,
+                  lastError: null,
+                  connectedAt: null,
+                }
+              : entry,
+          );
+          return {
+            connections,
+            connectedCount: connections.filter(
+              (entry) => entry.state === "connected",
+            ).length,
+            updatedAt: Date.now(),
+          };
+        });
+        setError(null);
+        setHostKeyTrust(null);
+      } catch (err) {
+        setError(formatRemoteTargetError(err));
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [onDisconnectRequested, targets],
+  );
 
   const removeTarget = useCallback(
     async (targetId: string) => {
@@ -598,378 +518,50 @@ export function RemoteTargetList({
     sections.available.length +
     sections.unavailable.length;
 
-  function renderSavedRow(
-    row: SavedMachineRow,
-    section: MachineSection,
-  ): ReactNode {
-    const { target, status } = row;
-    const targetSelected = selectedId === target.id;
-    const targetConnecting =
-      busyId === target.id || status?.state === "connecting";
-    const version =
-      status?.version ??
-      (connected?.target.id === target.id ? connected.version : null) ??
-      target.runtimeBinaryVersion ??
-      null;
-    const arch =
-      status?.arch ??
-      (connected?.target.id === target.id ? connected.arch : null) ??
-      target.lastSeenArch ??
-      null;
-    const route =
-      status?.route ??
-      (connected?.target.id === target.id ? connected.route : undefined);
-    const routeChip = row.connected ? formatRouteChip(route) : null;
-    const statusLabel = connectionStateLabel(
-      status ?? null,
-      connected?.target.id === target.id,
-    );
-    const warnings = targetSelected
-      ? status?.compatibilityWarnings ??
-        (connected?.target.id === target.id
-          ? connected.compatibilityWarnings
-          : []) ??
-        []
-      : status?.compatibilityWarnings ?? [];
-    const errorCard = selectMachineErrorCard({
-      errorInfo: status?.state === "error" ? status.lastErrorInfo : null,
-      rawError: status?.state === "error" ? status.lastError : null,
-      overrideMessage: targetSelected ? error : null,
-    });
-    const formOpen = formPrefill?.targetId === target.id;
-    const testOpen = testingId === target.id;
-
-    return (
-      <div key={target.id} style={{ display: "grid", gap: 8 }}>
-        <div
-          style={{
-            ...machineRowStyle,
-            opacity: section === "unavailable" ? 0.62 : 1,
-            borderColor: targetSelected ? COLORS.accent : COLORS.border,
-          }}
-        >
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "minmax(0,1fr) auto",
-              gap: 12,
-              alignItems: "start",
-            }}
-          >
-            <div style={{ minWidth: 0, display: "grid", gap: 5 }}>
-              <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
-                <span style={nameStyle}>{target.name}</span>
-                {row.connected ? (
-                  <CheckCircle size={15} weight="fill" color={COLORS.success} />
-                ) : null}
-                {routeChip ? (
-                  <span
-                    style={{
-                      color: COLORS.textMuted,
-                      fontFamily: SANS_FONT,
-                      fontSize: 11,
-                      whiteSpace: "nowrap",
-                      flexShrink: 0,
-                    }}
-                  >
-                    {routeChip}
-                  </span>
-                ) : null}
-              </div>
-              <div style={subTextStyle}>{targetConnectionLabel(target)}</div>
-              <div style={helperTextStyle}>
-                {section === "unavailable" && row.unavailableReason ? (
-                  <span>{row.unavailableReason}</span>
-                ) : (
-                  <>
-                    <span>{statusLabel}</span>
-                    {version || arch ? (
-                      <span>{` · ADE ${version ?? "unknown"} on ${arch ?? "unknown"}`}</span>
-                    ) : null}
-                    <span>{` · ${formatLastSeen(target.lastConnectedAt)}`}</span>
-                  </>
-                )}
-              </div>
-            </div>
-            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
-              {row.connected ? (
-                <button
-                  type="button"
-                  disabled={busyId != null}
-                  onClick={() => void disconnectTarget(target.id)}
-                  style={outlineButton({ height: 30, padding: "0 10px", fontSize: 11 })}
-                >
-                  Disconnect
-                </button>
-              ) : section !== "unavailable" ? (
-                <>
-                  <button
-                    type="button"
-                    disabled={busyId != null}
-                    onClick={() => void connectTarget(target.id)}
-                    style={primaryButton({ height: 30, padding: "0 10px", fontSize: 11 })}
-                  >
-                    <PlugsConnected size={14} weight="bold" />
-                    {targetConnecting ? "Connecting…" : "Connect"}
-                  </button>
-                  <button
-                    type="button"
-                    aria-controls={`remote-target-test-${target.id}`}
-                    aria-expanded={testOpen}
-                    disabled={busyId != null}
-                    onClick={() => toggleTest(target.id)}
-                    style={outlineButton({ height: 30, padding: "0 10px", fontSize: 11 })}
-                  >
-                    Test
-                  </button>
-                </>
-              ) : null}
-              {section !== "unavailable" ? (
-                <button
-                  type="button"
-                  aria-controls={`remote-target-edit-${target.id}`}
-                  aria-expanded={formOpen}
-                  disabled={busyId != null}
-                  onClick={() => toggleEditForm(target)}
-                  style={outlineButton({ height: 30, padding: "0 10px", fontSize: 11 })}
-                >
-                  Edit
-                  {formOpen ? (
-                    <CaretUp size={12} weight="bold" />
-                  ) : (
-                    <CaretDown size={12} weight="bold" />
-                  )}
-                </button>
-              ) : null}
-              <button
-                type="button"
-                aria-label={`Remove ${target.name}`}
-                disabled={busyId != null}
-                onClick={() => void removeTarget(target.id)}
-                style={outlineButton({ height: 30, padding: "0 9px", fontSize: 11 })}
-              >
-                <Trash size={14} />
-              </button>
-            </div>
-          </div>
-
-          {errorCard ? (
-            <RemoteErrorCard
-              card={errorCard}
-              onRetry={
-                busyId == null ? () => void connectTarget(target.id) : undefined
-              }
-              retrying={busyId === target.id}
-            />
-          ) : null}
-
-          {warnings.length > 0 ? (
-            <div
-              style={{
-                display: "grid",
-                gap: 4,
-                color: COLORS.warning,
-                fontFamily: SANS_FONT,
-                fontSize: 12,
-              }}
-            >
-              {warnings.map((warning) => (
-                <div key={warning} style={{ display: "flex", gap: 6 }}>
-                  <Warning size={14} weight="fill" style={{ flexShrink: 0, marginTop: 1 }} />
-                  <span>{warning}</span>
-                </div>
-              ))}
-            </div>
-          ) : null}
-
-          {targetSelected && selectedHostKeyTrust ? (
-            <div
-              style={{
-                display: "grid",
-                gap: 10,
-                borderRadius: 8,
-                border: `1px solid ${
-                  selectedHostKeyTrust.state === "changed"
-                    ? COLORS.danger
-                    : COLORS.warning
-                }`,
-                background:
-                  selectedHostKeyTrust.state === "changed"
-                    ? `color-mix(in srgb, ${COLORS.danger} 10%, transparent)`
-                    : `color-mix(in srgb, ${COLORS.warning} 10%, transparent)`,
-                padding: "10px 12px",
-              }}
-            >
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 8,
-                  color:
-                    selectedHostKeyTrust.state === "changed"
-                      ? COLORS.danger
-                      : COLORS.warning,
-                  fontFamily: SANS_FONT,
-                  fontSize: 12,
-                  fontWeight: 700,
-                }}
-              >
-                <Warning size={15} weight="fill" />
-                {selectedHostKeyTrust.state === "changed"
-                  ? "Machine identity changed"
-                  : "Trust this machine"}
-              </div>
-              <div style={helperTextStyle}>
-                {selectedHostKeyTrust.state === "changed"
-                  ? `ADE found a different SSH identity for ${selectedHostKeyTrust.host}:${selectedHostKeyTrust.port}. Review ${selectedHostKeyTrust.knownHostsPath ?? "known_hosts"} before connecting.`
-                  : `ADE found a new SSH identity for ${selectedHostKeyTrust.host}:${selectedHostKeyTrust.port}. Trust it once to connect.`}
-              </div>
-              <div
-                style={{
-                  color: COLORS.textPrimary,
-                  fontFamily: MONO_FONT,
-                  fontSize: 11,
-                  overflowWrap: "anywhere",
-                }}
-              >
-                {selectedHostKeyTrust.fingerprintSha256}
-              </div>
-              {selectedHostKeyTrust.state === "needs_trust" ? (
-                <div style={{ display: "flex", gap: 8 }}>
-                  <button
-                    type="button"
-                    disabled={trustingHostKey || busyId != null}
-                    onClick={() => void trustAndConnect()}
-                    style={{
-                      ...primaryButton({ height: 30, padding: "0 10px", fontSize: 11 }),
-                      opacity: trustingHostKey || busyId != null ? 0.65 : 1,
-                    }}
-                  >
-                    <CheckCircle size={15} weight="bold" />
-                    {trustingHostKey ? "Trusting…" : "Trust & connect"}
-                  </button>
-                  <button
-                    type="button"
-                    disabled={trustingHostKey}
-                    onClick={() => setHostKeyTrust(null)}
-                    style={outlineButton({ height: 30, padding: "0 10px", fontSize: 11 })}
-                  >
-                    Cancel
-                  </button>
-                </div>
-              ) : null}
-            </div>
-          ) : null}
-        </div>
-
-        {testOpen ? (
-          <div id={`remote-target-test-${target.id}`}>
-            <ConnectionDoctorPanel machineId={target.id} />
-          </div>
-        ) : null}
-
-        {formOpen ? (
-          <div id={`remote-target-edit-${target.id}`} style={inlineDetailStyle}>
-            <div
-              style={{
-                color: COLORS.textPrimary,
-                fontFamily: SANS_FONT,
-                fontSize: 13,
-                fontWeight: 700,
-              }}
-            >
-              Edit {target.name}
-            </div>
-            <RemoteTargetForm
-              busy={saving || busyId != null}
-              prefill={formPrefill}
-              submitLabel="Save and connect"
-              onSubmit={saveAndConnect}
-            />
-          </div>
-        ) : null}
-      </div>
-    );
-  }
-
-  function renderDiscoveredRow(
-    machine: RemoteRuntimeDiscoveredMachine,
-    section: MachineSection,
-  ): ReactNode {
-    const route = discoveredRoute(machine);
-    const testOpen = testingId === machine.id;
-    const unavailable = section === "unavailable";
-    return (
-      <div key={machine.id} style={{ display: "grid", gap: 8 }}>
-        <div style={{ ...machineRowStyle, opacity: unavailable ? 0.62 : 1 }}>
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "minmax(0,1fr) auto",
-              gap: 12,
-              alignItems: "center",
-            }}
-          >
-            <div style={{ minWidth: 0, display: "grid", gap: 5 }}>
-              <div style={nameStyle}>{machine.machineName}</div>
-              <div style={subTextStyle}>
-                {route ? `${route}:${machine.port}` : "No route advertised"}
-              </div>
-              <div style={helperTextStyle}>
-                {unavailable && machine.unsupportedReason
-                  ? machine.unsupportedReason
-                  : discoveredMachineSummary(machine)}
-              </div>
-            </div>
-            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
-              {!unavailable ? (
-                <>
-                  <button
-                    type="button"
-                    disabled={!route || busyId != null || saving}
-                    onClick={() => void connectDiscoveredMachine(machine)}
-                    style={{
-                      ...primaryButton({ height: 30, padding: "0 10px", fontSize: 11 }),
-                      opacity: route && busyId == null && !saving ? 1 : 0.55,
-                    }}
-                  >
-                    <PlugsConnected size={14} weight="bold" />
-                    {busyId === machine.id ? "Connecting…" : "Connect"}
-                  </button>
-                  <button
-                    type="button"
-                    aria-controls={`remote-discovered-test-${machine.id}`}
-                    aria-expanded={testOpen}
-                    disabled={busyId != null}
-                    onClick={() => toggleTest(machine.id)}
-                    style={outlineButton({ height: 30, padding: "0 10px", fontSize: 11 })}
-                  >
-                    Test
-                  </button>
-                </>
-              ) : null}
-            </div>
-          </div>
-        </div>
-        {testOpen ? (
-          <div id={`remote-discovered-test-${machine.id}`}>
-            <ConnectionDoctorPanel machineId={machine.id} />
-          </div>
-        ) : null}
-      </div>
-    );
-  }
-
-  function renderSection(section: MachineSection): ReactNode {
+  function renderSection(section: MachineSection) {
     const rows = sections[section];
     if (rows.length === 0) return null;
     return (
       <div style={{ display: "grid", gap: 8 }}>
         <div style={sectionHeaderStyle}>{SECTION_LABELS[section]}</div>
         {rows.map((row) =>
-          row.kind === "saved"
-            ? renderSavedRow(row, section)
-            : renderDiscoveredRow(row.machine, section),
+          row.kind === "saved" ? (
+            <SavedMachineRow
+              key={row.id}
+              row={row}
+              section={section}
+              selected={selectedId === row.target.id}
+              connected={connected}
+              busyId={busyId}
+              saving={saving}
+              formPrefill={formPrefill}
+              testOpen={testingId === row.target.id}
+              error={error}
+              hostKeyTrust={
+                selectedId === row.target.id ? selectedHostKeyTrust : null
+              }
+              trustingHostKey={trustingHostKey}
+              onConnect={(targetId) => void connectTarget(targetId)}
+              onDisconnect={(targetId) => void disconnectTarget(targetId)}
+              onToggleTest={toggleTest}
+              onToggleEdit={toggleEditForm}
+              onRemove={(targetId) => void removeTarget(targetId)}
+              onSaveAndConnect={saveAndConnect}
+              onTrustAndConnect={() => void trustAndConnect()}
+              onCancelHostKeyTrust={() => setHostKeyTrust(null)}
+            />
+          ) : (
+            <DiscoveredMachineRow
+              key={row.id}
+              machine={row.machine}
+              section={section}
+              busyId={busyId}
+              saving={saving}
+              testOpen={testingId === row.machine.id}
+              onConnect={(machine) => void connectDiscoveredMachine(machine)}
+              onToggleTest={toggleTest}
+            />
+          ),
         )}
       </div>
     );
@@ -1010,7 +602,11 @@ export function RemoteTargetList({
               type="button"
               onClick={toggleShare}
               aria-expanded={shareOpen}
-              style={outlineButton({ height: 30, padding: "0 10px", fontSize: 11 })}
+              style={outlineButton({
+                height: 30,
+                padding: "0 10px",
+                fontSize: 11,
+              })}
             >
               <ShareNetwork size={14} weight="bold" />
               Share
@@ -1020,7 +616,11 @@ export function RemoteTargetList({
               disabled={loadingDiscovered}
               onClick={() => void loadDiscoveredMachines()}
               style={{
-                ...outlineButton({ height: 30, padding: "0 10px", fontSize: 11 }),
+                ...outlineButton({
+                  height: 30,
+                  padding: "0 10px",
+                  fontSize: 11,
+                }),
                 opacity: loadingDiscovered ? 0.6 : 1,
               }}
             >
@@ -1030,7 +630,11 @@ export function RemoteTargetList({
               type="button"
               onClick={openAddMachine}
               aria-expanded={addMode != null}
-              style={primaryButton({ height: 30, padding: "0 12px", fontSize: 11 })}
+              style={primaryButton({
+                height: 30,
+                padding: "0 12px",
+                fontSize: 11,
+              })}
             >
               Add machine
             </button>
@@ -1041,7 +645,11 @@ export function RemoteTargetList({
 
         {addMode ? (
           <div style={inlineDetailStyle}>
-            <div style={{ display: "flex", gap: 4 }} role="tablist" aria-label="Add machine">
+            <div
+              style={{ display: "flex", gap: 4 }}
+              role="tablist"
+              aria-label="Add machine"
+            >
               {(["pair", "ssh"] as const).map((tab) => {
                 const active = activeTab === tab;
                 return (
@@ -1104,7 +712,13 @@ export function RemoteTargetList({
         ) : null}
 
         {loading ? (
-          <div style={{ color: COLORS.textMuted, fontFamily: MONO_FONT, fontSize: 12 }}>
+          <div
+            style={{
+              color: COLORS.textMuted,
+              fontFamily: MONO_FONT,
+              fontSize: 12,
+            }}
+          >
             Loading machines…
           </div>
         ) : null}
@@ -1121,7 +735,13 @@ export function RemoteTargetList({
           </div>
         ) : null}
         {loadingDiscovered ? (
-          <div style={{ color: COLORS.textMuted, fontFamily: MONO_FONT, fontSize: 12 }}>
+          <div
+            style={{
+              color: COLORS.textMuted,
+              fontFamily: MONO_FONT,
+              fontSize: 12,
+            }}
+          >
             Scanning nearby machines…
           </div>
         ) : null}

--- a/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetList.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetList.tsx
@@ -382,8 +382,11 @@ export function RemoteTargetList({
     [connectionSnapshot, selectedId],
   );
   const selectedConnectionError =
-    selectedConnection?.state === "error" && selectedConnection.lastError
-      ? formatRemoteTargetError(selectedConnection.lastError)
+    selectedConnection?.state === "error"
+      ? selectedConnection.lastErrorInfo?.message ??
+        (selectedConnection.lastError
+          ? formatRemoteTargetError(selectedConnection.lastError)
+          : null)
       : null;
   const selectedCompatibilityWarnings =
     selectedConnection?.compatibilityWarnings ??
@@ -693,6 +696,7 @@ export function RemoteTargetList({
 
   const connectDiscoveredMachine = useCallback(
     async (machine: RemoteRuntimeDiscoveredMachine) => {
+      if (machine.connectable === false) return;
       const input = discoveredTargetInput(machine);
       if (!input) return;
       setBusyId(machine.id);
@@ -898,9 +902,10 @@ export function RemoteTargetList({
             const targetSelected = selectedId === target.id;
             const targetError = targetSelected
               ? (error ?? selectedConnectionError)
-              : targetStatus?.lastError
-                ? formatRemoteTargetError(targetStatus.lastError)
-                : null;
+              : targetStatus?.lastErrorInfo?.message ??
+                (targetStatus?.lastError
+                  ? formatRemoteTargetError(targetStatus.lastError)
+                  : null);
             const targetWarnings = targetSelected
               ? selectedCompatibilityWarnings
               : targetStatus?.compatibilityWarnings ?? [];
@@ -1243,25 +1248,30 @@ export function RemoteTargetList({
                       <div style={helperTextStyle}>
                         Detected · {discoveredRuntimeLabel(machine)} ·{" "}
                         {discoveredProjectLabel(machine)}
+                        {machine.connectable === false && machine.unsupportedReason
+                          ? ` · ${machine.unsupportedReason}`
+                          : ""}
                       </div>
                     </div>
                     <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
-                      <button
-                        type="button"
-                        disabled={!route || busyId != null || saving}
-                        onClick={() => void connectDiscoveredMachine(machine)}
-                        style={{
-                          ...primaryButton({
-                            height: 30,
-                            padding: "0 10px",
-                            fontSize: 11,
-                          }),
-                          opacity: route && busyId == null && !saving ? 1 : 0.55,
-                        }}
-                      >
-                        <PlugsConnected size={14} weight="bold" />
-                        {busyId === machine.id ? "Connecting..." : "Connect"}
-                      </button>
+                      {machine.connectable !== false ? (
+                        <button
+                          type="button"
+                          disabled={!route || busyId != null || saving}
+                          onClick={() => void connectDiscoveredMachine(machine)}
+                          style={{
+                            ...primaryButton({
+                              height: 30,
+                              padding: "0 10px",
+                              fontSize: 11,
+                            }),
+                            opacity: route && busyId == null && !saving ? 1 : 0.55,
+                          }}
+                        >
+                          <PlugsConnected size={14} weight="bold" />
+                          {busyId === machine.id ? "Connecting..." : "Connect"}
+                        </button>
+                      ) : null}
                       <button
                         type="button"
                         aria-controls={`remote-discovered-edit-${machine.id}`}

--- a/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetList.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/RemoteTargetList.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useState,
   type CSSProperties,
+  type ReactNode,
 } from "react";
 import {
   CaretDown,
@@ -11,6 +12,7 @@ import {
   CheckCircle,
   DesktopTower,
   PlugsConnected,
+  ShareNetwork,
   Trash,
   Warning,
 } from "@phosphor-icons/react";
@@ -30,13 +32,29 @@ import type {
   RemoteRuntimeSshHostKeyTrustStatus,
   RemoteRuntimeTarget,
   RemoteRuntimeTargetInput,
-  RemoteRuntimeTargetRoute,
-  RemoteRuntimeTargetRouteSource,
 } from "../../../shared/types";
 import {
   RemoteTargetForm,
   type RemoteTargetFormPrefill,
 } from "./RemoteTargetForm";
+import { RemoteErrorCard } from "./RemoteErrorCard";
+import { ConnectionDoctorPanel } from "./ConnectionDoctorPanel";
+import { ShareMachineCard } from "./ShareMachineCard";
+import { PairMachineForm } from "./PairMachineForm";
+import {
+  assignMachineSections,
+  connectionStateLabel,
+  discoveredMachineSummary,
+  discoveredRoute,
+  discoveredTargetInput,
+  formatLastSeen,
+  formatRemoteTargetError,
+  formatRouteChip,
+  selectMachineErrorCard,
+  targetConnectionLabel,
+  type MachineSection,
+  type SavedMachineRow,
+} from "./remoteMachineModel";
 
 type RemoteTargetListProps = {
   onConnected?: (result: RemoteRuntimeConnectResult) => void;
@@ -52,15 +70,11 @@ type ConnectTargetOptions = {
   skipHostKeyTrustCheck?: boolean;
 };
 
+type AddMode = { tab: "pair" | "ssh" };
+
 const panelStyle: CSSProperties = {
   display: "grid",
   gap: 12,
-};
-
-const sectionStyle: CSSProperties = {
-  display: "grid",
-  gap: 12,
-  padding: 0,
 };
 
 const machineRowStyle: CSSProperties = {
@@ -89,139 +103,32 @@ const helperTextStyle: CSSProperties = {
   lineHeight: 1.45,
 };
 
-function formatLastSeen(value: number | null): string {
-  if (!value) return "Never connected";
-  const date = new Date(value);
-  if (!Number.isFinite(date.getTime())) return "Last connection unknown";
-  return `Last connected ${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
-}
+const sectionHeaderStyle: CSSProperties = {
+  color: COLORS.textMuted,
+  fontFamily: SANS_FONT,
+  fontSize: 10.5,
+  fontWeight: 600,
+  letterSpacing: "0.08em",
+};
 
-function discoveredRuntimeLabel(
-  machine: RemoteRuntimeDiscoveredMachine,
-): string {
-  const kind = (machine.runtimeKind ?? "").toLowerCase();
-  let label: string;
-  switch (kind) {
-    case "tailscale-peer":
-      label = "Tailscale SSH target";
-      break;
-    case "tailscale-peer-offline":
-      label = "Tailscale SSH target offline";
-      break;
-    case "daemon":
-    case "headless":
-      label = "Background ADE";
-      break;
-    case "desktop":
-    case "desktop-embedded":
-      label = "ADE app";
-      break;
-    default:
-      label = "ADE service";
-  }
-  return machine.runtimeVersion ? `${label} ${machine.runtimeVersion}` : label;
-}
+const nameStyle: CSSProperties = {
+  color: COLORS.textPrimary,
+  fontFamily: MONO_FONT,
+  fontSize: 13,
+  fontWeight: 700,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
 
-function discoveredProjectLabel(
-  machine: RemoteRuntimeDiscoveredMachine,
-): string {
-  if ((machine.runtimeKind ?? "").startsWith("tailscale-peer"))
-    return "Not saved yet";
-  const count = machine.projectCount ?? machine.projectIds.length;
-  if (count <= 0) return "No projects advertised";
-  return `${count} project${count === 1 ? "" : "s"} advertised`;
-}
-
-function discoveredRoute(
-  machine: RemoteRuntimeDiscoveredMachine,
-): string | null {
-  return (
-    machine.tailscaleAddress ??
-    machine.primaryRoute ??
-    machine.hostName ??
-    machine.addresses[0] ??
-    null
-  );
-}
-
-function isTailscaleRoute(hostname: string | null | undefined): boolean {
-  const normalized = hostname?.trim().toLowerCase().replace(/\.$/, "") ?? "";
-  if (normalized.endsWith(".ts.net")) return true;
-  const match = /^100\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(normalized);
-  if (!match) return false;
-  const second = Number.parseInt(match[1] ?? "", 10);
-  return second >= 64 && second <= 127;
-}
-
-function normalizeRouteHost(hostname: string | null | undefined): string {
-  return hostname?.trim().toLowerCase().replace(/\.$/, "") ?? "";
-}
-
-function normalizeRoutePort(port: number | null | undefined): number {
-  return port ?? 22;
-}
-
-function routeIdentity(hostname: string | null | undefined, port: number | null | undefined): string | null {
-  const host = normalizeRouteHost(hostname);
-  if (!host) return null;
-  return `${host}:${normalizeRoutePort(port)}`;
-}
-
-function discoveredRouteSource(
-  machine: RemoteRuntimeDiscoveredMachine,
-  hostname: string,
-): RemoteRuntimeTargetRouteSource {
-  if (
-    (machine.runtimeKind ?? "").startsWith("tailscale-peer") ||
-    hostname === machine.tailscaleAddress ||
-    isTailscaleRoute(hostname)
-  ) {
-    return "tailscale";
-  }
-  return "bonjour";
-}
-
-function discoveredSshRoutes(
-  machine: RemoteRuntimeDiscoveredMachine,
-): RemoteRuntimeTargetRoute[] {
-  const hostnames = [
-    machine.tailscaleAddress,
-    machine.primaryRoute,
-    machine.hostName,
-    ...machine.addresses,
-  ];
-  const routes: RemoteRuntimeTargetRoute[] = [];
-  const seen = new Set<string>();
-  for (const value of hostnames) {
-    const hostname = value?.trim().replace(/\.$/, "");
-    if (!hostname) continue;
-    const key = hostname.toLowerCase();
-    if (seen.has(key)) continue;
-    seen.add(key);
-    routes.push({
-      hostname,
-      port: null,
-      source: discoveredRouteSource(machine, hostname),
-      lastSucceededAt: null,
-    });
-  }
-  return routes;
-}
-
-function discoveredTargetInput(
-  machine: RemoteRuntimeDiscoveredMachine,
-): RemoteRuntimeTargetInput | null {
-  const route = discoveredRoute(machine);
-  if (!route) return null;
-  return {
-    name: machine.machineName,
-    hostname: route.replace(/\.$/, ""),
-    sshUser: null,
-    port: null,
-    sshKeyPath: null,
-    routes: discoveredSshRoutes(machine),
-  };
-}
+const subTextStyle: CSSProperties = {
+  color: COLORS.textMuted,
+  fontFamily: MONO_FONT,
+  fontSize: 12,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
 
 function targetFormPrefill(
   target: RemoteRuntimeTarget,
@@ -238,110 +145,11 @@ function targetFormPrefill(
   };
 }
 
-function targetConnectionLabel(target: RemoteRuntimeTarget): string {
-  const userPrefix = target.sshUser ? `${target.sshUser}@` : "";
-  const portSuffix = target.port ? `:${target.port}` : "";
-  let defaultHint = "";
-  if (!target.sshUser && !target.port) {
-    defaultHint = " (SSH defaults)";
-  } else if (!target.sshUser) {
-    defaultHint = " (default SSH user)";
-  } else if (!target.port) {
-    defaultHint = " (default port)";
-  }
-  const targetHostKey = target.hostname.toLowerCase().replace(/\.$/, "");
-  const fallbackRoutes = (target.routes ?? []).filter(
-    (route) =>
-      route.hostname.toLowerCase().replace(/\.$/, "") !== targetHostKey ||
-      route.port !== target.port,
-  ).length;
-  const fallbackHint =
-    fallbackRoutes > 0
-      ? ` + ${fallbackRoutes} route${fallbackRoutes === 1 ? "" : "s"}`
-      : "";
-  return `${userPrefix}${target.hostname}${portSuffix}${defaultHint}${fallbackHint}`;
-}
-
-function targetRouteIdentities(target: RemoteRuntimeTarget): Set<string> {
-  const identities = new Set<string>();
-  const primary = routeIdentity(target.hostname, target.port);
-  if (primary) identities.add(primary);
-  for (const route of target.routes ?? []) {
-    const identity = routeIdentity(route.hostname, route.port ?? target.port);
-    if (identity) identities.add(identity);
-  }
-  return identities;
-}
-
-function discoveredMachineRouteIdentities(
-  machine: RemoteRuntimeDiscoveredMachine,
-): Set<string> {
-  const identities = new Set<string>();
-  for (const route of discoveredSshRoutes(machine)) {
-    const identity = routeIdentity(route.hostname, route.port);
-    if (identity) identities.add(identity);
-  }
-  return identities;
-}
-
-function discoveredMachineMatchesSavedTarget(
-  machine: RemoteRuntimeDiscoveredMachine,
-  targets: RemoteRuntimeTarget[],
-): boolean {
-  const discovered = discoveredMachineRouteIdentities(machine);
-  if (discovered.size === 0) return false;
-  return targets.some((target) => {
-    const saved = targetRouteIdentities(target);
-    for (const identity of discovered) {
-      if (saved.has(identity)) return true;
-    }
-    return false;
-  });
-}
-
-function connectionStateLabel(
-  connection: RemoteRuntimeConnectionStatus | null,
-  connected: RemoteRuntimeConnectResult | null,
-): string {
-  if (connection?.state === "connected" || (!connection && connected))
-    return "Connected";
-  if (connection?.state === "connecting") return "Connecting";
-  if (connection?.state === "error") return "Connection failed";
-  return "Not connected";
-}
-
-function formatRemoteTargetError(error: unknown): string {
-  const message = extractError(error)
-    .replace(/^Error invoking remote method '[^']+':\s*/i, "")
-    .replace(/^Error:\s*/i, "")
-    .trim();
-
-  if (/^(?:read\s+)?ECONNRESET$/i.test(message)) {
-    return "SSH server closed the connection before ADE could finish the SSH handshake. Check that Remote Login/sshd is enabled on the remote machine and try again.";
-  }
-
-  if (/permission denied|all configured authentication methods failed/i.test(message)) {
-    return "SSH authentication failed. Check the SSH user, key path, and that this key is allowed on the remote machine.";
-  }
-
-  if (/host denied|verification failed|host key verification/i.test(message)) {
-    return "SSH host-key verification failed. Check that this is the right machine, then update the saved SSH host key or trust the new key when ADE prompts.";
-  }
-
-  if (/timed out.*handshake|handshake.*timed out|connect.*timed out/i.test(message)) {
-    return "SSH did not finish connecting. Check that the machine is awake, reachable on Tailscale or LAN, and Remote Login is enabled.";
-  }
-
-  if (/ECONNREFUSED/i.test(message)) {
-    return "The machine refused the SSH connection. Check the port and make sure Remote Login/sshd is running.";
-  }
-
-  if (/ENOTFOUND|could not resolve hostname|name or service not known/i.test(message)) {
-    return "ADE could not resolve that host. Check the hostname, or use the Tailscale 100.x address from discovery.";
-  }
-
-  return message || "Remote connection failed.";
-}
+const SECTION_LABELS: Record<MachineSection, string> = {
+  connected: "CONNECTED",
+  available: "AVAILABLE",
+  unavailable: "UNAVAILABLE",
+};
 
 export function RemoteTargetList({
   onConnected,
@@ -369,42 +177,38 @@ export function RemoteTargetList({
   const [discoveryError, setDiscoveryError] = useState<string | null>(null);
   const [hostKeyTrust, setHostKeyTrust] =
     useState<RemoteRuntimeSshHostKeyTrustStatus | null>(null);
+  const [addMode, setAddMode] = useState<AddMode | null>(null);
+  const [shareOpen, setShareOpen] = useState(false);
+  const [testingId, setTestingId] = useState<string | null>(null);
+  const [localMachineName, setLocalMachineName] = useState("");
 
   const selectedTarget = useMemo(
     () => targets.find((target) => target.id === selectedId) ?? null,
     [selectedId, targets],
   );
-  const selectedConnection = useMemo(
-    () =>
-      connectionSnapshot?.connections.find(
-        (entry) => entry.target.id === selectedId,
-      ) ?? null,
-    [connectionSnapshot, selectedId],
-  );
-  const selectedConnectionError =
-    selectedConnection?.state === "error"
-      ? selectedConnection.lastErrorInfo?.message ??
-        (selectedConnection.lastError
-          ? formatRemoteTargetError(selectedConnection.lastError)
-          : null)
-      : null;
-  const selectedCompatibilityWarnings =
-    selectedConnection?.compatibilityWarnings ??
-    (connected?.target.id === selectedId ? connected.compatibilityWarnings : []) ??
-    [];
   const selectedHostKeyTrust =
     selectedTarget && hostKeyTrust?.targetId === selectedTarget.id
       ? hostKeyTrust
       : null;
-  const visibleDiscoveredMachines = useMemo(
+
+  const statusById = useMemo(() => {
+    const map = new Map<string, RemoteRuntimeConnectionStatus>();
+    for (const entry of connectionSnapshot?.connections ?? []) {
+      map.set(entry.target.id, entry);
+    }
+    return map;
+  }, [connectionSnapshot]);
+
+  const sections = useMemo(
     () =>
-      discoveredMachines.filter(
-        (machine) => !discoveredMachineMatchesSavedTarget(machine, targets),
-      ),
-    [discoveredMachines, targets],
+      assignMachineSections({
+        targets,
+        statusById,
+        connectedFallbackId: connected?.target.id ?? null,
+        discoveredMachines,
+      }),
+    [targets, statusById, connected, discoveredMachines],
   );
-  const manualAddOpen = formPrefill?.key === "manual:add";
-  const activeFormKey = formPrefill?.key ?? null;
 
   const loadTargets = useCallback(async () => {
     setLoading(true);
@@ -445,27 +249,24 @@ export function RemoteTargetList({
   }, []);
 
   useEffect(() => {
-    if (!selectedConnection) return;
-    if (selectedConnection.state !== "connected") {
+    const status = selectedId ? statusById.get(selectedId) ?? null : null;
+    if (!status) return;
+    if (status.state !== "connected") {
       setConnected((current) =>
-        current?.target.id === selectedConnection.target.id ? null : current,
+        current?.target.id === status.target.id ? null : current,
       );
       return;
     }
     setConnected({
-      target: selectedConnection.target,
-      arch:
-        selectedConnection.arch ??
-        selectedConnection.target.lastSeenArch ??
-        "unknown",
-      version:
-        selectedConnection.version ??
-        selectedConnection.target.runtimeBinaryVersion,
-      capabilities: selectedConnection.capabilities,
-      compatibilityWarnings: selectedConnection.compatibilityWarnings,
-      projects: selectedConnection.projects,
+      target: status.target,
+      arch: status.arch ?? status.target.lastSeenArch ?? "unknown",
+      version: status.version ?? status.target.runtimeBinaryVersion,
+      route: status.route,
+      capabilities: status.capabilities,
+      compatibilityWarnings: status.compatibilityWarnings,
+      projects: status.projects,
     });
-  }, [selectedConnection]);
+  }, [selectedId, statusById]);
 
   const loadDiscoveredMachines = useCallback(async () => {
     setLoadingDiscovered(true);
@@ -488,47 +289,38 @@ export function RemoteTargetList({
     void loadDiscoveredMachines();
   }, [loadDiscoveredMachines]);
 
-  const openManualAddForm = useCallback(() => {
-    setSelectedId(null);
-    setFormPrefill({
-      key: "manual:add",
-      targetId: null,
-      name: null,
-      hostname: "",
-      sshUser: null,
-      port: null,
-      sshKeyPath: null,
-      routes: null,
-    });
-    setError(null);
-    setHostKeyTrust(null);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const info = await window.ade.remoteRuntime.getLocalPairingInfo();
+        if (!cancelled && info.machineName) setLocalMachineName(info.machineName);
+      } catch {
+        // Pairing info is optional; the pair form still works with a typed name.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  const toggleDiscoveredForm = useCallback(
-    (machine: RemoteRuntimeDiscoveredMachine) => {
-      const key = `${machine.id}:${machine.lastSeenAt}`;
-      setSelectedId(null);
-      setError(null);
-      setHostKeyTrust(null);
-      setFormPrefill((current) =>
-        current?.key === key
-          ? null
-          : {
-              key,
-              targetId: null,
-              ...(discoveredTargetInput(machine) ?? {
-                name: machine.machineName,
-                hostname: "",
-                sshUser: null,
-                port: null,
-                sshKeyPath: null,
-                routes: discoveredSshRoutes(machine),
-              }),
-            },
-      );
-    },
-    [],
-  );
+  const openAddMachine = useCallback(() => {
+    setSelectedId(null);
+    setShareOpen(false);
+    setFormPrefill(null);
+    setError(null);
+    setHostKeyTrust(null);
+    setAddMode((current) => (current ? null : { tab: "pair" }));
+  }, []);
+
+  const toggleShare = useCallback(() => {
+    setShareOpen((open) => !open);
+    setAddMode(null);
+  }, []);
+
+  const toggleTest = useCallback((rowId: string) => {
+    setTestingId((current) => (current === rowId ? null : rowId));
+  }, []);
 
   const toggleEditForm = useCallback((target: RemoteRuntimeTarget) => {
     setSelectedId(target.id);
@@ -590,6 +382,7 @@ export function RemoteTargetList({
                       state: "connected" as const,
                       arch: result.arch,
                       version: result.version,
+                      route: result.route,
                       capabilities: result.capabilities,
                       compatibilityWarnings: result.compatibilityWarnings,
                       projects: result.projects,
@@ -606,6 +399,7 @@ export function RemoteTargetList({
                   state: "connected" as const,
                   arch: result.arch,
                   version: result.version,
+                  route: result.route,
                   capabilities: result.capabilities,
                   compatibilityWarnings: result.compatibilityWarnings,
                   projects: result.projects,
@@ -625,6 +419,7 @@ export function RemoteTargetList({
         setSelectedId(result.target.id);
         setHostKeyTrust(null);
         setError(null);
+        setTestingId(null);
         onConnected?.(result);
         return true;
       } catch (err) {
@@ -677,7 +472,10 @@ export function RemoteTargetList({
         setSelectedId(target.id);
         setError(null);
         const connectedOk = await connectTarget(target.id);
-        if (connectedOk) setFormPrefill(null);
+        if (connectedOk) {
+          setFormPrefill(null);
+          setAddMode(null);
+        }
       } catch (err) {
         setError(formatRemoteTargetError(err));
       } finally {
@@ -710,6 +508,15 @@ export function RemoteTargetList({
       }
     },
     [saveTargetAndConnect],
+  );
+
+  const onPaired = useCallback(
+    async (targetId: string) => {
+      await loadTargets();
+      const connectedOk = await connectTarget(targetId);
+      if (connectedOk) setAddMode(null);
+    },
+    [connectTarget, loadTargets],
   );
 
   const disconnectTarget = useCallback(async (targetId: string) => {
@@ -765,13 +572,14 @@ export function RemoteTargetList({
       try {
         await window.ade.remoteRuntime.removeTarget(targetId);
         setTargets((current) =>
-          current.filter((target) => target.id !== targetId),
+          current.filter((entry) => entry.id !== targetId),
         );
         if (selectedId === targetId) {
           setSelectedId(null);
           setConnected(null);
         }
         if (formPrefill?.targetId === targetId) setFormPrefill(null);
+        if (testingId === targetId) setTestingId(null);
         setError(null);
       } catch (err) {
         setError(formatRemoteTargetError(err));
@@ -779,15 +587,399 @@ export function RemoteTargetList({
         setBusyId(null);
       }
     },
-    [formPrefill?.targetId, onRemoveRequested, selectedId, targets],
+    [formPrefill?.targetId, onRemoveRequested, selectedId, targets, testingId],
   );
 
   const connectedCount =
     connectionSnapshot?.connectedCount ?? (connected ? 1 : 0);
 
+  const totalRows =
+    sections.connected.length +
+    sections.available.length +
+    sections.unavailable.length;
+
+  function renderSavedRow(
+    row: SavedMachineRow,
+    section: MachineSection,
+  ): ReactNode {
+    const { target, status } = row;
+    const targetSelected = selectedId === target.id;
+    const targetConnecting =
+      busyId === target.id || status?.state === "connecting";
+    const version =
+      status?.version ??
+      (connected?.target.id === target.id ? connected.version : null) ??
+      target.runtimeBinaryVersion ??
+      null;
+    const arch =
+      status?.arch ??
+      (connected?.target.id === target.id ? connected.arch : null) ??
+      target.lastSeenArch ??
+      null;
+    const route =
+      status?.route ??
+      (connected?.target.id === target.id ? connected.route : undefined);
+    const routeChip = row.connected ? formatRouteChip(route) : null;
+    const statusLabel = connectionStateLabel(
+      status ?? null,
+      connected?.target.id === target.id,
+    );
+    const warnings = targetSelected
+      ? status?.compatibilityWarnings ??
+        (connected?.target.id === target.id
+          ? connected.compatibilityWarnings
+          : []) ??
+        []
+      : status?.compatibilityWarnings ?? [];
+    const errorCard = selectMachineErrorCard({
+      errorInfo: status?.state === "error" ? status.lastErrorInfo : null,
+      rawError: status?.state === "error" ? status.lastError : null,
+      overrideMessage: targetSelected ? error : null,
+    });
+    const formOpen = formPrefill?.targetId === target.id;
+    const testOpen = testingId === target.id;
+
+    return (
+      <div key={target.id} style={{ display: "grid", gap: 8 }}>
+        <div
+          style={{
+            ...machineRowStyle,
+            opacity: section === "unavailable" ? 0.62 : 1,
+            borderColor: targetSelected ? COLORS.accent : COLORS.border,
+          }}
+        >
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "minmax(0,1fr) auto",
+              gap: 12,
+              alignItems: "start",
+            }}
+          >
+            <div style={{ minWidth: 0, display: "grid", gap: 5 }}>
+              <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+                <span style={nameStyle}>{target.name}</span>
+                {row.connected ? (
+                  <CheckCircle size={15} weight="fill" color={COLORS.success} />
+                ) : null}
+                {routeChip ? (
+                  <span
+                    style={{
+                      color: COLORS.textMuted,
+                      fontFamily: SANS_FONT,
+                      fontSize: 11,
+                      whiteSpace: "nowrap",
+                      flexShrink: 0,
+                    }}
+                  >
+                    {routeChip}
+                  </span>
+                ) : null}
+              </div>
+              <div style={subTextStyle}>{targetConnectionLabel(target)}</div>
+              <div style={helperTextStyle}>
+                {section === "unavailable" && row.unavailableReason ? (
+                  <span>{row.unavailableReason}</span>
+                ) : (
+                  <>
+                    <span>{statusLabel}</span>
+                    {version || arch ? (
+                      <span>{` · ADE ${version ?? "unknown"} on ${arch ?? "unknown"}`}</span>
+                    ) : null}
+                    <span>{` · ${formatLastSeen(target.lastConnectedAt)}`}</span>
+                  </>
+                )}
+              </div>
+            </div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
+              {row.connected ? (
+                <button
+                  type="button"
+                  disabled={busyId != null}
+                  onClick={() => void disconnectTarget(target.id)}
+                  style={outlineButton({ height: 30, padding: "0 10px", fontSize: 11 })}
+                >
+                  Disconnect
+                </button>
+              ) : section !== "unavailable" ? (
+                <>
+                  <button
+                    type="button"
+                    disabled={busyId != null}
+                    onClick={() => void connectTarget(target.id)}
+                    style={primaryButton({ height: 30, padding: "0 10px", fontSize: 11 })}
+                  >
+                    <PlugsConnected size={14} weight="bold" />
+                    {targetConnecting ? "Connecting…" : "Connect"}
+                  </button>
+                  <button
+                    type="button"
+                    aria-controls={`remote-target-test-${target.id}`}
+                    aria-expanded={testOpen}
+                    disabled={busyId != null}
+                    onClick={() => toggleTest(target.id)}
+                    style={outlineButton({ height: 30, padding: "0 10px", fontSize: 11 })}
+                  >
+                    Test
+                  </button>
+                </>
+              ) : null}
+              {section !== "unavailable" ? (
+                <button
+                  type="button"
+                  aria-controls={`remote-target-edit-${target.id}`}
+                  aria-expanded={formOpen}
+                  disabled={busyId != null}
+                  onClick={() => toggleEditForm(target)}
+                  style={outlineButton({ height: 30, padding: "0 10px", fontSize: 11 })}
+                >
+                  Edit
+                  {formOpen ? (
+                    <CaretUp size={12} weight="bold" />
+                  ) : (
+                    <CaretDown size={12} weight="bold" />
+                  )}
+                </button>
+              ) : null}
+              <button
+                type="button"
+                aria-label={`Remove ${target.name}`}
+                disabled={busyId != null}
+                onClick={() => void removeTarget(target.id)}
+                style={outlineButton({ height: 30, padding: "0 9px", fontSize: 11 })}
+              >
+                <Trash size={14} />
+              </button>
+            </div>
+          </div>
+
+          {errorCard ? (
+            <RemoteErrorCard
+              card={errorCard}
+              onRetry={
+                busyId == null ? () => void connectTarget(target.id) : undefined
+              }
+              retrying={busyId === target.id}
+            />
+          ) : null}
+
+          {warnings.length > 0 ? (
+            <div
+              style={{
+                display: "grid",
+                gap: 4,
+                color: COLORS.warning,
+                fontFamily: SANS_FONT,
+                fontSize: 12,
+              }}
+            >
+              {warnings.map((warning) => (
+                <div key={warning} style={{ display: "flex", gap: 6 }}>
+                  <Warning size={14} weight="fill" style={{ flexShrink: 0, marginTop: 1 }} />
+                  <span>{warning}</span>
+                </div>
+              ))}
+            </div>
+          ) : null}
+
+          {targetSelected && selectedHostKeyTrust ? (
+            <div
+              style={{
+                display: "grid",
+                gap: 10,
+                borderRadius: 8,
+                border: `1px solid ${
+                  selectedHostKeyTrust.state === "changed"
+                    ? COLORS.danger
+                    : COLORS.warning
+                }`,
+                background:
+                  selectedHostKeyTrust.state === "changed"
+                    ? `color-mix(in srgb, ${COLORS.danger} 10%, transparent)`
+                    : `color-mix(in srgb, ${COLORS.warning} 10%, transparent)`,
+                padding: "10px 12px",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  color:
+                    selectedHostKeyTrust.state === "changed"
+                      ? COLORS.danger
+                      : COLORS.warning,
+                  fontFamily: SANS_FONT,
+                  fontSize: 12,
+                  fontWeight: 700,
+                }}
+              >
+                <Warning size={15} weight="fill" />
+                {selectedHostKeyTrust.state === "changed"
+                  ? "Machine identity changed"
+                  : "Trust this machine"}
+              </div>
+              <div style={helperTextStyle}>
+                {selectedHostKeyTrust.state === "changed"
+                  ? `ADE found a different SSH identity for ${selectedHostKeyTrust.host}:${selectedHostKeyTrust.port}. Review ${selectedHostKeyTrust.knownHostsPath ?? "known_hosts"} before connecting.`
+                  : `ADE found a new SSH identity for ${selectedHostKeyTrust.host}:${selectedHostKeyTrust.port}. Trust it once to connect.`}
+              </div>
+              <div
+                style={{
+                  color: COLORS.textPrimary,
+                  fontFamily: MONO_FONT,
+                  fontSize: 11,
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {selectedHostKeyTrust.fingerprintSha256}
+              </div>
+              {selectedHostKeyTrust.state === "needs_trust" ? (
+                <div style={{ display: "flex", gap: 8 }}>
+                  <button
+                    type="button"
+                    disabled={trustingHostKey || busyId != null}
+                    onClick={() => void trustAndConnect()}
+                    style={{
+                      ...primaryButton({ height: 30, padding: "0 10px", fontSize: 11 }),
+                      opacity: trustingHostKey || busyId != null ? 0.65 : 1,
+                    }}
+                  >
+                    <CheckCircle size={15} weight="bold" />
+                    {trustingHostKey ? "Trusting…" : "Trust & connect"}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={trustingHostKey}
+                    onClick={() => setHostKeyTrust(null)}
+                    style={outlineButton({ height: 30, padding: "0 10px", fontSize: 11 })}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+
+        {testOpen ? (
+          <div id={`remote-target-test-${target.id}`}>
+            <ConnectionDoctorPanel machineId={target.id} />
+          </div>
+        ) : null}
+
+        {formOpen ? (
+          <div id={`remote-target-edit-${target.id}`} style={inlineDetailStyle}>
+            <div
+              style={{
+                color: COLORS.textPrimary,
+                fontFamily: SANS_FONT,
+                fontSize: 13,
+                fontWeight: 700,
+              }}
+            >
+              Edit {target.name}
+            </div>
+            <RemoteTargetForm
+              busy={saving || busyId != null}
+              prefill={formPrefill}
+              submitLabel="Save and connect"
+              onSubmit={saveAndConnect}
+            />
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  function renderDiscoveredRow(
+    machine: RemoteRuntimeDiscoveredMachine,
+    section: MachineSection,
+  ): ReactNode {
+    const route = discoveredRoute(machine);
+    const testOpen = testingId === machine.id;
+    const unavailable = section === "unavailable";
+    return (
+      <div key={machine.id} style={{ display: "grid", gap: 8 }}>
+        <div style={{ ...machineRowStyle, opacity: unavailable ? 0.62 : 1 }}>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "minmax(0,1fr) auto",
+              gap: 12,
+              alignItems: "center",
+            }}
+          >
+            <div style={{ minWidth: 0, display: "grid", gap: 5 }}>
+              <div style={nameStyle}>{machine.machineName}</div>
+              <div style={subTextStyle}>
+                {route ? `${route}:${machine.port}` : "No route advertised"}
+              </div>
+              <div style={helperTextStyle}>
+                {unavailable && machine.unsupportedReason
+                  ? machine.unsupportedReason
+                  : discoveredMachineSummary(machine)}
+              </div>
+            </div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
+              {!unavailable ? (
+                <>
+                  <button
+                    type="button"
+                    disabled={!route || busyId != null || saving}
+                    onClick={() => void connectDiscoveredMachine(machine)}
+                    style={{
+                      ...primaryButton({ height: 30, padding: "0 10px", fontSize: 11 }),
+                      opacity: route && busyId == null && !saving ? 1 : 0.55,
+                    }}
+                  >
+                    <PlugsConnected size={14} weight="bold" />
+                    {busyId === machine.id ? "Connecting…" : "Connect"}
+                  </button>
+                  <button
+                    type="button"
+                    aria-controls={`remote-discovered-test-${machine.id}`}
+                    aria-expanded={testOpen}
+                    disabled={busyId != null}
+                    onClick={() => toggleTest(machine.id)}
+                    style={outlineButton({ height: 30, padding: "0 10px", fontSize: 11 })}
+                  >
+                    Test
+                  </button>
+                </>
+              ) : null}
+            </div>
+          </div>
+        </div>
+        {testOpen ? (
+          <div id={`remote-discovered-test-${machine.id}`}>
+            <ConnectionDoctorPanel machineId={machine.id} />
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  function renderSection(section: MachineSection): ReactNode {
+    const rows = sections[section];
+    if (rows.length === 0) return null;
+    return (
+      <div style={{ display: "grid", gap: 8 }}>
+        <div style={sectionHeaderStyle}>{SECTION_LABELS[section]}</div>
+        {rows.map((row) =>
+          row.kind === "saved"
+            ? renderSavedRow(row, section)
+            : renderDiscoveredRow(row.machine, section),
+        )}
+      </div>
+    );
+  }
+
+  const activeTab = addMode?.tab ?? "pair";
+
   return (
     <div style={panelStyle}>
-      <div style={sectionStyle}>
+      <div style={{ display: "grid", gap: 12 }}>
         <div
           style={{
             display: "flex",
@@ -811,21 +1003,24 @@ export function RemoteTargetList({
               <DesktopTower size={18} weight="duotone" color={COLORS.accent} />
               Machines
             </div>
-            <div style={helperTextStyle}>
-              {connectedCount} connected
-            </div>
+            <div style={helperTextStyle}>{connectedCount} connected</div>
           </div>
           <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
+            <button
+              type="button"
+              onClick={toggleShare}
+              aria-expanded={shareOpen}
+              style={outlineButton({ height: 30, padding: "0 10px", fontSize: 11 })}
+            >
+              <ShareNetwork size={14} weight="bold" />
+              Share
+            </button>
             <button
               type="button"
               disabled={loadingDiscovered}
               onClick={() => void loadDiscoveredMachines()}
               style={{
-                ...outlineButton({
-                  height: 30,
-                  padding: "0 10px",
-                  fontSize: 11,
-                }),
+                ...outlineButton({ height: 30, padding: "0 10px", fontSize: 11 }),
                 opacity: loadingDiscovered ? 0.6 : 1,
               }}
             >
@@ -833,36 +1028,62 @@ export function RemoteTargetList({
             </button>
             <button
               type="button"
-              onClick={openManualAddForm}
-              style={primaryButton({
-                height: 30,
-                padding: "0 12px",
-                fontSize: 11,
-              })}
+              onClick={openAddMachine}
+              aria-expanded={addMode != null}
+              style={primaryButton({ height: 30, padding: "0 12px", fontSize: 11 })}
             >
               Add machine
             </button>
           </div>
         </div>
 
-        {manualAddOpen ? (
+        {shareOpen ? <ShareMachineCard /> : null}
+
+        {addMode ? (
           <div style={inlineDetailStyle}>
-            <div
-              style={{
-                color: COLORS.textPrimary,
-                fontFamily: SANS_FONT,
-                fontSize: 13,
-                fontWeight: 700,
-              }}
-            >
-              Add machine
+            <div style={{ display: "flex", gap: 4 }} role="tablist" aria-label="Add machine">
+              {(["pair", "ssh"] as const).map((tab) => {
+                const active = activeTab === tab;
+                return (
+                  <button
+                    key={tab}
+                    type="button"
+                    role="tab"
+                    aria-selected={active}
+                    onClick={() => setAddMode({ tab })}
+                    style={{
+                      height: 30,
+                      padding: "0 12px",
+                      borderRadius: 7,
+                      border: "none",
+                      cursor: "pointer",
+                      fontFamily: SANS_FONT,
+                      fontSize: 12,
+                      fontWeight: 600,
+                      color: active ? COLORS.textPrimary : COLORS.textMuted,
+                      background: active
+                        ? "color-mix(in srgb, var(--color-fg) 10%, transparent)"
+                        : "transparent",
+                    }}
+                  >
+                    {tab === "pair" ? "Pair" : "SSH"}
+                  </button>
+                );
+              })}
             </div>
-            <RemoteTargetForm
-              busy={saving || busyId != null}
-              prefill={formPrefill}
-              submitLabel="Connect"
-              onSubmit={saveAndConnect}
-            />
+            {activeTab === "pair" ? (
+              <PairMachineForm
+                defaultDeviceName={localMachineName}
+                busy={saving || busyId != null}
+                onPaired={onPaired}
+              />
+            ) : (
+              <RemoteTargetForm
+                busy={saving || busyId != null}
+                submitLabel="Connect"
+                onSubmit={saveAndConnect}
+              />
+            )}
           </div>
         ) : null}
 
@@ -884,445 +1105,15 @@ export function RemoteTargetList({
 
         {loading ? (
           <div style={{ color: COLORS.textMuted, fontFamily: MONO_FONT, fontSize: 12 }}>
-            Loading machines...
+            Loading machines…
           </div>
         ) : null}
 
-        <div style={{ display: "grid", gap: 8 }}>
-          {targets.map((target) => {
-            const targetStatus =
-              connectionSnapshot?.connections.find(
-                (entry) => entry.target.id === target.id,
-              ) ?? null;
-            const targetConnected = targetStatus
-              ? targetStatus.state === "connected"
-              : connected?.target.id === target.id;
-            const targetConnecting =
-              busyId === target.id || targetStatus?.state === "connecting";
-            const targetSelected = selectedId === target.id;
-            const targetError = targetSelected
-              ? (error ?? selectedConnectionError)
-              : targetStatus?.lastErrorInfo?.message ??
-                (targetStatus?.lastError
-                  ? formatRemoteTargetError(targetStatus.lastError)
-                  : null);
-            const targetWarnings = targetSelected
-              ? selectedCompatibilityWarnings
-              : targetStatus?.compatibilityWarnings ?? [];
-            const version =
-              targetStatus?.version ??
-              (connected?.target.id === target.id ? connected.version : null) ??
-              target.runtimeBinaryVersion ??
-              null;
-            const arch =
-              targetStatus?.arch ??
-              (connected?.target.id === target.id ? connected.arch : null) ??
-              target.lastSeenArch ??
-              null;
-            const statusLabel = connectionStateLabel(
-              targetStatus,
-              connected?.target.id === target.id ? connected : null,
-            );
-            const formOpen = formPrefill?.targetId === target.id;
+        {renderSection("connected")}
+        {renderSection("available")}
+        {renderSection("unavailable")}
 
-            return (
-              <div key={target.id} style={{ display: "grid", gap: 8 }}>
-                <div
-                  style={{
-                    ...machineRowStyle,
-                    borderColor: targetSelected ? COLORS.accent : COLORS.border,
-                  }}
-                >
-                  <div
-                    style={{
-                      display: "grid",
-                      gridTemplateColumns: "minmax(0,1fr) auto",
-                      gap: 12,
-                      alignItems: "start",
-                    }}
-                  >
-                    <div style={{ minWidth: 0, display: "grid", gap: 5 }}>
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 8,
-                          minWidth: 0,
-                        }}
-                      >
-                        <span
-                          style={{
-                            color: COLORS.textPrimary,
-                            fontFamily: MONO_FONT,
-                            fontSize: 13,
-                            fontWeight: 700,
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                          }}
-                        >
-                          {target.name}
-                        </span>
-                        {targetConnected ? (
-                          <CheckCircle
-                            size={15}
-                            weight="fill"
-                            color={COLORS.success}
-                          />
-                        ) : null}
-                      </div>
-                      <div
-                        style={{
-                          color: COLORS.textMuted,
-                          fontFamily: MONO_FONT,
-                          fontSize: 12,
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {targetConnectionLabel(target)}
-                      </div>
-                      <div style={helperTextStyle}>
-                        <span>{statusLabel}</span>
-                        {version || arch ? (
-                          <span>{` · ADE ${version ?? "unknown"} on ${arch ?? "unknown"}`}</span>
-                        ) : null}
-                        <span>{` · ${formatLastSeen(target.lastConnectedAt)}`}</span>
-                      </div>
-                    </div>
-                    <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
-                      {targetConnected ? (
-                        <button
-                          type="button"
-                          disabled={busyId != null}
-                          onClick={() => void disconnectTarget(target.id)}
-                          style={outlineButton({
-                            height: 30,
-                            padding: "0 10px",
-                            fontSize: 11,
-                          })}
-                        >
-                          Disconnect
-                        </button>
-                      ) : (
-                        <button
-                          type="button"
-                          disabled={busyId != null}
-                          onClick={() => void connectTarget(target.id)}
-                          style={primaryButton({
-                            height: 30,
-                            padding: "0 10px",
-                            fontSize: 11,
-                          })}
-                        >
-                          <PlugsConnected size={14} weight="bold" />
-                          {targetConnecting ? "Connecting..." : "Connect"}
-                        </button>
-                      )}
-                      <button
-                        type="button"
-                        aria-controls={`remote-target-edit-${target.id}`}
-                        aria-expanded={formOpen}
-                        disabled={busyId != null}
-                        onClick={() => toggleEditForm(target)}
-                        style={outlineButton({
-                          height: 30,
-                          padding: "0 10px",
-                          fontSize: 11,
-                        })}
-                      >
-                        Edit
-                        {formOpen ? (
-                          <CaretUp size={12} weight="bold" />
-                        ) : (
-                          <CaretDown size={12} weight="bold" />
-                        )}
-                      </button>
-                      <button
-                        type="button"
-                        aria-label={`Remove ${target.name}`}
-                        disabled={busyId != null}
-                        onClick={() => void removeTarget(target.id)}
-                        style={outlineButton({
-                          height: 30,
-                          padding: "0 9px",
-                          fontSize: 11,
-                        })}
-                      >
-                        <Trash size={14} />
-                      </button>
-                    </div>
-                  </div>
-
-                  {targetError ? (
-                    <div
-                      style={{
-                        display: "flex",
-                        alignItems: "flex-start",
-                        gap: 8,
-                        color: COLORS.danger,
-                        fontFamily: SANS_FONT,
-                        fontSize: 12,
-                      }}
-                    >
-                      <Warning size={15} weight="fill" style={{ flexShrink: 0, marginTop: 1 }} />
-                      <span>{targetError}</span>
-                    </div>
-                  ) : null}
-
-                  {targetWarnings.length > 0 ? (
-                    <div
-                      style={{
-                        display: "grid",
-                        gap: 4,
-                        color: COLORS.warning,
-                        fontFamily: SANS_FONT,
-                        fontSize: 12,
-                      }}
-                    >
-                      {targetWarnings.map((warning) => (
-                        <div key={warning} style={{ display: "flex", gap: 6 }}>
-                          <Warning size={14} weight="fill" style={{ flexShrink: 0, marginTop: 1 }} />
-                          <span>{warning}</span>
-                        </div>
-                      ))}
-                    </div>
-                  ) : null}
-
-                  {targetSelected && selectedHostKeyTrust ? (
-                    <div
-                      style={{
-                        display: "grid",
-                        gap: 10,
-                        borderRadius: 8,
-                        border: `1px solid ${
-                          selectedHostKeyTrust.state === "changed"
-                            ? COLORS.danger
-                            : COLORS.warning
-                        }`,
-                        background:
-                          selectedHostKeyTrust.state === "changed"
-                            ? `color-mix(in srgb, ${COLORS.danger} 10%, transparent)`
-                            : `color-mix(in srgb, ${COLORS.warning} 10%, transparent)`,
-                        padding: "10px 12px",
-                      }}
-                    >
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 8,
-                          color:
-                            selectedHostKeyTrust.state === "changed"
-                              ? COLORS.danger
-                              : COLORS.warning,
-                          fontFamily: SANS_FONT,
-                          fontSize: 12,
-                          fontWeight: 700,
-                        }}
-                      >
-                        <Warning size={15} weight="fill" />
-                        {selectedHostKeyTrust.state === "changed"
-                          ? "Machine identity changed"
-                          : "Trust this machine"}
-                      </div>
-                      <div style={helperTextStyle}>
-                        {selectedHostKeyTrust.state === "changed"
-                          ? `ADE found a different SSH identity for ${selectedHostKeyTrust.host}:${selectedHostKeyTrust.port}. Review ${selectedHostKeyTrust.knownHostsPath ?? "known_hosts"} before connecting.`
-                          : `ADE found a new SSH identity for ${selectedHostKeyTrust.host}:${selectedHostKeyTrust.port}. Trust it once to connect.`}
-                      </div>
-                      <div
-                        style={{
-                          color: COLORS.textPrimary,
-                          fontFamily: MONO_FONT,
-                          fontSize: 11,
-                          overflowWrap: "anywhere",
-                        }}
-                      >
-                        {selectedHostKeyTrust.fingerprintSha256}
-                      </div>
-                      {selectedHostKeyTrust.state === "needs_trust" ? (
-                        <div style={{ display: "flex", gap: 8 }}>
-                          <button
-                            type="button"
-                            disabled={trustingHostKey || busyId != null}
-                            onClick={() => void trustAndConnect()}
-                            style={{
-                              ...primaryButton({
-                                height: 30,
-                                padding: "0 10px",
-                                fontSize: 11,
-                              }),
-                              opacity: trustingHostKey || busyId != null ? 0.65 : 1,
-                            }}
-                          >
-                            <CheckCircle size={15} weight="bold" />
-                            {trustingHostKey ? "Trusting..." : "Trust & connect"}
-                          </button>
-                          <button
-                            type="button"
-                            disabled={trustingHostKey}
-                            onClick={() => setHostKeyTrust(null)}
-                            style={outlineButton({
-                              height: 30,
-                              padding: "0 10px",
-                              fontSize: 11,
-                            })}
-                          >
-                            Cancel
-                          </button>
-                        </div>
-                      ) : null}
-                    </div>
-                  ) : null}
-                </div>
-
-                {formOpen ? (
-                  <div
-                    id={`remote-target-edit-${target.id}`}
-                    style={inlineDetailStyle}
-                  >
-                    <div
-                      style={{
-                        color: COLORS.textPrimary,
-                        fontFamily: SANS_FONT,
-                        fontSize: 13,
-                        fontWeight: 700,
-                      }}
-                    >
-                      Edit {target.name}
-                    </div>
-                    <RemoteTargetForm
-                      busy={saving || busyId != null}
-                      prefill={formPrefill}
-                      submitLabel="Save and connect"
-                      onSubmit={saveAndConnect}
-                    />
-                  </div>
-                ) : null}
-              </div>
-            );
-          })}
-
-          {visibleDiscoveredMachines.map((machine) => {
-            const route = discoveredRoute(machine);
-            const formOpen = activeFormKey === `${machine.id}:${machine.lastSeenAt}`;
-            return (
-              <div key={machine.id} style={{ display: "grid", gap: 8 }}>
-                <div style={machineRowStyle}>
-                  <div
-                    style={{
-                      display: "grid",
-                      gridTemplateColumns: "minmax(0,1fr) auto",
-                      gap: 12,
-                      alignItems: "center",
-                    }}
-                  >
-                    <div style={{ minWidth: 0, display: "grid", gap: 5 }}>
-                      <div
-                        style={{
-                          color: COLORS.textPrimary,
-                          fontFamily: MONO_FONT,
-                          fontSize: 13,
-                          fontWeight: 700,
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {machine.machineName}
-                      </div>
-                      <div
-                        style={{
-                          color: COLORS.textMuted,
-                          fontFamily: MONO_FONT,
-                          fontSize: 12,
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {route ? `${route}:${machine.port}` : "No route advertised"}
-                      </div>
-                      <div style={helperTextStyle}>
-                        Detected · {discoveredRuntimeLabel(machine)} ·{" "}
-                        {discoveredProjectLabel(machine)}
-                        {machine.connectable === false && machine.unsupportedReason
-                          ? ` · ${machine.unsupportedReason}`
-                          : ""}
-                      </div>
-                    </div>
-                    <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
-                      {machine.connectable !== false ? (
-                        <button
-                          type="button"
-                          disabled={!route || busyId != null || saving}
-                          onClick={() => void connectDiscoveredMachine(machine)}
-                          style={{
-                            ...primaryButton({
-                              height: 30,
-                              padding: "0 10px",
-                              fontSize: 11,
-                            }),
-                            opacity: route && busyId == null && !saving ? 1 : 0.55,
-                          }}
-                        >
-                          <PlugsConnected size={14} weight="bold" />
-                          {busyId === machine.id ? "Connecting..." : "Connect"}
-                        </button>
-                      ) : null}
-                      <button
-                        type="button"
-                        aria-controls={`remote-discovered-edit-${machine.id}`}
-                        aria-expanded={formOpen}
-                        disabled={busyId != null}
-                        onClick={() => toggleDiscoveredForm(machine)}
-                        style={outlineButton({
-                          height: 30,
-                          padding: "0 10px",
-                          fontSize: 11,
-                        })}
-                      >
-                        Edit
-                        {formOpen ? (
-                          <CaretUp size={12} weight="bold" />
-                        ) : (
-                          <CaretDown size={12} weight="bold" />
-                        )}
-                      </button>
-                    </div>
-                  </div>
-                </div>
-                {formOpen ? (
-                  <div
-                    id={`remote-discovered-edit-${machine.id}`}
-                    style={inlineDetailStyle}
-                  >
-                    <div
-                      style={{
-                        color: COLORS.textPrimary,
-                        fontFamily: SANS_FONT,
-                        fontSize: 13,
-                        fontWeight: 700,
-                      }}
-                    >
-                      Edit {machine.machineName}
-                    </div>
-                    <RemoteTargetForm
-                      busy={saving || busyId != null}
-                      prefill={formPrefill}
-                      submitLabel="Save and connect"
-                      onSubmit={saveAndConnect}
-                    />
-                  </div>
-                ) : null}
-              </div>
-            );
-          })}
-        </div>
-
-        {!loading && targets.length === 0 && !manualAddOpen && !loadingDiscovered && visibleDiscoveredMachines.length === 0 ? (
+        {!loading && totalRows === 0 && !addMode && !loadingDiscovered ? (
           <div style={helperTextStyle}>
             {discoveredMachines.length > 0
               ? "Nearby machines are already saved."
@@ -1331,10 +1122,13 @@ export function RemoteTargetList({
         ) : null}
         {loadingDiscovered ? (
           <div style={{ color: COLORS.textMuted, fontFamily: MONO_FONT, fontSize: 12 }}>
-            Scanning nearby machines...
+            Scanning nearby machines…
           </div>
         ) : null}
-        {!loadingDiscovered && targets.length > 0 && visibleDiscoveredMachines.length === 0 && discoveredMachines.length > 0 ? (
+        {!loadingDiscovered &&
+        targets.length > 0 &&
+        totalRows === targets.length &&
+        discoveredMachines.length > 0 ? (
           <div style={helperTextStyle}>Nearby machines are already saved.</div>
         ) : null}
       </div>

--- a/apps/desktop/src/renderer/components/remoteTargets/SavedMachineRow.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/SavedMachineRow.tsx
@@ -1,0 +1,341 @@
+import {
+  CaretDown,
+  CaretUp,
+  CheckCircle,
+  PlugsConnected,
+  Trash,
+  Warning,
+} from "@phosphor-icons/react";
+import type {
+  RemoteRuntimeConnectResult,
+  RemoteRuntimeSshHostKeyTrustStatus,
+  RemoteRuntimeTarget,
+  RemoteRuntimeTargetInput,
+} from "../../../shared/types";
+import {
+  COLORS,
+  SANS_FONT,
+  outlineButton,
+  primaryButton,
+} from "../lanes/laneDesignTokens";
+import { ConnectionDoctorPanel } from "./ConnectionDoctorPanel";
+import { HostKeyTrustCard } from "./HostKeyTrustCard";
+import {
+  connectionStateLabel,
+  formatLastSeen,
+  formatRouteChip,
+  selectMachineErrorCard,
+  targetConnectionLabel,
+  type MachineSection,
+  type SavedMachineRow as SavedMachineRowModel,
+} from "./remoteMachineModel";
+import { RemoteErrorCard } from "./RemoteErrorCard";
+import {
+  RemoteTargetForm,
+  type RemoteTargetFormPrefill,
+} from "./RemoteTargetForm";
+import {
+  helperTextStyle,
+  inlineDetailStyle,
+  machineRowStyle,
+  nameStyle,
+  subTextStyle,
+} from "./remoteTargetListStyles";
+
+type SavedMachineRowProps = {
+  row: SavedMachineRowModel;
+  section: MachineSection;
+  selected: boolean;
+  connected: RemoteRuntimeConnectResult | null;
+  busyId: string | null;
+  saving: boolean;
+  formPrefill: RemoteTargetFormPrefill | null;
+  testOpen: boolean;
+  error: string | null;
+  hostKeyTrust: RemoteRuntimeSshHostKeyTrustStatus | null;
+  trustingHostKey: boolean;
+  onConnect: (targetId: string) => void;
+  onDisconnect: (targetId: string) => void;
+  onToggleTest: (targetId: string) => void;
+  onToggleEdit: (target: RemoteRuntimeTarget) => void;
+  onRemove: (targetId: string) => void;
+  onSaveAndConnect: (input: RemoteRuntimeTargetInput) => void | Promise<void>;
+  onTrustAndConnect: () => void;
+  onCancelHostKeyTrust: () => void;
+};
+
+export function SavedMachineRow({
+  row,
+  section,
+  selected,
+  connected,
+  busyId,
+  saving,
+  formPrefill,
+  testOpen,
+  error,
+  hostKeyTrust,
+  trustingHostKey,
+  onConnect,
+  onDisconnect,
+  onToggleTest,
+  onToggleEdit,
+  onRemove,
+  onSaveAndConnect,
+  onTrustAndConnect,
+  onCancelHostKeyTrust,
+}: SavedMachineRowProps) {
+  const { target, status } = row;
+  const targetConnecting =
+    busyId === target.id || status?.state === "connecting";
+  const version =
+    status?.version ??
+    (connected?.target.id === target.id ? connected.version : null) ??
+    target.runtimeBinaryVersion ??
+    null;
+  const arch =
+    status?.arch ??
+    (connected?.target.id === target.id ? connected.arch : null) ??
+    target.lastSeenArch ??
+    null;
+  const route =
+    status?.route ??
+    (connected?.target.id === target.id ? connected.route : undefined);
+  const routeChip = row.connected ? formatRouteChip(route) : null;
+  const statusLabel = connectionStateLabel(
+    status ?? null,
+    connected?.target.id === target.id,
+  );
+  const warnings = selected
+    ? (status?.compatibilityWarnings ??
+      (connected?.target.id === target.id
+        ? connected.compatibilityWarnings
+        : []) ??
+      [])
+    : (status?.compatibilityWarnings ?? []);
+  const errorCard = selectMachineErrorCard({
+    errorInfo: status?.state === "error" ? status.lastErrorInfo : null,
+    rawError: status?.state === "error" ? status.lastError : null,
+    overrideMessage: selected ? error : null,
+  });
+  const formOpen = formPrefill?.targetId === target.id;
+
+  return (
+    <div style={{ display: "grid", gap: 8 }}>
+      <div
+        style={{
+          ...machineRowStyle,
+          opacity: section === "unavailable" ? 0.62 : 1,
+          borderColor: selected ? COLORS.accent : COLORS.border,
+        }}
+      >
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "minmax(0,1fr) auto",
+            gap: 12,
+            alignItems: "start",
+          }}
+        >
+          <div style={{ minWidth: 0, display: "grid", gap: 5 }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                minWidth: 0,
+              }}
+            >
+              <span style={nameStyle}>{target.name}</span>
+              {row.connected ? (
+                <CheckCircle size={15} weight="fill" color={COLORS.success} />
+              ) : null}
+              {routeChip ? (
+                <span
+                  style={{
+                    color: COLORS.textMuted,
+                    fontFamily: SANS_FONT,
+                    fontSize: 11,
+                    whiteSpace: "nowrap",
+                    flexShrink: 0,
+                  }}
+                >
+                  {routeChip}
+                </span>
+              ) : null}
+            </div>
+            <div style={subTextStyle}>{targetConnectionLabel(target)}</div>
+            <div style={helperTextStyle}>
+              {section === "unavailable" && row.unavailableReason ? (
+                <span>{row.unavailableReason}</span>
+              ) : (
+                <>
+                  <span>{statusLabel}</span>
+                  {version || arch ? (
+                    <span>{` · ADE ${version ?? "unknown"} on ${arch ?? "unknown"}`}</span>
+                  ) : null}
+                  <span>{` · ${formatLastSeen(target.lastConnectedAt)}`}</span>
+                </>
+              )}
+            </div>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              flexWrap: "wrap",
+              justifyContent: "flex-end",
+            }}
+          >
+            {row.connected ? (
+              <button
+                type="button"
+                disabled={busyId != null}
+                onClick={() => onDisconnect(target.id)}
+                style={outlineButton({
+                  height: 30,
+                  padding: "0 10px",
+                  fontSize: 11,
+                })}
+              >
+                Disconnect
+              </button>
+            ) : section !== "unavailable" ? (
+              <>
+                <button
+                  type="button"
+                  disabled={busyId != null}
+                  onClick={() => onConnect(target.id)}
+                  style={primaryButton({
+                    height: 30,
+                    padding: "0 10px",
+                    fontSize: 11,
+                  })}
+                >
+                  <PlugsConnected size={14} weight="bold" />
+                  {targetConnecting ? "Connecting…" : "Connect"}
+                </button>
+                <button
+                  type="button"
+                  aria-controls={`remote-target-test-${target.id}`}
+                  aria-expanded={testOpen}
+                  disabled={busyId != null}
+                  onClick={() => onToggleTest(target.id)}
+                  style={outlineButton({
+                    height: 30,
+                    padding: "0 10px",
+                    fontSize: 11,
+                  })}
+                >
+                  Test
+                </button>
+              </>
+            ) : null}
+            {section !== "unavailable" ? (
+              <button
+                type="button"
+                aria-controls={`remote-target-edit-${target.id}`}
+                aria-expanded={formOpen}
+                disabled={busyId != null}
+                onClick={() => onToggleEdit(target)}
+                style={outlineButton({
+                  height: 30,
+                  padding: "0 10px",
+                  fontSize: 11,
+                })}
+              >
+                Edit
+                {formOpen ? (
+                  <CaretUp size={12} weight="bold" />
+                ) : (
+                  <CaretDown size={12} weight="bold" />
+                )}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              aria-label={`Remove ${target.name}`}
+              disabled={busyId != null}
+              onClick={() => onRemove(target.id)}
+              style={outlineButton({
+                height: 30,
+                padding: "0 9px",
+                fontSize: 11,
+              })}
+            >
+              <Trash size={14} />
+            </button>
+          </div>
+        </div>
+
+        {errorCard ? (
+          <RemoteErrorCard
+            card={errorCard}
+            onRetry={busyId == null ? () => onConnect(target.id) : undefined}
+            retrying={busyId === target.id}
+          />
+        ) : null}
+
+        {warnings.length > 0 ? (
+          <div
+            style={{
+              display: "grid",
+              gap: 4,
+              color: COLORS.warning,
+              fontFamily: SANS_FONT,
+              fontSize: 12,
+            }}
+          >
+            {warnings.map((warning) => (
+              <div key={warning} style={{ display: "flex", gap: 6 }}>
+                <Warning
+                  size={14}
+                  weight="fill"
+                  style={{ flexShrink: 0, marginTop: 1 }}
+                />
+                <span>{warning}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        {selected && hostKeyTrust ? (
+          <HostKeyTrustCard
+            trust={hostKeyTrust}
+            trusting={trustingHostKey}
+            busy={busyId != null}
+            onTrustAndConnect={onTrustAndConnect}
+            onCancel={onCancelHostKeyTrust}
+          />
+        ) : null}
+      </div>
+
+      {testOpen ? (
+        <div id={`remote-target-test-${target.id}`}>
+          <ConnectionDoctorPanel machineId={target.id} />
+        </div>
+      ) : null}
+
+      {formOpen ? (
+        <div id={`remote-target-edit-${target.id}`} style={inlineDetailStyle}>
+          <div
+            style={{
+              color: COLORS.textPrimary,
+              fontFamily: SANS_FONT,
+              fontSize: 13,
+              fontWeight: 700,
+            }}
+          >
+            Edit {target.name}
+          </div>
+          <RemoteTargetForm
+            busy={saving || busyId != null}
+            prefill={formPrefill}
+            submitLabel="Save and connect"
+            onSubmit={onSaveAndConnect}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/remoteTargets/ShareMachineCard.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/ShareMachineCard.tsx
@@ -78,7 +78,9 @@ export function ShareMachineCard() {
 
   const copy = useCallback(async (value: string, which: "pin" | "link") => {
     try {
-      await window.ade?.app?.writeClipboardText?.(value);
+      const writeClipboardText = window.ade?.app?.writeClipboardText;
+      if (!writeClipboardText) return;
+      await writeClipboardText(value);
       setCopied(which);
       window.setTimeout(() => setCopied((c) => (c === which ? null : c)), 1500);
     } catch {

--- a/apps/desktop/src/renderer/components/remoteTargets/ShareMachineCard.tsx
+++ b/apps/desktop/src/renderer/components/remoteTargets/ShareMachineCard.tsx
@@ -1,0 +1,186 @@
+import { useCallback, useEffect, useState, type CSSProperties } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import { COLORS, MONO_FONT, SANS_FONT, outlineButton } from "../lanes/laneDesignTokens";
+import { publicAssetUrl } from "../onboarding/WelcomeVideoGate";
+import { openExternalUrl } from "../../lib/openExternal";
+import { extractError } from "../../lib/format";
+import type { RemoteRuntimeLocalPairingInfo } from "../../../shared/types";
+
+const labelStyle: CSSProperties = {
+  color: COLORS.textMuted,
+  fontFamily: SANS_FONT,
+  fontSize: 11,
+  fontWeight: 500,
+};
+
+// ADE-branded QR treatment mirrored from the Sync pairing panel: white tile,
+// accent-tinted border, excavated ADE mark (hence error-correction level H).
+function ShareQrBox({ value }: { value: string }) {
+  return (
+    <div
+      style={{
+        display: "inline-flex",
+        padding: 12,
+        borderRadius: 12,
+        background: "#FFFFFF",
+        border: "1px solid color-mix(in srgb, var(--color-accent, #A78BFA) 30%, transparent)",
+      }}
+    >
+      <QRCodeSVG
+        value={value}
+        size={128}
+        level="H"
+        marginSize={1}
+        bgColor="#FFFFFF"
+        fgColor="#111827"
+        title="Pairing QR code"
+        imageSettings={{
+          src: publicAssetUrl("welcome/ade-icon.webp"),
+          height: 28,
+          width: 28,
+          excavate: true,
+        }}
+      />
+    </div>
+  );
+}
+
+/**
+ * "Share this machine" surface: shows this Mac's pairing code, a copyable link,
+ * a scannable QR, and a plain reachability line. When no PIN is set, other
+ * machines cannot pair, so it points the user at Settings → Sync instead of
+ * showing a code that will not work.
+ */
+export function ShareMachineCard() {
+  const [info, setInfo] = useState<RemoteRuntimeLocalPairingInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [copied, setCopied] = useState<"pin" | "link" | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void (async () => {
+      try {
+        const result = await window.ade.remoteRuntime.getLocalPairingInfo();
+        if (!cancelled) setInfo(result);
+      } catch (err) {
+        if (!cancelled) setError(extractError(err));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const copy = useCallback(async (value: string, which: "pin" | "link") => {
+    try {
+      await window.ade?.app?.writeClipboardText?.(value);
+      setCopied(which);
+      window.setTimeout(() => setCopied((c) => (c === which ? null : c)), 1500);
+    } catch {
+      // Clipboard may be unavailable; the value stays visible to copy manually.
+    }
+  }, []);
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 14,
+        padding: 14,
+        borderRadius: 10,
+        border: `1px solid ${COLORS.border}`,
+        background: "rgba(0,0,0,0.16)",
+      }}
+    >
+      <div
+        style={{
+          color: COLORS.textPrimary,
+          fontFamily: SANS_FONT,
+          fontSize: 13,
+          fontWeight: 600,
+        }}
+      >
+        Share this machine
+      </div>
+
+      {loading ? (
+        <div style={labelStyle}>Loading pairing info…</div>
+      ) : error ? (
+        <div style={{ color: COLORS.danger, fontFamily: SANS_FONT, fontSize: 12 }}>
+          {error}
+        </div>
+      ) : info ? (
+        info.pin ? (
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "auto minmax(0,1fr)",
+              gap: 16,
+              alignItems: "start",
+            }}
+          >
+            <ShareQrBox value={info.url} />
+            <div style={{ display: "grid", gap: 12, minWidth: 0 }}>
+              <div style={{ display: "grid", gap: 4 }}>
+                <span style={labelStyle}>Pairing code</span>
+                <div
+                  style={{
+                    color: COLORS.textPrimary,
+                    fontFamily: MONO_FONT,
+                    fontSize: 18,
+                    letterSpacing: "0.28em",
+                    fontVariantNumeric: "tabular-nums",
+                  }}
+                >
+                  {info.pin}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => void copy(info.pin as string, "pin")}
+                  style={outlineButton({ height: 28, padding: "0 10px", fontSize: 11, justifySelf: "start" })}
+                >
+                  {copied === "pin" ? "Copied" : "Copy code"}
+                </button>
+              </div>
+              <div style={{ display: "grid", gap: 4, minWidth: 0 }}>
+                <span style={labelStyle}>Pairing link</span>
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                  <button
+                    type="button"
+                    onClick={() => void copy(info.url, "link")}
+                    style={outlineButton({ height: 28, padding: "0 10px", fontSize: 11 })}
+                  >
+                    {copied === "link" ? "Copied" : "Copy link"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => openExternalUrl(info.url)}
+                    style={outlineButton({ height: 28, padding: "0 10px", fontSize: 11 })}
+                  >
+                    Open link
+                  </button>
+                </div>
+              </div>
+              <div style={labelStyle}>
+                {info.machineName} · reachable over LAN
+                {info.relayAvailable ? " · relay" : ""}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div style={{ display: "grid", gap: 8 }}>
+            <div style={{ color: COLORS.textSecondary, fontFamily: SANS_FONT, fontSize: 12.5, lineHeight: 1.5 }}>
+              No pairing code is set, so other machines can't pair with this Mac
+              yet. Set a pairing PIN in Settings → Sync to share it.
+            </div>
+          </div>
+        )
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/remoteTargets/remoteMachineModel.ts
+++ b/apps/desktop/src/renderer/components/remoteTargets/remoteMachineModel.ts
@@ -1,0 +1,436 @@
+import { extractError } from "../../lib/format";
+import type {
+  RemoteRuntimeConnectErrorInfo,
+  RemoteRuntimeConnectionRoute,
+  RemoteRuntimeConnectionStatus,
+  RemoteRuntimeDiscoveredMachine,
+  RemoteRuntimeTarget,
+  RemoteRuntimeTargetInput,
+  RemoteRuntimeTargetRoute,
+  RemoteRuntimeTargetRouteSource,
+} from "../../../shared/types";
+
+// ---------------------------------------------------------------------------
+// Route identity + discovered-machine helpers (framework-free, unit-tested via
+// the panel). Kept in one module so the section model and the connect flow
+// agree on how a saved target and a discovered machine map to the same box.
+// ---------------------------------------------------------------------------
+
+export function isTailscaleRoute(hostname: string | null | undefined): boolean {
+  const normalized = hostname?.trim().toLowerCase().replace(/\.$/, "") ?? "";
+  if (normalized.endsWith(".ts.net")) return true;
+  const match = /^100\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(normalized);
+  if (!match) return false;
+  const second = Number.parseInt(match[1] ?? "", 10);
+  return second >= 64 && second <= 127;
+}
+
+function normalizeRouteHost(hostname: string | null | undefined): string {
+  return hostname?.trim().toLowerCase().replace(/\.$/, "") ?? "";
+}
+
+function normalizeRoutePort(port: number | null | undefined): number {
+  return port ?? 22;
+}
+
+export function routeIdentity(
+  hostname: string | null | undefined,
+  port: number | null | undefined,
+): string | null {
+  const host = normalizeRouteHost(hostname);
+  if (!host) return null;
+  return `${host}:${normalizeRoutePort(port)}`;
+}
+
+function discoveredRouteSource(
+  machine: RemoteRuntimeDiscoveredMachine,
+  hostname: string,
+): RemoteRuntimeTargetRouteSource {
+  if (
+    (machine.runtimeKind ?? "").startsWith("tailscale-peer") ||
+    hostname === machine.tailscaleAddress ||
+    isTailscaleRoute(hostname)
+  ) {
+    return "tailscale";
+  }
+  return "bonjour";
+}
+
+export function discoveredSshRoutes(
+  machine: RemoteRuntimeDiscoveredMachine,
+): RemoteRuntimeTargetRoute[] {
+  const hostnames = [
+    machine.tailscaleAddress,
+    machine.primaryRoute,
+    machine.hostName,
+    ...machine.addresses,
+  ];
+  const routes: RemoteRuntimeTargetRoute[] = [];
+  const seen = new Set<string>();
+  for (const value of hostnames) {
+    const hostname = value?.trim().replace(/\.$/, "");
+    if (!hostname) continue;
+    const key = hostname.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    routes.push({
+      hostname,
+      port: null,
+      source: discoveredRouteSource(machine, hostname),
+      lastSucceededAt: null,
+    });
+  }
+  return routes;
+}
+
+export function discoveredRoute(
+  machine: RemoteRuntimeDiscoveredMachine,
+): string | null {
+  return (
+    machine.tailscaleAddress ??
+    machine.primaryRoute ??
+    machine.hostName ??
+    machine.addresses[0] ??
+    null
+  );
+}
+
+export function discoveredTargetInput(
+  machine: RemoteRuntimeDiscoveredMachine,
+): RemoteRuntimeTargetInput | null {
+  const route = discoveredRoute(machine);
+  if (!route) return null;
+  return {
+    name: machine.machineName,
+    hostname: route.replace(/\.$/, ""),
+    sshUser: null,
+    port: null,
+    sshKeyPath: null,
+    routes: discoveredSshRoutes(machine),
+  };
+}
+
+export function targetRouteIdentities(
+  target: RemoteRuntimeTarget,
+): Set<string> {
+  const identities = new Set<string>();
+  const primary = routeIdentity(target.hostname, target.port);
+  if (primary) identities.add(primary);
+  for (const route of target.routes ?? []) {
+    const identity = routeIdentity(route.hostname, route.port ?? target.port);
+    if (identity) identities.add(identity);
+  }
+  return identities;
+}
+
+function discoveredMachineRouteIdentities(
+  machine: RemoteRuntimeDiscoveredMachine,
+): Set<string> {
+  const identities = new Set<string>();
+  for (const route of discoveredSshRoutes(machine)) {
+    const identity = routeIdentity(route.hostname, route.port);
+    if (identity) identities.add(identity);
+  }
+  return identities;
+}
+
+export function machineMatchesSavedTarget(
+  machine: RemoteRuntimeDiscoveredMachine,
+  target: RemoteRuntimeTarget,
+): boolean {
+  const discovered = discoveredMachineRouteIdentities(machine);
+  if (discovered.size === 0) return false;
+  const saved = targetRouteIdentities(target);
+  for (const identity of discovered) {
+    if (saved.has(identity)) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Labels + formatting
+// ---------------------------------------------------------------------------
+
+export function formatLastSeen(value: number | null): string {
+  if (!value) return "Never connected";
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return "Last connection unknown";
+  return `Last connected ${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
+}
+
+export function targetConnectionLabel(target: RemoteRuntimeTarget): string {
+  const userPrefix = target.sshUser ? `${target.sshUser}@` : "";
+  const portSuffix = target.port ? `:${target.port}` : "";
+  let defaultHint = "";
+  if (!target.sshUser && !target.port) {
+    defaultHint = " (SSH defaults)";
+  } else if (!target.sshUser) {
+    defaultHint = " (default SSH user)";
+  } else if (!target.port) {
+    defaultHint = " (default port)";
+  }
+  const targetHostKey = target.hostname.toLowerCase().replace(/\.$/, "");
+  const fallbackRoutes = (target.routes ?? []).filter(
+    (route) =>
+      route.hostname.toLowerCase().replace(/\.$/, "") !== targetHostKey ||
+      route.port !== target.port,
+  ).length;
+  const fallbackHint =
+    fallbackRoutes > 0
+      ? ` + ${fallbackRoutes} route${fallbackRoutes === 1 ? "" : "s"}`
+      : "";
+  return `${userPrefix}${target.hostname}${portSuffix}${defaultHint}${fallbackHint}`;
+}
+
+export function connectionStateLabel(
+  connection: RemoteRuntimeConnectionStatus | null,
+  connectedFallback: boolean,
+): string {
+  if (connection?.state === "connected" || (!connection && connectedFallback))
+    return "Connected";
+  if (connection?.state === "connecting") return "Connecting";
+  if (connection?.state === "error") return "Connection failed";
+  return "Not connected";
+}
+
+/** True when a discovered machine is a raw SSH peer with no ADE runtime. */
+export function isSshOnlyDiscovered(
+  machine: RemoteRuntimeDiscoveredMachine,
+): boolean {
+  return (machine.runtimeKind ?? "").startsWith("tailscale-peer");
+}
+
+/**
+ * The one-line "what is this" for a discovered machine: ADE services show their
+ * project count, raw SSH peers state they are SSH-only and (when known) which
+ * OS. Concrete and stateful — not a generic "detected device" blurb.
+ */
+export function discoveredMachineSummary(
+  machine: RemoteRuntimeDiscoveredMachine,
+): string {
+  if (isSshOnlyDiscovered(machine)) {
+    const os = machine.os?.trim();
+    return os ? `SSH only · ${os}` : "SSH only";
+  }
+  const count = machine.projectCount ?? machine.projectIds.length;
+  if (count <= 0) return "ADE · no projects";
+  return `ADE · ${count} project${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * A subtle route chip for a connected row, e.g. `tailnet · 4 ms`, `lan · 2 ms`,
+ * `relay · 90 ms`, or `ssh · studio.local` when the transport reports no
+ * round-trip latency.
+ */
+export function formatRouteChip(
+  route: RemoteRuntimeConnectionRoute | undefined,
+): string | null {
+  if (!route) return null;
+  const detail =
+    typeof route.latencyMs === "number" && Number.isFinite(route.latencyMs)
+      ? `${Math.round(route.latencyMs)} ms`
+      : route.endpoint?.trim() || null;
+  return detail ? `${route.kind} · ${detail}` : route.kind;
+}
+
+export function formatRemoteTargetError(error: unknown): string {
+  const message = extractError(error)
+    .replace(/^Error invoking remote method '[^']+':\s*/i, "")
+    .replace(/^Error:\s*/i, "")
+    .trim();
+
+  if (/^(?:read\s+)?ECONNRESET$/i.test(message)) {
+    return "SSH server closed the connection before ADE could finish the SSH handshake. Check that Remote Login/sshd is enabled on the remote machine and try again.";
+  }
+
+  if (/permission denied|all configured authentication methods failed/i.test(message)) {
+    return "SSH authentication failed. Check the SSH user, key path, and that this key is allowed on the remote machine.";
+  }
+
+  if (/host denied|verification failed|host key verification/i.test(message)) {
+    return "SSH host-key verification failed. Check that this is the right machine, then update the saved SSH host key or trust the new key when ADE prompts.";
+  }
+
+  if (/timed out.*handshake|handshake.*timed out|connect.*timed out/i.test(message)) {
+    return "SSH did not finish connecting. Check that the machine is awake, reachable on Tailscale or LAN, and Remote Login is enabled.";
+  }
+
+  if (/ECONNREFUSED/i.test(message)) {
+    return "The machine refused the SSH connection. Check the port and make sure Remote Login/sshd is running.";
+  }
+
+  if (/ENOTFOUND|could not resolve hostname|name or service not known/i.test(message)) {
+    return "ADE could not resolve that host. Check the hostname, or use the Tailscale 100.x address from discovery.";
+  }
+
+  return message || "Remote connection failed.";
+}
+
+// ---------------------------------------------------------------------------
+// Error card selection
+// ---------------------------------------------------------------------------
+
+export type MachineErrorCard = {
+  message: string;
+  /** Capped, copyable technical detail from a structured error, when present. */
+  detail: string | null;
+  /** True when the message came straight from a structured `lastErrorInfo`. */
+  structured: boolean;
+};
+
+/**
+ * Chooses what a failed connection should show the user. A structured
+ * `lastErrorInfo` wins and is shown verbatim (plain-language message + optional
+ * technical detail); otherwise the raw error string is run through the
+ * plain-English `formatRemoteTargetError` fallback. Returns null when there is
+ * nothing to surface.
+ */
+export function selectMachineErrorCard(args: {
+  errorInfo?: RemoteRuntimeConnectErrorInfo | null;
+  rawError?: string | null;
+  /** A locally-produced message (e.g. from a thrown connect call). */
+  overrideMessage?: string | null;
+}): MachineErrorCard | null {
+  const { errorInfo, rawError, overrideMessage } = args;
+  if (errorInfo?.message) {
+    return {
+      message: errorInfo.message,
+      detail: errorInfo.detail?.trim() ? errorInfo.detail : null,
+      structured: true,
+    };
+  }
+  const fallback =
+    overrideMessage?.trim() ||
+    (rawError ? formatRemoteTargetError(rawError) : null);
+  if (!fallback) return null;
+  return { message: fallback, detail: null, structured: false };
+}
+
+// ---------------------------------------------------------------------------
+// Section assignment
+// ---------------------------------------------------------------------------
+
+export type MachineSection = "connected" | "available" | "unavailable";
+
+export type SavedMachineRow = {
+  kind: "saved";
+  id: string;
+  target: RemoteRuntimeTarget;
+  status: RemoteRuntimeConnectionStatus | null;
+  connected: boolean;
+  /** Set only for the unavailable section (offline / unsupported). */
+  unavailableReason: string | null;
+};
+
+export type DiscoveredMachineRow = {
+  kind: "discovered";
+  id: string;
+  machine: RemoteRuntimeDiscoveredMachine;
+  unavailableReason: string | null;
+};
+
+export type MachineRow = SavedMachineRow | DiscoveredMachineRow;
+
+export type MachineSections = {
+  connected: MachineRow[];
+  available: MachineRow[];
+  unavailable: MachineRow[];
+};
+
+/**
+ * Splits saved targets and discovered machines into the CONNECTED / AVAILABLE /
+ * UNAVAILABLE buckets the panel renders. A discovered machine that is already
+ * saved is represented by its saved row only (no duplicate). A saved target
+ * that matches an unreachable discovered machine (offline / unsupported OS)
+ * inherits that unavailability so it greys out with a concrete reason.
+ */
+export function assignMachineSections(args: {
+  targets: RemoteRuntimeTarget[];
+  statusById: Map<string, RemoteRuntimeConnectionStatus>;
+  connectedFallbackId: string | null;
+  discoveredMachines: RemoteRuntimeDiscoveredMachine[];
+}): MachineSections {
+  const { targets, statusById, connectedFallbackId, discoveredMachines } = args;
+  const sections: MachineSections = {
+    connected: [],
+    available: [],
+    unavailable: [],
+  };
+
+  const claimedMachineIds = new Set<string>();
+
+  for (const target of targets) {
+    const status = statusById.get(target.id) ?? null;
+    const connected = status
+      ? status.state === "connected"
+      : target.id === connectedFallbackId;
+
+    const match = discoveredMachines.find((machine) =>
+      machineMatchesSavedTarget(machine, target),
+    );
+    if (match) claimedMachineIds.add(match.id);
+
+    if (connected) {
+      sections.connected.push({
+        kind: "saved",
+        id: target.id,
+        target,
+        status,
+        connected: true,
+        unavailableReason: null,
+      });
+      continue;
+    }
+
+    if (match && match.connectable === false) {
+      sections.unavailable.push({
+        kind: "saved",
+        id: target.id,
+        target,
+        status,
+        connected: false,
+        unavailableReason: match.unsupportedReason ?? "Offline",
+      });
+      continue;
+    }
+
+    sections.available.push({
+      kind: "saved",
+      id: target.id,
+      target,
+      status,
+      connected: false,
+      unavailableReason: null,
+    });
+  }
+
+  for (const machine of discoveredMachines) {
+    if (claimedMachineIds.has(machine.id)) continue;
+    if (
+      targets.some((target) => machineMatchesSavedTarget(machine, target))
+    ) {
+      continue;
+    }
+    if (machine.connectable === false) {
+      sections.unavailable.push({
+        kind: "discovered",
+        id: machine.id,
+        machine,
+        unavailableReason:
+          machine.unsupportedReason ??
+          (machine.os?.toLowerCase() === "windows"
+            ? "Windows — not supported yet"
+            : "Offline"),
+      });
+      continue;
+    }
+    sections.available.push({
+      kind: "discovered",
+      id: machine.id,
+      machine,
+      unavailableReason: null,
+    });
+  }
+
+  return sections;
+}

--- a/apps/desktop/src/renderer/components/remoteTargets/remoteMachineModel.ts
+++ b/apps/desktop/src/renderer/components/remoteTargets/remoteMachineModel.ts
@@ -9,21 +9,13 @@ import type {
   RemoteRuntimeTargetRoute,
   RemoteRuntimeTargetRouteSource,
 } from "../../../shared/types";
+import { isTailnetHostname } from "../../../shared/tailnet";
 
 // ---------------------------------------------------------------------------
 // Route identity + discovered-machine helpers (framework-free, unit-tested via
 // the panel). Kept in one module so the section model and the connect flow
 // agree on how a saved target and a discovered machine map to the same box.
 // ---------------------------------------------------------------------------
-
-export function isTailscaleRoute(hostname: string | null | undefined): boolean {
-  const normalized = hostname?.trim().toLowerCase().replace(/\.$/, "") ?? "";
-  if (normalized.endsWith(".ts.net")) return true;
-  const match = /^100\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(normalized);
-  if (!match) return false;
-  const second = Number.parseInt(match[1] ?? "", 10);
-  return second >= 64 && second <= 127;
-}
 
 function normalizeRouteHost(hostname: string | null | undefined): string {
   return hostname?.trim().toLowerCase().replace(/\.$/, "") ?? "";
@@ -49,7 +41,7 @@ function discoveredRouteSource(
   if (
     (machine.runtimeKind ?? "").startsWith("tailscale-peer") ||
     hostname === machine.tailscaleAddress ||
-    isTailscaleRoute(hostname)
+    isTailnetHostname(hostname)
   ) {
     return "tailscale";
   }
@@ -243,7 +235,11 @@ export function formatRemoteTargetError(error: unknown): string {
     return "SSH server closed the connection before ADE could finish the SSH handshake. Check that Remote Login/sshd is enabled on the remote machine and try again.";
   }
 
-  if (/permission denied|all configured authentication methods failed/i.test(message)) {
+  if (
+    /permission denied|all configured authentication methods failed/i.test(
+      message,
+    )
+  ) {
     return "SSH authentication failed. Check the SSH user, key path, and that this key is allowed on the remote machine.";
   }
 
@@ -251,7 +247,11 @@ export function formatRemoteTargetError(error: unknown): string {
     return "SSH host-key verification failed. Check that this is the right machine, then update the saved SSH host key or trust the new key when ADE prompts.";
   }
 
-  if (/timed out.*handshake|handshake.*timed out|connect.*timed out/i.test(message)) {
+  if (
+    /timed out.*handshake|handshake.*timed out|connect.*timed out/i.test(
+      message,
+    )
+  ) {
     return "SSH did not finish connecting. Check that the machine is awake, reachable on Tailscale or LAN, and Remote Login is enabled.";
   }
 
@@ -259,7 +259,11 @@ export function formatRemoteTargetError(error: unknown): string {
     return "The machine refused the SSH connection. Check the port and make sure Remote Login/sshd is running.";
   }
 
-  if (/ENOTFOUND|could not resolve hostname|name or service not known/i.test(message)) {
+  if (
+    /ENOTFOUND|could not resolve hostname|name or service not known/i.test(
+      message,
+    )
+  ) {
     return "ADE could not resolve that host. Check the hostname, or use the Tailscale 100.x address from discovery.";
   }
 
@@ -406,9 +410,7 @@ export function assignMachineSections(args: {
 
   for (const machine of discoveredMachines) {
     if (claimedMachineIds.has(machine.id)) continue;
-    if (
-      targets.some((target) => machineMatchesSavedTarget(machine, target))
-    ) {
+    if (targets.some((target) => machineMatchesSavedTarget(machine, target))) {
       continue;
     }
     if (machine.connectable === false) {

--- a/apps/desktop/src/renderer/components/remoteTargets/remoteTargetListStyles.ts
+++ b/apps/desktop/src/renderer/components/remoteTargets/remoteTargetListStyles.ts
@@ -1,0 +1,60 @@
+import type { CSSProperties } from "react";
+import { COLORS, MONO_FONT, SANS_FONT } from "../lanes/laneDesignTokens";
+
+export const panelStyle: CSSProperties = {
+  display: "grid",
+  gap: 12,
+};
+
+export const machineRowStyle: CSSProperties = {
+  display: "grid",
+  gap: 8,
+  padding: "12px 14px",
+  borderRadius: 8,
+  border: `1px solid ${COLORS.border}`,
+  background: "rgba(255,255,255,0.02)",
+};
+
+export const inlineDetailStyle: CSSProperties = {
+  display: "grid",
+  gap: 12,
+  marginTop: -4,
+  padding: 12,
+  borderRadius: 8,
+  border: `1px solid ${COLORS.border}`,
+  background: "rgba(0,0,0,0.16)",
+};
+
+export const helperTextStyle: CSSProperties = {
+  color: COLORS.textMuted,
+  fontFamily: SANS_FONT,
+  fontSize: 12,
+  lineHeight: 1.45,
+};
+
+export const sectionHeaderStyle: CSSProperties = {
+  color: COLORS.textMuted,
+  fontFamily: SANS_FONT,
+  fontSize: 10.5,
+  fontWeight: 600,
+  letterSpacing: "0.08em",
+};
+
+export const nameStyle: CSSProperties = {
+  color: COLORS.textPrimary,
+  fontFamily: MONO_FONT,
+  fontSize: 13,
+  fontWeight: 700,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+export const subTextStyle: CSSProperties = {
+  color: COLORS.textMuted,
+  fontFamily: MONO_FONT,
+  fontSize: 12,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};

--- a/apps/desktop/src/renderer/webclient/sync/__tests__/sync.test.ts
+++ b/apps/desktop/src/renderer/webclient/sync/__tests__/sync.test.ts
@@ -451,6 +451,42 @@ describe("browser sync connection and client", () => {
     client.dispose();
   });
 
+  it("ignores unknown rpc/fwd envelopes without disconnecting the browser client", async () => {
+    const storage = new MemoryStorage();
+    const environment = await makeEnvironment(storage);
+    const script = createSocketFactory((socket, envelope) => {
+      if (envelope.type === "hello") {
+        socket.serverSend({
+          type: "hello_ok",
+          requestId: envelope.requestId,
+          payload: helloOk(),
+        });
+      }
+    });
+    const client = new AdeSyncClient({
+      storage,
+      socketFactory: script.factory,
+      document: null,
+    });
+
+    await client.connect(environment.envId);
+    const socket = script.sockets[0]!;
+    socket.serverSend({
+      type: "rpc_open",
+      payload: { channelId: "desktop-only-rpc" },
+    });
+    socket.serverSend({
+      type: "fwd_data",
+      payload: { forwardId: "desktop-only-forward", data: "YQ==" },
+    });
+    await flush();
+
+    expect(client.getStatus().state).toBe("connected");
+    expect(socket.readyState).toBe(1);
+    expect(socket.sent.map((envelope) => envelope.type)).toEqual(["hello"]);
+    client.dispose();
+  });
+
   it("drops stored pairing only for attributed auth failures", async () => {
     const attributedStorage = new MemoryStorage();
     const attributedEnv = await makeEnvironment(attributedStorage);

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -50,6 +50,11 @@ export const IPC = {
   remoteRuntimeListTargets: "ade.remoteRuntime.listTargets",
   remoteRuntimeListDiscoveredMachines:
     "ade.remoteRuntime.listDiscoveredMachines",
+  remoteRuntimeParsePairingInput: "ade.remoteRuntime.parsePairingInput",
+  remoteRuntimePairWithMachine: "ade.remoteRuntime.pairWithMachine",
+  remoteRuntimeGetLocalPairingInfo:
+    "ade.remoteRuntime.getLocalPairingInfo",
+  remoteRuntimeRunDoctor: "ade.remoteRuntime.runDoctor",
   remoteRuntimeGetConnectionSnapshot: "ade.remoteRuntime.getConnectionSnapshot",
   remoteRuntimeConnectionSnapshotChanged:
     "ade.remoteRuntime.connectionSnapshotChanged",

--- a/apps/desktop/src/shared/pairingQr.test.ts
+++ b/apps/desktop/src/shared/pairingQr.test.ts
@@ -47,19 +47,22 @@ describe("pairingQr codec", () => {
     expect(parsedUrl.hash.length).toBeGreaterThan(1);
   });
 
-  it("includes optional relayUrl / claimToken only when provided", () => {
+  it("preserves distinct optional relay, claim, and runtime-grant fields", () => {
     const bare = buildPairingQrPayload({ connectInfo });
     expect(bare.relayUrl).toBeUndefined();
     expect(bare.claimToken).toBeUndefined();
+    expect(bare.runtimeHostGrant).toBeUndefined();
 
     const withRelay = buildPairingQrPayload({
       connectInfo,
       relayUrl: "wss://relay.ade-app.dev/tunnel/abc",
       claimToken: "claim-xyz",
+      runtimeHostGrant: "runtime-grant-xyz",
     });
     const parsed = parsePairingQrUrl(encodePairingQrUrl(withRelay));
     expect(parsed?.relayUrl).toBe("wss://relay.ade-app.dev/tunnel/abc");
     expect(parsed?.claimToken).toBe("claim-xyz");
+    expect(parsed?.runtimeHostGrant).toBe("runtime-grant-xyz");
   });
 
   it("drops a relayUrl that is not a wss:// URL", () => {

--- a/apps/desktop/src/shared/pairingQr.ts
+++ b/apps/desktop/src/shared/pairingQr.ts
@@ -50,6 +50,7 @@ export function buildPairingQrPayload(args: {
   connectInfo: SyncPairingConnectInfo;
   relayUrl?: string | null;
   claimToken?: string | null;
+  runtimeHostGrant?: string | null;
 }): SyncPairingQrPayload {
   return {
     version: PAIRING_QR_PAYLOAD_VERSION,
@@ -58,6 +59,7 @@ export function buildPairingQrPayload(args: {
     addressCandidates: args.connectInfo.addressCandidates,
     ...(args.relayUrl ? { relayUrl: args.relayUrl } : {}),
     ...(args.claimToken ? { claimToken: args.claimToken } : {}),
+    ...(args.runtimeHostGrant ? { runtimeHostGrant: args.runtimeHostGrant } : {}),
   };
 }
 
@@ -155,6 +157,7 @@ export function parsePairingQrUrl(raw: string): SyncPairingQrPayload | null {
 
   const relayUrl = readString(parsed, "relayUrl");
   const claimToken = readString(parsed, "claimToken");
+  const runtimeHostGrant = readString(parsed, "runtimeHostGrant");
   return {
     version: PAIRING_QR_PAYLOAD_VERSION,
     hostIdentity,
@@ -162,6 +165,7 @@ export function parsePairingQrUrl(raw: string): SyncPairingQrPayload | null {
     addressCandidates: parseAddressCandidates(parsed.addressCandidates),
     ...(relayUrl && /^wss:\/\//i.test(relayUrl) ? { relayUrl } : {}),
     ...(claimToken ? { claimToken } : {}),
+    ...(runtimeHostGrant ? { runtimeHostGrant } : {}),
   };
 }
 

--- a/apps/desktop/src/shared/tailnet.ts
+++ b/apps/desktop/src/shared/tailnet.ts
@@ -1,0 +1,18 @@
+function normalizeHostname(value: string | null | undefined): string {
+  return (
+    value
+      ?.trim()
+      .toLowerCase()
+      .replace(/\.$/, "")
+      .replace(/^\[|\]$/g, "") ?? ""
+  );
+}
+
+export function isTailnetHostname(value: string | null | undefined): boolean {
+  const hostname = normalizeHostname(value);
+  if (hostname.endsWith(".ts.net")) return true;
+  const match = /^100\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(hostname);
+  if (!match) return false;
+  const second = Number.parseInt(match[1] ?? "", 10);
+  return second >= 64 && second <= 127;
+}

--- a/apps/desktop/src/shared/types/index.ts
+++ b/apps/desktop/src/shared/types/index.ts
@@ -27,6 +27,7 @@ export * from "./sync";
 export * from "./devTools";
 export * from "./adeCli";
 export * from "./remoteRuntime";
+export * from "./pairedRuntime";
 export * from "./projectSecrets";
 export * from "./personalChats";
 

--- a/apps/desktop/src/shared/types/pairedRuntime.ts
+++ b/apps/desktop/src/shared/types/pairedRuntime.ts
@@ -89,10 +89,14 @@ export type PairedRuntimeSyncEnvelope =
   | PairedRuntimeForwardCloseEnvelope;
 
 export type PairedRuntimeFeatureFlags = {
-  /** Full newline-delimited runtime JSON-RPC over rpc_* envelopes. */
-  rpcChannel: true;
-  /** Loopback-only host TCP forwarding over fwd_* envelopes. */
-  portForward: true;
+  /**
+   * Full newline-delimited runtime JSON-RPC over rpc_* envelopes. Advertised
+   * `true` only to desktop runtime-host peers; non-desktop paired devices
+   * (phones/browsers) receive `false` and clients must not attempt the channel.
+   */
+  rpcChannel: boolean;
+  /** Loopback-only host TCP forwarding over fwd_* envelopes. Desktop-only, as above. */
+  portForward: boolean;
 };
 
 export type PairedRuntimeHelloOkPayload = Omit<SyncHelloOkPayload, "features"> & {

--- a/apps/desktop/src/shared/types/pairedRuntime.ts
+++ b/apps/desktop/src/shared/types/pairedRuntime.ts
@@ -1,0 +1,135 @@
+import type {
+  SyncHelloOkPayload,
+  SyncPairingHostIdentity,
+} from "./sync";
+
+export type PairedRuntimeRpcOpenPayload = {
+  channelId: string;
+};
+
+export type PairedRuntimeRpcDataPayload = {
+  channelId: string;
+  /** Base64-encoded bytes from the newline-delimited JSON-RPC stream. */
+  data: string;
+};
+
+export type PairedRuntimeRpcClosePayload = {
+  channelId: string;
+  reason?: string | null;
+};
+
+export type PairedRuntimeForwardOpenPayload = {
+  forwardId: string;
+  host: string;
+  port: number;
+};
+
+export type PairedRuntimeForwardDataPayload = {
+  forwardId: string;
+  /** Base64-encoded TCP stream bytes. */
+  data: string;
+};
+
+export type PairedRuntimeForwardClosePayload = {
+  forwardId: string;
+  reason?: string | null;
+};
+
+type PairedRuntimeEnvelopeBase<TType extends string> = {
+  version: 1;
+  type: TType;
+  projectId?: string | null;
+  requestId?: string | null;
+};
+
+type PairedRuntimeEnvelopeWithPayload<TType extends string, TPayload> =
+  | (PairedRuntimeEnvelopeBase<TType> & {
+      compression: "none";
+      payloadEncoding: "json";
+      payload: TPayload;
+    })
+  | (PairedRuntimeEnvelopeBase<TType> & {
+      compression: "gzip";
+      payloadEncoding: "base64";
+      payload: string;
+      uncompressedBytes: number;
+    });
+
+export type PairedRuntimeRpcOpenEnvelope = PairedRuntimeEnvelopeWithPayload<
+  "rpc_open",
+  PairedRuntimeRpcOpenPayload
+>;
+export type PairedRuntimeRpcDataEnvelope = PairedRuntimeEnvelopeWithPayload<
+  "rpc_data",
+  PairedRuntimeRpcDataPayload
+>;
+export type PairedRuntimeRpcCloseEnvelope = PairedRuntimeEnvelopeWithPayload<
+  "rpc_close",
+  PairedRuntimeRpcClosePayload
+>;
+export type PairedRuntimeForwardOpenEnvelope = PairedRuntimeEnvelopeWithPayload<
+  "fwd_open",
+  PairedRuntimeForwardOpenPayload
+>;
+export type PairedRuntimeForwardDataEnvelope = PairedRuntimeEnvelopeWithPayload<
+  "fwd_data",
+  PairedRuntimeForwardDataPayload
+>;
+export type PairedRuntimeForwardCloseEnvelope = PairedRuntimeEnvelopeWithPayload<
+  "fwd_close",
+  PairedRuntimeForwardClosePayload
+>;
+
+export type PairedRuntimeSyncEnvelope =
+  | PairedRuntimeRpcOpenEnvelope
+  | PairedRuntimeRpcDataEnvelope
+  | PairedRuntimeRpcCloseEnvelope
+  | PairedRuntimeForwardOpenEnvelope
+  | PairedRuntimeForwardDataEnvelope
+  | PairedRuntimeForwardCloseEnvelope;
+
+export type PairedRuntimeFeatureFlags = {
+  /** Full newline-delimited runtime JSON-RPC over rpc_* envelopes. */
+  rpcChannel: true;
+  /** Loopback-only host TCP forwarding over fwd_* envelopes. */
+  portForward: true;
+};
+
+export type PairedRuntimeHelloOkPayload = Omit<SyncHelloOkPayload, "features"> & {
+  features: SyncHelloOkPayload["features"] & PairedRuntimeFeatureFlags;
+};
+
+export type DesktopPairedMachineCredentials = {
+  version: 1;
+  hostIdentity: SyncPairingHostIdentity;
+  /** Optional tunnel-relay machine key parsed from a saved relay endpoint. */
+  machineKey?: string | null;
+  /** Device id registered in the host's pairing store. */
+  deviceId: string;
+  /** Stable local site id used in the sync hello metadata. */
+  siteId: string;
+  deviceName: string;
+  secret: string;
+  /** Base64 DER PKCS#8 P-256 private key. */
+  dpopPrivateKey: string;
+  /** Base64 X9.63 uncompressed P-256 public key. */
+  dpopPublicKey: string;
+  endpoints: string[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type DesktopPairedMachinesFile = {
+  version: 1;
+  machines: DesktopPairedMachineCredentials[];
+};
+
+export type PairedRuntimePortForward = {
+  remoteHost: string;
+  remotePort: number;
+  localHost: "127.0.0.1";
+  localPort: number;
+  localUrl: string;
+  createdAt: number;
+  lastUsedAt: number;
+};

--- a/apps/desktop/src/shared/types/pairedRuntime.ts
+++ b/apps/desktop/src/shared/types/pairedRuntime.ts
@@ -115,8 +115,17 @@ export type DesktopPairedMachineCredentials = {
   /** Base64 X9.63 uncompressed P-256 public key. */
   dpopPublicKey: string;
   endpoints: string[];
+  /** Relay endpoint advertised by the host, when one is available. */
+  relayUrl?: string | null;
+  /** Per-endpoint route history used to prefer recently successful routes. */
+  endpointStates?: DesktopPairedMachineEndpointState[];
   createdAt: string;
   updatedAt: string;
+};
+
+export type DesktopPairedMachineEndpointState = {
+  endpoint: string;
+  lastSucceededAt: number | null;
 };
 
 export type DesktopPairedMachinesFile = {

--- a/apps/desktop/src/shared/types/pairedRuntime.ts
+++ b/apps/desktop/src/shared/types/pairedRuntime.ts
@@ -91,11 +91,11 @@ export type PairedRuntimeSyncEnvelope =
 export type PairedRuntimeFeatureFlags = {
   /**
    * Full newline-delimited runtime JSON-RPC over rpc_* envelopes. Advertised
-   * `true` only to desktop runtime-host peers; non-desktop paired devices
-   * (phones/browsers) receive `false` and clients must not attempt the channel.
+   * `true` only to peers with a server-issued runtime-host grant; device type
+   * metadata alone is never authorization.
    */
   rpcChannel: boolean;
-  /** Loopback-only host TCP forwarding over fwd_* envelopes. Desktop-only, as above. */
+  /** Loopback-only host TCP forwarding over fwd_* envelopes. Grant-gated, as above. */
   portForward: boolean;
 };
 

--- a/apps/desktop/src/shared/types/remoteRuntime.ts
+++ b/apps/desktop/src/shared/types/remoteRuntime.ts
@@ -242,6 +242,7 @@ export type RemoteRuntimeParsedPairingInput = {
   machineName?: string;
   endpoints: string[];
   relayUrl?: string;
+  runtimeHostGrant?: string;
   requiresPin: true;
 };
 

--- a/apps/desktop/src/shared/types/remoteRuntime.ts
+++ b/apps/desktop/src/shared/types/remoteRuntime.ts
@@ -1,4 +1,14 @@
 import type { ProjectIcon } from "./core";
+import type { SyncPairingHostIdentity } from "./sync";
+
+export type RemoteRuntimeTransportKind = "ssh" | "paired";
+
+export type RemoteRuntimePairedMachineReference = {
+  /** Stable host device id in the desktop paired-machine credential store. */
+  hostIdentity: string;
+  /** Optional tunnel-relay machine key for lookup after relay-only pairing. */
+  machineKey?: string | null;
+};
 
 export type RemoteRuntimeTargetRouteSource =
   | "manual"
@@ -16,6 +26,9 @@ export type RemoteRuntimeTarget = {
   id: string;
   name: string;
   hostname: string;
+  /** Missing on older records means SSH. */
+  transport?: RemoteRuntimeTransportKind;
+  pairedMachine?: RemoteRuntimePairedMachineReference | null;
   sshUser: string | null;
   port: number | null;
   sshKeyPath: string | null;
@@ -29,6 +42,8 @@ export type RemoteRuntimeTarget = {
 export type RemoteRuntimeTargetInput = {
   name?: string | null;
   hostname: string;
+  transport?: RemoteRuntimeTransportKind | null;
+  pairedMachine?: RemoteRuntimePairedMachineReference | null;
   sshUser?: string | null;
   port?: number | null;
   sshKeyPath?: string | null;
@@ -88,6 +103,7 @@ export type RemoteRuntimeConnectResult = {
   target: RemoteRuntimeTarget;
   arch: string;
   version: string | null;
+  route?: RemoteRuntimeConnectionRoute;
   capabilities?: RemoteRuntimeCapabilities;
   compatibilityWarnings?: string[];
   projects: RemoteRuntimeProjectRecord[];
@@ -142,6 +158,14 @@ export type RemoteRuntimeConnectionState =
   | "connecting"
   | "connected"
   | "error";
+
+export type RemoteRuntimeRouteKind = "lan" | "tailnet" | "relay" | "ssh";
+
+export type RemoteRuntimeConnectionRoute = {
+  kind: RemoteRuntimeRouteKind;
+  endpoint: string;
+  latencyMs?: number;
+};
 
 export type RemoteRuntimeConnectErrorInfo = {
   kind: "disk_full" | "ssh_auth" | "unsupported_os" | "generic";
@@ -203,6 +227,7 @@ export type RemoteRuntimeConnectionStatus = {
   state: RemoteRuntimeConnectionState;
   arch: string | null;
   version: string | null;
+  route?: RemoteRuntimeConnectionRoute;
   capabilities?: RemoteRuntimeCapabilities;
   compatibilityWarnings?: string[];
   projects: RemoteRuntimeProjectRecord[];
@@ -210,6 +235,43 @@ export type RemoteRuntimeConnectionStatus = {
   lastErrorInfo?: RemoteRuntimeConnectErrorInfo | null;
   lastAttemptedAt: number | null;
   connectedAt: number | null;
+};
+
+export type RemoteRuntimeParsedPairingInput = {
+  hostIdentity: SyncPairingHostIdentity;
+  machineName?: string;
+  endpoints: string[];
+  relayUrl?: string;
+  requiresPin: true;
+};
+
+export type RemoteRuntimePairWithMachineArgs = {
+  input: string;
+  pin: string;
+  deviceName: string;
+};
+
+export type RemoteRuntimePairWithMachineResult = {
+  targetId: string;
+};
+
+export type RemoteRuntimeLocalPairingInfo = {
+  url: string;
+  pin: string | null;
+  machineName: string;
+  relayAvailable: boolean;
+};
+
+export type RemoteRuntimeDoctorCheck = {
+  route: RemoteRuntimeRouteKind;
+  endpoint: string;
+  ok: boolean;
+  latencyMs?: number;
+  error?: string;
+};
+
+export type RemoteRuntimeDoctorResult = {
+  checks: RemoteRuntimeDoctorCheck[];
 };
 
 export type RemoteRuntimeMachineProjectCapability =

--- a/apps/desktop/src/shared/types/remoteRuntime.ts
+++ b/apps/desktop/src/shared/types/remoteRuntime.ts
@@ -47,6 +47,9 @@ export type RemoteRuntimeDiscoveredMachine = {
   tailscaleAddress: string | null;
   runtimeKind: string | null;
   runtimeVersion: string | null;
+  os?: string;
+  connectable: boolean;
+  unsupportedReason?: string;
   projectIds: string[];
   projectCount: number | null;
   lastSeenAt: number;
@@ -140,6 +143,61 @@ export type RemoteRuntimeConnectionState =
   | "connected"
   | "error";
 
+export type RemoteRuntimeConnectErrorInfo = {
+  kind: "disk_full" | "ssh_auth" | "unsupported_os" | "generic";
+  message: string;
+  detail?: string;
+  freeBytes?: number;
+  requiredBytes?: number;
+};
+
+const REMOTE_RUNTIME_ERROR_DETAIL_MAX_CHARS = 4_000;
+const REMOTE_RUNTIME_ERROR_DETAIL_HEAD_CHARS = 3_000;
+const REMOTE_RUNTIME_ERROR_DETAIL_TAIL_CHARS = 1_000;
+
+export function capRemoteRuntimeErrorDetail(detail: string): string {
+  if (detail.length <= REMOTE_RUNTIME_ERROR_DETAIL_MAX_CHARS) return detail;
+  let tailChars = REMOTE_RUNTIME_ERROR_DETAIL_TAIL_CHARS;
+  let marker = "";
+  for (;;) {
+    const omitted = detail.length
+      - REMOTE_RUNTIME_ERROR_DETAIL_HEAD_CHARS
+      - tailChars;
+    marker = `\n… [truncated ${omitted} bytes] …\n`;
+    const nextTailChars = Math.min(
+      REMOTE_RUNTIME_ERROR_DETAIL_TAIL_CHARS,
+      REMOTE_RUNTIME_ERROR_DETAIL_MAX_CHARS
+        - REMOTE_RUNTIME_ERROR_DETAIL_HEAD_CHARS
+        - marker.length,
+    );
+    if (nextTailChars === tailChars) break;
+    tailChars = nextTailChars;
+  }
+  return `${detail.slice(0, REMOTE_RUNTIME_ERROR_DETAIL_HEAD_CHARS)}${marker}${detail.slice(-tailChars)}`;
+}
+
+export class RemoteRuntimeConnectError extends Error {
+  readonly info: RemoteRuntimeConnectErrorInfo;
+
+  constructor(info: RemoteRuntimeConnectErrorInfo, cause?: unknown) {
+    super(info.message);
+    this.name = "RemoteRuntimeConnectError";
+    this.info = {
+      ...info,
+      ...(info.detail
+        ? { detail: capRemoteRuntimeErrorDetail(info.detail) }
+        : {}),
+    };
+    if (cause !== undefined) {
+      Object.defineProperty(this, "cause", {
+        configurable: true,
+        enumerable: false,
+        value: cause,
+      });
+    }
+  }
+}
+
 export type RemoteRuntimeConnectionStatus = {
   target: RemoteRuntimeTarget;
   state: RemoteRuntimeConnectionState;
@@ -149,6 +207,7 @@ export type RemoteRuntimeConnectionStatus = {
   compatibilityWarnings?: string[];
   projects: RemoteRuntimeProjectRecord[];
   lastError: string | null;
+  lastErrorInfo?: RemoteRuntimeConnectErrorInfo | null;
   lastAttemptedAt: number | null;
   connectedAt: number | null;
 };

--- a/apps/desktop/src/shared/types/sync.ts
+++ b/apps/desktop/src/shared/types/sync.ts
@@ -15,6 +15,7 @@ import type {
   ExternalSessionSummary,
 } from "./externalSessions";
 import type { PtySendToSessionResult, TerminalSessionSummary } from "./sessions";
+import type { PairedRuntimeSyncEnvelope } from "./pairedRuntime";
 
 export type SyncScalarBytes = {
   type: "bytes";
@@ -1351,4 +1352,5 @@ export type SyncEnvelope =
   | SyncCommandEnvelope
   | SyncCommandAckEnvelope
   | SyncCommandResultEnvelope
-  | SyncEnvelopeChunkEnvelope;
+  | SyncEnvelopeChunkEnvelope
+  | PairedRuntimeSyncEnvelope;

--- a/apps/desktop/src/shared/types/sync.ts
+++ b/apps/desktop/src/shared/types/sync.ts
@@ -68,6 +68,11 @@ export type SyncPeerMetadata = {
    * back to `dbVersion` for older clients.
    */
   dbVersionBySite?: Record<string, number>;
+  /**
+   * Additive hello capabilities. `runtimeOnly` means the client consumes only
+   * rpc/fwd envelopes; hosts honor it only for an authenticated pairing record
+   * carrying the server-issued runtime-host grant.
+   */
   capabilities?: string[];
   appVersion?: string;
   appBuild?: string;

--- a/apps/desktop/src/shared/types/sync.ts
+++ b/apps/desktop/src/shared/types/sync.ts
@@ -599,6 +599,8 @@ export type SyncPairingQrPayload = {
   relayUrl?: string | null;
   /** Reserved for off-LAN pairing claims once the relay pairing flow ships. */
   claimToken?: string | null;
+  /** One-time host-issued authorization for desktop runtime RPC/forwarding. */
+  runtimeHostGrant?: string | null;
 };
 
 export type SyncPairingRequestPayload = {
@@ -609,6 +611,12 @@ export type SyncPairingRequestPayload = {
    * Stored with the pairing record so later hellos must prove possession.
    */
   dpopPublicKey?: string | null;
+  /**
+   * Short-lived, one-time server grant from a desktop-specific pairing link.
+   * A PIN and client-asserted desktop metadata alone never authorize runtime
+   * RPC or port forwarding.
+   */
+  runtimeHostGrant?: string | null;
 };
 
 export type SyncPairingResultPayload = {
@@ -1176,6 +1184,7 @@ export type SyncRemoteCommandAction =
   | "prs.reorderQueue"
   | "prs.getMobileSnapshot"
   | "sync.getWebPairingInfo"
+  | "sync.getDesktopPairingInfo"
   | "modelPicker.getFavorites"
   | "modelPicker.setFavorites"
   | "modelPicker.toggleFavorite"

--- a/docs/features/remote-runtime/README.md
+++ b/docs/features/remote-runtime/README.md
@@ -1,22 +1,34 @@
 # Remote Runtime
 
-The desktop app connects to an ADE runtime (`ade serve`) running on a remote machine over SSH. The remote project lives on that machine; lanes, PTYs, git, agent chat, and PR actions all run there. The local desktop is the controller — it spawns no project services of its own for a remote binding.
+The desktop app connects to an ADE runtime (`ade serve`) running on another
+machine. The remote project lives on that machine; lanes, PTYs, git, agent
+chat, and PR actions all run there. The local desktop is the controller — it
+spawns no project services of its own for a remote binding.
 
-The wire transport is the same JSON-RPC the local machine runtime answers. The remote-runtime layer just wraps it in an SSH `exec` channel running `ade rpc --stdio`.
+The recommended transport is **paired**: pair the two ADE desktops with a PIN
+and device-bound DPoP credentials, then carry the full runtime JSON-RPC over
+the machine sync WebSocket. ADE tries direct LAN routes, then tailnet routes,
+then the configured cloud relay. **SSH** remains the Advanced path and a
+fallback for paired targets that retain usable SSH routes and credentials. It
+runs the same JSON-RPC over an SSH `exec` channel using `ade rpc --stdio` and
+can upload or start the remote runtime when needed. The relay is not an
+end-to-end encrypted tunnel; see the trust boundary in
+[Internal architecture](internal-architecture.md).
 
 ## Source file map
 
-- `apps/desktop/src/main/services/remoteRuntime/` — SSH transport (multi-route
-  fallback, bounded connect/exec timeouts, normalized handshake errors),
-  runtime bootstrap, target registry (saved routes + per-route
-  `lastSucceededAt` plus manual-disconnect state), runtime RPC client
-  (timeouts treated as fatal), remote connection pool (eviction listeners,
-  retryable read-only actions and selected retryable sync reads, local TCP
-  forwards for remote preview URLs, optional-action fallbacks, event-stream
-  gap/epoch propagation), remote
-  connection service (`powerMonitor`-driven `probeSavedConnections`, explicit
-  connect vs implicit reconnect policy), `runtimeDiscovery.ts` (Bonjour +
-  Tailscale with `discoverLanRuntimes` returning `{ machines, diagnostics }`).
+- `apps/desktop/src/main/services/remoteRuntime/` — paired transport
+  (`syncRuntimeTransport.ts`), loopback preview forwarding
+  (`syncPortForwardClient.ts`), paired credential and endpoint history
+  (`syncPairedMachineStore.ts`), LAN → tailnet → relay ordering
+  (`pairedRuntimeRoutes.ts`), paired bootstrap and connection diagnostics;
+  plus the Advanced SSH transport (multi-route fallback, bounded connect/exec
+  timeouts, strict host-key verification, normalized handshake errors) and
+  runtime upload/bootstrap. The folder also owns the target registry, runtime
+  RPC client, remote connection pool (paired-first with eligible SSH fallback,
+  eviction listeners, retryable reads, preview forwards, optional-action
+  fallbacks, event-stream gap/epoch propagation), connection service, and
+  Bonjour + Tailscale discovery.
 - `apps/desktop/src/main/services/ipc/runtimeBridge.ts` — runtime IPC boundary:
   remote target registry, connect / projects / project-open channels, remote
   action/sync/event dispatch, local-runtime project action/sync/event routing,
@@ -34,14 +46,11 @@ The wire transport is the same JSON-RPC the local machine runtime answers. The r
   install/health state, and applies short per-call timeouts for project
   registration, file actions, and event polling so renderer IPC calls do not
   wait for the desktop handler timeout.
-- `apps/desktop/src/renderer/components/remoteTargets/` — remote machine form
-  (carries `routes` through saves), target list (Tailscale-preferred primary
-  route, "+ N routes" fallback hint, Tailscale/Bonjour discovery diagnostics
-  warning, and a yellow `Warning` strip for the
-  `compatibilityWarnings` the bootstrap returns for the selected
-  connection — version skew, channel mismatch, missing project
-  capabilities, runtime-home fallbacks), project picker, dirty-local-work
-  warning.
+- `apps/desktop/src/renderer/components/remoteTargets/` — Machines panel with
+  connected / available / unavailable sections, Pair and SSH entry paths,
+  share-this-machine and connection-doctor cards, saved/discovered machine
+  rows, route and latency status, SSH host-key trust, structured connection
+  errors, project picker, and the dirty-local-work warning.
 - `apps/desktop/src/renderer/components/projects/RemoteProjectOpenDialog.tsx` —
   confirmation dialog before opening a remote project, surfaces local matches
   with uncommitted changes.
@@ -88,17 +97,54 @@ The wire transport is the same JSON-RPC the local machine runtime answers. The r
 
 ## User model
 
-A **remote target** is a machine reachable by SSH. A **remote project** is a path on that machine that has been registered with that machine's ADE runtime (via `projects.add`). Opening a remote project does not copy local files or move a local lane; ADE controls the remote runtime and expects normal git workflow to move code between local and remote clones.
+A **remote target** is another ADE machine reachable through a paired sync
+route, SSH, or both. A paired target stores the machine identity and paired
+credentials separately from the saved target; the target may also retain SSH
+user, port, key, and route information for fallback. A **remote project** is a
+path on that machine that has been registered with its ADE runtime (via
+`projects.add`). Opening a remote project does not copy local files or move a
+local lane; ADE controls the remote runtime and expects normal git workflow to
+move code between local and remote clones.
 
 When opening a remote project, ADE checks local projects with the same git origin. If a matching local copy has uncommitted changes, ADE shows a confirmation dialog (`RemoteProjectOpenDialog`) before switching so the user can push, stash, or keep the divergent local work intentionally.
 
 ## Connect flow
 
-1. Add a machine from the remote machines panel or command palette. Discovered machines (LAN + Tailscale) prefill the form with the Tailscale FQDN as the primary host plus every other reachable route (LAN address, mDNS host, alt IPs) on the saved target so reconnects can fall back automatically.
-2. Enter a display name, hostname, SSH user, port, and optionally a private key path. If no key path is provided, ADE uses the user's local ssh-agent when `SSH_AUTH_SOCK` is available and reads matching `HostName` / `IdentityFile` entries from `~/.ssh/config`.
-3. Connect. If the machine's SSH host key has not been trusted on this Mac before, the Remote pane shows the key fingerprint and records the user's explicit "Trust & connect" decision in `known_hosts`; users should not need to run `ssh <host>` manually. ADE then opens an SSH session with a bounded handshake timeout, detects the remote platform with `uname -sm`, and starts `ade rpc --stdio`. If the primary host is unreachable, ADE walks alternate `routes` ranked by most-recent success and records the route that wins.
-4. If the bundled ADE runtime for that platform is present and the remote ADE binary is missing, stale, or hash-mismatched, ADE uploads `ade-<platform-arch>` to `~/.ade/bin/ade` (or the matching channel home), uploads native dependencies to `~/.ade/runtime/<platform-arch>/`, uploads the PTY host worker used by remote terminals, uploads bundled ADE agent skills to `<ADE_HOME>/agent-skills`, and verifies `~/.ade/bin/ade --version`. Uploads prefer SFTP and fall back to bounded SSH chunk uploads / OpenSSH when needed. The skills upload is content-hashed and skipped when the remote `<ADE_HOME>/agent-skills.sha256` marker is current, so remote `ade skill` and agent launches see the same version-locked ADE skills as the desktop bundle. If the desktop has no bundled binary for that arch, bootstrap probes the alternate channel homes (`.ade`, `.ade-alpha`, `.ade-beta`) for a working `ade` and uses whichever already serves a compatible RPC; the chosen home is recorded as a `compatibilityWarnings` entry so the UI explains why a non-default home was used.
-5. Pick an existing remote project or register a new remote path; the desktop
+1. Open the Machines panel. ADE combines Bonjour and Tailscale discovery,
+   removes this machine's own Bonjour advertisement, and merges routes that
+   identify the same machine. Discovered paired-capable ADE desktops appear in
+   Available; offline or unsupported machines remain visible in Unavailable.
+2. Use **Pair** for the normal flow. Paste or scan the machine's pairing link or
+   code, enter its six-digit PIN, and let ADE save the machine identity, DPoP
+   key, and advertised direct/relay endpoints. A discovered machine with an
+   existing pairing is upgraded to a paired target automatically.
+3. Connect. ADE dials paired routes in LAN → tailnet → relay order, preferring a
+   recently successful endpoint within each class. After authenticated
+   `hello_ok`, it requires `features.rpcChannel === true`, opens the runtime
+   JSON-RPC channel, and uses the paired port-forward channel for remote preview
+   URLs. The connected status reports the winning route and latency. A relay
+   route is a trusted-operator plaintext-readable path, not a confidential
+   channel.
+4. If paired dialing fails, or the remote runtime does not support the paired
+   RPC channel, ADE silently falls back to SSH only when that paired target has
+   usable SSH routes and credentials. SSH host-key trust is requested only
+   after fallback is actually needed; it is never pre-trusted or prompted
+   before the paired attempt.
+5. Use **SSH** under Advanced to configure or connect directly: enter a display
+   name, hostname, SSH user, port, and optional private key path. With no key
+   path, ADE uses the local ssh-agent when `SSH_AUTH_SOCK` is available and
+   matching `HostName` / `IdentityFile` entries from `~/.ssh/config`. An unknown
+   host key is shown with its fingerprint and requires explicit **Trust &
+   connect** approval before it is recorded in `known_hosts`.
+6. On an SSH connection, ADE detects the remote platform with `uname -sm` and
+   starts `ade rpc --stdio`. If the bundled runtime is present locally and the
+   remote binary is missing, stale, or hash-mismatched, ADE uploads the binary,
+   native dependencies, PTY worker, and bundled agent skills into the matching
+   ADE channel home, then verifies the runtime. Uploads prefer SFTP and fall
+   back to bounded SSH chunk uploads / OpenSSH. Without a bundled binary, ADE
+   probes alternate channel homes for a compatible installed runtime and
+   reports the selected fallback as a compatibility warning.
+7. Pick an existing remote project or register a new remote path; the desktop
    calls `projects.add { rootPath }` against the remote runtime to bind it.
    If the same window starts multiple remote opens concurrently, both preload
    and the main IPC bridge keep only the latest open as the durable binding.

--- a/docs/features/remote-runtime/internal-architecture.md
+++ b/docs/features/remote-runtime/internal-architecture.md
@@ -103,6 +103,31 @@ Desktop sync Settings IPC first talks to the active runtime for status, discover
 
 The sync command registry labels descriptors as `runtime` or `project` scope. Project-bound runtimes reject project-scoped commands that arrive without a matching `projectId`, while runtime-scoped commands operate on the ADE runtime as a whole. This keeps mobile/controller commands explicit in the multi-project runtime.
 
+## Paired transport & relay trust boundary
+
+Besides SSH, a remote target can use the **paired** transport: after PIN + DPoP
+pairing, the full runtime JSON-RPC rides the sync WebSocket as newline-delimited
+frames inside `rpc_*` envelopes, and loopback TCP previews ride `fwd_*`
+envelopes (host-side connect restricted to `127.0.0.1`). Both are gated to
+desktop runtime-host peers: the host only opens the RPC channel / port-forward
+for a peer that authenticated with `kind: "paired"` **and** advertised
+`deviceType: "desktop"`. Paired phones and browsers stay on the mobile command
+allowlist — a non-desktop paired peer that sends `rpc_open`/`fwd_open` gets the
+channel closed with "Runtime channel is only available to desktop clients", and
+`hello_ok` advertises `features.rpcChannel`/`features.portForward` as `false`
+for them. The host also caps concurrent channels per peer (32 RPC channels, 64
+forwards) so an authenticated peer cannot exhaust file descriptors or memory.
+
+**Relay trust boundary.** The sync WebSocket can reach the host over a direct
+LAN/tailnet route or through the cloud tunnel-relay. The relay is a plaintext
+byte pipe: TLS terminates *at* the relay and there is no end-to-end encryption
+between the two ADE machines. Over a relay route the relay operator can read all
+runtime RPC payloads and the paired `secret` that transits in the `hello`.
+Direct LAN/tailnet routes do not transit the relay and are not exposed to it.
+DPoP proof-of-possession protects against host impersonation only when a stored
+enclave key exists for the target; without one, DPoP cannot be asserted. Treat
+relay routes as trusted-operator paths, not confidential channels.
+
 ## Local runtime routing
 
 Local desktop windows go through the runtime binding. `callProjectRuntimeActionOr` and `callProjectRuntimeSyncOr` in `apps/desktop/src/preload/preload.ts` call the active local or remote runtime when a binding exists; legacy Electron IPC handlers are used only when no runtime route is bound or for desktop-only side effects. File actions are strict once a local or remote runtime is bound, which prevents a failed runtime-bound file write/read from being retried against the desktop's local filesystem when the bound project is owned by a daemon or remote host. Usage and budget reads use the remote runtime only for remote-bound windows; local-bound windows keep using desktop usage IPC. During `project.switchToPath`, preload temporarily binds local runtime calls to the requested root and main-process `runtimeBridge.ts` honors the explicit `rootPath` over the window session binding for local action, sync, and event-stream calls. During `remoteRuntime.openProject`, preload clears the binding while the switch is in flight; mutating runtime actions and mutating sync calls fail with the "Project is switching" message instead of refreshing or writing through a stale binding, while read-only project calls can wait for the active remote open and retry against the new binding.

--- a/docs/features/remote-runtime/internal-architecture.md
+++ b/docs/features/remote-runtime/internal-architecture.md
@@ -110,13 +110,15 @@ pairing, the full runtime JSON-RPC rides the sync WebSocket as newline-delimited
 frames inside `rpc_*` envelopes, and loopback TCP previews ride `fwd_*`
 envelopes (host-side connect restricted to `127.0.0.1`). Both are gated to
 desktop runtime-host peers: the host only opens the RPC channel / port-forward
-for a peer that authenticated with `kind: "paired"` **and** advertised
-`deviceType: "desktop"`. Paired phones and browsers stay on the mobile command
-allowlist — a non-desktop paired peer that sends `rpc_open`/`fwd_open` gets the
-channel closed with "Runtime channel is only available to desktop clients", and
-`hello_ok` advertises `features.rpcChannel`/`features.portForward` as `false`
-for them. The host also caps concurrent channels per peer (32 RPC channels, 64
-forwards) so an authenticated peer cannot exhaust file descriptors or memory.
+for a peer that authenticated with `kind: "paired"` **and** whose authoritative
+stored pairing record has `peerDeviceType: "desktop"`. The device type claimed
+in `hello.peer` is metadata, not authorization: a paired phone or browser that
+reconnects while claiming `deviceType: "desktop"` still stays on the mobile
+command allowlist. If it sends `rpc_open`/`fwd_open`, the host closes the channel
+with "Runtime channel is only available to desktop clients", and `hello_ok`
+advertises `features.rpcChannel`/`features.portForward` as `false`. The host also
+caps concurrent channels per peer (32 RPC channels, 64 forwards) so an
+authenticated peer cannot exhaust file descriptors or memory.
 
 **Relay trust boundary.** The sync WebSocket can reach the host over a direct
 LAN/tailnet route or through the cloud tunnel-relay. The relay is a plaintext
@@ -124,9 +126,11 @@ byte pipe: TLS terminates *at* the relay and there is no end-to-end encryption
 between the two ADE machines. Over a relay route the relay operator can read all
 runtime RPC payloads and the paired `secret` that transits in the `hello`.
 Direct LAN/tailnet routes do not transit the relay and are not exposed to it.
-DPoP proof-of-possession protects against host impersonation only when a stored
-enclave key exists for the target; without one, DPoP cannot be asserted. Treat
-relay routes as trusted-operator paths, not confidential channels.
+DPoP proves to the host that the connecting client possesses the private key
+registered for that paired device; it protects the host from replay with only a
+stolen paired secret. It does not authenticate the host to the client or prevent
+a relay operator from impersonating the host. Treat relay routes as
+trusted-operator paths, not confidential channels.
 
 ## Local runtime routing
 

--- a/docs/features/remote-runtime/internal-architecture.md
+++ b/docs/features/remote-runtime/internal-architecture.md
@@ -111,9 +111,11 @@ frames inside `rpc_*` envelopes, and loopback TCP previews ride `fwd_*`
 envelopes (host-side connect restricted to `127.0.0.1`). Both are gated to
 desktop runtime-host peers: the host only opens the RPC channel / port-forward
 for a peer that authenticated with `kind: "paired"` **and** whose authoritative
-stored pairing record has `peerDeviceType: "desktop"`. The device type claimed
-in `hello.peer` is metadata, not authorization: a paired phone or browser that
-reconnects while claiming `deviceType: "desktop"` still stays on the mobile
+stored pairing record has `runtimeHostGranted: true`. The Share Machine link
+carries a short-lived, one-time server grant that is consumed only after the
+PIN succeeds. The device type claimed in `hello.peer` is metadata, not
+authorization: a paired phone or browser that reconnects while claiming
+`deviceType: "desktop"` still stays on the mobile
 command allowlist. If it sends `rpc_open`/`fwd_open`, the host closes the channel
 with "Runtime channel is only available to desktop clients", and `hello_ok`
 advertises `features.rpcChannel`/`features.portForward` as `false`. The host also

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -893,7 +893,7 @@ payload.
 | Command routing | Send named actions (`chat.send`, `lanes.create`, `git.push`, `prs.getMobileSnapshot`, `work.listExternalSessions`, `work.importExternalSession`, etc.) | Controller devices |
 | Project switching | `project_catalog` + `project_switch_request/result` for multi-project runtimes | iOS project home |
 | Project actions | Runtime-scoped project browser plus open/create/clone/list-GitHub-repos/default-parent-dir/forget envelopes. Available from the active project host or the machine-wide fallback handler before a project is selected | iOS project home |
-| Paired desktop runtime | Full newline-delimited runtime JSON-RPC over `rpc_open` / `rpc_data` / `rpc_close`, plus host-loopback TCP previews over `fwd_open` / `fwd_data` / `fwd_close`. The host advertises both channels only to a paired peer whose stored pairing record identifies it as a desktop runtime host | ADE desktop remote machines |
+| Paired desktop runtime | Full newline-delimited runtime JSON-RPC over `rpc_open` / `rpc_data` / `rpc_close`, plus host-loopback TCP previews over `fwd_open` / `fwd_data` / `fwd_close`. The host advertises both channels only when pairing consumed a short-lived, one-time server grant from the Share Machine link; client-claimed device metadata never authorizes them | ADE desktop remote machines |
 | Runtime status | Runtime broadcasts cluster/version status (`brain_status` is the legacy envelope name) | All devices |
 | Lane presence | Controllers call `lanes.presence.announce` / `lanes.presence.release`; the runtime decorates `LaneSummary.devicesOpen` for 60 s TTL | iOS Lanes tab; desktop runtime presence heartbeat |
 

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -482,8 +482,9 @@ Canonical files (`apps/ade-cli/src/services/sync/`):
   cloud relay is enabled it keeps an outbound WebSocket registered with
   the relay worker (HMAC-signed host/pipe upgrades, exponential backoff
   with jitter capped at 60 s) so phones off the LAN/tailnet can dial the
-  machine through the relay; the normal ADE sync hello/pairing then runs
-  end-to-end over the piped connection.
+  machine through the relay; the normal ADE sync hello/pairing then runs inside
+  that pipe. TLS terminates at the relay, so the relay can inspect the handshake
+  and subsequent sync traffic.
 
 Push publisher (`apps/ade-cli/src/services/push/`) — the APNs push +
 Live Activity pipeline (`pushPublisherService.ts`,
@@ -796,6 +797,8 @@ Envelopes are JSON with fields:
         "project_catalog_chunk" |
         "project_switch_request" | "project_switch_result" |
         "command" | "command_ack" | "command_result" |
+        "rpc_open" | "rpc_data" | "rpc_close" |
+        "fwd_open" | "fwd_data" | "fwd_close" |
         "envelope_chunk",
   projectId?: string | null, // present on project-scoped envelopes
   requestId: string | null,
@@ -805,6 +808,15 @@ Envelopes are JSON with fields:
   uncompressedBytes?: number, // gzip only
 }
 ```
+
+Envelope types and `hello_ok.features` keys are additive within protocol
+version 1. Receivers decode the common envelope first and dispatch only the
+types they implement; an otherwise valid unknown type is ignored rather than
+closing the connection. This is how iOS and hosted-web clients safely coexist
+with the desktop-only `rpc_*` and `fwd_*` extensions. The paired desktop treats
+missing `features.rpcChannel` or `features.portForward` exactly like `false` and
+does not attempt that channel, while legacy phone/browser clients continue on
+their existing mobile command surface when those keys are absent or present.
 
 Payloads above `DEFAULT_SYNC_COMPRESSION_THRESHOLD_BYTES` (4 KB) are
 gzipped and base64-encoded. `parseSyncEnvelope` caps gzip inflate at
@@ -881,6 +893,7 @@ payload.
 | Command routing | Send named actions (`chat.send`, `lanes.create`, `git.push`, `prs.getMobileSnapshot`, `work.listExternalSessions`, `work.importExternalSession`, etc.) | Controller devices |
 | Project switching | `project_catalog` + `project_switch_request/result` for multi-project runtimes | iOS project home |
 | Project actions | Runtime-scoped project browser plus open/create/clone/list-GitHub-repos/default-parent-dir/forget envelopes. Available from the active project host or the machine-wide fallback handler before a project is selected | iOS project home |
+| Paired desktop runtime | Full newline-delimited runtime JSON-RPC over `rpc_open` / `rpc_data` / `rpc_close`, plus host-loopback TCP previews over `fwd_open` / `fwd_data` / `fwd_close`. The host advertises both channels only to a paired peer whose stored pairing record identifies it as a desktop runtime host | ADE desktop remote machines |
 | Runtime status | Runtime broadcasts cluster/version status (`brain_status` is the legacy envelope name) | All devices |
 | Lane presence | Controllers call `lanes.presence.announce` / `lanes.presence.release`; the runtime decorates `LaneSummary.devicesOpen` for 60 s TTL | iOS Lanes tab; desktop runtime presence heartbeat |
 
@@ -998,9 +1011,10 @@ feature is merged or because a deliberately isolated-port host is running.
   Phones prefer direct routes when they are currently usable; when an
   iPhone has no Tailscale tunnel and holds a saved relay URL, reconnect
   dials the relay ahead of stale saved LAN/Tailscale sweeps. The relay
-  only pipes bytes: the normal ADE hello / PIN / paired-secret / DPoP
-  handshake still runs end-to-end, so the relay never sees pairing
-  credentials in the clear.
+  pipes WebSocket bytes after terminating TLS. The normal ADE hello / PIN /
+  paired-secret / DPoP handshake still runs inside that pipe, but it is not
+  end-to-end encrypted: the relay can read paired secrets and runtime/sync
+  payloads. Treat the relay operator as trusted for confidentiality.
   The `machineKey` is an unguessable 32-hex identifier and the tunnel
   upgrades are HMAC-signed with a per-machine secret. Operators who
   never want traffic relayed flip the single "ADE relay" control in

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -584,6 +584,13 @@ Implemented envelope types on iOS:
 | `heartbeat` | Bidirectional | Connection health (30s) |
 | `brain_status` | Runtime → phone | Legacy-named cluster authority broadcast |
 
+Protocol version 1 is additive. The phone decodes the common envelope and its
+string `type`, then ignores types it does not implement. In particular,
+desktop-only `rpc_*` and `fwd_*` envelopes do not fail or disconnect an iOS
+client. `hello_ok.features` is also read additively: missing flags resolve to
+unsupported/limited behavior, so an older host or a newer host advertising
+desktop-only flags does not break the mobile handshake.
+
 Gzip decompression uses the system `zlib` module. `unwrapSyncCommandResponse`
 turns a raw response dict into either the `result` value or throws an
 `NSError` with `ADEErrorCode` when `ok: false`.

--- a/docs/features/web-client/README.md
+++ b/docs/features/web-client/README.md
@@ -201,6 +201,11 @@ Tests:
 - **The browser has no ADE database.** It does not load cr-sqlite, does not
   apply changesets, and does not advertise the `changesetAck` capability. A
   `changeset_batch` only tells the adapter which table domains to refresh.
+- **Protocol version 1 extensions are additive.** The browser decodes the
+  common envelope and ignores valid types it does not implement, including the
+  desktop-only `rpc_*` and `fwd_*` channels. Unknown `hello_ok.features` keys
+  are harmless, and missing additive keys mean the related capability is not
+  available rather than failing the handshake.
 - **IndexedDB is the pairing store.** Clearing site data removes the paired
   secret and the non-extractable DPoP private key, so the browser must pair
   again. The private key cannot be exported for backup or migration.


### PR DESCRIPTION
## Summary

- add authenticated desktop-to-desktop runtime RPC and loopback port forwarding over the sync WebSocket
- connect paired machines over LAN, tailnet, then relay with explicit route status and SSH fallback
- redesign the Machines panel, harden device authorization and channel limits, and preserve/forget credentials correctly
- fix SSH trust recording for discovered display names found during live Electron validation

## Validation

- desktop typecheck, lint, production build, and all 8 CI-style test shards
- ADE CLI typecheck, build, and full 1,626-test suite
- targeted remote/UI suite: 176 passing; 2 environment-gated socket tests skipped by design
- real-WebSocket spoofing regressions for phone records claiming desktop capabilities
- live Electron discovery/trust exercise against MacBook Pro (97); trust and route handling passed, but end-to-end pairing/PTY/relay could not be completed because both installed background services predate the pairing RPC and the MacBook rejected available SSH identities

## Security follow-up

The new desktop pairing store matches the existing sync secret stores (0600 plaintext). Moving all sync pairing material to OS-backed encrypted storage remains a separate cross-cutting migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added desktop pairing for remote runtimes, including QR/link-based setup and secure runtime connections.
  * Added local machine sharing with QR codes, pairing details, and copy actions.
  * Added remote machine discovery across LAN and Tailnet, with connection status and route information.
  * Added connection diagnostics for testing LAN, Tailnet, relay, and SSH routes.
  * Added paired runtime port forwarding and improved SSH fallback support.
* **Bug Fixes**
  * Improved connection errors with clearer messages, technical details, retry actions, host-key trust prompts, and disk-space reporting.
  * Prevented unsupported or unauthorized devices from opening runtime channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces authenticated desktop-to-desktop runtime RPC and loopback port forwarding over the existing sync WebSocket, adds a new Machines panel with QR-based pairing, discovers remotes over LAN/tailnet/relay with route status, and hardens device authorization with DPoP-backed credentials and server-issued one-time runtime-host grants.

- **New sync channel multiplexer** (`syncPairedChannelService.ts`): routes `rpc_*` and `fwd_*` envelopes to per-peer JSON-RPC servers and loopback TCP sockets, with per-peer caps (32 RPC channels, 64 forwards) and explicit authorization gates requiring both a `paired` auth kind and a server-issued `runtimeHostGranted` flag.
- **Desktop credential store** (`syncPairedMachineStore.ts`): persists paired-machine credentials and orchestrates the full pairing handshake (PIN \u2192 `pairing_result` \u2192 `hello_ok`) before writing final credentials.
- **Transport and port-forward client** (`syncRuntimeTransport.ts`, `syncPortForwardClient.ts`): opens an authenticated WebSocket, verifies host identity against stored credentials, opens an RPC channel, and proxies loopback TCP traffic with outbound backpressure via socket pause/resume.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the authorization layering (one-time server-issued grant + PIN + DPoP + deviceType check) is sound and well-tested.

All four gate paths (authentication, authorization, channel limits, and data validation) are correctly implemented. The noted issues are design-level robustness concerns that do not cause incorrect behavior in the normal single-client pairing flow.

apps/ade-cli/src/services/sync/syncPairingStore.ts (TOCTOU in grant consumption), apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts (missing dispose path), apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts (unbounded endpoint accumulation).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/services/sync/syncPairedChannelService.ts | New service multiplexing authenticated RPC and port-forward channels per peer; resource caps and authorization guards are correct, but no dispose handle is exposed to brainProjectActionsSyncHandler. |
| apps/ade-cli/src/services/sync/syncPairingStore.ts | Adds one-time runtime-host grant tokens stored as hashed values with TTL; the consumeRuntimeHostGrant read-validate-write cycle has a narrow TOCTOU race under concurrent pairing requests. |
| apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts | Correctly routes paired-runtime envelopes and gates RPC/forward on runtimeHostGranted; lacks a dispose hook for the shared pairedChannelService. |
| apps/desktop/src/main/services/remoteRuntime/syncRuntimeTransport.ts | DPoP authentication, host identity verification, and RPC channel lifecycle are correctly implemented with clean callback isolation. |
| apps/desktop/src/main/services/remoteRuntime/syncPairedMachineStore.ts | Thorough coercion, deduplication, and endpoint-state merging; replaceConnectionMetadata path correctly replaces relay info from the hello payload. |
| apps/desktop/src/main/services/remoteRuntime/syncPortForwardClient.ts | Outbound backpressure is properly handled but inbound direction terminates under load rather than throttling the remote sender. |
| apps/desktop/src/main/services/remoteRuntime/pairedRuntimeBootstrap.ts | Iterates ordered endpoint candidates (LAN to tailnet to relay), verifies feature flags before committing, and updates relay metadata correctly. |
| apps/desktop/src/main/services/remoteRuntime/remoteConnectionService.ts | Extended with pairing, doctor, and discovered-machine flows; stale endpoint accumulation in rememberDiscoveredMachines is a maintenance concern. |
| apps/ade-cli/src/services/sync/syncHostService.ts | Correctly integrates pairedChannelService with explicit dispose in stop and host-change handlers, runtime-host gating, and CRDT stream skip for runtime-only peers. |
| apps/desktop/src/main/services/remoteRuntime/runtimeDiscovery.ts | Adds Windows connectable=false gating, cross-source Bonjour/Tailscale deduplication, and self-machine filtering; logic is sound and well-tested. |

<sub>Reviews (6): Last reviewed commit: ["ship: iteration 5 — finalize remote reli..."](https://github.com/arul28/ade/commit/3c99917f4ffc0de1651cec8be6e50f669693b439) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43225067)</sub>

<!-- /greptile_comment -->