### PR TITLE
feat(sync): account attestation auth branch + pairPeerViaAccount

### DIFF
--- a/apps/ade-cli/package-lock.json
+++ b/apps/ade-cli/package-lock.json
@@ -26,6 +26,7 @@
         "highlight.js": "^11.11.1",
         "ink": "^7.1.0",
         "ink-text-input": "^6.0.0",
+        "jose": "^6.2.3",
         "marked": "^18.0.3",
         "node-cron": "^3.0.3",
         "node-pty": "^1.1.0",

--- a/apps/ade-cli/package.json
+++ b/apps/ade-cli/package.json
@@ -42,6 +42,7 @@
     "highlight.js": "^11.11.1",
     "ink": "^7.1.0",
     "ink-text-input": "^6.0.0",
+    "jose": "^6.2.3",
     "marked": "^18.0.3",
     "node-cron": "^3.0.3",
     "node-pty": "^1.1.0",

--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -1539,6 +1539,7 @@ export async function createAdeRuntime(args: {
       usageTrackingService,
       productAnalyticsService,
       logger,
+      accountAuthService,
       projectId: resolvedArgs.syncRuntime.registryProjectId ?? projectId,
       runtimeProjectId: projectId,
       projectRoot,

--- a/apps/ade-cli/src/services/account/accountAttestationVerifier.test.ts
+++ b/apps/ade-cli/src/services/account/accountAttestationVerifier.test.ts
@@ -1,0 +1,240 @@
+import fs from "node:fs";
+import { generateKeyPairSync } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { exportJWK, generateKeyPair, SignJWT, type CryptoKey } from "jose";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { SyncPeerMetadata } from "../../../../desktop/src/shared/types";
+import { createSyncPairingStore } from "../sync/syncPairingStore";
+import { createSyncPinStore } from "../sync/syncPinStore";
+import { verifyClerkAccountAttestation } from "./accountAttestationVerifier";
+
+const ISSUER = "https://clerk.test";
+const OAUTH_CLIENT_ID = "client_ade";
+const OWNER_USER_ID = "user_owner";
+const tempPaths: string[] = [];
+let jwksServer: Server;
+let jwksUrl = "";
+let signingKey: CryptoKey;
+let badSigningKey: CryptoKey;
+
+beforeAll(async () => {
+  const primary = await generateKeyPair("RS256", { extractable: true });
+  const bad = await generateKeyPair("RS256", { extractable: true });
+  signingKey = primary.privateKey;
+  badSigningKey = bad.privateKey;
+  const publicJwk = await exportJWK(primary.publicKey);
+  const jwks = { keys: [{ ...publicJwk, alg: "RS256", kid: "test-key", use: "sig" }] };
+  jwksServer = createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify(jwks));
+  });
+  await new Promise<void>((resolve, reject) => {
+    jwksServer.once("error", reject);
+    jwksServer.listen(0, "127.0.0.1", resolve);
+  });
+  jwksUrl = `http://127.0.0.1:${(jwksServer.address() as AddressInfo).port}/jwks`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    jwksServer.close((error) => error ? reject(error) : resolve());
+  });
+});
+
+afterEach(() => {
+  for (const target of tempPaths.splice(0)) {
+    fs.rmSync(target, { recursive: true, force: true });
+  }
+});
+
+function config() {
+  return { issuer: ISSUER, jwksUrl, oauthClientId: OAUTH_CLIENT_ID };
+}
+
+async function mintToken(args: {
+  sub?: string | null;
+  issuer?: string;
+  audience?: string | string[];
+  azp?: string;
+  expired?: boolean;
+  omitExpiration?: boolean;
+  useBadKey?: boolean;
+} = {}): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  let token = new SignJWT(args.azp === undefined ? {} : { azp: args.azp })
+    .setProtectedHeader({ alg: "RS256", kid: "test-key" })
+    .setIssuer(args.issuer ?? ISSUER)
+    .setIssuedAt(now);
+  if (!args.omitExpiration) token = token.setExpirationTime(args.expired ? now - 60 : now + 600);
+  if (args.sub !== null) token = token.setSubject(args.sub ?? OWNER_USER_ID);
+  if (args.audience !== undefined) token = token.setAudience(args.audience);
+  return token.sign(args.useBadKey ? badSigningKey : signingKey);
+}
+
+describe("verifyClerkAccountAttestation", () => {
+  it("accepts an owner OAuth token whose audience or azp is the configured Clerk client", async () => {
+    const audienceToken = await mintToken({ audience: OAUTH_CLIENT_ID });
+    const azpToken = await mintToken({ audience: "clerk-api", azp: OAUTH_CLIENT_ID });
+
+    await expect(verifyClerkAccountAttestation({
+      token: audienceToken,
+      expectedUserId: OWNER_USER_ID,
+      config: config(),
+    })).resolves.toMatchObject({ userId: OWNER_USER_ID });
+    await expect(verifyClerkAccountAttestation({
+      token: azpToken,
+      expectedUserId: OWNER_USER_ID,
+      config: config(),
+    })).resolves.toMatchObject({ userId: OWNER_USER_ID });
+  });
+
+  it("accepts a native Clerk session token with no aud", async () => {
+    const token = await mintToken({ azp: "https://desktop.ade.dev" });
+
+    await expect(verifyClerkAccountAttestation({
+      token,
+      expectedUserId: OWNER_USER_ID,
+      config: config(),
+    })).resolves.toMatchObject({ userId: OWNER_USER_ID });
+  });
+
+  it("rejects alg:none and HS256 algorithm-confusion tokens", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const claims = {
+      iss: ISSUER,
+      sub: OWNER_USER_ID,
+      aud: OAUTH_CLIENT_ID,
+      iat: now,
+      exp: now + 600,
+    };
+    const noneToken = [
+      Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url"),
+      Buffer.from(JSON.stringify(claims)).toString("base64url"),
+      "",
+    ].join(".");
+    const hs256Token = await new SignJWT({})
+      .setProtectedHeader({ alg: "HS256", kid: "test-key" })
+      .setIssuer(ISSUER)
+      .setSubject(OWNER_USER_ID)
+      .setAudience(OAUTH_CLIENT_ID)
+      .setIssuedAt(now)
+      .setExpirationTime(now + 600)
+      .sign(new TextEncoder().encode("attacker-controlled-hmac-secret"));
+
+    for (const token of [noneToken, hs256Token]) {
+      await expect(verifyClerkAccountAttestation({
+        token,
+        expectedUserId: OWNER_USER_ID,
+        config: config(),
+      })).rejects.toBeInstanceOf(Error);
+    }
+  });
+
+  it.each([
+    ["different Clerk user", { sub: "user_attacker" }],
+    ["expired token", { expired: true }],
+    ["missing expiration", { omitExpiration: true }],
+    ["wrong issuer", { issuer: "https://wrong-issuer.test" }],
+    ["bad signature", { useBadKey: true }],
+    ["missing subject", { sub: null }],
+    ["unapproved audience", { audience: "different-client", azp: "different-client" }],
+  ] as const)("rejects %s", async (_label, tokenArgs) => {
+    const token = await mintToken(tokenArgs);
+
+    await expect(verifyClerkAccountAttestation({
+      token,
+      expectedUserId: OWNER_USER_ID,
+      config: config(),
+    })).rejects.toBeInstanceOf(Error);
+  });
+});
+
+describe("pairPeerViaAccount", () => {
+  const phonePeer: SyncPeerMetadata = {
+    deviceId: "account-phone",
+    deviceName: "Account phone",
+    platform: "iOS",
+    deviceType: "phone",
+    siteId: "account-phone-site",
+    dbVersion: 0,
+  };
+
+  function harness() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ade-account-pairing-"));
+    tempPaths.push(dir);
+    const pinStore = createSyncPinStore({ filePath: path.join(dir, "pin.json") });
+    const pairingFile = path.join(dir, "pairings.json");
+    return {
+      pairingFile,
+      pinStore,
+      store: createSyncPairingStore({ filePath: pairingFile, pinStore }),
+    };
+  }
+
+  function dpopPublicKey(): string {
+    const { publicKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+    const jwk = publicKey.export({ format: "jwk" }) as { x: string; y: string };
+    return Buffer.concat([
+      Buffer.from([4]),
+      Buffer.from(jwk.x, "base64url"),
+      Buffer.from(jwk.y, "base64url"),
+    ]).toString("base64");
+  }
+
+  it("rejects any caller that does not present the verifier's opaque result", () => {
+    const { store } = harness();
+
+    expect(() => store.pairPeerViaAccount(
+      phonePeer,
+      { userId: OWNER_USER_ID } as never,
+    )).toThrow(/not verified/i);
+  });
+
+  it("mints and authenticates the same record shape without a PIN, preserving DPoP and runtime grant gates", async () => {
+    const { store, pinStore } = harness();
+    const attestation = await verifyClerkAccountAttestation({
+      token: await mintToken({ audience: OAUTH_CLIENT_ID }),
+      expectedUserId: OWNER_USER_ID,
+      config: config(),
+    });
+    const publicKey = dpopPublicKey();
+    expect(pinStore.hasPin()).toBe(false);
+
+    const copiedGrant = store.issueRuntimeHostGrant();
+    const phonePairing = store.pairPeerViaAccount(phonePeer, attestation, {
+      dpopPublicKey: publicKey,
+      runtimeHostGrant: copiedGrant,
+    });
+    expect(phonePairing.secret).toMatch(/^[0-9a-f]{48}$/);
+    expect(store.authenticate(phonePairing.deviceId, phonePairing.secret)).toBe(true);
+    expect(store.getPairingRecord(phonePairing.deviceId)).toMatchObject({
+      dpopPublicKey: publicKey,
+      runtimeHostGranted: false,
+      peerDeviceType: "phone",
+      lastUsedAt: expect.any(String),
+    });
+    const rotatedPhonePairing = store.pairPeerViaAccount(phonePeer, attestation);
+    expect(rotatedPhonePairing.secret).not.toBe(phonePairing.secret);
+    expect(store.getPairingRecord(phonePairing.deviceId)?.dpopPublicKey).toBe(publicKey);
+
+    const desktopGrant = store.issueRuntimeHostGrant();
+    const desktopPairing = store.pairPeerViaAccount({
+      ...phonePeer,
+      deviceId: "account-desktop",
+      deviceName: "Account desktop",
+      platform: "macOS",
+      deviceType: "desktop",
+    }, attestation, {
+      dpopPublicKey: publicKey,
+      runtimeHostGrant: desktopGrant,
+    });
+    expect(store.getPairingRecord(desktopPairing.deviceId)).toMatchObject({
+      dpopPublicKey: publicKey,
+      runtimeHostGranted: true,
+      peerDeviceType: "desktop",
+    });
+  });
+});

--- a/apps/ade-cli/src/services/account/accountAttestationVerifier.ts
+++ b/apps/ade-cli/src/services/account/accountAttestationVerifier.ts
@@ -1,0 +1,75 @@
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
+import type { AccountAttestationConfig } from "./sharedAccountAuthService";
+
+const remoteJwksByUrl = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+const VERIFIED_ACCOUNT_ATTESTATION = Symbol("verified-account-attestation");
+
+export type VerifiedAccountAttestation = {
+  readonly userId: string;
+  readonly [VERIFIED_ACCOUNT_ATTESTATION]: true;
+};
+
+function getRemoteJwks(rawUrl: string): ReturnType<typeof createRemoteJWKSet> {
+  const url = new URL(rawUrl);
+  const cacheKey = url.toString();
+  const cached = remoteJwksByUrl.get(cacheKey);
+  if (cached) return cached;
+  const jwks = createRemoteJWKSet(url);
+  remoteJwksByUrl.set(cacheKey, jwks);
+  return jwks;
+}
+
+function audienceIncludes(audience: JWTPayload["aud"], expected: string): boolean {
+  return typeof audience === "string"
+    ? audience === expected
+    : Array.isArray(audience) && audience.includes(expected);
+}
+
+function isAllowedCallerToken(payload: JWTPayload, oauthClientId: string): boolean {
+  // Clerk native session tokens have no audience. Their azp can be absent,
+  // empty, or origin-based, so azp alone must not reject that token shape.
+  if (payload.aud === undefined) return true;
+
+  // Daemon OAuth access tokens must be bound to ADE's configured client,
+  // either directly through aud or through Clerk's authorized-party claim.
+  return audienceIncludes(payload.aud, oauthClientId) || payload.azp === oauthClientId;
+}
+
+export async function verifyClerkAccountAttestation(args: {
+  token: string;
+  expectedUserId: string;
+  config: AccountAttestationConfig;
+}): Promise<VerifiedAccountAttestation> {
+  const token = args.token.trim();
+  const expectedUserId = args.expectedUserId.trim();
+  const issuer = args.config.issuer.trim();
+  const jwksUrl = args.config.jwksUrl.trim();
+  const oauthClientId = args.config.oauthClientId.trim();
+  if (!token || !expectedUserId) throw new Error("Account attestation is missing required identity data");
+  if (!issuer || !jwksUrl || !oauthClientId) throw new Error("Clerk account attestation is not configured");
+
+  const { payload } = await jwtVerify(token, getRemoteJwks(jwksUrl), {
+    issuer,
+    algorithms: ["RS256"],
+    clockTolerance: 5,
+    requiredClaims: ["sub", "exp"],
+  });
+  const subject = typeof payload.sub === "string" ? payload.sub.trim() : "";
+  if (!subject) throw new Error("Account attestation subject is required");
+  if (subject !== expectedUserId) throw new Error("Account attestation subject does not match this machine owner");
+  if (!isAllowedCallerToken(payload, oauthClientId)) {
+    throw new Error("Account attestation audience is not allowed");
+  }
+  return Object.freeze({
+    userId: subject,
+    [VERIFIED_ACCOUNT_ATTESTATION]: true as const,
+  });
+}
+
+export function isVerifiedAccountAttestation(value: unknown): value is VerifiedAccountAttestation {
+  return Boolean(
+    value
+    && typeof value === "object"
+    && (value as Partial<VerifiedAccountAttestation>)[VERIFIED_ACCOUNT_ATTESTATION] === true,
+  );
+}

--- a/apps/ade-cli/src/services/account/sharedAccountAuthService.test.ts
+++ b/apps/ade-cli/src/services/account/sharedAccountAuthService.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createProjectSecretService } from "../../../../desktop/src/main/services/secrets/projectSecretService";
 import type { AccountAuthService } from "./accountAuthService";
 import {
+  getSharedAccountAttestationConfig,
   getSharedAccountAuthService,
   registerAccountConfigProjectRoot,
 } from "./sharedAccountAuthService";
@@ -92,5 +93,28 @@ describe("getSharedAccountAuthService resolves CLERK OAuth config as an atomic p
     const authorizeUrl = new URL(start.authorizeUrl);
     expect(authorizeUrl.origin).toBe("https://invoking.example.test");
     expect(authorizeUrl.searchParams.get("client_id")).toBe("invoking-client");
+  });
+});
+
+describe("getSharedAccountAttestationConfig", () => {
+  it("resolves issuer, JWKS URL, and OAuth client id from one winning project", () => {
+    const issuerRoot = makeProjectRoot({ CLERK_ISSUER: "https://issuer-a.example.test" });
+    const otherRoot = makeProjectRoot({
+      CLERK_JWKS_URL: "https://wrong-project.example.test/jwks",
+      CLERK_OAUTH_CLIENT_ID: "wrong-project-client",
+    });
+
+    expect(getSharedAccountAttestationConfig({
+      secretsDir: uniqueSecretsDir(),
+      projectRoots: () => [issuerRoot, otherRoot],
+      env: {
+        CLERK_JWKS_URL: "https://env.example.test/jwks",
+        CLERK_OAUTH_CLIENT_ID: "env-client",
+      } as NodeJS.ProcessEnv,
+    })).toEqual({
+      issuer: "https://issuer-a.example.test",
+      jwksUrl: "https://env.example.test/jwks",
+      oauthClientId: "env-client",
+    });
   });
 });

--- a/apps/ade-cli/src/services/account/sharedAccountAuthService.ts
+++ b/apps/ade-cli/src/services/account/sharedAccountAuthService.ts
@@ -8,6 +8,12 @@ import {
   type AccountOAuthConfig,
 } from "./accountAuthService";
 
+export type AccountAttestationConfig = {
+  issuer: string;
+  jwksUrl: string;
+  oauthClientId: string;
+};
+
 const sharedServices = new Map<string, AccountAuthService>();
 const configProjectRoots = new Map<string, Set<string>>();
 
@@ -77,6 +83,48 @@ function resolveOAuthConfig(args: {
     issuer: args.env.CLERK_ISSUER?.trim() || "",
     clientId: args.env.CLERK_OAUTH_CLIENT_ID?.trim() || "",
   };
+}
+
+function resolveAttestationConfig(args: {
+  env: NodeJS.ProcessEnv;
+  projectRoots: Iterable<string>;
+}): AccountAttestationConfig {
+  // Keep all Clerk verification settings on the same atomic-resolution path as
+  // account login. The first project that defines any CLERK_* value wins, with
+  // only missing values filled from the daemon environment; values from two
+  // different projects are never combined.
+  for (const projectRoot of args.projectRoots) {
+    const issuer = readProjectSecret(projectRoot, "CLERK_ISSUER");
+    const jwksUrl = readProjectSecret(projectRoot, "CLERK_JWKS_URL");
+    const oauthClientId = readProjectSecret(projectRoot, "CLERK_OAUTH_CLIENT_ID");
+    if (issuer || jwksUrl || oauthClientId) {
+      return {
+        issuer: issuer ?? args.env.CLERK_ISSUER?.trim() ?? "",
+        jwksUrl: jwksUrl ?? args.env.CLERK_JWKS_URL?.trim() ?? "",
+        oauthClientId: oauthClientId ?? args.env.CLERK_OAUTH_CLIENT_ID?.trim() ?? "",
+      };
+    }
+  }
+  return {
+    issuer: args.env.CLERK_ISSUER?.trim() || "",
+    jwksUrl: args.env.CLERK_JWKS_URL?.trim() || "",
+    oauthClientId: args.env.CLERK_OAUTH_CLIENT_ID?.trim() || "",
+  };
+}
+
+export function getSharedAccountAttestationConfig(args: {
+  secretsDir?: string;
+  projectRoots?: () => Iterable<string>;
+  env?: NodeJS.ProcessEnv;
+} = {}): AccountAttestationConfig {
+  const secretsDir = path.resolve(args.secretsDir ?? resolveMachineAdeLayout().secretsDir);
+  for (const projectRoot of args.projectRoots?.() ?? []) {
+    registerAccountConfigProjectRoot(projectRoot, secretsDir);
+  }
+  return resolveAttestationConfig({
+    env: args.env ?? process.env,
+    projectRoots: rootsFor(secretsDir),
+  });
 }
 
 export function getSharedAccountAuthService(args: {

--- a/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
+++ b/apps/ade-cli/src/services/sync/brainProjectActionsSyncHandler.ts
@@ -923,7 +923,11 @@ export function createBrainProjectActionsSyncHandler(
               }
               return false;
             }
-            if (!auth || !safeStringEquals(bootstrapToken, auth.token)) return true;
+            // Account hellos are authenticated only by the project sync host,
+            // which owns the account session/config dependencies. The fallback
+            // brain handler must reject them rather than treating them as a
+            // bootstrap-shaped hello.
+            if (!auth || auth.kind !== "bootstrap" || !safeStringEquals(bootstrapToken, auth.token)) return true;
             // DPoP-upgraded devices must not enter through the shared
             // bootstrap token — that would bypass the enclave key binding.
             if (pairingStore.getPairingRecord(hello.peer.deviceId)?.dpopPublicKey) return true;
@@ -958,7 +962,9 @@ export function createBrainProjectActionsSyncHandler(
             return;
           }
           peer.authenticated = true;
-          peer.authKind = auth?.kind ?? null;
+          peer.authKind = auth?.kind === "bootstrap" || auth?.kind === "paired"
+            ? auth.kind
+            : null;
           clearAuthTimeout();
           peer.metadata = hello.peer;
           peer.pairingRecord = auth?.kind === "paired" ? authenticatedPairingRecord : null;

--- a/apps/ade-cli/src/services/sync/sharedSyncListener.ts
+++ b/apps/ade-cli/src/services/sync/sharedSyncListener.ts
@@ -61,7 +61,7 @@ export type SyncPeerHandoffSnapshot = {
   remoteAddress: string | null;
   remotePort: number | null;
   metadata: SyncPeerMetadata | null;
-  authKind: "bootstrap" | "paired" | null;
+  authKind: "bootstrap" | "paired" | "account" | null;
   pairedDeviceId: string | null;
   connectedAt: string;
   /**

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -1,8 +1,12 @@
 import fs from "node:fs";
+import { createSign, generateKeyPairSync } from "node:crypto";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { WebSocket, WebSocketServer } from "ws";
-import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { exportJWK, generateKeyPair, SignJWT } from "jose";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentChatEventEnvelope,
   CrsqlChangeRow,
@@ -38,6 +42,7 @@ import { buildChangesetBatchPayload } from "./changesetPump";
 import { createSharedSyncListener } from "./sharedSyncListener";
 import { createSyncPairingStore, type SyncPairingRecord } from "./syncPairingStore";
 import { createSyncPinStore } from "./syncPinStore";
+import { buildSyncDpopChallenge, sha256Hex } from "./syncDpop";
 import { encodeSyncEnvelope, parseSyncEnvelope, SYNC_RUNTIME_ONLY_CAPABILITY, wsDataToText, type ParsedSyncEnvelope } from "./syncProtocol";
 import { EncryptedFileCredentialStore } from "../credentials/credentialStore";
 
@@ -1180,6 +1185,436 @@ function createHostArgs(projectRoot: string, projects: SyncMobileProjectSummary[
     },
   };
 }
+
+describe("sync host account authentication", () => {
+  const issuer = "https://sync-host-clerk.test";
+  const oauthClientId = "sync-host-client";
+  const ownerUserId = "user_sync_owner";
+  let jwksServer: Server;
+  let jwksUrl = "";
+  let signingKey: Awaited<ReturnType<typeof generateKeyPair>>["privateKey"];
+
+  beforeAll(async () => {
+    const keyPair = await generateKeyPair("RS256", { extractable: true });
+    signingKey = keyPair.privateKey;
+    const publicJwk = await exportJWK(keyPair.publicKey);
+    const jwks = { keys: [{ ...publicJwk, alg: "RS256", kid: "sync-host-test-key", use: "sig" }] };
+    jwksServer = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify(jwks));
+    });
+    await new Promise<void>((resolve, reject) => {
+      jwksServer.once("error", reject);
+      jwksServer.listen(0, "127.0.0.1", resolve);
+    });
+    jwksUrl = `http://127.0.0.1:${(jwksServer.address() as AddressInfo).port}/jwks`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      jwksServer.close((error) => error ? reject(error) : resolve());
+    });
+  });
+
+  async function mintAccountToken(sub = ownerUserId): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    return new SignJWT({})
+      .setProtectedHeader({ alg: "RS256", kid: "sync-host-test-key" })
+      .setIssuer(issuer)
+      .setSubject(sub)
+      .setAudience(oauthClientId)
+      .setIssuedAt(now)
+      .setExpirationTime(now + 600)
+      .sign(signingKey);
+  }
+
+  function makeDpopKeyPair() {
+    const { publicKey, privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+    const jwk = publicKey.export({ format: "jwk" }) as { x: string; y: string };
+    const publicKeyX963 = Buffer.concat([
+      Buffer.from([4]),
+      Buffer.from(jwk.x, "base64url"),
+      Buffer.from(jwk.y, "base64url"),
+    ]).toString("base64");
+    return { privateKey, publicKeyX963 };
+  }
+
+  function signAccountDpop(args: {
+    privateKey: ReturnType<typeof makeDpopKeyPair>["privateKey"];
+    publicKeyX963: string;
+    deviceId: string;
+    accountToken: string;
+    advertisedPublicKeyX963?: string;
+    signedDeviceId?: string;
+  }) {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const nonce = `account-${args.deviceId}-${Math.random()}`;
+    const challenge = buildSyncDpopChallenge({
+      deviceId: args.signedDeviceId ?? args.deviceId,
+      secretSha256Hex: sha256Hex(args.accountToken),
+      timestamp,
+      nonce,
+    });
+    return {
+      publicKey: args.advertisedPublicKeyX963 ?? args.publicKeyX963,
+      timestamp,
+      nonce,
+      signature: createSign("sha256")
+        .update(challenge, "utf8")
+        .sign(args.privateKey)
+        .toString("base64"),
+    };
+  }
+
+  function accountDependencies(signedIn = true) {
+    return {
+      accountAuthService: {
+        getStatus: () => ({
+          signedIn,
+          userId: signedIn ? ownerUserId : null,
+          email: null,
+          name: null,
+          expiresAt: null,
+        }),
+      },
+      getAccountAttestationConfig: () => ({
+        issuer,
+        jwksUrl,
+        oauthClientId,
+      }),
+    };
+  }
+
+  async function openAccountClient(port: number) {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    const tracked = trackClientEnvelopes(ws);
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", resolve);
+      ws.once("error", reject);
+    });
+    return { ws, ...tracked };
+  }
+
+  function sendAccountHello(args: {
+    ws: WebSocket;
+    peer: SyncPeerMetadata;
+    accountToken: string;
+    dpop?: ReturnType<typeof signAccountDpop> | null;
+    runtimeHostGrant?: string | null;
+  }): void {
+    args.ws.send(encodeSyncEnvelope({
+      type: "hello",
+      payload: {
+        peer: args.peer,
+        auth: {
+          kind: "account",
+          deviceId: args.peer.deviceId,
+          accountToken: args.accountToken,
+          dpop: args.dpop ?? null,
+          runtimeHostGrant: args.runtimeHostGrant ?? null,
+        },
+      },
+    }));
+  }
+
+  it("authenticates the owner with JWKS + DPoP, mints a record, and enables the grant-gated desktop runtime channel", async () => {
+    const { projectRoot, cleanup } = createTempProjectRoot();
+    const secretsDir = path.join(projectRoot, ".ade", "secrets");
+    const pinStore = createSyncPinStore({ filePath: path.join(secretsDir, "sync-pin.json") });
+    const pairingSecretsPath = path.join(secretsDir, "sync-paired-devices.json");
+    const pairingStore = createSyncPairingStore({ filePath: pairingSecretsPath, pinStore });
+    const runtimeHostGrant = pairingStore.issueRuntimeHostGrant();
+    const baseArgs = createHostArgs(projectRoot, []);
+    const host = createSyncHostService({
+      ...baseArgs,
+      ...accountDependencies(),
+      pinStore,
+      pairingSecretsPath,
+      discoveryEnabled: false,
+      deviceRegistryService: {
+        ...baseArgs.deviceRegistryService,
+        upsertPeerMetadata: vi.fn(),
+      },
+    } as unknown as Parameters<typeof createSyncHostService>[0]);
+    let client: Awaited<ReturnType<typeof openAccountClient>> | null = null;
+    try {
+      const port = await host.waitUntilListening();
+      client = await openAccountClient(port);
+      const peer = {
+        deviceId: "account-desktop-runtime",
+        deviceName: "Account desktop runtime",
+        platform: "macOS",
+        deviceType: "desktop",
+        siteId: "account-desktop-runtime-site",
+        dbVersion: 0,
+        capabilities: [SYNC_RUNTIME_ONLY_CAPABILITY],
+      } satisfies SyncPeerMetadata;
+      const accountToken = await mintAccountToken();
+      const dpopKey = makeDpopKeyPair();
+      sendAccountHello({
+        ws: client.ws,
+        peer,
+        accountToken,
+        dpop: signAccountDpop({
+          privateKey: dpopKey.privateKey,
+          publicKeyX963: dpopKey.publicKeyX963,
+          deviceId: peer.deviceId,
+          accountToken,
+        }),
+        runtimeHostGrant,
+      });
+
+      const hello = await waitForValue(
+        () => client?.envelopes.find((envelope) => envelope.type === "hello_ok"),
+        "account hello_ok",
+      );
+      expect(hello.payload).toMatchObject({
+        features: { rpcChannel: true, portForward: true },
+      });
+      expect(pinStore.hasPin()).toBe(false);
+      expect(pairingStore.getPairingRecord(peer.deviceId)).toMatchObject({
+        dpopPublicKey: dpopKey.publicKeyX963,
+        runtimeHostGranted: true,
+        peerDeviceType: "desktop",
+        lastUsedAt: expect.any(String),
+      });
+      expect(isRuntimeOnlySyncPeer({
+        authKind: "account",
+        pairingRecord: pairingStore.getPairingRecord(peer.deviceId),
+        metadata: peer,
+      })).toBe(true);
+    } finally {
+      client?.ws.close();
+      await host.dispose();
+      cleanup();
+    }
+  });
+
+  it("pins account re-authentication to an existing DPoP key and never silently re-keys the record", async () => {
+    const { projectRoot, cleanup } = createTempProjectRoot();
+    const secretsDir = path.join(projectRoot, ".ade", "secrets");
+    const pinStore = createSyncPinStore({ filePath: path.join(secretsDir, "sync-pin.json") });
+    const pairingSecretsPath = path.join(secretsDir, "sync-paired-devices.json");
+    const pairingStore = createSyncPairingStore({ filePath: pairingSecretsPath, pinStore });
+    const peer = {
+      deviceId: "existing-account-device",
+      deviceName: "Existing account device",
+      platform: "iOS",
+      deviceType: "phone",
+      siteId: "existing-account-device-site",
+      dbVersion: 0,
+    } satisfies SyncPeerMetadata;
+    const legitimateKey = makeDpopKeyPair();
+    const attackerKey = makeDpopKeyPair();
+    pinStore.setPin("428193");
+    pairingStore.pairPeer(peer, "428193", { dpopPublicKey: legitimateKey.publicKeyX963 });
+    const baseArgs = createHostArgs(projectRoot, []);
+    const host = createSyncHostService({
+      ...baseArgs,
+      ...accountDependencies(),
+      pinStore,
+      pairingSecretsPath,
+      discoveryEnabled: false,
+      deviceRegistryService: {
+        ...baseArgs.deviceRegistryService,
+        upsertPeerMetadata: vi.fn(),
+      },
+    } as unknown as Parameters<typeof createSyncHostService>[0]);
+    const clients: Array<Awaited<ReturnType<typeof openAccountClient>>> = [];
+    try {
+      const port = await host.waitUntilListening();
+      const accountToken = await mintAccountToken();
+      const attackerClient = await openAccountClient(port);
+      clients.push(attackerClient);
+      sendAccountHello({
+        ws: attackerClient.ws,
+        peer,
+        accountToken,
+        dpop: signAccountDpop({
+          privateKey: attackerKey.privateKey,
+          publicKeyX963: attackerKey.publicKeyX963,
+          deviceId: peer.deviceId,
+          accountToken,
+        }),
+      });
+      await waitForValue(
+        () => attackerClient.envelopes.find((envelope) => envelope.type === "hello_error"),
+        "stored-key account hijack rejection",
+      );
+      expect(pairingStore.getPairingRecord(peer.deviceId)?.dpopPublicKey).toBe(legitimateKey.publicKeyX963);
+
+      const legitimateClient = await openAccountClient(port);
+      clients.push(legitimateClient);
+      sendAccountHello({
+        ws: legitimateClient.ws,
+        peer,
+        accountToken,
+        dpop: signAccountDpop({
+          privateKey: legitimateKey.privateKey,
+          publicKeyX963: legitimateKey.publicKeyX963,
+          advertisedPublicKeyX963: attackerKey.publicKeyX963,
+          deviceId: peer.deviceId,
+          accountToken,
+        }),
+      });
+      await waitForValue(
+        () => legitimateClient.envelopes.find((envelope) => envelope.type === "hello_ok"),
+        "stored-key account hello_ok",
+      );
+      expect(pairingStore.getPairingRecord(peer.deviceId)?.dpopPublicKey).toBe(legitimateKey.publicKeyX963);
+    } finally {
+      for (const client of clients) client.ws.close();
+      await host.dispose();
+      cleanup();
+    }
+  });
+
+  it("rejects missing and device-mismatched DPoP proofs without minting pairing records", async () => {
+    const { projectRoot, cleanup } = createTempProjectRoot();
+    const secretsDir = path.join(projectRoot, ".ade", "secrets");
+    const pinStore = createSyncPinStore({ filePath: path.join(secretsDir, "sync-pin.json") });
+    const pairingSecretsPath = path.join(secretsDir, "sync-paired-devices.json");
+    const pairingStore = createSyncPairingStore({ filePath: pairingSecretsPath, pinStore });
+    const baseArgs = createHostArgs(projectRoot, []);
+    const host = createSyncHostService({
+      ...baseArgs,
+      ...accountDependencies(),
+      pinStore,
+      pairingSecretsPath,
+      discoveryEnabled: false,
+      deviceRegistryService: {
+        ...baseArgs.deviceRegistryService,
+        upsertPeerMetadata: vi.fn(),
+      },
+    } as unknown as Parameters<typeof createSyncHostService>[0]);
+    const clients: Array<Awaited<ReturnType<typeof openAccountClient>>> = [];
+    try {
+      const port = await host.waitUntilListening();
+      const accountToken = await mintAccountToken();
+      const missingPeer = {
+        deviceId: "account-missing-dpop",
+        deviceName: "Missing DPoP",
+        platform: "iOS",
+        deviceType: "phone",
+        siteId: "account-missing-dpop-site",
+        dbVersion: 0,
+      } satisfies SyncPeerMetadata;
+      const missing = await openAccountClient(port);
+      clients.push(missing);
+      sendAccountHello({ ws: missing.ws, peer: missingPeer, accountToken, dpop: null });
+      await waitForValue(
+        () => missing.envelopes.find((envelope) => envelope.type === "hello_error"),
+        "missing DPoP hello_error",
+      );
+
+      const invalidPeer = {
+        ...missingPeer,
+        deviceId: "account-invalid-dpop",
+        deviceName: "Invalid DPoP",
+        siteId: "account-invalid-dpop-site",
+      };
+      const invalid = await openAccountClient(port);
+      clients.push(invalid);
+      const dpopKey = makeDpopKeyPair();
+      sendAccountHello({
+        ws: invalid.ws,
+        peer: invalidPeer,
+        accountToken,
+        dpop: signAccountDpop({
+          privateKey: dpopKey.privateKey,
+          publicKeyX963: dpopKey.publicKeyX963,
+          deviceId: invalidPeer.deviceId,
+          accountToken,
+          signedDeviceId: "different-account-device",
+        }),
+      });
+      await waitForValue(
+        () => invalid.envelopes.find((envelope) => envelope.type === "hello_error"),
+        "invalid DPoP hello_error",
+      );
+
+      expect(pairingStore.getPairingRecord(missingPeer.deviceId)).toBeNull();
+      expect(pairingStore.getPairingRecord(invalidPeer.deviceId)).toBeNull();
+    } finally {
+      for (const client of clients) client.ws.close();
+      await host.dispose();
+      cleanup();
+    }
+  });
+
+  it("rejects account auth while signed out and leaves PIN pairing available", async () => {
+    const { projectRoot, cleanup } = createTempProjectRoot();
+    const secretsDir = path.join(projectRoot, ".ade", "secrets");
+    const pinStore = createSyncPinStore({ filePath: path.join(secretsDir, "sync-pin.json") });
+    const pairingSecretsPath = path.join(secretsDir, "sync-paired-devices.json");
+    pinStore.setPin("428193");
+    const baseArgs = createHostArgs(projectRoot, []);
+    const host = createSyncHostService({
+      ...baseArgs,
+      ...accountDependencies(false),
+      pinStore,
+      pairingSecretsPath,
+      discoveryEnabled: false,
+      deviceRegistryService: {
+        ...baseArgs.deviceRegistryService,
+        upsertPeerMetadata: vi.fn(),
+      },
+    } as unknown as Parameters<typeof createSyncHostService>[0]);
+    const clients: Array<Awaited<ReturnType<typeof openAccountClient>>> = [];
+    try {
+      const port = await host.waitUntilListening();
+      const peer = {
+        deviceId: "signed-out-account-peer",
+        deviceName: "Signed-out account peer",
+        platform: "iOS",
+        deviceType: "phone",
+        siteId: "signed-out-account-site",
+        dbVersion: 0,
+      } satisfies SyncPeerMetadata;
+      const accountToken = await mintAccountToken();
+      const dpopKey = makeDpopKeyPair();
+      const accountClient = await openAccountClient(port);
+      clients.push(accountClient);
+      sendAccountHello({
+        ws: accountClient.ws,
+        peer,
+        accountToken,
+        dpop: signAccountDpop({
+          privateKey: dpopKey.privateKey,
+          publicKeyX963: dpopKey.publicKeyX963,
+          deviceId: peer.deviceId,
+          accountToken,
+        }),
+      });
+      await waitForValue(
+        () => accountClient.envelopes.find((envelope) => envelope.type === "hello_error"),
+        "signed-out account hello_error",
+      );
+
+      const pinClient = await openAccountClient(port);
+      clients.push(pinClient);
+      pinClient.ws.send(encodeSyncEnvelope({
+        type: "pairing_request",
+        requestId: "pin-fallback",
+        payload: { code: "428193", peer },
+      }));
+      const pairingResult = await waitForValue(
+        () => pinClient.envelopes.find((envelope) =>
+          envelope.type === "pairing_result" && envelope.requestId === "pin-fallback"),
+        "PIN fallback pairing_result",
+      );
+      expect(pairingResult.payload).toMatchObject({
+        ok: true,
+        deviceId: peer.deviceId,
+        secret: expect.stringMatching(/^[0-9a-f]{48}$/),
+      });
+    } finally {
+      for (const client of clients) client.ws.close();
+      await host.dispose();
+      cleanup();
+    }
+  });
+});
 
 describe("paired runtime host authorization", () => {
   it("refuses rpc/fwd when a PIN-authorized project-host pairing request merely claims desktop", async () => {

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -84,6 +84,9 @@ import type {
 import { parseAgentChatTranscript } from "../../../../desktop/src/shared/chatTranscript";
 import type { Logger } from "../../../../desktop/src/main/services/logging/logger";
 import type { ProductAnalyticsService } from "../../../../desktop/src/main/services/analytics/productAnalyticsService";
+import type { AccountAuthService } from "../account/accountAuthService";
+import type { AccountAttestationConfig } from "../account/sharedAccountAuthService";
+import { verifyClerkAccountAttestation } from "../account/accountAttestationVerifier";
 import type { createAgentChatService } from "../../../../desktop/src/main/services/chat/agentChatService";
 import type { createAiIntegrationService } from "../../../../desktop/src/main/services/ai/aiIntegrationService";
 import type { createCtoStateService } from "../../../../desktop/src/main/services/cto/ctoStateService";
@@ -195,12 +198,18 @@ export function isRuntimeHostPairingRecord(
   return record?.runtimeHostGranted === true;
 }
 
+type SyncHostAuthKind = "bootstrap" | "paired" | "account" | null;
+
+function isRecordBackedSyncAuthKind(kind: SyncHostAuthKind): kind is "paired" | "account" {
+  return kind === "paired" || kind === "account";
+}
+
 export function isRuntimeOnlySyncPeer(args: {
-  authKind: "bootstrap" | "paired" | null;
+  authKind: SyncHostAuthKind;
   pairingRecord: SyncPairingRecord | null;
   metadata: SyncPeerMetadata | null;
 }): boolean {
-  return args.authKind === "paired"
+  return isRecordBackedSyncAuthKind(args.authKind)
     && isRuntimeHostPairingRecord(args.pairingRecord)
     && Array.isArray(args.metadata?.capabilities)
     && args.metadata.capabilities.includes(SYNC_RUNTIME_ONLY_CAPABILITY);
@@ -398,7 +407,7 @@ type PeerState = {
   metadata: SyncPeerMetadata | null;
   authenticated: boolean;
   authTimeout: ReturnType<typeof setTimeout> | null;
-  authKind: "bootstrap" | "paired" | null;
+  authKind: SyncHostAuthKind;
   pairedDeviceId: string | null;
   pairingRecord: SyncPairingRecord | null;
   connectedAt: string;
@@ -657,6 +666,8 @@ type SyncHostServiceArgs = {
   dispatchDeeplinkUrl?: (url: string) => Promise<{ ok: boolean; message?: string }>;
   computerUseArtifactBrokerService: ReturnType<typeof createComputerUseArtifactBrokerService>;
   pinStore: SyncPinStore;
+  accountAuthService?: Pick<AccountAuthService, "getStatus">;
+  getAccountAttestationConfig?: () => AccountAttestationConfig;
   runtimeNameStore?: SyncRuntimeNameStore;
   bootstrapTokenPath?: string;
   pairingSecretsPath?: string;
@@ -1034,6 +1045,13 @@ function parseHelloPayload(payload: unknown): SyncHelloPayload | null {
     if (!toOptionalString(normalizedAuth.token)) return null;
   } else if (normalizedAuth.kind === "paired") {
     if (!toOptionalString(normalizedAuth.deviceId) || !toOptionalString(normalizedAuth.secret)) return null;
+  } else if (normalizedAuth.kind === "account") {
+    if (!toOptionalString(normalizedAuth.deviceId) || !toOptionalString(normalizedAuth.accountToken)) return null;
+    if (
+      normalizedAuth.dpop != null
+      && (typeof normalizedAuth.dpop !== "object" || Array.isArray(normalizedAuth.dpop))
+    ) return null;
+    if (normalizedAuth.runtimeHostGrant != null && !toOptionalString(normalizedAuth.runtimeHostGrant)) return null;
   } else {
     return null;
   }
@@ -2272,10 +2290,10 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       ws.removeAllListeners("error");
       const peer = registerPeer(ws, sanitizeRemoteAddress(snapshot.remoteAddress), snapshot.remotePort);
       if (snapshot.metadata && snapshot.authKind) {
-        const pairingRecord = snapshot.authKind === "paired" && snapshot.pairedDeviceId
+        const pairingRecord = isRecordBackedSyncAuthKind(snapshot.authKind) && snapshot.pairedDeviceId
           ? pairingStore.getPairingRecord(snapshot.pairedDeviceId)
           : null;
-        if (snapshot.authKind === "paired" && !pairingRecord) {
+        if (isRecordBackedSyncAuthKind(snapshot.authKind) && !pairingRecord) {
           // Pairing is not valid for this host (revoked or different secrets
           // store) — fail closed and force a fresh authenticated reconnect.
           clearPeerAuthTimeout(peer);
@@ -3952,7 +3970,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
   }
 
   function isMobilePeer(peer: PeerState): boolean {
-    if (peer.authKind === "paired") {
+    if (isRecordBackedSyncAuthKind(peer.authKind)) {
       return isMobilePairingRecord(peer.pairingRecord);
     }
     return peer.metadata?.platform === "iOS" || peer.metadata?.deviceType === "phone";
@@ -4533,7 +4551,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       // Return semantics: `true` means authentication FAILED -> the caller below
       // sends a `hello_error` (auth_failed) and closes the socket (4003).
       // `false` means the device is authenticated.
-      const authFailed = (() => {
+      const authFailed = await (async () => {
         if (hello.auth?.kind === "bootstrap") {
           // The bootstrap token is a shared, plaintext, never-rotating secret.
           // Once the sync host is bound to the LAN (the new 0.0.0.0 default),
@@ -4602,6 +4620,61 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
           }
           return false;
         }
+        if (hello.auth?.kind === "account") {
+          const accountAuth = hello.auth;
+          if (accountAuth.deviceId !== hello.peer.deviceId) return true;
+          try {
+            const ownerStatus = args.accountAuthService?.getStatus();
+            const ownerUserId = ownerStatus?.signedIn ? ownerStatus.userId?.trim() || null : null;
+            if (!ownerUserId) {
+              args.logger.warn("sync_host.account_owner_missing", {
+                deviceId: accountAuth.deviceId,
+              });
+              return true;
+            }
+            const config = args.getAccountAttestationConfig?.();
+            if (!config) return true;
+            const attestation = await verifyClerkAccountAttestation({
+              token: accountAuth.accountToken,
+              expectedUserId: ownerUserId,
+              config,
+            });
+            const existingPairingRecord = pairingStore.getPairingRecord(accountAuth.deviceId);
+            // A known device is pinned to its existing key; only a genuinely new
+            // device id may TOFU-adopt the inline key. The account token is the
+            // challenge secret, binding that verified token to the device key.
+            const dpopFailure = evaluatePairedHelloDpop({
+              storedPublicKey: existingPairingRecord?.dpopPublicKey ?? null,
+              deviceId: accountAuth.deviceId,
+              secret: accountAuth.accountToken,
+              proof: accountAuth.dpop ?? null,
+              requireDpop: true,
+              nonceCache: dpopNonceCache,
+            });
+            if (dpopFailure) {
+              args.logger.warn("sync_host.account_dpop_rejected", {
+                deviceId: accountAuth.deviceId,
+                reason: dpopFailure,
+              });
+              return true;
+            }
+            const paired = pairingStore.pairPeerViaAccount(hello.peer, attestation, {
+              dpopPublicKey: existingPairingRecord ? null : accountAuth.dpop?.publicKey ?? null,
+              runtimeHostGrant: accountAuth.runtimeHostGrant ?? null,
+            });
+            if (!pairingStore.authenticate(paired.deviceId, paired.secret)) return true;
+            authenticatedPairingRecord = pairingStore.getPairingRecord(paired.deviceId);
+            return authenticatedPairingRecord == null;
+          } catch (error) {
+            args.logger.warn("sync_host.account_auth_rejected", {
+              deviceId: accountAuth.deviceId,
+              reason: typeof (error as { code?: unknown } | null)?.code === "string"
+                ? (error as { code: string }).code
+                : "verification_failed",
+            });
+            return true;
+          }
+        }
         return true;
       })();
       if (authFailed) {
@@ -4632,8 +4705,9 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       peer.metadata = hello.peer;
       const auth = hello.auth ?? { kind: "bootstrap", token: "" };
       peer.authKind = auth.kind;
-      peer.pairedDeviceId = auth.kind === "paired" ? auth.deviceId : null;
-      peer.pairingRecord = auth.kind === "paired" ? authenticatedPairingRecord : null;
+      const recordBackedAuth = auth.kind === "paired" || auth.kind === "account";
+      peer.pairedDeviceId = recordBackedAuth ? auth.deviceId : null;
+      peer.pairingRecord = recordBackedAuth ? authenticatedPairingRecord : null;
       // Prefer the client's cursor for THIS project DB. The legacy single
       // dbVersion is only meaningful when the client last synced this same
       // DB; after a hosted-project change it points into a different DB's
@@ -4677,7 +4751,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         // even after successful pairing (phones/browsers stay on the mobile
         // command allowlist).
         runtimeChannelEnabled:
-          auth.kind === "paired" && isRuntimeHostPairingRecord(authenticatedPairingRecord),
+          isRecordBackedSyncAuthKind(auth.kind) && isRuntimeHostPairingRecord(authenticatedPairingRecord),
       }), envelope.requestId);
       args.onStateChanged?.();
       await pumpChanges();
@@ -4690,11 +4764,11 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         peer.ws,
         envelope.type,
         envelope.payload,
-        peer.authKind === "paired",
+        isRecordBackedSyncAuthKind(peer.authKind),
         // Gate the runtime RPC channel + port-forward to desktop runtime-host
         // peers; paired phones/browsers get the channel closed with a clear
         // reason instead of reaching the full runtime action registry.
-        peer.authKind === "paired" && isRuntimeHostPairingRecord(peer.pairingRecord),
+        isRecordBackedSyncAuthKind(peer.authKind) && isRuntimeHostPairingRecord(peer.pairingRecord),
       );
       return;
     }
@@ -5334,7 +5408,11 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       pairingStore.revoke(deviceId);
       let revokedConnectedPeer = false;
       for (const peer of peers) {
-        if (!peer.authenticated || peer.authKind !== "paired" || peer.pairedDeviceId !== deviceId) continue;
+        if (
+          !peer.authenticated
+          || !isRecordBackedSyncAuthKind(peer.authKind)
+          || peer.pairedDeviceId !== deviceId
+        ) continue;
         revokedConnectedPeer = true;
         const presenceDeviceId = peer.metadata?.deviceId ?? peer.pairedDeviceId ?? deviceId;
         const presenceRemoved = removeAllPresenceForDevice(presenceDeviceId, "remote");

--- a/apps/ade-cli/src/services/sync/syncPairingStore.ts
+++ b/apps/ade-cli/src/services/sync/syncPairingStore.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import type { SyncPeerMetadata } from "../../../../desktop/src/shared/types";
 import { nowIso, safeJsonParse, writeTextAtomic } from "../../../../desktop/src/main/services/shared/utils";
+import {
+  isVerifiedAccountAttestation,
+  type VerifiedAccountAttestation,
+} from "../account/accountAttestationVerifier";
 import type { SyncPinStore } from "./syncPinStore";
 
 export type SyncPairingRecord = {
@@ -27,6 +31,11 @@ type RuntimeHostGrantFile = Record<string, { expiresAt: number }>;
 type SyncPairingStoreArgs = {
   filePath: string;
   pinStore: SyncPinStore;
+};
+
+type NewPairingRecordOptions = {
+  dpopPublicKey?: string | null;
+  runtimeHostGrant?: string | null;
 };
 
 function hashSecret(secret: string): string {
@@ -57,7 +66,7 @@ function safeHashEquals(expectedHash: string, actualHash: string): boolean {
   return timingSafeEqual(expected, actual);
 }
 
-function pairingError(code: "pin_not_set" | "invalid_pin", message: string): Error {
+function pairingError(code: "pin_not_set" | "invalid_pin" | "account_not_verified", message: string): Error {
   const err = new Error(message) as Error & { code?: string };
   err.code = code;
   return err;
@@ -115,6 +124,40 @@ export function createSyncPairingStore(args: SyncPairingStoreArgs) {
     return granted;
   };
 
+  const writeNewPairingRecord = (
+    peer: SyncPeerMetadata,
+    options?: NewPairingRecordOptions,
+  ): { deviceId: string; secret: string } => {
+    // The server grant is necessary but not sufficient: pairing/account links
+    // can be used by phone/browser/custom clients, which must never become full
+    // runtime hosts. Consume every presented grant to preserve its one-time
+    // semantics, then authorize only a peer that connected as a desktop.
+    const consumedRuntimeHostGrant = consumeRuntimeHostGrant(options?.runtimeHostGrant);
+    const runtimeHostGranted = consumedRuntimeHostGrant && peer.deviceType === "desktop";
+    const secret = randomBytes(24).toString("hex");
+    const records = readRecords();
+    const existing = records[peer.deviceId] ?? null;
+    const offeredDpopKey = options?.dpopPublicKey?.trim() || null;
+    const dpopPublicKey = offeredDpopKey && isValidDpopPublicKey(offeredDpopKey) ? offeredDpopKey : null;
+    records[peer.deviceId] = {
+      secretHash: hashSecret(secret),
+      createdAt: existing?.createdAt ?? nowIso(),
+      lastUsedAt: null,
+      peerName: peer.deviceName,
+      peerPlatform: peer.platform,
+      peerDeviceType: peer.deviceType,
+      runtimeHostGranted,
+      // A gated re-pair may introduce or rotate the key when its caller allows
+      // that. Omitting a key preserves the existing binding without downgrade.
+      dpopPublicKey: dpopPublicKey ?? existing?.dpopPublicKey ?? null,
+    };
+    writeRecords(records);
+    return {
+      deviceId: peer.deviceId,
+      secret,
+    };
+  };
+
   return {
     issueRuntimeHostGrant(ttlMs = 10 * 60_000): string {
       const token = randomBytes(32).toString("base64url");
@@ -130,44 +173,25 @@ export function createSyncPairingStore(args: SyncPairingStoreArgs) {
       return token;
     },
 
-    pairPeer(peer: SyncPeerMetadata, pin: string, options?: {
-      dpopPublicKey?: string | null;
-      runtimeHostGrant?: string | null;
-    }): { deviceId: string; secret: string } {
+    pairPeer(peer: SyncPeerMetadata, pin: string, options?: NewPairingRecordOptions): { deviceId: string; secret: string } {
       if (!args.pinStore.hasPin()) {
         throw pairingError("pin_not_set", "No pairing PIN is set on this computer.");
       }
       if (!args.pinStore.verifyPin(pin)) {
         throw pairingError("invalid_pin", "Incorrect pairing PIN.");
       }
-      // The server grant is necessary but not sufficient: pairing links can be
-      // copied into phone/browser/custom clients, which must never become full
-      // runtime hosts. Consume every presented grant to preserve its one-time
-      // semantics, then authorize only a peer that paired as a desktop.
-      const consumedRuntimeHostGrant = consumeRuntimeHostGrant(options?.runtimeHostGrant);
-      const runtimeHostGranted = consumedRuntimeHostGrant && peer.deviceType === "desktop";
-      const secret = randomBytes(24).toString("hex");
-      const records = readRecords();
-      const existing = records[peer.deviceId] ?? null;
-      const offeredDpopKey = options?.dpopPublicKey?.trim() || null;
-      const dpopPublicKey = offeredDpopKey && isValidDpopPublicKey(offeredDpopKey) ? offeredDpopKey : null;
-      records[peer.deviceId] = {
-        secretHash: hashSecret(secret),
-        createdAt: existing?.createdAt ?? nowIso(),
-        lastUsedAt: null,
-        peerName: peer.deviceName,
-        peerPlatform: peer.platform,
-        peerDeviceType: peer.deviceType,
-        runtimeHostGranted,
-        // Re-pairing (PIN gated) may rotate or introduce the device key; a
-        // re-pair without a key keeps the existing one rather than downgrading.
-        dpopPublicKey: dpopPublicKey ?? existing?.dpopPublicKey ?? null,
-      };
-      writeRecords(records);
-      return {
-        deviceId: peer.deviceId,
-        secret,
-      };
+      return writeNewPairingRecord(peer, options);
+    },
+
+    pairPeerViaAccount(
+      peer: SyncPeerMetadata,
+      attestation: VerifiedAccountAttestation,
+      options?: NewPairingRecordOptions,
+    ): { deviceId: string; secret: string } {
+      if (!isVerifiedAccountAttestation(attestation)) {
+        throw pairingError("account_not_verified", "Account attestation was not verified.");
+      }
+      return writeNewPairingRecord(peer, options);
     },
 
     /**

--- a/apps/ade-cli/src/services/sync/syncService.ts
+++ b/apps/ade-cli/src/services/sync/syncService.ts
@@ -75,12 +75,20 @@ import type { SharedSyncListener } from "./sharedSyncListener";
 import type { ModelPickerStore } from "../modelPickerStore";
 import type { createUsageTrackingService } from "../../../../desktop/src/main/services/usage/usageTrackingService";
 import type { ProductAnalyticsService } from "../../../../desktop/src/main/services/analytics/productAnalyticsService";
+import type { AccountAuthService } from "../account/accountAuthService";
+import {
+  getSharedAccountAttestationConfig,
+  getSharedAccountAuthService,
+  type AccountAttestationConfig,
+} from "../account/sharedAccountAuthService";
 
 type SyncServiceArgs = {
   db: AdeDb;
   usageTrackingService?: ReturnType<typeof createUsageTrackingService> | null;
   productAnalyticsService?: ProductAnalyticsService | null;
   logger: Logger;
+  accountAuthService?: Pick<AccountAuthService, "getStatus">;
+  getAccountAttestationConfig?: () => AccountAttestationConfig;
   projectId?: string | null;
   runtimeProjectId?: string | null;
   projectRoot: string;
@@ -711,6 +719,12 @@ export function createSyncService(args: SyncServiceArgs) {
       dispatchDeeplinkUrl: args.dispatchDeeplinkUrl,
       computerUseArtifactBrokerService: args.computerUseArtifactBrokerService,
       pinStore,
+      accountAuthService: args.accountAuthService ?? getSharedAccountAuthService({
+        projectRoots: () => [args.projectRoot],
+        logger: args.logger,
+      }),
+      getAccountAttestationConfig: args.getAccountAttestationConfig ?? (() =>
+        getSharedAccountAttestationConfig({ projectRoots: () => [args.projectRoot] })),
       runtimeNameStore,
       bootstrapTokenPath: tokenPath,
       pairingSecretsPath,

--- a/apps/desktop/src/shared/types/sync.ts
+++ b/apps/desktop/src/shared/types/sync.ts
@@ -499,7 +499,15 @@ export type SyncDpopProof = {
 
 export type SyncHelloAuth =
   | { kind: "bootstrap"; token: string }
-  | { kind: "paired"; deviceId: string; secret: string; dpop?: SyncDpopProof | null };
+  | { kind: "paired"; deviceId: string; secret: string; dpop?: SyncDpopProof | null }
+  | {
+      kind: "account";
+      deviceId: string;
+      accountToken: string;
+      dpop?: SyncDpopProof | null;
+      /** Existing one-time desktop runtime authorization; account auth does not replace it. */
+      runtimeHostGrant?: string | null;
+    };
 
 export type SyncHelloOkPayload = {
   peer: SyncPeerMetadata;


### PR DESCRIPTION
## Sync `auth.kind:"account"` + `pairPeerViaAccount`

A device signed into the same Clerk account connects to a machine's sync host **without a PIN**, by presenting a Clerk attestation verified server-side. PIN / bootstrap / paired auth all stay unchanged as fallbacks.

- **Server-side attestation** (`accountAttestationVerifier`): RS256-pinned JWKS, exact issuer, `exp` enforced, and **`sub === machine owner userId`** (owner read live from the local account session); **mandatory DPoP** binding the token + deviceId to the device key + nonce; audience allowlist (mirrors the directory Worker). Signed-out/ownerless machines reject account auth. Fail-closed on every check; the fallback brain handler rejects account hellos.
- **`pairPeerViaAccount`** = `pairPeer` with only the gate swapped (a Symbol-branded verified attestation instead of the PIN check); identical 24-byte secret + record via a shared `writeNewPairingRecord`. Account auth alone never grants the runtime channel (still needs the one-time desktop grant).

**Reviewed via a full `/quality` security pass** (correctness/security + maintainability tracks). Fixes applied from it:
- **Existing devices must prove their stored DPoP key** — a captured owner token can no longer silently re-key/hijack a known device (only a genuinely new deviceId TOFU-adopts, matching the paired path).
- Adversarial **`alg:none` + HS256 rejection** tests locking the RS256-only gate.
- DRY extraction of the shared pairing-record writer.

**Known limitation (documented, follow-up — NOT in this PR):** a genuinely *new* device can still be account-paired by an on-path attacker who captures a live owner token over plaintext-LAN `ws://` (TOFU first-pairing gated by a capturable token vs a PIN). Recommended: restrict new-device account pairing to the TLS relay transport, or register trusted device keys with Clerk.

**Tests:** 24 verifier/config/DPoP + 75 sync-host + 14 pairing-store + ade-cli/desktop typechecks green. PIN / bootstrap / paired / `syncDpop.ts` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Faccounts-sync-auth-4c9c6eac num=817 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Faccounts-sync-auth-4c9c6eac&amp;pr=817">ade/accounts-sync-auth-4c9c6eac branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=817">PR #817</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Clerk account attestation as a new sync authentication path. The main changes are:

- Account-authenticated sync hellos with RS256/JWKS Clerk token verification.
- Mandatory DPoP binding for account auth using the device ID, token hash, timestamp, and nonce.
- Account-based pairing records through `pairPeerViaAccount` while keeping PIN, bootstrap, and paired auth paths unchanged.
- Runtime-channel access still gated by the existing one-time desktop runtime grant.
- Shared account attestation config resolution and tests for verifier, DPoP, sync host, and pairing-store behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The account-auth path fails closed, verifies the local signed-in owner, checks Clerk JWT claims with RS256/JWKS, requires DPoP, and preserves existing DPoP bindings for known devices.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The account verifier tests were run with Vitest and completed successfully (exit code 0).
- The sync host tests were executed with Vitest and all 75 tests passed (exit code 0).
- A search for pairing-store tests found no syncPairingStore.test.ts file in the checkout, confirming the absence of tests for pairing-store interactions.
- CLI typecheck was performed and finished with exit code 0.
- Desktop typecheck was attempted but the process was killed with exit code 137.

<a href="https://app.greptile.com/trex/runs/14484915/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/services/sync/syncHostService.ts | Adds account-auth hello handling with owner session checks, Clerk attestation verification, mandatory DPoP, record-backed runtime gating, and revocation integration. |
| apps/ade-cli/src/services/account/accountAttestationVerifier.ts | Adds RS256/JWKS Clerk attestation verification with issuer, expiration, subject, and audience/azp checks. |
| apps/ade-cli/src/services/sync/syncPairingStore.ts | Extracts shared pairing-record writing and adds symbol-branded account-pairing entry point while preserving PIN behavior. |
| apps/ade-cli/src/services/sync/syncService.ts | Passes account auth dependencies and attestation config resolution into sync host startup. |
| apps/desktop/src/shared/types/sync.ts | Extends sync wire types with account hello auth fields and DPoP/runtime grant metadata. |
| apps/ade-cli/src/services/sync/syncHostService.test.ts | Adds sync-host integration tests for successful account auth, DPoP pinning, failure cases, and PIN fallback. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Device as Account device
participant Host as Sync host
participant Clerk as Clerk JWKS / token verifier
participant Store as Sync pairing store

Device->>Host: "hello auth.kind="account" + accountToken + DPoP + optional runtimeHostGrant"
Host->>Host: read local accountAuthService.getStatus()
alt no signed-in owner or owner userId
    Host-->>Device: hello_error auth_failed
else owner present
    Host->>Clerk: verify RS256 JWT via configured JWKS/issuer
    Clerk-->>Host: verified payload
    Host->>Host: "require sub == owner userId and allowed audience/azp"
    Host->>Host: verify DPoP over token hash + deviceId + nonce
    alt attestation or DPoP fails
        Host-->>Device: hello_error auth_failed
    else valid account proof
        Host->>Store: pairPeerViaAccount(peer, verifiedAttestation, options)
        Store-->>Host: new device secret + record
        Host->>Store: authenticate(new secret) and load record
        Host-->>Device: hello_ok with runtimeChannelEnabled only for granted desktop records
    end
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Device as Account device
participant Host as Sync host
participant Clerk as Clerk JWKS / token verifier
participant Store as Sync pairing store

Device->>Host: "hello auth.kind="account" + accountToken + DPoP + optional runtimeHostGrant"
Host->>Host: read local accountAuthService.getStatus()
alt no signed-in owner or owner userId
    Host-->>Device: hello_error auth_failed
else owner present
    Host->>Clerk: verify RS256 JWT via configured JWKS/issuer
    Clerk-->>Host: verified payload
    Host->>Host: "require sub == owner userId and allowed audience/azp"
    Host->>Host: verify DPoP over token hash + deviceId + nonce
    alt attestation or DPoP fails
        Host-->>Device: hello_error auth_failed
    else valid account proof
        Host->>Store: pairPeerViaAccount(peer, verifiedAttestation, options)
        Store-->>Host: new device secret + record
        Host->>Store: authenticate(new secret) and load record
        Host-->>Device: hello_ok with runtimeChannelEnabled only for granted desktop records
    end
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(sync): account attestation auth bra..."](https://github.com/arul28/ade/commit/80dc50dc110500d4a4864a1ca97ad232ea6d0d42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44339217)</sub>

<!-- /greptile_comment -->