### PR TITLE
fix(webclient): detach inherited no-cache before immutable asset rule

### DIFF
--- a/apps/desktop/src/renderer/webclient/public/_headers
+++ b/apps/desktop/src/renderer/webclient/public/_headers
@@ -7,4 +7,5 @@
   Cache-Control: no-cache
 
 /assets/*
+  ! Cache-Control
   Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
One-line `_headers` fix, verified against the live deployment: Pages appends same-named headers across matching rules, so assets were getting `no-cache, ..., immutable` (no-cache wins). `! Cache-Control` detaches the inherited value first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caching behavior for web assets by ensuring the intended long-term caching policy is applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Cloudflare Pages headers for cached webclient assets. The main changes are:

- Adds `! Cache-Control` to the `/assets/*` rule.
- Removes the inherited `Cache-Control: no-cache` before applying immutable asset caching.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to one Cloudflare Pages header directive and matches the intended cache-header behavior for `/assets/*`.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the cache-control validation script (validate\_headers\_cache\_control.mjs) to compare temporary source/dist files against the repository assets, and it produced two logs that capture the before and after states.
- I examined the before-log and observed that with Cache-Control removed on temporary files, the inherited directives included no-cache and public, max-age, immutable, and the detach/order assertions did not pass.
- I examined the after-log and observed that the detach directive appears before immutable cache-control in the repository assets, leaving only public, max-age, immutable for the assets.

<a href="https://app.greptile.com/trex/runs/15111958/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/webclient/public/_headers | Updates the asset header rule to detach inherited `Cache-Control` before applying immutable caching. |

<sub>Reviews (1): Last reviewed commit: ["fix(webclient): detach inherited no-cach..."](https://github.com/arul28/ade/commit/afbf2b200df7709b1975685ed26f89e8cbd6f0a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45680669)</sub>

<!-- /greptile_comment -->