### PR TITLE
fix(account-directory): apply D1 migrations before deploying

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -95,8 +95,8 @@ jobs:
         with:
           node-version: 22
       - run: cd apps/account-directory && npm ci
-      - name: Deploy production Worker
-        run: cd apps/account-directory && npx wrangler deploy --env production
+      - name: Apply D1 migrations and deploy production Worker
+        run: cd apps/account-directory && npm run deploy:production
       - name: Verify health
         run: curl -fsS https://ade-account-directory-production.arulsharma1028.workers.dev/health | grep -q '"ok":true'
 

--- a/apps/account-directory/package.json
+++ b/apps/account-directory/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",
-    "deploy": "wrangler deploy",
-    "deploy:production": "wrangler deploy --env production",
+    "deploy": "npm run d1:migrate:remote && wrangler deploy",
+    "deploy:production": "npm run d1:migrate:production && wrangler deploy --env production",
     "build": "wrangler deploy --dry-run --outdir dist",
     "build:production": "wrangler deploy --dry-run --env production --outdir dist-production",
     "d1:migrate:local": "wrangler d1 migrations apply ade-account-directory --local",


### PR DESCRIPTION
## The bug

The account-directory Cloudflare Worker's deploy path never applied D1 migrations. Its sibling worker `push-relay` does. So when a schema change shipped, new Worker code could go live against a database missing the column its handlers read.

This already bit us for real: release **v1.2.44** added a `custom_name` column (`0003_machine_custom_names.sql`), and a human had to apply that migration manually before the auto-deploy — otherwise machine-rename would have errored in production.

Two things had to change, because either alone fixes nothing:

1. **`apps/account-directory/package.json`** — the deploy scripts now migrate first, mirroring push-relay's ordering. `deploy` runs `d1:migrate:remote`; `deploy:production` runs the previously-unused `d1:migrate:production`.
2. **`.github/workflows/deploy-web.yml`** — the account-directory job called `npx wrangler deploy --env production` *directly*, bypassing npm scripts entirely. It now runs `npm run deploy:production`, so the migration step is actually on the deploy path. The health-check step is unchanged.

## Verification

`d1:migrate:production` passes the *binding* name `DB` rather than a database name and had apparently never been executed, so I checked it read-only before trusting it:

- `wrangler d1 migrations list DB --remote --env production` resolves and reports **no migrations to apply**.
- It genuinely targets `ade-account-directory-production`: querying `d1_migrations` via `DB --env production` returns the same byte size and same 3 applied migrations as addressing the database by its explicit name.
- The selector is environment-aware — bare `DB` (no `--env`) resolves to a *different* database, where `0003` is still pending.

So the new production step is a no-op on this deploy, which is exactly what we want to see the first time it runs.

Note: because the non-production database has not had `0003` applied, the first `npm run deploy` (non-production) will apply it. That is the intended behavior of this fix.

`npm test` (36 tests) and `npm run typecheck` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fdeploy-migration-step-5f2668a4 num=958 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fdeploy-migration-step-5f2668a4&amp;pr=958">ade/deploy-migration-step-5f2668a4 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=958">PR #958</a>
</p>
<!-- /ade:link -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Production deployments now automatically apply the latest database migrations before deploying the application.
  * Standard deployments also run remote database migrations before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->