### PR TITLE
docs(release): v1.2.54 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.54] - 2026-08-05
+
+### Added
+
+- The POSIX installer writes `~/.ade/env` and, with consent, adds one marker-guarded line to your shell profile so `ade` is on PATH in new terminals. Idempotent across re-runs; `ADE_INSTALL_NO_PATH=1` opts out; fish and unrecognized shells get a printed hint instead of an edit.
+
+### Changed
+
+- The "ADE command" settings card moved from Integrations to General.
+- README reorganized around the four surfaces (desktop, web, terminal, mobile), with the install section split the same way. Local development detail moved to `docs/development/local-development.md`; CONTRIBUTING condensed.
+- Installer and CLI sign-in prompts now say "sign in or create your ADE account".
+
+### Fixed
+
+- `ADE_INSTALL_NO_PATH` is now honored by `install.ps1`; it was documented but unread, and `irm ... | iex` cannot pass `-NoPath`.
+- An unset `HOME` with `ADE_HOME` set, or an unwritable env file, no longer aborts the installer after the binary is in place.
+- Concurrent installs can no longer interleave their shell-profile edits.
+- Under `-NoPath` the printed next-step command is quoted, so it runs when the install path contains a space.
+- zsh always targets `.zshrc` instead of a login-shell-only `.zprofile`.
+
+
 ## [1.2.53] - 2026-08-05
 
 ### Added
@@ -1403,6 +1424,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial public release.
 
 [Unreleased]: https://github.com/arul28/ADE/compare/v1.2.49...HEAD
+[1.2.54]: https://github.com/arul28/ADE/compare/v1.2.53...v1.2.54
 [1.2.53]: https://github.com/arul28/ADE/compare/v1.2.52...v1.2.53
 [1.2.52]: https://github.com/arul28/ADE/compare/v1.2.51...v1.2.52
 [1.2.51]: https://github.com/arul28/ADE/compare/v1.2.50...v1.2.51

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -5,6 +5,6 @@ description: "Latest ADE release notes and release history."
 
 ADE release notes live here in newest-first order. Start with the latest release, or browse the release list in the sidebar.
 
-<Card title="Latest release" icon="tag" href="/changelog/v1.2.53">
-  v1.2.53 - One-command install with account connect, downloads a fraction of the size, and the macOS auto-update crash fixed structurally.
+<Card title="Latest release" icon="tag" href="/changelog/v1.2.54">
+  v1.2.54 - The one-command install now puts `ade` on your PATH, and the README is organized around the four ways you use ADE.
 </Card>

--- a/changelog/v1.2.54.mdx
+++ b/changelog/v1.2.54.mdx
@@ -1,0 +1,25 @@
+---
+title: "v1.2.54"
+description: "Release notes for ADE v1.2.54 - August 5, 2026"
+---
+
+The one-command install now finishes the job: `ade` lands on your PATH instead of leaving you to wire it up yourself.
+
+---
+
+## Install
+
+- **The installer puts `ade` on your PATH.** On macOS and Linux it writes `~/.ade/env` and, after asking, adds one marked line to your shell profile, so new terminals just find `ade`. It never touches a profile without consent, never duplicates the block when you re-run it, and prints the line to add yourself for fish or an unrecognized shell. `ADE_INSTALL_NO_PATH=1` skips the whole thing.
+- **`ADE_INSTALL_NO_PATH` works on Windows too.** It was documented but never read, and since `irm ... | iex` cannot take parameters, that environment variable was the only way to opt out of the PATH change on the command we actually promote.
+- **Sign-in copy says what it does.** Both installers and the CLI now offer to "sign in or create your ADE account", because the browser page has always handled both.
+- Fixed three ways a successful install could still end badly: an unset `HOME` alongside `ADE_HOME` aborted the script after the binary was already in place (Docker, systemd units, some CI images), an unwritable env file aborted it the same way, and two installs racing could interleave their profile edits. Under `-NoPath` on Windows the printed next step is now runnable when the install path contains a space.
+- zsh setups now always get `.zshrc` rather than an existing `.zprofile`, which is login-shell only and left `ade` missing from the terminals editors and multiplexers open.
+
+## Desktop
+
+- The **ADE command** card moved from Integrations to General. Whether `ade` is available in your terminal is not an integration, and it was buried at the bottom of the wrong page.
+
+## Docs
+
+- The README is organized around the four ways you use ADE: desktop app, web client, terminal, and mobile. The install section follows the same split, so each heading answers one question instead of mixing "which OS" with "which surface".
+- Local development detail moved to [docs/development/local-development.md](https://github.com/arul28/ADE/blob/main/docs/development/local-development.md), and CONTRIBUTING is down to the part that matters: contributions are wanted, and good pull requests get merged.

--- a/docs.json
+++ b/docs.json
@@ -181,6 +181,7 @@
             "expanded": true,
             "pages": [
               "changelog",
+              "changelog/v1.2.54",
               "changelog/v1.2.53",
               "changelog/v1.2.52",
               "changelog/v1.2.51",


### PR DESCRIPTION
Release notes and changelog surfaces for v1.2.54. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)