### PR TITLE
fix(web): portal the connections popover out of the header's clipped strip

### DIFF
--- a/apps/desktop/src/renderer/webclient/workspace/WebConnectionsChip.tsx
+++ b/apps/desktop/src/renderer/webclient/workspace/WebConnectionsChip.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import { createPortal } from "react-dom";
 import {
   CaretDown,
   CircleNotch,
@@ -102,6 +103,25 @@ export function WebConnectionsChip() {
   const [renameValue, setRenameValue] = useState("");
   const [error, setError] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  /**
+   * Where the portaled popover goes, measured from the chip. The header's
+   * trailing strip clips its own overflow so it cannot slide under the Windows
+   * caption buttons at narrow widths — which also clips anything rendered
+   * inline below the header. The desktop Connections panel already escapes
+   * through a body portal for exactly this reason; this popover does the same,
+   * so it needs explicit coordinates instead of `absolute` in the chip.
+   */
+  const [anchor, setAnchor] = useState<{ top: number; right: number } | null>(null);
+  const measureAnchor = useCallback(() => {
+    const rect = rootRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setAnchor({
+      top: rect.bottom + 8,
+      right: Math.max(8, window.innerWidth - rect.right),
+    });
+  }, []);
 
   const machines = useWebMachines();
 
@@ -151,8 +171,18 @@ export function WebConnectionsChip() {
 
   useEffect(() => {
     if (!open) return;
+    measureAnchor();
+    window.addEventListener("resize", measureAnchor);
+    return () => window.removeEventListener("resize", measureAnchor);
+  }, [open, measureAnchor]);
+
+  useEffect(() => {
+    if (!open) return;
     const onPointerDown = (event: PointerEvent) => {
+      // The popover lives in a body portal, so it is outside rootRef's subtree
+      // and needs its own containment check or every click inside it closes it.
       if (rootRef.current?.contains(event.target as Node)) return;
+      if (popoverRef.current?.contains(event.target as Node)) return;
       setOpen(false);
       setMenuKey(null);
     };
@@ -234,13 +264,14 @@ export function WebConnectionsChip() {
         <CaretDown size={9} weight="bold" className="shrink-0 opacity-70" />
       </button>
 
-      {open ? (
+      {open && anchor ? createPortal(
         <div
+          ref={popoverRef}
           role="dialog"
           aria-label="Machines"
           data-ade-web-connections
-          className="absolute right-0 top-[calc(100%+8px)] z-50 w-[300px] overflow-hidden"
-          style={POPOVER_SURFACE}
+          className="fixed z-[70] w-[300px] overflow-hidden"
+          style={{ ...POPOVER_SURFACE, top: anchor.top, right: anchor.right }}
         >
           <div className="max-h-[320px] overflow-auto p-2">
             {machines.length === 0 ? (
@@ -293,7 +324,8 @@ export function WebConnectionsChip() {
           >
             To add a machine: sign in to ADE on it.
           </div>
-        </div>
+        </div>,
+        document.body,
       ) : null}
     </div>
   );

--- a/apps/desktop/src/renderer/webclient/workspace/__tests__/WebConnectionsChip.test.tsx
+++ b/apps/desktop/src/renderer/webclient/workspace/__tests__/WebConnectionsChip.test.tsx
@@ -244,6 +244,23 @@ describe("WebConnectionsChip", () => {
     expect(screen.getByLabelText("Connect to Mac Studio")).toBeTruthy();
   });
 
+  it("portals the popover to document.body, out of the header's clipped strip", async () => {
+    // Regression: the header's trailing strip is overflow-hidden so it clips
+    // instead of sliding under the Windows caption buttons. Rendered inline,
+    // the popover opened INSIDE that strip — present in the DOM, styled
+    // visible, and completely clipped away, with nothing in the console. The
+    // desktop Connections panel escapes through a body portal; the chip's
+    // popover must do the same, and this is the one assertion jsdom can make
+    // about it (it cannot see CSS clipping).
+    renderChip([
+      machine({ machineKey: "studio", name: "Mac Studio", dialable: true, online: true }),
+    ]);
+
+    openPopover();
+    const popover = await screen.findByRole("dialog");
+    expect(popover.parentElement).toBe(document.body);
+  });
+
   it("reports the focused project tab's machine, not whichever one is live", () => {
     renderChip(
       [


### PR DESCRIPTION
The Windows caption-clearance commit (c6608ace) made the header's trailing strip `overflow-hidden`. The web client's connections popover rendered inline inside that strip, so it opened into a clipped box — in the DOM, visible by style, and completely unseeable, no console errors. Diagnosed live on the hosted client: `getBoundingClientRect` correct, `elementFromPoint` at its center hit the page content underneath.

Fix: portal to `document.body`, same as the desktop Connections panel. Outside-click checks both subtrees. Swept the header strip + webclient tree — every other popover already portals; this was the only inline one.

9/9 chip tests (new one pins `popover.parentElement === document.body`), desktop typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the connections popover positioning so it displays correctly without being clipped by the header.
  * Preserved interactions within the popover when clicking outside the connections chip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->