### PR TITLE
perf(work): focused grid ownership, memoized transcript boundary, self-clearing cache badge timer

### DIFF
--- a/apps/desktop/src/renderer/components/chat/AgentChatMessageList.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatMessageList.test.tsx
@@ -49,6 +49,28 @@ vi.mock("@lobehub/icons", () => {
   };
 });
 
+// Render-count instrumentation for the memo-boundary tests below.
+// AgentChatMessageListMain calls useAppStore exactly twice in its body and
+// nowhere else in the module (rows do not read the store), so a counting delegate
+// is an exact list-BODY render counter. It delegates to the real hook so store
+// behavior is unchanged for every other test in this file.
+let memoListBodyRenders = 0;
+vi.mock("../../state/appStore", async (importOriginal) => {
+  const actual = await importOriginal<typeof AppStoreModule>();
+  return {
+    ...actual,
+    useAppStore: ((selector: (s: unknown) => unknown, equality?: (a: unknown, b: unknown) => boolean) => {
+      memoListBodyRenders++;
+      return (actual.useAppStore as unknown as (s: typeof selector, e?: typeof equality) => unknown)(
+        selector,
+        equality,
+      );
+    }) as typeof actual.useAppStore,
+  };
+});
+
+import { useCallback, useMemo, useState } from "react";
+import type * as AppStoreModule from "../../state/appStore";
 import {
   AgentChatMessageList,
   calculateVirtualWindow,
@@ -3186,5 +3208,69 @@ describe("AgentChatMessageList inline ask-user card", () => {
       surfaces: ["main", "renderer"],
       handoff: "ready",
     });
+  });
+});
+
+describe("AgentChatMessageList memo boundary", () => {
+  const TEXT_EVENTS: AgentChatEventEnvelope[] = [
+    {
+      sessionId: "s1",
+      timestamp: "2026-03-17T10:00:00.000Z",
+      event: { type: "text", text: "Hello world.", itemId: "text-1", turnId: "turn-1" },
+    },
+  ];
+
+  /**
+   * A composer-like owner holding character-level draft state (like AgentChatPane /
+   * PersonalChatsPage) that renders the memoized transcript boundary. `unstable`
+   * recreates a row-facing callback each render to model the pre-fix inline-arrow
+   * props that defeated the boundary.
+   */
+  function Harness({ unstable = false }: { unstable?: boolean }) {
+    const [draft, setDraft] = useState("");
+    const events = useMemo(() => TEXT_EVENTS, []);
+    const stableApproval = useCallback(() => {}, []);
+    const onApproval = unstable ? () => {} : stableApproval;
+    return (
+      <MemoryRouter>
+        <input data-testid="draft" value={draft} onChange={(event) => setDraft(event.target.value)} />
+        <AgentChatMessageList
+          events={events}
+          sessionId="s1"
+          assistantLabel="Assistant"
+          onApproval={onApproval as never}
+        />
+      </MemoryRouter>
+    );
+  }
+
+  it("is a memoized component", () => {
+    expect((AgentChatMessageList as unknown as { $$typeof: symbol }).$$typeof).toBe(
+      Symbol.for("react.memo"),
+    );
+  });
+
+  it("does not re-render on a draft-only update when transcript props are unchanged", () => {
+    memoListBodyRenders = 0;
+    const { getByTestId } = render(<Harness />);
+    expect(memoListBodyRenders).toBeGreaterThan(0);
+
+    const before = memoListBodyRenders;
+    fireEvent.change(getByTestId("draft"), { target: { value: "typing a draft" } });
+    fireEvent.change(getByTestId("draft"), { target: { value: "typing a draft further" } });
+    // The memoized boundary bails out: the list body does not re-run on draft-only updates.
+    expect(memoListBodyRenders).toBe(before);
+  });
+
+  it("re-renders when a row-facing callback identity churns (guards the stabilization)", () => {
+    memoListBodyRenders = 0;
+    const { getByTestId } = render(<Harness unstable />);
+    expect(memoListBodyRenders).toBeGreaterThan(0);
+
+    const before = memoListBodyRenders;
+    fireEvent.change(getByTestId("draft"), { target: { value: "typing" } });
+    // An unstable row-facing prop defeats the boundary — proving the boundary + prop
+    // stabilization are load-bearing, not incidental.
+    expect(memoListBodyRenders).toBeGreaterThan(before);
   });
 });

--- a/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx
@@ -5735,4 +5735,11 @@ function AgentChatMessageListMain({
   );
 }
 
-export const AgentChatMessageList = AgentChatMessageListMain;
+// Memoized transcript boundary. Draft/composer keystrokes rerender the owning
+// pane (AgentChatPane / PersonalChatsPage), but those callers pass referentially
+// stable props (memoized events/state + useCallback'd row-facing handlers), so a
+// draft-only update no longer commits the message list or its virtualized rows.
+// The component still rerenders on real transcript/prop changes and on its own
+// appStore subscriptions (density, runtime name).
+export const AgentChatMessageList = React.memo(AgentChatMessageListMain);
+AgentChatMessageList.displayName = "AgentChatMessageList";

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -3709,6 +3709,10 @@ export function AgentChatPane({
   // below, which run from window-event listeners (stale-closure-safe).
   const selectedEventsForDisplayRef = useRef(selectedEventsForDisplay);
   selectedEventsForDisplayRef.current = selectedEventsForDisplay;
+  const chatHasMessages = useMemo(
+    () => selectedEventsForDisplay.some((env) => env.event.type === "user_message" || env.event.type === "text"),
+    [selectedEventsForDisplay],
+  );
   const [wakeAwayWindow, setWakeAwayWindow] = useState<{
     sessionId: string;
     lastViewedAtMs: number;
@@ -9280,6 +9284,43 @@ export function AgentChatPane({
     }
   }, [openRewindConfirmDialog, refreshSessions, selectedEvents, selectedSessionId]);
 
+  // Row-facing handlers for AgentChatMessageList are stabilized so a draft-only
+  // keystroke (which rerenders this pane) does not change the memoized transcript
+  // boundary's props. Each still observes current session/turn/model/lane state
+  // through its dependency list, so retry/recovery/model-picker behavior is
+  // unchanged. Do NOT depend on the draft here.
+  const handleListApproval = useCallback(
+    (
+      itemId: string,
+      decision: AgentChatApprovalDecision,
+      responseText?: string | null,
+      answers?: Record<string, string | string[]>,
+    ) => {
+      void handleApproval(itemId, decision, responseText, answers);
+    },
+    [handleApproval],
+  );
+  const handleListCodexRecovery = useCallback(
+    (args: AgentChatRecoverCodexTurnArgs) => window.ade.agentChat.recoverCodexTurn(args),
+    [],
+  );
+  const handleListRetryProviderFailure = useCallback(
+    async (failedTurnId: string | null) => {
+      if (!selectedSessionId) return "This chat is no longer selected.";
+      if (turnActive) return "A turn is already active in this thread. Wait for it to finish before retrying.";
+      return resendLastUserMessage(selectedSessionId, failedTurnId);
+    },
+    [resendLastUserMessage, selectedSessionId, turnActive],
+  );
+  const handleListChooseProviderFailureModel = useCallback(() => {
+    if (turnActive) return;
+    setModelPickerOpenRequest((request) => ({
+      key: (request?.key ?? 0) + 1,
+      sessionId: modelPickerOpenRequestSessionId,
+      laneId,
+    }));
+  }, [laneId, modelPickerOpenRequestSessionId, turnActive]);
+
   const interrupt = useCallback(async () => {
     if (!selectedSessionId) return;
     // Let the stop button disappear immediately while the main-process interrupt finishes.
@@ -10709,7 +10750,7 @@ export function AgentChatPane({
               }
             }}
             promptSuggestion={promptSuggestion}
-            chatHasMessages={selectedEventsForDisplay.some((env) => env.event.type === "user_message" || env.event.type === "text")}
+            chatHasMessages={chatHasMessages}
             pendingSteers={pendingSteers}
             onCancelSteer={(steerId) => {
               if (selectedSessionId) {
@@ -11417,29 +11458,13 @@ export function AgentChatPane({
                       laneId={laneId}
                       sessionId={selectedSessionId}
                       onInsertDraft={insertComposerDraft}
-                      onRevealChatTerminal={(terminal) => {
-                        revealChatTerminal(terminal);
-                      }}
+                      onRevealChatTerminal={revealChatTerminal}
                       turnDiffSummaries={selectedTurnDiffSummaries}
                       onRewindFiles={selectedSession?.provider === "claude" || selectedSession?.provider === "codex" ? rewindFilesFromMessage : undefined}
-                      onApproval={(itemId, decision, responseText, answers) => {
-                        void handleApproval(itemId, decision, responseText, answers);
-                      }}
-                      onCodexRecovery={(args: AgentChatRecoverCodexTurnArgs) =>
-                        window.ade.agentChat.recoverCodexTurn(args)}
-                      onRetryProviderFailure={async (failedTurnId) => {
-                        if (!selectedSessionId) return "This chat is no longer selected.";
-                        if (turnActive) return "A turn is already active in this thread. Wait for it to finish before retrying.";
-                        return resendLastUserMessage(selectedSessionId, failedTurnId);
-                      }}
-                      onChooseProviderFailureModel={() => {
-                        if (turnActive) return;
-                        setModelPickerOpenRequest((request) => ({
-                          key: (request?.key ?? 0) + 1,
-                          sessionId: modelPickerOpenRequestSessionId,
-                          laneId,
-                        }));
-                      }}
+                      onApproval={handleListApproval}
+                      onCodexRecovery={handleListCodexRecovery}
+                      onRetryProviderFailure={handleListRetryProviderFailure}
+                      onChooseProviderFailureModel={handleListChooseProviderFailureModel}
                       mosaic={subagentView ? undefined : mosaicContext}
                       scrollToRowKeyRequest={subagentView ? null : wakeJumpRequest}
                     />

--- a/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.tsx
+++ b/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { ArrowLeft, Globe, SpinnerGap, TerminalWindow } from "@phosphor-icons/react";
 import { useNavigate } from "react-router-dom";
 import type {
+  AgentChatApprovalDecision,
   AgentChatEventEnvelope,
   AgentChatEventHistorySnapshot,
   AgentChatModelCatalog,
@@ -296,6 +297,24 @@ export function PersonalChatsPage({ standalone = false }: { standalone?: boolean
 
   const selectedSession = sessions.find((session) => session.sessionId === selectedId) ?? null;
   const selectedEvents = selectedId ? eventsBySession[selectedId] ?? EMPTY_EVENTS : EMPTY_EVENTS;
+  // Stable row-facing handlers so a draft-only keystroke (which rerenders this
+  // page) does not defeat the memoized AgentChatMessageList boundary.
+  const handleListApproval = useCallback(
+    (
+      itemId: string,
+      decision: AgentChatApprovalDecision,
+      responseText?: string | null,
+      answers?: Record<string, string | string[]>,
+    ) => {
+      if (!selectedId) return;
+      void callPersonal<void>("respondToInput", { sessionId: selectedId, itemId, decision, responseText, answers });
+    },
+    [selectedId],
+  );
+  const appendDraft = useCallback(
+    (text: string) => setDraft((current) => (current ? `${current}\n${text}` : text)),
+    [],
+  );
   const dynamicCatalog = useMemo(
     () => catalog ? descriptorsFromAgentChatModelCatalog(catalog) : null,
     [catalog],
@@ -548,11 +567,8 @@ export function PersonalChatsPage({ standalone = false }: { standalone?: boolean
                     laneId={null}
                     sessionId={selectedId}
                     assistantLabel={selectedSession ? sessionTitle(selectedSession) : "ADE"}
-                    onApproval={(itemId, decision, responseText, answers) => {
-                      if (!selectedId) return;
-                      void callPersonal<void>("respondToInput", { sessionId: selectedId, itemId, decision, responseText, answers });
-                    }}
-                    onInsertDraft={(text) => setDraft((current) => current ? `${current}\n${text}` : text)}
+                    onApproval={handleListApproval}
+                    onInsertDraft={appendDraft}
                   />
                 </div>
               ) : heroMode ? (
@@ -569,7 +585,7 @@ export function PersonalChatsPage({ standalone = false }: { standalone?: boolean
             </div>
             {toolPanel === "browser" ? (
               <div className="w-[min(44%,560px)] min-w-[340px] border-l border-white/[0.07] bg-bg max-lg:absolute max-lg:inset-y-0 max-lg:right-0 max-lg:z-30 max-lg:w-[min(92%,560px)] max-lg:shadow-2xl">
-                <ChatBuiltInBrowserPanel sessionId={selectedId} projectRootOverride={null} onInsertDraft={(text) => setDraft((current) => current ? `${current}\n${text}` : text)} />
+                <ChatBuiltInBrowserPanel sessionId={selectedId} projectRootOverride={null} onInsertDraft={appendDraft} />
               </div>
             ) : null}
             {toolPanel === "terminal" ? (

--- a/apps/desktop/src/renderer/components/shared/ClaudeCacheTtlBadge.test.tsx
+++ b/apps/desktop/src/renderer/components/shared/ClaudeCacheTtlBadge.test.tsx
@@ -1,0 +1,108 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { ClaudeCacheTtlBadge } from "./ClaudeCacheTtlBadge";
+import { CLAUDE_CHAT_CACHE_TTL_MS } from "../../lib/claudeCacheTtl";
+
+const T0 = Date.parse("2026-04-08T12:00:00.000Z");
+
+/** idleSinceAt timestamp such that exactly `remainingMs` of cache TTL remain at T0. */
+function idleWithRemaining(remainingMs: number): string {
+  return new Date(T0 - (CLAUDE_CHAT_CACHE_TTL_MS - remainingMs)).toISOString();
+}
+
+describe("ClaudeCacheTtlBadge", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("counts down with ceil-based one-second resolution, then stops its interval once expired while mounted", () => {
+    const baseline = vi.getTimerCount();
+    // 2500ms remaining distinguishes ceil (→ "0:03") from floor (→ "0:02").
+    const { container } = render(<ClaudeCacheTtlBadge idleSinceAt={idleWithRemaining(2500)} />);
+
+    // One interval is installed and the ceil-based countdown is visible.
+    expect(vi.getTimerCount()).toBe(baseline + 1);
+    expect(container.textContent).toContain("0:03");
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    // 1500ms remaining → ceil → "0:02" (floor would be "0:01").
+    expect(container.textContent).toContain("0:02");
+    expect(vi.getTimerCount()).toBe(baseline + 1);
+
+    // Cross zero: the badge publishes the final (null) state and clears its timer.
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(container.textContent).toBe("");
+    expect(vi.getTimerCount()).toBe(baseline);
+
+    // No callbacks remain: further clock advances do nothing while still mounted.
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(vi.getTimerCount()).toBe(baseline);
+    expect(container.textContent).toBe("");
+  });
+
+  it("installs no interval when mounted already expired", () => {
+    const baseline = vi.getTimerCount();
+    const { container } = render(<ClaudeCacheTtlBadge idleSinceAt={idleWithRemaining(0)} />);
+    expect(container.textContent).toBe("");
+    expect(vi.getTimerCount()).toBe(baseline);
+  });
+
+  it("installs no interval when there is no idle timestamp", () => {
+    const baseline = vi.getTimerCount();
+    const { container } = render(<ClaudeCacheTtlBadge idleSinceAt={null} />);
+    expect(container.textContent).toBe("");
+    expect(vi.getTimerCount()).toBe(baseline);
+  });
+
+  it("clears the interval on unmount", () => {
+    const baseline = vi.getTimerCount();
+    const { unmount } = render(<ClaudeCacheTtlBadge idleSinceAt={idleWithRemaining(120_000)} />);
+    expect(vi.getTimerCount()).toBe(baseline + 1);
+    unmount();
+    expect(vi.getTimerCount()).toBe(baseline);
+  });
+
+  it("restarts a single interval and does not leak the old one when idleSinceAt changes", () => {
+    const baseline = vi.getTimerCount();
+    const { rerender } = render(<ClaudeCacheTtlBadge idleSinceAt={idleWithRemaining(120_000)} />);
+    expect(vi.getTimerCount()).toBe(baseline + 1);
+    rerender(<ClaudeCacheTtlBadge idleSinceAt={idleWithRemaining(60_000)} />);
+    expect(vi.getTimerCount()).toBe(baseline + 1);
+  });
+
+  it.each([1, 50, 500])(
+    "returns every interval timer to zero after expiry for %i mounted badges",
+    (count) => {
+      const baseline = vi.getTimerCount();
+      render(
+        <>
+          {Array.from({ length: count }, (_, i) => (
+            <ClaudeCacheTtlBadge key={i} idleSinceAt={idleWithRemaining(2000)} />
+          ))}
+        </>,
+      );
+      // One interval per mounted, unexpired badge.
+      expect(vi.getTimerCount()).toBe(baseline + count);
+
+      // After expiry every badge self-clears; no wakeups remain.
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(vi.getTimerCount()).toBe(baseline);
+    },
+  );
+});

--- a/apps/desktop/src/renderer/components/shared/ClaudeCacheTtlBadge.tsx
+++ b/apps/desktop/src/renderer/components/shared/ClaudeCacheTtlBadge.tsx
@@ -17,9 +17,20 @@ export function ClaudeCacheTtlBadge({
 
   useEffect(() => {
     if (!idleSinceAt) return;
-    setNowMs(Date.now());
+    const now = Date.now();
+    setNowMs(now);
+    // Already expired at mount: publish the final state, install no interval.
+    if (getClaudeCacheTtlRemainingMs(idleSinceAt, now) <= 0) return;
     const intervalId = window.setInterval(() => {
-      setNowMs(Date.now());
+      const tickNow = Date.now();
+      setNowMs(tickNow);
+      // Publish the final expired state, then stop the one-second interval while
+      // the component stays mounted. An expired badge must not keep waking the
+      // renderer once per second (offscreen cards / retained Work trees amplify
+      // this). Cleanup below still fires on prop change and unmount.
+      if (getClaudeCacheTtlRemainingMs(idleSinceAt, tickNow) <= 0) {
+        window.clearInterval(intervalId);
+      }
     }, 1000);
     return () => window.clearInterval(intervalId);
   }, [idleSinceAt]);

--- a/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
+++ b/apps/desktop/src/renderer/components/terminals/TerminalView.tsx
@@ -702,6 +702,10 @@ function clearDisposeTimer(runtime: CachedRuntime) {
 
 function parkRuntime(runtime: CachedRuntime) {
   setRuntimeInteractionState(runtime, false);
+  // A parked runtime is unmounted from any visible surface — hide its host from
+  // the interactive + AT tree (the parking root is also inert, but keep the host
+  // attribute explicit so it is hidden the instant it is parked).
+  setRuntimeHostHidden(runtime, true);
   const parking = ensureParkedRoot();
   if (runtime.host.parentElement !== parking) {
     parking.appendChild(runtime.host);
@@ -732,27 +736,36 @@ export function disposeTerminalRuntimesForProjectChange(
 }
 
 function setRuntimeInteractionState(runtime: CachedRuntime, active: boolean) {
+  // Active ownership gates keyboard input and tab-focusability only. It must NOT
+  // gate `inert`/`aria-hidden`: a visible-but-inactive grid tile has to stay
+  // clickable (so a pointer-down can transfer focus and activate it) and remain
+  // readable by assistive tech. Hiding from the interactive/AT tree is a
+  // visibility concern, handled by setRuntimeHostHidden.
   runtime.active = active;
   runtime.inputEnabled = active;
   try {
+    // tabIndex stays active-gated: an inactive tile stays out of the Tab order
+    // while remaining click/programmatically focusable.
     runtime.host.tabIndex = active ? 0 : -1;
   } catch {
     // ignore
   }
+}
+
+/**
+ * Visibility-gated hiding of a terminal host from the interactive + AT tree.
+ * A hidden host (parked or on an inactive/offscreen surface) is `inert` +
+ * `aria-hidden`; a visible host is fully interactive even when it is not the
+ * active grid member.
+ */
+function setRuntimeHostHidden(runtime: CachedRuntime, hidden: boolean) {
   try {
-    if (active) {
-      runtime.host.removeAttribute("aria-hidden");
-    } else {
+    if (hidden) {
       runtime.host.setAttribute("aria-hidden", "true");
-    }
-  } catch {
-    // ignore
-  }
-  try {
-    if (active) {
-      runtime.host.removeAttribute("inert");
-    } else {
       runtime.host.setAttribute("inert", "");
+    } else {
+      runtime.host.removeAttribute("aria-hidden");
+      runtime.host.removeAttribute("inert");
     }
   } catch {
     // ignore
@@ -2252,6 +2265,7 @@ export function TerminalView({
     clearDisposeTimer(runtime);
     setRuntimeInteractionState(runtime, mountConfig.isActive);
     setRuntimeVisibilityState(runtime, mountConfig.isVisible);
+    setRuntimeHostHidden(runtime, !mountConfig.isVisible);
 
     const onRuntimeSnapshot: RuntimeListener = (snapshot) => {
       setExited(snapshot.exitCode);
@@ -2464,6 +2478,9 @@ export function TerminalView({
     const wrapper = wrapperRef.current;
     setRuntimeInteractionState(runtime, isActive);
     setRuntimeVisibilityState(runtime, isVisible);
+    // Host hidden state follows visibility, not active ownership, so a visible
+    // inactive grid tile stays interactive/clickable and AT-readable.
+    setRuntimeHostHidden(runtime, !isVisible);
 
     if (wrapper) {
       wrapper.tabIndex = -1;

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.test.tsx
@@ -3,7 +3,7 @@
 import type * as ReactNamespace from "react";
 import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { TerminalSessionSummary } from "../../../shared/types";
+import type { LaneSummary, TerminalSessionSummary } from "../../../shared/types";
 import { isChatToolType } from "../../lib/sessions";
 import { WorkViewArea } from "./WorkViewArea";
 
@@ -151,6 +151,37 @@ vi.mock("../chat/AgentChatPane", async () => {
 
 vi.mock("./WorkStartSurface", () => ({
   WorkStartSurface: () => <div data-testid="work-start-surface" />,
+}));
+
+// The real grid renders through PaneTilingLayout (react-resizable-panels), which
+// needs ResizeObserver + measured sizes that jsdom lacks. Mock the tiling wrapper
+// so the test exercises the real renderGridSession/SessionSurface ownership logic
+// (isActive/visible derivation + onFocusSession pointer transfer) directly.
+vi.mock("./WorkGridView", () => ({
+  WorkGridView: ({
+    gridSet,
+    sessions,
+    renderSession,
+    onFocusSession,
+  }: {
+    gridSet: { sessionIds: string[] };
+    sessions: TerminalSessionSummary[];
+    renderSession: (session: TerminalSessionSummary) => ReactNamespace.ReactNode;
+    onFocusSession: (sessionId: string) => void;
+  }) => (
+    <div data-testid="work-grid-view">
+      {gridSet.sessionIds.map((id) => {
+        const session = sessions.find((s) => s.id === id);
+        if (!session) return null;
+        return (
+          <div key={id} data-testid="grid-tile" data-session-id={id} onMouseDown={() => onFocusSession(id)}>
+            {renderSession(session)}
+          </div>
+        );
+      })}
+    </div>
+  ),
+  SingleSessionGridDropZone: ({ children }: { children: ReactNamespace.ReactNode }) => <div>{children}</div>,
 }));
 
 const terminalPreviewMock = vi.fn();
@@ -1312,6 +1343,76 @@ describe("WorkViewArea", () => {
     terminal = within(view.container).getByTestId("terminal-view");
     expect(terminal.getAttribute("data-session-id")).toBe("session-2");
     expect(terminal.getAttribute("data-active")).toBe("true");
+  });
+
+  it("keeps exactly one active tile with every tile visible in a mixed grid, and transfers active ownership on focus", () => {
+    vi.mocked(isChatToolType).mockImplementation((toolType) => toolType === "codex-chat");
+    const chat = makeChatSession("chat-1");
+    const terminal = makeRunningSession("term-1", "pty-term-1");
+    const gridSets = [{ id: "grid-1", layoutId: "layout-grid-1", sessionIds: ["chat-1", "term-1"] }];
+    const lane: LaneSummary = {
+      id: "lane-1",
+      name: "Lane 1",
+      laneType: "worktree",
+      baseRef: "main",
+      branchRef: "lane-1",
+      worktreePath: "/tmp/lane-1",
+      parentLaneId: null,
+      childCount: 0,
+      stackDepth: 0,
+      parentStatus: null,
+      isEditProtected: false,
+      status: { dirty: false, ahead: 0, behind: 0, remoteBehind: 0, rebaseInProgress: false },
+      color: null,
+      icon: null,
+      tags: [],
+      createdAt: "2026-04-06T12:00:00.000Z",
+    };
+    const onSelectItem = vi.fn();
+    const renderTree = (activeItemId: string) => (
+      <WorkViewArea
+        lanes={[lane]}
+        sessions={[chat, terminal]}
+        visibleSessions={[chat, terminal]}
+        activeItemId={activeItemId}
+        gridSets={gridSets}
+        draftKind="chat"
+        onSelectItem={onSelectItem}
+        onCloseItem={() => {}}
+        onOpenChatSession={() => {}}
+        onLaunchPtySession={resolvePtyLaunch}
+        onShowDraftKind={() => {}}
+        closingPtyIds={new Set()}
+      />
+    );
+
+    const view = render(renderTree("chat-1"));
+
+    // Both tiles are visible; exactly the focused chat tile is active.
+    const chatPane = within(view.container).getByTestId("agent-chat-pane");
+    const term = within(view.container).getByTestId("terminal-view");
+    expect(chatPane.getAttribute("data-tile-visible")).toBe("true");
+    expect(term.getAttribute("data-visible")).toBe("true");
+    expect(chatPane.getAttribute("data-tile-active")).toBe("true");
+    expect(term.getAttribute("data-active")).toBe("false");
+    // Exactly one active member across all tiles.
+    const activeCount =
+      within(view.container).queryAllByTestId("agent-chat-pane").filter((el) => el.getAttribute("data-tile-active") === "true").length
+      + within(view.container).queryAllByTestId("terminal-view").filter((el) => el.getAttribute("data-active") === "true").length;
+    expect(activeCount).toBe(1);
+
+    // Pointer-down on the inactive terminal tile transfers activeItemId before any typing.
+    fireEvent.mouseDown(term);
+    expect(onSelectItem).toHaveBeenCalledWith("term-1");
+
+    // Focusing the terminal moves active ownership; both tiles remain visible.
+    view.rerender(renderTree("term-1"));
+    const chatPaneAfter = within(view.container).getByTestId("agent-chat-pane");
+    const termAfter = within(view.container).getByTestId("terminal-view");
+    expect(termAfter.getAttribute("data-active")).toBe("true");
+    expect(chatPaneAfter.getAttribute("data-tile-active")).toBe("false");
+    expect(termAfter.getAttribute("data-visible")).toBe("true");
+    expect(chatPaneAfter.getAttribute("data-tile-visible")).toBe("true");
   });
 
 });

--- a/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx
@@ -778,7 +778,12 @@ function SessionSurface({
 }) {
   const isChat = isChatToolType(session.toolType);
   const surfaceActive = pageActive && isActive;
-  const surfaceVisible = pageActive && (layoutVariant === "grid-tile" ? true : isActive);
+  // Visibility is decoupled from active ownership. `terminalVisible` means "keep
+  // this surface rendered and streaming" and defaults to `isActive`, so the
+  // single-session/tab callers that omit it are unchanged. The grid passes
+  // `terminalVisible` for every tile, so all tiles stay visible while only the
+  // focused one (session.id === activeItemId) is active.
+  const surfaceVisible = pageActive && terminalVisible;
   if (isChat) {
     return (
       <AgentChatPane
@@ -1079,7 +1084,11 @@ export function WorkViewArea({
     <SessionSurface
       session={session}
       lanes={lanes}
-      isActive
+      // Exactly the focused grid member is active; every displayed tile stays
+      // visible (terminalVisible) and keeps receiving live output. Only the
+      // active tile accepts keyboard input / autofocus; pointer-down on a tile
+      // transfers activeItemId (WorkGridView's onPaneMouseDown) before typing.
+      isActive={session.id === activeItemId}
       pageActive={pageActive}
       shouldAutofocus={session.id === activeItemId}
       terminalVisible


### PR DESCRIPTION
Renderer-only implementation of three confirmed findings from the desktop performance audit (2026-07-12). No shared/IPC/sync/CLI/TUI/iOS contract is touched.

## Findings

**`work-grid-all-active`** — Work grid tiles passed unconditional `isActive` to every `SessionSurface`, so every tile ran focused-only chat/terminal work (faster recovery, model/delta/computer-use effects, xterm refresh/focus/input) and contended for focus. Now only the focused member (`session.id === activeItemId`) is active. Every displayed tile stays **visible** and keeps streaming: `surfaceVisible` derives from `terminalVisible` (kept `true` for all grid tiles), and `TerminalView` gates host `inert`/`aria-hidden` on **visibility** (new `setRuntimeHostHidden`) rather than active — so a visible background terminal stays AT-readable and clickable while only the focused one accepts keyboard input. Pointer-down still transfers `activeItemId` before typing (verified in a real browser: a mousedown on an `inert` host bubbles to the pane).

**`composer-cross-transcript-rerender`** — `AgentChatMessageList` had no memo boundary and received fresh inline callback identities each keystroke, re-rendering the list and every mounted row on draft-only updates. It's now wrapped in `React.memo`, and every row-facing callback in `AgentChatPane` and `PersonalChatsPage` is stabilized (`useCallback`/`useMemo`) while still observing current session/turn/model/approval/lane state. No input/IME debounce; attachments, draft persistence, steering, retry/recovery, rewind, terminal reveal, model-picker, session switching, and failed-send restoration are preserved.

**`expired-claude-cache-badges-keep-one-second-timers`** — `ClaudeCacheTtlBadge` kept its 1s interval running forever after the countdown hit zero. It now publishes the final expired state, then clears the interval while mounted, and installs no interval when already expired. Ceil-based display and one-second resolution unchanged.

## Tests
- Mixed chat/terminal grid: exactly one active tile, all tiles visible, pointer-down transfers ownership, focus transfer moves the active owner.
- Badge fake-timers: self-clear at expiry, no interval when expired/no-idle, cleanup on unmount + prop change, and a 1/50/500-badge timer-count-returns-to-zero proof.
- Memo boundary: a draft-only update does not re-render the list body; an unstable row-facing callback does (guards the stabilization).

## Verification
- Typecheck + lint clean (no new warnings). 393 affected renderer tests pass (Node 22).
- `/quality` dual-review: 0 Blocker/High/Medium; applied the one overlap finding (dead `grid-tile` branch + comment) and a test precision fix.
- Docs/Mobile/CLI/TUI parity: none required (existing docs already describe the single-focus/active-vs-visible model; `validate-docs` PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reduces renderer work during chat typing and terminal grid interaction. The main changes are:

- Memoized the agent chat message list boundary.
- Stabilized chat row callbacks in agent and personal chat owners.
- Stopped expired Claude cache TTL badges from keeping interval timers alive.
- Split terminal visibility from active keyboard ownership in grid views.
- Added tests for memo behavior, TTL cleanup, and mixed grid ownership.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the code-execution proof and confirmed that 3 test files and 121 tests passed with exit code 0.
- Observed the Desktop Vite server reach a ready state and then be killed, as shown in the server log.
- Encountered a capture blocker where Playwright timed out navigating to the real Vite route after the server was killed, with earlier UI captures not counting as proof due to an empty DOM and connection failures.

<a href="https://app.greptile.com/trex/runs/14207115/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/chat/AgentChatMessageList.tsx | Wraps the transcript list in React.memo so unchanged transcript props can bail out during owner re-renders. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Memoizes chatHasMessages and stabilizes row-facing transcript callbacks without adding draft-state dependencies. |
| apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.tsx | Stabilizes approval and draft insertion callbacks passed into transcript and browser children. |
| apps/desktop/src/renderer/components/shared/ClaudeCacheTtlBadge.tsx | Skips timers for already-expired badges and clears active timers once the displayed TTL expires. |
| apps/desktop/src/renderer/components/terminals/TerminalView.tsx | Separates active input ownership from host hidden/inert state and hides hosts based on visibility. |
| apps/desktop/src/renderer/components/terminals/WorkViewArea.tsx | Keeps grid tiles visible while making only the focused tile active. |

<sub>Reviews (1): Last reviewed commit: ["perf(work): focused grid ownership, memo..."](https://github.com/arul28/ade/commit/709db1b9589476a8645ca0b60bcd37c8db9c92b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43751740)</sub>

<!-- /greptile_comment -->