### PR TITLE
Lane Title Visual Consistency -> Primary

### DIFF
--- a/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionCard.tsx
@@ -557,7 +557,7 @@ export const SessionCard = React.memo(function SessionCard({
       <span
         key="lane"
         data-session-lane-identity={lane.name}
-        className="inline-flex min-w-0 shrink items-center gap-1.5 text-[12px] font-medium"
+        className="inline-flex min-w-0 shrink items-center gap-1.5 text-[12px] font-semibold"
         // Inline style, not a class: the accent is per-lane user data.
         style={{ color: laneAccent ?? undefined }}
       >
@@ -567,7 +567,7 @@ export const SessionCard = React.memo(function SessionCard({
         >
           <LaneIcon size={12} weight="regular" />
         </span>
-        <span className={cn("min-w-0 truncate", laneAccent ? "" : "text-fg/80")}>
+        <span className={cn("min-w-0 truncate", laneAccent ? "" : "text-fg/85")}>
           <LaneNamingLabel laneName={lane.name} naming={isAutoNaming} />
         </span>
       </span>,

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
@@ -650,7 +650,7 @@ function StickyGroupHeader({
                 className={cn(
                   "min-w-0 shrink truncate leading-tight",
                   isLane
-                    ? "ade-lane-group-header-lane ade-lane-branch-inline-lane text-[12px] font-medium text-fg/85"
+                    ? "ade-lane-group-header-lane ade-lane-branch-inline-lane text-[12px] font-semibold text-fg/85"
                     // A quiet shelf ignores the shelf tone on purpose: colour is
                     // the lane divider's channel, and the whole reason Snoozed
                     // stopped being blue is that a coloured folding label with a


### PR DESCRIPTION


<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Flane-title-visual-consistency num=985 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Flane-title-visual-consistency&amp;pr=985">ade/lane-title-visual-consistency branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=985">PR #985</a>
</p>
<!-- /ade:link -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual hierarchy of terminal session labels with semibold text.
  * Brightened fallback text coloring for singleton lane labels.
  * Updated lane group headers for more consistent readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->