### PR TITLE
iOS: recover open chats across weak network transitions

### DIFF
--- a/apps/ios/ADE.xcodeproj/project.pbxproj
+++ b/apps/ios/ADE.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		1A0D93D06509796A389A4CAA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 31EC445F22FD38F90C16343E /* Foundation.framework */; };
 		26C8992F8D661707E9360503 /* Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51942BAC0965C7D0CCE6E8B8 /* Database.swift */; };
 		28CFE3D489EA1B208D231519 /* SyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66B5024B0A05F3D9754101F1 /* SyncService.swift */; };
+		B70000000000000000000002 /* SyncRecoveryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70000000000000000000001 /* SyncRecoveryPolicy.swift */; };
+		B70000000000000000000004 /* SyncRecoveryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70000000000000000000003 /* SyncRecoveryPolicyTests.swift */; };
 		A11700000000000000000002 /* MobileUsageQuotaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11700000000000000000001 /* MobileUsageQuotaStore.swift */; };
 		4DC17C7C8E82D387043B01FD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B17472FAC08845853BC6B4 /* ContentView.swift */; };
 		B2B52EED21B04E9700000002 /* RemoteProjectAddSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B52EED21B04E9700000001 /* RemoteProjectAddSheet.swift */; };
@@ -413,6 +415,8 @@
 		51942BAC0965C7D0CCE6E8B8 /* Database.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Database.swift; path = ADE/Services/Database.swift; sourceTree = "<group>"; };
 		5EE4D463D21266B62B422D11 /* PRsTabView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PRsTabView.swift; path = ADE/Views/PRsTabView.swift; sourceTree = "<group>"; };
 		66B5024B0A05F3D9754101F1 /* SyncService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyncService.swift; path = ADE/Services/SyncService.swift; sourceTree = "<group>"; };
+		B70000000000000000000001 /* SyncRecoveryPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyncRecoveryPolicy.swift; path = ADE/Services/SyncRecoveryPolicy.swift; sourceTree = "<group>"; };
+		B70000000000000000000003 /* SyncRecoveryPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SyncRecoveryPolicyTests.swift; path = ADETests/SyncRecoveryPolicyTests.swift; sourceTree = "<group>"; };
 		A11700000000000000000001 /* MobileUsageQuotaStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MobileUsageQuotaStore.swift; path = ADE/Services/MobileUsageQuotaStore.swift; sourceTree = "<group>"; };
 		73B17472FAC08845853BC6B4 /* ContentView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContentView.swift; path = ADE/App/ContentView.swift; sourceTree = "<group>"; };
 		B2B52EED21B04E9700000001 /* RemoteProjectAddSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RemoteProjectAddSheet.swift; path = ADE/App/RemoteProjectAddSheet.swift; sourceTree = "<group>"; };
@@ -820,6 +824,7 @@
 				B5D5B5B87564C73F2FF34B0D /* KeychainService.swift */,
 				A90000000000000000000011 /* ProductAnalytics.swift */,
 				66B5024B0A05F3D9754101F1 /* SyncService.swift */,
+				B70000000000000000000001 /* SyncRecoveryPolicy.swift */,
 				A11700000000000000000001 /* MobileUsageQuotaStore.swift */,
 				AE00000000000000000000A2 /* PushNotificationService.swift */,
 				AE00000000000000000000A3 /* LiveActivityService.swift */,
@@ -974,6 +979,7 @@
 			isa = PBXGroup;
 			children = (
 				14C0DF7FEB4C2EB854BAC888 /* ADETests.swift */,
+				B70000000000000000000003 /* SyncRecoveryPolicyTests.swift */,
 				AF00000000000000000000A4 /* PairingAndDpopTests.swift */,
 				AC1000000000000000000008 /* ClipPairingHandoffTests.swift */,
 				D30000000000000000000005 /* AttentionDrawerModelTests.swift */,
@@ -1276,6 +1282,7 @@
 				26C8992F8D661707E9360503 /* Database.swift in Sources */,
 				0375D32BA5870617FA1758C6 /* KeychainService.swift in Sources */,
 				28CFE3D489EA1B208D231519 /* SyncService.swift in Sources */,
+				B70000000000000000000002 /* SyncRecoveryPolicy.swift in Sources */,
 				A11700000000000000000002 /* MobileUsageQuotaStore.swift in Sources */,
 				6BDC22C6450AF0B3CBDB2650 /* FilesTabView.swift in Sources */,
 				E20000000000000000000042 /* FilesModels.swift in Sources */,
@@ -1445,6 +1452,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B70BE6839672E5D2D006B28 /* ADETests.swift in Sources */,
+				B70000000000000000000004 /* SyncRecoveryPolicyTests.swift in Sources */,
 				AF00000000000000000000C4 /* PairingAndDpopTests.swift in Sources */,
 				AC1100000000000000000008 /* ClipPairingHandoffTests.swift in Sources */,
 				D30000000000000000000015 /* AttentionDrawerModelTests.swift in Sources */,

--- a/apps/ios/ADE/Services/SyncRecoveryPolicy.swift
+++ b/apps/ios/ADE/Services/SyncRecoveryPolicy.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+func syncTransportProbeTimeoutNanoseconds(isExpensive: Bool, isConstrained: Bool) -> UInt64 {
+  if isConstrained {
+    return SyncSocketTiming.constrainedTransportProbeTimeoutNanoseconds
+  }
+  if isExpensive {
+    return SyncSocketTiming.expensiveTransportProbeTimeoutNanoseconds
+  }
+  return SyncSocketTiming.transportProbeTimeoutNanoseconds
+}
+
+func syncHeartbeatSilenceThresholdSeconds(
+  heartbeatIntervalNanoseconds: UInt64,
+  isExpensive: Bool,
+  isConstrained: Bool
+) -> TimeInterval {
+  let intervalSeconds = TimeInterval(heartbeatIntervalNanoseconds) / 1_000_000_000
+  if isConstrained {
+    return max(60, intervalSeconds * 4)
+  }
+  if isExpensive {
+    return max(45, intervalSeconds * 3)
+  }
+  return max(30, intervalSeconds * 2)
+}
+
+func syncShouldProbeTransportAfterHeartbeatSilence(
+  now: TimeInterval,
+  lastInboundMessageAt: TimeInterval?,
+  heartbeatIntervalNanoseconds: UInt64,
+  isExpensive: Bool,
+  isConstrained: Bool
+) -> Bool {
+  guard let lastInboundMessageAt else { return true }
+  return now - lastInboundMessageAt >= syncHeartbeatSilenceThresholdSeconds(
+    heartbeatIntervalNanoseconds: heartbeatIntervalNanoseconds,
+    isExpensive: isExpensive,
+    isConstrained: isConstrained
+  )
+}
+
+func syncJitteredReconnectDelayNanoseconds(base: UInt64, sample: Double) -> UInt64 {
+  let clampedSample = min(1, max(0, sample))
+  let factor = 0.8 + (0.4 * clampedSample)
+  return UInt64((Double(base) * factor).rounded())
+}
+
+enum SyncScheduledPathReconnectAction: Equatable {
+  case skip
+  case reconnect
+  case resetAndReconnect
+}
+
+func syncScheduledPathReconnectAction(
+  forceSocketReset: Bool,
+  scheduledConnectionGeneration: UInt64,
+  currentConnectionGeneration: UInt64,
+  hasLiveConnection: Bool
+) -> SyncScheduledPathReconnectAction {
+  if hasLiveConnection, scheduledConnectionGeneration != currentConnectionGeneration {
+    return .skip
+  }
+  if forceSocketReset, scheduledConnectionGeneration == currentConnectionGeneration {
+    return .resetAndReconnect
+  }
+  return .reconnect
+}
+
+enum SyncNetworkPathRecoveryAction: Equatable {
+  case scheduleForcedReset
+  case cancelScheduledReconnect
+  case scheduleReconnect
+  case none
+}
+
+func syncNetworkPathRecoveryAction(
+  shouldRoamToTailnet: Bool,
+  isPathSatisfied: Bool,
+  hasLiveConnection: Bool
+) -> SyncNetworkPathRecoveryAction {
+  if shouldRoamToTailnet { return .scheduleForcedReset }
+  guard isPathSatisfied else { return .none }
+  return hasLiveConnection ? .cancelScheduledReconnect : .scheduleReconnect
+}
+
+enum SyncRequestTimeoutRecoveryAction: Equatable {
+  case failRequestOnly
+  case probeTransport
+}
+
+func syncRequestTimeoutRecoveryAction(
+  disconnectOnTimeout: Bool,
+  now: TimeInterval,
+  lastInboundMessageAt: TimeInterval?,
+  silenceThreshold: TimeInterval = SyncSocketTiming.requestTimeoutReconnectSilenceSeconds
+) -> SyncRequestTimeoutRecoveryAction {
+  guard disconnectOnTimeout,
+        syncShouldReconnectAfterRequestTimeout(
+          now: now,
+          lastInboundMessageAt: lastInboundMessageAt,
+          silenceThreshold: silenceThreshold
+        ) else {
+    return .failRequestOnly
+  }
+  return .probeTransport
+}
+
+enum SyncSocketCompletionAction: Equatable {
+  case ignore
+  case failOpening
+  case failHandshake
+  case recoverTransport(closeCodeRawValue: Int?)
+}
+
+func syncSocketCompletionAction(
+  isCurrentSocket: Bool,
+  completedWhileOpening: Bool,
+  canSendLiveRequests: Bool,
+  closeCodeRawValue: Int?
+) -> SyncSocketCompletionAction {
+  guard isCurrentSocket else { return .ignore }
+  if completedWhileOpening { return .failOpening }
+  return canSendLiveRequests
+    ? .recoverTransport(closeCodeRawValue: closeCodeRawValue)
+    : .failHandshake
+}

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -177,7 +177,16 @@ func isSyncRequestTimeoutError(_ error: Error) -> Bool {
   return nsError.domain == "ADE" && nsError.code == 23
 }
 
-func syncShouldQueueCommandAfterSendFailure(error: Error, canSendLiveRequests: Bool, queueable: Bool) -> Bool {
+enum SyncAttemptedLiveFailurePolicy: Equatable {
+  case enqueueSafely
+  case preserveForManualRetry
+}
+
+func syncShouldQueueCommandAfterSendFailure(
+  error: Error,
+  canSendLiveRequests: Bool,
+  queueable: Bool
+) -> Bool {
   guard queueable else { return false }
   guard !isRemoteCommandApplicationError(error) else { return false }
   return !canSendLiveRequests || isSyncRequestTimeoutError(error) || isSyncHostUnavailableError(error)
@@ -282,8 +291,8 @@ enum SyncRequestTimeout {
   static let modelCatalogTimeoutNanoseconds: UInt64 = 6_000_000_000
   static let chatSendTimeoutNanoseconds: UInt64 = 120_000_000_000
   static let laneDeleteTimeoutNanoseconds: UInt64 = 240_000_000_000
-  static let message = "The machine took too long to respond. Reconnecting now."
-  static let chatSendMessage = "The machine is still starting this chat turn. Live updates will keep syncing."
+  static let message = "The machine took too long to respond. Try again."
+  static let chatSendMessage = "ADE couldn't confirm whether this message started. Your draft was restored; check the transcript before sending again."
 
   static func commandTimeoutNanoseconds(for action: String) -> UInt64 {
     switch action {
@@ -343,6 +352,9 @@ enum SyncSocketTiming {
   static let openTimeoutNanoseconds: UInt64 = 5_000_000_000
   static let lanePresenceHeartbeatNanoseconds: UInt64 = 30_000_000_000
   static let requestTimeoutReconnectSilenceSeconds: TimeInterval = 12
+  static let transportProbeTimeoutNanoseconds: UInt64 = 5_000_000_000
+  static let expensiveTransportProbeTimeoutNanoseconds: UInt64 = 8_000_000_000
+  static let constrainedTransportProbeTimeoutNanoseconds: UInt64 = 12_000_000_000
 }
 
 enum SyncTailnetDiscoveryTiming {
@@ -1123,13 +1135,6 @@ func syncConnectionStateAfterTransportFailure(error: Error, fallback: RemoteConn
   syncIsMessageTooLongError(error) ? .error : fallback
 }
 
-func syncConnectionStateAfterRequestTimeout(
-  lastInboundMessageAt: TimeInterval?,
-  fallback: RemoteConnectionState
-) -> RemoteConnectionState {
-  lastInboundMessageAt == nil ? .connecting : fallback
-}
-
 func syncShouldPublishForegroundReconnectStarted(
   allowAutoReconnect: Bool,
   autoReconnectPausedByUser: Bool,
@@ -1384,7 +1389,40 @@ private final class SyncSocketSessionDelegate: NSObject, URLSessionWebSocketDele
   ) {
     guard let webSocketTask = task as? URLSessionWebSocketTask, let error else { return }
     Task { @MainActor [weak service] in
-      service?.handleSocketDidComplete(webSocketTask, error: error)
+      service?.handleSocketDidComplete(
+        webSocketTask,
+        error: error,
+        closeCodeRawValue: Int(webSocketTask.closeCode.rawValue)
+      )
+    }
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    webSocketTask: URLSessionWebSocketTask,
+    didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+    reason: Data?
+  ) {
+    let reasonMessage = reason.flatMap { String(data: $0, encoding: .utf8) }
+    let message: String
+    if closeCode.rawValue == 4001 {
+      message = "The machine stopped responding. Reconnecting now."
+    } else if let reasonMessage, !reasonMessage.isEmpty {
+      message = reasonMessage
+    } else {
+      message = "The connection to the machine was interrupted. Reconnecting now."
+    }
+    let error = NSError(
+      domain: "ADE",
+      code: 24,
+      userInfo: [NSLocalizedDescriptionKey: message]
+    )
+    Task { @MainActor [weak service] in
+      service?.handleSocketDidComplete(
+        webSocketTask,
+        error: error,
+        closeCodeRawValue: Int(closeCode.rawValue)
+      )
     }
   }
 }
@@ -1528,6 +1566,31 @@ struct QueuedRemoteCommandError: LocalizedError {
 
   var errorDescription: String? {
     "That action is queued for this project and will run when the machine reconnects."
+  }
+}
+
+struct AmbiguousChatCreationError: LocalizedError {
+  let underlyingError: Error
+
+  var errorDescription: String? {
+    "ADE couldn't confirm whether the chat was created. Your draft was preserved; check the Work list before trying again."
+  }
+}
+
+func performLiveChatCreationWithoutReplay<T>(
+  request: () async throws -> T
+) async throws -> T {
+  do {
+    return try await request()
+  } catch is CancellationError {
+    throw CancellationError()
+  } catch {
+    guard !isRemoteCommandApplicationError(error) else { throw error }
+    // Once a live creation request is written, a transport failure or timeout
+    // cannot prove whether the host created the session. Replaying it later can
+    // duplicate a chat after the host's command ledger expires, so preserve the
+    // lane and draft and require the user to reconcile against the Work list.
+    throw AmbiguousChatCreationError(underlyingError: error)
   }
 }
 
@@ -1898,9 +1961,20 @@ final class SyncService: ObservableObject {
   private let pathMonitorQueue = DispatchQueue(label: "com.ade.sync.network-path")
   private let tailnetDiscovery = SyncTailnetProbe()
   private var socket: URLSessionWebSocketTask?
+  #if DEBUG
+  private var capturesOutboundEnvelopesForTesting = false
+  private var capturedOutboundEnvelopesForTesting: [(type: String, requestId: String?)] = []
+  private var completesCapturedRefreshRequestsForTesting = false
+  #endif
+  private struct PendingRequestTimeoutPolicy {
+    let disconnectOnTimeout: Bool
+    let error: NSError
+  }
+
   private struct PendingRequest {
     let completion: (Result<Any, Error>) -> Void
     let timeoutTask: Task<Void, Never>
+    let timeoutPolicy: PendingRequestTimeoutPolicy
     /// Monotonic timestamp captured via `ProcessInfo.processInfo.systemUptime`
     /// — RTT calculations must not be skewed by user-initiated wall-clock
     /// adjustments (DST, NTP step, manual time changes).
@@ -3955,8 +4029,9 @@ final class SyncService: ObservableObject {
     if !userInitiated && automaticAddresses.isEmpty {
       if !autoReconnectAwaitingLiveDiscovery {
         syncConnectLog.info("reconnect skipped: waiting for a saved or live route")
+        autoReconnectAwaitingLiveDiscovery = true
+        scheduleSlowReconnectHeartbeat()
       }
-      autoReconnectAwaitingLiveDiscovery = true
       return
     }
     autoReconnectAwaitingLiveDiscovery = false
@@ -3986,7 +4061,7 @@ final class SyncService: ObservableObject {
         error,
         shouldScheduleRetry: !userInitiated,
         phase: userInitiated ? .failed : .disconnected,
-        connectionState: userInitiated ? .error : .disconnected
+        connectionState: userInitiated ? .error : .connecting
       )
     }
   }
@@ -3997,7 +4072,8 @@ final class SyncService: ObservableObject {
     lastError = nil
   }
 
-  private func refreshReducedSyncLoad() {
+  @discardableResult
+  private func updateReducedSyncLoad() -> Bool {
     let route = currentAddress
       ?? activeHostProfile?.lastSuccessfulAddress
       ?? activeHostProfile?.tailscaleAddress
@@ -4038,6 +4114,13 @@ final class SyncService: ObservableObject {
       syncChatLog.notice(
         "reduced_load_changed enabled=\(next, privacy: .public) route=\(route ?? "none", privacy: .public) poorSamples=\(self.poorConnectionSampleCount, privacy: .public) healthySamples=\(self.healthyConnectionSampleCount, privacy: .public) forced=\(forcedReduced, privacy: .public) path=\(syncLogPathSummary(self.lastNetworkPathSnapshot), privacy: .public)"
       )
+      return true
+    }
+    return false
+  }
+
+  private func refreshReducedSyncLoad() {
+    if updateReducedSyncLoad() {
       restoreChatEventSubscriptions()
     }
   }
@@ -4135,18 +4218,23 @@ final class SyncService: ObservableObject {
       "path_changed state=\(self.connectionState.rawValue, privacy: .public) path=\(syncLogPathSummary(snapshot), privacy: .public) current=\(self.currentAddress ?? "none", privacy: .public) roamToTailnet=\(shouldRoamToTailnet, privacy: .public) liveRequests=\(self.canSendLiveRequests(), privacy: .public)"
     )
 
-    if shouldRoamToTailnet {
+    switch syncNetworkPathRecoveryAction(
+      shouldRoamToTailnet: shouldRoamToTailnet,
+      isPathSatisfied: snapshot.isSatisfied,
+      hasLiveConnection: canSendLiveRequests()
+    ) {
+    case .scheduleForcedReset:
       scheduleNetworkPathReconnect(
         forceSocketReset: true,
         delayNanoseconds: snapshot.isSatisfied ? 250_000_000 : 750_000_000
       )
-      return
-    }
-
-    guard snapshot.isSatisfied else { return }
-
-    if !canSendLiveRequests() {
+    case .cancelScheduledReconnect:
+      networkPathReconnectTask?.cancel()
+      networkPathReconnectTask = nil
+    case .scheduleReconnect:
       scheduleNetworkPathReconnect(forceSocketReset: false)
+    case .none:
+      break
     }
   }
 
@@ -4154,14 +4242,27 @@ final class SyncService: ObservableObject {
     forceSocketReset: Bool,
     delayNanoseconds: UInt64 = 250_000_000
   ) {
+    let scheduledConnectionGeneration = connectionGeneration
     syncChatLog.notice(
-      "network_path_reconnect_scheduled forceReset=\(forceSocketReset, privacy: .public) delayNs=\(delayNanoseconds, privacy: .public) state=\(self.connectionState.rawValue, privacy: .public) generation=\(self.connectionGeneration, privacy: .public) current=\(self.currentAddress ?? "none", privacy: .public)"
+      "network_path_reconnect_scheduled forceReset=\(forceSocketReset, privacy: .public) delayNs=\(delayNanoseconds, privacy: .public) state=\(self.connectionState.rawValue, privacy: .public) generation=\(scheduledConnectionGeneration, privacy: .public) current=\(self.currentAddress ?? "none", privacy: .public)"
     )
     networkPathReconnectTask?.cancel()
     networkPathReconnectTask = Task { @MainActor [weak self] in
       try? await Task.sleep(nanoseconds: delayNanoseconds)
       guard let self, !Task.isCancelled else { return }
-      if forceSocketReset {
+      let action = syncScheduledPathReconnectAction(
+        forceSocketReset: forceSocketReset,
+        scheduledConnectionGeneration: scheduledConnectionGeneration,
+        currentConnectionGeneration: self.connectionGeneration,
+        hasLiveConnection: self.canSendLiveRequests()
+      )
+      if action == .skip {
+        syncChatLog.notice(
+          "network_path_reconnect_skipped_stale scheduledGeneration=\(scheduledConnectionGeneration, privacy: .public) currentGeneration=\(self.connectionGeneration, privacy: .public) state=\(self.connectionState.rawValue, privacy: .public) current=\(self.currentAddress ?? "none", privacy: .public)"
+        )
+        return
+      }
+      if action == .resetAndReconnect {
         syncChatLog.notice(
           "network_path_reconnect_forcing_reset state=\(self.connectionState.rawValue, privacy: .public) generation=\(self.connectionGeneration, privacy: .public) current=\(self.currentAddress ?? "none", privacy: .public)"
         )
@@ -4173,16 +4274,15 @@ final class SyncService: ObservableObject {
 
   func handleForegroundTransition() async {
     refreshPhoneTailnetInterfaceState()
-    guard !reconnectConnectInFlight else { return }
     // Push registration + Live Activity token re-reporting are independent of
     // the connection branch below, so kick them off up front. They no-op when
     // no machine is paired.
     Task { await PushNotificationService.shared.enableIfPaired() }
     Task { await LiveActivityService.shared.handleForegroundTransition() }
+    guard !reconnectConnectInFlight else { return }
     if canSendLiveRequests() {
       lastError = nil
       await restoreTrackedOpenLanesAfterReconnect()
-      restoreChatEventSubscriptions()
       await refreshRemoteProjectCatalog()
       try? await refreshLaneSnapshots()
       try? await refreshWorkSessions()
@@ -6735,13 +6835,17 @@ final class SyncService: ObservableObject {
       ))
       throw QueuedRemoteCommandError(action: "chat.create")
     }
-    return try await sendDecodableCommand(
-      action: "chat.create",
-      args: args,
-      targetProjectId: targetProjectId,
-      targetProjectRootPath: targetProjectRootPath,
-      as: AgentChatSessionSummary.self
-    )
+    let commandId = makeRequestId()
+    return try await performLiveChatCreationWithoutReplay {
+      let response = try await performCommandRequest(
+        action: "chat.create",
+        args: args,
+        commandId: commandId,
+        targetProjectId: targetProjectId,
+        targetProjectRootPath: targetProjectRootPath
+      )
+      return try decode(response, as: AgentChatSessionSummary.self)
+    }
   }
 
   func launchChatSession(
@@ -6814,13 +6918,17 @@ final class SyncService: ObservableObject {
       throw QueuedRemoteCommandError(action: "chat.launch")
     }
 
-    return try await sendDecodableCommand(
-      action: "chat.launch",
-      args: args,
-      targetProjectId: targetProjectId,
-      targetProjectRootPath: targetProjectRootPath,
-      as: AgentChatSessionSummary.self
-    )
+    let commandId = makeRequestId()
+    return try await performLiveChatCreationWithoutReplay {
+      let response = try await performCommandRequest(
+        action: "chat.launch",
+        args: args,
+        commandId: commandId,
+        targetProjectId: targetProjectId,
+        targetProjectRootPath: targetProjectRootPath
+      )
+      return try decode(response, as: AgentChatSessionSummary.self)
+    }
   }
 
   private func chatSessionCreateArgs(
@@ -7198,11 +7306,16 @@ final class SyncService: ObservableObject {
     let response = try await sendCommand(
       action: chatActionName("chat.send", sessionId: sessionId),
       args: args,
-      disconnectOnTimeout: false,
+      // A chat timeout is ambiguous: the host may have started the turn without
+      // returning the command result. Never auto-resend it. Do run the same
+      // health-gated liveness probe as other requests so a silent socket starts
+      // service-owned recovery while the composer restores the user's draft.
+      disconnectOnTimeout: true,
       timeoutMessage: SyncRequestTimeout.chatSendMessage,
       timeoutNanoseconds: SyncRequestTimeout.chatSendTimeoutNanoseconds,
       targetProjectId: targetProjectId ?? scope.projectId,
-      targetProjectRootPath: targetProjectRootPath ?? scope.rootPath
+      targetProjectRootPath: targetProjectRootPath ?? scope.rootPath,
+      attemptedLiveFailurePolicy: .preserveForManualRetry
     )
     return syncChatMessageDelivery(from: response)
   }
@@ -8955,7 +9068,18 @@ final class SyncService: ObservableObject {
   }
 
   private func reconnectDelay() -> UInt64 {
-    reconnectState.nextDelayNanoseconds()
+    syncJitteredReconnectDelayNanoseconds(
+      base: reconnectState.nextDelayNanoseconds(),
+      sample: Double.random(in: 0...1)
+    )
+  }
+
+  private func reconnectDelay(forCloseCodeRawValue closeCodeRawValue: Int?) -> UInt64 {
+    let jittered = syncJitteredReconnectDelayNanoseconds(
+      base: reconnectState.nextDelayNanoseconds(forCloseCodeRawValue: closeCodeRawValue),
+      sample: Double.random(in: 0...1)
+    )
+    return closeCodeRawValue == 4001 ? max(1_500_000_000, jittered) : jittered
   }
 
   private func scheduleReconnectIfNeeded(after delayNanoseconds: UInt64) {
@@ -9551,6 +9675,28 @@ final class SyncService: ObservableObject {
     reconnectTask != nil || networkPathReconnectTask != nil
   }
 
+  func configureReconnectProfileForTesting(_ profile: HostConnectionProfile, token: String) {
+    saveProfile(profile)
+    keychain.saveToken(token, hostKey: profileStorageKey(profile))
+    allowAutoReconnect = true
+    setAutoReconnectPausedByUser(false)
+  }
+
+  func clearReconnectProfileForTesting(_ profile: HostConnectionProfile) {
+    keychain.clearToken(hostKey: profileStorageKey(profile))
+    saveProfile(nil)
+  }
+
+  func simulateAutomaticTransportFailureForTesting(
+    _ error: Error,
+    reconnectDelayNanoseconds: UInt64 = 60_000_000_000
+  ) {
+    beginAutomaticTransportRecovery(
+      error,
+      reconnectDelayNanoseconds: reconnectDelayNanoseconds
+    )
+  }
+
   func setActiveProjectForTesting(projectId: String?, rootPath: String?) {
     setActiveProjectId(projectId, rootPath: rootPath)
     resetOutboundCursorStateForActiveProject()
@@ -9630,6 +9776,113 @@ final class SyncService: ObservableObject {
         fallbackToActiveProjectScope: operation.fallbackToActiveProjectScope
       )
     }
+  }
+
+  func beginOutboundEnvelopeCaptureForTesting() {
+    capturedOutboundEnvelopesForTesting = []
+    capturesOutboundEnvelopesForTesting = true
+  }
+
+  func configureConnectedTransportForTesting() {
+    if socket == nil, let url = URL(string: "ws://127.0.0.1:8787") {
+      socket = socketSession.webSocketTask(with: url)
+    }
+    connectionState = .connected
+  }
+
+  func completeCapturedRefreshRequestsForTesting() {
+    completesCapturedRefreshRequestsForTesting = true
+  }
+
+  func resetOutboundEnvelopeCaptureForTesting() {
+    capturedOutboundEnvelopesForTesting = []
+  }
+
+  func capturedOutboundEnvelopeCountForTesting(type: String) -> Int {
+    capturedOutboundEnvelopesForTesting.filter { $0.type == type }.count
+  }
+
+  func capturedOutboundRequestIdsForTesting(type: String) -> [String] {
+    capturedOutboundEnvelopesForTesting.compactMap { envelope in
+      envelope.type == type ? envelope.requestId : nil
+    }
+  }
+
+  func firePendingRequestTimeoutForTesting(requestId: String) {
+    firePendingRequestTimeout(requestId: requestId)
+  }
+
+  func connectionGenerationForTesting() -> UInt64 {
+    connectionGeneration
+  }
+
+  func completeTransportProbeForTesting(
+    heardInboundTraffic: Bool,
+    error: NSError = NSError(
+      domain: NSURLErrorDomain,
+      code: NSURLErrorTimedOut,
+      userInfo: [NSLocalizedDescriptionKey: "Transport probe timed out."]
+    )
+  ) {
+    transportProbeTask?.cancel()
+    transportProbeTask = nil
+    let probeStartedAt = ProcessInfo.processInfo.systemUptime
+    lastInboundMessageAt = heardInboundTraffic ? probeStartedAt + 1 : nil
+    finishTransportProbe(
+      recoveryError: error,
+      trigger: "test",
+      generation: connectionGeneration,
+      probeStartedAt: probeStartedAt
+    )
+  }
+
+  func exhaustFastReconnectBudgetForTesting(_ error: Error) {
+    reconnectState.reset()
+    for _ in 0..<SyncReconnectState.maxAutomaticAttempts {
+      _ = reconnectState.nextDelayNanoseconds()
+    }
+    handleReconnectFailure(
+      error,
+      shouldScheduleRetry: true,
+      phase: .disconnected,
+      connectionState: .connecting
+    )
+  }
+
+  func endOutboundEnvelopeCaptureForTesting() {
+    capturesOutboundEnvelopesForTesting = false
+    capturedOutboundEnvelopesForTesting = []
+    completesCapturedRefreshRequestsForTesting = false
+  }
+
+  private func capturedRefreshResponseForTesting(type: String, payload: Any) -> Any? {
+    if type == "project_catalog_request" {
+      return ["projects": [Any]()] as [String: Any]
+    }
+    guard type == "command",
+          let payload = payload as? [String: Any],
+          let action = payload["action"] as? String
+    else { return nil }
+    let result: Any
+    switch action {
+    case "lanes.refreshSnapshots":
+      result = [
+        "refreshedCount": 0,
+        "lanes": [Any](),
+        "snapshots": [Any](),
+      ] as [String: Any]
+    case "work.listSessions":
+      result = [Any]()
+    case "prs.refresh":
+      result = [
+        "refreshedCount": 0,
+        "prs": [Any](),
+        "snapshots": [Any](),
+      ] as [String: Any]
+    default:
+      return nil
+    }
+    return ["ok": true, "result": result]
   }
   #endif
 
@@ -9764,7 +10017,10 @@ final class SyncService: ObservableObject {
       generation: connectAttemptGeneration
     )
     currentAddress = connectedHost
-    refreshReducedSyncLoad()
+    // The explicit post-hello restoration below owns the reconnect replay.
+    // Suppressing this incidental restoration prevents duplicate subscribe
+    // frames when the newly selected route changes reduced-load mode.
+    updateReducedSyncLoad()
     lastError = nil
     lastPairingErrorCode = nil
     markSyncActivity(force: true)
@@ -9893,14 +10149,13 @@ final class SyncService: ObservableObject {
             }
           } catch {
             if self.socket === task {
-              self.handleIncomingFailure(error, text: text)
+              self.handleIncomingFailure(error, text: text, task: task)
             }
             break
           }
         } catch {
           if self.socket === task {
             let closeCodeRawValue = Int(task.closeCode.rawValue)
-            let reconnectDelay = self.reconnectState.nextDelayNanoseconds(forCloseCodeRawValue: closeCodeRawValue)
             let failure: Error
             if closeCodeRawValue == 4001 {
               failure = NSError(
@@ -9911,11 +10166,10 @@ final class SyncService: ObservableObject {
             } else {
               failure = error
             }
-            self.handleTransportFailure(
-              failure,
-              phase: .disconnected,
-              connectionState: .connecting,
-              reconnectDelayNanoseconds: reconnectDelay
+            self.handleSocketFailure(
+              task,
+              error: failure,
+              closeCodeRawValue: closeCodeRawValue
             )
           }
           break
@@ -9924,7 +10178,11 @@ final class SyncService: ObservableObject {
     }
   }
 
-  private func handleIncomingFailure(_ error: Error, text: String) {
+  private func handleIncomingFailure(
+    _ error: Error,
+    text: String,
+    task: URLSessionWebSocketTask
+  ) {
     let type: String = {
       guard let data = text.data(using: .utf8),
             let envelope = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
@@ -9935,22 +10193,7 @@ final class SyncService: ObservableObject {
     syncConnectLog.error(
       "incoming message failed type=\(type, privacy: .public) error=\(String(describing: error), privacy: .public)"
     )
-    let friendlyError = SyncUserFacingError.error(from: error)
-    // Tear the socket down before flipping reduced-load preferences. The
-    // restoreChatEventSubscriptions() side-effect inside refreshReducedSyncLoad
-    // would otherwise enqueue chat_subscribe frames on a socket that is about
-    // to be cancelled, surfacing as send-on-closed errors and orphaned subs.
-    teardownSocket(reason: friendlyError.localizedDescription)
-    markConnectionLoadStrained()
-    clearConnectTimingMetrics()
-    lastError = friendlyError.localizedDescription
-    connectionState = syncConnectionStateAfterTransportFailure(error: error, fallback: .disconnected)
-    setDomainStatus(SyncDomain.allCases, phase: .failed, error: friendlyError.localizedDescription)
-    failPendingRequests(with: friendlyError)
-    // "Message too long" used to pause auto-reconnect permanently. With the
-    // raised socket receive budget and hosts chunking oversized envelopes it
-    // is an ordinary transport failure now — reconnect like any other drop.
-    scheduleReconnectIfNeeded(after: reconnectDelay())
+    handleSocketFailure(task, error: error)
   }
 
   private func handleIncoming(_ pre: SyncPreprocessedEnvelope) async throws {
@@ -10236,6 +10479,24 @@ final class SyncService: ObservableObject {
         try? await Task.sleep(nanoseconds: intervalNanoseconds)
         guard let self, !Task.isCancelled else { return }
         guard self.isCurrentConnectionGeneration(connectionGeneration), self.canSendLiveRequests() else { return }
+        let path = self.lastNetworkPathSnapshot
+        if syncShouldProbeTransportAfterHeartbeatSilence(
+          now: ProcessInfo.processInfo.systemUptime,
+          lastInboundMessageAt: self.lastInboundMessageAt,
+          heartbeatIntervalNanoseconds: intervalNanoseconds,
+          isExpensive: path?.isExpensive == true,
+          isConstrained: path?.isConstrained == true
+        ) {
+          self.verifyTransportAliveAfterSilence(
+            NSError(
+              domain: "ADE",
+              code: 24,
+              userInfo: [NSLocalizedDescriptionKey: "The machine stopped responding. Reconnecting now."]
+            ),
+            trigger: "heartbeat_silence"
+          )
+          continue
+        }
         self.sendEnvelope(type: "heartbeat", requestId: nil, payload: [
           "kind": "ping",
           "sentAt": ISO8601DateFormatter().string(from: Date()),
@@ -10375,14 +10636,12 @@ final class SyncService: ObservableObject {
   private func failPendingOutboundChangeset(_ message: String) {
     pendingOutboundChangeset = nil
     clearPendingOutboundChangesetForActiveProject()
-    handleTransportFailure(
+    beginAutomaticTransportRecovery(
       NSError(
         domain: "ADE",
         code: 27,
         userInfo: [NSLocalizedDescriptionKey: message]
-      ),
-      phase: .disconnected,
-      connectionState: .disconnected
+      )
     )
   }
 
@@ -10406,20 +10665,21 @@ final class SyncService: ObservableObject {
     send: () -> Void
   ) async throws -> Any {
     try await withCheckedThrowingContinuation { continuation in
+      let timeoutPolicy = PendingRequestTimeoutPolicy(
+        disconnectOnTimeout: disconnectOnTimeout,
+        error: SyncRequestTimeout.error(message: timeoutMessage)
+      )
       let timeoutTask = Task { @MainActor [weak self] in
         try? await Task.sleep(nanoseconds: timeoutNanoseconds)
         guard !Task.isCancelled else { return }
-        self?.handlePendingRequestTimeout(
-          requestId: requestId,
-          disconnectOnTimeout: disconnectOnTimeout,
-          timeoutError: SyncRequestTimeout.error(message: timeoutMessage)
-        )
+        self?.firePendingRequestTimeout(requestId: requestId)
       }
       pending[requestId] = PendingRequest(
         completion: { result in
           continuation.resume(with: result)
         },
         timeoutTask: timeoutTask,
+        timeoutPolicy: timeoutPolicy,
         startedAt: ProcessInfo.processInfo.systemUptime
       )
       send()
@@ -10427,6 +10687,17 @@ final class SyncService: ObservableObject {
   }
 
   private func sendEnvelope(type: String, requestId: String?, payload: Any) {
+    #if DEBUG
+    if capturesOutboundEnvelopesForTesting {
+      capturedOutboundEnvelopesForTesting.append((type: type, requestId: requestId))
+      if completesCapturedRefreshRequestsForTesting,
+         let requestId,
+         let response = capturedRefreshResponseForTesting(type: type, payload: payload) {
+        resolve(requestId: requestId, result: .success(response))
+      }
+      return
+    }
+    #endif
     guard let socket else { return }
     let sendSocket = socket
     guard let payloadData = try? adeJSONData(withJSONObject: payload) else { return }
@@ -10464,10 +10735,7 @@ final class SyncService: ObservableObject {
     sendSocket.send(.string(text)) { error in
       if let error {
         Task { @MainActor in
-          guard shouldHandleSocketSendCompletionError(currentSocket: self.socket, callbackSocket: sendSocket) else {
-            return
-          }
-          self.handleTransportFailure(error)
+          self.handleSocketFailure(sendSocket, error: error)
         }
       }
     }
@@ -10496,11 +10764,13 @@ final class SyncService: ObservableObject {
     }
   }
 
-  private func resolveSocketOpen(_ task: URLSessionWebSocketTask, result: Result<Void, Error>) {
+  @discardableResult
+  private func resolveSocketOpen(_ task: URLSessionWebSocketTask, result: Result<Void, Error>) -> Bool {
     let taskIdentifier = task.taskIdentifier
     pendingSocketOpenTimeoutTasks.removeValue(forKey: taskIdentifier)?.cancel()
-    guard let continuation = pendingSocketOpen.removeValue(forKey: taskIdentifier) else { return }
+    guard let continuation = pendingSocketOpen.removeValue(forKey: taskIdentifier) else { return false }
     continuation.resume(with: result)
+    return true
   }
 
   fileprivate func handleSocketDidOpen(_ task: URLSessionWebSocketTask) {
@@ -10508,8 +10778,47 @@ final class SyncService: ObservableObject {
     resolveSocketOpen(task, result: .success(()))
   }
 
-  fileprivate func handleSocketDidComplete(_ task: URLSessionWebSocketTask, error: Error) {
-    resolveSocketOpen(task, result: .failure(error))
+  fileprivate func handleSocketDidComplete(
+    _ task: URLSessionWebSocketTask,
+    error: Error,
+    closeCodeRawValue: Int? = nil
+  ) {
+    let completedWhileOpening = resolveSocketOpen(task, result: .failure(error))
+    handleSocketFailure(
+      task,
+      error: error,
+      completedWhileOpening: completedWhileOpening,
+      closeCodeRawValue: closeCodeRawValue
+    )
+  }
+
+  private func handleSocketFailure(
+    _ task: URLSessionWebSocketTask,
+    error: Error,
+    completedWhileOpening: Bool = false,
+    closeCodeRawValue: Int? = nil
+  ) {
+    let action = syncSocketCompletionAction(
+      isCurrentSocket: shouldHandleSocketSendCompletionError(currentSocket: socket, callbackSocket: task),
+      completedWhileOpening: completedWhileOpening,
+      canSendLiveRequests: canSendLiveRequests(),
+      closeCodeRawValue: closeCodeRawValue
+    )
+    switch action {
+    case .ignore, .failOpening:
+      return
+    case .recoverTransport(let closeCodeRawValue):
+      beginAutomaticTransportRecovery(
+        error,
+        reconnectDelayNanoseconds: reconnectDelay(forCloseCodeRawValue: closeCodeRawValue)
+      )
+    case .failHandshake:
+      // The WebSocket opened but died during hello. Fail the hello request so
+      // the existing route walker can try its next ranked candidate; scheduling
+      // a second reconnect owner here would race that in-flight attempt.
+      teardownSocket(reason: error.localizedDescription)
+      failPendingRequests(with: error)
+    }
   }
 
   private func teardownSocket(closeCode: URLSessionWebSocketTask.CloseCode = .goingAway, reason: String? = nil) {
@@ -10555,10 +10864,8 @@ final class SyncService: ObservableObject {
     connectionGeneration &+= 1
   }
 
-  private func handleTransportFailure(
+  private func beginAutomaticTransportRecovery(
     _ error: Error,
-    phase: SyncDomainPhase = .failed,
-    connectionState: RemoteConnectionState = .error,
     reconnectDelayNanoseconds: UInt64? = nil
   ) {
     let friendlyError = SyncUserFacingError.error(from: error)
@@ -10567,8 +10874,8 @@ final class SyncService: ObservableObject {
     markConnectionLoadStrained()
     clearConnectTimingMetrics()
     lastError = friendlyError.localizedDescription
-    self.connectionState = syncConnectionStateAfterTransportFailure(error: error, fallback: connectionState)
-    if phase == .failed || syncIsMessageTooLongError(error) {
+    connectionState = syncConnectionStateAfterTransportFailure(error: error, fallback: .connecting)
+    if syncIsMessageTooLongError(error) {
       setDomainStatus(SyncDomain.allCases, phase: .failed, error: friendlyError.localizedDescription)
     } else {
       setDomainStatus(SyncDomain.allCases, phase: .disconnected)
@@ -10579,19 +10886,21 @@ final class SyncService: ObservableObject {
     scheduleReconnectIfNeeded(after: reconnectDelayNanoseconds ?? reconnectDelay())
   }
 
+  private func firePendingRequestTimeout(requestId: String) {
+    guard let timeoutPolicy = pending[requestId]?.timeoutPolicy else { return }
+    handlePendingRequestTimeout(requestId: requestId, policy: timeoutPolicy)
+  }
+
   private func handlePendingRequestTimeout(
     requestId: String,
-    disconnectOnTimeout: Bool = true,
-    timeoutError: NSError = SyncRequestTimeout.error()
+    policy: PendingRequestTimeoutPolicy
   ) {
-    guard pending[requestId] != nil else { return }
-    let shouldReconnect = disconnectOnTimeout
-      && syncShouldReconnectAfterRequestTimeout(
-        now: ProcessInfo.processInfo.systemUptime,
-        lastInboundMessageAt: lastInboundMessageAt
-      )
-    if disconnectOnTimeout,
-       shouldReconnect {
+    let recoveryAction = syncRequestTimeoutRecoveryAction(
+      disconnectOnTimeout: policy.disconnectOnTimeout,
+      now: ProcessInfo.processInfo.systemUptime,
+      lastInboundMessageAt: lastInboundMessageAt
+    )
+    if recoveryAction == .probeTransport {
       // A timed-out request plus a quiet inbound window does NOT prove the
       // socket is dead — the host may just be slow (catalog/PR refreshes can
       // take 30s+) while nothing else streams. Tearing down here put cellular
@@ -10599,81 +10908,79 @@ final class SyncService: ObservableObject {
       // request, then actively probe the transport; only a probe that hears
       // nothing back tears the socket down.
       markConnectionLoadStrained()
-      resolve(requestId: requestId, result: .failure(SyncUserFacingError.error(from: SyncRequestTimeout.error(
-        message: "The machine took too long to respond. Try again."
-      ))))
+      resolve(requestId: requestId, result: .failure(SyncUserFacingError.error(from: policy.error)))
       syncChatLog.notice(
         "request_timeout_probe_scheduled requestId=\(requestId, privacy: .public) state=\(self.connectionState.rawValue, privacy: .public) generation=\(self.connectionGeneration, privacy: .public) lastInbound=\(self.lastInboundMessageAt ?? -1, privacy: .public)"
       )
-      verifyTransportAliveAfterRequestTimeout(timeoutError)
+      verifyTransportAliveAfterSilence(policy.error, trigger: "request_timeout")
     } else {
-      // The default `timeoutError` is `SyncRequestTimeout.error()`, whose
-      // message says "Reconnecting now." That copy is only honest in the
-      // reconnect branch above. When we explicitly do *not* tear the socket
-      // down (either disconnectOnTimeout was false, or the socket has been
-      // hearing inbound traffic recently and we don't want to reconnect),
-      // surfacing that message lies to the user. Fall back to a non-reconnect
-      // timeout message in that branch.
-      let resolvedError: NSError
-      if disconnectOnTimeout {
-        resolvedError = SyncRequestTimeout.error(
-          message: "The machine took too long to respond. Try again."
-        )
-      } else {
-        resolvedError = timeoutError
-      }
+      // One slow request is local failure evidence, not socket failure
+      // evidence. The neutral timeout copy stays honest whether recent inbound
+      // traffic kept the socket up or this command opted out of recovery.
       markConnectionLoadStrained()
       syncChatLog.notice(
-        "request_timeout_resolved_without_reconnect requestId=\(requestId, privacy: .public) disconnectOnTimeout=\(disconnectOnTimeout, privacy: .public) state=\(self.connectionState.rawValue, privacy: .public) generation=\(self.connectionGeneration, privacy: .public) lastInbound=\(self.lastInboundMessageAt ?? -1, privacy: .public)"
+        "request_timeout_resolved_without_reconnect requestId=\(requestId, privacy: .public) disconnectOnTimeout=\(policy.disconnectOnTimeout, privacy: .public) state=\(self.connectionState.rawValue, privacy: .public) generation=\(self.connectionGeneration, privacy: .public) lastInbound=\(self.lastInboundMessageAt ?? -1, privacy: .public)"
       )
-      resolve(requestId: requestId, result: .failure(resolvedError))
+      resolve(requestId: requestId, result: .failure(policy.error))
     }
   }
 
-  /// Active liveness check after a request timeout: ping the host and give it
-  /// a short window to send anything back. Inbound traffic (the pong, a
-  /// changeset, a status ping) proves the transport works and the socket is
-  /// kept; total silence means the connection is actually dead and the normal
-  /// transport-failure teardown runs. One probe at a time.
-  private func verifyTransportAliveAfterRequestTimeout(_ timeoutError: NSError) {
+  /// Shared liveness check for request timeouts and heartbeat silence. Inbound
+  /// traffic (the pong, a changeset, a status ping) proves the transport works;
+  /// total silence enters the single automatic recovery owner. One probe at a
+  /// time, guarded by the connection generation.
+  private func verifyTransportAliveAfterSilence(_ recoveryError: NSError, trigger: String) {
     guard transportProbeTask == nil, canSendLiveRequests() else {
       syncChatLog.notice(
-        "request_timeout_probe_skipped probeInFlight=\((self.transportProbeTask != nil), privacy: .public) liveRequests=\(self.canSendLiveRequests(), privacy: .public) state=\(self.connectionState.rawValue, privacy: .public) generation=\(self.connectionGeneration, privacy: .public)"
+        "transport_probe_skipped trigger=\(trigger, privacy: .public) probeInFlight=\((self.transportProbeTask != nil), privacy: .public) liveRequests=\(self.canSendLiveRequests(), privacy: .public) state=\(self.connectionState.rawValue, privacy: .public) generation=\(self.connectionGeneration, privacy: .public)"
       )
       return
     }
     let generation = connectionGeneration
     let probeStartedAt = ProcessInfo.processInfo.systemUptime
     syncChatLog.notice(
-      "request_timeout_probe_sent generation=\(generation, privacy: .public) state=\(self.connectionState.rawValue, privacy: .public) lastInbound=\(self.lastInboundMessageAt ?? -1, privacy: .public)"
+      "transport_probe_sent trigger=\(trigger, privacy: .public) generation=\(generation, privacy: .public) state=\(self.connectionState.rawValue, privacy: .public) lastInbound=\(self.lastInboundMessageAt ?? -1, privacy: .public)"
     )
     sendEnvelope(type: "heartbeat", requestId: nil, payload: [
       "kind": "ping",
       "sentAt": ISO8601DateFormatter().string(from: Date()),
       "dbVersion": database.currentDbVersion(),
     ])
+    let probeTimeoutNanoseconds = syncTransportProbeTimeoutNanoseconds(
+      isExpensive: lastNetworkPathSnapshot?.isExpensive == true,
+      isConstrained: lastNetworkPathSnapshot?.isConstrained == true
+    )
     transportProbeTask = Task { @MainActor [weak self] in
-      try? await Task.sleep(nanoseconds: 5_000_000_000)
+      try? await Task.sleep(nanoseconds: probeTimeoutNanoseconds)
       guard let self else { return }
       self.transportProbeTask = nil
-      guard !Task.isCancelled, self.connectionGeneration == generation else { return }
-      if let lastInbound = self.lastInboundMessageAt, lastInbound > probeStartedAt {
-        syncChatLog.notice(
-          "request_timeout_probe_succeeded generation=\(generation, privacy: .public) lastInbound=\(lastInbound, privacy: .public) probeStartedAt=\(probeStartedAt, privacy: .public)"
-        )
-        return
-      }
-      syncChatLog.notice(
-        "request_timeout_probe_failed generation=\(generation, privacy: .public) lastInbound=\(self.lastInboundMessageAt ?? -1, privacy: .public) probeStartedAt=\(probeStartedAt, privacy: .public)"
-      )
-      self.handleTransportFailure(
-        timeoutError,
-        connectionState: syncConnectionStateAfterRequestTimeout(
-          lastInboundMessageAt: self.lastInboundMessageAt,
-          fallback: .error
-        )
+      guard !Task.isCancelled else { return }
+      self.finishTransportProbe(
+        recoveryError: recoveryError,
+        trigger: trigger,
+        generation: generation,
+        probeStartedAt: probeStartedAt
       )
     }
+  }
+
+  private func finishTransportProbe(
+    recoveryError: NSError,
+    trigger: String,
+    generation: UInt64,
+    probeStartedAt: TimeInterval
+  ) {
+    guard connectionGeneration == generation else { return }
+    if let lastInbound = lastInboundMessageAt, lastInbound > probeStartedAt {
+      syncChatLog.notice(
+        "transport_probe_succeeded trigger=\(trigger, privacy: .public) generation=\(generation, privacy: .public) lastInbound=\(lastInbound, privacy: .public) probeStartedAt=\(probeStartedAt, privacy: .public)"
+      )
+      return
+    }
+    syncChatLog.notice(
+      "transport_probe_failed trigger=\(trigger, privacy: .public) generation=\(generation, privacy: .public) lastInbound=\(self.lastInboundMessageAt ?? -1, privacy: .public) probeStartedAt=\(probeStartedAt, privacy: .public)"
+    )
+    beginAutomaticTransportRecovery(recoveryError)
   }
 
   private func decodeEnvelopePayload(_ envelope: [String: Any]) throws -> Any {
@@ -11081,7 +11388,7 @@ final class SyncService: ObservableObject {
           connectionState = .error
         }
         if isSyncRequestTimeoutError(error) {
-          verifyTransportAliveAfterRequestTimeout(error as NSError)
+          verifyTransportAliveAfterSilence(error as NSError, trigger: "request_timeout")
           return stillLive
         }
         return false
@@ -11148,7 +11455,8 @@ final class SyncService: ObservableObject {
     timeoutNanoseconds: UInt64? = nil,
     targetProjectId: String? = nil,
     targetProjectRootPath: String? = nil,
-    fallbackToActiveProjectScope: Bool = true
+    fallbackToActiveProjectScope: Bool = true,
+    attemptedLiveFailurePolicy: SyncAttemptedLiveFailurePolicy = .enqueueSafely
   ) async throws -> Any {
     if !commandIsRuntimeScoped(action) && !fallbackToActiveProjectScope && syncNormalizedCommandScopeValue(targetProjectId) == nil {
       throw NSError(domain: "ADE", code: 26, userInfo: [NSLocalizedDescriptionKey: "This action needs the lane's project scope. Refresh lanes and try again."])
@@ -11169,7 +11477,8 @@ final class SyncService: ObservableObject {
         )
       } catch {
         let stillLive = canSendLiveRequests()
-        if syncShouldQueueCommandAfterSendFailure(
+        if attemptedLiveFailurePolicy == .enqueueSafely,
+           syncShouldQueueCommandAfterSendFailure(
           error: error,
           canSendLiveRequests: stillLive,
           queueable: commandPolicy(for: action)?.queueable == true
@@ -11184,7 +11493,7 @@ final class SyncService: ObservableObject {
             fallbackToActiveProjectScope: fallbackToActiveProjectScope
           )
           if stillLive, isSyncRequestTimeoutError(error) {
-            verifyTransportAliveAfterRequestTimeout(error as NSError)
+            verifyTransportAliveAfterSilence(error as NSError, trigger: "request_timeout")
           }
           return ["queued": true]
         }
@@ -11966,7 +12275,7 @@ extension SyncService {
         ) {
           try enqueueOperation(kind: "command", action: action, args: args, id: commandId)
           if stillLive, isSyncRequestTimeoutError(error) {
-            verifyTransportAliveAfterRequestTimeout(error as NSError)
+            verifyTransportAliveAfterSilence(error as NSError, trigger: "request_timeout")
           }
           return ["queued": true]
         }

--- a/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
+++ b/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
@@ -822,6 +822,7 @@ struct HubInlineComposer: View {
       targetLaneId = selectedLaneId
       targetLaneName = lanesForPickedProject.first(where: { $0.id == selectedLaneId })?.name ?? selectedLaneId
     }
+    var createdChatAfterSessionCreation: HubCreatedChat?
 
     do {
       let isCli = sessionMode == .cli
@@ -874,6 +875,15 @@ struct HubInlineComposer: View {
           targetProjectRootPath: targetProjectRootPath
         )
         sessionId = summary.sessionId
+        createdChatAfterSessionCreation = HubCreatedChat(
+          projectId: targetProjectId,
+          projectRootPath: targetProjectRootPath,
+          projectName: project.displayName,
+          laneName: targetLaneName,
+          sessionId: summary.sessionId,
+          isCli: false,
+          provider: provider
+        )
         try await syncService.sendChatMessage(
           sessionId: summary.sessionId,
           text: opener,
@@ -892,7 +902,7 @@ struct HubInlineComposer: View {
       ADEHaptics.success()
       busy = false
 
-      let created = HubCreatedChat(
+      let created = createdChatAfterSessionCreation ?? HubCreatedChat(
         projectId: targetProjectId,
         projectRootPath: targetProjectRootPath,
         projectName: project.displayName,
@@ -914,9 +924,59 @@ struct HubInlineComposer: View {
         )
       }
       return true
+    } catch let error as QueuedRemoteCommandError {
+      if workQueuedNewSessionConsumesOpeningDraft(sessionMode) {
+        // The queued CLI start already contains the opener as `initialInput`.
+        // Keep the cleared composer so a retry cannot duplicate that input.
+        ADEHaptics.medium()
+        errorMessage = nil
+        if let createdLaneId, let autoCreatedFallbackName {
+          startBackgroundLaneNaming(
+            laneId: createdLaneId,
+            opener: opener,
+            fallbackName: autoCreatedFallbackName,
+            targetProjectId: targetProjectId,
+            targetProjectRootPath: targetProjectRootPath
+          )
+        }
+        busy = false
+        return true
+      }
+      // The chat create itself is safely queued, but the opener was not sent.
+      // Keep the lane and return false so the hub preserves the exact draft and
+      // attachments until the pending session materializes after reconnect.
+      ADEHaptics.medium()
+      errorMessage = error.localizedDescription
+      busy = false
+      return false
+    } catch let error as AmbiguousChatCreationError {
+      // A live create may already have reached the host. Never delete its lane
+      // or retry blindly; preserve the draft while the Work list reconciles.
+      ADEHaptics.error()
+      errorMessage = error.localizedDescription
+      busy = false
+      return false
     } catch {
       ADEHaptics.error()
       errorMessage = error.localizedDescription
+      if let createdChatAfterSessionCreation {
+        // The session exists and the host may already have started the opener.
+        // Keep the lane/session, expose the chat through the hub toast, and
+        // return false so the inline composer restores the user's exact draft
+        // and attachments without auto-resending them.
+        onCreated(createdChatAfterSessionCreation)
+        if let createdLaneId, let autoCreatedFallbackName {
+          startBackgroundLaneNaming(
+            laneId: createdLaneId,
+            opener: opener,
+            fallbackName: autoCreatedFallbackName,
+            targetProjectId: targetProjectId,
+            targetProjectRootPath: targetProjectRootPath
+          )
+        }
+        busy = false
+        return false
+      }
       // The chat never launched into the lane we just minted — clean it up so
       // an auto-create failure doesn't leave an orphaned empty lane behind.
       if let createdLaneId {

--- a/apps/ios/ADE/Views/Linear/LinearLaunchModel.swift
+++ b/apps/ios/ADE/Views/Linear/LinearLaunchModel.swift
@@ -89,6 +89,15 @@ struct LinearQueuedAgentLaunchError: LocalizedError {
   var errorDescription: String? { underlying.errorDescription }
 }
 
+/// A live launch whose response was lost after dispatch. The lane must remain:
+/// the host may already be running the agent even though mobile cannot yet
+/// identify its session.
+struct LinearAmbiguousAgentLaunchError: LocalizedError {
+  let underlying: AmbiguousChatCreationError
+
+  var errorDescription: String? { underlying.errorDescription }
+}
+
 /// Create-lane → launch-agent → return, with lane rollback on a post-lane
 /// launch failure (desktop parity). This is the single-issue slice of the
 /// desktop `runBatchLaunch`.
@@ -118,6 +127,8 @@ func runLinearLaunch(
     return .session(laneId: laneId, sessionId: sessionId)
   } catch let queuedError as QueuedRemoteCommandError {
     throw LinearQueuedAgentLaunchError(underlying: queuedError)
+  } catch let ambiguousError as AmbiguousChatCreationError {
+    throw LinearAmbiguousAgentLaunchError(underlying: ambiguousError)
   } catch {
     // The agent never launched into the lane we just minted, so roll back the
     // empty lane. Queued offline launches keep the lane so the queue can drain.

--- a/apps/ios/ADE/Views/Linear/LinearLaunchScreen.swift
+++ b/apps/ios/ADE/Views/Linear/LinearLaunchScreen.swift
@@ -341,6 +341,10 @@ struct LinearLaunchScreen: View {
       // their initial input, so this handoff is complete from the sheet's view.
       ADEHaptics.medium()
       syncService.linearPanePresented = false
+    } catch let error as LinearAmbiguousAgentLaunchError {
+      ADEHaptics.error()
+      errorMessage = "ADE kept the new lane because the agent may already have started. \(error.localizedDescription)"
+      busy = false
     } catch is QueuedRemoteCommandError {
       if config.sessionType.needsAgentConfig {
         ADEHaptics.error()

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -164,6 +164,8 @@ struct WorkChatSessionView: View {
   let canSendMessages: Bool
   let sendWillQueue: Bool
   let sendWillQueueIsReconnect: Bool
+  let transportHealth: SyncTransportHealth
+  let composerDraftRestore: WorkChatComposerDraftRestore?
   var inputLockMessage: String? = nil
   let transitionNamespace: Namespace.ID?
   let onOpenLane: (() -> Void)?
@@ -519,8 +521,11 @@ struct WorkChatSessionView: View {
     if sendWillQueueIsReconnect, pendingSteers.isEmpty {
       return "Machine is reconnecting. Send will queue until it is back."
     }
+    if transportHealth == .connecting {
+      return "Reconnecting… Your draft is safe."
+    }
     if !canSendMessages {
-      return "Reconnect to send messages."
+      return "Waiting for the machine before sending."
     }
     if pendingInputs.count == 1 {
       // The single request renders in the consolidated strip directly above the
@@ -562,10 +567,10 @@ struct WorkChatSessionView: View {
 
     // Connection-caused failures are communicated via the top-right gear, but
     // cached/offline chat actions still need their own visible errors.
-    if let errorMessage, !hostUnreachable {
+    if let errorMessageSnapshot, !hostUnreachable {
       ADENoticeCard(
         title: "Chat error",
-        message: errorMessage,
+        message: errorMessageSnapshot,
         icon: "exclamationmark.triangle.fill",
         tint: ADEColor.danger,
         actionTitle: "Retry",
@@ -740,6 +745,7 @@ struct WorkChatSessionView: View {
         sending: sending && !sendWillQueue,
         settingsMutationInFlight: composerSettingMutationInFlight,
         codexFastModeOverride: pendingCodexFastMode,
+        composerDraftRestore: composerDraftRestore,
         compact: compactComposer,
         // Show Stop while a live turn has current transcript activity. The
         // broader live hint can lag after `done`; this stricter gate keeps the
@@ -1646,6 +1652,7 @@ private struct WorkChatComposerCard: View {
   let sending: Bool
   let settingsMutationInFlight: Bool
   let codexFastModeOverride: Bool?
+  let composerDraftRestore: WorkChatComposerDraftRestore?
   let compact: Bool
   /// True while the assistant is streaming a response. Swaps the Send button
   /// Desktop parity: red bordered stop control in the composer while a turn is
@@ -1673,6 +1680,7 @@ private struct WorkChatComposerCard: View {
       sending: sending,
       settingsMutationInFlight: settingsMutationInFlight,
       codexFastModeOverride: codexFastModeOverride,
+      composerDraftRestore: composerDraftRestore,
       compact: compact,
       showInterrupt: showInterrupt,
       interruptInFlight: interruptInFlight,
@@ -1710,6 +1718,7 @@ private struct WorkChatComposerDraftInput: View {
   let sending: Bool
   let settingsMutationInFlight: Bool
   let codexFastModeOverride: Bool?
+  let composerDraftRestore: WorkChatComposerDraftRestore?
   let compact: Bool
   let showInterrupt: Bool
   let interruptInFlight: Bool
@@ -1855,6 +1864,9 @@ private struct WorkChatComposerDraftInput: View {
       }
     }
     .onAppear { configureSuggestionController() }
+    .task(id: composerDraftRestore?.id) {
+      draftState.applyRestore(composerDraftRestore)
+    }
     .onChange(of: chatSummary.provider) { _, _ in configureSuggestionController() }
     .onChange(of: laneId) { _, _ in configureSuggestionController() }
   }
@@ -2105,9 +2117,20 @@ private struct WorkContextUsagePopover: View {
   }
 }
 
+struct WorkChatComposerDraftRestore: Equatable, Identifiable {
+  let id: UUID
+  let text: String
+
+  init(text: String, id: UUID = UUID()) {
+    self.id = id
+    self.text = text
+  }
+}
+
 final class WorkChatComposerDraftState: ObservableObject {
   @Published var text = ""
   @Published var isFocused = false
+  private var appliedRestoreId: UUID?
 
   var trimmedText: String {
     text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -2134,6 +2157,12 @@ final class WorkChatComposerDraftState: ObservableObject {
       }
     }
     isFocused = true
+  }
+
+  func applyRestore(_ restore: WorkChatComposerDraftRestore?) {
+    guard let restore, appliedRestoreId != restore.id else { return }
+    appliedRestoreId = restore.id
+    restoreUnsentText(restore.text)
   }
 }
 

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -209,6 +209,13 @@ enum WorkNewSessionMode: String, CaseIterable, Identifiable {
   }
 }
 
+func workQueuedNewSessionConsumesOpeningDraft(_ mode: WorkNewSessionMode) -> Bool {
+  // CLI start is atomic: its queued payload already contains initialInput.
+  // Chat creation queues only the empty session, so its separate opener must
+  // remain in the composer until the real session materializes.
+  mode == .cli
+}
+
 /// Per-project "last explicitly chosen" Chat vs CLI interface for the new-session
 /// composers. Restored as the default when the composer opens so the choice
 /// survives app restarts, project switches, and launching a session — desktop
@@ -1065,6 +1072,8 @@ struct WorkNewChatScreen: View {
     // Lane is ready; the naming/creating banner is done — the composer + nav
     // spinner carry the remaining "starting session" state.
     autoCreateStatus = nil
+    var createdChatSummary: AgentChatSessionSummary?
+    var createdChatAttachments: [AgentChatFileRef] = []
 
     do {
       if sessionMode == .cli {
@@ -1148,6 +1157,8 @@ struct WorkNewChatScreen: View {
         targetProjectRootPath: targetScope.projectRootPath,
         pendingDisplayName: opener
       )
+      createdChatSummary = summary
+      createdChatAttachments = attachmentRefs
       if attachmentRefs.isEmpty {
         await onStarted(summary, opener, false, nil, [])
       } else {
@@ -1175,16 +1186,61 @@ struct WorkNewChatScreen: View {
       }
       busy = false
       return true
-    } catch is QueuedRemoteCommandError {
+    } catch let error as QueuedRemoteCommandError {
+      if workQueuedNewSessionConsumesOpeningDraft(sessionMode) {
+        // The queued CLI start already owns `initialInput`; restoring it would
+        // invite a duplicate command when the user submits again.
+        ADEHaptics.medium()
+        errorMessage = nil
+        if let createdLaneId, let autoCreatedFallbackName {
+          startBackgroundLaneNaming(
+            laneId: createdLaneId,
+            opener: opener,
+            fallbackName: autoCreatedFallbackName
+          )
+        }
+        busy = false
+        return true
+      }
       // Offline: the create was queued and a "Pending sync" row now stands in
-      // for it on the Work list. Dismiss cleanly — not an error — and keep the
-      // (existing) lane; the queued command drains on reconnect.
+      // for it on the Work list. The opener itself was not sent, so keep the
+      // lane and return false to preserve the exact draft and attachments.
       ADEHaptics.medium()
+      errorMessage = error.localizedDescription
       busy = false
-      return true
+      return false
+    } catch let error as AmbiguousChatCreationError {
+      // The host may already have created the session. Keep its lane and draft,
+      // and let the Work list reconcile before the user chooses to retry.
+      ADEHaptics.error()
+      errorMessage = error.localizedDescription
+      busy = false
+      return false
     } catch {
       ADEHaptics.error()
       errorMessage = error.localizedDescription
+      if let createdChatSummary {
+        // Session creation succeeded, so the opener failure is ambiguous: the
+        // host may already be running it. Keep the lane/session, open the chat,
+        // mark the optimistic echo failed, and restore the exact text into the
+        // mounted composer. Never auto-resend or delete the live lane.
+        await onStarted(
+          createdChatSummary,
+          opener,
+          true,
+          "failed",
+          createdChatAttachments
+        )
+        if let createdLaneId, let autoCreatedFallbackName {
+          startBackgroundLaneNaming(
+            laneId: createdLaneId,
+            opener: opener,
+            fallbackName: autoCreatedFallbackName
+          )
+        }
+        busy = false
+        return true
+      }
       // The session never launched into a lane we just minted — tear it back
       // down so an auto-create failure doesn't leave an orphaned empty lane.
       if let createdLaneId {

--- a/apps/ios/ADE/Views/Work/WorkPreviews.swift
+++ b/apps/ios/ADE/Views/Work/WorkPreviews.swift
@@ -460,6 +460,8 @@ private enum WorkPreviewData {
       canSendMessages: true,
       sendWillQueue: false,
       sendWillQueueIsReconnect: false,
+      transportHealth: .connected,
+      composerDraftRestore: nil,
       transitionNamespace: nil,
       onOpenLane: {},
       onSend: { _, _ in true },

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
@@ -100,6 +100,7 @@ extension WorkSessionDestinationView {
         errorMessage = "Message not sent — the queue is full. Wait for the current turn to finish, then resend."
         return false
       }
+      openingDeliveryWarning = nil
       errorMessage = nil
       return true
     } catch {

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -395,6 +395,7 @@ struct WorkSessionDestinationView: View {
   @State var artifactDrawerPresented = false
   @State var sending = false
   @State var errorMessage: String?
+  @State var openingDeliveryWarning: String?
   @State var announcedLaneId: String?
   /// Lane→PR resolved asynchronously for the header overflow menu's "Open PR"
   /// item. Nil until resolved (or when the lane has no cached PR), which keeps
@@ -428,6 +429,13 @@ struct WorkSessionDestinationView: View {
   @State var canonicalTranscriptRefreshInFlight = false
   @State var handledOpeningPromptKey: String?
   @State var stagedOpeningPromptKey: String?
+  @State var composerDraftRestore: WorkChatComposerDraftRestore?
+
+  var initialOpeningPromptNeedsManualRetry: Bool {
+    initialOpeningPromptDispatchHandled
+      && initialOpeningDeliveryState == "failed"
+      && !trimmedInitialOpeningPrompt.isEmpty
+  }
 
   @MainActor
   func setTranscript(_ next: [WorkChatEnvelope]) {
@@ -899,6 +907,10 @@ struct WorkSessionDestinationView: View {
         chatSummary = initialChatSummary
         setTranscript(initialTranscript ?? [])
         seedTranscriptFromPresentationCacheIfNeeded()
+        if initialOpeningPromptNeedsManualRetry, let initialOpeningPrompt {
+          composerDraftRestore = WorkChatComposerDraftRestore(text: initialOpeningPrompt)
+          openingDeliveryWarning = SyncRequestTimeout.chatSendMessage
+        }
         stageInitialOpeningPromptEchoIfNeeded()
         await load()
         await sendInitialOpeningPromptIfNeeded()
@@ -1117,7 +1129,7 @@ struct WorkSessionDestinationView: View {
       artifactContentRenderSignature: artifactContentRenderSignature,
       artifactDrawerPresentedSnapshot: artifactDrawerPresented,
       sendingSnapshot: sending,
-      errorMessageSnapshot: errorMessage,
+      errorMessageSnapshot: errorMessage ?? openingDeliveryWarning,
       expandedToolCardIds: $expandedToolCardIds,
       artifactContent: $artifactContent,
       fullscreenImage: $fullscreenImage,
@@ -1132,6 +1144,8 @@ struct WorkSessionDestinationView: View {
       canSendMessages: canSendChatMessages && !viewingSubagent,
       sendWillQueue: sendWillQueueChatMessage || shouldSteer,
       sendWillQueueIsReconnect: sendWillQueueChatMessage,
+      transportHealth: syncService.connectionHealth.transport,
+      composerDraftRestore: composerDraftRestore,
       inputLockMessage: inputLockMessage,
       transitionNamespace: transitionNamespace,
       onOpenLane: openLaneAction,
@@ -1920,7 +1934,8 @@ struct WorkSessionDestinationView: View {
     } catch {
       ADEHaptics.error()
       localEchoMessages.removeAll { $0.id == echo.id }
-      errorMessage = "Opening message did not reach the machine. The chat exists; tap Send to retry. \(error.localizedDescription)"
+      composerDraftRestore = WorkChatComposerDraftRestore(text: prompt)
+      errorMessage = error.localizedDescription
     }
   }
 

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -1237,15 +1237,15 @@ final class ADETests: XCTestCase {
     }
   }
 
-  func testSyncRequestTimeoutUsesThirtySecondFriendlyReconnectMessage() {
+  func testSyncRequestTimeoutUsesFriendlyHealthCheckAndAmbiguousSendMessages() {
     XCTAssertEqual(SyncRequestTimeout.defaultTimeoutNanoseconds, 30_000_000_000)
     XCTAssertEqual(SyncRequestTimeout.chatSendTimeoutNanoseconds, 120_000_000_000)
     XCTAssertEqual(SyncRequestTimeout.commandTimeoutNanoseconds(for: "lanes.delete"), 240_000_000_000)
     XCTAssertEqual(SyncRequestTimeout.commandTimeoutNanoseconds(for: "lanes.rename"), 30_000_000_000)
-    XCTAssertEqual(SyncRequestTimeout.error().localizedDescription, "The machine took too long to respond. Reconnecting now.")
+    XCTAssertEqual(SyncRequestTimeout.error().localizedDescription, "The machine took too long to respond. Try again.")
     XCTAssertEqual(
       SyncRequestTimeout.error(message: SyncRequestTimeout.chatSendMessage).localizedDescription,
-      "The machine is still starting this chat turn. Live updates will keep syncing."
+      "ADE couldn't confirm whether this message started. Your draft was restored; check the transcript before sending again."
     )
   }
 
@@ -1311,6 +1311,10 @@ final class ADETests: XCTestCase {
         canSendLiveRequests: true,
         queueable: false
       )
+    )
+    XCTAssertFalse(
+      SyncAttemptedLiveFailurePolicy.preserveForManualRetry == .enqueueSafely,
+      "An ambiguous live chat send must use the manual-retry policy instead of the durable queue."
     )
   }
 
@@ -2468,6 +2472,52 @@ final class ADETests: XCTestCase {
     XCTAssertTrue(UserDefaults.standard.bool(forKey: pausedKey))
   }
 
+  @MainActor
+  func testAutomaticTransportFailureSchedulesRecoveryWithoutNavigation() {
+    let pausedKey = "ade.sync.autoReconnectPausedByUser"
+    let profileKey = "ade.sync.hostProfile"
+    let profilesKey = "ade.sync.hostProfiles"
+    UserDefaults.standard.removeObject(forKey: pausedKey)
+    UserDefaults.standard.removeObject(forKey: profileKey)
+    UserDefaults.standard.removeObject(forKey: profilesKey)
+
+    let database = makeDatabase(baseURL: makeTemporaryDirectory())
+    let service = SyncService(database: database)
+    let profile = HostConnectionProfile(
+      hostIdentity: "recovery-test-host",
+      hostName: "Recovery test Mac",
+      port: 8787,
+      authKind: "paired",
+      pairedDeviceId: "recovery-test-phone",
+      lastRemoteDbVersion: 0,
+      lastHostDeviceId: "recovery-test-host",
+      lastSuccessfulAddress: "127.0.0.1",
+      savedAddressCandidates: ["127.0.0.1"],
+      discoveredLanAddresses: ["127.0.0.1"],
+      tailscaleAddress: nil
+    )
+    service.configureReconnectProfileForTesting(profile, token: "recovery-test-token")
+    defer {
+      service.disconnect()
+      service.clearReconnectProfileForTesting(profile)
+      database.close()
+      UserDefaults.standard.removeObject(forKey: pausedKey)
+      UserDefaults.standard.removeObject(forKey: profileKey)
+      UserDefaults.standard.removeObject(forKey: profilesKey)
+    }
+
+    service.simulateAutomaticTransportFailureForTesting(
+      NSError(
+        domain: NSURLErrorDomain,
+        code: NSURLErrorNetworkConnectionLost,
+        userInfo: [NSLocalizedDescriptionKey: "Connection lost"]
+      )
+    )
+
+    XCTAssertEqual(service.connectionState, .connecting)
+    XCTAssertTrue(service.hasScheduledReconnectWorkForTesting())
+  }
+
   func testSyncMessageTooLongTransportFailureForcesErrorState() {
     let fatalError = NSError(
       domain: "ADE",
@@ -2482,17 +2532,6 @@ final class ADETests: XCTestCase {
 
     XCTAssertEqual(syncConnectionStateAfterTransportFailure(error: fatalError, fallback: .connecting), .error)
     XCTAssertEqual(syncConnectionStateAfterTransportFailure(error: transientError, fallback: .connecting), .connecting)
-  }
-
-  func testSyncRequestTimeoutWithoutInboundTrafficPublishesReconnectingState() {
-    XCTAssertEqual(
-      syncConnectionStateAfterRequestTimeout(lastInboundMessageAt: nil, fallback: .error),
-      .connecting
-    )
-    XCTAssertEqual(
-      syncConnectionStateAfterRequestTimeout(lastInboundMessageAt: 42, fallback: .error),
-      .error
-    )
   }
 
   func testSyncClientHeartbeatUsesHalfServerIntervalWithBounds() {
@@ -8961,6 +9000,17 @@ final class ADETests: XCTestCase {
     // switcher tap persists a mode).
     XCTAssertEqual(WorkNewSessionModePreferences.load(projectId: "proj-a"), .chat)
     XCTAssertEqual(WorkNewSessionModePreferences.load(projectId: "proj-b"), .cli)
+  }
+
+  func testQueuedCliOpenerIsConsumedWhileQueuedChatOpenerIsRestored() {
+    XCTAssertTrue(
+      workQueuedNewSessionConsumesOpeningDraft(.cli),
+      "A queued CLI start already contains initialInput and must not restore it for duplicate submission."
+    )
+    XCTAssertFalse(
+      workQueuedNewSessionConsumesOpeningDraft(.chat),
+      "A queued chat.create does not contain the separate opener, so the draft must remain."
+    )
   }
 
   func testWorkComposerRuntimeProviderCoercesLocalOpenCodeGroups() {
@@ -18540,6 +18590,24 @@ final class LinearPaneTests: XCTestCase {
     }
     let deleted = await spy.deletedLaneIds
     XCTAssertTrue(deleted.isEmpty, "Queued launches must keep the lane for reconnect drain")
+  }
+
+  func testRunLinearLaunchKeepsLaneWhenLiveChatLaunchIsAmbiguous() async {
+    let spy = LinearLaunchSpy()
+    let ambiguous = AmbiguousChatCreationError(underlyingError: SyncRequestTimeout.error())
+    let deps = makeDeps(spy: spy, chat: { throw ambiguous })
+
+    do {
+      _ = try await runLinearLaunch(issue: makeIssue(), config: makeConfig(.chat), deps: deps)
+      XCTFail("Expected the ambiguous launch to surface.")
+    } catch is LinearAmbiguousAgentLaunchError {
+      // Expected: callers can explain the uncertainty without deleting lane1.
+    } catch {
+      XCTFail("Expected an ambiguous agent launch error, got \(error)")
+    }
+
+    let deleted = await spy.deletedLaneIds
+    XCTAssertTrue(deleted.isEmpty, "Ambiguous live launches must keep the lane for host reconciliation.")
   }
 
   func testRunLinearLaunchSurfacesQueuedLaneCreationBeforeAgentLaunch() async {

--- a/apps/ios/ADETests/SyncRecoveryPolicyTests.swift
+++ b/apps/ios/ADETests/SyncRecoveryPolicyTests.swift
@@ -1,0 +1,462 @@
+import XCTest
+@testable import ADE
+
+final class SyncRecoveryPolicyTests: XCTestCase {
+  private let connectionDefaultsKeys = [
+    "ade.sync.hostProfile",
+    "ade.sync.hostProfiles",
+    "ade.sync.connectionDraft",
+    "ade.sync.autoReconnectPausedByUser",
+    "ade.sync.activeProjectHostIdentity",
+    "ade.sync.remoteCommandDescriptors",
+  ]
+
+  private func snapshotDefaults(keys: [String]) -> [String: Any] {
+    keys.reduce(into: [String: Any]()) { snapshot, key in
+      if let value = UserDefaults.standard.object(forKey: key) {
+        snapshot[key] = value
+      }
+    }
+  }
+
+  private func restoreDefaults(_ snapshot: [String: Any], keys: [String]) {
+    for key in keys {
+      UserDefaults.standard.removeObject(forKey: key)
+      if let value = snapshot[key] {
+        UserDefaults.standard.set(value, forKey: key)
+      }
+    }
+  }
+
+  private func makeReconnectProfile(hostIdentity: String) -> HostConnectionProfile {
+    HostConnectionProfile(
+      hostIdentity: hostIdentity,
+      hostName: "Mac Studio",
+      port: 8787,
+      authKind: "paired",
+      pairedDeviceId: nil,
+      lastRemoteDbVersion: 0,
+      lastHostDeviceId: hostIdentity,
+      lastSuccessfulAddress: "127.0.0.1",
+      savedAddressCandidates: ["127.0.0.1"],
+      discoveredLanAddresses: ["127.0.0.1"],
+      tailscaleAddress: nil
+    )
+  }
+
+  func testLiveChatCreationTimeoutIsAmbiguousAndNeverReplayedAutomatically() async {
+    do {
+      let _: AgentChatSessionSummary = try await performLiveChatCreationWithoutReplay {
+        throw SyncRequestTimeout.error()
+      }
+      XCTFail("Expected the timed-out live chat creation to remain ambiguous.")
+    } catch let error as AmbiguousChatCreationError {
+      XCTAssertTrue(isSyncRequestTimeoutError(error.underlyingError))
+    } catch {
+      XCTFail("Expected an ambiguous delivery error, got \(error)")
+    }
+  }
+
+  func testLiveChatCreationPreservesDefinitiveHostRejection() async {
+    let rejection = NSError(
+      domain: "ADE",
+      code: 17,
+      userInfo: [
+        NSLocalizedDescriptionKey: "Model unavailable.",
+        "ADEErrorCode": "model_unavailable",
+      ]
+    )
+
+    do {
+      let _: AgentChatSessionSummary = try await performLiveChatCreationWithoutReplay {
+        throw rejection
+      }
+      XCTFail("Expected the host rejection to be preserved.")
+    } catch is AmbiguousChatCreationError {
+      XCTFail("A definitive host rejection must not be marked ambiguous.")
+    } catch {
+      XCTAssertEqual((error as NSError).userInfo["ADEErrorCode"] as? String, "model_unavailable")
+    }
+  }
+
+  func testRequestTimeoutRecoveryProbesOnlyAfterSilence() {
+    XCTAssertEqual(
+      syncRequestTimeoutRecoveryAction(
+        disconnectOnTimeout: true,
+        now: 100,
+        lastInboundMessageAt: 94,
+        silenceThreshold: 12
+      ),
+      .failRequestOnly
+    )
+    XCTAssertEqual(
+      syncRequestTimeoutRecoveryAction(
+        disconnectOnTimeout: true,
+        now: 100,
+        lastInboundMessageAt: 80,
+        silenceThreshold: 12
+      ),
+      .probeTransport
+    )
+    XCTAssertEqual(
+      syncRequestTimeoutRecoveryAction(
+        disconnectOnTimeout: false,
+        now: 100,
+        lastInboundMessageAt: nil,
+        silenceThreshold: 12
+      ),
+      .failRequestOnly
+    )
+  }
+
+  func testTransportProbeAllowsMoreTimeOnExpensiveAndConstrainedPaths() {
+    XCTAssertEqual(syncTransportProbeTimeoutNanoseconds(isExpensive: false, isConstrained: false), 5_000_000_000)
+    XCTAssertEqual(syncTransportProbeTimeoutNanoseconds(isExpensive: true, isConstrained: false), 8_000_000_000)
+    XCTAssertEqual(syncTransportProbeTimeoutNanoseconds(isExpensive: true, isConstrained: true), 12_000_000_000)
+  }
+
+  func testHeartbeatSilenceProbeIsTolerantOfExpensiveAndConstrainedPaths() {
+    XCTAssertEqual(
+      syncHeartbeatSilenceThresholdSeconds(
+        heartbeatIntervalNanoseconds: 15_000_000_000,
+        isExpensive: false,
+        isConstrained: false
+      ),
+      30
+    )
+    XCTAssertEqual(
+      syncHeartbeatSilenceThresholdSeconds(
+        heartbeatIntervalNanoseconds: 15_000_000_000,
+        isExpensive: true,
+        isConstrained: false
+      ),
+      45
+    )
+    XCTAssertEqual(
+      syncHeartbeatSilenceThresholdSeconds(
+        heartbeatIntervalNanoseconds: 25_000_000_000,
+        isExpensive: true,
+        isConstrained: true
+      ),
+      100
+    )
+    XCTAssertFalse(
+      syncShouldProbeTransportAfterHeartbeatSilence(
+        now: 159,
+        lastInboundMessageAt: 100,
+        heartbeatIntervalNanoseconds: 15_000_000_000,
+        isExpensive: true,
+        isConstrained: true
+      )
+    )
+    XCTAssertTrue(
+      syncShouldProbeTransportAfterHeartbeatSilence(
+        now: 160,
+        lastInboundMessageAt: 100,
+        heartbeatIntervalNanoseconds: 15_000_000_000,
+        isExpensive: true,
+        isConstrained: true
+      )
+    )
+  }
+
+  func testReconnectStateExhaustionOpensOneQuietHeartbeatAttempt() {
+    var state = SyncReconnectState()
+
+    for _ in 0..<SyncReconnectState.maxAutomaticAttempts {
+      _ = state.nextDelayNanoseconds()
+    }
+    XCTAssertTrue(state.isExhausted)
+
+    state.allowOneSlowAttempt()
+    XCTAssertFalse(state.isExhausted)
+    _ = state.nextDelayNanoseconds()
+    XCTAssertTrue(state.isExhausted)
+  }
+
+  func testReconnectJitterStaysBoundedAndDeterministic() {
+    XCTAssertEqual(syncJitteredReconnectDelayNanoseconds(base: 10_000, sample: 0), 8_000)
+    XCTAssertEqual(syncJitteredReconnectDelayNanoseconds(base: 10_000, sample: 0.5), 10_000)
+    XCTAssertEqual(syncJitteredReconnectDelayNanoseconds(base: 10_000, sample: 1), 12_000)
+    XCTAssertEqual(syncJitteredReconnectDelayNanoseconds(base: 10_000, sample: -1), 8_000)
+    XCTAssertEqual(syncJitteredReconnectDelayNanoseconds(base: 10_000, sample: 2), 12_000)
+  }
+
+  func testPathHandoffSkipsStaleResetOfNewHealthySocket() {
+    XCTAssertEqual(
+      syncNetworkPathRecoveryAction(
+        shouldRoamToTailnet: true,
+        isPathSatisfied: true,
+        hasLiveConnection: true
+      ),
+      .scheduleForcedReset
+    )
+    XCTAssertEqual(
+      syncNetworkPathRecoveryAction(
+        shouldRoamToTailnet: false,
+        isPathSatisfied: true,
+        hasLiveConnection: true
+      ),
+      .cancelScheduledReconnect
+    )
+    XCTAssertEqual(
+      syncNetworkPathRecoveryAction(
+        shouldRoamToTailnet: false,
+        isPathSatisfied: true,
+        hasLiveConnection: false
+      ),
+      .scheduleReconnect
+    )
+    XCTAssertEqual(
+      syncScheduledPathReconnectAction(
+        forceSocketReset: true,
+        scheduledConnectionGeneration: 4,
+        currentConnectionGeneration: 4,
+        hasLiveConnection: true
+      ),
+      .resetAndReconnect
+    )
+    XCTAssertEqual(
+      syncScheduledPathReconnectAction(
+        forceSocketReset: true,
+        scheduledConnectionGeneration: 4,
+        currentConnectionGeneration: 5,
+        hasLiveConnection: true
+      ),
+      .skip
+    )
+    XCTAssertEqual(
+      syncScheduledPathReconnectAction(
+        forceSocketReset: true,
+        scheduledConnectionGeneration: 4,
+        currentConnectionGeneration: 5,
+        hasLiveConnection: false
+      ),
+      .reconnect
+    )
+  }
+
+  func testEstablishedSocketCompletionUsesRecoveryOwnerWithoutRacingOpenOrHandshake() {
+    XCTAssertEqual(
+      syncSocketCompletionAction(
+        isCurrentSocket: true,
+        completedWhileOpening: false,
+        canSendLiveRequests: true,
+        closeCodeRawValue: 4001
+      ),
+      .recoverTransport(closeCodeRawValue: 4001)
+    )
+    XCTAssertEqual(
+      syncSocketCompletionAction(
+        isCurrentSocket: true,
+        completedWhileOpening: true,
+        canSendLiveRequests: false,
+        closeCodeRawValue: 4001
+      ),
+      .failOpening
+    )
+    XCTAssertEqual(
+      syncSocketCompletionAction(
+        isCurrentSocket: true,
+        completedWhileOpening: false,
+        canSendLiveRequests: false,
+        closeCodeRawValue: nil
+      ),
+      .failHandshake
+    )
+    XCTAssertEqual(
+      syncSocketCompletionAction(
+        isCurrentSocket: false,
+        completedWhileOpening: false,
+        canSendLiveRequests: true,
+        closeCodeRawValue: 4001
+      ),
+      .ignore
+    )
+  }
+
+  @MainActor
+  func testAttemptedLiveChatSendTimeoutNeverEntersDurableQueue() async throws {
+    let pendingOperationsKey = "ade.sync.pendingOperations"
+    let pendingSnapshot = snapshotDefaults(keys: [pendingOperationsKey])
+    UserDefaults.standard.removeObject(forKey: pendingOperationsKey)
+    let baseURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+    let database = DatabaseService(baseURL: baseURL)
+    let service = SyncService(database: database)
+    service.beginOutboundEnvelopeCaptureForTesting()
+    service.configureConnectedTransportForTesting()
+    defer {
+      service.endOutboundEnvelopeCaptureForTesting()
+      service.disconnect(clearCredentials: false)
+      restoreDefaults(pendingSnapshot, keys: [pendingOperationsKey])
+      database.close()
+      try? FileManager.default.removeItem(at: baseURL)
+    }
+
+    let sendTask = Task {
+      try await service.sendChatMessage(sessionId: "chat-timeout", text: "Do this once")
+    }
+    var requestId: String?
+    for _ in 0..<10 where requestId == nil {
+      await Task.yield()
+      requestId = service.capturedOutboundRequestIdsForTesting(type: "command").first
+    }
+    service.firePendingRequestTimeoutForTesting(requestId: try XCTUnwrap(requestId))
+
+    do {
+      _ = try await sendTask.value
+      XCTFail("Expected the attempted live chat send to time out ambiguously.")
+    } catch {
+      XCTAssertTrue(isSyncRequestTimeoutError(error))
+    }
+    XCTAssertTrue(service.pendingOperationsForTesting().isEmpty)
+    XCTAssertEqual(service.pendingOperationCount, 0)
+  }
+
+  @MainActor
+  func testTransportProbeSuccessKeepsSocketWhileFailureSchedulesSingleRecoveryOwner() throws {
+    let defaultsSnapshot = snapshotDefaults(keys: connectionDefaultsKeys)
+    let baseURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+    let database = DatabaseService(baseURL: baseURL)
+    let service = SyncService(database: database)
+    let profile = makeReconnectProfile(hostIdentity: "probe-owner-host")
+    service.beginOutboundEnvelopeCaptureForTesting()
+    service.configureConnectedTransportForTesting()
+    service.configureReconnectProfileForTesting(profile, token: "probe-owner-token")
+    defer {
+      service.endOutboundEnvelopeCaptureForTesting()
+      service.disconnect(clearCredentials: false)
+      service.clearReconnectProfileForTesting(profile)
+      restoreDefaults(defaultsSnapshot, keys: connectionDefaultsKeys)
+      database.close()
+      try? FileManager.default.removeItem(at: baseURL)
+    }
+
+    let healthyGeneration = service.connectionGenerationForTesting()
+    service.completeTransportProbeForTesting(heardInboundTraffic: true)
+    XCTAssertEqual(service.connectionState, .connected)
+    XCTAssertEqual(service.connectionGenerationForTesting(), healthyGeneration)
+    XCTAssertFalse(service.hasScheduledReconnectWorkForTesting())
+
+    service.completeTransportProbeForTesting(heardInboundTraffic: false)
+    XCTAssertEqual(service.connectionState, .connecting)
+    XCTAssertGreaterThan(service.connectionGenerationForTesting(), healthyGeneration)
+    XCTAssertTrue(service.hasScheduledReconnectWorkForTesting())
+  }
+
+  @MainActor
+  func testFastBudgetExhaustionPublishesUnreachableAndArmsQuietHeartbeat() throws {
+    let defaultsSnapshot = snapshotDefaults(keys: connectionDefaultsKeys)
+    let baseURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+    let database = DatabaseService(baseURL: baseURL)
+    let service = SyncService(database: database)
+    let profile = makeReconnectProfile(hostIdentity: "slow-heartbeat-host")
+    service.configureReconnectProfileForTesting(profile, token: "slow-heartbeat-token")
+    defer {
+      service.disconnect(clearCredentials: false)
+      service.clearReconnectProfileForTesting(profile)
+      restoreDefaults(defaultsSnapshot, keys: connectionDefaultsKeys)
+      database.close()
+      try? FileManager.default.removeItem(at: baseURL)
+    }
+
+    service.exhaustFastReconnectBudgetForTesting(
+      NSError(
+        domain: NSURLErrorDomain,
+        code: NSURLErrorCannotConnectToHost,
+        userInfo: [NSLocalizedDescriptionKey: "Host unavailable."]
+      )
+    )
+
+    XCTAssertEqual(service.connectionState, .error)
+    XCTAssertEqual(service.connectionHealth.transport, .unreachable)
+    XCTAssertTrue(service.hasScheduledReconnectWorkForTesting())
+  }
+
+  @MainActor
+  func testHealthyForegroundDoesNotRebuildSocketOrReplayChatSubscriptions() async throws {
+    let baseURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+    let database = DatabaseService(baseURL: baseURL)
+    let service = SyncService(database: database)
+    service.beginOutboundEnvelopeCaptureForTesting()
+    service.configureConnectedTransportForTesting()
+    service.completeCapturedRefreshRequestsForTesting()
+    service.resetOutboundEnvelopeCaptureForTesting()
+    defer {
+      service.endOutboundEnvelopeCaptureForTesting()
+      service.disconnect(clearCredentials: false)
+      database.close()
+      try? FileManager.default.removeItem(at: baseURL)
+    }
+
+    let generation = service.connectionGenerationForTesting()
+    await service.handleForegroundTransition()
+
+    XCTAssertEqual(service.connectionState, .connected)
+    XCTAssertEqual(service.connectionGenerationForTesting(), generation)
+    XCTAssertFalse(service.hasScheduledReconnectWorkForTesting())
+    XCTAssertEqual(service.capturedOutboundEnvelopeCountForTesting(type: "chat_subscribe"), 0)
+  }
+
+  @MainActor
+  func testHelloReducedLoadTransitionRestoresEachChatSubscriptionOnce() async throws {
+    let defaultsSnapshot = snapshotDefaults(keys: connectionDefaultsKeys)
+    let baseURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+    let database = DatabaseService(baseURL: baseURL)
+    let service = SyncService(database: database)
+    let testProfile = makeReconnectProfile(hostIdentity: "host-subscribe-once")
+    service.beginOutboundEnvelopeCaptureForTesting()
+    service.configureConnectedTransportForTesting()
+    defer {
+      service.endOutboundEnvelopeCaptureForTesting()
+      service.disconnect(clearCredentials: false)
+      service.clearReconnectProfileForTesting(testProfile)
+      restoreDefaults(defaultsSnapshot, keys: connectionDefaultsKeys)
+      database.close()
+      try? FileManager.default.removeItem(at: baseURL)
+    }
+
+    service.setNetworkPathForTesting(
+      usesWiFi: true,
+      usesCellular: false,
+      usesWiredEthernet: false
+    )
+    let helloPayload: [String: Any] = [
+      "brain": [
+        "deviceId": "host-subscribe-once",
+        "deviceName": "Mac Studio",
+      ],
+      "features": [
+        "chatStreaming": true,
+      ],
+    ]
+    try service.applyHelloPayloadForTesting(helloPayload)
+    try await service.subscribeToChatEvents(sessionId: "chat-1")
+
+    service.resetOutboundEnvelopeCaptureForTesting()
+    service.setNetworkPathForTesting(
+      usesWiFi: false,
+      usesCellular: true,
+      usesWiredEthernet: false,
+      isExpensive: true,
+      isConstrained: true
+    )
+    try service.applyHelloPayloadForTesting(helloPayload)
+
+    XCTAssertEqual(
+      service.capturedOutboundEnvelopeCountForTesting(type: "chat_subscribe"),
+      1,
+      "Hello must own one subscription replay even when route load mode changes."
+    )
+  }
+}

--- a/apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift
+++ b/apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift
@@ -185,6 +185,29 @@ final class WorkComposerTriggerDetectorTests: XCTestCase {
   }
 
   @MainActor
+  func testAmbiguousOpeningPromptRestoresOnceIntoMountedComposer() {
+    let draft = WorkChatComposerDraftState()
+    let restore = WorkChatComposerDraftRestore(
+      text: "Check whether this already started",
+      id: UUID()
+    )
+
+    draft.applyRestore(restore)
+    XCTAssertEqual(draft.text, "Check whether this already started")
+    XCTAssertTrue(draft.isFocused)
+
+    XCTAssertEqual(draft.consumeSendableText(), "Check whether this already started")
+    draft.applyRestore(restore)
+    XCTAssertEqual(draft.text, "", "The same restoration token must not refill a draft after the user sends it.")
+
+    draft.applyRestore(WorkChatComposerDraftRestore(
+      text: "A later unconfirmed send",
+      id: UUID()
+    ))
+    XCTAssertEqual(draft.text, "A later unconfirmed send")
+  }
+
+  @MainActor
   func testChatComposerDefersAndCoalescesRequestedFocusTransitions() async {
     let draft = WorkChatComposerDraftState()
     let controller = WorkComposerSuggestionController()

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -1189,9 +1189,11 @@ feature is merged or because a deliberately isolated-port host is running.
   rows, plus rows for tables that no longer exist locally, before
   opening the apply transaction. A batch that contains only ignored
   tables is a no-op and preserves the local database version.
-- **Controller command queues replay on reconnect and on live-send
-  timeouts.** If the runtime advertises `chat.send` as queueable and the user
-  sends while the desktop is reconnecting, or the send request times out while
-  the socket still appears connected, the iOS app stores the command locally
-  with a queued delivery state and replays it with the same `commandId`. Do not
-  assume synchronous semantics from the phone side.
+- **Controller command queues replay on reconnect, but an attempted live chat
+  send is ambiguity-sensitive.** If the runtime advertises `chat.send` as
+  queueable and the user submits while already offline, iOS stores the command
+  locally and replays it with the same `commandId`. After a live `chat.send` was
+  attempted, however, a timeout or transport loss does not prove that the host
+  failed to start the turn. iOS therefore does not queue or resend that message:
+  it restores the draft and asks the user to check the transcript before a
+  manual retry. Do not assume synchronous semantics from the phone side.

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -129,6 +129,8 @@ apps/ios/
 │   │   │                             # aggregate "agent runs" activity
 │   │   ├── MobileUsageQuotaStore.swift # host-scoped cached Claude/Codex
 │   │   │                               # quota snapshot + refresh state
+│   │   ├── SyncRecoveryPolicy.swift # deterministic reconnect, path-change,
+│   │   │                            # heartbeat-silence, and timeout policy
 │   │   ├── Dictation/               # SpeechDictationService,
 │   │   │                            # DictationController, deterministic
 │   │   │                            # cleanup, VoiceGlossary loader
@@ -494,7 +496,8 @@ incoming changeset.
 
 ## Sync service
 
-Source: `apps/ios/ADE/Services/SyncService.swift`.
+Sources: `apps/ios/ADE/Services/SyncService.swift` and
+`apps/ios/ADE/Services/SyncRecoveryPolicy.swift`.
 
 ### Connection lifecycle
 
@@ -533,9 +536,12 @@ Source: `apps/ios/ADE/Services/SyncService.swift`.
    relay kill-switch, and the phone clears its saved relay routes).
    When the ACTIVE connection is a relay route, the Settings connection
    header shows one quiet line: "Using ADE relay. For faster, more
-   stable sync, connect both devices with Tailscale." `reconnectIfPossible` is guarded so overlapping
-   wake-ups never stack TCP/WebSocket attempts, and a reconnect never
-   tears down an already-live connection. The socket declares the
+   stable sync, connect both devices with Tailscale." `reconnectIfPossible` is
+   the single connection-attempt owner: socket delegate failures, path changes,
+   foreground return, heartbeat silence, and failed liveness probes all
+   converge there. Overlapping wake-ups are coalesced, delayed path tasks carry
+   a connection-generation guard, and an automatic reconnect never tears down
+   an already-live connection. The socket declares the
    `chunkedEnvelopes` capability and sets a 32 MiB
    `maximumMessageSize` receive budget.
    An `auth_failed` hello rejection drops the saved pairing **only**
@@ -564,13 +570,19 @@ Source: `apps/ios/ADE/Services/SyncService.swift`.
    in detached tasks (the SQLite connection is FULLMUTEX). The receive
    loop awaits frames in order, so application order is unchanged —
    the UI just never freezes under sync load.
-7. On transport disconnect: a fast exponential-backoff reconnect burst,
-   then an indefinite ~30 s slow-heartbeat retry loop. The phone never
-   permanently gives up — a paired machine that comes back minutes
-   later reconnects without the user touching anything. User-initiated
-   disconnects from Settings (including the connecting-state Cancel
-   button) cancel scheduled reconnect work and leave the phone in the
-   disconnected state until the user reconnects or pairs again.
+7. On transport disconnect: run a finite seven-attempt fast burst with
+   1 s -> 16 s exponential backoff and jitter. During that window the
+   connection health remains `connecting`, cached chat content stays mounted,
+   and the composer reports that the draft is safe. Exhausting the burst moves
+   the UI to `unreachable`, but an indefinite quiet 30-40 s heartbeat keeps
+   trying one route budget at a time. A paired machine that comes back minutes
+   later therefore reconnects without navigation or a user tap. A successful
+   hello restores the active project, chat and terminal subscriptions, tracked
+   lane presence, and pending safe operations without rebuilding the current
+   navigation stack. User-initiated disconnects from Settings (including the
+   connecting-state Cancel button) cancel scheduled reconnect work and leave
+   the phone in the disconnected state until the user reconnects or pairs
+   again.
 8. After pairing completes, the phone announces currently-open lanes
    via `lanes.presence.announce` so the runtime decorates
    `LaneSummary.devicesOpen` for other controllers; the phone calls
@@ -625,19 +637,22 @@ turns a raw response dict into either the `result` value or throws an
 
 - All synced state is available offline from the local DB.
 - Execution commands queue locally and replay on reconnect. Queueable commands
-  also enter the local queue when a send times out while the WebSocket still
-  appears connected; the phone keeps the same `commandId`, schedules a short
-  retry, and probes the transport instead of dropping the user's action. The
-  runtime deduplicates retried commands by `commandId` through a TTL'd cache +
-  persisted journal, so a replay returns the cached `command_ack` /
-  `command_result` instead of running twice.
+  normally also enter the local queue when a send times out while the WebSocket
+  still appears connected; the phone keeps the same `commandId` and probes the
+  transport instead of dropping the user's action. The runtime deduplicates
+  retried commands by `commandId` through a TTL'd cache + persisted journal, so
+  a replay returns the cached `command_ack` / `command_result` instead of
+  running twice. An attempted live `chat.send` is the exception: its outcome is
+  ambiguous, so iOS restores the draft for manual retry rather than enqueueing
+  an automatic replay that could duplicate a turn.
 - A `command_result` with `error.code: "host_unavailable"` (the brain-level
   ingress answering while the project sync host is restarting — see
   `remote-commands.md`) is treated exactly like a timeout, never like an
-  application rejection: `isSyncHostUnavailableError` makes it retryable and
-  queueable, and the queue-drain loop **keeps** a pending operation that hits
-  it so queued work survives host restarts instead of being deleted on
-  replay.
+  application rejection: `isSyncHostUnavailableError` makes it retryable, and
+  the queue-drain loop **keeps** a pending operation that hits it so queued work
+  survives host restarts instead of being deleted on replay. The same
+  attempted-live-chat exception applies here: preserve the draft instead of
+  creating a new queued replay after the host may already have started it.
 - **Offline chat creation shows a "Pending sync" row.** `chat.create` is
   not host-advertised as queueable while disconnected, so when the phone
   can't send a live request it explicitly enqueues the create with a
@@ -649,20 +664,22 @@ turns a raw response dict into either the `result` value or throws an
   Work list folds into its optimistic sessions so the new chat appears
   immediately; the row is not openable until the queued `chat.create`
   drains after reconnect and the real session id arrives, at which point
-  the pending snapshot is removed.
+  the pending snapshot is removed. The queued create contains only the empty
+  session; its separate opening prompt and attachments remain in the composer
+  and are not sent automatically after reconnect.
 - UI shows "pending sync" indicators for queued actions.
 
 ### Timeouts
 
 `SyncRequestTimeout.defaultTimeoutNanoseconds = 30_000_000_000` (30s).
 Timed-out requests throw with the message *"The machine took too long to
-respond. Reconnecting now."* Chat send commands (`chat.send` and the
-mobile CLI launchers) use an extended budget
+respond. Try again."* `chat.send` uses an extended budget
 `SyncRequestTimeout.chatSendTimeoutNanoseconds = 120_000_000_000` (120s)
-with the friendlier message *"The machine is still starting this chat
-turn. Live updates will keep syncing."* because warmup-heavy turns
-routinely outlast the 30 s default without indicating a transport
-failure.
+with the ambiguity-safe message *"ADE couldn't confirm whether this message
+started. Your draft was restored; check the transcript before sending
+again."* Warmup-heavy turns can outlast the 30 s default without indicating a
+transport failure, and a missing `command_result` does not prove the host
+failed to start the turn.
 
 A request timeout no longer unconditionally drops the connection. Inbound
 traffic on the WebSocket is timestamped via `lastInboundMessageAt`
@@ -676,9 +693,11 @@ phone keeps the connection and lets the user retry. Even when the
 connection has been silent for the full window, the phone does not
 tear down immediately: it fails the request, marks the connection
 load-strained, and runs an **active transport probe**
-(`verifyTransportAliveAfterRequestTimeout` — ping the host and wait
-briefly for any inbound traffic). Only a probe that hears nothing
-back triggers the normal transport-failure teardown. This avoids
+(`verifyTransportAliveAfterSilence` — ping the host and wait 5 s on an
+ordinary path, 8 s on an expensive path, or 12 s on a constrained path for any
+inbound traffic). Heartbeat silence uses the same coalesced probe, and only a
+probe that hears nothing back triggers the normal transport-failure teardown.
+This avoids
 cycling a healthy-but-slow connection (catalog/PR refreshes can take
 30 s+ on cellular) into a perpetual timeout→reconnect→re-request
 loop.
@@ -1438,16 +1457,26 @@ different machine's cached limits.
   command handlers on the runtime responsive; bulk operations should
   be batched into a single command with a single reply rather than
   rapid-fire command storms.
-- **A request timeout is not the same as a dead connection.** The 30 s
-  `SyncRequestTimeout` never tears the socket down directly. If
+- **A request timeout is not the same as a dead connection.** The default 30 s
+  `SyncRequestTimeout` (120 s for `chat.send`) never tears the socket down
+  directly. If
   anything has arrived on the WebSocket within the 12 s
   `requestTimeoutReconnectSilenceSeconds` window (heartbeats, change
   batches, a result), the timeout surfaces to the caller and nothing
-  else happens. If the socket has been fully silent, the phone runs an
+  else happens. If the socket has been fully silent, the phone runs the shared
   active transport probe and tears down only when the probe also hears
-  nothing. New transport-affecting code should bump
+  nothing. The probe waits 5 s on ordinary paths, 8 s on expensive paths, and
+  12 s on constrained paths. Heartbeat silence enters the same probe instead
+  of opening a second recovery loop. New transport-affecting code should bump
   `lastInboundMessageAt` on inbound traffic and treat that timestamp
   as the source of truth for "is this connection actually alive".
+- **An attempted live chat send is never replayed automatically after an
+  ambiguous failure.** The runtime may have started the turn even when the
+  command result times out or the socket closes. iOS restores the exact text to
+  the mounted composer, marks any optimistic echo failed, and asks the user to
+  check the transcript before sending again. Messages composed while already
+  offline may still enter the existing queue with a stable `commandId`; this
+  special case applies only after a live `chat.send` was attempted.
 - **Connection UI must use `SyncConnectionHealth`, not the raw state.**
   `RemoteConnectionState.syncing` is just transport `connected` doing
   catchup work, and `RemoteConnectionState.error` carries failure text

--- a/docs/features/sync-and-multi-device/remote-commands.md
+++ b/docs/features/sync-and-multi-device/remote-commands.md
@@ -106,10 +106,12 @@ host is restarting, or was blocked by a conflicting sync listener),
 `brainProjectActionsSyncHandler` answers immediately with a failed
 `command_result` carrying that code instead of silently dropping the
 command into a 30 s client timeout. The state is transient by
-definition, so controllers must treat it like a timeout: iOS marks it
-retryable and queueable (`isSyncHostUnavailableError`), and queued
-operations are preserved — not deleted — when a replay hits it during
-a host restart window.
+definition, so controllers treat it like a timeout: iOS marks it retryable
+(`isSyncHostUnavailableError`), and queued operations are preserved — not
+deleted — when a replay hits it during a host restart window. Queueable actions
+normally enter the offline queue, but an already-attempted live `chat.send` is
+the deliberate exception because its outcome is ambiguous; iOS restores the
+draft for a manual transcript-aware retry instead of risking a duplicate turn.
 
 Controllers read `SyncRemoteCommandDescriptor`s from the brain (via the
 `getSupportedActions` / `getDescriptors` surface) and gate UI
@@ -642,7 +644,10 @@ can be sensitive.
   (a plain new-turn send still returns just `{ ok: true }`; a steer queue
   already at its cap comes back `queued: false, reason: "queue_full"`). The extra fields are additive — older
   clients ignore them, and the phone uses them to reconcile the message it
-  echoed optimistically. Personal chat uses the same
+  echoed optimistically. If a live send times out or loses transport before the
+  acknowledgement arrives, the phone treats delivery as ambiguous: it does not
+  enqueue an automatic replay, restores the draft, and leaves transcript
+  reconciliation to show whether the host started the turn. Personal chat uses the same
   envelopes but sends `chatScope: "personal"`; that explicit discriminator
   resolves the hidden durable transcript and active-turn state without a
   `projectId`.


### PR DESCRIPTION
## Summary

- Makes iOS chat recovery service-owned so an already-mounted chat reconnects after transport loss or Wi-Fi/cellular handoff without hub navigation.
- Health-gates request timeouts: recent inbound traffic keeps the socket alive; silent sockets get one bounded liveness probe before entering the existing reconnect owner.
- Preserves active project state, chat and terminal subscriptions, cached transcript content, composer drafts, and safe pending operations across recovery.

## Recovery guarantees

- WebSocket close/completion, path changes, heartbeat silence, foreground return, and failed probes converge on one coalesced reconnect path.
- Connection-generation and cancellation guards prevent stale path tasks or socket callbacks from tearing down a newer connection.
- Seven jittered exponential fast retries transition to honest unreachable state plus a quiet slow heartbeat.
- Constrained and expensive paths use longer probe/silence thresholds and keep reduced-load behavior.
- Ambiguous live chat sends and chat creation are never automatically replayed; drafts remain available for manual reconciliation.
- Foregrounding a healthy connection does not rebuild the socket or duplicate chat subscriptions.
- Existing authentication, DPoP, route ranking, loopback nonce validation, and pairing safeguards remain intact.

## Verification

- /quality: no remaining Blocker, High, or Medium findings.
- /test: mobile, docs, CLI, and TUI parity complete.
- iOS recovery and pairing selection: 49 of 49 passed.
- Final recovery suite after review fixes: 14 of 14 passed.
- Simulator build passed using the existing iPhone 17 Pro, existing DerivedData, and parallel testing disabled.
- Swift parse, git diff check, and documentation validation passed.
- TUI: 47 files and 875 tests passed.
- No beta packaging, TestFlight flow, or deployment was run.

## Proof and residual risk

The existing simulator was not paired to a machine, so a live mounted-chat Reconnecting to Connected recording was not possible without creating new pairing state. ADE proof artifact 2c01e139-9183-4c19-955a-61b6b1cd5344 records that constraint; deterministic service tests cover the transition and duplicate-safety contracts.

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fmobile-connection-68971fa2 num=824 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fmobile-connection-68971fa2&amp;pr=824">ade/mobile-connection-68971fa2 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=824">PR #824</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes iOS chat recovery owned by the sync service. The main changes are:

- Coalesced recovery for socket close, path changes, heartbeat silence, foreground return, and timed-out probes.
- Health-gated request timeouts that keep recently active sockets alive and probe silent sockets before reconnecting.
- Generation and cancellation guards to prevent stale callbacks from tearing down newer connections.
- Draft, subscription, transcript, and pending-operation preservation across reconnects.
- Safer handling for ambiguous live chat sends, chat creation, and Linear launches without automatic replay.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

No actionable bugs were found in the changed recovery paths. The updated code uses generation checks, single-probe ownership, and explicit ambiguous-operation handling to avoid duplicate sends or stale reconnect teardown. Focused tests cover the main recovery policy decisions and draft-preservation behavior.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Toolchain checks for iOS sync recovery were executed, and the logs show xcodebuild exit code: 127 and swift exit code: 127.
- An iOS blocker was identified in the xcodebuild blocker log, which captured the requested XCTest command and the missing xcodebuild blocker.
- A fallback runtime proof via CLI parity tests shows Vitest ran with Test Files 3 passed (3) and Tests 92 passed (92), exit code 0.

<a href="https://app.greptile.com/trex/runs/14512979/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Services/SyncService.swift | Moves socket loss, timeout probing, heartbeat silence, chat creation ambiguity, and reconnect retry behavior into service-owned recovery paths with generation guards. |
| apps/ios/ADE/Services/SyncRecoveryPolicy.swift | Introduces pure recovery decision helpers for probe timeouts, path reconnect coalescing, request timeout handling, jitter, and socket completion actions. |
| apps/ios/ADETests/SyncRecoveryPolicyTests.swift | Adds focused tests for recovery policy decisions, ambiguous creation handling, reconnect budget behavior, and subscription restoration safeguards. |
| apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift | Wires recovery draft restoration, reconnect-aware composer state, and mounted-chat subscription restoration into the destination view. |
| apps/ios/ADE/Views/Work/WorkChatSessionView.swift | Restores unsent composer text and attachments when sends fail or become ambiguous, while keeping reconnect status copy aligned with draft safety. |
| apps/ios/ADE/Views/Work/WorkNewChatScreen.swift | Preserves new-chat drafts and lanes for queued or ambiguous creation flows instead of replaying live creation automatically. |
| apps/ios/ADE/Views/Linear/LinearLaunchModel.swift | Models queued and ambiguous Linear agent launch outcomes so post-lane failures do not delete lanes that may already be running work. |
| apps/ios/ADE/Views/Linear/LinearLaunchScreen.swift | Handles Linear launch recovery outcomes by keeping ambiguous lanes visible and surfacing manual reconciliation messaging. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Socket as WebSocket/Path/Heartbeat
  participant Sync as SyncService
  participant Probe as Transport Probe
  participant Reconnect as Reconnect Owner
  participant UI as Mounted Chat UI

  Socket->>Sync: close, path change, silence, or timeout
  Sync->>Sync: check generation and recovery policy
  alt recent inbound traffic
    Sync-->>UI: fail only the timed-out request / keep socket
  else silent live socket
    Sync->>Probe: send bounded heartbeat probe
    alt inbound arrives after probe start
      Probe-->>Sync: transport healthy
      Sync-->>UI: preserve mounted state and subscriptions
    else probe times out silently
      Probe->>Reconnect: begin automatic transport recovery
      Reconnect->>Sync: reconnect with jittered retry budget
      Sync-->>UI: restore open lanes, chat subscriptions, terminals, drafts
    end
  end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Socket as WebSocket/Path/Heartbeat
  participant Sync as SyncService
  participant Probe as Transport Probe
  participant Reconnect as Reconnect Owner
  participant UI as Mounted Chat UI

  Socket->>Sync: close, path change, silence, or timeout
  Sync->>Sync: check generation and recovery policy
  alt recent inbound traffic
    Sync-->>UI: fail only the timed-out request / keep socket
  else silent live socket
    Sync->>Probe: send bounded heartbeat probe
    alt inbound arrives after probe start
      Probe-->>Sync: transport healthy
      Sync-->>UI: preserve mounted state and subscriptions
    else probe times out silently
      Probe->>Reconnect: begin automatic transport recovery
      Reconnect->>Sync: reconnect with jittered retry budget
      Sync-->>UI: restore open lanes, chat subscriptions, terminals, drafts
    end
  end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(ios): recover chats across weak netw..."](https://github.com/arul28/ade/commit/e2bae4e83aaed5f6f23078009158d26141ea7c20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44395431)</sub>

<!-- /greptile_comment -->