### PR TITLE
feat(web): make the Windows download permanent

### DIFF
--- a/apps/desktop/scripts/windows-release-contract.test.mjs
+++ b/apps/desktop/scripts/windows-release-contract.test.mjs
@@ -672,16 +672,20 @@ test("Windows package smoke requires every bundled provider runtime", () => {
   assert.match(winArtifactValidator, /droidSdkCreateSession/);
 });
 
-test("the site gates the Windows release and enables dedicated analytics", () => {
-  assert.match(heroDownloads, /VITE_ADE_WINDOWS_DOWNLOAD_ENABLED/);
-  assert.match(heroDownloads, /=== "1"/);
-  // Ungated, the Windows CTA must not read as an available download, and must
-  // say what has to happen first. Wording is free to change; what this pins is
-  // that the disclosure exists at all, so nobody can quietly ship a Windows
-  // button implying an artifact is there. The label itself is checked because
-  // it is the only thing most visitors read.
-  assert.match(heroDownloads, /signed installer ships once the Windows release proof passes/);
-  assert.match(heroDownloads, /Windows \(beta\)/);
+test("the Windows download is permanently live and carries dedicated analytics", () => {
+  // The site-side gate existed so a Windows button could never imply an
+  // artifact that was not published. v1.2.52 shipped the signed installer, so
+  // the gate is retired: the button now pins the opposite invariant -- a
+  // permanent, ungated link straight to the latest release. If Windows assets
+  // ever have to be pulled, take the button out; do not resurrect the flag,
+  // because a dead env var reads as "off by accident" forever.
+  assert.doesNotMatch(heroDownloads, /VITE_ADE_WINDOWS_DOWNLOAD_ENABLED\s*===/);
+  assert.match(heroDownloads, /Download for Windows/);
+  // The Windows anchor specifically (its href sits directly above its
+  // analytics attribute) must point at the latest release, not the list.
+  assert.match(
+    heroDownloads,
+    /href=\{LINKS\.releasesLatest\}\s*\n\s*data-ade-analytics-feature=\{MARKETING_FEATURES\.DOWNLOAD_WINDOWS\}/,
+  );
   assert.match(heroDownloads, /MARKETING_FEATURES\.DOWNLOAD_WINDOWS/);
-  assert.match(heroDownloads, /WINDOWS_DOWNLOAD_ENABLED \? LINKS\.releasesLatest : LINKS\.releases/);
 });

--- a/apps/web/src/components/editorial/Lede.tsx
+++ b/apps/web/src/components/editorial/Lede.tsx
@@ -7,10 +7,10 @@ import {
   MARKETING_FEATURES,
 } from "../../lib/marketingAnalytics";
 
-// Windows downloads stay gated until the signed release proof passes. This is
-// the only switch the site reads; ADE_WINDOWS_PUBLIC_RELEASE_ENABLED is the CI
-// variable that actually produces the assets.
-const WINDOWS_DOWNLOAD_ENABLED = import.meta.env.VITE_ADE_WINDOWS_DOWNLOAD_ENABLED === "1";
+// The Windows download is permanently on: v1.2.52 shipped the first signed
+// Windows installer, so the VITE_ADE_WINDOWS_DOWNLOAD_ENABLED gate this
+// constant used to read is retired. ADE_WINDOWS_PUBLIC_RELEASE_ENABLED remains
+// the CI-side switch that produces the assets.
 
 /**
  * Real platform marks. lucide dropped brand logos over trademark concerns, so
@@ -99,28 +99,21 @@ export function Lede() {
           >
             <AppleMark className="h-4 w-4" /> Download for Mac
           </a>
-          {/* Windows sits beside macOS rather than behind a download page, but
-              the installer is not published until the release proof passes.
-              Until the gate flips this links to the releases list and says
-              "beta" rather than promising a file that 404s. The wording is
-              pinned by the Windows release contract test, which used to pin
-              the download page. */}
+          {/* Windows sits beside macOS rather than behind a download page.
+              The wording is pinned by the Windows release contract test, which
+              used to pin the download page. */}
           <a
-            href={WINDOWS_DOWNLOAD_ENABLED ? LINKS.releasesLatest : LINKS.releases}
+            href={LINKS.releasesLatest}
             data-ade-analytics-feature={MARKETING_FEATURES.DOWNLOAD_WINDOWS}
             data-ade-analytics-cta={MARKETING_CTA_LABELS.DOWNLOAD_WINDOWS}
             data-ade-analytics-position={MARKETING_CTA_POSITIONS.HERO}
             target="_blank"
             rel="noreferrer"
-            title={
-              WINDOWS_DOWNLOAD_ENABLED
-                ? "Windows 10/11 x64. Per-user installer, no administrator rights."
-                : "Windows 10/11 x64. The signed installer ships once the Windows release proof passes."
-            }
+            title="Windows 10/11 x64. Per-user installer, no administrator rights."
             className="inline-flex items-center gap-2 rounded-[2px] border border-[color:var(--color-hairline-strong)] px-5 py-3 text-[14px] font-medium text-[color:var(--color-cream)] transition-colors hover:border-[color:var(--color-cream)] hover:bg-white/[0.04]"
           >
             <WindowsMark className="h-[15px] w-[15px]" />
-            {WINDOWS_DOWNLOAD_ENABLED ? "Download for Windows" : "Windows (beta)"}
+            Download for Windows
           </a>
           <a
             href={LINKS.testflight}


### PR DESCRIPTION
v1.2.52 shipped the signed installer; the `VITE_ADE_WINDOWS_DOWNLOAD_ENABLED` gate is retired. Hero button links straight to the latest release. Contract test now pins the permanent link instead of the gate. 24/24, web typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows downloads are now permanently available.
  * Added a direct link to the latest Windows release with dedicated download analytics.
  * Updated the download call-to-action to consistently show the full label and signed-installer title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->