### PR TITLE
fix(release): verify pre-signed runtime archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,8 @@ jobs:
             apps/push-relay/node_modules
           key: nm-v2-${{ hashFiles('apps/desktop/package-lock.json','apps/ade-cli/package-lock.json','apps/web/package-lock.json','apps/webhook-relay/package-lock.json','apps/push-relay/package-lock.json') }}
       - run: cd apps/ade-cli && npm run typecheck
+      - name: Test release runtime archive guards
+        run: node --test apps/ade-cli/scripts/native-archive-verification.test.mjs apps/desktop/scripts/mac-runtime-archive-mode.test.mjs
 
   typecheck-web:
     needs: install

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -206,6 +206,10 @@ jobs:
 
       - name: Build signed ${{ matrix.arch }} macOS release
         env:
+          # These archives were signed and notarized by their native
+          # build-runtime-binaries matrix jobs. Verify them here instead of
+          # re-signing and re-timestamping foreign-arch payloads.
+          ADE_RUNTIME_ARCHIVES_PRE_SIGNED: "1"
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}

--- a/apps/ade-cli/scripts/native-archive-verification.mjs
+++ b/apps/ade-cli/scripts/native-archive-verification.mjs
@@ -1,0 +1,6 @@
+export function assertVerifiedMachOPayloads(verified, archivePath) {
+  if (!Number.isInteger(verified) || verified < 1) {
+    throw new Error(`No Mach-O payloads were verified in pre-signed native archive: ${archivePath}`);
+  }
+  return verified;
+}

--- a/apps/ade-cli/scripts/native-archive-verification.test.mjs
+++ b/apps/ade-cli/scripts/native-archive-verification.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { assertVerifiedMachOPayloads } from "./native-archive-verification.mjs";
+
+test("rejects a pre-signed archive with no Mach-O payloads", () => {
+  assert.throws(
+    () => assertVerifiedMachOPayloads(0, "/tmp/empty.native.tar.gz"),
+    /No Mach-O payloads were verified/,
+  );
+});
+
+test("accepts a pre-signed archive after at least one Mach-O signature is verified", () => {
+  assert.equal(assertVerifiedMachOPayloads(3, "/tmp/runtime.native.tar.gz"), 3);
+});

--- a/apps/ade-cli/scripts/notarize-static-runtime.mjs
+++ b/apps/ade-cli/scripts/notarize-static-runtime.mjs
@@ -138,6 +138,35 @@ async function signNativeArchiveIfPresent(binaryPath, identity) {
   }
 }
 
+async function verifyNativeArchiveIfPresent(binaryPath) {
+  const archivePath = `${binaryPath}.native.tar.gz`;
+  if (!(await pathExists(archivePath))) {
+    return;
+  }
+
+  const workDir = await fs.mkdtemp(path.join(os.tmpdir(), "ade-runtime-native-verify-"));
+  try {
+    console.log(`[runtime:notarize] Verifying pre-signed Mach-O payloads in ${archivePath}`);
+    await run("tar", ["-xzf", archivePath, "-C", workDir]);
+
+    const files = await walkFiles(workDir);
+    let verified = 0;
+    for (const filePath of files) {
+      if (!(await isMachO(filePath))) continue;
+      await run("codesign", ["--verify", "--strict", "--verbose=4", filePath]);
+      verified += 1;
+    }
+
+    if (verified === 0) {
+      console.log(`[runtime:notarize] No Mach-O payloads found in ${path.basename(archivePath)}`);
+    } else {
+      console.log(`[runtime:notarize] Verified ${verified} Mach-O payload(s) in ${path.basename(archivePath)}`);
+    }
+  } finally {
+    await fs.rm(workDir, { recursive: true, force: true });
+  }
+}
+
 async function stapleBinaryIfSupported(binaryPath) {
   let stapled = false;
   try {
@@ -202,9 +231,13 @@ function buildNotarytoolArgs(zipPath) {
 
 const binary = readFlag("--binary");
 if (!binary) {
-  throw new Error("Usage: node scripts/notarize-static-runtime.mjs --binary=/path/to/ade-darwin-arm64 [--sign-native-only]");
+  throw new Error("Usage: node scripts/notarize-static-runtime.mjs --binary=/path/to/ade-darwin-arm64 [--sign-native-only|--verify-native-only]");
 }
 const signNativeOnly = process.argv.includes("--sign-native-only");
+const verifyNativeOnly = process.argv.includes("--verify-native-only");
+if (signNativeOnly && verifyNativeOnly) {
+  throw new Error("Use only one of --sign-native-only or --verify-native-only.");
+}
 
 const binaryPath = path.resolve(binary);
 await assertExists(binaryPath, "ADE runtime binary");
@@ -213,14 +246,20 @@ if (process.platform !== "darwin") {
   throw new Error("Static runtime notarization must run on macOS.");
 }
 
-const identity = await findDeveloperIdIdentity();
-
 if (signNativeOnly) {
+  const identity = await findDeveloperIdIdentity();
   console.log(`[runtime:notarize] Signing native archive payloads for ${binaryPath} with ${identity}`);
   await signNativeArchiveIfPresent(binaryPath, identity);
   process.exit(0);
 }
 
+if (verifyNativeOnly) {
+  console.log(`[runtime:notarize] Verifying pre-signed native archive payloads for ${binaryPath}`);
+  await verifyNativeArchiveIfPresent(binaryPath);
+  process.exit(0);
+}
+
+const identity = await findDeveloperIdIdentity();
 console.log(`[runtime:notarize] Signing ${binaryPath} with ${identity}`);
 await signBinary(binaryPath, identity);
 await signNativeArchiveIfPresent(binaryPath, identity);

--- a/apps/ade-cli/scripts/notarize-static-runtime.mjs
+++ b/apps/ade-cli/scripts/notarize-static-runtime.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import { assertVerifiedMachOPayloads } from "./native-archive-verification.mjs";
 
 const execFileAsync = promisify(execFile);
 
@@ -157,11 +158,8 @@ async function verifyNativeArchiveIfPresent(binaryPath) {
       verified += 1;
     }
 
-    if (verified === 0) {
-      console.log(`[runtime:notarize] No Mach-O payloads found in ${path.basename(archivePath)}`);
-    } else {
-      console.log(`[runtime:notarize] Verified ${verified} Mach-O payload(s) in ${path.basename(archivePath)}`);
-    }
+    assertVerifiedMachOPayloads(verified, archivePath);
+    console.log(`[runtime:notarize] Verified ${verified} Mach-O payload(s) in ${path.basename(archivePath)}`);
   } finally {
     await fs.rm(workDir, { recursive: true, force: true });
   }

--- a/apps/desktop/scripts/mac-runtime-archive-mode.mjs
+++ b/apps/desktop/scripts/mac-runtime-archive-mode.mjs
@@ -1,0 +1,15 @@
+export const PRE_SIGNED_RUNTIME_ARCHIVES_ENV = "ADE_RUNTIME_ARCHIVES_PRE_SIGNED";
+
+export function nativeArchiveAction(env = process.env) {
+  return env[PRE_SIGNED_RUNTIME_ARCHIVES_ENV] === "1" ? "verify" : "sign";
+}
+
+export function nativeArchiveNotarizeArgs(binaryPath, action) {
+  if (action === "verify") {
+    return [`--binary=${binaryPath}`, "--verify-native-only"];
+  }
+  if (action === "sign") {
+    return [`--binary=${binaryPath}`, "--sign-native-only"];
+  }
+  throw new Error(`Unsupported native archive action: ${action}`);
+}

--- a/apps/desktop/scripts/mac-runtime-archive-mode.test.mjs
+++ b/apps/desktop/scripts/mac-runtime-archive-mode.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import {
+  PRE_SIGNED_RUNTIME_ARCHIVES_ENV,
+  nativeArchiveAction,
+  nativeArchiveNotarizeArgs,
+} from "./mac-runtime-archive-mode.mjs";
+
+test("uses verification, never re-signing, for explicitly pre-signed runtime archives", () => {
+  const binaryPath = "/tmp/ade-darwin-arm64";
+  assert.equal(nativeArchiveAction({ [PRE_SIGNED_RUNTIME_ARCHIVES_ENV]: "1" }), "verify");
+  assert.deepEqual(nativeArchiveNotarizeArgs(binaryPath, "verify"), [
+    `--binary=${binaryPath}`,
+    "--verify-native-only",
+  ]);
+});
+
+test("retains signing for local runtime archives", () => {
+  const binaryPath = "/tmp/ade-darwin-x64";
+  assert.equal(nativeArchiveAction({}), "sign");
+  assert.deepEqual(nativeArchiveNotarizeArgs(binaryPath, "sign"), [
+    `--binary=${binaryPath}`,
+    "--sign-native-only",
+  ]);
+});
+
+test("release mac packaging explicitly marks downloaded matrix artifacts as pre-signed", async () => {
+  const workflowPath = path.resolve(import.meta.dirname, "../../../.github/workflows/release-core.yml");
+  const workflow = await fs.readFile(workflowPath, "utf8");
+  assert.match(
+    workflow,
+    /Build signed \$\{\{ matrix\.arch \}\} macOS release[\s\S]*?ADE_RUNTIME_ARCHIVES_PRE_SIGNED: "1"[\s\S]*?npm run dist:mac:\$\{\{ matrix\.arch \}\}:signed/,
+  );
+});

--- a/apps/desktop/scripts/sign-mac-runtime-archives.mjs
+++ b/apps/desktop/scripts/sign-mac-runtime-archives.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { nativeArchiveAction, nativeArchiveNotarizeArgs } from "./mac-runtime-archive-mode.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const desktopRoot = path.resolve(scriptDir, "..");
@@ -9,6 +10,7 @@ const repoRoot = path.resolve(desktopRoot, "..", "..");
 const adeCliRoot = path.join(repoRoot, "apps", "ade-cli");
 const runtimeRoot = path.join(desktopRoot, "resources", "runtime");
 const darwinTargets = ["darwin-arm64", "darwin-x64"];
+const action = nativeArchiveAction();
 
 async function assertExists(filePath, label) {
   try {
@@ -40,9 +42,12 @@ for (const target of darwinTargets) {
     "run",
     "notarize:static",
     "--",
-    `--binary=${binaryPath}`,
-    "--sign-native-only",
+    ...nativeArchiveNotarizeArgs(binaryPath, action),
   ]);
 }
 
-console.log("[release:mac] Signed Mach-O payloads inside darwin runtime native archives");
+console.log(
+  action === "verify"
+    ? "[release:mac] Verified pre-signed Mach-O payloads inside darwin runtime native archives"
+    : "[release:mac] Signed Mach-O payloads inside darwin runtime native archives",
+);


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Improvements**
  * macOS release packaging now verifies pre-signed and notarized runtime archives instead of signing them again.
  * Added safeguards to ensure native runtime payloads are properly signed before release assembly.
  * Runtime archive processing now reports whether payloads were verified or signed.

* **Bug Fixes**
  * Prevented unnecessary re-signing and re-timestamping of already notarized macOS runtime components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR verifies pre-signed macOS runtime archives during release packaging. The main changes are:

- Select verification instead of re-signing for downloaded runtime archives.
- Reject pre-signed archives with no verified Mach-O payloads.
- Run the archive guard tests in CI.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

Empty Mach-O verification now fails instead of continuing. Both archive guard test files are executed by the merge-gating CI workflow.

No blocking issues were found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the pre-change test state in HEAD^, where 3/3 mode-selection tests passed with exit code 0.
- Ran the post-change contract validation and confirmed 5/5 tests passed, including the two non-empty verified-payload safety checks, with exit code 0.
- Inspected the test run logs to verify outcomes for before and after changes and to corroborate the pass statuses.
- Linked and reviewed artifacts capturing the pre-change and post-change test runs to provide verifiable evidence of results.

<a href="https://app.greptile.com/trex/runs/15338061/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/scripts/notarize-static-runtime.mjs | Adds verify-only archive processing and rejects archives with no verified Mach-O payloads. |
| apps/ade-cli/scripts/native-archive-verification.mjs | Adds the minimum verified-payload guard. |
| apps/desktop/scripts/sign-mac-runtime-archives.mjs | Chooses signing or verification from the release environment. |
| .github/workflows/release-core.yml | Marks downloaded runtime archives as pre-signed during macOS release assembly. |
| .github/workflows/ci.yml | Runs both runtime archive guard test files in CI. |

<sub>Reviews (2): Last reviewed commit: ["fix(release): fail closed on empty runti..."](https://github.com/arul28/ade/commit/3425428086de432cc0248834c697e7585ac4aa8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46141533)</sub>

<!-- /greptile_comment -->