### PR TITLE
Mobile chat UI overhaul: staged send, question cards, artifact cards

### DIFF
--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
@@ -3668,11 +3668,11 @@ function registerChatRemoteCommands({ args, register }: RemoteCommandRegistratio
     return summarizeChatSessionForRemote(agentChatService, session);
   });
   register("chat.send", { viewerAllowed: true, queueable: true }, async (payload) => {
-    await requireService(args.agentChatService, "Agent chat service not available.").sendMessage(
+    const result = await requireService(args.agentChatService, "Agent chat service not available.").sendMessage(
       parseAgentChatSendArgs(payload),
-      { awaitDispatch: false },
+      { awaitDispatch: false, routeActiveToSteer: true },
     );
-    return { ok: true };
+    return isRecord(result) ? { ...result, ok: true } : { ok: true };
   });
   register("chat.interrupt", { viewerAllowed: true, queueable: false }, async (payload) => {
     await requireService(args.agentChatService, "Agent chat service not available.").interrupt(parseAgentChatInterruptArgs(payload));

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -22981,19 +22981,38 @@ describe("createAgentChatService", () => {
       const result = await service.sendMessage({
         sessionId: session.id,
         text: "Follow up when the active turn finishes",
+        displayText: "Follow up soon",
+        reasoningEffort: "high",
+        executionMode: "subagents",
+        interactionMode: "plan",
       }, { routeActiveToSteer: true });
       expect(result).toMatchObject({ queued: true, steerId: expect.any(String) });
+      // The queued chip shows the display text, not the raw prompt text.
       expect(events.some((event) =>
         event.event.type === "user_message"
-        && event.event.text === "Follow up when the active turn finishes"
+        && event.event.text === "Follow up soon"
         && event.event.deliveryState === "queued"
       )).toBe(true);
 
       finishActiveTurn();
       await activeTurn;
       await vi.waitFor(() => {
+        // The delivered prompt carries the raw text plus the applied execution
+        // and interaction mode directives.
         expect(send).toHaveBeenCalledWith(expect.stringContaining("Follow up when the active turn finishes"));
+        const deliveredPrompt = send.mock.calls
+          .map((call) => String(call[0]))
+          .find((prompt) => prompt.includes("Follow up when the active turn finishes"));
+        expect(deliveredPrompt).toContain("Use Claude subagents");
+        expect(deliveredPrompt).toContain("plan mode for this turn");
       });
+      // The delivered transcript message keeps the display text distinct from
+      // the raw prompt text.
+      expect(events.some((event) =>
+        event.event.type === "user_message"
+        && event.event.deliveryState !== "queued"
+        && (event.event.displayText === "Follow up soon" || event.event.text === "Follow up soon")
+      )).toBe(true);
     });
 
     it("does not steer an empty send during an active turn", async () => {

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -22996,6 +22996,70 @@ describe("createAgentChatService", () => {
       });
     });
 
+    it("does not steer an empty send during an active turn", async () => {
+      const events: AgentChatEventEnvelope[] = [];
+      const send = vi.fn().mockResolvedValue(undefined);
+      let streamCall = 0;
+      let finishActiveTurn!: () => void;
+      const activeTurnGate = new Promise<void>((resolve) => { finishActiveTurn = resolve; });
+
+      const stream = vi.fn(() => (async function* () {
+        streamCall += 1;
+        if (streamCall === 1) {
+          yield { type: "system", subtype: "init", session_id: "sdk-empty-steer", slash_commands: [] };
+          return;
+        }
+        yield {
+          type: "assistant",
+          message: { content: [{ type: "text", text: "Still working" }], usage: { input_tokens: 1, output_tokens: 1 } },
+        };
+        await activeTurnGate;
+        yield { type: "result", usage: { input_tokens: 1, output_tokens: 1 } };
+      })());
+
+      vi.mocked(claudeSdkCreateSessionCompat).mockReturnValue({
+        send,
+        stream,
+        close: vi.fn(),
+        sessionId: "sdk-empty-steer",
+        setPermissionMode: vi.fn().mockResolvedValue(undefined),
+      } as any);
+
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "claude",
+        model: "sonnet",
+      });
+
+      const activeTurn = service.runSessionTurn({
+        sessionId: session.id,
+        text: "Do the foreground work",
+        timeoutMs: 15_000,
+      });
+      await waitForEvent(
+        events,
+        (event): event is AgentChatEventEnvelope =>
+          event.event.type === "text" && event.event.text.includes("Still working"),
+      );
+
+      const result = await service.sendMessage({
+        sessionId: session.id,
+        text: "   ",
+      }, { routeActiveToSteer: true });
+      expect(result).toBeUndefined();
+      expect(events.some((event) =>
+        event.event.type === "user_message" && event.event.deliveryState === "queued",
+      )).toBe(false);
+
+      finishActiveTurn();
+      await activeTurn;
+      // A queued steer would have started a third stream turn on delivery.
+      expect(streamCall).toBe(2);
+    });
+
     it("defers wake messages to the active Claude turn boundary", async () => {
       const events: AgentChatEventEnvelope[] = [];
       const send = vi.fn().mockResolvedValue(undefined);

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -22920,6 +22920,82 @@ describe("createAgentChatService", () => {
   // --------------------------------------------------------------------------
 
   describe("steer", () => {
+    it("routes a send during an active Claude turn through the queued steer path", async () => {
+      const events: AgentChatEventEnvelope[] = [];
+      const send = vi.fn().mockResolvedValue(undefined);
+      const setPermissionMode = vi.fn().mockResolvedValue(undefined);
+      let streamCall = 0;
+      let finishActiveTurn!: () => void;
+      const activeTurnGate = new Promise<void>((resolve) => { finishActiveTurn = resolve; });
+
+      const stream = vi.fn(() => (async function* () {
+        streamCall += 1;
+        if (streamCall === 1) {
+          yield { type: "system", subtype: "init", session_id: "sdk-send-to-steer", slash_commands: [] };
+          return;
+        }
+        if (streamCall === 2) {
+          yield {
+            type: "assistant",
+            message: { content: [{ type: "text", text: "Still working" }], usage: { input_tokens: 1, output_tokens: 1 } },
+          };
+          await activeTurnGate;
+          yield { type: "result", usage: { input_tokens: 1, output_tokens: 1 } };
+          return;
+        }
+        yield {
+          type: "assistant",
+          message: { content: [{ type: "text", text: "Queued send delivered" }], usage: { input_tokens: 1, output_tokens: 1 } },
+        };
+        yield { type: "result", usage: { input_tokens: 1, output_tokens: 1 } };
+      })());
+
+      vi.mocked(claudeSdkCreateSessionCompat).mockReturnValue({
+        send,
+        stream,
+        close: vi.fn(),
+        sessionId: "sdk-send-to-steer",
+        setPermissionMode,
+      } as any);
+
+      const { service } = createService({
+        onEvent: (event: AgentChatEventEnvelope) => events.push(event),
+      });
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "claude",
+        model: "sonnet",
+      });
+
+      const activeTurn = service.runSessionTurn({
+        sessionId: session.id,
+        text: "Do the foreground work",
+        timeoutMs: 15_000,
+      });
+      await waitForEvent(
+        events,
+        (event): event is AgentChatEventEnvelope =>
+          event.event.type === "text" && event.event.text.includes("Still working"),
+      );
+
+      const result = await service.sendMessage({
+        sessionId: session.id,
+        text: "Follow up when the active turn finishes",
+      }, { routeActiveToSteer: true });
+      expect(result).toMatchObject({ queued: true, steerId: expect.any(String) });
+      expect(events.some((event) =>
+        event.event.type === "user_message"
+        && event.event.text === "Follow up when the active turn finishes"
+        && event.event.deliveryState === "queued"
+      )).toBe(true);
+
+      finishActiveTurn();
+      await activeTurn;
+      await vi.waitFor(() => {
+        expect(send).toHaveBeenCalledWith(expect.stringContaining("Follow up when the active turn finishes"));
+      });
+    });
+
     it("defers wake messages to the active Claude turn boundary", async () => {
       const events: AgentChatEventEnvelope[] = [];
       const send = vi.fn().mockResolvedValue(undefined);

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -27393,7 +27393,10 @@ export function createAgentChatService(args: {
     const dispatchStartedAt = Date.now();
     if (await maybeHandleClaudeOutputStyleSlashCommand(args)) return;
     const managed = ensureManagedSession(args.sessionId);
-    if (options?.routeActiveToSteer && canRouteActiveSendToSteer(managed)) {
+    // Empty sends fall through to prepareSendMessage's no-op path instead of
+    // steering, so they don't report queued:false as a delivered message.
+    const routableText = args.text.trim().length > 0 || (args.contextAttachments?.length ?? 0) > 0;
+    if (options?.routeActiveToSteer && routableText && canRouteActiveSendToSteer(managed)) {
       return steer({
         sessionId: args.sessionId,
         text: args.text,

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -569,9 +569,13 @@ type PersistedChatState = {
 type PersistedPendingSteer = {
   steerId: string;
   text: string;
+  displayText?: string;
   attachments?: AgentChatFileRef[];
   contextAttachments?: AgentChatContextAttachment[];
   metadata?: AgentChatEventMetadata | null | undefined;
+  reasoningEffort?: string | null;
+  executionMode?: AgentChatExecutionMode | null;
+  interactionMode?: AgentChatInteractionMode | null;
 };
 
 type PendingRpc = {
@@ -725,10 +729,14 @@ type CodexRuntime = {
 type QueuedSteer = {
   steerId: string;
   text: string;
+  displayText?: string;
   attachments: AgentChatFileRef[];
   contextAttachments: AgentChatContextAttachment[];
   resolvedAttachments: ResolvedAgentChatFileRef[];
   metadata?: AgentChatEventMetadata | null | undefined;
+  reasoningEffort?: string | null;
+  executionMode?: AgentChatExecutionMode | null;
+  interactionMode?: AgentChatInteractionMode | null;
 };
 
 type ClaudeActiveSubagent = {
@@ -9404,9 +9412,13 @@ export function createAgentChatService(args: {
             pendingSteers: managed.runtime.pendingSteers.map((s): PersistedPendingSteer => ({
               steerId: s.steerId,
               text: s.text,
+              ...(s.displayText ? { displayText: s.displayText } : {}),
               ...(s.attachments.length ? { attachments: s.attachments } : {}),
               ...(s.contextAttachments.length ? { contextAttachments: s.contextAttachments } : {}),
               ...(s.metadata ? { metadata: s.metadata } : {}),
+              ...(s.reasoningEffort != null ? { reasoningEffort: s.reasoningEffort } : {}),
+              ...(s.executionMode ? { executionMode: s.executionMode } : {}),
+              ...(s.interactionMode ? { interactionMode: s.interactionMode } : {}),
             })),
           }
         : prevPersisted?.pendingSteers?.length ? { pendingSteers: prevPersisted.pendingSteers } : {}),
@@ -22227,6 +22239,7 @@ export function createAgentChatService(args: {
       persistChatState(managed);
       return false;
     }
+    const displayText = nextSteer.displayText?.trim().length ? nextSteer.displayText.trim() : trimmed;
 
     emitChatEvent(managed, {
       type: "system_notice",
@@ -22245,6 +22258,17 @@ export function createAgentChatService(args: {
       purpose: "deliver queued steer",
     });
     const personalSession = isPersonalSession(managed.session);
+    // Apply the per-send execution/interaction mode captured when the steer was
+    // queued, mirroring prepareSendMessage's session mutation + directives.
+    if (managed.session.provider === "claude") {
+      managed.session.interactionMode = nextSteer.interactionMode ?? managed.session.interactionMode ?? "default";
+      managed.session.permissionMode = syncLegacyPermissionMode(managed.session) ?? managed.session.permissionMode;
+    }
+    if (nextSteer.executionMode) {
+      managed.session.executionMode = nextSteer.executionMode;
+    } else if (managed.session.executionMode == null) {
+      managed.session.executionMode = "focused";
+    }
     const laneDirectiveKey = personalSession ? null : executionContext.laneDirectiveKey;
     const shouldInjectLaneDirective =
       laneDirectiveKey != null && managed.lastLaneDirectiveKey !== laneDirectiveKey;
@@ -22256,13 +22280,16 @@ export function createAgentChatService(args: {
           })
         : null,
       personalChatUserPromptFallback(managed.session),
+      personalSession ? null : buildExecutionModeDirective(nextSteer.executionMode, managed.session.provider),
+      personalSession ? null : buildClaudeInteractionModeDirective(managed.session.interactionMode, managed.session.provider),
       buildChatContextAttachmentPrompt(nextSteer.contextAttachments) || null,
     ]);
 
     if (runtime.kind === "claude") {
       await runClaudeTurn(managed, {
         promptText,
-        displayText: trimmed,
+        userText: trimmed,
+        displayText,
         attachments: nextSteer.attachments,
         contextAttachments: nextSteer.contextAttachments,
         resolvedAttachments: nextSteer.resolvedAttachments,
@@ -22272,7 +22299,8 @@ export function createAgentChatService(args: {
     } else if (runtime.kind === "cursor") {
       await runCursorTurn(managed, {
         promptText,
-        displayText: trimmed,
+        userText: trimmed,
+        displayText,
         attachments: nextSteer.attachments,
         contextAttachments: nextSteer.contextAttachments,
         resolvedAttachments: nextSteer.resolvedAttachments,
@@ -22282,7 +22310,8 @@ export function createAgentChatService(args: {
     } else if (runtime.kind === "droid") {
       await runDroidTurn(managed, {
         promptText,
-        displayText: trimmed,
+        userText: trimmed,
+        displayText,
         attachments: nextSteer.attachments,
         contextAttachments: nextSteer.contextAttachments,
         resolvedAttachments: nextSteer.resolvedAttachments,
@@ -22292,7 +22321,8 @@ export function createAgentChatService(args: {
     } else {
       await runTurn(managed, {
         promptText,
-        displayText: trimmed,
+        userText: trimmed,
+        displayText,
         attachments: nextSteer.attachments,
         contextAttachments: nextSteer.contextAttachments,
         resolvedAttachments: nextSteer.resolvedAttachments,
@@ -22315,6 +22345,12 @@ export function createAgentChatService(args: {
     contextAttachments: AgentChatContextAttachment[] = [],
     resolvedAttachments: ResolvedAgentChatFileRef[] = [],
     metadata?: AgentChatEventMetadata | null,
+    extra?: {
+      displayText?: string;
+      reasoningEffort?: string | null;
+      executionMode?: AgentChatExecutionMode | null;
+      interactionMode?: AgentChatInteractionMode | null;
+    },
   ): boolean => {
     if (runtime.pendingSteers.length >= MAX_PENDING_STEERS && !metadata?.scheduledWake) {
       logger.warn("agent_chat.steer_queue_full", { sessionId, queueSize: runtime.pendingSteers.length });
@@ -22326,13 +22362,25 @@ export function createAgentChatService(args: {
       });
       return false;
     }
-    runtime.pendingSteers.push({ steerId, text, attachments, contextAttachments, resolvedAttachments, ...(metadata ? { metadata } : {}) });
+    const displayText = extra?.displayText?.trim().length ? extra.displayText.trim() : text;
+    runtime.pendingSteers.push({
+      steerId,
+      text,
+      attachments,
+      contextAttachments,
+      resolvedAttachments,
+      ...(metadata ? { metadata } : {}),
+      ...(displayText !== text ? { displayText } : {}),
+      ...(extra?.reasoningEffort != null ? { reasoningEffort: extra.reasoningEffort } : {}),
+      ...(extra?.executionMode ? { executionMode: extra.executionMode } : {}),
+      ...(extra?.interactionMode ? { interactionMode: extra.interactionMode } : {}),
+    });
     const queuedMetadata = metadata?.scheduledWake
       ? Object.fromEntries(Object.entries(metadata).filter(([key]) => key !== "scheduledWake"))
       : metadata;
     emitChatEvent(managed, {
       type: "user_message",
-      text,
+      text: displayText,
       ...(attachments.length ? { attachments } : {}),
       ...(contextAttachments.length ? { contextAttachments } : {}),
       ...(queuedMetadata && Object.keys(queuedMetadata).length ? { metadata: queuedMetadata } : {}),
@@ -22527,10 +22575,14 @@ export function createAgentChatService(args: {
       out.push({
         steerId: entry.steerId,
         text,
+        ...(entry.displayText?.trim().length ? { displayText: entry.displayText.trim() } : {}),
         attachments,
         contextAttachments,
         resolvedAttachments,
         ...(entry.metadata ? { metadata: entry.metadata } : {}),
+        ...(typeof entry.reasoningEffort === "string" ? { reasoningEffort: entry.reasoningEffort } : {}),
+        ...(entry.executionMode ? { executionMode: entry.executionMode } : {}),
+        ...(entry.interactionMode ? { interactionMode: entry.interactionMode } : {}),
       });
       if (out.length >= MAX_PENDING_STEERS) break;
     }
@@ -27400,9 +27452,13 @@ export function createAgentChatService(args: {
       return steer({
         sessionId: args.sessionId,
         text: args.text,
+        displayText: args.displayText,
         attachments: args.attachments,
         contextAttachments: args.contextAttachments,
         metadata: args.metadata,
+        reasoningEffort: args.reasoningEffort,
+        executionMode: args.executionMode,
+        interactionMode: args.interactionMode,
       });
     }
     const prepared = prepareSendMessage(args);
@@ -27510,7 +27566,7 @@ export function createAgentChatService(args: {
     }
   }
 
-  const steer = async ({ sessionId, text, attachments = [], contextAttachments = [], metadata }: AgentChatSteerArgs): Promise<AgentChatSteerResult> => {
+  const steer = async ({ sessionId, text, displayText, attachments = [], contextAttachments = [], metadata, reasoningEffort, executionMode, interactionMode }: AgentChatSteerArgs): Promise<AgentChatSteerResult> => {
     const trimmed = text.trim();
     const steerId = randomUUID();
     // Allow context-only steers: if text is empty but issue context attachments
@@ -27531,7 +27587,7 @@ export function createAgentChatService(args: {
         const preparedSteer = prepareSendMessage({
           sessionId,
           text: trimmed,
-          displayText: trimmed,
+          displayText: displayText ?? trimmed,
           attachments,
           contextAttachments,
           metadata,
@@ -27544,18 +27600,19 @@ export function createAgentChatService(args: {
           runtime,
           sessionId,
           steerId,
-          preparedSteer.visibleText,
+          preparedSteer.submittedText,
           preparedSteer.attachments,
           preparedSteer.contextAttachments,
           preparedSteer.resolvedAttachments,
           preparedSteer.metadata,
+          { displayText: preparedSteer.visibleText, reasoningEffort, executionMode, interactionMode },
         );
         return { steerId, queued: true };
       }
       const preparedSteer = prepareSendMessage({
         sessionId,
         text: trimmed,
-        displayText: trimmed,
+        displayText: displayText ?? trimmed,
         attachments,
         contextAttachments,
         metadata,
@@ -27573,7 +27630,7 @@ export function createAgentChatService(args: {
         const preparedSteer = prepareSendMessage({
           sessionId,
           text: trimmed,
-          displayText: trimmed,
+          displayText: displayText ?? trimmed,
           attachments,
           contextAttachments,
           metadata,
@@ -27594,11 +27651,15 @@ export function createAgentChatService(args: {
         }
         rt.pendingSteers.push({
           steerId,
-          text: preparedSteer.visibleText,
+          text: preparedSteer.submittedText,
+          ...(preparedSteer.visibleText !== preparedSteer.submittedText ? { displayText: preparedSteer.visibleText } : {}),
           attachments: preparedSteer.attachments,
           contextAttachments: preparedSteer.contextAttachments,
           resolvedAttachments: preparedSteer.resolvedAttachments,
           ...(preparedSteer.metadata ? { metadata: preparedSteer.metadata } : {}),
+          ...(reasoningEffort != null ? { reasoningEffort } : {}),
+          ...(executionMode ? { executionMode } : {}),
+          ...(interactionMode ? { interactionMode } : {}),
         });
         emitChatEvent(managed, {
           type: "user_message",
@@ -27623,7 +27684,7 @@ export function createAgentChatService(args: {
       const preparedSteer = prepareSendMessage({
         sessionId,
         text: trimmed,
-        displayText: trimmed,
+        displayText: displayText ?? trimmed,
         attachments,
         contextAttachments,
         metadata,
@@ -27641,7 +27702,7 @@ export function createAgentChatService(args: {
         const preparedSteer = prepareSendMessage({
           sessionId,
           text: trimmed,
-          displayText: trimmed,
+          displayText: displayText ?? trimmed,
           attachments: [],
           contextAttachments,
           metadata,
@@ -27663,10 +27724,14 @@ export function createAgentChatService(args: {
         rt.pendingSteers.push({
           steerId,
           text: preparedSteer.submittedText,
+          ...(preparedSteer.visibleText !== preparedSteer.submittedText ? { displayText: preparedSteer.visibleText } : {}),
           attachments: [],
           contextAttachments: preparedSteer.contextAttachments,
           resolvedAttachments: [],
           ...(preparedSteer.metadata ? { metadata: preparedSteer.metadata } : {}),
+          ...(reasoningEffort != null ? { reasoningEffort } : {}),
+          ...(executionMode ? { executionMode } : {}),
+          ...(interactionMode ? { interactionMode } : {}),
         });
         emitChatEvent(managed, {
           type: "user_message",
@@ -27690,7 +27755,7 @@ export function createAgentChatService(args: {
       const preparedSteer = prepareSendMessage({
         sessionId,
         text: trimmed,
-        displayText: trimmed,
+        displayText: displayText ?? trimmed,
         attachments: [],
         contextAttachments,
         metadata,
@@ -27709,7 +27774,7 @@ export function createAgentChatService(args: {
       const preparedSteer = prepareSendMessage({
         sessionId,
         text: trimmed,
-        displayText: trimmed,
+        displayText: displayText ?? trimmed,
         attachments,
         contextAttachments,
         metadata,
@@ -27797,7 +27862,7 @@ export function createAgentChatService(args: {
     const preparedSteer = prepareSendMessage({
       sessionId,
       text: trimmed,
-      displayText: trimmed,
+      displayText: displayText ?? trimmed,
       attachments,
       contextAttachments,
       metadata,
@@ -27813,11 +27878,12 @@ export function createAgentChatService(args: {
           runtime,
           sessionId,
           steerId,
-          preparedSteer.visibleText,
+          preparedSteer.submittedText,
           preparedSteer.attachments,
           preparedSteer.contextAttachments,
           preparedSteer.resolvedAttachments,
           preparedSteer.metadata,
+          { displayText: preparedSteer.visibleText, reasoningEffort, executionMode, interactionMode },
         );
         return { steerId, queued: true };
       }
@@ -27964,6 +28030,7 @@ export function createAgentChatService(args: {
     }
 
     runtime.pendingSteers[idx].text = trimmed;
+    runtime.pendingSteers[idx].displayText = undefined;
     emitChatEvent(managed, {
       type: "user_message",
       text: trimmed,

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -27366,12 +27366,42 @@ export function createAgentChatService(args: {
     return true;
   };
 
-  const sendMessage = async (
+  const canRouteActiveSendToSteer = (managed: ManagedChatSession): boolean => {
+    const runtime = managed.runtime;
+    if (!runtime) return false;
+    if (runtime.kind === "codex") {
+      return Boolean(managed.session.threadId && runtime.activeTurnId);
+    }
+    if (runtime.kind === "claude" || runtime.kind === "opencode") {
+      return runtime.busy || managed.session.status === "active";
+    }
+    return runtime.busy;
+  };
+
+  async function sendMessage(
     args: AgentChatSendArgs,
-    options?: { awaitDispatch?: boolean },
-  ): Promise<void> => {
+    options: { awaitDispatch?: boolean; routeActiveToSteer: true },
+  ): Promise<void | AgentChatSteerResult>;
+  async function sendMessage(
+    args: AgentChatSendArgs,
+    options?: { awaitDispatch?: boolean; routeActiveToSteer?: false },
+  ): Promise<void>;
+  async function sendMessage(
+    args: AgentChatSendArgs,
+    options?: { awaitDispatch?: boolean; routeActiveToSteer?: boolean },
+  ): Promise<void | AgentChatSteerResult> {
     const dispatchStartedAt = Date.now();
     if (await maybeHandleClaudeOutputStyleSlashCommand(args)) return;
+    const managed = ensureManagedSession(args.sessionId);
+    if (options?.routeActiveToSteer && canRouteActiveSendToSteer(managed)) {
+      return steer({
+        sessionId: args.sessionId,
+        text: args.text,
+        attachments: args.attachments,
+        contextAttachments: args.contextAttachments,
+        metadata: args.metadata,
+      });
+    }
     const prepared = prepareSendMessage(args);
     if (!prepared) return;
     prepared.managed.lastActivityTimestamp = Date.now();
@@ -27475,7 +27505,7 @@ export function createAgentChatService(args: {
     if (dispatchPromise) {
       await dispatchPromise;
     }
-  };
+  }
 
   const steer = async ({ sessionId, text, attachments = [], contextAttachments = [], metadata }: AgentChatSteerArgs): Promise<AgentChatSteerResult> => {
     const trimmed = text.trim();

--- a/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
+++ b/apps/desktop/src/main/services/sync/syncRemoteCommandService.test.ts
@@ -1606,6 +1606,7 @@ describe("createSyncRemoteCommandService", () => {
         text: "hello",
       }, {
         awaitDispatch: false,
+        routeActiveToSteer: true,
       });
       expect(result).toEqual({ ok: true });
     });
@@ -1814,6 +1815,7 @@ describe("createSyncRemoteCommandService", () => {
           ],
         }, {
           awaitDispatch: false,
+          routeActiveToSteer: true,
         });
       });
 
@@ -1882,6 +1884,7 @@ describe("createSyncRemoteCommandService", () => {
           interactionMode: "chat",
         }, {
           awaitDispatch: false,
+          routeActiveToSteer: true,
         });
       });
 

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -1792,9 +1792,13 @@ export type AgentChatSendArgs = {
 export type AgentChatSteerArgs = {
   sessionId: string;
   text: string;
+  displayText?: string;
   attachments?: AgentChatFileRef[];
   contextAttachments?: AgentChatContextAttachment[];
   metadata?: AgentChatEventMetadata | null | undefined;
+  reasoningEffort?: string | null;
+  executionMode?: AgentChatExecutionMode | null;
+  interactionMode?: AgentChatInteractionMode | null;
 };
 
 export type AgentChatSteerResult = {

--- a/apps/ios/ADE/Views/Work/WorkArtifactTerminalViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkArtifactTerminalViews.swift
@@ -44,21 +44,23 @@ struct WorkArtifactView: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 10) {
-      HStack(spacing: 10) {
-        Image(systemName: artifact.artifactKind == "video_recording" ? "video.fill" : "photo.fill")
+      HStack(alignment: .top, spacing: 10) {
+        Image(systemName: workArtifactKindIcon(artifact))
+          .font(.system(size: 15, weight: .semibold))
           .foregroundStyle(ADEColor.accent)
+          .frame(width: 36, height: 36)
+          .background(ADEColor.accent.opacity(0.12), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
         VStack(alignment: .leading, spacing: 3) {
           Text(artifact.title)
             .font(.subheadline.weight(.semibold))
             .foregroundStyle(ADEColor.textPrimary)
-          Text(artifact.artifactKind.replacingOccurrences(of: "_", with: " ").capitalized)
+            .lineLimit(2)
+            .truncationMode(.tail)
+          Text([workArtifactKindLabel(artifact.artifactKind), relativeTimestamp(artifact.createdAt)].joined(separator: " · "))
             .font(.caption)
             .foregroundStyle(ADEColor.textSecondary)
         }
-        Spacer()
-        Text(relativeTimestamp(artifact.createdAt))
-          .font(.caption2)
-          .foregroundStyle(ADEColor.textMuted)
+        Spacer(minLength: 0)
       }
 
       Group {
@@ -98,9 +100,7 @@ struct WorkArtifactView: View {
         case .text(let text):
           WorkStructuredOutputBlock(title: "Artifact", text: text)
         case .error(let message):
-          Text(message)
-            .font(.caption)
-            .foregroundStyle(ADEColor.danger)
+          WorkArtifactInlineStatus(icon: "photo", message: message, tint: ADEColor.textMuted)
         case .none:
           HStack(spacing: 10) {
             ProgressView()
@@ -873,7 +873,8 @@ private struct WorkArtifactSelectedPreview: View {
           Text(artifact.title)
             .font(.headline)
             .foregroundStyle(ADEColor.textPrimary)
-            .fixedSize(horizontal: false, vertical: true)
+            .lineLimit(2)
+            .truncationMode(.tail)
 
           Text([workArtifactKindLabel(artifact.artifactKind), artifact.backendName, relativeTimestamp(artifact.createdAt)].joined(separator: " · "))
             .font(.caption)

--- a/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
@@ -800,9 +800,10 @@ struct WorkQueuedSteerRow: View {
             tint: ADEColor.textSecondary,
             label: "Edit",
             hint: nil,
-            identifier: "Work.Chat.StagedStrip.Edit",
-            syncAction: onBeginEdit
-          )
+            identifier: "Work.Chat.StagedStrip.Edit"
+          ) {
+            onBeginEdit()
+          }
 
           steerActionButton(
             systemImage: "xmark",
@@ -834,15 +835,10 @@ struct WorkQueuedSteerRow: View {
     label: String,
     hint: String?,
     identifier: String,
-    syncAction: (() -> Void)? = nil,
-    action: (@MainActor () async -> Void)? = nil
+    action: @escaping @MainActor () async -> Void
   ) -> some View {
     Button {
-      if let syncAction {
-        syncAction()
-      } else if let action {
-        Task { await action() }
-      }
+      Task { await action() }
     } label: {
       Image(systemName: systemImage)
         .font(.system(size: 14, weight: .semibold))
@@ -925,7 +921,7 @@ struct WorkStructuredQuestionCard: View {
   @State private var selections: [String: Set<String>] = [:]
   @State private var freeformByQuestion: [String: String] = [:]
   @State private var expandedPreviews: Set<String> = []
-  @State private var measuredBodyHeight: CGFloat = -1
+  @State private var measuredBodyHeight: CGFloat? = nil
   @FocusState private var freeformFocused: Bool
 
   private var isPaged: Bool { question.questions.count > 1 }
@@ -942,8 +938,8 @@ struct WorkStructuredQuestionCard: View {
   /// scroll internally. Falls back to the cap until the first measurement lands.
   private var resolvedBodyHeight: CGFloat {
     let cap = bodyMaxHeight
-    guard measuredBodyHeight >= 0 else { return cap }
-    return min(measuredBodyHeight, cap)
+    guard let measured = measuredBodyHeight else { return cap }
+    return min(measured, cap)
   }
 
   var body: some View {
@@ -968,8 +964,13 @@ struct WorkStructuredQuestionCard: View {
       .frame(height: resolvedBodyHeight)
       .scrollBounceBehavior(.basedOnSize)
       .onPreferenceChange(WorkQuestionBodyHeightKey.self) { height in
-        guard measuredBodyHeight < 0 || abs(measuredBodyHeight - height) > 0.5 else { return }
-        measuredBodyHeight = height
+        guard let measured = measuredBodyHeight else {
+          measuredBodyHeight = height
+          return
+        }
+        if abs(measured - height) > 0.5 {
+          measuredBodyHeight = height
+        }
       }
 
       if activeQuestion.allowsFreeform {

--- a/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift
@@ -747,90 +747,72 @@ struct WorkQueuedSteerRow: View {
           }
         }
       } else {
-        // Disposition ribbon mirrors the desktop staging-card treatment so
-        // users see at a glance what will happen with this message and that
-        // it hasn't been sent yet.
-        HStack(spacing: 6) {
-          Text("Sends after turn")
-            .font(.caption2.weight(.semibold))
-            .foregroundStyle(ADEColor.accent)
-            .padding(.horizontal, 7)
-            .padding(.vertical, 2)
-            .background(ADEColor.accent.opacity(0.12), in: Capsule())
-          Text(relativeTimestamp(steer.timestamp))
-            .font(.caption2)
-            .foregroundStyle(ADEColor.textMuted)
-          Spacer(minLength: 0)
-        }
-
-        // Clip the preview at two lines so long queued messages don't blow
-        // out the composer. Full text is still reachable via Edit.
+        // Compact row (mirrors the desktop staged strip): one truncated line of
+        // text, then a muted disposition + timestamp line with icon-only actions.
+        // Icon-only buttons are the fix for mid-word label wrapping ("Inter-rupt")
+        // that the old titleAndIcon chips hit in this non-scrolling HStack.
         Text(steer.text)
-          .font(.caption)
+          .font(.system(size: 13.5))
           .foregroundStyle(ADEColor.textPrimary)
-          .lineLimit(2)
+          .lineLimit(1)
           .truncationMode(.tail)
           .frame(maxWidth: .infinity, alignment: .leading)
 
-        HStack(spacing: 8) {
-          Spacer(minLength: 0)
+        HStack(spacing: 6) {
+          Text("Sends after turn")
+            .font(.caption2)
+            .foregroundStyle(ADEColor.textMuted)
+          Text("·")
+            .font(.caption2)
+            .foregroundStyle(ADEColor.textMuted)
+          Text(relativeTimestamp(steer.timestamp))
+            .font(.caption2)
+            .foregroundStyle(ADEColor.textMuted)
+
+          Spacer(minLength: 8)
+
           if let onDispatchInline {
-            Button {
-              Task { await onDispatchInline() }
-            } label: {
-              Label("Send now", systemImage: "arrow.turn.down.right")
-                .labelStyle(.titleAndIcon)
-                .font(.caption2.weight(.semibold))
+            steerActionButton(
+              systemImage: "paperplane.fill",
+              tint: ADEColor.accent,
+              label: "Send now",
+              hint: "Fold this message into the active turn",
+              identifier: "Work.Chat.StagedStrip.SendNow"
+            ) {
+              await onDispatchInline()
             }
-            .buttonStyle(.glass)
-            .tint(ADEColor.accent)
-            .controlSize(.mini)
-            .disabled(busy || !isLive)
-            .accessibilityHint("Fold this message into the active turn")
-            .accessibilityIdentifier("Work.Chat.StagedStrip.SendNow")
           }
 
           if let onDispatchInterrupt {
-            Button {
-              Task { await onDispatchInterrupt() }
-            } label: {
-              Label("Interrupt", systemImage: "bolt.fill")
-                .labelStyle(.titleAndIcon)
-                .font(.caption2.weight(.semibold))
+            steerActionButton(
+              systemImage: "bolt.fill",
+              tint: ADEColor.warning,
+              label: "Interrupt",
+              hint: "Stop the current turn and run this instead",
+              identifier: "Work.Chat.StagedStrip.Interrupt"
+            ) {
+              await onDispatchInterrupt()
             }
-            .buttonStyle(.glass)
-            .tint(ADEColor.warning)
-            .controlSize(.mini)
-            .disabled(busy || !isLive)
-            .accessibilityHint("Stop the current turn and run this instead")
-            .accessibilityIdentifier("Work.Chat.StagedStrip.Interrupt")
           }
 
-          Button {
-            onBeginEdit()
-          } label: {
-            Label("Edit", systemImage: "pencil")
-              .labelStyle(.titleAndIcon)
-              .font(.caption2.weight(.semibold))
-          }
-          .buttonStyle(.glass)
-          .tint(ADEColor.accent)
-          .controlSize(.mini)
-          .disabled(busy || !isLive)
-          .accessibilityIdentifier("Work.Chat.StagedStrip.Edit")
+          steerActionButton(
+            systemImage: "pencil",
+            tint: ADEColor.textSecondary,
+            label: "Edit",
+            hint: nil,
+            identifier: "Work.Chat.StagedStrip.Edit",
+            syncAction: onBeginEdit
+          )
 
-          Button(role: .destructive) {
-            Task { await onCancel() }
-          } label: {
-            Label("Cancel", systemImage: "xmark")
-              .labelStyle(.titleAndIcon)
-              .font(.caption2.weight(.semibold))
+          steerActionButton(
+            systemImage: "xmark",
+            tint: ADEColor.danger,
+            label: "Cancel staged message",
+            hint: nil,
+            identifier: "Work.Chat.StagedStrip.Cancel"
+          ) {
+            await onCancel()
           }
-          .buttonStyle(.glass)
-          .tint(ADEColor.danger)
-          .controlSize(.mini)
-          .disabled(busy || !isLive)
-          .accessibilityIdentifier("Work.Chat.StagedStrip.Cancel")
         }
       }
     }
@@ -841,6 +823,38 @@ struct WorkQueuedSteerRow: View {
         .stroke(ADEColor.glassBorder, lineWidth: 0.5)
     )
     .accessibilityElement(children: .contain)
+  }
+
+  // Icon-only tap target (≥32pt) with an accessibility label so the row's
+  // actions stay compact and never wrap their titles.
+  @ViewBuilder
+  private func steerActionButton(
+    systemImage: String,
+    tint: Color,
+    label: String,
+    hint: String?,
+    identifier: String,
+    syncAction: (() -> Void)? = nil,
+    action: (@MainActor () async -> Void)? = nil
+  ) -> some View {
+    Button {
+      if let syncAction {
+        syncAction()
+      } else if let action {
+        Task { await action() }
+      }
+    } label: {
+      Image(systemName: systemImage)
+        .font(.system(size: 14, weight: .semibold))
+        .foregroundStyle(tint)
+        .frame(width: 34, height: 32)
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+    .disabled(busy || !isLive)
+    .accessibilityLabel(label)
+    .accessibilityHint(hint ?? "")
+    .accessibilityIdentifier(identifier)
   }
 }
 
@@ -866,6 +880,15 @@ func workPreviewIsWireframe(_ text: String) -> Bool {
   return alignedColumnLines.count >= 2
 }
 
+/// Natural height of the question card's scrollable body, used to fit the
+/// internal ScrollView to its content up to the viewport-derived cap.
+private struct WorkQuestionBodyHeightKey: PreferenceKey {
+  static var defaultValue: CGFloat = 0
+  static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+    value = max(value, nextValue())
+  }
+}
+
 struct WorkStructuredQuestionCard: View {
   let question: WorkPendingQuestionModel
   let busy: Bool
@@ -882,6 +905,9 @@ struct WorkStructuredQuestionCard: View {
   /// Provider to fall back on when the parsed question carries no `source`
   /// (legacy `structured_question` envelopes). Usually the session provider.
   var fallbackProvider: String? = nil
+  /// Transcript viewport height, used to cap the card so long option lists
+  /// scroll internally instead of overflowing the screen. 0 until measured.
+  var viewportHeight: CGFloat = 0
 
   /// Resolved asking provider: the parsed question source, else the session
   /// fallback. Drives the header verb, logo, and per-provider accent.
@@ -899,6 +925,7 @@ struct WorkStructuredQuestionCard: View {
   @State private var selections: [String: Set<String>] = [:]
   @State private var freeformByQuestion: [String: String] = [:]
   @State private var expandedPreviews: Set<String> = []
+  @State private var measuredBodyHeight: CGFloat = -1
   @FocusState private var freeformFocused: Bool
 
   private var isPaged: Bool { question.questions.count > 1 }
@@ -908,25 +935,44 @@ struct WorkStructuredQuestionCard: View {
     return question.questions[index]
   }
 
+  private var bodyMaxHeight: CGFloat { max(240, viewportHeight * 0.62) }
+
+  /// Fit the scroll area to its content up to the cap: short lists render at
+  /// their natural height (no scroll, exactly as before); longer lists cap and
+  /// scroll internally. Falls back to the cap until the first measurement lands.
+  private var resolvedBodyHeight: CGFloat {
+    let cap = bodyMaxHeight
+    guard measuredBodyHeight >= 0 else { return cap }
+    return min(measuredBodyHeight, cap)
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
       headerRow
 
       if isPaged {
-        TabView(selection: $currentPage) {
-          ForEach(Array(question.questions.enumerated()), id: \.offset) { index, q in
-            questionPage(q)
-              .tag(index)
-              .padding(.bottom, 4)
-          }
-        }
-        .tabViewStyle(.page(indexDisplayMode: .never))
-        .frame(minHeight: 240)
-      } else {
-        questionPage(activeQuestion)
+        questionTabStrip
       }
 
-      if !isPaged, activeQuestion.allowsFreeform {
+      ScrollView {
+        questionPage(activeQuestion)
+          .background(
+            GeometryReader { geo in
+              Color.clear.preference(
+                key: WorkQuestionBodyHeightKey.self,
+                value: geo.size.height
+              )
+            }
+          )
+      }
+      .frame(height: resolvedBodyHeight)
+      .scrollBounceBehavior(.basedOnSize)
+      .onPreferenceChange(WorkQuestionBodyHeightKey.self) { height in
+        guard measuredBodyHeight < 0 || abs(measuredBodyHeight - height) > 0.5 else { return }
+        measuredBodyHeight = height
+      }
+
+      if activeQuestion.allowsFreeform {
         freeformRow(for: activeQuestion)
       }
 
@@ -960,11 +1006,6 @@ struct WorkStructuredQuestionCard: View {
           .font(.caption.weight(.semibold))
           .foregroundStyle(providerAccent)
         Spacer(minLength: 0)
-        if isPaged {
-          Text("\(currentPage + 1) of \(question.questions.count)")
-            .font(.caption2.weight(.bold).monospacedDigit())
-            .foregroundStyle(ADEColor.textMuted)
-        }
       }
       .accessibilityHidden(true)
 
@@ -1029,11 +1070,77 @@ struct WorkStructuredQuestionCard: View {
           }
         }
       }
-
-      if isPaged, q.allowsFreeform {
-        freeformRow(for: q)
-      }
     }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  // Horizontal tab strip replacing the old nested page-view pager: one chip per
+  // question (answered chips get a checkmark) plus an answered-count caption.
+  @ViewBuilder
+  private var questionTabStrip: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: 6) {
+          ForEach(Array(question.questions.enumerated()), id: \.offset) { index, q in
+            questionTabChip(index: index, question: q)
+          }
+        }
+        .padding(.horizontal, 1)
+      }
+      Text("\(answeredCount) of \(question.questions.count) answered")
+        .font(.caption2)
+        .foregroundStyle(ADEColor.textMuted)
+    }
+  }
+
+  @ViewBuilder
+  private func questionTabChip(index: Int, question q: WorkPendingQuestion) -> some View {
+    let isSelected = index == currentPage
+    let answered = isQuestionAnswered(q)
+    let chipLabel: String = {
+      if let header = q.header?.trimmingCharacters(in: .whitespacesAndNewlines), !header.isEmpty {
+        return header
+      }
+      return "Q\(index + 1)"
+    }()
+    Button {
+      withAnimation(.easeInOut(duration: 0.18)) { currentPage = index }
+    } label: {
+      HStack(spacing: 4) {
+        if answered {
+          Image(systemName: "checkmark.circle.fill")
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(ADEColor.success)
+        }
+        Text(chipLabel)
+          .font(.caption.weight(isSelected ? .semibold : .regular))
+          .lineLimit(1)
+      }
+      .foregroundStyle(isSelected ? ADEColor.textPrimary : ADEColor.textSecondary)
+      .padding(.horizontal, 10)
+      .padding(.vertical, 6)
+      .background(
+        isSelected ? providerAccent.opacity(0.16) : ADEColor.surfaceBackground.opacity(0.6),
+        in: Capsule(style: .continuous)
+      )
+      .overlay(
+        Capsule(style: .continuous)
+          .stroke(isSelected ? providerAccent.opacity(0.5) : ADEColor.border.opacity(0.25), lineWidth: 0.8)
+      )
+    }
+    .buttonStyle(.plain)
+    .disabled(busy)
+    .accessibilityLabel("Question \(index + 1) of \(question.questions.count)\(answered ? ", answered" : "")")
+  }
+
+  private func isQuestionAnswered(_ q: WorkPendingQuestion) -> Bool {
+    if !(selections[q.questionId] ?? []).isEmpty { return true }
+    let freeform = (freeformByQuestion[q.questionId] ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    return !freeform.isEmpty
+  }
+
+  private var answeredCount: Int {
+    question.questions.filter { isQuestionAnswered($0) }.count
   }
 
   @ViewBuilder
@@ -1066,11 +1173,6 @@ struct WorkStructuredQuestionCard: View {
 
       Spacer(minLength: 8)
 
-      if isPaged {
-        pageIndicator
-        Spacer(minLength: 8)
-      }
-
       Button(submitLabel) {
         Task { await submitAll() }
       }
@@ -1078,24 +1180,6 @@ struct WorkStructuredQuestionCard: View {
       .tint(providerAccent)
       .disabled(busy || !canSubmit)
     }
-  }
-
-  @ViewBuilder
-  private var pageIndicator: some View {
-    HStack(spacing: 6) {
-      ForEach(0..<question.questions.count, id: \.self) { index in
-        Button {
-          withAnimation(.easeInOut(duration: 0.18)) { currentPage = index }
-        } label: {
-          Circle()
-            .fill(index == currentPage ? ADEColor.accent : ADEColor.textMuted.opacity(0.35))
-            .frame(width: index == currentPage ? 7 : 6, height: index == currentPage ? 7 : 6)
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Question \(index + 1) of \(question.questions.count)")
-      }
-    }
-    .padding(.horizontal, 4)
   }
 
   private var submitLabel: String {

--- a/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
@@ -1366,11 +1366,10 @@ struct WorkCodexRecoveryCardView: View {
 }
 
 /// Resolved / historical structured-question card shown in the transcript once
-/// a question is no longer pending. Replaces the flat "Question asked · Input
-/// requested" event card: renders the asking provider's logo + "{Provider}
-/// asked", the question text as the primary line, clean option rows (recommended
-/// and chosen marked), and — when resolved — the outcome inline so the separate
-/// "Input resolved" ribbon can be folded away.
+/// a question is no longer pending. Collapses to a single compact row — status
+/// icon plus a one-line summary ("Answered · {choice}", a quoted typed answer,
+/// "Declined", or a question count) — mirroring Claude Code's resolved rows;
+/// the full option list only exists on the pending card.
 struct WorkResolvedQuestionCard: View {
   let card: WorkEventCardModel
   var fallbackProvider: String? = nil
@@ -1383,8 +1382,6 @@ struct WorkResolvedQuestionCard: View {
     }
     return fallbackProvider
   }
-
-  private var accent: Color { ADEColor.providerChatAccent(for: resolvedProvider) }
 
   private var resolution: String? {
     guard let trimmed = card.resolution?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -1459,7 +1456,9 @@ struct WorkResolvedQuestionCard: View {
     if isSecretResolution {
       return "Answered"
     }
-    if let resolution, !isPlainStatus(resolution) {
+    // Only echo a typed answer when the question model is present and known
+    // non-secret; without the model we can't rule out a secret, so stay mute.
+    if let resolution, model != nil, !isPlainStatus(resolution) {
       return "Answered · \u{201C}\(resolution)\u{201D}"
     }
     return "Answered"

--- a/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift
@@ -1392,8 +1392,6 @@ struct WorkResolvedQuestionCard: View {
     return trimmed
   }
 
-  private var isResolved: Bool { resolution != nil }
-
   private var isDeclined: Bool {
     switch (resolution ?? "").lowercased() {
     case "declined", "rejected", "cancelled", "canceled": return true
@@ -1415,124 +1413,82 @@ struct WorkResolvedQuestionCard: View {
     return nil
   }
 
-  var body: some View {
-    VStack(alignment: .leading, spacing: 10) {
-      header
-
-      if let model {
-        ForEach(Array(model.questions.enumerated()), id: \.offset) { _, question in
-          questionSection(question)
-        }
-      } else if let body = card.body, !body.isEmpty {
-        Text(body)
-          .font(.subheadline.weight(.semibold))
-          .foregroundStyle(ADEColor.textPrimary)
-          .frame(maxWidth: .infinity, alignment: .leading)
-      }
-
-      if isResolved {
-        resolutionPill
-      }
-    }
-    .padding(14)
-    .background(ADEColor.cardBackground.opacity(0.45), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-    .overlay(
-      RoundedRectangle(cornerRadius: 14, style: .continuous)
-        .stroke(accent.opacity(0.22), lineWidth: 1)
-    )
-    .accessibilityElement(children: .combine)
-    .accessibilityLabel(accessibilityText)
+  private var isMultiQuestion: Bool {
+    (model?.questions.count ?? 0) > 1
   }
 
-  private var header: some View {
+  /// Any question in the set requested a secret. When true the resolution is
+  /// never echoed — the answer could restate the secret value.
+  private var isSecretResolution: Bool {
+    model?.questions.contains(where: { $0.isSecret }) ?? false
+  }
+
+  /// Plain status words carry no user-authored content worth echoing; a typed
+  /// freeform answer is anything else.
+  private func isPlainStatus(_ value: String) -> Bool {
+    switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+    case "accepted", "answered", "declined", "rejected", "cancelled", "canceled", "resolved", "ok", "done":
+      return true
+    default:
+      return false
+    }
+  }
+
+  private var collapsedIcon: String {
+    isDeclined ? "xmark.circle" : "checkmark.circle.fill"
+  }
+
+  private var collapsedTint: Color {
+    isDeclined ? ADEColor.textMuted : ADEColor.success
+  }
+
+  /// One-line summary mirroring Claude Code's resolved-question row: the chosen
+  /// option, a truncated typed answer, a decline, or a bare count for multiple
+  /// questions. Secret answers collapse to "Answered" and are never echoed.
+  private var collapsedText: String {
+    if isDeclined {
+      return pendingInputResolutionLabel(for: (resolution ?? "declined").lowercased())
+    }
+    if isMultiQuestion {
+      let count = model?.questions.count ?? 0
+      return "\(count) questions answered"
+    }
+    if let chosen = chosenOption {
+      return "Answered · \(chosen.label)"
+    }
+    if isSecretResolution {
+      return "Answered"
+    }
+    if let resolution, !isPlainStatus(resolution) {
+      return "Answered · \u{201C}\(resolution)\u{201D}"
+    }
+    return "Answered"
+  }
+
+  var body: some View {
     HStack(spacing: 8) {
-      WorkProviderBareLogo(
-        provider: resolvedProvider,
-        fallbackSymbol: providerIcon(resolvedProvider ?? ""),
-        tint: accent,
-        size: 16
-      )
-      Text("\(workChatSurfaceProviderName(resolvedProvider)) asked")
-        .font(.caption.weight(.semibold))
-        .foregroundStyle(accent)
+      Image(systemName: collapsedIcon)
+        .font(.system(size: 14, weight: .semibold))
+        .foregroundStyle(collapsedTint)
+      Text(collapsedText)
+        .font(.caption)
+        .foregroundStyle(ADEColor.textSecondary)
+        .lineLimit(1)
+        .truncationMode(.tail)
       Spacer(minLength: 8)
       Text(relativeTimestamp(card.timestamp))
         .font(.caption2)
         .foregroundStyle(ADEColor.textMuted)
     }
-  }
-
-  @ViewBuilder
-  private func questionSection(_ question: WorkPendingQuestion) -> some View {
-    let questionText = question.isSecret ? "Secure response requested" : question.question
-    VStack(alignment: .leading, spacing: 8) {
-      if let header = question.header, !header.isEmpty {
-        Text(header.uppercased())
-          .font(.caption2.weight(.bold))
-          .tracking(0.6)
-          .foregroundStyle(ADEColor.textMuted)
-      }
-      if !questionText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-        Text(questionText)
-          .font(.subheadline.weight(.semibold))
-          .foregroundStyle(ADEColor.textPrimary)
-          .frame(maxWidth: .infinity, alignment: .leading)
-      }
-      // Secure-response questions mask more than the prompt: option labels and
-      // descriptions can restate the secret, so the whole option list is hidden.
-      if !question.isSecret, !question.options.isEmpty {
-        VStack(alignment: .leading, spacing: 6) {
-          ForEach(Array(question.options.enumerated()), id: \.offset) { _, option in
-            optionRow(option)
-          }
-        }
-      }
-    }
-    .frame(maxWidth: .infinity, alignment: .leading)
-  }
-
-  @ViewBuilder
-  private func optionRow(_ option: WorkPendingQuestionOption) -> some View {
-    let selected = isSelected(option)
-    HStack(alignment: .top, spacing: 8) {
-      Image(systemName: selected ? "checkmark.circle.fill" : "circle")
-        .font(.system(size: 13, weight: .semibold))
-        .foregroundStyle(selected ? accent : ADEColor.textMuted.opacity(0.55))
-      VStack(alignment: .leading, spacing: 2) {
-        HStack(spacing: 6) {
-          Text(option.label)
-            .font(.caption.weight(selected ? .semibold : .regular))
-            .foregroundStyle(selected ? ADEColor.textPrimary : ADEColor.textSecondary)
-            .frame(maxWidth: .infinity, alignment: .leading)
-          if option.recommended {
-            Text("Recommended")
-              .font(.caption2.weight(.semibold))
-              .foregroundStyle(accent)
-              .padding(.horizontal, 6)
-              .padding(.vertical, 2)
-              .background(accent.opacity(0.12), in: Capsule(style: .continuous))
-          }
-        }
-        if let description = option.description, !description.isEmpty {
-          Text(description)
-            .font(.caption2)
-            .foregroundStyle(ADEColor.textMuted)
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-      }
-    }
-    .padding(.vertical, 5)
-    .padding(.horizontal, 8)
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .background(
-      selected ? accent.opacity(0.08) : Color.clear,
-      in: RoundedRectangle(cornerRadius: 8, style: .continuous)
-    )
+    .padding(.horizontal, 12)
+    .padding(.vertical, 9)
+    .background(ADEColor.cardBackground.opacity(0.45), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
     .overlay(
-      RoundedRectangle(cornerRadius: 8, style: .continuous)
-        .stroke(selected ? accent.opacity(0.30) : Color.clear, lineWidth: 1)
+      RoundedRectangle(cornerRadius: 12, style: .continuous)
+        .stroke(collapsedTint.opacity(0.20), lineWidth: 0.8)
     )
-    .opacity(isDeclined ? 0.55 : 1)
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(accessibilityText)
   }
 
   private func isSelected(_ option: WorkPendingQuestionOption) -> Bool {
@@ -1542,28 +1498,6 @@ struct WorkResolvedQuestionCard: View {
       return true
     }
     return normalized == option.label.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-  }
-
-  private var resolutionPill: some View {
-    let key = (resolution ?? "").lowercased()
-    let tint = pendingInputResolutionTint(for: key).color
-    let label: String = {
-      if let chosen = chosenOption {
-        return "Answered · \(chosen.label)"
-      }
-      return isDeclined ? pendingInputResolutionLabel(for: key) : "Answered"
-    }()
-    return HStack(spacing: 5) {
-      Image(systemName: pendingInputResolutionIcon(for: key))
-        .font(.system(size: 11, weight: .semibold))
-      Text(label)
-        .font(.caption2.weight(.semibold))
-        .lineLimit(1)
-    }
-    .foregroundStyle(tint)
-    .padding(.horizontal, 8)
-    .padding(.vertical, 4)
-    .background(tint.opacity(0.10), in: Capsule(style: .continuous))
   }
 
   private var accessibilityText: String {

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView+Timeline.swift
@@ -157,7 +157,8 @@ extension WorkChatSessionView {
             }
           }
         },
-        fallbackProvider: chatSummaryContext.provider
+        fallbackProvider: chatSummaryContext.provider,
+        viewportHeight: scrollViewportHeight
       )
       .id("pending-question-\(question.id)")
     case .pendingPermission(let permission):
@@ -503,7 +504,8 @@ extension WorkChatSessionView {
             await onDeclineQuestion(model.id)
           }
         },
-        fallbackProvider: chatSummaryContext.provider
+        fallbackProvider: chatSummaryContext.provider,
+        viewportHeight: scrollViewportHeight
       )
     case .modelSelection(let model):
       WorkModelSelectionPendingCard(

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
@@ -489,7 +489,16 @@ extension WorkSessionDestinationView {
         setArtifactContent(.text(blob.content), for: artifact.id)
       }
     } catch {
-      setArtifactContent(.error(error.localizedDescription), for: artifact.id)
+      let raw = error.localizedDescription
+      let friendly: String
+      if raw.contains("must resolve within")
+        || raw.contains("Remote artifact URLs are not supported")
+        || raw.contains("file URL is invalid") {
+        friendly = "Preview isn't available on this device."
+      } else {
+        friendly = "Preview unavailable."
+      }
+      setArtifactContent(.error(friendly), for: artifact.id)
     }
   }
 

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -893,6 +893,18 @@ struct WorkSessionDestinationView: View {
         syncTranscriptFromLiveEvents()
         await reconcileIdleCanonicalTranscriptIfNeeded()
       }
+      .onChange(of: workChatTranscriptPreferenceStatus(
+        sessionStatus: normalizedWorkChatSessionStatus(session: session, summary: chatSummary),
+        liveTurnActiveHint: liveTurnActiveHint
+      )) { previous, current in
+        // On the active -> non-active transition, force a canonical refresh so
+        // any staged steers the host delivered at turn end stop lingering when
+        // their graduation events never reached the phone. Keyed on the effective
+        // status (which downgrades a stale-active row to idle via the fresher
+        // liveTurnActiveHint) so the belt still fires when the row lags.
+        guard previous == "active", current != "active" else { return }
+        Task { await reconcileOptimisticSteersAfterTurnEnd() }
+      }
       .task(id: emptyTranscriptHydrationKey) {
         await hydrateEmptyTranscriptFromHostIfNeeded()
       }
@@ -1986,6 +1998,22 @@ struct WorkSessionDestinationView: View {
     optimisticPendingSteers.removeAll { steer in
       transcriptContainsResolvedSteer(transcript, steer: steer) || pendingIds.contains(steer.id)
     }
+  }
+
+  /// Belt for the case where the host flushed queued steers at turn end
+  /// (`deliverNextQueuedSteer`) but the graduation events never reached the
+  /// phone, leaving optimistic steers stuck as "Sends after turn" forever.
+  /// After an authoritative refresh from a reachable host, any optimistic steer
+  /// the host no longer lists as pending has been delivered (or cancelled) — the
+  /// steer id is the host-assigned id, so absence is definitive. We never drop
+  /// while the host is unreachable or the refresh came back empty.
+  @MainActor
+  func reconcileOptimisticSteersAfterTurnEnd() async {
+    guard !optimisticPendingSteers.isEmpty, isLiveAndReachable else { return }
+    await loadTranscript(forceRemote: true, preferLightweight: false)
+    guard isLiveAndReachable, !transcript.isEmpty else { return }
+    let canonicalPendingIds = Set(derivePendingWorkSteers(from: transcript).map(\.id))
+    optimisticPendingSteers.removeAll { !canonicalPendingIds.contains($0.id) }
   }
 
   @MainActor

--- a/docs/features/chat/README.md
+++ b/docs/features/chat/README.md
@@ -253,7 +253,15 @@ Controls and summaries project this runtime state rather than owning it:
   (abort the current turn and run the queued message as the next
   turn). Inline dispatches are reversible until the model reads them
   via `cancelAsyncMessage(uuid)`. The pending-steer queue is persisted
-  with chat state so undelivered messages survive restart.
+  with chat state so undelivered messages survive restart. `sendMessage`
+  accepts an opt-in `routeActiveToSteer` flag (overloaded so the steered
+  path can return an `AgentChatSteerResult`): when set, a non-empty send
+  that arrives while `canRouteActiveSendToSteer` reports the session busy
+  is converted into a `steer()` call rather than starting a competing turn.
+  The desktop composer already routes its own sends, so this flag exists for
+  the sync command handler — a phone that fires `chat.send` mid-turn gets the
+  message queued as a steer instead of racing the live turn (see
+  [remote commands](../sync-and-multi-device/remote-commands.md)).
 - **Identity sessions.** Sessions carrying `identityKey` (now just
   `"cto"`) are filtered out of the Work tab list and rendered by the
   dedicated CTO tab. See [Agent Routing and

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -198,7 +198,10 @@ apps/ios/
 │   │   │                            #   timeline rows, plus the unified Chat
 │   │   │                            #   Info sheet — ordered Subagents /
 │   │   │                            #   Background / Schedule sections mirroring
-│   │   │                            #   desktop — and the subagent strip/badge),
+│   │   │                            #   desktop — the subagent strip/badge, and
+│   │   │                            #   the resolved-question card that collapses
+│   │   │                            #   an answered question to a one-line
+│   │   │                            #   "Answered · <choice>" / "Declined" row),
 │   │   │                            # WorkPlanComposerViews (plan-approval
 │   │   │                            #   strip + review sheet),
 │   │   │                            # WorkComposerTypedTriggers (UITextView
@@ -208,7 +211,14 @@ apps/ios/
 │   │   │                            #   WorkMentionsPickerSheet /
 │   │   │                            #   WorkSlashCommandsSheet modals),
 │   │   │                            # WorkChatAttachmentTray,
-│   │   │                            # WorkArtifactTerminalViews,
+│   │   │                            # WorkChatComposerAndInputViews (compacted
+│   │   │                            #   icon-only staged-steer strip + the
+│   │   │                            #   structured-question card: chip tab strip
+│   │   │                            #   over a viewport-capped internal scroll),
+│   │   │                            # WorkArtifactTerminalViews (in-thread
+│   │   │                            #   artifact card with a friendly
+│   │   │                            #   "Preview isn't available" fallback when
+│   │   │                            #   the blob can't render on-device),
 │   │   │                            # TerminalSessionScreen + SwiftTermSessionView
 │   │   │                            #   (full-screen SwiftTerm terminal,
 │   │   │                            #   offset resume/history paging +
@@ -1568,6 +1578,20 @@ does not duplicate the full desktop Stats page.
   model-selection — and flips `acceptForSession` on the current gate then
   accepts each remaining sweepable gate sequentially (stale itemIds no-op
   on the host, so re-sends after auto-resolution are safe).
+- **Optimistic steers reconcile on the active-to-idle turn boundary.**
+  A message the phone sends mid-turn is echoed as an optimistic "Sends
+  after turn" row (`WorkQueuedSteerRow`) using the host-assigned steer id
+  the `chat.send` ack returns. Those graduate out when the host's
+  `deliverNextQueuedSteer` folds them into the next turn — but if the
+  graduation events never reach the phone, the row would linger forever.
+  `WorkSessionDestinationView` watches the effective chat status (derived
+  through `workChatTranscriptPreferenceStatus`, which downgrades a
+  stale-active row to idle via the fresher `liveTurnActiveHint`) and, on the
+  active-to-non-active transition, runs `reconcileOptimisticSteersAfterTurnEnd`:
+  a forced canonical transcript refresh, then drop any optimistic steer the
+  reachable host no longer lists as pending. It never drops while the host is
+  unreachable or the refresh came back empty, so a transient gap cannot erase
+  a genuinely queued message.
 - **`AttentionDrawerModel.clearVisibleItems()` persists dismissals
   scoped to the active id set.** Ids are stored under
   `ade.attention.dismissedItemIDs` and pruned on every rebuild

--- a/docs/features/sync-and-multi-device/remote-commands.md
+++ b/docs/features/sync-and-multi-device/remote-commands.md
@@ -608,7 +608,14 @@ can be sensitive.
   a command, subscribe to the transcript stream for incremental
   events. `chat.send` waits for the runtime-side dispatch acknowledgement
   before returning `ok`, so the phone does not clear its local echo
-  while the desktop is still preparing the turn. Personal chat uses the same
+  while the desktop is still preparing the turn. The handler passes
+  `routeActiveToSteer: true` into `agentChatService.sendMessage`, so a send
+  that lands while a turn is already active is converted into a steer
+  instead of racing the live turn; when that happens the ack carries the
+  steer's `{ steerId, queued }` alongside `ok: true` (a plain new-turn send
+  still returns just `{ ok: true }`). The extra fields are additive — older
+  clients ignore them, and the phone uses them to reconcile the message it
+  echoed optimistically. Personal chat uses the same
   envelopes but sends `chatScope: "personal"`; that explicit discriminator
   resolves the hidden durable transcript and active-turn state without a
   `projectId`.


### PR DESCRIPTION
## Summary

Fixes four mobile chat defects visible in Claude Agent SDK chats but applying to all runtimes:

- **Staged prompt send (steer) strip**: compact rows — one-line truncated text, muted "Sends after turn · time" line, icon-only actions with accessibility labels (fixes mid-word button-label wrapping like "Inter-rupt"). Send now / Interrupt remain claude-only per the existing capability gate.
- **Staged-send reliability**: the sync host's `chat.send` now converts a send arriving during an active turn into the existing steer path (`routeActiveToSteer`, additive `{steerId, queued}` ack), so offline-replayed sends queue instead of being dropped; iOS additionally reconciles lingering optimistic steers on the active→idle transition via a forced canonical refresh.
- **Question cards**: pending card is capped to the transcript viewport (62%, min 240pt) with an internal self-sizing scroll for long option lists; the multi-question `TabView(.page)` pager is replaced with a chip tab strip + "n of m answered". Answered questions collapse to a single compact row ("Answered · {choice}", typed answers quoted, secrets never echoed) matching desktop/Claude Code.
- **Artifact in-thread card**: icon tile + 2-line-max title + "Kind · time" metadata line; raw backend errors ("Artifact path must resolve within .ade/artifacts.") replaced with a muted preview-unavailable fallback.

## Validation

- iOS: full `xcodebuild` green (twice, including post-review fixes).
- Desktop: `agentChatService` 534/534, including two new regression tests (send-during-active-turn queues + delivers at turn end; empty send stays a no-op).
- /quality dual-review: no Blocker/High; safe findings auto-applied; re-review CLEAN.
- Parity: docs updated; TUI/CLI/mobile-compat verified no changes needed (CLI already auto-steers via `chat.messageSession`; ack fields are additive for old clients).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates mobile chat behavior and presentation for staged sends, question cards, and artifact cards. The main changes are:

- Routes remote `chat.send` calls during active turns into the queued steer path.
- Persists queued steer display text and mode metadata for later delivery.
- Adds tests for active-turn send queuing and empty send no-op behavior.
- Reworks iOS staged-send rows with compact text and icon-only actions.
- Replaces mobile question paging with chip tabs and capped internal scrolling.
- Collapses resolved question cards and refreshes artifact card previews.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

No correctness or security issues were identified in the reviewed changed paths. The active-send routing behavior is covered by new tests, and the iOS changes are localized UI and reconciliation updates.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Primary test run verified by the general contract validation proof, showing agentChatService.test.ts (534 tests) and syncRemoteCommandService.test.ts (183 tests) passed.
- The regression scope was validated via the filtered log, confirming the named regression tests passed: send during active Claude turn queues through steer path, and empty send during active turn remains a no-op.
- Environment details were captured in the environment proof log, recording repo path, HEAD SHA, Node/npm versions, and blocked native iOS tooling.

<a href="https://app.greptile.com/trex/runs/14045279/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/chat/agentChatService.ts | Persists richer queued steer metadata and routes active sends through the existing steer delivery path. |
| apps/ade-cli/src/services/sync/syncRemoteCommandService.ts | Routes queued remote `chat.send` calls through steer when a turn is active and returns additive queue acknowledgement fields. |
| apps/ios/ADE/Views/Work/WorkChatComposerAndInputViews.swift | Overhauls staged steer rows and pending question cards with compact actions, tab chips, and internally capped question content. |
| apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift | Updates send and steer reconciliation actions so queued optimistic steers refresh and clear consistently. |
| apps/ios/ADE/Views/Work/WorkChatRichCardViews.swift | Collapses resolved question cards to a compact answer summary while avoiding secret answer echoing. |
| apps/ios/ADE/Views/Work/WorkArtifactTerminalViews.swift | Refreshes artifact cards with compact icon metadata rows and muted preview-unavailable status rendering. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant iOS as iOS chat UI
  participant Sync as Sync remote command
  participant Chat as AgentChatService
  participant Runtime as Active runtime

  iOS->>Sync: chat.send(text, attachments)
  Sync->>Chat: sendMessage(..., routeActiveToSteer: true)
  Chat->>Chat: canRouteActiveSendToSteer()
  alt turn active and message routable
    Chat->>Chat: steer(...displayText/modes)
    Chat->>iOS: user_message(deliveryState: queued, steerId)
    Chat-->>Sync: "{ steerId, queued: true }"
    Sync-->>iOS: "{ ok: true, steerId, queued: true }"
    Runtime-->>Chat: active turn completes
    Chat->>Runtime: deliver queued steer with saved directives
    Chat->>iOS: delivered transcript update
  else idle or empty no-op
    Chat->>Runtime: normal send or no-op
    Sync-->>iOS: "{ ok: true }"
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant iOS as iOS chat UI
  participant Sync as Sync remote command
  participant Chat as AgentChatService
  participant Runtime as Active runtime

  iOS->>Sync: chat.send(text, attachments)
  Sync->>Chat: sendMessage(..., routeActiveToSteer: true)
  Chat->>Chat: canRouteActiveSendToSteer()
  alt turn active and message routable
    Chat->>Chat: steer(...displayText/modes)
    Chat->>iOS: user_message(deliveryState: queued, steerId)
    Chat-->>Sync: "{ steerId, queued: true }"
    Sync-->>iOS: "{ ok: true, steerId, queued: true }"
    Runtime-->>Chat: active turn completes
    Chat->>Runtime: deliver queued steer with saved directives
    Chat->>iOS: delivered transcript update
  else idle or empty no-op
    Chat->>Runtime: normal send or no-op
    Sync-->>iOS: "{ ok: true }"
  end
```

</a>

<sub>Reviews (3): Last reviewed commit: ["Carry per-send options through the queue..."](https://github.com/arul28/ade/commit/bf329801cb5dfb1dca16f9547327cddb1c0d14f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43408347)</sub>

<!-- /greptile_comment -->