### PR TITLE
feat(prs): map native stacks across work surfaces

### DIFF
--- a/apps/ade-cli/src/tuiClient/__tests__/Drawer.test.tsx
+++ b/apps/ade-cli/src/tuiClient/__tests__/Drawer.test.tsx
@@ -600,6 +600,39 @@ describe("Drawer PR pill", () => {
     expect(frame).toContain("[#168 ·4/6]");
   });
 
+  it("renders native stack position inside the PR pill", () => {
+    const frame = stripAnsi(render(
+      <Drawer
+        lanes={[lane("lane-1", "stack ui", "ade/stack-ui", "2026-05-12T11:55:00.000Z")]}
+        sessions={[]}
+        activeLaneId={null}
+        activeSessionId={null}
+        browsingLaneId={null}
+        selectedLaneIndex={0}
+        selectedChatIndex={-1}
+        panelHeight={20}
+        width={48}
+        prByLaneId={{
+          "lane-1": {
+            number: 168,
+            state: "open",
+            checksPassed: 4,
+            checksTotal: 6,
+            stack: {
+              id: "stack-18",
+              number: 18,
+              size: 3,
+              position: 2,
+              baseBranch: "main",
+            },
+          },
+        }}
+      />,
+    ).lastFrame() ?? "");
+
+    expect(frame).toContain("[#168 ≋2/3 ·4/6]");
+  });
+
   it("does not render closed or merged PR pills", () => {
     for (const state of ["closed", "merged"] as const) {
       const frame = stripAnsi(render(

--- a/apps/ade-cli/src/tuiClient/__tests__/adeApi.test.ts
+++ b/apps/ade-cli/src/tuiClient/__tests__/adeApi.test.ts
@@ -1445,6 +1445,13 @@ describe("listPrsByLane", () => {
             state: "open",
             checksPassed: 4,
             checksTotal: 6,
+            stack: {
+              id: "stack-18",
+              number: 18,
+              size: 3,
+              position: 2,
+              baseBranch: "main",
+            },
           },
         ];
       },
@@ -1457,6 +1464,13 @@ describe("listPrsByLane", () => {
         state: "open",
         checksPassed: 4,
         checksTotal: 6,
+        stack: {
+          id: "stack-18",
+          number: 18,
+          size: 3,
+          position: 2,
+          baseBranch: "main",
+        },
       },
     ]);
 

--- a/apps/ade-cli/src/tuiClient/app.tsx
+++ b/apps/ade-cli/src/tuiClient/app.tsx
@@ -8469,6 +8469,7 @@ export function AdeCodeApp({ project, forceEmbedded, requireSocket, socketPath, 
             state: pr.state,
             checksPassed: pr.checksPassed,
             checksTotal: pr.checksTotal,
+            stack: pr.stack ?? null,
           };
         }
         setPrByLaneId(next);

--- a/apps/ade-cli/src/tuiClient/components/Drawer.tsx
+++ b/apps/ade-cli/src/tuiClient/components/Drawer.tsx
@@ -12,6 +12,7 @@ import { useSpinFrame } from "../spinTick";
 import { theme, type LaneStatusKind } from "../theme";
 import type { AdeCodeProvider } from "../types";
 import type { TuiChatSessionSummary } from "../adeApi";
+import type { GitHubPrStackMembership } from "../../../../desktop/src/shared/types/prs";
 import { useHoveredHitId } from "../hitTestRegistry";
 import {
   computeDrawerLayout,
@@ -37,6 +38,7 @@ export type DrawerPrSummary = {
   state: "open" | "closed" | "merged";
   checksPassed: number;
   checksTotal: number;
+  stack?: GitHubPrStackMembership | null;
 };
 
 /** Derive a wireframe-bucket status for a lane from its data + active session. */
@@ -669,7 +671,8 @@ function LaneCard({
 }
 
 function formatPrPillText(pr: DrawerPrSummary): string {
-  return `[#${pr.number} ·${pr.checksPassed}/${pr.checksTotal}]`;
+  const stack = pr.stack ? ` ≋${pr.stack.position}/${pr.stack.size}` : "";
+  return `[#${pr.number}${stack} ·${pr.checksPassed}/${pr.checksTotal}]`;
 }
 
 function PrPill({ pr }: { pr: DrawerPrSummary }) {
@@ -678,6 +681,13 @@ function PrPill({ pr }: { pr: DrawerPrSummary }) {
     <Text>
       <Text color={theme.color.violet}>[#</Text>
       <Text color={theme.color.t1}>{pr.number}</Text>
+      {pr.stack ? (
+        <>
+          <Text color={theme.color.t3}> </Text>
+          <Text color={theme.color.violet}>≋</Text>
+          <Text color={theme.color.t1}>{pr.stack.position}/{pr.stack.size}</Text>
+        </>
+      ) : null}
       <Text color={theme.color.t3}> ·</Text>
       <Text color={checksColor}>{pr.checksPassed}</Text>
       <Text color={theme.color.t3}>/{pr.checksTotal}</Text>

--- a/apps/desktop/src/main/services/prs/prService.test.ts
+++ b/apps/desktop/src/main/services/prs/prService.test.ts
@@ -550,7 +550,7 @@ describe("prService.getForLane", () => {
     ]);
   });
 
-  it("includes native GitHub stack membership in lane and list summaries", () => {
+  it("includes native GitHub stack membership in lane and list summaries", async () => {
     const lane = makeFakeLane({ branchRef: "refs/heads/stack-ui" });
     const service = buildGetForLaneService(
       lane,
@@ -612,6 +612,13 @@ describe("prService.getForLane", () => {
     };
     expect(service.getForLane(lane.id)?.stack).toEqual(expectedStack);
     expect(service.listAll()[0]?.stack).toEqual(expectedStack);
+    await expect(service.listPrsByLane()).resolves.toEqual([
+      expect.objectContaining({
+        laneId: lane.id,
+        number: 91,
+        stack: expectedStack,
+      }),
+    ]);
   });
 
   it("does not surface a PR for primary when primary is on its base branch", () => {
@@ -849,6 +856,7 @@ describe("prService.getForLane", () => {
         state: pr.state === "draft" ? "open" : pr.state,
         checksPassed: 0,
         checksTotal: 0,
+        stack: pr.stack ?? null,
       }));
 
     await expect(service.listPrsByLane()).resolves.toEqual(perLane);

--- a/apps/desktop/src/main/services/prs/prService.ts
+++ b/apps/desktop/src/main/services/prs/prService.ts
@@ -2008,6 +2008,7 @@ export function createPrService({
       state,
       checksPassed: checks.filter((check) => check.status === "completed" && check.conclusion === "success").length,
       checksTotal: checks.length,
+      stack: pr.stack ?? null,
     };
   };
 
@@ -10535,10 +10536,13 @@ export function createPrService({
         }))
         .filter((candidate): candidate is LanePrDisplayCandidate => candidate != null);
       const checksByPrId = new Map(listSnapshotRows().map((snapshot) => [snapshot.prId, snapshot.checks] as const));
-      return candidates.map(({ summary, mappedRow }) => summaryToLanePrSummary(
-        summary,
-        mappedRow && isActivePrState(summary.state) ? checksByPrId.get(mappedRow.id) ?? [] : [],
-      ));
+      return candidates.map(({ summary, mappedRow }) => {
+        const enriched = withGithubStackMembership(summary) ?? summary;
+        return summaryToLanePrSummary(
+          enriched,
+          mappedRow && isActivePrState(summary.state) ? checksByPrId.get(mappedRow.id) ?? [] : [],
+        );
+      });
     },
 
     /**

--- a/apps/desktop/src/renderer/components/lanes/LanePrBadgePopover.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanePrBadgePopover.tsx
@@ -13,6 +13,7 @@ import {
   getPrStateBadge,
 } from "../prs/shared/prVisuals";
 import { formatPrBadgeLabel } from "../prs/shared/prFormatters";
+import { GitHubStackBadge } from "../prs/shared/GitHubStackBadge";
 
 /** Caption beneath the state badge: "PR opened / merged / draft / closed". */
 function prStateCaption(state: LaneTabPrTag["state"]): string {
@@ -114,6 +115,7 @@ export function LanePrBadgePopover({
       >
         <GitPullRequest size={10} weight="bold" />
         {formatPrBadgeLabel(pr)}
+        <GitHubStackBadge stack={pr.stack} compact bare />
       </button>
 
       {/* Hover popover — pure-CSS group-hover, positioned below the badge. No JS
@@ -141,6 +143,7 @@ export function LanePrBadgePopover({
             >
               #{pr.githubPrNumber}
             </span>
+            <GitHubStackBadge stack={pr.stack} compact />
             <span className="ml-auto text-[10.5px]" style={{ color: COLORS.textMuted }}>
               {prStateCaption(pr.state)}
             </span>

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.test.ts
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.test.ts
@@ -545,6 +545,25 @@ describe("selectLaneTabPrTag", () => {
     });
   });
 
+  it("carries native stack position into the lane PR tag", () => {
+    const stack = {
+      id: "stack-18",
+      number: 18,
+      size: 3,
+      position: 2,
+      baseBranch: "main",
+    };
+
+    expect(selectLaneTabPrTag(
+      makeLane(),
+      [makePr({ stack })],
+      [makeGitHubPr({ stack })],
+    )).toMatchObject({
+      githubPrNumber: 224,
+      stack,
+    });
+  });
+
   it("prefers an ADE-mapped PR over an unlinked GitHub branch match", () => {
     const mappedPr = makePr({ id: "mapped-pr", state: "open" });
     const githubPr = makeGitHubPr({ id: "github-pr", state: "open" });

--- a/apps/desktop/src/renderer/components/lanes/lanePageModel.ts
+++ b/apps/desktop/src/renderer/components/lanes/lanePageModel.ts
@@ -1,6 +1,7 @@
 import { branchNameFromLaneRef } from "../../../shared/laneBaseResolution";
 import type {
   GitHubPrListItem,
+  GitHubPrStackMembership,
   LaneListSnapshot,
   LaneSummary,
   PrChecksStatus,
@@ -45,6 +46,7 @@ export type LaneTabPrTag = {
   updatedAt?: string;
   labels?: PrLabel[];
   author?: string | null;
+  stack?: GitHubPrStackMembership | null;
 };
 
 export const VISIBLE_LANE_PR_REFRESH_LIMIT = 4;
@@ -290,6 +292,7 @@ function toLaneTabPrTagFromPrSummary(pr: PrSummary): LaneTabPrTag {
     mergeConflicts: pr.mergeConflicts,
     behindBaseBy: pr.behindBaseBy,
     updatedAt: pr.updatedAt,
+    stack: pr.stack ?? null,
   };
 }
 
@@ -308,6 +311,7 @@ function toLaneTabPrTagFromGithubItem(pr: GitHubPrListItem, laneId: string): Lan
     updatedAt: pr.updatedAt,
     labels: pr.labels,
     author: pr.author,
+    stack: pr.stack ?? null,
   };
 }
 
@@ -332,6 +336,7 @@ function mergeLaneTabPrTags(base: LaneTabPrTag, secondary: LaneTabPrTag | null):
     updatedAt: base.updatedAt ?? secondary.updatedAt,
     labels: base.labels ?? secondary.labels,
     author: base.author ?? secondary.author,
+    stack: base.stack ?? secondary.stack ?? null,
   };
 }
 

--- a/apps/desktop/src/renderer/components/terminals/SessionCard.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.test.tsx
@@ -200,6 +200,27 @@ describe("SessionCard orchestration identity", () => {
 });
 
 describe("SessionCard lineage", () => {
+  it("shows the lane's native stack position on a chat row", () => {
+    render(
+      <SessionCard
+        session={makeSession()}
+        lane={lane}
+        githubStack={{
+          id: "stack-18",
+          number: 18,
+          size: 3,
+          position: 2,
+          baseBranch: "main",
+        }}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onContextMenu={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText("GitHub Stack 2 of 3")).toBeTruthy();
+  });
+
   it("renders the lineage glyph for a spawned session and not for a top-level one", () => {
     const { rerender } = render(
       <SessionCard

--- a/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
@@ -16,6 +16,7 @@ import {
 } from "@phosphor-icons/react";
 import { useNavigate } from "react-router-dom";
 import type {
+  GitHubPrStackMembership,
   LaneSummary,
   OpenProjectBinding,
   PrSummary,
@@ -60,6 +61,7 @@ import { navigateToSpawnedChat } from "../chat/spawnNavigation";
 import { requestLinearIssueQuickView } from "../../lib/linearIssueQuickViewNavigation";
 import { isSessionSnoozed, sessionWokeMarker, snoozeWakeLabel } from "../../lib/sessionSnooze";
 import { SessionStatusSlot } from "./SessionStatusSlot";
+import { GitHubStackBadge } from "../prs/shared/GitHubStackBadge";
 
 /* ──────────────────────────────────────────────────────────────────────────
    The Work-sidebar session card.
@@ -299,6 +301,7 @@ export const SessionCard = React.memo(function SessionCard({
   disabledBusy = true,
   runtimePin = null,
   deltaEnabled = true,
+  githubStack = null,
   showLaneIdentity = false,
   lanePr = null,
   suppressMachineChip = false,
@@ -324,6 +327,8 @@ export const SessionCard = React.memo(function SessionCard({
   runtimePin?: OpenProjectBinding | null;
   /** Foreign cards skip the active-project delta cache. */
   deltaEnabled?: boolean;
+  /** Native GitHub stack context for chats running in this lane. */
+  githubStack?: GitHubPrStackMembership | null;
   /**
    * Lane has exactly one session, so no lane divider renders above it — the
    * card carries the lane identity instead.
@@ -500,6 +505,11 @@ export const SessionCard = React.memo(function SessionCard({
         className="shrink-0 text-muted-fg/55"
         aria-label="Pinned"
       />,
+    );
+  }
+  if (githubStack) {
+    whereParts.push(
+      <GitHubStackBadge key="github-stack" stack={githubStack} compact bare />,
     );
   }
   if (showLaneIdentity && lane) {

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
@@ -1741,6 +1741,10 @@ export const SessionListPane = React.memo(function SessionListPane({
     const isFirst = !sessionItemAnchorEmitted;
     if (isFirst) sessionItemAnchorEmitted = true;
     const foreignRow = options?.foreignRow;
+    const sessionLane = foreignRow?.lane ?? laneById.get(session.laneId) ?? null;
+    const sessionPr = !foreignRow && sessionLane
+      ? selectPrimaryLanePr(sessionLane, prsByLaneId.get(session.laneId) ?? [])
+      : null;
     // A card on an unreachable machine is shown as last reported and every
     // action on it would fail, so it is inert and says which machine is gone.
     const disabledReason = foreignRow
@@ -1756,7 +1760,7 @@ export const SessionListPane = React.memo(function SessionListPane({
       <SessionCard
         key={session.id}
         session={session}
-        lane={foreignRow?.lane ?? laneById.get(session.laneId) ?? null}
+        lane={sessionLane}
         liveChildrenCount={foreignRow ? 0 : liveChildrenByParentId.get(session.id) ?? 0}
         parentSessionTitle={
           !foreignRow && session.orchestrationParentSessionId
@@ -1796,6 +1800,7 @@ export const SessionListPane = React.memo(function SessionListPane({
         runtimePin={foreignRow?.binding}
         suppressMachineChip={options?.suppressMachineChip}
         deltaEnabled={!foreignRow}
+        githubStack={isChatToolType(session.toolType) ? sessionPr?.stack ?? null : null}
         disabledReason={disabledReason}
         disabledBusy={!foreignRow}
       />

--- a/apps/desktop/src/renderer/components/terminals/useLanePrs.test.ts
+++ b/apps/desktop/src/renderer/components/terminals/useLanePrs.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { GitHubPrListItem, LaneSummary, PrSummary } from "../../../shared/types";
+import { buildLanePrsByLaneId } from "./useLanePrs";
+
+function lane(overrides: Partial<LaneSummary> = {}): LaneSummary {
+  return {
+    id: "lane-1",
+    name: "Stack UI",
+    laneType: "worktree",
+    baseRef: "main",
+    branchRef: "feature/stack-ui",
+    worktreePath: "/repo/.ade/worktrees/stack-ui",
+    parentLaneId: null,
+    childCount: 0,
+    stackDepth: 0,
+    status: null,
+    parentStatus: null,
+    isEditProtected: false,
+    createdAt: "2026-07-30T12:00:00Z",
+    archivedAt: null,
+    ...overrides,
+  } as LaneSummary;
+}
+
+function mappedPr(overrides: Partial<PrSummary> = {}): PrSummary {
+  return {
+    id: "pr-91",
+    laneId: "lane-1",
+    projectId: "project-1",
+    repoOwner: "arul28",
+    repoName: "ADE",
+    githubPrNumber: 91,
+    githubUrl: "https://github.com/arul28/ADE/pull/91",
+    githubNodeId: null,
+    title: "Stack UI",
+    state: "open",
+    baseBranch: "main",
+    headBranch: "feature/stack-ui",
+    checksStatus: "passing",
+    reviewStatus: "approved",
+    additions: 10,
+    deletions: 2,
+    lastSyncedAt: "2026-07-30T12:00:00Z",
+    createdAt: "2026-07-30T11:00:00Z",
+    updatedAt: "2026-07-30T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function githubPr(overrides: Partial<GitHubPrListItem> = {}): GitHubPrListItem {
+  return {
+    id: "github-pr-91",
+    scope: "repo",
+    repoOwner: "arul28",
+    repoName: "ADE",
+    githubPrNumber: 91,
+    githubUrl: "https://github.com/arul28/ADE/pull/91",
+    title: "Stack UI",
+    state: "open",
+    isDraft: false,
+    baseBranch: "main",
+    headBranch: "feature/stack-ui",
+    author: "arul28",
+    createdAt: "2026-07-30T11:00:00Z",
+    updatedAt: "2026-07-30T12:00:00Z",
+    linkedPrId: null,
+    linkedGroupId: null,
+    linkedLaneId: null,
+    linkedLaneName: null,
+    adeKind: null,
+    ...overrides,
+  } as GitHubPrListItem;
+}
+
+describe("buildLanePrsByLaneId", () => {
+  it("uses a single GitHub snapshot to surface an unmapped branch PR in Work", () => {
+    const result = buildLanePrsByLaneId({
+      lanes: [lane()],
+      prs: [],
+      githubPrs: [githubPr({
+        stack: {
+          id: "stack-18",
+          number: 18,
+          size: 3,
+          position: 2,
+          baseBranch: "main",
+        },
+      })],
+    });
+
+    expect(result.get("lane-1")).toEqual([
+      expect.objectContaining({
+        id: "gh:arul28/ADE#91",
+        laneId: "lane-1",
+        githubPrNumber: 91,
+        unmapped: true,
+        stack: expect.objectContaining({ number: 18, position: 2, size: 3 }),
+      }),
+    ]);
+  });
+
+  it("keeps the mapped summary while accepting fresher stack membership", () => {
+    const result = buildLanePrsByLaneId({
+      lanes: [lane()],
+      prs: [mappedPr()],
+      githubPrs: [githubPr({
+        linkedPrId: "pr-91",
+        linkedLaneId: "lane-1",
+        stack: {
+          id: "stack-18",
+          number: 18,
+          size: 3,
+          position: 2,
+          baseBranch: "main",
+        },
+      })],
+    });
+
+    expect(result.get("lane-1")?.[0]).toEqual(expect.objectContaining({
+      id: "pr-91",
+      checksStatus: "passing",
+      stack: expect.objectContaining({ number: 18, position: 2, size: 3 }),
+    }));
+  });
+
+  it("ignores stale mapped rows from an old lane branch", () => {
+    const result = buildLanePrsByLaneId({
+      lanes: [lane()],
+      prs: [mappedPr({ headBranch: "feature/old" })],
+      githubPrs: [],
+    });
+
+    expect(result.has("lane-1")).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/components/terminals/useLanePrs.ts
+++ b/apps/desktop/src/renderer/components/terminals/useLanePrs.ts
@@ -1,11 +1,67 @@
 import { useEffect, useMemo, useState } from "react";
-import type { PrSummary } from "../../../shared/types";
-import { listPrsCoalesced } from "../../lib/prReadCache";
+import type { GitHubPrListItem, LaneSummary, PrSummary } from "../../../shared/types";
+import { getGitHubSnapshotCoalesced, listPrsCoalesced } from "../../lib/prReadCache";
 import { selectActiveProjectRoot, useAppStore } from "../../state/appStore";
+import {
+  lanePrMatchesCurrentBranch,
+  selectGithubLanePrTag,
+} from "../lanes/lanePageModel";
+
+function githubItemToLanePr(item: GitHubPrListItem, laneId: string): PrSummary {
+  return {
+    id: item.linkedPrId ?? `gh:${item.repoOwner}/${item.repoName}#${item.githubPrNumber}`,
+    laneId,
+    projectId: "github-projection",
+    repoOwner: item.repoOwner,
+    repoName: item.repoName,
+    githubPrNumber: item.githubPrNumber,
+    githubUrl: item.githubUrl,
+    githubNodeId: null,
+    title: item.title,
+    state: item.isDraft ? "draft" : item.state,
+    baseBranch: item.baseBranch ?? "",
+    headBranch: item.headBranch ?? "",
+    checksStatus: "none",
+    reviewStatus: "none",
+    additions: 0,
+    deletions: 0,
+    lastSyncedAt: null,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+    stack: item.stack ?? null,
+    unmapped: item.linkedPrId == null ? true : undefined,
+  };
+}
+
+export function buildLanePrsByLaneId(args: {
+  lanes: LaneSummary[];
+  prs: PrSummary[];
+  githubPrs: GitHubPrListItem[];
+}): Map<string, PrSummary[]> {
+  const byLane = new Map<string, PrSummary[]>();
+  for (const lane of args.lanes) {
+    const githubPr = selectGithubLanePrTag(lane, args.githubPrs);
+    const mapped = args.prs
+      .filter((pr) => lanePrMatchesCurrentBranch(lane, pr))
+      .map((pr) => ({
+        ...pr,
+        stack: githubPr?.githubPrNumber === pr.githubPrNumber
+          ? githubPr.stack ?? pr.stack ?? null
+          : pr.stack ?? null,
+      }));
+    if (mapped.length > 0) {
+      byLane.set(lane.id, mapped);
+    } else if (githubPr) {
+      byLane.set(lane.id, [githubItemToLanePr(githubPr, lane.id)]);
+    }
+  }
+  return byLane;
+}
 
 /**
- * ADE-mapped PRs grouped by lane id. One lazy read plus the `prs-updated` push
- * keeps it fresh without polling.
+ * Canonical current-branch PRs grouped by lane id. A coalesced mapped-PR read
+ * and GitHub snapshot read cover both ADE-linked and GitHub-only PRs without
+ * per-lane requests. The `prs-updated` push keeps both caches fresh.
  *
  * Extracted from SessionListPane so the Work session hook can answer the
  * "Has PR" chip filter from the same data the lane-header badge renders. The
@@ -15,32 +71,41 @@ import { selectActiveProjectRoot, useAppStore } from "../../state/appStore";
  */
 export function useLanePrsByLaneId(): Map<string, PrSummary[]> {
   const projectRoot = useAppStore(selectActiveProjectRoot);
+  const lanes = useAppStore((state) => state.lanes);
   const [prs, setPrs] = useState<PrSummary[]>([]);
+  const [githubPrs, setGithubPrs] = useState<GitHubPrListItem[]>([]);
   useEffect(() => {
     // `window.ade.prs` is absent in some renders (e.g. tests with a partial
     // `window.ade` mock); no-op gracefully so the badge just doesn't render.
     if (!window.ade?.prs) return;
     let cancelled = false;
-    void listPrsCoalesced({ projectRoot })
-      .then((list) => {
-        if (!cancelled) setPrs(list);
+    const refresh = () => Promise.all([
+      listPrsCoalesced({ projectRoot }),
+      getGitHubSnapshotCoalesced({}, { projectRoot }),
+    ])
+      .then(([list, snapshot]) => {
+        if (cancelled) return;
+        setPrs(list);
+        setGithubPrs(snapshot?.repoPullRequests ?? []);
       })
       .catch(() => {});
+    void refresh();
     const unsubscribe = window.ade.prs.onEvent((event) => {
-      if (event.type === "prs-updated") setPrs(event.prs);
+      if (event.type !== "prs-updated") return;
+      setPrs(event.prs);
+      void getGitHubSnapshotCoalesced({}, { projectRoot })
+        .then((snapshot) => {
+          if (!cancelled) setGithubPrs(snapshot?.repoPullRequests ?? []);
+        })
+        .catch(() => {});
     });
     return () => {
       cancelled = true;
       unsubscribe();
     };
   }, [projectRoot]);
-  return useMemo(() => {
-    const byLane = new Map<string, PrSummary[]>();
-    for (const pr of prs) {
-      const list = byLane.get(pr.laneId);
-      if (list) list.push(pr);
-      else byLane.set(pr.laneId, [pr]);
-    }
-    return byLane;
-  }, [prs]);
+  return useMemo(
+    () => buildLanePrsByLaneId({ lanes, prs, githubPrs }),
+    [githubPrs, lanes, prs],
+  );
 }

--- a/apps/desktop/src/shared/types/prs.ts
+++ b/apps/desktop/src/shared/types/prs.ts
@@ -92,6 +92,7 @@ export type PrLaneSummary = {
   state: "open" | "merged" | "closed";
   checksPassed: number;
   checksTotal: number;
+  stack?: GitHubPrStackMembership | null;
 };
 
 export type PrStatus = {


### PR DESCRIPTION
## What changed
- keep lane-to-PR mapping aligned with each lane’s current branch, including GitHub-only PRs
- show native stack position on Lanes badges and Work chat cards
- include stack context in the ADE TUI PR pill

## Verification
- 375 focused desktop and TUI tests
- desktop production build
- ADE CLI build and packaged binary verification
- visual proof captured for Work and Lanes

Desktop typecheck has only the pre-existing `agentChatService.ts` SDK shape errors on this stack base.