### PR TITLE
docs(release): v1.2.53 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.53] - 2026-08-05
+
+### Added
+
+- One-command brain install: `curl -fsSL https://ade-app.dev/install.sh | sh` (macOS/Linux) and `irm https://ade-app.dev/install.ps1 | iex` (Windows), with checksum verification, staged rollback, background-service registration, sign-in, and optional desktop app install.
+- `ade connect` — idempotent sign-in → service → machine-publish chain; `ade tools status|ensure|gc` for the shared agent-tools cache.
+- Linux brain as a first-class target (x64/arm64), controllable from desktop, web, and iOS.
+- Website install dialog with per-platform one-liners, direct downloads, and Homebrew; stable `/install.sh`, `/install.ps1`, and `/download/*` endpoints on ade-app.dev.
+
+### Changed
+
+- Agent CLIs (Codex, Claude Code, OpenCode) are fetched on first run — manifest-pinned with sha512 integrity from the npm registry — into a shared versioned cache instead of being bundled twice per install; downloads and updates shrink by hundreds of megabytes.
+- Release packaging is target-only per platform/arch, enforced by pre-build purity gates and post-package size budgets (macOS ≤ 800 MiB, Windows ≤ 900 MiB).
+
+### Fixed
+
+- macOS auto-update crash on oversized archives (Squirrel.Mac CFData 1 GiB doubling cliff): the updater refuses oversized artifacts with a typed error, and CI prevents oversized packages from publishing.
+- Cross-platform SSH provisioning of a different-platform machine downloads the exact-version runtime from release assets, checksum-verified, instead of hard-failing.
+- Windows file-lock contention handling in the tools cache, per-tool fetch isolation, first-run "downloading" state for agent runtimes, and the packaged app dropped ~590 MiB of never-executed code.
+
+
 ## [1.2.52] - 2026-08-04
 
 ### Windows
@@ -1382,6 +1403,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial public release.
 
 [Unreleased]: https://github.com/arul28/ADE/compare/v1.2.49...HEAD
+[1.2.53]: https://github.com/arul28/ADE/compare/v1.2.52...v1.2.53
 [1.2.52]: https://github.com/arul28/ADE/compare/v1.2.51...v1.2.52
 [1.2.51]: https://github.com/arul28/ADE/compare/v1.2.50...v1.2.51
 [1.2.50]: https://github.com/arul28/ADE/compare/v1.2.49...v1.2.50

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.52">
-  v1.2.52 - ADE runs on Windows, plus the credential-store and main-thread fixes that came out of the same audit.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.53">
+  v1.2.53 - One-command install with account connect, downloads a fraction of the size, and the macOS auto-update crash fixed structurally.
 </Card>

--- a/changelog/v1.2.53.mdx
+++ b/changelog/v1.2.53.mdx
@@ -1,0 +1,34 @@
+---
+title: "v1.2.53"
+description: "Release notes for ADE v1.2.53 - August 5, 2026"
+---
+
+This release rebuilds how ADE is installed, downloaded, and updated. One command now installs the ADE brain on macOS, Windows, or a Linux server and connects it to your account; the desktop download is a fraction of its former size; and the macOS auto-update crash that v1.2.52 could trigger is fixed structurally, with CI gates that keep it fixed.
+
+---
+
+## Install ADE with one command
+
+- **`curl -fsSL https://ade-app.dev/install.sh | sh`** (macOS and Linux) or **`irm https://ade-app.dev/install.ps1 | iex`** (Windows) installs the ADE brain — the self-contained engine behind every ADE surface. No Node, npm, or any other prerequisite: the installer verifies checksums, stages with rollback, and registers the brain as a per-user background service (launchd, systemd, or a Windows startup entry — never an elevated shell).
+- **The installer signs you in and connects the machine.** After installing it offers `ade connect`: sign in (a copy-paste device flow when you're over SSH), publish the machine to your account, and it's reachable from ADE desktop, [the web client](https://app.ade-app.dev), and iOS. On macOS and Windows it can install the desktop app too.
+- **`ade connect` is idempotent.** Run it any time to check or repair the account → service → machine chain; `--status` reports without changing anything, `--no-login` keeps a machine local/LAN-only.
+- **Linux is now a first-class home for the brain.** Run one command on any Linux box (x64 or arm64) and drive it from your Mac, Windows machine, phone, or browser. There is no Linux desktop app — the brain is the whole engine.
+- The website now has an install dialog behind every download button: the one-liner, direct downloads per architecture, and Homebrew, side by side.
+
+## Downloads are a fraction of the size
+
+- **The macOS download is well under half its previous size, and the Windows installer shrank by more than a gigabyte.** Two structural fixes: every build previously shipped every platform's runtime (the Windows installer carried both macOS runtimes; macOS carried Windows), and the heavyweight agent CLIs were bundled twice per install.
+- **Agent CLIs are now fetched, pinned, and shared.** Codex, Claude Code, and OpenCode download on first run from the npm registry — exact versions pinned by a manifest with cryptographic integrity checks, stored once in a shared cache (`~/.ade/tools`) used by the desktop app and the brain alike. Updates stop re-downloading hundreds of megabytes of unchanged vendor binaries when nothing was repinned.
+- **Updates can never hit the crash cliff again.** v1.2.52's macOS package crossed 1 GiB and crashed Squirrel.Mac during auto-update. The updater now refuses oversized artifacts outright, and the release pipeline hard-fails any macOS package over 800 MiB before it can publish.
+
+## Fixes
+
+- Cross-platform remote provisioning works again: setting up a Linux or Windows machine over SSH from a Mac (or vice versa) downloads the exact-version runtime from the release, checksum-verified, instead of failing.
+- The auto-updater reports a typed, actionable error state instead of dying when an artifact is oversized, and preserves verified downloads across retries.
+- `ade tools status | ensure | gc` manages the shared agent-tools cache; the brain fetches missing tools in the background and repairs itself without a restart.
+- Dozens of correctness fixes from this release's review cycle, including Windows file-lock contention handling, per-tool fetch isolation, and a first-run state that says "downloading" instead of "not found" while agent runtimes are still arriving.
+
+## Under the hood
+
+- The packaged app dropped ~590 MiB of never-executed code: renderer libraries were shipping twice (bundled and raw), and dead packages are gone entirely.
+- Release CI now gates every build: target-purity checks in seconds before the build, size budgets after packaging, and archive-content assertions derived from one canonical package list.

--- a/docs.json
+++ b/docs.json
@@ -181,6 +181,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.53",
               "changelog/v1.2.52",
               "changelog/v1.2.51",
               "changelog/v1.2.50",


### PR DESCRIPTION
Release notes + changelog surfaces for v1.2.53 (distribution overhaul). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)