### PR TITLE
Fix iOS chat keyboard dismissal

### DIFF
--- a/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
+++ b/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
@@ -755,6 +755,7 @@ struct HubInlineComposer: View {
     guard !text.isEmpty else { return }
     let restoredDraft = draft
     let restoredAttachments = attachments
+    collapse()
     draft = ""
     attachments.removeAll()
     Task {

--- a/apps/ios/ADE/Views/PersonalChats/PersonalChatsScreen.swift
+++ b/apps/ios/ADE/Views/PersonalChats/PersonalChatsScreen.swift
@@ -552,6 +552,7 @@ struct PersonalChatNewScreen: View {
   private func create() async {
     let prompt = draft.trimmingCharacters(in: .whitespacesAndNewlines)
     guard canCreateChat, !prompt.isEmpty, !busy else { return }
+    composerFocused = false
     busy = true
     errorMessage = nil
     defer { busy = false }

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -2081,12 +2081,14 @@ final class WorkChatComposerDraftState: ObservableObject {
 
   func restoreUnsentText(_ value: String) {
     let currentDraft = trimmedText
-    guard currentDraft != value else { return }
-    if currentDraft.isEmpty {
-      text = value
-    } else {
-      text = "\(value)\n\(text)"
+    if currentDraft != value {
+      if currentDraft.isEmpty {
+        text = value
+      } else {
+        text = "\(value)\n\(text)"
+      }
     }
+    isFocused = true
   }
 }
 
@@ -2146,8 +2148,8 @@ private struct WorkChatComposerSendButton: View {
         if sent {
           onSent()
         } else {
-          draftState.restoreUnsentText(originalText)
           attachments = restoredAttachments
+          draftState.restoreUnsentText(originalText)
         }
       }
     }

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -2062,6 +2062,7 @@ private struct WorkContextUsagePopover: View {
 
 final class WorkChatComposerDraftState: ObservableObject {
   @Published var text = ""
+  @Published var isFocused = false
 
   var trimmedText: String {
     text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -2073,6 +2074,7 @@ final class WorkChatComposerDraftState: ObservableObject {
 
   func consumeSendableText() -> String {
     let value = trimmedText
+    isFocused = false
     text = ""
     return value
   }

--- a/apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift
+++ b/apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift
@@ -525,6 +525,7 @@ struct WorkComposerTextView: UIViewRepresentable {
       context.coordinator.setText(draftState.text, resetChips: true)
     }
     context.coordinator.applyPlaceholder(placeholder)
+    context.coordinator.applyFocusRequest(draftState.isFocused, to: textView)
     context.coordinator.updateHeight()
     return textView
   }
@@ -544,6 +545,7 @@ struct WorkComposerTextView: UIViewRepresentable {
     if draftState.text != textView.text {
       context.coordinator.setText(draftState.text, resetChips: false)
     }
+    context.coordinator.applyFocusRequest(draftState.isFocused, to: textView)
     context.coordinator.updateHeight()
   }
 
@@ -559,6 +561,7 @@ struct WorkComposerTextView: UIViewRepresentable {
     private var chips: [(range: NSRange, text: String)] = []
     private var placeholderLabel: UILabel?
     private var triggerInputTraitsActive = false
+    private var lastFocusRequest: Bool?
 
     init(_ parent: WorkComposerTextView) {
       self.parent = parent
@@ -569,6 +572,23 @@ struct WorkComposerTextView: UIViewRepresentable {
         .font: UIFont.preferredFont(forTextStyle: .body),
         .foregroundColor: UIColor(ADEColor.textPrimary),
       ]
+    }
+
+    func textViewDidBeginEditing(_ textView: UITextView) {
+      if !parent.draftState.isFocused { parent.draftState.isFocused = true }
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+      if parent.draftState.isFocused { parent.draftState.isFocused = false }
+    }
+
+    func applyFocusRequest(_ isFocused: Bool, to textView: UITextView) {
+      if isFocused, !textView.isFirstResponder {
+        textView.becomeFirstResponder()
+      } else if !isFocused, lastFocusRequest == true, textView.isFirstResponder {
+        textView.resignFirstResponder()
+      }
+      lastFocusRequest = isFocused
     }
 
     private func chipAttributes(kind: WorkComposerTriggerKind) -> [NSAttributedString.Key: Any] {

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -679,6 +679,14 @@ struct WorkNewChatScreen: View {
 
           laneSelector
           sessionActionChips
+
+          // Keep activity in the scrollable content instead of pinning it
+          // above the composer. When the keyboard appears, the composer can
+          // expand into this space without lifting the activity card with it.
+          WorkUsageActivityCarousel()
+            .environmentObject(syncService)
+            .padding(.top, 2)
+            .fixedSize(horizontal: false, vertical: true)
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 16)
@@ -688,15 +696,6 @@ struct WorkNewChatScreen: View {
       .refreshable {
         await MobileUsageQuotaStore.shared.load(using: syncService, refresh: true)
       }
-
-      // Kept outside the scroll view so lane selection can scroll away while
-      // the activity card stays pinned immediately above the composer. The
-      // keyboard lifts the composer without coupling it to chart scrolling.
-      WorkUsageActivityCarousel()
-        .environmentObject(syncService)
-        .padding(.horizontal, 20)
-        .padding(.bottom, 8)
-        .fixedSize(horizontal: false, vertical: true)
 
       if let autoCreateStatus, busy {
         HStack(spacing: 8) {
@@ -1378,6 +1377,7 @@ private struct WorkNewChatComposerBar: View {
     guard !text.isEmpty else { return }
     let restoredDraft = draft
     let restoredAttachments = attachments
+    composerFocused = false
     draft = ""
     attachments.removeAll()
     Task {

--- a/apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift
+++ b/apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift
@@ -156,6 +156,42 @@ final class WorkComposerTriggerDetectorTests: XCTestCase {
     XCTAssertEqual(textView.resignCount, 1)
     XCTAssertFalse(textView.fakeIsFirstResponder)
   }
+
+  @MainActor
+  func testSendingChatDraftClearsTextAndDismissesComposerFocus() {
+    let draft = WorkChatComposerDraftState()
+    draft.text = "  Ship this change  "
+    draft.isFocused = true
+
+    XCTAssertEqual(draft.consumeSendableText(), "Ship this change")
+    XCTAssertEqual(draft.text, "")
+    XCTAssertFalse(draft.isFocused)
+  }
+
+  @MainActor
+  func testChatComposerAppliesRequestedFocusTransitions() {
+    let draft = WorkChatComposerDraftState()
+    let controller = WorkComposerSuggestionController()
+    var measuredHeight: CGFloat = 24
+    let parent = WorkComposerTextView(
+      draftState: draft,
+      controller: controller,
+      canCompose: true,
+      placeholder: "Message ADE…",
+      measuredHeight: Binding(get: { measuredHeight }, set: { measuredHeight = $0 })
+    )
+    let coordinator = WorkComposerTextView.Coordinator(parent)
+    let textView = FocusRecordingTextView()
+    textView.resetRecording()
+
+    coordinator.applyFocusRequest(false, to: textView)
+    coordinator.applyFocusRequest(true, to: textView)
+    coordinator.applyFocusRequest(false, to: textView)
+
+    XCTAssertEqual(textView.becomeCount, 1)
+    XCTAssertEqual(textView.resignCount, 1)
+    XCTAssertFalse(textView.fakeIsFirstResponder)
+  }
 }
 
 private final class FocusRecordingTextView: UITextView {

--- a/apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift
+++ b/apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift
@@ -158,7 +158,7 @@ final class WorkComposerTriggerDetectorTests: XCTestCase {
   }
 
   @MainActor
-  func testSendingChatDraftClearsTextAndDismissesComposerFocus() {
+  func testSendingAndRestoringChatDraftUpdatesTextAndFocus() {
     let draft = WorkChatComposerDraftState()
     draft.text = "  Ship this change  "
     draft.isFocused = true
@@ -166,6 +166,10 @@ final class WorkComposerTriggerDetectorTests: XCTestCase {
     XCTAssertEqual(draft.consumeSendableText(), "Ship this change")
     XCTAssertEqual(draft.text, "")
     XCTAssertFalse(draft.isFocused)
+
+    draft.restoreUnsentText("Ship this change")
+    XCTAssertEqual(draft.text, "Ship this change")
+    XCTAssertTrue(draft.isFocused)
   }
 
   @MainActor

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -1036,6 +1036,16 @@ stored choice. `WorkNewChatScreen` captures the active project id when pushed;
 changes so a hub-created session cannot accidentally launch with the previous
 project's interface mode.
 
+Submitting a valid prompt dismisses the keyboard across every mobile chat
+composer: Work session chat clears the observable `UITextView` focus request,
+Work new-chat and personal new-chat clear their focus bindings, and the Hub
+inline composer collapses its full panel. The prompt field therefore returns to
+its compact resting state without an interactive keyboard swipe that can
+conflict with chat navigation. On `WorkNewChatScreen`, the cross-client activity
+carousel is part of the main scroll content rather than a pinned sibling above
+the composer, so keyboard presentation gives an expanding multi-line prompt the
+available space instead of lifting the activity panel with it.
+
 Mobile chat image attachments use the same host-side temp attachment contract as
 desktop. Work and Hub chat composers expose an add-attachment control beside the
 permission/model controls; its menu currently has one action, Attach from camera


### PR DESCRIPTION
## Summary

- dismiss the iOS keyboard and collapse the composer immediately after sending from every mobile chat surface
- keep the Work new-chat activity carousel in scroll content so keyboard-driven composer growth no longer pushes it upward
- document the mobile composer behavior

## Validation

- quality: clean after one synthesis/re-review pass
- xcodebuild test -only-testing:ADETests/WorkComposerTriggerDetectorTests (18 tests passed)
- node scripts/validate-docs.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Composers now collapse and dismiss keyboard focus immediately when sending messages or creating chats.
  * Improved synchronization of text-field focus transitions to prevent inconsistent composer states.
  * Moved the usage activity carousel into the chat’s scrollable content for a more consistent layout.

* **Tests**
  * Added coverage for clearing drafts, dismissing focus, and applying composer focus transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates mobile chat composer behavior on iOS. The main changes are:

- Chat composers dismiss keyboard focus after send or create actions.
- Work chat draft state now tracks focus requests for its text view bridge.
- Failed Work chat sends restore unsent text and attachments.
- The Work new-chat usage carousel now lives inside the scroll content.
- Tests and docs cover the new composer focus behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The environment was checked for iOS tooling, and xcodebuild, xcrun, and swift were all unavailable.
- ADETests command execution is blocked by the missing native iOS tooling, as recorded in the work-composer log.
- Docs validation completed successfully with exit code 0.

<a href="https://app.greptile.com/trex/runs/14064085/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Views/Hub/HubComposerDrawer.swift | Hub inline composer now collapses before clearing sent draft content. |
| apps/ios/ADE/Views/PersonalChats/PersonalChatsScreen.swift | Personal new-chat creation now clears composer focus before starting work. |
| apps/ios/ADE/Views/Work/WorkChatSessionView.swift | Work chat draft state now coordinates text clearing, restore behavior, and focus requests. |
| apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift | Work composer text view now applies requested focus changes and reports editing state. |
| apps/ios/ADE/Views/Work/WorkNewChatScreen.swift | Work new-chat layout now keeps the activity carousel in scroll content and clears composer focus on send. |
| apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift | Tests now cover draft focus state and requested focus transitions. |
| docs/features/sync-and-multi-device/ios-companion.md | Docs now describe mobile composer keyboard dismissal and carousel placement. |

<sub>Reviews (2): Last reviewed commit: ["ship: iteration 1 — restore focus after ..."](https://github.com/arul28/ade/commit/0d2f49a6d09a95c5ce7de1e750cfa1ebac198c82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43453433)</sub>

<!-- /greptile_comment -->