### PR TITLE
fix(ci): look for the Beta installer where channel builds actually write it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,7 +657,11 @@ jobs:
       - name: Test Stable and Beta installed-product lifecycles
         shell: pwsh
         run: |
-          $betaInstallers = @(Get-ChildItem "apps/desktop/release/ADE-Beta-[0-9]*-win-x64.exe" -File)
+          # Channel builds output to release-<channel>, not release/. Only
+          # Stable uses release/ (see scripts/run-electron-builder.mjs, which
+          # sets directories.output for every non-stable channel so a Beta build
+          # cannot overwrite Stable's artifacts).
+          $betaInstallers = @(Get-ChildItem "apps/desktop/release-beta/ADE-Beta-[0-9]*-win-x64.exe" -File)
           if ($betaInstallers.Count -ne 1) { throw "Expected exactly one Beta Windows installer, found $($betaInstallers.Count)." }
           & apps/desktop/scripts/windows-installed-product-smoke.ps1 `
             -InstallerPath $env:ADE_STABLE_INSTALLER `
@@ -671,6 +675,9 @@ jobs:
             apps/desktop/release/*.exe
             apps/desktop/release/*.exe.blockmap
             apps/desktop/release/latest.yml
+            apps/desktop/release-beta/*.exe
+            apps/desktop/release-beta/*.exe.blockmap
+            apps/desktop/release-beta/latest.yml
           if-no-files-found: error
           retention-days: 14
   validate-docs:

--- a/apps/desktop/scripts/windows-release-contract.test.mjs
+++ b/apps/desktop/scripts/windows-release-contract.test.mjs
@@ -323,12 +323,23 @@ test("Windows installer names stay GitHub-safe so latest.yml matches the publish
   );
   assert.match(winArtifactValidator, /isGithubSafeAssetName\(installerName\)/);
   assert.match(winArtifactValidator, /build\.win\.artifactName must be/);
-  // The Stable glob must not depend on step ordering to avoid selecting the
-  // Beta installer once both live in apps/desktop/release.
+  // Stable builds to apps/desktop/release; every non-stable channel is
+  // redirected to release-<channel> so a Beta build cannot overwrite Stable's
+  // artifacts. The workflow's lookups have to agree with that redirect --
+  // asserting the CI file merely CONTAINS a glob is not enough, because a glob
+  // pointing at the wrong directory reads as present and then finds nothing at
+  // run time. Pin both halves so they cannot drift apart again.
+  assert.match(electronBuilderWrapper, /--config\.directories\.output=release-\$\{packageChannel\}/);
   const packageJob = jobBlock(ciWorkflow, "package-win", "validate-docs");
   assert.match(packageJob, /release\/ADE-\[0-9\]\*-win-x64\.exe/);
-  assert.match(packageJob, /release\/ADE-Beta-\[0-9\]\*-win-x64\.exe/);
+  assert.match(packageJob, /release-beta\/ADE-Beta-\[0-9\]\*-win-x64\.exe/);
+  // The Beta installer no longer lands in release/, so a lookup there finds
+  // zero files rather than the wrong one.
+  assert.doesNotMatch(packageJob, /[^-]release\/ADE-Beta-/);
   assert.doesNotMatch(packageJob, /ADE Beta-/);
+  // Uploaded previews must cover both channels; release/ alone silently drops
+  // the Beta installer now that it builds elsewhere.
+  assert.match(packageJob, /apps\/desktop\/release-beta\/\*\.exe/);
   assert.match(releaseWorkflow, /release\/ADE-\[0-9\]\*-win-x64\.exe/);
 });
 


### PR DESCRIPTION
`package-win` failed on main. The Beta build succeeded and signed; the lifecycle step then globbed `apps/desktop/release/` and found 0 installers.

Channel builds are redirected to `release-<channel>` so a Beta build cannot overwrite Stable's artifacts. `validate-win-artifacts` was updated to match; this consumer was not. The same cause silently dropped the Beta installer from the uploaded preview artifacts.

The contract test asserted the **old** path and passed, because it checked that the CI file *contains* a glob rather than that the glob agrees with where the build writes. It now pins both halves against each other — verified by reverting the glob and watching the assertion fail.

Contract test: 24/24.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows preview build handling by keeping Beta installers and related metadata separate from Stable release files.
  * Ensured preview downloads and uploaded artifacts consistently reference the correct Beta release location.

* **Tests**
  * Added checks to verify Stable and Beta installers are generated, stored, and uploaded from their expected locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->