### PR TITLE
fix(release): make the Authenticode probe name its failure and retry transients

### DIFF
--- a/apps/desktop/scripts/validate-win-artifacts.mjs
+++ b/apps/desktop/scripts/validate-win-artifacts.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import asar from "@electron/asar";
 import { parse as parseYaml } from "yaml";
 import packagedAdeCliResourcesModule from "./packaged-ade-cli-resources.cjs";
-import { createAuthenticodeProbe } from "./windows-authenticode.mjs";
+import { AUTHENTICODE_PROBE_ERROR_STATUS, createAuthenticodeProbe } from "./windows-authenticode.mjs";
 import {
   isGithubSafeAssetName,
   resolveWindowsPackageIdentity,
@@ -922,20 +922,41 @@ async function validateAuthenticodeSignature(filePath, description, expectedIden
   // Passing filePath as a trailing argv value therefore turns it into source
   // code instead of $args[0]. Carry it in the child environment so paths with
   // spaces and PowerShell metacharacters remain data.
+  //
+  // Retried because the failure the probe reports as AdeProbeError is
+  // environmental, not a verdict about the artifact: the first signed release
+  // run died here on a file that existed and had just been signed, with the
+  // cmdlet throwing rather than answering — the shape of a scanner holding a
+  // just-written multi-GB installer. A real bad signature answers immediately
+  // ("NotSigned", "HashMismatch") and is never retried.
   const probe = createAuthenticodeProbe(filePath);
-  const { stdout } = await runCommand(probe.command, probe.args, { env: probe.env });
-
   let payload;
-  try {
-    payload = JSON.parse(stdout.trim());
-  } catch {
-    fail(`Unable to parse Authenticode signature status for ${description}: ${stdout.trim() || "empty output"}`);
+  let lastStderr = "";
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const { stdout, stderr } = await runCommand(probe.command, probe.args, { env: probe.env });
+    lastStderr = stderr.trim();
+    try {
+      payload = JSON.parse(stdout.trim());
+    } catch {
+      fail(
+        `Unable to parse Authenticode signature status for ${description}: ${stdout.trim() || "empty output"}` +
+          (lastStderr ? `\nprobe stderr: ${lastStderr}` : ""),
+      );
+    }
+    const retryable = payload?.Status === AUTHENTICODE_PROBE_ERROR_STATUS || !payload?.Status;
+    if (!retryable || attempt === 3) break;
+    console.log(
+      `[validate-win-artifacts] Signature probe for ${description} failed transiently ` +
+        `(${payload?.StatusMessage || lastStderr || "no detail"}); retrying in ${attempt * 10}s.`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, attempt * 10_000));
   }
 
   if (payload?.Status !== "Valid") {
     fail(
       `${description} is not Authenticode signed with a valid signature: ` +
-        `${payload?.Status ?? "unknown"} ${payload?.StatusMessage ?? ""}`.trim(),
+        `${payload?.Status || "unknown"} ${payload?.StatusMessage ?? ""}`.trim() +
+        (lastStderr ? `\nprobe stderr: ${lastStderr}` : ""),
     );
   }
   if (!payload?.TimestampSubject) {

--- a/apps/desktop/scripts/windows-authenticode.mjs
+++ b/apps/desktop/scripts/windows-authenticode.mjs
@@ -1,20 +1,46 @@
 export const AUTHENTICODE_FILE_PATH_ENV = "ADE_WINDOWS_AUTHENTICODE_FILE_PATH";
 
+/**
+ * Status the probe reports when Get-AuthenticodeSignature itself threw, as
+ * opposed to answering. Callers treat it as retryable: the observed cause is
+ * environmental (a virus scanner holding a just-written multi-GB installer),
+ * not a property of the artifact.
+ */
+export const AUTHENTICODE_PROBE_ERROR_STATUS = "AdeProbeError";
+
 export function createAuthenticodeProbe(filePath, baseEnv = process.env) {
   const normalizedPath = String(filePath ?? "").trim();
   if (!normalizedPath) {
     throw new Error("Authenticode validation requires a file path.");
   }
 
+  // A thrown Get-AuthenticodeSignature (file locked by a scanner, unreadable,
+  // provider error) previously left $sig null, so every field stringified to
+  // empty and the caller reported `not ... signed with a valid signature: `
+  // with nothing after the colon — the one release-blocking failure that then
+  // carried zero diagnosis. Catch it and put the exception message where the
+  // caller already looks, under a status no real signature check can produce.
   const script = [
-    `$sig = Get-AuthenticodeSignature -LiteralPath $env:${AUTHENTICODE_FILE_PATH_ENV}`,
-    "[pscustomobject]@{",
-    "  Status = [string]$sig.Status;",
-    "  StatusMessage = [string]$sig.StatusMessage;",
-    "  Subject = if ($sig.SignerCertificate) { [string]$sig.SignerCertificate.Subject } else { $null };",
-    "  Thumbprint = if ($sig.SignerCertificate) { [string]$sig.SignerCertificate.Thumbprint } else { $null };",
-    "  TimestampSubject = if ($sig.TimeStamperCertificate) { [string]$sig.TimeStamperCertificate.Subject } else { $null }",
-    "} | ConvertTo-Json -Compress",
+    "$result = $null",
+    "try {",
+    `  $sig = Get-AuthenticodeSignature -LiteralPath $env:${AUTHENTICODE_FILE_PATH_ENV} -ErrorAction Stop`,
+    "  $result = [pscustomobject]@{",
+    "    Status = [string]$sig.Status;",
+    "    StatusMessage = [string]$sig.StatusMessage;",
+    "    Subject = if ($sig.SignerCertificate) { [string]$sig.SignerCertificate.Subject } else { $null };",
+    "    Thumbprint = if ($sig.SignerCertificate) { [string]$sig.SignerCertificate.Thumbprint } else { $null };",
+    "    TimestampSubject = if ($sig.TimeStamperCertificate) { [string]$sig.TimeStamperCertificate.Subject } else { $null }",
+    "  }",
+    "} catch {",
+    "  $result = [pscustomobject]@{",
+    `    Status = "${AUTHENTICODE_PROBE_ERROR_STATUS}";`,
+    "    StatusMessage = [string]$_.Exception.Message;",
+    "    Subject = $null;",
+    "    Thumbprint = $null;",
+    "    TimestampSubject = $null",
+    "  }",
+    "}",
+    "$result | ConvertTo-Json -Compress",
   ].join("\n");
 
   return {

--- a/apps/desktop/scripts/windows-authenticode.test.mjs
+++ b/apps/desktop/scripts/windows-authenticode.test.mjs
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { spawnSync } from "node:child_process";
-import { createAuthenticodeProbe } from "./windows-authenticode.mjs";
+import { AUTHENTICODE_PROBE_ERROR_STATUS, createAuthenticodeProbe } from "./windows-authenticode.mjs";
 
 test("Authenticode probe treats paths as data instead of PowerShell source", {
   skip: process.platform !== "win32",
@@ -27,4 +27,27 @@ test("Authenticode probe treats paths as data instead of PowerShell source", {
   if (!/module could not be loaded/i.test(result.stderr)) {
     assert.equal(payload.Status, "NotSigned");
   }
+});
+
+test("Authenticode probe reports its own failure instead of an empty status", {
+  skip: process.platform !== "win32",
+}, () => {
+  // Regression: when Get-AuthenticodeSignature threw (scanner lock, unreadable
+  // file), $sig stayed null, every field stringified to empty, and the first
+  // signed Windows release died with `...not Authenticode signed with a valid
+  // signature: ` — a release blocker carrying zero diagnosis. The probe must
+  // answer with a status no real signature check produces, plus the exception
+  // text, so the validator can retry transients and name persistent failures.
+  const probe = createAuthenticodeProbe(
+    path.join(os.tmpdir(), "ade-authenticode-no-such-file.exe"),
+  );
+  const result = spawnSync(probe.command, probe.args, {
+    env: probe.env,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout.trim());
+  assert.equal(payload.Status, AUTHENTICODE_PROBE_ERROR_STATUS);
+  assert.match(String(payload.StatusMessage), /not found|cannot find|does not exist/i);
 });


### PR DESCRIPTION
The signed Windows release build failed at signature validation with an empty reason: when `Get-AuthenticodeSignature` throws (scanner holding a just-written 1.7GB installer being the likely cause), `$sig` stays null, every field stringifies to empty, and the validator discarded stderr. Reproduced the empty-status shape locally; ruled out file size empirically (1.8GB probes fine).

Probe now reports `AdeProbeError` + exception text from a try/catch; validator surfaces stderr in all failures and retries probe errors 3x with backoff. Real verdicts are never retried. 2/2 probe tests, 24/24 contract tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)