### PR TITLE
ci: stop building Windows installers on every commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,27 +17,6 @@ permissions:
   contents: read
 
 jobs:
-  # ── Stage 0: change detection ─────────────────────────────────────────
-  # package-win takes ~40 minutes and ran on every push, so a docs-only
-  # change paid for a full NSIS installer build. This job decides whether
-  # it has to; ci-pass below then distinguishes "skipped because nothing
-  # relevant changed" from "skipped because something upstream broke".
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      package-win: ${{ steps.filter.outputs.package-win }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            package-win:
-              - "apps/desktop/**"
-              - "apps/ade-cli/**"
-              - ".github/workflows/ci.yml"
-              - "!**/*.md"
-
   # ── Stage 1: Install & cache ──────────────────────────────────────────
   install:
     runs-on: ubuntu-latest
@@ -585,101 +564,6 @@ jobs:
           src/main/services/sync/syncHostService.test.ts
           src/main/services/sync/syncService.test.ts
 
-  package-win:
-    needs: [changes, build-runtime-binaries]
-    # Never runs on a pull request. Building the NSIS installer takes ~40
-    # minutes, which is not a reasonable price for review feedback, and a PR
-    # cannot ship anything on its own.
-    #
-    # It still runs on every push to main and on dispatch, and that is
-    # load-bearing rather than belt-and-braces: release-core.yml's verify job
-    # requires a ci-pass check run on the exact SHA it builds, so every SHA
-    # that could be released must have had its installer really built. That is
-    # why `github.ref == 'refs/heads/main'` is its own disjunct: on main the
-    # paths filter is deliberately bypassed, so even a docs-only commit builds
-    # the installer. Releasable SHAs are never sampled.
-    if: >-
-      github.event_name != 'pull_request'
-      && (needs.changes.outputs.package-win == 'true'
-        || github.event_name == 'workflow_dispatch'
-        || github.ref == 'refs/heads/main')
-    runs-on: windows-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: |
-            apps/desktop/package-lock.json
-            apps/ade-cli/package-lock.json
-
-      - name: Install desktop dependencies
-        run: cd apps/desktop && npm ci
-
-      - name: Install ADE CLI dependencies
-        run: cd apps/ade-cli && npm ci
-
-      - name: Download ADE runtime sidecars
-        uses: actions/download-artifact@v4
-        with:
-          pattern: ade-runtime-*
-          path: apps/desktop/resources/runtime
-          merge-multiple: true
-
-      - name: Validate Windows release contract
-        run: npm --prefix apps/desktop run test:win:release-contract
-
-      - name: Build unsigned Stable Windows preview
-        env:
-          ADE_RELEASE_REPOSITORY: ${{ github.repository }}
-          ELECTRON_CACHE: ${{ github.workspace }}\apps\desktop\.cache\electron
-          ELECTRON_BUILDER_CACHE: ${{ github.workspace }}\apps\desktop\.cache\electron-builder
-        run: cd apps/desktop && npm run dist:win
-
-      - name: Record Stable installer
-        shell: pwsh
-        run: |
-          $installers = @(Get-ChildItem "apps/desktop/release/ADE-[0-9]*-win-x64.exe" -File)
-          if ($installers.Count -ne 1) { throw "Expected exactly one Stable Windows installer, found $($installers.Count)." }
-          "ADE_STABLE_INSTALLER=$($installers[0].FullName)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Build unsigned Beta Windows preview
-        env:
-          ADE_PACKAGE_CHANNEL: beta
-          ADE_RELEASE_REPOSITORY: ${{ github.repository }}
-          ELECTRON_CACHE: ${{ github.workspace }}\apps\desktop\.cache\electron
-          ELECTRON_BUILDER_CACHE: ${{ github.workspace }}\apps\desktop\.cache\electron-builder
-        run: cd apps/desktop && npm run dist:win
-
-      - name: Test Stable and Beta installed-product lifecycles
-        shell: pwsh
-        run: |
-          # Channel builds output to release-<channel>, not release/. Only
-          # Stable uses release/ (see scripts/run-electron-builder.mjs, which
-          # sets directories.output for every non-stable channel so a Beta build
-          # cannot overwrite Stable's artifacts).
-          $betaInstallers = @(Get-ChildItem "apps/desktop/release-beta/ADE-Beta-[0-9]*-win-x64.exe" -File)
-          if ($betaInstallers.Count -ne 1) { throw "Expected exactly one Beta Windows installer, found $($betaInstallers.Count)." }
-          & apps/desktop/scripts/windows-installed-product-smoke.ps1 `
-            -InstallerPath $env:ADE_STABLE_INSTALLER `
-            -CompanionInstallerPath $betaInstallers[0].FullName
-
-      - name: Upload Windows preview artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ade-win-preview-${{ github.sha }}
-          path: |
-            apps/desktop/release/*.exe
-            apps/desktop/release/*.exe.blockmap
-            apps/desktop/release/latest.yml
-            apps/desktop/release-beta/*.exe
-            apps/desktop/release-beta/*.exe.blockmap
-            apps/desktop/release-beta/latest.yml
-          if-no-files-found: error
-          retention-days: 14
   validate-docs:
     needs: install
     runs-on: ubuntu-latest
@@ -711,7 +595,6 @@ jobs:
   ci-pass:
     if: always()
     needs:
-      - changes
       - install
       - secret-scan
       - typecheck-desktop
@@ -731,7 +614,6 @@ jobs:
       - build
       - build-runtime-binaries
       - windows-foundation
-      - package-win
       - validate-docs
     runs-on: ubuntu-latest
     steps:
@@ -743,8 +625,6 @@ jobs:
           # `needs:` and forgotten in the loop was never skip-checked, silently
           # and forever. Deriving the list means it cannot drift.
           NEEDS_JSON: ${{ toJSON(needs) }}
-          PACKAGE_WIN_CHANGED: ${{ needs.changes.outputs.package-win }}
-          IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
         run: |
           set -euo pipefail
           # Read the results ONCE into a variable rather than streaming jq
@@ -760,29 +640,15 @@ jobs:
           fi
           failed=0
           while IFS='=' read -r job result; do
-            case "$result" in
-              success) ;;
-              skipped)
-                # 'skipped' means failure for every job EXCEPT package-win, so a
-                # conditional job added later cannot start passing green while
-                # dead. package-win has exactly two legitimate skips: a pull
-                # request never builds the installer, and a push where the paths
-                # filter proved no packaging input changed.
-                if [[ "$job" != "package-win" ]]; then
-                  echo "::error::${job} was skipped"
-                  failed=1
-                elif [[ "$IS_PULL_REQUEST" != "true" && "$PACKAGE_WIN_CHANGED" == "true" ]]; then
-                  echo "::error::package-win was skipped although packaging inputs changed"
-                  failed=1
-                else
-                  echo "package-win skipped: pull request, or no packaging-relevant paths changed"
-                fi
-                ;;
-              *)
-                echo "::error::${job} did not succeed (${result})"
-                failed=1
-                ;;
-            esac
+            # 'skipped' means failure too: every job in needs is unconditional,
+            # so a conditional job added later cannot start passing green while
+            # dead. Installers are NOT built here -- release-core.yml builds
+            # macOS and Windows fresh on the release tag, exactly like macOS
+            # has always worked. CI's job is tests, not packaging.
+            if [[ "$result" != "success" ]]; then
+              echo "::error::${job} did not succeed (${result})"
+              failed=1
+            fi
           done <<< "$results"
           if [[ "$failed" != "0" ]]; then exit 1; fi
           echo "All required CI jobs passed"

--- a/apps/desktop/scripts/windows-release-contract.test.mjs
+++ b/apps/desktop/scripts/windows-release-contract.test.mjs
@@ -325,21 +325,9 @@ test("Windows installer names stay GitHub-safe so latest.yml matches the publish
   assert.match(winArtifactValidator, /build\.win\.artifactName must be/);
   // Stable builds to apps/desktop/release; every non-stable channel is
   // redirected to release-<channel> so a Beta build cannot overwrite Stable's
-  // artifacts. The workflow's lookups have to agree with that redirect --
-  // asserting the CI file merely CONTAINS a glob is not enough, because a glob
-  // pointing at the wrong directory reads as present and then finds nothing at
-  // run time. Pin both halves so they cannot drift apart again.
+  // artifacts. The release workflow builds only Stable (no ADE_PACKAGE_CHANNEL
+  // is set), so its lookup in release/ agrees with that redirect.
   assert.match(electronBuilderWrapper, /--config\.directories\.output=release-\$\{packageChannel\}/);
-  const packageJob = jobBlock(ciWorkflow, "package-win", "validate-docs");
-  assert.match(packageJob, /release\/ADE-\[0-9\]\*-win-x64\.exe/);
-  assert.match(packageJob, /release-beta\/ADE-Beta-\[0-9\]\*-win-x64\.exe/);
-  // The Beta installer no longer lands in release/, so a lookup there finds
-  // zero files rather than the wrong one.
-  assert.doesNotMatch(packageJob, /[^-]release\/ADE-Beta-/);
-  assert.doesNotMatch(packageJob, /ADE Beta-/);
-  // Uploaded previews must cover both channels; release/ alone silently drops
-  // the Beta installer now that it builds elsewhere.
-  assert.match(packageJob, /apps\/desktop\/release-beta\/\*\.exe/);
   assert.match(releaseWorkflow, /release\/ADE-\[0-9\]\*-win-x64\.exe/);
 });
 
@@ -644,29 +632,23 @@ test("one repository variable decides whether a release carries Windows", () => 
   assert.deepEqual([...windowsVariables], ["ADE_WINDOWS_PUBLIC_RELEASE_ENABLED"]);
 });
 
-test("pushes to main build and smoke an unsigned Windows installer", () => {
-  const packageJob = jobBlock(ciWorkflow, "package-win", "validate-docs");
-  // Read the gate out of the `if:` expression, not the whole job: the comment
-  // above it quotes both conditions verbatim, so a job-wide match would pass on
-  // the prose alone after someone deleted the condition itself.
-  const conditionStart = packageJob.indexOf("\n    if:");
-  assert.notEqual(conditionStart, -1, "package-win must carry an if: gate");
-  const packageJobCondition = packageJob.slice(
-    conditionStart,
-    packageJob.indexOf("\n    runs-on:", conditionStart),
-  );
-  assert.match(packageJobCondition, /github\.event_name != 'pull_request'/);
-  // The main-ref disjunct bypasses the paths filter on purpose, and
-  // release-core.yml's verify job depends on it: verify requires a ci-pass
-  // check run on the exact SHA it builds, so a releasable SHA must never be one
-  // whose installer the paths filter skipped.
-  assert.match(packageJobCondition, /github\.ref == 'refs\/heads\/main'/);
-  assert.match(packageJob, /runs-on: windows-latest/);
-  assert.match(packageJob, /npm run dist:win/);
-  assert.match(packageJob, /ADE_PACKAGE_CHANNEL: beta/);
-  assert.match(packageJob, /windows-installed-product-smoke\.ps1/);
-  assert.match(packageJob, /-CompanionInstallerPath/);
-  assert.match(packageJob, /ADE_STABLE_INSTALLER/);
+test("CI runs Windows tests but never builds installers -- packaging belongs to the release tag", () => {
+  // CI packaged a full unsigned Stable + Beta NSIS pair on every push to main:
+  // ~40 minutes per commit for artifacts nothing consumed. No macOS installer
+  // has ever been built in CI either -- release-core.yml builds every platform
+  // fresh on the release tag, signed, and its verify job needs ci-pass (the
+  // TESTS) on that SHA, not a pre-built installer. These pins keep packaging
+  // from creeping back into the per-commit path.
+  assert.doesNotMatch(ciWorkflow, /npm run dist:win/);
+  assert.doesNotMatch(ciWorkflow, /dist:win:signed/);
+  assert.doesNotMatch(ciWorkflow, /\bpackage-win\b/);
+  // The Windows test job stays: it is the platform's test-desktop, not packaging.
+  assert.match(ciWorkflow, /windows-foundation:/);
+  const ciPass = jobBlock(ciWorkflow, "ci-pass", null);
+  assert.match(ciPass, /- windows-foundation/);
+  // The signed release path carries the packaging + installed-product smoke.
+  assert.match(releaseWorkflow, /dist:win:signed/);
+  assert.match(releaseWorkflow, /windows-installed-product-smoke\.ps1/);
   const installedSmoke = fs.readFileSync(
     path.join(desktopRoot, "scripts", "windows-installed-product-smoke.ps1"),
     "utf8",
@@ -674,10 +656,6 @@ test("pushes to main build and smoke an unsigned Windows installer", () => {
   assert.match(installedSmoke, /Stop-InstalledProductProcesses/);
   assert.match(installedSmoke, /ExecutablePath/);
   assert.match(installedSmoke, /missing-executable repair/);
-  assert.match(packageJob, /Test Stable and Beta installed-product lifecycles/);
-  assert.doesNotMatch(packageJob, /dist:win:signed/);
-  const ciPass = jobBlock(ciWorkflow, "ci-pass", null);
-  assert.match(ciPass, /- package-win/);
 });
 
 test("Windows package smoke requires every bundled provider runtime", () => {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1515,8 +1515,9 @@ Stages:
    - `build` — desktop, ade-cli, and web built sequentially after install.
    - `validate-docs` — `node scripts/validate-docs.mjs`.
 3. **Windows foundation proof** (`windows-foundation`) — a native `windows-latest` runner typechecks desktop and CLI code and exercises the per-user/channel service, filesystem layout, process/executable, named-pipe, PTY, packaged CR-SQLite, and platform-capability contracts.
-4. **Windows package proof** (`package-win`) — a `windows-latest` runner downloads every Darwin/Linux runtime sidecar, runs the release-contract test, builds an unsigned x64 NSIS preview, performs packaged CLI/TUI/PTY/provider/CR-SQLite/updater-authority smoke validation, then exercises fresh install, repair, reinstall, launch/deep-link registration, file association, startup registration, PATH ownership, and uninstall cleanup before uploading the installer, blockmap, and `latest.yml` for 14 days.
-5. **Gate** (`ci-pass`) — all required jobs, including `windows-foundation` and `package-win`, must pass (`if: always()` with failure/cancelled detection).
+4. **Gate** (`ci-pass`) — every job in its `needs:` list must succeed; a `skipped` result counts as failure so a conditional job can never pass green while dead (`if: always()`, results derived from `toJSON(needs)`).
+
+CI never builds installers — for any platform. Packaging (macOS DMG/ZIP and the signed Windows NSIS installer, including the installed-product lifecycle smoke: install, repair, reinstall, deep-link/file-association/startup/PATH registration, uninstall cleanup) happens once, on the release tag, in `release-core.yml`. CI's job is tests; the release's job is artifacts.
 
 Sharding is required because the desktop suite is large enough to be slow in a single process.
 


### PR DESCRIPTION
Removes `package-win` (and its `changes` paths-filter job) from CI. It built an unsigned Stable + Beta NSIS pair on every push to main — ~40 min/commit for artifacts nothing consumed. macOS has never had a packaging job in CI; Windows now matches. `release-core.yml` builds both platforms fresh and signed on the release tag and runs the installed-product smoke there, and its verify gate needs `ci-pass` (tests) on the SHA, not a pre-built installer.

Contract test rewritten to pin the invariant: no `dist:win` anywhere in ci.yml, `windows-foundation` (tests) stays required, signed release path carries packaging + smoke. 24/24 passing; docs validators green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)