### PR TITLE
usage-pane-external-links -> Primary

### DIFF
--- a/apps/desktop/src/renderer/components/usage/UsageQuotaPanel.tsx
+++ b/apps/desktop/src/renderer/components/usage/UsageQuotaPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowClockwise, Gauge } from "@phosphor-icons/react";
+import { ArrowClockwise, ArrowSquareOut, Gauge } from "@phosphor-icons/react";
 import type {
   AiProviderConnectionStatus,
   AiProviderConnections,
@@ -11,15 +11,24 @@ import type {
   UsageWindow,
 } from "../../../shared/types";
 import { hasLocalProviderConnectionSignal } from "../../lib/aiProviderStatus";
+import { openExternalUrl } from "../../lib/openExternal";
 import { providerChatAccent } from "../chat/chatSurfaceTheme";
 import { ClaudeLogo, CodexLogo } from "../terminals/ToolLogos";
 import { cn } from "../ui/cn";
 
 const PROVIDER_ORDER: UsageProvider[] = ["claude", "codex"];
 
-const PROVIDER_META: Record<UsageProvider, { label: string; color: string }> = {
-  claude: { label: "Claude", color: "#D97757" },
-  codex: { label: "Codex", color: providerChatAccent("codex")! },
+const PROVIDER_META: Record<UsageProvider, { label: string; color: string; usageUrl?: string }> = {
+  claude: {
+    label: "Claude",
+    color: "#D97757",
+    usageUrl: "https://claude.ai/new#settings/usage",
+  },
+  codex: {
+    label: "Codex",
+    color: providerChatAccent("codex")!,
+    usageUrl: "https://chatgpt.com/codex/cloud/settings/analytics#usage",
+  },
   cursor: { label: "Cursor", color: "#00BFA5" },
 };
 
@@ -553,7 +562,7 @@ function ProviderUsageCard({
     return (
       <div className="rounded-xl px-4 py-3.5" style={CARD_STYLE}>
         <div className="flex items-start justify-between gap-3">
-          <ProviderHeading provider={provider} color={meta.color} label={meta.label} dim />
+          <ProviderHeading provider={provider} color={meta.color} label={meta.label} usageUrl={meta.usageUrl} dim />
           <span className="text-right text-[10px] text-fg/40">
             {providerSourceLabel(status)} · {providerUpdatedLabel(status, nowMs)}
           </span>
@@ -587,7 +596,7 @@ function ProviderUsageCard({
   return (
     <div className="rounded-xl px-4 py-3.5" style={CARD_STYLE}>
       <div className="mb-3 flex items-start justify-between gap-3">
-        <ProviderHeading provider={provider} color={meta.color} label={meta.label} />
+        <ProviderHeading provider={provider} color={meta.color} label={meta.label} usageUrl={meta.usageUrl} />
         <span className="text-right text-[10px] text-fg/40">
           {providerSourceLabel(status)} · {providerUpdatedLabel(status, nowMs)}
         </span>
@@ -672,14 +681,17 @@ function ProviderHeading({
   provider,
   color,
   label,
+  usageUrl,
   dim,
 }: {
   provider: UsageProvider;
   color: string;
   label: string;
+  usageUrl?: string;
   dim?: boolean;
 }) {
   const Logo = provider === "claude" ? ClaudeLogo : provider === "codex" ? CodexLogo : null;
+  const providerLabel = PROVIDER_META[provider].label;
   return (
     <div className="flex items-center gap-2">
       {Logo ? (
@@ -698,6 +710,17 @@ function ProviderHeading({
         />
       )}
       <span className="text-[12.5px] font-semibold tracking-[-0.01em] text-fg">{label}</span>
+      {usageUrl ? (
+        <button
+          type="button"
+          onClick={() => openExternalUrl(usageUrl)}
+          className="inline-flex h-5 w-5 items-center justify-center rounded text-fg/40 hover:bg-white/[0.06] hover:text-fg/75"
+          aria-label={`Open ${providerLabel} usage in browser`}
+          title={`Open ${providerLabel} usage in browser`}
+        >
+          <ArrowSquareOut size={12} weight="regular" />
+        </button>
+      ) : null}
     </div>
   );
 }
@@ -719,7 +742,7 @@ function ExtraUsageCard({ extra, reducedMotion }: { extra: ExtraUsage; reducedMo
   return (
     <div className="rounded-xl px-4 py-3.5" style={CARD_STYLE}>
       <div className="flex items-center justify-between gap-3">
-        <ProviderHeading provider={extra.provider} color={meta.color} label={`${meta.label} extra usage`} />
+        <ProviderHeading provider={extra.provider} color={meta.color} label={`${meta.label} extra usage`} usageUrl={meta.usageUrl} />
         <span className="text-[11px] tabular-nums text-fg/70">
           {formatUsd(usedUsd)}
           {limitUsd > 0 ? <span className="text-fg/40"> / {formatUsd(limitUsd)}</span> : null}

--- a/apps/desktop/src/renderer/components/usage/usage.test.tsx
+++ b/apps/desktop/src/renderer/components/usage/usage.test.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../lib/workSidebarBrowserResize";
 
 type UsageComponentTestBridge = {
+  app: Pick<Window["ade"]["app"], "openExternal">;
   usage: Pick<
     Window["ade"]["usage"],
     "getSnapshot" | "refresh" | "refreshHistory" | "noteDemand" | "getBudgetConfig" | "saveBudgetConfig" | "onUpdate"
@@ -262,6 +263,9 @@ describe("usage components", () => {
   beforeEach(() => {
     const snapshot = makeQuotaPanelSnapshot();
     const bridge = {
+      app: {
+        openExternal: vi.fn<[url: string], Promise<void>>(async () => {}),
+      },
       usage: {
         getSnapshot: vi.fn<[], Promise<UsageSnapshot | null>>(async () => snapshot),
         refresh: vi.fn<[], Promise<UsageSnapshot | null>>(async () => snapshot),
@@ -291,6 +295,20 @@ describe("usage components", () => {
       expect((await screen.findAllByText("Codex")).length).toBeGreaterThan(0);
       expect(await screen.findByText("63.0% used")).toBeTruthy();
       expect(screen.queryByText("37.0% remaining")).toBeNull();
+    });
+
+    it("opens each provider usage page in the user's browser", async () => {
+      render(<UsageQuotaPanel />);
+
+      await screen.findByText("Codex");
+      fireEvent.click(screen.getByRole("button", { name: "Open Claude usage in browser" }));
+      fireEvent.click(screen.getByRole("button", { name: "Open Codex usage in browser" }));
+
+      expect(window.ade.app.openExternal).toHaveBeenCalledTimes(2);
+      expect(window.ade.app.openExternal).toHaveBeenCalledWith("https://claude.ai/new#settings/usage");
+      expect(window.ade.app.openExternal).toHaveBeenCalledWith(
+        "https://chatgpt.com/codex/cloud/settings/analytics#usage",
+      );
     });
 
     it("renders weekly and monthly windows as separate meters", async () => {


### PR DESCRIPTION
<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstart-skill-screenshot-usage-pane-e9f8636d num=840 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstart-skill-screenshot-usage-pane-e9f8636d&amp;pr=840">ade/start-skill-screenshot-usage-pane-e9f8636d branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=840">PR #840</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds external usage links to the usage quota panel. The main changes are:

- Claude and Codex provider headings now show browser-launch buttons.
- Extra usage cards reuse the same provider usage links.
- The usage component tests now mock `window.ade.app.openExternal` and verify both provider URLs.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow, uses the existing external-open helper, and includes focused tests for the new provider links.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The usage quota panel test was run and showed the exact command, the working directory, and exit code 0, with the external-link test passing.
- The harness source used for the test seeds Claude/Codex usage snapshots and records window.ade.app.openExternal calls for the expected URLs.
- Supplemental capture artifacts were analyzed to understand the Chromium capture attempt and the connection-refused blocker, including the UI capture log and the DOM HTML dump.
- The supplemental headless Chromium screenshot and the DOM/click HTML artifact were reviewed as extra evidence, with the screenshot noted as not primary because the DOM dump showed the connection refusal.

<a href="https://app.greptile.com/trex/runs/14777158/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/usage/UsageQuotaPanel.tsx | Adds primary external usage links for Claude and Codex provider headings via the existing external-open bridge. |
| apps/desktop/src/renderer/components/usage/usage.test.tsx | Extends the usage component bridge mock and verifies provider usage buttons invoke the expected external URLs. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant User
  participant UsageQuotaPanel
  participant ProviderHeading
  participant openExternalUrl
  participant AdeBridge as window.ade.app.openExternal

  UsageQuotaPanel->>ProviderHeading: render provider label + usageUrl
  User->>ProviderHeading: click external usage button
  ProviderHeading->>openExternalUrl: openExternalUrl(usageUrl)
  openExternalUrl->>AdeBridge: openExternal(usageUrl)
  AdeBridge-->>User: opens provider usage page in browser
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant User
  participant UsageQuotaPanel
  participant ProviderHeading
  participant openExternalUrl
  participant AdeBridge as window.ade.app.openExternal

  UsageQuotaPanel->>ProviderHeading: render provider label + usageUrl
  User->>ProviderHeading: click external usage button
  ProviderHeading->>openExternalUrl: openExternalUrl(usageUrl)
  openExternalUrl->>AdeBridge: openExternal(usageUrl)
  AdeBridge-->>User: opens provider usage page in browser
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(usage): add provider usage links"](https://github.com/arul28/ade/commit/2ab4efc8bf20aa776efe8b417c9dcd9cdfe25091) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44953326)</sub>

<!-- /greptile_comment -->