### PR TITLE
files-tab-always-editable -> Primary

### DIFF
--- a/apps/desktop/src/renderer/components/files/FilesExplorer.test.tsx
+++ b/apps/desktop/src/renderer/components/files/FilesExplorer.test.tsx
@@ -51,22 +51,8 @@ function renderExplorer(overrides: Partial<FilesExplorerProps> = {}) {
 }
 
 describe("FilesExplorer mutating controls", () => {
-  it("disables create controls for read-only workspaces", () => {
-    const props = renderExplorer({ canMutate: false });
-
-    const newFile = screen.getByLabelText("New file") as HTMLButtonElement;
-    const newFolder = screen.getByLabelText("New folder") as HTMLButtonElement;
-    expect(newFile.disabled).toBe(true);
-    expect(newFolder.disabled).toBe(true);
-
-    fireEvent.click(newFile);
-    fireEvent.click(newFolder);
-    expect(props.onCreateFile).not.toHaveBeenCalled();
-    expect(props.onCreateDirectory).not.toHaveBeenCalled();
-  });
-
-  it("keeps create controls active for mutable workspaces", () => {
-    const props = renderExplorer({ canMutate: true });
+  it("keeps create controls active", () => {
+    const props = renderExplorer();
 
     const newFile = screen.getByLabelText("New file") as HTMLButtonElement;
     const newFolder = screen.getByLabelText("New folder") as HTMLButtonElement;

--- a/apps/desktop/src/renderer/components/files/FilesExplorer.tsx
+++ b/apps/desktop/src/renderer/components/files/FilesExplorer.tsx
@@ -81,7 +81,6 @@ export type FilesExplorerProps = {
   onContextMenu: (event: FilesExplorerContextMenuEvent) => void;
   onRenamePath: (sourcePath: string, destinationPath: string) => Promise<void>;
   onInlineRenameSettled: () => void;
-  canMutate?: boolean;
   compact?: boolean;
 };
 
@@ -192,7 +191,6 @@ export function FilesExplorer({
   onContextMenu,
   onRenamePath,
   onInlineRenameSettled,
-  canMutate = true,
   compact = false,
 }: FilesExplorerProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -310,7 +308,6 @@ export function FilesExplorer({
               type="button"
               title="New file"
               aria-label="New file"
-              disabled={!canMutate}
               style={{ ...outlineButton({ height: 24, padding: "0 6px", fontSize: 10 }) }}
               onClick={() => onCreateFile(activeContextDir)}
               onMouseEnter={(event) => { event.currentTarget.style.borderColor = COLORS.accent; event.currentTarget.style.color = COLORS.accent; }}
@@ -324,7 +321,6 @@ export function FilesExplorer({
               type="button"
               title="New folder"
               aria-label="New folder"
-              disabled={!canMutate}
               style={{ ...outlineButton({ height: 24, padding: "0 6px", fontSize: 10 }) }}
               onClick={() => onCreateDirectory(activeContextDir)}
               onMouseEnter={(event) => { event.currentTarget.style.borderColor = COLORS.accent; event.currentTarget.style.color = COLORS.accent; }}
@@ -387,7 +383,6 @@ export function FilesExplorer({
               type="button"
               title="New file"
               aria-label="New file"
-              disabled={!canMutate}
               style={{ ...outlineButton({ height: 28, padding: "0 7px", fontSize: 10 }) }}
               onClick={() => onCreateFile(activeContextDir)}
               onMouseEnter={(event) => { event.currentTarget.style.borderColor = COLORS.accent; event.currentTarget.style.color = COLORS.accent; }}
@@ -401,7 +396,6 @@ export function FilesExplorer({
               type="button"
               title="New folder"
               aria-label="New folder"
-              disabled={!canMutate}
               style={{ ...outlineButton({ height: 28, padding: "0 7px", fontSize: 10 }) }}
               onClick={() => onCreateDirectory(activeContextDir)}
               onMouseEnter={(event) => { event.currentTarget.style.borderColor = COLORS.accent; event.currentTarget.style.color = COLORS.accent; }}
@@ -490,7 +484,6 @@ export function FilesExplorer({
             type="button"
             title="New file"
             aria-label="New file"
-            disabled={!canMutate}
             style={{ ...outlineButton({ height: 24, padding: "0 6px", fontSize: 10 }) }}
             onClick={() => onCreateFile(activeContextDir)}
             onMouseEnter={(event) => { event.currentTarget.style.borderColor = COLORS.accent; event.currentTarget.style.color = COLORS.accent; }}
@@ -504,7 +497,6 @@ export function FilesExplorer({
             type="button"
             title="New folder"
             aria-label="New folder"
-            disabled={!canMutate}
             style={{ ...outlineButton({ height: 24, padding: "0 6px", fontSize: 10 }) }}
             onClick={() => onCreateDirectory(activeContextDir)}
             onMouseEnter={(event) => { event.currentTarget.style.borderColor = COLORS.accent; event.currentTarget.style.color = COLORS.accent; }}

--- a/apps/desktop/src/renderer/components/files/monacoModelRegistry.test.ts
+++ b/apps/desktop/src/renderer/components/files/monacoModelRegistry.test.ts
@@ -165,6 +165,62 @@ describe("monacoModelRegistry", () => {
     expect(registry.isDirty("a")).toBe(true);
   });
 
+  it("rekey moves the live buffer, dirty state, and identity to the new key", () => {
+    const { monaco, createdCount } = createFakeMonaco();
+    const registry = createMonacoModelRegistry();
+
+    const model = registry.getOrCreate(monaco, "stale-ws::src/a.ts", "draft", "typescript") as any;
+    model.__edit();
+    registry.rekey("stale-ws::src/a.ts", "host-ws::src/a.ts");
+
+    expect(registry.has("stale-ws::src/a.ts")).toBe(false);
+    expect(registry.getValue("host-ws::src/a.ts")).toBe("draft");
+    expect(registry.isDirty("host-ws::src/a.ts")).toBe(true);
+    // Reopening under the new key reuses the moved model — no rebuild from disk.
+    const reopened = registry.getOrCreate(monaco, "host-ws::src/a.ts", "disk content", "typescript");
+    expect(reopened).toBe(model);
+    expect(createdCount()).toBe(1);
+    expect(model.dispose).not.toHaveBeenCalled();
+  });
+
+  it("rekey collision keeps the dirty buffer and disposes the clean one", () => {
+    const { monaco } = createFakeMonaco();
+    const registry = createMonacoModelRegistry();
+
+    // Dirty incoming, clean existing → incoming wins.
+    const dirtyIncoming = registry.getOrCreate(monaco, "old-a", "edited", "plaintext") as any;
+    dirtyIncoming.__edit();
+    const cleanExisting = registry.getOrCreate(monaco, "new-a", "disk", "plaintext") as any;
+    registry.rekey("old-a", "new-a");
+    expect(cleanExisting.dispose).toHaveBeenCalledTimes(1);
+    expect(registry.getValue("new-a")).toBe("edited");
+    expect(registry.isDirty("new-a")).toBe(true);
+
+    // Dirty existing → existing wins, incoming disposed.
+    const cleanIncoming = registry.getOrCreate(monaco, "old-b", "stale", "plaintext") as any;
+    const dirtyExisting = registry.getOrCreate(monaco, "new-b", "kept edit", "plaintext") as any;
+    dirtyExisting.__edit();
+    registry.rekey("old-b", "new-b");
+    expect(cleanIncoming.dispose).toHaveBeenCalledTimes(1);
+    expect(dirtyExisting.dispose).not.toHaveBeenCalled();
+    expect(registry.getValue("new-b")).toBe("kept edit");
+    expect(registry.has("old-b")).toBe(false);
+  });
+
+  it("rekey is a no-op for identical or unknown keys", () => {
+    const { monaco } = createFakeMonaco();
+    const registry = createMonacoModelRegistry();
+
+    const model = registry.getOrCreate(monaco, "a", "x", "plaintext") as any;
+    registry.rekey("a", "a");
+    registry.rekey("missing", "b");
+
+    expect(registry.has("a")).toBe(true);
+    expect(registry.has("b")).toBe(false);
+    expect(registry.getValue("a")).toBe("x");
+    expect(model.dispose).not.toHaveBeenCalled();
+  });
+
   it("recreates a model whose underlying instance was disposed externally", () => {
     const { monaco, createdCount } = createFakeMonaco();
     const registry = createMonacoModelRegistry();

--- a/apps/desktop/src/renderer/components/files/monacoModelRegistry.ts
+++ b/apps/desktop/src/renderer/components/files/monacoModelRegistry.ts
@@ -108,6 +108,34 @@ export function createMonacoModelRegistry() {
       return Boolean(entry && !entry.model.isDisposed());
     },
 
+    /**
+     * Move a cached model to a new key (tab-id remap). The live buffer, undo
+     * stack, and dirty baseline follow the new key. When the new key already
+     * holds a live model — the remap collision case, where the stale tab was
+     * dropped in favor of an authoritative one — the old entry is disposed.
+     */
+    rekey(oldKey: string, newKey: string): void {
+      if (oldKey === newKey) return;
+      const entry = models.get(oldKey);
+      if (!entry) return;
+      models.delete(oldKey);
+      const existing = models.get(newKey);
+      if (existing && !existing.model.isDisposed()) {
+        // Collision: keep whichever buffer holds unsaved edits.
+        const entryDirty = !entry.model.isDisposed()
+          && entry.model.getAlternativeVersionId() !== entry.baseVersionId;
+        const existingDirty = existing.model.getAlternativeVersionId() !== existing.baseVersionId;
+        if (entryDirty && !existingDirty) {
+          safeDispose(existing.model);
+          models.set(newKey, entry);
+        } else {
+          safeDispose(entry.model);
+        }
+        return;
+      }
+      models.set(newKey, entry);
+    },
+
     dispose(modelKey: string): void {
       const entry = models.get(modelKey);
       if (!entry) return;

--- a/apps/desktop/src/renderer/components/files/v2/EditorGroup.test.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/EditorGroup.test.tsx
@@ -57,7 +57,6 @@ const baseProps: EditorGroupProps = {
     workspaceId: "workspace-1",
     rootPath: "/repo",
     laneId: "lane-1",
-    canEdit: true,
     canRevealInFinder: true,
   }),
   theme: "dark",
@@ -107,6 +106,7 @@ describe("EditorGroup", () => {
     render(<EditorGroup {...baseProps} />);
     expect(screen.getByRole("tab", { name: /file\.ts/i })).toBeTruthy();
     expect(screen.getByTestId("viewer-button")).toBeTruthy();
+    expect(screen.getByTitle("Save (⌘S)")).toBeTruthy();
   });
 
   it("marks the visible fallback tab active when lane scope hides the stored active tab", () => {

--- a/apps/desktop/src/renderer/components/files/v2/EditorGroup.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/EditorGroup.tsx
@@ -128,7 +128,7 @@ export function EditorGroup(props: EditorGroupProps) {
       });
       return;
     }
-    if (!activeContext.canEdit || activeTab.viewerKind !== "code") return;
+    if (activeTab.viewerKind !== "code") return;
     const text = registry.getValue(activeTab.id);
     if (text == null) return;
     void window.ade.files
@@ -143,7 +143,7 @@ export function EditorGroup(props: EditorGroupProps) {
   }, [activeContext, activeTab, onDirtyChange, onError, registry]);
 
   useEffect(() => {
-    if (!props.isActiveGroup || !activeTab || !activeContext?.canEdit || activeTab.viewerKind !== "code") return;
+    if (!props.isActiveGroup || !activeTab || activeTab.viewerKind !== "code") return;
     const onKey = (event: KeyboardEvent) => {
       const mod = event.metaKey || event.ctrlKey;
       if (!mod || event.shiftKey || event.altKey || (event.key !== "s" && event.key !== "S")) return;
@@ -156,7 +156,7 @@ export function EditorGroup(props: EditorGroupProps) {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [activeContext?.canEdit, activeTab, props.isActiveGroup, saveActive]);
+  }, [activeTab, props.isActiveGroup, saveActive]);
 
   return (
     <div
@@ -215,7 +215,7 @@ export function EditorGroup(props: EditorGroupProps) {
                 })}
               </div>
             ) : null}
-            {activeTab.viewerKind === "code" && activeContext.canEdit ? (
+            {activeTab.viewerKind === "code" ? (
               <button type="button" onClick={saveActive} title="Save (⌘S)" className="rounded p-1 hover:bg-white/5" style={{ color: COLORS.textMuted }}>
                 <FloppyDisk size={14} />
               </button>
@@ -235,7 +235,6 @@ export function EditorGroup(props: EditorGroupProps) {
             workspaceId={activeContext.workspaceId}
             rootPath={activeContext.rootPath}
             tab={activeTab}
-            canEdit={activeContext.canEdit}
             theme={props.theme}
             registry={props.registry}
             reloadToken={props.reloadTokensByTabId[activeTab.id] ?? 0}

--- a/apps/desktop/src/renderer/components/files/v2/EditorGroups.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/EditorGroups.tsx
@@ -15,7 +15,6 @@ export type TabWorkspaceContext = {
   workspaceId: string;
   rootPath: string;
   laneId: string | null;
-  canEdit: boolean;
   canRevealInFinder: boolean;
 };
 

--- a/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.test.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.test.tsx
@@ -1,11 +1,17 @@
 // @vitest-environment jsdom
 
 import React from "react";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FilesWorkspace } from "../../../../shared/types";
-import { filesSessionKey } from "../treeHelpers";
-import { useEditorGroupsStore } from "./editorGroupsStore";
+import { filesProjectSessionKey, filesSessionKey } from "../treeHelpers";
+import {
+  createInitialGroupsState,
+  editorTabId,
+  openInGroup,
+  type EditorTab,
+  useEditorGroupsStore,
+} from "./editorGroupsStore";
 import { FilesWorkbench } from "./FilesWorkbench";
 import { recordRecentFile } from "./recentFiles";
 
@@ -26,9 +32,8 @@ vi.mock("../../../state/appStore", () => ({
 }));
 
 vi.mock("../FilesExplorer", () => ({
-  FilesExplorer: ({ canMutate, onOpenFile }: { canMutate?: boolean; onOpenFile: (path: string) => void }) => (
+  FilesExplorer: ({ onOpenFile }: { onOpenFile: (path: string) => void }) => (
     <div>
-      <div data-testid="explorer-can-mutate">{String(canMutate)}</div>
       <button type="button" data-testid="open-file" onClick={() => onOpenFile("src/a.ts")}>
         Open file
       </button>
@@ -53,15 +58,14 @@ vi.mock("./EditorGroups", () => ({
   EditorGroups: (props: {
     state: { groups: Record<string, { tabs: Array<{ id: string }> }> };
     dirtyTabIds: ReadonlySet<string>;
-    resolveTabContext: (tab: { id: string }) => { canEdit: boolean };
     onDirtyChange: (tabId: string, dirty: boolean) => void;
   }) => {
     const tab = Object.values(props.state.groups).flatMap((group) => group.tabs)[0];
     return (
       <div>
         <div data-testid="tab-count">{tab ? 1 : 0}</div>
-        <div data-testid="can-edit">{tab ? String(props.resolveTabContext(tab).canEdit) : "unknown"}</div>
         <div data-testid="dirty-count">{props.dirtyTabIds.size}</div>
+        <div data-testid="dirty-ids">{[...props.dirtyTabIds].join(",")}</div>
         <button
           type="button"
           data-testid="mark-dirty"
@@ -77,6 +81,15 @@ vi.mock("./EditorGroups", () => ({
 }));
 
 const workspaces: FilesWorkspace[] = [
+  {
+    id: "workspace-primary",
+    kind: "primary",
+    name: "Primary",
+    rootPath: "/repo",
+    laneId: null,
+    isReadOnlyByDefault: true,
+    mobileReadOnly: true,
+  },
   {
     id: "workspace-a",
     kind: "worktree",
@@ -143,6 +156,7 @@ describe("FilesWorkbench", () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.restoreAllMocks();
     useEditorGroupsStore.setState({ sessions: {} });
     localStorage.clear();
@@ -153,7 +167,6 @@ describe("FilesWorkbench", () => {
 
     fireEvent.click(await screen.findByTestId("open-file"));
     await waitFor(() => expect(screen.getByTestId("tab-count").textContent).toBe("1"));
-    expect(screen.getByTestId("can-edit").textContent).toBe("true");
     expect(window.ade.files.readFile).toHaveBeenCalledWith({ workspaceId: "workspace-a", path: "src/a.ts" });
 
     fireEvent.click(screen.getByTestId("mark-dirty"));
@@ -171,12 +184,90 @@ describe("FilesWorkbench", () => {
     // workspace-b is isReadOnlyByDefault: true — it must still be freely editable.
     fireEvent.click(await screen.findByTestId("switch-workspace"));
 
-    await waitFor(() => expect(screen.getByTestId("explorer-can-mutate").textContent).toBe("true"));
     fireEvent.click(screen.getByTestId("open-file"));
-    await waitFor(() => expect(screen.getByTestId("can-edit").textContent).toBe("true"));
+    await waitFor(() => {
+      expect(window.ade.files.readFile).toHaveBeenCalledWith({
+        workspaceId: "workspace-b",
+        path: "src/a.ts",
+      });
+    });
 
     // There is no longer any "Enable editing" affordance.
     expect(screen.queryByRole("button", { name: /enable editing/i })).toBeNull();
+  });
+
+  it("remaps stale restored workspace ids by lane, then falls back to primary", async () => {
+    const restoredTab = (workspaceId: string, laneId: string | null, path: string): EditorTab => ({
+      id: editorTabId(workspaceId, path),
+      workspaceId,
+      laneId,
+      path,
+      title: path.split("/").pop() ?? path,
+      viewerKind: "code",
+      languageId: "typescript",
+      preview: false,
+      pinned: false,
+    });
+    const laneMatch = restoredTab("stale-lane-workspace", "lane-b", "src/matched.ts");
+    const staleDuplicate = restoredTab("stale-duplicate-workspace", "lane-b", "src/duplicate.ts");
+    const authoritativeDuplicate = restoredTab("workspace-b", "lane-b", "src/duplicate.ts");
+    const primaryFallback = restoredTab("stale-unmatched-workspace", "missing-lane", "src/fallback.ts");
+    let restored = createInitialGroupsState();
+    restored = openInGroup(restored, "group-1", laneMatch);
+    restored = openInGroup(restored, "group-1", staleDuplicate);
+    restored = openInGroup(restored, "group-1", authoritativeDuplicate);
+    restored = openInGroup(restored, "group-1", primaryFallback);
+    const sessionKey = filesProjectSessionKey("/repo");
+    useEditorGroupsStore.setState({ sessions: { [sessionKey]: restored } });
+
+    let resolveWorkspaces!: (value: FilesWorkspace[]) => void;
+    const listedWorkspaces = new Promise<FilesWorkspace[]>((resolve) => {
+      resolveWorkspaces = resolve;
+    });
+    window.ade.files.listWorkspaces = vi.fn(() => listedWorkspaces);
+
+    render(<FilesWorkbench active />);
+    expect(useEditorGroupsStore.getState().getSession(sessionKey)?.groups["group-1"]?.tabs)
+      .toContainEqual(laneMatch);
+    fireEvent.click(screen.getByTestId("mark-dirty"));
+    await waitFor(() => expect(screen.getByTestId("dirty-ids").textContent).toBe(laneMatch.id));
+
+    resolveWorkspaces(workspaces);
+
+    await waitFor(() => {
+      const group = useEditorGroupsStore.getState().getSession(sessionKey)?.groups["group-1"];
+      expect(group?.tabs.map((tab) => tab.id)).toEqual([
+        editorTabId("workspace-b", "src/matched.ts"),
+        editorTabId("workspace-b", "src/duplicate.ts"),
+        editorTabId("workspace-primary", "src/fallback.ts"),
+      ]);
+      expect(group?.activeTabId).toBe(editorTabId("workspace-primary", "src/fallback.ts"));
+      expect(screen.getByTestId("dirty-ids").textContent)
+        .toBe(editorTabId("workspace-b", "src/matched.ts"));
+    });
+  });
+
+  it("retries workspace listing after transient failures", async () => {
+    vi.useFakeTimers();
+    const listWorkspaces = vi.fn()
+      .mockRejectedValueOnce(new Error("runtime warming up"))
+      .mockRejectedValueOnce(new Error("runtime still warming up"))
+      .mockResolvedValue(workspaces);
+    window.ade.files.listWorkspaces = listWorkspaces;
+
+    render(<FilesWorkbench active />);
+    await act(async () => undefined);
+    expect(listWorkspaces).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(listWorkspaces).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    expect(listWorkspaces).toHaveBeenCalledTimes(3);
   });
 
   it("keeps recent files scoped to the selected lane workspace", async () => {

--- a/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx
@@ -31,6 +31,7 @@ import {
   closeTab,
   createInitialGroupsState,
   editorTabId,
+  isExternalFilesWorkspaceId,
   isTabOpenInGroups,
   mergeLegacyLaneSessions,
   moveTabToGroup,
@@ -60,25 +61,21 @@ import { joinDisplayPath } from "./pathDisplay";
 const TREE_PAGE_SIZE = 2_000;
 const MAX_AUTO_LOADED_CHILDREN = 10_000;
 const MAX_QUEUED_TREE_PARENT_REFRESHES = 24;
+const WORKSPACE_LIST_RETRY_DELAYS_MS = [1_000, 2_000, 5_000, 10_000] as const;
 
 // Module-level caches survive remounts (the route unmounts FilesWorkbench when you
 // switch tabs), so re-opening Files shows the workspace + tree instantly instead of
 // flashing a loading/empty state while listWorkspaces / listTree refetch.
 const workspacesCacheByProject = new Map<string, FilesWorkspace[]>();
 const rootTreeCacheByKey = new Map<string, FileTreeNode[]>();
-const readCachedWorkspaces = (projectRoot: string): FilesWorkspace[] => workspacesCacheByProject.get(projectRoot) ?? [];
-const rootTreeCacheKey = (projectRoot: string, workspaceId: string): string => `${projectRoot}::${workspaceId}`;
+const readCachedWorkspaces = (projectCacheKey: string): FilesWorkspace[] => workspacesCacheByProject.get(projectCacheKey) ?? [];
+const rootTreeCacheKey = (projectCacheKey: string, workspaceId: string): string => `${projectCacheKey}::${workspaceId}`;
 
 function recentScopeIdForWorkspace(workspace: FilesWorkspace | null | undefined, fallbackLaneId: string | null): string | null {
   if (!workspace) return fallbackLaneId;
   if (workspace.kind === "worktree") return workspace.laneId ?? workspace.id;
   if (workspace.kind === "primary") return workspace.laneId ?? fallbackLaneId;
   return workspace.id;
-}
-
-function canEditWorkspace(workspace: FilesWorkspace | null | undefined): boolean {
-  // Any resolved workspace is freely editable — there is no edit-protection gate.
-  return workspace != null;
 }
 
 function mergeExternalWorkspaces(next: FilesWorkspace[], previous: FilesWorkspace[]): FilesWorkspace[] {
@@ -122,21 +119,23 @@ export function FilesWorkbench({
 }) {
   const project = useAppStore((s) => s.project);
   const projectRootPath = project?.rootPath ?? "";
-  const isRemoteProject = useAppStore((s) => s.projectBinding?.kind === "remote");
+  const projectBinding = useAppStore((s) => s.projectBinding);
+  const isRemoteProject = projectBinding?.kind === "remote";
+  const bindingKey = projectBinding?.kind === "remote" ? `remote:${projectBinding.targetId}` : "local";
+  const projectCacheKey = `${bindingKey}::${projectRootPath}`;
   const selectedLaneId = useAppStore((s) => s.selectedLaneId);
   const lanes = useAppStore((s) => s.lanes);
   const globalLaneId = preferredLaneId ?? selectedLaneId ?? null;
 
   // Seed from the cross-mount cache so a repeat visit renders immediately.
-  const cachedWorkspaces = readCachedWorkspaces(projectRootPath);
+  const cachedWorkspaces = readCachedWorkspaces(projectCacheKey);
   const initialWorkspaceId = defaultFilesWorkspaceId(cachedWorkspaces, globalLaneId);
   const [workspaces, setWorkspaces] = useState<FilesWorkspace[]>(cachedWorkspaces);
   const [workspacesLoaded, setWorkspacesLoaded] = useState<boolean>(cachedWorkspaces.length > 0);
-  const [workspacesListedProjectRoot, setWorkspacesListedProjectRoot] = useState<string | null>(null);
+  const [workspacesListedCacheKey, setWorkspacesListedCacheKey] = useState<string | null>(null);
   const [workspaceId, setWorkspaceId] = useState<string>(initialWorkspaceId);
   const workspace = useMemo(() => workspaces.find((w) => w.id === workspaceId) ?? null, [workspaces, workspaceId]);
   const rootPath = workspace?.rootPath ?? projectRootPath;
-  const canEdit = canEditWorkspace(workspace);
   const canRevealInFinder = workspace != null && (workspace.kind === "external" || !isRemoteProject);
   const branch = workspace?.branchRef?.replace("refs/heads/", "") ?? null;
   const theme: EditorThemeMode = "dark";
@@ -148,7 +147,7 @@ export function FilesWorkbench({
   const [tabScope, setTabScope] = useState<FilesTabScope>(() => getFilesTabScope(projectRootPath));
 
   const [tree, setTree] = useState<FileTreeNode[]>(
-    () => rootTreeCacheByKey.get(rootTreeCacheKey(projectRootPath, initialWorkspaceId)) ?? [],
+    () => rootTreeCacheByKey.get(rootTreeCacheKey(projectCacheKey, initialWorkspaceId)) ?? [],
   );
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [loadingDirs, setLoadingDirs] = useState<Set<string>>(new Set());
@@ -176,6 +175,7 @@ export function FilesWorkbench({
   const handledExternalOpenRef = useRef<string | null>(null);
   const lastGlobalLaneIdRef = useRef(globalLaneId);
   const workspacesProjectRootRef = useRef(projectRootPath);
+  const workspacesCacheKeyRef = useRef(projectCacheKey);
   const renameNonceRef = useRef(0);
   const registryRef = useRef(createMonacoModelRegistry());
   const dragRef = useRef<{ groupId: string; tabId: string } | null>(null);
@@ -201,11 +201,11 @@ export function FilesWorkbench({
           ...prev.filter((candidate) => candidate.id !== nextWorkspace.id),
           nextWorkspace,
         ];
-        workspacesCacheByProject.set(projectRootPath, next);
+        workspacesCacheByProject.set(projectCacheKey, next);
         return next;
       });
     },
-    [projectRootPath],
+    [projectCacheKey],
   );
 
   const activeGroup = groupsState.groups[groupsState.activeGroupId];
@@ -224,7 +224,6 @@ export function FilesWorkbench({
         workspaceId: tab.workspaceId,
         rootPath: wsRoot,
         laneId: tab.laneId,
-        canEdit: canEditWorkspace(ws),
         canRevealInFinder: ws != null && (ws.kind === "external" || !isRemoteProject),
       };
     },
@@ -233,7 +232,7 @@ export function FilesWorkbench({
 
   const migratedSessionsRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!projectRootPath || workspaces.length === 0 || workspacesListedProjectRoot !== projectRootPath) return;
+    if (!projectRootPath || workspaces.length === 0 || workspacesListedCacheKey !== projectCacheKey) return;
     if (migratedSessionsRef.current === projectRootPath) return;
     migratedSessionsRef.current = projectRootPath;
     const projectKey = filesProjectSessionKey(projectRootPath);
@@ -253,7 +252,48 @@ export function FilesWorkbench({
     if (legacySessions.length > 0) {
       store.apply(projectKey, () => mergeLegacyLaneSessions(legacySessions));
     }
-  }, [projectRootPath, store, workspaces, workspacesListedProjectRoot]);
+  }, [projectCacheKey, projectRootPath, store, workspaces, workspacesListedCacheKey]);
+
+  useEffect(() => {
+    if (!projectRootPath || workspaces.length === 0 || workspacesListedCacheKey !== projectCacheKey) return;
+    const hostWorkspaces = workspaces.filter((candidate) => candidate.kind !== "external");
+    const workspaceIds = new Set(workspaces.map((candidate) => candidate.id));
+    const primaryWorkspace = hostWorkspaces.find((candidate) => candidate.kind === "primary");
+    const fallbackWorkspace = primaryWorkspace ?? hostWorkspaces[0];
+    if (!fallbackWorkspace) return;
+
+    const tabIdChanges = store.remapTabWorkspaces(sessionKey, (tab) => {
+      if (workspaceIds.has(tab.workspaceId) || isExternalFilesWorkspaceId(tab.workspaceId)) {
+        return tab.workspaceId;
+      }
+      const laneWorkspace = tab.laneId
+        ? hostWorkspaces.find((candidate) => candidate.laneId === tab.laneId)
+        : null;
+      return (laneWorkspace ?? fallbackWorkspace).id;
+    });
+    if (tabIdChanges.size === 0) return;
+
+    // Move live Monaco models to their remapped tab ids so unsaved buffers,
+    // undo stacks, and dirty baselines survive the workspace-identity change.
+    for (const [oldTabId, newTabId] of tabIdChanges) {
+      registryRef.current.rekey(oldTabId, newTabId);
+    }
+
+    setDirtyTabIds((prev) => {
+      const next = new Set<string>();
+      for (const tabId of prev) next.add(tabIdChanges.get(tabId) ?? tabId);
+      return next;
+    });
+    setReloadTokensByTabId((prev) => {
+      const next: Record<string, number> = {};
+      for (const [tabId, token] of Object.entries(prev)) {
+        const nextTabId = tabIdChanges.get(tabId) ?? tabId;
+        next[nextTabId] = Math.max(next[nextTabId] ?? 0, token);
+      }
+      return next;
+    });
+    setDirtyBufferRevision((revision) => revision + 1);
+  }, [projectCacheKey, projectRootPath, sessionKey, store, workspaces, workspacesListedCacheKey]);
 
   const allOpenTabsRef = useRef(allOpenTabs);
   allOpenTabsRef.current = allOpenTabs;
@@ -383,36 +423,49 @@ export function FilesWorkbench({
   useEffect(() => {
     if (!active) return;
     let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let retryIndex = 0;
     const projectChanged = workspacesProjectRootRef.current !== projectRootPath;
+    const cacheKeyChanged = workspacesCacheKeyRef.current !== projectCacheKey;
     workspacesProjectRootRef.current = projectRootPath;
-    if (projectChanged) {
-      const cachedForProject = readCachedWorkspaces(projectRootPath).filter((workspace) => workspace.kind !== "external");
-      setWorkspaces(cachedForProject);
+    workspacesCacheKeyRef.current = projectCacheKey;
+    if (cacheKeyChanged) {
+      const cachedForProject = readCachedWorkspaces(projectCacheKey).filter((workspace) => workspace.kind !== "external");
+      setWorkspaces((prev) => (
+        projectChanged ? cachedForProject : mergeExternalWorkspaces(cachedForProject, prev)
+      ));
       setWorkspacesLoaded(cachedForProject.length > 0);
-      setWorkspacesListedProjectRoot(null);
+      setWorkspacesListedCacheKey(null);
     }
-    window.ade.files
-      .listWorkspaces()
-      .then((ws) => {
+
+    const listWorkspaces = async (): Promise<void> => {
+      try {
+        const ws = await window.ade.files.listWorkspaces();
         if (cancelled) return;
         setWorkspaces((prev) => {
           const merged = projectChanged ? ws : mergeExternalWorkspaces(ws, prev);
-          workspacesCacheByProject.set(projectRootPath, merged);
+          workspacesCacheByProject.set(projectCacheKey, merged);
           return merged;
         });
         setWorkspacesLoaded(true);
-        setWorkspacesListedProjectRoot(projectRootPath);
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setWorkspacesLoaded(true);
-          setWorkspacesListedProjectRoot(projectRootPath);
-        }
-      });
+        setWorkspacesListedCacheKey(projectCacheKey);
+      } catch {
+        if (cancelled) return;
+        setWorkspacesLoaded(true);
+        const delay = WORKSPACE_LIST_RETRY_DELAYS_MS[
+          Math.min(retryIndex, WORKSPACE_LIST_RETRY_DELAYS_MS.length - 1)
+        ];
+        retryIndex += 1;
+        retryTimer = setTimeout(() => void listWorkspaces(), delay);
+      }
+    };
+
+    void listWorkspaces();
     return () => {
       cancelled = true;
+      if (retryTimer) clearTimeout(retryTimer);
     };
-  }, [active, projectRootPath]);
+  }, [active, projectCacheKey, projectRootPath]);
 
   // Resolve the explorer workspace from the global lane on mount + lane changes.
   useEffect(() => {
@@ -441,11 +494,11 @@ export function FilesWorkbench({
       if (workspaceIdRef.current !== reqId) return;
       setTree((prev) => {
         const decorated = applyGitStatusToTree(prev, decorations);
-        rootTreeCacheByKey.set(rootTreeCacheKey(projectRootPath, reqId), decorated);
+        rootTreeCacheByKey.set(rootTreeCacheKey(projectCacheKey, reqId), decorated);
         return decorated;
       });
     },
-    [projectRootPath, workspaceId],
+    [projectCacheKey, workspaceId],
   );
 
   const refreshRoot = useCallback(async (options: { preserveLoadedChildren?: boolean } = {}) => {
@@ -457,7 +510,7 @@ export function FilesWorkbench({
       if (workspaceIdRef.current !== reqId) return;
       setTree((prev) => {
         const merged = preserveLoadedChildren ? mergeTreePreservingLoadedChildren(nodes, prev) : nodes;
-        rootTreeCacheByKey.set(rootTreeCacheKey(projectRootPath, reqId), merged);
+        rootTreeCacheByKey.set(rootTreeCacheKey(projectCacheKey, reqId), merged);
         return merged;
       });
       setError(null);
@@ -465,18 +518,18 @@ export function FilesWorkbench({
     } catch (err) {
       if (workspaceIdRef.current === reqId) setError(err instanceof Error ? err.message : String(err));
     }
-  }, [workspaceId, projectRootPath, refreshTreeGitDecorations]);
+  }, [workspaceId, projectCacheKey, refreshTreeGitDecorations]);
 
   // Reload explorer tree when the selected workspace changes (tabs stay open).
   useEffect(() => {
     if (!active || !workspaceId) return;
-    setTree(rootTreeCacheByKey.get(rootTreeCacheKey(projectRootPath, workspaceId)) ?? []);
+    setTree(rootTreeCacheByKey.get(rootTreeCacheKey(projectCacheKey, workspaceId)) ?? []);
     setExpanded(new Set());
     setLoadingDirs(new Set());
     setError(null);
     void refreshRoot();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [active, workspaceId, refreshRoot, projectRootPath]);
+  }, [active, workspaceId, refreshRoot, projectCacheKey]);
 
   useEffect(() => {
     if (!active) return;
@@ -521,7 +574,7 @@ export function FilesWorkbench({
         if (!result || workspaceIdRef.current !== reqId) return;
         setTree((prev) => {
           const nextTree = replaceTreeNodeChildren(prev, parentPath, result.children, result.loadMoreOffset);
-          rootTreeCacheByKey.set(rootTreeCacheKey(projectRootPath, reqId), nextTree);
+          rootTreeCacheByKey.set(rootTreeCacheKey(projectCacheKey, reqId), nextTree);
           return nextTree;
         });
       } catch (err) {
@@ -536,7 +589,7 @@ export function FilesWorkbench({
         });
       }
     },
-    [fetchDirectoryChildren, projectRootPath, workspaceId],
+    [fetchDirectoryChildren, projectCacheKey, workspaceId],
   );
 
   const loadDirectory = useCallback(
@@ -583,7 +636,7 @@ export function FilesWorkbench({
         }
         setTree((prev) => {
           const nextTree = appendTreeNodeChildren(prev, parentPath, children, loadMoreOffset);
-          rootTreeCacheByKey.set(rootTreeCacheKey(projectRootPath, reqId), nextTree);
+          rootTreeCacheByKey.set(rootTreeCacheKey(projectCacheKey, reqId), nextTree);
           return nextTree;
         });
       } catch (err) {
@@ -596,7 +649,7 @@ export function FilesWorkbench({
         });
       }
     },
-    [projectRootPath, workspaceId],
+    [projectCacheKey, workspaceId],
   );
 
   const toggleDirectory = useCallback(
@@ -947,10 +1000,6 @@ export function FilesWorkbench({
   const renamePath = useCallback(
     async (sourcePath: string, destinationPath: string) => {
       if (!workspaceId) return;
-      if (!canEdit) {
-        setError("This workspace is read-only.");
-        return;
-      }
       if (!confirmDiscardDirtyTabIds(dirtyTabsUnder(workspaceId, sourcePath), "Rename it")) return;
       try {
         await window.ade.files.rename({ workspaceId, oldPath: sourcePath, newPath: destinationPath });
@@ -962,16 +1011,12 @@ export function FilesWorkbench({
       closeOpenTabsUnder(workspaceId, sourcePath);
       await refreshRoot();
     },
-    [canEdit, closeOpenTabsUnder, confirmDiscardDirtyTabIds, dirtyTabsUnder, recentSessionKey, refreshRoot, workspaceId],
+    [closeOpenTabsUnder, confirmDiscardDirtyTabIds, dirtyTabsUnder, recentSessionKey, refreshRoot, workspaceId],
   );
 
   const deletePath = useCallback(
     async (path: string) => {
       if (!workspaceId) return;
-      if (!canEdit) {
-        setError("This workspace is read-only.");
-        return;
-      }
       const ok = window.confirm(`Delete "${path}"? This cannot be undone.`);
       if (!ok) return;
       if (!confirmDiscardDirtyTabIds(dirtyTabsUnder(workspaceId, path), "Delete it")) return;
@@ -984,7 +1029,7 @@ export function FilesWorkbench({
         setError(err instanceof Error ? err.message : String(err));
       }
     },
-    [canEdit, closeOpenTabsUnder, confirmDiscardDirtyTabIds, dirtyTabsUnder, recentSessionKey, refreshRoot, workspaceId],
+    [closeOpenTabsUnder, confirmDiscardDirtyTabIds, dirtyTabsUnder, recentSessionKey, refreshRoot, workspaceId],
   );
 
   const dirForNode = (menu: FilesExplorerContextMenuEvent): string =>
@@ -1001,11 +1046,11 @@ export function FilesWorkbench({
       items.push({ type: "item", label: "Open", onClick: () => void openFile(path, { preview: false }) });
       items.push({ type: "separator" });
     }
-    items.push({ type: "item", label: "New File…", icon: <FilePlus size={14} />, onClick: () => setOverlay({ kind: "create", create: "file", baseDir }), disabled: !canEdit });
-    items.push({ type: "item", label: "New Folder…", icon: <FolderPlus size={14} />, onClick: () => setOverlay({ kind: "create", create: "directory", baseDir }), disabled: !canEdit });
+    items.push({ type: "item", label: "New File…", icon: <FilePlus size={14} />, onClick: () => setOverlay({ kind: "create", create: "file", baseDir }) });
+    items.push({ type: "item", label: "New Folder…", icon: <FolderPlus size={14} />, onClick: () => setOverlay({ kind: "create", create: "directory", baseDir }) });
     items.push({ type: "separator" });
-    items.push({ type: "item", label: "Rename…", icon: <PencilSimple size={14} />, onClick: () => setInlineRename({ path, nonce: ++renameNonceRef.current }), disabled: !canEdit });
-    items.push({ type: "item", label: "Delete", icon: <Trash size={14} />, danger: true, onClick: () => void deletePath(path), disabled: !canEdit });
+    items.push({ type: "item", label: "Rename…", icon: <PencilSimple size={14} />, onClick: () => setInlineRename({ path, nonce: ++renameNonceRef.current }) });
+    items.push({ type: "item", label: "Delete", icon: <Trash size={14} />, danger: true, onClick: () => void deletePath(path) });
     items.push({ type: "separator" });
     items.push({ type: "item", label: "Copy Full Path", icon: <Copy size={14} />, onClick: () => void window.ade.app.writeClipboardText?.(fullPath) });
     items.push({ type: "item", label: "Copy Relative Path", icon: <Copy size={14} />, onClick: () => void window.ade.app.writeClipboardText?.(path) });
@@ -1018,15 +1063,11 @@ export function FilesWorkbench({
       disabled: !canRevealInFinder,
     });
     return items;
-  }, [treeMenu, openFile, canEdit, deletePath, rootPath, canRevealInFinder]);
+  }, [treeMenu, openFile, deletePath, rootPath, canRevealInFinder]);
 
   const createInWorkspace = useCallback(
     async (kind: "file" | "directory", baseDir: string, name: string) => {
       if (!workspaceId) return;
-      if (!canEdit) {
-        setError("This workspace is read-only.");
-        return;
-      }
       const rel = baseDir ? `${baseDir}/${name}` : name;
       try {
         if (kind === "file") await window.ade.files.createFile({ workspaceId, path: rel });
@@ -1037,7 +1078,7 @@ export function FilesWorkbench({
         setError(err instanceof Error ? err.message : String(err));
       }
     },
-    [canEdit, workspaceId, refreshRoot, openFile],
+    [workspaceId, refreshRoot, openFile],
   );
 
   // Files-scoped keybindings: ⌘P / ⌘⇧F both open the unified in-depth search.
@@ -1139,7 +1180,6 @@ export function FilesWorkbench({
               onContextMenu={setTreeMenu}
               onRenamePath={renamePath}
               onInlineRenameSettled={() => setInlineRename(null)}
-              canMutate={canEdit}
               compact={embedded}
             />
           </div>

--- a/apps/desktop/src/renderer/components/files/v2/ViewerHost.tsx
+++ b/apps/desktop/src/renderer/components/files/v2/ViewerHost.tsx
@@ -18,7 +18,6 @@ export type ViewerHostProps = {
   workspaceId: string;
   rootPath: string;
   tab: EditorTab;
-  canEdit: boolean;
   theme: EditorThemeMode;
   registry: MonacoModelRegistry;
   reloadToken?: number;
@@ -48,7 +47,7 @@ export function ViewerHost(props: ViewerHostProps) {
     rootPath: props.rootPath,
     tab,
     content: contentState.content,
-    readOnly: !props.canEdit || tab.viewerKind !== "code",
+    readOnly: tab.viewerKind !== "code",
     theme: props.theme,
     registry: props.registry,
     onDirtyChange: props.onDirtyChange,

--- a/apps/desktop/src/renderer/components/files/v2/editorGroupsStore.test.ts
+++ b/apps/desktop/src/renderer/components/files/v2/editorGroupsStore.test.ts
@@ -17,6 +17,7 @@ import {
   splitGroup,
   splitTabToNewGroup,
   upgradeLegacySession,
+  useEditorGroupsStore,
 } from "./editorGroupsStore";
 
 const WS_A = "workspace-a";
@@ -242,6 +243,38 @@ describe("editorGroupsStore reducers", () => {
     expect(state.groupOrder).toEqual([g1]);
     expect(group(state).tabs).toEqual([]);
     expect(group(state).activeTabId).toBeNull();
+  });
+
+  it("remaps stale workspace ids, dedupes collisions, and preserves the active tab", () => {
+    const sessionKey = "project-session";
+    const stale = tab("same.ts", { workspaceId: "stale-workspace", laneId: LANE_B });
+    const authoritative = tab("same.ts", { workspaceId: WS_B, laneId: LANE_B });
+    const external = tab("outside.ts", {
+      id: "preserved-external-tab-id",
+      workspaceId: "external-local:outside",
+      laneId: null,
+    });
+    let state = createInitialGroupsState();
+    state = openInGroup(state, g1, stale);
+    state = openInGroup(state, g1, authoritative);
+    state = openInGroup(state, g1, external);
+    state = activateTab(state, g1, stale.id);
+    useEditorGroupsStore.setState({ sessions: { [sessionKey]: state } });
+
+    const mappedWorkspaceIds: string[] = [];
+    const tabIdChanges = useEditorGroupsStore.getState().remapTabWorkspaces(sessionKey, (candidate) => {
+      mappedWorkspaceIds.push(candidate.workspaceId);
+      return candidate.workspaceId === stale.workspaceId ? WS_B : candidate.workspaceId;
+    });
+    const remapped = useEditorGroupsStore.getState().getSession(sessionKey)!;
+
+    expect(group(remapped).tabs).toEqual([authoritative, external]);
+    expect(group(remapped).activeTabId).toBe(authoritative.id);
+    expect(group(remapped).recentTabIds).toEqual([authoritative.id, external.id]);
+    expect(tabIdChanges.get(stale.id)).toBe(authoritative.id);
+    expect(mappedWorkspaceIds).not.toContain(external.workspaceId);
+
+    useEditorGroupsStore.setState({ sessions: {} });
   });
 
   it("merges simple legacy per-lane sessions into one tab strip", () => {

--- a/apps/desktop/src/renderer/components/files/v2/editorGroupsStore.ts
+++ b/apps/desktop/src/renderer/components/files/v2/editorGroupsStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { EXTERNAL_FILES_WORKSPACE_ID_PREFIX } from "../../../../shared/types/files";
 
 /**
  * Editor-groups state for the v2 Files workbench.
@@ -50,6 +51,10 @@ type LegacyEditorTab = Partial<EditorTab> & {
 
 export function editorTabId(workspaceId: string, path: string): string {
   return `${workspaceId}::${path}`;
+}
+
+export function isExternalFilesWorkspaceId(workspaceId: string): boolean {
+  return workspaceId.startsWith(EXTERNAL_FILES_WORKSPACE_ID_PREFIX);
 }
 
 export type EditorGroup = {
@@ -311,6 +316,91 @@ export function cycleTab(state: GroupsState, groupId: string, direction: 1 | -1)
   return activateTab(state, groupId, order[nextIdx]!);
 }
 
+type RemapTabWorkspacesResult = {
+  state: GroupsState;
+  tabIdChanges: Map<string, string>;
+};
+
+/**
+ * Rewrite restored tab workspace identities after the authoritative workspace
+ * list changes (for example, when the same project path is opened remotely).
+ * External-file tabs are local-only and deliberately retain their identities.
+ */
+function remapTabWorkspacesInState(
+  state: GroupsState,
+  mapper: (tab: EditorTab) => string,
+): RemapTabWorkspacesResult {
+  const tabIdChanges = new Map<string, string>();
+  const nextGroups: Record<string, EditorGroup> = {};
+
+  for (const groupId of state.groupOrder) {
+    const group = state.groups[groupId];
+    if (!group) continue;
+
+    const candidates = group.tabs.map((tab) => {
+      if (isExternalFilesWorkspaceId(tab.workspaceId)) {
+        return { tab, workspaceId: tab.workspaceId, id: tab.id, changed: false };
+      }
+      const workspaceId = mapper(tab) || tab.workspaceId;
+      const id = editorTabId(workspaceId, tab.path);
+      return { tab, workspaceId, id, changed: workspaceId !== tab.workspaceId || id !== tab.id };
+    });
+    const existingIds = new Set(
+      candidates
+        .filter((candidate) => !candidate.changed)
+        .map((candidate) => candidate.id),
+    );
+    const keptIds = new Set<string>();
+    const nextTabs: EditorTab[] = [];
+
+    for (const candidate of candidates) {
+      if (candidate.changed) tabIdChanges.set(candidate.tab.id, candidate.id);
+
+      // If the remap collides with a tab that already had the authoritative id,
+      // keep that existing tab and discard the stale restored copy.
+      if ((candidate.changed && existingIds.has(candidate.id)) || keptIds.has(candidate.id)) {
+        continue;
+      }
+
+      keptIds.add(candidate.id);
+      nextTabs.push(
+        candidate.changed
+          ? { ...candidate.tab, workspaceId: candidate.workspaceId, id: candidate.id }
+          : candidate.tab,
+      );
+    }
+
+    const mappedActiveTabId = group.activeTabId
+      ? (tabIdChanges.get(group.activeTabId) ?? group.activeTabId)
+      : null;
+    const activeTabId = mappedActiveTabId && keptIds.has(mappedActiveTabId)
+      ? mappedActiveTabId
+      : nextTabs[nextTabs.length - 1]?.id ?? null;
+    const recentTabIds: string[] = [];
+    for (const tabId of group.recentTabIds) {
+      const mappedTabId = tabIdChanges.get(tabId) ?? tabId;
+      if (keptIds.has(mappedTabId) && !recentTabIds.includes(mappedTabId)) {
+        recentTabIds.push(mappedTabId);
+      }
+    }
+
+    const groupChanged = nextTabs.length !== group.tabs.length
+      || activeTabId !== group.activeTabId
+      || recentTabIds.length !== group.recentTabIds.length
+      || recentTabIds.some((tabId, index) => tabId !== group.recentTabIds[index])
+      || nextTabs.some((tab, index) => tab !== group.tabs[index]);
+    nextGroups[groupId] = groupChanged
+      ? { ...group, tabs: nextTabs, activeTabId, recentTabIds }
+      : group;
+  }
+
+  const changed = state.groupOrder.some((groupId) => nextGroups[groupId] !== state.groups[groupId]);
+  return {
+    state: changed ? { ...state, groups: nextGroups } : state,
+    tabIdChanges,
+  };
+}
+
 /** Upgrade tabs from legacy per-lane sessions that only stored `path`. */
 export function upgradeLegacySession(
   session: GroupsState,
@@ -424,6 +514,7 @@ type EditorGroupsStore = {
   ensureSession: (sessionKey: string) => GroupsState;
   getSession: (sessionKey: string) => GroupsState | undefined;
   apply: (sessionKey: string, reducer: (state: GroupsState) => GroupsState) => void;
+  remapTabWorkspaces: (sessionKey: string, mapper: (tab: EditorTab) => string) => Map<string, string>;
   resetSession: (sessionKey: string) => void;
 };
 
@@ -442,6 +533,14 @@ export const useEditorGroupsStore = create<EditorGroupsStore>((set, get) => ({
       const current = s.sessions[sessionKey] ?? createInitialGroupsState();
       return { sessions: { ...s.sessions, [sessionKey]: reducer(current) } };
     }),
+  remapTabWorkspaces: (sessionKey, mapper) => {
+    const current = get().sessions[sessionKey] ?? createInitialGroupsState();
+    const { state, tabIdChanges } = remapTabWorkspacesInState(current, mapper);
+    if (state !== current) {
+      set((s) => ({ sessions: { ...s.sessions, [sessionKey]: state } }));
+    }
+    return tabIdChanges;
+  },
   resetSession: (sessionKey) =>
     set((s) => ({ sessions: { ...s.sessions, [sessionKey]: createInitialGroupsState() } })),
 }));

--- a/docs/features/files-and-editor/README.md
+++ b/docs/features/files-and-editor/README.md
@@ -205,6 +205,21 @@ lane/worktree. Selecting an already-open tab from a different workspace moves
 the explorer back to that tab's workspace so the tree, mutation controls, and
 file actions stay aligned.
 
+Workspace ids are not portable across binding identities. The module-level
+workspace and root-tree caches are keyed by `bindingKey::projectRoot` (where
+`bindingKey` is `local` or `remote:<targetId>`), so a local and a remote
+session for the same path keep separate caches. Editor sessions, however, are
+keyed by project root alone, so a local↔remote rebind keeps tabs and dirty
+buffers open. Because a remote host lists workspaces under its own machine's
+lane UUIDs, a persisted tab's `workspaceId` can be stale after a rebind. After
+each `listWorkspaces`, `remapTabWorkspaces` repairs those tabs — matching by
+`laneId` to the corresponding host workspace, else falling back to the primary
+workspace — recomputing composite tab ids, deduping collisions to the
+authoritative tab, and leaving `external-local:*` tabs untouched. Live Monaco
+models follow via `registry.rekey`, and dirty/reload state is migrated with the
+new ids. See [editor-surfaces.md](./editor-surfaces.md) for the full remap and
+rekey rules.
+
 ## Editor modes
 
 Three modes, each driven by a tab's internal state (no service-side
@@ -376,6 +391,11 @@ For deeper detail on the watcher + trust boundary, see
 - Workspace switching is navigation, not a discard action. Dirty tabs remain
   open and published to the dirty-buffer map under their own workspace root
   until the user saves, closes, renames, deletes, or unloads the tab.
+- `listWorkspaces` failures are retried with a capped backoff
+  (`1s → 2s → 5s → 10s`, then steady) rather than swallowed, so a Files tab
+  opened before a remote runtime finishes connecting fills in its workspace
+  list once the host answers instead of staying empty. Individual file
+  reads/writes are still strict (a bound-runtime failure surfaces to the tab).
 - File watcher subscriptions are per sender (BrowserWindow /
   webContents). Closing a window calls `stopAllForSender` to tear
   down every subscription for that window.

--- a/docs/features/files-and-editor/editor-surfaces.md
+++ b/docs/features/files-and-editor/editor-surfaces.md
@@ -35,13 +35,44 @@ The component accepts `preferredLaneId`, `embedded`, and `active`. The
 implementation path.
 
 Module-level caches keep workspaces and root trees warm across route
-remounts:
+remounts. Both are keyed by the **binding identity** — a `bindingKey`
+of `local` or `remote:<targetId>` joined to the project root path as
+`projectCacheKey = "<bindingKey>::<projectRoot>"` — so a local session
+and a remote session for the same on-disk path never pollute each
+other's cached workspace list or tree:
 
-- `workspacesCacheByProject` keyed by project root
-- `rootTreeCacheByKey` keyed by `projectRoot::workspaceId`
+- `workspacesCacheByProject` keyed by `projectCacheKey`
+- `rootTreeCacheByKey` keyed by `projectCacheKey::workspaceId`
 
 Editor state is kept per `filesSessionKey(projectRoot, laneId)` through
-`useEditorGroupsStore`.
+`useEditorGroupsStore`. Editor sessions are keyed by project root
+(not binding), so open tabs and dirty buffers survive a local↔remote
+rebind of the same path; the tab workspace-remap pass (below) repairs
+any stale workspace ids the rebind leaves behind.
+
+`files.listWorkspaces()` is retried on failure with a capped backoff
+(`1s → 2s → 5s → 10s`, then steady at 10s) instead of being swallowed,
+so a Files tab opened before a remote runtime finishes connecting
+recovers its workspace list on its own once the host answers.
+
+### Restored-tab workspace remap
+
+Restored tabs carry the `workspaceId` they were persisted with, but
+those ids are not portable across binding identities: connecting to a
+remote host lists workspaces whose ids are the **host machine's** lane
+UUIDs, so a locally-persisted tab's `workspaceId` is stale against the
+freshly listed set. After every successful `listWorkspaces`, the
+workbench calls `store.remapTabWorkspaces(sessionKey, mapper)`. The
+mapper keeps any tab whose `workspaceId` is still present (or is an
+`external-local:*` id — those are local-only and deliberately
+untouched) and otherwise remaps by `laneId` to the matching host
+workspace, falling back to the primary workspace (or the first host
+workspace). Composite tab ids (`workspaceId::path`) are recomputed;
+collisions with an authoritative tab dedupe to the authoritative copy;
+`activeTabId` and `recentTabIds` are rewritten to the surviving ids.
+The workbench then migrates the live editor state to the new ids:
+Monaco models are moved with `registry.rekey`, and the dirty-tab set,
+per-tab reload tokens, and dirty-buffer revision follow the remap.
 
 ## Workspace Selector
 
@@ -53,8 +84,11 @@ picker chrome and preselects the active lane worktree. Switching workspaces:
 3. Switches the editor-group session key.
 4. Leaves file service and preload contracts unchanged.
 
-The main-process file service remains the source of truth for read-only
-policy, trust checks, and workspace roots.
+The main-process file service remains the source of truth for path
+safety, trust checks, and workspace roots. There is no read-only /
+view-only workspace policy: every resolved workspace is editable, and
+whether a tab shows editable Monaco is decided purely by viewer kind
+(code tabs edit; image/pdf/large-text viewers are naturally read-only).
 
 ## File Explorer Tree
 
@@ -99,14 +133,24 @@ workspace-relative path. Switching tabs calls `editor.setModel(existing)`
 instead of dispose/recreate, preserving tokenization and undo stacks.
 
 Callers dispose models on tab close, rename/delete cleanup, workspace switch,
-and unmount. Do not dispose models on tab switch, theme change, read-only
-toggle, or group move.
+and unmount. Do not dispose models on tab switch, theme change, or group move.
+
+`registry.rekey(oldKey, newKey)` moves a cached model to a new tab id in
+place so the live buffer, undo stack, and dirty baseline follow a tab-id
+remap (see the restored-tab workspace remap above) instead of being
+disposed and reloaded. On a key collision the dirty buffer wins: if the
+incoming entry has unsaved edits and the resident one does not, the
+resident is disposed and replaced; otherwise the incoming entry is
+discarded.
 
 Dirty tracking is based on Monaco alternative version ids. A save writes
 through the files write bridge, updates the model baseline, invalidates the
-content cache, and refreshes git decorations. The group-level save handler
-also catches `Cmd+S` / `Ctrl+S` while a code tab is in diff mode, saving the
-hidden Monaco model without forcing the user back to edit mode.
+content cache, and refreshes git decorations. Every `code`-viewer tab is
+saveable — the save button and the `Cmd+S` / `Ctrl+S` handler are gated on
+`viewerKind === "code"` alone, with no editability check. The group-level
+save handler also catches `Cmd+S` / `Ctrl+S` while a code tab is in diff
+mode, saving the hidden Monaco model without forcing the user back to edit
+mode.
 
 ## Viewers
 


### PR DESCRIPTION
<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fseeing-issue-where-some-reason-d7b589cc num=780 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fseeing-issue-where-some-reason-d7b589cc&amp;pr=780">ade/seeing-issue-where-some-reason-d7b589cc branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=780">PR #780</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the Files workspace editing path always editable and improves restored-tab handling. The main changes are:

- Removes the read-only edit gate from explorer create, rename, delete, editor save, and code viewer paths.
- Keys workspace and tree caches by local or remote binding identity.
- Retries workspace listing after transient failures with capped backoff.
- Remaps restored tab workspace ids after workspace listing and preserves dirty tabs, reload tokens, and Monaco models.
- Updates tests and docs for the new editability and remapping behavior.

<h3>Confidence Score: 5/5</h3>

This PR appears safe to merge with low risk.

The changes are cohesive, covered by focused tests, and preserve editor state during workspace remapping.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the narrow Vitest suite; it exited with code 0 and 45 tests passed.
- Started the Vite dev server on port 5173 and observed browser mock fallback messages.
- Generated the Playwright UI capture script and attempted the final isolated run; the UI capture failed with net::ERR\_CONNECTION\_REFUSED because no Vite process was available.

<a href="https://app.greptile.com/trex/runs/14015223/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/files/v2/FilesWorkbench.tsx | Makes all resolved workspaces editable, scopes caches by binding identity, retries workspace listing, and remaps stale restored tab workspace ids. |
| apps/desktop/src/renderer/components/files/v2/editorGroupsStore.ts | Adds workspace id remapping for restored editor tabs, skipping external workspaces and deduping collisions. |
| apps/desktop/src/renderer/components/files/monacoModelRegistry.ts | Adds `rekey` support to move live Monaco models across tab id remaps while preserving dirty buffers. |
| apps/desktop/src/renderer/components/files/v2/EditorGroup.tsx | Removes editability gating from save actions and viewer host props. |
| apps/desktop/src/renderer/components/files/FilesExplorer.tsx | Removes the `canMutate` prop and keeps file/folder creation controls enabled in all layouts. |
| docs/features/files-and-editor/editor-surfaces.md | Documents editor surface cache scoping, restored-tab remapping, Monaco rekeying, and always-editable code tabs. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Workbench as FilesWorkbench
participant Runtime as window.ade.files
participant Store as editorGroupsStore
participant Monaco as MonacoModelRegistry
participant Editor as EditorGroup/ViewerHost

Workbench->>Runtime: listWorkspaces()
alt list fails transiently
    Workbench-->>Workbench: retry after 1s/2s/5s/10s
    Workbench->>Runtime: listWorkspaces()
end
Runtime-->>Workbench: authoritative workspaces
Workbench->>Store: remapTabWorkspaces(sessionKey, mapper)
Store-->>Workbench: old tab id to new tab id changes
loop each changed tab id
    Workbench->>Monaco: rekey(oldTabId, newTabId)
end
Workbench-->>Workbench: remap dirty ids and reload tokens
Workbench->>Editor: render tabs with resolved workspace context
Editor->>Runtime: "writeText({ workspaceId, path, text }) on save"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Workbench as FilesWorkbench
participant Runtime as window.ade.files
participant Store as editorGroupsStore
participant Monaco as MonacoModelRegistry
participant Editor as EditorGroup/ViewerHost

Workbench->>Runtime: listWorkspaces()
alt list fails transiently
    Workbench-->>Workbench: retry after 1s/2s/5s/10s
    Workbench->>Runtime: listWorkspaces()
end
Runtime-->>Workbench: authoritative workspaces
Workbench->>Store: remapTabWorkspaces(sessionKey, mapper)
Store-->>Workbench: old tab id to new tab id changes
loop each changed tab id
    Workbench->>Monaco: rekey(oldTabId, newTabId)
end
Workbench-->>Workbench: remap dirty ids and reload tokens
Workbench->>Editor: render tabs with resolved workspace context
Editor->>Runtime: "writeText({ workspaceId, path, text }) on save"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Files tab: remove view-only mode, fix re..."](https://github.com/arul28/ade/commit/47ef42acfc2e695a482fbab2b84b6c06fea299ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43360691)</sub>

<!-- /greptile_comment -->