### PR TITLE
mobile usage layout -> Primary

### DIFF
--- a/apps/ios/ADE/Views/Work/WorkUsageActivityCarousel.swift
+++ b/apps/ios/ADE/Views/Work/WorkUsageActivityCarousel.swift
@@ -237,17 +237,6 @@ struct WorkUsageActivityCarousel: View {
     return daily.contains { workUsageDayActivityScore($0) > 0 }
   }
 
-  private var footerChip: (system: String, label: String)? {
-    guard let summary else { return nil }
-    if range == .all, let totalTokens = summary.totalTokens, totalTokens > 0 {
-      return ("trophy.fill", "\(workUsageCompact(totalTokens)) lifetime tokens")
-    }
-    if let streak = summary.currentStreakDays, streak >= 3 {
-      return ("flame.fill", "\(streak)-day streak")
-    }
-    return nil
-  }
-
   var body: some View {
     VStack(spacing: 10) {
       header
@@ -294,32 +283,42 @@ struct WorkUsageActivityCarousel: View {
 
   private var header: some View {
     HStack(spacing: 8) {
-      tabRow
+      tabControl
       Spacer(minLength: 6)
       if tab != .limits { rangeControl }
     }
   }
 
-  private var tabRow: some View {
-    HStack(spacing: 2) {
+  /// A menu keeps the full chart switcher available without forcing five labels
+  /// to share a narrow phone-width header.
+  private var tabControl: some View {
+    Menu {
       ForEach(WorkUsageTab.allCases) { option in
-        Button(option.title) {
+        Button {
           withAnimation(reduceMotion ? nil : .snappy(duration: 0.18)) { tabRaw = option.rawValue }
+        } label: {
+          if tab == option {
+            Label(option.title, systemImage: "checkmark")
+          } else {
+            Text(option.title)
+          }
         }
-        .font(.caption.weight(tab == option ? .semibold : .medium))
-        .foregroundStyle(tab == option ? ADEColor.textPrimary : ADEColor.textMuted)
-        .padding(.horizontal, 8)
-        .frame(minHeight: 34)
-        .background(
-          tab == option ? ADEColor.recessedBackground.opacity(0.9) : .clear,
-          in: RoundedRectangle(cornerRadius: 6, style: .continuous)
-        )
-        .contentShape(Rectangle())
-        .buttonStyle(.plain)
-        .accessibilityLabel("\(option.title) chart")
-        .accessibilityAddTraits(tab == option ? .isSelected : [])
       }
+    } label: {
+      HStack(spacing: 5) {
+        Text(tab.title)
+          .lineLimit(1)
+        Image(systemName: "chevron.down")
+          .font(.system(size: 9, weight: .semibold))
+      }
+      .font(.caption.weight(.semibold))
+      .foregroundStyle(ADEColor.textPrimary)
+      .padding(.horizontal, 10)
+      .frame(minHeight: 32)
+      .background(ADEColor.recessedBackground.opacity(0.9), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+      .fixedSize(horizontal: true, vertical: false)
     }
+    .accessibilityLabel("Activity chart, \(tab.title)")
   }
 
   private var rangeControl: some View {
@@ -332,14 +331,16 @@ struct WorkUsageActivityCarousel: View {
     } label: {
       HStack(spacing: 4) {
         Text(range.title)
+          .lineLimit(1)
           .font(.caption.weight(.medium))
         Image(systemName: "chevron.down")
           .font(.system(size: 9, weight: .semibold))
       }
       .foregroundStyle(ADEColor.textSecondary)
-      .padding(.horizontal, 10)
-      .frame(minHeight: 34)
+      .padding(.horizontal, 9)
+      .frame(minHeight: 32)
       .background(ADEColor.recessedBackground.opacity(0.7), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+      .fixedSize(horizontal: true, vertical: false)
     }
     .accessibilityLabel("Time range, \(range.title)")
   }
@@ -398,18 +399,6 @@ struct WorkUsageActivityCarousel: View {
       .lineLimit(1)
 
       Spacer(minLength: 0)
-
-      if tab != .limits, let chip = footerChip {
-        Label(chip.label, systemImage: chip.system)
-          .labelStyle(.titleAndIcon)
-          .font(.caption2.weight(.medium))
-          .foregroundStyle(ADEColor.accent)
-          .padding(.horizontal, 8)
-          .padding(.vertical, 3)
-          .background(ADEColor.accent.opacity(0.14), in: Capsule(style: .continuous))
-          .overlay(Capsule(style: .continuous).stroke(ADEColor.accent.opacity(0.28), lineWidth: 0.6))
-          .accessibilityLabel(chip.label)
-      }
     }
     .overlay(alignment: .top) { Divider().opacity(0.12) }
     .padding(.top, 2)


### PR DESCRIPTION
<!-- ade:link v=1 type=pr repo=arul28/ADE branch=fix%2Fmobile-usage-layout num=803 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=fix%2Fmobile-usage-layout&amp;pr=803">fix/mobile-usage-layout branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=803">PR #803</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the iOS work usage activity carousel for a narrower mobile layout. The main changes are:

- Replaces the five-label tab row with a compact menu-based chart selector.
- Keeps the existing range menu while reducing header control height and padding.
- Removes the optional footer chip so the footer stays compact.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is localized to SwiftUI layout code and preserves the existing tab, range, chart loading, and quota paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The iOS layout validation log shows that command -v xcodebuild and command -v swift exited with status 127, indicating they were unavailable.
- As a result, the attempted iOS simulator build was blocked before execution.
- No fake UI mock or lookalike capture was created due to the blockage.
- An accompanying Swift source artifact is available to review the code context used in the validation workflow.

<a href="https://app.greptile.com/trex/runs/14275037/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Views/Work/WorkUsageActivityCarousel.swift | Replaces the inline tab row with a menu selector and tightens header/footer spacing for mobile layout. |

<sub>Reviews (1): Last reviewed commit: ["fix(ios): compact usage activity control..."](https://github.com/arul28/ade/commit/4afbf4a41ad72f0da6fc2453ec554fd0157cd70f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43891554)</sub>

<!-- /greptile_comment -->