### PR TITLE
iOS Work session list: port the desktop session-card model

### DIFF
--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.test.ts
@@ -2313,6 +2313,7 @@ describe("session lifecycle remote commands", () => {
   function createLifecycleService(options?: {
     pushPublisherService?: Record<string, unknown>;
     session?: Record<string, unknown>;
+    agentChatService?: Record<string, unknown>;
   }) {
     const sessionService = {
       settleSession: vi.fn(() => true),
@@ -2330,6 +2331,7 @@ describe("session lifecycle remote commands", () => {
     const { service } = createService({
       sessionService,
       ...(options?.pushPublisherService ? { pushPublisherService: options.pushPublisherService } : {}),
+      ...(options?.agentChatService ? { agentChatService: options.agentChatService } : {}),
     });
     return { service, sessionService };
   }
@@ -2365,6 +2367,56 @@ describe("session lifecycle remote commands", () => {
 
     expect(handleSessionSettled).not.toHaveBeenCalled();
     expect(sessionService.settleSession).toHaveBeenCalledWith("session-1", {});
+  });
+
+  // `dismissPendingInputBeforeSettle` mutates and can then throw for a row with
+  // nothing pending. Run over a batch, that clears the earlier rows' prompts and
+  // then settles nothing — a half-applied write reported as a plain error. The
+  // guard has to reject before the first mutation, not merely fail overall.
+  it("rejects a multi-session settle that asks to dismiss, before mutating anything", async () => {
+    const dismissPendingInputForSettlement = vi.fn(() => true);
+    const { service, sessionService } = createLifecycleService({
+      agentChatService: { dismissPendingInputForSettlement },
+      session: { id: "session-1", toolType: "codex-chat" },
+    });
+
+    await expect(service.execute(makePayload("session.settleSessions", {
+      sessionIds: ["session-1", "session-2"],
+      dismissPendingInput: true,
+    }))).rejects.toThrow(/single session only/);
+
+    expect(dismissPendingInputForSettlement).not.toHaveBeenCalled();
+    expect(sessionService.settleSessions).not.toHaveBeenCalled();
+  });
+
+  it("still dismisses and settles a single-session bulk settle", async () => {
+    const dismissPendingInputForSettlement = vi.fn(() => true);
+    const { service, sessionService } = createLifecycleService({
+      agentChatService: { dismissPendingInputForSettlement },
+      session: { id: "session-1", toolType: "codex-chat" },
+    });
+
+    await expect(service.execute(makePayload("session.settleSessions", {
+      sessionIds: ["session-1"],
+      dismissPendingInput: true,
+    }))).resolves.toEqual(["session-1"]);
+
+    expect(dismissPendingInputForSettlement).toHaveBeenCalledWith({ sessionId: "session-1" });
+    expect(sessionService.settleSessions).toHaveBeenCalledWith(["session-1"]);
+  });
+
+  it("leaves a multi-session settle untouched when it does not ask to dismiss", async () => {
+    const dismissPendingInputForSettlement = vi.fn(() => true);
+    const { service, sessionService } = createLifecycleService({
+      agentChatService: { dismissPendingInputForSettlement },
+    });
+
+    await expect(service.execute(makePayload("session.settleSessions", {
+      sessionIds: ["session-1", "session-2"],
+    }))).resolves.toEqual(["session-1"]);
+
+    expect(dismissPendingInputForSettlement).not.toHaveBeenCalled();
+    expect(sessionService.settleSessions).toHaveBeenCalledWith(["session-1", "session-2"]);
   });
 
   it("leaves settlement push projection to the central session listener", async () => {

--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.test.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.test.ts
@@ -2405,6 +2405,45 @@ describe("session lifecycle remote commands", () => {
     expect(sessionService.settleSessions).toHaveBeenCalledWith(["session-1"]);
   });
 
+  // The non-chat branch is the one iOS actually exercises for an escalated
+  // `ade chat ask` on a CLI row: no chat service to ask, so the host clears the
+  // explicit attention request by forcing the pty back to idle.
+  it("dismisses a non-chat row through the pty runtime, not the chat service", async () => {
+    const dismissPendingInputForSettlement = vi.fn(() => true);
+    const { service, sessionService } = createLifecycleService({
+      agentChatService: { dismissPendingInputForSettlement },
+      session: {
+        id: "session-1",
+        toolType: "codex",
+        attentionRequestedAt: "2026-07-29T21:00:00.000Z",
+      },
+    });
+
+    await expect(service.execute(makePayload("session.settleSessions", {
+      sessionIds: ["session-1"],
+      dismissPendingInput: true,
+    }))).resolves.toEqual(["session-1"]);
+
+    expect(dismissPendingInputForSettlement).not.toHaveBeenCalled();
+    expect(sessionService.settleSessions).toHaveBeenCalledWith(["session-1"]);
+  });
+
+  // A bare terminal prompt has nothing the host knows how to clear. iOS gates
+  // this shape out of the menu, so reaching it means a race — it must surface as
+  // an error rather than settling a session still blocked on a human.
+  it("refuses to dismiss a non-chat row with nothing pending", async () => {
+    const { service, sessionService } = createLifecycleService({
+      session: { id: "session-1", toolType: "codex" },
+    });
+
+    await expect(service.execute(makePayload("session.settleSessions", {
+      sessionIds: ["session-1"],
+      dismissPendingInput: true,
+    }))).rejects.toThrow(/Resolve the terminal input/);
+
+    expect(sessionService.settleSessions).not.toHaveBeenCalled();
+  });
+
   it("leaves a multi-session settle untouched when it does not ask to dismiss", async () => {
     const dismissPendingInputForSettlement = vi.fn(() => true);
     const { service, sessionService } = createLifecycleService({

--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
@@ -4104,14 +4104,14 @@ function registerWorkRemoteCommands({ args, register }: RemoteCommandRegistratio
           "session.settleSessions supports dismissPendingInput for a single session only; send one id per request.",
         );
       }
-      for (const sessionId of sessionIds) {
-        await dismissPendingInputBeforeSettle({
-          sessionId,
-          sessionService: args.sessionService,
-          agentChatService: args.agentChatService ?? null,
-          ptyService: args.ptyService,
-        });
-      }
+      // Single call, not a loop: the guard above proved there is exactly one id,
+      // and a loop here would read as a batch the guard exists to forbid.
+      await dismissPendingInputBeforeSettle({
+        sessionId: sessionIds[0]!,
+        sessionService: args.sessionService,
+        agentChatService: args.agentChatService ?? null,
+        ptyService: args.ptyService,
+      });
     }
     return args.sessionService.settleSessions(sessionIds);
   });

--- a/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
+++ b/apps/ade-cli/src/services/sync/syncRemoteCommandService.ts
@@ -277,7 +277,7 @@ import type { createUsageTrackingService } from "../../../../desktop/src/main/se
 import type { ProductAnalyticsService } from "../../../../desktop/src/main/services/analytics/productAnalyticsService";
 import { parseProductAnalyticsCapture } from "../../../../desktop/src/shared/types/productAnalytics";
 import { deleteTerminalSessionWithRuntimeCleanup } from "../../../../desktop/src/main/services/sessions/deleteTerminalSession";
-import { settleTerminalSession } from "../../../../desktop/src/main/services/sessions/settleTerminalSession";
+import { dismissPendingInputBeforeSettle, settleTerminalSession } from "../../../../desktop/src/main/services/sessions/settleTerminalSession";
 import type { createSessionDeltaService } from "../../../../desktop/src/main/services/sessions/sessionDeltaService";
 import type { createSessionService } from "../../../../desktop/src/main/services/sessions/sessionService";
 import { getSharedModelPickerStore, type ModelPickerStore } from "../modelPickerStore";
@@ -4084,8 +4084,37 @@ function registerWorkRemoteCommands({ args, register }: RemoteCommandRegistratio
     const sessionId = requireString(payload.sessionId, "session.unsettleSession requires sessionId.");
     return { ok: args.sessionService.unsettleSession(sessionId), sessionId };
   });
-  register("session.settleSessions", { viewerAllowed: true, queueable: true }, async (payload) =>
-    args.sessionService.settleSessions(parseRemoteSessionIds(payload, "session.settleSessions")));
+  // Bulk settle. `dismissPendingInput` is OPTIONAL and additive: mobile sends
+  // it for the "Dismiss & settle" row action (the same thing desktop passes to
+  // `sessions.settle`), while older clients omit it and get the historical
+  // settle-only behaviour. The settle write itself is unchanged so the reply
+  // stays the changed-id list clients match on.
+  register("session.settleSessions", { viewerAllowed: true, queueable: true }, async (payload) => {
+    const sessionIds = parseRemoteSessionIds(payload, "session.settleSessions");
+    if (payload.dismissPendingInput === true) {
+      // Single-session only, ON PURPOSE. `dismissPendingInputBeforeSettle`
+      // throws for a row with nothing pending, and it mutates (clears pending
+      // input, forces the pty runtime idle) as it goes — so a mixed batch would
+      // dismiss the first k-1 rows, throw on the k-th, and settle none of them.
+      // Reject the combination before touching anything rather than leaving a
+      // half-applied batch behind a plain error. Do not "generalize" this
+      // without first making the dismiss loop atomic.
+      if (sessionIds.length !== 1) {
+        throw new Error(
+          "session.settleSessions supports dismissPendingInput for a single session only; send one id per request.",
+        );
+      }
+      for (const sessionId of sessionIds) {
+        await dismissPendingInputBeforeSettle({
+          sessionId,
+          sessionService: args.sessionService,
+          agentChatService: args.agentChatService ?? null,
+          ptyService: args.ptyService,
+        });
+      }
+    }
+    return args.sessionService.settleSessions(sessionIds);
+  });
   register("session.unsettleSessions", { viewerAllowed: true, queueable: true }, async (payload) => {
     args.sessionService.unsettleSessions(parseRemoteSessionIds(payload, "session.unsettleSessions"));
     return { ok: true };

--- a/apps/desktop/src/main/services/adeActions/registry.test.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.test.ts
@@ -1591,6 +1591,35 @@ describe("runtime session actions", () => {
     expect(runtime.sessionDeltaService?.getSessionDelta).toHaveBeenCalledWith("session-1");
   });
 
+  // The sync remote-command path honours `dismissPendingInput` for a single
+  // session. This bulk action never has, and used to drop the key silently — so
+  // the same argument meant "dismiss the prompt" over sync and nothing at all
+  // here. Settling while quietly ignoring half the request is the failure mode.
+  it("refuses a bulk settle that asks to dismiss pending input", () => {
+    const settleSessions = vi.fn(() => ["session-1"]);
+    const runtime = {
+      sessionService: {
+        get: vi.fn(),
+        list: vi.fn(),
+        settleSessions,
+      },
+    } as unknown as Parameters<typeof getAdeActionDomainServices>[0];
+    const sessionService = getAdeActionDomainServices(runtime).session as {
+      settleSessions: (args: unknown) => unknown;
+    } & Record<string, unknown>;
+
+    expect(() => sessionService.settleSessions({
+      sessionIds: ["session-1"],
+      dismissPendingInput: true,
+    })).toThrow(/does not dismiss pending input/);
+    expect(settleSessions).not.toHaveBeenCalled();
+
+    // Without the flag the bulk path is untouched.
+    expect(sessionService.settleSessions({ sessionIds: ["session-1", "session-2"] }))
+      .toEqual(["session-1"]);
+    expect(settleSessions).toHaveBeenCalledWith(["session-1", "session-2"]);
+  });
+
   it("exposes caller note/ask writes but no caller-scoped settle action", async () => {
     const requestAttention = vi.fn(() => true);
     const setStatusNote = vi.fn(() => true);

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -2111,6 +2111,16 @@ function buildSessionDomainService(runtime: AdeRuntime): OpaqueService | null {
       const sessionIds = Array.isArray(record.sessionIds)
         ? record.sessionIds.filter((id): id is string => typeof id === "string")
         : [];
+      // The sync remote-command path honours `dismissPendingInput` for a single
+      // session. This bulk action does not, and used to drop the key silently —
+      // so the same argument meant "dismiss the prompt" over sync and nothing at
+      // all here. Fail loudly instead of settling while quietly ignoring half of
+      // what was asked; `session.settleSession` is the path that dismisses.
+      if (record.dismissPendingInput === true) {
+        throw new Error(
+          "session.settleSessions does not dismiss pending input; use session.settleSession for a single session.",
+        );
+      }
       return sessionService.settleSessions(sessionIds);
     },
     unsettleSessions: (args?: unknown) => {

--- a/apps/desktop/src/main/services/adeActions/registry.ts
+++ b/apps/desktop/src/main/services/adeActions/registry.ts
@@ -2116,6 +2116,13 @@ function buildSessionDomainService(runtime: AdeRuntime): OpaqueService | null {
       // so the same argument meant "dismiss the prompt" over sync and nothing at
       // all here. Fail loudly instead of settling while quietly ignoring half of
       // what was asked; `session.settleSession` is the path that dismisses.
+      //
+      // Why the flag lives on the PLURAL action over sync at all, since that
+      // looks backwards from here: mobile cannot reach the singular one —
+      // `session.settleSession` is absent from the mobile compatibility lists
+      // in `shared/syncMobileCompatibility.ts`, so the phone only ever has
+      // `settleSessions`. This registry has no such constraint, so it refuses
+      // rather than duplicating the single-id special case.
       if (record.dismissPendingInput === true) {
         throw new Error(
           "session.settleSessions does not dismiss pending input; use session.settleSession for a single session.",

--- a/apps/desktop/src/main/services/sessions/settleTerminalSession.ts
+++ b/apps/desktop/src/main/services/sessions/settleTerminalSession.ts
@@ -10,6 +10,41 @@ export type SettleTerminalSessionOptions = {
   source?: SessionSettleSource;
 };
 
+/**
+ * Dismiss whatever the session is blocked on so a settle can follow.
+ *
+ * Split out of `settleTerminalSession` so the BULK settle paths (which write
+ * through `sessionService.settleSessions` and must keep returning the changed
+ * id list) can reuse the exact same dismissal semantics instead of inventing
+ * a second mechanism. Returns false when the row is missing — callers decide
+ * whether that is an error or just an id that settles nothing.
+ */
+export async function dismissPendingInputBeforeSettle(args: {
+  sessionId: string;
+  sessionService: ReturnType<typeof createSessionService>;
+  agentChatService?: ReturnType<typeof createAgentChatService> | null;
+  ptyService?: ReturnType<typeof createPtyService> | null;
+}): Promise<boolean> {
+  const session = args.sessionService.get(args.sessionId);
+  if (!session) return false;
+  if (isChatToolType(session.toolType)) {
+    if (!args.agentChatService) {
+      throw new Error("Agent chat service is unavailable; pending input could not be dismissed.");
+    }
+    await args.agentChatService.dismissPendingInputForSettlement({
+      sessionId: args.sessionId,
+    });
+  } else if (session.attentionRequestedAt) {
+    if (!args.ptyService) {
+      throw new Error("Terminal runtime is unavailable; the explicit attention request could not be dismissed.");
+    }
+    args.ptyService.setSessionRuntimeState(args.sessionId, "idle");
+  } else {
+    throw new Error("Resolve the terminal input before settling this session.");
+  }
+  return true;
+}
+
 export async function settleTerminalSession(args: {
   sessionId: string;
   opts?: SettleTerminalSessionOptions;
@@ -18,23 +53,13 @@ export async function settleTerminalSession(args: {
   ptyService?: ReturnType<typeof createPtyService> | null;
 }): Promise<boolean> {
   if (args.opts?.dismissPendingInput === true) {
-    const session = args.sessionService.get(args.sessionId);
-    if (!session) return false;
-    if (isChatToolType(session.toolType)) {
-      if (!args.agentChatService) {
-        throw new Error("Agent chat service is unavailable; pending input could not be dismissed.");
-      }
-      await args.agentChatService.dismissPendingInputForSettlement({
-        sessionId: args.sessionId,
-      });
-    } else if (session.attentionRequestedAt) {
-      if (!args.ptyService) {
-        throw new Error("Terminal runtime is unavailable; the explicit attention request could not be dismissed.");
-      }
-      args.ptyService.setSessionRuntimeState(args.sessionId, "idle");
-    } else {
-      throw new Error("Resolve the terminal input before settling this session.");
-    }
+    const dismissed = await dismissPendingInputBeforeSettle({
+      sessionId: args.sessionId,
+      sessionService: args.sessionService,
+      agentChatService: args.agentChatService ?? null,
+      ptyService: args.ptyService ?? null,
+    });
+    if (!dismissed) return false;
   }
 
   return args.sessionService.settleSession(

--- a/apps/ios/.ade/shipLane/ade__two-things-here-one-lot.json
+++ b/apps/ios/.ade/shipLane/ade__two-things-here-one-lot.json
@@ -1,0 +1,15 @@
+{
+  "branch": "ade/two-things-here-one-lot",
+  "prNumber": 1020,
+  "iteration": 0,
+  "lastPushSha": "b2550614feb7d1df1f1946ae76941612908e23a8",
+  "qualityValidatedSha": "b2550614feb7d1df1f1946ae76941612908e23a8",
+  "qualityValidatedTree": "1c75a2abbf1f84576191ddd03bcafcb3fbb1fb87",
+  "qualityValidatedBaseSha": "872807fc01425fc6a0014f6ee5f175e9fc399593",
+  "addressedCommentIds": [],
+  "status": "running",
+  "startedAt": "2026-08-04T03:52:00Z",
+  "lastPolledAt": null,
+  "exitReason": null,
+  "notes": "Windows CI jobs excluded from the CI-terminal wait per user instruction."
+}

--- a/apps/ios/ADE.xcodeproj/project.pbxproj
+++ b/apps/ios/ADE.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		E10000000000000000000022 /* WorkRootScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000022 /* WorkRootScreen.swift */; };
 		E10000000000000000000023 /* WorkRootScreen+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000023 /* WorkRootScreen+Actions.swift */; };
 		E10000000000000000000024 /* WorkRootComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000024 /* WorkRootComponents.swift */; };
+		E10000000000000000000F02 /* WorkSessionRowCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000F02 /* WorkSessionRowCard.swift */; };
 		E10000000000000000000025 /* WorkNewChatSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000025 /* WorkNewChatSheet.swift */; };
 		E10000000000000000000026 /* WorkSessionSettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000026 /* WorkSessionSettingsSheet.swift */; };
 		E10000000000000000000027 /* WorkSessionSettingsSheet+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000027 /* WorkSessionSettingsSheet+Actions.swift */; };
@@ -366,6 +367,7 @@
 		D10000000000000000000022 /* WorkRootScreen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkRootScreen.swift; path = ADE/Views/Work/WorkRootScreen.swift; sourceTree = "<group>"; };
 		D10000000000000000000023 /* WorkRootScreen+Actions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "WorkRootScreen+Actions.swift"; path = "ADE/Views/Work/WorkRootScreen+Actions.swift"; sourceTree = "<group>"; };
 		D10000000000000000000024 /* WorkRootComponents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkRootComponents.swift; path = ADE/Views/Work/WorkRootComponents.swift; sourceTree = "<group>"; };
+		D10000000000000000000F02 /* WorkSessionRowCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkSessionRowCard.swift; path = ADE/Views/Work/WorkSessionRowCard.swift; sourceTree = "<group>"; };
 		D10000000000000000000025 /* WorkNewChatSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkNewChatSheet.swift; path = ADE/Views/Work/WorkNewChatSheet.swift; sourceTree = "<group>"; };
 		D10000000000000000000026 /* WorkSessionSettingsSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WorkSessionSettingsSheet.swift; path = ADE/Views/Work/WorkSessionSettingsSheet.swift; sourceTree = "<group>"; };
 		D10000000000000000000027 /* WorkSessionSettingsSheet+Actions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "WorkSessionSettingsSheet+Actions.swift"; path = "ADE/Views/Work/WorkSessionSettingsSheet+Actions.swift"; sourceTree = "<group>"; };
@@ -820,6 +822,7 @@
 				D10000000000000000000022 /* WorkRootScreen.swift */,
 				D10000000000000000000023 /* WorkRootScreen+Actions.swift */,
 				D10000000000000000000024 /* WorkRootComponents.swift */,
+				D10000000000000000000F02 /* WorkSessionRowCard.swift */,
 				D10000000000000000000025 /* WorkNewChatSheet.swift */,
 				D10000000000000000000026 /* WorkSessionSettingsSheet.swift */,
 				D10000000000000000000027 /* WorkSessionSettingsSheet+Actions.swift */,
@@ -1515,6 +1518,7 @@
 				E10000000000000000000022 /* WorkRootScreen.swift in Sources */,
 				E10000000000000000000023 /* WorkRootScreen+Actions.swift in Sources */,
 				E10000000000000000000024 /* WorkRootComponents.swift in Sources */,
+				E10000000000000000000F02 /* WorkSessionRowCard.swift in Sources */,
 				E10000000000000000000025 /* WorkNewChatSheet.swift in Sources */,
 				E10000000000000000000026 /* WorkSessionSettingsSheet.swift in Sources */,
 				E10000000000000000000027 /* WorkSessionSettingsSheet+Actions.swift in Sources */,

--- a/apps/ios/ADE/Services/SyncService.swift
+++ b/apps/ios/ADE/Services/SyncService.swift
@@ -8998,11 +8998,27 @@ final class SyncService: ObservableObject {
   }
 
   /// Declared settle. Stamps `settled_at` locally to match what the host writes.
-  func settleSession(sessionId: String) async throws {
+  ///
+  /// `dismissPendingInput` is the needs-you variant — desktop's "Dismiss &
+  /// settle" — and it must ONLY be passed for a row that genuinely has a pending
+  /// prompt: the host throws "Resolve the terminal input before settling this
+  /// session." when the flag arrives for a row with nothing pending, which would
+  /// roll back the optimistic write and surface an error on an ordinary settle.
+  ///
+  /// It rides on the SAME plural action the plain settle uses. The singular
+  /// `session.settleSession` also accepts the flag but is not in the mobile
+  /// compatibility lists, so routing there would break against older hosts. The
+  /// argument itself is optional host-side and defaults to today's behaviour, so
+  /// a host that predates it simply settles the row and leaves the prompt.
+  func settleSession(sessionId: String, dismissPendingInput: Bool = false) async throws {
+    var args: [String: Any] = ["sessionIds": [sessionId]]
+    if dismissPendingInput {
+      args["dismissPendingInput"] = true
+    }
     try await sendSessionLifecycleCommand(
       sessionId: sessionId,
       action: "session.settleSessions",
-      args: ["sessionIds": [sessionId]],
+      args: args,
       // The bulk action answers with the ids it CHANGED, so an absent id means
       // the machine settled nothing. Mirrors the desktop `settleMany`.
       resultShape: .changedIdList,
@@ -10720,6 +10736,48 @@ final class SyncService: ObservableObject {
     _ = try await sendCommand(
       action: "work.stopRuntime",
       args: ["sessionId": sessionId],
+      targetProjectId: scope.projectId,
+      targetProjectRootPath: scope.rootPath
+    )
+  }
+
+  /// Whether this host advertises `work.deleteSession` — the delete path for a
+  /// CLI or shell row, which chats never used (`chat.delete` owns those). The
+  /// command is queueable, so this stays true while offline and the delete is
+  /// replayed on reconnect.
+  var supportsWorkSessionDeletion: Bool {
+    canInvokeRemoteAction("work.deleteSession")
+  }
+
+  /// Delete a non-chat session. The host handler is
+  /// `deleteTerminalSessionWithRuntimeCleanup`, so this ALREADY stops a live
+  /// runtime before deleting — "Stop & delete" and "Delete session" are the same
+  /// command with different labels, not two code paths.
+  ///
+  /// Advertise-checked rather than fired hopefully: an older host would answer
+  /// with an opaque method-not-found, and a delete that silently does nothing is
+  /// worse than one that says why.
+  ///
+  /// The guard reuses `supportsWorkSessionDeletion` so the condition that SHOWS
+  /// the affordance and the condition that THROWS cannot drift apart. The
+  /// message stays custom rather than routing through
+  /// `requireInvokableRemoteAction` because an out-of-date host is the only way
+  /// this fails in practice — the command is viewer-allowed and queueable, so
+  /// neither the viewer nor the offline branch of the shared helper can trip —
+  /// and "update the desktop app" is more actionable than the generic copy.
+  func deleteWorkSession(sessionId: String) async throws {
+    let trimmed = sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return }
+    guard supportsWorkSessionDeletion else {
+      throw NSError(domain: "ADE", code: 27, userInfo: [
+        NSLocalizedDescriptionKey:
+          "This machine's ADE is too old to delete sessions from a phone. Update the desktop app and try again.",
+      ])
+    }
+    let scope = chatCommandScope(for: trimmed)
+    _ = try await sendCommand(
+      action: "work.deleteSession",
+      args: ["sessionId": trimmed],
       targetProjectId: scope.projectId,
       targetProjectRootPath: scope.rootPath
     )

--- a/apps/ios/ADE/Views/Work/WorkBrowserHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkBrowserHelpers.swift
@@ -127,44 +127,6 @@ func workSessionShouldAppearInWorkList(
   return true
 }
 
-func workRunningBannerLiveCounts(_ liveSessions: [TerminalSessionSummary]) -> (chat: Int, terminal: Int) {
-  let chatCount = liveSessions.filter(isChatSession).count
-  return (chat: chatCount, terminal: max(0, liveSessions.count - chatCount))
-}
-
-func workRunningBannerTitle(liveChatCount: Int, liveTerminalCount: Int, attentionCount: Int) -> String {
-  let liveCount = liveChatCount + liveTerminalCount
-  if attentionCount > 0 && liveCount > 0 {
-    if liveTerminalCount > 0 {
-      return attentionCount == 1
-        ? (liveCount == 1 ? "1 chat needs input, 1 other session is live" : "1 chat needs input, \(liveCount) other sessions are live")
-        : (liveCount == 1 ? "\(attentionCount) chats need input, 1 other session is live" : "\(attentionCount) chats need input, \(liveCount) other sessions are live")
-    }
-    return "\(attentionCount) chat\(attentionCount == 1 ? "" : "s") need input, \(liveCount) still live"
-  }
-  if attentionCount > 0 {
-    return attentionCount == 1 ? "1 chat needs input" : "\(attentionCount) chats need input"
-  }
-  if liveTerminalCount > 0 && liveChatCount > 0 {
-    return "\(liveCount) live sessions across chat and terminal"
-  }
-  if liveTerminalCount > 0 {
-    return liveCount == 1 ? "1 terminal session is live" : "\(liveCount) terminal sessions are live"
-  }
-  return liveCount == 1 ? "1 chat is live" : "\(liveCount) chats are live"
-}
-
-func workRunningBannerMessage(liveTerminalCount: Int, attentionCount: Int) -> String {
-  if attentionCount > 0 {
-    return liveTerminalCount > 0
-      ? "Open the waiting chat to approve or answer it while the rest of the live work keeps streaming below."
-      : "Open the waiting chat to approve, answer, or resume work without leaving the phone."
-  }
-  return liveTerminalCount > 0
-    ? "The Work tab badge stays visible while live chats or terminal sessions continue running."
-    : "The Work tab badge stays visible until every active chat turn finishes."
-}
-
 func workFilesWorkspace(for laneId: String, in workspaces: [FilesWorkspace]) -> FilesWorkspace? {
   workspaces.first { $0.laneId == laneId }
 }

--- a/apps/ios/ADE/Views/Work/WorkPreviews.swift
+++ b/apps/ios/ADE/Views/Work/WorkPreviews.swift
@@ -752,8 +752,6 @@ private struct WorkRootPreviewHarness: View {
             organization: $organization,
             filterOpen: $filterOpen,
             lanes: WorkPreviewData.rootLanes,
-            liveCount: presentation.globalLiveSessionCount,
-            needsInputCount: presentation.globalNeedsInputCount,
             isLive: true,
             onClear: clearFilters,
             onNewChat: {},
@@ -813,19 +811,10 @@ private struct WorkRootPreviewHarness: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(.hidden, for: .navigationBar)
         .safeAreaInset(edge: .top, spacing: 0) {
+          // No count pill: the attention rollup is the bell, once, and nowhere
+          // else. See the note where `WorkLiveCountPill` used to be defined.
           ADERootTopBar(title: "Work") {
-            if presentation.globalLiveSessionCount > 0 {
-              WorkLiveCountPill(
-                liveCount: presentation.globalLiveSessionCount,
-                attentionCount: presentation.globalNeedsInputCount,
-                onTap: {
-                  guard let targetId = presentation.firstGlobalLiveSessionId else { return }
-                  withAnimation(.snappy) {
-                    proxy.scrollTo(targetId, anchor: .top)
-                  }
-                }
-              )
-            }
+            EmptyView()
           }
         }
       }

--- a/apps/ios/ADE/Views/Work/WorkRootComponents.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootComponents.swift
@@ -497,55 +497,6 @@ struct WorkSidebarSectionHeader: View {
 // jump-to-attention is already covered by the bell → Activity drawer, which
 // bands needs-you first with per-session navigation.
 
-struct WorkRunningBanner: View {
-  @Environment(\.accessibilityReduceMotion) var reduceMotion
-
-  let liveSessions: [TerminalSessionSummary]
-  let attentionCount: Int
-
-  @State var isPulsing = false
-
-  var body: some View {
-    HStack(spacing: 10) {
-      Circle()
-        .fill(attentionCount > 0 ? ADEColor.warning : ADEColor.success)
-        .frame(width: 10, height: 10)
-        .scaleEffect(isPulsing && !reduceMotion ? 1.2 : 1.0)
-        .animation(ADEMotion.pulse(reduceMotion: reduceMotion), value: isPulsing)
-        .onAppear {
-          guard !reduceMotion else { return }
-          isPulsing = true
-        }
-      VStack(alignment: .leading, spacing: 2) {
-        Text(bannerTitle)
-          .font(.subheadline.weight(.semibold))
-          .foregroundStyle(ADEColor.textPrimary)
-        Text(bannerMessage)
-          .font(.caption)
-          .foregroundStyle(ADEColor.textSecondary)
-      }
-      Spacer()
-    }
-    .adeGlassCard(cornerRadius: 18, padding: 14)
-  }
-
-  var bannerTitle: String {
-    workRunningBannerTitle(
-      liveChatCount: liveCounts.chat,
-      liveTerminalCount: liveCounts.terminal,
-      attentionCount: attentionCount
-    )
-  }
-
-  var bannerMessage: String {
-    workRunningBannerMessage(liveTerminalCount: liveCounts.terminal, attentionCount: attentionCount)
-  }
-
-  var liveCounts: (chat: Int, terminal: Int) {
-    workRunningBannerLiveCounts(liveSessions)
-  }
-}
-
 /// The lane half of a session row's long-press menu, mirroring desktop's
 /// `Lane ▸` submenu (`laneContextMenuItems.tsx`).
 ///
@@ -670,9 +621,11 @@ struct WorkSessionListRow: View {
   /// belongs to the status slot, which uses it to keep a heuristic row
   /// *settleable*, and it is a different question from "can the host dismiss
   /// this prompt". The only shape it admits that these three do not is a
-  /// non-chat row with no `attentionRequestedAt` — and `ptyService.ts:4494`
-  /// documents that stamp as a known MISLABEL from regex-scanning a plain PTY
-  /// stream. For that row `dismissPendingInputBeforeSettle` has nothing to
+  /// non-chat row with no `attentionRequestedAt` — which `ptyService.ts`
+  /// documents as a MISLABEL from regex-scanning a plain PTY stream (search
+  /// "is a MISLABEL and known to be one"; cited by phrase rather than line
+  /// because that file moves). For that row `dismissPendingInputBeforeSettle`
+  /// has nothing to
   /// clear and throws, so offering "Dismiss & settle" could only ever produce
   /// an error toast and a rolled-back optimistic write. Falling through to the
   /// disabled "Resolve input to settle" row is the honest answer.

--- a/apps/ios/ADE/Views/Work/WorkRootComponents.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootComponents.swift
@@ -2,10 +2,17 @@ import SwiftUI
 import UIKit
 import AVKit
 
-/// Work sidebar toolbar matching the desktop `SessionListPane` layout: compact search field,
-/// inline "New chat" accent button, and a funnel toggle that reveals the Group-by + Lane filter
-/// panel. Replaces the earlier phone-only filter card stack so mobile and desktop share the same
-/// information architecture.
+// The session row card itself (`WorkSessionRow`, its leaf views and the preview-line
+// helpers) lives in `WorkSessionRowCard.swift`; this file keeps the surrounding list chrome.
+
+/// Work sidebar toolbar matching the desktop `SessionListPane` layout: one 44pt row holding the
+/// search field, the funnel toggle that reveals the Group-by + Lane filter panel, and a compose
+/// menu carrying both creation actions.
+///
+/// The header is one row on purpose. It used to be three — search + funnel, then a full-width
+/// "Start new chat" / "Add lane" hero pair, then a `N waiting` chip — which pushed the first
+/// session row most of a thumb below the top bar and spent amber on a count that the bell already
+/// badges. Creation is a two-item menu behind one icon; the count rollup is gone entirely.
 struct WorkFiltersSection: View {
   @Binding var searchText: String
   @Binding var selectedLaneId: String
@@ -13,8 +20,6 @@ struct WorkFiltersSection: View {
   @Binding var organization: WorkSessionOrganization
   @Binding var filterOpen: Bool
   let lanes: [LaneSummary]
-  let liveCount: Int
-  let needsInputCount: Int
   let isLive: Bool
   let onClear: () -> Void
   let onNewChat: () -> Void
@@ -56,7 +61,10 @@ struct WorkFiltersSection: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
-        .frame(minHeight: 32)
+        // 44, not the old 32: a text field's tap target is its own bounds, so a
+        // `.contentShape` on a taller wrapper would not extend it. This is the
+        // one control in the row that has to grow to reach the minimum.
+        .frame(minHeight: 44)
         .frame(maxWidth: .infinity)
         .background(ADEColor.composerBackground, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
         .overlay(
@@ -81,74 +89,57 @@ struct WorkFiltersSection: View {
               RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .stroke(filterOpen ? ADEColor.accent.opacity(0.32) : ADEColor.glassBorder, lineWidth: 0.5)
             )
+            // The chip stays 32pt; the hit area is grown to 44 around it rather
+            // than by inflating the visual, which is what keeps the row's rhythm.
+            .frame(width: 44, height: 44)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Toggle filter panel")
-      }
 
-      HStack(spacing: 8) {
-        Button(action: onNewChat) {
-          HStack(spacing: 8) {
-            Image(systemName: "plus")
-              .font(.system(size: 13, weight: .bold))
-            Text("Start new chat")
-              .font(.subheadline.weight(.semibold))
+        // Creation is one icon with two items. Both used to be full-width hero
+        // buttons stacked under the search field; they are rare actions that were
+        // spending the most valuable strip on the screen.
+        Menu {
+          Button(action: onNewChat) {
+            Label("New chat", systemImage: "plus.bubble")
           }
-          .foregroundStyle(.white)
-          .frame(maxWidth: .infinity, minHeight: 44)
-          .background(ADEColor.accent, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-          .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-              .stroke(.white.opacity(0.18), lineWidth: 0.6)
-          )
-          .shadow(color: ADEColor.accent.opacity(0.18), radius: 6, x: 0, y: 2)
+          Button(action: onAddLane) {
+            Label("New lane", systemImage: "plus.square.on.square")
+          }
+        } label: {
+          Image(systemName: "square.and.pencil")
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(isLive ? ADEColor.accent : ADEColor.textMuted)
+            .frame(width: 32, height: 32)
+            .background(ADEColor.composerBackground, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay(
+              RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(isLive ? ADEColor.accent.opacity(0.3) : ADEColor.glassBorder, lineWidth: 0.6)
+            )
+            .frame(width: 44, height: 44)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .disabled(!isLive)
         .opacity(isLive ? 1 : 0.55)
-        .accessibilityLabel("Start new chat")
-
-        Button(action: onAddLane) {
-          HStack(spacing: 7) {
-            Image(systemName: "plus.square.on.square")
-              .font(.system(size: 13, weight: .semibold))
-            Text("Add lane")
-              .font(.subheadline.weight(.semibold))
-              .lineLimit(1)
-          }
-          .foregroundStyle(isLive ? ADEColor.accent : ADEColor.textMuted)
-          .frame(minWidth: 116, minHeight: 44)
-          .padding(.horizontal, 12)
-          .background(ADEColor.composerBackground, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-          .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-              .stroke(isLive ? ADEColor.accent.opacity(0.3) : ADEColor.glassBorder, lineWidth: 0.6)
-          )
-        }
-        .buttonStyle(.plain)
-        .disabled(!isLive)
-        .opacity(isLive ? 1 : 0.55)
-        .accessibilityLabel("Add lane")
-        .accessibilityHint(isLive ? "Opens lane creation options" : "Reconnect to machine before creating lanes")
+        .accessibilityLabel("New chat or lane")
+        .accessibilityHint(isLive ? "Opens chat and lane creation options" : "Reconnect to machine before creating lanes")
       }
+      .frame(minHeight: 44)
 
-      if needsInputCount > 0 || hasActiveFilters {
+      if hasActiveFilters {
         HStack(spacing: 6) {
-          if needsInputCount > 0 {
-            WorkFlatCountChip(icon: "exclamationmark.circle.fill", text: "\(needsInputCount) waiting", tint: ADEColor.warning)
-          }
           Spacer(minLength: 0)
-          if hasActiveFilters {
-            Button("Clear") {
-              withAnimation(.snappy(duration: 0.18)) {
-                onClear()
-              }
+          Button("Clear") {
+            withAnimation(.snappy(duration: 0.18)) {
+              onClear()
             }
-            .font(.caption.weight(.semibold))
-            .foregroundStyle(ADEColor.accent)
-            .buttonStyle(.plain)
-            .accessibilityLabel("Clear Work filters")
           }
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(ADEColor.accent)
+          .buttonStyle(.plain)
+          .accessibilityLabel("Clear Work filters")
         }
       }
 
@@ -292,7 +283,9 @@ struct WorkFilterMenuLabel: View {
           .font(.caption.weight(.semibold))
           .foregroundStyle(ADEColor.textPrimary)
           .lineLimit(1)
-          .truncationMode(.middle)
+          // Tail, never middle. Middle truncation eats the distinguishing middle
+          // of a name and leaves two fragments that read as one mangled word.
+          .truncationMode(.tail)
       }
       Spacer(minLength: 0)
       Image(systemName: "chevron.up.chevron.down")
@@ -324,6 +317,12 @@ struct WorkSidebarSectionHeader: View {
   /// harnesses don't have to wire it.
   var onOpenPullRequest: (LanePrTag) -> Void = { _ in }
   var onRefreshOrphanedSessions: (() -> Void)? = nil
+  /// Lane-scoped git state (dirty / ahead / behind). It used to be repeated on
+  /// every session row of the lane, which said the same fact five times and made
+  /// a row rebuild on every lane status poll. It is one lane's state, so it is
+  /// stated once, here. Nil for status and time sections, which span lanes and
+  /// therefore have no single true answer.
+  var laneStatus: LaneStatus? = nil
 
   /// Collapsed and holding only settled work: render one thin muted row with the
   /// count folded in, instead of a full-weight header over nothing.
@@ -359,6 +358,14 @@ struct WorkSidebarSectionHeader: View {
           .buttonStyle(.plain)
           .frame(minWidth: 44, minHeight: 44)
           .accessibilityHint("Refreshes lane and session records. Nothing is deleted.")
+      }
+
+      // Left of the PR indicator and deliberately quieter than both it and the
+      // lane name: this is context, not a call to action. Dropped entirely on a
+      // folded quiet row, where the section is one thin line and every glyph
+      // competes with the count.
+      if !isQuietRow, let laneStatus, laneGitStateIsNoteworthy(laneStatus) {
+        laneGitStateChips(laneStatus)
       }
 
       if let pullRequest {
@@ -399,6 +406,50 @@ struct WorkSidebarSectionHeader: View {
     .opacity(isQuietRow ? 0.72 : 1)
   }
 
+  /// Nothing to say when the worktree is clean and level with its base — an
+  /// always-present "0 ahead, 0 behind" would be chrome, not information.
+  private func laneGitStateIsNoteworthy(_ status: LaneStatus) -> Bool {
+    status.dirty || status.ahead > 0 || status.behind > 0
+  }
+
+  @ViewBuilder
+  private func laneGitStateChips(_ status: LaneStatus) -> some View {
+    HStack(spacing: 5) {
+      if status.dirty {
+        Circle()
+          .fill(ADEColor.warning.opacity(0.85))
+          .frame(width: 5, height: 5)
+      }
+      if status.ahead > 0 {
+        laneGitCountChip(symbol: "arrow.up", count: status.ahead)
+      }
+      if status.behind > 0 {
+        laneGitCountChip(symbol: "arrow.down", count: status.behind)
+      }
+    }
+    .foregroundStyle(ADEColor.textMuted)
+    .fixedSize()
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(laneGitStateAccessibilityLabel(status))
+  }
+
+  private func laneGitCountChip(symbol: String, count: Int) -> some View {
+    HStack(spacing: 1) {
+      Image(systemName: symbol)
+        .font(.system(size: 7, weight: .bold))
+      Text("\(count)")
+        .font(.caption2.monospacedDigit())
+    }
+  }
+
+  private func laneGitStateAccessibilityLabel(_ status: LaneStatus) -> String {
+    var parts: [String] = []
+    if status.dirty { parts.append("uncommitted changes") }
+    if status.ahead > 0 { parts.append("\(status.ahead) ahead") }
+    if status.behind > 0 { parts.append("\(status.behind) behind") }
+    return parts.joined(separator: ", ")
+  }
+
   private var quietAwareLabelColor: Color {
     if isQuietRow { return ADEColor.textSecondary }
     if group.isOrphaned { return ADEColor.warning }
@@ -437,65 +488,14 @@ struct WorkSidebarSectionHeader: View {
   }
 }
 
-/// Flat-capsule variant of `ADEGlassChip` used when the chip sits inside a `.adeGlassCard` so we avoid
-/// glass-on-glass stacking. Visual spec matches `ADEGlassChip` minus the inner `.glassEffect()`.
-struct WorkFlatCountChip: View {
-  let icon: String
-  let text: String
-  let tint: Color
-
-  var body: some View {
-    HStack(spacing: 3) {
-      Image(systemName: icon)
-        .font(.system(size: 8, weight: .semibold))
-      Text(text)
-        .font(.system(.caption2).weight(.medium))
-    }
-    .foregroundStyle(tint)
-    .padding(.horizontal, 6)
-    .padding(.vertical, 3)
-    .background(tint.opacity(0.1), in: Capsule())
-  }
-}
-
-/// Compact live-chat count pill for the Work toolbar. Mirrors the desktop's `ade-liquid-glass-pill`
-/// count badge next to the tab title \u2014 a tiny `\u25cf N` capsule that flips to warning tint when any
-/// chat is awaiting input. Tap target delegates to the caller so the list can scroll to the live row.
-struct WorkLiveCountPill: View {
-  let liveCount: Int
-  let attentionCount: Int
-  let onTap: () -> Void
-
-  var tint: Color {
-    attentionCount > 0 ? ADEColor.warning : ADEColor.success
-  }
-
-  var label: String {
-    attentionCount > 0 ? "\(attentionCount) waiting" : "\(liveCount) live"
-  }
-
-  var body: some View {
-    Button(action: onTap) {
-      HStack(spacing: 5) {
-        Circle()
-          .fill(tint)
-          .frame(width: 6, height: 6)
-          .shadow(color: tint.opacity(0.6), radius: 4, x: 0, y: 0)
-        Text(label)
-          .font(.caption2.monospacedDigit().weight(.semibold))
-          .foregroundStyle(tint)
-      }
-      .padding(.horizontal, 9)
-      .padding(.vertical, 5)
-      .background(tint.opacity(0.14), in: Capsule())
-      .overlay(
-        Capsule().stroke(tint.opacity(0.28), lineWidth: 0.5)
-      )
-    }
-    .buttonStyle(.plain)
-    .accessibilityLabel("\(liveCount) Work session\(liveCount == 1 ? "" : "s") live, \(attentionCount) waiting for input. Tap to jump.")
-  }
-}
+// `WorkFlatCountChip` and `WorkLiveCountPill` used to live here: an above-the-list
+// "N waiting" chip and a tappable top-bar pill, both fed from one screen-wide
+// needs-input count that `WorkRootSessionPresentation` no longer publishes at
+// all. They are deleted, not moved. Amber means "your move"
+// and nothing else, and spending it three times on one screen (pill, chip, row
+// badge) is precisely what made the per-row badge stop registering. The pill's
+// jump-to-attention is already covered by the bell → Activity drawer, which
+// bands needs-you first with per-session navigation.
 
 struct WorkRunningBanner: View {
   @Environment(\.accessibilityReduceMotion) var reduceMotion
@@ -546,6 +546,30 @@ struct WorkRunningBanner: View {
   }
 }
 
+/// The lane half of a session row's long-press menu, mirroring desktop's
+/// `Lane ▸` submenu (`laneContextMenuItems.tsx`).
+///
+/// Bundled instead of eight loose closures because every call site wires all of
+/// them or none, and because the two availability flags have to travel with the
+/// actions they gate. `colorAvailable` / `manageAvailable` are per-command
+/// gates: a host that does not advertise `lanes.updateAppearance` must not show
+/// a colour row that silently fails.
+///
+/// Desktop items with no phone analogue are deliberately absent, not forgotten:
+/// Open in / Remove from Split, Close Other Tabs, Select All Lanes and Reveal in
+/// Finder all describe a windowing model a phone does not have.
+struct WorkSessionLaneMenuActions {
+  var colorAvailable: Bool = false
+  var manageAvailable: Bool = false
+  var onStartChat: (LaneSummary) -> Void = { _ in }
+  var onCopyLaneLink: (LaneSummary) -> Void = { _ in }
+  var onCopyBranchLink: (LaneSummary) -> Void = { _ in }
+  var onCopyLinearLink: (LaneSummary) -> Void = { _ in }
+  var onCopyPath: (LaneSummary) -> Void = { _ in }
+  var onSetColor: (LaneSummary, String?) -> Void = { _, _ in }
+  var onManage: (LaneSummary) -> Void = { _ in }
+}
+
 /// Single-row renderer for the session list that carries the swipe + context-menu action set.
 /// Used inside the sidebar's grouped loop so the Work root screen can drive the section
 /// organization directly (byLane / byStatus / byTime) without a nested Section wrapper.
@@ -584,10 +608,27 @@ struct WorkSessionListRow: View {
   /// The host advertises snooze / wake.
   var snoozeAvailable: Bool = false
   var onSettle: (TerminalSessionSummary) -> Void = { _ in }
+  /// Settle a needs-you row AND clear its pending prompt. Separate from
+  /// `onSettle` because the host rejects the dismiss flag on a row with nothing
+  /// pending — the two are different commands, not one command with a toggle.
+  var onDismissAndSettle: (TerminalSessionSummary) -> Void = { _ in }
   var onUnsettle: (TerminalSessionSummary) -> Void = { _ in }
   var onKeepActive: (TerminalSessionSummary) -> Void = { _ in }
   var onSnooze: (TerminalSessionSummary, WorkSnoozeDuration) -> Void = { _, _ in }
   var onWake: (TerminalSessionSummary) -> Void = { _ in }
+  /// The host advertises `work.deleteSession` — the stop-then-delete path for a
+  /// non-chat row. Older hosts never had it, so a phone talking to one hides the
+  /// two destructive items rather than offering a control that always fails.
+  var deleteSessionAvailable: Bool = false
+  /// Deletes a CLI/shell session (running or stopped). Chats keep `onDelete`;
+  /// the two go through different host commands and different confirmations.
+  var onDeleteSession: (TerminalSessionSummary) -> Void = { _ in }
+  /// Opens this session in the hosted web client. Purely local — it builds a URL
+  /// and hands it to the system, so it needs no host command and no gate.
+  var onOpenInWeb: (TerminalSessionSummary) -> Void = { _ in }
+  /// Lane-scoped actions for the `Lane ▸` submenu. Nil (the default) renders no
+  /// submenu at all, which is also what a row with no resolvable lane gets.
+  var laneMenu: WorkSessionLaneMenuActions? = nil
 
   /// Observed so the muted glyph and menu label re-render the moment a mute
   /// flips anywhere (this menu, the open chat's header menu, settings).
@@ -607,21 +648,72 @@ struct WorkSessionListRow: View {
     session.isSnoozed()
   }
 
-  /// An escalated ask outranks settle: a row blocked on the user is not "done",
-  /// and settling it would bury the very thing asking for attention. Resolve
-  /// the ask first. Already-settled rows offer Unsettle instead.
+  private var isChat: Bool { isChatSession(session) }
+
+  /// Mid-flight. Desktop hides Settle for all three of these
+  /// (`SessionContextMenu.tsx:196-199`): filing away a row the machine is still
+  /// working in claims an outcome that has not happened yet, and the row is
+  /// about to change state on its own anyway. iOS used to allow it, which let a
+  /// user settle a session mid-turn.
+  private var isActivelyRunning: Bool {
+    canonicalPhase == .starting || canonicalPhase == .running || canonicalPhase == .stale
+  }
+
+  /// Whether a needs-you ask can be DISMISSED as part of settling. A chat
+  /// resolves its own prompts, and an escalated ask carries a record the host
+  /// knows how to clear. A bare terminal prompt has neither, so settling it
+  /// would hide a question the machine is still blocked on — which is why
+  /// desktop explains the absence instead of quietly dropping the item.
+  ///
+  /// These are exactly desktop's three clauses (`SessionContextMenu.tsx:200-203`).
+  /// Do NOT add `attentionSource == "provider_structured"` here: that clause
+  /// belongs to the status slot, which uses it to keep a heuristic row
+  /// *settleable*, and it is a different question from "can the host dismiss
+  /// this prompt". The only shape it admits that these three do not is a
+  /// non-chat row with no `attentionRequestedAt` — and `ptyService.ts:4494`
+  /// documents that stamp as a known MISLABEL from regex-scanning a plain PTY
+  /// stream. For that row `dismissPendingInputBeforeSettle` has nothing to
+  /// clear and throws, so offering "Dismiss & settle" could only ever produce
+  /// an error toast and a rolled-back optimistic write. Falling through to the
+  /// disabled "Resolve input to settle" row is the honest answer.
+  private var canDismissNeedsYou: Bool {
+    canonicalPhase != .needsYou
+      || isChat
+      || session.attentionRequestedAt != nil
+  }
+
   private var canSettle: Bool {
-    lifecycleAvailable && canonicalPhase != .needsYou && canonicalPhase != .settled
+    lifecycleAvailable
+      && canonicalPhase != .settled
+      && !isActivelyRunning
+      && canDismissNeedsYou
+  }
+
+  /// The settle for a needs-you row also clears the pending prompt, and says so.
+  /// The host REJECTS the dismiss flag on a row with nothing pending, so this is
+  /// the only condition under which the dismissing variant may be sent.
+  private var settleDismissesPendingInput: Bool {
+    canonicalPhase == .needsYou
+  }
+
+  /// Needs-you with an ask nothing can dismiss. Desktop renders a DISABLED row
+  /// here rather than nothing: an item that silently disappears reads as a bug,
+  /// while "Resolve input to settle" states the precondition.
+  private var settleBlockedOnInput: Bool {
+    lifecycleAvailable && canonicalPhase == .needsYou && !canDismissNeedsYou
   }
 
   private var canUnsettle: Bool {
     lifecycleAvailable && canonicalPhase == .settled
   }
 
-  /// "Keep active" only means something once a row would otherwise read settled
-  /// — explicitly declared by an agent, user, operator, or merge policy.
+  /// "Keep active" only means something against a DECLARED settle — one an
+  /// agent, user, operator or merge policy wrote into `settled_at`. A settle the
+  /// UI merely derived has no column for the pin to hold down, so desktop
+  /// restricts the item the same way (`SessionContextMenu.tsx:209`, `:250`).
   private var canKeepActive: Bool {
     lifecycleAvailable
+      && session.settledAt != nil
       && session.resolvedSettleOverride != .active
       && canonicalPhase == .settled
   }
@@ -663,13 +755,10 @@ struct WorkSessionListRow: View {
       }
     }
     .buttonStyle(.plain)
-    .simultaneousGesture(
-      LongPressGesture(minimumDuration: 0.45)
-        .onEnded { _ in
-          guard !isSelecting else { return }
-          onLongPressSelect(session)
-        }
-    )
+    // No raw `LongPressGesture` here. A 0.45s press competed with the very same
+    // long press that opens `.contextMenu`, so whichever recogniser won was a
+    // coin toss and the menu felt broken. The menu's own "Select" item is the
+    // single way into multi-select now.
     .swipeActions(edge: .trailing, allowsFullSwipe: false) {
       if isStoppableRuntimeStatus(session, status: rowStatus) {
         Button("Stop runtime", role: .destructive) {
@@ -677,8 +766,15 @@ struct WorkSessionListRow: View {
         }
         .tint(ADEColor.danger)
       } else if shouldShowDeleteAction {
-        Button("Delete", role: .destructive) {
+        Button("Delete chat", role: .destructive) {
           onDelete(session)
+        }
+        .tint(ADEColor.danger)
+      } else if canDeleteStoppedSession(status: rowStatus) {
+        // A stopped CLI or shell row. Until `work.deleteSession` was wired there
+        // was no way at all to delete one of these from a phone.
+        Button("Delete session", role: .destructive) {
+          onDeleteSession(session)
         }
         .tint(ADEColor.danger)
       }
@@ -687,9 +783,9 @@ struct WorkSessionListRow: View {
       // desktop-style always-visible moon button.
       if canSettle {
         Button {
-          onSettle(session)
+          settle()
         } label: {
-          Label("Settle", systemImage: "checkmark.circle")
+          Label(settleLabel, systemImage: "checkmark.circle")
         }
         .tint(ADEColor.accent)
       } else if canUnsettle {
@@ -720,69 +816,16 @@ struct WorkSessionListRow: View {
         }
       }
     }
+    // Desktop's tree, in desktop's order (`SessionContextMenu.tsx`): identity
+    // first, then lifecycle, then the places this session also appears, then —
+    // fenced behind a divider and never before it — the deletes. Ordering is not
+    // cosmetic here: a mis-tap right after the menu opens lands mid-list, which
+    // is exactly where the deletes used to sit.
     .contextMenu {
-      Button {
-        onLongPressSelect(session)
-      } label: {
-        Label("Select", systemImage: "checkmark.circle")
-      }
-      Button {
-        onRename(session)
-      } label: {
-        Label("Rename", systemImage: "pencil")
-      }
-      if isStoppableRuntimeStatus(session, status: rowStatus) {
-        Button(role: .destructive) {
-          onStopRuntime(session)
-        } label: {
-          Label("Stop runtime", systemImage: "stop.fill")
-        }
-      }
-      if shouldShowDeleteAction {
-        Button(role: .destructive) {
-          onDelete(session)
-        } label: {
-          Label("Delete chat", systemImage: "trash")
-        }
-      }
-      lifecycleMenuSection
-      Divider()
-      Button {
-        onGoToLane(session)
-      } label: {
-        Label("Go to lane", systemImage: "arrow.triangle.branch")
-      }
-      if let pullRequest {
-        Button {
-          onOpenPullRequest(session, pullRequest)
-        } label: {
-          Label("Open in PRs tab", systemImage: "arrow.triangle.pull")
-        }
-      }
-      Button {
-        onCopyId(session)
-      } label: {
-        Label("Copy session ID", systemImage: "doc.on.doc")
-      }
-      Button {
-        onCopyDeepLink(session)
-      } label: {
-        Label("Copy session link", systemImage: "link")
-      }
-      Button {
-        onPin(session)
-      } label: {
-        Label(session.pinned ? "Unpin from front" : "Pin to front",
-              systemImage: session.pinned ? "pin.slash" : "pin")
-      }
-      if isChatSession(session) {
-        Button {
-          PushNotificationService.shared.setMuted(!isMuted, sessionId: session.id)
-        } label: {
-          Label(isMuted ? "Unmute notifications" : "Mute notifications",
-                systemImage: isMuted ? "bell" : "bell.slash")
-        }
-      }
+      identityMenuSection
+      lifecycleMenuSection(status: rowStatus)
+      goToMenuSection
+      destructiveMenuSection(status: rowStatus)
     }
     .overlay {
       if isLaneDeleting {
@@ -805,32 +848,80 @@ struct WorkSessionListRow: View {
     isChatSession(session)
   }
 
-  /// Full lifecycle set: settle / unsettle, a snooze submenu of durations,
-  /// wake now, and the keep-active pin. Durations use a native nested `Menu`,
-  /// never a popover — this is a long-press context menu on a phone.
+  /// Stop-then-delete for a live CLI/shell row: desktop's "Stop & delete".
+  private func canStopAndDeleteSession(status: String) -> Bool {
+    deleteSessionAvailable && isStoppableRuntimeStatus(session, status: status)
+  }
+
+  /// Plain delete for a CLI/shell row that is already stopped. `work.delete
+  /// Session` handles both, but the labels differ because the consequences do.
+  private func canDeleteStoppedSession(status: String) -> Bool {
+    deleteSessionAvailable && !isChat && !isStoppableRuntimeStatus(session, status: status)
+  }
+
+  private var settleLabel: String {
+    settleDismissesPendingInput ? "Dismiss & settle" : "Settle"
+  }
+
+  private func settle() {
+    if settleDismissesPendingInput {
+      onDismissAndSettle(session)
+    } else {
+      onSettle(session)
+    }
+  }
+
+  // MARK: - Menu sections
+
+  /// What this row is called and how it is filed. Unlabelled: it is the first
+  /// block under the finger and needs no signpost.
   @ViewBuilder
-  private var lifecycleMenuSection: some View {
-    if lifecycleAvailable || snoozeAvailable {
+  private var identityMenuSection: some View {
+    Button {
+      onLongPressSelect(session)
+    } label: {
+      Label("Select", systemImage: "checkmark.circle")
+    }
+    Button {
+      onRename(session)
+    } label: {
+      Label("Rename", systemImage: "pencil")
+    }
+    Button {
+      onPin(session)
+    } label: {
+      Label(session.pinned ? "Unpin from front" : "Pin to front",
+            systemImage: session.pinned ? "pin.slash" : "pin")
+    }
+    if isChat {
+      Button {
+        PushNotificationService.shared.setMuted(!isMuted, sessionId: session.id)
+      } label: {
+        Label(isMuted ? "Unmute notifications" : "Mute notifications",
+              systemImage: isMuted ? "bell" : "bell.slash")
+      }
+    }
+  }
+
+  /// Everything that changes where the list files this row: stop (runtime),
+  /// snooze/wake (visibility), settle/keep-active (state). Durations use a
+  /// native nested `Menu`, never a popover — this is a long press on a phone.
+  ///
+  /// Keep it exhaustive. A row that reaches the end of this block with nothing
+  /// rendered is a row the user cannot un-hide.
+  @ViewBuilder
+  private func lifecycleMenuSection(status: String) -> some View {
+    let canStopRuntime = isStoppableRuntimeStatus(session, status: status)
+    if canStopRuntime || lifecycleAvailable || snoozeAvailable {
       Divider()
-      if canSettle {
+      // Stop runtime moved here from the identity block: it is a lifecycle
+      // change, and it is NOT destructive — the session and its transcript
+      // survive — so it must not sit next to the deletes.
+      if canStopRuntime {
         Button {
-          onSettle(session)
+          onStopRuntime(session)
         } label: {
-          Label("Settle", systemImage: "checkmark.circle")
-        }
-      }
-      if canUnsettle {
-        Button {
-          onUnsettle(session)
-        } label: {
-          Label("Unsettle", systemImage: "arrow.uturn.backward.circle")
-        }
-      }
-      if canKeepActive {
-        Button {
-          onKeepActive(session)
-        } label: {
-          Label("Keep active", systemImage: "pin.circle")
+          Label("Stop runtime", systemImage: "stop.fill")
         }
       }
       if snoozeAvailable {
@@ -852,6 +943,179 @@ struct WorkSessionListRow: View {
           } label: {
             Label("Snooze", systemImage: "moon.zzz")
           }
+        }
+      }
+      if canSettle {
+        Button {
+          settle()
+        } label: {
+          Label(settleLabel, systemImage: "checkmark.circle")
+        }
+      } else if settleBlockedOnInput {
+        // Disabled on purpose. Hiding Settle here would leave the user hunting
+        // for an item that simply vanished; this states the precondition.
+        Button {} label: {
+          Label("Resolve input to settle", systemImage: "exclamationmark.bubble")
+        }
+        .disabled(true)
+      }
+      if canUnsettle {
+        Button {
+          onUnsettle(session)
+        } label: {
+          Label("Unsettle", systemImage: "arrow.uturn.backward.circle")
+        }
+      }
+      if canKeepActive {
+        Button {
+          onKeepActive(session)
+        } label: {
+          Label("Keep active", systemImage: "pin.circle")
+        }
+      }
+    }
+  }
+
+  /// The other surfaces that show this same session, plus the clipboard rows and
+  /// the lane submenu. Copy and Lane are nested because a phone context menu
+  /// past roughly ten top-level rows stops being scannable.
+  @ViewBuilder
+  private var goToMenuSection: some View {
+    Divider()
+    Button {
+      onGoToLane(session)
+    } label: {
+      Label("Go to lane", systemImage: "arrow.triangle.branch")
+    }
+    if let pullRequest {
+      Button {
+        onOpenPullRequest(session, pullRequest)
+      } label: {
+        Label("Open in PRs tab", systemImage: "arrow.triangle.pull")
+      }
+    }
+    Button {
+      onOpenInWeb(session)
+    } label: {
+      Label("Open in web", systemImage: "safari")
+    }
+    Menu {
+      Button {
+        onCopyId(session)
+      } label: {
+        Label("Session ID", systemImage: "number")
+      }
+      Button {
+        onCopyDeepLink(session)
+      } label: {
+        Label("Session link", systemImage: "link")
+      }
+    } label: {
+      Label("Copy", systemImage: "doc.on.doc")
+    }
+    laneMenuSection
+  }
+
+  /// `Lane ▸`. Rendered only when the row actually resolves a lane and the
+  /// screen wired the actions — on iOS every row has a lane header or a lane
+  /// chip, so this is the lane menu for the whole app, not just singleton rows.
+  @ViewBuilder
+  private var laneMenuSection: some View {
+    if let lane, let laneMenu {
+      Menu {
+        Button {
+          laneMenu.onStartChat(lane)
+        } label: {
+          Label("Start chat in lane", systemImage: "plus.bubble")
+        }
+        Menu {
+          Button {
+            laneMenu.onCopyLaneLink(lane)
+          } label: {
+            Label("ADE lane link", systemImage: "link")
+          }
+          Button {
+            laneMenu.onCopyBranchLink(lane)
+          } label: {
+            Label("Branch link", systemImage: "arrow.triangle.branch")
+          }
+          // Only a lane that actually carries a Linear issue URL — the copy is
+          // that URL verbatim, so there is nothing to offer without one.
+          if primaryLaneLinearIssue(for: lane)?.url != nil {
+            Button {
+              laneMenu.onCopyLinearLink(lane)
+            } label: {
+              Label("Linear issue link", systemImage: "square.on.square")
+            }
+          }
+          Button {
+            laneMenu.onCopyPath(lane)
+          } label: {
+            Label("Path", systemImage: "folder")
+          }
+        } label: {
+          Label("Copy", systemImage: "doc.on.doc")
+        }
+        if laneMenu.colorAvailable {
+          Menu {
+            ForEach(LaneColorPalette.entries) { entry in
+              Button {
+                laneMenu.onSetColor(lane, entry.hex)
+              } label: {
+                Label(entry.name, systemImage: lane.color?.lowercased() == entry.hex.lowercased()
+                  ? "checkmark.circle.fill"
+                  : "circle.fill")
+              }
+            }
+            Divider()
+            Button {
+              laneMenu.onSetColor(lane, nil)
+            } label: {
+              Label("No color", systemImage: "circle.dashed")
+            }
+          } label: {
+            Label("Color", systemImage: "paintpalette")
+          }
+        }
+        if laneMenu.manageAvailable {
+          // Last inside the submenu, like desktop: it opens a surface that can
+          // archive or delete the lane.
+          Button {
+            laneMenu.onManage(lane)
+          } label: {
+            Label("Manage lane", systemImage: "slider.horizontal.3")
+          }
+        }
+      } label: {
+        Label("Lane", systemImage: "arrow.triangle.branch")
+      }
+    }
+  }
+
+  /// Destructive, last, and behind a divider — the whole point of the reorder.
+  @ViewBuilder
+  private func destructiveMenuSection(status: String) -> some View {
+    if canStopAndDeleteSession(status: status) || shouldShowDeleteAction || canDeleteStoppedSession(status: status) {
+      Divider()
+      if canStopAndDeleteSession(status: status) {
+        Button(role: .destructive) {
+          onDeleteSession(session)
+        } label: {
+          Label("Stop & delete", systemImage: "trash")
+        }
+      }
+      if shouldShowDeleteAction {
+        Button(role: .destructive) {
+          onDelete(session)
+        } label: {
+          Label("Delete chat", systemImage: "trash")
+        }
+      }
+      if canDeleteStoppedSession(status: status) {
+        Button(role: .destructive) {
+          onDeleteSession(session)
+        } label: {
+          Label("Delete session", systemImage: "trash")
         }
       }
     }
@@ -1013,510 +1277,6 @@ struct WorkLanePrIndicator: View {
     .fixedSize()
     .accessibilityElement(children: .ignore)
     .accessibilityLabel("Pull request #\(tag.githubPrNumber), \(lanePrStateLabel(tag.state))")
-  }
-}
-
-/// The compact second line shared by every native Work session row.
-///
-/// Keep this precedence identical to the desktop card:
-/// explicit ask → agent note → sanitized last output → summary → goal.
-/// Output intentionally wins over the older AI summary so a failed/missing
-/// status-note write still leaves the user with the freshest truthful line.
-func workSessionRowPreviewSource(
-  session: TerminalSessionSummary,
-  chatSummary: AgentChatSessionSummary?,
-  isSettled: Bool
-) -> String? {
-  let primaryText = chatSummary?.title ?? session.title
-
-  func inlineText(_ raw: String?, terminalOutput: Bool = false) -> String? {
-    guard let raw else { return nil }
-    let rendered = terminalOutput ? sanitizeTerminalOutputForDisplay(raw) : raw
-    guard let normalized = workSessionPreviewText(rendered) else { return nil }
-    let inline = workSummarizeInlineText(normalized, maxChars: 120)
-    return inline.isEmpty ? nil : inline
-  }
-
-  if session.attentionRequestedAt?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
-     let message = inlineText(session.attentionMessage) {
-    return message
-  }
-  if let note = inlineText(session.statusNote) {
-    return isSettled ? "Done: \(note)" : note
-  }
-  for rawOutput in [chatSummary?.lastOutputPreview, session.lastOutputPreview] {
-    if let output = inlineText(rawOutput, terminalOutput: true), output != primaryText {
-      return output
-    }
-  }
-  for rawSummary in [chatSummary?.summary, session.summary] {
-    if let summary = inlineText(rawSummary), summary != primaryText {
-      return summary
-    }
-  }
-  for rawGoal in [chatSummary?.goal, session.goal] {
-    if let goal = inlineText(rawGoal), goal != primaryText {
-      return goal
-    }
-  }
-  return nil
-}
-
-private struct WorkSessionRowRenderSignature: Equatable {
-  let sessionId: String
-  let title: String
-  let provider: String?
-  let symbolProvider: String?
-  let laneName: String
-  let laneColor: String?
-  let laneDirty: Bool
-  let laneAhead: Int
-  let laneBehind: Int
-  let activityTimestamp: String
-  let previewText: String?
-  let pinned: Bool
-  let pullRequestNumber: Int?
-  let pullRequestState: String?
-  let status: String
-  let canonicalPhase: CanonicalSessionPhase
-  /// The rendered capsule and dot, not just the phase behind them: the badge
-  /// kind moves on its own when planning starts or stops, and the tone is what
-  /// the dot is painted with.
-  let badgeKind: SessionBadgeKind?
-  let rowTone: ActivityTone
-  let model: String?
-  let showsLaneIdentity: Bool
-  let settledAt: String?
-  let statusNote: String?
-  let attentionRequestedAt: String?
-  let attentionMessage: String?
-  let lastTurnFailedAt: String?
-  let settleOverride: String?
-  let snoozedUntil: String?
-  // `snoozedAt` is the early-wake comparison baseline behind
-  // `session.wokeMarker()`, which the row body renders. Without it a change
-  // confined to that column leaves the stale woke marker on screen.
-  let snoozedAt: String?
-  let wokeAt: String?
-  let wokeReason: String?
-  // Deterministic inputs to the attention capsule, so a badge transition
-  // (needs_you / failed) re-renders even when the display status is unchanged.
-  let runtimeState: String
-  let pendingInputItemId: String?
-  let exitCode: Int?
-  let isArchived: Bool
-  let isMuted: Bool
-  let isSelectedTransitionSource: Bool
-  let compact: Bool
-
-  init(
-    session: TerminalSessionSummary,
-    lane: LaneSummary?,
-    pullRequest: LanePrTag?,
-    chatSummary: AgentChatSessionSummary?,
-    status: String,
-    isArchived: Bool,
-    isMuted: Bool,
-    isSelectedTransitionSource: Bool,
-    compact: Bool,
-    showsLaneIdentity: Bool
-  ) {
-    self.sessionId = session.id
-    self.title = chatSummary?.title ?? session.title
-    self.provider = chatSummary?.provider ?? session.toolType
-    self.symbolProvider = chatSummary?.provider
-    self.laneName = session.laneName
-    self.laneColor = lane?.color
-    self.laneDirty = lane?.status.dirty == true
-    self.laneAhead = lane?.status.ahead ?? 0
-    self.laneBehind = lane?.status.behind ?? 0
-    self.activityTimestamp = workSessionActivityTimestamp(session: session, summary: chatSummary)
-    let canonical = workCanonicalSessionState(session: session, summary: chatSummary)
-    self.previewText = workSessionRowPreviewSource(
-      session: session,
-      chatSummary: chatSummary,
-      isSettled: canonical.phase == .settled
-    )
-    self.pinned = session.pinned
-    self.pullRequestNumber = pullRequest?.githubPrNumber
-    self.pullRequestState = pullRequest.map { lanePrStateLabel($0.state) }
-    self.status = status
-    self.canonicalPhase = canonical.phase
-    self.badgeKind = workSessionStatusBadge(session: session, summary: chatSummary)?.kind
-    self.rowTone = workSessionRowTone(session: session, summary: chatSummary)
-    self.model = chatSummary?.model
-    self.showsLaneIdentity = showsLaneIdentity
-    self.settledAt = session.settledAt
-    self.statusNote = session.statusNote
-    self.attentionRequestedAt = session.attentionRequestedAt
-    self.attentionMessage = session.attentionMessage
-    self.lastTurnFailedAt = session.lastTurnFailedAt
-    self.settleOverride = session.settleOverride
-    self.snoozedUntil = session.snoozedUntil
-    self.snoozedAt = session.snoozedAt
-    self.wokeAt = session.wokeAt
-    self.wokeReason = session.wokeReason
-    self.runtimeState = session.runtimeState
-    self.pendingInputItemId = session.pendingInputItemId
-    self.exitCode = session.exitCode
-    self.isArchived = isArchived
-    self.isMuted = isMuted
-    self.isSelectedTransitionSource = isSelectedTransitionSource
-    self.compact = compact
-  }
-}
-
-struct WorkSessionRow: View, Equatable {
-  let session: TerminalSessionSummary
-  let lane: LaneSummary?
-  var pullRequest: LanePrTag? = nil
-  let chatSummary: AgentChatSessionSummary?
-  let status: String
-  let isArchived: Bool
-  var isMuted: Bool = false
-  let transitionNamespace: Namespace.ID?
-  let isSelectedTransitionSource: Bool
-  var compact: Bool = false
-  /// The singleton form: no lane header above this row, so the row shows the
-  /// lane itself. Under a lane header the chip would just repeat the header.
-  var showsLaneIdentity: Bool = true
-  private let renderSignature: WorkSessionRowRenderSignature
-
-  init(
-    session: TerminalSessionSummary,
-    lane: LaneSummary?,
-    pullRequest: LanePrTag? = nil,
-    chatSummary: AgentChatSessionSummary?,
-    status: String,
-    isArchived: Bool,
-    isMuted: Bool = false,
-    transitionNamespace: Namespace.ID?,
-    isSelectedTransitionSource: Bool,
-    compact: Bool = false,
-    showsLaneIdentity: Bool = true
-  ) {
-    self.session = session
-    self.lane = lane
-    self.pullRequest = pullRequest
-    self.chatSummary = chatSummary
-    self.status = status
-    self.isArchived = isArchived
-    self.isMuted = isMuted
-    self.transitionNamespace = transitionNamespace
-    self.isSelectedTransitionSource = isSelectedTransitionSource
-    self.compact = compact
-    self.showsLaneIdentity = showsLaneIdentity
-    self.renderSignature = WorkSessionRowRenderSignature(
-      session: session,
-      lane: lane,
-      pullRequest: pullRequest,
-      chatSummary: chatSummary,
-      status: status,
-      isArchived: isArchived,
-      isMuted: isMuted,
-      isSelectedTransitionSource: isSelectedTransitionSource,
-      compact: compact,
-      showsLaneIdentity: showsLaneIdentity
-    )
-  }
-
-  static func == (lhs: WorkSessionRow, rhs: WorkSessionRow) -> Bool {
-    lhs.renderSignature == rhs.renderSignature
-  }
-
-  var body: some View {
-    if compact {
-      compactBody
-    } else {
-      standardBody
-    }
-  }
-
-  private var compactBody: some View {
-    HStack(alignment: .center, spacing: 8) {
-      WorkProviderBareLogo(
-        provider: chatSummary?.provider ?? session.toolType,
-        fallbackSymbol: sessionSymbol(session, provider: chatSummary?.provider),
-        tint: providerTintColor,
-        size: 20
-      )
-
-      Text(chatSummary?.title ?? session.title)
-        .font(.caption.weight(.semibold))
-        .foregroundStyle(ADEColor.textPrimary)
-        .lineLimit(1)
-        .truncationMode(.tail)
-
-      if let badge = capsuleBadge {
-        WorkSessionStatusCapsule(badge: badge)
-      }
-
-      Spacer(minLength: 6)
-
-      if isPendingSyncCreation {
-        Text("Pending sync")
-          .font(.caption2.weight(.semibold))
-          .foregroundStyle(ADEColor.textMuted)
-          .lineLimit(1)
-      } else {
-        Text(relativeTimestampCompact(workSessionActivityTimestamp(session: session, summary: chatSummary)))
-          .font(.caption2.monospacedDigit())
-          .foregroundStyle(ADEColor.textMuted)
-          .lineLimit(1)
-      }
-    }
-    .padding(.horizontal, 10)
-    .padding(.vertical, 8)
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .background(providerTintColor.opacity(0.07), in: RoundedRectangle(cornerRadius: 11, style: .continuous))
-    .overlay(
-      RoundedRectangle(cornerRadius: 11, style: .continuous)
-        .stroke(providerTintColor.opacity(0.18), lineWidth: 0.6)
-    )
-    .opacity(isSettled ? 0.7 : 1)
-    .accessibilityElement(children: .combine)
-    .accessibilityLabel(accessibilityLabel)
-  }
-
-  private var standardBody: some View {
-    HStack(alignment: .center, spacing: 12) {
-      WorkProviderBareLogo(
-        provider: chatSummary?.provider ?? session.toolType,
-        fallbackSymbol: sessionSymbol(session, provider: chatSummary?.provider),
-        tint: providerTintColor,
-        size: 32
-      )
-      .adeMatchedGeometry(id: isSelectedTransitionSource ? "work-icon-\(session.id)" : nil, in: transitionNamespace)
-
-      VStack(alignment: .leading, spacing: 3) {
-        HStack(alignment: .center, spacing: 6) {
-          Group {
-            if isSettled {
-              // Hollow, not filled: settled work is put away, and the ring says
-              // that without spending a solid dot on it. Tinted rather than
-              // white so it still carries the phase's hue.
-              Circle()
-                .stroke(rowTint.opacity(0.7), lineWidth: 1)
-            } else {
-              Circle()
-                .fill(rowTint)
-            }
-          }
-          .frame(width: 6, height: 6)
-          Text(chatSummary?.title ?? session.title)
-            .font(.subheadline.weight(.semibold))
-            .foregroundStyle(ADEColor.textPrimary)
-            .lineLimit(1)
-            .truncationMode(.tail)
-            .adeMatchedGeometry(id: isSelectedTransitionSource ? "work-title-\(session.id)" : nil, in: transitionNamespace)
-          if session.pinned {
-            Image(systemName: "pin.fill")
-              .font(.caption2)
-              .foregroundStyle(ADEColor.accent)
-          }
-          if isMuted {
-            Image(systemName: "bell.slash")
-              .font(.caption2)
-              .foregroundStyle(ADEColor.textMuted)
-              .accessibilityLabel("Notifications muted")
-          }
-          if let badge = capsuleBadge {
-            WorkSessionStatusCapsule(badge: badge)
-          }
-          Spacer(minLength: 6)
-          Text(relativeTimestampCompact(renderSignature.activityTimestamp))
-            .font(.caption2.monospacedDigit())
-            .foregroundStyle(ADEColor.textMuted)
-            .lineLimit(1)
-        }
-
-        if let preview = renderSignature.previewText {
-          Text(preview)
-            .font(.caption2)
-            .foregroundStyle(ADEColor.textMuted)
-            .lineLimit(1)
-            .truncationMode(.tail)
-        }
-
-        HStack(spacing: 6) {
-          Text(shortProviderLabel(chatSummary?.provider ?? session.toolType))
-            .font(.caption2)
-            .foregroundStyle(ADEColor.textMuted)
-            .lineLimit(1)
-
-          // The model the turn actually runs on. iOS carried it in the chat
-          // summary and never showed it, so two rows on the same provider were
-          // indistinguishable.
-          if let model = renderSignature.model, !model.isEmpty {
-            Text("·")
-              .font(.caption2)
-              .foregroundStyle(ADEColor.textMuted.opacity(0.5))
-            Text(shortModelLabel(model))
-              .font(.caption2)
-              .foregroundStyle(ADEColor.textMuted)
-              .lineLimit(1)
-              .truncationMode(.middle)
-              .layoutPriority(-1)
-          }
-
-          // Under a lane header the lane chip only repeats the header, so it is
-          // spent here on the model instead. A headerless (singleton) row is the
-          // only thing carrying the lane, and always shows it.
-          if showsLaneIdentity {
-            Text("·")
-              .font(.caption2)
-              .foregroundStyle(ADEColor.textMuted.opacity(0.5))
-
-            if let laneAccent = LaneColorPalette.color(forHex: lane?.color) {
-              Circle()
-                .fill(laneAccent)
-                .frame(width: 6, height: 6)
-            } else {
-              Image(systemName: "arrow.triangle.branch")
-                .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(ADEColor.textMuted)
-            }
-            Text(session.laneName)
-              .font(.caption2)
-              .foregroundStyle(LaneColorPalette.color(forHex: lane?.color) ?? ADEColor.textMuted)
-              .lineLimit(1)
-              .truncationMode(.middle)
-              .layoutPriority(-1)
-          }
-
-          if lane?.status.dirty == true {
-            Circle()
-              .fill(ADEColor.warning)
-              .frame(width: 6, height: 6)
-              .accessibilityLabel("Uncommitted changes")
-          }
-
-          if let ahead = lane?.status.ahead, ahead > 0 {
-            HStack(spacing: 1) {
-              Image(systemName: "arrow.up")
-                .font(.system(size: 9, weight: .semibold))
-              Text("\(ahead)")
-                .font(.caption2.monospacedDigit())
-            }
-            .foregroundStyle(ADEColor.success)
-          }
-
-          if let behind = lane?.status.behind, behind > 0 {
-            HStack(spacing: 1) {
-              Image(systemName: "arrow.down")
-                .font(.system(size: 9, weight: .semibold))
-              Text("\(behind)")
-                .font(.caption2.monospacedDigit())
-            }
-            .foregroundStyle(ADEColor.warning)
-          }
-
-          Spacer(minLength: 0)
-
-          if let wakeLabel = snoozeWakeLabel {
-            WorkSessionLifecycleTag(symbol: "moon.zzz", text: wakeLabel, tint: ADEColor.info)
-          } else if let woke = session.wokeMarker() {
-            WorkSessionLifecycleTag(symbol: "sun.max", text: woke.wokeLabel, tint: ADEColor.warning)
-          }
-
-          if isPendingSyncCreation {
-            HStack(spacing: 4) {
-              Image(systemName: "clock.arrow.circlepath")
-                .font(.system(size: 9, weight: .semibold))
-              Text("Pending sync")
-                .font(.caption2.weight(.semibold))
-            }
-            .foregroundStyle(ADEColor.textMuted)
-          } else if isArchived {
-            Text("ARCHIVED")
-              .font(.caption2.monospaced().weight(.semibold))
-              .foregroundStyle(ADEColor.warning)
-              .adeMatchedGeometry(id: isSelectedTransitionSource ? "work-status-\(session.id)" : nil, in: transitionNamespace)
-          }
-        }
-      }
-    }
-    .padding(14)
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .background(providerTintColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
-    .overlay(
-      RoundedRectangle(cornerRadius: 16, style: .continuous)
-        .stroke(providerTintColor.opacity(0.25), lineWidth: 0.75)
-    )
-    .opacity(isSettled ? 0.7 : 1)
-    .adeMatchedTransitionSource(id: isSelectedTransitionSource ? "work-container-\(session.id)" : nil, in: transitionNamespace)
-    .accessibilityElement(children: .combine)
-    .accessibilityLabel(accessibilityLabel)
-    .adeInspectable(
-      "Work.Session.Row",
-      metadata: [
-        "sessionId": session.id,
-        "laneId": session.laneId,
-        "laneName": session.laneName,
-        "title": chatSummary?.title ?? session.title
-      ]
-    )
-  }
-
-  var providerTintColor: Color {
-    providerTint(chatSummary?.provider ?? session.toolType)
-  }
-
-  /// The row's status capsule, in the full shared vocabulary — needs you,
-  /// failed, stale, working, planning, done. Nil for the resting states, so the
-  /// row never shifts layout to say that nothing is happening.
-  var capsuleBadge: SessionBadge? {
-    workSessionStatusBadge(session: session, summary: chatSummary)
-  }
-
-  var canonicalState: CanonicalSessionState {
-    workCanonicalSessionState(session: session, summary: chatSummary)
-  }
-
-  var isSettled: Bool {
-    canonicalState.phase == .settled
-  }
-
-  /// Non-nil only while the snooze window is still open. Snooze is a visibility
-  /// overlay, so it changes what the row says, never its canonical phase.
-  var snoozeWakeLabel: String? {
-    guard session.isSnoozed() else { return nil }
-    return workSnoozeWakeLabel(session.snoozedUntil)
-  }
-
-  var isPendingSyncCreation: Bool {
-    workIsPendingChatCreationSession(session)
-  }
-
-  /// The status dot's hue. Reads the canonical phase through the shared tone
-  /// table rather than the coarse four-value status string, so the dot and the
-  /// capsule above it can never tell different stories.
-  var rowTint: Color {
-    if isPendingSyncCreation { return ADEColor.textMuted }
-    if isArchived { return ADEColor.warning }
-    return activityToneColor(renderSignature.rowTone)
-  }
-
-  var accessibilityLabel: String {
-    var parts = [chatSummary?.title ?? session.title, session.laneName, sessionStatusLabel(for: status)]
-    if let model = renderSignature.model, !model.isEmpty {
-      parts.append(shortModelLabel(model))
-    }
-    if session.pinned {
-      parts.append("pinned")
-    }
-    if isArchived {
-      parts.append("archived")
-    }
-    if isSettled {
-      parts.append("settled")
-    }
-    if let wakeLabel = snoozeWakeLabel {
-      parts.append("snoozed \(wakeLabel.lowercased())")
-    } else if let woke = session.wokeMarker() {
-      parts.append("woke, \(woke.wokeLabel.lowercased())")
-    }
-    return parts.joined(separator: ", ")
   }
 }
 

--- a/apps/ios/ADE/Views/Work/WorkRootScreen+Actions.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootScreen+Actions.swift
@@ -2,6 +2,20 @@ import SwiftUI
 import UIKit
 import AVKit
 
+/// Mirrors desktop `shared/webClientUrl.ts`: the web client serves the same
+/// https deeplinks `ade-app.dev/open` does, from its own origin. Kept as a
+/// string swap on an existing link rather than a second URL builder so the two
+/// forms cannot drift.
+private let workWebClientHost = "app.ade-app.dev"
+
+func workWebClientURL(for link: String) -> URL? {
+  guard var components = URLComponents(string: link) else { return nil }
+  components.scheme = "https"
+  components.host = workWebClientHost
+  components.port = nil
+  return components.url
+}
+
 private struct WorkPersistedProjectionLoad {
   let sessions: [TerminalSessionSummary]
   let lanes: [LaneSummary]
@@ -52,7 +66,10 @@ extension WorkRootScreen {
     let outputSearchBySessionId = workSessionOutputSearchIndexBySessionId(
       buffers: searchTextSnapshot.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? [:] : syncService.terminalBuffers
     )
-    let organization = WorkSessionOrganization(rawValue: sessionOrganizationRaw) ?? .byStatus
+    // `.byLane` is the real default (`WorkProjectViewState.organization`); an
+    // unparseable value must land on the same one the filter chip shows, or the
+    // rendered groups and the chip disagree until the next write.
+    let organization = WorkSessionOrganization(rawValue: sessionOrganizationRaw) ?? .byLane
     // A pin is an explicit "keep this where I can see it": it lifts the lane to
     // the top tier and keeps its header, singleton or not. Same store the Lanes
     // tab writes, so one pin means one thing across both surfaces.
@@ -435,6 +452,16 @@ extension WorkRootScreen {
     }
   }
 
+  /// Desktop's "Dismiss & settle": clears the row's pending prompt as part of
+  /// settling it. Only ever called for a row the menu resolved as needs-you —
+  /// the host rejects the dismiss flag on a row with nothing pending, so it is
+  /// a distinct action rather than a flag the caller may guess at.
+  func dismissAndSettleSession(_ session: TerminalSessionSummary) {
+    runSessionLifecycle { [syncService] in
+      try await syncService.settleSession(sessionId: session.id, dismissPendingInput: true)
+    }
+  }
+
   func unsettleSession(_ session: TerminalSessionSummary) {
     runSessionLifecycle { [syncService] in
       try await syncService.unsettleSession(sessionId: session.id)
@@ -680,6 +707,124 @@ extension WorkRootScreen {
       } catch {
         ADEHaptics.error()
         errorMessage = error.localizedDescription
+      }
+    }
+  }
+
+  /// Delete a CLI or shell session. The host command already stops a live
+  /// runtime first (`deleteTerminalSessionWithRuntimeCleanup`), so the same call
+  /// serves both "Stop & delete" and "Delete session" — the label differs
+  /// because the consequence does, not the transport.
+  func deleteWorkSession(_ session: TerminalSessionSummary) {
+    Task {
+      do {
+        try await syncService.deleteWorkSession(sessionId: session.id)
+        await reload(refreshRemote: true)
+      } catch {
+        ADEHaptics.error()
+        actionErrorMessage = error.localizedDescription
+      }
+    }
+  }
+
+  /// Opens this session in the hosted web client. No host command is involved:
+  /// the URL is the same https deeplink the copy action produces, re-homed on
+  /// the web client's origin exactly like desktop's `buildWebClientUrl`.
+  func openSessionInWeb(_ session: TerminalSessionSummary) {
+    let laneId = resolvedWorkNavigationLaneId(for: session, lanes: lanes)
+    let lane = lanes.first(where: { $0.id == laneId })
+    let pullRequest = pullRequests.first(where: { $0.laneId == laneId })
+    let link = workSessionDeepLink(
+      sessionId: session.id,
+      laneId: laneId,
+      envelope: LaneDeeplinkHelpers.envelope(lane: lane, pullRequest: pullRequest)
+    )
+    guard let url = workWebClientURL(for: link) else { return }
+    UIApplication.shared.open(url)
+  }
+
+  // MARK: - Lane submenu actions
+  //
+  // The lane half of a session row's long-press menu. Every command here is one
+  // the Lanes tab already sends; nothing new reaches the host from this menu.
+
+  func startChatInLane(_ lane: LaneSummary) {
+    pushNewChatRoute(preferredLaneId: lane.id)
+  }
+
+  func copyLaneLink(_ lane: LaneSummary) {
+    let pullRequest = pullRequests.first(where: { $0.laneId == lane.id })
+    UIPasteboard.general.string = LaneDeeplinkHelpers.laneLink(
+      laneId: lane.id,
+      envelope: LaneDeeplinkHelpers.envelope(lane: lane, pullRequest: pullRequest),
+      form: .ade
+    )
+  }
+
+  /// The cross-machine form: a branch link identifies work by repo and branch,
+  /// so it resolves on any machine that has the repo. It needs an owner/name,
+  /// which only a known PR carries here — without one, desktop falls back to the
+  /// lane link rather than copying nothing, and so does this.
+  func copyLaneBranchLink(_ lane: LaneSummary) {
+    let branch = normalizedPrBranchName(lane.branchRef)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    let pullRequest = pullRequests.first(where: { $0.laneId == lane.id })
+    guard !branch.isEmpty,
+          let owner = pullRequest?.repoOwner, !owner.isEmpty,
+          let name = pullRequest?.repoName, !name.isEmpty else {
+      copyLaneLink(lane)
+      return
+    }
+    UIPasteboard.general.string = LaneDeeplinkHelpers.branchLink(
+      repoOwner: owner,
+      repoName: name,
+      branch: branch
+    )
+  }
+
+  func copyLaneLinearLink(_ lane: LaneSummary) {
+    guard let url = primaryLaneLinearIssue(for: lane)?.url, !url.isEmpty else { return }
+    UIPasteboard.general.string = url
+  }
+
+  func copyLanePath(_ lane: LaneSummary) {
+    UIPasteboard.general.string = lane.worktreePath
+  }
+
+  /// An empty string clears the colour: `lanes.updateAppearance` reads "" as
+  /// "unset", which is the same contract the Lanes tab's swatch row uses.
+  func setLaneColor(_ lane: LaneSummary, hex: String?) {
+    Task {
+      do {
+        try await syncService.updateLaneAppearance(lane.id, color: hex ?? "")
+        await reload(refreshRemote: true)
+      } catch {
+        ADEHaptics.error()
+        actionErrorMessage = error.localizedDescription
+      }
+    }
+  }
+
+  /// Presents the Lanes tab's own manage sheet rather than a Work-local copy, so
+  /// rename / archive / delete cannot drift between the two surfaces. The
+  /// snapshot it needs carries runtime state the Work projection does not hold,
+  /// so it is fetched on demand; the sheet only appears once it resolves.
+  func manageLane(_ lane: LaneSummary) {
+    Task { @MainActor in
+      // Context-menu actions fire before iOS finishes dismissing the menu.
+      // Presenting a sheet into that dismissal drops it silently.
+      try? await Task.sleep(for: .milliseconds(450))
+      do {
+        let snapshots = try await syncService.fetchLaneListSnapshots(includeArchived: true)
+        guard let snapshot = snapshots.first(where: { $0.lane.id == lane.id }) else {
+          actionErrorMessage = "That lane is no longer on this machine."
+          return
+        }
+        manageLaneSnapshots = snapshots
+        manageLaneTarget = snapshot
+      } catch {
+        ADEHaptics.error()
+        actionErrorMessage = error.localizedDescription
       }
     }
   }

--- a/apps/ios/ADE/Views/Work/WorkRootScreen.swift
+++ b/apps/ios/ADE/Views/Work/WorkRootScreen.swift
@@ -189,6 +189,11 @@ struct WorkRootScreen: View {
   @State var workViewStateBeforeDeeplink: WorkProjectViewState?
   @State var filterPanelOpen = false
   @State var addLaneSheetPresented = false
+  /// Lane the row menu's "Manage lane" is opening, plus the sibling snapshots
+  /// the Lanes tab's manage sheet needs to resolve parents and colour reuse.
+  /// Both are transient: fetched when the item is tapped, cleared on dismiss.
+  @State var manageLaneTarget: LaneListSnapshot?
+  @State var manageLaneSnapshots: [LaneListSnapshot] = []
 
   var selectedStatus: WorkSessionStatusFilter {
     get { WorkSessionStatusFilter(rawValue: selectedStatusRawValue) ?? .all }
@@ -322,37 +327,26 @@ struct WorkRootScreen: View {
     sessionPresentation.displaySessions
   }
 
-  var liveChatSessions: [TerminalSessionSummary] {
-    sessionPresentation.liveChatSessions
-  }
-
   var hasActiveFilters: Bool {
     selectedStatus != .all
       || selectedLaneId != "all"
       || !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
   }
 
-  var globalNeedsInputCount: Int {
-    sessionPresentation.globalNeedsInputCount
-  }
-
-  var globalLiveSessionCount: Int {
-    sessionPresentation.globalLiveSessionCount
-  }
-
-  var firstGlobalAttentionSession: TerminalSessionSummary? {
-    guard let id = sessionPresentation.firstGlobalAttentionSessionId else { return nil }
-    return mergedSessions.first { $0.id == id }
-  }
-
-  var firstGlobalLiveSession: TerminalSessionSummary? {
-    guard let id = sessionPresentation.firstGlobalLiveSessionId else { return nil }
-    return mergedSessions.first { $0.id == id }
-  }
+  // No screen-wide live/attention rollup is derived here any more. The counts and
+  // the "first session wanting you" lookups that used to hang off
+  // `WorkRootSessionPresentation` fed only the deleted top-bar pill and its
+  // duplicate chip; the bell's Activity drawer owns that job now, and it reads
+  // the drawer's own model rather than this screen's projection.
 
   var sessionOrganizationBinding: Binding<WorkSessionOrganization> {
     Binding(
-      get: { WorkSessionOrganization(rawValue: sessionOrganizationRaw) ?? .byStatus },
+      // `.byLane`, not `.byStatus`: it is the real default in both the `@State`
+      // above and `WorkProjectViewState.organization`. A fallback that disagrees
+      // lets the rendered groups and the filter chip's selection show different
+      // groupings for a frame whenever the stored raw value is unparseable.
+      // Twin fallback in `WorkRootScreen+Actions.swift`.
+      get: { WorkSessionOrganization(rawValue: sessionOrganizationRaw) ?? .byLane },
       set: {
         restoreWorkViewStateAfterDeeplink()
         sessionOrganizationRaw = $0.rawValue
@@ -437,13 +431,22 @@ struct WorkRootScreen: View {
   }
 
   func pushNewChatRoute() {
-    guard !navigationMutationPending else { return }
     let preferred = selectedLaneId == "all" ? nil : selectedLaneId
+    pushNewChatRoute(preferredLaneId: preferred)
+  }
+
+  /// Same route, with the lane chosen by the caller rather than by the filter —
+  /// the row menu's "Start chat in lane" targets the row's lane, not whatever
+  /// the lane filter happens to be set to.
+  func pushNewChatRoute(preferredLaneId: String?) {
+    guard !navigationMutationPending else { return }
     navigationMutationPending = true
     selectedSessionTransitionId = nil
     Task { @MainActor in
+      // Long-press menu actions fire mid-dismissal; pushing a route into that
+      // animation is what the existing yield below is already guarding against.
       await Task.yield()
-      path.append(WorkNewChatRoute(preferredLaneId: preferred))
+      path.append(WorkNewChatRoute(preferredLaneId: preferredLaneId))
       navigationMutationPending = false
     }
   }
@@ -557,8 +560,6 @@ struct WorkRootScreen: View {
             organization: sessionOrganizationBinding,
             filterOpen: $filterPanelOpen,
             lanes: workOrderedLanes,
-            liveCount: globalLiveSessionCount,
-            needsInputCount: globalNeedsInputCount,
             isLive: isLive,
             onClear: clearWorkFilters,
             onNewChat: pushNewChatRoute,
@@ -621,7 +622,7 @@ struct WorkRootScreen: View {
             .listRowSeparator(.hidden)
           } else {
             ForEach(sessionGroups) { group in
-              workSessionGroupRows(group)
+              workSessionGroupSection(group)
             }
           }
         }
@@ -647,22 +648,15 @@ struct WorkRootScreen: View {
             }
             .accessibilityLabel("Cancel selection")
           } else {
-            if globalLiveSessionCount > 0 || globalNeedsInputCount > 0 {
-              WorkLiveCountPill(
-                liveCount: globalLiveSessionCount,
-                attentionCount: globalNeedsInputCount,
-                onTap: {
-                  guard let target = firstGlobalAttentionSession ?? firstGlobalLiveSession else { return }
-                  if sessionPresentation.displaySessionIds.contains(target.id) {
-                    withAnimation(.snappy) {
-                      proxy.scrollTo(target.id, anchor: .top)
-                    }
-                  } else {
-                    openSession(target)
-                  }
-                }
-              )
-            }
+            // No attention rollup lives here. A tappable count pill used to sit
+            // left of the Linear button and a flat chip repeated the very same
+            // count above the list, so amber — which means "your move" and
+            // nothing else — was spent three times on one screen and the per-row
+            // badge stopped registering. The jump-to-attention affordance already
+            // exists: the bell opens the Activity drawer, which bands needs-you
+            // first with per-session navigation. Do not reintroduce a
+            // replacement here, and do not re-derive the counts that fed it.
+            //
             // Real-Linear-logo button, immediately left of the bell; gated on the
             // active project's Linear connection.
             LinearPaneToolbarButton()
@@ -716,6 +710,20 @@ struct WorkRootScreen: View {
             addLaneSheetPresented = false
             restoreWorkViewStateAfterDeeplink()
             selectedLaneId = createdLaneId
+            await reload(refreshRemote: true)
+          }
+        )
+      }
+      .sheet(item: $manageLaneTarget) { snapshot in
+        LaneManageSheet(
+          snapshot: snapshot,
+          allLaneSnapshots: manageLaneSnapshots,
+          onDeleted: {
+            manageLaneTarget = nil
+            await reload(refreshRemote: true)
+          },
+          onComplete: {
+            manageLaneTarget = nil
             await reload(refreshRemote: true)
           }
         )
@@ -938,87 +946,230 @@ struct WorkRootScreen: View {
       : collapsedSectionIds.contains(group.id)
   }
 
-  @ViewBuilder
-  private func workSessionGroupRows(_ group: WorkSessionGroup) -> some View {
-    // The singleton form: one top-level row in the lane, so the header would be
-    // a divider carrying a name the row already says. The row takes the lane
-    // identity instead (its meta line and its "Go to lane" / PR actions).
-    if group.isHeaderless {
-      ForEach(group.sessions.filter { sessionPresentation.topLevelDisplaySessionIds.contains($0.id) }) { session in
-        workSessionRows(session, showsLaneIdentity: true)
-      }
-    } else {
-      workSessionGroupRowsWithHeader(group)
-    }
+  /// Top-level rows of a group, in display order. Child shells are rendered by
+  /// their parent row, so they are filtered out here.
+  private func workTopLevelSessions(in group: WorkSessionGroup) -> [TerminalSessionSummary] {
+    group.sessions.filter { sessionPresentation.topLevelDisplaySessionIds.contains($0.id) }
+  }
+
+  /// Gutter the lane accent rail occupies: the 1pt rail plus the 8pt gap to the
+  /// card. Rows under a lane header shift right by this much; the rail itself is
+  /// drawn in that gutter, so it costs no card width of its own.
+  private static let workLaneRailGutter: CGFloat = 9
+
+  /// Absolute leading indent of a nested child-shell block, measured from the
+  /// list's own 16pt margin. Held constant whether or not a lane rail is present
+  /// so a nested shell never reads as double-indented under the rail.
+  private static let workChildShellIndent: CGFloat = 30
+
+  /// The `Lane ▸` submenu's wiring. Every entry is a command the Lanes tab
+  /// already sends, so the two surfaces cannot disagree about what a lane action
+  /// does. The two flags are per-command capability gates: a host that does not
+  /// advertise `lanes.updateAppearance` or `lanes.rename` shows no colour or
+  /// manage row at all rather than one that fails on tap.
+  var workLaneMenuActions: WorkSessionLaneMenuActions {
+    WorkSessionLaneMenuActions(
+      colorAvailable: syncService.canInvokeRemoteAction("lanes.updateAppearance"),
+      manageAvailable: syncService.canInvokeRemoteAction("lanes.rename"),
+      onStartChat: startChatInLane,
+      onCopyLaneLink: copyLaneLink,
+      onCopyBranchLink: copyLaneBranchLink,
+      onCopyLinearLink: copyLaneLinearLink,
+      onCopyPath: copyLanePath,
+      onSetColor: setLaneColor,
+      onManage: manageLane
+    )
   }
 
   @ViewBuilder
-  private func workSessionGroupRowsWithHeader(_ group: WorkSessionGroup) -> some View {
+  private func workSessionGroupSection(_ group: WorkSessionGroup) -> some View {
+    // The singleton form: one top-level row in the lane, so the header would be
+    // a divider carrying a name the row already says. The row takes the lane
+    // identity instead (its meta line and its "Go to lane" / PR actions).
+    //
+    // Still a `Section`, headerless: it keeps `listSectionSpacing` in charge of
+    // the gap to the neighbouring lane, and it gives the group an `.id` for the
+    // lane deeplink to scroll to even when there is no header view to carry one.
+    if group.isHeaderless {
+      Section {
+        ForEach(workTopLevelSessions(in: group)) { session in
+          workSessionRows(session, showsLaneIdentity: true)
+        }
+      }
+      .id(group.id)
+    } else {
+      workSessionGroupSectionWithHeader(group)
+    }
+  }
+
+  /// A real `Section` with a `header:`, not a header emitted as an ordinary row.
+  /// `List(.plain)` only pins content passed as a section header — as plain rows
+  /// these scrolled away, which is what made a long lane lose its name.
+  @ViewBuilder
+  private func workSessionGroupSectionWithHeader(_ group: WorkSessionGroup) -> some View {
     let isLaneDeleting = group.laneId.map(syncService.pendingLaneDeletionIds.contains) ?? false
     let collapsed = workGroupIsCollapsed(group)
     let isQuietRow = group.isQuiet && collapsed
-    WorkSidebarSectionHeader(
-      group: group,
-      collapsed: collapsed,
-      onToggle: {
-        withAnimation(ADEMotion.quick(reduceMotion: reduceMotion)) {
-          toggleCollapsed(group.isQuiet ? group.quietOpenSectionId : group.id)
-        }
-      },
-      pullRequest: group.isOrphaned ? nil : group.laneId.flatMap { lanePrTagsByLaneId[$0] },
-      onOpenPullRequest: { tag in
-        openLanePullRequest(tag: tag, laneId: group.laneId)
-      },
-      onRefreshOrphanedSessions: group.isOrphaned
-        ? { Task { await refreshFromPullGesture() } }
-        : nil
-    )
-    .disabled(isLaneDeleting)
-    .redacted(reason: isLaneDeleting ? .placeholder : [])
-    .id(group.id)
-    .listRowBackground(Color.clear)
-    .listRowSeparator(.hidden)
-    .listRowInsets(EdgeInsets(
-      top: isQuietRow ? 2 : 8,
-      leading: 16,
-      bottom: isQuietRow ? 0 : 2,
-      trailing: 16
-    ))
+    // Real lane sections get the accent rail; status/time headers span multiple
+    // lanes, so a single lane color would be a lie there.
+    let railColor: Color? = group.laneId == nil
+      ? nil
+      : LaneColorPalette.displayColor(forHex: group.laneColor).opacity(0.35)
 
-    if group.isOrphaned && !collapsed {
-      Text("The lane record is missing from the latest machine snapshot. Refresh to reconcile it. ADE will not delete sessions, branches, worktrees, commits, or pull requests.")
-        .font(.footnote)
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .listRowBackground(Color.clear)
-        .listRowSeparator(.hidden)
-        .accessibilityIdentifier("work-orphan-session-explanation")
-    }
-
-    if !collapsed {
-      ForEach(group.sessions.filter { sessionPresentation.topLevelDisplaySessionIds.contains($0.id) }) { session in
-        // An expanded quiet lane holds only settled rows: the full card's
-        // preview line and meta row are about work in flight, of which there is
-        // none here.
-        //
-        // A row under a lane header does not repeat the lane name — the header
-        // two rows up already says it, and the space is worth more as the model.
-        workSessionRows(
-          session,
-          compact: group.isQuiet,
-          showsLaneIdentity: group.laneId == nil
-        )
+    Section {
+      if group.isOrphaned && !collapsed {
+        Text("The lane record is missing from the latest machine snapshot. Refresh to reconcile it. ADE will not delete sessions, branches, worktrees, commits, or pull requests.")
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+          .padding(.horizontal, 12)
+          .padding(.vertical, 8)
+          .listRowBackground(Color.clear)
+          .listRowSeparator(.hidden)
+          .accessibilityIdentifier("work-orphan-session-explanation")
       }
+
+      // Collapsed means an empty section body, never a hidden section: the
+      // header has to stay on screen or there is no way back into the group.
+      if !collapsed {
+        ForEach(workTopLevelSessions(in: group)) { session in
+          // An expanded quiet lane holds only settled rows: the full card's
+          // preview line and meta row are about work in flight, of which there is
+          // none here.
+          //
+          // A row under a lane header does not repeat the lane name — the header
+          // two rows up already says it, and the space is worth more as the model.
+          //
+          // Compactness is scoped to LANE groups on purpose. A quiet lane folds
+          // to compact rows because its header still names the lane, but the
+          // Snoozed and Settled shelves span lanes by construction and their
+          // headers name none — and `compactBody` has no lane chip to render.
+          // Folding a shelf to compact would leave three snoozed rows from three
+          // different lanes visually indistinguishable.
+          workSessionRows(
+            session,
+            compact: group.isQuiet && group.laneId != nil,
+            showsLaneIdentity: group.laneId == nil,
+            railColor: railColor
+          )
+        }
+      }
+    } header: {
+      WorkSidebarSectionHeader(
+        group: group,
+        collapsed: collapsed,
+        onToggle: {
+          withAnimation(ADEMotion.quick(reduceMotion: reduceMotion)) {
+            toggleCollapsed(group.isQuiet ? group.quietOpenSectionId : group.id)
+          }
+        },
+        pullRequest: group.isOrphaned ? nil : group.laneId.flatMap { lanePrTagsByLaneId[$0] },
+        onOpenPullRequest: { tag in
+          openLanePullRequest(tag: tag, laneId: group.laneId)
+        },
+        onRefreshOrphanedSessions: group.isOrphaned
+          ? { Task { await refreshFromPullGesture() } }
+          : nil,
+        // Lane-scoped git state belongs to the lane, so it is stated once here
+        // rather than repeated on every row beneath. Orphaned sections have no
+        // lane record to read it from.
+        laneStatus: group.isOrphaned ? nil : group.laneId.flatMap { laneById[$0]?.status }
+      )
+      .disabled(isLaneDeleting)
+      .redacted(reason: isLaneDeleting ? .placeholder : [])
+      // Opaque, not `.clear`: a pinned `List(.plain)` header is transparent by
+      // default, so rows would scroll visibly underneath the lane name. This is
+      // the same token `adeScreenBackground()` paints behind the list.
+      .listRowBackground(ADEColor.pageBackground)
+      .listRowSeparator(.hidden)
+      .listRowInsets(EdgeInsets(
+        top: isQuietRow ? 2 : 8,
+        leading: 16,
+        bottom: isQuietRow ? 0 : 2,
+        trailing: 16
+      ))
     }
+    // On the `Section`, not on the header row: the header is no longer a row of
+    // its own, and the lane deeplink scrolls to this id.
+    .id(group.id)
   }
 
   @ViewBuilder
   private func workSessionRows(
     _ session: TerminalSessionSummary,
     compact: Bool = false,
-    showsLaneIdentity: Bool = true
+    showsLaneIdentity: Bool = true,
+    railColor: Color? = nil
   ) -> some View {
+    sessionListRow(
+      session,
+      compact: compact,
+      showsLaneIdentity: showsLaneIdentity,
+      transitionNamespace: ADEMotion.allowsMatchedGeometry(reduceMotion: reduceMotion)
+        ? sessionTransitionNamespace
+        : nil
+    )
+    // The 4pt vertical gap belongs INSIDE the cell, not in `listRowInsets`. With
+    // it in the insets the lane rail is chopped into one 4pt-gapped segment per
+    // row instead of reading as a single line down the lane. Do not move it back.
+    .padding(.vertical, 4)
+    .workLaneAccentRail(railColor, gutter: Self.workLaneRailGutter)
+    .id(session.id)
+    .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+    .listRowBackground(Color.clear)
+    .listRowSeparator(.hidden)
+
+    if let childGroup = sessionPresentation.childGroupsByParentId[session.id] {
+      WorkChildShellSection(
+        group: childGroup,
+        collapsed: collapsedSectionIds.contains(childGroup.collapsedSectionId),
+        onToggle: {
+          withAnimation(ADEMotion.quick(reduceMotion: reduceMotion)) {
+            toggleCollapsed(childGroup.collapsedSectionId)
+          }
+        }
+      ) {
+        ForEach(childGroup.children) { child in
+          sessionListRow(
+            child,
+            compact: true,
+            // A child shell sits under its parent row, which already carries the
+            // lane identity — but this matches the previous default and is
+            // stated explicitly so the factory has no implicit callers.
+            showsLaneIdentity: true,
+            transitionNamespace: nil
+          )
+          .id(child.id)
+        }
+      }
+      // The nested shells sit at a fixed 30pt from the list margin whether or not
+      // a lane rail is present: the rail already consumes 9pt of that indent, so
+      // adding the old flat 30 on top of it would push nested shells a second
+      // step right and break the parent/child read.
+      .padding(.leading, Self.workChildShellIndent - 16 - (railColor == nil ? 0 : Self.workLaneRailGutter))
+      .padding(.bottom, 6)
+      .workLaneAccentRail(railColor, gutter: Self.workLaneRailGutter)
+      .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+      .listRowBackground(Color.clear)
+      .listRowSeparator(.hidden)
+    }
+  }
+
+  /// One argument list, two callers (the top-level session row and the child
+  /// shell loop). `WorkSessionListRow` takes ~35 arguments, nearly all of them
+  /// threaded straight off `self`; when they were spelled out at both call
+  /// sites every new callback had to be added twice, and one of the two was
+  /// eventually going to be missed. Only the three arguments that genuinely
+  /// differ between the callers are parameters here.
+  ///
+  /// List-cell concerns (`.id`, `.listRowInsets`, `.listRowBackground`,
+  /// `.listRowSeparator`, the lane accent rail, vertical padding) stay at the
+  /// call sites — those really do differ between the two.
+  private func sessionListRow(
+    _ session: TerminalSessionSummary,
+    compact: Bool,
+    showsLaneIdentity: Bool,
+    transitionNamespace: Namespace.ID?
+  ) -> WorkSessionListRow {
     WorkSessionListRow(
       session: session,
       lane: laneById[session.laneId],
@@ -1028,9 +1179,7 @@ struct WorkRootScreen: View {
         ?? lanePrTagsByLaneId[resolvedWorkNavigationLaneId(for: session, lanes: lanes)],
       chatSummary: chatSummaries[session.id],
       isArchived: archivedSessionIds.contains(session.id),
-      transitionNamespace: ADEMotion.allowsMatchedGeometry(reduceMotion: reduceMotion)
-        ? sessionTransitionNamespace
-        : nil,
+      transitionNamespace: transitionNamespace,
       compact: compact,
       showsLaneIdentity: showsLaneIdentity,
       isLaneDeleting: syncService.pendingLaneDeletionIds.contains(session.laneId),
@@ -1051,66 +1200,16 @@ struct WorkRootScreen: View {
       lifecycleAvailable: syncService.supportsSessionLifecycleActions,
       snoozeAvailable: syncService.supportsSessionSnoozeActions,
       onSettle: settleSession,
+      onDismissAndSettle: dismissAndSettleSession,
       onUnsettle: unsettleSession,
       onKeepActive: keepSessionActive,
       onSnooze: snoozeSession,
-      onWake: wakeSession
+      onWake: wakeSession,
+      deleteSessionAvailable: syncService.supportsWorkSessionDeletion,
+      onDeleteSession: deleteWorkSession,
+      onOpenInWeb: openSessionInWeb,
+      laneMenu: workLaneMenuActions
     )
-    .id(session.id)
-    .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
-    .listRowBackground(Color.clear)
-    .listRowSeparator(.hidden)
-
-    if let childGroup = sessionPresentation.childGroupsByParentId[session.id] {
-      WorkChildShellSection(
-        group: childGroup,
-        collapsed: collapsedSectionIds.contains(childGroup.collapsedSectionId),
-        onToggle: {
-          withAnimation(ADEMotion.quick(reduceMotion: reduceMotion)) {
-            toggleCollapsed(childGroup.collapsedSectionId)
-          }
-        }
-      ) {
-        ForEach(childGroup.children) { child in
-          WorkSessionListRow(
-            session: child,
-            lane: laneById[child.laneId],
-            pullRequest: lanePrTagsByLaneId[child.laneId]
-              ?? lanePrTagsByLaneId[resolvedWorkNavigationLaneId(for: child, lanes: lanes)],
-            chatSummary: chatSummaries[child.id],
-            isArchived: archivedSessionIds.contains(child.id),
-            transitionNamespace: nil,
-            compact: true,
-            isLaneDeleting: syncService.pendingLaneDeletionIds.contains(child.laneId),
-            selectedSessionId: $selectedSessionTransitionId,
-            isSelecting: isSelecting,
-            isChecked: selectedSessionIds.contains(child.id),
-            onLongPressSelect: startSelection,
-            onToggleSelect: toggleSelection,
-            onOpen: openSession,
-            onPin: togglePin,
-            onRename: beginRename,
-            onStopRuntime: { session in stopRuntimeTarget = session },
-            onDelete: deleteChatSession,
-            onCopyId: copySessionId,
-            onCopyDeepLink: copySessionDeepLink,
-            onGoToLane: goToLane,
-            onOpenPullRequest: openPullRequest,
-            lifecycleAvailable: syncService.supportsSessionLifecycleActions,
-            snoozeAvailable: syncService.supportsSessionSnoozeActions,
-            onSettle: settleSession,
-            onUnsettle: unsettleSession,
-            onKeepActive: keepSessionActive,
-            onSnooze: snoozeSession,
-            onWake: wakeSession
-          )
-          .id(child.id)
-        }
-      }
-      .listRowInsets(EdgeInsets(top: 0, leading: 30, bottom: 6, trailing: 16))
-      .listRowBackground(Color.clear)
-      .listRowSeparator(.hidden)
-    }
   }
 
   var renamePresentedBinding: Binding<Bool> {
@@ -1141,5 +1240,36 @@ struct WorkRootScreen: View {
     searchText = ""
     selectedLaneId = "all"
     selectedStatus = .all
+  }
+}
+
+private extension View {
+  /// Indents a session cell into a lane section and draws the lane's accent as a
+  /// 1pt rail in the gutter that indent opens up. Desktop's equivalent is `pl-2`
+  /// on the row container plus a rail at `left-1` (`SessionListPane.tsx`).
+  ///
+  /// Deliberately padding + overlay rather than wrapping the row in an `HStack`
+  /// with the rail as a sibling: the geometry is identical, but the session row
+  /// stays the root view of its list cell. `WorkSessionListRow` attaches
+  /// `.swipeActions` and `.contextMenu` to its own body, and burying that body
+  /// inside a container view inside the cell puts those row-level modifiers at
+  /// the mercy of how far SwiftUI propagates them. Keep the row at the root.
+  ///
+  /// A nil color means no rail and no indent — status and time sections span
+  /// several lanes, so there is no single lane color that would be true there.
+  @ViewBuilder
+  func workLaneAccentRail(_ color: Color?, gutter: CGFloat) -> some View {
+    if let color {
+      padding(.leading, gutter)
+        .overlay(alignment: .leading) {
+          // Spans the full cell height, vertical row padding included, so
+          // consecutive rows in a lane read as one unbroken line.
+          Capsule()
+            .fill(color)
+            .frame(width: 1)
+        }
+    } else {
+      self
+    }
   }
 }

--- a/apps/ios/ADE/Views/Work/WorkSessionCanonicalState.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionCanonicalState.swift
@@ -28,15 +28,17 @@ enum CanonicalSessionPhase: Equatable {
 
 /// The states that earn a capsule on a Work row.
 ///
-/// The first three are the attention states — the only ones `badge` has ever
-/// carried, and the only ones that survive on the `CanonicalSessionState` value
-/// so nothing downstream starts treating "Working" as something to act on. The
-/// rest are the descriptive half of the vocabulary, reached through
-/// `workSessionStatusBadge`, which is what the row actually renders.
+/// The first three are the attention states — the ones something downstream may
+/// reasonably treat as "act on this". The rest are the descriptive half of the
+/// vocabulary. All six are reached through `workSessionStatusBadge`, which is
+/// what the row actually renders; the canonical state itself carries only a
+/// phase, so nothing can render a badge without going through that table.
 ///
-/// The truly resting phases (ready / idle / stopped / ended) still earn no
-/// capsule: their story is the neutral dot and the timestamp, and a row must not
-/// shift layout to say "nothing is happening".
+/// Only `stopped` and `ended` earn no capsule: their story is the neutral dot
+/// and the timestamp, and a row must not shift layout to say "nothing is
+/// happening". `ready`/`idle` DO earn one — emerald "Done" — because a session
+/// resting after a turn is a finished outcome the reader has not looked at yet,
+/// which is a different thing from a process that simply stopped existing.
 enum SessionBadgeKind: Equatable {
   case needsYou
   case failed
@@ -63,10 +65,12 @@ struct SessionBadge: Equatable {
   }
 }
 
+/// Deliberately a phase and nothing else. Presentation — the capsule, the dot
+/// hue, the status slot — is derived from the phase by the row layer, so there
+/// is exactly one table turning a phase into words and colours and no second
+/// copy riding along on the state value where it could drift.
 struct CanonicalSessionState: Equatable {
   let phase: CanonicalSessionPhase
-  /// Non-nil ONLY for attention states — capsules never render for calm ones.
-  let badge: SessionBadge?
 }
 
 /// A session still marked running that has produced no output for this long is
@@ -76,24 +80,6 @@ struct CanonicalSessionState: Equatable {
 /// `SESSION_STALE_AFTER_MS` (3 hours); do not reuse other stale semantics
 /// (e.g. the 7-day chat reclassification in `normalizedWorkChatSessionStatus`).
 let sessionStaleAfterSeconds: TimeInterval = 3 * 60 * 60
-
-/// The attention badges, worded and hued by the shared vocabulary rather than
-/// by a second table that could drift away from it.
-private let badgeByKind: [SessionBadgeKind: SessionBadge] = [
-  .needsYou: workSessionBadge(kind: .needsYou, phase: .needsYou),
-  .failed: workSessionBadge(kind: .failed, phase: .failed),
-  .stale: workSessionBadge(kind: .stale, phase: .stale),
-]
-
-private func workSessionBadge(kind: SessionBadgeKind, phase: AccountAttentionPhase) -> SessionBadge {
-  let presentation = ActivityPhaseVocabulary.presentation(for: phase)
-  return SessionBadge(
-    kind: kind,
-    label: presentation.label,
-    tone: presentation.tone,
-    glyph: presentation.glyph
-  )
-}
 
 private func isSilentPast(_ lastActivityAt: String?, now: Date, thresholdSeconds: TimeInterval) -> Bool {
   guard let at = workParsedDate(lastActivityAt) else { return false }
@@ -174,7 +160,7 @@ func workCanonicalSessionState(
   // stale checks below (an agent explicitly asking is actionable regardless).
   // An escalated ask outranks BOTH override values.
   if !pending.isEmpty || providerStructuredInput || !attentionRequested.isEmpty {
-    return CanonicalSessionState(phase: .needsYou, badge: badgeByKind[.needsYou])
+    return CanonicalSessionState(phase: .needsYou)
   }
 
   // 2. Declared settle (or a "settled" override) — honored only AT REST,
@@ -186,7 +172,7 @@ func workCanonicalSessionState(
   let pinnedActive = override == .active
   let atRest = statusLower != "running" || runtimeLower == "idle"
   if !pinnedActive && atRest && (override == .settled || !settled.isEmpty) {
-    return CanonicalSessionState(phase: .settled, badge: nil)
+    return CanonicalSessionState(phase: .settled)
   }
 
   let ended = statusLower != "running"
@@ -195,87 +181,64 @@ func workCanonicalSessionState(
     // failure. Check before exit/runtime failures because disposed sessions are
     // currently persisted with runtimeState "killed" and often exitCode 130.
     if statusLower == "disposed" {
-      return CanonicalSessionState(phase: .stopped, badge: nil)
+      return CanonicalSessionState(phase: .stopped)
     }
 
     // Failure: a non-clean exit, an explicit "failed" persisted status
     // (spawn/setup failures that die before an exit code), or a killed runtime
     // — all deterministic "failed" signals a terminal-backed session reports.
     if let exitCode, exitCode != 0 {
-      return CanonicalSessionState(phase: .failed, badge: badgeByKind[.failed])
+      return CanonicalSessionState(phase: .failed)
     }
     if statusLower == "failed" {
-      return CanonicalSessionState(phase: .failed, badge: badgeByKind[.failed])
+      return CanonicalSessionState(phase: .failed)
     }
     if runtimeLower == "killed" {
-      return CanonicalSessionState(phase: .failed, badge: badgeByKind[.failed])
+      return CanonicalSessionState(phase: .failed)
     }
     // Chats rest between turns unless their last turn failed or their backing
     // runtime detached, which is genuinely ended.
     if chat {
       if !lastTurnFailed.isEmpty {
-        return CanonicalSessionState(phase: .failed, badge: badgeByKind[.failed])
+        return CanonicalSessionState(phase: .failed)
       }
       if statusLower == "detached" {
-        return CanonicalSessionState(phase: .ended, badge: nil)
+        return CanonicalSessionState(phase: .ended)
       }
-      return CanonicalSessionState(phase: .ready, badge: nil)
+      return CanonicalSessionState(phase: .ready)
     }
 
     // Process completion is not a lifecycle declaration.
-    return CanonicalSessionState(phase: .ended, badge: nil)
+    return CanonicalSessionState(phase: .ended)
   }
 
   // Running chats keep status "running" when a turn dies, so carry the
   // persisted failure marker ahead of calm running/ready states.
   if chat && !lastTurnFailed.isEmpty {
-    return CanonicalSessionState(phase: .failed, badge: badgeByKind[.failed])
+    return CanonicalSessionState(phase: .failed)
   }
 
   // 5. Stale: running but silent past the threshold.
   if isSilentPast(lastActivityAt, now: now, thresholdSeconds: sessionStaleAfterSeconds) {
-    return CanonicalSessionState(phase: .stale, badge: badgeByKind[.stale])
+    return CanonicalSessionState(phase: .stale)
   }
 
   // Idle chats between turns are ready (calm); idle agent CLIs stay calm here —
   // there is no deterministic ask.
   if runtimeLower == "idle" {
     return chat
-      ? CanonicalSessionState(phase: .ready, badge: nil)
-      : CanonicalSessionState(phase: .idle, badge: nil)
+      ? CanonicalSessionState(phase: .ready)
+      : CanonicalSessionState(phase: .idle)
   }
 
-  return CanonicalSessionState(phase: .running, badge: nil)
-}
-
-// MARK: - Row capsule wiring
-
-/// The one-word attention capsule for a Work session row, backed by the shared
-/// canonical state so the capsule, the Live Activity phase, and notifications
-/// always agree. Returns nil for every calm state — rows must not shift layout
-/// when no capsule renders.
-///
-/// This maps iOS's awaiting derivation (chat summary `awaitingInput`, plus
-/// `awaiting_input` session statuses) onto the canonical "waiting-input" runtime
-/// so a chat blocked on a question/plan/approval reads as needs_you exactly like
-/// `SyncService.isAwaiting`, without touching that derivation.
-func workSessionCapsuleBadge(
-  session: TerminalSessionSummary,
-  summary: AgentChatSessionSummary?,
-  now: Date = Date()
-) -> SessionBadge? {
-  return workCanonicalSessionState(
-    session: session,
-    summary: summary,
-    now: now
-  ).badge
+  return CanonicalSessionState(phase: .running)
 }
 
 // MARK: - The full status vocabulary
 
 /// Canonical phase → the shared Activity phase, so a Work row reads its label
 /// and its hue out of the same table the drawer, the hub strip, and the widget
-/// use. The four resting phases have no Activity phase of their own and are
+/// use. `stopped` and `ended` have no Activity phase of their own and are
 /// carried as additive raw values, which `ActivityPhaseVocabulary` answers with
 /// the quiet neutral presentation they want.
 func workActivityPhase(for phase: CanonicalSessionPhase) -> AccountAttentionPhase {
@@ -286,10 +249,23 @@ func workActivityPhase(for phase: CanonicalSessionPhase) -> AccountAttentionPhas
   case .failed: return .failed
   case .stale: return .stale
   // Settled is a declared "this is finished and filed", which is exactly what
-  // the emerald `completed` presentation says.
+  // the emerald `completed` presentation says. Note that the STATUS SLOT shows
+  // nothing at all for settled — see `workSessionStatusPresentation` — but the
+  // phase still needs a hue for the dot and for out-of-context capsules.
   case .settled: return .completed
-  case .ready: return .unrecognized("ready")
-  case .idle: return .unrecognized("idle")
+  // Ready and idle are emerald "Done", not the neutral "Ready"/"Idle" this file
+  // used to ask for. Desktop's `PHASE_PRESENTATION` maps both to
+  // `{label: "Done", tone: "emerald", prominent: true}` and explains why: they
+  // previously shared amber with `needs_you`, which made "finished, go look" and
+  // "blocked, go act" indistinguishable at a glance — the single worst confusion
+  // in the old row. Emerald says the work landed; amber stays reserved for the
+  // one thing that wants a human. A resting session IS an outcome you have not
+  // looked at yet, so it is prominent, not receded.
+  //
+  // The fix lives here rather than in `ActivityPhaseVocabulary`, which is shared
+  // with the widget extension and answers raw wire phases; its neutral
+  // "Ready"/"Idle" entries stay correct for a publisher that sends those words.
+  case .ready, .idle: return .completed
   case .stopped: return .unrecognized("stopped")
   case .ended: return .unrecognized("ended")
   }
@@ -303,42 +279,226 @@ func workSessionIsPlanning(summary: AgentChatSessionSummary?) -> Bool {
   summary?.interactionMode?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "plan"
 }
 
+/// Which capsule identity a phase wears, once planning has already been folded
+/// in by the caller. `stopped`/`ended` have none: their story is the neutral dot
+/// and the timestamp, and a row must not shift layout to say "nothing is
+/// happening".
+private func workSessionBadgeKind(for phase: CanonicalSessionPhase) -> SessionBadgeKind? {
+  switch phase {
+  case .needsYou: return .needsYou
+  case .failed: return .failed
+  case .stale: return .stale
+  case .starting, .running: return .working
+  case .ready, .idle, .settled: return .done
+  case .stopped, .ended: return nil
+  }
+}
+
+/// The phase half of the status vocabulary: planning folded in, everything else
+/// read out of the shared `ActivityPhaseVocabulary`. Deliberately overlay-blind
+/// — snooze and woke are resolved one level up, in `workSessionStatusSlot`, so
+/// the capsule and the status slot can differ on whether an overlay is allowed
+/// to speak.
+private func workSessionPhasePresentation(
+  phase: CanonicalSessionPhase,
+  isPlanning: Bool
+) -> (kind: SessionBadgeKind?, presentation: ActivityPhasePresentation) {
+  if phase == .running && isPlanning {
+    return (.planning, ActivityPhaseVocabulary.presentation(for: .unrecognized("planning")))
+  }
+  return (
+    workSessionBadgeKind(for: phase),
+    ActivityPhaseVocabulary.presentation(for: workActivityPhase(for: phase))
+  )
+}
+
+/// Everything the row's ONE status slot needs, including the two fields
+/// `SessionBadge` drops: `showsElapsed` (does the label carry a ticking
+/// duration) and `prominent` (does this state pull the eye). Prominence drives
+/// the recede rule — non-prominent rows render at 70% opacity so the few rows
+/// that want a human stand out without a banner.
+///
+/// `kind` is nil where the state has no `SessionBadgeKind` counterpart: the
+/// snoozed and woke overlays are not badge identities, they are what the slot
+/// says instead of the phase.
+struct WorkSessionStatusPresentation: Equatable {
+  let label: String
+  let tone: ActivityTone
+  let glyph: ActivityGlyph?
+  let showsElapsed: Bool
+  let prominent: Bool
+  let kind: SessionBadgeKind?
+}
+
+/// Everything one Work row renders about its state, derived ONCE.
+///
+/// A row needs four answers — the phase, the capsule, the dot hue, the status
+/// slot — and all four fall out of a single `workCanonicalSessionState`. Deriving
+/// them separately meant four passes AND four `Date()` calls per row per rebuild,
+/// so a row rebuilt across a stale or snooze boundary could paint a capsule from
+/// one instant and a status slot from another. One value, one clock.
+struct WorkSessionRowPresentation: Equatable {
+  let phase: CanonicalSessionPhase
+  /// The whole badge, not just its kind: the compact row renders the label and
+  /// tone directly and must not re-derive them from a second table.
+  let badge: SessionBadge?
+  let tone: ActivityTone
+  let status: WorkSessionStatusPresentation?
+}
+
+/// The one derivation behind every Work row. `workSessionStatusBadge`,
+/// `workSessionRowTone`, and `workSessionStatusPresentation` are thin reads of
+/// this; prefer calling it directly when a caller wants more than one of them.
+func workSessionRowPresentation(
+  session: TerminalSessionSummary,
+  summary: AgentChatSessionSummary?,
+  now: Date = Date()
+) -> WorkSessionRowPresentation {
+  let phase = workCanonicalSessionState(session: session, summary: summary, now: now).phase
+  let resolved = workSessionPhasePresentation(
+    phase: phase,
+    isPlanning: workSessionIsPlanning(summary: summary)
+  )
+
+  let badge = resolved.kind.map { kind in
+    SessionBadge(
+      kind: kind,
+      label: resolved.presentation.label,
+      tone: resolved.presentation.tone,
+      glyph: resolved.presentation.glyph
+    )
+  }
+
+  return WorkSessionRowPresentation(
+    phase: phase,
+    badge: badge,
+    tone: resolved.presentation.tone,
+    status: workSessionStatusSlot(session: session, phase: phase, resolved: resolved, now: now)
+  )
+}
+
+/// The status slot for one Work row, mirroring the desktop
+/// `sessionStatusPresentation()` precedence exactly:
+///
+///   1. `needsYou` outright, ABOVE both overlays — same precedence as the filing
+///      rule in `isSessionFiledAsSnoozed`, so where a row is filed and what it
+///      says can never disagree. Without this an "until I'm asked" snooze
+///      (~100 years) buries the very row whose hand is raised.
+///   2. snoozed — the return ticket IS the status, so the wake label takes the
+///      slot; neutral and not prominent, because a row you deferred is not
+///      asking for anything.
+///   3. woke — it came back early, which is worth the eye: amber and prominent.
+///   4. planning — a presentation fact derived from the chat's interaction mode,
+///      never a canonical phase. Already folded into `resolved` by the caller.
+///   5. the phase table.
+///
+/// Returns nil for `settled`, matching desktop's `null`: a settled row lives in
+/// the collapsed tail where the section itself is the status, and the free slot
+/// belongs to the timestamp — the only thing worth reading down there. This is
+/// deliberate, not a missing case; the row's `badge` still answers "Done" for
+/// callers that need a capsule out of that context.
+private func workSessionStatusSlot(
+  session: TerminalSessionSummary,
+  phase: CanonicalSessionPhase,
+  resolved: (kind: SessionBadgeKind?, presentation: ActivityPhasePresentation),
+  now: Date
+) -> WorkSessionStatusPresentation? {
+  // needsYou skips the overlay gate entirely and falls straight through to the
+  // phase table below, which already says "Needs you" in amber.
+  if phase != .needsYou {
+    if session.isSnoozed(now: now) {
+      return WorkSessionStatusPresentation(
+        // Falling back to the bare word keeps the slot meaningful when the
+        // deadline is missing or unparseable.
+        label: workSnoozeWakeLabel(session.snoozedUntil, now: now) ?? "Snoozed",
+        tone: .neutral,
+        // `ActivityGlyph` carries no snoozed/woke marks — the shared table is
+        // the phase vocabulary and these are overlays. The word is unambiguous.
+        glyph: nil,
+        showsElapsed: false,
+        prominent: false,
+        kind: nil
+      )
+    }
+
+    if session.wokeMarker(now: now) != nil {
+      return WorkSessionStatusPresentation(
+        label: "Woke",
+        tone: .amber,
+        glyph: nil,
+        showsElapsed: false,
+        prominent: true,
+        kind: nil
+      )
+    }
+
+    if phase == .settled { return nil }
+  }
+
+  return WorkSessionStatusPresentation(
+    label: resolved.presentation.label,
+    tone: resolved.presentation.tone,
+    glyph: resolved.presentation.glyph,
+    showsElapsed: resolved.presentation.showsElapsed,
+    prominent: resolved.presentation.prominent,
+    kind: resolved.kind
+  )
+}
+
 /// The capsule a Work row renders: the full vocabulary, not just the attention
-/// third. Nil for the resting phases, which say what they need to say with the
+/// third. Nil for `stopped`/`ended`, which say what they need to say with the
 /// neutral dot alone.
+///
+/// Overlay-blind on purpose. This is the out-of-context capsule — a settled row
+/// still reads "Done" here even though its status SLOT is empty, and a snoozed
+/// row still reports the state it is actually in. Anything rendering the row's
+/// one status slot wants `workSessionStatusPresentation` instead.
 func workSessionStatusBadge(
   session: TerminalSessionSummary,
   summary: AgentChatSessionSummary?,
   now: Date = Date()
 ) -> SessionBadge? {
-  let canonical = workCanonicalSessionState(session: session, summary: summary, now: now)
-  if canonical.phase == .running && workSessionIsPlanning(summary: summary) {
-    return workSessionBadge(kind: .planning, phase: .unrecognized("planning"))
-  }
-  switch canonical.phase {
-  case .needsYou, .failed, .stale:
-    return canonical.badge
-  case .starting, .running:
-    return workSessionBadge(kind: .working, phase: workActivityPhase(for: canonical.phase))
-  case .settled:
-    return workSessionBadge(kind: .done, phase: .completed)
-  case .ready, .idle, .stopped, .ended:
-    return nil
-  }
+  workSessionRowPresentation(session: session, summary: summary, now: now).badge
 }
 
-/// The hue of the row's status dot. Same table as the capsule, so a row whose
-/// capsule says "Working" can never wear a green dot.
+/// See `workSessionStatusSlot` for the precedence this answers.
+func workSessionStatusPresentation(
+  session: TerminalSessionSummary,
+  summary: AgentChatSessionSummary?,
+  now: Date = Date()
+) -> WorkSessionStatusPresentation? {
+  workSessionRowPresentation(session: session, summary: summary, now: now).status
+}
+
+/// The italic line-3 preview, with the provenance the renderer needs.
+///
+/// Only `ask` and `note` linkify: those two are prose an agent wrote AT the
+/// reader, where a `#123` or `ABC-123` is a real reference worth tapping. Raw
+/// terminal output, a rolled-up summary, and a goal are all machine-shaped text
+/// where the same token is far more often a coincidence than a link. Mirrors
+/// the desktop `SessionCard.tsx:174-179` split.
+struct WorkSessionPreviewLine: Equatable {
+  enum Source: String, Equatable {
+    case ask
+    case note
+    case output
+    case summary
+    case goal
+  }
+
+  let text: String
+  let linkify: Bool
+  let source: Source
+}
+
+/// The hue of the row's status dot. Same derivation as the capsule, so a row
+/// whose capsule says "Working" can never wear a green dot.
 func workSessionRowTone(
   session: TerminalSessionSummary,
   summary: AgentChatSessionSummary?,
   now: Date = Date()
 ) -> ActivityTone {
-  let canonical = workCanonicalSessionState(session: session, summary: summary, now: now)
-  if canonical.phase == .running && workSessionIsPlanning(summary: summary) {
-    return ActivityPhaseVocabulary.presentation(for: .unrecognized("planning")).tone
-  }
-  return ActivityPhaseVocabulary.presentation(for: workActivityPhase(for: canonical.phase)).tone
+  workSessionRowPresentation(session: session, summary: summary, now: now).tone
 }
 
 /// Canonical state for a concrete Work row. This is the one bridge from the
@@ -740,29 +900,6 @@ func workSnoozeWakeLabel(
     return remaining < 12 * 3600 ? "wakes in \(Int((remaining / 3600).rounded()))h" : "wakes tomorrow"
   }
   return "wakes in \(max(1, dayDelta))d"
-}
-
-/// Compact glyph + text chip for the snoozed / woke row markers. Deliberately
-/// quieter than `WorkSessionStatusCapsule`: neither is an attention state.
-struct WorkSessionLifecycleTag: View {
-  let symbol: String
-  let text: String
-  let tint: Color
-
-  var body: some View {
-    HStack(spacing: 3) {
-      Image(systemName: symbol)
-        .font(.system(size: 9, weight: .semibold))
-      Text(text)
-        .font(.caption2.weight(.medium))
-        .lineLimit(1)
-    }
-    .foregroundStyle(tint)
-    .padding(.horizontal, 6)
-    .padding(.vertical, 2)
-    .background(tint.opacity(0.12), in: Capsule())
-    .fixedSize()
-  }
 }
 
 /// Small status capsule shown next to a Work row title. The hue comes from the

--- a/apps/ios/ADE/Views/Work/WorkSessionCanonicalState.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionCanonicalState.swift
@@ -30,8 +30,8 @@ enum CanonicalSessionPhase: Equatable {
 ///
 /// The first three are the attention states — the ones something downstream may
 /// reasonably treat as "act on this". The rest are the descriptive half of the
-/// vocabulary. All six are reached through `workSessionStatusBadge`, which is
-/// what the row actually renders; the canonical state itself carries only a
+/// vocabulary. All six are reached through `workSessionRowPresentation`, which
+/// is what the row actually renders; the canonical state itself carries only a
 /// phase, so nothing can render a badge without going through that table.
 ///
 /// Only `stopped` and `ended` earn no capsule: their story is the neutral dot
@@ -250,8 +250,8 @@ func workActivityPhase(for phase: CanonicalSessionPhase) -> AccountAttentionPhas
   case .stale: return .stale
   // Settled is a declared "this is finished and filed", which is exactly what
   // the emerald `completed` presentation says. Note that the STATUS SLOT shows
-  // nothing at all for settled — see `workSessionStatusPresentation` — but the
-  // phase still needs a hue for the dot and for out-of-context capsules.
+  // nothing at all for settled — see `workSessionStatusSlot` — but the phase
+  // still needs a hue for the dot and for out-of-context capsules.
   case .settled: return .completed
   // Ready and idle are emerald "Done", not the neutral "Ready"/"Idle" this file
   // used to ask for. Desktop's `PHASE_PRESENTATION` maps both to
@@ -341,14 +341,24 @@ struct WorkSessionRowPresentation: Equatable {
   let phase: CanonicalSessionPhase
   /// The whole badge, not just its kind: the compact row renders the label and
   /// tone directly and must not re-derive them from a second table.
+  ///
+  /// Overlay-blind on purpose. This is the out-of-context capsule — a settled
+  /// row still reads "Done" here even though its `status` slot is nil, and a
+  /// snoozed row still reports the state it is actually in. Nil for
+  /// `stopped`/`ended`, which say what they need to say with the neutral dot
+  /// alone.
   let badge: SessionBadge?
+  /// The hue of the row's status dot. Same derivation as the capsule, so a row
+  /// whose capsule says "Working" can never wear a green dot.
   let tone: ActivityTone
+  /// The row's ONE status slot. See `workSessionStatusSlot` for the overlay
+  /// precedence this answers, and why settled resolves to nil.
   let status: WorkSessionStatusPresentation?
 }
 
-/// The one derivation behind every Work row. `workSessionStatusBadge`,
-/// `workSessionRowTone`, and `workSessionStatusPresentation` are thin reads of
-/// this; prefer calling it directly when a caller wants more than one of them.
+/// The one derivation behind every Work row — the phase, the capsule, the dot
+/// hue, and the status slot all come out of this single call, so nothing can
+/// read one of them from a second table or a second clock.
 func workSessionRowPresentation(
   session: TerminalSessionSummary,
   summary: AgentChatSessionSummary?,
@@ -445,31 +455,6 @@ private func workSessionStatusSlot(
   )
 }
 
-/// The capsule a Work row renders: the full vocabulary, not just the attention
-/// third. Nil for `stopped`/`ended`, which say what they need to say with the
-/// neutral dot alone.
-///
-/// Overlay-blind on purpose. This is the out-of-context capsule — a settled row
-/// still reads "Done" here even though its status SLOT is empty, and a snoozed
-/// row still reports the state it is actually in. Anything rendering the row's
-/// one status slot wants `workSessionStatusPresentation` instead.
-func workSessionStatusBadge(
-  session: TerminalSessionSummary,
-  summary: AgentChatSessionSummary?,
-  now: Date = Date()
-) -> SessionBadge? {
-  workSessionRowPresentation(session: session, summary: summary, now: now).badge
-}
-
-/// See `workSessionStatusSlot` for the precedence this answers.
-func workSessionStatusPresentation(
-  session: TerminalSessionSummary,
-  summary: AgentChatSessionSummary?,
-  now: Date = Date()
-) -> WorkSessionStatusPresentation? {
-  workSessionRowPresentation(session: session, summary: summary, now: now).status
-}
-
 /// The italic line-3 preview, with the provenance the renderer needs.
 ///
 /// Only `ask` and `note` linkify: those two are prose an agent wrote AT the
@@ -489,16 +474,6 @@ struct WorkSessionPreviewLine: Equatable {
   let text: String
   let linkify: Bool
   let source: Source
-}
-
-/// The hue of the row's status dot. Same derivation as the capsule, so a row
-/// whose capsule says "Working" can never wear a green dot.
-func workSessionRowTone(
-  session: TerminalSessionSummary,
-  summary: AgentChatSessionSummary?,
-  now: Date = Date()
-) -> ActivityTone {
-  workSessionRowPresentation(session: session, summary: summary, now: now).tone
 }
 
 /// Canonical state for a concrete Work row. This is the one bridge from the

--- a/apps/ios/ADE/Views/Work/WorkSessionGrouping.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionGrouping.swift
@@ -91,15 +91,25 @@ struct WorkSessionGroup: Identifiable, Equatable {
   let laneColor: String?
   let laneIcon: LaneIcon?
   let isOrphaned: Bool
-  /// Every session in this lane is settled (snoozed rows are already lifted into
-  /// the `status:snoozed` tail, so they can't be here). The section renders as a
-  /// single thin row instead of a full header over nothing.
-  let isQuiet: Bool
+  /// Nothing here wants attention, so the section renders as a single thin row
+  /// instead of a full header over nothing, and it defaults to collapsed. True
+  /// for a lane whose every session is settled (snoozed rows are already lifted
+  /// into the `status:snoozed` shelf, so they can't be here), and for the
+  /// quiet-zone shelves themselves.
+  /// Mutable so the by-lane pass can stamp it after construction — the quiet
+  /// rule needs the assembled group, and value semantics make an in-place
+  /// mutation identical to rebuilding the whole struct.
+  var isQuiet: Bool
   /// The singleton form: one top-level row, so the group renders with no header
   /// at all and the lone row carries the lane identity instead. Orthogonal to
   /// `isQuiet` — a quiet lane still has a header to fold, and the two rules are
   /// derived independently (see `workHeaderlessLaneIds`).
   let isHeaderless: Bool
+  /// A trailing quiet-zone shelf (Snoozed / Settled) rather than a lane section.
+  /// Shelves are always quiet, so they reuse the quiet header form and the
+  /// inverted collapse marker, but their marker is keyed by section id instead
+  /// of lane id — see `quietOpenSectionId`.
+  let isShelf: Bool
 
   enum Icon: Equatable {
     case statusDot
@@ -118,7 +128,8 @@ struct WorkSessionGroup: Identifiable, Equatable {
     laneIcon: LaneIcon? = nil,
     isOrphaned: Bool = false,
     isQuiet: Bool = false,
-    isHeaderless: Bool = false
+    isHeaderless: Bool = false,
+    isShelf: Bool = false
   ) {
     self.id = id
     self.label = label
@@ -130,12 +141,26 @@ struct WorkSessionGroup: Identifiable, Equatable {
     self.isOrphaned = isOrphaned
     self.isQuiet = isQuiet
     self.isHeaderless = isHeaderless
+    self.isShelf = isShelf
   }
 
-  /// Inverted collapse marker: a quiet lane starts collapsed, and only an
-  /// explicit expand is recorded, so it re-quiets on its own instead of leaving
-  /// a stale "expanded" entry behind. Mirrors the desktop sidebar.
-  var quietOpenSectionId: String { "lane-open:\(laneId ?? id)" }
+  /// Inverted collapse marker: a quiet lane, and every quiet-zone shelf, starts
+  /// collapsed, and only an explicit expand is recorded. `collapsedSectionIds`
+  /// lists the sections that ARE collapsed, so absence means expanded — a shape
+  /// that cannot express "closed until you say otherwise". Recording the
+  /// opposite fact keeps three states apart where the plain list had two: never
+  /// touched (no marker, collapsed), explicitly opened (marker present, and it
+  /// survives a relaunch), explicitly closed again (marker removed). It also
+  /// means a section re-quiets on its own instead of leaving a stale "expanded"
+  /// entry behind. Mirrors the desktop sidebar's `lane-open:`/`shelf-open:`
+  /// markers (`SessionListPane.tsx` `quietShelfOpenMarker`).
+  ///
+  /// Shelves use `shelf-open:` deliberately: they are global, not per-lane, so
+  /// they must stay outside the `lane-open:` namespace that
+  /// `pruneStaleQuietOpenMarkers` sweeps.
+  var quietOpenSectionId: String {
+    isShelf ? "shelf-open:\(id)" : "lane-open:\(laneId ?? id)"
+  }
 
   /// Lane id for by-lane sections (id is `lane:<laneId>`); nil for status/time
   /// groupings whose headers span multiple lanes and carry no single PR tag.
@@ -153,6 +178,7 @@ struct WorkSessionGroup: Identifiable, Equatable {
       && lhs.isOrphaned == rhs.isOrphaned
       && lhs.isQuiet == rhs.isQuiet
       && lhs.isHeaderless == rhs.isHeaderless
+      && lhs.isShelf == rhs.isShelf
       && lhs.sessions.map(\.id) == rhs.sessions.map(\.id)
   }
 }
@@ -173,15 +199,10 @@ struct WorkRootSessionPresentation: Equatable {
   let displaySessionIds: Set<String>
   let topLevelDisplaySessionIds: Set<String>
   let childGroupsByParentId: [String: WorkSessionChildGroup]
-  let liveChatSessions: [TerminalSessionSummary]
   let sessionGroups: [WorkSessionGroup]
   let workOrderedLanes: [LaneSummary]
   let laneById: [String: LaneSummary]
   let lanePrTagsByLaneId: [String: LanePrTag]
-  let globalNeedsInputCount: Int
-  let globalLiveSessionCount: Int
-  let firstGlobalAttentionSessionId: String?
-  let firstGlobalLiveSessionId: String?
   private let renderSignature: Int
 
   init(
@@ -190,15 +211,10 @@ struct WorkRootSessionPresentation: Equatable {
     displaySessionIds: Set<String>,
     topLevelDisplaySessionIds: Set<String>,
     childGroupsByParentId: [String: WorkSessionChildGroup],
-    liveChatSessions: [TerminalSessionSummary],
     sessionGroups: [WorkSessionGroup],
     workOrderedLanes: [LaneSummary],
     laneById: [String: LaneSummary],
     lanePrTagsByLaneId: [String: LanePrTag],
-    globalNeedsInputCount: Int,
-    globalLiveSessionCount: Int,
-    firstGlobalAttentionSessionId: String?,
-    firstGlobalLiveSessionId: String?,
     renderSignature: Int
   ) {
     self.mergedSessions = mergedSessions
@@ -206,15 +222,10 @@ struct WorkRootSessionPresentation: Equatable {
     self.displaySessionIds = displaySessionIds
     self.topLevelDisplaySessionIds = topLevelDisplaySessionIds
     self.childGroupsByParentId = childGroupsByParentId
-    self.liveChatSessions = liveChatSessions
     self.sessionGroups = sessionGroups
     self.workOrderedLanes = workOrderedLanes
     self.laneById = laneById
     self.lanePrTagsByLaneId = lanePrTagsByLaneId
-    self.globalNeedsInputCount = globalNeedsInputCount
-    self.globalLiveSessionCount = globalLiveSessionCount
-    self.firstGlobalAttentionSessionId = firstGlobalAttentionSessionId
-    self.firstGlobalLiveSessionId = firstGlobalLiveSessionId
     self.renderSignature = renderSignature
   }
 
@@ -224,15 +235,10 @@ struct WorkRootSessionPresentation: Equatable {
     displaySessionIds: [],
     topLevelDisplaySessionIds: [],
     childGroupsByParentId: [:],
-    liveChatSessions: [],
     sessionGroups: [],
     workOrderedLanes: [],
     laneById: [:],
     lanePrTagsByLaneId: [:],
-    globalNeedsInputCount: 0,
-    globalLiveSessionCount: 0,
-    firstGlobalAttentionSessionId: nil,
-    firstGlobalLiveSessionId: nil,
     renderSignature: 0
   )
 
@@ -269,11 +275,6 @@ func buildWorkRootSessionPresentation(
   )
   let mergedSessions = (sessions + draftValues)
     .sorted { compareWorkSessionSortOrder($0, $1, chatSummaries: chatSummaries) }
-  let statusBySessionId = Dictionary(
-    uniqueKeysWithValues: mergedSessions.map { session in
-      (session.id, normalizedWorkChatSessionStatus(session: session, summary: chatSummaries[session.id]))
-    }
-  )
 
   let displaySessions = workFilteredSessions(
     mergedSessions,
@@ -288,39 +289,6 @@ func buildWorkRootSessionPresentation(
   let childGroupsByParentId = workSessionChildGroupsByParentId(sessions: displaySessions)
   let childSessionIds = Set(childGroupsByParentId.values.flatMap { $0.children.map(\.id) })
   let topLevelDisplaySessionIds = displaySessionIds.subtracting(childSessionIds)
-
-  var liveChatSessions: [TerminalSessionSummary] = []
-  liveChatSessions.reserveCapacity(mergedSessions.count)
-  var globalNeedsInputCount = 0
-  var globalLiveSessionCount = 0
-  var firstGlobalAttentionSessionId: String?
-  var firstGlobalLiveSessionId: String?
-
-  for session in mergedSessions {
-    let isArchived = archivedSessionIds.contains(session.id)
-    let status = statusBySessionId[session.id] ?? "ended"
-
-    if isChatSession(session), status != "ended", !isArchived {
-      liveChatSessions.append(session)
-    }
-
-    guard !isArchived else { continue }
-    if status == "awaiting-input" {
-      globalNeedsInputCount += 1
-      globalLiveSessionCount += 1
-      if firstGlobalAttentionSessionId == nil {
-        firstGlobalAttentionSessionId = session.id
-      }
-      if firstGlobalLiveSessionId == nil {
-        firstGlobalLiveSessionId = session.id
-      }
-    } else if status == "active" || status == "idle" {
-      globalLiveSessionCount += 1
-      if firstGlobalLiveSessionId == nil {
-        firstGlobalLiveSessionId = session.id
-      }
-    }
-  }
 
   // Lane ordering and the singleton rule both read the UNFILTERED roster, so
   // neither the shelf a lane sits on nor whether it has a header changes while
@@ -351,7 +319,6 @@ func buildWorkRootSessionPresentation(
     sessions: displaySessions,
     quietReferenceSessions: mergedSessions,
     chatSummaries: chatSummaries,
-    statusBySessionId: statusBySessionId,
     archivedSessionIds: archivedSessionIds,
     orderedLanes: workOrderedLanes,
     deletingLaneIds: deletingLaneIds,
@@ -365,30 +332,19 @@ func buildWorkRootSessionPresentation(
     displaySessionIds: displaySessionIds,
     topLevelDisplaySessionIds: topLevelDisplaySessionIds,
     childGroupsByParentId: childGroupsByParentId,
-    liveChatSessions: liveChatSessions,
     sessionGroups: sessionGroups,
     workOrderedLanes: workOrderedLanes,
     laneById: laneById,
     lanePrTagsByLaneId: lanePrTagsByLaneId,
-    globalNeedsInputCount: globalNeedsInputCount,
-    globalLiveSessionCount: globalLiveSessionCount,
-    firstGlobalAttentionSessionId: firstGlobalAttentionSessionId,
-    firstGlobalLiveSessionId: firstGlobalLiveSessionId,
     renderSignature: workRootSessionPresentationRenderSignature(
       mergedSessions: mergedSessions,
       displaySessions: displaySessions,
       topLevelDisplaySessionIds: topLevelDisplaySessionIds,
       childGroupsByParentId: childGroupsByParentId,
-      liveChatSessions: liveChatSessions,
       sessionGroups: sessionGroups,
       workOrderedLanes: workOrderedLanes,
       lanePrTagsByLaneId: lanePrTagsByLaneId,
-      chatSummaries: chatSummaries,
-      statusBySessionId: statusBySessionId,
-      globalNeedsInputCount: globalNeedsInputCount,
-      globalLiveSessionCount: globalLiveSessionCount,
-      firstGlobalAttentionSessionId: firstGlobalAttentionSessionId,
-      firstGlobalLiveSessionId: firstGlobalLiveSessionId
+      chatSummaries: chatSummaries
     )
   )
 }
@@ -398,16 +354,10 @@ private func workRootSessionPresentationRenderSignature(
   displaySessions: [TerminalSessionSummary],
   topLevelDisplaySessionIds: Set<String>,
   childGroupsByParentId: [String: WorkSessionChildGroup],
-  liveChatSessions: [TerminalSessionSummary],
   sessionGroups: [WorkSessionGroup],
   workOrderedLanes: [LaneSummary],
   lanePrTagsByLaneId: [String: LanePrTag],
-  chatSummaries: [String: AgentChatSessionSummary],
-  statusBySessionId: [String: String],
-  globalNeedsInputCount: Int,
-  globalLiveSessionCount: Int,
-  firstGlobalAttentionSessionId: String?,
-  firstGlobalLiveSessionId: String?
+  chatSummaries: [String: AgentChatSessionSummary]
 ) -> Int {
   var hasher = Hasher()
   hasher.combine(mergedSessions.count)
@@ -437,7 +387,6 @@ private func workRootSessionPresentationRenderSignature(
     hasher.combine(session.wokeReason)
     hasher.combine(session.endedAt)
     hasher.combine(session.pinned)
-    hasher.combine(statusBySessionId[session.id])
     if let summary = chatSummaries[session.id] {
       hasher.combine(summary.title)
       hasher.combine(summary.provider)
@@ -451,7 +400,6 @@ private func workRootSessionPresentationRenderSignature(
   }
   hasher.combine(displaySessions.map(\.id))
   hasher.combine(topLevelDisplaySessionIds.sorted())
-  hasher.combine(liveChatSessions.map(\.id))
   for group in sessionGroups {
     hasher.combine(group.id)
     hasher.combine(group.label)
@@ -482,10 +430,6 @@ private func workRootSessionPresentationRenderSignature(
     hasher.combine(tag.githubPrNumber)
     hasher.combine(lanePrStateLabel(tag.state))
   }
-  hasher.combine(globalNeedsInputCount)
-  hasher.combine(globalLiveSessionCount)
-  hasher.combine(firstGlobalAttentionSessionId)
-  hasher.combine(firstGlobalLiveSessionId)
   return hasher.finalize()
 }
 
@@ -614,6 +558,12 @@ private let workSessionISO8601FormatterNoFractional: ISO8601DateFormatter = {
 
 /// Group session list by the user's chosen organization. Empty groups are filtered out.
 ///
+/// Every list closes with the same quiet zone: a **Snoozed** shelf above a
+/// **Settled** shelf, both collapsed until explicitly opened. By-lane is the one
+/// exemption — it has no global Settled shelf, because a settled row still
+/// belongs to its lane and by-lane already folds an all-quiet lane into a single
+/// thin row. See the `liftsSettled` comment below before "fixing" that.
+///
 /// Snooze is applied here as a visibility overlay on top of whichever
 /// organization is active: snoozed rows are lifted out of every other section
 /// into a single quiet "Snoozed" tail. Their canonical phase is untouched —
@@ -631,21 +581,41 @@ func workSessionGroups(
   sessions: [TerminalSessionSummary],
   quietReferenceSessions: [TerminalSessionSummary]? = nil,
   chatSummaries: [String: AgentChatSessionSummary],
-  statusBySessionId: [String: String] = [:],
   archivedSessionIds: Set<String>,
   orderedLanes: [LaneSummary],
   deletingLaneIds: Set<String> = [],
   headerlessLaneIds: Set<String> = [],
   now: Date = Date()
 ) -> [WorkSessionGroup] {
+  // The quiet zone is a shelf pair, and only by-status and by-time build it.
+  // By-lane deliberately keeps settled rows inside their lane and folds a lane
+  // whose rows are ALL quiet into one thin row (`workLaneGroupIsQuiet`): a
+  // settled row still belongs to its lane, and lifting settled rows out
+  // globally would leave lanes empty and that fold unreachable.
+  let liftsSettled = organization != .byLane
+
   var snoozed: [TerminalSessionSummary] = []
+  var settled: [TerminalSessionSummary] = []
   var awake: [TerminalSessionSummary] = []
   for session in sessions {
     if session.isFiledAsSnoozed(summary: chatSummaries[session.id], now: now) {
       snoozed.append(session)
-    } else {
-      awake.append(session)
+      continue
     }
+    // Archived is checked first so an archived-and-settled row keeps landing in
+    // "Archived" rather than being quietly re-filed under the settled shelf.
+    if liftsSettled, !archivedSessionIds.contains(session.id) {
+      let canonical = workCanonicalSessionState(
+        session: session,
+        summary: chatSummaries[session.id],
+        now: now
+      )
+      if canonical.phase == .settled {
+        settled.append(session)
+        continue
+      }
+    }
+    awake.append(session)
   }
 
   var groups: [WorkSessionGroup]
@@ -654,8 +624,8 @@ func workSessionGroups(
     groups = workSessionGroupsByStatus(
       sessions: awake,
       chatSummaries: chatSummaries,
-      statusBySessionId: statusBySessionId,
-      archivedSessionIds: archivedSessionIds
+      archivedSessionIds: archivedSessionIds,
+      now: now
     )
   case .byLane:
     groups = workSessionGroupsByLane(
@@ -664,27 +634,44 @@ func workSessionGroups(
       deletingLaneIds: deletingLaneIds,
       headerlessLaneIds: headerlessLaneIds
     ).map { group in
-      group.markingQuiet(
-        workLaneGroupIsQuiet(
-          group,
-          referenceSessions: quietReferenceSessions,
-          chatSummaries: chatSummaries,
-          archivedSessionIds: archivedSessionIds,
-          now: now
-        )
+      var group = group
+      group.isQuiet = workLaneGroupIsQuiet(
+        group,
+        referenceSessions: quietReferenceSessions,
+        chatSummaries: chatSummaries,
+        archivedSessionIds: archivedSessionIds,
+        now: now
       )
+      return group
     }
   case .byTime:
     groups = workSessionGroupsByTime(sessions: awake)
   }
 
+  // The quiet zone closes every list: Snoozed above Settled, both collapsed
+  // until explicitly opened. Ordering matters — snoozed work is dated (it comes
+  // back), settled work is finished, so the shelf nearer the live rows is the
+  // one that will re-enter them.
   if !snoozed.isEmpty {
     groups.append(WorkSessionGroup(
       id: workSnoozedSectionId,
       label: "Snoozed",
       icon: .statusDot,
       tint: ADEColor.info,
-      sessions: snoozed
+      sessions: snoozed,
+      isQuiet: true,
+      isShelf: true
+    ))
+  }
+  if !settled.isEmpty {
+    groups.append(WorkSessionGroup(
+      id: workSettledSectionId,
+      label: "Settled",
+      icon: .statusDot,
+      tint: ADEColor.textMuted,
+      sessions: settled,
+      isQuiet: true,
+      isShelf: true
     ))
   }
   return groups
@@ -694,39 +681,11 @@ func workSessionGroups(
 /// section, independent of the active organization.
 let workSnoozedSectionId = "status:snoozed"
 
-extension WorkSessionGroup {
-  func markingQuiet(_ quiet: Bool) -> WorkSessionGroup {
-    guard quiet != isQuiet else { return self }
-    return WorkSessionGroup(
-      id: id,
-      label: label,
-      icon: icon,
-      tint: tint,
-      sessions: sessions,
-      laneColor: laneColor,
-      laneIcon: laneIcon,
-      isOrphaned: isOrphaned,
-      isQuiet: quiet,
-      isHeaderless: isHeaderless
-    )
-  }
-
-  func markingHeaderless(_ headerless: Bool) -> WorkSessionGroup {
-    guard headerless != isHeaderless else { return self }
-    return WorkSessionGroup(
-      id: id,
-      label: label,
-      icon: icon,
-      tint: tint,
-      sessions: sessions,
-      laneColor: laneColor,
-      laneIcon: laneIcon,
-      isOrphaned: isOrphaned,
-      isQuiet: isQuiet,
-      isHeaderless: headerless
-    )
-  }
-}
+/// Stable id for the settled shelf. Deliberately the same id the old by-status
+/// "Settled" section used, so a persisted collapse entry from before the shelf
+/// existed stays coherent: it said "collapsed", which is now the default anyway,
+/// making it inert rather than wrong.
+let workSettledSectionId = "status:settled"
 
 /// A lane section holding nothing but settled work.
 ///
@@ -777,14 +736,14 @@ func workLaneSessionsAreQuiet(
 func workSessionGroupsByStatus(
   sessions: [TerminalSessionSummary],
   chatSummaries: [String: AgentChatSessionSummary],
-  statusBySessionId: [String: String] = [:],
-  archivedSessionIds: Set<String>
+  archivedSessionIds: Set<String>,
+  now: Date = Date()
 ) -> [WorkSessionGroup] {
   var needsInput: [TerminalSessionSummary] = []
+  var done: [TerminalSessionSummary] = []
   var pinned: [TerminalSessionSummary] = []
   var running: [TerminalSessionSummary] = []
   var ended: [TerminalSessionSummary] = []
-  var settled: [TerminalSessionSummary] = []
   var archived: [TerminalSessionSummary] = []
 
   for session in sessions {
@@ -792,15 +751,32 @@ func workSessionGroupsByStatus(
       archived.append(session)
       continue
     }
+    // Same clock as every sibling filing path (`workSessionGroups`' shelf lift,
+    // `workLaneGroupIsQuiet`, `isFiledAsSnoozed`). Reading the wall clock here
+    // instead would let by-status and by-lane file the same row differently.
     let canonical = workCanonicalSessionState(
       session: session,
-      summary: chatSummaries[session.id]
+      summary: chatSummaries[session.id],
+      now: now
     )
+    // Switch on the CANONICAL phase, never on `workActivityPhase`: the activity
+    // vocabulary folds `.ready`/`.idle` into `.completed` for badge purposes,
+    // and filing rows by that collapsed view would lose the distinction between
+    // "finished, unseen" and "the runtime stopped".
     switch canonical.phase {
-    case .needsYou, .ready, .idle:
+    case .needsYou:
       needsInput.append(session)
-    case .settled:
-      settled.append(session)
+    case .ready, .idle, .settled:
+      // Finished cleanly and not yet acknowledged. These used to sit under
+      // "Your move", which is exactly the confusion the shared vocabulary
+      // exists to kill: amber is reserved for a session actually blocked on the
+      // user, and a run that completed is emerald "Done".
+      //
+      // `.settled` only reaches here on a direct call: `workSessionGroups`
+      // lifts settled rows onto the trailing quiet shelf first. Filing it with
+      // the other finished phases matches `workSessionBadgeKind(for:)`, which
+      // already maps all three to `.done`.
+      done.append(session)
     case .starting, .running, .stale:
       if session.pinned {
         pinned.append(session)
@@ -820,6 +796,9 @@ func workSessionGroupsByStatus(
   if !needsInput.isEmpty {
     groups.append(WorkSessionGroup(id: "status:awaiting", label: "Your move", icon: .statusDot, tint: ADEColor.warning, sessions: needsInput))
   }
+  if !done.isEmpty {
+    groups.append(WorkSessionGroup(id: "status:done", label: "Done", icon: .statusDot, tint: ADEColor.success, sessions: done))
+  }
   if !pinned.isEmpty {
     groups.append(WorkSessionGroup(id: "status:pinned", label: "Pinned", icon: .statusDot, tint: ADEColor.accent, sessions: pinned))
   }
@@ -828,9 +807,6 @@ func workSessionGroupsByStatus(
   }
   if !ended.isEmpty {
     groups.append(WorkSessionGroup(id: "status:ended", label: "Ended", icon: .statusDot, tint: ADEColor.textMuted, sessions: ended))
-  }
-  if !settled.isEmpty {
-    groups.append(WorkSessionGroup(id: "status:settled", label: "Settled", icon: .statusDot, tint: ADEColor.textMuted, sessions: settled))
   }
   if !archived.isEmpty {
     groups.append(WorkSessionGroup(id: "status:archived", label: "Archived", icon: .statusDot, tint: ADEColor.warning, sessions: archived))

--- a/apps/ios/ADE/Views/Work/WorkSessionRowCard.swift
+++ b/apps/ios/ADE/Views/Work/WorkSessionRowCard.swift
@@ -1,0 +1,1063 @@
+import SwiftUI
+import UIKit
+import AVKit
+
+// Owns the Work session row card: `WorkSessionRow` and its private layout/title/status
+// leaf views, plus the preview-line helpers (`workSessionRowPreviewSource`,
+// `workLinkifiedPreview`, `workPreviewLinkTokenRegex`) and the
+// `WorkSessionRowRenderSignature` equality shim.
+//
+// Split out of `WorkRootComponents.swift`, which keeps the surrounding list chrome:
+// filters/chips, the sidebar section header, the running banner, the
+// `WorkSessionListRow` action shell (swipe + context menus), the child-shell section,
+// provider logos, the lane PR indicator and `WorkTag`.
+
+/// The compact second line shared by every native Work session row.
+///
+/// Keep this precedence identical to the desktop card:
+/// explicit ask → agent note → sanitized last output → summary → goal.
+/// Output intentionally wins over the older AI summary so a failed/missing
+/// status-note write still leaves the user with the freshest truthful line.
+///
+/// Returns the provenance alongside the text, because whether a `#123` in the
+/// line is a real reference depends entirely on who wrote it: only `ask` and
+/// `note` are prose an agent aimed at the reader, so only those two linkify.
+/// Terminal output, a rolled-up summary and a goal are machine-shaped text where
+/// the same token is far more often a coincidence than a link. Mirrors the
+/// desktop `SessionCard.tsx:174-179` split.
+func workSessionRowPreviewSource(
+  session: TerminalSessionSummary,
+  chatSummary: AgentChatSessionSummary?,
+  isSettled: Bool
+) -> WorkSessionPreviewLine? {
+  let primaryText = chatSummary?.title ?? session.title
+
+  func inlineText(_ raw: String?, terminalOutput: Bool = false) -> String? {
+    guard let raw else { return nil }
+    let rendered = terminalOutput ? sanitizeTerminalOutputForDisplay(raw) : raw
+    guard let normalized = workSessionPreviewText(rendered) else { return nil }
+    let inline = workSummarizeInlineText(normalized, maxChars: 120)
+    return inline.isEmpty ? nil : inline
+  }
+
+  if session.attentionRequestedAt?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
+     let message = inlineText(session.attentionMessage) {
+    return WorkSessionPreviewLine(text: message, linkify: true, source: .ask)
+  }
+  if let note = inlineText(session.statusNote) {
+    return WorkSessionPreviewLine(
+      text: isSettled ? "Done: \(note)" : note,
+      linkify: true,
+      source: .note
+    )
+  }
+  for rawOutput in [chatSummary?.lastOutputPreview, session.lastOutputPreview] {
+    if let output = inlineText(rawOutput, terminalOutput: true), output != primaryText {
+      return WorkSessionPreviewLine(text: output, linkify: false, source: .output)
+    }
+  }
+  for rawSummary in [chatSummary?.summary, session.summary] {
+    if let summary = inlineText(rawSummary), summary != primaryText {
+      return WorkSessionPreviewLine(text: summary, linkify: false, source: .summary)
+    }
+  }
+  for rawGoal in [chatSummary?.goal, session.goal] {
+    if let goal = inlineText(rawGoal), goal != primaryText {
+      return WorkSessionPreviewLine(text: goal, linkify: false, source: .goal)
+    }
+  }
+  return nil
+}
+
+/// The two reference shapes ADE's own prose uses: `#123` is a pull request and
+/// `ABC-123` is a Linear issue. Same pair the desktop card matches with
+/// `PREVIEW_LINK_TOKEN` (`SessionCard.tsx:211-213`).
+///
+/// `\b` in front of the Linear shape is what keeps it from firing inside a
+/// longer word — a boundary only exists where a non-word character precedes the
+/// first capital, so `xABC-1` and `ABCDEFGH-1` are both left alone.
+private let workPreviewLinkTokenRegex = try? NSRegularExpression(
+  pattern: "#\\d+|\\b[A-Z]{2,6}-\\d+\\b"
+)
+
+/// Marks `#123` / `ABC-123` inside a preview line so they read as references
+/// rather than as ordinary words swallowed by the italic muted run.
+///
+/// **These tokens are deliberately NOT tappable, and the styling is chosen to
+/// say so.** Desktop makes them links because it has a pointer and a hover
+/// state; on iOS the whole row is a `Button` whose label this text sits inside,
+/// and a tappable range inside a `Button` label never receives the tap — SwiftUI
+/// hands the gesture to the button. The documented fix is to demote the row from
+/// a `Button` to `.contentShape(Rectangle())` plus a tap gesture, which is a
+/// change to the primary open gesture of every Work row and cannot be proven
+/// from reading alone. Rather than ship link affordances that silently do
+/// nothing, the tokens get weight and a contrast step and nothing else: no
+/// underline, no accent hue, no touch target. If the row is ever converted, the
+/// routing already exists and needs no new callback chain —
+/// `SyncService.shared?.requestedPrNavigation = PrNavigationRequest(prNumber:)`
+/// and `requestedLinearIssueNavigation = LinearIssueNavigationRequest(identifier:)`,
+/// exactly what `DeepLinkRouter` assigns (`:405-430`, `:602-612`).
+func workLinkifiedPreview(_ text: String, linkify: Bool) -> AttributedString {
+  guard linkify, let regex = workPreviewLinkTokenRegex else { return AttributedString(text) }
+  let matches = regex.matches(in: text, range: NSRange(text.startIndex..., in: text))
+  guard !matches.isEmpty else { return AttributedString(text) }
+
+  // Built by concatenation rather than by converting UTF-16 match offsets into
+  // `AttributedString.Index` values: preview text is arbitrary agent prose, and
+  // index arithmetic across those two representations traps on the emoji and
+  // combining marks that prose actually contains.
+  var result = AttributedString()
+  var cursor = text.startIndex
+  for match in matches {
+    guard let range = Range(match.range, in: text), range.lowerBound >= cursor else { continue }
+    result += AttributedString(String(text[cursor..<range.lowerBound]))
+    var token = AttributedString(String(text[range]))
+    // Weight first, hue second. A token has to be legible for a reader who
+    // cannot separate it from the muted text by colour, so the difference is
+    // carried by the run's weight and only reinforced by the contrast step.
+    token.font = .caption2.italic().weight(.semibold)
+    token.foregroundColor = ADEColor.textSecondary
+    result += token
+    cursor = range.upperBound
+  }
+  result += AttributedString(String(text[cursor...]))
+  return result
+}
+
+private struct WorkSessionRowRenderSignature: Equatable {
+  let sessionId: String
+  let title: String
+  let provider: String?
+  let symbolProvider: String?
+  let laneName: String
+  let laneColor: String?
+  /// The lane's glyph, which line 1 actually draws. Without it in the signature
+  /// a lane icon changed from the manage sheet leaves every row of that lane
+  /// wearing the old mark until some unrelated field moves.
+  let laneIcon: LaneIcon?
+  // Lane git state is captured ONLY on a `showsLaneIdentity` row — the one shape
+  // that still draws it, because there is no lane header above it to own it
+  // (a headerless singleton lane, or a cross-lane status/time section where each
+  // row is a different lane anyway). Scoping it that way is what keeps the old
+  // problem away: a lane-status poll used to invalidate every row of a lane
+  // whether or not the row said anything about it. Only the three RENDERED
+  // fields are held, so `rebaseInProgress` / `remoteBehind` churn invalidates
+  // nothing.
+  let laneDirty: Bool
+  let laneAhead: Int
+  let laneBehind: Int
+  let activityTimestamp: String
+  /// The whole preview line, not just its text: `linkify` and `source` are part
+  /// of what gets rendered, so equality has to cover them or a note that becomes
+  /// terminal output with identical text would keep its tappable ranges.
+  let previewLine: WorkSessionPreviewLine?
+  let pinned: Bool
+  let pullRequestNumber: Int?
+  let pullRequestState: String?
+  let status: String
+  let canonicalPhase: CanonicalSessionPhase
+  /// The rendered capsule and dot, not just the phase behind them: the badge
+  /// moves on its own when planning starts or stops, and the tone is what the
+  /// dot is painted with. The WHOLE badge, because the compact row renders its
+  /// label and tone — re-deriving it at body time would put a second, later
+  /// clock outside the equality gate.
+  let badge: SessionBadge?
+  let rowTone: ActivityTone
+  /// The status slot's rendered contents. The label is what the slot literally
+  /// says — including a snooze's "wakes in 2h", which moves on its own while the
+  /// phase behind it never changes — so the phase alone cannot stand in for it.
+  ///
+  /// `showsElapsed` is here; the elapsed VALUE deliberately is not. The ticker is
+  /// rendered by a leaf `TimelineView` inside the slot, so a 1 Hz tick redraws
+  /// one `Text` instead of invalidating every visible row.
+  let statusLabel: String?
+  let statusGlyph: ActivityGlyph?
+  /// The slot's hue token, never a resolved `Color`: this signature is built on
+  /// the detached presentation rebuild, and `ActivityTone` is a String-backed
+  /// enum that crosses that boundary safely where a `Color` would not.
+  let statusTone: ActivityTone?
+  let showsElapsed: Bool
+  /// Drives the recede rule. Non-prominent rows render at 70% so the few rows
+  /// that want a human stand out with no banner at all.
+  let isProminent: Bool
+  let model: String?
+  let showsLaneIdentity: Bool
+  let settledAt: String?
+  let statusNote: String?
+  let attentionRequestedAt: String?
+  let attentionMessage: String?
+  let lastTurnFailedAt: String?
+  let settleOverride: String?
+  let snoozedUntil: String?
+  // `snoozedAt` is the early-wake comparison baseline behind
+  // `session.wokeMarker()`, which the row body renders. Without it a change
+  // confined to that column leaves the stale woke marker on screen.
+  let snoozedAt: String?
+  let wokeAt: String?
+  let wokeReason: String?
+  // Deterministic inputs to the attention capsule, so a badge transition
+  // (needs_you / failed) re-renders even when the display status is unchanged.
+  let runtimeState: String
+  let pendingInputItemId: String?
+  let exitCode: Int?
+  let isArchived: Bool
+  let isMuted: Bool
+  let isSelectedTransitionSource: Bool
+  let compact: Bool
+
+  init(
+    session: TerminalSessionSummary,
+    lane: LaneSummary?,
+    pullRequest: LanePrTag?,
+    chatSummary: AgentChatSessionSummary?,
+    status: String,
+    isArchived: Bool,
+    isMuted: Bool,
+    isSelectedTransitionSource: Bool,
+    compact: Bool,
+    showsLaneIdentity: Bool
+  ) {
+    self.sessionId = session.id
+    self.title = chatSummary?.title ?? session.title
+    self.provider = chatSummary?.provider ?? session.toolType
+    self.symbolProvider = chatSummary?.provider
+    self.laneName = session.laneName
+    self.laneColor = lane?.color
+    self.laneIcon = lane?.icon
+    // Under a lane header the header states the lane's git state once; capturing
+    // it here too would put it back on every row and re-invalidate them all.
+    //
+    // `!compact` is the other half of that gate, and it is load-bearing rather
+    // than belt-and-braces: a compact row has no line 1 at all, and child shells
+    // are always compact WITH `showsLaneIdentity` left at its default true. On
+    // `showsLaneIdentity` alone, a lane-status poll would invalidate every child
+    // shell in the lane to redraw state none of them draws.
+    let drawsLaneGitState = showsLaneIdentity && !compact
+    self.laneDirty = drawsLaneGitState && lane?.status.dirty == true
+    self.laneAhead = drawsLaneGitState ? (lane?.status.ahead ?? 0) : 0
+    self.laneBehind = drawsLaneGitState ? (lane?.status.behind ?? 0) : 0
+    self.activityTimestamp = workSessionActivityTimestamp(session: session, summary: chatSummary)
+    // One derivation, one clock. The phase, the capsule, the dot hue and the
+    // status slot all fall out of a single canonical state; reaching for the
+    // thin wrappers instead meant four passes AND four `Date()` values per row
+    // per rebuild, so two of them could land on opposite sides of a stale or
+    // snooze boundary and the row would paint a capsule from one instant beside
+    // a status slot from another.
+    let now = Date()
+    let row = workSessionRowPresentation(session: session, summary: chatSummary, now: now)
+    self.previewLine = workSessionRowPreviewSource(
+      session: session,
+      chatSummary: chatSummary,
+      isSettled: row.phase == .settled
+    )
+    self.pinned = session.pinned
+    self.pullRequestNumber = pullRequest?.githubPrNumber
+    self.pullRequestState = pullRequest.map { lanePrStateLabel($0.state) }
+    self.status = status
+    self.canonicalPhase = row.phase
+    self.badge = row.badge
+    self.rowTone = row.tone
+    self.statusLabel = row.status?.label
+    self.statusGlyph = row.status?.glyph
+    self.showsElapsed = row.status?.showsElapsed ?? false
+    // Settled resolves to a nil presentation, so it is not prominent and recedes.
+    // That is the intent, not an oversight: the timestamp owns its slot.
+    self.isProminent = row.status?.prominent ?? false
+    self.statusTone = row.status?.tone
+    self.model = chatSummary?.model
+    self.showsLaneIdentity = showsLaneIdentity
+    self.settledAt = session.settledAt
+    self.statusNote = session.statusNote
+    self.attentionRequestedAt = session.attentionRequestedAt
+    self.attentionMessage = session.attentionMessage
+    self.lastTurnFailedAt = session.lastTurnFailedAt
+    self.settleOverride = session.settleOverride
+    self.snoozedUntil = session.snoozedUntil
+    self.snoozedAt = session.snoozedAt
+    self.wokeAt = session.wokeAt
+    self.wokeReason = session.wokeReason
+    self.runtimeState = session.runtimeState
+    self.pendingInputItemId = session.pendingInputItemId
+    self.exitCode = session.exitCode
+    self.isArchived = isArchived
+    self.isMuted = isMuted
+    self.isSelectedTransitionSource = isSelectedTransitionSource
+    self.compact = compact
+  }
+
+  var previewText: String? { previewLine?.text }
+  var previewLinkify: Bool { previewLine?.linkify ?? false }
+}
+
+struct WorkSessionRow: View, Equatable {
+  let session: TerminalSessionSummary
+  let lane: LaneSummary?
+  var pullRequest: LanePrTag? = nil
+  let chatSummary: AgentChatSessionSummary?
+  let status: String
+  let isArchived: Bool
+  var isMuted: Bool = false
+  let transitionNamespace: Namespace.ID?
+  let isSelectedTransitionSource: Bool
+  var compact: Bool = false
+  /// The singleton form: no lane header above this row, so the row shows the
+  /// lane itself. Under a lane header the chip would just repeat the header.
+  var showsLaneIdentity: Bool = true
+  private let renderSignature: WorkSessionRowRenderSignature
+
+  init(
+    session: TerminalSessionSummary,
+    lane: LaneSummary?,
+    pullRequest: LanePrTag? = nil,
+    chatSummary: AgentChatSessionSummary?,
+    status: String,
+    isArchived: Bool,
+    isMuted: Bool = false,
+    transitionNamespace: Namespace.ID?,
+    isSelectedTransitionSource: Bool,
+    compact: Bool = false,
+    showsLaneIdentity: Bool = true
+  ) {
+    self.session = session
+    self.lane = lane
+    self.pullRequest = pullRequest
+    self.chatSummary = chatSummary
+    self.status = status
+    self.isArchived = isArchived
+    self.isMuted = isMuted
+    self.transitionNamespace = transitionNamespace
+    self.isSelectedTransitionSource = isSelectedTransitionSource
+    self.compact = compact
+    self.showsLaneIdentity = showsLaneIdentity
+    self.renderSignature = WorkSessionRowRenderSignature(
+      session: session,
+      lane: lane,
+      pullRequest: pullRequest,
+      chatSummary: chatSummary,
+      status: status,
+      isArchived: isArchived,
+      isMuted: isMuted,
+      isSelectedTransitionSource: isSelectedTransitionSource,
+      compact: compact,
+      showsLaneIdentity: showsLaneIdentity
+    )
+  }
+
+  static func == (lhs: WorkSessionRow, rhs: WorkSessionRow) -> Bool {
+    lhs.renderSignature == rhs.renderSignature
+  }
+
+  var body: some View {
+    if compact {
+      compactBody
+    } else {
+      // The Dynamic Type branch lives in a leaf rather than in this view because
+      // `WorkSessionRow` is rendered through `.equatable()`: an environment
+      // dependency read here can be short-circuited by the equality check, while
+      // a child that reads it owns the dependency itself and always re-evaluates.
+      WorkSessionRowLayoutSwitch(
+        standard: { standardBody },
+        accessible: { accessibleBody }
+      )
+    }
+  }
+
+  private var compactBody: some View {
+    HStack(alignment: .center, spacing: 8) {
+      WorkProviderBareLogo(
+        provider: chatSummary?.provider ?? session.toolType,
+        fallbackSymbol: sessionSymbol(session, provider: chatSummary?.provider),
+        tint: providerTintColor,
+        size: 20
+      )
+
+      Text(chatSummary?.title ?? session.title)
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(ADEColor.textPrimary)
+        .lineLimit(1)
+        .truncationMode(.tail)
+
+      if let badge = capsuleBadge {
+        WorkSessionStatusCapsule(badge: badge)
+      }
+
+      Spacer(minLength: 6)
+
+      if isPendingSyncCreation {
+        Text("Pending sync")
+          .font(.caption2.weight(.semibold))
+          .foregroundStyle(ADEColor.textMuted)
+          .lineLimit(1)
+      } else {
+        Text(relativeTimestampCompact(workSessionActivityTimestamp(session: session, summary: chatSummary)))
+          .font(.caption2.monospacedDigit())
+          .foregroundStyle(ADEColor.textMuted)
+          .lineLimit(1)
+      }
+    }
+    .padding(.horizontal, 10)
+    .padding(.vertical, 8)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    // Neutral, like the standard card: the provider tint survives only on the
+    // logo, which is the one place it is identity rather than state.
+    .background(surfaceFill, in: RoundedRectangle(cornerRadius: 11, style: .continuous))
+    .overlay {
+      if isSelectedTransitionSource {
+        RoundedRectangle(cornerRadius: 11, style: .continuous)
+          .stroke(ADEColor.accent.opacity(0.38), lineWidth: 0.8)
+      }
+    }
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel(accessibilityLabel)
+    .opacity(shouldRecede ? 0.7 : 1)
+  }
+
+  /// Three lines with fixed roles: line 1 is *where and what state*, line 2 is
+  /// *what it is*, line 3 is *the latest word*. The line count is fixed on
+  /// purpose — a column of rows whose shape is identical is scannable — but the
+  /// HEIGHT deliberately is not, so Dynamic Type can grow it.
+  private var standardBody: some View {
+    sessionCardSurface {
+      VStack(alignment: .leading, spacing: 3) {
+        lineOne
+        lineTwo
+        lineThree
+      }
+    }
+  }
+
+  /// Leading chrome glyphs, the lane and its git state (headerless rows only),
+  /// the floor, then the one status slot hard against the trailing edge.
+  ///
+  /// **Layout contract.** Exactly two children claim width: the lane chip when
+  /// it is present, and the floor label's flexible frame. Everything else —
+  /// including the status slot — is `.fixedSize()`, and an inflexible child is
+  /// sized before a flexible one. THAT is what guarantees the invariant that
+  /// matters: the status slot never truncates, never drops, and never degrades
+  /// to a glyph. (Note the floor label is `.fixedSize()` AND flexible-framed: it
+  /// takes its ideal width and the frame only holds the remaining space open, so
+  /// it pushes the slot to the trailing edge without ever competing for it.)
+  ///
+  /// Do not "fix" this by adding `layoutPriority` to the lane chip: a
+  /// higher-priority child is offered the entire remaining width first, which
+  /// would let a long lane name starve the status word. Do not reach for
+  /// `ViewThatFits` either — a candidate containing a `Spacer` reports an ideal
+  /// width that always fits, so the ladder would never advance past its first
+  /// rung.
+  private var lineOne: some View {
+    HStack(spacing: 5) {
+      if session.pinned {
+        // Muted, matching desktop: pinning is an ordering fact, not a state, and
+        // accent belongs to interaction.
+        Image(systemName: "pin.fill")
+          .font(.caption2)
+          .foregroundStyle(ADEColor.textMuted)
+          .fixedSize()
+      }
+      if isMuted {
+        Image(systemName: "bell.slash")
+          .font(.caption2)
+          .foregroundStyle(ADEColor.textMuted)
+          .fixedSize()
+      }
+      if showsLaneIdentity {
+        laneChip
+        laneGitState
+      }
+      // Always rendered, even when empty: its flexible frame is what holds the
+      // status slot against the trailing edge. `.lineLimit` / `.truncationMode`
+      // are deliberately absent — `.fixedSize()` gives this label its ideal
+      // width, so there is nothing left for them to do.
+      Text(rowFloorLabel)
+        .font(.caption2.monospacedDigit())
+        .foregroundStyle(ADEColor.textMuted)
+        .fixedSize()
+        .frame(maxWidth: .infinity, alignment: .leading)
+      Spacer(minLength: 4)
+      statusSlot(wraps: false)
+    }
+  }
+
+  private var lineTwo: some View {
+    HStack(spacing: 6) {
+      titleView(lineLimit: 1)
+
+      // Only on a headerless row. Under a lane header the PR already sits on the
+      // header, so rendering it per row prints the same "#14 Open" down the
+      // whole section.
+      if showsLaneIdentity, let pullRequest {
+        WorkLanePrIndicator(tag: pullRequest)
+          .fixedSize()
+      }
+    }
+  }
+
+  private var lineThree: some View {
+    HStack(spacing: 6) {
+      if renderSignature.previewText != nil {
+        previewView(lineLimit: 1)
+      } else {
+        Spacer()
+      }
+
+      if isPendingSyncCreation {
+        HStack(spacing: 3) {
+          Image(systemName: "clock.arrow.circlepath")
+            .font(.caption2)
+          Text("Pending sync")
+            .font(.caption2.weight(.semibold))
+        }
+        .foregroundStyle(ADEColor.textMuted)
+        .fixedSize()
+      } else if isArchived {
+        // Neutral, not amber. Archived is true but not actionable, and amber is
+        // spent exclusively on "your move" — an amber chip here would compete
+        // with the one status word that is allowed to claim a human.
+        Text("ARCHIVED")
+          .font(.caption2.monospaced().weight(.semibold))
+          .foregroundStyle(ADEColor.textMuted)
+          .fixedSize()
+          .adeMatchedGeometry(id: isSelectedTransitionSource ? "work-status-\(session.id)" : nil, in: transitionNamespace)
+      }
+
+      if let exitCode = failedExitCode {
+        Text("EXIT \(exitCode)")
+          .font(.caption2.monospaced().weight(.semibold))
+          .foregroundStyle(ADEColor.danger)
+          .fixedSize()
+      }
+
+      // The branded mark, and only the mark. The provider's NAME used to sit on
+      // this same line next to it, restating in words what the logo already says
+      // — and between them, the model label and the lane chip, they left the
+      // preview truncating mid-word.
+      WorkProviderBareLogo(
+        provider: chatSummary?.provider ?? session.toolType,
+        fallbackSymbol: sessionSymbol(session, provider: chatSummary?.provider),
+        tint: providerTintColor,
+        size: 18
+      )
+      .opacity(0.75)
+      .fixedSize()
+      .adeMatchedGeometry(id: isSelectedTransitionSource ? "work-icon-\(session.id)" : nil, in: transitionNamespace)
+    }
+  }
+
+  /// At accessibility sizes every element wants the full width, so competing for
+  /// one line stops being honest. The row stacks instead: status first (it is
+  /// what should be read first), then the title and preview at up to two lines,
+  /// then the lane. The pin/mute glyphs and the EXIT chip leave the VISUAL row —
+  /// they never leave `accessibilityLabel`, which is built from the raw session,
+  /// not from what was rendered.
+  private var accessibleBody: some View {
+    sessionCardSurface {
+      VStack(alignment: .leading, spacing: 6) {
+        statusSlot(wraps: true)
+
+        titleView(lineLimit: 2)
+
+        if renderSignature.previewText != nil {
+          previewView(lineLimit: 2)
+        }
+
+        if showsLaneIdentity {
+          laneChip
+          laneGitState
+          if let pullRequest {
+            WorkLanePrIndicator(tag: pullRequest)
+          }
+        }
+      }
+    }
+  }
+
+  /// Interaction owns the surface. Background, border and shadow are reserved
+  /// for selection and press; state never spends them.
+  ///
+  /// This card used to paint its whole body in the provider's brand hue
+  /// (`providerTintColor.opacity(0.12)` fill, a 0.25 stroke), and `providerTint`
+  /// maps Claude to amber — so every Claude row was already amber, and the amber
+  /// "Needs you" badge that is supposed to mean *your move* stopped registering.
+  /// Status now lives in exactly one place: the right-anchored slot on line 1.
+  private func sessionCardSurface<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
+    content()
+      .padding(.horizontal, 12)
+      .padding(.vertical, 9)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(surfaceFill, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+      .overlay {
+        if isSelectedTransitionSource {
+          RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .stroke(ADEColor.accent.opacity(0.38), lineWidth: 1)
+        }
+      }
+      .adeMatchedTransitionSource(id: isSelectedTransitionSource ? "work-container-\(session.id)" : nil, in: transitionNamespace)
+      .accessibilityElement(children: .combine)
+      .accessibilityLabel(accessibilityLabel)
+      .adeInspectable(
+        "Work.Session.Row",
+        metadata: [
+          "sessionId": session.id,
+          "laneId": session.laneId,
+          "laneName": session.laneName,
+          "title": chatSummary?.title ?? session.title
+        ]
+      )
+      // Last modifier, so it dims the finished card whole. Settled resolves to a
+      // nil status presentation and therefore recedes — intended, not an
+      // oversight: filed work should sit back.
+      .opacity(shouldRecede ? 0.7 : 1)
+  }
+
+  private var surfaceFill: Color {
+    isSelectedTransitionSource
+      ? ADEColor.accent.opacity(0.12)
+      : ADEColor.surfaceBackground.opacity(0.6)
+  }
+
+  /// Non-prominent states recede to 70%, which is how the few rows that want a
+  /// human stand out with no banner anywhere on screen.
+  private var shouldRecede: Bool { !renderSignature.isProminent }
+
+  /// The lane, stated once and only where nothing above the row states it.
+  ///
+  /// Tail truncation, never middle. Middle truncation at a negative layout
+  /// priority turned a lane called "Ok Needs Closing Issue" into
+  /// "Ok Need…osing Issue" — a name mangled into something the eye parses as a
+  /// status string. The lane-coloured dot that sat beside it is gone for the same
+  /// reason: a coloured dot on a row that also carries state reads as state.
+  private var laneChip: some View {
+    HStack(spacing: 3) {
+      WorkLaneLogoMark(color: laneTint, laneIcon: renderSignature.laneIcon, size: 11)
+      Text(renderSignature.laneName)
+        .font(.caption2.weight(.semibold))
+        .foregroundStyle(laneTint)
+        .lineLimit(1)
+        .truncationMode(.tail)
+    }
+  }
+
+  /// Dirty / ahead / behind for the lane, on `showsLaneIdentity` rows only.
+  ///
+  /// A LANE header owns this fact wherever there is one — stating it once per
+  /// lane instead of identically on every row of it is the whole point of moving
+  /// it there. But a lane with exactly one top-level session renders a
+  /// headerless `Section`, which is the common shape, and a status/time section
+  /// spans lanes so its header cannot speak for any of them. In both cases the
+  /// state would otherwise be unreachable anywhere in the Work tab. `laneChip`
+  /// is rendered under exactly the same condition, so the two travel together
+  /// and this can never print on every row of a lane again.
+  ///
+  /// Muted and `.fixedSize()`: this is context, not a call to action, and line 1
+  /// still owes its elastic width to the floor label alone. Nothing is drawn
+  /// when the worktree is clean and level — an always-present "0 ahead, 0
+  /// behind" would be chrome. Colour never carries the meaning: the dot is
+  /// accompanied by the arrow counts, and VoiceOver gets the words.
+  @ViewBuilder
+  private var laneGitState: some View {
+    if laneGitStateIsNoteworthy {
+      HStack(spacing: 5) {
+        if renderSignature.laneDirty {
+          Circle()
+            .fill(ADEColor.warning.opacity(0.85))
+            .frame(width: 5, height: 5)
+        }
+        if renderSignature.laneAhead > 0 {
+          laneGitCountChip(symbol: "arrow.up", count: renderSignature.laneAhead)
+        }
+        if renderSignature.laneBehind > 0 {
+          laneGitCountChip(symbol: "arrow.down", count: renderSignature.laneBehind)
+        }
+      }
+      .foregroundStyle(ADEColor.textMuted)
+      .fixedSize()
+      .accessibilityElement(children: .ignore)
+      .accessibilityLabel(laneGitStateAccessibilityLabel)
+    }
+  }
+
+  private var laneGitStateIsNoteworthy: Bool {
+    renderSignature.laneDirty || renderSignature.laneAhead > 0 || renderSignature.laneBehind > 0
+  }
+
+  private func laneGitCountChip(symbol: String, count: Int) -> some View {
+    HStack(spacing: 1) {
+      Image(systemName: symbol)
+        // Sized off the caption text style rather than a fixed point size, so
+        // the arrow grows with the count beside it under Dynamic Type.
+        .font(.caption2.weight(.bold))
+      Text("\(count)")
+        .font(.caption2.monospacedDigit())
+    }
+  }
+
+  private var laneGitStateAccessibilityLabel: String {
+    var parts: [String] = []
+    if renderSignature.laneDirty { parts.append("uncommitted changes") }
+    if renderSignature.laneAhead > 0 { parts.append("\(renderSignature.laneAhead) ahead") }
+    if renderSignature.laneBehind > 0 { parts.append("\(renderSignature.laneBehind) behind") }
+    return parts.joined(separator: ", ")
+  }
+
+  private var laneTint: Color {
+    LaneColorPalette.color(forHex: lane?.color) ?? ADEColor.textSecondary
+  }
+
+  /// Whether a title changing under the reader deserves the flash.
+  ///
+  /// The flash exists to explain a name that moved on its own — the agent's
+  /// generated title replacing the seed. A person who just renamed their own
+  /// chat needs no explanation, so a manual name suppresses it.
+  ///
+  /// Deliberately absent from `WorkSessionRowRenderSignature`: it changes only
+  /// alongside a rename, which moves `title` and reopens the gate anyway, and a
+  /// change confined to this flag has nothing to redraw.
+  /// Only the session row carries the flag — `AgentChatSessionSummary` has no
+  /// `manuallyNamed`, so there is nothing to fall back to.
+  private var flashesOnRename: Bool {
+    session.manuallyNamed != true
+  }
+
+  /// Line 1 is never allowed to be empty — an empty leading edge reads as a
+  /// half-loaded row. The model comes first because on a phone it is the only
+  /// thing that distinguishes two rows on the same provider; the compact
+  /// timestamp is the fallback.
+  private var rowFloorLabel: String {
+    let model = shortModelLabel(renderSignature.model)
+    if !model.isEmpty { return model }
+    // With no status word the slot itself renders the timestamp, so repeating it
+    // here would print the same "12m" twice on one line.
+    if renderSignature.statusLabel == nil { return "" }
+    return relativeTimestampCompact(renderSignature.activityTimestamp)
+  }
+
+  /// The row's ONE status slot. When there is no status word — settled, and only
+  /// settled — the slot renders the compact timestamp instead, which is the same
+  /// contract as desktop's `SessionStatusSlot` timestamp fallback: down in the
+  /// quiet tail the section is the status, and "when" is the only thing left
+  /// worth reading.
+  @ViewBuilder
+  private func statusSlot(wraps: Bool) -> some View {
+    if let label = renderSignature.statusLabel, let tone = renderSignature.statusTone {
+      WorkSessionRowStatusSlot(
+        label: label,
+        tone: tone,
+        glyph: renderSignature.statusGlyph,
+        showsElapsed: renderSignature.showsElapsed,
+        elapsedSince: renderSignature.showsElapsed
+          ? workParsedDate(renderSignature.activityTimestamp)
+          : nil,
+        wraps: wraps,
+        // The slot pulses once when this flips true underneath a reader who is
+        // already looking at the row. Passing the phase rather than a trigger
+        // keeps the decision in the leaf, which is the only view that knows
+        // whether it was on screen for the transition.
+        needsYou: renderSignature.canonicalPhase == .needsYou
+      )
+    } else {
+      HStack(spacing: 4) {
+        if isSettled {
+          // Hollow, not filled: settled work is put away, and the ring says that
+          // without spending a solid dot on it. Same treatment as before — it has
+          // only moved from line 2 into the slot it belongs in.
+          Circle()
+            .strokeBorder(rowTint.opacity(0.7), lineWidth: 1)
+            .frame(width: 6, height: 6)
+        }
+        Text(relativeTimestampCompact(renderSignature.activityTimestamp))
+          .font(.caption2.monospacedDigit())
+          .foregroundStyle(ADEColor.textMuted)
+          .lineLimit(1)
+      }
+      .fixedSize(horizontal: !wraps, vertical: false)
+    }
+  }
+
+  /// The title, shared by both bodies. Only the line limit differs between them
+  /// — the accent, the rename flash and the matched-geometry id are the same
+  /// facts at every type size, and a second copy of them is how a transition id
+  /// quietly stops matching on one branch only.
+  private func titleView(lineLimit: Int) -> some View {
+    WorkSessionRowTitle(
+      title: chatSummary?.title ?? session.title,
+      accent: laneTint,
+      flashesOnRename: flashesOnRename,
+      lineLimit: lineLimit
+    )
+    .adeMatchedGeometry(id: isSelectedTransitionSource ? "work-title-\(session.id)" : nil, in: transitionNamespace)
+  }
+
+  /// The italic line-3 preview. Same reason as `titleView`: one place decides
+  /// whether the preview linkifies, so the two bodies cannot drift on it.
+  @ViewBuilder
+  private func previewView(lineLimit: Int) -> some View {
+    if let preview = renderSignature.previewText {
+      Text(workLinkifiedPreview(preview, linkify: renderSignature.previewLinkify))
+        .font(.caption2.italic())
+        .foregroundStyle(ADEColor.textMuted)
+        .lineLimit(lineLimit)
+        .truncationMode(.tail)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+
+  /// 0 is success, and 130 (SIGINT) / 143 (SIGTERM) are how a person or ADE stops
+  /// a runtime on purpose. Painting those red would make every deliberate stop
+  /// look like a crash.
+  private var failedExitCode: Int? {
+    guard let code = renderSignature.exitCode, ![0, 130, 143].contains(code) else { return nil }
+    return code
+  }
+
+  var providerTintColor: Color {
+    providerTint(chatSummary?.provider ?? session.toolType)
+  }
+
+  /// The row's status capsule, in the full shared vocabulary — needs you,
+  /// failed, stale, working, planning, done. Nil for the resting states, so the
+  /// row never shifts layout to say that nothing is happening.
+  ///
+  /// Read from the signature, never re-derived. The signature is built on the
+  /// detached presentation rebuild; deriving the same fact again here would run
+  /// it on a LATER clock and outside the equality gate, so a row could show a
+  /// capsule and a status slot that disagree across a stale boundary.
+  var capsuleBadge: SessionBadge? { renderSignature.badge }
+
+  /// Same rule as `capsuleBadge`: the phase the row was BUILT with, not a fresh
+  /// one, so the settled ring and the status slot cannot disagree.
+  var isSettled: Bool { renderSignature.canonicalPhase == .settled }
+
+  var isPendingSyncCreation: Bool {
+    workIsPendingChatCreationSession(session)
+  }
+
+  /// The phase hue, read through the shared tone table rather than the coarse
+  /// four-value status string. Now spent on exactly one mark — the settled
+  /// hollow ring in the status slot — since the row no longer carries a separate
+  /// status dot that could tell a different story from the status word.
+  var rowTint: Color {
+    if isPendingSyncCreation { return ADEColor.textMuted }
+    if isArchived { return ADEColor.warning }
+    return activityToneColor(renderSignature.rowTone)
+  }
+
+  /// Built from the raw session, never from what was rendered.
+  ///
+  /// That distinction is load-bearing now that the row sheds chrome under
+  /// Dynamic Type and hides the lane chip and the PR under a section header: a
+  /// fact that leaves the VISUAL row must not leave VoiceOver with it. Every
+  /// clause below reads a model field, not a view.
+  var accessibilityLabel: String {
+    var parts = [chatSummary?.title ?? session.title, session.laneName, sessionStatusLabel(for: status)]
+    if let statusLabel = renderSignature.statusLabel {
+      parts.append(statusLabel)
+    }
+    if let model = renderSignature.model, !model.isEmpty {
+      parts.append(shortModelLabel(model))
+    }
+    if let pullRequest {
+      parts.append("pull request #\(pullRequest.githubPrNumber), \(lanePrStateLabel(pullRequest.state))")
+    }
+    if let exitCode = failedExitCode {
+      parts.append("exited with code \(exitCode)")
+    }
+    if session.pinned {
+      parts.append("pinned")
+    }
+    if isMuted {
+      parts.append("notifications muted")
+    }
+    if isArchived {
+      parts.append("archived")
+    }
+    // The card combines its children and then overrides the label, so the git
+    // chips' own label never reaches VoiceOver — it has to be stated here or the
+    // dot would be colour-only meaning. Headerless rows only, matching what is
+    // drawn: under a header the header says it.
+    if showsLaneIdentity && laneGitStateIsNoteworthy {
+      parts.append(laneGitStateAccessibilityLabel)
+    }
+    if isSettled {
+      parts.append("settled")
+    }
+    // Snooze and woke are NOT appended here. The status slot already speaks for
+    // both — `workSessionStatusSlot` puts "wakes in 30m" or "Woke" in the slot
+    // ahead of the phase — so `statusLabel` above is that sentence. Saying it
+    // again read as "wakes in 30m, snoozed wakes in 30m" to VoiceOver, and it was
+    // a third derivation of the same fact on a third clock.
+    return parts.joined(separator: ", ")
+  }
+}
+
+/// Picks the session row's layout for the current Dynamic Type size.
+///
+/// A leaf rather than an `@Environment` read on `WorkSessionRow` itself: that row
+/// is rendered through `.equatable()`, so an environment dependency declared up
+/// there can be short-circuited by the equality check. Declared here, the
+/// dependency belongs to a view whose body always re-evaluates when the trait
+/// changes.
+private struct WorkSessionRowLayoutSwitch<Standard: View, Accessible: View>: View {
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+  let standard: () -> Standard
+  let accessible: () -> Accessible
+
+  init(
+    @ViewBuilder standard: @escaping () -> Standard,
+    @ViewBuilder accessible: @escaping () -> Accessible
+  ) {
+    self.standard = standard
+    self.accessible = accessible
+  }
+
+  var body: some View {
+    if dynamicTypeSize >= .accessibility1 {
+      accessible()
+    } else {
+      standard()
+    }
+  }
+}
+
+/// The row's title, plus the one moment it needs to explain itself.
+///
+/// A chat is created with a seed name and renamed later by the agent that ran
+/// it, so a reader watching the list sees a row's name change with no input of
+/// their own. Desktop answers that by flashing the title's background in the
+/// lane accent for about 900ms (`SessionCard.tsx:906-920`) — long enough to draw
+/// the eye to what moved, short enough to leave nothing behind.
+///
+/// A leaf for the same reason the status slot is one: `WorkSessionRow` renders
+/// through `.equatable()`, so the reduce-motion environment read and the
+/// transient flash state both belong to a view that always re-evaluates rather
+/// than to one whose body can be short-circuited. The `@State` survives across
+/// updates because rows carry `.id(session.id)`, so SwiftUI keeps this view's
+/// identity as long as the session stays in the list.
+private struct WorkSessionRowTitle: View {
+  let title: String
+  /// The lane accent. The flash is the one place a lane hue touches the card
+  /// body, and it is gone in under a second.
+  let accent: Color
+  /// False when the user named this chat themselves — see `flashesOnRename`.
+  let flashesOnRename: Bool
+  var lineLimit: Int = 1
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var flashing = false
+
+  var body: some View {
+    Text(title)
+      .font(.subheadline.weight(.semibold))
+      .foregroundStyle(ADEColor.textPrimary)
+      .lineLimit(lineLimit)
+      .truncationMode(.tail)
+      // Before the flexible frame, so the flash hugs the words instead of
+      // painting the full row width behind a short title. A background never
+      // participates in layout, so nothing here can move the card.
+      .background {
+        RoundedRectangle(cornerRadius: 4, style: .continuous)
+          .fill(accent.opacity(flashing ? 0.3 : 0))
+          .padding(.horizontal, -4)
+          .padding(.vertical, -2)
+          .allowsHitTesting(false)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .onChange(of: title) { _, _ in
+        // Reduce motion takes the whole thing, not a shortened version of it:
+        // there is no cross-fade and no flash, just the new title. A brief
+        // colour wash IS the animation here, so softening it would still be one.
+        guard flashesOnRename, !reduceMotion else { return }
+        // Unanimated on, animated off. The wash should already be there when the
+        // new title lands — fading it in would draw the eye after the change it
+        // is supposed to announce.
+        flashing = true
+        withAnimation(ADEMotion.standard(reduceMotion: reduceMotion).delay(0.3)) {
+          flashing = false
+        }
+      }
+  }
+}
+
+/// The Work row's one status slot.
+///
+/// A separate leaf view for exactly one reason: the elapsed ticker.
+/// `TimelineView(.periodic(by: 1))` re-evaluates only its own body, so a running
+/// row redraws a single `Text` each second instead of invalidating every visible
+/// row — which is why the elapsed VALUE is deliberately absent from
+/// `WorkSessionRowRenderSignature` while `showsElapsed` is present.
+private struct WorkSessionRowStatusSlot: View {
+  let label: String
+  let tone: ActivityTone
+  let glyph: ActivityGlyph?
+  let showsElapsed: Bool
+  /// **Divergence, stated so nobody hunts for a bug.** iOS's
+  /// `TerminalSessionSummary` carries no `currentTurnStartedAt`, so the ticker
+  /// anchors on the row's activity timestamp: it measures time since last
+  /// activity, where desktop's `SessionStatusSlot` measures time since the turn
+  /// started. On a live turn the two agree closely; on a quiet one this reads
+  /// larger.
+  let elapsedSince: Date?
+  /// Accessibility sizes let the slot wrap instead of holding one line.
+  var wraps: Bool = false
+  /// The row is asking for a human right now. Only a TRANSITION into this state
+  /// pulses; the steady state does nothing.
+  var needsYou: Bool = false
+
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var pulsing = false
+
+  var body: some View {
+    HStack(spacing: 3) {
+      if let glyph {
+        // Sized via the text style, not a point size, so the mark scales with
+        // the label it sits beside.
+        Image(systemName: glyph.systemImage)
+          .font(.caption2.weight(.semibold))
+      }
+      if showsElapsed, let elapsedSince {
+        TimelineView(.periodic(from: .now, by: 1)) { context in
+          Text(tickerLabel(since: elapsedSince, now: context.date))
+            .font(.caption2.weight(.semibold).monospacedDigit())
+        }
+      } else {
+        Text(label)
+          .font(.caption2.weight(.semibold))
+      }
+    }
+    .foregroundStyle(activityToneColor(tone))
+    .lineLimit(wraps ? 2 : 1)
+    // The slot never truncates, never drops and never degrades to a glyph-only
+    // form: the word IS the deliverable, and the glyph set is deliberately
+    // partial (snoozed and woke have no `ActivityGlyph` at all). The only
+    // permitted compression is omitting the elapsed ticker.
+    .fixedSize(horizontal: !wraps, vertical: false)
+    // `scaleEffect` and not a size or padding change: it is drawn, not laid out,
+    // so a pulsing row cannot nudge line 1's width and re-truncate the lane name
+    // beside it.
+    .scaleEffect(pulsing ? 1.12 : 1)
+    .onChange(of: needsYou) { wasNeedsYou, isNeedsYou in
+      // ONE pulse, on the way in only. `onChange` never fires on first
+      // appearance, which is the whole reason the trigger lives here instead of
+      // in an `onAppear` comparison: a row scrolled into view already in
+      // needs-you is not news, it is just the list.
+      //
+      // A row arriving from settled misses this, because settled resolves to a
+      // nil presentation and renders the timestamp branch instead — the slot is
+      // constructed fresh and has no previous value to differ from. Accepted:
+      // the alternative is a trigger in the parent, which would put transient
+      // animation state behind the row's equality gate.
+      guard isNeedsYou, !wasNeedsYou, !reduceMotion else { return }
+      // `emphasis`, never `ADEMotion.pulse` — that one is `repeatForever` and
+      // would leave the row breathing for as long as it is on screen.
+      withAnimation(ADEMotion.emphasis(reduceMotion: reduceMotion)) { pulsing = true }
+      withAnimation(ADEMotion.quick(reduceMotion: reduceMotion).delay(0.22)) { pulsing = false }
+    }
+  }
+
+  private func tickerLabel(since: Date, now: Date) -> String {
+    guard let elapsed = ActivityRowPresentation.formatDuration(now.timeIntervalSince(since)) else {
+      return label
+    }
+    return "\(label) \(elapsed)"
+  }
+}

--- a/apps/ios/ADE/Views/Work/WorkStatusAndFormattingHelpers.swift
+++ b/apps/ios/ADE/Views/Work/WorkStatusAndFormattingHelpers.swift
@@ -599,8 +599,9 @@ func workChatStatusSortRank(_ status: String) -> Int {
 
 /// Tone for the coarse four-value chat status string, for the surfaces that only
 /// ever hold that string (the hub roster, personal chats, the session settings
-/// sheet). Rows that hold a real session use `workSessionRowTone` instead, which
-/// reads the canonical phase.
+/// sheet). Rows that hold a real session read
+/// `workSessionRowPresentation(...).tone` instead, which derives from the
+/// canonical phase.
 ///
 /// Both route through `ActivityTone`, which is what enforces the one-hue rule:
 /// amber is "your move" and nothing else. That rule moved two colours here — an

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -23712,12 +23712,14 @@ final class RosterDeltaTests: XCTestCase {
     XCTAssertEqual(settledSession.statusNote, "Shipped the lifecycle mirror")
     XCTAssertEqual(workCanonicalSessionState(session: settledSession, summary: nil).phase, .settled)
     XCTAssertEqual(
-      workSessionGroupsByStatus(
+      workSessionGroups(
+        organization: .byStatus,
         sessions: [settledSession],
         chatSummaries: [:],
-        archivedSessionIds: []
+        archivedSessionIds: [],
+        orderedLanes: []
       ).map(\.id),
-      ["status:settled"]
+      [workSettledSectionId]
     )
 
     var activeSettledSession = settledSession

--- a/apps/ios/ADETests/ADETests.swift
+++ b/apps/ios/ADETests/ADETests.swift
@@ -18760,7 +18760,6 @@ final class ADETests: XCTestCase {
     )
   }
 
-
   func testAssistantPreviewCacheHydratesBuiltChatMessages() {
     let markdown = (1...5000).map { "\($0). Line \($0)" }.joined(separator: "\n")
     let transcript = [
@@ -19370,21 +19369,6 @@ final class ADETests: XCTestCase {
     XCTAssertEqual(resolved, "apps/ios/ADE/Helpers/WorkView.swift")
   }
 
-  func testWorkRunningBannerCopyDescribesMixedLiveSessions() {
-    XCTAssertEqual(
-      workRunningBannerTitle(liveChatCount: 1, liveTerminalCount: 1, attentionCount: 1),
-      "1 chat needs input, 2 other sessions are live"
-    )
-    XCTAssertEqual(
-      workRunningBannerTitle(liveChatCount: 1, liveTerminalCount: 1, attentionCount: 0),
-      "2 live sessions across chat and terminal"
-    )
-    XCTAssertEqual(
-      workRunningBannerMessage(liveTerminalCount: 1, attentionCount: 0),
-      "The Work tab badge stays visible while live chats or terminal sessions continue running."
-    )
-  }
-
   func testWorkFilesWorkspaceSelectionRequiresMatchingLaneWorkspace() {
     let workspaces = [
       FilesWorkspace(
@@ -19488,7 +19472,6 @@ final class ADETests: XCTestCase {
     XCTAssertFalse(isStoppableRuntimeSession(makeTerminalSessionSummary(toolType: "shell", runtimeState: "stopped", status: "exited")))
     XCTAssertFalse(isStoppableRuntimeSession(makeTerminalSessionSummary(toolType: "codex-chat", runtimeState: "running", status: "running")))
   }
-
 
   func testWorkFilteredSessionsRetainsStaleStandaloneCliRowsAndChatOwnedShells() {
     let chatSession = makeTerminalSessionSummary(
@@ -23907,7 +23890,6 @@ final class RosterAttentionAndHostAvailabilityTests: XCTestCase {
   func testWorkListShowsEndedStandaloneCliAndHidesOrphanedEndedChildren() {
     let endedCli = session(toolType: "cli", status: "completed", runtimeState: "exited")
     XCTAssertTrue(workSessionShouldAppearInWorkList(endedCli, parentChatSessionIds: []))
-
 
     let orphanedEndedChild = session(
       toolType: "shell",

--- a/apps/ios/ADETests/SyncRecoveryPolicyTests.swift
+++ b/apps/ios/ADETests/SyncRecoveryPolicyTests.swift
@@ -1540,6 +1540,10 @@ final class SyncRecoveryPolicyTests: XCTestCase {
       service.supportsSessionSnoozeActions,
       "Snooze must stay hidden on a host that never advertised session.snoozeSession."
     )
+    XCTAssertFalse(
+      service.supportsWorkSessionDeletion,
+      "work.deleteSession is not in the REQUIRED contract, so a legacy host that never advertises it must leave the delete affordance hidden rather than offering a control that fails."
+    )
   }
 
   @MainActor
@@ -1631,6 +1635,123 @@ final class SyncRecoveryPolicyTests: XCTestCase {
       service.capturedOutboundEnvelopeCountForTesting(type: "command"),
       0,
       "An unsupported lifecycle action must never reach the wire or the durable queue."
+    )
+  }
+
+  // MARK: - work.deleteSession host compatibility
+  //
+  // `work.deleteSession` is NOT in MOBILE_SYNC_REQUIRED_REMOTE_COMMAND_ACTIONS
+  // (apps/desktop/src/shared/syncMobileCompatibility.ts) — adding it there would
+  // flip every shipped phone into limited mode against an older brain. So the
+  // phone must feature-detect it from the advertised descriptors, and every
+  // branch that cannot prove support has to refuse locally, before the wire.
+
+  @MainActor
+  func testWorkSessionDeletionIsGatedOnTheAdvertisedDescriptor() async throws {
+    let defaultsSnapshot = snapshotDefaults(keys: connectionDefaultsKeys)
+    let baseURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
+    let database = DatabaseService(baseURL: baseURL)
+    let service = SyncService(database: database)
+    service.beginOutboundEnvelopeCaptureForTesting()
+    service.configureConnectedTransportForTesting()
+    defer {
+      service.endOutboundEnvelopeCaptureForTesting()
+      service.disconnect(clearCredentials: false)
+      restoreDefaults(defaultsSnapshot, keys: connectionDefaultsKeys)
+      database.close()
+      try? FileManager.default.removeItem(at: baseURL)
+    }
+
+    // A host that satisfies the whole REQUIRED contract — `mode: "full"` — and
+    // still has never heard of `work.deleteSession`. This is the shape that
+    // matters: full compatibility is NOT permission to assume an optional
+    // action exists.
+    try service.applyHelloPayloadForTesting([
+      "brain": ["deviceId": "no-delete-host", "deviceName": "Mac Studio"],
+      "features": [
+        "mobileCompatibility": ["mode": "full", "missingActions": [String]()],
+        "commandRouting": [
+          "actions": [
+            ["action": "work.listSessions", "policy": ["viewerAllowed": true]],
+          ],
+        ],
+      ],
+    ])
+    XCTAssertEqual(service.hostCompatibilityMode, .full)
+    XCTAssertFalse(
+      service.supportsWorkSessionDeletion,
+      "No descriptor means no capability: the gate must default to false, not to the host's overall mode."
+    )
+
+    service.resetOutboundEnvelopeCaptureForTesting()
+    do {
+      try await service.deleteWorkSession(sessionId: "session-1")
+      XCTFail("Deleting against a host that never advertised work.deleteSession must throw.")
+    } catch {
+      XCTAssertTrue(
+        error.localizedDescription.contains("too old"),
+        "The refusal should tell the user their desktop is out of date rather than surface a method-not-found."
+      )
+    }
+    XCTAssertEqual(
+      service.capturedOutboundEnvelopeCountForTesting(type: "command"),
+      0,
+      "An unadvertised delete must never reach the wire or the durable queue."
+    )
+
+    // A viewer-denied descriptor is the second unsupported shape: the action
+    // exists on the host, but this device may not invoke it. `supports` is not
+    // the gate — `canInvokeRemoteAction` is — so the affordance must stay hidden.
+    try service.applyHelloPayloadForTesting([
+      "brain": ["deviceId": "viewer-host", "deviceName": "Mac Studio"],
+      "features": [
+        "mobileCompatibility": ["mode": "full", "missingActions": [String]()],
+        "commandRouting": [
+          "actions": [
+            ["action": "work.deleteSession", "policy": ["viewerAllowed": false, "queueable": true]],
+          ],
+        ],
+      ],
+    ])
+    XCTAssertTrue(service.supportsRemoteAction("work.deleteSession"))
+    XCTAssertFalse(
+      service.supportsWorkSessionDeletion,
+      "A viewer device must not be offered a delete the host will refuse."
+    )
+
+    service.resetOutboundEnvelopeCaptureForTesting()
+    do {
+      try await service.deleteWorkSession(sessionId: "session-1")
+      XCTFail("A viewer-denied delete must throw rather than reach the host.")
+    } catch {
+      // The message is the same "update your desktop" copy: from the phone's
+      // side both are "this machine will not let me do it", and the delete
+      // affordance is hidden in both cases anyway.
+    }
+    XCTAssertEqual(
+      service.capturedOutboundEnvelopeCountForTesting(type: "command"),
+      0,
+      "A viewer-denied delete must not reach the wire either."
+    )
+
+    // The real host shape: viewer-allowed and queueable, exactly as
+    // syncRemoteCommandService registers it.
+    try service.applyHelloPayloadForTesting([
+      "brain": ["deviceId": "new-host", "deviceName": "Mac Studio"],
+      "features": [
+        "mobileCompatibility": ["mode": "full", "missingActions": [String]()],
+        "commandRouting": [
+          "actions": [
+            ["action": "work.deleteSession", "policy": ["viewerAllowed": true, "queueable": true]],
+          ],
+        ],
+      ],
+    ])
+    XCTAssertTrue(
+      service.supportsWorkSessionDeletion,
+      "A host advertising the action viewer-allowed and queueable must unlock the delete affordance."
     )
   }
 

--- a/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
+++ b/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
@@ -251,7 +251,7 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
   func testStatusBadgeMapsChatAwaitingInputToNeedsYou() {
     let session = makeSession(status: "running", runtimeState: "running", toolType: "codex-chat")
     let summary = makeChatSummary(status: "active", awaitingInput: true)
-    let badge = workSessionStatusBadge(session: session, summary: summary, now: now)
+    let badge = workSessionRowPresentation(session: session, summary: summary, now: now).badge
     XCTAssertEqual(badge?.kind, .needsYou)
   }
 
@@ -279,13 +279,13 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
 
   func testStatusBadgeSurfacesFailedExit() {
     let session = makeSession(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 130)
-    let badge = workSessionStatusBadge(session: session, summary: nil, now: now)
+    let badge = workSessionRowPresentation(session: session, summary: nil, now: now).badge
     XCTAssertEqual(badge?.kind, .failed)
   }
 
   func testStatusBadgeNilForStoppedDisposedSession() {
     let session = makeSession(status: "disposed", runtimeState: "killed", toolType: "codex", exitCode: 130)
-    let badge = workSessionStatusBadge(session: session, summary: nil, now: now)
+    let badge = workSessionRowPresentation(session: session, summary: nil, now: now).badge
     XCTAssertNil(badge)
   }
 
@@ -293,93 +293,15 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
   /// "Working" capsule, never one of the three attention identities.
   func testStatusBadgeIsWorkingNotAttentionForFreshRunning() {
     let session = makeSession(status: "running", runtimeState: "running", toolType: "codex", startedAt: iso(now))
-    let badge = workSessionStatusBadge(session: session, summary: nil, now: now)
+    let badge = workSessionRowPresentation(session: session, summary: nil, now: now).badge
     XCTAssertEqual(badge?.kind, .working)
   }
 
   // MARK: - One derivation per row
 
-  /// The contract that keeps the three wrappers honest: they are reads of
-  /// `workSessionRowPresentation`, not independent derivations. If any of them
-  /// ever grows its own copy of the phase or planning fold this fails, which is
-  /// the whole point — four derivations per row also meant four `Date()` calls,
-  /// so a row rebuilt across the stale or snooze boundary could paint its
-  /// capsule from one instant and its status slot from another.
-  func testRowPresentationAgreesWithEveryWrapper() {
-    var staleSummary = makeChatSummary(status: "active", awaitingInput: false)
-    staleSummary.lastActivityAt = silentFor(sessionStaleAfterSeconds + 60)
-
-    let cases: [(name: String, session: TerminalSessionSummary, summary: AgentChatSessionSummary?)] = [
-      (
-        "needs-you",
-        makeSession(status: "running", runtimeState: "running", toolType: "codex-chat"),
-        makeChatSummary(status: "active", awaitingInput: true)
-      ),
-      (
-        "running",
-        makeSession(status: "running", runtimeState: "running", toolType: "codex", startedAt: iso(now)),
-        nil
-      ),
-      (
-        "running + planning",
-        makeSession(status: "running", runtimeState: "running", toolType: "codex-chat", startedAt: iso(now)),
-        makeChatSummary(status: "active", awaitingInput: false, interactionMode: "plan")
-      ),
-      (
-        "ready",
-        makeSession(status: "ended", runtimeState: "exited", toolType: "codex-chat", exitCode: 0),
-        nil
-      ),
-      (
-        "failed",
-        makeSession(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 1),
-        nil
-      ),
-      (
-        "stale",
-        makeSession(status: "running", runtimeState: "running", toolType: "codex-chat"),
-        staleSummary
-      ),
-      (
-        "settled",
-        makeSession(status: "running", runtimeState: "idle", toolType: "codex-chat", settledAt: iso(now)),
-        nil
-      ),
-      ("snoozed", snoozedSession(untilOffset: 3_600, atOffset: -60), nil),
-    ]
-
-    for testCase in cases {
-      let row = workSessionRowPresentation(
-        session: testCase.session,
-        summary: testCase.summary,
-        now: now
-      )
-      XCTAssertEqual(
-        row.phase,
-        workCanonicalSessionState(session: testCase.session, summary: testCase.summary, now: now).phase,
-        testCase.name
-      )
-      XCTAssertEqual(
-        row.badge,
-        workSessionStatusBadge(session: testCase.session, summary: testCase.summary, now: now),
-        testCase.name
-      )
-      XCTAssertEqual(
-        row.tone,
-        workSessionRowTone(session: testCase.session, summary: testCase.summary, now: now),
-        testCase.name
-      )
-      XCTAssertEqual(
-        row.status,
-        workSessionStatusPresentation(session: testCase.session, summary: testCase.summary, now: now),
-        testCase.name
-      )
-    }
-  }
-
-  /// The two states whose capsule and status slot deliberately disagree, so the
-  /// agreement test above cannot be satisfied by a wrapper that simply returns
-  /// the same thing for everything.
+  /// The two states whose capsule and status slot deliberately disagree, which
+  /// is what proves the row derives four distinct answers from one pass rather
+  /// than echoing a single value into every field.
   func testRowPresentationKeepsCapsuleAndSlotIndependent() {
     let settled = workSessionRowPresentation(
       session: makeSession(status: "running", runtimeState: "idle", toolType: "codex-chat", settledAt: iso(now)),
@@ -400,8 +322,8 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
 
   // MARK: - The full status vocabulary
   //
-  // `workSessionStatusBadge` is the whole vocabulary the row renders, not just
-  // the attention third, and every word and hue in it comes from the shared
+  // The row's `badge` is the whole vocabulary it renders, not just the attention
+  // third, and every word and hue in it comes from the shared
   // `ActivityPhaseVocabulary`, not from a second table here.
 
   func testStatusBadgeCoversTheDescriptiveStates() {
@@ -480,15 +402,13 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
       if testCase.name == "stale" {
         summary?.lastActivityAt = silentFor(sessionStaleAfterSeconds + 60)
       }
-      let badge = workSessionStatusBadge(session: testCase.session, summary: summary, now: now)
-      XCTAssertEqual(badge?.kind, testCase.kind, testCase.name)
-      XCTAssertEqual(badge?.label, testCase.label, testCase.name)
-      XCTAssertEqual(badge?.tone, testCase.tone, testCase.name)
-      XCTAssertEqual(
-        workSessionRowTone(session: testCase.session, summary: summary, now: now),
-        testCase.tone,
-        testCase.name
-      )
+      let row = workSessionRowPresentation(session: testCase.session, summary: summary, now: now)
+      XCTAssertEqual(row.badge?.kind, testCase.kind, testCase.name)
+      XCTAssertEqual(row.badge?.label, testCase.label, testCase.name)
+      XCTAssertEqual(row.badge?.tone, testCase.tone, testCase.name)
+      // The dot reads the same derivation, so a capsule and a dot describing the
+      // same row cannot pick different hues.
+      XCTAssertEqual(row.tone, testCase.tone, testCase.name)
     }
   }
 
@@ -500,8 +420,9 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     let ended = makeSession(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 0)
 
     for session in [stopped, ended] {
-      XCTAssertNil(workSessionStatusBadge(session: session, summary: nil, now: now))
-      XCTAssertEqual(workSessionRowTone(session: session, summary: nil, now: now), .neutral)
+      let row = workSessionRowPresentation(session: session, summary: nil, now: now)
+      XCTAssertNil(row.badge)
+      XCTAssertEqual(row.tone, .neutral)
     }
   }
 
@@ -513,15 +434,15 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     let idleCli = makeSession(status: "running", runtimeState: "idle", toolType: "codex")
 
     for session in [readyChat, idleCli] {
-      let badge = workSessionStatusBadge(session: session, summary: nil, now: now)
-      XCTAssertEqual(badge?.kind, .done)
-      XCTAssertEqual(badge?.label, "Done")
-      XCTAssertEqual(badge?.tone, .emerald)
-      XCTAssertEqual(workSessionRowTone(session: session, summary: nil, now: now), .emerald)
+      let row = workSessionRowPresentation(session: session, summary: nil, now: now)
+      XCTAssertEqual(row.badge?.kind, .done)
+      XCTAssertEqual(row.badge?.label, "Done")
+      XCTAssertEqual(row.badge?.tone, .emerald)
+      XCTAssertEqual(row.tone, .emerald)
     }
   }
 
-  // MARK: - The status slot (`workSessionStatusPresentation`)
+  // MARK: - The status slot (`WorkSessionRowPresentation.status`)
   //
   // The row renders ONE status slot, and it needs the two fields `SessionBadge`
   // drops: `showsElapsed` and `prominent`. Prominence drives the recede rule —
@@ -542,8 +463,8 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     ]
 
     for (name, session) in prominent {
-      let presentation = workSessionStatusPresentation(session: session, summary: nil, now: now)
-      XCTAssertEqual(presentation?.prominent, true, name)
+      let status = workSessionRowPresentation(session: session, summary: nil, now: now).status
+      XCTAssertEqual(status?.prominent, true, name)
     }
   }
 
@@ -570,8 +491,8 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     ]
 
     for (name, session, summary) in notProminent {
-      let presentation = workSessionStatusPresentation(session: session, summary: summary, now: now)
-      XCTAssertEqual(presentation?.prominent, false, name)
+      let status = workSessionRowPresentation(session: session, summary: summary, now: now).status
+      XCTAssertEqual(status?.prominent, false, name)
     }
     // `starting` has no constructible session — `workCanonicalSessionState`
     // never returns it — so its prominence is asserted against the shared table
@@ -589,9 +510,10 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
       toolType: "codex-chat",
       settledAt: iso(now.addingTimeInterval(-120))
     )
-    XCTAssertNil(workSessionStatusPresentation(session: settled, summary: nil, now: now))
+    let row = workSessionRowPresentation(session: settled, summary: nil, now: now)
+    XCTAssertNil(row.status)
     // The out-of-context capsule is unaffected — only the slot goes quiet.
-    XCTAssertEqual(workSessionStatusBadge(session: settled, summary: nil, now: now)?.kind, .done)
+    XCTAssertEqual(row.badge?.kind, .done)
   }
 
   /// Snooze is a visibility overlay and an overlay must YIELD to a raised hand,
@@ -607,11 +529,11 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     )
     blocked.pendingInputItemId = "item-1"
 
-    let presentation = workSessionStatusPresentation(session: blocked, summary: nil, now: now)
-    XCTAssertEqual(presentation?.kind, .needsYou)
-    XCTAssertEqual(presentation?.label, "Needs you")
-    XCTAssertEqual(presentation?.tone, .amber)
-    XCTAssertEqual(presentation?.prominent, true)
+    let status = workSessionRowPresentation(session: blocked, summary: nil, now: now).status
+    XCTAssertEqual(status?.kind, .needsYou)
+    XCTAssertEqual(status?.label, "Needs you")
+    XCTAssertEqual(status?.tone, .amber)
+    XCTAssertEqual(status?.prominent, true)
     // The raw column read is untouched — the overlay only lost the slot.
     XCTAssertTrue(blocked.isSnoozed(now: now))
   }
@@ -621,13 +543,13 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
   func testSnoozedCalmRowShowsItsWakeLabel() {
     let calm = snoozedSession(untilOffset: 1_800, atOffset: -60)
 
-    let presentation = workSessionStatusPresentation(session: calm, summary: nil, now: now)
-    XCTAssertEqual(presentation?.label, "wakes in 30m")
-    XCTAssertEqual(presentation?.tone, .neutral)
-    XCTAssertEqual(presentation?.prominent, false)
-    XCTAssertEqual(presentation?.showsElapsed, false)
+    let status = workSessionRowPresentation(session: calm, summary: nil, now: now).status
+    XCTAssertEqual(status?.label, "wakes in 30m")
+    XCTAssertEqual(status?.tone, .neutral)
+    XCTAssertEqual(status?.prominent, false)
+    XCTAssertEqual(status?.showsElapsed, false)
     // Snoozed is not a badge identity, so it carries no `SessionBadgeKind`.
-    XCTAssertNil(presentation?.kind)
+    XCTAssertNil(status?.kind)
   }
 
   /// Planning is a presentation fact derived from the chat's interaction mode,
@@ -637,7 +559,10 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     let summary = makeChatSummary(status: "active", awaitingInput: false, interactionMode: "plan")
 
     XCTAssertEqual(workCanonicalSessionState(session: session, summary: summary, now: now).phase, .running)
-    XCTAssertEqual(workSessionStatusBadge(session: session, summary: summary, now: now)?.kind, .planning)
+    XCTAssertEqual(
+      workSessionRowPresentation(session: session, summary: summary, now: now).badge?.kind,
+      .planning
+    )
   }
 
   /// A blocked session is amber whatever mode it is in — planning must never
@@ -651,7 +576,10 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     )
     let summary = makeChatSummary(status: "active", awaitingInput: false, interactionMode: "plan")
 
-    XCTAssertEqual(workSessionStatusBadge(session: session, summary: summary, now: now)?.kind, .needsYou)
+    XCTAssertEqual(
+      workSessionRowPresentation(session: session, summary: summary, now: now).badge?.kind,
+      .needsYou
+    )
   }
 
   func testCanonicalPhasesMapOntoTheSharedVocabulary() {

--- a/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
+++ b/apps/ios/ADETests/WorkSessionCanonicalStateTests.swift
@@ -3,7 +3,8 @@ import XCTest
 
 /// Table-driven coverage for the Work-tab canonical session vocabulary — the
 /// iOS mirror of desktop `sessionCanonicalState.ts`. Locks the precedence chain,
-/// the exact 3-hour stale boundary, and the no-badge-for-calm-states rule.
+/// the exact 3-hour stale boundary, and the single-derivation contract between
+/// `workSessionRowPresentation` and its wrappers.
 final class WorkSessionCanonicalStateTests: XCTestCase {
   private let now = Date(timeIntervalSince1970: 1_780_000_000)
 
@@ -16,6 +17,20 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
   /// lastActivityAt for a session that has been silent for `seconds`.
   private func silentFor(_ seconds: TimeInterval) -> String {
     iso(now.addingTimeInterval(-seconds))
+  }
+
+  /// The attention third of the vocabulary: the phases something downstream may
+  /// reasonably treat as "act on this". `CanonicalSessionState` carries a phase
+  /// and nothing else, so "this state is calm" is asserted here rather than
+  /// against a presentation field riding along on the state value.
+  private func isAttentionPhase(_ phase: CanonicalSessionPhase) -> Bool {
+    phase == .needsYou || phase == .failed || phase == .stale
+  }
+
+  /// The capsule word a phase wears, read out of the exact table the row renders
+  /// from — so a reworded vocabulary entry fails here too.
+  private func phaseLabel(_ phase: CanonicalSessionPhase) -> String {
+    ActivityPhaseVocabulary.presentation(for: workActivityPhase(for: phase)).label
   }
 
   // MARK: - Precedence
@@ -63,8 +78,8 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
         now: now
       )
       XCTAssertEqual(state.phase, .needsYou, c.name)
-      XCTAssertEqual(state.badge?.kind, .needsYou, c.name)
-      XCTAssertEqual(state.badge?.label, "Needs you", c.name)
+      XCTAssertTrue(isAttentionPhase(state.phase), c.name)
+      XCTAssertEqual(phaseLabel(state.phase), "Needs you", c.name)
     }
   }
 
@@ -94,18 +109,16 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
   func testStoppedDisposedSessionsAreNotFailed() {
     let disposed = workCanonicalSessionState(status: "disposed", runtimeState: "killed", toolType: "codex", exitCode: nil, now: now)
     XCTAssertEqual(disposed.phase, .stopped)
-    XCTAssertNil(disposed.badge)
 
     let userStop = workCanonicalSessionState(status: "disposed", runtimeState: "killed", toolType: "codex", exitCode: 130, now: now)
     XCTAssertEqual(userStop.phase, .stopped)
-    XCTAssertNil(userStop.badge)
   }
 
   func testFailedOnlyForEndedNonCleanExitOrKilled() {
     // Non-zero exit on an ended session → failed.
     let failedExit = workCanonicalSessionState(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 1, now: now)
     XCTAssertEqual(failedExit.phase, .failed)
-    XCTAssertEqual(failedExit.badge?.label, "Failed")
+    XCTAssertEqual(phaseLabel(failedExit.phase), "Failed")
 
     // Killed runtime → failed even with a nil exit code.
     let killed = workCanonicalSessionState(status: "ended", runtimeState: "killed", toolType: "codex", exitCode: nil, now: now)
@@ -114,13 +127,11 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     // Clean exit (0) → ended: process completion is not a lifecycle declaration.
     let clean = workCanonicalSessionState(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 0, now: now)
     XCTAssertEqual(clean.phase, .ended)
-    XCTAssertNil(clean.badge)
 
     // A non-zero exit while still running is ignored (failure is an ended-only
     // signal); the session stays running.
     let runningWithCode = workCanonicalSessionState(status: "running", runtimeState: "running", toolType: "codex", lastActivityAt: iso(now), exitCode: 5, now: now)
     XCTAssertEqual(runningWithCode.phase, .running)
-    XCTAssertNil(runningWithCode.badge)
   }
 
   func testStaleBoundaryIsExactlyThreeHours() {
@@ -133,7 +144,6 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
       now: now
     )
     XCTAssertEqual(justUnder.phase, .running)
-    XCTAssertNil(justUnder.badge)
 
     // Exactly at the threshold → stale.
     let exactly = workCanonicalSessionState(
@@ -144,8 +154,8 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
       now: now
     )
     XCTAssertEqual(exactly.phase, .stale)
-    XCTAssertEqual(exactly.badge?.kind, .stale)
-    XCTAssertEqual(exactly.badge?.label, "Stale")
+    XCTAssertTrue(isAttentionPhase(exactly.phase))
+    XCTAssertEqual(phaseLabel(exactly.phase), "Stale")
   }
 
   func testStaleBeatsRunningPreviewHeuristic() {
@@ -191,7 +201,6 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
       now: now
     )
     XCTAssertEqual(state.phase, .ended)
-    XCTAssertNil(state.badge)
   }
 
   func testBenignPreviewLeavesRunningCalm() {
@@ -204,31 +213,26 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
       now: now
     )
     XCTAssertEqual(state.phase, .running)
-    XCTAssertNil(state.badge)
   }
 
-  // MARK: - No badge for calm states
+  // MARK: - Calm states are not attention states
 
-  func testCalmStatesCarryNoBadge() {
+  func testCalmStatesCarryNoAttention() {
     // Fresh running CLI.
     let running = workCanonicalSessionState(status: "running", runtimeState: "running", toolType: "codex", lastActivityAt: iso(now), now: now)
     XCTAssertEqual(running.phase, .running)
-    XCTAssertNil(running.badge)
 
     // Idle chat rests between turns → ready.
     let idleChat = workCanonicalSessionState(status: "running", runtimeState: "idle", toolType: "codex-chat", lastActivityAt: iso(now), now: now)
     XCTAssertEqual(idleChat.phase, .ready)
-    XCTAssertNil(idleChat.badge)
 
     // Idle CLI → idle (calm, no deterministic ask).
     let idleCli = workCanonicalSessionState(status: "running", runtimeState: "idle", toolType: "codex", lastActivityAt: iso(now), now: now)
     XCTAssertEqual(idleCli.phase, .idle)
-    XCTAssertNil(idleCli.badge)
 
     // Ended chat rests, ready for input — never "ended".
     let endedChat = workCanonicalSessionState(status: "ended", runtimeState: "exited", toolType: "codex-chat", exitCode: 0, now: now)
     XCTAssertEqual(endedChat.phase, .ready)
-    XCTAssertNil(endedChat.badge)
   }
 
   // MARK: - Chat-tool predicate
@@ -244,10 +248,10 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
 
   // MARK: - Row wrapper (iOS field mapping)
 
-  func testCapsuleBadgeMapsChatAwaitingInputToNeedsYou() {
+  func testStatusBadgeMapsChatAwaitingInputToNeedsYou() {
     let session = makeSession(status: "running", runtimeState: "running", toolType: "codex-chat")
     let summary = makeChatSummary(status: "active", awaitingInput: true)
-    let badge = workSessionCapsuleBadge(session: session, summary: summary, now: now)
+    let badge = workSessionStatusBadge(session: session, summary: summary, now: now)
     XCTAssertEqual(badge?.kind, .needsYou)
   }
 
@@ -273,30 +277,132 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     )
   }
 
-  func testCapsuleBadgeSurfacesFailedExit() {
+  func testStatusBadgeSurfacesFailedExit() {
     let session = makeSession(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 130)
-    let badge = workSessionCapsuleBadge(session: session, summary: nil, now: now)
+    let badge = workSessionStatusBadge(session: session, summary: nil, now: now)
     XCTAssertEqual(badge?.kind, .failed)
   }
 
-  func testCapsuleBadgeNilForStoppedDisposedSession() {
+  func testStatusBadgeNilForStoppedDisposedSession() {
     let session = makeSession(status: "disposed", runtimeState: "killed", toolType: "codex", exitCode: 130)
-    let badge = workSessionCapsuleBadge(session: session, summary: nil, now: now)
+    let badge = workSessionStatusBadge(session: session, summary: nil, now: now)
     XCTAssertNil(badge)
   }
 
-  func testCapsuleBadgeNilForFreshRunning() {
+  /// A fresh running session is calm but not silent: it wears the descriptive
+  /// "Working" capsule, never one of the three attention identities.
+  func testStatusBadgeIsWorkingNotAttentionForFreshRunning() {
     let session = makeSession(status: "running", runtimeState: "running", toolType: "codex", startedAt: iso(now))
-    let badge = workSessionCapsuleBadge(session: session, summary: nil, now: now)
-    XCTAssertNil(badge)
+    let badge = workSessionStatusBadge(session: session, summary: nil, now: now)
+    XCTAssertEqual(badge?.kind, .working)
+  }
+
+  // MARK: - One derivation per row
+
+  /// The contract that keeps the three wrappers honest: they are reads of
+  /// `workSessionRowPresentation`, not independent derivations. If any of them
+  /// ever grows its own copy of the phase or planning fold this fails, which is
+  /// the whole point — four derivations per row also meant four `Date()` calls,
+  /// so a row rebuilt across the stale or snooze boundary could paint its
+  /// capsule from one instant and its status slot from another.
+  func testRowPresentationAgreesWithEveryWrapper() {
+    var staleSummary = makeChatSummary(status: "active", awaitingInput: false)
+    staleSummary.lastActivityAt = silentFor(sessionStaleAfterSeconds + 60)
+
+    let cases: [(name: String, session: TerminalSessionSummary, summary: AgentChatSessionSummary?)] = [
+      (
+        "needs-you",
+        makeSession(status: "running", runtimeState: "running", toolType: "codex-chat"),
+        makeChatSummary(status: "active", awaitingInput: true)
+      ),
+      (
+        "running",
+        makeSession(status: "running", runtimeState: "running", toolType: "codex", startedAt: iso(now)),
+        nil
+      ),
+      (
+        "running + planning",
+        makeSession(status: "running", runtimeState: "running", toolType: "codex-chat", startedAt: iso(now)),
+        makeChatSummary(status: "active", awaitingInput: false, interactionMode: "plan")
+      ),
+      (
+        "ready",
+        makeSession(status: "ended", runtimeState: "exited", toolType: "codex-chat", exitCode: 0),
+        nil
+      ),
+      (
+        "failed",
+        makeSession(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 1),
+        nil
+      ),
+      (
+        "stale",
+        makeSession(status: "running", runtimeState: "running", toolType: "codex-chat"),
+        staleSummary
+      ),
+      (
+        "settled",
+        makeSession(status: "running", runtimeState: "idle", toolType: "codex-chat", settledAt: iso(now)),
+        nil
+      ),
+      ("snoozed", snoozedSession(untilOffset: 3_600, atOffset: -60), nil),
+    ]
+
+    for testCase in cases {
+      let row = workSessionRowPresentation(
+        session: testCase.session,
+        summary: testCase.summary,
+        now: now
+      )
+      XCTAssertEqual(
+        row.phase,
+        workCanonicalSessionState(session: testCase.session, summary: testCase.summary, now: now).phase,
+        testCase.name
+      )
+      XCTAssertEqual(
+        row.badge,
+        workSessionStatusBadge(session: testCase.session, summary: testCase.summary, now: now),
+        testCase.name
+      )
+      XCTAssertEqual(
+        row.tone,
+        workSessionRowTone(session: testCase.session, summary: testCase.summary, now: now),
+        testCase.name
+      )
+      XCTAssertEqual(
+        row.status,
+        workSessionStatusPresentation(session: testCase.session, summary: testCase.summary, now: now),
+        testCase.name
+      )
+    }
+  }
+
+  /// The two states whose capsule and status slot deliberately disagree, so the
+  /// agreement test above cannot be satisfied by a wrapper that simply returns
+  /// the same thing for everything.
+  func testRowPresentationKeepsCapsuleAndSlotIndependent() {
+    let settled = workSessionRowPresentation(
+      session: makeSession(status: "running", runtimeState: "idle", toolType: "codex-chat", settledAt: iso(now)),
+      summary: nil,
+      now: now
+    )
+    XCTAssertEqual(settled.badge?.kind, .done, "a settled row still reads Done out of context")
+    XCTAssertNil(settled.status, "but its status slot belongs to the timestamp")
+
+    let snoozed = workSessionRowPresentation(
+      session: snoozedSession(untilOffset: 25 * 60, atOffset: -60),
+      summary: nil,
+      now: now
+    )
+    XCTAssertEqual(snoozed.badge?.kind, .working, "the capsule reports the state the row is actually in")
+    XCTAssertEqual(snoozed.status?.label, "wakes in 25m", "the slot carries the return ticket instead")
   }
 
   // MARK: - The full status vocabulary
   //
-  // `badge` stays the attention third — the three states something downstream
-  // may reasonably treat as "act on this". `workSessionStatusBadge` is the wider
-  // vocabulary the row renders, and every word and hue in it comes from the
-  // shared `ActivityPhaseVocabulary`, not from a second table here.
+  // `workSessionStatusBadge` is the whole vocabulary the row renders, not just
+  // the attention third, and every word and hue in it comes from the shared
+  // `ActivityPhaseVocabulary`, not from a second table here.
 
   func testStatusBadgeCoversTheDescriptiveStates() {
     struct Case {
@@ -386,17 +492,142 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     }
   }
 
-  /// Resting states still earn no capsule: the row must not shift layout to say
-  /// that nothing is happening.
-  func testStatusBadgeStaysNilForRestingStates() {
-    let ready = makeSession(status: "ended", runtimeState: "exited", toolType: "codex-chat")
-    let idle = makeSession(status: "running", runtimeState: "idle", toolType: "codex")
+  /// Stopped and ended earn no capsule: the row must not shift layout to say
+  /// that nothing is happening. Ready and idle are NOT in that set — they are
+  /// finished outcomes nobody has looked at, so they read emerald "Done".
+  func testStatusBadgeStaysNilForStoppedAndEnded() {
     let stopped = makeSession(status: "disposed", runtimeState: "killed", toolType: "codex", exitCode: 130)
+    let ended = makeSession(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 0)
 
-    for session in [ready, idle, stopped] {
+    for session in [stopped, ended] {
       XCTAssertNil(workSessionStatusBadge(session: session, summary: nil, now: now))
       XCTAssertEqual(workSessionRowTone(session: session, summary: nil, now: now), .neutral)
     }
+  }
+
+  /// The ready/idle drift correction, at the badge level. Before this, both
+  /// resolved to a nil badge and a neutral dot, which left a finished session
+  /// indistinguishable from a dead one.
+  func testReadyAndIdleReadAsDone() {
+    let readyChat = makeSession(status: "ended", runtimeState: "exited", toolType: "codex-chat")
+    let idleCli = makeSession(status: "running", runtimeState: "idle", toolType: "codex")
+
+    for session in [readyChat, idleCli] {
+      let badge = workSessionStatusBadge(session: session, summary: nil, now: now)
+      XCTAssertEqual(badge?.kind, .done)
+      XCTAssertEqual(badge?.label, "Done")
+      XCTAssertEqual(badge?.tone, .emerald)
+      XCTAssertEqual(workSessionRowTone(session: session, summary: nil, now: now), .emerald)
+    }
+  }
+
+  // MARK: - The status slot (`workSessionStatusPresentation`)
+  //
+  // The row renders ONE status slot, and it needs the two fields `SessionBadge`
+  // drops: `showsElapsed` and `prominent`. Prominence drives the recede rule —
+  // non-prominent rows fade to 70% — so getting it wrong is what makes a list
+  // read as undifferentiated noise.
+
+  /// The states that pull the eye: something wants a human, or something
+  /// finished and nobody has looked.
+  func testProminentStatesAreTheOnesWantingAHuman() {
+    let prominent: [(String, TerminalSessionSummary)] = [
+      (
+        "needs you",
+        makeSession(status: "running", runtimeState: "running", toolType: "codex-chat", pendingInputItemId: "ask-1")
+      ),
+      ("failed", makeSession(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 130)),
+      ("ready", makeSession(status: "ended", runtimeState: "exited", toolType: "codex-chat")),
+      ("idle", makeSession(status: "running", runtimeState: "idle", toolType: "codex")),
+    ]
+
+    for (name, session) in prominent {
+      let presentation = workSessionStatusPresentation(session: session, summary: nil, now: now)
+      XCTAssertEqual(presentation?.prominent, true, name)
+    }
+  }
+
+  /// Work in flight is deliberately NOT prominent: an agent mid-turn is not yet
+  /// your problem, and a state that is true but not actionable makes no claim.
+  func testNonProminentStatesRecede() {
+    let stale = makeSession(status: "running", runtimeState: "running", toolType: "codex-chat")
+    var staleSummary = makeChatSummary(status: "active", awaitingInput: false)
+    staleSummary.lastActivityAt = silentFor(sessionStaleAfterSeconds + 60)
+
+    let notProminent: [(String, TerminalSessionSummary, AgentChatSessionSummary?)] = [
+      (
+        "running",
+        makeSession(status: "running", runtimeState: "running", toolType: "codex", startedAt: iso(now)),
+        nil
+      ),
+      ("stale", stale, staleSummary),
+      (
+        "stopped",
+        makeSession(status: "disposed", runtimeState: "killed", toolType: "codex", exitCode: 130),
+        nil
+      ),
+      ("ended", makeSession(status: "ended", runtimeState: "exited", toolType: "codex", exitCode: 0), nil),
+    ]
+
+    for (name, session, summary) in notProminent {
+      let presentation = workSessionStatusPresentation(session: session, summary: summary, now: now)
+      XCTAssertEqual(presentation?.prominent, false, name)
+    }
+    // `starting` has no constructible session — `workCanonicalSessionState`
+    // never returns it — so its prominence is asserted against the shared table
+    // the slot reads from.
+    XCTAssertFalse(ActivityPhaseVocabulary.presentation(for: workActivityPhase(for: .starting)).prominent)
+  }
+
+  /// Settled is the deliberate hole in the vocabulary: desktop returns `null`
+  /// so the row's timestamp owns the slot, because in the collapsed tail the
+  /// section itself is already the status.
+  func testSettledHasNoStatusPresentation() {
+    let settled = makeSession(
+      status: "running",
+      runtimeState: "idle",
+      toolType: "codex-chat",
+      settledAt: iso(now.addingTimeInterval(-120))
+    )
+    XCTAssertNil(workSessionStatusPresentation(session: settled, summary: nil, now: now))
+    // The out-of-context capsule is unaffected — only the slot goes quiet.
+    XCTAssertEqual(workSessionStatusBadge(session: settled, summary: nil, now: now)?.kind, .done)
+  }
+
+  /// Snooze is a visibility overlay and an overlay must YIELD to a raised hand,
+  /// matching `isSessionFiledAsSnoozed`. Otherwise an "until I'm asked" window
+  /// (~100 years) makes the row say "wakes when asked" while it is blocked on
+  /// the user right now.
+  func testSnoozeYieldsToNeedsYouInTheStatusSlot() {
+    var blocked = snoozedSession(
+      untilOffset: TimeInterval(workSnoozeIndefiniteDays) * 86_400,
+      atOffset: -60,
+      status: "running",
+      runtimeState: "waiting-input"
+    )
+    blocked.pendingInputItemId = "item-1"
+
+    let presentation = workSessionStatusPresentation(session: blocked, summary: nil, now: now)
+    XCTAssertEqual(presentation?.kind, .needsYou)
+    XCTAssertEqual(presentation?.label, "Needs you")
+    XCTAssertEqual(presentation?.tone, .amber)
+    XCTAssertEqual(presentation?.prominent, true)
+    // The raw column read is untouched — the overlay only lost the slot.
+    XCTAssertTrue(blocked.isSnoozed(now: now))
+  }
+
+  /// For every calm phase the return ticket IS the status, so the wake label
+  /// takes the slot and the row recedes.
+  func testSnoozedCalmRowShowsItsWakeLabel() {
+    let calm = snoozedSession(untilOffset: 1_800, atOffset: -60)
+
+    let presentation = workSessionStatusPresentation(session: calm, summary: nil, now: now)
+    XCTAssertEqual(presentation?.label, "wakes in 30m")
+    XCTAssertEqual(presentation?.tone, .neutral)
+    XCTAssertEqual(presentation?.prominent, false)
+    XCTAssertEqual(presentation?.showsElapsed, false)
+    // Snoozed is not a badge identity, so it carries no `SessionBadgeKind`.
+    XCTAssertNil(presentation?.kind)
   }
 
   /// Planning is a presentation fact derived from the chat's interaction mode,
@@ -430,8 +661,12 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     XCTAssertEqual(workActivityPhase(for: .failed), .failed)
     XCTAssertEqual(workActivityPhase(for: .stale), .stale)
     XCTAssertEqual(workActivityPhase(for: .settled), .completed)
-    XCTAssertEqual(workActivityPhase(for: .ready), .unrecognized("ready"))
-    XCTAssertEqual(workActivityPhase(for: .idle), .unrecognized("idle"))
+    // Ready and idle are emerald "Done", matching desktop's `PHASE_PRESENTATION`.
+    // They used to resolve to the neutral "Ready"/"Idle" entries, which is the
+    // drift this corrects: a finished-but-unlooked-at row is an outcome, and
+    // outcomes are emerald.
+    XCTAssertEqual(workActivityPhase(for: .ready), .completed)
+    XCTAssertEqual(workActivityPhase(for: .idle), .completed)
     XCTAssertEqual(workActivityPhase(for: .stopped), .unrecognized("stopped"))
     XCTAssertEqual(workActivityPhase(for: .ended), .unrecognized("ended"))
   }
@@ -461,21 +696,21 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     summary.lastOutputPreview = "\u{001B}[33mFresh provider output\u{001B}[0m"
 
     XCTAssertEqual(
-      workSessionRowPreviewSource(session: session, chatSummary: summary, isSettled: false),
+      workSessionRowPreviewSource(session: session, chatSummary: summary, isSettled: false)?.text,
       "Fresh provider output"
     )
 
     summary.lastOutputPreview = nil
     session.lastOutputPreview = nil
     XCTAssertEqual(
-      workSessionRowPreviewSource(session: session, chatSummary: summary, isSettled: false),
+      workSessionRowPreviewSource(session: session, chatSummary: summary, isSettled: false)?.text,
       "Older chat summary"
     )
 
     summary.summary = nil
     session.summary = nil
     XCTAssertEqual(
-      workSessionRowPreviewSource(session: session, chatSummary: summary, isSettled: false),
+      workSessionRowPreviewSource(session: session, chatSummary: summary, isSettled: false)?.text,
       "Older chat goal"
     )
   }
@@ -489,18 +724,18 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     )
     session.statusNote = "Running focused tests"
     XCTAssertEqual(
-      workSessionRowPreviewSource(session: session, chatSummary: nil, isSettled: false),
+      workSessionRowPreviewSource(session: session, chatSummary: nil, isSettled: false)?.text,
       "Running focused tests"
     )
     XCTAssertEqual(
-      workSessionRowPreviewSource(session: session, chatSummary: nil, isSettled: true),
+      workSessionRowPreviewSource(session: session, chatSummary: nil, isSettled: true)?.text,
       "Done: Running focused tests"
     )
 
     session.attentionRequestedAt = iso(now)
     session.attentionMessage = "Choose the release target"
     XCTAssertEqual(
-      workSessionRowPreviewSource(session: session, chatSummary: nil, isSettled: true),
+      workSessionRowPreviewSource(session: session, chatSummary: nil, isSettled: true)?.text,
       "Choose the release target"
     )
   }
@@ -866,7 +1101,6 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
   func testActiveOverrideKeepsCleanExitEnded() {
     let result = cleanExitState(settleOverride: "active")
     XCTAssertEqual(result.phase, .ended)
-    XCTAssertNil(result.badge)
   }
 
   func testActiveOverrideAlsoSuppressesDeclaredSettle() {
@@ -1182,23 +1416,48 @@ final class WorkSessionCanonicalStateTests: XCTestCase {
     XCTAssertFalse(groups[0].isQuiet)
   }
 
-  func testStatusAndTimeGroupsAreNeverQuiet() {
-    // Quiet is a lane-folder affordance; status/time sections span lanes and
-    // keep their normal headers.
+  func testOnlyTheTrailingShelvesAreQuietInStatusAndTimeGroups() {
+    // Quiet used to be a lane-folder affordance only, and this test used to
+    // assert that status/time modes produced no quiet group at all. The quiet
+    // zone changed that on purpose: those two modes now close with Snoozed and
+    // Settled shelves, which ARE quiet so they render the thin collapsed form.
+    //
+    // The invariant that survives — and the one worth pinning — is narrower:
+    // quietness is confined to those trailing shelves. An ordinary section
+    // ("Your move", "Working", a time bucket) must never fold itself away.
     var settled = makeSession(status: "completed", runtimeState: "idle", toolType: "claude-chat")
     settled.id = "s-settled"
     settled.settledAt = iso(now.addingTimeInterval(-120))
 
+    var running = makeSession(status: "running", runtimeState: "running", toolType: "claude-chat")
+    running.id = "s-running"
+
     for organization in [WorkSessionOrganization.byStatus, .byTime] {
       let groups = workSessionGroups(
         organization: organization,
-        sessions: [settled],
+        sessions: [settled, running],
         chatSummaries: [:],
         archivedSessionIds: [],
         orderedLanes: [makeLane(id: "lane-1", name: "Lane 1")],
         now: now
       )
-      XCTAssertFalse(groups.contains(where: \.isQuiet), "\(organization) produced a quiet group")
+
+      for group in groups where group.isQuiet {
+        XCTAssertTrue(
+          group.isShelf,
+          "\(organization) marked non-shelf section \(group.id) quiet"
+        )
+      }
+
+      // The settled row is lifted out of its ordinary section onto the shelf.
+      let settledShelf = groups.first { $0.isShelf && $0.sessions.contains { $0.id == settled.id } }
+      XCTAssertNotNil(settledShelf, "\(organization) did not file the settled row onto a shelf")
+      XCTAssertTrue(settledShelf?.isQuiet == true)
+
+      // …and the live row stays in a normal, non-quiet section.
+      let runningGroup = groups.first { $0.sessions.contains { $0.id == running.id } }
+      XCTAssertNotNil(runningGroup)
+      XCTAssertFalse(runningGroup?.isQuiet ?? true, "\(organization) folded a live row into a shelf")
     }
   }
 

--- a/apps/ios/ADETests/WorkSessionGroupingTests.swift
+++ b/apps/ios/ADETests/WorkSessionGroupingTests.swift
@@ -286,6 +286,265 @@ final class WorkSessionGroupingTests: XCTestCase {
     )
   }
 
+  // MARK: - The quiet zone
+
+  /// Every list closes the same way: Snoozed above Settled. Snoozed work is
+  /// dated and will re-enter the live rows, settled work is finished, so the
+  /// shelf nearer the live rows is the one that comes back.
+  func testByStatusClosesWithSnoozedAboveSettled() {
+    let lane = makeLane(id: "lane-a", name: "feature/one")
+    let presentation = makePresentation(
+      sessions: [
+        makeSession(id: "s-live", laneId: lane.id),
+        makeSession(id: "s-settled", laneId: lane.id, settledAt: iso(now.addingTimeInterval(-60))),
+        makeSession(
+          id: "s-snoozed",
+          laneId: lane.id,
+          snoozedUntil: iso(now.addingTimeInterval(3600)),
+          snoozedAt: iso(now.addingTimeInterval(-60))
+        ),
+      ],
+      lanes: [lane],
+      organization: .byStatus
+    )
+
+    XCTAssertEqual(
+      presentation.sessionGroups.map(\.id),
+      ["status:running", workSnoozedSectionId, workSettledSectionId]
+    )
+    XCTAssertEqual(presentation.sessionGroups.last?.sessions.map(\.id), ["s-settled"])
+  }
+
+  func testByTimeClosesWithSnoozedAboveSettled() {
+    let lane = makeLane(id: "lane-a", name: "feature/one")
+    let presentation = makePresentation(
+      sessions: [
+        makeSession(id: "s-live", laneId: lane.id),
+        makeSession(id: "s-settled", laneId: lane.id, settledAt: iso(now.addingTimeInterval(-60))),
+        makeSession(
+          id: "s-snoozed",
+          laneId: lane.id,
+          snoozedUntil: iso(now.addingTimeInterval(3600)),
+          snoozedAt: iso(now.addingTimeInterval(-60))
+        ),
+      ],
+      lanes: [lane],
+      organization: .byTime
+    )
+
+    XCTAssertEqual(
+      Array(presentation.sessionGroups.map(\.id).suffix(2)),
+      [workSnoozedSectionId, workSettledSectionId]
+    )
+    XCTAssertFalse(
+      presentation.sessionGroups.dropLast(2).contains { $0.sessions.contains { $0.id == "s-settled" } },
+      "a lifted settled row must not also remain in its time bucket"
+    )
+  }
+
+  /// By-lane has no global settled shelf on purpose: a settled row still belongs
+  /// to its lane, and lifting settled rows out globally would leave lanes empty
+  /// and make the per-lane quiet fold unreachable.
+  func testByLaneKeepsSettledRowsInsideTheirLane() {
+    let lane = makeLane(id: "lane-a", name: "feature/one")
+    let presentation = makePresentation(
+      sessions: [
+        makeSession(id: "s-live", laneId: lane.id),
+        makeSession(id: "s-settled", laneId: lane.id, settledAt: iso(now.addingTimeInterval(-60))),
+      ],
+      lanes: [lane],
+      organization: .byLane
+    )
+
+    XCTAssertEqual(presentation.sessionGroups.map(\.id), ["lane:lane-a"])
+    XCTAssertEqual(presentation.sessionGroups.first?.sessions.map(\.id), ["s-live", "s-settled"])
+    XCTAssertFalse(presentation.sessionGroups.contains { $0.isShelf })
+  }
+
+  /// The fold this exemption exists to protect.
+  func testByLaneStillFoldsAnAllQuietLane() {
+    let lane = makeLane(id: "lane-a", name: "feature/one")
+    let presentation = makePresentation(
+      sessions: [
+        makeSession(id: "s-1", laneId: lane.id, settledAt: iso(now.addingTimeInterval(-60))),
+        makeSession(id: "s-2", laneId: lane.id, settledAt: iso(now.addingTimeInterval(-90))),
+      ],
+      lanes: [lane],
+      organization: .byLane
+    )
+
+    XCTAssertEqual(presentation.sessionGroups.map(\.id), ["lane:lane-a"])
+    XCTAssertEqual(presentation.sessionGroups.first?.isQuiet, true)
+    XCTAssertEqual(presentation.sessionGroups.first?.isShelf, false)
+  }
+
+  /// `collapsedSectionIds` lists what IS collapsed, so it cannot express
+  /// "collapsed by default". Both shelves therefore record the opposite fact
+  /// under a `shelf-open:` marker, and stay collapsed while it is absent.
+  func testQuietShelvesAreCollapsedUntilTheirOpenMarkerIsPresent() {
+    let lane = makeLane(id: "lane-a", name: "feature/one")
+    let presentation = makePresentation(
+      sessions: [
+        makeSession(id: "s-settled", laneId: lane.id, settledAt: iso(now.addingTimeInterval(-60))),
+        makeSession(
+          id: "s-snoozed",
+          laneId: lane.id,
+          snoozedUntil: iso(now.addingTimeInterval(3600)),
+          snoozedAt: iso(now.addingTimeInterval(-60))
+        ),
+      ],
+      lanes: [lane],
+      organization: .byStatus
+    )
+
+    let shelves = presentation.sessionGroups.filter(\.isShelf)
+    XCTAssertEqual(shelves.map(\.id), [workSnoozedSectionId, workSettledSectionId])
+    XCTAssertEqual(
+      shelves.map(\.quietOpenSectionId),
+      ["shelf-open:status:snoozed", "shelf-open:status:settled"]
+    )
+    // A shelf renders through the quiet-header form, which is what makes the
+    // inverted marker the one the toggle writes.
+    XCTAssertTrue(shelves.allSatisfy(\.isQuiet))
+
+    // Untouched: no marker, so both are collapsed. Explicitly opened: marker
+    // present, and it survives a relaunch because it is what gets persisted.
+    var collapsed = workParseCollapsedSectionIds("")
+    XCTAssertTrue(shelves.allSatisfy { !collapsed.contains($0.quietOpenSectionId) })
+    collapsed.insert("shelf-open:status:settled")
+    XCTAssertEqual(
+      shelves.filter { collapsed.contains($0.quietOpenSectionId) }.map(\.id),
+      [workSettledSectionId]
+    )
+
+    // The shelf namespace must stay clear of the per-lane sweep, which only
+    // scans `lane-open:` and would otherwise treat a shelf as a stale lane.
+    XCTAssertFalse(shelves.contains { $0.quietOpenSectionId.hasPrefix("lane-open:") })
+  }
+
+  // MARK: - One clock per grouping pass
+
+  /// By-status used to read the wall clock while every sibling filing path (the
+  /// shelf lift, `workLaneGroupIsQuiet`, `isFiledAsSnoozed`) threaded the
+  /// caller's. This row is calm at `now` and silent past the stale threshold a
+  /// few hours later, so the two clocks file it under different headers — which
+  /// is exactly what a single threaded clock has to prevent.
+  func testByStatusFilesAgainstTheInjectedClock() {
+    let lane = makeLane(id: "lane-a", name: "feature/one")
+    let calm = makeSession(
+      id: "s-1",
+      laneId: lane.id,
+      runtimeState: "idle",
+      chatIdleSinceAt: iso(now.addingTimeInterval(-60))
+    )
+
+    XCTAssertEqual(
+      workSessionGroups(
+        organization: .byStatus,
+        sessions: [calm],
+        chatSummaries: [:],
+        archivedSessionIds: [],
+        orderedLanes: [lane],
+        now: now
+      ).map(\.id),
+      ["status:done"]
+    )
+
+    XCTAssertEqual(
+      workSessionGroups(
+        organization: .byStatus,
+        sessions: [calm],
+        chatSummaries: [:],
+        archivedSessionIds: [],
+        orderedLanes: [lane],
+        now: now.addingTimeInterval(sessionStaleAfterSeconds + 60)
+      ).map(\.id),
+      ["status:running"]
+    )
+  }
+
+  /// The contract the shared clock exists for: one session, one instant, the
+  /// same verdict on both paths. Settled here, so by-status lifts it onto the
+  /// quiet shelf and by-lane folds its lane into the quiet form — two shapes,
+  /// one reading of the row.
+  func testByStatusAndByLaneAgreeOnTheSameSessionAtTheSameInstant() {
+    let lane = makeLane(id: "lane-a", name: "feature/one")
+    let settled = makeSession(
+      id: "s-1",
+      laneId: lane.id,
+      settledAt: iso(now.addingTimeInterval(-60))
+    )
+
+    let byStatus = workSessionGroups(
+      organization: .byStatus,
+      sessions: [settled],
+      chatSummaries: [:],
+      archivedSessionIds: [],
+      orderedLanes: [lane],
+      now: now
+    )
+    XCTAssertEqual(byStatus.map(\.id), [workSettledSectionId])
+    XCTAssertEqual(byStatus.first?.isQuiet, true)
+    XCTAssertEqual(byStatus.first?.sessions.map(\.id), ["s-1"])
+
+    let byLane = workSessionGroups(
+      organization: .byLane,
+      sessions: [settled],
+      chatSummaries: [:],
+      archivedSessionIds: [],
+      orderedLanes: [lane],
+      now: now
+    )
+    XCTAssertEqual(byLane.map(\.id), ["lane:lane-a"])
+    XCTAssertEqual(byLane.first?.isQuiet, true)
+    XCTAssertEqual(byLane.first?.sessions.map(\.id), ["s-1"])
+  }
+
+  // MARK: - Finished is not "Your move"
+
+  /// Ready and idle are emerald "Done" — finished, unseen. Filing them under
+  /// the amber "Your move" header is the exact confusion the shared vocabulary
+  /// exists to kill: amber must mean a session blocked on the user, nothing else.
+  func testReadyAndIdleLandInDoneAndNeedsYouStaysInYourMove() {
+    let lane = makeLane(id: "lane-a", name: "feature/one")
+    let presentation = makePresentation(
+      sessions: [
+        makeSession(id: "s-needs-you", laneId: lane.id, pendingInputItemId: "item-1"),
+        // A chat resting between turns is `.ready`.
+        makeSession(id: "s-ready", laneId: lane.id, runtimeState: "idle"),
+        // The same shape on a non-chat tool is `.idle`.
+        makeSession(id: "s-idle", laneId: lane.id, toolType: "codex", runtimeState: "idle"),
+      ],
+      lanes: [lane],
+      organization: .byStatus
+    )
+
+    let sessionIdsBySectionId = Dictionary(
+      uniqueKeysWithValues: presentation.sessionGroups.map { ($0.id, $0.sessions.map(\.id)) }
+    )
+    XCTAssertEqual(sessionIdsBySectionId["status:awaiting"], ["s-needs-you"])
+    XCTAssertEqual(sessionIdsBySectionId["status:done"]?.sorted(), ["s-idle", "s-ready"])
+  }
+
+  /// Done sits between the row that wants you and the rows that are over.
+  func testDoneIsOrderedAfterYourMoveAndBeforeEnded() {
+    let lane = makeLane(id: "lane-a", name: "feature/one")
+    let presentation = makePresentation(
+      sessions: [
+        makeSession(id: "s-needs-you", laneId: lane.id, pendingInputItemId: "item-1"),
+        makeSession(id: "s-ready", laneId: lane.id, runtimeState: "idle"),
+        makeSession(id: "s-ended", laneId: lane.id, toolType: "codex", status: "detached", runtimeState: "exited"),
+      ],
+      lanes: [lane],
+      organization: .byStatus
+    )
+
+    XCTAssertEqual(
+      presentation.sessionGroups.map(\.id),
+      ["status:awaiting", "status:done", "status:ended"]
+    )
+  }
+
   // MARK: - Offline machine banner
 
   func testOfflineBannerSurfacesOneEntryPerMachineInThisProject() {
@@ -332,7 +591,8 @@ final class WorkSessionGroupingTests: XCTestCase {
     sessions: [TerminalSessionSummary],
     lanes: [LaneSummary],
     pinnedLaneIds: Set<String> = [],
-    searchText: String = ""
+    searchText: String = "",
+    organization: WorkSessionOrganization = .byLane
   ) -> WorkRootSessionPresentation {
     buildWorkRootSessionPresentation(
       sessions: sessions,
@@ -342,7 +602,7 @@ final class WorkSessionGroupingTests: XCTestCase {
       selectedStatus: .all,
       selectedLaneId: "all",
       searchText: searchText,
-      organization: .byLane,
+      organization: organization,
       orderedLanes: lanes,
       pinnedLaneIds: pinnedLaneIds,
       now: now
@@ -369,10 +629,15 @@ final class WorkSessionGroupingTests: XCTestCase {
     id: String,
     laneId: String,
     title: String = "Session",
+    toolType: String = "codex-chat",
     status: String = "running",
     runtimeState: String = "running",
     settledAt: String? = nil,
-    chatSessionId: String? = nil
+    snoozedUntil: String? = nil,
+    snoozedAt: String? = nil,
+    chatSessionId: String? = nil,
+    pendingInputItemId: String? = nil,
+    chatIdleSinceAt: String? = nil
   ) -> TerminalSessionSummary {
     TerminalSessionSummary(
       id: id,
@@ -383,13 +648,15 @@ final class WorkSessionGroupingTests: XCTestCase {
       pinned: false,
       manuallyNamed: nil,
       goal: nil,
-      toolType: "codex-chat",
+      toolType: toolType,
       title: title,
       status: status,
       startedAt: iso(now.addingTimeInterval(-300)),
       endedAt: nil,
       archivedAt: nil,
       settledAt: settledAt,
+      snoozedUntil: snoozedUntil,
+      snoozedAt: snoozedAt,
       exitCode: nil,
       transcriptPath: "",
       headShaStart: nil,
@@ -399,8 +666,9 @@ final class WorkSessionGroupingTests: XCTestCase {
       runtimeState: settledAt == nil ? runtimeState : "idle",
       resumeCommand: nil,
       resumeMetadata: nil,
-      chatIdleSinceAt: nil,
-      chatSessionId: chatSessionId
+      chatIdleSinceAt: chatIdleSinceAt,
+      chatSessionId: chatSessionId,
+      pendingInputItemId: pendingInputItemId
     )
   }
 

--- a/docs/features/sync-and-multi-device/ios-companion.md
+++ b/docs/features/sync-and-multi-device/ios-companion.md
@@ -350,6 +350,20 @@ apps/ios/
 │   │   │                            #   inline FilesQueryCard search cards),
 │   │   │                            # FilesWorkspacePickerDropdown
 │   │   ├── Work/                    # WorkRootScreen, WorkChatSessionView,
+│   │   │                            # WorkRootComponents (list chrome: one-row
+│   │   │                            #   header, filter panel, sticky lane
+│   │   │                            #   section headers, WorkSessionListRow
+│   │   │                            #   swipe/context-menu shell),
+│   │   │                            # WorkSessionRowCard (the row card itself:
+│   │   │                            #   WorkSessionRow, its leaf views, the
+│   │   │                            #   render signature, and the preview-line
+│   │   │                            #   helpers),
+│   │   │                            # WorkSessionCanonicalState (Swift mirror of
+│   │   │                            #   the shared derivation +
+│   │   │                            #   workSessionRowPresentation),
+│   │   │                            # WorkSessionGrouping (by-lane/status/time
+│   │   │                            #   groups, quiet-zone shelves,
+│   │   │                            #   WorkViewStateStore),
 │   │   │                            # Work*Helpers, WorkNewChatScreen (chat/CLI
 │   │   │                            #   launcher + per-project interface
 │   │   │                            #   preference shared with Hub),
@@ -495,8 +509,11 @@ apps/ios/
     │                                     # join delay, network fingerprint +
     │                                     # route memory, endpoint failure
     │                                     # memory, relay dial single-flight
-    └── WorkSessionCanonicalStateTests.swift # settle-override / snooze / filing
-                                     # parity against the shared TS derivation
+    ├── WorkSessionCanonicalStateTests.swift # settle-override / snooze / filing
+    │                                # parity against the shared TS derivation,
+    │                                # plus the row status-slot vocabulary
+    └── WorkSessionGroupingTests.swift # grouping, quiet lanes, and the
+                                     # Snoozed/Settled quiet-zone shelves
 ```
 
 Each tab is factored into a root screen, one `+Actions` extension for
@@ -1754,14 +1771,16 @@ blue `Working`, only a raised hand is amber, a clean unseen outcome is emerald
 
 The replicated `terminal_sessions` lifecycle columns flow through
 `Database.swift`, the active-project session summaries, and
-`RemoteRosterChat`. Status grouping includes a final Settled section. Settled
-rows use the hollow status ring, lower opacity, stay openable, and render
-`statusNote` as `done: …`; an explicit attention request instead puts its
-question in the preview line. Ready/idle rows remain in Your move without a
-capsule, while `Needs you` is the loud tier used by awaiting counts, the
-  Activity drawer, push, and attention-first roster behavior. A settled chat
-woken by unattended scheduled work shows Running during the turn and returns
-to Settled at idle because only user activity clears its declaration.
+`RemoteRosterChat`. Settled rows recede, stay openable, and render `statusNote`
+as `Done: …`; an explicit attention request instead puts its question in the
+preview line. Under by-status grouping, finished rows (`ready` / `idle`) sit in
+a **Done** group rather than in "Your move" — they read emerald "Done", not
+amber, because sharing amber with `needs_you` made "finished, go look" and
+"blocked, go act" indistinguishable. Amber stays reserved for the one state that
+wants a human, which is also the tier the Activity drawer, push, and
+attention-first roster behavior key off. A settled chat woken by unattended
+scheduled work shows Running during the turn and returns to Settled at idle
+because only user activity clears its declaration.
 
 #### Settle override and snooze
 
@@ -1807,16 +1826,32 @@ The iOS pieces:
   callers. Mobile has no local write path for lifecycle, so these commands are
   the mechanism, and the connect-time descriptor list gates the affordances.
 - `apps/ios/ADE/Views/Work/WorkSessionCanonicalState.swift` is the Swift mirror
-  of the shared derivation, now including the settle-override tier and
-  `isSessionFiledAsSnoozed`. `WorkSessionGrouping.swift`'s `workSessionGroups`
-  grows a snoozed tail, and `WorkRootScreen.swift`,
-  `WorkRootScreen+Actions.swift`, and `WorkRootComponents.swift` render the
-  chips and menus and dispatch snooze / wake / settle / keep-active. By-lane
+  of the shared derivation, including the settle-override tier and
+  `isSessionFiledAsSnoozed`. It also owns the row's status vocabulary:
+  `workSessionRowPresentation(session:summary:now:)` derives phase, capsule,
+  dot tone, and status slot **once, from one clock**, so a row rebuilt across a
+  stale or snooze boundary cannot paint a capsule from one instant and a status
+  slot from another. `workSessionStatusBadge` / `workSessionRowTone` /
+  `workSessionStatusPresentation` are thin reads of it. Labels and hues come
+  from the shared `ActivityPhaseVocabulary` mirror, so a Work row, the Activity
+  drawer, the hub strip, and the widget all read the same table.
+- `WorkSessionGrouping.swift`'s `workSessionGroups` builds the by-lane (default)
+  / by-status / by-time groups, and `WorkRootScreen.swift`,
+  `WorkRootScreen+Actions.swift`, `WorkRootComponents.swift`, and
+  `WorkSessionRowCard.swift` render the chips and menus and dispatch snooze /
+  wake / settle / keep-active. By-lane
   groups whose full unfiltered roster is quiet use a thin collapsed header and
   an inverted `lane-open:<laneId>` expansion marker; expanding renders compact
   rows, and active work removes the marker so the next quiet spell collapses.
   The snooze helper yields to canonical `needs_you`, so a lane waiting on the
   user can never be folded into this quiet presentation.
+- By-status and by-time close with a **quiet zone**: a `Snoozed` shelf above a
+  `Settled` shelf, both collapsed by default behind an inverted
+  `shelf-open:<id>` marker. The `shelf-open:` namespace is deliberately separate
+  from `lane-open:`, which `pruneStaleQuietOpenMarkers` sweeps. By-lane is
+  exempt — a settled row still belongs to its lane there, and the per-lane quiet
+  fold already covers it. Archived rows are never lifted onto the Settled shelf;
+  they stay under "Archived" so filing them twice cannot hide them.
 - `WorkSessionGrouping.swift` also owns `WorkViewStateStore`, a versioned
   App-Group map keyed by project id plus host identity. `WorkRootScreen` swaps
   search, lane/status filters, organization, and collapsed ids when either
@@ -1824,8 +1859,10 @@ The iOS pieces:
   frame those fields transiently: persistence is suppressed until the user
   takes control, at which point edits resume from the saved base rather than
   making notification routing a permanent preference change.
-- `apps/ios/ADETests/WorkSessionCanonicalStateTests.swift` covers the derivation
-  and scoped view-state parity.
+- `apps/ios/ADETests/WorkSessionCanonicalStateTests.swift` covers the derivation,
+  the row status vocabulary, and scoped view-state parity;
+  `WorkSessionGroupingTests.swift` covers the grouping, quiet lanes, and the
+  quiet-zone shelves.
 
 Two invariants govern changes here. The Swift derivation must stay
 behaviourally identical to `apps/desktop/src/shared/sessionCanonicalState.ts` —
@@ -1838,13 +1875,91 @@ desktop. Like every replicated table, these columns are nullable with no unique
 index, because `terminal_sessions` goes through `crsql_as_crr`, which rejects
 any non-primary-key unique index.
 
+### Work session list rows
+
+The Work list is a port of the desktop Work sidebar, and it holds desktop's
+central invariant: **interaction owns the card surface; state never spends it.**
+Background, border and shadow mean selection and press, nothing else
+(`SessionCard.tsx:69-86`). There is no provider-brand tint on the card — tinting
+the body by provider made every Claude row amber, which is the hue that is
+supposed to mean *your move*, so the "Needs you" badge stopped registering.
+
+`WorkSessionRowCard.swift` renders three lines:
+
+1. The "where" cluster — pin, mute, the lane chip, lane git state (dirty /
+   ahead / behind), and a floor of model-or-timestamp — with a single
+   right-anchored **status slot**. One slot, one status.
+2. Title plus the lane's PR badge (`WorkLanePrIndicator` / `LanePrTag`).
+3. An italic preview line plus the provider mark.
+
+Non-prominent rows recede to 70% opacity, which is how the few rows that want a
+human stand out with no banner anywhere on screen. Settled resolves to a nil
+status presentation (the timestamp owns the free slot) and therefore recedes;
+that is intended, not a missing case — the row's `badge` still answers "Done"
+for callers that need a capsule out of that context.
+
+Lane identity is structural rather than repeated. The lane chip renders only on
+**headerless singleton lanes**; a multi-session lane gets a sticky `Section`
+header plus a lane-accent rail, and its rows do not repeat the name. The chip
+truncates at the tail, never in the middle — middle truncation turned a lane
+called "Ok Needs Closing Issue" into "Ok Need…osing Issue", which the eye parses
+as a status string — and the lane-coloured dot beside it is gone, because a
+coloured dot on a row that also carries state reads as state.
+
+The header is one 44pt row: search, a filter funnel, and a compose menu holding
+**New chat** / **New lane**. The previous three-row header (a full-width
+"Start new chat" / "Add lane" hero pair and an `N waiting` chip) pushed the
+first session row most of a thumb down the screen. Both `N waiting` indicators —
+the top-bar pill and its duplicate chip — were removed: attention is stated per
+row, and the bell's Activity drawer remains the only rollup.
+
+The long-press context menu matches desktop: destructive actions are fenced
+last, a `Lane ▸` submenu carries the lane actions the Lanes tab already sends,
+and lifecycle gating mirrors desktop exactly — Settle is hidden while a session
+is starting, running, or stale; **Keep active** appears only against a *declared*
+settle; a needs-you row offers **Dismiss & settle**, and a row whose prompt ADE
+cannot answer (a raw native CLI prompt) gets a disabled **Resolve input to
+settle** row rather than an action that could only ever fail. Non-chat sessions
+can now be deleted from the phone through `work.deleteSession`
+(`SyncService.deleteWorkSession`, advertise-checked via
+`supportsWorkSessionDeletion`); the host handler already stops a live runtime
+first, so "Stop & delete" and "Delete session" are one command with two labels.
+Chats keep `chat.delete`.
+
+**Dismiss & settle** rides `session.settleSessions` with the optional
+`dismissPendingInput` flag (the singular `session.settleSession` accepts it too
+but is not in the mobile compatibility lists). The flag must only be sent for a
+row that genuinely has a pending prompt — the host throws for a row with nothing
+pending — which is why it is a distinct menu action rather than a flag the
+caller guesses at. See
+[remote commands](remote-commands.md#registry).
+
+Known limits, all deliberate:
+
+- Preview tokens (`#123`, `ABC-123`) are styled — weight plus a contrast step —
+  but **not tappable**. The whole row is a `Button`, and a tappable range inside
+  a `Button` label never receives the tap. Shipping a link affordance that
+  silently does nothing is worse than styling alone; converting the row to
+  `.contentShape(Rectangle())` plus a tap gesture would change the primary open
+  gesture of every Work row. The routing already exists if it is ever converted
+  (`SyncService.requestedPrNavigation` /
+  `requestedLinearIssueNavigation`).
+- iOS `TerminalSessionSummary` carries no `orchestrationParentSessionId`,
+  `spawnKind`, `branchRef`, `currentTurnStartedAt`, `nextWakeAt`, or
+  `lastActivityAt`, so desktop's lineage chip, branch chip, machine tower glyph,
+  grid indicator, and `nextWakeAt`-driven "Waiting" status have no iOS
+  equivalent, and the elapsed ticker anchors on activity time rather than turn
+  start.
+- Against a host that predates `dismissPendingInput` on the bulk action, the
+  flag is ignored: the settle reports success and the row stays "Needs you".
+
 ### Shipped
 
 | Tab | Icon | Desktop equivalent | Capabilities |
 |---|---|---|---|
 | **Lanes** | `square.stack.3d.up` | `/lanes` | Full lane surface: search/filter chips, open/create/manage, stack canvas, git/diff/rebase/conflicts, template-backed environment setup progress, lane-scoped sessions and AI chats. `devicesOpen` presence chips show which other devices currently have the lane open. The lane detail screen (full-screen, custom tab bar hidden) is organized into collapsible sections (`LaneDetailSectionChrome`): each section auto-opens when it has content and auto-collapses when empty (`LaneSectionDisclosure`), and stays where the user last put it once they toggle it manually. Header chips and the git action buttons flow through `LaneChipFlowLayout`, a wrapping flow layout that wraps onto new lines instead of horizontally scrolling. Lane rows in the list carry a cheap render-relevant signature (mirroring the Hub row-signature pattern) so `.equatable()` re-renders only rows whose visible state changed. It embeds `LaneDetailGitActionsPane`, a port of desktop's git actions pane: commit message field with amend toggle and an AI "Suggest message" button (gated by runtime capability, with a setup-hint when the runtime reports "AI commit messages are off"), pull (rebase/merge mode) / push (with force-with-lease) / fetch, staged + unstaged file lists with per-file and bulk stage / unstage / discard / restore / open-diff / open-files, stash push/apply/pop/drop, recent-commit history with context-menu view-files / copy-message / revert / cherry-pick, and a "more actions" menu holding switch branch plus the destructive escape hatches (rebase lane, rebase + descendants, rebase and push, force push). A conflict banner offers rebase **and merge** continue/abort (`git.rebaseContinue`/`Abort`, `git.mergeContinue`/`Abort`), and a rescue sheet creates a new lane from uncommitted changes. The lane options menu copies shareable deeplinks (`LaneDeeplinkHelpers`: `ade://lane/<id>`, `ade://repo/<owner>/<repo>/branch/<branch>`) and opens `LaneManageSheet`, a tabbed manage dialog (delete / appearance / stack / archive) mirroring desktop's `ManageLaneDialog`. Every lane is managed the same way regardless of where its worktree lives, so there is no adopt or "move into `.ade/worktrees`" action. The previous `LaneAdvancedScreen`, `LaneCommitSheet`, `LaneStashesScreen`, and `LaneCommitHistoryScreen` destinations were deleted in favor of this single pane. |
 | **Files** | `doc.text` | `/files` | Lane-backed workspace picker (`FilesWorkspacePickerDropdown`, a desktop-shaped searchable dropdown that replaced the horizontal workspace chip row), live file tree/read. Search is a single full-screen page (`FilesSearchScreen`) opened from the magnifying-glass button in the Files top bar (desktop `SearchOverlay` parity): one query searches file *names* (quick open) and file *contents* (text search) together — name matches surface first under "Files", content hits are grouped per file with collapsible line previews, and tapping a line opens the file at that line. The inline `FilesQueryCard` quick-open / text-search cards (and their 40-row caps) were removed. Files are freely editable — the mobile read-only file-mutation gate (`mobileReadOnly` / edit-protection) was removed on both the host and the phone, matching the desktop change. |
-| **Work** | `terminal` | `/work` | Terminal + chat session list (standalone CLI sessions stay listed after they end, matching desktop — `workSessionShouldAppearInWorkList` in `WorkBrowserHelpers.swift` hides orphaned chat-owned child shells that are no longer live), cached history with persisted lane names, output streaming, native key-passthrough terminal input (keystrokes from the iOS keyboard flow straight into the PTY as `terminal_input`, coalesced ~16 ms; PTY echo is the only source of truth), Ctrl-C forwarding for subscribed live PTYs, in-app CLI session launcher (Claude / Codex / Cursor / OpenCode / Droid), message-to-continue on ended agent CLI rows, session pinning, live chat-event push from the runtime (no polling lag once subscribed). The new-session screen (`WorkNewChatScreen`) toggles between **Chat** and **CLI** via a compact nav-bar pill toggle (desktop `ModeSwitcherPills` parity); the lane is chosen through `WorkLanePickerDropdown` (searchable, with an auto-create-lane row), and in CLI mode the provider is derived from the picked model via `workResolveCliProvider` instead of a separate provider row — the explicit `workCliProviderOptions` picker (and its plain "Shell" launch option) was removed. The new-chat composer shares the in-session chat composer's `WorkComposerControlsRow` (the same controls strip used by `WorkComposerChipStrip`): a permission/access control that collapses to a single tone-dot dropdown when space is tight and expands to segmented chips when wide, a model pill, and a fast-mode lightning toggle. The fast-mode toggle is shown only in **Chat** mode for fast-capable models (threaded into `chat.create` via `codexFastMode`) and is hidden in CLI mode, where the launcher has no fast-mode parameter. The composer's last-used selection (model + access mode + reasoning effort + fast mode) persists across surfaces through `WorkComposerPreferences` (App Group `UserDefaults`, versioned key): the New Chat screen seeds its initial state from the saved selection instead of hardcoded defaults, and every change or send — from the New Chat composer, the in-session inline picker (`WorkSessionDestinationView`), or the session settings sheet — writes it back. Because the inline picker is cross-provider, the persisted provider is re-derived from the picked model, and a provider change resets the coupled access mode / sub-settings to that provider's defaults. Droid (Factory) is in the new-chat provider allowlist (`workNormalizedNewChatProvider`), so Droid Core models (GLM / Kimi / MiniMax) keep the `droid` provider instead of silently collapsing to the Claude runtime. The new-chat send button is the shared `ADEComposerSendButton` (an arrow-in-circle disc matching the in-session composer), replacing the earlier paperplane capsule. Each session row carries a minimal per-lane PR status indicator (`WorkLanePrIndicator`: a state-colored dot + `#num` + Open/Draft/Closed/Merged) beside the lane name. It and the Lanes tab chip both render the unified `LanePrTag` (`LaneHelpers.swift`, `selectLaneTabPrTag`, desktop parity), which merges ADE-mapped PRs (the synced `pull_requests` table) with GitHub PRs opened outside ADE — matched to a lane by branch and fetched into the shared `SyncService.laneGithubPrItems` cache (`refreshLaneGithubPrItems`, best-effort, throttled, reset on project switch / reconnect). When a row resolves a `LanePrTag` (mapped or GitHub-by-branch), its long-press context menu (`WorkSessionListRow`) also offers **"Open in PRs tab"**; `WorkRootScreen+Actions.openPullRequest` waits out the menu-dismiss animation, then publishes `syncService.requestedPrNavigation` (a `PrNavigationRequest` carrying the PR id + number + lane id, or just the GitHub PR number for an unmapped tag), and `ContentView`'s `onChange(of: requestedPrNavigation?.id)` flips the app to the PRs tab and opens that PR — the same cross-tab handoff the deep-link router and the in-chat PR menu use. CLI mode submits `work.startCliSession` with the resolved provider, permission mode (Claude additionally supports `auto`), an optional `reasoningEffort`, and an optional opening message. For most providers the runtime types the opening message into the spawned PTY; for Codex the opening message is forwarded as the final argv positional through `buildTrackedCliLaunchCommand`, so the prompt is treated as a real first turn instead of a typed shell line. The terminal viewer (`TerminalSessionScreen` + `SwiftTermSessionView`) is a full-bleed SwiftTerm (real VT100/xterm) emulator: tap-to-focus raises the iOS keyboard for direct passthrough, a single-row key bar provides esc/tab/latching-Ctrl/arrows/return plus an overflow menu, pinch adjusts font size, and the phone owns the PTY's cols×rows while the screen is open (sent as `terminal_resize`; the runtime restores the desktop size on detach). Live output streams via offset-stamped `terminal_data` with gap detection + `sinceOffset` delta resume (no snapshot polling); scrolling near the top auto-pages older transcript via `terminal_history`, and a floating "↓ Live N" pill snaps back to the live tail. Only real user drags can un-pin the viewport: layout-driven geometry changes (keyboard show/hide, key bar, pinch font changes) re-assert the live tail after the pass settles, so a pinned terminal with large scrollback keeps the prompt visible above the keyboard instead of stranding it (SwiftTerm only re-snaps when cols/rows change, and a mouse-mode TUI repainting in place emits no scroll events to self-heal). When the hosted program enables mouse reporting (Claude Code, htop), vertical pans are translated into SGR wheel events so the TUI scrolls itself; mouse-off sessions scroll native scrollback. Against pre-offset hosts (older brains, whose PTY→sync bridge never pushed terminal output) the screen detects the missing offsets and falls back to a 2s tail-refresh poll until offsets appear. The screen unsubscribes via `terminal_unsubscribe` on disappear. The legacy `WorkTerminalEmulatorView`/`WorkTerminalScreen` mini-parser remains only for inline preview cards. The earlier "activity feed" section was retired — running chats are surfaced through the session list and a Work tab badge bound to `SyncService.runningChatSessionCount`. In chat sessions, user-message attachments render through `WorkChatAttachmentTray` (image thumbnails embedded in the bubble, desktop `ChatAttachmentTray` parity, placeholder tiles when the image bytes have not synced from the host yet), and the chat header's PR menu opens the lane's open PR on GitHub, copies its link, or launches the create-PR wizard in `singleModeOnly` mode (eligibility read from `prs.getMobileSnapshot.createCapabilities`). The chat composer input is a `UITextView`-backed field (`WorkComposerTextView` in `WorkComposerTypedTriggers.swift`) rather than a plain SwiftUI `TextField`, because it needs the cursor position and inline styled runs. `WorkComposerTriggerDetector` runs the same cursor-relative regexes as the shared desktop/TUI `composerTriggers.ts` (slash `(?:^|\s)/([^\s/]*)$`, at `(?:^|\s)@([^\s@]*)$`), so a `/command` or `@file` trigger is detected anywhere in the draft, not just at position 0. `WorkComposerSuggestionController` drives an inline suggestion strip (`WorkComposerSuggestionStrip`) above the input — a curated per-provider slash catalog (`WorkComposerSlashCatalog`) resolved locally, and `@file` quick-open resolved over sync via `SyncService.quickOpen` against the lane's files workspace (40 ms debounce, workspace id cached per lane, invalidated on lane change). Its visibility derives purely from the active trigger match, never from `@FocusState`. Committing a suggestion splices exactly the trigger span on the live text view, and confirmed `/command` / `@path` tokens render as tinted chip pills drawn by a custom TextKit 1 `WorkComposerChipLayoutManager` (provider-accent tint, monospace for slash, semibold for at) while `draftState.text` stays the plain-text source of truth that is sent. `WorkSmartLinkDetector` styles GitHub, Linear, ADE, and generic web URLs with the same chip layout manager in both new-chat and in-session composers; Backspace/Delete removes an intersected URL atomically, and long press offers Copy link and Remove link. The raw URL remains the SwiftUI draft and sent prompt. This replaced the modal `WorkMentionsPickerSheet` and `WorkSlashCommandsSheet` (both deleted). |
+| **Work** | `terminal` | `/work` | Terminal + chat session list (standalone CLI sessions stay listed after they end, matching desktop — `workSessionShouldAppearInWorkList` in `WorkBrowserHelpers.swift` hides orphaned chat-owned child shells that are no longer live), cached history with persisted lane names, output streaming, native key-passthrough terminal input (keystrokes from the iOS keyboard flow straight into the PTY as `terminal_input`, coalesced ~16 ms; PTY echo is the only source of truth), Ctrl-C forwarding for subscribed live PTYs, in-app CLI session launcher (Claude / Codex / Cursor / OpenCode / Droid), message-to-continue on ended agent CLI rows, session pinning, live chat-event push from the runtime (no polling lag once subscribed). The new-session screen (`WorkNewChatScreen`) toggles between **Chat** and **CLI** via a compact nav-bar pill toggle (desktop `ModeSwitcherPills` parity); the lane is chosen through `WorkLanePickerDropdown` (searchable, with an auto-create-lane row), and in CLI mode the provider is derived from the picked model via `workResolveCliProvider` instead of a separate provider row — the explicit `workCliProviderOptions` picker (and its plain "Shell" launch option) was removed. The new-chat composer shares the in-session chat composer's `WorkComposerControlsRow` (the same controls strip used by `WorkComposerChipStrip`): a permission/access control that collapses to a single tone-dot dropdown when space is tight and expands to segmented chips when wide, a model pill, and a fast-mode lightning toggle. The fast-mode toggle is shown only in **Chat** mode for fast-capable models (threaded into `chat.create` via `codexFastMode`) and is hidden in CLI mode, where the launcher has no fast-mode parameter. The composer's last-used selection (model + access mode + reasoning effort + fast mode) persists across surfaces through `WorkComposerPreferences` (App Group `UserDefaults`, versioned key): the New Chat screen seeds its initial state from the saved selection instead of hardcoded defaults, and every change or send — from the New Chat composer, the in-session inline picker (`WorkSessionDestinationView`), or the session settings sheet — writes it back. Because the inline picker is cross-provider, the persisted provider is re-derived from the picked model, and a provider change resets the coupled access mode / sub-settings to that provider's defaults. Droid (Factory) is in the new-chat provider allowlist (`workNormalizedNewChatProvider`), so Droid Core models (GLM / Kimi / MiniMax) keep the `droid` provider instead of silently collapsing to the Claude runtime. The new-chat send button is the shared `ADEComposerSendButton` (an arrow-in-circle disc matching the in-session composer), replacing the earlier paperplane capsule. The session list itself is described in [Work session list rows](#work-session-list-rows). Each row carries a minimal per-lane PR status indicator (`WorkLanePrIndicator`: a state-colored dot + `#num` + Open/Draft/Closed/Merged) beside its title. It and the Lanes tab chip both render the unified `LanePrTag` (`LaneHelpers.swift`, `selectLaneTabPrTag`, desktop parity), which merges ADE-mapped PRs (the synced `pull_requests` table) with GitHub PRs opened outside ADE — matched to a lane by branch and fetched into the shared `SyncService.laneGithubPrItems` cache (`refreshLaneGithubPrItems`, best-effort, throttled, reset on project switch / reconnect). When a row resolves a `LanePrTag` (mapped or GitHub-by-branch), its long-press context menu (`WorkSessionListRow`) also offers **"Open in PRs tab"**; `WorkRootScreen+Actions.openPullRequest` waits out the menu-dismiss animation, then publishes `syncService.requestedPrNavigation` (a `PrNavigationRequest` carrying the PR id + number + lane id, or just the GitHub PR number for an unmapped tag), and `ContentView`'s `onChange(of: requestedPrNavigation?.id)` flips the app to the PRs tab and opens that PR — the same cross-tab handoff the deep-link router and the in-chat PR menu use. CLI mode submits `work.startCliSession` with the resolved provider, permission mode (Claude additionally supports `auto`), an optional `reasoningEffort`, and an optional opening message. For most providers the runtime types the opening message into the spawned PTY; for Codex the opening message is forwarded as the final argv positional through `buildTrackedCliLaunchCommand`, so the prompt is treated as a real first turn instead of a typed shell line. The terminal viewer (`TerminalSessionScreen` + `SwiftTermSessionView`) is a full-bleed SwiftTerm (real VT100/xterm) emulator: tap-to-focus raises the iOS keyboard for direct passthrough, a single-row key bar provides esc/tab/latching-Ctrl/arrows/return plus an overflow menu, pinch adjusts font size, and the phone owns the PTY's cols×rows while the screen is open (sent as `terminal_resize`; the runtime restores the desktop size on detach). Live output streams via offset-stamped `terminal_data` with gap detection + `sinceOffset` delta resume (no snapshot polling); scrolling near the top auto-pages older transcript via `terminal_history`, and a floating "↓ Live N" pill snaps back to the live tail. Only real user drags can un-pin the viewport: layout-driven geometry changes (keyboard show/hide, key bar, pinch font changes) re-assert the live tail after the pass settles, so a pinned terminal with large scrollback keeps the prompt visible above the keyboard instead of stranding it (SwiftTerm only re-snaps when cols/rows change, and a mouse-mode TUI repainting in place emits no scroll events to self-heal). When the hosted program enables mouse reporting (Claude Code, htop), vertical pans are translated into SGR wheel events so the TUI scrolls itself; mouse-off sessions scroll native scrollback. Against pre-offset hosts (older brains, whose PTY→sync bridge never pushed terminal output) the screen detects the missing offsets and falls back to a 2s tail-refresh poll until offsets appear. The screen unsubscribes via `terminal_unsubscribe` on disappear. The legacy `WorkTerminalEmulatorView`/`WorkTerminalScreen` mini-parser remains only for inline preview cards. The earlier "activity feed" section was retired — running chats are surfaced through the session list and a Work tab badge bound to `SyncService.runningChatSessionCount`. In chat sessions, user-message attachments render through `WorkChatAttachmentTray` (image thumbnails embedded in the bubble, desktop `ChatAttachmentTray` parity, placeholder tiles when the image bytes have not synced from the host yet), and the chat header's PR menu opens the lane's open PR on GitHub, copies its link, or launches the create-PR wizard in `singleModeOnly` mode (eligibility read from `prs.getMobileSnapshot.createCapabilities`). The chat composer input is a `UITextView`-backed field (`WorkComposerTextView` in `WorkComposerTypedTriggers.swift`) rather than a plain SwiftUI `TextField`, because it needs the cursor position and inline styled runs. `WorkComposerTriggerDetector` runs the same cursor-relative regexes as the shared desktop/TUI `composerTriggers.ts` (slash `(?:^|\s)/([^\s/]*)$`, at `(?:^|\s)@([^\s@]*)$`), so a `/command` or `@file` trigger is detected anywhere in the draft, not just at position 0. `WorkComposerSuggestionController` drives an inline suggestion strip (`WorkComposerSuggestionStrip`) above the input — a curated per-provider slash catalog (`WorkComposerSlashCatalog`) resolved locally, and `@file` quick-open resolved over sync via `SyncService.quickOpen` against the lane's files workspace (40 ms debounce, workspace id cached per lane, invalidated on lane change). Its visibility derives purely from the active trigger match, never from `@FocusState`. Committing a suggestion splices exactly the trigger span on the live text view, and confirmed `/command` / `@path` tokens render as tinted chip pills drawn by a custom TextKit 1 `WorkComposerChipLayoutManager` (provider-accent tint, monospace for slash, semibold for at) while `draftState.text` stays the plain-text source of truth that is sent. `WorkSmartLinkDetector` styles GitHub, Linear, ADE, and generic web URLs with the same chip layout manager in both new-chat and in-session composers; Backspace/Delete removes an intersected URL atomically, and long press offers Copy link and Remove link. The raw URL remains the SwiftUI draft and sent prompt. This replaced the modal `WorkMentionsPickerSheet` and `WorkSlashCommandsSheet` (both deleted). |
 | **PRs** | `arrow.triangle.pull` | `/prs` | PR list/detail driven by `prs.getMobileSnapshot`: GitHub stack visibility (`PrStackSheet`), create-PR wizard (`CreatePrWizardView`) gated by per-lane eligibility, Integration/Rebase workflow cards rendered from `PrWorkflowCard`, and per-PR action capabilities. The PR detail screen (`PrDetailView`) is a single-column adaptation of the desktop Timeline+Rails layout — its Overview is emitted as sibling `List` rows so the list virtualizes offscreen content, and it stays live off a warm-cache freshness gate (see [PR detail screen](#pr-detail-screen)). |
 | **CTO** | `brain` | `/cto` | The CTO chat thread rendered inline as the tab body (single persistent session via `CtoSessionDestinationView`) with a compact one-line voice/send composer. The top-bar gear opens settings for identity/personality, live model/reasoning/Fast selection, read-only Linear status, memory via `cto.getMemory`, and re-run setup. The tab badges when the thread is blocked on the user: `SyncService.refreshCtoAttentionIfNeeded()` calls the optional `cto.getAttention` command (5 s debounce, gated on `supportsRemoteAction`) and publishes `ctoAttention`. It rides the change pulse that rebuilds the session roster, but is invoked *before* `refreshActiveSessionsAndSnapshot`'s roster-signature early return — the CTO is excluded from that roster, so a CTO-only change leaves the signature unchanged and a probe below the guard could never fire. `saveRemoteCommandDescriptors` also calls it with `force: true`, so the first probe after a (re)connect happens as soon as the host advertises the command. Transport failures and the host's explicit `unknown` status both keep the last known value; an older brain that does not advertise the action clears it. The decoded status is optional so a new phone still infers idle/waiting correctly from the legacy `awaitingInput` field. |
 | **Settings** | `gearshape` | `/settings` (sync subset) | Connections — account sign-in (primary, PIN-less directory + Relay adoption), account-wide machine rename/clear, scan the QR (`SettingsPairingScannerSheet`) + PIN, or Nearby + PIN — plus advanced SSH bootstrap, appearance, diagnostics, reconnect, forget, and a **Push delivery** panel (`SettingsPushDeliverySection`: registration/permission state, APNs environment, relay reachability from `push.getStatus`, and notification / Live-Activity / quiet-hours toggles). `ConnectionSettingsView` binds to `SettingsConnectionPresentationModel`, which feeds plain `SettingsConnectionSnapshot` / `SettingsPairingSnapshot` / `SettingsDiagnosticsSnapshot` / `SettingsPushDeliverySnapshot` DTOs into the section views (`SettingsConnectionHeader`, `SettingsPairingSection`, `SettingsDiagnosticsSection`, `SettingsPushDeliverySection`) instead of having them reach into `SyncService` directly. The About row formats the marketing and build versions together as `v<marketing> (<build>)`. |

--- a/docs/features/sync-and-multi-device/remote-commands.md
+++ b/docs/features/sync-and-multi-device/remote-commands.md
@@ -273,6 +273,21 @@ tools) — it is not a desktop-only capability.
 `session.settleSession` routes through the shared `settleTerminalSession`
 transaction, so `dismissPendingInput` behaves identically to desktop.
 
+`session.settleSessions` accepts the same optional `dismissPendingInput` flag —
+this is the action mobile actually uses, because the singular
+`session.settleSession` is not in the mobile compatibility lists. When the flag
+is set the handler first runs `dismissPendingInputBeforeSettle`
+(`apps/desktop/src/main/services/sessions/settleTerminalSession.ts`, extracted
+from `settleTerminalSession` so bulk and single paths share one dismissal
+semantic), then performs the normal `settleSessions` write, so the reply stays
+the changed-id list clients match on. The flag is **rejected when more than one
+session id is sent**: the dismissal mutates as it goes and throws for a row with
+nothing pending, so a mixed batch would dismiss the first *k−1* rows, throw on
+the *k*-th, and settle none of them. Rejecting the combination up front is
+cheaper than a half-applied batch; generalizing it requires making the dismiss
+loop atomic first. The flag is additive, so a host that predates it ignores it
+and simply settles the row, leaving the pending prompt in place.
+
 Snooze deadlines arrive from clients with no local clock authority, so the
 registry validates them rather than trusting them: `parseRemoteSnoozeDeadline`
 accepts either `untilIso` or `snoozedUntil` and validates the instant,

--- a/docs/features/terminals-and-sessions/README.md
+++ b/docs/features/terminals-and-sessions/README.md
@@ -209,6 +209,14 @@ and in tests.
   first quiets an SDK chat through `agentChatService`, or clears a tracked
   CLI's explicit `ade chat ask` marker through `ptyService`; arbitrary native
   terminal prompts are rejected because ADE cannot answer them truthfully.
+  That dismissal is exported separately as `dismissPendingInputBeforeSettle`
+  so the **bulk** settle paths — which must write through
+  `sessionService.settleSessions` and keep returning the changed-id list — reuse
+  the exact same semantic instead of inventing a second mechanism. It returns
+  false when the row is missing and throws when there is nothing pending to
+  dismiss, which is why the bulk sync command refuses the flag for more than one
+  id (see
+  [remote commands](../sync-and-multi-device/remote-commands.md#registry)).
 - `apps/ade-cli/src/cli.ts`, `apps/ade-cli/src/adeRpcServer.ts` —
   `ade new chat --mode cli` forwards the parent chat id and spawn kind for
   agent providers; `start_cli_session` validates them and persists them in
@@ -1251,23 +1259,40 @@ iOS Work surfaces:
 
 - `apps/ios/ADE/Views/Work/WorkRootScreen.swift`,
   `WorkRootScreen+Actions.swift`, `WorkRootScreen+Selection.swift`, and
-  `WorkRootComponents.swift` — mobile Work list, filters, grouped
-  session rows, and live-count/status pills. Visibility mirrors desktop
+  `WorkRootComponents.swift` — mobile Work list: the one-row header
+  (search + filter funnel + a compose menu holding **New chat** / **New lane**),
+  the filter panel, sticky lane section headers, the child-shell section, and
+  the `WorkSessionListRow` action shell that hangs swipe and context menus off a
+  row. Visibility mirrors desktop
   (`workSessionShouldAppearInWorkList` in `WorkBrowserHelpers.swift`):
   standalone CLI sessions are always listed — **including ended ones**,
   which stay visible and resumable; chat-owned shell rows ride their
   parent chat's entry (an orphaned child whose parent chat isn't listed
   surfaces only while it is actually live). Agent CLI continuation is
   driven by sending text to the durable session, not a standalone
-  row action. The earlier
-  in-list activity feed is gone — running chats surface through the
-  session list and the live-count chip. Work filters, organization, and
+  row action. There is no rollup count anywhere on this screen: attention is
+  stated per row, and the bell's Activity drawer is the only aggregate.
+  Work filters, organization, and
   collapsed-section ids are restored from `WorkViewStateStore` per
   project-plus-host scope; lane deeplinks temporarily frame the list without
   persisting their resets. By-lane groups whose full roster is settled,
   snoozed, or archived use the same inverted `lane-open:<laneId>` marker as
   desktop: collapsed is a thin muted row, while explicit expansion shows
   compact session rows until active work returns.
+- `apps/ios/ADE/Views/Work/WorkSessionRowCard.swift` — the session row card
+  itself (`WorkSessionRow`, its leaf views, and the
+  `WorkSessionRowRenderSignature` equality shim) plus the preview-line helpers
+  (`workSessionRowPreviewSource`, `workLinkifiedPreview`). Split out of
+  `WorkRootComponents.swift`, which keeps the surrounding list chrome. Card
+  surface is neutral — background, border and shadow are reserved for selection
+  and press, never for state, matching desktop `SessionCard.tsx`. See
+  [the iOS companion](../sync-and-multi-device/ios-companion.md#work-session-list-rows).
+- `apps/ios/ADE/Views/Work/WorkSessionGrouping.swift` — the by-lane (default) /
+  by-status / by-time grouping, `WorkViewStateStore`, and the trailing quiet
+  zone: a **Snoozed** shelf above a **Settled** shelf, both collapsed until
+  explicitly opened via an inverted `shelf-open:<id>` marker. By-lane is exempt
+  from the shelves — a settled row still belongs to its lane there, and the
+  per-lane quiet fold already handles it.
 - `apps/ios/ADE/Views/Work/TerminalSessionScreen.swift` and
   `SwiftTermSessionView.swift` — full-screen SwiftTerm-backed terminal
   surface for CLI sessions. It subscribes with `sinceOffset`, applies


### PR DESCRIPTION
## Why

The iOS Work tab had drifted off the cross-client presentation contract, and the list was hard to read at a glance.

- **Every card was amber.** `WorkSessionRow` painted its whole body in the provider's brand colour (`providerTint` maps Claude → `.orange`). Desktop's rule is the opposite and is a written invariant (`SessionCard.tsx:69-86`): background, border and shadow belong to *interaction*; state never spends them. Because every Claude card was already amber, the amber "Needs you" badge stopped registering.
- **Amber was spent three times on one screen** — a top-bar pill, a non-interactive duplicate chip below it reading the same count, and the per-row badge. This is the exact failure `sessionStatusPresentation.ts` was written to kill.
- **The lane name looked like a status.** `Ok Need…osing Issue` was `session.laneName` at `.truncationMode(.middle)` with `layoutPriority(-1)` — first element crushed, middle-elided — and the coloured dot beside it was the *lane colour*, not state.

## What changed

- Neutral card surface; tint only on selection. Three lines: where + one right-anchored status slot / title + PR badge / preview + provider mark. Non-prominent rows recede to 70%.
- Both "N waiting" indicators deleted. Attention is per-row; the bell's Activity drawer stays the only rollup, as on desktop.
- One 44pt header row: search + filter + a compose menu (New chat / New lane).
- Lane stated once: chip on headerless singleton lanes, otherwise a sticky section header plus an accent rail. Tail truncation, never middle.
- Quiet zone closes by-status and by-time with Snoozed above Settled, both collapsed via the existing inverse-marker idiom. By-lane keeps its per-lane fold.
- Reuses the existing `ActivityPhaseVocabulary` mirror; phase, badge, tone and status are derived **once per row from one clock** (previously five derivations with five `Date()` calls).
- Context menu reaches desktop parity: destructive actions fenced last, a `Lane ▸` submenu, and delete for non-chat sessions — `work.deleteSession` was already advertised and viewer-allowed; iOS simply never called it, so a CLI session could not be deleted from the phone at all.
- Two lifecycle drifts corrected: the phone allowed settling mid-turn where desktop refuses, and by-status filed finished rows under a header reading "Your move".

## Host

`session.settleSessions` takes an optional `dismissPendingInput` and **refuses it for more than one id** — the dismissal mutates and can then throw, so a batch could half-apply. The ADE action registry refuses the same flag rather than dropping it silently.

## Verification

- iOS 1256 tests, `apps/ade-cli` 92, desktop registry 89 — the 5 remaining iOS failures are pre-existing and reproduce on `main` itself (verified against a stashed baseline: `main` = 1238 tests, same failures).
- Both typechecks clean; `plutil -lint` passes on the hand-edited `pbxproj`.

## Known limitations

- Preview tokens (`#123`, `ABC-123`) are styled but **not tappable** — making them tappable requires converting every row from a `Button` to a tap-gesture view, which was judged a poor trade.
- Against a host predating this PR, `dismissPendingInput` is ignored: the settle reports success and the row stays "Needs you". No capability signal exists to gate on.
- No visual verification: simulator pairing hits the known false "Incorrect PIN" bug, and Preview Lab needs a human Xcode "Allow" click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)