### PR TITLE
Restore chat minimap tick visibility

### DIFF
--- a/apps/desktop/src/renderer/components/chat/ChatUserMinimap.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatUserMinimap.test.tsx
@@ -1,0 +1,67 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useAppStore } from "../../state/appStore";
+import { ChatUserMinimap } from "./ChatUserMinimap";
+import type { ChatUserMinimapSourceEntry } from "./chatUserMinimap.logic";
+
+const ENTRIES: readonly ChatUserMinimapSourceEntry[] = [
+  {
+    rowIndex: 0,
+    key: "first",
+    preview: "First checkpoint",
+    fullUserOrdinal: 0,
+    assistantPreview: "Acknowledged.",
+    turnOutcome: null,
+  },
+  {
+    rowIndex: 2,
+    key: "second",
+    preview: "Second checkpoint",
+    fullUserOrdinal: 1,
+    assistantPreview: "Shipped it.",
+    turnOutcome: null,
+  },
+];
+
+const originalMinimapEnabled = useAppStore.getState().chatUserMinimapEnabled;
+
+beforeEach(() => {
+  useAppStore.setState({ chatUserMinimapEnabled: true });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  useAppStore.setState({ chatUserMinimapEnabled: originalMinimapEnabled });
+});
+
+describe("ChatUserMinimap", () => {
+  it("keeps resting and hovered ticks visible against the chat canvas", () => {
+    const view = render(
+      <ChatUserMinimap
+        entries={ENTRIES}
+        activeIndex={null}
+        onJumpToRow={vi.fn()}
+        listWidthPx={960}
+        listHeightPx={600}
+        listTopViewportPx={0}
+        columnWidthPx={720}
+      />,
+    );
+
+    const rail = screen.getByRole("button", { name: "Jump to message: User message" });
+    vi.spyOn(rail, "getBoundingClientRect").mockReturnValue(new DOMRect(0, 100, 24, 400));
+
+    const ticks = [...view.container.querySelectorAll<HTMLElement>("[data-minimap-tick]")];
+    const hoveredTick = ticks.at(1);
+    expect(ticks).toHaveLength(2);
+    expect(hoveredTick?.className).toContain("bg-[var(--color-fg)]/30");
+
+    fireEvent.mouseMove(rail, { clientY: 500 });
+
+    expect(hoveredTick?.className).toContain("bg-[var(--color-fg)]/75");
+    expect(hoveredTick?.className).toContain("w-6");
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/ChatUserMinimap.tsx
+++ b/apps/desktop/src/renderer/components/chat/ChatUserMinimap.tsx
@@ -56,8 +56,8 @@ function tickToneClass(
   if (outcome === "failed") return "bg-red-400/80";
   if (outcome === "interrupted") return "bg-amber-400/70";
   if (isActive) return "bg-[var(--chat-accent)]";
-  if (isLensCentre) return "bg-fg/75";
-  return "bg-fg/30";
+  if (isLensCentre) return "bg-[var(--color-fg)]/75";
+  return "bg-[var(--color-fg)]/30";
 }
 
 /** Human label for a non-`completed` turn; `null` means nothing to surface. */
@@ -222,6 +222,7 @@ export function ChatUserMinimap({
               <span
                 key={entry.key}
                 aria-hidden="true"
+                data-minimap-tick=""
                 data-outcome={outcome ?? undefined}
                 className={cn(
                   "pointer-events-none absolute left-0 -translate-y-1/2 rounded-full transition-[background-color,width] duration-150",


### PR DESCRIPTION
## Summary

- restore theme-aware resting and hover colors for the Work chat user-message minimap ticks
- keep the existing magnetic width animation readable on dark chat canvases
- add a focused interaction regression test for resting, hovered, and expanded tick states

## Validation

- quality dual-review: clean after re-review
- focused renderer tests: 126 passed
- CI-mirrored desktop shard 3/8: 925 passed

[ADE PR view](https://ade-app.dev/open?type=pr&repo=arul28%2FADE&number=922)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved chat minimap tick visibility and contrast.
  * Centered ticks now appear more prominent, while other ticks use a subtler appearance.
  * Added clearer hover feedback, including a darker color and wider active tick.

* **Tests**
  * Added coverage verifying minimap rendering, tick counts, initial hover state, and pointer interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->