### PR TITLE
docs(release): v1.2.31 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.31] - 2026-07-18
+
+### Added
+
+- iOS: connect, reconnect, and disconnect your Linear workspace from the Linear pane's new settings gear, using a native worker-bounce OAuth flow or an API key, with the workspace logo and status shown and controls gated for older hosts.
+- Desktop: the Linear connection card now renders the workspace logo.
+
+### Changed
+
+- Rebuilt the Providers settings panel with runtime cards, fully-managed OpenCode subscriptions, Kimi, and custom providers.
+- Added a Storage doctor and Storage tab health surface; eliminated ingress-payload bloat.
+- Overhauled iOS pull-requests reliability, performance, and UI.
+
+### Fixed
+
+- Glitchy fork and brief handoff: seeding lag, phantom duplicate sessions, and a false 30-second timeout (ADE-122).
+- Mobile settings and live provider usage.
+- Claude context-usage card spamming the chat thread.
+- Smart-link chip brand logos and paste centering.
+- Packaged builds now ignore development Clerk configuration.
+
 ## [1.2.30] - 2026-07-17
 
 ### Fixed
@@ -848,7 +869,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial public release.
 
-[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.30...HEAD
+[Unreleased]: https://github.com/arul28/ADE/compare/v1.2.31...HEAD
+[1.2.31]: https://github.com/arul28/ADE/compare/v1.2.30...v1.2.31
 [1.2.30]: https://github.com/arul28/ADE/compare/v1.2.29...v1.2.30
 [1.2.29]: https://github.com/arul28/ADE/compare/v1.2.28...v1.2.29
 [1.2.28]: https://github.com/arul28/ADE/compare/v1.2.27...v1.2.28

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.30">
-  v1.2.30 - Dependable browser access: the web client connects reliably over the account relay, stays signed in, shows your account identity, and Connections tells the Mac you're on apart from one you're working on remotely.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.31">
+  v1.2.31 - Manage Linear from your phone: the iOS Linear pane can now sign in, reconnect, and disconnect your workspace, alongside a rebuilt Providers panel and more reliable iOS PRs and chat.
 </Card>

--- a/changelog/v1.2.31.mdx
+++ b/changelog/v1.2.31.mdx
@@ -1,0 +1,23 @@
+---
+title: "v1.2.31"
+description: "Release notes for ADE v1.2.31 - July 18, 2026"
+---
+
+v1.2.31 brings Linear connection management to your phone, rebuilds the Providers settings, and makes iOS PRs and chat noticeably more reliable.
+
+---
+
+## Desktop and CLI
+
+- **Providers settings, rebuilt.** The Providers panel is now runtime cards with fully-managed OpenCode subscriptions, Kimi, and custom providers, alongside fixes to live provider usage.
+- **Storage health at a glance.** A new Storage doctor and Storage tab surface database health and cut ingress-payload bloat.
+- **Handoff is smooth again.** Fixed the glitchy fork and brief handoff — seeding lag, phantom duplicate sessions, and a false 30-second timeout are gone (ADE-122).
+- **Chat polish.** The Claude context-usage card no longer spams the thread, smart-link chips show real brand logos, and paste centering is fixed.
+- **Account hardening.** Packaged builds now ignore development Clerk configuration.
+- **Linear workspace logo.** The Linear connection card in Settings now shows your workspace's real logo.
+
+## iOS
+
+- **Connect and manage Linear from your phone.** The Linear pane has a settings gear to sign in, reconnect, and disconnect your Linear workspace — the same setup you get on the Mac. Sign-in runs a native OAuth flow (or an API key), the workspace logo and status are shown, and the controls degrade gracefully when your Mac is on an older build.
+- **PRs, overhauled.** A reliability, performance, and UI pass across the iOS pull-requests experience.
+- **Mobile settings and usage.** Fixed mobile settings and live provider usage on the phone.

--- a/docs.json
+++ b/docs.json
@@ -180,6 +180,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.31",
               "changelog/v1.2.30",
               "changelog/v1.2.29",
               "changelog/v1.2.28",


### PR DESCRIPTION
Release notes for v1.2.31 (Linear connect/manage on iOS + bundled merged PRs). Docs-only; validate-docs passes locally (196 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the ADE v1.2.31 release documentation. The main changes are:

- Adds the v1.2.31 entry to `CHANGELOG.md`.
- Adds a standalone `changelog/v1.2.31.mdx` release notes page.
- Updates the changelog landing card to point at v1.2.31.
- Registers the new release page in `docs.json` navigation.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

Changes are limited to release documentation and navigation metadata. The new files and links follow the existing changelog structure. No functional, syntax, or security issues were found.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The docs release validation script was executed with a 60-second timeout and completed successfully.
- The docs JSON sanity harness was run and reported a single changelog reference (v1.2.31) in the docs.json, confirming the reference mapping.
- A Node-based sanity-check harness used for the docs.json parse/config check was generated and is available for inspection.

<a href="https://app.greptile.com/trex/runs/14938219/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds the v1.2.31 changelog entry and updates comparison links; no issues found. |
| changelog/index.mdx | Updates the latest-release card to point at v1.2.31; no issues found. |
| changelog/v1.2.31.mdx | Adds the standalone v1.2.31 release notes page with frontmatter matching existing release pages; no issues found. |
| docs.json | Registers the v1.2.31 page in the changelog navigation in newest-first order; no issues found. |

<sub>Reviews (1): Last reviewed commit: ["docs(release): v1.2.31 changelog and rel..."](https://github.com/arul28/ade/commit/1c9a788f50a72ce14223bfd3885fe22176c5bbd5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45290876)</sub>

<!-- /greptile_comment -->