### PR TITLE
fix(sync): require authenticated relay for account auth

### DIFF
--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -1524,6 +1524,8 @@ export async function createAdeRuntime(args: {
       getSyncPort: () => resolvedArgs.syncRuntime?.sharedSyncListener?.getPort() ?? null,
       getExpectedLoopbackNonce: () =>
         resolvedArgs.syncRuntime?.sharedSyncListener?.getExpectedLoopbackNonce() ?? null,
+      getRelayBridgeProof: () =>
+        resolvedArgs.syncRuntime?.sharedSyncListener?.getRelayBridgeProof() ?? null,
     }));
   // Only the runtime that actually hosts phone sync (owns the brain-level
   // shared listener) may register the relay tunnel. The relay DO keeps ONE

--- a/apps/ade-cli/src/services/sync/sharedSyncListener.ts
+++ b/apps/ade-cli/src/services/sync/sharedSyncListener.ts
@@ -1,4 +1,5 @@
 import http from "node:http";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import { WebSocketServer, WebSocket, type RawData } from "ws";
 import type { SyncPeerMetadata } from "../../../../desktop/src/shared/types";
 import { DEFAULT_SYNC_HOST_PORT } from "./syncProtocol";
@@ -31,6 +32,9 @@ export const SYNC_HOST_BIND_LOOPBACK_ONLY: boolean =
   || SYNC_HOST_BIND_HOST_NORMALIZED === "localhost";
 
 export const SYNC_HOST_MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
+export const SYNC_RELAY_BRIDGE_PROOF_HEADER = "x-ade-sync-relay-bridge";
+
+export type SyncTransportOrigin = "direct" | "relay-bridge";
 
 // How long an unowned socket may sit parked (between sync host services, or
 // before the first one attaches) before the listener gives up and closes it.
@@ -55,6 +59,7 @@ export type SharedSyncListenerConnection = {
   ws: WebSocket;
   remoteAddress: string | null;
   remotePort: number | null;
+  transportOrigin: SyncTransportOrigin;
 };
 
 export type SharedSyncListenerConnectionHandler = (connection: SharedSyncListenerConnection) => void;
@@ -70,6 +75,7 @@ export type SyncPeerHandoffSnapshot = {
   ws: WebSocket;
   remoteAddress: string | null;
   remotePort: number | null;
+  transportOrigin: SyncTransportOrigin;
   metadata: SyncPeerMetadata | null;
   authKind: "bootstrap" | "paired" | "account" | null;
   pairedDeviceId: string | null;
@@ -114,6 +120,8 @@ export type SharedSyncListener = {
   getPort(): number | null;
   isListening(): boolean;
   getExpectedLoopbackNonce(): string;
+  /** Private in-process credential attached only by the trusted relay tunnel client. */
+  getRelayBridgeProof(): string;
   getLoopbackValidationStatus(): SyncLoopbackValidationStatus;
   /** Force-check that loopback still reaches this exact listener instance. */
   revalidateLoopback(): Promise<void>;
@@ -197,6 +205,18 @@ function rawDataBytes(data: RawData): number {
   return Buffer.byteLength(String(data), "utf8");
 }
 
+function hasValidRelayBridgeProof(request: http.IncomingMessage, expectedProof: Buffer): boolean {
+  const rawProof = request.headers[SYNC_RELAY_BRIDGE_PROOF_HEADER];
+  const proof = Array.isArray(rawProof) ? rawProof[0] : rawProof;
+  if (typeof proof !== "string" || !/^[A-Za-z0-9_-]{43}$/.test(proof)) return false;
+  const decoded = Buffer.from(proof, "base64url");
+  if (decoded.length !== expectedProof.length) {
+    timingSafeEqual(expectedProof, Buffer.alloc(expectedProof.length));
+    return false;
+  }
+  return timingSafeEqual(expectedProof, decoded);
+}
+
 export function createSharedSyncListener(options: {
   logger?: SharedSyncListenerLogger;
   bindHost?: string;
@@ -213,6 +233,10 @@ export function createSharedSyncListener(options: {
   // instance emits the same nonce, and only in-process validators receive the
   // expected value they must compare against.
   const expectedLoopbackNonce = generateLoopbackNonce();
+  // Separate from the public 426-probe nonce: this credential is disclosed
+  // only to the in-process tunnel client and rotates with the listener process.
+  const relayBridgeProofBytes = randomBytes(32);
+  const relayBridgeProof = relayBridgeProofBytes.toString("base64url");
 
   let server: WebSocketServer | null = null;
   // The http.Server fronting `server`. `ws` does not own/close an
@@ -403,6 +427,9 @@ export function createSharedSyncListener(options: {
           ws,
           remoteAddress: request.socket.remoteAddress ?? null,
           remotePort: request.socket.remotePort ?? null,
+          transportOrigin: hasValidRelayBridgeProof(request, relayBridgeProofBytes)
+            ? "relay-bridge"
+            : "direct",
         };
         const fallbackSuppressed = fallbackSuppressedUntilMs > Date.now();
         const activeHandler = handler ?? (fallbackSuppressed ? null : fallbackHandler);
@@ -414,6 +441,7 @@ export function createSharedSyncListener(options: {
           ws,
           remoteAddress: connection.remoteAddress,
           remotePort: connection.remotePort,
+          transportOrigin: connection.transportOrigin,
           metadata: null,
           authKind: null,
           pairedDeviceId: null,
@@ -510,6 +538,10 @@ export function createSharedSyncListener(options: {
 
     getExpectedLoopbackNonce(): string {
       return expectedLoopbackNonce;
+    },
+
+    getRelayBridgeProof(): string {
+      return relayBridgeProof;
     },
 
     getLoopbackValidationStatus(): SyncLoopbackValidationStatus {

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -39,13 +39,14 @@ import {
 } from "./syncHostService";
 import { createBrainProjectActionsSyncHandler } from "./brainProjectActionsSyncHandler";
 import { buildChangesetBatchPayload } from "./changesetPump";
-import { createSharedSyncListener } from "./sharedSyncListener";
+import { createSharedSyncListener, SYNC_RELAY_BRIDGE_PROOF_HEADER } from "./sharedSyncListener";
 import type { SyncLoopbackProbeResult } from "./syncLoopbackProbe";
 import { createSyncPairingStore, type SyncPairingRecord } from "./syncPairingStore";
 import { createSyncPinStore } from "./syncPinStore";
 import { buildSyncDpopChallenge, sha256Hex } from "./syncDpop";
 import { encodeSyncEnvelope, parseSyncEnvelope, SYNC_RUNTIME_ONLY_CAPABILITY, wsDataToText, type ParsedSyncEnvelope } from "./syncProtocol";
 import { EncryptedFileCredentialStore } from "../credentials/credentialStore";
+import { verifyClerkAccountAttestation } from "../account/accountAttestationVerifier";
 
 // The sync host now binds to all interfaces (0.0.0.0) by default so phones on
 // the LAN can reach it. These tests assert the LOOPBACK-only posture (no LAN
@@ -648,6 +649,7 @@ describe("brain project actions fallback handler", () => {
       ws,
       remoteAddress: request.socket.remoteAddress ?? null,
       remotePort: request.socket.remotePort ?? null,
+      transportOrigin: "direct",
     }));
     let client: WebSocket | null = null;
     try {
@@ -772,6 +774,7 @@ describe("brain project actions fallback handler", () => {
         ws,
         remoteAddress: request.socket.remoteAddress ?? null,
         remotePort: request.socket.remotePort ?? null,
+        transportOrigin: "direct",
       });
     });
 
@@ -851,6 +854,7 @@ describe("brain project actions fallback handler", () => {
         ws,
         remoteAddress: request.socket.remoteAddress ?? null,
         remotePort: request.socket.remotePort ?? null,
+        transportOrigin: "direct",
       });
     });
     let client: WebSocket | null = null;
@@ -913,6 +917,7 @@ describe("brain project actions fallback handler", () => {
         ws,
         remoteAddress: request.socket.remoteAddress ?? null,
         remotePort: request.socket.remotePort ?? null,
+        transportOrigin: "direct",
       });
     });
 
@@ -1267,6 +1272,31 @@ describe("sync host account authentication", () => {
     };
   }
 
+  function signPairedDpop(args: {
+    privateKey: ReturnType<typeof makeDpopKeyPair>["privateKey"];
+    publicKeyX963: string;
+    deviceId: string;
+    secret: string;
+  }) {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const nonce = `paired-${args.deviceId}-${Math.random()}`;
+    const challenge = buildSyncDpopChallenge({
+      deviceId: args.deviceId,
+      secretSha256Hex: sha256Hex(args.secret),
+      timestamp,
+      nonce,
+    });
+    return {
+      publicKey: args.publicKeyX963,
+      timestamp,
+      nonce,
+      signature: createSign("sha256")
+        .update(challenge, "utf8")
+        .sign(args.privateKey)
+        .toString("base64"),
+    };
+  }
+
   function accountDependencies(signedIn = true) {
     return {
       accountAuthService: {
@@ -1286,8 +1316,10 @@ describe("sync host account authentication", () => {
     };
   }
 
-  async function openAccountClient(port: number) {
-    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  async function openAccountClient(port: number, relayBridgeProof?: string | null) {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`, relayBridgeProof
+      ? { headers: { [SYNC_RELAY_BRIDGE_PROOF_HEADER]: relayBridgeProof } }
+      : undefined);
     const tracked = trackClientEnvelopes(ws);
     await new Promise<void>((resolve, reject) => {
       ws.once("open", resolve);
@@ -1318,7 +1350,7 @@ describe("sync host account authentication", () => {
     }));
   }
 
-  it("authenticates the owner with JWKS + DPoP, mints a record, and enables the grant-gated desktop runtime channel", async () => {
+  it("adopts a new account device only from an authenticated relay socket parked across host handoff", async () => {
     const { projectRoot, cleanup } = createTempProjectRoot();
     const secretsDir = path.join(projectRoot, ".ade", "secrets");
     const pinStore = createSyncPinStore({ filePath: path.join(secretsDir, "sync-pin.json") });
@@ -1326,21 +1358,12 @@ describe("sync host account authentication", () => {
     const pairingStore = createSyncPairingStore({ filePath: pairingSecretsPath, pinStore });
     const runtimeHostGrant = pairingStore.issueRuntimeHostGrant();
     const baseArgs = createHostArgs(projectRoot, []);
-    const host = createSyncHostService({
-      ...baseArgs,
-      ...accountDependencies(),
-      pinStore,
-      pairingSecretsPath,
-      discoveryEnabled: false,
-      deviceRegistryService: {
-        ...baseArgs.deviceRegistryService,
-        upsertPeerMetadata: vi.fn(),
-      },
-    } as unknown as Parameters<typeof createSyncHostService>[0]);
+    const listener = createSharedSyncListener({ bindHost: "127.0.0.1" });
+    let host: ReturnType<typeof createSyncHostService> | null = null;
     let client: Awaited<ReturnType<typeof openAccountClient>> | null = null;
     try {
-      const port = await host.waitUntilListening();
-      client = await openAccountClient(port);
+      const port = await listener.ensureListening([0]);
+      client = await openAccountClient(port, listener.getRelayBridgeProof());
       const peer = {
         deviceId: "account-desktop-runtime",
         deviceName: "Account desktop runtime",
@@ -1364,6 +1387,22 @@ describe("sync host account authentication", () => {
         }),
         runtimeHostGrant,
       });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(client.envelopes).toEqual([]);
+
+      host = createSyncHostService({
+        ...baseArgs,
+        ...accountDependencies(),
+        pinStore,
+        pairingSecretsPath,
+        sharedListener: listener,
+        discoveryEnabled: false,
+        deviceRegistryService: {
+          ...baseArgs.deviceRegistryService,
+          upsertPeerMetadata: vi.fn(),
+        },
+      } as unknown as Parameters<typeof createSyncHostService>[0]);
+      expect(await host.waitUntilListening()).toBe(port);
 
       const hello = await waitForValue(
         () => client?.envelopes.find((envelope) => envelope.type === "hello_ok"),
@@ -1386,12 +1425,82 @@ describe("sync host account authentication", () => {
       })).toBe(true);
     } finally {
       client?.ws.close();
-      await host.dispose();
+      await host?.dispose();
+      await listener.close();
       cleanup();
     }
   });
 
-  it("pins account re-authentication to an existing DPoP key and never silently re-keys the record", async () => {
+  it("rejects missing, forged, and stale relay proofs for first-time account adoption", async () => {
+    const { projectRoot, cleanup } = createTempProjectRoot();
+    const secretsDir = path.join(projectRoot, ".ade", "secrets");
+    const pinStore = createSyncPinStore({ filePath: path.join(secretsDir, "sync-pin.json") });
+    const pairingSecretsPath = path.join(secretsDir, "sync-paired-devices.json");
+    const pairingStore = createSyncPairingStore({ filePath: pairingSecretsPath, pinStore });
+    const staleListener = createSharedSyncListener({ bindHost: "127.0.0.1" });
+    const staleProof = staleListener.getRelayBridgeProof();
+    await staleListener.close();
+    const listener = createSharedSyncListener({ bindHost: "127.0.0.1" });
+    const baseArgs = createHostArgs(projectRoot, []);
+    const host = createSyncHostService({
+      ...baseArgs,
+      ...accountDependencies(),
+      pinStore,
+      pairingSecretsPath,
+      sharedListener: listener,
+      discoveryEnabled: false,
+      deviceRegistryService: {
+        ...baseArgs.deviceRegistryService,
+        upsertPeerMetadata: vi.fn(),
+      },
+    } as unknown as Parameters<typeof createSyncHostService>[0]);
+    const clients: Array<Awaited<ReturnType<typeof openAccountClient>>> = [];
+    try {
+      const port = await host.waitUntilListening();
+      const accountToken = await mintAccountToken();
+      const rejectedProofs = [
+        ["missing", null],
+        ["forged-static", "c".repeat(43)],
+        ["stale-process", staleProof],
+      ] as const;
+      for (const [label, proof] of rejectedProofs) {
+        const peer = {
+          deviceId: `account-${label}-relay-proof`,
+          deviceName: `Account ${label} relay proof`,
+          platform: "iOS",
+          deviceType: "phone",
+          siteId: `account-${label}-relay-proof-site`,
+          dbVersion: 0,
+        } satisfies SyncPeerMetadata;
+        const dpopKey = makeDpopKeyPair();
+        const client = await openAccountClient(port, proof);
+        clients.push(client);
+        sendAccountHello({
+          ws: client.ws,
+          peer,
+          accountToken,
+          dpop: signAccountDpop({
+            privateKey: dpopKey.privateKey,
+            publicKeyX963: dpopKey.publicKeyX963,
+            deviceId: peer.deviceId,
+            accountToken,
+          }),
+        });
+        await waitForValue(
+          () => client.envelopes.find((envelope) => envelope.type === "hello_error"),
+          `${label} relay proof rejection`,
+        );
+        expect(pairingStore.getPairingRecord(peer.deviceId)).toBeNull();
+      }
+    } finally {
+      for (const client of clients) client.ws.close();
+      await host.dispose();
+      await listener.close();
+      cleanup();
+    }
+  });
+
+  it("rejects direct account auth for an existing device but accepts direct paired auth with its stored DPoP key", async () => {
     const { projectRoot, cleanup } = createTempProjectRoot();
     const secretsDir = path.join(projectRoot, ".ade", "secrets");
     const pinStore = createSyncPinStore({ filePath: path.join(secretsDir, "sync-pin.json") });
@@ -1407,14 +1516,23 @@ describe("sync host account authentication", () => {
     } satisfies SyncPeerMetadata;
     const legitimateKey = makeDpopKeyPair();
     const attackerKey = makeDpopKeyPair();
-    pinStore.setPin("428193");
-    pairingStore.pairPeer(peer, "428193", { dpopPublicKey: legitimateKey.publicKeyX963 });
+    const accountToken = await mintAccountToken();
+    const attestation = await verifyClerkAccountAttestation({
+      token: accountToken,
+      expectedUserId: ownerUserId,
+      config: { issuer, jwksUrl, oauthClientId },
+    });
+    const pairing = pairingStore.pairPeerViaAccount(peer, attestation, {
+      dpopPublicKey: legitimateKey.publicKeyX963,
+    });
     const baseArgs = createHostArgs(projectRoot, []);
+    const listener = createSharedSyncListener({ bindHost: "127.0.0.1" });
     const host = createSyncHostService({
       ...baseArgs,
       ...accountDependencies(),
       pinStore,
       pairingSecretsPath,
+      sharedListener: listener,
       discoveryEnabled: false,
       deviceRegistryService: {
         ...baseArgs.deviceRegistryService,
@@ -1424,11 +1542,29 @@ describe("sync host account authentication", () => {
     const clients: Array<Awaited<ReturnType<typeof openAccountClient>>> = [];
     try {
       const port = await host.waitUntilListening();
-      const accountToken = await mintAccountToken();
-      const attackerClient = await openAccountClient(port);
-      clients.push(attackerClient);
+      const directAccountClient = await openAccountClient(port);
+      clients.push(directAccountClient);
       sendAccountHello({
-        ws: attackerClient.ws,
+        ws: directAccountClient.ws,
+        peer,
+        accountToken,
+        dpop: signAccountDpop({
+          privateKey: legitimateKey.privateKey,
+          publicKeyX963: legitimateKey.publicKeyX963,
+          deviceId: peer.deviceId,
+          accountToken,
+        }),
+      });
+      await waitForValue(
+        () => directAccountClient.envelopes.find((envelope) => envelope.type === "hello_error"),
+        "direct stored-key account rejection",
+      );
+      expect(pairingStore.getPairingRecord(peer.deviceId)?.dpopPublicKey).toBe(legitimateKey.publicKeyX963);
+
+      const relayAttackerClient = await openAccountClient(port, listener.getRelayBridgeProof());
+      clients.push(relayAttackerClient);
+      sendAccountHello({
+        ws: relayAttackerClient.ws,
         peer,
         accountToken,
         dpop: signAccountDpop({
@@ -1439,15 +1575,15 @@ describe("sync host account authentication", () => {
         }),
       });
       await waitForValue(
-        () => attackerClient.envelopes.find((envelope) => envelope.type === "hello_error"),
-        "stored-key account hijack rejection",
+        () => relayAttackerClient.envelopes.find((envelope) => envelope.type === "hello_error"),
+        "relay stored-key account hijack rejection",
       );
       expect(pairingStore.getPairingRecord(peer.deviceId)?.dpopPublicKey).toBe(legitimateKey.publicKeyX963);
 
-      const legitimateClient = await openAccountClient(port);
-      clients.push(legitimateClient);
+      const relayAccountClient = await openAccountClient(port, listener.getRelayBridgeProof());
+      clients.push(relayAccountClient);
       sendAccountHello({
-        ws: legitimateClient.ws,
+        ws: relayAccountClient.ws,
         peer,
         accountToken,
         dpop: signAccountDpop({
@@ -1459,13 +1595,38 @@ describe("sync host account authentication", () => {
         }),
       });
       await waitForValue(
-        () => legitimateClient.envelopes.find((envelope) => envelope.type === "hello_ok"),
-        "stored-key account hello_ok",
+        () => relayAccountClient.envelopes.find((envelope) => envelope.type === "hello_ok"),
+        "relay stored-key account hello_ok",
       );
       expect(pairingStore.getPairingRecord(peer.deviceId)?.dpopPublicKey).toBe(legitimateKey.publicKeyX963);
+
+      const directPairedClient = await openAccountClient(port);
+      clients.push(directPairedClient);
+      directPairedClient.ws.send(encodeSyncEnvelope({
+        type: "hello",
+        payload: {
+          peer,
+          auth: {
+            kind: "paired",
+            deviceId: peer.deviceId,
+            secret: pairing.secret,
+            dpop: signPairedDpop({
+              privateKey: legitimateKey.privateKey,
+              publicKeyX963: legitimateKey.publicKeyX963,
+              deviceId: peer.deviceId,
+              secret: pairing.secret,
+            }),
+          },
+        },
+      }));
+      await waitForValue(
+        () => directPairedClient.envelopes.find((envelope) => envelope.type === "hello_ok"),
+        "direct account-minted paired hello_ok after relay re-auth",
+      );
     } finally {
       for (const client of clients) client.ws.close();
       await host.dispose();
+      await listener.close();
       cleanup();
     }
   });
@@ -1477,11 +1638,13 @@ describe("sync host account authentication", () => {
     const pairingSecretsPath = path.join(secretsDir, "sync-paired-devices.json");
     const pairingStore = createSyncPairingStore({ filePath: pairingSecretsPath, pinStore });
     const baseArgs = createHostArgs(projectRoot, []);
+    const listener = createSharedSyncListener({ bindHost: "127.0.0.1" });
     const host = createSyncHostService({
       ...baseArgs,
       ...accountDependencies(),
       pinStore,
       pairingSecretsPath,
+      sharedListener: listener,
       discoveryEnabled: false,
       deviceRegistryService: {
         ...baseArgs.deviceRegistryService,
@@ -1500,7 +1663,7 @@ describe("sync host account authentication", () => {
         siteId: "account-missing-dpop-site",
         dbVersion: 0,
       } satisfies SyncPeerMetadata;
-      const missing = await openAccountClient(port);
+      const missing = await openAccountClient(port, listener.getRelayBridgeProof());
       clients.push(missing);
       sendAccountHello({ ws: missing.ws, peer: missingPeer, accountToken, dpop: null });
       await waitForValue(
@@ -1514,7 +1677,7 @@ describe("sync host account authentication", () => {
         deviceName: "Invalid DPoP",
         siteId: "account-invalid-dpop-site",
       };
-      const invalid = await openAccountClient(port);
+      const invalid = await openAccountClient(port, listener.getRelayBridgeProof());
       clients.push(invalid);
       const dpopKey = makeDpopKeyPair();
       sendAccountHello({
@@ -1539,6 +1702,7 @@ describe("sync host account authentication", () => {
     } finally {
       for (const client of clients) client.ws.close();
       await host.dispose();
+      await listener.close();
       cleanup();
     }
   });
@@ -1550,11 +1714,13 @@ describe("sync host account authentication", () => {
     const pairingSecretsPath = path.join(secretsDir, "sync-paired-devices.json");
     pinStore.setPin("428193");
     const baseArgs = createHostArgs(projectRoot, []);
+    const listener = createSharedSyncListener({ bindHost: "127.0.0.1" });
     const host = createSyncHostService({
       ...baseArgs,
       ...accountDependencies(false),
       pinStore,
       pairingSecretsPath,
+      sharedListener: listener,
       discoveryEnabled: false,
       deviceRegistryService: {
         ...baseArgs.deviceRegistryService,
@@ -1574,7 +1740,7 @@ describe("sync host account authentication", () => {
       } satisfies SyncPeerMetadata;
       const accountToken = await mintAccountToken();
       const dpopKey = makeDpopKeyPair();
-      const accountClient = await openAccountClient(port);
+      const accountClient = await openAccountClient(port, listener.getRelayBridgeProof());
       clients.push(accountClient);
       sendAccountHello({
         ws: accountClient.ws,
@@ -1612,6 +1778,7 @@ describe("sync host account authentication", () => {
     } finally {
       for (const client of clients) client.ws.close();
       await host.dispose();
+      await listener.close();
       cleanup();
     }
   });

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -144,6 +144,7 @@ import {
   SYNC_HOST_MAX_PAYLOAD_BYTES,
   type SharedSyncListener,
   type SyncPeerHandoffSnapshot,
+  type SyncTransportOrigin,
 } from "./sharedSyncListener";
 import {
   assertAdeLoopbackListener,
@@ -430,6 +431,7 @@ type PeerState = {
   backpressuredSinceMs: number | null;
   remoteAddress: string | null;
   remotePort: number | null;
+  transportOrigin: SyncTransportOrigin;
   subscribedSessionIds: Set<string>;
   subscribedChatSessionIds: Set<string>;
   chatSubscriptionScopes: Map<string, ChatSubscriptionScope>;
@@ -2171,7 +2173,12 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     peer.authTimeout = null;
   }
 
-  function registerPeer(ws: WebSocket, remoteAddress: string | null, remotePort: number | null): PeerState {
+  function registerPeer(
+    ws: WebSocket,
+    remoteAddress: string | null,
+    remotePort: number | null,
+    transportOrigin: SyncTransportOrigin,
+  ): PeerState {
     const peer: PeerState = {
       ws,
       metadata: null,
@@ -2190,6 +2197,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       backpressuredSinceMs: null,
       remoteAddress,
       remotePort,
+      transportOrigin,
       subscribedSessionIds: new Set(),
       subscribedChatSessionIds: new Set(),
       chatSubscriptionScopes: new Map(),
@@ -2288,7 +2296,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
   }
 
   server?.on("connection", (ws, request) => {
-    registerPeer(ws, sanitizeRemoteAddress(request.socket.remoteAddress), request.socket.remotePort ?? null);
+    registerPeer(ws, sanitizeRemoteAddress(request.socket.remoteAddress), request.socket.remotePort ?? null, "direct");
   });
 
   /**
@@ -2325,7 +2333,12 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       ws.removeAllListeners("message");
       ws.removeAllListeners("close");
       ws.removeAllListeners("error");
-      const peer = registerPeer(ws, sanitizeRemoteAddress(snapshot.remoteAddress), snapshot.remotePort);
+      const peer = registerPeer(
+        ws,
+        sanitizeRemoteAddress(snapshot.remoteAddress),
+        snapshot.remotePort,
+        snapshot.transportOrigin ?? "direct",
+      );
       if (snapshot.metadata && snapshot.authKind) {
         const pairingRecord = isRecordBackedSyncAuthKind(snapshot.authKind) && snapshot.pairedDeviceId
           ? pairingStore.getPairingRecord(snapshot.pairedDeviceId)
@@ -2454,7 +2467,12 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
   let detachSharedListener: (() => void) | null = null;
   if (sharedListener) {
     detachSharedListener = sharedListener.setConnectionHandler((connection) => {
-      registerPeer(connection.ws, sanitizeRemoteAddress(connection.remoteAddress), connection.remotePort);
+      registerPeer(
+        connection.ws,
+        sanitizeRemoteAddress(connection.remoteAddress),
+        connection.remotePort,
+        connection.transportOrigin,
+      );
     });
     void adoptHandedOffPeers().catch((error) => {
       args.logger.warn("sync_host.peer_adoption_failed", {
@@ -4712,6 +4730,17 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         if (hello.auth?.kind === "account") {
           const accountAuth = hello.auth;
           if (accountAuth.deviceId !== hello.peer.deviceId) return true;
+          // Account bearer credentials must never traverse or authenticate a
+          // plaintext direct sync route. Existing devices reconnect directly
+          // with their stored paired secret + DPoP key instead.
+          if (peer.transportOrigin !== "relay-bridge") {
+            args.logger.warn("sync_host.account_auth_requires_relay", {
+              deviceId: accountAuth.deviceId,
+              transportOrigin: peer.transportOrigin,
+            });
+            return true;
+          }
+          const existingPairingRecord = pairingStore.getPairingRecord(accountAuth.deviceId);
           try {
             const ownerStatus = args.accountAuthService?.getStatus();
             const ownerUserId = ownerStatus?.signedIn ? ownerStatus.userId?.trim() || null : null;
@@ -4728,10 +4757,10 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
               expectedUserId: ownerUserId,
               config,
             });
-            const existingPairingRecord = pairingStore.getPairingRecord(accountAuth.deviceId);
             // A known device is pinned to its existing key; only a genuinely new
-            // device id may TOFU-adopt the inline key. The account token is the
-            // challenge secret, binding that verified token to the device key.
+            // device id arriving through the authenticated relay bridge may
+            // TOFU-adopt the inline key. The account token is the challenge
+            // secret, binding that verified token to the device key.
             const dpopFailure = evaluatePairedHelloDpop({
               storedPublicKey: existingPairingRecord?.dpopPublicKey ?? null,
               deviceId: accountAuth.deviceId,
@@ -4747,8 +4776,16 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
               });
               return true;
             }
+            if (existingPairingRecord) {
+              // Account re-auth confirms the owner and possession of the
+              // already-pinned device key. Preserve the paired secret that
+              // direct LAN/tailnet reconnects depend on; only first adoption
+              // is allowed to mint a new pairing record.
+              authenticatedPairingRecord = existingPairingRecord;
+              return false;
+            }
             const paired = pairingStore.pairPeerViaAccount(hello.peer, attestation, {
-              dpopPublicKey: existingPairingRecord ? null : accountAuth.dpop?.publicKey ?? null,
+              dpopPublicKey: accountAuth.dpop?.publicKey ?? null,
               runtimeHostGrant: accountAuth.runtimeHostGrant ?? null,
             });
             if (!pairingStore.authenticate(paired.deviceId, paired.secret)) return true;
@@ -5705,6 +5742,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
             ws: peer.ws,
             remoteAddress: peer.remoteAddress,
             remotePort: peer.remotePort,
+            transportOrigin: peer.transportOrigin,
             metadata: peer.metadata,
             authKind: peer.authKind,
             pairedDeviceId: peer.pairedDeviceId,

--- a/apps/ade-cli/src/services/sync/syncTunnelClientService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncTunnelClientService.test.ts
@@ -6,6 +6,7 @@ import {
   parseControlMessage,
 } from "./syncTunnelClientService";
 import type { SyncCloudRelayStore } from "./syncCloudRelayStore";
+import { createSharedSyncListener } from "./sharedSyncListener";
 
 // syncCloudRelayStore itself (enablement default/migration, identity mint, url
 // derivation, signature builders) is covered in syncCloudRelayStore.test.ts.
@@ -62,6 +63,7 @@ describe("createSyncTunnelClientService", () => {
   it("is a no-op and reports disabled when the store is disabled", async () => {
     const service = createSyncTunnelClientService({
       getSyncPort: () => 12345,
+      getRelayBridgeProof: () => null,
       configStore: fakeStore(false),
     });
     await service.start();
@@ -104,6 +106,7 @@ describe("createSyncTunnelClientService", () => {
     const service = createSyncTunnelClientService({
       getSyncPort: () => 8787,
       getExpectedLoopbackNonce: () => expectedNonce,
+      getRelayBridgeProof: () => "e".repeat(43),
       configStore: fakeStore(true, `http://127.0.0.1:${relayPort}`),
       loopbackProbe,
     });
@@ -125,6 +128,55 @@ describe("createSyncTunnelClientService", () => {
     } finally {
       await service.dispose();
       globalThis.fetch = originalFetch;
+      await new Promise<void>((resolve) => relay.close(() => resolve()));
+    }
+  });
+
+  it("authenticates the tunnel client's local socket as the trusted relay bridge", async () => {
+    const listener = createSharedSyncListener({ bindHost: "127.0.0.1" });
+    const localOrigins: string[] = [];
+    listener.setConnectionHandler((connection) => {
+      localOrigins.push(connection.transportOrigin);
+    });
+    const syncPort = await listener.ensureListening([0]);
+    const relay = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    await new Promise<void>((resolve, reject) => {
+      relay.once("listening", resolve);
+      relay.once("error", reject);
+    });
+    const address = relay.address();
+    const relayPort = typeof address === "object" && address ? address.port : 0;
+    const connections: string[] = [];
+    relay.on("connection", (socket, request) => {
+      connections.push(request.url ?? "");
+      if (connections.length === 1) {
+        socket.send(JSON.stringify({ t: "open", id: "abcdef01" }));
+      }
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response(null, { status: 204 });
+    const service = createSyncTunnelClientService({
+      getSyncPort: () => syncPort,
+      getExpectedLoopbackNonce: () => listener.getExpectedLoopbackNonce(),
+      getRelayBridgeProof: () => listener.getRelayBridgeProof(),
+      configStore: fakeStore(true, `http://127.0.0.1:${relayPort}`),
+    });
+
+    try {
+      await service.start();
+      await vi.waitFor(() => {
+        expect(connections).toHaveLength(2);
+        expect(localOrigins).toEqual(["relay-bridge"]);
+      });
+      expect(connections[1]).toContain(`/pipe/abcdef01`);
+      expect(service.getStatus()).toMatchObject({
+        connected: true,
+        relayBridgeValidated: true,
+      });
+    } finally {
+      await service.dispose();
+      globalThis.fetch = originalFetch;
+      await listener.close();
       await new Promise<void>((resolve) => relay.close(() => resolve()));
     }
   });

--- a/apps/ade-cli/src/services/sync/syncTunnelClientService.ts
+++ b/apps/ade-cli/src/services/sync/syncTunnelClientService.ts
@@ -12,6 +12,7 @@ import {
   probeAdeLoopbackListener,
   type SyncLoopbackProbeResult,
 } from "./syncLoopbackProbe";
+import { SYNC_RELAY_BRIDGE_PROOF_HEADER } from "./sharedSyncListener";
 
 type Logger = {
   info?: (event: string, data?: Record<string, unknown>) => void;
@@ -48,6 +49,8 @@ type SyncTunnelClientArgs = {
   getSyncPort: () => number | null;
   /** Expected identity of the active in-process sync listener. */
   getExpectedLoopbackNonce?: () => string | null;
+  /** Private proof accepted only by the active in-process sync listener. */
+  getRelayBridgeProof: () => string | null;
   configStore: SyncCloudRelayStore;
   /** Overrides the identity from configStore (e.g. a shared machine store). */
   machineIdentity?: () => MachineIdentity | null;
@@ -243,12 +246,22 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
       });
       return;
     }
+    const relayBridgeProof = args.getRelayBridgeProof();
+    if (!relayBridgeProof) {
+      validatedPort = null;
+      validatedLoopbackNonce = null;
+      recordFailure("Relay bridge refused because the local bridge credential is unavailable.");
+      log.warn?.("sync_tunnel.no_bridge_credential", { connectionId, port });
+      return;
+    }
     const ts = nowSeconds();
     const sig = signRelayHmacHex(id.secret, buildPipeSignatureBase(id.machineKey, connectionId, ts));
     const pipeUrl = `${httpToWsUrl(relayHttpUrl())}/host/${id.machineKey}/pipe/${connectionId}?ts=${ts}&sig=${sig}`;
 
     const pipe = new WebSocket(pipeUrl);
-    const local = new WebSocket(`ws://127.0.0.1:${String(port)}`);
+    const local = new WebSocket(`ws://127.0.0.1:${String(port)}`, {
+      headers: { [SYNC_RELAY_BRIDGE_PROOF_HEADER]: relayBridgeProof },
+    });
     armOpenDeadline(pipe, () => {
       recordFailure("relay pipe connect timed out");
     });

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -1022,6 +1022,22 @@ feature is merged or because a deliberately isolated-port host is running.
   active), so a paired hello cannot skip proof-of-possession by racing a
   connection during a host restart. Keys are not restorable from
   device backups — a restored phone re-pairs with the PIN.
+- **Account bearer transport**: every `hello.auth.kind = "account"` is
+  accepted only when the shared listener verified that the socket came from
+  ADE's in-process cloud-relay bridge. The tunnel client attaches a private,
+  per-process 256-bit proof to its loopback WebSocket upgrade; the listener
+  validates the decoded proof with a constant-time comparison and carries the
+  resulting `relay-bridge` provenance through parked-socket host handoffs.
+  Missing, forged, or stale proof fails closed as a direct connection. The
+  runtime rejects account auth on LAN, tailnet, loopback, and every other
+  direct route before verifying the bearer, even when that device already has
+  a pairing record. Existing devices use `auth.kind = "paired"` with their
+  durable per-device secret and pinned DPoP key on direct routes; PIN pairing
+  remains available on LAN. This guarantees ADE does not send or accept the
+  Clerk account bearer over plaintext direct sync. It does not sender-bind a
+  bearer stolen outside ADE: generic bearer replay through a TLS relay remains
+  possible until the account session/token is sender-constrained to a device
+  key or equivalent platform attestation.
 - **Pairing**: two independent paths. Machine-to-machine pairing uses
   the shared bootstrap token from the machine secrets directory.
   Phone pairing uses a **user-set 6-digit PIN** stored as a PBKDF2 hash in


### PR DESCRIPTION
## Security decision

Require server-derived relay provenance for every `hello.auth.kind = "account"` authentication, including already-paired devices. Direct LAN, tailnet, and loopback reconnects continue through the existing `paired` secret + pinned DPoP path; PIN/bootstrap pairing remains unchanged.

This closes the plaintext-LAN bearer-capture path where a live owner Clerk token could otherwise authorize an attacker-controlled device key.

## Implementation

- Mint a fresh 256-bit relay-bridge proof for each shared-listener process.
- Make the tunnel client's proof provider required at the type boundary.
- Attach the private proof only to the tunnel client's local WebSocket upgrade.
- Validate decoded proof material with constant-time comparison and record `direct` vs `relay-bridge` transport origin.
- Preserve provenance through parked-socket and host-handoff snapshots; absent or stale provenance fails closed as direct.
- Reject direct account auth before verifying the bearer or writing a pairing record.
- Keep existing-device DPoP pinning intact and prevent relay account re-authentication from rotating its stored pairing secret.
- Keep the private bridge proof separate from the public loopback 426-probe nonce and avoid credential-bearing logs.

## Regression coverage

- Relay-authenticated first account adoption succeeds across parked-socket host handoff.
- Missing, forged/static, and stale-process bridge proofs are rejected without adoption.
- Direct account auth is rejected even for an existing pairing.
- Existing relay account auth cannot re-key the stored DPoP key or rotate the paired secret.
- A secret minted by the real `pairPeerViaAccount` path is accepted by the existing direct `paired` + DPoP branch.
- Tunnel-client bridge validation, PIN fallback, loopback probe, collision, pairing, and attestation coverage remain green.

## Verification

- `npm --prefix apps/ade-cli run typecheck`
- Post-rebase: `npx vitest run src/services/sync/syncHostService.test.ts src/services/sync/syncTunnelClientService.test.ts` — 90 tests passed
- Targeted security slice — 112 tests passed
- Full ADE CLI suite — 1,808 tests passed
- Documentation validation — 191 files passed
- `/quality` — no remaining scoped Blocker, High, or Medium findings
- `/test` — passed

## Compatibility boundary

This PR intentionally does not add the `hello_ok.accountPairing` response, client persistence, or web/TUI direct reconnect API. The coordinated web/TUI parity PR owns that externally returned/persisted secret flow and will ship after this security gate.

## Residual risk

Relay provenance prevents ADE from accepting account bearer authentication over plaintext direct sync, but it does not sender-bind a bearer stolen outside ADE. Generic replay through the authenticated TLS relay remains possible until the account token/session is sender-constrained to a device key or equivalent platform attestation.

[Open in ADE](https://ade-app.dev/open?type=pr&repo=arul28%2FADE&number=823)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR limits account bearer sync authentication to the verified relay bridge path. The main changes are:

- Adds a per-process relay bridge proof to the shared sync listener.
- Marks shared-listener connections as `direct` or `relay-bridge` and carries that through handoff.
- Rejects `hello.auth.kind = "account"` on direct sync routes before bearer verification.
- Sends the bridge proof from the tunnel client when opening the local loopback socket.
- Updates tests and docs for relay-only account pairing and direct paired reconnects.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The relay-origin field is carried through direct, shared-listener, and handoff paths. Account bearer auth now fails closed on non-relay sockets. Tests cover new adoption, rejection, stale proof, re-auth, and direct paired reconnect behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the PR test suite and captured a main proof log that records the exact command, working directory, timestamps, Vitest output, and exit code.
- The run reported that apps/ade-cli/src/services/sync/syncTunnelClientService.test.ts executed with 8 tests in 128ms.
- A blocking failure was observed in syncHostService.test.ts due to a failure to load url chokidar in orchestrationService.ts, blocking test execution.
- The overall run ended with a FAIL status for the test suite as recorded by the main log.

<a href="https://app.greptile.com/trex/runs/14512872/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/bootstrap.ts | Wires the shared sync listener relay bridge proof into the singleton tunnel client factory. |
| apps/ade-cli/src/services/sync/sharedSyncListener.ts | Adds per-process relay bridge proof generation/validation and preserves transport origin across parked handoffs. |
| apps/ade-cli/src/services/sync/syncHostService.test.ts | Updates account-auth tests to require authenticated relay-origin sockets and preserve direct paired reconnect behavior. |
| apps/ade-cli/src/services/sync/syncHostService.ts | Tracks connection transport origin and rejects account bearer authentication unless it arrived through the verified relay bridge. |
| apps/ade-cli/src/services/sync/syncTunnelClientService.test.ts | Covers loopback validation failure and successful bridge-proof propagation from tunnel client to shared listener. |
| apps/ade-cli/src/services/sync/syncTunnelClientService.ts | Requires a local bridge proof before opening relay pipes and attaches it to loopback WebSocket upgrades. |
| docs/features/sync-and-multi-device/README.md | Documents the relay-only account bearer transport model and direct-route fallback to paired auth. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Phone as Account sync client
participant Relay as Cloud relay
participant Tunnel as ADE tunnel client
participant Listener as Shared sync listener
participant Host as Sync host service

Phone->>Relay: account hello via relay connection
Relay->>Tunnel: "control {open, connectionId}"
Tunnel->>Listener: loopback probe with expected nonce
Listener-->>Tunnel: ADE listener nonce validated
Tunnel->>Listener: WebSocket upgrade + x-ade-sync-relay-bridge proof
Listener->>Host: "connection transportOrigin=relay-bridge"
Host->>Host: verify account token + DPoP
Host-->>Phone: hello_ok / hello_error through tunnel

Phone->>Listener: direct LAN/loopback account hello
Listener->>Host: "connection transportOrigin=direct"
Host-->>Phone: hello_error before bearer verification
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Phone as Account sync client
participant Relay as Cloud relay
participant Tunnel as ADE tunnel client
participant Listener as Shared sync listener
participant Host as Sync host service

Phone->>Relay: account hello via relay connection
Relay->>Tunnel: "control {open, connectionId}"
Tunnel->>Listener: loopback probe with expected nonce
Listener-->>Tunnel: ADE listener nonce validated
Tunnel->>Listener: WebSocket upgrade + x-ade-sync-relay-bridge proof
Listener->>Host: "connection transportOrigin=relay-bridge"
Host->>Host: verify account token + DPoP
Host-->>Phone: hello_ok / hello_error through tunnel

Phone->>Listener: direct LAN/loopback account hello
Listener->>Host: "connection transportOrigin=direct"
Host-->>Phone: hello_error before bearer verification
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(sync): require relay provenance for ..."](https://github.com/arul28/ade/commit/8fa666d4e49a674bfa84881cdcfed1fdae2a4075) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44395248)</sub>

<!-- /greptile_comment -->