### PR TITLE
Fix iOS image attachments across composers

### DIFF
--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -8035,6 +8035,7 @@ final class SyncService: ObservableObject {
     targetProjectId: String? = nil,
     targetProjectRootPath: String? = nil
   ) async throws -> SavedChatTempAttachment {
+    try requireInvokableRemoteAction("chat.saveTempAttachment")
     var args: [String: Any] = ["dataUrl": dataUrl]
     let trimmedFilename = filename.trimmingCharacters(in: .whitespacesAndNewlines)
     if !trimmedFilename.isEmpty {
@@ -9145,6 +9146,13 @@ final class SyncService: ObservableObject {
     commandDescriptor(for: action) != nil
   }
 
+  /// Whether the connected host advertises an action that this viewer is
+  /// allowed to invoke, independent of the current transport state.
+  func supportsViewerRemoteAction(_ action: String) -> Bool {
+    guard supportsRemoteAction(action) else { return false }
+    return commandPolicy(for: action)?.viewerAllowed != false
+  }
+
   func isRemoteActionQueueable(_ action: String) -> Bool {
     commandPolicy(for: action)?.queueable == true
   }
@@ -9154,8 +9162,7 @@ final class SyncService: ObservableObject {
   /// disabled while offline, while explicitly queueable commands remain
   /// available and are persisted for replay.
   func canInvokeRemoteAction(_ action: String) -> Bool {
-    guard supportsRemoteAction(action) else { return false }
-    guard commandPolicy(for: action)?.viewerAllowed != false else { return false }
+    guard supportsViewerRemoteAction(action) else { return false }
     return canSendLiveRequests() || isRemoteActionQueueable(action)
   }
 

--- a/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
+++ b/apps/ios/ADE/Views/Hub/HubComposerDrawer.swift
@@ -83,6 +83,7 @@ struct HubInlineComposer: View {
   @State private var errorMessage: String?
   @State private var modelPickerPresented = false
   @State private var destinationPickerPresented = false
+  @State private var attachmentPickerPresented = false
   @State private var isDictating = false
   @State private var controlsWidth: CGFloat = 0
   // Global top edge of the destination control, so the picker popover can size
@@ -136,7 +137,7 @@ struct HubInlineComposer: View {
   /// (not derived from focus) so every change happens inside a spring
   /// transaction instead of snapping with the focus flip.
   private var isExpanded: Bool {
-    expanded || isDictating || modelPickerPresented || destinationPickerPresented
+    expanded || isDictating || modelPickerPresented || destinationPickerPresented || attachmentPickerPresented
   }
 
   /// Collapses the panel, keeping the draft text and all settings.
@@ -202,23 +203,22 @@ struct HubInlineComposer: View {
       && !modelId.isEmpty
   }
 
-  private var canUploadAttachments: Bool {
-    syncService.connectionState == .connected || syncService.connectionState == .syncing
+  private var attachmentsAvailable: Bool {
+    syncService.supportsViewerRemoteAction("chat.saveTempAttachment")
   }
 
-  private var trimmedDraft: String {
-    draft.trimmingCharacters(in: .whitespacesAndNewlines)
+  private var canUploadAttachments: Bool {
+    attachmentsAvailable
+      && (syncService.connectionState == .connected || syncService.connectionState == .syncing)
   }
 
   private var canSend: Bool {
-    guard canStart else { return false }
-    if sessionMode != .chat {
-      return !trimmedDraft.isEmpty
-    }
-    let readyAttachments = workChatInputReadyAttachments(attachments)
-    return !workChatInputHasLoadingAttachments(attachments)
-      && (!trimmedDraft.isEmpty || !readyAttachments.isEmpty)
-      && (readyAttachments.isEmpty || canUploadAttachments)
+    workChatInputCanSend(
+      text: draft,
+      attachments: attachments,
+      baseEnabled: canStart,
+      canUploadAttachments: canUploadAttachments
+    )
   }
 
   private var isControlsCollapsed: Bool {
@@ -258,6 +258,11 @@ struct HubInlineComposer: View {
     .padding(.horizontal, 16)
     .padding(.top, isExpanded ? 12 : 0)
     .padding(.bottom, 8)
+    .workChatAttachmentPicker(
+      isPresented: $attachmentPickerPresented,
+      attachments: $attachments,
+      onDismiss: { composerFocused = true }
+    )
     .animation(hubComposerSpring, value: isExpanded)
     .animation(.easeOut(duration: 0.16), value: errorMessage != nil)
     // Dragging down anywhere on the panel collapses it (the keyboard follows
@@ -282,7 +287,11 @@ struct HubInlineComposer: View {
     // expanded with no keyboard and no way out — unless a picker or dictation
     // legitimately owns the screen.
     .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { _ in
-      guard expanded, !modelPickerPresented, !destinationPickerPresented, !isDictating else { return }
+      guard expanded,
+            !modelPickerPresented,
+            !destinationPickerPresented,
+            !attachmentPickerPresented,
+            !isDictating else { return }
       collapse()
     }
     .onChange(of: provider) { _, newProvider in
@@ -299,9 +308,6 @@ struct HubInlineComposer: View {
     }
     .onChange(of: sessionMode) { _, newMode in
       normalizeSelection(for: newMode)
-      if newMode != .chat {
-        attachments.removeAll()
-      }
     }
     .onChange(of: modelId) { _, newModel in
       if !modelSupportsReasoning(modelId: newModel, provider: provider) {
@@ -620,88 +626,34 @@ struct HubInlineComposer: View {
   private var composerCard: some View {
     VStack(alignment: .leading, spacing: 12) {
       WorkChatInputAttachmentTray(attachments: $attachments)
+        .fixedSize(horizontal: false, vertical: true)
+        .layoutPriority(2)
 
-      HStack(alignment: .center, spacing: 10) {
-        if !isExpanded {
-          Image(systemName: "sparkles")
-            .font(.system(size: 14, weight: .semibold))
-            .foregroundStyle(ADEColor.accent)
-            .transition(.opacity)
-        }
-
-        WorkPlainComposerTextView(
-          text: $draft,
-          isFocused: Binding(
-            get: { composerFocused },
-            set: { composerFocused = $0 }
-          ),
-          measuredHeight: $composerTextHeight,
-          placeholder: "Type to vibecode…",
-          acceptsPastedImages: sessionMode == .chat,
-          onPasteImages: { images in
-            workChatInputPasteImages(images, into: $attachments)
+      VStack(alignment: .leading, spacing: 12) {
+        HStack(alignment: .center, spacing: 10) {
+          if !isExpanded {
+            Image(systemName: "sparkles")
+              .font(.system(size: 14, weight: .semibold))
+              .foregroundStyle(ADEColor.accent)
+              .transition(.opacity)
           }
-        )
-        .frame(maxWidth: .infinity, minHeight: 28, idealHeight: composerTextHeight, maxHeight: composerTextHeight, alignment: .leading)
 
-        if !isExpanded {
-          ADEComposerSendButton(
-            enabled: canSend && !busy,
-            sending: busy,
-            accessibilityLabelText: "Start chat",
-            disabledAccessibilityLabel: "Enter a message to start"
-          ) {
-            dispatch()
-          }
-          .transition(.opacity)
-        }
-      }
-
-      if isExpanded {
-        HStack(alignment: .center, spacing: 8) {
-          if !isDictating {
-            WorkChatAttachmentAddButton(
-              attachments: $attachments,
-              disabled: busy || sessionMode != .chat || !canUploadAttachments
-            )
-
-            ScrollView(.horizontal, showsIndicators: false) {
-              WorkComposerControlsRow(
-                provider: provider,
-                modelDisplayName: hubPrettyModelName(modelId),
-                reasoningEffort: reasoningEffort,
-                currentMode: runtimeMode,
-                modeOptions: workRuntimeModeOptions(provider: provider),
-                modeLabel: workRuntimeModeLabel(provider: provider, mode: runtimeMode),
-                isCollapsed: isControlsCollapsed,
-                fastModeEnabled: codexFastMode,
-                onOpenModelPicker: { modelPickerPresented = true },
-                onSelectMode: { runtimeMode = $0 }
-              )
-              .padding(.trailing, 4)
+          WorkPlainComposerTextView(
+            text: $draft,
+            isFocused: Binding(
+              get: { composerFocused },
+              set: { composerFocused = $0 }
+            ),
+            measuredHeight: $composerTextHeight,
+            placeholder: "Type to vibecode…",
+            acceptsPastedImages: attachmentsAvailable,
+            onPasteImages: { images in
+              workChatInputPasteImages(images, into: $attachments)
             }
-            .background(
-              GeometryReader { proxy in
-                Color.clear
-                  .onAppear { controlsWidth = proxy.size.width }
-                  .onChange(of: proxy.size.width) { _, newValue in
-                    controlsWidth = newValue
-                  }
-              }
-            )
-
-            DictationRawUndoChip(coordinator: dictationCoordinator, draft: $draft)
-          }
-
-          DictationMicButton(
-            draft: $draft,
-            coordinator: dictationCoordinator,
-            targetId: dictationTargetId,
-            onRecordingChange: { isDictating = $0 }
           )
-          .frame(maxWidth: isDictating ? .infinity : nil)
+          .frame(maxWidth: .infinity, minHeight: 28, idealHeight: composerTextHeight, maxHeight: composerTextHeight, alignment: .leading)
 
-          if !isDictating {
+          if !isExpanded {
             ADEComposerSendButton(
               enabled: canSend && !busy,
               sending: busy,
@@ -710,10 +662,71 @@ struct HubInlineComposer: View {
             ) {
               dispatch()
             }
+            .transition(.opacity)
           }
         }
-        .transition(.move(edge: .top).combined(with: .opacity))
+
+        if isExpanded {
+          HStack(alignment: .center, spacing: 8) {
+            if !isDictating {
+              WorkChatAttachmentAddButton(
+                pickerPresented: $attachmentPickerPresented,
+                attachmentCount: attachments.count,
+                disabled: busy || !attachmentsAvailable
+              )
+
+              ScrollView(.horizontal, showsIndicators: false) {
+                WorkComposerControlsRow(
+                  provider: provider,
+                  modelDisplayName: hubPrettyModelName(modelId),
+                  reasoningEffort: reasoningEffort,
+                  currentMode: runtimeMode,
+                  modeOptions: workRuntimeModeOptions(provider: provider),
+                  modeLabel: workRuntimeModeLabel(provider: provider, mode: runtimeMode),
+                  isCollapsed: isControlsCollapsed,
+                  fastModeEnabled: codexFastMode,
+                  onOpenModelPicker: { modelPickerPresented = true },
+                  onSelectMode: { runtimeMode = $0 }
+                )
+                .padding(.trailing, 4)
+              }
+              .background(
+                GeometryReader { proxy in
+                  Color.clear
+                    .onAppear { controlsWidth = proxy.size.width }
+                    .onChange(of: proxy.size.width) { _, newValue in
+                      controlsWidth = newValue
+                    }
+                }
+              )
+
+              DictationRawUndoChip(coordinator: dictationCoordinator, draft: $draft)
+            }
+
+            DictationMicButton(
+              draft: $draft,
+              coordinator: dictationCoordinator,
+              targetId: dictationTargetId,
+              onRecordingChange: { isDictating = $0 }
+            )
+            .frame(maxWidth: isDictating ? .infinity : nil)
+
+            if !isDictating {
+              ADEComposerSendButton(
+                enabled: canSend && !busy,
+                sending: busy,
+                accessibilityLabelText: "Start chat",
+                disabledAccessibilityLabel: "Enter a message to start"
+              ) {
+                dispatch()
+              }
+            }
+          }
+          .transition(.move(edge: .top).combined(with: .opacity))
+        }
       }
+      .fixedSize(horizontal: false, vertical: true)
+      .layoutPriority(1)
     }
     .padding(.horizontal, 14)
     .padding(.vertical, isExpanded ? 14 : 10)
@@ -751,15 +764,14 @@ struct HubInlineComposer: View {
   @MainActor
   private func dispatch() {
     let outgoingAttachments = workChatInputReadyAttachments(attachments)
-    let text = workChatOutgoingText(draft, attachmentCount: outgoingAttachments.count)
-    guard !text.isEmpty else { return }
+    guard canSend else { return }
     let restoredDraft = draft
     let restoredAttachments = attachments
     collapse()
     draft = ""
     attachments.removeAll()
     Task {
-      let started = await submit(opener: text, attachments: outgoingAttachments)
+      let started = await submit(opener: restoredDraft, attachments: outgoingAttachments)
       if !started {
         draft = restoredDraft
         attachments = restoredAttachments
@@ -770,6 +782,7 @@ struct HubInlineComposer: View {
   @MainActor
   private func submit(opener rawOpener: String, attachments inputAttachments: [WorkChatInputAttachment]) async -> Bool {
     let readyAttachments = workChatInputReadyAttachments(inputAttachments)
+    let rawText = rawOpener.trimmingCharacters(in: .whitespacesAndNewlines)
     let opener = workChatOutgoingText(rawOpener, attachmentCount: readyAttachments.count)
     guard canStart, !opener.isEmpty, !modelId.isEmpty else { return false }
     guard readyAttachments.isEmpty || canUploadAttachments else {
@@ -826,6 +839,12 @@ struct HubInlineComposer: View {
 
     do {
       let isCli = sessionMode == .cli
+      let attachmentRefs = try await workChatSaveInputAttachments(
+        readyAttachments,
+        syncService: syncService,
+        targetProjectId: targetProjectId,
+        targetProjectRootPath: targetProjectRootPath
+      )
       let sessionId: String
       if isCli {
         let cliProvider = workResolveCliProvider(for: modelId, provider: provider)
@@ -837,7 +856,7 @@ struct HubInlineComposer: View {
           provider: cliProvider,
           permissionMode: workCliPermissionMode(provider: cliProvider, runtimeMode: runtimeMode),
           title: hubCliInitialTitle(opener: opener, provider: cliProvider),
-          initialInput: opener,
+          initialInput: workCliInitialInput(text: rawText, attachments: attachmentRefs),
           modelId: modelId,
           reasoningEffort: cliReasoning,
           fastMode: fastModeSupported ? codexFastMode : nil,
@@ -848,12 +867,6 @@ struct HubInlineComposer: View {
         )
         sessionId = result.sessionId
       } else {
-        let attachmentRefs = try await workChatSaveInputAttachments(
-          readyAttachments,
-          syncService: syncService,
-          targetProjectId: targetProjectId,
-          targetProjectRootPath: targetProjectRootPath
-        )
         let summary = try await syncService.createChatSession(
           laneId: targetLaneId,
           provider: provider,

--- a/apps/ios/ADE/Views/Work/WorkChatAttachmentTray.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatAttachmentTray.swift
@@ -9,6 +9,7 @@ private let workChatAttachmentPreviewMinimumPixels: CGFloat = 96
 private let workChatInputAttachmentMaxBytes = 10 * 1024 * 1024
 private let workChatInputAttachmentInitialMaxDimension: CGFloat = 2400
 private let workChatInputAttachmentMinimumMaxDimension: CGFloat = 960
+let workChatInputAttachmentLimit = 10
 
 private let workChatRemoteImageSession: URLSession = {
   let configuration = URLSessionConfiguration.ephemeral
@@ -100,12 +101,50 @@ func workChatOutgoingText(_ text: String, attachmentCount: Int) -> String {
   return attachmentCount == 1 ? "Attached image." : "Attached \(attachmentCount) images."
 }
 
+func workCliInitialInput(text: String, attachments: [AgentChatFileRef]) -> String {
+  let manifest: String
+  if attachments.isEmpty {
+    manifest = ""
+  } else {
+    let lines = attachments.enumerated().map { index, attachment in
+      if attachment.type == "image-url" {
+        return "\(index + 1). Image URL: \(attachment.url ?? "")"
+      }
+      let label = attachment.type == "image" ? "Image file" : "File"
+      return "\(index + 1). \(label): \(attachment.path)"
+    }
+    manifest = (["Attached files and images:"] + lines).joined(separator: "\n")
+  }
+
+  return [manifest, text.trimmingCharacters(in: .whitespacesAndNewlines)]
+    .filter { !$0.isEmpty }
+    .joined(separator: "\n\n")
+}
+
 func workChatInputReadyAttachments(_ attachments: [WorkChatInputAttachment]) -> [WorkChatInputAttachment] {
   attachments.filter(\.isReady)
 }
 
 func workChatInputHasLoadingAttachments(_ attachments: [WorkChatInputAttachment]) -> Bool {
   attachments.contains(where: \.isLoading)
+}
+
+func workChatInputHasFailedAttachments(_ attachments: [WorkChatInputAttachment]) -> Bool {
+  attachments.contains { $0.errorMessage != nil }
+}
+
+func workChatInputCanSend(
+  text: String,
+  attachments: [WorkChatInputAttachment],
+  baseEnabled: Bool,
+  canUploadAttachments: Bool
+) -> Bool {
+  let readyAttachments = workChatInputReadyAttachments(attachments)
+  return baseEnabled
+    && !workChatInputHasLoadingAttachments(attachments)
+    && !workChatInputHasFailedAttachments(attachments)
+    && (!text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !readyAttachments.isEmpty)
+    && (readyAttachments.isEmpty || canUploadAttachments)
 }
 
 func workChatInputAttachmentDataURL(_ attachment: WorkChatInputAttachment) -> String? {
@@ -136,7 +175,9 @@ func workChatInputAttachment(from image: UIImage, filename: String? = nil, id: U
 func workChatInputPasteImages(_ images: [UIImage], into attachments: Binding<[WorkChatInputAttachment]>) {
   guard !images.isEmpty else { return }
   var next = attachments.wrappedValue
-  for image in images {
+  next.removeAll { $0.filename == "attachment-limit" }
+  let availableSlots = max(0, workChatInputAttachmentLimit - next.count)
+  for image in images.prefix(availableSlots) {
     let id = UUID()
     if let attachment = workChatInputAttachment(from: image, filename: "pasted-\(id.uuidString.prefix(8)).jpg", id: id) {
       next.append(attachment)
@@ -147,6 +188,12 @@ func workChatInputPasteImages(_ images: [UIImage], into attachments: Binding<[Wo
         state: .failed("This image could not be prepared for upload.")
       ))
     }
+  }
+  if images.count > availableSlots {
+    next.append(WorkChatInputAttachment(
+      filename: "attachment-limit",
+      state: .failed("You can attach up to \(workChatInputAttachmentLimit) images at a time.")
+    ))
   }
   attachments.wrappedValue = next
 }
@@ -227,43 +274,60 @@ private func workChatRenderedJPEGImage(_ image: UIImage, maxDimension: CGFloat) 
 }
 
 struct WorkChatAttachmentAddButton: View {
-  @Binding var attachments: [WorkChatInputAttachment]
+  @Binding var pickerPresented: Bool
+  let attachmentCount: Int
   var disabled = false
 
-  @State private var pickerPresented = false
-  @State private var pickerItems: [PhotosPickerItem] = []
+  private var isDisabled: Bool {
+    disabled || attachmentCount >= workChatInputAttachmentLimit
+  }
 
   var body: some View {
-    Menu {
-      Button {
-        pickerPresented = true
-      } label: {
-        Label("Attach from camera roll", systemImage: "photo.on.rectangle")
-      }
+    Button {
+      pickerPresented = true
     } label: {
       Image(systemName: "plus")
         .font(.system(size: 14, weight: .bold))
-        .foregroundStyle(disabled ? ADEColor.textMuted.opacity(0.35) : ADEColor.textPrimary)
+        .foregroundStyle(isDisabled ? ADEColor.textMuted.opacity(0.35) : ADEColor.textPrimary)
         .frame(width: 28, height: 28)
-        .background(ADEColor.surfaceBackground.opacity(disabled ? 0.18 : 0.38), in: Circle())
-        .overlay(Circle().stroke(ADEColor.border.opacity(disabled ? 0.16 : 0.28), lineWidth: 0.6))
+        .background(ADEColor.surfaceBackground.opacity(isDisabled ? 0.18 : 0.38), in: Circle())
+        .overlay(Circle().stroke(ADEColor.border.opacity(isDisabled ? 0.16 : 0.28), lineWidth: 0.6))
+        .frame(width: 44, height: 44)
         .contentShape(Circle())
     }
-    .disabled(disabled)
-    .accessibilityLabel("Add attachment")
-    .accessibilityHint("Shows attachment options.")
-    .photosPicker(
-      isPresented: $pickerPresented,
-      selection: $pickerItems,
-      maxSelectionCount: 0,
-      matching: .images,
-      preferredItemEncoding: .automatic
-    )
-    .onChange(of: pickerItems) { _, newItems in
-      guard !newItems.isEmpty else { return }
-      pickerItems = []
-      Task { await appendPhotoPickerItems(newItems) }
-    }
+    .buttonStyle(.plain)
+    .disabled(isDisabled)
+    .accessibilityLabel("Attach from camera roll")
+    .accessibilityHint("Opens the photo picker.")
+  }
+}
+
+private struct WorkChatAttachmentPickerModifier: ViewModifier {
+  @Binding var isPresented: Bool
+  @Binding var attachments: [WorkChatInputAttachment]
+  let onDismiss: () -> Void
+
+  @State private var pickerItems: [PhotosPickerItem] = []
+
+  func body(content: Content) -> some View {
+    content
+      .photosPicker(
+        isPresented: $isPresented,
+        selection: $pickerItems,
+        maxSelectionCount: max(1, workChatInputAttachmentLimit - attachments.count),
+        matching: .images,
+        preferredItemEncoding: .automatic
+      )
+      .onChange(of: pickerItems) { _, newItems in
+        guard !newItems.isEmpty else { return }
+        pickerItems = []
+        Task { await appendPhotoPickerItems(newItems) }
+      }
+      .onChange(of: isPresented) { wasPresented, nowPresented in
+        if wasPresented && !nowPresented {
+          onDismiss()
+        }
+      }
   }
 
   @MainActor
@@ -308,6 +372,20 @@ struct WorkChatAttachmentAddButton: View {
   private func markAttachment(id: UUID, failed message: String) {
     guard let index = attachments.firstIndex(where: { $0.id == id }) else { return }
     attachments[index].state = .failed(message)
+  }
+}
+
+extension View {
+  func workChatAttachmentPicker(
+    isPresented: Binding<Bool>,
+    attachments: Binding<[WorkChatInputAttachment]>,
+    onDismiss: @escaping () -> Void
+  ) -> some View {
+    modifier(WorkChatAttachmentPickerModifier(
+      isPresented: isPresented,
+      attachments: attachments,
+      onDismiss: onDismiss
+    ))
   }
 }
 

--- a/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatSessionView.swift
@@ -219,7 +219,7 @@ struct WorkChatSessionView: View {
   var liveTurnActiveHint: Bool? = nil
   var compactComposer = false
   var isPersonalChat: Bool = false
-  var personalAttachmentsAvailable: Bool = true
+  var attachmentsAvailable: Bool = true
   var personalModelCatalogAvailable: Bool = true
   var personalSessionUpdatesAvailable: Bool = true
   /// Present only when the paired host advertises `chat.recoverCodexTurn`.
@@ -748,7 +748,8 @@ struct WorkChatSessionView: View {
         composerPlaceholder: composerPlaceholderText,
         canCompose: canCompose,
         canSend: canSend && !composerSettingMutationInFlight,
-        canUploadAttachments: isLive && (!isPersonalChat || personalAttachmentsAvailable),
+        attachmentsAvailable: attachmentsAvailable,
+        canUploadAttachments: isLive && attachmentsAvailable,
         sending: sending && !sendWillQueue,
         settingsMutationInFlight: composerSettingMutationInFlight,
         codexFastModeOverride: pendingCodexFastMode,
@@ -1655,6 +1656,7 @@ private struct WorkChatComposerCard: View {
   let composerPlaceholder: String
   let canCompose: Bool
   let canSend: Bool
+  let attachmentsAvailable: Bool
   let canUploadAttachments: Bool
   let sending: Bool
   let settingsMutationInFlight: Bool
@@ -1683,6 +1685,7 @@ private struct WorkChatComposerCard: View {
       composerPlaceholder: composerPlaceholder,
       canCompose: canCompose,
       canSend: canSend,
+      attachmentsAvailable: attachmentsAvailable,
       canUploadAttachments: canUploadAttachments,
       sending: sending,
       settingsMutationInFlight: settingsMutationInFlight,
@@ -1721,6 +1724,7 @@ private struct WorkChatComposerDraftInput: View {
   let composerPlaceholder: String
   let canCompose: Bool
   let canSend: Bool
+  let attachmentsAvailable: Bool
   let canUploadAttachments: Bool
   let sending: Bool
   let settingsMutationInFlight: Bool
@@ -1742,6 +1746,7 @@ private struct WorkChatComposerDraftInput: View {
   @StateObject private var dictationCoordinator = DictationInsertionCoordinator()
   @State private var isDictating = false
   @State private var inputAttachments: [WorkChatInputAttachment] = []
+  @State private var attachmentPickerPresented = false
 
   private var hasSendableDraftOrAttachment: Bool {
     draftState.hasSendableText || !workChatInputReadyAttachments(inputAttachments).isEmpty
@@ -1757,13 +1762,19 @@ private struct WorkChatComposerDraftInput: View {
 
         HStack(alignment: .center, spacing: 8) {
           if !isDictating {
+            WorkChatAttachmentAddButton(
+              pickerPresented: $attachmentPickerPresented,
+              attachmentCount: inputAttachments.count,
+              disabled: !canCompose || !attachmentsAvailable || settingsMutationInFlight
+            )
+
             WorkChatComposerTextField(
               draftState: draftState,
               controller: suggestionController,
               canCompose: canCompose,
               placeholder: composerPlaceholder,
+              acceptsPastedImages: canCompose && attachmentsAvailable,
               onPasteImages: { images in
-                guard canUploadAttachments else { return }
                 workChatInputPasteImages(images, into: $inputAttachments)
               },
               maxLines: 1
@@ -1793,8 +1804,8 @@ private struct WorkChatComposerDraftInput: View {
           controller: suggestionController,
           canCompose: canCompose,
           placeholder: composerPlaceholder,
+          acceptsPastedImages: canCompose && attachmentsAvailable,
           onPasteImages: { images in
-            guard canUploadAttachments else { return }
             workChatInputPasteImages(images, into: $inputAttachments)
           }
         )
@@ -1812,8 +1823,9 @@ private struct WorkChatComposerDraftInput: View {
         // expand into the row without a layout jump.
         if !isDictating {
           WorkChatAttachmentAddButton(
-            attachments: $inputAttachments,
-            disabled: !canCompose || !canUploadAttachments || settingsMutationInFlight
+            pickerPresented: $attachmentPickerPresented,
+            attachmentCount: inputAttachments.count,
+            disabled: !canCompose || !attachmentsAvailable || settingsMutationInFlight
           )
 
           WorkComposerChipStrip(
@@ -1876,6 +1888,13 @@ private struct WorkChatComposerDraftInput: View {
     }
     .onChange(of: chatSummary.provider) { _, _ in configureSuggestionController() }
     .onChange(of: laneId) { _, _ in configureSuggestionController() }
+    .workChatAttachmentPicker(
+      isPresented: $attachmentPickerPresented,
+      attachments: $inputAttachments,
+      onDismiss: {
+        if canCompose { draftState.isFocused = true }
+      }
+    )
   }
 
   @ViewBuilder
@@ -2178,6 +2197,7 @@ private struct WorkChatComposerTextField: View {
   @ObservedObject var controller: WorkComposerSuggestionController
   let canCompose: Bool
   let placeholder: String
+  var acceptsPastedImages = true
   var onPasteImages: (([UIImage]) -> Void)? = nil
   var maxLines = 6
   @State private var measuredHeight: CGFloat = 24
@@ -2189,6 +2209,7 @@ private struct WorkChatComposerTextField: View {
       canCompose: canCompose,
       placeholder: placeholder,
       measuredHeight: $measuredHeight,
+      acceptsPastedImages: acceptsPastedImages,
       onPasteImages: onPasteImages,
       maxLines: maxLines
     )
@@ -2208,11 +2229,12 @@ private struct WorkChatComposerSendButton: View {
   let onSent: () -> Void
 
   private var sendEnabled: Bool {
-    let readyAttachments = workChatInputReadyAttachments(attachments)
-    return canSend
-      && !workChatInputHasLoadingAttachments(attachments)
-      && (draftState.hasSendableText || !readyAttachments.isEmpty)
-      && (readyAttachments.isEmpty || canUploadAttachments)
+    workChatInputCanSend(
+      text: draftState.text,
+      attachments: attachments,
+      baseEnabled: canSend,
+      canUploadAttachments: canUploadAttachments
+    )
   }
 
   var body: some View {

--- a/apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift
+++ b/apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift
@@ -424,12 +424,29 @@ final class WorkComposerChipLayoutManager: NSLayoutManager {
 
 // MARK: - Composer text view
 
-private final class WorkComposerPastingTextView: UITextView {
+final class WorkComposerPastingTextView: UITextView {
   var onPasteImages: (([UIImage]) -> Bool)?
 
+  private var pastedImages: [UIImage] {
+    let images = UIPasteboard.general.images ?? []
+    if !images.isEmpty { return Array(images.prefix(workChatInputAttachmentLimit + 1)) }
+    if let image = UIPasteboard.general.image { return [image] }
+    return []
+  }
+
+  override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+    if action == #selector(paste(_:)),
+       onPasteImages != nil,
+       UIPasteboard.general.hasImages {
+      return true
+    }
+    return super.canPerformAction(action, withSender: sender)
+  }
+
   override func paste(_ sender: Any?) {
-    if let image = UIPasteboard.general.image,
-       onPasteImages?([image]) == true {
+    let images = pastedImages
+    if !images.isEmpty,
+       onPasteImages?(images) == true {
       return
     }
     super.paste(sender)
@@ -579,9 +596,11 @@ struct WorkPlainComposerTextView: UIViewRepresentable {
     textView.setContentHuggingPriority(.defaultLow, for: .horizontal)
     textView.accessibilityIdentifier = "Work.StartChat.Composer.TextView"
     textView.accessibilityHint = "Long press a link for copy and remove actions."
-    textView.onPasteImages = { [weak coordinator = context.coordinator] images in
-      coordinator?.handlePasteImages(images) ?? false
-    }
+    textView.onPasteImages = acceptsPastedImages
+      ? { [weak coordinator = context.coordinator] images in
+          coordinator?.handlePasteImages(images) ?? false
+        }
+      : nil
 
     context.coordinator.textView = textView
     context.coordinator.installSmartLinkMenu(on: textView)
@@ -596,9 +615,11 @@ struct WorkPlainComposerTextView: UIViewRepresentable {
   func updateUIView(_ textView: UITextView, context: Context) {
     context.coordinator.parent = self
     if let textView = textView as? WorkComposerPastingTextView {
-      textView.onPasteImages = { [weak coordinator = context.coordinator] images in
-        coordinator?.handlePasteImages(images) ?? false
-      }
+      textView.onPasteImages = acceptsPastedImages
+        ? { [weak coordinator = context.coordinator] images in
+            coordinator?.handlePasteImages(images) ?? false
+          }
+        : nil
     }
     if textView.text != text {
       textView.text = text
@@ -771,6 +792,7 @@ struct WorkComposerTextView: UIViewRepresentable {
   let canCompose: Bool
   let placeholder: String
   @Binding var measuredHeight: CGFloat
+  var acceptsPastedImages = true
   var onPasteImages: (([UIImage]) -> Void)? = nil
   var maxLines = 6
 
@@ -816,9 +838,11 @@ struct WorkComposerTextView: UIViewRepresentable {
     textView.setContentHuggingPriority(.defaultLow, for: .horizontal)
     textView.accessibilityIdentifier = "Work.Chat.Composer.TextView"
     textView.accessibilityHint = "Long press a link for copy and remove actions."
-    textView.onPasteImages = { [weak coordinator = context.coordinator] images in
-      coordinator?.handlePasteImages(images) ?? false
-    }
+    textView.onPasteImages = acceptsPastedImages
+      ? { [weak coordinator = context.coordinator] images in
+          coordinator?.handlePasteImages(images) ?? false
+        }
+      : nil
 
     context.coordinator.textView = textView
     context.coordinator.installSmartLinkMenu(on: textView)
@@ -840,9 +864,11 @@ struct WorkComposerTextView: UIViewRepresentable {
     context.coordinator.parent = self
     textView.isEditable = canCompose
     if let textView = textView as? WorkComposerPastingTextView {
-      textView.onPasteImages = { [weak coordinator = context.coordinator] images in
-        coordinator?.handlePasteImages(images) ?? false
-      }
+      textView.onPasteImages = acceptsPastedImages
+        ? { [weak coordinator = context.coordinator] images in
+            coordinator?.handlePasteImages(images) ?? false
+          }
+        : nil
     }
     context.coordinator.applyPlaceholder(placeholder)
 
@@ -1044,7 +1070,9 @@ struct WorkComposerTextView: UIViewRepresentable {
     }
 
     func handlePasteImages(_ images: [UIImage]) -> Bool {
-      guard let onPasteImages = parent.onPasteImages, !images.isEmpty else { return false }
+      guard parent.acceptsPastedImages,
+            let onPasteImages = parent.onPasteImages,
+            !images.isEmpty else { return false }
       onPasteImages(images)
       parent.controller.clear()
       return true

--- a/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkNewChatScreen.swift
@@ -649,8 +649,13 @@ struct WorkNewChatScreen: View {
     return lanes.first(where: { $0.id == selectedLaneId })
   }
 
+  private var attachmentsAvailable: Bool {
+    syncService.supportsViewerRemoteAction("chat.saveTempAttachment")
+  }
+
   private var canUploadAttachments: Bool {
-    syncService.connectionState == .connected || syncService.connectionState == .syncing
+    attachmentsAvailable
+      && (syncService.connectionState == .connected || syncService.connectionState == .syncing)
   }
 
   /// Fast mode only applies to in-app chat sessions on fast-tier models. The
@@ -929,6 +934,7 @@ struct WorkNewChatScreen: View {
       modelName: prettyNewChatModelName(modelId),
       busy: busy,
       canStart: !busy && !shellLaunchBusy && (isAutoCreateLane || !selectedLaneId.isEmpty) && !modelId.isEmpty,
+      attachmentsAvailable: attachmentsAvailable,
       canUploadAttachments: canUploadAttachments,
       runtimeMode: $runtimeMode,
       reasoningEffort: $reasoningEffort,
@@ -1016,6 +1022,7 @@ struct WorkNewChatScreen: View {
   @MainActor
   private func submit(openingMessage: String, attachments inputAttachments: [WorkChatInputAttachment]) async -> Bool {
     let readyAttachments = workChatInputReadyAttachments(inputAttachments)
+    let rawText = openingMessage.trimmingCharacters(in: .whitespacesAndNewlines)
     let opener = workChatOutgoingText(openingMessage, attachmentCount: readyAttachments.count)
     guard !busy && !shellLaunchBusy && (isAutoCreateLane || !selectedLaneId.isEmpty) else { return false }
     guard !opener.isEmpty && !modelId.isEmpty else { return false }
@@ -1076,6 +1083,12 @@ struct WorkNewChatScreen: View {
     var createdChatAttachments: [AgentChatFileRef] = []
 
     do {
+      let attachmentRefs = try await workChatSaveInputAttachments(
+        readyAttachments,
+        syncService: syncService,
+        targetProjectId: targetScope.projectId,
+        targetProjectRootPath: targetScope.projectRootPath
+      )
       if sessionMode == .cli {
         let cliProvider = workResolveCliProvider(for: modelId, provider: provider)
         let cliReasoningEffort = workCliSupportsReasoningSelection(provider: cliProvider) && !normalizedReasoning.isEmpty
@@ -1086,7 +1099,7 @@ struct WorkNewChatScreen: View {
           provider: cliProvider,
           permissionMode: workCliPermissionMode(provider: cliProvider, runtimeMode: runtimeMode),
           title: workCliInitialSessionTitle(provider: cliProvider, opener: opener),
-          initialInput: opener,
+          initialInput: workCliInitialInput(text: rawText, attachments: attachmentRefs),
           modelId: modelId,
           reasoningEffort: cliReasoningEffort,
           fastMode: fastModeSupported ? codexFastMode : nil,
@@ -1129,12 +1142,6 @@ struct WorkNewChatScreen: View {
         busy = false
         return true
       }
-      let attachmentRefs = try await workChatSaveInputAttachments(
-        readyAttachments,
-        syncService: syncService,
-        targetProjectId: targetScope.projectId,
-        targetProjectRootPath: targetScope.projectRootPath
-      )
       let summary = try await syncService.createChatSession(
         laneId: targetLaneId,
         provider: provider,
@@ -1385,6 +1392,7 @@ private struct WorkNewChatComposerBar: View {
   let modelName: String
   let busy: Bool
   let canStart: Bool
+  let attachmentsAvailable: Bool
   let canUploadAttachments: Bool
   @Binding var runtimeMode: String
   @Binding var reasoningEffort: String
@@ -1394,6 +1402,7 @@ private struct WorkNewChatComposerBar: View {
 
   @State private var draft: String = ""
   @State private var attachments: [WorkChatInputAttachment] = []
+  @State private var attachmentPickerPresented = false
   @State private var composerTextHeight: CGFloat = 28
   @State private var composerFocused: Bool = false
   @StateObject private var dictationCoordinator = DictationInsertionCoordinator()
@@ -1403,19 +1412,13 @@ private struct WorkNewChatComposerBar: View {
   @State private var controlsWidth: CGFloat = 0
   private let dictationTargetId = "work-new-chat-screen"
 
-  private var trimmedDraft: String {
-    draft.trimmingCharacters(in: .whitespacesAndNewlines)
-  }
-
   private var canSend: Bool {
-    guard canStart else { return false }
-    if sessionMode != .chat {
-      return !trimmedDraft.isEmpty
-    }
-    let readyAttachments = workChatInputReadyAttachments(attachments)
-    return !workChatInputHasLoadingAttachments(attachments)
-      && (!trimmedDraft.isEmpty || !readyAttachments.isEmpty)
-      && (readyAttachments.isEmpty || canUploadAttachments)
+    workChatInputCanSend(
+      text: draft,
+      attachments: attachments,
+      baseEnabled: canStart,
+      canUploadAttachments: canUploadAttachments
+    )
   }
 
   private var runtimeOptions: [WorkRuntimeModeOption] {
@@ -1433,15 +1436,14 @@ private struct WorkNewChatComposerBar: View {
   @MainActor
   private func dispatch() {
     let outgoingAttachments = workChatInputReadyAttachments(attachments)
-    let text = workChatOutgoingText(draft, attachmentCount: outgoingAttachments.count)
-    guard !text.isEmpty else { return }
+    guard canSend else { return }
     let restoredDraft = draft
     let restoredAttachments = attachments
     composerFocused = false
     draft = ""
     attachments.removeAll()
     Task {
-      let started = await onSubmit(text, outgoingAttachments)
+      let started = await onSubmit(restoredDraft, outgoingAttachments)
       if !started {
         draft = restoredDraft
         attachments = restoredAttachments
@@ -1452,69 +1454,76 @@ private struct WorkNewChatComposerBar: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
       WorkChatInputAttachmentTray(attachments: $attachments)
+        .fixedSize(horizontal: false, vertical: true)
+        .layoutPriority(2)
 
-      WorkPlainComposerTextView(
-        text: $draft,
-        isFocused: Binding(
-          get: { composerFocused },
-          set: { composerFocused = $0 }
-        ),
-        measuredHeight: $composerTextHeight,
-        placeholder: placeholder,
-        acceptsPastedImages: sessionMode == .chat,
-        onPasteImages: { images in
-          workChatInputPasteImages(images, into: $attachments)
-        }
-      )
-      .frame(maxWidth: .infinity, minHeight: 28, idealHeight: composerTextHeight, maxHeight: composerTextHeight, alignment: .leading)
-
-      HStack(alignment: .center, spacing: 8) {
-        if !isDictating {
-          WorkChatAttachmentAddButton(
-            attachments: $attachments,
-            disabled: busy || sessionMode != .chat || !canUploadAttachments
-          )
-
-          ScrollView(.horizontal, showsIndicators: false) {
-            WorkComposerControlsRow(
-              provider: provider,
-              modelDisplayName: modelName,
-              reasoningEffort: reasoningEffort,
-              currentMode: runtimeMode,
-              modeOptions: runtimeOptions,
-              modeLabel: workRuntimeModeLabel(provider: provider, mode: runtimeMode),
-              isCollapsed: isControlsCollapsed,
-              fastModeEnabled: codexFastMode,
-              onOpenModelPicker: onOpenModelPicker,
-              onSelectMode: { runtimeMode = $0 }
-            )
-            .padding(.trailing, 4)
+      VStack(alignment: .leading, spacing: 12) {
+        WorkPlainComposerTextView(
+          text: $draft,
+          isFocused: Binding(
+            get: { composerFocused },
+            set: { composerFocused = $0 }
+          ),
+          measuredHeight: $composerTextHeight,
+          placeholder: placeholder,
+          acceptsPastedImages: attachmentsAvailable,
+          onPasteImages: { images in
+            workChatInputPasteImages(images, into: $attachments)
           }
-          .background(
-            GeometryReader { proxy in
-              Color.clear
-                .onAppear { controlsWidth = proxy.size.width }
-                .onChange(of: proxy.size.width) { _, newValue in
-                  controlsWidth = newValue
-                }
-            }
-          )
-
-          DictationRawUndoChip(coordinator: dictationCoordinator, draft: $draft)
-        }
-
-        DictationMicButton(
-          draft: $draft,
-          coordinator: dictationCoordinator,
-          targetId: dictationTargetId,
-          onRecordingChange: { isDictating = $0 }
         )
-        .frame(maxWidth: isDictating ? .infinity : nil)
+        .frame(maxWidth: .infinity, minHeight: 28, idealHeight: composerTextHeight, maxHeight: composerTextHeight, alignment: .leading)
 
-        if !isDictating {
-          foregroundSendButton
+        HStack(alignment: .center, spacing: 8) {
+          if !isDictating {
+            WorkChatAttachmentAddButton(
+              pickerPresented: $attachmentPickerPresented,
+              attachmentCount: attachments.count,
+              disabled: busy || !attachmentsAvailable
+            )
+
+            ScrollView(.horizontal, showsIndicators: false) {
+              WorkComposerControlsRow(
+                provider: provider,
+                modelDisplayName: modelName,
+                reasoningEffort: reasoningEffort,
+                currentMode: runtimeMode,
+                modeOptions: runtimeOptions,
+                modeLabel: workRuntimeModeLabel(provider: provider, mode: runtimeMode),
+                isCollapsed: isControlsCollapsed,
+                fastModeEnabled: codexFastMode,
+                onOpenModelPicker: onOpenModelPicker,
+                onSelectMode: { runtimeMode = $0 }
+              )
+              .padding(.trailing, 4)
+            }
+            .background(
+              GeometryReader { proxy in
+                Color.clear
+                  .onAppear { controlsWidth = proxy.size.width }
+                  .onChange(of: proxy.size.width) { _, newValue in
+                    controlsWidth = newValue
+                  }
+              }
+            )
+
+            DictationRawUndoChip(coordinator: dictationCoordinator, draft: $draft)
+          }
+
+          DictationMicButton(
+            draft: $draft,
+            coordinator: dictationCoordinator,
+            targetId: dictationTargetId,
+            onRecordingChange: { isDictating = $0 }
+          )
+          .frame(maxWidth: isDictating ? .infinity : nil)
+
+          if !isDictating {
+            foregroundSendButton
+          }
         }
       }
+      .fixedSize(horizontal: false, vertical: true)
+      .layoutPriority(1)
     }
     .padding(.horizontal, 14)
     .padding(.vertical, 14)
@@ -1541,11 +1550,11 @@ private struct WorkNewChatComposerBar: View {
     .shadow(color: Color.black.opacity(0.32), radius: 14, y: 6)
     .padding(.horizontal, 16)
     .padding(.bottom, 0)
-    .onChange(of: sessionMode) { _, newMode in
-      if newMode != .chat {
-        attachments.removeAll()
-      }
-    }
+    .workChatAttachmentPicker(
+      isPresented: $attachmentPickerPresented,
+      attachments: $attachments,
+      onDismiss: { composerFocused = true }
+    )
   }
 
   /// Primary foreground launch button — the compact arrow-in-circle send glyph

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift
@@ -1231,8 +1231,9 @@ struct WorkSessionDestinationView: View {
       liveTurnActiveHint: liveTurnActiveHint,
       compactComposer: compactComposer,
       isPersonalChat: personalChat,
-      personalAttachmentsAvailable: !personalChat
-        || syncService.canInvokeRemoteAction("personalChats.saveTempAttachment"),
+      attachmentsAvailable: personalChat
+        ? syncService.supportsViewerRemoteAction("personalChats.saveTempAttachment")
+        : syncService.supportsViewerRemoteAction("chat.saveTempAttachment"),
       personalModelCatalogAvailable: !personalChat
         || syncService.canInvokeRemoteAction("personalChats.modelCatalog"),
       personalSessionUpdatesAvailable: !personalChat

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -5283,6 +5283,78 @@ final class ADETests: XCTestCase {
   }
 
   @MainActor
+  func testImageAttachmentCapabilityRequiresAdvertisedTempSaveAction() throws {
+    let legacyDatabase = makeDatabase(baseURL: makeTemporaryDirectory())
+    defer { legacyDatabase.close() }
+    let legacyService = SyncService(database: legacyDatabase)
+    try legacyService.applyHelloPayloadForTesting([
+      "brain": [
+        "deviceId": "host-legacy",
+        "deviceName": "Mac Studio",
+      ],
+      "features": [
+        "projectCatalog": false,
+        "commandRouting": [
+          "mode": "allowlisted",
+          "actions": [[
+            "action": "work.startCliSession",
+            "policy": ["viewerAllowed": true],
+          ]],
+        ],
+      ],
+    ])
+
+    XCTAssertFalse(legacyService.supportsRemoteAction("chat.saveTempAttachment"))
+    XCTAssertFalse(legacyService.supportsViewerRemoteAction("chat.saveTempAttachment"))
+
+    let deniedDatabase = makeDatabase(baseURL: makeTemporaryDirectory())
+    defer { deniedDatabase.close() }
+    let deniedService = SyncService(database: deniedDatabase)
+    try deniedService.applyHelloPayloadForTesting([
+      "brain": [
+        "deviceId": "host-denied",
+        "deviceName": "Mac Studio",
+      ],
+      "features": [
+        "projectCatalog": false,
+        "commandRouting": [
+          "mode": "allowlisted",
+          "actions": [[
+            "action": "chat.saveTempAttachment",
+            "policy": ["viewerAllowed": false],
+          ]],
+        ],
+      ],
+    ])
+
+    XCTAssertTrue(deniedService.supportsRemoteAction("chat.saveTempAttachment"))
+    XCTAssertFalse(deniedService.supportsViewerRemoteAction("chat.saveTempAttachment"))
+
+    let supportedDatabase = makeDatabase(baseURL: makeTemporaryDirectory())
+    defer { supportedDatabase.close() }
+    let supportedService = SyncService(database: supportedDatabase)
+    try supportedService.applyHelloPayloadForTesting([
+      "brain": [
+        "deviceId": "host-current",
+        "deviceName": "Mac Studio",
+      ],
+      "features": [
+        "projectCatalog": false,
+        "commandRouting": [
+          "mode": "allowlisted",
+          "actions": [[
+            "action": "chat.saveTempAttachment",
+            "policy": ["viewerAllowed": true],
+          ]],
+        ],
+      ],
+    ])
+
+    XCTAssertTrue(supportedService.supportsRemoteAction("chat.saveTempAttachment"))
+    XCTAssertTrue(supportedService.supportsViewerRemoteAction("chat.saveTempAttachment"))
+  }
+
+  @MainActor
   func testPersonalChatsStayLocallyActionGatedOnPartialHost() throws {
     let remoteCommandDescriptorsKey = "ade.sync.remoteCommandDescriptors"
     UserDefaults.standard.removeObject(forKey: remoteCommandDescriptorsKey)

--- a/apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift
+++ b/apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift
@@ -182,6 +182,128 @@ final class WorkComposerTriggerDetectorTests: XCTestCase {
     XCTAssertEqual(workChatOutgoingText("  hello  ", attachmentCount: 1), "hello")
   }
 
+  func testCliInitialInputIncludesDesktopParityAttachmentManifest() {
+    let prompt = workCliInitialInput(
+      text: "  Inspect these inputs  ",
+      attachments: [
+        AgentChatFileRef(path: "/tmp/screenshot.jpg", type: "image"),
+        AgentChatFileRef(path: "/tmp/notes.txt", type: "file"),
+        AgentChatFileRef(path: "", type: "image-url", url: "https://example.com/reference.png"),
+      ]
+    )
+
+    XCTAssertEqual(
+      prompt,
+      """
+      Attached files and images:
+      1. Image file: /tmp/screenshot.jpg
+      2. File: /tmp/notes.txt
+      3. Image URL: https://example.com/reference.png
+
+      Inspect these inputs
+      """
+    )
+    XCTAssertEqual(workCliInitialInput(text: "  hello  ", attachments: []), "hello")
+    XCTAssertEqual(
+      workCliInitialInput(
+        text: "",
+        attachments: [AgentChatFileRef(path: "/tmp/only-image.jpg", type: "image")]
+      ),
+      """
+      Attached files and images:
+      1. Image file: /tmp/only-image.jpg
+      """
+    )
+  }
+
+  @MainActor
+  func testOfflinePreparedAttachmentWaitsForReconnectBeforeSend() throws {
+    let image = UIGraphicsImageRenderer(size: CGSize(width: 4, height: 4)).image { context in
+      UIColor.systemGreen.setFill()
+      context.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+    }
+    let attachment = try XCTUnwrap(workChatInputAttachment(from: image))
+
+    XCTAssertFalse(workChatInputCanSend(
+      text: "Inspect this",
+      attachments: [attachment],
+      baseEnabled: true,
+      canUploadAttachments: false
+    ))
+    XCTAssertTrue(workChatInputCanSend(
+      text: "Inspect this",
+      attachments: [attachment],
+      baseEnabled: true,
+      canUploadAttachments: true
+    ))
+
+    let failed = WorkChatInputAttachment(filename: "bad.jpg", state: .failed("Could not load image."))
+    XCTAssertFalse(workChatInputCanSend(
+      text: "Send anyway",
+      attachments: [failed],
+      baseEnabled: true,
+      canUploadAttachments: true
+    ))
+  }
+
+  @MainActor
+  func testPastedImagesAreBoundedAndOverflowIsVisible() {
+    let image = UIGraphicsImageRenderer(size: CGSize(width: 2, height: 2)).image { context in
+      UIColor.black.setFill()
+      context.fill(CGRect(x: 0, y: 0, width: 2, height: 2))
+    }
+    var attachments: [WorkChatInputAttachment] = []
+    workChatInputPasteImages(
+      Array(repeating: image, count: workChatInputAttachmentLimit + 2),
+      into: Binding(get: { attachments }, set: { attachments = $0 })
+    )
+
+    XCTAssertEqual(workChatInputReadyAttachments(attachments).count, workChatInputAttachmentLimit)
+    XCTAssertEqual(attachments.count, workChatInputAttachmentLimit + 1)
+    XCTAssertTrue(workChatInputHasFailedAttachments(attachments))
+    XCTAssertEqual(attachments.last?.errorMessage, "You can attach up to 10 images at a time.")
+
+    workChatInputPasteImages(
+      Array(repeating: image, count: workChatInputAttachmentLimit),
+      into: Binding(get: { attachments }, set: { attachments = $0 })
+    )
+    XCTAssertEqual(attachments.count, workChatInputAttachmentLimit + 1)
+    XCTAssertEqual(
+      attachments.filter { $0.errorMessage == "You can attach up to 10 images at a time." }.count,
+      1
+    )
+  }
+
+  @MainActor
+  func testImageOnlyClipboardExposesPasteAndDispatchesEveryImage() {
+    let first = UIGraphicsImageRenderer(size: CGSize(width: 4, height: 4)).image { context in
+      UIColor.systemRed.setFill()
+      context.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+    }
+    let second = UIGraphicsImageRenderer(size: CGSize(width: 4, height: 4)).image { context in
+      UIColor.systemBlue.setFill()
+      context.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+    }
+    let pasteboard = UIPasteboard.general
+    let previousItems = pasteboard.items
+    defer { pasteboard.items = previousItems }
+    pasteboard.images = [first, second]
+
+    let textView = WorkComposerPastingTextView()
+    var receivedImages: [UIImage] = []
+    textView.onPasteImages = { images in
+      receivedImages = images
+      return true
+    }
+
+    XCTAssertTrue(textView.canPerformAction(
+      #selector(UIResponderStandardEditActions.paste(_:)),
+      withSender: nil
+    ))
+    textView.paste(nil)
+    XCTAssertEqual(receivedImages.count, 2)
+  }
+
   @MainActor
   func testPlainComposerDefersFocusTransitionsOutsideSwiftUIUpdate() async {
     var text = ""

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -1093,6 +1093,10 @@ strip (permission/model/mode/dictation) in place above the keyboard rather than
 presenting a modal drawer. Expansion is explicit state (never derived from
 `@FocusState`, which would snap) so every expand/collapse rides one shared
 spring, and a Project ▸ Lane destination picker chooses where the chat lands.
+The camera-roll picker is presented by the persistent composer root rather than
+the transient plus control. Presenting PhotosPicker may dismiss the keyboard,
+but the composer remains expanded until the picker closes, so its presenter is
+never unmounted underneath the system sheet.
 The chat is created in place and does **not** auto-open — a "Created in
 &lt;project&gt; · &lt;lane&gt;" toast offers an Open shortcut. Project cards are
 drag-reorderable (persisted per machine, mobile-only, never touching desktop
@@ -1172,20 +1176,23 @@ pinned sibling above the composer, so keyboard presentation gives an expanding
 multi-line prompt the available space instead of lifting the activity panel
 with it.
 
-Mobile chat image attachments use the same host-side temp attachment contract as
-desktop. Work and Hub chat composers expose an add-attachment control beside the
-permission/model controls; its menu currently has one action, Attach from camera
-roll, backed by scoped `PhotosPicker` access rather than a full photo-library
-permission. Picked or pasted images stage in `WorkChatInputAttachmentTray` above
-the prompt with thumbnail, loading, and failed states; tapping a staged image
-opens the larger preview sheet with copy and remove actions. The in-session
-`UITextView` composer intercepts pasted `UIPasteboard` images and feeds the same
-tray. Images are normalized to JPEG before upload, saved through
-`chat.saveTempAttachment`, and then sent on `chat.send` / `chat.steer` as
-`AgentChatFileRef` image refs. If a selected asset cannot be loaded yet (for
-example an iCloud-only photo that is not currently available on the phone), the
-tile remains local and shows a recoverable load error instead of sending a
-broken attachment.
+Mobile image attachments use the same host-side temp attachment contract as
+desktop. Hub, Work new-session, compact/in-session, Chat, and CLI composers open
+the scoped `PhotosPicker` directly from the plus control rather than through a
+one-item menu. Their `UITextView` inputs also advertise Paste for image-only
+clipboards and stage pasted images through the same path. Up to ten images are
+normalized to JPEG and retained locally; overflow and load failures stay visible
+as blocking tray errors instead of being silently dropped. Staging works while
+offline, while upload/send waits for reconnection. Hosts that do not advertise
+`chat.saveTempAttachment` do not offer attachment entry.
+
+`WorkChatInputAttachmentTray` is a separate fixed-height shelf above the input
+region, so adding previews grows the composer upward without reducing the text
+field's space. Attachments survive Chat/CLI mode switches. Chat sends attach the
+saved `AgentChatFileRef` image refs to `chat.send` / `chat.steer`. CLI launches
+save through the same contract, then `workCliInitialInput` serializes the temp
+paths into the desktop-compatible `Attached files and images:` manifest inside
+`work.startCliSession.initialInput`.
 
 Work can also import provider-native Claude, Codex, Cursor, Droid, and OpenCode
 CLI sessions. `WorkImportSessionScreen` first shows a compact searchable list,
@@ -1524,7 +1531,7 @@ different machine's cached limits.
 | Hub personal chats | Implemented; runtime-scoped list/create/read/send/interactive actions, owner-only scheduled-work creation capability, controller Cancel/Pause actions, per-host offline summary cache, explicit personal transcript subscriptions, native new-chat/model flow, Chat Info Cancel/Pause controls, and project/lane actions suppressed |
 | Lanes tab | Implemented to live machine parity (with `devicesOpen`, multi-attach, stack canvas, stack-position/base-branch editing in Manage Lane, and template environment progress) |
 | Files tab | Implemented with freely-editable workspaces (mobile read-only file gate removed) and a unified full-screen name + content search page (`FilesSearchScreen`) |
-| Work tab | Implemented; live chat-event push from runtime, subscribed terminal input/resize control with `terminal_unsubscribe` on view disappear, in-app CLI session launcher (`work.startCliSession`), external provider-session browse/import (`work.listExternalSessions` / `work.importExternalSession`), message-to-continue on ended agent CLI rows, fixed cross-client activity carousel above the new-chat composer |
+| Work tab | Implemented; live chat-event push from runtime, subscribed terminal input/resize control with `terminal_unsubscribe` on view disappear, in-app CLI session launcher (`work.startCliSession`) with camera-roll and pasted-image prompts, external provider-session browse/import (`work.listExternalSessions` / `work.importExternalSession`), message-to-continue on ended agent CLI rows, fixed cross-client activity carousel above the new-chat composer |
 | PRs tab | Implemented; driven by `prs.getMobileSnapshot` |
 | Settings tab (pairing / appearance / diagnostics) | Implemented |
 | Automations / Graph / History tabs | Planned |
@@ -1773,7 +1780,10 @@ different machine's cached limits.
   Claude CLI session at a non-default effort tier without going
   through the desktop.
 - **Codex CLI launches receive the initial prompt as argv, not PTY
-  echo.** Other providers still receive `initialInput` as bytes typed
+  echo.** Image attachments prepend the same `Attached files and images:`
+  temp-path manifest as desktop; attachment-only launches send that manifest
+  without synthetic message text. Other providers receive the same composed
+  `initialInput` as bytes typed
   into the spawned PTY (`writeBySessionId(sessionId, "${input}\\r")`),
   but Codex receives it as the final positional argv on `codex` via
   `buildTrackedCliLaunchCommand` so the model sees a clean first turn


### PR DESCRIPTION
## Summary

- keep the iOS photo picker mounted so camera-roll selection no longer dismisses immediately
- support camera-roll and clipboard images for Chat and CLI sessions across Hub, New Chat, and active composers
- preserve composer text space by growing attachment previews above the input
- add host capability, offline, failure, and attachment-limit safeguards
- document iOS attachment behavior and desktop-parity CLI manifests

## Validation

- quality skill: correctness and maintainability reviews clean
- test skill: mobile, CLI, TUI, and docs parity gates clean
- focused iOS simulator tests: 27 passed, 0 failed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds consistent mobile image-attachment support across iOS chat and CLI composers.
- Gates attachment entry on host-advertised remote-action capabilities while allowing offline staging.
- Adds direct photo-picker presentation, multi-image clipboard handling, a ten-image limit, and blocking load/overflow errors.
- Saves staged images before chat or CLI launch and serializes CLI attachment paths into the initial prompt manifest.
- Adds tests and companion documentation for capability gating, offline behavior, limits, clipboard handling, and CLI input formatting.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete changed-code failures identified.

Attachment capability checks, offline staging, upload gating, Chat and CLI dispatch, overflow handling, and clipboard behavior remain internally consistent across the changed paths.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Linux host/tool availability probe ran and the attempted simulator build failed because xcodebuild was not found (exit 127).
- The verification plan notes that checking picker/paste JPEG preparation, attachment-tray rendering, and send gating requires a macOS host with Xcode, an iOS 26 simulator runtime, and a launchable ADE scheme.
- Three log artifacts were uploaded to document the environment probe, the simulator build attempt, and the verification environment note.

<a href="https://app.greptile.com/trex/runs/15512702/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Services/SyncService.swift | Adds consistent capability and invocation-policy checks for temporary attachment uploads. |
| apps/ios/ADE/Views/Work/WorkChatAttachmentTray.swift | Centralizes attachment send eligibility, multi-image limits, picker presentation, and CLI manifest generation. |
| apps/ios/ADE/Views/Work/WorkChatSessionView.swift | Enables capability-gated picker and pasted-image staging in compact and expanded session composers. |
| apps/ios/ADE/Views/Work/WorkNewChatScreen.swift | Extends new Chat and CLI launches to upload staged attachments and preserve their original prompt text. |
| apps/ios/ADE/Views/Hub/HubComposerDrawer.swift | Adds persistent attachment picker presentation and attachment-aware Chat and CLI submission. |
| apps/ios/ADE/Views/Work/WorkComposerTypedTriggers.swift | Advertises image-only paste actions and forwards bounded multi-image clipboard contents. |
| apps/ios/ADE/Views/Work/WorkSessionDestinationView.swift | Selects the appropriate advertised attachment capability for project and personal chats. |
| apps/ios/ADETests/WorkComposerTriggerDetectorTests.swift | Covers CLI manifests, offline send gating, attachment overflow, and multi-image clipboard behavior. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Photo picker or clipboard] --> B[Normalize and stage images locally]
  B --> C{Host capability advertised?}
  C -- No --> D[Attachment entry unavailable]
  C -- Yes --> E{Live connection?}
  E -- No --> F[Retain staged attachments and disable send]
  E -- Yes --> G[chat.saveTempAttachment]
  G --> H{Session mode}
  H -- Chat --> I[Send AgentChatFileRef values]
  H -- CLI --> J[Build attachment path manifest]
  J --> K[work.startCliSession initialInput]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ios): support image attachments acro..."](https://github.com/arul28/ade/commit/318791ba4be231010e225d37735df82e9fc412c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46531473)</sub>

<!-- /greptile_comment -->