### PR TITLE
Harden the sync WebSocket surface: origin/path gating, per-device DPoP nonces, AEAD sunset telemetry

### DIFF
--- a/apps/ade-cli/src/services/sync/sharedSyncListener.test.ts
+++ b/apps/ade-cli/src/services/sync/sharedSyncListener.test.ts
@@ -1,0 +1,107 @@
+import { once } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import WebSocket from "ws";
+import {
+  createSharedSyncListener,
+  SYNC_RELAY_BRIDGE_PROOF_HEADER,
+} from "./sharedSyncListener";
+
+async function connect(
+  port: number,
+  path = "/",
+  options: { origin?: string; headers?: Record<string, string> } = {},
+): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}${path}`, {
+    origin: options.origin,
+    headers: options.headers,
+  });
+  await once(ws, "open");
+  return ws;
+}
+
+async function reject(
+  port: number,
+  path: string,
+  options: { origin?: string; headers?: Record<string, string> } = {},
+): Promise<number> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}${path}`, {
+    origin: options.origin,
+    headers: options.headers,
+  });
+  ws.on("error", () => {});
+  const [, response] = await once(ws, "unexpected-response");
+  response.resume();
+  return response.statusCode ?? 0;
+}
+
+describe("shared sync listener upgrade policy", () => {
+  it("accepts only the sync root path", async () => {
+    const listener = createSharedSyncListener({ bindHost: "127.0.0.1" });
+    const port = await listener.ensureListening([0]);
+    const accepted = await connect(port, "/");
+    try {
+      expect(accepted.readyState).toBe(WebSocket.OPEN);
+      expect(await reject(port, "/anything")).toBe(400);
+      expect(await reject(port, "/connect/machine-key")).toBe(400);
+    } finally {
+      accepted.terminate();
+      await listener.close();
+    }
+  });
+
+  it("accepts the hosted web and local Vite origins", async () => {
+    const listener = createSharedSyncListener({ bindHost: "127.0.0.1" });
+    const port = await listener.ensureListening([0]);
+    const sockets: WebSocket[] = [];
+    try {
+      for (const origin of [
+        "https://app.ade-app.dev",
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+      ]) {
+        const ws = await connect(port, "/", { origin });
+        sockets.push(ws);
+        expect(ws.readyState).toBe(WebSocket.OPEN);
+      }
+    } finally {
+      for (const ws of sockets) ws.terminate();
+      await listener.close();
+    }
+  });
+
+  it("accepts no-Origin non-browser and relay-bridge clients", async () => {
+    const listener = createSharedSyncListener({ bindHost: "127.0.0.1" });
+    const port = await listener.ensureListening([0]);
+    const origins: string[] = [];
+    listener.setConnectionHandler((connection) => {
+      origins.push(connection.transportOrigin);
+    });
+    const direct = await connect(port);
+    const relay = await connect(port, "/", {
+      headers: {
+        [SYNC_RELAY_BRIDGE_PROOF_HEADER]: listener.getRelayBridgeProof(),
+      },
+    });
+    expect(direct.readyState).toBe(WebSocket.OPEN);
+    expect(relay.readyState).toBe(WebSocket.OPEN);
+    expect(origins).toEqual(["direct", "relay-bridge"]);
+    direct.terminate();
+    relay.terminate();
+    await listener.close();
+  });
+
+  it("rejects and logs a foreign browser Origin", async () => {
+    const logger = { debug: vi.fn() };
+    const listener = createSharedSyncListener({ bindHost: "127.0.0.1", logger });
+    const port = await listener.ensureListening([0]);
+    try {
+      expect(await reject(port, "/", { origin: "https://evil.example" })).toBe(401);
+      expect(logger.debug).toHaveBeenCalledWith("sync_listener.origin_rejected", {
+        origin: "https://evil.example",
+      });
+      expect(listener.isListening()).toBe(true);
+    } finally {
+      await listener.close();
+    }
+  });
+});

--- a/apps/ade-cli/src/services/sync/sharedSyncListener.ts
+++ b/apps/ade-cli/src/services/sync/sharedSyncListener.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import { WebSocketServer, WebSocket, type RawData } from "ws";
 import type { SyncPeerMetadata } from "../../../../desktop/src/shared/types";
+import { WEB_CLIENT_BASE_URL } from "../../../../desktop/src/shared/webClientUrl";
 import { DEFAULT_SYNC_HOST_PORT, SYNC_HOST_MAX_PORT } from "./syncProtocol";
 import type { RelayAuthorizationSnapshot } from "./relayAuthorization";
 import {
@@ -43,6 +44,12 @@ export const SYNC_HOST_BIND_LOOPBACK_ONLY: boolean =
 
 export const SYNC_HOST_MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
 export const SYNC_RELAY_BRIDGE_PROOF_HEADER = "x-ade-sync-relay-bridge";
+export const SYNC_WEBSOCKET_PATH = "/";
+export const SYNC_BROWSER_ORIGINS: ReadonlySet<string> = new Set([
+  new URL(WEB_CLIENT_BASE_URL).origin,
+  "http://localhost:5173",
+  "http://127.0.0.1:5173",
+]);
 
 export type SyncTransportOrigin = "direct" | "relay-bridge";
 
@@ -61,6 +68,7 @@ const PREFERRED_PORT_BIND_ATTEMPTS = 8;
 const PREFERRED_PORT_BIND_RETRY_DELAY_MS = 400;
 
 type SharedSyncListenerLogger = {
+  debug?: (message: string, fields?: Record<string, unknown>) => void;
   info?: (message: string, fields?: Record<string, unknown>) => void;
   warn?: (message: string, fields?: Record<string, unknown>) => void;
 };
@@ -513,6 +521,13 @@ export function createSharedSyncListener(options: {
       const candidateServer = new WebSocketServer({
         server: candidateHttpServer,
         maxPayload: maxPayloadBytes,
+        path: SYNC_WEBSOCKET_PATH,
+        verifyClient: (info: { origin?: string }) => {
+          const origin = info.origin?.trim();
+          if (!origin || SYNC_BROWSER_ORIGINS.has(origin)) return true;
+          logger.debug?.("sync_listener.origin_rejected", { origin });
+          return false;
+        },
       });
       candidateHttpServer.listen(attemptedPort, bindHost);
       // Install the handler before the validation RTT so a LAN peer that

--- a/apps/ade-cli/src/services/sync/syncDpop.test.ts
+++ b/apps/ade-cli/src/services/sync/syncDpop.test.ts
@@ -103,6 +103,18 @@ describe("verifySyncDpopProof", () => {
     expect(check(proof)).toEqual({ ok: true });
   });
 
+  it("fails closed when the replay cache cannot safely record another nonce", () => {
+    const { privateKey, x963 } = makeKeyPair();
+    const proof = signProof(privateKey, {});
+    expect(verifySyncDpopProof({
+      publicKeyX963Base64: x963,
+      deviceId: DEVICE_ID,
+      secret: SECRET,
+      proof,
+      checkAndRecordNonce: () => "saturated",
+    })).toEqual({ ok: false, reason: "nonce_cache_saturated" });
+  });
+
   it("fails closed on malformed keys and proofs", () => {
     const { privateKey } = makeKeyPair();
     const proof = signProof(privateKey, {});
@@ -119,6 +131,36 @@ describe("verifySyncDpopProof", () => {
       publicKeyX963Base64: "irrelevant",
       proof: { timestamp: Number.NaN, nonce: "", signature: "" },
     })).toEqual({ ok: false, reason: "invalid_proof" });
+  });
+});
+
+describe("createSyncDpopNonceCache", () => {
+  it("does not let one device's flood reopen another device's replay window", () => {
+    const cache = createSyncDpopNonceCache({
+      maxEntries: 4,
+      maxEntriesPerDevice: 2,
+    });
+    const now = Date.now();
+
+    expect(cache.checkAndRecord("victim-device", "victim-nonce", now)).toBe(false);
+    expect(cache.checkAndRecord("flooding-device", "flood-1", now)).toBe(false);
+    expect(cache.checkAndRecord("flooding-device", "flood-2", now)).toBe(false);
+    expect(cache.checkAndRecord("flooding-device", "flood-3", now)).toBe(false);
+
+    expect(cache.checkAndRecord("victim-device", "victim-nonce", now)).toBe(true);
+  });
+
+  it("fails closed instead of evicting another device at the total entry cap", () => {
+    const cache = createSyncDpopNonceCache({
+      maxEntries: 2,
+      maxEntriesPerDevice: 2,
+    });
+    const now = Date.now();
+
+    expect(cache.checkAndRecord("device-a", "nonce-a", now)).toBe(false);
+    expect(cache.checkAndRecord("device-b", "nonce-b", now)).toBe(false);
+    expect(cache.checkAndRecord("device-c", "nonce-c", now)).toBe("saturated");
+    expect(cache.checkAndRecord("device-a", "nonce-a", now)).toBe(true);
   });
 });
 

--- a/apps/ade-cli/src/services/sync/syncDpop.ts
+++ b/apps/ade-cli/src/services/sync/syncDpop.ts
@@ -19,6 +19,7 @@ export const SYNC_DPOP_CONTEXT = "ade-dpop-v1";
 export const SYNC_DPOP_MAX_SKEW_SECONDS = 120;
 export const SYNC_DPOP_NONCE_TTL_MS = 10 * 60 * 1000;
 const SYNC_DPOP_NONCE_CACHE_MAX = 4096;
+const SYNC_DPOP_NONCES_PER_DEVICE_MAX = 256;
 const X963_UNCOMPRESSED_LENGTH = 65;
 
 export function buildSyncDpopChallenge(args: {
@@ -66,7 +67,16 @@ export function publicKeyFromX963Base64(publicKey: string): KeyObject | null {
 
 export type SyncDpopVerification =
   | { ok: true }
-  | { ok: false; reason: "invalid_key" | "invalid_signature" | "stale_timestamp" | "replayed_nonce" | "invalid_proof" };
+  | {
+      ok: false;
+      reason:
+        | "invalid_key"
+        | "invalid_signature"
+        | "stale_timestamp"
+        | "replayed_nonce"
+        | "nonce_cache_saturated"
+        | "invalid_proof";
+    };
 
 export function verifySyncDpopProof(args: {
   publicKeyX963Base64: string;
@@ -74,8 +84,8 @@ export function verifySyncDpopProof(args: {
   secret: string;
   proof: SyncDpopProof;
   nowSeconds?: number;
-  /** Returns true when the nonce was already seen (and records it otherwise). */
-  checkAndRecordNonce?: (nonce: string) => boolean;
+  /** Returns true for a replay, "saturated" when no safe slot remains, or false after recording. */
+  checkAndRecordNonce?: (nonce: string) => boolean | "saturated";
 }): SyncDpopVerification {
   const nonce = typeof args.proof.nonce === "string" ? args.proof.nonce.trim() : "";
   const signature = typeof args.proof.signature === "string" ? args.proof.signature.trim() : "";
@@ -111,7 +121,11 @@ export function verifySyncDpopProof(args: {
   if (!verified) return { ok: false, reason: "invalid_signature" };
   // Only burn the nonce after the signature checks out, so an attacker cannot
   // spend a victim's nonce with a garbage signature.
-  if (args.checkAndRecordNonce?.(nonce)) {
+  const nonceVerdict = args.checkAndRecordNonce?.(nonce);
+  if (nonceVerdict === "saturated") {
+    return { ok: false, reason: "nonce_cache_saturated" };
+  }
+  if (nonceVerdict) {
     return { ok: false, reason: "replayed_nonce" };
   }
   return { ok: true };
@@ -179,35 +193,69 @@ export function syncDpopFailureMessage(reason: string): string {
       return "This device's clock is too far from this machine's. Fix the date and time on both, then try again.";
     case "replayed_nonce":
       return "This device's security proof had already been used. Try connecting again.";
+    case "nonce_cache_saturated":
+      return "This machine is handling too many recent security proofs. Wait a moment, then try again.";
     default:
       return "This device could not prove it holds the security key this machine has on record. Pair it again.";
   }
 }
 
-/** Bounded nonce replay cache keyed by `deviceId:nonce`. */
-export function createSyncDpopNonceCache(args?: { ttlMs?: number; maxEntries?: number }) {
+/**
+ * Nonce replay cache partitioned by device id. Each device has its own bounded
+ * budget, so a valid proof flood from one paired device cannot evict another
+ * device's replay history inside the timestamp-skew window.
+ */
+export function createSyncDpopNonceCache(args?: {
+  ttlMs?: number;
+  maxEntries?: number;
+  maxEntriesPerDevice?: number;
+}) {
   const ttlMs = args?.ttlMs ?? SYNC_DPOP_NONCE_TTL_MS;
   const maxEntries = args?.maxEntries ?? SYNC_DPOP_NONCE_CACHE_MAX;
-  const seen = new Map<string, number>();
+  const maxEntriesPerDevice =
+    args?.maxEntriesPerDevice ?? SYNC_DPOP_NONCES_PER_DEVICE_MAX;
+  const seenByDevice = new Map<string, Map<string, number>>();
+  let entryCount = 0;
 
   const prune = (now: number): void => {
-    for (const [key, expiresAt] of seen) {
-      if (expiresAt <= now) seen.delete(key);
-    }
-    while (seen.size > maxEntries) {
-      const oldest = seen.keys().next().value;
-      if (oldest == null) break;
-      seen.delete(oldest);
+    for (const [deviceId, seen] of seenByDevice) {
+      for (const [nonce, expiresAt] of seen) {
+        if (expiresAt <= now) {
+          seen.delete(nonce);
+          entryCount -= 1;
+        }
+      }
+      if (seen.size === 0) seenByDevice.delete(deviceId);
     }
   };
 
   return {
     /** Returns true when the nonce was already seen; records it otherwise. */
-    checkAndRecord(deviceId: string, nonce: string, now = Date.now()): boolean {
+    checkAndRecord(
+      deviceId: string,
+      nonce: string,
+      now = Date.now(),
+    ): boolean | "saturated" {
       prune(now);
-      const key = `${deviceId}:${nonce}`;
-      if (seen.has(key)) return true;
-      seen.set(key, now + ttlMs);
+      let seen = seenByDevice.get(deviceId);
+      if (seen?.has(nonce)) return true;
+      if (seen && seen.size >= maxEntriesPerDevice) {
+        const oldest = seen.keys().next().value;
+        if (oldest != null) {
+          seen.delete(oldest);
+          entryCount -= 1;
+        }
+      } else if (entryCount >= maxEntries) {
+        // Never evict another device's active replay history to admit a new
+        // nonce. Failing closed preserves the security property under flood.
+        return "saturated";
+      }
+      if (!seen) {
+        seen = new Map();
+        seenByDevice.set(deviceId, seen);
+      }
+      seen.set(nonce, now + ttlMs);
+      entryCount += 1;
       return false;
     },
   };

--- a/apps/ade-cli/src/services/sync/syncHostService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.test.ts
@@ -2026,6 +2026,7 @@ describe("sync host account authentication", () => {
         deviceType: "desktop",
         siteId: "sealed-direct-site",
         dbVersion: 0,
+        appVersion: "1.8.0",
       } satisfies SyncPeerMetadata;
       const accountAuth = {
         deviceId: peer.deviceId,
@@ -2085,6 +2086,15 @@ describe("sync host account authentication", () => {
         peer.deviceId,
         openedHelloOk.accountPairing.secret,
       )).toBe(true);
+      expect(baseArgs.logger.warn).toHaveBeenCalledWith(
+        "sync_host.legacy_adoption_aead_unbound",
+        {
+          deviceId: peer.deviceId,
+          clientVersion: "1.8.0",
+          aead: "chacha20-poly1305",
+          transportOrigin: "direct",
+        },
+      );
       expect(baseArgs.logger.warn.mock.calls.some(
         ([message]) => message === "sync_host.account_auth_requires_relay",
       )).toBe(false);
@@ -2163,6 +2173,9 @@ describe("sync host account authentication", () => {
         aesPeer.deviceId,
         aesOpenedHelloOk.accountPairing.secret,
       )).toBe(true);
+      expect(baseArgs.logger.warn.mock.calls.filter(
+        ([message]) => message === "sync_host.legacy_adoption_aead_unbound",
+      )).toHaveLength(1);
 
       const plainClient = await openAccountClient(port);
       clients.push(plainClient);

--- a/apps/ade-cli/src/services/sync/syncHostService.ts
+++ b/apps/ade-cli/src/services/sync/syncHostService.ts
@@ -226,6 +226,16 @@ import {
 export { selectChangesetBatchChunk } from "./changesetPump";
 export { SYNC_HOST_MOBILE_REPLICA_RESEED_GAP } from "./mobileReplicaReseed";
 const execFileAsync = promisify(execFile);
+
+/**
+ * Sunset this compatibility path once ADE's supported-client floor guarantees
+ * every account adopter advertises `supportedAeads`. There is no
+ * minSupportedVersion gate in the sync handshake today; removal belongs in the
+ * `account_challenge` handler below, where a missing list can then be rejected
+ * and the conditional AEAD transcript fields can become unconditional.
+ */
+export const ALLOW_LEGACY_UNBOUND_ADOPTION_AEAD = true;
+
 // db_version window per pump poll. Large enough to cross sparse version
 // ranges quickly (a few polls per million versions), small enough that the
 // windowed crsql_changes scan completes in milliseconds.
@@ -610,6 +620,7 @@ type PeerState = {
     hostDeviceId: string;
     expiresAtMs: number;
     aead: AdoptChannelAead;
+    aeadBoundToSignature: boolean;
   } | null;
   subscribedSessionIds: Set<string>;
   pendingTerminalSnapshots: Map<string, PendingTerminalSnapshotBarrier>;
@@ -6555,6 +6566,16 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
           return;
         }
         const hostSupportedAeads = supportedAdoptChannelAeads();
+        if (
+          challenge.supportedAeads === null
+          && !ALLOW_LEGACY_UNBOUND_ADOPTION_AEAD
+        ) {
+          send(peer.ws, "account_challenge_error", {
+            message:
+              "This ADE version must advertise account adoption ciphers. Update ADE on this device.",
+          }, envelope.requestId);
+          return;
+        }
         const adoptAead = negotiateAdoptChannelAead(
           challenge.supportedAeads,
           hostSupportedAeads,
@@ -6611,6 +6632,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
             hostDeviceId,
             expiresAtMs: ts + ADOPT_CHANNEL_CHALLENGE_TTL_MS,
             aead: adoptAead,
+            aeadBoundToSignature: challenge.supportedAeads !== null,
           };
           send(peer.ws, "account_challenge_ok", {
             v: 1,
@@ -6806,6 +6828,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
         hostDeviceId: string;
         clientDeviceId: string;
         aead: AdoptChannelAead;
+        aeadBoundToSignature: boolean;
       } | null = null;
       if (hello.auth?.kind === "account_sealed") {
         const sealedAuth = hello.auth;
@@ -6864,6 +6887,7 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
             hostDeviceId: challenge.hostDeviceId,
             clientDeviceId: sealedAuth.deviceId,
             aead: challenge.aead,
+            aeadBoundToSignature: challenge.aeadBoundToSignature,
           };
         } catch (error) {
           const errorCode =
@@ -7402,6 +7426,14 @@ export function createSyncHostService(args: SyncHostServiceArgs) {
             sealedAdoption.aead,
           ),
         }, envelope.requestId);
+        if (!sealedAdoption.aeadBoundToSignature) {
+          args.logger.warn("sync_host.legacy_adoption_aead_unbound", {
+            deviceId: hello.peer.deviceId,
+            clientVersion: hello.peer.appVersion ?? null,
+            aead: sealedAdoption.aead,
+            transportOrigin: peer.transportOrigin,
+          });
+        }
       } else {
         send(peer.ws, "hello_ok", helloOkPayload, envelope.requestId);
       }

--- a/docs/features/sync-and-multi-device/README.md
+++ b/docs/features/sync-and-multi-device/README.md
@@ -612,7 +612,15 @@ Canonical files (`apps/ade-cli/src/services/sync/`):
   choice, echoes it in the `account_challenge_ok`, and binds it into the
   signature input, so a packaged Electron without ChaCha20-Poly1305 negotiates
   `aes-256-gcm` instead of failing to connect; a client advertising an AEAD set
-  with no host overlap is rejected rather than silently downgraded. A completed
+  with no host overlap is rejected rather than silently downgraded. Legacy
+  adopters that omit `supportedAeads` still fall back to
+  `chacha20-poly1305` for compatibility; that choice is not present in their
+  signed transcript. The host records
+  `sync_host.legacy_adoption_aead_unbound` with the client version when that
+  path completes. `ALLOW_LEGACY_UNBOUND_ADOPTION_AEAD` names the sunset gate:
+  once the supported-client floor guarantees AEAD advertisement, the
+  `account_challenge` handler can reject an omitted list and make transcript
+  binding unconditional. A completed
   single-use challenge is required, well-formed challenges feed no rate limiter
   while malformed/anomalous ones charge a per-IP + global cooldown, and unsealed
   `account_sealed` adoption is the one account path allowed over a direct
@@ -715,7 +723,13 @@ Canonical files (`apps/ade-cli/src/services/sync/`):
 - `sharedSyncListener.ts` — the brain-level WebSocket listener shared
   across per-project host services. Binds once (preferred-port retry:
   ~8 attempts over ~3.2 s on the saved port before falling back to a
-  port scan, so a brain restart does not drift the port phones saved).
+  port scan, so a brain restart does not drift the port phones saved). WebSocket
+  upgrades are accepted only on the sync root path (`/`). When an Origin header
+  is present, it must name the canonical hosted web client
+  (`https://app.ade-app.dev`) or one of the explicit local Vite origins;
+  foreign origins are rejected and logged at debug. An absent Origin remains
+  valid for non-browser clients such as iOS URLSession, ADE CLI peers, and the
+  relay bridge, whose private bridge-proof header is validated separately.
   On an `EADDRINUSE` for a port in the sync range (`DEFAULT_SYNC_HOST_PORT`
   8787 through `SYNC_HOST_MAX_PORT` 8999) it runs **sync-port zombie
   reaping**: it diagnoses the port's holders (`inspectSyncListenerPort`),
@@ -918,8 +932,12 @@ Canonical files (`apps/ade-cli/src/services/sync/`):
 - `syncDpop.ts` — device-bound pairing (DPoP) helpers: the canonical
   signing string builder, `evaluatePairedHelloDpop` (validates a
   `SyncDpopProof` against the stored P-256 public key and TOFU-adopts an
-  offered key for legacy devices), and `createSyncDpopNonceCache` (bounded
-  per-host replay guard). Shared by `syncHostService` and the brain
+  offered key for legacy devices), and `createSyncDpopNonceCache` (a replay
+  guard partitioned to 256 recent nonces per device with a 4,096-entry global
+  ceiling). A device may evict only its own oldest entries; when the global
+  ceiling has no safe slot, verification fails closed with
+  `nonce_cache_saturated` instead of evicting another device's replay history.
+  Shared by `syncHostService` and the brain
   ingress handler.
 - `syncSecurityStore.ts` — machine-level sync security posture stored at
   `~/.ade/secrets/sync-security.json` (chmod `0600`). Owns the
@@ -1824,7 +1842,11 @@ feature is merged or because a deliberately isolated-port host is running.
   chosen AEAD into the signed challenge string** so it cannot be downgraded on
   the wire — this is what lets a packaged Electron whose bundled BoringSSL lacks
   ChaCha20-Poly1305 adopt over `aes-256-gcm` instead of failing. A client whose
-  advertised set does not overlap the host's is rejected. The
+  advertised set does not overlap the host's is rejected. Legacy clients that
+  omit the AEAD list remain compatible by falling back to
+  `chacha20-poly1305`, but their chosen AEAD is not yet signature-bound; the
+  host emits a warn-level `sync_host.legacy_adoption_aead_unbound` record so
+  the supported-client floor can be measured before that path is disabled. The
   challenge is single-use and TTL-bounded (60 s); it is required before a sealed
   hello is accepted. `ade-adopt-v1` protects the exchanged *credentials* (bearer,
   DPoP proof, minted secret), not the confidentiality of the subsequent session:


### PR DESCRIPTION
Three hardening items found during the mobile connection audit and deliberately kept out of the functional PRs. No behavior change for any legitimate client.

## 1. The WebSocket upgrade accepted any origin on any path
`sharedSyncListener.ts` constructed `new WebSocketServer({ server, maxPayload })` with no `path` and no `verifyClient`, on a `0.0.0.0` default bind — so any page in any browser on the same LAN could open `ws://<desktop>:8787/anything` and reach the pre-auth message allowlist. Upgrades are now restricted to the sync path, and a browser `Origin` that is not an allowed ADE origin is rejected and debug-logged. Absence of `Origin` is still allowed, because that is what non-browser clients send: iOS URLSession, the `ade` CLI, and the relay bridge all keep working.

## 2. One flooding device could evict another device's DPoP nonces
Replay protection was a ±120s skew window plus a single 4096-entry global LRU, so a flood of synthetic proofs could evict a legitimate entry and reopen a replay window inside the skew. Nonce history is now partitioned per device (256 per device, 4096 globally, fail-closed on saturation).

**Residual risk, stated plainly:** a flooding device can still evict *its own* history, and authenticated multi-device flooding can cause temporary fail-closed rejections. Server-issued nonces — the real fix — remain future work; this closes the cross-device eviction path, which was the exploitable one.

## 3. Legacy adoptions get an AEAD unbound from the signed transcript
Kept for compatibility, but now measurable: a warn-level log fires when an unbound adoption completes, with the client version, so the tail can be sized before the compatibility path is removed. Sunset condition documented at the gate.

## Verification
- CLI sync/account suites: 616 tests across 28 files (Node 22)
- Desktop sync, hosted-web, paired-runtime suites: 385 tests across 12 files
- CLI build + binary verification, docs validation (205 files)
- Live relay still reachable with a fresh end-to-end verification (232ms)

Honest caveat: the live smoke ran against the installed brain, not this branch's build — loading it would have required restarting the running brain, which was out of bounds. The new listener code is covered by tests, not by the live process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fsecurity-hardening-a016c442 num=954 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fsecurity-hardening-a016c442&amp;pr=954">ade/security-hardening-a016c442 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=954">PR #954</a>
</p>
<!-- /ade:link -->
