### PR TITLE
docs: add v1.2.27 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.27] - 2026-07-14
+
+### Added
+
+- Added per-job scheduled-work management across Settings, Chat Info, ADE CLI/Code, and paired iOS Work chats.
+
+### Changed
+
+- Claude cron jobs, wakeups, and loops now retain their Claude Agent SDK session ownership across ADE persistence, with provider-confirmed cancellation for current owners and immediate quarantine during session rollover.
+- Scheduled-work reconciliation now refreshes active recurring ownership, retires fired one-shots, prunes terminal history, and migrates legacy provisional rows safely.
+
+### Fixed
+
+- Stale scheduled-work mirrors can no longer keep injecting prompts into a superseding chat after compaction or relaunch.
+- Legacy and orphaned jobs remain recoverable without allowing a busy or unavailable provider to block chat archive or deletion.
+- iOS preserves transcript-derived scheduled work when the managed snapshot is empty and uses authoritative managed state when available.
+
 ## [1.2.26] - 2026-07-14
 
 ### Added
@@ -773,7 +790,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.26...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.27...HEAD
+[1.2.27]: https://github.com/arul28/ADE/compare/v1.2.26...v1.2.27
 [1.2.26]: https://github.com/arul28/ADE/compare/v1.2.25...v1.2.26
 [1.2.25]: https://github.com/arul28/ADE/compare/v1.2.24...v1.2.25
 [1.2.24]: https://github.com/arul28/ADE/compare/v1.2.23...v1.2.24

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.26">
-  v1.2.26 - Durable browser sign-ins, broader Files editing, safer linked-worktree opening, and steadier chat and usage behavior across desktop and iOS.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.27">
+  v1.2.27 - Provider-owned Claude scheduled work, automatic stale-job quarantine, and per-job recovery across desktop, CLI, and iOS.
 </Card>

--- a/changelog/v1.2.27.mdx
+++ b/changelog/v1.2.27.mdx
@@ -1,0 +1,21 @@
+---
+title: "v1.2.27"
+description: "Release notes for ADE v1.2.27 - July 14, 2026"
+---
+
+v1.2.27 makes Claude scheduled work reliable across compaction, relaunch, and long-running chats. ADE now follows Claude Agent SDK ownership instead of letting stale mirrored jobs keep waking the wrong session.
+
+---
+
+## Desktop and CLI
+
+- **Scheduled work follows its Claude session.** Durable cron jobs, wakeups, and loops are bound to the Claude Agent SDK session that created them. Session rollover quarantines old work instead of silently rebinding it or continuing to inject prompts.
+- **Cancellation is provider-aware.** ADE asks the owning Claude session to delete current jobs and waits for provider confirmation where required. Legacy or unreachable work is paused immediately, and truly orphaned mirrors can still be cleared locally.
+- **Automatic cleanup is safer.** One-shot work is reconciled after it fires, recurring ownership is refreshed from Claude snapshots, inactive chats are quarantined, terminal history is pruned, and legacy provisional cron rows are removed during migration.
+- **Per-job recovery is available when needed.** Settings, Chat Info, `ade chat scheduled-work`, and ADE Code can list, pause, or cancel individual jobs. These controls are a recovery surface; normal scheduled work continues to operate without setup.
+- **Lifecycle actions always win.** A busy or unavailable provider can no longer prevent a user from archiving or deleting a chat.
+
+## iOS
+
+- Added scheduled-work status and individual cancellation to paired Work chats, including personal chats.
+- Kept transcript-derived schedule cards visible when the managed list is empty, while treating a non-empty managed snapshot as authoritative.

--- a/docs.json
+++ b/docs.json
@@ -179,6 +179,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.27",
               "changelog/v1.2.26",
               "changelog/v1.2.25",
               "changelog/v1.2.24",


### PR DESCRIPTION
## Summary
- add ADE v1.2.27 release notes for Claude scheduled-work ownership and recovery
- update changelog navigation and comparison links

## Validation
- node scripts/validate-docs.mjs
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the v1.2.27 release notes and points the changelog to them. The main changes are:

- New v1.2.27 entry in `CHANGELOG.md`.
- New `changelog/v1.2.27.mdx` release page.
- Updated latest-release card on the changelog index.
- Added the new release page to docs navigation.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the docs validator as part of contract validation and captured the results in the Docs validator log.
- Ran the Git whitespace diff check to ensure proper formatting and whitespace consistency, with results saved in the Git whitespace diff-check log.

<a href="https://app.greptile.com/trex/runs/14384164/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds the v1.2.27 changelog entry and advances the comparison links. |
| changelog/index.mdx | Updates the latest-release card to link to v1.2.27. |
| changelog/v1.2.27.mdx | Adds the standalone v1.2.27 release notes page. |
| docs.json | Adds the v1.2.27 page to the changelog sidebar. |

<sub>Reviews (1): Last reviewed commit: ["docs: add v1.2.27 release notes"](https://github.com/arul28/ade/commit/5c5c77cb7860b888da2e7a7925d3163b48e9880e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44122433)</sub>

<!-- /greptile_comment -->