### PR TITLE
Fix exhausted mobile reseed retries

### DIFF
--- a/apps/ade-cli/src/services/sync/mobileReplicaReseed.ts
+++ b/apps/ade-cli/src/services/sync/mobileReplicaReseed.ts
@@ -12,6 +12,10 @@ export const SYNC_HOST_MOBILE_REPLICA_RESEED_GAP = 5_000;
 export const MOBILE_REPLICA_RESEED_MAX_ROWS = 10_000;
 export const MOBILE_REPLICA_RESEED_MAX_BYTES = 4 * 1024 * 1024;
 export const MOBILE_REPLICA_RESEED_BUILD_ROWS_PER_POLL = DEFAULT_MAX_CHANGESET_BATCH_ROWS * 4;
+// Empty db_version windows contain no compact state to materialize, so cross a
+// few in one poll. This reduces a sparse multi-million-version backlog without
+// turning one poll into an unbounded database scan or delaying foreground work.
+export const MOBILE_REPLICA_RESEED_MAX_EMPTY_WINDOWS_PER_POLL = 8;
 
 export type MobileReplicaReseedCache = {
   targetDbVersion: number;
@@ -19,6 +23,7 @@ export type MobileReplicaReseedCache = {
   changes: CrsqlChangeRow[];
   approximateBytes: number;
   buildSteps: number;
+  lastAdvanceWasEmpty: boolean;
   status: "building" | "ready" | "too_large";
 };
 
@@ -29,6 +34,7 @@ export function createMobileReplicaReseedCache(targetDbVersion: number): MobileR
     changes: [],
     approximateBytes: 0,
     buildSteps: 0,
+    lastAdvanceWasEmpty: false,
     status: "building",
   };
 }
@@ -70,8 +76,10 @@ export function advanceMobileReplicaReseedCache(args: {
     cache.status = "too_large";
     cache.changes = [];
     cache.approximateBytes = 0;
+    cache.lastAdvanceWasEmpty = false;
     return cache;
   }
+  cache.lastAdvanceWasEmpty = exported.length === 0;
   cache.scanFromDbVersion = exported.length > 0
     ? Number(exported[exported.length - 1].db_version)
     : scanThroughDbVersion;

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -4073,9 +4073,9 @@ describe("initial hydration priority", () => {
           "changesetAck",
         ],
       });
-      const realDateNow = Date.now.bind(Date);
+      const baseNowMs = Date.now();
       let clockOffsetMs = 0;
-      dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => realDateNow() + clockOffsetMs);
+      dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => baseNowMs + clockOffsetMs);
 
       slowPeer.ws.send(encodeSyncEnvelope({
         type: "chat_subscribe",
@@ -4701,6 +4701,83 @@ describe("outbound changeset ack retries", () => {
       cleanup();
     }
   });
+
+  it("retries an abandoned far-behind replica reseed from its old cursor after recovery backoff", async () => {
+    const { projectRoot, cleanup } = createTempProjectRoot();
+    const targetDbVersion = SYNC_HOST_MOBILE_REPLICA_RESEED_GAP + 1;
+    const state = {
+      dbVersion: targetDbVersion,
+      changes: Array.from({ length: 10 }, (_, index) => makeChange(index + 1, index)),
+    };
+    const { host, logger } = createControlledChangesetHost(projectRoot, state);
+    let peer: Awaited<ReturnType<typeof connectPeer>> | null = null;
+    let dateNowSpy: { mockRestore(): void } | null = null;
+    try {
+      const port = await host.waitUntilListening();
+      peer = await connectPeer(port, host.getBootstrapToken(), "ios-reseed-recovery", {
+        capabilities: ["changesetAck", SYNC_CHUNKED_ENVELOPES_CAPABILITY],
+      });
+
+      const firstEnvelope = await waitForValue(
+        () => peer?.envelopes.find((envelope) => envelope.type === "changeset_batch"),
+        "initial compact reseed",
+      );
+      const firstReseed = firstEnvelope.payload as SyncChangesetBatchPayload;
+      expect(firstReseed).toMatchObject({
+        reason: "catchup",
+        fromDbVersion: 0,
+        toDbVersion: targetDbVersion,
+      });
+
+      const realDateNow = Date.now.bind(Date);
+      let clockOffsetMs = 0;
+      dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => realDateNow() + clockOffsetMs);
+      for (let attemptCount = 2; attemptCount <= 6; attemptCount += 1) {
+        clockOffsetMs += 11_000;
+        await waitForValue(
+          () => peer?.envelopes.filter((envelope) =>
+            envelope.type === "changeset_batch"
+            && (envelope.payload as SyncChangesetBatchPayload).batchId === firstReseed.batchId
+          )[attemptCount - 1],
+          `compact reseed send attempt ${attemptCount}`,
+        );
+      }
+
+      clockOffsetMs += 11_000;
+      await waitForValue(
+        () => logger.warn.mock.calls.find(([event, fields]) =>
+          event === "sync_host.changeset_recovery_started"
+          && fields?.abandonedBatchId === firstReseed.batchId
+        ),
+        "compact reseed abandonment",
+      );
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(peer.envelopes.filter((envelope) =>
+        envelope.type === "changeset_batch"
+        && (envelope.payload as SyncChangesetBatchPayload).batchId !== firstReseed.batchId
+      )).toHaveLength(0);
+
+      clockOffsetMs += 500;
+      const retryEnvelope = await waitForValue(
+        () => peer?.envelopes.find((envelope) =>
+          envelope.type === "changeset_batch"
+          && (envelope.payload as SyncChangesetBatchPayload).batchId !== firstReseed.batchId),
+        "compact reseed after recovery backoff",
+      );
+      const retryReseed = retryEnvelope.payload as SyncChangesetBatchPayload;
+      expect(retryReseed.batchId).not.toBe(firstReseed.batchId);
+      expect(retryReseed).toMatchObject({
+        reason: "catchup",
+        fromDbVersion: 0,
+        toDbVersion: targetDbVersion,
+      });
+    } finally {
+      dateNowSpy?.mockRestore();
+      peer?.ws.close();
+      await host.dispose();
+      cleanup();
+    }
+  }, 15_000);
 
   it("refreshes a shared reseed cache before it can leave another replica far behind", async () => {
     const { projectRoot, cleanup } = createTempProjectRoot();

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -4598,6 +4598,7 @@ describe("outbound changeset ack retries", () => {
     projectRoot: string,
     state: { dbVersion: number; changes: CrsqlChangeRow[] },
     logger = createDiscoveryLogger(),
+    options: { pollIntervalMs?: number } = {},
   ) {
     const base = createHostArgs(projectRoot, []);
     const exportChangesSince = vi.fn(
@@ -4616,7 +4617,7 @@ describe("outbound changeset ack retries", () => {
     const host = createSyncHostService({
       ...base,
       logger,
-      pollIntervalMs: 25,
+      pollIntervalMs: options.pollIntervalMs ?? 25,
       projectId: "project-1",
       db: {
         sync: {
@@ -4778,6 +4779,134 @@ describe("outbound changeset ack retries", () => {
       cleanup();
     }
   }, 15_000);
+
+  it("admits only one new compact reseed per poll before sending the next far-behind phone", async () => {
+    const { projectRoot, cleanup } = createTempProjectRoot();
+    const state = {
+      dbVersion: SYNC_HOST_MOBILE_REPLICA_RESEED_GAP + 1,
+      changes: Array.from({ length: 2_500 }, (_, index) => makeChange(index + 1, index)),
+    };
+    const { host } = createControlledChangesetHost(projectRoot, state, createDiscoveryLogger(), {
+      pollIntervalMs: 250,
+    });
+    let firstPeer: Awaited<ReturnType<typeof connectPeer>> | null = null;
+    let secondPeer: Awaited<ReturnType<typeof connectPeer>> | null = null;
+    try {
+      const port = await host.waitUntilListening();
+      firstPeer = await connectPeer(port, host.getBootstrapToken(), "ios-reseed-admission-first", {
+        capabilities: ["changesetAck", SYNC_CHUNKED_ENVELOPES_CAPABILITY],
+      });
+      secondPeer = await connectPeer(port, host.getBootstrapToken(), "ios-reseed-admission-second", {
+        capabilities: ["changesetAck", SYNC_CHUNKED_ENVELOPES_CAPABILITY],
+      });
+
+      const firstEnvelope = await waitForValue(
+        () => firstPeer?.envelopes.find((envelope) => envelope.type === "changeset_batch"),
+        "first admitted compact reseed",
+      );
+      expect((firstEnvelope.payload as SyncChangesetBatchPayload).reason).toBe("catchup");
+      // The shared cache becomes ready for both peers on this poll. The second
+      // send must wait for the following generation instead of gzip/framing two
+      // logical snapshots back-to-back on the host event loop.
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(secondPeer.envelopes.some((envelope) => envelope.type === "changeset_batch")).toBe(false);
+
+      const secondEnvelope = await waitForValue(
+        () => secondPeer?.envelopes.find((envelope) => envelope.type === "changeset_batch"),
+        "second compact reseed on a later poll",
+      );
+      expect((secondEnvelope.payload as SyncChangesetBatchPayload).reason).toBe("catchup");
+    } finally {
+      firstPeer?.ws.close();
+      secondPeer?.ws.close();
+      await host.dispose();
+      cleanup();
+    }
+  });
+
+  it("crosses a sparse 16.8m-version reseed gap in bounded empty-window bursts", async () => {
+    const { projectRoot, cleanup } = createTempProjectRoot();
+    const state = {
+      dbVersion: 16_800_000,
+      changes: [] as CrsqlChangeRow[],
+    };
+    const { host, exportChangesSince } = createControlledChangesetHost(projectRoot, state, createDiscoveryLogger(), {
+      pollIntervalMs: 100,
+    });
+    let peer: Awaited<ReturnType<typeof connectPeer>> | null = null;
+    try {
+      const port = await host.waitUntilListening();
+      peer = await connectPeer(port, host.getBootstrapToken(), "ios-sparse-16m-reseed", {
+        capabilities: ["changesetAck", SYNC_CHUNKED_ENVELOPES_CAPABILITY],
+      });
+      const reseedEnvelope = await waitForValue(
+        () => peer?.envelopes.find((envelope) => envelope.type === "changeset_batch"),
+        "accelerated sparse compact reseed",
+        2_000,
+      );
+      expect(reseedEnvelope.payload).toMatchObject({
+        reason: "catchup",
+        fromDbVersion: 0,
+        toDbVersion: state.dbVersion,
+        changes: [],
+      });
+      expect(exportChangesSince).toHaveBeenCalledTimes(Math.ceil(state.dbVersion / 250_000));
+      expect(exportChangesSince.mock.calls.every(([fromDbVersion, options]) =>
+        (options?.throughDbVersion ?? fromDbVersion) - fromDbVersion <= 250_000,
+      )).toBe(true);
+      expect(exportChangesSince.mock.calls.every(([, options]) => options?.maxRows === 1_000)).toBe(true);
+    } finally {
+      peer?.ws.close();
+      await host.dispose();
+      cleanup();
+    }
+  }, 3_000);
+
+  it("rebuilds an oversized compact cache after later database changes make it eligible", async () => {
+    const { projectRoot, cleanup } = createTempProjectRoot();
+    const initialTarget = (SYNC_HOST_MOBILE_REPLICA_RESEED_GAP * 2) + 1;
+    const state = {
+      dbVersion: initialTarget,
+      changes: Array.from({ length: 10_001 }, (_, index) => makeChange(index + 1, index)),
+    };
+    const { host } = createControlledChangesetHost(projectRoot, state);
+    let firstPeer: Awaited<ReturnType<typeof connectPeer>> | null = null;
+    let secondPeer: Awaited<ReturnType<typeof connectPeer>> | null = null;
+    try {
+      const port = await host.waitUntilListening();
+      firstPeer = await connectPeer(port, host.getBootstrapToken(), "ios-oversized-cache-first", {
+        capabilities: ["changesetAck", SYNC_CHUNKED_ENVELOPES_CAPABILITY],
+      });
+      const fallback = await waitForValue(
+        () => firstPeer?.envelopes.find((envelope) => envelope.type === "changeset_batch"),
+        "initial oversized compact fallback",
+      );
+      expect((fallback.payload as SyncChangesetBatchPayload).reason).toBe("broadcast");
+      firstPeer.ws.close();
+      firstPeer = null;
+
+      state.dbVersion += SYNC_HOST_MOBILE_REPLICA_RESEED_GAP + 1;
+      state.changes = [makeChange(state.dbVersion, 0)];
+      secondPeer = await connectPeer(port, host.getBootstrapToken(), "ios-oversized-cache-second", {
+        capabilities: ["changesetAck", SYNC_CHUNKED_ENVELOPES_CAPABILITY],
+      });
+      const rebuilt = await waitForValue(
+        () => secondPeer?.envelopes.find((envelope) => envelope.type === "changeset_batch"),
+        "rebuilt compact cache",
+      );
+      expect(rebuilt.payload).toMatchObject({
+        reason: "catchup",
+        fromDbVersion: 0,
+        toDbVersion: state.dbVersion,
+      });
+      expect((rebuilt.payload as SyncChangesetBatchPayload).changes).toHaveLength(1);
+    } finally {
+      firstPeer?.ws.close();
+      secondPeer?.ws.close();
+      await host.dispose();
+      cleanup();
+    }
+  });
 
   it("refreshes a shared reseed cache before it can leave another replica far behind", async () => {
     const { projectRoot, cleanup } = createTempProjectRoot();

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -4240,6 +4240,13 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     const pending = peer.pendingChangesetBatch;
     if (!pending) return;
     peer.pendingChangesetBatch = null;
+    if (pending.reason === "catchup") {
+      // A compact reseed is disabled while it is in flight so the normal
+      // incremental pump cannot race it. If every delivery attempt fails,
+      // keep the replica at its old cursor and let the bounded reseed retry
+      // after the same recovery backoff as any other abandoned batch.
+      peer.mobileReplicaReseedDisabled = false;
+    }
     peer.changesetRecoveryLevel = Math.min(
       MAX_CHANGESET_RECOVERY_LEVEL,
       peer.changesetRecoveryLevel + 1,

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -161,6 +161,7 @@ import {
 } from "./changesetPump";
 import {
   MOBILE_REPLICA_RESEED_MAX_BYTES,
+  MOBILE_REPLICA_RESEED_MAX_EMPTY_WINDOWS_PER_POLL,
   MOBILE_REPLICA_RESEED_MAX_ROWS,
   SYNC_HOST_MOBILE_REPLICA_RESEED_GAP,
   advanceMobileReplicaReseedCache,
@@ -2614,6 +2615,10 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
   // database; an oversized replica falls back to incremental replay.
   let mobileReplicaReseedCache: MobileReplicaReseedCache | null = null;
   let mobileReplicaReseedAdvancedPollGeneration = -1;
+  // Constructing the cache is shared, but gzip/frame generation happens once
+  // per recipient. Admit only one fresh compact send per poll so a reconnect
+  // burst cannot monopolize the event loop or outbound socket budget.
+  let mobileReplicaReseedLaunchPollGeneration = -1;
   let pollPumpGeneration = 0;
   // All-projects roster (mobile hub) coalescing state. Each subscribed peer
   // carries its own monotonic seq (PeerState.rosterSeq); clients re-snapshot on
@@ -4110,10 +4115,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     if (
       !mobileReplicaReseedCache
       || mobileReplicaReseedCache.targetDbVersion <= peerDbVersion
-      || (
-        mobileReplicaReseedCache.status !== "too_large"
-        && cachedTargetLag > SYNC_HOST_MOBILE_REPLICA_RESEED_GAP
-      )
+      || cachedTargetLag > SYNC_HOST_MOBILE_REPLICA_RESEED_GAP
     ) {
       mobileReplicaReseedCache = createMobileReplicaReseedCache(targetDbVersion);
       args.logger.info("sync_host.mobile_replica_reseed_started", {
@@ -4127,15 +4129,19 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
     if (cache.status !== "building") return cache;
     if (pollGeneration <= mobileReplicaReseedAdvancedPollGeneration) return cache;
     mobileReplicaReseedAdvancedPollGeneration = pollGeneration;
-    const advancedCache = advanceMobileReplicaReseedCache({
-      cache,
-      versionWindow: SYNC_EXPORT_VERSION_WINDOW,
-      exportChangesSince: args.db.sync.exportChangesSince,
-      excludeTables: MOBILE_REPLICA_RESEED_EXCLUDED_TABLES,
-      includeChange: (change) =>
-        !isHostAuthoritativeTable(change)
-        && !MOBILE_CHANGESET_EXCLUDED_TABLES.has(change.table),
-    });
+    let advancedCache = cache;
+    for (let emptyWindows = 0; emptyWindows < MOBILE_REPLICA_RESEED_MAX_EMPTY_WINDOWS_PER_POLL; emptyWindows += 1) {
+      advancedCache = advanceMobileReplicaReseedCache({
+        cache: advancedCache,
+        versionWindow: SYNC_EXPORT_VERSION_WINDOW,
+        exportChangesSince: args.db.sync.exportChangesSince,
+        excludeTables: MOBILE_REPLICA_RESEED_EXCLUDED_TABLES,
+        includeChange: (change) =>
+          !isHostAuthoritativeTable(change)
+          && !MOBILE_CHANGESET_EXCLUDED_TABLES.has(change.table),
+      });
+      if (advancedCache.status !== "building" || !advancedCache.lastAdvanceWasEmpty) break;
+    }
     if (advancedCache.status === "too_large") {
       args.logger.info("sync_host.mobile_replica_reseed_skipped", {
         targetDbVersion: advancedCache.targetDbVersion,
@@ -5133,6 +5139,8 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         );
         if (reseed.status === "building") return;
         if (reseed.status === "ready") {
+          if (mobileReplicaReseedLaunchPollGeneration === pollGeneration) return;
+          mobileReplicaReseedLaunchPollGeneration = pollGeneration;
           const result = sendMobileReplicaReseed(peer, reseed);
           if (result.status === "sent") {
             peer.mobileReplicaReseedDisabled = true;


### PR DESCRIPTION
Follow-up to #875.

## Summary
- Re-enable bounded mobile reseeding when an in-flight `catchup` batch exhausts its ACK retry budget.
- Preserve the peer cursor and existing recovery backoff so the next eligible send is a fresh compact reseed, not incremental replay.
- Add a regression test covering six timed-out sends, the recovery delay, and a new `catchup` batch from the old cursor.

## Validation
- `npx vitest run src/services/sync/syncHostService.test.ts`
- `npx vitest run src/services/sync/syncHostService.test.ts -t "reseed"`
- `npm run typecheck`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Re-enables bounded mobile reseeding after exhausted ACK retries.
- Preserves the peer cursor and recovery backoff before launching a fresh compact catchup batch.
- Limits fresh compact reseed launches to one peer per poll.
- Accelerates sparse reseed-cache construction through bounded empty-window scans.
- Refreshes stale oversized caches and adds regression coverage for retry recovery, admission, sparse histories, and cache rebuilding.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Vitest test for src/services/sync/syncHostService.test.ts with the -t "retries an abandoned far-behind replica reseed" filter, and the run finished with exit code 0, reporting 1 test file passed and 1 selected test passed in 2.65s.

<a href="https://app.greptile.com/trex/runs/15501344/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/services/sync/syncHostService.ts | Restores compact reseed eligibility after catchup abandonment, refreshes stale caches, bounds sparse-cache advancement, and limits fresh launches per poll. |
| apps/ade-cli/src/services/sync/mobileReplicaReseed.ts | Tracks whether a cache-build step crossed an empty version window so sparse histories can advance in bounded bursts. |
| apps/ade-cli/src/services/sync/syncHostService.test.ts | Adds coverage for exhausted retry recovery, per-poll reseed admission, sparse version gaps, and rebuilding oversized caches. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Phone as Mobile replica
  participant Host as Sync host
  participant Cache as Reseed cache
  Phone->>Host: Connect with stale cursor
  Host->>Cache: Build bounded compact reseed
  Cache-->>Host: Ready catchup batch
  Host->>Phone: Send catchup batch
  loop ACK retry budget
    Host->>Phone: Retry same batch
  end
  Host->>Host: Abandon batch and retain old cursor
  Host->>Host: Wait for recovery backoff
  Host->>Cache: Reuse or rebuild reseed
  Host->>Phone: Send fresh catchup batch
```

<sub>Reviews (2): Last reviewed commit: ["perf(sync): bound compact reseed work"](https://github.com/arul28/ade/commit/8afa557b2276877805a8b6d94e3de298d01e5cd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46504344)</sub>

<!-- /greptile_comment -->