### PR TITLE
docs(release): v1.2.32 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.32] - 2026-07-20
+
+### Web client
+
+- Login-path bundle cut from ~4.7 MB to ~250 KB with a build-time budget guard; hashed assets cache immutably; instant HTML splash and preconnects.
+- Sign-in and the machine directory render immediately; IndexedDB maintenance is batched, bounded, and recoverable (no more indefinite "Starting ADE").
+- Dead-connection watchdog, split transport/hello timeouts, overlapped credential preparation, and accurate relay close-code errors.
+
+### ADE Relay
+
+- Native ping/pong liveness on the Mac's relay control socket; half-open sockets after sleep or network changes recover in seconds.
+- Failed connection opens are rejected in under a second via new reject signaling; close codes survive the relay boundaries.
+- Machines publish directory availability immediately on relay-readiness transitions; idle relay objects stop scheduling needless sweeps.
+- Directory listings are bounded and expose Server-Timing.
+
+### iOS
+
+- Classifies the relay's new close codes for smarter retry behavior.
+
 ## [1.2.31] - 2026-07-18
 
 ### Added
@@ -870,6 +889,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial public release.
 
 [Unreleased]: https://github.com/arul28/ADE/compare/v1.2.31...HEAD
+[1.2.32]: https://github.com/arul28/ADE/compare/v1.2.31...v1.2.32
 [1.2.31]: https://github.com/arul28/ADE/compare/v1.2.30...v1.2.31
 [1.2.30]: https://github.com/arul28/ADE/compare/v1.2.29...v1.2.30
 [1.2.29]: https://github.com/arul28/ADE/compare/v1.2.28...v1.2.29

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.31">
-  v1.2.31 - Manage Linear from your phone: the iOS Linear pane can now sign in, reconnect, and disconnect your workspace, alongside a rebuilt Providers panel and more reliable iOS PRs and chat.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.32">
+  v1.2.32 - A much faster web client and a snappier, more resilient ADE Relay: the sign-in screen loads in a fraction of the time, dead connections recover in seconds, and your Mac shows up in the directory the moment it comes online.
 </Card>

--- a/changelog/v1.2.32.mdx
+++ b/changelog/v1.2.32.mdx
@@ -1,0 +1,25 @@
+---
+title: "v1.2.32"
+description: "Release notes for ADE v1.2.32 - July 20, 2026"
+---
+
+v1.2.32 makes the hosted web client dramatically faster to load and the ADE Relay noticeably quicker to connect and recover — closer to how a LAN connection feels.
+
+---
+
+## Web client
+
+- **The sign-in screen loads in a fraction of the time.** The login path previously shipped ~4.7 MB of JavaScript before the button could render; it is now ~250 KB, guarded by a build-time budget so it cannot regress. Hashed assets are cached immutably, so revisits and the OAuth callback stop re-downloading the app.
+- **Something on screen instantly.** The page shows a splash the moment HTML arrives, and the sign-in button and your machine list render immediately instead of waiting on browser-storage housekeeping.
+- **No more infinite "Starting ADE".** Browser-storage stalls are now bounded with a retry, instead of hanging the page indefinitely.
+- **Clearer connection errors.** The web client now tells you when your Mac is offline or busy rather than showing a generic failure, detects dead connections within about a minute, and recovers when you return to the tab.
+
+## ADE Relay
+
+- **Faster connects, faster failures.** Connection setup overlaps credential preparation with dialing, failed connection attempts are rejected in under a second instead of timing out for up to 30 seconds, and cold connections no longer trip an overly tight timeout.
+- **Your Mac comes back quickly after sleep.** The Mac's relay link now detects a dead connection within seconds and re-registers immediately, so "my Mac isn't showing up" windows after waking or switching networks are largely gone.
+- **Machines appear in the directory right away.** The Mac publishes its availability the moment relay readiness changes instead of waiting for the next 30-second cycle.
+
+## iOS
+
+- **Smarter relay retries.** The app now understands the relay's new failure signals and retries appropriately instead of treating them as generic errors.

--- a/docs.json
+++ b/docs.json
@@ -180,6 +180,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.32",
               "changelog/v1.2.31",
               "changelog/v1.2.30",
               "changelog/v1.2.29",


### PR DESCRIPTION
Release docs for v1.2.32 (web client + relay perf release). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the v1.2.32 release documentation. The main changes are:

- Adds v1.2.32 notes to the root `CHANGELOG.md`.
- Adds a dedicated `changelog/v1.2.32.mdx` release page.
- Updates the changelog landing card and docs sidebar to point to v1.2.32.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge after fixing the changelog compare link.

The docs updates are straightforward, but the stale `CHANGELOG.md` Unreleased link produces incorrect release comparison output.

`CHANGELOG.md`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The release docs validation command was executed and completed with exit code 0.
- The validation log confirms that the input was parsed as valid JSON.
- The log shows the validation reviewed navigation references, checked the changelog file existence, and performed frontmatter and content checks, resulting in the final release docs validation: PASS.

<a href="https://app.greptile.com/trex/runs/15110868/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds v1.2.32 release notes, but leaves the Unreleased compare link pointing at v1.2.31. |
| changelog/index.mdx | Updates the latest-release card to point to v1.2.32. |
| changelog/v1.2.32.mdx | Adds the v1.2.32 docs changelog page for web client, relay, and iOS changes. |
| docs.json | Adds the v1.2.32 page to the changelog sidebar in newest-first order. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Reader
participant ChangelogIndex as changelog/index.mdx
participant ReleasePage as changelog/v1.2.32.mdx
participant Sidebar as docs.json
participant Root as CHANGELOG.md

Reader->>ChangelogIndex: Open changelog landing page
ChangelogIndex-->>Reader: Latest release card links to v1.2.32
Reader->>ReleasePage: Open v1.2.32 release notes
Sidebar-->>Reader: Shows v1.2.32 in release navigation
Reader->>Root: Check root changelog history
Root-->>Reader: Shows v1.2.32 entry and compare references
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Reader
participant ChangelogIndex as changelog/index.mdx
participant ReleasePage as changelog/v1.2.32.mdx
participant Sidebar as docs.json
participant Root as CHANGELOG.md

Reader->>ChangelogIndex: Open changelog landing page
ChangelogIndex-->>Reader: Latest release card links to v1.2.32
Reader->>ReleasePage: Open v1.2.32 release notes
Sidebar-->>Reader: Shows v1.2.32 in release navigation
Reader->>Root: Check root changelog history
Root-->>Reader: Shows v1.2.32 entry and compare references
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACHANGELOG.md%3A891%0A**Update%20unreleased%20comparison**%0A%60%5BUnreleased%5D%60%20still%20compares%20from%20%60v1.2.31%60%2C%20so%20after%20this%20release%20the%20Unreleased%20link%20includes%20all%20%60v1.2.32%60%20changes%20as%20if%20they%20are%20unreleased.%20Since%20this%20PR%20adds%20the%20%601.2.32%60%20section%20and%20tag%20comparison%2C%20the%20rolling%20link%20should%20start%20from%20%60v1.2.32%60.%0A%0A&repo=arul28%2Fade&pr=865&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
CHANGELOG.md:891
**Update unreleased comparison**
`[Unreleased]` still compares from `v1.2.31`, so after this release the Unreleased link includes all `v1.2.32` changes as if they are unreleased. Since this PR adds the `1.2.32` section and tag comparison, the rolling link should start from `v1.2.32`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(release): v1.2.32 changelog and rel..."](https://github.com/arul28/ade/commit/64ec235630ed1a0602143811f087395267cf82fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45678618)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->