### PR TITLE
projectless-chat-reliability -> Primary

### DIFF
--- a/apps/ade-cli/src/cli.ts
+++ b/apps/ade-cli/src/cli.ts
@@ -15101,8 +15101,11 @@ async function runServe(
     { resolveMachineAdeLayout },
     { ProjectRegistry },
     { ProjectScopeRegistry },
-    { PersonalChatScope },
-    { createMultiProjectRpcRequestHandler, readMachineRuntimeActivitySummary },
+    {
+      createMultiProjectRpcRequestHandler,
+      createPersonalChatScope,
+      readMachineRuntimeActivitySummary,
+    },
     { createSharedSyncListener },
     { resolveMobileProjectIconDataUrl },
     { createBrainProjectActionsSyncHandler },
@@ -15113,7 +15116,6 @@ async function runServe(
     import("./services/projects/machineLayout"),
     import("./services/projects/projectRegistry"),
     import("./services/projects/projectScope"),
-    import("./services/personalChats/personalChatScope"),
     import("./multiProjectRpcServer"),
     import("./services/sync/sharedSyncListener"),
     import("../../desktop/src/main/services/projects/projectIconThumbnail"),
@@ -15168,7 +15170,7 @@ async function runServe(
   const port = parseOptionalPort(readValue(args, ["--port"]), "--port");
   const syncEnabled = !readFlag(args, ["--no-sync"]);
   const projectRegistry = new ProjectRegistry(layout);
-  const personalChatScope = new PersonalChatScope();
+  const personalChatScope = createPersonalChatScope();
   let preferredSyncProjectId: string | null = null;
   const preferredSyncProjectRoot = process.env.ADE_PROJECT_ROOT?.trim();
   if (preferredSyncProjectRoot) {

--- a/apps/ade-cli/src/headlessLinearServices.ts
+++ b/apps/ade-cli/src/headlessLinearServices.ts
@@ -423,12 +423,12 @@ async function readGitOriginAsync(projectRoot: string): Promise<string | null> {
   return remote || null;
 }
 
-async function runGitHeadlessAsync(
+function runGitHeadlessAsync(
   projectRoot: string,
   args: string[],
   timeoutMs: number,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  return await runCommandAsync("git", args, {
+  return runCommandAsync("git", args, {
     cwd: projectRoot,
     timeoutMs,
   });
@@ -1123,7 +1123,7 @@ export function createHeadlessGitHubService(
       };
     },
     async detectRepo() {
-      return await detectGitHubRepoAsync(projectRoot);
+      return detectGitHubRepoAsync(projectRoot);
     },
     async getAppInstallationStatus(args = {}) {
       const owner = args.owner?.trim();

--- a/apps/ade-cli/src/multiProjectRpcServer.test.ts
+++ b/apps/ade-cli/src/multiProjectRpcServer.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createEventBuffer } from "./eventBuffer";
 import {
   createMultiProjectRpcRequestHandler,
@@ -14,6 +14,20 @@ import { ProjectRegistry } from "./services/projects/projectRegistry";
 import { ProjectScopeRegistry } from "./services/projects/projectScope";
 import type { SyncRoleSnapshot } from "../../desktop/src/shared/types";
 import { RUNTIME_COMPAT_LEVEL } from "../../desktop/src/shared/adeRuntimeProtocol";
+
+const originalAdeHome = process.env.ADE_HOME;
+let isolatedAdeHome = "";
+
+beforeEach(() => {
+  isolatedAdeHome = fs.mkdtempSync(path.join(os.tmpdir(), "ade-multi-project-home-"));
+  process.env.ADE_HOME = isolatedAdeHome;
+});
+
+afterEach(() => {
+  if (originalAdeHome === undefined) delete process.env.ADE_HOME;
+  else process.env.ADE_HOME = originalAdeHome;
+  fs.rmSync(isolatedAdeHome, { recursive: true, force: true });
+});
 
 function createRegistry() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "ade-multi-project-rpc-"));

--- a/apps/ade-cli/src/multiProjectRpcServer.test.ts
+++ b/apps/ade-cli/src/multiProjectRpcServer.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createEventBuffer } from "./eventBuffer";
 import {
   createMultiProjectRpcRequestHandler,
+  createPersonalChatScope,
   decorateProjectListWithIcons,
   readMachineRuntimeActivitySummary,
 } from "./multiProjectRpcServer";
@@ -14,6 +15,7 @@ import { ProjectRegistry } from "./services/projects/projectRegistry";
 import { ProjectScopeRegistry } from "./services/projects/projectScope";
 import type { SyncRoleSnapshot } from "../../desktop/src/shared/types";
 import { RUNTIME_COMPAT_LEVEL } from "../../desktop/src/shared/adeRuntimeProtocol";
+import { PersonalChatScope } from "./services/personalChats/personalChatScope";
 
 const originalAdeHome = process.env.ADE_HOME;
 let isolatedAdeHome = "";
@@ -140,6 +142,30 @@ function makeRuntime(label: string) {
 }
 
 describe("multi-project RPC server", () => {
+  it("prewarms the production shared personal-chat scope only at creation", () => {
+    const warmExisting = vi.spyOn(PersonalChatScope.prototype, "warmExisting")
+      .mockResolvedValue();
+    try {
+      const personalChatScope = createPersonalChatScope();
+      const firstHandler = createMultiProjectRpcRequestHandler({
+        serverVersion: "test",
+        personalChatScope,
+      });
+      const secondHandler = createMultiProjectRpcRequestHandler({
+        serverVersion: "test",
+        personalChatScope,
+      });
+
+      expect(warmExisting).toHaveBeenCalledTimes(1);
+
+      firstHandler.dispose();
+      secondHandler.dispose();
+      expect(warmExisting).toHaveBeenCalledTimes(1);
+    } finally {
+      warmExisting.mockRestore();
+    }
+  });
+
   it("summarizes booted project and personal-chat work independently of client sockets", async () => {
     const summary = await readMachineRuntimeActivitySummary({
       projectRegistry: {

--- a/apps/ade-cli/src/multiProjectRpcServer.ts
+++ b/apps/ade-cli/src/multiProjectRpcServer.ts
@@ -694,6 +694,12 @@ export function createMultiProjectRpcRequestHandler(
   };
   const ownsPersonalChatScope = options.personalChatScope == null;
   const personalChatScope = options.personalChatScope ?? new PersonalChatScope();
+  if (ownsPersonalChatScope && personalChatScope instanceof PersonalChatScope) {
+    void personalChatScope.warmExisting().catch(() => {
+      // The first explicit personal-chat call retries runtime creation and
+      // returns the actionable error to the caller.
+    });
+  }
   const handlers = new Map<ProjectId, Promise<HandlerEntry>>();
   const eventSubscriptions = new Map<string, RuntimeEventSubscription>();
   const disposeProjectRuntimeCaches = (projectId: ProjectId): void => {

--- a/apps/ade-cli/src/multiProjectRpcServer.ts
+++ b/apps/ade-cli/src/multiProjectRpcServer.ts
@@ -693,13 +693,7 @@ export function createMultiProjectRpcRequestHandler(
     return typeof value.userId === "string" ? value.userId.trim() || null : null;
   };
   const ownsPersonalChatScope = options.personalChatScope == null;
-  const personalChatScope = options.personalChatScope ?? new PersonalChatScope();
-  if (ownsPersonalChatScope && personalChatScope instanceof PersonalChatScope) {
-    void personalChatScope.warmExisting().catch(() => {
-      // The first explicit personal-chat call retries runtime creation and
-      // returns the actionable error to the caller.
-    });
-  }
+  const personalChatScope = options.personalChatScope ?? createPersonalChatScope();
   const handlers = new Map<ProjectId, Promise<HandlerEntry>>();
   const eventSubscriptions = new Map<string, RuntimeEventSubscription>();
   const disposeProjectRuntimeCaches = (projectId: ProjectId): void => {
@@ -1582,4 +1576,13 @@ export function createMultiProjectRpcRequestHandler(
   };
 
   return handler;
+}
+
+export function createPersonalChatScope(): PersonalChatScope {
+  const scope = new PersonalChatScope();
+  void scope.warmExisting().catch(() => {
+    // The first explicit personal-chat call retries runtime creation and
+    // returns the actionable error to the caller.
+  });
+  return scope;
 }

--- a/apps/ade-cli/src/services/credentials/credentialStore.ts
+++ b/apps/ade-cli/src/services/credentials/credentialStore.ts
@@ -550,7 +550,7 @@ function readOrCreateMacKeychainMaterial(): Buffer | null {
 
 async function readMacKeychainMaterialAsync(): Promise<Buffer | null> {
   if (process.platform !== "darwin") return null;
-  return await new Promise((resolve) => {
+  return new Promise((resolve) => {
     execFile(
       "security",
       [
@@ -815,12 +815,12 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
     if (!key.equals(machineKey)) {
       try {
         const values = deserializeStore(raw, key, { emptyOnDecryptFailure: false });
-        this.lastReadState = credentialsExist ? "available" : "missing";
+        this.lastReadState = "available";
         return values;
       } catch {
         try {
           const values = deserializeStore(raw, machineKey, { emptyOnDecryptFailure: false });
-          this.lastReadState = credentialsExist ? "available" : "missing";
+          this.lastReadState = "available";
           return values;
         } catch (error) {
           this.lastReadState = "unreadable";
@@ -830,7 +830,7 @@ export class EncryptedFileCredentialStore implements SyncCredentialStore {
     }
     try {
       const values = deserializeStore(raw, machineKey, { emptyOnDecryptFailure: false });
-      this.lastReadState = credentialsExist ? "available" : "missing";
+      this.lastReadState = "available";
       return values;
     } catch {
       this.lastReadState = "unreadable";

--- a/apps/ade-cli/src/services/personalChats/personalChatScope.test.ts
+++ b/apps/ade-cli/src/services/personalChats/personalChatScope.test.ts
@@ -82,6 +82,7 @@ describe("PersonalChatScope", () => {
         paused: boolean;
       }) => ({ sessionId, paused, nextWakeAt: null })),
       updateSession: vi.fn(async () => summary),
+      ensureSessionSurface: vi.fn(),
       archiveSession: vi.fn(async () => undefined),
       unarchiveSession: vi.fn(async () => undefined),
       deleteSession: vi.fn(async () => undefined),
@@ -124,6 +125,23 @@ describe("PersonalChatScope", () => {
     await scope.dispose();
   });
 
+  it("repairs legacy surface metadata for transcript and activity subscriptions", async () => {
+    const { summary, service, runtime, createRuntime } = fixture("work");
+    service.getSessionSummary.mockResolvedValue({
+      ...summary,
+      status: "active",
+    } as never);
+    const durablePath = path.join(runtime.projectRoot, ".ade", "transcripts", "chat", "chat-1.jsonl");
+    fs.mkdirSync(path.dirname(durablePath), { recursive: true });
+    fs.writeFileSync(durablePath, "history\n");
+    const scope = new PersonalChatScope({ createRuntime });
+
+    await expect(scope.transcriptPath("chat-1")).resolves.toBe(durablePath);
+    await expect(scope.isTurnActive("chat-1")).resolves.toBe(true);
+    expect(service.ensureSessionSurface).toHaveBeenCalledWith("chat-1", "personal");
+    await scope.dispose();
+  });
+
   it("creates a hidden personal session and dispatches an optional kickoff", async () => {
     const { service, createRuntime } = fixture();
     const scope = new PersonalChatScope({ createRuntime });
@@ -159,7 +177,7 @@ describe("PersonalChatScope", () => {
     expect(runtimeArgs.publishPushEvents).toBe(false);
   });
 
-  it("filters the hidden scope list to personal sessions", async () => {
+  it("repairs legacy surface metadata while listing the hidden scope", async () => {
     const personal = fixture("personal");
     const scope = new PersonalChatScope({ createRuntime: personal.createRuntime });
     await expect(scope.call("list", { includeArchived: false })).resolves.toMatchObject({
@@ -169,20 +187,47 @@ describe("PersonalChatScope", () => {
 
     const work = fixture("work");
     const workScope = new PersonalChatScope({ createRuntime: work.createRuntime });
-    await expect(workScope.call("list", {})).resolves.toMatchObject({ result: [] });
+    await expect(workScope.call("list", {})).resolves.toMatchObject({
+      result: [{ sessionId: "chat-1", surface: "personal" }],
+    });
+    expect(work.service.ensureSessionSurface).toHaveBeenCalledWith("chat-1", "personal");
     expect(personal.service.listSessions).toHaveBeenCalledWith(
       undefined,
       expect.objectContaining({ includeArchived: false }),
     );
   });
 
-  it("rejects session-scoped calls when the session is not personal", async () => {
+  it("repairs legacy surface metadata before a session-scoped call", async () => {
     const { createRuntime, service } = fixture("work");
     const scope = new PersonalChatScope({ createRuntime });
-    await expect(scope.call("send", { sessionId: "chat-1", text: "nope" }))
-      .rejects.toThrow("Personal chat session 'chat-1' was not found");
+    await expect(scope.call("send", { sessionId: "chat-1", text: "continue" }))
+      .resolves.toMatchObject({ action: "send" });
     expect(service.getSessionSummary).toHaveBeenCalledWith("chat-1");
+    expect(service.ensureSessionSurface).toHaveBeenCalledWith("chat-1", "personal");
+    expect(service.sendMessage).toHaveBeenCalledWith({ sessionId: "chat-1", text: "continue" });
+  });
+
+  it("rejects session-scoped calls when the session row is missing", async () => {
+    const { createRuntime, service } = fixture();
+    service.getSessionSummary.mockResolvedValueOnce(null as never);
+    const scope = new PersonalChatScope({ createRuntime });
+    await expect(scope.call("send", { sessionId: "missing", text: "nope" }))
+      .rejects.toThrow("Personal chat session 'missing' was not found");
     expect(service.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("prewarms only when personal-chat state already exists", async () => {
+    const { createRuntime } = fixture();
+    const scope = new PersonalChatScope({ createRuntime });
+    await scope.warmExisting();
+    expect(createRuntime).not.toHaveBeenCalled();
+
+    const dbPath = path.join(adeHome, "personal-chats", "state", ".ade", "ade.db");
+    fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+    fs.writeFileSync(dbPath, "");
+
+    await scope.warmExisting();
+    expect(createRuntime).toHaveBeenCalledTimes(1);
   });
 
   it("cancels scheduled work only for an owned personal session", async () => {

--- a/apps/ade-cli/src/services/personalChats/personalChatScope.ts
+++ b/apps/ade-cli/src/services/personalChats/personalChatScope.ts
@@ -99,6 +99,17 @@ export class PersonalChatScope {
     return summarizeRuntimeActivity(runtime);
   }
 
+  /**
+   * Existing personal-chat users should not pay the hidden runtime's cold boot
+   * after opening the Chats pane. Fresh installs remain lazy.
+   */
+  async warmExisting(): Promise<void> {
+    const layout = resolveMachineAdeLayout();
+    const stateRoot = layout.personalChatsStateRoot ?? path.join(layout.adeDir, "personal-chats", "state");
+    if (!fs.existsSync(path.join(stateRoot, ".ade", "ade.db"))) return;
+    await this.getRuntime();
+  }
+
   async call(
     actionValue: unknown,
     argsValue: unknown,
@@ -115,13 +126,28 @@ export class PersonalChatScope {
 
     let result: unknown;
     switch (action) {
-      case "list":
-        result = (await service.listSessions(undefined, {
+      case "list": {
+        const sessions = await service.listSessions(undefined, {
           includeIdentity: false,
           includeAutomation: true,
           includeArchived: args.includeArchived === true,
-        })).filter((session) => session.surface === "personal");
+        });
+        // This runtime is a private machine-owned scope: every chat row inside
+        // it is personal. Older rows may have lost their surface while being
+        // reconstructed for a follow-up, so repair and return them instead of
+        // filtering intact transcripts out of the UI.
+        result = sessions
+          .filter((session) => session.surface !== "automation")
+          .map((session) => {
+            if (session.surface !== "personal") {
+              service.ensureSessionSurface(session.sessionId, "personal");
+            }
+            return session.surface === "personal"
+              ? session
+              : { ...session, surface: "personal" as const };
+          });
         break;
+      }
       case "create": {
         const provider = requiredString(args.provider, "provider") as AgentChatCreateArgs["provider"];
         const model = requiredString(args.model, "model");
@@ -373,8 +399,8 @@ export class PersonalChatScope {
   async transcriptPath(sessionIdValue: unknown): Promise<string | null> {
     const sessionId = requiredString(sessionIdValue, "sessionId");
     const runtime = await this.getRuntime();
-    const summary = await runtime.agentChatService?.getSessionSummary(sessionId);
-    if (!summary || summary.surface !== "personal") return null;
+    const service = runtime.agentChatService;
+    if (!service || !(await this.resolvePersonalSession(service, sessionId))) return null;
     // The session transcript is byte-capped. Remote clients must tail the
     // dedicated durable chat transcript or long conversations stop updating.
     const durablePath = path.join(resolveAdeLayout(runtime.projectRoot).chatTranscriptsDir, `${sessionId}.jsonl`);
@@ -387,8 +413,10 @@ export class PersonalChatScope {
   async isTurnActive(sessionIdValue: unknown): Promise<boolean> {
     const sessionId = requiredString(sessionIdValue, "sessionId");
     const runtime = await this.getRuntime();
-    const summary = await runtime.agentChatService?.getSessionSummary(sessionId);
-    return summary?.surface === "personal" && summary.status === "active";
+    const service = runtime.agentChatService;
+    if (!service) return false;
+    const summary = await this.resolvePersonalSession(service, sessionId);
+    return summary?.status === "active";
   }
 
   async dispose(): Promise<void> {
@@ -440,9 +468,24 @@ export class PersonalChatScope {
     service: NonNullable<AdeRuntime["agentChatService"]>,
     sessionId: string,
   ): Promise<AgentChatSessionSummary> {
-    const summary = await service.getSessionSummary(sessionId);
-    if (!summary || summary.surface !== "personal") {
+    const summary = await this.resolvePersonalSession(service, sessionId);
+    if (!summary) {
       throw new Error(`Personal chat session '${sessionId}' was not found.`);
+    }
+    return summary;
+  }
+
+  private async resolvePersonalSession(
+    service: NonNullable<AdeRuntime["agentChatService"]>,
+    sessionId: string,
+  ): Promise<AgentChatSessionSummary | null> {
+    const summary = await service.getSessionSummary(sessionId);
+    if (!summary || summary.surface === "automation") {
+      return null;
+    }
+    if (summary.surface !== "personal") {
+      service.ensureSessionSurface(sessionId, "personal");
+      return { ...summary, surface: "personal" };
     }
     return summary;
   }

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -1565,26 +1565,25 @@ function buildChatDomainService(runtime: AdeRuntime): OpaqueService | null {
     };
   }
   if (typeof base.getChatEventHistory === "function") {
-    service.getChatEventHistory = async (args?: unknown) => {
+    service.getChatEventHistory = (args?: unknown) => {
       const { sessionId, options } = readChatHistoryActionArgs(args, "chat.getChatEventHistory");
       const maxEvents = readOptionalIntegerActionField(options.maxEvents, "maxEvents");
       const maxBytes = readOptionalIntegerActionField(options.maxBytes, "maxBytes");
-      const historyOptions = {
+      return agentChatService.getChatEventHistory(sessionId, {
         ...(maxEvents !== undefined ? { maxEvents } : {}),
         ...(maxBytes !== undefined ? { maxBytes } : {}),
-      };
-      return await agentChatService.getChatEventHistory(sessionId, historyOptions);
+      });
     };
   }
   if (typeof base.getChatEventHistoryPage === "function") {
-    service.getChatEventHistoryPage = async (args?: unknown) => {
+    service.getChatEventHistoryPage = (args?: unknown) => {
       const { sessionId, options } = readChatHistoryActionArgs(args, "chat.getChatEventHistoryPage");
       const beforeOffset = readOptionalIntegerActionField(options.beforeOffset, "beforeOffset");
       if (beforeOffset === undefined) {
         throw new Error("Expected 'beforeOffset' to be a finite number.");
       }
       const maxBytes = readOptionalIntegerActionField(options.maxBytes, "maxBytes");
-      return await agentChatService.getChatEventHistoryPage(sessionId, {
+      return agentChatService.getChatEventHistoryPage(sessionId, {
         beforeOffset,
         ...(maxBytes !== undefined ? { maxBytes } : {}),
       });

--- a/apps/desktop/src/main/services/chat/agentChatService.test.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.test.ts
@@ -4020,6 +4020,26 @@ describe("createAgentChatService", () => {
       expect(persisted.provider).toBe("opencode");
     });
 
+    it("preserves the personal surface when reconstructing a persisted session", async () => {
+      const { service } = createService();
+      const session = await service.createSession({
+        laneId: "lane-1",
+        provider: "opencode",
+        model: "",
+        modelId: "opencode/anthropic/claude-sonnet-5",
+        surface: "personal",
+      });
+
+      await service.dispose({ sessionId: session.id });
+      await service.updateSession({ sessionId: session.id, title: "Reopened personal chat" });
+
+      await expect(service.getSessionSummary(session.id)).resolves.toMatchObject({
+        sessionId: session.id,
+        surface: "personal",
+      });
+      expect(readPersistedChatState(session.id).surface).toBe("personal");
+    });
+
     it("writes a chat transcript init record", async () => {
       const { service } = createService();
       const session = await service.createSession({

--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -15418,6 +15418,7 @@ export function createAgentChatService(args: {
         ...(persisted?.cursorPromotedTurnId ? { cursorPromotedTurnId: persisted.cursorPromotedTurnId } : {}),
         ...(persisted?.permissionMode ? { permissionMode: persisted.permissionMode } : {}),
         ...(persisted?.identityKey ? { identityKey: persisted.identityKey } : {}),
+        ...(persisted?.surface ? { surface: persisted.surface } : {}),
         capabilityMode: persisted?.capabilityMode ?? inferCapabilityMode(provider),
         completion: persisted?.completion ?? null,
         codexGoal: persisted?.codexGoal ?? null,
@@ -35665,6 +35666,23 @@ export function createAgentChatService(args: {
     return await summarizeSessionRow(row);
   };
 
+  /**
+   * Repairs the owning surface for a session loaded from legacy metadata.
+   * This is intentionally not part of the public chat action contract; the
+   * machine-owned personal-chat scope uses it to migrate sessions that predate
+   * persisted `surface` metadata without exposing a cross-surface mutation.
+   */
+  const ensureSessionSurface = (
+    sessionId: string,
+    surface: AgentChatSurface,
+  ): void => {
+    const managed = ensureManagedSession(sessionId);
+    if (managed.session.surface !== surface) {
+      managed.session.surface = surface;
+      persistChatState(managed);
+    }
+  };
+
   const toScheduledWorkItem = (schedule: ChatScheduledWorkRecord): AgentChatScheduledWorkItem => ({
     id: schedule.id,
     sessionId: schedule.sessionId,
@@ -40616,6 +40634,7 @@ export function createAgentChatService(args: {
     resumeSession,
     listSessions,
     getSessionSummary,
+    ensureSessionSurface,
     hasActiveWorkloads,
     hasRetainableSessions,
     countActiveForLane,

--- a/apps/desktop/src/main/services/pty/ptyService.ts
+++ b/apps/desktop/src/main/services/pty/ptyService.ts
@@ -21,7 +21,6 @@ import type { createAiIntegrationService } from "../ai/aiIntegrationService";
 import type { createProjectConfigService } from "../config/projectConfigService";
 import type { DiskPressureMonitor } from "../storage/diskPressure";
 import { readHistoryFileSync, reinflateHistoryFile } from "../storage/historyCompression";
-import { writeFileAtomic } from "../state/durableFile";
 import {
   resolveCodexComputerUseMcpConfig,
   type CodexComputerUseMcpConfig,
@@ -4359,8 +4358,13 @@ export function createPtyService({
       const sessionLinearEnv = getSessionLinearEnv?.({ sessionId, chatSessionId }) ?? {};
       const explicitNoColor = hasEnvKey(args.env ?? {}, "NO_COLOR") || hasEnvKey(laneRuntimeEnv, "NO_COLOR");
       const explicitForceColor = hasEnvKey(args.env ?? {}, "FORCE_COLOR") || hasEnvKey(laneRuntimeEnv, "FORCE_COLOR");
+      const inheritedProcessEnv = { ...process.env };
+      // The desktop/runtime itself may be launched from an agent shell. Do not
+      // leak that host role into an ordinary terminal; tracked agent CLIs set
+      // their role explicitly below.
+      delete inheritedProcessEnv.ADE_DEFAULT_ROLE;
       const baseLaunchEnv = {
-        ...process.env,
+        ...inheritedProcessEnv,
         ...laneRuntimeEnv,
         ...sessionLinearEnv,
         ...(args.env ?? {})

--- a/apps/desktop/src/main/services/sessions/chatSessionProjection.ts
+++ b/apps/desktop/src/main/services/sessions/chatSessionProjection.ts
@@ -117,16 +117,15 @@ export function projectChatSummariesOntoSessions(
   sessions: TerminalSessionSummary[],
   allChats: AgentChatSessionSummary[],
 ): TerminalSessionSummary[] {
-  const identitySessionIds = new Set(
-    allChats
-      .filter((chat) => Boolean(chat.identityKey))
-      .map((chat) => chat.sessionId),
-  );
-  const chatSummaryBySessionId = new Map(
-    allChats
-      .filter((chat) => !chat.identityKey)
-      .map((chat) => [chat.sessionId, chat] as const),
-  );
+  const identitySessionIds = new Set<string>();
+  const chatSummaryBySessionId = new Map<string, AgentChatSessionSummary>();
+  for (const chat of allChats) {
+    if (chat.identityKey) {
+      identitySessionIds.add(chat.sessionId);
+    } else {
+      chatSummaryBySessionId.set(chat.sessionId, chat);
+    }
+  }
 
   return sessions
     .filter((session) => !identitySessionIds.has(session.id))

--- a/apps/desktop/src/main/services/storage/historyCompression.ts
+++ b/apps/desktop/src/main/services/storage/historyCompression.ts
@@ -142,20 +142,7 @@ async function readPlainHistoryFileRange(
   signal?.throwIfAborted();
   const handle = await fs.promises.open(filePath, "r");
   try {
-    const out = Buffer.allocUnsafe(length);
-    let totalRead = 0;
-    while (totalRead < length) {
-      signal?.throwIfAborted();
-      const { bytesRead } = await handle.read(
-        out,
-        totalRead,
-        length - totalRead,
-        position + totalRead,
-      );
-      if (bytesRead <= 0) break;
-      totalRead += bytesRead;
-    }
-    return totalRead === length ? out : out.subarray(0, totalRead);
+    return await readFileHandleRange(handle, position, length, signal);
   } finally {
     await handle.close();
   }

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -1107,11 +1107,7 @@ function removeAgentChatSessionViewCache(sessionId: string): void {
 function estimateAgentChatSessionViewBytes(events: readonly AgentChatEventEnvelope[]): number {
   let estimatedBytes = 0;
   for (const event of events) {
-    try {
-      estimatedBytes += JSON.stringify(event).length * 2;
-    } catch {
-      return Number.POSITIVE_INFINITY;
-    }
+    estimatedBytes += estimatedChatEventResidentBytes(event);
     if (estimatedBytes > MAX_AGENT_CHAT_VIEW_CACHE_BYTES_PER_SESSION) break;
   }
   return estimatedBytes;
@@ -1754,17 +1750,14 @@ export function resolveNextSelectedSessionId(args: {
 
 const chatEventResidentSizeCache = new WeakMap<AgentChatEventEnvelope, number>();
 
-function estimatedChatEventResidentBytes(
-  event: AgentChatEventEnvelope,
-  maxBytes: number,
-): number {
+function estimatedChatEventResidentBytes(event: AgentChatEventEnvelope): number {
   const cached = chatEventResidentSizeCache.get(event);
   if (cached !== undefined) return cached;
   let eventBytes: number;
   try {
     eventBytes = JSON.stringify(event).length * 2;
   } catch {
-    eventBytes = maxBytes + 1;
+    eventBytes = Number.POSITIVE_INFINITY;
   }
   chatEventResidentSizeCache.set(event, eventBytes);
   return eventBytes;
@@ -1782,7 +1775,7 @@ function trimChatEventHistory(
   let estimatedBytes = 0;
   let byteStart = events.length;
   for (let index = events.length - 1; index >= countStart; index -= 1) {
-    const eventBytes = estimatedChatEventResidentBytes(events[index]!, maxBytes);
+    const eventBytes = estimatedChatEventResidentBytes(events[index]!);
     if (byteStart < events.length && estimatedBytes + eventBytes > maxBytes) break;
     estimatedBytes += eventBytes;
     byteStart = index;
@@ -1803,7 +1796,7 @@ function trimChatEventHistoryFromStart(
   let estimatedBytes = 0;
   let byteEnd = 0;
   for (let index = 0; index < countEnd; index += 1) {
-    const eventBytes = estimatedChatEventResidentBytes(events[index]!, maxBytes);
+    const eventBytes = estimatedChatEventResidentBytes(events[index]!);
     if (byteEnd > 0 && estimatedBytes + eventBytes > maxBytes) break;
     estimatedBytes += eventBytes;
     byteEnd = index + 1;

--- a/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.test.tsx
@@ -269,8 +269,29 @@ describe("PersonalChatsPage", () => {
     expect(navigate).toHaveBeenCalledWith({
       url: "https://example.test/docs",
       newTab: true,
-      projectRoot: null,
+      tabCollection: "personal",
     });
+  });
+
+  it("claims valid link requests and shows an ADE error when the browser bridge is missing", async () => {
+    const openExternal = vi.fn(async () => undefined);
+    const current = window.ade;
+    Object.defineProperty(window, "ade", {
+      configurable: true,
+      writable: true,
+      value: { ...current, app: { openExternal }, builtInBrowser: undefined },
+    });
+    await renderPage();
+
+    const handled = !window.dispatchEvent(new CustomEvent(ADE_OPEN_BUILT_IN_BROWSER_EVENT, {
+      detail: { url: "https://example.test/docs" },
+      cancelable: true,
+    }));
+
+    expect(handled).toBe(true);
+    expect(await screen.findByTestId("browser-panel")).toBeTruthy();
+    expect(await screen.findByText("ADE Browser couldn't open that link. Try again.")).toBeTruthy();
+    expect(openExternal).not.toHaveBeenCalled();
   });
 
   it("shows an ADE error instead of surprise-opening Safari when personal link navigation fails", async () => {
@@ -295,7 +316,7 @@ describe("PersonalChatsPage", () => {
     expect(navigate).toHaveBeenCalledWith({
       url: "https://example.test/docs",
       newTab: true,
-      projectRoot: null,
+      tabCollection: "personal",
     });
     expect(openExternal).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.test.tsx
@@ -6,6 +6,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentChatSessionSummary } from "../../../shared/types";
 import type { ModelDescriptor } from "../../../shared/modelRegistry";
+import { ADE_OPEN_BUILT_IN_BROWSER_EVENT } from "../../lib/openExternal";
 
 // Deliberately a LIGHT accent (Codex-style) so the contrast tests can tell the
 // colored path (dark glyph) apart from the neutral-tint path (white glyph).
@@ -230,6 +231,73 @@ describe("PersonalChatsPage", () => {
 
     resolveList([]);
     await waitFor(() => expect(screen.getByText(/No chats yet/)).toBeTruthy());
+  });
+
+  it("finishes chat-list loading without waiting for the model catalog", async () => {
+    state.sessions = [makeSession({ title: "Ready chat" })];
+    const pendingCatalog = new Promise<never>(() => {});
+    const bridge = (window as unknown as { ade: { personalChats: { call: ReturnType<typeof vi.fn> } } });
+    bridge.ade.personalChats.call.mockImplementation(async ({ action }: CallArgs) => {
+      if (action === "list") return { result: state.sessions };
+      if (action === "modelCatalog") return await pendingCatalog;
+      return { result: undefined };
+    });
+
+    await renderPage();
+
+    expect(await screen.findByText("Ready chat")).toBeTruthy();
+    const sidebar = screen.getByText("Chats").closest("aside");
+    await waitFor(() => expect(sidebar?.querySelector(".animate-spin")).toBeNull());
+  });
+
+  it("routes transcript link requests into the visible personal browser collection", async () => {
+    const navigate = vi.fn(async () => undefined);
+    const current = window.ade;
+    Object.defineProperty(window, "ade", {
+      configurable: true,
+      writable: true,
+      value: { ...current, builtInBrowser: { navigate } },
+    });
+    await renderPage();
+
+    window.dispatchEvent(new CustomEvent(ADE_OPEN_BUILT_IN_BROWSER_EVENT, {
+      detail: { url: "https://example.test/docs" },
+      cancelable: true,
+    }));
+
+    expect(await screen.findByTestId("browser-panel")).toBeTruthy();
+    expect(navigate).toHaveBeenCalledWith({
+      url: "https://example.test/docs",
+      newTab: true,
+      projectRoot: null,
+    });
+  });
+
+  it("shows an ADE error instead of surprise-opening Safari when personal link navigation fails", async () => {
+    const openExternal = vi.fn(async () => undefined);
+    const navigate = vi.fn(async () => {
+      throw new Error("browser unavailable");
+    });
+    const current = window.ade;
+    Object.defineProperty(window, "ade", {
+      configurable: true,
+      writable: true,
+      value: { ...current, app: { openExternal }, builtInBrowser: { navigate } },
+    });
+    await renderPage();
+
+    window.dispatchEvent(new CustomEvent(ADE_OPEN_BUILT_IN_BROWSER_EVENT, {
+      detail: { url: "https://example.test/docs" },
+      cancelable: true,
+    }));
+
+    expect(await screen.findByText("ADE Browser couldn't open that link. Try again.")).toBeTruthy();
+    expect(navigate).toHaveBeenCalledWith({
+      url: "https://example.test/docs",
+      newTab: true,
+      projectRoot: null,
+    });
+    expect(openExternal).not.toHaveBeenCalled();
   });
 
   it("docks (not hero) when selecting a session whose events have not loaded yet", async () => {

--- a/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.test.tsx
@@ -6,7 +6,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentChatSessionSummary } from "../../../shared/types";
 import type { ModelDescriptor } from "../../../shared/modelRegistry";
-import { ADE_OPEN_BUILT_IN_BROWSER_EVENT } from "../../lib/openExternal";
+import { ADE_OPEN_BUILT_IN_BROWSER_EVENT, openUrlInAdeBrowser } from "../../lib/openExternal";
 
 // Deliberately a LIGHT accent (Codex-style) so the contrast tests can tell the
 // colored path (dark glyph) apart from the neutral-tint path (white glyph).
@@ -123,6 +123,7 @@ describe("PersonalChatsPage", () => {
   beforeEach(() => {
     cleanup();
     vi.clearAllMocks();
+    delete window.__adeWebClient;
     state.sessions = [];
     state.catalogAvailable = true;
     state.historyEvents = [];
@@ -132,6 +133,7 @@ describe("PersonalChatsPage", () => {
 
   afterEach(() => {
     cleanup();
+    delete window.__adeWebClient;
   });
 
   it("renders the hero (greeting + composer + chips) with the composer inside the canvas and no shell footer", async () => {
@@ -292,6 +294,24 @@ describe("PersonalChatsPage", () => {
     expect(await screen.findByTestId("browser-panel")).toBeTruthy();
     expect(await screen.findByText("ADE Browser couldn't open that link. Try again.")).toBeTruthy();
     expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it("leaves hosted-web link requests unclaimed so they can fall back externally", async () => {
+    const openExternal = vi.fn(async () => undefined);
+    const current = window.ade;
+    window.__adeWebClient = true;
+    Object.defineProperty(window, "ade", {
+      configurable: true,
+      writable: true,
+      value: { ...current, app: { openExternal }, builtInBrowser: undefined },
+    });
+    await renderPage();
+
+    openUrlInAdeBrowser("https://example.test/docs");
+
+    expect(openExternal).toHaveBeenCalledWith("https://example.test/docs");
+    expect(screen.queryByTestId("browser-panel")).toBeNull();
+    expect(screen.queryByText("ADE Browser couldn't open that link. Try again.")).toBeNull();
   });
 
   it("shows an ADE error instead of surprise-opening Safari when personal link navigation fails", async () => {

--- a/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.tsx
+++ b/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.tsx
@@ -32,6 +32,11 @@ import { buildChatAppearanceRootStyle } from "../chat/chatAppearance";
 import { effectiveChatAccent } from "../chat/chatSurfaceTheme";
 import { descriptorsFromAgentChatModelCatalog } from "../shared/ModelPicker/modelCatalog";
 import { isWebClientMode } from "../../lib/webClientMode";
+import {
+  ADE_OPEN_BUILT_IN_BROWSER_EVENT,
+  navigateUrlInAdeBrowser,
+  type OpenBuiltInBrowserDetail,
+} from "../../lib/openExternal";
 import { useAppStore } from "../../state/appStore";
 
 type ToolPanel = "browser" | "terminal" | null;
@@ -227,20 +232,42 @@ export function PersonalChatsPage({ standalone = false }: { standalone?: boolean
     setModelId(DEFAULT_MODEL_ID);
     setLoading(true);
     setError(null);
-    void Promise.all([
-      refreshSessions(generation),
-      callPersonal<AgentChatModelCatalog>("modelCatalog", { mode: "cached" })
-        .then((next) => {
-          if (generation === targetGenerationRef.current) setCatalog(next);
-        }),
-    ]).catch((reason) => {
+    void refreshSessions(generation).catch((reason) => {
       if (generation === targetGenerationRef.current) {
         setError(reason instanceof Error ? reason.message : String(reason));
       }
     }).finally(() => {
       if (generation === targetGenerationRef.current) setLoading(false);
     });
+    void callPersonal<AgentChatModelCatalog>("modelCatalog", { mode: "cached" })
+      .then((next) => {
+        if (generation === targetGenerationRef.current) setCatalog(next);
+      })
+      .catch((reason) => {
+        if (generation === targetGenerationRef.current) {
+          setError(reason instanceof Error ? reason.message : String(reason));
+        }
+      });
   }, [refreshSessions, targetKey]);
+
+  useEffect(() => {
+    const openPersonalBrowser = (rawEvent: Event) => {
+      const event = rawEvent as CustomEvent<OpenBuiltInBrowserDetail>;
+      const browser = window.ade?.builtInBrowser;
+      if (!browser || !event.detail?.url) return;
+      event.preventDefault();
+      setToolPanel("browser");
+      navigateUrlInAdeBrowser(event.detail.url, {
+        newTab: true,
+        projectRoot: null,
+      }, {
+        fallbackToExternal: false,
+        onFailure: () => setError("ADE Browser couldn't open that link. Try again."),
+      });
+    };
+    window.addEventListener(ADE_OPEN_BUILT_IN_BROWSER_EVENT, openPersonalBrowser);
+    return () => window.removeEventListener(ADE_OPEN_BUILT_IN_BROWSER_EVENT, openPersonalBrowser);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.tsx
+++ b/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.tsx
@@ -253,13 +253,12 @@ export function PersonalChatsPage({ standalone = false }: { standalone?: boolean
   useEffect(() => {
     const openPersonalBrowser = (rawEvent: Event) => {
       const event = rawEvent as CustomEvent<OpenBuiltInBrowserDetail>;
-      const browser = window.ade?.builtInBrowser;
-      if (!browser || !event.detail?.url) return;
+      if (!event.detail?.url) return;
       event.preventDefault();
       setToolPanel("browser");
       navigateUrlInAdeBrowser(event.detail.url, {
         newTab: true,
-        projectRoot: null,
+        tabCollection: "personal",
       }, {
         fallbackToExternal: false,
         onFailure: () => setError("ADE Browser couldn't open that link. Try again."),

--- a/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.tsx
+++ b/apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.tsx
@@ -253,7 +253,7 @@ export function PersonalChatsPage({ standalone = false }: { standalone?: boolean
   useEffect(() => {
     const openPersonalBrowser = (rawEvent: Event) => {
       const event = rawEvent as CustomEvent<OpenBuiltInBrowserDetail>;
-      if (!event.detail?.url) return;
+      if (!event.detail?.url || isWebClientMode()) return;
       event.preventDefault();
       setToolPanel("browser");
       navigateUrlInAdeBrowser(event.detail.url, {

--- a/apps/desktop/src/renderer/lib/openExternal.test.ts
+++ b/apps/desktop/src/renderer/lib/openExternal.test.ts
@@ -36,7 +36,7 @@ describe("openUrlInAdeBrowser", () => {
     expect(openExternal).toHaveBeenCalledWith("https://example.test/docs");
   });
 
-  it("falls back on a short deadline instead of waiting for a delayed rejection", async () => {
+  it("does not fall back solely because in-app navigation remains pending", async () => {
     vi.useFakeTimers();
     const openExternal = vi.fn(async () => undefined);
     const navigate = vi.fn(() => new Promise<void>(() => {}));
@@ -52,9 +52,8 @@ describe("openUrlInAdeBrowser", () => {
     openUrlInAdeBrowser("https://example.test/docs");
     expect(openExternal).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(60_000);
 
-    expect(openExternal).toHaveBeenCalledOnce();
-    expect(openExternal).toHaveBeenCalledWith("https://example.test/docs");
+    expect(openExternal).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/lib/openExternal.test.ts
+++ b/apps/desktop/src/renderer/lib/openExternal.test.ts
@@ -1,0 +1,60 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { openUrlInAdeBrowser } from "./openExternal";
+
+describe("openUrlInAdeBrowser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("falls back immediately when in-app navigation rejects", async () => {
+    const openExternal = vi.fn(async () => undefined);
+    const navigate = vi.fn(async () => {
+      throw new Error("profile migration failed");
+    });
+    Object.defineProperty(window, "ade", {
+      configurable: true,
+      writable: true,
+      value: {
+        app: { openExternal },
+        builtInBrowser: { navigate },
+      },
+    });
+
+    openUrlInAdeBrowser("https://example.test/docs");
+
+    expect(navigate).toHaveBeenCalledWith({
+      url: "https://example.test/docs",
+      newTab: true,
+    });
+    await vi.waitFor(() => expect(openExternal).toHaveBeenCalledOnce());
+    expect(openExternal).toHaveBeenCalledWith("https://example.test/docs");
+  });
+
+  it("falls back on a short deadline instead of waiting for a delayed rejection", async () => {
+    vi.useFakeTimers();
+    const openExternal = vi.fn(async () => undefined);
+    const navigate = vi.fn(() => new Promise<void>(() => {}));
+    Object.defineProperty(window, "ade", {
+      configurable: true,
+      writable: true,
+      value: {
+        app: { openExternal },
+        builtInBrowser: { navigate },
+      },
+    });
+
+    openUrlInAdeBrowser("https://example.test/docs");
+    expect(openExternal).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(openExternal).toHaveBeenCalledOnce();
+    expect(openExternal).toHaveBeenCalledWith("https://example.test/docs");
+  });
+});

--- a/apps/desktop/src/renderer/lib/openExternal.ts
+++ b/apps/desktop/src/renderer/lib/openExternal.ts
@@ -4,6 +4,18 @@ export type OpenBuiltInBrowserDetail = {
   url: string;
 };
 
+type BuiltInBrowserNavigationOptions = {
+  newTab: boolean;
+  projectRoot?: string | null;
+};
+
+type BuiltInBrowserNavigationFailureOptions = {
+  fallbackToExternal?: boolean;
+  onFailure?: () => void;
+};
+
+const BUILT_IN_BROWSER_NAVIGATION_FALLBACK_MS = 4_000;
+
 // Renderer-local event that routes an in-app `ade://` deeplink through ADE's
 // internal navigation. App.tsx listens for this, parses the URL, and dispatches
 // the resulting target through the same handler that inbound OS/CLI deeplinks
@@ -90,22 +102,46 @@ export function openUrlInAdeBrowser(url: string | undefined | null): void {
   // which the event causes to mount via TerminalsPage — sees the flag in its
   // first default-tab effect and skips creating a Google tab.
   markPendingBuiltInBrowserNavigation();
-  window.dispatchEvent(new CustomEvent<OpenBuiltInBrowserDetail>(ADE_OPEN_BUILT_IN_BROWSER_EVENT, {
+  const openEvent = new CustomEvent<OpenBuiltInBrowserDetail>(ADE_OPEN_BUILT_IN_BROWSER_EVENT, {
     detail: { url: normalized },
-  }));
-  const browser = window.ade?.builtInBrowser;
-  if (browser) {
-    void browser.navigate({ url: normalized, newTab: true }).catch(() => {
-      // Navigation failed: clear the flag so a subsequent panel open can still
-      // surface the default tab.
-      consumePendingBuiltInBrowserNavigation();
-      openExternalUrl(normalized);
-    });
+    cancelable: true,
+  });
+  const handledBySurface = !window.dispatchEvent(openEvent);
+  if (handledBySurface) return;
+  navigateUrlInAdeBrowser(normalized, { newTab: true });
+}
+
+export function navigateUrlInAdeBrowser(
+  url: string,
+  options: BuiltInBrowserNavigationOptions,
+  failureOptions: BuiltInBrowserNavigationFailureOptions = {},
+): void {
+  const browser = typeof window !== "undefined" ? window.ade?.builtInBrowser : undefined;
+  if (!browser) {
+    consumePendingBuiltInBrowserNavigation();
+    failureOptions.onFailure?.();
+    if (failureOptions.fallbackToExternal !== false) openExternalUrl(url);
     return;
   }
-  // No bridge — clear the flag we just set since no IPC navigation will arrive.
-  consumePendingBuiltInBrowserNavigation();
-  openExternalUrl(normalized);
+
+  let finished = false;
+  const finish = (fallback: boolean) => {
+    if (finished) return;
+    finished = true;
+    window.clearTimeout(fallbackTimer);
+    if (!fallback) return;
+    consumePendingBuiltInBrowserNavigation();
+    failureOptions.onFailure?.();
+    if (failureOptions.fallbackToExternal !== false) openExternalUrl(url);
+  };
+  const fallbackTimer = window.setTimeout(
+    () => finish(true),
+    BUILT_IN_BROWSER_NAVIGATION_FALLBACK_MS,
+  );
+  void browser.navigate({ url, ...options }).then(
+    () => finish(false),
+    () => finish(true),
+  );
 }
 
 export function openExternalUrl(url: string | undefined | null): void {

--- a/apps/desktop/src/renderer/lib/openExternal.ts
+++ b/apps/desktop/src/renderer/lib/openExternal.ts
@@ -7,6 +7,7 @@ export type OpenBuiltInBrowserDetail = {
 type BuiltInBrowserNavigationOptions = {
   newTab: boolean;
   projectRoot?: string | null;
+  tabCollection?: "personal";
 };
 
 type BuiltInBrowserNavigationFailureOptions = {

--- a/apps/desktop/src/renderer/lib/openExternal.ts
+++ b/apps/desktop/src/renderer/lib/openExternal.ts
@@ -15,8 +15,6 @@ type BuiltInBrowserNavigationFailureOptions = {
   onFailure?: () => void;
 };
 
-const BUILT_IN_BROWSER_NAVIGATION_FALLBACK_MS = 4_000;
-
 // Renderer-local event that routes an in-app `ade://` deeplink through ADE's
 // internal navigation. App.tsx listens for this, parses the URL, and dispatches
 // the resulting target through the same handler that inbound OS/CLI deeplinks
@@ -125,24 +123,11 @@ export function navigateUrlInAdeBrowser(
     return;
   }
 
-  let finished = false;
-  const finish = (fallback: boolean) => {
-    if (finished) return;
-    finished = true;
-    window.clearTimeout(fallbackTimer);
-    if (!fallback) return;
+  void browser.navigate({ url, ...options }).catch(() => {
     consumePendingBuiltInBrowserNavigation();
     failureOptions.onFailure?.();
     if (failureOptions.fallbackToExternal !== false) openExternalUrl(url);
-  };
-  const fallbackTimer = window.setTimeout(
-    () => finish(true),
-    BUILT_IN_BROWSER_NAVIGATION_FALLBACK_MS,
-  );
-  void browser.navigate({ url, ...options }).then(
-    () => finish(false),
-    () => finish(true),
-  );
+  });
 }
 
 export function openExternalUrl(url: string | undefined | null): void {

--- a/docs/features/personal-chats/README.md
+++ b/docs/features/personal-chats/README.md
@@ -9,7 +9,7 @@ desktop, the hosted web client, mobile, and the ADE CLI.
 
 | Path | Role |
 |---|---|
-| `apps/ade-cli/src/services/personalChats/personalChatScope.ts` | Lazy machine-owned chat runtime, hidden persistence/scratch roots, action allowlist (including scheduled-work create/cancel/pause), attachment confinement, terminal ownership, and event stream. |
+| `apps/ade-cli/src/services/personalChats/personalChatScope.ts` | Machine-owned chat runtime, existing-state background prewarm, hidden persistence/scratch roots, personal-surface recovery for legacy session rows, action allowlist (including scheduled-work create/cancel/pause), attachment confinement, terminal ownership, and event stream. |
 | `apps/ade-cli/src/services/imageAttachment.ts` | Shared image validation, MIME sniffing, and bounded temporary-attachment persistence used by project and personal chat ingress. |
 | `apps/ade-cli/src/services/projects/machineLayout.ts` | Resolves the channel-local `$ADE_HOME/personal-chats/{state,workspaces}` roots. |
 | `apps/ade-cli/src/multiProjectRpcServer.ts` | Project-independent `personalChats.call` and `personalChats.streamEvents` machine RPC methods plus capability advertisement. |
@@ -17,8 +17,8 @@ desktop, the hosted web client, mobile, and the ADE CLI.
 | `apps/ade-cli/src/services/sync/` | Runtime-scoped personal-chat commands, feature advertisement, policy descriptors, and personal transcript subscriptions for controllers. Primary files: `syncService.ts`, `syncHostService.ts`, and `syncRemoteCommandService.ts`. |
 | `apps/desktop/src/shared/types/personalChats.ts` | Cross-process action, result, capability, queue-policy, scope, and event contracts, including the scheduled-work create/cancel/pause actions shared with project chat. |
 | `apps/desktop/src/main/services/ipc/runtimeBridge.ts` | Routes a local/no-project window to the local brain and a remotely bound project window to that remote machine's personal-chat scope. |
-| `apps/desktop/src/main/services/chat/agentChatService.ts` | Durable `personal` chat surface and neutral provider guidance/environment. |
-| `apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.tsx` | Desktop projectless surface: conversation load/stream, the hero-vs-docked composer switch once a session is selected, transcript, and compact Browser/Terminal tool panels. |
+| `apps/desktop/src/main/services/chat/agentChatService.ts` | Durable `personal` chat surface, persisted-surface reconstruction/repair support, and neutral provider guidance/environment. |
+| `apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.tsx` | Desktop projectless surface: independently loaded conversation list and model catalog, conversation stream, the hero-vs-docked composer switch once a session is selected, transcript, personal-scoped link routing, and compact Browser/Terminal tool panels. |
 | `apps/desktop/src/renderer/components/personalChats/ProjectlessHero.tsx` | Empty-state hero shown before a session is picked — heading, verb-first suggestion chips that prefill the draft, and the docked composer slot. |
 | `apps/desktop/src/renderer/components/personalChats/ProjectlessComposer.tsx` | Shared composer rendered in `hero` or `docked` variant, with model/reasoning/permission controls, send/interrupt, and provider-accent send button (`chatAccentContrast`). |
 | `apps/desktop/src/renderer/components/personalChats/ProjectlessSidebar.tsx` | Stateful conversation rail: recency-grouped, searchable session list with new-chat and per-session selection state. |
@@ -47,9 +47,11 @@ implementation details only:
 
 The runtime is channel-scoped with the rest of ADE machine state, so stable,
 beta, alpha, and isolated development homes do not share conversations. It is
-lazy and chat-only, does not run its own sync listener, and suppresses the
-project-oriented push/deeplink publisher because those links would otherwise
-open a project Work surface.
+chat-only and remains lazy for fresh installs; when existing personal-chat
+state is present, the brain prewarms it in the background so opening Chats does
+not pay the cold-start cost. It does not run its own sync listener and
+suppresses the project-oriented push/deeplink publisher because those links
+would otherwise open a project Work surface.
 
 Personal-chat provider processes run from the separate workspace root. Their
 environment retains the session identity needed by the provider bridge but
@@ -133,6 +135,12 @@ guidance rather than ADE's coding-agent prompt. The environment exposes the
 chat session and personal scope, but omits project/lane/workspace identity
 variables.
 
+The hidden runtime is authoritative for personal-chat ownership. Session
+reconstruction must preserve the persisted `surface`, and the personal scope
+repairs older non-automation rows whose marker is missing or stale before
+listing, reading, or continuing them. A missing marker must not hide an intact
+transcript from the conversation rail.
+
 Personal chat creation strips or overrides project-only fields such as a
 caller-supplied lane/cwd, orchestration metadata, automation ownership, and
 persistent project identity. The CLI separately rejects Linear attachment
@@ -144,7 +152,7 @@ domains into the hidden runtime.
 | Surface | Entry and behavior |
 |---|---|
 | Desktop | **Chats** sits above the profile control and stays enabled with no project selected. The welcome screen has a **Start a chat** action. Visiting `/chats` from the projectless shell opens a real machine-level **Chats** top tab (backed by `personalChatsTabOpen`) that stays present as a clickable tab across project open/switch/close. The "+" on `/chats` opens and activates Home/New Tab while the Chats tab stays as an inactive tab; closing New Tab returns to `/chats` when projectless; closing an inactive Chats tab does not navigate. The surface itself is a hero empty state — heading plus verb-first suggestion chips — whose composer docks to the bottom once a session is selected, alongside a stateful searchable recency-grouped conversation rail, shared model/reasoning/permission controls, provider-accent send button, transcript/approval handling, and compact Browser and Terminal buttons. |
-| ADE Browser | Personal chat uses the global authenticated browser profile and an explicit personal tab collection (`tabCollection: "personal"`). Cookies and site storage are shared across ADE, while personal visible tabs remain separate from project/window tabs. |
+| ADE Browser | Personal chat uses the global authenticated browser profile and an explicit personal tab collection (`tabCollection: "personal"`). HTTP(S) links in the transcript are intercepted by the active personal-chat surface, open its Browser panel, and navigate with projectless scope so they cannot land invisibly in a retained project's collection. Navigation failures stay in ADE as a visible error instead of surprise-opening the system browser later. Cookies and site storage are shared across ADE, while personal visible tabs remain separate from project/window tabs. |
 | Hosted web | The project picker and shell can enter `/chats` without selecting a project. The adapter uses runtime-scoped commands and personal chat subscriptions; browser-native ADE Browser is absent, while terminal IO runs on the paired machine. |
 | iOS | The Hub card is the only entry. It shows live count/attention state and pushes a native searchable list, new-chat model sheet, and reused Work transcript destination with project/lane actions suppressed. Chat Info uses the personal action descriptors for durable-schedule Cancel and per-chat Pause/Resume; schedule creation remains an API capability rather than a native control. Personal summaries are cached per paired host for offline list display; create and schedule mutations require a live host, while sends may queue. |
 | ADE CLI | `ade chat ... --personal` reaches the machine RPC directly. `--personal` is mutually exclusive with lane/Linear project context and requires a running brain. |
@@ -173,6 +181,9 @@ domains into the hidden runtime.
 - Keep personal browser calls on `tabCollection: "personal"`; omitting it routes
   the call to the source window's active project tab collection. This changes
   visible tab routing only, never the global authentication storage profile.
+- Preserve `surface: "personal"` whenever a persisted session is reconstructed.
+  The hidden personal runtime may repair missing legacy markers, but regular
+  project runtimes must never relabel a session across surfaces.
 - Older runtimes should report the feature as unavailable. Do not silently
   create a normal project chat.
 - The hosted web client has no local database. Lists and transcript updates


### PR DESCRIPTION
<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstart-skill-some-issues-saw-19e56cbe num=900 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstart-skill-some-issues-saw-19e56cbe&amp;pr=900">ade/start-skill-some-issues-saw-19e56cbe branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=900">PR #900</a>
</p>
<!-- /ade:link -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Personal chat sessions now repair legacy surface metadata and preserve correct session surface details when reopened.
  * Personal chats warm up in the background for faster access on existing setups.
  * Built-in browser link routing is improved, with cancelable navigation and clearer in-app vs external fallback behavior.
* **Bug Fixes**
  * Personal chat listing and transcript/turn-active checks now reliably resolve the correct personal session.
  * Session history handling and byte estimation for trimming are more robust.
* **Tests**
  * Added/expanded tests for browser navigation events, legacy metadata repair, session restoration, and isolated environment setup/teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves projectless personal chat reliability. The main changes are:

- Background warmup for existing personal chat runtimes.
- Preservation and repair of personal session surface metadata.
- Independent loading for the chat list and model catalog.
- Personal-scoped ADE browser routing for transcript links.
- Cleanup for chat history sizing, credential read state, terminal environment inheritance, tests, and docs.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are targeted, covered by focused tests, and no current correctness or security issues were identified.

**Files Needing Attention:** No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The general-contract-validation-proof run executed the tests for the personal chats route, and all the relevant assertions about loading, session filtering, built-in routing, external fallback behavior, IME handling, and contrast behavior passed.
- The test logs were inspected, confirming that the personal chats page loaded and that the UI asserted the expected page state and text content, including hasPage: true for the personal-chats-page and the provider unavailable notice.
- UI capture artifacts were reviewed, showing the initial screenshot of the real desktop renderer personal chats route and a later screenshot after it settled.
- A video artifact was examined to verify the run flow and transitions through the personal chats route across the test session.

<a href="https://app.greptile.com/trex/runs/15827211/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ade-cli/src/services/personalChats/personalChatScope.ts | Adds existing-state warmup and repairs non-automation legacy sessions to the personal surface before listing or acting on them. |
| apps/desktop/src/main/services/chat/agentChatService.ts | Preserves persisted surface when reconstructing sessions and exposes internal surface repair for personal chat migration. |
| apps/desktop/src/renderer/components/personalChats/PersonalChatsPage.tsx | Loads sessions independently from model catalog and routes transcript links into the personal browser collection with in-app failure handling. |
| apps/desktop/src/renderer/lib/openExternal.ts | Makes built-in browser navigation cancelable by surfaces and factors bridge navigation with configurable fallback behavior. |
| apps/ade-cli/src/multiProjectRpcServer.ts | Adds a personal chat scope factory that asynchronously warms existing personal chat state and reuses it for owned scopes. |
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Centralizes chat event resident-byte estimation and handles serialization failures consistently. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant User as Personal Chats UI
participant Scope as PersonalChatScope
participant Runtime as Hidden chat runtime
participant Chat as AgentChatService
participant Browser as ADE Browser

User->>Scope: list / read / send personal chat
Scope->>Runtime: getRuntime() or background warmExisting()
Runtime->>Chat: listSessions/getSessionSummary
Chat-->>Scope: session summary with persisted surface
alt legacy non-automation surface
    Scope->>Chat: ensureSessionSurface(sessionId, "personal")
    Chat-->>Scope: repaired personal summary
end
Scope-->>User: personal chat results
User->>Browser: navigate link with tabCollection "personal"
Browser-->>User: personal browser tab opens or ADE error is shown
```

<sub>Reviews (5): Last reviewed commit: ["ship: iteration 4 — prewarm shared perso..."](https://github.com/arul28/ade/commit/2898b3141e0cc354285eef02cb2b5ebdb01724be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47145043)</sub>

<!-- /greptile_comment -->