### PR TITLE
fix(web): explicit .js specifiers for Vercel native-ESM api functions

### DIFF
--- a/apps/web/api/download.ts
+++ b/apps/web/api/download.ts
@@ -29,7 +29,7 @@ import {
   type VercelQuery,
   type VercelReq,
   type VercelRes,
-} from "./releaseAssets";
+} from "./releaseAssets.js";
 
 function flatQuery(query: VercelQuery): Record<string, string | undefined> {
   return {

--- a/apps/web/api/install.ts
+++ b/apps/web/api/install.ts
@@ -28,7 +28,7 @@ import {
   stableAssetUrl,
   type VercelReq,
   type VercelRes,
-} from "./releaseAssets";
+} from "./releaseAssets.js";
 
 export default async function handler(req: VercelReq, res: VercelRes): Promise<void> {
   if (rejectDisallowedMethod(req, res)) return;

--- a/apps/web/api/releaseAssets.test.ts
+++ b/apps/web/api/releaseAssets.test.ts
@@ -15,9 +15,9 @@ import {
   selectAssetUrl,
   stableAssetUrl,
   type VercelRes,
-} from "./releaseAssets";
-import downloadHandler from "./download";
-import installHandler from "./install";
+} from "./releaseAssets.js";
+import downloadHandler from "./download.js";
+import installHandler from "./install.js";
 
 const DOWNLOAD_PREFIX = "https://github.com/arul28/ADE/releases/download/v1.2.52";
 

--- a/apps/web/api/tsconfig.json
+++ b/apps/web/api/tsconfig.json
@@ -1,11 +1,14 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "allowImportingTsExtensions": true,
-    "lib": ["ES2022"],
-    "types": ["node"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022"
+    ],
+    "types": [
+      "node"
+    ],
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
@@ -14,5 +17,7 @@
     "resolveJsonModule": true,
     "baseUrl": "."
   },
-  "include": ["./**/*.ts"]
+  "include": [
+    "./**/*.ts"
+  ]
 }


### PR DESCRIPTION
Runtime logs (vercel logs) show ERR_MODULE_NOT_FOUND: /var/task/apps/web/api/releaseAssets imported from install.js — the functions run as compiled native ESM which requires explicit extensions. NodeNext moduleResolution + .js import specifiers. 11/11 api tests, typecheck, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)