### PR TITLE
Show planning and background chat states

### DIFF
--- a/apps/desktop/src/main/services/chat/agentChatService.ts
+++ b/apps/desktop/src/main/services/chat/agentChatService.ts
@@ -37253,6 +37253,9 @@ export function createAgentChatService(args: {
     const claudeTag = provider === "claude"
       ? getClaudeSessionPointerForChat(row.id)?.tags[0] ?? null
       : undefined;
+    const activeBackgroundTaskCount = liveManaged?.runtime?.kind === "claude"
+      ? liveManaged.runtime.liveBackgroundTaskIds.size
+      : 0;
     let nextWakeAt: string | null = null;
     let scheduledWorkPaused = false;
     let scheduledWork: AgentChatScheduledWorkItem[] = [];
@@ -37360,6 +37363,7 @@ export function createAgentChatService(args: {
       summary: row.summary ?? null,
       ...(provider === "claude" ? { claudeTag } : {}),
       nextWakeAt,
+      activeBackgroundTaskCount,
       scheduledWorkPaused,
       scheduledWork,
       ...(sessionHasPendingInput ? { awaitingInput: true } : {}),

--- a/apps/desktop/src/main/services/sessions/chatSessionProjection.test.ts
+++ b/apps/desktop/src/main/services/sessions/chatSessionProjection.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { AgentChatSessionSummary, TerminalSessionSummary } from "../../../shared/types";
+import { projectChatOntoSession } from "./chatSessionProjection";
+
+function session(): TerminalSessionSummary {
+  return {
+    id: "chat-1",
+    laneId: "lane-1",
+    laneName: "Planning state",
+    ptyId: null,
+    tracked: true,
+    pinned: false,
+    goal: null,
+    toolType: "codex-chat",
+    title: "Planning state",
+    status: "running",
+    startedAt: "2026-08-01T10:00:00.000Z",
+    endedAt: null,
+    exitCode: null,
+    transcriptPath: "/tmp/chat-1.jsonl",
+    headShaStart: null,
+    headShaEnd: null,
+    lastOutputPreview: null,
+    summary: null,
+    runtimeState: "idle",
+    resumeCommand: null,
+  };
+}
+
+function chat(overrides: Partial<AgentChatSessionSummary> = {}): AgentChatSessionSummary {
+  return {
+    sessionId: "chat-1",
+    laneId: "lane-1",
+    provider: "codex",
+    model: "openai/gpt-5.6-sol",
+    status: "idle",
+    startedAt: "2026-08-01T10:00:00.000Z",
+    endedAt: null,
+    lastActivityAt: "2026-08-01T10:01:00.000Z",
+    lastOutputPreview: null,
+    summary: null,
+    nextWakeAt: null,
+    ...overrides,
+  };
+}
+
+describe("chatSessionProjection", () => {
+  it("projects current plan mode without changing idle chat lifecycle", () => {
+    const projected = projectChatOntoSession(session(), chat({
+      interactionMode: "plan",
+      permissionMode: "plan",
+    }));
+
+    expect(projected.chatActivityMode).toBe("planning");
+    expect(projected.runtimeState).toBe("idle");
+    expect(projected.activeBackgroundTaskCount).toBe(0);
+  });
+
+  it("projects authoritative background count and the next armed wake", () => {
+    const projected = projectChatOntoSession(session(), chat({
+      activeBackgroundTaskCount: 2,
+      nextWakeAt: "2026-08-01T12:00:00.000Z",
+    }));
+
+    expect(projected.activeBackgroundTaskCount).toBe(2);
+    expect(projected.nextWakeAt).toBe("2026-08-01T12:00:00.000Z");
+    expect(projected.runtimeState).toBe("idle");
+  });
+
+  it("clears stale presentation metadata when the chat reports normal mode and no tasks", () => {
+    const projected = projectChatOntoSession({
+      ...session(),
+      chatActivityMode: "planning",
+      activeBackgroundTaskCount: 3,
+    }, chat({
+      interactionMode: "default",
+      permissionMode: "default",
+      activeBackgroundTaskCount: 0,
+    }));
+
+    expect(projected.chatActivityMode).toBeNull();
+    expect(projected.activeBackgroundTaskCount).toBe(0);
+    expect(projected.nextWakeAt).toBeNull();
+  });
+
+  it("does not mistake a read-only legacy permission projection for plan interaction mode", () => {
+    const projected = projectChatOntoSession(session(), chat({
+      interactionMode: "default",
+      permissionMode: "plan",
+    }));
+
+    expect(projected.chatActivityMode).toBeNull();
+    expect(projected.runtimeState).toBe("idle");
+    expect(projected.activeBackgroundTaskCount).toBe(0);
+  });
+});

--- a/apps/desktop/src/main/services/sessions/chatSessionProjection.ts
+++ b/apps/desktop/src/main/services/sessions/chatSessionProjection.ts
@@ -73,6 +73,8 @@ export function projectChatOntoSession(
   const base: TerminalSessionSummary = {
     ...session,
     nextWakeAt: chat.nextWakeAt,
+    chatActivityMode: chat.interactionMode === "plan" ? "planning" : null,
+    activeBackgroundTaskCount: chat.activeBackgroundTaskCount ?? 0,
     ...(chat.claudeTag !== undefined ? { claudeTag: chat.claudeTag } : {}),
     ...(chat.orchestrationRunId
       ? {

--- a/apps/desktop/src/renderer/components/terminals/SessionCard.test.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.test.tsx
@@ -936,6 +936,77 @@ describe("SessionCard status vocabulary", () => {
     expect(screen.queryByText("Needs you")).toBeNull();
   });
 
+  it("shows Planning for an active ADE chat without adding schedule copy", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00.000Z"));
+    const { container } = render(
+      <SessionCard
+        session={makeSession({
+          toolType: "codex-chat",
+          runtimeState: "running",
+          chatActivityMode: "planning",
+          nextWakeAt: "2026-07-09T12:12:00.000Z",
+          lastActivityAt: "2026-07-09T11:59:30.000Z",
+        })}
+        lane={lane}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onContextMenu={vi.fn()}
+      />,
+    );
+
+    const status = container.querySelector("[data-session-status]")!;
+    expect(status.getAttribute("data-session-status")).toBe("Planning");
+    expect(status.getAttribute("data-session-tone")).toBe("violet");
+    expect(status.textContent).toContain("30s");
+    expect(status.textContent).not.toContain("12m");
+  });
+
+  it("shows Working when the foreground turn is idle but background work remains", () => {
+    const { container } = render(
+      <SessionCard
+        session={makeSession({
+          toolType: "claude-chat",
+          runtimeState: "idle",
+          activeBackgroundTaskCount: 1,
+        })}
+        lane={lane}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onContextMenu={vi.fn()}
+      />,
+    );
+
+    const status = container.querySelector("[data-session-status]")!;
+    expect(status.getAttribute("data-session-status")).toBe("Working");
+    expect(status.getAttribute("data-session-tone")).toBe("blue");
+    expect(status.textContent).toBe("Working");
+  });
+
+  it("shows a compact Waiting countdown only after the foreground turn is idle", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00.000Z"));
+    const { container } = render(
+      <SessionCard
+        session={makeSession({
+          toolType: "codex-chat",
+          runtimeState: "idle",
+          nextWakeAt: "2026-07-09T12:12:00.000Z",
+        })}
+        lane={lane}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onContextMenu={vi.fn()}
+      />,
+    );
+
+    const status = container.querySelector("[data-session-status]")!;
+    expect(status.getAttribute("data-session-status")).toBe("Waiting");
+    expect(status.getAttribute("data-session-tone")).toBe("neutral");
+    expect(status.textContent).toBe("Waiting12m");
+    expect(screen.getByRole("status").getAttribute("aria-label")).toContain("Next run");
+  });
+
   it("pulses once when an existing card transitions into Needs you", () => {
     vi.useFakeTimers();
     const baseProps = {

--- a/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
@@ -62,6 +62,7 @@ import { requestLinearIssueQuickView } from "../../lib/linearIssueQuickViewNavig
 import { isSessionSnoozed, sessionWokeMarker, snoozeWakeLabel } from "../../lib/sessionSnooze";
 import { SessionStatusSlot } from "./SessionStatusSlot";
 import { GitHubStackBadge } from "../prs/shared/GitHubStackBadge";
+import { formatFutureDuration } from "../../../shared/sessionStatusPresentation";
 
 /* ──────────────────────────────────────────────────────────────────────────
    The Work-sidebar session card.
@@ -252,18 +253,6 @@ function LinkifiedPreviewLine({
       </span>
     );
   });
-}
-
-function compactFutureDuration(timestampMs: number, nowMs: number): string | null {
-  if (!Number.isFinite(timestampMs) || timestampMs <= nowMs) return null;
-  const totalMinutes = Math.max(1, Math.ceil((timestampMs - nowMs) / 60_000));
-  if (totalMinutes < 60) return `${totalMinutes}m`;
-  const totalHours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  if (totalHours < 24) return minutes ? `${totalHours}h ${minutes}m` : `${totalHours}h`;
-  const days = Math.floor(totalHours / 24);
-  const hours = totalHours % 24;
-  return hours ? `${days}d ${hours}h` : `${days}d`;
 }
 
 /**
@@ -774,13 +763,13 @@ export const SessionCard = React.memo(function SessionCard({
     });
   }
   if (session.nextWakeAt) {
-    const wakeIn = compactFutureDuration(Date.parse(session.nextWakeAt), Date.now());
+    const wakeIn = formatFutureDuration(Date.parse(session.nextWakeAt), Date.now());
     // Neutral, never amber: a scheduled wake is the agent's move, not yours.
     if (wakeIn) {
       hoverRows.push({
         id: "next-wake",
         icon: <Alarm size={13} className="text-muted-fg/60" />,
-        value: `Wakes in ${wakeIn}`,
+        value: `Wakes in ${wakeIn} · ${new Date(session.nextWakeAt).toLocaleString()}`,
       });
     }
   }

--- a/apps/desktop/src/renderer/components/terminals/SessionStatusSlot.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionStatusSlot.tsx
@@ -7,11 +7,13 @@ import {
   Circle,
   CircleDashed,
   Clock,
+  NotePencil,
   Moon,
 } from "@phosphor-icons/react";
 import type { OpenProjectBinding, TerminalSessionSummary } from "../../../shared/types";
 import {
   SESSION_TONE_TEXT_CLASS,
+  formatFutureDuration,
   formatWorkingDuration,
   type SessionStatusGlyph,
   type SessionStatusPresentation,
@@ -54,6 +56,10 @@ function StatusGlyph({ glyph }: { glyph: SessionStatusGlyph }) {
   switch (glyph) {
     case "working":
       return <CircleDashed size={13} weight="bold" aria-hidden className="shrink-0" />;
+    case "planning":
+      return <NotePencil size={13} weight="bold" aria-hidden className="shrink-0" />;
+    case "waiting":
+      return <Alarm size={13} weight="regular" aria-hidden className="shrink-0" />;
     case "done":
       return <CheckCircle size={13} weight="bold" aria-hidden className="shrink-0" />;
     // Filled, not outlined: "your move" is the one state allowed to shout.
@@ -95,6 +101,24 @@ function useElapsedLabel(sinceIso: string | null | undefined, enabled: boolean):
 
   if (!enabled || sinceMs == null) return "";
   return formatWorkingDuration(nowMs - sinceMs);
+}
+
+function useFutureLabel(atIso: string | null | undefined, enabled: boolean): string {
+  const atMs = React.useMemo(() => {
+    const parsed = atIso ? Date.parse(atIso) : Number.NaN;
+    return Number.isFinite(parsed) ? parsed : null;
+  }, [atIso]);
+  const [nowMs, setNowMs] = React.useState(() => Date.now());
+
+  React.useEffect(() => {
+    if (!enabled || atMs == null) return undefined;
+    setNowMs(Date.now());
+    const intervalId = window.setInterval(() => setNowMs(Date.now()), 30_000);
+    return () => window.clearInterval(intervalId);
+  }, [atMs, enabled]);
+
+  if (!enabled || atMs == null) return "";
+  return formatFutureDuration(atMs, nowMs);
 }
 
 /**
@@ -149,6 +173,15 @@ export function SessionStatusSlot({
     session.lastActivityAt ?? session.startedAt,
     Boolean(presentation?.showsElapsed),
   );
+  const waiting = presentation?.glyph === "waiting";
+  const future = useFutureLabel(session.nextWakeAt, waiting);
+  const exactWakeTitle = React.useMemo(() => {
+    if (!waiting || !session.nextWakeAt) return undefined;
+    const wakeAt = Date.parse(session.nextWakeAt);
+    return Number.isFinite(wakeAt)
+      ? `Next run ${new Date(wakeAt).toLocaleString()}`
+      : undefined;
+  }, [session.nextWakeAt, waiting]);
   const canonicalPhase = sessionCanonicalUiState(canonicalInputFromSummary(session)).phase;
   const isActivelyRunning = canonicalPhase === "starting"
     || canonicalPhase === "running"
@@ -197,10 +230,15 @@ export function SessionStatusSlot({
             {/* role="status" sits on the LABEL alone. Putting it on a wrapper
                 that also contains the ticking duration makes screen readers
                 announce the row once per second. */}
-            <span role="status">{presentation.label}</span>
+            <span role="status" aria-label={exactWakeTitle}>{presentation.label}</span>
             {elapsed ? (
               <span aria-hidden className="tabular-nums">
                 {elapsed}
+              </span>
+            ) : null}
+            {future ? (
+              <span aria-hidden className="tabular-nums">
+                {future}
               </span>
             ) : null}
           </span>

--- a/apps/desktop/src/renderer/lib/terminalAttention.test.ts
+++ b/apps/desktop/src/renderer/lib/terminalAttention.test.ts
@@ -4,6 +4,7 @@ import {
   sanitizeTerminalInlineText,
   sessionNeedsChatTabHighlight,
   sessionStatusBucket,
+  sessionStatusDisplay,
   sessionStatusDot,
 } from "./terminalAttention";
 
@@ -248,6 +249,104 @@ describe("terminalAttention", () => {
       expect(dot.spinning).toBe(false);
       expect(dot.cls).toContain("emerald");
       expect(dot.label).toBe("Done");
+    });
+  });
+
+  describe("sessionStatusDisplay", () => {
+    it("shows Planning only while an ADE chat has an active plan-mode turn", () => {
+      const active = sessionStatusDisplay({
+        status: "running",
+        runtimeState: "running",
+        toolType: "codex-chat",
+        lastOutputPreview: "Inspecting the repository",
+        chatActivityMode: "planning",
+      });
+      const idle = sessionStatusDisplay({
+        status: "running",
+        runtimeState: "idle",
+        toolType: "codex-chat",
+        lastOutputPreview: "Plan ready",
+        chatActivityMode: "planning",
+      });
+
+      expect(active).toMatchObject({
+        label: "Planning",
+        tone: "violet",
+        glyph: "planning",
+        showsElapsed: true,
+      });
+      expect(idle?.label).toBe("Done");
+      expect(idle?.tone).toBe("emerald");
+    });
+
+    it("keeps an idle chat Working while authoritative background tasks remain", () => {
+      const presentation = sessionStatusDisplay({
+        status: "running",
+        runtimeState: "idle",
+        toolType: "claude-chat",
+        lastOutputPreview: "Foreground turn complete",
+        activeBackgroundTaskCount: 2,
+        nextWakeAt: "2026-08-01T12:00:00.000Z",
+        nowMs: Date.parse("2026-08-01T10:00:00.000Z"),
+      });
+
+      expect(presentation).toMatchObject({
+        label: "Working",
+        tone: "blue",
+        glyph: "working",
+      });
+      expect(presentation?.showsElapsed).toBe(false);
+    });
+
+    it("shows Waiting only for an idle chat with a valid future wake", () => {
+      const base = {
+        status: "running" as const,
+        runtimeState: "idle" as const,
+        toolType: "codex-chat" as const,
+        lastOutputPreview: "Current turn complete",
+        nowMs: Date.parse("2026-08-01T10:00:00.000Z"),
+      };
+      const future = sessionStatusDisplay({
+        ...base,
+        nextWakeAt: "2026-08-01T12:00:00.000Z",
+      });
+      const elapsed = sessionStatusDisplay({
+        ...base,
+        nextWakeAt: "2026-08-01T09:00:00.000Z",
+      });
+
+      expect(future).toMatchObject({
+        label: "Waiting",
+        tone: "neutral",
+        glyph: "waiting",
+      });
+      expect(elapsed?.label).toBe("Done");
+      expect(elapsed?.tone).toBe("emerald");
+    });
+
+    it("preserves attention and stale states over informational chat modes", () => {
+      const needsYou = sessionStatusDisplay({
+        status: "running",
+        runtimeState: "waiting-input",
+        toolType: "codex-chat",
+        pendingInputItemId: "approval-1",
+        lastOutputPreview: "Approve?",
+        chatActivityMode: "planning",
+      });
+      const stale = sessionStatusDisplay({
+        status: "running",
+        runtimeState: "running",
+        toolType: "claude-chat",
+        lastOutputPreview: "Still running",
+        lastActivityAt: "2026-08-01T06:00:00.000Z",
+        activeBackgroundTaskCount: 1,
+        nowMs: Date.parse("2026-08-01T10:00:00.000Z"),
+      });
+
+      expect(needsYou?.label).toBe("Needs you");
+      expect(needsYou?.tone).toBe("amber");
+      expect(stale?.label).toBe("Stale");
+      expect(stale?.tone).toBe("neutral");
     });
   });
 });

--- a/apps/desktop/src/renderer/lib/terminalAttention.ts
+++ b/apps/desktop/src/renderer/lib/terminalAttention.ts
@@ -139,6 +139,9 @@ type SessionCanonicalUiInput = {
   settleOverride?: SessionSettleOverride | null;
   attentionRequestedAt?: string | null;
   lastTurnFailedAt?: string | null;
+  nextWakeAt?: string | null;
+  chatActivityMode?: TerminalSessionSummary["chatActivityMode"];
+  activeBackgroundTaskCount?: number;
   nowMs?: number;
 };
 
@@ -161,6 +164,9 @@ export function canonicalInputFromSummary(session: TerminalSessionSummary): Sess
     settleOverride: session.settleOverride,
     attentionRequestedAt: session.attentionRequestedAt,
     lastTurnFailedAt: session.lastTurnFailedAt,
+    nextWakeAt: session.nextWakeAt,
+    chatActivityMode: session.chatActivityMode,
+    activeBackgroundTaskCount: session.activeBackgroundTaskCount,
   };
 }
 
@@ -213,7 +219,13 @@ export function sessionStatusDisplay(
   session: SessionCanonicalUiInput,
   overlay: SessionStatusOverlay = {},
 ): SessionStatusPresentation | null {
-  return sessionStatusPresentation(sessionCanonicalUiState(session).phase, overlay);
+  const phase = sessionCanonicalUiState(session).phase;
+  return sessionStatusPresentation(phase, overlay, {
+    chatActivityMode: session.chatActivityMode,
+    activeBackgroundTaskCount: session.activeBackgroundTaskCount,
+    nextWakeAt: session.nextWakeAt,
+    nowMs: session.nowMs,
+  });
 }
 
 /** Yellow Work tab border — agent chats blocked on approval/question/`ade chat ask` only. */

--- a/apps/desktop/src/shared/sessionStatusPresentation.ts
+++ b/apps/desktop/src/shared/sessionStatusPresentation.ts
@@ -41,7 +41,7 @@ import type { CanonicalSessionPhase } from "./sessionCanonicalState";
  * identity mark inside a neutral chip, not a status label, and it never renders
  * in the status slot this module owns. The two cannot collide.
  */
-export type SessionStatusTone = "blue" | "amber" | "emerald" | "red" | "neutral";
+export type SessionStatusTone = "blue" | "violet" | "amber" | "emerald" | "red" | "neutral";
 
 /**
  * Glyph identity, not an icon import. Each consumer maps these to its own icon
@@ -50,6 +50,8 @@ export type SessionStatusTone = "blue" | "amber" | "emerald" | "red" | "neutral"
  */
 export type SessionStatusGlyph =
   | "working"
+  | "planning"
+  | "waiting"
   | "needs-you"
   | "done"
   | "stale"
@@ -125,9 +127,17 @@ export type SessionStatusOverlay = {
   snoozeWakeLabel?: string | null;
 };
 
+export type SessionStatusActivityContext = {
+  chatActivityMode?: "planning" | null;
+  activeBackgroundTaskCount?: number;
+  nextWakeAt?: string | null;
+  nowMs?: number;
+};
+
 export function sessionStatusPresentation(
   phase: CanonicalSessionPhase,
   overlay: SessionStatusOverlay = {},
+  activity: SessionStatusActivityContext = {},
 ): SessionStatusPresentation | null {
   // A raised hand outranks both overlays — same precedence as the filing rule,
   // so where the row is filed and what it says can never disagree.
@@ -149,6 +159,42 @@ export function sessionStatusPresentation(
     return { label: "Woke", tone: "amber", glyph: "woke", showsElapsed: false, prominent: true };
   }
 
+  if (phase === "running" && activity.chatActivityMode === "planning") {
+    return {
+      label: "Planning",
+      tone: "violet",
+      glyph: "planning",
+      showsElapsed: true,
+      prominent: false,
+    };
+  }
+
+  if (
+    (phase === "ready" || phase === "idle")
+    && (activity.activeBackgroundTaskCount ?? 0) > 0
+  ) {
+    return {
+      label: "Working",
+      tone: "blue",
+      glyph: "working",
+      showsElapsed: false,
+      prominent: false,
+    };
+  }
+
+  if ((phase === "ready" || phase === "idle") && activity.nextWakeAt) {
+    const wakeAt = Date.parse(activity.nextWakeAt);
+    if (Number.isFinite(wakeAt) && wakeAt > (activity.nowMs ?? Date.now())) {
+      return {
+        label: "Waiting",
+        tone: "neutral",
+        glyph: "waiting",
+        showsElapsed: false,
+        prominent: false,
+      };
+    }
+  }
+
   return PHASE_PRESENTATION[phase];
 }
 
@@ -159,6 +205,7 @@ export function sessionStatusPresentation(
  */
 export const SESSION_TONE_TEXT_CLASS: Record<SessionStatusTone, string> = {
   blue: "text-sky-400",
+  violet: "text-violet-300",
   amber: "text-amber-300",
   emerald: "text-emerald-300",
   red: "text-red-300",
@@ -173,6 +220,7 @@ export const SESSION_TONE_TEXT_CLASS: Record<SessionStatusTone, string> = {
  */
 export const SESSION_TONE_DOT_CLASS: Record<SessionStatusTone, string> = {
   blue: "bg-sky-400",
+  violet: "bg-violet-400",
   amber: "bg-amber-300",
   emerald: "bg-emerald-400",
   red: "bg-red-400",
@@ -194,4 +242,16 @@ export function formatWorkingDuration(elapsedMs: number): string {
   const totalHours = Math.floor(totalMinutes / 60);
   if (totalHours < 24) return `${totalHours}h`;
   return `${Math.floor(totalHours / 24)}d`;
+}
+
+export function formatFutureDuration(timestampMs: number, nowMs: number): string {
+  if (!Number.isFinite(timestampMs) || timestampMs <= nowMs) return "";
+  const totalMinutes = Math.max(1, Math.ceil((timestampMs - nowMs) / 60_000));
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const totalHours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (totalHours < 24) return minutes ? `${totalHours}h ${minutes}m` : `${totalHours}h`;
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  return hours ? `${days}d ${hours}h` : `${days}d`;
 }

--- a/apps/desktop/src/shared/types/chat.ts
+++ b/apps/desktop/src/shared/types/chat.ts
@@ -1543,6 +1543,8 @@ export type AgentChatSessionSummary = {
   pendingInputItemId?: string | null;
   /** Earliest armed, unpaused schedule for this chat. */
   nextWakeAt: string | null;
+  /** Authoritative provider-reported background tasks still running after the foreground turn. */
+  activeBackgroundTaskCount?: number;
   /** True when this chat's durable schedules are paused. */
   scheduledWorkPaused?: boolean;
   /** KV-backed durable schedules. This is the management source of truth. */

--- a/apps/desktop/src/shared/types/sessions.ts
+++ b/apps/desktop/src/shared/types/sessions.ts
@@ -240,6 +240,10 @@ export type TerminalSessionSummary = {
   chatIdleSinceAt?: string | null;
   /** Earliest armed, unpaused scheduled wake for chat-backed sessions. */
   nextWakeAt?: string | null;
+  /** Current ADE-chat mode, projected for desktop Work-row presentation only. */
+  chatActivityMode?: "planning" | null;
+  /** Authoritative provider-reported background tasks still running after the foreground turn. */
+  activeBackgroundTaskCount?: number;
   /** First tag mirrored from the backing Claude SDK session pointer. */
   claudeTag?: string | null;
   /** Owner session id for attached terminals, historically a parent chat id and now also a tracked CLI session id. */

--- a/docs/features/chat/README.md
+++ b/docs/features/chat/README.md
@@ -325,9 +325,15 @@ Controls and summaries project this runtime state rather than owning it:
   connected host's descriptors, so an older host stays read-only for whichever
   controls it does not support. Create is owner-only; Pause/Resume and Cancel
   remain viewer-allowed recovery controls.
-- Session summaries expose the earliest unpaused `nextWakeAt`; Work rows show
-  it as a compact alarm countdown. The optional `scheduledWork` management
-  snapshot lets desktop merge KV truth over stale transcript projections.
+- Session summaries expose the earliest unpaused `nextWakeAt` plus the
+  authoritative count of live provider background tasks. After the foreground
+  turn becomes idle, Work rows show **Working** while background tasks remain,
+  then **Waiting** with a compact alarm countdown while a future wake is armed;
+  only a chat with neither reads **Done**. Active ADE chats use the current
+  `interactionMode` to distinguish violet **Planning** from ordinary
+  **Working**; legacy permission flags and CLI terminal text are not treated as
+  plan-mode truth. The optional `scheduledWork` management snapshot lets desktop
+  merge KV truth over stale transcript projections.
 - Every unattended turn starts with a `Woke on schedule` divider. Desktop
   tracks the last viewed time per session in renderer `localStorage` and
   offers a dismissible while-you-were-away strip with jump links to those

--- a/docs/features/terminals-and-sessions/README.md
+++ b/docs/features/terminals-and-sessions/README.md
@@ -296,9 +296,10 @@ Shared types and IPC:
   list.
 - `apps/desktop/src/renderer/components/terminals/SessionStatusSlot.tsx` —
   the row's single status surface and no-layout-shift hover/focus action swap.
-  It maps shared presentation glyph ids to Phosphor icons, ticks Working/Stale
-  elapsed time, and replaces the status label with snooze plus binding-aware
-  settle/un-settle controls while the row is hovered or keyboard-focused.
+  It maps shared presentation glyph ids to Phosphor icons, ticks active
+  Working/Planning elapsed time and idle scheduled-work countdowns, and
+  replaces the status label with snooze plus binding-aware settle/un-settle
+  controls while the row is hovered or keyboard-focused.
 - `apps/desktop/src/renderer/components/terminals/SessionHoverCard.tsx` —
   one-second hover-intent detail pane positioned to the right of the full-bleed
   source row. Direct row-to-row movement after a card opens hands off

--- a/docs/features/terminals-and-sessions/ui-surfaces.md
+++ b/docs/features/terminals-and-sessions/ui-surfaces.md
@@ -271,12 +271,19 @@ The full card is one full-bleed row with three lines:
 
 `SessionStatusSlot` is the card's only permanent status vocabulary. It resolves
 words, glyphs, tone, prominence, and elapsed-time behavior through
-`shared/sessionStatusPresentation.ts`. Working and stale tick once per second
-from last activity. On row hover or keyboard focus the status swaps, without
-reflow, for `SessionSnoozeControl` and the context-appropriate Settle or
-Un-settle action. An open snooze menu pins the action slot visible. A row whose
-snooze ended early shows the shared Woke presentation until it is opened, at
-which point `TerminalsPage` clears the marker — opening is the acknowledgement.
+`shared/sessionStatusPresentation.ts`. An active ADE chat in its authoritative
+plan interaction mode reads **Planning** in violet; other active turns retain
+**Working**. Once the foreground turn is idle, provider-reported background
+tasks keep the row at **Working**, while an armed `nextWakeAt` reads neutral
+**Waiting** with a compact countdown. These contextual labels do not change the
+canonical lifecycle, filing bucket, filters, or attention count, and CLI output
+is never scraped to infer plan mode. Working/Planning elapsed time ticks from
+last activity; Waiting refreshes on a quiet 30-second cadence. On row hover or
+keyboard focus the status swaps, without reflow, for `SessionSnoozeControl` and
+the context-appropriate Settle or Un-settle action. An open snooze menu pins the
+action slot visible. A row whose snooze ended early shows the shared Woke
+presentation until it is opened, at which point `TerminalsPage` clears the
+marker — opening is the acknowledgement.
 
 After one second of uninterrupted hover, `SessionHoverCard` opens over the
 content area to the right of the sidebar. It uses icon-led fact rows rather


### PR DESCRIPTION
## Summary
- show **Planning** while an ADE chat is actively in plan interaction mode
- show compact **Working** only after the foreground turn is idle when background tasks remain
- show neutral **Waiting <duration>** for idle chats with an armed scheduled wake
- preserve canonical lifecycle, attention, filing, and CLI plan-mode behavior

## Validation
- `/quality`: dual-track review complete; medium findings fixed; no blocker/high findings
- `/test`: focused 96 tests passed; touched desktop shards 3/4/6 passed (3,573 tests); TUI 1,050 tests passed; docs validation passed
- desktop and CLI typechecks remain blocked by pre-existing unrelated `agentChatService.ts` SDK type drift