### PR TITLE
Fix remote D1 migration splitting

### DIFF
--- a/apps/push-relay/migrations/0003_account_attention.sql
+++ b/apps/push-relay/migrations/0003_account_attention.sql
@@ -101,7 +101,7 @@ and (
 ) >= 32
 begin
   select raise(abort, 'attention account device limit reached');
-end;
+END;
 
 -- Durable ownership survives attention_devices deletion so delayed requests
 -- from a previous account cannot reclaim or remove a switched installation.
@@ -140,7 +140,7 @@ when exists (
 )
 begin
   select raise(abort, 'stale attention device ownership');
-end;
+END;
 
 create table if not exists attention_activity_tokens (
   user_id text not null,

--- a/apps/push-relay/package.json
+++ b/apps/push-relay/package.json
@@ -5,11 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "npm run d1:migrate:remote && wrangler deploy",
+    "deploy": "npm run validate:migrations && npm run d1:migrate:remote && wrangler deploy",
     "d1:migrate:local": "wrangler d1 migrations apply ade-push-relay --local",
     "d1:migrate:remote": "wrangler d1 migrations apply ade-push-relay --remote",
-    "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "test": "npm run validate:migrations && vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "validate:migrations": "node scripts/validate-d1-migrations.mjs"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260620.0",

--- a/apps/push-relay/scripts/validate-d1-migrations.mjs
+++ b/apps/push-relay/scripts/validate-d1-migrations.mjs
@@ -1,0 +1,59 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { unstable_splitSqlQuery } from "wrangler";
+
+const migrationsDirectory = path.join(import.meta.dirname, "..", "migrations");
+const migrationNames = fs
+  .readdirSync(migrationsDirectory)
+  .filter((name) => name.endsWith(".sql"))
+  .sort();
+
+const database = new DatabaseSync(":memory:");
+
+try {
+  for (const migrationName of migrationNames) {
+    const sql = fs.readFileSync(
+      path.join(migrationsDirectory, migrationName),
+      "utf8",
+    );
+    const statements = unstable_splitSqlQuery(sql);
+
+    for (const statement of statements) {
+      const triggerCount =
+        statement.match(/\bcreate\s+trigger\b/giu)?.length ?? 0;
+
+      if (triggerCount > 1) {
+        throw new Error(
+          `${migrationName} contains multiple triggers in one Wrangler query`,
+        );
+      }
+
+      if (triggerCount === 1 && !/\bEND\s*$/u.test(statement.trim())) {
+        throw new Error(
+          `${migrationName} contains a trigger Wrangler cannot split safely for D1 migration execution`,
+        );
+      }
+
+      database.exec(statement);
+    }
+  }
+
+  const triggerCount = database
+    .prepare(
+      "select count(*) as count from sqlite_master where type = 'trigger'",
+    )
+    .get().count;
+
+  if (triggerCount !== 2) {
+    throw new Error(
+      `Expected 2 D1 triggers after migrations, found ${triggerCount}`,
+    );
+  }
+
+  console.log(
+    `Validated ${migrationNames.length} D1 migrations with Wrangler's query splitter`,
+  );
+} finally {
+  database.close();
+}


### PR DESCRIPTION
## Summary

- use Wrangler-compatible uppercase `END` trigger terminators in the account attention migration
- validate every D1 migration with Wrangler’s SQL splitter and SQLite before tests or deployment
- fail deployment before touching remote D1 when a compound trigger is not safely split

## Verification

- `npm run validate:migrations`
- `npm run typecheck`
- all four migrations applied successfully to a fresh local D1 database
- regression probe: broken form splits into 16 statements; fixed form splits into 26 with two isolated triggers

[Open in ADE](https://ade-app.dev/open?type=pr&repo=arul28%2FADE&number=934)