### PR TITLE
fix(settings): route in-app CTAs through the settings manifest

### DIFF
--- a/apps/desktop/src/renderer/components/account/AccountPage.tsx
+++ b/apps/desktop/src/renderer/components/account/AccountPage.tsx
@@ -55,6 +55,7 @@ import { openExternalUrl } from "../../lib/openExternal";
 import { isWebClientMode } from "../../lib/webClientMode";
 import { docs } from "../../onboarding/docsLinks";
 import { useClampedFixedPosition } from "../../hooks/useClampedFixedPosition";
+import { settingsRouteFor } from "../settings/settingsManifest";
 
 const REPO_BRIDGE_DISMISS_KEY = "ade.account.repoBridgeDismissed.v1";
 const MACHINES_REFRESH_MS = 30_000;
@@ -1247,7 +1248,7 @@ export function AccountPage() {
                 </div>
                 <button
                   type="button"
-                  onClick={() => navigate("/settings?tab=general#github-connection")}
+                  onClick={() => navigate(settingsRouteFor("integrations.github"))}
                   style={outlineButton({ height: 30, fontSize: 12, padding: "0 12px", flexShrink: 0 })}
                 >
                   Connect GitHub

--- a/apps/desktop/src/renderer/components/app/IntegrationBannerHost.tsx
+++ b/apps/desktop/src/renderer/components/app/IntegrationBannerHost.tsx
@@ -19,6 +19,7 @@ import {
   githubAccountIssueCopy,
   githubRepoIssueCopy,
 } from "../../lib/githubIntegrationStatus";
+import { settingsRouteFor } from "../settings/settingsManifest";
 import { useBannerDismissals } from "../../lib/bannerDismiss";
 import { openExternalUrl } from "../../lib/openExternal";
 import { COLORS, SANS_FONT } from "../lanes/laneDesignTokens";
@@ -55,8 +56,10 @@ export type IntegrationBannerHostProps = {
   navigate: NavigateFunction;
 };
 
-const GITHUB_CONNECTION_SETTINGS_ROUTE = "/settings?tab=general#github-connection";
-const AI_SETTINGS_ROUTE = "/settings?tab=ai";
+// Derived from the settings manifest, never hand-written: these CTAs must land
+// on the card that actually owns the setting, wherever the manifest has moved it.
+const GITHUB_CONNECTION_SETTINGS_ROUTE = settingsRouteFor("integrations.github");
+const AI_SETTINGS_ROUTE = settingsRouteFor("agents.providers");
 const MAX_VISIBLE_BANNERS = 2;
 const SEVERITY_RANK: Record<BannerSeverity, number> = { error: 0, warning: 1, info: 2 };
 

--- a/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
+++ b/apps/desktop/src/renderer/components/app/LinearQuickViewButton.tsx
@@ -45,6 +45,7 @@ import {
 } from "../../lib/launchedLanesHighlight";
 import { copyLaunchPromptToClipboard } from "../../lib/launchPromptClipboard";
 import { announceWorkChatSessionCreated } from "../../lib/chatSessionEvents";
+import { settingsRouteFor } from "../settings/settingsManifest";
 
 const INITIAL_VISIBILITY_CHECK_DELAY_MS = 2_000;
 const VISIBILITY_RETRY_INTERVAL_MS = 3_000;
@@ -169,7 +170,7 @@ export function LinearQuickViewButton({
 
   const openLinearSettings = useCallback(() => {
     setConnectionPrompt(null);
-    window.location.hash = "#/settings?tab=general#linear-connection";
+    window.location.hash = `#${settingsRouteFor("integrations.linear")}`;
   }, []);
 
   const handleQuickViewRequest = useCallback((request: LinearIssueQuickViewRequest) => {

--- a/apps/desktop/src/renderer/components/app/ProjectRecoveryScreen.test.tsx
+++ b/apps/desktop/src/renderer/components/app/ProjectRecoveryScreen.test.tsx
@@ -9,6 +9,7 @@ import type {
 import { useAppStore } from "../../state/appStore";
 import { expectNoJargon, JARGON_PATTERN } from "../../../test/jargonGuard";
 import { ProjectRecoveryScreen } from "./ProjectRecoveryScreen";
+import { settingsRouteFor } from "../settings/settingsManifest";
 
 const { navigateMock } = vi.hoisted(() => ({ navigateMock: vi.fn() }));
 vi.mock("react-router-dom", () => ({ useNavigate: () => navigateMock }));
@@ -206,7 +207,9 @@ describe("ProjectRecoveryScreen", () => {
     // The takeover must exit (clear the error) before navigating, or
     // ProjectTabHost keeps rendering this screen and Settings never shows.
     expect(clear).toHaveBeenCalled();
-    expect(navigateMock).toHaveBeenCalledWith("/settings?tab=storage");
+    // Route comes from the settings manifest, so this assertion follows the
+    // storage card if it ever moves tabs instead of pinning a stale literal.
+    expect(navigateMock).toHaveBeenCalledWith(settingsRouteFor("storage.usage"));
   });
 
   it("clears the transition error when Back is pressed", async () => {

--- a/apps/desktop/src/renderer/components/app/ProjectRecoveryScreen.tsx
+++ b/apps/desktop/src/renderer/components/app/ProjectRecoveryScreen.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../../shared/types/recovery";
 import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { useAppStore } from "../../state/appStore";
+import { settingsRouteFor } from "../settings/settingsManifest";
 
 /**
  * Codes we can attempt an automatic repair for when a live diagnosis isn't
@@ -344,7 +345,7 @@ export function ProjectRecoveryScreen() {
                 // this screen and the route change alone would never reveal
                 // Settings.
                 clearProjectTransitionError();
-                navigate("/settings?tab=storage");
+                navigate(settingsRouteFor("storage.usage"));
               }}
               className="inline-flex h-9 items-center justify-center rounded-lg border border-border/80 bg-fg/[0.03] px-4 text-[13px] font-medium text-fg/75 transition-colors hover:bg-fg/[0.07]"
             >

--- a/apps/desktop/src/renderer/components/app/SettingsPage.test.tsx
+++ b/apps/desktop/src/renderer/components/app/SettingsPage.test.tsx
@@ -97,6 +97,19 @@ describe("SettingsPage", () => {
     expect(await screen.findByRole("heading", { name: "Integrations" })).toBeTruthy();
   });
 
+  it("follows the hash's owning tab when ?tab= disagrees with it", async () => {
+    // Links written before GitHub moved out of General still say
+    // `?tab=general#github-connection`. The hash names one exact card, so it
+    // wins: landing on General (where the card no longer is) is what made the
+    // "Set up ADE GitHub App" banner look like it did nothing.
+    renderSettings("/settings?tab=general#github-connection");
+
+    expect(await screen.findByRole("heading", { name: "Integrations" })).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByTestId("location").textContent).toBe("?tab=integrations#github-connection");
+    });
+  });
+
   it("falls back to General for a tab id it has never shipped", async () => {
     renderSettings("/settings?tab=not-a-real-tab");
     expect(await screen.findByRole("heading", { name: "General" })).toBeTruthy();

--- a/apps/desktop/src/renderer/components/app/SettingsPage.tsx
+++ b/apps/desktop/src/renderer/components/app/SettingsPage.tsx
@@ -302,7 +302,9 @@ function CrossTabResults({
 export function SettingsPage({ active = true }: { active?: boolean } = {}) {
   const location = useLocation();
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  // Read-only: every write to the settings URL goes through `navigate` so the
+  // hash survives alongside the search params.
+  const [searchParams] = useSearchParams();
   const tabParam = searchParams.get("tab");
   // Machine-scoped settings write to the machine the active project tab is
   // bound to, so on web they exist only while one is open. The manifest is what
@@ -331,7 +333,24 @@ export function SettingsPage({ active = true }: { active?: boolean } = {}) {
   // so it falls through to the first tab this renderer does serve.
   const tabs = useMemo(() => availableSettingsTabs(), [machineBound]);
   const defaultTab = tabs[0]?.id ?? "general";
-  const requestedTab = resolveSettingsTab(tabParam);
+  // A `#hash` names one specific setting, so it is strictly more precise than
+  // the `?tab=` next to it. When the two disagree — an older link that still
+  // says `?tab=general#github-connection` after GitHub moved to Integrations —
+  // follow the hash, which is the tab that actually contains the card we were
+  // asked to show. Without this the URL lands on the named tab and the scroll
+  // effect below silently no-ops, which is exactly how the GitHub App banner
+  // used to dump people on General.
+  const hashEntryTab = useMemo(() => {
+    if (!location.hash) return null;
+    let raw = location.hash.slice(1);
+    try {
+      raw = decodeURIComponent(raw);
+    } catch {
+      // A malformed hash should never break tab resolution.
+    }
+    return resolveSettingsHash(raw)?.tab ?? null;
+  }, [location.hash]);
+  const requestedTab = hashEntryTab ?? resolveSettingsTab(tabParam);
   const resolvedTab = requestedTab && tabs.some((tab) => tab.id === requestedTab)
     ? requestedTab
     : requestedTab
@@ -357,8 +376,14 @@ export function SettingsPage({ active = true }: { active?: boolean } = {}) {
     if (!tabParam || !resolvedTab || tabParam === resolvedTab) return;
     const nextParams = new URLSearchParams(searchParams);
     nextParams.set("tab", resolvedTab);
-    setSearchParams(nextParams, { replace: true });
-  }, [active, resolvedTab, searchParams, setSearchParams, tabParam]);
+    // Navigate rather than setSearchParams: the latter drops the hash, which
+    // would throw away the very anchor that selected this tab and leave the
+    // scroll effect below with nothing to scroll to.
+    navigate(
+      { pathname: location.pathname, search: `?${nextParams.toString()}`, hash: location.hash },
+      { replace: true },
+    );
+  }, [active, location.hash, location.pathname, navigate, resolvedTab, searchParams, tabParam]);
 
   // `?integration=github|linear|cli` predates the manifest.
   useEffect(() => {

--- a/apps/desktop/src/renderer/components/app/StoragePressureIndicator.test.tsx
+++ b/apps/desktop/src/renderer/components/app/StoragePressureIndicator.test.tsx
@@ -5,6 +5,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-libra
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DiskPressureSnapshot, DiskPressureState } from "../../../shared/types/storage";
 import { StoragePressureIndicator } from "./StoragePressureIndicator";
+import { settingsRouteFor } from "../settings/settingsManifest";
 
 function snapshot(state: DiskPressureState): DiskPressureSnapshot {
   return {
@@ -89,6 +90,6 @@ describe("StoragePressureIndicator", () => {
     render(<StoragePressureIndicator enabled />);
 
     fireEvent.click(await screen.findByRole("status"));
-    expect(window.location.hash).toBe("#/settings?tab=storage");
+    expect(window.location.hash).toBe(`#${settingsRouteFor("storage.usage")}`);
   });
 });

--- a/apps/desktop/src/renderer/components/app/StoragePressureIndicator.tsx
+++ b/apps/desktop/src/renderer/components/app/StoragePressureIndicator.tsx
@@ -3,6 +3,7 @@ import { HardDrive } from "@phosphor-icons/react";
 import { isUrgentDiskPressure, type DiskPressureSnapshot } from "../../../shared/types/storage";
 import { SmartTooltip } from "../ui/SmartTooltip";
 import { cn } from "../ui/cn";
+import { settingsRouteFor } from "../settings/settingsManifest";
 
 const STORAGE_PRESSURE_SAMPLE_MS = 30_000;
 const WARNING_DESCRIPTION = "Storage is running low — ADE and your active projects may create more files while agents work. Click to review ADE storage.";
@@ -80,7 +81,7 @@ export function StoragePressureIndicator({ enabled }: { enabled: boolean }) {
           outline: "none",
         }}
         onClick={() => {
-          window.location.hash = "#/settings?tab=storage";
+          window.location.hash = `#${settingsRouteFor("storage.usage")}`;
         }}
       >
         <HardDrive size={14} weight="fill" />

--- a/apps/desktop/src/renderer/components/app/TopBar.test.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.test.tsx
@@ -2134,7 +2134,7 @@ describe("TopBar", () => {
 
     expect(await screen.findByText("Connect Linear to open ADE-125")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: /open linear settings/i }));
-    expect(window.location.hash).toBe("#/settings?tab=general#linear-connection");
+    expect(window.location.hash).toBe("#/settings?tab=integrations#linear-connection");
   });
 
   it("offers the project picker when a Linear issue deeplink opens without an ADE project", async () => {

--- a/apps/desktop/src/renderer/components/app/TopBar.tsx
+++ b/apps/desktop/src/renderer/components/app/TopBar.tsx
@@ -86,6 +86,7 @@ import {
   ADE_BROWSER_VIEW_OCCLUSION_END_EVENT,
   ADE_BROWSER_VIEW_OCCLUSION_START_EVENT,
 } from "../../lib/workSidebarBrowserResize";
+import { settingsRouteFor } from "../settings/settingsManifest";
 
 // Hosted-client only: kept out of the desktop bundle's critical path, and out
 // of the desktop bundle's dependency graph for the sync client entirely.
@@ -330,7 +331,7 @@ function ResourcePressureIndicator({ usage }: { usage: AppResourceUsageSnapshot 
           outline: "none",
         }}
         onClick={() => {
-          window.location.hash = "#/settings?tab=storage#diagnostics";
+          window.location.hash = `#${settingsRouteFor("storage.diagnostics")}`;
         }}
       >
         <WarningCircle size={14} weight="fill" />

--- a/apps/desktop/src/renderer/components/automations/builder/TriggerCard.tsx
+++ b/apps/desktop/src/renderer/components/automations/builder/TriggerCard.tsx
@@ -24,6 +24,7 @@ import {
 import { GitHubTriggerFilters } from "../GitHubTriggerFilters";
 import { LinearTriggerFilters } from "../LinearTriggerFilters";
 import { ScheduleEditor } from "./ScheduleEditor";
+import { settingsRouteFor } from "../../settings/settingsManifest";
 
 function SmallField({
   label,
@@ -104,13 +105,13 @@ function TriggerDeliveryCallout({
   let action = null;
   if (deliveryKey === "github" || deliveryKey === "githubWebhook") {
     action = (
-      <CalloutActionButton label="Open GitHub settings" onClick={() => navigate("/settings?tab=general#github-connection")} />
+      <CalloutActionButton label="Open GitHub settings" onClick={() => navigate(settingsRouteFor("integrations.github"))} />
     );
   } else if (deliveryKey === "linear") {
     action = linearApi?.setup ? (
       <CalloutActionButton label="Connect Linear" disabled={linearPending} onClick={() => void setupLinear()} />
     ) : (
-      <CalloutActionButton label="Open Linear settings" onClick={() => navigate("/settings?tab=general#linear-connection")} />
+      <CalloutActionButton label="Open Linear settings" onClick={() => navigate(settingsRouteFor("integrations.linear"))} />
     );
   }
 

--- a/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatComposer.tsx
@@ -102,6 +102,7 @@ import {
   ComposerPromptStash,
   type ComposerPromptStashHandle,
 } from "./ComposerPromptStash";
+import { settingsRouteFor } from "../settings/settingsManifest";
 
 const MAX_TEMP_ATTACHMENT_BYTES = 10 * 1024 * 1024;
 const CLIPBOARD_IMAGE_PASTE_FALLBACK_DELAY_MS = 80;
@@ -5054,7 +5055,7 @@ export function AgentChatComposer({
                     type="button"
                     onClick={() => {
                       // HashRouter deep-link to the voice-input card under General.
-                      window.location.hash = "#/settings?tab=general#voice-input";
+                      window.location.hash = `#${settingsRouteFor("agents.dictation")}`;
                     }}
                     className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-muted-fg/30 transition-all hover:bg-[color:color-mix(in_srgb,var(--chat-accent)_10%,transparent)] hover:text-[var(--chat-accent)] active:scale-[0.97]"
                     aria-label="Set up voice input"

--- a/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentChatPane.tsx
@@ -198,6 +198,7 @@ import {
   releaseRetainedChatSession,
   retainChatSession,
 } from "./chatSessionRetention";
+import { settingsRouteFor } from "../settings/settingsManifest";
 import { ClaudeLoginPromptButton, createClaudeLoginTerminalInWork } from "../work/ClaudeLoginPromptButton";
 import { CHAT_AUTH_RECOVERED_EVENT, CHAT_AUTH_RETRY_REJECTED_EVENT, CHAT_RETRY_AUTH_TURN_EVENT } from "./AgentCliAuthCard";
 import { rootAppStoreApi, selectActiveProjectRoot, useAppStore, useRootAppStore } from "../../state/appStore";
@@ -3356,13 +3357,13 @@ export function AgentChatPane({
   }, [crossMachineLanesByMachineId, laneCacheByProject, lanes, openProjectBindings, projectBinding]);
   const navigate = useNavigate();
   const openAiProvidersSettings = useCallback(() => {
-    navigate("/settings?tab=ai#ai-providers");
+    navigate(settingsRouteFor("agents.providers"));
   }, [navigate]);
   const openLinearSettings = useCallback(() => {
-    navigate("/settings?tab=general#linear-connection");
+    navigate(settingsRouteFor("integrations.linear"));
   }, [navigate]);
   const openLaunchPromptClipboardSettings = useCallback(() => {
-    navigate("/settings?tab=general#chat-launch-clipboard");
+    navigate(settingsRouteFor("general.launch-prompt"));
   }, [navigate]);
   const copyPromptForLaunch = useCallback(async (promptText: string) => {
     if (!launchPromptClipboardEnabled) return;
@@ -12551,7 +12552,7 @@ export function AgentChatPane({
                 <button
                   type="button"
                   className="rounded-md px-2 py-0.5 text-[length:calc(var(--chat-font-size)*10.5/14)] font-medium text-fg/65 transition-colors hover:bg-white/10 hover:text-fg/85"
-                  onClick={() => navigate("/settings?tab=background-jobs")}
+                  onClick={() => navigate(settingsRouteFor("agents.background-jobs"))}
                 >
                   Settings
                 </button>

--- a/apps/desktop/src/renderer/components/cto/useCtoModelOptions.ts
+++ b/apps/desktop/src/renderer/components/cto/useCtoModelOptions.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getModelById, modelSupportsFastMode, selectSupportedReasoningEffort } from "../../../shared/modelRegistry";
 import { deriveConfiguredModelIds } from "../../lib/modelOptions";
+import { settingsRouteFor } from "../settings/settingsManifest";
 
 export type CtoModelSelection = {
   provider: string;
@@ -74,7 +75,7 @@ export function useCtoModelOptions(): {
   }, []);
 
   const openProviderSettings = useCallback(() => {
-    navigate("/settings?tab=ai#ai-providers");
+    navigate(settingsRouteFor("agents.providers"));
   }, [navigate]);
 
   return { availableModelIds, loadingModels, openProviderSettings };

--- a/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
+++ b/apps/desktop/src/renderer/components/lanes/LanesPage.tsx
@@ -108,6 +108,7 @@ import type {
 import { eventMatchesBinding, getEffectiveBinding } from "../../lib/keybindings";
 import { SmartTooltip } from "../ui/SmartTooltip";
 import { docs } from "../../onboarding/docsLinks";
+import { settingsRouteFor } from "../settings/settingsManifest";
 
 type RebaseScopePromptState = {
   laneId: string;
@@ -2002,7 +2003,7 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
     }
   };
 
-  const openAutoRebaseSettings = useCallback(() => { navigate("/settings?tab=lane-templates"); }, [navigate]);
+  const openAutoRebaseSettings = useCallback(() => { navigate(settingsRouteFor("lanes-git.lane-templates")); }, [navigate]);
   const openRebaseDetails = useCallback((laneId?: string | null) => {
     const trimmedLaneId = typeof laneId === "string" ? laneId.trim() : "";
     if (trimmedLaneId.length) {
@@ -3656,8 +3657,8 @@ export function LanesPage({ active = true }: { active?: boolean } = {}) {
         prefill={createPrefill}
         onCreated={handleLaneCreated}
         onBusyChange={(busy) => { createBusyRef.current = busy; }}
-        onOpenLinearSettings={() => navigate("/settings?tab=general#linear-connection")}
-        onNavigateToTemplates={() => navigate("/settings?tab=lane-templates")}
+        onOpenLinearSettings={() => navigate(settingsRouteFor("integrations.linear"))}
+        onNavigateToTemplates={() => navigate(settingsRouteFor("lanes-git.lane-templates"))}
       />
 
       {rebaseScopePrompt ? (

--- a/apps/desktop/src/renderer/components/prs/tabs/GitHubTab.tsx
+++ b/apps/desktop/src/renderer/components/prs/tabs/GitHubTab.tsx
@@ -56,6 +56,7 @@ import {
 import { GitHubTabView } from "./GitHubTabView";
 import { branchNameFromRef } from "./githubPrBranch";
 import { useGitHubTabListModel } from "./useGitHubTabListModel";
+import { settingsRouteFor } from "../../settings/settingsManifest";
 
 export type GitHubTabProps = {
   lanes: LaneSummary[];
@@ -943,7 +944,7 @@ export function GitHubTab({
           syncedAt: snapshot?.syncedAt ?? null,
           onSync: () => { void handleSync(); },
           error,
-          onConnectGitHub: () => navigate("/settings?tab=general#github-connection"),
+          onConnectGitHub: () => navigate(settingsRouteFor("integrations.github")),
         }}
         list={{
           parentRef: listRef,

--- a/apps/desktop/src/renderer/components/settings/AiFeaturesSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/AiFeaturesSection.test.tsx
@@ -133,7 +133,7 @@ describe("AiFeaturesSection", () => {
     fireEvent.click(screen.getByRole("button", { name: "Set up ai-feature-chat-auto-title" }));
 
     await waitFor(() => {
-      expect(screen.getByTestId("location").textContent).toBe("/settings?tab=ai#ai-providers");
+      expect(screen.getByTestId("location").textContent).toBe("/settings?tab=agents#ai-providers");
     });
   });
 

--- a/apps/desktop/src/renderer/components/settings/settingsManifest.test.ts
+++ b/apps/desktop/src/renderer/components/settings/settingsManifest.test.ts
@@ -14,6 +14,7 @@ import {
   searchSettingsEntries,
   settingsEntryPath,
   settingsGroupsForTab,
+  settingsRouteFor,
 } from "./settingsManifest";
 
 /**
@@ -47,6 +48,29 @@ describe("settings manifest", () => {
     for (const entry of SETTINGS_ENTRIES) {
       expect(settingsEntryPath(entry)).toBe(`/settings?tab=${entry.tab}#${entry.anchor}`);
     }
+  });
+
+  it("builds a live route for every id in-app CTAs link to", () => {
+    // The banners, callouts and empty states across the app now name settings
+    // by manifest id instead of hand-writing `?tab=...#anchor`. If a setting is
+    // renamed or dropped, this list is where it fails — loudly — instead of a
+    // CTA quietly dumping the user on the settings root.
+    const ctaIds = [
+      "integrations.github",
+      "integrations.linear",
+      "agents.providers",
+      "agents.background-jobs",
+      "agents.dictation",
+      "general.launch-prompt",
+      "lanes-git.lane-templates",
+      "storage.usage",
+      "storage.diagnostics",
+    ];
+    for (const id of ctaIds) {
+      expect(settingsRouteFor(id), `${id} has no manifest entry`).not.toBe("/settings");
+    }
+    expect(settingsRouteFor("integrations.github")).toBe("/settings?tab=integrations#github-connection");
+    expect(settingsRouteFor("nope.missing")).toBe("/settings");
   });
 
   it("resolves current tab ids unchanged", () => {

--- a/apps/desktop/src/renderer/components/settings/settingsManifest.ts
+++ b/apps/desktop/src/renderer/components/settings/settingsManifest.ts
@@ -883,6 +883,22 @@ export function settingsEntryPath(entry: SettingEntry): string {
   return `/settings?tab=${entry.tab}#${entry.anchor}`;
 }
 
+/**
+ * The route for a setting named by its manifest id — the form every in-app CTA
+ * (banners, callouts, empty states) should use.
+ *
+ * Hand-written `/settings?tab=general#github-connection` strings were the bug
+ * this replaces: when GitHub moved from General to Integrations, the tab in
+ * those literals kept pointing at General while the anchor moved, so the
+ * "Authorize" banner landed on General and scrolled nowhere. Deriving the whole
+ * route from the manifest means a setting can never move out from under a CTA
+ * again. Unknown ids fall back to the settings root rather than throwing.
+ */
+export function settingsRouteFor(entryId: string): string {
+  const entry = ENTRIES_BY_ID.get(entryId);
+  return entry ? settingsEntryPath(entry) : "/settings";
+}
+
 export function settingsTabLabel(tab: SettingsTabId): string {
   return SETTINGS_TABS.find((candidate) => candidate.id === tab)?.label ?? tab;
 }

--- a/apps/desktop/src/renderer/components/shared/useOpenProviderSignIn.ts
+++ b/apps/desktop/src/renderer/components/shared/useOpenProviderSignIn.ts
@@ -2,11 +2,12 @@ import { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import type { AuthType, ProviderFamily } from "../../../shared/modelRegistry";
 import { createClaudeLoginTerminalInWork } from "../work/ClaudeLoginPromptButton";
+import { settingsRouteFor } from "../settings/settingsManifest";
 
 export function useOpenProviderSignIn(): (family?: ProviderFamily, authTypes?: readonly AuthType[]) => void {
   const navigate = useNavigate();
   const openAiProvidersSettings = useCallback(() => {
-    navigate("/settings?tab=ai#ai-providers");
+    navigate(settingsRouteFor("agents.providers"));
   }, [navigate]);
 
   return useCallback((family?: ProviderFamily, authTypes?: readonly AuthType[]) => {

--- a/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
+++ b/apps/desktop/src/renderer/components/terminals/SessionListPane.tsx
@@ -68,6 +68,7 @@ import {
   handoffLaunchTitle,
   type HandoffLaunchJob,
 } from "../../lib/handoffLaunchJobs";
+import { settingsRouteFor } from "../settings/settingsManifest";
 
 
 const EMPTY_GRID_SETS: WorkGridSet[] = [];
@@ -3102,8 +3103,8 @@ export const SessionListPane = React.memo(function SessionListPane({
           open={createLaneOpen}
           onOpenChange={setCreateLaneOpen}
           behavior="close-on-create"
-          onNavigateToTemplates={() => navigate("/settings?tab=lane-templates")}
-          onOpenLinearSettings={() => navigate("/settings?tab=general#linear-connection")}
+          onNavigateToTemplates={() => navigate(settingsRouteFor("lanes-git.lane-templates"))}
+          onOpenLinearSettings={() => navigate(settingsRouteFor("integrations.linear"))}
         />
       ) : null}
       {settleUndo ? (

--- a/apps/desktop/src/renderer/components/terminals/WorkSidebar.tsx
+++ b/apps/desktop/src/renderer/components/terminals/WorkSidebar.tsx
@@ -44,6 +44,7 @@ import { LaneDiffPane } from "../lanes/LaneDiffPane";
 import { LaneGitActionsPane } from "../lanes/LaneGitActionsPane";
 import { GlowMenu, type GlowMenuItem } from "../ui/GlowMenu";
 import { cn } from "../ui/cn";
+import { settingsRouteFor } from "../settings/settingsManifest";
 
 const WORK_SIDEBAR_TABS: Array<GlowMenuItem<WorkSidebarTab>> = [
   {
@@ -574,7 +575,7 @@ export function WorkSidebar({
             <LaneGitActionsPane
               laneId={laneId}
               autoRebaseEnabled={false}
-              onOpenSettings={() => navigate("/settings?tab=lane-templates")}
+              onOpenSettings={() => navigate(settingsRouteFor("lanes-git.lane-templates"))}
               onSelectFile={(path, mode) => {
                 setSelectedPath(path);
                 setSelectedMode(mode);

--- a/apps/desktop/src/renderer/lib/githubIntegrationStatus.ts
+++ b/apps/desktop/src/renderer/lib/githubIntegrationStatus.ts
@@ -195,7 +195,7 @@ export function githubAccountIssueCopy(
   return {
     title: "GitHub App not authorized",
     detail: "Authorize ADE with GitHub to turn on real-time pull request updates.",
-    action: "Authorize",
+    action: "Set up ADE GitHub App",
   };
 }
 


### PR DESCRIPTION
## What

The GitHub App banner's **Authorize** button navigated to `/settings?tab=general#github-connection`. GitHub settings moved to the **Integrations** tab, but the hand-written tab in that literal never moved with it — the settings shell honors `?tab=`, and only scrolls to a hash whose card lives on the active tab. So the button dumped you on General and scrolled nowhere. Nine other CTAs had the same stale-literal drift (Linear ×5, voice input, background jobs).

## How

- **`settingsRouteFor(entryId)`** derives tab *and* anchor from the settings manifest. Every hand-written settings route across banners, callouts, empty states, the top bar, chat, lanes, PRs, account, and automations now goes through it, so a setting can't move out from under a CTA again.
- **A `#hash` now outranks a disagreeing `?tab=`** — the hash names one exact card, so links already saved by users or shipped in tour steps self-heal. The URL-canonicalizing effect also no longer drops the hash (`setSearchParams` did).
- **Copy:** banner CTA "Authorize" → **"Set up ADE GitHub App"**. The expired-token case stays "Re-authorize" — different action.

## Tests

- `SettingsPage.test.tsx` — a `?tab=` disagreeing with the `#hash` follows the hash's tab and canonicalizes the URL with the hash intact (fails on pre-fix behavior).
- `settingsManifest.test.ts` — every manifest id the app's CTAs link to resolves to a live route; unknown ids fall back to `/settings`.
- Four existing route assertions rebound from stale literals to `settingsRouteFor(...)`, so they follow a card that moves tabs.

Verification: `tsc --noEmit` clean, eslint 0 errors, 520 tests green across the touched folders, shard 3/8 green (1130 passed).

Windows parity: unaffected — renderer-side URL string construction and React Router state only; no paths, processes, IPC, or native modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2F4bcc2922 num=1037 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2F4bcc2922&amp;pr=1037">ade/4bcc2922 branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1037">PR #1037</a>
</p>
<!-- /ade:link -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Settings links throughout the app now open the correct tab and section consistently.
  * Updated navigation for GitHub, Linear, AI providers, storage, dictation, lane templates, and related setup actions.
  * Settings links now remain aligned with the current URL when navigating between tabs.
  * Updated the GitHub App action label to “Set up ADE GitHub App.”
* **Bug Fixes**
  * Resolved conflicts between URL tabs and section-specific links by prioritizing the relevant settings section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->