### PR TITLE
mobile-lane-background-deletion -> Primary

### DIFF
--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -455,6 +455,12 @@ enum SyncRequestTimeout {
   }
 }
 
+private struct LaneDeletionFailure: Equatable {
+  let projectId: String
+  let projectRootPath: String
+  let message: String
+}
+
 private let syncTerminalSubscriptionMaxBytes = 240_000
 /// Snapshot budget for the full-screen SwiftTerm session view, which renders
 /// real scrollback instead of a trimmed preview string.
@@ -2462,6 +2468,11 @@ final class SyncService: ObservableObject {
   @Published private(set) var pendingChatCreations: [PendingChatCreation] = []
   @Published private(set) var localStateRevision = 0
   @Published private(set) var lanesProjectionRevision = 0
+  /// Lane deletion can take several minutes while the host stops sessions and
+  /// removes a worktree. Keep that work out of the navigation path, but publish
+  /// the pending ids so lane-bound UI can stop presenting stale controls.
+  @Published private(set) var pendingLaneDeletionIds: Set<String> = []
+  @Published private var laneDeletionFailure: LaneDeletionFailure?
   @Published private(set) var laneDetailProjectionRevision = 0
   /// Per-lane detail revisions bumped only for local `lane_detail_snapshots`
   /// writes with a known lane id, so an open lane detail stops reloading when an
@@ -2765,6 +2776,7 @@ final class SyncService: ObservableObject {
   /// Coalesces bursty `adeDatabaseDidChange` notifications so SwiftUI projection
   /// reloads do not fire on every CRDT row during host sync.
   private var databaseRevisionDebounceTask: Task<Void, Never>?
+  private var laneDeletionTasks: [String: Task<Void, Never>] = [:]
   private var pendingDatabaseTouchedTables: Set<String> = []
   private var pendingLaneDetailIds: Set<String> = []
   private var pendingDatabaseChangeAffectsAll = false
@@ -8471,6 +8483,74 @@ final class SyncService: ObservableObject {
       "remoteName": remoteName,
       "force": force,
     ], targetProjectId: targetProjectId, targetProjectRootPath: targetProjectRootPath)
+  }
+
+  /// Starts a destructive lane cleanup without keeping the caller's sheet or
+  /// navigation stack alive for the host-side teardown. The task is retained by
+  /// the service (rather than a disappearing view) and a single lane can only
+  /// have one in-flight deletion request.
+  @discardableResult
+  func beginLaneDeletion(
+    _ laneId: String,
+    deleteBranch: Bool = true,
+    deleteRemoteBranch: Bool = false,
+    remoteName: String = "origin",
+    force: Bool = false
+  ) -> Bool {
+    guard !pendingLaneDeletionIds.contains(laneId) else { return false }
+    guard let scope = try? captureHydrationProjectScope() else { return false }
+
+    laneDeletionFailure = nil
+    pendingLaneDeletionIds.insert(laneId)
+    laneDeletionTasks[laneId] = Task { @MainActor [weak self] in
+      guard let self else { return }
+      defer {
+        self.pendingLaneDeletionIds.remove(laneId)
+        self.laneDeletionTasks[laneId] = nil
+      }
+
+      do {
+        try await self.deleteLane(
+          laneId,
+          deleteBranch: deleteBranch,
+          deleteRemoteBranch: deleteRemoteBranch,
+          remoteName: remoteName,
+          force: force,
+          targetProjectId: scope.projectId,
+          targetProjectRootPath: scope.rootPath
+        )
+      } catch {
+        self.laneDeletionFailure = LaneDeletionFailure(
+          projectId: scope.projectId,
+          projectRootPath: scope.rootPath,
+          message: "Couldn’t delete lane: \(SyncUserFacingError.message(for: error))"
+        )
+      }
+      // Restore the optimistic lane UI on failure, or converge promptly after
+      // success when CRR delivery is delayed.
+      try? await self.refreshLaneSnapshots(
+        includeStatus: true,
+        includeDecorations: true,
+        expectedScope: scope
+      )
+    }
+    return true
+  }
+
+  func isLaneDeletionPending(_ laneId: String) -> Bool {
+    pendingLaneDeletionIds.contains(laneId)
+  }
+
+  var activeLaneDeletionError: String? {
+    guard let laneDeletionFailure,
+          laneDeletionFailure.projectId == activeProjectId,
+          laneDeletionFailure.projectRootPath == activeProjectRootPath
+    else { return nil }
+    return laneDeletionFailure.message
+  }
+
+  func clearLaneDeletionFailure() {
+    laneDeletionFailure = nil
   }
 
   func fetchLaneTemplates() async throws -> [LaneTemplate] {

--- a/apps/ios/ADE/Views/Lanes/LaneDetailScreen.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneDetailScreen.swift
@@ -166,8 +166,9 @@ struct LaneDetailScreen: View {
         snapshot: currentSnapshot,
         allLaneSnapshots: allLaneSnapshots,
         onDeleted: {
-          await onRefreshRoot()
           dismiss()
+          // SyncService refreshes once its retained host cleanup finishes;
+          // starting another snapshot request here would duplicate that work.
         }
       ) {
         await loadDetail(refreshRemote: true)

--- a/apps/ios/ADE/Views/Lanes/LaneListViewParts.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneListViewParts.swift
@@ -23,7 +23,14 @@ extension LanesTabView {
   }
 
   var primaryLane: LaneSummary? {
-    laneSnapshots.first(where: { $0.lane.laneType == "primary" })?.lane
+    visibleLaneSnapshots.first(where: { $0.lane.laneType == "primary" })?.lane
+  }
+
+  /// A host-side lane delete may take several minutes. Keep its stale local
+  /// snapshot out of navigation and list affordances while SyncService owns
+  /// that cleanup request.
+  var visibleLaneSnapshots: [LaneListSnapshot] {
+    laneSnapshots.filter { !syncService.isLaneDeletionPending($0.lane.id) }
   }
 
   var manageableVisibleLaneIds: [String] {
@@ -35,7 +42,7 @@ extension LanesTabView {
 
   var openLaneSnapshots: [LaneListSnapshot] {
     openLaneIds.compactMap { laneId in
-      laneSnapshots.first(where: { $0.lane.id == laneId })
+      visibleLaneSnapshots.first(where: { $0.lane.id == laneId })
     }
   }
 
@@ -135,7 +142,7 @@ extension LanesTabView {
   @MainActor
   func refreshLaneListPresentation() {
     let filtered = laneListFilteredSnapshots(
-      laneSnapshots,
+      visibleLaneSnapshots,
       scope: scope,
       runtimeFilter: runtimeFilter,
       searchText: searchText,

--- a/apps/ios/ADE/Views/Lanes/LaneManageSheet.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneManageSheet.swift
@@ -694,26 +694,25 @@ struct LaneManageSheet: View {
       errorMessage = "Reconnect to machine before you delete lane."
       return
     }
-    do {
-      busyAction = "delete lane"
-      errorMessage = nil
-      try await syncService.deleteLane(
-        snapshot.lane.id,
-        deleteBranch: deleteSelection.localBranch,
-        deleteRemoteBranch: deleteSelection.remoteBranch,
-        force: deleteForce
-      )
-      dismiss()
-      if let onDeleted {
-        await onDeleted()
-      } else {
-        await onComplete()
-      }
-    } catch {
-      ADEHaptics.error()
-      errorMessage = error.localizedDescription
+    errorMessage = nil
+    guard syncService.beginLaneDeletion(
+      snapshot.lane.id,
+      deleteBranch: deleteSelection.localBranch,
+      deleteRemoteBranch: deleteSelection.remoteBranch,
+      force: deleteForce
+    ) else {
+      return
     }
-    busyAction = nil
+
+    // Host cleanup stops sessions and removes the worktree, so it can be much
+    // slower than a UI transition. Leave this sheet and the lane detail now;
+    // SyncService owns the request until the host finishes.
+    dismiss()
+    if let onDeleted {
+      await onDeleted()
+    } else {
+      await onComplete()
+    }
   }
 
   @MainActor

--- a/apps/ios/ADE/Views/LanesTabView.swift
+++ b/apps/ios/ADE/Views/LanesTabView.swift
@@ -94,6 +94,17 @@ struct LanesTabView: View {
             )
             .transition(.opacity)
           }
+          if let laneDeletionError = syncService.activeLaneDeletionError {
+            ADENoticeCard(
+              title: "Lane deletion failed",
+              message: laneDeletionError,
+              icon: "exclamationmark.triangle.fill",
+              tint: ADEColor.danger,
+              actionTitle: "Dismiss",
+              action: { syncService.clearLaneDeletionFailure() }
+            )
+            .transition(.opacity)
+          }
           if let primaryBranchError,
             laneStatus.phase == .ready,
             !syncService.connectionState.isHostUnreachable
@@ -182,6 +193,14 @@ struct LanesTabView: View {
       .onChange(of: runtimeFilter) { _, _ in refreshLaneListPresentation() }
       .onChange(of: pinnedLaneIdsStorage) { _, _ in refreshLaneListPresentation() }
       .onChange(of: syncService.laneGithubPrItems) { _, _ in refreshLaneListPresentation() }
+      .onChange(of: syncService.pendingLaneDeletionIds) { _, _ in
+        refreshLaneListPresentation()
+        let pendingIds = syncService.pendingLaneDeletionIds
+        openLaneIds.removeAll { pendingIds.contains($0) }
+        if let selectedLaneTransitionId, pendingIds.contains(selectedLaneTransitionId) {
+          self.selectedLaneTransitionId = nil
+        }
+      }
       .onChange(of: isActive) { _, active in
         guard active, syncService.requestedLaneNavigation != nil else { return }
         Task { await handleRequestedLaneNavigation() }

--- a/apps/ios/ADE/Views/Work/WorkRootComponents.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootComponents.swift
@@ -504,6 +504,7 @@ struct WorkSessionListRow: View {
   let isArchived: Bool
   let transitionNamespace: Namespace.ID?
   var compact: Bool = false
+  var isLaneDeleting = false
   @Binding var selectedSessionId: String?
   let isSelecting: Bool
   let isChecked: Bool
@@ -646,6 +647,21 @@ struct WorkSessionListRow: View {
         }
       }
     }
+    .overlay {
+      if isLaneDeleting {
+        HStack(spacing: 6) {
+          ProgressView().controlSize(.small)
+          Text("Updating lane…")
+            .font(.caption.weight(.semibold))
+        }
+        .foregroundStyle(ADEColor.textSecondary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(ADEColor.pageBackground.opacity(0.94), in: Capsule())
+      }
+    }
+    .disabled(isLaneDeleting)
+    .accessibilityHint(isLaneDeleting ? "This lane is being deleted" : "")
   }
 
   private var shouldShowDeleteAction: Bool {

--- a/apps/ios/ADE/Views/Work/WorkRootScreen+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootScreen+Actions.swift
@@ -32,7 +32,8 @@ extension WorkRootScreen {
     )
     let sessionsSnapshot = rosterProjection.sessions
     let chatSummariesSnapshot = localProjectionIsCurrent ? chatSummaries : [:]
-    let lanesSnapshot = rosterProjection.lanes
+    let deletingLaneIds = syncService.pendingLaneDeletionIds
+    let lanesSnapshot = rosterProjection.lanes.filter { !deletingLaneIds.contains($0.id) }
     let pullRequestsSnapshot = localProjectionIsCurrent ? pullRequests : []
     let githubPrsSnapshot = localProjectionIsCurrent ? syncService.laneGithubPrItems : []
     // Fold offline "Pending sync" chat-creation rows into the optimistic set so
@@ -68,7 +69,8 @@ extension WorkRootScreen {
         organization: organization,
         orderedLanes: lanesSnapshot,
         pullRequests: pullRequestsSnapshot,
-        githubPrs: githubPrsSnapshot
+        githubPrs: githubPrsSnapshot,
+        deletingLaneIds: deletingLaneIds
       )
       await MainActor.run {
         guard generation == sessionPresentationRebuildGeneration, !Task.isCancelled else { return }

--- a/apps/ios/ADE/Views/Work/WorkRootScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootScreen.swift
@@ -73,6 +73,7 @@ struct WorkRootSessionPresentationTaskKey: Equatable {
   let activeRosterRevision: Int
   let activeProjectId: String?
   let loadedProjectionProjectId: String?
+  let pendingLaneDeletionIds: Set<String>
 }
 
 struct WorkRootScreen: View {
@@ -290,7 +291,8 @@ struct WorkRootScreen: View {
       sessionOrganizationRaw: sessionOrganizationRaw,
       activeRosterRevision: syncService.rosterRevision(for: syncService.activeProject),
       activeProjectId: syncService.activeProjectId,
-      loadedProjectionProjectId: loadedProjectionProjectId
+      loadedProjectionProjectId: loadedProjectionProjectId,
+      pendingLaneDeletionIds: syncService.pendingLaneDeletionIds
     )
   }
 
@@ -400,8 +402,10 @@ struct WorkRootScreen: View {
             let rowCollapsedSectionIds = collapsedSectionIds
             let rowTopLevelDisplaySessionIds = sessionPresentation.topLevelDisplaySessionIds
             let rowChildGroupsByParentId = sessionPresentation.childGroupsByParentId
+            let rowDeletingLaneIds = syncService.pendingLaneDeletionIds
 
             ForEach(sessionGroups) { group in
+              let isLaneDeleting = group.laneId.map(rowDeletingLaneIds.contains) ?? false
               WorkSidebarSectionHeader(
                 group: group,
                 collapsed: rowCollapsedSectionIds.contains(group.id),
@@ -415,6 +419,8 @@ struct WorkRootScreen: View {
                   openLanePullRequest(tag: tag, laneId: group.laneId)
                 }
               )
+              .disabled(isLaneDeleting)
+              .redacted(reason: isLaneDeleting ? .placeholder : [])
               .id(group.id)
               .listRowBackground(Color.clear)
               .listRowSeparator(.hidden)
@@ -432,6 +438,7 @@ struct WorkRootScreen: View {
                       ?? rowPrTagsByLaneId[resolvedWorkNavigationLaneId(for: session, lanes: lanes)],
                     chatSummary: chatSummaries[session.id],
                     isArchived: rowArchivedSessionIds.contains(session.id),
+                    isLaneDeleting: rowDeletingLaneIds.contains(session.laneId),
                     transitionNamespace: ADEMotion.allowsMatchedGeometry(reduceMotion: reduceMotion) ? sessionTransitionNamespace : nil,
                     selectedSessionId: $selectedSessionTransitionId,
                     isSelecting: isSelecting,
@@ -471,6 +478,7 @@ struct WorkRootScreen: View {
                             ?? rowPrTagsByLaneId[resolvedWorkNavigationLaneId(for: child, lanes: lanes)],
                           chatSummary: chatSummaries[child.id],
                           isArchived: rowArchivedSessionIds.contains(child.id),
+                          isLaneDeleting: rowDeletingLaneIds.contains(child.laneId),
                           transitionNamespace: nil,
                           compact: true,
                           selectedSessionId: $selectedSessionTransitionId,

--- a/apps/ios/ADE/Views/Work/WorkSessionGrouping.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionGrouping.swift
@@ -228,7 +228,8 @@ func buildWorkRootSessionPresentation(
   organization: WorkSessionOrganization,
   orderedLanes: [LaneSummary],
   pullRequests: [PullRequestListItem] = [],
-  githubPrs: [GitHubPrListItem] = []
+  githubPrs: [GitHubPrListItem] = [],
+  deletingLaneIds: Set<String> = []
 ) -> WorkRootSessionPresentation {
   let committedIds = Set(sessions.map(\.id))
   let draftValues = optimisticSessions.values.filter { !committedIds.contains($0.id) }
@@ -300,7 +301,8 @@ func buildWorkRootSessionPresentation(
     chatSummaries: chatSummaries,
     statusBySessionId: statusBySessionId,
     archivedSessionIds: archivedSessionIds,
-    orderedLanes: workOrderedLanes
+    orderedLanes: workOrderedLanes,
+    deletingLaneIds: deletingLaneIds
   )
 
   return WorkRootSessionPresentation(
@@ -509,7 +511,8 @@ func workSessionGroups(
   chatSummaries: [String: AgentChatSessionSummary],
   statusBySessionId: [String: String] = [:],
   archivedSessionIds: Set<String>,
-  orderedLanes: [LaneSummary]
+  orderedLanes: [LaneSummary],
+  deletingLaneIds: Set<String> = []
 ) -> [WorkSessionGroup] {
   switch organization {
   case .byStatus:
@@ -522,7 +525,8 @@ func workSessionGroups(
   case .byLane:
     return workSessionGroupsByLane(
       sessions: sessions,
-      orderedLanes: orderedLanes
+      orderedLanes: orderedLanes,
+      deletingLaneIds: deletingLaneIds
     )
   case .byTime:
     return workSessionGroupsByTime(sessions: sessions)
@@ -595,7 +599,8 @@ func workSessionGroupsByStatus(
 
 func workSessionGroupsByLane(
   sessions: [TerminalSessionSummary],
-  orderedLanes: [LaneSummary]
+  orderedLanes: [LaneSummary],
+  deletingLaneIds: Set<String> = []
 ) -> [WorkSessionGroup] {
   var byLaneId: [String: [TerminalSessionSummary]] = [:]
   for session in sessions {
@@ -639,7 +644,9 @@ func workSessionGroupsByLane(
       return leftName.localizedCaseInsensitiveCompare(rightName) == .orderedAscending
     }
   for (laneId, list) in orphanEntries {
-    let label = orphanLabel(list.first?.laneName, fallback: laneId)
+    let label = deletingLaneIds.contains(laneId)
+      ? "Updating lane…"
+      : orphanLabel(list.first?.laneName, fallback: laneId)
     groups.append(WorkSessionGroup(id: "lane:\(laneId)", label: label, icon: .laneBranch, tint: ADEColor.textMuted, sessions: list))
   }
   return groups

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -13197,6 +13197,52 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(groups.last?.sessions.count, 2)
   }
 
+  func testWorkSessionGroupsByLaneShowsUpdatingPlaceholderForPendingLaneDeletion() {
+    let deletingSession = makeTerminalSessionSummary(
+      id: "session-deleting",
+      laneId: "lane-deleting",
+      laneName: "Feature cleanup",
+      toolType: "codex-chat",
+      startedAt: "2026-03-25T12:00:00.000Z"
+    )
+
+    let groups = workSessionGroupsByLane(
+      sessions: [deletingSession],
+      orderedLanes: [],
+      deletingLaneIds: ["lane-deleting"]
+    )
+
+    XCTAssertEqual(groups.map(\.id), ["lane:lane-deleting"])
+    XCTAssertEqual(groups.first?.label, "Updating lane…")
+  }
+
+  func testWorkRootPresentationForwardsPendingLaneDeletionToLaneGroups() {
+    let deletingSession = makeTerminalSessionSummary(
+      id: "session-deleting",
+      laneId: "lane-deleting",
+      laneName: "Feature cleanup",
+      toolType: "codex-chat",
+      startedAt: "2026-03-25T12:00:00.000Z"
+    )
+
+    let presentation = buildWorkRootSessionPresentation(
+      sessions: [deletingSession],
+      optimisticSessions: [:],
+      chatSummaries: [:],
+      archivedSessionIds: [],
+      selectedStatus: .all,
+      selectedLaneId: "all",
+      searchText: "",
+      organization: .byLane,
+      orderedLanes: [],
+      deletingLaneIds: ["lane-deleting"]
+    )
+
+    XCTAssertEqual(presentation.sessionGroups.map(\.id), ["lane:lane-deleting"])
+    XCTAssertEqual(presentation.sessionGroups.first?.label, "Updating lane…")
+    XCTAssertEqual(presentation.displaySessionIds, ["session-deleting"])
+  }
+
   func testWorkChatTranscriptPreservesReasoningIdentity() {
     let raw = """
     {"sessionId":"chat-1","timestamp":"2026-04-22T21:11:58.154Z","sequence":6,"event":{"type":"reasoning","text":"The user wants","turnId":"turn-1","itemId":"claude-thinking:turn-1:0","summaryIndex":0}}

--- a/docs/features/lanes/README.md
+++ b/docs/features/lanes/README.md
@@ -170,7 +170,14 @@ iOS companion (`apps/ios/ADE/Views/Lanes/`):
   its stack tab keeps the parent-lane picker, optional base-branch
   override, "Runs git rebase" disclosure, dirty/rebase-in-progress
   guards, and `lanes.reparent` payloads that omit `stackBaseBranchRef`
-  when the override is blank. `LaneDeeplinkHelpers.swift` mints the
+  when the override is blank. A confirmed delete dismisses the manage
+  sheet and lane detail immediately: `SyncService` retains the host
+  teardown task, publishes only the pending lane ids, and performs one
+  scoped snapshot refresh when it finishes. While pending, the Lanes
+  list removes the stale lane from navigation and the Work tab replaces
+  its lane-bound header and rows with a non-interactive updating state,
+  so long worktree cleanup never traps the user in the deletion UI or
+  causes polling-driven projection churn. `LaneDeeplinkHelpers.swift` mints the
   shareable `ade://lane/<id>` and
   `ade://repo/<owner>/<repo>/branch/<branch>` links the lane options
   menu copies to the pasteboard.

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -219,7 +219,9 @@ apps/ios/
 │   │                                # provider-aware scheduled-work cancel,
 │   │                                # machine project browse/open/create/clone,
 │   │                                # lane reparent stack-base override payloads,
-│   │                                # Linear read/launch RPC wrappers, worktree
+│   │                                # Linear read/launch RPC wrappers, retained
+│   │                                # background lane-deletion tasks + scoped
+│   │                                # completion refresh, worktree
 │   │                                # discovery, personal-chat cache/actions/
 │   │                                # subscription routing
 │   ├── Shared/


### PR DESCRIPTION
<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fstart-skill-work-then-run-353444c2 num=903 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fstart-skill-work-then-run-353444c2&amp;pr=903">ade/start-skill-work-then-run-353444c2 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=903">PR #903</a>
</p>
<!-- /ade:link -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves iOS lane deletion into a retained background flow. The main changes are:

- `SyncService` now owns lane deletion tasks and publishes pending lane IDs.
- Lanes UI hides pending-deletion lanes from navigation and shows scoped deletion failures.
- Work UI disables lane-bound headers and rows while deletion is in progress.
- Work session grouping labels deleting orphan lanes as updating.
- Tests and docs cover the new pending lane deletion behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changes are scoped to iOS UI state around lane deletion, keep host RPCs and refreshes project-scoped, and add targeted tests for the new Work grouping behavior.

**Files Needing Attention:** No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted the blocker harness but the initial run failed due to a shell substitution issue after recording missing tooling.
- The follow-up check confirmed the blocker status by showing that xcodebuild, xcrun, and swift were not available in the sandbox, each returning exit code 127.
- Because xcodebuild is unavailable in this sandbox, ADE XCTest target execution cannot run here; the next step is to rerun on macOS with Xcode using the preserved command.

<a href="https://app.greptile.com/trex/runs/15845450/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/ios/ADE/Services/SyncService.swift | Adds retained background lane deletion state, failure reporting, and scoped completion refresh for host-side cleanup. |
| apps/ios/ADE/Views/Lanes/LaneManageSheet.swift | Starts deletion through SyncService-owned background work and dismisses the manage UI immediately. |
| apps/ios/ADE/Views/LanesTabView.swift | Shows lane deletion failures and reacts to pending deletion IDs by pruning open and selected lanes. |
| apps/ios/ADE/Views/Work/WorkRootScreen+Actions.swift | Threads pending lane deletion IDs into work presentation rebuilds and hides deleting lanes from ordered lane metadata. |
| apps/ios/ADE/Views/Work/WorkRootScreen.swift | Includes pending deletion IDs in presentation invalidation and disables/redacts lane groups during deletion. |
| apps/ios/ADE/Views/Work/WorkSessionGrouping.swift | Carries deletion context through grouping and labels orphaned deleting-lane groups as updating. |
| apps/ios/ADETests/ADETests.swift | Adds tests covering pending lane deletion labels in lane grouping and presentation building. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User
  participant ManageSheet as LaneManageSheet
  participant SyncService
  participant Host as ADE brain
  participant LanesUI as Lanes tab
  participant WorkUI as Work tab

  User->>ManageSheet: Confirm lane deletion
  ManageSheet->>SyncService: beginLaneDeletion(laneId, options)
  SyncService->>SyncService: Publish pendingLaneDeletionIds
  SyncService-->>ManageSheet: Accepted
  ManageSheet-->>User: Dismiss sheet/detail
  SyncService->>Host: lanes.delete scoped to captured project
  SyncService-->>LanesUI: Pending lane removed from visible snapshots/navigation
  SyncService-->>WorkUI: Lane-bound groups/rows disabled as updating
  Host-->>SyncService: Delete success or failure
  alt failure
    SyncService->>SyncService: Store scoped laneDeletionFailure
    SyncService-->>LanesUI: Show deletion failure notice
  end
  SyncService->>Host: refreshLaneSnapshots(expectedScope)
  SyncService->>SyncService: Clear pending lane id
```

<sub>Reviews (1): Last reviewed commit: ["Fix mobile lane deletion navigation"](https://github.com/arul28/ade/commit/145f8068cf8523a48aed915a85902eb0b1ffe034) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47195236)</sub>

<!-- /greptile_comment -->