### PR TITLE
Suppress stale prompt-stash runtime error

### DIFF
--- a/apps/desktop/src/renderer/components/chat/ComposerPromptStash.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/ComposerPromptStash.test.tsx
@@ -47,6 +47,7 @@ function installBridge(overrides?: {
   delete?: ReturnType<typeof vi.fn>;
   getImageDataUrl?: ReturnType<typeof vi.fn>;
   saveTempAttachment?: ReturnType<typeof vi.fn>;
+  getWindowSession?: ReturnType<typeof vi.fn>;
 }) {
   const promptStashes = {
     list: overrides?.list ?? vi.fn().mockResolvedValue([]),
@@ -61,6 +62,14 @@ function installBridge(overrides?: {
       }),
       saveTempAttachment: overrides?.saveTempAttachment ?? vi.fn().mockResolvedValue({
         path: "/project/.ade/attachments/stashed-design.png",
+      }),
+    },
+    app: {
+      getWindowSession: overrides?.getWindowSession ?? vi.fn().mockResolvedValue({
+        windowId: 1,
+        project: null,
+        binding: null,
+        openProjectTabs: [],
       }),
     },
   };
@@ -80,6 +89,80 @@ afterEach(() => {
 });
 
 describe("ComposerPromptStash", () => {
+  it("ignores a prompt-stash refresh that lost its local project binding", async () => {
+    const staleBinding: OpenProjectBinding = {
+      kind: "local",
+      key: "local:/stale-project",
+      rootPath: "/stale-project",
+      displayName: "Stale project",
+    };
+    const currentBinding: OpenProjectBinding = {
+      kind: "local",
+      key: "local:/current-project",
+      rootPath: "/current-project",
+      displayName: "Current project",
+    };
+    const list = vi.fn().mockRejectedValue(new Error(
+      "Error invoking remote method 'ade.localRuntime.callAction': Error: Local runtime project is not available for this window.",
+    ));
+    const getWindowSession = vi.fn().mockResolvedValue({
+      windowId: 1,
+      project: { rootPath: currentBinding.rootPath, displayName: currentBinding.displayName },
+      binding: currentBinding,
+      openProjectTabs: [{ rootPath: currentBinding.rootPath, displayName: currentBinding.displayName }],
+    });
+    installBridge({ list, getWindowSession });
+
+    render(
+      <ComposerPromptStash
+        draft=""
+        composerMachineBinding={staleBinding}
+        active
+        buttonVisible
+        shortcutLabel="⌘+S"
+        onDraftChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(getWindowSession).toHaveBeenCalled());
+    expect(list).toHaveBeenCalledWith(staleBinding);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("shows a prompt-stash error when the local project binding is still current", async () => {
+    const currentBinding: OpenProjectBinding = {
+      kind: "local",
+      key: "local:/current-project",
+      rootPath: "/current-project",
+      displayName: "Current project",
+    };
+    const error = new Error(
+      "Error invoking remote method 'ade.localRuntime.callAction': Error: Local runtime project is not available for this window.",
+    );
+    installBridge({
+      list: vi.fn().mockRejectedValue(error),
+      getWindowSession: vi.fn().mockResolvedValue({
+        windowId: 1,
+        project: { rootPath: currentBinding.rootPath, displayName: currentBinding.displayName },
+        binding: currentBinding,
+        openProjectTabs: [{ rootPath: currentBinding.rootPath, displayName: currentBinding.displayName }],
+      }),
+    });
+
+    render(
+      <ComposerPromptStash
+        draft=""
+        composerMachineBinding={currentBinding}
+        active
+        buttonVisible
+        shortcutLabel="⌘+S"
+        onDraftChange={vi.fn()}
+      />,
+    );
+
+    expect((await screen.findByRole("alert")).textContent).toContain(error.message);
+  });
+
   it("stays out of the toolbar when the composer and stash list are both empty", async () => {
     const bridge = installBridge();
     render(

--- a/apps/desktop/src/renderer/components/chat/ComposerPromptStash.tsx
+++ b/apps/desktop/src/renderer/components/chat/ComposerPromptStash.tsx
@@ -31,6 +31,8 @@ const STASH_SNIPPET_MAX_CHARS = 110;
 const STASH_MENU_MAX_WIDTH = 380;
 const STASH_MENU_VIEWPORT_MARGIN = 16;
 const STASH_MENU_GAP = 10;
+const LOCAL_RUNTIME_PROJECT_UNAVAILABLE_MESSAGE =
+  "Local runtime project is not available for this window.";
 
 export type ComposerPromptStashHandle = {
   activate: () => void;
@@ -108,6 +110,45 @@ function stashAttachmentCount(entry: PromptStashEntry): number {
 
 function stashAttachmentsUnavailable(entry: PromptStashEntry): boolean {
   return entry.attachmentsAvailable === false && stashAttachmentCount(entry) > 0;
+}
+
+function normalizedProjectRoot(rootPath: string): string {
+  return rootPath.trim().replace(/[\\/]+$/, "");
+}
+
+function hasLocalProjectRoot(
+  session: Awaited<ReturnType<typeof window.ade.app.getWindowSession>>,
+  rootPath: string,
+): boolean {
+  const expectedRoot = normalizedProjectRoot(rootPath);
+  const sessionRoots = [
+    session.binding?.kind === "local" ? session.binding.rootPath : null,
+    session.project?.rootPath,
+    ...session.openProjectTabs.map((project) => project.rootPath),
+  ];
+  return sessionRoots.some(
+    (candidate) => candidate != null && normalizedProjectRoot(candidate) === expectedRoot,
+  );
+}
+
+async function isStaleLocalPromptStashRequest(
+  error: unknown,
+  binding: OpenProjectBinding | null,
+): Promise<boolean> {
+  if (
+    binding?.kind !== "local" ||
+    !(error instanceof Error) ||
+    !error.message.includes(LOCAL_RUNTIME_PROJECT_UNAVAILABLE_MESSAGE)
+  ) {
+    return false;
+  }
+  try {
+    const session = await window.ade.app.getWindowSession();
+    return !hasLocalProjectRoot(session, binding.rootPath);
+  } catch {
+    // Preserve the original runtime error when the window session cannot be read.
+    return false;
+  }
 }
 
 function StashImageThumbnail({
@@ -253,6 +294,10 @@ export const ComposerPromptStash = forwardRef<ComposerPromptStashHandle, Compose
       ));
       setError(null);
     } catch (refreshError) {
+      if (sequence !== refreshSequenceRef.current) return;
+      if (await isStaleLocalPromptStashRequest(refreshError, capturedBinding)) {
+        return;
+      }
       if (sequence !== refreshSequenceRef.current) return;
       setError(refreshError instanceof Error ? refreshError.message : "Could not load stashed prompts.");
     }


### PR DESCRIPTION
Suppress the prompt-stash refresh alert only when its captured local project is no longer authorized. Preserve current-project runtime errors and cover both paths with regression tests.

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fsuppress-remote-error-toast num=980 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fsuppress-remote-error-toast&amp;pr=980">ade/suppress-remote-error-toast branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=980">PR #980</a>
</p>
<!-- /ade:link -->
