### PR TITLE
Connections: restructure the this-computer card

### DIFF
--- a/apps/desktop/src/renderer/components/settings/SyncDevicesSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/SyncDevicesSection.test.tsx
@@ -154,6 +154,14 @@ function unreadableSessionStatus(): SyncRoleSnapshot {
 
 const autoConfirm = async () => true;
 
+/**
+ * Pairing controls live behind a disclosure that is closed on every mount, so
+ * every test that touches them has to open it first.
+ */
+function openPairing() {
+  fireEvent.click(screen.getByRole("button", { name: /^Pairing code/ }));
+}
+
 describe("ThisMacCard", () => {
   afterEach(() => {
     cleanup();
@@ -165,8 +173,55 @@ describe("ThisMacCard", () => {
   it("shows the account state line for a signed-in Mac", () => {
     render(<ThisMacCard sync={makeSync()} accountSignedIn />);
     expect(screen.getByText("Studio")).toBeTruthy();
-    expect(screen.getByText("Connected to your ADE account · 1 route published")).toBeTruthy();
-    expect(screen.getByText("Ready to accept connections")).toBeTruthy();
+    expect(screen.getByText("Connected to your ADE account")).toBeTruthy();
+  });
+
+  it("says nothing about readiness or routes when this computer is healthy", () => {
+    render(<ThisMacCard sync={makeSync()} accountSignedIn />);
+    // A healthy host has no actionable status, so it gets no status line at all.
+    expect(screen.queryByText("Ready to accept connections")).toBeNull();
+    expect(screen.queryByText(/Reachable via/)).toBeNull();
+  });
+
+  it("treats an unset pairing code as ordinary, not a fault", () => {
+    render(
+      <ThisMacCard
+        sync={makeSync({ status: makeStatus({ pairingPinConfigured: false }) })}
+        accountSignedIn
+      />,
+    );
+    // Connecting runs through the ADE account now; no code is a normal state.
+    expect(screen.queryByText(/Set a pairing code/)).toBeNull();
+    expect(screen.getByRole("button", { name: /^Pairing code/ }).textContent)
+      .toContain("Not set");
+  });
+
+  it("renames this computer and mirrors the name into the account directory", async () => {
+    const saveRuntimeName = vi.fn();
+    const renameMachine = vi.fn(async () => {});
+    (globalThis.window as any).ade = {
+      account: {
+        getLocalMachineIdentity: vi.fn(async () => ({ machineKey: "mk-1", deviceId: "dev-1" })),
+        renameMachine,
+      },
+    };
+    render(<ThisMacCard sync={makeSync({ saveRuntimeName })} accountSignedIn />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Rename Studio" }));
+    fireEvent.change(screen.getByLabelText("Machine name"), { target: { value: "Workshop" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save machine name" }));
+
+    // The runtime name is what this card renders, so it lands first…
+    expect(saveRuntimeName).toHaveBeenCalledWith("Workshop");
+    // …and the account directory catches up so other clients agree.
+    await waitFor(() => expect(renameMachine).toHaveBeenCalledWith("mk-1", "Workshop"));
+  });
+
+  it("keeps the pencil visible but inert while signed out", () => {
+    render(<ThisMacCard sync={makeSync()} accountSignedIn={false} />);
+    const pencil = screen.getByRole("button", { name: "Rename Studio" });
+    expect((pencil as HTMLButtonElement).disabled).toBe(true);
+    expect(pencil.getAttribute("title")).toBe("Sign in to rename this computer");
   });
 
   it("surfaces when desktop sign-in and brain publication disagree", () => {
@@ -195,7 +250,9 @@ describe("ThisMacCard", () => {
     expect(screen.getByRole("alert").textContent).toContain(
       "Phone sync is unavailable in this ADE installation.",
     );
-    expect(screen.getByText("Phone sync is unavailable")).toBeTruthy();
+    // The alert above carries the runtime's full explanation; the status line
+    // does not repeat a one-liner version of it.
+    expect(screen.queryByRole("button", { name: /^Pairing code/ })).toBeNull();
     expect(screen.queryByRole("button", { name: /Generate code/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /Remove/i })).toBeNull();
   });
@@ -268,7 +325,7 @@ describe("ThisMacCard", () => {
     ).toBeTruthy();
   });
 
-  it("prompts to set a pairing code and generates one", () => {
+  it("generates a code from inside the pairing disclosure", () => {
     const generatePin = vi.fn();
     render(
       <ThisMacCard
@@ -276,7 +333,9 @@ describe("ThisMacCard", () => {
         accountSignedIn
       />,
     );
-    expect(screen.getByText("Set a pairing code below so new devices can connect")).toBeTruthy();
+    // Closed on mount — nothing inside is reachable until it is opened.
+    expect(screen.queryByRole("button", { name: "Generate code" })).toBeNull();
+    openPairing();
     fireEvent.click(screen.getByRole("button", { name: "Generate code" }));
     expect(generatePin).toHaveBeenCalledTimes(1);
   });
@@ -290,6 +349,7 @@ describe("ThisMacCard", () => {
         accountSignedIn
       />,
     );
+    openPairing();
     fireEvent.click(screen.getByRole("button", { name: "Copy" }));
     await waitFor(() => expect(writeClipboardText).toHaveBeenCalledWith("123456"));
   });
@@ -303,49 +363,64 @@ describe("ThisMacCard", () => {
         accountSignedIn
       />,
     );
+    openPairing();
     fireEvent.click(screen.getByRole("button", { name: "Generate new code" }));
     expect(generatePin).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByRole("button", { name: "Remove" }));
     expect(clearPin).toHaveBeenCalledTimes(1);
   });
 
-  it("labels this computer with a chip and lists reachable routes plus the build line", async () => {
-    (globalThis.window as any).ade = {
-      app: { getInfo: vi.fn(async () => ({ appVersion: "1.2.28", platform: "darwin" })) },
-    };
-    const status = makeStatus({
-      routeHealth: {
-        listener: { listenerBound: true, loopbackAdeValidated: true, port: 8787, lastFailureAt: null, reason: null, lastSuccessAt: null },
-        tailscale: { enabled: true, tailscalePublished: true, tailscaleReachable: true, lastFailureAt: null, reason: null, lastSuccessAt: null },
-        relay: { enabled: true, relayControlConnected: true, relayBridgeValidated: true, lastFailureAt: null, skipReason: null, lastControlError: null, lastControlOpenAt: null, lastBridgeValidationAt: null },
-        accountDirectory: makeStatus().routeHealth.accountDirectory,
-      },
-    });
-    render(<ThisMacCard sync={makeSync({ status })} accountSignedIn />);
+  it("reopens the pairing disclosure closed every time, never remembering it", () => {
+    const { unmount } = render(<ThisMacCard sync={makeSync()} accountSignedIn />);
+    openPairing();
+    expect(screen.getByRole("button", { name: /^Pairing code/ }).getAttribute("aria-expanded"))
+      .toBe("true");
+    unmount();
 
+    render(<ThisMacCard sync={makeSync()} accountSignedIn />);
+    expect(screen.getByRole("button", { name: /^Pairing code/ }).getAttribute("aria-expanded"))
+      .toBe("false");
+  });
+
+  it.each([
+    ["darwin", "macOS"],
+    ["win32", "Windows"],
+    ["linux", "Linux"],
+  ])("marks the identity tile with the %s platform logo", async (platform, accessibleName) => {
+    (globalThis.window as any).ade = {
+      app: { getInfo: vi.fn(async () => ({ appVersion: "1.2.28", platform })) },
+    };
+    render(<ThisMacCard sync={makeSync()} accountSignedIn />);
+
+    expect(await screen.findByRole("img", { name: accessibleName })).toBeTruthy();
+    // The logo is the platform statement, so the version line never repeats it.
+    expect(await screen.findByText("ADE 1.2.28")).toBeTruthy();
+    expect(screen.queryByText(new RegExp(`ADE 1\\.2\\.28.*${accessibleName}`))).toBeNull();
+  });
+
+  it("labels this computer with a chip", () => {
+    render(<ThisMacCard sync={makeSync()} accountSignedIn />);
     // Composed from THIS_MACHINE_NAME, never spelled out: this badge was
     // macOS-only copy ("This Mac") until ADE shipped on Windows, and pinning the
     // literal here is what let Settings and Account miss the rename.
     expect(screen.getByText(THIS_MACHINE_NAME)).toBeTruthy();
-    expect(screen.getByText("Reachable via Wi-Fi · Tailscale · Relay")).toBeTruthy();
-    expect(await screen.findByText("ADE 1.2.28 · macOS")).toBeTruthy();
   });
 
-  it("omits unknown routes and only advertises the ones that are up", () => {
-    const status = makeStatus({
-      routeHealth: {
-        listener: { listenerBound: true, loopbackAdeValidated: true, port: 8787, lastFailureAt: null, reason: null, lastSuccessAt: null },
-        tailscale: { enabled: false, tailscalePublished: false, tailscaleReachable: false, lastFailureAt: null, reason: "off", lastSuccessAt: null },
-        // Relay control connected but bridge not yet validated → not reachable.
-        relay: { enabled: true, relayControlConnected: true, relayBridgeValidated: false, lastFailureAt: null, skipReason: null, lastControlError: null, lastControlOpenAt: null, lastBridgeValidationAt: null },
-        accountDirectory: makeStatus().routeHealth.accountDirectory,
-      },
-    });
+  it("swaps the version line for the fault while the listener is down", async () => {
+    (globalThis.window as any).ade = {
+      app: { getInfo: vi.fn(async () => ({ appVersion: "1.2.28", platform: "win32" })) },
+    };
+    const status = makeStatus({ pairingConnectInfo: null });
+    status.routeHealth.listener = {
+      ...status.routeHealth.listener,
+      listenerBound: false,
+      reason: "Port 8787 is already in use.",
+    };
     render(<ThisMacCard sync={makeSync({ status })} accountSignedIn />);
 
-    expect(screen.getByText("Reachable via Wi-Fi")).toBeTruthy();
-    expect(screen.queryByText(/Tailscale/)).toBeNull();
-    expect(screen.queryByText(/Relay/)).toBeNull();
+    expect(await screen.findByText("Port 8787 is already in use.")).toBeTruthy();
+    // One slot, so the card never grows a line in the unhappy path.
+    expect(screen.queryByText("ADE 1.2.28")).toBeNull();
   });
 
   it("no longer embeds a Connect-a-phone disclosure — the Phone tab owns pairing", () => {
@@ -379,6 +454,7 @@ describe("ThisMacCard", () => {
         accountSignedIn
       />,
     );
+    openPairing();
     expect(screen.getByText(`${THIS_MACHINE_NAME}'s pairing code is 123456.`)).toBeTruthy();
     expect(
       screen.getByText(/Pairing changes aren.t available while this window is connected to/),

--- a/apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/SyncDevicesSection.tsx
@@ -1,11 +1,17 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  AppleLogo,
   ArrowSquareOut,
+  CaretRight,
   Check,
   Cloud,
   CloudSlash,
   Globe,
   Laptop,
+  LinuxLogo,
+  PencilSimple,
+  WindowsLogo,
+  X,
 } from "@phosphor-icons/react";
 import { accountDirectorySummary } from "./accountDirectorySummary";
 import { QRCodeSVG } from "qrcode.react";
@@ -130,7 +136,24 @@ function isCrdtSyncUnavailable(status: SyncRoleSnapshot): boolean {
 // This-Mac card — persistent header block above the Connections tabs.
 // ---------------------------------------------------------------------------
 
-function platformLabel(platform: string | undefined): string {
+// The platform mark that fills the identity tile. It replaces the old generic
+// laptop glyph *and* the "· Windows" suffix that used to trail the version — the
+// logo is the platform statement, so spelling it out again is pure duplication.
+function PlatformGlyph({ platform }: { platform: string | undefined }) {
+  const props = { size: 17, weight: "duotone" as const, color: COLORS.accent };
+  switch (platform) {
+    case "darwin":
+      return <AppleLogo {...props} />;
+    case "win32":
+      return <WindowsLogo {...props} />;
+    case "linux":
+      return <LinuxLogo {...props} />;
+    default:
+      return <Laptop {...props} />;
+  }
+}
+
+function platformAccessibleName(platform: string | undefined): string {
   switch (platform) {
     case "darwin":
       return "macOS";
@@ -139,32 +162,12 @@ function platformLabel(platform: string | undefined): string {
     case "linux":
       return "Linux";
     default:
-      return "this computer";
+      return "This computer";
   }
 }
 
-// Which of the three inbound routes are actually reachable right now. Unknown or
-// down routes are omitted so the line only ever advertises a working path.
-function reachableRouteLabels(status: SyncRoleSnapshot): string[] {
-  const routes: string[] = [];
-  const health = status.routeHealth;
-  if (health?.listener?.listenerBound && health.listener.loopbackAdeValidated) {
-    routes.push("Wi-Fi");
-  }
-  if (health?.tailscale?.tailscaleReachable) {
-    routes.push("Tailscale");
-  }
-  if (
-    health?.relay?.skipReason == null &&
-    health?.relay?.relayControlConnected &&
-    health?.relay?.relayBridgeValidated
-  ) {
-    routes.push("Relay");
-  }
-  return routes;
-}
-
-// One-shot fetch of the local build/platform for the This-Mac detail line.
+// One-shot fetch of the local build/platform. `platform` stays the raw Node
+// identifier because the glyph, not a label, is what consumes it.
 function useAppInfoLine(): { version: string; platform: string } | null {
   const [info, setInfo] = useState<{ version: string; platform: string } | null>(null);
   useEffect(() => {
@@ -173,7 +176,7 @@ function useAppInfoLine(): { version: string; platform: string } | null {
       ?.getInfo?.()
       ?.then((next) => {
         if (!cancelled && next) {
-          setInfo({ version: next.appVersion, platform: platformLabel(next.platform) });
+          setInfo({ version: next.appVersion, platform: next.platform });
         }
       })
       .catch(() => {});
@@ -196,6 +199,25 @@ export function ThisMacCard({
   // Restarting the brain is the fix when it cannot read the stored account
   // session; re-read the snapshot once it settles so the banner clears.
   const repair = useBrainRepair(sync.refresh);
+
+  const { saveRuntimeName } = sync;
+  // The runtime name is what this card renders, so it is written first and the
+  // rename is visible immediately. The account directory then gets the same
+  // value so the account page and other clients agree — best effort, since a
+  // directory hiccup should not undo a rename the user already sees.
+  const saveMachineName = useCallback((next: string) => {
+    saveRuntimeName(next);
+    if (!accountSignedIn) return;
+    void (async () => {
+      try {
+        const account = window.ade?.account;
+        const identity = await account?.getLocalMachineIdentity?.();
+        if (identity?.machineKey) await account?.renameMachine?.(identity.machineKey, next);
+      } catch {
+        // Local rename already landed; the directory catches up on next publish.
+      }
+    })();
+  }, [saveRuntimeName, accountSignedIn]);
 
   if (sync.loading) {
     return <div style={helperTextStyle}>Getting connection details…</div>;
@@ -227,8 +249,11 @@ export function ThisMacCard({
   // copy of the literal is a place the next rename can miss.
   const machineName = status.runtimeName?.trim() || status.localDevice.name || THIS_MACHINE_NAME;
   const crdtUnavailable = isCrdtSyncUnavailable(status);
-  const acceptsConnections = acceptsConnectionsState(status, host);
-  const routeLabels = reachableRouteLabels(status);
+  // Only real, actionable faults render. A healthy host says nothing beyond its
+  // account line — "Ready to accept connections" and the route breakdown told
+  // the reader nothing they could act on, and a missing pairing code is a
+  // normal state now that the account is the primary way to connect.
+  const problem = connectionProblem(status, host);
   const directorySummary = accountDirectorySummary(status, accountSignedIn);
   // A brain-side unreadable account session is the one directory failure a
   // restart clears — same test RemoteTargetList runs on its publish health.
@@ -238,91 +263,89 @@ export function ThisMacCard({
 
   return (
     <div style={{ ...detailBlockStyle, display: "grid", gap: 12 }}>
-      <div style={{ display: "flex", alignItems: "center", gap: 10, minWidth: 0 }}>
+      <div style={{ display: "grid", gap: 10 }}>
         <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: 32,
-            height: 32,
-            borderRadius: 9,
-            flexShrink: 0,
-            background: "color-mix(in srgb, var(--color-accent) 14%, transparent)",
-            border: `1px solid ${COLORS.accentBorder}`,
-          }}
+          style={inlineBadge(COLORS.accent, {
+            fontSize: 10,
+            padding: "2px 7px",
+            justifySelf: "start",
+          })}
         >
-          <Laptop size={17} weight="duotone" color={COLORS.accent} />
+          {THIS_MACHINE_NAME}
         </span>
-        <div style={{ minWidth: 0 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
-            <span
-              style={{
-                color: COLORS.textPrimary,
-                fontFamily: SANS_FONT,
-                fontSize: 14,
-                fontWeight: 700,
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-                minWidth: 0,
-              }}
-            >
-              {machineName}
-            </span>
-            <span style={inlineBadge(COLORS.accent, { fontSize: 10, padding: "2px 7px", flexShrink: 0 })}>
-              {THIS_MACHINE_NAME}
-            </span>
-          </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 2, flexWrap: "wrap" }}>
-            {accountSignedIn ? (
-              <Cloud
-                size={13}
-                weight="fill"
-                color={directorySummary.healthy ? COLORS.accent : COLORS.warning}
-                style={{ flexShrink: 0 }}
-              />
-            ) : (
-              <CloudSlash size={13} weight="regular" color={COLORS.textMuted} style={{ flexShrink: 0 }} />
-            )}
-            <span
-              style={{
-                ...helperTextStyle,
-                lineHeight: 1.35,
-                color: directorySummary.healthy || !accountSignedIn
-                  ? helperTextStyle.color
-                  : COLORS.warning,
-              }}
-            >
-              {directorySummary.label}
-            </span>
-            {showRepair ? <BrainRepairButton repair={repair} height={24} /> : null}
+
+        <div style={{ display: "flex", alignItems: "flex-start", gap: 10, minWidth: 0 }}>
+          <span
+            aria-label={platformAccessibleName(appInfo?.platform)}
+            role="img"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: 32,
+              height: 32,
+              borderRadius: 9,
+              flexShrink: 0,
+              background: "color-mix(in srgb, var(--color-accent) 14%, transparent)",
+              border: `1px solid ${COLORS.accentBorder}`,
+            }}
+          >
+            <PlatformGlyph platform={appInfo?.platform} />
+          </span>
+          <div style={{ minWidth: 0, flex: 1, display: "grid", gap: 2 }}>
+            <MachineNameRow
+              name={machineName}
+              busy={busy}
+              accountSignedIn={accountSignedIn}
+              onSave={saveMachineName}
+            />
+            <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+              {accountSignedIn ? (
+                <Cloud
+                  size={13}
+                  weight="fill"
+                  color={directorySummary.healthy ? COLORS.accent : COLORS.warning}
+                  style={{ flexShrink: 0 }}
+                />
+              ) : (
+                <CloudSlash size={13} weight="regular" color={COLORS.textMuted} style={{ flexShrink: 0 }} />
+              )}
+              <span
+                style={{
+                  ...helperTextStyle,
+                  lineHeight: 1.35,
+                  color: directorySummary.healthy || !accountSignedIn
+                    ? helperTextStyle.color
+                    : COLORS.warning,
+                }}
+              >
+                {directorySummary.label}
+              </span>
+              {showRepair ? <BrainRepairButton repair={repair} height={24} /> : null}
+            </div>
+            {/* Third line is one slot: the fault takes the version's place while
+                something is wrong, so the card never grows a line. */}
+            {problem ? (
+              <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+                <span
+                  aria-hidden
+                  style={{
+                    width: 7,
+                    height: 7,
+                    borderRadius: "50%",
+                    flexShrink: 0,
+                    background: COLORS.warning,
+                  }}
+                />
+                <span style={{ ...helperTextStyle, lineHeight: 1.4, color: COLORS.warning }}>
+                  {problem}
+                </span>
+              </div>
+            ) : appInfo ? (
+              <div style={{ ...helperTextStyle, lineHeight: 1.4 }}>ADE {appInfo.version}</div>
+            ) : null}
           </div>
         </div>
-      </div>
-
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 8,
-          fontFamily: SANS_FONT,
-          fontSize: 12,
-        }}
-      >
-        <span
-          aria-hidden
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: "50%",
-            flexShrink: 0,
-            background: acceptsConnections.ready ? COLORS.success : COLORS.warning,
-          }}
-        />
-        <span style={{ color: acceptsConnections.ready ? COLORS.textSecondary : COLORS.warning }}>
-          {acceptsConnections.label}
-        </span>
       </div>
 
       {crdtUnavailable ? (
@@ -341,38 +364,25 @@ export function ThisMacCard({
         </div>
       ) : null}
 
-      {(host && routeLabels.length > 0) || appInfo ? (
-        <div style={{ display: "grid", gap: 3, paddingLeft: 16, marginTop: -6 }}>
-          {host && routeLabels.length > 0 ? (
-            <div style={{ ...helperTextStyle, lineHeight: 1.4 }}>
-              Reachable via {routeLabels.join(" · ")}
-            </div>
-          ) : null}
-          {appInfo ? (
-            <div style={{ ...helperTextStyle, lineHeight: 1.4 }}>
-              ADE {appInfo.version} · {appInfo.platform}
-            </div>
-          ) : null}
-        </div>
-      ) : null}
-
       {host && !crdtUnavailable ? (
-        isRemoteBound ? (
-          <PinManagerRemoteNote
-            pin={status.pairingPin}
-            pinConfigured={status.pairingPinConfigured}
-            boundMachineName={boundMachineName}
-          />
-        ) : (
-          <PinManager
-            pin={status.pairingPin}
-            pinConfigured={status.pairingPinConfigured}
-            busy={busy}
-            onSetPin={sync.setPinValue}
-            onGenerate={sync.generatePin}
-            onRemove={sync.clearPin}
-          />
-        )
+        <PairingDisclosure pinConfigured={status.pairingPinConfigured}>
+          {isRemoteBound ? (
+            <PinManagerRemoteNote
+              pin={status.pairingPin}
+              pinConfigured={status.pairingPinConfigured}
+              boundMachineName={boundMachineName}
+            />
+          ) : (
+            <PinManager
+              pin={status.pairingPin}
+              pinConfigured={status.pairingPinConfigured}
+              busy={busy}
+              onSetPin={sync.setPinValue}
+              onGenerate={sync.generatePin}
+              onRemove={sync.clearPin}
+            />
+          )}
+        </PairingDisclosure>
       ) : null}
 
       {notice ? <div style={{ ...helperTextStyle, color: COLORS.success }}>{notice}</div> : null}
@@ -385,16 +395,21 @@ export function ThisMacCard({
   );
 }
 
-function acceptsConnectionsState(
-  status: SyncRoleSnapshot,
-  host: boolean,
-): { ready: boolean; label: string } {
+/**
+ * The one fault worth interrupting the reader for, or null when this computer is
+ * fine. A healthy host renders no status line at all.
+ *
+ * Deliberately *not* a fault: having no pairing code. Signing in to your ADE
+ * account is the primary way to connect now, so an unset code is an ordinary
+ * state, not something to nag about.
+ */
+function connectionProblem(status: SyncRoleSnapshot, host: boolean): string | null {
   if (!host) {
-    return { ready: false, label: `${THIS_MACHINE_NAME} connects through your main ADE host` };
+    return `${THIS_MACHINE_NAME} connects through your main ADE host`;
   }
-  if (isCrdtSyncUnavailable(status)) {
-    return { ready: false, label: "Phone sync is unavailable" };
-  }
+  // The CRDT failure renders as its own alert block below, with the runtime's
+  // full explanation — repeating a one-liner here would just duplicate it.
+  if (isCrdtSyncUnavailable(status)) return null;
   if (!status.pairingConnectInfo) {
     // "Starting up" is only true while the listener is on its way up. When the
     // snapshot already knows why the listener is down (the background service
@@ -402,12 +417,204 @@ function acceptsConnectionsState(
     // reason is the whole point of this line and it never resolves on its own.
     const listener = status.routeHealth?.listener;
     const reason = listener?.listenerBound === false ? listener.reason?.trim() : null;
-    return { ready: false, label: reason || "Starting up — connection details will appear shortly" };
+    return reason || "Starting up — connection details will appear shortly";
   }
-  if (!status.pairingPinConfigured) {
-    return { ready: false, label: "Set a pairing code below so new devices can connect" };
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Machine name + inline rename
+// ---------------------------------------------------------------------------
+
+/**
+ * The machine name with a pencil beside it, mirroring the rename affordance on
+ * the account page. Saving writes the runtime name — the same value this card
+ * displays — so the change is visible immediately.
+ *
+ * Signed out the pencil stays visible but inert: the name is account-wide, and a
+ * hidden control would leave no hint that renaming is possible at all.
+ */
+function MachineNameRow({
+  name,
+  busy,
+  accountSignedIn,
+  onSave,
+}: {
+  name: string;
+  busy: boolean;
+  accountSignedIn: boolean;
+  onSave: (name: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(name);
+  useEffect(() => {
+    if (!editing) setValue(name);
+  }, [name, editing]);
+
+  const nameStyle: React.CSSProperties = {
+    color: COLORS.textPrimary,
+    fontFamily: SANS_FONT,
+    fontSize: 14,
+    fontWeight: 700,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    minWidth: 0,
+  };
+
+  if (editing) {
+    return (
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          const next = value.trim();
+          if (!next) return;
+          onSave(next);
+          setEditing(false);
+        }}
+        style={{ display: "flex", alignItems: "center", gap: 6, minWidth: 0 }}
+      >
+        <input
+          aria-label="Machine name"
+          autoFocus
+          maxLength={80}
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          disabled={busy}
+          style={{
+            minWidth: 0,
+            flex: 1,
+            height: 28,
+            borderRadius: 8,
+            border: `1px solid ${COLORS.accentBorder}`,
+            background: "rgba(255,255,255,0.06)",
+            color: COLORS.textPrimary,
+            fontFamily: SANS_FONT,
+            fontSize: 13,
+            fontWeight: 600,
+            padding: "0 9px",
+            outline: "none",
+          }}
+        />
+        <button
+          type="submit"
+          aria-label="Save machine name"
+          disabled={busy || !value.trim()}
+          style={outlineButton({ height: 28, padding: "0 8px", fontSize: 11 })}
+        >
+          <Check size={13} weight="bold" />
+        </button>
+        <button
+          type="button"
+          aria-label="Cancel rename"
+          disabled={busy}
+          onClick={() => setEditing(false)}
+          style={outlineButton({ height: 28, padding: "0 8px", fontSize: 11 })}
+        >
+          <X size={13} weight="bold" />
+        </button>
+      </form>
+    );
   }
-  return { ready: true, label: "Ready to accept connections" };
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 7, minWidth: 0 }}>
+      <span style={nameStyle}>{name}</span>
+      <button
+        type="button"
+        aria-label={`Rename ${name}`}
+        title={accountSignedIn ? `Rename ${name}` : "Sign in to rename this computer"}
+        disabled={busy || !accountSignedIn}
+        onClick={() => setEditing(true)}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 22,
+          height: 22,
+          flexShrink: 0,
+          padding: 0,
+          borderRadius: 6,
+          border: "none",
+          background: "transparent",
+          color: COLORS.textMuted,
+          cursor: accountSignedIn ? "pointer" : "not-allowed",
+          opacity: accountSignedIn ? 1 : 0.45,
+        }}
+      >
+        <PencilSimple size={13} weight="bold" />
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pairing-code disclosure
+// ---------------------------------------------------------------------------
+
+/**
+ * Collapsed wrapper around the pairing controls. Pairing codes are only needed
+ * for a manual connection to another ADE client, which is now the rare path —
+ * so the section starts closed every time the panel mounts and never remembers
+ * that it was opened.
+ */
+function PairingDisclosure({
+  pinConfigured,
+  children,
+}: {
+  pinConfigured: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{ display: "grid", gap: open ? 10 : 0 }}>
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 7,
+          width: "100%",
+          height: 30,
+          padding: "0 4px",
+          border: "none",
+          borderRadius: 8,
+          background: "transparent",
+          color: COLORS.textSecondary,
+          fontFamily: SANS_FONT,
+          fontSize: 12,
+          fontWeight: 600,
+          cursor: "pointer",
+          textAlign: "left",
+        }}
+      >
+        <CaretRight
+          size={12}
+          weight="bold"
+          style={{
+            flexShrink: 0,
+            transform: open ? "rotate(90deg)" : "none",
+            transition: "transform 120ms ease",
+          }}
+        />
+        Pairing code
+        <span style={{ color: COLORS.textMuted, fontWeight: 400 }}>
+          · {pinConfigured ? "Set" : "Not set"}
+        </span>
+      </button>
+      {open ? (
+        <div style={{ display: "grid", gap: 10 }}>
+          <div style={{ ...helperTextStyle, paddingLeft: 4 }}>
+            This code sets up a manual connection between this computer and another ADE client, like
+            the mobile app. Most connections go through your ADE account instead.
+          </div>
+          {children}
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -461,10 +668,8 @@ function PinManager({
 
   return (
     <div style={{ ...panelStyle, gap: 10 }}>
-      <div style={LABEL_STYLE}>Pairing code</div>
-      <div style={{ ...helperTextStyle, marginTop: -2 }}>
-        New nearby devices enter this code the first time they connect to this computer.
-      </div>
+      {/* The disclosure header above already names the section and explains what
+          the code is for, so this panel opens straight into the controls. */}
       {!pinConfigured ? (
         <EmptyPinBlock
           busy={busy}
@@ -506,8 +711,7 @@ function PinManagerRemoteNote({
       : `${THIS_MACHINE_NAME} has a pairing code set.`;
   return (
     <div style={{ ...panelStyle, gap: 8 }}>
-      <div style={LABEL_STYLE}>Pairing code</div>
-      <div style={{ ...helperTextStyle, marginTop: -2 }}>{stateLine}</div>
+      <div style={helperTextStyle}>{stateLine}</div>
       <div style={{ ...helperTextStyle, color: COLORS.textMuted }}>
         Pairing changes aren&rsquo;t available while this window is connected to{" "}
         {boundMachineName ?? "another computer"}.

--- a/apps/desktop/src/renderer/components/settings/accountDirectorySummary.ts
+++ b/apps/desktop/src/renderer/components/settings/accountDirectorySummary.ts
@@ -31,10 +31,9 @@ export function accountDirectorySummary(
         healthy: false,
       };
     }
-    return {
-      label: `Connected to your ADE account · ${health.reachableEndpointCount} route${health.reachableEndpointCount === 1 ? "" : "s"} published`,
-      healthy: true,
-    };
+    // Deliberately just the fact of the connection. The published-route count was
+    // plumbing detail the reader could neither act on nor interpret.
+    return { label: "Connected to your ADE account", healthy: true };
   }
   const reason = health.skipReason ?? health.state.replaceAll("_", " ");
   return {


### PR DESCRIPTION
The this-computer card led with a generic laptop glyph and three lines the reader could not act on — a readiness verdict, a route breakdown, and a platform name the icon already implied. Pairing, the rarest path now that the ADE account is the primary way to connect, took the most vertical space.

### What changed

- **Platform logo in the identity tile.** `AppleLogo` / `WindowsLogo` / `LinuxLogo`, with `Laptop` as the fallback and the OS name as the tile's accessible label. Since the logo is the platform statement, the version line drops its `· Windows` suffix.
- **Inline rename.** A pencil beside the name opens an inline input, mirroring the account page. It writes `saveRuntimeName` first — that is the value this card renders, so the change shows immediately — then mirrors to `account.renameMachine` so the account page and other clients agree. Best effort on the second write: a directory hiccup should not undo a rename the user can already see. Signed out, the pencil stays visible but disabled, with "Sign in to rename this computer".
- **Status only when actionable.** `acceptsConnectionsState` is replaced by `connectionProblem`, which returns `null` for a healthy host. "Ready to accept connections" and "Reachable via …" are gone. A fault renders in the version line's slot, so the card never grows a line. **A missing pairing code is no longer a fault** — it is an ordinary state now that connecting runs through the account.
- **Pairing behind a disclosure.** Header reads `Pairing code · Set` / `· Not set`. It opens closed on every mount and never remembers being opened. Opening it explains the code sets up a manual connection between this computer and another ADE client, like the mobile app.
- **Simpler account line.** Just "Connected to your ADE account" — the published-route count was plumbing the reader could neither act on nor interpret.

### Verification

- `npm run typecheck` — clean across the desktop tree.
- 505 tests pass across `settings`, `remoteTargets`, `account`, and `webclient`. New coverage for the three platform logos, the rename mirroring into the directory, the inert signed-out pencil, the disclosure never remembering its state, and the fault replacing the version line.
- Renderer-only, no OS-specific code paths; Windows renders its own logo through the same branch as macOS and Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ade:link v=1 type=pr repo=arul28/ADE branch=ade%2Fconnection-panel-ui num=1038 -->
<p>
  <img src="https://ade-app.dev/logo.png" height="18" align="left" alt="ADE">
  &nbsp;&nbsp;<strong>Open in ADE</strong>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=branch&amp;repo=arul28%2FADE&amp;branch=ade%2Fconnection-panel-ui&amp;pr=1038">ade/connection-panel-ui branch</a>
  &nbsp;·&nbsp; <a href="https://ade-app.dev/open?type=pr&amp;repo=arul28%2FADE&amp;number=1038">PR #1038</a>
</p>
<!-- /ade:link -->
