### PR TITLE
test(chat): make durable-cron scheduled-wake tests wait robustly

### DIFF
--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -1727,6 +1727,31 @@ async function waitForEvent<T extends AgentChatEventEnvelope>(
   throw new Error("Timed out waiting for agent chat event.");
 }
 
+async function waitForFakeTimerCondition(
+  predicate: () => boolean,
+  description: string,
+): Promise<void> {
+  const timeoutMs = 10_000;
+  for (let elapsedMs = 0; elapsedMs < timeoutMs; elapsedMs += 1) {
+    if (predicate()) return;
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.resolve();
+  }
+  if (predicate()) return;
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${description}.`);
+}
+
+async function waitForFakeTimerPromise<T>(
+  promise: Promise<T>,
+  description: string,
+): Promise<T> {
+  let settled = false;
+  const trackedPromise = promise.finally(() => { settled = true; });
+  void trackedPromise.catch(() => undefined);
+  await waitForFakeTimerCondition(() => settled, description);
+  return trackedPromise;
+}
+
 async function createClaudeStreamFixture(args: {
   sdkSessionId: string;
   messages: Array<Record<string, unknown>>;
@@ -13069,9 +13094,10 @@ describe("createAgentChatService", () => {
         sessionId: session.id,
         text: "Keep working through the backstop deadline.",
       });
-      for (let index = 0; index < 100 && !send.mock.calls.length; index += 1) {
-        await vi.advanceTimersByTimeAsync(1);
-      }
+      await waitForFakeTimerCondition(
+        () => send.mock.calls.length > 0,
+        "the foreground Claude send to start",
+      );
       expect(send).toHaveBeenCalled();
       expect(service.hasActiveWorkloads()).toBe(true);
       const options = vi.mocked(claudeSdkCreateSessionCompat).mock.calls.at(-1)?.[0] as {
@@ -15127,6 +15153,8 @@ describe("createAgentChatService", () => {
     });
 
     it("does not create task-id scheduled rows for ambiguous parentless cron runs", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(SCHEDULE_TEST_START);
       const scheduledWork = createScheduledWorkDb();
       const events: AgentChatEventEnvelope[] = [];
       const setPermissionMode = vi.fn().mockResolvedValue(undefined);
@@ -15204,13 +15232,14 @@ describe("createAgentChatService", () => {
       } | undefined;
       const stopHook = opts?.hooks?.Stop?.[0]?.hooks[0];
 
-      await service.runSessionTurn({
-        sessionId: session.id,
-        text: "Schedule two recurring crons.",
-      });
+      await waitForFakeTimerPromise(
+        service.runSessionTurn({
+          sessionId: session.id,
+          text: "Schedule two recurring crons.",
+        }),
+        "the cron setup turn to settle",
+      );
 
-      vi.useFakeTimers();
-      vi.setSystemTime(SCHEDULE_TEST_START);
       const postToolUseHook = opts?.hooks?.PostToolUse?.[0]?.hooks[0];
       await postToolUseHook?.({
         hook_event_name: "PostToolUse",
@@ -15246,15 +15275,20 @@ describe("createAgentChatService", () => {
         ],
       });
 
-      await vi.advanceTimersByTimeAsync(15 * 60_000);
+      vi.setSystemTime(SCHEDULE_TEST_START + 15 * 60_000);
       startCronRun();
-      for (let index = 0; index < 100 && !events.some((event) =>
-        event.sessionId === session.id
-        && event.event.type === "subagent_result"
-        && event.event.taskId === "cron-run-task-ambiguous"
-      ); index += 1) {
-        await vi.advanceTimersByTimeAsync(1);
-      }
+      await waitForFakeTimerCondition(
+        () => events.some((event) =>
+          event.sessionId === session.id
+          && event.event.type === "subagent_result"
+          && event.event.taskId === "cron-run-task-ambiguous"
+        ) && events.some((event) =>
+          event.sessionId === session.id
+          && event.event.type === "user_message"
+          && event.event.metadata?.scheduledWake != null
+        ),
+        "the ambiguous cron result and scheduled-wake message",
+      );
       expect(events.some((event) =>
         event.sessionId === session.id
         && event.event.type === "subagent_result"
@@ -15297,6 +15331,8 @@ describe("createAgentChatService", () => {
     });
 
     it("claims a native cron when unrelated idle output already opened the turn", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(SCHEDULE_TEST_START);
       const scheduledWork = createScheduledWorkDb();
       const events: AgentChatEventEnvelope[] = [];
       let streamCall = 0;
@@ -15378,12 +15414,13 @@ describe("createAgentChatService", () => {
       } | undefined;
       const postToolUseHook = options?.hooks?.PostToolUse?.[0]?.hooks[0];
 
-      await service.runSessionTurn({
-        sessionId: session.id,
-        text: "Keep watching CI in the background.",
-      });
-      vi.useFakeTimers();
-      vi.setSystemTime(SCHEDULE_TEST_START);
+      await waitForFakeTimerPromise(
+        service.runSessionTurn({
+          sessionId: session.id,
+          text: "Keep watching CI in the background.",
+        }),
+        "the idle-output setup turn to settle",
+      );
       await postToolUseHook?.({
         hook_event_name: "PostToolUse",
         session_id: "sdk-cron-existing-idle-turn",
@@ -15402,13 +15439,14 @@ describe("createAgentChatService", () => {
         }],
       });
       releaseIdle();
-      for (let index = 0; index < 100 && !events.some((event) =>
-        event.sessionId === session.id
-        && event.event.type === "activity"
-        && event.event.detail === "Tool 'BackgroundTask' running (1s)"
-      ); index += 1) {
-        await vi.advanceTimersByTimeAsync(1);
-      }
+      await waitForFakeTimerCondition(
+        () => events.some((event) =>
+          event.sessionId === session.id
+          && event.event.type === "activity"
+          && event.event.detail === "Tool 'BackgroundTask' running (1s)"
+        ),
+        "the unrelated idle activity",
+      );
       const idleActivity = events.find((event) =>
         event.sessionId === session.id
         && event.event.type === "activity"
@@ -15418,13 +15456,14 @@ describe("createAgentChatService", () => {
 
       await vi.advanceTimersByTimeAsync(15 * 60_000);
       releaseCron();
-      for (let index = 0; index < 100 && !events.some((event) =>
-        event.sessionId === session.id
-        && event.event.type === "user_message"
-        && event.event.metadata?.scheduledWake?.scheduleId === "cron-provider-existing-idle-turn"
-      ); index += 1) {
-        await vi.advanceTimersByTimeAsync(1);
-      }
+      await waitForFakeTimerCondition(
+        () => events.some((event) =>
+          event.sessionId === session.id
+          && event.event.type === "user_message"
+          && event.event.metadata?.scheduledWake?.scheduleId === "cron-provider-existing-idle-turn"
+        ),
+        "the native cron scheduled-wake message",
+      );
 
       const scheduledWake = events.find((event) =>
         event.sessionId === session.id


### PR DESCRIPTION
## Problem

`test-desktop (8)` was failing deterministically on `main` (blocking the v1.2.30 release gate, which requires a green `ci-pass` on the tagged commit). Two `agentChatService.test.ts` cron tests under `hasActiveWorkloads` failed:
- `does not create task-id scheduled rows for ambiguous parentless cron runs`
- `claims a native cron when unrelated idle output already opened the turn`

## Root cause

Both tests polled for an async scheduled-wake `user_message` by advancing fake timers only `100 × 1ms`. The durable-scheduling pipeline (#844) needs more timer+microtask cycles than that to emit the event, so the tests passed only on fast/unloaded runners. They began failing deterministically once an unrelated merge (#846) reshuffled the 8-way shard split onto a slower shard. Verified: running the whole file in isolation reproduced `2 failed / 671 passed` every time; same test+impl was green on `main` before the shard reshuffle.

## Fix

Replace the fragile fixed-iteration loops with a `waitForFakeTimerCondition` helper that advances fake time up to 10s while flushing microtasks until the predicate holds. **Test-only** — no product code changed, no assertions weakened or skipped.

## Verification

- Full file run **10×** in a row: `673 passed (673)` every time.
- `npm --prefix apps/desktop run typecheck`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of chat agent tests involving cron scheduling, idle activity, and foreground sends.
  * Added deterministic waiting utilities for asynchronous state changes when using simulated timers.
  * Updated tests to verify scheduled wake events and agent responses without relying on repeated manual timer advances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes durable-cron scheduled-wake tests wait more reliably. The main changes are:

- Adds a fake-timer condition helper with a bounded 10s timeout.
- Adds a helper for waiting on promises while advancing fake timers.
- Updates scheduled-work tests to wait for specific emitted events instead of fixed 100ms polling loops.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is confined to tests and preserves the existing assertions while replacing fragile fixed polling with bounded fake-timer waits.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The cron-focused Vitest run completed, showing that 1 file passed and 2 targeted tests passed.
- The desktop TypeScript type-check step was executed but was killed with exit code 137, so type-check completion could not be proven by a TypeScript diagnostic.
- The results indicate the relevant changed test behavior executed successfully despite the kill signal during type-checking, as reflected by the Vitest results.

<a href="https://app.greptile.com/trex/runs/14868157/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/chat/agentChatService.test.ts | Adds fake-timer wait helpers and updates durable-cron tests to wait for scheduled-wake events without fixed short polling loops; no issues found. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Test as Durable-cron test
participant Helper as waitForFakeTimerCondition
participant Timers as Vitest fake timers
participant Service as AgentChatService events

Test->>Service: start session turn / release cron gate
Test->>Helper: wait for expected event predicate
loop until predicate true or 10s fake time
    Helper->>Service: evaluate emitted events
    alt event not emitted yet
        Helper->>Timers: advanceTimersByTimeAsync(1)
        Helper->>Helper: flush microtasks
    else event emitted
        Helper-->>Test: return
    end
end
Test->>Service: assert scheduled-work / scheduled-wake behavior
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Test as Durable-cron test
participant Helper as waitForFakeTimerCondition
participant Timers as Vitest fake timers
participant Service as AgentChatService events

Test->>Service: start session turn / release cron gate
Test->>Helper: wait for expected event predicate
loop until predicate true or 10s fake time
    Helper->>Service: evaluate emitted events
    alt event not emitted yet
        Helper->>Timers: advanceTimersByTimeAsync(1)
        Helper->>Helper: flush microtasks
    else event emitted
        Helper-->>Test: return
    end
end
Test->>Service: assert scheduled-work / scheduled-wake behavior
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test(chat): make durable-cron scheduled-..."](https://github.com/arul28/ade/commit/98452efbb6180eb44b831cc6442950c9ad6537f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45141852)</sub>

<!-- /greptile_comment -->