### PR TITLE
Fix iOS same-account adoption cipher negotiation

### DIFF
--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -2243,6 +2243,40 @@ describe("sync host account authentication", () => {
         message: expect.stringMatching(/expired/i),
       });
 
+      const corruptClient = await openAccountClient(port);
+      clients.push(corruptClient);
+      await issueChallenge(corruptClient, "corrupt-sealed-challenge");
+      corruptClient.ws.send(encodeSyncEnvelope({
+        type: "hello",
+        requestId: "corrupt-sealed-hello",
+        payload: {
+          peer: { ...peer, deviceId: "corrupt-sealed-device" },
+          auth: {
+            kind: "account_sealed",
+            v: 1,
+            deviceId: "corrupt-sealed-device",
+            sealed: Buffer.alloc(28).toString("base64"),
+          },
+        },
+      }));
+      const corruptSealed = await waitForValue(
+        () => corruptClient.envelopes.find((entry) =>
+          entry.type === "hello_error" && entry.requestId === "corrupt-sealed-hello"
+        ),
+        "corrupt sealed hello rejection",
+      );
+      expect(corruptSealed.payload).toMatchObject({
+        code: "invalid_hello",
+        message: expect.stringMatching(/could not be opened/i),
+      });
+      expect(baseArgs.logger.warn).toHaveBeenCalledWith(
+        "sync_host.account_sealed_open_failed",
+        expect.objectContaining({
+          aead: "chacha20-poly1305",
+          transportOrigin: "direct",
+        }),
+      );
+
       const incompatibleClient = await openAccountClient(port);
       clients.push(incompatibleClient);
       const incompatibleEphemeral = generateX25519EphemeralKeyPair();
@@ -2266,11 +2300,32 @@ describe("sync host account authentication", () => {
       );
       expect(incompatible.payload).toEqual({
         message:
-          "No compatible account adoption cipher is available. Update ADE on both Macs.",
+          "No compatible account adoption cipher is available. Update ADE on both devices.",
       });
       expect(incompatibleClient.envelopes.some(
         (entry) => entry.type === "account_challenge_ok",
       )).toBe(false);
+      incompatibleClient.ws.send(encodeSyncEnvelope({
+        type: "account_challenge",
+        requestId: "incompatible-aead-repeat",
+        payload: {
+          v: 1,
+          nonce: Buffer.alloc(32, 12).toString("base64"),
+          clientEphemeralPublicKey:
+            incompatibleEphemeral.publicKeyRaw.toString("base64"),
+          supportedAeads: ["future-aead"],
+        },
+      }));
+      await waitForValue(
+        () => incompatibleClient.envelopes.find((entry) =>
+          entry.type === "account_challenge_error"
+          && entry.requestId === "incompatible-aead-repeat"
+        ),
+        "repeated incompatible AEAD rejection",
+      );
+      expect(baseArgs.logger.warn.mock.calls.filter(
+        ([event]) => event === "sync_host.account_challenge_cipher_incompatible",
+      )).toHaveLength(1);
 
       // Well-formed challenges only trigger a public signature and are the
       // normal adoption operation, so they must NEVER trip the abuse throttle —

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -165,6 +165,7 @@ import {
   decodeCanonicalBase64,
   deriveAdoptSessionKey,
   generateX25519EphemeralKeyPair,
+  negotiateAdoptChannelAead,
   seal,
   signEd25519,
   supportedAdoptChannelAeads,
@@ -588,6 +589,7 @@ type PeerState = {
   framesReceived: number;
   transportOrigin: SyncTransportOrigin;
   relayAuthorization: RelayAuthorizationLifecycle | null;
+  reportedIncompatibleAdoptCipher: boolean;
   adoptChallenge: {
     sessionKey: Buffer;
     nonce: string;
@@ -3246,6 +3248,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
       remotePort,
       transportOrigin,
       relayAuthorization: null,
+      reportedIncompatibleAdoptCipher: false,
       adoptChallenge: null,
       subscribedSessionIds: new Set(),
       pendingTerminalSnapshots: new Map(),
@@ -6586,18 +6589,27 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
           return;
         }
         const hostSupportedAeads = supportedAdoptChannelAeads();
-        const negotiatedAead = challenge.supportedAeads?.find(
-          (aead): aead is AdoptChannelAead =>
-            hostSupportedAeads.includes(aead as AdoptChannelAead),
+        const adoptAead = negotiateAdoptChannelAead(
+          challenge.supportedAeads,
+          hostSupportedAeads,
         );
-        if (challenge.supportedAeads !== null && !negotiatedAead) {
+        if (!adoptAead) {
+          if (!peer.reportedIncompatibleAdoptCipher) {
+            peer.reportedIncompatibleAdoptCipher = true;
+            args.logger.warn("sync_host.account_challenge_cipher_incompatible", {
+              remoteAddress: peer.remoteAddress,
+              transportOrigin: peer.transportOrigin,
+              clientAdvertisedAeads: challenge.supportedAeads !== null,
+              clientAeadCount: challenge.supportedAeads?.length ?? 0,
+              hostSupportedAeads,
+            });
+          }
           send(peer.ws, "account_challenge_error", {
             message:
-              "No compatible account adoption cipher is available. Update ADE on both Macs.",
+              "No compatible account adoption cipher is available. Update ADE on both devices.",
           }, envelope.requestId);
           return;
         }
-        const adoptAead = negotiatedAead ?? "chacha20-poly1305";
         // A well-formed challenge only triggers one public signature and is the
         // normal adoption operation, so it feeds no cooldown at all. Signing
         // load is already bounded by the per-connection single-active-challenge
@@ -6620,7 +6632,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
             clientEphemeralPublicKey: challenge.clientEphemeralPublicKey,
             hostEphemeralPublicKey,
             ts,
-            ...(negotiatedAead ? { aead: negotiatedAead } : {}),
+            ...(challenge.supportedAeads !== null ? { aead: adoptAead } : {}),
           });
           const sessionKey = deriveAdoptSessionKey({
             privateKey: hostEphemeral.privateKey,
@@ -6640,7 +6652,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
             ts,
             hostEphemeralPublicKey,
             signature: signEd25519(identity.privateKey, canonical).toString("base64"),
-            ...(negotiatedAead ? { aead: negotiatedAead } : {}),
+            ...(challenge.supportedAeads !== null ? { aead: adoptAead } : {}),
           }, envelope.requestId);
         } catch (error) {
           peer.adoptChallenge = null;
@@ -6868,7 +6880,21 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
             clientDeviceId: sealedAuth.deviceId,
             aead: challenge.aead,
           };
-        } catch {
+        } catch (error) {
+          const errorCode =
+            error !== null
+            && typeof error === "object"
+            && "code" in error
+            && typeof error.code === "string"
+              ? error.code
+              : null;
+          args.logger.warn("sync_host.account_sealed_open_failed", {
+            remoteAddress: peer.remoteAddress,
+            transportOrigin: peer.transportOrigin,
+            aead: challenge.aead,
+            errorName: error instanceof Error ? error.name : "UnknownError",
+            errorCode,
+          });
           rejectSealedHello("The sealed account credentials could not be opened.");
           return;
         }

--- a/apps/desktop/src/shared/sync/adoptChannelCrypto.test.ts
+++ b/apps/desktop/src/shared/sync/adoptChannelCrypto.test.ts
@@ -9,6 +9,7 @@ import {
   buildAdoptChallengeSignatureInput,
   deriveAdoptSessionKey,
   generateX25519EphemeralKeyPair,
+  negotiateAdoptChannelAead,
   rawPublicKeyFromSpki,
   seal,
   signEd25519,
@@ -17,6 +18,17 @@ import {
 } from "./adoptChannelCrypto";
 
 describe("adoptChannelCrypto", () => {
+  it("negotiates the first client AEAD supported by the host", () => {
+    expect(negotiateAdoptChannelAead(
+      ["chacha20-poly1305", "aes-256-gcm"],
+      ["aes-256-gcm"],
+    )).toBe("aes-256-gcm");
+    expect(negotiateAdoptChannelAead(
+      null,
+      ["aes-256-gcm"],
+    )).toBeNull();
+  });
+
   it("derives the same session key and seals/unseals a payload", () => {
     const client = generateX25519EphemeralKeyPair();
     const host = generateX25519EphemeralKeyPair();

--- a/apps/desktop/src/shared/sync/adoptChannelCrypto.ts
+++ b/apps/desktop/src/shared/sync/adoptChannelCrypto.ts
@@ -188,6 +188,16 @@ export function supportedAdoptChannelAeads(): AdoptChannelAead[] {
   return [...cachedSupportedAdoptChannelAeads];
 }
 
+export function negotiateAdoptChannelAead(
+  clientSupportedAeads: readonly string[] | null,
+  hostSupportedAeads: readonly AdoptChannelAead[],
+): AdoptChannelAead | null {
+  const clientChoices = clientSupportedAeads ?? ["chacha20-poly1305"];
+  return clientChoices.find((aead): aead is AdoptChannelAead =>
+    hostSupportedAeads.some((supported) => supported === aead)
+  ) ?? null;
+}
+
 export function seal(
   key: Buffer,
   aad: Buffer,

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -273,10 +273,33 @@ func adeJSONData(withJSONObject object: Any, options: JSONSerialization.WritingO
 /// Byte-for-byte counterpart of
 /// `apps/desktop/src/shared/sync/adoptChannelCrypto.ts`.
 enum AdoptChannelCrypto {
+  enum Aead: String, CaseIterable {
+    case chacha20Poly1305 = "chacha20-poly1305"
+    case aes256Gcm = "aes-256-gcm"
+  }
+
   static let context = "ade-adopt-v1"
   static let helloOkContext = "ade-adopt-v1-hellook"
   static let challengeTimeoutNanoseconds: UInt64 = 3_000_000_000
   static let maximumClockSkewMilliseconds: Double = 120_000
+  static let supportedAeads = Aead.allCases
+
+  static func resolveHostAead(_ value: Any?) throws -> Aead {
+    guard let value else {
+      // Hosts predating AEAD negotiation omitted the field and used ChaCha.
+      return .chacha20Poly1305
+    }
+    guard let rawValue = value as? String,
+          let aead = Aead(rawValue: rawValue),
+          supportedAeads.contains(aead) else {
+      throw NSError(
+        domain: "ADE.AdoptChannel",
+        code: 7,
+        userInfo: [NSLocalizedDescriptionKey: "The host selected an unsupported adoption cipher."]
+      )
+    }
+    return aead
+  }
 
   static func decodeCanonicalBase64(_ value: String, expectedBytes: Int? = nil) -> Data? {
     guard !value.isEmpty,
@@ -315,16 +338,21 @@ enum AdoptChannelCrypto {
     nonce: String,
     clientEphemeralPublicKey: String,
     hostEphemeralPublicKey: String,
-    timestampMilliseconds: Int64
+    timestampMilliseconds: Int64,
+    aead: Aead? = nil
   ) -> String {
-    [
+    var fields = [
       context,
       hostDeviceId,
       nonce,
       clientEphemeralPublicKey,
       hostEphemeralPublicKey,
       String(timestampMilliseconds),
-    ].joined(separator: "|")
+    ]
+    if let aead {
+      fields.append(aead.rawValue)
+    }
+    return fields.joined(separator: "|")
   }
 
   static func helloAAD(hostDeviceId: String, clientDeviceId: String) -> Data {
@@ -357,12 +385,38 @@ enum AdoptChannelCrypto {
     )
   }
 
-  static func seal(_ plaintext: Data, key: SymmetricKey, aad: Data) throws -> String {
-    let box = try ChaChaPoly.seal(plaintext, using: key, authenticating: aad)
-    return box.combined.base64EncodedString()
+  static func seal(
+    _ plaintext: Data,
+    key: SymmetricKey,
+    aad: Data,
+    aead: Aead = .chacha20Poly1305
+  ) throws -> String {
+    switch aead {
+    case .chacha20Poly1305:
+      return try ChaChaPoly.seal(
+        plaintext,
+        using: key,
+        authenticating: aad
+      ).combined.base64EncodedString()
+    case .aes256Gcm:
+      let box = try AES.GCM.seal(plaintext, using: key, authenticating: aad)
+      guard let combined = box.combined else {
+        throw NSError(
+          domain: "ADE.AdoptChannel",
+          code: 3,
+          userInfo: [NSLocalizedDescriptionKey: "The sealed adoption payload is malformed."]
+        )
+      }
+      return combined.base64EncodedString()
+    }
   }
 
-  static func unseal(_ blobBase64: String, key: SymmetricKey, aad: Data) throws -> Data {
+  static func unseal(
+    _ blobBase64: String,
+    key: SymmetricKey,
+    aad: Data,
+    aead: Aead = .chacha20Poly1305
+  ) throws -> Data {
     guard let combined = decodeCanonicalBase64(blobBase64), combined.count >= 28 else {
       throw NSError(
         domain: "ADE.AdoptChannel",
@@ -370,8 +424,14 @@ enum AdoptChannelCrypto {
         userInfo: [NSLocalizedDescriptionKey: "The sealed adoption payload is malformed."]
       )
     }
-    let box = try ChaChaPoly.SealedBox(combined: combined)
-    return try ChaChaPoly.open(box, using: key, authenticating: aad)
+    switch aead {
+    case .chacha20Poly1305:
+      let box = try ChaChaPoly.SealedBox(combined: combined)
+      return try ChaChaPoly.open(box, using: key, authenticating: aad)
+    case .aes256Gcm:
+      let box = try AES.GCM.SealedBox(combined: combined)
+      return try AES.GCM.open(box, using: key, authenticating: aad)
+    }
   }
 }
 
@@ -4935,6 +4995,7 @@ final class SyncService: ObservableObject {
   private struct AccountAdoptionChallengeSession {
     let key: SymmetricKey
     let hostDeviceId: String
+    let aead: AdoptChannelCrypto.Aead
   }
 
   private func accountAdoptionRoutes(
@@ -5046,6 +5107,7 @@ final class SyncService: ObservableObject {
         "v": 1,
         "nonce": nonceBase64,
         "clientEphemeralPublicKey": clientEphemeralPublicKey,
+        "supportedAeads": AdoptChannelCrypto.supportedAeads.map(\.rawValue),
       ])
     }
     guard isCurrentCandidate() else {
@@ -5063,6 +5125,13 @@ final class SyncService: ObservableObject {
           ),
           let signatureBase64 = payload["signature"] as? String,
           let signature = AdoptChannelCrypto.decodeCanonicalBase64(signatureBase64, expectedBytes: 64) else {
+      throw AccountAdoptionIdentityVerificationError(machineName: machineName)
+    }
+    let responseAead = payload["aead"]
+    let aead: AdoptChannelCrypto.Aead
+    do {
+      aead = try AdoptChannelCrypto.resolveHostAead(responseAead)
+    } catch {
       throw AccountAdoptionIdentityVerificationError(machineName: machineName)
     }
     let timestampValue = timestampNumber.doubleValue
@@ -5087,7 +5156,8 @@ final class SyncService: ObservableObject {
       nonce: nonceBase64,
       clientEphemeralPublicKey: clientEphemeralPublicKey,
       hostEphemeralPublicKey: hostEphemeralPublicKeyBase64,
-      timestampMilliseconds: timestampMilliseconds
+      timestampMilliseconds: timestampMilliseconds,
+      aead: responseAead == nil ? nil : aead
     )
     guard signingPublicKey.isValidSignature(signature, for: Data(canonical.utf8)) else {
       throw AccountAdoptionIdentityVerificationError(machineName: machineName)
@@ -5099,7 +5169,8 @@ final class SyncService: ObservableObject {
           hostPublicKeyRaw: hostEphemeralPublicKey,
           nonce: nonce
         ),
-        hostDeviceId: hostDeviceId
+        hostDeviceId: hostDeviceId,
+        aead: aead
       )
     } catch {
       throw AccountAdoptionIdentityVerificationError(machineName: machineName)
@@ -5178,7 +5249,8 @@ final class SyncService: ObservableObject {
           aad: AdoptChannelCrypto.helloAAD(
             hostDeviceId: challenge.hostDeviceId,
             clientDeviceId: deviceId
-          )
+          ),
+          aead: challenge.aead
         ),
       ]
     } else {
@@ -5213,7 +5285,8 @@ final class SyncService: ObservableObject {
         aad: AdoptChannelCrypto.helloOkAAD(
           hostDeviceId: challenge.hostDeviceId,
           clientDeviceId: deviceId
-        )
+        ),
+        aead: challenge.aead
       )
       guard let payload = try JSONSerialization.jsonObject(with: plaintext) as? [String: Any] else {
         throw NSError(domain: "ADE.AdoptChannel", code: 5)

--- a/apps/ios/ADETests/PairingAndDpopTests.swift
+++ b/apps/ios/ADETests/PairingAndDpopTests.swift
@@ -1017,6 +1017,58 @@ final class PairingAndDpopTests: XCTestCase {
     )
   }
 
+  func testAdoptChannelMatchesTypeScriptAESGCMVectorAndNegotiatedSignature() throws {
+    XCTAssertEqual(
+      AdoptChannelCrypto.supportedAeads,
+      [.chacha20Poly1305, .aes256Gcm]
+    )
+    let sessionKey = SymmetricKey(
+      data: pairingTestData(
+        hex: "73dd8c3462d2bd6af30580cd4147d5049e6b96d6e0caad0abb512e47ea9c056e"
+      )
+    )
+    let sealed =
+      "AAECAwQFBgcICQoL3y2dKj5Mf5T1oCPmxekaK7cism6xBa4nVL2OXy7fjrsrUJkqDISXnL4xejxcZFKlg0QtQ3ojlneNBDLJJAvf/QBwppTjKydmgm8J65KHSjtbCdNoJFo="
+    let plaintext = try AdoptChannelCrypto.unseal(
+      sealed,
+      key: sessionKey,
+      aad: Data("ade-adopt-v1|host-vector|client-vector".utf8),
+      aead: .aes256Gcm
+    )
+    XCTAssertEqual(
+      String(decoding: plaintext, as: UTF8.self),
+      #"{"deviceId":"client-vector","accountToken":"token-vector","dpop":null}"#
+    )
+    XCTAssertEqual(
+      AdoptChannelCrypto.challengeSignatureInput(
+        hostDeviceId: "host-device",
+        nonce: "bm9uY2U=",
+        clientEphemeralPublicKey: "Y2xpZW50",
+        hostEphemeralPublicKey: "aG9zdA==",
+        timestampMilliseconds: 1_783_500_123_456,
+        aead: .aes256Gcm
+      ),
+      "ade-adopt-v1|host-device|bm9uY2U=|Y2xpZW50|aG9zdA==|1783500123456|aes-256-gcm"
+    )
+  }
+
+  func testAdoptChannelAcceptsNegotiatedAndLegacyHostCipherSelections() throws {
+    XCTAssertEqual(
+      try AdoptChannelCrypto.resolveHostAead(nil),
+      .chacha20Poly1305
+    )
+    XCTAssertEqual(
+      try AdoptChannelCrypto.resolveHostAead("aes-256-gcm"),
+      .aes256Gcm
+    )
+    XCTAssertThrowsError(
+      try AdoptChannelCrypto.resolveHostAead("future-aead")
+    )
+    XCTAssertThrowsError(
+      try AdoptChannelCrypto.resolveHostAead(NSNull())
+    )
+  }
+
   func testAdoptChannelRejectsPresentMalformedDirectorySigningKey() throws {
     XCTAssertNil(
       try AdoptChannelCrypto.signingPublicKey(fromOptionalDirectoryValue: nil)

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -49,6 +49,16 @@ returned per-device secret and DPoP key for direct reconnects, and adds a fresh
 in-memory account token to every later Relay hello. The account token is never
 saved with the machine.
 
+For that sealed adoption, iOS advertises the AEADs its CryptoKit runtime
+supports (`chacha20-poly1305` and `aes-256-gcm`). The host selects the first
+mutual option, echoes it in `account_challenge_ok`, and signs the selected AEAD
+with the ephemeral-key challenge so an on-path peer cannot downgrade it. The
+phone uses that same AEAD for both the sealed account hello and the sealed
+paired credentials in `hello_ok`. A legacy host that omits `aead` remains
+compatible through the original ChaCha20-Poly1305 path; a host with no mutual
+cipher fails before the phone releases any account credential and asks for ADE
+to be updated on both devices.
+
 Device-bound machine trust and account transport authorization are separate.
 Signing out, switching accounts, or confirmed session loss closes an active
 Relay socket, removes account-directory visibility, and blocks every saved
@@ -218,7 +228,8 @@ apps/ios/
 │   │   │                            # DictationController, deterministic
 │   │   │                            # cleanup, VoiceGlossary loader
 │   │   └── SyncService.swift        # WebSocket client, command routing,
-│   │                                # PIN pairing, scoped projection
+│   │                                # PIN + sealed account adoption,
+│   │                                # scoped projection
 │   │                                # revisions, lane presence, logical-offset
 │   │                                # terminal snapshots, gap recovery,
 │   │                                # reliable input/resize,
@@ -804,6 +815,7 @@ Implemented envelope types on iOS:
 | Type | Direction | Purpose |
 |---|---|---|
 | `hello` / `hello_ok` / `hello_error` | Bidirectional | Handshake |
+| `account_challenge` / `account_challenge_ok` / `account_challenge_error` | Phone → runtime / runtime → phone | Signed X25519 challenge and AEAD negotiation before sealed same-account adoption |
 | `pairing_request` / `pairing_result` | Phone → runtime / runtime → phone | 6-digit PIN pairing |
 | `project_catalog_request` / `project_catalog` | Phone → runtime / runtime → phone | Refresh recent/available machine projects |
 | `project_switch_request` / `project_switch_result` | Phone → runtime / runtime → phone | Prepare a sync connection for a selected machine project |


### PR DESCRIPTION
## Summary

- negotiate an adoption AEAD between iOS and the ADE host, with AES-256-GCM support for Electron runtimes without ChaCha20
- bind the selected cipher into the signed challenge and preserve legacy-host ChaCha compatibility
- fail early on incompatible legacy clients, add bounded diagnostics, and document the protocol

## Validation

- `apps/ade-cli`: sync host suite (152 tests)
- `apps/desktop`: shared adoption crypto suite (7 tests)
- iOS: 3 targeted adoption crypto/compatibility tests on iPhone 17 Pro simulator
- CLI typecheck and TUI suite (1,022 tests)
- docs validation (204 files)
- `/quality` gate: no Blocker/High findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sync adoption now negotiates supported encryption methods between devices, including ChaCha20-Poly1305 and AES-256-GCM.
  * Adoption handshakes securely account for the selected encryption method.

* **Bug Fixes**
  * Improved handling and reporting of invalid or corrupted adoption credentials.
  * Incompatible encryption methods now provide clearer guidance to update both devices.
  * Repeated compatibility failures are reported without duplicate warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->