### PR TITLE
Fix Work attention for SDK chat questions

### DIFF
--- a/apps/desktop/src/main/services/adeActions/registry.test.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.test.ts
@@ -882,6 +882,170 @@ describe("runtime Linear OAuth actions", () => {
 });
 
 describe("runtime session actions", () => {
+  it("projects provider pending input into runtime-bound Work session rows", async () => {
+    const providers = [
+      ["codex-chat", "codex"],
+      ["claude-chat", "claude"],
+      ["opencode-chat", "opencode"],
+      ["cursor", "cursor"],
+      ["droid-chat", "droid"],
+    ] as const;
+    const sessions = providers.map(([toolType, provider]) =>
+      makeSession({
+        id: `${provider}-chat`,
+        laneId: "lane-1",
+        toolType,
+      }));
+    sessions.push(makeSession({
+      id: "identity-chat",
+      laneId: "lane-1",
+      toolType: "claude-chat",
+    }));
+    const list = vi.fn(() => sessions);
+    const enrichSessions = vi.fn((rows: TerminalSessionSummary[]) => rows);
+    const listSessions = vi.fn(async () => [
+      ...providers.map(([, provider]) => ({
+        sessionId: `${provider}-chat`,
+        provider,
+        status: "active",
+        awaitingInput: true,
+        pendingInputItemId: `${provider}-question`,
+        identityKey: null,
+      })),
+      {
+        sessionId: "identity-chat",
+        provider: "claude",
+        status: "idle",
+        identityKey: "cto",
+      },
+    ]);
+    const runtime = {
+      sessionService: {
+        list,
+        get: vi.fn(),
+      },
+      ptyService: {
+        enrichSessions,
+      },
+      agentChatService: {
+        listSessions,
+      },
+      logger: {
+        warn: vi.fn(),
+      },
+    } as unknown as Parameters<typeof getAdeActionDomainServices>[0];
+    const sessionActions = getAdeActionDomainServices(runtime).session as {
+      list: (args?: { laneId?: string }) => Promise<TerminalSessionSummary[]>;
+    };
+
+    const result = await sessionActions.list({ laneId: "lane-1" });
+
+    expect(list).toHaveBeenCalledWith({ laneId: "lane-1" });
+    expect(enrichSessions).toHaveBeenCalledWith(sessions);
+    expect(listSessions).toHaveBeenCalledWith("lane-1", {
+      includeIdentity: true,
+      includeAutomation: true,
+    });
+    expect(result).toHaveLength(providers.length);
+    expect(result.map((session) => session.id)).not.toContain("identity-chat");
+    for (const [, provider] of providers) {
+      expect(result.find((session) => session.id === `${provider}-chat`)).toMatchObject({
+        runtimeState: "waiting-input",
+        pendingInputItemId: `${provider}-question`,
+      });
+    }
+  });
+
+  it("clears stale pending input after the provider reports the chat active again", async () => {
+    const persisted = makeSession({
+      id: "codex-chat",
+      laneId: "lane-1",
+      toolType: "codex-chat",
+      runtimeState: "waiting-input",
+      pendingInputItemId: "resolved-question",
+    });
+    const get = vi.fn(() => persisted);
+    const enrichSessions = vi.fn((rows: TerminalSessionSummary[]) => rows);
+    const getSessionSummary = vi.fn(async () => ({
+      sessionId: "codex-chat",
+      provider: "codex",
+      status: "active",
+      awaitingInput: false,
+      pendingInputItemId: null,
+    }));
+    const runtime = {
+      sessionService: {
+        list: vi.fn(),
+        get,
+      },
+      ptyService: {
+        enrichSessions,
+      },
+      agentChatService: {
+        getSessionSummary,
+      },
+      logger: {
+        warn: vi.fn(),
+      },
+    } as unknown as Parameters<typeof getAdeActionDomainServices>[0];
+    const sessionActions = getAdeActionDomainServices(runtime).session as {
+      get: (sessionId: string) => Promise<TerminalSessionSummary | null>;
+    };
+
+    const result = await sessionActions.get("codex-chat");
+
+    expect(get).toHaveBeenCalledWith("codex-chat");
+    expect(enrichSessions).toHaveBeenCalledWith([persisted]);
+    expect(getSessionSummary).toHaveBeenCalledWith("codex-chat");
+    expect(result).toMatchObject({
+      id: "codex-chat",
+      runtimeState: "running",
+      pendingInputItemId: null,
+    });
+  });
+
+  it("degrades an unprojectable chat row to quiet instead of false running", async () => {
+    const persisted = makeSession({
+      id: "claude-chat",
+      laneId: "lane-1",
+      toolType: "claude-chat",
+      runtimeState: "running",
+    });
+    const warn = vi.fn();
+    const runtime = {
+      sessionService: {
+        list: vi.fn(() => [persisted]),
+        get: vi.fn(),
+      },
+      ptyService: {
+        enrichSessions: vi.fn((rows: TerminalSessionSummary[]) => rows),
+      },
+      agentChatService: {
+        listSessions: vi.fn(async () => {
+          throw new Error("provider state unavailable");
+        }),
+      },
+      logger: {
+        warn,
+      },
+    } as unknown as Parameters<typeof getAdeActionDomainServices>[0];
+    const sessionActions = getAdeActionDomainServices(runtime).session as {
+      list: () => Promise<TerminalSessionSummary[]>;
+    };
+
+    const result = await sessionActions.list();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "claude-chat",
+      runtimeState: "idle",
+    });
+    expect(warn).toHaveBeenCalledWith("sessions.chat_projection_failed", {
+      laneId: null,
+      error: "provider state unavailable",
+    });
+  });
+
   it("launches tracked CLI agents through runtime chat actions", async () => {
     const ptyCreate = vi.fn(async (args: { sessionId: string }) => ({
       sessionId: args.sessionId,

--- a/apps/desktop/src/main/services/adeActions/registry.test.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.test.ts
@@ -1046,6 +1046,62 @@ describe("runtime session actions", () => {
     });
   });
 
+  it("hydrates missing resume targets before runtime list and detail reads", async () => {
+    const persisted = makeSession({
+      id: "resumable-codex",
+      laneId: "lane-1",
+      toolType: "codex",
+      status: "completed",
+      runtimeState: "idle",
+      resumeMetadata: null,
+    });
+    const hydrated = {
+      ...persisted,
+      resumeMetadata: {
+        provider: "codex" as const,
+        targetId: "thread-123",
+      },
+    };
+    const list = vi.fn()
+      .mockReturnValueOnce([persisted])
+      .mockReturnValueOnce([hydrated]);
+    const get = vi.fn()
+      .mockReturnValueOnce(persisted)
+      .mockReturnValueOnce(hydrated);
+    const ensureResumeTargets = vi.fn(async () => {});
+    const enrichSessions = vi.fn((rows: TerminalSessionSummary[]) => rows);
+    const runtime = {
+      sessionService: {
+        list,
+        get,
+      },
+      ptyService: {
+        ensureResumeTargets,
+        enrichSessions,
+      },
+      agentChatService: {
+        listSessions: vi.fn(async () => []),
+      },
+      logger: {
+        warn: vi.fn(),
+      },
+    } as unknown as Parameters<typeof getAdeActionDomainServices>[0];
+    const sessionActions = getAdeActionDomainServices(runtime).session as {
+      list: (args?: { laneId?: string }) => Promise<TerminalSessionSummary[]>;
+      get: (sessionId: string) => Promise<TerminalSessionSummary | null>;
+    };
+
+    await expect(sessionActions.list({ laneId: "lane-1" })).resolves.toEqual([hydrated]);
+    await expect(sessionActions.get("resumable-codex")).resolves.toEqual(hydrated);
+
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(ensureResumeTargets).toHaveBeenNthCalledWith(1, ["resumable-codex"]);
+    expect(ensureResumeTargets).toHaveBeenNthCalledWith(2, ["resumable-codex"]);
+    expect(enrichSessions).toHaveBeenNthCalledWith(1, [hydrated]);
+    expect(enrichSessions).toHaveBeenNthCalledWith(2, [hydrated]);
+  });
+
   it("launches tracked CLI agents through runtime chat actions", async () => {
     const ptyCreate = vi.fn(async (args: { sessionId: string }) => ({
       sessionId: args.sessionId,

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -54,6 +54,7 @@ import type {
   LaneListSnapshot,
   LaneOverlayOverrides,
   LanePreviewInfo,
+  ListSessionsArgs,
   ListLanesArgs,
   PortLease,
   PrAgentPermissionMode,
@@ -87,6 +88,10 @@ import { parseLinearGraphQLInput } from "../cto/linearGraphQLInput";
 import { launchAgentChatCli } from "../chat/agentChatCliLaunch";
 import { deleteTerminalSessionWithRuntimeCleanup } from "../sessions/deleteTerminalSession";
 import { settleTerminalSession } from "../sessions/settleTerminalSession";
+import {
+  getSessionWithChatProjection,
+  listSessionsWithChatProjection,
+} from "../sessions/chatSessionProjection";
 import { createOrchestrationDomainService } from "../orchestration/orchestrationDomain";
 import { createAccountActionDomainService } from "../../../../../ade-cli/src/services/account/accountAuthService";
 
@@ -1658,6 +1663,13 @@ function buildSessionDomainService(runtime: AdeRuntime): OpaqueService | null {
   if (!sessionService) return null;
   return {
     ...(sessionService as unknown as OpaqueService),
+    async list(args?: ListSessionsArgs | null) {
+      return listSessionsWithChatProjection(runtime, args ?? {});
+    },
+    async get(arg?: unknown) {
+      const sessionId = readStringActionArg(arg, "sessionId");
+      return getSessionWithChatProjection(runtime, sessionId);
+    },
     requestSessionAttention: (args?: unknown) => {
       const record = readObjectActionArg(args, "session.requestSessionAttention");
       const sessionId = requireNonEmptyString(record.sessionId, "sessionId");

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -38,6 +38,7 @@ import {
   fallbackUnprojectedChatSession,
   isChatToolType,
   projectChatOntoSession,
+  projectChatSummariesOntoSessions,
 } from "../sessions/chatSessionProjection";
 import {
   removeProjectIconOverride,
@@ -6399,23 +6400,7 @@ export function registerIpc({
             });
           }
         }
-        const identitySessionIds = new Set(
-          allChats
-            .filter((chat) => Boolean(chat.identityKey))
-            .map((chat) => chat.sessionId),
-        );
-        if (identitySessionIds.size > 0) {
-          sessions = sessions.filter((session) => !identitySessionIds.has(session.id));
-        }
-        const chats = allChats.filter((chat) => !chat.identityKey);
-        const chatSummaryBySessionId = new Map(chats.map((chat) => [chat.sessionId, chat] as const));
-        return sessions.map((session) => {
-          if (!isChatToolType(session.toolType)) return session;
-          const chat = chatSummaryBySessionId.get(session.id);
-          return chat
-            ? projectChatOntoSession(session, chat)
-            : fallbackUnprojectedChatSession(session);
-        });
+        return projectChatSummariesOntoSessions(sessions, allChats);
       },
       {
         laneId: typeof arg?.laneId === "string" ? arg.laneId : null,

--- a/apps/desktop/src/main/services/ipc/registerIpc.ts
+++ b/apps/desktop/src/main/services/ipc/registerIpc.ts
@@ -35,10 +35,8 @@ import {
 import { deleteTerminalSessionWithRuntimeCleanup } from "../sessions/deleteTerminalSession";
 import { settleTerminalSession } from "../sessions/settleTerminalSession";
 import {
-  fallbackUnprojectedChatSession,
-  isChatToolType,
-  projectChatOntoSession,
-  projectChatSummariesOntoSessions,
+  getSessionWithChatProjection,
+  listSessionsWithChatProjection,
 } from "../sessions/chatSessionProjection";
 import {
   removeProjectIconOverride,
@@ -691,7 +689,6 @@ import type { createProjectScaffoldService } from "../projects/projectScaffoldSe
 import type { createAdeCliService } from "../cli/adeCliService";
 import { getErrorMessage, isRecord, nowIso, resolvePathWithinRoot } from "../shared/utils";
 import { quoteWindowsCmdArg } from "../shared/processExecution";
-import { sanitizeResumeTargetId } from "../../utils/terminalSessionSignals";
 import { probeLocalhostPort } from "../probeLocalhostPort";
 import type { ProcessRegistryService } from "../runtime/processRegistryService";
 import { openExternalUrl } from "../shared/externalLinks";
@@ -1373,22 +1370,6 @@ function formatLinearConnectionMessage(
     return "Linear rejected the API key. Paste a Linear personal API key from linear.app/settings/api; it should start with lin_api_.";
   }
   return trimmed || null;
-}
-
-function sessionNeedsResumeTargetHydration(session: {
-  tracked: boolean;
-  status: string;
-  toolType: string | null;
-  resumeMetadata?: { targetId?: string | null } | null;
-}): boolean {
-  if (!session.tracked || session.status === "running") return false;
-  if (sanitizeResumeTargetId(session.resumeMetadata?.targetId ?? null)) return false;
-  return (
-    session.toolType === "claude"
-    || session.toolType === "codex"
-    || session.toolType === "claude-orchestrated"
-    || session.toolType === "codex-orchestrated"
-  );
 }
 
 function inferPrAiProvider(modelId: string): "codex" | "claude" {
@@ -6366,42 +6347,7 @@ export function registerIpc({
     return await withIpcTiming(
       ctx,
       "sessions.list",
-      async () => {
-        let listedSessions = ctx.sessionService.list(arg);
-        const missingResumeTargetIds = listedSessions
-          .filter(sessionNeedsResumeTargetHydration)
-          .slice(0, 10)
-          .map((session) => session.id);
-        if (missingResumeTargetIds.length > 0) {
-          try {
-            await ptyService.ensureResumeTargets(missingResumeTargetIds);
-            listedSessions = ctx.sessionService.list(arg);
-          } catch (err) {
-            ctx.logger.warn("sessions.resume_target_hydration_failed", {
-              sessionIds: missingResumeTargetIds,
-              err: String(err),
-            });
-          }
-        }
-        let sessions = ptyService.enrichSessions(listedSessions);
-        const laneId = typeof arg?.laneId === "string" ? arg.laneId.trim() : "";
-        let allChats: AgentChatSessionSummary[] = [];
-        if (ctx.agentChatService) {
-          try {
-            allChats = await ctx.agentChatService.listSessions(laneId || undefined, {
-              includeIdentity: true,
-              includeAutomation: true,
-            });
-          } catch (error) {
-            allChats = [];
-            ctx.logger.warn("sessions.chat_projection_failed", {
-              laneId: laneId || null,
-              error: error instanceof Error ? error.message : String(error),
-            });
-          }
-        }
-        return projectChatSummariesOntoSessions(sessions, allChats);
-      },
+      () => listSessionsWithChatProjection(ctx, arg),
       {
         laneId: typeof arg?.laneId === "string" ? arg.laneId : null,
         limit: typeof arg?.limit === "number" ? arg.limit : null
@@ -6412,42 +6358,7 @@ export function registerIpc({
   ipcMain.handle(IPC.sessionsGet, async (_event, arg: { sessionId: string }): Promise<TerminalSessionDetail | null> => {
     const ctx = ensureSessionContext();
     const ptyService = requirePtyService();
-    let session = ctx.sessionService.get(arg.sessionId);
-    if (!session) return null;
-    if (sessionNeedsResumeTargetHydration(session)) {
-      const sessionId = session.id;
-      try {
-        await ptyService.ensureResumeTargets([sessionId]);
-        const hydratedSession = ctx.sessionService.get(arg.sessionId);
-        if (hydratedSession) session = hydratedSession;
-      } catch (err) {
-        ctx.logger.warn("sessions.resume_target_hydration_failed", {
-          sessionIds: [sessionId],
-          err: String(err),
-        });
-      }
-    }
-    let enriched = ptyService.enrichSessions([session])[0] ?? {
-      ...session,
-      runtimeState: ptyService.getRuntimeState(session.id, session.status)
-    };
-    if (enriched.status === "running" && isChatToolType(enriched.toolType)) {
-      try {
-        const chat = await ctx.agentChatService?.getSessionSummary(enriched.id);
-        enriched = chat
-          ? projectChatOntoSession(enriched, chat)
-          : fallbackUnprojectedChatSession(enriched);
-      } catch (error) {
-        // Detail reads should still return the persisted session if chat state
-        // hydration fails during runtime restart/recovery.
-        ctx.logger.warn("sessions.chat_projection_failed", {
-          sessionId: enriched.id,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        enriched = fallbackUnprojectedChatSession(enriched);
-      }
-    }
-    return enriched;
+    return getSessionWithChatProjection({ ...ctx, ptyService }, arg.sessionId);
   });
 
   ipcMain.handle(IPC.sessionsDelete, async (_event, arg: DeleteSessionArgs): Promise<void> => {

--- a/apps/desktop/src/main/services/sessions/chatSessionProjection.ts
+++ b/apps/desktop/src/main/services/sessions/chatSessionProjection.ts
@@ -1,7 +1,29 @@
 import type {
   AgentChatSessionSummary,
+  ListSessionsArgs,
   TerminalSessionSummary,
 } from "../../../shared/types";
+import { getErrorMessage } from "../shared/utils";
+
+type ChatProjectionServices = {
+  sessionService: {
+    list(args?: ListSessionsArgs): TerminalSessionSummary[];
+    get(sessionId: string): TerminalSessionSummary | null;
+  };
+  ptyService?: {
+    enrichSessions(sessions: TerminalSessionSummary[]): TerminalSessionSummary[];
+  } | null;
+  agentChatService?: {
+    listSessions(
+      laneId?: string,
+      options?: { includeIdentity?: boolean; includeAutomation?: boolean },
+    ): Promise<AgentChatSessionSummary[]>;
+    getSessionSummary(sessionId: string): Promise<AgentChatSessionSummary | null>;
+  } | null;
+  logger: {
+    warn(event: string, data: Record<string, unknown>): void;
+  };
+};
 
 export function isChatToolType(toolType: string | null | undefined): boolean {
   if (!toolType) return false;
@@ -59,10 +81,94 @@ export function projectChatOntoSession(
     };
   }
   if (chat.status === "active") {
-    return { ...base, runtimeState: "running", chatIdleSinceAt: null };
+    return {
+      ...base,
+      runtimeState: "running",
+      chatIdleSinceAt: null,
+      pendingInputItemId: null,
+    };
   }
   if (chat.status === "idle" || chat.status === "ended") {
-    return { ...base, runtimeState: "idle", chatIdleSinceAt: chat.idleSinceAt ?? null };
+    return {
+      ...base,
+      runtimeState: "idle",
+      chatIdleSinceAt: chat.idleSinceAt ?? null,
+      pendingInputItemId: null,
+    };
   }
   return fallbackUnprojectedChatSession(base);
+}
+
+export function projectChatSummariesOntoSessions(
+  sessions: TerminalSessionSummary[],
+  allChats: AgentChatSessionSummary[],
+): TerminalSessionSummary[] {
+  const identitySessionIds = new Set(
+    allChats
+      .filter((chat) => Boolean(chat.identityKey))
+      .map((chat) => chat.sessionId),
+  );
+  const chatSummaryBySessionId = new Map(
+    allChats
+      .filter((chat) => !chat.identityKey)
+      .map((chat) => [chat.sessionId, chat] as const),
+  );
+
+  return sessions
+    .filter((session) => !identitySessionIds.has(session.id))
+    .map((session) => {
+      if (!isChatToolType(session.toolType)) return session;
+      const chat = chatSummaryBySessionId.get(session.id);
+      return chat
+        ? projectChatOntoSession(session, chat)
+        : fallbackUnprojectedChatSession(session);
+    });
+}
+
+export async function listSessionsWithChatProjection(
+  services: ChatProjectionServices,
+  args: ListSessionsArgs = {},
+): Promise<TerminalSessionSummary[]> {
+  const listedSessions = services.sessionService.list(args);
+  const sessions = services.ptyService
+    ? services.ptyService.enrichSessions(listedSessions)
+    : listedSessions;
+  const laneId = typeof args.laneId === "string" ? args.laneId.trim() : "";
+  let allChats: AgentChatSessionSummary[] = [];
+  if (services.agentChatService) {
+    try {
+      allChats = await services.agentChatService.listSessions(laneId || undefined, {
+        includeIdentity: true,
+        includeAutomation: true,
+      });
+    } catch (error) {
+      services.logger.warn("sessions.chat_projection_failed", {
+        laneId: laneId || null,
+        error: getErrorMessage(error),
+      });
+    }
+  }
+  return projectChatSummariesOntoSessions(sessions, allChats);
+}
+
+export async function getSessionWithChatProjection(
+  services: ChatProjectionServices,
+  sessionId: string,
+): Promise<TerminalSessionSummary | null> {
+  const persisted = services.sessionService.get(sessionId);
+  if (!persisted) return null;
+  const session = services.ptyService?.enrichSessions([persisted])[0] ?? persisted;
+  if (!isChatToolType(session.toolType)) return session;
+  try {
+    const chat = await services.agentChatService?.getSessionSummary(sessionId);
+    return chat
+      ? projectChatOntoSession(session, chat)
+      : fallbackUnprojectedChatSession(session);
+  } catch (error) {
+    services.logger.warn("sessions.chat_projection_failed", {
+      sessionId,
+      error: getErrorMessage(error),
+    });
+    return fallbackUnprojectedChatSession(session);
+  }
 }

--- a/apps/desktop/src/main/services/sessions/chatSessionProjection.ts
+++ b/apps/desktop/src/main/services/sessions/chatSessionProjection.ts
@@ -1,8 +1,10 @@
 import type {
   AgentChatSessionSummary,
   ListSessionsArgs,
+  TerminalSessionDetail,
   TerminalSessionSummary,
 } from "../../../shared/types";
+import { sanitizeResumeTargetId } from "../../utils/terminalSessionSignals";
 import { getErrorMessage } from "../shared/utils";
 
 type ChatProjectionServices = {
@@ -12,6 +14,7 @@ type ChatProjectionServices = {
   };
   ptyService?: {
     enrichSessions(sessions: TerminalSessionSummary[]): TerminalSessionSummary[];
+    ensureResumeTargets?(sessionIds: string[]): Promise<void>;
   } | null;
   agentChatService?: {
     listSessions(
@@ -24,6 +27,17 @@ type ChatProjectionServices = {
     warn(event: string, data: Record<string, unknown>): void;
   };
 };
+
+function sessionNeedsResumeTargetHydration(session: TerminalSessionSummary): boolean {
+  if (!session.tracked || session.status === "running") return false;
+  if (sanitizeResumeTargetId(session.resumeMetadata?.targetId ?? null)) return false;
+  return (
+    session.toolType === "claude"
+    || session.toolType === "codex"
+    || session.toolType === "claude-orchestrated"
+    || session.toolType === "codex-orchestrated"
+  );
+}
 
 export function isChatToolType(toolType: string | null | undefined): boolean {
   if (!toolType) return false;
@@ -129,7 +143,22 @@ export async function listSessionsWithChatProjection(
   services: ChatProjectionServices,
   args: ListSessionsArgs = {},
 ): Promise<TerminalSessionSummary[]> {
-  const listedSessions = services.sessionService.list(args);
+  let listedSessions = services.sessionService.list(args);
+  const missingResumeTargetIds = listedSessions
+    .filter(sessionNeedsResumeTargetHydration)
+    .slice(0, 10)
+    .map((session) => session.id);
+  if (missingResumeTargetIds.length > 0 && services.ptyService?.ensureResumeTargets) {
+    try {
+      await services.ptyService.ensureResumeTargets(missingResumeTargetIds);
+      listedSessions = services.sessionService.list(args);
+    } catch (error) {
+      services.logger.warn("sessions.resume_target_hydration_failed", {
+        sessionIds: missingResumeTargetIds,
+        err: String(error),
+      });
+    }
+  }
   const sessions = services.ptyService
     ? services.ptyService.enrichSessions(listedSessions)
     : listedSessions;
@@ -154,9 +183,20 @@ export async function listSessionsWithChatProjection(
 export async function getSessionWithChatProjection(
   services: ChatProjectionServices,
   sessionId: string,
-): Promise<TerminalSessionSummary | null> {
-  const persisted = services.sessionService.get(sessionId);
+): Promise<TerminalSessionDetail | null> {
+  let persisted = services.sessionService.get(sessionId);
   if (!persisted) return null;
+  if (sessionNeedsResumeTargetHydration(persisted) && services.ptyService?.ensureResumeTargets) {
+    try {
+      await services.ptyService.ensureResumeTargets([sessionId]);
+      persisted = services.sessionService.get(sessionId) ?? persisted;
+    } catch (error) {
+      services.logger.warn("sessions.resume_target_hydration_failed", {
+        sessionIds: [sessionId],
+        err: String(error),
+      });
+    }
+  }
   const session = services.ptyService?.enrichSessions([persisted])[0] ?? persisted;
   if (!isChatToolType(session.toolType)) return session;
   try {

--- a/docs/features/terminals-and-sessions/README.md
+++ b/docs/features/terminals-and-sessions/README.md
@@ -147,7 +147,8 @@ and in tests.
   session persistence tests.
 - `apps/desktop/src/main/services/sessions/chatSessionProjection.ts` —
   canonical bridge from `AgentChatSessionSummary` runtime truth to the
-  `terminal_sessions` row used by Work, detail reads, and lane snapshots.
+  `terminal_sessions` row used by Work, detail reads, ADE runtime actions,
+  and lane snapshots.
   It projects active/idle/waiting state, pending input, wake time, and
   orchestration lineage. If chat hydration fails, a persisted resumable
   `status = "running"` row falls back to quiet idle/waiting instead of
@@ -1003,10 +1004,11 @@ See `apps/desktop/src/shared/types/sessions.ts` for the full shape.
 - **Session list cache** — the renderer shares `listSessionsCached()`
   (`sessionListCache.ts`) across Work, lanes, graph, and top-bar
   attention. Invalidate it when a new session is created or lifecycle metadata
-  changes outside the normal paths. Main-process list/get handlers and the
-  lane-list snapshot service all use `chatSessionProjection.ts`, include
-  automation chats when building the projection index, and fall back to quiet
-  chat state if runtime hydration fails.
+  changes outside the normal paths. Main-process IPC handlers, runtime action
+  `session.list` / `session.get`, and the lane-list snapshot service all use
+  `chatSessionProjection.ts`, include automation chats when building the
+  projection index, and fall back to quiet chat state if runtime hydration
+  fails.
 - **Two-tier attention** — the Your move bucket contains loud `needs_you` rows
   and quiet resting chats/idle CLIs. Only canonical `needs_you` increments the
   Work-tab highlight, notification count, and macOS Dock badge. A ready chat is
@@ -1118,9 +1120,9 @@ Processes (managed):
   `settleTerminalSession`, and keep raw native CLI prompts non-dismissible.
 - **Persisted chat `running` is not UI running.** Chat rows remain resumable
   across provider restarts, so the database status alone cannot drive the
-  green/running projection. Route list, detail, lane snapshot, and automation
-  rows through `chatSessionProjection.ts`; hydration failure must degrade to
-  quiet idle/waiting.
+  green/running projection. Route IPC and runtime-action list/detail reads,
+  lane snapshots, and automation rows through `chatSessionProjection.ts`;
+  hydration failure must degrade to quiet idle/waiting.
 - Chat sessions backed by the Claude/Codex SDK still insert a
   `terminal_sessions` row but they are not attached to a PTY. Guard
   UI code with `isChatToolType(toolType)` before calling PTY-only APIs.


### PR DESCRIPTION
## Summary
- project live SDK chat question state into runtime-backed session list and detail reads
- share one provider-neutral projection path across IPC and ADE runtime actions
- clear stale pending-input markers when a chat resumes and degrade hydration failures to quiet state

## Verification
- desktop registry contract: 75 tests passed
- desktop CI shard 1/8: 1,160 tests passed
- desktop typecheck passed
- full ADE CLI/TUI suite: 2,246 tests passed
- docs validation: 201 files passed
- quality dual-track review: no blockers or high-severity findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Chat sessions now accurately display running, idle, and waiting-for-input states.
  - Cleared stale pending-input indicators when sessions resume activity.
  - Improved session list and detail views with consistent chat status information.
  - Added graceful fallback behavior when chat status information cannot be loaded.
  - Identity-only chat sessions are excluded from terminal session listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves chat session state projection into a shared path for IPC and ADE runtime reads. The main changes are:

- Shared list and detail helpers for projecting chat state onto terminal session rows.
- Runtime `session.list` and `session.get` now use the same projection path as IPC.
- Stale pending-input markers are cleared when chats become active or idle again.
- Identity chat rows are filtered from Work session lists.
- Resume-target hydration and quiet fallback behavior are covered by tests and docs.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The updated code moves existing IPC behavior into a shared helper and extends it to runtime actions, with tests for the main state transitions and failure paths. No blocking correctness or security issues were found in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the registry attention Vitest test suite in the project workspace, capturing the full foreground commands, working directory, and verbose output.
- I verified the registry test run completed with 76 passing tests and detailed timing and exit codes in the log.
- I ran the follow-up session attention Vitest test set in the project workspace, capturing the verbose output and environment details.
- I verified the session test run completed with 92 passing tests and detailed timing and exit codes in the log.

<a href="https://app.greptile.com/trex/runs/15718781/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/adeActions/registry.test.ts | Adds tests for runtime session list/detail chat projection, stale pending-input cleanup, quiet hydration fallback, and resume-target hydration. |
| apps/desktop/src/main/services/adeActions/registry.ts | Routes ADE runtime session list/get actions through the shared chat projection helpers. |
| apps/desktop/src/main/services/ipc/registerIpc.ts | Replaces duplicated IPC list/get projection and hydration logic with the shared session projection helpers. |
| apps/desktop/src/main/services/sessions/chatSessionProjection.ts | Centralizes resume-target hydration, chat-state projection, identity-chat filtering, and quiet fallback behavior for session list/detail reads. |
| docs/features/terminals-and-sessions/README.md | Updates session documentation to include runtime action reads alongside IPC and lane snapshots in the canonical chat projection path. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Client as IPC / ADE runtime action
  participant Projection as chatSessionProjection.ts
  participant Sessions as sessionService
  participant PTY as ptyService
  participant Chat as agentChatService

  Client->>Projection: listSessionsWithChatProjection(args) / getSessionWithChatProjection(id)
  Projection->>Sessions: list(args) or get(id)
  alt missing resume target
    Projection->>PTY: ensureResumeTargets(sessionIds)
    Projection->>Sessions: reload hydrated rows
  end
  Projection->>PTY: enrichSessions(rows)
  Projection->>Chat: listSessions(laneId, includeIdentity/includeAutomation) or getSessionSummary(id)
  Projection->>Projection: filter identity rows and project active/idle/waiting state
  Projection-->>Client: terminal session rows with runtime-backed chat state
```

<sub>Reviews (2): Last reviewed commit: ["fix: share session resume hydration pipe..."](https://github.com/arul28/ade/commit/fb1ada9aa60f5a1e1ff0d3a10630bb0f8648a5e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46945682)</sub>

<!-- /greptile_comment -->