### PR TITLE
Install D1 triggers through file ingestion

### DIFF
--- a/apps/push-relay/README.md
+++ b/apps/push-relay/README.md
@@ -125,7 +125,8 @@ npm install
 # One-time: create the D1 database and paste the id into wrangler.jsonc
 npx wrangler d1 create ade-push-relay
 
-npm run d1:migrate:remote
+# Validates the schema, applies D1 migrations and trigger enforcement, then
+# deploys the Worker.
 npm run deploy
 ```
 

--- a/apps/push-relay/migrations/0003_account_attention.sql
+++ b/apps/push-relay/migrations/0003_account_attention.sql
@@ -87,22 +87,6 @@ create unique index if not exists idx_attention_devices_unique_apns_token
   on attention_devices(apns_token)
   where apns_token is not null;
 
-create trigger if not exists attention_devices_enforce_user_limit
-before insert on attention_devices
-when not exists (
-  select 1
-  from attention_devices
-  where user_id = new.user_id and device_id = new.device_id
-)
-and (
-  select count(*)
-  from attention_devices
-  where user_id = new.user_id
-) >= 32
-begin
-  select raise(abort, 'attention account device limit reached');
-END;
-
 -- Durable ownership survives attention_devices deletion so delayed requests
 -- from a previous account cannot reclaim or remove a switched installation.
 create table if not exists attention_device_ownership (
@@ -117,30 +101,6 @@ create table if not exists attention_device_ownership (
 create unique index if not exists idx_attention_device_ownership_apns_token
   on attention_device_ownership(apns_token)
   where apns_token is not null;
-
-create trigger if not exists attention_device_ownership_reject_stale
-before insert on attention_device_ownership
-when exists (
-  select 1
-  from attention_device_ownership as current
-  where (
-    current.device_id = new.device_id
-    or (
-      new.apns_token is not null
-      and current.apns_token = new.apns_token
-    )
-  )
-  and (
-    current.ownership_epoch > new.ownership_epoch
-    or (
-      current.ownership_epoch = new.ownership_epoch
-      and current.user_id <> new.user_id
-    )
-  )
-)
-begin
-  select raise(abort, 'stale attention device ownership');
-END;
 
 create table if not exists attention_activity_tokens (
   user_id text not null,

--- a/apps/push-relay/package.json
+++ b/apps/push-relay/package.json
@@ -6,8 +6,12 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "npm run validate:migrations && npm run d1:migrate:remote && wrangler deploy",
-    "d1:migrate:local": "wrangler d1 migrations apply ade-push-relay --local",
-    "d1:migrate:remote": "wrangler d1 migrations apply ade-push-relay --remote",
+    "d1:migrations:local": "wrangler d1 migrations apply ade-push-relay --local",
+    "d1:migrations:remote": "wrangler d1 migrations apply ade-push-relay --remote",
+    "d1:migrate:local": "npm run d1:migrations:local && npm run d1:triggers:local",
+    "d1:migrate:remote": "npm run d1:migrations:remote && npm run d1:triggers:remote",
+    "d1:triggers:local": "wrangler d1 execute ade-push-relay --local --file=./schema/attention_triggers.sql --yes",
+    "d1:triggers:remote": "wrangler d1 execute ade-push-relay --remote --file=./schema/attention_triggers.sql --yes",
     "test": "npm run validate:migrations && vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "validate:migrations": "node scripts/validate-d1-migrations.mjs"

--- a/apps/push-relay/schema/attention_triggers.sql
+++ b/apps/push-relay/schema/attention_triggers.sql
@@ -1,0 +1,42 @@
+-- Wrangler applies remote migrations through D1's query endpoint, whose
+-- multi-statement parser cannot preserve trigger-body semicolons. This
+-- idempotent sidecar is installed through D1's SQL file ingestion endpoint.
+create trigger if not exists attention_devices_enforce_user_limit
+before insert on attention_devices
+when not exists (
+  select 1
+  from attention_devices
+  where user_id = new.user_id and device_id = new.device_id
+)
+and (
+  select count(*)
+  from attention_devices
+  where user_id = new.user_id
+) >= 32
+begin
+  select raise(abort, 'attention account device limit reached');
+end;
+
+create trigger if not exists attention_device_ownership_reject_stale
+before insert on attention_device_ownership
+when exists (
+  select 1
+  from attention_device_ownership as current
+  where (
+    current.device_id = new.device_id
+    or (
+      new.apns_token is not null
+      and current.apns_token = new.apns_token
+    )
+  )
+  and (
+    current.ownership_epoch > new.ownership_epoch
+    or (
+      current.ownership_epoch = new.ownership_epoch
+      and current.user_id <> new.user_id
+    )
+  )
+)
+begin
+  select raise(abort, 'stale attention device ownership');
+end;

--- a/apps/push-relay/scripts/validate-d1-migrations.mjs
+++ b/apps/push-relay/scripts/validate-d1-migrations.mjs
@@ -1,9 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { unstable_splitSqlQuery } from "wrangler";
 
 const migrationsDirectory = path.join(import.meta.dirname, "..", "migrations");
+const triggersPath = path.join(
+  import.meta.dirname,
+  "..",
+  "schema",
+  "attention_triggers.sql",
+);
 const migrationNames = fs
   .readdirSync(migrationsDirectory)
   .filter((name) => name.endsWith(".sql"))
@@ -11,48 +16,99 @@ const migrationNames = fs
 
 const database = new DatabaseSync(":memory:");
 
+function expectSqliteError(callback, expectedMessage) {
+  try {
+    callback();
+  } catch (error) {
+    if (error instanceof Error && error.message.includes(expectedMessage)) {
+      return;
+    }
+    throw error;
+  }
+  throw new Error(`Expected SQLite error containing "${expectedMessage}"`);
+}
+
 try {
   for (const migrationName of migrationNames) {
     const sql = fs.readFileSync(
       path.join(migrationsDirectory, migrationName),
       "utf8",
     );
-    const statements = unstable_splitSqlQuery(sql);
-
-    for (const statement of statements) {
-      const triggerCount =
-        statement.match(/\bcreate\s+trigger\b/giu)?.length ?? 0;
-
-      if (triggerCount > 1) {
-        throw new Error(
-          `${migrationName} contains multiple triggers in one Wrangler query`,
-        );
-      }
-
-      if (triggerCount === 1 && !/\bEND\s*$/u.test(statement.trim())) {
-        throw new Error(
-          `${migrationName} contains a trigger Wrangler cannot split safely for D1 migration execution`,
-        );
-      }
-
-      database.exec(statement);
+    if (/\bcreate\s+trigger\b/iu.test(sql)) {
+      throw new Error(
+        `${migrationName} contains a trigger that D1's remote migration query cannot parse`,
+      );
     }
+    database.exec(sql);
   }
 
-  const triggerCount = database
-    .prepare(
-      "select count(*) as count from sqlite_master where type = 'trigger'",
-    )
-    .get().count;
+  database.exec(fs.readFileSync(triggersPath, "utf8"));
 
-  if (triggerCount !== 2) {
+  const triggerNames = database
+    .prepare(
+      "select name from sqlite_master where type = 'trigger' order by name",
+    )
+    .all()
+    .map(({ name }) => name);
+
+  const expectedTriggerNames = [
+    "attention_device_ownership_reject_stale",
+    "attention_devices_enforce_user_limit",
+  ];
+  if (JSON.stringify(triggerNames) !== JSON.stringify(expectedTriggerNames)) {
     throw new Error(
-      `Expected 2 D1 triggers after migrations, found ${triggerCount}`,
+      `Unexpected D1 triggers after schema install: ${triggerNames.join(", ")}`,
     );
   }
 
+  const insertDevice = database.prepare(`
+    insert into attention_devices(
+      user_id, device_id, bundle_id, aps_environment, preferences_json,
+      registered_at, updated_at, lease_expires_at
+    ) values (?, ?, 'com.ade.ios', 'production', '{}', ?, ?, ?)
+  `);
+  const timestamp = "2026-07-28T00:00:00.000Z";
+  for (let index = 0; index < 32; index += 1) {
+    insertDevice.run(
+      "user-limit",
+      `device-${index}`,
+      timestamp,
+      timestamp,
+      timestamp,
+    );
+  }
+  expectSqliteError(
+    () =>
+      insertDevice.run(
+        "user-limit",
+        "device-over-limit",
+        timestamp,
+        timestamp,
+        timestamp,
+      ),
+    "attention account device limit reached",
+  );
+
+  const insertOwnership = database.prepare(`
+    insert into attention_device_ownership(
+      device_id, user_id, ownership_epoch, apns_token, active, updated_at
+    ) values (?, ?, ?, ?, 1, ?)
+  `);
+  insertOwnership.run("owned-device", "current-user", 2, "owned-token", timestamp);
+  expectSqliteError(
+    () =>
+      insertOwnership.run(
+        "owned-device",
+        "stale-user",
+        2,
+        "new-token",
+        timestamp,
+      ),
+    "stale attention device ownership",
+  );
+
   console.log(
-    `Validated ${migrationNames.length} D1 migrations with Wrangler's query splitter`,
+    `Validated ${migrationNames.length} remote-safe D1 migrations and ${triggerNames.length} enforced triggers`,
   );
 } finally {
   database.close();

--- a/apps/push-relay/test/attention.test.ts
+++ b/apps/push-relay/test/attention.test.ts
@@ -85,6 +85,12 @@ class SqliteD1Database {
       ]) {
         this.native.exec(readFileSync(new URL(migration, import.meta.url), "utf8"));
       }
+      this.native.exec(
+        readFileSync(
+          new URL("../schema/attention_triggers.sql", import.meta.url),
+          "utf8",
+        ),
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

- keep numbered D1 migrations compatible with Wrangler’s remote query endpoint
- install account-attention triggers through D1’s SQL file-ingestion endpoint before Worker deployment
- validate both migration safety and the live trigger enforcement contracts
- keep local and remote schema installation paths identical

## Root cause

Remote `wrangler d1 migrations apply` posts each whole migration to D1 `/query`; that parser splits the required semicolon inside `CREATE TRIGGER ... BEGIN ... END`, producing `incomplete input`. Remote `wrangler d1 execute --file` uses the supported import/ingest endpoint instead.

## Verification

- `npm run validate:migrations`
- `npm run typecheck`
- all numbered migrations applied to a fresh local D1 store
- trigger sidecar ingested successfully into the same store
- validator proves 33rd-device and stale-ownership inserts abort

[Open in ADE](https://ade-app.dev/open?type=pr&repo=arul28%2FADE&number=935)