### PR TITLE
feat(prs): add native stack parity on iOS

### DIFF
--- a/apps/ios/ADE/Models/RemoteModels.swift
+++ b/apps/ios/ADE/Models/RemoteModels.swift
@@ -3825,6 +3825,36 @@ extension TerminalSessionSummary {
   }
 }
 
+struct GitHubPrStackMembership: Codable, Equatable {
+  var id: String
+  var number: Int
+  var size: Int
+  var position: Int
+  var baseBranch: String
+}
+
+struct GitHubPrStackEntry: Codable, Identifiable, Equatable {
+  var id: Int { githubPrNumber }
+  var githubPrNumber: Int
+  var position: Int
+  var state: String
+  var isDraft: Bool
+  var mergedAt: String?
+  var headBranch: String
+  var headSha: String
+}
+
+struct GitHubPrStack: Codable, Identifiable, Equatable {
+  var id: String
+  var number: Int
+  var baseBranch: String
+  var open: Bool
+  var entries: [GitHubPrStackEntry]
+  var createdAt: String
+  var syncedAt: String
+  var lastError: String?
+}
+
 struct PrSummary: Codable, Identifiable, Equatable {
   var id: String
   var laneId: String
@@ -3849,6 +3879,8 @@ struct PrSummary: Codable, Identifiable, Equatable {
   var mergedAt: String? = nil
   /// "pr_target" or "lane_base". Optional because legacy hosts / non-lane PRs omit it.
   var creationStrategy: String? = nil
+  /// Native GitHub stack membership. Nil against hosts before stacked PR support.
+  var stack: GitHubPrStackMembership? = nil
 }
 
 struct PullRequestListItem: Codable, Identifiable, Equatable {
@@ -3879,6 +3911,7 @@ struct PullRequestListItem: Codable, Identifiable, Equatable {
   var linkedGroupCount: Int
   var workflowDisplayState: String?
   var cleanupState: String?
+  var stack: GitHubPrStackMembership? = nil
 }
 
 struct PrGroupMemberSummary: Codable, Identifiable, Equatable {
@@ -4215,6 +4248,7 @@ struct GitHubPrListItem: Codable, Identifiable, Equatable {
   var labels: [PrLabel]
   var isBot: Bool
   var commentCount: Int
+  var stack: GitHubPrStackMembership? = nil
 }
 
 struct GitHubPrSnapshot: Codable, Equatable {
@@ -4224,6 +4258,7 @@ struct GitHubPrSnapshot: Codable, Equatable {
   var externalPullRequests: [GitHubPrListItem]
   var syncedAt: String
   var history: GitHubPrSnapshotHistory? = nil
+  var stacks: [GitHubPrStack]? = nil
 }
 
 struct GitHubPrSnapshotHistory: Codable, Equatable {

--- a/apps/ios/ADE/Services/Database.swift
+++ b/apps/ios/ADE/Services/Database.swift
@@ -1479,6 +1479,16 @@ final class DatabaseService {
             sqlite3_bind_null(statement, 20)
           }
         }
+
+        _ = try execute("""
+          insert into pull_request_stack_snapshots(pr_id, stack_json)
+          values (?, ?)
+          on conflict(pr_id) do update set
+            stack_json = excluded.stack_json
+        """) { statement in
+          try bindText(pr.id, to: statement, index: 1)
+          try bindOptionalJson(pr.stack, to: statement, index: 2)
+        }
       }
 
       for snapshot in payload.snapshots {
@@ -1514,7 +1524,11 @@ final class DatabaseService {
       }
 
       try exec("commit")
-      notifyDidChange(touchedTables: ["pull_requests", "pull_request_snapshots"])
+      notifyDidChange(touchedTables: [
+        "pull_requests",
+        "pull_request_snapshots",
+        "pull_request_stack_snapshots",
+      ])
     } catch {
       try? exec("rollback")
       throw error
@@ -2263,12 +2277,14 @@ final class DatabaseService {
   private func fetchPullRequestsLocked() -> [PrSummary] {
     guard let projectId = currentProjectIdLocked() else { return [] }
     let sql = """
-      select id, lane_id, project_id, repo_owner, repo_name, github_pr_number, github_url, github_node_id,
+      select pr.id, pr.lane_id, pr.project_id, pr.repo_owner, pr.repo_name, pr.github_pr_number,
+             pr.github_url, pr.github_node_id,
              title, state, base_branch, head_branch, checks_status, review_status, additions, deletions,
-             last_synced_at, created_at, updated_at, merged_at
-        from pull_requests
-       where project_id = ?
-       order by updated_at desc
+             last_synced_at, created_at, updated_at, merged_at, stack_snapshot.stack_json
+        from pull_requests pr
+        left join pull_request_stack_snapshots stack_snapshot on stack_snapshot.pr_id = pr.id
+       where pr.project_id = ?
+       order by pr.updated_at desc
     """
     return query(sql, bind: { [self] statement in
       try self.bindText(projectId, to: statement, index: 1)
@@ -2293,7 +2309,11 @@ final class DatabaseService {
         lastSyncedAt: stringValue(statement, index: 16),
         createdAt: stringValue(statement, index: 17) ?? "",
         updatedAt: stringValue(statement, index: 18) ?? "",
-        mergedAt: stringValue(statement, index: 19)
+        mergedAt: stringValue(statement, index: 19),
+        stack: decodeJson(
+          stringValue(statement, index: 20),
+          as: GitHubPrStackMembership.self
+        )
       )
     }
   }
@@ -2387,10 +2407,12 @@ final class DatabaseService {
              pr.last_synced_at,
              pr.created_at,
              pr.updated_at,
+             stack_snapshot.stack_json,
     \(prGroupSelect)
     \(integrationSelect)
         from pull_requests pr
         left join lanes l on l.id = pr.lane_id and l.project_id = pr.project_id
+        left join pull_request_stack_snapshots stack_snapshot on stack_snapshot.pr_id = pr.id
     \(prGroupJoins)
     \(integrationJoin)
     """
@@ -2429,14 +2451,14 @@ final class DatabaseService {
         lastSyncedAt: stringValue(statement, index: 16),
         createdAt: stringValue(statement, index: 17) ?? "",
         updatedAt: stringValue(statement, index: 18) ?? "",
-        groupId: stringValue(statement, index: 19),
-        groupType: stringValue(statement, index: 20),
-        groupName: stringValue(statement, index: 21),
-        groupPosition: columnIsNull(statement, index: 22) ? nil : Int(sqlite3_column_int64(statement, 22)),
-        groupCount: Int(sqlite3_column_int64(statement, 23)),
-        workflowDisplayState: stringValue(statement, index: 24),
-        cleanupState: stringValue(statement, index: 25),
-        linkedWorkflowGroupId: stringValue(statement, index: 26)
+        groupId: stringValue(statement, index: 20),
+        groupType: stringValue(statement, index: 21),
+        groupName: stringValue(statement, index: 22),
+        groupPosition: columnIsNull(statement, index: 23) ? nil : Int(sqlite3_column_int64(statement, 23)),
+        groupCount: Int(sqlite3_column_int64(statement, 24)),
+        workflowDisplayState: stringValue(statement, index: 25),
+        cleanupState: stringValue(statement, index: 26),
+        linkedWorkflowGroupId: stringValue(statement, index: 27)
       )
 
       let adeKind: String?
@@ -2477,7 +2499,11 @@ final class DatabaseService {
         linkedGroupPosition: row.groupPosition,
         linkedGroupCount: row.groupCount,
         workflowDisplayState: row.workflowDisplayState,
-        cleanupState: row.cleanupState
+        cleanupState: row.cleanupState,
+        stack: decodeJson(
+          stringValue(statement, index: 19),
+          as: GitHubPrStackMembership.self
+        )
       )
     }
   }
@@ -3094,6 +3120,12 @@ final class DatabaseService {
     try exec("create index if not exists idx_pull_request_snapshots_updated_at on pull_request_snapshots(updated_at)")
     try ensureColumn(tableName: "pull_request_snapshots", columnName: "commits_json", definition: "text")
     try exec("""
+      create table if not exists pull_request_stack_snapshots (
+        pr_id text primary key,
+        stack_json text
+      )
+    """)
+    try exec("""
       create table if not exists pull_request_ai_summaries (
         pr_id text not null,
         head_sha text not null,
@@ -3203,6 +3235,7 @@ final class DatabaseService {
   private func deleteStalePullRequestRows(projectId: String, keeping prIds: [String]) throws {
     let childTables = [
       "pull_request_snapshots",
+      "pull_request_stack_snapshots",
       "pull_request_ai_summaries",
       "pr_group_members",
     ]

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -8724,6 +8724,73 @@ final class SyncService: ObservableObject {
     database.fetchPullRequestListItems(forLane: laneId)
   }
 
+  func fetchGitHubStacks(
+    repoOwner: String? = nil,
+    repoName: String? = nil,
+    refresh: Bool = false
+  ) async throws -> [GitHubPrStack] {
+    var args: [String: Any] = [:]
+    if let repoOwner, !repoOwner.isEmpty { args["repoOwner"] = repoOwner }
+    if let repoName, !repoName.isEmpty { args["repoName"] = repoName }
+    return try await sendDecodableCommand(
+      action: refresh ? "prs.syncGithubStacks" : "prs.listGithubStacks",
+      args: args,
+      as: [GitHubPrStack].self
+    )
+  }
+
+  @discardableResult
+  func createGitHubStack(
+    pullRequests: [Int],
+    repoOwner: String? = nil,
+    repoName: String? = nil
+  ) async throws -> GitHubPrStack {
+    var args: [String: Any] = ["pullRequests": pullRequests]
+    if let repoOwner, !repoOwner.isEmpty { args["repoOwner"] = repoOwner }
+    if let repoName, !repoName.isEmpty { args["repoName"] = repoName }
+    return try await sendDecodableCommand(
+      action: "prs.createGithubStack",
+      args: args,
+      as: GitHubPrStack.self
+    )
+  }
+
+  @discardableResult
+  func addPullRequestsToGitHubStack(
+    stackNumber: Int,
+    pullRequests: [Int],
+    repoOwner: String? = nil,
+    repoName: String? = nil
+  ) async throws -> GitHubPrStack {
+    var args: [String: Any] = [
+      "stackNumber": stackNumber,
+      "pullRequests": pullRequests,
+    ]
+    if let repoOwner, !repoOwner.isEmpty { args["repoOwner"] = repoOwner }
+    if let repoName, !repoName.isEmpty { args["repoName"] = repoName }
+    return try await sendDecodableCommand(
+      action: "prs.addGithubStackPullRequests",
+      args: args,
+      as: GitHubPrStack.self
+    )
+  }
+
+  @discardableResult
+  func unstackGitHubStack(
+    stackNumber: Int,
+    repoOwner: String? = nil,
+    repoName: String? = nil
+  ) async throws -> GitHubPrStack? {
+    var args: [String: Any] = ["stackNumber": stackNumber]
+    if let repoOwner, !repoOwner.isEmpty { args["repoOwner"] = repoOwner }
+    if let repoName, !repoName.isEmpty { args["repoName"] = repoName }
+    return try await sendDecodableCommand(
+      action: "prs.unstackGithubStack",
+      args: args,
+      as: GitHubPrStack?.self
+    )
+  }
+
   func fetchPullRequestForLane(laneId: String) async throws -> PrSummary? {
     try await sendDecodableCommand(
       action: "prs.getForLane",

--- a/apps/ios/ADE/Views/Lanes/LaneComponents.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneComponents.swift
@@ -469,6 +469,9 @@ struct LanePrTagChip: View {
       Text(formatLanePrBadgeLabel(tag))
         .font(.caption2.monospaced().weight(.bold))
         .lineLimit(1)
+      if let stack = tag.stack {
+        GitHubStackPositionBadge(stack: stack, compact: true)
+      }
     }
     .foregroundStyle(tint)
     .padding(.horizontal, 7)
@@ -478,7 +481,11 @@ struct LanePrTagChip: View {
       RoundedRectangle(cornerRadius: 7, style: .continuous)
         .stroke(tint.opacity(0.28), lineWidth: 0.6)
     )
-    .accessibilityLabel(formatLanePrBadgeLabel(tag))
+    .accessibilityLabel(
+      tag.stack.map {
+        "\(formatLanePrBadgeLabel(tag)), GitHub Stack \($0.position) of \($0.size)"
+      } ?? formatLanePrBadgeLabel(tag)
+    )
   }
 }
 

--- a/apps/ios/ADE/Views/Lanes/LaneHelpers.swift
+++ b/apps/ios/ADE/Views/Lanes/LaneHelpers.swift
@@ -335,6 +335,7 @@ struct LanePrTag: Equatable {
   var state: String
   var headBranch: String
   var updatedAt: String
+  var stack: GitHubPrStackMembership? = nil
 }
 
 /// Common ordering signal shared by both PR sources so a single comparator ranks
@@ -436,7 +437,8 @@ private func lanePrTag(from pr: PullRequestListItem) -> LanePrTag {
     title: pr.title,
     state: pr.state,
     headBranch: pr.headBranch,
-    updatedAt: pr.updatedAt
+    updatedAt: pr.updatedAt,
+    stack: pr.stack
   )
 }
 
@@ -449,7 +451,8 @@ private func lanePrTag(from pr: GitHubPrListItem, laneId: String) -> LanePrTag {
     title: pr.title,
     state: pr.isDraft ? "draft" : pr.state,
     headBranch: pr.headBranch ?? "",
-    updatedAt: pr.updatedAt
+    updatedAt: pr.updatedAt,
+    stack: pr.stack
   )
 }
 
@@ -500,7 +503,10 @@ func selectLaneTabPrTag(
   guard let mappedPr else {
     return githubPr.map { lanePrTag(from: $0, laneId: lane.id) }
   }
-  let mappedTag = lanePrTag(from: mappedPr)
+  var mappedTag = lanePrTag(from: mappedPr)
+  if let githubPr, githubPrMatchesAdePr(mappedPr, githubPr) {
+    mappedTag.stack = githubPr.stack ?? mappedTag.stack
+  }
   if let terminalGithubPr = selectTerminalGithubUpdate(for: mappedPr, githubPrs: githubPrs) {
     var tag = lanePrTag(from: terminalGithubPr, laneId: lane.id)
     tag.prId = tag.prId ?? mappedTag.prId

--- a/apps/ios/ADE/Views/PRs/PrDetailOverviewPreviews.swift
+++ b/apps/ios/ADE/Views/PRs/PrDetailOverviewPreviews.swift
@@ -351,6 +351,27 @@ private struct PrUnmappedBannerPreviewScreen: View {
   }
 }
 
+private struct PrGitHubStackCardPreviewScreen: View {
+  var body: some View {
+    VStack {
+      PrOverviewGitHubStackCard(
+        stack: GitHubPrStackMembership(
+          id: "github-stack:966",
+          number: 966,
+          size: 5,
+          position: 4,
+          baseBranch: "main"
+        ),
+        prNumber: 972,
+        onOpenGitHub: {}
+      )
+    }
+    .padding(16)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    .background(prLiquidGlassBackdrop().ignoresSafeArea())
+  }
+}
+
 #Preview("PR detail · Overview thread") {
   PrDetailOverviewPreviewScreen()
     .preferredColorScheme(.dark)
@@ -363,5 +384,10 @@ private struct PrUnmappedBannerPreviewScreen: View {
 
 #Preview("PR detail · Unmapped banner") {
   PrUnmappedBannerPreviewScreen()
+    .preferredColorScheme(.dark)
+}
+
+#Preview("PR detail · GitHub stack") {
+  PrGitHubStackCardPreviewScreen()
     .preferredColorScheme(.dark)
 }

--- a/apps/ios/ADE/Views/PRs/PrDetailOverviewTab.swift
+++ b/apps/ios/ADE/Views/PRs/PrDetailOverviewTab.swift
@@ -793,6 +793,65 @@ struct PrOverviewStackCard: View {
   }
 }
 
+struct PrOverviewGitHubStackCard: View {
+  let stack: GitHubPrStackMembership
+  let prNumber: Int
+  let onOpenGitHub: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      PrSectionHdr(title: "GitHub stack") {
+        Text("\(stack.position) of \(stack.size)")
+      }
+
+      HStack(alignment: .top, spacing: 12) {
+        VStack(spacing: 3) {
+          ForEach(Array((1...max(stack.size, 1)).reversed()), id: \.self) { position in
+            Circle()
+              .fill(position == stack.position ? ADEColor.tintPRs : ADEColor.textMuted.opacity(0.35))
+              .frame(width: position == stack.position ? 10 : 6, height: position == stack.position ? 10 : 6)
+              .overlay {
+                if position == stack.position {
+                  Circle().stroke(Color.white.opacity(0.45), lineWidth: 1)
+                }
+              }
+            if position > 1 {
+              Rectangle()
+                .fill(ADEColor.tintPRs.opacity(0.25))
+                .frame(width: 2, height: 14)
+            }
+          }
+        }
+        .frame(width: 18)
+
+        VStack(alignment: .leading, spacing: 6) {
+          GitHubStackPositionBadge(stack: stack)
+          Text("PR #\(prNumber) is position \(stack.position) of \(stack.size), based on \(stack.baseBranch).")
+            .font(.subheadline.weight(.medium))
+            .foregroundStyle(ADEColor.textPrimary)
+          Text("GitHub manages stack-wide review, rebase, and merge. Open the pull request to preview or merge the stack.")
+            .font(.caption)
+            .foregroundStyle(ADEColor.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+
+      Button(action: onOpenGitHub) {
+        Label("Review and merge on GitHub", systemImage: "arrow.up.right.square")
+          .frame(maxWidth: .infinity)
+      }
+      .buttonStyle(.glassProminent)
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 12)
+    .prGlassCard(cornerRadius: 16)
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel(
+      "GitHub Stack \(stack.number), pull request \(stack.position) of \(stack.size), base \(stack.baseBranch)"
+    )
+  }
+}
+
 // MARK: - File row
 
 private struct PrOverviewFileRow: View {

--- a/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
+++ b/apps/ios/ADE/Views/PRs/PrDetailScreen.swift
@@ -295,7 +295,8 @@ struct PrDetailView: View {
       linkedGroupPosition: nil,
       linkedGroupCount: 0,
       workflowDisplayState: githubItem?.workflowDisplayState,
-      cleanupState: githubItem?.cleanupState
+      cleanupState: githubItem?.cleanupState,
+      stack: githubItem?.stack
     )
   }
 
@@ -361,6 +362,10 @@ struct PrDetailView: View {
 
   private var isCurrentPrDraft: Bool {
     currentPr.state == "draft" || snapshot?.status?.state == "draft" || snapshot?.detail?.isDraft == true
+  }
+
+  private var nativeStackMembership: GitHubPrStackMembership? {
+    currentPr.stack ?? githubItem?.stack
   }
 
   private var mergeGateInfo: PrMergeGateInfo {
@@ -1099,9 +1104,19 @@ struct PrDetailView: View {
         .prListRow()
     }
 
-    // Inline merge rail with the requirement checklist (desktop merge rail).
-    PrOverviewMergeRail(model: overviewMergeRailModel, checklist: mergeChecklistItems)
+    // GitHub owns stack-wide review, rebase, and merge semantics. Keep ADE's
+    // native stack context visible, then hand the final action to GitHub.
+    if let stack = nativeStackMembership {
+      PrOverviewGitHubStackCard(
+        stack: stack,
+        prNumber: currentPr.githubPrNumber,
+        onOpenGitHub: { openGitHub(urlString: currentPr.githubUrl) }
+      )
       .prListRow()
+    } else {
+      PrOverviewMergeRail(model: overviewMergeRailModel, checklist: mergeChecklistItems)
+        .prListRow()
+    }
 
     // Metadata cards — the desktop right rail, stacked.
     if let snapshot, !snapshot.checks.isEmpty {
@@ -1244,50 +1259,60 @@ struct PrDetailView: View {
     let isAmber: Bool     // amber = need rebase first
     let action: () -> Void
     let enabled: Bool
+    let isStackHandoff = nativeStackMembership != nil
 
-    switch gate.tone {
-    case .green:
-      label = "Merge"
-      symbol = "checkmark.seal.fill"
-      isPrimary = true
+    if nativeStackMembership != nil {
+      label = "Review stack on GitHub"
+      symbol = "square.stack.3d.up.fill"
+      isPrimary = false
       isAmber = false
-      // Same structured-checklist agreement rule as overviewMergeRailModel.
-      enabled = canRunPrActions
-        && (capabilities?.canMerge ?? actionAvailability.mergeEnabled)
-        && !mergeChecklistItems.contains(where: { $0.state == .fail })
-      action = { presentMergeMethodPicker() }
-    case .amber:
-      if canRebaseFromGate {
-        label = behindBaseBy > 0 ? "Rebase · \(behindBaseBy) behind" : "Rebase"
-        symbol = "arrow.triangle.2.circlepath"
-      } else if gate.target == .checks {
-        label = "Checks pending"
-        symbol = "clock.badge.checkmark"
-      } else if gate.target == .reviews {
-        label = "Review needed"
-        symbol = "person.crop.circle.badge.exclamationmark"
-      } else {
-        label = "Waiting for status"
-        symbol = "clock"
+      enabled = !currentPr.githubUrl.isEmpty
+      action = { openGitHub(urlString: currentPr.githubUrl) }
+    } else {
+      switch gate.tone {
+      case .green:
+        label = "Merge"
+        symbol = "checkmark.seal.fill"
+        isPrimary = true
+        isAmber = false
+        // Same structured-checklist agreement rule as overviewMergeRailModel.
+        enabled = canRunPrActions
+          && (capabilities?.canMerge ?? actionAvailability.mergeEnabled)
+          && !mergeChecklistItems.contains(where: { $0.state == .fail })
+        action = { presentMergeMethodPicker() }
+      case .amber:
+        if canRebaseFromGate {
+          label = behindBaseBy > 0 ? "Rebase · \(behindBaseBy) behind" : "Rebase"
+          symbol = "arrow.triangle.2.circlepath"
+        } else if gate.target == .checks {
+          label = "Checks pending"
+          symbol = "clock.badge.checkmark"
+        } else if gate.target == .reviews {
+          label = "Review needed"
+          symbol = "person.crop.circle.badge.exclamationmark"
+        } else {
+          label = "Waiting for status"
+          symbol = "clock"
+        }
+        isPrimary = false
+        isAmber = true
+        enabled = canRebaseFromGate && canRunPrActions && !currentPr.laneId.isEmpty
+        action = { if canRebaseFromGate { triggerRebase() } }
+      case .red where canAttemptBlockedMerge:
+        label = "Attempt merge"
+        symbol = "arrow.triangle.merge"
+        isPrimary = false
+        isAmber = true
+        enabled = true
+        action = { presentMergeMethodPicker() }
+      case .red:
+        label = "Merge blocked"
+        symbol = "xmark.octagon.fill"
+        isPrimary = false
+        isAmber = false
+        enabled = false
+        action = { }
       }
-      isPrimary = false
-      isAmber = true
-      enabled = canRebaseFromGate && canRunPrActions && !currentPr.laneId.isEmpty
-      action = { if canRebaseFromGate { triggerRebase() } }
-    case .red where canAttemptBlockedMerge:
-      label = "Attempt merge"
-      symbol = "arrow.triangle.merge"
-      isPrimary = false
-      isAmber = true
-      enabled = true
-      action = { presentMergeMethodPicker() }
-    case .red:
-      label = "Merge blocked"
-      symbol = "xmark.octagon.fill"
-      isPrimary = false
-      isAmber = false
-      enabled = false
-      action = { }
     }
 
     return PrStickyActionBar {
@@ -1304,7 +1329,9 @@ struct PrDetailView: View {
           if isDetailBusy {
             ProgressView()
               .controlSize(.small)
-              .tint(isPrimary ? .white : (isAmber ? ADEColor.warning : ADEColor.danger))
+              .tint(
+                isPrimary ? .white : (isStackHandoff ? ADEColor.tintPRs : (isAmber ? ADEColor.warning : ADEColor.danger))
+              )
           } else {
             Image(systemName: symbol)
               .font(.system(size: 14, weight: .bold))
@@ -1314,7 +1341,9 @@ struct PrDetailView: View {
             .lineLimit(1)
             .fixedSize(horizontal: true, vertical: false)
         }
-        .foregroundStyle(isPrimary ? Color.white : (isAmber ? ADEColor.warning : ADEColor.danger))
+        .foregroundStyle(
+          isPrimary ? Color.white : (isStackHandoff ? ADEColor.tintPRs : (isAmber ? ADEColor.warning : ADEColor.danger))
+        )
         .frame(maxWidth: .infinity)
         .padding(.vertical, 16)
         .background {
@@ -1326,14 +1355,20 @@ struct PrDetailView: View {
               RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(PrGlassPalette.threadCard)
               RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill((isAmber ? ADEColor.warning : ADEColor.danger).opacity(0.12))
+                .fill(
+                  (isStackHandoff ? ADEColor.tintPRs : (isAmber ? ADEColor.warning : ADEColor.danger)).opacity(0.12)
+                )
             }
           }
         }
         .overlay(
           RoundedRectangle(cornerRadius: 16, style: .continuous)
             .strokeBorder(
-              isPrimary ? Color.white.opacity(0.20) : (isAmber ? ADEColor.warning.opacity(0.45) : ADEColor.danger.opacity(0.45)),
+              isPrimary
+                ? Color.white.opacity(0.20)
+                : (isStackHandoff
+                    ? ADEColor.tintPRs.opacity(0.45)
+                    : (isAmber ? ADEColor.warning.opacity(0.45) : ADEColor.danger.opacity(0.45))),
               lineWidth: 0.75
             )
         )
@@ -1637,6 +1672,10 @@ struct PrDetailView: View {
     commitTitle: String? = nil,
     commitBody: String? = nil
   ) {
+    guard nativeStackMembership == nil else {
+      openGitHub(urlString: currentPr.githubUrl)
+      return
+    }
     // Stale-head guard: pass the SHA the status was computed against so GitHub
     // rejects (409) if the head advanced while the sheet was open.
     let expectedHeadSha = snapshot?.status?.headSha

--- a/apps/ios/ADE/Views/PRs/PrHelpers.swift
+++ b/apps/ios/ADE/Views/PRs/PrHelpers.swift
@@ -343,6 +343,7 @@ func prReconcileGitHubPullRequests(
       item.adeKind = mapped.adeKind
       item.workflowDisplayState = mapped.workflowDisplayState
       item.cleanupState = mapped.cleanupState
+      item.stack = item.stack ?? mapped.stack
       // Let the newest projection own state in either direction. This keeps a
       // terminal replicated row visible behind an older open-only response,
       // while also allowing a freshly reopened local row to override a stale
@@ -398,13 +399,47 @@ func prReconcileGitHubPullRequests(
       cleanupState: mapped.cleanupState,
       labels: [],
       isBot: false,
-      commentCount: 0
+      commentCount: 0,
+      stack: mapped.stack
     )
     indexByIdentity[key] = result.count
     result.append(item)
   }
 
   return result
+}
+
+struct GitHubStackPositionBadge: View {
+  let stack: GitHubPrStackMembership
+  var compact = false
+
+  var body: some View {
+    HStack(spacing: 4) {
+      Image(systemName: "square.stack.3d.up.fill")
+        .font(.system(size: compact ? 9 : 10, weight: .semibold))
+      Text(compact ? "\(stack.position)/\(stack.size)" : "Stack \(stack.position)/\(stack.size)")
+        .font(.caption2.monospaced().weight(.semibold))
+        .lineLimit(1)
+    }
+    .foregroundStyle(ADEColor.tintPRs)
+    .padding(.horizontal, compact ? 0 : 7)
+    .padding(.vertical, compact ? 0 : 3)
+    .background {
+      if !compact {
+        Capsule(style: .continuous)
+          .fill(ADEColor.tintPRs.opacity(0.12))
+      }
+    }
+    .overlay {
+      if !compact {
+        Capsule(style: .continuous)
+          .stroke(ADEColor.tintPRs.opacity(0.28), lineWidth: 0.6)
+      }
+    }
+    .accessibilityLabel(
+      "GitHub Stack \(stack.position) of \(stack.size), base \(stack.baseBranch)"
+    )
+  }
 }
 
 // MARK: - GitHub PR list filter/sort/count (free functions)

--- a/apps/ios/ADE/Views/PRs/PrRowCard.swift
+++ b/apps/ios/ADE/Views/PRs/PrRowCard.swift
@@ -118,6 +118,9 @@ struct PrRowCard: View {
   private var accessibilitySummary: String {
     var parts = ["Pull request \(data.prNumber)", data.title, "State \(data.state)"]
     if let author = data.authorLogin, !author.isEmpty { parts.append("Author \(author)") }
+    if let stack = data.githubStack {
+      parts.append("GitHub Stack \(stack.position) of \(stack.size)")
+    }
     if let head = data.headBranch, let base = data.baseBranch { parts.append("\(head) into \(base)") }
     if let ci = data.ciIndicator { parts.append(ci.title) }
     if let review = data.reviewIndicator { parts.append(review.label) }
@@ -135,6 +138,9 @@ struct PrRowCard: View {
     HStack(spacing: 5) {
       Text("#\(data.prNumber)")
         .foregroundStyle(PrRowDesktopPalette.stateColors(data.state).text)
+      if let stack = data.githubStack {
+        GitHubStackPositionBadge(stack: stack, compact: true)
+      }
       if let author = data.authorLogin, !author.isEmpty {
         Text("·")
         Text("@\(author)")
@@ -311,6 +317,7 @@ extension PrRowCard {
     let stackGroupId: String?
     let stackGroupName: String?
     let stackGroupCount: Int?
+    let githubStack: GitHubPrStackMembership?
 
     var timeAgo: String {
       prRelativeTime(updatedAt)
@@ -379,6 +386,7 @@ extension PrRowCard {
       self.stackGroupId = pr.linkedGroupId
       self.stackGroupName = pr.linkedGroupName
       self.stackGroupCount = pr.linkedGroupCount > 0 ? pr.linkedGroupCount : nil
+      self.githubStack = pr.stack
     }
 
     init(item: GitHubPrListItem, linkedPr: PullRequestListItem?) {
@@ -413,6 +421,7 @@ extension PrRowCard {
       self.stackGroupId = item.linkedGroupId
       self.stackGroupName = nil
       self.stackGroupCount = nil
+      self.githubStack = item.stack ?? linkedPr?.stack
     }
 
     private static func warnMessage(

--- a/apps/ios/ADE/Views/Work/WorkChatPrViews.swift
+++ b/apps/ios/ADE/Views/Work/WorkChatPrViews.swift
@@ -7,6 +7,7 @@ struct WorkChatPrBadgeModel: Equatable {
   let checksStatus: String?
   let reviewStatus: String?
   let updatedAt: String
+  let stack: GitHubPrStackMembership?
 }
 
 func workChatPrBadgeModel(tag: LanePrTag?, pr: PullRequestListItem?, summary: PrSummary? = nil) -> WorkChatPrBadgeModel? {
@@ -17,7 +18,8 @@ func workChatPrBadgeModel(tag: LanePrTag?, pr: PullRequestListItem?, summary: Pr
     state: tag.state,
     checksStatus: pr?.checksStatus ?? summary?.checksStatus,
     reviewStatus: pr?.reviewStatus ?? summary?.reviewStatus,
-    updatedAt: tag.updatedAt
+    updatedAt: tag.updatedAt,
+    stack: tag.stack ?? pr?.stack ?? summary?.stack
   )
 }
 
@@ -50,6 +52,9 @@ struct WorkChatPrActivePopup: View {
     if let reviewStatus = badge.reviewStatus, !reviewStatus.isEmpty, reviewStatus != "none" {
       parts.append("review \(reviewStatus.replacingOccurrences(of: "_", with: " "))")
     }
+    if let stack = badge.stack {
+      parts.append("GitHub Stack \(stack.position) of \(stack.size)")
+    }
     return parts.joined(separator: ", ") + ". Tap for details."
   }
 
@@ -65,6 +70,9 @@ struct WorkChatPrActivePopup: View {
       Text(badge.label)
         .font(.caption.weight(.semibold))
         .lineLimit(1)
+      if let stack = badge.stack {
+        GitHubStackPositionBadge(stack: stack, compact: true)
+      }
       if let ciSymbol {
         Image(systemName: ciSymbol)
           .font(.system(size: 10, weight: .bold))
@@ -175,6 +183,19 @@ struct WorkChatPrDetailsSheet: View {
         baseBranch: branches.base,
         tint: branchTint
       )
+
+      if let stack = tag.stack ?? pr?.stack ?? summary?.stack {
+        HStack(spacing: 9) {
+          GitHubStackPositionBadge(stack: stack)
+          Text("GitHub manages review, rebase, and merge for this stack.")
+            .font(.caption)
+            .foregroundStyle(ADEColor.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(ADEColor.tintPRs.opacity(0.08), in: RoundedRectangle(cornerRadius: 12))
+      }
 
       HStack(spacing: 10) {
         WorkChatPrChangesMetricCard(additions: additions, deletions: deletions)

--- a/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionDestinationView+Actions.swift
@@ -1076,7 +1076,8 @@ func workChatLanePrTag(from pr: PullRequestListItem) -> LanePrTag {
     title: pr.title,
     state: pr.state,
     headBranch: pr.headBranch,
-    updatedAt: pr.updatedAt
+    updatedAt: pr.updatedAt,
+    stack: pr.stack
   )
 }
 
@@ -1089,7 +1090,8 @@ func workChatLanePrTag(from pr: PrSummary) -> LanePrTag {
     title: pr.title,
     state: pr.state,
     headBranch: pr.headBranch,
-    updatedAt: pr.updatedAt
+    updatedAt: pr.updatedAt,
+    stack: pr.stack
   )
 }
 

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -10177,7 +10177,14 @@ final class ADETests: XCTestCase {
             lastSyncedAt: "2026-03-17T00:10:00.000Z",
             createdAt: "2026-03-17T00:10:00.000Z",
             updatedAt: "2026-03-17T00:10:00.000Z",
-            mergedAt: "2026-03-17T00:11:00.000Z"
+            mergedAt: "2026-03-17T00:11:00.000Z",
+            stack: GitHubPrStackMembership(
+              id: "stack-81",
+              number: 81,
+              size: 3,
+              position: 2,
+              baseBranch: "main"
+            )
           ),
         ],
         snapshots: [
@@ -10218,6 +10225,8 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(prs.first?.id, "pr-1")
     XCTAssertEqual(prs.first?.title, "Fix mobile hydration")
     XCTAssertEqual(prs.first?.mergedAt, "2026-03-17T00:11:00.000Z")
+    XCTAssertEqual(prs.first?.stack?.position, 2)
+    XCTAssertEqual(database.fetchPullRequestListItems().first?.stack?.number, 81)
     XCTAssertEqual(database.fetchPullRequestSnapshot(prId: "pr-1")?.status?.isMergeable, true)
 
     var legacySummary = try XCTUnwrap(prs.first)
@@ -12147,7 +12156,15 @@ final class ADETests: XCTestCase {
         cleanupState: nil
       )
     }
-    func githubPr(number: Int, state: String, headBranch: String, linkedLaneId: String?, linkedPrId: String?, headRepoOwner: String? = nil) -> GitHubPrListItem {
+    func githubPr(
+      number: Int,
+      state: String,
+      headBranch: String,
+      linkedLaneId: String?,
+      linkedPrId: String?,
+      headRepoOwner: String? = nil,
+      stack: GitHubPrStackMembership? = nil
+    ) -> GitHubPrListItem {
       GitHubPrListItem(
         id: "gh-\(number)",
         scope: "repo",
@@ -12174,7 +12191,8 @@ final class ADETests: XCTestCase {
         cleanupState: nil,
         labels: [],
         isBot: false,
-        commentCount: 0
+        commentCount: 0,
+        stack: stack
       )
     }
 
@@ -12194,6 +12212,33 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(githubOnly?.source, .github)
     XCTAssertEqual(githubOnly?.githubPrNumber, 777)
     XCTAssertNil(githubOnly?.prId)
+
+    let nativeStack = GitHubPrStackMembership(
+      id: "stack-966",
+      number: 966,
+      size: 4,
+      position: 3,
+      baseBranch: "main"
+    )
+    let stacked = selectLaneTabPrTag(
+      lane: lane,
+      pullRequests: [adePr(id: "pr-open", number: 561, state: "open")],
+      githubPrs: [
+        githubPr(
+          number: 561,
+          state: "open",
+          headBranch: "ade/mobile-audit-34b23435",
+          linkedLaneId: "lane-audit",
+          linkedPrId: "pr-open",
+          stack: nativeStack
+        ),
+      ]
+    )
+    XCTAssertEqual(stacked?.stack, nativeStack)
+    XCTAssertEqual(
+      workChatPrBadgeModel(tag: stacked, pr: nil)?.stack,
+      nativeStack
+    )
 
     // ADE row still says "open" but GitHub reports the same PR merged → adopt the
     // terminal GitHub state while preserving the ADE prId for in-app navigation.


### PR DESCRIPTION
## Summary
- decode and persist native GitHub stack membership in the iOS client
- show stack position across PR rows, lane chips, and Work chat badges
- add a dedicated stack card with clear GitHub review and merge handoff
- expose native stack create, add, refresh, and unstack actions through SyncService

## Validation
- focused iOS hydration and lane mapping tests
- iOS simulator build with parallel testing disabled
- git diff --check

Built as PR 5 in native GitHub Stack #966.
