### PR TITLE
Fix copying text from macOS CLI terminals

### DIFF
--- a/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx
@@ -1364,10 +1364,12 @@ describe("TerminalView", () => {
       const terminal = mockState.terminalInstances.at(-1) as {
         attachCustomKeyEventHandler: ReturnType<typeof vi.fn>;
         getSelection: ReturnType<typeof vi.fn>;
+        options: Record<string, unknown>;
       } | undefined;
       const keyHandler = terminal?.attachCustomKeyEventHandler.mock.calls.at(-1)?.[0] as ((ev: KeyboardEvent) => boolean) | undefined;
       expect(keyHandler).toBeTruthy();
       terminal!.getSelection.mockReturnValue("selected terminal text");
+      expect(terminal!.options.macOptionClickForcesSelection).toBe(true);
 
       const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
       const writeClipboardText = window.ade.app.writeClipboardText as unknown as ReturnType<typeof vi.fn>;
@@ -1683,76 +1685,79 @@ describe("TerminalView", () => {
     });
   });
 
-  it("leaves Shift+mouse gestures available for local selection while terminal mouse tracking is active", async () => {
-    render(<TerminalView ptyId="pty-shift-mouse" sessionId="session-shift-mouse" isActive />);
-    await flushAllTimers();
-
-    const terminal = mockState.terminalInstances.at(-1) as {
-      element: HTMLElement | null;
-    } | undefined;
-    expect(terminal?.element).toBeTruthy();
-
-    const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
-    ptyWrite.mockClear();
-
-    const ignoredDown = new MouseEvent("mousedown", {
-      bubbles: true,
-      cancelable: true,
-      shiftKey: true,
-      button: 0,
-      buttons: 1,
-      clientX: 0,
-      clientY: 0,
-    });
-    terminal!.element!.dispatchEvent(ignoredDown);
-    expect(ignoredDown.defaultPrevented).toBe(false);
-    expect(ptyWrite).not.toHaveBeenCalled();
-
-    for (const listener of mockState.ptyDataListeners) {
-      listener({
-        ptyId: "pty-shift-mouse",
-        sessionId: "session-shift-mouse",
-        projectRoot: "/project/a",
-        data: "\x1b[?1000h\x1b[?1002h\x1b[?1006h",
+  it("lets macOS Shift+drag select text while a remote CLI tracks the mouse", async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(window.navigator, "platform");
+    const originalPlatform = window.navigator.platform;
+    try {
+      Object.defineProperty(window.navigator, "platform", {
+        configurable: true,
+        value: "MacIntel",
       });
+
+      render(<TerminalView ptyId="pty-shift-mouse" sessionId="session-shift-mouse" isActive />);
+      await flushAllTimers();
+
+      const terminal = mockState.terminalInstances.at(-1) as {
+        element: HTMLElement | null;
+        options: Record<string, unknown>;
+      } | undefined;
+      expect(terminal?.element).toBeTruthy();
+      expect(terminal?.options.macOptionClickForcesSelection).toBe(true);
+
+      const ptyWrite = window.ade.pty.write as unknown as ReturnType<typeof vi.fn>;
+      ptyWrite.mockClear();
+      const mouseDowns: Array<{ altKey: boolean; shiftKey: boolean }> = [];
+      terminal!.element!.addEventListener("mousedown", (event) => {
+        mouseDowns.push({ altKey: event.altKey, shiftKey: event.shiftKey });
+      });
+
+      const ordinarySelection = new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        shiftKey: true,
+        button: 0,
+        buttons: 1,
+      });
+      terminal!.element!.dispatchEvent(ordinarySelection);
+      expect(ordinarySelection.defaultPrevented).toBe(false);
+      expect(mouseDowns).toEqual([{ altKey: false, shiftKey: true }]);
+
+      for (const listener of mockState.ptyDataListeners) {
+        listener({
+          ptyId: "pty-shift-mouse",
+          sessionId: "session-shift-mouse",
+          projectRoot: "/project/a",
+          data: "\x1b[?1000h\x1b[?1002h\x1b[?1006h",
+        });
+      }
+
+      const forcedSelection = new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        shiftKey: true,
+        button: 0,
+        buttons: 1,
+        clientX: 64,
+        clientY: 72,
+      });
+      terminal!.element!.dispatchEvent(forcedSelection);
+
+      expect(forcedSelection.defaultPrevented).toBe(true);
+      expect(mouseDowns).toEqual([
+        { altKey: false, shiftKey: true },
+        { altKey: true, shiftKey: false },
+      ]);
+      expect(ptyWrite).not.toHaveBeenCalled();
+    } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(window.navigator, "platform", platformDescriptor);
+      } else {
+        Object.defineProperty(window.navigator, "platform", {
+          configurable: true,
+          value: originalPlatform,
+        });
+      }
     }
-
-    const down = new MouseEvent("mousedown", {
-      bubbles: true,
-      cancelable: true,
-      shiftKey: true,
-      button: 0,
-      buttons: 1,
-      clientX: 0,
-      clientY: 0,
-    });
-    terminal!.element!.dispatchEvent(down);
-
-    const move = new MouseEvent("mousemove", {
-      bubbles: true,
-      cancelable: true,
-      shiftKey: true,
-      buttons: 1,
-      clientX: 64,
-      clientY: 72,
-    });
-    document.dispatchEvent(move);
-
-    const up = new MouseEvent("mouseup", {
-      bubbles: true,
-      cancelable: true,
-      shiftKey: true,
-      button: 0,
-      buttons: 0,
-      clientX: 64,
-      clientY: 72,
-    });
-    document.dispatchEvent(up);
-
-    expect(down.defaultPrevented).toBe(false);
-    expect(move.defaultPrevented).toBe(false);
-    expect(up.defaultPrevented).toBe(false);
-    expect(ptyWrite).not.toHaveBeenCalled();
   });
 
   it("falls back to native image paste when macOS Cmd+V does not fire a paste event", async () => {

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -12,6 +12,7 @@ import {
   type ThemeId,
 } from "../../state/appStore";
 import { WORK_SURFACE_REVEALED_EVENT } from "./workSurfaceVisibility";
+import { installMacShiftSelectionBridge } from "./terminalMacShiftSelection";
 import { openUrlInAdeBrowser } from "../../lib/openExternal";
 import { peekPendingSessionAnchor, takePendingSessionAnchor } from "./pendingSessionAnchors";
 import type {
@@ -110,6 +111,7 @@ type CachedRuntime = {
   imagePasteMode: TerminalImagePasteMode;
   bracketedPasteMode: boolean;
   mouseTrackingModes: Set<number>;
+  macShiftSelectionCleanup: (() => void) | null;
   // Set when a webgl→dom fallback is in flight and the runtime turned
   // invisible before the webgl restore could run. Persists across renderer
   // changes so the restore can be retried on the next visibility-true.
@@ -1088,6 +1090,7 @@ function teardownRuntime(runtime: CachedRuntime) {
   if (runtime.hydrateRetryTimer) clearTimeout(runtime.hydrateRetryTimer);
   if (runtime.hydrationBackfillTimer) clearTimeout(runtime.hydrationBackfillTimer);
   if (runtime.invalidFitRetryTimer) clearTimeout(runtime.invalidFitRetryTimer);
+  runtime.macShiftSelectionCleanup?.();
 
   try {
     runtime.ptyDataUnsub?.();
@@ -1918,6 +1921,7 @@ function createRuntime(args: {
     // box-drawing borders survive WebGL anti-aliasing without washing out the
     // intended dim/comment palette.
     minimumContrastRatio: 1.1,
+    macOptionClickForcesSelection: true,
     theme: args.theme
   });
 
@@ -1989,6 +1993,7 @@ function createRuntime(args: {
     imagePasteMode: args.imagePasteMode,
     bracketedPasteMode: false,
     mouseTrackingModes: new Set(),
+    macShiftSelectionCleanup: null,
     pendingWebGLRestore: false,
     invalidFitRetryTimer: null,
     fitWarningLogged: false,
@@ -2011,6 +2016,11 @@ function createRuntime(args: {
     }
     void pasteClipboardImageShortcut(runtime, runtime.imagePasteMode);
   }, true);
+  runtime.macShiftSelectionCleanup = installMacShiftSelectionBridge({
+    host,
+    isDisposed: () => runtime.disposed,
+    isMouseTrackingActive: () => isTerminalMouseTrackingActive(runtime),
+  });
 
   term.attachCustomKeyEventHandler((ev) => {
     if (!runtime.inputEnabled) return false;

--- a/apps/desktop/src/renderer/components/terminals/terminalMacShiftSelection.ts
+++ b/apps/desktop/src/renderer/components/terminals/terminalMacShiftSelection.ts
@@ -1,0 +1,46 @@
+export type MacShiftSelectionBridgeArgs = {
+  host: HTMLElement;
+  isDisposed: () => boolean;
+  isMouseTrackingActive: () => boolean;
+  platform?: string;
+};
+
+export function installMacShiftSelectionBridge({
+  host,
+  isDisposed,
+  isMouseTrackingActive,
+  platform = navigator.platform,
+}: MacShiftSelectionBridgeArgs): () => void {
+  if (!platform.toLowerCase().includes("mac")) return () => {};
+
+  const onMouseDown = (event: MouseEvent) => {
+    if (isDisposed() || !isMouseTrackingActive()) return;
+    if (!event.shiftKey || event.altKey || event.ctrlKey || event.metaKey || event.button !== 0) return;
+    const target = event.target;
+    if (!(target instanceof EventTarget)) return;
+
+    // xterm forces selection with Shift on other platforms, but on macOS it
+    // only recognizes Option when macOptionClickForcesSelection is enabled.
+    // Translate the initial gesture so remote/full-screen CLI mouse tracking
+    // does not make terminal text impossible to select and copy.
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    target.dispatchEvent(new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+      composed: event.composed,
+      detail: event.detail,
+      screenX: event.screenX,
+      screenY: event.screenY,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      altKey: true,
+      button: event.button,
+      buttons: event.buttons,
+      relatedTarget: event.relatedTarget,
+    }));
+  };
+
+  host.addEventListener("mousedown", onMouseDown, true);
+  return () => host.removeEventListener("mousedown", onMouseDown, true);
+}

--- a/docs/features/terminals-and-sessions/README.md
+++ b/docs/features/terminals-and-sessions/README.md
@@ -397,8 +397,16 @@ Renderer surfaces:
   and bracketed-pasting a short path/type stub into the PTY, while standalone
   terminals keep the native clipboard-image shortcut behavior. Selected terminal
   text copies through the local desktop clipboard bridge (with browser clipboard
-  fallback for previews), and Shift+drag remains available for local text
-  selection when a full-screen CLI enables terminal mouse tracking.
+  fallback for previews). Shift+drag remains available for local text
+  selection when a full-screen CLI enables terminal mouse tracking; on macOS,
+  ADE translates that gesture to xterm's Option-based force-selection path so
+  remote and local CLI sessions behave the same.
+- `apps/desktop/src/renderer/components/terminals/terminalMacShiftSelection.ts`
+  — macOS-only capture bridge used by `TerminalView`. While terminal mouse
+  tracking is active, it converts an unmodified left-button Shift+mousedown
+  into the Option+mousedown gesture recognized by xterm when
+  `macOptionClickForcesSelection` is enabled, preserving local text selection
+  without forwarding the gesture to the CLI.
 - `apps/desktop/src/renderer/components/terminals/workSessionTiling.ts` —
   pure helper that produces the seed `PaneSplit` for the Work grid from
   an ordered list of session IDs. Accepts a `TilingPreset` of

--- a/docs/features/terminals-and-sessions/ui-surfaces.md
+++ b/docs/features/terminals-and-sessions/ui-surfaces.md
@@ -510,13 +510,14 @@ Key behaviors:
   120 attempts) until the DOM reports renderable text. The backfill
   also re-arms whenever the tile becomes visible but the xterm rows
   are empty (e.g. after a webgl→dom fallback).
-- **Mouse tracking forwarding** — `TerminalView` tracks DECSET 1000 /
-  1002 / 1003 (SGR mouse modes) by scanning every PTY data chunk via
-  `updateTerminalMouseTrackingModes`. When the embedded TUI has mouse
-  tracking enabled, the renderer installs a Shift-mouse bridge
-  (`installShiftMouseBridge`) that forwards Shift-click + drag as SGR
-  mouse press/move/release sequences so users can drive in-app mouse UIs
-  through the surrounding xterm.
+- **Mouse tracking and forced selection** — `TerminalView` tracks DECSET 1000 /
+  1002 / 1003 mouse modes by scanning every PTY data chunk via
+  `updateTerminalInputModes`, alongside xterm's own mouse-tracking state.
+  xterm continues to forward ordinary mouse input to the embedded TUI. On
+  macOS, `terminalMacShiftSelection.ts` converts left-button Shift+mousedown
+  to xterm's Option-based force-selection gesture only while mouse tracking is
+  active, so local text selection and copy remain available without sending
+  that gesture to the CLI.
 - **Cmd+C → SIGINT on macOS** — when the terminal is focused on macOS,
   ⌘C with no current selection sends `\x03` to the PTY (matches the
   Terminal.app behaviour TUI users expect). Selection-aware copy is


### PR DESCRIPTION
## Summary

- restore Shift-drag text selection in macOS xterm sessions when Claude, Codex, or another full-screen CLI enables mouse tracking
- keep ordinary CLI mouse input working and prevent the forced-selection gesture from reaching the remote PTY
- document and regression-test the shared local/remote terminal behavior

## Validation

- `TerminalView.test.tsx`: 64 tests passed
- desktop typecheck passed
- ADE CLI parity: 1,695 tests passed
- ADE Code TUI parity: 858 tests passed
- CI shard 5 terminal coverage passed; an unrelated local-only `syncHostService.test.ts` command timeout reproduced in isolation

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstart-skill-ahev-issue-where-d9a58570 num=778 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstart-skill-ahev-issue-where-d9a58570&amp;pr=778">ade/start-skill-ahev-issue-where-d9a58570 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=778">PR #778</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes macOS terminal text selection when a remote CLI is tracking the mouse. The main changes are:

- Enables xterm’s Option-click force-selection behavior in `TerminalView`.
- Adds a macOS-only bridge that converts Shift-left-click into Option-left-click while mouse tracking is active.
- Cleans up the bridge during terminal runtime teardown.
- Updates tests for selected-text copy and Shift-drag selection under mouse tracking.
- Updates terminal feature docs for the new macOS selection behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The change is narrow, macOS-gated, tied to active mouse tracking, and cleaned up during runtime teardown. Tests cover the translated gesture and clipboard-copy path.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The macOS Shift+drag mouse-tracking test against the TerminalView jsdom harness ran and passed, validating translated selection behavior and the no-PTY-write assertion.
- Evidence from the test run was captured in the terminal-shift-selection-vitest.log to support review of harness execution.

<a href="https://app.greptile.com/trex/runs/14004110/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/terminals/TerminalView.tsx | Enables xterm macOS Option-force-selection and installs/cleans up a macOS Shift-selection bridge tied to mouse-tracking state. |
| apps/desktop/src/renderer/components/terminals/terminalMacShiftSelection.ts | Adds a scoped macOS capture listener that translates Shift-left mousedown into Option-mousedown only while terminal mouse tracking is active. |
| apps/desktop/src/renderer/components/terminals/TerminalView.test.tsx | Updates terminal interaction tests to cover macOS Option-force-selection behavior and selected-text copy configuration. |
| docs/features/terminals-and-sessions/README.md | Documents the macOS Shift-selection bridge and its relationship to xterm Option-based force selection. |
| docs/features/terminals-and-sessions/ui-surfaces.md | Updates terminal UI behavior documentation to describe mouse tracking and macOS forced-selection handling. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Host as Terminal host capture listener
participant Bridge as installMacShiftSelectionBridge
participant Xterm as xterm
participant CLI as Remote CLI

User->>Host: Shift + left mousedown
Host->>Bridge: capture mouse event
Bridge->>Bridge: Check macOS, not disposed, mouse tracking active
alt Mouse tracking active
    Bridge-->>Host: preventDefault + stopImmediatePropagation
    Bridge->>Xterm: dispatch synthetic Option + mousedown
    Xterm->>Xterm: start local force-selection
else Mouse tracking inactive
    Bridge-->>Xterm: allow original Shift event through
end
Xterm--xCLI: no Shift-selection gesture forwarded while bridged
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Host as Terminal host capture listener
participant Bridge as installMacShiftSelectionBridge
participant Xterm as xterm
participant CLI as Remote CLI

User->>Host: Shift + left mousedown
Host->>Bridge: capture mouse event
Bridge->>Bridge: Check macOS, not disposed, mouse tracking active
alt Mouse tracking active
    Bridge-->>Host: preventDefault + stopImmediatePropagation
    Bridge->>Xterm: dispatch synthetic Option + mousedown
    Xterm->>Xterm: start local force-selection
else Mouse tracking inactive
    Bridge-->>Xterm: allow original Shift event through
end
Xterm--xCLI: no Shift-selection gesture forwarded while bridged
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(work): restore copying from macOS CL..."](https://github.com/arul28/ade/commit/80dfc742c78248e0d70dcbdb4ccb5f5a3e83a0c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43339377)</sub>

<!-- /greptile_comment -->