### PR TITLE
Reliability follow-ups: referenced lifecycle timers, shared-signal token exchange

### DIFF
--- a/apps/ade-cli/src/serviceManager/common.ts
+++ b/apps/ade-cli/src/serviceManager/common.ts
@@ -261,9 +261,12 @@ export async function terminatePidGracefullyAsync(
   const deadline = Date.now() + (deps.graceTimeoutMs ?? 1_500);
   while (Date.now() < deadline) {
     if (!pidAlive(pid)) return;
+    // This timer is awaited: it must stay referenced, or a standalone CLI
+    // (e.g. `ade serve --install-service` repairing a wedged brain) can run
+    // out of referenced work and exit before the SIGKILL escalation and the
+    // subsequent `launchctl load` ever happen.
     await new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, 50);
-      timer.unref?.();
+      setTimeout(resolve, 50);
     });
   }
   try {

--- a/apps/ade-cli/src/serviceManager/installLaunchd.ts
+++ b/apps/ade-cli/src/serviceManager/installLaunchd.ts
@@ -211,9 +211,11 @@ function pidAlive(pid: number): boolean {
 }
 
 async function sleepAsync(ms: number): Promise<void> {
+  // Awaited lifecycle delays must stay referenced: in a standalone CLI the
+  // handover polling can be the only pending work, and an unref'd timer lets
+  // the process exit mid-repair (before SIGKILL escalation / launchctl load).
   await new Promise<void>((resolve) => {
-    const timer = setTimeout(resolve, ms);
-    timer.unref?.();
+    setTimeout(resolve, ms);
   });
 }
 

--- a/apps/ade-cli/src/services/account/accountAuthService.ts
+++ b/apps/ade-cli/src/services/account/accountAuthService.ts
@@ -1817,21 +1817,22 @@ export function createAccountAuthService(args: {
           return refreshed.accessToken;
         })().finally(() => {
           clearTimeout(envSharedTimer);
+          // Single-flight must be released by the SHARED exchange settling,
+          // never by an individual caller aborting out of the join below —
+          // otherwise a second caller starts a competing OAuth exchange with
+          // the same rotating refresh token.
+          if (envRefreshInFlight === refreshPromise) envRefreshInFlight = null;
         });
         envRefreshInFlight = refreshPromise;
       }
       const refreshPromise = envRefreshInFlight;
-      try {
-        // Race the caller's own signal; the shared exchange keeps running for
-        // every other caller when this one aborts.
-        return await runWithAbortSignal(
-          () => refreshPromise,
-          signal ?? undefined,
-          "The account token request was aborted.",
-        );
-      } finally {
-        if (envRefreshInFlight === refreshPromise) envRefreshInFlight = null;
-      }
+      // Race the caller's own signal; the shared exchange keeps running for
+      // every other caller when this one aborts.
+      return await runWithAbortSignal(
+        () => refreshPromise,
+        signal ?? undefined,
+        "The account token request was aborted.",
+      );
     }
 
     if (!record?.accessToken || !record.userId) {
@@ -1879,7 +1880,7 @@ export function createAccountAuthService(args: {
             token = await postTokenForm({
               fetchImpl,
               tokenUrl: `${config.issuer}/oauth/token`,
-              signal,
+              signal: sharedSignal,
               body: {
                 grant_type: "refresh_token",
                 refresh_token: refreshRecord.refreshToken!,


### PR DESCRIPTION
Three verified P1s from PR #889's final review round, fixed post-merge before the release:

- Awaited termination/handover timers in serviceManager stay referenced — an unref'd awaited timer could let a standalone `ade serve --install-service` exit before SIGKILL escalation and `launchctl load` while repairing a wedged brain.
- The coalesced session token exchange now actually uses the service-owned shared signal (one call site missed in #889), so a fast-aborting caller can't kill the refresh other callers await.
- The env-token refresh single-flight is released only by the shared exchange settling; an aborting caller no longer clears it early and triggers a competing OAuth exchange with the same rotating refresh token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ade doctor` health checks with readable status tables, JSON output, and optional online version checks.
  * Added runtime recovery notices and richer runtime health/activity details in the desktop app.
  * Added update banners for ready, parked, and automatically scheduled updates, including cancellation controls.
  * Improved remote machine publishing health visibility and port-conflict recovery.
  * Added stronger account pairing compatibility through negotiated encryption support.

* **Bug Fixes**
  * Improved cancellation and timeout handling for account refreshes, remote commands, GitHub requests, and service handoffs.
  * Added runtime freshness monitoring and recovery safeguards for stalled or outdated services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates service lifecycle waits and account token refresh cancellation. The main changes are:

- Keeps awaited service termination and launchd handover timers referenced.
- Uses shared cancellation for coalesced account refresh token exchanges.
- Releases the env-token refresh single-flight only when the shared refresh settles.

<h3>Confidence Score: 4/5</h3>

One contained account refresh bug should be fixed before merging.

The lifecycle timer changes are narrow and safe. The account refresh changes mostly preserve shared cancellation, but one env-token fallback can still let an aborted caller fail shared work.

apps/ade-cli/src/services/account/accountAuthService.ts

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed static verification of the shared fallback isolation; runtime evidence was blocked by the step limit, and static inspection confirmed the fallback calls getAccessTokenWithSignal({}, signal) at line 1806.
- Executed a verbose Vitest run for the ADE CLI tests, including common.test.ts and accountAuthService.test.ts, which completed with exit code 0, 2 test files and 112 tests passing in about 1.04 seconds.

<a href="https://app.greptile.com/trex/runs/15691933/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/serviceManager/common.ts | Keeps the awaited async termination poll timer referenced so SIGKILL escalation cannot be skipped by process exit. |
| apps/ade-cli/src/serviceManager/installLaunchd.ts | Keeps launchd handover sleep timers referenced during service repair polling. |
| apps/ade-cli/src/services/account/accountAuthService.ts | Moves token refresh single-flight cleanup to shared promise settlement and uses shared cancellation for refresh calls, but one fallback retry still captures an individual caller signal. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant Caller as Token caller
participant Join as getAccessToken join
participant Shared as Shared refresh promise
participant OAuth as OAuth token endpoint
participant Store as Env/session state

Caller->>Join: getAccessToken(signal)
Join->>Shared: create or join env/session refresh
Shared->>OAuth: refresh_token exchange(shared signal)
OAuth-->>Shared: access/refresh token
Shared->>Store: persist/update refreshed session
Shared-->>Join: shared result settles
Join-->>Caller: result or caller-local abort
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/ade-cli/src/services/account/accountAuthService.ts`, line 1803-1806 ([link](https://github.com/arul28/ade/blob/1ea60385570e768292dd0f16962f3fb587768abd/apps/ade-cli/src/services/account/accountAuthService.ts#L1803-L1806)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Keep shared fallback isolated**
   This fallback re-enters `getAccessTokenWithSignal` with the initiating caller's `signal`. When the env credential changes during the shared refresh after that caller has aborted, the shared `refreshPromise` rejects with that caller's abort instead of consuming the newer credential for other waiters. Use the shared signal for this internal retry so only the shared timeout controls it.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/ade-cli/src/services/account/accountAuthService.ts
   Line: 1803-1806

   Comment:
   **Keep shared fallback isolated**
   This fallback re-enters `getAccessTokenWithSignal` with the initiating caller's `signal`. When the env credential changes during the shared refresh after that caller has aborted, the shared `refreshPromise` rejects with that caller's abort instead of consuming the newer credential for other waiters. Use the shared signal for this internal retry so only the shared timeout controls it.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fade-cli%2Fsrc%2Fservices%2Faccount%2FaccountAuthService.ts%0ALine%3A%201803-1806%0A%0AComment%3A%0A**Keep%20shared%20fallback%20isolated**%0AThis%20fallback%20re-enters%20%60getAccessTokenWithSignal%60%20with%20the%20initiating%20caller's%20%60signal%60.%20When%20the%20env%20credential%20changes%20during%20the%20shared%20refresh%20after%20that%20caller%20has%20aborted%2C%20the%20shared%20%60refreshPromise%60%20rejects%20with%20that%20caller's%20abort%20instead%20of%20consuming%20the%20newer%20credential%20for%20other%20waiters.%20Use%20the%20shared%20signal%20for%20this%20internal%20retry%20so%20only%20the%20shared%20timeout%20controls%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20The%20credential%20changed%20while%20this%20process%20was%20refreshing.%20The%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20replacement%20is%20already%20newer%20than%20the%20request%20we%20started%2C%20so%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20consume%20it%20normally%20instead%20of%20force-rotating%20it%20again.%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20getAccessTokenWithSignal%28%7B%7D%2C%20envSharedSignal%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=arul28%2Fade&pr=891&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fade-cli%2Fsrc%2Fservices%2Faccount%2FaccountAuthService.ts%3A1803-1806%0A**Keep%20shared%20fallback%20isolated**%0AThis%20fallback%20re-enters%20%60getAccessTokenWithSignal%60%20with%20the%20initiating%20caller's%20%60signal%60.%20When%20the%20env%20credential%20changes%20during%20the%20shared%20refresh%20after%20that%20caller%20has%20aborted%2C%20the%20shared%20%60refreshPromise%60%20rejects%20with%20that%20caller's%20abort%20instead%20of%20consuming%20the%20newer%20credential%20for%20other%20waiters.%20Use%20the%20shared%20signal%20for%20this%20internal%20retry%20so%20only%20the%20shared%20timeout%20controls%20it.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20The%20credential%20changed%20while%20this%20process%20was%20refreshing.%20The%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20replacement%20is%20already%20newer%20than%20the%20request%20we%20started%2C%20so%0A%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20consume%20it%20normally%20instead%20of%20force-rotating%20it%20again.%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20getAccessTokenWithSignal%28%7B%7D%2C%20envSharedSignal%29%3B%0A%60%60%60%0A%0A&repo=arul28%2Fade&pr=891&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/ade-cli/src/services/account/accountAuthService.ts:1803-1806
**Keep shared fallback isolated**
This fallback re-enters `getAccessTokenWithSignal` with the initiating caller's `signal`. When the env credential changes during the shared refresh after that caller has aborted, the shared `refreshPromise` rejects with that caller's abort instead of consuming the newer credential for other waiters. Use the shared signal for this internal retry so only the shared timeout controls it.

```suggestion
            // The credential changed while this process was refreshing. The
            // replacement is already newer than the request we started, so
            // consume it normally instead of force-rotating it again.
            return getAccessTokenWithSignal({}, envSharedSignal);
```


`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(reliability): referenced lifecycle t..."](https://github.com/arul28/ade/commit/1ea60385570e768292dd0f16962f3fb587768abd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46886129)</sub>

<!-- /greptile_comment -->