### PR TITLE
Fix Claude usage refresh storm from stale credentials file

### DIFF
--- a/apps/desktop/src/main/services/ai/providerCredentialSources.test.ts
+++ b/apps/desktop/src/main/services/ai/providerCredentialSources.test.ts
@@ -105,6 +105,45 @@ describe("refreshClaudeCredentials", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("treats a token-endpoint 429 as transient, not a 24h rejection", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse(429, { error: "rate_limited" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(refreshClaudeCredentials("token")).resolves.toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // Still blocked inside the 10-minute transient window…
+      vi.setSystemTime(Date.now() + 5 * 60_000);
+      await expect(refreshClaudeCredentials("token")).resolves.toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // …but retried once the transient window has passed.
+      vi.setSystemTime(Date.now() + 6 * 60_000);
+      await expect(refreshClaudeCredentials("token")).resolves.toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a rejected (4xx) token blocked past the transient window", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse(400, { error: "invalid_grant" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(refreshClaudeCredentials("token")).resolves.toBeNull();
+      vi.setSystemTime(Date.now() + 60 * 60_000);
+      await expect(refreshClaudeCredentials("token")).resolves.toBeNull();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("readClaudeCredentialsWithRefresh", () => {
@@ -132,6 +171,23 @@ describe("readClaudeCredentialsWithRefresh", () => {
     ).resolves.toBeNull();
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(mockState.spawn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a usable file token when the Keychain read fails on a user-initiated read", async () => {
+    setPlatform("darwin");
+    mockState.spawn.mockImplementation(() => fakeShellChild("", 1));
+    const fileCreds = {
+      claudeAiOauth: {
+        accessToken: "file-access",
+        refreshToken: "file-refresh",
+        expiresAt: Date.now() + 8 * 60 * 60_000,
+      },
+    };
+    vi.spyOn(fs.promises, "readFile").mockResolvedValue(JSON.stringify(fileCreds));
+
+    const creds = await readClaudeCredentials();
+    expect(creds?.accessToken).toBe("file-access");
+    expect(creds?.source).toBe("claude-credentials-file");
   });
 
   it("lets background polls reuse credentials cached from a Keychain read", async () => {

--- a/apps/desktop/src/main/services/ai/providerCredentialSources.test.ts
+++ b/apps/desktop/src/main/services/ai/providerCredentialSources.test.ts
@@ -146,6 +146,18 @@ describe("refreshClaudeCredentials", () => {
   });
 });
 
+describe("readClaudeCredentials", () => {
+  it("skips macOS Keychain access for background reads", async () => {
+    setPlatform("darwin");
+    vi.spyOn(fs.promises, "readFile").mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+
+    await expect(readClaudeCredentials({ allowKeychain: false })).resolves.toBeNull();
+    expect(mockState.spawn).not.toHaveBeenCalled();
+  });
+});
+
 describe("readClaudeCredentialsWithRefresh", () => {
   it("returns null instead of expired credentials when refresh fails", async () => {
     setPlatform("darwin");

--- a/apps/desktop/src/main/services/ai/providerCredentialSources.test.ts
+++ b/apps/desktop/src/main/services/ai/providerCredentialSources.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+
+const mockState = vi.hoisted(() => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => mockState.spawn(...args),
+}));
+
+import {
+  clearClaudeCredentialCache,
+  readClaudeCredentials,
+  readClaudeCredentialsWithRefresh,
+  refreshClaudeCredentials,
+} from "./providerCredentialSources";
+
+function createLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value, configurable: true });
+}
+
+function fakeShellChild(stdout: string, exitCode = 0) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+    pid: number;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  child.pid = 1234;
+  queueMicrotask(() => {
+    if (stdout) child.stdout.emit("data", Buffer.from(stdout, "utf8"));
+    child.emit("exit", exitCode);
+  });
+  return child;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const originalPlatform = process.platform;
+
+beforeEach(() => {
+  clearClaudeCredentialCache();
+  mockState.spawn.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  setPlatform(originalPlatform);
+  clearClaudeCredentialCache();
+});
+
+describe("refreshClaudeCredentials", () => {
+  it("stops retrying a refresh token the endpoint rejected", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(400, { error: "invalid_grant" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(refreshClaudeCredentials("dead-token")).resolves.toBeNull();
+    await expect(refreshClaudeCredentials("dead-token")).resolves.toBeNull();
+    await expect(refreshClaudeCredentials("dead-token")).resolves.toBeNull();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not block a different refresh token after one is rejected", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(400, { error: "invalid_grant" }))
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "fresh", expires_in: 3600 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(refreshClaudeCredentials("dead-token")).resolves.toBeNull();
+    const refreshed = await refreshClaudeCredentials("new-token");
+
+    expect(refreshed?.accessToken).toBe("fresh");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("backs off after a transient network failure", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(refreshClaudeCredentials("token")).resolves.toBeNull();
+    await expect(refreshClaudeCredentials("token")).resolves.toBeNull();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("readClaudeCredentialsWithRefresh", () => {
+  it("returns null instead of expired credentials when refresh fails", async () => {
+    setPlatform("darwin");
+    const expired = {
+      claudeAiOauth: {
+        accessToken: "expired-access",
+        refreshToken: "dead-refresh",
+        expiresAt: Date.now() - 60 * 60_000,
+      },
+    };
+    vi.spyOn(fs.promises, "readFile").mockResolvedValue(JSON.stringify(expired));
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(400, { error: "invalid_grant" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const logger = createLogger();
+    await expect(
+      readClaudeCredentialsWithRefresh(logger, { allowKeychain: false }),
+    ).resolves.toBeNull();
+
+    // A second background poll must not attempt the refresh again.
+    await expect(
+      readClaudeCredentialsWithRefresh(logger, { allowKeychain: false }),
+    ).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mockState.spawn).not.toHaveBeenCalled();
+  });
+
+  it("lets background polls reuse credentials cached from a Keychain read", async () => {
+    setPlatform("darwin");
+    const keychainPayload = JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "live-access",
+        refreshToken: "live-refresh",
+        expiresAt: Date.now() + 8 * 60 * 60_000,
+      },
+    });
+    mockState.spawn.mockImplementation(() => fakeShellChild(keychainPayload));
+    const readFileSpy = vi.spyOn(fs.promises, "readFile").mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+
+    // A user-initiated read (Settings, provider status) hits the Keychain.
+    const fromKeychain = await readClaudeCredentials();
+    expect(fromKeychain?.accessToken).toBe("live-access");
+    expect(fromKeychain?.source).toBe("macos-keychain");
+
+    // A background poll (Keychain forbidden) must reuse the cached login
+    // rather than falling back to the (missing/stale) credentials file.
+    const logger = createLogger();
+    const background = await readClaudeCredentialsWithRefresh(logger, { allowKeychain: false });
+    expect(background?.accessToken).toBe("live-access");
+    expect(readFileSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/services/ai/providerCredentialSources.ts
+++ b/apps/desktop/src/main/services/ai/providerCredentialSources.ts
@@ -11,6 +11,11 @@ const CLAUDE_OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const TOKEN_REFRESH_BUFFER_MS = 5 * 60_000;
 const CODEX_TOKEN_REFRESH_DAYS = 8;
 const CLAUDE_CREDENTIAL_MISS_TTL_MS = 60_000;
+// A refresh token the endpoint rejected (4xx) is rotated or revoked; retrying
+// it on every poll cycle looks like an OAuth storm to Anthropic and gets the
+// whole client rate-limited. Remember the rejected token and stop asking.
+const CLAUDE_REFRESH_REJECTED_TTL_MS = 24 * 60 * 60_000;
+const CLAUDE_REFRESH_TRANSIENT_TTL_MS = 10 * 60_000;
 
 export type LocalAuthSource =
   | "macos-keychain"
@@ -153,7 +158,16 @@ export async function readClaudeCredentials(
           safeJsonParse<Record<string, unknown>>(result.stdout.trim(), {}),
           "macos-keychain",
         );
-        if (credentials) return credentials;
+        if (credentials) {
+          // The Keychain holds the CLI's live login while the credentials file
+          // can be a stale leftover from an older install. Cache every valid
+          // Keychain read so background pollers (which must not touch the
+          // Keychain) can reuse it instead of the possibly-dead file token.
+          if (!isClaudeTokenExpiredOrExpiring(credentials)) {
+            cacheClaudeCredentials(credentials);
+          }
+          return credentials;
+        }
       }
     } catch {
       // Fall back to the local credentials file.
@@ -183,7 +197,21 @@ type ClaudeTokenRefreshResponse = {
   expires_in?: number;
 };
 
+let failedClaudeRefresh: { refreshToken: string; untilMs: number } | null = null;
+
+function noteClaudeRefreshFailure(refreshToken: string, ttlMs: number): void {
+  failedClaudeRefresh = { refreshToken, untilMs: Date.now() + ttlMs };
+}
+
+function isClaudeRefreshBlocked(refreshToken: string): boolean {
+  return failedClaudeRefresh != null
+    && failedClaudeRefresh.refreshToken === refreshToken
+    && Date.now() < failedClaudeRefresh.untilMs;
+}
+
 export async function refreshClaudeCredentials(refreshToken: string): Promise<ClaudeLocalAuthCredentials | null> {
+  if (isClaudeRefreshBlocked(refreshToken)) return null;
+
   const body = new URLSearchParams({
     grant_type: "refresh_token",
     refresh_token: refreshToken,
@@ -199,16 +227,26 @@ export async function refreshClaudeCredentials(refreshToken: string): Promise<Cl
       body: body.toString(),
       signal: controller.signal,
     });
-    if (!response.ok) return null;
+    if (!response.ok) {
+      noteClaudeRefreshFailure(
+        refreshToken,
+        response.status >= 500 ? CLAUDE_REFRESH_TRANSIENT_TTL_MS : CLAUDE_REFRESH_REJECTED_TTL_MS,
+      );
+      return null;
+    }
 
     const payload = (await response.json()) as ClaudeTokenRefreshResponse;
-    if (!payload.access_token) return null;
+    if (!payload.access_token) {
+      noteClaudeRefreshFailure(refreshToken, CLAUDE_REFRESH_REJECTED_TTL_MS);
+      return null;
+    }
 
     const expiresAt =
       payload.expires_in != null
         ? Date.now() + payload.expires_in * 1000
         : undefined;
 
+    failedClaudeRefresh = null;
     return {
       accessToken: payload.access_token,
       refreshToken: payload.refresh_token ?? refreshToken,
@@ -216,6 +254,7 @@ export async function refreshClaudeCredentials(refreshToken: string): Promise<Cl
       source: "claude-credentials-file",
     };
   } catch {
+    noteClaudeRefreshFailure(refreshToken, CLAUDE_REFRESH_TRANSIENT_TTL_MS);
     return null;
   } finally {
     clearTimeout(timer);
@@ -228,6 +267,7 @@ let cachedClaudeMissUntilMs = 0;
 export function clearClaudeCredentialCache(): void {
   cachedClaudeCreds = null;
   cachedClaudeMissUntilMs = 0;
+  failedClaudeRefresh = null;
 }
 
 export function cacheClaudeCredentials(credentials: ClaudeLocalAuthCredentials): void {
@@ -258,7 +298,7 @@ export async function readClaudeCredentialsWithRefresh(
     return creds;
   }
 
-  if (creds.refreshToken) {
+  if (creds.refreshToken && !isClaudeRefreshBlocked(creds.refreshToken)) {
     logger.info("usage.token_refresh.attempting", { expiresAt: creds.expiresAt });
     const refreshed = await refreshClaudeCredentials(creds.refreshToken);
     if (refreshed) {
@@ -273,8 +313,12 @@ export async function readClaudeCredentialsWithRefresh(
     });
   }
 
-  cachedClaudeCreds = creds;
-  return creds;
+  // The token is expired and could not be refreshed. Returning it anyway
+  // guarantees a 401 (and another doomed refresh attempt) on every poll —
+  // enough of those and Anthropic rate-limits the whole client. Report
+  // "no usable credentials" instead so callers surface a reconnect state.
+  cachedClaudeMissUntilMs = Date.now() + CLAUDE_CREDENTIAL_MISS_TTL_MS;
+  return null;
 }
 
 export async function readCodexCredentials(): Promise<CodexLocalAuthCredentials | null> {

--- a/apps/desktop/src/main/services/ai/providerCredentialSources.ts
+++ b/apps/desktop/src/main/services/ai/providerCredentialSources.ts
@@ -228,9 +228,12 @@ export async function refreshClaudeCredentials(refreshToken: string): Promise<Cl
       signal: controller.signal,
     });
     if (!response.ok) {
+      // 5xx/429/408 are transient endpoint conditions; other 4xx mean the
+      // token itself was rejected (rotated or revoked) and will never work.
+      const transient = response.status >= 500 || response.status === 429 || response.status === 408;
       noteClaudeRefreshFailure(
         refreshToken,
-        response.status >= 500 ? CLAUDE_REFRESH_TRANSIENT_TTL_MS : CLAUDE_REFRESH_REJECTED_TTL_MS,
+        transient ? CLAUDE_REFRESH_TRANSIENT_TTL_MS : CLAUDE_REFRESH_REJECTED_TTL_MS,
       );
       return null;
     }
@@ -268,6 +271,17 @@ export function clearClaudeCredentialCache(): void {
   cachedClaudeCreds = null;
   cachedClaudeMissUntilMs = 0;
   failedClaudeRefresh = null;
+}
+
+/**
+ * Drop only the cached access token so the next read re-reads sources.
+ * Keeps the refresh-token refusal memory intact — a 401 on the usage API
+ * must not reopen per-poll refresh attempts for a token the token endpoint
+ * already rejected.
+ */
+export function invalidateCachedClaudeCredentials(): void {
+  cachedClaudeCreds = null;
+  cachedClaudeMissUntilMs = 0;
 }
 
 export function cacheClaudeCredentials(credentials: ClaudeLocalAuthCredentials): void {

--- a/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.test.ts
@@ -59,7 +59,6 @@ const {
   collectAdeUsageStats,
   pollCodexUsage,
   pollCodexViaCliRpc,
-  readClaudeCredentials,
   resolveTokenPrice,
   resetDynamicTokenPricingForTest,
   setDynamicTokenPricingForTest,
@@ -1055,23 +1054,8 @@ Resets Jul 12 at 3pm
   });
 });
 
-describe("readClaudeCredentials", () => {
-  it("skips macOS Keychain access for background reads", async () => {
-    const originalPlatform = process.platform;
-    const readFileSpy = vi.spyOn(fs.promises, "readFile").mockRejectedValue(
-      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
-    );
-    setPlatform("darwin");
-
-    try {
-      await expect(readClaudeCredentials({ allowKeychain: false })).resolves.toBeNull();
-      expect(mockState.spawn).not.toHaveBeenCalled();
-    } finally {
-      readFileSpy.mockRestore();
-      setPlatform(originalPlatform);
-    }
-  });
-});
+// readClaudeCredentials contract tests live in
+// ../ai/providerCredentialSources.test.ts, colocated with the module.
 
 describe("parseCodexRateLimitWindows", () => {
   it("accepts the wham HTTP response shape", () => {

--- a/apps/desktop/src/main/services/usage/usageTrackingService.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.ts
@@ -47,7 +47,6 @@ import {
   invalidateCachedClaudeCredentials,
   isClaudeTokenExpiredOrExpiring,
   isCodexTokenStale,
-  readClaudeCredentials,
   readClaudeCredentialsWithRefresh,
   readCodexCredentials,
   refreshClaudeCredentials,
@@ -3198,7 +3197,6 @@ export function createUsageTrackingService({
 export const _testing = {
   MIN_POLL_INTERVAL_MS,
   MAX_POLL_INTERVAL_MS,
-  readClaudeCredentials,
   readCodexCredentials,
   isCodexTokenStale,
   isTokenExpiredOrExpiring: isClaudeTokenExpiredOrExpiring,

--- a/apps/desktop/src/main/services/usage/usageTrackingService.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.ts
@@ -44,7 +44,7 @@ import {
 } from "../../../shared/modelRegistry";
 import {
   cacheClaudeCredentials,
-  clearClaudeCredentialCache,
+  invalidateCachedClaudeCredentials,
   isClaudeTokenExpiredOrExpiring,
   isCodexTokenStale,
   readClaudeCredentials,
@@ -772,7 +772,7 @@ async function pollClaudeUsage(
     if (!result.ok) {
       if (result.status === 401 && creds.refreshToken) {
         logger.info("usage.token_refresh.401_retry");
-        clearClaudeCredentialCache();
+        invalidateCachedClaudeCredentials();
         const refreshed = await measureUsagePhase(
           logger,
           { provider: "claude", phase: "token_refresh", reason: context.reason },

--- a/apps/desktop/src/main/services/usage/usageTrackingService.ts
+++ b/apps/desktop/src/main/services/usage/usageTrackingService.ts
@@ -2527,7 +2527,9 @@ function buildProviderWindows(
       ...(nextRetryAt ? { nextRetryAt } : {}),
       message: prevWindows.length > 0
         ? `Couldn't refresh ${name} — last reading expired`
-        : `Couldn't reach ${name} — retrying`,
+        : errorKind === "rate_limited"
+          ? `${name} is rate-limiting usage checks — waiting to retry`
+          : `Couldn't reach ${name} — retrying`,
     },
     lastSuccessAt: prevLastSuccessAt,
   };

--- a/docs/features/onboarding-and-settings/usage-tracking.md
+++ b/docs/features/onboarding-and-settings/usage-tracking.md
@@ -41,6 +41,23 @@ quota HTTP, CLI fallback, and history phases, including provider, trigger,
 duration, outcome, and error kind. These entries identify network/auth latency
 without logging credentials or quota payloads.
 
+## Claude credential hygiene (refresh storms)
+
+`~/.claude/.credentials.json` can be a stale leftover while the live login sits
+in the macOS Keychain (the Claude CLI's default store). Because background
+polls must not touch the Keychain, three rules prevent a dead file token from
+turning into an OAuth storm that gets the whole client rate-limited (429) by
+Anthropic:
+
+- Any successful Keychain read (explicit refresh, provider-status checks)
+  populates the shared in-memory credential cache, so background polls reuse
+  the live login instead of the file.
+- A refresh token the token endpoint rejects (4xx) is negative-cached for 24 h
+  (10 min for network/5xx failures) and never re-tried per poll.
+- When a token is expired and cannot be refreshed, the reader reports "no
+  usable credentials" (→ reconnect state) instead of returning the dead token,
+  which would guarantee a 401 plus another doomed refresh on every cycle.
+
 ## Reproducible baseline
 
 The pre-change baseline came from ADE structured logs for 2026-07-10. Measure

--- a/docs/features/onboarding-and-settings/usage-tracking.md
+++ b/docs/features/onboarding-and-settings/usage-tracking.md
@@ -52,11 +52,21 @@ Anthropic:
 - Any successful Keychain read (explicit refresh, provider-status checks)
   populates the shared in-memory credential cache, so background polls reuse
   the live login instead of the file.
-- A refresh token the token endpoint rejects (4xx) is negative-cached for 24 h
-  (10 min for network/5xx failures) and never re-tried per poll.
+- A refresh token the token endpoint *definitively* rejects — a non-transient
+  4xx such as `invalid_grant`, or a 200 with no `access_token` — is
+  negative-cached for 24 h and never re-tried per poll. Transient conditions
+  are cached for only 10 min so a temporary blip can't lock out an otherwise
+  valid token: 5xx, plus token-endpoint 429 (rate-limited) and 408, plus
+  network/timeout aborts. A rate-limited refresh is treated as transient, not
+  as a rejection.
 - When a token is expired and cannot be refreshed, the reader reports "no
   usable credentials" (→ reconnect state) instead of returning the dead token,
   which would guarantee a 401 plus another doomed refresh on every cycle.
+- A 401 from the usage API drops only the cached access token
+  (`invalidateCachedClaudeCredentials`) and forces the next read to re-consult
+  its sources. It deliberately preserves the refresh-token refusal memory, so a
+  revoked-but-unexpired file token can't reopen per-poll refresh attempts
+  against a refresh token the token endpoint already rejected.
 
 ## Reproducible baseline
 


### PR DESCRIPTION
## Problem

The usage window showed "Couldn't reach Claude — retrying" indefinitely even though the user was logged in and Claude chat worked. Root cause: the live Claude login lives in the macOS Keychain (the CLI's default store), while `~/.claude/.credentials.json` was a stale leftover with an expired access token and a rotated refresh token. Background usage polls skip the Keychain by design, so every poll cycle made two doomed token-refresh POSTs plus a 401 usage GET — for days — until Anthropic rate-limited the client (HTTP 429, retry-after ~50 min) on the OAuth usage endpoint. At that point even the manual Retry (which does read the Keychain) failed.

## Fix

- **Keychain reads warm the shared credential cache.** Any successful Keychain read (provider-status checks, explicit refresh) caches the live login in-memory so background polls reuse it instead of the stale file.
- **Refresh-token negative cache.** A refresh token the token endpoint definitively rejects (non-transient 4xx, or 200 with no `access_token`) is negative-cached for 24h; transient failures (5xx, token-endpoint 429/408, network/timeouts) back off for 10 min. No more per-poll refresh hammering.
- **Never hand dead creds to the poller.** `readClaudeCredentialsWithRefresh` returns null for expired+unrefreshable creds → the UI shows an honest reconnect state instead of generating guaranteed 401s.
- **Scoped 401 invalidation.** The usage 401 retry path now drops only the cached access token (`invalidateCachedClaudeCredentials`), preserving the refresh-token refusal memory so a revoked-but-unexpired file token can't reopen the storm.
- **Honest rate-limit copy.** 429 now renders "Claude is rate-limiting usage checks — waiting to retry" instead of "Couldn't reach Claude".

## Tests

New colocated `providerCredentialSources.test.ts` (9 tests): reject-once negative caching, per-token isolation, transient-vs-rejected TTL boundary (429/408 vs 400), null-instead-of-expired, background Keychain skip, Keychain-failure file fallback, Keychain-cache reuse by background polls. Consolidated the pre-existing `readClaudeCredentials` test out of `usageTrackingService.test.ts` and removed the service's test-only re-export. Docs: `usage-tracking.md` gains a "Claude credential hygiene (refresh storms)" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude credential refresh handling to avoid repeated attempts after rejected or temporarily unavailable tokens.
  * Added fallback behavior when secure credential storage is unavailable.
  * Prevented expired credentials from being used when refresh fails.
  * Improved provider status messages for rate limits and connectivity issues.

* **Tests**
  * Added coverage for credential refresh failures, retry timing, caching, Keychain access, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes Claude usage credential handling to avoid repeated failed refresh attempts.

- Adds negative caching for rejected Claude refresh tokens.
- Uses shorter backoff for transient refresh failures.
- Returns no usable Claude credentials when expired tokens cannot refresh.
- Caches valid macOS Keychain credentials for background usage polls.
- Updates usage-window rate-limit messaging, tests, and docs.

<h3>Confidence Score: 4/5</h3>

The changed Claude credential flow has one stale-login path that should be fixed before merging.

A Keychain token cached during an explicit read can keep powering background polls after logout or account switch. The refresh-failure backoff and expired-token handling are covered by focused tests. The usage-window messaging change is narrow and does not show a concrete breakage.

apps/desktop/src/main/services/ai/providerCredentialSources.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran a focused Vitest repro against the real providerCredentialSources module with process.platform mocked to darwin and child\_process/fs mocked, and observed that the first user-initiated read returned and cached token-A from the mocked macOS Keychain source, while a background read with allowKeychain:false reused token-A after simulating logout/account switch and the later Keychain source failure and credentials-file unavailability.
- Artifacts documenting the repro and its output were captured to support verification of the Keychain caching behavior.
- I reviewed the desktop-services-focused tests log to confirm the exact command, cwd, Vitest pass summary, and EXIT\_CODE: 0.
- I inspected the desktop-typecheck log from the typecheck attempt, which shows the heap-adjusted command, cwd, that the process was killed, and EXIT\_CODE: 137.

<a href="https://app.greptile.com/trex/runs/14072663/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/ai/providerCredentialSources.ts | Adds Claude refresh backoff, expired-token null handling, cache invalidation changes, and Keychain credential caching. |
| apps/desktop/src/main/services/usage/usageTrackingService.ts | Preserves refresh-token refusal memory across Claude usage 401 handling and updates rate-limit messaging. |
| apps/desktop/src/main/services/ai/providerCredentialSources.test.ts | Adds tests for Claude refresh rejection, transient backoff, Keychain avoidance, file fallback, and cache reuse. |
| apps/desktop/src/main/services/usage/usageTrackingService.test.ts | Moves Claude credential-source tests out of the usage tracking service test file. |
| docs/features/onboarding-and-settings/usage-tracking.md | Documents Claude credential hygiene and refresh-storm prevention behavior. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fdesktop%2Fsrc%2Fmain%2Fservices%2Fai%2FproviderCredentialSources.ts%3A166-167%0A**Keychain%20Cache%20Outlives%20Login%20State**%0A%0AWhen%20a%20Settings%20or%20provider-status%20read%20caches%20a%20valid%20Keychain%20token%20here%2C%20later%20background%20polls%20can%20keep%20using%20that%20module-level%20token%20until%20it%20expires.%20If%20the%20user%20logs%20out%20of%20Claude%20or%20switches%20accounts%20in%20the%20CLI%2FKeychain%20before%20then%2C%20%60readClaudeCredentialsWithRefresh%28...%2C%20%7B%20allowKeychain%3A%20false%20%7D%29%60%20can%20continue%20polling%20with%20the%20old%20credential%20instead%20of%20surfacing%20the%20changed%20login%20state.%0A%0A&repo=arul28%2Fade&pr=788&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/desktop/src/main/services/ai/providerCredentialSources.ts:166-167
**Keychain Cache Outlives Login State**

When a Settings or provider-status read caches a valid Keychain token here, later background polls can keep using that module-level token until it expires. If the user logs out of Claude or switches accounts in the CLI/Keychain before then, `readClaudeCredentialsWithRefresh(..., { allowKeychain: false })` can continue polling with the old credential instead of surfacing the changed login state.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Consolidate Claude credential tests into..."](https://github.com/arul28/ade/commit/68b0eae82130840ecfdb3547a160a7794efce25a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43471793)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->