### PR TITLE
release: changelog for v1.2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.23] - 2026-07-12
+
+### Changed
+
+- Kept context usage accurate after compaction across desktop, ADE Code, and iOS.
+- Strengthened Claude SDK turn lifecycle and steering for active turns, scheduled work, and subagent activity.
+- Preferred independently installed Git over Apple's license-gated Git on macOS, including login-shell discovery.
+
+### Fixed
+
+- Moved project-transition failures from a truncated top-bar pill to a full-width, wrapping, dismissible alert.
+- Explained that Apple's Xcode license prompt comes from the Git executable rather than ADE's iOS Simulator or code-signing features.
+- Preserved complete remote project-add errors on iOS instead of limiting danger messages to three lines.
+
 ## [1.2.22] - 2026-07-11
 
 ### Changed
@@ -705,7 +719,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.22...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.23...HEAD
+[1.2.23]: https://github.com/arul28/ADE/compare/v1.2.22...v1.2.23
 [1.2.22]: https://github.com/arul28/ADE/compare/v1.2.21...v1.2.22
 [1.2.21]: https://github.com/arul28/ADE/compare/v1.2.20...v1.2.21
 [1.2.20]: https://github.com/arul28/ADE/compare/v1.2.19...v1.2.20

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.22">
-  v1.2.22 - Claude chats behave like Claude Code, an end to the usage refresh storm, and smoother mobile chat input.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.23">
+  v1.2.23 - Accurate context after compaction, stronger Claude steering, and complete project-open errors.
 </Card>

--- a/changelog/v1.2.23.mdx
+++ b/changelog/v1.2.23.mdx
@@ -1,0 +1,22 @@
+---
+title: "v1.2.23"
+description: "Release notes for ADE v1.2.23 - July 12, 2026"
+---
+
+v1.2.23 keeps context usage accurate after compaction, strengthens Claude turn steering, and makes project-open failures fully visible and actionable.
+
+---
+
+## Desktop and CLI
+
+- **Accurate context after compaction.** Context usage now reconstructs from explicit turn snapshots after compaction instead of dropping, jumping, or accepting metadata-only updates. Desktop, ADE Code, and mobile stay aligned on the same usage state.
+- **Reliable Claude steering and turn lifecycle.** Messages sent while Claude is active now steer the current turn cleanly, while turn completion, scheduled work, and subagent activity settle without stale lifecycle state.
+- **Project-open errors stay readable.** Failed project opens now show a wrapping, dismissible alert below the top bar, so long recovery instructions are never truncated.
+- **No unnecessary Xcode dependency.** On macOS, ADE prefers an independently installed Git—including Git discovered through the login shell—before Apple's license-gated `/usr/bin/git`. If Apple Git is the only option, ADE explains that the Xcode license prompt comes from Git rather than iOS Simulator or code signing.
+
+---
+
+## iOS
+
+- **Context and Claude parity.** Mobile Work timelines preserve the corrected post-compaction context usage and Claude lifecycle events from the host.
+- **Complete project errors.** Remote project-add failures no longer cap danger messages at three lines, keeping full host recovery instructions visible.

--- a/docs.json
+++ b/docs.json
@@ -177,8 +177,9 @@
             "icon": "tag",
             "expanded": true,
             "pages": [
-              "changelog",
-              "changelog/v1.2.22",
+        "changelog",
+        "changelog/v1.2.23",
+        "changelog/v1.2.22",
               "changelog/v1.2.21",
               "changelog/v1.2.20",
               "changelog/v1.2.19",


### PR DESCRIPTION
Prepare the public changelog and docs navigation for desktop release v1.2.23.

Validation: `node scripts/validate-docs.mjs` (183 files).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR publishes the v1.2.23 release notes and updates the docs navigation.

- Added the v1.2.23 entry to `CHANGELOG.md`.
- Added the new `changelog/v1.2.23.mdx` release page.
- Updated the latest-release card to point to v1.2.23.
- Added v1.2.23 to the changelog sidebar.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed node scripts/validate-docs.mjs in the repository and confirmed the documentation validation finished with exit code 0 and a message that 183 files were validated as passed.

<a href="https://app.greptile.com/trex/runs/14135320/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds the v1.2.23 release notes and updates the compare links for the new release. |
| changelog/index.mdx | Updates the latest-release card to link to the v1.2.23 changelog page. |
| changelog/v1.2.23.mdx | Adds the public release page for ADE v1.2.23. |
| docs.json | Adds the v1.2.23 page to the changelog navigation. |

<sub>Reviews (1): Last reviewed commit: ["release: changelog for v1.2.23"](https://github.com/arul28/ade/commit/4861f3d20b316e3ce7e8e3472341befee3f185a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43601134)</sub>

<!-- /greptile_comment -->