### PR TITLE
feat(projects): gate the OS Open-repository dialog through the worktree check

### DIFF
--- a/apps/desktop/src/renderer/state/appStore.test.ts
+++ b/apps/desktop/src/renderer/state/appStore.test.ts
@@ -28,6 +28,10 @@ const mockLocalStorage = {
     keybindings: { get: vi.fn(async () => null) },
     project: {
       openRepo: vi.fn(async () => null),
+      // openRepo picks a folder, then runs the worktree gate. inspectPath is
+      // deliberately left unmocked here so the gate falls through (its catch)
+      // to a normal open — the gate itself is covered in appStore.worktreeGate.test.ts.
+      chooseDirectory: vi.fn(async () => "/p/picked"),
       listRecent: vi.fn(async () => []),
       switchToPath: vi.fn(async () => null),
       closeCurrent: vi.fn(async () => {}),
@@ -1374,11 +1378,14 @@ describe("appStore", () => {
     });
 
     it("tracks project opening progress and clears it when the user cancels", async () => {
-      let resolveOpen: (value: any) => void = () => {};
-      (window.ade.project.openRepo as any).mockImplementationOnce(
+      // openRepo shows the "opening" transition up front, then awaits the native
+      // folder picker. Cancelling the picker (chooseDirectory → null) must clear
+      // the transition without binding a project.
+      let resolvePick: (value: string | null) => void = () => {};
+      (window.ade.project.chooseDirectory as any).mockImplementationOnce(
         () =>
           new Promise((resolve) => {
-            resolveOpen = resolve;
+            resolvePick = resolve;
           }),
       );
 
@@ -1390,9 +1397,11 @@ describe("appStore", () => {
         }),
       );
 
-      resolveOpen(null);
-      await pending;
+      resolvePick(null);
+      const result = await pending;
 
+      expect(result).toBeNull();
+      expect(window.ade.project.openRepo).not.toHaveBeenCalled();
       expect(useAppStore.getState().projectTransition).toBeNull();
       expect(useAppStore.getState().projectTransitionError).toBeNull();
     });

--- a/apps/desktop/src/renderer/state/appStore.ts
+++ b/apps/desktop/src/renderer/state/appStore.ts
@@ -1696,6 +1696,32 @@ const createAppState: StateCreator<AppState> = (set, get) => {
     }));
   },
   openRepo: async () => {
+    // Pick the target folder first (native picker, no bind yet) so the worktree
+    // gate can run before we commit to opening — the OS "Open repository" dialog
+    // must behave like the in-app open flows. chooseDirectory uses the same
+    // showOpenDialog(["openDirectory"]) as the fused openRepo picker; passing the
+    // matching title keeps it visually identical.
+    const picked = await window.ade.project.chooseDirectory({ title: "Open repository" });
+    if (!picked) return null;
+
+    // Worktree gate (mirrors switchProjectToPath): if the picked folder is an
+    // external linked worktree whose owning repo resolves, surface the
+    // WorktreeOpenDialog instead of opening it as a standalone project, and defer
+    // the open until the user chooses. inspectPath resolves the worktree root
+    // even from a nested subfolder, and any failure falls through to a normal
+    // open so the gate can never break project opening.
+    if (!get().openProjectTabRoots.includes(picked)) {
+      try {
+        const inspection = await window.ade.project.inspectPath(picked);
+        if (inspection.kind === "linked-worktree" && inspection.parent !== null) {
+          set({ worktreeOpenPrompt: { inspection } });
+          return null;
+        }
+      } catch {
+        // Ignore — proceed with the normal open below.
+      }
+    }
+
     // Invalidate in-flight lane refreshes before the async open so stale
     // responses from the previous project are discarded immediately.
     ++laneRefreshVersion;
@@ -1709,7 +1735,7 @@ const createAppState: StateCreator<AppState> = (set, get) => {
       projectBinding: null,
     });
     try {
-      const project = await window.ade.project.openRepo();
+      const project = await window.ade.project.openRepo({ rootPath: picked });
       if (!project) {
         set({ projectTransition: null, lanesLoading: false });
         return null;

--- a/apps/desktop/src/renderer/state/appStore.ts
+++ b/apps/desktop/src/renderer/state/appStore.ts
@@ -1696,34 +1696,10 @@ const createAppState: StateCreator<AppState> = (set, get) => {
     }));
   },
   openRepo: async () => {
-    // Pick the target folder first (native picker, no bind yet) so the worktree
-    // gate can run before we commit to opening — the OS "Open repository" dialog
-    // must behave like the in-app open flows. chooseDirectory uses the same
-    // showOpenDialog(["openDirectory"]) as the fused openRepo picker; passing the
-    // matching title keeps it visually identical.
-    const picked = await window.ade.project.chooseDirectory({ title: "Open repository" });
-    if (!picked) return null;
-
-    // Worktree gate (mirrors switchProjectToPath): if the picked folder is an
-    // external linked worktree whose owning repo resolves, surface the
-    // WorktreeOpenDialog instead of opening it as a standalone project, and defer
-    // the open until the user chooses. inspectPath resolves the worktree root
-    // even from a nested subfolder, and any failure falls through to a normal
-    // open so the gate can never break project opening.
-    if (!get().openProjectTabRoots.includes(picked)) {
-      try {
-        const inspection = await window.ade.project.inspectPath(picked);
-        if (inspection.kind === "linked-worktree" && inspection.parent !== null) {
-          set({ worktreeOpenPrompt: { inspection } });
-          return null;
-        }
-      } catch {
-        // Ignore — proceed with the normal open below.
-      }
-    }
-
     // Invalidate in-flight lane refreshes before the async open so stale
-    // responses from the previous project are discarded immediately.
+    // responses from the previous project are discarded immediately. The
+    // "opening" transition is shown up front (it covers the native picker, as
+    // before) and cleared on any early exit below.
     ++laneRefreshVersion;
     set({
       projectTransition: {
@@ -1735,6 +1711,39 @@ const createAppState: StateCreator<AppState> = (set, get) => {
       projectBinding: null,
     });
     try {
+      // Pick the target folder first (native picker, no bind yet) so the
+      // worktree gate can run before we bind — the OS "Open repository" dialog
+      // must behave like the in-app open flows. chooseDirectory uses the same
+      // showOpenDialog(["openDirectory"]) as the fused openRepo picker; passing
+      // the matching title keeps it visually identical.
+      const picked = await window.ade.project.chooseDirectory({ title: "Open repository" });
+      if (!picked) {
+        set({ projectTransition: null, lanesLoading: false });
+        return null;
+      }
+
+      // Worktree gate (mirrors switchProjectToPath): if the picked folder is an
+      // external linked worktree whose owning repo resolves, surface the
+      // WorktreeOpenDialog instead of opening it as a standalone project, and
+      // defer the open until the user chooses. inspectPath resolves the worktree
+      // root even from a nested subfolder, and any failure falls through to a
+      // normal open so the gate can never break project opening.
+      if (!get().openProjectTabRoots.includes(picked)) {
+        try {
+          const inspection = await window.ade.project.inspectPath(picked);
+          if (inspection.kind === "linked-worktree" && inspection.parent !== null) {
+            set({
+              projectTransition: null,
+              lanesLoading: false,
+              worktreeOpenPrompt: { inspection },
+            });
+            return null;
+          }
+        } catch {
+          // Ignore — proceed with the normal open below.
+        }
+      }
+
       const project = await window.ade.project.openRepo({ rootPath: picked });
       if (!project) {
         set({ projectTransition: null, lanesLoading: false });

--- a/apps/desktop/src/renderer/state/appStore.worktreeGate.test.ts
+++ b/apps/desktop/src/renderer/state/appStore.worktreeGate.test.ts
@@ -7,6 +7,8 @@ import type { ProjectPathInspection } from "../../shared/types";
 // ---------------------------------------------------------------------------
 const inspectPath = vi.fn<[string], Promise<ProjectPathInspection>>();
 const switchToPath = vi.fn<[string], Promise<unknown>>();
+const chooseDirectory = vi.fn<[unknown], Promise<string | null>>();
+const openRepo = vi.fn<[unknown], Promise<unknown>>();
 
 (globalThis as any).window = globalThis.window ?? {};
 Object.assign((globalThis as any).window, {
@@ -19,7 +21,8 @@ Object.assign((globalThis as any).window, {
     ai: { getStatus: vi.fn(async () => null) },
     keybindings: { get: vi.fn(async () => null) },
     project: {
-      openRepo: vi.fn(async () => null),
+      openRepo,
+      chooseDirectory,
       listRecent: vi.fn(async () => []),
       switchToPath,
       inspectPath,
@@ -52,6 +55,9 @@ describe("appStore worktree open gate", () => {
   beforeEach(() => {
     inspectPath.mockReset();
     switchToPath.mockReset();
+    chooseDirectory.mockReset();
+    openRepo.mockReset();
+    openRepo.mockResolvedValue(null);
     switchToPath.mockImplementation(async (rootPath: string) => ({
       rootPath,
       displayName: "Project",
@@ -134,6 +140,48 @@ describe("appStore worktree open gate", () => {
 
     expect(switchToPath).toHaveBeenCalledWith("/repos/plain");
     expect(useAppStore.getState().worktreeOpenPrompt).toBeNull();
+  });
+
+  it("openRepo (OS dialog) surfaces the prompt for a picked worktree and does not bind", async () => {
+    chooseDirectory.mockResolvedValueOnce("/repos/app-feature");
+    inspectPath.mockResolvedValueOnce(linkedWorktree());
+
+    const result = await useAppStore.getState().openRepo();
+
+    expect(chooseDirectory).toHaveBeenCalledWith({ title: "Open repository" });
+    expect(inspectPath).toHaveBeenCalledWith("/repos/app-feature");
+    expect(openRepo).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+    expect(useAppStore.getState().worktreeOpenPrompt?.inspection.parent?.displayName).toBe("app");
+  });
+
+  it("openRepo binds a plain repo through the picked rootPath (no prompt)", async () => {
+    chooseDirectory.mockResolvedValueOnce("/repos/plain");
+    inspectPath.mockResolvedValueOnce({
+      inputPath: "/repos/plain",
+      worktreeRoot: "/repos/plain",
+      kind: "repo-root",
+      branchRef: "main",
+      parent: null,
+      standaloneState: null,
+    });
+    openRepo.mockResolvedValueOnce({ rootPath: "/repos/plain", displayName: "plain", baseRef: "main" });
+
+    const result = await useAppStore.getState().openRepo();
+
+    expect(openRepo).toHaveBeenCalledWith({ rootPath: "/repos/plain" });
+    expect(useAppStore.getState().worktreeOpenPrompt).toBeNull();
+    expect((result as { rootPath: string } | null)?.rootPath).toBe("/repos/plain");
+  });
+
+  it("openRepo returns null without inspecting when the picker is cancelled", async () => {
+    chooseDirectory.mockResolvedValueOnce(null);
+
+    const result = await useAppStore.getState().openRepo();
+
+    expect(result).toBeNull();
+    expect(inspectPath).not.toHaveBeenCalled();
+    expect(openRepo).not.toHaveBeenCalled();
   });
 
   it("dismissWorktreeOpenPrompt clears the prompt", () => {

--- a/docs/features/project-home/README.md
+++ b/docs/features/project-home/README.md
@@ -386,10 +386,14 @@ populated on `ProjectDetail`, `RecentProjectSummary`, and
 `ProjectBrowseEntry`; the welcome recents rows, palette browse rows, and
 `BrowsePreview` render it via `WorktreeBadge` ("worktree of X", compact
 label in browse rows), and badged local recents rows expose the merge
-affordance. Known v1 bypasses: the OS "Open repository" dialog and inbound
-deeplinks reach the main process's `switchProjectFromDialog` directly, and
-TopBar warm-tab switches pass `skipWorktreeGate`, so none of them show the
-prompt. Local project rows open via
+affordance. The OS "Open repository" dialog (TopBar/AppShell Relocate) is
+also gated: `appStore.openRepo` picks the folder with
+`window.ade.project.chooseDirectory` first, runs the same inspect step, and
+either surfaces the prompt or binds the picked path via
+`openRepo({ rootPath })` — so the native dialog behaves like the in-app
+flows. Remaining bypasses: inbound deeplinks reach the main process's
+`switchProjectFromDialog` directly, and warm-tab switches pass
+`skipWorktreeGate`, so neither shows the prompt. Local project rows open via
 `appStore.switchProjectToPath(path)` and the normal project open flow
 (`adeProjectService.openProject`). Connected remote rows open via
 `appStore.switchRemoteProject(targetId, projectId)`; disconnected remote


### PR DESCRIPTION
## Summary

Follow-up to #807. Closes the one remaining worktree-gate bypass that Codex flagged: the native **File → Open Repository** dialog (TopBar/AppShell **Relocate**).

That flow went through `appStore.openRepo` → `window.ade.project.openRepo()`, which popped the OS folder picker **and** bound the folder in a single main-process call — so the worktree gate that every in-app open flow runs never fired. Opening a linked worktree that way still created a duplicate standalone project with no interstitial.

### Change
`appStore.openRepo` now splits the fused pick+bind into two steps:
1. `window.ade.project.chooseDirectory({ title: "Open repository" })` — the identical native `showOpenDialog(["openDirectory"])` picker, returns a path without binding.
2. The same `inspectPath` gate `switchProjectToPath` uses — a linked worktree with a resolvable parent surfaces `WorktreeOpenDialog`; otherwise it binds the picked path via `openRepo({ rootPath })`.

`inspectPath` resolves the worktree root even from a nested subfolder, and any inspect failure falls through to a normal open, so the gate can never break project opening. Verified there is **no** main-process application-menu path to `projectOpenRepo` — the two renderer Relocate calls are the only entry points, so this fully covers the flagged bypass. Inbound deeplinks remain a documented bypass.

## Testing
- 3 new unit tests in `appStore.worktreeGate.test.ts` (picked-worktree → prompt + no bind; plain repo → binds via `{ rootPath }`; cancelled picker → null, no inspect). Full gate suite 10/10.
- Desktop typecheck clean; affected suites 35/35 (Node 22); lint clean.
- The native picker is byte-identical to the pre-existing one (same `showOpenDialog(["openDirectory"])` + title), so behavior for normal repos is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR routes the native Open Repository flow through the worktree gate.

- Splits folder picking from project binding in `appStore.openRepo`.
- Runs `inspectPath` before binding the picked folder.
- Shows the worktree prompt for linked worktrees with a parent repo.
- Adds tests for worktree, plain repo, and cancelled picker paths.
- Updates the project-home docs for the remaining bypasses.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the targeted appstore worktree gate test suite and verified the run exited with EXIT\_CODE: 0.
- Ran the adjacent affected suites for the appstore worktree gate and verified EXIT\_CODE: 0.
- Verified that no Electron or native OS picker automation was attempted; coverage comes from renderer state mocks and sandboxed Vitest tests.

<a href="https://app.greptile.com/trex/runs/14334473/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/state/appStore.ts | Changes `openRepo` to pick a folder, inspect it for linked-worktree handling, and bind the selected root explicitly. |
| apps/desktop/src/renderer/state/appStore.worktreeGate.test.ts | Adds coverage for the native dialog worktree prompt, normal repo binding, and picker cancellation. |
| apps/desktop/src/renderer/state/appStore.test.ts | Updates the open-progress cancellation test to use `chooseDirectory` and assert no project bind occurs. |
| docs/features/project-home/README.md | Documents that the OS Open Repository dialog is now gated and lists the remaining bypasses. |

<sub>Reviews (1): Last reviewed commit: ["fix(projects): keep openRepo transition ..."](https://github.com/arul28/ade/commit/17a89b2c5e58cd786bad4581d8446504350c829b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44018284)</sub>

<!-- /greptile_comment -->