### PR TITLE
Fix project-open error visibility and macOS Git fallback

### DIFF
--- a/apps/desktop/src/main/services/ai/cliExecutableResolver.test.ts
+++ b/apps/desktop/src/main/services/ai/cliExecutableResolver.test.ts
@@ -111,19 +111,34 @@ describe("cliExecutableResolver", () => {
 
   it("returns all executable candidates in PATH then known-directory order", () => {
     tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-cli-candidates-"));
+    const homeDir = path.join(tempRoot, "home");
     const firstBin = path.join(tempRoot, "first");
     const secondBin = path.join(tempRoot, "second");
+    const knownBin = path.join(homeDir, ".local", "bin");
     makeExecutable(path.join(firstBin, "git"));
     makeExecutable(path.join(secondBin, "git"));
+    makeExecutable(path.join(knownBin, "git"));
+
+    const realStatSync = fs.statSync;
+    vi.spyOn(fs, "statSync").mockImplementation(((p: fs.PathLike, opts?: any) => {
+      const normalizedCandidate = path.normalize(String(p));
+      if (path.parse(normalizedCandidate).name === "git" && !normalizedCandidate.startsWith(tempRoot!)) {
+        const err: NodeJS.ErrnoException = new Error("ENOENT");
+        err.code = "ENOENT";
+        throw err;
+      }
+      return realStatSync(normalizedCandidate, opts);
+    }) as typeof fs.statSync);
 
     const candidates = resolveExecutableCandidatesFromKnownLocations("git", {
-      HOME: path.join(tempRoot, "home"),
+      HOME: homeDir,
       PATH: [firstBin, secondBin].join(path.delimiter),
     });
 
-    expect(candidates.slice(0, 2)).toEqual([
+    expect(candidates.slice(0, 3)).toEqual([
       { path: path.join(firstBin, "git"), source: "path" },
       { path: path.join(secondBin, "git"), source: "path" },
+      { path: path.join(knownBin, "git"), source: "known-dir" },
     ]);
   });
 

--- a/apps/desktop/src/main/services/ai/cliExecutableResolver.test.ts
+++ b/apps/desktop/src/main/services/ai/cliExecutableResolver.test.ts
@@ -6,6 +6,7 @@ import {
   augmentPathWithKnownCliDirs,
   augmentProcessPathWithShellAndKnownCliDirs,
   getPathEnvValue,
+  resolveExecutableCandidatesFromKnownLocations,
   resolveExecutableFromKnownLocations,
   setPathEnvValue,
 } from "./cliExecutableResolver";
@@ -106,6 +107,24 @@ describe("cliExecutableResolver", () => {
     const entries = nextPath.split(currentPathDelimiter());
     expect(entries).toContain("/usr/local/bin");
     expect(entries).toContain("/opt/homebrew/bin");
+  });
+
+  it("returns all executable candidates in PATH then known-directory order", () => {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-cli-candidates-"));
+    const firstBin = path.join(tempRoot, "first");
+    const secondBin = path.join(tempRoot, "second");
+    makeExecutable(path.join(firstBin, "git"));
+    makeExecutable(path.join(secondBin, "git"));
+
+    const candidates = resolveExecutableCandidatesFromKnownLocations("git", {
+      HOME: path.join(tempRoot, "home"),
+      PATH: [firstBin, secondBin].join(path.delimiter),
+    });
+
+    expect(candidates.slice(0, 2)).toEqual([
+      { path: path.join(firstBin, "git"), source: "path" },
+      { path: path.join(secondBin, "git"), source: "path" },
+    ]);
   });
 
   it("augments PATH with known CLI dirs on Windows", () => {

--- a/apps/desktop/src/main/services/ai/cliExecutableResolver.ts
+++ b/apps/desktop/src/main/services/ai/cliExecutableResolver.ts
@@ -12,6 +12,37 @@ export type ResolvedExecutable = {
   source: ResolutionSource;
 };
 
+function* executableCandidatesFromKnownLocations(
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Generator<ResolvedExecutable> {
+  const seen = new Set<string>();
+  const nextCandidate = (
+    candidatePath: string | null,
+    source: ResolutionSource,
+  ): ResolvedExecutable | null => {
+    if (!candidatePath || seen.has(candidatePath)) return null;
+    seen.add(candidatePath);
+    return { path: candidatePath, source };
+  };
+
+  for (const dir of splitPathEntries(getPathEnvValue(env))) {
+    const candidate = nextCandidate(resolveFromDirs(command, [dir], env), "path");
+    if (candidate) yield candidate;
+  }
+  for (const dir of getKnownBinDirs(command, env)) {
+    const candidate = nextCandidate(resolveFromDirs(command, [dir], env), "known-dir");
+    if (candidate) yield candidate;
+  }
+}
+
+export function resolveExecutableCandidatesFromKnownLocations(
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedExecutable[] {
+  return [...executableCandidatesFromKnownLocations(command, env)];
+}
+
 function getHomeDir(env: NodeJS.ProcessEnv): string {
   const profile = env.USERPROFILE?.trim();
   if (process.platform === "win32") {
@@ -325,15 +356,5 @@ export function resolveExecutableFromKnownLocations(
   command: string,
   env: NodeJS.ProcessEnv = process.env,
 ): ResolvedExecutable | null {
-  const fromPath = resolveFromDirs(command, splitPathEntries(getPathEnvValue(env)), env);
-  if (fromPath) {
-    return { path: fromPath, source: "path" };
-  }
-
-  const fromKnownDirs = resolveFromDirs(command, getKnownBinDirs(command, env), env);
-  if (fromKnownDirs) {
-    return { path: fromKnownDirs, source: "known-dir" };
-  }
-
-  return null;
+  return executableCandidatesFromKnownLocations(command, env).next().value ?? null;
 }

--- a/apps/desktop/src/main/services/git/git.test.ts
+++ b/apps/desktop/src/main/services/git/git.test.ts
@@ -3,7 +3,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
-import { runGit, runGitMergeTree, runGitOrThrow } from "./git";
+import {
+  formatGitExecutionError,
+  runGit,
+  runGitMergeTree,
+  runGitOrThrow,
+  selectGitExecutable,
+  shouldProbeLoginShellForGit,
+} from "./git";
 
 function git(cwd: string, args: string[]): string {
   const result = spawnSync("git", args, { cwd, encoding: "utf8" });
@@ -130,5 +137,36 @@ describe("runGit", () => {
     expect(result.exitCode).not.toBe(0);
     expect(fs.existsSync(lockPath)).toBe(true);
     expect(fs.readdirSync(gitDir).some((entry) => entry.startsWith("index.lock.stale-"))).toBe(false);
+  });
+});
+
+describe("macOS git selection", () => {
+  it("prefers an independent Git installation over Apple's license-gated executable", () => {
+    expect(selectGitExecutable([
+      { path: "/usr/bin/git", source: "path" },
+      { path: "/opt/homebrew/bin/git", source: "known-dir" },
+    ], "darwin")).toBe("/opt/homebrew/bin/git");
+  });
+
+  it("uses Apple's Git when it is the only installation available", () => {
+    expect(selectGitExecutable([
+      { path: "/usr/bin/git", source: "path" },
+    ], "darwin")).toBe("/usr/bin/git");
+  });
+
+  it("checks the login shell before accepting Apple's Git", () => {
+    expect(shouldProbeLoginShellForGit("/usr/bin/git", "darwin")).toBe(true);
+    expect(shouldProbeLoginShellForGit("/opt/homebrew/bin/git", "darwin")).toBe(false);
+    expect(shouldProbeLoginShellForGit("/usr/bin/git", "linux")).toBe(false);
+  });
+
+  it("explains that an Xcode license failure comes from Git, not iOS features", () => {
+    const message = formatGitExecutionError(
+      "You have not agreed to the Xcode license agreements. Please run 'sudo xcodebuild -license'.",
+    );
+
+    expect(message).toContain("ADE needs Git");
+    expect(message).toContain("not an ADE iOS Simulator or code-signing requirement");
+    expect(message).toContain("sudo xcodebuild -license");
   });
 });

--- a/apps/desktop/src/main/services/git/git.ts
+++ b/apps/desktop/src/main/services/git/git.ts
@@ -3,40 +3,67 @@ import path from "node:path";
 import { execFileSync, spawn } from "node:child_process";
 import type { ConflictFileType } from "../../../shared/types";
 import { terminateProcessTree } from "../shared/processExecution";
-import { resolveExecutableFromKnownLocations } from "../ai/cliExecutableResolver";
+import {
+  resolveExecutableCandidatesFromKnownLocations,
+  type ResolvedExecutable,
+} from "../ai/cliExecutableResolver";
 
 // Electron apps launched from Finder/Dock can have a stripped PATH that misses
 // where the user actually installed git (e.g. /opt/homebrew/bin on Apple
 // Silicon when shell PATH probe times out). Resolve git's absolute path once
 // and reuse it so spawn never throws ENOENT.
 let cachedGitExecutable: string | null = null;
+export function selectGitExecutable(
+  candidates: readonly ResolvedExecutable[],
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const selected = platform === "darwin"
+    ? candidates.find((candidate) => candidate.path !== "/usr/bin/git") ?? candidates[0]
+    : candidates[0];
+  return selected?.path ?? null;
+}
+
+export function shouldProbeLoginShellForGit(
+  selectedExecutable: string | null,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return selectedExecutable == null
+    || (platform === "darwin" && selectedExecutable === "/usr/bin/git");
+}
+
 function resolveGitExecutable(): string {
   if (cachedGitExecutable) return cachedGitExecutable;
   if (process.env.ADE_GIT_EXECUTABLE && fs.existsSync(process.env.ADE_GIT_EXECUTABLE)) {
     cachedGitExecutable = process.env.ADE_GIT_EXECUTABLE;
     return cachedGitExecutable;
   }
-  const fromKnown = resolveExecutableFromKnownLocations(process.platform === "win32" ? "git.exe" : "git");
-  if (fromKnown?.path) {
-    cachedGitExecutable = fromKnown.path;
-    return cachedGitExecutable;
-  }
-  // Last resort: ask the user's login shell. Slower, but only runs if the
-  // direct probe missed (e.g. git lives in an unusual nvm/asdf shim dir).
-  if (process.platform !== "win32") {
+  const candidates = resolveExecutableCandidatesFromKnownLocations(
+    process.platform === "win32" ? "git.exe" : "git",
+  );
+  const resolvedCandidate = selectGitExecutable(candidates);
+  // A packaged macOS app can inherit a PATH containing only /usr/bin even
+  // though the user's login shell exposes an independent Git via a custom
+  // package-manager or version-manager directory. Check that shell before
+  // accepting Apple's license-gated Git.
+  if (process.platform !== "win32" && shouldProbeLoginShellForGit(resolvedCandidate)) {
     try {
       const shell = process.env.SHELL?.trim() || "/bin/sh";
       const out = execFileSync(shell, ["-lc", "command -v git"], {
         encoding: "utf8",
         timeout: 3_000,
       }).trim();
-      if (out && fs.existsSync(out)) {
+      const isIndependentMacGit = process.platform !== "darwin" || out !== "/usr/bin/git";
+      if (out && fs.existsSync(out) && (isIndependentMacGit || !resolvedCandidate)) {
         cachedGitExecutable = out;
         return cachedGitExecutable;
       }
     } catch {
       // fall through
     }
+  }
+  if (resolvedCandidate) {
+    cachedGitExecutable = resolvedCandidate;
+    return cachedGitExecutable;
   }
   // Fall back to bare "git" — spawn will surface the original ENOENT with a
   // clearer pre-check error message wrapped around it.
@@ -285,10 +312,15 @@ export async function runGit(args: string[], opts: GitRunOptions): Promise<GitRu
 export async function runGitOrThrow(args: string[], opts: GitRunOptions): Promise<string> {
   const res = await runGit(args, opts);
   if (res.exitCode !== 0) {
-    const msg = res.stderr.trim() || res.stdout.trim() || `git ${args.join(" ")} failed`;
-    throw new Error(msg);
+    const raw = res.stderr.trim() || res.stdout.trim() || `git ${args.join(" ")} failed`;
+    throw new Error(formatGitExecutionError(raw));
   }
   return res.stdout;
+}
+
+export function formatGitExecutionError(raw: string): string {
+  if (!/not agreed to the Xcode license agreements/i.test(raw)) return raw;
+  return "ADE needs Git to open and manage this project. macOS blocked Apple's Git because the Xcode license has not been accepted. This is a Git requirement, not an ADE iOS Simulator or code-signing requirement. In Terminal, run `sudo xcodebuild -license`, or install Git separately (for example with Homebrew) and restart ADE.";
 }
 
 /**

--- a/apps/desktop/src/renderer/components/app/AppShell.aiStatus.test.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.aiStatus.test.tsx
@@ -68,6 +68,7 @@ function resetStore() {
     projectHydrated: false,
     showWelcome: true,
     projectTransition: null,
+    projectTransitionError: null,
     lanes: [],
     laneSnapshots: [],
     lanesLoading: false,
@@ -164,6 +165,28 @@ describe("AppShell AI provider status", () => {
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
+  });
+
+  it("shows the full project error below the top bar and lets the user dismiss it", () => {
+    const message = "ADE needs Git to open and manage this project. macOS blocked Apple's Git because the Xcode license has not been accepted.";
+    useAppStore.setState({ projectTransitionError: message } as any);
+
+    render(
+      <MemoryRouter initialEntries={["/work"]}>
+        <AppShell>
+          <div>Work content</div>
+        </AppShell>
+      </MemoryRouter>,
+    );
+
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain(message);
+    expect(alert.querySelector(".truncate")).toBeNull();
+
+    act(() => {
+      screen.getByRole("button", { name: "Dismiss project error" }).click();
+    });
+    expect(useAppStore.getState().projectTransitionError).toBeNull();
   });
 
   it("refreshes the missing-provider banner when AI status cache is invalidated", async () => {

--- a/apps/desktop/src/renderer/components/app/AppShell.tsx
+++ b/apps/desktop/src/renderer/components/app/AppShell.tsx
@@ -17,6 +17,7 @@ import { CommandPalette } from "./CommandPalette";
 import { TabNav } from "./TabNav";
 import { isWebClientMode } from "../../lib/webClientMode";
 import { TopBar } from "./TopBar";
+import { ProjectTransitionErrorAlert } from "./ProjectTransitionErrorAlert";
 import {
   getPrToastHeadline,
   getPrToastMeta,
@@ -1251,6 +1252,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           onNavigate={(path, opts) => navigate(path, opts)}
         />
       </div>
+
+      <ProjectTransitionErrorAlert />
 
       {!hideSidebar && projectMissing && project?.rootPath ? (
         <div className="shrink-0 mx-2 mt-1 rounded bg-red-500/8 px-3 py-1.5 text-[11px] font-mono text-red-800">

--- a/apps/desktop/src/renderer/components/app/ProjectTransitionErrorAlert.tsx
+++ b/apps/desktop/src/renderer/components/app/ProjectTransitionErrorAlert.tsx
@@ -1,0 +1,35 @@
+import { WarningCircle, X } from "@phosphor-icons/react";
+import { useAppStore } from "../../state/appStore";
+
+export function ProjectTransitionErrorAlert() {
+  const projectTransition = useAppStore((state) => state.projectTransition);
+  const projectTransitionError = useAppStore(
+    (state) => state.projectTransitionError,
+  );
+  const clearProjectTransitionError = useAppStore(
+    (state) => state.clearProjectTransitionError,
+  );
+
+  if (projectTransition || !projectTransitionError) return null;
+
+  return (
+    <div
+      className="mx-2 mt-1 flex shrink-0 items-start gap-2 rounded-md border border-red-500/25 bg-red-500/10 px-3 py-2 text-[12px] text-red-200"
+      role="alert"
+    >
+      <WarningCircle size={15} weight="fill" className="mt-0.5 shrink-0" />
+      <span className="min-w-0 flex-1 whitespace-pre-wrap break-words">
+        {projectTransitionError}
+      </span>
+      <button
+        type="button"
+        className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-current opacity-75 transition-opacity hover:opacity-100"
+        onClick={clearProjectTransitionError}
+        title="Dismiss project error"
+        aria-label="Dismiss project error"
+      >
+        <X size={12} weight="bold" />
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/app/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.tsx
@@ -893,10 +893,6 @@ export function TopBar({
   const personalChatsTabOpen = useAppStore((s) => s.personalChatsTabOpen);
   const closePersonalChatsTab = useAppStore((s) => s.closePersonalChatsTab);
   const projectTransition = useAppStore((s) => s.projectTransition);
-  const projectTransitionError = useAppStore((s) => s.projectTransitionError);
-  const clearProjectTransitionError = useAppStore(
-    (s) => s.clearProjectTransitionError,
-  );
   const switchProjectToPath = useAppStore((s) => s.switchProjectToPath);
   const switchRemoteProject = useAppStore((s) => s.switchRemoteProject);
   const [recentProjects, setRecentProjects] = useState<RecentProjectSummary[]>(
@@ -2406,29 +2402,6 @@ export function TopBar({
           <span className="max-w-[240px] truncate">
             {projectTransitionLabel}
           </span>
-        </div>
-      ) : null}
-
-      {!projectTransitionLabel && projectTransitionError ? (
-        <div
-          className={cn(
-            "ade-shell-control shrink-0 inline-flex items-center gap-1.5 rounded-md px-2.5 py-1",
-            "text-[11px] font-medium text-red-300",
-          )}
-          style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
-          title={projectTransitionError}
-        >
-          <span className="max-w-[320px] truncate">
-            {projectTransitionError}
-          </span>
-          <button
-            type="button"
-            className="inline-flex h-4 w-4 items-center justify-center rounded-sm text-current opacity-80 transition-opacity hover:opacity-100"
-            onClick={clearProjectTransitionError}
-            title="Dismiss project error"
-          >
-            <X size={10} weight="regular" />
-          </button>
         </div>
       ) : null}
 

--- a/apps/desktop/src/renderer/state/appStore.test.ts
+++ b/apps/desktop/src/renderer/state/appStore.test.ts
@@ -1166,6 +1166,22 @@ describe("appStore", () => {
       );
     });
 
+    it("removes Electron's remote-method wrapper from project errors", async () => {
+      (window.ade.project.switchToPath as any).mockRejectedValueOnce(
+        new Error(
+          "Error invoking remote method 'ade.project.switchToPath': Error: ADE needs Git to open this project.",
+        ),
+      );
+
+      await expect(
+        useAppStore.getState().switchProjectToPath("/tmp/project"),
+      ).rejects.toThrow("Error invoking remote method");
+
+      expect(useAppStore.getState().projectTransitionError).toBe(
+        "ADE needs Git to open this project.",
+      );
+    });
+
     it("prunes banner-dismiss maps to the new project after switch settles", async () => {
       const originalWindowSetTimeout = window.setTimeout;
       vi.useFakeTimers();

--- a/apps/desktop/src/renderer/state/appStore.ts
+++ b/apps/desktop/src/renderer/state/appStore.ts
@@ -993,7 +993,10 @@ function formatProjectTransitionError(
   kind: "opening" | "switching" | "closing",
   error: unknown,
 ): string {
-  const raw = extractError(error).trim();
+  const raw = extractError(error)
+    .replace(/^Error invoking remote method '[^']+':\s*/i, "")
+    .replace(/^Error:\s*/i, "")
+    .trim();
   if (/timed out after 30000ms/i.test(raw)) {
     if (kind === "opening") {
       return "Opening this project took longer than 30 seconds, so ADE stopped waiting.";

--- a/apps/ios/ADE/App/RemoteProjectAddSheet.swift
+++ b/apps/ios/ADE/App/RemoteProjectAddSheet.swift
@@ -824,7 +824,7 @@ private struct InlineProjectNotice: View {
     Text(message)
       .font(.system(.caption, design: .monospaced))
       .foregroundStyle(tone == .danger ? ADEColor.danger : ADEColor.textMuted)
-      .lineLimit(3)
+      .lineLimit(tone == .danger ? nil : 3)
       .frame(maxWidth: .infinity, alignment: .leading)
       .padding(10)
       .background((tone == .danger ? ADEColor.danger : ADEColor.recessedBackground).opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -820,6 +820,7 @@ Related trust-boundary docs: [Computer-use artifact broker](./features/computer-
 
 - ADE **shells out** to the system `git` binary (not isomorphic-git). Rationale: full feature parity, hook compatibility, native credential handling, performance.
 - All commands go through `runGit` / `runGitOrThrow` in `apps/desktop/src/main/services/git/git.ts` (timeout support, structured output parsing).
+- Executable discovery reuses `ai/cliExecutableResolver.ts` to inspect PATH and known installation directories. On macOS, ADE prefers an independently installed Git over Apple's `/usr/bin/git` and probes the login shell before accepting `/usr/bin/git`; this keeps project opening usable when Apple's Git is blocked by an unaccepted Xcode license. If Apple's Git is the only available option, the surfaced error explains that accepting the license is a Git prerequisite, not an iOS Simulator or code-signing requirement, and points to installing Git separately as the alternative.
 - High-level ops in `gitOperationsService.ts` — wrap every mutation in `runLaneOperation()`: resolve lane, capture pre-HEAD, record operation, execute, capture post-HEAD, finalize record, fire `onHeadChanged` if needed.
 
 ### 9.2 Worktree-per-lane isolation

--- a/docs/features/project-home/README.md
+++ b/docs/features/project-home/README.md
@@ -77,7 +77,12 @@ Related pages for the broader "home" experience:
   project open, and cache pruning retains Work/lane/session state for every
   open project tab root.
 - `apps/desktop/src/renderer/components/app/AppShell.tsx` — top-level
-  nav, routes `/run` to `RunPage`.
+  nav, routes `/run` to `RunPage`, and mounts project-transition errors below
+  the TopBar where long messages can wrap without displacing header controls.
+- `apps/desktop/src/renderer/components/app/ProjectTransitionErrorAlert.tsx` —
+  dismissible, full-width alert for failed project open / switch / close
+  operations. It hides while another project transition is active and preserves
+  the complete error text with wrapping instead of truncation.
 - `apps/desktop/src/renderer/components/app/CommandPalette.tsx` —
   keyboard-first project browser and create/clone/open flows used by the
   welcome screen and global command palette.
@@ -286,6 +291,16 @@ the cache after forget / reorder / pin writes. Local project rows open via
 `appStore.switchRemoteProject(targetId, projectId)`; disconnected remote
 rows first call `window.ade.remoteRuntime.connect(targetId)` and then bind
 the project if the connection succeeds.
+
+Project-open failures are stored in `appStore.projectTransitionError` and
+rendered by `AppShell` as a full-width, wrapping alert below the TopBar; the
+TopBar never truncates the only visible copy of an error. Opening a local
+project requires Git because ADE validates the repository root before binding
+it. On macOS, Git resolution prefers a separately installed executable over
+Apple's `/usr/bin/git`, which can be blocked by an unaccepted Xcode license.
+When Apple's Git is the only option, ADE explains that the license prompt is a
+Git dependency rather than an iOS Simulator or code-signing requirement and
+offers a separate Git installation as the alternative.
 
 ### Command Palette project flows
 


### PR DESCRIPTION
## Summary

- move project-transition failures out of the cramped top bar into a wrapping, dismissible page alert
- prefer independently installed Git on macOS, including login-shell discovery, before Apple’s license-gated `/usr/bin/git`
- explain that the Xcode license message comes from Git rather than ADE iOS features
- preserve full host project-open errors in the iOS remote-project sheet

## Validation

- `/quality`: clean after 3 auto-applied findings
- focused desktop suites: 103 tests passed
- desktop CI-style shard 1/8: 927 tests passed
- ADE CLI: 1,712 tests passed
- ADE Code TUI: 871 tests passed
- iOS Swift parse passed
- internal docs validation passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git detection on macOS by preferring available non-Apple Git installations.
  * Added clearer guidance when Git is unavailable or blocked by Xcode license requirements.
  * Improved project transition error messages by removing technical wrapper text.

* **New Features**
  * Added a prominent project transition error alert with full details and a dismiss action.
  * Error alerts now remain visible in the main application layout instead of the top bar.
  * iOS project notices can display complete danger messages without truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves project-open errors and macOS Git discovery. The main changes are:

- Adds a full-width, dismissible project-transition error alert.
- Removes Electron wrapper text from displayed project errors.
- Prefers independently installed Git on macOS before Apple Git.
- Explains Xcode license failures as Git setup issues.
- Allows full danger messages in the iOS remote-project sheet.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A temporary attempt to add a query-param seeding hook in main.tsx was implemented briefly and then reverted before stopping.
- The Vite renderer dev server started successfully with browser mock data.
- The Playwright run attempted to import the real store module and failed, with details showing the command, working directory, and exit code in the logs.
- The run halted at the step limit, so no accepted proof artifacts were generated.
- A high-value next step was identified: run the real Vite renderer and seed the actual Zustand store from Playwright, or induce openRepo failure through the UI, then capture the alert and dismissal.

<a href="https://app.greptile.com/trex/runs/14134041/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/ai/cliExecutableResolver.ts | Adds ordered executable candidate discovery while keeping the existing single-result resolver. |
| apps/desktop/src/main/services/git/git.ts | Updates Git selection on macOS and improves the Xcode license error message. |
| apps/desktop/src/renderer/state/appStore.ts | Cleans remote-method wrapper text before storing project transition errors. |
| apps/desktop/src/renderer/components/app/ProjectTransitionErrorAlert.tsx | Adds the wrapping project-transition error alert with a dismiss action. |
| apps/ios/ADE/App/RemoteProjectAddSheet.swift | Lets danger notices show full text in the remote-project sheet. |

<sub>Reviews (2): Last reviewed commit: ["ship: iteration 1 — address review 46795..."](https://github.com/arul28/ade/commit/fda6c5b354c7e444d4ca161c34ed38ae72d35f81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43596181)</sub>

<!-- /greptile_comment -->