### PR TITLE
Shrink the new-chat ADE logo instead of clipping the hero column

### DIFF
--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -11934,15 +11934,22 @@ export function AgentChatPane({
                   >
                     <div className={cn(
                       "flex min-h-0 flex-1 items-center justify-center overflow-hidden",
-                      appPanelOpen ? "px-3" : "px-6 pb-24",
+                      // The optical lift lives in the padding rather than a negative margin on the
+                      // column, so `max-h-full` below can cap the column without clipping its top.
+                      // 136px = the previous pb-24 (96px) + the removed -mt-10 lift (40px), which
+                      // keeps the resting position pixel-identical whenever there is room to spare.
+                      appPanelOpen ? "px-3" : "px-6 pb-[136px]",
                     )}>
                       <div className={cn(
-                        "flex w-full flex-col items-center gap-3 text-center",
-                        appPanelOpen ? null : "-mt-10 max-w-[820px]",
+                        "flex max-h-full w-full flex-col items-center gap-3 text-center",
+                        appPanelOpen ? null : "max-w-[820px]",
                       )}>
                         <motion.div
                           className={cn(
-                            "relative flex w-full min-w-0 items-center justify-center",
+                            // The logo is the only flexible row: in a short window it absorbs the
+                            // overflow down to a legible floor, so the composer stays visible far
+                            // longer than it did when the whole column was rigid.
+                            "relative flex min-h-[56px] w-full min-w-0 shrink items-center justify-center",
                             appPanelOpen ? "max-w-[360px]" : "max-w-[520px]",
                           )}
                           style={{ aspectRatio: "560 / 300" }}
@@ -11955,14 +11962,14 @@ export function AgentChatPane({
                           />
                         </motion.div>
 
-                        <h2 className="font-sans text-[18px] font-semibold tracking-tight text-fg/80">
+                        <h2 className="shrink-0 font-sans text-[18px] font-semibold tracking-tight text-fg/80">
                           {isOrchestratorDraft ? "Orchestrate a swarm of agents" : "Start a new conversation"}
                         </h2>
 
                         {/* Lane selector pill */}
                         {showWorkspaceChrome && draftLaneSelectorLanes.length > 0 && onLaneChange ? (
                           <motion.div
-                            className="flex justify-center"
+                            className="flex shrink-0 justify-center"
                             exit={{ opacity: 0, transition: { duration: 0.15 } }}
                           >
                             <div className="flex flex-col items-center gap-2">
@@ -12023,7 +12030,7 @@ export function AgentChatPane({
                           </motion.div>
                         ) : showWorkspaceChrome && laneDisplayLabel ? (
                           <motion.div
-                            className="flex items-center gap-2 rounded-full px-4 py-1.5"
+                            className="flex shrink-0 items-center gap-2 rounded-full px-4 py-1.5"
                             style={{ background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.08)" }}
                             exit={{ opacity: 0, transition: { duration: 0.15 } }}
                           >
@@ -12043,14 +12050,14 @@ export function AgentChatPane({
 
                         {/* Inline composer for empty state (only when sim drawer closed) */}
                         {!appPanelOpen ? (
-                          <div className="w-full max-w-[820px]">
+                          <div className="w-full shrink-0">
                             {composerWithTypographyRoot}
                           </div>
                         ) : null}
 
                         {isWorkDraftComposer && !appPanelOpen ? (
                           <motion.div
-                            className="flex w-full justify-center"
+                            className="flex w-full shrink-0 justify-center"
                             initial={{ opacity: 0, y: 8 }}
                             animate={{ opacity: 1, y: 0 }}
                             exit={{ opacity: 0, y: 6 }}

--- a/docs/features/chat/composer-and-ui.md
+++ b/docs/features/chat/composer-and-ui.md
@@ -982,6 +982,15 @@ These modules are pure and unit-testable:
   immediately re-persist with a new timestamp. Normalization
   (`normalizeStoredComposerDraft`) validates every field defensively
   so corrupt stored data degrades gracefully instead of crashing.
+- **Empty-state hero column.** The new-chat hero column in
+  `AgentChatPane` lives in an `overflow-hidden` wrapper and caps itself
+  with `max-h-full`, so exactly one row — the ADE logo — may be
+  flexible; every sibling (heading, lane pill, inline composer, extras)
+  must be `shrink-0`, and the logo keeps a `min-h` floor so it shrinks
+  instead of the column overflowing and clipping top and bottom in a
+  short window. The optical lift is wrapper padding, not a negative
+  margin on the column: a negative margin escapes the `max-h-full` cap
+  and reintroduces the clipping.
 - **Session creation and first turn race.** When a new session is
   created from the composer, the pane awaits the `onSessionCreated`
   callback and the session-list refresh before sending the first agent


### PR DESCRIPTION
## The bug

In the new-chat pane, making the ADE window shorter clipped the hero content at **both** ends — the top of the ADE logo and the bottom of the activity module — instead of the logo scaling down.

Two things combined to cause it:

- The logo box is `aspect-ratio: 560/300` + `w-full`, so its height is purely **width**-derived and never responds to vertical space.
- The hero column had no definite height (it's a flex item under `items-center`, sized to content), so `flex-shrink` never engaged on anything. The column simply overflowed its `overflow-hidden` wrapper.

## The fix

Make the logo the **one flexible row**:

- Column caps itself with `max-h-full`; every sibling row gets `shrink-0`.
- Logo gets an explicit `min-h-[56px]`. This is what actually enables shrinking — it overrides the `min-height: auto` automatic minimum that an aspect-ratio box transfers from its width (~278px at `max-w-[520px]`). The `<img>` is already `object-contain max-h-full`, so it letterboxes rather than distorting.
- The optical lift moves from `-mt-10` on the column into the wrapper's padding (`pb-24` → `pb-[136px]`, i.e. 96 + 40). A negative margin escapes the `max-h-full` cap and would push the column's top back out of the clip, so the two are fundamentally incompatible.

With `align-items: center` a `-40px` margin-top yields a **20px** effective lift, and the padding form reproduces the resting position exactly.

## Verification

Driven against the real renderer via CDP at several viewport sizes:

| Viewport | Before | After |
|---|---|---|
| 1400×1000 (roomy) | baseline | **pixel-identical** (image diff bbox: none) |
| 1100×640 (short) | logo clipped at top, activity clipped at bottom | logo shrinks, everything fits |
| 1000×500 (extreme) | badly clipped | logo holds its 56px floor, composer stays visible |

Before/after screenshots are attached to the ADE proof drawer for this lane.

## Notes

- `/quality` dual-review: 0 Blocker / 0 High / 0 Medium. Three Low findings applied (removed a provably-dead duplicate `max-w-[820px]`, recorded the 96+40 provenance, softened an overstated comment).
- `/test`: no tests added — the change is purely visual and jsdom performs no layout, so a vitest test cannot observe `flex-shrink`; a class-name assertion would be a brittle render-only test. Existing coverage green: 38 files / 832 tests in `src/renderer/components/chat`.
- iOS needs nothing: `WorkNewChatScreen.swift` already puts the hero in a `ScrollView` with the composer pinned as a sibling, and the brand mark uses `.resizable().scaledToFit()` with `maxWidth`.
- Docs: recorded the one-flexible-row invariant in `docs/features/chat/composer-and-ui.md`'s fragile-wiring section, since a future editor adding a row without `shrink-0` would silently reintroduce this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the new-chat layout for improved spacing and visual balance when side panels are open.
  * Improved empty-state title and lane selector presentation.
  * Stabilized composer and lane chip sizing across different panel states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the new-chat empty-state layout so the ADE logo flexibly shrinks in short panes while the heading, lane controls, composer, and activity content retain their intended sizes.
- Replaces the negative vertical margin with equivalent wrapper padding.
- Caps the hero column height and gives the logo a 56px minimum height.
- Documents the empty-state hero column’s flex-sizing invariant.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The layout retains the prior optical offset while adding a definite height cap and allowing only the logo to absorb reduced vertical space; the accompanying documentation accurately describes that behavior.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P2 finding and linked it to the corresponding review comment.
- Contract-validation verified UI changes by comparing pre-change and post-change layouts at 1440x480 and 1440x900; the logo was clipped before and visible after, and the heading, lane selector, composer, and Activity module were visible after the change, with the heading and other elements shifting upward by about 39px at 1440x900.

<a href="https://app.greptile.com/trex/runs/15983054/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/desktop/src/renderer/components/chat/AgentChatPane.tsx | Refines the empty-state hero’s flex sizing to preserve the composer and other fixed-height controls in shorter panes. |
| docs/features/chat/composer-and-ui.md | Documents the hero column’s single-flexible-row layout and avoidance of negative margins. |


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Normal-height hero content shifts upward and the logo shrinks**

   - **Bug**
     - At the tested normal 1440×900 viewport, the changed layout does not preserve the prior resting position. The heading moves from y=383.3 to y=344, with the lane selector, composer, and Activity module receiving the same approximately 39px upward shift. The visible hero logo also shrinks from 253.3px to 200px high.
   - **Cause**
     - The new `max-h-full` column and `pb-[136px]` reserve enough vertical space that the logo's `shrink` behavior is already activated at 900px. Consequently, the intended short-window compression affects a normal-height window as well.
   - **Fix**
     - Apply the shrink/capped-column behavior only below the constrained-height threshold, or revise the available-height/padding calculation so a 900px viewport retains the previous logo size and element coordinates while shorter viewports still allow only the logo row to shrink.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Shrink the new-chat ADE logo instead of ..."](https://github.com/arul28/ade/commit/1e3af8310048f031b5ddca525044b4b1233faa1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47498745)</sub>

<!-- /greptile_comment -->