### PR TITLE
Recover Relay publication after pipe failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.35] - 2026-07-22
+
+### Relay recovery
+
+- Kept real Relay pipe and local-listener setup failures fail-closed for the current connection generation until a fresh tunnel is fully ready.
+- Preserved an already-ready Relay route when a secondary connection attempt fails, while republishing directory state when the active route becomes blocked or recovers.
+- Made sync status distinguish current bridge blockers from historical connection errors so reachability is reported truthfully.
+
 ## [1.2.34] - 2026-07-22
 
 ### Web client and sync
@@ -930,6 +938,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial public release.
 
 [Unreleased]: https://github.com/arul28/ADE/compare/v1.2.34...HEAD
+[1.2.35]: https://github.com/arul28/ADE/compare/v1.2.34...v1.2.35
 [1.2.34]: https://github.com/arul28/ADE/compare/v1.2.33...v1.2.34
 [1.2.33]: https://github.com/arul28/ADE/compare/v1.2.32...v1.2.33
 [1.2.32]: https://github.com/arul28/ADE/compare/v1.2.31...v1.2.32

--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -1567,6 +1567,7 @@ export async function createAdeRuntime(args: {
           : null;
       },
       onIdentityRotated: () => resolvedArgs.syncRuntime?.requestAccountMachinePublish?.(),
+      onRouteStateChanged: () => resolvedArgs.syncRuntime?.requestAccountMachinePublish?.(),
     });
     resolvedArgs.syncRuntime?.sharedSyncListener?.onLoopbackValidated(() => {
       void service.validateCurrentBridge().catch((error) => {

--- a/apps/ade-cli/src/bootstrap.ts
+++ b/apps/ade-cli/src/bootstrap.ts
@@ -1566,8 +1566,7 @@ export async function createAdeRuntime(args: {
           ? { userId, expiresAt: refreshed.expiresAt }
           : null;
       },
-      onIdentityRotated: () => resolvedArgs.syncRuntime?.requestAccountMachinePublish?.(),
-      onRouteStateChanged: () => resolvedArgs.syncRuntime?.requestAccountMachinePublish?.(),
+      onPublicationStateChanged: () => resolvedArgs.syncRuntime?.requestAccountMachinePublish?.(),
     });
     resolvedArgs.syncRuntime?.sharedSyncListener?.onLoopbackValidated(() => {
       void service.validateCurrentBridge().catch((error) => {

--- a/apps/ade-cli/src/cli.test.ts
+++ b/apps/ade-cli/src/cli.test.ts
@@ -1181,6 +1181,40 @@ describe("ADE CLI", () => {
     expect(output).toContain("Live processes must stop first.");
   });
 
+  it("formats the authoritative relay blocker without mistaking historical control errors for one", () => {
+    const plan = expectExecutePlan(buildCliPlan(["sync", "status"]));
+    const formatRelay = (skipReason: string | null) => formatOutput({
+      mode: "brain",
+      role: "brain",
+      runtimeRole: "host",
+      runtimeName: "Studio",
+      connectedPeers: [],
+      routeHealth: {
+        listener: { listenerBound: true, loopbackAdeValidated: true, port: 8787, reason: null },
+        tailscale: { enabled: false, tailscaleReachable: false, reason: null },
+        relay: {
+          enabled: true,
+          relayControlConnected: true,
+          relayBridgeValidated: true,
+          skipReason,
+          lastControlError: "Relay control closed (1012): historical restart",
+        },
+        accountDirectory: {
+          state: "published",
+          skipReason: null,
+          reachableEndpointCount: 1,
+        },
+      },
+    }, { text: true } as any, inferFormatter(plan));
+
+    const blocked = formatRelay("injected relay pipe open failure");
+    expect(blocked).toMatch(/relay\s+injected relay pipe open failure/);
+
+    const recovered = formatRelay(null);
+    expect(recovered).toMatch(/relay\s+reachable/);
+    expect(recovered).toContain("Relay control closed (1012): historical restart");
+  });
+
   it("formats sync web pairing info from sync status", () => {
     const plan = expectExecutePlan(buildCliPlan(["sync", "web"]));
     const connection = {

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -16106,11 +16106,12 @@ function formatSyncStatus(value: unknown): string {
   const tailscaleState = tailscale.tailscaleReachable === true
     ? "reachable"
     : asString(tailscale.reason) ?? (tailscale.enabled === true ? "not reachable" : "disabled");
-  const relaySkipReason = asString(relay.skipReason)
-    ?? asString(relay.lastControlError);
-  const relayState = relay.relayControlConnected === true && relay.relayBridgeValidated === true
-    ? "reachable"
-    : relaySkipReason ?? (relay.enabled === true ? "not reachable" : "disabled");
+  const relaySkipReason = asString(relay.skipReason);
+  const relayState = relaySkipReason
+    ?? (relay.relayControlConnected === true && relay.relayBridgeValidated === true
+      ? "reachable"
+      : asString(relay.lastControlError)
+        ?? (relay.enabled === true ? "not reachable" : "disabled"));
   const transferReadiness = isRecord(snapshot.transferReadiness)
     ? snapshot.transferReadiness
     : null;

--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -16107,11 +16107,15 @@ function formatSyncStatus(value: unknown): string {
     ? "reachable"
     : asString(tailscale.reason) ?? (tailscale.enabled === true ? "not reachable" : "disabled");
   const relaySkipReason = asString(relay.skipReason);
-  const relayState = relaySkipReason
-    ?? (relay.relayControlConnected === true && relay.relayBridgeValidated === true
-      ? "reachable"
-      : asString(relay.lastControlError)
-        ?? (relay.enabled === true ? "not reachable" : "disabled"));
+  let relayState: string;
+  if (relaySkipReason) {
+    relayState = relaySkipReason;
+  } else if (relay.relayControlConnected === true && relay.relayBridgeValidated === true) {
+    relayState = "reachable";
+  } else {
+    relayState = asString(relay.lastControlError)
+      ?? (relay.enabled === true ? "not reachable" : "disabled");
+  }
   const transferReadiness = isRecord(snapshot.transferReadiness)
     ? snapshot.transferReadiness
     : null;

--- a/apps/ade-cli/src/services/account/accountMachinePublisherService.test.ts
+++ b/apps/ade-cli/src/services/account/accountMachinePublisherService.test.ts
@@ -444,7 +444,10 @@ describe("account machine publisher health", () => {
   it("retains the verified Relay endpoint across a pipe blocker and republishes it on recovery", async () => {
     vi.useFakeTimers();
     const current = routeSnapshot();
-    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const fetchImpl = vi.fn(async (
+      _input: string | URL | Request,
+      _init?: RequestInit,
+    ) => new Response(null, { status: 200 }));
     const service = createAccountMachinePublisherService({
       getAccessToken: async () => "account-token",
       getAccountStatus: () => ({

--- a/apps/ade-cli/src/services/account/accountMachinePublisherService.test.ts
+++ b/apps/ade-cli/src/services/account/accountMachinePublisherService.test.ts
@@ -441,6 +441,51 @@ describe("account machine publisher health", () => {
     service.dispose();
   });
 
+  it("retains the verified Relay endpoint across a pipe blocker and republishes it on recovery", async () => {
+    vi.useFakeTimers();
+    const current = routeSnapshot();
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const service = createAccountMachinePublisherService({
+      getAccessToken: async () => "account-token",
+      getAccountStatus: () => ({
+        signedIn: true,
+        userId: "owner-a",
+        sessionReadState: "available" as const,
+      }),
+      getSnapshot: async () => current,
+      getMachineKey: () => "machine-studio",
+      directoryBaseUrl: () => "https://directory.example",
+      fetchImpl,
+    });
+
+    service.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    current.routeHealth.relay.skipReason = "injected relay pipe open failure";
+    await vi.advanceTimersByTimeAsync(ACCOUNT_MACHINE_RELAY_STATE_POLL_MS);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(String(fetchImpl.mock.calls[1]?.[1]?.body))).toEqual(
+      expect.objectContaining({
+        retainRelayEndpoints: true,
+        reachableEndpoints: expect.arrayContaining([
+          { kind: "relay", url: "wss://relay.example/connect/machine-studio" },
+        ]),
+      }),
+    );
+
+    current.routeHealth.relay.skipReason = null;
+    await vi.advanceTimersByTimeAsync(ACCOUNT_MACHINE_RELAY_STATE_POLL_MS);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    const recovered = JSON.parse(String(fetchImpl.mock.calls[2]?.[1]?.body));
+    expect(recovered.retainRelayEndpoints).toBeUndefined();
+    expect(recovered.reachableEndpoints).toContainEqual({
+      kind: "relay",
+      url: "wss://relay.example/connect/machine-studio",
+    });
+    service.dispose();
+  });
+
   it("does not retain a verified Relay route across account-owner changes", async () => {
     let accountOwnerId = "owner-a";
     const current = routeSnapshot();

--- a/apps/ade-cli/src/services/sync/syncLoopbackCollision.test.ts
+++ b/apps/ade-cli/src/services/sync/syncLoopbackCollision.test.ts
@@ -352,6 +352,80 @@ describe("sync loopback collision recovery", () => {
     },
   );
 
+  it.runIf(process.platform === "darwin")(
+    "keeps a current-generation bridge-open failure fail-closed until a fresh tunnel is ready",
+    async () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-sync-relay-pipe-failure-"));
+      const lockPath = path.join(projectRoot, "sync-host.lock");
+      const previousLockPath = process.env.ADE_SYNC_HOST_LOCK_PATH;
+      process.env.ADE_SYNC_HOST_LOCK_PATH = lockPath;
+      const listener = createSharedSyncListener({ bindHost: "127.0.0.1" });
+      const db = await openKvDb(path.join(projectRoot, ".ade", "kv.sqlite"), createLogger() as any);
+      (db.sync as { isAvailable?: () => boolean }).isAvailable = () => true;
+      const cloudRelayStore = createSyncCloudRelayStore({
+        filePath: path.join(projectRoot, ".ade", "secrets", "sync", "cloud-relay.json"),
+      });
+      const pipeFailure = "injected relay pipe open failure";
+      const tunnelStatus: SyncTunnelClientStatus = {
+        connected: true,
+        activeTunnels: 0,
+        lastError: pipeFailure,
+        bridgeOpenFailure: pipeFailure,
+        lastControlError: null,
+        relayBridgeValidated: true,
+        validatedPort: 8787,
+        lastFailureAt: "2026-07-22T12:00:00.000Z",
+        lastControlOpenAt: "2026-07-22T11:59:00.000Z",
+        lastBridgeValidationAt: "2026-07-22T11:59:30.000Z",
+        relayUrl: "https://relay.test.ade",
+        machineKey: "a".repeat(32),
+      };
+      const service = createService(db, projectRoot, {
+        sharedSyncListener: listener,
+        cloudRelayStore,
+        syncTunnelClientService: { getStatus: () => tunnelStatus },
+        accountAuthService: {
+          getStatus: () => ({ signedIn: true, userId: "relay-owner" }),
+        } as any,
+      });
+      const preferredPort = await findFreeLegacyPort();
+      tunnelStatus.validatedPort = preferredPort;
+      service.getDeviceRegistryService().touchLocalDevice({ lastPort: preferredPort });
+
+      try {
+        await service.initialize();
+        const blocked = await service.getStatus({ includeTransferReadiness: false });
+        expect(blocked.routeHealth.listener.loopbackAdeValidated).toBe(true);
+        expect(blocked.routeHealth.relay).toMatchObject({
+          enabled: true,
+          relayControlConnected: true,
+          relayBridgeValidated: true,
+          skipReason: pipeFailure,
+          lastFailureAt: "2026-07-22T12:00:00.000Z",
+        });
+
+        // A fresh tunnel's markReady clears only the current-generation
+        // blocker. The historical failure timestamp remains diagnostic.
+        tunnelStatus.bridgeOpenFailure = null;
+        tunnelStatus.activeTunnels = 1;
+        const recovered = await service.getStatus({ includeTransferReadiness: false });
+        expect(recovered.routeHealth.relay).toMatchObject({
+          relayControlConnected: true,
+          relayBridgeValidated: true,
+          skipReason: null,
+          lastFailureAt: "2026-07-22T12:00:00.000Z",
+        });
+      } finally {
+        await service.dispose();
+        await listener.close();
+        db.close();
+        fs.rmSync(projectRoot, { recursive: true, force: true });
+        if (previousLockPath === undefined) delete process.env.ADE_SYNC_HOST_LOCK_PATH;
+        else process.env.ADE_SYNC_HOST_LOCK_PATH = previousLockPath;
+      }
+    },
+  );
+
   // Finding #1: a bare `ws`-style 426 (no ADE marker) must be rejected, while the
   // real ADE listener — whose 426 carries the marker — passes. Status code alone
   // cannot tell ADE apart from any other WebSocket process.

--- a/apps/ade-cli/src/services/sync/syncService.ts
+++ b/apps/ade-cli/src/services/sync/syncService.ts
@@ -1375,10 +1375,12 @@ export function createSyncService(args: SyncServiceArgs) {
           : !tunnelStatus
             ? "Relay tunnel status is unavailable in this ADE process."
             : !relayControlConnected
-              ? tunnelStatus.lastError ?? "Relay control is not connected."
+              ? tunnelStatus.lastControlError
+                ?? tunnelStatus.lastError
+                ?? "Relay control is not connected."
               : !relayBridgeValidated
                 ? tunnelStatus.lastError ?? `Relay bridge to 127.0.0.1:${listenerPort} has not been validated against the current sync port.`
-                : tunnelStatus.lastError;
+                : tunnelStatus.bridgeOpenFailure ?? null;
       let accountDirectory: SyncAccountDirectoryHealth;
       try {
         accountDirectory = args.getAccountDirectoryHealth?.() ?? createSyncAccountDirectoryHealth(

--- a/apps/ade-cli/src/services/sync/syncTunnelClientService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncTunnelClientService.test.ts
@@ -811,7 +811,17 @@ describe("createSyncTunnelClientService", () => {
   it("keeps a failed pipe diagnostic until a fresh tunnel reaches ready", async () => {
     const sockets: StubWebSocket[] = [];
     const expectedNonce = "c".repeat(32);
-    const onRouteStateChanged = vi.fn();
+    const onPublicationStateChanged = vi.fn();
+    const latestBridgeSockets = (connectionId: string): {
+      pipe: StubWebSocket;
+      local: StubWebSocket;
+    } => {
+      const [pipe, local] = sockets.slice(-2);
+      if (!pipe || !local) throw new Error(`missing bridge sockets for ${connectionId}`);
+      expect(pipe.url).toContain(`/pipe/${connectionId}`);
+      expect(local.url).toBe("ws://127.0.0.1:8787");
+      return { pipe, local };
+    };
     const loopbackProbe = vi.fn(async (port: number) => ({
       ok: true as const,
       port,
@@ -829,7 +839,7 @@ describe("createSyncTunnelClientService", () => {
       getRelayBridgeProof: () => "e".repeat(43),
       configStore: fakeStore(),
       loopbackProbe,
-      onRouteStateChanged,
+      onPublicationStateChanged,
       reconnectBackoffMs: () => 0,
       createWebSocket: (url) => {
         const socket = new StubWebSocket(url);
@@ -847,21 +857,19 @@ describe("createSyncTunnelClientService", () => {
 
       control.receive(epochOpen(control.url, "abcdef10"));
       await vi.waitFor(() => expect(sockets).toHaveLength(3));
-      const cancelledPipe = sockets.find((socket) => socket.url.includes("/pipe/abcdef10"));
-      expect(cancelledPipe).toBeTruthy();
-      cancelledPipe!.remoteClose(1000, "candidate cancelled");
+      const cancelledBridge = latestBridgeSockets("abcdef10");
+      cancelledBridge.pipe.remoteClose(1000, "candidate cancelled");
       await vi.waitFor(() => expect(service.getStatus().activeTunnels).toBe(0));
       expect(service.getStatus()).toMatchObject({
         lastError: null,
         bridgeOpenFailure: null,
       });
-      expect(onRouteStateChanged).not.toHaveBeenCalled();
+      expect(onPublicationStateChanged).not.toHaveBeenCalled();
 
       control.receive(epochOpen(control.url, "abcdef11"));
       await vi.waitFor(() => expect(sockets).toHaveLength(5));
-      const firstPipe = sockets.find((socket) => socket.url.includes("/pipe/abcdef11"));
-      expect(firstPipe).toBeTruthy();
-      firstPipe!.emit("error", new Error("injected relay pipe open failure"));
+      const failedBridge = latestBridgeSockets("abcdef11");
+      failedBridge.pipe.emit("error", new Error("injected relay pipe open failure"));
 
       const failedAt = service.getStatus().lastFailureAt;
       expect(service.getStatus()).toMatchObject({
@@ -879,16 +887,16 @@ describe("createSyncTunnelClientService", () => {
       await expect(service.validateCurrentBridge()).resolves.toBe(true);
       expect(loopbackProbe).toHaveBeenCalledOnce();
       expect(service.getStatus().lastError).toBe("injected relay pipe open failure");
-      await vi.waitFor(() => expect(onRouteStateChanged).toHaveBeenCalledOnce());
+      await vi.waitFor(() => {
+        expect(onPublicationStateChanged).toHaveBeenCalledOnce();
+        expect(onPublicationStateChanged).toHaveBeenLastCalledWith("route-state-changed");
+      });
 
       control.receive(epochOpen(control.url, "abcdef12"));
       await vi.waitFor(() => expect(sockets).toHaveLength(7));
-      const secondPipe = sockets.find((socket) => socket.url.includes("/pipe/abcdef12"));
-      const secondLocal = sockets[6];
-      expect(secondPipe).toBeTruthy();
-      expect(secondLocal.url).toBe("ws://127.0.0.1:8787");
-      secondPipe!.open();
-      secondLocal.open();
+      const recoveredBridge = latestBridgeSockets("abcdef12");
+      recoveredBridge.pipe.open();
+      recoveredBridge.local.open();
 
       await vi.waitFor(() => {
         expect(control.sent.map((raw) => JSON.parse(raw) as { t?: string; id?: string }))
@@ -901,16 +909,15 @@ describe("createSyncTunnelClientService", () => {
           bridgeOpenFailure: null,
           lastFailureAt: failedAt,
         });
-        expect(onRouteStateChanged).toHaveBeenCalledTimes(2);
+        expect(onPublicationStateChanged).toHaveBeenCalledTimes(2);
       });
 
       // A secondary/losing attempt cannot poison the route while another
       // tunnel is already carrying authenticated traffic.
       control.receive(epochOpen(control.url, "abcdef13"));
       await vi.waitFor(() => expect(sockets).toHaveLength(9));
-      const thirdPipe = sockets.find((socket) => socket.url.includes("/pipe/abcdef13"));
-      expect(thirdPipe).toBeTruthy();
-      thirdPipe!.emit("error", new Error("secondary pipe failure"));
+      const secondaryBridge = latestBridgeSockets("abcdef13");
+      secondaryBridge.pipe.emit("error", new Error("secondary pipe failure"));
       expect(service.getStatus()).toMatchObject({
         connected: true,
         relayBridgeValidated: true,
@@ -918,13 +925,14 @@ describe("createSyncTunnelClientService", () => {
         lastError: null,
         bridgeOpenFailure: null,
       });
-      expect(onRouteStateChanged).toHaveBeenCalledTimes(2);
+      expect(onPublicationStateChanged).toHaveBeenCalledTimes(2);
 
       // Ready data tunnels can outlive their control socket. They prove only
       // their own generation and must not mask a new-generation setup failure.
       control.remoteClose();
       await vi.waitFor(() => expect(sockets).toHaveLength(10));
-      const replacementControl = sockets[9];
+      const replacementControl = sockets.at(-1);
+      if (!replacementControl) throw new Error("missing replacement control socket");
       replacementControl.open();
       await vi.waitFor(() => {
         expect(loopbackProbe).toHaveBeenCalledTimes(2);
@@ -932,9 +940,8 @@ describe("createSyncTunnelClientService", () => {
       });
       replacementControl.receive(epochOpen(replacementControl.url, "abcdef14"));
       await vi.waitFor(() => expect(sockets).toHaveLength(12));
-      const replacementPipe = sockets.find((socket) => socket.url.includes("/pipe/abcdef14"));
-      expect(replacementPipe).toBeTruthy();
-      replacementPipe!.emit("error", new Error("new-generation pipe failure"));
+      const replacementBridge = latestBridgeSockets("abcdef14");
+      replacementBridge.pipe.emit("error", new Error("new-generation pipe failure"));
       expect(service.getStatus()).toMatchObject({
         connected: true,
         relayBridgeValidated: true,
@@ -942,7 +949,7 @@ describe("createSyncTunnelClientService", () => {
         lastError: "new-generation pipe failure",
         bridgeOpenFailure: "new-generation pipe failure",
       });
-      await vi.waitFor(() => expect(onRouteStateChanged).toHaveBeenCalledTimes(3));
+      await vi.waitFor(() => expect(onPublicationStateChanged).toHaveBeenCalledTimes(3));
     } finally {
       await service.dispose();
       globalThis.fetch = originalFetch;
@@ -1397,14 +1404,14 @@ describe("createSyncTunnelClientService", () => {
       .mockResolvedValueOnce(new Response(null, { status: 409 }))
       .mockResolvedValueOnce(new Response(null, { status: 201 }));
     globalThis.fetch = fetchMock;
-    const onIdentityRotated = vi.fn();
+    const onPublicationStateChanged = vi.fn();
     const store = fakeStore(`http://127.0.0.1:${relayPort}`);
     const service = createSyncTunnelClientService({
       getSyncPort: () => 8787,
       getExpectedLoopbackNonce: () => "f".repeat(32),
       getRelayBridgeProof: () => "e".repeat(43),
       configStore: store,
-      onIdentityRotated,
+      onPublicationStateChanged,
       loopbackProbe: async (port, expectedNonce) => ({
         ok: true,
         port,
@@ -1420,14 +1427,17 @@ describe("createSyncTunnelClientService", () => {
       await service.start();
       await upgradeStarted;
       await expect(service.validateCurrentBridge()).resolves.toBe(true);
-      expect(onIdentityRotated).not.toHaveBeenCalled();
+      expect(onPublicationStateChanged).not.toHaveBeenCalled();
       pendingUpgrade.release?.();
       delete pendingUpgrade.release;
       await vi.waitFor(() => expect(service.getStatus().connected).toBe(true));
       expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(store.getMachineIdentity().machineKey).toBe("c".repeat(32));
       expect(service.getStatus().machineKey).toBe("c".repeat(32));
-      await vi.waitFor(() => expect(onIdentityRotated).toHaveBeenCalledOnce());
+      await vi.waitFor(() => {
+        expect(onPublicationStateChanged).toHaveBeenCalledOnce();
+        expect(onPublicationStateChanged).toHaveBeenCalledWith("identity-rotated");
+      });
     } finally {
       pendingUpgrade.release?.();
       await service.dispose();

--- a/apps/ade-cli/src/services/sync/syncTunnelClientService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncTunnelClientService.test.ts
@@ -808,6 +808,147 @@ describe("createSyncTunnelClientService", () => {
     }
   });
 
+  it("keeps a failed pipe diagnostic until a fresh tunnel reaches ready", async () => {
+    const sockets: StubWebSocket[] = [];
+    const expectedNonce = "c".repeat(32);
+    const onRouteStateChanged = vi.fn();
+    const loopbackProbe = vi.fn(async (port: number) => ({
+      ok: true as const,
+      port,
+      statusCode: 426,
+      statusMessage: "Upgrade Required",
+      markerValue: expectedNonce,
+      checkedAt: new Date().toISOString(),
+      reason: null,
+    }));
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => new Response(null, { status: 204 });
+    const service = createSyncTunnelClientService({
+      getSyncPort: () => 8787,
+      getExpectedLoopbackNonce: () => expectedNonce,
+      getRelayBridgeProof: () => "e".repeat(43),
+      configStore: fakeStore(),
+      loopbackProbe,
+      onRouteStateChanged,
+      reconnectBackoffMs: () => 0,
+      createWebSocket: (url) => {
+        const socket = new StubWebSocket(url);
+        sockets.push(socket);
+        return socket as unknown as WebSocket;
+      },
+    });
+
+    try {
+      await service.start();
+      const control = sockets[0];
+      control.open();
+      await vi.waitFor(() => expect(service.getStatus().relayBridgeValidated).toBe(true));
+      expect(loopbackProbe).toHaveBeenCalledOnce();
+
+      control.receive(epochOpen(control.url, "abcdef10"));
+      await vi.waitFor(() => expect(sockets).toHaveLength(3));
+      const cancelledPipe = sockets.find((socket) => socket.url.includes("/pipe/abcdef10"));
+      expect(cancelledPipe).toBeTruthy();
+      cancelledPipe!.remoteClose(1000, "candidate cancelled");
+      await vi.waitFor(() => expect(service.getStatus().activeTunnels).toBe(0));
+      expect(service.getStatus()).toMatchObject({
+        lastError: null,
+        bridgeOpenFailure: null,
+      });
+      expect(onRouteStateChanged).not.toHaveBeenCalled();
+
+      control.receive(epochOpen(control.url, "abcdef11"));
+      await vi.waitFor(() => expect(sockets).toHaveLength(5));
+      const firstPipe = sockets.find((socket) => socket.url.includes("/pipe/abcdef11"));
+      expect(firstPipe).toBeTruthy();
+      firstPipe!.emit("error", new Error("injected relay pipe open failure"));
+
+      const failedAt = service.getStatus().lastFailureAt;
+      expect(service.getStatus()).toMatchObject({
+        connected: true,
+        relayBridgeValidated: true,
+        activeTunnels: 0,
+        lastError: "injected relay pipe open failure",
+        bridgeOpenFailure: "injected relay pipe open failure",
+        lastControlError: null,
+      });
+      expect(failedAt).not.toBeNull();
+
+      // A cached/proactive loopback probe does not prove that the Relay pipe
+      // recovered, so it must not erase the diagnostic or publish success.
+      await expect(service.validateCurrentBridge()).resolves.toBe(true);
+      expect(loopbackProbe).toHaveBeenCalledOnce();
+      expect(service.getStatus().lastError).toBe("injected relay pipe open failure");
+      await vi.waitFor(() => expect(onRouteStateChanged).toHaveBeenCalledOnce());
+
+      control.receive(epochOpen(control.url, "abcdef12"));
+      await vi.waitFor(() => expect(sockets).toHaveLength(7));
+      const secondPipe = sockets.find((socket) => socket.url.includes("/pipe/abcdef12"));
+      const secondLocal = sockets[6];
+      expect(secondPipe).toBeTruthy();
+      expect(secondLocal.url).toBe("ws://127.0.0.1:8787");
+      secondPipe!.open();
+      secondLocal.open();
+
+      await vi.waitFor(() => {
+        expect(control.sent.map((raw) => JSON.parse(raw) as { t?: string; id?: string }))
+          .toContainEqual(expect.objectContaining({ t: "ready", id: "abcdef12" }));
+        expect(service.getStatus()).toMatchObject({
+          connected: true,
+          relayBridgeValidated: true,
+          activeTunnels: 1,
+          lastError: null,
+          bridgeOpenFailure: null,
+          lastFailureAt: failedAt,
+        });
+        expect(onRouteStateChanged).toHaveBeenCalledTimes(2);
+      });
+
+      // A secondary/losing attempt cannot poison the route while another
+      // tunnel is already carrying authenticated traffic.
+      control.receive(epochOpen(control.url, "abcdef13"));
+      await vi.waitFor(() => expect(sockets).toHaveLength(9));
+      const thirdPipe = sockets.find((socket) => socket.url.includes("/pipe/abcdef13"));
+      expect(thirdPipe).toBeTruthy();
+      thirdPipe!.emit("error", new Error("secondary pipe failure"));
+      expect(service.getStatus()).toMatchObject({
+        connected: true,
+        relayBridgeValidated: true,
+        activeTunnels: 1,
+        lastError: null,
+        bridgeOpenFailure: null,
+      });
+      expect(onRouteStateChanged).toHaveBeenCalledTimes(2);
+
+      // Ready data tunnels can outlive their control socket. They prove only
+      // their own generation and must not mask a new-generation setup failure.
+      control.remoteClose();
+      await vi.waitFor(() => expect(sockets).toHaveLength(10));
+      const replacementControl = sockets[9];
+      replacementControl.open();
+      await vi.waitFor(() => {
+        expect(loopbackProbe).toHaveBeenCalledTimes(2);
+        expect(service.getStatus().relayBridgeValidated).toBe(true);
+      });
+      replacementControl.receive(epochOpen(replacementControl.url, "abcdef14"));
+      await vi.waitFor(() => expect(sockets).toHaveLength(12));
+      const replacementPipe = sockets.find((socket) => socket.url.includes("/pipe/abcdef14"));
+      expect(replacementPipe).toBeTruthy();
+      replacementPipe!.emit("error", new Error("new-generation pipe failure"));
+      expect(service.getStatus()).toMatchObject({
+        connected: true,
+        relayBridgeValidated: true,
+        activeTunnels: 1,
+        lastError: "new-generation pipe failure",
+        bridgeOpenFailure: "new-generation pipe failure",
+      });
+      await vi.waitFor(() => expect(onRouteStateChanged).toHaveBeenCalledTimes(3));
+    } finally {
+      await service.dispose();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("closes both tunnel sides with 4509 when Node's live send queue is full", async () => {
     const sockets: StubWebSocket[] = [];
     const expectedNonce = "c".repeat(32);

--- a/apps/ade-cli/src/services/sync/syncTunnelClientService.ts
+++ b/apps/ade-cli/src/services/sync/syncTunnelClientService.ts
@@ -28,6 +28,8 @@ export type SyncTunnelClientStatus = {
   connected: boolean;
   activeTunnels: number;
   lastError: string | null;
+  /** Current-generation pipe/local setup blocker; additive for older consumers. */
+  bridgeOpenFailure?: string | null;
   lastControlError: string | null;
   relayBridgeValidated: boolean;
   validatedPort: number | null;
@@ -79,6 +81,8 @@ type SyncTunnelClientArgs = {
   ) => WebSocket;
   /** Requests a fresh directory publication after a confirmed-409 identity rotation opens. */
   onIdentityRotated?: () => void | Promise<void>;
+  /** Requests a directory refresh when a Relay bridge-open failure recovers or becomes unhealthy. */
+  onRouteStateChanged?: () => void | Promise<void>;
 };
 
 const BACKOFF_BASE_MS = 1_000;
@@ -241,6 +245,7 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
   let connected = false;
   let lastError: string | null = null;
   let lastControlError: string | null = null;
+  let bridgeOpenFailure: { key: string; reason: string } | null = null;
   let validatedPort: number | null = null;
   let validatedLoopbackNonce: string | null = null;
   let lastFailureAt: string | null = null;
@@ -273,6 +278,25 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
     lastFailureAt = new Date().toISOString();
   };
 
+  const requestRouteStatePublish = (): void => {
+    void Promise.resolve()
+      .then(() => args.onRouteStateChanged?.())
+      .catch((error) => {
+        log.warn?.("sync_tunnel.route_state_republish_failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+  };
+
+  const clearBridgeOpenFailure = (expectedKey?: string): void => {
+    if (!bridgeOpenFailure) return;
+    if (expectedKey && bridgeOpenFailure.key !== expectedKey) return;
+    const previousFailure = bridgeOpenFailure;
+    bridgeOpenFailure = null;
+    if (lastError === previousFailure.reason) lastError = null;
+    requestRouteStatePublish();
+  };
+
   const clearBridgeValidation = (): void => {
     validatedPort = null;
     validatedLoopbackNonce = null;
@@ -290,6 +314,7 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
     controlGeneration += 1;
     clearControlReadyTimer();
     clearBridgeValidation();
+    clearBridgeOpenFailure();
   };
 
   const recordControlFailure = (reason: string): void => {
@@ -770,7 +795,9 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
       validatedLoopbackNonce = expectedLoopbackNonce;
       validatedAtMs = Date.now();
       validatedBridgeKey = identityAtStart.key;
-      lastError = null;
+      // A loopback probe alone cannot prove a failed Relay pipe recovered.
+      // Only a later tunnel reaching markReady clears a bridge-open failure.
+      if (bridgeOpenFailure?.key !== identityAtStart.key) lastError = null;
       lastBridgeValidationAt = result.checkedAt;
       log.debug?.("sync_tunnel.bridge_validated", { port });
       publishRotatedIdentityIfReady();
@@ -791,6 +818,9 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
   const validateCurrentBridge = (): Promise<boolean> => {
     if (stopped) return Promise.resolve(false);
     const currentIdentity = bridgeValidationIdentity();
+    if (bridgeOpenFailure && bridgeOpenFailure.key !== currentIdentity.key) {
+      clearBridgeOpenFailure();
+    }
     if (validatedBridgeKey != null && validatedBridgeKey !== currentIdentity.key) {
       clearBridgeValidation();
     }
@@ -819,6 +849,34 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
       });
     bridgeValidationInFlight = { key: currentIdentity.key, promise: current };
     return current;
+  };
+
+  const recordBridgeOpenFailure = (
+    reason: string,
+    bridgeKey: string,
+    failedTunnel?: Tunnel,
+  ): void => {
+    const hasReadyBridge = [...tunnels].some(
+      (tunnel) => tunnel !== failedTunnel && tunnel.ready && tunnel.bridgeKey === bridgeKey,
+    );
+    if (hasReadyBridge) {
+      lastFailureAt = new Date().toISOString();
+      log.warn?.("sync_tunnel.bridge_open_failed", {
+        connectionId: failedTunnel?.connectionId ?? null,
+        error: reason,
+        routeRetained: true,
+      });
+      return;
+    }
+    const stateChanged = bridgeOpenFailure?.key !== bridgeKey;
+    bridgeOpenFailure = { key: bridgeKey, reason };
+    recordFailure(reason);
+    log.warn?.("sync_tunnel.bridge_open_failed", {
+      connectionId: failedTunnel?.connectionId ?? null,
+      error: reason,
+      routeRetained: false,
+    });
+    if (stateChanged) requestRouteStatePublish();
   };
 
   const sendControlLifecycle = (
@@ -950,7 +1008,7 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
       });
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
-      recordFailure(reason);
+      recordBridgeOpenFailure(reason, validatedKey);
       if (pipe) safeCloseWebSocket(pipe, RELAY_CLOSE_BRIDGE_REJECTED, "bridge setup failed");
       rejectOpen(
         pipe ? RELAY_CLOSE_HOST_UNAVAILABLE : RELAY_CLOSE_BRIDGE_REJECTED,
@@ -959,11 +1017,24 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
       return;
     }
 
-    const tunnel: Tunnel = { pipe, local, connectionId, controlSocket, ready: false };
+    const tunnel: Tunnel = {
+      pipe,
+      local,
+      connectionId,
+      controlSocket,
+      bridgeKey: validatedKey,
+      ready: false,
+    };
     tunnels.add(tunnel);
     let pipeOpen = false;
     let localOpen = false;
+    let bridgeFailureReported = false;
     const bridgeReady = (): boolean => pipeOpen && localOpen;
+    const reportBridgeFailure = (reason: string): void => {
+      if (tunnel.ready || bridgeFailureReported) return;
+      bridgeFailureReported = true;
+      recordBridgeOpenFailure(reason, validatedKey, tunnel);
+    };
     const closeBoth = (sourceCode: number, sourceReason: unknown): void => {
       if (!tunnels.delete(tunnel)) return;
       const code = applicationCloseCode(sourceCode);
@@ -1001,6 +1072,7 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
         }
       }
       tunnel.ready = true;
+      clearBridgeOpenFailure(validatedKey);
       acceptOpen();
       log.debug?.("sync_tunnel.ready", {
         connectionId,
@@ -1010,11 +1082,11 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
     };
 
     armOpenDeadline(pipe, () => {
-      recordFailure("relay pipe connect timed out");
+      reportBridgeFailure("relay pipe connect timed out");
       rejectOpen(RELAY_CLOSE_BRIDGE_REJECTED, "relay pipe unavailable");
     });
     armOpenDeadline(local, () => {
-      recordFailure("local sync socket connect timed out");
+      reportBridgeFailure("local sync socket connect timed out");
       rejectOpen(RELAY_CLOSE_HOST_UNAVAILABLE, "host sync listener unavailable");
     });
 
@@ -1032,7 +1104,10 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
     // Legacy Workers may flush an early hello before the local socket opens;
     // keep one bounded aggregate queue. Ready-v2 Workers wait for markReady.
     const forwardOrBuffer = makeBufferedForwarder((reason) => {
-      if (!tunnel.ready) rejectOpen(RELAY_CLOSE_BRIDGE_REJECTED, reason);
+      if (!tunnel.ready) {
+        reportBridgeFailure(reason);
+        rejectOpen(RELAY_CLOSE_BRIDGE_REJECTED, reason);
+      }
       closeBoth(RELAY_CLOSE_FORWARD_FAILED, reason);
     });
     pipe.on("message", (data: RawData, isBinary: boolean) => forwardOrBuffer(local, data, isBinary));
@@ -1048,13 +1123,23 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
       closeBoth(code, reason);
     });
     pipe.on("error", (error: Error) => {
-      recordFailure(error.message);
-      if (!tunnel.ready) rejectOpen(RELAY_CLOSE_BRIDGE_REJECTED, "relay pipe unavailable");
+      if (!tunnel.ready) {
+        reportBridgeFailure(error.message);
+        rejectOpen(RELAY_CLOSE_BRIDGE_REJECTED, "relay pipe unavailable");
+      } else {
+        lastFailureAt = new Date().toISOString();
+        log.warn?.("sync_tunnel.pipe_error", { connectionId, error: error.message });
+      }
       closeBoth(RELAY_CLOSE_PARTNER_CLOSED, "relay pipe error");
     });
     local.on("error", (error: Error) => {
-      recordFailure(error.message);
-      if (!tunnel.ready) rejectOpen(RELAY_CLOSE_HOST_UNAVAILABLE, "host sync listener unavailable");
+      if (!tunnel.ready) {
+        reportBridgeFailure(error.message);
+        rejectOpen(RELAY_CLOSE_HOST_UNAVAILABLE, "host sync listener unavailable");
+      } else {
+        lastFailureAt = new Date().toISOString();
+        log.warn?.("sync_tunnel.local_error", { connectionId, error: error.message });
+      }
       closeBoth(RELAY_CLOSE_PARTNER_CLOSED, "host sync listener error");
     });
 
@@ -1100,6 +1185,7 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
       accountGeneration += 1;
       clearControlReadyTimer();
       clearBridgeValidation();
+      clearBridgeOpenFailure();
     }
     accountEligible = nextEligibility;
     if (!nextEligibility) {
@@ -1131,6 +1217,7 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
           accountGeneration += 1;
           clearControlReadyTimer();
           clearBridgeValidation();
+          clearBridgeOpenFailure();
           closeRelayConnections(nextUserId ? "account identity changed" : "account lease unavailable");
         }
       } catch (error) {
@@ -1197,11 +1284,15 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
       const currentPort = currentValidationIdentity.port;
       const currentLoopbackNonce = currentValidationIdentity.nonce;
       const eligible = accountSignedIn();
+      const currentBridgeOpenFailure = bridgeOpenFailure?.key === currentValidationIdentity.key
+        ? bridgeOpenFailure.reason
+        : null;
       return {
         accountLeaseValid: eligible,
         connected: eligible && connected,
         activeTunnels: eligible ? tunnels.size : 0,
         lastError: eligible ? lastError : RELAY_SIGN_IN_REQUIRED_MESSAGE,
+        bridgeOpenFailure: eligible ? currentBridgeOpenFailure : null,
         lastControlError,
         relayBridgeValidated: eligible
           && currentPort != null
@@ -1229,6 +1320,7 @@ type Tunnel = {
   local: WebSocket;
   connectionId: string;
   controlSocket: WebSocket;
+  bridgeKey: string;
   ready: boolean;
 };
 

--- a/apps/ade-cli/src/services/sync/syncTunnelClientService.ts
+++ b/apps/ade-cli/src/services/sync/syncTunnelClientService.ts
@@ -79,10 +79,10 @@ type SyncTunnelClientArgs = {
     url: string,
     options?: { headers?: Record<string, string> },
   ) => WebSocket;
-  /** Requests a fresh directory publication after a confirmed-409 identity rotation opens. */
-  onIdentityRotated?: () => void | Promise<void>;
-  /** Requests a directory refresh when a Relay bridge-open failure recovers or becomes unhealthy. */
-  onRouteStateChanged?: () => void | Promise<void>;
+  /** Requests a directory refresh when publication-relevant Relay state changes. */
+  onPublicationStateChanged?: (
+    reason: "identity-rotated" | "route-state-changed",
+  ) => void | Promise<void>;
 };
 
 const BACKOFF_BASE_MS = 1_000;
@@ -278,11 +278,16 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
     lastFailureAt = new Date().toISOString();
   };
 
-  const requestRouteStatePublish = (): void => {
+  const requestPublicationStatePublish = (
+    reason: "identity-rotated" | "route-state-changed",
+  ): void => {
+    const failureEvent = reason === "identity-rotated"
+      ? "sync_tunnel.identity_republish_failed"
+      : "sync_tunnel.route_state_republish_failed";
     void Promise.resolve()
-      .then(() => args.onRouteStateChanged?.())
+      .then(() => args.onPublicationStateChanged?.(reason))
       .catch((error) => {
-        log.warn?.("sync_tunnel.route_state_republish_failed", {
+        log.warn?.(failureEvent, {
           error: error instanceof Error ? error.message : String(error),
         });
       });
@@ -294,7 +299,7 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
     const previousFailure = bridgeOpenFailure;
     bridgeOpenFailure = null;
     if (lastError === previousFailure.reason) lastError = null;
-    requestRouteStatePublish();
+    requestPublicationStatePublish("route-state-changed");
   };
 
   const clearBridgeValidation = (): void => {
@@ -325,13 +330,7 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
   const publishRotatedIdentityIfReady = (): void => {
     if (!identityRotationPendingPublish || !connected) return;
     identityRotationPendingPublish = false;
-    void Promise.resolve()
-      .then(() => args.onIdentityRotated?.())
-      .catch((error) => {
-        log.warn?.("sync_tunnel.identity_republish_failed", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      });
+    requestPublicationStatePublish("identity-rotated");
   };
 
   const identity = (): MachineIdentity => {
@@ -876,7 +875,7 @@ export function createSyncTunnelClientService(args: SyncTunnelClientArgs): SyncT
       error: reason,
       routeRetained: false,
     });
-    if (stateChanged) requestRouteStatePublish();
+    if (stateChanged) requestPublicationStatePublish("route-state-changed");
   };
 
   const sendControlLifecycle = (

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.34">
-  v1.2.34 - Web sessions hydrate in bounded stages, sync stays fair under load, terminal recovery is atomic, and desktop project work remains responsive.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.35">
+  v1.2.35 - Relay bridge failures recover cleanly, healthy routes stay published, and sync status reports current reachability truthfully.
 </Card>

--- a/changelog/v1.2.35.mdx
+++ b/changelog/v1.2.35.mdx
@@ -1,0 +1,15 @@
+---
+title: "v1.2.35"
+description: "Release notes for ADE v1.2.35 - July 22, 2026"
+---
+
+v1.2.35 closes a lower-level Relay recovery gap found while validating v1.2.34 against a live machine.
+
+---
+
+## Reliable Relay recovery
+
+- **A failed bridge cannot look healthy.** A real Relay pipe or local-listener setup failure now blocks the current route until a fresh tunnel is fully ready; a cached loopback probe cannot clear it early.
+- **Healthy connections stay healthy.** A failed secondary connection attempt does not poison an already-ready Relay tunnel, and cancelled connection-race candidates are ignored.
+- **Cloud presence follows the real route.** ADE republishes directory state when the active bridge becomes blocked or recovers, while retaining the last verified endpoint during the bounded recovery window.
+- **Diagnostics report the current failure.** Sync status prioritizes authoritative route blockers and no longer presents an old control error as a current outage after recovery.

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -729,11 +729,15 @@ Canonical files (`apps/ade-cli/src/services/sync/`):
   guarded reconnect state machine without waking the hibernated Durable Object
   with JSON traffic. Opens that fail validation, local-listener setup, or pipe
   setup send a bounded `{t:"reject"}` signal so the waiting controller closes
-  immediately instead of hanging. Pipe/local application close codes and
-  sanitized reasons are preserved across the bridge; other closes normalize to
-  `4000`. Account loss clears validation and all sockets, while account switches
-  force a clean control reconnect. Control observability preserves the
-  causal failure rather than replacing it with a generic WebSocket error:
+  immediately instead of hanging. A real pipe/local setup error or timeout is
+  also a generation-scoped publication blocker until a fresh tunnel reaches
+  `ready`; cached loopback validation cannot clear it, ordinary cancelled
+  candidate closes do not create it, and a failed secondary attempt cannot
+  poison a route that already has a ready tunnel. Pipe/local application close
+  codes and sanitized reasons are preserved across the bridge; other closes
+  normalize to `4000`. Account loss clears validation and all sockets, while
+  account switches force a clean control reconnect. Control observability
+  preserves the causal failure rather than replacing it with a generic WebSocket error:
   upgrade rejection captures the HTTP status and at most 512 sanitized response
   bytes; close telemetry records code, reason, and whether the socket opened.
   `sync_tunnel.claimed`, `.claim_failed`, `.control_open`, `.control_error`, and


### PR DESCRIPTION
## Summary

- keep real Relay pipe and local-listener setup failures fail-closed for the current connection generation until a fresh tunnel reaches ready
- preserve an already-ready Relay route when a secondary attempt fails, and republish account-directory state when the active route blocks or recovers
- report authoritative bridge blockers ahead of stale historical errors in sync diagnostics
- document the recovery contract and prepare v1.2.35 release notes

## Validation

- `npm --prefix apps/ade-cli run typecheck`
- `npm --prefix apps/ade-cli run test` (96 files, 2,147 tests)
- `npm --prefix apps/ade-cli run build`
- `npm --prefix apps/desktop run typecheck`
- `node scripts/validate-docs.mjs` (200 files)
- focused Relay/loopback/publisher/CLI suite (4 files, 361 tests)
- independent correctness and maintainability review

## Compatibility

- the tunnel status field is additive; the Worker wire protocol is unchanged
- no iOS payload, schema, or command contract changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved relay status reporting with clearer connection and failure details.
  * Automatically refreshes route information when relay health changes.
  * Preserves verified relay endpoints during temporary pipe failures and restores normal publishing after recovery.
* **Bug Fixes**
  * Retains accurate bridge failure diagnostics until a new tunnel is ready.
  * Prevents stale relay errors from masking current relay health.
  * Preserves historical failure timestamps across relay recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves Relay recovery and status reporting for sync routes. The main changes are:

- Tracks current-generation Relay pipe and local bridge setup failures until a fresh tunnel reaches `ready`.
- Preserves already-ready Relay routes when secondary attempts fail.
- Republishes account-directory state when the active Relay route becomes blocked or recovers.
- Updates CLI status output to prefer current Relay blockers over stale control errors.
- Adds focused tests and release documentation for the recovery behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are focused on Relay state tracking and diagnostics, with targeted tests covering blocker persistence, recovery, retained healthy routes, publisher behavior, and CLI status formatting. No blocking correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding.
- T-Rex ran the relay/loopback/publisher validation and finished with exit code 0 after 8 seconds, reporting 3 test files passed and a total of 77 tests passed with 3 skipped (80 total).
- T-Rex executed CLI diagnostics after the prior step, which finished with exit code 1 after 20 seconds and reported 1 failed test (1) and 279 passed with 1 skipped (281 total).
- T-Rex included a reproduction script transcript to capture the exact commands used for the executed validation.

<a href="https://app.greptile.com/trex/runs/15487213/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/services/sync/syncTunnelClientService.ts | Introduces generation-scoped bridge-open failure state and publication callbacks for route block/recovery events. |
| apps/ade-cli/src/services/sync/syncService.ts | Adjusts route health reasoning to distinguish control errors from bridge-open blockers. |
| apps/ade-cli/src/bootstrap.ts | Wires the tunnel client publication callback through the renamed publication-state hook. |
| apps/ade-cli/src/services/sync/syncTunnelClientService.test.ts | Adds detailed tunnel client coverage for bridge-open blockers, publication triggers, recovery, and retained active tunnels. |
| apps/ade-cli/src/services/account/accountMachinePublisherService.test.ts | Adds publisher coverage for retaining verified Relay endpoints during a blocker and clearing retention after recovery. |
| apps/ade-cli/src/cli.ts | Updates Relay status formatting to show authoritative skip reasons before reachability and stale control errors. |
| docs/features/sync-and-multi-device/README.md | Documents the Relay bridge recovery contract and publication blocker semantics. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Worker as Relay Worker
  participant Tunnel as SyncTunnelClientService
  participant Local as Local ADE listener
  participant Publisher as AccountMachinePublisher
  participant Directory as Account Directory

  Worker->>Tunnel: control open request
  Tunnel->>Local: validate loopback listener
  Local-->>Tunnel: ADE marker validated
  Worker->>Tunnel: data pipe open
  Tunnel->>Local: local websocket open
  alt pipe/local setup fails before ready
    Tunnel->>Tunnel: record bridgeOpenFailure for current generation
    Tunnel->>Publisher: onPublicationStateChanged(route-state-changed)
    Publisher->>Directory: publish with retained Relay endpoints hint
  else pipe and local both ready
    Tunnel->>Worker: ready
    Tunnel->>Tunnel: clear bridgeOpenFailure
    Tunnel->>Publisher: onPublicationStateChanged(route-state-changed)
    Publisher->>Directory: publish recovered reachable endpoints
  end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **CLI socketless headless login fails to initialize the ADE brain**

   - **Bug**
     - The requested CLI diagnostics test run fails in `apps/ade-cli/src/cli.test.ts` at `ADE CLI > autostarts a machine brain for socketless headless login`. The runtime error is `Failed to initialize the ADE brain for account login`, with details showing it could not attach to `/tmp/.../sock/ade.sock` because the socket did not exist. This indicates the changed CLI account-login/autostart path is not satisfying the expected socketless headless login behavior covered by the repository's real test.
   - **Cause**
     - The failure is thrown from the changed `runAccountLogin` path in `apps/ade-cli/src/cli.ts` after the attempted ADE brain initialization/attachment cannot find the expected local runtime socket. The test expected the CLI to autostart or otherwise make the machine brain available for socketless headless login, but the changed behavior leaves the attach path pointing at a nonexistent socket.
   - **Fix**
     - Restore the socketless headless login initialization contract in `runAccountLogin`: ensure the machine brain autostart path completes and publishes/creates the runtime socket before attempting to attach, or update the attach retry/readiness handling so it waits for the autostarted brain socket rather than failing immediately with ENOENT.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Simplify relay publication lifecycle"](https://github.com/arul28/ade/commit/dc78e0e385e77d55d4a6a7cd32dbb74b4a81151d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46458423)</sub>

<!-- /greptile_comment -->