### PR TITLE
Thread Grid View Indicator -> Primary

### DIFF
--- a/apps/desktop/src/renderer/components/terminals/SessionCard.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.test.tsx
@@ -118,7 +118,7 @@ describe("SessionCard orchestration identity", () => {
       />,
     );
 
-    const indicator = screen.getByLabelText("In the active grid");
+    const indicator = screen.getByRole("img", { name: "In the active grid" });
     const status = container.querySelector("[data-session-status-slot]");
     expect(indicator).toBeTruthy();
     expect(status).toBeTruthy();

--- a/apps/desktop/src/renderer/components/terminals/SessionCard.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.test.tsx
@@ -106,6 +106,25 @@ function row(container: HTMLElement): HTMLElement {
 }
 
 describe("SessionCard orchestration identity", () => {
+  it("shows grid membership immediately left of the status", () => {
+    const { container } = render(
+      <SessionCard
+        session={makeSession()}
+        lane={lane}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onContextMenu={vi.fn()}
+        gridBadge="active"
+      />,
+    );
+
+    const indicator = screen.getByLabelText("In the active grid");
+    const status = container.querySelector("[data-session-status-slot]");
+    expect(indicator).toBeTruthy();
+    expect(status).toBeTruthy();
+    expect(indicator.nextElementSibling).toBe(status);
+  });
+
   it("names the row with its orchestration role for assistive tech", () => {
     const { container } = render(
       <SessionCard

--- a/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
@@ -821,6 +821,7 @@ export const SessionCard = React.memo(function SessionCard({
   const gridIndicator = gridBadge ? (
     <span
       data-testid="session-grid-indicator"
+      role="img"
       className={cn(
         "inline-flex shrink-0 items-center justify-center",
         gridBadge === "active" ? "text-violet-300" : "text-muted-fg/40",

--- a/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
@@ -75,9 +75,11 @@ import { GitHubStackBadge } from "../prs/shared/GitHubStackBadge";
 
    Status lives in the row's CONTENT instead, in exactly one place: the status
    slot on line 1 (`SessionStatusSlot`). Everything that used to compete with
-   it on that line — role pills, spawn pills, Imported/grid badges, live-child
+   it on that line — role pills, spawn pills, Imported badges, live-child
    counts, wake chips, the Claude tag — moved into the hover tooltip. They are
-   real, they are just not worth a permanent seat.
+   real, they are just not worth a permanent seat. Grid membership is the one
+   compact identity marker that stays visible because it explains why a sidebar
+   session is also present in the workspace.
    ────────────────────────────────────────────────────────────────────────── */
 
 /* ── Full-bleed row geometry ───────────────────────────────────────────────
@@ -816,6 +818,19 @@ export const SessionCard = React.memo(function SessionCard({
       runtimePin={runtimePin}
     />
   );
+  const gridIndicator = gridBadge ? (
+    <span
+      data-testid="session-grid-indicator"
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center",
+        gridBadge === "active" ? "text-violet-300" : "text-muted-fg/40",
+      )}
+      title={gridBadge === "active" ? "In the active grid" : "In another grid"}
+      aria-label={gridBadge === "active" ? "In the active grid" : "In another grid"}
+    >
+      <GridFour size={11} weight={gridBadge === "active" ? "fill" : "bold"} />
+    </span>
+  ) : null;
 
   /* COMPACT ROWS ONLY. The full row carries lineage on line 1 now, and two
      lineage indicators on one row is exactly the duplication this pass removes.
@@ -920,6 +935,7 @@ export const SessionCard = React.memo(function SessionCard({
           {titleNode}
           {compactLineageGlyph}
           <ToolLogo toolType={session.toolType} size={14} className="shrink-0 opacity-75" />
+          {gridIndicator}
           {statusSlot}
         </div>
       ) : (
@@ -935,6 +951,7 @@ export const SessionCard = React.memo(function SessionCard({
                 {part}
               </React.Fragment>
             ))}
+            {gridIndicator}
             {statusSlot}
           </div>
 


### PR DESCRIPTION


<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fthread-grid-view-indicator num=978 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fthread-grid-view-indicator&amp;pr=978">ade/thread-grid-view-indicator branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=978">PR #978</a>
</p>
<!-- /ade:link -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a grid membership indicator to session cards, showing whether a session is actively connected to a grid.
  * The indicator is available in both compact and full session layouts.

* **Tests**
  * Added coverage to verify the indicator appears next to the session status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->