### PR TITLE
fix(release): stop pwsh's PSModulePath breaking the 5.1 Authenticode probe

### DIFF
--- a/apps/desktop/scripts/windows-authenticode.mjs
+++ b/apps/desktop/scripts/windows-authenticode.mjs
@@ -43,6 +43,22 @@ export function createAuthenticodeProbe(filePath, baseEnv = process.env) {
     "$result | ConvertTo-Json -Compress",
   ].join("\n");
 
+  // Windows PowerShell 5.1 must not inherit PowerShell 7's PSModulePath. On
+  // GitHub runners every workflow step runs under pwsh, which exports a
+  // PSModulePath whose PS7 Microsoft.PowerShell.Security shadows 5.1's
+  // built-in; 5.1 finds the Core-only module first and fails to load it, so
+  // Get-AuthenticodeSignature dies with "the module could not be loaded" on
+  // every probe -- which is exactly how the first signed release run failed.
+  // Reproduced locally by pointing PSModulePath at a Core-only Security
+  // module. Dropping the variable makes 5.1 rebuild its default module path.
+  const env = {
+    ...baseEnv,
+    [AUTHENTICODE_FILE_PATH_ENV]: normalizedPath,
+  };
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === "psmodulepath") delete env[key];
+  }
+
   return {
     command: "powershell.exe",
     args: [
@@ -52,9 +68,6 @@ export function createAuthenticodeProbe(filePath, baseEnv = process.env) {
       "-Command",
       script,
     ],
-    env: {
-      ...baseEnv,
-      [AUTHENTICODE_FILE_PATH_ENV]: normalizedPath,
-    },
+    env,
   };
 }

--- a/apps/desktop/scripts/windows-authenticode.test.mjs
+++ b/apps/desktop/scripts/windows-authenticode.test.mjs
@@ -24,9 +24,53 @@ test("Authenticode probe treats paths as data instead of PowerShell source", {
   const payload = JSON.parse(result.stdout.trim());
   assert.ok(Object.hasOwn(payload, "Status"));
   assert.doesNotMatch(result.stderr, /ParserError|positional parameter/i);
-  if (!/module could not be loaded/i.test(result.stderr)) {
-    assert.equal(payload.Status, "NotSigned");
-  }
+  // This assertion used to be skipped when stderr said "module could not be
+  // loaded" -- which was this test observing the PSModulePath poisoning bug
+  // and stepping around it instead of failing. The probe now strips
+  // PSModulePath, so the answer must always be real.
+  assert.equal(payload.Status, "NotSigned");
+});
+
+test("Authenticode probe survives inheriting PowerShell 7's PSModulePath", {
+  skip: process.platform !== "win32",
+}, (t) => {
+  // Regression for the failure that killed the first two signed release runs:
+  // GitHub runs workflow steps under pwsh, whose PSModulePath makes Windows
+  // PowerShell 5.1 find a Core-only Microsoft.PowerShell.Security first and
+  // fail to load it, so Get-AuthenticodeSignature dies before answering. The
+  // fixture reconstructs that shadowing exactly; the probe must still answer.
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ade-psmodulepath-"));
+  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+  const moduleDir = path.join(tempRoot, "Microsoft.PowerShell.Security");
+  fs.mkdirSync(moduleDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(moduleDir, "Microsoft.PowerShell.Security.psd1"),
+    [
+      "@{",
+      "ModuleVersion = '7.0.0.0'",
+      "PowerShellVersion = '7.2'",
+      "CompatiblePSEditions = @('Core')",
+      "CmdletsToExport = @('Get-AuthenticodeSignature')",
+      "}",
+      "",
+    ].join("\n"),
+  );
+  const targetPath = path.join(tempRoot, "unsigned.ps1");
+  fs.writeFileSync(targetPath, "Write-Output 'unsigned'\n");
+
+  const probe = createAuthenticodeProbe(targetPath, {
+    ...process.env,
+    PSModulePath: tempRoot,
+  });
+  const result = spawnSync(probe.command, probe.args, {
+    env: probe.env,
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout.trim());
+  assert.equal(payload.Status, "NotSigned");
+  assert.doesNotMatch(String(payload.StatusMessage), /module could not be loaded/i);
 });
 
 test("Authenticode probe reports its own failure instead of an empty status", {


### PR DESCRIPTION
Run 2's instrumented failure named the bug: `Microsoft.PowerShell.Security ... could not be loaded`. GitHub steps run under pwsh; its PSModulePath makes the spawned Windows PowerShell 5.1 find PS7's Core-only Security module first and fail to load it — deterministic, so the retries couldn't save it.

Reproduced byte-for-byte locally with a Core-only module manifest; fix (strip PSModulePath from the probe child) turns the same repro into a real `Valid`/`NotSigned` answer. Removed the old test's escape hatch that skipped asserting when this exact error appeared, and added a regression test reconstructing the shadowing. 3/3 probe tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows code-signature detection when PowerShell 7 environment settings interfere with Windows PowerShell.
  * Authenticode checks now reliably report unsigned files instead of failing with module-loading errors.

* **Tests**
  * Added regression coverage for PowerShell environment conflicts.
  * Strengthened validation of unsigned-file detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->