### PR TITLE
Fix built-in browser popup lifecycle

### DIFF
--- a/apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.test.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.test.ts
@@ -13,6 +13,7 @@ const fakes = vi.hoisted(() => {
   };
   type WindowOpenDetails = {
     url: string;
+    disposition?: "background-tab" | "foreground-tab" | "new-window";
     referrer?: { url: string; policy: string };
     postBody?: {
       boundary?: string;
@@ -142,12 +143,16 @@ const fakes = vi.hoisted(() => {
   }
 
   class FakeWebContentsView {
-    webContents = new FakeWebContents();
+    webContents: FakeWebContents;
     webPreferences: unknown;
-    constructor(options?: { webPreferences?: unknown }) {
+    backgroundColor: string | null = null;
+    constructor(options?: { webPreferences?: unknown; webContents?: FakeWebContents }) {
+      this.webContents = options?.webContents ?? new FakeWebContents();
       this.webPreferences = options?.webPreferences;
     }
-    setBackgroundColor = (_color: string): void => undefined;
+    setBackgroundColor = (color: string): void => {
+      this.backgroundColor = color;
+    };
     setBounds = (_rect: unknown): void => undefined;
     setVisible = (_visible: boolean): void => undefined;
   }
@@ -260,11 +265,13 @@ const fakes = vi.hoisted(() => {
     }
   }
   class TrackedFakeWebContentsView extends FakeWebContentsView {
-    constructor(options?: { webPreferences?: unknown }) {
+    constructor(options?: { webPreferences?: unknown; webContents?: FakeWebContents }) {
       super(options);
-      this.webContents = new TrackedFakeWebContents();
-      const partition = (options?.webPreferences as { partition?: string } | undefined)?.partition ?? "persist:ade-browser";
-      this.webContents.session = sessionForPartition(partition);
+      if (!options?.webContents) {
+        this.webContents = new TrackedFakeWebContents();
+        const partition = (options?.webPreferences as { partition?: string } | undefined)?.partition ?? "persist:ade-browser";
+        this.webContents.session = sessionForPartition(partition);
+      }
       webContentsViewInstances.push(this);
     }
   }
@@ -278,6 +285,7 @@ const fakes = vi.hoisted(() => {
 
   return {
     WebContentsView: TrackedFakeWebContentsView,
+    WebContents: TrackedFakeWebContents,
     debuggerInstances,
     webContentsInstances,
     webContentsViewInstances,
@@ -1251,6 +1259,7 @@ describe("createBuiltInBrowserService — bounds and status dedupe", () => {
     expect(fakes.webContentsViewInstances.at(-1)?.webPreferences).toMatchObject({
       partition: status.partition,
     });
+    expect(fakes.webContentsViewInstances.at(-1)?.backgroundColor).toBe("#ffffff");
   });
 
   it("targets browser events to the owning ADE window", async () => {
@@ -1456,6 +1465,8 @@ describe("createBuiltInBrowserService — bounds and status dedupe", () => {
     const firstTabId = service.getStatus().activeTabId;
     const firstWc = fakes.webContentsInstances[0];
     const postData = [{ bytes: Buffer.from("token=abc"), type: "rawData" }];
+    await service.startInspect();
+    expect(service.getStatus().isInspecting).toBe(true);
 
     const response = firstWc?.openWindow("https://accounts.google.com/gsi/select", {
       referrer: { url: "https://example.test/sign-in", policy: "strict-origin-when-cross-origin" },
@@ -1467,7 +1478,10 @@ describe("createBuiltInBrowserService — bounds and status dedupe", () => {
 
     expect(response?.action).toBe("allow");
     expect(response?.createWindow).toEqual(expect.any(Function));
+    const electronPopupWc = new fakes.WebContents();
+    electronPopupWc.session = fakes.sessionForPartition(service.getStatus().partition);
     const popupWc = response?.createWindow?.({
+      webContents: electronPopupWc,
       webPreferences: {
         additionalArguments: ["--popup"],
         javascript: false,
@@ -1476,7 +1490,11 @@ describe("createBuiltInBrowserService — bounds and status dedupe", () => {
         webviewTag: true,
       },
     });
-    expect(popupWc).toBe(fakes.webContentsInstances.at(-1));
+    expect(popupWc).toBe(electronPopupWc);
+    expect(fakes.webContentsViewInstances.at(-1)?.webContents).toBe(electronPopupWc);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(service.getStatus().isInspecting).toBe(false);
+    expect(firstWc?.debugger.isAttached()).toBe(false);
     await popupWc?.loadURL("https://accounts.google.com/gsi/select");
 
     expect(service.getStatus().tabs).toHaveLength(2);
@@ -1486,24 +1504,80 @@ describe("createBuiltInBrowserService — bounds and status dedupe", () => {
       ownerLaneId: null,
       ownerChatSessionId: null,
     });
-    const popupWebPreferences = fakes.webContentsViewInstances.at(-1)?.webPreferences as Record<string, unknown>;
-    expect(popupWebPreferences).toMatchObject({
-      partition: service.getStatus().partition,
-      nodeIntegration: false,
-      contextIsolation: true,
-      sandbox: true,
-      webSecurity: true,
-      backgroundThrottling: false,
-    });
-    expect(popupWebPreferences.additionalArguments).toBeUndefined();
-    expect(popupWebPreferences.javascript).toBeUndefined();
-    expect(popupWebPreferences.webviewTag).toBeUndefined();
+    expect(fakes.webContentsViewInstances.at(-1)?.webPreferences).toBeUndefined();
+    expect(fakes.webContentsViewInstances.at(-1)?.backgroundColor).toBe("#ffffff");
 
     const openEvent = collector.events.findLast((event) => event.type === "open-request");
     expect(openEvent).toMatchObject({
       type: "open-request",
       url: "https://accounts.google.com/gsi/select",
       tabId: service.getStatus().activeTabId,
+    });
+  });
+
+  it("loads deferred background popups without stealing focus", async () => {
+    fakes.setSendCommand(async (method) => {
+      switch (method) {
+        case "DOM.getNodeForLocation":
+          return { backendNodeId: 42 };
+        case "DOM.resolveNode":
+          return { object: { objectId: "background-popup-selection" } };
+        case "Runtime.callFunctionOn":
+          return {
+            result: {
+              value: {
+                tagName: "button",
+                selector: "button#keep-selected",
+                testId: null,
+                frame: { x: 0, y: 0, width: 10, height: 10 },
+                pixelRatio: 1,
+                url: "https://example.test/",
+                title: "test",
+                metadata: { viewport: { width: 100, height: 100 } },
+              },
+            },
+          };
+        default:
+          return {};
+      }
+    });
+    const service = createBuiltInBrowserService({ onEvent: collector.onEvent });
+    await service.createTab({
+      url: "https://example.test",
+      activate: true,
+    });
+    const firstTabId = service.getStatus().activeTabId;
+    const firstWc = fakes.webContentsInstances[0];
+    await service.selectPoint({ x: 5, y: 5, includeScreenshot: false });
+    expect(service.getStatus().hasSelection).toBe(true);
+    collector.events.length = 0;
+
+    const response = firstWc?.openWindow("https://example.test/background", {
+      disposition: "background-tab",
+    });
+    const popupWc = response?.createWindow?.({});
+
+    expect(response?.action).toBe("allow");
+    expect(popupWc).toBe(fakes.webContentsInstances.at(-1));
+    expect(popupWc?.loadURLCalls).toEqual([{
+      url: "https://example.test/background",
+      options: undefined,
+    }]);
+    expect(service.getStatus()).toMatchObject({
+      activeTabId: firstTabId,
+      url: "https://example.test/",
+      hasSelection: true,
+    });
+    expect(service.getStatus().tabs).toHaveLength(2);
+    expect(service.getStatus().tabs.at(-1)?.url).toBe("https://example.test/background");
+    expect(collector.events.some((event) => event.type === "open-request")).toBe(false);
+    expect(collector.events.some((event) => event.type === "selection-cleared")).toBe(false);
+    expect(fakes.webContentsViewInstances.at(-1)?.webPreferences).toMatchObject({
+      partition: service.getStatus().partition,
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      webSecurity: true,
     });
   });
 
@@ -3202,6 +3276,51 @@ describe("createBuiltInBrowserService — switchTab and navigate inspect/selecti
         }),
       }),
     ]));
+  });
+
+  it("keeps a new popup inspect session intact while the opener finishes inspect cleanup", async () => {
+    fakes.setSendCommand(async () => ({}));
+    const service = createBuiltInBrowserService({ onEvent: collector.onEvent });
+    await service.navigate({ url: "https://example.test", newTab: true });
+    await service.startInspect();
+
+    const openerWc = fakes.webContentsInstances[0];
+    const cleanupDeferred = createDeferred<unknown>();
+    let delayedCleanup = false;
+    fakes.setSendCommand(async (method, params) => {
+      const expression = typeof params?.expression === "string" ? params.expression : "";
+      if (
+        !delayedCleanup
+        && method === "Runtime.evaluate"
+        && expression.includes("const current = window.__adeBuiltInBrowserInspector")
+      ) {
+        delayedCleanup = true;
+        return cleanupDeferred.promise;
+      }
+      return {};
+    });
+
+    const response = openerWc?.openWindow("https://accounts.google.com/signin", {
+      disposition: "foreground-tab",
+    });
+    const popupWc = new fakes.WebContents();
+    popupWc.session = fakes.sessionForPartition(service.getStatus().partition);
+    response?.createWindow?.({ webContents: popupWc });
+
+    await service.startInspect();
+    expect(service.getStatus().isInspecting).toBe(true);
+    expect(popupWc.debugger.isAttached()).toBe(true);
+
+    cleanupDeferred.resolve({});
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(service.getStatus().isInspecting).toBe(true);
+    expect(openerWc?.debugger.isAttached()).toBe(false);
+    expect(popupWc.debugger.isAttached()).toBe(true);
+
+    await service.stopInspect();
+    expect(service.getStatus().isInspecting).toBe(false);
+    expect(popupWc.debugger.isAttached()).toBe(false);
   });
 
   it("selects inspect clicks from the ADE overlay binding", async () => {

--- a/apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.ts
+++ b/apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.ts
@@ -1482,10 +1482,20 @@ function createBuiltInBrowserWindowService(args: {
       }
       return {
         action: "allow",
-        createWindow: () => {
-          const tab = createPopupTabStateFromView(popupUrl, opener, new WebContentsView({
-            webPreferences: browserWebPreferences(),
-          }));
+        createWindow: (options) => {
+          const activate = details.disposition !== "background-tab";
+          const popupWebContents = (
+            options as Electron.BrowserWindowConstructorOptions & { webContents?: WebContents }
+          ).webContents;
+          const nextView = popupWebContents
+            ? new WebContentsView({ webContents: popupWebContents })
+            : new WebContentsView({ webPreferences: browserWebPreferences() });
+          const tab = createPopupTabStateFromView(popupUrl, opener, nextView, { activate });
+          if (!popupWebContents) {
+            void tab.webContents.loadURL(popupUrl).catch((error) => {
+              emitError(new Error(`Could not load deferred browser popup: ${errorMessage(error)}`));
+            });
+          }
           return tab.webContents;
         },
       };
@@ -1544,13 +1554,19 @@ function createBuiltInBrowserWindowService(args: {
       emitStatus();
     });
     wc.on("did-navigate", () => {
-      notifyTabActivity(tabForWebContents(wc));
-      clearSelectionInternal();
+      const tab = tabForWebContents(wc);
+      notifyTabActivity(tab);
+      if (tab?.id === lastSelectedTabId) {
+        clearSelectionInternal();
+      }
       emitStatus();
     });
     wc.on("did-navigate-in-page", () => {
-      notifyTabActivity(tabForWebContents(wc));
-      clearSelectionInternal();
+      const tab = tabForWebContents(wc);
+      notifyTabActivity(tab);
+      if (tab?.id === lastSelectedTabId) {
+        clearSelectionInternal();
+      }
       emitStatus();
     });
     wc.on("page-title-updated", () => {
@@ -1610,7 +1626,10 @@ function createBuiltInBrowserWindowService(args: {
   });
 
   const createTabStateForView = (nextView: WebContentsView): BrowserTabState => {
-    nextView.setBackgroundColor("#111827");
+    // Match a normal browser canvas. Many sites leave their root background
+    // transparent, so a dark ADE-specific backing color makes light pages
+    // unreadable even though the site's own text remains dark.
+    nextView.setBackgroundColor("#ffffff");
     nextView.setBounds(toElectronRect(bounds));
     nextView.setVisible(false);
 
@@ -1659,15 +1678,29 @@ function createBuiltInBrowserWindowService(args: {
     popupUrl: string,
     opener: BrowserTabState | null,
     nextView: WebContentsView,
+    options: { activate: boolean },
   ): BrowserTabState => {
     configureBrowserSession();
     const tab = createTabStateForView(nextView);
     copyTabOwner(opener, tab);
     tabs = [...tabs, tab];
-    activeTabId = tab.id;
-    clearSelectionInternal();
+    const shouldActivate = options.activate || !activeTab();
+    if (shouldActivate) {
+      if (inspecting) {
+        inspecting = false;
+        void teardownInspectWebContents(inspectListenerWebContents).catch((error) => {
+          logger()?.debug("built_in_browser.popup_stop_inspect_failed", {
+            err: error instanceof Error ? error.message : String(error),
+          });
+        });
+      }
+      activeTabId = tab.id;
+      clearSelectionInternal();
+    }
     attachViewsToCurrentWindow();
-    requestOpenPanel({ url: popupUrl, tabId: tab.id });
+    if (shouldActivate) {
+      requestOpenPanel({ url: popupUrl, tabId: tab.id });
+    }
     emitStatus();
     return tab;
   };
@@ -2390,6 +2423,23 @@ function createBuiltInBrowserWindowService(args: {
     const tab = wc ? tabForWebContents(wc) : null;
     if (tab) await prepareAgentReadTabAsync(tab, input, "The agent requested access to stop DOM inspection.");
     inspecting = false;
+    await teardownInspectWebContents(wc);
+    emitStatus();
+    return scopeStatusForInput(getStatus(), input);
+  }
+
+  const teardownInspectWebContents = async (wc: WebContents | null): Promise<void> => {
+    const ownsInspectDebugger = Boolean(
+      wc
+      && inspectListenerWebContents === wc
+      && debuggerAttachedForInspect,
+    );
+    if (wc && inspectListenerWebContents === wc) {
+      detachDebuggerListeners(wc);
+      if (ownsInspectDebugger) {
+        debuggerAttachedForInspect = false;
+      }
+    }
     if (wc?.debugger.isAttached()) {
       try {
         await sendDebuggerCommand(wc, "Runtime.evaluate", {
@@ -2404,11 +2454,15 @@ function createBuiltInBrowserWindowService(args: {
           err: error instanceof Error ? error.message : String(error),
         });
       }
-      detachDebuggerIfOwned(wc);
+      if (ownsInspectDebugger) {
+        try {
+          if (wc.debugger.isAttached()) wc.debugger.detach();
+        } catch {
+          // ignore debugger detach races
+        }
+      }
     }
-    emitStatus();
-    return scopeStatusForInput(getStatus(), input);
-  }
+  };
 
   async function captureScreenshot(input: BuiltInBrowserTabTargetArgs = {}): Promise<BuiltInBrowserScreenshot> {
     const tab = targetTabFromInput(input, "No active browser tab. Open a tab before capturing a screenshot.");

--- a/docs/features/chat/README.md
+++ b/docs/features/chat/README.md
@@ -624,11 +624,15 @@ Controls and summaries project this runtime state rather than owning it:
   the sidebar instead of the system browser. The broker uses
   Electron's stock Chrome User-Agent — header rewriting is gone. Pages
   that call `window.open()` are honoured via `setWindowOpenHandler`
-  returning `action: "allow"` with a `createWindow` factory that
-  produces a new internal tab and hands its `webContents` back to
-  Chromium; this preserves `window.opener` for OAuth `postMessage`
-  callbacks instead of denying the popup and re-navigating in the
-  background. Download requests are assigned sanitized, unique filenames
+  returning `action: "allow"` with a `createWindow` factory that adopts
+  Electron's pre-created `webContents` into a new internal tab; this
+  preserves Chromium's popup lifecycle and `window.opener` for OAuth
+  `postMessage` callbacks. Foreground popups end Inspect on the opener
+  before activating, while deferred `background-tab` popups use the same
+  secure browser preferences and load without stealing focus or clearing
+  the opener's selection. Every browser view uses a white backing canvas
+  so light sites with transparent roots remain readable. Download requests
+  are assigned sanitized, unique filenames
   in the user's Downloads folder by the Electron session so download
   buttons do not fall through to unstable default handling. The renderer
   panel hides the native view whenever ADE overlays overlap the browser


### PR DESCRIPTION
## Summary
- adopt Electron pre-created popup web contents to prevent OAuth/new-tab crashes
- preserve background-tab focus and selection while safely ending Inspect for foreground popups
- use a white browser canvas so transparent light pages remain readable
- document the popup lifecycle contract

## Validation
- builtInBrowserService.test.ts: 84 passed
- adeActions registry tests: 76 passed
- desktop Vitest shard 1/8: 1,160 passed
- desktop typecheck passed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the built-in browser popup and inspect lifecycle. The main changes are:

- Adopt Electron-created popup `webContents` for foreground popup tabs.
- Load deferred `background-tab` popups without changing the active tab or clearing selection.
- Use a white backing canvas for browser views.
- Keep inspect teardown scoped to the web contents that started the inspect session.
- Update tests and feature docs for the revised browser behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changed popup and inspect lifecycle paths have focused test coverage, and no concrete correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused test proof for the popup OAuth service was run, and the popup/OAuth service tests executed and passed.
- A typecheck attempt for the popup code was started with tsc -p tsconfig.json --noEmit using the requested heap option and was subsequently killed.

<a href="https://app.greptile.com/trex/runs/15748048/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.ts | Updates popup tab adoption, background-tab focus behavior, navigation selection clearing, white browser backing color, and inspect teardown ownership. |
| apps/desktop/src/main/services/builtInBrowser/builtInBrowserService.test.ts | Expands Electron fakes and coverage for adopted popup webContents, background popups, white backgrounds, and inspect teardown races. |
| docs/features/chat/README.md | Documents the revised built-in browser popup lifecycle, inspect behavior, background-tab handling, and white backing canvas. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant Page as Opener page
participant Electron as Electron windowOpenHandler
participant Service as Built-in browser service
participant Tab as Internal browser tab
participant Inspect as Inspect teardown

Page->>Electron: window.open(popupUrl, disposition)
Electron->>Service: createWindow(options)
Service->>Service: validate URL and agent access
alt Electron supplies popup webContents
  Service->>Tab: adopt webContents in WebContentsView
else deferred/background popup
  Service->>Tab: create WebContentsView with browser preferences
  Service->>Tab: loadURL(popupUrl)
end
alt foreground popup
  Service->>Inspect: stop opener inspect if active
  Service->>Tab: activate tab and open panel
else background-tab popup
  Service->>Tab: keep opener active and preserve selection
end
Service-->>Electron: return tab.webContents
```

<sub>Reviews (1): Last reviewed commit: ["Fix built-in browser popup lifecycle"](https://github.com/arul28/ade/commit/a1e5b54a421c5781bdcf550011e65f0851bc0986) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47008662)</sub>

<!-- /greptile_comment -->